### PR TITLE
fix(dolt): normalize metadata and waiters in UpdateIssue

### DIFF
--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -220,7 +221,21 @@ func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates ma
 			columnName = "ephemeral"
 		}
 		setClauses = append(setClauses, fmt.Sprintf("`%s` = ?", columnName))
-		args = append(args, value)
+
+		// Handle JSON serialization for array fields stored as TEXT
+		if key == "waiters" {
+			waitersJSON, _ := json.Marshal(value)
+			args = append(args, string(waitersJSON))
+		} else if key == "metadata" {
+			// GH#1417: Normalize metadata to string, accepting string/[]byte/json.RawMessage
+			metadataStr, err := storage.NormalizeMetadataValue(value)
+			if err != nil {
+				return fmt.Errorf("invalid metadata: %w", err)
+			}
+			args = append(args, metadataStr)
+		} else {
+			args = append(args, value)
+		}
 	}
 
 	args = append(args, id)


### PR DESCRIPTION
## Summary

- `UpdateIssue` in the transactional layer passed metadata and waiters values through without normalization, causing Dolt to silently drop them
- Now normalizes metadata via `NormalizeMetadataValue` (accepting string/[]byte/json.RawMessage) and JSON-serializes waiters before writing

The SELECT projection gap (also #1912) was independently fixed by the `issueSelectColumns` centralization (bfb5defb, PR #1914).

Fixes #1912

## Changes

**1 file, +16 lines, -1 deletion** — `internal/storage/dolt/transaction.go`

## Test plan

- [x] Compiles cleanly
- [ ] Manual: `bd update <id> --metadata '{"team":"platform"}' && bd show <id> --json | jq .metadata` — verify metadata persists

*Extracted from #1910 to keep the bug fix reviewable independently.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)