### PR TITLE
fix(sync): Handle redirected beads directories in gitCommitBeadsDir

### DIFF
--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -209,10 +209,21 @@ func gitCommitBeadsDir(ctx context.Context, message string) error {
 		return fmt.Errorf("no .beads directory found")
 	}
 
-	// Get the repository root (handles worktrees properly)
-	repoRoot := getRepoRootForWorktree(ctx)
-	if repoRoot == "" {
-		return fmt.Errorf("cannot determine repository root")
+	// Determine the repository root
+	// When beads directory is redirected (bd-arjb), we need to run git commands
+	// from the directory containing the actual .beads/, not the current working directory
+	var repoRoot string
+	redirectInfo := beads.GetRedirectInfo()
+	if redirectInfo.IsRedirected {
+		// beadsDir is the target (e.g., /path/to/mayor/rig/.beads)
+		// We need to run git from the parent of .beads (e.g., /path/to/mayor/rig)
+		repoRoot = filepath.Dir(beadsDir)
+	} else {
+		// Get the repository root (handles worktrees properly)
+		repoRoot = getRepoRootForWorktree(ctx)
+		if repoRoot == "" {
+			return fmt.Errorf("cannot determine repository root")
+		}
 	}
 
 	// Stage only the specific sync-related files


### PR DESCRIPTION
## Summary
- Fixes `bd sync` failing with `git add failed: exit status 128` when beads directory is redirected

## Problem
When beads directory is redirected to a different repository (via `.beads_redirect` file), `gitCommitBeadsDir()` was running git add from the current working directory's repo root instead of the beads directory's repo root.

## Solution
Added the same redirect handling already present in `gitHasBeadsChanges()` and `gitHasUncommittedBeadsChanges()`:
- Check `beads.GetRedirectInfo()` before determining repo root
- When redirected, use `filepath.Dir(beadsDir)` as the repo root instead of `getRepoRootForWorktree(ctx)`

## Test plan
- [x] Built and installed new bd binary
- [x] Verified `bd sync` works from redirected directory (previously failed with exit 128)
- [x] Verified normal (non-redirected) `bd sync` still works