### PR TITLE
docs: fix bd daemon CLI syntax to use flag format

### DIFF
--- a/docs/PROTECTED_BRANCHES.md
+++ b/docs/PROTECTED_BRANCHES.md
@@ -69,7 +69,7 @@ The sync branch (beads-metadata) will contain:
 **2. Start the daemon with auto-commit:**
 
 ```bash
-bd daemon start --auto-commit
+bd daemon --start --auto-commit
 ```
 
 The daemon will automatically commit issue changes to the `beads-metadata` branch.
@@ -165,7 +165,7 @@ If you already have beads set up and want to switch to a separate branch:
 bd config set sync.branch beads-metadata
 
 # Start the daemon (it will create the worktree automatically)
-bd daemon start --auto-commit
+bd daemon --start --auto-commit
 ```
 
 ### Daemon Configuration
@@ -174,10 +174,10 @@ For automatic commits to the sync branch:
 
 ```bash
 # Start daemon with auto-commit
-bd daemon start --auto-commit
+bd daemon --start --auto-commit
 
 # Or with auto-commit and auto-push
-bd daemon start --auto-commit --auto-push
+bd daemon --start --auto-commit --auto-push
 ```
 
 **Daemon modes:**
@@ -193,7 +193,7 @@ You can also configure the sync branch via environment variable:
 
 ```bash
 export BEADS_SYNC_BRANCH=beads-metadata
-bd daemon start --auto-commit
+bd daemon --start --auto-commit
 ```
 
 This is useful for CI/CD or temporary overrides.
@@ -361,7 +361,7 @@ rm -rf .git/beads-worktrees/beads-metadata
 git worktree prune
 
 # Restart daemon (it will recreate the worktree)
-bd daemon restart
+bd daemon --stop && bd daemon --start
 ```
 
 ### "branch 'beads-metadata' not found"
@@ -389,13 +389,13 @@ Check daemon status and logs:
 
 ```bash
 # Check status
-bd daemon status
+bd daemon --status
 
 # View logs
 tail -f ~/.beads/daemon.log
 
 # Restart daemon
-bd daemon restart
+bd daemon --stop && bd daemon --start
 ```
 
 Common issues:
@@ -415,7 +415,7 @@ bd config get sync.branch  # Should be the same (e.g., beads-metadata)
 bd sync --no-push
 
 # Check daemon is running
-bd daemon status
+bd daemon --status
 ```
 
 ## FAQ
@@ -440,7 +440,7 @@ Yes:
 
 ```bash
 bd config set sync.branch new-branch-name
-bd daemon restart
+bd daemon --stop && bd daemon --start
 ```
 
 The old worktree will remain (no harm), and a new worktree will be created for the new branch.
@@ -451,7 +451,7 @@ Unset the sync branch config:
 
 ```bash
 bd config set sync.branch ""
-bd daemon restart
+bd daemon --stop && bd daemon --start
 ```
 
 Beads will go back to committing directly to your current branch.
@@ -501,7 +501,7 @@ Yes, but the daemon will recreate it. If you want to clean up permanently:
 
 ```bash
 # Stop daemon
-bd daemon stop
+bd daemon --stop
 
 # Remove worktree
 git worktree remove .git/beads-worktrees/beads-metadata
@@ -526,7 +526,7 @@ However, if you want fully automated sync:
 
 ```bash
 # WARNING: This bypasses branch protection!
-bd daemon start --auto-commit --auto-push
+bd daemon --start --auto-commit --auto-push
 bd sync --merge  # Run periodically (e.g., via cron)
 ```
 
@@ -672,7 +672,7 @@ If you have an existing beads setup committing to `main`:
 
 2. **Restart daemon:**
    ```bash
-   bd daemon restart
+   bd daemon --stop && bd daemon --start
    ```
 
 3. **Verify:**
@@ -693,7 +693,7 @@ If you want to stop using a sync branch:
 
 2. **Restart daemon:**
    ```bash
-   bd daemon restart
+   bd daemon --stop && bd daemon --start
    ```
 
 Future commits will go to your current branch (e.g., `main`).

--- a/examples/multi-phase-development/README.md
+++ b/examples/multi-phase-development/README.md
@@ -24,7 +24,7 @@ cd my-project
 bd init
 
 # Start daemon for auto-sync (optional)
-bd daemon start --auto-commit --auto-push
+bd daemon --start --auto-commit --auto-push
 ```
 
 ## Phase 1: Research & Planning

--- a/examples/multiple-personas/README.md
+++ b/examples/multiple-personas/README.md
@@ -27,7 +27,7 @@ cd my-project
 bd init
 
 # Start daemon for auto-sync (optional for teams)
-bd daemon start --auto-commit --auto-push
+bd daemon --start --auto-commit --auto-push
 ```
 
 ## Persona: Architect

--- a/examples/protected-branch/README.md
+++ b/examples/protected-branch/README.md
@@ -52,7 +52,7 @@ bd update bd-XXXXX --status in_progress
 
 ```bash
 # Start daemon with auto-commit
-bd daemon start --auto-commit
+bd daemon --start --auto-commit
 
 # All issue changes are now automatically committed to beads-metadata branch
 ```
@@ -221,14 +221,14 @@ JSONL is append-only and line-based, so conflicts are rare. If they occur:
 The daemon creates it automatically on first commit. To create manually:
 ```bash
 bd config get sync.branch  # Verify it's set
-bd daemon restart          # Daemon will create worktree
+bd daemon --stop && bd daemon --start          # Daemon will create worktree
 ```
 
 **"Changes not syncing"**
 
 Make sure:
 - `bd config get sync.branch` returns the same value on all clones
-- Daemon is running: `bd daemon status`
+- Daemon is running: `bd daemon --status`
 - Both clones have fetched: `git fetch origin beads-metadata`
 
 ## Advanced: GitHub Actions Integration

--- a/examples/team-workflow/README.md
+++ b/examples/team-workflow/README.md
@@ -216,7 +216,7 @@ bd close bd-abc --reason "PR #123 merged"
 Daemon commits and pushes automatically:
 
 ```bash
-bd daemon start --auto-commit --auto-push
+bd daemon --start --auto-commit --auto-push
 ```
 
 Benefits:
@@ -349,7 +349,7 @@ A: Add to your CI pipeline:
 Check daemon status:
 
 ```bash
-bd daemon status
+bd daemon --status
 bd daemons list
 ```
 
@@ -363,8 +363,8 @@ bd config get daemon.auto_push
 Restart daemon:
 
 ```bash
-bd daemon stop
-bd daemon start --auto-commit --auto-push
+bd daemon --stop
+bd daemon --start --auto-commit --auto-push
 ```
 
 ### Issue: Merge conflicts in JSONL

--- a/integrations/beads-mcp/README.md
+++ b/integrations/beads-mcp/README.md
@@ -288,7 +288,7 @@ Test daemon RPC with multiple repositories:
 ```bash
 # Start the daemon first
 cd /path/to/beads
-./bd daemon start
+./bd daemon --start
 
 # Run multi-repo test
 cd integrations/beads-mcp

--- a/integrations/beads-mcp/SETUP_DAEMON.md
+++ b/integrations/beads-mcp/SETUP_DAEMON.md
@@ -137,7 +137,7 @@ bd daemon --start
 
 1. Check where daemon is running:
    ```bash
-   bd daemon status
+   bd daemon --status
    ```
 
 2. Use `set_context` tool in Claude to set workspace root:


### PR DESCRIPTION
## Summary

Fix incorrect `bd daemon` CLI syntax in documentation. The command only accepts flags with `--` prefix, not positional subcommands.

## Changes

| Incorrect | Correct |
|-----------|---------|
| `bd daemon start` | `bd daemon --start` |
| `bd daemon status` | `bd daemon --status` |
| `bd daemon stop` | `bd daemon --stop` |
| `bd daemon restart` | `bd daemon --stop && bd daemon --start` |

## Files Updated

- `docs/PROTECTED_BRANCHES.md` (13 occurrences)
- `examples/team-workflow/README.md` (4 occurrences)
- `examples/protected-branch/README.md` (3 occurrences)
- `examples/multi-phase-development/README.md` (1 occurrence)
- `examples/multiple-personas/README.md` (1 occurrence)
- `integrations/beads-mcp/README.md` (1 occurrence)
- `integrations/beads-mcp/SETUP_DAEMON.md` (1 occurrence)

## Testing

Verified against `bd daemon --help` output which shows the correct flag-based syntax.