### PR TITLE
Fix bd sync with Hosted Dolt: TLS, auth, pull, and branch handling

### DIFF
--- a/cmd/bd/doctor/server.go
+++ b/cmd/bd/doctor/server.go
@@ -172,13 +172,18 @@ func checkDoltVersion(cfg *configfile.Config) (DoctorCheck, *sql.DB) {
 	password := os.Getenv("BEADS_DOLT_PASSWORD")
 
 	// Build DSN without database (just to test server connectivity)
+	// Include tls=true if configured (required by Hosted Dolt)
+	params := "parseTime=true&timeout=5s"
+	if cfg.GetDoltServerTLS() {
+		params += "&tls=true"
+	}
 	var connStr string
 	if password != "" {
-		connStr = fmt.Sprintf("%s:%s@tcp(%s:%d)/?parseTime=true&timeout=5s",
-			user, password, host, port)
+		connStr = fmt.Sprintf("%s:%s@tcp(%s:%d)/?%s",
+			user, password, host, port, params)
 	} else {
-		connStr = fmt.Sprintf("%s@tcp(%s:%d)/?parseTime=true&timeout=5s",
-			user, host, port)
+		connStr = fmt.Sprintf("%s@tcp(%s:%d)/?%s",
+			user, host, port, params)
 	}
 
 	db, err := sql.Open("mysql", connStr)

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -642,6 +642,8 @@ var rootCmd = &cobra.Command{
 					opts.ServerMode = true
 					opts.ServerHost = cfg.GetDoltServerHost()
 					opts.ServerPort = cfg.GetDoltServerPort()
+					opts.ServerUser = cfg.GetDoltServerUser()
+					opts.ServerTLS = cfg.GetDoltServerTLS()
 				}
 			}
 

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -27,6 +27,7 @@ type Config struct {
 	DoltServerPort int    `json:"dolt_server_port,omitempty"` // Server port (default: 3307)
 	DoltServerUser string `json:"dolt_server_user,omitempty"` // MySQL user (default: root)
 	DoltDatabase   string `json:"dolt_database,omitempty"`    // SQL database name (default: beads)
+	DoltServerTLS  bool   `json:"dolt_server_tls,omitempty"`  // Enable TLS for server connections (required by Hosted Dolt)
 	// Note: Password should be set via BEADS_DOLT_PASSWORD env var for security
 
 	// Stale closed issues check configuration
@@ -302,4 +303,14 @@ func (c *Config) GetDoltDatabase() string {
 		return c.DoltDatabase
 	}
 	return DefaultDoltDatabase
+}
+
+// GetDoltServerTLS returns whether TLS should be used for server connections.
+// Checks BEADS_DOLT_SERVER_TLS env var first, then config.
+// Hosted Dolt instances require TLS; local servers typically don't.
+func (c *Config) GetDoltServerTLS() bool {
+	if t := os.Getenv("BEADS_DOLT_SERVER_TLS"); t == "1" || strings.EqualFold(t, "true") {
+		return true
+	}
+	return c.DoltServerTLS
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -762,15 +762,16 @@ func (s *DoltStore) Push(ctx context.Context) error {
 // Pull pulls changes from the remote
 func (s *DoltStore) Pull(ctx context.Context) error {
 	if s.remoteUser != "" {
-		// Authenticated pull (e.g., Hosted Dolt requires --user flag)
-		_, err := s.db.ExecContext(ctx, "CALL DOLT_PULL('--user', ?, ?)", s.remoteUser, s.remote)
+		// Authenticated pull with explicit branch (Hosted Dolt requires --user flag,
+		// and branch must be explicit since tracking may not be configured)
+		_, err := s.db.ExecContext(ctx, "CALL DOLT_PULL('--user', ?, ?, ?)", s.remoteUser, s.remote, s.branch)
 		if err != nil {
-			return fmt.Errorf("failed to pull from %s: %w", s.remote, err)
+			return fmt.Errorf("failed to pull from %s/%s: %w", s.remote, s.branch, err)
 		}
 	} else {
-		_, err := s.db.ExecContext(ctx, "CALL DOLT_PULL(?)", s.remote)
+		_, err := s.db.ExecContext(ctx, "CALL DOLT_PULL(?, ?)", s.remote, s.branch)
 		if err != nil {
-			return fmt.Errorf("failed to pull from %s: %w", s.remote, err)
+			return fmt.Errorf("failed to pull from %s/%s: %w", s.remote, s.branch, err)
 		}
 	}
 	return nil

--- a/internal/storage/factory/factory.go
+++ b/internal/storage/factory/factory.go
@@ -35,6 +35,10 @@ type Options struct {
 	ServerTLS   bool          // Enable TLS for MySQL connections (required by Hosted Dolt)
 	Database    string        // Database name for Dolt server mode (default: beads)
 	OpenTimeout time.Duration // Advisory lock timeout for embedded dolt (0 = no lock)
+
+	// Remote authentication for push/pull (Hosted Dolt)
+	RemoteUser     string // User for authenticated push/pull
+	RemotePassword string // Password for authenticated push/pull
 }
 
 // New creates a storage backend based on the backend type.

--- a/internal/storage/factory/factory.go
+++ b/internal/storage/factory/factory.go
@@ -28,10 +28,11 @@ type Options struct {
 	LockTimeout time.Duration
 
 	// Dolt server mode options (federation)
-	ServerMode bool   // Connect to dolt sql-server instead of embedded
-	ServerHost string // Server host (default: 127.0.0.1)
-	ServerPort int    // Server port (default: 3307)
+	ServerMode  bool          // Connect to dolt sql-server instead of embedded
+	ServerHost  string        // Server host (default: 127.0.0.1)
+	ServerPort  int           // Server port (default: 3307)
 	ServerUser  string        // MySQL user (default: root)
+	ServerTLS   bool          // Enable TLS for MySQL connections (required by Hosted Dolt)
 	Database    string        // Database name for Dolt server mode (default: beads)
 	OpenTimeout time.Duration // Advisory lock timeout for embedded dolt (0 = no lock)
 }
@@ -105,6 +106,9 @@ func NewFromConfigWithOptions(ctx context.Context, beadsDir string, opts Options
 			}
 			if opts.Database == "" {
 				opts.Database = cfg.GetDoltDatabase()
+			}
+			if !opts.ServerTLS {
+				opts.ServerTLS = cfg.GetDoltServerTLS()
 			}
 		}
 		return NewWithOptions(ctx, backend, cfg.DatabasePath(beadsDir), opts)

--- a/internal/storage/factory/factory_dolt.go
+++ b/internal/storage/factory/factory_dolt.go
@@ -25,15 +25,17 @@ func init() {
 		}
 
 		store, err := dolt.New(ctx, &dolt.Config{
-			Path:        path,
-			Database:    opts.Database,
-			ReadOnly:    opts.ReadOnly,
-			OpenTimeout: opts.OpenTimeout,
-			ServerMode:  opts.ServerMode,
-			ServerHost:  opts.ServerHost,
-			ServerPort:  opts.ServerPort,
-			ServerUser:  opts.ServerUser,
-			ServerTLS:   opts.ServerTLS,
+			Path:           path,
+			Database:       opts.Database,
+			ReadOnly:       opts.ReadOnly,
+			OpenTimeout:    opts.OpenTimeout,
+			ServerMode:     opts.ServerMode,
+			ServerHost:     opts.ServerHost,
+			ServerPort:     opts.ServerPort,
+			ServerUser:     opts.ServerUser,
+			ServerTLS:      opts.ServerTLS,
+			RemoteUser:     opts.RemoteUser,
+			RemotePassword: opts.RemotePassword,
 		})
 		if err != nil {
 			// If server mode failed with a connection error, fall back to embedded mode.

--- a/internal/storage/factory/factory_dolt.go
+++ b/internal/storage/factory/factory_dolt.go
@@ -33,6 +33,7 @@ func init() {
 			ServerHost:  opts.ServerHost,
 			ServerPort:  opts.ServerPort,
 			ServerUser:  opts.ServerUser,
+			ServerTLS:   opts.ServerTLS,
 		})
 		if err != nil {
 			// If server mode failed with a connection error, fall back to embedded mode.


### PR DESCRIPTION
## Summary

This PR fixes four issues that prevent `bd sync` from working with Hosted Dolt remotes. Together, they make it possible to round-trip data between a local embedded Dolt database and a Hosted Dolt instance via `bd sync`.

## Fix 1: TLS support for Dolt server mode connections (`858a6fbb`)

Hosted Dolt requires TLS. The existing MySQL DSN construction didn't support TLS, causing connection failures. Added `BEADS_DOLT_SERVER_TLS` env var (and config key `DoltServerTLS`) to enable `tls=true` on the DSN. Also added a TLS connectivity check to `bd doctor`.

**Files:** `cmd/bd/doctor/server.go`, `cmd/bd/main.go`, `internal/configfile/configfile.go`, `internal/storage/dolt/store.go`, `internal/storage/factory/factory.go`, `internal/storage/factory/factory_dolt.go`

## Fix 2: Remote authentication for push/pull (`dafa6289`)

Hosted Dolt requires the `--user` flag in `CALL DOLT_PUSH()` and `CALL DOLT_PULL()`. Without it, calls fail with `authorization header did not start with 'Basic'`. Because this error message contains the substring "remote", the existing error handling misinterprets it as "No Dolt remote configured" and silently skips the operation.

Added `remoteUser` and `remotePassword` fields to `DoltStore` and `Config`. When `DOLT_REMOTE_USER` env var (or config `RemoteUser`) is set, Push/Pull include the `--user` flag. The password is read by Dolt from the `DOLT_REMOTE_PASSWORD` env var per Dolt convention.

**Files:** `internal/storage/dolt/store.go`, `internal/storage/factory/factory.go`, `internal/storage/factory/factory_dolt.go`

## Fix 3: `bd sync` never pulls in dolt-native mode (`a8523e2f`)

`bd sync` (via `doExportSync()`) only performed commit + push. It never pulled from the remote, so changes made through Hosted Dolt were never synced back. Pull only happened in `doPullFirstSync()`, which requires the `--full` flag.

Added a pull step to `doExportSync()` before commit + push for dolt-native and belt-and-suspenders modes. Flow is now: pull → commit → push.

**Files:** `cmd/bd/sync.go`

## Fix 4: DOLT_PULL fails without explicit branch (`26051064`)

`CALL DOLT_PULL('origin')` fails when branch tracking is not configured: `You asked to pull from the remote 'origin', but did not specify a branch.` This error also contains "remote", triggering the same silent skip as Fix 2.

Pass the branch name explicitly in all DOLT_PULL calls, matching what DOLT_PUSH already does.

**Files:** `internal/storage/dolt/store.go`

## Testing

Tested against a live Hosted Dolt instance (`my-instance.dbs.hosted.doltdb.com`):
- `bd sync` successfully pulls changes from Hosted Dolt to local embedded Dolt
- `bd sync` successfully pushes local commits to Hosted Dolt
- Round-trip verified: changes made via Hosted Dolt appear locally after sync

Unit tests pass (`go test -short ./...`). The Dolt storage package tests fail to build on both this branch and `main` due to a missing ICU C header (`go-icu-regex`) — this is a pre-existing issue unrelated to these changes.