### PR TITLE
Add repository guards to deployment workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -83,6 +83,8 @@ jobs:
           path: website/build
 
   deploy:
+    # Guard: deploy should only run in the canonical repository (not in forks)
+    if: ${{ github.repository == 'steveyegge/beads' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   goreleaser:
+    # Guard: only run goreleaser in the canonical repository (not in forks)
+    if: ${{ github.repository == 'steveyegge/beads' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   test-publish:
+    # Guard: only allow test PyPI publish runs in the canonical repository
+    if: ${{ github.repository == 'steveyegge/beads' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   update-formula:
+    # Guard: only run homebrew update in the canonical repository (not in forks)
+    if: ${{ github.repository == 'steveyegge/beads' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout beads repo


### PR DESCRIPTION
Prevents fork workflows from attempting to deploy, release, or publish to external services by adding conditional checks that only allow these jobs to run in the canonical repository.

Changes:
- Guard deploy-docs job to only run in canonical repository
- Guard goreleaser job to only run in canonical repository  
- Guard update-homebrew job to only run in canonical repository
- Guard test-pypi job to only run in canonical repository