### PR TITLE
chore: cleanup .beads/.gitignore

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -36,14 +36,10 @@ beads.right.meta.json
 # These files are machine-specific and should not be shared across clones
 .sync.lock
 sync_base.jsonl
-config.local.yaml
+export-state/
 
-# Gas Town runtime files (local state)
-.gt-types-configured
-PRIME.md
-beads_rig/
-dolt/
-metadata.json
+# Process semaphore slot files (runtime concurrency limiting)
+sem/
 
 # NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.
 # They would override fork protection in .git/info/exclude, allowing


### PR DESCRIPTION
## Summary
- Remove Gas Town runtime entries (`.gt-types-configured`, `PRIME.md`, `beads_rig/`, `dolt/`, `metadata.json`)
- Add `export-state/` and `sem/` directories to ignore list
- Remove `config.local.yaml` entry (moved or no longer needed)

## Context
These gitignore changes were split out from PRs #1498, #1532, and #1539 as requested in review feedback to keep PRs single-concern.