### PR TITLE
Add dependency and dependent counts to bd list JSON output

### DIFF
--- a/integrations/beads-mcp/src/beads_mcp/models.py
+++ b/integrations/beads-mcp/src/beads_mcp/models.py
@@ -31,6 +31,8 @@ class Issue(BaseModel):
     labels: list[str] = Field(default_factory=list)
     dependencies: list["Issue"] = Field(default_factory=list)
     dependents: list["Issue"] = Field(default_factory=list)
+    dependency_count: int = 0
+    dependent_count: int = 0
 
     @field_validator("priority")
     @classmethod

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -25,6 +25,7 @@ type Storage interface {
 	GetDependents(ctx context.Context, issueID string) ([]*types.Issue, error)
 	GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error)
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
+	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetDependencyTree(ctx context.Context, issueID string, maxDepth int, showAllPaths bool, reverse bool) ([]*types.TreeNode, error)
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -147,6 +147,19 @@ type Dependency struct {
 	CreatedBy   string         `json:"created_by"`
 }
 
+// DependencyCounts holds counts for dependencies and dependents
+type DependencyCounts struct {
+	DependencyCount int `json:"dependency_count"` // Number of issues this issue depends on
+	DependentCount  int `json:"dependent_count"`  // Number of issues that depend on this issue
+}
+
+// IssueWithCounts extends Issue with dependency relationship counts
+type IssueWithCounts struct {
+	*Issue
+	DependencyCount int `json:"dependency_count"`
+	DependentCount  int `json:"dependent_count"`
+}
+
 // DependencyType categorizes the relationship
 type DependencyType string
 


### PR DESCRIPTION
## Summary

Adds `dependency_count` and `dependent_count` fields to `bd list --json` output, providing quick access to relationship metrics without needing multiple `bd show` commands.

**Example output:**
```json
{
  "id": "bd-373c",
  "title": "Fix daemon crash",
  "dependency_count": 1,
  "dependent_count": 0,
  ...
}
```

## Performance

✅ **Optimized with bulk query** - avoids N+1 problem

- **Baseline**: 19ms for 500 issues
- **This PR**: 24ms for 500 issues (26% overhead)
- **Avoided**: 42ms naive implementation (2.2x slowdown)

Uses single `GetDependencyCounts(issueIDs)` query instead of N individual queries.

## Implementation

- Added `GetDependencyCounts(issueIDs []string)` to Storage interface for bulk counting
- Efficient SQLite query using `UNION ALL` + `GROUP BY` to count both directions at once
- Memory storage implementation for testing
- Moved `IssueWithCounts` to `types` package to avoid duplication
- Both RPC and direct modes use optimized bulk query
- Updated MCP server's `Issue` model to include the new count fields

## Tests

- Added comprehensive tests for `GetDependencyCounts`
- Tests cover: normal operation, empty list, nonexistent IDs
- All existing tests continue to pass

## Backwards Compatibility

✅ JSON structure is additive - all original fields preserved. Existing scripts continue to work.

## Design Decision

Counts only **direct** dependencies/dependents (not transitive) for consistency with `bd show` output. Can add transitive counts later if needed for prioritization.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)