### PR TITLE
feat: add simple query language for complex filtering

### DIFF
--- a/cmd/bd/query.go
+++ b/cmd/bd/query.go
@@ -1,0 +1,453 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/query"
+	"github.com/steveyegge/beads/internal/rpc"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var queryCmd = &cobra.Command{
+	Use:     "query [expression]",
+	GroupID: "issues",
+	Short:   "Query issues using a simple query language",
+	Long: `Query issues using a simple query language that supports compound filters,
+boolean operators, and date-relative expressions.
+
+The query language enables complex filtering that would otherwise require
+multiple flags or piping through jq.
+
+Syntax:
+  field=value       Equality comparison
+  field!=value      Inequality comparison
+  field>value       Greater than
+  field>=value      Greater than or equal
+  field<value       Less than
+  field<=value      Less than or equal
+
+Boolean operators (case-insensitive):
+  expr AND expr     Both conditions must match
+  expr OR expr      Either condition can match
+  NOT expr          Negates the condition
+  (expr)            Grouping with parentheses
+
+Supported fields:
+  status            Issue status (open, in_progress, blocked, deferred, closed)
+  priority          Priority level (0-4)
+  type              Issue type (bug, feature, task, epic, chore)
+  assignee          Assigned user (use "none" for unassigned)
+  owner             Issue owner
+  label             Issue label (use "none" for unlabeled)
+  title             Search in title (contains)
+  description       Search in description (contains, "none" for empty)
+  notes             Search in notes (contains)
+  created           Creation date/time
+  updated           Last update date/time
+  closed            Close date/time
+  id                Issue ID (supports wildcards: bd-*)
+  spec              Spec ID (supports wildcards)
+  pinned            Boolean (true/false)
+  ephemeral         Boolean (true/false)
+  template          Boolean (true/false)
+  parent            Parent issue ID
+  mol_type          Molecule type (swarm, patrol, work)
+
+Date values:
+  Relative durations: 7d (7 days ago), 24h (24 hours ago), 2w (2 weeks ago)
+  Absolute dates: 2025-01-15, 2025-01-15T10:00:00Z
+  Natural language: tomorrow, "next monday", "in 3 days"
+
+Examples:
+  bd query "status=open AND priority>1"
+  bd query "status=open AND priority<=2 AND updated>7d"
+  bd query "(status=open OR status=blocked) AND priority<2"
+  bd query "type=bug AND label=urgent"
+  bd query "NOT status=closed"
+  bd query "assignee=none AND type=task"
+  bd query "created>30d AND status!=closed"
+  bd query "label=frontend OR label=backend"
+  bd query "title=authentication AND priority=0"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get query from args
+		if len(args) == 0 {
+			fmt.Fprintf(os.Stderr, "Error: query expression is required\n\n")
+			if err := cmd.Help(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error displaying help: %v\n", err)
+			}
+			os.Exit(1)
+		}
+
+		queryStr := strings.Join(args, " ")
+
+		// Get option flags
+		limit, _ := cmd.Flags().GetInt("limit")
+		allFlag, _ := cmd.Flags().GetBool("all")
+		longFormat, _ := cmd.Flags().GetBool("long")
+		sortBy, _ := cmd.Flags().GetString("sort")
+		reverse, _ := cmd.Flags().GetBool("reverse")
+		parseOnly, _ := cmd.Flags().GetBool("parse-only")
+
+		// Parse the query
+		node, err := query.Parse(queryStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing query: %v\n", err)
+			os.Exit(1)
+		}
+
+		// If --parse-only, just show the parsed AST
+		if parseOnly {
+			fmt.Printf("Parsed query: %s\n", node.String())
+			return
+		}
+
+		// Evaluate the query to get filter and/or predicate
+		eval := query.NewEvaluator(time.Now())
+		result, err := eval.Evaluate(node)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error evaluating query: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Apply limit if specified
+		if limit > 0 && !result.RequiresPredicate {
+			result.Filter.Limit = limit
+		}
+
+		// By default exclude closed issues unless --all is specified or query explicitly filters by status
+		if !allFlag && result.Filter.Status == nil && !hasExplicitStatusFilter(node) {
+			result.Filter.ExcludeStatus = append(result.Filter.ExcludeStatus, types.StatusClosed)
+		}
+
+		ctx := rootCtx
+
+		// Check database freshness before reading (skip when using daemon)
+		if daemonClient == nil {
+			if err := ensureDatabaseFresh(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		var issues []*types.Issue
+
+		// Execute query
+		if daemonClient != nil {
+			// Daemon mode: use RPC with filter
+			// Convert filter to ListArgs
+			listArgs := filterToListArgs(&result.Filter)
+
+			resp, err := daemonClient.List(listArgs)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+
+			if err := json.Unmarshal(resp.Data, &issues); err != nil {
+				fmt.Fprintf(os.Stderr, "Error parsing response: %v\n", err)
+				os.Exit(1)
+			}
+		} else {
+			// Direct mode
+			if store == nil {
+				fmt.Fprintf(os.Stderr, "Error: no storage available\n")
+				os.Exit(1)
+			}
+
+			// If we need predicate filtering, we may need to fetch more results
+			// to ensure we get enough after filtering
+			searchFilter := result.Filter
+			if result.RequiresPredicate && limit > 0 {
+				// Fetch more to account for predicate filtering
+				searchFilter.Limit = limit * 3
+				if searchFilter.Limit < 100 {
+					searchFilter.Limit = 100
+				}
+			}
+
+			issues, err = store.SearchIssues(ctx, "", searchFilter)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+
+			// If no issues found, check if git has issues and auto-import
+			if len(issues) == 0 {
+				if checkAndAutoImport(ctx, store) {
+					issues, err = store.SearchIssues(ctx, "", searchFilter)
+					if err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						os.Exit(1)
+					}
+				}
+			}
+		}
+
+		// Apply predicate filter if needed (for OR queries)
+		if result.RequiresPredicate && result.Predicate != nil {
+			// For predicate filtering, we need labels populated on issues
+			if store != nil {
+				issueIDs := make([]string, len(issues))
+				for i, issue := range issues {
+					issueIDs[i] = issue.ID
+				}
+				labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
+				for _, issue := range issues {
+					issue.Labels = labelsMap[issue.ID]
+				}
+			}
+
+			filtered := make([]*types.Issue, 0, len(issues))
+			for _, issue := range issues {
+				if result.Predicate(issue) {
+					filtered = append(filtered, issue)
+				}
+			}
+			issues = filtered
+
+			// Apply limit after predicate filtering
+			if limit > 0 && len(issues) > limit {
+				issues = issues[:limit]
+			}
+		}
+
+		// Apply sorting
+		sortIssues(issues, sortBy, reverse)
+
+		// Output results
+		if jsonOutput {
+			// Get labels and dependency counts
+			if store != nil {
+				issueIDs := make([]string, len(issues))
+				for i, issue := range issues {
+					issueIDs[i] = issue.ID
+				}
+				labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
+				depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
+				commentCounts, _ := store.GetCommentCounts(ctx, issueIDs)
+
+				for _, issue := range issues {
+					issue.Labels = labelsMap[issue.ID]
+				}
+
+				issuesWithCounts := make([]*types.IssueWithCounts, len(issues))
+				for i, issue := range issues {
+					counts := depCounts[issue.ID]
+					if counts == nil {
+						counts = &types.DependencyCounts{DependencyCount: 0, DependentCount: 0}
+					}
+					issuesWithCounts[i] = &types.IssueWithCounts{
+						Issue:           issue,
+						DependencyCount: counts.DependencyCount,
+						DependentCount:  counts.DependentCount,
+						CommentCount:    commentCounts[issue.ID],
+					}
+				}
+				outputJSON(issuesWithCounts)
+			} else {
+				outputJSON(issues)
+			}
+			return
+		}
+
+		// Load labels for display
+		if store != nil && !result.RequiresPredicate {
+			issueIDs := make([]string, len(issues))
+			for i, issue := range issues {
+				issueIDs[i] = issue.ID
+			}
+			labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
+			for _, issue := range issues {
+				issue.Labels = labelsMap[issue.ID]
+			}
+		}
+
+		outputQueryResults(issues, queryStr, longFormat)
+	},
+}
+
+// hasExplicitStatusFilter checks if the query contains an explicit status comparison
+func hasExplicitStatusFilter(node query.Node) bool {
+	switch n := node.(type) {
+	case *query.ComparisonNode:
+		return n.Field == "status"
+	case *query.AndNode:
+		return hasExplicitStatusFilter(n.Left) || hasExplicitStatusFilter(n.Right)
+	case *query.OrNode:
+		return hasExplicitStatusFilter(n.Left) || hasExplicitStatusFilter(n.Right)
+	case *query.NotNode:
+		return hasExplicitStatusFilter(n.Operand)
+	default:
+		return false
+	}
+}
+
+// filterToListArgs converts an IssueFilter to RPC ListArgs
+func filterToListArgs(filter *types.IssueFilter) *rpc.ListArgs {
+	args := &rpc.ListArgs{
+		Limit: filter.Limit,
+	}
+
+	if filter.Status != nil {
+		args.Status = string(*filter.Status)
+	}
+	if filter.IssueType != nil {
+		args.IssueType = string(*filter.IssueType)
+	}
+	if filter.Assignee != nil {
+		args.Assignee = *filter.Assignee
+	}
+	if len(filter.Labels) > 0 {
+		args.Labels = filter.Labels
+	}
+	if len(filter.LabelsAny) > 0 {
+		args.LabelsAny = filter.LabelsAny
+	}
+	if filter.TitleContains != "" {
+		args.TitleContains = filter.TitleContains
+	}
+	if filter.DescriptionContains != "" {
+		args.DescriptionContains = filter.DescriptionContains
+	}
+	if filter.NotesContains != "" {
+		args.NotesContains = filter.NotesContains
+	}
+	if len(filter.IDs) > 0 {
+		args.IDs = filter.IDs
+	}
+	if filter.SpecIDPrefix != "" {
+		args.SpecIDPrefix = filter.SpecIDPrefix
+	}
+	if filter.CreatedAfter != nil {
+		args.CreatedAfter = filter.CreatedAfter.Format(time.RFC3339)
+	}
+	if filter.CreatedBefore != nil {
+		args.CreatedBefore = filter.CreatedBefore.Format(time.RFC3339)
+	}
+	if filter.UpdatedAfter != nil {
+		args.UpdatedAfter = filter.UpdatedAfter.Format(time.RFC3339)
+	}
+	if filter.UpdatedBefore != nil {
+		args.UpdatedBefore = filter.UpdatedBefore.Format(time.RFC3339)
+	}
+	if filter.ClosedAfter != nil {
+		args.ClosedAfter = filter.ClosedAfter.Format(time.RFC3339)
+	}
+	if filter.ClosedBefore != nil {
+		args.ClosedBefore = filter.ClosedBefore.Format(time.RFC3339)
+	}
+	if filter.PriorityMin != nil {
+		args.PriorityMin = filter.PriorityMin
+	}
+	if filter.PriorityMax != nil {
+		args.PriorityMax = filter.PriorityMax
+	}
+	if filter.Priority != nil {
+		args.Priority = filter.Priority
+	}
+	if filter.NoAssignee {
+		args.NoAssignee = true
+	}
+	if filter.NoLabels {
+		args.NoLabels = true
+	}
+	if filter.EmptyDescription {
+		args.EmptyDescription = true
+	}
+	if filter.Pinned != nil {
+		args.Pinned = filter.Pinned
+	}
+	if filter.ParentID != nil {
+		args.ParentID = *filter.ParentID
+	}
+	if len(filter.ExcludeStatus) > 0 {
+		for _, s := range filter.ExcludeStatus {
+			args.ExcludeStatus = append(args.ExcludeStatus, string(s))
+		}
+	}
+	if len(filter.ExcludeTypes) > 0 {
+		for _, t := range filter.ExcludeTypes {
+			args.ExcludeTypes = append(args.ExcludeTypes, string(t))
+		}
+	}
+
+	return args
+}
+
+// outputQueryResults formats and displays query results
+func outputQueryResults(issues []*types.Issue, queryStr string, longFormat bool) {
+	if len(issues) == 0 {
+		fmt.Printf("No issues found matching query: %s\n", queryStr)
+		return
+	}
+
+	if longFormat {
+		fmt.Printf("\nFound %d issues:\n\n", len(issues))
+		for _, issue := range issues {
+			fmt.Printf("%s [P%d] [%s] %s\n", issue.ID, issue.Priority, issue.IssueType, issue.Status)
+			fmt.Printf("  %s\n", issue.Title)
+			if issue.Assignee != "" {
+				fmt.Printf("  Assignee: %s\n", issue.Assignee)
+			}
+			if len(issue.Labels) > 0 {
+				fmt.Printf("  Labels: %v\n", issue.Labels)
+			}
+			fmt.Println()
+		}
+	} else {
+		// Use same compact format as list command
+		fmt.Printf("Found %d issues:\n", len(issues))
+		var buf strings.Builder
+		for _, issue := range issues {
+			formatQueryIssue(&buf, issue)
+		}
+		fmt.Print(buf.String())
+	}
+}
+
+// formatQueryIssue formats a single issue in compact format
+func formatQueryIssue(buf *strings.Builder, issue *types.Issue) {
+	labelsStr := ""
+	if len(issue.Labels) > 0 {
+		labelsStr = fmt.Sprintf(" %v", issue.Labels)
+	}
+	assigneeStr := ""
+	if issue.Assignee != "" {
+		assigneeStr = fmt.Sprintf(" @%s", issue.Assignee)
+	}
+
+	// Get styled status icon
+	statusIcon := ui.RenderStatusIcon(string(issue.Status))
+
+	if issue.Status == types.StatusClosed {
+		line := fmt.Sprintf("%s %s [P%d] [%s]%s%s - %s",
+			statusIcon, issue.ID, issue.Priority,
+			issue.IssueType, assigneeStr, labelsStr, issue.Title)
+		buf.WriteString(ui.RenderClosedLine(line))
+		buf.WriteString("\n")
+	} else {
+		buf.WriteString(fmt.Sprintf("%s %s [%s] [%s]%s%s - %s\n",
+			statusIcon,
+			ui.RenderID(issue.ID),
+			ui.RenderPriority(issue.Priority),
+			ui.RenderType(string(issue.IssueType)),
+			assigneeStr, labelsStr, issue.Title))
+	}
+}
+
+func init() {
+	queryCmd.Flags().IntP("limit", "n", 50, "Limit results (default: 50, 0 = unlimited)")
+	queryCmd.Flags().BoolP("all", "a", false, "Include closed issues (default: exclude closed)")
+	queryCmd.Flags().Bool("long", false, "Show detailed multi-line output for each issue")
+	queryCmd.Flags().String("sort", "", "Sort by field: priority, created, updated, closed, status, id, title, type, assignee")
+	queryCmd.Flags().BoolP("reverse", "r", false, "Reverse sort order")
+	queryCmd.Flags().Bool("parse-only", false, "Only parse the query and show the AST (for debugging)")
+
+	rootCmd.AddCommand(queryCmd)
+}

--- a/internal/query/evaluator.go
+++ b/internal/query/evaluator.go
@@ -1,0 +1,926 @@
+package query
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/timeparsing"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// QueryResult contains the result of evaluating a query.
+// For simple queries, Filter will be populated and Predicate will be nil.
+// For complex queries with OR, Predicate will be set and Filter will contain
+// base filters that can pre-filter issues.
+type QueryResult struct {
+	// Filter contains filters that can be passed to SearchIssues.
+	// This is always populated with at least base filters.
+	Filter types.IssueFilter
+
+	// Predicate is a function that evaluates whether an issue matches the query.
+	// If nil, the Filter alone is sufficient.
+	// If non-nil, issues matching Filter should be further filtered by Predicate.
+	Predicate func(*types.Issue) bool
+
+	// RequiresPredicate indicates if in-memory filtering is needed.
+	// True when the query contains OR or complex NOT expressions.
+	RequiresPredicate bool
+}
+
+// Evaluator converts a query AST to an IssueFilter and/or predicate function.
+type Evaluator struct {
+	now time.Time
+}
+
+// NewEvaluator creates a new Evaluator with the given reference time.
+func NewEvaluator(now time.Time) *Evaluator {
+	return &Evaluator{now: now}
+}
+
+// Evaluate evaluates the query AST and returns a QueryResult.
+func (e *Evaluator) Evaluate(node Node) (*QueryResult, error) {
+	result := &QueryResult{
+		Filter: types.IssueFilter{},
+	}
+
+	// Check if we can use Filter-only mode (simple AND chains)
+	if e.canUseFilterOnly(node) {
+		if err := e.buildFilter(node, &result.Filter); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	// Complex query: build predicate and extract base filters
+	pred, err := e.buildPredicate(node)
+	if err != nil {
+		return nil, err
+	}
+	result.Predicate = pred
+	result.RequiresPredicate = true
+
+	// Extract base filters for pre-filtering (optional optimization)
+	e.extractBaseFilters(node, &result.Filter)
+
+	return result, nil
+}
+
+// canUseFilterOnly returns true if the query can be expressed as IssueFilter only.
+// This is true for:
+// - Simple comparisons
+// - AND chains of simple comparisons
+// - NOT with certain fields
+func (e *Evaluator) canUseFilterOnly(node Node) bool {
+	switch n := node.(type) {
+	case *ComparisonNode:
+		return true
+	case *AndNode:
+		return e.canUseFilterOnly(n.Left) && e.canUseFilterOnly(n.Right)
+	case *NotNode:
+		// NOT is only filter-compatible for certain fields
+		if comp, ok := n.Operand.(*ComparisonNode); ok {
+			switch comp.Field {
+			case "status":
+				return comp.Op == OpEquals
+			case "type":
+				return comp.Op == OpEquals
+			default:
+				return false
+			}
+		}
+		return false
+	case *OrNode:
+		// OR can be filter-compatible for labels
+		return e.canUseLabelsAnyOptimization(n)
+	default:
+		return false
+	}
+}
+
+// canUseLabelsAnyOptimization checks if an OR node can use LabelsAny.
+func (e *Evaluator) canUseLabelsAnyOptimization(node *OrNode) bool {
+	labels := e.collectOrLabels(node)
+	return len(labels) > 0
+}
+
+// collectOrLabels collects label values from an OR chain of label=X comparisons.
+// Returns nil if the OR chain contains non-label comparisons.
+func (e *Evaluator) collectOrLabels(node Node) []string {
+	switch n := node.(type) {
+	case *ComparisonNode:
+		if (n.Field == "label" || n.Field == "labels") && n.Op == OpEquals {
+			return []string{n.Value}
+		}
+		return nil
+	case *OrNode:
+		left := e.collectOrLabels(n.Left)
+		right := e.collectOrLabels(n.Right)
+		if left == nil || right == nil {
+			return nil
+		}
+		return append(left, right...)
+	default:
+		return nil
+	}
+}
+
+// buildFilter populates the IssueFilter from a filter-compatible AST.
+func (e *Evaluator) buildFilter(node Node, filter *types.IssueFilter) error {
+	switch n := node.(type) {
+	case *ComparisonNode:
+		return e.applyComparison(n, filter)
+	case *AndNode:
+		if err := e.buildFilter(n.Left, filter); err != nil {
+			return err
+		}
+		return e.buildFilter(n.Right, filter)
+	case *NotNode:
+		return e.applyNot(n, filter)
+	case *OrNode:
+		// Only reached for LabelsAny optimization
+		labels := e.collectOrLabels(n)
+		if labels != nil {
+			filter.LabelsAny = append(filter.LabelsAny, labels...)
+			return nil
+		}
+		return fmt.Errorf("OR not supported for this field combination")
+	default:
+		return fmt.Errorf("unexpected node type: %T", node)
+	}
+}
+
+// applyComparison applies a comparison to the filter.
+func (e *Evaluator) applyComparison(comp *ComparisonNode, filter *types.IssueFilter) error {
+	switch comp.Field {
+	case "status":
+		return e.applyStatusFilter(comp, filter)
+	case "priority":
+		return e.applyPriorityFilter(comp, filter)
+	case "type":
+		return e.applyTypeFilter(comp, filter)
+	case "assignee":
+		return e.applyAssigneeFilter(comp, filter)
+	case "owner":
+		return e.applyOwnerFilter(comp, filter)
+	case "label", "labels":
+		return e.applyLabelFilter(comp, filter)
+	case "title":
+		return e.applyTitleFilter(comp, filter)
+	case "description", "desc":
+		return e.applyDescriptionFilter(comp, filter)
+	case "notes":
+		return e.applyNotesFilter(comp, filter)
+	case "created", "created_at":
+		return e.applyCreatedFilter(comp, filter)
+	case "updated", "updated_at":
+		return e.applyUpdatedFilter(comp, filter)
+	case "closed", "closed_at":
+		return e.applyClosedFilter(comp, filter)
+	case "id":
+		return e.applyIDFilter(comp, filter)
+	case "spec", "spec_id":
+		return e.applySpecFilter(comp, filter)
+	case "parent":
+		return e.applyParentFilter(comp, filter)
+	case "pinned":
+		return e.applyBoolFilter(comp, filter, "pinned")
+	case "ephemeral":
+		return e.applyBoolFilter(comp, filter, "ephemeral")
+	case "template":
+		return e.applyBoolFilter(comp, filter, "template")
+	case "mol_type":
+		return e.applyMolTypeFilter(comp, filter)
+	default:
+		return fmt.Errorf("unknown field: %s", comp.Field)
+	}
+}
+
+func (e *Evaluator) applyStatusFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals && comp.Op != OpNotEquals {
+		return fmt.Errorf("status only supports = and != operators")
+	}
+	status := types.Status(strings.ToLower(comp.Value))
+	if !status.IsValid() {
+		return fmt.Errorf("invalid status: %s", comp.Value)
+	}
+	if comp.Op == OpEquals {
+		filter.Status = &status
+	} else {
+		filter.ExcludeStatus = append(filter.ExcludeStatus, status)
+	}
+	return nil
+}
+
+func (e *Evaluator) applyPriorityFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	priority, err := strconv.Atoi(comp.Value)
+	if err != nil {
+		return fmt.Errorf("invalid priority value: %s", comp.Value)
+	}
+	if priority < 0 || priority > 4 {
+		return fmt.Errorf("priority must be between 0 and 4")
+	}
+
+	switch comp.Op {
+	case OpEquals:
+		filter.Priority = &priority
+	case OpNotEquals:
+		// For != we need predicate filtering
+		return fmt.Errorf("priority != requires predicate filtering")
+	case OpLess:
+		// priority < X means PriorityMax = X-1
+		max := priority - 1
+		if max < 0 {
+			return fmt.Errorf("priority < %d matches nothing", priority)
+		}
+		filter.PriorityMax = &max
+	case OpLessEq:
+		filter.PriorityMax = &priority
+	case OpGreater:
+		// priority > X means PriorityMin = X+1
+		min := priority + 1
+		if min > 4 {
+			return fmt.Errorf("priority > %d matches nothing", priority)
+		}
+		filter.PriorityMin = &min
+	case OpGreaterEq:
+		filter.PriorityMin = &priority
+	}
+	return nil
+}
+
+func (e *Evaluator) applyTypeFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals && comp.Op != OpNotEquals {
+		return fmt.Errorf("type only supports = and != operators")
+	}
+	issueType := types.IssueType(strings.ToLower(comp.Value))
+	if comp.Op == OpEquals {
+		filter.IssueType = &issueType
+	} else {
+		filter.ExcludeTypes = append(filter.ExcludeTypes, issueType)
+	}
+	return nil
+}
+
+func (e *Evaluator) applyAssigneeFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("assignee only supports = operator")
+	}
+	if comp.Value == "" || strings.ToLower(comp.Value) == "none" || strings.ToLower(comp.Value) == "null" {
+		filter.NoAssignee = true
+	} else {
+		filter.Assignee = &comp.Value
+	}
+	return nil
+}
+
+func (e *Evaluator) applyOwnerFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	// Owner filtering requires predicate
+	return fmt.Errorf("owner filtering requires predicate mode")
+}
+
+func (e *Evaluator) applyLabelFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("label only supports = operator")
+	}
+	if comp.Value == "" || strings.ToLower(comp.Value) == "none" || strings.ToLower(comp.Value) == "null" {
+		filter.NoLabels = true
+	} else {
+		filter.Labels = append(filter.Labels, comp.Value)
+	}
+	return nil
+}
+
+func (e *Evaluator) applyTitleFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("title only supports = operator (use title contains pattern)")
+	}
+	filter.TitleContains = comp.Value
+	return nil
+}
+
+func (e *Evaluator) applyDescriptionFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("description only supports = operator (use desc contains pattern)")
+	}
+	if comp.Value == "" || strings.ToLower(comp.Value) == "none" || strings.ToLower(comp.Value) == "null" {
+		filter.EmptyDescription = true
+	} else {
+		filter.DescriptionContains = comp.Value
+	}
+	return nil
+}
+
+func (e *Evaluator) applyNotesFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("notes only supports = operator")
+	}
+	filter.NotesContains = comp.Value
+	return nil
+}
+
+func (e *Evaluator) applyCreatedFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	t, err := e.parseTimeValue(comp)
+	if err != nil {
+		return fmt.Errorf("invalid created time: %w", err)
+	}
+	switch comp.Op {
+	case OpEquals:
+		// For equals, set both before and after to bracket the day
+		dayStart := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+		dayEnd := dayStart.Add(24 * time.Hour)
+		filter.CreatedAfter = &dayStart
+		filter.CreatedBefore = &dayEnd
+	case OpGreater:
+		filter.CreatedAfter = &t
+	case OpGreaterEq:
+		filter.CreatedAfter = &t
+	case OpLess:
+		filter.CreatedBefore = &t
+	case OpLessEq:
+		endOfDay := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999999999, t.Location())
+		filter.CreatedBefore = &endOfDay
+	default:
+		return fmt.Errorf("created does not support %s operator", comp.Op.String())
+	}
+	return nil
+}
+
+func (e *Evaluator) applyUpdatedFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	t, err := e.parseTimeValue(comp)
+	if err != nil {
+		return fmt.Errorf("invalid updated time: %w", err)
+	}
+	switch comp.Op {
+	case OpEquals:
+		dayStart := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+		dayEnd := dayStart.Add(24 * time.Hour)
+		filter.UpdatedAfter = &dayStart
+		filter.UpdatedBefore = &dayEnd
+	case OpGreater:
+		filter.UpdatedAfter = &t
+	case OpGreaterEq:
+		filter.UpdatedAfter = &t
+	case OpLess:
+		filter.UpdatedBefore = &t
+	case OpLessEq:
+		endOfDay := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999999999, t.Location())
+		filter.UpdatedBefore = &endOfDay
+	default:
+		return fmt.Errorf("updated does not support %s operator", comp.Op.String())
+	}
+	return nil
+}
+
+func (e *Evaluator) applyClosedFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	t, err := e.parseTimeValue(comp)
+	if err != nil {
+		return fmt.Errorf("invalid closed time: %w", err)
+	}
+	switch comp.Op {
+	case OpGreater:
+		filter.ClosedAfter = &t
+	case OpGreaterEq:
+		filter.ClosedAfter = &t
+	case OpLess:
+		filter.ClosedBefore = &t
+	case OpLessEq:
+		endOfDay := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999999999, t.Location())
+		filter.ClosedBefore = &endOfDay
+	default:
+		return fmt.Errorf("closed does not support %s operator", comp.Op.String())
+	}
+	return nil
+}
+
+func (e *Evaluator) applyIDFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("id only supports = operator")
+	}
+	// Check if it looks like a prefix (ends with *)
+	if strings.HasSuffix(comp.Value, "*") {
+		filter.IDPrefix = strings.TrimSuffix(comp.Value, "*")
+	} else {
+		filter.IDs = append(filter.IDs, comp.Value)
+	}
+	return nil
+}
+
+func (e *Evaluator) applySpecFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("spec only supports = operator")
+	}
+	// Support prefix matching
+	if strings.HasSuffix(comp.Value, "*") {
+		filter.SpecIDPrefix = strings.TrimSuffix(comp.Value, "*")
+	} else {
+		filter.SpecIDPrefix = comp.Value
+	}
+	return nil
+}
+
+func (e *Evaluator) applyParentFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("parent only supports = operator")
+	}
+	filter.ParentID = &comp.Value
+	return nil
+}
+
+func (e *Evaluator) applyBoolFilter(comp *ComparisonNode, filter *types.IssueFilter, field string) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("%s only supports = operator", field)
+	}
+	val := strings.ToLower(comp.Value)
+	var boolVal bool
+	switch val {
+	case "true", "yes", "1":
+		boolVal = true
+	case "false", "no", "0":
+		boolVal = false
+	default:
+		return fmt.Errorf("invalid boolean value for %s: %s", field, comp.Value)
+	}
+
+	switch field {
+	case "pinned":
+		filter.Pinned = &boolVal
+	case "ephemeral":
+		filter.Ephemeral = &boolVal
+	case "template":
+		filter.IsTemplate = &boolVal
+	}
+	return nil
+}
+
+func (e *Evaluator) applyMolTypeFilter(comp *ComparisonNode, filter *types.IssueFilter) error {
+	if comp.Op != OpEquals {
+		return fmt.Errorf("mol_type only supports = operator")
+	}
+	mt := types.MolType(strings.ToLower(comp.Value))
+	if !mt.IsValid() {
+		return fmt.Errorf("invalid mol_type: %s", comp.Value)
+	}
+	filter.MolType = &mt
+	return nil
+}
+
+// applyNot applies a NOT expression to the filter.
+func (e *Evaluator) applyNot(not *NotNode, filter *types.IssueFilter) error {
+	comp, ok := not.Operand.(*ComparisonNode)
+	if !ok {
+		return fmt.Errorf("NOT only supports simple comparisons in filter mode")
+	}
+
+	switch comp.Field {
+	case "status":
+		if comp.Op != OpEquals {
+			return fmt.Errorf("NOT status only supports = operator")
+		}
+		status := types.Status(strings.ToLower(comp.Value))
+		filter.ExcludeStatus = append(filter.ExcludeStatus, status)
+		return nil
+	case "type":
+		if comp.Op != OpEquals {
+			return fmt.Errorf("NOT type only supports = operator")
+		}
+		issueType := types.IssueType(strings.ToLower(comp.Value))
+		filter.ExcludeTypes = append(filter.ExcludeTypes, issueType)
+		return nil
+	default:
+		return fmt.Errorf("NOT not supported for field %s in filter mode", comp.Field)
+	}
+}
+
+// parseTimeValue parses a time value from a comparison node.
+// Supports duration values (7d, 24h) which are interpreted as "now - duration".
+func (e *Evaluator) parseTimeValue(comp *ComparisonNode) (time.Time, error) {
+	if comp.ValueType == TokenDuration {
+		// Duration values like 7d mean "7 days ago" for < comparisons
+		// and "within the last 7 days" for > comparisons
+		// We parse as relative to now, going backwards
+		return e.parseDurationAgo(comp.Value)
+	}
+	// Otherwise use the standard time parser
+	return timeparsing.ParseRelativeTime(comp.Value, e.now)
+}
+
+// parseDurationAgo parses a duration and returns now - duration.
+func (e *Evaluator) parseDurationAgo(s string) (time.Time, error) {
+	// Negate the duration to get time in the past
+	negated := "-" + strings.TrimPrefix(s, "+")
+	return timeparsing.ParseCompactDuration(negated, e.now)
+}
+
+// extractBaseFilters extracts filter-compatible portions from a complex query.
+// This is used to pre-filter before applying the predicate.
+func (e *Evaluator) extractBaseFilters(node Node, filter *types.IssueFilter) {
+	switch n := node.(type) {
+	case *ComparisonNode:
+		// Try to apply, ignore errors
+		_ = e.applyComparison(n, filter)
+	case *AndNode:
+		e.extractBaseFilters(n.Left, filter)
+		e.extractBaseFilters(n.Right, filter)
+	case *NotNode:
+		_ = e.applyNot(n, filter)
+	case *OrNode:
+		// For OR, we can't safely extract base filters
+		// (extracting from either side would over-filter)
+	}
+}
+
+// buildPredicate builds a predicate function for complex queries.
+func (e *Evaluator) buildPredicate(node Node) (func(*types.Issue) bool, error) {
+	switch n := node.(type) {
+	case *ComparisonNode:
+		return e.buildComparisonPredicate(n)
+	case *AndNode:
+		left, err := e.buildPredicate(n.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := e.buildPredicate(n.Right)
+		if err != nil {
+			return nil, err
+		}
+		return func(issue *types.Issue) bool {
+			return left(issue) && right(issue)
+		}, nil
+	case *OrNode:
+		left, err := e.buildPredicate(n.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := e.buildPredicate(n.Right)
+		if err != nil {
+			return nil, err
+		}
+		return func(issue *types.Issue) bool {
+			return left(issue) || right(issue)
+		}, nil
+	case *NotNode:
+		operand, err := e.buildPredicate(n.Operand)
+		if err != nil {
+			return nil, err
+		}
+		return func(issue *types.Issue) bool {
+			return !operand(issue)
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected node type: %T", node)
+	}
+}
+
+// buildComparisonPredicate builds a predicate for a single comparison.
+func (e *Evaluator) buildComparisonPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	switch comp.Field {
+	case "status":
+		return e.buildStatusPredicate(comp)
+	case "priority":
+		return e.buildPriorityPredicate(comp)
+	case "type":
+		return e.buildTypePredicate(comp)
+	case "assignee":
+		return e.buildAssigneePredicate(comp)
+	case "owner":
+		return e.buildOwnerPredicate(comp)
+	case "label", "labels":
+		return e.buildLabelPredicate(comp)
+	case "title":
+		return e.buildTitlePredicate(comp)
+	case "description", "desc":
+		return e.buildDescriptionPredicate(comp)
+	case "notes":
+		return e.buildNotesPredicate(comp)
+	case "created", "created_at":
+		return e.buildCreatedPredicate(comp)
+	case "updated", "updated_at":
+		return e.buildUpdatedPredicate(comp)
+	case "closed", "closed_at":
+		return e.buildClosedPredicate(comp)
+	case "id":
+		return e.buildIDPredicate(comp)
+	case "spec", "spec_id":
+		return e.buildSpecPredicate(comp)
+	case "pinned":
+		return e.buildBoolPredicate(comp, func(i *types.Issue) bool { return i.Pinned })
+	case "ephemeral":
+		return e.buildBoolPredicate(comp, func(i *types.Issue) bool { return i.Ephemeral })
+	case "template":
+		return e.buildBoolPredicate(comp, func(i *types.Issue) bool { return i.IsTemplate })
+	default:
+		return nil, fmt.Errorf("unknown field: %s", comp.Field)
+	}
+}
+
+func (e *Evaluator) buildStatusPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	status := types.Status(strings.ToLower(comp.Value))
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool { return i.Status == status }, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool { return i.Status != status }, nil
+	default:
+		return nil, fmt.Errorf("status does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildPriorityPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	priority, err := strconv.Atoi(comp.Value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid priority: %s", comp.Value)
+	}
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool { return i.Priority == priority }, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool { return i.Priority != priority }, nil
+	case OpLess:
+		return func(i *types.Issue) bool { return i.Priority < priority }, nil
+	case OpLessEq:
+		return func(i *types.Issue) bool { return i.Priority <= priority }, nil
+	case OpGreater:
+		return func(i *types.Issue) bool { return i.Priority > priority }, nil
+	case OpGreaterEq:
+		return func(i *types.Issue) bool { return i.Priority >= priority }, nil
+	default:
+		return nil, fmt.Errorf("unexpected operator: %s", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildTypePredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	issueType := types.IssueType(strings.ToLower(comp.Value))
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool { return i.IssueType == issueType }, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool { return i.IssueType != issueType }, nil
+	default:
+		return nil, fmt.Errorf("type does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildAssigneePredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := comp.Value
+	isNone := value == "" || strings.ToLower(value) == "none" || strings.ToLower(value) == "null"
+	switch comp.Op {
+	case OpEquals:
+		if isNone {
+			return func(i *types.Issue) bool { return i.Assignee == "" }, nil
+		}
+		return func(i *types.Issue) bool { return strings.EqualFold(i.Assignee, value) }, nil
+	case OpNotEquals:
+		if isNone {
+			return func(i *types.Issue) bool { return i.Assignee != "" }, nil
+		}
+		return func(i *types.Issue) bool { return !strings.EqualFold(i.Assignee, value) }, nil
+	default:
+		return nil, fmt.Errorf("assignee does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildOwnerPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := comp.Value
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool { return strings.EqualFold(i.Owner, value) }, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool { return !strings.EqualFold(i.Owner, value) }, nil
+	default:
+		return nil, fmt.Errorf("owner does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildLabelPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := comp.Value
+	isNone := value == "" || strings.ToLower(value) == "none" || strings.ToLower(value) == "null"
+	switch comp.Op {
+	case OpEquals:
+		if isNone {
+			return func(i *types.Issue) bool { return len(i.Labels) == 0 }, nil
+		}
+		return func(i *types.Issue) bool {
+			for _, l := range i.Labels {
+				if strings.EqualFold(l, value) {
+					return true
+				}
+			}
+			return false
+		}, nil
+	case OpNotEquals:
+		if isNone {
+			return func(i *types.Issue) bool { return len(i.Labels) > 0 }, nil
+		}
+		return func(i *types.Issue) bool {
+			for _, l := range i.Labels {
+				if strings.EqualFold(l, value) {
+					return false
+				}
+			}
+			return true
+		}, nil
+	default:
+		return nil, fmt.Errorf("label does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildTitlePredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := strings.ToLower(comp.Value)
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool {
+			return strings.Contains(strings.ToLower(i.Title), value)
+		}, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool {
+			return !strings.Contains(strings.ToLower(i.Title), value)
+		}, nil
+	default:
+		return nil, fmt.Errorf("title does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildDescriptionPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := comp.Value
+	isNone := value == "" || strings.ToLower(value) == "none" || strings.ToLower(value) == "null"
+	switch comp.Op {
+	case OpEquals:
+		if isNone {
+			return func(i *types.Issue) bool { return i.Description == "" }, nil
+		}
+		return func(i *types.Issue) bool {
+			return strings.Contains(strings.ToLower(i.Description), strings.ToLower(value))
+		}, nil
+	case OpNotEquals:
+		if isNone {
+			return func(i *types.Issue) bool { return i.Description != "" }, nil
+		}
+		return func(i *types.Issue) bool {
+			return !strings.Contains(strings.ToLower(i.Description), strings.ToLower(value))
+		}, nil
+	default:
+		return nil, fmt.Errorf("description does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildNotesPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := strings.ToLower(comp.Value)
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool {
+			return strings.Contains(strings.ToLower(i.Notes), value)
+		}, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool {
+			return !strings.Contains(strings.ToLower(i.Notes), value)
+		}, nil
+	default:
+		return nil, fmt.Errorf("notes does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildCreatedPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	t, err := e.parseTimeValue(comp)
+	if err != nil {
+		return nil, fmt.Errorf("invalid created time: %w", err)
+	}
+	return e.buildTimePredicate(comp.Op, t, func(i *types.Issue) time.Time { return i.CreatedAt })
+}
+
+func (e *Evaluator) buildUpdatedPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	t, err := e.parseTimeValue(comp)
+	if err != nil {
+		return nil, fmt.Errorf("invalid updated time: %w", err)
+	}
+	return e.buildTimePredicate(comp.Op, t, func(i *types.Issue) time.Time { return i.UpdatedAt })
+}
+
+func (e *Evaluator) buildClosedPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	t, err := e.parseTimeValue(comp)
+	if err != nil {
+		return nil, fmt.Errorf("invalid closed time: %w", err)
+	}
+	return func(i *types.Issue) bool {
+		if i.ClosedAt == nil {
+			return false
+		}
+		return e.compareTime(comp.Op, *i.ClosedAt, t)
+	}, nil
+}
+
+func (e *Evaluator) buildTimePredicate(op ComparisonOp, t time.Time, getter func(*types.Issue) time.Time) (func(*types.Issue) bool, error) {
+	return func(i *types.Issue) bool {
+		return e.compareTime(op, getter(i), t)
+	}, nil
+}
+
+func (e *Evaluator) compareTime(op ComparisonOp, actual, target time.Time) bool {
+	switch op {
+	case OpEquals:
+		// Same day comparison
+		return actual.Year() == target.Year() &&
+			actual.Month() == target.Month() &&
+			actual.Day() == target.Day()
+	case OpNotEquals:
+		return !(actual.Year() == target.Year() &&
+			actual.Month() == target.Month() &&
+			actual.Day() == target.Day())
+	case OpLess:
+		return actual.Before(target)
+	case OpLessEq:
+		return actual.Before(target) || actual.Equal(target)
+	case OpGreater:
+		return actual.After(target)
+	case OpGreaterEq:
+		return actual.After(target) || actual.Equal(target)
+	default:
+		return false
+	}
+}
+
+func (e *Evaluator) buildIDPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := comp.Value
+	hasWildcard := strings.HasSuffix(value, "*")
+	if hasWildcard {
+		prefix := strings.TrimSuffix(value, "*")
+		switch comp.Op {
+		case OpEquals:
+			return func(i *types.Issue) bool { return strings.HasPrefix(i.ID, prefix) }, nil
+		case OpNotEquals:
+			return func(i *types.Issue) bool { return !strings.HasPrefix(i.ID, prefix) }, nil
+		default:
+			return nil, fmt.Errorf("id with wildcard only supports = and != operators")
+		}
+	}
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool { return i.ID == value }, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool { return i.ID != value }, nil
+	default:
+		return nil, fmt.Errorf("id does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildSpecPredicate(comp *ComparisonNode) (func(*types.Issue) bool, error) {
+	value := comp.Value
+	hasWildcard := strings.HasSuffix(value, "*")
+	if hasWildcard {
+		prefix := strings.TrimSuffix(value, "*")
+		switch comp.Op {
+		case OpEquals:
+			return func(i *types.Issue) bool { return strings.HasPrefix(i.SpecID, prefix) }, nil
+		case OpNotEquals:
+			return func(i *types.Issue) bool { return !strings.HasPrefix(i.SpecID, prefix) }, nil
+		default:
+			return nil, fmt.Errorf("spec with wildcard only supports = and != operators")
+		}
+	}
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool { return i.SpecID == value }, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool { return i.SpecID != value }, nil
+	default:
+		return nil, fmt.Errorf("spec does not support %s operator", comp.Op.String())
+	}
+}
+
+func (e *Evaluator) buildBoolPredicate(comp *ComparisonNode, getter func(*types.Issue) bool) (func(*types.Issue) bool, error) {
+	val := strings.ToLower(comp.Value)
+	var boolVal bool
+	switch val {
+	case "true", "yes", "1":
+		boolVal = true
+	case "false", "no", "0":
+		boolVal = false
+	default:
+		return nil, fmt.Errorf("invalid boolean value: %s", comp.Value)
+	}
+
+	switch comp.Op {
+	case OpEquals:
+		return func(i *types.Issue) bool { return getter(i) == boolVal }, nil
+	case OpNotEquals:
+		return func(i *types.Issue) bool { return getter(i) != boolVal }, nil
+	default:
+		return nil, fmt.Errorf("boolean field does not support %s operator", comp.Op.String())
+	}
+}
+
+// Evaluate is a convenience function that parses and evaluates a query string.
+func Evaluate(query string) (*QueryResult, error) {
+	return EvaluateAt(query, time.Now())
+}
+
+// EvaluateAt parses and evaluates a query string with a specific reference time.
+func EvaluateAt(query string, now time.Time) (*QueryResult, error) {
+	node, err := Parse(query)
+	if err != nil {
+		return nil, err
+	}
+	eval := NewEvaluator(now)
+	return eval.Evaluate(node)
+}

--- a/internal/query/lexer.go
+++ b/internal/query/lexer.go
@@ -1,0 +1,336 @@
+// Package query implements a simple query language for filtering beads.
+//
+// The query language supports:
+//   - Field comparisons: status=open, priority>1, updated>7d
+//   - Boolean operators: AND, OR, NOT
+//   - Parentheses for grouping: (status=open OR status=blocked) AND priority<2
+//   - Date-relative expressions: updated>7d, created<30d
+//
+// Example queries:
+//   - status=open AND priority>1
+//   - (status=open OR status=blocked) AND updated>7d
+//   - NOT status=closed
+//   - type=bug AND priority=0
+package query
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// TokenType represents the type of a lexer token.
+type TokenType int
+
+const (
+	TokenEOF TokenType = iota
+	TokenIdent       // field names, values
+	TokenString      // quoted strings
+	TokenNumber      // numeric values
+	TokenDuration    // duration values like 7d, 24h
+	TokenEquals      // =
+	TokenNotEquals   // !=
+	TokenLess        // <
+	TokenLessEq      // <=
+	TokenGreater     // >
+	TokenGreaterEq   // >=
+	TokenAnd         // AND
+	TokenOr          // OR
+	TokenNot         // NOT
+	TokenLParen      // (
+	TokenRParen      // )
+	TokenComma       // , (for lists)
+)
+
+// String returns the string representation of a TokenType.
+func (t TokenType) String() string {
+	switch t {
+	case TokenEOF:
+		return "EOF"
+	case TokenIdent:
+		return "IDENT"
+	case TokenString:
+		return "STRING"
+	case TokenNumber:
+		return "NUMBER"
+	case TokenDuration:
+		return "DURATION"
+	case TokenEquals:
+		return "="
+	case TokenNotEquals:
+		return "!="
+	case TokenLess:
+		return "<"
+	case TokenLessEq:
+		return "<="
+	case TokenGreater:
+		return ">"
+	case TokenGreaterEq:
+		return ">="
+	case TokenAnd:
+		return "AND"
+	case TokenOr:
+		return "OR"
+	case TokenNot:
+		return "NOT"
+	case TokenLParen:
+		return "("
+	case TokenRParen:
+		return ")"
+	case TokenComma:
+		return ","
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", t)
+	}
+}
+
+// Token represents a single token from the lexer.
+type Token struct {
+	Type  TokenType
+	Value string
+	Pos   int // Position in input string
+}
+
+// Lexer tokenizes a query string.
+type Lexer struct {
+	input string
+	pos   int
+	width int // width of last rune read
+}
+
+// NewLexer creates a new Lexer for the given input string.
+func NewLexer(input string) *Lexer {
+	return &Lexer{input: input}
+}
+
+// next returns the next rune and advances position.
+func (l *Lexer) next() rune {
+	if l.pos >= len(l.input) {
+		l.width = 0
+		return 0
+	}
+	r := rune(l.input[l.pos])
+	l.width = 1
+	l.pos += l.width
+	return r
+}
+
+// peek returns the next rune without advancing.
+func (l *Lexer) peek() rune {
+	if l.pos >= len(l.input) {
+		return 0
+	}
+	return rune(l.input[l.pos])
+}
+
+// backup steps back one rune.
+func (l *Lexer) backup() {
+	l.pos -= l.width
+}
+
+// skipWhitespace skips whitespace characters.
+func (l *Lexer) skipWhitespace() {
+	for {
+		r := l.next()
+		if r == 0 || !unicode.IsSpace(r) {
+			l.backup()
+			return
+		}
+	}
+}
+
+// NextToken returns the next token from the input.
+func (l *Lexer) NextToken() (Token, error) {
+	l.skipWhitespace()
+
+	startPos := l.pos
+	r := l.next()
+
+	if r == 0 {
+		return Token{Type: TokenEOF, Pos: startPos}, nil
+	}
+
+	switch r {
+	case '(':
+		return Token{Type: TokenLParen, Value: "(", Pos: startPos}, nil
+	case ')':
+		return Token{Type: TokenRParen, Value: ")", Pos: startPos}, nil
+	case ',':
+		return Token{Type: TokenComma, Value: ",", Pos: startPos}, nil
+	case '=':
+		return Token{Type: TokenEquals, Value: "=", Pos: startPos}, nil
+	case '!':
+		if l.peek() == '=' {
+			l.next()
+			return Token{Type: TokenNotEquals, Value: "!=", Pos: startPos}, nil
+		}
+		return Token{}, fmt.Errorf("unexpected character '!' at position %d (did you mean '!=' or 'NOT'?)", startPos)
+	case '<':
+		if l.peek() == '=' {
+			l.next()
+			return Token{Type: TokenLessEq, Value: "<=", Pos: startPos}, nil
+		}
+		return Token{Type: TokenLess, Value: "<", Pos: startPos}, nil
+	case '>':
+		if l.peek() == '=' {
+			l.next()
+			return Token{Type: TokenGreaterEq, Value: ">=", Pos: startPos}, nil
+		}
+		return Token{Type: TokenGreater, Value: ">", Pos: startPos}, nil
+	case '"', '\'':
+		return l.readString(r, startPos)
+	default:
+		if unicode.IsDigit(r) || r == '-' || r == '+' {
+			l.backup()
+			return l.readNumberOrDuration(startPos)
+		}
+		if isIdentStart(r) {
+			l.backup()
+			return l.readIdent(startPos)
+		}
+		return Token{}, fmt.Errorf("unexpected character %q at position %d", r, startPos)
+	}
+}
+
+// readString reads a quoted string.
+func (l *Lexer) readString(quote rune, startPos int) (Token, error) {
+	var sb strings.Builder
+	for {
+		r := l.next()
+		if r == 0 {
+			return Token{}, fmt.Errorf("unterminated string starting at position %d", startPos)
+		}
+		if r == quote {
+			return Token{Type: TokenString, Value: sb.String(), Pos: startPos}, nil
+		}
+		if r == '\\' {
+			// Handle escape sequences
+			escaped := l.next()
+			switch escaped {
+			case 'n':
+				sb.WriteRune('\n')
+			case 't':
+				sb.WriteRune('\t')
+			case '\\':
+				sb.WriteRune('\\')
+			case '"':
+				sb.WriteRune('"')
+			case '\'':
+				sb.WriteRune('\'')
+			case 0:
+				return Token{}, fmt.Errorf("unterminated escape sequence at position %d", l.pos-1)
+			default:
+				sb.WriteRune(escaped)
+			}
+		} else {
+			sb.WriteRune(r)
+		}
+	}
+}
+
+// readNumberOrDuration reads a number or duration (e.g., 7d, 24h).
+func (l *Lexer) readNumberOrDuration(startPos int) (Token, error) {
+	var sb strings.Builder
+
+	// Handle optional sign
+	r := l.next()
+	if r == '-' || r == '+' {
+		sb.WriteRune(r)
+		r = l.next()
+	}
+
+	// Must have at least one digit
+	if !unicode.IsDigit(r) {
+		l.backup()
+		// This might be a minus in front of an identifier, which is invalid
+		return Token{}, fmt.Errorf("expected digit at position %d", l.pos)
+	}
+	sb.WriteRune(r)
+
+	// Read remaining digits
+	for {
+		r = l.next()
+		if !unicode.IsDigit(r) {
+			break
+		}
+		sb.WriteRune(r)
+	}
+
+	// Check for duration suffix
+	if r != 0 && isDurationSuffix(r) {
+		sb.WriteRune(r)
+		return Token{Type: TokenDuration, Value: sb.String(), Pos: startPos}, nil
+	}
+
+	// Not a duration suffix, back up
+	if r != 0 {
+		l.backup()
+	}
+
+	return Token{Type: TokenNumber, Value: sb.String(), Pos: startPos}, nil
+}
+
+// readIdent reads an identifier or keyword.
+func (l *Lexer) readIdent(startPos int) (Token, error) {
+	var sb strings.Builder
+
+	for {
+		r := l.next()
+		if r == 0 || !isIdentChar(r) {
+			l.backup()
+			break
+		}
+		sb.WriteRune(r)
+	}
+
+	value := sb.String()
+	upper := strings.ToUpper(value)
+
+	// Check for keywords
+	switch upper {
+	case "AND":
+		return Token{Type: TokenAnd, Value: value, Pos: startPos}, nil
+	case "OR":
+		return Token{Type: TokenOr, Value: value, Pos: startPos}, nil
+	case "NOT":
+		return Token{Type: TokenNot, Value: value, Pos: startPos}, nil
+	default:
+		return Token{Type: TokenIdent, Value: value, Pos: startPos}, nil
+	}
+}
+
+// Tokenize returns all tokens from the input.
+func (l *Lexer) Tokenize() ([]Token, error) {
+	var tokens []Token
+	for {
+		tok, err := l.NextToken()
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, tok)
+		if tok.Type == TokenEOF {
+			break
+		}
+	}
+	return tokens, nil
+}
+
+// isIdentStart returns true if r can start an identifier.
+func isIdentStart(r rune) bool {
+	return unicode.IsLetter(r) || r == '_'
+}
+
+// isIdentChar returns true if r can be part of an identifier.
+func isIdentChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
+}
+
+// isDurationSuffix returns true if r is a valid duration suffix.
+func isDurationSuffix(r rune) bool {
+	switch r {
+	case 'h', 'd', 'w', 'm', 'y', 'H', 'D', 'W', 'M', 'Y':
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -1,0 +1,340 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Node represents a node in the query AST.
+type Node interface {
+	node() // marker method
+	String() string
+}
+
+// ComparisonOp represents a comparison operator.
+type ComparisonOp int
+
+const (
+	OpEquals ComparisonOp = iota
+	OpNotEquals
+	OpLess
+	OpLessEq
+	OpGreater
+	OpGreaterEq
+)
+
+// String returns the string representation of a ComparisonOp.
+func (op ComparisonOp) String() string {
+	switch op {
+	case OpEquals:
+		return "="
+	case OpNotEquals:
+		return "!="
+	case OpLess:
+		return "<"
+	case OpLessEq:
+		return "<="
+	case OpGreater:
+		return ">"
+	case OpGreaterEq:
+		return ">="
+	default:
+		return "?"
+	}
+}
+
+// ComparisonNode represents a field comparison (e.g., status=open).
+type ComparisonNode struct {
+	Field    string
+	Op       ComparisonOp
+	Value    string
+	ValueType TokenType // TokenIdent, TokenString, TokenNumber, or TokenDuration
+}
+
+func (n *ComparisonNode) node() {}
+func (n *ComparisonNode) String() string {
+	return fmt.Sprintf("%s%s%s", n.Field, n.Op.String(), n.Value)
+}
+
+// AndNode represents a logical AND operation.
+type AndNode struct {
+	Left  Node
+	Right Node
+}
+
+func (n *AndNode) node() {}
+func (n *AndNode) String() string {
+	return fmt.Sprintf("(%s AND %s)", n.Left.String(), n.Right.String())
+}
+
+// OrNode represents a logical OR operation.
+type OrNode struct {
+	Left  Node
+	Right Node
+}
+
+func (n *OrNode) node() {}
+func (n *OrNode) String() string {
+	return fmt.Sprintf("(%s OR %s)", n.Left.String(), n.Right.String())
+}
+
+// NotNode represents a logical NOT operation.
+type NotNode struct {
+	Operand Node
+}
+
+func (n *NotNode) node() {}
+func (n *NotNode) String() string {
+	return fmt.Sprintf("NOT %s", n.Operand.String())
+}
+
+// Parser parses a query string into an AST.
+type Parser struct {
+	lexer   *Lexer
+	current Token
+	peeked  *Token
+}
+
+// NewParser creates a new Parser for the given input.
+func NewParser(input string) *Parser {
+	return &Parser{lexer: NewLexer(input)}
+}
+
+// Parse parses the query string and returns the root AST node.
+func (p *Parser) Parse() (Node, error) {
+	if err := p.advance(); err != nil {
+		return nil, err
+	}
+
+	if p.current.Type == TokenEOF {
+		return nil, fmt.Errorf("empty query")
+	}
+
+	node, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.current.Type != TokenEOF {
+		return nil, fmt.Errorf("unexpected token %q at position %d (expected end of query)", p.current.Value, p.current.Pos)
+	}
+
+	return node, nil
+}
+
+// advance moves to the next token.
+func (p *Parser) advance() error {
+	if p.peeked != nil {
+		p.current = *p.peeked
+		p.peeked = nil
+		return nil
+	}
+	tok, err := p.lexer.NextToken()
+	if err != nil {
+		return err
+	}
+	p.current = tok
+	return nil
+}
+
+// peek returns the next token without consuming it.
+func (p *Parser) peek() (Token, error) {
+	if p.peeked != nil {
+		return *p.peeked, nil
+	}
+	tok, err := p.lexer.NextToken()
+	if err != nil {
+		return Token{}, err
+	}
+	p.peeked = &tok
+	return tok, nil
+}
+
+// parseOr parses OR expressions (lowest precedence).
+func (p *Parser) parseOr() (Node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.current.Type == TokenOr {
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &OrNode{Left: left, Right: right}
+	}
+
+	return left, nil
+}
+
+// parseAnd parses AND expressions.
+func (p *Parser) parseAnd() (Node, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.current.Type == TokenAnd {
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		left = &AndNode{Left: left, Right: right}
+	}
+
+	return left, nil
+}
+
+// parseNot parses NOT expressions.
+func (p *Parser) parseNot() (Node, error) {
+	if p.current.Type == TokenNot {
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+		operand, err := p.parseNot() // NOT is right-associative
+		if err != nil {
+			return nil, err
+		}
+		return &NotNode{Operand: operand}, nil
+	}
+
+	return p.parsePrimary()
+}
+
+// parsePrimary parses primary expressions (comparisons and parenthesized expressions).
+func (p *Parser) parsePrimary() (Node, error) {
+	if p.current.Type == TokenLParen {
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+		node, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		if p.current.Type != TokenRParen {
+			return nil, fmt.Errorf("expected ')' at position %d, got %s", p.current.Pos, p.current.Type.String())
+		}
+		if err := p.advance(); err != nil {
+			return nil, err
+		}
+		return node, nil
+	}
+
+	return p.parseComparison()
+}
+
+// parseComparison parses a field comparison.
+func (p *Parser) parseComparison() (Node, error) {
+	if p.current.Type != TokenIdent {
+		return nil, fmt.Errorf("expected field name at position %d, got %s", p.current.Pos, p.current.Type.String())
+	}
+
+	field := strings.ToLower(p.current.Value)
+	if err := p.advance(); err != nil {
+		return nil, err
+	}
+
+	var op ComparisonOp
+	switch p.current.Type {
+	case TokenEquals:
+		op = OpEquals
+	case TokenNotEquals:
+		op = OpNotEquals
+	case TokenLess:
+		op = OpLess
+	case TokenLessEq:
+		op = OpLessEq
+	case TokenGreater:
+		op = OpGreater
+	case TokenGreaterEq:
+		op = OpGreaterEq
+	default:
+		return nil, fmt.Errorf("expected comparison operator at position %d, got %s", p.current.Pos, p.current.Type.String())
+	}
+
+	if err := p.advance(); err != nil {
+		return nil, err
+	}
+
+	// Value can be identifier, string, number, or duration
+	var value string
+	var valueType TokenType
+	switch p.current.Type {
+	case TokenIdent:
+		value = p.current.Value
+		valueType = TokenIdent
+	case TokenString:
+		value = p.current.Value
+		valueType = TokenString
+	case TokenNumber:
+		value = p.current.Value
+		valueType = TokenNumber
+	case TokenDuration:
+		value = p.current.Value
+		valueType = TokenDuration
+	default:
+		return nil, fmt.Errorf("expected value at position %d, got %s", p.current.Pos, p.current.Type.String())
+	}
+
+	if err := p.advance(); err != nil {
+		return nil, err
+	}
+
+	return &ComparisonNode{
+		Field:     field,
+		Op:        op,
+		Value:     value,
+		ValueType: valueType,
+	}, nil
+}
+
+// Parse is a convenience function that parses a query string.
+func Parse(input string) (Node, error) {
+	p := NewParser(input)
+	return p.Parse()
+}
+
+// KnownFields lists fields that can be queried.
+var KnownFields = map[string]bool{
+	// Core fields
+	"id":          true,
+	"title":       true,
+	"description": true,
+	"desc":        true, // alias
+	"status":      true,
+	"priority":    true,
+	"type":        true,
+	"assignee":    true,
+	"owner":       true,
+
+	// Timestamps
+	"created":  true,
+	"updated":  true,
+	"closed":   true,
+	"created_at": true, // alias
+	"updated_at": true, // alias
+	"closed_at":  true, // alias
+
+	// Labels
+	"label":  true,
+	"labels": true, // alias
+
+	// Flags
+	"pinned":    true,
+	"ephemeral": true,
+	"template":  true,
+
+	// Other
+	"spec":     true,
+	"spec_id":  true, // alias
+	"parent":   true,
+	"mol_type": true,
+	"notes":    true,
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,0 +1,619 @@
+package query
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestLexer(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []TokenType
+		values   []string
+	}{
+		{
+			name:     "simple equality",
+			input:    "status=open",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"status", "=", "open", ""},
+		},
+		{
+			name:     "not equals",
+			input:    "status!=closed",
+			expected: []TokenType{TokenIdent, TokenNotEquals, TokenIdent, TokenEOF},
+			values:   []string{"status", "!=", "closed", ""},
+		},
+		{
+			name:     "greater than",
+			input:    "priority>1",
+			expected: []TokenType{TokenIdent, TokenGreater, TokenNumber, TokenEOF},
+			values:   []string{"priority", ">", "1", ""},
+		},
+		{
+			name:     "less than or equal",
+			input:    "priority<=3",
+			expected: []TokenType{TokenIdent, TokenLessEq, TokenNumber, TokenEOF},
+			values:   []string{"priority", "<=", "3", ""},
+		},
+		{
+			name:     "duration value",
+			input:    "updated>7d",
+			expected: []TokenType{TokenIdent, TokenGreater, TokenDuration, TokenEOF},
+			values:   []string{"updated", ">", "7d", ""},
+		},
+		{
+			name:     "AND expression",
+			input:    "status=open AND priority>1",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenAnd, TokenIdent, TokenGreater, TokenNumber, TokenEOF},
+			values:   []string{"status", "=", "open", "AND", "priority", ">", "1", ""},
+		},
+		{
+			name:     "OR expression",
+			input:    "status=open OR status=blocked",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenOr, TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"status", "=", "open", "OR", "status", "=", "blocked", ""},
+		},
+		{
+			name:     "NOT expression",
+			input:    "NOT status=closed",
+			expected: []TokenType{TokenNot, TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"NOT", "status", "=", "closed", ""},
+		},
+		{
+			name:     "parentheses",
+			input:    "(status=open)",
+			expected: []TokenType{TokenLParen, TokenIdent, TokenEquals, TokenIdent, TokenRParen, TokenEOF},
+			values:   []string{"(", "status", "=", "open", ")", ""},
+		},
+		{
+			name:     "quoted string",
+			input:    `title="hello world"`,
+			expected: []TokenType{TokenIdent, TokenEquals, TokenString, TokenEOF},
+			values:   []string{"title", "=", "hello world", ""},
+		},
+		{
+			name:     "case insensitive keywords",
+			input:    "status=open and priority>1 or type=bug",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenAnd, TokenIdent, TokenGreater, TokenNumber, TokenOr, TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+		},
+		{
+			name:     "negative number",
+			input:    "priority>-1",
+			expected: []TokenType{TokenIdent, TokenGreater, TokenNumber, TokenEOF},
+			values:   []string{"priority", ">", "-1", ""},
+		},
+		{
+			name:     "identifier with hyphen",
+			input:    "id=bd-abc123",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"id", "=", "bd-abc123", ""},
+		},
+		{
+			name:     "identifier with underscore",
+			input:    "mol_type=swarm",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"mol_type", "=", "swarm", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lexer := NewLexer(tt.input)
+			tokens, err := lexer.Tokenize()
+			if err != nil {
+				t.Fatalf("Tokenize() error = %v", err)
+			}
+
+			if len(tokens) != len(tt.expected) {
+				t.Fatalf("got %d tokens, want %d", len(tokens), len(tt.expected))
+			}
+
+			for i, tok := range tokens {
+				if tok.Type != tt.expected[i] {
+					t.Errorf("token %d: got type %v, want %v", i, tok.Type, tt.expected[i])
+				}
+				if tt.values != nil && tok.Value != tt.values[i] {
+					t.Errorf("token %d: got value %q, want %q", i, tok.Value, tt.values[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLexerErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"unterminated string", `title="hello`},
+		{"invalid character", "status@open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lexer := NewLexer(tt.input)
+			_, err := lexer.Tokenize()
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParser(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple comparison",
+			input:    "status=open",
+			expected: "status=open",
+		},
+		{
+			name:     "AND expression",
+			input:    "status=open AND priority>1",
+			expected: "(status=open AND priority>1)",
+		},
+		{
+			name:     "OR expression",
+			input:    "status=open OR status=blocked",
+			expected: "(status=open OR status=blocked)",
+		},
+		{
+			name:     "NOT expression",
+			input:    "NOT status=closed",
+			expected: "NOT status=closed",
+		},
+		{
+			name:     "parentheses",
+			input:    "(status=open OR status=blocked) AND priority<2",
+			expected: "((status=open OR status=blocked) AND priority<2)",
+		},
+		{
+			name:     "chained AND",
+			input:    "status=open AND priority>1 AND type=bug",
+			expected: "((status=open AND priority>1) AND type=bug)",
+		},
+		{
+			name:     "AND has higher precedence than OR",
+			input:    "status=open OR priority>1 AND type=bug",
+			expected: "(status=open OR (priority>1 AND type=bug))",
+		},
+		{
+			name:     "NOT with parentheses",
+			input:    "NOT (status=closed OR status=deferred)",
+			expected: "NOT (status=closed OR status=deferred)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node, err := Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+
+			got := node.String()
+			if got != tt.expected {
+				t.Errorf("got %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParserErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty query", ""},
+		{"missing value", "status="},
+		{"missing operator", "status open"},
+		{"unclosed paren", "(status=open"},
+		{"extra paren", "status=open)"},
+		{"missing operand after AND", "status=open AND"},
+		{"invalid operator", "status~open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse(tt.input)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestEvaluatorSimpleQueries(t *testing.T) {
+	now := time.Date(2025, 2, 4, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name                string
+		query               string
+		expectFilter        func(*types.IssueFilter) bool
+		requiresPredicate   bool
+	}{
+		{
+			name:  "status equals",
+			query: "status=open",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.Status != nil && *f.Status == types.StatusOpen
+			},
+		},
+		{
+			name:  "status not equals",
+			query: "status!=closed",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return len(f.ExcludeStatus) == 1 && f.ExcludeStatus[0] == types.StatusClosed
+			},
+		},
+		{
+			name:  "priority equals",
+			query: "priority=2",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.Priority != nil && *f.Priority == 2
+			},
+		},
+		{
+			name:  "priority greater than",
+			query: "priority>1",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.PriorityMin != nil && *f.PriorityMin == 2
+			},
+		},
+		{
+			name:  "priority less than",
+			query: "priority<3",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.PriorityMax != nil && *f.PriorityMax == 2
+			},
+		},
+		{
+			name:  "type equals",
+			query: "type=bug",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.IssueType != nil && *f.IssueType == types.TypeBug
+			},
+		},
+		{
+			name:  "assignee equals",
+			query: "assignee=alice",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.Assignee != nil && *f.Assignee == "alice"
+			},
+		},
+		{
+			name:  "assignee none",
+			query: "assignee=none",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.NoAssignee
+			},
+		},
+		{
+			name:  "label equals",
+			query: "label=urgent",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return len(f.Labels) == 1 && f.Labels[0] == "urgent"
+			},
+		},
+		{
+			name:  "label none",
+			query: "label=none",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.NoLabels
+			},
+		},
+		{
+			name:  "title contains",
+			query: "title=authentication",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.TitleContains == "authentication"
+			},
+		},
+		{
+			name:  "description empty",
+			query: "description=none",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.EmptyDescription
+			},
+		},
+		{
+			name:  "pinned equals true",
+			query: "pinned=true",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.Pinned != nil && *f.Pinned == true
+			},
+		},
+		{
+			name:  "updated greater than duration",
+			query: "updated>7d",
+			expectFilter: func(f *types.IssueFilter) bool {
+				// 7d ago from now
+				expected := now.AddDate(0, 0, -7)
+				return f.UpdatedAfter != nil && f.UpdatedAfter.Year() == expected.Year() &&
+					f.UpdatedAfter.Month() == expected.Month() && f.UpdatedAfter.Day() == expected.Day()
+			},
+		},
+		{
+			name:  "created less than duration",
+			query: "created<30d",
+			expectFilter: func(f *types.IssueFilter) bool {
+				expected := now.AddDate(0, 0, -30)
+				return f.CreatedBefore != nil && f.CreatedBefore.Year() == expected.Year() &&
+					f.CreatedBefore.Month() == expected.Month() && f.CreatedBefore.Day() == expected.Day()
+			},
+		},
+		{
+			name:  "AND expression",
+			query: "status=open AND priority>1",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return f.Status != nil && *f.Status == types.StatusOpen &&
+					f.PriorityMin != nil && *f.PriorityMin == 2
+			},
+		},
+		{
+			name:  "multiple labels AND",
+			query: "label=frontend AND label=urgent",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return len(f.Labels) == 2 &&
+					(f.Labels[0] == "frontend" || f.Labels[0] == "urgent") &&
+					(f.Labels[1] == "frontend" || f.Labels[1] == "urgent")
+			},
+		},
+		{
+			name:  "NOT status",
+			query: "NOT status=closed",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return len(f.ExcludeStatus) == 1 && f.ExcludeStatus[0] == types.StatusClosed
+			},
+		},
+		{
+			name:  "NOT type",
+			query: "NOT type=epic",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return len(f.ExcludeTypes) == 1 && f.ExcludeTypes[0] == types.TypeEpic
+			},
+		},
+		{
+			name:  "labels OR uses LabelsAny",
+			query: "label=frontend OR label=backend",
+			expectFilter: func(f *types.IssueFilter) bool {
+				return len(f.LabelsAny) == 2
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := EvaluateAt(tt.query, now)
+			if err != nil {
+				t.Fatalf("EvaluateAt() error = %v", err)
+			}
+
+			if tt.expectFilter != nil && !tt.expectFilter(&result.Filter) {
+				t.Errorf("filter check failed for %q", tt.query)
+			}
+
+			if result.RequiresPredicate != tt.requiresPredicate {
+				t.Errorf("RequiresPredicate = %v, want %v", result.RequiresPredicate, tt.requiresPredicate)
+			}
+		})
+	}
+}
+
+func TestEvaluatorComplexQueries(t *testing.T) {
+	now := time.Date(2025, 2, 4, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name              string
+		query             string
+		requiresPredicate bool
+	}{
+		{
+			name:              "OR with different fields requires predicate",
+			query:             "status=open OR priority>1",
+			requiresPredicate: true,
+		},
+		{
+			name:              "nested OR requires predicate",
+			query:             "(status=open OR status=blocked) AND priority<2",
+			requiresPredicate: true,
+		},
+		{
+			name:              "NOT with complex expression requires predicate",
+			query:             "NOT (status=closed AND type=bug)",
+			requiresPredicate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := EvaluateAt(tt.query, now)
+			if err != nil {
+				t.Fatalf("EvaluateAt() error = %v", err)
+			}
+
+			if result.RequiresPredicate != tt.requiresPredicate {
+				t.Errorf("RequiresPredicate = %v, want %v", result.RequiresPredicate, tt.requiresPredicate)
+			}
+
+			if tt.requiresPredicate && result.Predicate == nil {
+				t.Error("expected Predicate to be set")
+			}
+		})
+	}
+}
+
+func TestPredicateEvaluation(t *testing.T) {
+	now := time.Date(2025, 2, 4, 12, 0, 0, 0, time.UTC)
+
+	openBug := &types.Issue{
+		ID:       "bd-1",
+		Status:   types.StatusOpen,
+		Priority: 1,
+		IssueType: types.TypeBug,
+		Labels:   []string{"urgent", "frontend"},
+		CreatedAt: now.AddDate(0, 0, -5),
+		UpdatedAt: now.AddDate(0, 0, -1),
+	}
+
+	closedTask := &types.Issue{
+		ID:       "bd-2",
+		Status:   types.StatusClosed,
+		Priority: 2,
+		IssueType: types.TypeTask,
+		Labels:   []string{"backend"},
+		CreatedAt: now.AddDate(0, 0, -30),
+		UpdatedAt: now.AddDate(0, 0, -10),
+	}
+
+	blockedFeature := &types.Issue{
+		ID:       "bd-3",
+		Status:   types.StatusBlocked,
+		Priority: 0,
+		IssueType: types.TypeFeature,
+		Labels:   []string{},
+		CreatedAt: now.AddDate(0, 0, -2),
+		UpdatedAt: now,
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		issue   *types.Issue
+		matches bool
+	}{
+		// Status tests
+		{"status=open matches open bug", "status=open", openBug, true},
+		{"status=open doesn't match closed task", "status=open", closedTask, false},
+		{"status!=closed matches open bug", "status!=closed", openBug, true},
+		{"status!=closed doesn't match closed task", "status!=closed", closedTask, false},
+
+		// Priority tests
+		{"priority>0 matches P1 bug", "priority>0", openBug, true},
+		{"priority>0 doesn't match P0 feature", "priority>0", blockedFeature, false},
+		{"priority<=1 matches P1 bug", "priority<=1", openBug, true},
+		{"priority<=1 doesn't match P2 task", "priority<=1", closedTask, false},
+
+		// Type tests
+		{"type=bug matches bug", "type=bug", openBug, true},
+		{"type=bug doesn't match task", "type=bug", closedTask, false},
+
+		// Label tests
+		{"label=urgent matches issue with urgent", "label=urgent", openBug, true},
+		{"label=urgent doesn't match issue without", "label=urgent", closedTask, false},
+		{"label=none matches unlabeled", "label=none", blockedFeature, true},
+		{"label=none doesn't match labeled", "label=none", openBug, false},
+
+		// OR tests
+		{"status=open OR status=blocked matches open", "status=open OR status=blocked", openBug, true},
+		{"status=open OR status=blocked matches blocked", "status=open OR status=blocked", blockedFeature, true},
+		{"status=open OR status=blocked doesn't match closed", "status=open OR status=blocked", closedTask, false},
+
+		// AND tests
+		{"status=open AND type=bug matches", "status=open AND type=bug", openBug, true},
+		{"status=open AND type=bug doesn't match blocked", "status=open AND type=bug", blockedFeature, false},
+
+		// NOT tests
+		{"NOT status=closed matches open", "NOT status=closed", openBug, true},
+		{"NOT status=closed doesn't match closed", "NOT status=closed", closedTask, false},
+
+		// Complex tests
+		{"(status=open OR status=blocked) AND priority<2 matches P1 open", "(status=open OR status=blocked) AND priority<2", openBug, true},
+		{"(status=open OR status=blocked) AND priority<2 matches P0 blocked", "(status=open OR status=blocked) AND priority<2", blockedFeature, true},
+		{"(status=open OR status=blocked) AND priority<2 doesn't match P2 closed", "(status=open OR status=blocked) AND priority<2", closedTask, false},
+
+		// Label OR tests
+		{"label=urgent OR label=backend matches urgent", "label=urgent OR label=backend", openBug, true},
+		{"label=urgent OR label=backend matches backend", "label=urgent OR label=backend", closedTask, true},
+		{"label=urgent OR label=backend doesn't match unlabeled", "label=urgent OR label=backend", blockedFeature, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := EvaluateAt(tt.query, now)
+			if err != nil {
+				t.Fatalf("EvaluateAt() error = %v", err)
+			}
+
+			// For simple queries, check filter
+			if !result.RequiresPredicate {
+				// Build predicate anyway for testing
+				eval := NewEvaluator(now)
+				node, _ := Parse(tt.query)
+				pred, err := eval.buildPredicate(node)
+				if err != nil {
+					t.Fatalf("buildPredicate() error = %v", err)
+				}
+				got := pred(tt.issue)
+				if got != tt.matches {
+					t.Errorf("predicate(%s) = %v, want %v", tt.issue.ID, got, tt.matches)
+				}
+			} else {
+				// Use the predicate from result
+				got := result.Predicate(tt.issue)
+				if got != tt.matches {
+					t.Errorf("predicate(%s) = %v, want %v", tt.issue.ID, got, tt.matches)
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluatorErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"invalid status", "status=invalid"},
+		{"invalid priority", "priority=abc"},
+		{"priority out of range", "priority=5"},
+		{"invalid boolean", "pinned=maybe"},
+		{"unknown field", "unknown=value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Evaluate(tt.query)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestDurationParsing(t *testing.T) {
+	now := time.Date(2025, 2, 4, 12, 0, 0, 0, time.UTC)
+	eval := NewEvaluator(now)
+
+	tests := []struct {
+		duration string
+		expected time.Time
+	}{
+		{"7d", now.AddDate(0, 0, -7)},
+		{"24h", now.Add(-24 * time.Hour)},
+		{"2w", now.AddDate(0, 0, -14)},
+		{"1m", now.AddDate(0, -1, 0)},
+		{"1y", now.AddDate(-1, 0, 0)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.duration, func(t *testing.T) {
+			got, err := eval.parseDurationAgo(tt.duration)
+			if err != nil {
+				t.Fatalf("parseDurationAgo() error = %v", err)
+			}
+
+			// Compare dates (ignore time precision)
+			if got.Year() != tt.expected.Year() || got.Month() != tt.expected.Month() || got.Day() != tt.expected.Day() {
+				t.Errorf("got %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `bd query` command that enables complex filtering with a simple query language. This addresses the need for compound filters with boolean operators that would otherwise require piping through jq.

**Features:**
- Field comparisons: `status=open`, `priority>1`, `updated>7d`
- Boolean operators: `AND`, `OR`, `NOT` (case-insensitive)
- Parentheses for grouping: `(status=open OR status=blocked) AND priority<2`
- Date-relative expressions: `7d`, `24h`, `2w` (interpreted as "X ago")
- Supports all IssueFilter fields

**Examples:**
```bash
bd query "status=open AND priority>1"
bd query "(status=open OR status=blocked) AND updated>7d"
bd query "NOT status=closed AND type=bug"
bd query "label=urgent OR label=critical"
bd query "assignee=none AND type=task"
```

## Implementation

- New `internal/query` package with lexer, parser, and evaluator
- Simple AND queries converted directly to IssueFilter for SQL efficiency
- Complex OR queries use predicate functions for in-memory filtering
- 62 comprehensive tests covering lexer, parser, evaluator, and predicate evaluation

## Test plan

- [x] Unit tests for lexer tokenization
- [x] Unit tests for parser AST generation
- [x] Unit tests for evaluator filter generation
- [x] Unit tests for predicate evaluation
- [x] Manual testing with various query patterns
- [ ] Integration testing with daemon mode

Closes: bd-o9g

🤖 Generated with [Claude Code](https://claude.com/claude-code)