### PR TITLE
fix: Update Nix flake vendorHash for Go dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
       {
         packages.default = pkgs.buildGoModule {
           pname = "beads";
-          version = "0.9.6";
+          version = "0.9.9";
 
           src = self;
 
@@ -27,7 +27,7 @@
           subPackages = [ "cmd/bd" ];
 
           # Go module dependencies hash (computed via nix build)
-          vendorHash = "sha256-WvwT48izxMxx9qQmZp/6zwv7hHgTVd9KmOJFm7RWvrI=";
+          vendorHash = "sha256-1ufUs1PvFGsSR0DTSymni3RqecEBzAm//OBUWgaTwEs=";
 
           meta = with pkgs.lib; {
             description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";


### PR DESCRIPTION
## Problem

The current flake.nix has an outdated `vendorHash` which causes installation to fail:

```
error: hash mismatch in fixed-output derivation
         specified: sha256-WvwT48izxMxx9qQmZp/6zwv7hHgTVd9KmOJFm7RWvrI=
            got:    sha256-1ufUs1PvFGsSR0DTSymni3RqecEBzAm//OBUWgaTwEs=
```

This prevents users from installing with `nix profile install github:steveyegge/beads`.

## Solution

This PR updates the `vendorHash` to match the current Go module dependencies.

**Note:** I also bumped the version from 0.9.6 to 0.9.9 to match the current project version in `cmd/bd/version.go`. However, if you prefer to only update the hash and keep version at 0.9.6, I'm happy to adjust this PR - just let me know!

## Test Plan

- [x] Build succeeds: `nix build .#default`
- [x] Binary works: `bd version` outputs `0.9.9 (dev)`
- [x] Install from GitHub works: `nix profile install github:heartpunk/beads/fix/nix-flake-vendor-hash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)