### PR TITLE
fix: remove stale --no-db flag references from help and errors

### DIFF
--- a/cmd/bd/defer.go
+++ b/cmd/bd/defer.go
@@ -58,7 +58,7 @@ Examples:
 		// Direct storage access
 		if store == nil {
 			FatalErrorWithHint("database not initialized",
-				"run 'bd init' to create a database, or use 'bd --no-db' for JSONL-only mode")
+				"run 'bd init' to create a database")
 		}
 
 		for _, id := range args {

--- a/cmd/bd/lint.go
+++ b/cmd/bd/lint.go
@@ -53,7 +53,7 @@ Examples:
 
 		if store == nil {
 			FatalErrorWithHint("database not initialized",
-				"run 'bd init' to create a database, or use 'bd --no-db' for JSONL-only mode")
+				"run 'bd init' to create a database")
 		}
 
 		if len(args) > 0 {

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -454,15 +454,13 @@ var rootCmd = &cobra.Command{
 							fmt.Fprintf(os.Stderr, "This looks like a fresh clone or JSONL-only project.\n\n")
 							fmt.Fprintf(os.Stderr, "Options:\n")
 							fmt.Fprintf(os.Stderr, "  • Run 'bd init' to create database and import issues\n")
-							fmt.Fprintf(os.Stderr, "  • Use 'bd --no-db %s' for JSONL-only mode\n", cmd.Name())
-							fmt.Fprintf(os.Stderr, "  • Add 'no-db: true' to .beads/config.yaml for permanent JSONL-only mode\n")
+							fmt.Fprintf(os.Stderr, "  • Add 'no-db: true' to .beads/config.yaml for JSONL-only mode\n")
 							os.Exit(1)
 						}
 					}
 
 					// Generic error - no beads directory or JSONL found
 					fmt.Fprintf(os.Stderr, "Hint: run 'bd init' to create a database in the current directory\n")
-					fmt.Fprintf(os.Stderr, "      or use 'bd --no-db' to work with JSONL only (no database)\n")
 					fmt.Fprintf(os.Stderr, "      or set BEADS_DIR to point to your .beads directory\n")
 					os.Exit(1)
 				}

--- a/cmd/bd/markdown.go
+++ b/cmd/bd/markdown.go
@@ -319,7 +319,7 @@ func createIssuesFromMarkdown(_ *cobra.Command, filepath string) {
 	// Ensure globals are initialized
 	if store == nil {
 		FatalErrorWithHint("database not initialized",
-			"run 'bd init' to create a database, or use 'bd --no-db' for JSONL-only mode")
+			"run 'bd init' to create a database")
 	}
 	if actor == "" {
 		actor = "bd" // Default actor if not set

--- a/cmd/bd/promote.go
+++ b/cmd/bd/promote.go
@@ -41,7 +41,7 @@ Examples:
 		// Direct mode
 		if store == nil {
 			FatalErrorWithHint("database not initialized",
-				"run 'bd init' to create a database, or use 'bd --no-db' for JSONL-only mode")
+				"run 'bd init' to create a database")
 		}
 
 		fullID, err := utils.ResolvePartialID(ctx, store, id)

--- a/cmd/bd/reopen.go
+++ b/cmd/bd/reopen.go
@@ -32,7 +32,7 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 		// Direct storage access
 		if store == nil {
 			FatalErrorWithHint("database not initialized",
-				"run 'bd init' to create a database, or use 'bd --no-db' for JSONL-only mode")
+				"run 'bd init' to create a database")
 		}
 		for _, id := range args {
 			fullID, err := utils.ResolvePartialID(ctx, store, id)

--- a/cmd/bd/sql.go
+++ b/cmd/bd/sql.go
@@ -34,7 +34,7 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 		csvOutput, _ := cmd.Flags().GetBool("csv")
 
 		if store == nil {
-			FatalErrorRespectJSON("no database connection available (try without --no-db)")
+			FatalErrorRespectJSON("no database connection available (run 'bd init' first)")
 		}
 
 		db := store.UnderlyingDB()

--- a/cmd/bd/undefer.go
+++ b/cmd/bd/undefer.go
@@ -39,7 +39,7 @@ Examples:
 		// Direct storage access
 		if store == nil {
 			FatalErrorWithHint("database not initialized",
-				"run 'bd init' to create a database, or use 'bd --no-db' for JSONL-only mode")
+				"run 'bd init' to create a database")
 		}
 
 		for _, id := range args {


### PR DESCRIPTION
## Summary

- The `--no-db` CLI flag was removed when beads switched to Dolt-only backend, but user-facing messages still referenced it
- `bd init -h` showed "With --no-db: creates .beads/ directory and issues.jsonl file instead of database" but `bd init --no-db` returns "unknown flag"
- Error messages in 6 commands (defer, lint, markdown, promote, reopen, undefer) suggested `bd --no-db` as a workaround
- Generic "no database found" error also suggested the removed flag
- Dead code block in `init.go` handled the removed `--no-db` initialization path

**Note**: The `no-db: true` config key in `.beads/config.yaml` is still valid (used by the CGO fallback path). Only CLI flag references are removed.

### Files changed (9)

| File | Change |
|------|--------|
| `init.go` | Remove `--no-db` from help text, remove dead `noDb` code block |
| `main.go` | Remove `--no-db` from error message suggestions |
| `defer.go` | Remove `--no-db` from hint |
| `lint.go` | Remove `--no-db` from hint |
| `markdown.go` | Remove `--no-db` from hint |
| `promote.go` | Remove `--no-db` from hint |
| `reopen.go` | Remove `--no-db` from hint |
| `undefer.go` | Remove `--no-db` from hint |
| `sql.go` | Replace `--no-db` hint with "run 'bd init' first" |

## Test plan

- [ ] `bd init -h` no longer mentions `--no-db`
- [ ] Error messages no longer suggest `--no-db` as a workaround
- [ ] CGO fallback in `bd init` still works (creates JSONL-only when Dolt fails)

Fixes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)