### PR TITLE
fix(doctor): exclude wisp tables from Dolt Status/Locks warnings

### DIFF
--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -334,6 +334,14 @@ func CheckDoltIssueCount(path string) DoctorCheck {
 	return checkIssueCountWithDB(conn)
 }
 
+// isWispTable returns true if the table name refers to a wisp (ephemeral) table.
+// Wisp tables are expected to have uncommitted changes since they are excluded
+// from Dolt version tracking via dolt_ignore. Reporting them as uncommitted
+// produces self-fulfilling warnings that can never be cleared.
+func isWispTable(tableName string) bool {
+	return tableName == "wisps" || strings.HasPrefix(tableName, "wisp_")
+}
+
 // checkStatusWithDB reports uncommitted changes in Dolt using an existing connection.
 // Separated from CheckDoltStatus to allow connection reuse across checks.
 func checkStatusWithDB(conn *doltConn) DoctorCheck {
@@ -358,6 +366,11 @@ func checkStatusWithDB(conn *doltConn) DoctorCheck {
 		var staged bool
 		var status string
 		if err := rows.Scan(&tableName, &staged, &status); err != nil {
+			continue
+		}
+		// Skip wisp tables — they are ephemeral and expected to have
+		// uncommitted changes (covered by dolt_ignore).
+		if isWispTable(tableName) {
 			continue
 		}
 		stageMark := ""

--- a/cmd/bd/doctor/dolt_test.go
+++ b/cmd/bd/doctor/dolt_test.go
@@ -194,6 +194,35 @@ func TestCheckLockHealth_HeldNomsLOCK(t *testing.T) {
 	}
 }
 
+func TestIsWispTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		table    string
+		expected bool
+	}{
+		{"wisps table", "wisps", true},
+		{"wisp_events", "wisp_events", true},
+		{"wisp_labels", "wisp_labels", true},
+		{"wisp_dependencies", "wisp_dependencies", true},
+		{"wisp_comments", "wisp_comments", true},
+		{"issues table", "issues", false},
+		{"events table", "events", false},
+		{"labels table", "labels", false},
+		{"dependencies table", "dependencies", false},
+		{"config table", "config", false},
+		{"dolt_ignore", "dolt_ignore", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWispTable(tt.table); got != tt.expected {
+				t.Errorf("isWispTable(%q) = %v, want %v", tt.table, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestCheckLockHealth_NonDoltBackend(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")

--- a/cmd/bd/doctor/migration_validation.go
+++ b/cmd/bd/doctor/migration_validation.go
@@ -467,6 +467,11 @@ func checkDoltLocks(beadsDir string) (bool, string) {
 		if err := rows.Scan(&tableName, &staged, &status); err != nil {
 			continue
 		}
+		// Skip wisp tables — they are ephemeral and expected to have
+		// uncommitted changes (covered by dolt_ignore).
+		if isWispTable(tableName) {
+			continue
+		}
 		mark := ""
 		if staged {
 			mark = " (staged)"


### PR DESCRIPTION
## Summary

- Filter wisp tables (`wisps`, `wisp_*`) from both "Dolt Status" and "Dolt Locks" doctor checks
- Add `isWispTable()` helper with table-driven unit tests

## Problem

`bd doctor` warns about uncommitted Dolt changes in wisp tables (`wisps`, `wisp_events`), but these tables are ephemeral and excluded from Dolt version tracking via `dolt_ignore`. The warnings are self-fulfilling — wisp activity occurs naturally during normal bd usage, and since ignored tables can't be committed, the warnings can never be cleared.

Both the "Dolt Status" (CategoryData) and "Dolt Locks" (CategoryMaintenance) checks query `dolt_status` without filtering, producing duplicate warnings for the same non-issue.

## Solution

Add an `isWispTable(tableName)` helper that identifies wisp-related tables (`wisps` exact match, or `wisp_` prefix). Both `checkStatusWithDB()` and `checkDoltLocks()` now skip these tables when iterating `dolt_status` results.

## Before / After

**Before** (immediately after `bd vc commit`):
```
⚠  Dolt Status    2 uncommitted change(s)
   └─ Changes: [wisp_events: modified  wisps: modified ]
⚠  Dolt Locks     Uncommitted changes detected
   └─ wisp_events: modified, wisps: modified
```

**After**:
```
✓  Dolt Status    Clean working set
✓  Dolt Locks     No locks or uncommitted changes
```

## Testing

- `TestIsWispTable` — table-driven test covering all wisp tables and negative cases
- `go test ./cmd/bd/doctor/` — all related tests pass
- `go vet ./cmd/bd/doctor/` — clean
- `gofmt -l` — clean
- Manual validation: `bd vc commit && bd doctor -v` shows clean status