### PR TITLE
fix: bootstrap schemaReady() ignores prefix-based database name

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -630,14 +630,17 @@ var rootCmd = &cobra.Command{
 			// For Dolt, use the dolt subdirectory
 			doltPath := filepath.Join(beadsDir, "dolt")
 
-			// Check if server mode is configured in metadata.json
+			// Load config to get database name and server mode settings
 			cfg, cfgErr := configfile.Load(beadsDir)
-			if cfgErr == nil && cfg != nil && cfg.IsDoltServerMode() {
-				opts.ServerMode = true
-				opts.ServerHost = cfg.GetDoltServerHost()
-				opts.ServerPort = cfg.GetDoltServerPort()
-				if cfg.Database != "" {
-					opts.Database = cfg.GetDoltDatabase()
+			if cfgErr == nil && cfg != nil {
+				// Always set database name (needed for bootstrap to find
+				// prefix-based databases like "beads_hq"; see #1669)
+				opts.Database = cfg.GetDoltDatabase()
+
+				if cfg.IsDoltServerMode() {
+					opts.ServerMode = true
+					opts.ServerHost = cfg.GetDoltServerHost()
+					opts.ServerPort = cfg.GetDoltServerPort()
 				}
 			}
 

--- a/internal/storage/dolt/bootstrap.go
+++ b/internal/storage/dolt/bootstrap.go
@@ -40,6 +40,7 @@ type BootstrapConfig struct {
 	BeadsDir    string        // Path to .beads directory
 	DoltPath    string        // Path to dolt subdirectory
 	LockTimeout time.Duration // Timeout waiting for bootstrap lock
+	Database    string        // Database name (e.g. "beads_hq"); defaults to "beads"
 }
 
 // Bootstrap checks if Dolt DB needs bootstrapping from JSONL and performs it if needed.
@@ -56,7 +57,7 @@ func Bootstrap(ctx context.Context, cfg BootstrapConfig) (bool, *BootstrapResult
 	}
 
 	// Check if Dolt database already exists and is ready
-	if doltExists(cfg.DoltPath) && schemaReady(ctx, cfg.DoltPath) {
+	if doltExists(cfg.DoltPath) && schemaReady(ctx, cfg.DoltPath, cfg.Database) {
 		return false, nil, nil
 	}
 
@@ -76,7 +77,7 @@ func Bootstrap(ctx context.Context, cfg BootstrapConfig) (bool, *BootstrapResult
 	defer releaseBootstrapLock(lockFile, lockPath)
 
 	// Double-check after acquiring lock - another process may have bootstrapped
-	if doltExists(cfg.DoltPath) && schemaReady(ctx, cfg.DoltPath) {
+	if doltExists(cfg.DoltPath) && schemaReady(ctx, cfg.DoltPath, cfg.Database) {
 		return false, nil, nil
 	}
 
@@ -119,11 +120,14 @@ func doltExists(doltPath string) bool {
 // schemaReady checks if the Dolt database has the required schema
 // This is a simple check based on the existence of expected files.
 // We avoid opening a connection here since the caller will do that.
-func schemaReady(_ context.Context, doltPath string) bool {
+func schemaReady(_ context.Context, doltPath string, dbName string) bool {
+	if dbName == "" {
+		dbName = "beads"
+	}
 	// The embedded Dolt driver stores databases in subdirectories.
 	// Check for the expected database name's config.json which indicates
 	// the database was initialized.
-	configPath := filepath.Join(doltPath, "beads", ".dolt", "config.json")
+	configPath := filepath.Join(doltPath, dbName, ".dolt", "config.json")
 	_, err := os.Stat(configPath)
 	return err == nil
 }

--- a/internal/storage/dolt/bootstrap_test.go
+++ b/internal/storage/dolt/bootstrap_test.go
@@ -662,6 +662,71 @@ func TestBootstrapDuplicateExternalRef(t *testing.T) {
 	}
 }
 
+func TestBootstrapRecognizesPrefixDatabase(t *testing.T) {
+	// When a prefix-based database exists (e.g. "beads_hq" from `bd migrate --to-dolt`),
+	// Bootstrap() should recognize it and NOT re-bootstrap from JSONL.
+	// This is the regression test for issue #1669.
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create beads dir: %v", err)
+	}
+
+	// Create a Dolt store with a prefix-based database name
+	ctx := context.Background()
+	store, err := New(ctx, &Config{Path: doltDir, Database: "beads_hq"})
+	if err != nil {
+		t.Fatalf("failed to create store with prefix db: %v", err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", "hq"); err != nil {
+		t.Fatalf("failed to set config: %v", err)
+	}
+	store.Close()
+
+	// Create JSONL file that would trigger a bootstrap if the DB is not detected
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	issue := types.Issue{
+		ID:     "hq-001",
+		Title:  "Should not be imported",
+		Status: types.StatusOpen,
+	}
+	data, _ := json.Marshal(issue)
+	if err := os.WriteFile(jsonlPath, append(data, '\n'), 0644); err != nil {
+		t.Fatalf("failed to write JSONL: %v", err)
+	}
+
+	// Attempt bootstrap with the correct database name - should be no-op
+	bootstrapped, result, err := Bootstrap(ctx, BootstrapConfig{
+		BeadsDir:    beadsDir,
+		DoltPath:    doltDir,
+		LockTimeout: 10 * time.Second,
+		Database:    "beads_hq",
+	})
+
+	if err != nil {
+		t.Fatalf("bootstrap failed: %v", err)
+	}
+	if bootstrapped {
+		t.Error("expected no bootstrap when prefix-named Dolt DB already exists")
+	}
+	if result != nil {
+		t.Error("expected nil result when no bootstrap performed")
+	}
+
+	// Verify original config is preserved (not overwritten by re-bootstrap)
+	store, err = New(ctx, &Config{Path: doltDir, Database: "beads_hq"})
+	if err != nil {
+		t.Fatalf("failed to reopen store: %v", err)
+	}
+	defer store.Close()
+
+	prefix, _ := store.GetConfig(ctx, "issue_prefix")
+	if prefix != "hq" {
+		t.Errorf("expected prefix 'hq', got '%s'", prefix)
+	}
+}
+
 func TestBootstrapWithoutOptionalFiles(t *testing.T) {
 	// Test that bootstrap succeeds when routes.jsonl and interactions.jsonl don't exist
 	tmpDir := t.TempDir()

--- a/internal/storage/factory/factory_dolt.go
+++ b/internal/storage/factory/factory_dolt.go
@@ -79,6 +79,7 @@ func bootstrapEmbeddedDolt(ctx context.Context, path string, opts Options) error
 		BeadsDir:    beadsDir,
 		DoltPath:    path,
 		LockTimeout: opts.LockTimeout,
+		Database:    opts.Database,
 	})
 	if err != nil {
 		return fmt.Errorf("bootstrap failed: %w", err)


### PR DESCRIPTION
## Summary

- Fix `schemaReady()` hardcoding `"beads"` as the database name, causing it to miss prefix-based databases (e.g. `beads_hq`) created by `bd migrate --to-dolt`
- Set `opts.Database` from `metadata.json` unconditionally in `main.go` — it was previously gated behind `IsDoltServerMode()`, so embedded mode never received the database name
- Add regression test `TestBootstrapRecognizesPrefixDatabase`

Server mode was never affected (bootstrap is skipped entirely in that path).

Fixes #1669

## Test plan

- [x] All existing bootstrap tests pass (`go test ./internal/storage/dolt/ -run TestBootstrap -v`)
- [x] All factory tests pass (`go test ./internal/storage/factory/ -v`)
- [x] New regression test: creates a `beads_hq` database, verifies `Bootstrap()` recognizes it and does NOT re-bootstrap
- [x] Manual test: deleted spurious `beads/` dir, ran `bd list` from `/data/projects/gt/` — correctly used `beads_hq` without re-bootstrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)