### PR TITLE
Fix regression in Nix Flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,23 @@ jobs:
         with:
           version: v1.62.0
           args: --timeout=5m
+  test-nix:
+    name: Test Nix Flake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - run: nix run .#default > help.txt
+      - name: Verify help text
+        run: |
+          FIRST_LINE=$(head -n 1 help.txt)
+          EXPECTED="Issues chained together like beads. A lightweight issue tracker with first-class dependency support."
+          if [ "$FIRST_LINE" != "$EXPECTED" ]; then
+            echo "❌ First line of help.txt doesn't match expected output"
+            echo "Expected: $EXPECTED"
+            echo "Got: $FIRST_LINE"
+            exit 1
+          fi
+          echo "✅ Help text first line is correct"

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          packages.default = pkgs.callPackage { inherit pkgs self; };
+          packages.default = pkgs.callPackage ./default.nix { inherit pkgs self; };
 
           apps.default = {
             type = "app";


### PR DESCRIPTION
In PR #105, a regression was introduced into the nix flake which disabled consumers from access the package.

This pr fixes that regression.

Additionally adds a nix smoke test for a backstop against this in the future

See https://github.com/steveyegge/beads/pull/105#issuecomment-3434375083 for context