### PR TITLE
fix: exclude tombstones from external_ref uniqueness validation

### DIFF
--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1561,6 +1561,10 @@ func validateNoDuplicateExternalRefs(issues []*types.Issue, clearDuplicates bool
 	seen := make(map[string][]string)
 
 	for _, issue := range issues {
+		// Skip tombstone records - their external_ref is no longer "claimed" (GH#55u)
+		if issue.Status == types.StatusTombstone {
+			continue
+		}
 		if issue.ExternalRef != nil && *issue.ExternalRef != "" {
 			ref := *issue.ExternalRef
 			seen[ref] = append(seen[ref], issue.ID)

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -958,6 +958,30 @@ func TestValidateNoDuplicateExternalRefs(t *testing.T) {
 			t.Errorf("Expected no error for empty refs, got: %v", err)
 		}
 	})
+
+	t.Run("ignores tombstone external_refs (bd-55u)", func(t *testing.T) {
+		ref := "LINEAR-123"
+		issues := []*types.Issue{
+			{ID: "bd-1", Title: "Deleted Issue", ExternalRef: &ref, Status: types.StatusTombstone},
+			{ID: "bd-2", Title: "Live Issue", ExternalRef: &ref, Status: types.StatusOpen},
+		}
+		err := validateNoDuplicateExternalRefs(issues, false, nil)
+		if err != nil {
+			t.Errorf("Expected no error when tombstone has same external_ref as live issue, got: %v", err)
+		}
+	})
+
+	t.Run("multiple tombstones with same external_ref are allowed", func(t *testing.T) {
+		ref := "LINEAR-456"
+		issues := []*types.Issue{
+			{ID: "bd-1", Title: "Deleted 1", ExternalRef: &ref, Status: types.StatusTombstone},
+			{ID: "bd-2", Title: "Deleted 2", ExternalRef: &ref, Status: types.StatusTombstone},
+		}
+		err := validateNoDuplicateExternalRefs(issues, false, nil)
+		if err != nil {
+			t.Errorf("Expected no error for multiple tombstones with same ref, got: %v", err)
+		}
+	})
 }
 
 func TestConcurrentExternalRefImports(t *testing.T) {


### PR DESCRIPTION
Tombstone records should not conflict with live issues on external_ref during import. A tombstone represents a deleted issue - its external_ref is no longer claimed and should be available for live issues.