### PR TITLE
Fix nil pointer dereference in bd show command

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1347,9 +1347,15 @@ var showCmd = &cobra.Command{
 			if jsonOutput {
 				fmt.Println(string(resp.Data))
 			} else {
+				// Check if issue exists (daemon returns null for non-existent issues)
+				if string(resp.Data) == "null" || len(resp.Data) == 0 {
+					fmt.Fprintf(os.Stderr, "Issue %s not found\n", args[0])
+					os.Exit(1)
+				}
+
 				// Parse response and use existing formatting code
 				type IssueDetails struct {
-					*types.Issue
+					types.Issue
 					Labels       []string       `json:"labels,omitempty"`
 					Dependencies []*types.Issue `json:"dependencies,omitempty"`
 					Dependents   []*types.Issue `json:"dependents,omitempty"`
@@ -1359,7 +1365,7 @@ var showCmd = &cobra.Command{
 					fmt.Fprintf(os.Stderr, "Error parsing response: %v\n", err)
 					os.Exit(1)
 				}
-				issue := details.Issue
+				issue := &details.Issue
 
 				cyan := color.New(color.FgCyan).SprintFunc()
 				


### PR DESCRIPTION
## Summary
Fixed crash in `bd show` when querying non-existent issues via daemon mode.

## Root Cause
The daemon returns `null` for non-existent issues. The client-side JSON unmarshaling failed due to:
1. `IssueDetails` struct embedding `*types.Issue` as a pointer field
2. Missing validation for null responses before unmarshaling

This caused a nil pointer dereference at line 1369 when accessing `issue.CompactionLevel`.

## Changes
- Changed `IssueDetails` struct to embed `types.Issue` by value instead of pointer
- Added null response validation before JSON unmarshaling
- Return appropriate "Issue not found" error for missing issues

## Testing
✓ Non-existent issue (`bd show ts-51`): Returns "Issue ts-51 not found"  
✓ Valid issue (`bd show ts-36`): Displays complete issue details  
✓ JSON output mode (`--json`): Unchanged behavior  
✓ Direct mode (no daemon): No regression  

Fixes panic: `runtime error: invalid memory address or nil pointer dereference`