### PR TITLE
fix(install): stop existing daemons before binary replacement

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,6 +109,25 @@ detect_platform() {
     echo "${os}_${arch}"
 }
 
+# Stop existing daemons before upgrade (safe for fresh installs)
+stop_existing_daemons() {
+    # Skip if bd isn't installed (fresh install)
+    if ! command -v bd &> /dev/null; then
+        return 0
+    fi
+
+    log_info "Stopping existing bd daemons before upgrade..."
+
+    # Try graceful shutdown via bd daemons killall
+    if bd daemons killall 2>/dev/null; then
+        log_success "Stopped existing daemons"
+    else
+        log_warning "No daemons running or failed to stop (continuing anyway)"
+    fi
+
+    return 0
+}
+
 # Download and install from GitHub releases
 install_from_release() {
     log_info "Installing bd from GitHub releases..."
@@ -448,6 +467,9 @@ main() {
     local platform
     platform=$(detect_platform)
     log_info "Platform: $platform"
+
+    # Stop any running daemons before replacing binary
+    stop_existing_daemons
 
     # Try downloading from GitHub releases first
     if install_from_release "$platform"; then


### PR DESCRIPTION
## Summary

Stop existing bd daemons before binary replacement during upgrades.

## Problem

When using `install.sh` to upgrade bd, running daemons may still be using the old binary. Replacing the binary mid-execution can cause undefined behavior, especially with multiple repos each running their own daemon (all sharing `/usr/local/bin/bd`).

## Solution

Add a `stop_existing_daemons()` function that:

1. **Checks if bd is installed** - Skips entirely on fresh installs (no bd to call)
2. **Calls `bd daemons killall`** - Gracefully stops all running daemons system-wide
3. **Uses non-fatal error handling** - Warnings only, doesn't block installation

## Changes

- Add `stop_existing_daemons()` function (lines 112-129)
- Call it in `main()` after platform detection, before any install method (line 472)

## Testing

| Scenario | Expected Behavior |
|----------|-------------------|
| Fresh install | Function skips (no bd available) |
| Upgrade with daemon running | Stops daemon, then installs |
| Upgrade with no daemon | Proceeds without error |

## Notes

- Daemons auto-restart on next bd command after upgrade (existing behavior)
- This matches the recommendation in DAEMON.md: "Clean restart after major upgrades"
