### PR TITLE
fix(config): remove duplicate declarations and fix test failures

### DIFF
--- a/cmd/bd/show_test.go
+++ b/cmd/bd/show_test.go
@@ -32,8 +32,9 @@ func TestShow_ExternalRef(t *testing.T) {
 	}
 
 	// Create issue with external ref
+	// Use --repo . to override auto-routing and create in the test directory
 	createCmd := exec.Command(tmpBin, "--no-daemon", "create", "External ref test", "-p", "1",
-		"--external-ref", "https://example.com/spec.md", "--json")
+		"--external-ref", "https://example.com/spec.md", "--json", "--repo", ".")
 	createCmd.Dir = tmpDir
 	createOut, err := createCmd.CombinedOutput()
 	if err != nil {
@@ -86,7 +87,8 @@ func TestShow_NoExternalRef(t *testing.T) {
 	}
 
 	// Create issue WITHOUT external ref
-	createCmd := exec.Command(tmpBin, "--no-daemon", "create", "No ref test", "-p", "1", "--json")
+	// Use --repo . to override auto-routing and create in the test directory
+	createCmd := exec.Command(tmpBin, "--no-daemon", "create", "No ref test", "-p", "1", "--json", "--repo", ".")
 	createCmd.Dir = tmpDir
 	createOut, err := createCmd.CombinedOutput()
 	if err != nil {

--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -848,7 +848,7 @@ func ClearSyncConflictState(beadsDir string) error {
 //   - "ours": Keep local version
 //   - "theirs": Keep remote version
 //   - "manual": Interactive resolution with user prompts
-func resolveSyncConflicts(ctx context.Context, jsonlPath string, strategy string, dryRun bool) error {
+func resolveSyncConflicts(ctx context.Context, jsonlPath string, strategy config.ConflictStrategy, dryRun bool) error {
 	beadsDir := filepath.Dir(jsonlPath)
 
 	conflictState, err := LoadSyncConflictState(beadsDir)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,25 +12,6 @@ import (
 	"github.com/steveyegge/beads/internal/debug"
 )
 
-// Sync mode constants define how beads syncs with git/remotes.
-const (
-	// SyncModeGitPortable exports JSONL on push, imports on pull (default).
-	// This is the standard git-based workflow where JSONL is committed.
-	SyncModeGitPortable = "git-portable"
-
-	// SyncModeRealtime exports JSONL on every database change.
-	// Legacy behavior, more frequent writes but higher I/O.
-	SyncModeRealtime = "realtime"
-
-	// SyncModeDoltNative uses Dolt remotes directly (dolthub://, gs://, s3://).
-	// No JSONL export needed - Dolt handles sync.
-	SyncModeDoltNative = "dolt-native"
-
-	// SyncModeBeltAndSuspenders uses both Dolt remote AND JSONL backup.
-	// Maximum redundancy for critical data.
-	SyncModeBeltAndSuspenders = "belt-and-suspenders"
-)
-
 // Sync trigger constants define when sync operations occur.
 const (
 	// SyncTriggerPush triggers sync on git push operations.
@@ -41,36 +22,6 @@ const (
 
 	// SyncTriggerPull triggers import on git pull operations.
 	SyncTriggerPull = "pull"
-)
-
-// Conflict strategy constants define how sync conflicts are resolved.
-const (
-	// ConflictStrategyNewest keeps whichever version has the newer updated_at timestamp.
-	ConflictStrategyNewest = "newest"
-
-	// ConflictStrategyOurs keeps the local version on conflict.
-	ConflictStrategyOurs = "ours"
-
-	// ConflictStrategyTheirs keeps the remote version on conflict.
-	ConflictStrategyTheirs = "theirs"
-
-	// ConflictStrategyManual requires manual resolution of conflicts.
-	ConflictStrategyManual = "manual"
-)
-
-// Federation sovereignty tiers define data sovereignty levels.
-const (
-	// SovereigntyT1 - Full sovereignty: data never leaves controlled infrastructure.
-	SovereigntyT1 = "T1"
-
-	// SovereigntyT2 - Regional sovereignty: data stays within region/jurisdiction.
-	SovereigntyT2 = "T2"
-
-	// SovereigntyT3 - Provider sovereignty: data with trusted cloud provider.
-	SovereigntyT3 = "T3"
-
-	// SovereigntyT4 - No restrictions: data can be anywhere (e.g., DoltHub public).
-	SovereigntyT4 = "T4"
 )
 
 var v *viper.Viper
@@ -607,9 +558,9 @@ func GetIdentity(flagValue string) string {
 
 // SyncConfig holds the sync mode configuration.
 type SyncConfig struct {
-	Mode     string // git-portable, realtime, dolt-native, belt-and-suspenders
-	ExportOn string // push, change
-	ImportOn string // pull, change
+	Mode     SyncMode // git-portable, realtime, dolt-native, belt-and-suspenders
+	ExportOn string   // push, change
+	ImportOn string   // pull, change
 }
 
 // GetSyncConfig returns the current sync configuration.
@@ -621,35 +572,9 @@ func GetSyncConfig() SyncConfig {
 	}
 }
 
-// GetSyncMode returns the configured sync mode.
-// Returns git-portable if not configured or invalid.
-func GetSyncMode() string {
-	mode := GetString("sync.mode")
-	if mode == "" {
-		return SyncModeGitPortable
-	}
-	// Validate mode
-	switch mode {
-	case SyncModeGitPortable, SyncModeRealtime, SyncModeDoltNative, SyncModeBeltAndSuspenders:
-		return mode
-	default:
-		return SyncModeGitPortable
-	}
-}
-
-// IsSyncModeValid checks if the given sync mode is valid.
-func IsSyncModeValid(mode string) bool {
-	switch mode {
-	case SyncModeGitPortable, SyncModeRealtime, SyncModeDoltNative, SyncModeBeltAndSuspenders:
-		return true
-	default:
-		return false
-	}
-}
-
 // ConflictConfig holds the conflict resolution configuration.
 type ConflictConfig struct {
-	Strategy string // newest, ours, theirs, manual
+	Strategy ConflictStrategy // newest, ours, theirs, manual
 }
 
 // GetConflictConfig returns the current conflict resolution configuration.
@@ -659,36 +584,10 @@ func GetConflictConfig() ConflictConfig {
 	}
 }
 
-// GetConflictStrategy returns the configured conflict resolution strategy.
-// Returns newest if not configured or invalid.
-func GetConflictStrategy() string {
-	strategy := GetString("conflict.strategy")
-	if strategy == "" {
-		return ConflictStrategyNewest
-	}
-	// Validate strategy
-	switch strategy {
-	case ConflictStrategyNewest, ConflictStrategyOurs, ConflictStrategyTheirs, ConflictStrategyManual:
-		return strategy
-	default:
-		return ConflictStrategyNewest
-	}
-}
-
-// IsConflictStrategyValid checks if the given conflict strategy is valid.
-func IsConflictStrategyValid(strategy string) bool {
-	switch strategy {
-	case ConflictStrategyNewest, ConflictStrategyOurs, ConflictStrategyTheirs, ConflictStrategyManual:
-		return true
-	default:
-		return false
-	}
-}
-
 // FederationConfig holds the federation (Dolt remote) configuration.
 type FederationConfig struct {
-	Remote      string // dolthub://org/beads, gs://bucket/beads, s3://bucket/beads
-	Sovereignty string // T1, T2, T3, T4
+	Remote      string      // dolthub://org/beads, gs://bucket/beads, s3://bucket/beads
+	Sovereignty Sovereignty // T1, T2, T3, T4
 }
 
 // GetFederationConfig returns the current federation configuration.
@@ -699,27 +598,23 @@ func GetFederationConfig() FederationConfig {
 	}
 }
 
-// GetSovereignty returns the configured data sovereignty tier.
-// Returns empty string if not configured.
-func GetSovereignty() string {
-	sovereignty := GetString("federation.sovereignty")
-	// Validate sovereignty tier
-	switch sovereignty {
-	case SovereigntyT1, SovereigntyT2, SovereigntyT3, SovereigntyT4:
-		return sovereignty
-	default:
-		return ""
-	}
+// IsSyncModeValid checks if the given sync mode string is valid.
+func IsSyncModeValid(mode string) bool {
+	return validSyncModes[SyncMode(mode)]
 }
 
-// IsSovereigntyValid checks if the given sovereignty tier is valid.
+// IsConflictStrategyValid checks if the given conflict strategy string is valid.
+func IsConflictStrategyValid(strategy string) bool {
+	return validConflictStrategies[ConflictStrategy(strategy)]
+}
+
+// IsSovereigntyValid checks if the given sovereignty tier string is valid.
+// Note: empty string is valid (means no restriction).
 func IsSovereigntyValid(sovereignty string) bool {
-	switch sovereignty {
-	case "", SovereigntyT1, SovereigntyT2, SovereigntyT3, SovereigntyT4:
+	if sovereignty == "" {
 		return true
-	default:
-		return false
 	}
+	return validSovereigntyTiers[Sovereignty(sovereignty)]
 }
 
 // ShouldExportOnChange returns true if sync.export_on is set to "change".

--- a/internal/storage/dolt/concurrent_test.go
+++ b/internal/storage/dolt/concurrent_test.go
@@ -459,10 +459,10 @@ func TestBranchPerAgentMergeRace(t *testing.T) {
 	}
 
 	// First merge should succeed
-	err1 := store.Merge(ctx, "agent-1")
+	_, err1 := store.Merge(ctx, "agent-1")
 
 	// Second merge may conflict (both modified same row)
-	err2 := store.Merge(ctx, "agent-2")
+	_, err2 := store.Merge(ctx, "agent-2")
 
 	t.Logf("Merge agent-1 result: %v", err1)
 	t.Logf("Merge agent-2 result: %v", err2)


### PR DESCRIPTION
## Summary

Fixes build failure and test issues caused by duplicate declarations and pre-existing test setup problems.

### Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Remove duplicate `SyncMode`, `ConflictStrategy`, `Sovereignty` constants and `GetSyncMode`, `GetConflictStrategy`, `GetSovereignty`, `Is*Valid` functions (keep typed versions in sync.go). Update struct types to use typed values. |
| `internal/config/config_test.go` | Update tests to work with typed constants (add `string()` casts, change struct field types, fix expected default values). |
| `cmd/bd/sync.go` | Change `resolveSyncConflicts` parameter from `strategy string` to `strategy config.ConflictStrategy`. |
| `internal/storage/dolt/concurrent_test.go` | Fix `store.Merge()` calls to capture both return values `([]storage.Conflict, error)`. |
| `cmd/bd/show_test.go` | Add `--repo .` flag to `create` commands to bypass auto-routing and create issues in the test directory. |

### Root Cause

- Commit `16f8c3d3` added untyped string constants to `config.go`
- Commit `e82e15a8` created `sync.go` with typed constants but forgot to remove duplicates from `config.go`
- This caused redeclaration errors preventing the project from building

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 39 packages)
- [x] `make install` succeeds