### PR TITLE
    Add .gitignore to .beads directory during init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ go.work
 *.swo
 *~
 
+# Claude Code
+.claude/settings.local.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -774,16 +774,9 @@ Each line is a complete JSON issue object:
 
 ### Setup
 
-Add to `.gitignore`:
-```
-.beads/*.db
-.beads/*.db-*
-```
-
-Add to git:
-```
-.beads/issues.jsonl
-```
+The `.beads/` directory is automatically configured during `bd init`:
+- Database files (`.beads/*.db`, `.beads/*.db-*`) are gitignored automatically
+- JSONL file (`.beads/issues.jsonl`) is tracked in git
 
 ### Workflow
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -42,6 +42,14 @@ and database file. Optionally specify a custom issue prefix.`,
 			os.Exit(1)
 		}
 
+		// Create .gitignore in .beads directory
+		gitignorePath := filepath.Join(beadsDir, ".gitignore")
+		gitignoreContent := "*.db\n*.db-*\n"
+		if err := os.WriteFile(gitignorePath, []byte(gitignoreContent), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to create .gitignore: %v\n", err)
+			// Non-fatal - continue anyway
+		}
+
 		// Create database
 		dbPath := filepath.Join(beadsDir, prefix+".db")
 		store, err := sqlite.New(dbPath)

--- a/cmd/bd/testdata/init.txt
+++ b/cmd/bd/testdata/init.txt
@@ -2,3 +2,6 @@
 bd init --prefix test
 stdout 'initialized successfully'
 exists .beads/test.db
+exists .beads/.gitignore
+grep '^\*\.db$' .beads/.gitignore
+grep '^\*\.db-\*$' .beads/.gitignore


### PR DESCRIPTION
    - Create .gitignore file in .beads/ when running bd init
    - Ignores *.db and *.db-* patterns to prevent database commits
    - Add test coverage to verify .gitignore creation
    - Add .claude/settings.local.json to project .gitignore

    🤖 Generated with [Claude Code](https://claude.com/claude-code)

    Co-Authored-By: Claude <noreply@anthropic.com>