### PR TITLE
fix(sync): add --sparse flag to git add for worktree compatibility

### DIFF
--- a/cmd/bd/daemon_sync_branch.go
+++ b/cmd/bd/daemon_sync_branch.go
@@ -161,7 +161,8 @@ func gitCommitInWorktree(ctx context.Context, worktreePath, filePath, message st
 	}
 
 	// Stage the file
-	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", relPath) // #nosec G204 - worktreePath and relPath are derived from trusted git operations
+	// Use --sparse to work correctly with sparse-checkout enabled worktrees (fixes #1076)
+	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", "--sparse", relPath) // #nosec G204 - worktreePath and relPath are derived from trusted git operations
 	if err := addCmd.Run(); err != nil {
 		return fmt.Errorf("git add failed in worktree: %w", err)
 	}

--- a/cmd/bd/migrate_sync.go
+++ b/cmd/bd/migrate_sync.go
@@ -339,7 +339,8 @@ func commitInitialSyncState(ctx context.Context, worktreePath, jsonlRelPath stri
 	beadsRelDir := filepath.Dir(jsonlRelPath)
 
 	// Stage all beads files
-	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", beadsRelDir)
+	// Use --sparse to work correctly with sparse-checkout enabled worktrees (fixes #1076)
+	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", "--sparse", beadsRelDir)
 	if err := addCmd.Run(); err != nil {
 		return fmt.Errorf("git add failed: %w", err)
 	}

--- a/cmd/bd/sync_branch.go
+++ b/cmd/bd/sync_branch.go
@@ -304,7 +304,8 @@ func commitToExternalBeadsRepo(ctx context.Context, beadsDir, message string, pu
 		relBeadsDir = beadsDir // Fallback to absolute path
 	}
 
-	addCmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "add", relBeadsDir) //nolint:gosec // paths from trusted sources
+	// Use --sparse to work correctly with sparse-checkout enabled worktrees (fixes #1076)
+	addCmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "add", "--sparse", relBeadsDir) //nolint:gosec // paths from trusted sources
 	if output, err := addCmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("git add failed: %w\n%s", err, output)
 	}

--- a/internal/syncbranch/worktree.go
+++ b/internal/syncbranch/worktree.go
@@ -728,7 +728,8 @@ func commitInWorktree(ctx context.Context, worktreePath, jsonlRelPath, message s
 
 	// Use -f (force) to add files even if they're gitignored
 	// In contributor mode, .beads/ is excluded in .git/info/exclude but needs to be tracked in sync branch
-	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", "-f", beadsRelDir)
+	// Use --sparse to work correctly with sparse-checkout enabled worktrees (fixes #1076)
+	addCmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "add", "-f", "--sparse", beadsRelDir)
 	if err := addCmd.Run(); err != nil {
 		return fmt.Errorf("git add failed in worktree: %w", err)
 	}


### PR DESCRIPTION
## Summary

Add `--sparse` flag to all `git add` commands that operate in worktree contexts. This fixes issue #1076 where beads operations fail with "local changes would be overwritten" errors when using git worktrees with sparse-checkout enabled.

## Problem

When using `git worktree` in a beads-enabled repository, git reports "Your local changes to the following files would be overwritten by checkout" errors when attempting to switch branches, even when `git status` shows a completely clean working tree.

**Root cause:** The worktrees have sparse-checkout enabled (configured to `.beads/*`), but `git add` without `--sparse` attempts to operate on files outside the sparse pattern.

## Solution

Add `--sparse` flag to `git add` commands in worktree operations:

- `internal/syncbranch/worktree.go`: `commitInWorktree()`
- `cmd/bd/daemon_sync_branch.go`: `gitCommitInWorktree()`
- `cmd/bd/migrate_sync.go`: `commitInitialSyncState()`
- `cmd/bd/sync_branch.go`: `stageBeadsChanges()`

The `--sparse` flag tells git to:
1. Only operate on files matching the sparse-checkout cone
2. Avoid errors from attempting to stage files outside the sparse pattern
3. Respect the sparse checkout configuration already established

## Test plan

- [x] `go build ./cmd/bd` passes
- [x] Changes are minimal and focused (4 files, ~8 lines changed)
- [ ] Manual test: `bd sync` works with git worktrees (verified by @nstandif in #1076 comments)

## References

- Issue: #1076
- Community fix confirmation: https://github.com/steveyegge/beads/issues/1076#issuecomment-3747168466