### PR TITLE
fix: correct main repo root detection for submodules

### DIFF
--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -149,8 +149,13 @@ func GetMainRepoRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// The main repo root is the parent of the .git directory (commonDir)
-	return filepath.Dir(ctx.commonDir), nil
+	if ctx.isWorktree {
+		// For worktrees, the main repo root is the parent of the shared .git directory.
+		return filepath.Dir(ctx.commonDir), nil
+	}
+
+	// For regular repos (including submodules), repoRoot is the correct root.
+	return ctx.repoRoot, nil
 }
 
 // GetRepoRoot returns the root directory of the current git repository.


### PR DESCRIPTION
## Problem
In a submodule, GetMainRepoRoot used the parent of --git-common-dir, which points to
<super>/.git/modules, not the submodule working tree. This caused git commands in bd sync
(e.g., git status/add) to fail with exit status 128.

## Solution
Return --show-toplevel for non-worktree repos (including submodules), while keeping the
worktree behavior unchanged. Add a submodule regression test to lock in the correct root.

## Changes
- internal/git/gitdir.go: use repoRoot for non-worktree repos
- internal/git/worktree_test.go: add submodule coverage for GetMainRepoRoot

## Testing
go test ./internal/git -run TestGetMainRepoRoot -count=1