### PR TITLE
fix(utils): prevent nil pointer panic in ResolvePartialID

### DIFF
--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -37,6 +37,10 @@ func ParseIssueID(input string, prefix string) string {
 // - No issue found matching the ID
 // - Multiple issues match (ambiguous prefix)
 func ResolvePartialID(ctx context.Context, store storage.Storage, input string) (string, error) {
+	if store == nil {
+		return "", fmt.Errorf("cannot resolve issue ID %q: storage is nil", input)
+	}
+
 	// Fast path: Use SearchIssues with exact ID filter (GH#942).
 	// This uses the same query path as "bd list --id", ensuring consistency.
 	// Previously we used GetIssue which could fail in cases where SearchIssues

--- a/internal/utils/id_parser_test.go
+++ b/internal/utils/id_parser_test.go
@@ -316,6 +316,21 @@ func TestResolvePartialID_NoConfig(t *testing.T) {
 	}
 }
 
+func TestResolvePartialID_NilStorage(t *testing.T) {
+	ctx := context.Background()
+
+	// Test that nil storage returns an error instead of panicking
+	_, err := ResolvePartialID(ctx, nil, "bd-123")
+	if err == nil {
+		t.Fatal("ResolvePartialID with nil storage should return error, got nil")
+	}
+
+	expectedMsg := "storage is nil"
+	if !contains(err.Error(), expectedMsg) {
+		t.Errorf("ResolvePartialID error = %q; want error containing %q", err.Error(), expectedMsg)
+	}
+}
+
 func TestExtractIssuePrefix(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Adds nil check at start of `ResolvePartialID` to return a proper error instead of panicking

## Problem
When `ResolvePartialID` is called with a nil storage (e.g., in daemon mode where the global store isn't initialized), the function would panic with a nil pointer dereference. This manifests when running commands like `bd refile` in daemon mode.

## Solution
Add a defensive nil check that returns a clear error message:
```go
if store == nil {
    return "", fmt.Errorf("cannot resolve issue ID %q: storage is nil", input)
}
```

## Test plan
- [x] Added unit test for nil storage case
- [x] Verified existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)