### PR TITLE
fix(mcp): Fix AsyncIO crash on Windows

### DIFF
--- a/integrations/beads-mcp/src/beads_mcp/server.py
+++ b/integrations/beads-mcp/src/beads_mcp/server.py
@@ -1,5 +1,6 @@
 """FastMCP server for beads issue tracker."""
 
+import asyncio
 import os
 import subprocess
 from functools import wraps
@@ -374,9 +375,14 @@ async def debug_env() -> str:
     return "".join(info)
 
 
+async def async_main() -> None:
+    """Async entry point for the MCP server."""
+    await mcp.run_async(transport="stdio")
+
+
 def main() -> None:
     """Entry point for the MCP server."""
-    mcp.run()
+    asyncio.run(async_main())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since our implementation uses `async` IO for subprocess communication, it's crucial to utilize the `fastMCP.run_async()` entry-point of FastMCP.

This should fix crashes on Windows.

ref: steveyegge/beads#53

*NOTE*: Resending the Pull Request because somehow the previous PR commit is missing from the `main` branch.