### PR TITLE
fix(config): log when viper uninitialized in getConfigList

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -786,6 +786,7 @@ func GetNamedRoles() []string {
 // getConfigList is a helper that retrieves a comma-separated list from config.yaml.
 func getConfigList(key string) []string {
 	if v == nil {
+		debug.Logf("config: viper not initialized, returning nil for key %q", key)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- Add `debug.Logf` call in `getConfigList()` when the viper instance is nil, making the silent nil return traceable
- Defense-in-depth: in practice daemon mode initializes config early, but if initialization fails this provides observability

## Context

Found during QA review of PR #1503 (silent-failure-hunter finding 2.2). When `config.Initialize()` was never called or failed, `GetCustomTypesFromYAML()` silently returns nil with no indication that the config system isn't operational.

## Test plan

- [x] Existing `TestGetCustomTypesFromYAML_NilViper` passes
- [x] All `TestGetCustomTypes*` tests pass
- [x] No new dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)