### PR TITLE
fix(fork-protection): only apply protection to actual beads forks (#823)

### DIFF
--- a/cmd/bd/fork_protection_test.go
+++ b/cmd/bd/fork_protection_test.go
@@ -2,10 +2,55 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// setupGitRepoForForkTest creates a temporary git repository for testing
+func setupGitRepoForForkTest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Create .beads directory
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init", "--initial-branch=main")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+
+	// Configure git user
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	return dir
+}
+
+// addRemote adds a git remote to the test repo
+func addRemote(t *testing.T, dir, name, url string) {
+	t.Helper()
+	cmd := exec.Command("git", "remote", "add", name, url)
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to add remote %s: %v", name, err)
+	}
+}
+
+// ============================================================================
+// Test isUpstreamRepo (existing tests, updated)
+// ============================================================================
 
 func TestIsUpstreamRepo(t *testing.T) {
 	tests := []struct {
@@ -45,6 +90,118 @@ func TestIsUpstreamRepo(t *testing.T) {
 	}
 }
 
+// Test 1: Upstream maintainer (origin = steveyegge/beads)
+func TestIsUpstreamRepo_Maintainer(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "https://github.com/steveyegge/beads.git")
+
+	if !isUpstreamRepo(dir) {
+		t.Error("expected isUpstreamRepo to return true for steveyegge/beads")
+	}
+}
+
+// Test 1b: Upstream maintainer with SSH URL
+func TestIsUpstreamRepo_MaintainerSSH(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "git@github.com:steveyegge/beads.git")
+
+	if !isUpstreamRepo(dir) {
+		t.Error("expected isUpstreamRepo to return true for SSH steveyegge/beads")
+	}
+}
+
+// Test isUpstreamRepo with non-beads origin
+func TestIsUpstreamRepo_NotUpstream(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "https://github.com/peterkc/beads.git")
+
+	if isUpstreamRepo(dir) {
+		t.Error("expected isUpstreamRepo to return false for fork origin")
+	}
+}
+
+// Test isUpstreamRepo with no origin
+func TestIsUpstreamRepo_NoOrigin(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	// Don't add origin remote
+
+	if isUpstreamRepo(dir) {
+		t.Error("expected isUpstreamRepo to return false when no origin exists")
+	}
+}
+
+// ============================================================================
+// Test isForkOfBeads (new tests for GH#823)
+// ============================================================================
+
+// Test 2: Fork (standard) - origin=fork, upstream=beads
+func TestIsForkOfBeads_StandardFork(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "https://github.com/peterkc/beads.git")
+	addRemote(t, dir, "upstream", "https://github.com/steveyegge/beads.git")
+
+	if !isForkOfBeads(dir) {
+		t.Error("expected isForkOfBeads to return true for standard fork setup")
+	}
+}
+
+// Test 3: Fork (custom naming) - origin=fork, github=beads
+func TestIsForkOfBeads_CustomNaming(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "https://github.com/peterkc/beads.git")
+	addRemote(t, dir, "github", "https://github.com/steveyegge/beads.git")
+
+	if !isForkOfBeads(dir) {
+		t.Error("expected isForkOfBeads to return true for custom remote naming")
+	}
+}
+
+// Test 4: User's own project (no beads remote) - THE BUG CASE
+func TestIsForkOfBeads_UserProject(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "https://github.com/mycompany/myapp.git")
+
+	if isForkOfBeads(dir) {
+		t.Error("expected isForkOfBeads to return false for user's own project")
+	}
+}
+
+// Test 5: User's project with unrelated upstream - THE BUG CASE
+func TestIsForkOfBeads_UserProjectWithUpstream(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "https://github.com/mycompany/myapp.git")
+	addRemote(t, dir, "upstream", "https://github.com/other/repo.git")
+
+	if isForkOfBeads(dir) {
+		t.Error("expected isForkOfBeads to return false for user's project with unrelated upstream")
+	}
+}
+
+// Test 6: No remotes
+func TestIsForkOfBeads_NoRemotes(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	// Don't add any remotes
+
+	if isForkOfBeads(dir) {
+		t.Error("expected isForkOfBeads to return false when no remotes exist")
+	}
+}
+
+// Test SSH URL detection
+func TestIsForkOfBeads_SSHRemote(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "git@github.com:peterkc/beads.git")
+	addRemote(t, dir, "upstream", "git@github.com:steveyegge/beads.git")
+
+	if !isForkOfBeads(dir) {
+		t.Error("expected isForkOfBeads to return true for SSH upstream")
+	}
+}
+
+// ============================================================================
+// Test isAlreadyExcluded (existing tests)
+// ============================================================================
+
 func TestIsAlreadyExcluded(t *testing.T) {
 	// Create temp file with exclusion
 	tmpDir := t.TempDir()
@@ -71,6 +228,10 @@ func TestIsAlreadyExcluded(t *testing.T) {
 		t.Error("expected file with exclusion to return true")
 	}
 }
+
+// ============================================================================
+// Test addToExclude (existing tests)
+// ============================================================================
 
 func TestAddToExclude(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -109,5 +270,66 @@ func TestAddToExclude(t *testing.T) {
 	}
 	if !strings.Contains(string(content), ".beads/issues.jsonl") {
 		t.Errorf("exclude file missing .beads/issues.jsonl: %s", content)
+	}
+}
+
+// ============================================================================
+// Test isForkProtectionDisabled (git config opt-out)
+// ============================================================================
+
+// Test isForkProtectionDisabled with various git config values
+func TestIsForkProtectionDisabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string // value to set, empty = don't set
+		expected bool
+	}{
+		{"not set", "", false},
+		{"set to false", "false", true},
+		{"set to true", "true", false},
+		{"set to other", "disabled", false}, // only "false" disables
+		{"set to FALSE", "FALSE", false},    // case-sensitive
+		{"set to 0", "0", false},            // only "false" disables
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := setupGitRepoForForkTest(t)
+
+			if tt.config != "" {
+				cmd := exec.Command("git", "-C", dir, "config", "beads.fork-protection", tt.config)
+				if err := cmd.Run(); err != nil {
+					t.Fatalf("failed to set git config: %v", err)
+				}
+			}
+
+			result := isForkProtectionDisabled(dir)
+			if result != tt.expected {
+				t.Errorf("isForkProtectionDisabled() = %v, want %v (config=%q)", result, tt.expected, tt.config)
+			}
+		})
+	}
+}
+
+// Test 8: Config opt-out via git config (replaces YAML config)
+func TestConfigOptOut_GitConfig(t *testing.T) {
+	dir := setupGitRepoForForkTest(t)
+	addRemote(t, dir, "origin", "https://github.com/peterkc/beads.git")
+	addRemote(t, dir, "upstream", "https://github.com/steveyegge/beads.git")
+
+	// Verify this IS a fork of beads
+	if !isForkOfBeads(dir) {
+		t.Fatal("expected isForkOfBeads to return true for test setup")
+	}
+
+	// Set git config opt-out
+	cmd := exec.Command("git", "-C", dir, "config", "beads.fork-protection", "false")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set git config: %v", err)
+	}
+
+	// Verify opt-out is detected
+	if !isForkProtectionDisabled(dir) {
+		t.Error("expected isForkProtectionDisabled to return true after setting git config")
 	}
 }

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -38,8 +38,8 @@ var YamlOnlyKeys = map[string]bool{
 	// Git settings
 	"git.author":       true,
 	"git.no-gpg-sign":  true,
-	"no-push":          true,
-	"no-git-ops":       true, // Disable git ops in bd prime session close protocol (GH#593)
+	"no-push":    true,
+	"no-git-ops": true, // Disable git ops in bd prime session close protocol (GH#593)
 
 	// Sync settings
 	"sync-branch":                           true,


### PR DESCRIPTION
## Summary

Fixes #823 - Fork protection was incorrectly triggering on user's own projects that just use beads as a tool.

## Problem

`ensureForkProtection()` treated "not upstream maintainer" as "is a fork":

```
Is origin == steveyegge/beads?
         │
    ┌────┴────┐
   YES       NO
    │         │
    ▼         ▼
  Skip    Add to exclude ← BUG!
          (assume fork)
```

Any repo where `origin != steveyegge/beads` got fork protection, including users' own projects.

## Solution

Check if ANY remote points to `steveyegge/beads` before applying protection:

```
Is origin == steveyegge/beads?
         │
    ┌────┴────┐
   YES       NO
    │         │
    ▼         ▼
  Skip    Does ANY remote contain steveyegge/beads?
                    │
              ┌─────┴─────┐
             YES         NO
              │           │
              ▼           ▼
        Add to exclude   Skip
        (confirmed fork) (user's project)
```

## Changes

- **`cmd/bd/fork_protection.go`**: Add `isForkOfBeads()` that scans all remotes, plus `isForkProtectionDisabled()` for git config opt-out
- **`cmd/bd/fork_protection_test.go`**: 8 test scenarios + edge case coverage
- **`internal/config/yaml_config.go`**: Removed `fork-protection` from YAML keys (using git config instead)

## Config Opt-Out

For edge cases, users can disable fork protection per-clone:

```bash
git config beads.fork-protection false
```

This uses git config (not `.beads/config.yaml`) so it's per-clone and never propagates to forks. Matches the `beads.role` pattern in `routing.go`.

## Test Matrix

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | Upstream maintainer | Skip | ✅ |
| 2 | Fork (standard) | Protect | ✅ |
| 3 | Fork (custom naming) | Protect | ✅ |
| 4 | User's own project | Skip | ✅ |
| 5 | User + unrelated upstream | Skip | ✅ |
| 6 | No remotes | Skip | ✅ |
| 7 | Already excluded | Skip | ✅ |
| 8 | Git config opt-out | Skip | ✅ |

## Test Plan

- [x] `go test ./cmd/bd/...` passes
- [x] `go vet` clean
- [x] Build succeeds