### PR TITLE
fix(ready): exclude children of deferred parents from ready work

### DIFF
--- a/internal/storage/dolt/schema.go
+++ b/internal/storage/dolt/schema.go
@@ -299,7 +299,16 @@ FROM issues i
 LEFT JOIN blocked_transitively bt ON bt.issue_id = i.id
 WHERE i.status = 'open'
   AND (i.ephemeral = 0 OR i.ephemeral IS NULL)
-  AND bt.issue_id IS NULL;
+  AND bt.issue_id IS NULL
+  AND (i.defer_until IS NULL OR i.defer_until <= NOW())
+  AND NOT EXISTS (
+    SELECT 1 FROM dependencies d_parent
+    JOIN issues parent ON parent.id = d_parent.depends_on_id
+    WHERE d_parent.issue_id = i.id
+      AND d_parent.type = 'parent-child'
+      AND parent.defer_until IS NOT NULL
+      AND parent.defer_until > NOW()
+  );
 `
 
 // blockedIssuesView is a MySQL-compatible view for blocked issues.

--- a/internal/storage/sqlite/schema.go
+++ b/internal/storage/sqlite/schema.go
@@ -256,6 +256,15 @@ WHERE i.status = 'open'
   AND (i.ephemeral = 0 OR i.ephemeral IS NULL)
   AND NOT EXISTS (
     SELECT 1 FROM blocked_transitively WHERE issue_id = i.id
+  )
+  AND (i.defer_until IS NULL OR datetime(i.defer_until) <= datetime('now'))
+  AND NOT EXISTS (
+    SELECT 1 FROM dependencies d_parent
+    JOIN issues parent ON parent.id = d_parent.depends_on_id
+    WHERE d_parent.issue_id = i.id
+      AND d_parent.type = 'parent-child'
+      AND parent.defer_until IS NOT NULL
+      AND datetime(parent.defer_until) > datetime('now')
   );
 
 -- Blocked issues view


### PR DESCRIPTION
## Summary

When a parent issue has `defer_until` set to a future date, its children now correctly get excluded from `bd ready` output. Previously only the parent itself was filtered, leaving orphaned children appearing as actionable work.

### Changes Made

- **Added deferred-parent exclusion to `dolt/queries.go`** — NOT EXISTS clause checking for deferred parents via parent-child dependencies
- **Added deferred-parent exclusion to `sqlite/ready.go`** — Same clause for SQLite with `datetime()` functions
- **Updated `dolt/schema.go` readyIssuesView** — Added self-deferral and deferred-parent filters to the view
- **Updated `sqlite/schema.go` readyIssuesView** — Same filters for SQLite view
- **Added `TestDeferredParentExcludesChildren`** — Verifies parent deferred, child excluded, unrelated still ready, and `IncludeDeferred` bypasses the filter

### Backward Compatibility

✅ **Maintained**: Issues without `defer_until` are unaffected
✅ **Same behavior**: `IncludeDeferred: true` still shows all deferred issues and their children
✅ **Consistent**: Both GetReadyWork query and ready_issues views produce matching results

### Technical Details

The fix adds a `NOT EXISTS` subquery that joins `dependencies` (type='parent-child') with `issues` to check if any parent has a future `defer_until`. This runs for both the dynamic query path (GetReadyWork) and the materialized views (ready_issues).

Fixes #1190

### Size: Small ✓

Five files changed: two query files, two schema files, one test file.

🤖 Generated with [Claude Code](https://claude.ai/code)