### PR TITLE
Fix quickstart EXTENDING.md reference to use full URL

### DIFF
--- a/cmd/bd/quickstart.go
+++ b/cmd/bd/quickstart.go
@@ -82,7 +82,8 @@ var quickstartCmd = &cobra.Command{
 		fmt.Printf("  Applications can extend bd's SQLite database:\n")
 		fmt.Printf("    • Add your own tables (e.g., %s)\n", cyan("myapp_executions"))
 		fmt.Printf("    • Join with %s table for powerful queries\n", cyan("issues"))
-		fmt.Printf("    • See %s for integration patterns\n\n", cyan("EXTENDING.md"))
+		fmt.Printf("    • See database extension docs for integration patterns:\n")
+		fmt.Printf("      %s\n\n", cyan("https://github.com/steveyegge/beads/blob/main/EXTENDING.md"))
 
 		fmt.Printf("%s\n", green("Ready to start!"))
 		fmt.Printf("Run %s to create your first issue.\n\n", cyan("bd create \"My first issue\""))


### PR DESCRIPTION
The quickstart command referenced EXTENDING.md as if it were a local file, which was confusing for users running bd in their own projects. Now it clearly points to the upstream documentation with a full GitHub URL.

- Changed from "See EXTENDING.md" to "See database extension docs"
- Added full URL to the original repo's EXTENDING.md
- Preserved the original "integration patterns" context

🤖 Generated with [Claude Code](https://claude.com/claude-code)