### PR TITLE
fix(cli): show only base types in --type flag help text

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -778,7 +778,7 @@ func init() {
 	createCmd.Flags().Bool("silent", false, "Output only the issue ID (for scripting)")
 	createCmd.Flags().Bool("dry-run", false, "Preview what would be created without actually creating")
 	registerPriorityFlag(createCmd, "2")
-	createCmd.Flags().StringP("type", "t", "task", "Issue type (bug|feature|task|epic|chore|decision|merge-request|molecule|gate|agent|role|rig|convoy|event); aliases: enhancement/feat→feature, dec/adr→decision")
+	createCmd.Flags().StringP("type", "t", "task", "Issue type (bug|feature|task|epic|chore|decision); custom types require types.custom config; aliases: enhancement/feat→feature, dec/adr→decision")
 	registerCommonIssueFlags(createCmd)
 	createCmd.Flags().String("spec-id", "", "Link to specification document")
 	createCmd.Flags().StringSliceP("labels", "l", []string{}, "Labels (comma-separated)")

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -408,7 +408,7 @@ func init() {
 	updateCmd.Flags().StringP("status", "s", "", "New status")
 	registerPriorityFlag(updateCmd, "")
 	updateCmd.Flags().String("title", "", "New title")
-	updateCmd.Flags().StringP("type", "t", "", "New type (bug|feature|task|epic|chore|decision|merge-request|molecule|gate|agent|role|rig|convoy|event|slot)")
+	updateCmd.Flags().StringP("type", "t", "", "New type (bug|feature|task|epic|chore|decision); custom types require types.custom config")
 	registerCommonIssueFlags(updateCmd)
 	updateCmd.Flags().String("spec-id", "", "Link to specification document")
 	updateCmd.Flags().String("acceptance-criteria", "", "DEPRECATED: use --acceptance")


### PR DESCRIPTION
## Summary

The `--type` flag help text for `bd create` and `bd update` listed Gas Town types (molecule, gate, convoy, merge-request, etc.) as valid options, but they all fail with 'invalid issue type' unless `types.custom` is configured. This fixes the help text to show only the six built-in types and notes that custom types require configuration.

Closes #1727

### Changes Made

- **Updated `bd create --type` help** — now shows `bug|feature|task|epic|chore|decision` with a note about custom types requiring config; aliases still documented
- **Updated `bd update --type` help** — same change, also removed `slot` which was inconsistently included only here

### Backward Compatibility

✅ **Maintained**: No behavioral changes — only help text is updated
✅ **Same validation**: Type validation logic is unchanged; custom types still work when configured via `bd config set types.custom`

### Technical Details

The `bd types` subcommand already properly separates core vs custom types in its output. This change brings the `--type` flag help text in line with that separation.

Users who need custom types can:
1. Run `bd types` to see all available types
2. Configure custom types via `bd config set types.custom "molecule,gate,..."`

### Size: Small ✓

Two one-line help text changes in `create.go` and `update.go`.

🤖 Generated with [Claude Code](https://claude.ai/code)