### PR TITLE
fix(rpc): populate dependencies in handleList response

### DIFF
--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -1313,6 +1313,12 @@ func (s *Server) handleList(req *Request) Response {
 	}
 	depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
 
+	// Populate dependencies for JSON output
+	allDeps, _ := store.GetAllDependencyRecords(ctx)
+	for _, issue := range issues {
+		issue.Dependencies = allDeps[issue.ID]
+	}
+
 	// Build response with counts
 	issuesWithCounts := make([]*types.IssueWithCounts, len(issues))
 	for i, issue := range issues {


### PR DESCRIPTION
## Summary

The daemon server's `handleList` was returning dependency counts but not the actual
dependency records. This complements PR #1296 which fixed the direct CLI path.

## Code paths now fixed

| Mode | File | PR |
|------|------|-----|
| Direct (`--no-daemon`) | `cmd/bd/list.go` | #1296 |
| Daemon (default) | `internal/rpc/server_issues_epics.go` | This PR |

## Changes

Added dependency population in `handleList` after the existing `depCounts` fetch,
following the same pattern as labels population:

```go
// Populate dependencies for JSON output
allDeps, _ := store.GetAllDependencyRecords(ctx)
for _, issue := range issues {
    issue.Dependencies = allDeps[issue.ID]
}
```

## Testing

```bash
bd list --limit 1 --id <issue-with-deps> --json | jq '.[0].dependencies'
```

Now returns actual dependency records instead of `null`.

Fixes bd-d240