### PR TITLE
feat: add source_repo to bd list --json output

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -117,12 +117,12 @@ var listCmd = &cobra.Command{
 		longFormat, _ := cmd.Flags().GetBool("long")
 		sortBy, _ := cmd.Flags().GetString("sort")
 		reverse, _ := cmd.Flags().GetBool("reverse")
-		
+
 		// Pattern matching flags
 		titleContains, _ := cmd.Flags().GetString("title-contains")
 		descContains, _ := cmd.Flags().GetString("desc-contains")
 		notesContains, _ := cmd.Flags().GetString("notes-contains")
-		
+
 		// Date range flags
 		createdAfter, _ := cmd.Flags().GetString("created-after")
 		createdBefore, _ := cmd.Flags().GetString("created-before")
@@ -130,12 +130,12 @@ var listCmd = &cobra.Command{
 		updatedBefore, _ := cmd.Flags().GetString("updated-before")
 		closedAfter, _ := cmd.Flags().GetString("closed-after")
 		closedBefore, _ := cmd.Flags().GetString("closed-before")
-		
+
 		// Empty/null check flags
 		emptyDesc, _ := cmd.Flags().GetBool("empty-description")
 		noAssignee, _ := cmd.Flags().GetBool("no-assignee")
 		noLabels, _ := cmd.Flags().GetBool("no-labels")
-		
+
 		// Priority range flags
 		priorityMinStr, _ := cmd.Flags().GetString("priority-min")
 		priorityMaxStr, _ := cmd.Flags().GetString("priority-max")
@@ -199,7 +199,7 @@ var listCmd = &cobra.Command{
 				filter.IDs = ids
 			}
 		}
-		
+
 		// Pattern matching
 		if titleContains != "" {
 			filter.TitleContains = titleContains
@@ -210,7 +210,7 @@ var listCmd = &cobra.Command{
 		if notesContains != "" {
 			filter.NotesContains = notesContains
 		}
-		
+
 		// Date ranges
 		if createdAfter != "" {
 			t, err := parseTimeFlag(createdAfter)
@@ -260,7 +260,7 @@ var listCmd = &cobra.Command{
 			}
 			filter.ClosedBefore = &t
 		}
-		
+
 		// Empty/null checks
 		if emptyDesc {
 			filter.EmptyDescription = true
@@ -271,7 +271,7 @@ var listCmd = &cobra.Command{
 		if noLabels {
 			filter.NoLabels = true
 		}
-		
+
 		// Priority ranges
 		if cmd.Flags().Changed("priority-min") {
 			priorityMin, err := validation.ValidatePriority(priorityMinStr)
@@ -320,7 +320,7 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-	// If daemon is running, use RPC
+		// If daemon is running, use RPC
 		if daemonClient != nil {
 			listArgs := &rpc.ListArgs{
 				Status:    status,
@@ -345,17 +345,17 @@ var listCmd = &cobra.Command{
 			}
 			// Forward title search via Query field (searches title/description/id)
 			if titleSearch != "" {
-			 listArgs.Query = titleSearch
+				listArgs.Query = titleSearch
 			}
-			 if len(filter.IDs) > 0 {
-			listArgs.IDs = filter.IDs
-			 }
-			
+			if len(filter.IDs) > 0 {
+				listArgs.IDs = filter.IDs
+			}
+
 			// Pattern matching
 			listArgs.TitleContains = titleContains
 			listArgs.DescriptionContains = descContains
 			listArgs.NotesContains = notesContains
-			
+
 			// Date ranges
 			if filter.CreatedAfter != nil {
 				listArgs.CreatedAfter = filter.CreatedAfter.Format(time.RFC3339)
@@ -375,12 +375,12 @@ var listCmd = &cobra.Command{
 			if filter.ClosedBefore != nil {
 				listArgs.ClosedBefore = filter.ClosedBefore.Format(time.RFC3339)
 			}
-			
+
 			// Empty/null checks
 			listArgs.EmptyDescription = filter.EmptyDescription
 			listArgs.NoAssignee = filter.NoAssignee
 			listArgs.NoLabels = filter.NoLabels
-			
+
 			// Priority range
 			listArgs.PriorityMin = filter.PriorityMin
 			listArgs.PriorityMax = filter.PriorityMax
@@ -391,7 +391,7 @@ var listCmd = &cobra.Command{
 			// Template filtering (beads-1ra)
 			listArgs.IncludeTemplates = includeTemplates
 
-			 resp, err := daemonClient.List(listArgs)
+			resp, err := daemonClient.List(listArgs)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
@@ -484,21 +484,21 @@ var listCmd = &cobra.Command{
 		// ctx already created above for staleness check
 		issues, err := store.SearchIssues(ctx, "", filter)
 		if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
 		}
 
-	// If no issues found, check if git has issues and auto-import
-	if len(issues) == 0 {
-		if checkAndAutoImport(ctx, store) {
-			// Re-run the query after import
-			issues, err = store.SearchIssues(ctx, "", filter)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+		// If no issues found, check if git has issues and auto-import
+		if len(issues) == 0 {
+			if checkAndAutoImport(ctx, store) {
+				// Re-run the query after import
+				issues, err = store.SearchIssues(ctx, "", filter)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					os.Exit(1)
+				}
 			}
 		}
-	}
 
 		// Apply sorting
 		sortIssues(issues, sortBy, reverse)
@@ -537,6 +537,7 @@ var listCmd = &cobra.Command{
 					Issue:           issue,
 					DependencyCount: counts.DependencyCount,
 					DependentCount:  counts.DependentCount,
+					SourceRepo:      issue.SourceRepo,
 				}
 			}
 			outputJSON(issuesWithCounts)
@@ -635,12 +636,12 @@ func init() {
 	listCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
 	listCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")
 	listCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
-	
+
 	// Pattern matching
 	listCmd.Flags().String("title-contains", "", "Filter by title substring (case-insensitive)")
 	listCmd.Flags().String("desc-contains", "", "Filter by description substring (case-insensitive)")
 	listCmd.Flags().String("notes-contains", "", "Filter by notes substring (case-insensitive)")
-	
+
 	// Date ranges
 	listCmd.Flags().String("created-after", "", "Filter issues created after date (YYYY-MM-DD or RFC3339)")
 	listCmd.Flags().String("created-before", "", "Filter issues created before date (YYYY-MM-DD or RFC3339)")
@@ -648,12 +649,12 @@ func init() {
 	listCmd.Flags().String("updated-before", "", "Filter issues updated before date (YYYY-MM-DD or RFC3339)")
 	listCmd.Flags().String("closed-after", "", "Filter issues closed after date (YYYY-MM-DD or RFC3339)")
 	listCmd.Flags().String("closed-before", "", "Filter issues closed before date (YYYY-MM-DD or RFC3339)")
-	
+
 	// Empty/null checks
 	listCmd.Flags().Bool("empty-description", false, "Filter issues with empty or missing description")
 	listCmd.Flags().Bool("no-assignee", false, "Filter issues with no assignee")
 	listCmd.Flags().Bool("no-labels", false, "Filter issues with no labels")
-	
+
 	// Priority ranges
 	listCmd.Flags().String("priority-min", "", "Filter by minimum priority (inclusive, 0-4 or P0-P4)")
 	listCmd.Flags().String("priority-max", "", "Filter by maximum priority (inclusive, 0-4 or P0-P4)")

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -309,6 +309,7 @@ Examples:
 					Issue:           issue,
 					DependencyCount: counts.DependencyCount,
 					DependentCount:  counts.DependentCount,
+					SourceRepo:      issue.SourceRepo,
 				}
 			}
 			outputJSON(issuesWithCounts)

--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -21,17 +21,17 @@ func parseTimeRPC(s string) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339, s); err == nil {
 		return t, nil
 	}
-	
+
 	// Try YYYY-MM-DD format (common user input)
 	if t, err := time.Parse("2006-01-02", s); err == nil {
 		return t, nil
 	}
-	
+
 	// Try YYYY-MM-DD HH:MM:SS format
 	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
 		return t, nil
 	}
-	
+
 	return time.Time{}, fmt.Errorf("unsupported date format: %q (use YYYY-MM-DD or RFC3339)", s)
 }
 
@@ -180,7 +180,7 @@ func (s *Server) handleCreate(req *Request) Response {
 		Wisp:   createArgs.Wisp,
 		// NOTE: RepliesTo now handled via replies-to dependency (Decision 004)
 	}
-	
+
 	// Check if any dependencies are discovered-from type
 	// If so, inherit source_repo from the parent issue
 	var discoveredFromParentID string
@@ -189,16 +189,16 @@ func (s *Server) handleCreate(req *Request) Response {
 		if depSpec == "" {
 			continue
 		}
-		
+
 		var depType types.DependencyType
 		var dependsOnID string
-		
+
 		if strings.Contains(depSpec, ":") {
 			parts := strings.SplitN(depSpec, ":", 2)
 			if len(parts) == 2 {
 				depType = types.DependencyType(strings.TrimSpace(parts[0]))
 				dependsOnID = strings.TrimSpace(parts[1])
-				
+
 				if depType == types.DepDiscoveredFrom {
 					discoveredFromParentID = dependsOnID
 					break
@@ -206,7 +206,7 @@ func (s *Server) handleCreate(req *Request) Response {
 			}
 		}
 	}
-	
+
 	// If we found a discovered-from dependency, inherit source_repo from parent
 	if discoveredFromParentID != "" {
 		parentIssue, err := store.GetIssue(ctx, discoveredFromParentID)
@@ -215,7 +215,7 @@ func (s *Server) handleCreate(req *Request) Response {
 		}
 		// If error getting parent or parent has no source_repo, continue with default
 	}
-	
+
 	if err := store.CreateIssue(ctx, issue, s.reqActor(req)); err != nil {
 		return Response{
 			Success: false,
@@ -629,13 +629,13 @@ func (s *Server) handleList(req *Request) Response {
 	filter := types.IssueFilter{
 		Limit: listArgs.Limit,
 	}
-	
+
 	// Normalize status: treat "" or "all" as unset (no filter)
 	if listArgs.Status != "" && listArgs.Status != "all" {
 		status := types.Status(listArgs.Status)
 		filter.Status = &status
 	}
-	
+
 	if listArgs.IssueType != "" {
 		issueType := types.IssueType(listArgs.IssueType)
 		filter.IssueType = &issueType
@@ -646,7 +646,7 @@ func (s *Server) handleList(req *Request) Response {
 	if listArgs.Priority != nil {
 		filter.Priority = listArgs.Priority
 	}
-	
+
 	// Normalize and apply label filters
 	labels := util.NormalizeLabels(listArgs.Labels)
 	labelsAny := util.NormalizeLabels(listArgs.LabelsAny)
@@ -665,12 +665,12 @@ func (s *Server) handleList(req *Request) Response {
 			filter.IDs = ids
 		}
 	}
-	
+
 	// Pattern matching
 	filter.TitleContains = listArgs.TitleContains
 	filter.DescriptionContains = listArgs.DescriptionContains
 	filter.NotesContains = listArgs.NotesContains
-	
+
 	// Date ranges - use parseTimeRPC helper for flexible formats
 	if listArgs.CreatedAfter != "" {
 		t, err := parseTimeRPC(listArgs.CreatedAfter)
@@ -732,12 +732,12 @@ func (s *Server) handleList(req *Request) Response {
 		}
 		filter.ClosedBefore = &t
 	}
-	
+
 	// Empty/null checks
 	filter.EmptyDescription = listArgs.EmptyDescription
 	filter.NoAssignee = listArgs.NoAssignee
 	filter.NoLabels = listArgs.NoLabels
-	
+
 	// Priority range
 	filter.PriorityMin = listArgs.PriorityMin
 	filter.PriorityMax = listArgs.PriorityMax
@@ -793,6 +793,7 @@ func (s *Server) handleList(req *Request) Response {
 			Issue:           issue,
 			DependencyCount: counts.DependencyCount,
 			DependentCount:  counts.DependentCount,
+			SourceRepo:      issue.SourceRepo,
 		}
 	}
 
@@ -1101,7 +1102,7 @@ func (s *Server) handleShow(req *Request) Response {
 
 	// Populate labels, dependencies (with metadata), and dependents (with metadata)
 	labels, _ := store.GetLabels(ctx, issue.ID)
-	
+
 	// Get dependencies and dependents with metadata (including dependency type)
 	var deps []*types.IssueWithDependencyMetadata
 	var dependents []*types.IssueWithDependencyMetadata
@@ -1129,7 +1130,7 @@ func (s *Server) handleShow(req *Request) Response {
 	// Create detailed response with related data
 	type IssueDetails struct {
 		*types.Issue
-		Labels       []string                              `json:"labels,omitempty"`
+		Labels       []string                             `json:"labels,omitempty"`
 		Dependencies []*types.IssueWithDependencyMetadata `json:"dependencies,omitempty"`
 		Dependents   []*types.IssueWithDependencyMetadata `json:"dependents,omitempty"`
 	}


### PR DESCRIPTION
## Summary

Include `source_repo` field in JSON output for `bd list` and `bd search`.

## Problem

Multi-repo hydration stores `source_repo` in SQLite, but `bd list --json` didn't expose it. This prevented beads-ui from filtering issues by repository.

## Solution

Added `source_repo` to the JSON output for list and search commands.

## Testing

```bash
$ bd list --json | jq '.[0] | {id, source_repo}'
{
  "id": "proj-123",
  "source_repo": "/Users/me/projects/other-repo"
}
```