### PR TITLE
fix(dolt): use correct column name for dolt_conflicts system table

### DIFF
--- a/internal/storage/dolt/history_test.go
+++ b/internal/storage/dolt/history_test.go
@@ -369,10 +369,19 @@ func TestGetIssueDiff_InvalidRefs(t *testing.T) {
 // =============================================================================
 
 func TestGetInternalConflicts_NoConflicts(t *testing.T) {
-	// Skip: The dolt_conflicts system table schema varies by Dolt version.
-	// Some versions use (table, num_conflicts), others use (table_name, num_conflicts).
-	// This needs to be fixed in the implementation to handle version differences.
-	t.Skip("Skipping: dolt_conflicts table schema varies by Dolt version")
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	conflicts, err := store.GetInternalConflicts(ctx)
+	if err != nil {
+		t.Fatalf("failed to get conflicts: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("expected 0 conflicts, got %d", len(conflicts))
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- The `dolt_conflicts` system table in MySQL-flavored Dolt uses `table` (a reserved word requiring backtick escaping) as its column name, not `table_name`
- `table_name` is the Doltgres (Postgres-flavored) column name and was never valid for MySQL-flavored Dolt
- This caused `bd doctor` to always report a warning: `column "table_name" could not be found in any table in scope`
- Enables the previously-skipped `TestGetInternalConflicts_NoConflicts` test

## Test plan

- [x] Verified fix against Dolt 1.81.5 server — `bd doctor` now shows `Federation Conflicts: No conflicts`
- [x] Confirmed `table` is the correct column per [Dolt system tables docs](https://docs.dolthub.com/sql-reference/version-control/dolt-system-tables)
- [ ] CI passes with unskipped test

🤖 Generated with [Claude Code](https://claude.com/claude-code)