### PR TITLE
feat(nix): add shell completion outputs to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,27 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          bd = pkgs.callPackage ./default.nix { inherit pkgs self; };
         in
         {
-          packages.default = pkgs.callPackage ./default.nix { inherit pkgs self; };
+          packages = {
+            default = bd;
+
+            fish-completions = pkgs.runCommand "bd-fish-completions" { } ''
+              mkdir -p $out/share/fish/vendor_completions.d
+              ${bd}/bin/bd completion fish > $out/share/fish/vendor_completions.d/bd.fish
+            '';
+
+            bash-completions = pkgs.runCommand "bd-bash-completions" { } ''
+              mkdir -p $out/share/bash-completion/completions
+              ${bd}/bin/bd completion bash > $out/share/bash-completion/completions/bd
+            '';
+
+            zsh-completions = pkgs.runCommand "bd-zsh-completions" { } ''
+              mkdir -p $out/share/zsh/site-functions
+              ${bd}/bin/bd completion zsh > $out/share/zsh/site-functions/_bd
+            '';
+          };
 
           apps.default = {
             type = "app";


### PR DESCRIPTION
## Summary

- Add fish, bash, and zsh shell completion packages to the Nix flake
- Completions are generated at build time using `bd completion <shell>`

## Usage

Build individual completion packages:

```bash
nix build github:steveyegge/beads#fish-completions
nix build github:steveyegge/beads#bash-completions
nix build github:steveyegge/beads#zsh-completions
```

Install completions (example for fish):

```bash
# Build and check output path
nix build .#fish-completions --print-out-paths
# /nix/store/...-bd-fish-completions

# The completion file is at:
# $out/share/fish/vendor_completions.d/bd.fish
```

Or add to your NixOS/home-manager configuration:

```nix
# home-manager example
programs.fish.enable = true;
home.packages = [
  inputs.beads.packages.${system}.default
  inputs.beads.packages.${system}.fish-completions
];
```

## Output paths

| Package | Completion file path |
|---------|---------------------|
| `fish-completions` | `share/fish/vendor_completions.d/bd.fish` |
| `bash-completions` | `share/bash-completion/completions/bd` |
| `zsh-completions` | `share/zsh/site-functions/_bd` |

## Test plan

- [x] Verified `nix build .#fish-completions` succeeds
- [x] Verified `nix build .#bash-completions` succeeds
- [x] Verified `nix build .#zsh-completions` succeeds
- [x] Verified fish completions load correctly by sourcing

---

*This PR was created with assistance from Claude Code.*