### PR TITLE
fix documentation regressions

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -199,7 +199,7 @@ bd automatically:
 
 **Optional**: For immediate export (no 5-second wait) and guaranteed import after git operations, install the git hooks:
 ```bash
-cd examples/git-hooks && ./install.sh
+bd hooks install
 ```
 
 **Disable auto-sync** if needed:

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -40,16 +40,22 @@ There are two ways to install the beads plugin:
 #### Option 2: Local Development
 
 ```bash
-# Clone the repository
+# Clone the repository (shell command)
 git clone https://github.com/steveyegge/beads
 cd beads
+```
 
-# Add local marketplace
-/plugin marketplace add .
+Then in Claude Code:
+
+```
+# Add local marketplace (Claude Code command)
+/plugin marketplace add ./beads
 
 # Install plugin
 /plugin install beads
 ```
+
+**Note:** If you want to install the plugin from a different repo, first `cd` to that repo's directory in your terminal, then use `./beads` (or the relative path to the beads directory) in Claude Code.
 
 ### Restart Claude Code
 
@@ -282,7 +288,7 @@ git commit -m "Add feature tracking"
 
 # After pull, JSONL auto-imports
 git pull
-bd ready  # Fresh data from git!
+bd ready  # Shows issues ready to work on (with fresh data from git)
 ```
 
 ## Updating

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -402,7 +402,7 @@ bd export -o .beads/issues.jsonl
 bd import -i .beads/issues.jsonl
 
 # Install git hooks for guaranteed sync
-cd examples/git-hooks && ./install.sh
+bd hooks install
 ```
 
 If you disabled auto-sync with `--no-auto-flush` or `--no-auto-import`, remove those flags or use `bd sync` manually.


### PR DESCRIPTION
This is a resubmission of #512, #513, and #514 which were introduced with 6b6d2dc4af23eb46c21b0060ae500868c7df295f and then (presumably accidentally) reverted by 57b1d90196705c854779253d9ed42e13b0858736 and e01b7412d9b35ac57b8fff7c57dfd775a8577fb8.

**Please [preserve attribution](https://github.com/steveyegge/beads/pull/512#issuecomment-3651488992) if rewriting this commit - TIA!**

## Changes

- Clarify that `bd ready` shows issues ready to work on (#512)
- Update git hooks install command from deprecated script to `bd hooks install` (#513)
- Fix Claude Code plugin local install: use `./beads` not `.`, clarify shell vs CC commands (#514)