### PR TITLE
doctor: fix --deep on Dolt backend

### DIFF
--- a/cmd/bd/doctor/deep.go
+++ b/cmd/bd/doctor/deep.go
@@ -60,8 +60,8 @@ func RunDeepValidation(path string) DeepValidationResult {
 		return result
 	}
 
-	// Open database
-	db, err := sql.Open("sqlite3", sqliteConnString(dbPath, true))
+	// Open database (backend-aware)
+	db, closeFn, err := openDeepValidationDB(beadsDir, dbPath)
 	if err != nil {
 		check := DoctorCheck{
 			Name:     "Deep Validation",
@@ -74,7 +74,7 @@ func RunDeepValidation(path string) DeepValidationResult {
 		result.OverallOK = false
 		return result
 	}
-	defer db.Close()
+	defer closeFn()
 
 	// Get counts for progress reporting
 	_ = db.QueryRow("SELECT COUNT(*) FROM issues").Scan(&result.TotalIssues)             // Best effort: zero counts are safe defaults for diagnostic display

--- a/cmd/bd/doctor/deep_open_cgo.go
+++ b/cmd/bd/doctor/deep_open_cgo.go
@@ -1,0 +1,25 @@
+//go:build cgo
+
+package doctor
+
+import (
+	"database/sql"
+	"os"
+)
+
+func openDeepValidationDB(beadsDir string, sqliteDBPath string) (*sql.DB, func(), error) {
+	if info, err := os.Stat(sqliteDBPath); err == nil && info.IsDir() {
+		conn, err := openDoltDBWithLock(beadsDir)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return conn.db, conn.Close, nil
+	}
+
+	db, err := sql.Open("sqlite3", sqliteConnString(sqliteDBPath, true))
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	return db, func() { _ = db.Close() }, nil
+}

--- a/cmd/bd/doctor/deep_open_nocgo.go
+++ b/cmd/bd/doctor/deep_open_nocgo.go
@@ -1,0 +1,12 @@
+//go:build !cgo
+
+package doctor
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func openDeepValidationDB(_ string, _ string) (*sql.DB, func(), error) {
+	return nil, func() {}, fmt.Errorf("deep validation requires CGO-enabled build")
+}


### PR DESCRIPTION
Fixes #1943.

- `bd doctor --deep` unconditionally opened the configured DB path as SQLite.
- On Dolt backend, that path is `.beads/dolt` (a directory), which yields `sqlite3: disk I/O error` and results in deep validation scanning 0 issues.

This change opens the database backend-aware:
- If the DB path is a directory, it uses the existing Dolt connection helper (`openDoltDBWithLock`) and runs the deep-validation SQL checks against that connection.
- If the DB path is a file, it uses SQLite as before.

Tests:
- `go test ./cmd/bd/doctor -run TestRunDeepValidation`