### PR TITLE
fix(hooks): prevent infinite loop when chaining to bd shims

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -374,7 +374,6 @@ func installHooks(embeddedHooks map[string]string, force bool, shared bool, chai
 						return fmt.Errorf("failed to rename %s to .old for chaining: %w", hookName, err)
 					}
 				}
-				// If it's a bd shim, we just overwrite it (no need to chain to ourselves)
 			} else if !force {
 				// Default mode - back it up
 				backupPath := hookPath + ".backup"
@@ -473,7 +472,7 @@ func runChainedHook(hookName string, args []string) int {
 	// Check if .old file is a bd shim - if so, skip to prevent infinite loop
 	// See: https://github.com/steveyegge/beads/issues/843
 	if isBdShim(oldHookPath) {
-		return 0 // Skip execution - chaining to a bd shim would cause infinite recursion
+		return 0
 	}
 
 	// Run the chained hook

--- a/cmd/bd/hooks_test.go
+++ b/cmd/bd/hooks_test.go
@@ -508,7 +508,6 @@ exit 0
 		}
 
 		// The shim should NOT have been executed (marker file should not exist)
-		// This is the key assertion - currently FAILS because the bug exists
 		if _, err := os.Stat(markerFile); err == nil {
 			t.Errorf("runChainedHook() executed a bd shim .old file - this causes infinite loop in real usage")
 		}
@@ -551,7 +550,6 @@ func TestInstallHooksChaining_SkipsExistingBdShim(t *testing.T) {
 				t.Fatalf("Failed to read .old file: %v", err)
 			}
 
-			// This is the key assertion - currently FAILS because the bug exists
 			if strings.Contains(string(content), "# bd-shim") {
 				t.Errorf("installHooks(chain=true) renamed a bd shim to .old - this causes infinite loop when hooks run")
 			}


### PR DESCRIPTION
## Summary

Fixes #843 - `bd hooks run` enters infinite loop when `.git/hooks/<hook>.old` is itself a bd shim.

## Changes

- Add `isBdShim()` helper to detect bd shim files by checking for `# bd-shim` marker
- `runChainedHook()`: Skip execution if `.old` file is a bd shim
- `installHooks()`: Don't rename bd shims to `.old` in chain mode

## Root Cause

When `bd hooks install --chain` runs on a repo with existing bd shims:
1. The shim gets renamed to `.old`
2. `bd hooks run` chains to `.old` which calls `bd hooks run` again
3. Infinite recursion

## Testing

- Added 2 regression tests that verify the fix
- Tested manually in reproduction environment
- All existing hook tests pass

## Commits

1. `test(hooks)`: Add regression tests (initially failing)
2. `fix(hooks)`: Implement the fix
3. `style`: Remove redundant comments