### PR TITLE
fix(daemon): respect BD_SOCKET environment variable

### DIFF
--- a/cmd/bd/daemon.go
+++ b/cmd/bd/daemon.go
@@ -604,7 +604,13 @@ The daemon will now exit.`, strings.ToUpper(backend))
 	// Get actual workspace root (parent of .beads)
 	workspacePath := filepath.Dir(beadsDir)
 	// Use short socket path to avoid Unix socket path length limits (macOS: 104 chars)
-	socketPath, err := rpc.EnsureSocketDir(rpc.ShortSocketPath(workspacePath))
+	// Check BD_SOCKET env var first for custom socket path (e.g., test isolation,
+	// or filesystems that don't support sockets in .beads directory)
+	socketPath := os.Getenv("BD_SOCKET")
+	if socketPath == "" {
+		socketPath = rpc.ShortSocketPath(workspacePath)
+	}
+	socketPath, err = rpc.EnsureSocketDir(socketPath)
 	if err != nil {
 		log.Error("failed to create socket directory", "error", err)
 		return


### PR DESCRIPTION
## Summary

The daemon loop in `runDaemonLoop()` was calling `rpc.ShortSocketPath()` directly instead of checking for the `BD_SOCKET` environment variable first. This caused issues on filesystems where sockets cannot be created in the `.beads` directory.

## Problem

When running `bd daemon start` with `BD_SOCKET` set to a custom path:
```bash
export BD_SOCKET=/tmp/bd-custom.sock
bd daemon start
```

The daemon would ignore this and still try to create the socket in `.beads/bd.sock`, failing with:
```
failed to set socket permissions: chmod /workspaces/eval/.beads/bd.sock: invalid argument
```

### Specific Setup

This was encountered on **macOS with a bind-mounted workspace volume** in a devcontainer/devpod setup. The workspace at `/workspaces/eval` is mounted from the host filesystem. On this mount:
- Regular files work fine
- Unix sockets can be created but `chmod()` on the socket returns `EINVAL`
- This appears to be a limitation of how macOS handles socket permissions on certain mount types

The daemon creates the socket successfully but then tries to set permissions (0600) on it, which fails on this filesystem.

## Solution

Check `BD_SOCKET` environment variable before falling back to the default path computation, consistent with how `getSocketPath()` and `getSocketPathForPID()` already work.

This allows users to set `BD_SOCKET` to a path on a local filesystem (like `/tmp`) where socket operations work normally.

## Workaround

Until this fix is merged, users can work around the issue by setting `no-daemon: true` in `.beads/config.yaml`, which disables the daemon entirely and uses direct database access.

## Test plan

- [x] Added `TestDaemonLoopSocketPathEnvOverride` to verify BD_SOCKET is respected
- [x] Added `TestDaemonLoopSocketPathDefault` to verify default behavior unchanged
- [x] All existing socket tests pass
- [x] Manually verified fix works on macOS bind-mounted filesystem

🤖 Generated with [Claude Code](https://claude.ai/code)