### PR TITLE
feat(list): show blocking dependencies inline in output

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -695,9 +695,20 @@ Default output without `--json`:
 
 ```bash
 bd ready
-# bd-42  Fix authentication bug  [P1, bug, in_progress]
-# bd-43  Add user settings page  [P2, feature, open]
+# ○ bd-42 [P1] [bug] - Fix authentication bug
+# ○ bd-43 [P2] [feature] - Add user settings page
 ```
+
+**Dependency visibility:** When issues have blocking dependencies, they appear inline:
+
+```bash
+bd list --parent epic-123
+# ○ bd-123.1 [P1] [task] - Design API (blocks: bd-123.2, bd-123.3)
+# ○ bd-123.2 [P1] [task] - Implement endpoints (blocked by: bd-123.1, blocks: bd-123.3)
+# ○ bd-123.3 [P1] [task] - Add tests (blocked by: bd-123.1, bd-123.2)
+```
+
+This makes blocking relationships visible without running `bd show` on each issue.
 
 ## Common Patterns for AI Agents
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,6 +58,15 @@ Notes:
 
 **Note:** Issue IDs are hash-based (e.g., `bd-a1b2`, `bd-f14c`) to prevent collisions when multiple agents/branches work concurrently.
 
+**Dependency visibility:** When issues have blocking dependencies, `bd list` shows them inline:
+```
+○ bd-a1b2 [P1] [task] - Set up database
+○ bd-f14c [P2] [feature] - Create API (blocked by: bd-a1b2)
+○ bd-g25d [P2] [feature] - Add authentication (blocked by: bd-f14c)
+```
+
+This makes dependencies unmissable when reviewing epic subtasks.
+
 ## Hierarchical Issues (Epics)
 
 For large features, use hierarchical IDs to organize work:


### PR DESCRIPTION
## Summary
- When issues have blocking dependencies, `bd list` now shows them inline
- Format: `(blocked by: X, Y)` and `(blocks: A, B)`
- Makes dependencies unmissable when reviewing epic subtasks

## Problem Addressed
Agents reviewing epics with subtasks routinely point out "tasks have no dependencies" as feedback, then admit they didn't check dependencies when asked. The root cause: `bd list` shows no dependency information - agents have to remember to run `bd show` on each issue.

## Solution
Display blocking dependency info directly in the list output:
```
○ bd-123 [P1] [task] - Design API (blocks: bd-124, bd-125)
○ bd-124 [P1] [task] - Implement (blocked by: bd-123, blocks: bd-125)
○ bd-125 [P1] [task] - Test (blocked by: bd-123, bd-124)
```

## Implementation Details
- Only shows blocking dependencies (blocks, parent-child, conditional-blocks, waits-for)
- Does not show soft relationships (related, discovered-from)
- Works in both daemon and direct mode
- Works in both compact and agent output formats
- Added `buildBlockingMaps()` helper and tests

## Test plan
- [x] Added unit tests for `formatIssueCompact` with dependencies
- [x] Added unit tests for `formatAgentIssue` with dependencies
- [x] Added unit tests for `buildBlockingMaps()`
- [x] Verified existing list tests still pass
- [x] Updated QUICKSTART.md and CLI_REFERENCE.md documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)