### PR TITLE
fix: remove unnecessary cd commands

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -121,7 +121,6 @@ install_from_release() {
 
     # Extract archive
     log_info "Extracting archive..."
-        cd - > /dev/null || cd "$HOME"
     if ! tar -xzf "$archive_name"; then
         log_error "Failed to extract archive"
         rm -rf "$tmp_dir"
@@ -154,10 +153,9 @@ install_from_release() {
         echo "Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
         echo "  export PATH=\"\$PATH:$install_dir\""
         echo ""
-    cd - > /dev/null || cd "$HOME"
     fi
 
-    cd - > /dev/null
+    cd - > /dev/null || cd "$HOME"
     rm -rf "$tmp_dir"
     return 0
 }
@@ -265,12 +263,10 @@ build_from_source() {
                 echo ""
                 echo "Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
                 echo "  export PATH=\"\$PATH:$install_dir\""
-        cd - > /dev/null || cd "$HOME"
                 echo ""
             fi
 
-            cd - > /dev/null
-        cd - > /dev/null || cd "$HOME"
+            cd - > /dev/null || cd "$HOME"
             rm -rf "$tmp_dir"
             return 0
         else
@@ -442,3 +438,4 @@ main() {
 }
 
 main "$@"
+


### PR DESCRIPTION
Fixes an issue with the installer that was failing to install from the latest release and falling back to compiling the dev version.

❯ curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash

🔗 Beads (bd) Installer

==> Detecting platform...
==> Platform: linux_amd64
==> Installing bd from GitHub releases...
==> Fetching latest release...
==> Latest version: v0.22.1
==> Downloading beads_0.22.1_linux_amd64.tar.gz...
==> Extracting archive...
tar (child): beads_0.22.1_linux_amd64.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
Error: Failed to extract archive
==> Failed to install from releases, trying alternative methods...
==> Go detected: go version go1.25.4 linux/amd64
==> Installing bd using 'go install'...
go: downloading github.com/steveyegge/beads v0.22.1
==> bd installed successfully via go install
==> bd is installed and ready!


❯ bash scripts/install.sh

🔗 Beads (bd) Installer

==> Detecting platform...
==> Platform: linux_amd64
==> Installing bd from GitHub releases...
==> Fetching latest release...
==> Latest version: v0.22.1
==> Downloading beads_0.22.1_linux_amd64.tar.gz...
==> Extracting archive...
==> Installing to /home/trly/.local/bin...
==> bd installed to /home/trly/.local/bin/bd
==> bd is installed and ready!
