### PR TITLE
fix: use file: URI prefix for SQLite open in migrate_dolt

### DIFF
--- a/cmd/bd/migrate_dolt.go
+++ b/cmd/bd/migrate_dolt.go
@@ -224,7 +224,7 @@ func handleToSQLiteMigration(_ bool, _ bool) {
 
 // extractFromSQLite extracts all data from a SQLite database using raw SQL.
 func extractFromSQLite(ctx context.Context, dbPath string) (*migrationData, error) {
-	db, err := sql.Open("sqlite3", dbPath+"?mode=ro")
+	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open SQLite database: %w", err)
 	}


### PR DESCRIPTION
## Summary

The `extractFromSQLite()` function in `cmd/bd/migrate_dolt.go` opens the SQLite database with:

```go
sql.Open("sqlite3", dbPath+"?mode=ro")
```

The ncruces/go-sqlite3 driver treats this as a literal filename, creating a file named `beads.db?mode=ro` instead of opening `beads.db` in read-only mode.

## Fix

Prefix the path with `file:` so the driver parses it as a URI:

```go
sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
```

## Testing

Built and ran `bd migrate --to-dolt` against a project with a valid SQLite database. Before the fix, a literal `beads.db?mode=ro` file was created. After the fix, the database opens correctly (no spurious file).

The migration proceeds past the SQLite open and hits a separate pre-existing issue with timestamp scanning (`compacted_at` column), which is unrelated to this fix.

Fixes #1783
See also #1752