### PR TITLE
Fix: Pin golangci-lint to v1.62.0 to unblock CI (temporary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.62.0
           args: --timeout=5m


### PR DESCRIPTION
## Problem

All PRs are currently failing CI due to golangci-lint v1.64.8 rejecting the `.golangci.yml` configuration:

```
jsonschema: "linters.exclusions" does not validate with "/properties/linters/properties/exclusions/additionalProperties": additional properties 'presets' not allowed
jsonschema: "linters" does not validate with "/properties/linters/additionalProperties": additional properties 'settings' not allowed
jsonschema: "" does not validate with "/additionalProperties": additional properties 'formatters', 'version' not allowed
```

This is blocking all development, including PR #85 (Claude Code skill updates).

## Solution

**This is a temporary workaround** - pins golangci-lint to v1.62.0 (last known working version) to immediately unblock all PRs.

## Proper Fix (for later)

Two options for a proper long-term fix:

1. **Update `.golangci.yml`** to conform to v1.64+ schema (requires research into what changed)
2. **Wait for golangci-lint fix** - this might be a validation bug in v1.64.8

Until then, keeping the version pinned ensures CI stability.

## Testing

Can verify this works by checking CI runs from before the golangci-lint v1.64.8 release.