### PR TITLE
docs: Add `-e` flag to echo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ bd init --branch beads-metadata
 # - Auto-start daemon for sync
 
 # Then tell your agent about bd:
-echo "\nBEFORE ANYTHING ELSE: run 'bd onboard' and follow the instructions" >> AGENTS.md
+echo -e "\nBEFORE ANYTHING ELSE: run 'bd onboard' and follow the instructions" >> AGENTS.md
 ```
 
 **Protected branches?** If your `main` branch is protected, use `bd init --branch beads-metadata` to commit issue updates to a separate branch. See [docs/PROTECTED_BRANCHES.md](docs/PROTECTED_BRANCHES.md) for details.


### PR DESCRIPTION
Was getting set up and noticed it was printing a literal `\n` in my AGENTS.md without this -e flag. Thanks for this project!