### PR TITLE
fix: bd sync works when sync.branch matches current branch (fixes #519)

### DIFF
--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -385,7 +385,15 @@ Use --merge to merge the sync branch back to main branch.`,
 					fmt.Fprintf(os.Stderr, "Warning: sync.branch configured but failed to get repo root: %v\n", err)
 					fmt.Fprintf(os.Stderr, "Falling back to current branch commits\n")
 				} else {
-					useSyncBranch = true
+					// GitHub #519: Check if sync.branch is the currently checked-out branch
+					// If so, we can't use worktree (git won't allow it), so fall back to direct commits
+					currentBranch, branchErr := getCurrentBranch(ctx)
+					if branchErr == nil && currentBranch == syncBranchName {
+						fmt.Printf("→ sync.branch '%s' is currently checked out, using direct commits\n", syncBranchName)
+						useSyncBranch = false
+					} else {
+						useSyncBranch = true
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes https://github.com/steveyegge/beads/issues/519

When `sync.branch` is set to the same branch that's currently checked out (e.g., setting `sync.branch=main` while on the `main` branch), `bd sync` would fail with a worktree error:

```
fatal: 'main' is already used by worktree at '/Users/username/project'
```

## Changes

This PR adds a check to detect when `sync.branch` matches the current branch and falls back to direct commits instead of trying to create a worktree.

The worktree approach is only used when `sync.branch` is a different branch than the one currently checked out, which is the intended use case.

## Code Changes

- **1 file changed**: `cmd/bd/sync.go`
- **9 insertions, 1 deletion**: Minimal, focused fix

## Testing

- Built and verified the fix compiles
- Existing tests pass
- The fix is minimal and focused on the specific issue

## Behavior

**Before**: `bd sync` fails with worktree error when `sync.branch` == current branch  
**After**: `bd sync` detects this case and prints:
```
→ sync.branch 'main' is currently checked out, using direct commits
```
Then proceeds with normal sync flow.