### PR TITLE
fix(sync): validate custom types in batch issue creation

### DIFF
--- a/internal/storage/sqlite/batch_ops.go
+++ b/internal/storage/sqlite/batch_ops.go
@@ -16,13 +16,6 @@ func validateBatchIssues(issues []*types.Issue) error {
 	return validateBatchIssuesWithCustom(issues, nil, nil)
 }
 
-// validateBatchIssuesWithCustomStatuses validates all issues in a batch,
-// allowing custom statuses in addition to built-in ones.
-// Deprecated: Use validateBatchIssuesWithCustom instead.
-func validateBatchIssuesWithCustomStatuses(issues []*types.Issue, customStatuses []string) error {
-	return validateBatchIssuesWithCustom(issues, customStatuses, nil)
-}
-
 // validateBatchIssuesWithCustom validates all issues in a batch,
 // allowing custom statuses and types in addition to built-in ones.
 func validateBatchIssuesWithCustom(issues []*types.Issue, customStatuses, customTypes []string) error {


### PR DESCRIPTION
Fix validation in CreateIssuesWithFullOptions to check custom types
from config. Previously only validated custom statuses, causing sync
to fail when JSONL contained issues with types removed from core
(agent, role, rig, convoy, slot).

Changes:
- Fetch customTypes via GetCustomTypes() in CreateIssuesWithFullOptions
- Call validateBatchIssuesWithCustom() instead of deprecated
  validateBatchIssuesWithCustomStatuses()
- Update config to register removed Gas Town types as custom

Fixes sync errors like:
  "validation failed for issue 119: invalid issue type: agent"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>