### PR TITLE
fix(doctor): use sync-worktree JSONL for DB/mtime checks in sync-branch mode (fixes #1667)

### DIFF
--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -556,25 +556,8 @@ func CheckDatabaseJSONLSync(path string) DoctorCheck {
 		dbPath = cfg.DatabasePath(beadsDir)
 	}
 
-	// Find JSONL file (respects metadata.json override when set).
-	jsonlPath := ""
-	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
-		if cfg.JSONLExport != "" && !isSystemJSONLFilename(cfg.JSONLExport) {
-			p := cfg.JSONLPath(beadsDir)
-			if _, err := os.Stat(p); err == nil {
-				jsonlPath = p
-			}
-		}
-	}
-	if jsonlPath == "" {
-		for _, name := range []string{"issues.jsonl", "beads.jsonl"} {
-			testPath := filepath.Join(beadsDir, name)
-			if _, err := os.Stat(testPath); err == nil {
-				jsonlPath = testPath
-				break
-			}
-		}
-	}
+	// Find JSONL file. In sync-branch mode prefer the sync worktree JSONL path.
+	jsonlPath := findJSONLFileWithSyncWorktree(path, beadsDir)
 
 	// If no database, skip this check
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {

--- a/cmd/bd/doctor/sync_branch_jsonl.go
+++ b/cmd/bd/doctor/sync_branch_jsonl.go
@@ -1,0 +1,153 @@
+package doctor
+
+import (
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
+	"gopkg.in/yaml.v3"
+)
+
+// findJSONLFileWithSyncWorktree returns the effective JSONL path for doctor checks.
+//
+// In sync-branch mode, JSONL writes happen in the sync worktree
+// (.git/beads-worktrees/<branch>/.beads/issues.jsonl) while main's .beads/issues.jsonl
+// may lag behind until branch merge. For DB-vs-JSONL checks we should compare against
+// the worktree JSONL when available.
+func findJSONLFileWithSyncWorktree(repoPath, beadsDir string) string {
+	mainJSONL := findJSONLFile(beadsDir)
+	if mainJSONL == "" {
+		return ""
+	}
+
+	worktreeJSONL := resolveSyncWorktreeJSONLPath(repoPath, beadsDir, mainJSONL)
+	if worktreeJSONL != "" {
+		return worktreeJSONL
+	}
+
+	return mainJSONL
+}
+
+func resolveSyncWorktreeJSONLPath(repoPath, beadsDir, mainJSONLPath string) string {
+	syncBranch := getConfiguredSyncBranch(beadsDir)
+	if syncBranch == "" {
+		return ""
+	}
+
+	repoRoot, gitCommonDir := getGitPaths(repoPath)
+	if repoRoot == "" || gitCommonDir == "" {
+		return ""
+	}
+
+	relPath, err := filepath.Rel(repoRoot, mainJSONLPath)
+	if err != nil {
+		return ""
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return ""
+	}
+
+	worktreeRoot := filepath.Join(gitCommonDir, "beads-worktrees", syncBranch)
+	worktreeJSONL := filepath.Join(worktreeRoot, relPath)
+	if _, err := os.Stat(worktreeJSONL); err != nil {
+		return ""
+	}
+	return worktreeJSONL
+}
+
+func getGitPaths(repoPath string) (repoRoot, gitCommonDir string) {
+	rootCmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	rootCmd.Dir = repoPath
+	rootOut, err := rootCmd.Output()
+	if err != nil {
+		return "", ""
+	}
+	repoRoot = strings.TrimSpace(string(rootOut))
+	if repoRoot == "" {
+		return "", ""
+	}
+
+	commonCmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	commonCmd.Dir = repoPath
+	commonOut, err := commonCmd.Output()
+	if err != nil {
+		return "", ""
+	}
+	gitCommonDir = strings.TrimSpace(string(commonOut))
+	if gitCommonDir == "" {
+		return "", ""
+	}
+	if !filepath.IsAbs(gitCommonDir) {
+		gitCommonDir = filepath.Join(repoRoot, gitCommonDir)
+	}
+
+	return repoRoot, gitCommonDir
+}
+
+type syncBranchYAML struct {
+	SyncBranch string `yaml:"sync-branch"`
+	Sync       struct {
+		Branch string `yaml:"branch"`
+	} `yaml:"sync"`
+}
+
+func getConfiguredSyncBranch(beadsDir string) string {
+	if envBranch := strings.TrimSpace(os.Getenv("BEADS_SYNC_BRANCH")); envBranch != "" {
+		return envBranch
+	}
+
+	if yamlBranch := getSyncBranchFromYAML(beadsDir); yamlBranch != "" {
+		return yamlBranch
+	}
+
+	return getSyncBranchFromDB(beadsDir)
+}
+
+func getSyncBranchFromYAML(beadsDir string) string {
+	data, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+	if err != nil {
+		return ""
+	}
+
+	var cfg syncBranchYAML
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return ""
+	}
+
+	if b := strings.TrimSpace(cfg.SyncBranch); b != "" {
+		return b
+	}
+	if b := strings.TrimSpace(cfg.Sync.Branch); b != "" {
+		return b
+	}
+	return ""
+}
+
+func getSyncBranchFromDB(beadsDir string) string {
+	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
+	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil && cfg.Database != "" {
+		dbPath = cfg.DatabasePath(beadsDir)
+	}
+
+	if _, err := os.Stat(dbPath); err != nil {
+		return ""
+	}
+
+	db, err := sql.Open("sqlite3", sqliteConnString(dbPath, true))
+	if err != nil {
+		return ""
+	}
+	defer db.Close()
+
+	var branch string
+	err = db.QueryRow("SELECT value FROM config WHERE key = 'sync.branch'").Scan(&branch)
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(branch)
+}

--- a/cmd/bd/doctor/sync_branch_jsonl_test.go
+++ b/cmd/bd/doctor/sync_branch_jsonl_test.go
@@ -1,0 +1,126 @@
+package doctor
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func setupSyncBranchWorktreeRepo(t *testing.T) (repoPath, worktreePath string) {
+	t.Helper()
+
+	repoPath = mkTmpDirInTmp(t, "bd-doctor-sync-worktree-*")
+	initRepo(t, repoPath, "main")
+	commitFile(t, repoPath, "README.md", "# test\n", "initial commit")
+	commitFile(t, repoPath, ".gitignore", ".beads/beads.db\n.beads/beads.db-wal\n.beads/beads.db-shm\n", "ignore sqlite db")
+	commitFile(t, repoPath, ".beads/config.yaml", "sync-branch: beads-sync\n", "configure sync branch")
+	commitFile(t, repoPath, ".beads/issues.jsonl", `{"id":"bd-1","title":"Issue 1","status":"open"}`+"\n", "add main jsonl")
+
+	runGit(t, repoPath, "branch", "beads-sync")
+
+	worktreePath = filepath.Join(repoPath, ".git", "beads-worktrees", "beads-sync")
+	runGit(t, repoPath, "worktree", "add", worktreePath, "beads-sync")
+
+	return repoPath, worktreePath
+}
+
+func writeJSONLIssues(t *testing.T, jsonlPath string, count int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(jsonlPath), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(jsonlPath), err)
+	}
+
+	var b strings.Builder
+	for i := 1; i <= count; i++ {
+		b.WriteString(fmt.Sprintf(`{"id":"bd-%d","title":"Issue %d","status":"open"}`, i, i))
+		b.WriteString("\n")
+	}
+	if err := os.WriteFile(jsonlPath, []byte(b.String()), 0644); err != nil {
+		t.Fatalf("write %s: %v", jsonlPath, err)
+	}
+}
+
+func createSyncDoctorTestDB(t *testing.T, dbPath string, issueCount int, lastImportTime *time.Time) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(dbPath), err)
+	}
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("CREATE TABLE issues (id TEXT PRIMARY KEY, status TEXT, ephemeral INTEGER)"); err != nil {
+		t.Fatalf("create issues table: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE config (key TEXT PRIMARY KEY, value TEXT)"); err != nil {
+		t.Fatalf("create config table: %v", err)
+	}
+	if _, err := db.Exec("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT)"); err != nil {
+		t.Fatalf("create metadata table: %v", err)
+	}
+
+	for i := 1; i <= issueCount; i++ {
+		if _, err := db.Exec("INSERT INTO issues (id, status, ephemeral) VALUES (?, ?, ?)", fmt.Sprintf("bd-%d", i), "open", 0); err != nil {
+			t.Fatalf("insert issue %d: %v", i, err)
+		}
+	}
+
+	if lastImportTime != nil {
+		if _, err := db.Exec("INSERT INTO metadata (key, value) VALUES (?, ?)", "last_import_time", lastImportTime.Format(time.RFC3339)); err != nil {
+			t.Fatalf("insert metadata: %v", err)
+		}
+	}
+}
+
+func TestCheckDatabaseJSONLSync_UsesSyncWorktreeJSONL(t *testing.T) {
+	repoPath, worktreePath := setupSyncBranchWorktreeRepo(t)
+
+	mainJSONL := filepath.Join(repoPath, ".beads", "issues.jsonl")
+	worktreeJSONL := filepath.Join(worktreePath, ".beads", "issues.jsonl")
+	dbPath := filepath.Join(repoPath, ".beads", "beads.db")
+
+	// Main JSONL is stale, sync worktree JSONL has current state.
+	writeJSONLIssues(t, mainJSONL, 1)
+	writeJSONLIssues(t, worktreeJSONL, 3)
+	createSyncDoctorTestDB(t, dbPath, 3, nil)
+
+	check := CheckDatabaseJSONLSync(repoPath)
+	if check.Status != StatusOK {
+		t.Fatalf("status=%q want %q (msg=%q detail=%q)", check.Status, StatusOK, check.Message, check.Detail)
+	}
+}
+
+func TestCheckSyncDivergence_UsesSyncWorktreeJSONLForMtime(t *testing.T) {
+	repoPath, worktreePath := setupSyncBranchWorktreeRepo(t)
+
+	mainJSONL := filepath.Join(repoPath, ".beads", "issues.jsonl")
+	worktreeJSONL := filepath.Join(worktreePath, ".beads", "issues.jsonl")
+	dbPath := filepath.Join(repoPath, ".beads", "beads.db")
+
+	writeJSONLIssues(t, mainJSONL, 1)
+	writeJSONLIssues(t, worktreeJSONL, 1)
+
+	worktreeTime := time.Now().Add(-1 * time.Minute).Round(time.Second)
+	mainTime := worktreeTime.Add(-10 * time.Minute)
+	if err := os.Chtimes(worktreeJSONL, worktreeTime, worktreeTime); err != nil {
+		t.Fatalf("chtimes worktree jsonl: %v", err)
+	}
+	if err := os.Chtimes(mainJSONL, mainTime, mainTime); err != nil {
+		t.Fatalf("chtimes main jsonl: %v", err)
+	}
+
+	createSyncDoctorTestDB(t, dbPath, 1, &worktreeTime)
+
+	check := CheckSyncDivergence(repoPath)
+	if check.Status != StatusOK {
+		t.Fatalf("status=%q want %q (msg=%q detail=%q)", check.Status, StatusOK, check.Message, check.Detail)
+	}
+}

--- a/cmd/bd/doctor/sync_divergence.go
+++ b/cmd/bd/doctor/sync_divergence.go
@@ -165,7 +165,7 @@ func checkJSONLGitDivergence(path, beadsDir string) *SyncDivergenceIssue {
 }
 
 // checkSQLiteMtimeDivergence checks if SQLite last_import_time matches JSONL mtime.
-func checkSQLiteMtimeDivergence(_, beadsDir string) *SyncDivergenceIssue { //nolint:unparam // path reserved for future use
+func checkSQLiteMtimeDivergence(path, beadsDir string) *SyncDivergenceIssue {
 	// Get database path
 	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil && cfg.Database != "" {
@@ -177,8 +177,8 @@ func checkSQLiteMtimeDivergence(_, beadsDir string) *SyncDivergenceIssue { //nol
 		return nil // No database
 	}
 
-	// Find JSONL file
-	jsonlPath := findJSONLFile(beadsDir)
+	// Find JSONL file. In sync-branch mode prefer the sync worktree JSONL path.
+	jsonlPath := findJSONLFileWithSyncWorktree(path, beadsDir)
 	if jsonlPath == "" {
 		return nil // No JSONL file
 	}


### PR DESCRIPTION
## Summary

Fixes #1667.

In `sync-branch` mode, `bd doctor` was comparing SQLite state against the main working copy JSONL (`.beads/issues.jsonl`), even though the active JSONL source-of-truth is the sync worktree JSONL (`.git/beads-worktrees/<branch>/.beads/issues.jsonl`).

This caused false positives such as:

- `DB-JSONL Sync: Count mismatch`
- `Sync Divergence: Database import time is newer than JSONL`

This PR makes doctor use the sync worktree JSONL (when available) for the two checks above.

Related reports: #1379, #1046  
Historical context: #927, #858, #1103  
Related prior fixes: #860, #916, #1144

## Background / Root Cause

After sync-branch workflow changes (notably #1103), JSONL writes are intentionally redirected to the sync worktree to avoid merge conflicts on the main branch.  
In that model:

- main `.beads/issues.jsonl` may be stale by design
- sync worktree JSONL is the current state used for sync operations

However, doctor checks still read JSONL from the main `.beads` directory, creating a source-of-truth mismatch and producing false warnings.

## What This PR Changes

1. Added a new helper: `cmd/bd/doctor/sync_branch_jsonl.go`
- Resolves the effective JSONL path for doctor checks.
- In sync-branch mode, prefers the sync worktree JSONL if it exists.
- Falls back to the existing main `.beads` JSONL path when sync-branch/worktree is not available.
- Sync-branch resolution precedence:
  - `BEADS_SYNC_BRANCH`
  - `.beads/config.yaml` (`sync-branch` / `sync.branch`)
  - DB config key `sync.branch` (legacy fallback)

2. Updated DB-JSONL check to use the effective JSONL path
- `CheckDatabaseJSONLSync` now calls the sync-worktree-aware resolver.

3. Updated SQLite mtime divergence check to use the effective JSONL path
- `checkSQLiteMtimeDivergence` now compares `last_import_time` against the same effective JSONL source.

## Scope / Non-goals

This PR intentionally changes only:
- DB-vs-JSONL comparison path selection
- SQLite-vs-JSONL mtime comparison path selection

It does **not** alter other doctor checks outside this false-positive path issue.

## Tests

Added regression tests in `cmd/bd/doctor/sync_branch_jsonl_test.go`:

- `TestCheckDatabaseJSONLSync_UsesSyncWorktreeJSONL`
  - main JSONL stale, worktree JSONL current, DB matches worktree
  - expected: `StatusOK` (no false count mismatch)

- `TestCheckSyncDivergence_UsesSyncWorktreeJSONLForMtime`
  - DB `last_import_time` matches worktree JSONL mtime, main JSONL older
  - expected: `StatusOK` (no false mtime divergence)

Validated locally with:
- `go test ./cmd/bd/doctor -run "TestCheckDatabaseJSONLSync_UsesSyncWorktreeJSONL|TestCheckSyncDivergence_UsesSyncWorktreeJSONLForMtime" -count=1`
- `go test ./cmd/bd/doctor -run "TestCheckDatabaseJSONLSync|TestCheckSyncDivergence" -count=1`

## Why this is safe

- No behavior change for non-sync-branch repos.
- In sync-branch repos, this aligns doctor checks with actual runtime data flow and existing worktree-based sync semantics.
- Fallback behavior preserves previous path resolution when worktree JSONL is unavailable.