### PR TITLE
fix: add Limit to wisp gc/list SearchIssues to prevent OOM

### DIFF
--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -367,6 +367,7 @@ func runWispList(cmd *cobra.Command, args []string) {
 	ephemeralFlag := true
 	filter := types.IssueFilter{
 		Ephemeral: &ephemeralFlag,
+		Limit:     5000,
 	}
 	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
@@ -572,6 +573,7 @@ func runWispGC(cmd *cobra.Command, args []string) {
 	ephemeralFlag := true
 	filter := types.IssueFilter{
 		Ephemeral: &ephemeralFlag,
+		Limit:     5000,
 	}
 	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
@@ -647,6 +649,7 @@ func runWispPurgeClosed(ctx context.Context, dryRun bool, force bool) {
 	filter := types.IssueFilter{
 		Status:    &statusClosed,
 		Ephemeral: &ephemeralTrue,
+		Limit:     5000,
 	}
 
 	closedIssues, err := store.SearchIssues(ctx, "", filter)


### PR DESCRIPTION
## Summary
- Adds `Limit: 5000` to all three unbounded `SearchIssues` calls in wisp gc, wisp list, and purge-closed
- Prevents sqlite3 OOM when thousands of ephemeral wisps accumulate
- Phase 1 mitigation; Phase 2 would add proper pagination with Offset

## Test plan
- [ ] Run `bd mol wisp gc --age 1h` on a store with many ephemeral wisps
- [ ] Verify `bd mol wisp list` returns results (capped at 5000)
- [ ] Verify `bd mol wisp gc --closed` works without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)