### PR TITLE
fix: warn when bd defer --until date is in the past

### DIFF
--- a/cmd/bd/defer.go
+++ b/cmd/bd/defer.go
@@ -40,6 +40,12 @@ Examples:
 			if err != nil {
 				FatalError("invalid --until format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", untilStr)
 			}
+			// Warn if defer date is in the past (user probably meant future)
+			if t.Before(time.Now()) && !jsonOutput {
+				fmt.Fprintf(os.Stderr, "%s Defer date %q is in the past. Issue will appear in bd ready immediately.\n",
+					ui.RenderWarn("!"), t.Format("2006-01-02 15:04"))
+				fmt.Fprintf(os.Stderr, "  Did you mean a future date? Use --until=+1h or --until=tomorrow\n")
+			}
 			deferUntil = &t
 		}
 

--- a/cmd/bd/protocol/defer_test.go
+++ b/cmd/bd/protocol/defer_test.go
@@ -1,0 +1,19 @@
+package protocol
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProtocol_DeferPastDateWarns asserts that bd defer --until with a past
+// date warns the user. The bd update --defer path already warns; bd defer
+// should be consistent.
+func TestProtocol_DeferPastDateWarns(t *testing.T) {
+	w := newWorkspace(t)
+	id := w.create("--title", "Defer target", "--type", "task")
+
+	out, _ := w.tryRun("defer", id, "--until=2020-01-01")
+	if !strings.Contains(out, "past") {
+		t.Errorf("bd defer --until=<past date> should warn about past date:\n%s", out)
+	}
+}

--- a/cmd/bd/protocol/protocol_test.go
+++ b/cmd/bd/protocol/protocol_test.go
@@ -180,6 +180,16 @@ func (w *workspace) run(args ...string) string {
 	return string(out)
 }
 
+// tryRun runs a bd command and returns output + error (does not fatal on failure).
+func (w *workspace) tryRun(args ...string) (string, error) {
+	w.t.Helper()
+	cmd := exec.Command(w.bd, args...)
+	cmd.Dir = w.dir
+	cmd.Env = w.env()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // create runs bd create --silent and returns the issue ID.
 func (w *workspace) create(args ...string) string {
 	w.t.Helper()


### PR DESCRIPTION
## Summary

- `bd defer ISSUE --until=2020-01-01` silently stored the past date with no warning
- `bd update ISSUE --defer=2020-01-01` already warns — this makes `bd defer` consistent
- Warning prints to stderr: "Defer date is in the past. Issue will appear in bd ready immediately."

## Test plan

- [x] `TestProtocol_DeferPastDateWarns` passes with fix, fails without
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)