### PR TITLE
fix(dolt): remove fk_dep_depends_on to allow external refs

### DIFF
--- a/internal/storage/dolt/schema.go
+++ b/internal/storage/dolt/schema.go
@@ -99,8 +99,8 @@ CREATE TABLE IF NOT EXISTS dependencies (
     INDEX idx_dependencies_depends_on (depends_on_id),
     INDEX idx_dependencies_depends_on_type (depends_on_id, type),
     INDEX idx_dependencies_thread (thread_id),
-    CONSTRAINT fk_dep_issue FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE,
-    CONSTRAINT fk_dep_depends_on FOREIGN KEY (depends_on_id) REFERENCES issues(id) ON DELETE CASCADE
+    CONSTRAINT fk_dep_issue FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE
+    -- Note: fk_dep_depends_on removed to allow external refs (matches SQLite migration 025)
 );
 
 -- Labels table

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -366,6 +366,13 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		}
 	}
 
+	// Drop fk_dep_depends_on to allow external refs (matches SQLite migration 025).
+	// The depends_on_id can reference issues in other databases (external refs).
+	if _, fkErr := db.ExecContext(ctx, "ALTER TABLE dependencies DROP FOREIGN KEY fk_dep_depends_on"); fkErr != nil {
+		// Ignore errors - constraint may not exist in new databases or already dropped
+		_ = fkErr
+	}
+
 	// Create views
 	if _, err := db.ExecContext(ctx, readyIssuesView); err != nil {
 		return fmt.Errorf("failed to create ready_issues view: %w", err)


### PR DESCRIPTION
## Summary

Removes the `fk_dep_depends_on` foreign key constraint from the Dolt `dependencies` table to match SQLite migration 025. This constraint blocks external references (`external:<project>:<capability>`) which are a supported feature in beads.

## Problem

When using Dolt storage backend, inserting dependencies with external references fails with:

```
Error 1452 (HY000): cannot add or update a child row - Foreign key violation on fk: `fk_dep_depends_on`, 
table: `dependencies`, referenced table: `issues`, key: `[external:oe-fgri:oe-fgri]`
```

This occurs because `depends_on_id` can legitimately reference:
- External capabilities (`external:<project>:<capability>`)
- Issues in other databases (multi-rig setups)

The SQLite backend already handles this correctly via migration 025 (`025_remove_depends_on_fk.go`), but the Dolt schema was not updated to match.

## Solution

1. **schema.go**: Remove `fk_dep_depends_on` constraint from table definition, add comment explaining why
2. **store.go**: Add migration to drop the FK on existing databases (idempotent - ignores errors if constraint doesn't exist)

## Testing

Verified in a Gas Town multi-rig Dolt setup:
- External reference dependencies now insert successfully
- Existing functionality unaffected
- Migration runs cleanly on both new and existing databases

## Design Context

See `025_remove_depends_on_fk.go` which documents the original design decision for SQLite. The `issue_id` FK is retained (source issue must exist), only the `depends_on_id` FK is removed (target can be external).