### PR TITLE
docs: consolidate community tools into dedicated page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,7 @@ Beads supports hierarchical IDs for epics:
 
 ## 🌐 Community Tools
 
-- **[beads_viewer](https://github.com/Dicklesworthstone/beads_viewer)** - Keyboard-driven terminal UI with kanban board, insights panel, and graph view. Built by [@Dicklesworthstone](https://github.com/Dicklesworthstone).
-- **[beads.el](https://codeberg.org/ctietze/beads.el)** - Emacs UI to browse, edit, and manage beads. Built by [@ctietze](https://codeberg.org/ctietze).
-- **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni).
-- **[bdui](https://github.com/assimelha/bdui)** - Real-time terminal UI with tree view, dependency graph, and vim-style navigation. Built by [@assimelha](https://github.com/assimelha).
-- **[perles](https://github.com/zjrosen/perles)** - Terminal UI with BQL (Beads Query Language) and multi-view kanban. Built by [@zjrosen](https://github.com/zjrosen).
-- **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and daemon management. Built by [@jdillon](https://github.com/jdillon).
-- **[opencode-beads](https://github.com/joshuadavidthomas/opencode-beads)** - OpenCode plugin with automatic context injection, `/bd-*` slash commands, and autonomous task agent. Built by [@joshuadavidthomas](https://github.com/joshuadavidthomas).
+See [docs/COMMUNITY_TOOLS.md](docs/COMMUNITY_TOOLS.md) for a curated list of community-built UIs, extensions, and integrations—including terminal interfaces, web UIs, editor extensions, and native apps.
 
 ## 📝 Documentation
 

--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -1,0 +1,45 @@
+# Beads Community Tools
+
+A curated list of community-built UIs, extensions, and integrations for Beads. Ranked by activity and maturity.
+
+## Terminal UIs
+
+- **[beads_viewer](https://github.com/Dicklesworthstone/beads_viewer)** - Elegant, keyboard-driven terminal interface with tree navigation and vim-style commands. Built by [@Dicklesworthstone](https://github.com/Dicklesworthstone). (Go)
+
+- **[bdui](https://github.com/assimelha/bdui)** - Real-time terminal UI with tree view, dependency graph, and vim-style navigation. Built by [@assimelha](https://github.com/assimelha). (Node.js)
+
+- **[perles](https://github.com/zjrosen/perles)** - Terminal UI with BQL (Beads Query Language) and multi-view kanban. Built by [@zjrosen](https://github.com/zjrosen). (Node.js)
+
+- **[beads.el](https://codeberg.org/ctietze/beads.el)** - Emacs UI to browse, edit, and manage beads. Built by [@ctietze](https://codeberg.org/ctietze). (Elisp)
+
+## Web UIs
+
+- **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. Run with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni). (Node.js)
+
+- **[Monitor WebUI](https://github.com/steveyegge/beads/tree/main/examples/monitor-webui)** - Real-time Issue Tracking Dashboard. Standalone web-based monitoring interface with clean, responsive design. Built by Beads core team. (Go)
+
+- **[beads-viz-prototype](https://github.com/mattbeane/beads-viz-prototype)** - Web-based visualization generating interactive HTML from `bd export`. Built by [@mattbeane](https://github.com/mattbeane). (Python)
+
+## Editor Extensions
+
+- **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and daemon management. Built by [@jdillon](https://github.com/jdillon). (TypeScript)
+
+- **[Agent Native Abstraction Layer for Beads](https://marketplace.visualstudio.com/items?itemName=AgentNativeAbstractionLayer.agent-native-kanban)** (ANAL Beads) - VS Code Kanban board. Maintained by [@sebcook-ctrl](https://github.com/sebcook-ctrl). (Node.js)
+
+- **[opencode-beads](https://github.com/joshuadavidthomas/opencode-beads)** - OpenCode plugin with automatic context injection, `/bd-*` slash commands, and autonomous task agent. Built by [@joshuadavidthomas](https://github.com/joshuadavidthomas). (Node.js)
+
+## Native Apps
+
+- **[Beadster](https://github.com/beadster/beadster)** - macOS app for browsing and managing issues from `.beads/` directories in git repositories. Built by [@podviaznikov](https://github.com/podviaznikov). (Swift)
+
+## Historical / Stale
+
+- **[beady](https://github.com/maphew/beady)** - Early prototype effort, now stale. Built by [@maphew](https://github.com/maphew). (Go)
+
+## Discussion
+
+See [GitHub Discussions #276](https://github.com/steveyegge/beads/discussions/276) for ongoing UI development conversations, design decisions, and community contributions.
+
+## Contributing
+
+Found or built a tool? Open a PR to add it to this list or comment on discussion #276.


### PR DESCRIPTION
Consolidates tools from README.md and GitHub discussion #276 into a single, organized docs/COMMUNITY_TOOLS.md file.

Changes:
- Create docs/COMMUNITY_TOOLS.md with curated list ranked by activity
- Organize into categories: Terminal UIs, Web UIs, Editor Extensions, Native Apps, Historical
- Update README.md to reference the new dedicated page
- Link to ongoing discussion #276