### PR TITLE
Fix doctor incorrectly diagnosing hash IDs as sequential (#322)

### DIFF
--- a/cmd/bd/migrate_hash_ids_test.go
+++ b/cmd/bd/migrate_hash_ids_test.go
@@ -251,13 +251,33 @@ func TestIsHashID(t *testing.T) {
 		id       string
 		expected bool
 	}{
+		// Sequential IDs (numeric only, short)
 		{"bd-1", false},
 		{"bd-123", false},
+		{"bd-9999", false},
+		
+		// Hash IDs with letters
 		{"bd-a3f8e9a2", true},
 		{"bd-abc123", true},
 		{"bd-123abc", true},
 		{"bd-a3f8e9a2.1", true},
 		{"bd-a3f8e9a2.1.2", true},
+		
+		// Hash IDs that are numeric but 5+ characters (likely hash)
+		{"bd-12345", true},
+		{"bd-0088", false}, // 4 chars, all numeric - ambiguous, defaults to false
+		{"bd-00880", true},  // 5+ chars, likely hash
+		
+		// Base36 hash IDs with letters
+		{"bd-5n3", true},
+		{"bd-65w", true},
+		{"bd-jmx", true},
+		{"bd-4rt", true},
+		
+		// Edge cases
+		{"bd-", false},     // Empty suffix
+		{"invalid", false}, // No dash
+		{"bd-0", false},    // Single digit
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
Fixes #322 - bd doctor was incorrectly flagging hash-based IDs as sequential when IDs were numeric-only (e.g., pf-0088, pf-02a4).

## Root Cause
The checkIDFormat function only checked **one issue** and relied on heuristics that couldn't distinguish between:
- Sequential IDs: bd-1, bd-2, bd-3
- Numeric hash IDs: bd-0088, bd-02a4, bd-05a1 (base36 can be all numeric)

## Solution
Enhanced detection with multiple heuristics:
1. **Schema check**: Presence of child_counters table indicates hash IDs
2. **Letter detection**: Base36 hash IDs contain letters (a-z)
3. **Leading zeros**: Common in hash IDs (bd-0088), rare in sequential
4. **Variable length**: Adaptive hash IDs use 3+ different lengths
5. **Non-sequential ordering**: Hash IDs aren't in numeric sequence

## Changes
- Modified checkIDFormat() to sample up to 10 issues
- Added detectHashBasedIDs() function with robust multi-heuristic detection
- Added 16 comprehensive test cases covering all edge cases
- Fixed variable length heuristic to avoid false positives

## Testing


**Manual verification:**
- ✅ Hash IDs with letters: Correctly detected as hash-based ✓
- ✅ Numeric hash IDs with leading zeros: Correctly detected as hash-based ✓
- ✅ Sequential IDs: Still correctly warned as sequential (e.g., bd-1, bd-2, ...)

## Backward Compatibility
- ✅ Fully backward compatible
- ✅ No API changes
- ✅ Conservative approach: defaults to sequential if uncertain
