### PR TITLE
fix(sync): force-add .beads in worktree for contributor mode

### DIFF
--- a/internal/syncbranch/worktree.go
+++ b/internal/syncbranch/worktree.go
@@ -726,7 +726,9 @@ func commitInWorktree(ctx context.Context, worktreePath, jsonlRelPath, message s
 	// Stage the entire .beads directory
 	beadsRelDir := filepath.Dir(jsonlRelPath)
 
-	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", beadsRelDir)
+	// Use -f (force) to add files even if they're gitignored
+	// In contributor mode, .beads/ is excluded in .git/info/exclude but needs to be tracked in sync branch
+	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", "-f", beadsRelDir)
 	if err := addCmd.Run(); err != nil {
 		return fmt.Errorf("git add failed in worktree: %w", err)
 	}


### PR DESCRIPTION
In contributor mode (bd init --contributor), .beads/ is excluded in .git/info/exclude to prevent committing upstream issue databases. However, this exclusion applies to ALL worktrees, including the sync worktree where .beads/ must be committed.

The fix adds -f flag to git add in commitInWorktree() to force-add files even when gitignored. This follows the existing pattern in beads where -f is used for worktree operations (git worktree add -f).

Fixes: bd sync failing with "git add failed in worktree: exit status 1"

🤖 Generated with [Claude Code](https://claude.com/claude-code)