### PR TITLE
fix(docs): correct Homebrew upgrade command in INSTALLING.md

### DIFF
--- a/cmd/bd/sync_git_remote_test.go
+++ b/cmd/bd/sync_git_remote_test.go
@@ -36,8 +36,8 @@ type mockRemoteStore struct {
 	pullCount  atomic.Int32
 	commitMsgs []string
 
-	pushErr  error // inject Push error
-	pullErr  error // inject Pull error
+	pushErr error // inject Push error
+	pullErr error // inject Pull error
 }
 
 // Compile-time check: mockRemoteStore implements RemoteStorage.

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -73,7 +73,7 @@ The installer will:
 
 | Method | Best For | Updates | Prerequisites | Notes |
 |--------|----------|---------|---------------|-------|
-| **Homebrew** | macOS/Linux users | `brew upgrade beads` | Homebrew | Recommended. Handles everything automatically |
+| **Homebrew** | macOS/Linux users | `brew upgrade bd` | Homebrew | Recommended. Handles everything automatically |
 | **npm** | JS/Node.js projects | `npm update -g @beads/bd` | Node.js | Convenient if npm is your ecosystem |
 | **bun** | JS/Bun.js projects | `bun install -g --trust @beads/bd` | Bun.js | Convenient if bun is your ecosystem |
 | **Install script** | Quick setup, CI/CD | Re-run script | curl, bash | Good for automation and one-liners |
@@ -469,7 +469,7 @@ irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 ### Homebrew
 
 ```bash
-brew upgrade beads
+brew upgrade bd
 ```
 
 ### npm


### PR DESCRIPTION
## Summary

Fixes the docs portion of #1654. The Homebrew formula name is `bd`, not `beads`. `brew upgrade beads` returns `Error: beads not installed`.

### Changes Made

- **`docs/INSTALLING.md`** — Changed `brew upgrade beads` to `brew upgrade bd` in two places (comparison table and upgrade section)

### Backward Compatibility

✅ **Maintained**: Documentation-only change

### Size: Small ✓

🤖 Generated with [Claude Code](https://claude.ai/code)