### PR TITLE
fix(context): complete RepoContext migration for remaining sync files

### DIFF
--- a/cmd/bd/reinit_test.go
+++ b/cmd/bd/reinit_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/types"
@@ -41,6 +42,7 @@ func TestDatabaseReinitialization(t *testing.T) {
 
 // testFreshCloneAutoImport verifies auto-import works on fresh clone
 func testFreshCloneAutoImport(t *testing.T) {
+	beads.ResetCaches() // Reset cached RepoContext between subtests
 	dir := t.TempDir()
 
 	// Initialize git repo
@@ -124,6 +126,7 @@ func testFreshCloneAutoImport(t *testing.T) {
 
 // testDatabaseRemovalScenario tests the primary bug scenario
 func testDatabaseRemovalScenario(t *testing.T) {
+	beads.ResetCaches() // Reset cached RepoContext between subtests
 	dir := t.TempDir()
 
 	// Initialize git repo
@@ -225,6 +228,7 @@ func testDatabaseRemovalScenario(t *testing.T) {
 
 // testLegacyFilenameSupport tests issues.jsonl fallback
 func testLegacyFilenameSupport(t *testing.T) {
+	beads.ResetCaches() // Reset cached RepoContext between subtests
 	dir := t.TempDir()
 
 	// Initialize git repo
@@ -303,6 +307,7 @@ func testLegacyFilenameSupport(t *testing.T) {
 
 // testPrecedenceTest verifies issues.jsonl is preferred over beads.jsonl
 func testPrecedenceTest(t *testing.T) {
+	beads.ResetCaches() // Reset cached RepoContext between subtests
 	dir := t.TempDir()
 
 	// Initialize git repo
@@ -358,6 +363,7 @@ func testPrecedenceTest(t *testing.T) {
 
 // testInitSafetyCheck tests the safety check that prevents silent data loss
 func testInitSafetyCheck(t *testing.T) {
+	beads.ResetCaches() // Reset cached RepoContext between subtests
 	dir := t.TempDir()
 
 	// Initialize git repo

--- a/cmd/bd/status.go
+++ b/cmd/bd/status.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -178,7 +180,8 @@ Examples:
 	},
 }
 
-// getGitActivity calculates activity stats from git log of issues.jsonl
+// getGitActivity calculates activity stats from git log of issues.jsonl.
+// GH#1110: Now uses RepoContext to ensure git commands run in beads repo.
 func getGitActivity(hours int) *RecentActivitySummary {
 	activity := &RecentActivitySummary{
 		HoursTracked: hours,
@@ -186,7 +189,12 @@ func getGitActivity(hours int) *RecentActivitySummary {
 
 	// Run git log to get patches for the last N hours
 	since := fmt.Sprintf("%d hours ago", hours)
-	cmd := exec.Command("git", "log", "--since="+since, "--numstat", "--pretty=format:%H", ".beads/issues.jsonl") // #nosec G204 -- bounded arguments for local git history inspection
+	var cmd *exec.Cmd
+	if rc, err := beads.GetRepoContext(); err == nil {
+		cmd = rc.GitCmd(context.Background(), "log", "--since="+since, "--numstat", "--pretty=format:%H", ".beads/issues.jsonl")
+	} else {
+		cmd = exec.Command("git", "log", "--since="+since, "--numstat", "--pretty=format:%H", ".beads/issues.jsonl") // #nosec G204 -- bounded arguments for local git history inspection
+	}
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -222,7 +230,11 @@ func getGitActivity(hours int) *RecentActivitySummary {
 	}
 
 	// Get detailed diff to analyze changes
-	cmd = exec.Command("git", "log", "--since="+since, "-p", ".beads/issues.jsonl") // #nosec G204 -- bounded arguments for local git history inspection
+	if rc, err := beads.GetRepoContext(); err == nil {
+		cmd = rc.GitCmd(context.Background(), "log", "--since="+since, "-p", ".beads/issues.jsonl")
+	} else {
+		cmd = exec.Command("git", "log", "--since="+since, "-p", ".beads/issues.jsonl") // #nosec G204 -- bounded arguments for local git history inspection
+	}
 	output, err = cmd.Output()
 	if err != nil {
 		return nil

--- a/cmd/bd/sync_branch.go
+++ b/cmd/bd/sync_branch.go
@@ -8,13 +8,22 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/syncbranch"
 )
 
-// getCurrentBranch returns the name of the current git branch
+// getCurrentBranch returns the name of the current git branch in the beads repo.
 // Uses symbolic-ref instead of rev-parse to work in fresh repos without commits (bd-flil)
+// GH#1110: Now uses RepoContext to ensure we query the beads repo, not CWD.
+// Falls back to CWD-based query if no beads context found (for tests/standalone git).
 func getCurrentBranch(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "--short", "HEAD")
+	var cmd *exec.Cmd
+	if rc, err := beads.GetRepoContext(); err == nil {
+		cmd = rc.GitCmd(ctx, "symbolic-ref", "--short", "HEAD")
+	} else {
+		// Fallback to CWD for tests or repos without beads
+		cmd = exec.CommandContext(ctx, "git", "symbolic-ref", "--short", "HEAD")
+	}
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current branch: %w", err)
@@ -53,10 +62,16 @@ func getSyncBranch(ctx context.Context) (string, error) {
 	return syncBranch, nil
 }
 
-// showSyncStatus shows the diff between sync branch and main branch
+// showSyncStatus shows the diff between sync branch and main branch.
+// GH#1110: Now uses RepoContext to ensure git commands run in beads repo.
 func showSyncStatus(ctx context.Context) error {
 	if !isGitRepo() {
 		return fmt.Errorf("not in a git repository")
+	}
+
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		return fmt.Errorf("failed to get repo context: %w", err)
 	}
 
 	currentBranch := getCurrentBranchOrHEAD(ctx)
@@ -67,7 +82,7 @@ func showSyncStatus(ctx context.Context) error {
 	}
 
 	// Check if sync branch exists
-	checkCmd := exec.CommandContext(ctx, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+syncBranch) //nolint:gosec // syncBranch from config
+	checkCmd := rc.GitCmd(ctx, "show-ref", "--verify", "--quiet", "refs/heads/"+syncBranch)
 	if err := checkCmd.Run(); err != nil {
 		return fmt.Errorf("sync branch '%s' does not exist", syncBranch)
 	}
@@ -77,7 +92,7 @@ func showSyncStatus(ctx context.Context) error {
 
 	// Show commit diff
 	fmt.Println("Commits in sync branch not in main:")
-	logCmd := exec.CommandContext(ctx, "git", "log", "--oneline", currentBranch+".."+syncBranch) //nolint:gosec // branch names from git
+	logCmd := rc.GitCmd(ctx, "log", "--oneline", currentBranch+".."+syncBranch)
 	logOutput, err := logCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to get commit log: %w\n%s", err, logOutput)
@@ -90,7 +105,7 @@ func showSyncStatus(ctx context.Context) error {
 	}
 
 	fmt.Println("\nCommits in main not in sync branch:")
-	logCmd = exec.CommandContext(ctx, "git", "log", "--oneline", syncBranch+".."+currentBranch) //nolint:gosec // branch names from git
+	logCmd = rc.GitCmd(ctx, "log", "--oneline", syncBranch+".."+currentBranch)
 	logOutput, err = logCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to get commit log: %w\n%s", err, logOutput)
@@ -104,7 +119,7 @@ func showSyncStatus(ctx context.Context) error {
 
 	// Show file diff for .beads/issues.jsonl
 	fmt.Println("\nFile differences in .beads/issues.jsonl:")
-	diffCmd := exec.CommandContext(ctx, "git", "diff", currentBranch+"..."+syncBranch, "--", ".beads/issues.jsonl") //nolint:gosec // branch names from git
+	diffCmd := rc.GitCmd(ctx, "diff", currentBranch+"..."+syncBranch, "--", ".beads/issues.jsonl")
 	diffOutput, err := diffCmd.CombinedOutput()
 	if err != nil {
 		// diff returns non-zero when there are differences, which is fine
@@ -122,10 +137,16 @@ func showSyncStatus(ctx context.Context) error {
 	return nil
 }
 
-// mergeSyncBranch merges the sync branch back to the main branch
+// mergeSyncBranch merges the sync branch back to the main branch.
+// GH#1110: Now uses RepoContext to ensure git commands run in beads repo.
 func mergeSyncBranch(ctx context.Context, dryRun bool) error {
 	if !isGitRepo() {
 		return fmt.Errorf("not in a git repository")
+	}
+
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		return fmt.Errorf("failed to get repo context: %w", err)
 	}
 
 	currentBranch, err := getCurrentBranch(ctx)
@@ -139,13 +160,13 @@ func mergeSyncBranch(ctx context.Context, dryRun bool) error {
 	}
 
 	// Check if sync branch exists
-	checkCmd := exec.CommandContext(ctx, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+syncBranch) //nolint:gosec // syncBranch from config
+	checkCmd := rc.GitCmd(ctx, "show-ref", "--verify", "--quiet", "refs/heads/"+syncBranch)
 	if err := checkCmd.Run(); err != nil {
 		return fmt.Errorf("sync branch '%s' does not exist", syncBranch)
 	}
 
 	// Check if there are uncommitted changes
-	statusCmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
+	statusCmd := rc.GitCmd(ctx, "status", "--porcelain")
 	statusOutput, err := statusCmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to check git status: %w", err)
@@ -159,7 +180,7 @@ func mergeSyncBranch(ctx context.Context, dryRun bool) error {
 	if dryRun {
 		fmt.Println("→ [DRY RUN] Would merge sync branch")
 		// Show what would be merged
-		logCmd := exec.CommandContext(ctx, "git", "log", "--oneline", currentBranch+".."+syncBranch) //nolint:gosec // branch names from git
+		logCmd := rc.GitCmd(ctx, "log", "--oneline", currentBranch+".."+syncBranch)
 		logOutput, _ := logCmd.CombinedOutput()
 		if len(strings.TrimSpace(string(logOutput))) > 0 {
 			fmt.Println("\nCommits that would be merged:")
@@ -171,7 +192,7 @@ func mergeSyncBranch(ctx context.Context, dryRun bool) error {
 	}
 
 	// Perform the merge
-	mergeCmd := exec.CommandContext(ctx, "git", "merge", syncBranch, "-m", fmt.Sprintf("Merge sync branch '%s'", syncBranch)) //nolint:gosec // syncBranch from config
+	mergeCmd := rc.GitCmd(ctx, "merge", syncBranch, "-m", fmt.Sprintf("Merge sync branch '%s'", syncBranch))
 	mergeOutput, err := mergeCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("merge failed: %w\n%s", err, mergeOutput)


### PR DESCRIPTION
## Summary

Follow-up to #1102 - migrates remaining git command locations to use RepoContext API for correct repo resolution when `BEADS_DIR` is set.

### Files Migrated

| File | Functions | Git Commands |
|------|-----------|--------------|
| `sync_branch.go` | `getCurrentBranch`, `showSyncStatus`, `mergeSyncBranch` | 9 |
| `sync_check.go` | `checkForcedPush` | 5 |
| `sync_import.go` | `doSyncFromMain` | 3 |
| `autoimport.go` | `readFromGitRef`, `checkGitForIssues` | 4 |
| `status.go` | `getGitActivity` | 2 |
| `import.go` | `attemptAutoMerge` | 1 (gitRoot lookup) |
| `reinit_test.go` | Test isolation | `ResetCaches()` calls |

### Pattern Used

```go
var cmd *exec.Cmd
if rc, err := beads.GetRepoContext(); err == nil {
    cmd = rc.GitCmd(ctx, "git-args...")
} else {
    // Fallback to CWD for tests or repos without beads
    cmd = exec.CommandContext(ctx, "git", "git-args...")
}
```

This ensures:
- Git commands run in beads repo (not CWD) when BEADS_DIR is set
- Graceful fallback for tests and standalone git repos
- Backwards compatibility maintained

## Related

- Continues work from #1102
- Addresses edge cases for GH#1110

## Test Plan

- [x] Unit tests pass (pre-existing failures unrelated to these changes)
- [x] Build succeeds
- [ ] Manual test: `cd /other/repo && BEADS_DIR=/beads/repo bd sync`