### PR TITLE
fix: exclude role and rig types from bd ready

### DIFF
--- a/internal/storage/sqlite/ready.go
+++ b/internal/storage/sqlite/ready.go
@@ -43,7 +43,9 @@ func (s *SQLiteStorage) GetReadyWork(ctx context.Context, filter types.WorkFilte
 		// - molecule: workflow containers
 		// - message: mail/communication items
 		// - agent: identity/state tracking beads
-		whereClauses = append(whereClauses, "i.issue_type NOT IN ('merge-request', 'gate', 'molecule', 'message', 'agent')")
+		// - role: agent role definitions (reference metadata)
+		// - rig: rig identity beads (reference metadata)
+		whereClauses = append(whereClauses, "i.issue_type NOT IN ('merge-request', 'gate', 'molecule', 'message', 'agent', 'role', 'rig')")
 	}
 
 	if filter.Priority != nil {


### PR DESCRIPTION
## Summary

- Add `role` and `rig` types to the issue type exclusion list in `GetReadyWork`
- Role and rig beads are reference metadata that should never be closed or appear as actionable work
- They are similar to agent beads which are already excluded

## Problem

Role beads (`hq-mayor-role`, `hq-deacon-role`, etc.) and rig beads (`da-rig-da`, etc.) were appearing in `bd ready` output, causing confusion. Agents would see them as actionable work and attempt to close them, when they are actually permanent reference metadata.

This was documented in AGENTS.md as a workaround ("ignore role beads in bd ready"), but the proper fix is to exclude these types automatically like agent, gate, and molecule types.

## Test plan

- [x] Run `go test ./internal/storage/sqlite/... -run Ready` - all pass
- [x] Run `go test ./cmd/bd/... -run Ready` - all pass
- [x] Verify `bd ready` excludes role/rig types with `--no-daemon` flag
- [x] Verify `bd ready --type=role` still works for explicit queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)