### PR TITLE
fix(nix): allow Go toolchain auto-download for version compatibility

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,10 @@ pkgs.buildGoModule {
   # Go module dependencies hash - if build fails with hash mismatch, update with the "got:" value
   vendorHash = "sha256-YU+bRLVlWtHzJ1QPzcKJ70f+ynp8lMoIeFlm+29BNPE=";
 
+  # Allow Go toolchain to auto-download newer version if needed
+  # (go.mod requires 1.25.6+ but nixpkgs may have older)
+  env.GOTOOLCHAIN = "auto";
+
   # Git is required for tests
   nativeBuildInputs = [ pkgs.git ];
 


### PR DESCRIPTION
## Summary
Set `GOTOOLCHAIN=auto` in Nix build to allow Go to auto-download the required version (1.25.6) when nixpkgs has an older version.

This fixes the CI failure:
```
go.mod requires go >= 1.25.6 (running go 1.25.1; GOTOOLCHAIN=local)
```

## Test plan
- [ ] CI Nix flake test passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)