### PR TITLE
docs: update paths for claude-plugin subdirectory structure

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -343,7 +343,7 @@ git push origin main
 **Files updated automatically:**
 
 - `cmd/bd/version.go` - CLI version
-- `.claude-plugin/plugin.json` - Plugin version
+- `claude-plugin/.claude-plugin/plugin.json` - Plugin version
 - `.claude-plugin/marketplace.json` - Marketplace version
 - `integrations/beads-mcp/pyproject.toml` - MCP server version
 - `README.md` - Documentation version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -134,7 +134,7 @@ This updates:
 - `cmd/bd/version.go` - CLI version constant
 - `integrations/beads-mcp/pyproject.toml` - MCP server version
 - `integrations/beads-mcp/src/beads_mcp/__init__.py` - MCP Python version
-- `.claude-plugin/plugin.json` - Plugin version
+- `claude-plugin/.claude-plugin/plugin.json` - Plugin version
 - `.claude-plugin/marketplace.json` - Marketplace version
 - `npm-package/package.json` - npm package version
 - `cmd/bd/templates/hooks/*` - Git hook versions
@@ -338,11 +338,11 @@ Update the Claude Code marketplace metadata files:
 # Change version to match current release
 vim .claude-plugin/marketplace.json
 
-# Update .claude-plugin/plugin.json if needed
-vim .claude-plugin/plugin.json
+# Update claude-plugin/.claude-plugin/plugin.json if needed
+vim claude-plugin/.claude-plugin/plugin.json
 
 # Commit changes
-git add .claude-plugin/
+git add .claude-plugin/ claude-plugin/.claude-plugin/
 git commit -m "chore: Update Claude Code marketplace to v0.22.0"
 ```
 

--- a/claude-plugin/skills/beads/CLAUDE.md
+++ b/claude-plugin/skills/beads/CLAUDE.md
@@ -66,7 +66,7 @@ After skill updates:
 
 ```bash
 # Verify SKILL.md is within token budget
-wc -w skills/beads/SKILL.md  # Target: 400-600 words
+wc -w claude-plugin/skills/beads/SKILL.md  # Target: 400-600 words
 
 # Verify links resolve
 # (Manual check: ensure all resource links in SKILL.md exist)

--- a/claude-plugin/skills/beads/README.md
+++ b/claude-plugin/skills/beads/README.md
@@ -107,7 +107,7 @@ NEXT: Implement rate limiting"
 
 ## Contributing
 
-This skill is maintained at [github.com/steveyegge/beads](https://github.com/steveyegge/beads) in the `skills/beads/` directory.
+This skill is maintained at [github.com/steveyegge/beads](https://github.com/steveyegge/beads) in the `claude-plugin/skills/beads/` directory.
 
 Issues and PRs welcome for:
 - Documentation improvements

--- a/docs/DAEMON.md
+++ b/docs/DAEMON.md
@@ -592,4 +592,4 @@ bd daemons killall
 - [AGENTS.md](../AGENTS.md) - Main agent workflow guide
 - [EXCLUSIVE_LOCK.md](EXCLUSIVE_LOCK.md) - External tool integration
 - [GIT_INTEGRATION.md](GIT_INTEGRATION.md) - Git workflow and merge strategies
-- [commands/daemons.md](../commands/daemons.md) - Daemon command reference
+- [commands/daemons.md](../claude-plugin/commands/daemons.md) - Daemon command reference

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -3,7 +3,7 @@
 This document explains the design decisions behind `bd sync` - why it works the way it does, and the problems each design choice solves.
 
 > **Looking for something else?**
-> - Command usage: [commands/sync.md](/commands/sync.md) (Reference)
+> - Command usage: [commands/sync.md](/claude-plugin/commands/sync.md) (Reference)
 > - Troubleshooting: [website/docs/recovery/sync-failures.md](/website/docs/recovery/sync-failures.md) (How-To)
 > - Deletion behavior: [docs/DELETIONS.md](/docs/DELETIONS.md) (Explanation)
 

--- a/examples/protected-branch/README.md
+++ b/examples/protected-branch/README.md
@@ -278,4 +278,4 @@ jobs:
 
 - [docs/PROTECTED_BRANCHES.md](../../docs/PROTECTED_BRANCHES.md) - Complete guide
 - [AGENTS.md](../../AGENTS.md) - Agent integration instructions
-- [commands/sync.md](../../commands/sync.md) - `bd sync` command reference
+- [commands/sync.md](../../claude-plugin/commands/sync.md) - `bd sync` command reference

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,7 +88,7 @@ Bumps the version number across all beads components in a single command.
 
 Updates version in all these files:
 - `cmd/bd/version.go` - bd CLI version constant
-- `.claude-plugin/plugin.json` - Plugin version
+- `claude-plugin/.claude-plugin/plugin.json` - Plugin version
 - `.claude-plugin/marketplace.json` - Marketplace plugin version
 - `integrations/beads-mcp/pyproject.toml` - MCP server version
 - `README.md` - Alpha status version

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -313,9 +313,9 @@ main() {
         "Version = \"$CURRENT_VERSION\"" \
         "Version = \"$NEW_VERSION\""
 
-    # 2. Update .claude-plugin/plugin.json
-    echo "  • .claude-plugin/plugin.json"
-    update_file ".claude-plugin/plugin.json" \
+    # 2. Update claude-plugin/.claude-plugin/plugin.json
+    echo "  • claude-plugin/.claude-plugin/plugin.json"
+    update_file "claude-plugin/.claude-plugin/plugin.json" \
         "\"version\": \"$CURRENT_VERSION\"" \
         "\"version\": \"$NEW_VERSION\""
 
@@ -383,7 +383,7 @@ main() {
     echo "Verifying version consistency..."
     VERSIONS=(
         "$(grep 'Version = ' cmd/bd/version.go | sed 's/.*"\(.*\)".*/\1/')"
-        "$(jq -r '.version' .claude-plugin/plugin.json)"
+        "$(jq -r '.version' claude-plugin/.claude-plugin/plugin.json)"
         "$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)"
         "$(grep 'version = ' integrations/beads-mcp/pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
         "$(grep '__version__ = ' integrations/beads-mcp/src/beads_mcp/__init__.py | sed 's/.*"\(.*\)".*/\1/')"
@@ -722,7 +722,7 @@ main() {
         echo "Creating git commit..."
 
         git add cmd/bd/version.go \
-                .claude-plugin/plugin.json \
+                claude-plugin/.claude-plugin/plugin.json \
                 .claude-plugin/marketplace.json \
                 integrations/beads-mcp/pyproject.toml \
                 integrations/beads-mcp/src/beads_mcp/__init__.py \

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -43,8 +43,8 @@ check_version "integrations/beads-mcp/src/beads_mcp/__init__.py" \
     "$(grep '__version__ = ' integrations/beads-mcp/src/beads_mcp/__init__.py 2>/dev/null | sed 's/.*"\(.*\)".*/\1/')" \
     "MCP __init__.py"
 
-check_version ".claude-plugin/plugin.json" \
-    "$(jq -r '.version' .claude-plugin/plugin.json 2>/dev/null)" \
+check_version "claude-plugin/.claude-plugin/plugin.json" \
+    "$(jq -r '.version' claude-plugin/.claude-plugin/plugin.json 2>/dev/null)" \
     "Claude plugin.json"
 
 check_version ".claude-plugin/marketplace.json" \


### PR DESCRIPTION
## Summary

- Update documentation links to reference `claude-plugin/commands/` instead of `commands/`
- Update scripts to reference `claude-plugin/.claude-plugin/plugin.json` instead of `.claude-plugin/plugin.json`
- Update skill documentation paths

Follow-up to #985  - the plugin move was completed but several documentation files still referenced the old paths.

## Files Updated

**Documentation:**
- `docs/DAEMON.md` - Fixed command reference link
- `docs/SYNC.md` - Fixed command reference link  
- `examples/protected-branch/README.md` - Fixed command reference link
- `RELEASING.md` - Updated plugin.json paths (2 locations)
- `AGENT_INSTRUCTIONS.md` - Updated plugin.json path

**Scripts:**
- `scripts/README.md` - Updated documented paths
- `scripts/bump-version.sh` - Updated plugin.json path (4 locations)
- `scripts/check-versions.sh` - Updated plugin.json path

**Skill docs:**
- `claude-plugin/skills/beads/README.md` - Updated directory reference
- `claude-plugin/skills/beads/CLAUDE.md` - Updated wc command path

## Test plan

- [x] `./scripts/check-versions.sh` passes with all versions matching
- [x] No remaining references to old `.claude-plugin/plugin.json` path in scripts
- [x] No remaining references to old `commands/` path in docs

🤖 Generated with [Claude Code](https://claude.ai/code)