### PR TITLE
fix(lint): use secure file permissions for lock file (G302)

### DIFF
--- a/internal/storage/dolt/access_lock.go
+++ b/internal/storage/dolt/access_lock.go
@@ -44,7 +44,7 @@ func AcquireAccessLock(doltDir string, exclusive bool, timeout time.Duration) (*
 
 	// Open or create lock file
 	// #nosec G304 - controlled path derived from database configuration
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open access lock: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Change lock file permissions from 0644 to 0600 to satisfy gosec G302
- Lock files don't need to be world-readable

## Test plan
- [x] `golangci-lint run` passes for this file
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)