### PR TITLE
feat(linear): add Project sync support

### DIFF
--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -15,6 +15,34 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// projectsQuery is the GraphQL query for fetching projects.
+const projectsQuery = `
+	query Projects($filter: ProjectFilter!, $first: Int!, $after: String) {
+		projects(
+			first: $first
+			after: $after
+			filter: $filter
+		) {
+			nodes {
+				id
+				name
+				description
+				slugId
+				url
+				state
+				progress
+				createdAt
+				updatedAt
+				completedAt
+			}
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+		}
+	}
+`
+
 // issuesQuery is the GraphQL query for fetching issues with all required fields.
 // Used by both FetchIssues and FetchIssuesSince for consistency.
 const issuesQuery = `
@@ -706,4 +734,159 @@ func (c *Client) FetchTeams(ctx context.Context) ([]Team, error) {
 	}
 
 	return teamsResp.Teams.Nodes, nil
+}
+
+// FetchProjects retrieves projects from Linear with optional filtering by state.
+// state can be: "planned", "started", "paused", "completed", "canceled", or "all"/"".
+func (c *Client) FetchProjects(ctx context.Context, state string) ([]Project, error) {
+	var allProjects []Project
+	var cursor string
+
+	filter := map[string]interface{}{
+		"team": map[string]interface{}{
+			"id": map[string]interface{}{
+				"eq": c.TeamID,
+			},
+		},
+	}
+
+	if state != "all" && state != "" {
+		filter["state"] = map[string]interface{}{
+			"eq": state,
+		}
+	}
+
+	for {
+		variables := map[string]interface{}{
+			"filter": filter,
+			"first":  MaxPageSize,
+		}
+		if cursor != "" {
+			variables["after"] = cursor
+		}
+
+		req := &GraphQLRequest{
+			Query:     projectsQuery,
+			Variables: variables,
+		}
+
+		data, err := c.Execute(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch projects: %w", err)
+		}
+
+		var projectsResp ProjectsResponse
+		if err := json.Unmarshal(data, &projectsResp); err != nil {
+			return nil, fmt.Errorf("failed to parse projects response: %w", err)
+		}
+
+		allProjects = append(allProjects, projectsResp.Projects.Nodes...)
+
+		if !projectsResp.Projects.PageInfo.HasNextPage {
+			break
+		}
+		cursor = projectsResp.Projects.PageInfo.EndCursor
+	}
+
+	return allProjects, nil
+}
+
+// CreateProject creates a new project in Linear.
+func (c *Client) CreateProject(ctx context.Context, name, description, state string) (*Project, error) {
+	query := `
+		mutation CreateProject($input: ProjectCreateInput!) {
+			projectCreate(input: $input) {
+				success
+				project {
+					id
+					name
+					description
+					slugId
+					url
+					state
+					progress
+					createdAt
+					updatedAt
+				}
+			}
+		}
+	`
+
+	input := map[string]interface{}{
+		"teamId":      c.TeamID,
+		"name":        name,
+		"description": description,
+	}
+
+	if state != "" {
+		input["state"] = state
+	}
+
+	req := &GraphQLRequest{
+		Query: query,
+		Variables: map[string]interface{}{
+			"input": input,
+		},
+	}
+
+	data, err := c.Execute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create project: %w", err)
+	}
+
+	var createResp ProjectCreateResponse
+	if err := json.Unmarshal(data, &createResp); err != nil {
+		return nil, fmt.Errorf("failed to parse create project response: %w", err)
+	}
+
+	if !createResp.ProjectCreate.Success {
+		return nil, fmt.Errorf("project creation reported as unsuccessful")
+	}
+
+	return &createResp.ProjectCreate.Project, nil
+}
+
+// UpdateProject updates an existing project in Linear.
+func (c *Client) UpdateProject(ctx context.Context, projectID string, updates map[string]interface{}) (*Project, error) {
+	query := `
+		mutation UpdateProject($id: String!, $input: ProjectUpdateInput!) {
+			projectUpdate(id: $id, input: $input) {
+				success
+				project {
+					id
+					name
+					description
+					slugId
+					url
+					state
+					progress
+					updatedAt
+				}
+			}
+		}
+	`
+
+	req := &GraphQLRequest{
+		Query: query,
+		Variables: map[string]interface{}{
+			"id":    projectID,
+			"input": updates,
+		},
+	}
+
+	data, err := c.Execute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update project: %w", err)
+	}
+
+	var updateResp ProjectUpdateResponse
+	if err := json.Unmarshal(data, &updateResp); err != nil {
+		return nil, fmt.Errorf("failed to parse update project response: %w", err)
+	}
+
+	if !updateResp.ProjectUpdate.Success {
+		return nil, fmt.Errorf("project update reported as unsuccessful")
+	}
+
+	return &updateResp.ProjectUpdate.Project, nil
 }

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -69,6 +69,7 @@ type Issue struct {
 	State       *State     `json:"state"`
 	Assignee    *User      `json:"assignee"`
 	Labels      *Labels    `json:"labels"`
+	Project     *Project   `json:"project,omitempty"`
 	Parent      *Parent    `json:"parent,omitempty"`
 	Relations   *Relations `json:"relations,omitempty"`
 	CreatedAt   string     `json:"createdAt"`
@@ -164,6 +165,47 @@ type IssueUpdateResponse struct {
 // TeamResponse represents the response from team query.
 type TeamResponse struct {
 	Team TeamStates `json:"team"`
+}
+
+// Project represents a project in Linear.
+type Project struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	SlugId      string `json:"slugId"`
+	URL         string `json:"url"`
+	State       string `json:"state"` // "planned", "started", "paused", "completed", "canceled"
+	Progress    int    `json:"progress"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+	CompletedAt string `json:"completedAt,omitempty"`
+}
+
+// ProjectsResponse represents the response from projects query.
+type ProjectsResponse struct {
+	Projects struct {
+		Nodes    []Project `json:"nodes"`
+		PageInfo struct {
+			HasNextPage bool   `json:"hasNextPage"`
+			EndCursor   string `json:"endCursor"`
+		} `json:"pageInfo"`
+	} `json:"projects"`
+}
+
+// ProjectCreateResponse represents the response from projectCreate mutation.
+type ProjectCreateResponse struct {
+	ProjectCreate struct {
+		Success bool    `json:"success"`
+		Project Project `json:"project"`
+	} `json:"projectCreate"`
+}
+
+// ProjectUpdateResponse represents the response from projectUpdate mutation.
+type ProjectUpdateResponse struct {
+	ProjectUpdate struct {
+		Success bool    `json:"success"`
+		Project Project `json:"project"`
+	} `json:"projectUpdate"`
 }
 
 // SyncStats tracks statistics for a Linear sync operation.


### PR DESCRIPTION
This PR adds Project sync support to the Linear integration.

Summary:
- Add Project type and related GraphQL response types
- Add FetchProjects, CreateProject, UpdateProject methods
- Add ProjectToEpic mapping function

Related to closed PR #1709