### PR TITLE
fix(sync): write to worktree JSONL only when sync-branch configured

### DIFF
--- a/cmd/bd/sync_branch.go
+++ b/cmd/bd/sync_branch.go
@@ -175,6 +175,11 @@ func mergeSyncBranch(ctx context.Context, dryRun bool) error {
 		return fmt.Errorf("uncommitted changes detected - commit or stash them first")
 	}
 
+	// GH#1103: Skip-worktree conflict handling removed.
+	// The architectural fix ensures daemon/bd writes ONLY to the worktree JSONL
+	// when sync-branch is configured, so main's JSONL never has uncommitted changes
+	// that would conflict with merge. See autoflush.go:findJSONLPath()
+
 	fmt.Printf("Merging sync branch '%s' into '%s'...\n", syncBranch, currentBranch)
 
 	if dryRun {
@@ -277,6 +282,11 @@ func getRepoRootFromPath(ctx context.Context, path string) (string, error) {
 	}
 	return strings.TrimSpace(string(output)), nil
 }
+
+// detectAndClearSkipWorktree and restoreSkipWorktree were removed in GH#1103.
+// The architectural fix ensures daemon/bd writes ONLY to the worktree JSONL
+// when sync-branch is configured, eliminating the need for skip-worktree manipulation.
+// See autoflush.go:findJSONLPath() for the implementation.
 
 // commitToExternalBeadsRepo commits changes directly to an external beads repo.
 // Used when BEADS_DIR points to a different git repository than cwd.


### PR DESCRIPTION
## Summary
- Fixes #1103: `bd sync --merge` fails when sync-branch configured due to skip-worktree/daemon write conflict
- When sync-branch is configured, redirects all JSONL writes to the worktree only
- Main repo's JSONL is now read-only and only updated via merges from the sync branch

## Root Cause
When sync-branch is configured, daemon/bd writes to main's `.beads/issues.jsonl` which has skip-worktree set. This hides changes from `git status` but `git merge` still detects them, causing "local changes would be overwritten by merge" errors.

## Solution
Architectural fix: when sync-branch is configured, `findJSONLPath()` returns the worktree JSONL path instead of main's. This ensures:
1. All daemon/bd writes go to worktree JSONL only
2. Main's JSONL never has uncommitted changes
3. `bd sync --merge` always merges cleanly

## Test plan
- [x] Build succeeds: `go build ./cmd/bd`
- [x] Key sync-branch tests pass: `TestSyncBranchE2E`, `TestSyncBranchModeWithPullFirst`
- [ ] Manual testing with sync-branch workflow