### PR TITLE
feat: bd setup claude --with-sync and --with-status-check

### DIFF
--- a/cmd/bd/setup.go
+++ b/cmd/bd/setup.go
@@ -13,14 +13,16 @@ import (
 )
 
 var (
-	setupProject bool
-	setupCheck   bool
-	setupRemove  bool
-	setupStealth bool
-	setupPrint   bool
-	setupOutput  string
-	setupList    bool
-	setupAdd     string
+	setupProject         bool
+	setupCheck           bool
+	setupRemove          bool
+	setupStealth         bool
+	setupPrint           bool
+	setupOutput          string
+	setupList            bool
+	setupAdd             string
+	setupWithSync        bool
+	setupWithStatusCheck bool
 )
 
 var setupCmd = &cobra.Command{
@@ -263,7 +265,7 @@ func runClaudeRecipe() {
 		setup.RemoveClaude(setupProject)
 		return
 	}
-	setup.InstallClaude(setupProject, setupStealth)
+	setup.InstallClaude(setupProject, setupStealth, setupWithSync, setupWithStatusCheck)
 }
 
 func runGeminiRecipe() {
@@ -351,6 +353,8 @@ func init() {
 	setupCmd.Flags().BoolVar(&setupRemove, "remove", false, "Remove the integration")
 	setupCmd.Flags().BoolVar(&setupProject, "project", false, "Install for this project only (claude/gemini)")
 	setupCmd.Flags().BoolVar(&setupStealth, "stealth", false, "Use stealth mode (claude/gemini)")
+	setupCmd.Flags().BoolVar(&setupWithSync, "with-sync", false, "Add 'bd sync' before 'bd prime' in hooks (claude)")
+	setupCmd.Flags().BoolVar(&setupWithStatusCheck, "with-status-check", false, "Add 'bd sync --status' before 'bd prime' in hooks (claude)")
 
 	rootCmd.AddCommand(setupCmd)
 }

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -93,6 +93,12 @@ bd setup claude --project
 # Use stealth mode (flush only, no git operations)
 bd setup claude --stealth
 
+# Run bd sync --status before bd prime on each session start
+bd setup claude --with-status-check
+
+# Run bd sync before bd prime on each session start
+bd setup claude --with-sync
+
 # Check installation status
 bd setup claude --check
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -910,9 +910,11 @@ bd setup aider --remove
 
 **Claude Code options:**
 ```bash
-bd setup claude              # Install globally (~/.claude/settings.json)
-bd setup claude --project    # Install for this project only
-bd setup claude --stealth    # Use stealth mode (flush only, no git operations)
+bd setup claude                        # Install globally (~/.claude/settings.json)
+bd setup claude --project              # Install for this project only
+bd setup claude --stealth              # Use stealth mode (flush only, no git operations)
+bd setup claude --with-status-check    # Run bd sync --status before bd prime
+bd setup claude --with-sync            # Run bd sync before bd prime
 ```
 
 **What each setup does:**

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -174,6 +174,12 @@ bd setup claude --project
 
 # With stealth mode (flush only, no git operations)
 bd setup claude --stealth
+
+# Run bd sync --status before bd prime on each session start
+bd setup claude --with-status-check
+
+# Run bd sync before bd prime on each session start
+bd setup claude --with-sync
 ```
 
 ### What Gets Installed
@@ -193,6 +199,8 @@ bd setup claude --stealth
 | `--remove` | Remove beads hooks |
 | `--project` | Install for this project only (not globally) |
 | `--stealth` | Use `bd prime --stealth` (flush only, no git operations) |
+| `--with-status-check` | Run `bd sync --status` before `bd prime` in hooks |
+| `--with-sync` | Run `bd sync` before `bd prime` in hooks |
 
 ### Examples
 


### PR DESCRIPTION
## Problem

When the beads daemon dies silently, `bd prime` (which runs on every Claude Code session start via hooks) has no way to detect or warn about stale sync state. Users can work for hours on outdated data without realizing their daemon stopped syncing.

The first step toward fixing this is giving `bd setup claude` the ability to install hooks that run `bd sync` or `bd sync --status` before `bd prime`, so the sync state is checked or refreshed at every session start.

Closes #1638

## Changes

Adds two new flags to `bd setup claude`:

- **`--with-sync`**: Hook command becomes `bd sync && bd prime` — does a full sync before priming context
- **`--with-status-check`**: Hook command becomes `bd sync --status && bd prime` — prints sync status (stale, dirty, conflicts) before priming, without actually syncing

Both compose with existing `--stealth` flag. `--with-sync` takes precedence if both are specified.

The `&&` chaining is safe because `bd sync --status` exits 0 for all informational output (stale, dirty issues, conflicts) and only exits non-zero when the database can't open — so `bd prime` always runs unless something is fundamentally broken.

### Implementation details

- `knownBeadsCommands` is a single allowlist of all 6 possible hook command strings (2 base × 3 sync modes), used consistently for detection (`hasBeadsHooks`), removal (`removeClaude`), and tests
- `buildHookCommand()` constructs the correct command string from flag combinations
- `bd setup claude --remove` now cleans up all variants, not just the original two
- Docs updated in `CLAUDE_INTEGRATION.md`, `CLI_REFERENCE.md`, `SETUP.md`

## Test plan

- `TestBuildHookCommand` — all 7 flag combinations including precedence
- `TestInstallClaudeWithSync`, `TestInstallClaudeWithStatusCheck`, `TestInstallClaudeWithSyncStealth` — verify correct commands written to settings JSON
- `TestHasBeadsHooksSyncVariants` — all 6 known commands detected
- `TestRemoveClaudeAllVariants` — install with sync, verify remove cleans everything up
- `TestIdempotencyWithSync` — no duplicate hooks on repeated install
- Existing tests updated for new signatures, all passing
- `go test -race` and `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)