### PR TITLE
fix: remove stale daemon references from user-facing messages

### DIFF
--- a/cmd/bd/hook.go
+++ b/cmd/bd/hook.go
@@ -689,18 +689,14 @@ func hookPostCheckout(args []string) int {
 		return 0
 	}
 
-	// Detect git worktree and show warning
+	// Detect git worktree and show notice
 	if isGitWorktree() {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════════════╗")
 		fmt.Fprintln(os.Stderr, "║ Welcome to beads in git worktree!                                        ║")
 		fmt.Fprintln(os.Stderr, "╠══════════════════════════════════════════════════════════════════════════╣")
-		fmt.Fprintln(os.Stderr, "║ Note: Daemon mode is not recommended with git worktrees.                 ║")
-		fmt.Fprintln(os.Stderr, "║ Worktrees share the same database, and the daemon may commit changes     ║")
-		fmt.Fprintln(os.Stderr, "║ to the wrong branch.                                                     ║")
-		fmt.Fprintln(os.Stderr, "║                                                                          ║")
-		fmt.Fprintln(os.Stderr, "║ RECOMMENDED: Disable daemon for this session:                            ║")
-		fmt.Fprintln(os.Stderr, "║   export BEADS_NO_DAEMON=1                                               ║")
+		fmt.Fprintln(os.Stderr, "║ Note: Worktrees share the same database. Auto-commit changes may         ║")
+		fmt.Fprintln(os.Stderr, "║ go to the wrong branch. Run 'bd doctor' for recommendations.             ║")
 		fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════════════╝")
 		fmt.Fprintln(os.Stderr, "")
 	}

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -798,22 +798,18 @@ func runPostCheckoutHook(args []string) int {
 		return 0
 	}
 
-	// Detect git worktree and show warning
+	// Detect git worktree and show notice
 	if isGitWorktree() {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════════════╗")
 		fmt.Fprintln(os.Stderr, "║ Welcome to beads in git worktree!                                        ║")
 		fmt.Fprintln(os.Stderr, "╠══════════════════════════════════════════════════════════════════════════╣")
-		fmt.Fprintln(os.Stderr, "║ Note: Daemon mode is not recommended with git worktrees.                 ║")
-		fmt.Fprintln(os.Stderr, "║ Worktrees share the same database, and the daemon may commit changes     ║")
-		fmt.Fprintln(os.Stderr, "║ to the wrong branch.                                                     ║")
-		fmt.Fprintln(os.Stderr, "║                                                                          ║")
-		fmt.Fprintln(os.Stderr, "║ RECOMMENDED: Disable daemon for this session:                            ║")
-		fmt.Fprintln(os.Stderr, "║   export BEADS_NO_DAEMON=1                                               ║")
+		fmt.Fprintln(os.Stderr, "║ Note: Worktrees share the same database. Auto-commit changes may         ║")
+		fmt.Fprintln(os.Stderr, "║ go to the wrong branch. Run 'bd doctor' for recommendations.             ║")
 		fmt.Fprintln(os.Stderr, "║                                                                          ║")
 		fmt.Fprintln(os.Stderr, "║ For more information:                                                    ║")
 		fmt.Fprintln(os.Stderr, "║   - Run: bd doctor                                                       ║")
-		fmt.Fprintln(os.Stderr, "║   - Read: docs/GIT_INTEGRATION.md (lines 10-53)                          ║")
+		fmt.Fprintln(os.Stderr, "║   - Read: docs/GIT_INTEGRATION.md                                        ║")
 		fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════════════╝")
 		fmt.Fprintln(os.Stderr, "")
 	}

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -746,11 +746,8 @@ func handleToSeparateBranch(branch string, dryRun bool) {
 		fmt.Printf("%s\n\n", ui.RenderPass("✓ Enabled separate branch workflow"))
 		fmt.Printf("Set sync.branch to '%s'\n\n", b)
 		fmt.Println("Next steps:")
-		fmt.Println("  1. Restart the daemon to create worktree and start committing to the branch:")
-		fmt.Printf("     bd daemon restart\n")
-		fmt.Printf("     bd daemon start --auto-commit\n\n")
-		fmt.Println("  2. Your existing data is preserved - no changes to git history")
-		fmt.Println("  3. Future issue updates will be committed to the separate branch")
+		fmt.Println("  1. Your existing data is preserved - no changes to git history")
+		fmt.Println("  2. Future issue updates will be committed to the separate branch")
 		fmt.Println("\nSee docs/PROTECTED_BRANCHES.md for complete workflow guide")
 	}
 }


### PR DESCRIPTION
## Summary

The daemon was removed in v0.50.0, but several user-facing messages still referenced daemon commands:

- **hook.go** and **hooks.go**: Worktree warnings recommended `export BEADS_NO_DAEMON=1` and mentioned "daemon mode"
- **migrate.go**: Separate branch setup instructions told users to run `bd daemon restart` and `bd daemon start --auto-commit`

### Changes

- Replace daemon-specific worktree warnings with simpler notices that point to `bd doctor`
- Remove stale daemon restart/start instructions from migration output
- **Preserved**: Changelog entries (historical records) and gitignore patterns (`daemon.log`, `daemon.lock`) for backwards compatibility

## Test plan

- [ ] `bd hook post-checkout` in a worktree no longer mentions daemon
- [ ] `bd migrate --to-separate-branch` no longer shows daemon commands
- [ ] Gitignore still includes legacy daemon file patterns

Fixes #1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)