### PR TITLE
fix(storage): commit SQL tx when DOLT_COMMIT finds nothing to commit

### DIFF
--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -73,11 +73,17 @@ func (s *DoltStore) runDoltTransaction(ctx context.Context, commitMsg string, fn
 			_ = sqlTx.Rollback()
 			return fmt.Errorf("dolt commit: %w", err)
 		}
-		// DOLT_COMMIT already ended the transaction; do not call tx.Commit().
-		return nil
+		if err == nil {
+			// DOLT_COMMIT succeeded and already ended the transaction; do not call tx.Commit().
+			return nil
+		}
+		// DOLT_COMMIT returned "nothing to commit" — this happens when only
+		// dolt_ignore tables (e.g. wisps) were modified. The SQL transaction
+		// is still open, so we must commit it explicitly to persist the data.
 	}
 
-	// No dolt commit requested — commit the SQL transaction normally.
+	// No dolt commit requested (or only ignored tables changed) —
+	// commit the SQL transaction normally.
 	return sqlTx.Commit()
 }
 


### PR DESCRIPTION
## Summary

When only `dolt_ignore` tables (e.g., wisps) are modified, `DOLT_COMMIT` returns "nothing to commit" but the code previously returned `nil` without calling `sqlTx.Commit()`. This left the SQL transaction open, so wisp data was never persisted to disk.

- `bd mol wisp` creates would report success but issues were not queryable afterward
- The fix falls through to `sqlTx.Commit()` when `isDoltNothingToCommit(err)` is true, persisting the ignored-table writes

## Changes

- `internal/storage/dolt/transaction.go`: When `DOLT_COMMIT` returns "nothing to commit", fall through to `sqlTx.Commit()` instead of returning early

## Test plan

- [ ] Create a wisp via `bd mol wisp create` and verify it's queryable with `bd mol wisp list`
- [ ] Verify non-ephemeral creates still commit normally via `DOLT_COMMIT`
- [ ] Run `go test ./internal/storage/dolt/...` to confirm no regressions
- [ ] Run `go test -short ./...` for the full fast test suite

Related: GH#2031 (unify issue/wisp write paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)