### PR TITLE
fix: filter closed blockers from bd list annotations

### DIFF
--- a/cmd/bd/AGENTS.md
+++ b/cmd/bd/AGENTS.md
@@ -5,12 +5,18 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 ## Quick Reference
 
 ```bash
-bd ready              # Find available work
+bd ready              # Find available work (open, no blockers)
+bd blocked            # Show blocked issues and what blocks them
+bd list               # List all issues (with blocker annotations)
 bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
+bd claim <id>         # Claim work (atomic compare-and-swap)
 bd close <id>         # Complete work
 bd sync               # Sync with git
 ```
+
+**Dependency status**: `bd ready` and `bd blocked` are the authoritative
+sources for whether work is blocked. `bd list` shows active blocker
+annotations but use `bd ready`/`bd blocked` for accurate blocking status.
 
 ## Agent Warning: Interactive Commands
 

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -739,7 +739,8 @@ var listCmd = &cobra.Command{
 
 		// Load dependencies for blocking info display
 		allDepsForList, _ := activeStore.GetAllDependencyRecords(ctx)
-		blockedByMap, blocksMap, _ := buildBlockingMaps(allDepsForList)
+		closedIDs := getClosedBlockerIDs(ctx, activeStore, allDepsForList)
+		blockedByMap, blocksMap, _ := buildBlockingMaps(allDepsForList, closedIDs)
 
 		// Build output in buffer for pager support (bd-jdz3)
 		var buf strings.Builder


### PR DESCRIPTION
## Summary
- `buildBlockingMaps` now filters out closed blockers from "blocked by" and "blocks" annotations in `bd list` output
- Previously showed stale `(blocked by: X)` even when X was closed, confusing agents into thinking work was still blocked
- Added `bd blocked`, `bd list`, and `bd claim` to the AGENTS.md quick reference template
- Added note that `bd ready`/`bd blocked` are the authoritative sources for blocking status

## Test plan
- [x] New unit tests: `TestBuildBlockingMaps_ClosedBlockersFiltered` verifies closed blockers excluded
- [x] New unit tests: `TestBuildBlockingMaps_NilClosedIDs` verifies backward compat when no closed set
- [x] Existing tests updated and passing: `TestBuildBlockingMaps`, `TestBuildBlockingMaps_ParentChildSeparation`
- [x] All `TestFormatIssueCompact*` tests passing
- [ ] Manual test: `bd list` no longer shows "(blocked by: X)" when X is closed

Fixes bd-yit

🤖 Generated with [Claude Code](https://claude.com/claude-code)