### PR TITLE
feat: bd prime warns when daemon sync may be stale

### DIFF
--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/rpc"
 )
 
 func TestOutputContextFunction(t *testing.T) {
@@ -129,7 +132,7 @@ func TestOutputContextFunction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer stubIsEphemeralBranch(tt.ephemeralMode)()
-			defer stubIsDaemonAutoSyncing(false)()           // Default: no auto-sync in tests
+			defer stubPrimeDaemonStatus(nil)()                // Default: no daemon in tests
 			defer stubPrimeHasGitRemote(!tt.localOnlyMode)() // localOnly = !primeHasGitRemote
 
 			var buf bytes.Buffer
@@ -172,15 +175,15 @@ func stubIsEphemeralBranch(isEphem bool) func() {
 	}
 }
 
-// stubIsDaemonAutoSyncing temporarily replaces isDaemonAutoSyncing
-// with a stub returning returnValue.
-func stubIsDaemonAutoSyncing(isAutoSync bool) func() {
-	original := isDaemonAutoSyncing
-	isDaemonAutoSyncing = func() bool {
-		return isAutoSync
+// stubPrimeDaemonStatus temporarily replaces primeDaemonStatus
+// with a stub returning the given status.
+func stubPrimeDaemonStatus(status *rpc.StatusResponse) func() {
+	original := primeDaemonStatus
+	primeDaemonStatus = func() *rpc.StatusResponse {
+		return status
 	}
 	return func() {
-		isDaemonAutoSyncing = original
+		primeDaemonStatus = original
 	}
 }
 
@@ -198,5 +201,192 @@ func stubPrimeHasGitRemote(hasRemote bool) func() {
 	}
 	return func() {
 		primeHasGitRemote = original
+	}
+}
+
+func TestOutputContextStalenessWarning(t *testing.T) {
+	tests := []struct {
+		name       string
+		mcpMode    bool
+		status     *rpc.StatusResponse
+		expectText []string
+		rejectText []string
+	}{
+		{
+			name:       "nil status shows daemon not running warning (CLI)",
+			mcpMode:    false,
+			status:     nil,
+			expectText: []string{"Sync freshness unknown"},
+		},
+		{
+			name:       "nil status shows daemon not running warning (MCP)",
+			mcpMode:    true,
+			status:     nil,
+			expectText: []string{"Sync freshness unknown"},
+		},
+		{
+			name:    "stale daemon shows warning",
+			mcpMode: false,
+			status: &rpc.StatusResponse{
+				AutoCommit:       true,
+				AutoPush:         true,
+				LastActivityTime: time.Now().Add(-3 * time.Hour).Format(time.RFC3339),
+			},
+			expectText: []string{"Sync may be stale"},
+		},
+		{
+			name:    "fresh daemon no warning",
+			mcpMode: false,
+			status: &rpc.StatusResponse{
+				AutoCommit:       true,
+				AutoPush:         true,
+				LastActivityTime: time.Now().Add(-5 * time.Minute).Format(time.RFC3339),
+			},
+			rejectText: []string{"Sync may be stale", "Sync freshness unknown"},
+		},
+		{
+			name:    "daemon not auto-syncing no warning",
+			mcpMode: false,
+			status: &rpc.StatusResponse{
+				AutoCommit:       false,
+				AutoPush:         false,
+				LastActivityTime: time.Now().Add(-3 * time.Hour).Format(time.RFC3339),
+			},
+			rejectText: []string{"Sync may be stale"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer stubIsEphemeralBranch(false)()
+			defer stubPrimeDaemonStatus(tt.status)()
+			defer stubPrimeHasGitRemote(true)()
+
+			var buf bytes.Buffer
+			err := outputPrimeContext(&buf, tt.mcpMode, false)
+			if err != nil {
+				t.Fatalf("outputPrimeContext failed: %v", err)
+			}
+
+			output := buf.String()
+
+			for _, expected := range tt.expectText {
+				if !strings.Contains(output, expected) {
+					t.Errorf("Expected text not found: %q\nOutput:\n%s", expected, output)
+				}
+			}
+
+			for _, rejected := range tt.rejectText {
+				if strings.Contains(output, rejected) {
+					t.Errorf("Unexpected text found: %q", rejected)
+				}
+			}
+		})
+	}
+}
+
+func TestOutputContextStalenessSkippedInStealth(t *testing.T) {
+	defer stubIsEphemeralBranch(false)()
+	defer stubPrimeDaemonStatus(nil)() // nil would normally trigger warning
+	defer stubPrimeHasGitRemote(true)()
+
+	var buf bytes.Buffer
+	err := outputPrimeContext(&buf, false, true) // stealth=true
+	if err != nil {
+		t.Fatalf("outputPrimeContext failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "Sync freshness unknown") {
+		t.Error("Staleness warning should not appear in stealth mode")
+	}
+}
+
+func TestOutputContextStalenessSkippedInLocalOnly(t *testing.T) {
+	defer stubIsEphemeralBranch(false)()
+	defer stubPrimeDaemonStatus(nil)() // nil would normally trigger warning
+	defer stubPrimeHasGitRemote(false)() // local-only
+
+	var buf bytes.Buffer
+	err := outputPrimeContext(&buf, false, false)
+	if err != nil {
+		t.Fatalf("outputPrimeContext failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "Sync freshness unknown") {
+		t.Error("Staleness warning should not appear in local-only mode")
+	}
+}
+
+func TestCheckSyncStaleness(t *testing.T) {
+	tests := []struct {
+		name   string
+		status *rpc.StatusResponse
+		want   string
+	}{
+		{
+			name:   "nil status",
+			status: nil,
+			want:   "Sync freshness unknown",
+		},
+		{
+			name: "not auto-syncing",
+			status: &rpc.StatusResponse{
+				AutoCommit: false,
+				AutoPush:   false,
+			},
+			want: "",
+		},
+		{
+			name: "empty activity time",
+			status: &rpc.StatusResponse{
+				AutoCommit: true,
+				AutoPush:   true,
+			},
+			want: "",
+		},
+		{
+			name: "recent activity",
+			status: &rpc.StatusResponse{
+				AutoCommit:       true,
+				AutoPush:         true,
+				LastActivityTime: time.Now().Add(-10 * time.Minute).Format(time.RFC3339),
+			},
+			want: "",
+		},
+		{
+			name: "stale activity",
+			status: &rpc.StatusResponse{
+				AutoCommit:       true,
+				AutoPush:         true,
+				LastActivityTime: time.Now().Add(-2 * time.Hour).Format(time.RFC3339),
+			},
+			want: "Sync may be stale",
+		},
+		{
+			name: "invalid time format",
+			status: &rpc.StatusResponse{
+				AutoCommit:       true,
+				AutoPush:         true,
+				LastActivityTime: "not-a-time",
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkSyncStaleness(tt.status)
+			if tt.want == "" {
+				if got != "" {
+					t.Errorf("checkSyncStaleness() = %q, want empty", got)
+				}
+			} else {
+				if !strings.Contains(got, tt.want) {
+					t.Errorf("checkSyncStaleness() = %q, want to contain %q", got, tt.want)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

When the beads daemon dies silently or hasn't synced recently, `bd prime` (which runs on every Claude Code session start) gives no indication that the agent may be working with stale data. The agent proceeds with full confidence while issues could be hours out of date.

Closes #1637

## Changes

Adds advisory markdown warnings to `bd prime` output when sync freshness is questionable:

- **Daemon not running/unreachable** → `> ⚠ **Sync freshness unknown** (daemon not running). Run bd sync --status to check.`
- **Daemon running but last activity >1 hour ago** → `> ⚠ **Sync may be stale** — daemon last active Xh Ym ago. Run bd sync --status to check.`
- **No warning** when daemon is fresh, when auto-sync is disabled (user's choice), or in stealth/local-only mode

The warning appears in both CLI and MCP output modes, placed between the header and SESSION CLOSE PROTOCOL so it's visible early.

### Implementation

- Replaces `isDaemonAutoSyncing` (returned `bool`) with `primeDaemonStatus` (returns `*rpc.StatusResponse`) — single RPC call shared for both auto-sync detection and staleness checking
- New `checkSyncStaleness()` function with fail-safe behavior (returns "" on any error)
- No DB access — prime stays fast (milliseconds, RPC only)
- 1-hour threshold (conservative, avoids false positives from short breaks)
- Dolt-native safe: warning only mentions daemon activity and suggests `bd sync --status` (which is mode-aware)

## Test plan

- `TestOutputContextStalenessWarning` — 5 cases: nil status CLI/MCP, stale daemon, fresh daemon, not-auto-syncing
- `TestOutputContextStalenessSkippedInStealth` — nil status doesn't warn in stealth
- `TestOutputContextStalenessSkippedInLocalOnly` — nil status doesn't warn without git remote
- `TestCheckSyncStaleness` — 6 unit cases: nil, not-auto-syncing, empty time, recent, stale, invalid format
- All existing `TestOutputContextFunction` cases pass (updated stubs)
- `go test -race` and `golangci-lint` clean (3 pre-existing issues in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)