### PR TITLE
Add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Beads supports hierarchical IDs for epics:
 ## 📝 Documentation
 
 * [Installing](docs/INSTALLING.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [FAQ](docs/FAQ.md)
+* [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/steveyegge/beads)


### PR DESCRIPTION
DeepWiki provides up-to-date documentation people can talk to, for every public repo in the world (after being added to it's index). Adding this badge to a repository Readme tells DeepWiki to refresh it's docs automatically.

The DeepWiki link for Beads is https://deepwiki.com/steveyegge/beads 
(last refreshed Nov 26 as I write this)