### PR TITLE
fix(update): fall back to config.yaml for custom types in daemon mode

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/hooks"
 	"github.com/steveyegge/beads/internal/rpc"
 	"github.com/steveyegge/beads/internal/timeparsing"
@@ -123,6 +124,9 @@ create, update, show, or close operation).`,
 				if ct, err := store.GetCustomTypes(cmd.Context()); err == nil {
 					customTypes = ct
 				}
+			} else {
+				// Daemon mode: store is nil, fall back to config.yaml (GH#1499)
+				customTypes = config.GetCustomTypesFromYAML()
 			}
 			if !types.IssueType(issueType).IsValidWithCustom(customTypes) {
 				validTypes := "bug, feature, task, epic, chore"


### PR DESCRIPTION
## Summary

`bd update --type=<custom>` fails when daemon is running, even when `types.custom` is configured in config.yaml. This PR adds a fallback to load custom types from config.yaml when `store` is nil (daemon mode).

## Root Cause

PR #1356 fixed custom type validation to use `IsValidWithCustom()`, but it depends on `store`:

```go
var customTypes []string
if store != nil {
    if ct, err := store.GetCustomTypes(cmd.Context()); err == nil {
        customTypes = ct
    }
}
```

In daemon mode, `store` is `nil` by design (daemon owns the database, CLI uses RPC). So `customTypes` stays empty and validation rejects all custom types.

## Fix

Add fallback to `config.GetCustomTypesFromYAML()` when `store` is nil:

```go
} else {
    // Daemon mode: store is nil, fall back to config.yaml (GH#1499)
    customTypes = config.GetCustomTypesFromYAML()
}
```

This follows the same pattern already used in the storage layer (`internal/storage/sqlite/config.go:175`, `internal/storage/dolt/config.go:131`).

## Testing

- Build passes
- `config.GetCustomTypesFromYAML()` has existing test coverage
- CI will run full test suite

## Workaround (before this fix)

```sh
bd update <id> --type=<custom> --no-daemon
```

Fixes: #1499

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)