### PR TITLE
feat: add bd todo command for lightweight task management

### DIFF
--- a/cmd/bd/todo.go
+++ b/cmd/bd/todo.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var todoCmd = &cobra.Command{
+	Use:     "todo",
+	GroupID: "issues",
+	Short:   "Manage TODO items (convenience wrapper for task issues)",
+	Long: `Manage TODO items as lightweight task issues.
+
+TODOs are regular task-type issues with convenient shortcuts:
+  bd todo add "Title"    -> bd create "Title" -t task -p 2
+  bd todo                -> bd list --type task --status open
+  bd todo done <id>      -> bd close <id>
+
+TODOs can be promoted to full issues by changing type or priority:
+  bd update todo-123 --type bug --priority 0`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Default action: list todos
+		listTodosCmd.Run(cmd, args)
+	},
+}
+
+var addTodoCmd = &cobra.Command{
+	Use:   "add <title>",
+	Short: "Add a new TODO item",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("todo add")
+		title := strings.Join(args, " ")
+
+		// Get priority flag, default to 2
+		priority, _ := cmd.Flags().GetInt("priority")
+
+		// Get description flag
+		description, _ := cmd.Flags().GetString("description")
+
+		// Create the issue as a task type
+		ctx := rootCtx
+
+		issueType := types.TypeTask
+		issue := &types.Issue{
+			Title:       title,
+			Description: description,
+			Priority:    priority,
+			IssueType:   issueType,
+			Status:      types.StatusOpen,
+			Assignee:    getActorWithGit(),
+			Owner:       getOwner(),
+			CreatedBy:   getActorWithGit(),
+		}
+
+		// Generate ID
+		if err := store.CreateIssue(ctx, issue, getActorWithGit()); err != nil {
+			FatalError("failed to create TODO: %v", err)
+		}
+
+		if jsonOutput {
+			data, err := json.MarshalIndent(issue, "", "  ")
+			if err != nil {
+				FatalError("failed to marshal JSON: %v", err)
+			}
+			fmt.Println(string(data))
+		} else {
+			fmt.Printf("Created %s: %s\n", ui.RenderID(issue.ID), issue.Title)
+		}
+	},
+}
+
+var listTodosCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List TODO items",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get show-all flag
+		showAll, _ := cmd.Flags().GetBool("all")
+
+		ctx := rootCtx
+
+		// Build filter for task-type issues
+		taskType := types.TypeTask
+		filter := types.IssueFilter{
+			IssueType: &taskType,
+		}
+		if !showAll {
+			openStatus := types.StatusOpen
+			filter.Status = &openStatus
+		}
+
+		issues, err := store.SearchIssues(ctx, "", filter)
+		if err != nil {
+			FatalError("failed to list TODOs: %v", err)
+		}
+
+		if jsonOutput {
+			data, err := json.MarshalIndent(issues, "", "  ")
+			if err != nil {
+				FatalError("failed to marshal JSON: %v", err)
+			}
+			fmt.Println(string(data))
+		} else {
+			if len(issues) == 0 {
+				fmt.Println("No TODOs found")
+				return
+			}
+
+			// Sort by priority then ID
+			todoSortIssues(issues)
+
+			// Pretty print
+			for _, issue := range issues {
+				statusIcon := ui.RenderStatusIcon(string(issue.Status))
+				priority := ui.RenderPriority(issue.Priority)
+				fmt.Printf("  %s %s  %-40s  %s  %s\n",
+					statusIcon,
+					ui.RenderID(issue.ID),
+					todoTruncate(issue.Title, 40),
+					priority,
+					issue.Status)
+			}
+			fmt.Printf("\nTotal: %d TODOs\n", len(issues))
+		}
+	},
+}
+
+var doneTodoCmd = &cobra.Command{
+	Use:   "done <id> [<id>...]",
+	Short: "Mark TODO(s) as done",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("todo done")
+		ctx := rootCtx
+
+		reason, _ := cmd.Flags().GetString("reason")
+		if reason == "" {
+			reason = "Completed"
+		}
+
+		var closedIDs []string
+		for _, issueID := range args {
+			// Verify it exists
+			issue, err := store.GetIssue(ctx, issueID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to get issue %s: %v\n", issueID, err)
+				continue
+			}
+			if issue == nil {
+				fmt.Fprintf(os.Stderr, "Error: issue %s not found\n", issueID)
+				continue
+			}
+
+			// Close the issue (session is empty string for CLI operations)
+			if err := store.CloseIssue(ctx, issueID, reason, getActorWithGit(), ""); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to close %s: %v\n", issueID, err)
+				continue
+			}
+			closedIDs = append(closedIDs, issueID)
+		}
+
+		if jsonOutput {
+			data, err := json.MarshalIndent(map[string]interface{}{
+				"closed": closedIDs,
+				"reason": reason,
+			}, "", "  ")
+			if err != nil {
+				FatalError("failed to marshal JSON: %v", err)
+			}
+			fmt.Println(string(data))
+		} else {
+			for _, id := range closedIDs {
+				fmt.Printf("Closed %s\n", ui.RenderID(id))
+			}
+		}
+	},
+}
+
+func init() {
+	// Add subcommands
+	todoCmd.AddCommand(addTodoCmd)
+	todoCmd.AddCommand(listTodosCmd)
+	todoCmd.AddCommand(doneTodoCmd)
+
+	// Add flags
+	addTodoCmd.Flags().IntP("priority", "p", 2, "Priority (0-4, default 2)")
+	addTodoCmd.Flags().StringP("description", "d", "", "Description")
+
+	listTodosCmd.Flags().Bool("all", false, "Show all TODOs including completed")
+
+	doneTodoCmd.Flags().String("reason", "", "Reason for closing (default: Completed)")
+
+	// Register with root
+	rootCmd.AddCommand(todoCmd)
+}
+
+// todoTruncate truncates a string to the specified length with ellipsis
+func todoTruncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// todoSortIssues sorts issues by priority (ascending) then ID
+func todoSortIssues(issues []*types.Issue) {
+	slices.SortFunc(issues, func(a, b *types.Issue) int {
+		if a.Priority != b.Priority {
+			return a.Priority - b.Priority
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,165 @@
+# TODO Command
+
+The `bd todo` command provides a lightweight interface for managing TODO items as task-type issues.
+
+## Philosophy
+
+TODOs in bd are not a separate tracking system - they are regular task-type issues with convenient shortcuts. This means:
+
+- **No parallel systems**: TODOs use the same storage and sync as all other issues
+- **Promotable**: Easy to convert a TODO to a bug/feature when needed
+- **Full featured**: TODOs support all bd features (dependencies, labels, routing)
+- **Simple interface**: Quick commands for common TODO workflows
+
+## Quick Start
+
+```bash
+# Add a TODO
+bd todo add "Fix the login bug" -p 1
+
+# List TODOs
+bd todo
+
+# Mark TODO as done
+bd todo done <id>
+```
+
+## Commands
+
+### `bd todo` (or `bd todo list`)
+
+List all open task-type issues.
+
+```bash
+bd todo                  # List open TODOs
+bd todo list            # Same as above
+bd todo list --all      # Show completed TODOs too
+bd todo list --json     # JSON output
+```
+
+**Output:**
+```
+  ○ test-yxg  Fix the login bug                         ● P1  open
+  ○ test-ryl  Update documentation                      ● P3  open
+
+Total: 2 TODOs
+```
+
+### `bd todo add <title>`
+
+Create a new TODO item (task-type issue).
+
+```bash
+bd todo add "Fix the login bug"                                # Default P2
+bd todo add "Update docs" -p 3 -d "Add examples"              # With priority and description
+bd todo add "Critical fix" --priority 0 --description "ASAP"  # P0 task
+```
+
+**Flags:**
+- `-p, --priority <0-4>`: Priority (default: 2)
+- `-d, --description <text>`: Description
+
+### `bd todo done <id> [<id>...]`
+
+Mark one or more TODOs as complete.
+
+```bash
+bd todo done test-abc              # Close one TODO
+bd todo done test-abc test-def     # Close multiple
+bd todo done test-abc --reason "Fixed in PR #42"  # With reason
+```
+
+**Flags:**
+- `--reason <text>`: Reason for closing (default: "Completed")
+
+## Converting TODOs
+
+TODOs are regular task issues, so you can convert them:
+
+```bash
+# Promote TODO to bug
+bd update test-abc --type bug --priority 0
+
+# Add dependencies
+bd dep add test-abc test-def
+
+# Add labels
+bd update test-abc --labels "urgent,frontend"
+```
+
+## Viewing TODO Details
+
+Use regular bd commands:
+
+```bash
+bd show test-abc        # View TODO details
+bd list --type task     # List all tasks (including TODOs)
+bd ready               # See ready TODOs in work queue
+```
+
+## Examples
+
+### Daily TODO workflow
+
+```bash
+# Morning: add your tasks
+bd todo add "Review PRs"
+bd todo add "Fix CI pipeline" -p 1
+bd todo add "Update changelog" -p 3
+
+# Check what's on your plate
+bd todo
+
+# Complete work
+bd todo done <id>
+bd todo done <id>
+
+# End of day: see what's left
+bd todo
+```
+
+### Converting TODO to full issue
+
+```bash
+# Start with a quick TODO
+bd todo add "Login is broken"
+
+# Later, realize it's more serious
+bd update <id> --type bug --priority 0 --description "Users can't login, multiple reports"
+bd update <id> --acceptance "Login works for all user types"
+
+# Now it's a full-fledged bug with proper tracking
+bd show <id>
+```
+
+## FAQ
+
+**Q: Are TODOs different from tasks?**
+A: No, TODOs are just task-type issues. The `bd todo` command provides shortcuts for common task operations.
+
+**Q: Can TODOs have dependencies?**
+A: Yes! Use `bd dep add <todo-id> <blocks-id>` like any other issue.
+
+**Q: Do TODOs sync with git?**
+A: Yes, they're exported to `.beads/issues.jsonl` like all other issues.
+
+**Q: Can I use TODOs with bd ready?**
+A: Yes! `bd ready` shows all unblocked issues, including task-type TODOs.
+
+**Q: Should I use TODOs or regular tasks?**
+A: Use `bd todo` for quick, informal tasks. Use `bd create -t task` for tasks that need more context or are part of larger planning.
+
+## Design Rationale
+
+The TODO command follows beads' philosophy of **minimal surface area**:
+
+1. **No new types**: TODOs are task-type issues
+2. **No special storage**: Same database and JSONL as everything else
+3. **Convenience layer**: Just shortcuts for common operations
+4. **Fully compatible**: Works with all bd features and commands
+
+This ensures:
+- No duplicate tracking systems
+- No migration needed between TODOs and tasks
+- Works with all existing bd tooling (federation, compaction, routing)
+- Simple to understand and maintain


### PR DESCRIPTION
## Summary
- Adds `bd todo` command as a convenience wrapper around task-type issues
- `bd todo add "title"` — create a task (default P2)
- `bd todo` / `bd todo list` — list open tasks
- `bd todo done <id>` — mark task(s) complete

TODOs are regular task-type issues — no schema changes, no new storage. They support all bd features (deps, labels, routing) and can be promoted to full issues via `bd update`.

## Origin

Cleaned-up version of PR #1534 by @mattdurham (generated via Crush/Claude Sonnet). Changes from original:
- Removed ~270 files of unrelated `go fmt` formatting changes (should be a separate PR)
- Restored accidentally deleted `cmd/bd/doctor_migrate_fix_test.go` and `docs/METADATA.md`
- Fixed misleading comment in `doneTodoCmd`

## Test plan
- [x] `go build ./cmd/bd/` compiles cleanly
- [ ] Manual testing of `bd todo add`, `bd todo list`, `bd todo done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)