### PR TITLE
Add Parade app to community tools list

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -32,6 +32,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[Beadster](https://github.com/beadster/beadster)** - macOS app for browsing and managing issues from `.beads/` directories in git repositories. Built by [@podviaznikov](https://github.com/podviaznikov). (Swift)
 
+-  **[Parade](https://github.com/JeremyKalmus/parade)** - Electron app for workflow orchestration with visual Kanban board, discovery wizard, and task visualization. Run with `npx parade-init`. Built by [@JeremyKalmus](https://github.com/JeremyKalmus). (Electron/React)
+
 ## Historical / Stale
 
 - **[beady](https://github.com/maphew/beady)** - Early prototype effort, now stale. Built by [@maphew](https://github.com/maphew). (Go)


### PR DESCRIPTION
Hi Steve,

Adding Parade to the community tools list.

**What it is:**
Parade is a workflow wrapper built on top of Beads that adds:
- Discovery phase with SME sub-agents (technical, domain, UI/UX, codebase context) to generate detailed specs before coding starts
- Persistent spec/task storage so work survives session loss and network issues
- Swimlane visualization (Electron app) showing task status across batches in real-time
- Self-improving loop that documents new patterns and feeds them back into future discovery

**Why I built it:**
I'm a non-technical user who got deep into Claude Code. Beads solved task tracking brilliantly, but I needed visibility into what sub-agents were doing, persistence when sessions crashed, and a discovery layer to help me write better specs. Parade wraps Beads to add those pieces.

**Links:**
- npm: https://www.npmjs.com/package/parade-init
- GitHub: https://github.com/JeremyKalmus/parade

Thanks for building Beads—it's the foundation that made this possible.