### PR TITLE
fix: wrap AddDependency/RemoveDependency in explicit transactions

### DIFF
--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -10,18 +10,24 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// AddDependency adds a dependency between two issues
+// AddDependency adds a dependency between two issues.
+// Uses an explicit transaction so writes persist when @@autocommit is OFF
+// (e.g. Dolt server started with --no-auto-commit).
 func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
 	metadata := dep.Metadata
 	if metadata == "" {
 		metadata = "{}"
 	}
 
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	// Validate that the source issue exists
 	var issueExists int
-	if err := s.queryRowContext(ctx, func(row *sql.Row) error {
-		return row.Scan(&issueExists)
-	}, `SELECT COUNT(*) FROM issues WHERE id = ?`, dep.IssueID); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM issues WHERE id = ?`, dep.IssueID).Scan(&issueExists); err != nil {
 		return fmt.Errorf("failed to check issue existence: %w", err)
 	}
 	if issueExists == 0 {
@@ -31,9 +37,7 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 	// Validate that the target issue exists (skip for external cross-rig references)
 	if !strings.HasPrefix(dep.DependsOnID, "external:") {
 		var targetExists int
-		if err := s.queryRowContext(ctx, func(row *sql.Row) error {
-			return row.Scan(&targetExists)
-		}, `SELECT COUNT(*) FROM issues WHERE id = ?`, dep.DependsOnID); err != nil {
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM issues WHERE id = ?`, dep.DependsOnID).Scan(&targetExists); err != nil {
 			return fmt.Errorf("failed to check target issue existence: %w", err)
 		}
 		if targetExists == 0 {
@@ -45,9 +49,7 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 	// would create a cycle by seeing if depends_on_id can already reach issue_id.
 	if dep.Type == types.DepBlocks {
 		var reachable int
-		err := s.queryRowContext(ctx, func(row *sql.Row) error {
-			return row.Scan(&reachable)
-		}, `
+		if err := tx.QueryRowContext(ctx, `
 			WITH RECURSIVE reachable AS (
 				SELECT ? AS node, 0 AS depth
 				UNION ALL
@@ -58,8 +60,7 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 				  AND r.depth < 100
 			)
 			SELECT COUNT(*) FROM reachable WHERE node = ?
-		`, dep.DependsOnID, dep.IssueID)
-		if err != nil {
+		`, dep.DependsOnID, dep.IssueID).Scan(&reachable); err != nil {
 			return fmt.Errorf("failed to check for dependency cycle: %w", err)
 		}
 		if reachable > 0 {
@@ -67,26 +68,33 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		}
 	}
 
-	_, err := s.execContext(ctx, `
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id)
 		VALUES (?, ?, ?, NOW(), ?, ?, ?)
 		ON DUPLICATE KEY UPDATE type = VALUES(type), metadata = VALUES(metadata)
-	`, dep.IssueID, dep.DependsOnID, dep.Type, actor, metadata, dep.ThreadID)
-	if err != nil {
+	`, dep.IssueID, dep.DependsOnID, dep.Type, actor, metadata, dep.ThreadID); err != nil {
 		return fmt.Errorf("failed to add dependency: %w", err)
 	}
-	return nil
+
+	return tx.Commit()
 }
 
-// RemoveDependency removes a dependency between two issues
+// RemoveDependency removes a dependency between two issues.
+// Uses an explicit transaction so writes persist when @@autocommit is OFF.
 func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
-	_, err := s.execContext(ctx, `
-		DELETE FROM dependencies WHERE issue_id = ? AND depends_on_id = ?
-	`, issueID, dependsOnID)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM dependencies WHERE issue_id = ? AND depends_on_id = ?
+	`, issueID, dependsOnID); err != nil {
 		return fmt.Errorf("failed to remove dependency: %w", err)
 	}
-	return nil
+
+	return tx.Commit()
 }
 
 // GetDependencies retrieves issues that this issue depends on

--- a/internal/storage/dolt/server_dependency_test.go
+++ b/internal/storage/dolt/server_dependency_test.go
@@ -1,0 +1,234 @@
+//go:build cgo
+
+package dolt
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestServerMode_AddDependencyPersistsAcrossConnections verifies that AddDependency
+// commits data that survives connection close when the server uses --no-auto-commit
+// (@@autocommit = 0).
+func TestServerMode_AddDependencyPersistsAcrossConnections(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping server mode test")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dolt-dep-persist-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cmd := exec.Command("dolt", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to init dolt repo: %v", err)
+	}
+
+	// Start server (passes --no-auto-commit, setting @@autocommit = 0)
+	server := NewServer(ServerConfig{
+		DataDir:        tmpDir,
+		SQLPort:        13311,
+		RemotesAPIPort: 18085,
+		Host:           "127.0.0.1",
+		LogFile:        filepath.Join(tmpDir, "server.log"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer func() {
+		if err := server.Stop(); err != nil {
+			t.Logf("warning: failed to stop server: %v", err)
+		}
+	}()
+
+	storeCfg := &Config{
+		Path:       tmpDir,
+		Database:   "beads",
+		ServerMode: true,
+		ServerHost: "127.0.0.1",
+		ServerPort: 13311,
+	}
+
+	// --- Connection 1: create issues and add dependency ---
+	store1, err := New(ctx, storeCfg)
+	if err != nil {
+		t.Fatalf("failed to create store (conn 1): %v", err)
+	}
+
+	if err := store1.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	issueA := &types.Issue{
+		Title:     "Blocker issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store1.CreateIssue(ctx, issueA, "test"); err != nil {
+		t.Fatalf("failed to create issue A: %v", err)
+	}
+
+	issueB := &types.Issue{
+		Title:     "Blocked issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store1.CreateIssue(ctx, issueB, "test"); err != nil {
+		t.Fatalf("failed to create issue B: %v", err)
+	}
+
+	dep := &types.Dependency{
+		IssueID:     issueB.ID,
+		DependsOnID: issueA.ID,
+		Type:        types.DepBlocks,
+	}
+	if err := store1.AddDependency(ctx, dep, "test"); err != nil {
+		t.Fatalf("AddDependency failed: %v", err)
+	}
+
+	// Close the first connection entirely
+	store1.Close()
+
+	// --- Connection 2: verify dependency persisted ---
+	store2, err := New(ctx, storeCfg)
+	if err != nil {
+		t.Fatalf("failed to create store (conn 2): %v", err)
+	}
+	defer store2.Close()
+
+	deps, err := store2.GetDependencies(ctx, issueB.ID)
+	if err != nil {
+		t.Fatalf("GetDependencies failed on new connection: %v", err)
+	}
+
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency after reconnect, got %d (dependency was lost)", len(deps))
+	}
+	if deps[0].ID != issueA.ID {
+		t.Errorf("expected dependency on %s, got %s", issueA.ID, deps[0].ID)
+	}
+}
+
+// TestServerMode_RemoveDependencyPersistsAcrossConnections verifies that
+// RemoveDependency commits data that survives connection close.
+func TestServerMode_RemoveDependencyPersistsAcrossConnections(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping server mode test")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dolt-dep-remove-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cmd := exec.Command("dolt", "init")
+	cmd.Dir = tmpDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to init dolt repo: %v", err)
+	}
+
+	server := NewServer(ServerConfig{
+		DataDir:        tmpDir,
+		SQLPort:        13312,
+		RemotesAPIPort: 18086,
+		Host:           "127.0.0.1",
+		LogFile:        filepath.Join(tmpDir, "server.log"),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	defer func() {
+		if err := server.Stop(); err != nil {
+			t.Logf("warning: failed to stop server: %v", err)
+		}
+	}()
+
+	storeCfg := &Config{
+		Path:       tmpDir,
+		Database:   "beads",
+		ServerMode: true,
+		ServerHost: "127.0.0.1",
+		ServerPort: 13312,
+	}
+
+	// --- Connection 1: create issues, add dependency, then remove it ---
+	store1, err := New(ctx, storeCfg)
+	if err != nil {
+		t.Fatalf("failed to create store (conn 1): %v", err)
+	}
+
+	if err := store1.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("failed to set issue_prefix: %v", err)
+	}
+
+	issueA := &types.Issue{
+		Title:     "Issue A",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store1.CreateIssue(ctx, issueA, "test"); err != nil {
+		t.Fatalf("failed to create issue A: %v", err)
+	}
+
+	issueB := &types.Issue{
+		Title:     "Issue B",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store1.CreateIssue(ctx, issueB, "test"); err != nil {
+		t.Fatalf("failed to create issue B: %v", err)
+	}
+
+	dep := &types.Dependency{
+		IssueID:     issueB.ID,
+		DependsOnID: issueA.ID,
+		Type:        types.DepBlocks,
+	}
+	if err := store1.AddDependency(ctx, dep, "test"); err != nil {
+		t.Fatalf("AddDependency failed: %v", err)
+	}
+
+	if err := store1.RemoveDependency(ctx, issueB.ID, issueA.ID, "test"); err != nil {
+		t.Fatalf("RemoveDependency failed: %v", err)
+	}
+
+	store1.Close()
+
+	// --- Connection 2: verify removal persisted ---
+	store2, err := New(ctx, storeCfg)
+	if err != nil {
+		t.Fatalf("failed to create store (conn 2): %v", err)
+	}
+	defer store2.Close()
+
+	deps, err := store2.GetDependencies(ctx, issueB.ID)
+	if err != nil {
+		t.Fatalf("GetDependencies failed on new connection: %v", err)
+	}
+
+	if len(deps) != 0 {
+		t.Fatalf("expected 0 dependencies after reconnect (removal was lost), got %d", len(deps))
+	}
+}


### PR DESCRIPTION
The Dolt server is started with --no-auto-commit which sets @@autocommit=0 for all sessions. AddDependency and RemoveDependency used s.execContext() (bare SQL exec without a transaction), so their writes went into an implicit transaction that was never committed and silently rolled back on connection close. CreateIssue was unaffected because it already used BeginTx/tx.Commit.

Wrap both methods in explicit BeginTx/tx.Commit transactions, matching the pattern used by CreateIssue. All validation queries and the mutation now run within the same transaction.

Add server-mode integration tests that verify dependency persistence across separate connections, directly reproducing the bug scenario.