### PR TITLE
feat(config): support .beads/config.local.yaml for local overrides

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -36,6 +36,7 @@ beads.right.meta.json
 # These files are machine-specific and should not be shared across clones
 .sync.lock
 sync_base.jsonl
+config.local.yaml
 
 # Gas Town runtime files (local state)
 .gt-types-configured

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,18 @@ func Initialize() error {
 			return fmt.Errorf("error reading config file: %w", err)
 		}
 		debug.Logf("Debug: loaded config from %s\n", v.ConfigFileUsed())
+
+		// Merge local config overrides if present (config.local.yaml)
+		// This allows machine-specific settings without polluting tracked config
+		configDir := filepath.Dir(v.ConfigFileUsed())
+		localConfigPath := filepath.Join(configDir, "config.local.yaml")
+		if _, err := os.Stat(localConfigPath); err == nil {
+			v.SetConfigFile(localConfigPath)
+			if err := v.MergeInConfig(); err != nil {
+				return fmt.Errorf("error merging local config file: %w", err)
+			}
+			debug.Logf("Debug: merged local config from %s\n", localConfigPath)
+		}
 	} else {
 		// No config.yaml found - use defaults and environment variables
 		debug.Logf("Debug: no config.yaml found; using defaults and environment variables\n")


### PR DESCRIPTION
## Summary

Add support for a `.beads/config.local.yaml` file that allows machine-specific settings without polluting the tracked project config.

**Changes:**
- In `Initialize()`, after loading `config.yaml`, check for `config.local.yaml` in the same directory and merge it using Viper's `MergeInConfig()`
- Add `config.local.yaml` to `.beads/.gitignore`
- Add tests for local config override and missing local config scenarios

**Use case:** Different clones may use different backends (SQLite vs Dolt) requiring different local settings like `no-daemon: true`. Currently these local preferences get tracked in `config.yaml` and cause merge conflicts on `git pull`.

## Test plan

- [x] Added `TestLocalConfigOverride` - verifies local config values override project config
- [x] Added `TestLocalConfigMissing` - verifies missing local config doesn't cause errors
- [x] All existing config tests pass

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)