### PR TITLE
fix: stabilize Dolt backend — locking, migration, compaction

### DIFF
--- a/cmd/bd/compact_test.go
+++ b/cmd/bd/compact_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCompactSuite(t *testing.T) {
-	t.Skip("Compaction not yet implemented for Dolt backend")
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
 	s := newTestStore(t, testDB)
@@ -51,22 +50,24 @@ func TestCompactSuite(t *testing.T) {
 		// Create mix of issues - some eligible, some not
 		issues := []*types.Issue{
 			{
-				ID:        "test-stats-1",
-				Title:     "Old closed",
-				Status:    types.StatusClosed,
-				Priority:  2,
-				IssueType: types.TypeTask,
-				CreatedAt: time.Now().Add(-60 * 24 * time.Hour),
-				ClosedAt:  ptrTime(time.Now().Add(-35 * 24 * time.Hour)),
+				ID:          "test-stats-1",
+				Title:       "Old closed",
+				Description: "Content that makes this issue eligible for compaction.",
+				Status:      types.StatusClosed,
+				Priority:    2,
+				IssueType:   types.TypeTask,
+				CreatedAt:   time.Now().Add(-60 * 24 * time.Hour),
+				ClosedAt:    ptrTime(time.Now().Add(-35 * 24 * time.Hour)),
 			},
 			{
-				ID:        "test-stats-2",
-				Title:     "Recent closed",
-				Status:    types.StatusClosed,
-				Priority:  2,
-				IssueType: types.TypeTask,
-				CreatedAt: time.Now().Add(-10 * 24 * time.Hour),
-				ClosedAt:  ptrTime(time.Now().Add(-5 * 24 * time.Hour)),
+				ID:          "test-stats-2",
+				Title:       "Recent closed",
+				Description: "Some content here too.",
+				Status:      types.StatusClosed,
+				Priority:    2,
+				IssueType:   types.TypeTask,
+				CreatedAt:   time.Now().Add(-10 * 24 * time.Hour),
+				ClosedAt:    ptrTime(time.Now().Add(-5 * 24 * time.Hour)),
 			},
 			{
 				ID:        "test-stats-3",

--- a/cmd/bd/doctor/artifacts.go
+++ b/cmd/bd/doctor/artifacts.go
@@ -266,7 +266,13 @@ func scanJSONLArtifacts(beadsDir string, report *ArtifactReport) {
 }
 
 // scanSQLiteArtifacts checks for leftover SQLite database files.
+// Only flags SQLite files as artifacts if Dolt is the active backend.
+// If SQLite is still the active backend, beads.db is the live database.
 func scanSQLiteArtifacts(beadsDir string, report *ArtifactReport) {
+	if !isDoltNative(beadsDir) {
+		return
+	}
+
 	entries, err := os.ReadDir(beadsDir)
 	if err != nil {
 		return
@@ -283,7 +289,7 @@ func scanSQLiteArtifacts(beadsDir string, report *ArtifactReport) {
 			report.SQLiteArtifacts = append(report.SQLiteArtifacts, ArtifactFinding{
 				Path:        filepath.Join(beadsDir, name),
 				Type:        "sqlite",
-				Description: "SQLite database file",
+				Description: "SQLite database file (Dolt is active backend)",
 				SafeDelete:  name == "beads.db-shm" || name == "beads.db-wal",
 			})
 			continue

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -137,8 +137,11 @@ func watchIssues(ctx context.Context, store *dolt.DoltStore, filter types.IssueF
 	}
 
 	// Initial display
-	// Best effort: display gracefully degrades with empty data
-	issues, _ := store.SearchIssues(ctx, "", filter)
+	issues, err := store.SearchIssues(ctx, "", filter)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error querying issues: %v\n", err)
+		return
+	}
 	sortIssues(issues, sortBy, reverse)
 	displayPrettyList(issues, true)
 
@@ -170,8 +173,11 @@ func watchIssues(ctx context.Context, store *dolt.DoltStore, filter types.IssueF
 						debounceTimer.Stop()
 					}
 					debounceTimer = time.AfterFunc(debounceDelay, func() {
-						// Best effort: display gracefully degrades with empty data
-						issues, _ := store.SearchIssues(ctx, "", filter)
+						issues, err := store.SearchIssues(ctx, "", filter)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "Error refreshing issues: %v\n", err)
+							return
+						}
 						sortIssues(issues, sortBy, reverse)
 						displayPrettyList(issues, true)
 						fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -373,6 +373,23 @@ func LogOverride(override ConfigOverride) {
 		override.Key, overrideDesc, override.OriginalValue, sourceDesc, override.EffectiveValue)
 }
 
+// SaveConfigValue sets a key-value pair and writes it to the config file.
+// If no config file is currently loaded, it creates config.yaml in the given beadsDir.
+func SaveConfigValue(key string, value interface{}, beadsDir string) error {
+	if v == nil {
+		return fmt.Errorf("config not initialized")
+	}
+	v.Set(key, value)
+
+	configPath := v.ConfigFileUsed()
+	if configPath == "" {
+		configPath = filepath.Join(beadsDir, "config.yaml")
+		v.SetConfigFile(configPath)
+	}
+
+	return v.WriteConfigAs(configPath)
+}
+
 // GetString retrieves a string configuration value
 func GetString(key string) string {
 	if v == nil {

--- a/internal/storage/dolt/access_lock.go
+++ b/internal/storage/dolt/access_lock.go
@@ -81,7 +81,8 @@ func AcquireAccessLock(doltDir string, exclusive bool, timeout time.Duration) (*
 	if exclusive {
 		kind = "exclusive"
 	}
-	return nil, fmt.Errorf("dolt access lock timeout (%s, %v): another bd process is using the database: %w",
+	return nil, fmt.Errorf("dolt access lock timeout (%s, %v): another bd process is using the database; "+
+		"if no other process is running, try 'bd doctor --fix' to clean stale locks: %w",
 		kind, timeout, lockfile.ErrLockBusy)
 }
 

--- a/internal/storage/dolt/compact.go
+++ b/internal/storage/dolt/compact.go
@@ -4,31 +4,151 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
 
+const (
+	defaultTier1Days = 30
+	defaultTier2Days = 90
+)
+
 // CheckEligibility checks if an issue is eligible for compaction at the given tier.
-// TODO: Implement compaction eligibility for Dolt backend.
-func (s *DoltStore) CheckEligibility(_ context.Context, _ string, _ int) (bool, string, error) {
-	return false, "compaction not yet implemented for Dolt backend", nil
+func (s *DoltStore) CheckEligibility(ctx context.Context, issueID string, tier int) (bool, string, error) {
+	var status string
+	var closedAt sql.NullTime
+	var compactionLevel int
+	var descLen, designLen, notesLen, acLen int
+
+	err := s.queryRowContext(ctx, func(row *sql.Row) error {
+		return row.Scan(&status, &closedAt, &compactionLevel, &descLen, &designLen, &notesLen, &acLen)
+	}, `SELECT status, closed_at, COALESCE(compaction_level, 0),
+		LENGTH(COALESCE(description, '')), LENGTH(COALESCE(design, '')),
+		LENGTH(COALESCE(notes, '')), LENGTH(COALESCE(acceptance_criteria, ''))
+	FROM issues WHERE id = ?`, issueID)
+
+	if err == sql.ErrNoRows {
+		return false, "issue not found", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("failed to query issue: %w", err)
+	}
+
+	if status != "closed" {
+		return false, "issue is not closed", nil
+	}
+	if !closedAt.Valid {
+		return false, "issue has no closed_at timestamp", nil
+	}
+
+	// Check compaction level
+	requiredLevel := tier - 1
+	if compactionLevel != requiredLevel {
+		return false, fmt.Sprintf("compaction_level is %d, need %d for tier %d", compactionLevel, requiredLevel, tier), nil
+	}
+
+	// Check content size
+	contentSize := descLen + designLen + notesLen + acLen
+	if contentSize == 0 {
+		return false, "no content to compact", nil
+	}
+
+	// Check age threshold
+	thresholdDays, err := s.getCompactionThresholdDays(ctx, tier)
+	if err != nil {
+		return false, "", err
+	}
+	daysSinceClosed := int(time.Since(closedAt.Time).Hours() / 24)
+	if daysSinceClosed < thresholdDays {
+		return false, fmt.Sprintf("closed %d days ago, need %d for tier %d", daysSinceClosed, thresholdDays, tier), nil
+	}
+
+	return true, "", nil
 }
 
 // ApplyCompaction records a compaction result in the database.
-// TODO: Implement compaction tracking for Dolt backend.
-func (s *DoltStore) ApplyCompaction(_ context.Context, _ string, _ int, _, _ int, _ string) error {
-	return fmt.Errorf("compaction not yet implemented for Dolt backend")
+func (s *DoltStore) ApplyCompaction(ctx context.Context, issueID string, tier int, originalSize int, _ int, commitHash string) error {
+	_, err := s.execContext(ctx, `
+		UPDATE issues SET compaction_level = ?, compacted_at = NOW(),
+			compacted_at_commit = ?, original_size = ?
+		WHERE id = ?`,
+		tier, commitHash, originalSize, issueID)
+	if err != nil {
+		return fmt.Errorf("failed to apply compaction: %w", err)
+	}
+	return nil
 }
 
 // GetTier1Candidates returns issues eligible for tier 1 compaction.
-// TODO: Implement for Dolt backend.
-func (s *DoltStore) GetTier1Candidates(_ context.Context) ([]*types.CompactionCandidate, error) {
-	return nil, nil
+func (s *DoltStore) GetTier1Candidates(ctx context.Context) ([]*types.CompactionCandidate, error) {
+	return s.getCandidates(ctx, 1)
 }
 
 // GetTier2Candidates returns issues eligible for tier 2 compaction.
-// TODO: Implement for Dolt backend.
-func (s *DoltStore) GetTier2Candidates(_ context.Context) ([]*types.CompactionCandidate, error) {
-	return nil, nil
+func (s *DoltStore) GetTier2Candidates(ctx context.Context) ([]*types.CompactionCandidate, error) {
+	return s.getCandidates(ctx, 2)
+}
+
+// getCandidates returns compaction candidates for the given tier.
+func (s *DoltStore) getCandidates(ctx context.Context, tier int) ([]*types.CompactionCandidate, error) {
+	requiredLevel := tier - 1
+	thresholdDays, err := s.getCompactionThresholdDays(ctx, tier)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := s.queryContext(ctx, `
+		SELECT id, closed_at,
+			LENGTH(COALESCE(description, '')) + LENGTH(COALESCE(design, '')) +
+			LENGTH(COALESCE(notes, '')) + LENGTH(COALESCE(acceptance_criteria, '')) as original_size
+		FROM issues
+		WHERE status = 'closed'
+			AND closed_at IS NOT NULL
+			AND COALESCE(compaction_level, 0) = ?
+			AND TIMESTAMPDIFF(DAY, closed_at, NOW()) >= ?
+			AND (LENGTH(COALESCE(description, '')) + LENGTH(COALESCE(design, '')) +
+				LENGTH(COALESCE(notes, '')) + LENGTH(COALESCE(acceptance_criteria, ''))) > 0
+		ORDER BY closed_at ASC`,
+		requiredLevel, thresholdDays)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query tier %d candidates: %w", tier, err)
+	}
+	defer rows.Close()
+
+	var candidates []*types.CompactionCandidate
+	for rows.Next() {
+		var c types.CompactionCandidate
+		if err := rows.Scan(&c.IssueID, &c.ClosedAt, &c.OriginalSize); err != nil {
+			return nil, fmt.Errorf("failed to scan candidate: %w", err)
+		}
+		candidates = append(candidates, &c)
+	}
+	return candidates, rows.Err()
+}
+
+// getCompactionThresholdDays reads the compaction threshold from config, with defaults.
+func (s *DoltStore) getCompactionThresholdDays(ctx context.Context, tier int) (int, error) {
+	key := fmt.Sprintf("compact_tier%d_days", tier)
+	value, err := s.GetConfig(ctx, key)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read config %s: %w", key, err)
+	}
+	if value != "" {
+		days, err := strconv.Atoi(value)
+		if err == nil && days > 0 {
+			return days, nil
+		}
+	}
+	switch tier {
+	case 1:
+		return defaultTier1Days, nil
+	case 2:
+		return defaultTier2Days, nil
+	default:
+		return defaultTier1Days, nil
+	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -250,6 +250,12 @@ func New(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		}
 	}
 
+	// Guard: if the path is an existing regular file (e.g., beads.db from SQLite era),
+	// MkdirAll will fail confusingly. Give a clear error instead.
+	if info, statErr := os.Stat(cfg.Path); statErr == nil && !info.IsDir() {
+		return nil, fmt.Errorf("database path %q is a file, not a directory — run 'bd migrate --to-dolt' to migrate from SQLite", cfg.Path)
+	}
+
 	// Ensure directory exists
 	if err := os.MkdirAll(cfg.Path, 0o750); err != nil {
 		return nil, fmt.Errorf("failed to create database directory: %w", err)


### PR DESCRIPTION
## Summary

Stabilizes three major areas of the Dolt backend: lock contention error handling, SQLite→Dolt migration polish, and compaction implementation. All three workstreams were independent and executed in parallel.

### Changes Made

**WS1: Locking — Surface Errors, Don't Swallow Them** (GH #1773, #1776)
- **`cmd/bd/list.go`** — `SearchIssues` errors at lines 141/174 now propagate to stderr instead of being silently discarded with `_`. Initial display fails loudly; watch loop logs and continues.
- **`internal/storage/dolt/access_lock.go`** — Lock timeout error message now includes actionable hint: `bd doctor --fix` to clean stale locks.
- **`cmd/bd/doctor/fix/locks.go`** — Added cleanup of Dolt noms `LOCK` files (`.beads/dolt/<db>/.dolt/noms/LOCK`) with flock probe to verify no active process before deletion.

**WS2: Migration Polish** (GH #1723, #1752, #1787, #1794)
- **`cmd/bd/migrate_dolt.go`** — After migration, writes `sync.mode: dolt-native` to `config.yaml`, fixing split-brain where viper reads stale `git-portable` from config.yaml while DB has `dolt-native`.
- **`internal/config/config.go`** — Added `SaveConfigValue(key, value, beadsDir)` for persisting config changes to disk via viper.
- **`internal/storage/dolt/store.go`** — Guards `MkdirAll` against file-as-directory path (e.g., `beads.db` from SQLite era) with clear error suggesting `bd migrate --to-dolt`.
- **`cmd/bd/doctor/artifacts.go`** — `scanSQLiteArtifacts` now only flags `beads.db` as an artifact when Dolt IS the active backend, eliminating false positives for SQLite users.

**WS3: Compaction Implementation**
- **`internal/storage/dolt/compact.go`** — Replaced all 4 TODO stubs with real implementations:
  - `CheckEligibility`: Validates status=closed, closed_at set, compaction_level, content size > 0, age threshold from config
  - `ApplyCompaction`: Updates `compaction_level`, `compacted_at`, `compacted_at_commit`, `original_size`
  - `GetTier1Candidates` / `GetTier2Candidates`: Query eligible closed issues per configurable tier thresholds (default 30/90 days)
- **`cmd/bd/compact_test.go`** — Unskipped `TestCompactSuite`, added descriptions to test issues for eligibility checks.

### Backward Compatibility

✅ **Maintained**: All existing behavior preserved — errors that were silently ignored now surface to stderr
✅ **Same behavior**: Compaction stubs that returned "not implemented" now work; callers already handle the interface
✅ **No breaking changes**: `SaveConfigValue` is additive; `scanSQLiteArtifacts` change only reduces false positives

### Technical Details

- Compaction uses `s.queryContext()`/`s.execContext()` wrappers for server-mode retry support
- Config thresholds read via `s.GetConfig(ctx, "compact_tier1_days")` with defaults (30/90)
- Noms LOCK cleanup uses flock probe (`FlockExclusiveNonBlock`) to verify no active holder before deletion
- `SaveConfigValue` uses viper's `WriteConfigAs()` for atomic config persistence

### Benefits

- **Reliability**: Lock contention no longer causes silent data loss (0 results instead of error)
- **Migration correctness**: Migrated users immediately get `dolt-native` sync without manual config editing
- **Compaction**: Enables the full compaction pipeline for Dolt backend (was completely blocked)
- **Doctor accuracy**: Eliminates false positive warnings for non-migrated users

### Size: Medium ✓

9 files changed, 249 insertions, 33 deletions across 3 independent workstreams.

🤖 Generated with [Claude Code](https://claude.ai/code)