### PR TITLE
resolve-conflicts: default to canonical issues.jsonl

### DIFF
--- a/cmd/bd/resolve_conflicts.go
+++ b/cmd/bd/resolve_conflicts.go
@@ -29,10 +29,10 @@ Modes:
   mechanical (default)  Uses deterministic merge rules (updated_at wins, etc.)
   interactive           Prompts for each conflict (not yet implemented)
 
-The file defaults to .beads/beads.jsonl if not specified.
+The file defaults to .beads/issues.jsonl if not specified.
 
 Examples:
-  bd resolve-conflicts                    # Resolve conflicts in .beads/beads.jsonl
+  bd resolve-conflicts                    # Resolve conflicts in .beads/issues.jsonl
   bd resolve-conflicts --dry-run          # Show what would be resolved
   bd resolve-conflicts custom.jsonl       # Resolve conflicts in custom file
   bd resolve-conflicts --json             # Output results as JSON`,
@@ -94,7 +94,7 @@ func runResolveConflicts(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		filePath = args[0]
 	} else {
-		filePath = filepath.Join(resolveConflictsPath, ".beads", "beads.jsonl")
+		filePath = defaultResolveConflictsFilePath(resolveConflictsPath)
 	}
 
 	// Validate mode
@@ -217,6 +217,10 @@ func runResolveConflicts(cmd *cobra.Command, args []string) {
 		fmt.Printf("%s Resolved %d conflict(s) in %s\n", ui.RenderPass("✓"), len(conflicts), filepath.Base(filePath))
 		fmt.Printf("Backup preserved at: %s\n", filepath.Base(backupPath))
 	}
+}
+
+func defaultResolveConflictsFilePath(rootPath string) string {
+	return filepath.Join(rootPath, ".beads", "issues.jsonl")
 }
 
 // parseConflicts extracts conflict regions and non-conflicted lines from content

--- a/cmd/bd/resolve_conflicts_test.go
+++ b/cmd/bd/resolve_conflicts_test.go
@@ -31,6 +31,26 @@ func testMergeIssue(jsonStr string) merge.Issue {
 	return issue
 }
 
+func TestDefaultResolveConflictsFilePath(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+	}{
+		{name: "relative root", root: "."},
+		{name: "absolute root", root: "/tmp/workspace"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := defaultResolveConflictsFilePath(tt.root)
+			want := filepath.Join(tt.root, ".beads", "issues.jsonl")
+			if got != want {
+				t.Fatalf("defaultResolveConflictsFilePath(%q) = %q, want %q", tt.root, got, want)
+			}
+		})
+	}
+}
+
 func TestParseConflicts(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- switch `resolve-conflicts` default target from legacy `.beads/beads.jsonl` to canonical `.beads/issues.jsonl`
- update command help/examples to match the canonical default file
- extract default path selection into a helper and add unit coverage for it

## Validation
- CGO_ENABLED=0 go test ./cmd/bd -run 'TestDefaultResolveConflictsFilePath|TestParseConflicts|TestResolveConflict|TestResolveConflictsEndToEnd'
