### PR TITLE
fix(doctor): respect dolt_mode server in embedded Dolt checks

### DIFF
--- a/cmd/bd/doctor/server.go
+++ b/cmd/bd/doctor/server.go
@@ -110,8 +110,8 @@ func RunServerHealthChecks(path string) ServerHealthResult {
 		}
 	}()
 
-	// Get database name from config (default: "beads")
-	database := "beads" // Default database name for Dolt server mode
+	// Get database name from config (uses dolt_database field, default: "beads")
+	database := cfg.GetDoltDatabase()
 
 	// Check 3: Database exists and is queryable
 	dbExistsCheck := checkDatabaseExists(db, database)


### PR DESCRIPTION
## Summary

- Fix crash in `bd doctor` when `dolt_mode: "server"` is configured: the embedded Dolt checks unconditionally used `sql.Open("dolt", ...)`, causing a nil pointer dereference when the embedded driver's scanner found `.dolt-data/` in the working directory
- Add `openDoltDB`/`closeDoltDB` helpers that check `IsDoltServerMode()` and route to MySQL driver (server) or embedded driver accordingly
- Fix `RunServerHealthChecks` to use `cfg.GetDoltDatabase()` instead of hardcoded "beads" database name

## Root Cause

Five functions in the doctor package (`CheckDoltConnection`, `CheckDoltSchema`, `CheckDoltIssueCount`, `CheckDoltStatus` in `dolt.go`, and `checkDoltLocks` in `migration_validation.go`) hardcoded the Dolt embedded driver. In server-mode setups:

1. `sql.Open("dolt", "file://...")` triggers the embedded driver's `MultiRepoEnv` scanner
2. Scanner scans CWD for databases, finds `.dolt-data/.dolt/` (the running server's metadata)
3. Attempts to open databases locked by the running Dolt SQL server
4. Nil pointer dereference in `ref.WorkingSetRefForHead` → panic

This caused `bd doctor --json` to panic, making `gt doctor` hang at the `repo-fingerprint` check for minutes. Affects all Gas Town users with `dolt_mode: "server"` and `bd` >= `30e8c992` (Feb 4, 2026).

## Changes

| File | Change |
|------|--------|
| `dolt.go` | Add `openDoltDB`/`closeDoltDB` helpers; refactor 4 check functions |
| `migration_validation.go` | Refactor `checkDoltLocks` to use helpers; remove redundant driver import |
| `server.go` | Use `cfg.GetDoltDatabase()` instead of hardcoded "beads" |

## User Impact

- **Embedded-mode users**: No change — existing code path preserved (`openDoltDBEmbedded`)
- **Server-mode users with server running**: Checks now connect via MySQL, work correctly
- **Server-mode users with server down**: Graceful error (StatusWarning) instead of crash

## Test plan

- [x] `CGO_ENABLED=1 go build ./cmd/bd/` passes
- [x] `CGO_ENABLED=0 go build ./cmd/bd/` passes
- [x] `go test ./cmd/bd/doctor/...` passes (13.7s)
- [x] `bd doctor --migration=post`: `dolt_healthy: true`, `dolt_locked: false` (confirms `checkDoltLocks` works via server)
- [x] `bd doctor --server`: All checks pass including `Database 'hq' accessible` (was failing with hardcoded "beads")
- [ ] Test with embedded-mode beads installation (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)