### PR TITLE
docs: fix AGENTS.md references to nonexistent CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ See [AGENT_INSTRUCTIONS.md](AGENT_INSTRUCTIONS.md) for full instructions.
 
 This file exists for compatibility with tools that look for AGENTS.md.
 
-## Key Sections in CLAUDE.md
+## Key Sections
 
 - **Issue Tracking** - How to use bd for work management
 - **Development Guidelines** - Code standards and testing
@@ -18,7 +18,7 @@ This file exists for compatibility with tools that look for AGENTS.md.
 - Status: `○ ◐ ● ✓ ❄`
 - Priority: `● P0` (filled circle with color)
 
-See CLAUDE.md "Visual Design System" section for full guidance.
+See [AGENT_INSTRUCTIONS.md](AGENT_INSTRUCTIONS.md) for full development guidelines.
 
 ## Landing the Plane (Session Completion)
 


### PR DESCRIPTION
## Summary
- Fixes #1049
- AGENTS.md referenced CLAUDE.md which doesn't exist on main

## Changes
- "Key Sections in CLAUDE.md" → "Key Sections"
- "See CLAUDE.md..." → "See AGENT_INSTRUCTIONS.md..."

## Test plan
- [x] Verify no more references to nonexistent CLAUDE.md in AGENTS.md

🤖 Generated with [Claude Code](https://claude.ai/code)