### PR TITLE
docs: add beads-compound to COMMUNITY_TOOLS.md

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -73,6 +73,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 ## Claude Code Orchestration
 
+- **[beads-compound](https://github.com/roberto-mello/beads-compound-plugin)** - Claude Code plugin marketplace with persistent memory and compound-engineering workflows. Hooks auto-capture knowledge from `bd comments add` at session end and inject relevant entries at session start based on open beads. Includes 28 specialized agents, 26 commands, and 15 skills for planning, review, research, and parallel work. Also supports OpenCode and Gemini CLI. Built by [@roberto-mello](https://github.com/roberto-mello). (Bash/TypeScript)
+
 - **[beads-orchestration](https://github.com/AvivK5498/Claude-Code-Beads-Orchestration)** - Multi-agent orchestration skill for Claude Code. Orchestrator investigates issues, manages beads tasks automatically, and delegates to tech-specific supervisors on isolated branches. Includes hooks for workflow enforcement, epic/subtask support, and optional external provider delegation (Codex/Gemini). Install via npm: `npm install -g @avivkaplan/beads-orchestration`. Built by [@AvivK5498](https://github.com/AvivK5498). (Node.js/Python)
 
 ## Historical / Stale


### PR DESCRIPTION
## What

Adds [beads-compound](https://github.com/roberto-mello/beads-compound-plugin) to the Claude Code Orchestration section of COMMUNITY_TOOLS.md.

## About the plugin

beads-compound is a Claude Code plugin that adds persistent memory and compound-engineering multi-agent workflows on top of beads. The core value prop is the knowledge loop:

- **SessionStart hook** — injects relevant knowledge entries at session start, based on your open/in-progress beads and git branch
- **PostToolUse hook** — captures knowledge from `bd comments add LEARNED/DECISION/FACT/PATTERN/INVESTIGATION` automatically
- **SubagentStop hook** — prompts subagents to log at least one knowledge entry before completing

On top of that it ships 28 specialized agents (review, research, design, workflow), 26 commands, and 15 skills that all use beads for task tracking.

Also supports OpenCode (native TypeScript plugin) and Gemini CLI (extension manifest).

**Install:**
```bash
git clone https://github.com/roberto-mello/beads-compound-plugin
./beads-compound-plugin/install.sh /path/to/your-project
```