### PR TITLE
feat(github): add GitHub Issues integration

### DIFF
--- a/cmd/bd/github.go
+++ b/cmd/bd/github.go
@@ -1,0 +1,422 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	gh "github.com/steveyegge/beads/internal/github"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// GitHubConfig holds GitHub connection configuration.
+type GitHubConfig struct {
+	Token string // Personal access token
+	Owner string // Repository owner (user or org)
+	Repo  string // Repository name
+}
+
+// githubCmd is the root command for GitHub operations.
+var githubCmd = &cobra.Command{
+	Use:   "github",
+	Short: "GitHub integration commands",
+	Long: `Commands for syncing issues between beads and GitHub.
+
+Configuration can be set via 'bd config' or environment variables:
+  github.owner / GITHUB_OWNER     - Repository owner (user or org)
+  github.repo / GITHUB_REPO       - Repository name
+  github.token / GITHUB_TOKEN     - Personal access token`,
+}
+
+// githubSyncCmd synchronizes issues between beads and GitHub.
+var githubSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync issues with GitHub",
+	Long: `Synchronize issues between beads and GitHub.
+
+By default, performs bidirectional sync:
+- Pulls new/updated issues from GitHub to beads
+- Pushes local beads issues to GitHub
+
+Use --pull-only or --push-only to limit direction.`,
+	RunE: runGitHubSync,
+}
+
+// githubStatusCmd displays GitHub configuration and sync status.
+var githubStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show GitHub sync status",
+	Long:  `Display current GitHub configuration and sync status.`,
+	RunE:  runGitHubStatus,
+}
+
+// githubReposCmd lists accessible GitHub repositories.
+var githubReposCmd = &cobra.Command{
+	Use:   "repos",
+	Short: "List accessible GitHub repositories",
+	Long:  `List GitHub repositories that the configured token has access to.`,
+	RunE:  runGitHubRepos,
+}
+
+var (
+	githubSyncDryRun   bool
+	githubSyncPullOnly bool
+	githubSyncPushOnly bool
+	githubPreferLocal  bool
+	githubPreferGitHub bool
+	githubPreferNewer  bool
+)
+
+func init() {
+	githubCmd.AddCommand(githubSyncCmd)
+	githubCmd.AddCommand(githubStatusCmd)
+	githubCmd.AddCommand(githubReposCmd)
+
+	githubSyncCmd.Flags().BoolVar(&githubSyncDryRun, "dry-run", false, "Show what would be synced without making changes")
+	githubSyncCmd.Flags().BoolVar(&githubSyncPullOnly, "pull-only", false, "Only pull issues from GitHub")
+	githubSyncCmd.Flags().BoolVar(&githubSyncPushOnly, "push-only", false, "Only push issues to GitHub")
+
+	githubSyncCmd.Flags().BoolVar(&githubPreferLocal, "prefer-local", false, "On conflict, keep local beads version")
+	githubSyncCmd.Flags().BoolVar(&githubPreferGitHub, "prefer-github", false, "On conflict, use GitHub version")
+	githubSyncCmd.Flags().BoolVar(&githubPreferNewer, "prefer-newer", false, "On conflict, use most recent version (default)")
+
+	rootCmd.AddCommand(githubCmd)
+}
+
+// getGitHubConfig returns GitHub configuration from bd config or environment.
+func getGitHubConfig() GitHubConfig {
+	ctx := context.Background()
+	config := GitHubConfig{}
+
+	config.Token = getGitHubConfigValue(ctx, "github.token")
+	config.Owner = getGitHubConfigValue(ctx, "github.owner")
+	config.Repo = getGitHubConfigValue(ctx, "github.repo")
+
+	return config
+}
+
+// getGitHubConfigValue reads a GitHub configuration value from store or environment.
+func getGitHubConfigValue(ctx context.Context, key string) string {
+	if store != nil {
+		value, _ := store.GetConfig(ctx, key)
+		if value != "" {
+			return value
+		}
+	} else if dbPath != "" {
+		tempStore, err := sqlite.NewWithTimeout(ctx, dbPath, 5*time.Second)
+		if err == nil {
+			defer func() { _ = tempStore.Close() }()
+			value, _ := tempStore.GetConfig(ctx, key)
+			if value != "" {
+				return value
+			}
+		}
+	}
+
+	envKey := githubConfigToEnvVar(key)
+	if envKey != "" {
+		if value := os.Getenv(envKey); value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+// githubConfigToEnvVar maps GitHub config keys to their environment variable names.
+func githubConfigToEnvVar(key string) string {
+	switch key {
+	case "github.token":
+		return "GITHUB_TOKEN"
+	case "github.owner":
+		return "GITHUB_OWNER"
+	case "github.repo":
+		return "GITHUB_REPO"
+	default:
+		return ""
+	}
+}
+
+// validateGitHubConfig checks that required configuration is present.
+func validateGitHubConfig(config GitHubConfig) error {
+	if config.Token == "" {
+		return fmt.Errorf("github.token is not configured. Set via 'bd config set github.token <token>' or GITHUB_TOKEN environment variable")
+	}
+	if config.Owner == "" {
+		return fmt.Errorf("github.owner is not configured. Set via 'bd config set github.owner <owner>' or GITHUB_OWNER environment variable")
+	}
+	if config.Repo == "" {
+		return fmt.Errorf("github.repo is not configured. Set via 'bd config set github.repo <repo>' or GITHUB_REPO environment variable")
+	}
+	return nil
+}
+
+// maskGitHubToken masks a token for safe display.
+func maskGitHubToken(token string) string {
+	if token == "" {
+		return "(not set)"
+	}
+	if len(token) <= 4 {
+		return "****"
+	}
+	return token[:4] + "****"
+}
+
+// getGitHubClient creates a GitHub client from the current configuration.
+func getGitHubClient(config GitHubConfig) *gh.Client {
+	return gh.NewClient(config.Token, config.Owner, config.Repo)
+}
+
+// runGitHubStatus implements the github status command.
+func runGitHubStatus(cmd *cobra.Command, args []string) error {
+	config := getGitHubConfig()
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "GitHub Configuration")
+	_, _ = fmt.Fprintln(out, "====================")
+	_, _ = fmt.Fprintf(out, "Owner: %s\n", config.Owner)
+	_, _ = fmt.Fprintf(out, "Repo:  %s\n", config.Repo)
+	_, _ = fmt.Fprintf(out, "Token: %s\n", maskGitHubToken(config.Token))
+
+	if err := validateGitHubConfig(config); err != nil {
+		_, _ = fmt.Fprintf(out, "\nStatus: ❌ Not configured\n")
+		_, _ = fmt.Fprintf(out, "Error: %v\n", err)
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(out, "\nStatus: ✓ Configured\n")
+	return nil
+}
+
+// runGitHubRepos implements the github repos command.
+func runGitHubRepos(cmd *cobra.Command, args []string) error {
+	config := getGitHubConfig()
+	if config.Token == "" {
+		return fmt.Errorf("github.token is required to list repositories")
+	}
+
+	out := cmd.OutOrStdout()
+	client := getGitHubClient(config)
+	ctx := context.Background()
+
+	repos, err := client.ListRepositories(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch repositories: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(out, "Accessible GitHub Repositories")
+	_, _ = fmt.Fprintln(out, "==============================")
+	for _, r := range repos {
+		_, _ = fmt.Fprintf(out, "Name: %s\n", r.FullName)
+		_, _ = fmt.Fprintf(out, "  URL:     %s\n", r.HTMLURL)
+		if r.Description != "" {
+			_, _ = fmt.Fprintf(out, "  Desc:    %s\n", r.Description)
+		}
+		_, _ = fmt.Fprintf(out, "  Private: %v\n", r.Private)
+		_, _ = fmt.Fprintln(out)
+	}
+
+	if len(repos) == 0 {
+		_, _ = fmt.Fprintln(out, "No repositories found (or no access)")
+	}
+
+	return nil
+}
+
+// runGitHubSync implements the github sync command.
+func runGitHubSync(cmd *cobra.Command, args []string) error {
+	config := getGitHubConfig()
+	if err := validateGitHubConfig(config); err != nil {
+		return err
+	}
+
+	if !githubSyncDryRun {
+		CheckReadonly("github sync")
+	}
+
+	if githubSyncPullOnly && githubSyncPushOnly {
+		return fmt.Errorf("cannot use both --pull-only and --push-only")
+	}
+
+	conflictStrategy, err := getGitHubConflictStrategy(githubPreferLocal, githubPreferGitHub, githubPreferNewer)
+	if err != nil {
+		return fmt.Errorf("%w (--prefer-local, --prefer-github, --prefer-newer)", err)
+	}
+
+	if err := ensureStoreActive(); err != nil {
+		return fmt.Errorf("database not available: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	client := getGitHubClient(config)
+	ctx := context.Background()
+	mappingConfig := gh.DefaultMappingConfig()
+
+	syncCtx := NewSyncContext()
+	syncCtx.SetStore(store)
+	syncCtx.SetActor(actor)
+	syncCtx.SetDBPath(dbPath)
+
+	if githubSyncDryRun {
+		_, _ = fmt.Fprintln(out, "Dry run mode - no changes will be made")
+		_, _ = fmt.Fprintln(out)
+	}
+
+	pull := !githubSyncPushOnly
+	push := !githubSyncPullOnly
+
+	result := &gh.SyncResult{Success: true}
+
+	// Pull from GitHub
+	if pull {
+		if githubSyncDryRun {
+			_, _ = fmt.Fprintln(out, "→ [DRY RUN] Would pull issues from GitHub")
+		} else {
+			_, _ = fmt.Fprintln(out, "→ Pulling issues from GitHub...")
+		}
+
+		pullStats, err := doPullFromGitHubWithContext(ctx, syncCtx, client, config.Owner, config.Repo, mappingConfig, githubSyncDryRun, "all", nil)
+		if err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			_, _ = fmt.Fprintf(out, "Error pulling from GitHub: %v\n", err)
+			return err
+		}
+
+		result.Stats.Pulled = pullStats.Created + pullStats.Updated
+		result.Stats.Created += pullStats.Created
+		result.Stats.Updated += pullStats.Updated
+		result.Stats.Skipped += pullStats.Skipped
+
+		if !githubSyncDryRun {
+			_, _ = fmt.Fprintf(out, "✓ Pulled %d issues (%d created, %d updated)\n",
+				result.Stats.Pulled, pullStats.Created, pullStats.Updated)
+		}
+	}
+
+	// Detect conflicts before push
+	var conflicts []gh.Conflict
+	skipUpdateIDs := make(map[string]bool)
+	forceUpdateIDs := make(map[string]bool)
+
+	if pull && push && !githubSyncDryRun {
+		var localIssues []*types.Issue
+		if syncCtx.Store() != nil {
+			var err error
+			localIssues, err = syncCtx.Store().SearchIssues(ctx, "", types.IssueFilter{})
+			if err != nil {
+				_, _ = fmt.Fprintf(out, "Warning: failed to get local issues for conflict detection: %v\n", err)
+			} else {
+				conflicts, err = detectGitHubConflictsWithContext(ctx, syncCtx, client, localIssues)
+				if err != nil {
+					_, _ = fmt.Fprintf(out, "Warning: failed to detect conflicts: %v\n", err)
+				} else if len(conflicts) > 0 {
+					for _, c := range conflicts {
+						switch conflictStrategy {
+						case GitHubConflictPreferLocal:
+							forceUpdateIDs[c.IssueID] = true
+						case GitHubConflictPreferGitHub:
+							skipUpdateIDs[c.IssueID] = true
+						case GitHubConflictPreferNewer:
+							if c.LocalUpdated.After(c.GitHubUpdated) {
+								forceUpdateIDs[c.IssueID] = true
+							} else {
+								skipUpdateIDs[c.IssueID] = true
+							}
+						}
+					}
+					_, _ = fmt.Fprintf(out, "→ Detected %d conflicts (strategy: %s)\n", len(conflicts), conflictStrategy)
+				}
+			}
+		}
+	}
+
+	// Push to GitHub
+	if push {
+		if githubSyncDryRun {
+			_, _ = fmt.Fprintln(out, "→ [DRY RUN] Would push issues to GitHub")
+		} else {
+			_, _ = fmt.Fprintln(out, "→ Pushing issues to GitHub...")
+		}
+
+		var localIssues []*types.Issue
+		if syncCtx.Store() != nil {
+			var err error
+			localIssues, err = syncCtx.Store().SearchIssues(ctx, "", types.IssueFilter{})
+			if err != nil {
+				return fmt.Errorf("failed to get local issues: %w", err)
+			}
+		}
+
+		pushStats, err := doPushToGitHubWithContext(ctx, syncCtx, client, config.Owner, config.Repo, mappingConfig, localIssues, githubSyncDryRun, false, forceUpdateIDs, skipUpdateIDs)
+		if err != nil {
+			result.Success = false
+			result.Error = err.Error()
+			_, _ = fmt.Fprintf(out, "Error pushing to GitHub: %v\n", err)
+			return err
+		}
+
+		result.Stats.Pushed = pushStats.Created + pushStats.Updated
+		result.Stats.Created += pushStats.Created
+		result.Stats.Updated += pushStats.Updated
+		result.Stats.Skipped += pushStats.Skipped
+
+		if !githubSyncDryRun {
+			_, _ = fmt.Fprintf(out, "✓ Pushed %d issues (%d created, %d updated)\n",
+				result.Stats.Pushed, pushStats.Created, pushStats.Updated)
+		}
+	}
+
+	// Resolve conflicts where GitHub won
+	if len(skipUpdateIDs) > 0 && !githubSyncDryRun {
+		_, _ = fmt.Fprintf(out, "→ Updating %d local issues from GitHub...\n", len(skipUpdateIDs))
+		var conflictsToResolve []gh.Conflict
+		for _, c := range conflicts {
+			if skipUpdateIDs[c.IssueID] {
+				conflictsToResolve = append(conflictsToResolve, c)
+			}
+		}
+		if err := resolveGitHubConflictsWithContext(ctx, syncCtx, client, config.Owner, config.Repo, mappingConfig, conflictsToResolve, conflictStrategy); err != nil {
+			_, _ = fmt.Fprintf(out, "Warning: failed to resolve some conflicts: %v\n", err)
+		} else {
+			_, _ = fmt.Fprintf(out, "✓ Updated %d local issues\n", len(conflictsToResolve))
+		}
+		result.Stats.Conflicts = len(conflicts)
+	}
+
+	if githubSyncDryRun {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out, "Run without --dry-run to apply changes")
+	}
+
+	return nil
+}
+
+// parseGitHubSourceSystem parses a source system string like "github:owner/repo:42".
+// Returns owner, repo, number, and ok (whether it's a valid GitHub source).
+func parseGitHubSourceSystem(sourceSystem string) (owner, repo string, number int, ok bool) {
+	if !strings.HasPrefix(sourceSystem, "github:") {
+		return "", "", 0, false
+	}
+
+	parts := strings.Split(sourceSystem, ":")
+	if len(parts) != 3 {
+		return "", "", 0, false
+	}
+
+	ownerRepo := strings.SplitN(parts[1], "/", 2)
+	if len(ownerRepo) != 2 {
+		return "", "", 0, false
+	}
+
+	n, err := fmt.Sscanf(parts[2], "%d", &number)
+	if err != nil || n != 1 {
+		return "", "", 0, false
+	}
+
+	return ownerRepo[0], ownerRepo[1], number, true
+}

--- a/cmd/bd/github_sync.go
+++ b/cmd/bd/github_sync.go
@@ -1,0 +1,397 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	gh "github.com/steveyegge/beads/internal/github"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// GitHubConflictStrategy defines how to resolve conflicts between local and GitHub versions.
+type GitHubConflictStrategy string
+
+const (
+	GitHubConflictPreferNewer  GitHubConflictStrategy = "prefer-newer"
+	GitHubConflictPreferLocal  GitHubConflictStrategy = "prefer-local"
+	GitHubConflictPreferGitHub GitHubConflictStrategy = "prefer-github"
+)
+
+// getGitHubConflictStrategy determines the conflict strategy from flag values.
+func getGitHubConflictStrategy(preferLocal, preferGitHub, preferNewer bool) (GitHubConflictStrategy, error) {
+	flagsSet := 0
+	if preferLocal {
+		flagsSet++
+	}
+	if preferGitHub {
+		flagsSet++
+	}
+	if preferNewer {
+		flagsSet++
+	}
+	if flagsSet > 1 {
+		return "", fmt.Errorf("cannot use multiple conflict resolution flags")
+	}
+
+	if preferLocal {
+		return GitHubConflictPreferLocal, nil
+	}
+	if preferGitHub {
+		return GitHubConflictPreferGitHub, nil
+	}
+	return GitHubConflictPreferNewer, nil
+}
+
+// doPullFromGitHubWithContext imports issues from GitHub using SyncContext.
+func doPullFromGitHubWithContext(ctx context.Context, syncCtx *SyncContext, client *gh.Client, owner, repo string, config *gh.MappingConfig, dryRun bool, state string, skipGitHubNumbers map[int]bool) (*gh.PullStats, error) {
+	stats := &gh.PullStats{}
+
+	var githubIssues []gh.Issue
+	var err error
+
+	lastSyncStr := ""
+	if syncCtx.store != nil {
+		lastSyncStr, _ = syncCtx.store.GetConfig(ctx, "github.last_sync")
+	}
+
+	if lastSyncStr != "" {
+		lastSync, parseErr := time.Parse(time.RFC3339, lastSyncStr)
+		if parseErr != nil {
+			fmt.Printf("Warning: invalid github.last_sync timestamp, doing full sync\n")
+			githubIssues, err = client.FetchIssues(ctx, state)
+		} else {
+			stats.Incremental = true
+			stats.SyncedSince = lastSyncStr
+			githubIssues, err = client.FetchIssuesSince(ctx, state, lastSync)
+			if !dryRun {
+				fmt.Printf("  Incremental sync since %s\n", lastSync.Format("2006-01-02 15:04:05"))
+			}
+		}
+	} else {
+		githubIssues, err = client.FetchIssues(ctx, state)
+		if !dryRun {
+			fmt.Println("  Full sync (no previous sync timestamp)")
+		}
+	}
+
+	if err != nil {
+		return stats, fmt.Errorf("failed to fetch issues from GitHub: %w", err)
+	}
+
+	var beadsIssues []*types.Issue
+	githubNumToBeadsID := make(map[int]string)
+
+	for _, ghIssue := range githubIssues {
+		if skipGitHubNumbers != nil && skipGitHubNumbers[ghIssue.Number] {
+			stats.Skipped++
+			continue
+		}
+
+		conversion := gh.GitHubIssueToBeads(&ghIssue, owner, repo, config)
+		beadsIssue := conversion.Issue
+
+		// Check if this issue already exists in local DB
+		if syncCtx.store != nil {
+			existingIssues, searchErr := syncCtx.store.SearchIssues(ctx, "", types.IssueFilter{})
+			if searchErr == nil {
+				for _, existing := range existingIssues {
+					if existing.SourceSystem == beadsIssue.SourceSystem {
+						beadsIssue.ID = existing.ID
+						break
+					}
+				}
+			}
+		}
+
+		// Generate ID if new
+		if beadsIssue.ID == "" {
+			prefix := "bd"
+			if syncCtx.store != nil {
+				if p, err := syncCtx.store.GetConfig(ctx, "issue_prefix"); err == nil && p != "" {
+					prefix = p
+				}
+			}
+			beadsIssue.ID = syncCtx.GenerateIssueID(prefix)
+		}
+
+		beadsIssues = append(beadsIssues, beadsIssue)
+		githubNumToBeadsID[ghIssue.Number] = beadsIssue.ID
+	}
+
+	if dryRun {
+		for _, issue := range beadsIssues {
+			fmt.Printf("  Would import: %s - %s\n", issue.ID, issue.Title)
+		}
+		stats.Created = len(beadsIssues)
+		return stats, nil
+	}
+
+	// Import issues into store
+	if syncCtx.store != nil {
+		for _, issue := range beadsIssues {
+			existingIssue, getErr := syncCtx.store.GetIssue(ctx, issue.ID)
+			if getErr != nil || existingIssue == nil {
+				if err := syncCtx.store.CreateIssue(ctx, issue, syncCtx.actor); err != nil {
+					if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate") {
+						stats.Skipped++
+					} else {
+						fmt.Printf("Warning: failed to create issue %s: %v\n", issue.ID, err)
+						stats.Skipped++
+					}
+					continue
+				}
+				stats.Created++
+			} else {
+				updates := map[string]interface{}{
+					"title":         issue.Title,
+					"description":   issue.Description,
+					"status":        string(issue.Status),
+					"priority":      issue.Priority,
+					"issue_type":    string(issue.IssueType),
+					"assignee":      issue.Assignee,
+					"external_ref":  ptrToString(issue.ExternalRef),
+					"source_system": issue.SourceSystem,
+				}
+				if err := syncCtx.store.UpdateIssue(ctx, issue.ID, updates, syncCtx.actor); err != nil {
+					fmt.Printf("Warning: failed to update issue %s: %v\n", issue.ID, err)
+				} else {
+					stats.Updated++
+				}
+			}
+		}
+
+		// Build mapping for existing issues
+		allIssues, searchErr := syncCtx.store.SearchIssues(ctx, "", types.IssueFilter{})
+		if searchErr == nil {
+			for _, issue := range allIssues {
+				if issue.SourceSystem != "" && strings.HasPrefix(issue.SourceSystem, "github:") {
+					_, _, num, ok := parseGitHubSourceSystem(issue.SourceSystem)
+					if ok {
+						githubNumToBeadsID[num] = issue.ID
+					}
+				}
+			}
+		}
+
+		// Update last sync timestamp
+		if err := syncCtx.store.SetConfig(ctx, "github.last_sync", time.Now().UTC().Format(time.RFC3339)); err != nil {
+			warning := fmt.Sprintf("failed to save github.last_sync: %v (next sync will be full instead of incremental)", err)
+			stats.Warnings = append(stats.Warnings, warning)
+			fmt.Printf("Warning: %s\n", warning)
+		}
+	} else {
+		stats.Created = len(beadsIssues)
+	}
+
+	return stats, nil
+}
+
+// doPushToGitHubWithContext pushes local beads issues to GitHub using SyncContext.
+func doPushToGitHubWithContext(ctx context.Context, syncCtx *SyncContext, client *gh.Client, owner, repo string, config *gh.MappingConfig, localIssues []*types.Issue, dryRun, createOnly bool, _ /* forceUpdateIDs */, skipUpdateIDs map[string]bool) (*gh.PushStats, error) {
+	stats := &gh.PushStats{}
+
+	for _, issue := range localIssues {
+		_, _, number, isGitHub := parseGitHubSourceSystem(issue.SourceSystem)
+
+		if !isGitHub || number == 0 {
+			// New issue - create in GitHub
+			if dryRun {
+				fmt.Printf("  Would create: %s - %s\n", issue.ID, issue.Title)
+				continue
+			}
+
+			fields := gh.BeadsIssueToGitHubFields(issue, config)
+			labels, _ := fields["labels"].([]string)
+
+			created, err := client.CreateIssue(ctx, issue.Title, issue.Description, labels)
+			if err != nil {
+				stats.Errors++
+				fmt.Printf("Error creating issue %s: %v\n", issue.ID, err)
+				continue
+			}
+
+			// Update local issue with GitHub reference
+			if syncCtx.store != nil {
+				sourceSystem := fmt.Sprintf("github:%s/%s:%d", owner, repo, created.Number)
+				updates := map[string]interface{}{
+					"external_ref":  created.HTMLURL,
+					"source_system": sourceSystem,
+				}
+				if err := syncCtx.store.UpdateIssue(ctx, issue.ID, updates, syncCtx.actor); err != nil {
+					fmt.Printf("Warning: failed to update local issue %s with GitHub ref: %v\n", issue.ID, err)
+				}
+			}
+
+			stats.Created++
+			fmt.Printf("  Created GitHub #%d: %s\n", created.Number, issue.Title)
+		} else {
+			// Existing issue - update in GitHub
+			if createOnly {
+				stats.Skipped++
+				continue
+			}
+
+			if skipUpdateIDs != nil && skipUpdateIDs[issue.ID] {
+				stats.Skipped++
+				continue
+			}
+
+			if dryRun {
+				fmt.Printf("  Would update: %s - %s (GitHub #%d)\n", issue.ID, issue.Title, number)
+				continue
+			}
+
+			// Verify we're updating the right repo
+			srcOwner, srcRepo, _, _ := parseGitHubSourceSystem(issue.SourceSystem)
+			if srcOwner != owner || srcRepo != repo {
+				stats.Skipped++
+				continue
+			}
+
+			fields := gh.BeadsIssueToGitHubFields(issue, config)
+			_, err := client.UpdateIssue(ctx, number, fields)
+			if err != nil {
+				stats.Errors++
+				fmt.Printf("Error updating issue %s: %v\n", issue.ID, err)
+				continue
+			}
+
+			stats.Updated++
+			fmt.Printf("  Updated GitHub #%d: %s\n", number, issue.Title)
+		}
+	}
+
+	return stats, nil
+}
+
+// detectGitHubConflictsWithContext finds conflicts using SyncContext.
+func detectGitHubConflictsWithContext(ctx context.Context, _ *SyncContext, client *gh.Client, localIssues []*types.Issue) ([]gh.Conflict, error) {
+	var conflicts []gh.Conflict
+
+	githubIssues, err := client.FetchIssues(ctx, "all")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch GitHub issues: %w", err)
+	}
+
+	githubByNumber := make(map[int]*gh.Issue)
+	for i := range githubIssues {
+		githubByNumber[githubIssues[i].Number] = &githubIssues[i]
+	}
+
+	for _, local := range localIssues {
+		_, _, number, isGitHub := parseGitHubSourceSystem(local.SourceSystem)
+		if !isGitHub || number == 0 {
+			continue
+		}
+
+		githubIssue, exists := githubByNumber[number]
+		if !exists {
+			continue
+		}
+
+		if githubIssue.UpdatedAt != nil && !local.UpdatedAt.IsZero() {
+			localTime := local.UpdatedAt
+			githubTime := *githubIssue.UpdatedAt
+
+			diff := localTime.Sub(githubTime)
+			if diff < -time.Second || diff > time.Second {
+				conflict := gh.Conflict{
+					IssueID:           local.ID,
+					LocalUpdated:      localTime,
+					GitHubUpdated:     githubTime,
+					GitHubExternalRef: githubIssue.HTMLURL,
+					GitHubNumber:      number,
+					GitHubID:          githubIssue.ID,
+				}
+				conflicts = append(conflicts, conflict)
+			}
+		}
+	}
+
+	return conflicts, nil
+}
+
+// resolveGitHubConflictsWithContext resolves conflicts using SyncContext.
+//
+//nolint:unparam // error return kept for API consistency
+func resolveGitHubConflictsWithContext(ctx context.Context, syncCtx *SyncContext, client *gh.Client, owner, repo string, config *gh.MappingConfig, conflicts []gh.Conflict, strategy GitHubConflictStrategy) error {
+	for _, conflict := range conflicts {
+		var useGitHub bool
+
+		switch strategy {
+		case GitHubConflictPreferLocal:
+			useGitHub = false
+		case GitHubConflictPreferGitHub:
+			useGitHub = true
+		case GitHubConflictPreferNewer:
+			useGitHub = conflict.GitHubUpdated.After(conflict.LocalUpdated)
+		default:
+			useGitHub = conflict.GitHubUpdated.After(conflict.LocalUpdated)
+		}
+
+		if useGitHub {
+			issue, err := client.FetchIssueByNumber(ctx, conflict.GitHubNumber)
+			if err != nil {
+				fmt.Printf("Warning: failed to fetch GitHub issue #%d: %v\n", conflict.GitHubNumber, err)
+				continue
+			}
+
+			conversion := gh.GitHubIssueToBeads(issue, owner, repo, config)
+			beadsIssue := conversion.Issue
+
+			if syncCtx.store != nil {
+				updates := map[string]interface{}{
+					"title":       beadsIssue.Title,
+					"description": beadsIssue.Description,
+					"status":      string(beadsIssue.Status),
+					"priority":    beadsIssue.Priority,
+					"issue_type":  string(beadsIssue.IssueType),
+					"assignee":    beadsIssue.Assignee,
+				}
+				if err := syncCtx.store.UpdateIssue(ctx, conflict.IssueID, updates, syncCtx.actor); err != nil {
+					fmt.Printf("Warning: failed to update local issue %s: %v\n", conflict.IssueID, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// ptrToString safely dereferences a string pointer.
+func ptrToString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// Convenience wrappers using global variables (for tests).
+
+func doPullFromGitHub(ctx context.Context, client *gh.Client, owner, repo string, config *gh.MappingConfig, dryRun bool, state string, skipNumbers map[int]bool) (*gh.PullStats, error) {
+	syncCtx := NewSyncContext()
+	syncCtx.SetStore(store)
+	syncCtx.SetActor(actor)
+	syncCtx.SetDBPath(dbPath)
+	return doPullFromGitHubWithContext(ctx, syncCtx, client, owner, repo, config, dryRun, state, skipNumbers)
+}
+
+func doPushToGitHub(ctx context.Context, client *gh.Client, owner, repo string, config *gh.MappingConfig, localIssues []*types.Issue, dryRun, createOnly bool, forceUpdateIDs, skipUpdateIDs map[string]bool) (*gh.PushStats, error) {
+	syncCtx := NewSyncContext()
+	syncCtx.SetStore(store)
+	syncCtx.SetActor(actor)
+	syncCtx.SetDBPath(dbPath)
+	return doPushToGitHubWithContext(ctx, syncCtx, client, owner, repo, config, localIssues, dryRun, createOnly, forceUpdateIDs, skipUpdateIDs)
+}
+
+func detectGitHubConflicts(ctx context.Context, client *gh.Client, localIssues []*types.Issue) ([]gh.Conflict, error) {
+	syncCtx := NewSyncContext()
+	syncCtx.SetStore(store)
+	syncCtx.SetActor(actor)
+	syncCtx.SetDBPath(dbPath)
+	return detectGitHubConflictsWithContext(ctx, syncCtx, client, localIssues)
+}
+
+

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,343 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// NewClient creates a new GitHub client.
+func NewClient(token, owner, repo string) *Client {
+	return &Client{
+		Token:   token,
+		Owner:   owner,
+		Repo:    repo,
+		BaseURL: DefaultAPIEndpoint,
+		HTTPClient: &http.Client{
+			Timeout: DefaultTimeout,
+		},
+	}
+}
+
+// WithHTTPClient returns a new client with a custom HTTP client.
+func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
+	return &Client{
+		Token:      c.Token,
+		Owner:      c.Owner,
+		Repo:       c.Repo,
+		BaseURL:    c.BaseURL,
+		HTTPClient: httpClient,
+	}
+}
+
+// WithBaseURL returns a new client with a custom base URL (for testing or GitHub Enterprise).
+func (c *Client) WithBaseURL(baseURL string) *Client {
+	return &Client{
+		Token:      c.Token,
+		Owner:      c.Owner,
+		Repo:       c.Repo,
+		BaseURL:    baseURL,
+		HTTPClient: c.HTTPClient,
+	}
+}
+
+// repoPath returns the "owner/repo" path segment.
+func (c *Client) repoPath() string {
+	return c.Owner + "/" + c.Repo
+}
+
+// buildURL constructs a full API URL.
+func (c *Client) buildURL(path string, params map[string]string) string {
+	u := c.BaseURL + path
+
+	if len(params) > 0 {
+		values := url.Values{}
+		for k, v := range params {
+			values.Set(k, v)
+		}
+		u += "?" + values.Encode()
+	}
+
+	return u
+}
+
+// doRequest performs an HTTP request with authentication and retry logic.
+func (c *Client) doRequest(ctx context.Context, method, urlStr string, body interface{}) ([]byte, http.Header, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonBody)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= MaxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, method, urlStr, reqBody)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed (attempt %d/%d): %w", attempt+1, MaxRetries+1, err)
+			continue
+		}
+
+		const maxResponseSize = 50 * 1024 * 1024
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		_ = resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("failed to read response (attempt %d/%d): %w", attempt+1, MaxRetries+1, err)
+			continue
+		}
+
+		// Handle rate limiting (GitHub uses 403 with X-RateLimit-Remaining: 0, or 429)
+		if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-RateLimit-Remaining") == "0") {
+			delay := RetryDelay * time.Duration(1<<attempt)
+			if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+				if seconds, err := strconv.Atoi(retryAfter); err == nil {
+					delay = time.Duration(seconds) * time.Second
+				}
+			}
+			lastErr = fmt.Errorf("rate limited (attempt %d/%d)", attempt+1, MaxRetries+1)
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			case <-time.After(delay):
+				if body != nil {
+					jsonBody, err := json.Marshal(body)
+					if err != nil {
+						lastErr = fmt.Errorf("retry marshal failed: %w", err)
+						continue
+					}
+					reqBody = bytes.NewReader(jsonBody)
+				}
+				continue
+			}
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, nil, fmt.Errorf("API error: %s (status %d)", string(respBody), resp.StatusCode)
+		}
+
+		return respBody, resp.Header, nil
+	}
+
+	return nil, nil, fmt.Errorf("max retries (%d) exceeded: %w", MaxRetries+1, lastErr)
+}
+
+// linkNextPattern matches the "next" relation in GitHub Link headers.
+var linkNextPattern = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
+
+// hasNextPage checks the Link header for a next page URL and returns it.
+func hasNextPage(headers http.Header) (string, bool) {
+	link := headers.Get("Link")
+	if link == "" {
+		return "", false
+	}
+	matches := linkNextPattern.FindStringSubmatch(link)
+	if len(matches) < 2 {
+		return "", false
+	}
+	return matches[1], true
+}
+
+// FetchIssues retrieves issues from GitHub with optional state filtering.
+// state can be: "open", "closed", or "all".
+// This filters out pull requests (GitHub returns PRs in the issues endpoint).
+func (c *Client) FetchIssues(ctx context.Context, state string) ([]Issue, error) {
+	var allIssues []Issue
+	page := 1
+
+	for {
+		select {
+		case <-ctx.Done():
+			return allIssues, ctx.Err()
+		default:
+		}
+
+		params := map[string]string{
+			"per_page": strconv.Itoa(MaxPageSize),
+			"page":     strconv.Itoa(page),
+		}
+		if state != "" && state != "all" {
+			params["state"] = state
+		} else {
+			params["state"] = "all"
+		}
+
+		urlStr := c.buildURL("/repos/"+c.repoPath()+"/issues", params)
+		respBody, headers, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch issues: %w", err)
+		}
+
+		var issues []Issue
+		if err := json.Unmarshal(respBody, &issues); err != nil {
+			return nil, fmt.Errorf("failed to parse issues response: %w", err)
+		}
+
+		for i := range issues {
+			if issues[i].PullRequest == nil {
+				allIssues = append(allIssues, issues[i])
+			}
+		}
+
+		if _, ok := hasNextPage(headers); !ok {
+			break
+		}
+		page++
+
+		if page > MaxPages {
+			return nil, fmt.Errorf("pagination limit exceeded: stopped after %d pages", MaxPages)
+		}
+	}
+
+	return allIssues, nil
+}
+
+// FetchIssuesSince retrieves issues updated since the given time.
+func (c *Client) FetchIssuesSince(ctx context.Context, state string, since time.Time) ([]Issue, error) {
+	var allIssues []Issue
+	page := 1
+	sinceStr := since.UTC().Format(time.RFC3339)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return allIssues, ctx.Err()
+		default:
+		}
+
+		params := map[string]string{
+			"per_page": strconv.Itoa(MaxPageSize),
+			"page":     strconv.Itoa(page),
+			"since":    sinceStr,
+		}
+		if state != "" && state != "all" {
+			params["state"] = state
+		} else {
+			params["state"] = "all"
+		}
+
+		urlStr := c.buildURL("/repos/"+c.repoPath()+"/issues", params)
+		respBody, headers, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch issues since %s: %w", sinceStr, err)
+		}
+
+		var issues []Issue
+		if err := json.Unmarshal(respBody, &issues); err != nil {
+			return nil, fmt.Errorf("failed to parse issues response: %w", err)
+		}
+
+		for i := range issues {
+			if issues[i].PullRequest == nil {
+				allIssues = append(allIssues, issues[i])
+			}
+		}
+
+		if _, ok := hasNextPage(headers); !ok {
+			break
+		}
+		page++
+
+		if page > MaxPages {
+			return nil, fmt.Errorf("pagination limit exceeded: stopped after %d pages", MaxPages)
+		}
+	}
+
+	return allIssues, nil
+}
+
+// CreateIssue creates a new issue in GitHub.
+func (c *Client) CreateIssue(ctx context.Context, title, body string, labels []string) (*Issue, error) {
+	reqBody := map[string]interface{}{
+		"title": title,
+		"body":  body,
+	}
+	if len(labels) > 0 {
+		reqBody["labels"] = labels
+	}
+
+	urlStr := c.buildURL("/repos/"+c.repoPath()+"/issues", nil)
+	respBody, _, err := c.doRequest(ctx, http.MethodPost, urlStr, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue: %w", err)
+	}
+
+	var issue Issue
+	if err := json.Unmarshal(respBody, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse create response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+// UpdateIssue updates an existing issue in GitHub.
+// GitHub uses PATCH for issue updates.
+func (c *Client) UpdateIssue(ctx context.Context, number int, updates map[string]interface{}) (*Issue, error) {
+	urlStr := c.buildURL("/repos/"+c.repoPath()+"/issues/"+strconv.Itoa(number), nil)
+	respBody, _, err := c.doRequest(ctx, http.MethodPatch, urlStr, updates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update issue: %w", err)
+	}
+
+	var issue Issue
+	if err := json.Unmarshal(respBody, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse update response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+// FetchIssueByNumber retrieves a single issue by its number.
+func (c *Client) FetchIssueByNumber(ctx context.Context, number int) (*Issue, error) {
+	urlStr := c.buildURL("/repos/"+c.repoPath()+"/issues/"+strconv.Itoa(number), nil)
+	respBody, _, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch issue #%d: %w", number, err)
+	}
+
+	var issue Issue
+	if err := json.Unmarshal(respBody, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse issue response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+// ListRepositories retrieves repositories accessible to the authenticated user.
+func (c *Client) ListRepositories(ctx context.Context) ([]Repository, error) {
+	params := map[string]string{
+		"per_page": "100",
+		"sort":     "updated",
+	}
+	urlStr := c.buildURL("/user/repos", params)
+	respBody, _, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list repositories: %w", err)
+	}
+
+	var repos []Repository
+	if err := json.Unmarshal(respBody, &repos); err != nil {
+		return nil, fmt.Errorf("failed to parse repositories response: %w", err)
+	}
+
+	return repos, nil
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,506 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestNewClient verifies the constructor creates a properly configured client.
+func TestNewClient(t *testing.T) {
+	client := NewClient("test-token", "owner", "repo")
+
+	if client.Token != "test-token" {
+		t.Errorf("Token = %q, want %q", client.Token, "test-token")
+	}
+	if client.Owner != "owner" {
+		t.Errorf("Owner = %q, want %q", client.Owner, "owner")
+	}
+	if client.Repo != "repo" {
+		t.Errorf("Repo = %q, want %q", client.Repo, "repo")
+	}
+	if client.BaseURL != DefaultAPIEndpoint {
+		t.Errorf("BaseURL = %q, want %q", client.BaseURL, DefaultAPIEndpoint)
+	}
+	if client.HTTPClient == nil {
+		t.Error("HTTPClient is nil, want non-nil default client")
+	}
+}
+
+// TestClientWithHTTPClient verifies the builder pattern for custom HTTP client.
+func TestClientWithHTTPClient(t *testing.T) {
+	customClient := &http.Client{Timeout: 60 * time.Second}
+	client := NewClient("token", "owner", "repo").WithHTTPClient(customClient)
+
+	if client.HTTPClient != customClient {
+		t.Error("HTTPClient not set to custom client")
+	}
+	if client.Token != "token" {
+		t.Errorf("Token = %q, want %q", client.Token, "token")
+	}
+}
+
+// TestClientWithBaseURL verifies custom base URL setting.
+func TestClientWithBaseURL(t *testing.T) {
+	client := NewClient("token", "owner", "repo").WithBaseURL("https://github.example.com/api/v3")
+
+	if client.BaseURL != "https://github.example.com/api/v3" {
+		t.Errorf("BaseURL = %q, want custom URL", client.BaseURL)
+	}
+	if client.Owner != "owner" {
+		t.Errorf("Owner = %q, want %q", client.Owner, "owner")
+	}
+}
+
+// TestBuildURL verifies URL construction for API endpoints.
+func TestBuildURL(t *testing.T) {
+	client := NewClient("token", "owner", "repo")
+
+	tests := []struct {
+		name    string
+		path    string
+		params  map[string]string
+		wantURL string
+	}{
+		{
+			name:    "issues endpoint",
+			path:    "/repos/owner/repo/issues",
+			params:  nil,
+			wantURL: "https://api.github.com/repos/owner/repo/issues",
+		},
+		{
+			name:    "with query params",
+			path:    "/repos/owner/repo/issues",
+			params:  map[string]string{"state": "open", "per_page": "100"},
+			wantURL: "https://api.github.com/repos/owner/repo/issues",
+		},
+		{
+			name:    "single issue",
+			path:    "/repos/owner/repo/issues/42",
+			params:  nil,
+			wantURL: "https://api.github.com/repos/owner/repo/issues/42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.buildURL(tt.path, tt.params)
+			if !strings.HasPrefix(got, tt.wantURL) {
+				t.Errorf("buildURL(%q) = %q, want prefix %q", tt.path, got, tt.wantURL)
+			}
+			for k, v := range tt.params {
+				if !strings.Contains(got, k+"="+v) {
+					t.Errorf("buildURL missing param %s=%s in %q", k, v, got)
+				}
+			}
+		})
+	}
+}
+
+// TestFetchIssues_Success verifies fetching issues from GitHub API.
+func TestFetchIssues_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Method = %s, want GET", r.Method)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("Authorization header = %q, want Bearer prefix", r.Header.Get("Authorization"))
+		}
+		if !strings.Contains(r.URL.Path, "/repos/owner/repo/issues") {
+			t.Errorf("URL path = %s, want to contain /repos/owner/repo/issues", r.URL.Path)
+		}
+
+		issues := []Issue{
+			{ID: 1, Number: 1, Title: "First issue", State: "open"},
+			{ID: 2, Number: 2, Title: "Second issue", State: "open"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	issues, err := client.FetchIssues(ctx, "open")
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if len(issues) != 2 {
+		t.Errorf("FetchIssues() returned %d issues, want 2", len(issues))
+	}
+	if issues[0].Title != "First issue" {
+		t.Errorf("issues[0].Title = %q, want %q", issues[0].Title, "First issue")
+	}
+}
+
+// TestFetchIssues_FiltersPullRequests verifies PRs are filtered out.
+func TestFetchIssues_FiltersPullRequests(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		issues := []Issue{
+			{ID: 1, Number: 1, Title: "Issue", State: "open"},
+			{ID: 2, Number: 2, Title: "PR", State: "open", PullRequest: &PullRef{URL: "https://api.github.com/repos/o/r/pulls/2"}},
+			{ID: 3, Number: 3, Title: "Another issue", State: "open"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(issues)
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	issues, err := client.FetchIssues(ctx, "open")
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if len(issues) != 2 {
+		t.Errorf("FetchIssues() returned %d issues, want 2 (PR filtered)", len(issues))
+	}
+}
+
+// TestFetchIssues_Pagination verifies client handles paginated responses via Link header.
+func TestFetchIssues_Pagination(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page++
+		w.Header().Set("Content-Type", "application/json")
+
+		if page == 1 {
+			w.Header().Set("Link", `<`+r.URL.String()+`?page=2>; rel="next"`)
+			issues := []Issue{{ID: 1, Number: 1, Title: "Issue 1"}}
+			_ = json.NewEncoder(w).Encode(issues)
+		} else {
+			issues := []Issue{{ID: 2, Number: 2, Title: "Issue 2"}}
+			_ = json.NewEncoder(w).Encode(issues)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	issues, err := client.FetchIssues(ctx, "all")
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if len(issues) != 2 {
+		t.Errorf("FetchIssues() returned %d issues, want 2 (from 2 pages)", len(issues))
+	}
+}
+
+// TestFetchIssuesSince verifies incremental sync with since param.
+func TestFetchIssuesSince(t *testing.T) {
+	since := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	var capturedURL string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	_, err := client.FetchIssuesSince(ctx, "all", since)
+	if err != nil {
+		t.Fatalf("FetchIssuesSince() error = %v", err)
+	}
+
+	if !strings.Contains(capturedURL, "since=2024-01-15") {
+		t.Errorf("URL = %s, want to contain since=2024-01-15", capturedURL)
+	}
+}
+
+// TestCreateIssue_Success verifies creating an issue via POST.
+func TestCreateIssue_Success(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %s, want POST", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/repos/owner/repo/issues") {
+			t.Errorf("URL path = %s, want to contain /repos/owner/repo/issues", r.URL.Path)
+		}
+
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(Issue{
+			ID:     100,
+			Number: 42,
+			Title:  "New issue",
+			State:  "open",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	issue, err := client.CreateIssue(ctx, "New issue", "Description here", []string{"bug", "priority:high"})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+
+	if issue.Number != 42 {
+		t.Errorf("issue.Number = %d, want 42", issue.Number)
+	}
+	if capturedBody["title"] != "New issue" {
+		t.Errorf("request body title = %v, want %q", capturedBody["title"], "New issue")
+	}
+	if capturedBody["body"] != "Description here" {
+		t.Errorf("request body body = %v, want %q", capturedBody["body"], "Description here")
+	}
+}
+
+// TestUpdateIssue_Success verifies updating an issue via PATCH.
+func TestUpdateIssue_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("Method = %s, want PATCH", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/repos/owner/repo/issues/42") {
+			t.Errorf("URL path = %s, want to contain /repos/owner/repo/issues/42", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Issue{
+			ID:     100,
+			Number: 42,
+			Title:  "Updated title",
+			State:  "open",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	issue, err := client.UpdateIssue(ctx, 42, map[string]interface{}{
+		"title": "Updated title",
+	})
+	if err != nil {
+		t.Fatalf("UpdateIssue() error = %v", err)
+	}
+
+	if issue.Title != "Updated title" {
+		t.Errorf("issue.Title = %q, want %q", issue.Title, "Updated title")
+	}
+}
+
+// TestFetchIssueByNumber_Success verifies fetching a single issue.
+func TestFetchIssueByNumber_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/repos/owner/repo/issues/42") {
+			t.Errorf("URL path = %s, want to contain /repos/owner/repo/issues/42", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Issue{
+			ID:     100,
+			Number: 42,
+			Title:  "Test issue",
+			State:  "open",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	issue, err := client.FetchIssueByNumber(ctx, 42)
+	if err != nil {
+		t.Fatalf("FetchIssueByNumber() error = %v", err)
+	}
+
+	if issue.Number != 42 {
+		t.Errorf("issue.Number = %d, want 42", issue.Number)
+	}
+}
+
+// TestFetchIssues_APIError verifies error handling for non-2xx responses.
+func TestFetchIssues_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message": "Server error"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	_, err := client.FetchIssues(ctx, "open")
+	if err == nil {
+		t.Fatal("FetchIssues() error = nil, want error for 500")
+	}
+}
+
+// TestFetchIssues_RateLimitRetry verifies rate limit handling with retry.
+func TestFetchIssues_RateLimitRetry(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts <= 2 {
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{{ID: 1, Number: 1, Title: "After retry"}})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	issues, err := client.FetchIssues(ctx, "open")
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v, want success after retries", err)
+	}
+
+	if attempts < 3 {
+		t.Errorf("attempts = %d, want >= 3 (initial + 2 retries)", attempts)
+	}
+	if len(issues) != 1 || issues[0].Title != "After retry" {
+		t.Errorf("unexpected issues after retry: %v", issues)
+	}
+}
+
+// TestHasNextPage verifies Link header parsing.
+func TestHasNextPage(t *testing.T) {
+	tests := []struct {
+		name     string
+		link     string
+		wantURL  string
+		wantNext bool
+	}{
+		{
+			name:     "has next page",
+			link:     `<https://api.github.com/repos/o/r/issues?page=2>; rel="next", <https://api.github.com/repos/o/r/issues?page=5>; rel="last"`,
+			wantURL:  "https://api.github.com/repos/o/r/issues?page=2",
+			wantNext: true,
+		},
+		{
+			name:     "no next page",
+			link:     `<https://api.github.com/repos/o/r/issues?page=1>; rel="prev"`,
+			wantURL:  "",
+			wantNext: false,
+		},
+		{
+			name:     "empty link header",
+			link:     "",
+			wantURL:  "",
+			wantNext: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := http.Header{}
+			if tt.link != "" {
+				headers.Set("Link", tt.link)
+			}
+			gotURL, gotNext := hasNextPage(headers)
+			if gotNext != tt.wantNext {
+				t.Errorf("hasNextPage() next = %v, want %v", gotNext, tt.wantNext)
+			}
+			if gotURL != tt.wantURL {
+				t.Errorf("hasNextPage() url = %q, want %q", gotURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+// TestFetchIssues_PaginationLimit verifies that FetchIssues stops after MaxPages.
+func TestFetchIssues_PaginationLimit(t *testing.T) {
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<http://example.com?page=999>; rel="next"`)
+		_ = json.NewEncoder(w).Encode([]Issue{{ID: requestCount, Number: requestCount, Title: "Issue"}})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	_, err := client.FetchIssues(ctx, "all")
+
+	if err == nil {
+		t.Fatal("FetchIssues() error = nil, want pagination limit error")
+	}
+	if !strings.Contains(err.Error(), "pagination limit exceeded") {
+		t.Errorf("error = %v, want to contain 'pagination limit exceeded'", err)
+	}
+	if requestCount > MaxPages+1 {
+		t.Errorf("requestCount = %d, want <= %d (MaxPages+1)", requestCount, MaxPages+1)
+	}
+}
+
+// TestFetchIssues_ContextCancellation verifies context cancellation stops pagination.
+func TestFetchIssues_ContextCancellation(t *testing.T) {
+	var requestCount atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := requestCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", `<http://example.com?page=2>; rel="next"`)
+		_ = json.NewEncoder(w).Encode([]Issue{{ID: int(count), Number: int(count), Title: "Issue"}})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := client.FetchIssues(ctx, "all")
+
+	if err == nil {
+		t.Fatal("FetchIssues() error = nil, want error to stop infinite loop")
+	}
+
+	isContextCanceled := err == context.Canceled || strings.Contains(err.Error(), "context canceled")
+	isPaginationLimit := strings.Contains(err.Error(), "pagination limit exceeded")
+	if !isContextCanceled && !isPaginationLimit {
+		t.Errorf("error = %v, want context.Canceled or pagination limit exceeded", err)
+	}
+}
+
+// TestCreateIssue_InvalidJSON verifies JSON parse error handling.
+func TestCreateIssue_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{not valid json`))
+	}))
+	defer server.Close()
+
+	client := NewClient("token", "owner", "repo").WithBaseURL(server.URL)
+	ctx := context.Background()
+
+	_, err := client.CreateIssue(ctx, "Test", "Description", []string{})
+	if err == nil {
+		t.Fatal("CreateIssue() error = nil, want error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "failed to parse create response") {
+		t.Errorf("error = %v, want to contain 'failed to parse create response'", err)
+	}
+}

--- a/internal/github/mapping.go
+++ b/internal/github/mapping.go
@@ -1,0 +1,235 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// MappingConfig configures how GitHub fields map to beads fields.
+type MappingConfig struct {
+	PriorityMap  map[string]int    // priority label value → beads priority (0-4)
+	StateMap     map[string]string // GitHub state → beads status
+	LabelTypeMap map[string]string // type label value → beads issue type
+}
+
+// DefaultMappingConfig returns the default mapping configuration.
+func DefaultMappingConfig() *MappingConfig {
+	priorityMap := make(map[string]int, len(PriorityMapping))
+	for k, v := range PriorityMapping {
+		priorityMap[k] = v
+	}
+
+	labelTypeMap := make(map[string]string, len(TypeMapping))
+	for k, v := range TypeMapping {
+		labelTypeMap[k] = v
+	}
+
+	return &MappingConfig{
+		PriorityMap: priorityMap,
+		// GitHub uses "open"/"closed" (not "opened"/"closed" like GitLab)
+		StateMap: map[string]string{
+			"open":   "open",
+			"closed": "closed",
+		},
+		LabelTypeMap: labelTypeMap,
+	}
+}
+
+// PriorityFromLabels extracts priority from GitHub labels.
+// Returns default priority (2 = medium) if no priority label found.
+// Supports label formats: "priority:high", "priority/high", "P0", "P1", etc.
+func PriorityFromLabels(labels []Label, config *MappingConfig) int {
+	for _, label := range labels {
+		name := label.Name
+		// Check scoped format: "priority:high" or "priority/high"
+		prefix, value := ParseLabelName(name)
+		if prefix == "priority" {
+			if p, ok := config.PriorityMap[strings.ToLower(value)]; ok {
+				return p
+			}
+		}
+		// Check shorthand format: P0, P1, P2, P3, P4
+		upper := strings.ToUpper(name)
+		switch upper {
+		case "P0":
+			return 0
+		case "P1":
+			return 1
+		case "P2":
+			return 2
+		case "P3":
+			return 3
+		case "P4":
+			return 4
+		}
+	}
+	return 2 // Default to medium
+}
+
+// StatusFromLabelsAndState determines beads status from GitHub labels and state.
+// GitHub's closed state takes precedence over status labels.
+func StatusFromLabelsAndState(labels []Label, state string, config *MappingConfig) string {
+	// Closed state always wins
+	if state == "closed" {
+		return "closed"
+	}
+
+	// Check for status label
+	for _, label := range labels {
+		prefix, value := ParseLabelName(label.Name)
+		if prefix == "status" {
+			normalized := strings.ToLower(value)
+			if normalized == "in_progress" || normalized == "in-progress" {
+				return "in_progress"
+			}
+			if normalized == "blocked" {
+				return "blocked"
+			}
+			if normalized == "deferred" {
+				return "deferred"
+			}
+		}
+	}
+
+	// Default: map GitHub state to beads status
+	if s, ok := config.StateMap[state]; ok {
+		return s
+	}
+	return "open"
+}
+
+// TypeFromLabels extracts issue type from GitHub labels.
+// Checks scoped labels (type:bug, type/bug) and bare labels (bug).
+// Returns "task" if no type label found.
+func TypeFromLabels(labels []Label, config *MappingConfig) string {
+	for _, label := range labels {
+		prefix, value := ParseLabelName(label.Name)
+		if prefix == "type" {
+			if t, ok := config.LabelTypeMap[strings.ToLower(value)]; ok {
+				return t
+			}
+		}
+		// Also check bare labels (no prefix)
+		if prefix == "" {
+			if t, ok := config.LabelTypeMap[strings.ToLower(value)]; ok {
+				return t
+			}
+		}
+	}
+	return "task" // Default to task
+}
+
+// GitHubIssueToBeads converts a GitHub Issue to a beads Issue.
+func GitHubIssueToBeads(gh *Issue, owner, repo string, config *MappingConfig) *IssueConversion {
+	htmlURL := gh.HTMLURL
+	sourceSystem := fmt.Sprintf("github:%s/%s:%d", owner, repo, gh.Number)
+
+	labelNames := LabelNames(gh.Labels)
+
+	issue := &types.Issue{
+		Title:        gh.Title,
+		Description:  gh.Body,
+		ExternalRef:  &htmlURL,
+		SourceSystem: sourceSystem,
+		IssueType:    types.IssueType(TypeFromLabels(gh.Labels, config)),
+		Priority:     PriorityFromLabels(gh.Labels, config),
+		Status:       types.Status(StatusFromLabelsAndState(gh.Labels, gh.State, config)),
+		Labels:       FilterNonScopedLabels(labelNames),
+	}
+
+	// Set assignee from GitHub user
+	if gh.Assignee != nil {
+		issue.Assignee = gh.Assignee.Login
+	}
+
+	// Set timestamps
+	if gh.CreatedAt != nil {
+		issue.CreatedAt = *gh.CreatedAt
+	}
+	if gh.UpdatedAt != nil {
+		issue.UpdatedAt = *gh.UpdatedAt
+	}
+
+	return &IssueConversion{
+		Issue:        issue,
+		Dependencies: []DependencyInfo{},
+	}
+}
+
+// BeadsIssueToGitHubFields converts a beads Issue to GitHub API update fields.
+func BeadsIssueToGitHubFields(issue *types.Issue, config *MappingConfig) map[string]interface{} {
+	fields := map[string]interface{}{
+		"title": issue.Title,
+		"body":  issue.Description,
+	}
+
+	// Build labels from type, priority, and status
+	var labels []string
+
+	// Add type label
+	if issue.IssueType != "" {
+		labels = append(labels, "type:"+string(issue.IssueType))
+	}
+
+	// Add priority label
+	priorityLabel := priorityToLabel(issue.Priority)
+	if priorityLabel != "" {
+		labels = append(labels, "priority:"+priorityLabel)
+	}
+
+	// Add status label (if not open or closed - those are handled by state)
+	if issue.Status == types.StatusInProgress {
+		labels = append(labels, "status:in_progress")
+	} else if issue.Status == types.StatusBlocked {
+		labels = append(labels, "status:blocked")
+	} else if issue.Status == types.StatusDeferred {
+		labels = append(labels, "status:deferred")
+	}
+
+	// Add any existing non-scoped labels
+	labels = append(labels, issue.Labels...)
+
+	fields["labels"] = labels
+
+	// Set state for closed issues
+	if issue.Status == types.StatusClosed {
+		fields["state"] = "closed"
+	}
+
+	return fields
+}
+
+// priorityToLabel converts beads priority (0-4) to GitHub priority label value.
+func priorityToLabel(priority int) string {
+	switch priority {
+	case 0:
+		return "critical"
+	case 1:
+		return "high"
+	case 2:
+		return "medium"
+	case 3:
+		return "low"
+	case 4:
+		return "none"
+	default:
+		return "medium"
+	}
+}
+
+// FilterNonScopedLabels returns only labels without scoped prefixes.
+// Removes priority:*, status:*, and type:* labels.
+func FilterNonScopedLabels(labels []string) []string {
+	var filtered []string
+	for _, label := range labels {
+		prefix, _ := ParseLabelName(label)
+		if prefix == "priority" || prefix == "status" || prefix == "type" {
+			continue
+		}
+		filtered = append(filtered, label)
+	}
+	return filtered
+}

--- a/internal/github/mapping_test.go
+++ b/internal/github/mapping_test.go
@@ -1,0 +1,434 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestDefaultMappingConfig verifies the default configuration has proper mappings.
+func TestDefaultMappingConfig(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	if len(config.PriorityMap) == 0 {
+		t.Error("PriorityMap is empty, want default priority mappings")
+	}
+	if p, ok := config.PriorityMap["high"]; !ok || p != 1 {
+		t.Errorf("PriorityMap[\"high\"] = %d, want 1", p)
+	}
+
+	if len(config.StateMap) == 0 {
+		t.Error("StateMap is empty, want default state mappings")
+	}
+	// GitHub uses "open" not "opened"
+	if s, ok := config.StateMap["open"]; !ok || s != "open" {
+		t.Errorf("StateMap[\"open\"] = %q, want \"open\"", s)
+	}
+
+	if len(config.LabelTypeMap) == 0 {
+		t.Error("LabelTypeMap is empty, want default type mappings")
+	}
+	if typ, ok := config.LabelTypeMap["bug"]; !ok || typ != "bug" {
+		t.Errorf("LabelTypeMap[\"bug\"] = %q, want \"bug\"", typ)
+	}
+}
+
+// TestPriorityFromLabels verifies parsing priority labels.
+func TestPriorityFromLabels(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	tests := []struct {
+		name         string
+		labels       []Label
+		wantPriority int
+	}{
+		{
+			name:         "priority:critical",
+			labels:       []Label{{Name: "priority:critical"}, {Name: "bug"}},
+			wantPriority: 0,
+		},
+		{
+			name:         "priority:high",
+			labels:       []Label{{Name: "priority:high"}},
+			wantPriority: 1,
+		},
+		{
+			name:         "priority/medium (slash separator)",
+			labels:       []Label{{Name: "priority/medium"}},
+			wantPriority: 2,
+		},
+		{
+			name:         "P0 shorthand",
+			labels:       []Label{{Name: "P0"}},
+			wantPriority: 0,
+		},
+		{
+			name:         "P1 shorthand",
+			labels:       []Label{{Name: "P1"}},
+			wantPriority: 1,
+		},
+		{
+			name:         "P3 shorthand",
+			labels:       []Label{{Name: "p3"}},
+			wantPriority: 3,
+		},
+		{
+			name:         "no priority label defaults to medium",
+			labels:       []Label{{Name: "bug"}, {Name: "backend"}},
+			wantPriority: 2,
+		},
+		{
+			name:         "empty labels defaults to medium",
+			labels:       []Label{},
+			wantPriority: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PriorityFromLabels(tt.labels, config)
+			if got != tt.wantPriority {
+				t.Errorf("PriorityFromLabels() = %d, want %d", got, tt.wantPriority)
+			}
+		})
+	}
+}
+
+// TestStatusFromLabelsAndState verifies status determination.
+func TestStatusFromLabelsAndState(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	tests := []struct {
+		name       string
+		labels     []Label
+		state      string
+		wantStatus string
+	}{
+		{
+			name:       "status:in_progress overrides open state",
+			labels:     []Label{{Name: "status:in_progress"}},
+			state:      "open",
+			wantStatus: "in_progress",
+		},
+		{
+			name:       "status:in-progress with hyphen",
+			labels:     []Label{{Name: "status:in-progress"}},
+			state:      "open",
+			wantStatus: "in_progress",
+		},
+		{
+			name:       "status:blocked",
+			labels:     []Label{{Name: "status:blocked"}, {Name: "bug"}},
+			state:      "open",
+			wantStatus: "blocked",
+		},
+		{
+			name:       "status:deferred",
+			labels:     []Label{{Name: "status:deferred"}},
+			state:      "open",
+			wantStatus: "deferred",
+		},
+		{
+			name:       "closed state wins over status labels",
+			labels:     []Label{{Name: "status:in_progress"}},
+			state:      "closed",
+			wantStatus: "closed",
+		},
+		{
+			name:       "open state without status label",
+			labels:     []Label{{Name: "bug"}},
+			state:      "open",
+			wantStatus: "open",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StatusFromLabelsAndState(tt.labels, tt.state, config)
+			if got != tt.wantStatus {
+				t.Errorf("StatusFromLabelsAndState() = %q, want %q", got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestTypeFromLabels verifies parsing type labels.
+func TestTypeFromLabels(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	tests := []struct {
+		name     string
+		labels   []Label
+		wantType string
+	}{
+		{
+			name:     "type:bug",
+			labels:   []Label{{Name: "type:bug"}, {Name: "priority:high"}},
+			wantType: "bug",
+		},
+		{
+			name:     "type:feature",
+			labels:   []Label{{Name: "type:feature"}},
+			wantType: "feature",
+		},
+		{
+			name:     "type/task (slash separator)",
+			labels:   []Label{{Name: "type/task"}},
+			wantType: "task",
+		},
+		{
+			name:     "bare bug label (no prefix)",
+			labels:   []Label{{Name: "bug"}},
+			wantType: "bug",
+		},
+		{
+			name:     "enhancement maps to feature",
+			labels:   []Label{{Name: "enhancement"}},
+			wantType: "feature",
+		},
+		{
+			name:     "no type label defaults to task",
+			labels:   []Label{{Name: "priority:high"}},
+			wantType: "task",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TypeFromLabels(tt.labels, config)
+			if got != tt.wantType {
+				t.Errorf("TypeFromLabels() = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}
+
+// TestGitHubIssueToBeads verifies full conversion from GitHub Issue to beads Issue.
+func TestGitHubIssueToBeads(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	createdAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2024, 1, 16, 14, 0, 0, 0, time.UTC)
+
+	ghIssue := &Issue{
+		ID:        123456,
+		Number:    42,
+		Title:     "Fix authentication bug",
+		Body:      "Users cannot log in with SSO",
+		State:     "open",
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+		Labels: []Label{
+			{Name: "type:bug"},
+			{Name: "priority:high"},
+			{Name: "status:in_progress"},
+			{Name: "backend"},
+		},
+		Assignee: &User{
+			ID:    101,
+			Login: "jdoe",
+			Name:  "John Doe",
+		},
+		User: &User{
+			ID:    102,
+			Login: "alice",
+			Name:  "Alice Smith",
+		},
+		HTMLURL: "https://github.com/myorg/myrepo/issues/42",
+	}
+
+	conversion := GitHubIssueToBeads(ghIssue, "myorg", "myrepo", config)
+	issue := conversion.Issue
+
+	if issue.Title != "Fix authentication bug" {
+		t.Errorf("Title = %q, want %q", issue.Title, "Fix authentication bug")
+	}
+	if issue.Description != "Users cannot log in with SSO" {
+		t.Errorf("Description = %q, want %q", issue.Description, "Users cannot log in with SSO")
+	}
+	if issue.SourceSystem != "github:myorg/myrepo:42" {
+		t.Errorf("SourceSystem = %q, want %q", issue.SourceSystem, "github:myorg/myrepo:42")
+	}
+	if issue.ExternalRef == nil || *issue.ExternalRef != "https://github.com/myorg/myrepo/issues/42" {
+		t.Errorf("ExternalRef = %v, want %q", issue.ExternalRef, "https://github.com/myorg/myrepo/issues/42")
+	}
+	if issue.IssueType != "bug" {
+		t.Errorf("IssueType = %q, want %q", issue.IssueType, "bug")
+	}
+	if issue.Priority != 1 {
+		t.Errorf("Priority = %d, want 1 (high)", issue.Priority)
+	}
+	if issue.Status != "in_progress" {
+		t.Errorf("Status = %q, want %q", issue.Status, "in_progress")
+	}
+	if issue.Assignee != "jdoe" {
+		t.Errorf("Assignee = %q, want %q", issue.Assignee, "jdoe")
+	}
+	if !issue.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want %v", issue.CreatedAt, createdAt)
+	}
+	if !issue.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", issue.UpdatedAt, updatedAt)
+	}
+
+	// Labels should only contain non-scoped labels
+	hasBackend := false
+	for _, l := range issue.Labels {
+		if l == "backend" {
+			hasBackend = true
+		}
+		if l == "type:bug" || l == "priority:high" || l == "status:in_progress" {
+			t.Errorf("Labels should not contain scoped label %q", l)
+		}
+	}
+	if !hasBackend {
+		t.Error("Labels should contain 'backend'")
+	}
+}
+
+// TestBeadsIssueToGitHubFields verifies conversion from beads Issue to GitHub fields.
+func TestBeadsIssueToGitHubFields(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	estimatedMinutes := 300
+	issue := &types.Issue{
+		Title:            "Feature request",
+		Description:      "Add dark mode",
+		IssueType:        "feature",
+		Priority:         1,
+		Status:           types.StatusInProgress,
+		Labels:           []string{"frontend"},
+		EstimatedMinutes: &estimatedMinutes,
+	}
+
+	fields := BeadsIssueToGitHubFields(issue, config)
+
+	if fields["title"] != "Feature request" {
+		t.Errorf("fields[title] = %v, want %q", fields["title"], "Feature request")
+	}
+	if fields["body"] != "Add dark mode" {
+		t.Errorf("fields[body] = %v, want %q", fields["body"], "Add dark mode")
+	}
+
+	labels, ok := fields["labels"].([]string)
+	if !ok {
+		t.Fatal("fields[labels] is not []string")
+	}
+
+	hasType := false
+	hasPriority := false
+	hasStatus := false
+	hasFrontend := false
+	for _, l := range labels {
+		if l == "type:feature" {
+			hasType = true
+		}
+		if l == "priority:high" {
+			hasPriority = true
+		}
+		if l == "status:in_progress" {
+			hasStatus = true
+		}
+		if l == "frontend" {
+			hasFrontend = true
+		}
+	}
+	if !hasType {
+		t.Errorf("labels missing type:feature, got %v", labels)
+	}
+	if !hasPriority {
+		t.Errorf("labels missing priority:high, got %v", labels)
+	}
+	if !hasStatus {
+		t.Errorf("labels missing status:in_progress, got %v", labels)
+	}
+	if !hasFrontend {
+		t.Errorf("labels missing frontend, got %v", labels)
+	}
+}
+
+// TestBeadsIssueToGitHubFields_Closed verifies state is set for closed issues.
+func TestBeadsIssueToGitHubFields_Closed(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	closedIssue := &types.Issue{
+		Title:  "Completed task",
+		Status: types.StatusClosed,
+	}
+
+	fields := BeadsIssueToGitHubFields(closedIssue, config)
+
+	if fields["state"] != "closed" {
+		t.Errorf("fields[state] = %v, want %q", fields["state"], "closed")
+	}
+}
+
+// TestFilterNonScopedLabels verifies that scoped labels are removed.
+func TestFilterNonScopedLabels(t *testing.T) {
+	labels := []string{
+		"type:bug",
+		"priority:high",
+		"status:in_progress",
+		"backend",
+		"needs-review",
+		"urgent",
+	}
+
+	filtered := FilterNonScopedLabels(labels)
+
+	expected := []string{"backend", "needs-review", "urgent"}
+	if len(filtered) != len(expected) {
+		t.Fatalf("FilterNonScopedLabels returned %d labels, want %d", len(filtered), len(expected))
+	}
+
+	for i, l := range filtered {
+		if l != expected[i] {
+			t.Errorf("filtered[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}
+
+// TestPriorityToLabel verifies conversion from beads priority to label value.
+func TestPriorityToLabel(t *testing.T) {
+	tests := []struct {
+		priority int
+		want     string
+	}{
+		{0, "critical"},
+		{1, "high"},
+		{2, "medium"},
+		{3, "low"},
+		{4, "none"},
+		{-1, "medium"},
+		{5, "medium"},
+	}
+
+	for _, tt := range tests {
+		got := priorityToLabel(tt.priority)
+		if got != tt.want {
+			t.Errorf("priorityToLabel(%d) = %q, want %q", tt.priority, got, tt.want)
+		}
+	}
+}
+
+// TestMappingConfigUsesTypesConstants verifies DefaultMappingConfig uses
+// the exported mapping constants from types.go.
+func TestMappingConfigUsesTypesConstants(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	if p := config.PriorityMap["critical"]; p != PriorityMapping["critical"] {
+		t.Errorf("PriorityMap[critical] = %d, want %d", p, PriorityMapping["critical"])
+	}
+	if p := config.PriorityMap["high"]; p != PriorityMapping["high"] {
+		t.Errorf("PriorityMap[high] = %d, want %d", p, PriorityMapping["high"])
+	}
+
+	if typ := config.LabelTypeMap["bug"]; typ != TypeMapping["bug"] {
+		t.Errorf("LabelTypeMap[bug] = %q, want %q", typ, TypeMapping["bug"])
+	}
+	if typ := config.LabelTypeMap["enhancement"]; typ != TypeMapping["enhancement"] {
+		t.Errorf("LabelTypeMap[enhancement] = %q, want %q", typ, TypeMapping["enhancement"])
+	}
+}

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -1,0 +1,268 @@
+// Package github provides client and data types for the GitHub REST API.
+//
+// This package handles all interactions with GitHub's issue tracking system,
+// including fetching, creating, and updating issues. It provides bidirectional
+// mapping between GitHub's data model and Beads' internal types.
+package github
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// API configuration constants.
+const (
+	// DefaultAPIEndpoint is the GitHub REST API base URL.
+	DefaultAPIEndpoint = "https://api.github.com"
+
+	// DefaultTimeout is the default HTTP request timeout.
+	DefaultTimeout = 30 * time.Second
+
+	// MaxRetries is the maximum number of retries for rate-limited requests.
+	MaxRetries = 3
+
+	// RetryDelay is the base delay between retries (exponential backoff).
+	RetryDelay = time.Second
+
+	// MaxPageSize is the maximum number of issues to fetch per page.
+	MaxPageSize = 100
+
+	// MaxPages is the maximum number of pages to fetch before stopping.
+	// This prevents infinite loops from malformed Link headers.
+	MaxPages = 1000
+)
+
+// Client provides methods to interact with the GitHub REST API.
+type Client struct {
+	Token      string       // GitHub personal access token
+	Owner      string       // Repository owner (user or org)
+	Repo       string       // Repository name
+	BaseURL    string       // API base URL (default: https://api.github.com)
+	HTTPClient *http.Client // Optional custom HTTP client
+}
+
+// Issue represents an issue from the GitHub API.
+type Issue struct {
+	ID          int        `json:"id"`                       // Global unique ID
+	Number      int        `json:"number"`                   // Repository-scoped issue number
+	Title       string     `json:"title"`
+	Body        string     `json:"body"`
+	State       string     `json:"state"`                    // "open" or "closed"
+	CreatedAt   *time.Time `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	ClosedAt    *time.Time `json:"closed_at,omitempty"`
+	Labels      []Label    `json:"labels"`
+	Assignee    *User      `json:"assignee,omitempty"`
+	Assignees   []User     `json:"assignees,omitempty"`
+	User        *User      `json:"user,omitempty"`           // Author
+	Milestone   *Milestone `json:"milestone,omitempty"`
+	HTMLURL     string     `json:"html_url"`
+	PullRequest *PullRef   `json:"pull_request,omitempty"`   // Non-nil if this is a PR
+}
+
+// PullRef indicates an issue is actually a pull request.
+// The GitHub Issues API returns PRs alongside issues; this field
+// distinguishes them.
+type PullRef struct {
+	URL string `json:"url,omitempty"`
+}
+
+// User represents a GitHub user.
+type User struct {
+	ID        int    `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name,omitempty"`
+	Email     string `json:"email,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	HTMLURL   string `json:"html_url,omitempty"`
+}
+
+// Label represents a GitHub label.
+type Label struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description,omitempty"`
+}
+
+// Milestone represents a GitHub milestone.
+type Milestone struct {
+	ID          int        `json:"id"`
+	Number      int        `json:"number"`
+	Title       string     `json:"title"`
+	Description string     `json:"description,omitempty"`
+	State       string     `json:"state"`                  // "open" or "closed"
+	DueOn       *time.Time `json:"due_on,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	HTMLURL     string     `json:"html_url,omitempty"`
+}
+
+// Repository represents a GitHub repository (for listing repos).
+type Repository struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	FullName      string `json:"full_name"`
+	Description   string `json:"description,omitempty"`
+	HTMLURL       string `json:"html_url"`
+	DefaultBranch string `json:"default_branch,omitempty"`
+	Private       bool   `json:"private"`
+	Owner         *User  `json:"owner,omitempty"`
+}
+
+// SyncStats tracks statistics for a GitHub sync operation.
+type SyncStats struct {
+	Pulled    int `json:"pulled"`
+	Pushed    int `json:"pushed"`
+	Created   int `json:"created"`
+	Updated   int `json:"updated"`
+	Skipped   int `json:"skipped"`
+	Errors    int `json:"errors"`
+	Conflicts int `json:"conflicts"`
+}
+
+// SyncResult represents the result of a GitHub sync operation.
+type SyncResult struct {
+	Success  bool      `json:"success"`
+	Stats    SyncStats `json:"stats"`
+	LastSync string    `json:"last_sync,omitempty"`
+	Error    string    `json:"error,omitempty"`
+	Warnings []string  `json:"warnings,omitempty"`
+}
+
+// PullStats tracks pull operation statistics.
+type PullStats struct {
+	Created     int
+	Updated     int
+	Skipped     int
+	Incremental bool     // Whether this was an incremental sync
+	SyncedSince string   // Timestamp we synced since (if incremental)
+	Warnings    []string // Non-fatal warnings encountered during pull
+}
+
+// PushStats tracks push operation statistics.
+type PushStats struct {
+	Created int
+	Updated int
+	Skipped int
+	Errors  int
+}
+
+// Conflict represents a conflict between local and GitHub versions.
+// A conflict occurs when both the local and GitHub versions have been modified
+// since the last sync.
+type Conflict struct {
+	IssueID           string    // Beads issue ID
+	LocalUpdated      time.Time // When the local version was last modified
+	GitHubUpdated     time.Time // When the GitHub version was last modified
+	GitHubExternalRef string    // URL to the GitHub issue
+	GitHubNumber      int       // GitHub issue number (repository-scoped)
+	GitHubID          int       // GitHub's global issue ID
+}
+
+// IssueConversion holds the result of converting a GitHub issue to Beads.
+// It includes the issue and any dependencies that should be created.
+type IssueConversion struct {
+	Issue        *types.Issue
+	Dependencies []DependencyInfo
+}
+
+// DependencyInfo represents a dependency to be created after issue import.
+// Stored separately since we need all issues imported before linking dependencies.
+type DependencyInfo struct {
+	FromGitHubNumber int    // GitHub number of the dependent issue
+	ToGitHubNumber   int    // GitHub number of the dependency target
+	Type             string // Beads dependency type (blocks, related, parent-child)
+}
+
+// PriorityMapping maps priority label values to beads priority (0-4).
+// This is the single source of truth for priority mappings.
+// Exported so DefaultMappingConfig in mapping.go can use it.
+var PriorityMapping = map[string]int{
+	"critical": 0, // P0
+	"high":     1, // P1
+	"medium":   2, // P2
+	"low":      3, // P3
+	"none":     4, // P4
+}
+
+// StatusMapping maps status label values to beads status strings.
+// This is the single source of truth for status mappings.
+// Exported so DefaultMappingConfig in mapping.go can use it.
+var StatusMapping = map[string]string{
+	"open":        "open",
+	"in_progress": "in_progress",
+	"blocked":     "blocked",
+	"deferred":    "deferred",
+	"closed":      "closed",
+}
+
+// TypeMapping maps type label values to beads issue type strings.
+// This is the single source of truth for type mappings.
+// Exported so DefaultMappingConfig in mapping.go can use it.
+var TypeMapping = map[string]string{
+	"bug":         "bug",
+	"feature":     "feature",
+	"task":        "task",
+	"epic":        "epic",
+	"chore":       "chore",
+	"enhancement": "feature",
+}
+
+// validStates for GitHub issues.
+var validStates = map[string]bool{
+	"open":   true,
+	"closed": true,
+}
+
+// IsValidState checks if a GitHub state string is valid.
+func IsValidState(state string) bool {
+	return validStates[state]
+}
+
+// ParseLabelName extracts prefix and value from a label like "priority:high" or "priority/high".
+// GitHub doesn't have scoped labels like GitLab (::), so we support both ":" and "/" separators.
+func ParseLabelName(label string) (prefix, value string) {
+	// Try colon separator first (priority:high)
+	if parts := strings.SplitN(label, ":", 2); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	// Try slash separator (priority/high)
+	if parts := strings.SplitN(label, "/", 2); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", label
+}
+
+// GetPriorityFromLabel returns the beads priority for a priority label value.
+// Returns -1 if the value is not recognized.
+func GetPriorityFromLabel(value string) int {
+	if p, ok := PriorityMapping[strings.ToLower(value)]; ok {
+		return p
+	}
+	return -1
+}
+
+// GetStatusFromLabel returns the beads status for a status label value.
+// Returns empty string if the value is not recognized.
+func GetStatusFromLabel(value string) string {
+	return StatusMapping[strings.ToLower(value)]
+}
+
+// GetTypeFromLabel returns the beads issue type for a type label value.
+// Returns empty string if the value is not recognized.
+func GetTypeFromLabel(value string) string {
+	return TypeMapping[strings.ToLower(value)]
+}
+
+// LabelNames extracts label name strings from a slice of Label structs.
+func LabelNames(labels []Label) []string {
+	names := make([]string, len(labels))
+	for i, l := range labels {
+		names[i] = l.Name
+	}
+	return names
+}

--- a/internal/github/types_test.go
+++ b/internal/github/types_test.go
@@ -1,0 +1,311 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestIssueJSONUnmarshal verifies that GitHub API JSON responses
+// can be correctly unmarshaled into our Issue type.
+func TestIssueJSONUnmarshal(t *testing.T) {
+	jsonData := `{
+		"id": 123456,
+		"number": 42,
+		"title": "Fix authentication bug",
+		"body": "Users cannot log in with SSO",
+		"state": "open",
+		"created_at": "2024-01-15T10:30:00Z",
+		"updated_at": "2024-01-16T14:45:00Z",
+		"closed_at": null,
+		"labels": [
+			{"id": 1, "name": "bug", "color": "d73a4a"},
+			{"id": 2, "name": "priority:high", "color": "ff0000"}
+		],
+		"assignee": {
+			"id": 101,
+			"login": "jdoe",
+			"name": "John Doe"
+		},
+		"user": {
+			"id": 102,
+			"login": "alice",
+			"name": "Alice Smith"
+		},
+		"milestone": {
+			"id": 5,
+			"number": 1,
+			"title": "Sprint 5"
+		},
+		"html_url": "https://github.com/owner/repo/issues/42"
+	}`
+
+	var issue Issue
+	err := json.Unmarshal([]byte(jsonData), &issue)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal issue: %v", err)
+	}
+
+	if issue.ID != 123456 {
+		t.Errorf("ID = %d, want 123456", issue.ID)
+	}
+	if issue.Number != 42 {
+		t.Errorf("Number = %d, want 42", issue.Number)
+	}
+	if issue.Title != "Fix authentication bug" {
+		t.Errorf("Title = %q, want %q", issue.Title, "Fix authentication bug")
+	}
+	if issue.Body != "Users cannot log in with SSO" {
+		t.Errorf("Body = %q, want %q", issue.Body, "Users cannot log in with SSO")
+	}
+	if issue.State != "open" {
+		t.Errorf("State = %q, want %q", issue.State, "open")
+	}
+	if issue.HTMLURL != "https://github.com/owner/repo/issues/42" {
+		t.Errorf("HTMLURL = %q, want %q", issue.HTMLURL, "https://github.com/owner/repo/issues/42")
+	}
+
+	if len(issue.Labels) != 2 {
+		t.Errorf("Labels count = %d, want 2", len(issue.Labels))
+	}
+	if issue.Labels[0].Name != "bug" {
+		t.Errorf("Labels[0].Name = %q, want %q", issue.Labels[0].Name, "bug")
+	}
+
+	if issue.Assignee == nil {
+		t.Fatal("Assignee is nil, want non-nil")
+	}
+	if issue.Assignee.Login != "jdoe" {
+		t.Errorf("Assignee.Login = %q, want %q", issue.Assignee.Login, "jdoe")
+	}
+
+	if issue.User == nil {
+		t.Fatal("User is nil, want non-nil")
+	}
+	if issue.User.Login != "alice" {
+		t.Errorf("User.Login = %q, want %q", issue.User.Login, "alice")
+	}
+
+	if issue.Milestone == nil {
+		t.Fatal("Milestone is nil, want non-nil")
+	}
+	if issue.Milestone.Title != "Sprint 5" {
+		t.Errorf("Milestone.Title = %q, want %q", issue.Milestone.Title, "Sprint 5")
+	}
+
+	if issue.PullRequest != nil {
+		t.Error("PullRequest should be nil for a regular issue")
+	}
+}
+
+// TestIssueWithPullRequest verifies PR detection.
+func TestIssueWithPullRequest(t *testing.T) {
+	jsonData := `{
+		"id": 100,
+		"number": 10,
+		"title": "PR title",
+		"state": "open",
+		"pull_request": {
+			"url": "https://api.github.com/repos/owner/repo/pulls/10"
+		}
+	}`
+
+	var issue Issue
+	err := json.Unmarshal([]byte(jsonData), &issue)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal issue: %v", err)
+	}
+
+	if issue.PullRequest == nil {
+		t.Error("PullRequest is nil, want non-nil for PR")
+	}
+}
+
+// TestStateMapping verifies GitHub states are valid.
+func TestStateMapping(t *testing.T) {
+	tests := []struct {
+		state     string
+		wantValid bool
+	}{
+		{"open", true},
+		{"closed", true},
+		{"reopened", false}, // GitHub doesn't have "reopened" state
+		{"invalid", false},
+	}
+
+	for _, tt := range tests {
+		got := IsValidState(tt.state)
+		if got != tt.wantValid {
+			t.Errorf("IsValidState(%q) = %v, want %v", tt.state, got, tt.wantValid)
+		}
+	}
+}
+
+// TestParseLabelName verifies label prefix parsing.
+func TestParseLabelName(t *testing.T) {
+	tests := []struct {
+		label      string
+		wantPrefix string
+		wantValue  string
+	}{
+		{"priority:high", "priority", "high"},
+		{"status:in_progress", "status", "in_progress"},
+		{"type:bug", "type", "bug"},
+		{"priority/high", "priority", "high"},
+		{"type/feature", "type", "feature"},
+		{"simple-label", "", "simple-label"},
+		{"bug", "", "bug"},
+	}
+
+	for _, tt := range tests {
+		prefix, value := ParseLabelName(tt.label)
+		if prefix != tt.wantPrefix {
+			t.Errorf("ParseLabelName(%q) prefix = %q, want %q", tt.label, prefix, tt.wantPrefix)
+		}
+		if value != tt.wantValue {
+			t.Errorf("ParseLabelName(%q) value = %q, want %q", tt.label, value, tt.wantValue)
+		}
+	}
+}
+
+// TestGetPriorityFromLabel verifies priority label value to beads priority mapping.
+func TestGetPriorityFromLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		want  int
+	}{
+		{"critical", 0},
+		{"CRITICAL", 0},
+		{"high", 1},
+		{"medium", 2},
+		{"low", 3},
+		{"none", 4},
+		{"invalid", -1},
+		{"", -1},
+	}
+
+	for _, tt := range tests {
+		got := GetPriorityFromLabel(tt.value)
+		if got != tt.want {
+			t.Errorf("GetPriorityFromLabel(%q) = %d, want %d", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestGetStatusFromLabel verifies status label value to beads status mapping.
+func TestGetStatusFromLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"open", "open"},
+		{"OPEN", "open"},
+		{"in_progress", "in_progress"},
+		{"blocked", "blocked"},
+		{"deferred", "deferred"},
+		{"closed", "closed"},
+		{"invalid", ""},
+	}
+
+	for _, tt := range tests {
+		got := GetStatusFromLabel(tt.value)
+		if got != tt.want {
+			t.Errorf("GetStatusFromLabel(%q) = %q, want %q", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestGetTypeFromLabel verifies type label value to beads issue type mapping.
+func TestGetTypeFromLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"bug", "bug"},
+		{"feature", "feature"},
+		{"task", "task"},
+		{"epic", "epic"},
+		{"chore", "chore"},
+		{"enhancement", "feature"},
+		{"invalid", ""},
+	}
+
+	for _, tt := range tests {
+		got := GetTypeFromLabel(tt.value)
+		if got != tt.want {
+			t.Errorf("GetTypeFromLabel(%q) = %q, want %q", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestLabelNames verifies extracting names from Label structs.
+func TestLabelNames(t *testing.T) {
+	labels := []Label{
+		{ID: 1, Name: "bug"},
+		{ID: 2, Name: "priority:high"},
+		{ID: 3, Name: "enhancement"},
+	}
+
+	names := LabelNames(labels)
+	if len(names) != 3 {
+		t.Fatalf("LabelNames returned %d names, want 3", len(names))
+	}
+	if names[0] != "bug" {
+		t.Errorf("names[0] = %q, want %q", names[0], "bug")
+	}
+	if names[1] != "priority:high" {
+		t.Errorf("names[1] = %q, want %q", names[1], "priority:high")
+	}
+}
+
+// TestSyncStatsZeroValue verifies SyncStats initializes correctly.
+func TestSyncStatsZeroValue(t *testing.T) {
+	stats := SyncStats{}
+	if stats.Pulled != 0 {
+		t.Errorf("Pulled = %d, want 0", stats.Pulled)
+	}
+	if stats.Pushed != 0 {
+		t.Errorf("Pushed = %d, want 0", stats.Pushed)
+	}
+}
+
+// TestConflictFields verifies Conflict type has required fields.
+func TestConflictFields(t *testing.T) {
+	now := time.Now()
+	conflict := Conflict{
+		IssueID:           "bd-abc123",
+		LocalUpdated:      now,
+		GitHubUpdated:     now.Add(time.Hour),
+		GitHubExternalRef: "https://github.com/owner/repo/issues/42",
+		GitHubNumber:      42,
+		GitHubID:          123456,
+	}
+
+	if conflict.IssueID != "bd-abc123" {
+		t.Errorf("IssueID = %q, want %q", conflict.IssueID, "bd-abc123")
+	}
+	if conflict.GitHubNumber != 42 {
+		t.Errorf("GitHubNumber = %d, want 42", conflict.GitHubNumber)
+	}
+}
+
+// TestIssueConversion verifies IssueConversion struct field access.
+func TestIssueConversion(t *testing.T) {
+	conversion := &IssueConversion{
+		Issue: &types.Issue{
+			Title:       "Test issue",
+			Description: "Test description",
+		},
+		Dependencies: []DependencyInfo{},
+	}
+
+	if conversion.Issue == nil {
+		t.Fatal("Issue field is nil, want *types.Issue")
+	}
+	if conversion.Issue.Title != "Test issue" {
+		t.Errorf("Issue.Title = %q, want %q", conversion.Issue.Title, "Test issue")
+	}
+}


### PR DESCRIPTION
- Add internal/github package with client, types, and mapping
- Add bd github sync/status/repos CLI commands
- Support bidirectional sync (pull/push) with incremental sync
- Support conflict resolution strategies (prefer-local/github/newer)
- Filter out pull requests from GitHub issues endpoint
- Map GitHub labels to beads priority/status/type fields
- Include comprehensive unit tests

Amp-Thread-ID: https://ampcode.com/threads/T-019c4a48-ce4f-7788-a604-325f64d10f98