### PR TITLE
Properly pipe BD_ACTOR through to Comment.Author field in bd comments…

### DIFF
--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -127,17 +127,20 @@ Examples:
 			commentText = args[1]
 		}
 
-		// Get author from environment or system
-		author := os.Getenv("BD_AUTHOR")
+		// Get author from author flag, BD_ACTOR var, or system USER var
+		author, _ := cmd.Flags().GetString("author")
 		if author == "" {
-			author = os.Getenv("USER")
-		}
-		if author == "" {
-			if u, err := user.Current(); err == nil {
-				author = u.Username
-			} else {
-				author = "unknown"
-			}
+            author := os.Getenv("BD_ACTOR")
+            if author == "" {
+                author = os.Getenv("USER")
+            }
+            if author == "" {
+                if u, err := user.Current(); err == nil {
+                    author = u.Username
+                } else {
+                    author = "unknown"
+                }
+            }
 		}
 
 		var comment *types.Comment
@@ -198,6 +201,7 @@ Examples:
 func init() {
 	commentsCmd.AddCommand(commentsAddCmd)
 	commentsAddCmd.Flags().StringP("file", "f", "", "Read comment text from file")
+	commentsAddCmd.Flags().StringP("author", "a", "", "Add author to comment")
 	rootCmd.AddCommand(commentsCmd)
 }
 


### PR DESCRIPTION
Properly pipe BD_ACTOR through to Comment.Author field in bd comments add. Add flag to bd comments add to accept author. Precedence is now flag, BD_ACTOR, USER.

Previous behavior piped through a non-existing BD_AUTHOR var (not documented anywhere, likely supposed to have been BD_ACTOR per previous docs) and did not have a way to pass in the author as a param.