### PR TITLE
Fix git hooks not working in worktrees

### DIFF
--- a/cmd/bd/doctor/fix/hooks.go
+++ b/cmd/bd/doctor/fix/hooks.go
@@ -108,20 +108,20 @@ var hookManagerPatterns = []hookManagerPattern{
 // DetectActiveHookManager reads the git hooks to determine which manager installed them.
 // This is more reliable than just checking for config files when multiple managers exist.
 func DetectActiveHookManager(path string) string {
-	// Get git dir
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	// Get common git dir (hooks are shared across worktrees)
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = path
 	output, err := cmd.Output()
 	if err != nil {
 		return ""
 	}
-	gitDir := strings.TrimSpace(string(output))
-	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(path, gitDir)
+	gitCommonDir := strings.TrimSpace(string(output))
+	if !filepath.IsAbs(gitCommonDir) {
+		gitCommonDir = filepath.Join(path, gitCommonDir)
 	}
 
 	// Check for custom hooks path (core.hooksPath)
-	hooksDir := filepath.Join(gitDir, "hooks")
+	hooksDir := filepath.Join(gitCommonDir, "hooks")
 	hooksPathCmd := exec.Command("git", "config", "--get", "core.hooksPath")
 	hooksPathCmd.Dir = path
 	if hooksPathOutput, err := hooksPathCmd.Output(); err == nil {

--- a/cmd/bd/init_git_hooks.go
+++ b/cmd/bd/init_git_hooks.go
@@ -21,12 +21,12 @@ var preCommitFrameworkPattern = regexp.MustCompile(`(?i)(pre-commit\s+run|prek\s
 
 // hooksInstalled checks if bd git hooks are installed
 func hooksInstalled() bool {
-	gitDir, err := git.GetGitDir()
+	hooksDir, err := git.GetGitHooksDir()
 	if err != nil {
 		return false
 	}
-	preCommit := filepath.Join(gitDir, "hooks", "pre-commit")
-	postMerge := filepath.Join(gitDir, "hooks", "post-merge")
+	preCommit := filepath.Join(hooksDir, "pre-commit")
+	postMerge := filepath.Join(hooksDir, "post-merge")
 
 	// Check if both hooks exist
 	_, err1 := os.Stat(preCommit)
@@ -81,11 +81,10 @@ type hookInfo struct {
 
 // detectExistingHooks scans for existing git hooks
 func detectExistingHooks() []hookInfo {
-	gitDir, err := git.GetGitDir()
+	hooksDir, err := git.GetGitHooksDir()
 	if err != nil {
 		return nil
 	}
-	hooksDir := filepath.Join(gitDir, "hooks")
 	hooks := []hookInfo{
 		{name: "pre-commit", path: filepath.Join(hooksDir, "pre-commit")},
 		{name: "post-merge", path: filepath.Join(hooksDir, "post-merge")},
@@ -137,11 +136,10 @@ func promptHookAction(existingHooks []hookInfo) string {
 
 // installGitHooks installs git hooks inline (no external dependencies)
 func installGitHooks() error {
-	gitDir, err := git.GetGitDir()
+	hooksDir, err := git.GetGitHooksDir()
 	if err != nil {
 		return err
 	}
-	hooksDir := filepath.Join(gitDir, "hooks")
 
 	// Ensure hooks directory exists
 	if err := os.MkdirAll(hooksDir, 0750); err != nil {

--- a/internal/git/gitdir.go
+++ b/internal/git/gitdir.go
@@ -118,13 +118,15 @@ func GetGitCommonDir() (string, error) {
 }
 
 // GetGitHooksDir returns the path to the Git hooks directory.
-// This function is worktree-aware and handles both regular repos and worktrees.
+// This function is worktree-aware: hooks are shared across all worktrees
+// and live in the common git directory (e.g., /repo/.git/hooks), not in
+// the worktree-specific directory (e.g., /repo/.git/worktrees/feature/hooks).
 func GetGitHooksDir() (string, error) {
-	gitDir, err := GetGitDir()
+	commonDir, err := GetGitCommonDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(gitDir, "hooks"), nil
+	return filepath.Join(commonDir, "hooks"), nil
 }
 
 // GetGitRefsDir returns the path to the Git refs directory.


### PR DESCRIPTION
## Summary

Fixes #1127

Git hooks are shared across all worktrees and live in the common git directory, not the worktree-specific directory. Several places were using `GetGitDir()` or `--git-dir`, causing hooks to not be found when running in a worktree.

## Background: gitDir vs gitCommonDir

| Function | Regular Repo | Worktree |
|----------|--------------|----------|
| `GetGitDir()` / `--git-dir` | `/repo/.git` | `/repo/.git/worktrees/feature-branch` |
| `GetGitCommonDir()` / `--git-common-dir` | `/repo/.git` | `/repo/.git` |

Git stores hooks in the **common** directory (`/repo/.git/hooks`) so they're shared across all worktrees. The bug was that code was using `GetGitDir()` or `--git-dir`, which in a worktree returns the worktree-specific path where hooks don't exist.

## Changes

1. `GetGitHooksDir()` now uses `GetGitCommonDir()` instead of `GetGitDir()`
2. `runChainedHook()` now uses `GetGitHooksDir()`
3. `DetectActiveHookManager()` now uses `--git-common-dir`
4. `CheckGitHooks()` now uses `GetGitHooksDir()`
5. `CheckSyncBranchHookCompatibility()` now uses `--git-common-dir`
6. Hook installation/detection functions now use `GetGitHooksDir()`

## Symptoms this fixes

- Chained hooks (e.g., `pre-commit.old`) not running in worktrees
- `bd hooks install` installing to wrong directory in worktrees
- `bd hooks list` showing incorrect status in worktrees
- `bd doctor` showing incorrect hook status/detection in worktrees

## Test plan

- [x] All existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)