### PR TITLE
fix: bd ready now shows in_progress issues

### DIFF
--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -1610,7 +1610,7 @@ func (s *Server) handleReady(req *Request) Response {
 	}
 
 	wf := types.WorkFilter{
-		Status:          types.StatusOpen,
+		// Leave Status empty to get both 'open' and 'in_progress' (GH#5aml)
 		Type:            readyArgs.Type,
 		Priority:        readyArgs.Priority,
 		Unassigned:      readyArgs.Unassigned,


### PR DESCRIPTION
## Fix: bd ready now shows in_progress issues

The help text and code comments clearly indicate `bd ready` should show both 'open' and 'in_progress' issues, but it was only showing 'open' ones when using the daemon (default mode).

### Root Cause

Bug introduced in PR #847 (commit d371baf): The RPC layer's `handleReady()` hardcoded `Status: types.StatusOpen` instead of leaving it empty.

### Intended Behavior

The intended behavior is to show both open and in_progress:

  1. Help text: "Show ready work (no blockers, open or in_progress)" [cmd/bd/ready.go:20]
  2. CLI comment: "Leave Status empty to get both 'open' and 'in_progress'" [cmd/bd/ready.go:70]
  3. Storage docs: "By default, shows both 'open' and 'in_progress' issues" [internal/storage/sqlite/ready.go:15]
  4. Storage impl correctly handles empty Status → both statuses [internal/storage/sqlite/ready.go:26-27]

### The Fix

Removed the Status field assignment in `internal/rpc/server_issues_epics.go:1613` so it remains empty (zero value), allowing the storage layer to correctly return both statuses.

### Testing
  - All existing tests pass
  - Verified `bd ready` now shows in_progress issues

## Local testing

```shell

## binary versions built - prior system and local copy
$ bd --version
bd version 0.43.0 (76359764)
$ bd-fixed --version
bd version 0.43.0 (dab2502e)

## create a new bug repo with upstream bd
$ cd /tmp && rm -rf bd-test && mkdir bd-test && cd bd-test
$ bd init --prefix test  # system
Warning: could not compute repository ID: not a git repository
Warning: could not compute clone ID: not a git repository: exit status 128
  ✓ Created AGENTS.md with landing-the-plane instructions
  ✓ bd initialized successfully!

  Database: .beads/beads.db
  Issue prefix: test
  Issues will be named: test-<hash> (e.g., test-a3f2dd)

....

## create a task, defaults to open, in ready
$ bd create "Fix validation test" -t task -p 1 -d "Testing in_progress shows in ready" 
Warning: Daemon took too long to start (>5s). Running in direct mode.
  Hint: Run 'bd doctor' to diagnose daemon issues
✓ Created issue: test-enr
  Title: Fix validation test
  Priority: P1
  Status: open


## start upstream bd daemon
$ bd daemon --start --local  # system bd
Starting bd daemon in LOCAL mode (interval: 5s, no git sync)
Daemon started (PID 38891)

## show ready using upstream bd deamon
$ bd ready 

📋 Ready work (1 issues with no blockers):

1. [P1] [task] test-enr: Fix validation test

## mark issue in_progress, confirm it is not visible

$ bd update test-enr --status in_progress
✓ Updated issue: test-enr
$ bd ready 

✨ No ready work found (all issues have blocking dependencies)

## stop upstream bd daemon, start local version

$ bd daemon --stop   # stop system daemon
Stopping daemon (PID 38891)...
Daemon stopped
$ bd-fixed daemon --start --local  # start fixed daemon
Starting bd daemon in LOCAL mode (interval: 5s, no git sync)
Daemon started (PID 39703)

## query daemon with both system and fixed copy (both should show our in_progress issue)

$ bd ready

📋 Ready work (1 issues with no blockers):

1. [P1] [task] test-enr: Fix validation test

$ bd-fixed ready

📋 Ready work (1 issues with no blockers):

1. [P1] [task] test-enr: Fix validation test
```
