### PR TITLE
fix(nix): bake shell completions into default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,25 +23,49 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          bd = pkgs.callPackage ./default.nix { inherit pkgs self; };
+          bdBase = pkgs.callPackage ./default.nix { inherit pkgs self; };
+          # Wrap the base package with shell completions baked in
+          bd = pkgs.stdenv.mkDerivation {
+            pname = "beads";
+            version = bdBase.version;
+
+            phases = [ "installPhase" ];
+
+            installPhase = ''
+              mkdir -p $out/bin
+              cp ${bdBase}/bin/bd $out/bin/bd
+
+              # Generate shell completions
+              mkdir -p $out/share/fish/vendor_completions.d
+              mkdir -p $out/share/bash-completion/completions
+              mkdir -p $out/share/zsh/site-functions
+
+              $out/bin/bd completion fish > $out/share/fish/vendor_completions.d/bd.fish
+              $out/bin/bd completion bash > $out/share/bash-completion/completions/bd
+              $out/bin/bd completion zsh > $out/share/zsh/site-functions/_bd
+            '';
+
+            meta = bdBase.meta;
+          };
         in
         {
           packages = {
             default = bd;
 
+            # Keep separate completion packages for users who only want specific shells
             fish-completions = pkgs.runCommand "bd-fish-completions" { } ''
               mkdir -p $out/share/fish/vendor_completions.d
-              ${bd}/bin/bd completion fish > $out/share/fish/vendor_completions.d/bd.fish
+              ln -s ${bd}/share/fish/vendor_completions.d/bd.fish $out/share/fish/vendor_completions.d/bd.fish
             '';
 
             bash-completions = pkgs.runCommand "bd-bash-completions" { } ''
               mkdir -p $out/share/bash-completion/completions
-              ${bd}/bin/bd completion bash > $out/share/bash-completion/completions/bd
+              ln -s ${bd}/share/bash-completion/completions/bd $out/share/bash-completion/completions/bd
             '';
 
             zsh-completions = pkgs.runCommand "bd-zsh-completions" { } ''
               mkdir -p $out/share/zsh/site-functions
-              ${bd}/bin/bd completion zsh > $out/share/zsh/site-functions/_bd
+              ln -s ${bd}/share/zsh/site-functions/_bd $out/share/zsh/site-functions/_bd
             '';
           };
 


### PR DESCRIPTION
## Summary

The default package now includes fish, bash, and zsh completions at standard paths. This means users only need to install the default package to get both the binary and completions - no need to install a separate completions package.

## Changes

- Wrap the base Go build with a derivation that generates completions
- Completions are installed to standard paths that Nix/home-manager automatically pick up
- Keep separate completion packages for backwards compatibility (now symlink to default)

## Standard completion paths

| Shell | Path |
|-------|------|
| fish | `share/fish/vendor_completions.d/bd.fish` |
| bash | `share/bash-completion/completions/bd` |
| zsh | `share/zsh/site-functions/_bd` |

## Usage

Before (required two packages):
```nix
home.packages = [
  inputs.beads.packages.${system}.default
  inputs.beads.packages.${system}.fish-completions  # extra package needed
];
```

After (just the default):
```nix
home.packages = [
  inputs.beads.packages.${system}.default  # completions included!
];
```

## Test plan

- [x] Verified `nix flake check` passes
- [x] Verified default package includes completions at expected paths

---

*This PR was created with assistance from Claude Code.*