### PR TITLE
feat: Add bd human command for focused help menu

### DIFF
--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var humanCmd = &cobra.Command{
+	Use:     "human",
+	GroupID: "setup",
+	Short:   "Show essential commands for human users",
+	Long: `Display a focused help menu showing only the most common commands.
+
+bd has 70+ commands - many for AI agents, integrations, and advanced workflows.
+This command shows the ~15 essential commands that human users need most often.
+
+For the full command list, run: bd --help`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("\n%s\n", ui.RenderBold("bd - Essential Commands for Humans"))
+		fmt.Printf("For all 70+ commands: bd --help\n\n")
+
+		// Issues - Core workflow
+		fmt.Printf("%s\n", ui.RenderAccent("Working With Issues:"))
+		printCmd("create", "Create a new issue")
+		printCmd("list", "List issues (filter with --status, --priority, --label)")
+		printCmd("show <id>", "Show issue details")
+		printCmd("update <id>", "Update an issue (--status, --priority, --assignee)")
+		printCmd("close <id>", "Close one or more issues")
+		printCmd("reopen <id>", "Reopen a closed issue")
+		printCmd("comment <id>", "Add a comment to an issue")
+		fmt.Println()
+
+		// Workflow
+		fmt.Printf("%s\n", ui.RenderAccent("Finding Work:"))
+		printCmd("ready", "Show issues ready to work on (no blockers)")
+		printCmd("search <query>", "Search issues by text")
+		printCmd("status", "Show project overview and counts")
+		printCmd("stats", "Show detailed statistics")
+		fmt.Println()
+
+		// Dependencies
+		fmt.Printf("%s\n", ui.RenderAccent("Dependencies:"))
+		printCmd("dep add <a> <b>", "Add dependency (a depends on b)")
+		printCmd("dep remove <a> <b>", "Remove a dependency")
+		printCmd("dep tree <id>", "Show dependency tree")
+		printCmd("graph", "Display visual dependency graph")
+		printCmd("blocked", "Show all blocked issues")
+		fmt.Println()
+
+		// Setup & Maintenance
+		fmt.Printf("%s\n", ui.RenderAccent("Setup & Sync:"))
+		printCmd("init", "Initialize bd in current directory")
+		printCmd("sync", "Sync issues with git remote")
+		printCmd("doctor", "Check installation health")
+		fmt.Println()
+
+		// Help
+		fmt.Printf("%s\n", ui.RenderAccent("Getting Help:"))
+		printCmd("quickstart", "Quick start guide with examples")
+		printCmd("help <cmd>", "Help for any command")
+		printCmd("--help", "Full command list (70+ commands)")
+		fmt.Println()
+
+		// Common examples
+		fmt.Printf("%s\n", ui.RenderAccent("Quick Examples:"))
+		fmt.Printf("  %s\n", ui.RenderMuted("# Create and track an issue"))
+		fmt.Printf("  bd create \"Fix login bug\" --priority 1\n")
+		fmt.Printf("  bd update bd-abc123 --status in_progress\n")
+		fmt.Printf("  bd close bd-abc123\n\n")
+
+		fmt.Printf("  %s\n", ui.RenderMuted("# See what needs doing"))
+		fmt.Printf("  bd ready                    # What can I work on?\n")
+		fmt.Printf("  bd list --status open       # All open issues\n")
+		fmt.Printf("  bd blocked                  # What's stuck?\n\n")
+	},
+}
+
+// printCmd prints a command with consistent formatting
+func printCmd(cmd, description string) {
+	fmt.Printf("  %-20s %s\n", ui.RenderCommand(cmd), description)
+}
+
+func init() {
+	rootCmd.AddCommand(humanCmd)
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -442,6 +442,7 @@ var rootCmd = &cobra.Command{
 			"fish",
 			"help",
 			"hooks",
+			"human",
 			"init",
 			"merge",
 			"onboard",


### PR DESCRIPTION
bd has 70+ commands, which can be overwhelming for human users who just want to track issues. The new `bd human` command displays a curated list of ~15 essential commands organized by workflow:

- Working With Issues: create, list, show, update, close, reopen, comment
- Finding Work: ready, search, status, stats
- Dependencies: dep add/remove/tree, graph, blocked
- Setup & Sync: init, sync, doctor
- Getting Help: quickstart, help, --help

Also includes quick examples showing common workflows.

Changes:
- Add cmd/bd/human.go with curated help output
- Add "human" to noDbCommands list in main.go (no database needed)