### PR TITLE
Fix: Dynamic status summary in bd list with icons

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -216,17 +216,39 @@ func displayPrettyListWithDeps(issues []*types.Issue, showHeader bool, allDeps m
 	// Summary
 	fmt.Println()
 	fmt.Println(strings.Repeat("-", 80))
-	openCount := 0
-	inProgressCount := 0
+
+	counts := make(map[types.Status]int)
 	for _, issue := range issues {
-		switch issue.Status {
-		case "open":
-			openCount++
-		case "in_progress":
-			inProgressCount++
+		counts[issue.Status]++
+	}
+
+	var details []string
+	// Order: open, in_progress, blocked, deferred, closed, pinned, hooked
+	displayOrder := []types.Status{
+		types.StatusOpen,
+		types.StatusInProgress,
+		types.StatusBlocked,
+		types.StatusDeferred,
+		types.StatusClosed,
+		types.StatusPinned,
+		types.StatusHooked,
+	}
+
+	for _, s := range displayOrder {
+		if c := counts[s]; c > 0 {
+			// Get styled icon for this status
+			icon := ui.RenderStatusIcon(string(s))
+			// Replace underscore in status name with space for better readability
+			name := strings.ReplaceAll(string(s), "_", " ")
+			details = append(details, fmt.Sprintf("%s %d %s", icon, c, name))
 		}
 	}
-	fmt.Printf("Total: %d issues (%d open, %d in progress)\n", len(issues), openCount, inProgressCount)
+
+	summary := fmt.Sprintf("Total: %d issues", len(issues))
+	if len(details) > 0 {
+		summary += fmt.Sprintf(" (%s)", strings.Join(details, ", "))
+	}
+	fmt.Println(summary)
 	fmt.Println()
 	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
 }


### PR DESCRIPTION
## Description

This PR addresses an issue where `bd list` summary was misleading when filtering by status (e.g., showing '0 in progress' when filtering for 'open' issues, even if in-progress issues exist).

**Original Issue:**
The user reported:
> bd list doesn't show "in_progress" status properly as seen from the output.
> ...
> Total: 15 issues (15 open, 0 in progress)
> ...
> But I have one IN_PROGRESS issue (directoryresearch-7i8) which was filtered out by --status open.

**The Fix:**
I have updated the summary generation logic in `cmd/bd/list.go` to:
1.  **Dynamic Counting:** Instead of hardcoding checks for only 'open' and 'in_progress', the summary now dynamically counts and displays *all* statuses present in the filtered result set.
2.  **Visual Consistency:** Added semantic status icons to the summary line (e.g., ○ for open, ◐ for in progress), ensuring it matches the visual style of the list items and the legend.
3.  **Readability:** Status names in the summary now have underscores replaced with spaces (e.g., 'in progress' instead of 'in_progress').

**Example Output:**
```text
Total: 15 issues (○ 15 open)
```
Or for a mixed list:
```text
Total: 16 issues (○ 15 open, ◐ 1 in progress)
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX improvement

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have verified the fix locally with manual testing (reproduced the issue and verified the fix)
- [x] I have not modified .beads/issues.jsonl (as per CONTRIBUTING.md)

## Testing

1.  Ran `bd list --status open` and verified the summary no longer claims '0 in progress'.
2.  Ran `bd list` (no filter) and verified it correctly counts and icons for multiple statuses.
