### PR TITLE
Add `.direnv` folder to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ Thumbs.db
 result
 
 # direnv (machine-specific environment)
+.direnv
 .envrc
 
 # GoReleaser build artifacts


### PR DESCRIPTION
The `.envrc` file was added to `.gitignore` in 7a187cbf689bde361da4e6c0ae85c48a7bd40797, but the `.direnv` folder itself was not, so when I cloned the repo and ran `echo use flake > .envrc && direnv allow` just now, I got a dirty `git status`.