### PR TITLE
fix(doctor): correct brew upgrade command from "bd" to "beads"

### DIFF
--- a/cmd/bd/doctor/claude.go
+++ b/cmd/bd/doctor/claude.go
@@ -325,7 +325,7 @@ func CheckBdInPath() DoctorCheck {
 			Detail:  "Claude hooks execute 'bd prime' and won't work without bd in PATH",
 			Fix: "Install bd globally:\n" +
 				"  • Homebrew: brew install beads\n" +
-				"  • Script: curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n" +
+				"  • Script: " + installScriptCommand + "\n" +
 				"  • Or add bd to your PATH",
 		}
 	}
@@ -381,8 +381,8 @@ func CheckDocumentationBdPrimeReference(repoPath string) DoctorCheck {
 			Message: "Documentation references 'bd prime' but command not found",
 			Detail:  "Files: " + strings.Join(filesWithBdPrime, ", "),
 			Fix: "Upgrade bd to get the 'bd prime' command:\n" +
-				"  • Homebrew: brew upgrade bd\n" +
-				"  • Script: curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n" +
+				"  • Homebrew: brew upgrade beads\n" +
+				"  • Script: " + installScriptCommand + "\n" +
 				"  Or remove 'bd prime' references from documentation if using older version",
 		}
 	}

--- a/cmd/bd/doctor/version_test.go
+++ b/cmd/bd/doctor/version_test.go
@@ -65,6 +65,30 @@ func TestIsValidSemver(t *testing.T) {
 	}
 }
 
+func TestUpgradeCommandForPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		execPath string
+		expected string
+	}{
+		{"homebrew apple silicon", "/opt/homebrew/Cellar/beads/0.49.4/bin/bd", "brew upgrade beads"},
+		{"homebrew intel mac", "/usr/local/Cellar/beads/0.49.4/bin/bd", "brew upgrade beads"},
+		{"homebrew linux", "/home/linuxbrew/.linuxbrew/Cellar/beads/0.49.4/bin/bd", "brew upgrade beads"},
+		{"legacy tap formula", "/opt/homebrew/Cellar/bd/0.49.0/bin/bd", "brew upgrade beads"},
+		{"usr local bin symlink", "/usr/local/bin/bd", installScriptCommand},
+		{"go install", "/home/user/go/bin/bd", installScriptCommand},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := upgradeCommandForPath(tt.execPath)
+			if result != tt.expected {
+				t.Errorf("upgradeCommandForPath(%q)\n  got:  %q\n  want: %q", tt.execPath, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestParseVersionParts(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- `bd doctor` suggests `brew upgrade bd` but the homebrew-core formula is named `beads` (Formula/b/beads.rb). The legacy tap `steveyegge/homebrew-beads` had formula `bd.rb` but is stuck at v0.49.0. Fixes #1426.
- Extracted `upgradeCommandForPath` for testability and narrowed Homebrew detection to Cellar paths (symlinks are resolved by `EvalSymlinks`)
- Also fixed the same wrong command in `claude.go` and extracted a shared `installScriptCommand` constant

## Test plan

- [x] Added `TestUpgradeCommandForPath` with 6 table-driven subtests:
  - Apple Silicon, Intel Mac, Linuxbrew (all via `/Cellar/beads/`)
  - Legacy tap path (`/Cellar/bd/`) → still suggests `brew upgrade beads`
  - Non-Homebrew paths (`/usr/local/bin/bd`, `~/go/bin/bd`) → install script fallback
- [x] `go test ./cmd/bd/doctor/ -run TestUpgradeCommandForPath -v` — all pass
- [x] `go vet ./cmd/bd/doctor/` — clean
- [x] Full doctor test suite — no regressions (pre-existing git-env failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)