### PR TITLE
feat: add no-push config to disable automatic git push

### DIFF
--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -57,6 +57,11 @@ Use --merge to merge the sync branch back to main branch.`,
 		squash, _ := cmd.Flags().GetBool("squash")
 		checkIntegrity, _ := cmd.Flags().GetBool("check")
 
+		// If --no-push not explicitly set, check no-push config
+		if !cmd.Flags().Changed("no-push") {
+			noPush = config.GetBool("no-push")
+		}
+
 		// bd-sync-corruption fix: Force direct mode for sync operations.
 		// This prevents stale daemon SQLite connections from corrupting exports.
 		// If the daemon was running but its database file was deleted and recreated

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -34,6 +34,7 @@ Tool-level settings you can configure:
 | `no-daemon` | `--no-daemon` | `BD_NO_DAEMON` | `false` | Force direct mode, bypass daemon |
 | `no-auto-flush` | `--no-auto-flush` | `BD_NO_AUTO_FLUSH` | `false` | Disable auto JSONL export |
 | `no-auto-import` | `--no-auto-import` | `BD_NO_AUTO_IMPORT` | `false` | Disable auto JSONL import |
+| `no-push` | `--no-push` | `BD_NO_PUSH` | `false` | Skip pushing to remote in bd sync |
 | `db` | `--db` | `BD_DB` | (auto-discover) | Database path |
 | `actor` | `--actor` | `BD_ACTOR` | `$USER` | Actor name for audit trail |
 | `flush-debounce` | - | `BEADS_FLUSH_DEBOUNCE` | `5s` | Debounce time for auto-flush |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,9 @@ func Initialize() error {
 	// Sync configuration defaults (bd-4u8)
 	v.SetDefault("sync.require_confirmation_on_mass_delete", false)
 
+	// Push configuration defaults
+	v.SetDefault("no-push", false)
+
 	// Read config file if it was found
 	if configFileSet {
 		if err := v.ReadInConfig(); err != nil {


### PR DESCRIPTION
Wire up the existing --no-push flag to a config option so it can be set as the default, and update bd prime output accordingly. This allows working with upstream branches while deferring push to manual control.

- Add no-push default to config.go, matching existing pattern
- Check config in sync.go when --no-push flag not explicitly set
- Update bd prime output to omit git push step when enabled