### PR TITLE
Add Mermaid.js format for dependency tree visualization

### DIFF
--- a/cmd/bd/dep_test.go
+++ b/cmd/bd/dep_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -264,5 +268,219 @@ func TestDepRemove(t *testing.T) {
 
 	if len(deps) != 0 {
 		t.Errorf("Expected 0 dependencies after removal, got %d", len(deps))
+	}
+}
+
+func TestDepTreeFormatFlag(t *testing.T) {
+	// Test that the --format flag exists on depTreeCmd
+	flag := depTreeCmd.Flags().Lookup("format")
+	if flag == nil {
+		t.Fatal("depTreeCmd should have --format flag")
+	}
+
+	// Test default value is empty string
+	if flag.DefValue != "" {
+		t.Errorf("Expected default format='', got %q", flag.DefValue)
+	}
+
+	// Test usage text mentions mermaid
+	if !strings.Contains(flag.Usage, "mermaid") {
+		t.Errorf("Expected flag usage to mention 'mermaid', got %q", flag.Usage)
+	}
+}
+
+func TestGetStatusEmoji(t *testing.T) {
+	tests := []struct {
+		status types.Status
+		want   string
+	}{
+		{types.StatusOpen, "☐"},
+		{types.StatusInProgress, "◧"},
+		{types.StatusBlocked, "⚠"},
+		{types.StatusClosed, "☑"},
+		{types.Status("unknown"), "?"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := getStatusEmoji(tt.status)
+			if got != tt.want {
+				t.Errorf("getStatusEmoji(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutputMermaidTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		tree   []*types.TreeNode
+		rootID string
+		want   []string // Lines that must appear in output
+	}{
+		{
+			name:   "empty tree",
+			tree:   []*types.TreeNode{},
+			rootID: "test-1",
+			want: []string{
+				"flowchart TD",
+				`test-1["No dependencies"]`,
+			},
+		},
+		{
+			name: "single dependency",
+			tree: []*types.TreeNode{
+				{
+					Issue:    types.Issue{ID: "test-1", Title: "Task 1", Status: types.StatusInProgress},
+					Depth:    0,
+					ParentID: "",
+				},
+				{
+					Issue:    types.Issue{ID: "test-2", Title: "Task 2", Status: types.StatusClosed},
+					Depth:    1,
+					ParentID: "test-1",
+				},
+			},
+			rootID: "test-1",
+			want: []string{
+				"flowchart TD",
+				`test-1["◧ test-1: Task 1"]`,
+				`test-2["☑ test-2: Task 2"]`,
+				"test-1 --> test-2",
+			},
+		},
+		{
+			name: "multiple dependencies",
+			tree: []*types.TreeNode{
+				{
+					Issue:    types.Issue{ID: "test-1", Title: "Main", Status: types.StatusOpen},
+					Depth:    0,
+					ParentID: "",
+				},
+				{
+					Issue:    types.Issue{ID: "test-2", Title: "Sub 1", Status: types.StatusClosed},
+					Depth:    1,
+					ParentID: "test-1",
+				},
+				{
+					Issue:    types.Issue{ID: "test-3", Title: "Sub 2", Status: types.StatusBlocked},
+					Depth:    1,
+					ParentID: "test-1",
+				},
+			},
+			rootID: "test-1",
+			want: []string{
+				"flowchart TD",
+				`test-1["☐ test-1: Main"]`,
+				`test-2["☑ test-2: Sub 1"]`,
+				`test-3["⚠ test-3: Sub 2"]`,
+				"test-1 --> test-2",
+				"test-1 --> test-3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout
+			old := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			outputMermaidTree(tt.tree, tt.rootID)
+
+			w.Close()
+			os.Stdout = old
+
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			output := buf.String()
+
+			// Verify all expected lines appear
+			for _, line := range tt.want {
+				if !strings.Contains(output, line) {
+					t.Errorf("expected output to contain %q, got:\n%s", line, output)
+				}
+			}
+		})
+	}
+}
+
+func TestOutputMermaidTree_Siblings(t *testing.T) {
+	// Test case: Siblings with children (reproduces issue with wrong parent inference)
+	// Structure:
+	//   BD-1 (root)
+	//   ├── BD-2 (sibling 1)
+	//   │   └── BD-4 (child of BD-2)
+	//   └── BD-3 (sibling 2)
+	//       └── BD-5 (child of BD-3)
+	tree := []*types.TreeNode{
+		{
+			Issue:    types.Issue{ID: "BD-1", Title: "Parent", Status: types.StatusOpen},
+			Depth:    0,
+			ParentID: "",
+		},
+		{
+			Issue:    types.Issue{ID: "BD-2", Title: "Sibling 1", Status: types.StatusOpen},
+			Depth:    1,
+			ParentID: "BD-1",
+		},
+		{
+			Issue:    types.Issue{ID: "BD-3", Title: "Sibling 2", Status: types.StatusOpen},
+			Depth:    1,
+			ParentID: "BD-1",
+		},
+		{
+			Issue:    types.Issue{ID: "BD-4", Title: "Child of Sibling 1", Status: types.StatusOpen},
+			Depth:    2,
+			ParentID: "BD-2",
+		},
+		{
+			Issue:    types.Issue{ID: "BD-5", Title: "Child of Sibling 2", Status: types.StatusOpen},
+			Depth:    2,
+			ParentID: "BD-3",
+		},
+	}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	outputMermaidTree(tree, "BD-1")
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	// Verify correct edges exist
+	correctEdges := []string{
+		"BD-1 --> BD-2",
+		"BD-1 --> BD-3",
+		"BD-2 --> BD-4",
+		"BD-3 --> BD-5",
+	}
+
+	for _, edge := range correctEdges {
+		if !strings.Contains(output, edge) {
+			t.Errorf("expected edge %q to be present, got:\n%s", edge, output)
+		}
+	}
+
+	// Verify incorrect edges do NOT exist (siblings shouldn't be connected)
+	incorrectEdges := []string{
+		"BD-2 --> BD-3",   // Siblings shouldn't be connected
+		"BD-3 --> BD-4",   // BD-4's parent is BD-2, not BD-3
+		"BD-4 --> BD-3",   // Wrong direction
+		"BD-4 --> BD-5",   // These are cousins, not parent-child
+	}
+
+	for _, edge := range incorrectEdges {
+		if strings.Contains(output, edge) {
+			t.Errorf("incorrect edge %q should NOT be present, got:\n%s", edge, output)
+		}
 	}
 }

--- a/commands/dep.md
+++ b/commands/dep.md
@@ -23,6 +23,7 @@ Manage dependencies between beads issues.
   - $2: Issue ID
   - Flags:
     - `--reverse`: Show dependent tree (what was discovered from this) instead of dependency tree (what blocks this)
+    - `--format mermaid`: Output as Mermaid.js flowchart (renders in GitHub/GitLab markdown)
     - `--json`: Output as JSON
     - `--max-depth N`: Limit tree depth (default: 50)
     - `--show-all-paths`: Show all paths (no deduplication for diamond dependencies)
@@ -36,12 +37,45 @@ Manage dependencies between beads issues.
 - **parent-child**: Epic/subtask relationship
 - **discovered-from**: Track issues found during work
 
+## Mermaid Format
+
+The `--format mermaid` option outputs the dependency tree as a Mermaid.js flowchart:
+
+**Example:**
+```bash
+bd dep tree bd-1 --format mermaid
+```
+
+Output can be embedded in markdown:
+
+````markdown
+```mermaid
+flowchart TD
+  bd-1["◧ bd-1: Main task"]
+  bd-2["☑ bd-2: Subtask"]
+
+  bd-1 --> bd-2
+```
+````
+
+**Status Indicators:**
+
+Each node includes a symbol indicator for quick visual status identification:
+
+- ☐ **Open** - Not started yet (empty checkbox)
+- ◧ **In Progress** - Currently being worked on (half-filled box)
+- ⚠ **Blocked** - Waiting on something (warning sign)
+- ☑ **Closed** - Completed! (checked checkbox)
+
+The diagram colors are determined by your Mermaid theme (default, dark, forest, neutral, or base). Mermaid diagrams render natively in GitHub, GitLab, VSCode markdown preview, and can be imported to Miro.
+
 ## Examples
 
 - `bd dep add bd-10 bd-20 --type blocks`: bd-10 blocks bd-20
 - `bd dep tree bd-20`: Show what blocks bd-20 (dependency tree going UP)
 - `bd dep tree bd-1 --reverse`: Show what was discovered from bd-1 (dependent tree going DOWN)
 - `bd dep tree bd-1 --reverse --max-depth 3`: Show discovery tree with depth limit
+- `bd dep tree bd-20 --format mermaid > tree.md`: Generate Mermaid diagram for documentation
 - `bd dep cycles`: Check for circular dependencies
 
 ## Reverse Mode: Discovery Trees

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -616,6 +616,7 @@ func (m *MemoryStorage) SetJSONLFileHash(ctx context.Context, fileHash string) e
 // GetDependencyTree gets the dependency tree for an issue
 func (m *MemoryStorage) GetDependencyTree(ctx context.Context, issueID string, maxDepth int, showAllPaths bool, reverse bool) ([]*types.TreeNode, error) {
 	// Simplified implementation - just return direct dependencies
+	// Note: reverse parameter is accepted for interface compatibility but not fully implemented in memory storage
 	deps, err := m.GetDependencies(ctx, issueID)
 	if err != nil {
 		return nil, err

--- a/internal/storage/sqlite/dependencies.go
+++ b/internal/storage/sqlite/dependencies.go
@@ -587,7 +587,7 @@ func (s *SQLiteStorage) GetDependencyTree(ctx context.Context, issueID string, m
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan tree node: %w", err)
 		}
-		_ = parentID // Silence unused variable warning
+		node.ParentID = parentID
 
 		if closedAt.Valid {
 			node.ClosedAt = &closedAt.Time

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -222,8 +222,9 @@ type BlockedIssue struct {
 // TreeNode represents a node in a dependency tree
 type TreeNode struct {
 	Issue
-	Depth     int  `json:"depth"`
-	Truncated bool `json:"truncated"`
+	Depth     int    `json:"depth"`
+	ParentID  string `json:"parent_id"`
+	Truncated bool   `json:"truncated"`
 }
 
 // Statistics provides aggregate metrics


### PR DESCRIPTION
## Credit
This PR is based on the excellent work by @mrdavidlaing in #161. Thank you!

Due to 279 commits on main since Oct 27, I've rebased and resolved conflicts to bring this feature into the current codebase.

## Feature

Adds `bd dep tree --format mermaid` to export dependency trees as Mermaid.js flowcharts.

**Usage:**
```bash
bd dep tree bd-123 --format mermaid > diagram.md
```

**Example Output:**

```mermaid
flowchart TD
  bd-b014["☐ bd-b014: Test mermaid parent"]
  bd-6f1b["◧ bd-6f1b: Test mermaid child 1"]
  bd-e5f4["☑ bd-e5f4: Test mermaid child 2"]

  bd-b014 --> bd-6f1b
  bd-b014 --> bd-e5f4
```

**Status Indicators:**
- ☐ Open - Empty checkbox (not started)
- ◧ In Progress - Half-filled box (work in progress)
- ⚠ Blocked - Warning sign (attention needed)
- ☑ Closed - Checked checkbox (completed)

## Why Mermaid.js
- Renders natively in GitHub, GitLab, VSCode markdown preview
- Text-based (version control friendly)
- No external dependencies
- Theme-agnostic Unicode symbols

## Changes
- Added `--format mermaid` flag to `bd dep tree`
- Works with `--reverse` flag
- Comprehensive unit tests
- Documentation in commands/dep.md

Closes #161