### PR TITLE
Add export-state/ to gitignore template

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -50,6 +50,7 @@ beads.right.meta.json
 # These files are machine-specific and should not be shared across clones
 .sync.lock
 sync_base.jsonl
+export-state/
 
 # NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.
 # They would override fork protection in .git/info/exclude, allowing
@@ -71,6 +72,7 @@ var requiredPatterns = []string{
 	"last-touched",
 	".sync.lock",
 	"sync_base.jsonl",
+	"export-state/",
 }
 
 // CheckGitignore checks if .beads/.gitignore is up to date


### PR DESCRIPTION
## Summary
- Adds `export-state/` to the gitignore template created by `bd init`
- Adds `export-state/` to `requiredPatterns` so `bd doctor` can validate existing gitignore files

The `export-state/` directory contains machine-specific state (absolute paths, timestamps) that should not be committed.

## Test plan
- [x] Ran `go test ./cmd/bd/doctor/... -v -run Gitignore` - all tests pass

Fixes #1319

Generated with [Claude Code](https://claude.ai/code)