### PR TITLE
fix: dolt_conflicts column, doctor gastown detection, explicit routing mode

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -337,7 +337,7 @@ Checks:
   - federation.remote is set when sync.mode requires it
   - Remote URL format is valid (dolthub://, gs://, s3://, file://)
   - sync.branch is a valid git branch name
-  - routing.mode is valid (auto, maintainer, contributor)
+  - routing.mode is valid (auto, maintainer, contributor, explicit)
 
 Examples:
   bd config validate

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -293,6 +293,14 @@ func runDiagnostics(path string) doctorResult {
 		OverallOK:  true,
 	}
 
+	// Auto-detect gastown mode: routes.jsonl is only created by gastown workspaces
+	if !doctorGastown {
+		routesFile := filepath.Join(path, ".beads", "routes.jsonl")
+		if _, err := os.Stat(routesFile); err == nil {
+			doctorGastown = true
+		}
+	}
+
 	// Check 1: Installation (.beads/ directory)
 	installCheck := convertWithCategory(doctor.CheckInstallation(path), doctor.CategoryCore)
 	result.Checks = append(result.Checks, installCheck)

--- a/cmd/bd/doctor/config_values.go
+++ b/cmd/bd/doctor/config_values.go
@@ -22,6 +22,7 @@ var validRoutingModes = map[string]bool{
 	"auto":        true,
 	"maintainer":  true,
 	"contributor": true,
+	"explicit":    true,
 }
 
 // validBranchNameRegex validates git branch names

--- a/internal/storage/dolt/history.go
+++ b/internal/storage/dolt/history.go
@@ -310,9 +310,8 @@ type IssueDiff struct {
 // GetInternalConflicts returns any merge conflicts in the current state (internal format).
 // For the public interface, use GetConflicts which returns storage.Conflict.
 func (s *DoltStore) GetInternalConflicts(ctx context.Context) ([]*TableConflict, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT table_name, num_conflicts FROM dolt_conflicts
-	`)
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT `table`, num_conflicts FROM dolt_conflicts")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get conflicts: %w", err)
 	}


### PR DESCRIPTION
## Summary

Three fixes for Dolt-backed and Gas Town environments:

- **Fix dolt_conflicts query column name** (`history.go`): Dolt's `dolt_conflicts` system table uses column `table`, not `table_name`. This caused `bd doctor` to report "column not found" on the federation conflicts check.

- **Auto-detect gastown mode in `bd doctor`** (`doctor.go`): When `routes.jsonl` exists in `.beads/`, automatically set gastown mode so the JSONL files check doesn't false-warn about "Multiple JSONL files found: issues.jsonl, routes.jsonl". Previously required `--gastown` flag which nothing passed automatically.

- **Add `explicit` to valid routing modes** (`config_values.go`, `config.go`): Gas Town sets `routing.mode=explicit` for prefix-based routing. `bd doctor` rejected this as invalid (only accepted `auto`, `maintainer`, `contributor`), conflicting with `gt doctor` which requires `explicit`. Both tools now accept the same value.

## Test plan

- [ ] Run `bd doctor` in a Gas Town workspace — no JSONL or routing.mode warnings
- [ ] Run `bd doctor` in a Dolt-backed repo — federation conflicts check passes
- [ ] Run `gt doctor` — routing-mode check passes with `explicit`
- [ ] Run `bd doctor` in a non-gastown repo — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)