### PR TITLE
fix: include waits-for deps in bd blocked output

### DIFF
--- a/cmd/bd/protocol/blocked_test.go
+++ b/cmd/bd/protocol/blocked_test.go
@@ -1,0 +1,52 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestProtocol_WaitsForAppearsInBlocked asserts that an issue blocked by a
+// waits-for dependency appears in bd blocked output. Previously,
+// GetBlockedIssues only checked 'blocks' deps, making waits-for blocked
+// issues invisible to both bd ready and bd blocked.
+func TestProtocol_WaitsForAppearsInBlocked(t *testing.T) {
+	w := newWorkspace(t)
+
+	// Create a spawner (parent) and a gate issue
+	spawner := w.create("--title", "Spawner", "--type", "epic")
+	gate := w.create("--title", "Gate issue", "--type", "task")
+
+	// Create a child of the spawner so the waits-for gate is active.
+	// The all-children gate blocks while any child of the spawner is active.
+	_ = w.create("--title", "Child task", "--type", "task", "--parent", spawner)
+
+	// Add waits-for dependency: gate waits-for spawner's children
+	w.run("dep", "add", gate, spawner, "--type", "waits-for")
+
+	// Verify gate does NOT appear in bd ready
+	readyIDs := parseReadyIDs(t, w)
+	if readyIDs[gate] {
+		t.Errorf("gate issue %s should NOT be in bd ready (has waits-for dep on %s)", gate, spawner)
+	}
+
+	// Verify gate DOES appear in bd blocked
+	blockedOut := w.run("blocked", "--json")
+	var blocked []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(blockedOut), &blocked); err != nil {
+		t.Fatalf("failed to parse bd blocked --json: %v\noutput: %s", err, blockedOut)
+	}
+
+	found := false
+	for _, b := range blocked {
+		if b.ID == gate {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("gate issue %s should appear in bd blocked (waits-for %s with active child)",
+			gate, spawner)
+	}
+}

--- a/cmd/bd/protocol/protocol_test.go
+++ b/cmd/bd/protocol/protocol_test.go
@@ -180,6 +180,16 @@ func (w *workspace) run(args ...string) string {
 	return string(out)
 }
 
+// tryRun runs a bd command and returns output + error (does not fatal on failure).
+func (w *workspace) tryRun(args ...string) (string, error) {
+	w.t.Helper()
+	cmd := exec.Command(w.bd, args...)
+	cmd.Dir = w.dir
+	cmd.Env = w.env()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
 // create runs bd create --silent and returns the issue ID.
 func (w *workspace) create(args ...string) string {
 	w.t.Helper()


### PR DESCRIPTION
## Summary
- `GetBlockedIssues` only checked `blocks` dependencies, ignoring `waits-for` gates
- Issues blocked by `waits-for` were invisible to both `bd ready` and `bd blocked`
- Now uses `computeBlockedIDs` (which already handles both dep types with full gate evaluation) as the canonical source of truth for which issues are blocked

## Test plan
- [x] Protocol test: `TestProtocol_WaitsForAppearsInBlocked` — creates a waits-for gate with an active child, verifies the gate appears in `bd blocked`
- [x] Test fails without fix, passes with fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)