### PR TITLE
fix: unify hook outdated detection between CheckGitHooks and hooksNeedUpdate

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -84,8 +84,8 @@ func CheckGitHooks() []HookStatus {
 			status.IsShim = versionInfo.IsShim
 
 			// Thin shims are never outdated (they delegate to bd)
-			// Legacy hooks are outdated if version differs from current bd version
-			if !versionInfo.IsShim && versionInfo.Version != "" && versionInfo.Version != Version {
+			// bd hooks are outdated if version is missing (legacy inline) or differs
+			if !versionInfo.IsShim && versionInfo.IsBdHook && versionInfo.Version != Version {
 				status.Outdated = true
 			}
 		}


### PR DESCRIPTION
## Summary

Follow-up to #2008 (GH#1466). Fixes two issues in hook version checking:

- **`CheckGitHooks()` missed inline hooks**: guarded on `Version != ""` which skipped legacy inline bd hooks (empty version string). Non-bd hooks also have empty version, so the fix uses `IsBdHook` instead — correctly flagging inline bd hooks as outdated without false-flagging non-bd hooks
- **Duplicated logic**: `hooksNeedUpdate()` reimplemented the same version-checking loop as `CheckGitHooks()`. Consolidated to delegate to `CheckGitHooks()`, reducing `init_git_hooks.go` by 27 lines

## Test plan

- [x] All 17 existing hook tests pass (`TestCheckGitHooks` + `TestHooksNeedUpdate`)
- [x] `TestHooksNeedUpdate/inline_hooks_without_version` validates the fix path
- [x] Build succeeds on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)