### PR TITLE
fix: prevent event storm when gitRefsPath is empty

### DIFF
--- a/cmd/bd/daemon_watcher.go
+++ b/cmd/bd/daemon_watcher.go
@@ -210,7 +210,8 @@ func (fw *FileWatcher) Start(ctx context.Context, log daemonLogger) {
 				}
 
 				// Handle git ref changes (only events under gitRefsPath)
-				if event.Op&fsnotify.Write != 0 && strings.HasPrefix(event.Name, fw.gitRefsPath) {
+				// Fix: check gitRefsPath is not empty, otherwise HasPrefix("any", "") is always true
+				if fw.gitRefsPath != "" && event.Op&fsnotify.Write != 0 && strings.HasPrefix(event.Name, fw.gitRefsPath) {
 					if fw.shouldLogGitRefChange() {
 						log.log("Git ref change detected: %s", event.Name)
 					}


### PR DESCRIPTION
When gitRefsPath is empty (not in a git repo), strings.HasPrefix(path, "") always returns true, causing every file write in .beads/ directory (including daemon.log) to trigger debouncer and create an event storm.

This fix adds a check to ensure gitRefsPath is not empty before the HasPrefix comparison.

Fixes the issue where daemon.log grows rapidly (17MB+) due to the self-triggering loop: write log -> detect change -> write log -> ...