### PR TITLE
feat(release): enable CGO_ENABLED=1 for all release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,27 @@ jobs:
       - name: Install cross-compilation toolchains and signing tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode
+          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode libicu-dev
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.13.0
+
+      - name: Create zig cross-compilation wrappers
+        run: |
+          mkdir -p /tmp/zigcc
+          for pair in \
+            "cc-x86_64-macos:x86_64-macos" \
+            "cc-aarch64-macos:aarch64-macos" \
+            "cc-aarch64-windows-gnu:aarch64-windows-gnu" \
+            "cc-aarch64-linux-android:aarch64-linux-android" \
+            "cc-x86_64-freebsd:x86_64-freebsd"; do
+            name="${pair%%:*}"
+            target="${pair##*:}"
+            printf '#!/bin/sh\nexec zig cc -target %s "$@"\n' "$target" > "/tmp/zigcc/$name"
+            chmod +x "/tmp/zigcc/$name"
+          done
 
       - name: Install go-winres for Windows PE resource embedding
         run: go install github.com/tc-hib/go-winres@latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,9 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=gcc
+      - CXX=g++
     goos:
       - linux
     goarch:
@@ -32,7 +34,10 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+    tags:
+      - gms_pure_go
     goos:
       - linux
     goarch:
@@ -48,7 +53,10 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=/tmp/zigcc/cc-aarch64-linux-android
+    tags:
+      - gms_pure_go
     goos:
       - android
     goarch:
@@ -64,7 +72,10 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=/tmp/zigcc/cc-x86_64-macos
+    tags:
+      - gms_pure_go
     goos:
       - darwin
     goarch:
@@ -80,7 +91,10 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=/tmp/zigcc/cc-aarch64-macos
+    tags:
+      - gms_pure_go
     goos:
       - darwin
     goarch:
@@ -96,7 +110,10 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+    tags:
+      - gms_pure_go
     goos:
       - windows
     goarch:
@@ -118,7 +135,10 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=/tmp/zigcc/cc-aarch64-windows-gnu
+    tags:
+      - gms_pure_go
     goos:
       - windows
     goarch:
@@ -140,7 +160,10 @@ builds:
     main: ./cmd/bd
     binary: bd
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=/tmp/zigcc/cc-x86_64-freebsd
+    tags:
+      - gms_pure_go
     goos:
       - freebsd
     goarch:


### PR DESCRIPTION
## Summary

- Enable `CGO_ENABLED=1` for all 8 goreleaser build targets so the Dolt storage backend works in released binaries
- Use **zig** as a cross-compiler for non-native targets (darwin, windows/arm64, android, freebsd)
- Add `gms_pure_go` build tag on cross-compiled targets to bypass ICU C++ dependency; native linux/amd64 retains full ICU regex performance

## Motivation

Every binary released via goreleaser is built with `CGO_ENABLED=0`. This means the `!cgo` stub files (`internal/storage/dolt/store_nocgo.go`, `cmd/bd/dolt_nocgo.go`, etc.) return `errNoCGO` for every Dolt operation — init, create, list, show, update, close, commit, push, pull, sync, federation — all of them. Users who install beads from a GitHub release get a binary that cannot use Dolt at all.

## Changes

### `.goreleaser.yml`
All 8 build targets changed from `CGO_ENABLED=0` to `CGO_ENABLED=1` with appropriate C compilers:

| Target | CC | Build Tags |
|---|---|---|
| linux/amd64 | `gcc` + `CXX=g++` | _(none — full ICU)_ |
| linux/arm64 | `aarch64-linux-gnu-gcc` | `gms_pure_go` |
| android/arm64 | zig wrapper | `gms_pure_go` |
| darwin/amd64 | zig wrapper | `gms_pure_go` |
| darwin/arm64 | zig wrapper | `gms_pure_go` |
| windows/amd64 | `x86_64-w64-mingw32-gcc` | `gms_pure_go` |
| windows/arm64 | zig wrapper | `gms_pure_go` |
| freebsd/amd64 | zig wrapper | `gms_pure_go` |

### `.github/workflows/release.yml`
- Added `libicu-dev` to apt-get install (for native linux/amd64 ICU support)
- Added **Install Zig** step (`mlugg/setup-zig@v2`, zig 0.13.0)
- Added **Create zig cross-compilation wrappers** step (5 shell scripts in `/tmp/zigcc/`)

## Test plan

- [ ] `goreleaser release --snapshot --clean` builds all 8 targets with CGO_ENABLED=1
- [ ] Native linux/amd64 binary can `bd init --backend dolt` without "built without CGO" error
- [ ] Cross-compiled binaries exist in `dist/` for all targets
- [ ] CI release workflow passes on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)