### PR TITLE
Add bun installation method to INSTALLING.md

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -61,6 +61,7 @@ The installer will:
 |--------|----------|---------|---------------|-------|
 | **Homebrew** | macOS/Linux users | `brew upgrade bd` | Homebrew | Recommended. Handles everything automatically |
 | **npm** | JS/Node.js projects | `npm update -g @beads/bd` | Node.js | Convenient if npm is your ecosystem |
+| **bun** | JS/Bun.js projects | `bun install -g --trust @beads/bd` | Bun.js | Convenient if bun is your ecosystem |
 | **Install script** | Quick setup, CI/CD | Re-run script | curl, bash | Good for automation and one-liners |
 | **go install** | Go developers | Re-run command | Go 1.24+ | Builds from source, always latest |
 | **From source** | Contributors, custom builds | `git pull && go build` | Go, git | Full control, can modify code |


### PR DESCRIPTION
my AI agent was struggling trying to install it with bun because of how [trustedDependencies](https://bun.com/docs/pm/lifecycle#trusteddependencies) in Bun work