### PR TITLE
DECISION: bd reopen leaves defer_until set — issue vanishes from bd ready

### DIFF
--- a/cmd/bd/reopen.go
+++ b/cmd/bd/reopen.go
@@ -49,9 +49,13 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 				fmt.Fprintf(os.Stderr, "%s is already open\n", fullID)
 				continue
 			}
-			// UpdateIssue automatically clears closed_at when status changes from closed
+			// UpdateIssue automatically clears closed_at when status changes from closed.
+			// Also clear defer_until so the issue appears in bd ready immediately.
+			// Without this, a deferred issue that was closed and reopened stays
+			// hidden from bd ready despite being "open".
 			updates := map[string]interface{}{
-				"status": string(types.StatusOpen),
+				"status":      string(types.StatusOpen),
+				"defer_until": nil,
 			}
 			if err := store.UpdateIssue(ctx, fullID, updates, actor); err != nil {
 				fmt.Fprintf(os.Stderr, "Error reopening %s: %v\n", fullID, err)

--- a/cmd/bd/reopen_defer_test.go
+++ b/cmd/bd/reopen_defer_test.go
@@ -1,0 +1,72 @@
+// reopen_defer_test.go - Test that reopen clears defer_until.
+
+//go:build cgo && integration
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestCLI_ReopenClearsDeferUntil tests that reopening a deferred+closed issue
+// clears defer_until so the issue appears in bd ready immediately.
+//
+// This documents the decision: reopen means "I want to work on this NOW",
+// so defer_until is cleared.
+func TestCLI_ReopenClearsDeferUntil(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := initExecTestDB(t)
+	id := createExecTestIssue(t, tmpDir, "Deferred then reopened")
+
+	// Defer the issue to far future
+	cmd := exec.Command(testBD, "update", id, "--defer", "+8760h") // 1 year
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("defer failed: %v\n%s", err, out)
+	}
+
+	// Close it
+	cmd = exec.Command(testBD, "close", id)
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("close failed: %v\n%s", err, out)
+	}
+
+	// Reopen it
+	cmd = exec.Command(testBD, "reopen", id)
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("reopen failed: %v\n%s", err, out)
+	}
+
+	// Verify defer_until is cleared
+	cmd = exec.Command(testBD, "show", id, "--json")
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(), "BEADS_NO_DAEMON=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("show failed: %v\n%s", err, out)
+	}
+
+	var issues []map[string]interface{}
+	json.Unmarshal(out, &issues)
+	if len(issues) == 0 {
+		t.Fatalf("show returned no issues")
+	}
+
+	issue := issues[0]
+	if issue["status"] != "open" {
+		t.Errorf("expected status=open after reopen, got: %v", issue["status"])
+	}
+	if deferUntil, ok := issue["defer_until"]; ok && deferUntil != nil && deferUntil != "" {
+		t.Errorf("expected defer_until to be cleared after reopen, got: %v", deferUntil)
+	}
+}


### PR DESCRIPTION
## Problem

`bd defer +2w` → `bd close` → `bd reopen` produces an issue that is `status=open` but **invisible to `bd ready`** because `defer_until` is still set in the future.

The user explicitly asked to reopen the issue NOW, but it silently disappears from their work queue.

## This PR implements Option 1: reopen clears defer_until

One line change: `"defer_until": nil` added to the reopen updates map.
Issue appears in `bd ready` immediately after reopen.

## Alternatives — your call

**Option 2: Restore status=deferred if defer_until is in the future**
- `bd reopen` checks defer_until: if still future, sets status=deferred instead of open
- Preserves scheduling intent ("I deferred this for a reason")
- But: user said "reopen", not "re-defer"

**Option 3: Leave as-is, document the interaction**
- Add a warning message when reopening a deferred issue
- But: `bd defer` + `bd close` + `bd reopen` remains a trap for the unwary

## Diff

```go
 updates := map[string]interface{}{
     "status":      string(types.StatusOpen),
+    "defer_until": nil,
 }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)