### PR TITLE
fix(types): show custom types when daemon is running

### DIFF
--- a/cmd/bd/types.go
+++ b/cmd/bd/types.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -53,6 +54,13 @@ Examples:
   bd types --json       # Output as JSON
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Ensure direct mode for database access (types command needs to read config).
+		// In daemon mode, store is nil so custom types would never be fetched.
+		if err := ensureDirectMode("types command requires direct database access"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return
+		}
+
 		// Get custom types from config
 		var customTypes []string
 		ctx := context.Background()


### PR DESCRIPTION
## Summary
- Fix `bd types` not showing custom types when daemon is running
- In daemon mode, `store` is nil so custom types were never fetched
- Added `ensureDirectMode()` call to match pattern used by `bd config get`

## Test plan
- [ ] Run `bd types` with daemon running, verify custom types appear
- [ ] Run `bd types --no-daemon`, verify same output
- [ ] Run `bd config get types.custom`, verify matches `bd types` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)