### PR TITLE
fix: surface Dolt lock errors instead of silent empty results

### DIFF
--- a/internal/storage/dolt/lock_error_test.go
+++ b/internal/storage/dolt/lock_error_test.go
@@ -1,0 +1,66 @@
+package dolt
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestIsLockError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"generic", errors.New("some error"), false},
+		{"database is locked", errors.New("database is locked"), true},
+		{"lock file", errors.New("cannot open lock file"), true},
+		{"noms lock", errors.New("noms lock contention"), true},
+		{"locked by another", errors.New("locked by another dolt process"), true},
+		{"case insensitive", errors.New("DATABASE IS LOCKED"), true},
+		{"connection refused", errors.New("connection refused"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLockError(tt.err); got != tt.want {
+				t.Errorf("isLockError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapLockError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil passes through", func(t *testing.T) {
+		if err := wrapLockError(nil); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("non-lock error passes through", func(t *testing.T) {
+		orig := errors.New("some other error")
+		got := wrapLockError(orig)
+		if got != orig {
+			t.Fatalf("expected original error, got %v", got)
+		}
+	})
+
+	t.Run("lock error gets wrapped with guidance", func(t *testing.T) {
+		orig := errors.New("database is locked")
+		got := wrapLockError(orig)
+		if got == orig {
+			t.Fatal("expected wrapped error, got original")
+		}
+		if !strings.Contains(got.Error(), "bd doctor --fix") {
+			t.Fatalf("expected actionable guidance in error, got: %v", got)
+		}
+		if !errors.Is(got, orig) {
+			t.Fatal("wrapped error should unwrap to original")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

When a stale noms LOCK file exists in the Dolt database directory, queries can fail with lock-related errors that are hard to diagnose. This PR detects lock contention errors in the embedded Dolt query path and wraps them with actionable guidance pointing users to `bd doctor --fix`.

### Changes Made

- **Added `isLockError()` detection** — identifies Dolt lock contention errors by matching common error message patterns ("database is locked", "lock file", "noms lock", "locked by another dolt process")
- **Added `wrapLockError()` wrapping** — appends actionable guidance to lock errors, telling users to run `bd doctor --fix`
- **Wrapped `queryContext`, `execContext`, `queryRowContext`** — all three query wrappers now detect and annotate lock errors
- **Wrapped `PingContext` in `New()`** — lock errors during store initialization also get actionable guidance
- **Added unit tests** — `TestIsLockError` and `TestWrapLockError` cover detection and wrapping behavior

### Backward Compatibility

✅ **Maintained**: Non-lock errors pass through unchanged
✅ **Same behavior**: All existing error propagation paths preserved
✅ **Wrapped errors unwrap correctly**: `errors.Is()` still works on wrapped errors

### Technical Details

The fix targets the embedded mode query path where `withRetry` just calls `op()` directly (no retry for embedded mode). When the embedded Dolt engine encounters a stale noms LOCK file, it may return errors containing lock-related keywords. These are now intercepted and wrapped with:

```
The Dolt database is locked. This usually means a previous bd process
crashed without releasing its lock.
Run 'bd doctor --fix' to clean stale lock files.
```

Error propagation in `cmd/bd/list.go` and `cmd/bd/ready.go` was verified to already correctly print errors to stderr and exit non-zero — no changes needed there.

### Benefits

- **User experience**: Users get clear, actionable error messages instead of cryptic lock errors or silent empty results
- **Discoverability**: Points users directly to `bd doctor --fix` which already handles stale lock cleanup

### Size: Small ✓

~30 lines of lock detection logic + ~65 lines of tests.

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #1773