### PR TITLE
fix(prime): make beads default, avoid TodoWrite/TaskCreate where possible

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -244,9 +244,10 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 ` + closeProtocol + `
 
 ## Core Rules
-- Track strategic work in beads (multi-session, dependencies, discovered work)
-- TodoWrite is fine for simple single-session linear tasks
-- When in doubt, prefer bd—persistence you don't need beats lost context
+- **Default**: Use beads for ALL task tracking (` + "`bd create`" + `, ` + "`bd ready`" + `, ` + "`bd close`" + `)
+- **Prohibited**: Do NOT use TodoWrite, TaskCreate, or markdown files for task tracking
+- **Workflow**: Create beads issue BEFORE writing code, mark in_progress when starting
+- Persistence you don't need beats lost context
 
 Start: Check ` + "`ready`" + ` tool for available work.
 `
@@ -371,9 +372,10 @@ bd sync                     # Push to remote
 ` + closeNote + `
 
 ## Core Rules
-- Track strategic work in beads (multi-session, dependencies, discovered work)
-- Use ` + "`bd create`" + ` for issues, TodoWrite for simple single-session execution
-- When in doubt, prefer bd—persistence you don't need beats lost context
+- **Default**: Use beads for ALL task tracking (` + "`bd create`" + `, ` + "`bd ready`" + `, ` + "`bd close`" + `)
+- **Prohibited**: Do NOT use TodoWrite, TaskCreate, or markdown files for task tracking
+- **Workflow**: Create beads issue BEFORE writing code, mark in_progress when starting
+- Persistence you don't need beats lost context
 - ` + gitWorkflowRule + `
 - Session management: check ` + "`bd ready`" + ` for available work
 


### PR DESCRIPTION
## Summary
- Makes beads the **default** for ALL task tracking instead of just "strategic" work
- Avoid TodoWrite, TaskCreate, and markdown files for task tracking
- Removes language that gave AI agents permission to use alternatives

## Problem
The previous `bd prime` output said:
> "Track strategic work in beads (multi-session, dependencies, discovered work)"
> "Use `bd create` for issues, TodoWrite for simple single-session execution"

This gave Claude explicit permission to use TodoWrite for anything "simple" - which Claude interprets as most tasks!

## Solution
Updated both MCP and CLI output to state:
- **Default**: Use beads for ALL task tracking
- **Prohibited**: Do NOT use TodoWrite, TaskCreate, or markdown files

## Test plan
- [ ] Run `bd prime --full` and verify new Core Rules text
- [ ] Run `bd prime --mcp` and verify new Core Rules text
- [ ] Test in Claude Code session to confirm agent uses beads for task tracking