### PR TITLE
fix(hook): prevent embedded Dolt self-deadlock in git hooks

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -379,6 +379,7 @@ var rootCmd = &cobra.Command{
 			"doctor",
 			"fish",
 			"help",
+			"hook",  // manages its own store lifecycle; double-open deadlocks embedded Dolt (#1719)
 			"hooks",
 			"human",
 			"init",


### PR DESCRIPTION
## Summary

- Add `"hook"` to `noDbCommands` in `cmd/bd/main.go` so `PersistentPreRun` skips opening the global store for `bd hook` commands
- The hook implementations (`pre-commit`, `post-checkout`, `post-merge`) manage their own store lifecycle via `factory.NewFromConfig()`; the extra open from `PersistentPreRun` causes a noms LOCK deadlock when the Dolt server is unreachable and both opens fall back to embedded mode
- Same bug class as the `migrate` deadlock (#1668, fixed in #1716)

Closes #1719

## Test plan

- [x] `go build ./cmd/bd` succeeds
- [x] `go test -short ./cmd/bd/` passes
- [ ] Manual: configure `dolt_mode: server` with no server running, run `git commit` — no more double warning + lock error

🤖 Generated with [Claude Code](https://claude.com/claude-code)