### PR TITLE
feat: optimize CLI test suite with template DB pattern

### DIFF
--- a/cmd/bd/cli_coverage_show_test.go
+++ b/cmd/bd/cli_coverage_show_test.go
@@ -26,11 +26,6 @@ func runBDForCoverage(t *testing.T, dir string, args ...string) (stdout string, 
 	cliCoverageMutex.Lock()
 	defer cliCoverageMutex.Unlock()
 
-	// Add --no-daemon to all commands except init.
-	if len(args) > 0 && args[0] != "init" {
-		args = append([]string{"--no-daemon"}, args...)
-	}
-
 	oldStdout := os.Stdout
 	oldStderr := os.Stderr
 	oldDir, _ := os.Getwd()

--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,11 +30,83 @@ var (
 	inProcessMutex sync.Mutex // Protects concurrent access to rootCmd and global state
 )
 
-// setupCLITestDB creates a fresh initialized bd database for CLI tests
+// templateDB holds a pre-initialized bd database directory.
+// Created once via sync.Once, then copied for each test to avoid
+// running bd init (which creates SQLite DB, config files, etc.) per test.
+// This optimization eliminates ~2s per test from repeated initialization.
+var (
+	templateDBDir  string
+	templateDBOnce sync.Once
+	templateDBErr  error
+)
+
+// initTemplateDB creates a single template database that can be copied for each test.
+// Uses exec.Command (subprocess) to avoid polluting Cobra global state.
+// The testBD binary is already built once in init().
+func initTemplateDB() {
+	templateDBOnce.Do(func() {
+		tmpDir, err := os.MkdirTemp("", "bd-cli-template-*")
+		if err != nil {
+			templateDBErr = fmt.Errorf("failed to create template dir: %w", err)
+			return
+		}
+		templateDBDir = tmpDir
+
+		// Use exec.Command to run bd init in a subprocess.
+		// This avoids any Cobra global state pollution that would affect subsequent
+		// in-process test runs.
+		cmd := exec.Command(testBD, "init", "--prefix", "test", "--quiet")
+		cmd.Dir = tmpDir
+		cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			templateDBErr = fmt.Errorf("template bd init failed: %v\n%s", err, out)
+			return
+		}
+	})
+}
+
+// copyDir recursively copies a directory tree.
+func copyDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0750); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		if entry.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			data, err := os.ReadFile(srcPath)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(dstPath, data, 0600); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// setupCLITestDB creates a fresh initialized bd database for CLI tests.
+// Uses a cached template directory to avoid running bd init for every test.
+// The template is created once via sync.Once and copied for each test.
 func setupCLITestDB(t *testing.T) string {
 	t.Helper()
+	initTemplateDB()
+	if templateDBErr != nil {
+		t.Fatalf("Template DB initialization failed: %v", templateDBErr)
+	}
 	tmpDir := createTempDirWithCleanup(t)
-	runBDInProcess(t, tmpDir, "init", "--prefix", "test", "--quiet")
+	if err := copyDir(templateDBDir, tmpDir); err != nil {
+		t.Fatalf("Failed to copy template DB: %v", err)
+	}
 	return tmpDir
 }
 
@@ -76,11 +149,6 @@ func runBDInProcess(t *testing.T, dir string, args ...string) string {
 	inProcessMutex.Lock()
 	defer inProcessMutex.Unlock()
 
-	// Add --no-daemon to all commands except init
-	if len(args) > 0 && args[0] != "init" {
-		args = append([]string{"--no-daemon"}, args...)
-	}
-
 	// Save original state
 	oldStdout := os.Stdout
 	oldStderr := os.Stderr
@@ -101,10 +169,6 @@ func runBDInProcess(t *testing.T, dir string, args ...string) string {
 	// Set args for rootCmd
 	rootCmd.SetArgs(args)
 	os.Args = append([]string{"bd"}, args...)
-
-	// Set environment
-	os.Setenv("BEADS_NO_DAEMON", "1")
-	defer os.Unsetenv("BEADS_NO_DAEMON")
 
 	// Execute command
 	err := rootCmd.Execute()
@@ -686,20 +750,28 @@ func init() {
 func runBDExec(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 
-	// Add --no-daemon to all commands except init
-	if len(args) > 0 && args[0] != "init" {
-		args = append([]string{"--no-daemon"}, args...)
-	}
-
 	cmd := exec.Command(testBD, args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	cmd.Env = os.Environ()
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("bd %v failed: %v\nOutput: %s", args, err, out)
 	}
 	return string(out)
+}
+
+// runBDExecAllowErrorWithEnv runs bd via exec.Command with custom env vars,
+// returning combined output and any error (does not fail the test on error).
+func runBDExecAllowErrorWithEnv(t *testing.T, dir string, env []string, args ...string) (string, error) {
+	t.Helper()
+
+	cmd := exec.Command(testBD, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }
 
 // TestCLI_EndToEnd performs end-to-end testing using the actual binary
@@ -847,10 +919,6 @@ func runBDInProcessAllowError(t *testing.T, dir string, args ...string) (string,
 	inProcessMutex.Lock()
 	defer inProcessMutex.Unlock()
 
-	if len(args) > 0 && args[0] != "init" {
-		args = append([]string{"--no-daemon"}, args...)
-	}
-
 	oldStdout := os.Stdout
 	oldStderr := os.Stderr
 	oldDir, _ := os.Getwd()
@@ -867,9 +935,6 @@ func runBDInProcessAllowError(t *testing.T, dir string, args ...string) (string,
 
 	rootCmd.SetArgs(args)
 	os.Args = append([]string{"bd"}, args...)
-
-	os.Setenv("BEADS_NO_DAEMON", "1")
-	defer os.Unsetenv("BEADS_NO_DAEMON")
 
 	cmdErr := rootCmd.Execute()
 
@@ -1067,7 +1132,7 @@ func TestCLI_CreateDryRun(t *testing.T) {
 		os.WriteFile(mdFile, []byte("# Test Issue\n\nDescription here"), 0644)
 
 		// Run create with --dry-run and --file (should error)
-		cmd := exec.Command(testBD, "--no-daemon", "create", "--file", mdFile, "--dry-run")
+		cmd := exec.Command(testBD, "create", "--file", mdFile, "--dry-run")
 		cmd.Dir = tmpDir
 		cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
 		out, err := cmd.CombinedOutput()

--- a/cmd/bd/doctor_repair_chaos_test.go
+++ b/cmd/bd/doctor_repair_chaos_test.go
@@ -366,9 +366,6 @@ func startDaemonForChaosTest(t *testing.T, bdExe, ws, dbPath string) *exec.Cmd {
 
 func runBDWithEnv(ctx context.Context, exe, dir, dbPath string, env map[string]string, args ...string) (string, error) {
 	fullArgs := []string{"--db", dbPath}
-	if len(args) > 0 && args[0] != "init" {
-		fullArgs = append(fullArgs, "--no-daemon")
-	}
 	fullArgs = append(fullArgs, args...)
 
 	cmd := exec.CommandContext(ctx, exe, fullArgs...)

--- a/cmd/bd/doctor_repair_test.go
+++ b/cmd/bd/doctor_repair_test.go
@@ -44,9 +44,6 @@ func mkTmpDirInTmp(t *testing.T, prefix string) string {
 func runBDSideDB(t *testing.T, exe, dir, dbPath string, args ...string) (string, error) {
 	t.Helper()
 	fullArgs := []string{"--db", dbPath}
-	if len(args) > 0 && args[0] != "init" {
-		fullArgs = append(fullArgs, "--no-daemon")
-	}
 	fullArgs = append(fullArgs, args...)
 
 	cmd := exec.Command(exe, fullArgs...)

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -654,7 +654,7 @@ func TestInitNoDbMode(t *testing.T) {
 	}()
 
 	// Initialize with --no-db flag
-	rootCmd.SetArgs([]string{"init", "--no-db", "--no-daemon", "--prefix", "test", "--quiet"})
+	rootCmd.SetArgs([]string{"init", "--no-db", "--prefix", "test", "--quiet"})
 
 	t.Logf("DEBUG: noDb before Execute=%v", noDb)
 

--- a/cmd/bd/integration_test_stubs_test.go
+++ b/cmd/bd/integration_test_stubs_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+// +build integration
+
+package main
+
+// Stubs for missing test helper functions that prevent integration tests from compiling.
+// These functions were referenced by tests but their definitions were removed/moved.
+// Filed as pre-existing issue: these stubs allow the integration test suite to compile
+// while the proper implementations are restored.
+//
+// Pre-existing build failure: the following functions are called but never defined:
+//   - makeSocketTempDir (delete_rpc_test.go, dual_mode_test.go)
+//   - initTestGitRepo (delete_rpc_test.go, dual_mode_test.go)
+//   - startRPCServer (delete_rpc_test.go, dual_mode_test.go)
+//   - newTestLogger (export_mtime_test.go)
+//   - createTestLogger (periodic_remote_sync_test.go)
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/rpc"
+	"github.com/steveyegge/beads/internal/storage/sqlite"
+)
+
+// DefaultRemoteSyncInterval is a stub constant for the removed periodic_remote_sync module.
+const DefaultRemoteSyncInterval = 30 * time.Second
+
+// makeSocketTempDir creates a temporary directory for socket files.
+// STUB: This is a placeholder for a removed function definition.
+func makeSocketTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "bd-socket-test-*")
+	if err != nil {
+		t.Fatalf("makeSocketTempDir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+// initTestGitRepo initializes a git repository in the given directory.
+// STUB: This is a placeholder for a removed function definition.
+func initTestGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init", "--initial-branch=main")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("initTestGitRepo: git init failed: %v\n%s", err, out)
+	}
+	cmd = exec.Command("git", "config", "user.email", "test@test.com")
+	cmd.Dir = dir
+	cmd.Run()
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = dir
+	cmd.Run()
+}
+
+// startRPCServer starts an RPC server for testing.
+// STUB: This is a placeholder for a removed function definition.
+// Tests using this will fail at runtime until the proper implementation is restored.
+func startRPCServer(
+	_ context.Context,
+	_ string,
+	_ *sqlite.SQLiteStorage,
+	_ string,
+	_ string,
+	_ *slog.Logger,
+) (*rpc.Server, <-chan error, error) {
+	return nil, nil, fmt.Errorf("startRPCServer: STUB - proper implementation was removed, tests using this will fail")
+}
+
+// newTestLogger returns a logger that discards output.
+// STUB: This is a placeholder for a removed function definition.
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// createTestLogger returns a logger that discards output.
+// STUB: This is a placeholder for a removed function definition.
+func createTestLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// getRemoteSyncInterval is a stub for the removed periodic remote sync function.
+// STUB: This is a placeholder for a removed function definition.
+func getRemoteSyncInterval(_ *slog.Logger) time.Duration {
+	return DefaultRemoteSyncInterval
+}

--- a/cmd/bd/show_test.go
+++ b/cmd/bd/show_test.go
@@ -36,7 +36,7 @@ func TestShow(t *testing.T) {
 
 		// Create issue with external ref
 		// Use --repo . to override auto-routing and create in the test directory
-		createCmd := exec.Command(tmpBin, "--no-daemon", "create", "External ref test", "-p", "1",
+		createCmd := exec.Command(tmpBin, "create", "External ref test", "-p", "1",
 			"--external-ref", "https://example.com/spec.md", "--json", "--repo", ".")
 		createCmd.Dir = tmpDir
 		createOut, err := createCmd.CombinedOutput()
@@ -51,7 +51,7 @@ func TestShow(t *testing.T) {
 		id := issue["id"].(string)
 
 		// Show the issue and verify external ref is displayed
-		showCmd := exec.Command(tmpBin, "--no-daemon", "show", id)
+		showCmd := exec.Command(tmpBin, "show", id)
 		showCmd.Dir = tmpDir
 		showOut, err := showCmd.CombinedOutput()
 		if err != nil {
@@ -81,7 +81,7 @@ func TestShow(t *testing.T) {
 
 		// Create issue WITHOUT external ref
 		// Use --repo . to override auto-routing and create in the test directory
-		createCmd := exec.Command(tmpBin, "--no-daemon", "create", "No ref test", "-p", "1", "--json", "--repo", ".")
+		createCmd := exec.Command(tmpBin, "create", "No ref test", "-p", "1", "--json", "--repo", ".")
 		createCmd.Dir = tmpDir
 		createOut, err := createCmd.CombinedOutput()
 		if err != nil {
@@ -95,7 +95,7 @@ func TestShow(t *testing.T) {
 		id := issue["id"].(string)
 
 		// Show the issue - should NOT contain External Ref line
-		showCmd := exec.Command(tmpBin, "--no-daemon", "show", id)
+		showCmd := exec.Command(tmpBin, "show", id)
 		showCmd.Dir = tmpDir
 		showOut, err := showCmd.CombinedOutput()
 		if err != nil {
@@ -121,7 +121,7 @@ func TestShow(t *testing.T) {
 		}
 
 		// Create an issue
-		createCmd := exec.Command(tmpBin, "--no-daemon", "create", "ID flag test", "-p", "1", "--json", "--repo", ".")
+		createCmd := exec.Command(tmpBin, "create", "ID flag test", "-p", "1", "--json", "--repo", ".")
 		createCmd.Dir = tmpDir
 		createOut, err := createCmd.CombinedOutput()
 		if err != nil {
@@ -135,7 +135,7 @@ func TestShow(t *testing.T) {
 		id := issue["id"].(string)
 
 		// Test 1: Using --id flag works
-		showCmd := exec.Command(tmpBin, "--no-daemon", "show", "--id="+id, "--short")
+		showCmd := exec.Command(tmpBin, "show", "--id="+id, "--short")
 		showCmd.Dir = tmpDir
 		showOut, err := showCmd.CombinedOutput()
 		if err != nil {
@@ -146,7 +146,7 @@ func TestShow(t *testing.T) {
 		}
 
 		// Test 2: Multiple --id flags work
-		showCmd2 := exec.Command(tmpBin, "--no-daemon", "show", "--id="+id, "--id="+id, "--short")
+		showCmd2 := exec.Command(tmpBin, "show", "--id="+id, "--id="+id, "--short")
 		showCmd2.Dir = tmpDir
 		showOut2, err := showCmd2.CombinedOutput()
 		if err != nil {
@@ -158,7 +158,7 @@ func TestShow(t *testing.T) {
 		}
 
 		// Test 3: Combining positional and --id flag
-		showCmd3 := exec.Command(tmpBin, "--no-daemon", "show", id, "--id="+id, "--short")
+		showCmd3 := exec.Command(tmpBin, "show", id, "--id="+id, "--short")
 		showCmd3.Dir = tmpDir
 		showOut3, err := showCmd3.CombinedOutput()
 		if err != nil {
@@ -170,7 +170,7 @@ func TestShow(t *testing.T) {
 		}
 
 		// Test 4: No args at all should fail
-		showCmd4 := exec.Command(tmpBin, "--no-daemon", "show")
+		showCmd4 := exec.Command(tmpBin, "show")
 		showCmd4.Dir = tmpDir
 		_, err = showCmd4.CombinedOutput()
 		if err == nil {
@@ -191,7 +191,7 @@ func TestShow(t *testing.T) {
 		}
 
 		// Show nonexistent issue should exit non-zero
-		showCmd := exec.Command(tmpBin, "--no-daemon", "show", "test-nonexistent")
+		showCmd := exec.Command(tmpBin, "show", "test-nonexistent")
 		showCmd.Dir = tmpDir
 		_, err := showCmd.CombinedOutput()
 		if err == nil {
@@ -213,7 +213,7 @@ func TestShow(t *testing.T) {
 
 		// Show nonexistent issue with --json should exit non-zero
 		// and output structured JSON error to stdout (not empty stdout)
-		showCmd := exec.Command(tmpBin, "--no-daemon", "show", "test-nonexistent", "--json")
+		showCmd := exec.Command(tmpBin, "show", "test-nonexistent", "--json")
 		showCmd.Dir = tmpDir
 		var stdout, stderr strings.Builder
 		showCmd.Stdout = &stdout

--- a/cmd/bd/update_edge_cases_test.go
+++ b/cmd/bd/update_edge_cases_test.go
@@ -232,7 +232,7 @@ func TestCLI_UpdateInvalidPriority(t *testing.T) {
 
 	for _, tc := range invalidPriorities {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command(testBD, "--no-daemon", "update", id, "-p", tc.priority)
+			cmd := exec.Command(testBD, "update", id, "-p", tc.priority)
 			cmd.Dir = tmpDir
 			cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
 			out, err := cmd.CombinedOutput()
@@ -331,7 +331,7 @@ func TestCLI_UpdateNegativeEstimate(t *testing.T) {
 	id := createExecTestIssue(t, tmpDir, "Estimate test")
 
 	// Try negative estimate
-	cmd := exec.Command(testBD, "--no-daemon", "update", id, "--estimate", "-5")
+	cmd := exec.Command(testBD, "update", id, "--estimate", "-5")
 	cmd.Dir = tmpDir
 	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
 	out, err := cmd.CombinedOutput()
@@ -425,7 +425,7 @@ func TestCLI_UpdateInvalidDueDate(t *testing.T) {
 	tmpDir := initExecTestDB(t)
 	id := createExecTestIssue(t, tmpDir, "Due date test")
 
-	cmd := exec.Command(testBD, "--no-daemon", "update", id, "--due", "not-a-date")
+	cmd := exec.Command(testBD, "update", id, "--due", "not-a-date")
 	cmd.Dir = tmpDir
 	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
 	out, err := cmd.CombinedOutput()
@@ -454,7 +454,7 @@ func initExecTestDB(t *testing.T) string {
 // createExecTestIssue creates a test issue using exec.Command and returns the ID.
 func createExecTestIssue(t *testing.T, tmpDir, title string) string {
 	t.Helper()
-	createCmd := exec.Command(testBD, "--no-daemon", "create", title, "-p", "1", "--json")
+	createCmd := exec.Command(testBD, "create", title, "-p", "1", "--json")
 	createCmd.Dir = tmpDir
 	createCmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
 	out, err := createCmd.CombinedOutput()
@@ -591,7 +591,7 @@ func TestCLI_UpdateMultipleIssuesExec(t *testing.T) {
 	id2 := createExecTestIssue(t, tmpDir, "Second issue")
 
 	// Update both at once
-	cmd := exec.Command(testBD, "--no-daemon", "update", id1, id2, "--status", "in_progress")
+	cmd := exec.Command(testBD, "update", id1, id2, "--status", "in_progress")
 	cmd.Dir = tmpDir
 	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -600,7 +600,7 @@ func TestCLI_UpdateMultipleIssuesExec(t *testing.T) {
 
 	// Verify both were updated
 	for _, id := range []string{id1, id2} {
-		showCmd := exec.Command(testBD, "--no-daemon", "show", id, "--json")
+		showCmd := exec.Command(testBD, "show", id, "--json")
 		showCmd.Dir = tmpDir
 		showCmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
 		showOut, err := showCmd.CombinedOutput()


### PR DESCRIPTION
## Summary
- **Issue**: bd-ktng - Optimize CLI test suite by eliminating redundant git init calls
- Introduces a `sync.Once` template database pattern: one `bd init` creates a template DB, each test copies it instead of running full initialization
- Removes stale `--no-daemon` flag references from all test files (daemon subsystem was removed in 32697661)
- Adds `runBDExecAllowErrorWithEnv` helper and integration test stubs for pre-existing missing function references

## Changes
- `cmd/bd/cli_fast_test.go` - Template DB pattern (sync.Once + copyDir), removed --no-daemon, added missing helper
- `cmd/bd/integration_test_stubs_test.go` - New file with stubs for removed functions (integration build fix)
- `cmd/bd/show_test.go` - Removed --no-daemon references
- `cmd/bd/update_edge_cases_test.go` - Removed --no-daemon references
- `cmd/bd/doctor_repair_chaos_test.go` - Removed --no-daemon references
- `cmd/bd/doctor_repair_test.go` - Removed --no-daemon references
- `cmd/bd/cli_coverage_show_test.go` - Removed --no-daemon references
- `cmd/bd/init_test.go` - Removed --no-daemon references

## Test plan
- [x] `go vet ./cmd/bd/` passes (non-integration)
- [x] `go vet -tags integration ./cmd/bd/` passes (integration)
- [x] 15+ CLI integration tests pass in ~2s (down from ~31s estimated)
- [x] Pre-existing failures unchanged: TestCLI_UpdateLabels (set-labels bug), TestCLI_UpdatePersistent (Cobra state leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)