### PR TITLE
Make bd init cancelable

### DIFF
--- a/cmd/bd/init_cancel_e2e_test.go
+++ b/cmd/bd/init_cancel_e2e_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+// +build integration
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestInitCancel_E2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping SIGINT E2E test on Windows")
+	}
+
+	tmpDir := createTempDirWithCleanup(t)
+	runGitCmd(t, tmpDir, "init", "-b", "main")
+
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinW.Close() }()
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	defer func() { _ = stdoutR.Close() }()
+
+	cmd := exec.Command(testBD, "init", "--prefix", "test", "--contributor")
+	cmd.Dir = tmpDir
+	cmd.Stdin = stdinR
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stdoutW
+	cmd.Env = append(filteredEnv("BEADS_DB", "BEADS_DIR", "BEADS_NO_DAEMON", "HOME", "XDG_CONFIG_HOME"),
+		"BEADS_DB=",
+		"BEADS_NO_DAEMON=1",
+		"HOME="+tmpDir,
+		"XDG_CONFIG_HOME="+filepath.Join(tmpDir, "xdg-config"),
+	)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start bd init: %v", err)
+	}
+
+	_ = stdinR.Close()
+	_ = stdoutW.Close()
+
+	prompts := [][]byte{
+		[]byte("Continue with contributor setup? [y/N]: "),
+		[]byte("Continue anyway? [y/N]: "),
+	}
+	promptSeen := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	var output bytes.Buffer
+	var outputMu sync.Mutex
+	var promptOnce sync.Once
+
+	go func() {
+		defer close(readerDone)
+		buf := make([]byte, 1024)
+		for {
+			n, err := stdoutR.Read(buf)
+			if n > 0 {
+				outputMu.Lock()
+				output.Write(buf[:n])
+				for _, prompt := range prompts {
+					if bytes.Contains(output.Bytes(), prompt) {
+						promptOnce.Do(func() { close(promptSeen) })
+						break
+					}
+				}
+				outputMu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	getOutput := func() string {
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		return output.String()
+	}
+
+	select {
+	case <-promptSeen:
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
+			t.Fatalf("failed to send SIGINT: %v", err)
+		}
+	case err := <-waitCh:
+		t.Fatalf("bd init exited before prompt: %v\nOutput: %s", err, getOutput())
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		err := <-waitCh
+		t.Fatalf("timeout waiting for prompt (exit=%v)\nOutput: %s", err, getOutput())
+	}
+
+	err = <-waitCh
+
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+		t.Log("timeout waiting for output drain")
+	}
+
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got success\nOutput: %s", getOutput())
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("unexpected error type: %v\nOutput: %s", err, getOutput())
+	}
+	if exitErr.ExitCode() != exitCodeCanceled {
+		t.Fatalf("expected exit code %d, got %d\nOutput: %s", exitCodeCanceled, exitErr.ExitCode(), getOutput())
+	}
+	if !strings.Contains(getOutput(), "Setup canceled.") {
+		t.Fatalf("expected cancel message, got:\n%s", getOutput())
+	}
+}
+
+func filteredEnv(keys ...string) []string {
+	strip := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		strip[key+"="] = struct{}{}
+	}
+
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		trim := false
+		for prefix := range strip {
+			if strings.HasPrefix(entry, prefix) {
+				trim = true
+				break
+			}
+		}
+		if !trim {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}

--- a/cmd/bd/init_contributor.go
+++ b/cmd/bd/init_contributor.go
@@ -33,7 +33,7 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 		fmt.Println("  you likely don't need --contributor.")
 		fmt.Println()
 		fmt.Print("Continue anyway? [y/N]: ")
-		response, err := readLineWithContext(ctx, reader)
+		response, err := readLineWithContext(ctx, reader, os.Stdin)
 		if err != nil {
 			if isCanceled(err) {
 				return err
@@ -64,7 +64,7 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 
 		// Ask if they want to continue anyway
 		fmt.Print("Continue with contributor setup? [y/N]: ")
-		response, err := readLineWithContext(ctx, reader)
+		response, err := readLineWithContext(ctx, reader, os.Stdin)
 		if err != nil {
 			if isCanceled(err) {
 				return err
@@ -89,7 +89,7 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 		fmt.Printf("  %s You can commit directly to this repository.\n", ui.RenderWarn("⚠"))
 		fmt.Println()
 		fmt.Print("Do you want to use a separate planning repo anyway? [Y/n]: ")
-		response, err := readLineWithContext(ctx, reader)
+		response, err := readLineWithContext(ctx, reader, os.Stdin)
 		if err != nil {
 			if isCanceled(err) {
 				return err
@@ -126,7 +126,7 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Printf("Default: %s\n", ui.RenderAccent(defaultPlanningRepo))
 	fmt.Print("Planning repo path [press Enter for default]: ")
 
-	planningPath, err := readLineWithContext(ctx, reader)
+	planningPath, err := readLineWithContext(ctx, reader, os.Stdin)
 	if err != nil {
 		if isCanceled(err) {
 			return err

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -200,7 +200,7 @@ func promptForkExclude(upstreamURL string, quiet bool) (bool, error) {
 	fmt.Print("\n[Y/n]: ")
 
 	reader := bufio.NewReader(os.Stdin)
-	response, err := readLineWithContext(getRootContext(), reader)
+	response, err := readLineWithContext(getRootContext(), reader, os.Stdin)
 	if err != nil {
 		if isCanceled(err) {
 			return false, err

--- a/cmd/bd/init_team.go
+++ b/cmd/bd/init_team.go
@@ -52,7 +52,7 @@ func runTeamWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Println("  GitLab: Settings → Repository → Protected branches")
 	fmt.Print("\nProtected main branch? [y/N]: ")
 
-	response, err := readLineWithContext(ctx, reader)
+	response, err := readLineWithContext(ctx, reader, os.Stdin)
 	if err != nil {
 		if isCanceled(err) {
 			return err
@@ -71,7 +71,7 @@ func runTeamWizard(ctx context.Context, store storage.Storage) error {
 		fmt.Printf("  Default sync branch: %s\n", ui.RenderAccent("beads-metadata"))
 		fmt.Print("\n  Sync branch name [press Enter for default]: ")
 
-		branchName, err := readLineWithContext(ctx, reader)
+		branchName, err := readLineWithContext(ctx, reader, os.Stdin)
 		if err != nil {
 			if isCanceled(err) {
 				return err
@@ -129,7 +129,7 @@ func runTeamWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Println("  • Auto-push: Pushes commits to remote")
 	fmt.Print("\nEnable auto-sync? [Y/n]: ")
 
-	response, err = readLineWithContext(ctx, reader)
+	response, err = readLineWithContext(ctx, reader, os.Stdin)
 	if err != nil {
 		if isCanceled(err) {
 			return err

--- a/cmd/bd/prompt_test.go
+++ b/cmd/bd/prompt_test.go
@@ -40,7 +40,7 @@ func TestReadLineWithContextReadsLine(t *testing.T) {
 	stub := installNotifyStub(t)
 
 	reader := bufio.NewReader(strings.NewReader("yes\n"))
-	line, err := readLineWithContext(context.Background(), reader)
+	line, err := readLineWithContext(context.Background(), reader, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestReadLineWithContextCanceled(t *testing.T) {
 	reader := bufio.NewReader(pr)
 	done := make(chan error, 1)
 	go func() {
-		_, err := readLineWithContext(context.Background(), reader)
+		_, err := readLineWithContext(context.Background(), reader, pr)
 		done <- err
 	}()
 


### PR DESCRIPTION
## Summary
- make init prompts cancelable with SIGINT-aware reads and exit code 130
- propagate cancellation handling through contributor/team/fork prompts
- add E2E test for SIGINT cancel during init

## Testing
- `CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c/lib" go test ./cmd/bd -run TestReadLineWithContext -count=1`
- `PATH="/usr/bin:/bin:/opt/homebrew/bin" CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c/lib" go test -tags=integration ./cmd/bd -run TestInitCancel_E2E -count=1`

Co-authored-by: Codex <codex@openai.com>
