### PR TITLE
fix: reject empty and whitespace-only comment text

### DIFF
--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -113,6 +113,10 @@ Examples:
 			commentText = args[1]
 		}
 
+		if strings.TrimSpace(commentText) == "" {
+			FatalErrorRespectJSON("comment text cannot be empty")
+		}
+
 		// Get author from author flag, or use git-aware default
 		author, _ := cmd.Flags().GetString("author")
 		if author == "" {

--- a/cmd/bd/protocol/comments_test.go
+++ b/cmd/bd/protocol/comments_test.go
@@ -1,0 +1,24 @@
+package protocol
+
+import "testing"
+
+// TestProtocol_CommentRejectsEmptyText asserts that bd comments add rejects
+// empty and whitespace-only comment text with a non-zero exit code.
+func TestProtocol_CommentRejectsEmptyText(t *testing.T) {
+	w := newWorkspace(t)
+	id := w.create("--title", "Comment target", "--type", "task")
+
+	t.Run("empty", func(t *testing.T) {
+		_, err := w.tryRun("comments", "add", id, "")
+		if err == nil {
+			t.Error("bd comments add with empty text should fail but exited 0")
+		}
+	})
+
+	t.Run("whitespace", func(t *testing.T) {
+		_, err := w.tryRun("comments", "add", id, "   ")
+		if err == nil {
+			t.Error("bd comments add with whitespace-only text should fail but exited 0")
+		}
+	})
+}

--- a/cmd/bd/protocol/protocol_test.go
+++ b/cmd/bd/protocol/protocol_test.go
@@ -180,6 +180,16 @@ func (w *workspace) run(args ...string) string {
 	return string(out)
 }
 
+// tryRun runs a bd command and returns output + error (does not fatal on failure).
+func (w *workspace) tryRun(args ...string) (string, error) {
+	w.t.Helper()
+	cmd := exec.Command(w.bd, args...)
+	cmd.Dir = w.dir
+	cmd.Env = w.env()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // create runs bd create --silent and returns the issue ID.
 func (w *workspace) create(args ...string) string {
 	w.t.Helper()


### PR DESCRIPTION
## Summary

- `bd comments add ISSUE ""` silently created a blank comment — now errors with "comment text cannot be empty"
- `bd comments add ISSUE "   "` (whitespace-only) also rejected
- Validation uses `strings.TrimSpace`, consistent with the empty-title check on `bd update`

## Test plan

- [x] `TestProtocol_CommentRejectsEmptyText/empty` passes with fix, fails without
- [x] `TestProtocol_CommentRejectsEmptyText/whitespace` passes with fix, fails without
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)