### PR TITLE
feat(config): add status.non_blocking option for custom statuses

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -36,10 +36,25 @@ Custom Status States:
   This enables issues to use statuses like 'awaiting_review' in addition to
   the built-in statuses (open, in_progress, blocked, deferred, closed).
 
+Non-Blocking Statuses:
+  By default, open issues block their dependents. You can configure certain
+  statuses to be "non-blocking" - issues with these statuses will release
+  their dependents just like closed issues do.
+
+  This is useful for workflows where code review or testing doesn't need to
+  block downstream work.
+
+  Example:
+    bd config set status.non_blocking "in_review,awaiting_deploy"
+
+  With this config, when an issue is set to 'in_review', its dependent issues
+  will appear in 'bd ready' output.
+
 Examples:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
+  bd config set status.non_blocking "in_review"
   bd config get jira.url
   bd config list
   bd config unset jira.url`,


### PR DESCRIPTION
## Summary
- Add `status.non_blocking` config option that allows custom statuses to release dependent issues
- Issues with non_blocking statuses behave like `closed` for dependency resolution
- Enables workflows where code review or testing doesn't block downstream work

## Example Usage
```bash
bd config set status.custom "in_review"
bd config set status.non_blocking "in_review"

# When blocker is set to in_review, dependents appear in bd ready
bd update <blocker-id> --status in_review
bd ready  # dependent issues now shown
```

## Changes
- Add `NonBlockingStatusConfigKey` and `GetNonBlockingStatuses()` in `config.go`
- Update `rebuildBlockedCache()` to exclude non_blocking statuses from blockers
- Update `GetBlockedIssues()` to exclude non_blocking statuses from blockers
- Add SQL injection protection via `isValidStatusName()` validation
- Add 7 comprehensive tests for non_blocking functionality
- Update `bd config` help text with documentation

## Test plan
- [x] `TestNonBlockingStatusReleasesDependent` - basic functionality
- [x] `TestNonBlockingStatusWithParentChild` - transitive blocking
- [x] `TestMultipleNonBlockingStatuses` - multiple statuses
- [x] `TestEmptyNonBlockingConfig` - default behavior
- [x] `TestNonBlockingStatusWithGetBlockedIssues` - GetBlockedIssues integration
- [x] `TestNonBlockingStatusWithGetReadyWork` - GetReadyWork integration
- [x] Manual testing with `bd ready` command