### PR TITLE
Normalize acceptance criteria flag for bd create & bd update command to be --acceptance (bd-228)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1968,8 +1968,8 @@ var updateCmd = &cobra.Command{
 			notes, _ := cmd.Flags().GetString("notes")
 			updates["notes"] = notes
 		}
-		if cmd.Flags().Changed("acceptance-criteria") {
-			acceptanceCriteria, _ := cmd.Flags().GetString("acceptance-criteria")
+		if cmd.Flags().Changed("acceptance") {
+			acceptanceCriteria, _ := cmd.Flags().GetString("acceptance")
 			updates["acceptance_criteria"] = acceptanceCriteria
 		}
 		if cmd.Flags().Changed("external-ref") {
@@ -2052,7 +2052,7 @@ func init() {
 	updateCmd.Flags().StringP("assignee", "a", "", "New assignee")
 	updateCmd.Flags().String("design", "", "Design notes")
 	updateCmd.Flags().String("notes", "", "Additional notes")
-	updateCmd.Flags().String("acceptance-criteria", "", "Acceptance criteria")
+	updateCmd.Flags().String("acceptance", "", "Acceptance criteria")
 	updateCmd.Flags().String("external-ref", "", "External reference (e.g., 'gh-9', 'jira-ABC')")
 	rootCmd.AddCommand(updateCmd)
 }

--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -424,7 +424,7 @@ class BdCliClient(BdClientBase):
         if params.design:
             args.extend(["--design", params.design])
         if params.acceptance_criteria:
-            args.extend(["--acceptance-criteria", params.acceptance_criteria])
+            args.extend(["--acceptance", params.acceptance_criteria])
         if params.notes:
             args.extend(["--notes", params.notes])
         if params.external_ref:


### PR DESCRIPTION
The --acceptance flag was split brained as --acceptance and --acceptance-criteria depending on if bd create --acceptance was used or bd update --acceptance-criteria was required. this was confusing claude code as the skill was not specific that it was a different flag depending on the subcommand.  

This seems to have been an oversight since both flags are for acceptance criteria but differ between subcommands.  This PR standardizes on --acceptance.

Thanks for making a great tool, hope this helps a little!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>