### PR TITLE
perf(tests): speed up cmd/bd test suite from ~158s to ~50s

### DIFF
--- a/cmd/bd/comments_test.go
+++ b/cmd/bd/comments_test.go
@@ -12,6 +12,7 @@ import (
 const testUserAlice = "alice"
 
 func TestCommentsSuite(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -152,6 +153,7 @@ func TestCommentsSuite(t *testing.T) {
 }
 
 func TestIsUnknownOperationError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		err      error

--- a/cmd/bd/create_test.go
+++ b/cmd/bd/create_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCreateSuite(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)

--- a/cmd/bd/daemon_autostart_unit_test.go
+++ b/cmd/bd/daemon_autostart_unit_test.go
@@ -103,6 +103,7 @@ func captureStderr(t *testing.T, fn func()) string {
 }
 
 func TestDaemonAutostart_AcquireStartLock_CreatesAndCleansStale(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	lockPath := filepath.Join(tmpDir, "bd.sock.startlock")
 	pid, err := readPIDFromFile(lockPath)
@@ -138,6 +139,7 @@ func TestDaemonAutostart_AcquireStartLock_CreatesAndCleansStale(t *testing.T) {
 }
 
 func TestDaemonAutostart_AcquireStartLock_CreatesMissingDir(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	socketPath := filepath.Join(tmpDir, "missing", "bd.sock")
 	lockPath := socketPath + ".startlock"
@@ -481,6 +483,7 @@ func TestDaemonAutostart_RestartDaemonForVersionMismatch_Stubbed(t *testing.T) {
 
 // TestIsWispOperation tests the wisp operation detection for auto-daemon-bypass (bd-ta4r)
 func TestIsWispOperation(t *testing.T) {
+	t.Parallel()
 	// Helper to create a command with parent hierarchy
 	makeCmd := func(names ...string) *cobra.Command {
 		var current *cobra.Command

--- a/cmd/bd/label_test.go
+++ b/cmd/bd/label_test.go
@@ -116,6 +116,7 @@ func (h *labelTestHelper) assertLabelEvent(issueID string, eventType types.Event
 }
 
 func TestLabelCommands(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "bd-test-label-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)

--- a/cmd/bd/list_test.go
+++ b/cmd/bd/list_test.go
@@ -92,6 +92,7 @@ func (h *listTestHelper) assertAtMost(count, maxCount int, desc string) {
 }
 
 func TestListCommandSuite(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -220,6 +221,7 @@ func TestListCommandSuite(t *testing.T) {
 }
 
 func TestListQueryCapabilitiesSuite(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -461,6 +463,7 @@ func TestListQueryCapabilitiesSuite(t *testing.T) {
 // This test specifically addresses the bug where --tree output was non-deterministic due to
 // unstable ordering of root issues and children within the same priority level
 func TestStableTreeOrdering(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	store := newTestStore(t, testDB)
@@ -625,6 +628,7 @@ func slicesEqual(a, b []string) bool {
 }
 
 func TestFormatIssueLong(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		issue  *types.Issue
@@ -695,6 +699,7 @@ func TestFormatIssueLong(t *testing.T) {
 }
 
 func TestFormatIssueCompact(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		issue  *types.Issue
@@ -765,6 +770,7 @@ func TestFormatIssueCompact(t *testing.T) {
 }
 
 func TestBuildBlockingMaps(t *testing.T) {
+	t.Parallel()
 	// Create test dependency records
 	allDeps := map[string][]*types.Dependency{
 		"issue-A": {
@@ -800,6 +806,7 @@ func TestBuildBlockingMaps(t *testing.T) {
 }
 
 func TestFormatIssueCompactWithDependencies(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		issue     *types.Issue
@@ -874,6 +881,7 @@ func TestFormatIssueCompactWithDependencies(t *testing.T) {
 }
 
 func TestParseTimeFlag(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -907,6 +915,7 @@ func TestParseTimeFlag(t *testing.T) {
 
 // TestListTimeBasedFilters tests the time-based scheduling filters (GH#820)
 func TestListTimeBasedFilters(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -1081,6 +1090,7 @@ func TestListTimeBasedFilters(t *testing.T) {
 
 // TestHierarchicalChildren tests the --tree --parent functionality for showing all descendants
 func TestHierarchicalChildren(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	store := newTestStore(t, testDB)

--- a/cmd/bd/ready_test.go
+++ b/cmd/bd/ready_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestReadySuite(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -267,6 +268,7 @@ func TestReadySuite(t *testing.T) {
 }
 
 func TestReadyCommandInit(t *testing.T) {
+	t.Parallel()
 	if readyCmd == nil {
 		t.Fatal("readyCmd should be initialized")
 	}
@@ -282,6 +284,7 @@ func TestReadyCommandInit(t *testing.T) {
 
 // GH#820: Tests for defer_until filtering in ready work
 func TestReadyWorkDeferUntil(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -385,6 +388,7 @@ func TestReadyWorkDeferUntil(t *testing.T) {
 }
 
 func TestReadyWorkUnassigned(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)

--- a/cmd/bd/search_test.go
+++ b/cmd/bd/search_test.go
@@ -23,6 +23,7 @@ import (
 // - The error from Help() is rare (typically I/O errors writing to stderr)
 // - Since we're already in an error state, ignoring Help() errors is acceptable
 func TestSearchCommand_HelpErrorHandling(t *testing.T) {
+	t.Parallel()
 	// Create a test command similar to searchCmd
 	cmd := &cobra.Command{
 		Use:   "search [query]",
@@ -77,6 +78,7 @@ func TestSearchCommand_HelpErrorHandling(t *testing.T) {
 
 // TestSearchCommand_HelpSuppression verifies that #nosec comment is appropriate
 func TestSearchCommand_HelpSuppression(t *testing.T) {
+	t.Parallel()
 	// This test documents why ignoring cmd.Help() error is safe:
 	//
 	// 1. Help() is called in an error path (missing required argument)
@@ -118,6 +120,7 @@ func (fw *failingWriter) Write(p []byte) (n int, err error) {
 
 // TestSearchCommand_MissingQueryShowsHelp verifies the intended behavior
 func TestSearchCommand_MissingQueryShowsHelp(t *testing.T) {
+	t.Parallel()
 	// This test verifies that when query is missing, we:
 	// 1. Print error message to stderr
 	// 2. Show help (even if it fails, we tried)
@@ -165,6 +168,7 @@ func TestSearchCommand_MissingQueryShowsHelp(t *testing.T) {
 
 // TestSearchWithDateAndPriorityFilters tests bd search with date range and priority filters
 func TestSearchWithDateAndPriorityFilters(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)

--- a/cmd/bd/stale_test.go
+++ b/cmd/bd/stale_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestStaleIssues(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -115,6 +116,7 @@ func TestStaleIssues(t *testing.T) {
 }
 
 func TestStaleIssuesWithStatusFilter(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -205,6 +207,7 @@ func TestStaleIssuesWithStatusFilter(t *testing.T) {
 }
 
 func TestStaleIssuesWithLimit(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -255,6 +258,7 @@ func TestStaleIssuesWithLimit(t *testing.T) {
 }
 
 func TestStaleIssuesEmpty(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -292,6 +296,7 @@ func TestStaleIssuesEmpty(t *testing.T) {
 }
 
 func TestStaleIssuesDifferentDaysThreshold(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -380,6 +385,7 @@ func TestStaleIssuesDifferentDaysThreshold(t *testing.T) {
 }
 
 func TestStaleCommandInit(t *testing.T) {
+	t.Parallel()
 	if staleCmd == nil {
 		t.Fatal("staleCmd should be initialized")
 	}

--- a/cmd/bd/template_test.go
+++ b/cmd/bd/template_test.go
@@ -18,6 +18,7 @@ import (
 
 // TestExtractVariables tests the {{variable}} pattern extraction
 func TestExtractVariables(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -98,6 +99,7 @@ func TestExtractVariables(t *testing.T) {
 
 // TestSubstituteVariables tests the variable substitution
 func TestSubstituteVariables(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -186,6 +188,7 @@ func (h *templateTestHelper) addLabel(issueID, label string) {
 
 // TestLoadTemplateSubgraph tests loading a template epic with children
 func TestLoadTemplateSubgraph(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "bd-test-template-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -262,6 +265,7 @@ func TestLoadTemplateSubgraph(t *testing.T) {
 
 // TestCloneSubgraph tests cloning a template with variable substitution
 func TestCloneSubgraph(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "bd-test-clone-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -451,6 +455,7 @@ func TestCloneSubgraph(t *testing.T) {
 
 // TestExtractAllVariables tests extracting variables from entire subgraph
 func TestExtractAllVariables(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "bd-test-extractall-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -510,6 +515,7 @@ func (h *templateTestHelper) createIssueWithID(id, title, description string, is
 
 // TestResolveProtoIDOrTitle tests proto lookup by ID or title (bd-drcx)
 func TestResolveProtoIDOrTitle(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "bd-test-proto-lookup-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -610,6 +616,7 @@ func TestResolveProtoIDOrTitle(t *testing.T) {
 // TestLoadTemplateSubgraphWithManyChildren tests loading with 4+ children (bd-c8d5)
 // This reproduces the bug where only 2 of 4 children were loaded.
 func TestLoadTemplateSubgraphWithManyChildren(t *testing.T) {
+	t.Parallel()
 	tmpDir, err := os.MkdirTemp("", "bd-test-many-children-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -848,6 +855,7 @@ func TestLoadTemplateSubgraphWithManyChildren(t *testing.T) {
 // TestExtractRequiredVariables_IgnoresUndeclaredVars tests that handlebars in
 // description text that are NOT defined in VarDefs are ignored (gt-ky9loa).
 func TestExtractRequiredVariables_IgnoresUndeclaredVars(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		issues       []*types.Issue


### PR DESCRIPTION
## Summary
- Consolidate `show_test.go` to build the `bd` binary once instead of 3 times (~8s saved)
- Group 12 standalone `init_test.go` tests into 3 parent functions (`TestInitSyncBranch`, `TestInitBEADS_DIR`, `TestInitRedirect`) with shared setup helpers
- Add `t.Parallel()` to 38 test functions across 8 files (`create`, `comments`, `list`, `ready`, `stale`, `label`, `search`, `template`) that use isolated temp dirs and no shared global state
- Add `t.Parallel()` to 3 safe daemon autostart unit tests

Closes bd-1rh.

## Test plan
- [x] `go test ./cmd/bd/ -skip Dolt -count=1` — PASS (50s, down from ~158s)
- [x] `go test ./cmd/bd/ -skip Dolt -count=1 -race` — PASS (2 pre-existing race failures in `daemon_lifecycle_race_test.go` unrelated to this change)
- [x] `go vet ./cmd/bd/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)