### PR TITLE
chore: clean up orphaned embedded Dolt references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ INSTALL_DIR := $(HOME)/.local/bin
 build:
 	@echo "Building bd..."
 ifeq ($(OS),Windows_NT)
-	go build -tags gms_pure_go -ldflags="-X main.Build=$$(git rev-parse --short HEAD)" -o $(BUILD_DIR)/$(BINARY) ./cmd/bd
+	go build -ldflags="-X main.Build=$$(git rev-parse --short HEAD)" -o $(BUILD_DIR)/$(BINARY) ./cmd/bd
 else
 	go build -ldflags="-X main.Build=$$(git rev-parse --short HEAD)" -o $(BUILD_DIR)/$(BINARY) ./cmd/bd
 ifeq ($(shell uname),Darwin)

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -71,31 +71,6 @@ The installer will:
 
 **TL;DR:** Use Homebrew if available. Use npm if you're in a Node.js environment. Use the script for quick one-off installs or CI.
 
-## Build Dependencies (go install / from source)
-
-If you install via `go install` or build from source, you need system dependencies for CGO:
-
-macOS (Homebrew):
-```bash
-brew install icu4c zstd
-```
-
-Linux (Debian/Ubuntu):
-```bash
-sudo apt-get install -y libicu-dev libzstd-dev
-```
-
-Linux (Fedora/RHEL):
-```bash
-sudo dnf install -y libicu-devel libzstd-devel
-```
-
-If you see `unicode/uregex.h` missing on macOS, `icu4c` is keg-only. Use:
-```bash
-ICU_PREFIX="$(brew --prefix icu4c)"
-CGO_CFLAGS="-I${ICU_PREFIX}/include" CGO_CPPFLAGS="-I${ICU_PREFIX}/include" CGO_LDFLAGS="-L${ICU_PREFIX}/lib" go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
 ## Platform-Specific Installation
 
 ### macOS
@@ -175,14 +150,12 @@ irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 
 The script installs a prebuilt Windows release if available. Go is only required for `go install` or building from source.
 
-**Dolt backend on Windows:** Supported via pure-Go regex backend. Windows builds automatically use Go's stdlib `regexp` instead of ICU regex to avoid CGO/header dependencies. If you need full ICU regex semantics, use Linux/macOS (or WSL) with ICU installed.
+**Dolt backend on Windows:** Supported. Connects to dolt sql-server via MySQL protocol.
 
 **Via go install**:
 ```pwsh
 go install github.com/steveyegge/beads/cmd/bd@latest
 ```
-
-The installer automatically applies the pure-Go regex backend on Windows.
 
 **From source**:
 ```pwsh
@@ -191,8 +164,6 @@ cd beads
 go build -o bd.exe ./cmd/bd
 Move-Item bd.exe $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\
 ```
-
-The build automatically applies the pure-Go regex backend on Windows via the `gms_pure_go` build tag. If you see `unicode/uregex.h` missing while building, this is normal—the build will skip it on Windows.
 
 **Verify installation**:
 ```pwsh
@@ -384,21 +355,20 @@ go install github.com/steveyegge/beads/cmd/bd@latest
 
 ### `zsh: killed bd` or crashes on macOS
 
-Some users report crashes when running `bd init` or other commands on macOS. This is typically caused by CGO/SQLite compatibility issues.
+Some users report crashes when running `bd init` or other commands on macOS. Try reinstalling:
 
-**Workaround:**
 ```bash
-# Build with CGO enabled
-CGO_ENABLED=1 go install github.com/steveyegge/beads/cmd/bd@latest
+# Via Homebrew (recommended)
+brew reinstall beads
 
-# Or if building from source
+# Or rebuild from source
 git clone https://github.com/steveyegge/beads
 cd beads
-CGO_ENABLED=1 go build -o bd ./cmd/bd
+go build -o bd ./cmd/bd
 sudo mv bd /usr/local/bin/
 ```
 
-If you installed via Homebrew, this shouldn't be necessary as the formula already enables CGO. If you're still seeing crashes with the Homebrew version, please [file an issue](https://github.com/steveyegge/beads/issues).
+If you're still seeing crashes, please [file an issue](https://github.com/steveyegge/beads/issues).
 
 ### Claude Code Plugin: MCP server fails to start
 

--- a/internal/storage/dolt/dolt_benchmark_test.go
+++ b/internal/storage/dolt/dolt_benchmark_test.go
@@ -1,4 +1,3 @@
-//go:build cgo
 // Package dolt provides performance benchmarks for the Dolt storage backend.
 // Run with: go test -bench=. -benchmem ./internal/storage/dolt/...
 //
@@ -70,9 +69,9 @@ func setupBenchStore(b *testing.B) (*DoltStore, func()) {
 // Bootstrap & Connection Benchmarks
 // =============================================================================
 
-// BenchmarkBootstrapEmbedded measures store initialization time in embedded mode.
+// BenchmarkBootstrap measures store initialization time.
 // This is the critical path for CLI commands that open/close the store each time.
-func BenchmarkBootstrapEmbedded(b *testing.B) {
+func BenchmarkBootstrap(b *testing.B) {
 	if _, err := os.LookupEnv("DOLT_PATH"); err != false {
 		if _, err := os.Stat("/usr/local/bin/dolt"); os.IsNotExist(err) {
 			if _, err := os.Stat("/usr/bin/dolt"); os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

Removes three clearly orphaned build artifacts left behind when the embedded Dolt driver was removed (commit e5330641):

- **Makefile**: Remove dead `-tags gms_pure_go` from Windows cross-compile target
- **dolt_benchmark_test.go**: Remove `//go:build cgo` constraint that prevents benchmarks from ever running (server-mode Dolt doesn't need CGO); rename `BenchmarkBootstrapEmbedded` → `BenchmarkBootstrap`
- **INSTALLING.md**: Remove CGO/ICU build dependencies section and `gms_pure_go` references that no longer apply

### What we intentionally left alone

During the audit we initially drafted a larger changeset that also modified `doctor/federation.go` messages, `DOLT.md`, `DOLT-BACKEND.md`, and `CONFIG.md`. We scaled back after discovering that `DoltModeEmbedded` is **deliberately kept** in `internal/configfile/configfile.go` for backward compatibility — existing configs with `mode: embedded` are silently accepted and treated as server mode. Tests in `configfile_test.go` verify this compat path.

The doctor diagnostic messages and docs referencing embedded mode are therefore technically correct for users with older configs, so we left them as-is.

### CI note

This PR depends on #1577 (which fixes the broken `pure_go_windows.go`, go.mod version, Nix vendorHash, and pre-existing lint issues). Lint/Windows/Nix failures here are pre-existing on `main` and will resolve once #1577 lands and this branch is rebased.

## Test plan

- [ ] `go build ./...` succeeds
- [ ] `go test ./internal/storage/dolt/...` passes (benchmark no longer skipped by `cgo` constraint)
- [ ] CI passes on all platforms (after rebase on #1577)

🤖 Generated with [Claude Code](https://claude.com/claude-code)