### PR TITLE
Fix bd doctor fix suggestion: bd daemon stop requires workspace path

### DIFF
--- a/cmd/bd/doctor/daemon.go
+++ b/cmd/bd/doctor/daemon.go
@@ -235,7 +235,7 @@ func CheckDaemonAutoSync(path string) DoctorCheck {
 			Status:  StatusWarning,
 			Message: fmt.Sprintf("Daemon running without %v (slows agent workflows)", missing),
 			Detail:  "With sync-branch configured, auto-commit and auto-push should be enabled",
-			Fix:     "Restart daemon: bd daemon stop && bd daemon start",
+			Fix:     "Restart daemon: bd daemon stop . && bd daemon start",
 		}
 	}
 

--- a/internal/rpc/server_routing_validation_diagnostics.go
+++ b/internal/rpc/server_routing_validation_diagnostics.go
@@ -48,7 +48,7 @@ func (s *Server) checkVersionCompatibility(clientVersion string) error {
 		cmp := semver.Compare(serverVer, clientVer)
 		if cmp < 0 {
 			// Daemon is older - needs upgrade
-			return fmt.Errorf("incompatible major versions: client %s, daemon %s. Daemon is older; upgrade and restart daemon: 'bd daemon stop && bd daemon start'",
+			return fmt.Errorf("incompatible major versions: client %s, daemon %s. Daemon is older; upgrade and restart daemon: 'bd daemon stop . && bd daemon start'",
 				clientVersion, ServerVersion)
 		}
 		// Daemon is newer - client needs upgrade


### PR DESCRIPTION
## Summary

- `bd daemon stop` requires a workspace path or PID argument (`cobra.ExactArgs(1)`), but doctor suggestions omitted it
- Users following the suggested `bd daemon stop && bd daemon start` got: `Error: accepts 1 arg(s), received 0`
- Added ` .` (current directory) to `bd daemon stop` in fix suggestions so the commands work when copy-pasted
- Fixed in both `cmd/bd/doctor/daemon.go` (CheckDaemonAutoSync) and `internal/rpc/server_routing_validation_diagnostics.go` (version mismatch error)

## Test plan

- [x] `go build ./cmd/bd/` compiles
- [x] `go test -short -run TestCheckDaemon ./cmd/bd/doctor/` passes
- [x] `go test -short ./internal/rpc/` passes

Fixes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)