### PR TITLE
feat(setup claude): add --stealth flag

### DIFF
--- a/cmd/bd/setup.go
+++ b/cmd/bd/setup.go
@@ -9,6 +9,7 @@ var (
 	setupProject bool
 	setupCheck   bool
 	setupRemove  bool
+	setupStealth bool
 )
 
 var setupCmd = &cobra.Command{
@@ -86,7 +87,7 @@ agents from forgetting bd workflow after context compaction.`,
 			return
 		}
 
-		setup.InstallClaude(setupProject)
+		setup.InstallClaude(setupProject, setupStealth)
 	},
 }
 
@@ -94,6 +95,7 @@ func init() {
 	setupClaudeCmd.Flags().BoolVar(&setupProject, "project", false, "Install for this project only (not globally)")
 	setupClaudeCmd.Flags().BoolVar(&setupCheck, "check", false, "Check if Claude integration is installed")
 	setupClaudeCmd.Flags().BoolVar(&setupRemove, "remove", false, "Remove bd hooks from Claude settings")
+	setupClaudeCmd.Flags().BoolVar(&setupStealth, "stealth", false, "Use 'bd prime --stealth' (flush only, no git operations)")
 
 	setupCursorCmd.Flags().BoolVar(&setupCheck, "check", false, "Check if Cursor integration is installed")
 	setupCursorCmd.Flags().BoolVar(&setupRemove, "remove", false, "Remove bd rules from Cursor")

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -8,7 +8,7 @@ import (
 )
 
 // InstallClaude installs Claude Code hooks
-func InstallClaude(project bool) {
+func InstallClaude(project bool, stealth bool) {
 	var settingsPath string
 
 	if project {
@@ -49,13 +49,19 @@ func InstallClaude(project bool) {
 		settings["hooks"] = hooks
 	}
 
+	// Determine which command to use
+	command := "bd prime"
+	if stealth {
+		command = "bd prime --stealth"
+	}
+
 	// Add SessionStart hook
-	if addHookCommand(hooks, "SessionStart", "bd prime") {
+	if addHookCommand(hooks, "SessionStart", command) {
 		fmt.Println("✓ Registered SessionStart hook")
 	}
 
 	// Add PreCompact hook
-	if addHookCommand(hooks, "PreCompact", "bd prime") {
+	if addHookCommand(hooks, "PreCompact", command) {
 		fmt.Println("✓ Registered PreCompact hook")
 	}
 
@@ -137,9 +143,11 @@ func RemoveClaude(project bool) {
 		return
 	}
 
-	// Remove bd prime hooks
+	// Remove bd prime hooks (both variants for backwards compatibility)
 	removeHookCommand(hooks, "SessionStart", "bd prime")
 	removeHookCommand(hooks, "PreCompact", "bd prime")
+	removeHookCommand(hooks, "SessionStart", "bd prime --stealth")
+	removeHookCommand(hooks, "PreCompact", "bd prime --stealth")
 
 	// Write back
 	data, err = json.MarshalIndent(settings, "", "  ")
@@ -284,7 +292,9 @@ func hasBeadsHooks(settingsPath string) bool {
 				if !ok {
 					continue
 				}
-				if cmdMap["command"] == "bd prime" {
+				// Check for either variant
+				cmd := cmdMap["command"]
+				if cmd == "bd prime" || cmd == "bd prime --stealth" {
 					return true
 				}
 			}


### PR DESCRIPTION
Depends on #455

Adds a `--stealth` flag to `bd setup claude` that installs
Claude Code hooks using `bd prime --stealth` instead of `bd prime`.
This extends the stealth workflow introduced for `bd prime` (#455)
enabling workflows where git operations should be deferred
or handled separately from bd database flushing.

When `--stealth` is specified, the installed hooks call `bd prime --stealth`,
which outputs only `bd sync --flush-only` in the close protocol,
omitting all git operations.

`bd claude setup --remove` will remove both variants of the hooks
(`bd prime` and `bd prime --stealth`) to ensure clean uninstallation
regardless of which was installed.

`bd setup claude --check` will detect
either variant of the installed hooks as well.

Includes tests for relevant functionality.

(**Do not merge before #455.**)
