### PR TITLE
Revert "docs: Improve Claude Code plugin quickstart documentation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ Drop Beads into any project where you're using a coding agent, and you'll enjoy 
 
 Instant start:
 
-**Claude Code users:**
-```bash
-/plugin marketplace add steveyegge/beads
-/plugin install beads
-```
-
-**Everyone else:**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash
 ```
@@ -102,9 +95,9 @@ paru -S beads-git
 
 Thanks to [@v4rgas](https://github.com/v4rgas) for maintaining the AUR package!
 
-### Claude Code Plugin (Recommended for Claude Code Users)
+### Claude Code Plugin
 
-**The easiest way to use Beads in Claude Code!** One-command installation with zero configuration:
+Prefer a one-command installation in Claude Code? Install the beads plugin for instant access via slash commands and MCP tools:
 
 ```bash
 # In Claude Code
@@ -112,25 +105,11 @@ Thanks to [@v4rgas](https://github.com/v4rgas) for maintaining the AUR package!
 /plugin install beads
 ```
 
-**Why use the plugin?**
-- ✨ **Zero manual setup** - No need to install Go or build from source
-- 🔧 **MCP tools built-in** - Agents can use beads directly without Bash commands
-- ⚡ **Instant availability** - Works immediately after plugin install
-- 🎯 **Slash commands** - Quick access to common operations
-- 🤖 **Agent-ready** - MCP tools like `mcp__plugin_beads_beads__ready`, `mcp__plugin_beads_beads__create`, etc.
-
-**What you get:**
-- **Slash commands**: `/bd-ready`, `/bd-create`, `/bd-show`, `/bd-update`, `/bd-close`, etc.
-- **Full MCP server**: All bd tools available via MCP protocol (agents use these automatically)
-- **Task agent**: Autonomous task execution
-- **Auto-configured**: bd CLI installed and configured automatically
-
-**For agents:** After plugin installation, agents can use MCP tools directly instead of calling `bd` commands via Bash. The plugin provides tools like:
-- `mcp__plugin_beads_beads__ready` - Find ready work
-- `mcp__plugin_beads_beads__create` - Create new issues
-- `mcp__plugin_beads_beads__update` - Update issue status
-- `mcp__plugin_beads_beads__show` - Show issue details
-- ...and all other bd commands
+The plugin includes:
+- Slash commands: `/bd-ready`, `/bd-create`, `/bd-show`, `/bd-update`, `/bd-close`, etc.
+- Full MCP server with all bd tools
+- Task agent for autonomous execution
+- Auto-configured for instant use
 
 See [PLUGIN.md](PLUGIN.md) for complete plugin documentation.
 


### PR DESCRIPTION
Was trying to follow the README instructions and it isn't quite a one-command installation, recommend reverting until README can be updated to be clearer.

If the intention was for claude to trigger the install on init like mine did I can change the PR to reflect that but otherwise I found it confusing.

```
❯ claude

 ▐▛███▜▌   Claude Code v2.0.15
▝▜█████▛▘  Sonnet 4.5 · Claude Max
  ▘▘ ▝▝    /home/jjshanks/workspace/racgoat

> /plugin marketplace add steveyegge/beads
  ⎿  (no content)

> /plugin install beads
  ⎿  ✓ Installed beads. Restart Claude Code to load new plugins.

# use bd to track work instead of markdown files
  ⎿  Good to know.

> /exit
  ⎿  Bye!
```

```
❯ claude

 ▐▛███▜▌   Claude Code v2.0.15
▝▜█████▛▘  Sonnet 4.5 · Claude Max
  ▘▘ ▝▝    /home/jjshanks/workspace/racgoat

> mcp__plugin_beads_beads__init

● I'll initialize the Beads issue tracking system in this directory.

● plugin:beads:beads - init (MCP)(prefix: "RG")
  ⎿  Error: Error calling tool 'init': Beads MCP Server Configuration Error

     1 validation error for Config
     beads_path
       Value error, bd executable not found at: /home/jjshanks/.local/bin/bd

     The beads Claude Code plugin requires the bd CLI to be installed.

     Install bd CLI:
       curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash
     … +20 lines (ctrl+o to see all)

● I see that the bd CLI tool isn't installed yet. The Beads MCP server requires the bd executable to be available. Let me install it for you:

● Bash(curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash)
  ⎿  Running…
```