### PR TITLE
fix(worktree): resolve worktrees by name from git registry

### DIFF
--- a/cmd/bd/worktree_test.go
+++ b/cmd/bd/worktree_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
@@ -62,4 +65,104 @@ func TestGitRevParse(t *testing.T) {
 		// Not in a git repo or error
 		t.Logf("Not in git repo or error")
 	}
+}
+
+// TestResolveWorktreePathByName verifies that resolveWorktreePath can find
+// worktrees by name (basename) when they're in subdirectories like .worktrees/
+func TestResolveWorktreePathByName(t *testing.T) {
+	// Create a temp directory for the main repo
+	mainDir := t.TempDir()
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init", "--initial-branch=main")
+	cmd.Dir = mainDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to init git repo: %v\n%s", err, output)
+	}
+
+	// Configure git user
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = mainDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = mainDir
+	_ = cmd.Run()
+
+	// Create initial commit (required for worktrees)
+	if err := os.WriteFile(filepath.Join(mainDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = mainDir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = mainDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to create initial commit: %v\n%s", err, output)
+	}
+
+	// Create .worktrees subdirectory
+	worktreesDir := filepath.Join(mainDir, ".worktrees")
+	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
+		t.Fatalf("Failed to create .worktrees dir: %v", err)
+	}
+
+	// Create a worktree inside .worktrees/
+	worktreePath := filepath.Join(worktreesDir, "test-wt")
+	cmd = exec.Command("git", "worktree", "add", "-b", "test-wt", worktreePath)
+	cmd.Dir = mainDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to create worktree: %v\n%s", err, output)
+	}
+	defer func() {
+		// Cleanup worktree
+		cmd := exec.Command("git", "worktree", "remove", worktreePath, "--force")
+		cmd.Dir = mainDir
+		_ = cmd.Run()
+	}()
+
+	t.Run("resolves by name when worktree is in subdirectory", func(t *testing.T) {
+		// This should find the worktree by consulting git's registry
+		resolved, err := resolveWorktreePath(mainDir, "test-wt")
+		if err != nil {
+			t.Errorf("resolveWorktreePath(repoRoot, \"test-wt\") failed: %v", err)
+			return
+		}
+		// Compare resolved paths to handle symlinks (e.g., /var -> /private/var on macOS)
+		wantResolved, _ := filepath.EvalSymlinks(worktreePath)
+		gotResolved, _ := filepath.EvalSymlinks(resolved)
+		if gotResolved != wantResolved {
+			t.Errorf("resolveWorktreePath returned %q, want %q", resolved, worktreePath)
+		}
+	})
+
+	t.Run("resolves by relative path", func(t *testing.T) {
+		// This should work via the existing relative-to-repo-root logic
+		resolved, err := resolveWorktreePath(mainDir, ".worktrees/test-wt")
+		if err != nil {
+			t.Errorf("resolveWorktreePath(repoRoot, \".worktrees/test-wt\") failed: %v", err)
+			return
+		}
+		if resolved != worktreePath {
+			t.Errorf("resolveWorktreePath returned %q, want %q", resolved, worktreePath)
+		}
+	})
+
+	t.Run("resolves by absolute path", func(t *testing.T) {
+		resolved, err := resolveWorktreePath(mainDir, worktreePath)
+		if err != nil {
+			t.Errorf("resolveWorktreePath(repoRoot, absolutePath) failed: %v", err)
+			return
+		}
+		if resolved != worktreePath {
+			t.Errorf("resolveWorktreePath returned %q, want %q", resolved, worktreePath)
+		}
+	})
+
+	t.Run("returns error for non-existent worktree", func(t *testing.T) {
+		_, err := resolveWorktreePath(mainDir, "non-existent")
+		if err == nil {
+			t.Error("resolveWorktreePath should return error for non-existent worktree")
+		}
+	})
 }


### PR DESCRIPTION
## Problem

`bd worktree remove <name>` fails with "worktree not found" even when the worktree exists in `bd worktree list` and on the filesystem. This occurs because `resolveWorktreePath()` only checks filesystem paths (absolute, relative to cwd, relative to repo root) but never consults git's worktree registry.

This is particularly problematic for worktrees created in subdirectories (e.g., `.worktrees/foo` or `../agents/worker-1`) where the name shown in `bd worktree list` doesn't match a simple path lookup.

## Impact

Users cannot remove worktrees by the name displayed in `bd worktree list`. They must know and provide the full filesystem path, creating a UX mismatch between list and remove commands.

## Resolution

Updated `resolveWorktreePath()` to consult `git worktree list --porcelain` as a fallback when filesystem lookups fail. The function now matches worktrees by:
- Name (basename of path)
- Full path from git registry

This makes `bd worktree remove` consistent with how `bd worktree list` discovers worktrees.

## Verification

- Added unit test `TestResolveWorktreePathByName` covering:
  - Resolution by name when worktree is in subdirectory
  - Resolution by relative path
  - Resolution by absolute path
  - Error for non-existent worktree
- Manual verification in cloud-hira repo with worktrees in `.worktrees/` subdirectory
- All existing tests pass

Fixes: bd-w7gc

🤖 Generated with [Claude Code](https://claude.com/claude-code)