### PR TITLE
fix(close,update): exit non-zero when individual issues fail

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -87,6 +87,7 @@ create, update, show, or close operation).`,
 		// Direct mode
 		closedIssues := []*types.Issue{}
 		closedCount := 0
+		hasErrors := false
 
 		// Handle local IDs
 		for _, id := range resolvedIDs {
@@ -95,6 +96,7 @@ create, update, show, or close operation).`,
 
 			if err := validateIssueClosable(id, issue, force); err != nil {
 				fmt.Fprintf(os.Stderr, "%s\n", err)
+				hasErrors = true
 				continue
 			}
 
@@ -102,6 +104,7 @@ create, update, show, or close operation).`,
 			if !force {
 				if err := checkGateSatisfaction(issue); err != nil {
 					fmt.Fprintf(os.Stderr, "cannot close %s: %s\n", id, err)
+					hasErrors = true
 					continue
 				}
 			}
@@ -111,16 +114,19 @@ create, update, show, or close operation).`,
 				blocked, blockers, err := store.IsBlocked(ctx, id)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error checking blockers for %s: %v\n", id, err)
+					hasErrors = true
 					continue
 				}
 				if blocked && len(blockers) > 0 {
 					fmt.Fprintf(os.Stderr, "cannot close %s: blocked by open issues %v (use --force to override)\n", id, blockers)
+					hasErrors = true
 					continue
 				}
 			}
 
 			if err := store.CloseIssue(ctx, id, reason, actor, session); err != nil {
 				fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
+				hasErrors = true
 				continue
 			}
 
@@ -146,6 +152,7 @@ create, update, show, or close operation).`,
 			result, err := resolveAndGetIssueWithRouting(ctx, store, id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+				hasErrors = true
 				continue
 			}
 			if result == nil || result.Issue == nil {
@@ -153,12 +160,14 @@ create, update, show, or close operation).`,
 					result.Close()
 				}
 				fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+				hasErrors = true
 				continue
 			}
 
 			if err := validateIssueClosable(result.ResolvedID, result.Issue, force); err != nil {
 				result.Close()
 				fmt.Fprintf(os.Stderr, "%s\n", err)
+				hasErrors = true
 				continue
 			}
 
@@ -167,6 +176,7 @@ create, update, show, or close operation).`,
 				if err := checkGateSatisfaction(result.Issue); err != nil {
 					result.Close()
 					fmt.Fprintf(os.Stderr, "cannot close %s: %s\n", id, err)
+					hasErrors = true
 					continue
 				}
 			}
@@ -177,11 +187,13 @@ create, update, show, or close operation).`,
 				if err != nil {
 					result.Close()
 					fmt.Fprintf(os.Stderr, "Error checking blockers for %s: %v\n", id, err)
+					hasErrors = true
 					continue
 				}
 				if blocked && len(blockers) > 0 {
 					result.Close()
 					fmt.Fprintf(os.Stderr, "cannot close %s: blocked by open issues %v (use --force to override)\n", id, blockers)
+					hasErrors = true
 					continue
 				}
 			}
@@ -189,6 +201,7 @@ create, update, show, or close operation).`,
 			if err := result.Store.CloseIssue(ctx, result.ResolvedID, reason, actor, session); err != nil {
 				result.Close()
 				fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
+				hasErrors = true
 				continue
 			}
 
@@ -249,6 +262,11 @@ create, update, show, or close operation).`,
 
 		if jsonOutput && len(closedIssues) > 0 {
 			outputJSON(closedIssues)
+		}
+
+		// Exit non-zero if any issues failed to close
+		if hasErrors {
+			os.Exit(1)
 		}
 	},
 }

--- a/cmd/bd/exit_code_test.go
+++ b/cmd/bd/exit_code_test.go
@@ -1,0 +1,129 @@
+// exit_code_test.go - Tests that commands exit non-zero on partial failures.
+//
+// Uses exec.Command because the fix calls os.Exit(1) which cannot be
+// captured in-process.
+
+//go:build cgo && integration
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestCLI_CloseBlockedExitCode tests that closing a blocked issue exits non-zero.
+func TestCLI_CloseBlockedExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := initExecTestDB(t)
+
+	// Create parent and child issues
+	parentID := createExecTestIssue(t, tmpDir, "Parent issue")
+	childID := createExecTestIssue(t, tmpDir, "Child blocker")
+
+	// Add dependency: parent depends on child
+	depCmd := exec.Command(testBD, "dep", "add", parentID, childID)
+	depCmd.Dir = tmpDir
+	depCmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	if out, err := depCmd.CombinedOutput(); err != nil {
+		t.Fatalf("dep add failed: %v\n%s", err, out)
+	}
+
+	// Try to close parent (should fail — blocked by open child)
+	closeCmd := exec.Command(testBD, "close", parentID)
+	closeCmd.Dir = tmpDir
+	closeCmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	out, err := closeCmd.CombinedOutput()
+
+	if err == nil {
+		t.Errorf("Expected non-zero exit code when closing blocked issue, but got success. Output: %s", out)
+	}
+	if !strings.Contains(string(out), "blocked by open issues") {
+		t.Errorf("Expected 'blocked by open issues' in stderr, got: %s", out)
+	}
+}
+
+// TestCLI_CloseNonexistentExitCode tests that closing a nonexistent issue exits non-zero.
+func TestCLI_CloseNonexistentExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := initExecTestDB(t)
+
+	cmd := exec.Command(testBD, "close", "nonexistent-xyz")
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	_, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Errorf("Expected non-zero exit code when closing nonexistent issue")
+	}
+}
+
+// TestCLI_UpdateNonexistentExitCode tests that updating a nonexistent issue exits non-zero.
+func TestCLI_UpdateNonexistentExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := initExecTestDB(t)
+
+	cmd := exec.Command(testBD, "update", "nonexistent-xyz", "--title", "Should fail")
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	_, err := cmd.CombinedOutput()
+
+	if err == nil {
+		t.Errorf("Expected non-zero exit code when updating nonexistent issue")
+	}
+}
+
+// TestCLI_ClosePartialFailureExitCode tests that closing multiple issues exits non-zero
+// when some succeed and some fail.
+func TestCLI_ClosePartialFailureExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := initExecTestDB(t)
+
+	// Create two issues: one closeable, one blocked
+	closeable := createExecTestIssue(t, tmpDir, "Closeable issue")
+	blocked := createExecTestIssue(t, tmpDir, "Blocked issue")
+	blocker := createExecTestIssue(t, tmpDir, "Blocker issue")
+
+	// blocked depends on blocker
+	depCmd := exec.Command(testBD, "dep", "add", blocked, blocker)
+	depCmd.Dir = tmpDir
+	depCmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	if out, err := depCmd.CombinedOutput(); err != nil {
+		t.Fatalf("dep add failed: %v\n%s", err, out)
+	}
+
+	// Try to close both: closeable should succeed, blocked should fail
+	closeCmd := exec.Command(testBD, "close", closeable, blocked)
+	closeCmd.Dir = tmpDir
+	closeCmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	out, err := closeCmd.CombinedOutput()
+
+	if err == nil {
+		t.Errorf("Expected non-zero exit code for partial close failure, but got success. Output: %s", out)
+	}
+
+	// Verify the closeable one was actually closed
+	showCmd := exec.Command(testBD, "show", closeable, "--json")
+	showCmd.Dir = tmpDir
+	showCmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	showOut, err := showCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("show failed: %v\n%s", err, showOut)
+	}
+	var details []map[string]interface{}
+	json.Unmarshal(showOut, &details)
+	if len(details) > 0 && details[0]["status"] != "closed" {
+		t.Errorf("Closeable issue should still be closed despite partial failure, got: %v", details[0]["status"])
+	}
+}

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -245,6 +245,7 @@ create, update, show, or close operation).`,
 		ctx := rootCtx
 
 		updatedIssues := []*types.Issue{}
+		hasErrors := false
 		var firstUpdatedID string // Track first successful update for last-touched
 		for _, id := range args {
 			// Resolve and get issue with routing (e.g., gt-xyz routes to gastown)
@@ -254,6 +255,7 @@ create, update, show, or close operation).`,
 					result.Close()
 				}
 				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+				hasErrors = true
 				continue
 			}
 			if result == nil || result.Issue == nil {
@@ -261,6 +263,7 @@ create, update, show, or close operation).`,
 					result.Close()
 				}
 				fmt.Fprintf(os.Stderr, "Issue %s not found\n", id)
+				hasErrors = true
 				continue
 			}
 			issue := result.Issue
@@ -269,6 +272,7 @@ create, update, show, or close operation).`,
 			if err := validateIssueUpdatable(id, issue); err != nil {
 				fmt.Fprintf(os.Stderr, "%s\n", err)
 				result.Close()
+				hasErrors = true
 				continue
 			}
 
@@ -277,6 +281,7 @@ create, update, show, or close operation).`,
 				if err := issueStore.ClaimIssue(ctx, result.ResolvedID, actor); err != nil {
 					fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
 					result.Close()
+					hasErrors = true
 					continue
 				}
 			}
@@ -301,6 +306,7 @@ create, update, show, or close operation).`,
 				if err := issueStore.UpdateIssue(ctx, result.ResolvedID, regularUpdates, actor); err != nil {
 					fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
 					result.Close()
+					hasErrors = true
 					continue
 				}
 			}
@@ -320,6 +326,7 @@ create, update, show, or close operation).`,
 				if err := applyLabelUpdates(ctx, issueStore, result.ResolvedID, actor, setLabels, addLabels, removeLabels); err != nil {
 					fmt.Fprintf(os.Stderr, "Error updating labels for %s: %v\n", id, err)
 					result.Close()
+					hasErrors = true
 					continue
 				}
 			}
@@ -332,11 +339,13 @@ create, update, show, or close operation).`,
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "Error getting parent %s: %v\n", newParent, err)
 						result.Close()
+						hasErrors = true
 						continue
 					}
 					if parentIssue == nil {
 						fmt.Fprintf(os.Stderr, "Error: parent issue %s not found\n", newParent)
 						result.Close()
+						hasErrors = true
 						continue
 					}
 				}
@@ -346,6 +355,7 @@ create, update, show, or close operation).`,
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error getting dependencies for %s: %v\n", id, err)
 					result.Close()
+					hasErrors = true
 					continue
 				}
 				for _, dep := range deps {
@@ -367,6 +377,7 @@ create, update, show, or close operation).`,
 					if err := issueStore.AddDependency(ctx, newDep, actor); err != nil {
 						fmt.Fprintf(os.Stderr, "Error adding parent dependency: %v\n", err)
 						result.Close()
+						hasErrors = true
 						continue
 					}
 				}
@@ -400,6 +411,11 @@ create, update, show, or close operation).`,
 
 		if jsonOutput && len(updatedIssues) > 0 {
 			outputJSON(updatedIssues)
+		}
+
+		// Exit non-zero if any issues failed to update
+		if hasErrors {
+			os.Exit(1)
 		}
 	},
 }


### PR DESCRIPTION
## Summary

- `bd close` and `bd update` process multiple IDs in a loop. When individual items fail (blocked by open issues, not found, claim error, etc.), they print to stderr and `continue` — but the process always exits 0.
- This makes it impossible for scripts, CI, and agent toolchains to detect failures.
- Fix: track `hasErrors` across all error paths and `os.Exit(1)` at the end if any items had errors. Successful items in the same batch are still processed normally.

Discovered during regression testing of the Dolt migration (see #1906).

## Test plan

- [x] New integration tests: `TestCLI_CloseBlockedExitCode`, `TestCLI_CloseNonexistentExitCode`, `TestCLI_UpdateNonexistentExitCode`, `TestCLI_ClosePartialFailureExitCode`
- [x] Partial failure test verifies that closeable issues are still closed even when batch exits non-zero
- [x] Existing tests pass (`go test ./cmd/bd/` unit tests)
- [ ] Manual: `bd close <blocked-id>` exits non-zero
- [ ] Manual: `bd update <nonexistent-id> --title foo` exits non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)