### PR TITLE
feat(daemon): increase default sync interval from 5s to 30s

### DIFF
--- a/cmd/bd/daemon.go
+++ b/cmd/bd/daemon.go
@@ -207,7 +207,7 @@ Run 'bd daemon' with no flags to see available options.`,
 
 func init() {
 	daemonCmd.Flags().Bool("start", false, "Start the daemon")
-	daemonCmd.Flags().Duration("interval", 5*time.Second, "Sync check interval")
+	daemonCmd.Flags().Duration("interval", 30*time.Second, "Sync check interval")
 	daemonCmd.Flags().Bool("auto-commit", false, "Automatically commit changes")
 	daemonCmd.Flags().Bool("auto-push", false, "Automatically push commits")
 	daemonCmd.Flags().Bool("auto-pull", false, "Automatically pull from remote (default: true when sync.branch configured)")


### PR DESCRIPTION
## Summary
- Increases default daemon polling interval from 5s to 30s
- Reduces CPU overhead by ~6x while maintaining responsive sync

## Motivation
When running multiple bd daemons (common in Gas Town multi-rig setups with 3+ beads workspaces), the 5-second polling causes noticeable CPU overhead. Each daemon performs:
- File system checks
- Database comparisons  
- Git operations (when auto-sync enabled)

30 seconds is still responsive for typical workflows while being much lighter on resources.

## Changes
- `cmd/bd/daemon.go`: Change default interval flag from `5*time.Second` to `30*time.Second`

## Backward Compatibility
Users can still override with `--interval 5s` if they need faster polling.

🤖 Generated with [Claude Code](https://claude.ai/code)