### PR TITLE
fix(autoflush): preserve comments during full re-export

### DIFF
--- a/cmd/bd/autoflush.go
+++ b/cmd/bd/autoflush.go
@@ -626,6 +626,13 @@ func fetchAndMergeIssues(ctx context.Context, s storage.Storage, dirtyIDs []stri
 		}
 		issue.Dependencies = deps
 
+		// Get comments for this issue
+		comments, err := s.GetIssueComments(ctx, issueID)
+		if err != nil {
+			return fmt.Errorf("failed to get comments for %s: %w", issueID, err)
+		}
+		issue.Comments = comments
+
 		// Update map
 		issueMap[issueID] = issue
 	}


### PR DESCRIPTION
### Problem
When a JSONL file hash mismatch was detected (e.g., after git operations that modify the JSONL without updating export_hashes), the autoflush system would trigger a full re-export. During this re-export, all issue comments were silently dropped from the exported JSONL file.

### Steps to reproduce
1. Have a beads database with issues containing comments
2. Create a situation where JSONL hash doesn't match stored hash (e.g., clone a repo, or manual JSONL edits)
3. Run any bd command that triggers autoflush (e.g., `bd create foo`)
4. Observe warning: "JSONL file hash mismatch detected"
5. Check `.beads/issues.jsonl` - all comments are now missing

### Root cause
Two different export code paths existed:
- `exportToJSONLWithStore` (`daemon_sync.go`) - correctly populated comments
- `fetchAndMergeIssues` (`autoflush.go`) - only fetched dependencies, NOT comments

When hash mismatch triggered a full re-export via the autoflush path, fetchAndMergeIssues was called but it never populated `issue.Comments`, resulting in all comments being lost.

### Fix
Add `GetIssueComments` call in `fetchAndMergeIssues` to populate comments for each issue before export, matching the behavior of `exportToJSONLWithStore`.

Note: Labels were not affected because `GetIssue()` already populates them internally. Comments are stored in a separate table and require explicit fetching via `GetIssueComments()`.