### PR TITLE
fix(ci): unblock baseline Windows smoke, lint, and fmt checks (unblock many other PRs — it fixes several tests)

### DIFF
--- a/cmd/bd/doctor/federation.go
+++ b/cmd/bd/doctor/federation.go
@@ -23,13 +23,13 @@ func doltDatabaseName(beadsDir string) string {
 	return dbName
 }
 
-// doltServerConfig returns a dolt.Config populated with server connection settings
-// from the beads configuration. This ensures federation checks use the configured
-// host/port rather than falling back to defaults.
-func doltServerConfig(beadsDir, doltPath string, readOnly bool) *dolt.Config {
+// doltServerConfig returns a read-only dolt.Config populated with server
+// connection settings from beads configuration. This ensures federation checks
+// use the configured host/port rather than falling back to defaults.
+func doltServerConfig(beadsDir, doltPath string) *dolt.Config {
 	cfg := &dolt.Config{
 		Path:     doltPath,
-		ReadOnly: readOnly,
+		ReadOnly: true,
 		Database: doltDatabaseName(beadsDir),
 	}
 	if bcfg, err := configfile.Load(beadsDir); err == nil && bcfg != nil {
@@ -74,7 +74,7 @@ func CheckFederationRemotesAPI(path string) DoctorCheck {
 	if !serverRunning {
 		// No server running - check if we have remotes configured
 		ctx := context.Background()
-		store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath, true))
+		store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath))
 		if err != nil {
 			return DoctorCheck{
 				Name:     "Federation remotesapi",
@@ -159,7 +159,7 @@ func CheckFederationPeerConnectivity(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath, true))
+	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath))
 	if err != nil {
 		return DoctorCheck{
 			Name:     "Peer Connectivity",
@@ -276,7 +276,7 @@ func CheckFederationSyncStaleness(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath, true))
+	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath))
 	if err != nil {
 		return DoctorCheck{
 			Name:     "Sync Staleness",
@@ -369,7 +369,7 @@ func CheckFederationConflicts(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath, true))
+	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath))
 	if err != nil {
 		return DoctorCheck{
 			Name:     "Federation Conflicts",
@@ -475,7 +475,7 @@ func CheckDoltServerModeMismatch(path string) DoctorCheck {
 
 	// Open storage to check for remotes
 	ctx := context.Background()
-	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath, true))
+	store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath))
 	if err != nil {
 		return DoctorCheck{
 			Name:     "Dolt Mode",

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1981,7 +1981,7 @@ func TestContainsGitignorePattern(t *testing.T) {
 		{"*.db\n.dolt/\n", ".dolt/", true},
 		{"node_modules/\n", ".dolt/", false},
 		{"# .dolt/ is ignored\n", ".dolt/", false}, // comment, not pattern
-		{"  .dolt/  \n", ".dolt/", true},            // whitespace trimmed
+		{"  .dolt/  \n", ".dolt/", true},           // whitespace trimmed
 		{"", ".dolt/", false},
 		{".dolt/foo\n", ".dolt/", false}, // not exact match
 	}

--- a/cmd/bd/doctor/migration.go
+++ b/cmd/bd/doctor/migration.go
@@ -95,4 +95,3 @@ func hasGitRemote(repoPath string) bool {
 	}
 	return len(strings.TrimSpace(string(output))) > 0
 }
-

--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -19,7 +19,7 @@ import (
 func openStoreDB(beadsDir string) (*sql.DB, *dolt.DoltStore, error) {
 	ctx := context.Background()
 	doltPath := filepath.Join(beadsDir, "dolt")
-	cfg := doltServerConfig(beadsDir, doltPath, true)
+	cfg := doltServerConfig(beadsDir, doltPath)
 	store, err := dolt.New(ctx, cfg)
 	if err != nil {
 		return nil, nil, err

--- a/cmd/bd/doctor_test.go
+++ b/cmd/bd/doctor_test.go
@@ -678,9 +678,9 @@ func TestExportDiagnostics(t *testing.T) {
 		OverallOK:  true,
 		Timestamp:  "2025-01-01T00:00:00Z",
 		Platform: map[string]string{
-			"os_arch":        "darwin/arm64",
-			"go_version":     "go1.21.0",
-			"backend": "dolt",
+			"os_arch":    "darwin/arm64",
+			"go_version": "go1.21.0",
+			"backend":    "dolt",
 		},
 		Checks: []doctorCheck{
 			{

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -67,6 +67,7 @@ func importIssuesCore(ctx context.Context, _ string, store *dolt.DoltStore, issu
 // any manual cleanup done to the JSONL file (e.g., via bd compact --purge-tombstones).
 // Returns the number of issues imported and any error.
 func importFromLocalJSONL(ctx context.Context, store *dolt.DoltStore, localPath string) (int, error) {
+	// #nosec G304 -- localPath is provided by internal callers and points to workspace-controlled files.
 	data, err := os.ReadFile(localPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read JSONL file %s: %w", localPath, err)

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -303,13 +303,13 @@ func Start(beadsDir string) (*State, error) {
 	cmd.Stderr = logFile
 	cmd.Stdin = nil
 	// New process group so server survives bd exit
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = detachedProcessAttr()
 
 	if err := cmd.Start(); err != nil {
-		logFile.Close()
+		_ = logFile.Close()
 		return nil, fmt.Errorf("starting dolt sql-server: %w", err)
 	}
-	logFile.Close()
+	_ = logFile.Close()
 
 	pid := cmd.Process.Pid
 
@@ -511,7 +511,7 @@ func forkIdleMonitor(beadsDir string) {
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = nil
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = detachedProcessAttr()
 
 	if err := cmd.Start(); err != nil {
 		return // best effort

--- a/internal/doltserver/sysprocattr_unix.go
+++ b/internal/doltserver/sysprocattr_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package doltserver
+
+import "syscall"
+
+// detachedProcessAttr configures detached child process groups on Unix-like OSes.
+func detachedProcessAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/doltserver/sysprocattr_windows.go
+++ b/internal/doltserver/sysprocattr_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package doltserver
+
+import "syscall"
+
+// detachedProcessAttr configures detached child process groups on Windows.
+func detachedProcessAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}

--- a/internal/storage/dolt/migrations/helpers.go
+++ b/internal/storage/dolt/migrations/helpers.go
@@ -14,6 +14,7 @@ func columnExists(db *sql.DB, table, column string) (bool, error) {
 	// Use string interpolation instead of parameterized query because Dolt
 	// doesn't support prepared-statement parameters for SHOW commands.
 	// Table/column names come from internal constants, not user input.
+	// #nosec G202 -- table and column names come from internal constants, not user input.
 	rows, err := db.Query("SHOW COLUMNS FROM `" + table + "` LIKE '" + column + "'")
 	if err != nil {
 		return false, fmt.Errorf("failed to check column %s.%s: %w", table, column, err)
@@ -31,6 +32,7 @@ func tableExists(db *sql.DB, table string) (bool, error) {
 	// Use string interpolation instead of parameterized query because Dolt
 	// doesn't support prepared-statement parameters for SHOW commands.
 	// Table names come from internal constants, not user input.
+	// #nosec G202 -- table names come from internal constants, not user input.
 	rows, err := db.Query("SHOW TABLES LIKE '" + table + "'")
 	if err != nil {
 		return false, fmt.Errorf("failed to check table %s: %w", table, err)


### PR DESCRIPTION
Fixes baseline CI failures currently visible on `main` and PRs.

## What this changes

1. Windows smoke build fix
- `internal/doltserver/doltserver.go` now uses platform-specific process attributes via:
  - `internal/doltserver/sysprocattr_unix.go`
  - `internal/doltserver/sysprocattr_windows.go`
- Replaces direct `Setpgid` usage (invalid on Windows) with `detachedProcessAttr()`.

2. Lint fixes
- `cmd/bd/import_shared.go`: add explicit `#nosec G304` rationale for workspace-controlled local path read.
- `internal/storage/dolt/migrations/helpers.go`: add explicit `#nosec G202` rationale for SHOW query interpolation using internal constants.
- `cmd/bd/doctor/federation.go` + `cmd/bd/doctor/validation.go`: remove unused `readOnly` parameter from `doltServerConfig` to satisfy `unparam`.
- `internal/doltserver/doltserver.go`: handle `logFile.Close()` return values to satisfy `gosec G104`.

3. Formatting baseline
- gofmt-normalized files flagged by CI:
  - `cmd/bd/doctor/gitignore_test.go`
  - `cmd/bd/doctor/migration.go`
  - `cmd/bd/doctor_test.go`

## Validation run locally
- `make fmt-check`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --timeout=5m`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -v -tags gms_pure_go -o /tmp/bd-ci-smoke.exe ./cmd/bd`
- `go test ./internal/doltserver ./cmd/bd/doctor ./internal/storage/dolt/migrations`

This PR is intentionally scoped to CI unblocking and does not modify feature behavior beyond platform-safe process attribute handling.
