### PR TITLE
feat: make metadata queryable from list, search, and query DSL

### DIFF
--- a/cmd/bd/metadata_filter_test.go
+++ b/cmd/bd/metadata_filter_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestSearchIssues_MetadataFieldMatch(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	store := newTestStore(t, tmpDir)
+	ctx := context.Background()
+
+	issue1 := &types.Issue{
+		Title:     "Platform issue",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Metadata:  json.RawMessage(`{"team":"platform","sprint":"Q1"}`),
+	}
+	issue2 := &types.Issue{
+		Title:     "Frontend issue",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Metadata:  json.RawMessage(`{"team":"frontend","sprint":"Q1"}`),
+	}
+	if err := store.CreateIssue(ctx, issue1, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if err := store.CreateIssue(ctx, issue2, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	// Search for team=platform → should find only issue1
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		MetadataFields: map[string]string{"team": "platform"},
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != issue1.ID {
+		t.Errorf("expected issue %s, got %s", issue1.ID, results[0].ID)
+	}
+}
+
+func TestSearchIssues_MetadataFieldNoMatch(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	store := newTestStore(t, tmpDir)
+	ctx := context.Background()
+
+	issue := &types.Issue{
+		Title:     "Platform issue",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Metadata:  json.RawMessage(`{"team":"platform"}`),
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		MetadataFields: map[string]string{"team": "backend"},
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestSearchIssues_HasMetadataKey(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	store := newTestStore(t, tmpDir)
+	ctx := context.Background()
+
+	issue1 := &types.Issue{
+		Title:     "Has team key",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Metadata:  json.RawMessage(`{"team":"platform"}`),
+	}
+	issue2 := &types.Issue{
+		Title:     "No metadata",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+	}
+	if err := store.CreateIssue(ctx, issue1, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if err := store.CreateIssue(ctx, issue2, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		HasMetadataKey: "team",
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != issue1.ID {
+		t.Errorf("expected issue %s, got %s", issue1.ID, results[0].ID)
+	}
+}
+
+func TestSearchIssues_MultipleMetadataFieldsANDed(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	store := newTestStore(t, tmpDir)
+	ctx := context.Background()
+
+	issue1 := &types.Issue{
+		Title:     "Both match",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Metadata:  json.RawMessage(`{"team":"platform","sprint":"Q1"}`),
+	}
+	issue2 := &types.Issue{
+		Title:     "Partial match",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Metadata:  json.RawMessage(`{"team":"platform","sprint":"Q2"}`),
+	}
+	if err := store.CreateIssue(ctx, issue1, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if err := store.CreateIssue(ctx, issue2, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		MetadataFields: map[string]string{
+			"team":   "platform",
+			"sprint": "Q1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != issue1.ID {
+		t.Errorf("expected issue %s, got %s", issue1.ID, results[0].ID)
+	}
+}
+
+func TestSearchIssues_MetadataFieldInvalidKey(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	store := newTestStore(t, tmpDir)
+	ctx := context.Background()
+
+	_, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		MetadataFields: map[string]string{"'; DROP TABLE issues; --": "val"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid metadata key, got nil")
+	}
+}
+
+func TestSearchIssues_HasMetadataKeyInvalidKey(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	store := newTestStore(t, tmpDir)
+	ctx := context.Background()
+
+	_, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		HasMetadataKey: "bad key!",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid metadata key, got nil")
+	}
+}
+
+func TestSearchIssues_NoMetadataDoesNotMatch(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	store := newTestStore(t, tmpDir)
+	ctx := context.Background()
+
+	issue := &types.Issue{
+		Title:     "No metadata",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		MetadataFields: map[string]string{"team": "platform"},
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for issue without metadata, got %d", len(results))
+	}
+}
+
+// Key validation unit tests (don't need a store)
+
+func TestValidateMetadataKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		key     string
+		wantErr bool
+	}{
+		{"team", false},
+		{"story_points", false},
+		{"jira.sprint", false},
+		{"_private", false},
+		{"CamelCase", false},
+		{"a1b2c3", false},
+		{"", true},
+		{"bad key", true},
+		{"bad-key", true},       // hyphens not allowed
+		{"123start", true},      // must start with letter/underscore
+		{"key=value", true},     // equals not allowed
+		{"'; DROP TABLE", true}, // SQL injection
+		{"$.path", true},        // JSON path chars not allowed
+		{"key\nvalue", true},    // newlines not allowed
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			err := storage.ValidateMetadataKey(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateMetadataKey(%q) error = %v, wantErr %v", tt.key, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/utils"
 	"github.com/steveyegge/beads/internal/validation"
@@ -190,6 +191,32 @@ Examples:
 			filter.PriorityMax = &priorityMax
 		}
 
+		// Metadata filters (GH#1406)
+		metadataFieldFlags, _ := cmd.Flags().GetStringArray("metadata-field")
+		if len(metadataFieldFlags) > 0 {
+			filter.MetadataFields = make(map[string]string, len(metadataFieldFlags))
+			for _, mf := range metadataFieldFlags {
+				k, v, ok := strings.Cut(mf, "=")
+				if !ok || k == "" {
+					fmt.Fprintf(os.Stderr, "Error: invalid --metadata-field: expected key=value, got %q\n", mf)
+					os.Exit(1)
+				}
+				if err := storage.ValidateMetadataKey(k); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: invalid --metadata-field key: %v\n", err)
+					os.Exit(1)
+				}
+				filter.MetadataFields[k] = v
+			}
+		}
+		hasMetadataKey, _ := cmd.Flags().GetString("has-metadata-key")
+		if hasMetadataKey != "" {
+			if err := storage.ValidateMetadataKey(hasMetadataKey); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: invalid --has-metadata-key: %v\n", err)
+				os.Exit(1)
+			}
+			filter.HasMetadataKey = hasMetadataKey
+		}
+
 		ctx := rootCtx
 
 		// Direct mode - search using store
@@ -333,6 +360,10 @@ func init() {
 	searchCmd.Flags().Bool("empty-description", false, "Filter issues with empty or missing description")
 	searchCmd.Flags().Bool("no-assignee", false, "Filter issues with no assignee")
 	searchCmd.Flags().Bool("no-labels", false, "Filter issues with no labels")
+
+	// Metadata filtering (GH#1406)
+	searchCmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")
+	searchCmd.Flags().String("has-metadata-key", "", "Filter issues that have this metadata key set")
 
 	rootCmd.AddCommand(searchCmd)
 }

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -260,6 +261,32 @@ func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types
 	if filter.DueBefore != nil {
 		whereClauses = append(whereClauses, "due_at < ?")
 		args = append(args, filter.DueBefore.Format(time.RFC3339))
+	}
+
+	// Metadata existence check (GH#1406)
+	if filter.HasMetadataKey != "" {
+		if err := storage.ValidateMetadataKey(filter.HasMetadataKey); err != nil {
+			return nil, err
+		}
+		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
+		args = append(args, "$."+filter.HasMetadataKey)
+	}
+
+	// Metadata field equality filters (GH#1406)
+	// Sort keys for deterministic query generation (important for testing)
+	if len(filter.MetadataFields) > 0 {
+		metaKeys := make([]string, 0, len(filter.MetadataFields))
+		for k := range filter.MetadataFields {
+			metaKeys = append(metaKeys, k)
+		}
+		sort.Strings(metaKeys)
+		for _, k := range metaKeys {
+			if err := storage.ValidateMetadataKey(k); err != nil {
+				return nil, err
+			}
+			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
+			args = append(args, "$."+k, filter.MetadataFields[k])
+		}
 	}
 
 	whereSQL := ""

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -4,6 +4,7 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 )
 
 // NormalizeMetadataValue converts metadata values to a validated JSON string.
@@ -31,4 +32,18 @@ func NormalizeMetadataValue(value interface{}) (string, error) {
 	}
 
 	return jsonStr, nil
+}
+
+// validMetadataKeyRe validates metadata key names for use in JSON path expressions.
+// Allows alphanumeric, underscore, and dot (for nested paths like "jira.sprint").
+var validMetadataKeyRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.]*$`)
+
+// ValidateMetadataKey checks that a metadata key is safe for use in JSON path
+// expressions. Keys must start with a letter or underscore and contain only
+// alphanumeric characters, underscores, and dots.
+func ValidateMetadataKey(key string) error {
+	if !validMetadataKeyRe.MatchString(key) {
+		return fmt.Errorf("invalid metadata key %q: must match [a-zA-Z_][a-zA-Z0-9_.]*", key)
+	}
+	return nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -959,6 +959,10 @@ type IssueFilter struct {
 	DueAfter    *time.Time // Filter issues with due_at > this time
 	DueBefore   *time.Time // Filter issues with due_at < this time
 	Overdue     bool       // Filter issues where due_at < now AND status != closed
+
+	// Metadata field filtering (GH#1406)
+	MetadataFields map[string]string // Top-level key=value equality; AND semantics (all must match)
+	HasMetadataKey string            // Existence check: issue has this top-level key set (non-null)
 }
 
 // SortPolicy determines how ready work is ordered


### PR DESCRIPTION
## Summary

- Add SQL-level metadata filtering to `bd list` and `bd search` using Dolt's `JSON_EXTRACT`/`JSON_UNQUOTE` with parameterized queries
- New CLI flags: `--metadata-field key=value` (repeatable, AND semantics) and `--has-metadata-key key` (existence check)
- Add `metadata.<key> = "<value>"` support to `bd query` DSL (both filter and predicate modes)
- Strict key validation (`ValidateMetadataKey`) prevents JSON path injection

## Details

Implements the queryability layer for the metadata system (GH#1406). This builds on the existing `types.Issue.Metadata` JSON column and the visibility work in #1905.

**Files changed (8):**
- `internal/types/types.go` — Add `MetadataFields` and `HasMetadataKey` to `IssueFilter`
- `internal/storage/metadata.go` — Add `ValidateMetadataKey()` with strict regex
- `internal/storage/dolt/queries.go` — Generate WHERE clauses using `JSON_EXTRACT`/`JSON_UNQUOTE` with `?` params
- `cmd/bd/list.go` — Add `--metadata-field` and `--has-metadata-key` flags
- `cmd/bd/search.go` — Add same flags
- `internal/query/evaluator.go` — Add `metadata.` prefix handling in filter and predicate modes
- `cmd/bd/metadata_filter_test.go` — 7 Dolt integration tests + 14 key validation unit tests
- `internal/query/query_test.go` — 5 evaluator metadata tests + predicate evaluation tests

## Test plan

- [x] `TestSearchIssues_MetadataFieldMatch` — single key=value filter returns matching issue
- [x] `TestSearchIssues_MetadataFieldNoMatch` — non-matching value returns empty
- [x] `TestSearchIssues_HasMetadataKey` — existence check filters correctly
- [x] `TestSearchIssues_MultipleMetadataFieldsANDed` — multiple fields use AND semantics
- [x] `TestSearchIssues_MetadataFieldInvalidKey` — SQL injection attempt rejected
- [x] `TestSearchIssues_HasMetadataKeyInvalidKey` — invalid key rejected
- [x] `TestSearchIssues_NoMetadataDoesNotMatch` — issues without metadata don't match
- [x] `TestValidateMetadataKey` — 14 cases (valid keys, empty, spaces, hyphens, digits-first, SQL injection, JSON path chars, newlines)
- [x] `TestEvaluatorMetadataQueries` — 5 DSL query cases including AND
- [x] `TestMetadataPredicateEvaluation` — predicate mode with JSON parsing
- [x] Full build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)