### PR TITLE
fix(test): clean orphaned temp dirs for all test server prefixes

### DIFF
--- a/internal/testutil/testdoltserver.go
+++ b/internal/testutil/testdoltserver.go
@@ -24,7 +24,7 @@ type TestDoltServer struct {
 	tmpDir   string
 	pidFile  string
 	crashed  chan struct{} // closed when server exits unexpectedly
-	exitErr  error        // set before crashed is closed
+	exitErr  error         // set before crashed is closed
 	exitOnce sync.Once
 }
 
@@ -299,11 +299,27 @@ func cleanPIDFile(pidFile string) {
 }
 
 // cleanOrphanedTempDirs removes test temp directories whose owning server
-// process is no longer running. Handles both data dirs (beads-test-dolt-*)
-// and test working dirs (beads-bd-tests-*) in the system temp directory.
+// process is no longer running. Covers all prefixes used by StartTestDoltServer
+// callers and test working dirs in the system temp directory.
 func cleanOrphanedTempDirs() {
 	tmpDir := os.TempDir()
-	for _, prefix := range []string{"beads-test-dolt-", "beads-bd-tests-", "fix-test-dolt-", "doctor-test-dolt-"} {
+	for _, prefix := range []string{
+		// Server data dirs (one per StartTestDoltServer caller)
+		"beads-test-dolt-",
+		"beads-root-test-",
+		"beads-integration-test-",
+		"bd-regression-dolt-",
+		"tracker-pkg-test-",
+		"dolt-pkg-test-",
+		"molecules-pkg-test-",
+		"doctor-test-dolt-",
+		"fix-test-dolt-",
+		"protocol-test-dolt-",
+		// Test working dirs
+		"beads-bd-tests-",
+		// Legacy prefix (no longer created)
+		"dolt-test-server-",
+	} {
 		pattern := filepath.Join(tmpDir, prefix+"*")
 		entries, err := filepath.Glob(pattern)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Add 7 missing temp directory prefixes to `cleanOrphanedTempDirs()` plus the legacy `dolt-test-server-` prefix
- No behavior change for the 4 prefixes already covered

## Problem

`cleanOrphanedTempDirs()` only cleaned directories matching 4 of 11 prefixes used by `StartTestDoltServer` callers. When tests using the other 7 prefixes were interrupted (Ctrl+C, timeout, killed tmux pane), their temp directories in `/tmp` were never cleaned up.

In production this manifested as 7 zombie Dolt test servers consuming ~850MB RAM collectively, with orphaned `/tmp/dolt-test-server-*` and other prefix directories accumulating over time.

### Prefixes added

| Prefix | Package |
|--------|---------|
| `beads-root-test-` | root package |
| `beads-integration-test-` | `internal/beads` |
| `bd-regression-dolt-` | `tests/regression` |
| `tracker-pkg-test-` | `internal/tracker` |
| `dolt-pkg-test-` | `internal/storage/dolt` |
| `molecules-pkg-test-` | `internal/molecules` |
| `protocol-test-dolt-` | `cmd/bd/protocol` |
| `dolt-test-server-` | legacy (no longer created) |

### Already covered

`beads-test-dolt-`, `beads-bd-tests-`, `fix-test-dolt-`, `doctor-test-dolt-`

## Testing

```
go build ./...        # clean
go vet ./...          # clean
golangci-lint run ./internal/testutil/...  # only pre-existing gosec issues
go test ./internal/testutil/...            # pass
```