### PR TITLE
Fix #249: Add nil storage checks to prevent RPC daemon crashes

### DIFF
--- a/internal/rpc/server_compact.go
+++ b/internal/rpc/server_compact.go
@@ -19,6 +19,12 @@ func (s *Server) handleCompact(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	sqliteStore, ok := store.(*sqlite.SQLiteStorage)
 	if !ok {
@@ -228,6 +234,12 @@ func (s *Server) handleCompactStats(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	sqliteStore, ok := store.(*sqlite.SQLiteStorage)
 	if !ok {

--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -87,6 +87,12 @@ func (s *Server) handleCreate(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 	ctx := s.reqCtx(req)
 
 	// If parent is specified, generate child ID
@@ -242,6 +248,12 @@ func (s *Server) handleUpdate(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	ctx := s.reqCtx(req)
 	updates := updatesFromArgs(updateArgs)
@@ -284,6 +296,12 @@ func (s *Server) handleClose(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	ctx := s.reqCtx(req)
 	if err := store.CloseIssue(ctx, closeArgs.ID, closeArgs.Reason, s.reqActor(req)); err != nil {
@@ -314,6 +332,12 @@ func (s *Server) handleList(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	filter := types.IssueFilter{
 		Limit: listArgs.Limit,
@@ -492,6 +516,13 @@ func (s *Server) handleResolveID(req *Request) Response {
 		}
 	}
 
+	if s.storage == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
+
 	ctx := s.reqCtx(req)
 	resolvedID, err := utils.ResolvePartialID(ctx, s.storage, args.ID)
 	if err != nil {
@@ -518,6 +549,12 @@ func (s *Server) handleShow(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	ctx := s.reqCtx(req)
 	issue, err := store.GetIssue(ctx, showArgs.ID)
@@ -593,6 +630,12 @@ func (s *Server) handleReady(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	wf := types.WorkFilter{
 		Status:     types.StatusOpen,
@@ -632,6 +675,12 @@ func (s *Server) handleStale(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	filter := types.StaleFilter{
 		Days:   staleArgs.Days,
@@ -657,6 +706,12 @@ func (s *Server) handleStale(req *Request) Response {
 
 func (s *Server) handleStats(req *Request) Response {
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	ctx := s.reqCtx(req)
 	stats, err := store.GetStatistics(ctx)
@@ -684,6 +739,12 @@ func (s *Server) handleEpicStatus(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	ctx := s.reqCtx(req)
 	epics, err := store.GetEpicsEligibleForClosure(ctx)

--- a/internal/rpc/server_labels_deps_comments.go
+++ b/internal/rpc/server_labels_deps_comments.go
@@ -19,6 +19,12 @@ func (s *Server) handleDepAdd(req *Request) Response {
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	dep := &types.Dependency{
 		IssueID:     depArgs.FromID,
@@ -51,6 +57,12 @@ func (s *Server) handleSimpleStoreOp(req *Request, argsPtr interface{}, argDesc 
 	}
 
 	store := s.storage
+	if store == nil {
+		return Response{
+			Success: false,
+			Error:   "storage not available (global daemon deprecated - use local daemon instead with 'bd daemon' in your project)",
+		}
+	}
 
 	ctx := s.reqCtx(req)
 	if err := opFunc(ctx, store, s.reqActor(req)); err != nil {


### PR DESCRIPTION
## Summary
The daemon RPC server was crashing with a nil pointer dereference when receiving list, ready, stats, or other storage-dependent RPC requests.

## Problem
- Global daemon is created with nil storage (cmd/bd/daemon_server.go:55)
- RPC handlers directly called s.storage methods without nil check
- Nil pointer dereference caused daemon to crash
- Client received 'Daemon closed connection without responding' error
- MCP tools could not function at all

## Solution
Added defensive nil storage checks to all RPC handlers that require storage access. When storage is unavailable, they return a proper JSON-RPC error response instead of crashing the daemon.

## Handlers Modified (14 total)

**internal/rpc/server_issues_epics.go:**
- handleCreate() - added nil check
- handleUpdate() - added nil check  
- handleClose() - added nil check
- handleList() - added nil check
- handleShow() - added nil check
- handleReady() - added nil check
- handleStale() - added nil check
- handleResolveID() - added nil check
- handleStats() - added nil check
- handleEpicStatus() - added nil check

**internal/rpc/server_labels_deps_comments.go:**
- handleDepAdd() - added nil check
- handleSimpleStoreOp() - added nil check (covers all label/dep/comment operations)

**internal/rpc/server_compact.go:**
- handleCompact() - added nil check
- handleCompactStats() - added nil check

## Testing Results

**Before Fix (v0.22.1):**
- MCP ready call: 'Daemon closed connection without responding'
- Daemon: CRASHED ✗
- Socket: CLOSED

**After Fix:**
- MCP ready call: 'Daemon returned error: storage not available...'
- Daemon: RUNNING ✓
- Socket: OPEN and listening

## Impact
- Daemon stays running instead of crashing
- Proper error responses sent to clients
- MCP tools can handle errors gracefully
- Clear message guides users to use local daemons
- Fixes issue where daemon was unusable via RPC

Fixes #249