### PR TITLE
fix: Improve missing git hook message

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -1202,7 +1202,7 @@ func checkGitHooks(path string) doctorCheck {
 		}
 	}
 
-	hookInstallMsg := "See https://github.com/steveyegge/beads/tree/main/examples/git-hooks for installation instructions"
+	hookInstallMsg := "Install hooks with 'bd hooks install'. See https://github.com/steveyegge/beads/tree/main/examples/git-hooks for installation instructions"
 
 	if len(installedHooks) > 0 {
 		return doctorCheck{


### PR DESCRIPTION
Currently, the 'bd doctor' message about fixing missing git hooks suggests looking at a page of information in the repo. Given that beads has a command specifically to install hooks, I think adding that to the message is appropriate.