### PR TITLE
docs: use --claim when starting work

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ bd stale --days 30 --json          # Forgotten issues
 
 # Create and manage (ALWAYS include --description)
 bd create "Title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd update <id> --status in_progress --json
+bd update <id> --claim --json
 bd close <id> --reason "Done" --json
 
 # Search
@@ -66,7 +66,7 @@ bd sync  # Force immediate export/commit/push
 ### Workflow
 
 1. **Check ready work**: `bd ready --json`
-2. **Claim task**: `bd update <id> --status in_progress`
+2. **Claim task**: `bd update <id> --claim`
 3. **Work on it**: Implement, test, document
 4. **Discover new work?** `bd create "Found bug" --description="What was found and why" -p 1 --deps discovered-from:<parent-id> --json`
 5. **Complete**: `bd close <id> --reason "Done" --json`

--- a/claude-plugin/agents/task-agent.md
+++ b/claude-plugin/agents/task-agent.md
@@ -39,7 +39,7 @@ You are a task-completion agent for beads. Your goal is to find ready work and c
 
 # Important Guidelines
 
-- Always update issue status (`in_progress` when starting, close when done)
+- Always claim before working (MCP: set status to `in_progress`; CLI: `--claim` for atomic assignee + status) and close when done
 - Link discovered work with `discovered-from` dependencies
 - Don't close issues unless work is actually complete
 - If blocked, use `update` to set status to `blocked` and explain why

--- a/claude-plugin/commands/update.md
+++ b/claude-plugin/commands/update.md
@@ -19,6 +19,6 @@ Use the beads MCP `update` tool to apply the changes. Show the updated issue to 
 **Note:** Comments are managed separately with `bd comments add`. The `update` command is for singular, versioned properties (title, status, priority, etc.), while comments form a discussion thread that's appended to, not updated.
 
 Common workflows:
-- Start work: Update status to `in_progress`
+- Start work: `bd update <id> --claim` (atomic claim + `in_progress`)
 - Mark blocked: Update status to `blocked`
 - Reprioritize: Update priority (0-4)

--- a/claude-plugin/commands/workflow.md
+++ b/claude-plugin/commands/workflow.md
@@ -12,8 +12,8 @@ Beads is an issue tracker designed for AI-supervised coding workflows. Here's ho
 Use `/beads:ready` or the `ready` MCP tool to see tasks with no blockers.
 
 ## 2. Claim Your Task
-Update the issue status to `in_progress`:
-- Via command: `/beads:update <id> in_progress`
+Claim the issue atomically (assignee + `in_progress` in one step):
+- Via command: `/beads:update <id> --claim`
 - Via MCP tool: `update` with `status: "in_progress"`
 
 ## 3. Work on It

--- a/claude-plugin/skills/beads/SKILL.md
+++ b/claude-plugin/skills/beads/SKILL.md
@@ -59,7 +59,7 @@ Essential commands: `bd ready`, `bd create`, `bd show`, `bd update`, `bd close`,
 
 1. `bd ready` — Find unblocked work
 2. `bd show <id>` — Get full context
-3. `bd update <id> --status in_progress` — Start work
+3. `bd update <id> --claim` — Claim and start work atomically
 4. Add notes as you work (critical for compaction survival)
 5. `bd close <id> --reason "..."` — Complete task
 6. `bd sync` — Persist to git (always run at session end)


### PR DESCRIPTION
## Why

This updates start-work guidance from `bd update <id> --status in_progress` to `bd update <id> --claim` in key docs.

`--claim` is atomic: it sets assignee and status to `in_progress` in one update, which avoids concurrent claim races when multiple agents try to take the same task.

## Changes
- `claude-plugin/skills/beads/SKILL.md` session protocol step now uses `--claim`.
- `claude-plugin/commands/workflow.md` claim step now uses `--claim` and notes atomic behavior.
- `claude-plugin/commands/update.md` start-work workflow now uses `--claim`.
- `.github/copilot-instructions.md` start-work snippets now use `--claim`.
- `claude-plugin/agents/task-agent.md` guideline mentions CLI atomic claim semantics.