### PR TITLE
fix(create): validate explicit IDs against allowed_prefixes using starts-with matching

### DIFF
--- a/internal/validation/bead_test.go
+++ b/internal/validation/bead_test.go
@@ -327,6 +327,56 @@ func TestValidatePrefixWithAllowed(t *testing.T) {
 	}
 }
 
+// TestValidateIDPrefixAllowed tests the new function that validates IDs using
+// "starts with" matching to handle multi-hyphen prefixes correctly (GH#1135).
+func TestValidateIDPrefixAllowed(t *testing.T) {
+	tests := []struct {
+		name            string
+		id              string
+		dbPrefix        string
+		allowedPrefixes string
+		force           bool
+		wantError       bool
+	}{
+		// Basic cases
+		{"matching prefix", "bd-abc123", "bd", "", false, false},
+		{"empty db prefix", "bd-abc123", "", "", false, false},
+		{"mismatched with force", "foo-abc123", "bd", "", true, false},
+		{"mismatched without force", "foo-abc123", "bd", "", false, true},
+
+		// Multi-hyphen prefix cases (GH#1135 - the main bug)
+		{"hq-cv prefix with word suffix", "hq-cv-test", "djdefi-ops", "hq,hq-cv", false, false},
+		{"hq-cv prefix with hash suffix", "hq-cv-abc123", "djdefi-ops", "hq,hq-cv", false, false},
+		{"djdefi-ops with word suffix", "djdefi-ops-test", "djdefi-ops", "", false, false},
+
+		// Allowed prefixes list
+		{"allowed prefix gt", "gt-abc123", "hq", "gt,hmc", false, false},
+		{"allowed prefix hmc", "hmc-abc123", "hq", "gt,hmc", false, false},
+		{"primary prefix still works", "hq-abc123", "hq", "gt,hmc", false, false},
+		{"prefix not in allowed list", "foo-abc123", "hq", "gt,hmc", false, true},
+
+		// Edge cases
+		{"allowed with spaces", "gt-abc123", "hq", "gt, hmc, foo", false, false},
+		{"allowed with trailing dash", "gt-abc123", "hq", "gt-, hmc-", false, false},
+		{"empty allowed list", "gt-abc123", "hq", "", false, true},
+		{"single allowed prefix", "gt-abc123", "hq", "gt", false, false},
+
+		// Multi-hyphen allowed prefixes
+		{"multi-hyphen in allowed list", "my-cool-prefix-abc123", "hq", "my-cool-prefix,other", false, false},
+		{"partial match should fail", "hq-cv-extra-test", "hq", "hq-cv-extra", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateIDPrefixAllowed(tt.id, tt.dbPrefix, tt.allowedPrefixes, tt.force)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ValidateIDPrefixAllowed(%q, %q, %q) error = %v, wantError %v",
+					tt.id, tt.dbPrefix, tt.allowedPrefixes, err, tt.wantError)
+			}
+		})
+	}
+}
+
 func TestValidateAgentID(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Fixes #1135 - `bd create` was rejecting explicit IDs with prefixes listed in `allowed_prefixes`.

### Root Cause

When creating an issue with `bd create --id hq-cv-test`:

1. `ExtractIssuePrefix("hq-cv-test")` returns `"hq"` (not `"hq-cv"`)
   - Because "test" looks like an English word, the algorithm falls back to the first hyphen
2. `ValidatePrefixWithAllowed("hq", "djdefi-ops", "hq,hq-cv", false)` fails
   - It checks if `"hq"` equals any entry in the allowed list
   - The list contains `"hq-cv"`, not `"hq"`, so validation fails

### The Fix

Added `ValidateIDPrefixAllowed()` which validates the full ID using **"starts with" matching** instead of extracting the prefix first:

```go
// Checks if ID starts with any allowed prefix + "-"
if strings.HasPrefix(id, allowed+"-") {
    return nil
}
```

This is the same approach the importer uses successfully in `handlePrefixMismatch()`.

### Changes Made

- **internal/validation/bead.go**: Added `ValidateIDPrefixAllowed()` function
- **cmd/bd/create.go**: Use new function for explicit ID validation
- **internal/validation/bead_test.go**: Added comprehensive tests

### Backward Compatibility

✅ **Maintained**: Existing validation behavior unchanged for simple prefixes
✅ **Fixed**: Multi-hyphen prefixes like `hq-cv-` now work correctly

### Test Plan

- [x] `TestValidateIDPrefixAllowed` covers all cases including the bug scenario
- [x] Existing validation tests still pass

### Size: Small ✓

98 lines added, 2 lines removed.

🤖 Generated with [Claude Code](https://claude.ai/code)