### PR TITLE
feat(mol): add hint to view step instructions in mol current output

### DIFF
--- a/cmd/bd/mol_current.go
+++ b/cmd/bd/mol_current.go
@@ -483,6 +483,17 @@ func printMoleculeProgress(mol *MoleculeProgress) {
 		fmt.Printf("\nNext ready: %s - %s\n", mol.NextStep.ID, mol.NextStep.Title)
 		fmt.Printf("  Start with: bd update %s --status in_progress\n", mol.NextStep.ID)
 	}
+
+	// Show hint about viewing step instructions
+	var hintStepID string
+	if mol.CurrentStep != nil {
+		hintStepID = mol.CurrentStep.ID
+	} else if mol.NextStep != nil {
+		hintStepID = mol.NextStep.ID
+	}
+	if hintStepID != "" {
+		fmt.Printf("\n%s Run `bd show %s` to see detailed instructions.\n", ui.RenderAccent("💡"), hintStepID)
+	}
 }
 
 // getStatusIcon returns the icon for a step status
@@ -670,6 +681,11 @@ func printLargeMoleculeSummary(stats *types.MoleculeProgressStats) {
 	fmt.Printf("  bd mol current %s --limit 50        # First 50 steps\n", stats.MoleculeID)
 	fmt.Printf("  bd mol current %s --range 1-50     # Steps 1-50\n", stats.MoleculeID)
 	fmt.Printf("  bd mol progress %s                 # Efficient progress summary\n", stats.MoleculeID)
+
+	// Show hint about viewing step instructions
+	if stats.CurrentStepID != "" {
+		fmt.Printf("\n%s Run `bd show %s` to see detailed instructions.\n", ui.RenderAccent("💡"), stats.CurrentStepID)
+	}
 }
 
 func init() {


### PR DESCRIPTION
## Summary

When `bd mol current` displays the step list with "YOU ARE HERE" marker, agents often improvise based on the step title alone without reading the detailed step instructions stored in the step bead's description.

This adds a footer hint after the progress line:

```
Progress: 1/22 steps complete

💡 Run `bd show feed-stranded-convoys` to see detailed instructions.
```

The hint shows the current step ID if one is in_progress, otherwise the next ready step ID.

## Problem

Step descriptions are stored in formula files and copied to step beads when molecules are poured. `bd show <step-id>` displays these descriptions. However, agents don't know to run this command because nothing tells them about it.

Evidence: The Deacon patrol saw step title "Feed stranded convoys" and improvised with `bd list | grep` instead of using `gt convoy stranded --json` as specified in the step description.

See: https://github.com/steveyegge/gastown/issues/1128

## Test plan

- [x] `go build ./cmd/bd` - compiles
- [x] `go test ./cmd/bd/... -run "Mol"` - all tests pass
- [x] Manual: run `bd mol current` on an active molecule and verify hint appears

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)