### PR TITLE
Add beads-kanban-ui to Community Tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -26,6 +26,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[beads-dashboard](https://github.com/rhydlewis/beads-dashboard)** - A local, lean metrics dashboard for your beads data. Provides insights insights into lead time, throughput and other continuous improvement metrics. Includes a filterable table view of "all issues". Built by [@rhydlewis](https://github.com/rhydlewis). (Node.js/React)
 
+- **[beads-kanban-ui](https://github.com/AvivK5498/Beads-Kanban-UI)** - Visual Kanban board with git branch status tracking, epic/subtask management, design doc viewer, and activity timeline. Install via npm: `npm install -g beads-kanban-ui`. Built by [@AvivK5498](https://github.com/AvivK5498). (TypeScript/Rust)
+
 ## Editor Extensions
 
 - **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and daemon management. Built by [@jdillon](https://github.com/jdillon). (TypeScript)
@@ -47,6 +49,10 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 ## Data Source Middleware
 
 - **[jira-beads-sync](https://github.com/conallob/jira-beads-sync)** - CLI tool & Claude Code plugin to sync tasks from Jira into beads and publish beads task states back to Jira. Built by [@conallob](https://github.com/conallob). (Go)
+
+## Claude Code Orchestration
+
+- **[beads-orchestration](https://github.com/AvivK5498/Claude-Code-Beads-Orchestration)** - Multi-agent orchestration skill for Claude Code. Orchestrator investigates issues, manages beads tasks automatically, and delegates to tech-specific supervisors on isolated branches. Includes hooks for workflow enforcement, epic/subtask support, and optional external provider delegation (Codex/Gemini). Install via npm: `npm install -g @avivkaplan/beads-orchestration`. Built by [@AvivK5498](https://github.com/AvivK5498). (Node.js/Python)
 
 ## Historical / Stale
 


### PR DESCRIPTION
## Summary

Adding two community tools:

1. **[beads-kanban-ui](https://github.com/AvivK5498/Beads-Kanban-UI)** → Web UIs section
2. **[beads-orchestration](https://github.com/AvivK5498/Claude-Code-Beads-Orchestration)** → New "Claude Code Orchestration" section

---

## beads-kanban-ui

Visual Kanban board for Beads with:
- **Kanban board** - Drag-and-drop across Open/In Progress/In Review/Closed
- **Git branch status** - Shows Synced/Ready to merge/Merged/Needs rebase badges
- **Epic and subtask management** - Full support for epics with dependencies
- **Design document viewer** - Embedded markdown viewer
- **Activity timeline** - Track comments and status changes

**Install:** `npm install -g beads-kanban-ui`

**Tech:** Next.js/TypeScript frontend, Rust backend

---

## beads-orchestration

Multi-agent orchestration skill for Claude Code:
- **Orchestrator pattern** - Investigates issues, delegates to supervisors
- **Automatic task management** - Creates/updates/closes beads automatically
- **Tech-specific supervisors** - Discovery agent creates supervisors for your stack
- **Workflow hooks** - Enforces branch discipline, epic dependencies
- **External providers** - Optional Codex/Gemini delegation for read-only agents

**Install:** `npm install -g @avivkaplan/beads-orchestration`

**Tech:** Node.js installer, Python MCP server