### PR TITLE
Add Beadbox to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -57,6 +57,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 -  **[Parade](https://github.com/JeremyKalmus/parade)** - Electron app for workflow orchestration with visual Kanban board, discovery wizard, and task visualization. Run with `npx parade-init`. Built by [@JeremyKalmus](https://github.com/JeremyKalmus). (Electron/React)
 
+- **[Beadbox](https://github.com/beadbox/beadbox)** - Native macOS dashboard with real-time sync, epic tree progress bars, multi-workspace support, and inline editing. Install with `brew tap beadbox/cask && brew install --cask beadbox`. Built by [@nmelo](https://github.com/nmelo). (Tauri/Next.js)
+
 ## Data Source Middleware
 
 - **[jira-beads-sync](https://github.com/conallob/jira-beads-sync)** - CLI tool & Claude Code plugin to sync tasks from Jira into beads and publish beads task states back to Jira. Built by [@conallob](https://github.com/conallob). (Go)


### PR DESCRIPTION
Adds [Beadbox](https://github.com/beadbox/beadbox) to the Native Apps section of COMMUNITY_TOOLS.md.

Beadbox is a native macOS dashboard for beads with real-time sync, epic tree progress bars, multi-workspace support, and inline editing. Available via Homebrew and direct download.