### PR TITLE
fix(mcp): Update Stats model to match bd stats --json output

### DIFF
--- a/integrations/beads-mcp/src/beads_mcp/models.py
+++ b/integrations/beads-mcp/src/beads_mcp/models.py
@@ -247,16 +247,39 @@ class ShowIssueParams(BaseModel):
     issue_id: str
 
 
-class Stats(BaseModel):
-    """Beads task statistics."""
+class StatsSummary(BaseModel):
+    """Summary statistics from bd stats."""
 
     total_issues: int
     open_issues: int
     in_progress_issues: int
     closed_issues: int
     blocked_issues: int
+    deferred_issues: int = 0
     ready_issues: int
+    tombstone_issues: int = 0
+    pinned_issues: int = 0
+    epics_eligible_for_closure: int = 0
     average_lead_time_hours: float
+
+
+class RecentActivity(BaseModel):
+    """Recent activity from bd stats."""
+
+    hours_tracked: int = 24
+    commit_count: int = 0
+    issues_created: int = 0
+    issues_closed: int = 0
+    issues_updated: int = 0
+    issues_reopened: int = 0
+    total_changes: int = 0
+
+
+class Stats(BaseModel):
+    """Beads task statistics matching bd stats --json output."""
+
+    summary: StatsSummary
+    recent_activity: RecentActivity | None = None
 
 
 class BlockedIssue(Issue):

--- a/integrations/beads-mcp/tests/test_mcp_server_integration.py
+++ b/integrations/beads-mcp/tests/test_mcp_server_integration.py
@@ -558,9 +558,10 @@ async def test_stats_tool(mcp_client):
     result = await mcp_client.call_tool("stats", {})
     stats = json.loads(result.content[0].text)
 
-    assert "total_issues" in stats
-    assert "open_issues" in stats
-    assert stats["total_issues"] >= 2
+    assert "summary" in stats
+    assert "total_issues" in stats["summary"]
+    assert "open_issues" in stats["summary"]
+    assert stats["summary"]["total_issues"] >= 2
 
 
 @pytest.mark.asyncio

--- a/integrations/beads-mcp/tests/test_tools.py
+++ b/integrations/beads-mcp/tests/test_tools.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from beads_mcp.models import BlockedIssue, Issue, Stats
+from beads_mcp.models import BlockedIssue, Issue, Stats, StatsSummary
 from beads_mcp.tools import (
     beads_add_dependency,
     beads_blocked,
@@ -426,13 +426,16 @@ async def test_update_issue_routes_open_to_reopen(sample_issue):
 async def test_beads_stats():
     """Test beads_stats tool."""
     stats_data = Stats(
-        total_issues=10,
-        open_issues=5,
-        in_progress_issues=2,
-        closed_issues=3,
-        blocked_issues=1,
-        ready_issues=4,
-        average_lead_time_hours=24.5,
+        summary=StatsSummary(
+            total_issues=10,
+            open_issues=5,
+            in_progress_issues=2,
+            closed_issues=3,
+            blocked_issues=1,
+            ready_issues=4,
+            average_lead_time_hours=24.5,
+        ),
+        recent_activity=None,
     )
     mock_client = AsyncMock()
     mock_client.stats = AsyncMock(return_value=stats_data)
@@ -440,8 +443,8 @@ async def test_beads_stats():
     with patch("beads_mcp.tools._get_client", return_value=mock_client):
         result = await beads_stats()
 
-    assert result.total_issues == 10
-    assert result.open_issues == 5
+    assert result.summary.total_issues == 10
+    assert result.summary.open_issues == 5
     mock_client.stats.assert_called_once()
 
 


### PR DESCRIPTION
The Stats Pydantic model had flat fields but bd stats --json returns nested summary/recent_activity. This caused validation errors. Fixed by adding StatsSummary and RecentActivity models.