### PR TITLE
onboard: add step to commit JSONL with code changes

### DIFF
--- a/cmd/bd/onboard.go
+++ b/cmd/bd/onboard.go
@@ -66,6 +66,7 @@ bd close bd-42 --reason "Completed" --json
 4. **Discover new work?** Create linked issue:
    - ` + "`bd create \"Found bug\" -p 1 --deps discovered-from:<parent-id>`" + `
 5. **Complete**: ` + "`bd close <id> --reason \"Done\"`" + `
+6. **Commit together**: Always commit the `.beads/issues.jsonl` file together with the code changes so issue state stays in sync with code state
 
 ### Auto-Sync
 


### PR DESCRIPTION
Add a new step to the onboarding workflow reminding AI agents to commit the `.beads/issues.jsonl` file together with code changes. This ensures issue state stays synchronized with code state.

I find this useful but I'm not sure if we want to enforce this for all users.