### PR TITLE
feat(dolt): auto-commit write commands and set explicit commit authors

### DIFF
--- a/cmd/bd/autoflush.go
+++ b/cmd/bd/autoflush.go
@@ -438,7 +438,7 @@ func autoImportIfNewer() {
 // Thread-safe: Safe to call from multiple goroutines (uses atomic.Bool).
 // No-op if auto-flush is disabled via --no-auto-flush flag.
 func markDirtyAndScheduleFlush() {
-// Track that this command performed a write (atomic to avoid data races).
+	// Track that this command performed a write (atomic to avoid data races).
 	commandDidWrite.Store(true)
 
 	// Use FlushManager if available

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -407,10 +407,9 @@ NOTE: Import requires direct database access and does not work with daemon mode.
 			fmt.Fprintf(os.Stderr, "\nAll text and dependency references have been updated.\n")
 		}
 
-		// Mark this command as having performed a write if it changed anything.
-		// This enables Dolt auto-commit in PersistentPostRun.
+		// Record that this command performed a write (for Dolt auto-commit).
 		if result.Created > 0 || result.Updated > 0 || len(result.IDMapping) > 0 {
-commandDidWrite.Store(true)
+			commandDidWrite.Store(true)
 		}
 
 		// Flush immediately after import (no debounce) to ensure daemon sees changes

--- a/cmd/bd/sync_import.go
+++ b/cmd/bd/sync_import.go
@@ -136,8 +136,7 @@ func importFromJSONLInline(ctx context.Context, jsonlPath string, renameOnImport
 		return fmt.Errorf("import failed: %w", err)
 	}
 
-	// Mark command as having performed a write when the import changed anything.
-	// This enables Dolt auto-commit in PersistentPostRun.
+	// Record that this command performed a write (for Dolt auto-commit) when the import changed anything.
 	if result.Created > 0 || result.Updated > 0 || len(result.IDMapping) > 0 {
 		commandDidWrite.Store(true)
 	}


### PR DESCRIPTION
  Summary

  • Add Dolt auto-commit after successful write commands via dolt.auto-commit (default on), BD_DOLT_AUTO_COMMIT, and --dolt-auto-commit (off|on) so Dolt-backed
    changes don’t linger only in the working set.
  • Track “command performed a write” and run the Dolt commit after final auto-flush in PersistentPostRun (treat “nothing to commit” as a no-op).
  • Make Dolt history deterministic by passing an explicit --author to DOLT_COMMIT and DOLT_MERGE (avoid root@localhost), and add integration/unit coverage + docs
    updates clarifying git auto-commit vs Dolt auto-commit.


  Test plan

  • go test ./...
  • go test -tags=integration ./cmd/bd -run DoltAutoCommit
  • Manual:
    • bd init --backend dolt --prefix test
    • bd create "test issue"
    • bd vc log / bd vc status (verify HEAD advanced + author matches expected)