### PR TITLE
fix(doctor): pass configured db name to remaining call sites

### DIFF
--- a/cmd/bd/doctor/maintenance.go
+++ b/cmd/bd/doctor/maintenance.go
@@ -131,7 +131,7 @@ func CheckStaleMolecules(path string) DoctorCheck {
 	// Open database using Dolt
 	ctx := context.Background()
 	doltPath := filepath.Join(beadsDir, "dolt")
-	store, err := dolt.New(ctx, &dolt.Config{Path: doltPath, ReadOnly: true})
+	store, err := dolt.New(ctx, &dolt.Config{Path: doltPath, ReadOnly: true, Database: doltDatabaseName(beadsDir)})
 	if err != nil {
 		return DoctorCheck{
 			Name:     "Stale Molecules",

--- a/cmd/bd/doctor/migration_validation.go
+++ b/cmd/bd/doctor/migration_validation.go
@@ -230,7 +230,7 @@ func CheckMigrationCompletion(path string) (DoctorCheck, MigrationValidationResu
 	// Check Dolt database health
 	ctx := context.Background()
 	doltPath := filepath.Join(beadsDir, "dolt")
-	store, err := dolt.New(ctx, &dolt.Config{Path: doltPath, ReadOnly: true})
+	store, err := dolt.New(ctx, &dolt.Config{Path: doltPath, ReadOnly: true, Database: doltDatabaseName(beadsDir)})
 	if err != nil {
 		result.Ready = false
 		result.DoltHealthy = false

--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -20,7 +20,7 @@ import (
 func openStoreDB(beadsDir string) (*sql.DB, *dolt.DoltStore, error) {
 	ctx := context.Background()
 	doltPath := filepath.Join(beadsDir, "dolt")
-	store, err := dolt.New(ctx, &dolt.Config{Path: doltPath, ReadOnly: true})
+	store, err := dolt.New(ctx, &dolt.Config{Path: doltPath, ReadOnly: true, Database: doltDatabaseName(beadsDir)})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1929 — passes `doltDatabaseName(beadsDir)` to the 3 remaining `dolt.New()` call sites that were still using the hardcoded default database name.

| File | Function |
|------|----------|
| `validation.go` | `openStoreDB()` |
| `maintenance.go` | `CheckStaleMolecules()` |
| `migration_validation.go` | `CheckMigrationCompletion()` |

Supersedes #1932 (which covered these sites but bundled unrelated lint changes).

Fixes #1904

## Test plan
- [x] `go build ./cmd/bd/doctor/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)