### PR TITLE
fix(bd): separate parent-child deps from blocking deps in bd show

### DIFF
--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -245,11 +245,47 @@ var showCmd = &cobra.Command{
 						fmt.Printf("\n%s %s\n", ui.RenderBold("LABELS:"), strings.Join(details.Labels, ", "))
 					}
 
-					// Dependencies with semantic colors
+					// Dependencies grouped by type with semantic colors
 					if len(details.Dependencies) > 0 {
-						fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
+						var blocks, parent, related, discovered []*types.IssueWithDependencyMetadata
 						for _, dep := range details.Dependencies {
-							fmt.Println(formatDependencyLine("→", dep))
+							switch dep.DependencyType {
+							case types.DepBlocks:
+								blocks = append(blocks, dep)
+							case types.DepParentChild:
+								parent = append(parent, dep)
+							case types.DepRelated:
+								related = append(related, dep)
+							case types.DepDiscoveredFrom:
+								discovered = append(discovered, dep)
+							default:
+								blocks = append(blocks, dep)
+							}
+						}
+
+						if len(parent) > 0 {
+							fmt.Printf("\n%s\n", ui.RenderBold("PARENT"))
+							for _, dep := range parent {
+								fmt.Println(formatDependencyLine("↑", dep))
+							}
+						}
+						if len(blocks) > 0 {
+							fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
+							for _, dep := range blocks {
+								fmt.Println(formatDependencyLine("→", dep))
+							}
+						}
+						if len(related) > 0 {
+							fmt.Printf("\n%s\n", ui.RenderBold("RELATED"))
+							for _, dep := range related {
+								fmt.Println(formatDependencyLine("↔", dep))
+							}
+						}
+						if len(discovered) > 0 {
+							fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED FROM"))
+							for _, dep := range discovered {
+								fmt.Println(formatDependencyLine("◊", dep))
+							}
 						}
 					}
 
@@ -433,18 +469,67 @@ var showCmd = &cobra.Command{
 				fmt.Printf("\n%s %s\n", ui.RenderBold("LABELS:"), strings.Join(labels, ", "))
 			}
 
-			// Show dependencies with semantic colors
-			deps, _ := issueStore.GetDependencies(ctx, issue.ID)
-			if len(deps) > 0 {
-				fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
-				for _, dep := range deps {
-					fmt.Println(formatSimpleDependencyLine("→", dep))
+			// Show dependencies - grouped by dependency type for clarity
+			// Use GetDependenciesWithMetadata to get the dependency type
+			sqliteStore, ok := issueStore.(*sqlite.SQLiteStorage)
+			if ok {
+				depsWithMeta, _ := sqliteStore.GetDependenciesWithMetadata(ctx, issue.ID)
+				if len(depsWithMeta) > 0 {
+					// Group by dependency type
+					var blocks, parent, related, discovered []*types.IssueWithDependencyMetadata
+					for _, dep := range depsWithMeta {
+						switch dep.DependencyType {
+						case types.DepBlocks:
+							blocks = append(blocks, dep)
+						case types.DepParentChild:
+							parent = append(parent, dep)
+						case types.DepRelated:
+							related = append(related, dep)
+						case types.DepDiscoveredFrom:
+							discovered = append(discovered, dep)
+						default:
+							blocks = append(blocks, dep) // Default to blocks
+						}
+					}
+
+					if len(parent) > 0 {
+						fmt.Printf("\n%s\n", ui.RenderBold("PARENT"))
+						for _, dep := range parent {
+							fmt.Println(formatDependencyLine("↑", dep))
+						}
+					}
+					if len(blocks) > 0 {
+						fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
+						for _, dep := range blocks {
+							fmt.Println(formatDependencyLine("→", dep))
+						}
+					}
+					if len(related) > 0 {
+						fmt.Printf("\n%s\n", ui.RenderBold("RELATED"))
+						for _, dep := range related {
+							fmt.Println(formatDependencyLine("↔", dep))
+						}
+					}
+					if len(discovered) > 0 {
+						fmt.Printf("\n%s\n", ui.RenderBold("DISCOVERED FROM"))
+						for _, dep := range discovered {
+							fmt.Println(formatDependencyLine("◊", dep))
+						}
+					}
+				}
+			} else {
+				// Fallback for non-SQLite storage (no dependency type metadata)
+				deps, _ := issueStore.GetDependencies(ctx, issue.ID)
+				if len(deps) > 0 {
+					fmt.Printf("\n%s\n", ui.RenderBold("DEPENDS ON"))
+					for _, dep := range deps {
+						fmt.Println(formatSimpleDependencyLine("→", dep))
+					}
 				}
 			}
 
 			// Show dependents - grouped by dependency type for clarity
-			// Use GetDependentsWithMetadata to get the dependency type
-			sqliteStore, ok := issueStore.(*sqlite.SQLiteStorage)
+			// Use GetDependentsWithMetadata to get the dependency type (sqliteStore already checked above)
 			if ok {
 				dependentsWithMeta, _ := sqliteStore.GetDependentsWithMetadata(ctx, issue.ID)
 				if len(dependentsWithMeta) > 0 {


### PR DESCRIPTION
## Summary

- Fixes `bd show` displaying parent-child relationships under "DEPENDS ON" heading
- Dependencies now grouped by type like Dependents already were
- Fix applies to both daemon and non-daemon modes

## Problem

When using `gt sling --on` to create molecules from formulas, the created steps showed their parent molecule under "DEPENDS ON", making it appear they were blocked by the molecule when they weren't.

## Arrow Legend

**Dependencies (what this issue depends on):**
```
PARENT
  ↑ ○ bd-wisp-yq32: (EPIC) tackle ● P2

DEPENDS ON
  → ○ bd-abc123: blocking issue ● P1

RELATED
  ↔ ○ bd-def456: related issue ● P2

DISCOVERED FROM
  ◊ ○ bd-ghi789: source issue ● P3
```

**Dependents (what depends on this issue):**
```
CHILDREN
  ↳ ○ bd-step-1: child step ● P2

BLOCKS
  ← ○ bd-blocked: blocked by this ● P1

RELATED
  ↔ ○ bd-related: related issue ● P2

DISCOVERED
  ◊ ○ bd-found: discovered from this ● P3
```

## Test plan

- [x] Run tests: `go test ./cmd/bd/... -count=1` - all pass
- [x] Verify with `bd show --no-daemon <step>` - PARENT section works
- [x] Verify with `bd show <step>` (daemon mode) - PARENT section works
- [x] Check isolation - only `cmd/bd/show.go` changed

Fixes: bd-69d7

🤖 Generated with [Claude Code](https://claude.com/claude-code)