### PR TITLE
fix(dolt): replace correlated EXISTS in GetBlockedIssues with Go-level filtering

### DIFF
--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -1,10 +1,12 @@
 //go:build cgo
+
 package dolt
 
 import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -319,90 +321,88 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 	return s.scanIssueIDs(ctx, rows)
 }
 
-// GetBlockedIssues returns issues that are blocked by other issues
+// GetBlockedIssues returns issues that are blocked by other issues.
+// Uses separate single-table queries with Go-level filtering to avoid
+// correlated EXISTS subqueries that trigger Dolt's joinIter panic
+// (slice bounds out of range at join_iters.go:192).
+// Same fix pattern as GetStatistics blocked count (fc16065c, a4a21958).
 func (s *DoltStore) GetBlockedIssues(ctx context.Context, filter types.WorkFilter) ([]*types.BlockedIssue, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Use correlated subquery to avoid three-table merge join (Dolt mergeJoinIter panic)
-	rows, err := s.queryContext(ctx, `
-		SELECT i.id,
-		  (SELECT COUNT(*)
-		   FROM dependencies d
-		   WHERE d.issue_id = i.id
-		     AND d.type = 'blocks'
-		     AND EXISTS (
-		       SELECT 1 FROM issues blocker
-		       WHERE blocker.id = d.depends_on_id
-		         AND blocker.status IN ('open', 'in_progress', 'blocked', 'deferred', 'hooked')
-		     )
-		  ) as blocked_by_count
-		FROM issues i
-		WHERE i.status IN ('open', 'in_progress', 'blocked', 'deferred', 'hooked')
-		  AND EXISTS (
-		    SELECT 1 FROM dependencies d
-		    WHERE d.issue_id = i.id
-		      AND d.type = 'blocks'
-		      AND EXISTS (
-		        SELECT 1 FROM issues blocker
-		        WHERE blocker.id = d.depends_on_id
-		          AND blocker.status IN ('open', 'in_progress', 'blocked', 'deferred', 'hooked')
-		      )
-		  )
-		ORDER BY i.priority ASC, i.created_at DESC
+	// Step 1: Get all open/active issue IDs into a set (single-table scan)
+	activeIDs := make(map[string]bool)
+	activeRows, err := s.queryContext(ctx, `
+		SELECT id FROM issues
+		WHERE status IN ('open', 'in_progress', 'blocked', 'deferred', 'hooked')
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get blocked issues: %w", err)
+		return nil, fmt.Errorf("failed to get active issues: %w", err)
 	}
-	defer rows.Close()
-
-	var results []*types.BlockedIssue
-	for rows.Next() {
+	for activeRows.Next() {
 		var id string
-		var count int
-		if err := rows.Scan(&id, &count); err != nil {
+		if err := activeRows.Scan(&id); err != nil {
+			_ = activeRows.Close()
 			return nil, err
 		}
+		activeIDs[id] = true
+	}
+	_ = activeRows.Close()
+	if err := activeRows.Err(); err != nil {
+		return nil, err
+	}
 
+	// Step 2: Get all blocking dependencies (single-table scan)
+	depRows, err := s.queryContext(ctx, `
+		SELECT issue_id, depends_on_id FROM dependencies
+		WHERE type = 'blocks'
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blocking dependencies: %w", err)
+	}
+
+	// Step 3: Filter in Go — both sides must be active
+	// blockerMap: blocked_issue_id -> list of active blocker IDs
+	blockerMap := make(map[string][]string)
+	for depRows.Next() {
+		var issueID, blockerID string
+		if err := depRows.Scan(&issueID, &blockerID); err != nil {
+			_ = depRows.Close()
+			return nil, err
+		}
+		if activeIDs[issueID] && activeIDs[blockerID] {
+			blockerMap[issueID] = append(blockerMap[issueID], blockerID)
+		}
+	}
+	_ = depRows.Close()
+	if err := depRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Step 4: Hydrate blocked issues and build results
+	var results []*types.BlockedIssue
+	for id, blockerIDs := range blockerMap {
 		issue, err := s.GetIssue(ctx, id)
 		if err != nil || issue == nil {
 			continue
 		}
 
-		// Get blocker IDs
-		var blockerIDs []string
-		blockerRows, err := s.queryContext(ctx, `
-			SELECT d.depends_on_id
-			FROM dependencies d
-			WHERE d.issue_id = ?
-			  AND d.type = 'blocks'
-			  AND EXISTS (
-			    SELECT 1 FROM issues blocker
-			    WHERE blocker.id = d.depends_on_id
-			      AND blocker.status IN ('open', 'in_progress', 'blocked', 'deferred', 'hooked')
-			  )
-		`, id)
-		if err != nil {
-			return nil, err
-		}
-		for blockerRows.Next() {
-			var blockerID string
-			if err := blockerRows.Scan(&blockerID); err != nil {
-				_ = blockerRows.Close() // nolint:gosec // G104: error ignored on early return
-				return nil, err
-			}
-			blockerIDs = append(blockerIDs, blockerID)
-		}
-		_ = blockerRows.Close() // nolint:gosec // G104: rows already read successfully
-
 		results = append(results, &types.BlockedIssue{
 			Issue:          *issue,
-			BlockedByCount: count,
+			BlockedByCount: len(blockerIDs),
 			BlockedBy:      blockerIDs,
 		})
 	}
 
-	return results, rows.Err()
+	// Sort by priority ASC, then created_at DESC (matching original SQL ORDER BY)
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Issue.Priority != results[j].Issue.Priority {
+			return results[i].Issue.Priority < results[j].Issue.Priority
+		}
+		return results[i].Issue.CreatedAt.After(results[j].Issue.CreatedAt)
+	})
+
+	return results, nil
 }
 
 // GetEpicsEligibleForClosure returns epics whose children are all closed


### PR DESCRIPTION
## Summary

`GetBlockedIssues` hangs indefinitely on Dolt backends due to correlated `EXISTS` subqueries triggering the same `joinIter` panic (slice bounds out of range at `join_iters.go:192`) that was previously fixed in `GetStatistics` (fc16065c, a4a21958).

This patch applies the same fix pattern: replace nested correlated subqueries with two simple single-table queries (`SELECT id FROM issues`, `SELECT issue_id, depends_on_id FROM dependencies`) and perform the join filtering in Go using a map.

## Problem

`bd blocked` (which calls `GetBlockedIssues`) would hang forever on any non-trivial Dolt database. Tested against:

- `file-browser` (26 issues): hung indefinitely
- `hq` (14,575 issues): hung indefinitely

The root cause is the same Dolt query planner limitation that affected `GetStatistics` — correlated `EXISTS` inside another correlated `EXISTS` causes the merge join iterator to panic or loop.

## Fix

- Query 1: `SELECT id FROM issues WHERE status IN (...)` → build `activeIDs` map
- Query 2: `SELECT issue_id, depends_on_id FROM dependencies WHERE type = 'blocks'` → filter in Go where both sides are in `activeIDs`
- Hydrate results with `GetIssue()` per blocked issue (same as before)
- Sort in Go to match original `ORDER BY priority ASC, created_at DESC`

## Performance

| Database | Before | After |
|----------|--------|-------|
| file-browser (26 issues) | ∞ (hung) | 86ms |
| hq (14,575 issues) | ∞ (hung) | ~9s |

## Related

- Closes #1571
- Same pattern as GetStatistics fix: fc16065c, a4a21958