### PR TITLE
fix(doctor): add rotated daemon logs to gitignore template and skip rewrite when current

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -22,6 +22,7 @@ const GitignoreTemplate = `# SQLite databases
 # Daemon runtime files
 daemon.lock
 daemon.log
+daemon-*.log.gz
 daemon.pid
 bd.sock
 sync-state.json

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1369,6 +1369,15 @@ func TestRequiredPatterns_ContainsRedirect(t *testing.T) {
 	}
 }
 
+// TestGitignoreTemplate_ContainsDaemonRotatedLogs verifies that rotated daemon
+// log files (daemon-*.log.gz) are gitignored to prevent log churn in commits.
+// GH#1142, GH#919
+func TestGitignoreTemplate_ContainsDaemonRotatedLogs(t *testing.T) {
+	if !strings.Contains(GitignoreTemplate, "daemon-*.log.gz") {
+		t.Error("GitignoreTemplate should contain 'daemon-*.log.gz' pattern for rotated daemon logs")
+	}
+}
+
 // TestGitignoreTemplate_ContainsSyncStateFiles verifies that sync state files
 // introduced in PR #918 (pull-first sync with 3-way merge) are gitignored.
 // These files are machine-specific and should not be shared across clones.

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -312,11 +312,14 @@ variable.`,
 				return
 			}
 
-			// Create/update .gitignore in .beads directory (idempotent - always update to latest)
+			// Create/update .gitignore in .beads directory (only if missing or outdated)
 			gitignorePath := filepath.Join(beadsDir, ".gitignore")
-			if err := os.WriteFile(gitignorePath, []byte(doctor.GitignoreTemplate), 0600); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to create/update .gitignore: %v\n", err)
-				// Non-fatal - continue anyway
+			check := doctor.CheckGitignore()
+			if check.Status != "ok" {
+				if err := os.WriteFile(gitignorePath, []byte(doctor.GitignoreTemplate), 0600); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to create/update .gitignore: %v\n", err)
+					// Non-fatal - continue anyway
+				}
 			}
 
 			// Ensure interactions.jsonl exists (append-only agent audit log)


### PR DESCRIPTION
## Summary

Two improvements to the gitignore template system:
1. Add `daemon-*.log.gz` pattern for rotated daemon log files that cause git churn
2. Make `bd init` skip rewriting `.beads/.gitignore` when it already has all required patterns

### Changes Made

- **Added `daemon-*.log.gz`** to `GitignoreTemplate` in the "Daemon runtime files" section — prevents rotated daemon logs from being tracked
- **Updated `bd init`** to use `doctor.CheckGitignore()` before overwriting `.beads/.gitignore` — skips the rewrite when the file is already current, reducing unnecessary file changes on re-init
- **Added test** `TestGitignoreTemplate_ContainsDaemonRotatedLogs` to verify the pattern is present

### Backward Compatibility

✅ **Maintained**: Existing `.gitignore` files will be updated on next `bd init` or `bd doctor --fix` only if they're missing required patterns
✅ **Same behavior**: `bd doctor` already detects missing patterns; now `bd init` respects that check too

### Technical Details

The init change uses the same `doctor.CheckGitignore()` that `bd doctor` uses, so the "is up to date" logic is consistent. If the check returns `"ok"`, the file is left untouched.

Fixes #1142, #919

### Size: Small ✓

Three files changed: template addition, init guard, one test.

🤖 Generated with [Claude Code](https://claude.ai/code)