### PR TITLE
fix(worktree): add -f flag to handle "missing but registered" state (Fixes #609)

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -52,13 +52,15 @@ func (wm *WorktreeManager) CreateBeadsWorktree(branch, worktreePath string) erro
 	branchExists := wm.branchExists(branch)
 
 	// Create worktree without checking out files initially
+	// Use -f (force) to handle "missing but already registered" state (issue #609)
+	// This occurs when the worktree directory was deleted but git registration persists
 	var cmd *exec.Cmd
 	if branchExists {
 		// Checkout existing branch
-		cmd = exec.Command("git", "worktree", "add", "--no-checkout", worktreePath, branch)
+		cmd = exec.Command("git", "worktree", "add", "-f", "--no-checkout", worktreePath, branch)
 	} else {
 		// Create new branch
-		cmd = exec.Command("git", "worktree", "add", "--no-checkout", "-b", branch, worktreePath)
+		cmd = exec.Command("git", "worktree", "add", "-f", "--no-checkout", "-b", branch, worktreePath)
 	}
 	cmd.Dir = wm.repoPath
 


### PR DESCRIPTION
## Summary

Fixes #609 - Daemon auto-sync fails with recurring "missing but already registered worktree" error.

## Problem

When running the beads daemon with `--auto-commit --auto-push`, the sync branch pull operation consistently fails with:

```
fatal: '.git/beads-worktrees/beads-metadata' is a missing but already registered worktree;
use 'add -f' to override, or 'prune' or 'remove' to clear
```

## Root Cause Analysis

The issue occurs in the worktree lifecycle management:

1. Daemon creates worktree at `.git/beads-worktrees/<branch>`
2. Git registers it in `.git/worktrees/<branch>`
3. After the operation, the worktree contents are removed
4. The git registration persists, pointing to the now-empty path
5. Subsequent `CreateBeadsWorktree` calls fail because:
   - `os.Stat(worktreePath)` returns error (path doesn't exist)
   - Code skips the cleanup/removal logic
   - `git worktree add` fails because git still has it registered

The existing `git worktree prune` call (line 30-32) was intended to handle this, but it runs before the path check and may not always clear the registration in time due to race conditions.

## Solution

Per @steveyegge's [recommendation in the issue](https://github.com/steveyegge/beads/issues/609#issuecomment-2553393556):

> Fix should ensure proper cleanup via `git worktree remove` or use `git worktree add -f` to handle the "missing but registered" state.

This PR adds the `-f` (force) flag to both `git worktree add` commands in `CreateBeadsWorktree()`:

```go
// Before (line 58-61)
cmd = exec.Command("git", "worktree", "add", "--no-checkout", worktreePath, branch)
cmd = exec.Command("git", "worktree", "add", "--no-checkout", "-b", branch, worktreePath)

// After
cmd = exec.Command("git", "worktree", "add", "-f", "--no-checkout", worktreePath, branch)
cmd = exec.Command("git", "worktree", "add", "-f", "--no-checkout", "-b", branch, worktreePath)
```

Per [git-worktree documentation](https://git-scm.com/docs/git-worktree#_options), `-f` overrides the safeguard that prevents creating a worktree when the path is already registered but missing.

## Changes

- **`internal/git/worktree.go`**: Added `-f` flag to `git worktree add` commands in `CreateBeadsWorktree()` with explanatory comment referencing GH#609
- **`internal/git/worktree_test.go`**: Added regression test `TestCreateBeadsWorktree_MissingButRegistered` that simulates the exact bug scenario

## Testing

### Automated Tests
- ✅ All existing worktree tests pass
- ✅ New regression test `TestCreateBeadsWorktree_MissingButRegistered` passes

```bash
$ go test -v -run "Worktree" ./internal/git/...
=== RUN   TestCreateBeadsWorktree
--- PASS: TestCreateBeadsWorktree (0.36s)
=== RUN   TestCreateBeadsWorktree_MissingButRegistered
--- PASS: TestCreateBeadsWorktree_MissingButRegistered (0.08s)
# ... all other worktree tests pass
```

### Regression Test Details

The new test simulates the exact GH#609 scenario:
1. Creates a worktree (registered in git)
2. Manually deletes the worktree directory (leaving git registration)
3. Attempts to recreate the worktree
4. Verifies it succeeds (would fail without the `-f` flag fix)

## Risk Assessment

**Low risk** - The `-f` flag is the recommended approach per git documentation for handling this exact scenario. It does not bypass any meaningful safety checks in this context because:

1. We already call `git worktree prune` before attempting to create
2. We check if the path exists and remove invalid worktrees
3. The `-f` flag only overrides the "missing but registered" check, which is exactly the bug we're fixing

## Verification Steps for Maintainers

To manually verify this fix:

1. Initialize beads with a sync branch:
   ```bash
   bd init
   git config beads.sync.branch beads-metadata
   ```

2. Start the daemon:
   ```bash
   bd daemon --start --auto-commit --auto-push
   ```

3. Create an issue:
   ```bash
   bd create "Test issue"
   ```

4. Check daemon logs - should no longer show the "missing but already registered" error:
   ```bash
   tail -20 .beads/daemon.log
   ```
