### PR TITLE
docs(README): fix incorrect docs for how to install git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ bd sync  # Immediately flush pending changes and import latest JSONL
 
 **For zero-lag sync**, install the git hooks:
 ```bash
-cd examples/git-hooks && ./install.sh
+bd hooks install
 ```
 
 This adds:


### PR DESCRIPTION
Commit 497f12fca5 removed `examples/git-hooks/install.sh` in favour of `bd hooks install` but forgot to update `README.md` to match.  So apply that fix retroactively.