### PR TITLE
Fix pointer dereferencing in Update RPC handler

### DIFF
--- a/internal/rpc/rpc_test.go
+++ b/internal/rpc/rpc_test.go
@@ -213,9 +213,18 @@ func TestUpdateIssue(t *testing.T) {
 	json.Unmarshal(createResp.Data, &issue)
 
 	newTitle := "Updated Title"
+	notes := "Some important notes"
+	design := "Design details"
+	assignee := "alice"
+	acceptance := "Acceptance criteria"
+
 	updateArgs := &UpdateArgs{
-		ID:    issue.ID,
-		Title: &newTitle,
+		ID:                 issue.ID,
+		Title:              &newTitle,
+		Notes:              &notes,
+		Design:             &design,
+		Assignee:           &assignee,
+		AcceptanceCriteria: &acceptance,
 	}
 
 	updateResp, err := client.Update(updateArgs)
@@ -228,6 +237,18 @@ func TestUpdateIssue(t *testing.T) {
 
 	if updatedIssue.Title != newTitle {
 		t.Errorf("Expected title %s, got %s", newTitle, updatedIssue.Title)
+	}
+	if updatedIssue.Notes != notes {
+		t.Errorf("Expected notes %s, got %s", notes, updatedIssue.Notes)
+	}
+	if updatedIssue.Design != design {
+		t.Errorf("Expected design %s, got %s", design, updatedIssue.Design)
+	}
+	if updatedIssue.Assignee != assignee {
+		t.Errorf("Expected assignee %s, got %s", assignee, updatedIssue.Assignee)
+	}
+	if updatedIssue.AcceptanceCriteria != acceptance {
+		t.Errorf("Expected acceptance criteria %s, got %s", acceptance, updatedIssue.AcceptanceCriteria)
 	}
 }
 

--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -50,16 +50,16 @@ func updatesFromArgs(a UpdateArgs) map[string]interface{} {
 		u["priority"] = *a.Priority
 	}
 	if a.Design != nil {
-		u["design"] = a.Design
+		u["design"] = *a.Design
 	}
 	if a.AcceptanceCriteria != nil {
-		u["acceptance_criteria"] = a.AcceptanceCriteria
+		u["acceptance_criteria"] = *a.AcceptanceCriteria
 	}
 	if a.Notes != nil {
-		u["notes"] = a.Notes
+		u["notes"] = *a.Notes
 	}
 	if a.Assignee != nil {
-		u["assignee"] = a.Assignee
+		u["assignee"] = *a.Assignee
 	}
 	return u
 }


### PR DESCRIPTION
When you run `bd update issue-123 --notes "foo"`, it fails with `Error: failed to read response: EOF`.

This was because `Design`, `AcceptanceCriteria`, `Notes`, and `Assignee` weren't being dereferenced properly in `updatesFromArgs`.

In this PR I've fixed that, and added a regression test (that I've checked on `main` and can attest that it is broken there without the fix).