### PR TITLE
fix: remove stale --from-main flag from prime.go session prompts

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -206,7 +206,7 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 		// Stealth mode or local-only: only flush to JSONL, no git operations
 		closeProtocol = "Before saying \"done\": bd sync --flush-only"
 	} else if ephemeral {
-		closeProtocol = "Before saying \"done\": git status → git add → bd sync --from-main → git commit (no push - ephemeral branch)"
+		closeProtocol = "Before saying \"done\": git status → git add → bd sync → git commit (no push - ephemeral branch)"
 	} else if noPush {
 		closeProtocol = "Before saying \"done\": git status → git add → bd sync → git commit (push disabled - run git push manually)"
 	} else {
@@ -265,20 +265,20 @@ bd sync --flush-only        # Export to JSONL
 	} else if ephemeral {
 		closeProtocol = `[ ] 1. git status              (check what changed)
 [ ] 2. git add <files>         (stage code changes)
-[ ] 3. bd sync --from-main     (pull beads updates from main)
+[ ] 3. bd sync     (pull beads updates from main)
 [ ] 4. git commit -m "..."     (commit code changes)`
 		closeNote = "**Note:** This is an ephemeral branch (no upstream). Code is merged to main locally, not pushed."
 		syncSection = `### Sync & Collaboration
-- ` + "`bd sync --from-main`" + ` - Pull beads updates from main (for ephemeral branches)
+- ` + "`bd sync`" + ` - Pull beads updates from main (for ephemeral branches)
 - ` + "`bd sync --status`" + ` - Check sync status without syncing`
 		completingWorkflow = `**Completing work:**
 ` + "```bash" + `
 bd close <id1> <id2> ...    # Close all completed issues at once
-bd sync --from-main         # Pull latest beads from main
+bd sync         # Pull latest beads from main
 git add . && git commit -m "..."  # Commit your changes
 # Merge to main when ready (local merge, not push)
 ` + "```"
-		gitWorkflowRule = "Git workflow: run `bd sync --from-main` at session end"
+		gitWorkflowRule = "Git workflow: run `bd sync` at session end"
 	} else if noPush {
 		closeProtocol = `[ ] 1. git status              (check what changed)
 [ ] 2. git add <files>         (stage code changes)

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -31,8 +31,8 @@ func TestOutputContextFunction(t *testing.T) {
 			stealthMode:   false,
 			ephemeralMode: true,
 			localOnlyMode: false,
-			expectText:    []string{"Beads Workflow Context", "bd sync --from-main", "ephemeral branch"},
-			rejectText:    []string{"bd sync --flush-only", "git push"},
+			expectText:    []string{"Beads Workflow Context", "bd sync", "ephemeral branch"},
+			rejectText:    []string{"bd sync --flush-only", "git push", "--from-main"},
 		},
 		{
 			name:          "CLI Stealth",
@@ -85,8 +85,8 @@ func TestOutputContextFunction(t *testing.T) {
 			stealthMode:   false,
 			ephemeralMode: true,
 			localOnlyMode: false,
-			expectText:    []string{"Beads Issue Tracker Active", "bd sync --from-main", "ephemeral branch"},
-			rejectText:    []string{"bd sync --flush-only", "git push"},
+			expectText:    []string{"Beads Issue Tracker Active", "bd sync", "ephemeral branch"},
+			rejectText:    []string{"bd sync --flush-only", "git push", "--from-main"},
 		},
 		{
 			name:          "MCP Stealth",


### PR DESCRIPTION
## Summary

`bd prime` output for ephemeral branches includes `bd sync --from-main` in the session close protocol. The `--from-main` flag was removed from `bd sync`, so agents following the prime instructions always fail at the sync step with `Error: unknown flag: --from-main`.

- Replace all 5 occurrences of `bd sync --from-main` with `bd sync` in `prime.go` (`outputMCPContext` and `outputCLIContext`)
- Update corresponding test expectations in `prime_test.go`

## Steps to Reproduce

```bash
# On an ephemeral branch (no upstream)
bd prime | grep from-main
# → [ ] 3. bd sync --from-main     (pull beads updates from main)

bd sync --from-main
# → Error: unknown flag: --from-main
```

## Test Plan

- All 12 `TestOutputContextFunction` subtests pass with `-short` flag
- Ephemeral test cases now assert `--from-main` does NOT appear in output
- `gofmt` clean, no `.beads/issues.jsonl` changes

## Environment

- bd version: 0.55.4
- OS: Linux (Arch, kernel 6.19.3)
- Go: 1.24