### PR TITLE
fix(lint): add batch_ops.go to G201 exclusion - Fixes CI lint check failure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,7 @@ linters:
           - gosec
         text: "G115"
       # G201: SQL with fmt.Sprintf using placeholders (IN clause expansion)
-      - path: 'internal/storage/sqlite/dependencies\.go'
+      - path: 'internal/storage/sqlite/(dependencies|batch_ops)\.go'
         linters:
           - gosec
         text: "G201"


### PR DESCRIPTION
Add batch_ops.go to gosec G201 exclusion - uses safe parameterized placeholders for IN clause expansion, same pattern as dependencies.go. (Fixes CI lint check failure)