### PR TITLE
fix(dep): populate ParentID in tree and show [BLOCKED] for root

### DIFF
--- a/cmd/bd/dep_test.go
+++ b/cmd/bd/dep_test.go
@@ -868,7 +868,7 @@ func TestFormatTreeNode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := formatTreeNode(tt.node)
+			result := formatTreeNode(tt.node, false)
 			for _, want := range tt.contains {
 				if !strings.Contains(result, want) {
 					t.Errorf("formatTreeNode() = %q, want to contain %q", result, want)
@@ -883,6 +883,26 @@ func TestFormatTreeNode(t *testing.T) {
 			}
 		})
 	}
+
+	// Test that blocked root shows [BLOCKED] instead of [READY]
+	t.Run("blocked root shows BLOCKED not READY", func(t *testing.T) {
+		node := &types.TreeNode{
+			Issue: types.Issue{
+				ID:       "BD-10",
+				Title:    "Blocked Root",
+				Status:   types.StatusOpen,
+				Priority: 1,
+			},
+			Depth: 0,
+		}
+		result := formatTreeNode(node, true)
+		if strings.Contains(result, "[READY]") {
+			t.Errorf("blocked root should not show [READY], got: %q", result)
+		}
+		if !strings.Contains(result, "[BLOCKED]") {
+			t.Errorf("blocked root should show [BLOCKED], got: %q", result)
+		}
+	})
 }
 
 func TestRenderTreeOutput(t *testing.T) {

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -607,10 +607,10 @@ func (s *DoltStore) GetDependencyTree(ctx context.Context, issueID string, maxDe
 
 	// Simple implementation - can be optimized with CTE
 	visited := make(map[string]bool)
-	return s.buildDependencyTree(ctx, issueID, 0, maxDepth, reverse, visited)
+	return s.buildDependencyTree(ctx, issueID, 0, maxDepth, reverse, visited, "")
 }
 
-func (s *DoltStore) buildDependencyTree(ctx context.Context, issueID string, depth, maxDepth int, reverse bool, visited map[string]bool) ([]*types.TreeNode, error) {
+func (s *DoltStore) buildDependencyTree(ctx context.Context, issueID string, depth, maxDepth int, reverse bool, visited map[string]bool, parentID string) ([]*types.TreeNode, error) {
 	if depth >= maxDepth || visited[issueID] {
 		return nil, nil
 	}
@@ -644,14 +644,15 @@ func (s *DoltStore) buildDependencyTree(ctx context.Context, issueID string, dep
 	}
 
 	node := &types.TreeNode{
-		Issue: *issue,
-		Depth: depth,
+		Issue:    *issue,
+		Depth:    depth,
+		ParentID: parentID,
 	}
 
 	// TreeNode doesn't have Children field - return flat list
 	nodes := []*types.TreeNode{node}
 	for _, childID := range childIDs {
-		children, err := s.buildDependencyTree(ctx, childID, depth+1, maxDepth, reverse, visited)
+		children, err := s.buildDependencyTree(ctx, childID, depth+1, maxDepth, reverse, visited, issueID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- **BUG-2**: `buildDependencyTree()` never set `TreeNode.ParentID`, so `renderTree()` built an empty children map (all nodes keyed under `""` instead of the root ID). Fix: thread `parentID` through the recursion.
- **BUG-3**: `formatTreeNode()` showed `[READY]` for any open root node, even when it had open blocking children. Fix: compute whether root has open children and show `[BLOCKED]` instead.

Discovered during regression testing of the Dolt migration (see #1906).

Fixes #1954

## Test plan

- [x] Existing `TestFormatTreeNode` subtests still pass (open/depth-0 shows READY, depth-1 does not, closed node)
- [x] New test: "blocked root shows BLOCKED not READY"
- [x] `TestRenderTreeOutput` and `TestDepTreeFormatFlag` pass
- [ ] Manual: `bd dep tree <blocked-issue>` shows `[BLOCKED]` instead of `[READY]`
- [ ] Manual: `bd dep tree <ready-issue>` still shows `[READY]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)