### PR TITLE
fix: consolidate redirect resolution into single FollowRedirect function

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -89,6 +89,10 @@ func FollowRedirect(beadsDir string) string {
 		fmt.Fprintf(os.Stderr, "Warning: redirect chains not allowed, ignoring redirect in %s\n", target)
 	}
 
+	if os.Getenv("BD_DEBUG_ROUTING") != "" {
+		fmt.Fprintf(os.Stderr, "[routing] Followed redirect from %s -> %s\n", beadsDir, target)
+	}
+
 	return target
 }
 


### PR DESCRIPTION
Previously, resolveRedirect in internal/routing/routes.go duplicated the redirect resolution logic from beads.FollowRedirect. This created risk of inconsistent behavior between routing-based lookups and direct beads discovery.

The specific bug that prompted this was that some redirect files were resolved relative to the `.beads` directory and some relative to its parent directory. Additionally, `resolveRedirect` didn't detect chains. 

Changes:
- Remove resolveRedirect from routes.go entirely
- Update callsites to use beads.FollowRedirect directly
- Add BD_DEBUG_ROUTING logging to FollowRedirect for debugging parity

This ensures all redirect resolution goes through a single code path with consistent behavior: comment handling, path canonicalization (absolute paths, symlinks, case-sensitivity), and redirect chain prevention.