### PR TITLE
Add rename-prefix --repair flag and consolidate issue ID parsing

### DIFF
--- a/cmd/bd/autoimport.go
+++ b/cmd/bd/autoimport.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // checkAndAutoImport checks if the database is empty but git has issues.
@@ -174,7 +175,7 @@ func importFromGit(ctx context.Context, dbFilePath string, store storage.Storage
 		configuredPrefix, err := store.GetConfig(ctx, "issue_prefix")
 		if err == nil && strings.TrimSpace(configuredPrefix) == "" {
 			// Database has no prefix configured - derive from first issue
-			firstPrefix := extractPrefix(issues[0].ID)
+			firstPrefix := utils.ExtractIssuePrefix(issues[0].ID)
 			if firstPrefix != "" {
 				if err := store.SetConfig(ctx, "issue_prefix", firstPrefix); err != nil {
 					return fmt.Errorf("failed to set issue_prefix from imported issues: %w", err)

--- a/cmd/bd/helpers_test.go
+++ b/cmd/bd/helpers_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 func TestIsBoundary(t *testing.T) {
@@ -82,9 +84,9 @@ func TestExtractPrefix(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := extractPrefix(tt.input)
+		result := utils.ExtractIssuePrefix(tt.input)
 		if result != tt.expected {
-			t.Errorf("extractPrefix(%q) = %q, want %q", tt.input, result, tt.expected)
+			t.Errorf("ExtractIssuePrefix(%q) = %q, want %q", tt.input, result, tt.expected)
 		}
 	}
 }

--- a/cmd/bd/import_phases.go
+++ b/cmd/bd/import_phases.go
@@ -9,6 +9,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // Phase 1: Get or create SQLite store for import
@@ -58,7 +59,7 @@ func handlePrefixMismatch(ctx context.Context, sqliteStore *sqlite.SQLiteStorage
 
 	// Analyze prefixes in imported issues
 	for _, issue := range issues {
-		prefix := extractPrefix(issue.ID)
+		prefix := utils.ExtractIssuePrefix(issue.ID)
 		if prefix != configuredPrefix {
 			result.PrefixMismatch = true
 			result.MismatchPrefixes[prefix]++
@@ -349,14 +350,6 @@ func importComments(ctx context.Context, sqliteStore *sqlite.SQLiteStorage, issu
 }
 
 // Helper functions
-
-func extractPrefix(issueID string) string {
-	parts := strings.SplitN(issueID, "-", 2)
-	if len(parts) < 2 {
-		return "" // No prefix found
-	}
-	return parts[0]
-}
 
 func getPrefixList(prefixes map[string]int) []string {
 	var result []string

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // fieldComparator handles comparison logic for a specific field type
@@ -259,13 +260,13 @@ func importIssuesCore(ctx context.Context, dbPath string, store storage.Storage,
 func renameImportedIssuePrefixes(issues []*types.Issue, targetPrefix string) error {
 	// Build a mapping of old IDs to new IDs
 	idMapping := make(map[string]string)
-	
+
 	for _, issue := range issues {
-		oldPrefix := extractPrefix(issue.ID)
+		oldPrefix := utils.ExtractIssuePrefix(issue.ID)
 		if oldPrefix == "" {
 			return fmt.Errorf("cannot rename issue %s: malformed ID (no hyphen found)", issue.ID)
 		}
-		
+
 		if oldPrefix != targetPrefix {
 			// Extract the numeric part
 			numPart := strings.TrimPrefix(issue.ID, oldPrefix+"-")

--- a/cmd/bd/rename_prefix_repair_test.go
+++ b/cmd/bd/rename_prefix_repair_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestRepairMultiplePrefixes(t *testing.T) {
+	// Create a temporary database
+	dbPath := t.TempDir() + "/test.db"
+	store, err := sqlite.New(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Set initial prefix
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("failed to set prefix: %v", err)
+	}
+
+	// Create issues with multiple prefixes (simulating corruption)
+	// We'll manually create issues with different prefixes
+	issues := []*types.Issue{
+		{ID: "test-1", Title: "Test issue 1", Status: "open", Priority: 2, IssueType: "task"},
+		{ID: "test-2", Title: "Test issue 2", Status: "open", Priority: 2, IssueType: "task"},
+		{ID: "old-1", Title: "Old issue 1", Status: "open", Priority: 2, IssueType: "task"},
+		{ID: "old-2", Title: "Old issue 2", Status: "open", Priority: 2, IssueType: "task"},
+		{ID: "another-1", Title: "Another issue 1", Status: "open", Priority: 2, IssueType: "task"},
+	}
+
+	for _, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("failed to create issue %s: %v", issue.ID, err)
+		}
+	}
+
+	// Verify we have multiple prefixes
+	allIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("failed to search issues: %v", err)
+	}
+
+	prefixes := detectPrefixes(allIssues)
+	if len(prefixes) != 3 {
+		t.Fatalf("expected 3 prefixes, got %d: %v", len(prefixes), prefixes)
+	}
+
+	// Test repair
+	if err := repairPrefixes(ctx, store, "test", "test", allIssues, prefixes, false); err != nil {
+		t.Fatalf("repair failed: %v", err)
+	}
+
+	// Verify all issues now have correct prefix
+	allIssues, err = store.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("failed to search issues after repair: %v", err)
+	}
+
+	prefixes = detectPrefixes(allIssues)
+	if len(prefixes) != 1 {
+		t.Fatalf("expected 1 prefix after repair, got %d: %v", len(prefixes), prefixes)
+	}
+
+	if _, ok := prefixes["test"]; !ok {
+		t.Fatalf("expected prefix 'test', got %v", prefixes)
+	}
+
+	// Verify the original test-1 and test-2 are unchanged
+	for _, id := range []string{"test-1", "test-2"} {
+		issue, err := store.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("expected issue %s to exist unchanged: %v", id, err)
+		}
+		if issue == nil {
+			t.Fatalf("expected issue %s to exist", id)
+		}
+	}
+
+	// Verify the others were renumbered
+	issue, err := store.GetIssue(ctx, "test-3")
+	if err != nil || issue == nil {
+		t.Fatalf("expected test-3 to exist (renamed from another-1)")
+	}
+
+	issue, err = store.GetIssue(ctx, "test-4")
+	if err != nil || issue == nil {
+		t.Fatalf("expected test-4 to exist (renamed from old-1)")
+	}
+
+	issue, err = store.GetIssue(ctx, "test-5")
+	if err != nil || issue == nil {
+		t.Fatalf("expected test-5 to exist (renamed from old-2)")
+	}
+}

--- a/internal/utils/issue_id.go
+++ b/internal/utils/issue_id.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ExtractIssuePrefix extracts the prefix from an issue ID like "bd-123" -> "bd"
+func ExtractIssuePrefix(issueID string) string {
+	parts := strings.SplitN(issueID, "-", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0]
+}
+
+// ExtractIssueNumber extracts the number from an issue ID like "bd-123" -> 123
+func ExtractIssueNumber(issueID string) int {
+	parts := strings.SplitN(issueID, "-", 2)
+	if len(parts) < 2 {
+		return 0
+	}
+	var num int
+	fmt.Sscanf(parts[1], "%d", &num)
+	return num
+}


### PR DESCRIPTION
Enhances rename-prefix command with --repair flag to consolidate databases with multiple prefixes. Creates shared issue ID utilities to eliminate code duplication across import and rename operations.

Key changes:
- Add --repair flag to detect and consolidate multiple issue prefixes
- Create internal/utils/issue_id.go with ExtractIssuePrefix() and ExtractIssueNumber()
- Update all duplicate prefix extraction code to use shared utilities
- Add comprehensive tests for repair functionality

Example of running this version of the PR on my machine:
```
bd rename-prefix mtg- --repair --dry-run
✗ Multiple prefixes detected in database:
  - mtg: 76 issues
  - vc: 7 issues
  - workspace: 2 issues

DRY RUN: Would repair 9 issues with incorrect prefixes

Issues with correct prefix (mtg): 76 (highest number: 76)
Issues to repair: 9

Planned renames (showing first 10):
  vc-1 -> mtg-77
  vc-2 -> mtg-78
  vc-3 -> mtg-79
  vc-4 -> mtg-80
  vc-5 -> mtg-81
  vc-6 -> mtg-82
  vc-7 -> mtg-83
  workspace-1 -> mtg-84
  workspace-2 -> mtg-85
```

