### PR TITLE
docs: Add 'beads-dashboard' to community tools list (Web UIs)

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -24,6 +24,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[beads-viz-prototype](https://github.com/mattbeane/beads-viz-prototype)** - Web-based visualization generating interactive HTML from `bd export`. Built by [@mattbeane](https://github.com/mattbeane). (Python)
 
+- **[beads-dashboard](https://github.com/rhydlewis/beads-dashboard)** - A local, lean metrics dashboard for your beads data. Provides insights insights into lead time, throughput and other continuous improvement metrics. Includes a filterable table view of "all issues". Built by [@rhydlewis](https://github.com/rhydlewis). (Node.js/React)
+
 ## Editor Extensions
 
 - **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and daemon management. Built by [@jdillon](https://github.com/jdillon). (TypeScript)


### PR DESCRIPTION
Added a new tool entry for 'beads-dashboard' including details on functionality and author. See [NPM Package](https://www.npmjs.com/package/beads-dashboard) and [GitHub Repo](https://github.com/rhydlewis/beads-dashboard).