### PR TITLE
fix(test): use atomic counter to fix data race in gitlab test

### DIFF
--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -853,13 +854,13 @@ func TestFetchIssues_ContextCancellation(t *testing.T) {
 
 // TestFetchIssuesSince_ContextCancellation verifies that FetchIssuesSince respects context cancellation.
 func TestFetchIssuesSince_ContextCancellation(t *testing.T) {
-	requestCount := 0
+	var requestCount atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		count := requestCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		// Always return X-Next-Page to continue pagination
 		w.Header().Set("X-Next-Page", "2")
-		_ = json.NewEncoder(w).Encode([]Issue{{ID: requestCount, IID: requestCount, Title: "Issue"}})
+		_ = json.NewEncoder(w).Encode([]Issue{{ID: int(count), IID: int(count), Title: "Issue"}})
 	}))
 	defer server.Close()
 
@@ -883,10 +884,10 @@ func TestFetchIssuesSince_ContextCancellation(t *testing.T) {
 		t.Errorf("error = %v, want context.Canceled or error containing 'context canceled'", err)
 	}
 	// Verify the loop was stopped (not infinite) - requestCount should be reasonable
-	if requestCount > 1000 {
-		t.Errorf("requestCount = %d, expected loop to stop due to context cancellation", requestCount)
+	if requestCount.Load() > 1000 {
+		t.Errorf("requestCount = %d, expected loop to stop due to context cancellation", requestCount.Load())
 	}
 	// Note: partial results may or may not be returned depending on whether cancellation
 	// was caught by our loop check (returns partial) or by doRequest (returns nil)
-	t.Logf("Context cancelled after %d requests, %d issues returned", requestCount, len(issues))
+	t.Logf("Context cancelled after %d requests, %d issues returned", requestCount.Load(), len(issues))
 }


### PR DESCRIPTION
## Summary
`TestFetchIssuesSince_ContextCancellation` had a data race where `requestCount` was:
- Written by the HTTP handler goroutine
- Read by the test goroutine

without synchronization.

Use `sync/atomic.Int64` to make the counter thread-safe.

## Test plan
- [x] `go test -race -run TestFetchIssuesSince_ContextCancellation ./internal/gitlab` passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)