### PR TITLE
Linear Sync - exclude ephemeral issues from sync push by default (relates #1204, #1205)

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -83,8 +83,9 @@ Modes:
   (no flags)     Bidirectional sync: pull then push, with conflict resolution
 
 Type Filtering (--push only):
-  --type task,feature    Only sync issues of these types
-  --exclude-type wisp    Exclude issues of these types
+  --type task,feature       Only sync issues of these types
+  --exclude-type wisp       Exclude issues of these types
+  --include-ephemeral       Include ephemeral issues (wisps, etc.); default is to exclude
 
 Conflict Resolution:
   By default, newer timestamp wins. Override with:
@@ -138,6 +139,7 @@ func init() {
 	linearSyncCmd.Flags().String("state", "all", "Issue state to sync: open, closed, all")
 	linearSyncCmd.Flags().StringSlice("type", nil, "Only sync issues of these types (can be repeated)")
 	linearSyncCmd.Flags().StringSlice("exclude-type", nil, "Exclude issues of these types (can be repeated)")
+	linearSyncCmd.Flags().Bool("include-ephemeral", false, "Include ephemeral issues (wisps, etc.) when pushing to Linear")
 
 	linearCmd.AddCommand(linearSyncCmd)
 	linearCmd.AddCommand(linearStatusCmd)
@@ -156,6 +158,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	state, _ := cmd.Flags().GetString("state")
 	typeFilters, _ := cmd.Flags().GetStringSlice("type")
 	excludeTypes, _ := cmd.Flags().GetStringSlice("exclude-type")
+	includeEphemeral, _ := cmd.Flags().GetBool("include-ephemeral")
 
 	if !dryRun {
 		CheckReadonly("linear sync")
@@ -324,7 +327,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 			fmt.Println("→ Pushing issues to Linear...")
 		}
 
-		pushStats, err := doPushToLinear(ctx, dryRun, createOnly, updateRefs, forceUpdateIDs, skipUpdateIDs, typeFilters, excludeTypes)
+		pushStats, err := doPushToLinear(ctx, dryRun, createOnly, updateRefs, forceUpdateIDs, skipUpdateIDs, typeFilters, excludeTypes, includeEphemeral)
 		if err != nil {
 			result.Success = false
 			result.Error = err.Error()

--- a/cmd/bd/linear_sync.go
+++ b/cmd/bd/linear_sync.go
@@ -211,7 +211,8 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 // doPushToLinear exports issues to Linear using the GraphQL API.
 // typeFilters includes only issues matching these types (empty means all).
 // excludeTypes excludes issues matching these types.
-func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRefs bool, forceUpdateIDs map[string]bool, skipUpdateIDs map[string]bool, typeFilters []string, excludeTypes []string) (*linear.PushStats, error) {
+// includeEphemeral: if false (default), ephemeral issues (wisps, etc.) are excluded from push.
+func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRefs bool, forceUpdateIDs map[string]bool, skipUpdateIDs map[string]bool, typeFilters []string, excludeTypes []string, includeEphemeral bool) (*linear.PushStats, error) {
 	stats := &linear.PushStats{}
 
 	client, err := getLinearClient(ctx)
@@ -219,7 +220,11 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 		return stats, fmt.Errorf("failed to create Linear client: %w", err)
 	}
 
-	allIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+	filter := types.IssueFilter{}
+	if !includeEphemeral {
+		filter.Ephemeral = &includeEphemeral
+	}
+	allIssues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
 		return stats, fmt.Errorf("failed to get local issues: %w", err)
 	}

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -1220,7 +1220,7 @@ func TestDoPushToLinearPreferLocalForcesUpdate(t *testing.T) {
 	})
 
 	forceUpdateIDs := map[string]bool{issue.ID: true}
-	stats, err := doPushToLinear(ctx, false, false, true, forceUpdateIDs, nil, nil, nil)
+	stats, err := doPushToLinear(ctx, false, false, true, forceUpdateIDs, nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("doPushToLinear failed: %v", err)
 	}
@@ -1232,6 +1232,73 @@ func TestDoPushToLinearPreferLocalForcesUpdate(t *testing.T) {
 	}
 	if stats.Skipped != 0 {
 		t.Fatalf("expected Skipped=0, got %d", stats.Skipped)
+	}
+}
+
+func TestDoPushToLinearIncludeEphemeralFlag(t *testing.T) {
+	testStore, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if err := testStore.SetConfig(ctx, "linear.api_key", "test-api-key"); err != nil {
+		t.Fatalf("SetConfig linear.api_key failed: %v", err)
+	}
+	if err := testStore.SetConfig(ctx, "linear.team_id", "12345678-1234-1234-1234-123456789abc"); err != nil {
+		t.Fatalf("SetConfig linear.team_id failed: %v", err)
+	}
+
+	now := time.Now()
+	persistent := &types.Issue{
+		Title:      "Persistent issue",
+		Priority:   2,
+		IssueType:  types.TypeTask,
+		Status:     types.StatusOpen,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		Ephemeral:  false,
+	}
+	if err := testStore.CreateIssue(ctx, persistent, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue persistent failed: %v", err)
+	}
+
+	ephemeral := &types.Issue{
+		Title:      "Ephemeral wisp",
+		Priority:   2,
+		IssueType:  types.TypeTask,
+		Status:     types.StatusOpen,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+		Ephemeral:  true,
+	}
+	if err := testStore.CreateIssue(ctx, ephemeral, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue ephemeral failed: %v", err)
+	}
+
+	origStore := store
+	origActor := actor
+	store = testStore
+	actor = "test-actor"
+	t.Cleanup(func() {
+		store = origStore
+		actor = origActor
+	})
+
+	// Default (includeEphemeral=false): only non-ephemeral issues are pushed
+	statsExclude, err := doPushToLinear(ctx, true, false, false, nil, nil, nil, nil, false)
+	if err != nil {
+		t.Fatalf("doPushToLinear includeEphemeral=false failed: %v", err)
+	}
+	if statsExclude.Created != 1 {
+		t.Errorf("includeEphemeral=false: expected Created=1 (persistent only), got %d", statsExclude.Created)
+	}
+
+	// includeEphemeral=true: both issues are pushed
+	statsInclude, err := doPushToLinear(ctx, true, false, false, nil, nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("doPushToLinear includeEphemeral=true failed: %v", err)
+	}
+	if statsInclude.Created != 2 {
+		t.Errorf("includeEphemeral=true: expected Created=2 (persistent + ephemeral), got %d", statsInclude.Created)
 	}
 }
 


### PR DESCRIPTION
`bd linear sync` was including local-only ephemeral beads (wisps, etc.), causing noise. We now exclude them by using the `ephemeral` field. Addresses the same underlying problem as #1204. 

- Exclude ephemeral issues (wisps, etc.) from push to Linear by default. 
- Add `--include-ephemeral` flag to override behaviour if needed.

Tests and linters ran with no regressions against main at https://github.com/steveyegge/beads/commit/761d2e76379a03c7fe0efc2157ac23e8a52217df.