### PR TITLE
fix(show): display external_ref field in text output

### DIFF
--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -231,6 +231,9 @@ var showCmd = &cobra.Command{
 					if issue.DeferUntil != nil {
 						fmt.Printf("Deferred until: %s\n", issue.DeferUntil.Format("2006-01-02 15:04"))
 					}
+					if issue.ExternalRef != nil && *issue.ExternalRef != "" {
+						fmt.Printf("External Ref: %s\n", *issue.ExternalRef)
+					}
 
 					// Show compaction status
 					if issue.CompactionLevel > 0 {
@@ -456,6 +459,9 @@ var showCmd = &cobra.Command{
 			}
 			if issue.DeferUntil != nil {
 				fmt.Printf("Deferred until: %s\n", issue.DeferUntil.Format("2006-01-02 15:04"))
+			}
+			if issue.ExternalRef != nil && *issue.ExternalRef != "" {
+				fmt.Printf("External Ref: %s\n", *issue.ExternalRef)
 			}
 
 			// Show compaction status footer

--- a/cmd/bd/show_test.go
+++ b/cmd/bd/show_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShow_ExternalRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI test in short mode")
+	}
+
+	// Build bd binary
+	tmpBin := filepath.Join(t.TempDir(), "bd")
+	buildCmd := exec.Command("go", "build", "-o", tmpBin, "./")
+	buildCmd.Dir = "."
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build bd: %v\n%s", err, out)
+	}
+
+	// Create temp directory for test database
+	tmpDir := t.TempDir()
+
+	// Initialize beads
+	initCmd := exec.Command(tmpBin, "init", "--prefix", "test", "--quiet")
+	initCmd.Dir = tmpDir
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+
+	// Create issue with external ref
+	createCmd := exec.Command(tmpBin, "--no-daemon", "create", "External ref test", "-p", "1",
+		"--external-ref", "https://example.com/spec.md", "--json")
+	createCmd.Dir = tmpDir
+	createOut, err := createCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("create failed: %v\n%s", err, createOut)
+	}
+
+	var issue map[string]interface{}
+	if err := json.Unmarshal(createOut, &issue); err != nil {
+		t.Fatalf("failed to parse create output: %v, output: %s", err, createOut)
+	}
+	id := issue["id"].(string)
+
+	// Show the issue and verify external ref is displayed
+	showCmd := exec.Command(tmpBin, "--no-daemon", "show", id)
+	showCmd.Dir = tmpDir
+	showOut, err := showCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("show failed: %v\n%s", err, showOut)
+	}
+
+	out := string(showOut)
+	if !strings.Contains(out, "External Ref:") {
+		t.Errorf("expected 'External Ref:' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "https://example.com/spec.md") {
+		t.Errorf("expected external ref URL in output, got: %s", out)
+	}
+}
+
+func TestShow_NoExternalRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping CLI test in short mode")
+	}
+
+	// Build bd binary
+	tmpBin := filepath.Join(t.TempDir(), "bd")
+	buildCmd := exec.Command("go", "build", "-o", tmpBin, "./")
+	buildCmd.Dir = "."
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build bd: %v\n%s", err, out)
+	}
+
+	tmpDir := t.TempDir()
+
+	// Initialize beads
+	initCmd := exec.Command(tmpBin, "init", "--prefix", "test", "--quiet")
+	initCmd.Dir = tmpDir
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("init failed: %v\n%s", err, out)
+	}
+
+	// Create issue WITHOUT external ref
+	createCmd := exec.Command(tmpBin, "--no-daemon", "create", "No ref test", "-p", "1", "--json")
+	createCmd.Dir = tmpDir
+	createOut, err := createCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("create failed: %v\n%s", err, createOut)
+	}
+
+	var issue map[string]interface{}
+	if err := json.Unmarshal(createOut, &issue); err != nil {
+		t.Fatalf("failed to parse create output: %v, output: %s", err, createOut)
+	}
+	id := issue["id"].(string)
+
+	// Show the issue - should NOT contain External Ref line
+	showCmd := exec.Command(tmpBin, "--no-daemon", "show", id)
+	showCmd.Dir = tmpDir
+	showOut, err := showCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("show failed: %v\n%s", err, showOut)
+	}
+
+	out := string(showOut)
+	if strings.Contains(out, "External Ref:") {
+		t.Errorf("expected no 'External Ref:' line for issue without external ref, got: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Display `external_ref` in `bd show` text output. The field was stored correctly (and visible in `--json`) but missing from the human-readable display.

## Example

```bash
$ bd show beads-xyz
...
Defer Until: (not set)
External Ref: https://github.com/org/repo/blob/main/specs/feature.md
```

## Changes

- `cmd/bd/show.go`: Added `External Ref` display in both daemon and direct mode paths (+6 lines)
- `cmd/bd/show_test.go`: Added tests for external_ref display (+114 lines)

## Test Plan

- [x] `go build ./cmd/bd` - compiles clean
- [x] `go test ./cmd/bd/...` - all tests pass
- [x] `go test -race ./cmd/bd/...` - race detector clean
- [x] `TestShow_ExternalRef` - verifies external ref is displayed
- [x] `TestShow_NoExternalRef` - verifies no line when field is empty