### PR TITLE
fix(list): separate parent-child deps from blocking deps in bd list

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -653,9 +653,10 @@ type IssueWithDependencyMetadata struct {
 // IssueWithCounts extends Issue with dependency relationship counts
 type IssueWithCounts struct {
 	*Issue
-	DependencyCount int `json:"dependency_count"`
-	DependentCount  int `json:"dependent_count"`
-	CommentCount    int `json:"comment_count"`
+	DependencyCount int     `json:"dependency_count"`
+	DependentCount  int     `json:"dependent_count"`
+	CommentCount    int     `json:"comment_count"`
+	Parent          *string `json:"parent,omitempty"` // Computed parent from parent-child dep (bd-ym8c)
 }
 
 // IssueDetails extends Issue with labels, dependencies, dependents, and comments.


### PR DESCRIPTION
## Summary

`bd list` displays parent-child dependencies as `(blocked by: <parent>)`, identical to actual blocking deps. This is the `bd list` counterpart to PR #1293 which fixed the same issue in `bd show`.

**This causes real problems for AI agents:** when an agent sees `(blocked by: bd-xxx)` on a child issue, it concludes the child is blocked and either:
- Skips the issue when looking for available work
- Attempts to remove the "blocking" dependency to unblock it
- Reports false circular dependencies (children "blocked by" parent, parent can't close until children close)

`bd ready` already correctly treats parent-child as non-blocking — this fix makes `bd list` consistent.

## Changes

### Human-readable output (compact + agent mode)
Parent-child deps now render as `(parent: X)` instead of `(blocked by: X)`:

**Before:**
```
○ bd-xxx.1 [P2] [task] - Child Task (blocked by: bd-xxx)
```

**After:**
```
○ bd-xxx.1 [P2] [task] - Child Task (parent: bd-xxx)
```

Mixed relationships render correctly:
```
○ bd-xxx.1 [P2] [task] - Child Task (parent: bd-xxx, blocked by: bd-yyy)
```

### JSON output (`bd list --json`)
Added computed `parent` field to `IssueWithCounts`, matching `bd show --json` behaviour:

**Before:** consumers had to manually parse the `dependencies` array for `type: "parent-child"`
**After:** `"parent": "bd-xxx"` available directly on the issue object

### Implementation
- `GetBlockingInfoForIssues` (DoltStore + ephemeral) returns `parentMap` as new 3rd return value
- Display functions (`formatDependencyInfo`, `formatIssueCompact`, `formatAgentIssue`) accept parent parameter
- `IssueWithCounts` struct gains `Parent *string` field

## Testing
- Updated existing `formatIssueCompact` and `formatIssueCompactWithDependencies` tests for new signatures
- Added `TestFormatDependencyInfoWithParent` — unit tests for all parent display combinations
- Added `TestFormatIssueCompactWithParent` — verifies parent annotation rendering
- Added `TestGetBlockingInfoForIssues_ParentChildSeparation` — integration test: parent-child goes to parentMap, blocking deps stay in blockedByMap
- Added `TestListJSON_ParentField` — verifies computed parent field in JSON output
- Manual testing: create parent/child/blocker hierarchy, verify all three output modes (compact, agent, JSON)

## Related issues
- PR #1293 (merged): same fix for `bd show` — this PR completes the fix for `bd list`
- #1155: `bd show` displays parent-child under DEPENDS ON (likely stale, fixed by #1293)
- #1122: `bv` treats parent-child as blocking (same family of bugs)