### PR TITLE
Fix symlink path resolution in findDatabaseInTree

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -233,6 +233,12 @@ func findDatabaseInTree() string {
 		return ""
 	}
 
+	// Resolve symlinks in working directory to ensure consistent path handling
+	// This prevents issues when repos are accessed via symlinks (e.g. /Users/user/Code -> /Users/user/Documents/Code)
+	if resolvedDir, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolvedDir
+	}
+
 	// Walk up directory tree
 	for {
 		beadsDir := filepath.Join(dir, ".beads")


### PR DESCRIPTION
Resolve symlinks in working directory before walking up the tree to find .beads directory. This ensures consistent path handling when repositories are accessed via symlinks.

Without this fix, daemon operations can fail with 'operation not permitted' errors when trying to export to JSONL, because the daemon resolves paths differently than the CLI commands.

Example issue: /Users/user/Code -> /Users/user/Documents/Code The daemon would try to write to the symlinked path while the file system expects operations on the resolved path.a