### PR TITLE
fix(doctor): use read-only mode to avoid creating database

### DIFF
--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -187,14 +187,15 @@ func CheckDuplicateIssues(path string, gastownMode bool, gastownThreshold int) D
 	// Follow redirect to resolve actual beads directory (bd-tvus fix)
 	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
 
-	// Open store using factory to respect backend configuration (bd-m2jr: SQLite fallback fix)
+	// Open store using factory in read-only mode to avoid creating new database.
+	// ReadOnly mode fails if database doesn't exist.
 	ctx := context.Background()
-	store, err := factory.NewFromConfig(ctx, beadsDir)
+	store, err := factory.NewFromConfigWithOptions(ctx, beadsDir, factory.Options{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Duplicate Issues",
-			Status:  "ok",
-			Message: "N/A (unable to open database)",
+			Status:  StatusOK,
+			Message: "N/A (no database)",
 		}
 	}
 	defer func() { _ = store.Close() }()


### PR DESCRIPTION
## Summary
`CheckDuplicateIssues` was creating a new empty database when checking a directory without an existing database, causing it to report "No duplicate issues" instead of "N/A (no database)".

Use `factory.Options{ReadOnly: true}` which fails if the database doesn't exist, giving the expected behavior.

Fixes `TestCheckDuplicateIssues_NoDatabase`.

## Test plan
- [x] `go test -run TestCheckDuplicateIssues ./cmd/bd/doctor` passes (all 10 tests)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)