### PR TITLE
fix(storage): normalize timestamps to UTC to prevent validation failures

### DIFF
--- a/internal/storage/dolt/dirty.go
+++ b/internal/storage/dolt/dirty.go
@@ -82,7 +82,7 @@ func (s *DoltStore) SetExportHash(ctx context.Context, issueID, contentHash stri
 		INSERT INTO export_hashes (issue_id, content_hash, exported_at)
 		VALUES (?, ?, ?)
 		ON DUPLICATE KEY UPDATE content_hash = VALUES(content_hash), exported_at = VALUES(exported_at)
-	`, issueID, contentHash, time.Now())
+	`, issueID, contentHash, time.Now().UTC())
 	if err != nil {
 		return fmt.Errorf("failed to set export hash: %w", err)
 	}

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -68,7 +68,7 @@ func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text s
 	result, err := s.db.ExecContext(ctx, `
 		INSERT INTO comments (issue_id, author, text, created_at)
 		VALUES (?, ?, ?, ?)
-	`, issueID, author, text, time.Now())
+	`, issueID, author, text, time.Now().UTC())
 	if err != nil {
 		return nil, fmt.Errorf("failed to add comment: %w", err)
 	}
@@ -83,7 +83,7 @@ func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text s
 		IssueID:   issueID,
 		Author:    author,
 		Text:      text,
-		CreatedAt: time.Now(),
+		CreatedAt: time.Now().UTC(),
 	}, nil
 }
 

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -24,7 +24,7 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 	}
 
 	// Set timestamps
-	now := time.Now()
+	now := time.Now().UTC()
 	if issue.CreatedAt.IsZero() {
 		issue.CreatedAt = now
 	}
@@ -136,7 +136,7 @@ func (s *DoltStore) CreateIssues(ctx context.Context, issues []*types.Issue, act
 	defer func() { _ = tx.Rollback() }()
 
 	for _, issue := range issues {
-		now := time.Now()
+		now := time.Now().UTC()
 		if issue.CreatedAt.IsZero() {
 			issue.CreatedAt = now
 		}
@@ -239,7 +239,7 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 
 	// Build update query
 	setClauses := []string{"updated_at = ?"}
-	args := []interface{}{time.Now()}
+	args := []interface{}{time.Now().UTC()}
 
 	for key, value := range updates {
 		if !isAllowedUpdateField(key) {
@@ -289,7 +289,7 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 
 // CloseIssue closes an issue with a reason
 func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
-	now := time.Now()
+	now := time.Now().UTC()
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -597,7 +597,7 @@ func markDirty(ctx context.Context, tx *sql.Tx, issueID string) error {
 		INSERT INTO dirty_issues (issue_id, marked_at)
 		VALUES (?, ?)
 		ON DUPLICATE KEY UPDATE marked_at = VALUES(marked_at)
-	`, issueID, time.Now())
+	`, issueID, time.Now().UTC())
 	return err
 }
 
@@ -645,7 +645,7 @@ func manageClosedAt(oldIssue *types.Issue, updates map[string]interface{}, setCl
 	}
 
 	if newStatus == string(types.StatusClosed) {
-		now := time.Now()
+		now := time.Now().UTC()
 		setClauses = append(setClauses, "closed_at = ?")
 		args = append(args, now)
 	} else if oldIssue.Status == types.StatusClosed {

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -198,7 +198,7 @@ func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types
 	}
 	if filter.Overdue {
 		whereClauses = append(whereClauses, "due_at IS NOT NULL AND due_at < ? AND status != ?")
-		args = append(args, time.Now().Format(time.RFC3339), types.StatusClosed)
+		args = append(args, time.Now().UTC().Format(time.RFC3339), types.StatusClosed)
 	}
 
 	whereSQL := ""
@@ -402,7 +402,7 @@ func (s *DoltStore) GetEpicsEligibleForClosure(ctx context.Context) ([]*types.Ep
 
 // GetStaleIssues returns issues that haven't been updated recently
 func (s *DoltStore) GetStaleIssues(ctx context.Context, filter types.StaleFilter) ([]*types.Issue, error) {
-	cutoff := time.Now().AddDate(0, 0, -filter.Days)
+	cutoff := time.Now().UTC().AddDate(0, 0, -filter.Days)
 
 	statusClause := "status IN ('open', 'in_progress')"
 	if filter.Status != "" {

--- a/internal/storage/dolt/rename.go
+++ b/internal/storage/dolt/rename.go
@@ -21,7 +21,7 @@ func (s *DoltStore) UpdateIssueID(ctx context.Context, oldID, newID string, issu
 		UPDATE issues
 		SET id = ?, title = ?, description = ?, design = ?, acceptance_criteria = ?, notes = ?, updated_at = ?
 		WHERE id = ?
-	`, newID, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes, time.Now(), oldID)
+	`, newID, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes, time.Now().UTC(), oldID)
 	if err != nil {
 		return fmt.Errorf("failed to update issue ID: %w", err)
 	}
@@ -68,7 +68,7 @@ func (s *DoltStore) UpdateIssueID(ctx context.Context, oldID, newID string, issu
 		INSERT INTO dirty_issues (issue_id, marked_at)
 		VALUES (?, ?)
 		ON DUPLICATE KEY UPDATE marked_at = VALUES(marked_at)
-	`, newID, time.Now())
+	`, newID, time.Now().UTC())
 	if err != nil {
 		return fmt.Errorf("failed to mark issue dirty: %w", err)
 	}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -43,7 +43,7 @@ func (s *DoltStore) RunInTransaction(ctx context.Context, fn func(tx storage.Tra
 
 // CreateIssue creates an issue within the transaction
 func (t *doltTransaction) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	if issue.CreatedAt.IsZero() {
 		issue.CreatedAt = now
 	}
@@ -122,7 +122,7 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 // UpdateIssue updates an issue within the transaction
 func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
 	setClauses := []string{"updated_at = ?"}
-	args := []interface{}{time.Now()}
+	args := []interface{}{time.Now().UTC()}
 
 	for key, value := range updates {
 		if !isAllowedUpdateField(key) {
@@ -145,7 +145,7 @@ func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates ma
 
 // CloseIssue closes an issue within the transaction
 func (t *doltTransaction) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
-	now := time.Now()
+	now := time.Now().UTC()
 	_, err := t.tx.ExecContext(ctx, `
 		UPDATE issues SET status = ?, closed_at = ?, updated_at = ?, close_reason = ?, closed_by_session = ?
 		WHERE id = ?


### PR DESCRIPTION
## Summary

This fixes a subtle timezone bug that can cause `bv` validation to reject beads with an error indicating `updated_at` is earlier than `created_at`.

## The Bug

When beads are created or updated through different code paths, timestamps can end up with mixed timezone formats:

- Some paths produce UTC timestamps: `2026-01-15T21:52:00Z`
- Others produce local time with offset: `2026-01-15T22:24:44+01:00`

When `created_at` is UTC and `updated_at` is local, the **absolute times can be inverted**:

```
created_at: 2026-01-15T21:52:00Z      (21:52 UTC)
updated_at: 2026-01-15T22:24:44+01:00 (21:24 UTC) ← actually earlier!
```

This causes validation to fail because `updated_at` appears to be before `created_at`.

## The Fix

Normalize all `time.Now()` calls to `time.Now().UTC()` in the dolt storage layer. This ensures all timestamps are stored consistently in UTC, regardless of the server's local timezone.

**Files modified:**
- `transaction.go` - CreateIssue, UpdateIssue, CloseIssue
- `issues.go` - CreateIssue, CreateIssues, UpdateIssue, CloseIssue, markDirty, manageClosedAt
- `rename.go` - UpdateIssueID (2 locations)
- `events.go` - AddIssueComment (2 locations)
- `dirty.go` - SetExportHash
- `queries.go` - Overdue filter, GetStaleIssues

## Testing

- All existing tests pass
- Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)