### PR TITLE
Add Beadspace to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -33,6 +33,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[beads-pm-ui](https://github.com/qosha1/beads-pm-ui)** - Gantt chart timeline view, project / team based filtering (via folder structure), quarterly goal setting and dependency chain visualization. Inline editable. Built by [@qosha1](https://github.com/qosha1). (Nextjs/Typscript)
 
+- **[Beadspace](https://github.com/cameronsjo/beadspace)** - Drop-in GitHub Pages dashboard with triage suggestions, priority/status breakdowns, and searchable issue table. Single HTML file, zero build dependencies, auto-deploys via GitHub Action. Built by [@cameronsjo](https://github.com/cameronsjo). (HTML/CSS/JS)
+
 ## Editor Extensions
 
 - **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and daemon management. Built by [@jdillon](https://github.com/jdillon). (TypeScript)


### PR DESCRIPTION
## Summary

- Adds [Beadspace](https://github.com/cameronsjo/beadspace) to the Web UIs section of COMMUNITY_TOOLS.md

Drop-in GitHub Pages dashboard for beads. Single HTML file, zero build dependencies, auto-deploys via GitHub Action. Includes triage suggestions that auto-flag misprioritized items, searchable/sortable issue table, and pure CSS charts.

**Live example:** https://cameronsjo.github.io/llm-council/

Inspired by [@mattbeane](https://github.com/mattbeane)'s beads-viz-prototype.