### PR TITLE
Fix double-prefix in wisp ID generation

### DIFF
--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -226,12 +226,14 @@ func scanIssueTxFromTable(ctx context.Context, tx *sql.Tx, table, id string) (*t
 
 // wispPrefix returns the ID prefix for wisp ID generation.
 // Appends "-wisp" to the config prefix (e.g., "bd" -> "bd-wisp").
+// When IDPrefix is set (e.g., "wisp"), it replaces the default "-wisp" suffix
+// to avoid double-prefixing (e.g., "es-wisp" not "es-wisp-wisp").
 func wispPrefix(configPrefix string, issue *types.Issue) string {
 	prefix := configPrefix
 	if issue.PrefixOverride != "" {
 		prefix = issue.PrefixOverride
 	} else if issue.IDPrefix != "" {
-		prefix = configPrefix + "-" + issue.IDPrefix
+		return configPrefix + "-" + issue.IDPrefix
 	}
 	return prefix + "-wisp"
 }


### PR DESCRIPTION
## Summary
- `wispPrefix()` was appending `-wisp` unconditionally, even when `IDPrefix` was already set to `"wisp"`, producing IDs like `es-wisp-wisp-w70u` instead of `es-wisp-w70u`
- Fix: return early when `IDPrefix` is set, since it already specifies the desired prefix segment

## Test plan
- [x] Existing `TestCreateWispNoDoubleHyphen` passes
- [x] All wisp storage tests pass
- [x] All `TestInstantiateFormulaOnBead` tests pass (gastown integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)