### PR TITLE
fix: add interactions.jsonl to .gitignore allowlist

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -28,5 +28,6 @@ beads.right.meta.json
 
 # Keep JSONL exports and config (source of truth for git)
 !issues.jsonl
+!interactions.jsonl
 !metadata.json
 !config.json

--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -37,6 +37,7 @@ beads.right.meta.json
 
 # Keep JSONL exports and config (source of truth for git)
 !issues.jsonl
+!interactions.jsonl
 !metadata.json
 !config.json
 `


### PR DESCRIPTION
## Summary

The `interactions.jsonl` file is an append-only audit log that should be tracked in git (synced with `bd sync`), but it was missing from the negation patterns in `.beads/.gitignore`.

## Changes

Adds `!interactions.jsonl` alongside `!issues.jsonl` and `!metadata.json` in:
- `cmd/bd/doctor/gitignore.go` (the canonical template)
- `.beads/.gitignore` (this repo's instance)

## Why

Looking at the code:
1. `interactions.jsonl` is explicitly included in the sync file list in `cmd/bd/sync.go`
2. It's created during `bd init` (both with and without `--no-db`)
3. The `internal/audit/audit.go` shows it's meant as a permanent audit trail
4. But the gitignore template didn't have a negation pattern for it like the other tracked files

This ensures clarity that `interactions.jsonl` should be committed, consistent with how `issues.jsonl` and `metadata.json` are handled.