### PR TITLE
fix(lint): handle rows.Close() errors explicitly (G104)

### DIFF
--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -563,7 +563,7 @@ func (s *DoltStore) scanIssueIDs(ctx context.Context, rows *sql.Rows) ([]*types.
 	// result sets on one connection - the first must be closed before starting
 	// a new query, otherwise "driver: bad connection" errors occur.
 	// Closing here is safe because sql.Rows.Close() is idempotent.
-	rows.Close()
+	_ = rows.Close()
 
 	if len(ids) == 0 {
 		return nil, nil

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -142,16 +142,16 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return nil, err
 		}
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return nil, err
 	}
-	rows.Close()
+	_ = rows.Close()
 
 	// Now fetch each issue (safe since rows is closed)
 	var issues []*types.Issue


### PR DESCRIPTION
## Summary
- Explicitly ignore `rows.Close()` return values with blank identifier to satisfy gosec G104
- Affects `dependencies.go` (1 place) and `transaction.go` (3 places)

The error is intentionally ignored because:
- Close errors are not actionable (we're closing anyway)
- The close is for resource cleanup, not data integrity
- This is standard Go idiom for `defer rows.Close()` scenarios

## Test plan
- [x] `golangci-lint run` passes for these files
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)