### PR TITLE
fix(export): remove export from read-only commands

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -98,7 +98,7 @@ var readOnlyCommands = map[string]bool{
 	"graph":      true,
 	"duplicates": true,
 	"comments":   true, // list comments (not add)
-	"export":     true, // export only reads
+	// NOTE: "export" is NOT read-only - it writes to clear dirty issues and update jsonl_file_hash
 }
 
 // isReadOnlyCommand returns true if the command only reads from the database.


### PR DESCRIPTION
The export command was incorrectly listed in readOnlyCommands, causing the SQLite database to be opened in read-only mode. This prevented export from clearing dirty issues and updating the JSONL file hash.

Root cause:
- #804 introduced readOnlyCommands optimization to prevent file watcher triggers for read-only operations
- Export was added with comment "export only reads"
- However, export actually writes: `ClearDirtyIssuesByID()` and `SetJSONLFileHash()`

Symptoms:
- After import, running export produces warning: `Warning: failed to clear dirty issues: failed to clear dirty issue <id>: sqlite3: attempt to write a readonly database`

Steps to reproduce:
1. Create a fresh beads database: `bd init --prefix test`
2. Import issues from JSONL: `bd import -i issues.jsonl`
3. Run export: `bd export`
4. Observe the "attempt to write a readonly database" warning

The fix removes "export" from readOnlyCommands so the database is opened in read-write mode, allowing the post-export cleanup to succeed.