### PR TITLE
Update links to install.sh

### DIFF
--- a/commands/version.md
+++ b/commands/version.md
@@ -19,7 +19,7 @@ Display:
 - Compatibility status (✓ compatible or ⚠️ update needed)
 
 If versions are mismatched, provide instructions:
-- Update bd CLI: `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash`
+- Update bd CLI: `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash`
 - Update plugin: `/plugin update beads`
 - Restart Claude Code after updating
 

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -16,7 +16,7 @@ Beads (`bd`) is an issue tracker designed specifically for AI-supervised coding 
 
 1. Install beads CLI:
 ```bash
-curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
 ```
 
 2. Install Python and uv (for MCP server):
@@ -310,7 +310,7 @@ The plugin requires the `bd` CLI to be installed. Update it separately:
 
 ```bash
 # Quick update
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
 
 # Or with go
 go install github.com/steveyegge/beads/cmd/bd@latest

--- a/examples/compaction/workflow.sh
+++ b/examples/compaction/workflow.sh
@@ -23,7 +23,7 @@ if ! command -v bd &> /dev/null; then
   echo "❌ Error: bd command not found"
   echo
   echo "Install bd:"
-  echo "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash"
+  echo "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash"
   echo
   exit 1
 fi

--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -49,7 +49,7 @@ class BdNotFoundError(BdError):
             f"bd CLI not found at: {attempted_path}\n\n"
             "The beads Claude Code plugin requires the bd CLI to be installed separately.\n\n"
             "Install bd CLI:\n"
-            "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash\n\n"
+            "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n\n"
             "Or visit: https://github.com/steveyegge/beads#installation\n\n"
             "After installation, restart Claude Code to reload the MCP server."
         )
@@ -363,7 +363,7 @@ class BdCliClient(BdClientBase):
         if version < min_version:
             min_ver_str = ".".join(str(x) for x in min_version)
             cur_ver_str = ".".join(str(x) for x in version)
-            install_cmd = "curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash"
+            install_cmd = "curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash"
             raise BdVersionError(
                 f"bd version {cur_ver_str} is too old. "
                 f"This MCP server requires bd >= {min_ver_str}. "

--- a/integrations/beads-mcp/src/beads_mcp/config.py
+++ b/integrations/beads-mcp/src/beads_mcp/config.py
@@ -66,7 +66,7 @@ class Config(BaseSettings):
                     f"bd executable not found at: {v}\n\n"
                     + "The beads Claude Code plugin requires the bd CLI to be installed.\n\n"
                     + "Install bd CLI:\n"
-                    + "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash\n\n"
+                    + "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n\n"
                     + "Or visit: https://github.com/steveyegge/beads#installation\n\n"
                     + "After installation, restart Claude Code to reload the MCP server."
                 )
@@ -154,7 +154,7 @@ def load_config() -> Config:
             "Beads MCP Server Configuration Error\n\n"
             + f"{e}\n\n"
             + "Common fix: Install the bd CLI first:\n"
-            + "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/install.sh | bash\n\n"
+            + "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n\n"
             + "Or visit: https://github.com/steveyegge/beads#installation\n\n"
             + "After installation, restart Claude Code.\n\n"
             + "Advanced configuration (optional):\n"


### PR DESCRIPTION
## Summary
The install scripts were relocated under the scripts/ directory, but the documentation was not updated accordingly.

## Changes

Replaced references to
https://raw.githubusercontent.com/steveyegge/beads/main/install.sh
with
https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh

Ensures install instructions match the current repository layout

## Why
Outdated docs caused install instructions to fail after the script move.