### PR TITLE
fix(hooks): update hook templates to use 'bd hooks run'

### DIFF
--- a/cmd/bd/templates/hooks/post-checkout
+++ b/cmd/bd/templates/hooks/post-checkout
@@ -4,15 +4,9 @@
 #
 # bd (beads) post-checkout hook - thin shim
 #
-# This shim delegates to 'bd hook post-checkout' which contains
+# This shim delegates to 'bd hooks run post-checkout' which contains
 # the actual hook logic. This pattern ensures hook behavior is always
 # in sync with the installed bd version - no manual updates needed.
-#
-# The 'bd hook' command (singular) supports:
-# - Guard against frequent firing
-# - Per-worktree state tracking
-# - Dolt branch-then-merge pattern
-# - Hook chaining configuration
 
 # Check if bd is available
 if ! command -v bd >/dev/null 2>&1; then
@@ -20,4 +14,4 @@ if ! command -v bd >/dev/null 2>&1; then
     exit 0
 fi
 
-exec bd hook post-checkout "$@"
+exec bd hooks run post-checkout "$@"

--- a/cmd/bd/templates/hooks/post-merge
+++ b/cmd/bd/templates/hooks/post-merge
@@ -4,14 +4,9 @@
 #
 # bd (beads) post-merge hook - thin shim
 #
-# This shim delegates to 'bd hook post-merge' which contains
+# This shim delegates to 'bd hooks run post-merge' which contains
 # the actual hook logic. This pattern ensures hook behavior is always
 # in sync with the installed bd version - no manual updates needed.
-#
-# The 'bd hook' command (singular) supports:
-# - Dolt push/pull sync
-# - Per-worktree state tracking
-# - Hook chaining configuration
 
 # Check if bd is available
 if ! command -v bd >/dev/null 2>&1; then
@@ -21,4 +16,4 @@ if ! command -v bd >/dev/null 2>&1; then
     exit 0
 fi
 
-exec bd hook post-merge "$@"
+exec bd hooks run post-merge "$@"

--- a/cmd/bd/templates/hooks/pre-commit
+++ b/cmd/bd/templates/hooks/pre-commit
@@ -4,15 +4,9 @@
 #
 # bd (beads) pre-commit hook — thin shim
 #
-# Delegates to 'bd hook pre-commit' which contains the actual hook logic.
+# Delegates to 'bd hooks run pre-commit' which contains the actual hook logic.
 # This pattern ensures hook behavior is always in sync with the installed
 # bd version — no manual updates needed.
-#
-# The 'bd hook' command supports:
-# - Per-worktree export state tracking
-# - Dolt in-process export (no lock deadlocks)
-# - Sync-branch routing
-# - Hook chaining configuration
 
 # Check if bd is available
 if ! command -v bd >/dev/null 2>&1; then
@@ -22,4 +16,4 @@ if ! command -v bd >/dev/null 2>&1; then
     exit 0
 fi
 
-exec bd hook pre-commit "$@"
+exec bd hooks run pre-commit "$@"


### PR DESCRIPTION
## Summary

- Hook templates installed by `bd hooks install` reference `bd hook <name>` (singular), but the `hook` command was deleted during the JSONL removal refactor
- This causes all git hooks (pre-commit, post-checkout, post-merge) to fail with `unknown command "hook" for "bd"`
- Updates all three hook templates to use `bd hooks run <name>` which is the correct command
- Removes stale comments describing features of the deleted `bd hook` command

## Test plan

- [ ] Run `bd hooks install` in a repo
- [ ] Verify `git commit` works without "unknown command" errors
- [ ] Verify `git checkout` and `git merge` hooks fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)