### PR TITLE
fix(init): update output to show hash-based ID format

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -222,7 +222,7 @@ With --stealth: configures global git settings for invisible beads usage:
 					fmt.Printf("  Mode: %s\n", cyan("no-db (JSONL-only)"))
 					fmt.Printf("  Issues file: %s\n", cyan(jsonlPath))
 					fmt.Printf("  Issue prefix: %s\n", cyan(prefix))
-					fmt.Printf("  Issues will be named: %s\n\n", cyan(prefix+"-1, "+prefix+"-2, ..."))
+					fmt.Printf("  Issues will be named: %s\n\n", cyan(prefix+"-<hash> (e.g., "+prefix+"-a3f2dd)"))
 					fmt.Printf("Run %s to get started.\n\n", cyan("bd --no-db quickstart"))
 				}
 				return
@@ -440,7 +440,7 @@ With --stealth: configures global git settings for invisible beads usage:
 		fmt.Printf("\n%s bd initialized successfully!\n\n", green("✓"))
 		fmt.Printf("  Database: %s\n", cyan(initDBPath))
 		fmt.Printf("  Issue prefix: %s\n", cyan(prefix))
-		fmt.Printf("  Issues will be named: %s\n\n", cyan(prefix+"-1, "+prefix+"-2, ..."))
+		fmt.Printf("  Issues will be named: %s\n\n", cyan(prefix+"-<hash> (e.g., "+prefix+"-a3f2dd)"))
 		fmt.Printf("Run %s to get started.\n\n", cyan("bd quickstart"))
 
 		// Run bd doctor diagnostics to catch setup issues early (bd-zwtq)

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -27,7 +27,7 @@ func TestInitCommand(t *testing.T) {
 			name:           "init with custom prefix",
 			prefix:         "myproject",
 			quiet:          false,
-			wantOutputText: "myproject-1, myproject-2",
+			wantOutputText: "myproject-<hash>",
 		},
 		{
 			name:         "init with quiet flag",
@@ -39,7 +39,7 @@ func TestInitCommand(t *testing.T) {
 			name:           "init with prefix ending in hyphen",
 			prefix:         "test-",
 			quiet:          false,
-			wantOutputText: "test-1, test-2",
+			wantOutputText: "test-<hash>",
 		},
 	}
 

--- a/cmd/bd/quickstart.go
+++ b/cmd/bd/quickstart.go
@@ -26,7 +26,7 @@ var quickstartCmd = &cobra.Command{
 		fmt.Printf("            Auto-detects prefix from directory name (e.g., myapp-1, myapp-2)\n\n")
 
 		fmt.Printf("  %s   Initialize with custom prefix\n", cyan("bd init --prefix api"))
-		fmt.Printf("            Issues will be named: api-1, api-2, ...\n\n")
+		fmt.Printf("            Issues will be named: api-<hash> (e.g., api-a3f2dd)\n\n")
 
 		fmt.Printf("%s\n", bold("CREATING ISSUES"))
 		fmt.Printf("  %s\n", cyan("bd create \"Fix login bug\""))


### PR DESCRIPTION
## Summary

Updates the `bd init` and `bd quickstart` output messages to accurately reflect the hash-based ID format that beads actually uses.

**Before (incorrect):**
```
  Issue prefix: my-project
  Issues will be named: my-project-1, my-project-2, ...
```

**After (correct):**
```
  Issue prefix: my-project
  Issues will be named: my-project-<hash> (e.g., my-project-a3f2dd)
```

## Background

Beads uses **content-based hash IDs** (not sequential integers) for issue identification. This was implemented in v0.20.1 (commit https://github.com/steveyegge/beads/commit/5d137ffe - "Remove sequential ID generation and SyncAllCounters"), which removed the sequential `AllocateNextID` functions in favor of `GenerateHashID`.

The hash-based approach provides several benefits:
- **Collision-free across distributed teams** - No coordination needed between agents/users
- **Deterministic** - Same content produces same hash, enabling deduplication
- **Progressive length** - Starts at 6 chars, extends to 7-8 only on collision
- **Git-friendly** - Works well with distributed workflows and merges

However, the init output messages were never updated to reflect this change, leaving new users with an incorrect mental model of how issue IDs work.

## Why This Matters

First impressions matter. When a user runs `bd init` for the first time, they form a mental model of how the tool works. Showing `my-project-1, my-project-2` suggests a simple sequential system, which:

1. **Sets wrong expectations** - Users might expect to predict the next ID
2. **Hides a key feature** - Hash IDs are a deliberate design choice for distributed workflows
3. **Could cause confusion** - When they see `my-project-a3f2dd` instead of `my-project-1`

The fix is minimal (3 lines) but improves the onboarding experience for all new users.

## Changes

Updated 3 locations:
1. `cmd/bd/init.go:225` - No-db mode success message
2. `cmd/bd/init.go:443` - Normal mode success message  
3. `cmd/bd/quickstart.go:29` - Quickstart help example

## Testing

- ✅ `go build ./cmd/bd/` - Builds successfully
- ✅ `go test -short ./cmd/bd/...` - Tests pass