### PR TITLE
feat(doctor): make stale closed issues check configurable

### DIFF
--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -18,7 +18,7 @@ type Config struct {
 	// Deletions configuration
 	DeletionsRetentionDays int `json:"deletions_retention_days,omitempty"` // 0 means use default (3 days)
 
-	// Dolt server mode configuration (bd-dolt.2.2)
+// Dolt server mode configuration (bd-dolt.2.2)
 	// When Mode is "server", connects to external dolt sql-server instead of embedded.
 	// This enables multi-writer access for multi-agent environments.
 	DoltMode       string `json:"dolt_mode,omitempty"`        // "embedded" (default) or "server"
@@ -26,6 +26,10 @@ type Config struct {
 	DoltServerPort int    `json:"dolt_server_port,omitempty"` // Server port (default: 3307)
 	DoltServerUser string `json:"dolt_server_user,omitempty"` // MySQL user (default: root)
 	// Note: Password should be set via BEADS_DOLT_PASSWORD env var for security
+
+	// Stale closed issues check configuration
+	// 0 = disabled (default), positive = threshold in days
+	StaleClosedIssuesDays int `json:"stale_closed_issues_days,omitempty"`
 
 	// Deprecated: LastBdVersion is no longer used for version tracking.
 	// Version is now stored in .local_version (gitignored) to prevent
@@ -150,6 +154,15 @@ func (c *Config) GetDeletionsRetentionDays() int {
 		return DefaultDeletionsRetentionDays
 	}
 	return c.DeletionsRetentionDays
+}
+
+// GetStaleClosedIssuesDays returns the configured threshold for stale closed issues.
+// Returns 0 if disabled (the default), or a positive value if enabled.
+func (c *Config) GetStaleClosedIssuesDays() int {
+	if c.StaleClosedIssuesDays < 0 {
+		return 0
+	}
+	return c.StaleClosedIssuesDays
 }
 
 // Backend constants


### PR DESCRIPTION
## Summary

- Add `stale_closed_issues_days` config option to `.beads/metadata.json`
- **Default (0)**: Check disabled - repos keep unlimited beads
- **Positive value**: Enable check with specified day threshold
- Warn when check is disabled but >10,000 closed issues exist

## Design Philosophy

Time-based thresholds are a crude proxy for the real concern, which is database size:
- A repo with 100 closed issues from 5 years ago doesn't need cleanup
- A repo with 50,000 closed issues from yesterday might

The check is **disabled by default**. Users who want time-based pruning must explicitly enable it.

```mermaid
flowchart TD
    A[bd doctor] --> B{stale_closed_issues_days set?}
    B -->|0 or unset| C{>10k closed issues?}
    C -->|No| D[OK: Disabled]
    C -->|Yes| E[Warning: Consider enabling]
    B -->|>0| F{Issues older than N days?}
    F -->|No| G[OK: No stale issues]
    F -->|Yes| H[Warning: N issues can be cleaned]
```

## Config Examples

**Default (disabled):**
```json
{
  "database": "beads.db",
  "jsonl_export": "issues.jsonl"
}
```

**Enable with 30-day threshold:**
```json
{
  "database": "beads.db",
  "jsonl_export": "issues.jsonl",
  "stale_closed_issues_days": 30
}
```

## Test plan

- [ ] Run `bd doctor` with no config set - should show "Disabled"
- [ ] Set `stale_closed_issues_days: 30` - should warn about old closed issues
- [ ] Run `bd doctor --fix` with threshold set - should clean up issues
- [ ] Run `bd doctor --fix` with no threshold - should skip cleanup