### PR TITLE
fix(formula): ignore undeclared handlebars in description text

### DIFF
--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -796,25 +796,25 @@ func extractAllVariables(subgraph *TemplateSubgraph) []string {
 func extractRequiredVariables(subgraph *TemplateSubgraph) []string {
 	allVars := extractAllVariables(subgraph)
 
-	// If no VarDefs, assume all variables are required
-	if subgraph.VarDefs == nil || len(subgraph.VarDefs) == 0 {
+	// If no VarDefs, assume all variables are required (legacy template behavior)
+	if subgraph.VarDefs == nil {
 		return allVars
 	}
 
-	// Filter to only required variables (no default and marked as required, or not defined in VarDefs)
+	// VarDefs exists (from a cooked formula) - only declared variables matter.
+	// Variables in text but NOT in VarDefs are ignored - they're documentation
+	// handlebars meant for LLM agents, not formula input variables (gt-ky9loa).
 	var required []string
 	for _, v := range allVars {
 		def, exists := subgraph.VarDefs[v]
-		// A variable is required if:
-		// 1. It's not defined in VarDefs at all, OR
-		// 2. It's defined with Required=true and no Default, OR
-		// 3. It's defined with no Default (even if Required is false)
 		if !exists {
-			required = append(required, v)
-		} else if def.Default == "" {
+			// Not a declared formula variable - skip (documentation handlebars)
+			continue
+		}
+		// A declared variable is required if it has no default
+		if def.Default == "" {
 			required = append(required, v)
 		}
-		// If exists and has default, it's not required
 	}
 	return required
 }

--- a/cmd/bd/template_test.go
+++ b/cmd/bd/template_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -827,4 +828,103 @@ func TestLoadTemplateSubgraphWithManyChildren(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestExtractRequiredVariables_IgnoresUndeclaredVars tests that handlebars in
+// description text that are NOT defined in VarDefs are ignored (gt-ky9loa).
+func TestExtractRequiredVariables_IgnoresUndeclaredVars(t *testing.T) {
+	tests := []struct {
+		name         string
+		issues       []*types.Issue
+		varDefs      map[string]formula.VarDef
+		wantRequired []string
+	}{
+		{
+			name: "declared var without default is required",
+			issues: []*types.Issue{
+				{Title: "Deploy {{component}}", Description: "Deploy the component"},
+			},
+			varDefs: map[string]formula.VarDef{
+				"component": {Required: true},
+			},
+			wantRequired: []string{"component"},
+		},
+		{
+			name: "declared var with default is not required",
+			issues: []*types.Issue{
+				{Title: "Deploy {{component}}", Description: "Deploy the component"},
+			},
+			varDefs: map[string]formula.VarDef{
+				"component": {Default: "api"},
+			},
+			wantRequired: []string{},
+		},
+		{
+			name: "undeclared var in description is ignored when VarDefs exists",
+			issues: []*types.Issue{
+				{
+					Title:       "Generate report",
+					Description: "Output format:\n**Ready**: {{ready_count}}\n**Done**: {{done_count}}",
+				},
+			},
+			varDefs: map[string]formula.VarDef{
+				// VarDefs exists but doesn't include ready_count or done_count
+				// These are documentation handlebars, not formula variables
+			},
+			wantRequired: []string{},
+		},
+		{
+			name: "mix of declared and undeclared vars",
+			issues: []*types.Issue{
+				{
+					Title:       "Deploy {{component}} to {{env}}",
+					Description: "Shows: {{status_count}} items processed",
+				},
+			},
+			varDefs: map[string]formula.VarDef{
+				"component": {Required: true},
+				"env":       {Default: "prod"},
+				// status_count is NOT declared - it's documentation
+			},
+			wantRequired: []string{"component"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subgraph := &TemplateSubgraph{
+				Issues:  tt.issues,
+				VarDefs: tt.varDefs,
+			}
+
+			got := extractRequiredVariables(subgraph)
+
+			// Convert to map for easier comparison
+			gotMap := make(map[string]bool)
+			for _, v := range got {
+				gotMap[v] = true
+			}
+			wantMap := make(map[string]bool)
+			for _, v := range tt.wantRequired {
+				wantMap[v] = true
+			}
+
+			if len(got) != len(tt.wantRequired) {
+				t.Errorf("extractRequiredVariables() = %v, want %v", got, tt.wantRequired)
+				return
+			}
+
+			for _, v := range tt.wantRequired {
+				if !gotMap[v] {
+					t.Errorf("extractRequiredVariables() missing expected var %q, got %v", v, got)
+				}
+			}
+
+			for _, v := range got {
+				if !wantMap[v] {
+					t.Errorf("extractRequiredVariables() has unexpected var %q, want %v", v, tt.wantRequired)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fixes formula variable extraction to only require variables declared in the `[vars]` section. Handlebars-style placeholders in description text (meant as documentation for LLM agents) are now ignored rather than treated as required input variables.

## Problem

`gt sling mol-convoy-feed --var convoy=hq-cv-vbx5o` fails with:
```
Error: missing required variables: ready_count, available_count, dispatch_count, ...
```

These patterns like `{{ready_count}}` in description text are documentation showing LLM agents what output format to use, not formula input variables.

## Solution

Modified `extractRequiredVariables()` in `cmd/bd/template.go`:
- When `VarDefs` exists (from a cooked formula), only consider variables declared in `VarDefs`
- Variables found in text but NOT in `VarDefs` are skipped (they're documentation handlebars)

## Test plan

- [x] Added test cases for the fix in `cmd/bd/template_test.go`
- [x] Verified existing template tests still pass
- [x] Build and lint pass

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)