### PR TITLE
Fix custom issue type validation during import

### DIFF
--- a/internal/storage/sqlite/queries.go
+++ b/internal/storage/sqlite/queries.go
@@ -887,10 +887,15 @@ func (s *SQLiteStorage) UpdateIssue(ctx context.Context, id string, updates map[
 		return fmt.Errorf("issue %s not found", id)
 	}
 
-	// Fetch custom statuses for validation
+	// Fetch custom statuses and types for validation
 	customStatuses, err := s.GetCustomStatuses(ctx)
 	if err != nil {
 		return wrapDBError("get custom statuses", err)
+	}
+
+	customTypes, err := s.GetCustomTypes(ctx)
+	if err != nil {
+		return wrapDBError("get custom types", err)
 	}
 
 	// Build update query with validated field names
@@ -903,8 +908,8 @@ func (s *SQLiteStorage) UpdateIssue(ctx context.Context, id string, updates map[
 			return fmt.Errorf("invalid field for update: %s", key)
 		}
 
-		// Validate field values (with custom status support)
-		if err := validateFieldUpdateWithCustomStatuses(key, value, customStatuses); err != nil {
+		// Validate field values (with custom status and type support)
+		if err := validateFieldUpdateWithCustom(key, value, customStatuses, customTypes); err != nil {
 			return wrapDBError("validate field update", err)
 		}
 

--- a/internal/storage/sqlite/transaction.go
+++ b/internal/storage/sqlite/transaction.go
@@ -400,10 +400,15 @@ func (t *sqliteTxStorage) UpdateIssue(ctx context.Context, id string, updates ma
 		return fmt.Errorf("issue %s not found", id)
 	}
 
-	// Fetch custom statuses for validation
+	// Fetch custom statuses and types for validation
 	customStatuses, err := t.GetCustomStatuses(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get custom statuses: %w", err)
+	}
+
+	customTypes, err := t.GetCustomTypes(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get custom types: %w", err)
 	}
 
 	// Build update query with validated field names
@@ -416,8 +421,8 @@ func (t *sqliteTxStorage) UpdateIssue(ctx context.Context, id string, updates ma
 			return fmt.Errorf("invalid field for update: %s", key)
 		}
 
-		// Validate field values (with custom status support)
-		if err := validateFieldUpdateWithCustomStatuses(key, value, customStatuses); err != nil {
+		// Validate field values (with custom status and type support)
+		if err := validateFieldUpdateWithCustom(key, value, customStatuses, customTypes); err != nil {
 			return fmt.Errorf("failed to validate field update: %w", err)
 		}
 

--- a/internal/storage/sqlite/validators_test.go
+++ b/internal/storage/sqlite/validators_test.go
@@ -189,6 +189,50 @@ func TestValidateFieldUpdateWithCustomStatuses(t *testing.T) {
 	}
 }
 
+func TestValidateFieldUpdateWithCustom(t *testing.T) {
+	customStatuses := []string{"awaiting_review", "awaiting_testing"}
+	customTypes := []string{"molecule", "agent", "convoy", "role", "event"}
+
+	tests := []struct {
+		name           string
+		key            string
+		value          interface{}
+		customStatuses []string
+		customTypes    []string
+		wantErr        bool
+	}{
+		// Custom type validation
+		{"valid custom type agent", "issue_type", "agent", customStatuses, customTypes, false},
+		{"valid custom type molecule", "issue_type", "molecule", customStatuses, customTypes, false},
+		{"valid custom type convoy", "issue_type", "convoy", customStatuses, customTypes, false},
+		{"valid built-in type task", "issue_type", "task", customStatuses, customTypes, false},
+		{"valid built-in type bug", "issue_type", "bug", customStatuses, customTypes, false},
+		{"invalid type", "issue_type", "invalid_type", customStatuses, customTypes, true},
+		{"valid type without custom types", "issue_type", "task", customStatuses, nil, false},
+		{"custom type without custom types configured", "issue_type", "agent", customStatuses, nil, true},
+
+		// Custom status validation
+		{"valid custom status", "status", "awaiting_review", customStatuses, customTypes, false},
+		{"valid built-in status", "status", "open", customStatuses, customTypes, false},
+		{"invalid status", "status", "invalid_status", customStatuses, customTypes, true},
+
+		// Other field validation
+		{"valid priority", "priority", 3, customStatuses, customTypes, false},
+		{"invalid priority", "priority", 5, customStatuses, customTypes, true},
+		{"valid title", "title", "Test title", customStatuses, customTypes, false},
+		{"empty title", "title", "", customStatuses, customTypes, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFieldUpdateWithCustom(tt.key, tt.value, tt.customStatuses, tt.customTypes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateFieldUpdateWithCustom() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestParseCustomStatuses(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Problem

Auto-import fails with `validation failed: invalid issue type: agent` even when `custom-issue-types` is properly configured.

This is a regression from commit 7cf67153 (Jan 21, 2026) which extracted Gas Town types to make beads more generic. The refactoring updated `ValidateForImport()` to handle custom types correctly, but missed updating `UpdateIssue()` validation.

## Root Cause

`validateFieldUpdateWithCustomStatuses()` only supported custom **statuses**, not custom **types**:

```go
func validateFieldUpdateWithCustomStatuses(key string, value interface{}, customStatuses []string) error {
    if key == "status" {
        return validateStatusWithCustom(value, customStatuses)
    }
    // Falls through to default validator which only checks built-in types
    if validator, ok := fieldValidators[key]; ok {
        return validator(value)
    }
    return nil
}
```

When importing via `UpdateIssue()`, the `issue_type` field validation falls through to `validateIssueType()` which only checks built-in types, rejecting any custom types.

## Solution

1. Add `validateFieldUpdateWithCustom()` accepting both `customStatuses` and `customTypes`
2. Add `validateIssueTypeWithCustom()` for custom type validation using federation trust model
3. Update `UpdateIssue()` to fetch and pass custom types to validator

This aligns `UpdateIssue()` validation with the federation trust model that `ValidateForImport()` already implements correctly.

## Testing

- ✅ Direct SQL INSERT of custom-type issues works
- ✅ JSONL import of custom-type issues works
- ✅ Multi-repo auto-import works with custom types (tested with agent, convoy, role, event types)
- ✅ Custom-type issues display correctly

## Impact

This affects any beads project using `custom-issue-types` config, not just Gas Town. Anyone configuring custom types would hit this validation error during import operations.