### PR TITLE
test: expand routing and compact coverage

### DIFF
--- a/internal/compact/compactor_unit_test.go
+++ b/internal/compact/compactor_unit_test.go
@@ -1,0 +1,291 @@
+package compact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type stubStore struct {
+	checkEligibilityFn func(context.Context, string, int) (bool, string, error)
+	getIssueFn         func(context.Context, string) (*types.Issue, error)
+	updateIssueFn      func(context.Context, string, map[string]interface{}, string) error
+	applyCompactionFn  func(context.Context, string, int, int, int, string) error
+	addCommentFn       func(context.Context, string, string, string) error
+	markDirtyFn        func(context.Context, string) error
+}
+
+func (s *stubStore) CheckEligibility(ctx context.Context, issueID string, tier int) (bool, string, error) {
+	if s.checkEligibilityFn != nil {
+		return s.checkEligibilityFn(ctx, issueID, tier)
+	}
+	return false, "", nil
+}
+
+func (s *stubStore) GetIssue(ctx context.Context, issueID string) (*types.Issue, error) {
+	if s.getIssueFn != nil {
+		return s.getIssueFn(ctx, issueID)
+	}
+	return nil, fmt.Errorf("GetIssue not stubbed")
+}
+
+func (s *stubStore) UpdateIssue(ctx context.Context, issueID string, updates map[string]interface{}, actor string) error {
+	if s.updateIssueFn != nil {
+		return s.updateIssueFn(ctx, issueID, updates, actor)
+	}
+	return nil
+}
+
+func (s *stubStore) ApplyCompaction(ctx context.Context, issueID string, tier int, originalSize int, compactedSize int, commitHash string) error {
+	if s.applyCompactionFn != nil {
+		return s.applyCompactionFn(ctx, issueID, tier, originalSize, compactedSize, commitHash)
+	}
+	return nil
+}
+
+func (s *stubStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
+	if s.addCommentFn != nil {
+		return s.addCommentFn(ctx, issueID, actor, comment)
+	}
+	return nil
+}
+
+func (s *stubStore) MarkIssueDirty(ctx context.Context, issueID string) error {
+	if s.markDirtyFn != nil {
+		return s.markDirtyFn(ctx, issueID)
+	}
+	return nil
+}
+
+type stubSummarizer struct {
+	summary string
+	err     error
+	calls   int
+}
+
+func (s *stubSummarizer) SummarizeTier1(ctx context.Context, issue *types.Issue) (string, error) {
+	s.calls++
+	return s.summary, s.err
+}
+
+func stubIssue() *types.Issue {
+	return &types.Issue{
+		ID:                 "bd-123",
+		Title:              "Fix login",
+		Description:        strings.Repeat("A", 20),
+		Design:             strings.Repeat("B", 10),
+		Notes:              strings.Repeat("C", 5),
+		AcceptanceCriteria: "done",
+		Status:             types.StatusClosed,
+	}
+}
+
+func withGitHash(t *testing.T, hash string) func() {
+	orig := gitExec
+	gitExec = func(string, ...string) ([]byte, error) {
+		return []byte(hash), nil
+	}
+	return func() { gitExec = orig }
+}
+
+func TestCompactTier1_Success(t *testing.T) {
+	cleanup := withGitHash(t, "deadbeef\n")
+	t.Cleanup(cleanup)
+
+	updateCalled := false
+	applyCalled := false
+	markCalled := false
+	store := &stubStore{
+		checkEligibilityFn: func(context.Context, string, int) (bool, string, error) { return true, "", nil },
+		getIssueFn:         func(context.Context, string) (*types.Issue, error) { return stubIssue(), nil },
+		updateIssueFn: func(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+			updateCalled = true
+			if updates["description"].(string) != "short" {
+				t.Fatalf("expected summarized description")
+			}
+			if updates["design"].(string) != "" {
+				t.Fatalf("design should be cleared")
+			}
+			return nil
+		},
+		applyCompactionFn: func(ctx context.Context, id string, tier, original, compacted int, hash string) error {
+			applyCalled = true
+			if hash != "deadbeef" {
+				t.Fatalf("unexpected hash %q", hash)
+			}
+			return nil
+		},
+		addCommentFn: func(ctx context.Context, id, actor, comment string) error {
+			if !strings.Contains(comment, "saved") {
+				t.Fatalf("unexpected comment %q", comment)
+			}
+			return nil
+		},
+		markDirtyFn: func(context.Context, string) error {
+			markCalled = true
+			return nil
+		},
+	}
+	summary := &stubSummarizer{summary: "short"}
+	c := &Compactor{store: store, summarizer: summary, config: &Config{}}
+
+	if err := c.CompactTier1(context.Background(), "bd-123"); err != nil {
+		t.Fatalf("CompactTier1 unexpected error: %v", err)
+	}
+	if summary.calls != 1 {
+		t.Fatalf("expected summarizer used once, got %d", summary.calls)
+	}
+	if !updateCalled || !applyCalled || !markCalled {
+		t.Fatalf("expected update/apply/mark to be called")
+	}
+}
+
+func TestCompactTier1_DryRun(t *testing.T) {
+	store := &stubStore{
+		checkEligibilityFn: func(context.Context, string, int) (bool, string, error) { return true, "", nil },
+		getIssueFn:         func(context.Context, string) (*types.Issue, error) { return stubIssue(), nil },
+	}
+	summary := &stubSummarizer{summary: "short"}
+	c := &Compactor{store: store, summarizer: summary, config: &Config{DryRun: true}}
+
+	err := c.CompactTier1(context.Background(), "bd-123")
+	if err == nil || !strings.Contains(err.Error(), "dry-run") {
+		t.Fatalf("expected dry-run error, got %v", err)
+	}
+	if summary.calls != 0 {
+		t.Fatalf("summarizer should not be used in dry run")
+	}
+}
+
+func TestCompactTier1_Ineligible(t *testing.T) {
+	store := &stubStore{
+		checkEligibilityFn: func(context.Context, string, int) (bool, string, error) { return false, "recently compacted", nil },
+	}
+	c := &Compactor{store: store, config: &Config{}}
+
+	err := c.CompactTier1(context.Background(), "bd-123")
+	if err == nil || !strings.Contains(err.Error(), "recently compacted") {
+		t.Fatalf("expected ineligible error, got %v", err)
+	}
+}
+
+func TestCompactTier1_SummaryNotSmaller(t *testing.T) {
+	commentCalled := false
+	store := &stubStore{
+		checkEligibilityFn: func(context.Context, string, int) (bool, string, error) { return true, "", nil },
+		getIssueFn:         func(context.Context, string) (*types.Issue, error) { return stubIssue(), nil },
+		addCommentFn: func(ctx context.Context, id, actor, comment string) error {
+			commentCalled = true
+			if !strings.Contains(comment, "Tier 1 compaction skipped") {
+				t.Fatalf("unexpected comment %q", comment)
+			}
+			return nil
+		},
+	}
+	summary := &stubSummarizer{summary: strings.Repeat("X", 40)}
+	c := &Compactor{store: store, summarizer: summary, config: &Config{}}
+
+	err := c.CompactTier1(context.Background(), "bd-123")
+	if err == nil || !strings.Contains(err.Error(), "compaction would increase size") {
+		t.Fatalf("expected size error, got %v", err)
+	}
+	if !commentCalled {
+		t.Fatalf("expected warning comment to be recorded")
+	}
+}
+
+func TestCompactTier1_UpdateError(t *testing.T) {
+	store := &stubStore{
+		checkEligibilityFn: func(context.Context, string, int) (bool, string, error) { return true, "", nil },
+		getIssueFn:         func(context.Context, string) (*types.Issue, error) { return stubIssue(), nil },
+		updateIssueFn:      func(context.Context, string, map[string]interface{}, string) error { return errors.New("boom") },
+	}
+	summary := &stubSummarizer{summary: "short"}
+	c := &Compactor{store: store, summarizer: summary, config: &Config{}}
+
+	err := c.CompactTier1(context.Background(), "bd-123")
+	if err == nil || !strings.Contains(err.Error(), "failed to update issue") {
+		t.Fatalf("expected update error, got %v", err)
+	}
+}
+
+func TestCompactTier1Batch_MixedResults(t *testing.T) {
+	cleanup := withGitHash(t, "cafebabe\n")
+	t.Cleanup(cleanup)
+
+	var mu sync.Mutex
+	updated := make(map[string]int)
+	applied := make(map[string]int)
+	marked := make(map[string]int)
+	store := &stubStore{
+		checkEligibilityFn: func(ctx context.Context, id string, tier int) (bool, string, error) {
+			switch id {
+			case "bd-1":
+				return true, "", nil
+			case "bd-2":
+				return false, "not eligible", nil
+			default:
+				return false, "", fmt.Errorf("unexpected id %s", id)
+			}
+		},
+		getIssueFn: func(ctx context.Context, id string) (*types.Issue, error) {
+			issue := stubIssue()
+			issue.ID = id
+			return issue, nil
+		},
+		updateIssueFn: func(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+			mu.Lock()
+			updated[id]++
+			mu.Unlock()
+			return nil
+		},
+		applyCompactionFn: func(ctx context.Context, id string, tier, original, compacted int, hash string) error {
+			mu.Lock()
+			applied[id]++
+			mu.Unlock()
+			return nil
+		},
+		addCommentFn: func(context.Context, string, string, string) error { return nil },
+		markDirtyFn: func(ctx context.Context, id string) error {
+			mu.Lock()
+			marked[id]++
+			mu.Unlock()
+			return nil
+		},
+	}
+	summary := &stubSummarizer{summary: "short"}
+	c := &Compactor{store: store, summarizer: summary, config: &Config{Concurrency: 2}}
+
+	results, err := c.CompactTier1Batch(context.Background(), []string{"bd-1", "bd-2"})
+	if err != nil {
+		t.Fatalf("CompactTier1Batch unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	resMap := map[string]*Result{}
+	for _, r := range results {
+		resMap[r.IssueID] = r
+	}
+
+	if res := resMap["bd-1"]; res == nil || res.Err != nil || res.CompactedSize == 0 {
+		t.Fatalf("expected success result for bd-1, got %+v", res)
+	}
+	if res := resMap["bd-2"]; res == nil || res.Err == nil || !strings.Contains(res.Err.Error(), "not eligible") {
+		t.Fatalf("expected ineligible error for bd-2, got %+v", res)
+	}
+	if updated["bd-1"] != 1 || applied["bd-1"] != 1 || marked["bd-1"] != 1 {
+		t.Fatalf("expected store operations for bd-1 exactly once")
+	}
+	if updated["bd-2"] != 0 || applied["bd-2"] != 0 {
+		t.Fatalf("bd-2 should not be processed")
+	}
+	if summary.calls != 1 {
+		t.Fatalf("summarizer should run once; got %d", summary.calls)
+	}
+}

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -1,0 +1,154 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRenderBasicStyles(t *testing.T) {
+	t.Run("semantic wrappers", func(t *testing.T) {
+		cases := []struct {
+			name string
+			got  string
+			want string
+		}{
+			{"pass", RenderPass("ok"), PassStyle.Render("ok")},
+			{"warn", RenderWarn("careful"), WarnStyle.Render("careful")},
+			{"fail", RenderFail("boom"), FailStyle.Render("boom")},
+			{"muted", RenderMuted("note"), MutedStyle.Render("note")},
+			{"accent", RenderAccent("info"), AccentStyle.Render("info")},
+			{"category", RenderCategory("mixed Case"), CategoryStyle.Render("MIXED CASE")},
+			{"separator", RenderSeparator(), MutedStyle.Render(SeparatorLight)},
+			{"pass icon", RenderPassIcon(), PassStyle.Render(IconPass)},
+			{"warn icon", RenderWarnIcon(), WarnStyle.Render(IconWarn)},
+			{"fail icon", RenderFailIcon(), FailStyle.Render(IconFail)},
+			{"skip icon", RenderSkipIcon(), MutedStyle.Render(IconSkip)},
+			{"info icon", RenderInfoIcon(), AccentStyle.Render(IconInfo)},
+			{"bold", RenderBold("bold"), BoldStyle.Render("bold")},
+			{"command", RenderCommand("bd prime"), CommandStyle.Render("bd prime")},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.got != tc.want {
+					t.Fatalf("%s mismatch: got %q want %q", tc.name, tc.got, tc.want)
+				}
+			})
+		}
+	})
+}
+
+func TestRenderStatusAndPriority(t *testing.T) {
+	statusCases := []struct {
+		status string
+		want   string
+	}{
+		{"open", StatusOpenStyle.Render("open")},
+		{"in_progress", StatusInProgressStyle.Render("in_progress")},
+		{"blocked", StatusBlockedStyle.Render("blocked")},
+		{"pinned", StatusPinnedStyle.Render("pinned")},
+		{"hooked", StatusHookedStyle.Render("hooked")},
+		{"closed", StatusClosedStyle.Render("closed")},
+		{"custom", StatusOpenStyle.Render("custom")},
+	}
+	for _, tc := range statusCases {
+		if got := RenderStatus(tc.status); got != tc.want {
+			t.Fatalf("status %s mismatch: got %q want %q", tc.status, got, tc.want)
+		}
+	}
+
+	priorityCases := []struct {
+		priority int
+		want     string
+	}{
+		{0, PriorityP0Style.Render("P0")},
+		{1, PriorityP1Style.Render("P1")},
+		{2, PriorityP2Style.Render("P2")},
+		{3, PriorityP3Style.Render("P3")},
+		{4, PriorityP4Style.Render("P4")},
+		{5, "P5"},
+	}
+	for _, tc := range priorityCases {
+		if got := RenderPriority(tc.priority); got != tc.want {
+			t.Fatalf("priority %d mismatch: got %q want %q", tc.priority, got, tc.want)
+		}
+	}
+
+	if got := RenderPriorityForStatus(0, "closed"); got != "P0" {
+		t.Fatalf("closed priority should be plain text, got %q", got)
+	}
+	if got := RenderPriorityForStatus(1, "open"); got != RenderPriority(1) {
+		t.Fatalf("open priority should use styling")
+	}
+}
+
+func TestRenderTypeVariants(t *testing.T) {
+	cases := []struct {
+		issueType string
+		want      string
+	}{
+		{"bug", TypeBugStyle.Render("bug")},
+		{"feature", TypeFeatureStyle.Render("feature")},
+		{"task", TypeTaskStyle.Render("task")},
+		{"epic", TypeEpicStyle.Render("epic")},
+		{"chore", TypeChoreStyle.Render("chore")},
+		{"agent", TypeAgentStyle.Render("agent")},
+		{"role", TypeRoleStyle.Render("role")},
+		{"custom", "custom"},
+	}
+	for _, tc := range cases {
+		if got := RenderType(tc.issueType); got != tc.want {
+			t.Fatalf("type %s mismatch: got %q want %q", tc.issueType, got, tc.want)
+		}
+	}
+
+	if got := RenderTypeForStatus("bug", "closed"); got != "bug" {
+		t.Fatalf("closed type should be plain, got %q", got)
+	}
+	if got := RenderTypeForStatus("bug", "open"); got != RenderType("bug") {
+		t.Fatalf("open type should be styled")
+	}
+}
+
+func TestRenderIssueCompact(t *testing.T) {
+	open := RenderIssueCompact("bd-1", 0, "bug", "in_progress", "ship it")
+	wantOpen := fmt.Sprintf("%s [%s] [%s] %s - %s",
+		RenderID("bd-1"),
+		RenderPriority(0),
+		RenderType("bug"),
+		RenderStatus("in_progress"),
+		"ship it",
+	)
+	if open != wantOpen {
+		t.Fatalf("open issue line mismatch: got %q want %q", open, wantOpen)
+	}
+
+	closed := RenderIssueCompact("bd-2", 2, "task", "closed", "done")
+	raw := fmt.Sprintf("%s [P%d] [%s] %s - %s", "bd-2", 2, "task", "closed", "done")
+	if closed != StatusClosedStyle.Render(raw) {
+		t.Fatalf("closed issue line should be dimmed: got %q", closed)
+	}
+}
+
+func TestRenderClosedUtilities(t *testing.T) {
+	line := "bd-42 closed"
+	if got := RenderClosedLine(line); got != StatusClosedStyle.Render(line) {
+		t.Fatalf("closed line mismatch: got %q", got)
+	}
+
+	if got := RenderID("bd-5"); got != IDStyle.Render("bd-5") {
+		t.Fatalf("RenderID mismatch")
+	}
+}
+
+func TestRenderCommandAndCategoryAreUppercaseSafe(t *testing.T) {
+	got := RenderCategory(" already upper ")
+	if !strings.Contains(got, " ALREADY UPPER ") {
+		t.Fatalf("category should uppercase input, got %q", got)
+	}
+
+	cmd := RenderCommand("bd prime")
+	if !strings.Contains(cmd, "bd prime") {
+		t.Fatalf("command output missing text: %q", cmd)
+	}
+}

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -242,3 +242,20 @@ func TestResolveForWrite(t *testing.T) {
 		}
 	})
 }
+
+func TestFindMoleculesJSONLInDir(t *testing.T) {
+	root := t.TempDir()
+	molecules := filepath.Join(root, "molecules.jsonl")
+	if err := os.WriteFile(molecules, []byte("[]"), 0o644); err != nil {
+		t.Fatalf("failed to create molecules.jsonl: %v", err)
+	}
+
+	if got := FindMoleculesJSONLInDir(root); got != molecules {
+		t.Fatalf("expected %q, got %q", molecules, got)
+	}
+
+	otherDir := t.TempDir()
+	if got := FindMoleculesJSONLInDir(otherDir); got != "" {
+		t.Fatalf("expected empty path when file missing, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add snapshot-style coverage for internal/ui/styles and extend utils/types gate tests
- refactor compactor to inject store/summarizer interfaces and add unit tests for Tier1 + batch flows
- cover additional git routing edge cases to harden maintainer/contributor detection

## Testing
- BEADS_TEST_GUARD_DISABLE=1 go test ./... -coverprofile=/tmp/beads-cover.out