### PR TITLE
Fix DATETIME scan error with modernc.org/sqlite

### DIFF
--- a/internal/storage/sqlite/sqlite.go
+++ b/internal/storage/sqlite/sqlite.go
@@ -32,7 +32,8 @@ func New(path string) (*SQLiteStorage, error) {
 	// Open database with WAL mode for better concurrency and busy timeout for parallel writes
 	// _pragma=busy_timeout(30000) means wait up to 30 seconds for locks instead of failing immediately
 	// Higher timeout helps with parallel issue creation from multiple processes
-	db, err := sql.Open("sqlite", path+"?_journal_mode=WAL&_foreign_keys=ON&_pragma=busy_timeout(30000)")
+	// _time_format=sqlite uses SQLite's native time format for DATETIME columns
+	db, err := sql.Open("sqlite", path+"?_journal_mode=WAL&_foreign_keys=ON&_pragma=busy_timeout(30000)&_time_format=sqlite")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}


### PR DESCRIPTION
Fixes #60

## Problem
`bd list` fails with error: `unsupported Scan, storing driver.Value type string into type *time.Time`

## Root Cause
The modernc.org/sqlite driver stores `time.Time` values as strings by default, which it cannot scan back into `*time.Time`.

## Solution
Add `_time_format=sqlite` to use SQLite's native datetime format, which the driver can read/write properly.

## Reference
https://www.sqlite.org/lang_datefunc.html#time_values
https://pkg.go.dev/modernc.org/sqlite#Driver.Open