### PR TITLE
fix(migrate): use sqlite backend for sqlite paths in dolt migrations (fixes #1752)

### DIFF
--- a/cmd/bd/migrate_dolt.go
+++ b/cmd/bd/migrate_dolt.go
@@ -278,7 +278,7 @@ func handleToSQLiteMigration(dryRun bool, autoYes bool) {
 	// Create SQLite database
 	printProgress("Creating SQLite database...")
 
-	sqliteStore, err := factory.New(ctx, configfile.BackendDolt, sqlitePath)
+	sqliteStore, err := factory.New(ctx, configfile.BackendSQLite, sqlitePath)
 	if err != nil {
 		exitWithError("sqlite_create_failed", err.Error(), "")
 	}
@@ -314,7 +314,7 @@ func handleToSQLiteMigration(dryRun bool, autoYes bool) {
 
 // extractFromSQLite extracts all data from a SQLite database
 func extractFromSQLite(ctx context.Context, dbPath string) (*migrationData, error) {
-	store, err := factory.NewWithOptions(ctx, configfile.BackendDolt, dbPath, factory.Options{ReadOnly: true})
+	store, err := factory.NewWithOptions(ctx, configfile.BackendSQLite, dbPath, factory.Options{ReadOnly: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to open SQLite database: %w", err)
 	}

--- a/cmd/bd/migrate_dolt_extraction_test.go
+++ b/cmd/bd/migrate_dolt_extraction_test.go
@@ -1,0 +1,36 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractFromSQLite_OpensSQLiteFile(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "beads.db")
+	store := newTestStore(t, dbPath)
+	if err := store.Close(); err != nil {
+		t.Fatalf("failed to close sqlite store: %v", err)
+	}
+
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("failed to stat sqlite database: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatalf("expected sqlite database file, got directory: %s", dbPath)
+	}
+
+	data, err := extractFromSQLite(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("extractFromSQLite should open sqlite file successfully: %v", err)
+	}
+	if data == nil {
+		t.Fatal("extractFromSQLite returned nil data")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1752.

`bd migrate dolt` / `bd migrate --to-dolt` can fail when opening the source SQLite database because the migration code was using the Dolt backend while passing a SQLite file path. In that case Dolt bootstrap may attempt directory initialization on a regular file path and fail (e.g. `mkdir .../.beads/beads.db`).

This PR switches the SQLite source/target code paths to use the SQLite backend and adds a regression test.

Related report: #1752

## Background / Root Cause

Two call sites in `cmd/bd/migrate_dolt.go` were using `configfile.BackendDolt` with SQLite file paths:

- `extractFromSQLite(...)` (source open path for SQLite -> Dolt migration)
- `handleToSQLiteMigration(...)` when creating the target SQLite store (Dolt -> SQLite escape hatch)

Both should use `configfile.BackendSQLite`.

## What This PR Changes

1. Fix SQLite source extraction backend
- In `extractFromSQLite`, changed:
  - `factory.NewWithOptions(..., configfile.BackendDolt, dbPath, ...)`
  - to `factory.NewWithOptions(..., configfile.BackendSQLite, dbPath, ...)`

2. Fix SQLite target creation backend
- In `handleToSQLiteMigration`, changed:
  - `factory.New(..., configfile.BackendDolt, sqlitePath)`
  - to `factory.New(..., configfile.BackendSQLite, sqlitePath)`

3. Add regression test
- New test: `TestExtractFromSQLite_OpensSQLiteFile` in `cmd/bd/migrate_dolt_extraction_test.go`
- Verifies that `extractFromSQLite` can open a real SQLite file path and return extracted data.
- This test would fail before this fix because the code attempted Dolt initialization against a SQLite file path.

## Scope / Non-goals

This PR only fixes backend selection for SQLite paths in migration code.

It does **not** change:
- migration plan/output UX,
- Dolt schema/content import semantics,
- other `doctor --fix` workflows.

## Tests

Added:
- `cmd/bd/migrate_dolt_extraction_test.go`
  - `TestExtractFromSQLite_OpensSQLiteFile`

## Why this is safe

- The change is backend selection only, scoped to migration helpers handling SQLite file paths.
- It aligns implementation with function intent (`extractFromSQLite`, "Creating SQLite database...").
- No behavioral change for non-migration command paths.
