### PR TITLE
feat(human): Add native 'bd human' subcommands for human bead management

### DIFF
--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/rpc"
+	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -16,7 +21,13 @@ var humanCmd = &cobra.Command{
 bd has 70+ commands - many for AI agents, integrations, and advanced workflows.
 This command shows the ~15 essential commands that human users need most often.
 
-For the full command list, run: bd --help`,
+For the full command list, run: bd --help
+
+SUBCOMMANDS:
+  human list              List all human-needed beads (issues with 'human' label)
+  human respond <id>      Respond to a human-needed bead (adds comment and closes)
+  human dismiss <id>      Dismiss a human-needed bead permanently
+  human stats             Show summary statistics for human-needed beads`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("\n%s\n", ui.RenderBold("bd - Essential Commands for Humans"))
 		fmt.Printf("For all 70+ commands: bd --help\n\n")
@@ -77,11 +88,343 @@ For the full command list, run: bd --help`,
 	},
 }
 
+// human list command
+var humanListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all human-needed beads",
+	Long: `List all issues labeled with 'human' tag.
+
+These are issues that require human intervention or input.
+
+Examples:
+  bd human list
+  bd human list --status=open
+  bd human list --json`,
+	Run: func(cmd *cobra.Command, args []string) {
+		status, _ := cmd.Flags().GetString("status")
+
+		ctx := rootCtx
+
+		// Build filter for human-labeled issues
+		filter := types.IssueFilter{
+			Labels: []string{"human"},
+		}
+
+		if status != "" {
+			s := types.Status(status)
+			filter.Status = &s
+		}
+
+		var issues []*types.Issue
+
+		// Try daemon first
+		if daemonClient != nil {
+			listArgs := &rpc.ListArgs{
+				Labels: []string{"human"},
+				Status: status,
+			}
+
+			resp, err := daemonClient.List(listArgs)
+			if err == nil && !isUnknownOperationError(err) {
+				if jsonOutput {
+					fmt.Printf("%s\n", string(resp.Data))
+				} else {
+					// Parse and format output
+					if err := json.Unmarshal(resp.Data, &issues); err == nil {
+						printHumanList(issues)
+					} else {
+						fmt.Printf("%s\n", string(resp.Data))
+					}
+				}
+				return
+			}
+		}
+
+		// Direct mode
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("listing human beads: %v", err)
+		}
+
+		var err error
+		issues, err = store.SearchIssues(ctx, "", filter)
+		if err != nil {
+			FatalErrorRespectJSON("listing human beads: %v", err)
+		}
+
+		if jsonOutput {
+			// Get labels for JSON output
+			issueIDs := make([]string, len(issues))
+			for i, issue := range issues {
+				issueIDs[i] = issue.ID
+			}
+			labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
+			for _, issue := range issues {
+				issue.Labels = labelsMap[issue.ID]
+			}
+
+			data, err := json.MarshalIndent(issues, "", "  ")
+			if err != nil {
+				FatalErrorRespectJSON("encoding JSON: %v", err)
+			}
+			fmt.Println(string(data))
+			return
+		}
+
+		printHumanList(issues)
+	},
+}
+
+func printHumanList(issues []*types.Issue) {
+	if len(issues) == 0 {
+		fmt.Println("No human-needed beads found.")
+		return
+	}
+
+	fmt.Printf("\n%s (%d found)\n\n", ui.RenderBold("Human-needed beads"), len(issues))
+	for _, issue := range issues {
+		fmt.Printf("  %s %s\n", ui.RenderCommand(issue.ID), issue.Title)
+		if issue.Status != "open" {
+			fmt.Printf("    Status: %s\n", issue.Status)
+		}
+		if issue.Priority != 0 {
+			fmt.Printf("    Priority: P%d\n", issue.Priority)
+		}
+		fmt.Println()
+	}
+}
+
+// human respond command
+var humanRespondCmd = &cobra.Command{
+	Use:   "respond <issue-id>",
+	Short: "Respond to a human-needed bead",
+	Long: `Respond to a human-needed bead by adding a comment and closing it.
+
+The response is added as a comment and the issue is closed with reason "Responded".
+
+Examples:
+  bd human respond bd-123 --response "Use OAuth2 for authentication"
+  bd human respond bd-123 -r "Approved, proceed with implementation"`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		response, _ := cmd.Flags().GetString("response")
+
+		if response == "" {
+			FatalErrorRespectJSON("--response is required")
+		}
+
+		CheckReadonly("human respond")
+
+		ctx := rootCtx
+		issueID := args[0]
+
+		// Resolve partial ID and get issue
+		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
+		if err != nil {
+			FatalErrorRespectJSON("resolving issue ID %s: %v", issueID, err)
+		}
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue not found: %s", issueID)
+		}
+		defer result.Close()
+
+		resolvedID := result.ResolvedID
+		issue := result.Issue
+		targetStore := result.Store
+
+		// Check if issue has 'human' label
+		hasHumanLabel := false
+		for _, label := range issue.Labels {
+			if label == "human" {
+				hasHumanLabel = true
+				break
+			}
+		}
+
+		if !hasHumanLabel {
+			fmt.Fprintf(os.Stderr, "Warning: Issue %s does not have 'human' label\n", resolvedID)
+		}
+
+		// Add comment using AddIssueComment (issueID, author, text)
+		commentText := fmt.Sprintf("Response: %s", response)
+		_, err = targetStore.AddIssueComment(ctx, resolvedID, actor, commentText)
+		if err != nil {
+			FatalErrorRespectJSON("adding comment: %v", err)
+		}
+
+		// Close the issue using CloseIssue (id, reason, actor, session)
+		if err := targetStore.CloseIssue(ctx, resolvedID, "Responded", actor, ""); err != nil {
+			FatalErrorRespectJSON("closing bead: %v", err)
+		}
+
+		fmt.Printf("%s Bead %s closed with response.\n", ui.RenderPass("✔"), resolvedID)
+	},
+}
+
+// human dismiss command
+var humanDismissCmd = &cobra.Command{
+	Use:   "dismiss <issue-id>",
+	Short: "Dismiss a human-needed bead",
+	Long: `Dismiss a human-needed bead permanently without responding.
+
+The issue is closed with a "Dismissed" reason and optional note.
+
+Examples:
+  bd human dismiss bd-123
+  bd human dismiss bd-123 --reason "No longer applicable"`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		reason, _ := cmd.Flags().GetString("reason")
+
+		CheckReadonly("human dismiss")
+
+		ctx := rootCtx
+		issueID := args[0]
+
+		// Resolve partial ID and get issue
+		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
+		if err != nil {
+			FatalErrorRespectJSON("resolving issue ID %s: %v", issueID, err)
+		}
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue not found: %s", issueID)
+		}
+		defer result.Close()
+
+		resolvedID := result.ResolvedID
+		issue := result.Issue
+		targetStore := result.Store
+
+		// Check if issue has 'human' label
+		hasHumanLabel := false
+		for _, label := range issue.Labels {
+			if label == "human" {
+				hasHumanLabel = true
+				break
+			}
+		}
+
+		if !hasHumanLabel {
+			fmt.Fprintf(os.Stderr, "Warning: Issue %s does not have 'human' label\n", resolvedID)
+		}
+
+		// Build close reason
+		closeReason := "Dismissed"
+		if reason != "" {
+			closeReason = fmt.Sprintf("Dismissed: %s", reason)
+		}
+
+		// Close the issue
+		if err := targetStore.CloseIssue(ctx, resolvedID, closeReason, actor, ""); err != nil {
+			FatalErrorRespectJSON("closing bead: %v", err)
+		}
+
+		fmt.Printf("%s Bead %s dismissed.\n", ui.RenderPass("✔"), resolvedID)
+	},
+}
+
+// human stats command
+var humanStatsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show summary statistics for human-needed beads",
+	Long: `Display summary statistics for human-needed beads.
+
+Shows counts for total, pending (open), responded (closed without dismiss),
+and dismissed beads.
+
+Example:
+  bd human stats`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := rootCtx
+
+		filter := types.IssueFilter{
+			Labels: []string{"human"},
+		}
+
+		var issues []*types.Issue
+
+		// Try daemon first
+		if daemonClient != nil {
+			listArgs := &rpc.ListArgs{
+				Labels: []string{"human"},
+			}
+
+			resp, err := daemonClient.List(listArgs)
+			if err == nil && !isUnknownOperationError(err) {
+				if err := json.Unmarshal(resp.Data, &issues); err == nil {
+					printHumanStats(issues)
+					return
+				}
+			}
+		}
+
+		// Direct mode
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("getting human bead stats: %v", err)
+		}
+
+		var err error
+		issues, err = store.SearchIssues(ctx, "", filter)
+		if err != nil {
+			FatalErrorRespectJSON("getting human bead stats: %v", err)
+		}
+
+		printHumanStats(issues)
+	},
+}
+
+func printHumanStats(issues []*types.Issue) {
+	total := len(issues)
+	open := 0
+	closed := 0
+	dismissed := 0
+
+	for _, issue := range issues {
+		if issue.Status == "open" {
+			open++
+		} else if issue.Status == "closed" {
+			closed++
+			// Check if dismissed by looking at close_reason
+			if strings.Contains(strings.ToLower(issue.CloseReason), "dismiss") {
+				dismissed++
+			}
+		}
+	}
+
+	responded := closed - dismissed
+
+	fmt.Printf("\n%s\n", ui.RenderBold("Human Beads Stats"))
+	fmt.Println()
+	fmt.Printf("  Total:      %d\n", total)
+	fmt.Printf("  Pending:    %d\n", open)
+	fmt.Printf("  Responded:  %d\n", responded)
+	fmt.Printf("  Dismissed:  %d\n", dismissed)
+	fmt.Println()
+}
+
 // printCmd prints a command with consistent formatting
 func printCmd(cmd, description string) {
 	fmt.Printf("  %-20s %s\n", ui.RenderCommand(cmd), description)
 }
 
 func init() {
+	// Add subcommands to humanCmd
+	humanCmd.AddCommand(humanListCmd)
+	humanCmd.AddCommand(humanRespondCmd)
+	humanCmd.AddCommand(humanDismissCmd)
+	humanCmd.AddCommand(humanStatsCmd)
+
+	// Add flags for subcommands
+	humanListCmd.Flags().StringP("status", "s", "", "Filter by status (open, closed, etc.)")
+	humanRespondCmd.Flags().StringP("response", "r", "", "Response text (required)")
+	humanRespondCmd.MarkFlagRequired("response")
+	humanDismissCmd.Flags().StringP("reason", "", "", "Reason for dismissal (optional)")
+
+	// Register with root command
 	rootCmd.AddCommand(humanCmd)
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive subcommands to the `bd human` command for managing human-needed beads (issues labeled with 'human' tag).

## New Subcommands

- `bd human list [--status STATUS] [--json]` - List all human-needed beads
- `bd human respond <id> --response TEXT` - Respond to a human bead (adds comment and closes)
- `bd human dismiss <id> [--reason REASON]` - Dismiss a human bead permanently  
- `bd human stats` - Show summary statistics for human beads

## Implementation Details

- All commands support both daemon and direct mode
- JSON output support for list command (useful for scripting)
- Proper label validation (warns if issue lacks 'human' label)
- Graceful handling of partial issue IDs via existing routing infrastructure
- Statistics distinguish between "responded" and "dismissed" closures

## Use Cases

These commands enable:
- Humans to quickly see what needs their attention
- Workers to submit human intervention requests
- Clean workflow for responding to or dismissing human beads
- Tracking of human bead metrics

## Example Usage

```bash
# List all human-needed beads
bd human list

# List only open human beads
bd human list --status open

# List as JSON for scripting
bd human list --json

# Respond to a human bead
bd human respond bd-123 --response "Use OAuth2 for authentication"

# Dismiss a human bead with reason
bd human dismiss bd-456 --reason "No longer applicable"

# Show statistics
bd human stats
```

## Related

This addresses bead bd-4dku (Option 1: Direct Integration - Submit PR to br/beads project)

🤖 Generated with Claude Code
Co-Authored-By: Claude Worker <noreply@anthropic.com>