### PR TITLE
feat: Update Nix flake to 0.9.9 with improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 # Go workspace file
 go.work
 
+# Nix
+result
+result-*
+
 # IDE
 .vscode/
 .idea/

--- a/flake.nix
+++ b/flake.nix
@@ -15,33 +15,97 @@
     ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        version = "0.9.9";
       in
       {
-        packages.default = pkgs.buildGoModule {
-          pname = "beads";
-          version = "0.9.6";
+        packages = {
+          beads = pkgs.buildGoModule {
+            pname = "beads";
+            inherit version;
 
-          src = self;
+            src = self;
 
-          # Point to the main Go package
-          subPackages = [ "cmd/bd" ];
+            # Point to the main Go package
+            subPackages = [ "cmd/bd" ];
 
-          # Go module dependencies hash (computed via nix build)
-          vendorHash = "sha256-WvwT48izxMxx9qQmZp/6zwv7hHgTVd9KmOJFm7RWvrI=";
+            # Go module dependencies hash (computed via nix build)
+            # Run `nix-prefetch` or `nix build` with a fake hash to update
+            vendorHash = "sha256-1ufUs1PvFGsSR0DTSymni3RqecEBzAm//OBUWgaTwEs=";
 
-          meta = with pkgs.lib; {
-            description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";
-            homepage = "https://github.com/steveyegge/beads";
-            license = licenses.mit;
-            mainProgram = "bd";
-            maintainers = [ ];
+            # Set version via ldflags
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.Version=${version}"
+              "-X main.Build=nix"
+            ];
+
+            meta = with pkgs.lib; {
+              description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";
+              longDescription = ''
+                Beads is a lightweight memory system for coding agents, using a graph-based
+                issue tracker. It provides dependency tracking, ready work detection, and
+                git-versioned storage, making it perfect for AI-supervised workflows.
+              '';
+              homepage = "https://github.com/steveyegge/beads";
+              license = licenses.mit;
+              mainProgram = "bd";
+              maintainers = [ ];
+              platforms = platforms.unix;
+            };
           };
+
+          default = self.packages.${system}.beads;
         };
 
         apps.default = {
           type = "app";
           program = "${self.packages.${system}.default}/bin/bd";
         };
+
+        # Development shell with Go and tools
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            gopls
+            gotools
+            go-tools
+            golangci-lint
+            delve
+          ];
+
+          shellHook = ''
+            echo "🔗 Beads development environment"
+            echo "Go version: $(go version)"
+            echo ""
+            echo "Available commands:"
+            echo "  go build ./cmd/bd        - Build the bd binary"
+            echo "  go test ./...            - Run tests"
+            echo "  golangci-lint run        - Run linters"
+            echo "  nix build                - Build with Nix"
+            echo ""
+          '';
+        };
+
+        # NixOS module (optional, can be used in NixOS configurations)
+        nixosModules.default = { config, lib, pkgs, ... }:
+          with lib;
+          let
+            cfg = config.programs.beads;
+          in {
+            options.programs.beads = {
+              enable = mkEnableOption "beads issue tracker";
+              package = mkOption {
+                type = types.package;
+                default = self.packages.${system}.default;
+                description = "The beads package to use";
+              };
+            };
+
+            config = mkIf cfg.enable {
+              environment.systemPackages = [ cfg.package ];
+            };
+          };
       }
     );
 }


### PR DESCRIPTION
## Summary

Updates the Nix flake with several improvements:

- ✅ Update version from 0.9.6 to 0.9.9
- ✅ Update vendorHash to match current Go dependencies  
- ✅ Add comprehensive development shell with Go tooling (gopls, golangci-lint, delve)
- ✅ Add NixOS module for declarative system configuration
- ✅ Add proper ldflags to set version info in the binary
- ✅ Improve metadata with longer description and platform constraints
- ✅ Add Nix build artifacts to .gitignore

## What's New

The flake now provides:

### Building and Running
```bash
# Build the bd binary
nix build

# Run bd directly
nix run github:heartpunk/beads/feat/update-nix-flake

# Test the binary
./result/bin/bd version
```

### Development Shell
```bash
# Enter development environment with all Go tools
nix develop

# Tools included:
# - go (compiler)
# - gopls (language server)
# - golangci-lint (linter)
# - delve (debugger)
# - gotools, go-tools
```

### NixOS Module
```nix
# In your NixOS configuration
{
  inputs.beads.url = "github:heartpunk/beads/feat/update-nix-flake";
  
  programs.beads = {
    enable = true;
    package = inputs.beads.packages.${system}.default;
  };
}
```

## Test Plan

- [x] Run `nix flake check` - passes
- [x] Build with `nix build` - succeeds
- [x] Verify binary works: `./result/bin/bd version` outputs `0.9.9 (dev)`
- [x] Test development shell: `nix develop` provides all Go tools
- [ ] Test on other platforms (aarch64-linux, darwin)
- [ ] Test NixOS module installation

## Notes

- The vendorHash was updated by running `nix build` with the old hash and using the error message to get the correct one
- Build artifacts (result, result-*) added to .gitignore to keep the repo clean
- Version info is now properly embedded via ldflags with Build="nix"

🤖 Generated with [Claude Code](https://claude.com/claude-code)