### PR TITLE
fix(validation): accept prefix when it's a prefix of allowed entry (GH#1135)

### DIFF
--- a/internal/validation/bead_test.go
+++ b/internal/validation/bead_test.go
@@ -314,6 +314,14 @@ func TestValidatePrefixWithAllowed(t *testing.T) {
 		{"allowed with spaces", "gt", "hq", "gt, hmc, foo", false, false},
 		{"empty allowed list", "gt", "hq", "", false, true},
 		{"single allowed prefix", "gt", "hq", "gt", false, false},
+
+		// GH#1135: prefix-of-allowed cases
+		// When ExtractIssuePrefix returns "hq" from "hq-cv-test", but "hq-cv" is allowed
+		{"GH#1135 prefix-of-allowed hq->hq-cv", "hq", "djdefi-ops", "djdefi-ops,hq-cv", false, false},
+		{"GH#1135 prefix-of-allowed with multiple", "hq", "djdefi-ops", "hq-cv,hq-other,foo", false, false},
+		{"GH#1135 exact match still works", "hq-cv", "djdefi-ops", "hq-cv", false, false},
+		{"GH#1135 no false positive for unrelated prefix", "bar", "djdefi-ops", "hq-cv", false, true},
+		{"GH#1135 no false positive for partial overlap", "hq", "djdefi-ops", "hqx-cv", false, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fixes prefix validation to accept `hq` when `hq-cv` is in allowed prefixes
- Handles cases where ExtractIssuePrefix returns a shorter prefix than intended
- Adds comprehensive test cases for the new behavior

## Problem
When an ID like `hq-cv-test` is parsed, ExtractIssuePrefix returns `hq` (because "test" is word-like). If the user has configured `hq-cv` in `allowed_prefixes`, the validation was incorrectly rejecting `hq`.

## Solution
Also accept if `requestedPrefix` is a prefix of any entry in `allowedPrefixes` (with a `-` separator to avoid false positives like `hq` matching `hqx-cv`).

## Test plan
- [x] Added test cases for GH#1135 scenarios
- [x] Verified no false positives for unrelated prefixes
- [x] All existing tests pass

Closes #1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)