### PR TITLE
fix: reject non-positive --days flag on bd stale

### DIFF
--- a/cmd/bd/protocol/protocol_test.go
+++ b/cmd/bd/protocol/protocol_test.go
@@ -180,6 +180,16 @@ func (w *workspace) run(args ...string) string {
 	return string(out)
 }
 
+// tryRun runs a bd command and returns output + error (does not fatal on failure).
+func (w *workspace) tryRun(args ...string) (string, error) {
+	w.t.Helper()
+	cmd := exec.Command(w.bd, args...)
+	cmd.Dir = w.dir
+	cmd.Env = w.env()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // create runs bd create --silent and returns the issue ID.
 func (w *workspace) create(args ...string) string {
 	w.t.Helper()

--- a/cmd/bd/protocol/stale_test.go
+++ b/cmd/bd/protocol/stale_test.go
@@ -1,0 +1,24 @@
+package protocol
+
+import "testing"
+
+// TestProtocol_StaleRejectsNonPositiveDays asserts that bd stale rejects
+// --days values less than 1. Zero and negative days are nonsensical for
+// a staleness check and should fail with a non-zero exit code.
+func TestProtocol_StaleRejectsNonPositiveDays(t *testing.T) {
+	w := newWorkspace(t)
+
+	t.Run("zero", func(t *testing.T) {
+		_, err := w.tryRun("stale", "--days", "0")
+		if err == nil {
+			t.Error("bd stale --days 0 should fail but exited 0")
+		}
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		_, err := w.tryRun("stale", "--days", "-1")
+		if err == nil {
+			t.Error("bd stale --days -1 should fail but exited 0")
+		}
+	})
+}

--- a/cmd/bd/stale.go
+++ b/cmd/bd/stale.go
@@ -23,6 +23,9 @@ This helps identify:
 		status, _ := cmd.Flags().GetString("status")
 		limit, _ := cmd.Flags().GetInt("limit")
 		// Use global jsonOutput set by PersistentPreRun
+		if days < 1 {
+			FatalError("--days must be at least 1")
+		}
 		// Validate status if provided
 		if status != "" && status != "open" && status != "in_progress" && status != "blocked" && status != "deferred" {
 			FatalError("invalid status '%s'. Valid values: open, in_progress, blocked, deferred", status)


### PR DESCRIPTION
## Summary

- `bd stale --days 0` and `bd stale --days -1` silently returned no results instead of reporting an error
- Adds early validation: `days < 1` triggers `FatalError`, matching the existing status validation pattern in the same command
- Includes protocol test verifying both `--days 0` and `--days -1` are rejected

## Test plan

- [x] `go test ./cmd/bd/protocol/ -run TestProtocol_StaleRejectsNonPositiveDays` passes with fix
- [x] Same test fails without fix (both subtests report "should fail but exited 0")
- [x] `go vet ./cmd/bd/protocol/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)