### PR TITLE
fix(doctor): query metadata table instead of config for last_import_time

### DIFF
--- a/cmd/bd/doctor/sync_divergence.go
+++ b/cmd/bd/doctor/sync_divergence.go
@@ -180,7 +180,7 @@ func checkSQLiteMtimeDivergence(path, beadsDir string) *SyncDivergenceIssue {
 	defer db.Close()
 
 	var lastImportTimeStr string
-	err = db.QueryRow("SELECT value FROM config WHERE key = 'last_import_time'").Scan(&lastImportTimeStr)
+	err = db.QueryRow("SELECT value FROM metadata WHERE key = 'last_import_time'").Scan(&lastImportTimeStr)
 	if err != nil {
 		// No last_import_time recorded - this is a potential issue
 		return &SyncDivergenceIssue{


### PR DESCRIPTION
## Problem

`bd doctor` reports "No last_import_time recorded in database (may need sync)" even when the value exists, because it queries the wrong table.

```sql
-- Doctor was querying:
SELECT value FROM config WHERE key = 'last_import_time'

-- But sync writes to:
SELECT value FROM metadata WHERE key = 'last_import_time'
```

## Impact

Low severity - cosmetic only. Sync works correctly, data integrity unaffected. Causes user confusion with spurious warnings.

## Fix

Changed `sync_divergence.go:183` to query `metadata` table instead of `config`.

## Verification

- Added regression test that creates both tables and stores value only in `metadata`
- All existing tests updated and passing
- `bd doctor` no longer shows spurious warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)