### PR TITLE
fix: Add 'file:' prefix to SQLite URIs in doctor.go

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -314,7 +314,7 @@ func checkIDFormat(path string) doctorCheck {
 	}
 
 	// Open database
-	db, err := sql.Open("sqlite3", dbPath+"?mode=ro")
+	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
 	if err != nil {
 		return doctorCheck{
 			Name:    "Issue IDs",
@@ -400,7 +400,7 @@ func checkCLIVersion() doctorCheck {
 }
 
 func getDatabaseVersionFromPath(dbPath string) string {
-	db, err := sql.Open("sqlite3", dbPath+"?mode=ro")
+	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
 	if err != nil {
 		return "unknown"
 	}


### PR DESCRIPTION
## Problem

Without the `file:` URI scheme prefix, SQLite treats query parameters like `?mode=ro` as part of the filename instead of connection options.

This caused:
- Creation of bogus files named `beads.db?mode=ro` in the `.beads/` directory
- Failure to read database version from the metadata table
- `bd doctor` incorrectly reporting `version pre-0.17.5 (very old)` even after running `bd migrate`

## Solution

Fixed two `sql.Open()` calls in `doctor.go`:
- Line 317 (`checkIssueIDs` function)
- Line 403 (`getDatabaseVersionFromPath` function)

Changed from:
```go
db, err := sql.Open("sqlite3", dbPath+"?mode=ro")
```

To:
```go
db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
```

This matches the pattern already used correctly in `migrate.go:524`.

## Testing

- ✅ All unit tests pass (`go test -short ./...`)
- ✅ Verified `bd doctor` now correctly detects database version
- ✅ Confirmed no bogus `beads.db?mode=ro` files are created
- ✅ Tested with fresh `bd init --quiet` installation

Fixes #260