### PR TITLE
Add scripttest-based integration tests

### DIFF
--- a/cmd/bd/scripttest_test.go
+++ b/cmd/bd/scripttest_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"rsc.io/script"
+	"rsc.io/script/scripttest"
+)
+
+func TestScripts(t *testing.T) {
+	// Build the bd binary
+	exe := t.TempDir() + "/bd"
+	if err := exec.Command("go", "build", "-o", exe, ".").Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create minimal engine with default commands plus bd
+	engine := script.NewEngine()
+	engine.Cmds["bd"] = script.Program(exe, nil, 100*time.Millisecond)
+
+	// Run all tests
+	scripttest.Test(t, context.Background(), engine, nil, "testdata/*.txt")
+}

--- a/cmd/bd/testdata/blocked.txt
+++ b/cmd/bd/testdata/blocked.txt
@@ -1,0 +1,7 @@
+# Test bd blocked command
+bd init --prefix test
+bd create 'First issue'
+bd create 'Second issue' --deps test-1
+bd blocked
+stdout 'Blocked issues'
+stdout 'test-2'

--- a/cmd/bd/testdata/close.txt
+++ b/cmd/bd/testdata/close.txt
@@ -1,0 +1,8 @@
+# Test bd close command
+bd init --prefix test
+bd create 'Issue to close'
+bd close test-1 --reason 'Fixed'
+stdout 'Closed test-1'
+
+bd show test-1
+stdout 'closed'

--- a/cmd/bd/testdata/create.txt
+++ b/cmd/bd/testdata/create.txt
@@ -1,0 +1,5 @@
+# Test bd create command
+bd init --prefix test
+bd create 'Test issue'
+stdout 'Created issue:'
+stdout 'test-'

--- a/cmd/bd/testdata/dep_add.txt
+++ b/cmd/bd/testdata/dep_add.txt
@@ -1,0 +1,10 @@
+# Test bd dep add command
+bd init --prefix test
+bd create 'First issue'
+bd create 'Second issue'
+bd dep add test-2 test-1
+stdout 'Added dependency'
+
+bd show test-2
+stdout 'Depends on'
+stdout 'test-1'

--- a/cmd/bd/testdata/dep_remove.txt
+++ b/cmd/bd/testdata/dep_remove.txt
@@ -1,0 +1,10 @@
+# Test bd dep remove command
+bd init --prefix test
+bd create 'First issue'
+bd create 'Second issue'
+bd dep add test-2 test-1
+bd dep remove test-2 test-1
+stdout 'Removed dependency'
+
+bd show test-2
+! stdout 'test-1'

--- a/cmd/bd/testdata/dep_tree.txt
+++ b/cmd/bd/testdata/dep_tree.txt
@@ -1,0 +1,7 @@
+# Test bd dep tree command
+bd init --prefix test
+bd create 'Root issue'
+bd create 'Child issue'
+bd dep add test-2 test-1
+bd dep tree test-1
+stdout 'test-1'

--- a/cmd/bd/testdata/export.txt
+++ b/cmd/bd/testdata/export.txt
@@ -1,0 +1,10 @@
+# Test bd export command
+bd init --prefix test
+bd create 'Test issue'
+bd export -o export.jsonl
+exists export.jsonl
+
+# Verify the exported file contains the issue
+bd import -i export.jsonl
+bd list
+stdout 'Test issue'

--- a/cmd/bd/testdata/help.txt
+++ b/cmd/bd/testdata/help.txt
@@ -1,0 +1,7 @@
+# Test bd help command
+bd help
+stdout 'Usage:'
+stdout 'Available Commands:'
+stdout 'create'
+stdout 'list'
+stdout 'show'

--- a/cmd/bd/testdata/import.txt
+++ b/cmd/bd/testdata/import.txt
@@ -1,0 +1,8 @@
+# Test bd import command
+bd init --prefix test
+bd import -i import.jsonl
+bd show test-99
+stdout 'Imported issue'
+
+-- import.jsonl --
+{"id":"test-99","title":"Imported issue","status":"open","priority":1,"issue_type":"task","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}

--- a/cmd/bd/testdata/init.txt
+++ b/cmd/bd/testdata/init.txt
@@ -1,0 +1,4 @@
+# Test bd init command
+bd init --prefix test
+stdout 'initialized successfully'
+exists .beads/test.db

--- a/cmd/bd/testdata/list.txt
+++ b/cmd/bd/testdata/list.txt
@@ -1,0 +1,7 @@
+# Test bd list command
+bd init --prefix test
+bd create 'First issue'
+bd create 'Second issue'
+bd list
+stdout 'First issue'
+stdout 'Second issue'

--- a/cmd/bd/testdata/quickstart.txt
+++ b/cmd/bd/testdata/quickstart.txt
@@ -1,0 +1,5 @@
+# Test bd quickstart command
+bd quickstart
+stdout 'Dependency-Aware'
+stdout 'bd init'
+stdout 'bd create'

--- a/cmd/bd/testdata/ready.txt
+++ b/cmd/bd/testdata/ready.txt
@@ -1,0 +1,5 @@
+# Test bd ready command
+bd init --prefix test
+bd create 'Ready issue'
+bd ready
+stdout 'Ready'

--- a/cmd/bd/testdata/show.txt
+++ b/cmd/bd/testdata/show.txt
@@ -1,0 +1,8 @@
+# Test bd show command
+bd init --prefix test
+bd create 'Test issue for show'
+
+bd show test-1
+stdout 'Test issue for show'
+stdout 'Status:'
+stdout 'Priority:'

--- a/cmd/bd/testdata/stats.txt
+++ b/cmd/bd/testdata/stats.txt
@@ -1,0 +1,9 @@
+# Test bd stats command
+bd init --prefix test
+bd create 'First issue'
+bd create 'Second issue'
+bd close test-1
+bd stats
+stdout 'Total Issues:'
+stdout 'Open:'
+stdout 'Closed:'

--- a/cmd/bd/testdata/update.txt
+++ b/cmd/bd/testdata/update.txt
@@ -1,0 +1,8 @@
+# Test bd update command
+bd init --prefix test
+bd create 'Issue to update'
+bd update test-1 --status in_progress
+stdout 'Updated issue:'
+
+bd show test-1
+stdout 'in_progress'

--- a/cmd/bd/testdata/version.txt
+++ b/cmd/bd/testdata/version.txt
@@ -1,0 +1,3 @@
+# Test bd version command
+bd version
+stdout 'bd version'

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,9 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/tools v0.34.0 // indirect
 	modernc.org/libc v1.66.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
+	rsc.io/script v0.0.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -76,3 +76,5 @@ modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+rsc.io/script v0.0.2 h1:eYoG7A3GFC3z1pRx3A2+s/vZ9LA8cxojHyCvslnj4RI=
+rsc.io/script v0.0.2/go.mod h1:cKBjCtFBBeZ0cbYFRXkRoxP+xGqhArPa9t3VWhtXfzU=


### PR DESCRIPTION
As covered by @rsc in https://research.swtch.com/testing, the https://pkg.go.dev/rsc.io/script and https://pkg.go.dev/rsc.io/script/scripttest packages offer a nice way to test cli commands in a go testing native manner.

This adds basic testing of cli command output of the bd subcommands.