### PR TITLE
fix: isHashID matches for hyphenated application names

### DIFF
--- a/cmd/bd/migrate_hash_ids.go
+++ b/cmd/bd/migrate_hash_ids.go
@@ -328,12 +328,12 @@ func replaceIDReferences(text string, mapping map[string]string) string {
 func isHashID(id string) bool {
 	// Hash IDs contain hex letters (a-f), sequential IDs are only digits
 	// May have hierarchical suffix like .1 or .1.2
-	parts := strings.SplitN(id, "-", 2)
-	if len(parts) != 2 {
+	lastSeperatorIndex := strings.LastIndex(id, "-")
+	if lastSeperatorIndex == -1 {
 		return false
 	}
 	
-	suffix := parts[1]
+	suffix := id[lastSeperatorIndex+1:]
 	// Strip hierarchical suffix like .1 or .1.2
 	baseSuffix := strings.Split(suffix, ".")[0]
 	

--- a/cmd/bd/migrate_hash_ids_test.go
+++ b/cmd/bd/migrate_hash_ids_test.go
@@ -258,6 +258,13 @@ func TestIsHashID(t *testing.T) {
 		{"bd-123abc", true},
 		{"bd-a3f8e9a2.1", true},
 		{"bd-a3f8e9a2.1.2", true},
+		{"bd-beads-1", false},
+		{"bd-beads-123", false},
+		{"bd-beads-a3f8e9a2", true},
+		{"bd-beads-abc123", true},
+		{"bd-beads-123abc", true},
+		{"bd-beads-a3f8e9a2.1", true},
+		{"bd-beads-a3f8e9a2.1.2", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes `isHashID` checks for hyphenated application names

When a user calls bd init inside an application that has a "-" for example my-first-application without any options than ids will follow a pattern of my-first-application-{ID}. When using SplitN on the "-" separator it would result in the split parts returning as [my, first-application-{ID}] which is incorrectly pulling out the {ID} resulting in the `isHashID` returning false when it could be a hash id.

Instead of using SplitN, this changes to find the last index of the separator resulting in the suffix becoming the actual {ID}.