### PR TITLE
fix(migrate): use config-based backend instead of hardcoded Dolt

### DIFF
--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -292,7 +292,7 @@ Subcommands:
 			// Clean up WAL files before opening to avoid "disk I/O error"
 			cleanupWALFiles(currentDB.path)
 
-			store, err := storagefactory.New(rootCtx, configfile.BackendDolt, currentDB.path)
+			store, err := storagefactory.NewFromConfigWithOptions(rootCtx, beadsDir, storagefactory.Options{})
 			if err != nil {
 				if jsonOutput {
 					outputJSON(map[string]interface{}{


### PR DESCRIPTION
## Summary

- `bd migrate` schema version update path was hardcoded to `storagefactory.New(ctx, BackendDolt, path)`, causing SQLite-backend databases to fail with: `bootstrap failed: failed to create Dolt store: mkdir .beads/beads.db: not a directory`
- Changed to use `NewFromConfigWithOptions` which reads backend from `metadata.json`, consistent with every other code path in `migrate.go`
- One-line fix, zero risk to Dolt backend (Dolt path is handled earlier in `handleDoltMetadataUpdate`)

## Test plan

- [x] Verified `bd migrate --yes` succeeds on 5 SQLite-backend databases (was failing before)
- [x] Verified `bd ready` works after migration
- [ ] Dolt-backend migration path should be unaffected (early return at line 113-116)

🤖 Generated with [Claude Code](https://claude.com/claude-code)