### PR TITLE
fix(update): log DB error when GetCustomTypes fails

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -124,7 +124,14 @@ create, update, show, or close operation).`,
 			if daemonClient == nil {
 				var customTypes []string
 				if store != nil {
-					if ct, err := store.GetCustomTypes(cmd.Context()); err == nil {
+					ct, err := store.GetCustomTypes(cmd.Context())
+					if err != nil {
+						// Log DB error but continue with YAML fallback (GH#1499 bd-2ll)
+						if !jsonOutput {
+							fmt.Fprintf(os.Stderr, "%s Failed to get custom types from DB: %v (falling back to config.yaml)\n",
+								ui.RenderWarn("!"), err)
+						}
+					} else {
 						customTypes = ct
 					}
 				}


### PR DESCRIPTION
## Problem

In direct mode (no daemon), when `store.GetCustomTypes()` returns a database error, the error is silently swallowed:

```go
if ct, err := store.GetCustomTypes(cmd.Context()); err == nil {
    customTypes = ct
}
```

The code then falls back to `config.yaml`, which may not have the custom types the user expects. If the type isn't found, the user sees:

```
invalid issue type "molecule". Valid types: bug, feature, task, epic, chore
```

This is misleading — the real problem is a database error, not an invalid type.

## Solution

Log the database error before falling back:

```
! Failed to get custom types from DB: <error> (falling back to config.yaml)
```

This preserves the graceful fallback behavior while giving users visibility into the actual problem.

## Test plan

- [x] Existing tests pass (`go test ./cmd/bd/...`)
- [ ] Manual: lock the DB file and run `bd update <id> --type=molecule` — verify warning appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)