### PR TITLE
refactor: define Storage interface for testability

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -16,7 +16,6 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage"
-	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/utils"
 )
 
@@ -240,7 +239,7 @@ func findDatabaseInBeadsDir(beadsDir string, _ bool) string {
 }
 
 // Storage provides the minimal interface for extension orchestration
-type Storage = *dolt.DoltStore
+type Storage = storage.Storage
 
 // Transaction provides atomic multi-operation support within a database transaction.
 // Use Storage.RunInTransaction() to obtain a Transaction instance.

--- a/internal/gitlab/tracker.go
+++ b/internal/gitlab/tracker.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -26,14 +26,14 @@ var issueIIDPattern = regexp.MustCompile(`/issues/(\d+)`)
 type Tracker struct {
 	client *Client
 	config *MappingConfig
-	store  *dolt.DoltStore
+	store  storage.Storage
 }
 
 func (t *Tracker) Name() string         { return "gitlab" }
 func (t *Tracker) DisplayName() string  { return "GitLab" }
 func (t *Tracker) ConfigPrefix() string { return "gitlab" }
 
-func (t *Tracker) Init(ctx context.Context, store *dolt.DoltStore) error {
+func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 	t.store = store
 
 	token, err := t.getConfig(ctx, "gitlab.token", "GITLAB_TOKEN")

--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -20,7 +20,7 @@ func init() {
 // Tracker implements tracker.IssueTracker for Jira.
 type Tracker struct {
 	client     *Client
-	store      *dolt.DoltStore
+	store      storage.Storage
 	jiraURL    string
 	projectKey string
 }
@@ -29,7 +29,7 @@ func (t *Tracker) Name() string         { return "jira" }
 func (t *Tracker) DisplayName() string  { return "Jira" }
 func (t *Tracker) ConfigPrefix() string { return "jira" }
 
-func (t *Tracker) Init(ctx context.Context, store *dolt.DoltStore) error {
+func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 	t.store = store
 
 	jiraURL, err := t.getConfig(ctx, "jira.url", "JIRA_URL")

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -21,7 +21,7 @@ func init() {
 type Tracker struct {
 	client    *Client
 	config    *MappingConfig
-	store     *dolt.DoltStore
+	store     storage.Storage
 	teamID    string
 	projectID string
 }
@@ -30,7 +30,7 @@ func (t *Tracker) Name() string         { return "linear" }
 func (t *Tracker) DisplayName() string  { return "Linear" }
 func (t *Tracker) ConfigPrefix() string { return "linear" }
 
-func (t *Tracker) Init(ctx context.Context, store *dolt.DoltStore) error {
+func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 	t.store = store
 
 	apiKey, err := t.getConfig(ctx, "linear.api_key", "LINEAR_API_KEY")
@@ -250,10 +250,10 @@ func BuildStateCacheFromTracker(ctx context.Context, t *Tracker) (*StateCache, e
 	return BuildStateCache(ctx, t.client)
 }
 
-// configLoaderAdapter wraps *dolt.DoltStore to implement linear.ConfigLoader.
+// configLoaderAdapter wraps storage.Storage to implement linear.ConfigLoader.
 type configLoaderAdapter struct {
 	ctx   context.Context
-	store *dolt.DoltStore
+	store storage.Storage
 }
 
 func (c *configLoaderAdapter) GetAllConfig() (map[string]string, error) {

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -61,7 +61,7 @@ type PushHooks struct {
 // integrations follow, eliminating duplication between Linear, GitLab, etc.
 type Engine struct {
 	Tracker   IssueTracker
-	Store     *dolt.DoltStore
+	Store     storage.Storage
 	Actor     string
 	PullHooks *PullHooks
 	PushHooks *PushHooks
@@ -76,7 +76,7 @@ type Engine struct {
 }
 
 // NewEngine creates a new sync engine for the given tracker and storage.
-func NewEngine(tracker IssueTracker, store *dolt.DoltStore, actor string) *Engine {
+func NewEngine(tracker IssueTracker, store storage.Storage, actor string) *Engine {
 	return &Engine{
 		Tracker: tracker,
 		Store:   store,

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -52,7 +53,7 @@ func newMockTracker(name string) *mockTracker {
 func (m *mockTracker) Name() string                                    { return m.name }
 func (m *mockTracker) DisplayName() string                             { return m.name }
 func (m *mockTracker) ConfigPrefix() string                            { return m.name }
-func (m *mockTracker) Init(_ context.Context, _ *dolt.DoltStore) error { return nil }
+func (m *mockTracker) Init(_ context.Context, _ storage.Storage) error { return nil }
 func (m *mockTracker) Validate() error                                 { return nil }
 func (m *mockTracker) Close() error                                    { return nil }
 func (m *mockTracker) FieldMapper() FieldMapper                        { return m.fieldMapper }

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -3,7 +3,7 @@ package tracker
 import (
 	"context"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -22,7 +22,7 @@ type IssueTracker interface {
 
 	// Init initializes the tracker with configuration from the beads config store.
 	// Called once before any sync operations.
-	Init(ctx context.Context, store *dolt.DoltStore) error
+	Init(ctx context.Context, store storage.Storage) error
 
 	// Validate checks that the tracker is properly configured and can connect.
 	Validate() error

--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -36,7 +36,7 @@ func parseIssueID(input string, prefix string) string {
 // Returns an error if:
 // - No issue found matching the ID
 // - Multiple issues match (ambiguous prefix)
-func ResolvePartialID(ctx context.Context, store *dolt.DoltStore, input string) (string, error) {
+func ResolvePartialID(ctx context.Context, store storage.Storage, input string) (string, error) {
 	if store == nil {
 		return "", fmt.Errorf("cannot resolve issue ID %q: storage is nil", input)
 	}
@@ -149,7 +149,7 @@ func ResolvePartialID(ctx context.Context, store *dolt.DoltStore, input string) 
 
 // ResolvePartialIDs resolves multiple potentially partial issue IDs.
 // Returns the resolved IDs and any errors encountered.
-func ResolvePartialIDs(ctx context.Context, store *dolt.DoltStore, inputs []string) ([]string, error) {
+func ResolvePartialIDs(ctx context.Context, store storage.Storage, inputs []string) ([]string, error) {
 	var resolved []string
 	for _, input := range inputs {
 		fullID, err := ResolvePartialID(ctx, store, input)


### PR DESCRIPTION
## Summary

Extracts a `Storage` interface from the concrete `*dolt.DoltStore` type so that consumers depend on an interface rather than a concrete implementation. This enables mock/proxy substitution for testing and decouples packages from the Dolt storage layer.

### Changes Made

- **Added `Storage` interface** to `internal/storage/storage.go` with all 28 methods from `*dolt.DoltStore`
- **Updated `beads.go`** — `type Storage = storage.Storage` (was `*dolt.DoltStore`)
- **Updated `id_parser.go`** — accepts `storage.Storage` instead of `*dolt.DoltStore`
- **Updated tracker packages** — `tracker.go`, `engine.go`, `engine_test.go`, `linear/tracker.go`, `jira/tracker.go`, `gitlab/tracker.go` all accept the interface

### Backward Compatibility

✅ **Maintained**: All existing callers continue to work since `*dolt.DoltStore` satisfies `storage.Storage`
✅ **Same behavior**: No runtime behavior changes, purely a type-level refactor

### Benefits

- **Testability**: Consumers can now use mock implementations
- **Decoupling**: Packages no longer import `internal/storage/dolt` directly
- **Extensibility**: Alternative storage backends can be added without changing consumers

### Size: Small ✓

9 files changed, 74 insertions, 22 deletions.

🤖 Generated with [Claude Code](https://claude.ai/code)