### PR TITLE
fix(migrate): prevent embedded Dolt self-deadlock

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -383,6 +383,7 @@ var rootCmd = &cobra.Command{
 			"human",
 			"init",
 			"merge",
+			"migrate", // manages its own store lifecycle; double-open deadlocks embedded Dolt (#1668)
 			"onboard",
 			"powershell",
 			"prime",


### PR DESCRIPTION
## Summary

- Add `migrate` to `noDbCommands` list in `PersistentPreRun`, preventing the global store from being opened before the migrate command opens its own

## Root Cause

`bd migrate` (all subpaths: `--update-repo-id`, `--inspect`, `--to-dolt`, `--to-sqlite`, and the default flow) manages its own store lifecycle — it calls `storagefactory.NewFromConfigWithOptions()` or `factory.NewWithOptions()` internally. However, `migrate` was not in the `noDbCommands` list, so `PersistentPreRun` also opened a global store.

On Dolt backends, both opens attempt embedded mode (or fall back to it when the server is unreachable). The first open acquires the noms `LOCK` file; the second open in the same process deadlocks against it:

```
Warning: Dolt server at 127.0.0.1:3307 is not reachable, falling back to embedded mode
Warning: Dolt server at 127.0.0.1:3307 is not reachable, falling back to embedded mode
Error: failed to open database: failed to create dolt database: the database is locked by another dolt process
```

The two warnings correspond to the two separate `dolt.New()` → server-fail → embedded-fallback paths: one from `PersistentPreRun`, one from the migrate handler.

## Test plan

- [x] `go build ./cmd/bd` compiles cleanly
- [x] `go test -short ./cmd/bd/` passes (42s, all existing tests)
- [x] Manual verification: `bd migrate --update-repo-id` no longer deadlocks on Dolt embedded backend

Closes #1668

🤖 Generated with [Claude Code](https://claude.com/claude-code)