### PR TITLE
Fix: Restore JSON unmarshaling in ResolveID for fixing failed bd show/update/close operations

### DIFF
--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -34,7 +34,12 @@ var showCmd = &cobra.Command{
 					fmt.Fprintf(os.Stderr, "Error resolving ID %s: %v\n", id, err)
 					os.Exit(1)
 				}
-				resolvedIDs = append(resolvedIDs, string(resp.Data))
+				var resolvedID string
+				if err := json.Unmarshal(resp.Data, &resolvedID); err != nil {
+					fmt.Fprintf(os.Stderr, "Error unmarshaling resolved ID: %v\n", err)
+					os.Exit(1)
+				}
+				resolvedIDs = append(resolvedIDs, resolvedID)
 			}
 		} else {
 			// In direct mode, resolve via storage
@@ -392,7 +397,12 @@ var updateCmd = &cobra.Command{
 					fmt.Fprintf(os.Stderr, "Error resolving ID %s: %v\n", id, err)
 					os.Exit(1)
 				}
-				resolvedIDs = append(resolvedIDs, string(resp.Data))
+				var resolvedID string
+				if err := json.Unmarshal(resp.Data, &resolvedID); err != nil {
+					fmt.Fprintf(os.Stderr, "Error unmarshaling resolved ID: %v\n", err)
+					os.Exit(1)
+				}
+				resolvedIDs = append(resolvedIDs, resolvedID)
 			}
 		} else {
 			var err error
@@ -710,7 +720,12 @@ var closeCmd = &cobra.Command{
 					fmt.Fprintf(os.Stderr, "Error resolving ID %s: %v\n", id, err)
 					os.Exit(1)
 				}
-				resolvedIDs = append(resolvedIDs, string(resp.Data))
+				var resolvedID string
+				if err := json.Unmarshal(resp.Data, &resolvedID); err != nil {
+					fmt.Fprintf(os.Stderr, "Error unmarshaling resolved ID: %v\n", err)
+					os.Exit(1)
+				}
+				resolvedIDs = append(resolvedIDs, resolvedID)
 			}
 		} else {
 			var err error


### PR DESCRIPTION
## Summary
Fixes #336 

Restores proper JSON unmarshaling of resolved issue IDs in `bd show`, `bd update`, and `bd close` commands, fixing a regression where issue IDs with custom prefixes (e.g., `ao-izl`) fail to resolve.

## Problem
The bd show/update/close commands incorrectly used `string(resp.Data)` to extract resolved IDs from RPC responses, which treats raw JSON bytes as strings without decoding. This caused resolved IDs to literally include quotes (`"ao-izl"` instead of `ao-izl`), leading to "issue not found" errors.

## Changes
1. **cmd/bd/show.go**: Restored `json.Unmarshal(resp.Data, &resolvedID)` in 3 locations:
   - showCmd (lines 37-42)
   - updateCmd (lines 400-405)
   - closeCmd (lines 723-728)

2. **internal/utils/id_parser.go**: Added fast-path exact match in `ResolvePartialID()` to preserve cross-repo ID behavior (e.g., `ao-izl`) while maintaining prefix-based resolution

## Testing
- ✅ All existing tests pass
- ✅ Verified `bd show <issue-id>` works in both daemon and direct modes
- ✅ Tested with prefixed IDs that don't match configured `issue_prefix`

## Checklist
- [x] Code follows standard Go conventions
- [x] All tests pass (`go test ./...`)
- [x] No new linter warnings introduced
- [x] Changes are focused on single issue