### PR TITLE
Ensure daemon autostart lock dir exists

### DIFF
--- a/cmd/bd/daemon_autostart_unit_test.go
+++ b/cmd/bd/daemon_autostart_unit_test.go
@@ -127,6 +127,24 @@ func TestDaemonAutostart_AcquireStartLock_CreatesAndCleansStale(t *testing.T) {
 	}
 }
 
+func TestDaemonAutostart_AcquireStartLock_CreatesMissingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "missing", "bd.sock")
+	lockPath := socketPath + ".startlock"
+
+	if _, err := os.Stat(filepath.Dir(lockPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected lock dir to be missing before test, got: %v", err)
+	}
+
+	if !acquireStartLock(lockPath, socketPath) {
+		t.Fatalf("expected acquireStartLock to succeed when directory missing")
+	}
+
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lock file to exist, stat error: %v", err)
+	}
+}
+
 func TestDaemonAutostart_SocketHealthAndReadiness(t *testing.T) {
 	socketPath, cleanup := startTestRPCServer(t)
 	defer cleanup()


### PR DESCRIPTION
## Background

While running `bd ready` inside a deeply nested workspace path (`~/git/company/project/team/svc`), the CLI blew up with a stack overflow. The panic trace showed `acquireStartLock` recursing forever because it could neither create nor remove `bd.sock.startlock`. That workspace path exceeds the 104‑char Unix socket limit, so `rpc.ShortSocketPath` relocates the daemon socket to `/tmp/beads-<hash>/bd.sock`. Auto-start tries to create the lock beside that socket *before* the daemon runs, but the `/tmp/beads-<hash>` directory isn’t created until the daemon launches. As soon as the `os.OpenFile(lockPath, O_CREATE|O_EXCL)` call hit ENOENT, the code assumed the lock already existed and recursed, eventually exhausting the stack.

<details>

```
2026-01-12T10:54:07-0500
user@COMP-XXXX
~/git/company/project/team/svc
$ bd ready
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x1402107a390 stack=[0x1402107a000, 0x1404107a000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x10318fea5?, 0x1025e9210?})
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/runtime/panic.go:1094 +0x34 fp=0x16e18eda0 sp=0x16e18ed70 pc=0x10262fd44
runtime.newstack()
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/runtime/stack.go:1159 +0x44c fp=0x16e18eed0 sp=0x16e18eda0 pc=0x10261511c
runtime.morestack()
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/runtime/asm_arm64.s:392 +0x70 fp=0x16e18eed0 sp=0x16e18eed0 pc=0x102635f40

goroutine 1 gp=0x140000021c0 m=17 mp=0x14000901808 [running]:
runtime.makeslicecopy(...)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/runtime/slice.go:38
syscall.ByteSliceFromString(...)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/syscall/syscall.go:52
syscall.Open(...)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/syscall/zsyscall_darwin_arm64.go:1158
os.openFileNolog(...)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/os/file_unix.go:259
os.OpenFile(...)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/os/file.go:412
os.ReadFile(...)
        /opt/homebrew/Cellar/go/1.25.1/libexec/src/os/file.go:868
main.readPIDFromFile({0x1400003b170?, 0x25?})
        cmd/bd/daemon_autostart.go:391
main.acquireStartLock({0x1400003b170, 0x25}, {0x14000445e40, 0x1b})
        cmd/bd/daemon_autostart.go:222
...
```

</details>

## Fix

We now ensure the parent directory exists before touching the lock. `ensureLockDirectory` safely `MkdirAll`s the directory (only when missing) so auto-start can always write `bd.sock.startlock`, even when ShortSocketPath relocates the socket. We also added a regression test that recreates the “missing directory” scenario, so future refactors can’t regress it. With the lock directory created up front, auto-start succeeds and the daemon can create the socket and `/tmp/beads-*` directory as usual.

## Related Work

We searched the public tracker (`gh issue list/search` for “startlock”, “short socket”, “bd.sock”, “daemon stack overflow”), but couldn’t find any existing issues/PRs/discussions covering this bug. This PR documents and fixes it here.

Co-authored-by: OpenAI Codex <codex@openai.com>
