### PR TITLE
fix: Add Windows build support for daemon command

### DIFF
--- a/cmd/bd/daemon.go
+++ b/cmd/bd/daemon.go
@@ -262,7 +262,7 @@ func startDaemon(interval time.Duration, autoCommit, autoPush bool, logFile, pid
 
 	cmd := exec.Command(exe, args...)
 	cmd.Env = append(os.Environ(), "BD_DAEMON_FOREGROUND=1")
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	configureDaemonProcess(cmd)
 	
 	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
 	if err != nil {

--- a/cmd/bd/daemon_unix.go
+++ b/cmd/bd/daemon_unix.go
@@ -1,0 +1,13 @@
+//go:build unix || linux || darwin
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureDaemonProcess sets up platform-specific process attributes for daemon
+func configureDaemonProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/cmd/bd/daemon_windows.go
+++ b/cmd/bd/daemon_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// configureDaemonProcess sets up platform-specific process attributes for daemon
+func configureDaemonProcess(cmd *exec.Cmd) {
+	// Windows doesn't support Setsid, use CREATE_NEW_PROCESS_GROUP instead
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}


### PR DESCRIPTION
  ## Summary
  - Fixed Windows build compilation error for daemon command
  - Split platform-specific daemon process configuration into separate files
  - `daemon_unix.go`: Uses `Setsid` for Unix/Linux/macOS
  - `daemon_windows.go`: Uses `CREATE_NEW_PROCESS_GROUP` for Windows

  ## Problem
  Building on Windows failed with error:
  cmd\bd\daemon.go:265:41: unknown field Setsid in struct literal of type syscall.SysProcAttr

  The `Setsid` field only exists on Unix/Linux systems.

  ## Solution
  Created platform-specific files using Go build tags to handle daemon process configuration differently on each platform.