### PR TITLE
fix: validate project files in FindBeadsDir (bd-420)

### DIFF
--- a/cmd/bd/version_tracking_test.go
+++ b/cmd/bd/version_tracking_test.go
@@ -124,11 +124,17 @@ func TestTrackBdVersion_NoBeadsDir(t *testing.T) {
 }
 
 func TestTrackBdVersion_FirstRun(t *testing.T) {
-	// Create temp .beads directory
+	// Create temp .beads directory with a project file (bd-420)
+	// FindBeadsDir now requires actual project files, not just directory existence
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
 		t.Fatalf("Failed to create .beads: %v", err)
+	}
+	// Create a database file so FindBeadsDir finds this directory
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	if err := os.WriteFile(dbPath, []byte{}, 0644); err != nil {
+		t.Fatalf("Failed to create db file: %v", err)
 	}
 
 	// Change to temp directory


### PR DESCRIPTION
## Summary

Fixes #420 - `bd prime` incorrectly outputs workflow context in non-git directories when `~/.beads/` daemon registry exists.

### Root Cause
`FindBeadsDir()` checked only directory existence, not whether the directory contains actual beads project files. When `~/.beads/` exists (containing only daemon registry files), it was incorrectly returned as a valid beads directory.

### Changes
- Add `hasBeadsProjectFiles()` helper that validates a `.beads` directory contains:
  - `metadata.json` or `config.yaml` (project configuration)
  - Any `*.db` file (excluding `.backup` and `vc.db`)
  - Any `*.jsonl` file (JSONL-only mode support)
- Update `FindBeadsDir()` to validate directories during tree search
- Add comprehensive table-driven tests for project file detection
- Update `version_tracking_test.go` to create project files (test was affected by the fix)

### Testing
- `go test -short ./...` passes
- New tests cover: empty directory, daemon-only, database, JSONL, config files, backup exclusion

### Related
- Separate tech debt identified: duplicate `findBeadsDir()` in `cmd/bd/autoimport.go` (12 callers) lacks bd-c8x git root check. Suggest separate PR to consolidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)