### PR TITLE
 fix(init): prevent initialization from within git worktrees

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -147,19 +147,30 @@ With --stealth: configures per-repository git settings for invisible beads usage
 		if isGitRepo() {
 			isWorktree = git.IsWorktree()
 		}
-		var beadsDir string
+
+		// Prevent initialization from within a worktree
 		if isWorktree {
-			// For worktrees, .beads should be in the main repository root
 			mainRepoRoot, err := git.GetMainRepoRoot()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error: failed to get main repository root: %v\n", err)
 				os.Exit(1)
 			}
-			beadsDir = filepath.Join(mainRepoRoot, ".beads")
-		} else {
-			// For regular repos, use current directory
-			beadsDir = filepath.Join(cwd, ".beads")
+
+			fmt.Fprintf(os.Stderr, "Error: cannot run 'bd init' from within a git worktree\n\n")
+			fmt.Fprintf(os.Stderr, "Git worktrees share the .beads database from the main repository.\n")
+			fmt.Fprintf(os.Stderr, "To fix this:\n\n")
+			fmt.Fprintf(os.Stderr, "  1. Initialize beads in the main repository:\n")
+			fmt.Fprintf(os.Stderr, "     cd %s\n", mainRepoRoot)
+			fmt.Fprintf(os.Stderr, "     bd init\n\n")
+			fmt.Fprintf(os.Stderr, "  2. Then create worktrees with beads support:\n")
+			fmt.Fprintf(os.Stderr, "     bd worktree create <path> --branch <branch-name>\n\n")
+			fmt.Fprintf(os.Stderr, "For more information, see: https://github.com/steveyegge/beads/blob/main/docs/WORKTREES.md\n")
+			os.Exit(1)
 		}
+
+		var beadsDir string
+		// For regular repos, use current directory
+		beadsDir = filepath.Join(cwd, ".beads")
 
 		// Prevent nested .beads directories
 		// Check if current working directory is inside a .beads directory


### PR DESCRIPTION
Add check to prevent 'bd init' from running inside a git worktree. Worktrees should share the .beads database from the main repository, not create their own.

The error message guides users to:
    1. Run 'bd init' from the main repository
    2. Use 'bd worktree create' to create worktrees with proper redirects

This prevents the confusing behavior where init would create files in unexpected locations or fail with "pathspec '.beads/.gitignore' did not match any files" errors.

According to docs/WORKTREES.md, the proper workflow is:
    - Initialize beads once in the main repository
    - Use 'bd worktree create' to create worktrees with redirect files
    - All worktrees share the single .beads/ database via redirects

    Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>