### PR TITLE
feat: add Hosted Dolt support (TLS, auth, explicit branch)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -560,6 +560,9 @@ var rootCmd = &cobra.Command{
 				doltCfg.ServerMode = true
 				doltCfg.ServerHost = cfg.GetDoltServerHost()
 				doltCfg.ServerPort = cfg.GetDoltServerPort()
+				doltCfg.ServerUser = cfg.GetDoltServerUser()
+				doltCfg.ServerPassword = cfg.GetDoltServerPassword()
+				doltCfg.ServerTLS = cfg.GetDoltServerTLS()
 			}
 		}
 

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -27,6 +27,7 @@ type Config struct {
 	DoltServerPort int    `json:"dolt_server_port,omitempty"` // Server port (default: 3307)
 	DoltServerUser string `json:"dolt_server_user,omitempty"` // MySQL user (default: root)
 	DoltDatabase   string `json:"dolt_database,omitempty"`    // SQL database name (default: beads)
+	DoltServerTLS  bool   `json:"dolt_server_tls,omitempty"`  // Enable TLS for server connections (required for Hosted Dolt)
 	// Note: Password should be set via BEADS_DOLT_PASSWORD env var for security
 
 	// Stale closed issues check configuration
@@ -282,4 +283,20 @@ func (c *Config) GetDoltDatabase() string {
 		return c.DoltDatabase
 	}
 	return DefaultDoltDatabase
+}
+
+// GetDoltServerPassword returns the Dolt server password.
+// Checks BEADS_DOLT_PASSWORD env var (password should never be stored in config files).
+func (c *Config) GetDoltServerPassword() string {
+	return os.Getenv("BEADS_DOLT_PASSWORD")
+}
+
+// GetDoltServerTLS returns whether TLS is enabled for server connections.
+// Required for Hosted Dolt instances.
+// Checks BEADS_DOLT_SERVER_TLS env var first ("1" or "true"), then config.
+func (c *Config) GetDoltServerTLS() bool {
+	if t := os.Getenv("BEADS_DOLT_SERVER_TLS"); t != "" {
+		return t == "1" || strings.ToLower(t) == "true"
+	}
+	return c.DoltServerTLS
 }


### PR DESCRIPTION
## Summary

Fix four issues that prevent bd from working with Hosted Dolt instances in server mode.

### Fix 1: TLS support for server mode connections

Hosted Dolt requires TLS. Added `ServerTLS` config option and `BEADS_DOLT_SERVER_TLS` env var (`"1"` or `"true"`) to append `tls=true` to the MySQL DSN. Refactored DSN construction into `buildServerDSN()` helper for consistency between main and init connections.

**Files:** `internal/storage/dolt/store.go`, `internal/configfile/configfile.go`

### Fix 2: Remote authentication for push/pull

Hosted Dolt requires the `--user` flag in `CALL DOLT_PUSH()` and `CALL DOLT_PULL()`. Without it, calls fail with `authorization header did not start with 'Basic'`. Added `RemoteUser`/`RemotePassword` fields to `dolt.Config`, populated from `DOLT_REMOTE_USER`/`DOLT_REMOTE_PASSWORD` env vars. When set, `Push()` and `Pull()` pass `--user` and set credentials via the existing `setFederationCredentials()` mechanism.

**Files:** `internal/storage/dolt/store.go`

### Fix 3: Explicit branch in Pull()

`CALL DOLT_PULL(remote)` fails when branch tracking is not configured: `You asked to pull from the remote 'origin', but did not specify a branch.` Now passes branch explicitly in all `Pull()` calls, matching what `Push()` already does.

**Files:** `internal/storage/dolt/store.go`

### Fix 4: Config plumbing for server user/password/TLS

Wired `GetDoltServerUser()`, `GetDoltServerPassword()`, and `GetDoltServerTLS()` from `configfile` through `main.go` to `dolt.Config`. Previously only host and port were passed through, so server mode always connected as "root" without TLS.

**Files:** `cmd/bd/main.go`, `internal/configfile/configfile.go`

## Testing

Validated against a live Hosted Dolt instance (`bryanhirscht-bead-manager-dev0.dbs.hosted.doltdb.com`):
- TLS connection succeeds with `BEADS_DOLT_SERVER_TLS=1`
- `bd list` connects and queries the remote database
- All existing tests pass (the one failing test `TestDeleteIssuesCircularDeps` is pre-existing on main)

## Environment Variables

| Variable | Purpose |
|----------|---------|
| `BEADS_DOLT_SERVER_TLS` | Enable TLS (`1` or `true`) |
| `BEADS_DOLT_SERVER_USER` | MySQL connection user |
| `BEADS_DOLT_PASSWORD` | MySQL connection password |
| `DOLT_REMOTE_USER` | Push/pull auth user |
| `DOLT_REMOTE_PASSWORD` | Push/pull auth password |

## Previous PR

This is a rework of #1704 which was closed because v0.50.0 removed the storage factory layer. This PR targets the current v0.50.x codebase directly.