### PR TITLE
fix: advisory flock to prevent zombie bd processes from dolt lock contention

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -836,6 +836,17 @@ var rootCmd = &cobra.Command{
 			LockTimeout: lockTimeout,
 		}
 
+		// Set advisory lock timeout for dolt embedded mode.
+		// Reads get a shorter timeout (shared lock, less contention expected).
+		// Writes get a longer timeout (exclusive lock, may need to wait for readers).
+		if backend == configfile.BackendDolt {
+			if useReadOnly {
+				opts.OpenTimeout = 5 * time.Second
+			} else {
+				opts.OpenTimeout = 15 * time.Second
+			}
+		}
+
 		if backend == configfile.BackendDolt {
 			// For Dolt, use the dolt subdirectory
 			doltPath := filepath.Join(beadsDir, "dolt")

--- a/internal/lockfile/lock.go
+++ b/internal/lockfile/lock.go
@@ -2,6 +2,7 @@ package lockfile
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,10 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrLockBusy is returned when a non-blocking lock cannot be acquired
+// because another process holds a conflicting lock.
+var ErrLockBusy = errors.New("lock busy: held by another process")
 
 // LockInfo represents the metadata stored in the daemon.lock file
 type LockInfo struct {

--- a/internal/lockfile/lock_shared_unix.go
+++ b/internal/lockfile/lock_shared_unix.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package lockfile
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// FlockSharedNonBlock acquires a shared non-blocking lock on the file.
+// Multiple processes can hold shared locks concurrently.
+// Returns ErrLockBusy if an exclusive lock is already held.
+func FlockSharedNonBlock(f *os.File) error {
+	err := unix.Flock(int(f.Fd()), unix.LOCK_SH|unix.LOCK_NB)
+	if err == unix.EWOULDBLOCK {
+		return ErrLockBusy
+	}
+	return err
+}
+
+// FlockExclusiveNonBlock acquires an exclusive non-blocking lock on the file.
+// Returns ErrLockBusy if any lock (shared or exclusive) is already held.
+func FlockExclusiveNonBlock(f *os.File) error {
+	err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == unix.EWOULDBLOCK {
+		return ErrLockBusy
+	}
+	return err
+}

--- a/internal/lockfile/lock_shared_wasm.go
+++ b/internal/lockfile/lock_shared_wasm.go
@@ -1,0 +1,15 @@
+//go:build js && wasm
+
+package lockfile
+
+import "os"
+
+// FlockSharedNonBlock is a no-op in WASM (single-process environment).
+func FlockSharedNonBlock(f *os.File) error {
+	return nil
+}
+
+// FlockExclusiveNonBlock is a no-op in WASM (single-process environment).
+func FlockExclusiveNonBlock(f *os.File) error {
+	return nil
+}

--- a/internal/lockfile/lock_shared_windows.go
+++ b/internal/lockfile/lock_shared_windows.go
@@ -1,0 +1,54 @@
+//go:build windows
+
+package lockfile
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// FlockSharedNonBlock acquires a shared non-blocking lock on the file.
+// Multiple processes can hold shared locks concurrently.
+// Returns ErrLockBusy if an exclusive lock is already held.
+func FlockSharedNonBlock(f *os.File) error {
+	// Shared + fail immediately (no LOCKFILE_EXCLUSIVE_LOCK)
+	const flags = windows.LOCKFILE_FAIL_IMMEDIATELY
+
+	ol := &windows.Overlapped{}
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		flags,
+		0,
+		0xFFFFFFFF,
+		0xFFFFFFFF,
+		ol,
+	)
+
+	if err == windows.ERROR_LOCK_VIOLATION || err == syscall.EWOULDBLOCK {
+		return ErrLockBusy
+	}
+	return err
+}
+
+// FlockExclusiveNonBlock acquires an exclusive non-blocking lock on the file.
+// Returns ErrLockBusy if any lock (shared or exclusive) is already held.
+func FlockExclusiveNonBlock(f *os.File) error {
+	const flags = windows.LOCKFILE_EXCLUSIVE_LOCK | windows.LOCKFILE_FAIL_IMMEDIATELY
+
+	ol := &windows.Overlapped{}
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		flags,
+		0,
+		0xFFFFFFFF,
+		0xFFFFFFFF,
+		ol,
+	)
+
+	if err == windows.ERROR_LOCK_VIOLATION || err == syscall.EWOULDBLOCK {
+		return ErrLockBusy
+	}
+	return err
+}

--- a/internal/storage/dolt/access_lock.go
+++ b/internal/storage/dolt/access_lock.go
@@ -1,0 +1,97 @@
+package dolt
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/steveyegge/beads/internal/lockfile"
+)
+
+// AccessLock coordinates access to the embedded Dolt database using flock.
+// Shared locks allow concurrent readers; exclusive locks ensure single-writer.
+// The lock file lives in .beads/dolt-access.lock (alongside daemon.lock).
+type AccessLock struct {
+	file *os.File
+	path string
+}
+
+const (
+	// accessLockFile is the name of the advisory lock file in .beads/.
+	accessLockFile = "dolt-access.lock"
+
+	// lockPollInterval is how often we retry acquiring the lock.
+	lockPollInterval = 50 * time.Millisecond
+)
+
+// AcquireAccessLock acquires an advisory flock on the dolt-access.lock file.
+// If exclusive is true, acquires an exclusive lock (for writes); otherwise shared (for reads).
+// Polls with lockPollInterval until timeout expires. Returns ErrLockBusy on timeout.
+//
+// The doltDir parameter is the path to the dolt data directory (e.g., .beads/dolt).
+// The lock file is placed in the parent directory (.beads/) alongside daemon.lock.
+func AcquireAccessLock(doltDir string, exclusive bool, timeout time.Duration) (*AccessLock, error) {
+	// Lock file goes in parent of dolt dir (i.e., .beads/)
+	beadsDir := filepath.Dir(doltDir)
+	lockPath := filepath.Join(beadsDir, accessLockFile)
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		return nil, fmt.Errorf("create lock dir: %w", err)
+	}
+
+	// Open or create lock file
+	// #nosec G304 - controlled path derived from database configuration
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open access lock: %w", err)
+	}
+
+	// Pick the right lock function
+	lockFn := lockfile.FlockSharedNonBlock
+	if exclusive {
+		lockFn = lockfile.FlockExclusiveNonBlock
+	}
+
+	// Try once immediately
+	if err := lockFn(f); err == nil {
+		return &AccessLock{file: f, path: lockPath}, nil
+	} else if !errors.Is(err, lockfile.ErrLockBusy) {
+		_ = f.Close()
+		return nil, fmt.Errorf("access lock: %w", err)
+	}
+
+	// Poll until timeout
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(lockPollInterval)
+
+		if err := lockFn(f); err == nil {
+			return &AccessLock{file: f, path: lockPath}, nil
+		} else if !errors.Is(err, lockfile.ErrLockBusy) {
+			_ = f.Close()
+			return nil, fmt.Errorf("access lock: %w", err)
+		}
+	}
+
+	_ = f.Close()
+	kind := "shared"
+	if exclusive {
+		kind = "exclusive"
+	}
+	return nil, fmt.Errorf("dolt access lock timeout (%s, %v): another bd process is using the database: %w",
+		kind, timeout, lockfile.ErrLockBusy)
+}
+
+// Release releases the advisory lock and closes the underlying file.
+// Safe to call multiple times (idempotent).
+func (l *AccessLock) Release() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = lockfile.FlockUnlock(l.file)
+	_ = l.file.Close()
+	l.file = nil
+}

--- a/internal/storage/factory/factory.go
+++ b/internal/storage/factory/factory.go
@@ -26,6 +26,7 @@ func RegisterBackend(name string, factory BackendFactory) {
 type Options struct {
 	ReadOnly    bool
 	LockTimeout time.Duration
+	OpenTimeout time.Duration // Advisory lock timeout for dolt embedded mode (0 = no lock)
 
 	// Dolt server mode options (federation)
 	ServerMode bool   // Connect to dolt sql-server instead of embedded

--- a/internal/storage/factory/factory_dolt.go
+++ b/internal/storage/factory/factory_dolt.go
@@ -45,13 +45,14 @@ func init() {
 		}
 
 		return dolt.New(ctx, &dolt.Config{
-			Path:       path,
-			Database:   opts.Database,
-			ReadOnly:   opts.ReadOnly,
-			ServerMode: opts.ServerMode,
-			ServerHost: opts.ServerHost,
-			ServerPort: opts.ServerPort,
-			ServerUser: opts.ServerUser,
+			Path:        path,
+			Database:    opts.Database,
+			ReadOnly:    opts.ReadOnly,
+			OpenTimeout: opts.OpenTimeout,
+			ServerMode:  opts.ServerMode,
+			ServerHost:  opts.ServerHost,
+			ServerPort:  opts.ServerPort,
+			ServerUser:  opts.ServerUser,
 		})
 	})
 }


### PR DESCRIPTION
## Summary

- Adds a beads-level advisory lock (`dolt-access.lock`) using `flock` that bd processes acquire **before** opening embedded dolt, preventing them from blocking on dolt's internal LOCK file and hanging indefinitely
- Read-only commands (list, show, stats, etc.) use **shared** locks -- multiple readers run concurrently with zero contention
- Write commands (create, close, update, etc.) use **exclusive** locks -- single writer, fails fast with clear error if busy
- Timeouts: 5s for reads, 15s for writes -- fail fast instead of hanging forever
- `flock` auto-releases on process exit (even SIGKILL), so no stale lock cleanup needed

## Problem

Multiple concurrent bd processes (deacon patrol, activity watcher, mail polling, Claude Code hooks) all open embedded dolt, which requires an exclusive LOCK file at `.dolt/noms/LOCK`. They block each other and hang indefinitely, creating zombie processes.

## Changes

**New files (4):**
- `internal/lockfile/lock_shared_{unix,windows,wasm}.go` -- platform-specific shared/exclusive non-blocking flock
- `internal/storage/dolt/access_lock.go` -- `AcquireAccessLock`/`Release` coordinator with polling timeout

**Modified files (5):**
- `internal/lockfile/lock.go` -- add exported `ErrLockBusy` error
- `internal/storage/dolt/store.go` -- acquire advisory lock in `New()`, context timeout in `openEmbeddedConnection()`, release in `Close()`
- `internal/storage/factory/factory.go` -- add `OpenTimeout` to `Options`
- `internal/storage/factory/factory_dolt.go` -- thread `OpenTimeout` to dolt `Config`
- `cmd/bd/main.go` -- set `OpenTimeout` based on read/write (5s/15s)

## Test plan

- [ ] `go build ./...` compiles on all platforms
- [ ] `go test ./internal/lockfile/...` passes
- [ ] `go test ./internal/storage/dolt/...` passes
- [ ] Manual: `bd list` while another write command is active -- succeeds immediately (shared lock)
- [ ] Manual: two `bd create` simultaneously -- second fails fast with clear error
- [ ] Manual: kill bd mid-operation, run another command -- succeeds (flock auto-released)
