### PR TITLE
fix: set git index flags on init when sync-branch is configured

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -683,3 +683,10 @@ func FixSyncBranchGitignore() error {
 
 	return fix.SyncBranchGitignore(cwd)
 }
+
+// SetSyncBranchGitignoreFlags sets git index flags on .beads/*.jsonl files.
+// This is called directly by init when --branch is specified, bypassing the
+// GetFromYAML() check since the in-memory config may not be updated yet.
+func SetSyncBranchGitignoreFlags(path string) error {
+	return fix.SyncBranchGitignore(path)
+}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -525,6 +525,23 @@ With --stealth: configures per-repository git settings for invisible beads usage
 			}
 		}
 
+		// Set git index flags to hide JSONL from git status when sync.branch is configured.
+		// These flags are local-only (don't transfer via git clone), so each clone needs them set.
+		// This fixes the issue where fresh clones show .beads/issues.jsonl as modified.
+		if isGitRepo() {
+			if branch != "" {
+				// --branch flag was passed: set flags directly (in-memory config not updated yet)
+				if err := doctor.SetSyncBranchGitignoreFlags(cwd); err != nil && !quiet {
+					fmt.Fprintf(os.Stderr, "Warning: failed to set git index flags: %v\n", err)
+				}
+			} else {
+				// No --branch flag: check if sync-branch exists in config.yaml (cloned repo scenario)
+				if err := doctor.FixSyncBranchGitignore(); err != nil && !quiet {
+					fmt.Fprintf(os.Stderr, "Warning: failed to set git index flags: %v\n", err)
+				}
+			}
+		}
+
 		// Add "landing the plane" instructions to AGENTS.md and @AGENTS.md
 		// Skip in stealth mode (user wants invisible setup) and quiet mode (suppress all output)
 		if !stealth {


### PR DESCRIPTION
Fresh clones with sync-branch configured show `.beads/issues.jsonl` as modified because git index flags (skip-worktree, assume-unchanged) are local-only and don't transfer via clone.

This adds flag setting to `bd init` so each clone gets them automatically.