### PR TITLE
fix: qualify Expand-Archive to avoid Pscx module conflict on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -176,7 +176,7 @@ function Install-FromRelease {
         Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath
 
         Write-Info "Extracting archive..."
-        Expand-Archive -Path $zipPath -DestinationPath $tempRoot -Force
+        Microsoft.PowerShell.Archive\Expand-Archive -Path $zipPath -DestinationPath $tempRoot -Force
 
         $bdPath = Join-Path $tempRoot "bd.exe"
         if (-not (Test-Path $bdPath)) {


### PR DESCRIPTION
## Problem

The `Expand-Archive` call in `Install-FromRelease` fails on systems with the PowerShell Community Extensions (Pscx) module installed:

```
Expand-Archive : A parameter cannot be found that matches parameter name 'DestinationPath'.
```

Pscx exports its own `Expand-Archive` cmdlet which shadows the built-in `Microsoft.PowerShell.Archive\Expand-Archive`. The Pscx version uses `-Destination` instead of `-DestinationPath`, causing the parameter binding to fail.

## Fix

Fully qualify the cmdlet call as `Microsoft.PowerShell.Archive\Expand-Archive` so the built-in version is always used regardless of imported modules.