### PR TITLE
fix(routing): disable auto-routing by default to fix v0.47.2 regression

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,11 @@ func Initialize() error {
 	v.SetDefault("remote-sync-interval", "30s")
 
 	// Routing configuration defaults
-	v.SetDefault("routing.mode", "auto")
+	// NOTE: routing.mode must default to "" (disabled) not "auto" to prevent
+	// accidental routing when contributor routing isn't explicitly configured.
+	// See GH#1088 regression where auto-routing to ~/.beads-planning broke
+	// all issue creation for users detected as contributors.
+	v.SetDefault("routing.mode", "")
 	v.SetDefault("routing.default", ".")
 	v.SetDefault("routing.maintainer", ".")
 	v.SetDefault("routing.contributor", "~/.beads-planning")


### PR DESCRIPTION
## Summary
Fixes critical regression in v0.47.2 where `bd create` succeeds but data is silently lost.

## Problem
After v0.47.1, all issue creation fails for users detected as contributors:
- `bd create` prints success with issue ID
- `bd list` returns empty array
- Database has 0 rows
- Warning: `auto-flush failed: sql: database is closed`

## Root Cause
The commit 31239495 added code to act on routing defaults that were already set:
- `routing.mode = "auto"` (enabled by default!)
- `routing.contributor = "~/.beads-planning"`

When a user is detected as Contributor (the fallback for repos without write access):
1. Issue routed to `~/.beads-planning`
2. New store opened at that path
3. Global `store` variable set to new store
4. Store closed via `defer` when command completes
5. Auto-flush tries to use closed global store → **"database is closed"**

## Fix
Change default `routing.mode` from `"auto"` to `""` (disabled).

Users who want contributor routing must now explicitly configure it:
- Run `bd init --contributor`, OR
- Set `routing.mode: auto` in config

## Testing
```bash
# Verify fix (should persist issue)
rm -rf /tmp/test && mkdir /tmp/test && cd /tmp/test
git init && bd init
bd create "Test" -d "body"
bd list --json  # Should show the issue
sqlite3 .beads/beads.db "SELECT count(*) FROM issues"  # Should be 1
```

## Reproduce
```bash
# Install broken version
go install github.com/steveyegge/beads/cmd/bd@v0.47.2

# Create fresh test environment  
rm -rf /tmp/bd-bug-test && mkdir /tmp/bd-bug-test && cd /tmp/bd-bug-test
git init && bd init

# This will "succeed" but not persist
bd create "Test issue" -d "This should be saved"

# Verify bug - returns empty
bd list --json

# Direct DB check confirms no data
sqlite3 .beads/beads.db "SELECT count(*) FROM issues"
# Returns: 0
```
