### PR TITLE
fix(doctor): detect missing git repo and improve daemon startup message

### DIFF
--- a/cmd/bd/daemon_autostart.go
+++ b/cmd/bd/daemon_autostart.go
@@ -310,6 +310,14 @@ func determineSocketPath(socketPath string) string {
 }
 
 func startDaemonProcess(socketPath string) bool {
+	// Early check: daemon requires a git repository (unless --local mode)
+	// Skip attempting to start and avoid the 5-second wait if not in git repo
+	if !isGitRepo() {
+		debugLog("not in a git repository, skipping daemon start")
+		fmt.Fprintf(os.Stderr, "%s No git repository initialized - running without background sync\n", ui.RenderMuted("Note:"))
+		return false
+	}
+
 	binPath, err := executableFn()
 	if err != nil {
 		binPath = os.Args[0]

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -349,7 +349,12 @@ func runDiagnostics(path string) doctorResult {
 		result.OverallOK = false
 	}
 
-	// Check 8: Daemon health
+	// Check 8a: Git sync setup (informational - explains why daemon might not start)
+	gitSyncCheck := convertWithCategory(doctor.CheckGitSyncSetup(path), doctor.CategoryRuntime)
+	result.Checks = append(result.Checks, gitSyncCheck)
+	// Don't fail overall check for git sync warning - beads works fine without git
+
+	// Check 8b: Daemon health
 	daemonCheck := convertWithCategory(doctor.CheckDaemonStatus(path, Version), doctor.CategoryRuntime)
 	result.Checks = append(result.Checks, daemonCheck)
 	if daemonCheck.Status == statusWarning || daemonCheck.Status == statusError {

--- a/cmd/bd/doctor/daemon_test.go
+++ b/cmd/bd/doctor/daemon_test.go
@@ -2,8 +2,11 @@ package doctor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/git"
 )
 
 func TestCheckDaemonStatus(t *testing.T) {
@@ -30,6 +33,74 @@ func TestCheckDaemonStatus(t *testing.T) {
 		// Should check daemon status - may be OK or warning depending on daemon state
 		if check.Name != "Daemon Health" {
 			t.Errorf("Name = %q, want %q", check.Name, "Daemon Health")
+		}
+	})
+}
+
+func TestCheckGitSyncSetup(t *testing.T) {
+	t.Run("not in git repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		oldDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(oldDir)
+			git.ResetCaches()
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		git.ResetCaches()
+
+		check := CheckGitSyncSetup(tmpDir)
+
+		if check.Status != StatusWarning {
+			t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+		}
+		if check.Name != "Git Sync Setup" {
+			t.Errorf("Name = %q, want %q", check.Name, "Git Sync Setup")
+		}
+		if check.Fix == "" {
+			t.Error("Expected Fix to contain instructions")
+		}
+	})
+
+	t.Run("in git repository without sync-branch", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		oldDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(oldDir)
+			git.ResetCaches()
+		}()
+
+		// Initialize git repo
+		cmd := exec.Command("git", "init")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to init git repo: %v", err)
+		}
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		git.ResetCaches()
+
+		check := CheckGitSyncSetup(tmpDir)
+
+		if check.Status != StatusOK {
+			t.Errorf("Status = %q, want %q", check.Status, StatusOK)
+		}
+		if check.Name != "Git Sync Setup" {
+			t.Errorf("Name = %q, want %q", check.Name, "Git Sync Setup")
+		}
+		// Should mention sync-branch not configured
+		if check.Detail == "" {
+			t.Error("Expected Detail to contain sync-branch hint")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fix confusing `"Daemon took too long to start"` message when running `bd` commands in a directory without a git repository.

**Problem:** When not in a git repo, the daemon would try to start, wait 5 seconds for the socket, then show a misleading timeout warning. `bd doctor` also didn't detect or explain this situation.

**Solution:**
- Early detection of missing git repo in daemon startup - shows clear message immediately without waiting
- New `bd doctor` check "Git Sync Setup" that explains the three possible states

## NEW Doctor Output

**No git repository:**
⚠ Git Sync Setup: No git repository (background sync unavailable)
└─ Fix: Run 'git init' to enable background sync

**Git repo, no sync-branch:**
✓ Git Sync Setup: Git repository detected (sync-branch not configured)
└─ Hint: Run 'bd config set sync.branch beads-sync' for team collaboration

**Git repo + sync-branch:**
✓ Git Sync Setup: Git repository and sync-branch configured

## Test Plan

- [x] `go test ./cmd/bd/...` - All tests pass
- [x] `go build ./cmd/bd/...` - Builds successfully