### PR TITLE
Fix daemon ignoring auto-sync config from YAML

### DIFF
--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -48,8 +48,13 @@ var YamlOnlyKeys = map[string]bool{
 	"sync.require_confirmation_on_mass_delete": true,
 
 	// Daemon settings (GH#871: team-wide auto-sync config)
+	"daemon.auto-sync":   true,
+	"daemon.auto_sync":   true,
+	"daemon.auto-commit": true,
 	"daemon.auto_commit": true,
+	"daemon.auto-push":   true,
 	"daemon.auto_push":   true,
+	"daemon.auto-pull":   true,
 	"daemon.auto_pull":   true,
 
 	// Routing settings


### PR DESCRIPTION
## Summary

- Viper treats hyphens and underscores as distinct in YAML keys (`daemon.auto-sync` vs `daemon.auto_sync`)
- `SetYamlConfig` writes flat keys preserving the original format, but `loadYAMLDaemonSettings` only checked hyphenated variants
- Users with underscore keys in config.yaml (e.g., `daemon.auto_commit: true`) had their settings silently ignored
- Added `getDaemonYAMLConfig()` helper that checks both hyphen and underscore variants
- Added both variants of all daemon keys to `YamlOnlyKeys` map

## Test plan

- [x] `go build ./cmd/bd/` compiles
- [x] `go test -short ./cmd/bd/` passes
- [x] `go test -short ./internal/config/` passes
- [ ] Manual test: set `daemon.auto_commit: true` in config.yaml, verify daemon starts with auto-commit enabled
- [ ] Manual test: set `daemon.auto-sync: true` in config.yaml, verify daemon starts with full sync

Fixes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)