### PR TITLE
feat(cli): add 'view' as alias for 'show' command

### DIFF
--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -17,6 +17,7 @@ import (
 
 var showCmd = &cobra.Command{
 	Use:     "show [id...]",
+	Aliases: []string{"view"},
 	GroupID: "issues",
 	Short:   "Show issue details",
 	Args:    cobra.MinimumNArgs(1),


### PR DESCRIPTION
## Summary
- Add `view` as an alias for the `show` command
- Users naturally try `bd view <id>` when they want to see an issue

## Test plan
- [x] `bd view --help` shows alias in output
- [x] `go build ./cmd/bd/...` passes

Fixes bd-bpx35

🤖 Generated with [Claude Code](https://claude.com/claude-code)