### PR TITLE
fix(worktree): integrate health check into CreateBeadsWorktree to prevent redundant checks

### DIFF
--- a/cmd/bd/daemon_sync_branch.go
+++ b/cmd/bd/daemon_sync_branch.go
@@ -62,21 +62,11 @@ func syncBranchCommitAndPushWithOptions(ctx context.Context, store storage.Stora
 	// Initialize worktree manager
 	wtMgr := git.NewWorktreeManager(repoRoot)
 	
-	// Ensure worktree exists
+	// Ensure worktree exists and is healthy
+	// CreateBeadsWorktree now performs a full health check internally and
+	// automatically repairs unhealthy worktrees by removing and recreating them
 	if err := wtMgr.CreateBeadsWorktree(syncBranch, worktreePath); err != nil {
 		return false, fmt.Errorf("failed to create worktree: %w", err)
-	}
-	
-	// Check worktree health and repair if needed
-	if err := wtMgr.CheckWorktreeHealth(worktreePath); err != nil {
-		log.log("Worktree health check failed, attempting repair: %v", err)
-		// Try to recreate worktree
-		if err := wtMgr.RemoveBeadsWorktree(worktreePath); err != nil {
-			log.log("Failed to remove unhealthy worktree: %v", err)
-		}
-		if err := wtMgr.CreateBeadsWorktree(syncBranch, worktreePath); err != nil {
-			return false, fmt.Errorf("failed to recreate worktree after health check: %w", err)
-		}
 	}
 	
 	// Sync JSONL file to worktree

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -35,11 +35,20 @@ func (wm *WorktreeManager) CreateBeadsWorktree(branch, worktreePath string) erro
 	if _, err := os.Stat(worktreePath); err == nil {
 		// Worktree path exists, check if it's a valid worktree
 		if valid, err := wm.isValidWorktree(worktreePath); err == nil && valid {
-			return nil // Already exists and is valid
-		}
-		// Path exists but isn't a valid worktree, remove it
-		if err := os.RemoveAll(worktreePath); err != nil {
-			return fmt.Errorf("failed to remove invalid worktree path: %w", err)
+			// Worktree exists and is in git worktree list, verify full health
+			if err := wm.CheckWorktreeHealth(worktreePath); err == nil {
+				return nil // Already exists and is fully healthy
+			}
+			// Health check failed, try to repair by removing and recreating
+			if err := wm.RemoveBeadsWorktree(worktreePath); err != nil {
+				// Log but continue - we'll try to recreate anyway
+				_ = os.RemoveAll(worktreePath)
+			}
+		} else {
+			// Path exists but isn't a valid worktree, remove it
+			if err := os.RemoveAll(worktreePath); err != nil {
+				return fmt.Errorf("failed to remove invalid worktree path: %w", err)
+			}
 		}
 	}
 

--- a/internal/syncbranch/worktree.go
+++ b/internal/syncbranch/worktree.go
@@ -83,21 +83,11 @@ func CommitToSyncBranch(ctx context.Context, repoRoot, syncBranch, jsonlPath str
 	// Initialize worktree manager
 	wtMgr := git.NewWorktreeManager(repoRoot)
 
-	// Ensure worktree exists
+	// Ensure worktree exists and is healthy
+	// CreateBeadsWorktree performs a full health check internally and
+	// automatically repairs unhealthy worktrees by removing and recreating them
 	if err := wtMgr.CreateBeadsWorktree(syncBranch, worktreePath); err != nil {
 		return nil, fmt.Errorf("failed to create worktree: %w", err)
-	}
-
-	// Check worktree health and repair if needed
-	if err := wtMgr.CheckWorktreeHealth(worktreePath); err != nil {
-		// Try to recreate worktree
-		if err := wtMgr.RemoveBeadsWorktree(worktreePath); err != nil {
-			// Log but continue - removal might fail but recreation might work
-			_ = err
-		}
-		if err := wtMgr.CreateBeadsWorktree(syncBranch, worktreePath); err != nil {
-			return nil, fmt.Errorf("failed to recreate worktree after health check: %w", err)
-		}
 	}
 
 	// Get remote name


### PR DESCRIPTION
## Summary

Fixes confusing error message in daemon.log: 'path exists but is not a valid git worktree'

Closes #710

## Problem

The daemon.log showed the error message even though the worktree was being repaired successfully. This occurred because:
1. `CreateBeadsWorktree` only checked if worktree was in git worktree list
2. `CheckWorktreeHealth` was called separately and failed on additional checks
3. Error was logged, repair was attempted (successfully)

## Solution

Integrate the full health check into `CreateBeadsWorktree`:
- When an existing worktree is found, perform full health check
- If health check fails, automatically remove and recreate
- Remove redundant `CheckWorktreeHealth` calls from callers

## Changes

- `internal/git/worktree.go`: Integrate health check into CreateBeadsWorktree
- `cmd/bd/daemon_sync_branch.go`: Remove redundant health check
- `internal/syncbranch/worktree.go`: Remove redundant health check

## Testing

- All existing worktree tests pass
- Linter passes
- Build succeeds