### PR TITLE
docs: add Beads Task-Issue Tracker to Community Tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -47,6 +47,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 ## Native Apps
 
+- **[Beads Task-Issue Tracker](https://github.com/w3dev33/beads-task-issue-tracker)** - Cross-platform desktop application (macOS, Windows, Linux) for browsing, creating, and managing Beads issues with a visual interface. Features multi-project support with favorites, image attachments, dashboard with statistics, advanced filtering, and dark/light theme. Built by [@w3dev33](https://github.com/w3dev33). (Tauri/Vue)
+
 - **[Beadster](https://github.com/beadster/beadster)** - macOS app for browsing and managing issues from `.beads/` directories in git repositories. Built by [@podviaznikov](https://github.com/podviaznikov). (Swift)
 
 -  **[Parade](https://github.com/JeremyKalmus/parade)** - Electron app for workflow orchestration with visual Kanban board, discovery wizard, and task visualization. Run with `npx parade-init`. Built by [@JeremyKalmus](https://github.com/JeremyKalmus). (Electron/React)


### PR DESCRIPTION
## Summary

Adds **Beads Task-Issue Tracker** to the Native Apps section in `docs/COMMUNITY_TOOLS.md`.

This is a cross-platform desktop application (macOS, Windows, Linux) built with:
- **Tauri 2** (Rust backend)
- **Nuxt 4 / Vue 3** (frontend framework)

### Features

- **Multi-project support** with favorites for quick switching
- **Image attachments** for issues
- **Dashboard** with statistics overview
- **Advanced filtering** by status, priority, labels, etc.
- **Dark/light theme**

Repository: https://github.com/w3dev33/beads-task-issue-tracker

## Screenshot

![App Overview](https://github.com/w3dev33/beads-task-issue-tracker/raw/master/docs/screenshots/app-overview-1.6.4.png)