### PR TITLE
DECISION: bd dep add silently overwrites type — silent data loss risk

### DIFF
--- a/cmd/bd/dep_type_overwrite_test.go
+++ b/cmd/bd/dep_type_overwrite_test.go
@@ -1,0 +1,70 @@
+// dep_type_overwrite_test.go - Test that dep add rejects type change on existing pair.
+
+//go:build cgo && integration
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestCLI_DepAddRejectsTypeOverwrite tests that adding a dependency with a
+// different type on an existing (issue_id, depends_on_id) pair returns an error
+// instead of silently overwriting.
+//
+// This documents the decision: dep add errors on type mismatch; use
+// dep remove + dep add to change types explicitly.
+func TestCLI_DepAddRejectsTypeOverwrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := initExecTestDB(t)
+
+	issueA := createExecTestIssue(t, tmpDir, "Issue A")
+	issueB := createExecTestIssue(t, tmpDir, "Issue B")
+
+	// Add blocks dependency
+	cmd := exec.Command(testBD, "dep", "add", issueA, issueB)
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("initial dep add failed: %v\n%s", err, out)
+	}
+
+	// Try to add caused-by on the same pair — should error
+	cmd2 := exec.Command(testBD, "dep", "add", issueA, issueB, "--type", "caused-by")
+	cmd2.Dir = tmpDir
+	cmd2.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	out, err := cmd2.CombinedOutput()
+	if err == nil {
+		t.Errorf("dep add with different type should fail, but succeeded. Output: %s", out)
+	}
+	if !strings.Contains(string(out), "already exists with type") {
+		t.Errorf("expected 'already exists with type' error, got: %s", out)
+	}
+}
+
+// TestCLI_DepAddIdempotentSameType tests that re-adding the same dependency
+// with the same type is a no-op (idempotent).
+func TestCLI_DepAddIdempotentSameType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := initExecTestDB(t)
+
+	issueA := createExecTestIssue(t, tmpDir, "Issue A")
+	issueB := createExecTestIssue(t, tmpDir, "Issue B")
+
+	// Add blocks dependency twice — second should succeed silently
+	for i := 0; i < 2; i++ {
+		cmd := exec.Command(testBD, "dep", "add", issueA, issueB)
+		cmd.Dir = tmpDir
+		cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("dep add (attempt %d) failed: %v\n%s", i+1, err, out)
+		}
+	}
+}

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -72,10 +72,27 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		}
 	}
 
+	// Check for existing dependency between the same pair with a different type.
+	// Previously this was an upsert (ON DUPLICATE KEY UPDATE type = VALUES(type))
+	// which silently changed e.g. "blocks" to "caused-by", removing the blocking
+	// relationship without warning.
+	var existingType string
+	err = tx.QueryRowContext(ctx, `
+		SELECT type FROM dependencies WHERE issue_id = ? AND depends_on_id = ?
+	`, dep.IssueID, dep.DependsOnID).Scan(&existingType)
+	if err == nil {
+		// Row exists
+		if existingType == string(dep.Type) {
+			// Same type — idempotent, nothing to do
+			return tx.Commit()
+		}
+		return fmt.Errorf("dependency %s -> %s already exists with type %q (requested %q); remove it first with 'bd dep remove' then re-add",
+			dep.IssueID, dep.DependsOnID, existingType, dep.Type)
+	}
+
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id)
 		VALUES (?, ?, ?, NOW(), ?, ?, ?)
-		ON DUPLICATE KEY UPDATE type = VALUES(type), metadata = VALUES(metadata)
 	`, dep.IssueID, dep.DependsOnID, dep.Type, actor, metadata, dep.ThreadID); err != nil {
 		return fmt.Errorf("failed to add dependency: %w", err)
 	}


### PR DESCRIPTION
## Problem

`bd dep add A B --type=caused-by` when A→B already exists as `blocks` **silently overwrites the type** via `ON DUPLICATE KEY UPDATE`. This removes the blocking relationship without any warning.

A user trying to annotate a relationship (`caused-by`, `validates`) can accidentally unblock an issue they thought was still guarded.

Root cause: `dependencies` PRIMARY KEY is `(issue_id, depends_on_id)` — type is not part of the key.

## This PR implements Option 1: Error unless type matches

If the pair exists with a different type, return an error telling the user to `bd dep remove` first.
Same-type re-add is idempotent (no-op).

## Alternatives — your call

**Option 2: Allow multiple types per pair (schema change)**
- Add `type` to PRIMARY KEY → `(issue_id, depends_on_id, type)`
- A→B can be both `blocks` AND `caused-by` simultaneously
- More expressive but changes semantics of remove

**Option 3: Allow overwrite with --force + warning**
- Keep current behavior but require `--force` flag
- Print warning: "changing dependency type from X to Y"

## Test plan

- [x] Compiles, existing tests pass
- [ ] Manual: `bd dep add A B` then `bd dep add A B --type=caused-by` → error message
- [ ] Manual: `bd dep add A B` then `bd dep add A B` → idempotent success

🤖 Generated with [Claude Code](https://claude.com/claude-code)