### PR TITLE
fix(dep): use factory.NewFromConfig for cross-rig dependency resolution

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/rpc"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/factory"
 	"github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
@@ -1227,12 +1228,11 @@ func resolveExternalDependencies(ctx context.Context, issueID string, typeFilter
 			fmt.Fprintf(os.Stderr, "[external-deps] resolved beads dir: %s\n", targetBeadsDir)
 		}
 
-		// Open storage for the target rig
-		targetDBPath := filepath.Join(targetBeadsDir, "beads.db")
-		targetStore, err := sqlite.New(ctx, targetDBPath)
+		// Open storage for the target rig (auto-detect backend from metadata.json)
+		targetStore, err := factory.NewFromConfig(ctx, targetBeadsDir)
 		if err != nil {
 			if isVerbose() {
-				fmt.Fprintf(os.Stderr, "[external-deps] failed to open target db %s: %v\n", targetDBPath, err)
+				fmt.Fprintf(os.Stderr, "[external-deps] failed to open target db %s: %v\n", targetBeadsDir, err)
 			}
 			continue // Can't open target database
 		}


### PR DESCRIPTION
## Summary

`resolveExternalDependencies()` in `cmd/bd/dep.go` hardcodes SQLite storage when resolving cross-rig dependencies via routing. This fails silently when the target rig uses Dolt backend.

## Changes

- Replace hardcoded `sqlite.New()` with `factory.NewFromConfig()` which reads `metadata.json` to auto-detect the correct backend (SQLite, Dolt embedded, or Dolt server mode)
- Update error message to reference `targetBeadsDir` instead of removed `targetDBPath` variable

## Impact

- `bd dep list` now correctly resolves external dependencies for Dolt-backed rigs
- `gt convoy status` will show accurate counts for convoys tracking cross-rig issues

Fixes #1374

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)