### PR TITLE
fix(doctor): add bd.sock.startlock to gitignore template

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -15,6 +15,7 @@ dolt-access.lock
 
 # Runtime files
 bd.sock
+bd.sock.startlock
 sync-state.json
 last-touched
 
@@ -69,6 +70,7 @@ var requiredPatterns = []string{
 	"*.db?*",
 	"redirect",
 	"last-touched",
+	"bd.sock.startlock",
 	".sync.lock",
 	".jsonl.lock",
 	"sync_base.jsonl",


### PR DESCRIPTION
## Summary

Fixes #1878 — `bd.sock.startlock` occasionally appears in git status.

Adds `bd.sock.startlock` to:
- `GitignoreTemplate` (the canonical `.beads/.gitignore` content)
- `requiredPatterns` (so `bd doctor` detects outdated gitignore files)

Also mentioned in #1352.

## Changed files

- `cmd/bd/doctor/gitignore.go`

## Test plan

- [ ] `bd init` creates `.beads/.gitignore` containing `bd.sock.startlock`
- [ ] `bd doctor` reports "ok" for gitignore after the update
- [ ] `bd doctor --fix` adds the pattern to existing gitignore files
- [ ] `bd.sock.startlock` no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)