### PR TITLE
fix: validate JSON metadata on issue creation path

### DIFF
--- a/internal/storage/dolt/metadata_validation_test.go
+++ b/internal/storage/dolt/metadata_validation_test.go
@@ -1,0 +1,33 @@
+package dolt
+
+import "testing"
+
+func TestJsonMetadata_NilReturnsEmptyObject(t *testing.T) {
+	got := jsonMetadata(nil)
+	if got != "{}" {
+		t.Errorf("jsonMetadata(nil) = %q, want %q", got, "{}")
+	}
+}
+
+func TestJsonMetadata_EmptyReturnsEmptyObject(t *testing.T) {
+	got := jsonMetadata([]byte{})
+	if got != "{}" {
+		t.Errorf("jsonMetadata(empty) = %q, want %q", got, "{}")
+	}
+}
+
+func TestJsonMetadata_ValidJSONPassesThrough(t *testing.T) {
+	input := []byte(`{"key":"value"}`)
+	got := jsonMetadata(input)
+	if got != `{"key":"value"}` {
+		t.Errorf("jsonMetadata(%q) = %q, want %q", input, got, `{"key":"value"}`)
+	}
+}
+
+func TestJsonMetadata_InvalidJSONFallsBackToEmptyObject(t *testing.T) {
+	input := []byte(`{not valid json`)
+	got := jsonMetadata(input)
+	if got != "{}" {
+		t.Errorf("jsonMetadata(%q) = %q, want %q (should reject invalid JSON)", input, got, "{}")
+	}
+}


### PR DESCRIPTION
## Summary
- The `jsonMetadata` helper used during issue creation (`insertIssue`) did not validate that metadata was well-formed JSON
- The update path (`UpdateIssue`) validates via `NormalizeMetadataValue`, but creation skipped validation
- Invalid JSON metadata would cause a Dolt JSON column insert error with an unclear message
- Now validates with `json.Valid()` and falls back to `"{}"` on invalid input, matching the defensive behavior of the update path

## Test plan
- [x] `go build` and `go vet` pass cleanly
- [x] Existing metadata round-trip tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)