### PR TITLE
Fix typo in dolt migrate command

### DIFF
--- a/docs/DOLT-BACKEND.md
+++ b/docs/DOLT-BACKEND.md
@@ -36,7 +36,7 @@ dolt version
 bd init --backend=dolt
 
 # Or convert existing SQLite database
-bd migrate --to=dolt
+bd migrate --to-dolt
 ```
 
 ### 3. Configure Sync Mode


### PR DESCRIPTION
current documentation features an invalid command:
```
$ bd migrate --to=dolt
Error: unknown flag: --to
```

The intent was probably `bd migration --to-dolt`.