### PR TITLE
fix(formula): distinguish "no default" from default="" in VarDef

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -227,8 +227,8 @@ func outputCookDryRun(resolved *formula.Formula, protoID string, runtimeMode boo
 		modeLabel = "runtime"
 		// Apply defaults for runtime mode display
 		for name, def := range resolved.Vars {
-			if _, provided := inputVars[name]; !provided && def.Default != "" {
-				inputVars[name] = def.Default
+			if _, provided := inputVars[name]; !provided && def.Default != nil {
+				inputVars[name] = *def.Default
 			}
 		}
 	}
@@ -268,8 +268,8 @@ func outputCookDryRun(resolved *formula.Formula, protoID string, runtimeMode boo
 			if def.Required {
 				attrs = append(attrs, "required")
 			}
-			if def.Default != "" {
-				attrs = append(attrs, fmt.Sprintf("default=%s", def.Default))
+			if def.Default != nil {
+				attrs = append(attrs, fmt.Sprintf("default=%s", *def.Default))
 			}
 			if len(def.Enum) > 0 {
 				attrs = append(attrs, fmt.Sprintf("enum=[%s]", strings.Join(def.Enum, ",")))
@@ -288,8 +288,8 @@ func outputCookEphemeral(resolved *formula.Formula, runtimeMode bool, inputVars 
 	if runtimeMode {
 		// Apply defaults from formula variable definitions
 		for name, def := range resolved.Vars {
-			if _, provided := inputVars[name]; !provided && def.Default != "" {
-				inputVars[name] = def.Default
+			if _, provided := inputVars[name]; !provided && def.Default != nil {
+				inputVars[name] = *def.Default
 			}
 		}
 
@@ -727,8 +727,8 @@ func resolveAndCookFormulaWithVars(formulaName string, searchPaths []string, con
 		// Merge with formula defaults for complete evaluation
 		mergedVars := make(map[string]string)
 		for name, def := range resolved.Vars {
-			if def != nil && def.Default != "" {
-				mergedVars[name] = def.Default
+			if def != nil && def.Default != nil {
+				mergedVars[name] = *def.Default
 			}
 		}
 		for k, v := range conditionVars {

--- a/cmd/bd/formula.go
+++ b/cmd/bd/formula.go
@@ -234,8 +234,8 @@ func runFormulaShow(cmd *cobra.Command, args []string) {
 			if v.Required {
 				attrs = append(attrs, ui.RenderFail("required"))
 			}
-			if v.Default != "" {
-				attrs = append(attrs, fmt.Sprintf("default=%q", v.Default))
+			if v.Default != nil {
+				attrs = append(attrs, fmt.Sprintf("default=%q", *v.Default))
 			}
 			if len(v.Enum) > 0 {
 				attrs = append(attrs, fmt.Sprintf("enum=[%s]", strings.Join(v.Enum, ",")))

--- a/cmd/bd/mol_test.go
+++ b/cmd/bd/mol_test.go
@@ -2744,7 +2744,7 @@ func TestPourRootTitleDescSubstitution(t *testing.T) {
 			"desc": {
 				Description: "Task description",
 				Required:    false,
-				Default:     "No description provided",
+				Default:     formula.StringPtr("No description provided"),
 			},
 		},
 		Steps: []*formula.Step{

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -594,9 +594,10 @@ func extractRequiredVariables(subgraph *TemplateSubgraph) []string {
 			// Not a declared formula variable - skip (documentation handlebars)
 			continue
 		}
-		// A declared variable is required only if explicitly marked as such.
-		// Variables with empty-string defaults (default="") are optional.
-		if def.Required {
+		// A declared variable is required if it has no default.
+		// nil Default = no default specified (must provide).
+		// Non-nil Default (including &"") = has explicit default (optional).
+		if def.Default == nil {
 			required = append(required, v)
 		}
 	}
@@ -617,8 +618,8 @@ func applyVariableDefaults(vars map[string]string, subgraph *TemplateSubgraph) m
 
 	// Apply defaults for missing variables (including empty-string defaults)
 	for name, def := range subgraph.VarDefs {
-		if _, exists := result[name]; !exists && !def.Required {
-			result[name] = def.Default
+		if _, exists := result[name]; !exists && def.Default != nil {
+			result[name] = *def.Default
 		}
 	}
 

--- a/internal/formula/expand.go
+++ b/internal/formula/expand.go
@@ -276,8 +276,8 @@ func mergeVars(formula *Formula, overrides map[string]string) map[string]string 
 
 	// Start with formula defaults
 	for name, def := range formula.Vars {
-		if def.Default != "" {
-			result[name] = def.Default
+		if def.Default != nil {
+			result[name] = *def.Default
 		}
 	}
 

--- a/internal/formula/expand_test.go
+++ b/internal/formula/expand_test.go
@@ -485,8 +485,8 @@ func TestSubstituteVars(t *testing.T) {
 func TestMergeVars(t *testing.T) {
 	formula := &Formula{
 		Vars: map[string]*VarDef{
-			"env":     {Default: "staging"},
-			"version": {Default: "1.0"},
+			"env":     {Default: StringPtr("staging")},
+			"version": {Default: StringPtr("1.0")},
 			"name":    {Required: true}, // No default
 		},
 	}
@@ -517,6 +517,31 @@ func TestMergeVars(t *testing.T) {
 
 		if result["env"] != "staging" {
 			t.Errorf("env = %q, want 'staging'", result["env"])
+		}
+	})
+
+	t.Run("empty-string defaults are included in merge", func(t *testing.T) {
+		f := &Formula{
+			Vars: map[string]*VarDef{
+				"setup_cmd": {Default: StringPtr("")},
+				"name":      {Default: StringPtr("default-name")},
+				"required":  {Required: true}, // nil default
+			},
+		}
+		result := mergeVars(f, nil)
+
+		if v, ok := result["setup_cmd"]; !ok {
+			t.Error("setup_cmd should be present in merged result (empty-string default)")
+		} else if v != "" {
+			t.Errorf("setup_cmd = %q, want empty string", v)
+		}
+
+		if result["name"] != "default-name" {
+			t.Errorf("name = %q, want 'default-name'", result["name"])
+		}
+
+		if _, ok := result["required"]; ok {
+			t.Error("required should NOT be in merged result (nil default)")
 		}
 	})
 }

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -374,8 +374,8 @@ func ValidateVars(formula *Formula, values map[string]string) error {
 		}
 
 		// Use default if not provided
-		if !provided && def.Default != "" {
-			val = def.Default
+		if !provided && def.Default != nil {
+			val = *def.Default
 		}
 
 		// Skip further validation if no value
@@ -426,8 +426,8 @@ func ApplyDefaults(formula *Formula, values map[string]string) map[string]string
 
 	// Apply defaults for missing values
 	for name, def := range formula.Vars {
-		if _, exists := result[name]; !exists && def.Default != "" {
-			result[name] = def.Default
+		if _, exists := result[name]; !exists && def.Default != nil {
+			result[name] = *def.Default
 		}
 	}
 

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -58,7 +58,7 @@ func TestParse_BasicFormula(t *testing.T) {
 	if v := formula.Vars["component"]; v == nil || !v.Required {
 		t.Error("component var should be required")
 	}
-	if v := formula.Vars["framework"]; v == nil || v.Default != "react" {
+	if v := formula.Vars["framework"]; v == nil || v.Default == nil || *v.Default != "react" {
 		t.Error("framework var should have default 'react'")
 	}
 	if v := formula.Vars["framework"]; v == nil || len(v.Enum) != 3 {
@@ -145,7 +145,7 @@ func TestValidate_RequiredWithDefault(t *testing.T) {
 		Version: 1,
 		Type:    TypeWorkflow,
 		Vars: map[string]*VarDef{
-			"bad": {Required: true, Default: "value"}, // can't have both
+			"bad": {Required: true, Default: StringPtr("value")}, // can't have both
 		},
 		Steps: []*Step{{ID: "step1", Title: "Step 1"}},
 	}
@@ -343,7 +343,7 @@ func TestValidateVars(t *testing.T) {
 			"required_var": {Required: true},
 			"enum_var":     {Enum: []string{"a", "b", "c"}},
 			"pattern_var":  {Pattern: `^[a-z]+$`},
-			"optional_var": {Default: "default"},
+			"optional_var": {Default: StringPtr("default")},
 		},
 	}
 
@@ -398,7 +398,7 @@ func TestApplyDefaults(t *testing.T) {
 	formula := &Formula{
 		Formula: "mol-defaults",
 		Vars: map[string]*VarDef{
-			"with_default":    {Default: "default_value"},
+			"with_default":    {Default: StringPtr("default_value")},
 			"without_default": {},
 		},
 	}
@@ -1395,14 +1395,14 @@ title = "Start {{wisp_type}} on {{rig_name}}"
 	// Simple string should become Default
 	if v := formula.Vars["wisp_type"]; v == nil {
 		t.Error("wisp_type var not found")
-	} else if v.Default != "patrol" {
-		t.Errorf("wisp_type.Default = %q, want 'patrol'", v.Default)
+	} else if v.Default == nil || *v.Default != "patrol" {
+		t.Errorf("wisp_type.Default = %v, want 'patrol'", v.Default)
 	}
 
 	if v := formula.Vars["rig_name"]; v == nil {
 		t.Error("rig_name var not found")
-	} else if v.Default != "mayor" {
-		t.Errorf("rig_name.Default = %q, want 'mayor'", v.Default)
+	} else if v.Default == nil || *v.Default != "mayor" {
+		t.Errorf("rig_name.Default = %v, want 'mayor'", v.Default)
 	}
 }
 
@@ -1449,8 +1449,8 @@ title = "Test"
 	// Check simple var
 	if v := formula.Vars["simple_var"]; v == nil {
 		t.Error("simple_var not found")
-	} else if v.Default != "simple_value" {
-		t.Errorf("simple_var.Default = %q, want 'simple_value'", v.Default)
+	} else if v.Default == nil || *v.Default != "simple_value" {
+		t.Errorf("simple_var.Default = %v, want 'simple_value'", v.Default)
 	}
 
 	// Check complex var
@@ -1460,8 +1460,8 @@ title = "Test"
 		if v.Description != "A complex variable" {
 			t.Errorf("complex_var.Description = %q, want 'A complex variable'", v.Description)
 		}
-		if v.Default != "complex_default" {
-			t.Errorf("complex_var.Default = %q, want 'complex_default'", v.Default)
+		if v.Default == nil || *v.Default != "complex_default" {
+			t.Errorf("complex_var.Default = %v, want 'complex_default'", v.Default)
 		}
 		if len(v.Enum) != 3 {
 			t.Errorf("len(complex_var.Enum) = %d, want 3", len(v.Enum))
@@ -1478,5 +1478,115 @@ title = "Test"
 		if v.Description != "A required variable" {
 			t.Errorf("required_var.Description = %q, want 'A required variable'", v.Description)
 		}
+	}
+}
+
+func TestVarDef_UnmarshalTOML_EmptyDefault(t *testing.T) {
+	// default = "" should parse as non-nil *string pointing to ""
+	tomlData := `
+formula = "mol-empty-default"
+version = 1
+type = "workflow"
+
+[vars.setup_command]
+description = "Optional setup command"
+default = ""
+
+[[steps]]
+id = "step1"
+title = "Run {{setup_command}}"
+`
+	p := NewParser()
+	formula, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+
+	v := formula.Vars["setup_command"]
+	if v == nil {
+		t.Fatal("setup_command var not found")
+	}
+	if v.Default == nil {
+		t.Fatal("setup_command.Default should be non-nil (explicitly set to empty string)")
+	}
+	if *v.Default != "" {
+		t.Errorf("setup_command.Default = %q, want empty string", *v.Default)
+	}
+}
+
+func TestVarDef_UnmarshalTOML_NoDefault(t *testing.T) {
+	// No default key at all should parse as nil *string
+	tomlData := `
+formula = "mol-no-default"
+version = 1
+type = "workflow"
+
+[vars.component]
+description = "Required component"
+required = true
+
+[[steps]]
+id = "step1"
+title = "Build {{component}}"
+`
+	p := NewParser()
+	formula, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+
+	v := formula.Vars["component"]
+	if v == nil {
+		t.Fatal("component var not found")
+	}
+	if v.Default != nil {
+		t.Errorf("component.Default should be nil (no default specified), got %q", *v.Default)
+	}
+}
+
+func TestValidate_RequiredWithEmptyDefault(t *testing.T) {
+	// required: true + default: "" (non-nil) should fail validation
+	formula := &Formula{
+		Formula: "mol-bad",
+		Version: 1,
+		Type:    TypeWorkflow,
+		Vars: map[string]*VarDef{
+			"bad": {Required: true, Default: StringPtr("")},
+		},
+		Steps: []*Step{{ID: "step1", Title: "Step 1"}},
+	}
+
+	err := formula.Validate()
+	if err == nil {
+		t.Error("Validate should fail for required var with empty-string default")
+	}
+}
+
+func TestApplyDefaults_EmptyStringDefault(t *testing.T) {
+	// Variables with default="" should have their empty-string default applied
+	formula := &Formula{
+		Formula: "mol-empty-defaults",
+		Vars: map[string]*VarDef{
+			"setup_command": {Default: StringPtr("")},
+			"required_var":  {Required: true},
+			"normal_default": {Default: StringPtr("value")},
+		},
+	}
+
+	values := map[string]string{"required_var": "provided"}
+	result := ApplyDefaults(formula, values)
+
+	if v, ok := result["setup_command"]; !ok {
+		t.Error("setup_command should be present in result (empty-string default)")
+	} else if v != "" {
+		t.Errorf("setup_command = %q, want empty string", v)
+	}
+
+	if result["required_var"] != "provided" {
+		t.Errorf("required_var = %q, want 'provided'", result["required_var"])
+	}
+
+	if result["normal_default"] != "value" {
+		t.Errorf("normal_default = %q, want 'value'", result["normal_default"])
 	}
 }


### PR DESCRIPTION
## Summary

`VarDef.Default` was a plain `string`, so Go's zero value `""` was indistinguishable from an explicit `default = ""`. This caused ~50+ formula variables with `default = ""` (meaning "optional, skip if empty") to be treated as required, breaking `gt sling` for operational formulas like `mol-polecat-work`, `mol-orphan-scan`, and `mol-refinery-patrol`.

Fixes: steveyegge/gastown#1551

### Changes Made

- **`internal/formula/types.go`** — Change `Default string` to `Default *string`. `nil` = no default specified, non-nil (including `&""`) = explicit default. Added `StringPtr()` helper for constructing VarDef literals. Updated `UnmarshalTOML` to use `&val`/`&def`, updated `Validate` to check `!= nil`.
- **`internal/formula/parser.go`** — Updated `ValidateVars` and `ApplyDefaults`: `!= ""` → `!= nil`, value reads dereference with `*`.
- **`internal/formula/expand.go`** — Updated `mergeVars`: same pattern.
- **`cmd/bd/cook.go`** — Updated 4 sites (dry-run display, ephemeral defaults, condition eval merging).
- **`cmd/bd/formula.go`** — Updated formula show display.
- **`cmd/bd/template.go`** — Updated `extractRequiredVariables` and `applyVariableDefaults`. Supersedes the `def.Required`/`!def.Required` workaround from commit `1f59a21b`, which was subtly wrong (conflated "not required" with "has a default").

### Test Coverage

11 new test cases added across 4 test files:

- **`parser_test.go`** — `TestVarDef_UnmarshalTOML_EmptyDefault`, `TestVarDef_UnmarshalTOML_NoDefault`, `TestValidate_RequiredWithEmptyDefault`, `TestApplyDefaults_EmptyStringDefault`
- **`expand_test.go`** — `"empty-string defaults are included in merge"` case in `TestMergeVars`
- **`template_test.go`** — `TestExtractRequiredVariables_EmptyStringDefault` (2 cases), `TestApplyVariableDefaults` (5 cases)
- **`mol_test.go`** — Updated existing VarDef literal to use `StringPtr()`

### Backward Compatibility

✅ JSON: `omitempty` on `*string` omits `nil` (same behavior as `""` on `string`). Existing stored beads with no `"default"` key deserialize as `nil` (correct). Existing beads with `"default":"value"` deserialize as `*"value"` (correct).
✅ TOML: `UnmarshalTOML` handles simple string → `&val`, table with `default` key → `&def`, table without `default` key → `nil`.
✅ No breaking changes to exported API — `StringPtr` is the only new export.

### Size: Medium ✓

10 files changed, 284 insertions(+), 42 deletions(-). Mechanical type change across all consumer sites + comprehensive new tests.

🤖 Generated with [Claude Code](https://claude.ai/code)