### PR TITLE
Make bd init cancelable

### DIFF
--- a/cmd/bd/init_cancel_e2e_test.go
+++ b/cmd/bd/init_cancel_e2e_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+// +build integration
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestInitCancel_E2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping SIGINT E2E test on Windows")
+	}
+
+	tmpDir := createTempDirWithCleanup(t)
+	runGitCmd(t, tmpDir, "init", "-b", "main")
+
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdin pipe: %v", err)
+	}
+	defer func() { _ = stdinW.Close() }()
+
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+	defer func() { _ = stdoutR.Close() }()
+
+	cmd := exec.Command(testBD, "init", "--prefix", "test", "--contributor")
+	cmd.Dir = tmpDir
+	cmd.Stdin = stdinR
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stdoutW
+	cmd.Env = append(filteredEnv("BEADS_DB", "BEADS_DIR", "BEADS_NO_DAEMON", "HOME", "XDG_CONFIG_HOME"),
+		"BEADS_DB=",
+		"BEADS_NO_DAEMON=1",
+		"HOME="+tmpDir,
+		"XDG_CONFIG_HOME="+filepath.Join(tmpDir, "xdg-config"),
+	)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start bd init: %v", err)
+	}
+
+	_ = stdinR.Close()
+	_ = stdoutW.Close()
+
+	prompts := [][]byte{
+		[]byte("Continue with contributor setup? [y/N]: "),
+		[]byte("Continue anyway? [y/N]: "),
+	}
+	promptSeen := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	var output bytes.Buffer
+	var outputMu sync.Mutex
+	var promptOnce sync.Once
+
+	go func() {
+		defer close(readerDone)
+		buf := make([]byte, 1024)
+		for {
+			n, err := stdoutR.Read(buf)
+			if n > 0 {
+				outputMu.Lock()
+				output.Write(buf[:n])
+				for _, prompt := range prompts {
+					if bytes.Contains(output.Bytes(), prompt) {
+						promptOnce.Do(func() { close(promptSeen) })
+						break
+					}
+				}
+				outputMu.Unlock()
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	getOutput := func() string {
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		return output.String()
+	}
+
+	select {
+	case <-promptSeen:
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
+			t.Fatalf("failed to send SIGINT: %v", err)
+		}
+	case err := <-waitCh:
+		t.Fatalf("bd init exited before prompt: %v\nOutput: %s", err, getOutput())
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		err := <-waitCh
+		t.Fatalf("timeout waiting for prompt (exit=%v)\nOutput: %s", err, getOutput())
+	}
+
+	err = <-waitCh
+
+	select {
+	case <-readerDone:
+	case <-time.After(2 * time.Second):
+		t.Log("timeout waiting for output drain")
+	}
+
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got success\nOutput: %s", getOutput())
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("unexpected error type: %v\nOutput: %s", err, getOutput())
+	}
+	if exitErr.ExitCode() != exitCodeCanceled {
+		t.Fatalf("expected exit code %d, got %d\nOutput: %s", exitCodeCanceled, exitErr.ExitCode(), getOutput())
+	}
+	if !strings.Contains(getOutput(), "Setup canceled.") {
+		t.Fatalf("expected cancel message, got:\n%s", getOutput())
+	}
+}
+
+func filteredEnv(keys ...string) []string {
+	strip := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		strip[key+"="] = struct{}{}
+	}
+
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		trim := false
+		for prefix := range strip {
+			if strings.HasPrefix(entry, prefix) {
+				trim = true
+				break
+			}
+		}
+		if !trim {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}

--- a/cmd/bd/init_contributor.go
+++ b/cmd/bd/init_contributor.go
@@ -20,6 +20,11 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Println("This wizard will configure beads for OSS contribution.")
 	fmt.Println()
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	reader := bufio.NewReader(os.Stdin)
+
 	// Early check: BEADS_DIR takes precedence over routing
 	if beadsDir := os.Getenv("BEADS_DIR"); beadsDir != "" {
 		fmt.Printf("%s BEADS_DIR is set: %s\n", ui.RenderWarn("⚠"), beadsDir)
@@ -28,8 +33,13 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 		fmt.Println("  you likely don't need --contributor.")
 		fmt.Println()
 		fmt.Print("Continue anyway? [y/N]: ")
-		reader := bufio.NewReader(os.Stdin)
-		response, _ := reader.ReadString('\n')
+		response, err := readLineWithContext(ctx, reader, os.Stdin)
+		if err != nil {
+			if isCanceled(err) {
+				return err
+			}
+			response = ""
+		}
 		response = strings.TrimSpace(strings.ToLower(response))
 
 		if response != "y" && response != "yes" {
@@ -54,8 +64,13 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 
 		// Ask if they want to continue anyway
 		fmt.Print("Continue with contributor setup? [y/N]: ")
-		reader := bufio.NewReader(os.Stdin)
-		response, _ := reader.ReadString('\n')
+		response, err := readLineWithContext(ctx, reader, os.Stdin)
+		if err != nil {
+			if isCanceled(err) {
+				return err
+			}
+			response = ""
+		}
 		response = strings.TrimSpace(strings.ToLower(response))
 
 		if response != "y" && response != "yes" {
@@ -74,8 +89,13 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 		fmt.Printf("  %s You can commit directly to this repository.\n", ui.RenderWarn("⚠"))
 		fmt.Println()
 		fmt.Print("Do you want to use a separate planning repo anyway? [Y/n]: ")
-		reader := bufio.NewReader(os.Stdin)
-		response, _ := reader.ReadString('\n')
+		response, err := readLineWithContext(ctx, reader, os.Stdin)
+		if err != nil {
+			if isCanceled(err) {
+				return err
+			}
+			response = ""
+		}
 		response = strings.TrimSpace(strings.ToLower(response))
 
 		if response == "n" || response == "no" {
@@ -106,8 +126,13 @@ func runContributorWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Printf("Default: %s\n", ui.RenderAccent(defaultPlanningRepo))
 	fmt.Print("Planning repo path [press Enter for default]: ")
 
-	reader := bufio.NewReader(os.Stdin)
-	planningPath, _ := reader.ReadString('\n')
+	planningPath, err := readLineWithContext(ctx, reader, os.Stdin)
+	if err != nil {
+		if isCanceled(err) {
+			return err
+		}
+		planningPath = ""
+	}
 	planningPath = strings.TrimSpace(planningPath)
 
 	if planningPath == "" {

--- a/cmd/bd/init_team.go
+++ b/cmd/bd/init_team.go
@@ -20,6 +20,11 @@ func runTeamWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Println("This wizard will configure beads for team collaboration.")
 	fmt.Println()
 
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	reader := bufio.NewReader(os.Stdin)
+
 	// Step 1: Check if we're in a git repository
 	fmt.Printf("%s Detecting git repository setup...\n", ui.RenderAccent("▶"))
 
@@ -47,8 +52,13 @@ func runTeamWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Println("  GitLab: Settings → Repository → Protected branches")
 	fmt.Print("\nProtected main branch? [y/N]: ")
 
-	reader := bufio.NewReader(os.Stdin)
-	response, _ := reader.ReadString('\n')
+	response, err := readLineWithContext(ctx, reader, os.Stdin)
+	if err != nil {
+		if isCanceled(err) {
+			return err
+		}
+		response = ""
+	}
 	response = strings.TrimSpace(strings.ToLower(response))
 
 	protectedMain := (response == "y" || response == "yes")
@@ -61,7 +71,13 @@ func runTeamWizard(ctx context.Context, store storage.Storage) error {
 		fmt.Printf("  Default sync branch: %s\n", ui.RenderAccent("beads-metadata"))
 		fmt.Print("\n  Sync branch name [press Enter for default]: ")
 
-		branchName, _ := reader.ReadString('\n')
+		branchName, err := readLineWithContext(ctx, reader, os.Stdin)
+		if err != nil {
+			if isCanceled(err) {
+				return err
+			}
+			branchName = ""
+		}
 		branchName = strings.TrimSpace(branchName)
 
 		if branchName == "" {
@@ -113,7 +129,13 @@ func runTeamWizard(ctx context.Context, store storage.Storage) error {
 	fmt.Println("  • Auto-push: Pushes commits to remote")
 	fmt.Print("\nEnable auto-sync? [Y/n]: ")
 
-	response, _ = reader.ReadString('\n')
+	response, err = readLineWithContext(ctx, reader, os.Stdin)
+	if err != nil {
+		if isCanceled(err) {
+			return err
+		}
+		response = ""
+	}
 	response = strings.TrimSpace(strings.ToLower(response))
 
 	autoSync := !(response == "n" || response == "no")

--- a/cmd/bd/prompt.go
+++ b/cmd/bd/prompt.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// notifyContext is overridden in tests to avoid sending real signals.
+var notifyContext = signal.NotifyContext
+
+const exitCodeCanceled = 130
+
+// readLineWithContext returns a line from reader or ctx.Err() if canceled.
+// If closer is provided, it is closed on cancellation to unblock the read.
+func readLineWithContext(ctx context.Context, reader *bufio.Reader, closer io.Closer) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	sigCtx, stop := notifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := sigCtx.Err(); err != nil {
+		return "", err
+	}
+
+	type result struct {
+		line string
+		err  error
+	}
+
+	resultCh := make(chan result, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		resultCh <- result{line: line, err: err}
+	}()
+
+	select {
+	case <-sigCtx.Done():
+		if closer != nil {
+			_ = closer.Close()
+		}
+		return "", sigCtx.Err()
+	case res := <-resultCh:
+		return res.line, res.err
+	}
+}
+
+func isCanceled(err error) bool {
+	return errors.Is(err, context.Canceled)
+}
+
+func exitCanceled() {
+	os.Exit(exitCodeCanceled)
+}

--- a/cmd/bd/prompt_test.go
+++ b/cmd/bd/prompt_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type notifyStub struct {
+	ready   chan struct{}
+	cancel  context.CancelFunc
+	signals []os.Signal
+}
+
+func installNotifyStub(t *testing.T) *notifyStub {
+	t.Helper()
+	stub := &notifyStub{ready: make(chan struct{}, 1)}
+	original := notifyContext
+	notifyContext = func(parent context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
+		stub.signals = append([]os.Signal(nil), signals...)
+		ctx, cancel := context.WithCancel(parent)
+		stub.cancel = cancel
+		select {
+		case stub.ready <- struct{}{}:
+		default:
+		}
+		return ctx, cancel
+	}
+	t.Cleanup(func() { notifyContext = original })
+	return stub
+}
+
+func TestReadLineWithContextReadsLine(t *testing.T) {
+	stub := installNotifyStub(t)
+
+	reader := bufio.NewReader(strings.NewReader("yes\n"))
+	line, err := readLineWithContext(context.Background(), reader, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if line != "yes\n" {
+		t.Fatalf("unexpected line: %q", line)
+	}
+	if len(stub.signals) != 2 || stub.signals[0] != os.Interrupt || stub.signals[1] != syscall.SIGTERM {
+		t.Fatalf("unexpected signals: %v", stub.signals)
+	}
+}
+
+func TestReadLineWithContextCanceled(t *testing.T) {
+	stub := installNotifyStub(t)
+
+	pr, pw := io.Pipe()
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+
+	reader := bufio.NewReader(pr)
+	done := make(chan error, 1)
+	go func() {
+		_, err := readLineWithContext(context.Background(), reader, pr)
+		done <- err
+	}()
+
+	select {
+	case <-stub.ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for notifyContext")
+	}
+	if stub.cancel == nil {
+		t.Fatal("expected cancel function")
+	}
+
+	stub.cancel()
+	_ = pw.Close()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for readLineWithContext")
+	}
+}


### PR DESCRIPTION

## Summary
- make init prompts cancelable with SIGINT-aware reads and exit code 130
- propagate cancellation handling through contributor/team/fork prompts
- add E2E test for SIGINT cancel during init

## Testing
- `CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c/lib" go test ./cmd/bd -run TestReadLineWithContext -count=1`
- `PATH="/usr/bin:/bin:/opt/homebrew/bin" CGO_CPPFLAGS="-I/opt/homebrew/opt/icu4c/include" CGO_LDFLAGS="-L/opt/homebrew/opt/icu4c/lib" go test -tags=integration ./cmd/bd -run TestInitCancel_E2E -count=1`

## CI

I believe all the CI errors pre-exist this PR. I formatted/linted the files that I changed but I'm not going to address base-level errors in the interest of keeping this PR focussed.

Co-authored-by: Codex <codex@openai.com>