### PR TITLE
doctor: add label mutex invariant check (validation.labels.mutex)

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -739,6 +739,11 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, doltLocksCheck)
 	// Don't fail overall check for Dolt locks, just warn
 
+	// Check 33: Label mutex invariants (validation.labels.mutex)
+	labelMutexCheck := convertDoctorCheck(doctor.CheckLabelMutexInvariants(path))
+	result.Checks = append(result.Checks, labelMutexCheck)
+	// Don't fail overall check for label mutex violations, just warn
+
 	return result
 }
 

--- a/cmd/bd/doctor/label_mutex.go
+++ b/cmd/bd/doctor/label_mutex.go
@@ -1,0 +1,372 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/steveyegge/beads/internal/query"
+	"github.com/steveyegge/beads/internal/storage/factory"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// MutexGroup defines a mutually exclusive label set parsed from config.
+type MutexGroup struct {
+	Name     string
+	Labels   []string
+	Required bool
+	Query    string // optional scope query using internal/query syntax
+}
+
+// mutexViolation records a single label mutex violation on an issue.
+type mutexViolation struct {
+	IssueID   string
+	GroupName string
+	Kind      string   // "conflict" or "missing"
+	Present   []string // conflicting labels (for conflict) or empty (for missing)
+	Expected  []string // the mutex group labels
+}
+
+// parseMutexGroups reads validation.labels.mutex from a config.yaml file.
+// Returns nil, nil if the key is absent or the file doesn't exist.
+func parseMutexGroups(configPath string) ([]MutexGroup, error) {
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	v := viper.New()
+	v.SetConfigFile(configPath)
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	raw := v.Get("validation.labels.mutex")
+	if raw == nil {
+		return nil, nil
+	}
+
+	rawSlice, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("validation.labels.mutex must be a list, got %T", raw)
+	}
+
+	var groups []MutexGroup
+	for i, item := range rawSlice {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: expected map, got %T", i, item)
+		}
+
+		group := MutexGroup{}
+
+		// Parse name (optional)
+		if name, ok := m["name"].(string); ok {
+			group.Name = strings.TrimSpace(name)
+		}
+
+		// Parse labels (required)
+		labelsRaw, ok := m["labels"]
+		if !ok {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: missing 'labels' field", i)
+		}
+		labelsSlice, ok := labelsRaw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: 'labels' must be a list", i)
+		}
+		for j, l := range labelsSlice {
+			s, ok := l.(string)
+			if !ok {
+				return nil, fmt.Errorf("validation.labels.mutex[%d].labels[%d]: expected string, got %T", i, j, l)
+			}
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			group.Labels = append(group.Labels, s)
+		}
+		if len(group.Labels) < 2 {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: need at least 2 labels, got %d", i, len(group.Labels))
+		}
+
+		// Dedupe labels within group
+		seen := make(map[string]bool, len(group.Labels))
+		deduped := group.Labels[:0]
+		for _, l := range group.Labels {
+			if !seen[l] {
+				seen[l] = true
+				deduped = append(deduped, l)
+			}
+		}
+		group.Labels = deduped
+
+		// Parse required (optional, defaults to false)
+		if req, ok := m["required"].(bool); ok {
+			group.Required = req
+		}
+
+		// Parse scope.query (optional)
+		if scope, ok := m["scope"].(map[string]any); ok {
+			if q, ok := scope["query"].(string); ok {
+				group.Query = strings.TrimSpace(q)
+			}
+		}
+
+		// Synthesize name if not provided
+		if group.Name == "" {
+			group.Name = "labels: " + strings.Join(group.Labels, ",")
+		}
+
+		groups = append(groups, group)
+	}
+
+	return groups, nil
+}
+
+// shouldExcludeIssue returns true if the issue should be excluded from mutex checks
+// by default (when no scope query is provided).
+func shouldExcludeIssue(issue *types.Issue) bool {
+	if issue.Status == types.StatusTombstone {
+		return true
+	}
+	if issue.Ephemeral {
+		return true
+	}
+	if issue.IsTemplate {
+		return true
+	}
+	if issue.Pinned {
+		return true
+	}
+	if issue.Status == types.StatusPinned {
+		return true
+	}
+	return false
+}
+
+// findViolations checks a set of issues+labels against mutex groups.
+func findViolations(issues []*types.Issue, labelsMap map[string][]string, groups []MutexGroup) []mutexViolation {
+	var violations []mutexViolation
+
+	for _, issue := range issues {
+		issueLabels := labelsMap[issue.ID]
+		labelSet := make(map[string]bool, len(issueLabels))
+		for _, l := range issueLabels {
+			labelSet[l] = true
+		}
+
+		for _, group := range groups {
+			var present []string
+			for _, gl := range group.Labels {
+				if labelSet[gl] {
+					present = append(present, gl)
+				}
+			}
+
+			if len(present) > 1 {
+				violations = append(violations, mutexViolation{
+					IssueID:   issue.ID,
+					GroupName: group.Name,
+					Kind:      "conflict",
+					Present:   present,
+					Expected:  group.Labels,
+				})
+			}
+			if group.Required && len(present) == 0 {
+				violations = append(violations, mutexViolation{
+					IssueID:   issue.ID,
+					GroupName: group.Name,
+					Kind:      "missing",
+					Expected:  group.Labels,
+				})
+			}
+		}
+	}
+
+	return violations
+}
+
+// CheckLabelMutexInvariants checks that issues conform to label mutex rules
+// defined in validation.labels.mutex in .beads/config.yaml.
+func CheckLabelMutexInvariants(path string) DoctorCheck {
+	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
+
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	groups, err := parseMutexGroups(configPath)
+	if err != nil {
+		return DoctorCheck{
+			Name:     "Label Mutex Invariants",
+			Status:   StatusWarning,
+			Message:  "Invalid label mutex config",
+			Detail:   err.Error(),
+			Fix:      "Fix the validation.labels.mutex section in .beads/config.yaml",
+			Category: CategoryData,
+		}
+	}
+	if len(groups) == 0 {
+		return DoctorCheck{
+			Name:     "Label Mutex Invariants",
+			Status:   StatusOK,
+			Message:  "No label mutex rules configured",
+			Category: CategoryData,
+		}
+	}
+
+	// Open store read-only using the backend-agnostic factory.
+	ctx := context.Background()
+	store, err := factory.NewFromConfigWithOptions(ctx, beadsDir, factory.Options{ReadOnly: true})
+	if err != nil {
+		return DoctorCheck{
+			Name:     "Label Mutex Invariants",
+			Status:   StatusOK,
+			Message:  "N/A (no database)",
+			Category: CategoryData,
+		}
+	}
+	defer func() { _ = store.Close() }()
+
+	// Process each group — groups may have different scopes.
+	var allViolations []mutexViolation
+
+	// Partition groups by scope query to batch queries where possible.
+	// Groups with no scope query share a default fetch.
+	var defaultGroups []MutexGroup
+	scopedGroups := make(map[string][]MutexGroup) // query string -> groups
+	for _, g := range groups {
+		if g.Query == "" {
+			defaultGroups = append(defaultGroups, g)
+		} else {
+			scopedGroups[g.Query] = append(scopedGroups[g.Query], g)
+		}
+	}
+
+	// Check default-scoped groups (all non-excluded issues).
+	if len(defaultGroups) > 0 {
+		issues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+		if err != nil {
+			return DoctorCheck{
+				Name:     "Label Mutex Invariants",
+				Status:   StatusWarning,
+				Message:  "Unable to query issues",
+				Detail:   err.Error(),
+				Category: CategoryData,
+			}
+		}
+
+		// Apply default exclusions.
+		var filtered []*types.Issue
+		for _, issue := range issues {
+			if !shouldExcludeIssue(issue) {
+				filtered = append(filtered, issue)
+			}
+		}
+
+		if len(filtered) > 0 {
+			issueIDs := make([]string, len(filtered))
+			for i, issue := range filtered {
+				issueIDs[i] = issue.ID
+			}
+			labelsMap, err := store.GetLabelsForIssues(ctx, issueIDs)
+			if err != nil {
+				return DoctorCheck{
+					Name:     "Label Mutex Invariants",
+					Status:   StatusWarning,
+					Message:  "Unable to query labels",
+					Detail:   err.Error(),
+					Category: CategoryData,
+				}
+			}
+			allViolations = append(allViolations, findViolations(filtered, labelsMap, defaultGroups)...)
+		}
+	}
+
+	// Check scoped groups using the query evaluator.
+	for scopeQuery, scopeGroups := range scopedGroups {
+		qr, err := query.EvaluateAt(scopeQuery, time.Now())
+		if err != nil {
+			allViolations = append(allViolations, mutexViolation{
+				IssueID:   "",
+				GroupName: scopeGroups[0].Name,
+				Kind:      "config",
+				Present:   []string{fmt.Sprintf("invalid scope query: %v", err)},
+			})
+			continue
+		}
+
+		issues, err := store.SearchIssues(ctx, "", qr.Filter)
+		if err != nil {
+			continue
+		}
+
+		// Apply predicate if needed (complex queries with OR/NOT).
+		if qr.RequiresPredicate && qr.Predicate != nil {
+			var filtered []*types.Issue
+			for _, issue := range issues {
+				if qr.Predicate(issue) {
+					filtered = append(filtered, issue)
+				}
+			}
+			issues = filtered
+		}
+
+		if len(issues) > 0 {
+			issueIDs := make([]string, len(issues))
+			for i, issue := range issues {
+				issueIDs[i] = issue.ID
+			}
+			labelsMap, err := store.GetLabelsForIssues(ctx, issueIDs)
+			if err != nil {
+				continue
+			}
+			allViolations = append(allViolations, findViolations(issues, labelsMap, scopeGroups)...)
+		}
+	}
+
+	if len(allViolations) == 0 {
+		return DoctorCheck{
+			Name:     "Label Mutex Invariants",
+			Status:   StatusOK,
+			Message:  fmt.Sprintf("All issues conform to %d mutex rule(s)", len(groups)),
+			Category: CategoryData,
+		}
+	}
+
+	// Build detail output, sorted for deterministic output.
+	sort.Slice(allViolations, func(i, j int) bool {
+		if allViolations[i].IssueID != allViolations[j].IssueID {
+			return allViolations[i].IssueID < allViolations[j].IssueID
+		}
+		return allViolations[i].GroupName < allViolations[j].GroupName
+	})
+
+	var detail strings.Builder
+	const maxDetail = 20
+	for i, v := range allViolations {
+		if i >= maxDetail {
+			fmt.Fprintf(&detail, "... and %d more\n", len(allViolations)-maxDetail)
+			break
+		}
+		switch v.Kind {
+		case "conflict":
+			fmt.Fprintf(&detail, "%s: %s conflict (%s)\n", v.IssueID, v.GroupName, strings.Join(v.Present, ", "))
+		case "missing":
+			fmt.Fprintf(&detail, "%s: %s missing (expected one of: %s)\n", v.IssueID, v.GroupName, strings.Join(v.Expected, ", "))
+		case "config":
+			fmt.Fprintf(&detail, "scope error for %s: %s\n", v.GroupName, strings.Join(v.Present, "; "))
+		}
+	}
+
+	return DoctorCheck{
+		Name:     "Label Mutex Invariants",
+		Status:   StatusWarning,
+		Message:  fmt.Sprintf("%d label mutex violation(s)", len(allViolations)),
+		Detail:   strings.TrimSpace(detail.String()),
+		Fix:      "Remove conflicting labels (bd update <id> --remove-label <label>) or add missing required labels (bd update <id> --add-label <label>)",
+		Category: CategoryData,
+	}
+}

--- a/cmd/bd/doctor/label_mutex_test.go
+++ b/cmd/bd/doctor/label_mutex_test.go
@@ -1,0 +1,512 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// setupMutexTestRepo creates a temp repo with a SQLite DB, issues, labels, and config.yaml.
+// Returns the tmpDir path. The store is closed before returning.
+func setupMutexTestRepo(t *testing.T, configYAML string, issuesAndLabels []struct {
+	issue  *types.Issue
+	labels []string
+}) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
+	ctx := context.Background()
+
+	store, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set issue_prefix: %v", err)
+	}
+
+	for _, item := range issuesAndLabels {
+		if err := store.CreateIssue(ctx, item.issue, "test"); err != nil {
+			t.Fatalf("Failed to create issue: %v", err)
+		}
+		for _, label := range item.labels {
+			if err := store.AddLabel(ctx, item.issue.ID, label, "test"); err != nil {
+				t.Fatalf("Failed to add label %q to %s: %v", label, item.issue.ID, err)
+			}
+		}
+	}
+
+	store.Close()
+
+	if configYAML != "" {
+		configPath := filepath.Join(beadsDir, "config.yaml")
+		if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+	}
+
+	return tmpDir
+}
+
+func TestCheckLabelMutexInvariants_NoConfig(t *testing.T) {
+	tmpDir := setupMutexTestRepo(t, "", nil)
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q", check.Status, StatusOK)
+	}
+	if check.Message != "No label mutex rules configured" {
+		t.Errorf("Message = %q, want 'No label mutex rules configured'", check.Message)
+	}
+}
+
+func TestCheckLabelMutexInvariants_NoViolations(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: false
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			issue:  &types.Issue{Title: "Task A", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"inbox"},
+		},
+		{
+			issue:  &types.Issue{Title: "Task B", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"accepted"},
+		},
+		{
+			issue:  &types.Issue{Title: "Task C", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{}, // no labels — OK for optional mutex
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q", check.Status, StatusOK)
+		t.Logf("Detail: %s", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_ConflictDetected(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: false
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			issue:  &types.Issue{Title: "Conflicting", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"inbox", "accepted"},
+		},
+		{
+			issue:  &types.Issue{Title: "Clean", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"inbox"},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if !strings.Contains(check.Message, "1 label mutex violation") {
+		t.Errorf("Message = %q, want it to contain '1 label mutex violation'", check.Message)
+	}
+	if !strings.Contains(check.Detail, "triage conflict") {
+		t.Errorf("Detail = %q, want it to contain 'triage conflict'", check.Detail)
+	}
+	if !strings.Contains(check.Detail, "inbox, accepted") {
+		t.Errorf("Detail = %q, want it to contain 'inbox, accepted'", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_MissingRequired(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: work_status
+        labels: [status:todo, status:doing, status:done]
+        required: true
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			issue:  &types.Issue{Title: "Has status", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"status:todo"},
+		},
+		{
+			issue:  &types.Issue{Title: "Missing status", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"unrelated"},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if !strings.Contains(check.Detail, "work_status missing") {
+		t.Errorf("Detail = %q, want it to contain 'work_status missing'", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_ExcludesTombstones(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: true
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			// Tombstone has no labels — should NOT be flagged for missing required.
+			issue:  &types.Issue{Title: "Deleted", Status: types.StatusTombstone, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q (tombstones should be excluded)", check.Status, StatusOK)
+		t.Logf("Detail: %s", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_ExcludesTemplates(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: true
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			issue:  &types.Issue{Title: "Template", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, IsTemplate: true},
+			labels: []string{},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q (templates should be excluded)", check.Status, StatusOK)
+		t.Logf("Detail: %s", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_ExcludesEphemeral(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: true
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			issue:  &types.Issue{Title: "Wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true},
+			labels: []string{},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q (ephemeral should be excluded)", check.Status, StatusOK)
+		t.Logf("Detail: %s", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_ExcludesPinned(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: true
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			issue:  &types.Issue{Title: "Pinned", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Pinned: true},
+			labels: []string{},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q (pinned should be excluded)", check.Status, StatusOK)
+		t.Logf("Detail: %s", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_InvalidConfig(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: bad
+        labels: [only_one]
+`
+	tmpDir := setupMutexTestRepo(t, config, nil)
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if !strings.Contains(check.Detail, "at least 2 labels") {
+		t.Errorf("Detail = %q, want it to mention 'at least 2 labels'", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_MultipleGroups(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: false
+      - name: work_status
+        labels: [status:todo, status:doing, status:done]
+        required: true
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			// Conflict on triage + missing work_status
+			issue:  &types.Issue{Title: "Double trouble", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"inbox", "accepted"},
+		},
+		{
+			// Clean on both
+			issue:  &types.Issue{Title: "Clean", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{"inbox", "status:todo"},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	// Should have 2 violations: one conflict + one missing
+	if !strings.Contains(check.Message, "2 label mutex violation") {
+		t.Errorf("Message = %q, want it to contain '2 label mutex violation'", check.Message)
+	}
+	if !strings.Contains(check.Detail, "triage conflict") {
+		t.Errorf("Detail = %q, want it to contain 'triage conflict'", check.Detail)
+	}
+	if !strings.Contains(check.Detail, "work_status missing") {
+		t.Errorf("Detail = %q, want it to contain 'work_status missing'", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_ScopedQuery(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: task_triage
+        labels: [inbox, accepted]
+        required: true
+        scope:
+          query: "type=task"
+`
+	tmpDir := setupMutexTestRepo(t, config, []struct {
+		issue  *types.Issue
+		labels []string
+	}{
+		{
+			// Task with no triage label — should be flagged (required, scoped to tasks)
+			issue:  &types.Issue{Title: "A task", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+			labels: []string{},
+		},
+		{
+			// Bug with no triage label — should NOT be flagged (scope=type=task)
+			issue:  &types.Issue{Title: "A bug", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeBug},
+			labels: []string{},
+		},
+	})
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if !strings.Contains(check.Message, "1 label mutex violation") {
+		t.Errorf("Message = %q, want '1 label mutex violation'", check.Message)
+	}
+	if !strings.Contains(check.Detail, "task_triage missing") {
+		t.Errorf("Detail = %q, want it to contain 'task_triage missing'", check.Detail)
+	}
+}
+
+func TestCheckLabelMutexInvariants_NoDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckLabelMutexInvariants(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q (no database should be OK)", check.Status, StatusOK)
+	}
+	if check.Message != "N/A (no database)" {
+		t.Errorf("Message = %q, want 'N/A (no database)'", check.Message)
+	}
+}
+
+func TestParseMutexGroups_Defaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	config := `
+validation:
+  labels:
+    mutex:
+      - labels: [a, b, c]
+`
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, err := parseMutexGroups(configPath)
+	if err != nil {
+		t.Fatalf("parseMutexGroups: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+
+	g := groups[0]
+	if g.Required {
+		t.Error("expected required=false by default")
+	}
+	if g.Name != "labels: a,b,c" {
+		t.Errorf("synthesized name = %q, want 'labels: a,b,c'", g.Name)
+	}
+	if len(g.Labels) != 3 {
+		t.Errorf("expected 3 labels, got %d", len(g.Labels))
+	}
+}
+
+func TestParseMutexGroups_Deduplication(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	config := `
+validation:
+  labels:
+    mutex:
+      - labels: [a, b, a, c, b]
+`
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, err := parseMutexGroups(configPath)
+	if err != nil {
+		t.Fatalf("parseMutexGroups: %v", err)
+	}
+
+	g := groups[0]
+	if len(g.Labels) != 3 {
+		t.Errorf("expected 3 labels after dedup, got %d: %v", len(g.Labels), g.Labels)
+	}
+}
+
+func TestParseMutexGroups_MissingFile(t *testing.T) {
+	groups, err := parseMutexGroups("/nonexistent/config.yaml")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if groups != nil {
+		t.Errorf("expected nil groups for missing file, got: %v", groups)
+	}
+}
+
+func TestParseMutexGroups_NoMutexKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	config := `
+validation:
+  on-create: warn
+`
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, err := parseMutexGroups(configPath)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if groups != nil {
+		t.Errorf("expected nil groups, got: %v", groups)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `validation.labels.mutex` config in `.beads/config.yaml` for declaring mutually exclusive label sets
- Add `bd doctor` check ("Label Mutex Invariants") that audits issues for violations
- Support optional (`required: false`) and required (`required: true`) mutex groups
- Support scoped queries (`scope.query`) using the existing `internal/query` evaluator

This is PR 1 of 2 for #1606. It adds policy definition and audit only — no DB enforcement, no `--fix`, no schema changes. PR 2 will add DB-level triggers and `bd doctor --fix` to apply policy.

## Config format

```yaml
validation:
  labels:
    mutex:
      - name: triage_state
        labels: [inbox, accepted]
        required: false
      - name: work_status
        labels: [status:todo, status:doing, status:done]
        required: true
        scope:
          query: "type=task OR type=bug OR type=feature"
```

## Implementation

- **`cmd/bd/doctor/label_mutex.go`**: Check function + config parser. Opens store via `factory.NewFromConfigWithOptions` (backend-agnostic). Loads config from target repo's `config.yaml` via local viper instance (not global state). Bulk fetches via `SearchIssues` + `GetLabelsForIssues`.
- **`cmd/bd/doctor/label_mutex_test.go`**: 16 tests covering: no config, no violations, conflicts, missing required, exclusions (tombstones/templates/ephemeral/pinned), invalid config, multiple groups, scoped queries, no database, parser edge cases.
- **`cmd/bd/doctor.go`**: Wired as Check 33 after Dolt locks.

## Default exclusions

Tombstones, ephemeral, templates, and pinned issues are excluded from checks (when no scope query is set) to avoid noisy false positives on non-work beads.

## Test plan

- [x] All 16 new tests pass
- [x] All existing doctor tests pass (no regressions)
- [x] `go build ./cmd/bd/` succeeds
- [x] Smoke test: `bd doctor --json` shows check with `status: ok` when no mutex config present
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)