### PR TITLE
feat: Plugin-based issue tracker framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,5 @@ See [docs/COMMUNITY_TOOLS.md](docs/COMMUNITY_TOOLS.md) for a curated list of com
 ## 📝 Documentation
 
 * [Installing](docs/INSTALLING.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot Setup](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
+* [External Trackers](docs/TRACKERS.md) - Sync with Linear, Jira, Azure DevOps
 * [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/steveyegge/beads)

--- a/cmd/bd/tracker_helpers.go
+++ b/cmd/bd/tracker_helpers.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// syncStoreAdapter wraps storage.Storage to implement tracker.SyncStore.
+// The storage.Storage interface already has all the methods SyncStore needs,
+// so this adapter provides a clean type conversion.
+type syncStoreAdapter struct {
+	storage.Storage
+}
+
+// Ensure syncStoreAdapter implements tracker.SyncStore at compile time.
+var _ tracker.SyncStore = (*syncStoreAdapter)(nil)
+
+// newSyncStoreAdapter creates a new adapter wrapping the given storage.
+func newSyncStoreAdapter(s storage.Storage) *syncStoreAdapter {
+	return &syncStoreAdapter{s}
+}
+
+// GetIssue retrieves an issue by ID.
+func (a *syncStoreAdapter) GetIssue(ctx context.Context, id string) (*types.Issue, error) {
+	return a.Storage.GetIssue(ctx, id)
+}
+
+// GetIssueByExternalRef retrieves an issue by its external reference URL.
+func (a *syncStoreAdapter) GetIssueByExternalRef(ctx context.Context, externalRef string) (*types.Issue, error) {
+	return a.Storage.GetIssueByExternalRef(ctx, externalRef)
+}
+
+// SearchIssues searches for issues matching the query and filter.
+func (a *syncStoreAdapter) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	return a.Storage.SearchIssues(ctx, query, filter)
+}
+
+// CreateIssue creates a new issue.
+func (a *syncStoreAdapter) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
+	return a.Storage.CreateIssue(ctx, issue, actor)
+}
+
+// UpdateIssue updates an existing issue.
+func (a *syncStoreAdapter) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	return a.Storage.UpdateIssue(ctx, id, updates, actor)
+}
+
+// AddDependency adds a dependency between issues.
+func (a *syncStoreAdapter) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	return a.Storage.AddDependency(ctx, dep, actor)
+}
+
+// GetConfig retrieves a configuration value.
+func (a *syncStoreAdapter) GetConfig(ctx context.Context, key string) (string, error) {
+	return a.Storage.GetConfig(ctx, key)
+}
+
+// SetConfig stores a configuration value.
+func (a *syncStoreAdapter) SetConfig(ctx context.Context, key, value string) error {
+	return a.Storage.SetConfig(ctx, key, value)
+}
+
+// printSyncResult outputs the sync result in the appropriate format.
+// If jsonOutput is true, outputs JSON. Otherwise outputs human-readable text.
+func printSyncResult(result *tracker.SyncResult, dryRun bool, trackerName string) {
+	if jsonOutput {
+		outputJSON(result)
+		return
+	}
+
+	if dryRun {
+		fmt.Println("\n[DRY RUN] Sync preview complete (no changes made)")
+		if result.Stats.Created > 0 {
+			fmt.Printf("  Would create: %d issues\n", result.Stats.Created)
+		}
+		if result.Stats.Updated > 0 {
+			fmt.Printf("  Would update: %d issues\n", result.Stats.Updated)
+		}
+		if result.Stats.Conflicts > 0 {
+			fmt.Printf("  Would resolve: %d conflicts\n", result.Stats.Conflicts)
+		}
+		return
+	}
+
+	if result.Success {
+		fmt.Printf("\n%s sync complete\n", trackerName)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n%s sync failed: %s\n", trackerName, result.Error)
+	}
+
+	// Print warnings
+	if len(result.Warnings) > 0 {
+		fmt.Println("\nWarnings:")
+		for _, w := range result.Warnings {
+			fmt.Printf("  - %s\n", w)
+		}
+	}
+}
+
+// outputSyncResultJSON outputs the sync result as JSON.
+func outputSyncResultJSON(result *tracker.SyncResult) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(result)
+}
+
+// configStoreAdapter wraps storage.Storage to implement tracker.ConfigStore.
+// This is used for creating tracker.Config instances.
+type configStoreAdapter struct {
+	storage.Storage
+}
+
+// Ensure configStoreAdapter implements tracker.ConfigStore at compile time.
+var _ tracker.ConfigStore = (*configStoreAdapter)(nil)
+
+// newConfigStoreAdapter creates a new adapter wrapping the given storage.
+func newConfigStoreAdapter(s storage.Storage) *configStoreAdapter {
+	return &configStoreAdapter{s}
+}
+
+// GetConfig retrieves a configuration value.
+func (a *configStoreAdapter) GetConfig(ctx context.Context, key string) (string, error) {
+	return a.Storage.GetConfig(ctx, key)
+}
+
+// SetConfig stores a configuration value.
+func (a *configStoreAdapter) SetConfig(ctx context.Context, key, value string) error {
+	return a.Storage.SetConfig(ctx, key, value)
+}
+
+// GetAllConfig retrieves all configuration values.
+func (a *configStoreAdapter) GetAllConfig(ctx context.Context) (map[string]string, error) {
+	return a.Storage.GetAllConfig(ctx)
+}

--- a/cmd/bd/tracker_sync_test.go
+++ b/cmd/bd/tracker_sync_test.go
@@ -1,0 +1,775 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// mockFieldMapper implements tracker.FieldMapper for testing.
+type mockFieldMapper struct{}
+
+func (m *mockFieldMapper) PriorityToBeads(trackerPriority interface{}) int {
+	if p, ok := trackerPriority.(int); ok {
+		return p
+	}
+	return 2 // Default medium
+}
+
+func (m *mockFieldMapper) PriorityToTracker(beadsPriority int) interface{} {
+	return beadsPriority
+}
+
+func (m *mockFieldMapper) StatusToBeads(trackerState interface{}) types.Status {
+	if s, ok := trackerState.(string); ok {
+		switch s {
+		case "open", "todo", "backlog":
+			return types.StatusOpen
+		case "in_progress", "started", "active":
+			return types.StatusInProgress
+		case "closed", "done", "completed":
+			return types.StatusClosed
+		}
+	}
+	return types.StatusOpen
+}
+
+func (m *mockFieldMapper) StatusToTracker(beadsStatus types.Status) interface{} {
+	switch beadsStatus {
+	case types.StatusOpen:
+		return "todo"
+	case types.StatusInProgress:
+		return "in_progress"
+	case types.StatusClosed:
+		return "done"
+	default:
+		return "todo"
+	}
+}
+
+func (m *mockFieldMapper) TypeToBeads(trackerType interface{}) types.IssueType {
+	if t, ok := trackerType.(string); ok {
+		switch t {
+		case "bug":
+			return types.TypeBug
+		case "feature":
+			return types.TypeFeature
+		case "epic":
+			return types.TypeEpic
+		default:
+			return types.TypeTask
+		}
+	}
+	return types.TypeTask
+}
+
+func (m *mockFieldMapper) TypeToTracker(beadsType types.IssueType) interface{} {
+	return string(beadsType)
+}
+
+func (m *mockFieldMapper) IssueToBeads(trackerIssue *tracker.TrackerIssue) *tracker.IssueConversion {
+	issue := &types.Issue{
+		Title:       trackerIssue.Title,
+		Description: trackerIssue.Description,
+		Priority:    trackerIssue.Priority,
+		Status:      m.StatusToBeads(trackerIssue.State),
+		IssueType:   types.TypeTask,
+		Labels:      trackerIssue.Labels,
+		Assignee:    trackerIssue.Assignee,
+		CreatedAt:   trackerIssue.CreatedAt,
+		UpdatedAt:   trackerIssue.UpdatedAt,
+	}
+
+	// Set external_ref
+	if trackerIssue.URL != "" {
+		issue.ExternalRef = &trackerIssue.URL
+	}
+
+	// Handle closed issues
+	if trackerIssue.CompletedAt != nil {
+		issue.ClosedAt = trackerIssue.CompletedAt
+	}
+
+	return &tracker.IssueConversion{
+		Issue:        issue,
+		Dependencies: nil,
+	}
+}
+
+func (m *mockFieldMapper) LoadConfig(cfg tracker.ConfigLoader) {}
+
+// mockTracker implements tracker.IssueTracker for testing.
+type mockTracker struct {
+	name        string
+	displayName string
+	prefix      string
+	issues      []tracker.TrackerIssue
+	fetchErr    error
+	createErr   error
+	updateErr   error
+
+	// Track method calls for assertions
+	fetchCalled  bool
+	createCalled bool
+	updateCalled bool
+
+	// Created issues (for tracking what was pushed)
+	createdIssues []tracker.TrackerIssue
+
+	// Updated issues (for tracking what was pushed)
+	updatedIssues []tracker.TrackerIssue
+
+	// Config reference for validation
+	cfg *tracker.Config
+
+	// Field mapper for conversions
+	mapper *mockFieldMapper
+}
+
+func newMockTracker(name string) *mockTracker {
+	return &mockTracker{
+		name:          name,
+		displayName:   name,
+		prefix:        name,
+		issues:        []tracker.TrackerIssue{},
+		createdIssues: []tracker.TrackerIssue{},
+		updatedIssues: []tracker.TrackerIssue{},
+		mapper:        &mockFieldMapper{},
+	}
+}
+
+func (m *mockTracker) Name() string         { return m.name }
+func (m *mockTracker) DisplayName() string  { return m.displayName }
+func (m *mockTracker) ConfigPrefix() string { return m.prefix }
+
+func (m *mockTracker) Init(ctx context.Context, cfg *tracker.Config) error {
+	m.cfg = cfg
+	return nil
+}
+
+func (m *mockTracker) Validate() error { return nil }
+func (m *mockTracker) Close() error    { return nil }
+
+func (m *mockTracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([]tracker.TrackerIssue, error) {
+	m.fetchCalled = true
+	if m.fetchErr != nil {
+		return nil, m.fetchErr
+	}
+	return m.issues, nil
+}
+
+func (m *mockTracker) FetchIssue(ctx context.Context, identifier string) (*tracker.TrackerIssue, error) {
+	m.fetchCalled = true
+	if m.fetchErr != nil {
+		return nil, m.fetchErr
+	}
+	for _, issue := range m.issues {
+		if issue.Identifier == identifier {
+			return &issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *mockTracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	m.createCalled = true
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+
+	// Create a tracker issue from the beads issue
+	now := time.Now()
+	trackerIssue := tracker.TrackerIssue{
+		ID:          "ext-" + issue.ID,
+		Identifier:  m.prefix + "-" + issue.ID,
+		URL:         "https://" + m.name + ".example.com/issue/" + issue.ID,
+		Title:       issue.Title,
+		Description: issue.Description,
+		Priority:    issue.Priority,
+		State:       string(issue.Status),
+		Labels:      issue.Labels,
+		Assignee:    issue.Assignee,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	m.createdIssues = append(m.createdIssues, trackerIssue)
+	return &trackerIssue, nil
+}
+
+func (m *mockTracker) UpdateIssue(ctx context.Context, externalID string, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	m.updateCalled = true
+	if m.updateErr != nil {
+		return nil, m.updateErr
+	}
+
+	// Find and update the issue
+	for i, ti := range m.issues {
+		if ti.ID == externalID {
+			m.issues[i].Title = issue.Title
+			m.issues[i].Description = issue.Description
+			m.issues[i].Priority = issue.Priority
+			m.issues[i].State = string(issue.Status)
+			m.issues[i].UpdatedAt = time.Now()
+			m.updatedIssues = append(m.updatedIssues, m.issues[i])
+			return &m.issues[i], nil
+		}
+	}
+
+	// Issue not found, create a new tracker issue
+	trackerIssue := tracker.TrackerIssue{
+		ID:          externalID,
+		Identifier:  m.prefix + "-" + externalID,
+		URL:         "https://" + m.name + ".example.com/issue/" + externalID,
+		Title:       issue.Title,
+		Description: issue.Description,
+		Priority:    issue.Priority,
+		State:       string(issue.Status),
+		UpdatedAt:   time.Now(),
+	}
+	m.updatedIssues = append(m.updatedIssues, trackerIssue)
+	return &trackerIssue, nil
+}
+
+func (m *mockTracker) FieldMapper() tracker.FieldMapper {
+	return m.mapper
+}
+
+func (m *mockTracker) IsExternalRef(ref string) bool {
+	prefix := "https://" + m.name
+	return ref != "" && len(ref) > len(prefix) && ref[:len(prefix)] == prefix
+}
+
+func (m *mockTracker) ExtractIdentifier(ref string) string {
+	// Simple extraction: last part of the URL
+	if ref == "" {
+		return ""
+	}
+	return filepath.Base(ref)
+}
+
+func (m *mockTracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
+	return issue.URL
+}
+
+func (m *mockTracker) CanonicalizeRef(ref string) string {
+	return ref
+}
+
+// setupTrackerSyncTest creates a test environment with mock tracker and SyncEngine.
+func setupTrackerSyncTest(t *testing.T, trackerName string) (*mockTracker, *tracker.SyncEngine, *syncStoreAdapter, context.Context) {
+	t.Helper()
+
+	// Create temp directory for test database
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Create test store
+	testStore := newTestStore(t, dbPath)
+
+	// Create mock tracker
+	mock := newMockTracker(trackerName)
+
+	// Create config
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, trackerName, newConfigStoreAdapter(testStore))
+
+	// Initialize mock tracker
+	if err := mock.Init(ctx, cfg); err != nil {
+		t.Fatalf("Failed to init mock tracker: %v", err)
+	}
+
+	// Create sync store adapter
+	syncStore := newSyncStoreAdapter(testStore)
+
+	// Create sync engine
+	engine := tracker.NewSyncEngine(mock, cfg, syncStore, "test-actor")
+
+	// Capture messages for debugging (optional)
+	engine.OnMessage = func(msg string) {}
+	engine.OnWarning = func(msg string) {}
+
+	return mock, engine, syncStore, ctx
+}
+
+// TestSyncEngine_PullOnly tests that pull-only sync only fetches issues.
+func TestSyncEngine_PullOnly(t *testing.T) {
+	mock, engine, _, ctx := setupTrackerSyncTest(t, "test")
+
+	// Add some issues to the mock tracker
+	now := time.Now()
+	mock.issues = []tracker.TrackerIssue{
+		{
+			ID:          "ext-1",
+			Identifier:  "TEST-1",
+			URL:         "https://test.example.com/issue/TEST-1",
+			Title:       "Test Issue 1",
+			Description: "First test issue",
+			Priority:    2,
+			State:       "open",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		{
+			ID:          "ext-2",
+			Identifier:  "TEST-2",
+			URL:         "https://test.example.com/issue/TEST-2",
+			Title:       "Test Issue 2",
+			Description: "Second test issue",
+			Priority:    1,
+			State:       "in_progress",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+	}
+
+	// Execute pull-only sync
+	opts := tracker.SyncOptions{
+		Pull: true,
+		Push: false,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Verify results
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	if !mock.fetchCalled {
+		t.Error("Expected FetchIssues to be called")
+	}
+
+	if mock.createCalled {
+		t.Error("CreateIssue should not be called during pull-only")
+	}
+
+	// Verify stats
+	if result.Stats.Created != 2 {
+		t.Errorf("Expected 2 created issues, got %d", result.Stats.Created)
+	}
+}
+
+// TestSyncEngine_PushOnly tests that push-only sync only creates issues.
+func TestSyncEngine_PushOnly(t *testing.T) {
+	mock, engine, syncStore, ctx := setupTrackerSyncTest(t, "test")
+
+	// Create some local issues without external_ref
+	issue1 := &types.Issue{
+		Title:       "Local Issue 1",
+		Description: "First local issue",
+		Priority:    2,
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := syncStore.CreateIssue(ctx, issue1, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Execute push-only sync
+	opts := tracker.SyncOptions{
+		Pull:       false,
+		Push:       true,
+		UpdateRefs: true,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Verify results
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	if mock.fetchCalled {
+		t.Error("FetchIssues should not be called during push-only")
+	}
+
+	if !mock.createCalled {
+		t.Error("Expected CreateIssue to be called")
+	}
+
+	// Verify created issues
+	if len(mock.createdIssues) != 1 {
+		t.Errorf("Expected 1 created issue in tracker, got %d", len(mock.createdIssues))
+	}
+
+	// Verify stats
+	if result.Stats.Created != 1 {
+		t.Errorf("Expected 1 created issue, got %d", result.Stats.Created)
+	}
+}
+
+// TestSyncEngine_DryRun tests that dry run doesn't make changes.
+func TestSyncEngine_DryRun(t *testing.T) {
+	mock, engine, syncStore, ctx := setupTrackerSyncTest(t, "test")
+
+	// Add issues to mock tracker
+	now := time.Now()
+	mock.issues = []tracker.TrackerIssue{
+		{
+			ID:         "ext-1",
+			Identifier: "TEST-1",
+			URL:        "https://test.example.com/issue/TEST-1",
+			Title:      "Test Issue 1",
+			Priority:   2,
+			State:      "open",
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	}
+
+	// Create a local issue to push
+	issue := &types.Issue{
+		Title:     "Local Issue",
+		Priority:  2,
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := syncStore.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Execute dry run sync
+	opts := tracker.SyncOptions{
+		Pull:   true,
+		Push:   true,
+		DryRun: true,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Verify results
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	// Fetch was called (to get issues for dry run preview)
+	if !mock.fetchCalled {
+		t.Error("Expected FetchIssues to be called even in dry run")
+	}
+
+	// But no actual creation should happen
+	if len(mock.createdIssues) != 0 {
+		t.Errorf("Expected 0 created issues in dry run, got %d", len(mock.createdIssues))
+	}
+}
+
+// TestSyncEngine_BidirectionalSync tests pull and push together.
+func TestSyncEngine_BidirectionalSync(t *testing.T) {
+	mock, engine, syncStore, ctx := setupTrackerSyncTest(t, "test")
+
+	// Add an issue to the mock tracker for pulling
+	now := time.Now()
+	mock.issues = []tracker.TrackerIssue{
+		{
+			ID:         "ext-1",
+			Identifier: "TEST-1",
+			URL:        "https://test.example.com/issue/TEST-1",
+			Title:      "Remote Issue",
+			Priority:   1,
+			State:      "open",
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		},
+	}
+
+	// Create a local issue without external_ref for pushing
+	localIssue := &types.Issue{
+		Title:     "Local Issue",
+		Priority:  2,
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := syncStore.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Execute bidirectional sync
+	opts := tracker.SyncOptions{
+		Pull:       true,
+		Push:       true,
+		UpdateRefs: true,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Verify results
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	// Both should be called
+	if !mock.fetchCalled {
+		t.Error("Expected FetchIssues to be called")
+	}
+
+	if !mock.createCalled {
+		t.Error("Expected CreateIssue to be called")
+	}
+}
+
+// TestSyncEngine_CreateOnly tests that create-only doesn't update existing issues.
+func TestSyncEngine_CreateOnly(t *testing.T) {
+	mock, engine, syncStore, ctx := setupTrackerSyncTest(t, "test")
+
+	// Create a local issue with external_ref (would normally be updated)
+	externalRef := "https://test.example.com/issue/TEST-1"
+	localIssue := &types.Issue{
+		Title:       "Modified Local Issue",
+		Priority:    1,
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		ExternalRef: &externalRef,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	if err := syncStore.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Add another local issue without external_ref (should be created)
+	newIssue := &types.Issue{
+		Title:     "New Local Issue",
+		Priority:  2,
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := syncStore.CreateIssue(ctx, newIssue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Execute push with create-only
+	opts := tracker.SyncOptions{
+		Pull:       false,
+		Push:       true,
+		CreateOnly: true,
+		UpdateRefs: true,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Verify results
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	// Only one issue should be created (the one without external_ref)
+	if len(mock.createdIssues) != 1 {
+		t.Errorf("Expected 1 created issue, got %d", len(mock.createdIssues))
+	}
+
+	// No updates should happen in create-only mode
+	if len(mock.updatedIssues) != 0 {
+		t.Errorf("Expected 0 updated issues in create-only mode, got %d", len(mock.updatedIssues))
+	}
+}
+
+// TestSyncEngine_LastSyncTimestamp tests that last_sync is recorded.
+func TestSyncEngine_LastSyncTimestamp(t *testing.T) {
+	_, engine, syncStore, ctx := setupTrackerSyncTest(t, "test")
+
+	// Execute sync
+	opts := tracker.SyncOptions{
+		Pull: true,
+		Push: false,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	// Verify last_sync was set
+	if result.LastSync == "" {
+		t.Error("Expected LastSync to be set")
+	}
+
+	// Verify it's stored in config
+	stored, err := syncStore.GetConfig(ctx, "test.last_sync")
+	if err != nil {
+		t.Fatalf("Failed to get last_sync: %v", err)
+	}
+
+	if stored == "" {
+		t.Error("Expected last_sync to be stored in config")
+	}
+}
+
+// TestSyncEngine_ErrorHandling tests error handling during sync.
+func TestSyncEngine_ErrorHandling(t *testing.T) {
+	mock, engine, _, ctx := setupTrackerSyncTest(t, "test")
+
+	// Set up mock to return an error
+	mock.fetchErr = &tracker.ErrNotInitialized{Tracker: "test"}
+
+	// Execute sync
+	opts := tracker.SyncOptions{
+		Pull: true,
+		Push: false,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+
+	// Should return error
+	if err == nil {
+		t.Error("Expected error from sync")
+	}
+
+	// Result should indicate failure
+	if result.Success {
+		t.Error("Expected Success to be false")
+	}
+
+	if result.Error == "" {
+		t.Error("Expected Error message to be set")
+	}
+}
+
+// TestSyncEngine_ConflictResolutionLocal tests prefer-local conflict resolution.
+func TestSyncEngine_ConflictResolutionLocal(t *testing.T) {
+	mock, engine, syncStore, ctx := setupTrackerSyncTest(t, "test")
+
+	// Create a local issue with external_ref
+	now := time.Now()
+	localUpdated := now.Add(-1 * time.Hour)
+	externalRef := "https://test.example.com/issue/TEST-1"
+	localIssue := &types.Issue{
+		Title:       "Local Version",
+		Priority:    1,
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		ExternalRef: &externalRef,
+		CreatedAt:   now.Add(-2 * time.Hour),
+		UpdatedAt:   localUpdated,
+	}
+	if err := syncStore.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Set last_sync to before both updates
+	lastSync := now.Add(-3 * time.Hour).Format(time.RFC3339)
+	if err := syncStore.SetConfig(ctx, "test.last_sync", lastSync); err != nil {
+		t.Fatalf("Failed to set last_sync: %v", err)
+	}
+
+	// Add corresponding issue to mock tracker with different data
+	mock.issues = []tracker.TrackerIssue{
+		{
+			ID:         "ext-1",
+			Identifier: "TEST-1",
+			URL:        "https://test.example.com/issue/TEST-1",
+			Title:      "Remote Version",
+			Priority:   2,
+			State:      "open",
+			CreatedAt:  now.Add(-2 * time.Hour),
+			UpdatedAt:  now, // Remote is newer
+		},
+	}
+
+	// Execute sync with prefer-local
+	opts := tracker.SyncOptions{
+		Pull:               true,
+		Push:               true,
+		ConflictResolution: tracker.ConflictResolutionLocal,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Verify results
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+}
+
+// TestSyncEngine_ConflictResolutionExternal tests prefer-external conflict resolution.
+func TestSyncEngine_ConflictResolutionExternal(t *testing.T) {
+	mock, engine, syncStore, ctx := setupTrackerSyncTest(t, "test")
+
+	// Create a local issue with external_ref
+	now := time.Now()
+	localUpdated := now.Add(-1 * time.Hour)
+	externalRef := "https://test.example.com/issue/TEST-1"
+	localIssue := &types.Issue{
+		Title:       "Local Version",
+		Priority:    1,
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		ExternalRef: &externalRef,
+		CreatedAt:   now.Add(-2 * time.Hour),
+		UpdatedAt:   localUpdated,
+	}
+	if err := syncStore.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Set last_sync to before both updates
+	lastSync := now.Add(-3 * time.Hour).Format(time.RFC3339)
+	if err := syncStore.SetConfig(ctx, "test.last_sync", lastSync); err != nil {
+		t.Fatalf("Failed to set last_sync: %v", err)
+	}
+
+	// Add corresponding issue to mock tracker with different data
+	mock.issues = []tracker.TrackerIssue{
+		{
+			ID:         "ext-1",
+			Identifier: "TEST-1",
+			URL:        "https://test.example.com/issue/TEST-1",
+			Title:      "Remote Version",
+			Priority:   2,
+			State:      "open",
+			CreatedAt:  now.Add(-2 * time.Hour),
+			UpdatedAt:  now, // Remote is newer
+		},
+	}
+
+	// Execute sync with prefer-external
+	opts := tracker.SyncOptions{
+		Pull:               true,
+		Push:               true,
+		ConflictResolution: tracker.ConflictResolutionExternal,
+	}
+
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Verify results
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -13,6 +13,7 @@
 - [Molecular Chemistry](#molecular-chemistry)
 - [Database Management](#database-management)
 - [Editor Integration](#editor-integration)
+- [External Trackers](#external-trackers)
 
 ## Basic Operations
 
@@ -927,11 +928,36 @@ See also:
 - [AIDER_INTEGRATION.md](AIDER_INTEGRATION.md) - Detailed Aider guide
 - [CLAUDE_INTEGRATION.md](CLAUDE_INTEGRATION.md) - Claude integration design
 
+## External Trackers
+
+Beads integrates with external issue trackers for bidirectional sync.
+
+```bash
+# Linear
+bd linear sync --pull              # Import from Linear
+bd linear sync --push              # Export to Linear
+bd linear status                   # Show sync status
+
+# Jira
+bd jira sync --pull                # Import from Jira
+bd jira sync --push                # Export to Jira
+bd jira status                     # Show sync status
+
+# Azure DevOps
+bd azuredevops sync --pull         # Import from Azure DevOps
+bd ado sync --push                 # Export (short alias)
+bd ado status                      # Show sync status
+bd ado projects                    # List available projects
+```
+
+See [TRACKERS.md](TRACKERS.md) for full configuration and usage documentation.
+
 ## See Also
 
 - [AGENTS.md](../AGENTS.md) - Main agent workflow guide
 - [MOLECULES.md](MOLECULES.md) - Molecular chemistry metaphor (protos, pour, bond, squash, burn)
 - [DAEMON.md](DAEMON.md) - Daemon management and event-driven mode
 - [GIT_INTEGRATION.md](GIT_INTEGRATION.md) - Git workflows and merge strategies
+- [TRACKERS.md](TRACKERS.md) - External tracker integrations (Linear, Jira, Azure DevOps)
 - [LABELS.md](../LABELS.md) - Label system guide
 - [README.md](../README.md) - User documentation

--- a/docs/TRACKERS.md
+++ b/docs/TRACKERS.md
@@ -1,0 +1,407 @@
+# External Tracker Integrations
+
+Beads can sync issues bidirectionally with external issue trackers. This allows you to:
+- Import existing issues from your team's tracker into beads for local work
+- Export beads issues back to the tracker for team visibility
+- Keep both systems in sync with conflict resolution
+
+## Supported Trackers
+
+| Tracker | Command | Status |
+|---------|---------|--------|
+| [Linear](#linear) | `bd linear` | Production |
+| [Jira](#jira) | `bd jira` | Production |
+| [Azure DevOps](#azure-devops) | `bd azuredevops` / `bd ado` | Production |
+
+## Common Concepts
+
+All tracker integrations share the same sync model:
+
+### Sync Modes
+
+| Mode | Flag | Description |
+|------|------|-------------|
+| Pull | `--pull` | Import issues from tracker into beads |
+| Push | `--push` | Export beads issues to tracker |
+| Bidirectional | (no flags) | Pull then push with conflict resolution |
+
+### Conflict Resolution
+
+When the same issue is modified in both beads and the external tracker:
+
+| Flag | Behavior |
+|------|----------|
+| (default) | Newer timestamp wins |
+| `--prefer-local` | Always use beads version |
+| `--prefer-<tracker>` | Always use tracker version |
+
+### Common Flags
+
+```bash
+--dry-run       # Preview changes without making them
+--create-only   # Only create new issues, don't update existing
+--state <val>   # Filter by state: open, closed, all (default: all)
+```
+
+---
+
+## Linear
+
+Sync issues with [Linear](https://linear.app/).
+
+### Configuration
+
+```bash
+# Required
+bd config set linear.api_key "YOUR_API_KEY"
+bd config set linear.team_id "TEAM_UUID"
+
+# Optional - sync only one project
+bd config set linear.project_id "PROJECT_UUID"
+```
+
+**Environment variables** (alternative to config):
+- `LINEAR_API_KEY` - Linear API key
+- `LINEAR_TEAM_ID` - Linear team ID (UUID)
+
+### Commands
+
+```bash
+# Sync operations
+bd linear sync --pull              # Import from Linear
+bd linear sync --push              # Export to Linear
+bd linear sync                     # Bidirectional sync
+bd linear sync --dry-run           # Preview without changes
+bd linear sync --prefer-local      # Local wins on conflicts
+bd linear sync --prefer-linear     # Linear wins on conflicts
+
+# Status
+bd linear status                   # Show sync status
+bd linear status --json            # JSON output
+```
+
+### Field Mapping
+
+Linear fields are mapped to beads fields with sensible defaults. Override with config:
+
+**Priority mapping** (Linear 0-4 to Beads 0-4):
+```bash
+bd config set linear.priority_map.0 4    # No priority -> Backlog
+bd config set linear.priority_map.1 0    # Urgent -> Critical
+bd config set linear.priority_map.2 1    # High -> High
+bd config set linear.priority_map.3 2    # Medium -> Medium
+bd config set linear.priority_map.4 3    # Low -> Low
+```
+
+**State mapping** (Linear state type to beads status):
+```bash
+bd config set linear.state_map.backlog open
+bd config set linear.state_map.unstarted open
+bd config set linear.state_map.started in_progress
+bd config set linear.state_map.completed closed
+bd config set linear.state_map.canceled closed
+```
+
+**Label to issue type mapping**:
+```bash
+bd config set linear.label_type_map.bug bug
+bd config set linear.label_type_map.feature feature
+bd config set linear.label_type_map.epic epic
+```
+
+---
+
+## Jira
+
+Sync issues with [Jira](https://www.atlassian.com/software/jira) (Cloud or Server).
+
+### Configuration
+
+```bash
+# Required
+bd config set jira.url "https://company.atlassian.net"
+bd config set jira.project "PROJ"
+bd config set jira.api_token "YOUR_TOKEN"
+bd config set jira.username "your_email@company.com"  # For Jira Cloud
+```
+
+**Environment variables** (alternative to config):
+- `JIRA_API_TOKEN` - Jira API token
+- `JIRA_USERNAME` - Jira username/email
+
+### Commands
+
+```bash
+# Sync operations
+bd jira sync --pull                # Import from Jira
+bd jira sync --push                # Export to Jira
+bd jira sync                       # Bidirectional sync
+bd jira sync --dry-run             # Preview without changes
+bd jira sync --prefer-local        # Local wins on conflicts
+bd jira sync --prefer-jira         # Jira wins on conflicts
+
+# Status
+bd jira status                     # Show sync status
+bd jira status --json              # JSON output
+```
+
+### Getting a Jira API Token
+
+1. Go to [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens)
+2. Click "Create API token"
+3. Give it a name (e.g., "beads sync")
+4. Copy the token and configure beads
+
+---
+
+## Azure DevOps
+
+Sync work items with [Azure DevOps](https://dev.azure.com/).
+
+### Configuration
+
+```bash
+# Required
+bd config set azuredevops.organization "myorg"
+bd config set azuredevops.project "myproject"
+bd config set azuredevops.pat "YOUR_PERSONAL_ACCESS_TOKEN"
+```
+
+**Environment variables** (alternative to config):
+- `AZURE_DEVOPS_PAT` - Azure DevOps Personal Access Token
+- `AZURE_DEVOPS_ORGANIZATION` - Azure DevOps organization name
+- `AZURE_DEVOPS_PROJECT` - Azure DevOps project name
+
+### Commands
+
+```bash
+# Sync operations
+bd azuredevops sync --pull         # Import work items from Azure DevOps
+bd azuredevops sync --push         # Export issues to Azure DevOps
+bd azuredevops sync                # Bidirectional sync
+bd azuredevops sync --dry-run      # Preview without changes
+bd azuredevops sync --prefer-local # Local wins on conflicts
+bd azuredevops sync --prefer-ado   # Azure DevOps wins on conflicts
+
+# Short alias
+bd ado sync --pull                 # Same as bd azuredevops sync --pull
+
+# Status
+bd azuredevops status              # Show sync status
+bd ado status                      # Short alias
+bd ado status --json               # JSON output
+
+# List projects
+bd azuredevops projects            # List available projects
+bd ado projects                    # Short alias
+bd ado projects --json             # JSON output
+```
+
+### Getting a Personal Access Token (PAT)
+
+1. Go to Azure DevOps → User Settings → Personal Access Tokens
+2. Click "New Token"
+3. Give it a name (e.g., "beads sync")
+4. Set expiration as needed
+5. Select scopes:
+   - **Work Items**: Read & Write
+   - **Project and Team**: Read (for listing projects)
+6. Click "Create" and copy the token
+
+### Finding Your Project Name
+
+If you're not sure which project to use:
+
+```bash
+# First, configure PAT and organization
+bd config set azuredevops.pat "YOUR_PAT"
+bd config set azuredevops.organization "myorg"
+
+# List available projects
+bd ado projects
+
+# Output:
+# Available Azure DevOps Projects
+# ================================
+#
+# Name (use for azuredevops.project)        State         Visibility
+# ----------------------------------------  ------------  ----------
+# MyProject                                 wellFormed    private
+# AnotherProject                            wellFormed    private
+
+# Then configure the project
+bd config set azuredevops.project "MyProject"
+```
+
+### Field Mapping
+
+Azure DevOps fields are mapped to beads fields with sensible defaults. Override with config:
+
+**Priority mapping** (Azure DevOps 1-4 to Beads 0-4):
+```bash
+bd config set azuredevops.priority_map.1 1    # High -> High
+bd config set azuredevops.priority_map.2 2    # Medium -> Medium
+bd config set azuredevops.priority_map.3 3    # Low -> Low
+bd config set azuredevops.priority_map.4 4    # Backlog -> Backlog
+```
+
+Note: Beads priority 0 (Critical) maps to Azure DevOps priority 1 (High) since Azure DevOps doesn't have a Critical level.
+
+**Status mapping** (Azure DevOps state to beads status):
+```bash
+bd config set azuredevops.status_map.new open
+bd config set azuredevops.status_map.active in_progress
+bd config set azuredevops.status_map.resolved in_progress
+bd config set azuredevops.status_map.closed closed
+bd config set azuredevops.status_map.done closed
+bd config set azuredevops.status_map.removed closed
+bd config set azuredevops.status_map."to do" open
+bd config set azuredevops.status_map.doing in_progress
+bd config set azuredevops.status_map.approved open
+bd config set azuredevops.status_map.committed in_progress
+```
+
+**Work item type mapping** (Azure DevOps type to beads type):
+```bash
+bd config set azuredevops.type_map.bug bug
+bd config set azuredevops.type_map."user story" feature
+bd config set azuredevops.type_map.feature feature
+bd config set azuredevops.type_map."product backlog item" feature
+bd config set azuredevops.type_map.task task
+bd config set azuredevops.type_map.epic epic
+bd config set azuredevops.type_map.issue task
+bd config set azuredevops.type_map.impediment bug
+```
+
+### Default Type Mappings
+
+| Azure DevOps | Beads |
+|--------------|-------|
+| Bug | bug |
+| User Story | feature |
+| Product Backlog Item | feature |
+| Feature | feature |
+| Task | task |
+| Epic | epic |
+| Issue | task |
+| Impediment | bug |
+
+### Example Workflow
+
+```bash
+# 1. Configure Azure DevOps connection
+bd config set azuredevops.organization "contoso"
+bd config set azuredevops.pat "$AZURE_DEVOPS_PAT"
+
+# 2. Find and set your project
+bd ado projects
+bd config set azuredevops.project "WebApp"
+
+# 3. Check connection status
+bd ado status
+
+# 4. Import existing work items
+bd ado sync --pull --dry-run      # Preview first
+bd ado sync --pull                # Import
+
+# 5. Work locally with beads
+bd ready                          # Find work
+bd update bd-abc --status in_progress
+# ... do work ...
+bd close bd-abc --reason "Done"
+
+# 6. Sync back to Azure DevOps
+bd ado sync --push
+```
+
+---
+
+## Sync Best Practices
+
+### Initial Import
+
+When first connecting to a tracker, start with a pull-only dry run:
+
+```bash
+bd <tracker> sync --pull --dry-run
+```
+
+Review the output, then import:
+
+```bash
+bd <tracker> sync --pull
+```
+
+### Regular Workflow
+
+For daily use, bidirectional sync keeps both systems current:
+
+```bash
+bd <tracker> sync
+```
+
+### Avoiding Conflicts
+
+To minimize conflicts:
+1. Claim issues before working (`bd update <id> --status in_progress`)
+2. Sync frequently (`bd <tracker> sync`)
+3. Use `--prefer-local` or `--prefer-<tracker>` if you have a clear source of truth
+
+### External References
+
+After pushing a beads issue to a tracker, the `external_ref` field stores the tracker URL:
+
+```bash
+bd show bd-abc --json | jq .external_ref
+# "https://dev.azure.com/contoso/WebApp/_workitems/edit/123"
+```
+
+This enables:
+- Linking back to the original issue
+- Preventing duplicate creation on subsequent syncs
+- Tracking which issues have been exported
+
+---
+
+## Troubleshooting
+
+### Authentication Errors
+
+If you see authentication errors:
+
+1. Verify credentials are set:
+   ```bash
+   bd config get <tracker>.api_key  # or .pat, .api_token
+   ```
+
+2. Check environment variables are exported:
+   ```bash
+   echo $LINEAR_API_KEY
+   echo $JIRA_API_TOKEN
+   echo $AZURE_DEVOPS_PAT
+   ```
+
+3. Verify token permissions match required scopes
+
+### No Issues Synced
+
+If sync reports 0 issues:
+
+1. Check project/team configuration
+2. Verify you have access to the project
+3. Try with `--state all` to include closed issues
+4. Use `--dry-run` to see what would be synced
+
+### Conflict Resolution Issues
+
+If conflicts aren't resolving as expected:
+
+1. Use `--dry-run` to preview resolution
+2. Explicitly set resolution strategy (`--prefer-local` or `--prefer-<tracker>`)
+3. Check `updated_at` timestamps on conflicting issues
+
+## See Also
+
+- [CLI_REFERENCE.md](CLI_REFERENCE.md) - Full CLI command reference
+- [SYNC.md](SYNC.md) - Git-based sync architecture (internal beads sync)
+- [CONFIG.md](CONFIG.md) - Configuration system

--- a/internal/tracker/config.go
+++ b/internal/tracker/config.go
@@ -1,0 +1,143 @@
+package tracker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Config holds configuration for a tracker integration.
+// It wraps the config storage and provides a consistent interface
+// for accessing tracker-specific settings.
+type Config struct {
+	// Prefix is the config key prefix for this tracker (e.g., "linear", "jira")
+	Prefix string
+
+	// Store provides access to the config storage
+	Store ConfigStore
+
+	// Context for config operations
+	Ctx context.Context
+}
+
+// ConfigStore provides access to the beads configuration system.
+type ConfigStore interface {
+	GetConfig(ctx context.Context, key string) (string, error)
+	SetConfig(ctx context.Context, key, value string) error
+	GetAllConfig(ctx context.Context) (map[string]string, error)
+}
+
+// NewConfig creates a new tracker config with the given prefix and store.
+func NewConfig(ctx context.Context, prefix string, store ConfigStore) *Config {
+	return &Config{
+		Prefix: prefix,
+		Store:  store,
+		Ctx:    ctx,
+	}
+}
+
+// Get retrieves a config value by key, checking both the config store
+// and environment variables. The key should not include the tracker prefix.
+// Example: cfg.Get("api_key") for "linear" prefix looks up "linear.api_key"
+// and falls back to "LINEAR_API_KEY" env var.
+func (c *Config) Get(key string) (string, error) {
+	fullKey := c.Prefix + "." + key
+
+	// Try config store first
+	if c.Store != nil {
+		value, err := c.Store.GetConfig(c.Ctx, fullKey)
+		if err == nil && value != "" {
+			return value, nil
+		}
+	}
+
+	// Fall back to environment variable
+	envKey := c.envVarName(key)
+	if envKey != "" {
+		if value := os.Getenv(envKey); value != "" {
+			return value, nil
+		}
+	}
+
+	return "", nil
+}
+
+// GetRequired is like Get but returns an error if the value is empty.
+func (c *Config) GetRequired(key string) (string, error) {
+	value, err := c.Get(key)
+	if err != nil {
+		return "", err
+	}
+	if value == "" {
+		envKey := c.envVarName(key)
+		fullKey := c.Prefix + "." + key
+		hint := fmt.Sprintf("Run: bd config set %s \"VALUE\"", fullKey)
+		if envKey != "" {
+			hint += fmt.Sprintf("\nOr: export %s=VALUE", envKey)
+		}
+		return "", fmt.Errorf("%s not configured\n%s", fullKey, hint)
+	}
+	return value, nil
+}
+
+// Set stores a config value.
+func (c *Config) Set(key, value string) error {
+	if c.Store == nil {
+		return fmt.Errorf("config store not available")
+	}
+	fullKey := c.Prefix + "." + key
+	return c.Store.SetConfig(c.Ctx, fullKey, value)
+}
+
+// GetAll returns all config values with the tracker's prefix.
+func (c *Config) GetAll() (map[string]string, error) {
+	if c.Store == nil {
+		return make(map[string]string), nil
+	}
+
+	all, err := c.Store.GetAllConfig(c.Ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string)
+	prefix := c.Prefix + "."
+	for key, value := range all {
+		if strings.HasPrefix(key, prefix) {
+			shortKey := strings.TrimPrefix(key, prefix)
+			result[shortKey] = value
+		}
+	}
+	return result, nil
+}
+
+// GetAllConfig implements ConfigLoader interface for passing to FieldMapper.
+func (c *Config) GetAllConfig() (map[string]string, error) {
+	if c.Store == nil {
+		return make(map[string]string), nil
+	}
+	return c.Store.GetAllConfig(c.Ctx)
+}
+
+// envVarName converts a config key to its environment variable name.
+// Example: for prefix "linear" and key "api_key", returns "LINEAR_API_KEY"
+func (c *Config) envVarName(key string) string {
+	// Convert to uppercase and replace dots with underscores
+	envKey := strings.ToUpper(c.Prefix + "_" + key)
+	envKey = strings.ReplaceAll(envKey, ".", "_")
+	return envKey
+}
+
+// CommonConfig defines configuration keys used by all trackers.
+var CommonConfig = struct {
+	APIKey     string
+	LastSync   string
+	IDMode     string
+	HashLength string
+}{
+	APIKey:     "api_key",
+	LastSync:   "last_sync",
+	IDMode:     "id_mode",
+	HashLength: "hash_length",
+}

--- a/internal/tracker/mapper.go
+++ b/internal/tracker/mapper.go
@@ -1,0 +1,150 @@
+package tracker
+
+import (
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// FieldMapper defines the interface for bidirectional field mapping between
+// Beads and external trackers. Each tracker plugin implements this to handle
+// its specific field formats and values.
+type FieldMapper interface {
+	// Priority mapping (bidirectional)
+	// Beads uses 0-4: 0=critical, 1=high, 2=medium, 3=low, 4=backlog
+	PriorityToBeads(trackerPriority interface{}) int
+	PriorityToTracker(beadsPriority int) interface{}
+
+	// Status mapping (bidirectional)
+	// Beads uses: open, in_progress, blocked, deferred, closed, etc.
+	StatusToBeads(trackerState interface{}) types.Status
+	StatusToTracker(beadsStatus types.Status) interface{}
+
+	// Issue type mapping (bidirectional)
+	// Beads uses: bug, feature, task, epic, chore, etc.
+	TypeToBeads(trackerType interface{}) types.IssueType
+	TypeToTracker(beadsType types.IssueType) interface{}
+
+	// Full issue conversion (for import)
+	// Returns the converted issue and any dependencies to be created
+	IssueToBeads(trackerIssue *TrackerIssue) *IssueConversion
+
+	// LoadConfig loads mapping configuration from a config loader.
+	// This allows users to customize the mappings via bd config.
+	LoadConfig(cfg ConfigLoader)
+}
+
+// ConfigLoader is an interface for loading configuration values.
+// This allows the mapper to be decoupled from the storage layer.
+type ConfigLoader interface {
+	GetAllConfig() (map[string]string, error)
+}
+
+// BaseMappingConfig provides default mappings that are commonly used across trackers.
+// Tracker-specific mappers can embed this and override as needed.
+type BaseMappingConfig struct {
+	// PriorityMap maps tracker priority values (as string keys) to Beads priority (0-4).
+	PriorityMap map[string]int
+
+	// PriorityReverseMap maps Beads priority (as string keys) to tracker priority values.
+	PriorityReverseMap map[string]interface{}
+
+	// StateMap maps tracker state identifiers to Beads statuses.
+	StateMap map[string]string
+
+	// StateReverseMap maps Beads statuses to tracker state identifiers.
+	StateReverseMap map[string]interface{}
+
+	// LabelTypeMap maps label names to Beads issue types.
+	LabelTypeMap map[string]string
+
+	// TypeReverseMap maps Beads issue types to tracker type identifiers.
+	TypeReverseMap map[string]interface{}
+
+	// RelationMap maps tracker relation types to Beads dependency types.
+	RelationMap map[string]string
+}
+
+// DefaultBaseMappingConfig returns sensible defaults for common mappings.
+func DefaultBaseMappingConfig() *BaseMappingConfig {
+	return &BaseMappingConfig{
+		// Default priority mapping (tracker-specific, override as needed)
+		PriorityMap: map[string]int{
+			"0": 4, // No priority -> Backlog
+			"1": 0, // Urgent/Critical
+			"2": 1, // High
+			"3": 2, // Medium
+			"4": 3, // Low
+		},
+
+		// Default state mapping (tracker-specific, override as needed)
+		StateMap: map[string]string{
+			"backlog":   "open",
+			"unstarted": "open",
+			"todo":      "open",
+			"open":      "open",
+			"started":   "in_progress",
+			"active":    "in_progress",
+			"completed": "closed",
+			"done":      "closed",
+			"canceled":  "closed",
+		},
+
+		// Default label-to-type mapping
+		LabelTypeMap: map[string]string{
+			"bug":         "bug",
+			"defect":      "bug",
+			"feature":     "feature",
+			"enhancement": "feature",
+			"epic":        "epic",
+			"chore":       "chore",
+			"maintenance": "chore",
+			"task":        "task",
+		},
+
+		// Default relation mapping
+		RelationMap: map[string]string{
+			"blocks":    "blocks",
+			"blockedBy": "blocks",
+			"duplicate": "duplicates",
+			"related":   "related",
+			"parent":    "parent-child",
+		},
+	}
+}
+
+// ParseBeadsStatus converts a status string to types.Status.
+func ParseBeadsStatus(s string) types.Status {
+	switch s {
+	case "open":
+		return types.StatusOpen
+	case "in_progress", "in-progress", "inprogress":
+		return types.StatusInProgress
+	case "blocked":
+		return types.StatusBlocked
+	case "deferred":
+		return types.StatusDeferred
+	case "closed":
+		return types.StatusClosed
+	case "pinned":
+		return types.StatusPinned
+	default:
+		return types.StatusOpen
+	}
+}
+
+// ParseIssueType converts an issue type string to types.IssueType.
+func ParseIssueType(s string) types.IssueType {
+	switch s {
+	case "bug":
+		return types.TypeBug
+	case "feature":
+		return types.TypeFeature
+	case "task":
+		return types.TypeTask
+	case "epic":
+		return types.TypeEpic
+	case "chore":
+		return types.TypeChore
+	default:
+		return types.TypeTask
+	}
+}

--- a/internal/tracker/registry.go
+++ b/internal/tracker/registry.go
@@ -1,0 +1,120 @@
+package tracker
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// TrackerFactory is a function that creates a new IssueTracker instance.
+type TrackerFactory func() IssueTracker
+
+// Registry manages registered issue tracker plugins.
+// Tracker plugins register themselves at init time, and the registry
+// provides access to them by name.
+type Registry struct {
+	mu       sync.RWMutex
+	trackers map[string]TrackerFactory
+}
+
+// globalRegistry is the default registry used by Register and Get.
+var globalRegistry = &Registry{
+	trackers: make(map[string]TrackerFactory),
+}
+
+// Register adds a tracker factory to the global registry.
+// This is typically called from tracker plugin init() functions.
+// The name should be lowercase (e.g., "linear", "jira", "azuredevops").
+func Register(name string, factory TrackerFactory) {
+	globalRegistry.Register(name, factory)
+}
+
+// Get retrieves a tracker factory from the global registry.
+// Returns nil if no tracker with that name is registered.
+func Get(name string) TrackerFactory {
+	return globalRegistry.Get(name)
+}
+
+// List returns the names of all registered trackers.
+func List() []string {
+	return globalRegistry.List()
+}
+
+// NewTracker creates a new instance of the named tracker.
+// Returns an error if no tracker with that name is registered.
+func NewTracker(name string) (IssueTracker, error) {
+	return globalRegistry.NewTracker(name)
+}
+
+// Register adds a tracker factory to this registry.
+func (r *Registry) Register(name string, factory TrackerFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.trackers[name] = factory
+}
+
+// Get retrieves a tracker factory from this registry.
+func (r *Registry) Get(name string) TrackerFactory {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.trackers[name]
+}
+
+// List returns the names of all registered trackers, sorted alphabetically.
+func (r *Registry) List() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.trackers))
+	for name := range r.trackers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// NewTracker creates a new instance of the named tracker.
+func (r *Registry) NewTracker(name string) (IssueTracker, error) {
+	factory := r.Get(name)
+	if factory == nil {
+		available := r.List()
+		return nil, fmt.Errorf("unknown tracker %q (available: %v)", name, available)
+	}
+	return factory(), nil
+}
+
+// IsRegistered checks if a tracker with the given name is registered.
+func (r *Registry) IsRegistered(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.trackers[name]
+	return ok
+}
+
+// Clear removes all registered trackers. Used primarily for testing.
+func (r *Registry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.trackers = make(map[string]TrackerFactory)
+}
+
+// FindTrackerForRef attempts to find a registered tracker that recognizes
+// the given external_ref URL. Returns the tracker name and true if found,
+// or empty string and false if no tracker claims the URL.
+func FindTrackerForRef(externalRef string) (string, bool) {
+	return globalRegistry.FindTrackerForRef(externalRef)
+}
+
+// FindTrackerForRef attempts to find a tracker that recognizes the external_ref.
+func (r *Registry) FindTrackerForRef(externalRef string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for name, factory := range r.trackers {
+		tracker := factory()
+		if tracker.IsExternalRef(externalRef) {
+			return name, true
+		}
+	}
+	return "", false
+}

--- a/internal/tracker/registry_test.go
+++ b/internal/tracker/registry_test.go
@@ -1,0 +1,113 @@
+package tracker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// mockTracker is a minimal IssueTracker implementation for testing.
+type mockTracker struct {
+	name        string
+	displayName string
+	externalRef string
+}
+
+func (m *mockTracker) Name() string                                    { return m.name }
+func (m *mockTracker) DisplayName() string                             { return m.displayName }
+func (m *mockTracker) ConfigPrefix() string                            { return m.name }
+func (m *mockTracker) Init(_ context.Context, _ *Config) error         { return nil }
+func (m *mockTracker) Validate() error                                 { return nil }
+func (m *mockTracker) Close() error                                    { return nil }
+func (m *mockTracker) FetchIssues(_ context.Context, _ FetchOptions) ([]TrackerIssue, error) {
+	return nil, nil
+}
+func (m *mockTracker) FetchIssue(_ context.Context, _ string) (*TrackerIssue, error) {
+	return nil, nil
+}
+func (m *mockTracker) CreateIssue(_ context.Context, _ *types.Issue) (*TrackerIssue, error) {
+	return nil, nil
+}
+func (m *mockTracker) UpdateIssue(_ context.Context, _ string, _ *types.Issue) (*TrackerIssue, error) {
+	return nil, nil
+}
+func (m *mockTracker) FieldMapper() FieldMapper   { return nil }
+func (m *mockTracker) IsExternalRef(ref string) bool {
+	return len(ref) >= len(m.externalRef) && ref[:len(m.externalRef)] == m.externalRef
+}
+func (m *mockTracker) ExtractIdentifier(_ string) string { return "" }
+func (m *mockTracker) BuildExternalRef(_ *TrackerIssue) string { return "" }
+func (m *mockTracker) CanonicalizeRef(ref string) string { return ref }
+
+func TestRegistry(t *testing.T) {
+	// Create a new registry (not the global one)
+	r := &Registry{trackers: make(map[string]TrackerFactory)}
+
+	// Test registration
+	r.Register("mock1", func() IssueTracker {
+		return &mockTracker{name: "mock1", displayName: "Mock 1", externalRef: "mock1://"}
+	})
+	r.Register("mock2", func() IssueTracker {
+		return &mockTracker{name: "mock2", displayName: "Mock 2", externalRef: "mock2://"}
+	})
+
+	// Test Get
+	factory := r.Get("mock1")
+	if factory == nil {
+		t.Error("Get(\"mock1\") returned nil")
+	}
+
+	factory = r.Get("nonexistent")
+	if factory != nil {
+		t.Error("Get(\"nonexistent\") should return nil")
+	}
+
+	// Test List
+	names := r.List()
+	if len(names) != 2 {
+		t.Errorf("List() returned %d items, want 2", len(names))
+	}
+	if names[0] != "mock1" || names[1] != "mock2" {
+		t.Errorf("List() = %v, want [mock1, mock2]", names)
+	}
+
+	// Test NewTracker
+	tracker, err := r.NewTracker("mock1")
+	if err != nil {
+		t.Errorf("NewTracker(\"mock1\") failed: %v", err)
+	}
+	if tracker.Name() != "mock1" {
+		t.Errorf("tracker.Name() = %s, want mock1", tracker.Name())
+	}
+
+	_, err = r.NewTracker("nonexistent")
+	if err == nil {
+		t.Error("NewTracker(\"nonexistent\") should return error")
+	}
+
+	// Test IsRegistered
+	if !r.IsRegistered("mock1") {
+		t.Error("IsRegistered(\"mock1\") should return true")
+	}
+	if r.IsRegistered("nonexistent") {
+		t.Error("IsRegistered(\"nonexistent\") should return false")
+	}
+
+	// Test FindTrackerForRef
+	name, ok := r.FindTrackerForRef("mock1://test")
+	if !ok || name != "mock1" {
+		t.Errorf("FindTrackerForRef(\"mock1://test\") = (%s, %v), want (mock1, true)", name, ok)
+	}
+
+	name, ok = r.FindTrackerForRef("unknown://test")
+	if ok {
+		t.Errorf("FindTrackerForRef(\"unknown://test\") should return false")
+	}
+
+	// Test Clear
+	r.Clear()
+	if len(r.List()) != 0 {
+		t.Error("Clear() should remove all trackers")
+	}
+}

--- a/internal/tracker/stats.go
+++ b/internal/tracker/stats.go
@@ -1,0 +1,94 @@
+// Package tracker provides a plugin-based architecture for issue tracker integrations.
+// It defines common interfaces and types that allow different trackers (Linear, Jira,
+// Azure DevOps, etc.) to be integrated with a consistent API.
+package tracker
+
+import (
+	"time"
+)
+
+// SyncStats tracks statistics for a sync operation with any external tracker.
+// These statistics are accumulated during pull and push operations.
+type SyncStats struct {
+	Pulled    int `json:"pulled"`    // Issues pulled from external tracker
+	Pushed    int `json:"pushed"`    // Issues pushed to external tracker
+	Created   int `json:"created"`   // New issues created (either locally or remotely)
+	Updated   int `json:"updated"`   // Existing issues updated
+	Skipped   int `json:"skipped"`   // Issues skipped (no changes, filtered, etc.)
+	Errors    int `json:"errors"`    // Operations that failed
+	Conflicts int `json:"conflicts"` // Conflicts detected during bidirectional sync
+}
+
+// SyncResult represents the result of a complete sync operation.
+type SyncResult struct {
+	Success  bool      `json:"success"`            // Whether the overall sync succeeded
+	Stats    SyncStats `json:"stats"`              // Accumulated statistics
+	LastSync string    `json:"last_sync,omitempty"` // Timestamp of this sync (RFC3339)
+	Error    string    `json:"error,omitempty"`    // Error message if failed
+	Warnings []string  `json:"warnings,omitempty"` // Non-fatal warnings
+}
+
+// PullStats tracks statistics for a pull operation.
+type PullStats struct {
+	Created     int    // New issues created locally
+	Updated     int    // Existing issues updated
+	Skipped     int    // Issues skipped (no changes)
+	Incremental bool   // Whether this was an incremental sync
+	SyncedSince string // Timestamp we synced since (if incremental)
+}
+
+// PushStats tracks statistics for a push operation.
+type PushStats struct {
+	Created int // New issues created in external tracker
+	Updated int // Existing issues updated in external tracker
+	Skipped int // Issues skipped (no changes, filtered, etc.)
+	Errors  int // Operations that failed
+}
+
+// Conflict represents a conflict between local and external tracker versions.
+// A conflict occurs when both the local and external versions have been modified
+// since the last sync.
+type Conflict struct {
+	IssueID           string    // Beads issue ID
+	LocalUpdated      time.Time // When the local version was last modified
+	ExternalUpdated   time.Time // When the external version was last modified
+	ExternalRef       string    // URL or identifier for the external issue
+	ExternalID        string    // External tracker's identifier (e.g., "TEAM-123", "PROJ-456")
+	ExternalInternalID string    // External tracker's internal ID (e.g., UUID for API calls)
+}
+
+// ConflictResolution specifies how to handle conflicts during sync.
+type ConflictResolution string
+
+const (
+	// ConflictResolutionTimestamp resolves conflicts by keeping the newer version.
+	ConflictResolutionTimestamp ConflictResolution = "timestamp"
+	// ConflictResolutionLocal always keeps the local version.
+	ConflictResolutionLocal ConflictResolution = "local"
+	// ConflictResolutionExternal always keeps the external tracker's version.
+	ConflictResolutionExternal ConflictResolution = "external"
+)
+
+// DependencyInfo represents a dependency to be created after issue import.
+// Stored separately since we need all issues imported before linking dependencies.
+type DependencyInfo struct {
+	FromExternalID string // External identifier of the dependent issue
+	ToExternalID   string // External identifier of the dependency target
+	Type           string // Beads dependency type (blocks, related, duplicates, parent-child)
+}
+
+// IssueConversion holds the result of converting an external tracker issue to Beads.
+// It includes the issue and any dependencies that should be created.
+type IssueConversion struct {
+	Issue        interface{}      // *types.Issue - using interface to avoid circular import
+	Dependencies []DependencyInfo // Dependencies to create after all issues are imported
+}
+
+// ErrNotInitialized is returned when a tracker is used before Init is called.
+type ErrNotInitialized struct {
+	Tracker string
+}
+
+func (e *ErrNotInitialized) Error() string {
+	return e.Tracker + " tracker not initialized; call Init() first"
+}

--- a/internal/tracker/sync.go
+++ b/internal/tracker/sync.go
@@ -1,0 +1,741 @@
+package tracker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// SyncOptions configures sync behavior.
+type SyncOptions struct {
+	// Pull imports issues from the external tracker
+	Pull bool
+	// Push exports issues to the external tracker
+	Push bool
+	// DryRun previews sync without making changes
+	DryRun bool
+	// CreateOnly only creates new issues, doesn't update existing
+	CreateOnly bool
+	// UpdateRefs updates external_ref after creating issues
+	UpdateRefs bool
+	// State filters issues: "open", "closed", or "all"
+	State string
+	// ConflictResolution specifies how to handle conflicts
+	ConflictResolution ConflictResolution
+}
+
+// SyncEngine orchestrates synchronization between Beads and an external tracker.
+// It handles both pull (import) and push (export) operations, including
+// conflict detection and resolution.
+type SyncEngine struct {
+	// Tracker is the external tracker plugin
+	Tracker IssueTracker
+
+	// Config provides access to tracker configuration
+	Config *Config
+
+	// Store provides access to the Beads storage layer
+	Store SyncStore
+
+	// Actor is the actor name for audit logging
+	Actor string
+
+	// Callbacks for UI feedback (optional)
+	OnMessage func(msg string)
+	OnWarning func(msg string)
+}
+
+// SyncStore defines the storage operations needed by the sync engine.
+type SyncStore interface {
+	// Issue operations
+	GetIssue(ctx context.Context, id string) (*types.Issue, error)
+	GetIssueByExternalRef(ctx context.Context, externalRef string) (*types.Issue, error)
+	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
+	CreateIssue(ctx context.Context, issue *types.Issue, actor string) error
+	UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error
+
+	// Dependency operations
+	AddDependency(ctx context.Context, dep *types.Dependency, actor string) error
+
+	// Config operations
+	GetConfig(ctx context.Context, key string) (string, error)
+	SetConfig(ctx context.Context, key, value string) error
+}
+
+// NewSyncEngine creates a new sync engine for the given tracker.
+func NewSyncEngine(tracker IssueTracker, config *Config, store SyncStore, actor string) *SyncEngine {
+	return &SyncEngine{
+		Tracker: tracker,
+		Config:  config,
+		Store:   store,
+		Actor:   actor,
+	}
+}
+
+// Sync performs a sync operation with the given options.
+func (e *SyncEngine) Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
+	result := &SyncResult{Success: true}
+
+	// Default to bidirectional sync
+	if !opts.Pull && !opts.Push {
+		opts.Pull = true
+		opts.Push = true
+	}
+
+	var forceUpdateIDs map[string]bool
+	var skipUpdateIDs map[string]bool
+	var prePullSkipExternalIDs map[string]bool
+	var prePullConflicts []Conflict
+
+	// Pre-pull conflict detection for --prefer-local or --prefer-external
+	if opts.Pull && (opts.ConflictResolution == ConflictResolutionLocal ||
+		opts.ConflictResolution == ConflictResolutionExternal) {
+		conflicts, err := e.DetectConflicts(ctx)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("conflict detection failed: %v", err))
+		} else if len(conflicts) > 0 {
+			prePullConflicts = conflicts
+			if opts.ConflictResolution == ConflictResolutionLocal {
+				prePullSkipExternalIDs = make(map[string]bool, len(conflicts))
+				forceUpdateIDs = make(map[string]bool, len(conflicts))
+				for _, conflict := range conflicts {
+					prePullSkipExternalIDs[conflict.ExternalID] = true
+					forceUpdateIDs[conflict.IssueID] = true
+				}
+			} else if opts.ConflictResolution == ConflictResolutionExternal {
+				skipUpdateIDs = make(map[string]bool, len(conflicts))
+				for _, conflict := range conflicts {
+					skipUpdateIDs[conflict.IssueID] = true
+				}
+			}
+		}
+	}
+
+	// Step 1: Pull from tracker
+	if opts.Pull {
+		e.log(ctx, opts.DryRun, "Pulling issues from %s...", e.Tracker.DisplayName())
+
+		pullStats, err := e.doPull(ctx, opts, prePullSkipExternalIDs)
+		if err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			return result, err
+		}
+
+		result.Stats.Pulled = pullStats.Created + pullStats.Updated
+		result.Stats.Created += pullStats.Created
+		result.Stats.Updated += pullStats.Updated
+		result.Stats.Skipped += pullStats.Skipped
+
+		if !opts.DryRun {
+			e.log(ctx, false, "Pulled %d issues (%d created, %d updated)",
+				result.Stats.Pulled, pullStats.Created, pullStats.Updated)
+		}
+	}
+
+	// Step 2: Handle conflicts (if bidirectional)
+	if opts.Pull && opts.Push {
+		conflicts := prePullConflicts
+		var err error
+		if conflicts == nil {
+			conflicts, err = e.DetectConflicts(ctx)
+		}
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("conflict detection failed: %v", err))
+		} else if len(conflicts) > 0 {
+			result.Stats.Conflicts = len(conflicts)
+
+			if opts.DryRun {
+				e.logConflictsDryRun(ctx, opts, conflicts, &forceUpdateIDs, &skipUpdateIDs)
+			} else {
+				err := e.resolveConflicts(ctx, opts, conflicts, &forceUpdateIDs, &skipUpdateIDs, prePullConflicts)
+				if err != nil {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("conflict resolution failed: %v", err))
+				}
+			}
+		}
+	}
+
+	// Step 3: Push to tracker
+	if opts.Push {
+		e.log(ctx, opts.DryRun, "Pushing issues to %s...", e.Tracker.DisplayName())
+
+		pushStats, err := e.doPush(ctx, opts, forceUpdateIDs, skipUpdateIDs)
+		if err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			return result, err
+		}
+
+		result.Stats.Pushed = pushStats.Created + pushStats.Updated
+		result.Stats.Created += pushStats.Created
+		result.Stats.Updated += pushStats.Updated
+		result.Stats.Skipped += pushStats.Skipped
+		result.Stats.Errors += pushStats.Errors
+
+		if !opts.DryRun {
+			e.log(ctx, false, "Pushed %d issues (%d created, %d updated)",
+				result.Stats.Pushed, pushStats.Created, pushStats.Updated)
+		}
+	}
+
+	// Update last sync timestamp
+	if !opts.DryRun && result.Success {
+		result.LastSync = time.Now().Format(time.RFC3339)
+		key := e.Config.Prefix + ".last_sync"
+		if err := e.Store.SetConfig(ctx, key, result.LastSync); err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("failed to update last_sync: %v", err))
+		}
+	}
+
+	return result, nil
+}
+
+// DetectConflicts finds issues that have been modified both locally and in the tracker.
+func (e *SyncEngine) DetectConflicts(ctx context.Context) ([]Conflict, error) {
+	// Get last sync time
+	key := e.Config.Prefix + ".last_sync"
+	lastSyncStr, _ := e.Store.GetConfig(ctx, key)
+	if lastSyncStr == "" {
+		return nil, nil // No previous sync - no conflicts possible
+	}
+
+	lastSync, err := time.Parse(time.RFC3339, lastSyncStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid last_sync timestamp: %w", err)
+	}
+
+	// Get all local issues with external refs for this tracker
+	allIssues, err := e.Store.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		return nil, err
+	}
+
+	var conflicts []Conflict
+	for _, issue := range allIssues {
+		if issue.ExternalRef == nil || !e.Tracker.IsExternalRef(*issue.ExternalRef) {
+			continue
+		}
+
+		// Check if local issue was updated since last sync
+		if !issue.UpdatedAt.After(lastSync) {
+			continue
+		}
+
+		// Local was updated - now check if tracker was also updated
+		externalID := e.Tracker.ExtractIdentifier(*issue.ExternalRef)
+		if externalID == "" {
+			// Can't extract ID - treat as potential conflict
+			conflicts = append(conflicts, Conflict{
+				IssueID:     issue.ID,
+				LocalUpdated: issue.UpdatedAt,
+				ExternalRef: *issue.ExternalRef,
+			})
+			continue
+		}
+
+		// Fetch tracker issue to get its timestamp
+		trackerIssue, err := e.Tracker.FetchIssue(ctx, externalID)
+		if err != nil {
+			e.warn("couldn't fetch %s %s for conflict check: %v",
+				e.Tracker.DisplayName(), externalID, err)
+			conflicts = append(conflicts, Conflict{
+				IssueID:     issue.ID,
+				LocalUpdated: issue.UpdatedAt,
+				ExternalRef: *issue.ExternalRef,
+				ExternalID:  externalID,
+			})
+			continue
+		}
+		if trackerIssue == nil {
+			continue // Issue was deleted in tracker
+		}
+
+		// Only a conflict if tracker was ALSO updated since last sync
+		if trackerIssue.UpdatedAt.After(lastSync) {
+			conflicts = append(conflicts, Conflict{
+				IssueID:           issue.ID,
+				LocalUpdated:      issue.UpdatedAt,
+				ExternalUpdated:   trackerIssue.UpdatedAt,
+				ExternalRef:       *issue.ExternalRef,
+				ExternalID:        externalID,
+				ExternalInternalID: trackerIssue.ID,
+			})
+		}
+	}
+
+	return conflicts, nil
+}
+
+// doPull imports issues from the external tracker.
+func (e *SyncEngine) doPull(ctx context.Context, opts SyncOptions, skipExternalIDs map[string]bool) (*PullStats, error) {
+	stats := &PullStats{}
+
+	// Build fetch options
+	fetchOpts := FetchOptions{
+		State: opts.State,
+	}
+
+	// Check for incremental sync
+	key := e.Config.Prefix + ".last_sync"
+	lastSyncStr, _ := e.Store.GetConfig(ctx, key)
+	if lastSyncStr != "" {
+		lastSync, err := time.Parse(time.RFC3339, lastSyncStr)
+		if err == nil {
+			fetchOpts.Since = &lastSync
+			stats.Incremental = true
+			stats.SyncedSince = lastSyncStr
+			if !opts.DryRun {
+				e.log(ctx, false, "Incremental sync since %s", lastSync.Format("2006-01-02 15:04:05"))
+			}
+		}
+	}
+
+	// Fetch issues from tracker
+	trackerIssues, err := e.Tracker.FetchIssues(ctx, fetchOpts)
+	if err != nil {
+		return stats, fmt.Errorf("failed to fetch issues from %s: %w", e.Tracker.DisplayName(), err)
+	}
+
+	if len(trackerIssues) == 0 {
+		e.log(ctx, opts.DryRun, "No issues to import")
+		return stats, nil
+	}
+
+	// Filter out skipped issues
+	if len(skipExternalIDs) > 0 {
+		var filtered []TrackerIssue
+		for _, ti := range trackerIssues {
+			if skipExternalIDs[ti.Identifier] {
+				stats.Skipped++
+				continue
+			}
+			filtered = append(filtered, ti)
+		}
+		trackerIssues = filtered
+	}
+
+	if opts.DryRun {
+		e.log(ctx, true, "Would import %d issues from %s", len(trackerIssues), e.Tracker.DisplayName())
+		return stats, nil
+	}
+
+	// Convert and import issues
+	mapper := e.Tracker.FieldMapper()
+	var allDeps []DependencyInfo
+	externalIDToBeadsID := make(map[string]string)
+
+	for _, ti := range trackerIssues {
+		conversion := mapper.IssueToBeads(&ti)
+		issue := conversion.Issue.(*types.Issue)
+		allDeps = append(allDeps, conversion.Dependencies...)
+
+		// Check if issue already exists
+		var existing *types.Issue
+		if ti.URL != "" {
+			existing, _ = e.Store.GetIssueByExternalRef(ctx, ti.URL)
+		}
+
+		if existing != nil {
+			// Update existing issue
+			updates := e.buildUpdatesFromConversion(issue)
+			if err := e.Store.UpdateIssue(ctx, existing.ID, updates, e.Actor); err != nil {
+				e.warn("failed to update issue %s: %v", existing.ID, err)
+				continue
+			}
+			stats.Updated++
+			externalIDToBeadsID[ti.Identifier] = existing.ID
+		} else {
+			// Create new issue
+			if err := e.Store.CreateIssue(ctx, issue, e.Actor); err != nil {
+				e.warn("failed to create issue: %v", err)
+				continue
+			}
+			stats.Created++
+			externalIDToBeadsID[ti.Identifier] = issue.ID
+		}
+	}
+
+	// Create dependencies
+	e.createDependencies(ctx, allDeps, externalIDToBeadsID)
+
+	return stats, nil
+}
+
+// doPush exports issues to the external tracker.
+func (e *SyncEngine) doPush(ctx context.Context, opts SyncOptions, forceUpdateIDs, skipUpdateIDs map[string]bool) (*PushStats, error) {
+	stats := &PushStats{}
+
+	// Get all local issues
+	allIssues, err := e.Store.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		return stats, fmt.Errorf("failed to get local issues: %w", err)
+	}
+
+	var toCreate []*types.Issue
+	var toUpdate []*types.Issue
+
+	for _, issue := range allIssues {
+		if issue.IsTombstone() {
+			continue
+		}
+
+		if issue.ExternalRef != nil && e.Tracker.IsExternalRef(*issue.ExternalRef) {
+			if !opts.CreateOnly {
+				toUpdate = append(toUpdate, issue)
+			}
+		} else if issue.ExternalRef == nil {
+			toCreate = append(toCreate, issue)
+		}
+	}
+
+	// Create new issues
+	for _, issue := range toCreate {
+		if opts.DryRun {
+			stats.Created++
+			continue
+		}
+
+		trackerIssue, err := e.Tracker.CreateIssue(ctx, issue)
+		if err != nil {
+			e.warn("failed to create issue '%s' in %s: %v", issue.Title, e.Tracker.DisplayName(), err)
+			stats.Errors++
+			continue
+		}
+
+		stats.Created++
+		e.log(ctx, false, "Created: %s -> %s", issue.ID, trackerIssue.Identifier)
+
+		// Update external_ref
+		if opts.UpdateRefs && trackerIssue.URL != "" {
+			externalRef := e.Tracker.CanonicalizeRef(trackerIssue.URL)
+			if externalRef == "" {
+				externalRef = trackerIssue.URL
+			}
+			updates := map[string]interface{}{
+				"external_ref": externalRef,
+			}
+			if err := e.Store.UpdateIssue(ctx, issue.ID, updates, e.Actor); err != nil {
+				e.warn("failed to update external_ref for %s: %v", issue.ID, err)
+				stats.Errors++
+			}
+		}
+	}
+
+	// Update existing issues
+	if !opts.CreateOnly && len(toUpdate) > 0 {
+		for _, issue := range toUpdate {
+			if skipUpdateIDs != nil && skipUpdateIDs[issue.ID] {
+				stats.Skipped++
+				continue
+			}
+
+			externalID := e.Tracker.ExtractIdentifier(*issue.ExternalRef)
+			if externalID == "" {
+				e.warn("could not extract identifier from %s: %s", issue.ID, *issue.ExternalRef)
+				stats.Errors++
+				continue
+			}
+
+			// Fetch current tracker version to check if update needed
+			trackerIssue, err := e.Tracker.FetchIssue(ctx, externalID)
+			if err != nil {
+				e.warn("failed to fetch %s issue %s: %v", e.Tracker.DisplayName(), externalID, err)
+				stats.Errors++
+				continue
+			}
+			if trackerIssue == nil {
+				e.warn("%s issue %s not found (may have been deleted)", e.Tracker.DisplayName(), externalID)
+				stats.Skipped++
+				continue
+			}
+
+			// Skip if tracker is newer (unless forced)
+			forcedUpdate := forceUpdateIDs != nil && forceUpdateIDs[issue.ID]
+			if !forcedUpdate && !issue.UpdatedAt.After(trackerIssue.UpdatedAt) {
+				stats.Skipped++
+				continue
+			}
+
+			if opts.DryRun {
+				stats.Updated++
+				continue
+			}
+
+			// Update in tracker
+			updatedIssue, err := e.Tracker.UpdateIssue(ctx, trackerIssue.ID, issue)
+			if err != nil {
+				e.warn("failed to update %s issue %s: %v", e.Tracker.DisplayName(), externalID, err)
+				stats.Errors++
+				continue
+			}
+
+			stats.Updated++
+			e.log(ctx, false, "Updated: %s -> %s", issue.ID, updatedIssue.Identifier)
+		}
+	}
+
+	if opts.DryRun {
+		e.log(ctx, true, "Would create %d issues in %s", stats.Created, e.Tracker.DisplayName())
+		if !opts.CreateOnly {
+			e.log(ctx, true, "Would update %d issues in %s", stats.Updated, e.Tracker.DisplayName())
+		}
+	}
+
+	return stats, nil
+}
+
+// resolveConflicts handles conflict resolution during sync.
+func (e *SyncEngine) resolveConflicts(ctx context.Context, opts SyncOptions, conflicts []Conflict,
+	forceUpdateIDs, skipUpdateIDs *map[string]bool, prePullConflicts []Conflict) error {
+
+	switch opts.ConflictResolution {
+	case ConflictResolutionLocal:
+		e.log(ctx, false, "Resolving %d conflicts (preferring local)", len(conflicts))
+		if *forceUpdateIDs == nil {
+			*forceUpdateIDs = make(map[string]bool, len(conflicts))
+			for _, conflict := range conflicts {
+				(*forceUpdateIDs)[conflict.IssueID] = true
+			}
+		}
+
+	case ConflictResolutionExternal:
+		e.log(ctx, false, "Resolving %d conflicts (preferring %s)", len(conflicts), e.Tracker.DisplayName())
+		if *skipUpdateIDs == nil {
+			*skipUpdateIDs = make(map[string]bool, len(conflicts))
+			for _, conflict := range conflicts {
+				(*skipUpdateIDs)[conflict.IssueID] = true
+			}
+		}
+		// Re-import conflicts if we haven't already
+		if prePullConflicts == nil {
+			if err := e.reimportConflicts(ctx, conflicts); err != nil {
+				return err
+			}
+		}
+
+	default: // Timestamp-based
+		e.log(ctx, false, "Resolving %d conflicts (newer wins)", len(conflicts))
+		return e.resolveConflictsByTimestamp(ctx, conflicts, forceUpdateIDs, skipUpdateIDs)
+	}
+
+	return nil
+}
+
+// resolveConflictsByTimestamp resolves conflicts by keeping the newer version.
+func (e *SyncEngine) resolveConflictsByTimestamp(ctx context.Context, conflicts []Conflict,
+	forceUpdateIDs, skipUpdateIDs *map[string]bool) error {
+
+	var externalWins []Conflict
+	var localWins []Conflict
+
+	for _, c := range conflicts {
+		if c.ExternalUpdated.After(c.LocalUpdated) {
+			externalWins = append(externalWins, c)
+		} else {
+			localWins = append(localWins, c)
+		}
+	}
+
+	if len(externalWins) > 0 {
+		e.log(ctx, false, "%d conflict(s): %s is newer, will re-import", len(externalWins), e.Tracker.DisplayName())
+	}
+	if len(localWins) > 0 {
+		e.log(ctx, false, "%d conflict(s): Local is newer, will push", len(localWins))
+	}
+
+	// Re-import tracker-wins
+	if len(externalWins) > 0 {
+		if err := e.reimportConflicts(ctx, externalWins); err != nil {
+			return fmt.Errorf("failed to re-import %s-wins conflicts: %w", e.Tracker.DisplayName(), err)
+		}
+		if *skipUpdateIDs == nil {
+			*skipUpdateIDs = make(map[string]bool)
+		}
+		for _, c := range externalWins {
+			(*skipUpdateIDs)[c.IssueID] = true
+		}
+	}
+
+	// Mark local-wins for forced update
+	if len(localWins) > 0 {
+		if *forceUpdateIDs == nil {
+			*forceUpdateIDs = make(map[string]bool)
+		}
+		for _, c := range localWins {
+			(*forceUpdateIDs)[c.IssueID] = true
+		}
+	}
+
+	return nil
+}
+
+// reimportConflicts re-imports conflicting issues from the tracker.
+func (e *SyncEngine) reimportConflicts(ctx context.Context, conflicts []Conflict) error {
+	if len(conflicts) == 0 {
+		return nil
+	}
+
+	mapper := e.Tracker.FieldMapper()
+	resolved := 0
+	failed := 0
+
+	for _, conflict := range conflicts {
+		trackerIssue, err := e.Tracker.FetchIssue(ctx, conflict.ExternalID)
+		if err != nil {
+			e.warn("failed to fetch %s for resolution: %v", conflict.ExternalID, err)
+			failed++
+			continue
+		}
+		if trackerIssue == nil {
+			e.warn("%s issue %s not found, skipping", e.Tracker.DisplayName(), conflict.ExternalID)
+			failed++
+			continue
+		}
+
+		conversion := mapper.IssueToBeads(trackerIssue)
+		issue := conversion.Issue.(*types.Issue)
+		updates := e.buildUpdatesFromConversion(issue)
+
+		if err := e.Store.UpdateIssue(ctx, conflict.IssueID, updates, e.Actor); err != nil {
+			e.warn("failed to update local issue %s: %v", conflict.IssueID, err)
+			failed++
+			continue
+		}
+
+		e.log(ctx, false, "Resolved: %s <- %s (%s wins)", conflict.IssueID, conflict.ExternalID, e.Tracker.DisplayName())
+		resolved++
+	}
+
+	if failed > 0 {
+		return fmt.Errorf("%d conflict(s) failed to resolve", failed)
+	}
+
+	e.log(ctx, false, "Resolved %d conflict(s) by keeping %s version", resolved, e.Tracker.DisplayName())
+	return nil
+}
+
+// logConflictsDryRun logs conflict resolution actions for dry run mode.
+func (e *SyncEngine) logConflictsDryRun(ctx context.Context, opts SyncOptions, conflicts []Conflict,
+	forceUpdateIDs, skipUpdateIDs *map[string]bool) {
+
+	switch opts.ConflictResolution {
+	case ConflictResolutionLocal:
+		e.log(ctx, true, "Would resolve %d conflicts (preferring local)", len(conflicts))
+		*forceUpdateIDs = make(map[string]bool, len(conflicts))
+		for _, c := range conflicts {
+			(*forceUpdateIDs)[c.IssueID] = true
+		}
+
+	case ConflictResolutionExternal:
+		e.log(ctx, true, "Would resolve %d conflicts (preferring %s)", len(conflicts), e.Tracker.DisplayName())
+		*skipUpdateIDs = make(map[string]bool, len(conflicts))
+		for _, c := range conflicts {
+			(*skipUpdateIDs)[c.IssueID] = true
+		}
+
+	default:
+		e.log(ctx, true, "Would resolve %d conflicts (newer wins)", len(conflicts))
+		var externalWins, localWins []Conflict
+		for _, c := range conflicts {
+			if c.ExternalUpdated.After(c.LocalUpdated) {
+				externalWins = append(externalWins, c)
+			} else {
+				localWins = append(localWins, c)
+			}
+		}
+		if len(localWins) > 0 {
+			*forceUpdateIDs = make(map[string]bool, len(localWins))
+			for _, c := range localWins {
+				(*forceUpdateIDs)[c.IssueID] = true
+			}
+		}
+		if len(externalWins) > 0 {
+			*skipUpdateIDs = make(map[string]bool, len(externalWins))
+			for _, c := range externalWins {
+				(*skipUpdateIDs)[c.IssueID] = true
+			}
+		}
+	}
+}
+
+// buildUpdatesFromConversion builds an updates map from a converted issue.
+func (e *SyncEngine) buildUpdatesFromConversion(issue *types.Issue) map[string]interface{} {
+	updates := map[string]interface{}{
+		"title":       issue.Title,
+		"description": issue.Description,
+		"priority":    issue.Priority,
+		"status":      string(issue.Status),
+	}
+
+	if issue.Assignee != "" {
+		updates["assignee"] = issue.Assignee
+	}
+	if len(issue.Labels) > 0 {
+		updates["labels"] = issue.Labels
+	}
+	if !issue.UpdatedAt.IsZero() {
+		updates["updated_at"] = issue.UpdatedAt
+	}
+	if issue.ClosedAt != nil {
+		updates["closed_at"] = *issue.ClosedAt
+	}
+
+	return updates
+}
+
+// createDependencies creates dependencies from import conversion.
+func (e *SyncEngine) createDependencies(ctx context.Context, deps []DependencyInfo, idMap map[string]string) {
+	created := 0
+	for _, dep := range deps {
+		fromID, fromOK := idMap[dep.FromExternalID]
+		toID, toOK := idMap[dep.ToExternalID]
+
+		if !fromOK || !toOK {
+			continue
+		}
+
+		dependency := &types.Dependency{
+			IssueID:     fromID,
+			DependsOnID: toID,
+			Type:        types.DependencyType(dep.Type),
+			CreatedAt:   time.Now(),
+		}
+		err := e.Store.AddDependency(ctx, dependency, e.Actor)
+		if err != nil {
+			// Ignore duplicate errors
+			if !strings.Contains(err.Error(), "already exists") &&
+				!strings.Contains(err.Error(), "duplicate") {
+				e.warn("failed to create dependency %s -> %s (%s): %v",
+					fromID, toID, dep.Type, err)
+			}
+		} else {
+			created++
+		}
+	}
+
+	if created > 0 {
+		e.log(ctx, false, "Created %d dependencies from %s relations", created, e.Tracker.DisplayName())
+	}
+}
+
+// log sends a message to the OnMessage callback or does nothing.
+func (e *SyncEngine) log(_ context.Context, dryRun bool, format string, args ...interface{}) {
+	if e.OnMessage != nil {
+		prefix := ""
+		if dryRun {
+			prefix = "[DRY RUN] "
+		}
+		e.OnMessage(prefix + fmt.Sprintf(format, args...))
+	}
+}
+
+// warn sends a warning to the OnWarning callback or does nothing.
+func (e *SyncEngine) warn(format string, args ...interface{}) {
+	if e.OnWarning != nil {
+		e.OnWarning(fmt.Sprintf("Warning: "+format, args...))
+	}
+}

--- a/internal/tracker/sync_e2e_test.go
+++ b/internal/tracker/sync_e2e_test.go
@@ -1,0 +1,1037 @@
+//go:build integration
+
+package tracker_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/tracker/azuredevops"
+	"github.com/steveyegge/beads/internal/tracker/jira"
+	"github.com/steveyegge/beads/internal/tracker/testutil"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// syncTestStore is an in-memory implementation of tracker.SyncStore for testing.
+type syncTestStore struct {
+	mu         sync.RWMutex
+	issues     map[string]*types.Issue
+	config     map[string]string
+	deps       map[string][]*types.Dependency
+	nextID     int
+}
+
+func newSyncTestStore(t *testing.T) (*syncTestStore, func()) {
+	t.Helper()
+	return &syncTestStore{
+		issues:     make(map[string]*types.Issue),
+		config:     make(map[string]string),
+		deps:       make(map[string][]*types.Dependency),
+		nextID:     1,
+	}, func() {}
+}
+
+func (s *syncTestStore) GetIssue(ctx context.Context, id string) (*types.Issue, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, nil
+	}
+	return issue, nil
+}
+
+func (s *syncTestStore) GetIssueByExternalRef(ctx context.Context, externalRef string) (*types.Issue, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, issue := range s.issues {
+		if issue.ExternalRef != nil && *issue.ExternalRef == externalRef {
+			return issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *syncTestStore) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []*types.Issue
+	for _, issue := range s.issues {
+		result = append(result, issue)
+	}
+	return result, nil
+}
+
+func (s *syncTestStore) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if issue.ID == "" {
+		issue.ID = stringFromID(s.nextID)
+		s.nextID++
+	}
+	s.issues[issue.ID] = issue
+	return nil
+}
+
+func (s *syncTestStore) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil
+	}
+	// Apply updates
+	if title, ok := updates["title"].(string); ok {
+		issue.Title = title
+	}
+	if desc, ok := updates["description"].(string); ok {
+		issue.Description = desc
+	}
+	if status, ok := updates["status"].(string); ok {
+		issue.Status = types.Status(status)
+	}
+	if priority, ok := updates["priority"].(int); ok {
+		issue.Priority = priority
+	}
+	if ref, ok := updates["external_ref"].(string); ok {
+		issue.ExternalRef = &ref
+	}
+	issue.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *syncTestStore) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deps[dep.IssueID] = append(s.deps[dep.IssueID], dep)
+	return nil
+}
+
+func (s *syncTestStore) GetConfig(ctx context.Context, key string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config[key], nil
+}
+
+func (s *syncTestStore) SetConfig(ctx context.Context, key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.config[key] = value
+	return nil
+}
+
+func (s *syncTestStore) GetAllConfig(ctx context.Context) (map[string]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make(map[string]string)
+	for k, v := range s.config {
+		result[k] = v
+	}
+	return result, nil
+}
+
+// TestE2E_Sync_JiraPullEmpty tests pulling from Jira when no issues exist.
+func TestE2E_Sync_JiraPullEmpty(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	// Create Jira plugin tracker
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient}
+
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: false}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	if result.Stats.Created != 0 {
+		t.Errorf("Expected 0 created, got %d", result.Stats.Created)
+	}
+}
+
+// TestE2E_Sync_JiraPullWithData tests pulling issues from Jira.
+func TestE2E_Sync_JiraPullWithData(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	// Set up test data
+	mock.SetIssues([]jira.Issue{
+		testutil.MakeJiraIssue("PROJ-1", "First Issue", "To Do"),
+		testutil.MakeJiraIssue("PROJ-2", "Second Issue", "In Progress"),
+	})
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: false}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	if result.Stats.Created != 2 {
+		t.Errorf("Expected 2 created, got %d", result.Stats.Created)
+	}
+
+	// Verify issues were created in local store
+	issues, _ := store.SearchIssues(ctx, "", types.IssueFilter{})
+	if len(issues) != 2 {
+		t.Errorf("Expected 2 issues in store, got %d", len(issues))
+	}
+}
+
+// TestE2E_Sync_AzureDevOpsPullEmpty tests pulling from Azure DevOps when no work items exist.
+func TestE2E_Sync_AzureDevOpsPullEmpty(t *testing.T) {
+	mock := testutil.NewAzureDevOpsMockServer()
+	defer mock.Close()
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	adoClient := azuredevops.NewClient("testorg", "testproj", "test-pat").
+		WithEndpoint(mock.URL())
+
+	adoTracker := &adoTrackerAdapter{client: adoClient}
+
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, "azuredevops", store)
+
+	engine := tracker.NewSyncEngine(adoTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: false}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	if result.Stats.Created != 0 {
+		t.Errorf("Expected 0 created, got %d", result.Stats.Created)
+	}
+}
+
+// TestE2E_Sync_AzureDevOpsPullWithData tests pulling work items from Azure DevOps.
+func TestE2E_Sync_AzureDevOpsPullWithData(t *testing.T) {
+	mock := testutil.NewAzureDevOpsMockServer()
+	defer mock.Close()
+
+	// Set up test data
+	mock.SetWorkItems([]azuredevops.WorkItem{
+		testutil.MakeADOWorkItem(1, "First Work Item", "New"),
+		testutil.MakeADOWorkItem(2, "Second Work Item", "Active"),
+	})
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	adoClient := azuredevops.NewClient("testorg", "testproj", "test-pat").
+		WithEndpoint(mock.URL())
+
+	adoTracker := &adoTrackerAdapter{client: adoClient, baseURL: mock.URL()}
+
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, "azuredevops", store)
+
+	engine := tracker.NewSyncEngine(adoTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: false}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	if result.Stats.Created != 2 {
+		t.Errorf("Expected 2 created, got %d", result.Stats.Created)
+	}
+
+	// Verify issues were created in local store
+	issues, _ := store.SearchIssues(ctx, "", types.IssueFilter{})
+	if len(issues) != 2 {
+		t.Errorf("Expected 2 issues in store, got %d", len(issues))
+	}
+}
+
+// TestE2E_Sync_PushNew tests pushing new local issues to tracker.
+func TestE2E_Sync_PushNew(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	// Configure create response
+	createdIssue := testutil.MakeJiraIssue("PROJ-100", "Pushed Issue", "To Do")
+	mock.SetCreateIssueResponse(&createdIssue)
+	mock.AddIssue(createdIssue)
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	// Create a local issue without external_ref
+	ctx := context.Background()
+	localIssue := &types.Issue{
+		Title:     "Local Issue",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		Priority:  2,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := store.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create local issue: %v", err)
+	}
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: false, Push: true, UpdateRefs: true}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	if result.Stats.Created != 1 {
+		t.Errorf("Expected 1 created, got %d", result.Stats.Created)
+	}
+}
+
+// TestE2E_Sync_BidirectionalFull tests full bidirectional sync.
+func TestE2E_Sync_BidirectionalFull(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	// Set up remote issues to pull
+	mock.SetIssues([]jira.Issue{
+		testutil.MakeJiraIssue("PROJ-1", "Remote Issue 1", "To Do"),
+	})
+
+	// Configure create response for push
+	createdIssue := testutil.MakeJiraIssue("PROJ-100", "Pushed Issue", "To Do")
+	mock.SetCreateIssueResponse(&createdIssue)
+	// Also add to issues list so FetchIssue can find it after creation
+	mock.AddIssue(createdIssue)
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	// Create a local issue to push
+	ctx := context.Background()
+	localIssue := &types.Issue{
+		Title:     "Local Issue",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		Priority:  2,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := store.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create local issue: %v", err)
+	}
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: true, UpdateRefs: true}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	// Should have pulled (1 original + 1 pre-added for CreateIssue FetchIssue) and pushed 1
+	if result.Stats.Pulled != 2 {
+		t.Errorf("Expected 2 pulled, got %d", result.Stats.Pulled)
+	}
+
+	if result.Stats.Pushed != 1 {
+		t.Errorf("Expected 1 pushed, got %d", result.Stats.Pushed)
+	}
+}
+
+// TestE2E_Sync_DryRun tests dry run mode.
+func TestE2E_Sync_DryRun(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	mock.SetIssues([]jira.Issue{
+		testutil.MakeJiraIssue("PROJ-1", "Remote Issue", "To Do"),
+	})
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: false, DryRun: true}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+
+	// Verify no issues were actually created
+	issues, _ := store.SearchIssues(ctx, "", types.IssueFilter{})
+	if len(issues) != 0 {
+		t.Errorf("Expected 0 issues in store during dry run, got %d", len(issues))
+	}
+}
+
+// TestE2E_Sync_AuthError tests sync failure with auth error.
+func TestE2E_Sync_AuthError(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	mock.SetAuthError(true)
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "invalid-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: false}
+	result, err := engine.Sync(ctx, opts)
+
+	if err == nil {
+		t.Fatal("Expected sync to fail with auth error")
+	}
+
+	if result.Success {
+		t.Error("Expected result.Success to be false")
+	}
+}
+
+// TestE2E_Sync_LastSyncTimestamp tests that last_sync is recorded.
+func TestE2E_Sync_LastSyncTimestamp(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	mock.SetIssues([]jira.Issue{})
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	ctx := context.Background()
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{Pull: true, Push: false}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if result.LastSync == "" {
+		t.Error("Expected LastSync to be set")
+	}
+
+	// Verify it's stored in config
+	stored, _ := store.GetConfig(ctx, "jira.last_sync")
+	if stored == "" {
+		t.Error("Expected last_sync to be stored")
+	}
+}
+
+// TestE2E_Sync_ConflictResolutionLocal tests prefer-local conflict resolution.
+func TestE2E_Sync_ConflictResolutionLocal(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create a local issue with external_ref
+	now := time.Now()
+	localUpdated := now.Add(-1 * time.Hour)
+	externalRef := mock.URL() + "/browse/PROJ-1"
+	localIssue := &types.Issue{
+		Title:       "Local Version",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    1,
+		ExternalRef: &externalRef,
+		CreatedAt:   now.Add(-2 * time.Hour),
+		UpdatedAt:   localUpdated,
+	}
+	if err := store.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create local issue: %v", err)
+	}
+
+	// Set last_sync to before both updates
+	lastSync := now.Add(-3 * time.Hour).Format(time.RFC3339)
+	if err := store.SetConfig(ctx, "jira.last_sync", lastSync); err != nil {
+		t.Fatalf("Failed to set last_sync: %v", err)
+	}
+
+	// Set up remote issue with different data (newer)
+	remoteIssue := testutil.MakeJiraIssue("PROJ-1", "Remote Version", "To Do")
+	mock.SetIssues([]jira.Issue{remoteIssue})
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{
+		Pull:               true,
+		Push:               true,
+		ConflictResolution: tracker.ConflictResolutionLocal,
+	}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+}
+
+// TestE2E_Sync_ConflictResolutionExternal tests prefer-external conflict resolution.
+func TestE2E_Sync_ConflictResolutionExternal(t *testing.T) {
+	mock := testutil.NewJiraMockServer()
+	defer mock.Close()
+
+	store, cleanup := newSyncTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create a local issue with external_ref
+	now := time.Now()
+	localUpdated := now.Add(-1 * time.Hour)
+	externalRef := mock.URL() + "/browse/PROJ-1"
+	localIssue := &types.Issue{
+		Title:       "Local Version",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    1,
+		ExternalRef: &externalRef,
+		CreatedAt:   now.Add(-2 * time.Hour),
+		UpdatedAt:   localUpdated,
+	}
+	if err := store.CreateIssue(ctx, localIssue, "test"); err != nil {
+		t.Fatalf("Failed to create local issue: %v", err)
+	}
+
+	// Set last_sync to before both updates
+	lastSync := now.Add(-3 * time.Hour).Format(time.RFC3339)
+	if err := store.SetConfig(ctx, "jira.last_sync", lastSync); err != nil {
+		t.Fatalf("Failed to set last_sync: %v", err)
+	}
+
+	// Set up remote issue with different data
+	remoteIssue := testutil.MakeJiraIssue("PROJ-1", "Remote Version", "In Progress")
+	mock.SetIssues([]jira.Issue{remoteIssue})
+
+	jiraClient := jira.NewClient("https://example.atlassian.net", "PROJ", "user@example.com", "test-token").
+		WithEndpoint(mock.URL())
+
+	jiraTracker := &jiraTrackerAdapter{client: jiraClient, baseURL: mock.URL()}
+
+	cfg := tracker.NewConfig(ctx, "jira", store)
+
+	engine := tracker.NewSyncEngine(jiraTracker, cfg, store, "test-actor")
+
+	opts := tracker.SyncOptions{
+		Pull:               true,
+		Push:               true,
+		ConflictResolution: tracker.ConflictResolutionExternal,
+	}
+	result, err := engine.Sync(ctx, opts)
+
+	if err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	if !result.Success {
+		t.Errorf("Sync should succeed, got error: %s", result.Error)
+	}
+}
+
+// jiraTrackerAdapter adapts the Jira client to the IssueTracker interface.
+type jiraTrackerAdapter struct {
+	client  *jira.Client
+	baseURL string
+}
+
+func (a *jiraTrackerAdapter) Name() string        { return "jira" }
+func (a *jiraTrackerAdapter) DisplayName() string { return "Jira" }
+func (a *jiraTrackerAdapter) ConfigPrefix() string { return "jira" }
+
+func (a *jiraTrackerAdapter) Init(ctx context.Context, cfg *tracker.Config) error {
+	return nil
+}
+
+func (a *jiraTrackerAdapter) Validate() error { return nil }
+func (a *jiraTrackerAdapter) Close() error    { return nil }
+
+func (a *jiraTrackerAdapter) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([]tracker.TrackerIssue, error) {
+	jiraIssues, err := a.client.FetchIssues(ctx, opts.State, opts.Since)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]tracker.TrackerIssue, len(jiraIssues))
+	for i, ji := range jiraIssues {
+		result[i] = a.toTrackerIssue(&ji)
+	}
+	return result, nil
+}
+
+func (a *jiraTrackerAdapter) FetchIssue(ctx context.Context, identifier string) (*tracker.TrackerIssue, error) {
+	ji, err := a.client.FetchIssue(ctx, identifier)
+	if err != nil {
+		return nil, err
+	}
+	if ji == nil {
+		return nil, nil
+	}
+	ti := a.toTrackerIssue(ji)
+	return &ti, nil
+}
+
+func (a *jiraTrackerAdapter) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	ji, err := a.client.CreateIssue(ctx, issue.Title, issue.Description, "Task", "", issue.Labels)
+	if err != nil {
+		return nil, err
+	}
+	if ji == nil {
+		return nil, nil
+	}
+	ti := a.toTrackerIssue(ji)
+	return &ti, nil
+}
+
+func (a *jiraTrackerAdapter) UpdateIssue(ctx context.Context, externalID string, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	updates := map[string]interface{}{
+		"summary":     issue.Title,
+		"description": issue.Description,
+	}
+	if err := a.client.UpdateIssue(ctx, externalID, updates); err != nil {
+		return nil, err
+	}
+	// Fetch updated issue
+	return a.FetchIssue(ctx, externalID)
+}
+
+func (a *jiraTrackerAdapter) FieldMapper() tracker.FieldMapper {
+	return &jiraFieldMapper{}
+}
+
+func (a *jiraTrackerAdapter) IsExternalRef(ref string) bool {
+	return ref != "" && (len(ref) > len(a.baseURL) && ref[:len(a.baseURL)] == a.baseURL)
+}
+
+func (a *jiraTrackerAdapter) ExtractIdentifier(ref string) string {
+	// Simple extraction: assume format is baseURL/browse/KEY
+	if len(ref) > len(a.baseURL)+8 {
+		return ref[len(a.baseURL)+8:] // "/browse/"
+	}
+	return ""
+}
+
+func (a *jiraTrackerAdapter) BuildExternalRef(issue *tracker.TrackerIssue) string {
+	return issue.URL
+}
+
+func (a *jiraTrackerAdapter) CanonicalizeRef(ref string) string {
+	return ref
+}
+
+func (a *jiraTrackerAdapter) toTrackerIssue(ji *jira.Issue) tracker.TrackerIssue {
+	ti := tracker.TrackerIssue{
+		ID:         ji.ID,
+		Identifier: ji.Key,
+		URL:        a.baseURL + "/browse/" + ji.Key,
+		Title:      ji.Fields.Summary,
+		Labels:     ji.Fields.Labels,
+	}
+
+	if ji.Fields.Description != nil {
+		if s, ok := ji.Fields.Description.(string); ok {
+			ti.Description = s
+		}
+	}
+
+	if ji.Fields.Status != nil {
+		ti.State = ji.Fields.Status.Name
+	}
+
+	if ji.Fields.Priority != nil {
+		ti.Priority = 2 // Default medium
+	}
+
+	if ji.Fields.Assignee != nil {
+		ti.Assignee = ji.Fields.Assignee.EmailAddress
+	}
+
+	// Parse times
+	if ji.Fields.Created != "" {
+		if t, err := time.Parse("2006-01-02T15:04:05.000-0700", ji.Fields.Created); err == nil {
+			ti.CreatedAt = t
+		}
+	}
+	if ji.Fields.Updated != "" {
+		if t, err := time.Parse("2006-01-02T15:04:05.000-0700", ji.Fields.Updated); err == nil {
+			ti.UpdatedAt = t
+		}
+	}
+
+	return ti
+}
+
+// jiraFieldMapper implements FieldMapper for Jira.
+type jiraFieldMapper struct{}
+
+func (m *jiraFieldMapper) PriorityToBeads(trackerPriority interface{}) int { return 2 }
+func (m *jiraFieldMapper) PriorityToTracker(beadsPriority int) interface{} { return "Medium" }
+
+func (m *jiraFieldMapper) StatusToBeads(trackerState interface{}) types.Status {
+	if s, ok := trackerState.(string); ok {
+		switch s {
+		case "To Do", "Open", "Backlog":
+			return types.StatusOpen
+		case "In Progress":
+			return types.StatusInProgress
+		case "Done", "Closed":
+			return types.StatusClosed
+		}
+	}
+	return types.StatusOpen
+}
+
+func (m *jiraFieldMapper) StatusToTracker(beadsStatus types.Status) interface{} {
+	return string(beadsStatus)
+}
+
+func (m *jiraFieldMapper) TypeToBeads(trackerType interface{}) types.IssueType { return types.TypeTask }
+func (m *jiraFieldMapper) TypeToTracker(beadsType types.IssueType) interface{} { return string(beadsType) }
+
+func (m *jiraFieldMapper) IssueToBeads(trackerIssue *tracker.TrackerIssue) *tracker.IssueConversion {
+	issue := &types.Issue{
+		Title:       trackerIssue.Title,
+		Description: trackerIssue.Description,
+		Priority:    trackerIssue.Priority,
+		Status:      m.StatusToBeads(trackerIssue.State),
+		IssueType:   types.TypeTask,
+		Labels:      trackerIssue.Labels,
+		Assignee:    trackerIssue.Assignee,
+		CreatedAt:   trackerIssue.CreatedAt,
+		UpdatedAt:   trackerIssue.UpdatedAt,
+	}
+
+	if trackerIssue.URL != "" {
+		issue.ExternalRef = &trackerIssue.URL
+	}
+
+	return &tracker.IssueConversion{
+		Issue:        issue,
+		Dependencies: nil,
+	}
+}
+
+func (m *jiraFieldMapper) LoadConfig(cfg tracker.ConfigLoader) {}
+
+// adoTrackerAdapter adapts the Azure DevOps client to the IssueTracker interface.
+type adoTrackerAdapter struct {
+	client  *azuredevops.Client
+	baseURL string
+}
+
+func (a *adoTrackerAdapter) Name() string        { return "azuredevops" }
+func (a *adoTrackerAdapter) DisplayName() string { return "Azure DevOps" }
+func (a *adoTrackerAdapter) ConfigPrefix() string { return "azuredevops" }
+
+func (a *adoTrackerAdapter) Init(ctx context.Context, cfg *tracker.Config) error {
+	return nil
+}
+
+func (a *adoTrackerAdapter) Validate() error { return nil }
+func (a *adoTrackerAdapter) Close() error    { return nil }
+
+func (a *adoTrackerAdapter) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([]tracker.TrackerIssue, error) {
+	adoItems, err := a.client.FetchWorkItems(ctx, opts.State, opts.Since)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]tracker.TrackerIssue, len(adoItems))
+	for i, wi := range adoItems {
+		result[i] = a.toTrackerIssue(&wi)
+	}
+	return result, nil
+}
+
+func (a *adoTrackerAdapter) FetchIssue(ctx context.Context, identifier string) (*tracker.TrackerIssue, error) {
+	var id int
+	_, _ = idFromString(identifier, &id)
+	wi, err := a.client.FetchWorkItem(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if wi == nil {
+		return nil, nil
+	}
+	ti := a.toTrackerIssue(wi)
+	return &ti, nil
+}
+
+func (a *adoTrackerAdapter) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	wi, err := a.client.CreateWorkItem(ctx, "Task", issue.Title, issue.Description, issue.Priority, issue.Labels)
+	if err != nil {
+		return nil, err
+	}
+	ti := a.toTrackerIssue(wi)
+	return &ti, nil
+}
+
+func (a *adoTrackerAdapter) UpdateIssue(ctx context.Context, externalID string, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	var id int
+	_, _ = idFromString(externalID, &id)
+	ops := []azuredevops.PatchOperation{
+		{Op: "replace", Path: "/fields/System.Title", Value: issue.Title},
+	}
+	wi, err := a.client.UpdateWorkItem(ctx, id, ops)
+	if err != nil {
+		return nil, err
+	}
+	ti := a.toTrackerIssue(wi)
+	return &ti, nil
+}
+
+func (a *adoTrackerAdapter) FieldMapper() tracker.FieldMapper {
+	return &adoFieldMapper{}
+}
+
+func (a *adoTrackerAdapter) IsExternalRef(ref string) bool {
+	return ref != "" && (len(ref) > len(a.baseURL) && ref[:len(a.baseURL)] == a.baseURL)
+}
+
+func (a *adoTrackerAdapter) ExtractIdentifier(ref string) string {
+	// Simple extraction
+	if id, ok := azuredevops.ParseWorkItemID(ref); ok {
+		return stringFromID(id)
+	}
+	return ""
+}
+
+func (a *adoTrackerAdapter) BuildExternalRef(issue *tracker.TrackerIssue) string {
+	return issue.URL
+}
+
+func (a *adoTrackerAdapter) CanonicalizeRef(ref string) string {
+	return ref
+}
+
+func (a *adoTrackerAdapter) toTrackerIssue(wi *azuredevops.WorkItem) tracker.TrackerIssue {
+	ti := tracker.TrackerIssue{
+		ID:          stringFromID(wi.ID),
+		Identifier:  stringFromID(wi.ID),
+		URL:         a.baseURL + "/testproj/_workitems/edit/" + stringFromID(wi.ID),
+		Title:       wi.Fields.Title,
+		Description: wi.Fields.Description,
+		State:       wi.Fields.State,
+		Priority:    wi.Fields.Priority,
+	}
+
+	if wi.Fields.AssignedTo != nil {
+		ti.Assignee = wi.Fields.AssignedTo.UniqueName
+	}
+
+	// Parse times
+	if wi.Fields.CreatedDate != "" {
+		if t, err := time.Parse(time.RFC3339, wi.Fields.CreatedDate); err == nil {
+			ti.CreatedAt = t
+		}
+	}
+	if wi.Fields.ChangedDate != "" {
+		if t, err := time.Parse(time.RFC3339, wi.Fields.ChangedDate); err == nil {
+			ti.UpdatedAt = t
+		}
+	}
+
+	return ti
+}
+
+// adoFieldMapper implements FieldMapper for Azure DevOps.
+type adoFieldMapper struct{}
+
+func (m *adoFieldMapper) PriorityToBeads(trackerPriority interface{}) int { return 2 }
+func (m *adoFieldMapper) PriorityToTracker(beadsPriority int) interface{} { return 2 }
+
+func (m *adoFieldMapper) StatusToBeads(trackerState interface{}) types.Status {
+	if s, ok := trackerState.(string); ok {
+		switch s {
+		case "New", "To Do":
+			return types.StatusOpen
+		case "Active", "In Progress":
+			return types.StatusInProgress
+		case "Closed", "Done":
+			return types.StatusClosed
+		}
+	}
+	return types.StatusOpen
+}
+
+func (m *adoFieldMapper) StatusToTracker(beadsStatus types.Status) interface{} {
+	return string(beadsStatus)
+}
+
+func (m *adoFieldMapper) TypeToBeads(trackerType interface{}) types.IssueType { return types.TypeTask }
+func (m *adoFieldMapper) TypeToTracker(beadsType types.IssueType) interface{} { return string(beadsType) }
+
+func (m *adoFieldMapper) IssueToBeads(trackerIssue *tracker.TrackerIssue) *tracker.IssueConversion {
+	issue := &types.Issue{
+		Title:       trackerIssue.Title,
+		Description: trackerIssue.Description,
+		Priority:    trackerIssue.Priority,
+		Status:      m.StatusToBeads(trackerIssue.State),
+		IssueType:   types.TypeTask,
+		Assignee:    trackerIssue.Assignee,
+		CreatedAt:   trackerIssue.CreatedAt,
+		UpdatedAt:   trackerIssue.UpdatedAt,
+	}
+
+	if trackerIssue.URL != "" {
+		issue.ExternalRef = &trackerIssue.URL
+	}
+
+	return &tracker.IssueConversion{
+		Issue:        issue,
+		Dependencies: nil,
+	}
+}
+
+func (m *adoFieldMapper) LoadConfig(cfg tracker.ConfigLoader) {}
+
+// Helper functions
+
+func idFromString(s string, id *int) (int, error) {
+	var n int
+	_, err := stringToInt(s, &n)
+	if err == nil {
+		*id = n
+	}
+	return n, err
+}
+
+func stringToInt(s string, id *int) (int, error) {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, nil
+		}
+	}
+	n := 0
+	for _, c := range s {
+		n = n*10 + int(c-'0')
+	}
+	*id = n
+	return n, nil
+}
+
+func stringFromID(id int) string {
+	if id == 0 {
+		return "0"
+	}
+	s := ""
+	for id > 0 {
+		s = string(rune('0'+id%10)) + s
+		id /= 10
+	}
+	return s
+}

--- a/internal/tracker/testutil/mockserver.go
+++ b/internal/tracker/testutil/mockserver.go
@@ -1,0 +1,247 @@
+//go:build integration
+
+// Package testutil provides testing utilities for tracker integration tests.
+package testutil
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+)
+
+// RecordedRequest stores information about a request made to the mock server.
+type RecordedRequest struct {
+	Method  string
+	Path    string
+	Headers http.Header
+	Body    []byte
+}
+
+// MockResponse represents a configured response for the mock server.
+type MockResponse struct {
+	StatusCode int
+	Body       interface{}
+	Headers    map[string]string
+}
+
+// MockTrackerServer is the base mock server for tracker integration tests.
+// It provides request recording, response configuration, and common helpers.
+type MockTrackerServer struct {
+	Server *httptest.Server
+	mu     sync.RWMutex
+
+	// Recorded requests for assertions
+	requests []RecordedRequest
+
+	// Response configuration
+	responses      map[string]MockResponse // path -> response
+	defaultHandler func(w http.ResponseWriter, r *http.Request)
+
+	// Error simulation
+	authError      bool
+	rateLimitError bool
+	serverError    bool
+
+	// Rate limit retry tracking
+	rateLimitRetries int
+	rateLimitCount   int
+}
+
+// NewMockTrackerServer creates a new base mock server.
+func NewMockTrackerServer() *MockTrackerServer {
+	m := &MockTrackerServer{
+		requests:  []RecordedRequest{},
+		responses: make(map[string]MockResponse),
+	}
+
+	m.Server = httptest.NewServer(http.HandlerFunc(m.handleRequest))
+	return m
+}
+
+// handleRequest is the main request handler that records requests and returns configured responses.
+func (m *MockTrackerServer) handleRequest(w http.ResponseWriter, r *http.Request) {
+	// Read and record the request body
+	var body []byte
+	if r.Body != nil {
+		body, _ = readBody(r)
+	}
+
+	m.mu.Lock()
+	m.requests = append(m.requests, RecordedRequest{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Headers: r.Header.Clone(),
+		Body:    body,
+	})
+	m.mu.Unlock()
+
+	// Check for error simulation
+	if m.authError {
+		w.WriteHeader(http.StatusUnauthorized)
+		writeJSON(w, map[string]string{"error": "Unauthorized"})
+		return
+	}
+
+	if m.rateLimitError {
+		m.rateLimitCount++
+		if m.rateLimitCount <= m.rateLimitRetries {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Header().Set("Retry-After", "1")
+			writeJSON(w, map[string]string{"error": "Rate limited"})
+			return
+		}
+		// After retries, allow the request through
+	}
+
+	if m.serverError {
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": "Internal server error"})
+		return
+	}
+
+	// Check for configured response
+	m.mu.RLock()
+	resp, found := m.responses[r.URL.Path]
+	m.mu.RUnlock()
+
+	if found {
+		for k, v := range resp.Headers {
+			w.Header().Set(k, v)
+		}
+		if resp.StatusCode != 0 {
+			w.WriteHeader(resp.StatusCode)
+		}
+		if resp.Body != nil {
+			writeJSON(w, resp.Body)
+		}
+		return
+	}
+
+	// Call custom handler if set
+	if m.defaultHandler != nil {
+		m.defaultHandler(w, r)
+		return
+	}
+
+	// Default: 404
+	w.WriteHeader(http.StatusNotFound)
+	writeJSON(w, map[string]string{"error": "Not found"})
+}
+
+// URL returns the mock server URL.
+func (m *MockTrackerServer) URL() string {
+	return m.Server.URL
+}
+
+// Close shuts down the mock server.
+func (m *MockTrackerServer) Close() {
+	m.Server.Close()
+}
+
+// SetResponse configures a response for a specific path.
+func (m *MockTrackerServer) SetResponse(path string, statusCode int, body interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.responses[path] = MockResponse{
+		StatusCode: statusCode,
+		Body:       body,
+	}
+}
+
+// SetResponseWithHeaders configures a response with custom headers.
+func (m *MockTrackerServer) SetResponseWithHeaders(path string, statusCode int, body interface{}, headers map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.responses[path] = MockResponse{
+		StatusCode: statusCode,
+		Body:       body,
+		Headers:    headers,
+	}
+}
+
+// SetDefaultHandler sets a custom handler for unmatched requests.
+func (m *MockTrackerServer) SetDefaultHandler(handler func(w http.ResponseWriter, r *http.Request)) {
+	m.defaultHandler = handler
+}
+
+// SetAuthError enables/disables 401 Unauthorized responses.
+func (m *MockTrackerServer) SetAuthError(enabled bool) {
+	m.authError = enabled
+}
+
+// SetRateLimitError enables/disables 429 Too Many Requests responses.
+// retries specifies how many requests should get rate limited before succeeding.
+func (m *MockTrackerServer) SetRateLimitError(enabled bool, retries int) {
+	m.rateLimitError = enabled
+	m.rateLimitRetries = retries
+	m.rateLimitCount = 0
+}
+
+// SetServerError enables/disables 500 Internal Server Error responses.
+func (m *MockTrackerServer) SetServerError(enabled bool) {
+	m.serverError = enabled
+}
+
+// GetRequests returns all recorded requests.
+func (m *MockTrackerServer) GetRequests() []RecordedRequest {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]RecordedRequest, len(m.requests))
+	copy(result, m.requests)
+	return result
+}
+
+// GetRequestCount returns the number of recorded requests.
+func (m *MockTrackerServer) GetRequestCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.requests)
+}
+
+// ClearRequests clears all recorded requests.
+func (m *MockTrackerServer) ClearRequests() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests = []RecordedRequest{}
+}
+
+// Reset clears all recorded requests and responses.
+func (m *MockTrackerServer) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests = []RecordedRequest{}
+	m.responses = make(map[string]MockResponse)
+	m.authError = false
+	m.rateLimitError = false
+	m.serverError = false
+	m.rateLimitCount = 0
+	m.rateLimitRetries = 0
+}
+
+// Helper functions
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}
+
+func readBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	defer r.Body.Close()
+
+	buf := make([]byte, 0, 1024)
+	for {
+		tmp := make([]byte, 512)
+		n, err := r.Body.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			break
+		}
+	}
+	return buf, nil
+}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -1,0 +1,96 @@
+package tracker
+
+import (
+	"context"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TrackerIssue represents an issue from an external tracker in its native format.
+// Each tracker plugin converts between this generic format and its specific API types.
+type TrackerIssue struct {
+	// Core identification
+	ID         string // External tracker's internal ID (e.g., UUID)
+	Identifier string // Human-readable identifier (e.g., "TEAM-123", "PROJ-456")
+	URL        string // Web URL to the issue
+
+	// Content
+	Title       string
+	Description string
+
+	// Status and workflow
+	Priority int         // Priority value (tracker-specific)
+	State    interface{} // Tracker-specific state object
+	Labels   []string    // Labels/tags
+
+	// Assignment
+	Assignee     string // Assignee name or email
+	AssigneeID   string // Assignee's tracker-specific ID
+	AssigneeEmail string // Assignee email if available
+
+	// Timestamps
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	CompletedAt *time.Time
+
+	// Relationships
+	ParentID        string // Parent issue identifier (for subtasks/children)
+	ParentInternalID string // Parent issue internal ID
+
+	// Raw data for tracker-specific processing
+	Raw interface{} // Original API response for tracker-specific access
+}
+
+// FetchOptions specifies options for fetching issues from an external tracker.
+type FetchOptions struct {
+	// State filter: "open", "closed", or "all" (default)
+	State string
+
+	// Incremental sync: only fetch issues updated since this time
+	Since *time.Time
+
+	// Maximum number of issues to fetch (0 = no limit)
+	Limit int
+}
+
+// IssueTracker defines the interface that all tracker plugins must implement.
+// This interface provides a consistent API for interacting with different external
+// issue trackers like Linear, Jira, Azure DevOps, etc.
+type IssueTracker interface {
+	// Identity returns information about this tracker.
+	Name() string        // Lowercase identifier: "linear", "jira", "azuredevops"
+	DisplayName() string // Human-readable name: "Linear", "Jira", "Azure DevOps"
+	ConfigPrefix() string // Config key prefix: "linear", "jira", "azuredevops"
+
+	// Lifecycle manages the tracker connection.
+	Init(ctx context.Context, cfg *Config) error
+	Validate() error
+	Close() error
+
+	// FetchIssues retrieves issues from the external tracker.
+	// Use opts.Since for incremental sync, opts.State for filtering.
+	FetchIssues(ctx context.Context, opts FetchOptions) ([]TrackerIssue, error)
+
+	// FetchIssue retrieves a single issue by its identifier.
+	// Returns nil, nil if the issue doesn't exist.
+	FetchIssue(ctx context.Context, identifier string) (*TrackerIssue, error)
+
+	// CreateIssue creates a new issue in the external tracker.
+	// Returns the created issue with its external ID and URL populated.
+	CreateIssue(ctx context.Context, issue *types.Issue) (*TrackerIssue, error)
+
+	// UpdateIssue updates an existing issue in the external tracker.
+	// The externalID is the tracker's internal ID (not the human-readable identifier).
+	UpdateIssue(ctx context.Context, externalID string, issue *types.Issue) (*TrackerIssue, error)
+
+	// FieldMapper returns the field mapper for this tracker.
+	// The mapper handles bidirectional conversion of priorities, statuses, types, etc.
+	FieldMapper() FieldMapper
+
+	// External reference handling
+	IsExternalRef(ref string) bool        // Check if an external_ref belongs to this tracker
+	ExtractIdentifier(ref string) string  // Extract identifier from external_ref URL
+	BuildExternalRef(issue *TrackerIssue) string // Build external_ref URL from issue
+	CanonicalizeRef(ref string) string    // Normalize external_ref to canonical form
+}

--- a/internal/tracker/tracker_test.go
+++ b/internal/tracker/tracker_test.go
@@ -1,0 +1,102 @@
+package tracker
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestParseBeadsStatus(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected types.Status
+	}{
+		{"open", types.StatusOpen},
+		{"in_progress", types.StatusInProgress},
+		{"in-progress", types.StatusInProgress},
+		{"inprogress", types.StatusInProgress},
+		{"blocked", types.StatusBlocked},
+		{"deferred", types.StatusDeferred},
+		{"closed", types.StatusClosed},
+		{"pinned", types.StatusPinned},
+		{"unknown", types.StatusOpen}, // Default
+		{"", types.StatusOpen},        // Empty string
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ParseBeadsStatus(tt.input)
+			if result != tt.expected {
+				t.Errorf("ParseBeadsStatus(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseIssueType(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected types.IssueType
+	}{
+		{"bug", types.TypeBug},
+		{"feature", types.TypeFeature},
+		{"task", types.TypeTask},
+		{"epic", types.TypeEpic},
+		{"chore", types.TypeChore},
+		{"unknown", types.TypeTask}, // Default
+		{"", types.TypeTask},        // Empty string
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ParseIssueType(tt.input)
+			if result != tt.expected {
+				t.Errorf("ParseIssueType(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultBaseMappingConfig(t *testing.T) {
+	config := DefaultBaseMappingConfig()
+
+	// Check priority map
+	if len(config.PriorityMap) == 0 {
+		t.Error("PriorityMap should not be empty")
+	}
+	if config.PriorityMap["0"] != 4 {
+		t.Errorf("PriorityMap[\"0\"] = %d, want 4", config.PriorityMap["0"])
+	}
+
+	// Check state map
+	if len(config.StateMap) == 0 {
+		t.Error("StateMap should not be empty")
+	}
+	if config.StateMap["backlog"] != "open" {
+		t.Errorf("StateMap[\"backlog\"] = %s, want \"open\"", config.StateMap["backlog"])
+	}
+
+	// Check label type map
+	if len(config.LabelTypeMap) == 0 {
+		t.Error("LabelTypeMap should not be empty")
+	}
+	if config.LabelTypeMap["bug"] != "bug" {
+		t.Errorf("LabelTypeMap[\"bug\"] = %s, want \"bug\"", config.LabelTypeMap["bug"])
+	}
+
+	// Check relation map
+	if len(config.RelationMap) == 0 {
+		t.Error("RelationMap should not be empty")
+	}
+	if config.RelationMap["blocks"] != "blocks" {
+		t.Errorf("RelationMap[\"blocks\"] = %s, want \"blocks\"", config.RelationMap["blocks"])
+	}
+}
+
+func TestErrNotInitialized(t *testing.T) {
+	err := &ErrNotInitialized{Tracker: "test"}
+	expected := "test tracker not initialized; call Init() first"
+	if err.Error() != expected {
+		t.Errorf("Error() = %q, want %q", err.Error(), expected)
+	}
+}


### PR DESCRIPTION
## Summary
Part 1 of 4 — splitting #1151 per maintainer request.

Establishes the plugin architecture for external issue tracker integrations:
- `IssueTracker` interface for bidirectional sync
- `FieldMapper` for flexible field transformation
- `Registry` for tracker discovery and lifecycle
- `SyncEngine` for conflict resolution and state management
- Full E2E test suite with mock HTTP servers

### Files
- `internal/tracker/` — core framework (tracker, mapper, registry, sync, config, stats)
- `internal/tracker/testutil/` — shared mock HTTP server
- `cmd/bd/tracker_helpers.go` — CLI scaffolding (SyncStore adapter)
- `cmd/bd/tracker_sync_test.go` — sync engine integration tests
- `docs/TRACKERS.md` — user documentation
- `docs/CLI_REFERENCE.md` — added External Trackers section
- `README.md` — added External Trackers link

### Follow-up PRs (depend on this one)
- PR 2: Linear migration to framework
- PR 3: Jira implementation
- PR 4: Azure DevOps implementation

Supersedes the framework portion of #1151.