### PR TITLE
Add bsv terminal viewer to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -14,6 +14,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[lazybeads](https://github.com/codegangsta/lazybeads)** - Lightweight terminal UI built with Bubble Tea for browsing and managing beads issues. Built by [@codegangsta](https://github.com/codegangsta). (Go)
 
+- **[bsv](https://github.com/bglenden/bsv)** - Simple two-panel terminal (TUI) viewer with tree navigation organized by epic/task/sub-task, markdown rendering, and mouse support. Built by [@bglenden](https://github.com/bglenden). (Rust)
+
 ## Web UIs
 
 - **[beads-ui](https://github.com/mantoni/beads-ui)** - Local web interface with live updates and kanban board. Run with `npx beads-ui start`. Built by [@mantoni](https://github.com/mantoni). (Node.js)


### PR DESCRIPTION
  Adds [bsv](https://github.com/bglenden/bsv) - a Rust-based terminal UI for viewing beads issues.

  Features:
  - Two-panel layout (tree + details)
  - Hierarchical display organized by epic/task/sub-task
  - Markdown rendering
  - Mouse support
  - Auto-refresh on file changes