### PR TITLE
Fix daemon database discovery to match other commands

### DIFF
--- a/cmd/bd/daemon.go
+++ b/cmd/bd/daemon.go
@@ -115,8 +115,14 @@ func ensureBeadsDir() (string, error) {
 	if dbPath != "" {
 		beadsDir = filepath.Dir(dbPath)
 	} else {
-		// No database path - error out instead of falling back to ~/.beads
-		return "", fmt.Errorf("no database path configured (run 'bd init' or set BEADS_DB)")
+		// Use public API to find database (same logic as other commands)
+		if foundDB := beads.FindDatabasePath(); foundDB != "" {
+			dbPath = foundDB // Store it for later use
+			beadsDir = filepath.Dir(foundDB)
+		} else {
+			// No database found - error out instead of falling back to ~/.beads
+			return "", fmt.Errorf("no database path configured (run 'bd init' or set BEADS_DB)")
+		}
 	}
 
 	if err := os.MkdirAll(beadsDir, 0700); err != nil {


### PR DESCRIPTION
The daemon's ensureBeadsDir() was failing with "no database path configured" while other commands could find the database just fine. It wasn't using beads.FindDatabasePath() like everything else.

Fixed by making the daemon use the same discovery logic as all other commands. Now it properly walks up the directory tree looking for .beads/*.db before giving up.