### PR TITLE
fix(config): normalize keys in GetYamlConfig to match SetYamlConfig

### DIFF
--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -130,11 +130,13 @@ func SetYamlConfig(key, value string) error {
 
 // GetYamlConfig gets a configuration value from config.yaml.
 // Returns empty string if key is not found or is commented out.
+// Keys are normalized to their canonical yaml format (e.g., sync.branch -> sync-branch).
 func GetYamlConfig(key string) string {
 	if v == nil {
 		return ""
 	}
-	return v.GetString(key)
+	normalizedKey := normalizeYamlKey(key)
+	return v.GetString(normalizedKey)
 }
 
 // findProjectConfigYaml finds the project's .beads/config.yaml file.


### PR DESCRIPTION
## Summary

`GetYamlConfig` was not normalizing key aliases (e.g., `sync.branch` → `sync-branch`), causing `bd config get sync.branch` to return "not set" even when the value was correctly stored.

`SetYamlConfig` already normalized keys, but `GetYamlConfig` did not, leading to a confusing mismatch where set appeared to work but get could not find the value.

## Reproduction

```bash
bd config set sync.branch beads-sync
# Output: Set sync.branch = beads-sync (in config.yaml)

bd config get sync.branch  
# Output: sync.branch (not set in config.yaml)

cat .beads/config.yaml | grep sync
# Output: sync-branch: "beads-sync"  # It IS there!
```

## Fix

Added key normalization to `GetYamlConfig` to match `SetYamlConfig`:

```go
func GetYamlConfig(key string) string {
    if v == nil {
        return ""
    }
    normalizedKey := normalizeYamlKey(key)  // Added this line
    return v.GetString(normalizedKey)
}
```

## Test Plan

- [x] Added `TestGetYamlConfig_KeyNormalization` - verifies aliased key lookup works
- [x] Existing `TestNormalizeYamlKey` still passes
- [x] Existing `TestSetYamlConfig_KeyNormalization` still passes  
- [x] All `./internal/config/...` tests pass

Fixes #873