### PR TITLE
Add bdui to Third-Party Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,7 @@ For advanced usage, see:
 ### Third-Party Tools
 
 - **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates, kanban board, and keyboard navigation. Zero-setup launch with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni).
+- **[bdui](https://github.com/assimelha/bdui)** - Real-time terminal UI with kanban board, tree view, dependency graph, and statistics dashboard. Vim-style navigation, search/filter, themes, and native notifications. Built by [@assimelha](https://github.com/assimelha).
 
 Have you built something cool with bd? [Open an issue](https://github.com/steveyegge/beads/issues) to get it featured here!
 


### PR DESCRIPTION
## Summary

Adds [bdui](https://github.com/assimelha/bdui) to the Third-Party Tools section in the Community & Ecosystem docs.

bdui is a real-time terminal UI for bd that provides:
- Kanban board view (4-column status layout)
- Tree view (parent-child hierarchies)
- Dependency graph (ASCII visualization)
- Statistics dashboard
- Vim-style navigation (hjkl)
- Search and filter capabilities
- 5 color themes
- Native desktop notifications
- Cross-platform support (macOS, Linux, Windows)

Built with Bun + Ink (React for CLIs) + Zustand.

## Screenshot

![bdui screenshot](https://raw.githubusercontent.com/assimelha/bdui/master/assets/screenshot.png)