### PR TITLE
Fix other instances of dolt db lock due to hanging process (follow-up)

### DIFF
--- a/cmd/bd/doctor/perf_dolt.go
+++ b/cmd/bd/doctor/perf_dolt.go
@@ -139,7 +139,7 @@ func runDoltEmbeddedDiagnostics(metrics *DoltPerfMetrics, doltDir string) error 
 	if err != nil {
 		return fmt.Errorf("failed to open Dolt database: %w", err)
 	}
-	defer db.Close()
+	defer closeDoltDBWithTimeout(db)
 
 	// Single connection for embedded mode
 	db.SetMaxOpenConns(1)

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -916,7 +917,7 @@ func TestDoltStoreGetReadyWork(t *testing.T) {
 func TestCloseWithTimeout(t *testing.T) {
 	// Test 1: Fast close succeeds
 	t.Run("fast close succeeds", func(t *testing.T) {
-		err := closeWithTimeout("test", func() error {
+		err := doltutil.CloseWithTimeout("test", func() error {
 			return nil
 		})
 		if err != nil {
@@ -927,7 +928,7 @@ func TestCloseWithTimeout(t *testing.T) {
 	// Test 2: Fast close with error returns error
 	t.Run("fast close with error", func(t *testing.T) {
 		expectedErr := context.Canceled
-		err := closeWithTimeout("test", func() error {
+		err := doltutil.CloseWithTimeout("test", func() error {
 			return expectedErr
 		})
 		if err != expectedErr {
@@ -938,15 +939,15 @@ func TestCloseWithTimeout(t *testing.T) {
 	// Test 3: Slow close times out (use shorter timeout for test)
 	t.Run("slow close times out", func(t *testing.T) {
 		// Save original timeout and restore after test
-		originalTimeout := closeTimeout
-		// Note: closeTimeout is a const, so we can't actually change it
+		originalTimeout := doltutil.CloseTimeout
+		// Note: CloseTimeout is a const, so we can't actually change it
 		// This test verifies the timeout mechanism works conceptually
 		// In practice, the 5s timeout is reasonable for production use
 
 		// This test would take 5+ seconds with the real timeout,
 		// so we just verify the function signature works correctly
 		start := time.Now()
-		err := closeWithTimeout("test", func() error {
+		err := doltutil.CloseWithTimeout("test", func() error {
 			// Return immediately for this test
 			return nil
 		})

--- a/internal/storage/dolt/migrations/migrations_test.go
+++ b/internal/storage/dolt/migrations/migrations_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	embedded "github.com/dolthub/driver"
+
+	"github.com/steveyegge/beads/internal/storage/doltutil"
 )
 
 // openTestDolt creates a temporary embedded Dolt database for testing.
@@ -41,12 +43,12 @@ func openTestDolt(t *testing.T) *sql.DB {
 	initDB := sql.OpenDB(initConnector)
 	_, err = initDB.Exec("CREATE DATABASE IF NOT EXISTS beads")
 	if err != nil {
-		_ = initDB.Close()
-		_ = initConnector.Close()
+		_ = doltutil.CloseWithTimeout("initDB", initDB.Close)
+		_ = doltutil.CloseWithTimeout("initConnector", initConnector.Close)
 		t.Fatalf("failed to create database: %v", err)
 	}
-	_ = initDB.Close()
-	_ = initConnector.Close()
+	_ = doltutil.CloseWithTimeout("initDB", initDB.Close)
+	_ = doltutil.CloseWithTimeout("initConnector", initConnector.Close)
 
 	// Now connect with database specified
 	dsn := fmt.Sprintf("file://%s?commitname=test&commitemail=test@test.com&database=beads", absPath)
@@ -59,10 +61,10 @@ func openTestDolt(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("failed to create connector: %v", err)
 	}
-	t.Cleanup(func() { _ = connector.Close() })
+	t.Cleanup(func() { _ = doltutil.CloseWithTimeout("connector", connector.Close) })
 
 	db := sql.OpenDB(connector)
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { _ = doltutil.CloseWithTimeout("db", db.Close) })
 
 	// Create minimal issues table without wisp_type (simulating old schema)
 	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS issues (

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
 )
 
 // DoltStore implements the Storage interface using Dolt
@@ -548,27 +549,6 @@ func isOnlyComments(stmt string) bool {
 	return true
 }
 
-// closeTimeout is the maximum time to wait for db/connector close operations.
-// Embedded Dolt can hang indefinitely on close; this prevents bd from hanging.
-const closeTimeout = 5 * time.Second
-
-// closeWithTimeout runs a close function with a timeout to prevent indefinite hangs.
-// Returns the close error, or a timeout error if the close doesn't complete in time.
-func closeWithTimeout(name string, closeFn func() error) error {
-	done := make(chan error, 1)
-	go func() {
-		done <- closeFn()
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(closeTimeout):
-		// Close is hanging - log and continue rather than blocking forever
-		return fmt.Errorf("%s close timed out after %v", name, closeTimeout)
-	}
-}
-
 // Close closes the database connection
 func (s *DoltStore) Close() error {
 	s.closed.Store(true)
@@ -576,7 +556,7 @@ func (s *DoltStore) Close() error {
 	defer s.mu.Unlock()
 	var err error
 	if s.db != nil {
-		if cerr := closeWithTimeout("db", s.db.Close); cerr != nil {
+		if cerr := doltutil.CloseWithTimeout("db", s.db.Close); cerr != nil {
 			// Timeout is non-fatal for cleanup - just log it
 			if !errors.Is(cerr, context.Canceled) {
 				err = errors.Join(err, cerr)
@@ -585,7 +565,7 @@ func (s *DoltStore) Close() error {
 	}
 	// For embedded mode, ensure the underlying engine is closed to release filesystem locks.
 	if s.embeddedConnector != nil {
-		cerr := closeWithTimeout("embeddedConnector", s.embeddedConnector.Close)
+		cerr := doltutil.CloseWithTimeout("embeddedConnector", s.embeddedConnector.Close)
 		// Ignore context cancellation noise from Dolt shutdown plumbing.
 		if cerr != nil && !errors.Is(cerr, context.Canceled) {
 			err = errors.Join(err, cerr)

--- a/internal/storage/doltutil/close.go
+++ b/internal/storage/doltutil/close.go
@@ -1,0 +1,30 @@
+// Package doltutil provides shared utilities for embedded Dolt operations.
+// This package exists to avoid import cycles between dolt and dolt/migrations.
+package doltutil
+
+import (
+	"fmt"
+	"time"
+)
+
+// CloseTimeout is the maximum time to wait for close operations.
+// Embedded Dolt can hang indefinitely on close; this prevents commands from hanging.
+const CloseTimeout = 5 * time.Second
+
+// CloseWithTimeout runs a close function with a timeout to prevent indefinite hangs.
+// This is needed because embedded Dolt's engine can hang during shutdown.
+// Returns an error if the close times out or if the close function returns an error.
+func CloseWithTimeout(name string, closeFn func() error) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- closeFn()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(CloseTimeout):
+		// Close is hanging - log and continue rather than blocking forever
+		return fmt.Errorf("%s close timed out after %v", name, CloseTimeout)
+	}
+}


### PR DESCRIPTION
Follow-up on #1441 

---

## Summary
- Fixed additional locations where commands would hang indefinitely when using the embedded Dolt backend. The embedded Dolt connector's `Close()` method can hang forever during shutdown, blocking the CLI from exiting.
- Created a util method to handle the close with timeout behavior

  ## Changes
  - Add `closeTimeout` constant (5 seconds) for close operations
  - Add `closeWithTimeout` helper function that wraps close operations in a goroutine with timeout
  - Modify `DoltStore.Close()` to use timeout wrapper for both `db.Close()` and `embeddedConnector.Close()`
  - Add unit tests for the new `closeWithTimeout` helper

  ## Testing
  - [x] Unit tests pass (`go test ./...`) — the other dolt test failures (TestServerModeConnection, TestServerStartStop) are pre-existing issues unrelated to this change. They fail due to missing dolt global config (user.email/user.name).
  - [x] Manual testing performed

  ## Checklist
  - [x] Code follows project style
  - [x] Documentation updated (if applicable) - comments
  - [x] No breaking changes (or documented in summary)

