### PR TITLE
fix: handle unhandled error from hash.Write (gosec G104)

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -255,7 +255,7 @@ func applyConfigDefaults(cfg *Config) {
 			// Each test creates a unique temp directory, so hashing the path
 			// gives each test its own database on the shared test server.
 			h := fnv.New64a()
-			h.Write([]byte(cfg.Path))
+			_, _ = h.Write([]byte(cfg.Path)) // hash.Hash.Write never returns an error
 			cfg.Database = fmt.Sprintf("testdb_%x", h.Sum64())
 		} else {
 			cfg.Database = "beads"


### PR DESCRIPTION
## Summary
- Explicitly discard the error return from `hash.Hash.Write` in `internal/storage/dolt/store.go` to satisfy gosec G104 lint check
- `hash.Hash.Write` is documented to never return an error, so this is purely a lint fix

## Test plan
- [ ] CI lint passes (gosec G104 no longer flags line 258)

🤖 Generated with [Claude Code](https://claude.com/claude-code)