### PR TITLE
fix: skip JSONL staleness check in dolt-native mode

### DIFF
--- a/cmd/bd/staleness.go
+++ b/cmd/bd/staleness.go
@@ -28,6 +28,12 @@ func ensureDatabaseFresh(ctx context.Context) error {
 		return nil
 	}
 
+	// In dolt-native mode, Dolt is the source of truth and JSONL is irrelevant.
+	// Skip the staleness check entirely to avoid blocking reads due to stale JSONL.
+	if !ShouldExportJSONL(ctx, store) {
+		return nil
+	}
+
 	// Check if database is stale
 	isStale, err := autoimport.CheckStaleness(ctx, store, dbPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
- In dolt-native mode, `ensureDatabaseFresh()` now returns early without checking JSONL staleness, since Dolt is the source of truth and JSONL is irrelevant
- Existing staleness tests updated to explicitly set `git-portable` mode so they continue exercising the JSONL path
- New test `TestEnsureDatabaseFresh_DoltNativeSkipsCheck` verifies the skip behavior

Fixes: gt-dolt-stale-jsonl

## Test plan
- [x] All 5 `TestEnsureDatabaseFresh_*` tests pass
- [x] `go build ./cmd/bd/` succeeds
- [ ] Verify `bd show`, `bd list`, `bd ready` work without `--allow-stale` in dolt-native mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)