### PR TITLE
feat: DB-level label mutex enforcement + doctor drift check

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -739,7 +739,12 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, doltLocksCheck)
 	// Don't fail overall check for Dolt locks, just warn
 
-	// Check 33: Label mutex invariants (validation.labels.mutex)
+	// Check 33: Label mutex policy drift (YAML vs DB)
+	labelMutexPolicyCheck := convertDoctorCheck(doctor.CheckLabelMutexPolicy(path))
+	result.Checks = append(result.Checks, labelMutexPolicyCheck)
+	// Don't fail overall check for policy drift, just warn
+
+	// Check 34: Label mutex invariants (validation.labels.mutex)
 	labelMutexCheck := convertDoctorCheck(doctor.CheckLabelMutexInvariants(path))
 	result.Checks = append(result.Checks, labelMutexCheck)
 	// Don't fail overall check for label mutex violations, just warn

--- a/cmd/bd/doctor/fix/label_mutex.go
+++ b/cmd/bd/doctor/fix/label_mutex.go
@@ -1,0 +1,154 @@
+package fix
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/labelmutex"
+	"github.com/steveyegge/beads/internal/storage/factory"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// LabelMutexPolicy syncs YAML label mutex config to the DB policy tables.
+// This activates DB-level enforcement (triggers consult these tables).
+//
+// Safety: refuses to apply if there are existing conflict violations,
+// because enabling enforcement on a dirty DB would cause hard failures on
+// subsequent label operations. Missing-required violations are ignored
+// (required is soft-only, not enforced by DB triggers).
+func LabelMutexPolicy(path string) error {
+	if err := validateBeadsWorkspace(path); err != nil {
+		return err
+	}
+
+	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
+	configPath := filepath.Join(beadsDir, "config.yaml")
+
+	// 1. Parse YAML config.
+	groups, err := labelmutex.ParseMutexGroups(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse label mutex config: %w", err)
+	}
+
+	// 2. Open store read-write.
+	ctx := context.Background()
+	store, err := factory.NewFromConfig(ctx, beadsDir)
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// 3. Audit for existing conflict violations before applying.
+	if len(groups) > 0 {
+		issues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+		if err != nil {
+			return fmt.Errorf("failed to query issues for audit: %w", err)
+		}
+
+		// Filter excluded issues (same logic as the doctor check).
+		var filtered []*types.Issue
+		for _, issue := range issues {
+			if !labelmutex.ShouldExcludeIssue(issue) {
+				filtered = append(filtered, issue)
+			}
+		}
+
+		if len(filtered) > 0 {
+			issueIDs := make([]string, len(filtered))
+			for i, issue := range filtered {
+				issueIDs[i] = issue.ID
+			}
+			labelsMap, err := store.GetLabelsForIssues(ctx, issueIDs)
+			if err != nil {
+				return fmt.Errorf("failed to query labels for audit: %w", err)
+			}
+
+			violations := labelmutex.FindViolations(filtered, labelsMap, groups)
+			// Only block on conflict violations, not missing-required.
+			var conflicts int
+			var firstIDs []string
+			for _, v := range violations {
+				if v.Kind == "conflict" {
+					conflicts++
+					if len(firstIDs) < 3 {
+						firstIDs = append(firstIDs, v.IssueID)
+					}
+				}
+			}
+			if conflicts > 0 {
+				return fmt.Errorf("cannot apply label mutex policy: %d conflict violation(s) exist (e.g. %s); resolve them first",
+					conflicts, joinIDs(firstIDs))
+			}
+		}
+	}
+
+	// 4. Replace DB policy tables in a transaction.
+	db := store.UnderlyingDB()
+	if db == nil {
+		return fmt.Errorf("backend does not expose a SQL database")
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM label_mutex_members`)
+	if err != nil {
+		return fmt.Errorf("failed to clear label_mutex_members: %w", err)
+	}
+	_, err = tx.ExecContext(ctx, `DELETE FROM label_mutex_groups`)
+	if err != nil {
+		return fmt.Errorf("failed to clear label_mutex_groups: %w", err)
+	}
+
+	for _, g := range groups {
+		required := 0
+		if g.Required {
+			required = 1
+		}
+		result, err := tx.ExecContext(ctx,
+			`INSERT INTO label_mutex_groups (name, required) VALUES (?, ?)`,
+			g.Name, required)
+		if err != nil {
+			return fmt.Errorf("failed to insert group %q: %w", g.Name, err)
+		}
+		groupID, err := result.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("failed to get group ID for %q: %w", g.Name, err)
+		}
+		for _, label := range g.Labels {
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO label_mutex_members (group_id, label) VALUES (?, ?)`,
+				groupID, label)
+			if err != nil {
+				return fmt.Errorf("failed to insert member %q in group %q: %w", label, g.Name, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit policy: %w", err)
+	}
+
+	if len(groups) == 0 {
+		fmt.Println("  Cleared label mutex policy (no groups in YAML)")
+	} else {
+		fmt.Printf("  Applied %d label mutex group(s) to database\n", len(groups))
+	}
+
+	return nil
+}
+
+func joinIDs(ids []string) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	result := ids[0]
+	for i := 1; i < len(ids); i++ {
+		result += ", " + ids[i]
+	}
+	return result
+}

--- a/cmd/bd/doctor/label_mutex_policy.go
+++ b/cmd/bd/doctor/label_mutex_policy.go
@@ -1,0 +1,259 @@
+package doctor
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/labelmutex"
+	"github.com/steveyegge/beads/internal/storage/factory"
+)
+
+// canonicalGroup is a normalized representation of a mutex group for comparison.
+type canonicalGroup struct {
+	Name     string
+	Labels   []string // sorted
+	Required bool
+}
+
+// canonicalizeYAMLGroups converts parsed YAML MutexGroups into canonical form.
+func canonicalizeYAMLGroups(groups []labelmutex.MutexGroup) []canonicalGroup {
+	result := make([]canonicalGroup, len(groups))
+	for i, g := range groups {
+		labels := make([]string, len(g.Labels))
+		copy(labels, g.Labels)
+		sort.Strings(labels)
+		result[i] = canonicalGroup{
+			Name:     g.Name,
+			Labels:   labels,
+			Required: g.Required,
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return strings.Join(result[i].Labels, ",") < strings.Join(result[j].Labels, ",")
+	})
+	return result
+}
+
+// readDBGroups reads label_mutex_groups and label_mutex_members from the
+// underlying database and returns them in canonical form.
+func readDBGroups(db *sql.DB) ([]canonicalGroup, error) {
+	// Check if tables exist (migration may not have run yet).
+	var tableCount int
+	err := db.QueryRow(`
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'table' AND name = 'label_mutex_groups'
+	`).Scan(&tableCount)
+	if err != nil || tableCount == 0 {
+		// Try information_schema for Dolt/MySQL compatibility.
+		err2 := db.QueryRow(`
+			SELECT COUNT(*) FROM information_schema.tables
+			WHERE table_schema = DATABASE() AND table_name = 'label_mutex_groups'
+		`).Scan(&tableCount)
+		if err2 != nil || tableCount == 0 {
+			return nil, nil
+		}
+	}
+
+	rows, err := db.Query(`
+		SELECT g.id, g.name, g.required
+		FROM label_mutex_groups g
+		ORDER BY g.id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query label_mutex_groups: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type dbGroup struct {
+		id       int64
+		name     string
+		required bool
+	}
+	var dbGroups []dbGroup
+	for rows.Next() {
+		var g dbGroup
+		if err := rows.Scan(&g.id, &g.name, &g.required); err != nil {
+			return nil, fmt.Errorf("failed to scan group: %w", err)
+		}
+		dbGroups = append(dbGroups, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating groups: %w", err)
+	}
+
+	if len(dbGroups) == 0 {
+		return nil, nil
+	}
+
+	// Fetch members for all groups.
+	memberRows, err := db.Query(`
+		SELECT group_id, label
+		FROM label_mutex_members
+		ORDER BY group_id, label
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query label_mutex_members: %w", err)
+	}
+	defer func() { _ = memberRows.Close() }()
+
+	membersByGroup := make(map[int64][]string)
+	for memberRows.Next() {
+		var groupID int64
+		var label string
+		if err := memberRows.Scan(&groupID, &label); err != nil {
+			return nil, fmt.Errorf("failed to scan member: %w", err)
+		}
+		membersByGroup[groupID] = append(membersByGroup[groupID], label)
+	}
+	if err := memberRows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating members: %w", err)
+	}
+
+	result := make([]canonicalGroup, 0, len(dbGroups))
+	for _, g := range dbGroups {
+		labels := membersByGroup[g.id]
+		sort.Strings(labels)
+		result = append(result, canonicalGroup{
+			Name:     g.name,
+			Labels:   labels,
+			Required: g.required,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return strings.Join(result[i].Labels, ",") < strings.Join(result[j].Labels, ",")
+	})
+	return result, nil
+}
+
+// groupsEqual returns true if two canonical group slices are equal.
+func groupsEqual(a, b []canonicalGroup) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].Required != b[i].Required {
+			return false
+		}
+		if len(a[i].Labels) != len(b[i].Labels) {
+			return false
+		}
+		for j := range a[i].Labels {
+			if a[i].Labels[j] != b[i].Labels[j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// CheckLabelMutexPolicy checks whether the DB policy tables match the YAML config.
+// Name must be "Label Mutex Policy" to match the fix dispatcher.
+func CheckLabelMutexPolicy(path string) DoctorCheck {
+	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
+
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	yamlGroups, err := labelmutex.ParseMutexGroups(configPath)
+	if err != nil {
+		return DoctorCheck{
+			Name:     "Label Mutex Policy",
+			Status:   StatusWarning,
+			Message:  "Invalid label mutex config",
+			Detail:   err.Error(),
+			Fix:      "Fix the validation.labels.mutex section in .beads/config.yaml",
+			Category: CategoryData,
+		}
+	}
+
+	// Open store read-only.
+	ctx := context.Background()
+	store, err := factory.NewFromConfigWithOptions(ctx, beadsDir, factory.Options{ReadOnly: true})
+	if err != nil {
+		// No database — if YAML has groups, that's a drift.
+		if len(yamlGroups) > 0 {
+			return DoctorCheck{
+				Name:     "Label Mutex Policy",
+				Status:   StatusWarning,
+				Message:  fmt.Sprintf("YAML defines %d mutex group(s) but no database available", len(yamlGroups)),
+				Category: CategoryData,
+			}
+		}
+		return DoctorCheck{
+			Name:     "Label Mutex Policy",
+			Status:   StatusOK,
+			Message:  "No label mutex policy configured",
+			Category: CategoryData,
+		}
+	}
+	defer func() { _ = store.Close() }()
+
+	db := store.UnderlyingDB()
+	if db == nil {
+		if len(yamlGroups) > 0 {
+			return DoctorCheck{
+				Name:     "Label Mutex Policy",
+				Status:   StatusWarning,
+				Message:  "YAML defines mutex groups but backend has no SQL database",
+				Category: CategoryData,
+			}
+		}
+		return DoctorCheck{
+			Name:     "Label Mutex Policy",
+			Status:   StatusOK,
+			Message:  "No label mutex policy configured",
+			Category: CategoryData,
+		}
+	}
+
+	dbGroups, err := readDBGroups(db)
+	if err != nil {
+		return DoctorCheck{
+			Name:     "Label Mutex Policy",
+			Status:   StatusWarning,
+			Message:  "Unable to read DB policy tables",
+			Detail:   err.Error(),
+			Category: CategoryData,
+		}
+	}
+
+	yamlCanonical := canonicalizeYAMLGroups(yamlGroups)
+
+	// Both empty → OK, nothing configured.
+	if len(yamlCanonical) == 0 && len(dbGroups) == 0 {
+		return DoctorCheck{
+			Name:     "Label Mutex Policy",
+			Status:   StatusOK,
+			Message:  "No label mutex policy configured",
+			Category: CategoryData,
+		}
+	}
+
+	if groupsEqual(yamlCanonical, dbGroups) {
+		return DoctorCheck{
+			Name:     "Label Mutex Policy",
+			Status:   StatusOK,
+			Message:  fmt.Sprintf("DB policy matches YAML (%d group(s))", len(yamlCanonical)),
+			Category: CategoryData,
+		}
+	}
+
+	// Mismatch — report drift.
+	detail := fmt.Sprintf("YAML defines %d group(s), DB has %d group(s)", len(yamlCanonical), len(dbGroups))
+	return DoctorCheck{
+		Name:     "Label Mutex Policy",
+		Status:   StatusWarning,
+		Message:  "Label mutex policy drift (YAML != DB)",
+		Detail:   detail,
+		Fix:      "Run 'bd doctor --fix' to apply label mutex policy to database",
+		Category: CategoryData,
+	}
+}

--- a/cmd/bd/doctor/label_mutex_policy_test.go
+++ b/cmd/bd/doctor/label_mutex_policy_test.go
@@ -1,0 +1,285 @@
+package doctor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestCheckLabelMutexPolicy_NothingConfigured(t *testing.T) {
+	tmpDir := setupMutexTestRepo(t, "", nil)
+
+	check := CheckLabelMutexPolicy(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q", check.Status, StatusOK)
+	}
+	if !strings.Contains(check.Message, "No label mutex policy configured") {
+		t.Errorf("Message = %q, want 'No label mutex policy configured'", check.Message)
+	}
+}
+
+func TestCheckLabelMutexPolicy_DriftDetected(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+`
+	tmpDir := setupMutexTestRepo(t, config, nil)
+
+	check := CheckLabelMutexPolicy(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if !strings.Contains(check.Message, "drift") {
+		t.Errorf("Message = %q, want it to contain 'drift'", check.Message)
+	}
+	if !strings.Contains(check.Detail, "YAML defines 1 group(s), DB has 0 group(s)") {
+		t.Errorf("Detail = %q, want it to describe the mismatch", check.Detail)
+	}
+	if check.Fix == "" {
+		t.Error("Fix should not be empty for drift warning")
+	}
+}
+
+func TestCheckLabelMutexPolicy_InSync(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+        required: false
+`
+	tmpDir := setupMutexTestRepo(t, config, nil)
+
+	// Manually populate DB tables to match YAML.
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
+	ctx := context.Background()
+
+	store, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to open store: %v", err)
+	}
+	db := store.UnderlyingDB()
+
+	_, err = db.Exec(`INSERT INTO label_mutex_groups (name, required) VALUES ('triage', 0)`)
+	if err != nil {
+		t.Fatalf("Failed to insert group: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO label_mutex_members (group_id, label) VALUES (1, 'accepted')`)
+	if err != nil {
+		t.Fatalf("Failed to insert member: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO label_mutex_members (group_id, label) VALUES (1, 'inbox')`)
+	if err != nil {
+		t.Fatalf("Failed to insert member: %v", err)
+	}
+	store.Close()
+
+	check := CheckLabelMutexPolicy(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q", check.Status, StatusOK)
+		t.Logf("Message: %s", check.Message)
+		t.Logf("Detail: %s", check.Detail)
+	}
+	if !strings.Contains(check.Message, "DB policy matches YAML") {
+		t.Errorf("Message = %q, want 'DB policy matches YAML'", check.Message)
+	}
+}
+
+func TestCheckLabelMutexPolicy_NoDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckLabelMutexPolicy(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q (YAML groups but no DB)", check.Status, StatusWarning)
+	}
+}
+
+func TestTriggerEnforcement_ConflictBlocked(t *testing.T) {
+	config := `
+validation:
+  labels:
+    mutex:
+      - name: triage
+        labels: [inbox, accepted]
+`
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
+	ctx := context.Background()
+
+	store, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set issue_prefix: %v", err)
+	}
+
+	issue := &types.Issue{Title: "Test issue", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Populate policy tables to activate the trigger.
+	db := store.UnderlyingDB()
+	_, err = db.Exec(`INSERT INTO label_mutex_groups (name, required) VALUES ('triage', 0)`)
+	if err != nil {
+		t.Fatalf("Failed to insert group: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO label_mutex_members (group_id, label) VALUES (1, 'inbox')`)
+	if err != nil {
+		t.Fatalf("Failed to insert member: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO label_mutex_members (group_id, label) VALUES (1, 'accepted')`)
+	if err != nil {
+		t.Fatalf("Failed to insert member: %v", err)
+	}
+
+	// Add first label — should succeed.
+	if err := store.AddLabel(ctx, issue.ID, "inbox", "test"); err != nil {
+		t.Fatalf("AddLabel('inbox') should succeed, got: %v", err)
+	}
+
+	// Add conflicting label — should fail.
+	err = store.AddLabel(ctx, issue.ID, "accepted", "test")
+	if err == nil {
+		t.Fatal("AddLabel('accepted') should have failed with mutex violation")
+	}
+	if !strings.Contains(err.Error(), "label mutex violation") {
+		t.Errorf("Error = %q, want it to contain 'label mutex violation'", err.Error())
+	}
+
+	// Write config for completeness
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	store.Close()
+}
+
+func TestTriggerEnforcement_EmptyPolicyAllowsAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
+	ctx := context.Background()
+
+	store, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set issue_prefix: %v", err)
+	}
+
+	issue := &types.Issue{Title: "Test issue", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// With empty policy tables, trigger "fails open" — any labels allowed.
+	if err := store.AddLabel(ctx, issue.ID, "inbox", "test"); err != nil {
+		t.Fatalf("AddLabel('inbox') with empty policy should succeed, got: %v", err)
+	}
+	if err := store.AddLabel(ctx, issue.ID, "accepted", "test"); err != nil {
+		t.Fatalf("AddLabel('accepted') with empty policy should succeed, got: %v", err)
+	}
+
+	store.Close()
+}
+
+func TestTriggerEnforcement_NonMutexLabelsAllowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
+	ctx := context.Background()
+
+	store, err := sqlite.New(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set issue_prefix: %v", err)
+	}
+
+	issue := &types.Issue{Title: "Test issue", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	// Populate policy: only inbox/accepted are mutex.
+	db := store.UnderlyingDB()
+	_, err = db.Exec(`INSERT INTO label_mutex_groups (name, required) VALUES ('triage', 0)`)
+	if err != nil {
+		t.Fatalf("Failed to insert group: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO label_mutex_members (group_id, label) VALUES (1, 'inbox')`)
+	if err != nil {
+		t.Fatalf("Failed to insert member: %v", err)
+	}
+	_, err = db.Exec(`INSERT INTO label_mutex_members (group_id, label) VALUES (1, 'accepted')`)
+	if err != nil {
+		t.Fatalf("Failed to insert member: %v", err)
+	}
+
+	// Add inbox (in mutex group).
+	if err := store.AddLabel(ctx, issue.ID, "inbox", "test"); err != nil {
+		t.Fatalf("AddLabel('inbox') should succeed, got: %v", err)
+	}
+
+	// Add unrelated labels — should succeed (not in any mutex group).
+	if err := store.AddLabel(ctx, issue.ID, "bug", "test"); err != nil {
+		t.Fatalf("AddLabel('bug') should succeed, got: %v", err)
+	}
+	if err := store.AddLabel(ctx, issue.ID, "priority:high", "test"); err != nil {
+		t.Fatalf("AddLabel('priority:high') should succeed, got: %v", err)
+	}
+
+	store.Close()
+}

--- a/cmd/bd/doctor/label_mutex_test.go
+++ b/cmd/bd/doctor/label_mutex_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/labelmutex"
 	"github.com/steveyegge/beads/internal/storage/sqlite"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -437,9 +438,9 @@ validation:
 		t.Fatal(err)
 	}
 
-	groups, err := parseMutexGroups(configPath)
+	groups, err := labelmutex.ParseMutexGroups(configPath)
 	if err != nil {
-		t.Fatalf("parseMutexGroups: %v", err)
+		t.Fatalf("ParseMutexGroups: %v", err)
 	}
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 group, got %d", len(groups))
@@ -470,9 +471,9 @@ validation:
 		t.Fatal(err)
 	}
 
-	groups, err := parseMutexGroups(configPath)
+	groups, err := labelmutex.ParseMutexGroups(configPath)
 	if err != nil {
-		t.Fatalf("parseMutexGroups: %v", err)
+		t.Fatalf("ParseMutexGroups: %v", err)
 	}
 
 	g := groups[0]
@@ -482,7 +483,7 @@ validation:
 }
 
 func TestParseMutexGroups_MissingFile(t *testing.T) {
-	groups, err := parseMutexGroups("/nonexistent/config.yaml")
+	groups, err := labelmutex.ParseMutexGroups("/nonexistent/config.yaml")
 	if err != nil {
 		t.Fatalf("expected nil error for missing file, got: %v", err)
 	}
@@ -502,7 +503,7 @@ validation:
 		t.Fatal(err)
 	}
 
-	groups, err := parseMutexGroups(configPath)
+	groups, err := labelmutex.ParseMutexGroups(configPath)
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -195,6 +195,7 @@ func applyFixList(path string, fixes []doctorCheck) {
 		"Database Integrity",
 		"Database",
 		"Schema Compatibility",
+		"Label Mutex Policy",
 		"JSONL Integrity",
 		"DB-JSONL Sync",
 		"Sync Divergence",
@@ -304,6 +305,8 @@ func applyFixList(path string, fixes []doctorCheck) {
 			// No auto-fix: git conflicts require manual resolution
 			fmt.Printf("  ⚠ Resolve conflicts manually: git checkout --ours or --theirs .beads/issues.jsonl\n")
 			continue
+		case "Label Mutex Policy":
+			err = fix.LabelMutexPolicy(path)
 		case "Stale Closed Issues":
 			// consolidate cleanup into doctor --fix
 			err = fix.StaleClosedIssues(path)

--- a/internal/labelmutex/policy.go
+++ b/internal/labelmutex/policy.go
@@ -1,0 +1,189 @@
+// Package labelmutex provides shared logic for label mutex validation.
+// It is imported by both cmd/bd/doctor and cmd/bd/doctor/fix to avoid
+// code duplication without creating import cycles.
+package labelmutex
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/viper"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// MutexGroup defines a mutually exclusive label set parsed from config.
+type MutexGroup struct {
+	Name     string
+	Labels   []string
+	Required bool
+	Query    string // optional scope query using internal/query syntax
+}
+
+// Violation records a single label mutex violation on an issue.
+type Violation struct {
+	IssueID   string
+	GroupName string
+	Kind      string   // "conflict", "missing", or "config"
+	Present   []string // conflicting labels (for conflict) or error info (for config)
+	Expected  []string // the mutex group labels
+}
+
+// ParseMutexGroups reads validation.labels.mutex from a config.yaml file.
+// Returns nil, nil if the key is absent or the file doesn't exist.
+func ParseMutexGroups(configPath string) ([]MutexGroup, error) {
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	v := viper.New()
+	v.SetConfigFile(configPath)
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	raw := v.Get("validation.labels.mutex")
+	if raw == nil {
+		return nil, nil
+	}
+
+	rawSlice, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("validation.labels.mutex must be a list, got %T", raw)
+	}
+
+	var groups []MutexGroup
+	for i, item := range rawSlice {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: expected map, got %T", i, item)
+		}
+
+		group := MutexGroup{}
+
+		// Parse name (optional)
+		if name, ok := m["name"].(string); ok {
+			group.Name = strings.TrimSpace(name)
+		}
+
+		// Parse labels (required)
+		labelsRaw, ok := m["labels"]
+		if !ok {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: missing 'labels' field", i)
+		}
+		labelsSlice, ok := labelsRaw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: 'labels' must be a list", i)
+		}
+		for j, l := range labelsSlice {
+			s, ok := l.(string)
+			if !ok {
+				return nil, fmt.Errorf("validation.labels.mutex[%d].labels[%d]: expected string, got %T", i, j, l)
+			}
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			group.Labels = append(group.Labels, s)
+		}
+		if len(group.Labels) < 2 {
+			return nil, fmt.Errorf("validation.labels.mutex[%d]: need at least 2 labels, got %d", i, len(group.Labels))
+		}
+
+		// Dedupe labels within group
+		seen := make(map[string]bool, len(group.Labels))
+		deduped := group.Labels[:0]
+		for _, l := range group.Labels {
+			if !seen[l] {
+				seen[l] = true
+				deduped = append(deduped, l)
+			}
+		}
+		group.Labels = deduped
+
+		// Parse required (optional, defaults to false)
+		if req, ok := m["required"].(bool); ok {
+			group.Required = req
+		}
+
+		// Parse scope.query (optional)
+		if scope, ok := m["scope"].(map[string]any); ok {
+			if q, ok := scope["query"].(string); ok {
+				group.Query = strings.TrimSpace(q)
+			}
+		}
+
+		// Synthesize name if not provided
+		if group.Name == "" {
+			group.Name = "labels: " + strings.Join(group.Labels, ",")
+		}
+
+		groups = append(groups, group)
+	}
+
+	return groups, nil
+}
+
+// ShouldExcludeIssue returns true if the issue should be excluded from mutex
+// checks by default (when no scope query is provided).
+func ShouldExcludeIssue(issue *types.Issue) bool {
+	if issue.Status == types.StatusTombstone {
+		return true
+	}
+	if issue.Ephemeral {
+		return true
+	}
+	if issue.IsTemplate {
+		return true
+	}
+	if issue.Pinned {
+		return true
+	}
+	if issue.Status == types.StatusPinned {
+		return true
+	}
+	return false
+}
+
+// FindViolations checks a set of issues+labels against mutex groups.
+func FindViolations(issues []*types.Issue, labelsMap map[string][]string, groups []MutexGroup) []Violation {
+	var violations []Violation
+
+	for _, issue := range issues {
+		issueLabels := labelsMap[issue.ID]
+		labelSet := make(map[string]bool, len(issueLabels))
+		for _, l := range issueLabels {
+			labelSet[l] = true
+		}
+
+		for _, group := range groups {
+			var present []string
+			for _, gl := range group.Labels {
+				if labelSet[gl] {
+					present = append(present, gl)
+				}
+			}
+
+			if len(present) > 1 {
+				violations = append(violations, Violation{
+					IssueID:   issue.ID,
+					GroupName: group.Name,
+					Kind:      "conflict",
+					Present:   present,
+					Expected:  group.Labels,
+				})
+			}
+			if group.Required && len(present) == 0 {
+				violations = append(violations, Violation{
+					IssueID:   issue.ID,
+					GroupName: group.Name,
+					Kind:      "missing",
+					Expected:  group.Labels,
+				})
+			}
+		}
+	}
+
+	return violations
+}

--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -22,6 +22,7 @@ type Migration struct {
 var migrationsList = []Migration{
 	{"wisp_type_column", migrations.MigrateWispTypeColumn},
 	{"spec_id_column", migrations.MigrateSpecIDColumn},
+	{"label_mutex_policy", migrations.MigrateLabelMutexPolicy},
 }
 
 // RunMigrations executes all registered Dolt migrations in order.

--- a/internal/storage/dolt/migrations/003_label_mutex_policy.go
+++ b/internal/storage/dolt/migrations/003_label_mutex_policy.go
@@ -1,0 +1,87 @@
+//go:build cgo
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// MigrateLabelMutexPolicy creates tables and a trigger to enforce label mutex
+// constraints at the database level (MySQL/Dolt dialect).
+//
+// The trigger "fails open" — if the policy tables are empty, all label inserts
+// succeed. Policy is populated by `bd doctor --fix` from YAML config.
+func MigrateLabelMutexPolicy(db *sql.DB) error {
+	// --- Tables ---
+
+	exists, err := tableExists(db, "label_mutex_groups")
+	if err != nil {
+		return fmt.Errorf("failed to check label_mutex_groups: %w", err)
+	}
+	if !exists {
+		_, err = db.Exec(`
+			CREATE TABLE label_mutex_groups (
+				id       BIGINT AUTO_INCREMENT PRIMARY KEY,
+				name     VARCHAR(255) NOT NULL DEFAULT '',
+				required TINYINT(1)   NOT NULL DEFAULT 0
+			)
+		`)
+		if err != nil {
+			return fmt.Errorf("failed to create label_mutex_groups: %w", err)
+		}
+	}
+
+	exists, err = tableExists(db, "label_mutex_members")
+	if err != nil {
+		return fmt.Errorf("failed to check label_mutex_members: %w", err)
+	}
+	if !exists {
+		_, err = db.Exec(`
+			CREATE TABLE label_mutex_members (
+				group_id BIGINT       NOT NULL,
+				label    VARCHAR(255) NOT NULL,
+				PRIMARY KEY (group_id, label),
+				FOREIGN KEY (group_id) REFERENCES label_mutex_groups(id) ON DELETE CASCADE
+			)
+		`)
+		if err != nil {
+			return fmt.Errorf("failed to create label_mutex_members: %w", err)
+		}
+
+		_, err = db.Exec(`CREATE INDEX idx_label_mutex_members_label ON label_mutex_members(label)`)
+		if err != nil {
+			return fmt.Errorf("failed to create label_mutex_members index: %w", err)
+		}
+	}
+
+	// --- Trigger ---
+	// Drop-and-recreate for idempotency.
+	_, err = db.Exec(`DROP TRIGGER IF EXISTS label_mutex_enforce_insert`)
+	if err != nil {
+		return fmt.Errorf("failed to drop existing trigger: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TRIGGER label_mutex_enforce_insert
+		BEFORE INSERT ON labels
+		FOR EACH ROW
+		BEGIN
+			IF EXISTS (
+				SELECT 1
+				FROM labels l
+				JOIN label_mutex_members m1 ON m1.label = NEW.label
+				JOIN label_mutex_members m2 ON m2.group_id = m1.group_id AND m2.label = l.label
+				WHERE l.issue_id = NEW.issue_id
+				  AND l.label != NEW.label
+			) THEN
+				SIGNAL SQLSTATE '45000'
+					SET MESSAGE_TEXT = 'label mutex violation';
+			END IF;
+		END
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create label_mutex_enforce_insert trigger: %w", err)
+	}
+
+	return nil
+}

--- a/internal/storage/sqlite/migrations.go
+++ b/internal/storage/sqlite/migrations.go
@@ -60,6 +60,7 @@ var migrationsList = []Migration{
 	{"metadata_column", migrations.MigrateMetadataColumn},
 	{"wisp_type_column", migrations.MigrateWispTypeColumn},
 	{"spec_id_column", migrations.MigrateSpecIDColumn},
+	{"label_mutex_policy", migrations.MigrateLabelMutexPolicy},
 }
 
 // migrationInfo contains metadata about a migration for inspection
@@ -127,6 +128,7 @@ func getMigrationDescription(name string) string {
 		"metadata_column":            "Adds metadata column for arbitrary JSON data (tool annotations, file lists) per GH#1406",
 		"wisp_type_column":           "Adds wisp_type column for TTL-based compaction classification (gt-9br)",
 		"spec_id_column":             "Adds spec_id column for linking issues to specification documents",
+		"label_mutex_policy":         "Adds label mutex policy tables and trigger for at-most-one label enforcement",
 	}
 
 	if desc, ok := descriptions[name]; ok {

--- a/internal/storage/sqlite/migrations/044_label_mutex_policy.go
+++ b/internal/storage/sqlite/migrations/044_label_mutex_policy.go
@@ -1,0 +1,78 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// MigrateLabelMutexPolicy creates tables and a trigger to enforce label mutex
+// constraints at the database level. The trigger prevents inserting a label
+// that conflicts with another label already assigned to the same issue within
+// the same mutex group.
+//
+// The trigger "fails open" — if the policy tables are empty (no groups
+// registered), all label inserts succeed. Policy is populated by
+// `bd doctor --fix` from the YAML config (source of truth).
+func MigrateLabelMutexPolicy(db *sql.DB) error {
+	// --- Tables ---
+
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS label_mutex_groups (
+			id       INTEGER PRIMARY KEY AUTOINCREMENT,
+			name     TEXT    NOT NULL DEFAULT '',
+			required INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create label_mutex_groups: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS label_mutex_members (
+			group_id INTEGER NOT NULL,
+			label    TEXT    NOT NULL,
+			PRIMARY KEY (group_id, label),
+			FOREIGN KEY (group_id) REFERENCES label_mutex_groups(id) ON DELETE CASCADE
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create label_mutex_members: %w", err)
+	}
+
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_label_mutex_members_label ON label_mutex_members(label)`)
+	if err != nil {
+		return fmt.Errorf("failed to create label_mutex_members index: %w", err)
+	}
+
+	// --- Trigger ---
+	// Drop-and-recreate for idempotency (allows trigger logic updates on re-migration).
+	_, err = db.Exec(`DROP TRIGGER IF EXISTS label_mutex_enforce_insert`)
+	if err != nil {
+		return fmt.Errorf("failed to drop existing trigger: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TRIGGER label_mutex_enforce_insert
+		BEFORE INSERT ON labels
+		FOR EACH ROW
+		WHEN EXISTS (
+			SELECT 1 FROM label_mutex_members WHERE label = NEW.label
+		)
+		BEGIN
+			SELECT RAISE(ABORT, 'label mutex violation')
+			WHERE EXISTS (
+				SELECT 1
+				FROM labels l
+				JOIN label_mutex_members m1 ON m1.label = NEW.label
+				JOIN label_mutex_members m2 ON m2.group_id = m1.group_id AND m2.label = l.label
+				WHERE l.issue_id = NEW.issue_id
+				  AND l.label != NEW.label
+			);
+		END
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create label_mutex_enforce_insert trigger: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- **DB triggers** (SQLite + Dolt) enforce label mutex constraints at insert time — prevents conflicting labels on the same issue
- **Doctor drift check** (`Label Mutex Policy`) detects when YAML config and DB policy tables are out of sync
- **`bd doctor --fix`** syncs YAML → DB (refuses if conflicts exist), activating enforcement
- **`internal/labelmutex`** package extracts shared logic (parsing, violation detection, exclusion) to avoid import cycle between `doctor` and `doctor/fix`

Builds on #1607 (doctor audit check). Together they implement #1606.

### How it works
1. Migration creates `label_mutex_groups` + `label_mutex_members` tables and a `BEFORE INSERT` trigger on `labels`
2. Trigger "fails open" — empty policy tables = all labels allowed
3. User runs `bd doctor --fix` to populate policy from YAML config
4. After that, conflicting label inserts are rejected with `label mutex violation`

### Architecture
- `internal/labelmutex/policy.go` — shared types + logic (extracted from PR1's doctor check to avoid import cycle)
- `internal/storage/sqlite/migrations/044_label_mutex_policy.go` — tables + trigger
- `internal/storage/dolt/migrations/003_label_mutex_policy.go` — MySQL dialect
- `cmd/bd/doctor/label_mutex_policy.go` — drift check (YAML vs DB)
- `cmd/bd/doctor/fix/label_mutex.go` — fix function (YAML → DB sync)
- `cmd/bd/doctor.go` + `cmd/bd/doctor_fix.go` — wiring

## Test plan
- [x] 7 new tests: drift detection, in-sync, trigger enforcement (conflict blocked), fail-open (empty policy), non-mutex labels allowed
- [x] All 16 PR1 tests still pass after refactor to `internal/labelmutex`
- [x] Full `cmd/bd/doctor/...` test suite passes
- [x] Full `internal/storage/sqlite/` test suite passes
- [x] Zero lint issues
- [x] Clean build of entire project

🤖 Generated with [Claude Code](https://claude.com/claude-code)