### PR TITLE
fix(lint): resolve pre-existing golangci-lint and gofmt warnings

### DIFF
--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -97,7 +97,7 @@ func openDoltDBEmbedded(beadsDir string) (*sql.DB, error) {
 
 	ctx := context.Background()
 	if _, err := db.ExecContext(ctx, "USE beads"); err != nil {
-		db.Close()
+		_ = db.Close()
 		return nil, fmt.Errorf("failed to switch to beads database: %w", err)
 	}
 

--- a/cmd/bd/doctor/sync_branch_jsonl.go
+++ b/cmd/bd/doctor/sync_branch_jsonl.go
@@ -108,7 +108,7 @@ func getConfiguredSyncBranch(beadsDir string) string {
 }
 
 func getSyncBranchFromYAML(beadsDir string) string {
-	data, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+	data, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml")) //nolint:gosec // G304: beadsDir is from FindBeadsDir, not user input
 	if err != nil {
 		return ""
 	}

--- a/cmd/bd/help_all.go
+++ b/cmd/bd/help_all.go
@@ -39,6 +39,8 @@ func registerHelpAllFlag() {
 
 // writeAllHelp writes a complete markdown reference for all commands,
 // generated from the live Cobra command tree.
+//
+//nolint:errcheck // help text writer — nothing to do with Fprintf errors
 func writeAllHelp(w io.Writer, root *cobra.Command) {
 	fmt.Fprintf(w, "# bd — Complete Command Reference\n\n")
 	fmt.Fprintf(w, "Generated from `bd help --all` (bd version %s)\n\n", Version)

--- a/cmd/bd/sync_git_remote_test.go
+++ b/cmd/bd/sync_git_remote_test.go
@@ -36,8 +36,8 @@ type mockRemoteStore struct {
 	pullCount  atomic.Int32
 	commitMsgs []string
 
-	pushErr  error // inject Push error
-	pullErr  error // inject Pull error
+	pushErr error // inject Push error
+	pullErr error // inject Pull error
 }
 
 // Compile-time check: mockRemoteStore implements RemoteStorage.


### PR DESCRIPTION
## Summary

Fixes 5 golangci-lint warnings and 1 gofmt issue that exist on `main`, causing CI failures for every PR branching from it.

### Changes Made

- **`cmd/bd/help_all.go`** — added `//nolint:errcheck` on `writeAllHelp()` since checking `fmt.Fprintf` errors in a help text writer is pointless
- **`cmd/bd/doctor/dolt.go:100`** — explicitly discard `db.Close()` error with `_ =` on the early-return error path (gosec G104)
- **`cmd/bd/doctor/sync_branch_jsonl.go:111`** — added `//nolint:gosec` for `os.ReadFile` with a path constructed from `FindBeadsDir()`, not user input (gosec G304)
- **`cmd/bd/sync_git_remote_test.go`** — fixed struct field alignment (`pushErr`/`pullErr`) to satisfy `gofmt`

### Backward Compatibility

✅ **Maintained**: No behavior changes, only lint suppressions and formatting

### Benefits

- Unblocks CI for all PRs branching from `main`
- Removes noise from every contributor's CI results

### Size: Small ✓

🤖 Generated with [Claude Code](https://claude.ai/code)