### PR TITLE
fix(doctor): skip JSONL tracking checks in sync-branch mode (GH#858)

### DIFF
--- a/cmd/bd/doctor/installation.go
+++ b/cmd/bd/doctor/installation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/cmd/bd/doctor/fix"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
+	"github.com/steveyegge/beads/internal/syncbranch"
 )
 
 // CheckInstallation verifies that .beads directory exists
@@ -142,7 +143,9 @@ func CheckPermissions(path string) DoctorCheck {
 	}
 }
 
-// CheckUntrackedBeadsFiles checks for untracked .beads/*.jsonl files that should be committed
+// CheckUntrackedBeadsFiles checks for untracked .beads/*.jsonl files that should be committed.
+// In sync-branch mode, JSONL files are intentionally untracked in working branches
+// and only committed to the dedicated sync branch (GH#858).
 func CheckUntrackedBeadsFiles(path string) DoctorCheck {
 	beadsDir := filepath.Join(path, ".beads")
 
@@ -152,6 +155,17 @@ func CheckUntrackedBeadsFiles(path string) DoctorCheck {
 			Name:    "Untracked Files",
 			Status:  StatusOK,
 			Message: "N/A (no .beads directory)",
+		}
+	}
+
+	// In sync-branch mode, JSONL files are intentionally untracked in working branches.
+	// They are committed only to the dedicated sync branch via bd sync.
+	if branch := syncbranch.GetFromYAML(); branch != "" {
+		return DoctorCheck{
+			Name:    "Untracked Files",
+			Status:  StatusOK,
+			Message: "N/A (sync-branch mode)",
+			Detail:  fmt.Sprintf("JSONL files tracked in '%s' branch only", branch),
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #858

When `sync-branch` is configured (e.g., via `bd init --branch beads-sync`), JSONL files are intentionally untracked in working branches—they're committed only to the dedicated sync branch. However, `bd doctor` was generating misleading warnings:

- `CheckIssuesTracking`: "issues.jsonl is ignored by git (bd sync will fail)"
- `CheckUntrackedBeadsFiles`: "Untracked JSONL files: issues.jsonl"

These warnings are false positives in sync-branch mode, potentially confusing users who have correctly configured the protected branch workflow.

## Changes

- **`CheckIssuesTracking`**: Added early return when `syncbranch.GetFromYAML()` detects sync-branch mode
- **`CheckUntrackedBeadsFiles`**: Added early return when `syncbranch.GetFromYAML()` detects sync-branch mode

Both checks now return `OK` status with message `"N/A (sync-branch mode)"` and detail indicating which branch tracks JSONL files.

## Design Decision

Used `GetFromYAML()` (env var + config.yaml) rather than `IsConfiguredWithDB()` (which also checks database) for consistency with all other sync-branch checks in the doctor package. Database-only sync-branch config is legacy; users should migrate to `config.yaml`.

## Test Plan

- [x] `go build ./cmd/bd/...` — compiles clean
- [x] `go test ./cmd/bd/doctor/...` — all tests pass
- [x] Manual verification: `bd doctor --json` shows correct output for both checks in sync-branch mode

**Before:**
```
⚠ Issues Tracking: issues.jsonl is ignored by git
⚠ Untracked Files: Untracked JSONL files: issues.jsonl
```

**After:**
```
✓ Issues Tracking: N/A (sync-branch mode)
✓ Untracked Files: N/A (sync-branch mode)
```