### PR TITLE
dolt: add bounded contention tests for access lock timeouts

### DIFF
--- a/internal/storage/dolt/access_lock_test.go
+++ b/internal/storage/dolt/access_lock_test.go
@@ -1,0 +1,82 @@
+package dolt
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/lockfile"
+)
+
+func TestAcquireAccessLock_TimesOutWhenHeld(t *testing.T) {
+	t.Parallel()
+
+	doltDir := filepath.Join(t.TempDir(), ".beads", "dolt")
+	holder, err := AcquireAccessLock(doltDir, true, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to acquire holder lock: %v", err)
+	}
+	defer holder.Release()
+
+	start := time.Now()
+	_, err = AcquireAccessLock(doltDir, true, 120*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, lockfile.ErrLockBusy) {
+		t.Fatalf("expected lock busy error, got: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("lock acquisition exceeded bounded retry window: %v", elapsed)
+	}
+}
+
+func TestAcquireAccessLock_BoundedRetriesUnderContention(t *testing.T) {
+	t.Parallel()
+
+	doltDir := filepath.Join(t.TempDir(), ".beads", "dolt")
+	holder, err := AcquireAccessLock(doltDir, true, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to acquire holder lock: %v", err)
+	}
+	defer holder.Release()
+
+	const workers = 12
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, acquireErr := AcquireAccessLock(doltDir, false, 150*time.Millisecond)
+			errs <- acquireErr
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("contention test hung; lock retries are not bounded")
+	}
+
+	close(errs)
+	for err := range errs {
+		if err == nil {
+			t.Fatal("expected lock contention errors, got nil")
+		}
+		if !errors.Is(err, lockfile.ErrLockBusy) {
+			t.Fatalf("expected lock busy error, got: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
Fixes #1505. Lock contention regressions can present as hangs; we need explicit bounded-time behavior checks to ensure contention returns in finite time.

## What Changed
- Added `internal/storage/dolt/access_lock_test.go` with contention-focused tests.
- Verifies lock acquisition times out when lock is held.
- Adds concurrent load test that ensures lock attempts complete within a bounded window and return lock-busy errors instead of hanging.

## Validation
- `CGO_ENABLED=0 go test ./internal/storage/dolt -run 'TestAcquireAccessLock'`
  - Passed
- `go test ./internal/storage/dolt -run 'TestAcquireAccessLock'`
  - Blocked locally by missing ICU header (`unicode/regex.h`) in CGO toolchain.
