### PR TITLE
fix: add multi-prefix support via allowed_prefixes config

### DIFF
--- a/internal/validation/bead_test.go
+++ b/internal/validation/bead_test.go
@@ -195,6 +195,43 @@ func TestValidatePrefix(t *testing.T) {
 	}
 }
 
+func TestValidatePrefixWithAllowed(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestedPrefix string
+		dbPrefix        string
+		allowedPrefixes string
+		force           bool
+		wantError       bool
+	}{
+		// Basic cases (same as ValidatePrefix)
+		{"matching prefixes", "bd", "bd", "", false, false},
+		{"empty db prefix", "bd", "", "", false, false},
+		{"mismatched with force", "foo", "bd", "", true, false},
+		{"mismatched without force", "foo", "bd", "", false, true},
+
+		// Multi-prefix cases (Gas Town use case)
+		{"allowed prefix gt", "gt", "hq", "gt,hmc", false, false},
+		{"allowed prefix hmc", "hmc", "hq", "gt,hmc", false, false},
+		{"primary prefix still works", "hq", "hq", "gt,hmc", false, false},
+		{"prefix not in allowed list", "foo", "hq", "gt,hmc", false, true},
+
+		// Edge cases
+		{"allowed with spaces", "gt", "hq", "gt, hmc, foo", false, false},
+		{"empty allowed list", "gt", "hq", "", false, true},
+		{"single allowed prefix", "gt", "hq", "gt", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePrefixWithAllowed(tt.requestedPrefix, tt.dbPrefix, tt.allowedPrefixes, tt.force)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidatePrefixWithAllowed() error = %v, wantError %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
 func TestValidateAgentID(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Adds support for allowing multiple prefixes in a beads database via the `allowed_prefixes` config key.

This is needed for **Gas Town** which uses different prefixes for different purposes:
- `hq-` for convoys (headquarters)
- `gt-` for agent beads  
- `<rig>-` prefixes for per-rig beads (e.g., `hmc-` for hytopia-map-compression)

Currently, `bd create` only validates against a single `issue_prefix`, causing errors like:
```
Error: prefix mismatch: database uses 'hq' but you specified 'gt' (use --force to override)
```

## Changes

- Add `ValidatePrefixWithAllowed()` function that checks against a comma-separated list of allowed prefixes
- Update `create.go` to fetch and use `allowed_prefixes` config
- Add comprehensive tests for multi-prefix validation

## Usage

```bash
bd config set allowed_prefixes "gt,hq,hmc"
```

## Backwards Compatibility

This maintains full backwards compatibility - if `allowed_prefixes` is not set, validation works exactly as before.

## Test Plan

- [x] All existing tests pass
- [x] New tests for `ValidatePrefixWithAllowed()` pass
- [x] Manual testing with Gas Town multi-prefix scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)