### PR TITLE
fix: load types.custom from config.yaml during init auto-import

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -638,3 +638,30 @@ func NeedsJSONL() bool {
 	mode := GetSyncMode()
 	return mode == SyncModeGitPortable || mode == SyncModeRealtime || mode == SyncModeBeltAndSuspenders
 }
+
+// GetCustomTypesFromYAML retrieves custom issue types from config.yaml.
+// This is used as a fallback when the database doesn't have types.custom set yet
+// (e.g., during bd init auto-import before the database is fully configured).
+// Returns nil if no custom types are configured in config.yaml.
+func GetCustomTypesFromYAML() []string {
+	if v == nil {
+		return nil
+	}
+
+	// Try to get types.custom from viper (config.yaml or env var)
+	value := v.GetString("types.custom")
+	if value == "" {
+		return nil
+	}
+
+	// Parse comma-separated list
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/internal/storage/sqlite/config.go
+++ b/internal/storage/sqlite/config.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"strings"
+
+	"github.com/steveyegge/beads/internal/config"
 )
 
 // SetConfig sets a configuration value
@@ -147,16 +149,27 @@ func (s *SQLiteStorage) GetCustomStatuses(ctx context.Context) ([]string, error)
 
 // GetCustomTypes retrieves the list of custom issue types from config.
 // Custom types are stored as comma-separated values in the "types.custom" config key.
+// If the database doesn't have custom types configured, falls back to config.yaml.
+// This fallback is essential during bd init when the database is being created
+// but auto-import needs to validate issues with custom types (GH#1225).
 // Returns an empty slice if no custom types are configured.
 func (s *SQLiteStorage) GetCustomTypes(ctx context.Context) ([]string, error) {
 	value, err := s.GetConfig(ctx, CustomTypeConfigKey)
 	if err != nil {
 		return nil, err
 	}
-	if value == "" {
-		return nil, nil
+	if value != "" {
+		return parseCommaSeparatedList(value), nil
 	}
-	return parseCommaSeparatedList(value), nil
+
+	// Fallback to config.yaml when database doesn't have types.custom set.
+	// This allows auto-import during bd init to work with custom types
+	// defined in config.yaml before they're persisted to the database.
+	if yamlTypes := config.GetCustomTypesFromYAML(); len(yamlTypes) > 0 {
+		return yamlTypes, nil
+	}
+
+	return nil, nil
 }
 
 // parseCommaSeparatedList splits a comma-separated string into a slice of trimmed entries.


### PR DESCRIPTION
## Summary

- Adds `GetCustomTypesFromYAML()` to read `types.custom` from config.yaml
- Modifies `GetCustomTypes()` to fallback to config.yaml when database doesn't have types.custom set
- Adds tests for the new function

## Problem

During `bd init`, auto-import fails with "invalid issue type" errors even when `types.custom` is defined in `.beads/config.yaml`. This happens because custom types are read from the database, but the database is being created during init and doesn't have the config set yet.

This affects fresh clones of repositories that use Gas Town custom types (`molecule`, `gate`, `convoy`, `merge-request`, `slot`, `agent`, `role`, `rig`, `event`, `message`).

## Solution

Add a fallback in `GetCustomTypes()` to read from config.yaml when the database value is empty. This allows auto-import during `bd init` to work with custom types defined in config.yaml before they're persisted to the database.

## Test plan

- [x] Added unit tests for `GetCustomTypesFromYAML()`
- [x] Verified manually that `bd init --from-jsonl` works with custom types in config.yaml
- [x] Full test suite passes with `-short` flag

Fixes #1225

🤖 Generated with [Claude Code](https://claude.ai/code)