### PR TITLE
feat(linear): implement full project sync with hierarchy support

### DIFF
--- a/cmd/bd/linear_sync.go
+++ b/cmd/bd/linear_sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,6 +24,7 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 	}
 
 	var linearIssues []linear.Issue
+	var linearProjects []linear.Project
 	lastSyncStr, _ := store.GetConfig(ctx, "linear.last_sync")
 
 	if lastSyncStr != "" {
@@ -33,6 +35,10 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 			if err != nil {
 				return stats, fmt.Errorf("failed to fetch issues from Linear: %w", err)
 			}
+			linearProjects, err = client.FetchProjects(ctx, state)
+			if err != nil {
+				return stats, fmt.Errorf("failed to fetch projects from Linear: %w", err)
+			}
 		} else {
 			stats.Incremental = true
 			stats.SyncedSince = lastSyncStr
@@ -40,6 +46,16 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 			if err != nil {
 				return stats, fmt.Errorf("failed to fetch issues from Linear (incremental): %w", err)
 			}
+			// Note: Linear API doesn't support FetchProjectsSince easily, so we fetch all for now
+			// or we could implement FetchProjectsSince if needed. For now, full fetch of projects
+			// is usually acceptable as there are fewer projects than issues.
+			// Ideally we would filter by updatedAt in the client.
+			// Let's assume FetchProjects fetches all relevant projects for now.
+			linearProjects, err = client.FetchProjects(ctx, state)
+			if err != nil {
+				return stats, fmt.Errorf("failed to fetch projects from Linear: %w", err)
+			}
+
 			if !dryRun {
 				fmt.Printf("  Incremental sync since %s\n", lastSync.Format("2006-01-02 15:04:05"))
 			}
@@ -48,6 +64,10 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 		linearIssues, err = client.FetchIssues(ctx, state)
 		if err != nil {
 			return stats, fmt.Errorf("failed to fetch issues from Linear: %w", err)
+		}
+		linearProjects, err = client.FetchProjects(ctx, state)
+		if err != nil {
+			return stats, fmt.Errorf("failed to fetch projects from Linear: %w", err)
 		}
 		if !dryRun {
 			fmt.Println("  Full sync (no previous sync timestamp)")
@@ -62,6 +82,16 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 	var beadsIssues []*types.Issue
 	var allDeps []linear.DependencyInfo
 	linearIDToBeadsID := make(map[string]string)
+
+	// Process Projects first (Epics)
+	for i := range linearProjects {
+		epic := linear.ProjectToEpic(&linearProjects[i])
+		beadsIssues = append(beadsIssues, epic)
+		// No dependencies from Project -> Epic conversion directly here,
+		// but we track the ID mapping.
+		// Note: Project IDs are UUIDs, not user-facing IDs like TEAM-123.
+		// We use the URL or ID as the external ref.
+	}
 
 	for i := range linearIssues {
 		conversion := linear.IssueToBeads(&linearIssues[i], mappingConfig)
@@ -82,6 +112,14 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 				filteredIssues = append(filteredIssues, issue)
 				continue
 			}
+			// Check if it's a linear issue or project URL
+			if !linear.IsLinearExternalRef(*issue.ExternalRef) {
+				// Might be a project URL, check logic here or just allow if not standard issue ref
+				// For now, if we can't extract an ID, we assume it's not skippable by ID
+				filteredIssues = append(filteredIssues, issue)
+				continue
+			}
+
 			linearID := linear.ExtractLinearIdentifier(*issue.ExternalRef)
 			if linearID != "" && skipLinearIDs[linearID] {
 				skipped++
@@ -151,10 +189,10 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 
 	if dryRun {
 		if stats.Incremental {
-			fmt.Printf("  Would import %d issues from Linear (incremental since %s)\n",
-				len(linearIssues), stats.SyncedSince)
+			fmt.Printf("  Would import %d issues and %d projects from Linear (incremental since %s)\n",
+				len(linearIssues), len(linearProjects), stats.SyncedSince)
 		} else {
-			fmt.Printf("  Would import %d issues from Linear (full sync)\n", len(linearIssues))
+			fmt.Printf("  Would import %d issues and %d projects from Linear (full sync)\n", len(linearIssues), len(linearProjects))
 		}
 		return stats, nil
 	}
@@ -165,14 +203,45 @@ func doPullFromLinear(ctx context.Context, dryRun bool, state string, skipLinear
 		return stats, nil
 	}
 
+	// Re-scan for mapping, including Projects which might use UUIDs
+	// We need to fetch all issues again to be safe, or just iterate what we have in memory if we trust it
+	// But `store.SearchIssues` is authoritative.
 	for _, issue := range allBeadsIssues {
-		if issue.ExternalRef != nil && linear.IsLinearExternalRef(*issue.ExternalRef) {
+		if issue.ExternalRef == nil {
+			continue
+		}
+		// Check for standard Linear Issue
+		if linear.IsLinearExternalRef(*issue.ExternalRef) {
 			linearID := linear.ExtractLinearIdentifier(*issue.ExternalRef)
 			if linearID != "" {
 				linearIDToBeadsID[linearID] = issue.ID
 			}
+		} else {
+			// Check if it's a Project
+			// Project URLs: https://linear.app/team/project/name-slug-uuid
+			// We can try to match the URL against the projects we just fetched to find the UUID
+			for _, proj := range linearProjects {
+				if proj.URL == *issue.ExternalRef {
+					linearIDToBeadsID[proj.ID] = issue.ID
+					break
+				}
+			}
 		}
 	}
+
+	// Prioritize parent-child dependencies to avoid cycle detection failures.
+	// We consider parent-child relationships structural and more important than blocking links.
+	sort.Slice(allDeps, func(i, j int) bool {
+		isParentChildI := allDeps[i].Type == "parent-child"
+		isParentChildJ := allDeps[j].Type == "parent-child"
+		if isParentChildI && !isParentChildJ {
+			return true
+		}
+		if !isParentChildI && isParentChildJ {
+			return false
+		}
+		return false
+	})
 
 	depsCreated := 0
 	for _, dep := range allDeps {
@@ -259,9 +328,25 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 
 	var toCreate []*types.Issue
 	var toUpdate []*types.Issue
+	var epicsToCreate []*types.Issue
+	var epicsToUpdate []*types.Issue
 
 	for _, issue := range allIssues {
 		if issue.IsTombstone() {
+			continue
+		}
+
+		// Separate Epics (Projects) from other issues
+		if issue.IssueType == types.TypeEpic {
+			if issue.ExternalRef != nil {
+				// Assume it's a linear project if it has an external ref (weak check, but ok for now)
+				// We really should check if it's a linear URL
+				if !createOnly {
+					epicsToUpdate = append(epicsToUpdate, issue)
+				}
+			} else {
+				epicsToCreate = append(epicsToCreate, issue)
+			}
 			continue
 		}
 
@@ -284,6 +369,154 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 
 	mappingConfig := loadLinearMappingConfig(ctx)
 
+	// Map to track created/existing Project IDs for linking tasks
+	// Map: Beads Epic ID -> Linear Project ID
+	epicIDToProjectID := make(map[string]string)
+
+	// Phase 1: Sync Epics (Projects)
+	// 1a. Create new Projects
+	for _, issue := range epicsToCreate {
+		if dryRun {
+			stats.Created++
+			continue
+		}
+
+		projectState := "planned" // default
+		switch issue.Status {
+		case types.StatusInProgress:
+			projectState = "started"
+		case types.StatusBlocked:
+			projectState = "paused"
+		case types.StatusClosed:
+			if issue.ClosedAt != nil {
+				projectState = "completed"
+			} else {
+				projectState = "canceled"
+			}
+		}
+
+		proj, err := client.CreateProject(ctx, issue.Title, issue.Description, projectState)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to create project '%s' in Linear: %v\n", issue.Title, err)
+			stats.Errors++
+			continue
+		}
+
+		stats.Created++
+		fmt.Printf("  Created Project: %s -> %s\n", issue.ID, proj.Name)
+		epicIDToProjectID[issue.ID] = proj.ID
+
+		if updateRefs && proj.URL != "" {
+			updates := map[string]interface{}{
+				"external_ref": proj.URL,
+			}
+			if err := store.UpdateIssue(ctx, issue.ID, updates, actor); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to update external_ref for %s: %v\n", issue.ID, err)
+				stats.Errors++
+			}
+		}
+	}
+
+	// 1b. Update existing Projects
+	if !createOnly && len(epicsToUpdate) > 0 {
+		// Need to know the Project ID for existing epics to update them.
+		// Fetch all projects to map URL -> ID.
+		var projects []linear.Project
+		var err error
+		if !dryRun {
+			projects, err = client.FetchProjects(ctx, "all")
+			if err != nil {
+				return stats, fmt.Errorf("failed to fetch projects for update mapping: %w", err)
+			}
+		}
+
+		projectURLToID := make(map[string]string)
+		for _, p := range projects {
+			projectURLToID[p.URL] = p.ID
+		}
+
+		for _, issue := range epicsToUpdate {
+			if dryRun {
+				stats.Updated++
+				continue
+			}
+
+			projectID, ok := projectURLToID[*issue.ExternalRef]
+			if !ok {
+				// Try to extract ID if URL format allows, or skip
+				// For now, warn and skip
+				fmt.Fprintf(os.Stderr, "Warning: could not resolve Project ID for %s (ref: %s), skipping update\n",
+					issue.ID, *issue.ExternalRef)
+				stats.Skipped++
+				continue
+			}
+
+			// Add to map for task linking (in case we didn't fetch it in 1b setup)
+			epicIDToProjectID[issue.ID] = projectID
+
+			// Build project updates (no helper for Local->Project yet, doing manually)
+			projectUpdates := map[string]interface{}{
+				"name":        issue.Title,
+				"description": issue.Description,
+			}
+
+			// Map State
+			var projectState string
+			switch issue.Status {
+			case types.StatusOpen:
+				projectState = "planned"
+			case types.StatusInProgress:
+				projectState = "started"
+			case types.StatusBlocked:
+				projectState = "paused"
+			case types.StatusClosed:
+				if issue.ClosedAt != nil {
+					projectState = "completed"
+				} else {
+					projectState = "canceled"
+				}
+			}
+			projectUpdates["state"] = projectState
+
+			// We should check if update is needed (timestamps/hash), but for now force update
+			// as hash logic for projects isn't fully robust yet.
+			// TODO: Add hash check for projects to reduce API calls.
+
+			_, err := client.UpdateProject(ctx, projectID, projectUpdates)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to update project '%s' in Linear: %v\n", issue.Title, err)
+				stats.Errors++
+				continue
+			}
+			stats.Updated++
+			fmt.Printf("  Updated Project: %s -> %s\n", issue.ID, issue.Title)
+		}
+	} else if !dryRun {
+		// Populate epicIDToProjectID even if we're not updating projects, so we can link tasks
+		projects, err := client.FetchProjects(ctx, "all")
+		if err == nil {
+			projectURLToID := make(map[string]string)
+			for _, p := range projects {
+				projectURLToID[p.URL] = p.ID
+			}
+			for _, issue := range allIssues {
+				if issue.IssueType == types.TypeEpic && issue.ExternalRef != nil {
+					if pid, ok := projectURLToID[*issue.ExternalRef]; ok {
+						epicIDToProjectID[issue.ID] = pid
+					}
+				}
+			}
+		}
+	}
+
+	// Phase 2: Sync Tasks/Bugs (Issues)
+	// We separate creation from linking to handle dependencies robustly.
+
+	// Track issues processed in this batch to support linking in Phase 3
+	// Map: BeadsID -> Linear Issue (with Identifier)
+	processedIssues := make(map[string]*linear.Issue)
+
+	// Phase 2a: Create new issues (without parent link)
 	for _, issue := range toCreate {
 		if dryRun {
 			stats.Created++
@@ -292,10 +525,26 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 
 		linearPriority := linear.PriorityToLinear(issue.Priority, mappingConfig)
 		stateID := stateCache.FindStateForBeadsStatus(issue.Status)
-
 		description := linear.BuildLinearDescription(issue)
 
-		linearIssue, err := client.CreateIssue(ctx, issue.Title, description, linearPriority, stateID, nil)
+		// Resolve Project ID (Epic) - OK to do here as Epics are already processed
+		var projectID string
+		deps, err := store.GetDependencyRecords(ctx, issue.ID)
+		if err == nil {
+			for _, dep := range deps {
+				if dep.Type == types.DepParentChild {
+					parentIssue, err := store.GetIssue(ctx, dep.DependsOnID)
+					if err == nil && parentIssue.IssueType == types.TypeEpic {
+						if pid, ok := epicIDToProjectID[parentIssue.ID]; ok {
+							projectID = pid
+						}
+					}
+				}
+			}
+		}
+
+		// Create without parentID (will link in Phase 3)
+		linearIssue, err := client.CreateIssue(ctx, issue.Title, description, linearPriority, stateID, nil, projectID, "")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to create issue '%s' in Linear: %v\n", issue.Title, err)
 			stats.Errors++
@@ -304,6 +553,7 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 
 		stats.Created++
 		fmt.Printf("  Created: %s -> %s\n", issue.ID, linearIssue.Identifier)
+		processedIssues[issue.ID] = linearIssue
 
 		if updateRefs && linearIssue.URL != "" {
 			externalRef := linearIssue.URL
@@ -313,13 +563,16 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 			updates := map[string]interface{}{
 				"external_ref": externalRef,
 			}
+			// Update local issue so Phase 3 can find the ref
 			if err := store.UpdateIssue(ctx, issue.ID, updates, actor); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update external_ref for %s: %v\n", issue.ID, err)
 				stats.Errors++
 			}
+			issue.ExternalRef = &externalRef // Update in-memory object too
 		}
 	}
 
+	// Phase 2b: Update existing issues (content + project link)
 	if len(toUpdate) > 0 && !createOnly {
 		for _, issue := range toUpdate {
 			if skipUpdateIDs != nil && skipUpdateIDs[issue.ID] {
@@ -349,6 +602,8 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 				continue
 			}
 
+			processedIssues[issue.ID] = linearIssue
+
 			linearUpdatedAt, err := time.Parse(time.RFC3339, linearIssue.UpdatedAt)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to parse Linear UpdatedAt for %s: %v\n",
@@ -358,7 +613,11 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 			}
 
 			forcedUpdate := forceUpdateIDs != nil && forceUpdateIDs[issue.ID]
+			// We check dependencies for project change, which might not be reflected in UpdatedAt.
+			// But for now, we rely on standard freshness check unless forced.
 			if !forcedUpdate && !issue.UpdatedAt.After(linearUpdatedAt) {
+				// Even if content matches, we might need to link subtasks in Phase 3.
+				// So we continue to next issue but still add to processedIssues (done above).
 				stats.Skipped++
 				continue
 			}
@@ -378,7 +637,6 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 			}
 
 			description := linear.BuildLinearDescription(issue)
-
 			updatePayload := map[string]interface{}{
 				"title":       issue.Title,
 				"description": description,
@@ -394,6 +652,30 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 				updatePayload["stateId"] = stateID
 			}
 
+			// Update Project if changed
+			var projectID string
+			deps, err := store.GetDependencyRecords(ctx, issue.ID)
+			if err == nil {
+				for _, dep := range deps {
+					if dep.Type == types.DepParentChild {
+						parentIssue, err := store.GetIssue(ctx, dep.DependsOnID)
+						if err == nil && parentIssue.IssueType == types.TypeEpic {
+							if pid, ok := epicIDToProjectID[parentIssue.ID]; ok {
+								projectID = pid
+							}
+						}
+					}
+				}
+			}
+			if projectID != "" {
+				updatePayload["projectId"] = projectID
+			} else if linearIssue.Project != nil {
+				// If issue has project in Linear but not locally (or dependency removed),
+				// we should clear it. Linear API allows null?
+				// "projectId": nil
+				updatePayload["projectId"] = nil
+			}
+
 			updatedLinearIssue, err := client.UpdateIssue(ctx, linearIssue.ID, updatePayload)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update Linear issue %s: %v\n",
@@ -404,6 +686,76 @@ func doPushToLinear(ctx context.Context, dryRun bool, createOnly bool, updateRef
 
 			stats.Updated++
 			fmt.Printf("  Updated: %s -> %s\n", issue.ID, updatedLinearIssue.Identifier)
+		}
+	}
+
+	// Phase 3: Link Subtasks (Parent-Child relationships)
+	// Iterate over all processed issues and check if they need to be linked to a parent Task.
+	if !dryRun && !createOnly {
+		// Identify issues that need parent linking
+		// We can check allIssues (that were processed)
+		for beadsID, linearIssue := range processedIssues {
+			// Find parent dependency
+			deps, err := store.GetDependencyRecords(ctx, beadsID)
+			if err != nil {
+				continue
+			}
+
+			var targetParentID string
+			for _, dep := range deps {
+				if dep.Type == types.DepParentChild {
+					// Check if parent is a Task (not Epic)
+					parentIssue, err := store.GetIssue(ctx, dep.DependsOnID)
+					if err == nil && parentIssue.IssueType != types.TypeEpic {
+						// This is a subtask relationship
+						// Need parent's Linear ID (UUID)
+						// Check if parent is in processedIssues (created/updated in this batch)
+						if pLinear, ok := processedIssues[parentIssue.ID]; ok {
+							targetParentID = pLinear.ID
+						} else if parentIssue.ExternalRef != nil && linear.IsLinearExternalRef(*parentIssue.ExternalRef) {
+							// Parent exists but wasn't processed in this batch
+							// Need to fetch/resolve its ID.
+							// IsLinearExternalRef gives URL. Extract identifier.
+							pIdentifier := linear.ExtractLinearIdentifier(*parentIssue.ExternalRef)
+							if pIdentifier != "" {
+								// Optimization: We could cache these lookups
+								pIssue, err := client.FetchIssueByIdentifier(ctx, pIdentifier)
+								if err == nil && pIssue != nil {
+									targetParentID = pIssue.ID
+								}
+							}
+						}
+						break // Only one parent allowed in Linear
+					}
+				}
+			}
+
+			// Check if we need to update
+			currentParentID := ""
+			if linearIssue.Parent != nil {
+				currentParentID = linearIssue.Parent.ID
+			}
+
+			if targetParentID != currentParentID {
+				if targetParentID == "" && currentParentID == "" {
+					continue
+				}
+
+				fmt.Printf("  Linking subtask %s to parent %s...\n", linearIssue.Identifier, targetParentID)
+
+				updatePayload := map[string]interface{}{}
+				if targetParentID != "" {
+					updatePayload["parentId"] = targetParentID
+				} else {
+					updatePayload["parentId"] = nil
+				}
+
+				_, err := client.UpdateIssue(ctx, linearIssue.ID, updatePayload)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to link subtask %s: %v\n", linearIssue.Identifier, err)
+					// Don't count as error in stats to avoid double counting if issue was already counted
+				}
+			}
 		}
 	}
 

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -1448,7 +1448,7 @@ func TestLinearClientCreateIssue(t *testing.T) {
 	client := linear.NewClient("test-api-key", "test-team-id").WithEndpoint(server.URL)
 	ctx := context.Background()
 
-	issue, err := client.CreateIssue(ctx, "New Test Issue", "Created via API", 2, "", nil)
+	issue, err := client.CreateIssue(ctx, "New Test Issue", "Created via API", 2, "", nil, "", "")
 	if err != nil {
 		t.Fatalf("CreateIssue failed: %v", err)
 	}

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -15,6 +15,34 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// ProjectsQuery is the GraphQL query for fetching projects.
+const ProjectsQuery = `
+	query Projects($filter: ProjectFilter!, $first: Int!, $after: String) {
+		projects(
+			first: $first
+			after: $after
+			filter: $filter
+		) {
+			nodes {
+				id
+				name
+				description
+				slugId
+				url
+				state
+				progress
+				createdAt
+				updatedAt
+				completedAt
+			}
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+		}
+	}
+`
+
 // issuesQuery is the GraphQL query for fetching issues with all required fields.
 // Used by both FetchIssues and FetchIssuesSince for consistency.
 const issuesQuery = `
@@ -48,7 +76,12 @@ const issuesQuery = `
 						name
 					}
 				}
-				parent {
+				project {
+				id
+				name
+				slugId
+			}
+			parent {
 					id
 					identifier
 				}
@@ -387,8 +420,163 @@ func (c *Client) GetTeamStates(ctx context.Context) ([]State, error) {
 	return teamResp.Team.States.Nodes, nil
 }
 
+// FetchProjects retrieves projects from Linear with optional filtering by state.
+// state can be: "planned", "started", "paused", "completed", "canceled", or "all".
+func (c *Client) FetchProjects(ctx context.Context, state string) ([]Project, error) {
+	var allProjects []Project
+	var cursor string
+
+	filter := map[string]interface{}{
+		"team": map[string]interface{}{
+			"id": map[string]interface{}{
+				"eq": c.TeamID,
+			},
+		},
+	}
+
+	if state != "all" && state != "" {
+		filter["state"] = map[string]interface{}{
+			"eq": state,
+		}
+	}
+
+	for {
+		variables := map[string]interface{}{
+			"filter": filter,
+			"first":  MaxPageSize,
+		}
+		if cursor != "" {
+			variables["after"] = cursor
+		}
+
+		req := &GraphQLRequest{
+			Query:     ProjectsQuery,
+			Variables: variables,
+		}
+
+		data, err := c.Execute(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch projects: %w", err)
+		}
+
+		var projectsResp ProjectsResponse
+		if err := json.Unmarshal(data, &projectsResp); err != nil {
+			return nil, fmt.Errorf("failed to parse projects response: %w", err)
+		}
+
+		allProjects = append(allProjects, projectsResp.Projects.Nodes...)
+
+		if !projectsResp.Projects.PageInfo.HasNextPage {
+			break
+		}
+		cursor = projectsResp.Projects.PageInfo.EndCursor
+	}
+
+	return allProjects, nil
+}
+
+// CreateProject creates a new project in Linear.
+func (c *Client) CreateProject(ctx context.Context, name, description, state string) (*Project, error) {
+	query := `
+		mutation CreateProject($input: ProjectCreateInput!) {
+			projectCreate(input: $input) {
+				success
+				project {
+					id
+					name
+					description
+					slugId
+					url
+					state
+					progress
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`
+
+	input := map[string]interface{}{
+		"teamIds":     []string{c.TeamID},
+		"name":        name,
+		"description": description,
+	}
+
+	if state != "" {
+		input["state"] = state
+	}
+
+	req := &GraphQLRequest{
+		Query: query,
+		Variables: map[string]interface{}{
+			"input": input,
+		},
+	}
+
+	data, err := c.Execute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create project: %w", err)
+	}
+
+	var createResp ProjectCreateResponse
+	if err := json.Unmarshal(data, &createResp); err != nil {
+		return nil, fmt.Errorf("failed to parse create response: %w", err)
+	}
+
+	if !createResp.ProjectCreate.Success {
+		return nil, fmt.Errorf("project creation reported as unsuccessful")
+	}
+
+	return &createResp.ProjectCreate.Project, nil
+}
+
+// UpdateProject updates an existing project in Linear.
+func (c *Client) UpdateProject(ctx context.Context, projectID string, updates map[string]interface{}) (*Project, error) {
+	query := `
+		mutation UpdateProject($id: String!, $input: ProjectUpdateInput!) {
+			projectUpdate(id: $id, input: $input) {
+				success
+				project {
+					id
+					name
+					description
+					slugId
+					url
+					state
+					progress
+					updatedAt
+				}
+			}
+		}
+	`
+
+	req := &GraphQLRequest{
+		Query: query,
+		Variables: map[string]interface{}{
+			"id":    projectID,
+			"input": updates,
+		},
+	}
+
+	data, err := c.Execute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update project: %w", err)
+	}
+
+	var updateResp ProjectUpdateResponse
+	if err := json.Unmarshal(data, &updateResp); err != nil {
+		return nil, fmt.Errorf("failed to parse update response: %w", err)
+	}
+
+	if !updateResp.ProjectUpdate.Success {
+		return nil, fmt.Errorf("project update reported as unsuccessful")
+	}
+
+	return &updateResp.ProjectUpdate.Project, nil
+}
+
 // CreateIssue creates a new issue in Linear.
-func (c *Client) CreateIssue(ctx context.Context, title, description string, priority int, stateID string, labelIDs []string) (*Issue, error) {
+func (c *Client) CreateIssue(ctx context.Context, title, description string, priority int, stateID string, labelIDs []string, projectID string, parentID string) (*Issue, error) {
 	query := `
 		mutation CreateIssue($input: IssueCreateInput!) {
 			issueCreate(input: $input) {
@@ -418,9 +606,15 @@ func (c *Client) CreateIssue(ctx context.Context, title, description string, pri
 		"description": description,
 	}
 
-	// Include project if configured
-	if c.ProjectID != "" {
+	// Include project if configured or provided
+	if projectID != "" {
+		input["projectId"] = projectID
+	} else if c.ProjectID != "" {
 		input["projectId"] = c.ProjectID
+	}
+
+	if parentID != "" {
+		input["parentId"] = parentID
 	}
 
 	if priority > 0 {

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -69,6 +69,7 @@ type Issue struct {
 	State       *State     `json:"state"`
 	Assignee    *User      `json:"assignee"`
 	Labels      *Labels    `json:"labels"`
+	Project     *Project   `json:"project,omitempty"`
 	Parent      *Parent    `json:"parent,omitempty"`
 	Relations   *Relations `json:"relations,omitempty"`
 	CreatedAt   string     `json:"createdAt"`
@@ -134,6 +135,11 @@ type StatesWrapper struct {
 	Nodes []State `json:"nodes"`
 }
 
+// TeamResponse represents the response from team query.
+type TeamResponse struct {
+	Team TeamStates `json:"team"`
+}
+
 // IssuesResponse represents the response from issues query.
 type IssuesResponse struct {
 	Issues struct {
@@ -161,9 +167,46 @@ type IssueUpdateResponse struct {
 	} `json:"issueUpdate"`
 }
 
-// TeamResponse represents the response from team query.
-type TeamResponse struct {
-	Team TeamStates `json:"team"`
+
+// Project represents a project in Linear.
+type Project struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	SlugId      string `json:"slugId"`
+	URL         string `json:"url"`
+	State       string `json:"state"` // "planned", "started", "paused", "completed", "canceled"
+	Progress    int    `json:"progress"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+	CompletedAt string `json:"completedAt,omitempty"`
+}
+
+// ProjectsResponse represents the response from projects query.
+type ProjectsResponse struct {
+	Projects struct {
+		Nodes    []Project `json:"nodes"`
+		PageInfo struct {
+			HasNextPage bool   `json:"hasNextPage"`
+			EndCursor   string `json:"endCursor"`
+		} `json:"pageInfo"`
+	} `json:"projects"`
+}
+
+// ProjectCreateResponse represents the response from projectCreate mutation.
+type ProjectCreateResponse struct {
+	ProjectCreate struct {
+		Success bool    `json:"success"`
+		Project Project `json:"project"`
+	} `json:"projectCreate"`
+}
+
+// ProjectUpdateResponse represents the response from projectUpdate mutation.
+type ProjectUpdateResponse struct {
+	ProjectUpdate struct {
+		Success bool    `json:"success"`
+		Project Project `json:"project"`
+	} `json:"projectUpdate"`
 }
 
 // SyncStats tracks statistics for a Linear sync operation.


### PR DESCRIPTION
## Summary
- Add Project support to Linear client (Create, Update)
- Map beads Epics to Linear Projects and vice versa
- Refactor sync logic to handle hierarchy (Epics -> Tasks -> Subtasks)
- Fix cycle detection by prioritizing parent-child links
- Update mapping to handle state and priority for Projects

This PR is split from #1674 as requested - focusing on Linear project sync as the first PR.