### PR TITLE
fix(doctor): improve diagnostic fix message output

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"time"
 
 	_ "github.com/ncruces/go-sqlite3/driver"
@@ -774,7 +775,15 @@ func printDiagnostics(result doctorResult) {
 				fmt.Printf("  %s  %s %s\n", ui.RenderWarnIcon(), ui.RenderWarn(fmt.Sprintf("%d.", i+1)), line)
 			}
 			if check.Fix != "" {
-				fmt.Printf("        %s%s\n", ui.MutedStyle.Render(ui.TreeLast), check.Fix)
+				// Handle multiline Fix messages with proper indentation
+				lines := strings.Split(check.Fix, "\n")
+				for i, line := range lines {
+					if i == 0 {
+						fmt.Printf("        %s%s\n", ui.MutedStyle.Render(ui.TreeLast), line)
+					} else {
+						fmt.Printf("          %s\n", line)
+					}
+				}
 			}
 		}
 	} else {

--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -542,11 +542,11 @@ func CheckDatabaseJSONLSync(path string) DoctorCheck {
 			fixMsg = "Run 'bd doctor --fix' to fix automatically, or manually run 'bd sync --import-only' or 'bd export' depending on which has newer data"
 		}
 		if strings.Contains(strings.Join(issues, " "), "Prefix mismatch") {
-			fixMsg = "Run 'bd import -i " + filepath.Base(jsonlPath) + " --rename-on-import' to fix prefixes"
+			fixMsg = "Run 'bd import -i .beads/issues.jsonl --rename-on-import' to fix prefixes"
 		}
 		// GH#885: For status mismatches, provide specific guidance and include detail
 		if strings.Contains(strings.Join(issues, " "), "Status mismatch") {
-			fixMsg = "Run 'bd export -o " + filepath.Base(jsonlPath) + "' to update JSONL from DB (DB is usually source of truth)"
+			fixMsg = "Run 'bd export -o .beads/issues.jsonl' to update JSONL from DB (DB is usually source of truth)"
 			detail = statusMismatchDetail
 		}
 

--- a/cmd/bd/doctor/maintenance.go
+++ b/cmd/bd/doctor/maintenance.go
@@ -93,7 +93,7 @@ func CheckStaleClosedIssues(path string) DoctorCheck {
 		Status:   StatusWarning,
 		Message:  fmt.Sprintf("%d closed issue(s) older than %d days", cleanable, DefaultCleanupAgeDays),
 		Detail:   "These issues can be cleaned up to reduce database size",
-		Fix:      "Run 'bd doctor --fix' to cleanup, or 'bd cleanup --force' for more options",
+		Fix:      "Run 'bd doctor --fix' to cleanup, or 'bd admin cleanup --force' for more options",
 		Category: CategoryMaintenance,
 	}
 }
@@ -155,7 +155,7 @@ func CheckExpiredTombstones(path string) DoctorCheck {
 		Status:   StatusWarning,
 		Message:  fmt.Sprintf("%d tombstone(s) older than %d days", expiredCount, ttlDays),
 		Detail:   "Expired tombstones can be pruned to reduce JSONL file size",
-		Fix:      "Run 'bd doctor --fix' to prune, or 'bd cleanup --force' for more options",
+		Fix:      "Run 'bd doctor --fix' to prune, or 'bd admin cleanup --force' for more options",
 		Category: CategoryMaintenance,
 	}
 }


### PR DESCRIPTION
## Summary

Fixes three related issues in `bd doctor` output:

- **#1170**: Stale closed issues warning suggests deprecated `bd cleanup` instead of `bd admin cleanup`
- **#1171**: Multiline fix messages lack proper indentation, making them hard to read
- **#1172**: Database sync fix messages show `issues.jsonl` instead of `.beads/issues.jsonl`

## Changes

| File | Change |
|------|--------|
| `cmd/bd/doctor.go` | Handle multiline Fix strings with proper indentation |
| `cmd/bd/doctor/database.go` | Use `.beads/issues.jsonl` path in fix messages |
| `cmd/bd/doctor/maintenance.go` | Update to `bd admin cleanup --force` |

## Before/After

### #1171: Multiline indentation

**Before** (continuation lines flush-left):
```
  ⚠  4. Claude Integration: Not configured
        └─ Set up Claude integration:
  Option 1: Install the beads plugin (recommended)
    • Provides hooks, slash commands, and MCP tools automatically

  Option 2: CLI-only mode
    • Run 'bd setup claude' to add SessionStart/PreCompact hooks

Benefits:
    • Auto-inject workflow context on session start (~50-2k tokens)
  ⚠  5. Stale Closed Issues: 7 closed issue(s) older than 30 days
```

**After** (proper indentation):
```
  ⚠  9. Claude Integration: Not configured
        └─ Set up Claude integration:
            Option 1: Install the beads plugin (recommended)
              • Provides hooks, slash commands, and MCP tools automatically
              • See: https://github.com/steveyegge/beads/blob/main/docs/PLUGIN.md
          
            Option 2: CLI-only mode
              • Run 'bd setup claude' to add SessionStart/PreCompact hooks
              • No slash commands, but hooks provide workflow context
          
          Benefits:
            • Auto-inject workflow context on session start (~50-2k tokens)
            • Automatic context recovery before compaction
```

### #1170: Deprecated command

**Before:**
```
  ⚠  5. Stale Closed Issues: 7 closed issue(s) older than 30 days
        └─ Run 'bd doctor --fix' to cleanup, or 'bd cleanup --force' for more options
```

**After:**
```
  ⚠  11. Expired Tombstones: 62 tombstone(s) older than 30 days
        └─ Run 'bd doctor --fix' to prune, or 'bd admin cleanup --force' for more options
```

### #1172: Wrong directory path

**Before:**
```
        └─ Run 'bd export -o issues.jsonl' to update JSONL from DB
```

**After:**
```
        └─ Run 'bd export -o .beads/issues.jsonl' to update JSONL from DB
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cmd/bd/doctor/...` passes
- [x] Manual verification of `bd doctor` output formatting

Fixes #1170, Fixes #1171, Fixes #1172