### PR TITLE
fix(storage): batch SQL IN-clause queries to prevent query explosion

### DIFF
--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -698,6 +698,12 @@ func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 // Kept small to avoid large IN-clause queries. See steveyegge/beads#1692.
 const deleteBatchSize = 50
 
+// queryBatchSize controls the maximum number of IDs per IN-clause in read
+// queries (label hydration, wisp lookups). Without batching, queries like
+// `SELECT ... FROM wisp_labels WHERE issue_id IN (?,?,?,...thousands)` take
+// 20+ seconds on databases with many wisps (e.g., hq with 29K wisps).
+const queryBatchSize = 200
+
 func (s *DoltStore) DeleteIssues(ctx context.Context, ids []string, cascade bool, force bool, dryRun bool) (*types.DeleteIssuesResult, error) {
 	if len(ids) == 0 {
 		return &types.DeleteIssuesResult{}, nil


### PR DESCRIPTION
## Summary

- `getWispsByIDs` and `GetLabelsForIssues` were building unbounded SQL `IN(...)` clauses with 7,000+ parameters against `wisp_labels` and `labels` tables, causing 15-20 second query times on databases with 29K+ wisps
- Batches both query paths in chunks of 200 IDs using the existing `doltBuildSQLInClause` helper
- Eliminates the N+1 loop in the wisp label path that called `getWispLabels` one ID at a time

## Changes

- `issues.go`: Added `queryBatchSize = 200` constant
- `wisps.go`: Rewrote `getWispsByIDs` to batch both the wisps fetch and label hydration
- `labels.go`: Rewrote `GetLabelsForIssues` to batch both wisp-label and dolt-label query paths

## Testing

- All existing tests pass (`go test ./internal/storage/dolt/...`)
- Verified on a production database with 29K wisps: `bd list --status=open -n 5 --json` dropped from 15-20s to 0.16s