### PR TITLE
fix(plugin): correct inverted bd dep add argument order in docs

### DIFF
--- a/claude-plugin/commands/dep.md
+++ b/claude-plugin/commands/dep.md
@@ -71,7 +71,7 @@ The diagram colors are determined by your Mermaid theme (default, dark, forest, 
 
 ## Examples
 
-- `bd dep add bd-10 bd-20 --type blocks`: bd-10 blocks bd-20
+- `bd dep add bd-10 bd-20 --type blocks`: bd-10 depends on bd-20 (bd-20 blocks bd-10)
 - `bd dep tree bd-20`: Show what blocks bd-20 (dependency tree going UP)
 - `bd dep tree bd-1 --reverse`: Show what was discovered from bd-1 (dependent tree going DOWN)
 - `bd dep tree bd-1 --reverse --max-depth 3`: Show discovery tree with depth limit

--- a/claude-plugin/commands/epic.md
+++ b/claude-plugin/commands/epic.md
@@ -19,7 +19,8 @@ Manage epics (large features composed of multiple issues).
 ## Epic Workflow
 
 1. Create epic: `bd create "Large Feature" -t epic -p 1`
-2. Link subtasks: `bd dep add bd-10 bd-20 --type parent-child` (epic bd-10 is parent of task bd-20)
+2. Link subtasks: `bd dep add bd-20 bd-10 --type parent-child` (task bd-20 is child of epic bd-10)
+   - Or at creation: `bd create "Subtask title" -t task --parent bd-10`
 3. Track progress: `bd epic status`
 4. Auto-close when done: `bd epic close-eligible`
 

--- a/claude-plugin/skills/beads/resources/DEPENDENCIES.md
+++ b/claude-plugin/skills/beads/resources/DEPENDENCIES.md
@@ -123,12 +123,12 @@ Effect: Can't start auth-2 until setup-1 complete
 ### Creating blocks Dependencies
 
 ```bash
-bd dep add prerequisite-issue blocked-issue
+bd dep add blocked-issue prerequisite-issue
 # or explicitly:
-bd dep add prerequisite-issue blocked-issue --type blocks
+bd dep add blocked-issue prerequisite-issue --type blocks
 ```
 
-**Direction matters**: `from_id` blocks `to_id`. Think: "prerequisite blocks dependent".
+**Direction matters**: `from_id` depends on `to_id`. Think: "dependent depends on prerequisite".
 
 ### Common Patterns
 
@@ -454,10 +454,10 @@ Context: Issues discovered as side effect of refactoring
 ### Creating discovered-from Dependencies
 
 ```bash
-bd dep add original-work-id discovered-issue-id --type discovered-from
+bd dep add discovered-issue-id original-work-id --type discovered-from
 ```
 
-**Direction matters**: `to_id` was discovered while working on `from_id`.
+**Direction matters**: `from_id` was discovered while working on `to_id`.
 
 ### Common Patterns
 
@@ -614,21 +614,21 @@ Everything blocks everything else in strict sequential order.
 
 **Wrong**:
 ```bash
-bd dep add api-endpoint database-schema
+bd dep add database-schema api-endpoint
 
-Meaning: api-endpoint blocks database-schema
+Meaning: database-schema depends on api-endpoint (schema needs endpoint?!)
 ```
 
-**Problem**: Backwards! Schema should block endpoint, not other way around.
+**Problem**: Backwards! The endpoint depends on the schema, not the other way around.
 
 **Right**:
 ```bash
-bd dep add database-schema api-endpoint
+bd dep add api-endpoint database-schema
 
-Meaning: database-schema blocks api-endpoint
+Meaning: api-endpoint depends on database-schema (endpoint needs schema ✓)
 ```
 
-**Mnemonic**: "from_id blocks to_id" or "prerequisite blocks dependent"
+**Mnemonic**: "from_id depends on to_id" or "dependent depends on prerequisite"
 
 ---
 

--- a/claude-plugin/skills/beads/resources/INTEGRATION_PATTERNS.md
+++ b/claude-plugin/skills/beads/resources/INTEGRATION_PATTERNS.md
@@ -307,11 +307,13 @@ TESTS: All 12 tests passing (auth, rotation, expiry, error handling)"
    bd create "Update middleware" -t task
    bd create "Update tests" -t task
 
-   # Link hierarchy
-   bd dep add auth-epic login-1 --type parent-child
-   bd dep add auth-epic validation-2 --type parent-child
-   bd dep add auth-epic middleware-3 --type parent-child
-   bd dep add auth-epic tests-4 --type parent-child
+   # Link hierarchy (child depends on parent)
+   bd dep add login-1 auth-epic --type parent-child
+   bd dep add validation-2 auth-epic --type parent-child
+   bd dep add middleware-3 auth-epic --type parent-child
+   bd dep add tests-4 auth-epic --type parent-child
+   # Or use --parent at creation time:
+   # bd create "Update login endpoint" -t task --parent auth-epic
 
    # Add ordering
    bd dep add validation-2 login-1  # validation depends on login

--- a/claude-plugin/skills/beads/resources/PATTERNS.md
+++ b/claude-plugin/skills/beads/resources/PATTERNS.md
@@ -57,7 +57,7 @@ NEXT: Need user input on budget constraints before finalizing recommendations"
 
 **Pattern**:
 1. Create issue immediately: `bd create "Found: inventory system needs refactoring"`
-2. Link provenance: `bd dep add main-task new-issue --type discovered-from`
+2. Link provenance: `bd dep add new-issue main-task --type discovered-from`
 3. Assess urgency: blocker or can defer?
 4. **If blocker**:
    - `bd update main-task --status blocked`
@@ -317,7 +317,7 @@ When closing reveals new work:
 bd create "Optimize token lookup query" -t task -p 2
 
 # Link the provenance
-bd dep add auth-5 perf-99 --type discovered-from
+bd dep add perf-99 auth-5 --type discovered-from
 
 # Now close original
 bd close auth-5 --reason "OAuth refresh implemented. Discovered perf optimization needed (filed perf-99)."

--- a/claude-plugin/skills/beads/resources/WORKFLOWS.md
+++ b/claude-plugin/skills/beads/resources/WORKFLOWS.md
@@ -99,7 +99,7 @@ Discovery Workflow:
 - [ ] Notice bug, improvement, or follow-up work
 - [ ] Assess: Can defer or is blocker?
 - [ ] Create issue with bd create "Issue title"
-- [ ] Add discovered-from dependency: bd dep add current-id new-id --type discovered-from
+- [ ] Add discovered-from dependency: bd dep add new-id current-id --type discovered-from
 - [ ] If blocker: pause and switch; if not: continue current work
 - [ ] Issue persists for future sessions
 ```


### PR DESCRIPTION
## Summary

- Fix inverted `bd dep add` argument order across 6 claude-plugin doc files
- `bd dep add A B` means "A depends on B", but multiple examples had arguments reversed
- This caused agents following the docs to create inverted dependency relationships (blocks, parent-child, discovered-from)
- Add `--parent` flag recommendations where parent-child examples appear

## Files Changed

| File | Fix |
|------|-----|
| `resources/DEPENDENCIES.md` | blocks args (L126-131), discovered-from args (L457-460), Mistake 5 wrong/right examples (L617-631) |
| `resources/INTEGRATION_PATTERNS.md` | parent-child args (L311-314), added --parent note |
| `resources/PATTERNS.md` | discovered-from args (L60, L320) |
| `resources/WORKFLOWS.md` | discovered-from args (L102) |
| `commands/epic.md` | parent-child args (L22), added --parent alternative |
| `commands/dep.md` | blocks description (L74) |

## Impact

Agents reading the inverted examples would create backwards dependency relationships — e.g., parent depends on child instead of child depends on parent. This was confirmed to cause all 27 deps in a real epic to be created backwards.

**A note on the "depends on" language:** `bd dep add A B` uniformly means "A depends on B" regardless of dependency type. For parent-child this produces the counterintuitive-sounding `bd dep add child parent` ("child depends on parent"), but this is how the CLI works — confirmed by `bd dep add --help`, the `--depends-on` / `--blocked-by` flag aliases, and the existing correct examples in README.md and CLI_REFERENCE.md. The previous docs had the arguments flipped, which reads more naturally to humans but produces the wrong relationship in the database.

## Test plan

- [x] Verify all corrected examples match `bd dep add A B` = "A depends on B" semantics per `bd dep add --help`
- [x] Verify files marked "already correct" (README.md:73, CLI_REFERENCE.md:220, DEPENDENCIES.md:335, MOLECULES.md:50) were not modified
- [x] Cross-reference with `bd dep add --help` and `bd dep --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)