### PR TITLE
fix(autoimport): auto-correct deleted status to tombstone for JSONL compatibility (GH#1223)

### DIFF
--- a/internal/autoimport/autoimport.go
+++ b/internal/autoimport/autoimport.go
@@ -217,7 +217,7 @@ func checkForMergeConflicts(jsonlData []byte, jsonlPath string) error {
 	return nil
 }
 
-func parseJSONL(jsonlData []byte, _ Notifier) ([]*types.Issue, error) {
+func parseJSONL(jsonlData []byte, notify Notifier) ([]*types.Issue, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(jsonlData))
 	scanner.Buffer(make([]byte, 0, 1024), 2*1024*1024)
 	var allIssues []*types.Issue
@@ -239,9 +239,28 @@ func parseJSONL(jsonlData []byte, _ Notifier) ([]*types.Issue, error) {
 			return nil, fmt.Errorf("parse error at line %d: %v\nSnippet: %s", lineNo, err, snippet)
 		}
 
+		// Migrate old JSONL format: auto-correct deleted status to tombstone
+		// This handles JSONL files from versions that used "deleted" instead of "tombstone"
+		// (GH#1223: Stuck in sync diversion loop)
+		if issue.Status == types.Status("deleted") && issue.DeletedAt != nil {
+			issue.Status = types.StatusTombstone
+			if notify != nil {
+				notify.Debugf("Auto-corrected status 'deleted' to 'tombstone' for issue %s", issue.ID)
+			}
+		}
+
 		if issue.Status == types.StatusClosed && issue.ClosedAt == nil {
 			now := time.Now()
 			issue.ClosedAt = &now
+		}
+
+		// Ensure tombstones have deleted_at set (fix for malformed data)
+		if issue.Status == types.StatusTombstone && issue.DeletedAt == nil {
+			now := time.Now()
+			issue.DeletedAt = &now
+			if notify != nil {
+				notify.Debugf("Auto-added deleted_at timestamp for tombstone issue %s", issue.ID)
+			}
 		}
 
 		allIssues = append(allIssues, &issue)


### PR DESCRIPTION
This fix addresses the 'Stuck in sync diversion loop' issue where v0.48.0
encountered validation errors during JSONL import. The issue occurs when
JSONL files from older versions have issues with status='deleted' but the
current code expects status='tombstone' for deleted issues.

Changes:
- Add migration logic in parseJSONL to auto-correct 'deleted' status to 'tombstone'
- Ensure tombstones always have deleted_at timestamp set
- Add debug logging for both migration operations
- Prevents users from being stuck in sync divergence when upgrading

Fixes GH#1223: Stuck in sync diversion loop
