### PR TITLE
fix(compact): restore safety logic accidentally removed in cb1e3555

### DIFF
--- a/internal/compact/compactor_unit_test.go
+++ b/internal/compact/compactor_unit_test.go
@@ -66,11 +66,20 @@ type stubSummarizer struct {
 	summary string
 	err     error
 	calls   int
+	mu      sync.Mutex
 }
 
 func (s *stubSummarizer) SummarizeTier1(ctx context.Context, issue *types.Issue) (string, error) {
+	s.mu.Lock()
 	s.calls++
+	s.mu.Unlock()
 	return s.summary, s.err
+}
+
+func (s *stubSummarizer) getCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
 }
 
 func stubIssue() *types.Issue {


### PR DESCRIPTION
## Summary

Commit `cb1e3555` ("refactor(rpc): fix leaky abstraction") accidentally rewrote `CompactTier1()` and removed critical safety features.

### Restored functionality:

| Feature | Before fix | After fix |
|---------|-----------|-----------|
| `CheckEligibility()` | ❌ Removed | ✅ Called first (fail fast) |
| DryRun behavior | Returns `nil` (silent) | Returns error with details |
| Size check | ❌ Removed | ✅ Skip if summary ≥ original |
| Git hash capture | Hardcoded `""` | ✅ `GetCurrentCommitHash()` |
| Skip warning | Always "applied" | ✅ "skipped" when appropriate |

### Also fixed:
- **Data race** in `stubSummarizer.calls` - added mutex for thread-safe access in batch test

## Root cause analysis

The tests were correct - they defined the original intended behavior from commit `65f59e6b`. The regression was introduced when an AI agent ("opal") was doing an interface refactor but accidentally rewrote the core business logic.

## Test plan
- [x] `go test -race -run TestCompactTier1 ./internal/compact` - all 6 tests pass
- [x] No data race warnings
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)