### PR TITLE
fix: auto-clean stale Dolt noms LOCK files on bd startup

### DIFF
--- a/cmd/bd/doctor/locks.go
+++ b/cmd/bd/doctor/locks.go
@@ -67,10 +67,10 @@ func CheckStaleLockFiles(path string) DoctorCheck {
 	}
 
 	// Note: Dolt internal noms LOCK files (.beads/dolt/<db>/.dolt/noms/LOCK)
-	// are NOT checked here. These files are created by the embedded Dolt engine
-	// and are never deleted, even after a clean close. Age-based detection
-	// produces false positives because the file persists indefinitely.
-	// Use CheckLockHealth() (which probes flock state) instead. (GH#1981)
+	// are NOT checked here as diagnostics. These are auto-cleaned on bd startup
+	// (pre-flight in PersistentPreRun) and by 'bd doctor --fix'. Stale noms LOCK
+	// files from crashed processes would prevent the Dolt server from opening
+	// databases. The auto-cleanup makes this a non-issue for most users.
 
 	// Check startup lock (bd.sock.startlock)
 	// Look for any .startlock files in beadsDir

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -509,6 +509,14 @@ var rootCmd = &cobra.Command{
 		}
 
 		doltCfg.Path = doltPath
+
+		// Pre-flight: clean stale noms LOCK files left by crashed Dolt processes.
+		// These prevent the Dolt server from opening databases (SIGSEGV or
+		// "database is locked"). Safe because we haven't connected yet.
+		if removed, _ := dolt.CleanStaleNomsLocks(doltPath); removed > 0 {
+			debug.Logf("cleaned %d stale noms LOCK file(s) from %s", removed, doltPath)
+		}
+
 		store, err = dolt.New(rootCtx, doltCfg)
 
 		// Track final read-only state for staleness checks (GH#1089)

--- a/internal/storage/dolt/noms_lock.go
+++ b/internal/storage/dolt/noms_lock.go
@@ -1,0 +1,48 @@
+package dolt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CleanStaleNomsLocks removes stale Dolt noms LOCK files from all databases
+// in the given dolt directory (typically .beads/dolt/).
+//
+// Dolt's noms storage layer creates a file-based LOCK at
+// <db>/.dolt/noms/LOCK when opening a database. If the process is killed
+// uncleanly (SIGKILL, OOM, etc.), this LOCK file persists and prevents the
+// Dolt server from opening the database on restart — causing either a SIGSEGV
+// (nil pointer dereference in DoltDB.SetCrashOnFatalError) or a "database is
+// locked" error.
+//
+// This function is safe to call before starting or connecting to a Dolt server
+// because the server is not yet using the databases. It scans all subdirectories
+// of doltDir for <db>/.dolt/noms/LOCK and removes them.
+//
+// Returns the number of lock files removed. Errors removing individual files
+// are collected but do not abort the scan.
+func CleanStaleNomsLocks(doltDir string) (removed int, errs []error) {
+	entries, err := os.ReadDir(doltDir)
+	if err != nil {
+		// Directory doesn't exist or can't be read — nothing to clean.
+		return 0, nil
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		lockPath := filepath.Join(doltDir, entry.Name(), ".dolt", "noms", "LOCK")
+		if _, statErr := os.Stat(lockPath); os.IsNotExist(statErr) {
+			continue
+		}
+		if rmErr := os.Remove(lockPath); rmErr != nil {
+			errs = append(errs, fmt.Errorf("removing %s: %w", lockPath, rmErr))
+		} else {
+			removed++
+		}
+	}
+
+	return removed, errs
+}

--- a/internal/storage/dolt/noms_lock_test.go
+++ b/internal/storage/dolt/noms_lock_test.go
@@ -1,0 +1,133 @@
+package dolt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanStaleNomsLocks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes stale LOCK file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		// Create a database directory with a stale noms LOCK
+		nomsDir := filepath.Join(dir, "mydb", ".dolt", "noms")
+		if err := os.MkdirAll(nomsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		lockPath := filepath.Join(nomsDir, "LOCK")
+		if err := os.WriteFile(lockPath, []byte("stale"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		removed, errs := CleanStaleNomsLocks(dir)
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if removed != 1 {
+			t.Fatalf("expected 1 removed, got %d", removed)
+		}
+
+		// Verify file is gone
+		if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+			t.Fatal("LOCK file should have been removed")
+		}
+	})
+
+	t.Run("handles multiple databases", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		// Create two databases with stale locks
+		for _, db := range []string{"db1", "db2"} {
+			nomsDir := filepath.Join(dir, db, ".dolt", "noms")
+			if err := os.MkdirAll(nomsDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(nomsDir, "LOCK"), []byte("stale"), 0600); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		removed, errs := CleanStaleNomsLocks(dir)
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if removed != 2 {
+			t.Fatalf("expected 2 removed, got %d", removed)
+		}
+	})
+
+	t.Run("no lock files present", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		// Create a database directory without a LOCK file
+		nomsDir := filepath.Join(dir, "mydb", ".dolt", "noms")
+		if err := os.MkdirAll(nomsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		removed, errs := CleanStaleNomsLocks(dir)
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if removed != 0 {
+			t.Fatalf("expected 0 removed, got %d", removed)
+		}
+	})
+
+	t.Run("directory does not exist", func(t *testing.T) {
+		t.Parallel()
+		removed, errs := CleanStaleNomsLocks("/nonexistent/path/that/does/not/exist")
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if removed != 0 {
+			t.Fatalf("expected 0 removed, got %d", removed)
+		}
+	})
+
+	t.Run("skips non-directory entries", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		// Create a regular file (not a directory) at the top level
+		if err := os.WriteFile(filepath.Join(dir, "not-a-dir"), []byte("data"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a real database with a lock
+		nomsDir := filepath.Join(dir, "realdb", ".dolt", "noms")
+		if err := os.MkdirAll(nomsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(nomsDir, "LOCK"), []byte("stale"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		removed, errs := CleanStaleNomsLocks(dir)
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if removed != 1 {
+			t.Fatalf("expected 1 removed, got %d", removed)
+		}
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		removed, errs := CleanStaleNomsLocks(dir)
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if removed != 0 {
+			t.Fatalf("expected 0 removed, got %d", removed)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `CleanStaleNomsLocks()` to `internal/storage/dolt/` that scans a dolt data directory and removes stale `noms/LOCK` files left by crashed Dolt processes
- Call it pre-flight in `PersistentPreRun` before connecting to the Dolt server — prevents SIGSEGV or "database is locked" errors on restart
- Update `doctor/fix/locks.go` to remove the flock probe dependency for noms LOCK cleanup — the probe was designed for the now-removed embedded mode and is unreliable in server mode

## Context

When a Dolt server process is killed uncleanly (SIGKILL, OOM, tmux kill-session), it leaves behind `.dolt/noms/LOCK` files. On restart, these stale LOCK files prevent the server from opening databases, causing either:
- SIGSEGV nil pointer dereference in `DoltDB.SetCrashOnFatalError`
- "database is locked by another dolt process" error

This is highly disruptive in Gas Town where agent processes are frequently killed and restarted.

## Changes

| File | Change |
|------|--------|
| `internal/storage/dolt/noms_lock.go` | New `CleanStaleNomsLocks()` function |
| `internal/storage/dolt/noms_lock_test.go` | 6 test cases covering all edge cases |
| `cmd/bd/main.go` | Pre-flight cleanup call before `dolt.New()` |
| `cmd/bd/doctor/fix/locks.go` | Remove flock probe gate for noms LOCK removal |
| `cmd/bd/doctor/fix/locks_test.go` | Update test expectations for new behavior |
| `cmd/bd/doctor/locks.go` | Update diagnostic comment |

## Test plan

- [x] `go test ./internal/storage/dolt/ -run TestCleanStaleNomsLocks` — 6/6 pass
- [x] `go test ./cmd/bd/doctor/fix/ -run TestStaleLockFiles` — 8/8 pass
- [x] `go test ./cmd/bd/doctor/fix/ -run TestProbeStale` — 3/3 pass
- [x] Manual verification: created stale LOCK file, ran `bd list --verbose`, confirmed cleanup message and file removal
- [ ] Existing tests: `go test ./internal/storage/dolt/...` (requires running Dolt server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)