### PR TITLE
fix(routing): disable auto-routing by default

### DIFF
--- a/docs/CONTRIBUTOR_NAMESPACE_ISOLATION.md
+++ b/docs/CONTRIBUTOR_NAMESPACE_ISOLATION.md
@@ -126,7 +126,7 @@ accordingly:
 
 2. **Routing Configuration** (`internal/config/config.go`):
    ```go
-   v.SetDefault("routing.mode", "auto")
+   v.SetDefault("routing.mode", "")  // Empty = disabled by default
    v.SetDefault("routing.default", ".")
    v.SetDefault("routing.contributor", "~/.beads-planning")
    ```

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -45,7 +45,10 @@ bd create "Fix bug" -p 1
 Routing is configured via the database config:
 
 ```bash
-# Set routing mode (auto = detect role, explicit = always use default)
+# Auto-routing is disabled by default (routing.mode="")
+# Enable with:
+bd init --contributor
+# OR manually:
 bd config set routing.mode auto
 
 # Set default planning repo

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ func Initialize() error {
 	v.SetDefault("remote-sync-interval", "30s")
 
 	// Routing configuration defaults
-	v.SetDefault("routing.mode", "auto")
+	v.SetDefault("routing.mode", "")
 	v.SetDefault("routing.default", ".")
 	v.SetDefault("routing.maintainer", ".")
 	v.SetDefault("routing.contributor", "~/.beads-planning")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -941,6 +941,35 @@ external_projects:
 	})
 }
 
+func TestRoutingModeDefaultIsEmpty(t *testing.T) {
+	// GH#1165: routing.mode must default to empty (disabled)
+	// to prevent unexpected auto-routing to ~/.beads-planning
+	// Isolate from environment variables
+	restore := envSnapshot(t)
+	defer restore()
+
+	// Initialize config
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	// Verify routing.mode defaults to empty string (disabled)
+	if got := GetString("routing.mode"); got != "" {
+		t.Errorf("GetString(routing.mode) = %q, want \"\" (empty = disabled by default)", got)
+	}
+
+	// Verify other routing defaults are still set correctly
+	if got := GetString("routing.default"); got != "." {
+		t.Errorf("GetString(routing.default) = %q, want \".\"", got)
+	}
+	if got := GetString("routing.maintainer"); got != "." {
+		t.Errorf("GetString(routing.maintainer) = %q, want \".\"", got)
+	}
+	if got := GetString("routing.contributor"); got != "~/.beads-planning" {
+		t.Errorf("GetString(routing.contributor) = %q, want \"~/.beads-planning\"", got)
+	}
+}
+
 func TestValidationConfigDefaults(t *testing.T) {
 	// Isolate from environment variables
 	restore := envSnapshot(t)


### PR DESCRIPTION
## Summary

Fixes #1165 - Fresh `bd init` unexpectedly routes to `~/.beads-planning`

Changed `routing.mode` default from `"auto"` to `""` (disabled).

Auto-routing now requires explicit opt-in via:
- `bd init --contributor` flag, OR
- `bd config set routing.mode auto`

## Before/After

```
BEFORE (routing.mode = "auto" by default)
─────────────────────────────────────────
bd init --prefix X
    │
    ▼
routing.mode = "auto" (Viper default)
    │
    ▼
Role detection triggers
    │
    ▼
Non-SSH remote → "contributor" role
    │
    ▼
Routes to ~/.beads-planning
    │
    ▼
ERROR: issue_prefix config is missing


AFTER (routing.mode = "" by default)
────────────────────────────────────
bd init --prefix X
    │
    ▼
routing.mode = "" (disabled)
    │
    ▼
No role detection
    │
    ▼
Creates issue locally ✓
```

## Changes

| File | Change |
|------|--------|
| `internal/config/config.go` | Default `""` instead of `"auto"` |
| `internal/config/config_test.go` | Added `TestRoutingModeDefaultIsEmpty` |
| `docs/ROUTING.md` | Clarified opt-in requirement |
| `docs/CONTRIBUTOR_NAMESPACE_ISOLATION.md` | Updated code example |

## Test Matrix

| Scenario | Command | Before Fix | After Fix | Status |
|----------|---------|------------|-----------|--------|
| Fresh init + create | `bd init --prefix X && bd create "Test"` | Routes to ~/.beads-planning, fails | Creates locally | ✅ Fixed |
| Explicit contributor | `bd init --prefix X --contributor && bd create "Test"` | Routes to ~/.beads-planning | Routes to ~/.beads-planning | ✅ Unchanged |
| Manual auto mode | `bd config set routing.mode auto && bd create "Test"` | Routes based on role | Routes based on role | ✅ Unchanged |
| Existing auto config | (repo with `routing.mode=auto` in DB) | Routes based on role | Routes based on role | ✅ Unchanged |
| SSH remote (maintainer) | `git remote add origin git@github.com:...` | Creates locally | Creates locally | ✅ Unchanged |
| HTTPS + contributor flag | `bd init --contributor` (HTTPS remote) | Routes to planning repo | Routes to planning repo | ✅ Unchanged |

## Test Plan

- [x] `go test -v ./internal/config/... -run "RoutingMode"` passes
- [x] `go test -v ./internal/routing/...` passes (0 failures)
- [ ] Manual verification: fresh init + create works locally