### PR TITLE
docs: define conventions for common issue.metadata keys

### DIFF
--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -1,0 +1,16 @@
+# Issue Metadata
+
+The `metadata` field on issues accepts arbitrary JSON. Any valid JSON value is stored as-is.
+
+## Reserved Key Prefixes
+
+| Prefix | Reserved For |
+|--------|------------|
+| `bd:` | Beads internal use |
+| `_` | Internal/private keys |
+
+Avoid these prefixes in user-defined keys to prevent conflicts with future Beads features.
+
+## Related
+
+- [#1416](https://github.com/steveyegge/beads/issues/1416) — Optional schema enforcement (future)


### PR DESCRIPTION
## Summary
- Documents the `metadata` field and reserved key prefixes (`bd:`, `_`)
- Intentionally minimal — no prescriptive conventions until real usage patterns emerge

Closes #1415

## Test plan
- [x] Doc is accurate and non-speculative

🤖 Generated with [Claude Code](https://claude.com/claude-code)