### PR TITLE
fix(linear): use project_id when creating issues via sync --push (GH#973)

### DIFF
--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -418,6 +418,11 @@ func (c *Client) CreateIssue(ctx context.Context, title, description string, pri
 		"description": description,
 	}
 
+	// Include project if configured
+	if c.ProjectID != "" {
+		input["projectId"] = c.ProjectID
+	}
+
 	if priority > 0 {
 		input["priority"] = priority
 	}


### PR DESCRIPTION
## Summary
- Fixes bd linear sync --push ignoring the linear.project_id config
- The config was already being used for filtering issues on pull, but not included when creating new issues
- Added projectId to the IssueCreateInput mutation when configured

## Root Cause
In internal/linear/client.go, CreateIssue() was not including the clients ProjectID in the GraphQL mutation input, even though WithProjectID() was being called correctly from getLinearClient().

## Fix
Added 4 lines to include projectId in the mutation input when the client has a project configured.

Fixes #973

## Test plan
- [ ] All existing tests pass (go test ./...)
- [ ] Manual test: Configure linear.project_id, run bd linear sync --push, verify issues are created in the correct project

Generated with Claude Code