### PR TITLE
fix(dolt): resolve lint and Windows build issues

### DIFF
--- a/cmd/bd/federation.go
+++ b/cmd/bd/federation.go
@@ -374,7 +374,7 @@ func runFederationAddPeer(cmd *cobra.Command, args []string) {
 	password := federationPassword
 	if federationUser != "" && password == "" {
 		fmt.Fprint(os.Stderr, "Password: ")
-		pwBytes, err := term.ReadPassword(int(syscall.Stdin))
+		pwBytes, err := term.ReadPassword(syscall.Stdin)
 		fmt.Fprintln(os.Stderr) // newline after password
 		if err != nil {
 			FatalErrorRespectJSON("failed to read password: %v", err)

--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -263,14 +263,14 @@ func (s *DoltStore) UpdatePeerLastSync(ctx context.Context, name string) error {
 // The caller must hold federationEnvMutex.
 func setFederationCredentials(username, password string) func() {
 	if username != "" {
-		os.Setenv("DOLT_REMOTE_USER", username)
+		_ = os.Setenv("DOLT_REMOTE_USER", username)
 	}
 	if password != "" {
-		os.Setenv("DOLT_REMOTE_PASSWORD", password)
+		_ = os.Setenv("DOLT_REMOTE_PASSWORD", password)
 	}
 	return func() {
-		os.Unsetenv("DOLT_REMOTE_USER")
-		os.Unsetenv("DOLT_REMOTE_PASSWORD")
+		_ = os.Unsetenv("DOLT_REMOTE_USER")
+		_ = os.Unsetenv("DOLT_REMOTE_PASSWORD")
 	}
 }
 

--- a/internal/storage/dolt/server.go
+++ b/internal/storage/dolt/server.go
@@ -103,13 +103,12 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	// Create command
+	// #nosec G204 -- dolt binary path is fixed, args are from trusted config
 	s.cmd = exec.CommandContext(ctx, "dolt", args...)
 	s.cmd.Dir = s.cfg.DataDir
 
-	// Set up process group for clean shutdown
-	s.cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
+	// Set up process group for clean shutdown (platform-specific)
+	setSysProcAttr(s.cmd)
 
 	// Set up logging
 	if s.cfg.LogFile != "" {
@@ -272,6 +271,7 @@ func (s *Server) waitForReady(ctx context.Context) error {
 // GetRunningServerPID returns the PID of a running server from the PID file, or 0 if not running
 func GetRunningServerPID(dataDir string) int {
 	pidFile := filepath.Join(dataDir, "dolt-server.pid")
+	// #nosec G304 -- pidFile is constructed from dataDir which is a trusted internal path
 	data, err := os.ReadFile(pidFile)
 	if err != nil {
 		return 0

--- a/internal/storage/dolt/server_unix.go
+++ b/internal/storage/dolt/server_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package dolt
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setSysProcAttr sets platform-specific process attributes for clean shutdown.
+// On Unix, this sets up a process group for clean shutdown.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/internal/storage/dolt/server_windows.go
+++ b/internal/storage/dolt/server_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package dolt
+
+import (
+	"os/exec"
+)
+
+// setSysProcAttr sets platform-specific process attributes for clean shutdown.
+// On Windows, no special process attributes are needed.
+func setSysProcAttr(cmd *exec.Cmd) {
+	// No special SysProcAttr needed on Windows
+}


### PR DESCRIPTION
## Summary
- Fix errcheck lint errors in `internal/storage/dolt/credentials.go` - explicitly ignore `os.Setenv`/`os.Unsetenv` returns
- Fix gosec warnings in `internal/storage/dolt/server.go` - add nolint comments for intentional subprocess/file access
- Fix unconvert warning in `cmd/bd/federation.go` - remove unnecessary `int()` cast
- Fix Windows build failure - extract platform-specific `SysProcAttr` handling to `server_unix.go` and `server_windows.go`

These are pre-existing issues on main that are blocking PR #1228 from being merged.

## Test plan
- CI should pass with all lint checks
- Windows smoke test should build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)