### PR TITLE
feat: add prek support as pre-commit alternative

### DIFF
--- a/cmd/bd/doctor/fix/hooks.go
+++ b/cmd/bd/doctor/fix/hooks.go
@@ -27,6 +27,8 @@ type hookManagerConfig struct {
 
 // hookManagerConfigs defines external hook managers in priority order.
 // See https://lefthook.dev/configuration/ for lefthook config options.
+// Note: prek (https://prek.j178.dev) uses the same config files as pre-commit
+// but is a faster Rust-based alternative. We detect both from the same config.
 var hookManagerConfigs = []hookManagerConfig{
 	{"lefthook", []string{
 		// YAML variants
@@ -38,6 +40,7 @@ var hookManagerConfigs = []hookManagerConfig{
 		"lefthook.json", ".lefthook.json", ".config/lefthook.json",
 	}},
 	{"husky", []string{".husky"}},
+	// pre-commit and prek share the same config files; we detect which is active from git hooks
 	{"pre-commit", []string{".pre-commit-config.yaml", ".pre-commit-config.yml"}},
 	{"overcommit", []string{".overcommit.yml"}},
 	{"yorkie", []string{".yorkie"}},
@@ -92,9 +95,12 @@ type hookManagerPattern struct {
 }
 
 // hookManagerPatterns identifies which hook manager installed a git hook (in priority order).
+// Note: prek must come before pre-commit since prek hooks may also contain "pre-commit" in paths.
 var hookManagerPatterns = []hookManagerPattern{
 	{"lefthook", regexp.MustCompile(`(?i)lefthook`)},
 	{"husky", regexp.MustCompile(`(?i)(\.husky|husky\.sh)`)},
+	// prek (https://prek.j178.dev) - faster Rust-based pre-commit alternative
+	{"prek", regexp.MustCompile(`(?i)(prek\s+run|prek\s+hook-impl)`)},
 	{"pre-commit", regexp.MustCompile(`(?i)(pre-commit\s+run|\.pre-commit-config|INSTALL_PYTHON|PRE_COMMIT)`)},
 	{"simple-git-hooks", regexp.MustCompile(`(?i)simple-git-hooks`)},
 }
@@ -470,8 +476,13 @@ func checkManagerBdIntegration(name, path string) *HookIntegrationStatus {
 		return CheckLefthookBdIntegration(path)
 	case "husky":
 		return CheckHuskyBdIntegration(path)
-	case "pre-commit":
-		return CheckPrecommitBdIntegration(path)
+	case "pre-commit", "prek":
+		// prek uses the same config format as pre-commit
+		status := CheckPrecommitBdIntegration(path)
+		if status != nil {
+			status.Manager = name // Use the actual detected manager name
+		}
+		return status
 	default:
 		return nil
 	}

--- a/cmd/bd/doctor/fix/hooks_test.go
+++ b/cmd/bd/doctor/fix/hooks_test.go
@@ -587,6 +587,16 @@ func TestDetectActiveHookManager(t *testing.T) {
 			expected:    "pre-commit",
 		},
 		{
+			name:        "prek run signature",
+			hookContent: "#!/bin/sh\nprek run pre-commit\n",
+			expected:    "prek",
+		},
+		{
+			name:        "prek hook-impl signature",
+			hookContent: "#!/usr/bin/env bash\nexec prek hook-impl --hook-type=pre-commit\n",
+			expected:    "prek",
+		},
+		{
 			name:        "simple-git-hooks signature",
 			hookContent: "#!/bin/sh\n# simple-git-hooks\nnpm run lint\n",
 			expected:    "simple-git-hooks",

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -24,12 +24,12 @@ func TestDetectExistingHooks(t *testing.T) {
 		hooksDir := filepath.Join(gitDirPath, "hooks")
 
 		tests := []struct {
-			name            string
-			setupHook       string
-			hookContent     string
-			wantExists      bool
-			wantIsBdHook    bool
-			wantIsPreCommit bool
+			name                     string
+			setupHook                string
+			hookContent              string
+			wantExists               bool
+			wantIsBdHook             bool
+			wantIsPreCommitFramework bool
 		}{
 			{
 				name:       "no hook",
@@ -44,11 +44,11 @@ func TestDetectExistingHooks(t *testing.T) {
 				wantIsBdHook: true,
 			},
 			{
-				name:            "pre-commit framework hook",
-				setupHook:       "pre-commit",
-				hookContent:     "#!/bin/sh\n# pre-commit framework\npre-commit run",
-				wantExists:      true,
-				wantIsPreCommit: true,
+				name:                     "pre-commit framework hook",
+				setupHook:                "pre-commit",
+				hookContent:              "#!/bin/sh\n# pre-commit framework\npre-commit run",
+				wantExists:               true,
+				wantIsPreCommitFramework: true,
 			},
 			{
 				name:        "custom hook",
@@ -90,8 +90,8 @@ func TestDetectExistingHooks(t *testing.T) {
 				if found.isBdHook != tt.wantIsBdHook {
 					t.Errorf("isBdHook = %v, want %v", found.isBdHook, tt.wantIsBdHook)
 				}
-				if found.isPreCommit != tt.wantIsPreCommit {
-					t.Errorf("isPreCommit = %v, want %v", found.isPreCommit, tt.wantIsPreCommit)
+				if found.isPreCommitFramework != tt.wantIsPreCommitFramework {
+					t.Errorf("isPreCommitFramework = %v, want %v", found.isPreCommitFramework, tt.wantIsPreCommitFramework)
 				}
 			})
 		}


### PR DESCRIPTION
## Summary

[prek](https://prek.j178.dev) is a faster Rust-based alternative to pre-commit that uses the same `.pre-commit-config.yaml` config files. This PR adds prek support to beads hook detection.

## Changes

- **`cmd/bd/doctor/fix/hooks.go`**: 
  - Add prek detection pattern in `hookManagerPatterns` (before pre-commit to ensure correct detection since prek hooks may contain 'pre-commit' in paths)
  - Handle prek in `checkManagerBdIntegration` using same config parser as pre-commit
  - Add comments documenting prek compatibility

- **`cmd/bd/init_git_hooks.go`**:
  - Rename `isPreCommit` field to `isPreCommitFramework` for clarity
  - Add `preCommitFrameworkPattern` regex matching all pre-commit/prek signatures
  - Update display message to show "pre-commit/prek framework"

- **`cmd/bd/doctor/fix/hooks_test.go`**:
  - Add test cases for `prek run` and `prek hook-impl` signatures

- **`cmd/bd/init_hooks_test.go`**:
  - Update test to use renamed field

## Testing

All relevant tests pass:
```
go test -v -run "TestDetectExistingHooks|TestDetectActiveHookManager" ./cmd/bd/...
```

## Notes

- prek uses the same config files as pre-commit, so config detection remains unchanged
- The key difference is in git hook content: prek uses `prek run` or `prek hook-impl` instead of `pre-commit run`
- Detection order matters: prek pattern comes before pre-commit to avoid false matches