### PR TITLE
feat(kv): add key-value store commands

### DIFF
--- a/cmd/bd/kv.go
+++ b/cmd/bd/kv.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// kvPrefix is prepended to all user keys to separate them from internal config
+const kvPrefix = "kv."
+
+// setCmd sets a key-value pair (top-level: bd set key value)
+var setCmd = &cobra.Command{
+	Use:     "set <key> <value>",
+	GroupID: "setup",
+	Short:   "Set a key-value pair",
+	Long: `Set a key-value pair in the beads key-value store.
+
+This is useful for storing flags, environment variables, or other
+user-defined data that persists across sessions.
+
+Examples:
+  bd set feature_flag true
+  bd set api_endpoint https://api.example.com
+  bd set max_retries 3`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("set")
+
+		if err := ensureDirectMode("set requires direct database access"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		key := args[0]
+		value := args[1]
+		storageKey := kvPrefix + key
+
+		ctx := rootCtx
+		if err := store.SetConfig(ctx, storageKey, value); err != nil {
+			FatalErrorRespectJSON("setting key: %v", err)
+		}
+
+		if jsonOutput {
+			outputJSON(map[string]string{
+				"key":   key,
+				"value": value,
+			})
+		} else {
+			fmt.Printf("Set %s = %s\n", key, value)
+		}
+	},
+}
+
+// getCmd gets a value by key (top-level: bd get key)
+var getCmd = &cobra.Command{
+	Use:     "get <key>",
+	GroupID: "setup",
+	Short:   "Get a value by key",
+	Long: `Get a value from the beads key-value store.
+
+Examples:
+  bd get feature_flag
+  bd get api_endpoint`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := ensureDirectMode("get requires direct database access"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		key := args[0]
+		storageKey := kvPrefix + key
+
+		ctx := rootCtx
+		value, err := store.GetConfig(ctx, storageKey)
+		if err != nil {
+			FatalErrorRespectJSON("getting key: %v", err)
+		}
+
+		if jsonOutput {
+			outputJSON(map[string]string{
+				"key":   key,
+				"value": value,
+			})
+		} else {
+			if value == "" {
+				fmt.Printf("%s (not set)\n", key)
+			} else {
+				fmt.Printf("%s\n", value)
+			}
+		}
+	},
+}
+
+// clearCmd deletes a key (top-level: bd clear key)
+var clearCmd = &cobra.Command{
+	Use:     "clear <key>",
+	GroupID: "setup",
+	Short:   "Delete a key-value pair",
+	Long: `Delete a key from the beads key-value store.
+
+Examples:
+  bd clear feature_flag
+  bd clear api_endpoint`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("clear")
+
+		if err := ensureDirectMode("clear requires direct database access"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		key := args[0]
+		storageKey := kvPrefix + key
+
+		ctx := rootCtx
+		if err := store.DeleteConfig(ctx, storageKey); err != nil {
+			FatalErrorRespectJSON("deleting key: %v", err)
+		}
+
+		if jsonOutput {
+			outputJSON(map[string]string{
+				"key":     key,
+				"deleted": "true",
+			})
+		} else {
+			fmt.Printf("Cleared %s\n", key)
+		}
+	},
+}
+
+// kvCmd is the parent command for kv subcommands
+var kvCmd = &cobra.Command{
+	Use:     "kv",
+	GroupID: "setup",
+	Short:   "Key-value store commands",
+	Long: `Commands for working with the beads key-value store.
+
+The key-value store is useful for storing flags, environment variables,
+or other user-defined data that persists across sessions.
+
+Examples:
+  bd kv list              # List all key-value pairs
+  bd set mykey myvalue    # Set a value (top-level alias)
+  bd get mykey            # Get a value (top-level alias)
+  bd clear mykey          # Delete a key (top-level alias)`,
+}
+
+// kvListCmd lists all key-value pairs (bd kv list)
+var kvListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all key-value pairs",
+	Long: `List all key-value pairs in the beads key-value store.
+
+Examples:
+  bd kv list
+  bd kv list --json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := ensureDirectMode("kv list requires direct database access"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		ctx := rootCtx
+		allConfig, err := store.GetAllConfig(ctx)
+		if err != nil {
+			FatalErrorRespectJSON("listing keys: %v", err)
+		}
+
+		// Filter for kv.* keys and strip prefix
+		kvPairs := make(map[string]string)
+		for k, v := range allConfig {
+			if strings.HasPrefix(k, kvPrefix) {
+				userKey := strings.TrimPrefix(k, kvPrefix)
+				kvPairs[userKey] = v
+			}
+		}
+
+		if jsonOutput {
+			outputJSON(kvPairs)
+			return
+		}
+
+		if len(kvPairs) == 0 {
+			fmt.Println("No key-value pairs set")
+			return
+		}
+
+		// Sort keys for consistent output
+		keys := make([]string, 0, len(kvPairs))
+		for k := range kvPairs {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		fmt.Println("\nKey-Value Store:")
+		for _, k := range keys {
+			fmt.Printf("  %s = %s\n", k, kvPairs[k])
+		}
+	},
+}
+
+func init() {
+	// Register top-level commands
+	rootCmd.AddCommand(setCmd)
+	rootCmd.AddCommand(getCmd)
+	rootCmd.AddCommand(clearCmd)
+
+	// Register kv subcommand with list
+	kvCmd.AddCommand(kvListCmd)
+	rootCmd.AddCommand(kvCmd)
+}

--- a/cmd/bd/sync.go
+++ b/cmd/bd/sync.go
@@ -848,7 +848,7 @@ func ClearSyncConflictState(beadsDir string) error {
 //   - "ours": Keep local version
 //   - "theirs": Keep remote version
 //   - "manual": Interactive resolution with user prompts
-func resolveSyncConflicts(ctx context.Context, jsonlPath string, strategy string, dryRun bool) error {
+func resolveSyncConflicts(ctx context.Context, jsonlPath string, strategy config.ConflictStrategy, dryRun bool) error {
 	beadsDir := filepath.Dir(jsonlPath)
 
 	conflictState, err := LoadSyncConflictState(beadsDir)

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -31,6 +31,16 @@ var validSyncModes = map[SyncMode]bool{
 	SyncModeBeltAndSuspenders: true,
 }
 
+// Sync trigger constants define when sync operations occur.
+const (
+	// SyncTriggerPush triggers sync on git push operations.
+	SyncTriggerPush = "push"
+	// SyncTriggerChange triggers sync on every database change.
+	SyncTriggerChange = "change"
+	// SyncTriggerPull triggers import on git pull operations.
+	SyncTriggerPull = "pull"
+)
+
 // ConflictStrategy represents the conflict resolution strategy
 type ConflictStrategy string
 


### PR DESCRIPTION
Add user-facing key-value store for storing flags and environment variables:
- `bd set <key> <value>` - Set a key-value pair
- `bd get <key>` - Get a value by key
- `bd clear <key>` - Delete a key
- `bd kv list` - List all key-value pairs

Uses existing config table with `kv.` prefix to avoid schema migrations. Also fixes duplicate constant declarations between config.go and sync.go.

  ## Why Add a Key-Value Store to Beads?                                                                  
                                                                                                          
  **Problem:** Beads is an issue tracker, but when working across multiple sessions (especially with AI   
  agents), there's often a need to persist small pieces of state that don't fit the "issue" model:        
                                                                                                          
  1. **Feature flags** - Toggle behaviors during development (`bd set debug_mode true`)                   
  2. **Environment-specific config** - Store API endpoints, project-specific settings (`bd set api_url    
  https://staging.example.com`)                                                                           
  3. **Session state** - Remember user preferences or workflow context across sessions (`bd set           
  current_sprint 42`)                                                                                     
  4. **Agent memory** - AI agents can store and retrieve context that survives conversation compaction    
                                                                                                          
  **Why not just use environment variables or .env files?**                                               
  - Environment variables aren't persisted across shell sessions                                          
  - `.env` files require manual editing and aren't tracked in the beads workflow                          
  - The KV store integrates with beads' existing sync mechanism (JSONL export), so this state travels with
   your issues                                                                                            
                                                                                                          
  **Why not use `bd config`?**                                                                            
  - `bd config` is designed for beads' internal settings (sync mode, conflict strategy, integrations)     
  - Mixing user data with internal config creates namespace collisions and confusion                      
  - The `bd set/get/clear` commands are simpler and more intuitive for quick storage                      
                                                                                                          
  **Use case examples:**                                                                                  
  ```bash                                                                                                 
  # Track database migration state                                                                        
  bd set last_migration 20240115_add_users_table.sql                                                      
                                                                                                          
  # Store the main entry point for a codebase                                                             
  bd set entry_point src/server/main.ts                                                                   
                                                                                                          
  # Flag a feature toggle                                                                                 
  bd set use_new_auth true                                                                                
                                                                                                          
  # Later session, recover context                                                                        
  bd get last_migration  # → 20240115_add_users_table.sql                                                 
                                                                                                          
  New Commands                                                                                            
  ┌──────────────────────┬──────────────────────────┐                                                     
  │       Command        │       Description        │                                                     
  ├──────────────────────┼──────────────────────────┤                                                     
  │ bd set <key> <value> │ Set a key-value pair     │                                                     
  ├──────────────────────┼──────────────────────────┤                                                     
  │ bd get <key>         │ Get a value by key       │                                                     
  ├──────────────────────┼──────────────────────────┤                                                     
  │ bd clear <key>       │ Delete a key             │                                                     
  ├──────────────────────┼──────────────────────────┤                                                     
  │ bd kv list           │ List all key-value pairs │                                                     
  └──────────────────────┴──────────────────────────┘                                                     
  All commands support --json for machine-readable output.                                                
                                                                                                          
  Implementation                                                                                          
                                                                                                          
  Uses the existing config table with a kv. prefix to store user data. This avoids schema migrations while
   keeping user data separate from internal beads configuration.                                          
  ```   