### PR TITLE
Fix prefix detection for hyphenated issue IDs

### DIFF
--- a/cmd/bd/nodb.go
+++ b/cmd/bd/nodb.go
@@ -173,11 +173,11 @@ func detectPrefix(beadsDir string, memStore *memory.MemoryStorage) (string, erro
 
 // extractIssuePrefix extracts the prefix from an issue ID like "bd-123" -> "bd"
 func extractIssuePrefix(issueID string) string {
-	parts := strings.SplitN(issueID, "-", 2)
-	if len(parts) < 2 {
+	idx := strings.LastIndex(issueID, "-")
+	if idx <= 0 {
 		return ""
 	}
-	return parts[0]
+	return issueID[:idx]
 }
 
 // writeIssuesToJSONL writes all issues from memory storage to JSONL file atomically

--- a/cmd/bd/nodb_test.go
+++ b/cmd/bd/nodb_test.go
@@ -18,6 +18,7 @@ func TestExtractIssuePrefix(t *testing.T) {
 		{"standard ID", "bd-123", "bd"},
 		{"custom prefix", "myproject-456", "myproject"},
 		{"hash ID", "bd-abc123def", "bd"},
+		{"hyphenated prefix", "alpha-beta-1", "alpha-beta"},
 		{"no hyphen", "nohyphen", ""},
 		{"empty", "", ""},
 	}

--- a/internal/utils/id_parser_test.go
+++ b/internal/utils/id_parser_test.go
@@ -321,6 +321,11 @@ func TestExtractIssuePrefix(t *testing.T) {
 			issueID:  "bd-",
 			expected: "bd",
 		},
+		{
+			name:     "hyphenated prefix",
+			issueID:  "alpha-beta-1",
+			expected: "alpha-beta",
+		},
 	}
 
 	for _, tt := range tests {
@@ -378,6 +383,11 @@ func TestExtractIssueNumber(t *testing.T) {
 			name:     "number with text after",
 			issueID:  "bd-123abc",
 			expected: 123,
+		},
+		{
+			name:     "hyphenated prefix with number",
+			issueID:  "alpha-beta-7",
+			expected: 7,
 		},
 	}
 

--- a/internal/utils/issue_id.go
+++ b/internal/utils/issue_id.go
@@ -7,20 +7,20 @@ import (
 
 // ExtractIssuePrefix extracts the prefix from an issue ID like "bd-123" -> "bd"
 func ExtractIssuePrefix(issueID string) string {
-	parts := strings.SplitN(issueID, "-", 2)
-	if len(parts) < 2 {
+	idx := strings.LastIndex(issueID, "-")
+	if idx <= 0 {
 		return ""
 	}
-	return parts[0]
+	return issueID[:idx]
 }
 
 // ExtractIssueNumber extracts the number from an issue ID like "bd-123" -> 123
 func ExtractIssueNumber(issueID string) int {
-	parts := strings.SplitN(issueID, "-", 2)
-	if len(parts) < 2 {
+	idx := strings.LastIndex(issueID, "-")
+	if idx < 0 || idx == len(issueID)-1 {
 		return 0
 	}
 	var num int
-	fmt.Sscanf(parts[1], "%d", &num)
+	fmt.Sscanf(issueID[idx+1:], "%d", &num)
 	return num
 }


### PR DESCRIPTION
### Problem

`internal/utils.ExtractIssuePrefix()`, `cmd/bd/nodb.extractIssuePrefix()` stops at the first hyphen when parsing IDs. For entries like `alpha-beta-7`, this returns `alpha`, so imports compare `alpha` against the configured prefix `alpha-beta` and treat it as a mismatch. During `bd import -i ...`, the importer surfaces:

> Import failed: failed to rename prefixes: cannot rename issue alpha-beta-1: non-numeric suffix 'beta-1'

### Root Cause

`ExtractIssuePrefix` / `ExtractIssueNumber` split on the first dash (`strings.SplitN(issueID, "-", 2)`), assuming prefixes never contain additional hyphens. Modern hash IDs and user prefixes (e.g., `alpha-beta`) violate that assumption, so the first comparison is wrong even though issue_prefix is set correctly (beads database expects `alpha-beta`).

### Fix

Switch both helpers to locate the last hyphen via `strings.LastIndex`:

- Prefix: `issueID[:idx]`
- Numeric suffix: `issueID[idx+1:]`

This preserves existing behavior (IDs without additional hyphens still parse) while allowing multi-hyphen prefixes to round-trip correctly.