### PR TITLE
feat(bd): add --ephemeral and --persistent flags to bd update

### DIFF
--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -92,7 +92,7 @@ func updatesFromArgs(a UpdateArgs) (map[string]interface{}, error) {
 		u["sender"] = *a.Sender
 	}
 	if a.Ephemeral != nil {
-		u["ephemeral"] = *a.Ephemeral
+		u["wisp"] = *a.Ephemeral // Storage API uses "wisp", maps to "ephemeral" column
 	}
 	if a.RepliesTo != nil {
 		u["replies_to"] = *a.RepliesTo


### PR DESCRIPTION
## Summary

Add CLI flags to `bd update` for marking existing issues as ephemeral (wisps) or promoting them to persistent:

- `--ephemeral`: Mark issue as ephemeral (not exported to JSONL)
- `--persistent`: Promote wisp to regular issue
- Flags are mutually exclusive

This enables `gt doctor --fix` to automatically fix misclassified wisps.

Implements the beads portion of https://github.com/steveyegge/gastown/issues/852

## Bug Fix

Also fixes a latent bug in the RPC server: `UpdateArgs.Ephemeral` was mapped to `u["ephemeral"]` but the storage API expects `u["wisp"]` (which maps to the `ephemeral` database column). This bug was never triggered because no CLI command previously set `UpdateArgs.Ephemeral`.

## Changes

- `cmd/bd/update.go`: Add flag definitions, handling, and RPC mapping
- `internal/rpc/server_issues_epics.go`: Fix field name mapping (`ephemeral` -> `wisp`)
- `cmd/bd/cli_fast_test.go`: Add integration tests

## Test plan

- [x] `bd update <id> --ephemeral` sets Ephemeral=true
- [x] `bd update <id> --persistent` sets Ephemeral=false  
- [x] Both flags together produces error
- [x] All existing tests pass (`go test ./...`)
- [x] New integration tests pass individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)