### PR TITLE
fix(doctor): honor --yes for repo fingerprint fix in doctor --fix

### DIFF
--- a/cmd/bd/doctor/fix/repo_fingerprint_test.go
+++ b/cmd/bd/doctor/fix/repo_fingerprint_test.go
@@ -1,0 +1,76 @@
+package fix
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestRepoFingerprint_AutoYesSkipsPromptAndPassesYesToMigrate(t *testing.T) {
+	dir := setupTestWorkspace(t)
+
+	oldGetBinary := repoFingerprintGetBdBinary
+	oldReadLine := repoFingerprintReadLine
+	oldNewCmd := repoFingerprintNewBdCmd
+	defer func() {
+		repoFingerprintGetBdBinary = oldGetBinary
+		repoFingerprintReadLine = oldReadLine
+		repoFingerprintNewBdCmd = oldNewCmd
+	}()
+
+	var gotArgs []string
+	readCalled := false
+
+	repoFingerprintGetBdBinary = func() (string, error) { return "bd", nil }
+	repoFingerprintReadLine = func() (string, error) {
+		readCalled = true
+		return "", nil
+	}
+	repoFingerprintNewBdCmd = func(_ string, args ...string) *exec.Cmd {
+		gotArgs = append([]string{}, args...)
+		return exec.Command("go", "version")
+	}
+
+	if err := RepoFingerprint(dir, true); err != nil {
+		t.Fatalf("RepoFingerprint(autoYes=true) returned error: %v", err)
+	}
+
+	if readCalled {
+		t.Fatal("expected autoYes path to skip interactive stdin read")
+	}
+
+	wantArgs := []string{"migrate", "--update-repo-id", "--yes"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected command args: got %v, want %v", gotArgs, wantArgs)
+	}
+}
+
+func TestRepoFingerprint_ChoiceOneRunsUpdateRepoIDWithoutYes(t *testing.T) {
+	dir := setupTestWorkspace(t)
+
+	oldGetBinary := repoFingerprintGetBdBinary
+	oldReadLine := repoFingerprintReadLine
+	oldNewCmd := repoFingerprintNewBdCmd
+	defer func() {
+		repoFingerprintGetBdBinary = oldGetBinary
+		repoFingerprintReadLine = oldReadLine
+		repoFingerprintNewBdCmd = oldNewCmd
+	}()
+
+	var gotArgs []string
+	repoFingerprintGetBdBinary = func() (string, error) { return "bd", nil }
+	repoFingerprintReadLine = func() (string, error) { return "1", nil }
+	repoFingerprintNewBdCmd = func(_ string, args ...string) *exec.Cmd {
+		gotArgs = append([]string{}, args...)
+		return exec.Command("go", "version")
+	}
+
+	if err := RepoFingerprint(dir, false); err != nil {
+		t.Fatalf("RepoFingerprint(autoYes=false, choice=1) returned error: %v", err)
+	}
+
+	wantArgs := []string{"migrate", "--update-repo-id"}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected command args: got %v, want %v", gotArgs, wantArgs)
+	}
+}

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -274,7 +274,7 @@ func applyFixList(path string, fixes []doctorCheck) {
 		case "Schema Compatibility":
 			err = fix.SchemaCompatibility(path)
 		case "Repo Fingerprint":
-			err = fix.RepoFingerprint(path)
+			err = fix.RepoFingerprint(path, doctorYes)
 			// Also repair any other missing metadata fields (bd_version, repo_id, clone_id)
 			if mErr := fix.FixMissingMetadata(path, Version); mErr != nil && err == nil {
 				err = mErr


### PR DESCRIPTION
## Summary

Fixes #1772.

`bd doctor --fix --yes` is documented as non-interactive, but `Repo Fingerprint` fix still prompted for `Choice [1/2/s]` and blocked automation (or failed with EOF in non-interactive environments).

This PR makes `--yes` fully non-interactive for the fingerprint fix path by auto-selecting the recommended action (`update-repo-id`) and passing `--yes` through to migrate.

Related report: #1772

## Background / Root Cause

`applyFixList(...)` in `cmd/bd/doctor_fix.go` called `fix.RepoFingerprint(path)` without passing `doctorYes`.

Inside `cmd/bd/doctor/fix/repo_fingerprint.go`, `RepoFingerprint` always read from stdin (`Choice [1/2/s]`) before deciding an action.

So even with `bd doctor --fix --yes`, the fingerprint fix path remained interactive.

## What This PR Changes

1. Thread `--yes` into fingerprint fix flow
- `cmd/bd/doctor_fix.go`
- `Repo Fingerprint` case now calls:
  - `fix.RepoFingerprint(path, doctorYes)`

2. Add explicit non-interactive auto path
- `cmd/bd/doctor/fix/repo_fingerprint.go`
- `RepoFingerprint(path, autoYes bool)` now:
  - when `autoYes=true`, skips prompt
  - auto-runs `bd migrate --update-repo-id --yes`

3. Preserve existing interactive behavior when `--yes` is not set
- Existing `[1]/[2]/[s]` flow remains unchanged for interactive runs.

4. Add regression tests
- `cmd/bd/doctor/fix/repo_fingerprint_test.go`
  - `TestRepoFingerprint_AutoYesSkipsPromptAndPassesYesToMigrate`
  - `TestRepoFingerprint_ChoiceOneRunsUpdateRepoIDWithoutYes`

## Scope / Non-goals

This PR only addresses non-interactive semantics for `Repo Fingerprint` in `doctor --fix`.

It does **not** change:
- fingerprint detection logic,
- migrate repo-id computation behavior,
- unrelated doctor checks.

## Tests

Added:
- `cmd/bd/doctor/fix/repo_fingerprint_test.go`

Validated locally with:
- `go build -tags gms_pure_go ./cmd/bd`
- `go test -tags gms_pure_go ./cmd/bd/doctor/fix -run RepoFingerprint -count=1`

## Why this is safe

- `--yes` is explicitly intended for non-interactive operation.
- Auto path chooses the existing recommended safe action ([1] update repo ID), not destructive reset.
- Interactive workflow is preserved when `--yes` is absent.
