### PR TITLE
fix: use route prefix when creating issues in rigs

### DIFF
--- a/internal/storage/sqlite/queries.go
+++ b/internal/storage/sqlite/queries.go
@@ -167,10 +167,14 @@ func (s *SQLiteStorage) CreateIssue(ctx context.Context, issue *types.Issue, act
 		return fmt.Errorf("failed to get config: %w", err)
 	}
 
-	// Use IDPrefix override if set, combined with config prefix
-	// e.g., configPrefix="bd" + IDPrefix="wisp" → "bd-wisp"
+	// Determine prefix for ID generation and validation:
+	// 1. PrefixOverride completely replaces config prefix (for cross-rig creation)
+	// 2. IDPrefix appends to config prefix (e.g., "bd" + "wisp" → "bd-wisp")
+	// 3. Otherwise use config prefix as-is
 	prefix := configPrefix
-	if issue.IDPrefix != "" {
+	if issue.PrefixOverride != "" {
+		prefix = issue.PrefixOverride
+	} else if issue.IDPrefix != "" {
 		prefix = configPrefix + "-" + issue.IDPrefix
 	}
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -56,8 +56,9 @@ type Issue struct {
 	OriginalSize      int        `json:"original_size,omitempty"`
 
 	// ===== Internal Routing (not exported to JSONL) =====
-	SourceRepo string `json:"-"` // Which repo owns this issue (multi-repo support)
-	IDPrefix   string `json:"-"` // Override prefix for ID generation
+	SourceRepo     string `json:"-"` // Which repo owns this issue (multi-repo support)
+	IDPrefix       string `json:"-"` // Override prefix for ID generation (appends to config prefix)
+	PrefixOverride string `json:"-"` // Completely replace config prefix (for cross-rig creation)
 
 	// ===== Relational Data (populated for export/import) =====
 	Labels       []string      `json:"labels,omitempty"`


### PR DESCRIPTION
## Summary

When using `bd create --rig <name>`, the prefix from `routes.jsonl` was being discarded. This caused issues to be created with the database's default prefix instead of the route-specified prefix.

**Bug**: In `createInRig()`, the second return value from `ResolveBeadsDirForRig()` (the prefix) was assigned to `_` and ignored.

**Fix**: 
- Add `PrefixOverride` field to `types.Issue`
- In `CreateIssue`, check `PrefixOverride` first and use it if set (overrides config prefix)
- In `createInRig`, set `issue.PrefixOverride` from the route prefix

This passes state as a parameter rather than mutating shared config, making it safe for concurrent multi-user access.

## Use Case

This enables sharing a single database across multiple projects with different prefixes via the redirect mechanism:

- `~/writing/.beads/` - main database with default prefix `ns`
- `~/src/project/.beads/redirect` - points to `~/writing/.beads/`
- `~/.beads/routes.jsonl` - routes `aops-` prefix to `~/src/project`

Without this fix, `bd create --rig project` would create `ns-xxx` issues instead of `aops-xxx`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing failures in TestDetectPrefix unrelated to this change)
- [ ] Manual test: create issue with `--rig` flag using routes.jsonl routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)