### PR TITLE
fix(ci): resolve lint failures and test guard false positive

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -90,7 +90,7 @@ var configSetCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "Error: invalid role %q (valid values: maintainer, contributor)\n", value)
 				os.Exit(1)
 			}
-			cmd := exec.Command("git", "config", "beads.role", value)
+			cmd := exec.Command("git", "config", "beads.role", value) //nolint:gosec // value is validated against allowlist above
 			if err := cmd.Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "Error setting beads.role in git config: %v\n", err)
 				os.Exit(1)

--- a/cmd/bd/doctor_validate.go
+++ b/cmd/bd/doctor_validate.go
@@ -142,7 +142,7 @@ func applyValidateFixes(path string, checks []validateCheckResult) {
 		}
 		fmt.Print("\nContinue? (Y/n): ")
 		var response string
-		fmt.Scanln(&response)
+		_, _ = fmt.Scanln(&response)
 		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "" && response != "y" && response != "yes" {
 			fmt.Println("Fix canceled.")

--- a/cmd/bd/test_repo_beads_guard_test.go
+++ b/cmd/bd/test_repo_beads_guard_test.go
@@ -89,7 +89,7 @@ func TestMain(m *testing.M) {
 		"issues.jsonl",
 		"beads.jsonl",
 		"metadata.json",
-		"interactions.jsonl",
+		// interactions.jsonl excluded: legitimately created by init during tests
 		"deletions.jsonl",
 		"molecules.jsonl",
 		"daemon.lock",

--- a/internal/storage/sqlite/batch_ops.go
+++ b/internal/storage/sqlite/batch_ops.go
@@ -276,7 +276,7 @@ func (s *SQLiteStorage) CreateIssuesWithFullOptions(ctx context.Context, issues 
 	// Start IMMEDIATE transaction with retry logic for SQLITE_BUSY.
 	// Retries with exponential backoff handle cases where busy_timeout alone
 	// is insufficient (e.g., SQLITE_BUSY_SNAPSHOT).
-	if err := beginImmediateWithRetry(ctx, conn, 5, 10*time.Millisecond); err != nil {
+	if err := beginImmediateWithRetry(ctx, conn); err != nil {
 		return fmt.Errorf("failed to begin immediate transaction: %w", err)
 	}
 

--- a/internal/storage/sqlite/queries.go
+++ b/internal/storage/sqlite/queries.go
@@ -162,7 +162,7 @@ func (s *SQLiteStorage) CreateIssue(ctx context.Context, issue *types.Issue, act
 	// modes in BeginTx, and modernc.org/sqlite's BeginTx always uses DEFERRED mode.
 	//
 	// Retries with exponential backoff handle cases where busy_timeout alone is insufficient.
-	if err := beginImmediateWithRetry(ctx, conn, 5, 10*time.Millisecond); err != nil {
+	if err := beginImmediateWithRetry(ctx, conn); err != nil {
 		return fmt.Errorf("failed to begin immediate transaction: %w", err)
 	}
 

--- a/internal/storage/sqlite/transaction.go
+++ b/internal/storage/sqlite/transaction.go
@@ -58,7 +58,7 @@ func (s *SQLiteStorage) RunInTransaction(ctx context.Context, fn func(tx storage
 
 	// Start IMMEDIATE transaction to acquire write lock early.
 	// Use retry logic with exponential backoff to handle SQLITE_BUSY
-	if err := beginImmediateWithRetry(ctx, conn, 5, 10*time.Millisecond); err != nil {
+	if err := beginImmediateWithRetry(ctx, conn); err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
 
@@ -105,7 +105,9 @@ func (s *SQLiteStorage) RunInTransaction(ctx context.Context, fn func(tx storage
 // 1. Some BUSY errors aren't retryable by the busy handler (SQLITE_BUSY_SNAPSHOT)
 // 2. Explicit retries give us control over backoff timing
 // 3. We can log retry attempts for debugging
-func beginImmediateWithRetry(ctx context.Context, conn *sql.Conn, maxRetries int, initialBackoff time.Duration) error {
+func beginImmediateWithRetry(ctx context.Context, conn *sql.Conn) error {
+	const maxRetries = 5
+	const initialBackoff = 10 * time.Millisecond
 	backoff := initialBackoff
 	var lastErr error
 

--- a/internal/storage/sqlite/util.go
+++ b/internal/storage/sqlite/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"strings"
-	"time"
 )
 
 // QueryContext exposes the underlying database QueryContext method for advanced queries
@@ -41,7 +40,7 @@ func (s *SQLiteStorage) withTx(ctx context.Context, fn func(*sql.Conn) error) er
 	// rather than upgrading from a read lock later. Retries with exponential
 	// backoff handle cases where busy_timeout alone is insufficient
 	// (e.g., SQLITE_BUSY_SNAPSHOT).
-	if err := beginImmediateWithRetry(ctx, conn, 5, 10*time.Millisecond); err != nil {
+	if err := beginImmediateWithRetry(ctx, conn); err != nil {
 		return wrapDBError("begin transaction", err)
 	}
 


### PR DESCRIPTION
## Summary

- **errcheck**: handle `fmt.Scanln` return value in `cmd/bd/validate.go:198`
- **gosec G204**: add `nolint` directive for `exec.Command` in `cmd/bd/config.go:93` (input is validated against an allowlist)
- **unparam**: make `maxRetries` a const inside `beginImmediateWithRetry` since all 4 callers pass `5`
- **test guard**: exclude `interactions.jsonl` from watched files (legitimately created by `init` during tests)

These 4 issues are the sole cause of CI red on main (excluding the pre-existing Nix flake failure). 

## Related

- Supersedes #1532 (test guard fix for `interactions.jsonl`)
- Lint regressions introduced by #1542, #1543, #1544

## Test plan

- [ ] CI lint job passes (errcheck, gosec, unparam all resolved)
- [ ] CI test jobs pass on macOS and Ubuntu (test guard no longer flags `interactions.jsonl`)
- [ ] `go vet` and `go build` clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)