### PR TITLE
fix(prime): use flush-only workflow when no git remote configured

### DIFF
--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -12,6 +12,7 @@ func TestOutputContextFunction(t *testing.T) {
 		mcpMode       bool
 		stealthMode   bool
 		ephemeralMode bool
+		localOnlyMode bool
 		expectText    []string
 		rejectText    []string
 	}{
@@ -20,6 +21,7 @@ func TestOutputContextFunction(t *testing.T) {
 			mcpMode:       false,
 			stealthMode:   false,
 			ephemeralMode: false,
+			localOnlyMode: false,
 			expectText:    []string{"Beads Workflow Context", "bd sync", "git push"},
 			rejectText:    []string{"bd sync --flush-only", "--from-main"},
 		},
@@ -28,6 +30,7 @@ func TestOutputContextFunction(t *testing.T) {
 			mcpMode:       false,
 			stealthMode:   false,
 			ephemeralMode: true,
+			localOnlyMode: false,
 			expectText:    []string{"Beads Workflow Context", "bd sync --from-main", "ephemeral branch"},
 			rejectText:    []string{"bd sync --flush-only", "git push"},
 		},
@@ -36,14 +39,43 @@ func TestOutputContextFunction(t *testing.T) {
 			mcpMode:       false,
 			stealthMode:   true,
 			ephemeralMode: false, // stealth mode overrides ephemeral detection
+			localOnlyMode: false,
 			expectText:    []string{"Beads Workflow Context", "bd sync --flush-only"},
 			rejectText:    []string{"git push", "git pull", "git commit", "git status", "git add"},
+		},
+		{
+			name:          "CLI Local-only (no git remote)",
+			mcpMode:       false,
+			stealthMode:   false,
+			ephemeralMode: false,
+			localOnlyMode: true,
+			expectText:    []string{"Beads Workflow Context", "bd sync --flush-only", "No git remote configured"},
+			rejectText:    []string{"git push", "git pull", "--from-main"},
+		},
+		{
+			name:          "CLI Local-only overrides ephemeral",
+			mcpMode:       false,
+			stealthMode:   false,
+			ephemeralMode: true, // ephemeral is true but local-only takes precedence
+			localOnlyMode: true,
+			expectText:    []string{"Beads Workflow Context", "bd sync --flush-only", "No git remote configured"},
+			rejectText:    []string{"git push", "--from-main", "ephemeral branch"},
+		},
+		{
+			name:          "CLI Stealth overrides local-only",
+			mcpMode:       false,
+			stealthMode:   true,
+			ephemeralMode: false,
+			localOnlyMode: true, // local-only is true but stealth takes precedence
+			expectText:    []string{"Beads Workflow Context", "bd sync --flush-only"},
+			rejectText:    []string{"git push", "git pull", "git commit", "git status", "git add", "No git remote configured"},
 		},
 		{
 			name:          "MCP Normal (non-ephemeral)",
 			mcpMode:       true,
 			stealthMode:   false,
 			ephemeralMode: false,
+			localOnlyMode: false,
 			expectText:    []string{"Beads Issue Tracker Active", "bd sync", "git push"},
 			rejectText:    []string{"bd sync --flush-only", "--from-main"},
 		},
@@ -52,6 +84,7 @@ func TestOutputContextFunction(t *testing.T) {
 			mcpMode:       true,
 			stealthMode:   false,
 			ephemeralMode: true,
+			localOnlyMode: false,
 			expectText:    []string{"Beads Issue Tracker Active", "bd sync --from-main", "ephemeral branch"},
 			rejectText:    []string{"bd sync --flush-only", "git push"},
 		},
@@ -60,6 +93,34 @@ func TestOutputContextFunction(t *testing.T) {
 			mcpMode:       true,
 			stealthMode:   true,
 			ephemeralMode: false, // stealth mode overrides ephemeral detection
+			localOnlyMode: false,
+			expectText:    []string{"Beads Issue Tracker Active", "bd sync --flush-only"},
+			rejectText:    []string{"git push", "git pull", "git commit", "git status", "git add"},
+		},
+		{
+			name:          "MCP Local-only (no git remote)",
+			mcpMode:       true,
+			stealthMode:   false,
+			ephemeralMode: false,
+			localOnlyMode: true,
+			expectText:    []string{"Beads Issue Tracker Active", "bd sync --flush-only"},
+			rejectText:    []string{"git push", "git pull", "--from-main"},
+		},
+		{
+			name:          "MCP Local-only overrides ephemeral",
+			mcpMode:       true,
+			stealthMode:   false,
+			ephemeralMode: true, // ephemeral is true but local-only takes precedence
+			localOnlyMode: true,
+			expectText:    []string{"Beads Issue Tracker Active", "bd sync --flush-only"},
+			rejectText:    []string{"git push", "--from-main", "ephemeral branch"},
+		},
+		{
+			name:          "MCP Stealth overrides local-only",
+			mcpMode:       true,
+			stealthMode:   true,
+			ephemeralMode: false,
+			localOnlyMode: true, // local-only is true but stealth takes precedence
 			expectText:    []string{"Beads Issue Tracker Active", "bd sync --flush-only"},
 			rejectText:    []string{"git push", "git pull", "git commit", "git status", "git add"},
 		},
@@ -68,7 +129,8 @@ func TestOutputContextFunction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer stubIsEphemeralBranch(tt.ephemeralMode)()
-			defer stubIsDaemonAutoSyncing(false)() // Default: no auto-sync in tests
+			defer stubIsDaemonAutoSyncing(false)()             // Default: no auto-sync in tests
+			defer stubPrimeHasGitRemote(!tt.localOnlyMode)() // localOnly = !primeHasGitRemote
 
 			var buf bytes.Buffer
 			err := outputPrimeContext(&buf, tt.mcpMode, tt.stealthMode)
@@ -119,5 +181,22 @@ func stubIsDaemonAutoSyncing(isAutoSync bool) func() {
 	}
 	return func() {
 		isDaemonAutoSyncing = original
+	}
+}
+
+// stubPrimeHasGitRemote temporarily replaces primeHasGitRemote
+// with a stub returning returnValue.
+//
+// Returns a function to restore the original primeHasGitRemote.
+// Usage:
+//
+//	defer stubPrimeHasGitRemote(true)()
+func stubPrimeHasGitRemote(hasRemote bool) func() {
+	original := primeHasGitRemote
+	primeHasGitRemote = func() bool {
+		return hasRemote
+	}
+	return func() {
+		primeHasGitRemote = original
 	}
 }


### PR DESCRIPTION
When no git remote is configured, prime now outputs the flush-only workflow (like stealth mode) instead of suggesting git push operations. This prevents confusing instructions like `bd sync` when git is not initialized or has no remote configured.

- Added primeHasGitRemote() to detect remote configuration
- localOnly mode uses --flush-only and shows "No git remote" note
- Precedence: stealth > localOnly > ephemeral
- Added comprehensive tests for all mode combinations