### PR TITLE
fix: guard dolt directory creation with server-mode check

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -242,38 +242,46 @@ func New(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		}
 	}
 
-	// Ensure directory exists
-	if err := os.MkdirAll(cfg.Path, 0o750); err != nil {
-		return nil, fmt.Errorf("failed to create database directory: %w", err)
-	}
-
-	// IMPORTANT: Use an absolute path for embedded DSNs.
-	//
-	// The embedded driver sets its internal filesystem working directory to Config.Directory
-	// and also passes the directory path through to lower layers. If we pass a relative path,
-	// the working-directory stacking can effectively double it (e.g. ".beads/dolt/.beads/dolt").
-	absPath, err := filepath.Abs(cfg.Path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get absolute path: %w", err)
-	}
-
-	// Acquire advisory flock before opening dolt (embedded mode only).
-	// This prevents multiple bd processes from competing for dolt's internal LOCK file.
-	// Set BD_SKIP_ACCESS_LOCK=1 to bypass flock for testing whether Dolt's internal
-	// locking is sufficient. See bd-39gso for testing plan.
+	// Embedded-only: create local directory and acquire access lock.
+	// In server mode, the database lives on the remote dolt sql-server;
+	// creating a local dolt/ directory would shadow the server connection
+	// with an empty embedded db (see bd-vyr).
+	var absPath string
 	var accessLock *AccessLock
-	if !cfg.ServerMode && cfg.OpenTimeout > 0 && os.Getenv("BD_SKIP_ACCESS_LOCK") == "" {
-		exclusive := !cfg.ReadOnly
-		var lockErr error
-		accessLock, lockErr = AcquireAccessLock(absPath, exclusive, cfg.OpenTimeout)
-		if lockErr != nil {
-			return nil, fmt.Errorf("failed to acquire dolt access lock: %w", lockErr)
+	if !cfg.ServerMode {
+		if err := os.MkdirAll(cfg.Path, 0o750); err != nil {
+			return nil, fmt.Errorf("failed to create database directory: %w", err)
+		}
+
+		// IMPORTANT: Use an absolute path for embedded DSNs.
+		//
+		// The embedded driver sets its internal filesystem working directory to Config.Directory
+		// and also passes the directory path through to lower layers. If we pass a relative path,
+		// the working-directory stacking can effectively double it (e.g. ".beads/dolt/.beads/dolt").
+		var err error
+		absPath, err = filepath.Abs(cfg.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path: %w", err)
+		}
+
+		// Acquire advisory flock before opening dolt (embedded mode only).
+		// This prevents multiple bd processes from competing for dolt's internal LOCK file.
+		// Set BD_SKIP_ACCESS_LOCK=1 to bypass flock for testing whether Dolt's internal
+		// locking is sufficient. See bd-39gso for testing plan.
+		if cfg.OpenTimeout > 0 && os.Getenv("BD_SKIP_ACCESS_LOCK") == "" {
+			exclusive := !cfg.ReadOnly
+			var lockErr error
+			accessLock, lockErr = AcquireAccessLock(absPath, exclusive, cfg.OpenTimeout)
+			if lockErr != nil {
+				return nil, fmt.Errorf("failed to acquire dolt access lock: %w", lockErr)
+			}
 		}
 	}
 
 	var db *sql.DB
 	var connStr string
 	var embeddedConnector *embedded.Connector
+	var err error
 
 	if cfg.ServerMode {
 		// Fail-fast TCP check before MySQL protocol initialization.


### PR DESCRIPTION
## Summary

Fixes #1799 — `dolt.New()` unconditionally creates a local `.beads/dolt/` directory even in server mode, shadowing the remote dolt sql-server connection with an empty embedded db.

## Changes

Guard `os.MkdirAll`, `filepath.Abs`, and access lock acquisition in `internal/storage/dolt/store.go` with `!cfg.ServerMode` so server-mode connections never touch the local filesystem.

## Root cause

The Phase 7 refactor removed the factory pattern (`factory_dolt.go`) which had server-mode routing that prevented local directory creation. The replacement path (`direct_mode.go` → `dolt.NewFromConfig()` → `dolt.New()`) reaches `os.MkdirAll(cfg.Path)` before the `cfg.ServerMode` branch, creating the directory unconditionally.

## Test plan

- [ ] Build passes (`make build`)
- [ ] Existing tests unaffected (pre-existing failures are from Phase 8, not this change)
- [ ] With `dolt_mode: server` configured, verify no local `.beads/dolt/` directory is created
- [ ] With `dolt_mode: server`, verify queries return data from the remote dolt server
- [ ] Embedded mode still works (directory creation, access lock, schema init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)