### PR TITLE
fix(lint): check AcceptanceCriteria field in LintIssue

### DIFF
--- a/internal/validation/template.go
+++ b/internal/validation/template.go
@@ -73,10 +73,16 @@ func ValidateTemplate(issueType types.IssueType, description string) error {
 
 // LintIssue checks an existing issue for missing template sections.
 // Unlike ValidateTemplate, this operates on a full Issue struct.
+// It checks both Description and AcceptanceCriteria fields, since
+// required sections (like "## Acceptance Criteria") may appear in either.
 // Returns nil if the issue passes validation or has no requirements.
 func LintIssue(issue *types.Issue) error {
 	if issue == nil {
 		return nil
 	}
-	return ValidateTemplate(issue.IssueType, issue.Description)
+	text := issue.Description
+	if issue.AcceptanceCriteria != "" {
+		text = text + "\n" + issue.AcceptanceCriteria
+	}
+	return ValidateTemplate(issue.IssueType, text)
 }

--- a/internal/validation/template_test.go
+++ b/internal/validation/template_test.go
@@ -235,6 +235,24 @@ func TestLintIssue(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "bug with acceptance in dedicated field",
+			issue: &types.Issue{
+				IssueType:          types.TypeBug,
+				Description:        "## Steps to Reproduce\nClick button",
+				AcceptanceCriteria: "## Acceptance Criteria\nButton works",
+			},
+			wantErr: false,
+		},
+		{
+			name: "task with acceptance in dedicated field",
+			issue: &types.Issue{
+				IssueType:          types.TypeTask,
+				Description:        "Do the thing",
+				AcceptanceCriteria: "Acceptance Criteria: thing is done",
+			},
+			wantErr: false,
+		},
+		{
 			name: "chore always valid",
 			issue: &types.Issue{
 				IssueType:   types.TypeChore,


### PR DESCRIPTION
## Summary

- `LintIssue()` now checks both `Description` and `AcceptanceCriteria` fields when validating required template sections
- Adds two test cases covering the dedicated field path for bug and task types

## Problem

`bd lint` reports missing "Acceptance Criteria" sections even when they exist in the dedicated `AcceptanceCriteria` field. This happens because `LintIssue()` only passes `issue.Description` to `ValidateTemplate()`, ignoring the structured field entirely.

For example, a bug issue with `Steps to Reproduce` in the description and `Acceptance Criteria` in the dedicated field would incorrectly fail lint with:

```
missing required sections for bug:
  - ## Acceptance Criteria (Define criteria to verify the fix)
```

## Solution

`LintIssue()` now concatenates `Description` and `AcceptanceCriteria` before passing to `ValidateTemplate()`. This way, required sections found in either field satisfy the lint check. The `AcceptanceCriteria` field is only appended when non-empty to avoid spurious whitespace.

## Testing

- `go test ./internal/validation/ -run LintIssue -v -count=1` — 6/6 pass
- New test: `bug with acceptance in dedicated field` — bug with steps in Description, acceptance in AcceptanceCriteria field
- New test: `task with acceptance in dedicated field` — task with acceptance in dedicated field using inline text (no markdown heading)
- `go vet ./internal/validation/` — clean
- `make build` — succeeds

Closes #1472