### PR TITLE
fix(mcp): Fix three critical bugs in beads MCP plugin

### DIFF
--- a/integrations/beads-mcp/src/beads_mcp/tools.py
+++ b/integrations/beads-mcp/src/beads_mcp/tools.py
@@ -51,12 +51,13 @@ async def _get_client() -> BdClientBase:
         
         _client = create_bd_client(
             prefer_daemon=use_daemon,
-            workspace_root=workspace_root
+            working_dir=workspace_root
         )
 
-    # Check version once per server lifetime
+    # Check version once per server lifetime (only for CLI client)
     if not _version_checked:
-        await _client._check_version()
+        if hasattr(_client, '_check_version'):
+            await _client._check_version()
         _version_checked = True
 
     return _client


### PR DESCRIPTION
## Summary

This PR fixes three bugs that prevented the MCP plugin from working correctly. These fixes enable the MCP plugin to work as documented for single-repository setups.

## Bugs Fixed

### 1. Parameter Name Mismatch in tools.py
**Error:** `got an unexpected keyword argument 'workspace_root'`

**Root cause:** In `tools.py` line 54, the code was calling:
```python
_client = create_bd_client(
    prefer_daemon=use_daemon,
    workspace_root=workspace_root  # ❌ Wrong parameter name
)
```

But `create_bd_client()` expects `working_dir`, not `workspace_root`.

**Fix:** Changed to `working_dir=workspace_root`

### 2. Missing Version Check Guard  
**Error:** `'BdDaemonClient' object has no attribute '_check_version'`

**Root cause:** In `tools.py` lines 58-60, the code unconditionally calls:
```python
await _client._check_version()
```

But only `BdCliClient` has this method - `BdDaemonClient` doesn't.

**Fix:** Added guard:
```python
if hasattr(_client, '_check_version'):
    await _client._check_version()
```

### 3. Broken Daemon Fallback Logic
**Error:** `Daemon socket not found at .beads/bd.sock`

**Root cause:** In `bd_client.py` lines 637-649, `create_bd_client()` immediately returns the daemon client without checking if the daemon is actually running. The error only occurs when methods are called later, so the fallback never happens.

**Fix:** Added synchronous socket file check before creating daemon client:
- Walks up directory tree looking for `.beads/bd.sock`
- Only creates daemon client if socket exists
- Falls back to CLI client if socket doesn't exist
- This enables the documented "automatic fallback" behavior

## Testing

Verified on macOS with bd v0.9.9:
- ✅ MCP tools work correctly in single-repo setup
- ✅ Automatic fallback to CLI when daemon isn't running
- ✅ All MCP tool calls succeed after calling `set_context()`

## Related Issues

Addresses symptoms similar to #65 (Windows BEADS_WORKING_DIR issue)

## Notes

- Only modified Python source files, not generated files (uv.lock)
- Changes are backward compatible
- Fixes enable MCP plugin to work as documented for single-repository setups
- Multi-repository bug mentioned in README remains a separate issue