### PR TITLE
fix: Mark dependent issues dirty when deleting to prevent orphan deps in JSONL

### DIFF
--- a/internal/storage/sqlite/queries.go
+++ b/internal/storage/sqlite/queries.go
@@ -1343,6 +1343,32 @@ func (s *SQLiteStorage) DeleteIssue(ctx context.Context, id string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	// Mark issues that depend on this one as dirty so they get re-exported
+	// without the stale dependency reference (fixes orphan deps in JSONL)
+	rows, err := tx.QueryContext(ctx, `SELECT issue_id FROM dependencies WHERE depends_on_id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("failed to query dependent issues: %w", err)
+	}
+	var dependentIDs []string
+	for rows.Next() {
+		var depID string
+		if err := rows.Scan(&depID); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("failed to scan dependent issue ID: %w", err)
+		}
+		dependentIDs = append(dependentIDs, depID)
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate dependent issues: %w", err)
+	}
+
+	if len(dependentIDs) > 0 {
+		if err := markIssuesDirtyTx(ctx, tx, dependentIDs); err != nil {
+			return fmt.Errorf("failed to mark dependent issues dirty: %w", err)
+		}
+	}
+
 	// Delete dependencies (both directions)
 	_, err = tx.ExecContext(ctx, `DELETE FROM dependencies WHERE issue_id = ? OR depends_on_id = ?`, id, id)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix bug where deleting an issue leaves orphan dependency references in JSONL
- Add test `TestDeleteIssueMarksDependentsDirty` to verify the fix

## Problem

When an issue is deleted, issues that depend on it were not being marked dirty. This caused stale dependency references to persist in JSONL after the target issue was deleted, because the dependent issues were never re-exported.

This manifests as FK validation failures during multi-repo hydration:
```
foreign key violation: issue X depends on non-existent issue Y
```

Common scenario:
1. Patrol molecule (wisp) is created
2. Squash creates digest with parent-child dependency to wisp root
3. Digest is flushed to JSONL with dependency
4. Later, wisp is deleted (cleanup)
5. Dependency row deleted from DB, but digest not marked dirty
6. JSONL retains stale dependency → FK violation on hydration

## Solution

Before deleting dependencies in `DeleteIssue()`, query for issues that depend on the deleted issue and mark them dirty. This ensures they get re-exported without the stale reference.

## Additional Considerations

For existing data with orphan dependencies, additional cleanup may be needed:
- Consider adding a `bd doctor --fix` check that removes dependencies pointing to ephemeral issues
- Or filter ephemeral-target deps during JSONL export in `GetAllDependencyRecords()`

## Test plan

- [x] New test `TestDeleteIssueMarksDependentsDirty` verifies fix
- [x] All existing delete tests pass
- [x] Manually verified multi-repo hydration works after fix

🤖 Generated with [Claude Code](https://claude.ai/code)