### PR TITLE
fix(doctor): handle Dolt backend in gitignore, redirect target, and config checks

### DIFF
--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -353,6 +353,15 @@ func CheckDatabaseConfig(repoPath string) DoctorCheck {
 		}
 	}
 
+	// Dolt backend stores data on the server — no local .db or .jsonl files expected
+	if cfg.GetBackend() == configfile.BackendDolt {
+		return DoctorCheck{
+			Name:    "Database Config",
+			Status:  "ok",
+			Message: "Dolt backend (data on server)",
+		}
+	}
+
 	var issues []string
 
 	// Check if configured database exists


### PR DESCRIPTION
## Summary

Three `bd doctor` checks produce false warnings when using Dolt server mode with `.beads/redirect`:

- **CheckGitignore**: now follows `.beads/redirect` to check the gitignore at the redirect target, instead of the redirect-only directory which only contains the redirect file
- **CheckRedirectTargetValid**: now recognizes Dolt backend via `metadata.json`, so it no longer warns about missing `.db` files in server mode
- **CheckDatabaseConfig**: skips JSONL/db file existence checks entirely for Dolt backend, since data lives on the server — not as local `.db` or `.jsonl` files

## Test plan
- [x] Run `bd doctor` from a directory using `.beads/redirect` pointing to a Dolt-backend target — no false gitignore or redirect target warnings
- [x] Run `bd doctor` from a Dolt-backend repo with `jsonl_export` in metadata.json — no "Configuration mismatch" warning
- [x] Run `bd doctor` from a SQLite-backend repo — all existing checks still function normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)