### PR TITLE
fix(storage): persist close_reason to issues table on close

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -333,6 +333,9 @@ func TestCLI_Close(t *testing.T) {
 	if closed[0]["status"] != "closed" {
 		t.Errorf("Expected status 'closed', got: %v", closed[0]["status"])
 	}
+	if closed[0]["close_reason"] != "Done" {
+		t.Errorf("Expected close_reason 'Done', got: %v", closed[0]["close_reason"])
+	}
 }
 
 func TestCLI_DepAdd(t *testing.T) {

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -706,6 +706,10 @@ func TestCloseIssue(t *testing.T) {
 	if closed.ClosedAt == nil {
 		t.Error("ClosedAt should be set")
 	}
+
+	if closed.CloseReason != "Done" {
+		t.Errorf("CloseReason not set: got %q, want %q", closed.CloseReason, "Done")
+	}
 }
 
 func TestClosedAtInvariant(t *testing.T) {
@@ -766,13 +770,16 @@ func TestClosedAtInvariant(t *testing.T) {
 			t.Fatalf("CloseIssue failed: %v", err)
 		}
 
-		// Verify it's closed with closed_at set
+		// Verify it's closed with closed_at and close_reason set
 		closed, err := store.GetIssue(ctx, issue.ID)
 		if err != nil {
 			t.Fatalf("GetIssue failed: %v", err)
 		}
 		if closed.ClosedAt == nil {
 			t.Fatal("ClosedAt should be set after closing")
+		}
+		if closed.CloseReason != "Done" {
+			t.Errorf("CloseReason should be 'Done', got %q", closed.CloseReason)
 		}
 
 		// Reopen the issue
@@ -784,7 +791,7 @@ func TestClosedAtInvariant(t *testing.T) {
 			t.Fatalf("UpdateIssue failed: %v", err)
 		}
 
-		// Verify closed_at was cleared
+		// Verify closed_at and close_reason were cleared
 		reopened, err := store.GetIssue(ctx, issue.ID)
 		if err != nil {
 			t.Fatalf("GetIssue failed: %v", err)
@@ -794,6 +801,9 @@ func TestClosedAtInvariant(t *testing.T) {
 		}
 		if reopened.ClosedAt != nil {
 			t.Error("ClosedAt should be cleared when reopening issue")
+		}
+		if reopened.CloseReason != "" {
+			t.Errorf("CloseReason should be cleared when reopening issue, got %q", reopened.CloseReason)
 		}
 	})
 

--- a/internal/storage/sqlite/transaction.go
+++ b/internal/storage/sqlite/transaction.go
@@ -462,13 +462,14 @@ func applyUpdatesToIssue(issue *types.Issue, updates map[string]interface{}) {
 }
 
 // CloseIssue closes an issue within the transaction.
+// NOTE: close_reason is stored in both issues table and events table - see SQLiteStorage.CloseIssue.
 func (t *sqliteTxStorage) CloseIssue(ctx context.Context, id string, reason string, actor string) error {
 	now := time.Now()
 
 	result, err := t.conn.ExecContext(ctx, `
-		UPDATE issues SET status = ?, closed_at = ?, updated_at = ?
+		UPDATE issues SET status = ?, closed_at = ?, updated_at = ?, close_reason = ?
 		WHERE id = ?
-	`, types.StatusClosed, now, now, id)
+	`, types.StatusClosed, now, now, reason, id)
 	if err != nil {
 		return fmt.Errorf("failed to close issue: %w", err)
 	}

--- a/internal/storage/sqlite/transaction_test.go
+++ b/internal/storage/sqlite/transaction_test.go
@@ -268,6 +268,9 @@ func TestTransactionCloseIssue(t *testing.T) {
 	if closed.Status != types.StatusClosed {
 		t.Errorf("expected status 'closed', got %q", closed.Status)
 	}
+	if closed.CloseReason != "Done" {
+		t.Errorf("expected close_reason 'Done', got %q", closed.CloseReason)
+	}
 }
 
 // TestTransactionDeleteIssue tests deleting an issue within a transaction.


### PR DESCRIPTION
CloseIssue was storing the reason only in the events table, not in the issues.close_reason column. This caused `bd show --json` to return an empty close_reason even when one was provided.

- Update CloseIssue in queries.go and transaction.go to set close_reason
- Clear close_reason when reopening issues (in manageClosedAt)
- Add tests for close_reason in storage and CLI JSON output
- Document the dual-storage of close_reason (issues + events tables)