### PR TITLE
fix(doctor): add dolt/ and dolt-access.lock to gitignore template

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -46,6 +46,10 @@ beads.left.meta.json
 beads.right.jsonl
 beads.right.meta.json
 
+# Dolt backend (binary database files, can grow to 500MB+)
+dolt/
+dolt-access.lock
+
 # Sync state (local-only, per-machine)
 # These files are machine-specific and should not be shared across clones
 .sync.lock
@@ -71,6 +75,8 @@ var requiredPatterns = []string{
 	"*.db?*",
 	"redirect",
 	"last-touched",
+	"dolt/",
+	"dolt-access.lock",
 	".sync.lock",
 	".jsonl.lock",
 	"sync_base.jsonl",

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1642,6 +1642,46 @@ func TestRequiredPatterns_ContainsLastTouched(t *testing.T) {
 	}
 }
 
+// TestGitignoreTemplate_ContainsDoltPatterns verifies that the .beads/.gitignore template
+// includes dolt/ and dolt-access.lock to prevent Dolt backend binary files from being
+// committed to git. Dolt noms journal files can grow to 500MB+ and are binary.
+// GH#1713
+func TestGitignoreTemplate_ContainsDoltPatterns(t *testing.T) {
+	doltPatterns := []string{
+		"dolt/",
+		"dolt-access.lock",
+	}
+
+	for _, pattern := range doltPatterns {
+		if !strings.Contains(GitignoreTemplate, pattern) {
+			t.Errorf("GitignoreTemplate should contain '%s' pattern", pattern)
+		}
+	}
+}
+
+// TestRequiredPatterns_ContainsDoltPatterns verifies that bd doctor validates
+// the presence of Dolt backend patterns in .beads/.gitignore.
+// GH#1713
+func TestRequiredPatterns_ContainsDoltPatterns(t *testing.T) {
+	doltPatterns := []string{
+		"dolt/",
+		"dolt-access.lock",
+	}
+
+	for _, expected := range doltPatterns {
+		found := false
+		for _, pattern := range requiredPatterns {
+			if pattern == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("requiredPatterns should include '%s'", expected)
+		}
+	}
+}
+
 // TestGitignoreTemplate_ContainsJSONLLock verifies that the .beads/.gitignore template
 // includes .jsonl.lock to prevent the JSONL coordination lock file from being tracked.
 // The lock file is a runtime artifact in the same category as daemon.lock and .sync.lock.


### PR DESCRIPTION
## Summary

Add missing `dolt/` and `dolt-access.lock` patterns to the `.beads/.gitignore` template. Without these, `bd init --backend dolt` creates binary database files that can grow to 500MB+ and would be staged by `git add .beads/`.

Closes #1713

### Changes Made

- **Added `dolt/` and `dolt-access.lock`** to `GitignoreTemplate` in `doctor/gitignore.go` with a descriptive comment section
- **Added both patterns to `requiredPatterns`** so `bd doctor` detects their absence and `bd doctor --fix` restores them
- **Added tests** verifying both patterns exist in the template and required patterns list

### Backward Compatibility

✅ **Maintained**: `FixGitignore()` always writes the full canonical template, so existing users running `bd doctor --fix` or `bd init` will automatically get the new patterns
✅ **Same behavior**: No changes to check/fix logic, only template content and validation list

### Technical Details

- The Dolt backend stores its database under `.beads/dolt/` which contains binary noms journal files
- `dolt-access.lock` is a runtime lock file for the embedded Dolt database
- Both are local-only artifacts that should never be committed to git

### Size: Small ✓

Two-line template addition plus corresponding `requiredPatterns` entries and tests.

🤖 Generated with [Claude Code](https://claude.ai/code)