### PR TITLE
fix(routing): handle symlinked .beads directories correctly

### DIFF
--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -2,6 +2,8 @@ package routing
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -284,5 +286,108 @@ func TestDetectUserRole_DefaultContributor(t *testing.T) {
 	}
 	if role != Contributor {
 		t.Fatalf("expected %s, got %s", Contributor, role)
+	}
+}
+
+// TestFindTownRoutes_SymlinkedBeadsDir verifies that findTownRoutes correctly
+// handles symlinked .beads directories by using findTownRootFromCWD() instead of
+// walking up from the beadsDir path.
+//
+// Scenario: ~/gt/.beads is a symlink to ~/gt/olympus/.beads
+// Before fix: walking up from ~/gt/olympus/.beads finds ~/gt/olympus (WRONG)
+// After fix: findTownRootFromCWD() walks up from CWD to find mayor/town.json at ~/gt
+func TestFindTownRoutes_SymlinkedBeadsDir(t *testing.T) {
+	// Create temporary directory structure simulating Gas Town:
+	// tmpDir/
+	//   mayor/
+	//     town.json    <- town root marker
+	//   olympus/       <- actual beads storage
+	//     .beads/
+	//       routes.jsonl
+	//   .beads -> olympus/.beads  <- symlink
+	//   daedalus/
+	//     mayor/
+	//       rig/
+	//         .beads/  <- target rig
+	tmpDir, err := os.MkdirTemp("", "routing-symlink-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Resolve symlinks in tmpDir (macOS /var -> /private/var)
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mayor/town.json to mark town root
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	townJSON := filepath.Join(mayorDir, "town.json")
+	if err := os.WriteFile(townJSON, []byte(`{"name": "test-town"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create olympus/.beads with routes.jsonl
+	olympusBeadsDir := filepath.Join(tmpDir, "olympus", ".beads")
+	if err := os.MkdirAll(olympusBeadsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	routesContent := `{"prefix": "gt-", "path": "daedalus/mayor/rig"}
+`
+	routesPath := filepath.Join(olympusBeadsDir, "routes.jsonl")
+	if err := os.WriteFile(routesPath, []byte(routesContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create daedalus/mayor/rig/.beads as target rig
+	daedalusBeadsDir := filepath.Join(tmpDir, "daedalus", "mayor", "rig", ".beads")
+	if err := os.MkdirAll(daedalusBeadsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Create metadata.json so the rig is recognized as valid
+	if err := os.WriteFile(filepath.Join(daedalusBeadsDir, "metadata.json"), []byte(`{}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create symlink: tmpDir/.beads -> olympus/.beads
+	symlinkPath := filepath.Join(tmpDir, ".beads")
+	if err := os.Symlink(olympusBeadsDir, symlinkPath); err != nil {
+		t.Skip("Cannot create symlinks on this system (may require admin on Windows)")
+	}
+
+	// Change to the town root directory - this simulates the user running bd from ~/gt
+	// The fix uses findTownRootFromCWD() which needs CWD to be inside the town
+	t.Chdir(tmpDir)
+
+	// Simulate what happens when FindBeadsDir() returns the resolved symlink path
+	// (this is what CanonicalizePath does)
+	resolvedBeadsDir := olympusBeadsDir // This is what would be passed to findTownRoutes
+
+	// Call findTownRoutes with the resolved symlink path
+	routes, townRoot := findTownRoutes(resolvedBeadsDir)
+
+	// Verify we got the routes
+	if len(routes) == 0 {
+		t.Fatal("findTownRoutes returned no routes")
+	}
+
+	// Verify the town root is correct (should be tmpDir, NOT tmpDir/olympus)
+	if townRoot != tmpDir {
+		t.Errorf("findTownRoutes returned wrong townRoot:\n  got:  %s\n  want: %s", townRoot, tmpDir)
+	}
+
+	// Verify route resolution works - the route should resolve to the correct path
+	expectedRigPath := filepath.Join(tmpDir, "daedalus", "mayor", "rig", ".beads")
+	for _, route := range routes {
+		if route.Prefix == "gt-" {
+			actualPath := filepath.Join(townRoot, route.Path, ".beads")
+			if actualPath != expectedRigPath {
+				t.Errorf("Route resolution failed:\n  got:  %s\n  want: %s", actualPath, expectedRigPath)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`bd show <rig-prefix-id>` fails when `~/gt/.beads` is a symlink because `findTownRoutes()` uses `filepath.Dir()` on the resolved symlink path, finding the wrong town root.

This PR fixes the issue by walking up from CWD to find the town root, rather than from the beads directory path.

## Problem

When `.beads` is a symlink:
```bash
$ ls -la ~/gt/.beads
lrwxr-xr-x  .beads -> olympus/.beads
```

The routing breaks:
```bash
$ cd ~/gt && BD_DEBUG_ROUTING=1 bd show gt-6r7
[routing] ID gt-6r7 matched prefix gt- but target ~/gt/olympus/daedalus/mayor/rig/.beads not found
Error: no issue found
```

**Root cause:** `filepath.Dir("~/gt/olympus/.beads")` returns `~/gt/olympus` instead of `~/gt`.

## Changes

- Added `findTownRootFromCWD()` - walks up from CWD to find `mayor/town.json`
- Updated `findTownRoutes()` to use CWD-based town root detection when routes are found
- Added fallback to `filepath.Dir()` for non-Gas Town repos
- Added debug logging for routing decisions (`BD_DEBUG_ROUTING=1`)
- Added `TestFindTownRoutes_SymlinkedBeadsDir` test case

## Test Results

| Test Case | Result |
|-----------|--------|
| `TestFindTownRoutes_SymlinkedBeadsDir` | ✅ PASS |
| All existing routing tests | ✅ PASS |
| `go test ./internal/routing/...` | ✅ PASS |
| `go build ./...` | ✅ PASS |

## Reproduction

**Before fix:**
```bash
$ cd ~/gt && BD_DEBUG_ROUTING=1 bd show gt-6r7 --allow-stale
[routing] ID gt-6r7 matched prefix gt- but target /Users/.../gt/olympus/daedalus/mayor/rig/.beads not found
Error fetching gt-6r7: no issue found
```

**After fix:**
```bash
$ cd ~/gt && BD_DEBUG_ROUTING=1 bd show gt-6r7 --allow-stale
[routing] findTownRoutes: found routes in .../olympus/.beads, townRoot=/Users/.../gt (via findTownRootFromCWD)
✓ Found issue gt-6r7
```

## Why This Matters

Symlinked `.beads` directories are a valid configuration pattern in Gas Town. For example, pointing the town's `.beads` to a rig's `.beads` for centralized storage. Without this fix, any installation using symlinks breaks routing entirely.

The fix ensures routing works correctly regardless of filesystem layout by using the logical working directory rather than the resolved symlink path.

## Related

- Discovered while investigating: https://github.com/steveyegge/gastown/pull/512
- Discussion with root cause analysis: https://github.com/steveyegge/gastown/pull/512#issuecomment-3754421230
- Internal tracking: gt-2t2
