### PR TITLE
fix: bd init in clean room should have zero doctor issues

### DIFF
--- a/cmd/bd/doctor/claude.go
+++ b/cmd/bd/doctor/claude.go
@@ -409,7 +409,7 @@ func CheckDocumentationBdPrimeReference(repoPath string) DoctorCheck {
 
 // isClaudePresent returns true when the Claude CLI binary exists in PATH or the
 // ~/.claude/ directory is present.  CLAUDECODE=1 can be set by AI coding tools
-// other than Claude Code itself, so checking for actual Claude artefacts prevents
+// other than Claude Code itself, so checking for actual Claude artifacts prevents
 // spurious warnings for users who never installed Claude Code.
 func isClaudePresent() bool {
 	if _, err := exec.LookPath("claude"); err == nil {

--- a/cmd/bd/doctor/claude_test.go
+++ b/cmd/bd/doctor/claude_test.go
@@ -790,128 +790,128 @@ func TestCheckHookEvents(t *testing.T) {
 		if pc {
 			t.Error("Expected PreCompact=false")
 		}
-		})
-	}
-	
-	// TestIsClaudePresent tests the isClaudePresent helper across different scenarios.
-	// Tests that require claude to be absent from PATH are skipped when claude is
-	// installed locally; they run in CI where claude is not available.
-	func TestIsClaudePresent(t *testing.T) {
-		t.Run("claude_binary_in_path", func(t *testing.T) {
-			// Create a fake "claude" script in a temp bin dir so we can test
-			// the exec.LookPath success path without depending on a real installation.
-			tmpBin := t.TempDir()
-			claudePath := filepath.Join(tmpBin, "claude")
-			if err := os.WriteFile(claudePath, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			t.Setenv("PATH", tmpBin+string(os.PathListSeparator)+os.Getenv("PATH"))
-			t.Setenv("HOME", t.TempDir())
-			t.Setenv("USERPROFILE", t.TempDir())
-	
-			if !isClaudePresent() {
-				t.Error("Expected isClaudePresent() to return true when claude binary is in PATH")
-			}
-		})
-	
-		t.Run("dot_claude_dir_exists", func(t *testing.T) {
-			// Only meaningful when claude binary is absent; skip otherwise so we actually
-			// exercise the ~/.claude stat path rather than returning early via LookPath.
-			if _, lookErr := exec.LookPath("claude"); lookErr == nil {
-				t.Skip("claude binary found in PATH; ~/.claude directory check is unreachable")
-			}
-			tmpDir := t.TempDir()
-			t.Setenv("HOME", tmpDir)
-			t.Setenv("USERPROFILE", tmpDir)
-			if err := os.Mkdir(filepath.Join(tmpDir, ".claude"), 0o750); err != nil {
-				t.Fatal(err)
-			}
-			if !isClaudePresent() {
-				t.Error("Expected isClaudePresent() to return true when ~/.claude directory exists")
-			}
-		})
-	
-		t.Run("dot_claude_is_file_not_dir", func(t *testing.T) {
-			if _, lookErr := exec.LookPath("claude"); lookErr == nil {
-				t.Skip("claude binary found in PATH; IsDir() check is unreachable")
-			}
-			tmpDir := t.TempDir()
-			t.Setenv("HOME", tmpDir)
-			t.Setenv("USERPROFILE", tmpDir)
-			if err := os.WriteFile(filepath.Join(tmpDir, ".claude"), []byte("not a dir"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			// .claude exists but is a file, not a directory — should return false.
-			if isClaudePresent() {
-				t.Error("Expected isClaudePresent() to return false when ~/.claude is a file, not a directory")
-			}
-		})
-	
-		t.Run("no_binary_no_dot_claude", func(t *testing.T) {
-			if _, lookErr := exec.LookPath("claude"); lookErr == nil {
-				t.Skip("claude binary found in PATH; skipping no-claude absence test")
-			}
-			tmpDir := t.TempDir()
-			t.Setenv("HOME", tmpDir)
-			t.Setenv("USERPROFILE", tmpDir)
-			if isClaudePresent() {
-				t.Error("Expected isClaudePresent() to return false when claude not in PATH and ~/.claude absent")
-			}
-		})
-	}
-	
-	// TestCheckClaudePlugin_ClaudeCodeWithoutClaude verifies that CheckClaudePlugin
-	// returns StatusOK early when CLAUDECODE=1 but the claude CLI/dir is absent.
-	// This tests the !isClaudePresent() gating condition introduced in this PR.
-	func TestCheckClaudePlugin_ClaudeCodeWithoutClaude(t *testing.T) {
+	})
+}
+
+// TestIsClaudePresent tests the isClaudePresent helper across different scenarios.
+// Tests that require claude to be absent from PATH are skipped when claude is
+// installed locally; they run in CI where claude is not available.
+func TestIsClaudePresent(t *testing.T) {
+	t.Run("claude_binary_in_path", func(t *testing.T) {
+		// Create a fake "claude" script in a temp bin dir so we can test
+		// the exec.LookPath success path without depending on a real installation.
+		tmpBin := t.TempDir()
+		claudePath := filepath.Join(tmpBin, "claude")
+		if err := os.WriteFile(claudePath, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("PATH", tmpBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("USERPROFILE", t.TempDir())
+
+		if !isClaudePresent() {
+			t.Error("Expected isClaudePresent() to return true when claude binary is in PATH")
+		}
+	})
+
+	t.Run("dot_claude_dir_exists", func(t *testing.T) {
+		// Only meaningful when claude binary is absent; skip otherwise so we actually
+		// exercise the ~/.claude stat path rather than returning early via LookPath.
 		if _, lookErr := exec.LookPath("claude"); lookErr == nil {
-			t.Skip("claude binary found in PATH; cannot exercise !isClaudePresent() short-circuit")
+			t.Skip("claude binary found in PATH; ~/.claude directory check is unreachable")
 		}
 		tmpDir := t.TempDir()
-		t.Chdir(tmpDir)
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("USERPROFILE", tmpDir)
-		t.Setenv("CLAUDECODE", "1")
-	
-		check := CheckClaudePlugin()
-	
-		if check.Name != "Claude Plugin" {
-			t.Errorf("Expected name %q, got %q", "Claude Plugin", check.Name)
+		if err := os.Mkdir(filepath.Join(tmpDir, ".claude"), 0o750); err != nil {
+			t.Fatal(err)
 		}
-		if check.Status != StatusOK {
-			t.Errorf("Expected %s when CLAUDECODE=1 but claude absent, got %s: %s",
-				StatusOK, check.Status, check.Message)
+		if !isClaudePresent() {
+			t.Error("Expected isClaudePresent() to return true when ~/.claude directory exists")
 		}
-		if check.Message != "N/A (not running in Claude Code)" {
-			t.Errorf("Expected message %q, got %q", "N/A (not running in Claude Code)", check.Message)
-		}
-	}
-	
-	// TestCheckClaude_ClaudeCodeWithoutClaude verifies that CheckClaude returns
-	// "CLI-only mode" (ok) when CLAUDECODE=1 but the claude CLI/dir is absent.
-	// This tests the !isClaudePresent() gating condition in CheckClaude.
-	func TestCheckClaude_ClaudeCodeWithoutClaude(t *testing.T) {
+	})
+
+	t.Run("dot_claude_is_file_not_dir", func(t *testing.T) {
 		if _, lookErr := exec.LookPath("claude"); lookErr == nil {
-			t.Skip("claude binary found in PATH; cannot exercise !isClaudePresent() short-circuit in CheckClaude")
+			t.Skip("claude binary found in PATH; IsDir() check is unreachable")
 		}
 		tmpDir := t.TempDir()
-		t.Chdir(tmpDir)
 		t.Setenv("HOME", tmpDir)
 		t.Setenv("USERPROFILE", tmpDir)
-		t.Setenv("CLAUDECODE", "1")
-	
-		check := CheckClaude()
-	
-		if check.Name != "Claude Integration" {
-			t.Errorf("Expected name %q, got %q", "Claude Integration", check.Name)
+		if err := os.WriteFile(filepath.Join(tmpDir, ".claude"), []byte("not a dir"), 0o644); err != nil {
+			t.Fatal(err)
 		}
-		// With CLAUDECODE=1 and isClaudePresent()=false, the condition
-		// "!inClaudeCode || !isClaudePresent()" evaluates to true, returning "CLI-only mode".
-		if check.Status != "ok" {
-			t.Errorf("Expected %q status when CLAUDECODE=1 but claude absent, got %q: %s",
-				"ok", check.Status, check.Message)
+		// .claude exists but is a file, not a directory — should return false.
+		if isClaudePresent() {
+			t.Error("Expected isClaudePresent() to return false when ~/.claude is a file, not a directory")
 		}
-		if check.Message != "CLI-only mode" {
-			t.Errorf("Expected message %q, got %q", "CLI-only mode", check.Message)
+	})
+
+	t.Run("no_binary_no_dot_claude", func(t *testing.T) {
+		if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+			t.Skip("claude binary found in PATH; skipping no-claude absence test")
 		}
+		tmpDir := t.TempDir()
+		t.Setenv("HOME", tmpDir)
+		t.Setenv("USERPROFILE", tmpDir)
+		if isClaudePresent() {
+			t.Error("Expected isClaudePresent() to return false when claude not in PATH and ~/.claude absent")
+		}
+	})
+}
+
+// TestCheckClaudePlugin_ClaudeCodeWithoutClaude verifies that CheckClaudePlugin
+// returns StatusOK early when CLAUDECODE=1 but the claude CLI/dir is absent.
+// This tests the !isClaudePresent() gating condition introduced in this PR.
+func TestCheckClaudePlugin_ClaudeCodeWithoutClaude(t *testing.T) {
+	if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+		t.Skip("claude binary found in PATH; cannot exercise !isClaudePresent() short-circuit")
 	}
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDECODE", "1")
+
+	check := CheckClaudePlugin()
+
+	if check.Name != "Claude Plugin" {
+		t.Errorf("Expected name %q, got %q", "Claude Plugin", check.Name)
+	}
+	if check.Status != StatusOK {
+		t.Errorf("Expected %s when CLAUDECODE=1 but claude absent, got %s: %s",
+			StatusOK, check.Status, check.Message)
+	}
+	if check.Message != "N/A (not running in Claude Code)" {
+		t.Errorf("Expected message %q, got %q", "N/A (not running in Claude Code)", check.Message)
+	}
+}
+
+// TestCheckClaude_ClaudeCodeWithoutClaude verifies that CheckClaude returns
+// "CLI-only mode" (ok) when CLAUDECODE=1 but the claude CLI/dir is absent.
+// This tests the !isClaudePresent() gating condition in CheckClaude.
+func TestCheckClaude_ClaudeCodeWithoutClaude(t *testing.T) {
+	if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+		t.Skip("claude binary found in PATH; cannot exercise !isClaudePresent() short-circuit in CheckClaude")
+	}
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDECODE", "1")
+
+	check := CheckClaude()
+
+	if check.Name != "Claude Integration" {
+		t.Errorf("Expected name %q, got %q", "Claude Integration", check.Name)
+	}
+	// With CLAUDECODE=1 and isClaudePresent()=false, the condition
+	// "!inClaudeCode || !isClaudePresent()" evaluates to true, returning "CLI-only mode".
+	if check.Status != "ok" {
+		t.Errorf("Expected %q status when CLAUDECODE=1 but claude absent, got %q: %s",
+			"ok", check.Status, check.Message)
+	}
+	if check.Message != "CLI-only mode" {
+		t.Errorf("Expected message %q, got %q", "CLI-only mode", check.Message)
+	}
+}

--- a/cmd/bd/doctor/claude_test.go
+++ b/cmd/bd/doctor/claude_test.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -789,5 +790,128 @@ func TestCheckHookEvents(t *testing.T) {
 		if pc {
 			t.Error("Expected PreCompact=false")
 		}
-	})
-}
+		})
+	}
+	
+	// TestIsClaudePresent tests the isClaudePresent helper across different scenarios.
+	// Tests that require claude to be absent from PATH are skipped when claude is
+	// installed locally; they run in CI where claude is not available.
+	func TestIsClaudePresent(t *testing.T) {
+		t.Run("claude_binary_in_path", func(t *testing.T) {
+			// Create a fake "claude" script in a temp bin dir so we can test
+			// the exec.LookPath success path without depending on a real installation.
+			tmpBin := t.TempDir()
+			claudePath := filepath.Join(tmpBin, "claude")
+			if err := os.WriteFile(claudePath, []byte("#!/bin/sh\necho ok\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", tmpBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("USERPROFILE", t.TempDir())
+	
+			if !isClaudePresent() {
+				t.Error("Expected isClaudePresent() to return true when claude binary is in PATH")
+			}
+		})
+	
+		t.Run("dot_claude_dir_exists", func(t *testing.T) {
+			// Only meaningful when claude binary is absent; skip otherwise so we actually
+			// exercise the ~/.claude stat path rather than returning early via LookPath.
+			if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+				t.Skip("claude binary found in PATH; ~/.claude directory check is unreachable")
+			}
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+			t.Setenv("USERPROFILE", tmpDir)
+			if err := os.Mkdir(filepath.Join(tmpDir, ".claude"), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if !isClaudePresent() {
+				t.Error("Expected isClaudePresent() to return true when ~/.claude directory exists")
+			}
+		})
+	
+		t.Run("dot_claude_is_file_not_dir", func(t *testing.T) {
+			if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+				t.Skip("claude binary found in PATH; IsDir() check is unreachable")
+			}
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+			t.Setenv("USERPROFILE", tmpDir)
+			if err := os.WriteFile(filepath.Join(tmpDir, ".claude"), []byte("not a dir"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			// .claude exists but is a file, not a directory — should return false.
+			if isClaudePresent() {
+				t.Error("Expected isClaudePresent() to return false when ~/.claude is a file, not a directory")
+			}
+		})
+	
+		t.Run("no_binary_no_dot_claude", func(t *testing.T) {
+			if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+				t.Skip("claude binary found in PATH; skipping no-claude absence test")
+			}
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+			t.Setenv("USERPROFILE", tmpDir)
+			if isClaudePresent() {
+				t.Error("Expected isClaudePresent() to return false when claude not in PATH and ~/.claude absent")
+			}
+		})
+	}
+	
+	// TestCheckClaudePlugin_ClaudeCodeWithoutClaude verifies that CheckClaudePlugin
+	// returns StatusOK early when CLAUDECODE=1 but the claude CLI/dir is absent.
+	// This tests the !isClaudePresent() gating condition introduced in this PR.
+	func TestCheckClaudePlugin_ClaudeCodeWithoutClaude(t *testing.T) {
+		if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+			t.Skip("claude binary found in PATH; cannot exercise !isClaudePresent() short-circuit")
+		}
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+		t.Setenv("HOME", tmpDir)
+		t.Setenv("USERPROFILE", tmpDir)
+		t.Setenv("CLAUDECODE", "1")
+	
+		check := CheckClaudePlugin()
+	
+		if check.Name != "Claude Plugin" {
+			t.Errorf("Expected name %q, got %q", "Claude Plugin", check.Name)
+		}
+		if check.Status != StatusOK {
+			t.Errorf("Expected %s when CLAUDECODE=1 but claude absent, got %s: %s",
+				StatusOK, check.Status, check.Message)
+		}
+		if check.Message != "N/A (not running in Claude Code)" {
+			t.Errorf("Expected message %q, got %q", "N/A (not running in Claude Code)", check.Message)
+		}
+	}
+	
+	// TestCheckClaude_ClaudeCodeWithoutClaude verifies that CheckClaude returns
+	// "CLI-only mode" (ok) when CLAUDECODE=1 but the claude CLI/dir is absent.
+	// This tests the !isClaudePresent() gating condition in CheckClaude.
+	func TestCheckClaude_ClaudeCodeWithoutClaude(t *testing.T) {
+		if _, lookErr := exec.LookPath("claude"); lookErr == nil {
+			t.Skip("claude binary found in PATH; cannot exercise !isClaudePresent() short-circuit in CheckClaude")
+		}
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+		t.Setenv("HOME", tmpDir)
+		t.Setenv("USERPROFILE", tmpDir)
+		t.Setenv("CLAUDECODE", "1")
+	
+		check := CheckClaude()
+	
+		if check.Name != "Claude Integration" {
+			t.Errorf("Expected name %q, got %q", "Claude Integration", check.Name)
+		}
+		// With CLAUDECODE=1 and isClaudePresent()=false, the condition
+		// "!inClaudeCode || !isClaudePresent()" evaluates to true, returning "CLI-only mode".
+		if check.Status != "ok" {
+			t.Errorf("Expected %q status when CLAUDECODE=1 but claude absent, got %q: %s",
+				"ok", check.Status, check.Message)
+		}
+		if check.Message != "CLI-only mode" {
+			t.Errorf("Expected message %q, got %q", "CLI-only mode", check.Message)
+		}
+	}

--- a/cmd/bd/doctor/git.go
+++ b/cmd/bd/doctor/git.go
@@ -337,6 +337,18 @@ func CheckGitUpstream(path string) DoctorCheck {
 	}
 	branch := strings.TrimSpace(string(branchOut))
 
+	// Check if any remotes exist — no point warning about upstream if there's no remote
+	remoteCmd := exec.Command("git", "remote")
+	remoteCmd.Dir = path
+	remoteOut, err := remoteCmd.Output()
+	if err != nil || strings.TrimSpace(string(remoteOut)) == "" {
+		return DoctorCheck{
+			Name:    "Git Upstream",
+			Status:  StatusOK,
+			Message: "N/A — no remotes configured",
+		}
+	}
+
 	cmd = exec.Command("git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
 	cmd.Dir = path
 	upOut, err := cmd.Output()

--- a/cmd/bd/doctor/git_hygiene_test.go
+++ b/cmd/bd/doctor/git_hygiene_test.go
@@ -100,8 +100,13 @@ func TestCheckGitWorkingTree(t *testing.T) {
 func TestCheckGitUpstream(t *testing.T) {
 	t.Run("no upstream", func(t *testing.T) {
 		dir := mkTmpDirInTmp(t, "bd-git-up-*")
+		remote := mkTmpDirInTmp(t, "bd-git-remote-noup-*")
+		runGit(t, remote, "init", "--bare", "--initial-branch=main")
+
 		initRepo(t, dir, "main")
 		commitFile(t, dir, "README.md", "# test\n", "initial")
+		// Add a remote but don't push -u, so there's no upstream tracking branch.
+		runGit(t, dir, "remote", "add", "origin", remote)
 
 		check := CheckGitUpstream(dir)
 		if check.Status != StatusWarning {
@@ -109,6 +114,17 @@ func TestCheckGitUpstream(t *testing.T) {
 		}
 		if !strings.Contains(check.Message, "No upstream") {
 			t.Fatalf("message=%q want to mention upstream", check.Message)
+		}
+	})
+
+	t.Run("no remotes", func(t *testing.T) {
+		dir := mkTmpDirInTmp(t, "bd-git-norem-*")
+		initRepo(t, dir, "main")
+		commitFile(t, dir, "README.md", "# test\n", "initial")
+
+		check := CheckGitUpstream(dir)
+		if check.Status != StatusOK {
+			t.Fatalf("status=%q want %q (msg=%q)", check.Status, StatusOK, check.Message)
 		}
 	})
 


### PR DESCRIPTION
## Summary

A project aiming to use beads should have ZERO doctor issues after initialization. In a clean room, `bd init` followed by `bd doctor` should green across the board.

After `bd init` in a fresh git repo, `bd doctor` previously reported **10 warnings** (6 after committing). This PR eliminates all of them.

### Clean Room Verification
```
bd doctor v0.54.0  ──────────────  ✓ 69 passed  ⚠ 0 warnings  ✖ 0 errors
```

## Changes

### 1. Federation checks use correct database name
**Files:** `cmd/bd/doctor/federation.go`

All 5 federation check functions (`CheckFederationRemotesAPI`, `CheckFederationPeerConnectivity`, `CheckFederationSyncStaleness`, `CheckFederationConflicts`, `CheckDoltServerModeMismatch`) were constructing `dolt.Config{}` without setting the `Database` field, causing it to default to `"beads"` instead of the actual `"beads_<prefix>"` name. Now loads the correct name via `configfile.Load()`.

**Eliminates:** 3 warnings ("database not found: beads")

### 2. Dolt noms LOCK file cleanup
**Files:** `cmd/bd/init.go`, `internal/storage/dolt/store.go`, `internal/storage/dolt/store_embedded.go`

The embedded Dolt engine creates a 0-byte `LOCK` file when opening a database. Three layers of cleanup:
- `bd init` removes LOCK after initial store close
- `bd init` removes LOCK again after git commit (which triggers pre-commit hook that reopens DB)
- `store.Close()` now removes 0-byte LOCK files as part of shutdown

Related: PR #1802 (closed, attempted LOCK cleanup with age threshold), PR #1850 (merged, `releaseDiagnosticLocks()` between doctor phases). This addresses the remaining gap where `bd init` and normal store operations leave LOCK files behind.

Related: #1861 (open, `bd doctor --fix` hangs on embedded mode — same deadlock class)

**Eliminates:** 1 warning ("noms LOCK file exists")

### 3. Git upstream check skips when no remotes exist
**Files:** `cmd/bd/doctor/git.go`

`CheckGitUpstream()` now checks `git remote` first. If no remotes are configured, returns OK instead of warning about missing upstream tracking.

Related: #1095 (open, `doctor.suppress` config — this is a direct fix instead of suppression)

**Eliminates:** 1 warning ("No upstream configured")

### 4. Claude plugin check gates on actual Claude presence
**Files:** `cmd/bd/doctor/claude.go`

`CheckClaudePlugin()` and `CheckClaude()` now verify that the `claude` CLI binary exists or `~/.claude/` directory is present before warning. The `CLAUDECODE=1` env var alone is insufficient since other AI coding tools may set it.

Related: #1095 (open, same suppress mechanism), #1787 (open, false positive warnings for specific backend configs)

**Eliminates:** 1 warning ("Claude Plugin: not installed")

### 5. Init auto-stages and commits beads files
**Files:** `cmd/bd/init.go`

After creating all `.beads/` files and hooks, `bd init` now runs `git add .beads/` (+ `AGENTS.md` if present) and `git commit -m "bd init: initialize beads issue tracking"`. Only runs when not in stealth mode and in a git repo with local beads storage.

Related: #409 (closed, related init file creation issue)

**Eliminates:** 4 warnings (Sync Divergence, JSONL missing, Git Working Tree dirty, missing hooks)

### 6. JJ (Jujutsu) detection respects git repo boundary
**Files:** `internal/git/gitdir.go`

`GetJujutsuRoot()` now stops walking parent directories when it encounters a `.git` directory/file. Previously, a git repo nested inside a JJ-managed workspace would incorrectly detect the parent's `.jj/` and install JJ-specific hooks instead of regular git hooks.

**Eliminates:** Cascade of wrong hooks → untracked files → LOCK recreation

## Testing

Clean room reproduction:
```bash
mkdir -p /tmp/cleanroom && cd /tmp/cleanroom
git init && git commit --allow-empty -m "initial commit"
bd init
bd doctor  # ✓ 69 passed  ⚠ 0 warnings  ✖ 0 errors
```
