### PR TITLE
fix: update nix vendorHash for Go dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ pkgs.buildGoModule {
   subPackages = [ "cmd/bd" ];
   doCheck = false;
   # Go module dependencies hash (computed via nix build)
-  vendorHash = "sha256-ha3sFcbr3fGrHVtSnbrDut/DAnCEy3uGtrcQAozAFJs=";
+  vendorHash = "sha256-Gyj/Vs3IEWPwqzfNoNBSL4VFifEhjnltlr1AROwGPc4=";
 
   # Git is required for tests
   nativeBuildInputs = [ pkgs.git ];


### PR DESCRIPTION
The go dependencies hash changed since the last update.