### PR TITLE
fix: allow shell completions to work without a database

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -355,6 +355,8 @@ var rootCmd = &cobra.Command{
 		// Skip database initialization for commands that don't need a database
 		noDbCommands := []string{
 			cmdDaemon,
+			"__complete",       // Cobra's internal completion command (shell completions work without db)
+			"__completeNoDesc", // Cobra's completion without descriptions (used by fish)
 			"bash",
 			"completion",
 			"doctor",


### PR DESCRIPTION
## Summary
- Add `__complete` to noDbCommands list so Cobra's internal completion command can run without requiring a beads database
- Shell completions now work in directories without `.beads` - they return empty results gracefully instead of failing with "no beads database found"
- Added integration test that verifies `__complete` command works without a database

## Problem
Running shell completions (e.g., `bd show <TAB>`) in a directory without a `.beads` database would fail with:
```
Error: no beads database found
```

This made completions unusable outside of beads-enabled directories.

## Solution
The `__complete` command is Cobra's internal command used by shell completion scripts. By adding it to the `noDbCommands` list, `PersistentPreRun` skips database initialization for completion requests.

The `issueIDCompletion` function already handles missing databases gracefully by returning empty completions, so this change just allows it to be reached.