### PR TITLE
perf(list): optimize bd list --json to fetch only needed dependencies

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -1189,7 +1189,7 @@ var listCmd = &cobra.Command{
 			}
 			labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
 			depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
-			allDeps, _ := store.GetAllDependencyRecords(ctx)
+			allDeps, _ := store.GetDependencyRecordsForIssues(ctx, issueIDs)
 
 			// Populate labels and dependencies for JSON output
 			for _, issue := range issues {

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -875,6 +875,20 @@ func (m *MemoryStorage) GetAllDependencyRecords(ctx context.Context) (map[string
 	return result, nil
 }
 
+// GetDependencyRecordsForIssues returns dependency records for specific issues
+func (m *MemoryStorage) GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make(map[string][]*types.Dependency)
+	for _, id := range issueIDs {
+		if deps, ok := m.dependencies[id]; ok {
+			result[id] = deps
+		}
+	}
+	return result, nil
+}
+
 // GetDirtyIssueHash returns the hash for dirty issue tracking
 func (m *MemoryStorage) GetDirtyIssueHash(ctx context.Context, issueID string) (string, error) {
 	// Memory storage doesn't track dirty hashes, return empty string

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -101,6 +101,7 @@ type Storage interface {
 	GetDependentsWithMetadata(ctx context.Context, issueID string) ([]*types.IssueWithDependencyMetadata, error)
 	GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error)
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
+	GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error)
 	GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
 	GetDependencyTree(ctx context.Context, issueID string, maxDepth int, showAllPaths bool, reverse bool) ([]*types.TreeNode, error)
 	DetectCycles(ctx context.Context) ([][]*types.Issue, error)

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -69,6 +69,9 @@ func (m *mockStorage) GetDependencyRecords(ctx context.Context, issueID string) 
 func (m *mockStorage) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {
 	return nil, nil
 }
+func (m *mockStorage) GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error) {
+	return nil, nil
+}
 func (m *mockStorage) GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

Optimizes `bd list --json` to fetch dependencies only for the listed issues instead of fetching ALL dependencies in the database.

### Problem

PR #1296 fixed `bd list --json` to populate the `dependencies` field, but used `GetAllDependencyRecords(ctx)` which fetches ALL dependencies in the database. For a query like `bd list --limit 10`, this fetches dependencies for potentially thousands of issues when only 10 are needed.

### Solution

Add a targeted method `GetDependencyRecordsForIssues(ctx, issueIDs []string)` that only fetches dependencies for the specified issues using a SQL `WHERE issue_id IN (?)` clause.

### Changes

- Add `GetDependencyRecordsForIssues` to Storage interface
- Implement in SQLite, Dolt, and Memory backends
- Update `list.go` JSON output to use the new targeted method

### Testing

- All existing tests pass
- New method follows established patterns from `GetDependencyCounts` and `GetLabelsForIssues`

### Origin

From Mayor's review comment on PR #1296: https://github.com/steveyegge/beads/pull/1296#issuecomment-3793804716

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)