### PR TITLE
docs: add lazybeads to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -12,6 +12,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[beads.el](https://codeberg.org/ctietze/beads.el)** - Emacs UI to browse, edit, and manage beads. Built by [@ctietze](https://codeberg.org/ctietze). (Elisp)
 
+- **[lazybeads](https://github.com/codegangsta/lazybeads)** - Lightweight terminal UI built with Bubble Tea for browsing and managing beads issues. Built by [@codegangsta](https://github.com/codegangsta). (Go)
+
 ## Web UIs
 
 - **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. Run with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni). (Node.js)


### PR DESCRIPTION
## Summary

- Add lazybeads to the Terminal UIs section of COMMUNITY_TOOLS.md
- lazybeads is a lightweight terminal UI built with Bubble Tea for browsing and managing beads issues

## Links

- Repository: https://github.com/codegangsta/lazybeads

🤖 Generated with [Claude Code](https://claude.com/claude-code)