### PR TITLE
fix: use flock probe for noms LOCK health check

### DIFF
--- a/cmd/bd/doctor/dolt_test.go
+++ b/cmd/bd/doctor/dolt_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -263,7 +264,10 @@ func TestCheckLockHealth_NoIssues(t *testing.T) {
 	}
 }
 
-func TestCheckLockHealth_DetectsNomsLOCK(t *testing.T) {
+func TestCheckLockHealth_UnlockedNomsLOCK(t *testing.T) {
+	// A noms LOCK file that is NOT flock'd should not produce a warning.
+	// This is the common case: a previous bd process created the file,
+	// released the flock on close, but the file persists on disk.
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	nomsDir := filepath.Join(beadsDir, "dolt", "beads", ".dolt", "noms")
@@ -282,8 +286,45 @@ func TestCheckLockHealth_DetectsNomsLOCK(t *testing.T) {
 	}
 
 	check := CheckLockHealth(tmpDir)
+	if check.Status != StatusOK {
+		t.Errorf("expected OK status with unlocked noms LOCK file, got %s (detail: %s)", check.Status, check.Detail)
+	}
+}
+
+func TestCheckLockHealth_HeldNomsLOCK(t *testing.T) {
+	// A noms LOCK file that IS flock'd should produce a warning —
+	// another process is actively using the database.
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	nomsDir := filepath.Join(beadsDir, "dolt", "beads", ".dolt", "noms")
+	if err := os.MkdirAll(nomsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := []byte(`{"backend":"dolt"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), configContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := filepath.Join(nomsDir, "LOCK")
+	if err := os.WriteFile(lockPath, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold an exclusive flock on the LOCK file to simulate an active dolt process
+	f, err := os.OpenFile(lockPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := lockfile.FlockExclusiveNonBlocking(f); err != nil {
+		t.Fatalf("failed to acquire flock: %v", err)
+	}
+	defer func() { _ = lockfile.FlockUnlock(f) }()
+
+	check := CheckLockHealth(tmpDir)
 	if check.Status != StatusWarning {
-		t.Errorf("expected Warning status with noms LOCK present, got %s", check.Status)
+		t.Errorf("expected Warning status with held noms LOCK, got %s", check.Status)
 	}
 	if !strings.Contains(check.Detail, "noms LOCK") {
 		t.Errorf("expected detail to mention noms LOCK, got: %s", check.Detail)


### PR DESCRIPTION
## Summary

- Fix false positive in `bd doctor` "Dolt Lock Health" check for embedded Dolt mode
- Use flock probing (same pattern as `dolt-access.lock`) instead of `os.Stat` file existence check for noms LOCK files
- Dolt's noms LOCK files are never deleted — only the flock is released on close — so the existence check always triggers after any database access

## Details

Earlier doctor checks (`CheckDatabaseVersion`, `CheckSchemaCompatibility`, `CheckDatabaseIntegrity`) open the database before `CheckLockHealth` runs, creating noms LOCK files that persist after close. The previous `os.Stat` check always found them, producing an unavoidable warning.

The fix applies the same flock-probing pattern already used for `dolt-access.lock` (lines 599-613 in `dolt.go`): attempt a non-blocking exclusive flock to distinguish an actively held lock (real contention, worth warning about) from a stale file (harmless).

## Test plan

- [x] `TestCheckLockHealth_UnlockedNomsLOCK` — unlocked LOCK file produces no warning
- [x] `TestCheckLockHealth_HeldNomsLOCK` — flock'd LOCK file produces warning
- [x] All existing `TestCheckLockHealth_*` tests pass
- [x] `go test ./cmd/bd/doctor/ -run TestCheckLockHealth -v` — 5/5 pass

Fixes #1959

🤖 Generated with [Claude Code](https://claude.com/claude-code)