### PR TITLE
fix(template): filter Handlebars keywords in extractVariables

### DIFF
--- a/cmd/bd/template_test.go
+++ b/cmd/bd/template_test.go
@@ -63,6 +63,21 @@ func TestExtractVariables(t *testing.T) {
 			input:    "{{}}",
 			expected: nil,
 		},
+		{
+			name:     "handlebars else keyword ignored",
+			input:    "{{ready}} then {{else}} or {{other}}",
+			expected: []string{"ready", "other"},
+		},
+		{
+			name:     "handlebars this keyword ignored",
+			input:    "{{this}} and {{name}}",
+			expected: []string{"name"},
+		},
+		{
+			name:     "multiple handlebars keywords ignored",
+			input:    "{{else}} {{this}} {{root}} {{index}} {{key}} {{first}} {{last}} {{actual_var}}",
+			expected: []string{"actual_var"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
  - Filter Handlebars control keywords (`else`, `this`, `root`, `index`, `key`, `first`, `last`) in `extractVariables()` at extraction time

  ## Problem
  The previous fix (#1394 / 9e807505) filters undeclared variables in `extractRequiredVariables()` only when `VarDefs` exists. This misses two cases:

  1. **Legacy templates** where `VarDefs` is nil - falls back to returning all extracted vars including keywords
  2. **Display contexts** - `mol_show.go` uses `extractAllVariables()` directly, showing `else`, `this` etc. as "variables" to users

  ## Solution
  Add `isHandlebarsKeyword()` check directly in `extractVariables()` to filter keywords at the source, rather than at each usage site.

  ## Test plan
  - [x] Added 3 new test cases for handlebars keyword filtering
  - [x] Verified tests fail without the fix, pass with it
  - [x] All existing `TestExtractVariables` tests still pass

  ```bash
  go test -v -run TestExtractVariables ./cmd/bd/