### PR TITLE
refactor(test): replace testify with stdlib in daemon tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/olebedev/when v1.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
-	github.com/stretchr/testify v1.11.1
 	github.com/tetratelabs/wazero v1.11.0
 	golang.org/x/mod v0.31.0
 	golang.org/x/sys v0.39.0
@@ -37,7 +36,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
@@ -53,7 +51,6 @@ require (
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect


### PR DESCRIPTION
## Summary

Converts daemon socket tests from testify/assert to standard library testing.

This addresses the review feedback from #914 — Steve requested stdlib style for consistency with the rest of the codebase.

## Changes

- Replace `assert.Equal(t, ...)` with `if got != want { t.Errorf(...) }`
- Replace `assert.Contains(t, ...)` with `if !strings.Contains(...) { t.Errorf(...) }`
- Remove `github.com/stretchr/testify` from go.mod (and associated indirects)

## Test Plan

- [x] `go test -v ./cmd/bd -run TestSocket` — All pass
- [x] `go test -v ./cmd/bd -run TestDaemonSocket` — All pass