### PR TITLE
fix(daemon): make daemon start idempotent

### DIFF
--- a/cmd/bd/daemon.go
+++ b/cmd/bd/daemon.go
@@ -163,11 +163,10 @@ Run 'bd daemon --help' to see all subcommands.`,
 					health, healthErr := client.Health()
 					_ = client.Close()
 
-					// If we can check version and it's compatible, exit
+					// If we can check version and it's compatible, exit successfully (idempotent)
 					if healthErr == nil && health.Compatible {
-						fmt.Fprintf(os.Stderr, "Error: daemon already running (PID %d, version %s)\n", pid, health.Version)
-						fmt.Fprintf(os.Stderr, "Use 'bd daemon stop' to stop it first\n")
-						os.Exit(1)
+						fmt.Printf("Daemon already running (PID %d, version %s)\n", pid, health.Version)
+						os.Exit(0)
 					}
 
 					// Version mismatch - auto-stop old daemon

--- a/cmd/bd/daemon_start.go
+++ b/cmd/bd/daemon_start.go
@@ -90,11 +90,10 @@ Examples:
 					health, healthErr := client.Health()
 					_ = client.Close()
 
-					// If we can check version and it's compatible, exit
+					// If we can check version and it's compatible, exit successfully (idempotent)
 					if healthErr == nil && health.Compatible {
-						fmt.Fprintf(os.Stderr, "Error: daemon already running (PID %d, version %s)\n", pid, health.Version)
-						fmt.Fprintf(os.Stderr, "Use 'bd daemon stop' to stop it first\n")
-						os.Exit(1)
+						fmt.Printf("Daemon already running (PID %d, version %s)\n", pid, health.Version)
+						os.Exit(0)
 					}
 
 					// Version mismatch - auto-stop old daemon


### PR DESCRIPTION
## Summary

Make `bd daemon start` idempotent - when a compatible daemon is already running, exit successfully (code 0) instead of failing (code 1).

## Problem

During `gt reload`, there's a race condition where something auto-starts the bd daemon between the killall and start phases. This causes "already running" errors even though the reload should succeed.

The root cause is that `bd` auto-starts daemons when running any command. A hook, background task, or any `bd` command can trigger this.

## Solution

If the daemon is already running AND healthy AND version-compatible, print a message and exit 0 instead of exit 1. This makes the operation idempotent.

```
$ bd daemon start
Starting bd daemon...
$ bd daemon start  
Daemon already running (PID 12345, version 0.49.0)  # exit 0, not exit 1
```

## Test plan

- [x] Build bd with fix
- [x] Verify `bd daemon start` returns exit 0 when daemon already running
- [x] Verify `gt reload` completes successfully without race condition errors

Fixes: #1331

🤖 Generated with [Claude Code](https://claude.ai/code)