### PR TITLE
Add runtime health checks to bd doctor (daemon freshness, sync state)

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -497,6 +497,16 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, hydratedRepoDaemonsCheck)
 	// Note: Don't set OverallOK = false for this - it's a performance/freshness hint
 
+	// Check 8j: Daemon freshness (warn if daemon hasn't processed requests recently)
+	daemonFreshnessCheck := convertWithCategory(doctor.CheckDaemonFreshness(path), doctor.CategoryRuntime)
+	result.Checks = append(result.Checks, daemonFreshnessCheck)
+	// Note: Don't set OverallOK = false for this - it's advisory
+
+	// Check 8k: Sync freshness (JSONL uncommitted, conflict markers - no SQLite)
+	syncFreshnessCheck := convertWithCategory(doctor.CheckSyncFreshness(path), doctor.CategoryRuntime)
+	result.Checks = append(result.Checks, syncFreshnessCheck)
+	// Note: Don't set OverallOK = false for this - it's advisory
+
 	// Check 9: Database-JSONL sync
 	syncCheck := convertWithCategory(doctor.CheckDatabaseJSONLSync(path), doctor.CategoryData)
 	result.Checks = append(result.Checks, syncCheck)

--- a/cmd/bd/doctor/sync_freshness.go
+++ b/cmd/bd/doctor/sync_freshness.go
@@ -1,0 +1,109 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// CheckSyncFreshness checks for signs of stale or problematic sync state
+// using only git and file-based signals (no SQLite access).
+func CheckSyncFreshness(path string) DoctorCheck {
+	// Skip for dolt-native mode (JSONL checks don't apply)
+	if config.GetSyncMode() == config.SyncModeDoltNative {
+		return DoctorCheck{
+			Name:    "Sync Freshness",
+			Status:  StatusOK,
+			Message: "N/A (dolt-native mode)",
+		}
+	}
+
+	beadsDir := filepath.Join(path, ".beads")
+
+	var warnings []string
+
+	if w := checkJSONLUncommitted(path, beadsDir); w != "" {
+		warnings = append(warnings, w)
+	}
+	if w := checkSyncConflicts(beadsDir); w != "" {
+		warnings = append(warnings, w)
+	}
+
+	if len(warnings) == 0 {
+		return DoctorCheck{
+			Name:    "Sync Freshness",
+			Status:  StatusOK,
+			Message: "No sync freshness issues detected",
+		}
+	}
+
+	return DoctorCheck{
+		Name:    "Sync Freshness",
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("Sync freshness: %d issue(s) detected", len(warnings)),
+		Detail:  strings.Join(warnings, "; "),
+		Fix:     "Run 'bd sync --status' to check full sync state",
+	}
+}
+
+// checkJSONLUncommitted checks if the JSONL file has uncommitted changes in git.
+func checkJSONLUncommitted(repoPath, beadsDir string) string {
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if _, err := os.Stat(jsonlPath); os.IsNotExist(err) {
+		return "" // no JSONL file, nothing to check
+	}
+
+	// Use relative path for git status
+	relPath, err := filepath.Rel(repoPath, jsonlPath)
+	if err != nil {
+		return "" // fail-safe
+	}
+
+	cmd := exec.Command("git", "status", "--porcelain", "--", relPath) // #nosec G204 -- relPath derived from validated paths
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		return "" // fail-safe (not in a git repo, etc.)
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed != "" {
+		return "JSONL file has uncommitted changes"
+	}
+	return ""
+}
+
+// checkSyncConflicts checks if sync_conflicts.json exists and has entries.
+func checkSyncConflicts(beadsDir string) string {
+	conflictPath := filepath.Join(beadsDir, "sync_conflicts.json")
+	data, err := os.ReadFile(conflictPath) // #nosec G304 -- path constructed from known beadsDir
+	if err != nil {
+		return "" // no conflict file
+	}
+
+	// Try to parse as array or object with conflicts
+	var conflicts []any
+	if err := json.Unmarshal(data, &conflicts); err == nil {
+		if len(conflicts) > 0 {
+			return fmt.Sprintf("%d unresolved sync conflict(s)", len(conflicts))
+		}
+		return ""
+	}
+
+	// Try as object with "conflicts" key
+	var wrapper struct {
+		Conflicts []any `json:"conflicts"`
+	}
+	if err := json.Unmarshal(data, &wrapper); err == nil {
+		if len(wrapper.Conflicts) > 0 {
+			return fmt.Sprintf("%d unresolved sync conflict(s)", len(wrapper.Conflicts))
+		}
+	}
+
+	return ""
+}

--- a/cmd/bd/doctor/sync_freshness_test.go
+++ b/cmd/bd/doctor/sync_freshness_test.go
@@ -1,0 +1,277 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckSyncFreshness_DoltNative(t *testing.T) {
+	// When sync mode is dolt-native, should return N/A
+	// This test requires config.GetSyncMode() to return dolt-native,
+	// which depends on Viper config. We test the non-dolt path instead.
+	// See TestCheckSyncFreshness_NoIssues for the default path.
+}
+
+func TestCheckSyncFreshness_NoIssues(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckSyncFreshness(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q", check.Status, StatusOK)
+	}
+	if check.Name != "Sync Freshness" {
+		t.Errorf("Name = %q, want %q", check.Name, "Sync Freshness")
+	}
+}
+
+func TestCheckJSONLUncommitted(t *testing.T) {
+	t.Run("no JSONL file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.Mkdir(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		result := checkJSONLUncommitted(tmpDir, beadsDir)
+		if result != "" {
+			t.Errorf("Expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("JSONL uncommitted in git", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Init git repo
+		cmd := exec.Command("git", "init", "--initial-branch=main")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git init failed: %v", err)
+		}
+
+		// Configure git user for commits
+		for _, args := range [][]string{
+			{"config", "user.email", "test@test.com"},
+			{"config", "user.name", "Test User"},
+		} {
+			cmd = exec.Command("git", args...)
+			cmd.Dir = tmpDir
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("git config failed: %v", err)
+			}
+		}
+
+		// Create .beads dir and JSONL file
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.Mkdir(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(`{"id":"test-1"}`+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Stage but don't commit — file is uncommitted
+		result := checkJSONLUncommitted(tmpDir, beadsDir)
+		if result != "JSONL file has uncommitted changes" {
+			t.Errorf("Expected uncommitted warning, got %q", result)
+		}
+	})
+
+	t.Run("JSONL committed and clean", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Init git repo
+		cmd := exec.Command("git", "init", "--initial-branch=main")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git init failed: %v", err)
+		}
+
+		// Configure git user
+		for _, args := range [][]string{
+			{"config", "user.email", "test@test.com"},
+			{"config", "user.name", "Test User"},
+		} {
+			cmd = exec.Command("git", args...)
+			cmd.Dir = tmpDir
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("git config failed: %v", err)
+			}
+		}
+
+		// Create .beads dir and JSONL file
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.Mkdir(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(`{"id":"test-1"}`+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Commit the file
+		cmd = exec.Command("git", "add", ".beads/issues.jsonl")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git add failed: %v", err)
+		}
+		cmd = exec.Command("git", "commit", "-m", "add JSONL")
+		cmd.Dir = tmpDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git commit failed: %v", err)
+		}
+
+		result := checkJSONLUncommitted(tmpDir, beadsDir)
+		if result != "" {
+			t.Errorf("Expected empty string for committed file, got %q", result)
+		}
+	})
+
+	t.Run("not in git repo", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.Mkdir(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(`{"id":"test-1"}`+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// No git init — should fail-safe to empty string
+		result := checkJSONLUncommitted(tmpDir, beadsDir)
+		if result != "" {
+			t.Errorf("Expected empty string outside git repo, got %q", result)
+		}
+	})
+}
+
+func TestCheckSyncConflicts(t *testing.T) {
+	t.Run("no conflict file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		result := checkSyncConflicts(tmpDir)
+		if result != "" {
+			t.Errorf("Expected empty string, got %q", result)
+		}
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		conflictPath := filepath.Join(tmpDir, "sync_conflicts.json")
+		if err := os.WriteFile(conflictPath, []byte("[]"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := checkSyncConflicts(tmpDir)
+		if result != "" {
+			t.Errorf("Expected empty string for empty conflicts, got %q", result)
+		}
+	})
+
+	t.Run("array with conflicts", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		conflicts := []map[string]string{
+			{"id": "test-1", "field": "title"},
+			{"id": "test-2", "field": "status"},
+		}
+		data, _ := json.Marshal(conflicts)
+		conflictPath := filepath.Join(tmpDir, "sync_conflicts.json")
+		if err := os.WriteFile(conflictPath, data, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := checkSyncConflicts(tmpDir)
+		if result != "2 unresolved sync conflict(s)" {
+			t.Errorf("Expected '2 unresolved sync conflict(s)', got %q", result)
+		}
+	})
+
+	t.Run("object with conflicts key", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		wrapper := map[string]any{
+			"conflicts": []map[string]string{
+				{"id": "test-1"},
+			},
+		}
+		data, _ := json.Marshal(wrapper)
+		conflictPath := filepath.Join(tmpDir, "sync_conflicts.json")
+		if err := os.WriteFile(conflictPath, data, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := checkSyncConflicts(tmpDir)
+		if result != "1 unresolved sync conflict(s)" {
+			t.Errorf("Expected '1 unresolved sync conflict(s)', got %q", result)
+		}
+	})
+
+	t.Run("object with empty conflicts", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		wrapper := map[string]any{
+			"conflicts": []any{},
+		}
+		data, _ := json.Marshal(wrapper)
+		conflictPath := filepath.Join(tmpDir, "sync_conflicts.json")
+		if err := os.WriteFile(conflictPath, data, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		result := checkSyncConflicts(tmpDir)
+		if result != "" {
+			t.Errorf("Expected empty string for empty conflicts object, got %q", result)
+		}
+	})
+}
+
+func TestCheckSyncFreshness_WithWarnings(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create conflict file with entries
+	conflicts := []map[string]string{{"id": "test-1"}}
+	data, _ := json.Marshal(conflicts)
+	conflictPath := filepath.Join(beadsDir, "sync_conflicts.json")
+	if err := os.WriteFile(conflictPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckSyncFreshness(tmpDir)
+
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if check.Fix == "" {
+		t.Error("Expected Fix to contain remediation")
+	}
+}
+
+func TestCheckDaemonFreshness_NoDaemon(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckDaemonFreshness(tmpDir)
+
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q", check.Status, StatusOK)
+	}
+	if check.Name != "Daemon Freshness" {
+		t.Errorf("Name = %q, want %q", check.Name, "Daemon Freshness")
+	}
+	if check.Message != "No daemon running (N/A)" {
+		t.Errorf("Message = %q, want 'No daemon running (N/A)'", check.Message)
+	}
+}


### PR DESCRIPTION
## Problem

When the beads daemon dies silently or sync becomes stale between sessions, `bd doctor` had no way to detect it. Users discover stale state only when they notice missing issues or failed syncs — too late to prevent data loss or confusion.

## Solution

Add two new advisory checks to `bd doctor` under the Runtime category:

**Daemon Freshness** — Connects to the daemon via RPC and checks `LastActivityTime`. If the daemon is running with auto-sync enabled but hasn't processed a request in over an hour, warns the user. No SQLite access needed.

**Sync Freshness** — Detects two common problems without opening the database:
- Uncommitted JSONL changes (`git status --porcelain`)
- Unresolved sync conflicts (`sync_conflicts.json` with entries)

Both checks are warning-only (don't affect `OverallOK`). Dolt-native mode returns N/A for sync freshness since JSONL checks don't apply.

## What's not included

This implements the non-SQLite parts of #1639. The database-dependent checks (dirty issue count via `store.GetDirtyIssues()`, last sync activity via `store.GetMetadata("last_import_time")`) are deliberately held back given the ongoing Dolt migration — adding new SQLite-specific doctor checks would need to be reworked or duplicated once the backend changes.

## Design decisions

- **No SQLite access** — These checks avoid opening the database, keeping `bd doctor` fast and avoiding contention with the daemon
- **RPC-only for daemon** — Reuses the same `rpc.TryConnect` + `client.Status()` pattern as existing daemon checks
- **1-hour threshold** — Conservative to avoid false positives from short breaks
- **Fail-safe** — On any error (parse failure, no daemon, no git), returns OK rather than warning

## Test plan

- [x] `CheckSyncFreshness` returns OK when no issues exist
- [x] `checkJSONLUncommitted` detects uncommitted JSONL in git repo
- [x] `checkJSONLUncommitted` returns clean for committed JSONL
- [x] `checkJSONLUncommitted` fails safely outside git repos
- [x] `checkSyncConflicts` handles array, object-with-key, and empty formats
- [x] `CheckDaemonFreshness` returns N/A when no daemon is running
- [x] Build clean, lint clean, race clean

Ref #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)