### PR TITLE
fix(storage): find ephemeral beads with explicit IDs in single-bead lookups

### DIFF
--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -1728,3 +1728,113 @@ func assertOrder(t *testing.T, ids []string, expected ...string) {
 		t.Errorf("expected order %v but got %v (matched %d of %d)", expected, ids, pos, len(expected))
 	}
 }
+
+// TestEphemeralExplicitID_GetIssue verifies that GetIssue finds ephemeral beads
+// created with explicit (non-wisp) IDs. Regression test for GH#2053.
+func TestEphemeralExplicitID_GetIssue(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Create an ephemeral bead with an explicit ID (no -wisp- in name)
+	issue := &types.Issue{
+		ID:        "test-agent-emma",
+		Title:     "Agent: test-agent-emma",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, issue, "test-user"); err != nil {
+		t.Fatalf("CreateIssue (ephemeral with explicit ID) failed: %v", err)
+	}
+
+	// GetIssue should find it (this was the GH#2053 bug)
+	got, err := store.GetIssue(ctx, "test-agent-emma")
+	if err != nil {
+		t.Fatalf("GetIssue failed for ephemeral bead with explicit ID: %v", err)
+	}
+	if got.ID != "test-agent-emma" {
+		t.Errorf("Expected ID %q, got %q", "test-agent-emma", got.ID)
+	}
+	if !got.Ephemeral {
+		t.Error("Expected Ephemeral=true")
+	}
+}
+
+// TestEphemeralExplicitID_UpdateIssue verifies that UpdateIssue works on
+// ephemeral beads created with explicit IDs. Regression test for GH#2053.
+func TestEphemeralExplicitID_UpdateIssue(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "test-agent-max",
+		Title:     "Agent: test-agent-max",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, issue, "test-user"); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+
+	// UpdateIssue should work (this was broken per GH#2053)
+	updates := map[string]interface{}{
+		"agent_state": "running",
+	}
+	if err := store.UpdateIssue(ctx, "test-agent-max", updates, "test-user"); err != nil {
+		t.Fatalf("UpdateIssue failed for ephemeral bead with explicit ID: %v", err)
+	}
+
+	// Verify the update persisted
+	got, err := store.GetIssue(ctx, "test-agent-max")
+	if err != nil {
+		t.Fatalf("GetIssue after update failed: %v", err)
+	}
+	if got.AgentState != "running" {
+		t.Errorf("Expected agent_state %q, got %q", "running", got.AgentState)
+	}
+}
+
+// TestEphemeralExplicitID_SearchIssues verifies that SearchIssues finds
+// ephemeral beads with explicit IDs (this already worked pre-fix via wisp merge).
+func TestEphemeralExplicitID_SearchIssues(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "test-agent-furiosa",
+		Title:     "Agent: test-agent-furiosa",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, issue, "test-user"); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+
+	// SearchIssues with nil Ephemeral filter should find it (merges wisps)
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		IDs: []string{"test-agent-furiosa"},
+	})
+	if err != nil {
+		t.Fatalf("SearchIssues failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != "test-agent-furiosa" {
+		t.Errorf("Expected ID %q, got %q", "test-agent-furiosa", results[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary

- `isActiveWisp()` now checks the wisps table for all IDs, not just those matching the `-wisp-` pattern
- Adds lightweight `SELECT 1` existence check as fallback for non-wisp-named IDs
- Preserves the full-row-scan fast path for auto-generated `-wisp-` IDs

## Problem

Ephemeral beads created with explicit IDs (`bd create --ephemeral --id=gt-emma`) are stored in the wisps table but invisible to single-bead lookup commands. `bd list` finds them fine (via wisp merge in `SearchIssues`), but `bd show`, `bd update`, `bd agent state`, `bd agent show`, and `bd agent heartbeat` all fail with "not found".

The root cause: `isActiveWisp()` gates on `IsEphemeralID()` which checks for `-wisp-` in the ID string. Explicit IDs like `gt-emma` don't contain `-wisp-`, so `isActiveWisp()` returns false and the lookup falls through to only the `issues` table — missing the bead in the `wisps` table entirely.

This breaks Gas Town's `SetAgentState` flow: polecat agent beads are created as ephemeral, then `bd agent state <id> running` fails because the agent bead can't be found.

## Solution

Remove the `IsEphemeralID()` early-return guard from `isActiveWisp()`. Instead:

1. **Fast path** (unchanged): IDs matching `-wisp-` do a full row scan via `getWisp()`
2. **Fallback** (new): Other IDs do a lightweight `SELECT 1 FROM wisps WHERE id = ? LIMIT 1` existence check

This fixes all 20+ call sites that route through `isActiveWisp()`: `GetIssue`, `UpdateIssue`, `ClaimIssue`, `CloseIssue`, `DeleteIssue`, plus all dependency and label operations.

## Testing

- 3 new regression tests: `TestEphemeralExplicitID_GetIssue`, `TestEphemeralExplicitID_UpdateIssue`, `TestEphemeralExplicitID_SearchIssues`
- All existing ephemeral/wisp tests pass
- Manual verification: `bd create --ephemeral --id=bd-ephtest1`, `bd show`, `bd update`, `bd close` all work

Closes #2053