### PR TITLE
fix(dolt): remove FK constraint on depends_on_id for external references

### DIFF
--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -577,4 +577,102 @@ func TestGetNewlyUnblockedByClose_ClosedDependent(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// External Dependency Tests (cross-rig references)
+// =============================================================================
+
+func TestAddDependency_ExternalReference(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Create a local issue
+	issue := &types.Issue{
+		ID:        "ext-dep-issue",
+		Title:     "Issue with External Dependency",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+
+	// Add dependency on external reference (cross-rig tracking)
+	// This should NOT fail with FK violation after the fix
+	externalRef := "external:da:da-7eo"
+	dep := &types.Dependency{
+		IssueID:     issue.ID,
+		DependsOnID: externalRef,
+		Type:        types.DepBlocks,
+	}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("failed to add external dependency: %v", err)
+	}
+
+	// Verify the dependency was created
+	records, err := store.GetDependencyRecords(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords failed: %v", err)
+	}
+
+	if len(records) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(records))
+	}
+
+	if records[0].DependsOnID != externalRef {
+		t.Errorf("expected DependsOnID %q, got %q", externalRef, records[0].DependsOnID)
+	}
+}
+
+func TestAddDependency_MultipleExternalReferences(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Create a convoy-like issue
+	convoy := &types.Issue{
+		ID:        "convoy-test",
+		Title:     "Test Convoy",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, convoy, "tester"); err != nil {
+		t.Fatalf("failed to create convoy: %v", err)
+	}
+
+	// Add multiple external dependencies (simulating cross-rig tracking)
+	externalRefs := []string{
+		"external:da:da-7eo",
+		"external:da:da-1nw",
+		"external:gt:gt-abc",
+	}
+
+	for _, ref := range externalRefs {
+		dep := &types.Dependency{
+			IssueID:     convoy.ID,
+			DependsOnID: ref,
+			Type:        "tracks", // convoy tracking type
+		}
+		if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("failed to add external dependency %s: %v", ref, err)
+		}
+	}
+
+	// Verify all dependencies were created
+	records, err := store.GetDependencyRecords(ctx, convoy.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords failed: %v", err)
+	}
+
+	if len(records) != len(externalRefs) {
+		t.Errorf("expected %d dependencies, got %d", len(externalRefs), len(records))
+	}
+}
+
 // Note: testContext is already defined in dolt_test.go for this package

--- a/internal/storage/dolt/schema.go
+++ b/internal/storage/dolt/schema.go
@@ -86,6 +86,8 @@ CREATE TABLE IF NOT EXISTS issues (
 );
 
 -- Dependencies table (edge schema)
+-- Note: No FK on depends_on_id to allow external references (external:<rig>:<id>).
+-- See SQLite migration 025_remove_depends_on_fk.go for design context.
 CREATE TABLE IF NOT EXISTS dependencies (
     issue_id VARCHAR(255) NOT NULL,
     depends_on_id VARCHAR(255) NOT NULL,
@@ -99,8 +101,7 @@ CREATE TABLE IF NOT EXISTS dependencies (
     INDEX idx_dependencies_depends_on (depends_on_id),
     INDEX idx_dependencies_depends_on_type (depends_on_id, type),
     INDEX idx_dependencies_thread (thread_id),
-    CONSTRAINT fk_dep_issue FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE,
-    CONSTRAINT fk_dep_depends_on FOREIGN KEY (depends_on_id) REFERENCES issues(id) ON DELETE CASCADE
+    CONSTRAINT fk_dep_issue FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE
 );
 
 -- Labels table


### PR DESCRIPTION
## Summary

Removes the `fk_dep_depends_on` foreign key constraint from the Dolt dependencies table to allow cross-rig tracking with external references (`external:<rig>:<id>`).

**Problem:** When creating a convoy in HQ that tracks issues in other rigs, Dolt fails with FK violation:
```
gt convoy create "War game improvements" da-7eo da-1nw ...
⚠ Warning: couldn't track da-7eo: Error: failed to add dependency: Error 1452 (HY000): 
cannot add or update a child row - Foreign key violation on fk: `fk_dep_depends_on`
```

**Solution:** Mirror SQLite migration 025 - remove the FK constraint on `depends_on_id` while keeping the FK on `issue_id` (source must exist). External references are validated at query time by `external_deps.go`.

## Changes

- **schema.go**: Remove `fk_dep_depends_on` constraint from dependencies table definition
- **store.go**: Add idempotent migration to drop constraint from existing databases
- **dependencies_extended_test.go**: Add tests for external reference dependencies

## Test plan

- [x] New tests for external references pass
- [x] Existing Dolt tests pass
- [x] Single commit, single concern

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)