### PR TITLE
fix: allow /var/home in safe boundary check (SEC-003)

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -36,14 +36,10 @@ beads.right.meta.json
 # These files are machine-specific and should not be shared across clones
 .sync.lock
 sync_base.jsonl
-config.local.yaml
+export-state/
 
-# Gas Town runtime files (local state)
-.gt-types-configured
-PRIME.md
-beads_rig/
-dolt/
-metadata.json
+# Process semaphore slot files (runtime concurrency limiting)
+sem/
 
 # NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.
 # They would override fork protection in .git/info/exclude, allowing

--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -252,6 +252,11 @@ func isPathInSafeBoundary(path string) bool {
 		return true
 	}
 
+	// Allow /var/home as a valid user home directory (used by Fedora Silverblue, Bluefin, etc.)
+	if strings.HasPrefix(absPath, "/var/home/") {
+		return true
+	}
+
 	for _, prefix := range unsafePrefixes {
 		if strings.HasPrefix(absPath, prefix+"/") || absPath == prefix {
 			return false


### PR DESCRIPTION
Fedora Silverblue and derivatives (like Bluefin) use /var/home as the user home directory instead of /home.

The isPathInSafeBoundary check was too restrictive and blocked all paths under /var, including legitimate user home directories.

This adds an explicit allowlist for /var/home/ paths since they are valid user home locations on these systems.

Fixes: BEADS_DIR points to unsafe location error on Fedora Silverblue systems