### PR TITLE
Add Beads-Kanban VSCode extension to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -30,6 +30,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[Agent Native Abstraction Layer for Beads](https://marketplace.visualstudio.com/items?itemName=AgentNativeAbstractionLayer.agent-native-kanban)** (ANAL Beads) - VS Code Kanban board. Maintained by [@sebcook-ctrl](https://github.com/sebcook-ctrl). (Node.js)
 
+- **[Beads-Kanban](https://github.com/davidcforbes/Beads-Kanban)** - VS Code Kanban board for Beads issue tracking. Maintained by [@davidcforbes](https://github.com/davidcforbes). (TypeScript)
+
 - **[opencode-beads](https://github.com/joshuadavidthomas/opencode-beads)** - OpenCode plugin with automatic context injection, `/bd-*` slash commands, and autonomous task agent. Built by [@joshuadavidthomas](https://github.com/joshuadavidthomas). (Node.js)
 
 ## Native Apps


### PR DESCRIPTION
## Summary

add Beads-Kanban to the Editor Extensions in docs/COMMUNITY_TOOLS.md

[Beads-Kanban](https://github.com/davidcforbes/beads-tui.git) - VS Code extension for Beads Issue Kanban board, TableView, and Record Form Editor. Maintained by [@davidcforbes] (Node.js)


