### PR TITLE
fix: add WAL checkpoint robustness with retry logic

### DIFF
--- a/cmd/bd/flush_manager_race_test.go
+++ b/cmd/bd/flush_manager_race_test.go
@@ -1,0 +1,553 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// =============================================================================
+// FlushManager Race Condition Tests
+// =============================================================================
+//
+// These tests verify correct FlushManager behavior under concurrent access.
+// Run with: go test -race -run TestFlushManager -v
+//
+// Race conditions being tested:
+// 1. Shutdown timeout with large database (simulated)
+// 2. Concurrent MarkDirty calls
+// 3. Flush during import
+// 4. Debounce timer race conditions
+// 5. Context cancellation during flush
+//
+// =============================================================================
+
+// TestFlushManagerShutdownTimeoutLargeDB simulates shutdown timeout with large DB.
+//
+// Race condition tested: Shutdown initiated while a long-running flush is in progress.
+// Shutdown should timeout gracefully without blocking indefinitely.
+func TestFlushManagerShutdownTimeoutLargeDB(t *testing.T) {
+	// set up test environment
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	// create flush manager with very short debounce
+	fm := NewFlushManager(true, 10*time.Millisecond)
+
+	// mark dirty to trigger flush
+	fm.MarkDirty(true)
+
+	// wait for debounce
+	time.Sleep(50 * time.Millisecond)
+
+	// shutdown should complete within timeout
+	start := time.Now()
+	err := fm.Shutdown()
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Logf("Shutdown returned error (may be expected): %v", err)
+	}
+
+	// should not take longer than shutdown timeout
+	if elapsed > 35*time.Second {
+		t.Errorf("Shutdown took too long: %v (expected < 35s)", elapsed)
+	}
+
+	t.Logf("Shutdown completed in %v", elapsed)
+}
+
+// TestFlushManagerConcurrentMarkDirtyRace tests concurrent MarkDirty under race detector.
+//
+// Race condition tested: Multiple goroutines calling MarkDirty simultaneously.
+// Channel send should not cause data races.
+func TestFlushManagerConcurrentMarkDirtyRace(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(true, 100*time.Millisecond)
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const numGoroutines = 100
+	const callsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	var markCount int32
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			fullExport := (id%2 == 0)
+			for j := 0; j < callsPerGoroutine; j++ {
+				fm.MarkDirty(fullExport)
+				atomic.AddInt32(&markCount, 1)
+
+				// vary timing to increase interleaving
+				if j%10 == 0 {
+					time.Sleep(time.Microsecond)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	t.Logf("Completed %d MarkDirty calls without race", markCount)
+}
+
+// TestFlushManagerFlushDuringImport simulates flush occurring during import.
+//
+// Race condition tested: MarkDirty called while storeActive is being toggled.
+// Should handle gracefully without data races.
+func TestFlushManagerFlushDuringImport(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(true, 10*time.Millisecond)
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const iterations = 50
+	var wg sync.WaitGroup
+
+	// goroutine 1: toggle storeActive (simulating import)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			storeMutex.Lock()
+			storeActive = false
+			storeMutex.Unlock()
+
+			time.Sleep(time.Millisecond)
+
+			storeMutex.Lock()
+			storeActive = true
+			storeMutex.Unlock()
+
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// goroutine 2: mark dirty continuously
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations*10; i++ {
+			fm.MarkDirty(i%5 == 0)
+			time.Sleep(100 * time.Microsecond)
+		}
+	}()
+
+	// goroutine 3: request flushes
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = fm.FlushNow()
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// verify storeActive is in consistent state
+	storeMutex.Lock()
+	storeActive = true
+	storeMutex.Unlock()
+}
+
+// TestFlushManagerDebounceTimerRace tests debounce timer race conditions.
+//
+// Race condition tested: Timer firing while MarkDirty is resetting it.
+// Timer operations should not cause data races.
+func TestFlushManagerDebounceTimerRace(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	// very short debounce to increase timer race likelihood
+	fm := NewFlushManager(true, 1*time.Millisecond)
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+
+	// rapidly mark dirty to cause timer resets
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations/10; j++ {
+				fm.MarkDirty(false)
+				// no sleep - maximum contention on timer
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// wait for any pending timers
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestFlushManagerContextCancellationDuringFlush tests context cancellation.
+//
+// Race condition tested: FlushManager context cancelled while flush in progress.
+// Should clean up without blocking or panicking.
+func TestFlushManagerContextCancellationDuringFlush(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(true, 10*time.Millisecond)
+
+	// mark dirty
+	fm.MarkDirty(true)
+
+	// start flush in goroutine
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = fm.FlushNow()
+	}()
+
+	// cancel context immediately (simulated by shutdown)
+	time.Sleep(time.Millisecond)
+	if err := fm.Shutdown(); err != nil {
+		t.Logf("Shutdown error (may be expected): %v", err)
+	}
+
+	// wait with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// expected
+	case <-time.After(5 * time.Second):
+		t.Error("FlushNow did not complete after context cancellation")
+	}
+}
+
+// TestFlushManagerMultipleShutdowns tests idempotent shutdown behavior.
+//
+// Race condition tested: Multiple goroutines calling Shutdown simultaneously.
+// Only one should do work, others should return immediately.
+func TestFlushManagerMultipleShutdowns(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(true, 50*time.Millisecond)
+
+	// mark dirty
+	fm.MarkDirty(false)
+
+	const numShutdowns = 10
+	var (
+		wg           sync.WaitGroup
+		successCount int32
+		errorCount   int32
+	)
+
+	for i := 0; i < numShutdowns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := fm.Shutdown()
+			if err == nil {
+				atomic.AddInt32(&successCount, 1)
+			} else {
+				atomic.AddInt32(&errorCount, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	t.Logf("Multiple shutdowns: %d success, %d errors", successCount, errorCount)
+
+	// all should succeed (idempotent)
+	if successCount != numShutdowns {
+		t.Errorf("Expected all %d shutdowns to succeed, got %d", numShutdowns, successCount)
+	}
+}
+
+// TestFlushManagerFlushNowRace tests concurrent FlushNow calls.
+//
+// Race condition tested: Multiple goroutines calling FlushNow simultaneously.
+// Should serialize correctly without data races.
+func TestFlushManagerFlushNowRace(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(true, 100*time.Millisecond)
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const numGoroutines = 20
+	var (
+		wg           sync.WaitGroup
+		successCount int32
+		errorCount   int32
+	)
+
+	// first mark dirty
+	fm.MarkDirty(false)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := fm.FlushNow()
+			if err == nil {
+				atomic.AddInt32(&successCount, 1)
+			} else {
+				atomic.AddInt32(&errorCount, 1)
+				t.Logf("FlushNow error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	t.Logf("Concurrent FlushNow: %d success, %d errors", successCount, errorCount)
+
+	// most should succeed
+	if successCount < int32(numGoroutines/2) {
+		t.Errorf("Expected at least %d successes, got %d", numGoroutines/2, successCount)
+	}
+}
+
+// TestFlushManagerChannelBufferOverflow tests behavior when channels fill up.
+//
+// Race condition tested: markDirtyCh buffer full while sending.
+// Should not block indefinitely.
+func TestFlushManagerChannelBufferOverflow(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	// create manager with very long debounce (won't process events quickly)
+	fm := NewFlushManager(true, 10*time.Second)
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const numCalls = 1000
+
+	// rapidly fill the buffer
+	start := time.Now()
+	for i := 0; i < numCalls; i++ {
+		fm.MarkDirty(false)
+	}
+	elapsed := time.Since(start)
+
+	t.Logf("Made %d MarkDirty calls in %v", numCalls, elapsed)
+
+	// should complete quickly (not block on full buffer)
+	if elapsed > time.Second {
+		t.Errorf("MarkDirty blocked too long: %v", elapsed)
+	}
+}
+
+// TestFlushManagerDisabledRace tests disabled manager under concurrent access.
+//
+// Race condition tested: Disabled manager receiving concurrent calls.
+// All should be no-ops without races.
+func TestFlushManagerDisabledRace(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(false, 50*time.Millisecond) // disabled
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			for j := 0; j < 100; j++ {
+				fm.MarkDirty(id%2 == 0)
+				if j%10 == 0 {
+					_ = fm.FlushNow()
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// TestFlushManagerShutdownDuringMarkDirty tests shutdown during active marking.
+//
+// Race condition tested: Shutdown called while MarkDirty goroutines are active.
+// Should complete without blocking.
+func TestFlushManagerShutdownDuringMarkDirty(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(true, 50*time.Millisecond)
+
+	const numGoroutines = 20
+	var wg sync.WaitGroup
+
+	// start marking goroutines
+	ctx, cancel := context.WithCancel(context.Background())
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					fm.MarkDirty(false)
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+	}
+
+	// let marking run for a bit
+	time.Sleep(100 * time.Millisecond)
+
+	// shutdown while marking is active
+	shutdownDone := make(chan struct{})
+	go func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+		close(shutdownDone)
+	}()
+
+	// wait for shutdown with timeout
+	select {
+	case <-shutdownDone:
+		// expected
+	case <-time.After(35 * time.Second):
+		t.Error("Shutdown did not complete in time")
+	}
+
+	// stop marking goroutines
+	cancel()
+	wg.Wait()
+}
+
+// TestFlushManagerFullExportFlagRace tests fullExport flag under concurrent access.
+//
+// Race condition tested: Multiple goroutines setting different fullExport values.
+// The flag should be "sticky" - once true, stays true until flush.
+func TestFlushManagerFullExportFlagRace(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	fm := NewFlushManager(true, 100*time.Millisecond)
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const numGoroutines = 20
+	var wg sync.WaitGroup
+
+	// half set fullExport=true, half set fullExport=false
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			fullExport := (id % 2 == 0)
+			for j := 0; j < 50; j++ {
+				fm.MarkDirty(fullExport)
+				time.Sleep(time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// trigger final flush
+	_ = fm.FlushNow()
+}
+
+// TestFlushManagerTimerFireRace tests timer firing while being stopped.
+//
+// Race condition tested: Timer fires while FlushNow is stopping it.
+// Should not cause double flush or panic.
+func TestFlushManagerTimerFireRace(t *testing.T) {
+	setupTestEnvironmentForRace(t)
+	defer teardownTestEnvironmentForRace(t)
+
+	// use exact debounce time to maximize race window
+	debounce := 10 * time.Millisecond
+	fm := NewFlushManager(true, debounce)
+	defer func() {
+		if err := fm.Shutdown(); err != nil {
+			t.Logf("Shutdown error: %v", err)
+		}
+	}()
+
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		// mark dirty to start timer
+		fm.MarkDirty(false)
+
+		// wait almost exactly until timer would fire
+		time.Sleep(debounce - time.Millisecond)
+
+		// call FlushNow which stops timer
+		_ = fm.FlushNow()
+	}
+}
+
+// Helper functions for race tests
+
+func setupTestEnvironmentForRace(t *testing.T) {
+	t.Helper()
+	autoFlushEnabled = true
+	storeMutex.Lock()
+	storeActive = true
+	storeMutex.Unlock()
+}
+
+func teardownTestEnvironmentForRace(t *testing.T) {
+	t.Helper()
+	storeMutex.Lock()
+	storeActive = false
+	storeMutex.Unlock()
+	if flushManager != nil {
+		_ = flushManager.Shutdown()
+		flushManager = nil
+	}
+}

--- a/internal/storage/sqlite/wal_test.go
+++ b/internal/storage/sqlite/wal_test.go
@@ -1,0 +1,911 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestWALCheckpointWithConcurrentReaders tests that WAL checkpoint works correctly
+// when concurrent readers are active.
+func TestWALCheckpointWithConcurrentReaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping WAL checkpoint test in short mode")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "beads-wal-checkpoint-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create some initial data
+	for i := 0; i < 20; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("Initial Issue %d", i),
+			Status:    types.StatusOpen,
+			Priority:  i % 4,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "setup"); err != nil {
+			t.Fatalf("CreateIssue failed: %v", err)
+		}
+	}
+
+	// start concurrent readers - they run for a fixed number of iterations
+	const numReaders = 5
+	const readsPerReader = 30
+
+	var wg sync.WaitGroup
+	var readSuccess atomic.Int64
+	var readErrors atomic.Int64
+
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func(readerID int) {
+			defer wg.Done()
+
+			for j := 0; j < readsPerReader; j++ {
+				issues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+				if err == nil && len(issues) >= 20 {
+					readSuccess.Add(1)
+				} else {
+					readErrors.Add(1)
+					if err != nil {
+						t.Logf("reader %d error: %v", readerID, err)
+					}
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	// perform checkpoints concurrently with readers
+	var checkpointSuccess int
+	var checkpointWg sync.WaitGroup
+	checkpointWg.Add(1)
+	go func() {
+		defer checkpointWg.Done()
+		for i := 0; i < 5; i++ {
+			time.Sleep(15 * time.Millisecond)
+			if err := store.CheckpointWAL(ctx); err != nil {
+				t.Logf("checkpoint %d failed: %v", i, err)
+			} else {
+				checkpointSuccess++
+			}
+		}
+	}()
+
+	// wait for both readers and checkpoints
+	wg.Wait()
+	checkpointWg.Wait()
+
+	totalReads := int64(numReaders * readsPerReader)
+	t.Logf("checkpoints: %d/5 successful, reads: %d/%d (errors: %d)",
+		checkpointSuccess, readSuccess.Load(), totalReads, readErrors.Load())
+
+	// all checkpoints should succeed
+	if checkpointSuccess != 5 {
+		t.Errorf("expected 5 successful checkpoints, got %d", checkpointSuccess)
+	}
+
+	// all reads should succeed (WAL mode allows concurrent reads during checkpoint)
+	if readSuccess.Load() != totalReads {
+		t.Errorf("not all reads succeeded: %d/%d", readSuccess.Load(), totalReads)
+	}
+}
+
+// TestWALCheckpointFailureHandling tests graceful handling of checkpoint failures.
+func TestWALCheckpointFailureHandling(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-wal-fail-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create issue to generate WAL data
+	issue := &types.Issue{
+		Title:     "WAL Test Issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+
+	// checkpoint should succeed normally
+	if err := store.CheckpointWAL(ctx); err != nil {
+		t.Errorf("normal checkpoint failed: %v", err)
+	}
+
+	// checkpoint with cancelled context should fail gracefully
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel() // cancel immediately
+
+	err = store.CheckpointWAL(cancelCtx)
+	if err == nil {
+		t.Log("checkpoint with cancelled context succeeded (acceptable)")
+	} else {
+		t.Logf("checkpoint with cancelled context: %v (expected)", err)
+	}
+
+	// store should still be usable after checkpoint failure
+	issue2 := &types.Issue{
+		Title:     "Post-Checkpoint Issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue2, "test"); err != nil {
+		t.Errorf("CreateIssue after checkpoint failure failed: %v", err)
+	}
+}
+
+// TestWALGrowthUnderSustainedWrites tests WAL file growth under sustained write load.
+func TestWALGrowthUnderSustainedWrites(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping WAL growth test in short mode")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "beads-wal-growth-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	walPath := dbPath + "-wal"
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// record initial state
+	var initialWALSize int64
+	if info, err := os.Stat(walPath); err == nil {
+		initialWALSize = info.Size()
+	}
+
+	// sustained writes without checkpoint
+	const numWrites = 100
+	for i := 0; i < numWrites; i++ {
+		issue := &types.Issue{
+			Title:       fmt.Sprintf("Sustained Write %d", i),
+			Description: "This is a test issue with some content to grow the WAL file.",
+			Status:      types.StatusOpen,
+			Priority:    i % 4,
+			IssueType:   types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "writer"); err != nil {
+			t.Fatalf("CreateIssue %d failed: %v", i, err)
+		}
+	}
+
+	// check WAL size after writes
+	var postWriteWALSize int64
+	if info, err := os.Stat(walPath); err == nil {
+		postWriteWALSize = info.Size()
+	}
+
+	t.Logf("WAL size: initial=%d, after %d writes=%d",
+		initialWALSize, numWrites, postWriteWALSize)
+
+	// WAL should have grown
+	if postWriteWALSize <= initialWALSize {
+		t.Logf("WAL did not grow (may have auto-checkpointed)")
+	}
+
+	// checkpoint to truncate WAL
+	if err := store.CheckpointWAL(ctx); err != nil {
+		t.Fatalf("checkpoint failed: %v", err)
+	}
+
+	// check WAL size after checkpoint
+	var postCheckpointWALSize int64
+	if info, err := os.Stat(walPath); err == nil {
+		postCheckpointWALSize = info.Size()
+	}
+
+	t.Logf("WAL size after checkpoint: %d", postCheckpointWALSize)
+
+	// TRUNCATE checkpoint should reduce WAL to minimal size
+	// (Close() uses TRUNCATE which empties the WAL)
+	// But CheckpointWAL uses FULL which may leave some data
+}
+
+// TestWALDataVisibilityAfterCheckpoint tests that data is visible after checkpoint.
+func TestWALDataVisibilityAfterCheckpoint(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-wal-visibility-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	// create store and add data
+	store1, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store1: %v", err)
+	}
+
+	if err := store1.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		store1.Close()
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create issue
+	issue := &types.Issue{
+		Title:     "Visibility Test Issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store1.CreateIssue(ctx, issue, "test"); err != nil {
+		store1.Close()
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+	issueID := issue.ID
+
+	// checkpoint to flush WAL to main DB
+	if err := store1.CheckpointWAL(ctx); err != nil {
+		store1.Close()
+		t.Fatalf("checkpoint failed: %v", err)
+	}
+
+	// close store1
+	store1.Close()
+
+	// open new store and verify data is visible
+	store2, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store2: %v", err)
+	}
+	defer store2.Close()
+
+	if err := store2.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	foundIssue, err := store2.GetIssue(ctx, issueID)
+	if err != nil {
+		t.Fatalf("GetIssue failed: %v", err)
+	}
+
+	if foundIssue == nil {
+		t.Error("issue not visible after checkpoint and reopen")
+	} else if foundIssue.Title != "Visibility Test Issue" {
+		t.Errorf("wrong title: got %q, want %q", foundIssue.Title, "Visibility Test Issue")
+	}
+}
+
+// TestWALModeIsEnabled verifies that WAL mode is actually enabled.
+func TestWALModeIsEnabled(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-wal-mode-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	// query journal mode
+	var journalMode string
+	if err := store.db.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("failed to query journal_mode: %v", err)
+	}
+
+	t.Logf("journal_mode: %s", journalMode)
+
+	if journalMode != "wal" {
+		t.Errorf("expected journal_mode=wal, got %q", journalMode)
+	}
+}
+
+// TestWALConcurrentReadersWriters tests WAL mode's support for concurrent readers and writers.
+func TestWALConcurrentReadersWriters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent readers/writers test in short mode")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "beads-wal-concurrent-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create initial data
+	for i := 0; i < 10; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("Initial %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "setup"); err != nil {
+			t.Fatalf("CreateIssue failed: %v", err)
+		}
+	}
+
+	const numReaders = 10
+	const numWriters = 2
+	const opsPerWorker = 50
+
+	var wg sync.WaitGroup
+	var readSuccess atomic.Int64
+	var writeSuccess atomic.Int64
+	var readErrors atomic.Int64
+	var writeErrors atomic.Int64
+
+	// start readers
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func(readerID int) {
+			defer wg.Done()
+
+			for j := 0; j < opsPerWorker; j++ {
+				_, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+				if err != nil {
+					readErrors.Add(1)
+				} else {
+					readSuccess.Add(1)
+				}
+			}
+		}(i)
+	}
+
+	// start writers
+	for i := 0; i < numWriters; i++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+
+			for j := 0; j < opsPerWorker; j++ {
+				issue := &types.Issue{
+					Title:     fmt.Sprintf("Writer %d Issue %d", writerID, j),
+					Status:    types.StatusOpen,
+					Priority:  2,
+					IssueType: types.TypeTask,
+				}
+				if err := store.CreateIssue(ctx, issue, "writer"); err != nil {
+					writeErrors.Add(1)
+				} else {
+					writeSuccess.Add(1)
+				}
+			}
+		}(i)
+	}
+
+	// wait for all operations
+	wg.Wait()
+
+	totalReads := int64(numReaders * opsPerWorker)
+	totalWrites := int64(numWriters * opsPerWorker)
+
+	t.Logf("reads: %d/%d (%d errors), writes: %d/%d (%d errors)",
+		readSuccess.Load(), totalReads, readErrors.Load(),
+		writeSuccess.Load(), totalWrites, writeErrors.Load())
+
+	// WAL mode should allow all reads to succeed
+	if readSuccess.Load() != totalReads {
+		t.Errorf("not all reads succeeded: %d/%d", readSuccess.Load(), totalReads)
+	}
+
+	// writes may have some contention but should mostly succeed
+	if writeSuccess.Load() < totalWrites*90/100 {
+		t.Errorf("too few writes succeeded: %d/%d", writeSuccess.Load(), totalWrites)
+	}
+}
+
+// TestWALFileCreation tests that WAL and SHM files are created.
+func TestWALFileCreation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-wal-files-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	walPath := dbPath + "-wal"
+	shmPath := dbPath + "-shm"
+	ctx := context.Background()
+
+	// initially no files should exist
+	if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
+		t.Error("database file exists before creation")
+	}
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	// database should exist
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Error("database file does not exist after creation")
+	}
+
+	// WAL file may not exist until first write
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create an issue to trigger WAL write
+	issue := &types.Issue{
+		Title:     "WAL File Test",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+
+	// WAL file should exist after write (in WAL mode)
+	if _, err := os.Stat(walPath); os.IsNotExist(err) {
+		t.Log("WAL file does not exist (may have been checkpointed)")
+	} else {
+		t.Log("WAL file exists")
+	}
+
+	// SHM file should exist (used for shared memory in WAL mode)
+	if _, err := os.Stat(shmPath); os.IsNotExist(err) {
+		t.Log("SHM file does not exist (expected)")
+	} else {
+		t.Log("SHM file exists")
+	}
+}
+
+// TestCheckpointModes tests different checkpoint modes (PASSIVE, FULL, TRUNCATE).
+func TestCheckpointModes(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-checkpoint-modes-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	walPath := dbPath + "-wal"
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create some data
+	for i := 0; i < 10; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("Checkpoint Test %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("CreateIssue failed: %v", err)
+		}
+	}
+
+	getWALSize := func() int64 {
+		if info, err := os.Stat(walPath); err == nil {
+			return info.Size()
+		}
+		return 0
+	}
+
+	// test PASSIVE checkpoint (won't block, may not complete)
+	_, err = store.db.Exec("PRAGMA wal_checkpoint(PASSIVE)")
+	if err != nil {
+		t.Errorf("PASSIVE checkpoint failed: %v", err)
+	}
+	t.Logf("after PASSIVE: WAL size = %d", getWALSize())
+
+	// test FULL checkpoint (waits for readers, checkpoints all frames)
+	_, err = store.db.Exec("PRAGMA wal_checkpoint(FULL)")
+	if err != nil {
+		t.Errorf("FULL checkpoint failed: %v", err)
+	}
+	t.Logf("after FULL: WAL size = %d", getWALSize())
+
+	// test TRUNCATE checkpoint (like FULL but also truncates WAL file)
+	_, err = store.db.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	if err != nil {
+		t.Errorf("TRUNCATE checkpoint failed: %v", err)
+	}
+	truncateSize := getWALSize()
+	t.Logf("after TRUNCATE: WAL size = %d", truncateSize)
+
+	// TRUNCATE should result in small or zero WAL file
+	if truncateSize > 4096 { // some filesystem overhead is ok
+		t.Log("WAL file larger than expected after TRUNCATE")
+	}
+}
+
+// TestCheckpointDuringTransaction tests checkpoint behavior during active transaction.
+func TestCheckpointDuringTransaction(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-checkpoint-during-tx-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create initial data
+	for i := 0; i < 5; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("Pre-TX Issue %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "setup"); err != nil {
+			t.Fatalf("CreateIssue failed: %v", err)
+		}
+	}
+
+	// start a read transaction
+	txStarted := make(chan struct{})
+	txRelease := make(chan struct{})
+	var txErr error
+
+	go func() {
+		// get a connection and start a read transaction
+		conn, err := store.db.Conn(ctx)
+		if err != nil {
+			txErr = err
+			close(txStarted)
+			return
+		}
+		defer conn.Close()
+
+		// start read transaction
+		_, err = conn.ExecContext(ctx, "BEGIN DEFERRED")
+		if err != nil {
+			txErr = err
+			close(txStarted)
+			return
+		}
+
+		// perform a read (starts read lock)
+		var count int
+		conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues").Scan(&count)
+
+		close(txStarted)
+		<-txRelease
+
+		conn.ExecContext(ctx, "COMMIT")
+	}()
+
+	<-txStarted
+	if txErr != nil {
+		t.Fatalf("transaction setup failed: %v", txErr)
+	}
+
+	// try PASSIVE checkpoint while read transaction is active
+	// PASSIVE won't wait, so it should return immediately
+	_, err = store.db.Exec("PRAGMA wal_checkpoint(PASSIVE)")
+	if err != nil {
+		t.Errorf("PASSIVE checkpoint during read TX failed: %v", err)
+	}
+
+	// release transaction
+	close(txRelease)
+	time.Sleep(50 * time.Millisecond)
+
+	// FULL checkpoint should work now
+	_, err = store.db.Exec("PRAGMA wal_checkpoint(FULL)")
+	if err != nil {
+		t.Errorf("FULL checkpoint after TX release failed: %v", err)
+	}
+}
+
+// TestWALAutoCheckpoint tests SQLite's auto-checkpoint behavior.
+func TestWALAutoCheckpoint(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-auto-checkpoint-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	// check auto-checkpoint threshold
+	var threshold int
+	if err := store.db.QueryRow("PRAGMA wal_autocheckpoint").Scan(&threshold); err != nil {
+		t.Fatalf("failed to query wal_autocheckpoint: %v", err)
+	}
+
+	t.Logf("wal_autocheckpoint threshold: %d pages", threshold)
+
+	// default is 1000 pages, which is about 4MB
+	// we won't change it as it's a reasonable default
+}
+
+// BenchmarkCheckpointOverhead measures the overhead of WAL checkpoint.
+func BenchmarkCheckpointOverhead(b *testing.B) {
+	tmpDir, err := os.MkdirTemp("", "beads-checkpoint-bench-*")
+	if err != nil {
+		b.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "bench.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		b.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	store.SetConfig(ctx, "issue_prefix", "bd")
+
+	// create some data
+	for i := 0; i < 100; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("Bench Issue %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		store.CreateIssue(ctx, issue, "bench")
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		store.CheckpointWAL(ctx)
+	}
+}
+
+// TestWALReaderIsolation tests that readers see a consistent snapshot.
+func TestWALReaderIsolation(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-reader-isolation-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	ctx := context.Background()
+
+	store, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create initial issues
+	for i := 0; i < 5; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("Initial %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "setup"); err != nil {
+			t.Fatalf("CreateIssue failed: %v", err)
+		}
+	}
+
+	// start a read transaction and count issues
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("failed to get connection: %v", err)
+	}
+	defer conn.Close()
+
+	// begin read transaction
+	if _, err := conn.ExecContext(ctx, "BEGIN DEFERRED"); err != nil {
+		t.Fatalf("BEGIN failed: %v", err)
+	}
+
+	// count issues at start of transaction
+	var initialCount int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues").Scan(&initialCount); err != nil {
+		t.Fatalf("count query failed: %v", err)
+	}
+	t.Logf("initial count in read TX: %d", initialCount)
+
+	// add more issues via the main store (different connection)
+	for i := 0; i < 3; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("During Read TX %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "writer"); err != nil {
+			t.Fatalf("CreateIssue during read TX failed: %v", err)
+		}
+	}
+
+	// count again in the same read transaction
+	// should still see the same count (snapshot isolation)
+	var midCount int
+	if err := conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues").Scan(&midCount); err != nil {
+		t.Fatalf("mid count query failed: %v", err)
+	}
+	t.Logf("mid count in read TX: %d", midCount)
+
+	// commit read transaction
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		t.Fatalf("COMMIT failed: %v", err)
+	}
+
+	// new query should see all issues
+	var finalCount int
+	if err := store.db.QueryRow("SELECT COUNT(*) FROM issues").Scan(&finalCount); err != nil {
+		t.Fatalf("final count query failed: %v", err)
+	}
+	t.Logf("final count: %d", finalCount)
+
+	// in WAL mode, mid-transaction reads may or may not see new rows
+	// depending on when the read snapshot was taken
+	// the key is that within a transaction, counts should be consistent
+	if finalCount != initialCount+3 {
+		t.Errorf("expected final count %d, got %d", initialCount+3, finalCount)
+	}
+}
+
+// TestWALRecoveryAfterCrash simulates recovery after unclean shutdown.
+func TestWALRecoveryAfterCrash(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-wal-recovery-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "test.db")
+	walPath := dbPath + "-wal"
+	ctx := context.Background()
+
+	// create store and write data
+	store1, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store1: %v", err)
+	}
+
+	if err := store1.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		store1.Close()
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	// create issues
+	var issueIDs []string
+	for i := 0; i < 5; i++ {
+		issue := &types.Issue{
+			Title:     fmt.Sprintf("Recovery Test %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store1.CreateIssue(ctx, issue, "test"); err != nil {
+			store1.Close()
+			t.Fatalf("CreateIssue failed: %v", err)
+		}
+		issueIDs = append(issueIDs, issue.ID)
+	}
+
+	// close WITHOUT checkpoint (simulates crash)
+	// use raw db.Close() to skip checkpoint
+	store1.db.Close()
+
+	// check that WAL file exists and has content
+	if info, err := os.Stat(walPath); err == nil && info.Size() > 0 {
+		t.Logf("WAL file exists with %d bytes (will be recovered)", info.Size())
+	}
+
+	// reopen database - WAL should be automatically recovered
+	store2, err := New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store2 after crash: %v", err)
+	}
+	defer store2.Close()
+
+	// verify all issues are present (recovered from WAL)
+	for _, id := range issueIDs {
+		issue, err := store2.GetIssue(ctx, id)
+		if err != nil {
+			t.Errorf("GetIssue %s after recovery failed: %v", id, err)
+			continue
+		}
+		if issue == nil {
+			t.Errorf("issue %s not recovered from WAL", id)
+		}
+	}
+
+	t.Logf("recovered %d issues from WAL", len(issueIDs))
+}


### PR DESCRIPTION
## Summary
- Add WAL checkpoint retry logic with exponential backoff
- Prevent silent data loss when checkpoint fails due to concurrent readers

## Changes
- `store.go`: Add 5-retry exponential backoff for WAL checkpoint in Close()
- `flush_manager_race_test.go`: Concurrency tests for flush manager
- `wal_test.go`: Tests for checkpoint with concurrent readers

## Security Fixes
- SECURITY_AUDIT.md Issue #8: WAL checkpoint failure silently losing data

## Test Plan
- [ ] Run `go test -race ./cmd/bd/... -run FlushManager` for flush tests
- [ ] Run `go test -race ./internal/storage/sqlite/... -run WAL` for WAL tests

## Related Issues
- Part of race condition fixes from #1085

```mermaid
sequenceDiagram
    participant S as Store.Close()
    participant W as WAL

    S->>W: Checkpoint (attempt 1)
    W-->>S: SQLITE_BUSY (reader lock)
    S->>S: Sleep 100ms
    S->>W: Checkpoint (attempt 2)
    W-->>S: SQLITE_BUSY
    S->>S: Sleep 200ms
    S->>W: Checkpoint (attempt 3)
    W-->>S: Success
    S->>S: Close DB
```