### PR TITLE
beads: Show issue type in bd list output

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -655,7 +655,7 @@ var listCmd = &cobra.Command{
 
 		fmt.Printf("\nFound %d issues:\n\n", len(issues))
 		for _, issue := range issues {
-			fmt.Printf("%s [P%d] %s\n", issue.ID, issue.Priority, issue.Status)
+			fmt.Printf("%s [P%d] [%s] %s\n", issue.ID, issue.Priority, issue.IssueType, issue.Status)
 			fmt.Printf("  %s\n", issue.Title)
 			if issue.Assignee != "" {
 				fmt.Printf("  Assignee: %s\n", issue.Assignee)


### PR DESCRIPTION
Updated the list command to display issue type alongside priority and status.

Before:
  beads-48 [P1] open

After:
  beads-48 [P1] [epic] open

This makes it easier to distinguish between bugs, features, tasks, epics, and chores at a glance without using --json or bd show.

Fixes #16 16