### PR TITLE
fix(main): use GetDoltDatabase() for server mode database name

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -847,7 +847,7 @@ var rootCmd = &cobra.Command{
 				opts.ServerHost = cfg.GetDoltServerHost()
 				opts.ServerPort = cfg.GetDoltServerPort()
 				if cfg.Database != "" {
-					opts.Database = cfg.Database
+					opts.Database = cfg.GetDoltDatabase()
 				}
 			}
 


### PR DESCRIPTION
## Summary

- Fix `main.go` startup path to use `cfg.GetDoltDatabase()` instead of raw `cfg.Database` when setting the SQL database name for Dolt server mode
- `cfg.Database` contains the filesystem directory name (e.g. `"dolt"`), not the SQL database name (e.g. `"beads"`)
- This also means the `BEADS_DOLT_SERVER_DATABASE` env var override was not applied on the main startup path

## Test plan

- [x] `golangci-lint run` — clean (1 pre-existing gosec warning in unrelated file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)