### PR TITLE
perf: replace N+1 GetLabels calls with batch GetLabelsForIssues in RPC list

### DIFF
--- a/internal/rpc/server_issues_epics.go
+++ b/internal/rpc/server_issues_epics.go
@@ -1328,17 +1328,19 @@ func (s *Server) handleList(req *Request) Response {
 		}
 	}
 
-	// Populate labels for each issue
-	for _, issue := range issues {
-		labels, _ := store.GetLabels(ctx, issue.ID)
-		issue.Labels = labels
-	}
-
-	// Get dependency counts in bulk (single query instead of N queries)
+	// Build issue ID list for batch queries
 	issueIDs := make([]string, len(issues))
 	for i, issue := range issues {
 		issueIDs[i] = issue.ID
 	}
+
+	// Populate labels in bulk (single query instead of N queries)
+	labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
+	for _, issue := range issues {
+		issue.Labels = labelsMap[issue.ID]
+	}
+
+	// Get dependency counts in bulk (single query instead of N queries)
 	depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
 	commentCounts, _ := store.GetCommentCounts(ctx, issueIDs)
 


### PR DESCRIPTION
## Summary

- RPC `handleList` called `store.GetLabels()` per-issue in a loop (N+1 queries), even though `SearchIssues` via `scanIssues` already batch-loaded labels
- Replaced with a single `store.GetLabelsForIssues()` batch call
- This is backend-agnostic (uses the `Storage` interface method, not SQLite internals)
- Moved `issueIDs` slice construction earlier to reuse it for labels, dep counts, and comment counts

## Test plan

- [x] `go build ./internal/rpc/` compiles cleanly
- [x] Full RPC test suite passes (`go test ./internal/rpc/`)

Fixes #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)