### PR TITLE
fix(jira): use correct API v3 /search/jql endpoint

### DIFF
--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -147,7 +147,7 @@ func (c *Client) SearchIssues(ctx context.Context, jql string) ([]Issue, error) 
 			"maxResults": {fmt.Sprintf("%d", maxResults)},
 		}
 
-		apiURL := fmt.Sprintf("%s/rest/api/3/search?%s", c.URL, params.Encode())
+		apiURL := fmt.Sprintf("%s/rest/api/3/search/jql?%s", c.URL, params.Encode())
 
 		body, err := c.doRequest(ctx, "GET", apiURL, nil)
 		if err != nil {


### PR DESCRIPTION
 ## Summary
  Fixes #1947 - Jira sync failing with HTTP 410 due to deprecated API endpoint.

  ## Problem
  The Jira integration was using `/rest/api/3/search` which Atlassian has deprecated and now returns HTTP 410 Gone. The error message confusingly mentioned `/rest/api/2/search` but the actual issue was the missing `/jql` suffix on the v3 endpoint.

  ## Solution
  Changed the endpoint from `/rest/api/3/search` to `/rest/api/3/search/jql` in `internal/jira/client.go`.

  ## Changes
  - `internal/jira/client.go`: Updated `SearchIssues()` to use correct endpoint (line 150)

  ## Verification
  - The Python import script (`jira2jsonl.py`) already uses the correct endpoint - this brings the Go native client into alignment.
  - Single line change, no breaking changes to the API or behavior.

  ## References
  - Atlassian migration guide: https://developer.atlassian.com/changelog/#CHANGE-2046

  What Was Fixed

   Before               After
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   /rest/api/3/search   /rest/api/3/search/jql

  This resolves the HTTP 410 error reported in #1947.