### PR TITLE
Fix: harden JSONL path handling

### DIFF
--- a/cmd/bd/doctor/fix/common_test.go
+++ b/cmd/bd/doctor/fix/common_test.go
@@ -1,0 +1,55 @@
+package fix
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSafeWorkspacePath(t *testing.T) {
+	root := t.TempDir()
+	absEscape, _ := filepath.Abs(filepath.Join(root, "..", "escape"))
+
+	tests := []struct {
+		name    string
+		relPath string
+		wantErr bool
+	}{
+		{
+			name:    "normal relative path",
+			relPath: ".beads/issues.jsonl",
+			wantErr: false,
+		},
+		{
+			name:    "nested relative path",
+			relPath: filepath.Join(".beads", "nested", "file.txt"),
+			wantErr: false,
+		},
+		{
+			name:    "absolute path rejected",
+			relPath: absEscape,
+			wantErr: true,
+		},
+		{
+			name:    "path traversal rejected",
+			relPath: filepath.Join("..", "escape"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeWorkspacePath(root, tt.relPath)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("safeWorkspacePath() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				if !isWithinWorkspace(root, got) {
+					t.Fatalf("resolved path %q not within workspace %q", got, root)
+				}
+				if !filepath.IsAbs(got) {
+					t.Fatalf("resolved path is not absolute: %q", got)
+				}
+			}
+		})
+	}
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -92,11 +92,11 @@ var (
 )
 
 var (
-	noAutoFlush  bool
-	noAutoImport bool
-	sandboxMode  bool
-	allowStale   bool // Use --allow-stale: skip staleness check (emergency escape hatch)
-	noDb         bool // Use --no-db mode: load from JSONL, write back after each command
+	noAutoFlush    bool
+	noAutoImport   bool
+	sandboxMode    bool
+	allowStale     bool // Use --allow-stale: skip staleness check (emergency escape hatch)
+	noDb           bool // Use --no-db mode: load from JSONL, write back after each command
 	profileEnabled bool
 	profileFile    *os.File
 	traceFile      *os.File
@@ -590,8 +590,14 @@ var rootCmd = &cobra.Command{
 		if store != nil {
 			_ = store.Close()
 		}
-		if profileFile != nil { pprof.StopCPUProfile(); _ = profileFile.Close() }
-		if traceFile != nil { trace.Stop(); _ = traceFile.Close() }
+		if profileFile != nil {
+			pprof.StopCPUProfile()
+			_ = profileFile.Close()
+		}
+		if traceFile != nil {
+			trace.Stop()
+			_ = traceFile.Close()
+		}
 
 		// Cancel the signal context to clean up resources
 		if rootCancel != nil {
@@ -623,6 +629,24 @@ func isFreshCloneError(err error) bool {
 		strings.Contains(errStr, "required config key missing: issue_prefix")
 }
 
+// isPathWithinDir reports whether candidate resides within baseDir (or is the same path).
+// Paths are cleaned before comparison to defend against directory traversal.
+func isPathWithinDir(baseDir, candidate string) bool {
+	cleanBase := filepath.Clean(baseDir)
+	cleanCandidate := filepath.Clean(candidate)
+
+	rel, err := filepath.Rel(cleanBase, cleanCandidate)
+	if err != nil {
+		return false
+	}
+
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false
+	}
+
+	return true
+}
+
 // handleFreshCloneError displays a helpful message when a fresh clone is detected
 // and returns true if the error was handled (so caller should exit).
 // If not a fresh clone error, returns false and does nothing.
@@ -636,12 +660,20 @@ func handleFreshCloneError(err error, beadsDir string) bool {
 	issueCount := 0
 
 	if beadsDir != "" {
+		if absBeadsDir, err := filepath.Abs(beadsDir); err == nil {
+			beadsDir = absBeadsDir
+		}
+
 		// Check for issues.jsonl (canonical) first, then beads.jsonl (legacy)
 		for _, name := range []string{"issues.jsonl", "beads.jsonl"} {
 			candidate := filepath.Join(beadsDir, name)
+			if !isPathWithinDir(beadsDir, candidate) {
+				continue
+			}
 			if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
 				jsonlPath = candidate
 				// Count lines (approximately = issue count)
+				// #nosec G304 -- candidate limited to known JSONL files inside .beads
 				if data, readErr := os.ReadFile(candidate); readErr == nil {
 					for _, line := range strings.Split(string(data), "\n") {
 						if strings.TrimSpace(line) != "" {


### PR DESCRIPTION
## Summary
- Fix CI lint failure (gosec G304) by bounding JSONL discovery during fresh-clone errors: normalize .beads to abs path and skip any candidate outside the directory before reading.
- Add shared path guards for doctor fixes (`safeWorkspacePath`, `isWithinWorkspace`) and use them in `database_config` + `untracked` to reject absolute or traversal inputs; keep .gitattributes rewrite within workspace.
- Add regression tests for path guards and make them portable across OSes (Windows-friendly path construction).

## Rationale
CI was failing on lint (G304 file inclusion via variable). The root cause was reading/adding .beads JSONL files from unvalidated paths in fresh-clone handling and doctor fixes. This patch constrains all such paths to the workspace and adds tests so the guards stay in place. Tests were updated to avoid POSIX-only paths so Windows CI remains green.

## Testing
- golangci-lint run
- go test -v -race -short ./...