### PR TITLE
docs: use make install instead of go build for bd binary

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -34,11 +34,11 @@ beads/
 
 ```bash
 # Create test issues in isolated database
-BEADS_DB=/tmp/test.db ./bd init --quiet --prefix test
-BEADS_DB=/tmp/test.db ./bd create "Test issue" -p 1
+BEADS_DB=/tmp/test.db bd init --quiet --prefix test
+BEADS_DB=/tmp/test.db bd create "Test issue" -p 1
 
 # Or for quick testing
-BEADS_DB=/tmp/test.db ./bd create "Test feature" -p 1
+BEADS_DB=/tmp/test.db bd create "Test feature" -p 1
 ```
 
 **For automated tests**, use `t.TempDir()` in Go tests:
@@ -254,8 +254,8 @@ This installs:
 ## Building and Testing
 
 ```bash
-# Build
-go build -o bd ./cmd/bd
+# Build and install bd to ~/.local/bin (the canonical location)
+make install
 
 # Test (local baseline)
 make test
@@ -267,11 +267,15 @@ make test-full-cgo
 go test -coverprofile=coverage.out ./...
 go tool cover -html=coverage.out
 
-# Run locally
-./bd init --prefix test
-./bd create "Test issue" -p 1
-./bd ready
+# Verify installed binary
+bd init --prefix test
+bd create "Test issue" -p 1
+bd ready
 ```
+
+> **WARNING**: Do NOT use `go build -o bd ./cmd/bd` or `go install ./cmd/bd`.
+> These create stale binaries in the working directory or `~/go/bin/` that
+> shadow the canonical install at `~/.local/bin/bd`. Always use `make install`.
 
 ## Version Management
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -62,8 +62,10 @@ See `internal/types/types.go`:
 ## Common Development Commands
 
 ```bash
-# Build and test
-go build -o bd ./cmd/bd
+# Build and install bd to ~/.local/bin (canonical location)
+make install
+
+# Test
 go test ./...
 go test -coverprofile=coverage.out ./...
 
@@ -73,11 +75,14 @@ golangci-lint run ./...
 # Version management
 ./scripts/bump-version.sh 0.9.3 --commit
 
-# Local testing
-./bd init --prefix test
-./bd create "Test issue" -p 1
-./bd ready
+# Verify installed binary
+bd init --prefix test
+bd create "Test issue" -p 1
+bd ready
 ```
+
+> **Do NOT** use `go build -o bd` or `go install` directly — they create
+> stale binaries that shadow `~/.local/bin/bd`. Always use `make install`.
 
 ## Testing Philosophy
 


### PR DESCRIPTION
## Summary

- Agent instructions (`AGENT_INSTRUCTIONS.md`) and `docs/CLAUDE.md` told agents to run `go build -o bd ./cmd/bd` and then `./bd`, which created stale local binaries in every git worktree
- Changed to recommend `make install` (which places the binary in `~/.local/bin`) and `bd` from PATH instead of `./bd`
- Added warnings against using bare `go build` or `go install` directly

## Problem

In multi-worktree setups (refinery, deacon dogs), each agent followed the build instructions and created its own local `bd` binary. This led to 4-5 copies of the binary on disk, some stale, causing confusion when debugging performance issues.