### PR TITLE
fix(sync): use GetGitCommonDir for worktree creation in bare repo setups

### DIFF
--- a/cmd/bd/daemon_sync_branch.go
+++ b/cmd/bd/daemon_sync_branch.go
@@ -62,10 +62,14 @@ func syncBranchCommitAndPushWithOptions(ctx context.Context, store storage.Stora
 		return false, fmt.Errorf("failed to get main repo root: %w", err)
 	}
 
-	// Use worktree-aware git directory detection
-	gitDir, err := git.GetGitDir()
+	// Use GetGitCommonDir() instead of GetGitDir() for worktree creation.
+	// In a bare repo + worktree setup, GetGitDir() returns the worktree-specific
+	// path (e.g., .git/worktrees/main), but we need the common git directory
+	// to create new worktrees. GetGitCommonDir() always returns the bare repo's
+	// .git directory. GH#1500
+	gitDir, err := git.GetGitCommonDir()
 	if err != nil {
-		return false, fmt.Errorf("not a git repository: %w", err)
+		return false, fmt.Errorf("failed to get git common dir: %w", err)
 	}
 
 	// Worktree path is under .git/beads-worktrees/<branch>


### PR DESCRIPTION
## Problem

In a bare repo + worktree setup, running `bd sync` fails with:

```
fatal: not a git repository (or any of the root directories): .git
```

This happens because `GetGitDir()` returns the worktree-specific path (e.g., `.git/worktrees/main`) instead of the bare repo's `.git` directory. When beads tries to create a new worktree at `worktreePath = filepath.Join(gitDir, "beads-worktrees", syncBranch)`, it fails because you cannot create a worktree from within another worktree.

## Solution

Replace `GetGitDir()` with `GetGitCommonDir()` which always returns the shared bare repo `.git` directory. This function was specifically designed for this use case (see `gitdir.go:105-111`):

> Use this instead of GetGitDir() when you need to create new worktrees or access shared git data that should not be scoped to a single worktree. GH#639: This is critical for bare repo setups where GetGitDir() returns a worktree-specific path that cannot host new worktrees.

## Changes

- `cmd/bd/daemon_sync_branch.go`: Changed `git.GetGitDir()` → `git.GetGitCommonDir()` for worktree creation
- Added comments explaining why `GetGitCommonDir()` is needed in bare repo + worktree setups

## Testing

This fix should resolve the error in issue #1500 where `bd sync` fails in:

```
/path/to/project/project.git (bare)
/path/to/project/main [main] <- working here
/path/to/project/feature-branch [feature]
```

Fixes #1500