### PR TITLE
fix: doctor check skips interactions.jsonl and molecules.jsonl (GH#709)

### DIFF
--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -154,6 +154,8 @@ func CheckLegacyJSONLFilename(repoPath string) DoctorCheck {
 			strings.Contains(lowerName, "~") ||
 			strings.HasPrefix(lowerName, "backup_") ||
 			name == "deletions.jsonl" ||
+			name == "interactions.jsonl" ||
+			name == "molecules.jsonl" ||
 			// Git merge conflict artifacts (e.g., issues.base.jsonl, issues.left.jsonl)
 			strings.Contains(lowerName, ".base.jsonl") ||
 			strings.Contains(lowerName, ".left.jsonl") ||

--- a/cmd/bd/doctor/legacy_test.go
+++ b/cmd/bd/doctor/legacy_test.go
@@ -278,6 +278,24 @@ func TestCheckLegacyJSONLFilename(t *testing.T) {
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
+		{
+			name:           "interactions.jsonl ignored as system file (GH#709)",
+			files:          []string{"issues.jsonl", "interactions.jsonl"},
+			expectedStatus: "ok",
+			expectWarning:  false,
+		},
+		{
+			name:           "molecules.jsonl ignored as system file",
+			files:          []string{"issues.jsonl", "molecules.jsonl"},
+			expectedStatus: "ok",
+			expectWarning:  false,
+		},
+		{
+			name:           "all system files ignored together",
+			files:          []string{"issues.jsonl", "deletions.jsonl", "interactions.jsonl", "molecules.jsonl"},
+			expectedStatus: "ok",
+			expectWarning:  false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Doctor check now skips `interactions.jsonl` and `molecules.jsonl` when counting JSONL files
- Fixes incomplete fix for GH#709 - `FindJSONLInDir` was updated but `CheckLegacyJSONLFilename` was not
- Adds test cases for the new skip behavior

## Problem

After running `bd init` on a fresh repository, `bd doctor` shows a warning:

```
⚠  WARNINGS
  ⚠  1. JSONL Files: Multiple JSONL files found: interactions.jsonl, issues.jsonl
```

This is because `bd init` creates both `issues.jsonl` (the issue database) and `interactions.jsonl` (the audit trail), which is expected behavior.

The fix for https://github.com/steveyegge/beads/issues/709 (commit 94800416) updated `FindJSONLInDir` to skip `interactions.jsonl`, but the doctor check in `CheckLegacyJSONLFilename` was not updated to match.

## Test plan

- [x] Added test cases for `interactions.jsonl`, `molecules.jsonl`, and all system files together
- [x] All existing tests pass
- [x] `go test -v ./cmd/bd/doctor/... -run TestCheckLegacyJSONLFilename` passes