### PR TITLE
fix(doctor): gracefully handle non-git-repo in fingerprint and role checks

### DIFF
--- a/cmd/bd/doctor/integrity.go
+++ b/cmd/bd/doctor/integrity.go
@@ -360,6 +360,13 @@ func CheckRepoFingerprint(path string) DoctorCheck {
 
 		currentRepoID, err := beads.ComputeRepoID()
 		if err != nil {
+			if strings.Contains(err.Error(), "not a git repository") {
+				return DoctorCheck{
+					Name:    "Repo Fingerprint",
+					Status:  StatusOK,
+					Message: "N/A (not a git repository)",
+				}
+			}
 			return DoctorCheck{
 				Name:    "Repo Fingerprint",
 				Status:  StatusWarning,
@@ -451,6 +458,13 @@ func CheckRepoFingerprint(path string) DoctorCheck {
 	// Compute current repo ID
 	currentRepoID, err := beads.ComputeRepoID()
 	if err != nil {
+		if strings.Contains(err.Error(), "not a git repository") {
+			return DoctorCheck{
+				Name:    "Repo Fingerprint",
+				Status:  StatusOK,
+				Message: "N/A (not a git repository)",
+			}
+		}
 		return DoctorCheck{
 			Name:    "Repo Fingerprint",
 			Status:  StatusWarning,

--- a/cmd/bd/doctor/role_test.go
+++ b/cmd/bd/doctor/role_test.go
@@ -95,18 +95,22 @@ func TestCheckBeadsRole_NotGitRepo(t *testing.T) {
 	// Don't initialize git - just a plain directory
 	check := CheckBeadsRole(tmpDir)
 
-	// Should return warning since git config will fail
-	if check.Status != StatusWarning {
-		t.Errorf("expected status %s, got %s", StatusWarning, check.Status)
+	// Should return OK/N/A since we're not in a git repo — the role may
+	// be correctly configured in a worktree (e.g., rig roots use .repo.git).
+	if check.Status != StatusOK {
+		t.Errorf("expected status %s, got %s", StatusOK, check.Status)
+	}
+	if check.Message != "N/A (not a git repository)" {
+		t.Errorf("expected message 'N/A (not a git repository)', got %q", check.Message)
 	}
 }
 
 func TestCheckBeadsRole_NonexistentPath(t *testing.T) {
-	// Test with a path that doesn't exist
+	// Test with a path that doesn't exist — git will report "not a git repository"
 	check := CheckBeadsRole(filepath.Join(os.TempDir(), "nonexistent-beads-test-dir"))
 
-	// Should return warning since git config will fail
-	if check.Status != StatusWarning {
-		t.Errorf("expected status %s, got %s", StatusWarning, check.Status)
+	// Should return OK/N/A since the path is not a git repository
+	if check.Status != StatusOK {
+		t.Errorf("expected status %s, got %s", StatusOK, check.Status)
 	}
 }


### PR DESCRIPTION
## Summary

- Repo Fingerprint check now returns N/A instead of warning when `ComputeRepoID()` fails with "not a git repository"
- Role Configuration check now detects non-git-repo directories and returns N/A instead of "beads.role not configured"
- Both Dolt and SQLite code paths in fingerprint check are covered

Fixes the spurious warnings when `bd doctor` runs from a directory that isn't a standard git repository (e.g., rig roots that use `.repo.git` instead of `.git`).

## Test plan

- [x] All 6 existing role tests pass (updated 2 to expect new N/A behavior)
- [x] Pre-existing validation test failures confirmed unrelated (fail on base commit too)
- [x] Full `go build ./cmd/bd/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)