### PR TITLE
fix: normalize CRLF line endings in git hook files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 
 # Use bd merge for beads JSONL files
 .beads/issues.jsonl merge=beads
+
+# Shell scripts must always use LF line endings (especially git hook templates)
+*.sh text eol=lf
+cmd/bd/templates/hooks/* text eol=lf

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -28,7 +28,10 @@ func getEmbeddedHooks() (map[string]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read embedded hook %s: %w", name, err)
 		}
-		hooks[name] = string(content)
+		// Normalize line endings to LF — embedded templates may contain CRLF
+		// when built on Windows or from an NTFS-mounted filesystem (e.g. WSL).
+		// Git hooks with CRLF fail: /usr/bin/env: 'sh\r': No such file or directory
+		hooks[name] = strings.ReplaceAll(string(content), "\r\n", "\n")
 	}
 
 	return hooks, nil

--- a/cmd/bd/init_git_hooks.go
+++ b/cmd/bd/init_git_hooks.go
@@ -154,6 +154,12 @@ func installGitHooks() error {
 	postMergePath := filepath.Join(hooksDir, "post-merge")
 	postMergeContent := buildPostMergeHook(chainHooks, existingHooks)
 
+	// Normalize line endings to LF — on Windows/NTFS, Go string literals
+	// are fine but concatenated content from other sources may have CRLF.
+	// Git hooks with CRLF fail: /usr/bin/env: 'sh\r': No such file or directory
+	preCommitContent = strings.ReplaceAll(preCommitContent, "\r\n", "\n")
+	postMergeContent = strings.ReplaceAll(postMergeContent, "\r\n", "\n")
+
 	// Write pre-commit hook (executable scripts need 0700)
 	// #nosec G306 - git hooks must be executable
 	if err := os.WriteFile(preCommitPath, []byte(preCommitContent), 0700); err != nil {


### PR DESCRIPTION
## Summary

On Windows and WSL with NTFS-mounted repos, `bd hooks install` writes hook files with CRLF line endings, causing git operations to fail:

```
/usr/bin/env: 'sh\r': No such file or directory
```

**Two sources of CRLF contamination:**
1. `//go:embed` captures template files as-is from disk — if built on Windows/NTFS, the embedded content has CRLF
2. The `prepare-commit-msg` template already contained CRLF in the repo

**Fix:**
- Normalize embedded hook content (`strings.ReplaceAll("\r\n", "\n")`) before writing in both `hooks.go` (embedded templates path) and `init_git_hooks.go` (inline builders path)
- Add `.gitattributes` rules to enforce LF for shell scripts and hook templates regardless of platform

## Test plan
- [x] `go build` succeeds
- [x] `go test ./cmd/bd/ -run Hook` passes
- [x] Verified on WSL2 with NTFS mount: hooks installed with LF after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)