### PR TITLE
Multishow -- allow bd show on multiple issues

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1773,6 +1773,12 @@ Examples:
 			// Use provided IDs
 			issueIDs = args
 		}
+
+		// Sort issue IDs for consistent ordering when showing multiple issues
+		if len(issueIDs) > 1 {
+			sort.Strings(issueIDs)
+		}
+
 		// If daemon is running, use RPC
 		if daemonClient != nil {
 			allDetails := []interface{}{}


### PR DESCRIPTION
```
bd show bd-1 bd-2
bd show --all-issues
```

When I'm collaborating with the AI I keep getting hit by these little papercuts that make it a bit more painful to use bd commands myself. Maybe the answer is that I should write my own scripts to access the issues.jsonl directly (but that runs up against the async exports to it, i.e. #149).

But for now I keep looking for little tweaks that make it a bit easier to use as a human.  Showing multiple issues is one of those. For small-to-medium projects I find it useful to dump entire priority levels at once.



