### PR TITLE
Add --gastown flag to bd doctor for gastown-specific checks

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -54,7 +54,9 @@ var (
 	checkHealthMode      bool
 	doctorCheckFlag      string // run specific check (e.g., "pollution")
 	doctorClean          bool   // for pollution check, delete detected issues
-	doctorDeep           bool   // full graph integrity validation
+	doctorDeep                  bool // full graph integrity validation
+	doctorGastown               bool // running in gastown multi-workspace mode
+	gastownDuplicatesThreshold  int  // duplicate tolerance threshold for gastown mode
 )
 
 // ConfigKeyHintsDoctor is the config key for suppressing doctor hints
@@ -225,6 +227,8 @@ func init() {
 	doctorCmd.Flags().BoolVarP(&doctorVerbose, "verbose", "v", false, "Show detailed output during fixes (e.g., list each removed dependency)")
 	doctorCmd.Flags().BoolVar(&doctorForce, "force", false, "Force repair mode: attempt recovery even when database cannot be opened")
 	doctorCmd.Flags().StringVar(&doctorSource, "source", "auto", "Choose source of truth for recovery: auto (detect), jsonl (prefer JSONL), db (prefer database)")
+	doctorCmd.Flags().BoolVar(&doctorGastown, "gastown", false, "Running in gastown multi-workspace mode (routes.jsonl is expected, higher duplicate tolerance)")
+	doctorCmd.Flags().IntVar(&gastownDuplicatesThreshold, "gastown-duplicates-threshold", 1000, "Duplicate tolerance threshold for gastown mode (wisps are ephemeral)")
 }
 
 func runDiagnostics(path string) doctorResult {
@@ -319,7 +323,7 @@ func runDiagnostics(path string) doctorResult {
 	}
 
 	// Check 6: Multiple JSONL files (excluding merge artifacts)
-	jsonlCheck := convertWithCategory(doctor.CheckLegacyJSONLFilename(path), doctor.CategoryData)
+	jsonlCheck := convertWithCategory(doctor.CheckLegacyJSONLFilename(path, doctorGastown), doctor.CategoryData)
 	result.Checks = append(result.Checks, jsonlCheck)
 	if jsonlCheck.Status == statusWarning || jsonlCheck.Status == statusError {
 		result.OverallOK = false
@@ -546,7 +550,7 @@ func runDiagnostics(path string) doctorResult {
 	// Don't fail overall check for child→parent deps, just warn
 
 	// Check 23: Duplicate issues (from bd validate)
-	duplicatesCheck := convertDoctorCheck(doctor.CheckDuplicateIssues(path))
+	duplicatesCheck := convertDoctorCheck(doctor.CheckDuplicateIssues(path, doctorGastown, gastownDuplicatesThreshold))
 	result.Checks = append(result.Checks, duplicatesCheck)
 	// Don't fail overall check for duplicates, just warn
 

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -121,7 +121,8 @@ func CheckAgentDocumentation(repoPath string) DoctorCheck {
 
 // CheckLegacyJSONLFilename detects if there are multiple JSONL files,
 // which can cause sync/merge issues. Ignores merge artifacts and backups.
-func CheckLegacyJSONLFilename(repoPath string) DoctorCheck {
+// When gastownMode is true, routes.jsonl is treated as a valid system file.
+func CheckLegacyJSONLFilename(repoPath string, gastownMode bool) DoctorCheck {
 	beadsDir := filepath.Join(repoPath, ".beads")
 
 	// Find all .jsonl files
@@ -160,7 +161,9 @@ func CheckLegacyJSONLFilename(repoPath string) DoctorCheck {
 			// Git merge conflict artifacts (e.g., issues.base.jsonl, issues.left.jsonl)
 			strings.Contains(lowerName, ".base.jsonl") ||
 			strings.Contains(lowerName, ".left.jsonl") ||
-			strings.Contains(lowerName, ".right.jsonl") {
+			strings.Contains(lowerName, ".right.jsonl") ||
+			// Skip routes.jsonl in gastown mode (valid system file)
+			(gastownMode && name == "routes.jsonl") {
 			continue
 		}
 

--- a/cmd/bd/doctor/legacy_test.go
+++ b/cmd/bd/doctor/legacy_test.go
@@ -209,96 +209,126 @@ func TestCheckLegacyJSONLFilename(t *testing.T) {
 	tests := []struct {
 		name           string
 		files          []string
+		gastownMode    bool
 		expectedStatus string
 		expectWarning  bool
 	}{
 		{
 			name:           "no JSONL files",
 			files:          []string{},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "single issues.jsonl",
 			files:          []string{"issues.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "single beads.jsonl is ok",
 			files:          []string{"beads.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "custom name is ok",
 			files:          []string{"my-issues.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "multiple JSONL files warning",
 			files:          []string{"beads.jsonl", "issues.jsonl"},
+			gastownMode:    false,
+			expectedStatus: "warning",
+			expectWarning:  true,
+		},
+		{
+			name:           "routes.jsonl with gastown flag",
+			files:          []string{"issues.jsonl", "routes.jsonl"},
+			gastownMode:    true,
+			expectedStatus: "ok",
+			expectWarning:  false,
+		},
+		{
+			name:           "routes.jsonl without gastown flag",
+			files:          []string{"issues.jsonl", "routes.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "warning",
 			expectWarning:  true,
 		},
 		{
 			name:           "backup files ignored",
 			files:          []string{"issues.jsonl", "issues.jsonl.backup", "BACKUP_issues.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "multiple real files with backups",
 			files:          []string{"issues.jsonl", "beads.jsonl", "issues.jsonl.backup"},
+			gastownMode:    false,
 			expectedStatus: "warning",
 			expectWarning:  true,
 		},
 		{
 			name:           "deletions.jsonl ignored as system file",
 			files:          []string{"beads.jsonl", "deletions.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "merge artifacts ignored",
 			files:          []string{"issues.jsonl", "issues.base.jsonl", "issues.left.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "merge artifacts with right variant ignored",
 			files:          []string{"issues.jsonl", "issues.right.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "beads merge artifacts ignored (bd-ov1)",
 			files:          []string{"issues.jsonl", "beads.base.jsonl", "beads.left.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "interactions.jsonl ignored as system file (GH#709)",
 			files:          []string{"issues.jsonl", "interactions.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "molecules.jsonl ignored as system file",
 			files:          []string{"issues.jsonl", "molecules.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "sync_base.jsonl ignored as system file (GH#1021)",
 			files:          []string{"issues.jsonl", "sync_base.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
 		{
 			name:           "all system files ignored together",
 			files:          []string{"issues.jsonl", "deletions.jsonl", "interactions.jsonl", "molecules.jsonl", "sync_base.jsonl"},
+			gastownMode:    false,
 			expectedStatus: "ok",
 			expectWarning:  false,
 		},
@@ -320,7 +350,7 @@ func TestCheckLegacyJSONLFilename(t *testing.T) {
 				}
 			}
 
-			check := CheckLegacyJSONLFilename(tmpDir)
+			check := CheckLegacyJSONLFilename(tmpDir, tt.gastownMode)
 
 			if check.Status != tt.expectedStatus {
 				t.Errorf("Expected status %s, got %s", tt.expectedStatus, check.Status)


### PR DESCRIPTION
# Problem

When running `bd doctor` in a gastown environment, it reports two false positive warnings:

### 1. JSONL Files Warning
```
⚠  JSONL Files: Multiple JSONL files found: issues.jsonl, routes.jsonl
```

**Root Cause**: The `CheckLegacyJSONLFilename` function doesn't know that `routes.jsonl` is a valid gastown configuration file (not an issue tracking file).

**Context**: In gastown, `routes.jsonl` maps issue prefixes to rig directories:
- `{"prefix":"hq-","path":"."}` → headquarters issues at town root
- `{"prefix":"pq-","path":"pgqueue"}` → pgqueue rig issues in pgqueue/.beads/

### 2. Duplicate Issues Warning
```
⚠  Duplicate Issues: 70 duplicate issue(s) in 30 group(s)
```

**Root Cause**: The `CheckDuplicateIssues` function doesn't understand gastown's wisp architecture where duplicate issues are expected and normal.

**Context**: In gastown, wisps are ephemeral per-session execution contexts that are created repeatedly:
- Patrol cycles create new sets of wisps with identical titles (e.g., "Check own context limit")
- Agents respawn with fresh sessions, creating new wisps
- Squashing mechanism compacts old wisps to digests after each cycle
- GC removes wisps past retention period (24 hours conservative, 1 hour aggressive)
- 70-100 duplicates is normal operational state; thousands would indicate a problem

# Solution

Add a `--gastown` flag to `bd doctor` that modifies checks to accommodate gastown's architecture:
1. Skip warning about `routes.jsonl` (valid system file)
2. Increase duplicate tolerance threshold from default to 1000 (wisps are ephemeral and numerous)

## Flags Added
- `--gastown`: Enable gastown mode (routes.jsonl is expected, higher duplicate tolerance)
- `--gastown-duplicates-threshold=N`: Set duplicate tolerance threshold (default: 1000)

## Benefits
- **Explicit and clear intent**: Gastown users opt-in with a flag
- **Configurable threshold**: Can be adjusted via `--gastown-duplicates-threshold`
- **Backward compatible**: No changes to non-gastown behavior
- **Future-proof**: Can support other multi-workspace systems

## Usage
```bash
# In gastown town root
cd ~/gt
bd doctor --gastown                                  # Default threshold 1000
bd doctor --gastown --gastown-duplicates-threshold=100  # Custom threshold

# In regular beads repo
cd ~/some-regular-project
bd doctor                        # Works as before (no false positives)
```

## Changes Made
1. Added `--gastown` and `--gastown-duplicates-threshold` flags to `bd doctor`
2. Updated `CheckLegacyJSONLFilename` to skip `routes.jsonl` when gastown mode active
3. Updated `CheckDuplicateIssues` to use configurable threshold when gastown mode active
4. Added comprehensive test cases for both checks with gastown mode

## Testing
All tests pass:
- ✅ `TestCheckLegacyJSONLFilename` (including gastown mode cases)
- ✅ `TestCheckDuplicateIssues_GastownUnderThreshold`
- ✅ `TestCheckDuplicateIssues_GastownOverThreshold`
- ✅ `TestCheckDuplicateIssues_GastownCustomThreshold`
- ✅ `TestCheckDuplicateIssues_NonGastownMode`

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>