### PR TITLE
fix(sync): default noGitHistory=true for --from-main mode

### DIFF
--- a/cmd/bd/sync_test.go
+++ b/cmd/bd/sync_test.go
@@ -1003,3 +1003,50 @@ func TestSanitizeJSONLWithDeletions_NonexistentJSONL(t *testing.T) {
 		t.Errorf("expected 0 removed for missing file, got %d", result.RemovedCount)
 	}
 }
+
+// TestResolveNoGitHistoryForFromMain tests that --from-main forces noGitHistory=true
+// to prevent creating incorrect deletion records for locally-created beads.
+// See: https://github.com/steveyegge/beads/issues/417
+func TestResolveNoGitHistoryForFromMain(t *testing.T) {
+	tests := []struct {
+		name         string
+		fromMain     bool
+		noGitHistory bool
+		want         bool
+	}{
+		{
+			name:         "fromMain=true forces noGitHistory=true regardless of flag",
+			fromMain:     true,
+			noGitHistory: false,
+			want:         true,
+		},
+		{
+			name:         "fromMain=true with noGitHistory=true stays true",
+			fromMain:     true,
+			noGitHistory: true,
+			want:         true,
+		},
+		{
+			name:         "fromMain=false preserves noGitHistory=false",
+			fromMain:     false,
+			noGitHistory: false,
+			want:         false,
+		},
+		{
+			name:         "fromMain=false preserves noGitHistory=true",
+			fromMain:     false,
+			noGitHistory: true,
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveNoGitHistoryForFromMain(tt.fromMain, tt.noGitHistory)
+			if got != tt.want {
+				t.Errorf("resolveNoGitHistoryForFromMain(%v, %v) = %v, want %v",
+					tt.fromMain, tt.noGitHistory, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Forces `noGitHistory=true` when `--from-main` is used (explicit or auto-detected)
- Prevents incorrect deletion records for locally-created beads that don't exist on main
- Matches existing daemon behavior (`daemon_sync.go` already uses `NoGitHistory: true`)

## Problem

When syncing from main, git history backfill incorrectly identifies locally-created beads as "deleted" because it searches LOCAL git history rather than main's history. This creates spurious deletion records for beads that were never in main.

## Test plan

- [x] Added unit test `TestResolveNoGitHistoryForFromMain` that fails without fix, passes with fix
- [x] All existing tests pass (`go test -short ./...`)

Fixes #417