### PR TITLE
fix: treat molecule as core issue type

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -433,6 +433,7 @@ const (
 	TypeChore    IssueType = "chore"
 	TypeDecision IssueType = "decision"
 	TypeMessage  IssueType = "message"
+	TypeMolecule IssueType = "molecule" // Molecule type for swarm coordination (internal use)
 )
 
 // TypeEvent is a system-internal type used by set-state for audit trail beads.
@@ -448,11 +449,11 @@ const TypeEvent IssueType = "event"
 // (message was re-promoted to built-in for inter-agent communication — GH#1347.)
 
 // IsValid checks if the issue type is a core work type.
-// Only core work types (bug, feature, task, epic, chore, decision) are built-in.
-// Other types (molecule, gate, convoy, etc.) require types.custom configuration.
+// Core work types (bug, feature, task, epic, chore, decision, message) and molecule type are built-in.
+// Other types (gate, convoy, etc.) require types.custom configuration.
 func (t IssueType) IsValid() bool {
 	switch t {
-	case TypeBug, TypeFeature, TypeTask, TypeEpic, TypeChore, TypeDecision, TypeMessage:
+	case TypeBug, TypeFeature, TypeTask, TypeEpic, TypeChore, TypeDecision, TypeMessage, TypeMolecule:
 		return true
 	}
 	return false

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -473,9 +473,10 @@ func TestIssueTypeIsValid(t *testing.T) {
 		{TypeChore, true},
 		{TypeDecision, true},
 		{TypeMessage, true},
+		// Molecule is now a core type (used by swarm create)
+		{IssueType("molecule"), true},
 		// Gas Town types are now custom types (not built-in)
 		{IssueType("merge-request"), false},
-		{IssueType("molecule"), false},
 		{IssueType("gate"), false},
 		{IssueType("agent"), false},
 		{IssueType("role"), false},
@@ -536,10 +537,11 @@ func TestEventTypeValidation(t *testing.T) {
 		t.Error("TypeEvent.IsValidWithCustom(custom list) = false, want true")
 	}
 
-	// custom types must NOT be treated as built-in
-	if IssueType("molecule").IsBuiltIn() {
-		t.Error("IssueType(molecule).IsBuiltIn() = true, want false")
+	// molecule is now a built-in type (used by swarm create)
+	if !IssueType("molecule").IsBuiltIn() {
+		t.Error("IssueType(molecule).IsBuiltIn() = false, want true")
 	}
+	// custom types must NOT be treated as built-in
 	if IssueType("gate").IsBuiltIn() {
 		t.Error("IssueType(gate).IsBuiltIn() = true, want false")
 	}

--- a/internal/validation/bead_test.go
+++ b/internal/validation/bead_test.go
@@ -217,9 +217,10 @@ func TestParseIssueType(t *testing.T) {
 		{"task type", "task", types.TypeTask, false, ""},
 		{"epic type", "epic", types.TypeEpic, false, ""},
 		{"chore type", "chore", types.TypeChore, false, ""},
+		// Molecule is now a core type (used by swarm create)
+		{"molecule type", "molecule", types.TypeMolecule, false, ""},
 		// Gas Town types require types.custom configuration (invalid without config)
 		{"merge-request type", "merge-request", types.TypeTask, true, "invalid issue type"},
-		{"molecule type", "molecule", types.TypeTask, true, "invalid issue type"},
 		{"gate type", "gate", types.TypeTask, true, "invalid issue type"},
 		{"event type", "event", types.TypeTask, true, "invalid issue type"},
 		{"message type", "message", types.TypeMessage, false, ""},


### PR DESCRIPTION
I was running into this issue trying to create some swarmies, saw an issue #1402  existed, decided to send a PR. 
Thanks for the great work everyone. Loving this project.  
## Summary
Fixes `bd swarm create` failing with **invalid issue type: molecule** by making `molecule` a core type.

## Issue
Closes #1402 (or at least addresses root cause described there).

## Changes
- Add `TypeMolecule` as core type
- Update validation and tests

## Tests
- `go test ./internal/types/... ./internal/validation/... ./cmd/bd/... -short`
  - **Note:** `cmd/bd` suite has existing failures unrelated to this change (hooks / artifacts).