### PR TITLE
Use prebuilt Windows releases in installer

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -148,6 +148,8 @@ Beads now ships with native Windows support—no MSYS or MinGW required.
 irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 ```
 
+The script installs a prebuilt Windows release if available. Go is only required for `go install` or building from source.
+
 **Via go install**:
 ```pwsh
 go install github.com/steveyegge/beads/cmd/bd@latest
@@ -160,6 +162,8 @@ cd beads
 go build -o bd.exe ./cmd/bd
 Move-Item bd.exe $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\
 ```
+
+If you see `unicode/uregex.h` missing while building, use the PowerShell install script instead (it downloads a prebuilt binary).
 
 **Verify installation**:
 ```pwsh

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -101,10 +101,14 @@ Beads ships with native Windows support—no MSYS or MinGW required.
 irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 ```
 
+The script installs a prebuilt Windows release if available. Go is only required for `go install` or building from source.
+
 **Via go install**:
 ```pwsh
 go install github.com/steveyegge/beads/cmd/bd@latest
 ```
+
+If you see `unicode/uregex.h` missing while building, use the PowerShell install script instead.
 
 ## IDE and Editor Integrations
 


### PR DESCRIPTION
## Summary
- add Windows release download path to install.ps1 before go install/build
- document that the PowerShell script uses prebuilt releases and avoids ICU header issues

## Testing
- not run (docs/script change only)

Fixes #1493