### PR TITLE
fix(worktree): correct redirect path computation in bd worktree create

### DIFF
--- a/cmd/bd/worktree_cmd.go
+++ b/cmd/bd/worktree_cmd.go
@@ -207,7 +207,10 @@ func runWorktreeCreate(cmd *cobra.Command, args []string) error {
 	// Ensure mainBeadsDir is absolute for correct filepath.Rel() computation (GH#1098)
 	// beads.FindBeadsDir() may return a relative path in some contexts
 	absMainBeadsDir := utils.CanonicalizeIfRelative(mainBeadsDir)
-	relPath, err := filepath.Rel(worktreeBeadsDir, absMainBeadsDir)
+	// Compute relative path from worktree root (not .beads dir) because
+	// FollowRedirect resolves paths relative to the parent of .beads
+	worktreeRoot := filepath.Dir(worktreeBeadsDir)
+	relPath, err := filepath.Rel(worktreeRoot, absMainBeadsDir)
 	if err != nil {
 		// Fall back to absolute path
 		relPath = absMainBeadsDir


### PR DESCRIPTION
## Fix: Correct redirect path computation in `bd worktree create`

### Problem

`bd worktree create` wrote incorrect relative paths to the redirect file. The path was computed relative to the `.beads` directory:

```go
relPath, err := filepath.Rel(worktreeBeadsDir, absMainBeadsDir)
// Produced: ../../main-repo/.beads
```

However, `FollowRedirect` in `beads.go` resolves redirect paths relative to the **project root** (parent of `.beads`):

```go
projectRoot := filepath.Dir(beadsDir)
target = filepath.Join(projectRoot, target)
```

This off-by-one directory level caused redirect resolution to fail silently, as the resolved path didn't exist.

### Fix

Compute the relative path from the worktree root to match `FollowRedirect`'s expectations:

```go
worktreeRoot := filepath.Dir(worktreeBeadsDir)
relPath, err := filepath.Rel(worktreeRoot, absMainBeadsDir)
// Now produces: ../main-repo/.beads
```

### Impact

- `bd worktree info` incorrectly reported "local (no redirect)" for worktrees created with `bd worktree create`
- Other commands (`bd where`, `bd list`, etc.) were unaffected because `FindBeadsDir()` locates the main repo's `.beads` directly via `GetMainRepoRoot()` rather than following the redirect file
- Existing worktrees with broken redirects will continue to function but will show incorrect info until recreated

### Testing

- All existing worktree tests pass
- Manual verification confirms `bd worktree info` now correctly reports redirect status
