### PR TITLE
docs: add beadsmap to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -35,6 +35,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[Beadspace](https://github.com/cameronsjo/beadspace)** - Drop-in GitHub Pages dashboard with triage suggestions, priority/status breakdowns, and searchable issue table. Single HTML file, zero build dependencies, auto-deploys via GitHub Action. Built by [@cameronsjo](https://github.com/cameronsjo). (HTML/CSS/JS)
 
+- **[beadsmap](https://github.com/dariye/beadsmap)** - Interactive roadmap visualization with timeline (Gantt), list, and table views. Multi-source support, dependency arrows, milestone grouping, GitHub integration via OAuth device flow, and light/dark/system themes. Ships as a single `index.html`. Built by [@dariye](https://github.com/dariye). (Svelte/TypeScript)
+
 ## Editor Extensions
 
 - **[vscode-beads](https://marketplace.visualstudio.com/items?itemName=planet57.vscode-beads)** - VS Code extension with issues panel and daemon management. Built by [@jdillon](https://github.com/jdillon). (TypeScript)


### PR DESCRIPTION
## Summary

Adds [beadsmap](https://github.com/dariye/beadsmap) to the Web UIs section of COMMUNITY_TOOLS.md.

beadsmap is an interactive roadmap visualization for beads issues with:

- **Timeline view** — Gantt-style chart with dependency arrows, milestones, and zoom controls
- **List view** — Group by priority, status, type, assignee, label, or source
- **Table view** — Sortable columns with inline status badges
- **Multi-source** — Load multiple projects with color-coded differentiation
- **GitHub integration** — Connect via OAuth device flow, load repos with `.beads/`, sync back
- **File / Paste input** — Drag-and-drop `.jsonl`, browse files, or paste `bd export` output
- **Light / Dark / System themes**
- **Single-file build** — Ships as one `index.html` via `vite-plugin-singlefile`

Built with Svelte 5 and TypeScript.

![screenshot](https://raw.githubusercontent.com/dariye/beadsmap/main/docs/screenshot.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)