### PR TITLE
fix(sqlite): add missing agent fields to scanIssues and query functions

### DIFF
--- a/internal/storage/sqlite/dependencies.go
+++ b/internal/storage/sqlite/dependencies.go
@@ -911,6 +911,17 @@ func (s *SQLiteStorage) scanIssues(ctx context.Context, rows *sql.Rows) ([]*type
 		var awaitID sql.NullString
 		var timeoutNs sql.NullInt64
 		var waiters sql.NullString
+		// Agent fields
+		var hookBead sql.NullString
+		var roleBead sql.NullString
+		var agentState sql.NullString
+		var lastActivity sql.NullTime
+		var roleType sql.NullString
+		var rig sql.NullString
+		var molType sql.NullString
+		// Time-based scheduling fields
+		var dueAt sql.NullTime
+		var deferUntil sql.NullTime
 
 		err := rows.Scan(
 			&issue.ID, &contentHash, &issue.Title, &issue.Description, &issue.Design,
@@ -920,6 +931,8 @@ func (s *SQLiteStorage) scanIssues(ctx context.Context, rows *sql.Rows) ([]*type
 			&deletedAt, &deletedBy, &deleteReason, &originalType,
 			&sender, &wisp, &pinned, &isTemplate, &crystallizes,
 			&awaitType, &awaitID, &timeoutNs, &waiters,
+			&hookBead, &roleBead, &agentState, &lastActivity, &roleType, &rig, &molType,
+			&dueAt, &deferUntil,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan issue: %w", err)
@@ -991,6 +1004,35 @@ func (s *SQLiteStorage) scanIssues(ctx context.Context, rows *sql.Rows) ([]*type
 		}
 		if waiters.Valid && waiters.String != "" {
 			issue.Waiters = parseJSONStringArray(waiters.String)
+		}
+		// Agent fields
+		if hookBead.Valid {
+			issue.HookBead = hookBead.String
+		}
+		if roleBead.Valid {
+			issue.RoleBead = roleBead.String
+		}
+		if agentState.Valid {
+			issue.AgentState = types.AgentState(agentState.String)
+		}
+		if lastActivity.Valid {
+			issue.LastActivity = &lastActivity.Time
+		}
+		if roleType.Valid {
+			issue.RoleType = roleType.String
+		}
+		if rig.Valid {
+			issue.Rig = rig.String
+		}
+		if molType.Valid {
+			issue.MolType = types.MolType(molType.String)
+		}
+		// Time-based scheduling fields
+		if dueAt.Valid {
+			issue.DueAt = &dueAt.Time
+		}
+		if deferUntil.Valid {
+			issue.DeferUntil = &deferUntil.Time
 		}
 
 		issues = append(issues, &issue)

--- a/internal/storage/sqlite/labels.go
+++ b/internal/storage/sqlite/labels.go
@@ -173,7 +173,9 @@ func (s *SQLiteStorage) GetIssuesByLabel(ctx context.Context, label string) ([]*
 		       i.created_at, i.created_by, i.owner, i.updated_at, i.closed_at, i.external_ref, i.source_repo, i.close_reason,
 		       i.deleted_at, i.deleted_by, i.delete_reason, i.original_type,
 		       i.sender, i.ephemeral, i.pinned, i.is_template, i.crystallizes,
-		       i.await_type, i.await_id, i.timeout_ns, i.waiters
+		       i.await_type, i.await_id, i.timeout_ns, i.waiters,
+		       i.hook_bead, i.role_bead, i.agent_state, i.last_activity, i.role_type, i.rig, i.mol_type,
+		       i.due_at, i.defer_until
 		FROM issues i
 		JOIN labels l ON i.id = l.issue_id
 		WHERE l.label = ?

--- a/internal/storage/sqlite/queries.go
+++ b/internal/storage/sqlite/queries.go
@@ -2021,7 +2021,9 @@ func (s *SQLiteStorage) SearchIssues(ctx context.Context, query string, filter t
 		       created_at, created_by, owner, updated_at, closed_at, external_ref, source_repo, close_reason,
 		       deleted_at, deleted_by, delete_reason, original_type,
 		       sender, ephemeral, pinned, is_template, crystallizes,
-		       await_type, await_id, timeout_ns, waiters
+		       await_type, await_id, timeout_ns, waiters,
+		       hook_bead, role_bead, agent_state, last_activity, role_type, rig, mol_type,
+		       due_at, defer_until
 		FROM issues
 		%s
 		ORDER BY priority ASC, created_at DESC

--- a/internal/storage/sqlite/ready.go
+++ b/internal/storage/sqlite/ready.go
@@ -158,7 +158,9 @@ func (s *SQLiteStorage) GetReadyWork(ctx context.Context, filter types.WorkFilte
 		i.created_at, i.created_by, i.owner, i.updated_at, i.closed_at, i.external_ref, i.source_repo, i.close_reason,
 		i.deleted_at, i.deleted_by, i.delete_reason, i.original_type,
 		i.sender, i.ephemeral, i.pinned, i.is_template, i.crystallizes,
-		i.await_type, i.await_id, i.timeout_ns, i.waiters
+		i.await_type, i.await_id, i.timeout_ns, i.waiters,
+		i.hook_bead, i.role_bead, i.agent_state, i.last_activity, i.role_type, i.rig, i.mol_type,
+		i.due_at, i.defer_until
 		FROM issues i
 		WHERE %s
 		AND NOT EXISTS (
@@ -750,7 +752,9 @@ func (s *SQLiteStorage) GetNewlyUnblockedByClose(ctx context.Context, closedIssu
 		       i.created_at, i.created_by, i.owner, i.updated_at, i.closed_at, i.external_ref, i.source_repo, i.close_reason,
 		       i.deleted_at, i.deleted_by, i.delete_reason, i.original_type,
 		       i.sender, i.ephemeral, i.pinned, i.is_template, i.crystallizes,
-		       i.await_type, i.await_id, i.timeout_ns, i.waiters
+		       i.await_type, i.await_id, i.timeout_ns, i.waiters,
+		       i.hook_bead, i.role_bead, i.agent_state, i.last_activity, i.role_type, i.rig, i.mol_type,
+		       i.due_at, i.defer_until
 		FROM issues i
 		JOIN dependencies d ON i.id = d.issue_id
 		WHERE d.depends_on_id = ?

--- a/internal/storage/sqlite/transaction.go
+++ b/internal/storage/sqlite/transaction.go
@@ -332,7 +332,9 @@ func (t *sqliteTxStorage) GetIssue(ctx context.Context, id string) (*types.Issue
 		       compaction_level, compacted_at, compacted_at_commit, original_size, source_repo, close_reason,
 		       deleted_at, deleted_by, delete_reason, original_type,
 		       sender, ephemeral, pinned, is_template, crystallizes,
-		       await_type, await_id, timeout_ns, waiters
+		       await_type, await_id, timeout_ns, waiters,
+		       hook_bead, role_bead, agent_state, last_activity, role_type, rig, mol_type,
+		       due_at, defer_until
 		FROM issues
 		WHERE id = ?
 	`, id)
@@ -1261,7 +1263,9 @@ func (t *sqliteTxStorage) SearchIssues(ctx context.Context, query string, filter
 		       compaction_level, compacted_at, compacted_at_commit, original_size, source_repo, close_reason,
 		       deleted_at, deleted_by, delete_reason, original_type,
 		       sender, ephemeral, pinned, is_template, crystallizes,
-		       await_type, await_id, timeout_ns, waiters
+		       await_type, await_id, timeout_ns, waiters,
+		       hook_bead, role_bead, agent_state, last_activity, role_type, rig, mol_type,
+		       due_at, defer_until
 		FROM issues
 		%s
 		ORDER BY priority ASC, created_at DESC
@@ -1316,6 +1320,17 @@ func scanIssueRow(row scanner) (*types.Issue, error) {
 	var awaitID sql.NullString
 	var timeoutNs sql.NullInt64
 	var waiters sql.NullString
+	// Agent fields
+	var hookBead sql.NullString
+	var roleBead sql.NullString
+	var agentState sql.NullString
+	var lastActivity sql.NullTime
+	var roleType sql.NullString
+	var rig sql.NullString
+	var molType sql.NullString
+	// Time-based scheduling fields
+	var dueAt sql.NullTime
+	var deferUntil sql.NullTime
 
 	err := row.Scan(
 		&issue.ID, &contentHash, &issue.Title, &issue.Description, &issue.Design,
@@ -1326,6 +1341,8 @@ func scanIssueRow(row scanner) (*types.Issue, error) {
 		&deletedAt, &deletedBy, &deleteReason, &originalType,
 		&sender, &wisp, &pinned, &isTemplate, &crystallizes,
 		&awaitType, &awaitID, &timeoutNs, &waiters,
+		&hookBead, &roleBead, &agentState, &lastActivity, &roleType, &rig, &molType,
+		&dueAt, &deferUntil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan issue: %w", err)
@@ -1406,6 +1423,35 @@ func scanIssueRow(row scanner) (*types.Issue, error) {
 	}
 	if waiters.Valid && waiters.String != "" {
 		issue.Waiters = parseJSONStringArray(waiters.String)
+	}
+	// Agent fields
+	if hookBead.Valid {
+		issue.HookBead = hookBead.String
+	}
+	if roleBead.Valid {
+		issue.RoleBead = roleBead.String
+	}
+	if agentState.Valid {
+		issue.AgentState = types.AgentState(agentState.String)
+	}
+	if lastActivity.Valid {
+		issue.LastActivity = &lastActivity.Time
+	}
+	if roleType.Valid {
+		issue.RoleType = roleType.String
+	}
+	if rig.Valid {
+		issue.Rig = rig.String
+	}
+	if molType.Valid {
+		issue.MolType = types.MolType(molType.String)
+	}
+	// Time-based scheduling fields
+	if dueAt.Valid {
+		issue.DueAt = &dueAt.Time
+	}
+	if deferUntil.Valid {
+		issue.DeferUntil = &deferUntil.Time
 	}
 
 	return &issue, nil


### PR DESCRIPTION
## Summary

Adds missing agent-related fields and time-based scheduling fields to all issue scanning functions and SQL queries, fixing incomplete data retrieval for agent beads.

## Problem

The `scanIssues()` function and multiple SQL queries were not selecting or scanning agent-related fields. This caused `bd list --json` to return `null` for `last_activity` and other agent fields even when the database contained valid data.

This prevented proper agent health monitoring, as the witness couldn't see the `last_activity` timestamp to determine if agents were responsive.

## Solution

Updated all issue scanning code paths to include the missing fields:

**Fields added:**
- Agent identity: `hook_bead`, `role_bead`, `agent_state`, `last_activity`, `role_type`, `rig`, `mol_type`
- Time-based scheduling: `due_at`, `defer_until`

**Files modified:**
- `internal/storage/sqlite/dependencies.go`: `scanIssues()` - variable declarations, scan calls, field assignments
- `internal/storage/sqlite/queries.go`: `SearchIssues` query
- `internal/storage/sqlite/labels.go`: `GetIssuesByLabel` query
- `internal/storage/sqlite/ready.go`: `GetReadyWork` and `GetNewlyUnblockedByClose` queries
- `internal/storage/sqlite/transaction.go`: `GetIssue` query, `SearchIssues` query, `scanIssueRow()` function

## Testing

- All existing SQLite storage tests pass
- Verified `bd list --json` now correctly returns `last_activity` and other agent fields

## Related Issues

Fixes #1175

Also related to [steveyegge/gastown#773](https://github.com/steveyegge/gastown/issues/773) which tracks the writing side of this issue.