### PR TITLE
fix(sync): use store.Path() for database mtime update

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -595,9 +595,10 @@ Examples:
 			// This prevents validatePreExport from incorrectly blocking on next export
 			if output == "" || output == findJSONLPath() {
 				// Dolt backend does not have a SQLite DB file, so only touch mtime for SQLite.
-				if _, ok := store.(*sqlite.SQLiteStorage); ok {
-					beadsDir := filepath.Dir(finalPath)
-					dbPath := filepath.Join(beadsDir, "beads.db")
+				// Use store.Path() to get the actual database location, not the JSONL directory,
+				// since sync-branch exports write JSONL to a worktree but the DB stays in the main repo.
+				if sqliteStore, ok := store.(*sqlite.SQLiteStorage); ok {
+					dbPath := sqliteStore.Path()
 					if err := TouchDatabaseFile(dbPath, finalPath); err != nil {
 						// Log warning but don't fail export
 						fmt.Fprintf(os.Stderr, "Warning: failed to update database mtime: %v\n", err)

--- a/cmd/bd/sync_export.go
+++ b/cmd/bd/sync_export.go
@@ -116,10 +116,11 @@ func finalizeExport(ctx context.Context, result *ExportResult) {
 	// This prevents validatePreExport from incorrectly blocking on next export.
 	//
 	// Dolt backend does not use a SQLite DB file, so this check is SQLite-only.
+	// Use store.Path() to get the actual database location, not the JSONL directory,
+	// since sync-branch exports write JSONL to a worktree but the DB stays in the main repo.
 	if result.JSONLPath != "" {
-		if _, ok := store.(*sqlite.SQLiteStorage); ok {
-			beadsDir := filepath.Dir(result.JSONLPath)
-			dbPath := filepath.Join(beadsDir, "beads.db")
+		if sqliteStore, ok := store.(*sqlite.SQLiteStorage); ok {
+			dbPath := sqliteStore.Path()
 			if err := TouchDatabaseFile(dbPath, result.JSONLPath); err != nil {
 				// Non-fatal warning
 				fmt.Fprintf(os.Stderr, "Warning: failed to update database mtime: %v\n", err)


### PR DESCRIPTION
## Summary

- Fixes warning when running `bd sync` with a sync-branch configured:
  `Warning: failed to update database mtime: chtimes .../beads-worktrees/beads-sync/.beads/beads.db: no such file or directory`
- When exporting to a sync-branch worktree, JSONL is written to `.git/beads-worktrees/<branch>/.beads/issues.jsonl`, but the SQLite database remains in the main repo's `.beads/` directory
- The code was incorrectly deriving the database path from the JSONL directory instead of using `store.Path()`

## Test plan

- [x] Added `TestWorktreeExportUsesCorrectDBPath` test that verifies the fix
- [x] Test confirms old behavior (worktree-derived path) fails as expected
- [x] Test confirms new behavior (store.Path()) works correctly
- [x] Existing mtime tests pass
- [x] Build passes
- [x] Linter passes on modified files

🤖 Generated with [Claude Code](https://claude.ai/code)