### PR TITLE
fix: report correct status when reopen/undefer is a no-op

### DIFF
--- a/cmd/bd/protocol/lifecycle_test.go
+++ b/cmd/bd/protocol/lifecycle_test.go
@@ -1,0 +1,42 @@
+package protocol
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProtocol_ReopenAlreadyOpenReportsStatus asserts that bd reopen on an
+// already-open issue does NOT print a false "Reopened" message. The stderr
+// output should indicate the issue is already open.
+func TestProtocol_ReopenAlreadyOpenReportsStatus(t *testing.T) {
+	w := newWorkspace(t)
+	id := w.create("--title", "Already open", "--type", "task")
+
+	out, err := w.tryRun("reopen", id)
+	// Command may succeed (exit 0) or fail — either way, the output should
+	// NOT contain the false positive "Reopened" message.
+	_ = err
+	if strings.Contains(out, "Reopened") {
+		t.Errorf("bd reopen on already-open issue printed false 'Reopened' message:\n%s", out)
+	}
+	if !strings.Contains(out, "already open") {
+		t.Errorf("bd reopen on already-open issue should mention 'already open':\n%s", out)
+	}
+}
+
+// TestProtocol_UndeferNonDeferredReportsStatus asserts that bd undefer on a
+// non-deferred issue does NOT print a false "Undeferred" message. The stderr
+// output should indicate the issue is not deferred.
+func TestProtocol_UndeferNonDeferredReportsStatus(t *testing.T) {
+	w := newWorkspace(t)
+	id := w.create("--title", "Not deferred", "--type", "task")
+
+	out, err := w.tryRun("undefer", id)
+	_ = err
+	if strings.Contains(out, "Undeferred") {
+		t.Errorf("bd undefer on non-deferred issue printed false 'Undeferred' message:\n%s", out)
+	}
+	if !strings.Contains(out, "not deferred") {
+		t.Errorf("bd undefer on non-deferred issue should mention 'not deferred':\n%s", out)
+	}
+}

--- a/cmd/bd/protocol/protocol_test.go
+++ b/cmd/bd/protocol/protocol_test.go
@@ -180,6 +180,16 @@ func (w *workspace) run(args ...string) string {
 	return string(out)
 }
 
+// tryRun runs a bd command and returns output + error (does not fatal on failure).
+func (w *workspace) tryRun(args ...string) (string, error) {
+	w.t.Helper()
+	cmd := exec.Command(w.bd, args...)
+	cmd.Dir = w.dir
+	cmd.Env = w.env()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // create runs bd create --silent and returns the issue ID.
 func (w *workspace) create(args ...string) string {
 	w.t.Helper()

--- a/cmd/bd/reopen.go
+++ b/cmd/bd/reopen.go
@@ -39,6 +39,16 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
 				continue
 			}
+			// Skip if already open — avoid false "Reopened" message
+			issue, err := store.GetIssue(ctx, fullID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting %s: %v\n", fullID, err)
+				continue
+			}
+			if issue.Status == types.StatusOpen {
+				fmt.Fprintf(os.Stderr, "%s is already open\n", fullID)
+				continue
+			}
 			// UpdateIssue automatically clears closed_at when status changes from closed
 			updates := map[string]interface{}{
 				"status": string(types.StatusOpen),

--- a/cmd/bd/undefer.go
+++ b/cmd/bd/undefer.go
@@ -48,6 +48,17 @@ Examples:
 				continue
 			}
 
+			// Skip if not deferred — avoid false "Undeferred" message
+			issue, err := store.GetIssue(ctx, fullID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error getting %s: %v\n", fullID, err)
+				continue
+			}
+			if issue.Status != types.StatusDeferred {
+				fmt.Fprintf(os.Stderr, "%s is not deferred (status: %s)\n", fullID, string(issue.Status))
+				continue
+			}
+
 			updates := map[string]interface{}{
 				"status":      string(types.StatusOpen),
 				"defer_until": nil, // Clear defer_until timestamp (GH#820)


### PR DESCRIPTION
## Summary

- `bd reopen` on an already-open issue printed "Reopened" — now prints "already open" to stderr and skips
- `bd undefer` on a non-deferred issue printed "Undeferred (now open)" — now prints "not deferred" to stderr and skips
- Both commands check current status before operating, avoiding unnecessary updates and misleading output

## Changes

- `cmd/bd/reopen.go`: Add `GetIssue` check before update, skip with message if already open
- `cmd/bd/undefer.go`: Add `GetIssue` check before update, skip with message if not deferred
- `cmd/bd/protocol/protocol_test.go`: 2 new tests verifying correct messages

## Test plan

- [x] `TestProtocol_ReopenAlreadyOpenReportsStatus` passes with fix, fails without
- [x] `TestProtocol_UndeferNonDeferredReportsStatus` passes with fix, fails without
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)