### PR TITLE
feat(migrate): agent-managed Dolt upgrade path

### DIFF
--- a/cmd/bd/autoimport.go
+++ b/cmd/bd/autoimport.go
@@ -176,11 +176,12 @@ func checkGitForIssues() (int, string, string) {
 	return 0, "", ""
 }
 
-// localConfig represents the subset of config.yaml we need for auto-import and no-db detection.
+// localConfig represents the subset of config.yaml we need for auto-import, no-db, and prefer-dolt detection.
 // Using proper YAML parsing handles edge cases like comments, indentation, and special characters.
 type localConfig struct {
 	SyncBranch string `yaml:"sync-branch"`
 	NoDb       bool   `yaml:"no-db"`
+	PreferDolt bool   `yaml:"prefer-dolt"`
 }
 
 // isNoDbModeConfigured checks if no-db: true is set in config.yaml.
@@ -199,6 +200,24 @@ func isNoDbModeConfigured(beadsDir string) bool {
 	}
 
 	return cfg.NoDb
+}
+
+// isPreferDoltConfigured checks if prefer-dolt: true is set in config.yaml.
+// Uses proper YAML parsing to avoid false matches in comments or nested keys.
+func isPreferDoltConfigured(beadsDir string) bool {
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	data, err := os.ReadFile(configPath) // #nosec G304 - config file path from beadsDir
+	if err != nil {
+		return false
+	}
+
+	var cfg localConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		debug.Logf("Warning: failed to parse config.yaml for prefer-dolt check: %v", err)
+		return false
+	}
+
+	return cfg.PreferDolt
 }
 
 // getLocalSyncBranch reads sync-branch from the local config.yaml file.

--- a/cmd/bd/backend.go
+++ b/cmd/bd/backend.go
@@ -142,6 +142,15 @@ Displays:
 				}
 			}
 
+			// Add migration info for SQLite backends (agent detection path)
+			if backend == configfile.BackendSQLite {
+				result["migration_available"] = true
+				if isPreferDoltConfigured(beadsDir) {
+					result["needs_migration"] = true
+					result["migration_command"] = "bd migrate dolt"
+				}
+			}
+
 			outputJSON(result)
 			return
 		}

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -329,6 +329,11 @@ func runDiagnostics(path string) doctorResult {
 		result.OverallOK = false
 	}
 
+	// Check 2d: Backend migration (SQLite + prefer-dolt → recommend Dolt)
+	backendMigrationCheck := convertDoctorCheck(doctor.CheckBackendMigration(path))
+	result.Checks = append(result.Checks, backendMigrationCheck)
+	// Don't fail overall check for backend migration, just warn
+
 	// Check 3: ID format (hash vs sequential)
 	idCheck := convertWithCategory(doctor.CheckIDFormat(path), doctor.CategoryCore)
 	result.Checks = append(result.Checks, idCheck)

--- a/cmd/bd/doctor/backend_migration.go
+++ b/cmd/bd/doctor/backend_migration.go
@@ -1,0 +1,63 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"gopkg.in/yaml.v3"
+)
+
+// CheckBackendMigration checks if the backend needs migration from SQLite to Dolt.
+// This is triggered when prefer-dolt: true is set in config.yaml but the backend is still SQLite.
+func CheckBackendMigration(path string) DoctorCheck {
+	backend, beadsDir := getBackendAndBeadsDir(path)
+
+	// Already on Dolt — all good
+	if backend == configfile.BackendDolt {
+		return DoctorCheck{
+			Name:     "Backend Migration",
+			Status:   StatusOK,
+			Message:  "Backend: Dolt",
+			Category: CategoryCore,
+		}
+	}
+
+	// SQLite backend — check if prefer-dolt is configured
+	if !isPreferDoltConfigured(beadsDir) {
+		return DoctorCheck{
+			Name:     "Backend Migration",
+			Status:   StatusOK,
+			Message:  "Backend: SQLite",
+			Category: CategoryCore,
+		}
+	}
+
+	// SQLite + prefer-dolt set → recommend migration
+	return DoctorCheck{
+		Name:     "Backend Migration",
+		Status:   StatusWarning,
+		Message:  "SQLite backend detected, Dolt migration recommended",
+		Fix:      "Run 'bd migrate dolt' to upgrade to Dolt backend",
+		Category: CategoryCore,
+	}
+}
+
+// isPreferDoltConfigured checks if prefer-dolt: true is set in config.yaml.
+// Uses proper YAML parsing following the isNoDbModeConfigured pattern.
+func isPreferDoltConfigured(beadsDir string) bool {
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	data, err := os.ReadFile(configPath) // #nosec G304 - config file path from beadsDir
+	if err != nil {
+		return false
+	}
+
+	var cfg struct {
+		PreferDolt bool `yaml:"prefer-dolt"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return false
+	}
+
+	return cfg.PreferDolt
+}

--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -21,10 +21,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// localConfig represents the config.yaml structure for no-db mode detection
+// localConfig represents the config.yaml structure for no-db and prefer-dolt detection
 type localConfig struct {
 	SyncBranch string `yaml:"sync-branch"`
 	NoDb       bool   `yaml:"no-db"`
+	PreferDolt bool   `yaml:"prefer-dolt"`
 }
 
 // CheckDatabaseVersion checks the database version and migration status

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -430,6 +430,11 @@ var rootCmd = &cobra.Command{
 		// Protect forks from accidentally committing upstream issue database
 		ensureForkProtection()
 
+		// Show migration hint if SQLite + prefer-dolt configured (rate-limited, non-blocking)
+		if hintDir := beads.FindBeadsDir(); hintDir != "" {
+			maybeShowMigrationHint(hintDir)
+		}
+
 		// Performance profiling setup
 		// When --profile is enabled, force direct mode to capture actual database operations
 		// rather than just RPC serialization/network overhead. This gives accurate profiles

--- a/cmd/bd/migrate_dolt_cmd.go
+++ b/cmd/bd/migrate_dolt_cmd.go
@@ -1,0 +1,44 @@
+//go:build cgo
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var migrateDoltCmd = &cobra.Command{
+	Use:   "dolt",
+	Short: "Migrate from SQLite to Dolt backend",
+	Long: `Migrate the current beads installation from SQLite to Dolt backend.
+
+This command:
+  1. Creates a backup of the SQLite database
+  2. Creates a Dolt database in .beads/dolt/
+  3. Imports all issues, labels, dependencies, and events
+  4. Copies all config values
+  5. Updates metadata.json to use Dolt backend
+
+The original SQLite database is preserved (can be deleted after verification).
+
+Examples:
+  bd migrate dolt            # Interactive migration with confirmation
+  bd migrate dolt --dry-run  # Preview what would happen
+  bd migrate dolt --yes      # Non-interactive (for automation)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		autoYes, _ := cmd.Flags().GetBool("yes")
+
+		// Block writes in readonly mode (migration modifies data)
+		if !dryRun {
+			CheckReadonly("migrate dolt")
+		}
+
+		handleToDoltMigration(dryRun, autoYes)
+	},
+}
+
+func init() {
+	migrateDoltCmd.Flags().Bool("dry-run", false, "Preview migration without making changes")
+	migrateDoltCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt (for automation)")
+	migrateCmd.AddCommand(migrateDoltCmd)
+}

--- a/cmd/bd/migrate_dolt_cmd_nocgo.go
+++ b/cmd/bd/migrate_dolt_cmd_nocgo.go
@@ -1,0 +1,35 @@
+//go:build !cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var migrateDoltCmd = &cobra.Command{
+	Use:   "dolt",
+	Short: "Migrate from SQLite to Dolt backend",
+	Long:  `Migrate the current beads installation from SQLite to Dolt backend. (Requires CGO)`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"error":   "dolt_not_available",
+				"message": "Dolt backend requires CGO. This binary was built without CGO support.",
+			})
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: Dolt backend requires CGO\n")
+			fmt.Fprintf(os.Stderr, "This binary was built without CGO support.\n")
+			fmt.Fprintf(os.Stderr, "To use Dolt, rebuild with: CGO_ENABLED=1 go build\n")
+		}
+		os.Exit(1)
+	},
+}
+
+func init() {
+	migrateDoltCmd.Flags().Bool("dry-run", false, "Preview migration without making changes")
+	migrateDoltCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt (for automation)")
+	migrateCmd.AddCommand(migrateDoltCmd)
+}

--- a/cmd/bd/migration_hint.go
+++ b/cmd/bd/migration_hint.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/debug"
+	"gopkg.in/yaml.v3"
+)
+
+// migrationHintCooldown is the minimum duration between migration hints (24 hours).
+const migrationHintCooldown = 24 * time.Hour
+
+// maybeShowMigrationHint prints a one-time stderr hint when the rig is on SQLite
+// but prefer-dolt is configured. Rate-limited to once per 24 hours via a timestamp file.
+// Non-blocking: returns immediately, commands continue normally with SQLite.
+func maybeShowMigrationHint(beadsDir string) {
+	// Don't show hints in JSON or quiet mode
+	if jsonOutput || quietFlag {
+		return
+	}
+
+	// Check if backend is already Dolt
+	cfg, err := configfile.Load(beadsDir)
+	if err == nil && cfg != nil && cfg.GetBackend() == configfile.BackendDolt {
+		return
+	}
+
+	// Check if prefer-dolt is configured
+	if !isPreferDoltConfiguredLocal(beadsDir) {
+		return
+	}
+
+	// Rate-limit: check timestamp file
+	tsFile := filepath.Join(beadsDir, ".migration-hint-ts")
+	if data, err := os.ReadFile(tsFile); err == nil { // #nosec G304 - path from beadsDir
+		if ts, err := strconv.ParseInt(string(data), 10, 64); err == nil {
+			lastShown := time.Unix(ts, 0)
+			if time.Since(lastShown) < migrationHintCooldown {
+				return
+			}
+		}
+	}
+
+	// Show the hint
+	fmt.Fprintf(os.Stderr, "Note: This rig uses SQLite but Dolt is preferred. Run 'bd migrate dolt' to upgrade.\n")
+
+	// Write current timestamp (best-effort)
+	tsStr := strconv.FormatInt(time.Now().Unix(), 10)
+	if err := os.WriteFile(tsFile, []byte(tsStr), 0600); err != nil {
+		debug.Logf("warning: failed to write migration hint timestamp: %v", err)
+	}
+}
+
+// isPreferDoltConfiguredLocal checks if prefer-dolt: true is set in config.yaml.
+// This is a package-local copy following the isNoDbModeConfigured pattern in autoimport.go.
+func isPreferDoltConfiguredLocal(beadsDir string) bool {
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	data, err := os.ReadFile(configPath) // #nosec G304 - config file path from beadsDir
+	if err != nil {
+		return false
+	}
+
+	var cfg struct {
+		PreferDolt bool `yaml:"prefer-dolt"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		debug.Logf("warning: failed to parse config.yaml for prefer-dolt check: %v", err)
+		return false
+	}
+
+	return cfg.PreferDolt
+}


### PR DESCRIPTION
## Summary

- Add `bd migrate dolt` subcommand (with cgo/nocgo stubs) wrapping existing `handleToDoltMigration`
- Add `prefer-dolt` config detection in `localConfig` structs (autoimport.go, doctor/database.go)
- Add `bd doctor` check: warns when SQLite backend + `prefer-dolt: true` in config.yaml
- Enhance `bd backend show --json` with `needs_migration`, `migration_command`, `migration_available` fields for agent detection
- Add rate-limited stderr migration hint in PersistentPreRun for non-agent users (once per 24h)

## Test plan

- [x] `go build ./cmd/bd/` compiles
- [x] `go test ./cmd/bd/doctor/...` passes
- [ ] Manual: set `prefer-dolt: true` in test config.yaml with SQLite backend, verify `bd doctor` shows warning
- [ ] Manual: `bd backend show --json` includes `needs_migration: true` when prefer-dolt set
- [ ] Manual: `bd migrate dolt --dry-run` works as subcommand
- [ ] Manual: stderr hint appears once, then suppressed for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)