### PR TITLE
fix(staleness): skip auto-import when store is read-only (GH#1089)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -76,8 +76,9 @@ var (
 	sandboxMode    bool
 	allowStale     bool          // Use --allow-stale: skip staleness check (emergency escape hatch)
 	noDb           bool          // Use --no-db mode: load from JSONL, write back after each command
-	readonlyMode   bool          // Read-only mode: block write operations (for worker sandboxes)
-	lockTimeout    time.Duration // SQLite busy_timeout (default 30s, 0 = fail immediately)
+	readonlyMode    bool          // Read-only mode: block write operations (for worker sandboxes)
+	storeIsReadOnly bool          // Track if store was opened read-only (for staleness checks)
+	lockTimeout     time.Duration // SQLite busy_timeout (default 30s, 0 = fail immediately)
 	profileEnabled bool
 	profileFile    *os.File
 	traceFile      *os.File
@@ -786,6 +787,10 @@ var rootCmd = &cobra.Command{
 				needsBootstrap = true // New DB needs auto-import (GH#b09)
 			}
 		}
+
+		// Track final read-only state for staleness checks (GH#1089)
+		// opts.ReadOnly may have changed if read-only open failed and fell back
+		storeIsReadOnly = opts.ReadOnly
 
 		if err != nil {
 			// Check for fresh clone scenario

--- a/cmd/bd/staleness.go
+++ b/cmd/bd/staleness.go
@@ -46,7 +46,8 @@ func ensureDatabaseFresh(ctx context.Context) error {
 	// Database is stale - auto-import to refresh (bd-9dao fix)
 	// For read-only commands running in --no-daemon mode, auto-import instead of
 	// returning an error. This allows commands like `bd show` to work after git pull.
-	if !noAutoImport {
+	// Skip auto-import if store is read-only - it can't write anyway (GH#1089)
+	if !noAutoImport && !storeIsReadOnly {
 		autoImportIfNewer()
 		return nil
 	}


### PR DESCRIPTION
## Summary
- Tracks actual read-only state of store (not just requested state)
- Skips auto-import in staleness checks when store is read-only
- Prevents errors when auto-import would fail due to read-only mode

## Problem
When the store is opened read-only (either by request or fallback), the staleness check was still trying to auto-import, which would fail since the store cannot be written to.

## Solution
Add storeIsReadOnly variable that tracks the final read-only state after any fallback logic, and check this before attempting auto-import.

## Test plan
- [x] Build passes
- [x] Manual verification: bd show with read-only store no longer errors on stale check

Closes #1089

Generated with Claude Code