### PR TITLE
fix: add .dolt/ to project .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ pkg/
 .DS_Store
 Thumbs.db
 
+# Dolt database files
+.dolt/
+
 # Legacy SQLite database files
 *.db
 *.db-journal


### PR DESCRIPTION
## Summary

- Add `.dolt/` exclusion pattern to the project root `.gitignore`

## Problem

`bd doctor` warns that the project `.gitignore` is missing Dolt exclusion patterns (`.dolt/`). The `*.db` pattern is already present but `.dolt/` is not. This causes a circular warning situation: adding it locally silences the Project Gitignore check but triggers a Git Working Tree "uncommitted changes" warning, since upstream doesn't have the pattern.

## Solution

Add `.dolt/` to the project `.gitignore` upstream so that repos using Dolt backend don't get false doctor warnings. The `.beads/.gitignore` already handles Dolt files inside `.beads/`, but the project-level exclusion prevents accidentally committing any `.dolt/` directory in the project root.

## Testing

- `bd doctor` no longer warns about missing Dolt exclusion patterns
- All doctor tests pass (`go test ./cmd/bd/ -run "Doctor"`)
- `go vet ./...` clean