### PR TITLE
feat(linear): add project_id filter for sync

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -26,6 +26,7 @@ var linearCmd = &cobra.Command{
 Configuration:
   bd config set linear.api_key "YOUR_API_KEY"
   bd config set linear.team_id "TEAM_ID"
+  bd config set linear.project_id "PROJECT_ID"  # Optional: sync only this project
 
 Environment variables (alternative to config):
   LINEAR_API_KEY - Linear API key
@@ -585,6 +586,10 @@ func getLinearClient(ctx context.Context) (*linear.Client, error) {
 	if store != nil {
 		if endpoint, _ := store.GetConfig(ctx, "linear.api_endpoint"); endpoint != "" {
 			client = client.WithEndpoint(endpoint)
+		}
+		// Filter to specific project if configured
+		if projectID, _ := store.GetConfig(ctx, "linear.project_id"); projectID != "" {
+			client = client.WithProjectID(projectID)
 		}
 	}
 

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -32,6 +32,7 @@ const (
 type Client struct {
 	APIKey     string
 	TeamID     string
+	ProjectID  string // Optional: filter issues to a specific project
 	Endpoint   string // GraphQL endpoint URL (defaults to DefaultAPIEndpoint)
 	HTTPClient *http.Client
 }


### PR DESCRIPTION
## Summary

When `linear.project_id` is configured, `bd linear sync` will only fetch issues belonging to that project instead of all team issues.

## Changes

- Add `ProjectID` field to `Client` struct in `internal/linear/types.go`
- Add `WithProjectID` method for fluent configuration in `internal/linear/client.go`
- Update `FetchIssues` and `FetchIssuesSince` to filter by project when `ProjectID` is set
- Read `linear.project_id` config in `getLinearClient` in `cmd/bd/linear.go`
- Document `project_id` in help text

## Usage

```bash
# Configure project filter (optional)
bd config set linear.project_id "PROJECT_UUID_OR_SLUG"

# Sync only issues from that project
bd linear sync --pull
```

## Test Plan

- [x] `go build ./...` passes
- [x] `go test -short ./internal/linear/... ./cmd/bd/...` passes
- [ ] Manual test with real Linear project

Closes #937