### PR TITLE
fix(sync): write sync.mode to config.yaml in addition to database

### DIFF
--- a/cmd/bd/migrate_dolt.go
+++ b/cmd/bd/migrate_dolt.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
@@ -139,6 +140,11 @@ func handleToDoltMigration(dryRun bool, autoYes bool) {
 		printWarning(fmt.Sprintf("failed to set sync.mode in DB: %v", err))
 	} else {
 		printSuccess("Set sync.mode = dolt-native in database")
+	}
+
+	// Also write to config.yaml for consistent reads via config.GetSyncMode()
+	if err := config.SetYamlConfig("sync.mode", SyncModeDoltNative); err != nil {
+		printWarning(fmt.Sprintf("failed to write sync.mode to config.yaml: %v", err))
 	}
 
 	// Commit the migration

--- a/cmd/bd/sync_mode_cmd.go
+++ b/cmd/bd/sync_mode_cmd.go
@@ -151,10 +151,15 @@ Example:
 			os.Exit(1)
 		}
 
-		// Set the mode
+		// Set the mode in database
 		if err := SetSyncMode(rootCtx, store, mode); err != nil {
 			fmt.Fprintf(os.Stderr, "Error setting sync mode: %v\n", err)
 			os.Exit(1)
+		}
+
+		// Also write to config.yaml so reads via config.GetSyncMode() stay consistent
+		if err := config.SetYamlConfig("sync.mode", mode); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write sync.mode to config.yaml: %v\n", err)
 		}
 
 		if jsonOutput {


### PR DESCRIPTION
## Summary

Fixes #1723. `bd sync mode set` and `bd migrate` wrote `sync.mode` only to the database, but `GetSyncMode()` and `config.GetSyncMode()` read from config.yaml first. This caused stale reads: after `bd sync mode set dolt-native`, callers using the YAML path still saw `git-portable` (the default), causing dolt-native users to pay 10-25s JSONL export overhead on every write.

### Changes Made

- **`cmd/bd/sync_mode_cmd.go`** — After `SetSyncMode()` writes to the DB, also call `config.SetYamlConfig("sync.mode", mode)` to persist to config.yaml
- **`cmd/bd/migrate_dolt.go`** — After writing `sync.mode = dolt-native` to the DB during migration, also write to config.yaml

### Backward Compatibility

✅ **Maintained**: `bd config set sync.mode X` already wrote to YAML via `IsYamlOnlyKey()`. This change makes `bd sync mode set` and `bd migrate` consistent with that behavior.
✅ **Maintained**: `GetSyncMode()` already checks YAML first, so writing there doesn't change the read path priority.

### Technical Details

The `config.SetYamlConfig()` function writes directly to `.beads/config.yaml`, matching the behavior of `bd config set sync.mode X`. The YAML write is non-fatal (warning only) to match the pattern used elsewhere for config.yaml writes.

### Size: Small ✓

🤖 Generated with [Claude Code](https://claude.ai/code)