### PR TITLE
Add support for ARM Linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,8 +14,6 @@ builds:
     binary: bd
     env:
       - CGO_ENABLED=1
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
     goos:
       - linux
     goarch:


### PR DESCRIPTION
Adding ARM support for Linux. We use ARM to run Docker containers and we're currently just compiling from source. This works, but if we can get ARM Linux artifacts, that would be easier. 

I added the `CC` flags to support cross compilation regardless of host platform. I'm not an expert at cross compilation but I believe this should work; I did some testing here locally using `goreleaser` to try to produce each of the artifacts for each architecture. 

