### PR TITLE
feat: config-driven metadata schema enforcement

### DIFF
--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -17,6 +17,12 @@ import (
 
 // CreateIssue creates a new issue
 func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
+	// Validate metadata against schema if configured (GH#1416 Phase 2)
+	// Runs before ephemeral routing so wisps are also validated.
+	if err := validateMetadataIfConfigured(issue.Metadata); err != nil {
+		return err
+	}
+
 	// Route ephemeral issues to wisps table
 	if issue.Ephemeral {
 		return s.createWisp(ctx, issue, actor)
@@ -147,6 +153,9 @@ func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*t
 	}
 	if allEph {
 		for _, issue := range issues {
+			if err := validateMetadataIfConfigured(issue.Metadata); err != nil {
+				return fmt.Errorf("metadata validation failed for issue %s: %w", issue.ID, err)
+			}
 			if err := s.createWisp(ctx, issue, actor); err != nil {
 				return err
 			}
@@ -201,6 +210,11 @@ func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*t
 		// Validate issue
 		if err := issue.ValidateWithCustom(customStatuses, customTypes); err != nil {
 			return fmt.Errorf("validation failed for issue %s: %w", issue.ID, err)
+		}
+
+		// Validate metadata against schema if configured (GH#1416 Phase 2)
+		if err := validateMetadataIfConfigured(issue.Metadata); err != nil {
+			return fmt.Errorf("metadata validation failed for issue %s: %w", issue.ID, err)
 		}
 
 		if issue.ContentHash == "" {
@@ -395,6 +409,17 @@ func (s *DoltStore) GetIssueByExternalRef(ctx context.Context, externalRef strin
 
 // UpdateIssue updates fields on an issue
 func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	// Validate metadata against schema before wisp routing (GH#1416 Phase 2)
+	if rawMeta, ok := updates["metadata"]; ok {
+		metadataStr, err := storage.NormalizeMetadataValue(rawMeta)
+		if err != nil {
+			return fmt.Errorf("invalid metadata: %w", err)
+		}
+		if err := validateMetadataIfConfigured(json.RawMessage(metadataStr)); err != nil {
+			return err
+		}
+	}
+
 	// Route ephemeral IDs to wisps table (falls through for promoted wisps)
 	if s.isActiveWisp(ctx, id) {
 		return s.updateWisp(ctx, id, updates, actor)
@@ -433,6 +458,7 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 			args = append(args, string(waitersJSON))
 		} else if key == "metadata" {
 			// GH#1417: Normalize metadata to string, accepting string/[]byte/json.RawMessage
+			// Schema validation already ran in the pre-routing block above.
 			metadataStr, err := storage.NormalizeMetadataValue(value)
 			if err != nil {
 				return fmt.Errorf("invalid metadata: %w", err)

--- a/internal/storage/dolt/metadata_schema.go
+++ b/internal/storage/dolt/metadata_schema.go
@@ -1,0 +1,131 @@
+package dolt
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// loadMetadataSchema reads the metadata validation config from YAML and
+// returns a parsed schema. Returns mode "none" with empty fields if config
+// is not initialized, mode is empty/unknown, or no fields are defined.
+func loadMetadataSchema() storage.MetadataSchemaConfig {
+	mode := config.MetadataValidationMode()
+	if mode == "none" {
+		return storage.MetadataSchemaConfig{Mode: "none"}
+	}
+
+	rawFields := config.MetadataSchemaFields()
+	if rawFields == nil {
+		return storage.MetadataSchemaConfig{Mode: "none"}
+	}
+
+	fields := make(map[string]storage.MetadataFieldSchema)
+	for name, raw := range rawFields {
+		fieldMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		schema := parseFieldSchema(fieldMap)
+		fields[name] = schema
+	}
+
+	if len(fields) == 0 {
+		return storage.MetadataSchemaConfig{Mode: "none"}
+	}
+
+	return storage.MetadataSchemaConfig{
+		Mode:   mode,
+		Fields: fields,
+	}
+}
+
+// parseFieldSchema converts a raw config map into a MetadataFieldSchema.
+func parseFieldSchema(m map[string]interface{}) storage.MetadataFieldSchema {
+	schema := storage.MetadataFieldSchema{}
+
+	if t, ok := m["type"].(string); ok {
+		schema.Type = storage.MetadataFieldType(t)
+	}
+
+	if req, ok := m["required"].(bool); ok {
+		schema.Required = req
+	}
+
+	// Parse enum values
+	if vals, ok := m["values"]; ok {
+		switch v := vals.(type) {
+		case []interface{}:
+			for _, item := range v {
+				if s, ok := item.(string); ok {
+					schema.Values = append(schema.Values, s)
+				}
+			}
+		case string:
+			// Comma-separated fallback
+			for _, s := range strings.Split(v, ",") {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					schema.Values = append(schema.Values, s)
+				}
+			}
+		}
+	}
+
+	// Parse min/max for numeric types
+	if min, ok := toFloat64(m["min"]); ok {
+		schema.Min = &min
+	}
+	if max, ok := toFloat64(m["max"]); ok {
+		schema.Max = &max
+	}
+
+	return schema
+}
+
+// toFloat64 converts an interface{} to float64, handling int and float YAML values.
+func toFloat64(v interface{}) (float64, bool) {
+	if v == nil {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// validateMetadataIfConfigured checks metadata against the schema from config.
+// In "warn" mode, prints warnings to stderr and returns nil.
+// In "error" mode, returns the first validation error.
+// In "none" mode (or if config is not initialized), does nothing.
+func validateMetadataIfConfigured(metadata json.RawMessage) error {
+	schema := loadMetadataSchema()
+	if schema.Mode == "none" {
+		return nil
+	}
+
+	errs := storage.ValidateMetadataSchema(metadata, schema)
+	if len(errs) == 0 {
+		return nil
+	}
+
+	if schema.Mode == "warn" {
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", e.Error())
+		}
+		return nil
+	}
+
+	// mode == "error"
+	return fmt.Errorf("metadata schema violation: %s", errs[0].Error())
+}

--- a/internal/storage/dolt/metadata_schema_test.go
+++ b/internal/storage/dolt/metadata_schema_test.go
@@ -1,0 +1,104 @@
+package dolt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestLoadMetadataSchema_DefaultNone(t *testing.T) {
+	// Without config.Initialize(), mode should default to "none"
+	schema := loadMetadataSchema()
+	if schema.Mode != "none" {
+		t.Errorf("expected mode 'none', got %q", schema.Mode)
+	}
+	if len(schema.Fields) != 0 {
+		t.Errorf("expected no fields, got %d", len(schema.Fields))
+	}
+}
+
+func TestValidateMetadataIfConfigured_NoneMode(t *testing.T) {
+	// With no config initialized, should always return nil
+	err := validateMetadataIfConfigured(json.RawMessage(`{"anything":"goes"}`))
+	if err != nil {
+		t.Errorf("expected nil error in none mode, got %v", err)
+	}
+}
+
+func TestParseFieldSchema(t *testing.T) {
+	t.Run("EnumField", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"type":     "enum",
+			"values":   []interface{}{"a", "b", "c"},
+			"required": true,
+		}
+		schema := parseFieldSchema(raw)
+		if schema.Type != storage.MetadataFieldEnum {
+			t.Errorf("expected type enum, got %q", schema.Type)
+		}
+		if !schema.Required {
+			t.Error("expected required=true")
+		}
+		if len(schema.Values) != 3 {
+			t.Errorf("expected 3 values, got %d", len(schema.Values))
+		}
+	})
+
+	t.Run("IntFieldWithMinMax", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"type": "int",
+			"min":  0,
+			"max":  100,
+		}
+		schema := parseFieldSchema(raw)
+		if schema.Type != storage.MetadataFieldInt {
+			t.Errorf("expected type int, got %q", schema.Type)
+		}
+		if schema.Min == nil || *schema.Min != 0 {
+			t.Errorf("expected min=0, got %v", schema.Min)
+		}
+		if schema.Max == nil || *schema.Max != 100 {
+			t.Errorf("expected max=100, got %v", schema.Max)
+		}
+	})
+
+	t.Run("StringField", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"type": "string",
+		}
+		schema := parseFieldSchema(raw)
+		if schema.Type != storage.MetadataFieldString {
+			t.Errorf("expected type string, got %q", schema.Type)
+		}
+		if schema.Required {
+			t.Error("expected required=false by default")
+		}
+	})
+}
+
+func TestToFloat64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   interface{}
+		want    float64
+		wantOK  bool
+	}{
+		{"float64", float64(3.14), 3.14, true},
+		{"int", int(42), 42, true},
+		{"int64", int64(99), 99, true},
+		{"nil", nil, 0, false},
+		{"string", "not a number", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := toFloat64(tt.input)
+			if ok != tt.wantOK {
+				t.Errorf("toFloat64(%v) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("toFloat64(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -140,6 +140,11 @@ func (t *doltTransaction) CreateIssue(ctx context.Context, issue *types.Issue, a
 		issue.ID = generatedID
 	}
 
+	// Validate metadata against schema if configured (GH#1416 Phase 2)
+	if err := validateMetadataIfConfigured(issue.Metadata); err != nil {
+		return err
+	}
+
 	return insertIssueTxIntoTable(ctx, t.tx, table, issue)
 }
 
@@ -270,6 +275,10 @@ func (t *doltTransaction) UpdateIssue(ctx context.Context, id string, updates ma
 			metadataStr, err := storage.NormalizeMetadataValue(value)
 			if err != nil {
 				return fmt.Errorf("invalid metadata: %w", err)
+			}
+			// Validate against schema if configured (GH#1416 Phase 2)
+			if err := validateMetadataIfConfigured(json.RawMessage(metadataStr)); err != nil {
+				return err
 			}
 			args = append(args, metadataStr)
 		} else {

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -34,6 +34,176 @@ func NormalizeMetadataValue(value interface{}) (string, error) {
 	return jsonStr, nil
 }
 
+// MetadataFieldType defines the type of a metadata field for schema validation.
+type MetadataFieldType string
+
+const (
+	MetadataFieldString MetadataFieldType = "string"
+	MetadataFieldInt    MetadataFieldType = "int"
+	MetadataFieldFloat  MetadataFieldType = "float"
+	MetadataFieldBool   MetadataFieldType = "bool"
+	MetadataFieldEnum   MetadataFieldType = "enum"
+)
+
+// MetadataFieldSchema defines validation rules for a single metadata field.
+type MetadataFieldSchema struct {
+	Type     MetadataFieldType
+	Values   []string // allowed values for enum type
+	Required bool
+	Min      *float64 // min value for int/float
+	Max      *float64 // max value for int/float
+}
+
+// MetadataSchemaConfig holds the parsed metadata validation configuration.
+type MetadataSchemaConfig struct {
+	Mode   string                         // "none", "warn", "error"
+	Fields map[string]MetadataFieldSchema // field name → schema
+}
+
+// MetadataValidationError describes a single schema violation.
+type MetadataValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e MetadataValidationError) Error() string {
+	return fmt.Sprintf("metadata.%s: %s", e.Field, e.Message)
+}
+
+// ValidateMetadataSchema validates a metadata blob against a schema config.
+// Returns a list of validation errors. An empty list means validation passed.
+// If metadata is nil/empty and no fields are required, returns no errors.
+func ValidateMetadataSchema(metadata json.RawMessage, schema MetadataSchemaConfig) []MetadataValidationError {
+	if len(schema.Fields) == 0 {
+		return nil
+	}
+
+	// Parse metadata into a map
+	var parsed map[string]interface{}
+	if len(metadata) == 0 || string(metadata) == "{}" || string(metadata) == "null" {
+		parsed = map[string]interface{}{}
+	} else {
+		if err := json.Unmarshal(metadata, &parsed); err != nil {
+			// Not a JSON object — can't validate fields
+			return []MetadataValidationError{{Field: "(root)", Message: "metadata must be a JSON object for schema validation"}}
+		}
+	}
+
+	var errs []MetadataValidationError
+
+	for fieldName, fieldSchema := range schema.Fields {
+		val, exists := parsed[fieldName]
+
+		// Check required
+		if fieldSchema.Required && !exists {
+			errs = append(errs, MetadataValidationError{
+				Field:   fieldName,
+				Message: "required field is missing",
+			})
+			continue
+		}
+
+		if !exists {
+			continue
+		}
+
+		// Type-check the value
+		switch fieldSchema.Type {
+		case MetadataFieldString:
+			if _, ok := val.(string); !ok {
+				errs = append(errs, MetadataValidationError{
+					Field:   fieldName,
+					Message: fmt.Sprintf("expected string, got %T", val),
+				})
+			}
+
+		case MetadataFieldInt:
+			num, ok := val.(float64)
+			if !ok {
+				errs = append(errs, MetadataValidationError{
+					Field:   fieldName,
+					Message: fmt.Sprintf("expected int, got %T", val),
+				})
+			} else {
+				if num != float64(int64(num)) {
+					errs = append(errs, MetadataValidationError{
+						Field:   fieldName,
+						Message: fmt.Sprintf("expected int, got float %v", num),
+					})
+				} else {
+					if fieldSchema.Min != nil && num < *fieldSchema.Min {
+						errs = append(errs, MetadataValidationError{
+							Field:   fieldName,
+							Message: fmt.Sprintf("value %v is below minimum %v", num, *fieldSchema.Min),
+						})
+					}
+					if fieldSchema.Max != nil && num > *fieldSchema.Max {
+						errs = append(errs, MetadataValidationError{
+							Field:   fieldName,
+							Message: fmt.Sprintf("value %v exceeds maximum %v", num, *fieldSchema.Max),
+						})
+					}
+				}
+			}
+
+		case MetadataFieldFloat:
+			num, ok := val.(float64)
+			if !ok {
+				errs = append(errs, MetadataValidationError{
+					Field:   fieldName,
+					Message: fmt.Sprintf("expected float, got %T", val),
+				})
+			} else {
+				if fieldSchema.Min != nil && num < *fieldSchema.Min {
+					errs = append(errs, MetadataValidationError{
+						Field:   fieldName,
+						Message: fmt.Sprintf("value %v is below minimum %v", num, *fieldSchema.Min),
+					})
+				}
+				if fieldSchema.Max != nil && num > *fieldSchema.Max {
+					errs = append(errs, MetadataValidationError{
+						Field:   fieldName,
+						Message: fmt.Sprintf("value %v exceeds maximum %v", num, *fieldSchema.Max),
+					})
+				}
+			}
+
+		case MetadataFieldBool:
+			if _, ok := val.(bool); !ok {
+				errs = append(errs, MetadataValidationError{
+					Field:   fieldName,
+					Message: fmt.Sprintf("expected bool, got %T", val),
+				})
+			}
+
+		case MetadataFieldEnum:
+			str, ok := val.(string)
+			if !ok {
+				errs = append(errs, MetadataValidationError{
+					Field:   fieldName,
+					Message: fmt.Sprintf("expected string (enum), got %T", val),
+				})
+			} else {
+				found := false
+				for _, allowed := range fieldSchema.Values {
+					if str == allowed {
+						found = true
+						break
+					}
+				}
+				if !found {
+					errs = append(errs, MetadataValidationError{
+						Field:   fieldName,
+						Message: fmt.Sprintf("value %q is not one of: %v", str, fieldSchema.Values),
+					})
+				}
+			}
+		}
+	}
+
+	return errs
+}
+
 // validMetadataKeyRe validates metadata key names for use in JSON path expressions.
 // Allows alphanumeric, underscore, and dot (for nested paths like "jira.sprint").
 var validMetadataKeyRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.]*$`)

--- a/internal/storage/metadata_schema_test.go
+++ b/internal/storage/metadata_schema_test.go
@@ -1,0 +1,261 @@
+package storage
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateMetadataSchema_NoFields(t *testing.T) {
+	schema := MetadataSchemaConfig{Mode: "error", Fields: nil}
+	errs := ValidateMetadataSchema(json.RawMessage(`{"anything":"goes"}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for empty schema, got %v", errs)
+	}
+}
+
+func TestValidateMetadataSchema_RequiredField(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"team": {Type: MetadataFieldEnum, Values: []string{"platform", "frontend"}, Required: true},
+		},
+	}
+
+	// Missing required field
+	errs := ValidateMetadataSchema(json.RawMessage(`{}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != "team" {
+		t.Errorf("expected field 'team', got %q", errs[0].Field)
+	}
+
+	// Present and valid
+	errs = ValidateMetadataSchema(json.RawMessage(`{"team":"platform"}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidateMetadataSchema_EnumValidation(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"severity": {Type: MetadataFieldEnum, Values: []string{"low", "medium", "high", "critical"}},
+		},
+	}
+
+	// Valid value
+	errs := ValidateMetadataSchema(json.RawMessage(`{"severity":"high"}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+
+	// Invalid value
+	errs = ValidateMetadataSchema(json.RawMessage(`{"severity":"extreme"}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != "severity" {
+		t.Errorf("expected field 'severity', got %q", errs[0].Field)
+	}
+
+	// Wrong type
+	errs = ValidateMetadataSchema(json.RawMessage(`{"severity":42}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMetadataSchema_IntValidation(t *testing.T) {
+	min := float64(0)
+	max := float64(100)
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"points": {Type: MetadataFieldInt, Min: &min, Max: &max},
+		},
+	}
+
+	// Valid
+	errs := ValidateMetadataSchema(json.RawMessage(`{"points":5}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+
+	// Below min
+	errs = ValidateMetadataSchema(json.RawMessage(`{"points":-1}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+
+	// Above max
+	errs = ValidateMetadataSchema(json.RawMessage(`{"points":101}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+
+	// Float when int expected
+	errs = ValidateMetadataSchema(json.RawMessage(`{"points":3.5}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+
+	// Wrong type entirely
+	errs = ValidateMetadataSchema(json.RawMessage(`{"points":"five"}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMetadataSchema_StringValidation(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"tool": {Type: MetadataFieldString},
+		},
+	}
+
+	// Valid
+	errs := ValidateMetadataSchema(json.RawMessage(`{"tool":"golangci-lint"}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+
+	// Wrong type
+	errs = ValidateMetadataSchema(json.RawMessage(`{"tool":42}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMetadataSchema_BoolValidation(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"urgent": {Type: MetadataFieldBool},
+		},
+	}
+
+	// Valid
+	errs := ValidateMetadataSchema(json.RawMessage(`{"urgent":true}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+
+	// Wrong type
+	errs = ValidateMetadataSchema(json.RawMessage(`{"urgent":"yes"}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMetadataSchema_FloatValidation(t *testing.T) {
+	min := float64(0.0)
+	max := float64(1.0)
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"confidence": {Type: MetadataFieldFloat, Min: &min, Max: &max},
+		},
+	}
+
+	// Valid
+	errs := ValidateMetadataSchema(json.RawMessage(`{"confidence":0.95}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+
+	// Above max
+	errs = ValidateMetadataSchema(json.RawMessage(`{"confidence":1.5}`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMetadataSchema_UnknownKeysAllowed(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"team": {Type: MetadataFieldString, Required: true},
+		},
+	}
+
+	// Has required field plus unknown keys — should pass
+	errs := ValidateMetadataSchema(json.RawMessage(`{"team":"platform","foo":"bar","custom":123}`), schema)
+	if len(errs) != 0 {
+		t.Errorf("expected unknown keys to be allowed, got %v", errs)
+	}
+}
+
+func TestValidateMetadataSchema_NilMetadata(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"optional_field": {Type: MetadataFieldString},
+		},
+	}
+
+	// nil metadata with no required fields — should pass
+	errs := ValidateMetadataSchema(nil, schema)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for nil metadata with no required fields, got %v", errs)
+	}
+}
+
+func TestValidateMetadataSchema_NilMetadataWithRequired(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"team": {Type: MetadataFieldString, Required: true},
+		},
+	}
+
+	// nil metadata with required field — should fail
+	errs := ValidateMetadataSchema(nil, schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for nil metadata with required field, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMetadataSchema_NotAnObject(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"team": {Type: MetadataFieldString},
+		},
+	}
+
+	// Array metadata — should error
+	errs := ValidateMetadataSchema(json.RawMessage(`["a","b"]`), schema)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for non-object metadata, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != "(root)" {
+		t.Errorf("expected field '(root)', got %q", errs[0].Field)
+	}
+}
+
+func TestValidateMetadataSchema_MultipleErrors(t *testing.T) {
+	schema := MetadataSchemaConfig{
+		Mode: "error",
+		Fields: map[string]MetadataFieldSchema{
+			"team":     {Type: MetadataFieldEnum, Values: []string{"a", "b"}, Required: true},
+			"severity": {Type: MetadataFieldEnum, Values: []string{"low", "high"}, Required: true},
+		},
+	}
+
+	// Both required fields missing
+	errs := ValidateMetadataSchema(json.RawMessage(`{}`), schema)
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestMetadataValidationError_Error(t *testing.T) {
+	e := MetadataValidationError{Field: "team", Message: "required field is missing"}
+	want := "metadata.team: required field is missing"
+	if e.Error() != want {
+		t.Errorf("got %q, want %q", e.Error(), want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `validation.metadata` config in `.beads/config.yaml` for schema enforcement
- Projects define field types (`string`, `int`, `float`, `bool`, `enum`), `required` constraints, and `min`/`max` ranges
- Mode controls behavior: `none` (default), `warn` (stderr warnings), `error` (reject write)
- Enforcement runs in the storage layer (`CreateIssue`/`UpdateIssue`) — cannot be bypassed
- Unknown metadata keys always pass (extensibility preserved)
- Safe default: returns `none` if config is not initialized (batch tools, tests, integrations)

## Example config

```yaml
validation:
  metadata:
    mode: warn
    fields:
      team:
        type: enum
        values: [platform, frontend, backend, infra]
        required: true
      story_points:
        type: int
        min: 0
        max: 100
```

## Architecture

Implements Phase 2 of GH#1416, following Option A from Discussion #1588 (metadata blob is canonical).

- **Config accessor** (`internal/config/config.go`): `MetadataValidationMode()` and `MetadataSchemaFields()` with safe nil-viper defaults
- **Validation function** (`internal/storage/metadata.go`): Pure `ValidateMetadataSchema()` — takes metadata + schema, returns errors
- **Bridge** (`internal/storage/dolt/metadata_schema.go`): Parses raw config into schema structs, calls validator, handles warn vs error mode
- **Hooks** (`internal/storage/dolt/issues.go`): Called in `CreateIssue` (after issue validation) and `UpdateIssue` (after metadata normalization)

YAML-only config — no DB storage needed. The `validation.*` prefix is already treated as YAML-only by existing config rules.

## Test plan

- [x] 13 unit tests for `ValidateMetadataSchema` (required, enum, int, float, bool, string, unknown keys, nil metadata, non-object, multiple errors)
- [x] 4 unit tests for config parsing (`parseFieldSchema`, `toFloat64`)
- [x] 2 integration tests for safe defaults (`loadMetadataSchema`, `validateMetadataIfConfigured` with no config)
- [x] All existing storage, config, and cmd tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)