### PR TITLE
fix: add missing CreatedBy in RPC path

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -223,6 +223,7 @@ var createCmd = &cobra.Command{
 				WaitsFor:           waitsFor,
 				WaitsForGate:       waitsForGate,
 				Wisp:               wisp,
+				CreatedBy:          getActorWithGit(),
 			}
 
 			resp, err := daemonClient.Create(createArgs)

--- a/internal/rpc/protocol.go
+++ b/internal/rpc/protocol.go
@@ -93,7 +93,8 @@ type CreateArgs struct {
 	Wisp   bool   `json:"wisp,omitempty"`   // Wisp = ephemeral vapor from the Steam Engine; bulk-deleted when closed
 	RepliesTo string `json:"replies_to,omitempty"` // Issue ID for conversation threading
 	// ID generation (bd-hobo)
-	IDPrefix string `json:"id_prefix,omitempty"` // Override prefix for ID generation (mol, wisp, etc.)
+	IDPrefix  string `json:"id_prefix,omitempty"`  // Override prefix for ID generation (mol, wisp, etc.)
+	CreatedBy string `json:"created_by,omitempty"` // Who created the issue
 }
 
 // UpdateArgs represents arguments for the update operation

--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -180,7 +180,8 @@ func (s *Server) handleCreate(req *Request) Response {
 		Wisp:   createArgs.Wisp,
 		// NOTE: RepliesTo now handled via replies-to dependency (Decision 004)
 		// ID generation (bd-hobo)
-		IDPrefix: createArgs.IDPrefix,
+		IDPrefix:  createArgs.IDPrefix,
+		CreatedBy: createArgs.CreatedBy,
 	}
 	
 	// Check if any dependencies are discovered-from type


### PR DESCRIPTION
created_by was recently added in https://github.com/steveyegge/beads/commit/c3ef1c3f382ac2485a9b793051a291937b4ed37c but was missing support for passing in the CreatedBy through the RPC path so a create that was using the daemon was never having the created_by field set.