### PR TITLE
fix: resolve all golangci-lint errors

### DIFF
--- a/cmd/bd/mol_burn.go
+++ b/cmd/bd/mol_burn.go
@@ -91,7 +91,7 @@ func runMolBurn(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error opening wisp storage: %v\n", err)
 		os.Exit(1)
 	}
-	defer wispStore.Close()
+	defer func() { _ = wispStore.Close() }()
 
 	// Resolve molecule ID in wisp storage
 	resolvedID, err := utils.ResolvePartialID(ctx, wispStore, moleculeID)
@@ -140,9 +140,9 @@ func runMolBurn(cmd *cobra.Command, args []string) {
 		fmt.Printf("\nContinue? [y/N] ")
 
 		var response string
-		fmt.Scanln(&response)
+		_, _ = fmt.Scanln(&response)
 		if response != "y" && response != "Y" {
-			fmt.Println("Cancelled.")
+			fmt.Println("Canceled.")
 			return
 		}
 	}

--- a/cmd/bd/mol_squash.go
+++ b/cmd/bd/mol_squash.go
@@ -92,7 +92,7 @@ func runMolSquash(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "Error resolving molecule ID %s: %v\n", args[0], err)
 			os.Exit(1)
 		}
-		defer wispStore.Close()
+		defer func() { _ = wispStore.Close() }()
 
 		wispMolID, wispResolveErr := utils.ResolvePartialID(ctx, wispStore, args[0])
 		if wispResolveErr != nil {
@@ -119,7 +119,7 @@ func runMolSquash(cmd *cobra.Command, args []string) {
 		// Check if there's a corresponding wisp in wisp storage
 		wispStore, wispErr := beads.NewWispStorage(ctx)
 		if wispErr == nil {
-			defer wispStore.Close()
+			defer func() { _ = wispStore.Close() }()
 			if wispIssue, _ := wispStore.GetIssue(ctx, moleculeID); wispIssue != nil {
 				// Found in wisp storage - do cross-store squash
 				runWispSquash(ctx, cmd, wispStore, store, moleculeID, dryRun, keepChildren, summary)
@@ -208,7 +208,7 @@ func runMolSquash(cmd *cobra.Command, args []string) {
 
 // runWispSquash handles squashing a wisp from wisp storage into permanent storage.
 // This is the cross-store squash operation: load from wisp, create digest in permanent, delete wisp.
-func runWispSquash(ctx context.Context, cmd *cobra.Command, wispStore, permanentStore storage.Storage, moleculeID string, dryRun, keepChildren bool, summary string) {
+func runWispSquash(ctx context.Context, _ *cobra.Command, wispStore, permanentStore storage.Storage, moleculeID string, dryRun, keepChildren bool, summary string) {
 	// Load the molecule subgraph from wisp storage
 	subgraph, err := loadTemplateSubgraph(ctx, wispStore, moleculeID)
 	if err != nil {

--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -216,7 +216,7 @@ func runWispCreate(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error: failed to open wisp storage: %v\n", err)
 		os.Exit(1)
 	}
-	defer wispStore.Close()
+	defer func() { _ = wispStore.Close() }()
 
 	// Ensure wisp directory is gitignored
 	if err := beads.EnsureWispGitignore(); err != nil {
@@ -358,7 +358,7 @@ func runWispList(cmd *cobra.Command, args []string) {
 		}
 		return
 	}
-	defer wispStore.Close()
+	defer func() { _ = wispStore.Close() }()
 
 	// List all issues from wisp storage
 	issues, err := listWispIssues(ctx, wispStore, showAll)
@@ -597,7 +597,7 @@ func runWispGC(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error opening wisp storage: %v\n", err)
 		os.Exit(1)
 	}
-	defer wispStore.Close()
+	defer func() { _ = wispStore.Close() }()
 
 	// Get all issues from wisp storage
 	filter := types.IssueFilter{}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -684,11 +684,11 @@ func NewWispStorage(ctx context.Context) (Storage, error) {
 		if mainDBPath != "" {
 			mainStore, mainErr := sqlite.New(ctx, mainDBPath)
 			if mainErr == nil {
-				defer mainStore.Close()
+				defer func() { _ = mainStore.Close() }()
 				mainPrefix, _ := mainStore.GetConfig(ctx, "issue_prefix")
 				if mainPrefix != "" {
 					if setErr := wispStore.SetConfig(ctx, "issue_prefix", mainPrefix); setErr != nil {
-						wispStore.Close()
+						_ = wispStore.Close()
 						return nil, fmt.Errorf("setting wisp issue_prefix: %w", setErr)
 					}
 				}

--- a/internal/storage/sqlite/multirepo.go
+++ b/internal/storage/sqlite/multirepo.go
@@ -408,12 +408,12 @@ func (s *SQLiteStorage) DeleteIssuesBySourceRepo(ctx context.Context, sourceRepo
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return 0, fmt.Errorf("failed to scan issue ID: %w", err)
 		}
 		issueIDs = append(issueIDs, id)
 	}
-	rows.Close()
+	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return 0, fmt.Errorf("failed to iterate issues: %w", err)
 	}


### PR DESCRIPTION
## Summary

This PR fixes all 12 linting issues that were causing CI failures on other PRs.

## Issues Fixed

### errcheck (8 fixes)
- `cmd/bd/mol_burn.go:94`: wrap `wispStore.Close()` in defer func
- `cmd/bd/mol_burn.go:143`: handle `fmt.Scanln()` return value  
- `cmd/bd/mol_squash.go:95`: wrap `wispStore.Close()` in defer func
- `cmd/bd/mol_squash.go:122`: wrap `wispStore.Close()` in defer func
- `cmd/bd/wisp.go:219,361,600`: wrap `wispStore.Close()` in defer func (3 locations)
- `internal/beads/beads.go:687,691`: wrap `mainStore.Close()` and `wispStore.Close()`

### gosec G104 (2 fixes)
- `internal/storage/sqlite/multirepo.go:411,416`: handle `rows.Close()` errors

### misspell (1 fix)
- `cmd/bd/mol_burn.go:145`: change "Cancelled" to "Canceled"

### unparam (1 fix)
- `cmd/bd/mol_squash.go:211`: use blank identifier for unused `cmd` parameter

## Approach

All fixes follow existing patterns in the codebase:
- `defer func() { _ = store.Close() }()` for deferred closes
- `_ = rows.Close()` for explicit closes with ignored errors
- `_, _ = fmt.Scanln()` for ignored return values

## Testing

```bash
# Run linter locally
golangci-lint run ./...
# Result: 0 issues

# Run tests
go test -short ./...
# Result: All tests pass
```

## Checklist

- [x] Code follows project style guidelines
- [x] Linting passes (`golangci-lint run ./...`)
- [x] Tests pass locally (`go test -short ./...`)
- [x] No changes to `.beads/issues.jsonl`