### PR TITLE
fix: skip sync when source and destination JSONL paths are identical

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -199,6 +199,15 @@ func (wm *WorktreeManager) SyncJSONLToWorktreeWithOptions(worktreePath, jsonlRel
 	normalizedRelPath := NormalizeBeadsRelPath(jsonlRelPath)
 	dstPath := filepath.Join(worktreePath, normalizedRelPath)
 
+	// GH#1298: When sync-branch is configured, findJSONLPath() returns the worktree
+	// path due to GH#1103. This causes jsonlRelPath to include the worktree path
+	// (e.g., ".git/beads-worktrees/beads-sync/.beads/issues.jsonl"), making srcPath
+	// point to the worktree JSONL instead of the main repo JSONL. In this case,
+	// srcPath == dstPath and we're copying the file to itself - skip the sync.
+	if srcPath == dstPath {
+		return nil
+	}
+
 	// Ensure destination directory exists
 	dstDir := filepath.Dir(dstPath)
 	if err := os.MkdirAll(dstDir, 0750); err != nil {


### PR DESCRIPTION
## Summary

Fixes #1298

When sync-branch is configured, `findJSONLPath()` returns the worktree path due to GH#1103. This causes `CommitToSyncBranch` to receive a `jsonlPath` that is already inside the worktree, making the sync attempt to copy the file to itself:

```
srcPath = repo/.git/beads-worktrees/sync/.beads/issues.jsonl
dstPath = repo/.git/beads-worktrees/sync/.beads/issues.jsonl
```

Since `srcPath == dstPath`, the file was being copied to itself, resulting in no changes detected and "No changes to commit" even when there were uncommitted modifications in the worktree.

## Changes

- Added early return in `SyncJSONLToWorktreeWithOptions` when source and destination paths are identical
- Added test case `TestSyncJSONLToWorktree_SelfCopy` to verify the fix

## Root Cause Analysis

The interaction between GH#1103 and `CommitToSyncBranch`:

1. GH#1103 redirects `findJSONLPath()` to return worktree path when sync-branch is configured
2. `CommitToSyncBranch` receives this worktree path as `jsonlPath`
3. `jsonlRelPath = filepath.Rel(repoRoot, jsonlPath)` produces `.git/beads-worktrees/sync/.beads/issues.jsonl`
4. `SyncJSONLToWorktree` joins `repoRoot + jsonlRelPath` = worktree path (same as destination)
5. File is "synced" to itself, no changes detected

## Test plan

- [x] Added unit test for self-copy detection
- [x] All existing `TestSyncJSONL*` tests pass
- [x] Build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)