### PR TITLE
fix: use nullish coalescing to fix priority 0 bug display

### DIFF
--- a/examples/monitor-webui/web/index.html
+++ b/examples/monitor-webui/web/index.html
@@ -64,6 +64,7 @@
                 <div class="filter-group">
                     <label for="filter-priority">Priority</label>
                     <select id="filter-priority" multiple>
+                        <option value="0" selected>P0</option>
                         <option value="1" selected>P1</option>
                         <option value="2" selected>P2</option>
                         <option value="3" selected>P3</option>

--- a/examples/monitor-webui/web/static/js/app.js
+++ b/examples/monitor-webui/web/static/js/app.js
@@ -127,18 +127,18 @@ function renderIssues(issues) {
     // Render table view
     tbody.innerHTML = issues.map(issue => {
         const statusClass = 'status-' + (issue.status || 'open').toLowerCase().replace('_', '-');
-        const priorityClass = 'priority-' + (issue.priority || 2);
-        return '<tr onclick="showIssueDetail(\'' + issue.id + '\')"><td>' + issue.id + '</td><td>' + issue.title + '</td><td class="' + statusClass + '">' + (issue.status || 'open') + '</td><td class="' + priorityClass + '">P' + (issue.priority || 2) + '</td><td>' + (issue.issue_type || 'task') + '</td><td>' + (issue.assignee || '-') + '</td></tr>';
+        const priorityClass = 'priority-' + (issue.priority ?? 2);
+        return '<tr onclick="showIssueDetail(\'' + issue.id + '\')"><td>' + issue.id + '</td><td>' + issue.title + '</td><td class="' + statusClass + '">' + (issue.status || 'open') + '</td><td class="' + priorityClass + '">P' + (issue.priority ?? 2) + '</td><td>' + (issue.issue_type || 'task') + '</td><td>' + (issue.assignee || '-') + '</td></tr>';
     }).join('');
 
     // Render card view for mobile
     cardView.innerHTML = issues.map(issue => {
         const statusClass = 'status-' + (issue.status || 'open').toLowerCase().replace('_', '-');
-        const priorityClass = 'priority-' + (issue.priority || 2);
+        const priorityClass = 'priority-' + (issue.priority ?? 2);
         let html = '<div class="issue-card" onclick="showIssueDetail(\'' + issue.id + '\')">';
         html += '<div class="issue-card-header">';
         html += '<span class="issue-card-id">' + issue.id + '</span>';
-        html += '<span class="' + priorityClass + '">P' + (issue.priority || 2) + '</span>';
+        html += '<span class="' + priorityClass + '">P' + (issue.priority ?? 2) + '</span>';
         html += '</div>';
         html += '<h3 class="issue-card-title">' + issue.title + '</h3>';
         html += '<div class="issue-card-meta">';


### PR DESCRIPTION
The monitor-ui javascript rendering has logic for displaying issue priority with a fallback to 2 if there is no priority. That logic relies on a logical OR operator `||` which will treat a falsey value like 0 as false. The result is an issue with a priority of 0 will render on the ui as P2 instead of being displayed as P0. 

Instead of using the `||` operator this changes to use the `??` [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) which will only treat a null or undefined priority as a missing value not a falsey value like 0.

This PR also adds P0 as a filter to the priority selector so P0s can also be filtered on without requiring removing all the priority filters.

---

Before 

<img width="1220" height="608" alt="Screenshot 2025-11-23 at 3 58 12 PM" src="https://github.com/user-attachments/assets/265d18f4-b646-4cf6-9a2b-8430138350b0" />

---

After

<img width="1224" height="673" alt="Screenshot 2025-11-23 at 3 53 17 PM" src="https://github.com/user-attachments/assets/f1d6150a-b2d5-43a8-900f-9821c560d4ec" />


