### PR TITLE
fix(hooks): add --no-daemon to git hook sync commands

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -499,7 +499,8 @@ func runPreCommitHook() int {
 
 	// Flush pending changes to JSONL
 	// Use --flush-only to skip git operations (we're already in a git hook)
-	cmd := exec.Command("bd", "sync", "--flush-only")
+	// Use --no-daemon to ensure direct mode (inline import requires local store)
+	cmd := exec.Command("bd", "sync", "--flush-only", "--no-daemon")
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "Warning: Failed to flush bd changes to JSONL")
 		fmt.Fprintln(os.Stderr, "Run 'bd sync --flush-only' manually to diagnose")
@@ -572,7 +573,8 @@ func runPostMergeHook() int {
 	}
 
 	// Run bd sync --import-only --no-git-history
-	cmd := exec.Command("bd", "sync", "--import-only", "--no-git-history")
+	// Use --no-daemon to ensure direct mode (inline import requires local store)
+	cmd := exec.Command("bd", "sync", "--import-only", "--no-git-history", "--no-daemon")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Warning: Failed to sync bd changes after merge")
@@ -613,7 +615,8 @@ func runPrePushHook() int {
 	}
 
 	// Flush pending bd changes
-	flushCmd := exec.Command("bd", "sync", "--flush-only")
+	// Use --no-daemon to ensure direct mode (inline import requires local store)
+	flushCmd := exec.Command("bd", "sync", "--flush-only", "--no-daemon")
 	_ = flushCmd.Run() // Ignore errors
 
 	// Check for uncommitted JSONL changes
@@ -710,7 +713,8 @@ func runPostCheckoutHook(args []string) int {
 	}
 
 	// Run bd sync --import-only --no-git-history
-	cmd := exec.Command("bd", "sync", "--import-only", "--no-git-history")
+	// Use --no-daemon to ensure direct mode (inline import requires local store)
+	cmd := exec.Command("bd", "sync", "--import-only", "--no-git-history", "--no-daemon")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Warning: Failed to sync bd changes after checkout")


### PR DESCRIPTION
Git hooks (post-checkout, post-merge, pre-commit, pre-push) were calling 'bd sync' without --no-daemon flag. When the daemon was running, bd would connect to it instead of initializing the local store, causing importFromJSONLInline() to fail with "no database store available for inline import".

The inline import optimization requires a local store to be initialized. In daemon mode, only daemonClient is set and the local store variable remains nil.

Fix: Added --no-daemon flag to all bd sync calls in git hooks to ensure direct mode with local store initialization:
- runPreCommitHook: bd sync --flush-only --no-daemon
- runPostMergeHook: bd sync --import-only --no-git-history --no-daemon
- runPrePushHook: bd sync --flush-only --no-daemon
- runPostCheckoutHook: bd sync --import-only --no-git-history --no-daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)