### PR TITLE
Add native Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Build
         run: go build -v ./cmd/bd
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ bd daemon --global
 
 **How it works:**
 The single MCP server instance automatically:
-1. Checks for local daemon socket (`.beads/bd.sock`) in your current workspace
+1. Checks for local daemon socket (`.beads/bd.sock`) in your current workspace (Windows note: this file stores the loopback TCP endpoint used by the daemon)
 2. Falls back to global daemon socket (`~/.beads/bd.sock`)
 3. Routes requests to the correct database based on your current working directory
 4. Auto-starts the daemon if it's not running (with exponential backoff on failures)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The installer will:
 ### Manual Install
 
 ```bash
-# Using go install (requires Go 1.23+)
+# Using go install (requires Go 1.24+)
 go install github.com/steveyegge/beads/cmd/bd@latest
 
 # Or build from source
@@ -162,22 +162,41 @@ For other MCP clients, refer to their documentation for how to configure MCP ser
 See [integrations/beads-mcp/README.md](integrations/beads-mcp/README.md) for detailed MCP server documentation.
 
 #### Windows 11
-For Windows you must build from source.
-Assumes git, go-lang and mingw-64 installed and in path.
+
+Beads now ships with native Windows support-no MSYS or MinGW required. Make sure you have:
+
+- [Go 1.24+](https://go.dev/dl/) installed (add `%USERPROFILE%\go\bin` to your `PATH`)
+- Git for Windows
+
+Install via PowerShell:
+
+```pwsh
+irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+```
+
+Install with `go install`:
+
+```pwsh
+go install github.com/steveyegge/beads/cmd/bd@latest
+```
+
+After installation, confirm `bd.exe` is discoverable:
+
+```pwsh
+bd version
+```
+
+Or build from source:
 
 ```pwsh
 git clone https://github.com/steveyegge/beads
 cd beads
-$env:CGO_ENABLED=1
 go build -o bd.exe ./cmd/bd
-mv bd.exe $env:USERPROFILE/.local/bin/ # or anywhere in your PATH
+Move-Item bd.exe $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\
+# or copy anywhere on your PATH
 ```
 
-Tested with mingw64 from https://github.com/niXman/mingw-builds-binaries
-- version: `1.5.20`
-- architecture: `64 bit`
-- thread model: `posix`
-- C runtime: `ucrt`
+The background daemon listens on a loopback TCP endpoint recorded in `.beads\bd.sock`. Keep that metadata file intact and allow `bd.exe` loopback traffic through any host firewall.
 
 
 ## Quick Start
@@ -1044,6 +1063,8 @@ bd daemon --migrate-to-global
 |------|----------------|----------|
 | **Local** (default) | `.beads/bd.sock` | Single project, per-repo daemon |
 | **Global** (`--global`) | `~/.beads/bd.sock` | Multiple projects, system-wide daemon |
+
+> ℹ️ On Windows these paths refer to metadata files that record the daemon’s loopback TCP endpoint; leave them in place so clients can discover the daemon.
 
 **When to use global daemon:**
 - ✅ Working on multiple beads-enabled projects

--- a/cmd/bd/autoimport_collision_test.go
+++ b/cmd/bd/autoimport_collision_test.go
@@ -83,11 +83,11 @@ func setupAutoImportTest(t *testing.T, testStore *sqlite.SQLiteStorage, tmpDir s
 	t.Helper()
 	store = testStore
 	dbPath = filepath.Join(tmpDir, "test.db")
-	
+
 	storeMutex.Lock()
 	storeActive = true
 	storeMutex.Unlock()
-	
+
 	t.Cleanup(func() {
 		storeMutex.Lock()
 		storeActive = false
@@ -100,7 +100,7 @@ func TestAutoImportMultipleCollisionsRemapped(t *testing.T) {
 	// Create 5 issues in DB with local modifications
 	now := time.Now().UTC()
 	closedTime := now.Add(-1 * time.Hour)
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-mc-1",
@@ -269,7 +269,7 @@ func TestAutoImportMultipleCollisionsRemapped(t *testing.T) {
 func TestAutoImportAllCollisionsRemapped(t *testing.T) {
 	now := time.Now().UTC()
 	closedTime := now.Add(-1 * time.Hour)
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-ac-1",
@@ -345,7 +345,7 @@ func TestAutoImportAllCollisionsRemapped(t *testing.T) {
 // TestAutoImportExactMatchesOnly tests happy path with no conflicts
 func TestAutoImportExactMatchesOnly(t *testing.T) {
 	now := time.Now().UTC()
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-em-1",
@@ -408,7 +408,7 @@ func TestAutoImportExactMatchesOnly(t *testing.T) {
 // TestAutoImportHashUnchanged tests fast path when JSONL hasn't changed
 func TestAutoImportHashUnchanged(t *testing.T) {
 	now := time.Now().UTC()
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-hu-1",
@@ -429,9 +429,9 @@ func TestAutoImportHashUnchanged(t *testing.T) {
 	// Run auto-import first time
 	os.Setenv("BD_DEBUG", "1")
 	defer os.Unsetenv("BD_DEBUG")
-	
+
 	stderrOutput1 := captureStderr(t, autoImportIfNewer)
-	
+
 	// Should trigger import on first run
 	if !strings.Contains(stderrOutput1, "auto-import triggered") && !strings.Contains(stderrOutput1, "hash changed") {
 		t.Logf("First run: %s", stderrOutput1)
@@ -449,7 +449,7 @@ func TestAutoImportHashUnchanged(t *testing.T) {
 // TestAutoImportParseError tests that parse errors are handled gracefully
 func TestAutoImportParseError(t *testing.T) {
 	now := time.Now().UTC()
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-pe-1",
@@ -483,7 +483,7 @@ func TestAutoImportParseError(t *testing.T) {
 // TestAutoImportEmptyJSONL tests behavior with empty JSONL file
 func TestAutoImportEmptyJSONL(t *testing.T) {
 	now := time.Now().UTC()
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-ej-1",
@@ -518,7 +518,7 @@ func TestAutoImportEmptyJSONL(t *testing.T) {
 // TestAutoImportNewIssuesOnly tests importing only new issues
 func TestAutoImportNewIssuesOnly(t *testing.T) {
 	now := time.Now().UTC()
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-ni-1",
@@ -584,7 +584,7 @@ func TestAutoImportNewIssuesOnly(t *testing.T) {
 func TestAutoImportUpdatesExactMatches(t *testing.T) {
 	now := time.Now().UTC()
 	oldTime := now.Add(-24 * time.Hour)
-	
+
 	dbIssues := []*types.Issue{
 		{
 			ID:        "test-um-1",
@@ -670,7 +670,7 @@ func TestAutoImportJSONLNotFound(t *testing.T) {
 // TestAutoImportCollisionRemapMultipleFields tests remapping with different field conflicts
 func TestAutoImportCollisionRemapMultipleFields(t *testing.T) {
 	now := time.Now().UTC()
-	
+
 	// Create issue with many fields set
 	dbIssues := []*types.Issue{
 		{

--- a/cmd/bd/autostart_test.go
+++ b/cmd/bd/autostart_test.go
@@ -125,19 +125,19 @@ func TestDaemonStartFailureTracking(t *testing.T) {
 			{3, 20 * time.Second},
 			{4, 40 * time.Second},
 			{5, 80 * time.Second},
-			{6, 120 * time.Second}, // Capped
+			{6, 120 * time.Second},  // Capped
 			{10, 120 * time.Second}, // Still capped
 		}
 
 		for _, tc := range testCases {
 			daemonStartFailures = tc.failures
 			lastDaemonStartAttempt = time.Now()
-			
+
 			// Should not allow retry immediately
 			if canRetryDaemonStart() {
 				t.Errorf("Failures=%d: Expected immediate retry to be blocked", tc.failures)
 			}
-			
+
 			// Should allow retry after expected duration
 			lastDaemonStartAttempt = time.Now().Add(-(tc.expected + time.Second))
 			if !canRetryDaemonStart() {
@@ -174,7 +174,7 @@ func TestGetSocketPath(t *testing.T) {
 
 	t.Run("prefers local socket when it exists", func(t *testing.T) {
 		localSocket := filepath.Join(beadsDir, "bd.sock")
-		
+
 		// Create local socket file
 		if err := os.WriteFile(localSocket, []byte{}, 0644); err != nil {
 			t.Fatalf("Failed to create socket file: %v", err)
@@ -202,7 +202,7 @@ func TestGetSocketPath(t *testing.T) {
 			t.Fatalf("Failed to create global beads directory: %v", err)
 		}
 		globalSocket := filepath.Join(globalBeadsDir, "bd.sock")
-		
+
 		if err := os.WriteFile(globalSocket, []byte{}, 0644); err != nil {
 			t.Fatalf("Failed to create global socket file: %v", err)
 		}
@@ -218,7 +218,7 @@ func TestGetSocketPath(t *testing.T) {
 		// Ensure no sockets exist
 		localSocket := filepath.Join(beadsDir, "bd.sock")
 		os.Remove(localSocket)
-		
+
 		home, err := os.UserHomeDir()
 		if err != nil {
 			t.Skip("Cannot get home directory")

--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -123,10 +123,10 @@ func runCompactSingle(ctx context.Context, compactor *compact.Compactor, store *
 	if compactDryRun {
 		if jsonOutput {
 			output := map[string]interface{}{
-				"dry_run":       true,
-				"tier":          compactTier,
-				"issue_id":      issueID,
-				"original_size": originalSize,
+				"dry_run":             true,
+				"tier":                compactTier,
+				"issue_id":            issueID,
+				"original_size":       originalSize,
 				"estimated_reduction": "70-80%",
 			}
 			outputJSON(output)

--- a/cmd/bd/daemon_rotation_test.go
+++ b/cmd/bd/daemon_rotation_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestLogRotation(t *testing.T) {
-	
+
 	// Set small max size for testing (1 MB)
 	os.Setenv("BEADS_DAEMON_LOG_MAX_SIZE", "1")
 	os.Setenv("BEADS_DAEMON_LOG_MAX_BACKUPS", "2")
@@ -18,18 +18,18 @@ func TestLogRotation(t *testing.T) {
 		os.Unsetenv("BEADS_DAEMON_LOG_MAX_AGE")
 		os.Unsetenv("BEADS_DAEMON_LOG_COMPRESS")
 	}()
-	
+
 	// Test env parsing
 	maxSize := getEnvInt("BEADS_DAEMON_LOG_MAX_SIZE", 10)
 	if maxSize != 1 {
 		t.Errorf("Expected max size 1, got %d", maxSize)
 	}
-	
+
 	maxBackups := getEnvInt("BEADS_DAEMON_LOG_MAX_BACKUPS", 3)
 	if maxBackups != 2 {
 		t.Errorf("Expected max backups 2, got %d", maxBackups)
 	}
-	
+
 	compress := getEnvBool("BEADS_DAEMON_LOG_COMPRESS", true)
 	if compress {
 		t.Errorf("Expected compress false, got true")
@@ -49,7 +49,7 @@ func TestGetEnvInt(t *testing.T) {
 		{"zero", "0", 10, 0},
 		{"negative", "-5", 10, -5},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envValue != "" {
@@ -58,7 +58,7 @@ func TestGetEnvInt(t *testing.T) {
 			} else {
 				os.Unsetenv("TEST_INT")
 			}
-			
+
 			result := getEnvInt("TEST_INT", tt.defaultValue)
 			if result != tt.expected {
 				t.Errorf("Expected %d, got %d", tt.expected, result)
@@ -82,7 +82,7 @@ func TestGetEnvBool(t *testing.T) {
 		{"0 string", "0", true, false},
 		{"invalid string", "invalid", true, false},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.envValue != "" {
@@ -91,7 +91,7 @@ func TestGetEnvBool(t *testing.T) {
 			} else {
 				os.Unsetenv("TEST_BOOL")
 			}
-			
+
 			result := getEnvBool("TEST_BOOL", tt.defaultValue)
 			if result != tt.expected {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
@@ -106,22 +106,22 @@ func TestLogFileRotationDefaults(t *testing.T) {
 	os.Unsetenv("BEADS_DAEMON_LOG_MAX_BACKUPS")
 	os.Unsetenv("BEADS_DAEMON_LOG_MAX_AGE")
 	os.Unsetenv("BEADS_DAEMON_LOG_COMPRESS")
-	
+
 	maxSize := getEnvInt("BEADS_DAEMON_LOG_MAX_SIZE", 10)
 	if maxSize != 10 {
 		t.Errorf("Expected default max size 10, got %d", maxSize)
 	}
-	
+
 	maxBackups := getEnvInt("BEADS_DAEMON_LOG_MAX_BACKUPS", 3)
 	if maxBackups != 3 {
 		t.Errorf("Expected default max backups 3, got %d", maxBackups)
 	}
-	
+
 	maxAge := getEnvInt("BEADS_DAEMON_LOG_MAX_AGE", 7)
 	if maxAge != 7 {
 		t.Errorf("Expected default max age 7, got %d", maxAge)
 	}
-	
+
 	compress := getEnvBool("BEADS_DAEMON_LOG_COMPRESS", true)
 	if !compress {
 		t.Errorf("Expected default compress true, got false")

--- a/cmd/bd/daemon_unix.go
+++ b/cmd/bd/daemon_unix.go
@@ -3,11 +3,26 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
 
+var daemonSignals = []os.Signal{syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP}
+
 // configureDaemonProcess sets up platform-specific process attributes for daemon
 func configureDaemonProcess(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+func sendStopSignal(process *os.Process) error {
+	return process.Signal(syscall.SIGTERM)
+}
+
+func isReloadSignal(sig os.Signal) bool {
+	return sig == syscall.SIGHUP
+}
+
+func isProcessRunning(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
 }

--- a/cmd/bd/daemon_windows.go
+++ b/cmd/bd/daemon_windows.go
@@ -3,14 +3,47 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
+
+const stillActive = 259
+
+var daemonSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
 
 // configureDaemonProcess sets up platform-specific process attributes for daemon
 func configureDaemonProcess(cmd *exec.Cmd) {
-	// Windows doesn't support Setsid, use CREATE_NEW_PROCESS_GROUP instead
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		HideWindow:    true,
 	}
+}
+
+func sendStopSignal(process *os.Process) error {
+	if err := process.Signal(syscall.SIGTERM); err == nil {
+		return nil
+	}
+	return process.Kill()
+}
+
+func isReloadSignal(os.Signal) bool {
+	return false
+}
+
+func isProcessRunning(pid int) bool {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+
+	var code uint32
+	if err := windows.GetExitCodeProcess(handle, &code); err != nil {
+		return false
+	}
+
+	return code == stillActive
 }

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -54,11 +54,11 @@ Force: Delete and orphan dependents
 		force, _ := cmd.Flags().GetBool("force")
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		cascade, _ := cmd.Flags().GetBool("cascade")
-		
+
 		// Collect issue IDs from args and/or file
 		issueIDs := make([]string, 0, len(args))
 		issueIDs = append(issueIDs, args...)
-		
+
 		if fromFile != "" {
 			fileIDs, err := readIssueIDsFromFile(fromFile)
 			if err != nil {
@@ -67,38 +67,40 @@ Force: Delete and orphan dependents
 			}
 			issueIDs = append(issueIDs, fileIDs...)
 		}
-		
+
 		if len(issueIDs) == 0 {
 			fmt.Fprintf(os.Stderr, "Error: no issue IDs provided\n")
 			cmd.Usage()
 			os.Exit(1)
 		}
-		
+
 		// Remove duplicates
 		issueIDs = uniqueStrings(issueIDs)
-		
+
 		// Handle batch deletion
 		if len(issueIDs) > 1 {
 			deleteBatch(cmd, issueIDs, force, dryRun, cascade)
 			return
 		}
-		
+
 		// Single issue deletion (legacy behavior)
 		issueID := issueIDs[0]
-		
-		// If daemon is running but doesn't support this command, use direct storage
-		if daemonClient != nil && store == nil {
-			var err error
-			store, err = sqlite.New(dbPath)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: failed to open database: %v\n", err)
+
+		// Ensure we have a direct store when daemon lacks delete support
+		if daemonClient != nil {
+			if err := ensureDirectMode("daemon does not support delete command"); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
-			defer store.Close()
+		} else if store == nil {
+			if err := ensureStoreActive(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
 		}
-		
+
 		ctx := context.Background()
-		
+
 		// Get the issue to be deleted
 		issue, err := store.GetIssue(ctx, issueID)
 		if err != nil {
@@ -109,10 +111,10 @@ Force: Delete and orphan dependents
 			fmt.Fprintf(os.Stderr, "Error: issue %s not found\n", issueID)
 			os.Exit(1)
 		}
-		
+
 		// Find all connected issues (dependencies in both directions)
 		connectedIssues := make(map[string]*types.Issue)
-		
+
 		// Get dependencies (issues this one depends on)
 		deps, err := store.GetDependencies(ctx, issueID)
 		if err != nil {
@@ -122,7 +124,7 @@ Force: Delete and orphan dependents
 		for _, dep := range deps {
 			connectedIssues[dep.ID] = dep
 		}
-		
+
 		// Get dependents (issues that depend on this one)
 		dependents, err := store.GetDependents(ctx, issueID)
 		if err != nil {
@@ -132,29 +134,29 @@ Force: Delete and orphan dependents
 		for _, dependent := range dependents {
 			connectedIssues[dependent.ID] = dependent
 		}
-		
+
 		// Get dependency records (outgoing) to count how many we'll remove
 		depRecords, err := store.GetDependencyRecords(ctx, issueID)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting dependency records: %v\n", err)
 			os.Exit(1)
 		}
-		
+
 		// Build the regex pattern for matching issue IDs (handles hyphenated IDs properly)
 		// Pattern: (^|non-word-char)(issueID)($|non-word-char) where word-char includes hyphen
 		idPattern := `(^|[^A-Za-z0-9_-])(` + regexp.QuoteMeta(issueID) + `)($|[^A-Za-z0-9_-])`
 		re := regexp.MustCompile(idPattern)
 		replacementText := `$1[deleted:` + issueID + `]$3`
-		
+
 		// Preview mode
 		if !force {
 			red := color.New(color.FgRed).SprintFunc()
 			yellow := color.New(color.FgYellow).SprintFunc()
-			
+
 			fmt.Printf("\n%s\n", red("⚠️  DELETE PREVIEW"))
 			fmt.Printf("\nIssue to delete:\n")
 			fmt.Printf("  %s: %s\n", issueID, issue.Title)
-			
+
 			totalDeps := len(depRecords) + len(dependents)
 			if totalDeps > 0 {
 				fmt.Printf("\nDependency links to remove: %d\n", totalDeps)
@@ -165,7 +167,7 @@ Force: Delete and orphan dependents
 					fmt.Printf("  %s → %s (inbound)\n", dep.ID, issueID)
 				}
 			}
-			
+
 			if len(connectedIssues) > 0 {
 				fmt.Printf("\nConnected issues where text references will be updated:\n")
 				issuesWithRefs := 0
@@ -175,7 +177,7 @@ Force: Delete and orphan dependents
 						(connIssue.Notes != "" && re.MatchString(connIssue.Notes)) ||
 						(connIssue.Design != "" && re.MatchString(connIssue.Design)) ||
 						(connIssue.AcceptanceCriteria != "" && re.MatchString(connIssue.AcceptanceCriteria))
-					
+
 					if hasRefs {
 						fmt.Printf("  %s: %s\n", id, connIssue.Title)
 						issuesWithRefs++
@@ -185,43 +187,43 @@ Force: Delete and orphan dependents
 					fmt.Printf("  (none have text references)\n")
 				}
 			}
-			
+
 			fmt.Printf("\n%s\n", yellow("This operation cannot be undone!"))
 			fmt.Printf("To proceed, run: %s\n\n", yellow("bd delete "+issueID+" --force"))
 			return
 		}
-		
+
 		// Actually delete
-		
+
 		// 1. Update text references in connected issues (all text fields)
 		updatedIssueCount := 0
 		for id, connIssue := range connectedIssues {
 			updates := make(map[string]interface{})
-			
+
 			// Replace in description
 			if re.MatchString(connIssue.Description) {
 				newDesc := re.ReplaceAllString(connIssue.Description, replacementText)
 				updates["description"] = newDesc
 			}
-			
+
 			// Replace in notes
 			if connIssue.Notes != "" && re.MatchString(connIssue.Notes) {
 				newNotes := re.ReplaceAllString(connIssue.Notes, replacementText)
 				updates["notes"] = newNotes
 			}
-			
+
 			// Replace in design
 			if connIssue.Design != "" && re.MatchString(connIssue.Design) {
 				newDesign := re.ReplaceAllString(connIssue.Design, replacementText)
 				updates["design"] = newDesign
 			}
-			
+
 			// Replace in acceptance_criteria
 			if connIssue.AcceptanceCriteria != "" && re.MatchString(connIssue.AcceptanceCriteria) {
 				newAC := re.ReplaceAllString(connIssue.AcceptanceCriteria, replacementText)
 				updates["acceptance_criteria"] = newAC
 			}
-			
+
 			if len(updates) > 0 {
 				if err := store.UpdateIssue(ctx, id, updates, actor); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: Failed to update references in %s: %v\n", id, err)
@@ -230,43 +232,43 @@ Force: Delete and orphan dependents
 				}
 			}
 		}
-		
+
 		// 2. Remove all dependency links (outgoing)
 		outgoingRemoved := 0
 		for _, dep := range depRecords {
 			if err := store.RemoveDependency(ctx, dep.IssueID, dep.DependsOnID, actor); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to remove dependency %s → %s: %v\n", 
+				fmt.Fprintf(os.Stderr, "Warning: Failed to remove dependency %s → %s: %v\n",
 					dep.IssueID, dep.DependsOnID, err)
 			} else {
 				outgoingRemoved++
 			}
 		}
-		
+
 		// 3. Remove inbound dependency links (issues that depend on this one)
 		inboundRemoved := 0
 		for _, dep := range dependents {
 			if err := store.RemoveDependency(ctx, dep.ID, issueID, actor); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: Failed to remove dependency %s → %s: %v\n", 
+				fmt.Fprintf(os.Stderr, "Warning: Failed to remove dependency %s → %s: %v\n",
 					dep.ID, issueID, err)
 			} else {
 				inboundRemoved++
 			}
 		}
-		
+
 		// 4. Delete the issue itself from database
 		if err := deleteIssue(ctx, issueID); err != nil {
 			fmt.Fprintf(os.Stderr, "Error deleting issue: %v\n", err)
 			os.Exit(1)
 		}
-		
+
 		// 5. Remove from JSONL (auto-flush can't see deletions)
 		if err := removeIssueFromJSONL(issueID); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to remove from JSONL: %v\n", err)
 		}
-		
+
 		// Schedule auto-flush to update neighbors
 		markDirtyAndScheduleFlush()
-		
+
 		totalDepsRemoved := outgoingRemoved + inboundRemoved
 		if jsonOutput {
 			outputJSON(map[string]interface{}{
@@ -291,11 +293,11 @@ func deleteIssue(ctx context.Context, issueID string) error {
 	type deleter interface {
 		DeleteIssue(ctx context.Context, id string) error
 	}
-	
+
 	if d, ok := store.(deleter); ok {
 		return d.DeleteIssue(ctx, issueID)
 	}
-	
+
 	return fmt.Errorf("delete operation not supported by this storage backend")
 }
 
@@ -306,7 +308,7 @@ func removeIssueFromJSONL(issueID string) error {
 	if path == "" {
 		return nil // No JSONL file yet
 	}
-	
+
 	// Read all issues except the deleted one
 	f, err := os.Open(path)
 	if err != nil {
@@ -315,8 +317,7 @@ func removeIssueFromJSONL(issueID string) error {
 		}
 		return fmt.Errorf("failed to open JSONL: %w", err)
 	}
-	defer f.Close()
-	
+
 	var issues []*types.Issue
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -334,16 +335,21 @@ func removeIssueFromJSONL(issueID string) error {
 		}
 	}
 	if err := scanner.Err(); err != nil {
+		f.Close()
 		return fmt.Errorf("failed to read JSONL: %w", err)
 	}
-	
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close JSONL: %w", err)
+	}
+
 	// Write to temp file atomically
 	temp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
 	out, err := os.OpenFile(temp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	
+
 	enc := json.NewEncoder(out)
 	for _, iss := range issues {
 		if err := enc.Encode(iss); err != nil {
@@ -352,43 +358,45 @@ func removeIssueFromJSONL(issueID string) error {
 			return fmt.Errorf("failed to write issue: %w", err)
 		}
 	}
-	
+
 	if err := out.Close(); err != nil {
 		os.Remove(temp)
 		return fmt.Errorf("failed to close temp file: %w", err)
 	}
-	
+
 	// Atomic rename
 	if err := os.Rename(temp, path); err != nil {
 		os.Remove(temp)
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
-	
+
 	return nil
 }
 
 // deleteBatch handles deletion of multiple issues
 func deleteBatch(cmd *cobra.Command, issueIDs []string, force bool, dryRun bool, cascade bool) {
-	// If daemon is running but doesn't support this command, use direct storage
-	if daemonClient != nil && store == nil {
-		var err error
-		store, err = sqlite.New(dbPath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: failed to open database: %v\n", err)
+	// Ensure we have a direct store when daemon lacks delete support
+	if daemonClient != nil {
+		if err := ensureDirectMode("daemon does not support delete command"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		defer store.Close()
+	} else if store == nil {
+		if err := ensureStoreActive(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 	}
-	
+
 	ctx := context.Background()
-	
+
 	// Type assert to SQLite storage
 	d, ok := store.(*sqlite.SQLiteStorage)
 	if !ok {
 		fmt.Fprintf(os.Stderr, "Error: batch delete not supported by this storage backend\n")
 		os.Exit(1)
 	}
-	
+
 	// Verify all issues exist
 	issues := make(map[string]*types.Issue)
 	notFound := []string{}
@@ -404,12 +412,12 @@ func deleteBatch(cmd *cobra.Command, issueIDs []string, force bool, dryRun bool,
 			issues[id] = issue
 		}
 	}
-	
+
 	if len(notFound) > 0 {
 		fmt.Fprintf(os.Stderr, "Error: issues not found: %s\n", strings.Join(notFound, ", "))
 		os.Exit(1)
 	}
-	
+
 	// Dry-run or preview mode
 	if dryRun || !force {
 		result, err := d.DeleteIssues(ctx, issueIDs, cascade, false, true)
@@ -418,38 +426,38 @@ func deleteBatch(cmd *cobra.Command, issueIDs []string, force bool, dryRun bool,
 			showDeletionPreview(issueIDs, issues, cascade, err)
 			os.Exit(1)
 		}
-		
+
 		showDeletionPreview(issueIDs, issues, cascade, nil)
 		fmt.Printf("\nWould delete: %d issues\n", result.DeletedCount)
-		fmt.Printf("Would remove: %d dependencies, %d labels, %d events\n", 
+		fmt.Printf("Would remove: %d dependencies, %d labels, %d events\n",
 			result.DependenciesCount, result.LabelsCount, result.EventsCount)
 		if len(result.OrphanedIssues) > 0 {
 			fmt.Printf("Would orphan: %d issues\n", len(result.OrphanedIssues))
 		}
-		
+
 		if dryRun {
 			fmt.Printf("\n(Dry-run mode - no changes made)\n")
 		} else {
 			yellow := color.New(color.FgYellow).SprintFunc()
 			fmt.Printf("\n%s\n", yellow("This operation cannot be undone!"))
 			if cascade {
-				fmt.Printf("To proceed with cascade deletion, run: %s\n", 
+				fmt.Printf("To proceed with cascade deletion, run: %s\n",
 					yellow("bd delete "+strings.Join(issueIDs, " ")+" --cascade --force"))
 			} else {
-				fmt.Printf("To proceed, run: %s\n", 
+				fmt.Printf("To proceed, run: %s\n",
 					yellow("bd delete "+strings.Join(issueIDs, " ")+" --force"))
 			}
 		}
 		return
 	}
-	
+
 	// Pre-collect connected issues before deletion (so we can update their text references)
 	connectedIssues := make(map[string]*types.Issue)
 	idSet := make(map[string]bool)
 	for _, id := range issueIDs {
 		idSet[id] = true
 	}
-	
+
 	for _, id := range issueIDs {
 		// Get dependencies (issues this one depends on)
 		deps, err := store.GetDependencies(ctx, id)
@@ -460,7 +468,7 @@ func deleteBatch(cmd *cobra.Command, issueIDs []string, force bool, dryRun bool,
 				}
 			}
 		}
-		
+
 		// Get dependents (issues that depend on this one)
 		dependents, err := store.GetDependents(ctx, id)
 		if err == nil {
@@ -471,27 +479,27 @@ func deleteBatch(cmd *cobra.Command, issueIDs []string, force bool, dryRun bool,
 			}
 		}
 	}
-	
+
 	// Actually delete
 	result, err := d.DeleteIssues(ctx, issueIDs, cascade, force, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	// Update text references in connected issues (using pre-collected issues)
 	updatedCount := updateTextReferencesInIssues(ctx, issueIDs, connectedIssues)
-	
+
 	// Remove from JSONL
 	for _, id := range issueIDs {
 		if err := removeIssueFromJSONL(id); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to remove %s from JSONL: %v\n", id, err)
 		}
 	}
-	
+
 	// Schedule auto-flush
 	markDirtyAndScheduleFlush()
-	
+
 	// Output results
 	if jsonOutput {
 		outputJSON(map[string]interface{}{
@@ -512,7 +520,7 @@ func deleteBatch(cmd *cobra.Command, issueIDs []string, force bool, dryRun bool,
 		fmt.Printf("  Updated text references in %d issue(s)\n", updatedCount)
 		if len(result.OrphanedIssues) > 0 {
 			yellow := color.New(color.FgYellow).SprintFunc()
-			fmt.Printf("  %s Orphaned %d issue(s): %s\n", 
+			fmt.Printf("  %s Orphaned %d issue(s): %s\n",
 				yellow("⚠"), len(result.OrphanedIssues), strings.Join(result.OrphanedIssues, ", "))
 		}
 	}
@@ -522,7 +530,7 @@ func deleteBatch(cmd *cobra.Command, issueIDs []string, force bool, dryRun bool,
 func showDeletionPreview(issueIDs []string, issues map[string]*types.Issue, cascade bool, depError error) {
 	red := color.New(color.FgRed).SprintFunc()
 	yellow := color.New(color.FgYellow).SprintFunc()
-	
+
 	fmt.Printf("\n%s\n", red("⚠️  DELETE PREVIEW"))
 	fmt.Printf("\nIssues to delete (%d):\n", len(issueIDs))
 	for _, id := range issueIDs {
@@ -530,11 +538,11 @@ func showDeletionPreview(issueIDs []string, issues map[string]*types.Issue, casc
 			fmt.Printf("  %s: %s\n", id, issue.Title)
 		}
 	}
-	
+
 	if cascade {
 		fmt.Printf("\n%s Cascade mode enabled - will also delete all dependent issues\n", yellow("⚠"))
 	}
-	
+
 	if depError != nil {
 		fmt.Printf("\n%s\n", red(depError.Error()))
 	}
@@ -543,17 +551,17 @@ func showDeletionPreview(issueIDs []string, issues map[string]*types.Issue, casc
 // updateTextReferencesInIssues updates text references to deleted issues in pre-collected connected issues
 func updateTextReferencesInIssues(ctx context.Context, deletedIDs []string, connectedIssues map[string]*types.Issue) int {
 	updatedCount := 0
-	
+
 	// For each deleted issue, update references in all connected issues
 	for _, id := range deletedIDs {
 		// Build regex pattern
 		idPattern := `(^|[^A-Za-z0-9_-])(` + regexp.QuoteMeta(id) + `)($|[^A-Za-z0-9_-])`
 		re := regexp.MustCompile(idPattern)
 		replacementText := `$1[deleted:` + id + `]$3`
-		
+
 		for connID, connIssue := range connectedIssues {
 			updates := make(map[string]interface{})
-			
+
 			if re.MatchString(connIssue.Description) {
 				updates["description"] = re.ReplaceAllString(connIssue.Description, replacementText)
 			}
@@ -566,7 +574,7 @@ func updateTextReferencesInIssues(ctx context.Context, deletedIDs []string, conn
 			if connIssue.AcceptanceCriteria != "" && re.MatchString(connIssue.AcceptanceCriteria) {
 				updates["acceptance_criteria"] = re.ReplaceAllString(connIssue.AcceptanceCriteria, replacementText)
 			}
-			
+
 			if len(updates) > 0 {
 				if err := store.UpdateIssue(ctx, connID, updates, actor); err == nil {
 					updatedCount++
@@ -587,7 +595,7 @@ func updateTextReferencesInIssues(ctx context.Context, deletedIDs []string, conn
 			}
 		}
 	}
-	
+
 	return updatedCount
 }
 
@@ -598,7 +606,7 @@ func readIssueIDsFromFile(filename string) ([]string, error) {
 		return nil, err
 	}
 	defer f.Close()
-	
+
 	var ids []string
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
@@ -609,11 +617,11 @@ func readIssueIDsFromFile(filename string) ([]string, error) {
 		}
 		ids = append(ids, line)
 	}
-	
+
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-	
+
 	return ids, nil
 }
 

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -59,8 +59,8 @@ var depAddCmd = &cobra.Command{
 
 		ctx := context.Background()
 		if err := store.AddDependency(ctx, dep, actor); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
 		}
 
 		// Schedule auto-flush
@@ -69,41 +69,41 @@ var depAddCmd = &cobra.Command{
 		// Check for cycles after adding dependency
 		cycles, err := store.DetectCycles(ctx)
 		if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Failed to check for cycles: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: Failed to check for cycles: %v\n", err)
 		} else if len(cycles) > 0 {
-		yellow := color.New(color.FgYellow).SprintFunc()
-		fmt.Fprintf(os.Stderr, "\n%s Warning: Dependency cycle detected!\n", yellow("⚠"))
-		fmt.Fprintf(os.Stderr, "This can hide issues from the ready work list and cause confusion.\n\n")
-		 fmt.Fprintf(os.Stderr, "Cycle path:\n")
-		for _, cycle := range cycles {
-		  for j, issue := range cycle {
-		   if j == 0 {
-		   fmt.Fprintf(os.Stderr, "  %s", issue.ID)
-				} else {
-					fmt.Fprintf(os.Stderr, " → %s", issue.ID)
+			yellow := color.New(color.FgYellow).SprintFunc()
+			fmt.Fprintf(os.Stderr, "\n%s Warning: Dependency cycle detected!\n", yellow("⚠"))
+			fmt.Fprintf(os.Stderr, "This can hide issues from the ready work list and cause confusion.\n\n")
+			fmt.Fprintf(os.Stderr, "Cycle path:\n")
+			for _, cycle := range cycles {
+				for j, issue := range cycle {
+					if j == 0 {
+						fmt.Fprintf(os.Stderr, "  %s", issue.ID)
+					} else {
+						fmt.Fprintf(os.Stderr, " → %s", issue.ID)
+					}
 				}
+				if len(cycle) > 0 {
+					fmt.Fprintf(os.Stderr, " → %s", cycle[0].ID)
+				}
+				fmt.Fprintf(os.Stderr, "\n")
 			}
-			if len(cycle) > 0 {
-				fmt.Fprintf(os.Stderr, " → %s", cycle[0].ID)
-			}
-			fmt.Fprintf(os.Stderr, "\n")
+			fmt.Fprintf(os.Stderr, "\nRun 'bd dep cycles' for detailed analysis.\n\n")
 		}
-		fmt.Fprintf(os.Stderr, "\nRun 'bd dep cycles' for detailed analysis.\n\n")
-	}
 
-	if jsonOutput {
-		outputJSON(map[string]interface{}{
-			"status":       "added",
-			"issue_id":     args[0],
-			"depends_on_id": args[1],
-			"type":         depType,
-		})
-		return
-	}
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"status":        "added",
+				"issue_id":      args[0],
+				"depends_on_id": args[1],
+				"type":          depType,
+			})
+			return
+		}
 
-	green := color.New(color.FgGreen).SprintFunc()
-	fmt.Printf("%s Added dependency: %s depends on %s (%s)\n",
-		green("✓"), args[0], args[1], depType)
+		green := color.New(color.FgGreen).SprintFunc()
+		fmt.Printf("%s Added dependency: %s depends on %s (%s)\n",
+			green("✓"), args[0], args[1], depType)
 	},
 }
 
@@ -148,8 +148,8 @@ var depRemoveCmd = &cobra.Command{
 
 		if jsonOutput {
 			outputJSON(map[string]interface{}{
-				"status":       "removed",
-				"issue_id":     args[0],
+				"status":        "removed",
+				"issue_id":      args[0],
 				"depends_on_id": args[1],
 			})
 			return
@@ -179,12 +179,12 @@ var depTreeCmd = &cobra.Command{
 
 		showAllPaths, _ := cmd.Flags().GetBool("show-all-paths")
 		maxDepth, _ := cmd.Flags().GetInt("max-depth")
-		
+
 		if maxDepth < 1 {
 			fmt.Fprintf(os.Stderr, "Error: --max-depth must be >= 1\n")
 			os.Exit(1)
 		}
-		
+
 		ctx := context.Background()
 		tree, err := store.GetDependencyTree(ctx, args[0], maxDepth, showAllPaths)
 		if err != nil {

--- a/cmd/bd/direct_mode.go
+++ b/cmd/bd/direct_mode.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/steveyegge/beads"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+)
+
+// ensureDirectMode makes sure the CLI is operating in direct-storage mode.
+// If the daemon is active, it is cleanly disconnected and the shared store is opened.
+func ensureDirectMode(reason string) error {
+	if daemonClient != nil {
+		if err := fallbackToDirectMode(reason); err != nil {
+			return err
+		}
+		return nil
+	}
+	return ensureStoreActive()
+}
+
+// fallbackToDirectMode disables the daemon client and ensures a local store is ready.
+func fallbackToDirectMode(reason string) error {
+	disableDaemonForFallback(reason)
+	return ensureStoreActive()
+}
+
+// disableDaemonForFallback closes the daemon client and updates status metadata.
+func disableDaemonForFallback(reason string) {
+	if daemonClient != nil {
+		_ = daemonClient.Close()
+		daemonClient = nil
+	}
+
+	daemonStatus.Mode = "direct"
+	daemonStatus.Connected = false
+	daemonStatus.Degraded = true
+	if reason != "" {
+		daemonStatus.Detail = reason
+	}
+	if daemonStatus.FallbackReason == FallbackNone {
+		daemonStatus.FallbackReason = FallbackDaemonUnsupported
+	}
+
+	if reason != "" && os.Getenv("BD_DEBUG") != "" {
+		fmt.Fprintf(os.Stderr, "Debug: %s\n", reason)
+	}
+}
+
+// ensureStoreActive guarantees that a local SQLite store is initialized and tracked.
+func ensureStoreActive() error {
+	storeMutex.Lock()
+	active := storeActive && store != nil
+	storeMutex.Unlock()
+	if active {
+		return nil
+	}
+
+	if dbPath == "" {
+		if found := beads.FindDatabasePath(); found != "" {
+			dbPath = found
+		} else {
+			return fmt.Errorf("no beads database found. Hint: run 'bd init' in this directory")
+		}
+	}
+
+	sqlStore, err := sqlite.New(dbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	storeMutex.Lock()
+	store = sqlStore
+	storeActive = true
+	storeMutex.Unlock()
+
+	checkVersionMismatch()
+	if autoImportEnabled {
+		autoImportIfNewer()
+	}
+
+	return nil
+}

--- a/cmd/bd/direct_mode_test.go
+++ b/cmd/bd/direct_mode_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/rpc"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestFallbackToDirectModeEnablesFlush(t *testing.T) {
+	origDaemonClient := daemonClient
+	origDaemonStatus := daemonStatus
+	origStore := store
+	origStoreActive := storeActive
+	origDBPath := dbPath
+	origAutoImport := autoImportEnabled
+	origAutoFlush := autoFlushEnabled
+	origIsDirty := isDirty
+	origNeedsFull := needsFullExport
+	origFlushFailures := flushFailureCount
+	origLastFlushErr := lastFlushError
+
+	flushMutex.Lock()
+	if flushTimer != nil {
+		flushTimer.Stop()
+		flushTimer = nil
+	}
+	flushMutex.Unlock()
+
+	defer func() {
+		if store != nil && store != origStore {
+			_ = store.Close()
+		}
+		storeMutex.Lock()
+		store = origStore
+		storeActive = origStoreActive
+		storeMutex.Unlock()
+
+		daemonClient = origDaemonClient
+		daemonStatus = origDaemonStatus
+		dbPath = origDBPath
+		autoImportEnabled = origAutoImport
+		autoFlushEnabled = origAutoFlush
+		isDirty = origIsDirty
+		needsFullExport = origNeedsFull
+		flushFailureCount = origFlushFailures
+		lastFlushError = origLastFlushErr
+
+		flushMutex.Lock()
+		if flushTimer != nil {
+			flushTimer.Stop()
+			flushTimer = nil
+		}
+		flushMutex.Unlock()
+	}()
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+	testDBPath := filepath.Join(beadsDir, "test.db")
+
+	// Seed database with issues
+	setupStore, err := sqlite.New(testDBPath)
+	if err != nil {
+		t.Fatalf("failed to create seed store: %v", err)
+	}
+
+	ctx := context.Background()
+	target := &types.Issue{
+		Title:     "Issue to delete",
+		IssueType: types.TypeTask,
+		Priority:  2,
+		Status:    types.StatusOpen,
+	}
+	if err := setupStore.CreateIssue(ctx, target, "test"); err != nil {
+		t.Fatalf("failed to create target issue: %v", err)
+	}
+
+	neighbor := &types.Issue{
+		Title:       "Neighbor issue",
+		Description: "See " + target.ID,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		Status:      types.StatusOpen,
+	}
+	if err := setupStore.CreateIssue(ctx, neighbor, "test"); err != nil {
+		t.Fatalf("failed to create neighbor issue: %v", err)
+	}
+	if err := setupStore.Close(); err != nil {
+		t.Fatalf("failed to close seed store: %v", err)
+	}
+
+	// Simulate daemon-connected state before fallback
+	dbPath = testDBPath
+	storeMutex.Lock()
+	store = nil
+	storeActive = false
+	storeMutex.Unlock()
+	daemonClient = &rpc.Client{}
+	daemonStatus = DaemonStatus{}
+	autoImportEnabled = false
+	autoFlushEnabled = true
+	isDirty = false
+	needsFullExport = false
+
+	if err := fallbackToDirectMode("test fallback"); err != nil {
+		t.Fatalf("fallbackToDirectMode failed: %v", err)
+	}
+
+	if daemonClient != nil {
+		t.Fatal("expected daemonClient to be nil after fallback")
+	}
+
+	storeMutex.Lock()
+	active := storeActive && store != nil
+	storeMutex.Unlock()
+	if !active {
+		t.Fatal("expected store to be active after fallback")
+	}
+
+	// Force a full export and flush synchronously
+	markDirtyAndScheduleFullExport()
+	flushMutex.Lock()
+	if flushTimer != nil {
+		flushTimer.Stop()
+		flushTimer = nil
+	}
+	flushMutex.Unlock()
+	flushToJSONL()
+
+	jsonlPath := findJSONLPath()
+	data, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatalf("failed to read JSONL export: %v", err)
+	}
+
+	if !bytes.Contains(data, []byte(target.ID)) {
+		t.Fatalf("expected JSONL export to contain deleted issue ID %s", target.ID)
+	}
+	if !bytes.Contains(data, []byte(neighbor.ID)) {
+		t.Fatalf("expected JSONL export to contain neighbor issue ID %s", neighbor.ID)
+	}
+}

--- a/cmd/bd/export_import_test.go
+++ b/cmd/bd/export_import_test.go
@@ -252,10 +252,10 @@ func TestExportEmpty(t *testing.T) {
 
 func TestImportInvalidJSON(t *testing.T) {
 	invalidJSON := []string{
-		`{"id":"test-1"`,                    // Incomplete JSON
-		`{"id":"test-1","title":}`,          // Invalid syntax
-		`not json at all`,                   // Not JSON
-		`{"id":"","title":"No ID"}`,         // Empty ID
+		`{"id":"test-1"`,            // Incomplete JSON
+		`{"id":"test-1","title":}`,  // Invalid syntax
+		`not json at all`,           // Not JSON
+		`{"id":"","title":"No ID"}`, // Empty ID
 	}
 
 	for i, line := range invalidJSON {

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -88,7 +88,7 @@ Behavior:
 		}
 
 		result, err := importIssuesCore(ctx, dbPath, store, allIssues, opts)
-		
+
 		// Handle errors and special cases
 		if err != nil {
 			// Check if it's a collision error when not resolving
@@ -124,7 +124,7 @@ Behavior:
 		if len(result.IDMapping) > 0 {
 			fmt.Fprintf(os.Stderr, "\n=== Remapping Report ===\n")
 			fmt.Fprintf(os.Stderr, "Issues remapped: %d\n\n", len(result.IDMapping))
-			
+
 			// Sort by old ID for consistent output
 			type mapping struct {
 				oldID string
@@ -137,7 +137,7 @@ Behavior:
 			sort.Slice(mappings, func(i, j int) bool {
 				return mappings[i].oldID < mappings[j].oldID
 			})
-			
+
 			fmt.Fprintf(os.Stderr, "Remappings:\n")
 			for _, m := range mappings {
 				fmt.Fprintf(os.Stderr, "  %s → %s\n", m.oldID, m.newID)

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -20,7 +20,7 @@ and database file. Optionally specify a custom issue prefix.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		prefix, _ := cmd.Flags().GetString("prefix")
 		quiet, _ := cmd.Flags().GetBool("quiet")
-		
+
 		if prefix == "" {
 			// Auto-detect from directory name
 			cwd, err := os.Getwd()

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -51,7 +51,7 @@ func TestInitCommand(t *testing.T) {
 			rootCmd.SetArgs([]string{})
 			initCmd.Flags().Set("prefix", "")
 			initCmd.Flags().Set("quiet", "false")
-			
+
 			tmpDir := t.TempDir()
 			originalWd, err := os.Getwd()
 			if err != nil {
@@ -80,12 +80,12 @@ func TestInitCommand(t *testing.T) {
 			if tt.quiet {
 				args = append(args, "--quiet")
 			}
-			
+
 			rootCmd.SetArgs(args)
 
 			// Run command
 			err = rootCmd.Execute()
-			
+
 			// Restore stdout and read output
 			w.Close()
 			buf.ReadFrom(r)

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -23,7 +23,7 @@ var labelCmd = &cobra.Command{
 // executeLabelCommand executes a label operation and handles output
 func executeLabelCommand(issueID, label, operation string, operationFunc func(context.Context, string, string, string) error) {
 	ctx := context.Background()
-	
+
 	// Use daemon if available
 	if daemonClient != nil {
 		var err error
@@ -38,7 +38,7 @@ func executeLabelCommand(issueID, label, operation string, operationFunc func(co
 				Label: label,
 			})
 		}
-		
+
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
@@ -100,7 +100,7 @@ var labelListCmd = &cobra.Command{
 
 		ctx := context.Background()
 		var labels []string
-		
+
 		// Use daemon if available
 		if daemonClient != nil {
 			resp, err := daemonClient.Show(&rpc.ShowArgs{ID: issueID})
@@ -108,7 +108,7 @@ var labelListCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
-			
+
 			var issue types.Issue
 			if err := json.Unmarshal(resp.Data, &issue); err != nil {
 				fmt.Fprintf(os.Stderr, "Error parsing response: %v\n", err)
@@ -156,7 +156,7 @@ var labelListAllCmd = &cobra.Command{
 
 		var issues []*types.Issue
 		var err error
-		
+
 		// Use daemon if available
 		if daemonClient != nil {
 			resp, err := daemonClient.List(&rpc.ListArgs{})
@@ -164,7 +164,7 @@ var labelListAllCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
-			
+
 			if err := json.Unmarshal(resp.Data, &issues); err != nil {
 				fmt.Fprintf(os.Stderr, "Error parsing response: %v\n", err)
 				os.Exit(1)

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -163,7 +163,7 @@ var listCmd = &cobra.Command{
 		for _, issue := range issues {
 			// Load labels for display
 			labels, _ := store.GetLabels(ctx, issue.ID)
-			
+
 			fmt.Printf("%s [P%d] [%s] %s\n", issue.ID, issue.Priority, issue.IssueType, issue.Status)
 			fmt.Printf("  %s\n", issue.Title)
 			if issue.Assignee != "" {

--- a/cmd/bd/main_test.go
+++ b/cmd/bd/main_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -555,6 +556,10 @@ func TestAutoFlushJSONLContent(t *testing.T) {
 
 // TestAutoFlushErrorHandling tests error scenarios in flush operations
 func TestAutoFlushErrorHandling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based read-only directory behavior is not reliable on Windows")
+	}
+
 	// Create temp directory for test database
 	tmpDir, err := os.MkdirTemp("", "bd-test-error-*")
 	if err != nil {

--- a/cmd/bd/markdown.go
+++ b/cmd/bd/markdown.go
@@ -156,33 +156,35 @@ func validateMarkdownPath(path string) (string, error) {
 
 // parseMarkdownFile parses a markdown file and extracts issue templates.
 // Expected format:
-//   ## Issue Title
-//   Description text...
 //
-//   ### Priority
-//   2
+//	## Issue Title
+//	Description text...
 //
-//   ### Type
-//   feature
+//	### Priority
+//	2
 //
-//   ### Description
-//   Detailed description...
+//	### Type
+//	feature
 //
-//   ### Design
-//   Design notes...
+//	### Description
+//	Detailed description...
 //
-//   ### Acceptance Criteria
-//   - Criterion 1
-//   - Criterion 2
+//	### Design
+//	Design notes...
 //
-//   ### Assignee
-//   username
+//	### Acceptance Criteria
+//	- Criterion 1
+//	- Criterion 2
 //
-//   ### Labels
-//   label1, label2
+//	### Assignee
+//	username
 //
-//   ### Dependencies
-//   bd-10, bd-20
+//	### Labels
+//	label1, label2
+//
+//	### Dependencies
+//	bd-10, bd-20
+//
 // markdownParseState holds state for parsing markdown files
 type markdownParseState struct {
 	issues         []*IssueTemplate

--- a/cmd/bd/markdown_test.go
+++ b/cmd/bd/markdown_test.go
@@ -149,7 +149,7 @@ Just a title and description.
 				{
 					Title:       "Minimal Issue",
 					Description: "Just a title and description.",
-					Priority:    2,    // default
+					Priority:    2,      // default
 					IssueType:   "task", // default
 				},
 			},

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -22,7 +22,7 @@ var readyCmd = &cobra.Command{
 
 		filter := types.WorkFilter{
 			// Leave Status empty to get both 'open' and 'in_progress' (bd-165)
-			Limit:  limit,
+			Limit: limit,
 		}
 		// Use Changed() to properly handle P0 (priority=0)
 		if cmd.Flags().Changed("priority") {
@@ -246,12 +246,12 @@ var statsCmd = &cobra.Command{
 		fmt.Printf("Blocked:                %d\n", stats.BlockedIssues)
 		fmt.Printf("Ready:                  %s\n", green(fmt.Sprintf("%d", stats.ReadyIssues)))
 		if stats.EpicsEligibleForClosure > 0 {
-		fmt.Printf("Epics Ready to Close:   %s\n", green(fmt.Sprintf("%d", stats.EpicsEligibleForClosure)))
+			fmt.Printf("Epics Ready to Close:   %s\n", green(fmt.Sprintf("%d", stats.EpicsEligibleForClosure)))
 		}
 		if stats.AverageLeadTime > 0 {
-		fmt.Printf("Avg Lead Time:          %.1f hours\n", stats.AverageLeadTime)
-	}
-	fmt.Println()
+			fmt.Printf("Avg Lead Time:          %.1f hours\n", stats.AverageLeadTime)
+		}
+		fmt.Println()
 	},
 }
 

--- a/cmd/bd/rename_prefix.go
+++ b/cmd/bd/rename_prefix.go
@@ -142,7 +142,7 @@ func renamePrefixInDB(ctx context.Context, oldPrefix, newPrefix string, issues [
 	// the database in a mixed state with some issues renamed and others not.
 	// For production use, consider implementing a single atomic RenamePrefix() method
 	// in the storage layer that wraps all updates in one transaction.
-	
+
 	oldPrefixPattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(oldPrefix) + `-(\d+)\b`)
 
 	replaceFunc := func(match string) string {

--- a/cmd/bd/rename_prefix_test.go
+++ b/cmd/bd/rename_prefix_test.go
@@ -49,7 +49,7 @@ func TestRenamePrefixCommand(t *testing.T) {
 	defer testStore.Close()
 
 	ctx := context.Background()
-	
+
 	store = testStore
 	actor = "test"
 	defer func() {

--- a/cmd/bd/renumber_test.go
+++ b/cmd/bd/renumber_test.go
@@ -36,7 +36,7 @@ func TestRenumberWithGaps(t *testing.T) {
 		title string
 	}{
 		{"bd-1", "Issue 1"},
-		{"bd-4", "Issue 4"},    // Gap here (2, 3 missing)
+		{"bd-4", "Issue 4"},     // Gap here (2, 3 missing)
 		{"bd-100", "Issue 100"}, // Large gap
 		{"bd-200", "Issue 200"}, // Another large gap
 		{"bd-344", "Issue 344"}, // Final issue

--- a/cmd/bd/scripttest_test.go
+++ b/cmd/bd/scripttest_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,7 +14,11 @@ import (
 
 func TestScripts(t *testing.T) {
 	// Build the bd binary
-	exe := t.TempDir() + "/bd"
+	exeName := "bd"
+	if runtime.GOOS == "windows" {
+		exeName += ".exe"
+	}
+	exe := filepath.Join(t.TempDir(), exeName)
 	if err := exec.Command("go", "build", "-o", exe, ".").Run(); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -161,7 +161,7 @@ func gitHasUnmergedPaths() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("git status failed: %w", err)
 	}
-	
+
 	// Check for unmerged status codes (DD, AU, UD, UA, DU, AA, UU)
 	for _, line := range strings.Split(string(out), "\n") {
 		if len(line) >= 2 {
@@ -171,12 +171,12 @@ func gitHasUnmergedPaths() (bool, error) {
 			}
 		}
 	}
-	
+
 	// Check if MERGE_HEAD exists (merge in progress)
 	if exec.Command("git", "rev-parse", "-q", "--verify", "MERGE_HEAD").Run() == nil {
 		return true, nil
 	}
-	
+
 	return false, nil
 }
 
@@ -335,7 +335,7 @@ func importFromJSONL(ctx context.Context, jsonlPath string) error {
 	if err != nil {
 		return fmt.Errorf("cannot resolve current executable: %w", err)
 	}
-	
+
 	// Run import command with --resolve-collisions to automatically handle conflicts
 	cmd := exec.CommandContext(ctx, exe, "import", "-i", jsonlPath, "--resolve-collisions")
 	output, err := cmd.CombinedOutput()

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -21,12 +21,12 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Run: func(cmd *cobra.Command, args []string) {
 		checkDaemon, _ := cmd.Flags().GetBool("daemon")
-		
+
 		if checkDaemon {
 			showDaemonVersion()
 			return
 		}
-		
+
 		if jsonOutput {
 			outputJSON(map[string]string{
 				"version": Version,
@@ -47,7 +47,7 @@ func showDaemonVersion() {
 			dbPath = foundDB
 		}
 	}
-	
+
 	socketPath := getSocketPath()
 	client, err := rpc.TryConnect(socketPath)
 	if err != nil || client == nil {
@@ -56,19 +56,19 @@ func showDaemonVersion() {
 		os.Exit(1)
 	}
 	defer client.Close()
-	
+
 	health, err := client.Health()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error checking daemon health: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	if jsonOutput {
 		outputJSON(map[string]interface{}{
-			"daemon_version":  health.Version,
-			"client_version":  Version,
-			"compatible":      health.Compatible,
-			"daemon_uptime":   health.Uptime,
+			"daemon_version": health.Version,
+			"client_version": Version,
+			"compatible":     health.Compatible,
+			"daemon_uptime":  health.Uptime,
 		})
 	} else {
 		fmt.Printf("Daemon version: %s\n", health.Version)
@@ -80,7 +80,7 @@ func showDaemonVersion() {
 		}
 		fmt.Printf("Daemon uptime: %.1f seconds\n", health.Uptime)
 	}
-	
+
 	if !health.Compatible {
 		os.Exit(1)
 	}

--- a/commands/daemon.md
+++ b/commands/daemon.md
@@ -10,6 +10,8 @@ Run a background daemon that manages database connections and optionally syncs w
 - **Local daemon**: Socket at `.beads/bd.sock` (per-repository)
 - **Global daemon**: Socket at `~/.beads/bd.sock` (all repositories)
 
+> On Windows these files store the daemon’s loopback TCP endpoint metadata—leave them in place so bd can reconnect.
+
 ## Common Operations
 
 - **Start**: `bd daemon` or `bd daemon --global`

--- a/examples/bd-example-extension-go/go.mod
+++ b/examples/bd-example-extension-go/go.mod
@@ -1,6 +1,6 @@
 module bd-example-extension-go
 
-go 1.23.0
+go 1.24.0
 
 require github.com/steveyegge/beads v0.0.0-00010101000000-000000000000
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,201 @@
+# Beads (bd) Windows installer
+# Usage:
+#   irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Script:SkipGoInstall = $env:BEADS_INSTALL_SKIP_GOINSTALL -eq "1"
+$Script:SourceOverride = $env:BEADS_INSTALL_SOURCE
+
+function Write-Info($Message)    { Write-Host "==> $Message" -ForegroundColor Cyan }
+function Write-Success($Message) { Write-Host "==> $Message" -ForegroundColor Green }
+function Write-WarningMsg($Message) { Write-Warning $Message }
+function Write-Err($Message)     { Write-Host "Error: $Message" -ForegroundColor Red }
+
+function Test-GoSupport {
+    $goCmd = Get-Command go -ErrorAction SilentlyContinue
+    if (-not $goCmd) {
+        return [pscustomobject]@{
+            Present = $false
+            MeetsRequirement = $false
+            RawVersion = $null
+        }
+    }
+
+    try {
+        $output = & go version
+    } catch {
+        return [pscustomobject]@{
+            Present = $false
+            MeetsRequirement = $false
+            RawVersion = $null
+        }
+    }
+
+    $match = [regex]::Match($output, 'go(?<major>\d+)\.(?<minor>\d+)')
+    if (-not $match.Success) {
+        return [pscustomobject]@{
+            Present = $true
+            MeetsRequirement = $true
+            RawVersion = $output
+        }
+    }
+
+    $major = [int]$match.Groups["major"].Value
+    $minor = [int]$match.Groups["minor"].Value
+    $meets = ($major -gt 1) -or ($major -eq 1 -and $minor -ge 24)
+
+    return [pscustomobject]@{
+        Present = $true
+        MeetsRequirement = $meets
+        RawVersion = $output.Trim()
+    }
+}
+
+function Install-WithGo {
+    if ($Script:SkipGoInstall) {
+        Write-Info "Skipping go install (BEADS_INSTALL_SKIP_GOINSTALL=1)."
+        return $false
+    }
+
+    Write-Info "Installing bd via go install..."
+    try {
+        & go install github.com/steveyegge/beads/cmd/bd@latest
+        if ($LASTEXITCODE -ne 0) {
+            Write-WarningMsg "go install exited with code $LASTEXITCODE"
+            return $false
+        }
+    } catch {
+        Write-WarningMsg "go install failed: $_"
+        return $false
+    }
+
+    $gopath = (& go env GOPATH)
+    if (-not $gopath) {
+        return $true
+    }
+
+    $binDir = Join-Path $gopath "bin"
+    $bdPath = Join-Path $binDir "bd.exe"
+    if (-not (Test-Path $bdPath)) {
+        Write-WarningMsg "bd.exe not found in $binDir after install"
+    }
+
+    $pathEntries = [Environment]::GetEnvironmentVariable("PATH", "Process").Split([IO.Path]::PathSeparator) | ForEach-Object { $_.Trim() }
+    if (-not ($pathEntries -contains $binDir)) {
+        Write-WarningMsg "$binDir is not in your PATH. Add it with:`n  setx PATH `"$Env:PATH;$binDir`""
+    }
+
+    return $true
+}
+
+function Install-FromSource {
+    Write-Info "Building bd from source..."
+
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("beads-install-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $tempRoot | Out-Null
+
+    try {
+        $repoPath = Join-Path $tempRoot "beads"
+        if ($Script:SourceOverride) {
+            Write-Info "Using source override: $Script:SourceOverride"
+            if (Test-Path $Script:SourceOverride) {
+                New-Item -ItemType Directory -Path $repoPath | Out-Null
+                Get-ChildItem -LiteralPath $Script:SourceOverride -Force | Where-Object { $_.Name -ne ".git" } | ForEach-Object {
+                    $destination = Join-Path $repoPath $_.Name
+                    if ($_.PSIsContainer) {
+                        Copy-Item -LiteralPath $_.FullName -Destination $destination -Recurse -Force
+                    } else {
+                        Copy-Item -LiteralPath $_.FullName -Destination $repoPath -Force
+                    }
+                }
+            } else {
+                Write-Info "Cloning override repository..."
+                & git clone $Script:SourceOverride $repoPath
+                if ($LASTEXITCODE -ne 0) {
+                    throw "git clone failed with exit code $LASTEXITCODE"
+                }
+            }
+        } else {
+            Write-Info "Cloning repository..."
+            & git clone --depth 1 https://github.com/steveyegge/beads.git $repoPath
+            if ($LASTEXITCODE -ne 0) {
+                throw "git clone failed with exit code $LASTEXITCODE"
+            }
+        }
+
+        Push-Location $repoPath
+        try {
+            Write-Info "Compiling bd.exe..."
+            & go build -o bd.exe ./cmd/bd
+            if ($LASTEXITCODE -ne 0) {
+                throw "go build failed with exit code $LASTEXITCODE"
+            }
+        } finally {
+            Pop-Location
+        }
+
+        $installDir = Join-Path $env:LOCALAPPDATA "Programs\bd"
+        New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+
+        Copy-Item -Path (Join-Path $repoPath "bd.exe") -Destination (Join-Path $installDir "bd.exe") -Force
+        Write-Success "bd installed to $installDir\bd.exe"
+
+        $pathEntries = [Environment]::GetEnvironmentVariable("PATH", "Process").Split([IO.Path]::PathSeparator) | ForEach-Object { $_.Trim() }
+        if (-not ($pathEntries -contains $installDir)) {
+            Write-WarningMsg "$installDir is not in your PATH. Add it with:`n  setx PATH `"$Env:PATH;$installDir`""
+        }
+    } finally {
+        Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    return $true
+}
+
+function Verify-Install {
+    Write-Info "Verifying installation..."
+    try {
+        $versionOutput = & bd version 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-WarningMsg "bd version exited with code $LASTEXITCODE"
+            return $false
+        }
+        Write-Success "bd is installed: $versionOutput"
+        return $true
+    } catch {
+        Write-WarningMsg "bd is not on PATH yet. Add the install directory to PATH and re-open your shell."
+        return $false
+    }
+}
+
+$goSupport = Test-GoSupport
+
+if ($goSupport.Present) {
+    Write-Info "Detected Go: $($goSupport.RawVersion)"
+} else {
+    Write-WarningMsg "Go not found on PATH."
+}
+
+$installed = $false
+
+if ($goSupport.Present -and $goSupport.MeetsRequirement) {
+    $installed = Install-WithGo
+    if (-not $installed) {
+        Write-WarningMsg "Falling back to source build..."
+    }
+} elseif ($goSupport.Present -and -not $goSupport.MeetsRequirement) {
+    Write-Err "Go 1.24 or newer is required (found: $($goSupport.RawVersion)). Please upgrade Go or use the fallback build."
+}
+
+if (-not $installed) {
+    $installed = Install-FromSource
+}
+
+if ($installed) {
+    Verify-Install | Out-Null
+    Write-Success "Installation complete. Run 'bd quickstart' inside a repo to begin."
+} else {
+    Write-Err "Installation failed. Please install Go 1.24+ and try again."
+    exit 1
+}

--- a/integrations/beads-mcp/README.md
+++ b/integrations/beads-mcp/README.md
@@ -80,7 +80,7 @@ bd daemon --global
 The MCP server automatically detects the global daemon and routes requests based on your working directory. No configuration changes needed!
 
 **How it works:**
-1. MCP server checks for local daemon socket (`.beads/bd.sock`)
+1. MCP server checks for local daemon socket (`.beads/bd.sock`) — on Windows this file contains the TCP endpoint metadata
 2. Falls back to global daemon socket (`~/.beads/bd.sock`)
 3. Routes requests to correct database based on working directory
 4. Each project keeps its own database at `.beads/*.db`

--- a/integrations/beads-mcp/SETUP_DAEMON.md
+++ b/integrations/beads-mcp/SETUP_DAEMON.md
@@ -32,7 +32,7 @@ bd daemon start
 ```
 
 The daemon will:
-- Listen on `.beads/bd.sock`
+- Listen on `.beads/bd.sock` (Windows: file stores loopback TCP metadata)
 - Route operations to correct database based on request cwd
 - Handle multiple repos simultaneously
 

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -22,6 +22,8 @@ const (
 	initialBackoff = 1 * time.Second
 )
 
+var ErrAPIKeyRequired = errors.New("API key required")
+
 // HaikuClient wraps the Anthropic API for issue summarization.
 type HaikuClient struct {
 	client         anthropic.Client
@@ -39,7 +41,7 @@ func NewHaikuClient(apiKey string) (*HaikuClient, error) {
 		apiKey = envKey
 	}
 	if apiKey == "" {
-		return nil, fmt.Errorf("API key required: set ANTHROPIC_API_KEY environment variable or provide via config")
+		return nil, fmt.Errorf("%w: set ANTHROPIC_API_KEY environment variable or provide via config", ErrAPIKeyRequired)
 	}
 
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))

--- a/internal/compact/haiku_test.go
+++ b/internal/compact/haiku_test.go
@@ -17,6 +17,9 @@ func TestNewHaikuClient_RequiresAPIKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when API key is missing")
 	}
+	if !errors.Is(err, ErrAPIKeyRequired) {
+		t.Fatalf("expected ErrAPIKeyRequired, got %v", err)
+	}
 	if !strings.Contains(err.Error(), "API key required") {
 		t.Errorf("unexpected error message: %v", err)
 	}
@@ -53,13 +56,13 @@ func TestRenderTier1Prompt(t *testing.T) {
 	}
 
 	issue := &types.Issue{
-		ID:          "bd-1",
-		Title:       "Fix authentication bug",
-		Description: "Users can't log in with OAuth",
-		Design:      "Add error handling to OAuth flow",
+		ID:                 "bd-1",
+		Title:              "Fix authentication bug",
+		Description:        "Users can't log in with OAuth",
+		Design:             "Add error handling to OAuth flow",
 		AcceptanceCriteria: "Users can log in successfully",
-		Notes:       "Related to issue bd-2",
-		Status:      types.StatusClosed,
+		Notes:              "Related to issue bd-2",
+		Status:             types.StatusClosed,
 	}
 
 	prompt, err := client.renderTier1Prompt(issue)

--- a/internal/rpc/comments_test.go
+++ b/internal/rpc/comments_test.go
@@ -1,0 +1,113 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sqlitestorage "github.com/steveyegge/beads/internal/storage/sqlite"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestCommentOperationsViaRPC(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	socketPath := filepath.Join(tmpDir, "bd.sock")
+
+	store, err := sqlitestorage.New(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	server := NewServer(socketPath, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- server.Start(ctx)
+	}()
+
+	select {
+	case <-server.WaitReady():
+	case err := <-serverErr:
+		t.Fatalf("server failed to start: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for server to start")
+	}
+
+	client, err := TryConnect(socketPath)
+	if err != nil {
+		t.Fatalf("failed to connect to server: %v", err)
+	}
+	if client == nil {
+		t.Fatal("client is nil after successful connection")
+	}
+	defer client.Close()
+
+	createResp, err := client.Create(&CreateArgs{
+		Title:     "Comment test",
+		IssueType: "task",
+		Priority:  2,
+	})
+	if err != nil {
+		t.Fatalf("create issue failed: %v", err)
+	}
+
+	var created types.Issue
+	if err := json.Unmarshal(createResp.Data, &created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected issue ID to be set")
+	}
+
+	addResp, err := client.AddComment(&CommentAddArgs{
+		ID:     created.ID,
+		Author: "tester",
+		Text:   "first comment",
+	})
+	if err != nil {
+		t.Fatalf("add comment failed: %v", err)
+	}
+
+	var added types.Comment
+	if err := json.Unmarshal(addResp.Data, &added); err != nil {
+		t.Fatalf("failed to decode add comment response: %v", err)
+	}
+
+	if added.Text != "first comment" {
+		t.Fatalf("expected comment text 'first comment', got %q", added.Text)
+	}
+
+	listResp, err := client.ListComments(&CommentListArgs{ID: created.ID})
+	if err != nil {
+		t.Fatalf("list comments failed: %v", err)
+	}
+
+	var comments []*types.Comment
+	if err := json.Unmarshal(listResp.Data, &comments); err != nil {
+		t.Fatalf("failed to decode comment list: %v", err)
+	}
+
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if comments[0].Text != "first comment" {
+		t.Fatalf("expected comment text 'first comment', got %q", comments[0].Text)
+	}
+
+	if err := server.Stop(); err != nil {
+		t.Fatalf("failed to stop server: %v", err)
+	}
+	cancel()
+	select {
+	case err := <-serverErr:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("server returned error: %v", err)
+		}
+	default:
+	}
+}

--- a/internal/rpc/protocol.go
+++ b/internal/rpc/protocol.go
@@ -8,25 +8,27 @@ import (
 
 // Operation constants for all bd commands
 const (
-	OpPing           = "ping"
-	OpHealth         = "health"
-	OpMetrics        = "metrics"
-	OpCreate         = "create"
-	OpUpdate         = "update"
-	OpClose          = "close"
-	OpList           = "list"
-	OpShow           = "show"
-	OpReady          = "ready"
-	OpStats          = "stats"
-	OpDepAdd         = "dep_add"
-	OpDepRemove      = "dep_remove"
-	OpDepTree        = "dep_tree"
-	OpLabelAdd       = "label_add"
-	OpLabelRemove    = "label_remove"
-	OpBatch          = "batch"
-	OpReposList      = "repos_list"
-	OpReposReady     = "repos_ready"
-	OpReposStats     = "repos_stats"
+	OpPing            = "ping"
+	OpHealth          = "health"
+	OpMetrics         = "metrics"
+	OpCreate          = "create"
+	OpUpdate          = "update"
+	OpClose           = "close"
+	OpList            = "list"
+	OpShow            = "show"
+	OpReady           = "ready"
+	OpStats           = "stats"
+	OpDepAdd          = "dep_add"
+	OpDepRemove       = "dep_remove"
+	OpDepTree         = "dep_tree"
+	OpLabelAdd        = "label_add"
+	OpLabelRemove     = "label_remove"
+	OpCommentList     = "comment_list"
+	OpCommentAdd      = "comment_add"
+	OpBatch           = "batch"
+	OpReposList       = "repos_list"
+	OpReposReady      = "repos_ready"
+	OpReposStats      = "repos_stats"
 	OpReposClearCache = "repos_clear_cache"
 )
 
@@ -36,7 +38,7 @@ type Request struct {
 	Args          json.RawMessage `json:"args"`
 	Actor         string          `json:"actor,omitempty"`
 	RequestID     string          `json:"request_id,omitempty"`
-	Cwd           string          `json:"cwd,omitempty"`      // Working directory for database discovery
+	Cwd           string          `json:"cwd,omitempty"`            // Working directory for database discovery
 	ClientVersion string          `json:"client_version,omitempty"` // Client version for compatibility checks
 }
 
@@ -86,8 +88,8 @@ type ListArgs struct {
 	Priority  *int     `json:"priority,omitempty"`
 	IssueType string   `json:"issue_type,omitempty"`
 	Assignee  string   `json:"assignee,omitempty"`
-	Label     string   `json:"label,omitempty"`     // Deprecated: use Labels
-	Labels    []string `json:"labels,omitempty"`    // AND semantics
+	Label     string   `json:"label,omitempty"`      // Deprecated: use Labels
+	Labels    []string `json:"labels,omitempty"`     // AND semantics
 	LabelsAny []string `json:"labels_any,omitempty"` // OR semantics
 	Limit     int      `json:"limit,omitempty"`
 }
@@ -136,6 +138,18 @@ type LabelRemoveArgs struct {
 	Label string `json:"label"`
 }
 
+// CommentListArgs represents arguments for listing comments on an issue
+type CommentListArgs struct {
+	ID string `json:"id"`
+}
+
+// CommentAddArgs represents arguments for adding a comment to an issue
+type CommentAddArgs struct {
+	ID     string `json:"id"`
+	Author string `json:"author"`
+	Text   string `json:"text"`
+}
+
 // PingResponse is the response for a ping operation
 type PingResponse struct {
 	Message string `json:"message"`
@@ -144,19 +158,19 @@ type PingResponse struct {
 
 // HealthResponse is the response for a health check operation
 type HealthResponse struct {
-	Status          string  `json:"status"`           // "healthy", "degraded", "unhealthy"
-	Version         string  `json:"version"`          // Server/daemon version
-	ClientVersion   string  `json:"client_version,omitempty"`  // Client version from request
-	Compatible      bool    `json:"compatible"`       // Whether versions are compatible
-	Uptime          float64 `json:"uptime_seconds"`
-	CacheSize       int     `json:"cache_size"`
-	CacheHits       int64   `json:"cache_hits"`
-	CacheMisses     int64   `json:"cache_misses"`
-	DBResponseTime  float64 `json:"db_response_ms"`
-	ActiveConns     int32   `json:"active_connections"`
-	MaxConns        int     `json:"max_connections"`
-	MemoryAllocMB   uint64  `json:"memory_alloc_mb"`
-	Error           string  `json:"error,omitempty"`
+	Status         string  `json:"status"`                   // "healthy", "degraded", "unhealthy"
+	Version        string  `json:"version"`                  // Server/daemon version
+	ClientVersion  string  `json:"client_version,omitempty"` // Client version from request
+	Compatible     bool    `json:"compatible"`               // Whether versions are compatible
+	Uptime         float64 `json:"uptime_seconds"`
+	CacheSize      int     `json:"cache_size"`
+	CacheHits      int64   `json:"cache_hits"`
+	CacheMisses    int64   `json:"cache_misses"`
+	DBResponseTime float64 `json:"db_response_ms"`
+	ActiveConns    int32   `json:"active_connections"`
+	MaxConns       int     `json:"max_connections"`
+	MemoryAllocMB  uint64  `json:"memory_alloc_mb"`
+	Error          string  `json:"error,omitempty"`
 }
 
 // BatchArgs represents arguments for batch operations
@@ -200,7 +214,7 @@ type RepoInfo struct {
 
 // RepoReadyWork represents ready work for a single repository
 type RepoReadyWork struct {
-	RepoPath string `json:"repo_path"`
+	RepoPath string         `json:"repo_path"`
 	Issues   []*types.Issue `json:"issues"`
 }
 

--- a/internal/rpc/protocol_test.go
+++ b/internal/rpc/protocol_test.go
@@ -115,6 +115,8 @@ func TestAllOperations(t *testing.T) {
 		OpDepTree,
 		OpLabelAdd,
 		OpLabelRemove,
+		OpCommentList,
+		OpCommentAdd,
 	}
 
 	for _, op := range operations {

--- a/internal/rpc/server_eviction_test.go
+++ b/internal/rpc/server_eviction_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestStorageCacheEviction_TTL(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -82,7 +82,7 @@ func TestStorageCacheEviction_TTL(t *testing.T) {
 
 func TestStorageCacheEviction_LRU(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -94,7 +94,7 @@ func TestStorageCacheEviction_LRU(t *testing.T) {
 	// Create server with small cache size
 	socketPath := filepath.Join(tmpDir, "test.sock")
 	server := NewServer(socketPath, mainStore)
-	server.maxCacheSize = 2 // Only keep 2 entries
+	server.maxCacheSize = 2         // Only keep 2 entries
 	server.cacheTTL = 1 * time.Hour // Long TTL so we test LRU
 	defer server.Stop()
 
@@ -167,7 +167,7 @@ func TestStorageCacheEviction_LRU(t *testing.T) {
 
 func TestStorageCacheEviction_LastAccessUpdate(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -225,7 +225,7 @@ func TestStorageCacheEviction_LastAccessUpdate(t *testing.T) {
 
 func TestStorageCacheEviction_EnvVars(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -257,7 +257,7 @@ func TestStorageCacheEviction_EnvVars(t *testing.T) {
 
 func TestStorageCacheEviction_CleanupOnStop(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -309,7 +309,7 @@ func TestStorageCacheEviction_CleanupOnStop(t *testing.T) {
 
 func TestStorageCacheEviction_CanonicalKey(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -362,7 +362,7 @@ func TestStorageCacheEviction_CanonicalKey(t *testing.T) {
 
 func TestStorageCacheEviction_ImmediateLRU(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -410,7 +410,7 @@ func TestStorageCacheEviction_ImmediateLRU(t *testing.T) {
 
 func TestStorageCacheEviction_InvalidTTL(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -437,7 +437,7 @@ func TestStorageCacheEviction_InvalidTTL(t *testing.T) {
 
 func TestStorageCacheEviction_ReopenAfterEviction(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)
@@ -499,7 +499,7 @@ func TestStorageCacheEviction_ReopenAfterEviction(t *testing.T) {
 
 func TestStorageCacheEviction_StopIdempotent(t *testing.T) {
 	tmpDir := t.TempDir()
-	
+
 	// Create main DB
 	mainDB := filepath.Join(tmpDir, "main.db")
 	mainStore, err := sqlite.New(mainDB)

--- a/internal/rpc/signals_unix.go
+++ b/internal/rpc/signals_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package rpc
+
+import (
+	"os"
+	"syscall"
+)
+
+var serverSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}

--- a/internal/rpc/signals_windows.go
+++ b/internal/rpc/signals_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package rpc
+
+import (
+	"os"
+	"syscall"
+)
+
+var serverSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/internal/rpc/transport_unix.go
+++ b/internal/rpc/transport_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package rpc
+
+import (
+	"net"
+	"os"
+	"time"
+)
+
+func listenRPC(socketPath string) (net.Listener, error) {
+	return net.Listen("unix", socketPath)
+}
+
+func dialRPC(socketPath string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("unix", socketPath, timeout)
+}
+
+func endpointExists(socketPath string) bool {
+	_, err := os.Stat(socketPath)
+	return err == nil
+}

--- a/internal/rpc/transport_windows.go
+++ b/internal/rpc/transport_windows.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package rpc
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"time"
+)
+
+type endpointInfo struct {
+	Network string `json:"network"`
+	Address string `json:"address"`
+}
+
+func listenRPC(socketPath string) (net.Listener, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	info := endpointInfo{
+		Network: "tcp",
+		Address: listener.Addr().String(),
+	}
+
+	data, err := json.Marshal(info)
+	if err != nil {
+		listener.Close()
+		return nil, err
+	}
+
+	if err := os.WriteFile(socketPath, data, 0o600); err != nil {
+		listener.Close()
+		return nil, err
+	}
+
+	return listener, nil
+}
+
+func dialRPC(socketPath string, timeout time.Duration) (net.Conn, error) {
+	data, err := os.ReadFile(socketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var info endpointInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+
+	if info.Address == "" {
+		return nil, errors.New("invalid RPC endpoint: missing address")
+	}
+
+	network := info.Network
+	if network == "" {
+		network = "tcp"
+	}
+
+	return net.DialTimeout(network, info.Address, timeout)
+}
+
+func endpointExists(socketPath string) bool {
+	_, err := os.Stat(socketPath)
+	return err == nil
+}

--- a/internal/rpc/version_test.go
+++ b/internal/rpc/version_test.go
@@ -462,7 +462,7 @@ func TestMetricsOperation(t *testing.T) {
 
 // Helper function
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
 		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,12 +69,12 @@ check_go() {
         log_info "Go detected: $(go version)"
 
         # Extract major and minor version numbers
-        local major=$(echo "$go_version" | cut -d. -f1)
-        local minor=$(echo "$go_version" | cut -d. -f2)
+    local major=$(echo "$go_version" | cut -d. -f1)
+    local minor=$(echo "$go_version" | cut -d. -f2)
 
-        # Check if Go version is 1.23 or later
-        if [ "$major" -eq 1 ] && [ "$minor" -lt 23 ]; then
-            log_error "Go 1.23 or later is required (found: $go_version)"
+    # Check if Go version is 1.24 or later
+    if [ "$major" -eq 1 ] && [ "$minor" -lt 24 ]; then
+        log_error "Go 1.24 or later is required (found: $go_version)"
             echo ""
             echo "Please upgrade Go:"
             echo "  - Download from https://go.dev/dl/"
@@ -175,7 +175,7 @@ build_from_source() {
 offer_go_installation() {
     log_warning "Go is not installed"
     echo ""
-    echo "bd requires Go 1.23 or later. You can:"
+        echo "bd requires Go 1.24 or later. You can:"
     echo "  1. Install Go from https://go.dev/dl/"
     echo "  2. Use your package manager:"
     echo "     - macOS: brew install go"

--- a/smoke_test_results.md
+++ b/smoke_test_results.md
@@ -1,0 +1,55 @@
+# Smoke Test Results
+
+_Date:_ October 21, 2025  
+_Tester:_ Codex (GPT-5)  
+_Environment:_  
+- Linux run: WSL (Ubuntu), Go 1.24.0, locally built `bd` binary  
+- Windows run: Windows 11 (via WSL interop), cross-compiled `bd.exe`
+
+## Scope
+
+- Full CLI lifecycle using local SQLite database: init, create, list, ready/blocked, label ops, deps, rename, comments, markdown import/export, delete (single & batch), renumber, auto-flush/import behavior, daemon interactions (local mode fallback).
+- JSONL sync verification.
+- Error handling and edge cases (duplicate IDs, validation failures, cascade deletes, daemon fallback scenarios).
+
+## Test Matrix – Linux CLI (`bd`)
+
+| Test Case | Description | Status | Notes |
+|-----------|-------------|--------|-------|
+| Init-001 | Initialize new workspace with custom prefix | ✅ Pass | `/tmp/bd-smoke`, `./bd init --prefix smoke` |
+| CRUD-001 | Create issues with JSON output (task/feature/bug) | ✅ Pass | Created smoke-1..3 via `bd create` with flags |
+| Read-001 | Verify list/ready/blocked views (human & JSON) | ✅ Pass | `bd list/ready/blocked` with `--json` |
+| Label-001 | Add/remove/list labels | ✅ Pass | Added backend label to smoke-2 and removed |
+| Dep-001 | Add/remove dependency, view tree, cycle prevention | ✅ Pass | Added blocks, viewed tree, removal succeeded, cycle rejected |
+| Comment-001 | Add/list comments (direct mode) | ✅ Pass | Added inline + file-based comments to smoke-3; verified JSON & human output |
+| ImportExport-001 | Manual export + import new issue | ✅ Pass | `bd export -o export.jsonl`; imported smoke-4 from JSONL |
+| Delete-001 | Single delete preview/force flush check | ✅ Pass | smoke-4 removed; `.beads/issues.jsonl` updated |
+| Delete-002 | Batch delete multi issues | ✅ Pass | Deleted smoke-5 & smoke-6 with `--dry-run`, `--force` |
+| ImportExport-002 | Auto-import detection from manual JSONL edit | ✅ Pass | Append smoke-8 to `.beads/issues.jsonl`; `bd list` auto-imported |
+| Renumber-001 | Force renumber to close gaps | ✅ Pass | `bd renumber --force --json`; IDs compacted |
+| Rename-001 | Prefix rename dry-run | ✅ Pass | `bd rename-prefix new- --dry-run` |
+
+## Test Matrix – Windows CLI (`bd.exe`)
+
+| Test Case | Description | Status | Notes |
+|-----------|-------------|--------|-------|
+| Win-Init-001 | Initialize workspace on `D:\tmp\bd-smoke-win` | ✅ Pass | `/mnt/d/.../bd.exe init --prefix win` |
+| Win-CRUD-001 | Create task/feature/bug issues | ✅ Pass | win-1..3 via `bd.exe create` |
+| Win-Read-001 | list/ready/blocked output | ✅ Pass | `bd.exe list/ready/blocked` |
+| Win-Label-001 | Label add/list/remove | ✅ Pass | `platform` label on win-2 |
+| Win-Dep-001 | Add dep, cycle prevention, removal | ✅ Pass | win-2 blocks win-1; cycle rejected |
+| Win-Comment-001 | Add/list comments | ✅ Pass | Added comment to win-3 |
+| Win-Export-001 | Export + JSONL inspection | ✅ Pass | `bd.exe export -o export.jsonl` |
+| Win-Import-001 | Manual JSONL edit triggers auto-import | ✅ Pass | Appended `win-4` directly to `.beads\issues.jsonl` |
+| Win-Delete-001 | Delete issue with JSONL rewrite | ✅ Pass | `bd.exe delete win-5 --force` (initial failure -> B-001; retest after fix succeeded) |
+
+## Bugs / Issues
+
+| ID | Description | Status | Notes |
+|----|-------------|--------|-------|
+| B-001 | `bd delete --force` on Windows warned `Access is denied` while renaming issues.jsonl temp file | ✅ Fixed | Closed by ensuring `.beads/issues.jsonl` reader closes before rename (`cmd/bd/delete.go`) |
+
+## Follow-up Actions
+
+| Action | Owner | Status |
+|--------|-------|--------|


### PR DESCRIPTION
## Summary
- Native Windows support end-to-end: daemon now exchanges loopback TCP endpoints via metadata files, honors Windows signals/process APIs, and documents the behavior for operators
- CLI/daemon interoperability: introduced direct-mode fallback so commands seamlessly downgrade when an older daemon lacks newer RPCs, restoring reliable delete/flush behavior and keeping JSONL exports accurate
- Comment flows over RPC: added comment_list/comment_add operations, wired them into the daemon and CLI, and covered them with integration tests to guarantee parity across transport modes
- Windows installer + docs: published a PowerShell bootstrap script and raised the documented Go requirement to 1.24 for both platforms, matching the toolchain used in CI
- Captured cross-OS smoke testing so reviewers can audit the Linux/Windows validation matrix that exercised the new paths

## Testing
- go test ./...
