### PR TITLE
fix(docs): correct Homebrew upgrade command in upgrading docs

### DIFF
--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -27,7 +27,7 @@ Use the command that matches your install method.
 |---|---|---|
 | Quick install script | macOS, Linux, FreeBSD | `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh \| bash` |
 | PowerShell installer | Windows | `irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 \| iex` |
-| Homebrew | macOS, Linux | `brew upgrade bd` |
+| Homebrew | macOS, Linux | `brew upgrade beads` |
 | go install | macOS, Linux, FreeBSD, Windows | `go install github.com/steveyegge/beads/cmd/bd@latest` |
 | npm | macOS, Linux, Windows | `npm update -g @beads/bd` |
 | bun | macOS, Linux, Windows | `bun install -g --trust @beads/bd` |


### PR DESCRIPTION
## Summary

Fixes the Homebrew upgrade command in the comparison table at `website/docs/getting-started/upgrading.md` — it listed `brew upgrade bd` but the correct formula name is `beads`.

### Changes Made

- **Fixed `upgrading.md` line 30** — Changed `brew upgrade bd` → `brew upgrade beads` in the install-method comparison table

Note: Our existing PR #1737 already fixes the same typo in `docs/INSTALLING.md`. This PR catches the remaining reference in the website docs.

### Backward Compatibility

✅ **No code changes** — documentation only

Fixes #1561

### Size: Small ✓

Single-line documentation fix.

🤖 Generated with [Claude Code](https://claude.ai/code)