### PR TITLE
fix(doctor): detect plugin and hooks in project-level settings

### DIFF
--- a/cmd/bd/doctor/claude.go
+++ b/cmd/bd/doctor/claude.go
@@ -183,10 +183,11 @@ func hasClaudeHooks() bool {
 		return false
 	}
 
-	globalSettings := filepath.Join(home, ".claude/settings.json")
-	projectSettings := ".claude/settings.local.json"
+	globalSettings := filepath.Join(home, ".claude", "settings.json")
+	projectSettings := filepath.Join(".claude", "settings.json")
+	projectLocalSettings := filepath.Join(".claude", "settings.local.json")
 
-	return hasBeadsHooks(globalSettings) || hasBeadsHooks(projectSettings)
+	return hasBeadsHooks(globalSettings) || hasBeadsHooks(projectSettings) || hasBeadsHooks(projectLocalSettings)
 }
 
 // hasBeadsHooks checks if a settings file has bd prime hooks


### PR DESCRIPTION
## Summary

- Fix `isBeadsPluginInstalled()` to check project-level settings (`.claude/settings.json` and `.claude/settings.local.json`)
- Fix `hasClaudeHooks()` which was missing `.claude/settings.json` (only checked `.claude/settings.local.json`)

Both functions now check all three locations:
- `~/.claude/settings.json` (user-level)
- `.claude/settings.json` (project-level)
- `.claude/settings.local.json` (project-level, gitignored)

Fixes #1090

## Test plan

- [x] Added `TestIsBeadsPluginInstalledProjectLevel` with positive and negative cases
- [x] Added `TestHasClaudeHooksProjectLevel` with positive and negative cases
- [x] Verified tests fail when fixes are commented out
- [x] All doctor tests pass

## Note

`isMCPServerInstalled()` may have the same issue (only checks user-level settings). Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.ai/code)