### PR TITLE
feat: batch auto-commit mode for Dolt to reduce commit bloat

### DIFF
--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -19,7 +19,9 @@ type doltAutoCommitParams struct {
 // maybeAutoCommit creates a Dolt commit after a successful write command when enabled.
 //
 // Semantics:
-// - Only applies when dolt auto-commit is enabled (on) AND the active store is versioned (Dolt).
+// - Only applies when dolt auto-commit is "on" AND the active store is versioned (Dolt).
+// - In "batch" mode, commits are deferred — changes accumulate in the working set
+//   until an explicit commit point (bd sync, bd dolt commit).
 // - Uses Dolt's "commit all" behavior under the hood (DOLT_COMMIT -Am).
 // - Treats "nothing to commit" as a no-op.
 func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
@@ -27,6 +29,8 @@ func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
 	if err != nil {
 		return err
 	}
+	// In batch mode, skip per-command commits. Changes stay in the working set
+	// and are committed at logical boundaries (bd sync, bd dolt commit).
 	if mode != doltAutoCommitOn {
 		return nil
 	}

--- a/cmd/bd/dolt_autocommit_config.go
+++ b/cmd/bd/dolt_autocommit_config.go
@@ -8,8 +8,9 @@ import (
 type doltAutoCommitMode string
 
 const (
-	doltAutoCommitOff doltAutoCommitMode = "off"
-	doltAutoCommitOn  doltAutoCommitMode = "on"
+	doltAutoCommitOff   doltAutoCommitMode = "off"
+	doltAutoCommitOn    doltAutoCommitMode = "on"
+	doltAutoCommitBatch doltAutoCommitMode = "batch"
 )
 
 func getDoltAutoCommitMode() (doltAutoCommitMode, error) {
@@ -24,7 +25,9 @@ func getDoltAutoCommitMode() (doltAutoCommitMode, error) {
 		return doltAutoCommitOff, nil
 	case doltAutoCommitOn:
 		return doltAutoCommitOn, nil
+	case doltAutoCommitBatch:
+		return doltAutoCommitBatch, nil
 	default:
-		return "", fmt.Errorf("invalid --dolt-auto-commit=%q (valid: off, on)", doltAutoCommit)
+		return "", fmt.Errorf("invalid --dolt-auto-commit=%q (valid: off, on, batch)", doltAutoCommit)
 	}
 }

--- a/cmd/bd/dolt_autocommit_test.go
+++ b/cmd/bd/dolt_autocommit_test.go
@@ -38,3 +38,43 @@ func TestIsDoltNothingToCommit(t *testing.T) {
 		t.Fatal("unexpected classification")
 	}
 }
+
+func TestGetDoltAutoCommitMode_Batch(t *testing.T) {
+	old := doltAutoCommit
+	defer func() { doltAutoCommit = old }()
+
+	doltAutoCommit = "batch"
+	mode, err := getDoltAutoCommitMode()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != doltAutoCommitBatch {
+		t.Fatalf("expected batch, got %q", mode)
+	}
+
+	// Also verify the other modes still work
+	doltAutoCommit = "on"
+	mode, err = getDoltAutoCommitMode()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != doltAutoCommitOn {
+		t.Fatalf("expected on, got %q", mode)
+	}
+
+	doltAutoCommit = "off"
+	mode, err = getDoltAutoCommitMode()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != doltAutoCommitOff {
+		t.Fatalf("expected off, got %q", mode)
+	}
+
+	// Invalid mode
+	doltAutoCommit = "invalid"
+	_, err = getDoltAutoCommitMode()
+	if err == nil {
+		t.Fatal("expected error for invalid mode")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds batch auto-commit mode that defers DOLT_COMMIT until logical boundaries (bd sync, bd dolt commit) instead of committing after every CLI invocation
- Changes embedded mode default from on to batch
- Adds CommitPending method that generates descriptive summary messages by querying dolt_diff
- Addresses the 49K commit bloat problem identified by Dolt team (Tim Sehn)

Closes bd-bsyux

## Test plan
- [x] Existing auto-commit tests pass
- [x] New batch mode tests added
- [ ] Verify commit count does not grow per-command in batch mode
- [ ] Verify bd sync triggers pending commit

Generated with Claude Code