### PR TITLE
fix: pass hookArgs to runPrePushHook for chained hook support

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -593,9 +593,9 @@ func runPostMergeHook() int {
 
 // runPrePushHook prevents pushing stale JSONL.
 // Returns 0 to allow push, non-zero to block.
-func runPrePushHook() int {
+func runPrePushHook(args []string) int {
 	// Run chained hook first (if exists)
-	if exitCode := runChainedHook("pre-push", nil); exitCode != 0 {
+	if exitCode := runChainedHook("pre-push", args); exitCode != 0 {
 		return exitCode
 	}
 
@@ -640,9 +640,9 @@ func runPrePushHook() int {
 	}
 
 	// Check for uncommitted changes using git status
-	args := append([]string{"status", "--porcelain", "--"}, files...)
-	// #nosec G204 - args built from hardcoded list and git subcommands
-	statusCmd := exec.Command("git", args...)
+	statusArgs := append([]string{"status", "--porcelain", "--"}, files...)
+	// #nosec G204 - statusArgs built from hardcoded list and git subcommands
+	statusCmd := exec.Command("git", statusArgs...)
 	output, _ := statusCmd.Output()
 	if len(output) > 0 {
 		fmt.Fprintln(os.Stderr, "❌ Error: Uncommitted changes detected")
@@ -1114,7 +1114,7 @@ installed bd version - upgrading bd automatically updates hook behavior.`,
 		case "post-merge":
 			exitCode = runPostMergeHook()
 		case "pre-push":
-			exitCode = runPrePushHook()
+			exitCode = runPrePushHook(hookArgs)
 		case "post-checkout":
 			exitCode = runPostCheckoutHook(hookArgs)
 		case "prepare-commit-msg":


### PR DESCRIPTION
Fixes #1041

## Problem

The pre-push hook was not passing arguments to chained hooks, causing them to fail. When `runPrePushHook()` called `runChainedHook("pre-push", nil)`, the chained hook manager (e.g., prek, pre-commit) didn't receive the required arguments.

## Fix

1. Changed `runPrePushHook()` to accept `args []string` parameter
2. Pass `args` to `runChainedHook()` instead of `nil`
3. Updated call site at line 1117 to pass `hookArgs`
4. Renamed local `args` variable to `statusArgs` to avoid shadowing

## Testing

- All hook-related tests pass
- Verified no changes to `.beads/issues.jsonl`