### PR TITLE
Fix doctor role check false positive when role set via bd config

### DIFF
--- a/cmd/bd/doctor/role.go
+++ b/cmd/bd/doctor/role.go
@@ -1,38 +1,52 @@
 package doctor
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/factory"
 )
 
-// CheckBeadsRole verifies that beads.role is configured in git config.
-// This check helps users migrate from the deprecated URL-heuristic role detection
-// to explicit configuration.
+// CheckBeadsRole verifies that beads.role is configured.
+// Checks git config first (canonical location), then falls back to the
+// database config for users who ran "bd config set role maintainer"
+// (without the "beads." prefix) or "bd config set beads.role maintainer"
+// before GH#1531 moved storage to git config.
 func CheckBeadsRole(path string) DoctorCheck {
-	// Read beads.role from git config
+	// Read beads.role from git config (canonical location)
 	cmd := exec.Command("git", "config", "--get", "beads.role")
 	if path != "" {
 		cmd.Dir = path
 	}
 	output, err := cmd.Output()
 
-	if err != nil {
-		// Config not set - this is a warning, not an error
-		// Existing users can still work with URL heuristic fallback
-		return DoctorCheck{
-			Name:     "Role Configuration",
-			Status:   StatusWarning,
-			Message:  "beads.role not configured",
-			Detail:   "Run 'bd init' to configure your role (maintainer or contributor).",
-			Fix:      "bd init",
-			Category: CategoryData,
-		}
+	if err == nil {
+		role := strings.TrimSpace(string(output))
+		return validateRole(role)
 	}
 
-	role := strings.TrimSpace(string(output))
+	// Git config not set — check database config as fallback.
+	// Users may have set it via "bd config set role maintainer" (stored in SQLite)
+	// or the git config may be unavailable (e.g., worktree without local config).
+	if role := getRoleFromDatabase(path); role != "" {
+		return validateRole(role)
+	}
 
-	// Validate the role value
+	// Neither git config nor database has the role configured
+	return DoctorCheck{
+		Name:     "Role Configuration",
+		Status:   StatusWarning,
+		Message:  "beads.role not configured",
+		Detail:   "Run 'bd init' to configure your role (maintainer or contributor).",
+		Fix:      "bd config set beads.role maintainer",
+		Category: CategoryData,
+	}
+}
+
+// validateRole checks that the role value is valid and returns the appropriate check.
+func validateRole(role string) DoctorCheck {
 	if role != "maintainer" && role != "contributor" {
 		return DoctorCheck{
 			Name:     "Role Configuration",
@@ -51,3 +65,29 @@ func CheckBeadsRole(path string) DoctorCheck {
 		Category: CategoryData,
 	}
 }
+
+// getRoleFromDatabase checks for role in the database config.
+// Checks both "beads.role" and "role" keys since users may have used either.
+func getRoleFromDatabase(path string) string {
+	_, beadsDir := getBackendAndBeadsDir(path)
+	if beadsDir == "" {
+		return ""
+	}
+
+	ctx := context.Background()
+	store, err := factory.NewFromConfigWithOptions(ctx, beadsDir, factory.Options{ReadOnly: true})
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = store.Close() }()
+
+	// Check "beads.role" first, then "role"
+	for _, key := range []string{"beads.role", "role"} {
+		if val, err := store.GetConfig(ctx, key); err == nil && val != "" {
+			return strings.TrimSpace(val)
+		}
+	}
+
+	return ""
+}
+

--- a/cmd/bd/doctor/role_test.go
+++ b/cmd/bd/doctor/role_test.go
@@ -31,8 +31,8 @@ func TestCheckBeadsRole_NotConfigured(t *testing.T) {
 	if check.Name != "Role Configuration" {
 		t.Errorf("expected name 'Role Configuration', got %q", check.Name)
 	}
-	if check.Fix != "bd init" {
-		t.Errorf("expected fix 'bd init', got %q", check.Fix)
+	if check.Fix != "bd config set beads.role maintainer" {
+		t.Errorf("expected fix 'bd config set beads.role maintainer', got %q", check.Fix)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `CheckBeadsRole` only checked git config for `beads.role`, missing users who set their role via `bd config set role maintainer` (stored in SQLite)
- Now falls back to checking the database config for both `beads.role` and `role` keys when git config doesn't have the value
- Improved fix suggestion from generic `bd init` to specific `bd config set beads.role maintainer`

## Test plan

- [x] `go build ./cmd/bd/` compiles
- [x] `go test -short -run TestCheckBeadsRole ./cmd/bd/doctor/` passes (updated test for new fix suggestion)
- [ ] Manual test: `bd config set role maintainer` then `bd doctor` shows role as configured

Fixes #1509
Fixes #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)