### PR TITLE
Fix CI failures: gofmt, gosec G204, and unparam warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,7 @@ linters:
           - gosec
         text: "G306.*0700"
       # G204: Safe subprocess launches with validated arguments
-      - path: 'cmd/bd/doctor\.go|cmd/bd/doctor/fix/sync_branch\.go|cmd/bd/gate\.go|cmd/bd/gate_discover\.go|cmd/bd/jira\.go|cmd/bd/show\.go|cmd/bd/sync\.go|internal/git/worktree\.go|internal/syncbranch/worktree\.go'
+      - path: 'cmd/bd/doctor\.go|cmd/bd/doctor/fix/sync_branch\.go|cmd/bd/gate\.go|cmd/bd/gate_discover\.go|cmd/bd/jira\.go|cmd/bd/show\.go|cmd/bd/stubs\.go|cmd/bd/sync\.go|internal/git/worktree\.go|internal/syncbranch/worktree\.go'
         linters:
           - gosec
         text: 'G204'


### PR DESCRIPTION
## Summary

CI on `main` is failing with formatting violations, a gosec G204 warning, and an unparam warning. This PR fixes all three to unblock PRs.

### Changes Made

- **Run `gofmt` on all files** — fixes trailing whitespace, extra blank lines, and comment alignment across 24 files
- **Add `cmd/bd/stubs.go` to G204 exclusion** in `.golangci.yml` — the `exec.Command` args come from internal logic, not user input, matching the existing pattern for 12+ other files
- **Remove unused `error` return from `performContentMerge()`** — the function always returned `nil` since errors from `extractJSONLFromCommit` are intentionally swallowed (falls back to empty content). Updated 2 call sites and 2 test call sites.

### Backward Compatibility

✅ **Maintained**: No behavioral changes — formatting only + removing dead error path
✅ **Same behavior**: `performContentMerge` already never returned an error

### Size: Small ✓

Mechanical formatting + two targeted lint fixes.

🤖 Generated with [Claude Code](https://claude.ai/code)