### PR TITLE
fix(release): enable CGO for macOS builds via GoReleaser Pro split/merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,18 @@ permissions:
   contents: write
 
 jobs:
-  goreleaser:
-    # Guard: only run goreleaser in the canonical repository (not in forks)
+  # Build binaries on native runners using GoReleaser Pro split/merge
+  # macOS runs natively to enable CGO for Dolt backend support
+  prepare:
     if: ${{ github.repository == 'steveyegge/beads' }}
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+          - os: macos-13
+            goos: darwin
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -29,28 +37,93 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install cross-compilation toolchains and signing tools
+      # Linux: Install cross-compilation toolchains
+      - name: Install cross-compilation toolchains (Linux)
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode
 
-      - name: Run GoReleaser
+      # macOS: Install ICU4C for CGO (Dolt backend)
+      - name: Install ICU4C (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install icu4c
+          ICU_PREFIX="$(brew --prefix icu4c)"
+          echo "CGO_CFLAGS=-I${ICU_PREFIX}/include" >> $GITHUB_ENV
+          echo "CGO_CPPFLAGS=-I${ICU_PREFIX}/include" >> $GITHUB_ENV
+          echo "CGO_LDFLAGS=-L${ICU_PREFIX}/lib" >> $GITHUB_ENV
+
+      - name: Get short SHA
+        shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      # Cache dist directory for merge step
+      - name: Cache dist
+        uses: actions/cache@v5
+        with:
+          path: dist/${{ matrix.goos }}
+          key: ${{ matrix.goos }}-${{ env.sha_short }}
+
+      - name: Run GoReleaser (split)
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: '~> v2'
-          args: >
-            release --clean
-            ${{ github.repository != 'steveyegge/beads' && '--skip=publish --skip=announce' || '' }}
+          args: release --clean --split
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           # Windows code signing (optional - signing is skipped if not set)
           WINDOWS_SIGNING_CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_PFX_BASE64 }}
           WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
 
+  # Merge all platform builds and publish the release
+  release:
+    if: ${{ github.repository == 'steveyegge/beads' }}
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Get short SHA
+        shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      # Restore caches from prepare jobs
+      - name: Restore Linux dist
+        uses: actions/cache@v5
+        with:
+          path: dist/linux
+          key: linux-${{ env.sha_short }}
+
+      - name: Restore Darwin dist
+        uses: actions/cache@v5
+        with:
+          path: dist/darwin
+          key: darwin-${{ env.sha_short }}
+
+      - name: Run GoReleaser (merge)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          version: '~> v2'
+          args: continue --merge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
   publish-pypi:
     runs-on: ubuntu-latest
-    needs: goreleaser
+    needs: release
     if: ${{ always() && github.repository == 'steveyegge/beads' }}
     steps:
       - name: Checkout
@@ -79,7 +152,7 @@ jobs:
 
   publish-npm:
     runs-on: ubuntu-latest
-    needs: goreleaser
+    needs: release
     if: ${{ github.repository == 'steveyegge/beads' }}
     permissions:
       contents: read
@@ -106,7 +179,7 @@ jobs:
 
   update-homebrew:
     runs-on: ubuntu-latest
-    needs: goreleaser
+    needs: release
     if: ${{ github.repository == 'steveyegge/beads' }}
     steps:
       - name: Checkout
@@ -172,4 +245,3 @@ jobs:
             end
           end
           EOF
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,11 +57,13 @@ builds:
       - -X main.Commit={{.Commit}}
       - -X main.Branch={{.Branch}}
 
+  # macOS builds with CGO enabled for Dolt backend support
+  # These builds run on native macOS runners via GoReleaser Pro split/merge
   - id: bd-darwin-amd64
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - darwin
     goarch:
@@ -72,12 +74,15 @@ builds:
       - -X main.Build={{.ShortCommit}}
       - -X main.Commit={{.Commit}}
       - -X main.Branch={{.Branch}}
+    hooks:
+      post:
+        - codesign -s - -f "{{ .Path }}"
 
   - id: bd-darwin-arm64
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - darwin
     goarch:
@@ -88,6 +93,9 @@ builds:
       - -X main.Build={{.ShortCommit}}
       - -X main.Commit={{.Commit}}
       - -X main.Branch={{.Branch}}
+    hooks:
+      post:
+        - codesign -s - -f "{{ .Path }}"
 
   - id: bd-windows-amd64
     main: ./cmd/bd


### PR DESCRIPTION
## Summary

macOS pre-built binaries currently lack CGO support, which means the Dolt backend doesn't work. Users have to build from source with CGO flags to use Dolt (see #1433).

This PR enables CGO for macOS builds by using GoReleaser Pro's split/merge feature to build macOS binaries on native macOS runners where ICU4C can be properly linked.

## Changes

### `.goreleaser.yml`
- Enable `CGO_ENABLED=1` for darwin builds (amd64 and arm64)
- Add `codesign` post-build hook for macOS binaries

### `.github/workflows/release.yml`
- Replace single `goreleaser` job with split/merge workflow:
  - `prepare` job: Matrix strategy running on `ubuntu-latest` (Linux/Windows/etc) and `macos-13` (macOS)
  - `release` job: Merges cached artifacts and publishes
- Install ICU4C on macOS runner for CGO compilation
- Use `goreleaser-pro` distribution with `GORELEASER_KEY` secret

## How it works

1. `prepare` job runs `goreleaser release --split` on each OS
   - Ubuntu builds: Linux, Windows, Android, FreeBSD (CGO disabled)
   - macOS builds: darwin/amd64, darwin/arm64 (CGO enabled with ICU4C)
2. Each job caches its `dist/{goos}` directory
3. `release` job restores all caches and runs `goreleaser continue --merge`

## Requirements

- `GORELEASER_KEY` secret must be set for GoReleaser Pro

## Test plan

- [ ] Verify GoReleaser Pro license/key is available
- [ ] Test workflow on a tag push or manual dispatch
- [ ] Verify macOS binaries have Dolt support: `bd init --backend dolt`

Fixes #1433

---

🤖 Generated with [Claude Code](https://claude.ai/code)