### PR TITLE
fix(dolt): use correct variable in initSchemaOnDB

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -359,7 +359,7 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		"CREATE INDEX idx_issues_issue_type ON issues(issue_type)",
 	}
 	for _, migration := range indexMigrations {
-		_, err := s.db.ExecContext(ctx, migration)
+		_, err := db.ExecContext(ctx, migration)
 		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "duplicate") &&
 			!strings.Contains(strings.ToLower(err.Error()), "already exists") {
 			return fmt.Errorf("failed to apply index migration: %w", err)


### PR DESCRIPTION
## Summary
- Fixes a build error where `s.db` was used instead of `db` in `initSchemaOnDB` function

## Problem
The function `initSchemaOnDB` receives `db *sql.DB` as parameter, but line 362 incorrectly referenced `s.db` (likely copy-pasted from a Store struct method).

This causes a compile error:
```
internal/storage/dolt/store.go:362:13: undefined: s
```

## Fix
Changed `s.db.ExecContext(ctx, migration)` to `db.ExecContext(ctx, migration)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)