### PR TITLE
fix(release): auto-publish Homebrew tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,9 @@ jobs:
             ${{ github.repository != 'steveyegge/beads' && '--skip=publish --skip=announce' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Homebrew tap publishing (requires PAT with contents:write on homebrew-beads)
+          # If not set, goreleaser skips the brew publish step gracefully
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           # Windows code signing (optional - signing is skipped if not set)
           WINDOWS_SIGNING_CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_PFX_BASE64 }}
           WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -194,6 +194,19 @@ archives:
       - README.md
       - CHANGELOG.md
 
+homebrew_casks:
+  - name: bd
+    repository:
+      owner: steveyegge
+      name: homebrew-beads
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/steveyegge/beads"
+    description: "AI-supervised issue tracker for coding workflows"
+    license: "MIT"
+    binaries:
+      - bd
+
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
## Problem

`brew install beads` is stuck on v0.55.4 while GitHub releases are at v0.56.1. The Homebrew tap (`steveyegge/homebrew-beads`) is even further behind at v0.49.0. Neither updates automatically when a new release is tagged.

This was flagged by a user in #2072 — they upgraded via Homebrew and hit a SIGSEGV that was fixed in v0.56.1, but Homebrew hadn't caught up.

## Solution

Add a `homebrew_casks:` section to `.goreleaser.yml` so each tagged release auto-updates `steveyegge/homebrew-beads/Formula/bd.rb`. Uses the modern `homebrew_casks:` API (goreleaser v2.10+) instead of the deprecated `brews:`.

## Changes

| File | Change |
|------|--------|
| `.goreleaser.yml` | Add `homebrew_casks:` section targeting `steveyegge/homebrew-beads` |
| `.github/workflows/release.yml` | Pass `HOMEBREW_TAP_TOKEN` env var to goreleaser |

## Setup Required

After merging, a **fine-grained PAT** must be added as a repo secret:

1. Create a fine-grained PAT with `Contents: Read and write` on `steveyegge/homebrew-beads`
2. Add it as `HOMEBREW_TAP_TOKEN` in `steveyegge/beads` → Settings → Secrets → Actions
3. Without the secret, goreleaser skips the tap publish gracefully (no release breakage)

## Note on homebrew-core

This PR updates the **tap** (`brew tap steveyegge/beads && brew install steveyegge/beads/bd`). The homebrew-core formula (`brew install beads`) is maintained separately by the Homebrew team and requires a `brew bump-formula-pr` to update.

## Validation

- `goreleaser check` passes (only pre-existing `archives.format` deprecation warnings)
- `homebrew_casks:` avoids the `brews:` deprecation warning
- `directory: Formula` matches existing tap layout

Built with AI in the loop — intent, architecture, and review: human. Drafting and execution assist: Claude.