### PR TITLE
Add jira-beads-sync CLI+Claude plugin to COMMUNITY_TOOLS.md

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -38,6 +38,10 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 -  **[Parade](https://github.com/JeremyKalmus/parade)** - Electron app for workflow orchestration with visual Kanban board, discovery wizard, and task visualization. Run with `npx parade-init`. Built by [@JeremyKalmus](https://github.com/JeremyKalmus). (Electron/React)
 
+## Data Source Middleware
+
+- **[jira-beads-sync](https://github.com/conallob/jira-beads-sync)** - CLI tool & Claude Code plugin to sync tasks from Jira into beads and publish beads task states back to Jira. Built by [@conallob](https://github.com/conallob). (Go)
+
 ## Historical / Stale
 
 - **[beady](https://github.com/maphew/beady)** - Early prototype effort, now stale. Built by [@maphew](https://github.com/maphew). (Go)


### PR DESCRIPTION
Add a link to a little helper tool to transfer Jira tasks into beads, and to publish beads state back into Jira