### PR TITLE
fix(sqlite): Add missing rows.Err() checks after row iteration

### DIFF
--- a/internal/storage/sqlite/dependencies.go
+++ b/internal/storage/sqlite/dependencies.go
@@ -997,6 +997,11 @@ func (s *SQLiteStorage) scanIssues(ctx context.Context, rows *sql.Rows) ([]*type
 		issueIDs = append(issueIDs, issue.ID)
 	}
 
+	// Check for errors during iteration (e.g., connection issues, context cancellation)
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating issue rows: %w", err)
+	}
+
 	// Second pass: batch-load labels for all issues
 	labelsMap, err := s.GetLabelsForIssues(ctx, issueIDs)
 	if err != nil {
@@ -1136,6 +1141,11 @@ func (s *SQLiteStorage) scanIssuesWithDependencyType(ctx context.Context, rows *
 			DependencyType: depType,
 		}
 		results = append(results, result)
+	}
+
+	// Check for errors during iteration (e.g., connection issues, context cancellation)
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating issue rows with dependency type: %w", err)
 	}
 
 	return results, nil


### PR DESCRIPTION
## Summary

Adds missing `rows.Err()` checks after row iteration loops in the SQLite storage layer. Per Go `database/sql` best practices, `rows.Err()` should always be checked after a `rows.Next()` loop completes to catch any errors that occurred during iteration.

### Changes Made

- **`scanIssues`** - Added `rows.Err()` check after the main iteration loop
- **`scanIssuesWithDependencyType`** - Added `rows.Err()` check after the main iteration loop

### Backward Compatibility

✅ **Maintained**: Same API, just better error handling
✅ **Same behavior**: Successful queries behave identically
❌ **Breaking changes**: None

### Technical Details

**Before (errors silently ignored):**
```go
for rows.Next() {
    // ... scan row ...
}
return issues, nil  // Any iteration error lost
```

**After (errors properly propagated):**
```go
for rows.Next() {
    // ... scan row ...
}
if err := rows.Err(); err != nil {
    return nil, fmt.Errorf("error iterating issue rows: %w", err)
}
return issues, nil
```

### Why This Matters

Errors can occur during iteration for various reasons:
- Database connection drops mid-query
- Context cancellation (timeout, user cancel)
- Network issues in remote database scenarios
- Corrupted rows in the result set

Without checking `rows.Err()`, these errors would be silently ignored and the caller would receive a partial result set with no indication of failure.

### Benefits

- **Better error visibility** - Iteration errors are properly reported
- **Consistent with codebase** - Other functions in the same file already check `rows.Err()`
- **Go best practices** - Per `database/sql` documentation

### Size: Small ✓

8 lines added (two 4-line error checks), no functional changes to happy path.

🤖 Generated with [Claude Code](https://claude.ai/code)