### PR TITLE
ci(nix): add weekly flake.lock update workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,22 @@
+name: "Update flake.lock"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "chore(nix): update flake.lock"
+          pr-labels: |
+            dependencies
+            nix


### PR DESCRIPTION
## Summary

Add a weekly cron workflow using [DeterminateSystems/update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) to keep `flake.lock` fresh.

## Motivation

The `flake.lock` has been updated [only twice in 4 months](https://github.com/steveyegge/beads/commits?path=flake.lock) (Oct 2025 and Feb 2026). This means the Nix dev shell and build use a stale nixpkgs snapshot, which is a major source of recurring Nix breakage — the pinned nixpkgs often ships a Go version older than what `go.mod` requires.

This workflow:
- Runs weekly (Sunday midnight UTC) and on manual trigger
- Automatically opens a PR to update all flake inputs
- Labels the PR `dependencies` + `nix` for easy filtering

## What it doesn't do

This does not fix `vendorHash` drift or the `postPatch` go.mod rewrite. Those are tracked in #1676 as part of a broader proposal to slim down the in-repo flake and delegate packaging to nixpkgs.

## Test plan

- [ ] Verify workflow file is valid YAML
- [ ] Trigger manually via `workflow_dispatch` to confirm it opens a PR