### PR TITLE
fix(sync): disable JSONL imports in dolt-native mode

### DIFF
--- a/cmd/bd/autoflush.go
+++ b/cmd/bd/autoflush.go
@@ -208,6 +208,11 @@ func autoImportIfNewer() {
 		return
 	}
 
+	if !ShouldImportJSONL(rootCtx, store) {
+		debug.Logf("auto-import skipped (dolt-native mode)")
+		return
+	}
+
 	// Find JSONL path
 	jsonlPath := findJSONLPath()
 
@@ -828,7 +833,6 @@ type flushState struct {
 //   - Store already closed (storeActive=false)
 //   - Database not dirty (isDirty=false) AND forceDirty=false
 //   - No dirty issues found (incremental mode only)
-//   - Sync mode is dolt-native (bd-ixip: skip JSONL export)
 func flushToJSONLWithState(state flushState) {
 	// Check if store is still active (not closed) and not nil
 	storeMutex.Lock()
@@ -838,13 +842,7 @@ func flushToJSONLWithState(state flushState) {
 	}
 	storeMutex.Unlock()
 
-	// Check sync mode before JSONL export (bd-ixip: dolt-native mode should skip JSONL)
 	ctx := rootCtx
-	if !ShouldExportJSONL(ctx, store) {
-		debug.Logf("skipping autoflush (dolt-native mode)")
-		return
-	}
-
 	jsonlPath := findJSONLPath()
 
 	// Double-check store is still active before accessing

--- a/cmd/bd/autoimport.go
+++ b/cmd/bd/autoimport.go
@@ -51,6 +51,11 @@ func checkAndAutoImport(ctx context.Context, store storage.Storage) bool {
 		return false
 	}
 
+	if !ShouldImportJSONL(ctx, store) {
+		debug.Logf("auto-import skipped (dolt-native mode)")
+		return false
+	}
+
 	// Check if database has any issues
 	stats, err := store.GetStatistics(ctx)
 	if err != nil || stats.TotalIssues > 0 {

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -759,15 +759,9 @@ var createCmd = &cobra.Command{
 
 // flushRoutedRepo ensures the target repo's JSONL is updated after routing an issue.
 // This is critical for multi-repo hydration to work correctly (bd-fix-routing).
-// Respects sync mode: skips JSONL export in dolt-native mode (bd-a9ka).
+// Always writes local JSONL as a safety net (even in dolt-native mode).
 func flushRoutedRepo(targetStore storage.Storage, repoPath string) {
 	ctx := context.Background()
-
-	// Check sync mode before JSONL export (bd-a9ka: dolt-native mode should skip JSONL)
-	if !ShouldExportJSONL(ctx, targetStore) {
-		debug.Logf("skipping JSONL flush for routed repo (dolt-native mode)")
-		return
-	}
 
 	// Expand the repo path and construct the .beads directory path
 	targetBeadsDir := routing.ExpandPath(repoPath)

--- a/cmd/bd/daemon_sync.go
+++ b/cmd/bd/daemon_sync.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
-	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/syncbranch"
@@ -62,14 +61,8 @@ func shouldSkipDueToSameBranch(ctx context.Context, store storage.Storage, opera
 // exportToJSONLWithStore exports issues to JSONL using the provided store.
 // If multi-repo mode is configured, routes issues to their respective JSONL files.
 // Otherwise, exports to a single JSONL file.
-// Respects sync mode: skips JSONL export in dolt-native mode (bd-u9yv).
+// Always writes local JSONL as a safety net (even in dolt-native mode).
 func exportToJSONLWithStore(ctx context.Context, store storage.Storage, jsonlPath string) error {
-	// Check sync mode before JSONL export (bd-u9yv: dolt-native mode should skip JSONL)
-	if !ShouldExportJSONL(ctx, store) {
-		debug.Logf("skipping JSONL export (dolt-native mode)")
-		return nil
-	}
-
 	// Try multi-repo export first
 	sqliteStore, ok := store.(*sqlite.SQLiteStorage)
 	if ok {

--- a/cmd/bd/direct_mode.go
+++ b/cmd/bd/direct_mode.go
@@ -103,7 +103,7 @@ func ensureStoreActive() error {
 	setStoreActive(true)
 	unlockStore()
 
-	if isAutoImportEnabled() {
+	if isAutoImportEnabled() && ShouldImportJSONL(rootCtx, store) {
 		autoImportIfNewer()
 	}
 

--- a/cmd/bd/sync_mode.go
+++ b/cmd/bd/sync_mode.go
@@ -106,10 +106,21 @@ func GetImportTrigger(ctx context.Context, s storage.Storage) string {
 	return trigger
 }
 
-// ShouldExportJSONL returns true if the current sync mode uses JSONL export.
+// ShouldExportJSONL returns true if the current sync mode uses JSONL export
+// for git sync operations (commit/push/pull on the sync branch).
+// Note: Local JSONL file writes (autoflush) always happen as a safety net,
+// regardless of this setting. This only controls git-based JSONL sync.
 func ShouldExportJSONL(ctx context.Context, s storage.Storage) bool {
 	mode := GetSyncMode(ctx, s)
 	// All modes except dolt-native use JSONL
+	return mode != SyncModeDoltNative
+}
+
+// ShouldImportJSONL returns true if the current sync mode should import from JSONL.
+// In dolt-native mode, imports are disabled to prevent stale JSONL from overwriting
+// dolt data.
+func ShouldImportJSONL(ctx context.Context, s storage.Storage) bool {
+	mode := GetSyncMode(ctx, s)
 	return mode != SyncModeDoltNative
 }
 

--- a/cmd/bd/sync_mode_test.go
+++ b/cmd/bd/sync_mode_test.go
@@ -124,6 +124,47 @@ func TestShouldExportJSONL(t *testing.T) {
 	}
 }
 
+// TestShouldImportJSONL verifies JSONL import behavior per mode.
+func TestShouldImportJSONL(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	testStore, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer testStore.Close()
+
+	tests := []struct {
+		mode       string
+		wantImport bool
+	}{
+		{SyncModeGitPortable, true},
+		{SyncModeRealtime, true},
+		{SyncModeDoltNative, false},
+		{SyncModeBeltAndSuspenders, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			if err := SetSyncMode(ctx, testStore, tt.mode); err != nil {
+				t.Fatalf("failed to set mode: %v", err)
+			}
+
+			got := ShouldImportJSONL(ctx, testStore)
+			if got != tt.wantImport {
+				t.Errorf("ShouldImportJSONL() = %v, want %v", got, tt.wantImport)
+			}
+		})
+	}
+}
+
 // TestShouldUseDoltRemote verifies Dolt remote usage per mode.
 func TestShouldUseDoltRemote(t *testing.T) {
 	ctx := context.Background()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -695,6 +695,15 @@ func NeedsJSONL() bool {
 	return mode == SyncModeGitPortable || mode == SyncModeRealtime || mode == SyncModeBeltAndSuspenders
 }
 
+// NeedsJSONLImport returns true if the sync mode should import from JSONL.
+// In dolt-native mode, imports are disabled to prevent stale JSONL from
+// overwriting dolt data. This is for use by internal/rpc which can't
+// import cmd/bd.
+func NeedsJSONLImport() bool {
+	mode := GetSyncMode()
+	return mode != SyncModeDoltNative
+}
+
 // GetCustomTypesFromYAML retrieves custom issue types from config.yaml.
 // This is used as a fallback when the database doesn't have types.custom set yet
 // (e.g., during bd init auto-import before the database is fully configured).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1392,6 +1392,35 @@ func TestNeedsJSONL(t *testing.T) {
 	}
 }
 
+func TestNeedsJSONLImport(t *testing.T) {
+	// Isolate from environment variables
+	restore := envSnapshot(t)
+	defer restore()
+
+	tests := []struct {
+		mode       SyncMode
+		needsImport bool
+	}{
+		{SyncModeGitPortable, true},
+		{SyncModeRealtime, true},
+		{SyncModeDoltNative, false},
+		{SyncModeBeltAndSuspenders, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.mode), func(t *testing.T) {
+			if err := Initialize(); err != nil {
+				t.Fatalf("Initialize() returned error: %v", err)
+			}
+			Set("sync.mode", string(tt.mode))
+
+			if got := NeedsJSONLImport(); got != tt.needsImport {
+				t.Errorf("NeedsJSONLImport() with mode=%s = %v, want %v", tt.mode, got, tt.needsImport)
+			}
+		})
+	}
+}
+
 func TestGetSyncModeInvalid(t *testing.T) {
 	// Isolate from environment variables
 	restore := envSnapshot(t)

--- a/internal/rpc/server_export_import_auto.go
+++ b/internal/rpc/server_export_import_auto.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/autoimport"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/export"
 	"github.com/steveyegge/beads/internal/importer"
@@ -264,6 +265,10 @@ func (s *Server) handleImport(req *Request) Response {
 // This fixes bd-132: daemon shows stale data after git pull
 // This fixes bd-8931: daemon gets stuck when auto-import blocked by git conflicts
 func (s *Server) checkAndAutoImportIfStale(req *Request) error {
+	if !config.NeedsJSONLImport() {
+		return nil
+	}
+
 	// Get storage for this request
 	store := s.storage
 


### PR DESCRIPTION
## Summary

- **Disables all JSONL import paths in dolt-native mode** to prevent stale JSONL from overwriting dolt data
- **Enables local JSONL file writes in dolt-native mode** as a safety net backup (removes overly broad export guards from autoflush/create/daemon_sync)
- Git-based JSONL sync (commit/push/pull on sync branch) remains disabled in dolt-native mode

## Test plan

- [x] `go build ./cmd/bd` passes
- [x] `go test ./cmd/bd/...` — new `TestShouldImportJSONL` passes
- [x] `go test ./internal/config/...` — new `TestNeedsJSONLImport` passes
- [x] `go test ./internal/rpc/...` passes
- [ ] Manual: verify dolt-native mode no longer auto-imports from JSONL
- [ ] Manual: verify dolt-native mode still writes local JSONL files

🤖 Generated with [Claude Code](https://claude.com/claude-code)