### PR TITLE
fix(config): add YAML config support for daemon auto-sync settings

### DIFF
--- a/cmd/bd/daemon.go
+++ b/cmd/bd/daemon.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/daemon"
 	"github.com/steveyegge/beads/internal/rpc"
@@ -691,6 +692,56 @@ func runDaemonLoop(interval time.Duration, autoCommit, autoPush, autoPull, local
 //
 // 4. Fallback: all default to true when sync-branch configured
 //
+// loadYAMLDaemonSettings loads daemon auto-settings from YAML config and env vars only (no database).
+// This is safe to call from the parent process since it doesn't require database access.
+// Returns (autoCommit, autoPush, autoPull, hasSettings) where hasSettings indicates
+// if any settings were found (env var or YAML).
+func loadYAMLDaemonSettings() (autoCommit, autoPush, autoPull, hasSettings bool) {
+	// Check unified auto-sync first (env var > YAML)
+	if envVal := os.Getenv("BEADS_AUTO_SYNC"); envVal == "true" || envVal == "1" {
+		return true, true, true, true
+	}
+	if yamlAutoSync := config.GetString("daemon.auto-sync"); yamlAutoSync == "true" {
+		return true, true, true, true
+	}
+
+	// Check individual settings (env var > YAML for each)
+	yamlAutoCommit := config.GetString("daemon.auto-commit")
+	yamlAutoPush := config.GetString("daemon.auto-push")
+	yamlAutoPull := config.GetString("daemon.auto-pull")
+	envAutoCommit := os.Getenv("BEADS_AUTO_COMMIT")
+	envAutoPush := os.Getenv("BEADS_AUTO_PUSH")
+	envAutoPull := os.Getenv("BEADS_AUTO_PULL")
+
+	hasSettings = yamlAutoCommit != "" || yamlAutoPush != "" || yamlAutoPull != "" ||
+		envAutoCommit != "" || envAutoPush != "" || envAutoPull != ""
+
+	if !hasSettings {
+		return false, false, false, false
+	}
+
+	// For each: env var > YAML
+	if envAutoCommit != "" {
+		autoCommit = envAutoCommit == "true" || envAutoCommit == "1"
+	} else if yamlAutoCommit != "" {
+		autoCommit = yamlAutoCommit == "true"
+	}
+
+	if envAutoPush != "" {
+		autoPush = envAutoPush == "true" || envAutoPush == "1"
+	} else if yamlAutoPush != "" {
+		autoPush = yamlAutoPush == "true"
+	}
+
+	if envAutoPull != "" {
+		autoPull = envAutoPull == "true" || envAutoPull == "1"
+	} else if yamlAutoPull != "" {
+		autoPull = yamlAutoPull == "true"
+	}
+
+	return autoCommit, autoPush, autoPull, true
+}
+
 // Note: The individual auto-commit/auto-push settings are deprecated.
 // Use auto-sync for read/write mode, auto-pull for read-only mode.
 func loadDaemonAutoSettings(cmd *cobra.Command, autoCommit, autoPush, autoPull bool) (bool, bool, bool) {
@@ -711,9 +762,12 @@ func loadDaemonAutoSettings(cmd *cobra.Command, autoCommit, autoPush, autoPull b
 	hasSyncBranch := syncBranch != ""
 
 	// Check unified auto-sync setting first (controls auto-commit + auto-push)
+	// Priority: env var > YAML config > database config
 	unifiedAutoSync := ""
 	if envVal := os.Getenv("BEADS_AUTO_SYNC"); envVal != "" {
 		unifiedAutoSync = envVal
+	} else if configVal := config.GetString("daemon.auto-sync"); configVal != "" {
+		unifiedAutoSync = configVal
 	} else if configVal, _ := store.GetConfig(ctx, "daemon.auto-sync"); configVal != "" {
 		unifiedAutoSync = configVal
 	}
@@ -734,10 +788,13 @@ func loadDaemonAutoSettings(cmd *cobra.Command, autoCommit, autoPush, autoPull b
 		autoCommit = false
 		autoPush = false
 		// Auto-pull can still be enabled via CLI flag or individual config
+		// Priority: CLI flag > env var > YAML config > database config
 		if cmd.Flags().Changed("auto-pull") {
 			// Use the CLI flag value (already in autoPull)
 		} else if envVal := os.Getenv("BEADS_AUTO_PULL"); envVal != "" {
 			autoPull = envVal == "true" || envVal == "1"
+		} else if configVal := config.GetString("daemon.auto-pull"); configVal != "" {
+			autoPull = configVal == "true"
 		} else if configVal, _ := store.GetConfig(ctx, "daemon.auto-pull"); configVal != "" {
 			autoPull = configVal == "true"
 		} else if configVal, _ := store.GetConfig(ctx, "daemon.auto_pull"); configVal != "" {
@@ -751,19 +808,61 @@ func loadDaemonAutoSettings(cmd *cobra.Command, autoCommit, autoPush, autoPull b
 		return autoCommit, autoPush, autoPull
 	}
 
-	// No unified setting - check legacy individual settings for backward compat
-	// If either legacy auto-commit or auto-push is enabled, treat as auto-sync=true
+	// Check YAML config for individual daemon settings (allows fine-grained control)
+	// Priority for each setting: CLI flag > env var > YAML config > database config
+	yamlAutoCommit := config.GetString("daemon.auto-commit")
+	yamlAutoPush := config.GetString("daemon.auto-push")
+	yamlAutoPull := config.GetString("daemon.auto-pull")
+
+	// Check individual env vars (take precedence over YAML)
+	envAutoCommit := os.Getenv("BEADS_AUTO_COMMIT")
+	envAutoPush := os.Getenv("BEADS_AUTO_PUSH")
+	envAutoPull := os.Getenv("BEADS_AUTO_PULL")
+
+	// If any YAML individual settings OR individual env vars are set, use fine-grained control
+	// This allows users to set just auto-commit without forcing auto-push/auto-pull
+	hasIndividualSettings := yamlAutoCommit != "" || yamlAutoPush != "" || yamlAutoPull != "" ||
+		envAutoCommit != "" || envAutoPush != "" || envAutoPull != ""
+
+	if hasIndividualSettings {
+		// For each setting: CLI flag > env var > YAML config
+		if !cmd.Flags().Changed("auto-commit") {
+			if envAutoCommit != "" {
+				autoCommit = envAutoCommit == "true" || envAutoCommit == "1"
+			} else if yamlAutoCommit != "" {
+				autoCommit = yamlAutoCommit == "true"
+			}
+		}
+		if !cmd.Flags().Changed("auto-push") {
+			if envAutoPush != "" {
+				autoPush = envAutoPush == "true" || envAutoPush == "1"
+			} else if yamlAutoPush != "" {
+				autoPush = yamlAutoPush == "true"
+			}
+		}
+		if !cmd.Flags().Changed("auto-pull") {
+			if envAutoPull != "" {
+				autoPull = envAutoPull == "true" || envAutoPull == "1"
+			} else if yamlAutoPull != "" {
+				autoPull = yamlAutoPull == "true"
+			}
+		}
+		return autoCommit, autoPush, autoPull
+	}
+
+	// No YAML individual settings - check legacy env vars and database config
+	// Legacy behavior: if either auto-commit or auto-push is enabled, enable full auto-sync
 	legacyCommit := false
 	legacyPush := false
 
-	// Check legacy auto-commit (env var or config)
+	// Check legacy auto-commit (env var or database config)
 	if envVal := os.Getenv("BEADS_AUTO_COMMIT"); envVal != "" {
 		legacyCommit = envVal == "true" || envVal == "1"
 	} else if configVal, _ := store.GetConfig(ctx, "daemon.auto_commit"); configVal != "" {
 		legacyCommit = configVal == "true"
 	}
 
-	// Check legacy auto-push (env var or config)
+	// Check legacy auto-push (env var or database config)
 	if envVal := os.Getenv("BEADS_AUTO_PUSH"); envVal != "" {
 		legacyPush = envVal == "true" || envVal == "1"
 	} else if configVal, _ := store.GetConfig(ctx, "daemon.auto_push"); configVal != "" {
@@ -780,6 +879,7 @@ func loadDaemonAutoSettings(cmd *cobra.Command, autoCommit, autoPush, autoPull b
 	}
 
 	// Neither legacy write option enabled - check auto-pull for read-only mode
+	// Priority: CLI flag > env var > database config
 	if !cmd.Flags().Changed("auto-pull") {
 		if envVal := os.Getenv("BEADS_AUTO_PULL"); envVal != "" {
 			autoPull = envVal == "true" || envVal == "1"

--- a/cmd/bd/daemon_autosettings_yaml_test.go
+++ b/cmd/bd/daemon_autosettings_yaml_test.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+)
+
+// TestDaemonAutoSyncFromYAML verifies that daemon.auto-sync is read from config.yaml.
+func TestDaemonAutoSyncFromYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads directory: %v", err)
+	}
+
+	// Create config.yaml with daemon.auto-sync: true
+	configYAML := `daemon:
+  auto-sync: true
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	// Create database without daemon settings
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	ctx := context.Background()
+	testStore, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer testStore.Close()
+
+	// Change to temp directory and reinitialize config
+	t.Chdir(tmpDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize config: %v", err)
+	}
+
+	// Create a mock cobra command
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("auto-commit", false, "")
+	cmd.Flags().Bool("auto-push", false, "")
+	cmd.Flags().Bool("auto-pull", false, "")
+
+	// Test loadDaemonAutoSettings
+	autoCommit, autoPush, autoPull := loadDaemonAutoSettings(cmd, false, false, false)
+
+	// auto-sync: true should enable all three
+	if !autoCommit {
+		t.Errorf("Expected autoCommit=true when daemon.auto-sync=true in YAML, got false")
+	}
+	if !autoPush {
+		t.Errorf("Expected autoPush=true when daemon.auto-sync=true in YAML, got false")
+	}
+	if !autoPull {
+		t.Errorf("Expected autoPull=true when daemon.auto-sync=true in YAML, got false")
+	}
+}
+
+// TestDaemonAutoCommitOnlyFromYAML verifies that individual daemon.auto-commit works
+// without enabling auto-push and auto-pull.
+func TestDaemonAutoCommitOnlyFromYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads directory: %v", err)
+	}
+
+	// Create config.yaml with only daemon.auto-commit: true
+	configYAML := `daemon:
+  auto-commit: true
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	// Create database without daemon settings
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	ctx := context.Background()
+	testStore, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer testStore.Close()
+
+	// Change to temp directory and reinitialize config
+	t.Chdir(tmpDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize config: %v", err)
+	}
+
+	// Create a mock cobra command
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("auto-commit", false, "")
+	cmd.Flags().Bool("auto-push", false, "")
+	cmd.Flags().Bool("auto-pull", false, "")
+
+	// Test loadDaemonAutoSettings
+	autoCommit, autoPush, autoPull := loadDaemonAutoSettings(cmd, false, false, false)
+
+	// Individual YAML settings should NOT enable other options
+	if !autoCommit {
+		t.Errorf("Expected autoCommit=true when daemon.auto-commit=true in YAML, got false")
+	}
+	if autoPush {
+		t.Errorf("Expected autoPush=false when only daemon.auto-commit is set in YAML, got true")
+	}
+	if autoPull {
+		t.Errorf("Expected autoPull=false when only daemon.auto-commit is set in YAML, got true")
+	}
+}
+
+// TestDaemonIndividualSettingsFromYAML verifies that individual settings can be
+// set independently via YAML config.
+func TestDaemonIndividualSettingsFromYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads directory: %v", err)
+	}
+
+	// Create config.yaml with mixed individual settings
+	configYAML := `daemon:
+  auto-commit: true
+  auto-push: false
+  auto-pull: true
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	// Create database without daemon settings
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	ctx := context.Background()
+	testStore, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer testStore.Close()
+
+	// Change to temp directory and reinitialize config
+	t.Chdir(tmpDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize config: %v", err)
+	}
+
+	// Create a mock cobra command
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("auto-commit", false, "")
+	cmd.Flags().Bool("auto-push", false, "")
+	cmd.Flags().Bool("auto-pull", false, "")
+
+	// Test loadDaemonAutoSettings
+	autoCommit, autoPush, autoPull := loadDaemonAutoSettings(cmd, false, false, false)
+
+	if !autoCommit {
+		t.Errorf("Expected autoCommit=true, got false")
+	}
+	if autoPush {
+		t.Errorf("Expected autoPush=false, got true")
+	}
+	if !autoPull {
+		t.Errorf("Expected autoPull=true, got false")
+	}
+}
+
+// TestDaemonEnvVarOverridesYAML verifies that env vars take precedence over YAML config.
+func TestDaemonEnvVarOverridesYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads directory: %v", err)
+	}
+
+	// Create config.yaml with daemon.auto-sync: true
+	configYAML := `daemon:
+  auto-sync: true
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	// Create database
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	ctx := context.Background()
+	testStore, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer testStore.Close()
+
+	// Change to temp directory and reinitialize config
+	t.Chdir(tmpDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize config: %v", err)
+	}
+
+	// Set env var to override YAML (env var takes precedence)
+	t.Setenv("BEADS_AUTO_SYNC", "false")
+
+	// Create a mock cobra command
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("auto-commit", false, "")
+	cmd.Flags().Bool("auto-push", false, "")
+	cmd.Flags().Bool("auto-pull", false, "")
+
+	// Test loadDaemonAutoSettings
+	autoCommit, autoPush, _ := loadDaemonAutoSettings(cmd, false, false, false)
+
+	// Env var BEADS_AUTO_SYNC=false should override YAML auto-sync: true
+	if autoCommit {
+		t.Errorf("Expected autoCommit=false (env var override), got true")
+	}
+	if autoPush {
+		t.Errorf("Expected autoPush=false (env var override), got true")
+	}
+	// auto-pull defaults based on other factors when auto-sync=false
+}
+
+// TestDaemonCLIFlagOverridesYAML verifies that CLI flags take precedence over YAML config.
+func TestDaemonCLIFlagOverridesYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads directory: %v", err)
+	}
+
+	// Create config.yaml with daemon settings
+	configYAML := `daemon:
+  auto-commit: true
+  auto-push: true
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	// Create database
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	ctx := context.Background()
+	testStore, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer testStore.Close()
+
+	// Change to temp directory and reinitialize config
+	t.Chdir(tmpDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize config: %v", err)
+	}
+
+	// Create a mock cobra command with flags explicitly set
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("auto-commit", false, "")
+	cmd.Flags().Bool("auto-push", false, "")
+	cmd.Flags().Bool("auto-pull", false, "")
+
+	// Simulate CLI flag being explicitly set
+	_ = cmd.Flags().Set("auto-commit", "false")
+
+	// Test loadDaemonAutoSettings - CLI flag should override YAML config
+	autoCommit, autoPush, autoPull := loadDaemonAutoSettings(cmd, false, false, false)
+
+	// CLI flag --auto-commit=false should override YAML auto-commit: true
+	if autoCommit {
+		t.Errorf("Expected autoCommit=false (CLI flag override), got true")
+	}
+	// auto-push should still come from YAML since flag wasn't changed
+	if !autoPush {
+		t.Errorf("Expected autoPush=true (from YAML), got false")
+	}
+	if autoPull {
+		t.Errorf("Expected autoPull=false (not set), got true")
+	}
+}
+
+// TestDaemonIndividualEnvVarOverridesYAML verifies that individual env vars
+// (BEADS_AUTO_PULL) override individual YAML settings.
+func TestDaemonIndividualEnvVarOverridesYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads directory: %v", err)
+	}
+
+	// Create config.yaml with auto-commit: true and auto-pull: false
+	configYAML := `daemon:
+  auto-commit: true
+  auto-pull: false
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	// Create database
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	ctx := context.Background()
+	testStore, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+	defer testStore.Close()
+
+	// Change to temp directory and reinitialize config
+	t.Chdir(tmpDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize config: %v", err)
+	}
+
+	// Set individual env var to override YAML (BEADS_AUTO_PULL should override daemon.auto-pull)
+	t.Setenv("BEADS_AUTO_PULL", "true")
+
+	// Create a mock cobra command
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("auto-commit", false, "")
+	cmd.Flags().Bool("auto-push", false, "")
+	cmd.Flags().Bool("auto-pull", false, "")
+
+	// Test loadDaemonAutoSettings
+	autoCommit, autoPush, autoPull := loadDaemonAutoSettings(cmd, false, false, false)
+
+	// auto-commit should come from YAML (true)
+	if !autoCommit {
+		t.Errorf("Expected autoCommit=true (from YAML), got false")
+	}
+	// auto-push should be false (not set anywhere)
+	if autoPush {
+		t.Errorf("Expected autoPush=false (not set), got true")
+	}
+	// auto-pull should be true (env var BEADS_AUTO_PULL=true overrides YAML auto-pull: false)
+	if !autoPull {
+		t.Errorf("Expected autoPull=true (env var override), got false")
+	}
+}

--- a/cmd/bd/daemon_start.go
+++ b/cmd/bd/daemon_start.go
@@ -61,6 +61,12 @@ Examples:
 		// (the BD_DAEMON_FOREGROUND=1 child spawned by startDaemon).
 		if foreground {
 			autoCommit, autoPush, autoPull = loadDaemonAutoSettings(cmd, autoCommit, autoPush, autoPull)
+		} else {
+			// In background mode, load YAML/env settings for the startup message
+			// (full settings including database are loaded in the child process)
+			if yamlCommit, yamlPush, yamlPull, hasSettings := loadYAMLDaemonSettings(); hasSettings {
+				autoCommit, autoPush, autoPull = yamlCommit, yamlPush, yamlPull
+			}
 		}
 
 		if interval <= 0 {


### PR DESCRIPTION
Add ability to configure daemon.auto-sync, daemon.auto-commit, daemon.auto-push, and daemon.auto-pull via config.yaml.

Priority order: CLI flag > env var > YAML config > database config

Individual YAML settings allow fine-grained control without triggering the legacy "enable everything" behavior. Tests cover unified and individual settings, env var overrides, and CLI flag overrides.