### PR TITLE
docs(setup): use --claim in generated templates

### DIFF
--- a/cmd/bd/@AGENTS.md
+++ b/cmd/bd/@AGENTS.md
@@ -7,7 +7,7 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 ```bash
 bd ready              # Find available work
 bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
+bd update <id> --claim  # Claim work atomically
 bd close <id>         # Complete work
 bd dolt push          # Push to Dolt remote
 ```
@@ -36,4 +36,3 @@ bd dolt push          # Push to Dolt remote
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
-

--- a/cmd/bd/setup/aider.go
+++ b/cmd/bd/setup/aider.go
@@ -31,7 +31,7 @@ This project uses **Beads (bd)** for issue tracking. Aider requires explicit com
 - ` + "`bd ready`" + ` - Show unblocked issues
 - ` + "`bd list --status=open`" + ` - List all open issues
 - ` + "`bd create --title=\"...\" --type=task`" + ` - Create new issue
-- ` + "`bd update <id> --status=in_progress`" + ` - Claim work
+- ` + "`bd update <id> --claim`" + ` - Claim work atomically
 - ` + "`bd close <id>`" + ` - Mark complete
 - ` + "`bd dep add <issue> <depends-on>`" + ` - Add dependency (issue depends on depends-on)
 - ` + "`bd sync`" + ` - Sync with git remote
@@ -39,7 +39,7 @@ This project uses **Beads (bd)** for issue tracking. Aider requires explicit com
 ## Workflow Pattern to Suggest
 
 1. **Check ready work**: "Let's run ` + "`/run bd ready`" + ` to see what's available"
-2. **Claim task**: "Run ` + "`/run bd update <id> --status=in_progress`" + ` to claim it"
+2. **Claim task**: "Run ` + "`/run bd update <id> --claim`" + ` to claim it atomically"
 3. **Do the work**
 4. **Complete**: "Run ` + "`/run bd close <id>`" + ` when done"
 5. **Sync**: "Run ` + "`/run bd sync`" + ` to push changes"
@@ -97,7 +97,7 @@ The AI will **suggest** bd commands, but you must confirm them.
 
 3. Claim work:
    ` + "```bash" + `
-   /run bd update bd-42 --status in_progress
+   /run bd update bd-42 --claim
    ` + "```" + `
 
 4. Complete work:

--- a/cmd/bd/setup/cursor.go
+++ b/cmd/bd/setup/cursor.go
@@ -25,7 +25,7 @@ bd prime                              # Load complete workflow context
 bd ready                              # Show issues ready to work (no blockers)
 bd list --status=open                 # List all open issues
 bd create --title="..." --type=task  # Create new issue
-bd update <id> --status=in_progress  # Claim work
+bd update <id> --claim               # Claim work atomically
 bd close <id>                         # Mark complete
 bd dep add <issue> <depends-on>       # Add dependency (issue depends on depends-on)
 bd sync                               # Sync with git remote
@@ -33,7 +33,7 @@ bd sync                               # Sync with git remote
 
 ## Workflow
 1. Check for ready work: ` + "`bd ready`" + `
-2. Claim an issue: ` + "`bd update <id> --status=in_progress`" + `
+2. Claim an issue atomically: ` + "`bd update <id> --claim`" + `
 3. Do the work
 4. Mark complete: ` + "`bd close <id>`" + `
 5. Sync: ` + "`bd sync`" + ` (or let git hooks handle it)

--- a/cmd/bd/setup/junie.go
+++ b/cmd/bd/setup/junie.go
@@ -36,7 +36,7 @@ bd create "Found bug" --description="Details" --deps discovered-from:bd-42 --jso
 
 ### Working on Issues
 ` + "```bash" + `
-bd update <id> --status in_progress  # Claim work
+bd update <id> --claim               # Claim work atomically
 bd update <id> --priority 1          # Change priority
 bd close <id> --reason "Completed"   # Mark complete
 ` + "```" + `

--- a/internal/recipes/template.go
+++ b/internal/recipes/template.go
@@ -21,7 +21,7 @@ bd prime                              # Load complete workflow context
 bd ready                              # Show issues ready to work (no blockers)
 bd list --status=open                 # List all open issues
 bd create --title="..." --type=task   # Create new issue
-bd update <id> --status=in_progress   # Claim work
+bd update <id> --claim                # Claim work atomically
 bd close <id>                         # Mark complete
 bd dep add <issue> <depends-on>       # Add dependency
 bd sync                               # Sync with git remote
@@ -30,7 +30,7 @@ bd sync                               # Sync with git remote
 ## Workflow
 
 1. Check for ready work: ` + "`bd ready`" + `
-2. Claim an issue: ` + "`bd update <id> --status=in_progress`" + `
+2. Claim an issue atomically: ` + "`bd update <id> --claim`" + `
 3. Do the work
 4. Mark complete: ` + "`bd close <id>`" + `
 5. Sync: ` + "`bd sync`" + ` (or let git hooks handle it)

--- a/internal/templates/agents/defaults/agents.md.tmpl
+++ b/internal/templates/agents/defaults/agents.md.tmpl
@@ -7,7 +7,7 @@ This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get sta
 ```bash
 bd ready              # Find available work
 bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
+bd update <id> --claim  # Claim work atomically
 bd close <id>         # Complete work
 bd sync               # Sync with git
 ```
@@ -42,7 +42,7 @@ bd create "Issue title" --description="What this issue is about" -p 1 --deps dis
 **Claim and update:**
 
 ```bash
-bd update bd-42 --status in_progress --json
+bd update <id> --claim --json
 bd update bd-42 --priority 1 --json
 ```
 
@@ -71,7 +71,7 @@ bd close bd-42 --reason "Completed" --json
 ### Workflow for AI Agents
 
 1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task**: `bd update <id> --status in_progress`
+2. **Claim your task atomically**: `bd update <id> --claim`
 3. **Work on it**: Implement, test, document
 4. **Discover new work?** Create linked issue:
    - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`

--- a/internal/templates/agents/defaults/beads-section.md
+++ b/internal/templates/agents/defaults/beads-section.md
@@ -28,7 +28,7 @@ bd create "Issue title" --description="What this issue is about" -p 1 --deps dis
 **Claim and update:**
 
 ```bash
-bd update bd-42 --status in_progress --json
+bd update <id> --claim --json
 bd update bd-42 --priority 1 --json
 ```
 
@@ -57,7 +57,7 @@ bd close bd-42 --reason "Completed" --json
 ### Workflow for AI Agents
 
 1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task**: `bd update <id> --status in_progress`
+2. **Claim your task atomically**: `bd update <id> --claim`
 3. **Work on it**: Implement, test, document
 4. **Discover new work?** Create linked issue:
    - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`


### PR DESCRIPTION
Follow-up to #1920.

This updates remaining generated setup/agent templates that still showed claim flows as `bd update <id> --status in_progress`.

## Why
`bd update <id> --claim` is the atomic claim path (assignee + `in_progress` via CAS), so it is safer for concurrent agents than status-only updates.

## Changes
- Updated embedded AGENTS templates used by `bd setup codex` and `bd init`:
  - `internal/templates/agents/defaults/beads-section.md`
  - `internal/templates/agents/defaults/agents.md.tmpl`
- Updated setup recipe templates:
  - `cmd/bd/setup/aider.go`
  - `cmd/bd/setup/cursor.go`
  - `cmd/bd/setup/junie.go`
  - `internal/recipes/template.go`
- Updated local agent quick-reference doc:
  - `cmd/bd/@AGENTS.md`

## Validation
- `go test ./internal/templates/agents`
- `go test ./internal/recipes`
- `go test ./cmd/bd/setup -run 'Test(UpdateBeadsSection|CreateNewAgentsFile|InstallFactoryCreatesNewFile|InstallFactoryUpdatesExistingSection|InstallAider|InstallCursor|InstallJunie|CheckFactoryScenarios)$' -count=1`

Note: baseline test `TestWrapperExitsOnError/RemoveFactory` fails on `origin/main` as well (unrelated to this change).
