### PR TITLE
feat: allow UpdateIssue metadata updates via json.RawMessage/[]byte

### DIFF
--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -337,6 +337,13 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 		if key == "waiters" {
 			waitersJSON, _ := json.Marshal(value)
 			args = append(args, string(waitersJSON))
+		} else if key == "metadata" {
+			// GH#1417: Normalize metadata to string, accepting string/[]byte/json.RawMessage
+			metadataStr, err := storage.NormalizeMetadataValue(value)
+			if err != nil {
+				return fmt.Errorf("invalid metadata: %w", err)
+			}
+			args = append(args, metadataStr)
 		} else {
 			args = append(args, value)
 		}

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -1,0 +1,34 @@
+// Package storage defines the interface for issue storage backends.
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// NormalizeMetadataValue converts metadata values to a validated JSON string.
+// Accepts string, []byte, or json.RawMessage and returns a validated JSON string.
+// Returns an error if the value is not valid JSON or is an unsupported type.
+//
+// This supports GH#1417: allow UpdateIssue metadata updates via json.RawMessage/[]byte.
+func NormalizeMetadataValue(value interface{}) (string, error) {
+	var jsonStr string
+
+	switch v := value.(type) {
+	case string:
+		jsonStr = v
+	case []byte:
+		jsonStr = string(v)
+	case json.RawMessage:
+		jsonStr = string(v)
+	default:
+		return "", fmt.Errorf("metadata must be string, []byte, or json.RawMessage, got %T", value)
+	}
+
+	// Validate that it's valid JSON
+	if !json.Valid([]byte(jsonStr)) {
+		return "", fmt.Errorf("metadata is not valid JSON")
+	}
+
+	return jsonStr, nil
+}

--- a/internal/storage/metadata_test.go
+++ b/internal/storage/metadata_test.go
@@ -1,0 +1,95 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeMetadataValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "string input",
+			input:   `{"key":"value"}`,
+			want:    `{"key":"value"}`,
+			wantErr: false,
+		},
+		{
+			name:    "[]byte input",
+			input:   []byte(`{"key":"value"}`),
+			want:    `{"key":"value"}`,
+			wantErr: false,
+		},
+		{
+			name:    "json.RawMessage input",
+			input:   json.RawMessage(`{"key":"value"}`),
+			want:    `{"key":"value"}`,
+			wantErr: false,
+		},
+		{
+			name:    "empty object string",
+			input:   `{}`,
+			want:    `{}`,
+			wantErr: false,
+		},
+		{
+			name:    "empty object []byte",
+			input:   []byte(`{}`),
+			want:    `{}`,
+			wantErr: false,
+		},
+		{
+			name:    "complex JSON",
+			input:   `{"files":["foo.go","bar.go"],"tool":"linter@1.0"}`,
+			want:    `{"files":["foo.go","bar.go"],"tool":"linter@1.0"}`,
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON string",
+			input:   `{invalid}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON []byte",
+			input:   []byte(`not json`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON json.RawMessage",
+			input:   json.RawMessage(`{broken`),
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type int",
+			input:   123,
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type map",
+			input:   map[string]string{"key": "value"},
+			wantErr: true,
+		},
+		{
+			name:    "unsupported type struct",
+			input:   struct{ Key string }{Key: "value"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeMetadataValue(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeMetadataValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("NormalizeMetadataValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/storage/sqlite/queries.go
+++ b/internal/storage/sqlite/queries.go
@@ -950,6 +950,13 @@ func (s *SQLiteStorage) UpdateIssue(ctx context.Context, id string, updates map[
 		if key == "waiters" {
 			waitersJSON, _ := json.Marshal(value)
 			args = append(args, string(waitersJSON))
+		} else if key == "metadata" {
+			// GH#1417: Normalize metadata to string, accepting string/[]byte/json.RawMessage
+			metadataStr, err := storage.NormalizeMetadataValue(value)
+			if err != nil {
+				return fmt.Errorf("invalid metadata: %w", err)
+			}
+			args = append(args, metadataStr)
 		} else {
 			args = append(args, value)
 		}


### PR DESCRIPTION
## Summary

Add `NormalizeMetadataValue` helper that accepts `string`, `[]byte`, or `json.RawMessage` for metadata updates, making the programmatic API more convenient for callers.

## Changes

- `internal/storage/metadata.go` — New `NormalizeMetadataValue(value interface{}) (string, error)` helper
- `internal/storage/metadata_test.go` — Unit tests (12 test cases)
- `internal/storage/sqlite/queries.go` — SQLite `UpdateIssue` integration
- `internal/storage/sqlite/metadata_test.go` — Integration tests (4 new test cases)  
- `internal/storage/dolt/issues.go` — Dolt `UpdateIssue` integration

## Usage

```go
// All three now work:
store.UpdateIssue(ctx, id, map[string]interface{}{
    "metadata": `{"key":"value"}`,           // string (existing)
    "metadata": []byte(`{"key":"value"}`),   // []byte (new)
    "metadata": json.RawMessage(`{...}`),    // json.RawMessage (new)
}, actor)
```

Invalid JSON or unsupported types return clear errors.

## Related Issues & PRs

**Closes:** #1417 

**Parent feature:**
- #1406 — Original feature request for metadata field
- #1407 — PR that added the metadata field (SQLite + Dolt)
- #1419 — PR that added `bd update --metadata` CLI support

**Related open issues:**
- #1415 — docs: define conventions for common metadata keys
- #1416 — feat: optional schema enforcement for metadata

## Test Plan

- [x] `go test ./internal/storage/... -run TestNormalizeMetadata -v` — Unit tests pass
- [x] `go test ./internal/storage/sqlite/... -run TestIssueMetadata -v` — Integration tests pass
- [x] `go test ./internal/storage/... -count=1` — All storage tests pass

## Security

- SQL injection protected via parameterized queries
- Type whitelist (string/[]byte/json.RawMessage only)
- JSON validation via `json.Valid()` before storage
- No deserialization (avoids gadget attacks)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)