### PR TITLE
fix(list): populate dependencies field in JSON output

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -1189,10 +1189,12 @@ var listCmd = &cobra.Command{
 			}
 			labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
 			depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
+			allDeps, _ := store.GetAllDependencyRecords(ctx)
 
-			// Populate labels for JSON output
+			// Populate labels and dependencies for JSON output
 			for _, issue := range issues {
 				issue.Labels = labelsMap[issue.ID]
+				issue.Dependencies = allDeps[issue.ID]
 			}
 
 			// Build response with counts


### PR DESCRIPTION
## Summary
- Fixes `bd list --json` to populate the `dependencies` field on each issue
- Previously only `dependency_count`/`dependent_count` were included, but not actual dependency records
- This broke callers like `gt hook --json` that need to see what each issue depends on

## Justification

**Consistency:** `bd show --json` already includes dependencies array - `bd list --json` should too.

**Use case:** `gt hook --json` uses `bd list --parent` to get molecule children, then needs to check blocking dependencies to determine which steps are ready. Without the actual dependency records, ALL steps appeared ready regardless of blockers.

**Before (broken):**
```json
{"id": "bd-wisp-jcer", "dependency_count": 2, "dependent_count": 0}
// No way to know WHAT it depends on - just that it has 2 deps
```

**After (fixed):**
```json
{
  "id": "bd-wisp-jcer",
  "dependency_count": 2,
  "dependencies": [
    {"type": "blocks", "depends_on_id": "bd-wisp-0ysi"},
    {"type": "parent-child", "depends_on_id": "bd-wisp-zw9d"}
  ]
}
// Caller can filter type:"blocks" and check if those are closed
```

## Changes
- `cmd/bd/list.go`: Call `GetAllDependencyRecords` and populate `issue.Dependencies` in JSON output path (3 lines added)

## Test plan
- [x] `go test -race ./cmd/bd/...` passes
- [x] `golangci-lint run ./cmd/bd/...` passes  
- [x] Manual test: `bd list --json` now includes `dependencies` array
- [x] Verified molecule steps show blocking deps correctly

Fixes bd-tjxh

🤖 Generated with [Claude Code](https://claude.com/claude-code)