### PR TITLE
feat(query): add has_metadata_key to bd query DSL

### DIFF
--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -332,9 +332,10 @@ var KnownFields = map[string]bool{
 	"template":  true,
 
 	// Other
-	"spec":     true,
-	"spec_id":  true, // alias
-	"parent":   true,
-	"mol_type": true,
-	"notes":    true,
+	"spec":             true,
+	"spec_id":          true, // alias
+	"parent":           true,
+	"mol_type":         true,
+	"notes":            true,
+	"has_metadata_key": true, // GH#1406
 }


### PR DESCRIPTION
## Summary

- Adds `has_metadata_key` support to the query DSL: `bd query "has_metadata_key=team AND status=open"`
- Completes the list/search/query triangle for metadata existence filtering
- Uses existing `IssueFilter.HasMetadataKey` field and SQL-level `JSON_EXTRACT IS NOT NULL` from #1908

Implements GH#1406.

## Test plan

- [x] 3 new query DSL tests covering has_metadata_key parsing and evaluation
- [x] Existing query tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)