### PR TITLE
Add BD_ACTOR environment variable for actor override

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -83,10 +83,14 @@ var rootCmd = &cobra.Command{
 		storeActive = true
 		storeMutex.Unlock()
 
-		// Set actor from env or default
+		// Set actor from flag, env, or default
+		// Priority: --actor flag > BD_ACTOR env > USER env > "unknown"
 		if actor == "" {
-			actor = os.Getenv("USER")
-			if actor == "" {
+			if bdActor := os.Getenv("BD_ACTOR"); bdActor != "" {
+				actor = bdActor
+			} else if user := os.Getenv("USER"); user != "" {
+				actor = user
+			} else {
 				actor = "unknown"
 			}
 		}
@@ -517,7 +521,7 @@ var (
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&dbPath, "db", "", "Database path (default: auto-discover .beads/*.db or ~/.beads/default.db)")
-	rootCmd.PersistentFlags().StringVar(&actor, "actor", "", "Actor name for audit trail (default: $USER)")
+	rootCmd.PersistentFlags().StringVar(&actor, "actor", "", "Actor name for audit trail (default: $BD_ACTOR or $USER)")
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	rootCmd.PersistentFlags().BoolVar(&noAutoFlush, "no-auto-flush", false, "Disable automatic JSONL sync after CRUD operations")
 	rootCmd.PersistentFlags().BoolVar(&noAutoImport, "no-auto-import", false, "Disable automatic JSONL import when newer than DB")


### PR DESCRIPTION
Allow BD_ACTOR environment variable to set the default actor name, providing a cleaner alternative to the --actor flag for automated workflows.

Priority order for actor determination:
1. --actor flag (highest)
2. BD_ACTOR environment variable
3. USER environment variable
4. "unknown" (fallback)

Updated --actor flag help text to reflect the new environment variable.