### PR TITLE
feat(mcp): Add `reopen` command support for closed issues

### DIFF
--- a/integrations/beads-mcp/README.md
+++ b/integrations/beads-mcp/README.md
@@ -79,6 +79,7 @@ Then use in Claude Desktop config:
 - `dep` - Add dependency (blocks, related, parent-child, discovered-from)
 - `blocked` - Get blocked issues
 - `stats` - Get project statistics
+- `reopen` - Reopen a closed issue with optional reason
 
 
 ## Development

--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -15,6 +15,7 @@ from .models import (
     Issue,
     ListIssuesParams,
     ReadyWorkParams,
+    ReopenIssueParams,
     ShowIssueParams,
     Stats,
     UpdateIssueParams,
@@ -378,6 +379,26 @@ class BdClient:
         data = await self._run_command(*args)
         if not isinstance(data, list):
             raise BdCommandError(f"Invalid response for close {params.issue_id}")
+
+        return [Issue.model_validate(issue) for issue in data]
+
+    async def reopen(self, params: ReopenIssueParams) -> list[Issue]:
+        """Reopen one or more closed issues.
+
+        Args:
+            params: Reopen parameters
+
+        Returns:
+            List of reopened issues
+        """
+        args = ["reopen", *params.issue_ids]
+
+        if params.reason:
+            args.extend(["--reason", params.reason])
+
+        data = await self._run_command(*args)
+        if not isinstance(data, list):
+            raise BdCommandError(f"Invalid response for reopen {params.issue_ids}")
 
         return [Issue.model_validate(issue) for issue in data]
 

--- a/integrations/beads-mcp/src/beads_mcp/models.py
+++ b/integrations/beads-mcp/src/beads_mcp/models.py
@@ -86,6 +86,13 @@ class CloseIssueParams(BaseModel):
     reason: str = "Completed"
 
 
+class ReopenIssueParams(BaseModel):
+    """Parameters for reopening issues."""
+
+    issue_ids: list[str]
+    reason: str | None = None
+
+
 class AddDependencyParams(BaseModel):
     """Parameters for adding a dependency."""
 

--- a/integrations/beads-mcp/src/beads_mcp/server.py
+++ b/integrations/beads-mcp/src/beads_mcp/server.py
@@ -14,6 +14,7 @@ from beads_mcp.tools import (
     beads_list_issues,
     beads_quickstart,
     beads_ready_work,
+    beads_reopen_issue,
     beads_show_issue,
     beads_stats,
     beads_update_issue,
@@ -151,6 +152,15 @@ async def update_issue(
 async def close_issue(issue_id: str, reason: str = "Completed") -> list[Issue]:
     """Close (complete) an issue."""
     return await beads_close_issue(issue_id=issue_id, reason=reason)
+
+
+@mcp.tool(
+    name="reopen",
+    description="Reopen one or more closed issues. Sets status to 'open' and clears closed_at timestamp.",
+)
+async def reopen_issue(issue_ids: list[str], reason: str | None = None) -> list[Issue]:
+    """Reopen one or more closed issues."""
+    return await beads_reopen_issue(issue_ids=issue_ids, reason=reason)
 
 
 @mcp.tool(

--- a/integrations/beads-mcp/src/beads_mcp/tools.py
+++ b/integrations/beads-mcp/src/beads_mcp/tools.py
@@ -15,6 +15,7 @@ from .models import (
     IssueType,
     ListIssuesParams,
     ReadyWorkParams,
+    ReopenIssueParams,
     ShowIssueParams,
     Stats,
     UpdateIssueParams,
@@ -175,6 +176,20 @@ async def beads_close_issue(
     client = await _get_client()
     params = CloseIssueParams(issue_id=issue_id, reason=reason)
     return await client.close(params)
+
+
+async def beads_reopen_issue(
+    issue_ids: Annotated[list[str], "Issue IDs to reopen (e.g., ['bd-1', 'bd-2'])"],
+    reason: Annotated[str | None, "Reason for reopening"] = None,
+) -> list[Issue]:
+    """Reopen one or more closed issues.
+
+    Sets status to 'open' and clears the closed_at timestamp.
+    More explicit than 'update --status open'.
+    """
+    client = await _get_client()
+    params = ReopenIssueParams(issue_ids=issue_ids, reason=reason)
+    return await client.reopen(params)
 
 
 async def beads_add_dependency(

--- a/integrations/beads-mcp/uv.lock
+++ b/integrations/beads-mcp/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "beads-mcp"
-version = "0.9.6"
+version = "0.9.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
Implements the `bd` reopen command in the MCP server, enabling agents to reopen closed issues with optional reason tracking for audit trails. This addresses the need to handle regressions and incorrectly closed issues without manual `bd` CLI intervention.

The reopen command is more explicit than `bd update --status open` and emits a dedicated Reopened event in the audit log, making it easier to track why issues were reopened during analysis.

Changes:
  - `models.py`: Add ReopenIssueParams with issue_ids list and optional reason
  - `bd_client.py`: Implement reopen() method with JSON response parsing
  - `tools.py`: Add beads_reopen_issue() wrapper with Annotated types for MCP
  - `server.py`: Register 'reopen' MCP tool with description and parameters

Testing (10 new):
  - `test_bd_client.py`: 4 unit tests (mocked subprocess)
  - `test_bd_client_integration.py`: 3 integration tests (real `bd` CLI)
  - `test_mcp_server_integration.py`: 3 MCP integration tests (FastMCP Client)
  - `test_tools.py`: 3 tools wrapper tests (mocked BdClient)

Also updated `README.md`.