### PR TITLE
fix(docs): correct bd dep add syntax and semantics

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -227,7 +227,7 @@ bd sync            # Push to remote
 - ` + "`bd close <id> --reason=\"explanation\"`" + ` - Close with reason
 
 ### Dependencies & Blocking
-- ` + "`bd dep <from> <to>`" + ` - Add blocker dependency (from blocks to)
+- ` + "`bd dep add <issue> <depends-on>`" + ` - Add dependency (issue depends on depends-on)
 - ` + "`bd blocked`" + ` - Show all blocked issues
 - ` + "`bd show <id>`" + ` - See what's blocking/blocked by this issue
 
@@ -252,7 +252,7 @@ bd update <id> --status=in_progress  # Claim it
 ` + "```bash" + `
 bd create --title="Implement feature X" --type=feature
 bd create --title="Write tests for X" --type=task
-bd dep beads-xxx beads-yyy  # Feature blocks tests
+bd dep add beads-yyy beads-xxx  # Tests depend on Feature (Feature blocks tests)
 ` + "```" + `
 `
 	fmt.Print(context)

--- a/cmd/bd/setup/aider.go
+++ b/cmd/bd/setup/aider.go
@@ -33,7 +33,7 @@ This project uses **Beads (bd)** for issue tracking. Aider requires explicit com
 - ` + "`bd create --title=\"...\" --type=task`" + ` - Create new issue
 - ` + "`bd update <id> --status=in_progress`" + ` - Claim work
 - ` + "`bd close <id>`" + ` - Mark complete
-- ` + "`bd dep <from> <to>`" + ` - Add dependency (from blocks to)
+- ` + "`bd dep add <issue> <depends-on>`" + ` - Add dependency (issue depends on depends-on)
 - ` + "`bd sync`" + ` - Sync with git remote
 
 ## Workflow Pattern to Suggest

--- a/cmd/bd/setup/cursor.go
+++ b/cmd/bd/setup/cursor.go
@@ -27,7 +27,7 @@ bd list --status=open                 # List all open issues
 bd create --title="..." --type=task  # Create new issue
 bd update <id> --status=in_progress  # Claim work
 bd close <id>                         # Mark complete
-bd dep <from> <to>                    # Add dependency (from blocks to)
+bd dep add <issue> <depends-on>       # Add dependency (issue depends on depends-on)
 bd sync                               # Sync with git remote
 ` + "```" + `
 


### PR DESCRIPTION
## Summary

- Fixed incorrect `bd dep` documentation in `prime.go`, `cursor.go`, and `aider.go`
- Added missing `add` subcommand (was `bd dep <from> <to>`, now `bd dep add <issue> <depends-on>`)
- Corrected semantics (docs claimed "from blocks to" but actual behavior is "issue depends on depends-on")

## Problem

The documentation for `bd dep` had two issues:

1. **Missing subcommand**: `bd dep <from> <to>` is invalid; the correct syntax is `bd dep add <issue> <depends-on>`

2. **Backwards semantics**: Docs claimed "from blocks to" but the actual CLI behavior per `bd dep add --help` is:
   ```
   bd dep add [issue-id] [depends-on-id]
   ```
   This means `issue-id` **depends on** `depends-on-id`, so `depends-on-id` blocks `issue-id`.

This caused AI agents and users to consistently create dependencies in the wrong direction, requiring manual correction.

## Files Changed

- `cmd/bd/prime.go` (lines 230, 255)
- `cmd/bd/setup/cursor.go` (line 30)  
- `cmd/bd/setup/aider.go` (line 36)

## Test plan

- [x] Verified `bd dep add --help` confirms correct semantics
- [x] Cross-referenced with `quickstart.go:43` which had correct documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)