### PR TITLE
fix(bootstrap): handle empty JSONL gracefully instead of failing

### DIFF
--- a/internal/storage/dolt/bootstrap.go
+++ b/internal/storage/dolt/bootstrap.go
@@ -168,7 +168,7 @@ func findJSONLPath(beadsDir string) string {
 	}
 
 	for _, path := range candidates {
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() && info.Size() > 0 {
 			return path
 		}
 	}
@@ -264,7 +264,7 @@ func performBootstrap(ctx context.Context, cfg BootstrapConfig, jsonlPath string
 	}
 
 	if len(issues) == 0 {
-		return nil, fmt.Errorf("no valid issues found in JSONL file %s", jsonlPath)
+		return &BootstrapResult{}, nil
 	}
 
 	// Detect prefix from issues


### PR DESCRIPTION
## Summary

- An empty `issues.jsonl` (0 bytes) is the expected state for a freshly-initialized database, but bootstrap crashes with `"no valid issues found in JSONL file"` when this file exists and the Dolt database name in `metadata.json` doesn't match the actual directory (e.g. during server-mode embedded fallback)
- `findJSONLPath` now skips empty (0-byte) files — nothing to bootstrap from
- `performBootstrap` returns an empty result instead of a fatal error when no issues are found (defense in depth)

## How to reproduce

```bash
mkdir /tmp/test && cd /tmp/test && git init && git commit --allow-empty -m init
bd init --prefix tst
touch .beads/issues.jsonl
# Edit .beads/metadata.json: set dolt_database to a mismatched name
bd list  # ← crashes with "bootstrap failed: no valid issues found in JSONL file"
```

## Test plan

- [x] Added `TestBootstrapEmptyJSONL` — verifies empty JSONL is treated as a no-op
- [x] All existing bootstrap tests pass (9/9)
- [x] `go test -short ./...` — no new failures
- [x] Manual reproduction confirmed fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)