### PR TITLE
fix: guard auto-import against nil pointer panic in dolt-native mode

### DIFF
--- a/cmd/bd/autostart_test.go
+++ b/cmd/bd/autostart_test.go
@@ -11,10 +11,17 @@ import (
 
 func TestDaemonAutoStart(t *testing.T) {
 	// Initialize config for tests
+	config.ResetForTesting()
 	if err := config.Initialize(); err != nil {
 		t.Fatalf("Failed to initialize config: %v", err)
 	}
-	
+
+	// Isolate dbPath so isDoltBackend() doesn't find the repo's .beads/metadata.json
+	origDbPath := dbPath
+	tmpDir := t.TempDir()
+	dbPath = filepath.Join(tmpDir, "beads.db")
+	defer func() { dbPath = origDbPath }()
+
 	// Save original env
 	origAutoStart := os.Getenv("BEADS_AUTO_START_DAEMON")
 	origNoDaemon := os.Getenv("BEADS_NO_DAEMON")

--- a/cmd/bd/daemon_autostart_unit_test.go
+++ b/cmd/bd/daemon_autostart_unit_test.go
@@ -329,6 +329,11 @@ func TestDaemonAutostart_EmitVerboseWarning(t *testing.T) {
 }
 
 func TestDaemonAutostart_StartDaemonProcess_Stubbed(t *testing.T) {
+	// Isolate dbPath so isDoltBackend() doesn't find the repo's .beads/metadata.json
+	origDbPath := dbPath
+	dbPath = filepath.Join(t.TempDir(), "beads.db")
+	defer func() { dbPath = origDbPath }()
+
 	oldExec := execCommandFn
 	oldWait := waitForSocketReadinessFn
 	oldCfg := configureDaemonProcessFn

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -2126,6 +2126,11 @@ func TestInit_WithBEADS_DIR_DoltBackend(t *testing.T) {
 		t.Skip("Skipping BEADS_DIR Dolt test on Windows")
 	}
 
+	// Skip when CGO is not available (Dolt embedded requires CGO)
+	if !DoltServerAvailable() {
+		t.Skip("Dolt backend requires CGO, skipping")
+	}
+
 	// Check if dolt is available
 	if _, err := exec.LookPath("dolt"); err != nil {
 		t.Skip("Dolt not installed, skipping Dolt backend test")

--- a/cmd/bd/test_repo_beads_guard_test.go
+++ b/cmd/bd/test_repo_beads_guard_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/beads/internal/config"
 )
 
 // Guardrail: ensure the cmd/bd test suite does not touch the real repo .beads state.
@@ -28,6 +30,15 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("USERPROFILE", tmp) // Windows compatibility
 	_ = os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "xdg-config"))
 	_ = os.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+
+	// Re-initialize config after setting isolation env vars.
+	// The package-level init() in main.go calls config.Initialize() before TestMain
+	// runs, so viper has already loaded .beads/config.yaml (with sync.mode=dolt-native).
+	// Reset and reinitialize so tests see clean defaults.
+	config.ResetForTesting()
+	if err := config.Initialize(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: config re-init: %v\n", err)
+	}
 
 	// Enable test mode that forces accessor functions to use legacy globals.
 	// This ensures backward compatibility with tests that manipulate globals directly.


### PR DESCRIPTION
## Summary
- Adds `ShouldImportJSONL()` guard to skip JSONL auto-import when in dolt-native sync mode, preventing nil pointer panic in `GetStatistics()` when DoltStore.db is nil
- Fixes config discovery to stop walking at module root when `BEADS_TEST_IGNORE_REPO_CONFIG` is set, preventing parent rig configs from polluting test state
- Fixes 20 pre-existing test failures caused by `init()` loading repo config before `TestMain` could set isolation env vars

## Test plan
- [x] All cmd/bd tests pass: `ok github.com/steveyegge/beads/cmd/bd 40.637s`
- [ ] Verify auto-import is skipped in dolt-native mode (no panic)
- [ ] Verify auto-import still works in git-portable mode (default)

Generated with Claude Code