### PR TITLE
fix: prevent nil context panic in multi-repo hydration

### DIFF
--- a/cmd/bd/context.go
+++ b/cmd/bd/context.go
@@ -194,11 +194,18 @@ func setDBPath(p string) {
 }
 
 // getRootContext returns the signal-aware root context.
+// Returns context.Background() if the root context is nil (e.g., before CLI initialization).
 func getRootContext() context.Context {
+	var ctx context.Context
 	if shouldUseGlobals() {
-		return rootCtx
+		ctx = rootCtx
+	} else {
+		ctx = cmdCtx.RootCtx
 	}
-	return cmdCtx.RootCtx
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
 }
 
 // setRootContext updates the root context and cancel function.

--- a/cmd/bd/context_test.go
+++ b/cmd/bd/context_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetRootContext_NilFallback(t *testing.T) {
+	// Save original state
+	oldRootCtx := rootCtx
+	oldCmdCtx := cmdCtx
+	defer func() {
+		rootCtx = oldRootCtx
+		cmdCtx = oldCmdCtx
+	}()
+
+	t.Run("returns background when rootCtx is nil", func(t *testing.T) {
+		rootCtx = nil
+		cmdCtx = &CommandContext{}
+
+		ctx := getRootContext()
+		if ctx == nil {
+			t.Fatal("getRootContext() returned nil, expected context.Background()")
+		}
+	})
+
+	t.Run("returns rootCtx when set", func(t *testing.T) {
+		expected := context.WithValue(context.Background(), "test", "value")
+		rootCtx = expected
+		cmdCtx = &CommandContext{}
+
+		ctx := getRootContext()
+		if ctx != expected {
+			t.Errorf("getRootContext() = %v, want %v", ctx, expected)
+		}
+	})
+
+	t.Run("returns cmdCtx.RootCtx when globals disabled", func(t *testing.T) {
+		expected := context.WithValue(context.Background(), "cmd", "ctx")
+		rootCtx = nil
+		cmdCtx = &CommandContext{RootCtx: expected}
+
+		ctx := getRootContext()
+		if ctx == nil {
+			t.Fatal("getRootContext() returned nil")
+		}
+	})
+}


### PR DESCRIPTION
### Problem

`getRootContext()` can return nil when called before CLI initialization is complete. When multi-repo hydration is configured, this nil context propagates through `sqlite.New()` → `HydrateFromMultiRepo()` → database queries, causing a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
database/sql.(*DB).QueryRowContext(...)
  .../multirepo.go:89
```

### Solution

Add nil check in `getRootContext()` to return `context.Background()` as fallback. This fixes the issue at the source, protecting all callers (not just multi-repo hydration).

### Changes

- `cmd/bd/context.go`: Return `context.Background()` when ctx is nil
- `cmd/bd/context_test.go`: Add tests for nil fallback behavior

### Testing

```bash
go test ./cmd/bd/... -run "TestGetRootContext" -v
```

All existing tests pass.