### PR TITLE
  fix: handle nil pointer dereference in bd restore with invalid issu…

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -615,6 +615,12 @@ var rootCmd = &cobra.Command{
 			noDaemon = true
 		}
 
+		// Restore should always run in direct mode. It performs git checkouts to read
+		// historical issue data, which could conflict with daemon operations.
+		if cmd.Name() == "restore" {
+			noDaemon = true
+		}
+
 		// Wisp operations auto-bypass daemon
 		// Wisps are ephemeral (Ephemeral=true) and never exported to JSONL,
 		// so daemon can't help anyway. This reduces friction in wisp workflows.

--- a/cmd/bd/restore.go
+++ b/cmd/bd/restore.go
@@ -42,7 +42,11 @@ This is read-only and does not modify the database or git state.`,
 		// Get the issue
 		issue, err := store.GetIssue(ctx, issueID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: issue %s not found: %v\n", issueID, err)
+			fmt.Fprintf(os.Stderr, "Error: issue '%s' not found: %v\n", issueID, err)
+			os.Exit(1)
+		}
+		if issue == nil {
+			fmt.Fprintf(os.Stderr, "Error: issue '%s' not found\n", issueID)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
###  Fix panic in `restore` with invalid issue ID

  The `restore` command could panic when given an invalid issue ID.

  Root cause

  - `GetIssue` returns `(nil, nil)` when an issue isn't found
  - The code didn't check for this case before dereferencing

  Changes

  - Add `nil` check for the issue returned by GetIssue
  - Add test covering the `(nil, nil)` case

  ---

###  Run restore in direct mode

`restore` performs git checkouts to read historical issue data, which temporarily changes the working tree. Running through the daemon could cause conflicts with filesystem state.

  This matches similar commands that bypass the daemon:
  - `edit` (opens an editor)
  - `doctor` (runs diagnostics)
