### PR TITLE
fix: add lock health diagnostics to bd doctor

### DIFF
--- a/cmd/bd/doctor/dolt_nocgo.go
+++ b/cmd/bd/doctor/dolt_nocgo.go
@@ -9,6 +9,7 @@ func RunDoltHealthChecks(path string) []DoctorCheck {
 		{Name: "Dolt Schema", Status: StatusOK, Message: "N/A (requires CGO for Dolt)", Category: CategoryCore},
 		{Name: "Dolt-JSONL Sync", Status: StatusOK, Message: "N/A (requires CGO for Dolt)", Category: CategoryData},
 		{Name: "Dolt Status", Status: StatusOK, Message: "N/A (requires CGO for Dolt)", Category: CategoryData},
+		{Name: "Dolt Lock Health", Status: StatusOK, Message: "N/A (requires CGO for Dolt)", Category: CategoryRuntime},
 	}
 }
 
@@ -49,5 +50,15 @@ func CheckDoltStatus(path string) DoctorCheck {
 		Status:   StatusOK,
 		Message:  "N/A (requires CGO for Dolt)",
 		Category: CategoryData,
+	}
+}
+
+// CheckLockHealth returns N/A when CGO is not available.
+func CheckLockHealth(path string) DoctorCheck {
+	return DoctorCheck{
+		Name:     "Dolt Lock Health",
+		Status:   StatusOK,
+		Message:  "N/A (requires CGO for Dolt)",
+		Category: CategoryRuntime,
 	}
 }


### PR DESCRIPTION
## Summary

Adds proactive lock health diagnostics to `bd doctor`, helping users identify and resolve Dolt lock contention issues after migration. Closes #1769.

### Changes Made

- **Added `CheckLockHealth()` to `cmd/bd/doctor/dolt.go`** — New diagnostic function that:
  - Scans for stale noms `LOCK` files under `.beads/dolt/<db>/.dolt/noms/`
  - Probes the advisory lock (`dolt-access.lock`) with a non-blocking exclusive flock to detect active holders
  - Returns `StatusWarning` with actionable guidance when issues are found
  - Returns `StatusOK` when no lock issues detected
- **Wired `CheckLockHealth` into `RunDoltHealthChecks()`** — Lock health check runs before DB open and is included in both success and error return paths
- **Updated error-path fix suggestion** — Changed from "Run 'bd daemon killall'" to "Run 'bd doctor --fix'" for consistency
- **Added nocgo stub** — `CheckLockHealth` returns N/A when CGO is not available, matching existing pattern
- **Updated `RunDoltHealthChecks` nocgo stub** — Includes lock health entry in the stub results
- **Fixed existing test assertions** — Updated 3 tests that checked exact check counts (`!= 1` → `< 1`) to accommodate the new lock health check
- **Added 4 new tests** — `TestCheckLockHealth_NoIssues`, `TestCheckLockHealth_DetectsNomsLOCK`, `TestCheckLockHealth_DetectsHeldAdvisoryLock`, `TestCheckLockHealth_NonDoltBackend`

### Backward Compatibility

✅ **Maintained**: All existing doctor checks unchanged in behavior
✅ **Same behavior**: `RunDoltHealthChecks` returns the same checks plus the new lock health check
✅ **nocgo safe**: Stub returns N/A status, no behavioral change for non-CGO builds

### Technical Details

`CheckLockHealth` uses `lockfile.FlockExclusiveNonBlocking` to probe the advisory lock without blocking:
- If the probe succeeds (lock acquired), the lock is immediately released — no active holder detected
- If the probe fails with `ErrLockBusy`, another process holds the lock — reported as warning
- Stale noms LOCK detection uses `filepath.Glob` to scan all database directories under `.beads/dolt/`

### Benefits

- **Faster diagnosis**: Users can run `bd doctor` to immediately see if lock contention is the problem
- **Actionable guidance**: Each warning includes specific steps to resolve the issue
- **Non-invasive**: Read-only probing with no side effects on running processes

### Size: Small ✓

Single-function addition with tests and nocgo stub.

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #1769