### PR TITLE
fix(lint): check error return from provider.Close()

### DIFF
--- a/cmd/bd/doctor/git.go
+++ b/cmd/bd/doctor/git.go
@@ -893,7 +893,7 @@ func FindOrphanedIssuesFromPath(path string) ([]OrphanIssue, error) {
 	if err != nil {
 		return []OrphanIssue{}, nil
 	}
-	defer provider.Close()
+	defer func() { _ = provider.Close() }()
 
 	return FindOrphanedIssues(path, provider)
 }

--- a/cmd/bd/orphans.go
+++ b/cmd/bd/orphans.go
@@ -117,7 +117,7 @@ func getIssueProvider() (types.IssueProvider, func(), error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to open database at %s: %w", dbPath, err)
 		}
-		return provider, func() { provider.Close() }, nil
+		return provider, func() { _ = provider.Close() }, nil
 	}
 
 	// Use the global store (already opened by PersistentPreRun)


### PR DESCRIPTION
## Summary
- Fix unchecked `provider.Close()` error returns that were breaking CI

Two lint errors introduced in recent commits:
- `cmd/bd/doctor/git.go:896` - unchecked `provider.Close()`
- `cmd/bd/orphans.go:120` - unchecked `provider.Close()`

## Test plan
- [x] `golangci-lint run` passes locally

🤖 Generated with [Claude Code](https://claude.ai/code)