### PR TITLE
feat(ui): add Markdown rendering to comment text

### DIFF
--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/rpc"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
 )
 
@@ -94,7 +95,12 @@ Examples:
 
 		fmt.Printf("\nComments on %s:\n\n", issueID)
 		for _, comment := range comments {
-			fmt.Printf("[%s] %s at %s\n", comment.Author, comment.Text, comment.CreatedAt.Format("2006-01-02 15:04"))
+			fmt.Printf("[%s] at %s\n", comment.Author, comment.CreatedAt.Format("2006-01-02 15:04"))
+			rendered := ui.RenderMarkdown(comment.Text)
+			// TrimRight removes trailing newlines that Glamour adds, preventing extra blank lines
+			for _, line := range strings.Split(strings.TrimRight(rendered, "\n"), "\n") {
+				fmt.Printf("  %s\n", line)
+			}
 			fmt.Println()
 		}
 	},

--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -286,8 +286,9 @@ var showCmd = &cobra.Command{
 						fmt.Printf("\n%s\n", ui.RenderBold("COMMENTS"))
 						for _, comment := range details.Comments {
 							fmt.Printf("  %s %s\n", ui.RenderMuted(comment.CreatedAt.Format("2006-01-02")), comment.Author)
-							commentLines := strings.Split(comment.Text, "\n")
-							for _, line := range commentLines {
+							rendered := ui.RenderMarkdown(comment.Text)
+							// TrimRight removes trailing newlines that Glamour adds, preventing extra blank lines
+							for _, line := range strings.Split(strings.TrimRight(rendered, "\n"), "\n") {
 								fmt.Printf("    %s\n", line)
 							}
 						}
@@ -491,8 +492,9 @@ var showCmd = &cobra.Command{
 				fmt.Printf("\n%s\n", ui.RenderBold("COMMENTS"))
 				for _, comment := range comments {
 					fmt.Printf("  %s %s\n", ui.RenderMuted(comment.CreatedAt.Format("2006-01-02")), comment.Author)
-					commentLines := strings.Split(comment.Text, "\n")
-					for _, line := range commentLines {
+					rendered := ui.RenderMarkdown(comment.Text)
+					// TrimRight removes trailing newlines that Glamour adds, preventing extra blank lines
+					for _, line := range strings.Split(strings.TrimRight(rendered, "\n"), "\n") {
 						fmt.Printf("    %s\n", line)
 					}
 				}


### PR DESCRIPTION
Apply ui.RenderMarkdown() to comment text in both bd show and bd comments commands. This enables syntax highlighting, code blocks, and other Markdown formatting in comments.