### PR TITLE
fix(bd-68e4): export must specify -o to write to file, not stdout

### DIFF
--- a/cmd/bd/doctor/fix/sync.go
+++ b/cmd/bd/doctor/fix/sync.go
@@ -105,7 +105,9 @@ func DBJSONLSync(path string) error {
 	// Run the appropriate sync command
 	var cmd *exec.Cmd
 	if syncDirection == "export" {
-		cmd = exec.Command(bdBinary, "export") // #nosec G204 -- bdBinary from validated executable path
+		// Export DB to JSONL file (must specify -o to write to file, not stdout)
+		jsonlOutputPath := filepath.Join(beadsDir, "issues.jsonl")
+		cmd = exec.Command(bdBinary, "export", "-o", jsonlOutputPath, "--force") // #nosec G204 -- bdBinary from validated executable path
 	} else {
 		cmd = exec.Command(bdBinary, "sync", "--import-only") // #nosec G204 -- bdBinary from validated executable path
 	}


### PR DESCRIPTION
When 'bd doctor --fix' detects DB has more issues than JSONL, it runs 'bd export' to sync them. However, 'bd export' without -o flag outputs to stdout instead of writing to .beads/issues.jsonl, making the fix a no-op.

Add -o .beads/issues.jsonl --force to the export command to ensure the JSONL file is actually updated.