### PR TITLE
CI Fix 2025/10/16

### DIFF
--- a/cmd/bd/autoimport_collision_test.go
+++ b/cmd/bd/autoimport_collision_test.go
@@ -42,7 +42,7 @@ func createTestDBWithIssues(t *testing.T, issues []*types.Issue) (string, *sqlit
 }
 
 // Helper function to write JSONL file
-func writeJSONLFile(t *testing.T, dir string, issues []*types.Issue) string {
+func writeJSONLFile(t *testing.T, dir string, issues []*types.Issue) {
 	t.Helper()
 	jsonlPath := filepath.Join(dir, "issues.jsonl")
 	f, err := os.Create(jsonlPath)
@@ -57,8 +57,6 @@ func writeJSONLFile(t *testing.T, dir string, issues []*types.Issue) string {
 			t.Fatalf("Failed to encode issue %s: %v", issue.ID, err)
 		}
 	}
-
-	return jsonlPath
 }
 
 // Helper function to capture stderr output
@@ -469,7 +467,7 @@ func TestAutoImportParseError(t *testing.T) {
 	jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
 	os.WriteFile(jsonlPath, []byte(`{"id":"test-pe-1","title":"Good issue","status":"open","priority":1,"issue_type":"task","created_at":"2025-10-16T00:00:00Z","updated_at":"2025-10-16T00:00:00Z"}
 {invalid json here}
-`), 0644)
+`), 0600)
 
 	// Run auto-import (should skip due to parse error)
 	stderrOutput := captureStderr(t, autoImportIfNewer)
@@ -501,7 +499,7 @@ func TestAutoImportEmptyJSONL(t *testing.T) {
 
 	// Create empty JSONL
 	jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
-	os.WriteFile(jsonlPath, []byte(""), 0644)
+	os.WriteFile(jsonlPath, []byte(""), 0600)
 
 	// Run auto-import
 	autoImportIfNewer()

--- a/cmd/bd/daemon_test.go
+++ b/cmd/bd/daemon_test.go
@@ -87,7 +87,7 @@ func TestIsDaemonRunning_StalePIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	pidFile := filepath.Join(tmpDir, "test.pid")
 
-	if err := os.WriteFile(pidFile, []byte("99999"), 0644); err != nil {
+	if err := os.WriteFile(pidFile, []byte("99999"), 0600); err != nil {
 		t.Fatalf("Failed to write PID file: %v", err)
 	}
 
@@ -102,7 +102,7 @@ func TestIsDaemonRunning_CurrentProcess(t *testing.T) {
 	pidFile := filepath.Join(tmpDir, "test.pid")
 
 	currentPID := os.Getpid()
-	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(currentPID)), 0644); err != nil {
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(currentPID)), 0600); err != nil {
 		t.Fatalf("Failed to write PID file: %v", err)
 	}
 
@@ -179,7 +179,7 @@ func TestDaemonPIDFileManagement(t *testing.T) {
 	pidFile := filepath.Join(tmpDir, "daemon.pid")
 
 	testPID := 12345
-	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(testPID)), 0644); err != nil {
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(testPID)), 0600); err != nil {
 		t.Fatalf("Failed to write PID file: %v", err)
 	}
 

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -12,6 +12,10 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+const (
+	statusClosed = "closed"
+)
+
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List issues",
@@ -123,7 +127,7 @@ func outputDotFormat(ctx context.Context, store storage.Storage, issues []*types
 		fontColor := "black"
 
 		switch issue.Status {
-		case "closed":
+		case statusClosed:
 			fillColor = "lightgray"
 			fontColor = "dimgray"
 		case "in_progress":

--- a/cmd/bd/main_test.go
+++ b/cmd/bd/main_test.go
@@ -1031,7 +1031,7 @@ func TestAutoImportMergeConflict(t *testing.T) {
 {"id":"test-conflict-1","title":"Incoming version","status":"in_progress","priority":2,"issue_type":"bug","created_at":"2025-10-16T00:00:00Z","updated_at":"2025-10-16T00:00:00Z"}
 >>>>>>> incoming-branch
 `
-	if err := os.WriteFile(jsonlPath, []byte(conflictContent), 0644); err != nil {
+	if err := os.WriteFile(jsonlPath, []byte(conflictContent), 0600); err != nil {
 		t.Fatalf("Failed to create conflicted JSONL: %v", err)
 	}
 

--- a/internal/compact/compactor_test.go
+++ b/internal/compact/compactor_test.go
@@ -98,7 +98,7 @@ func TestNew(t *testing.T) {
 	defer store.Close()
 
 	t.Run("creates compactor with config", func(t *testing.T) {
-		config := &CompactConfig{
+		config := &Config{
 			Concurrency: 10,
 			DryRun:      true,
 		}
@@ -128,7 +128,7 @@ func TestCompactTier1_DryRun(t *testing.T) {
 
 	issue := createClosedIssue(t, store, "test-1")
 
-	config := &CompactConfig{DryRun: true}
+	config := &Config{DryRun: true}
 	c, err := New(store, "", config)
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
@@ -172,7 +172,7 @@ func TestCompactTier1_IneligibleIssue(t *testing.T) {
 		t.Fatalf("failed to create issue: %v", err)
 	}
 
-	config := &CompactConfig{DryRun: true}
+	config := &Config{DryRun: true}
 	c, err := New(store, "", config)
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
@@ -197,7 +197,7 @@ func TestCompactTier1_WithAPI(t *testing.T) {
 
 	issue := createClosedIssue(t, store, "test-api")
 
-	c, err := New(store, "", &CompactConfig{Concurrency: 1})
+	c, err := New(store, "", &Config{Concurrency: 1})
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestCompactTier1Batch_DryRun(t *testing.T) {
 	issue1 := createClosedIssue(t, store, "test-batch-1")
 	issue2 := createClosedIssue(t, store, "test-batch-2")
 
-	config := &CompactConfig{DryRun: true, Concurrency: 2}
+	config := &Config{DryRun: true, Concurrency: 2}
 	c, err := New(store, "", config)
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
@@ -281,7 +281,7 @@ func TestCompactTier1Batch_WithIneligible(t *testing.T) {
 		t.Fatalf("failed to create issue: %v", err)
 	}
 
-	config := &CompactConfig{DryRun: true, Concurrency: 2}
+	config := &Config{DryRun: true, Concurrency: 2}
 	c, err := New(store, "", config)
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
@@ -321,7 +321,7 @@ func TestCompactTier1Batch_WithAPI(t *testing.T) {
 	issue2 := createClosedIssue(t, store, "test-api-batch-2")
 	issue3 := createClosedIssue(t, store, "test-api-batch-3")
 
-	c, err := New(store, "", &CompactConfig{Concurrency: 2})
+	c, err := New(store, "", &Config{Concurrency: 2})
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestMockAPI_CompactTier1(t *testing.T) {
 
 	issue := createClosedIssue(t, store, "test-mock")
 
-	c, err := New(store, "", &CompactConfig{DryRun: true, Concurrency: 1})
+	c, err := New(store, "", &Config{DryRun: true, Concurrency: 1})
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestBatchOperations_ErrorHandling(t *testing.T) {
 		t.Fatalf("failed to create open issue: %v", err)
 	}
 
-	c, err := New(store, "", &CompactConfig{DryRun: true, Concurrency: 2})
+	c, err := New(store, "", &Config{DryRun: true, Concurrency: 2})
 	if err != nil {
 		t.Fatalf("failed to create compactor: %v", err)
 	}

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -141,7 +141,7 @@ func isRetryable(err error) bool {
 	}
 
 	var netErr net.Error
-	if errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary()) {
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true
 	}
 

--- a/internal/compact/haiku_test.go
+++ b/internal/compact/haiku_test.go
@@ -190,7 +190,7 @@ func TestCallWithRetry_ContextCancellation(t *testing.T) {
 
 	_, err = client.callWithRetry(ctx, "test prompt")
 	if err == nil {
-		t.Fatal("expected error when context is cancelled")
+		t.Fatal("expected error when context is canceled")
 	}
 	if err != context.Canceled {
 		t.Errorf("expected context.Canceled error, got: %v", err)

--- a/internal/rpc/client.go
+++ b/internal/rpc/client.go
@@ -67,17 +67,17 @@ func (c *Client) Execute(req *Request) (*Response, error) {
 	reqJSON = append(reqJSON, '\n')
 
 	if _, err := c.conn.Write(reqJSON); err != nil {
-		c.reconnect()
+		_ = c.reconnect()
 		return nil, fmt.Errorf("failed to write request: %w", err)
 	}
 
 	scanner := bufio.NewScanner(c.conn)
 	if !scanner.Scan() {
 		if err := scanner.Err(); err != nil {
-			c.reconnect()
+			_ = c.reconnect()
 			return nil, fmt.Errorf("failed to read response: %w", err)
 		}
-		c.reconnect()
+		_ = c.reconnect()
 		return nil, fmt.Errorf("connection closed")
 	}
 

--- a/internal/storage/sqlite/compact.go
+++ b/internal/storage/sqlite/compact.go
@@ -128,12 +128,9 @@ func (s *SQLiteStorage) GetTier2Candidates(ctx context.Context) ([]*CompactionCa
 		daysStr = "90"
 	}
 
-	depthStr, err := s.GetConfig(ctx, "compact_tier2_dep_levels")
+	_, err = s.GetConfig(ctx, "compact_tier2_dep_levels")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get compact_tier2_dep_levels: %w", err)
-	}
-	if depthStr == "" {
-		depthStr = "5"
 	}
 
 	commitsStr, err := s.GetConfig(ctx, "compact_tier2_commits")
@@ -230,15 +227,6 @@ func (s *SQLiteStorage) CheckEligibility(ctx context.Context, issueID string, ti
 	if tier == 1 {
 		if compactionLevel != 0 {
 			return false, "issue is already compacted", nil
-		}
-		
-		// Check if closed long enough
-		daysStr, err := s.GetConfig(ctx, "compact_tier1_days")
-		if err != nil {
-			return false, "", fmt.Errorf("failed to get compact_tier1_days: %w", err)
-		}
-		if daysStr == "" {
-			daysStr = "30"
 		}
 		
 		// Check if it appears in tier1 candidates


### PR DESCRIPTION
Bug Fixes

- Fix test failure in compact package - HaikuClient creation now requires API key to be present, preventing initialization errors in tests
- Fix auto-import metadata handling - Treat metadata read errors as first import instead of failing
- Fix auto-import performance - Replace N+1 query pattern with batch fetch for better performance

Features

- New bd delete command - Comprehensive cleanup including dependencies, comments, labels, and JSONL sync
- Warning banner - Added critical warning about managing multiple workstreams

Code Quality

- Rename CompactConfig/CompactResult to Config/Result for cleaner naming
- Remove unused variables and deprecated API calls
- Improve test file permissions (0600 instead of 0644)
- Fix spelling inconsistencies

All tests passing with race detection enabled.