### PR TITLE
Fix bd gate list: Separate closed gates into own section

### DIFF
--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -2108,9 +2108,9 @@ func (s *Server) handleGateList(req *Request) Response {
 	filter := types.IssueFilter{
 		IssueType: &gateType,
 	}
+	// By default, exclude closed gates (consistent with CLI behavior)
 	if !args.All {
-		openStatus := types.StatusOpen
-		filter.Status = &openStatus
+		filter.ExcludeStatus = []types.Status{types.StatusClosed}
 	}
 
 	gates, err := store.SearchIssues(ctx, "", filter)


### PR DESCRIPTION
## Summary
- Fixes `bd gate list` showing closed gates in the Open Gates section
- Separates gates into distinct Open and Closed sections in display

## Changes
- Modified `displayGates()` to filter and display gates by status
- Fixed `handleGateList` RPC to use `ExcludeStatus` for proper filtering

## Test Plan
- Run `bd gate list` with mix of open/closed gates
- Verify closed gates appear in "Closed Gates" section only

Closes go-47m