### PR TITLE
fix(daemon): socket path shortening for long workspace paths

### DIFF
--- a/cmd/bd/daemon.go
+++ b/cmd/bd/daemon.go
@@ -478,7 +478,12 @@ func runDaemonLoop(interval time.Duration, autoCommit, autoPush, autoPull, local
 	// Get workspace path (.beads directory) - beadsDir already defined above
 	// Get actual workspace root (parent of .beads)
 	workspacePath := filepath.Dir(beadsDir)
-	socketPath := filepath.Join(beadsDir, "bd.sock")
+	// Use short socket path to avoid Unix socket path length limits (macOS: 104 chars)
+	socketPath, err := rpc.EnsureSocketDir(rpc.ShortSocketPath(workspacePath))
+	if err != nil {
+		log.Error("failed to create socket directory", "error", err)
+		return
+	}
 	serverCtx, serverCancel := context.WithCancel(ctx)
 	defer serverCancel()
 

--- a/cmd/bd/daemon_socket_test.go
+++ b/cmd/bd/daemon_socket_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/rpc"
 )
 
 // TestSocketPathEnvOverride verifies that BD_SOCKET env var overrides default socket path.
@@ -50,6 +52,77 @@ func TestSocketPathDefaultBehavior(t *testing.T) {
 	want := "/path/to/.beads/bd.sock"
 	if got != want {
 		t.Errorf("getSocketPathForPID(%q) = %q, want %q", pidFile, got, want)
+	}
+}
+
+// TestSocketPathForPIDLongPath verifies that long workspace paths use shortened socket paths.
+// This fixes GH#1001 where pytest temp directories exceeded macOS's 104-byte socket path limit.
+func TestSocketPathForPIDLongPath(t *testing.T) {
+	t.Setenv("BD_SOCKET", "")
+
+	// Create a path that would exceed the 103-byte limit when .beads/bd.sock is appended
+	// /long/path/.beads/daemon.pid -> workspace is /long/path
+	// socket would be /long/path/.beads/bd.sock
+	longWorkspace := "/" + strings.Repeat("a", 90) // 91 bytes
+	pidFile := filepath.Join(longWorkspace, ".beads", "daemon.pid")
+
+	got := getSocketPathForPID(pidFile)
+
+	// Should NOT be the natural path (which would be too long)
+	naturalPath := filepath.Join(longWorkspace, ".beads", "bd.sock")
+	if got == naturalPath {
+		t.Errorf("getSocketPathForPID should use short path for long workspaces, got natural path %q (%d bytes)",
+			got, len(got))
+	}
+
+	// Should be in /tmp/beads-{hash}/
+	if !strings.HasPrefix(got, "/tmp/beads-") {
+		t.Errorf("getSocketPathForPID(%q) = %q, want path starting with /tmp/beads-", pidFile, got)
+	}
+
+	// Should end with bd.sock
+	if !strings.HasSuffix(got, "/bd.sock") {
+		t.Errorf("getSocketPathForPID(%q) = %q, want path ending with /bd.sock", pidFile, got)
+	}
+
+	// Should be under the limit
+	if len(got) > 103 {
+		t.Errorf("getSocketPathForPID returned path of %d bytes, want <= 103", len(got))
+	}
+}
+
+// TestSocketPathForPIDClientDaemonAgreement verifies that getSocketPathForPID
+// returns the same path as rpc.ShortSocketPath for the same workspace.
+// This is critical - if they disagree, the daemon listens on one path while
+// the client tries to connect to another, causing connection failures.
+// This test caught the GH#1001 bug where daemon.go used filepath.Join directly
+// instead of rpc.ShortSocketPath.
+func TestSocketPathForPIDClientDaemonAgreement(t *testing.T) {
+	t.Setenv("BD_SOCKET", "")
+
+	tests := []struct {
+		name          string
+		workspacePath string
+	}{
+		{"short_path", "/home/user/project"},
+		{"medium_path", "/Users/testuser/Documents/projects/myapp"},
+		{"long_path", "/" + strings.Repeat("a", 90)}, // Forces short socket path
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// What getSocketPathForPID returns (used by daemon operations)
+			pidFile := filepath.Join(tt.workspacePath, ".beads", "daemon.pid")
+			fromPID := getSocketPathForPID(pidFile)
+
+			// What rpc.ShortSocketPath returns (used by client via getSocketPath)
+			fromRPC := rpc.ShortSocketPath(tt.workspacePath)
+
+			if fromPID != fromRPC {
+				t.Errorf("socket path mismatch for workspace %q:\n  getSocketPathForPID: %q\n  rpc.ShortSocketPath: %q",
+					tt.workspacePath, fromPID, fromRPC)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#1001 introduced `rpc.ShortSocketPath()` to handle macOS's 104-byte Unix socket path limit, but only updated the client side (`getSocketPath()`). The daemon side at daemon.go:481 still used `filepath.Join(beadsDir, "bd.sock")`, causing a client-daemon socket path mismatch.

When workspace paths are long (e.g., pytest temp directories like `/var/folders/.../pytest-of-user/pytest-714/test_name/.beads/bd.sock`), the client would look for `/tmp/beads-{hash}/bd.sock` while the daemon tried to listen at the long path, which failed with "bind: invalid argument". This caused a 5-second timeout on every bd command as the client waited for a socket that would never appear.

Changes:
- daemon.go: Use `rpc.ShortSocketPath()` + `EnsureSocketDir()` for daemon socket
- daemon_config.go: Update `getSocketPathForPID()` to use `rpc.ShortSocketPath()`

Added tests:
- `TestSocketPathForPIDLongPath`: Verifies long paths use `/tmp/beads-{hash}/`
- `TestSocketPathForPIDClientDaemonAgreement`: Ensures `getSocketPathForPID()` and `rpc.ShortSocketPath()` return identical paths, preventing future client-daemon mismatches

Closes #1001