### PR TITLE
init: add daemon.lock to .gitignore

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -90,6 +90,7 @@ and database file. Optionally specify a custom issue prefix.`,
 *.db-shm
 
 # Daemon runtime files
+daemon.lock
 daemon.log
 daemon.pid
 bd.sock


### PR DESCRIPTION
The `daemon.lock` file should be ignored in git since it's a runtime file created by the daemon to manage exclusive database access.