### PR TITLE
Fix: Respect BEADS_DIR when loading config.yaml

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,18 @@ func Initialize() error {
 	v.SetConfigType("yaml")
 
 	// Explicitly locate config.yaml and use SetConfigFile to avoid picking up config.json
-	// Precedence: project .beads/config.yaml > ~/.config/bd/config.yaml > ~/.beads/config.yaml
+	// Precedence: BEADS_DIR > project .beads/config.yaml > ~/.config/bd/config.yaml > ~/.beads/config.yaml
 	configFileSet := false
+
+	// 0. Check BEADS_DIR first (highest priority)
+	// This ensures bd commands with BEADS_DIR set find the correct config
+	if beadsDir := os.Getenv("BEADS_DIR"); beadsDir != "" && !configFileSet {
+		configPath := filepath.Join(beadsDir, "config.yaml")
+		if _, err := os.Stat(configPath); err == nil {
+			v.SetConfigFile(configPath)
+			configFileSet = true
+		}
+	}
 
 	// 1. Walk up from CWD to find project .beads/config.yaml
 	//    This allows commands to work from subdirectories


### PR DESCRIPTION
## Fix: Respect BEADS_DIR when loading config.yaml

### Summary

Makes `bd` commands respect the `BEADS_DIR` environment variable when loading `config.yaml`, fixing custom type validation failures.

### Problem

When `BEADS_DIR` is set to a non-default location (e.g., `rig/.beads`), commands like:
```bash
BEADS_DIR=rig/.beads bd update <id> --type=agent
```

Fail with:
```
Error: invalid issue type "agent". Valid types: bug, feature, task, epic, chore
```

This happens because `bd` looks for `config.yaml` by walking up from the current working directory, ignoring `BEADS_DIR`.

### Solution

Add `BEADS_DIR` as the highest priority config location in `internal/config/config.go`.

### Changes

- `internal/config/config.go`: Check `BEADS_DIR/config.yaml` before walking up from CWD

### Testing

- Verified config loading order with `BEADS_DIR` set
- Custom types are now recognized when using `BEADS_DIR`

### Notes

This is a **root cause fix** for a bug that was previously worked around in Gastown. With this fix, Gastown's defensive workaround can be removed.
