### PR TITLE
feat: add Nix flake for declarative builds and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ Thumbs.db
 result
 
 # direnv (machine-specific environment)
+.direnv/
 .envrc
 
 # GoReleaser build artifacts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,19 @@ go test -race ./...
 go install ./cmd/bd
 ```
 
+### Nix Users
+
+If you have Nix with flakes enabled, you can enter a development shell with all dependencies:
+
+```bash
+# Enter development shell
+nix develop
+
+# Or build and run directly
+nix build
+nix run . -- --help
+```
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Beads supports hierarchical IDs for epics:
 * **npm:** `npm install -g @beads/bd`
 * **Homebrew:** `brew install steveyegge/beads/bd`
 * **Go:** `go install github.com/steveyegge/beads/cmd/bd@latest`
+* **Nix:** `nix run github:steveyegge/beads` or `nix profile install github:steveyegge/beads`
 
 **Requirements:** Linux (glibc 2.32+), macOS, or Windows.
 

--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,26 @@
 { pkgs, self }:
 pkgs.buildGoModule {
   pname = "beads";
-  version = "0.37.0";
+  version = "0.38.0";
 
   src = self;
 
   # Point to the main Go package
   subPackages = [ "cmd/bd" ];
   doCheck = false;
-  # Go module dependencies hash - if build fails with hash mismatch, update with the "got:" value
-  vendorHash = "sha256-Brzb6HZHYtF8LTkP3uQ21GG72c5ekzSkQ2EdrqkdeO0=";
+
+  # Go module dependencies hash.
+  # To update when go.mod/go.sum changes:
+  #   1. Set vendorHash = pkgs.lib.fakeHash;
+  #   2. Run: nix build 2>&1 | grep 'got:' | awk '{print $2}'
+  #   3. Replace with the new hash
+  vendorHash = "sha256-ovG0EWQFtifHF5leEQTFvTjGvc+yiAjpAaqaV0OklgE=";
 
   # Git is required for tests
   nativeBuildInputs = [ pkgs.git ];
 
   meta = with pkgs.lib; {
-    description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";
+    description = "beads (bd) - Distributed, git-backed graph issue tracker for AI agents";
     homepage = "https://github.com/steveyegge/beads";
     license = licenses.mit;
     mainProgram = "bd";

--- a/flake.lock
+++ b/flake.lock
@@ -1,58 +1,24 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760284886,
-        "narHash": "sha256-TK9Kr0BYBQ/1P5kAsnNQhmWWKgmZXwUQr4ZMjCzWf2c=",
+        "lastModified": 1766736597,
+        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf3f5c4def3c7b5f1fc012b3d839575dbe552d43",
+        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,44 +1,86 @@
 {
-  description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";
+  description = "beads (bd) - Distributed, git-backed graph issue tracker for AI agents";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };
 
-  outputs =
-    {
-      self,
-      nixpkgs,
-      flake-utils,
-    }:
-    flake-utils.lib.eachSystem
-      [
+  outputs = { self, nixpkgs }:
+    let
+      # Systems to support
+      supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
         "x86_64-darwin"
         "aarch64-darwin"
-      ]
-      (
-        system:
+      ];
+
+      # Helper to generate outputs for each system
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Get pkgs for a specific system
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = pkgsFor system;
         in
         {
-          packages.default = pkgs.callPackage ./default.nix { inherit pkgs self; };
+          default = pkgs.buildGoModule (finalAttrs: {
+            pname = "beads";
+            version = "0.38.0";
 
-          apps.default = {
-            type = "app";
-            program = "${self.packages.${system}.default}/bin/bd";
-          };
+            src = ./.;
 
-          devShells.default = pkgs.mkShell {
+            subPackages = [ "cmd/bd" ];
+
+            # Go module dependencies hash.
+            # To update when go.mod/go.sum changes:
+            #   1. Set vendorHash = pkgs.lib.fakeHash;
+            #   2. Run: nix build 2>&1 | grep 'got:' | awk '{print $2}'
+            #   3. Replace with the new hash
+            vendorHash = "sha256-ovG0EWQFtifHF5leEQTFvTjGvc+yiAjpAaqaV0OklgE=";
+
+            # Skip tests during nix build (they require git setup)
+            doCheck = false;
+
+            # Git is required for some build-time operations
+            nativeBuildInputs = [ pkgs.git ];
+
+            meta = with pkgs.lib; {
+              description = "Distributed, git-backed graph issue tracker for AI agents";
+              homepage = "https://github.com/steveyegge/beads";
+              license = licenses.mit;
+              mainProgram = "bd";
+              maintainers = [ ];
+              platforms = supportedSystems;
+            };
+          });
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/bd";
+        };
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
             buildInputs = with pkgs; [
+              # Go toolchain (1.24+)
               go
-              git
               gopls
               gotools
               golangci-lint
+              # Development utilities
+              git
               sqlite
             ];
 
@@ -49,4 +91,5 @@
           };
         }
       );
+    };
 }


### PR DESCRIPTION
## Summary

- Add improved Nix flake using nixos-25.11 stable with modern `finalAttrs` pattern
- Enable `nix run`, `nix build`, and `nix develop` for the project
- Includes development shell with Go toolchain, gopls, golangci-lint, and other dev tools

## Changes

- **flake.nix**: Rewritten to use nixos-25.11 stable (instead of unstable), remove flake-utils dependency, and use the modern `finalAttrs` pattern for `buildGoModule`
- **flake.lock**: Updated to lock nixos-25.11
- **default.nix**: Updated version and vendorHash for consistency
- **README.md**: Added Nix installation option
- **CONTRIBUTING.md**: Added section for Nix users
- **.gitignore**: Added `.direnv/` for direnv users

## Usage

```bash
# Run directly
nix run github:steveyegge/beads -- --help

# Install to profile
nix profile install github:steveyegge/beads

# Enter development shell
nix develop

# Build locally
nix build
```

## Verification

All commands tested and working:
- `nix build` ✓
- `nix run . -- --version` ✓ (shows `bd version 0.38.0`)
- `nix flake check` ✓