### PR TITLE
fix(nix): drop Go requirement from 1.25.7 to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steveyegge/beads
 
-go 1.25.7
+go 1.25.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

- Drop `go 1.25.7` → `go 1.25.5` in go.mod
- The embedded Dolt driver (`dolthub/driver`) that required Go 1.25.6 was removed in e5330641 — server-only Dolt via MySQL protocol remains and has no elevated Go requirement
- No remaining dependency requires Go > 1.25.5
- The 1.25.7 bump was solely for CVE-2025-68121, a runtime-only TLS fix that doesn't gate compilation

This partially unblocks Nix CI (#1465, #1551) by allowing the build to succeed with Go 1.25.5, which is what `nixpkgs-unstable` currently ships. A companion PR will address the stale `flake.lock` (pinned to Oct 2025 / Go 1.25.1).

## Test plan

- [x] `go build ./cmd/bd` succeeds locally with Go 1.25.5 directive
- [x] `go test -short ./internal/storage/sqlite/...` passes
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)