### PR TITLE
Fix doctor DB-JSONL sync check to exclude ephemeral wisps

### DIFF
--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -412,9 +412,9 @@ func CheckDatabaseJSONLSync(path string) DoctorCheck {
 	}
 	defer db.Close()
 
-	// Get database count
+	// Get database count (exclude ephemeral/wisp issues - they're never exported to JSONL)
 	var dbCount int
-	err = db.QueryRow("SELECT COUNT(*) FROM issues").Scan(&dbCount)
+	err = db.QueryRow("SELECT COUNT(*) FROM issues WHERE ephemeral = 0 OR ephemeral IS NULL").Scan(&dbCount)
 	if err != nil {
 		// Database opened but can't query. If JSONL has issues, suggest recovery.
 		if jsonlErr == nil && jsonlCount > 0 {


### PR DESCRIPTION
## Problem

The `bd doctor` DB-JSONL Sync check was reporting false positive warnings when ephemeral issues (wisps) existed in the database:

```
⚠  DB-JSONL Sync: Count mismatch: database has 92 issues, JSONL has 30
```

This warning appeared even when the database and JSONL were correctly in sync. The issue occurred because:

1. **Wisps are ephemeral tracking issues** - temporary work items created during molecule workflows
2. **Wisps are intentionally excluded from JSONL exports** - they get "digested" into summary tasks rather than persisted
3. **The doctor check counted all issues** - it compared total database count (including wisps) against JSONL count (excluding wisps)

The count mismatch was expected behavior, not a sync problem.

## What Was Broken

`CheckDatabaseJSONLSync()` in `cmd/bd/doctor/database.go:417` was using:

```go
err = db.QueryRow("SELECT COUNT(*) FROM issues").Scan(&dbCount)
```

This counted **all** issues in the database, including ephemeral wisps, but compared it against the JSONL count which intentionally excludes wisps (see `cmd/bd/export.go:374-382`).

## The Fix

Updated the count query to match export behavior by excluding ephemeral issues:

```go
err = db.QueryRow("SELECT COUNT(*) FROM issues WHERE ephemeral = 0 OR ephemeral IS NULL").Scan(&dbCount)
```

This ensures the doctor check only counts issues that **should** be in the JSONL, eliminating false positives.

## Changes

- **cmd/bd/doctor/database.go**: Updated `CheckDatabaseJSONLSync()` to exclude ephemeral issues from count
- **cmd/bd/doctor/database_test.go**: 
  - Added `ephemeral` column to test database schema
  - Added new test case `ephemeral_wisps_excluded_from_count` to verify the fix
  - Updated `TestCheckDatabaseJSONLSync_MoleculePrefix` to include ephemeral column

## Testing

All existing tests pass, plus new test case specifically validates that:
- Database with 3 issues (2 regular + 1 ephemeral)
- JSONL with 2 issues (ephemeral correctly excluded)
- Results in **StatusOK** instead of false warning

```bash
go test -v ./cmd/bd/doctor -run TestCheckDatabaseJSONLSync
# PASS: All tests passing
```

## Impact

Users with active molecule/wisp workflows will no longer see spurious sync warnings from `bd doctor`.