### PR TITLE
Add git user.name to actor fallback chain

### DIFF
--- a/cmd/bd/actor_test.go
+++ b/cmd/bd/actor_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestGetActorWithGit tests the actor resolution fallback chain.
+// Priority: --actor flag > BD_ACTOR env > BEADS_ACTOR env > git config user.name > $USER > "unknown"
+func TestGetActorWithGit(t *testing.T) {
+	// Save original environment and actor variable
+	origActor := actor
+	origBdActor, bdActorSet := os.LookupEnv("BD_ACTOR")
+	origBeadsActor, beadsActorSet := os.LookupEnv("BEADS_ACTOR")
+	origUser, userSet := os.LookupEnv("USER")
+
+	// Cleanup after test
+	defer func() {
+		actor = origActor
+		if bdActorSet {
+			os.Setenv("BD_ACTOR", origBdActor)
+		} else {
+			os.Unsetenv("BD_ACTOR")
+		}
+		if beadsActorSet {
+			os.Setenv("BEADS_ACTOR", origBeadsActor)
+		} else {
+			os.Unsetenv("BEADS_ACTOR")
+		}
+		if userSet {
+			os.Setenv("USER", origUser)
+		} else {
+			os.Unsetenv("USER")
+		}
+	}()
+
+	// Helper to get current git user.name (may be empty if not configured)
+	getGitUserName := func() string {
+		out, err := exec.Command("git", "config", "user.name").Output()
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	gitUserName := getGitUserName()
+
+	tests := []struct {
+		name          string
+		actorFlag     string
+		bdActor       string
+		beadsActor    string
+		user          string
+		expected      string
+		skipIfNoGit   bool // Skip if git user.name is not configured
+	}{
+		{
+			name:      "actor flag takes priority",
+			actorFlag: "flag-actor",
+			bdActor:   "bd-actor",
+			beadsActor: "beads-actor",
+			user:      "system-user",
+			expected:  "flag-actor",
+		},
+		{
+			name:      "BD_ACTOR takes priority when no flag",
+			actorFlag: "",
+			bdActor:   "bd-actor",
+			beadsActor: "beads-actor",
+			user:      "system-user",
+			expected:  "bd-actor",
+		},
+		{
+			name:      "BEADS_ACTOR takes priority when no BD_ACTOR",
+			actorFlag: "",
+			bdActor:   "",
+			beadsActor: "beads-actor",
+			user:      "system-user",
+			expected:  "beads-actor",
+		},
+		{
+			name:        "git config user.name used when no env vars",
+			actorFlag:   "",
+			bdActor:     "",
+			beadsActor:  "",
+			user:        "system-user",
+			expected:    gitUserName, // Will be git user.name if configured
+			skipIfNoGit: true,
+		},
+		{
+			name:      "USER fallback when no git config",
+			actorFlag: "",
+			bdActor:   "",
+			beadsActor: "",
+			user:      "fallback-user",
+			expected:  "fallback-user",
+			// Note: This test may fail if git user.name is configured
+			// We handle this by checking the actual git config in the test
+		},
+		{
+			name:      "unknown as final fallback",
+			actorFlag: "",
+			bdActor:   "",
+			beadsActor: "",
+			user:      "",
+			expected:  "unknown",
+			// Note: This test may get git user.name instead if configured
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Skip tests that require git user.name to not be configured
+			if tt.skipIfNoGit && gitUserName == "" {
+				t.Skip("Skipping: git config user.name is not configured")
+			}
+
+			// For tests expecting USER or unknown, skip if git user.name is configured
+			// because git takes priority over USER
+			if (tt.expected == tt.user || tt.expected == "unknown") && gitUserName != "" && tt.bdActor == "" && tt.beadsActor == "" && tt.actorFlag == "" {
+				t.Skipf("Skipping: git config user.name (%s) takes priority over expected %s", gitUserName, tt.expected)
+			}
+
+			// Set up test environment
+			actor = tt.actorFlag
+
+			if tt.bdActor != "" {
+				os.Setenv("BD_ACTOR", tt.bdActor)
+			} else {
+				os.Unsetenv("BD_ACTOR")
+			}
+
+			if tt.beadsActor != "" {
+				os.Setenv("BEADS_ACTOR", tt.beadsActor)
+			} else {
+				os.Unsetenv("BEADS_ACTOR")
+			}
+
+			if tt.user != "" {
+				os.Setenv("USER", tt.user)
+			} else {
+				os.Unsetenv("USER")
+			}
+
+			// Call the function
+			result := getActorWithGit()
+
+			// Check result
+			if result != tt.expected {
+				t.Errorf("getActorWithGit() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetActorWithGit_PriorityOrder tests that the priority order is respected
+func TestGetActorWithGit_PriorityOrder(t *testing.T) {
+	// Save original state
+	origActor := actor
+	origBdActor, bdActorSet := os.LookupEnv("BD_ACTOR")
+	origBeadsActor, beadsActorSet := os.LookupEnv("BEADS_ACTOR")
+
+	defer func() {
+		actor = origActor
+		if bdActorSet {
+			os.Setenv("BD_ACTOR", origBdActor)
+		} else {
+			os.Unsetenv("BD_ACTOR")
+		}
+		if beadsActorSet {
+			os.Setenv("BEADS_ACTOR", origBeadsActor)
+		} else {
+			os.Unsetenv("BEADS_ACTOR")
+		}
+	}()
+
+	// Test: flag > BD_ACTOR > BEADS_ACTOR
+	actor = "from-flag"
+	os.Setenv("BD_ACTOR", "from-bd-actor")
+	os.Setenv("BEADS_ACTOR", "from-beads-actor")
+
+	result := getActorWithGit()
+	if result != "from-flag" {
+		t.Errorf("Expected flag to take priority, got %q", result)
+	}
+
+	// Test: BD_ACTOR > BEADS_ACTOR (no flag)
+	actor = ""
+	result = getActorWithGit()
+	if result != "from-bd-actor" {
+		t.Errorf("Expected BD_ACTOR to take priority over BEADS_ACTOR, got %q", result)
+	}
+
+	// Test: BEADS_ACTOR when BD_ACTOR is empty
+	os.Unsetenv("BD_ACTOR")
+	result = getActorWithGit()
+	if result != "from-beads-actor" {
+		t.Errorf("Expected BEADS_ACTOR to be used, got %q", result)
+	}
+}

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/user"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -132,20 +131,10 @@ Examples:
 			commentText = args[1]
 		}
 
-		// Get author from author flag, BD_ACTOR var, or system USER var
+		// Get author from author flag, or use git-aware default
 		author, _ := cmd.Flags().GetString("author")
 		if author == "" {
-			author = os.Getenv("BD_ACTOR")
-			if author == "" {
-				author = os.Getenv("USER")
-			}
-			if author == "" {
-				if u, err := user.Current(); err == nil {
-					author = u.Username
-				} else {
-					author = "unknown"
-				}
-			}
+			author = getActorWithGit()
 		}
 
 		var comment *types.Comment

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -800,30 +799,6 @@ func uniqueStrings(slice []string) []string {
 		}
 	}
 	return result
-}
-
-// getActorWithGit returns the actor for audit trail with git config fallback.
-// Priority: global actor var (from --actor flag or BD_ACTOR env) > git config user.name > $USER > "unknown"
-func getActorWithGit() string {
-	// If actor is already set (from flag or env), use it
-	if actor != "" && actor != "unknown" {
-		return actor
-	}
-
-	// Try git config user.name
-	cmd := exec.Command("git", "config", "user.name")
-	if output, err := cmd.Output(); err == nil {
-		if gitUser := strings.TrimSpace(string(output)); gitUser != "" {
-			return gitUser
-		}
-	}
-
-	// Fall back to USER env
-	if user := os.Getenv("USER"); user != "" {
-		return user
-	}
-
-	return "unknown"
 }
 
 func init() {

--- a/cmd/bd/main_daemon.go
+++ b/cmd/bd/main_daemon.go
@@ -64,17 +64,8 @@ func signalOrchestratorActivity() {
 	// Build command line from os.Args
 	cmdLine := strings.Join(os.Args, " ")
 
-	// Determine actor (use package-level var if set, else fall back to env)
-	actorName := actor
-	if actorName == "" {
-		if bdActor := os.Getenv("BD_ACTOR"); bdActor != "" {
-			actorName = bdActor
-		} else if user := os.Getenv("USER"); user != "" {
-			actorName = user
-		} else {
-			actorName = "unknown"
-		}
-	}
+	// Determine actor (uses git config user.name as default)
+	actorName := getActorWithGit()
 
 	// Build activity signal
 	activity := struct {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -43,13 +43,31 @@ Tool-level settings you can configure:
 | `directory.labels` | - | - | (none) | Map directories to labels for automatic filtering |
 | `external_projects` | - | - | (none) | Map project names to paths for cross-project deps |
 | `db` | `--db` | `BD_DB` | (auto-discover) | Database path |
-| `actor` | `--actor` | `BD_ACTOR` | `$USER` | Actor name for audit trail |
+| `actor` | `--actor` | `BD_ACTOR` | `git config user.name` | Actor name for audit trail (see below) |
 | `flush-debounce` | - | `BEADS_FLUSH_DEBOUNCE` | `5s` | Debounce time for auto-flush |
 | `auto-start-daemon` | - | `BEADS_AUTO_START_DAEMON` | `true` | Auto-start daemon if not running |
 | `daemon-log-max-size` | - | `BEADS_DAEMON_LOG_MAX_SIZE` | `50` | Max daemon log size in MB before rotation |
 | `daemon-log-max-backups` | - | `BEADS_DAEMON_LOG_MAX_BACKUPS` | `7` | Max number of old log files to keep |
 | `daemon-log-max-age` | - | `BEADS_DAEMON_LOG_MAX_AGE` | `30` | Max days to keep old log files |
 | `daemon-log-compress` | - | `BEADS_DAEMON_LOG_COMPRESS` | `true` | Compress rotated log files |
+
+### Actor Identity Resolution
+
+The actor name (used for `created_by` in issues and audit trails) is resolved in this order:
+
+1. `--actor` flag (explicit override)
+2. `BD_ACTOR` environment variable
+3. `BEADS_ACTOR` environment variable (alias for MCP/integration compatibility)
+4. `git config user.name`
+5. `$USER` environment variable (system username fallback)
+6. `"unknown"` (final fallback)
+
+For most developers, no configuration is needed - beads will use your git identity automatically. This ensures your issue authorship matches your commit authorship.
+
+To override, set `BD_ACTOR` in your shell profile:
+```bash
+export BD_ACTOR="my-github-handle"
+```
 
 ### Example Config File
 


### PR DESCRIPTION
Adds `git config user.name` to the actor identity fallback chain as a more developer-friendly fallback if not explicitly set.

## Motivation

Developers often work across multiple machines where `$USER` varies - a corporate laptop might use `jsmith123` and a personal machine might use a real name or an old nick/handle.  But _usually_ `git config user.name` is set the same across devices.  So preferring the git value over `$USER` seems like a more natural fit.

It also would make the beads actor messages tie in better with git commits, which is a nice side-effect for auditing.

## Changes

- Add centralised `getActorWithGit()` function with the full fallback chain
- Consolidate 5 duplicate actor resolution blocks into calls to this one function
- Add `BEADS_ACTOR` as an env var alias (for MCP/integration compatibility)
- Add tests for actor resolution priority
- Update `CONFIG.md` with new "Actor Identity Resolution" section

## New Fallback Order

```
1. Explicit --actor flag
2. BD_ACTOR environment variable
3. BEADS_ACTOR environment variable (alias)
4. git config user.name ← new
5. $USER environment variable
6. "unknown"
```

## Compatibility

- Existing `--actor` flag and `BD_ACTOR` overrides still take priority
- Users without git configured fall back to `$USER` as before
