### PR TITLE
fix(doctor): stop false-positive SQLite artifact warnings

### DIFF
--- a/cmd/bd/doctor/artifacts.go
+++ b/cmd/bd/doctor/artifacts.go
@@ -270,7 +270,7 @@ func scanJSONLArtifacts(beadsDir string, report *ArtifactReport) {
 // Only flags SQLite files as artifacts if Dolt is the active backend.
 // If SQLite is still the active backend, beads.db is the live database.
 func scanSQLiteArtifacts(beadsDir string, report *ArtifactReport) {
-	if !isDoltNative(beadsDir) {
+	if !IsDoltBackend(beadsDir) {
 		return
 	}
 


### PR DESCRIPTION
## Summary

Fixes #1787

`scanSQLiteArtifacts()` used `isDoltNative()` (checks for `dolt/` subdirectory) to decide whether to flag `.db` files as artifacts. This caused false positives for users intentionally using SQLite who also had a `dolt/` directory present.

Changed to `IsDoltBackend()` which checks the actual configured backend from `config.yaml`/`metadata.json` — matching the function's own doc comment.

One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)