### PR TITLE
fix: use doltserver.DefaultConfig for port resolution across codebase

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -50,7 +50,7 @@ Version control:
 Configuration keys for 'bd dolt set':
   database  Database name (default: issue prefix or "beads")
   host      Server host (default: 127.0.0.1)
-  port      Server port (default: 3307)
+  port      Server port (auto-detected; override with bd dolt set port <N>)
   user      MySQL user (default: root)
 
 Flags for 'bd dolt set':
@@ -78,7 +78,7 @@ var doltSetCmd = &cobra.Command{
 Keys:
   database  Database name (default: issue prefix or "beads")
   host      Server host (default: 127.0.0.1)
-  port      Server port (default: 3307)
+  port      Server port (auto-detected; override with bd dolt set port <N>)
   user      MySQL user (default: root)
 
 Use --update-config to also write to config.yaml for team-wide defaults.
@@ -592,17 +592,22 @@ func showDoltConfig(testConnection bool) {
 
 	backend := cfg.GetBackend()
 
+	// Resolve actual server port for connection testing
+	showHost := cfg.GetDoltServerHost()
+	dsCfg := doltserver.DefaultConfig(beadsDir)
+	showPort := dsCfg.Port
+
 	if jsonOutput {
 		result := map[string]interface{}{
 			"backend": backend,
 		}
 		if backend == configfile.BackendDolt {
 			result["database"] = cfg.GetDoltDatabase()
-			result["host"] = cfg.GetDoltServerHost()
-			result["port"] = cfg.GetDoltServerPort()
+			result["host"] = showHost
+			result["port"] = showPort
 			result["user"] = cfg.GetDoltServerUser()
 			if testConnection {
-				result["connection_ok"] = testServerConnection(cfg)
+				result["connection_ok"] = testServerConnection(showHost, showPort)
 			}
 		}
 		outputJSON(result)
@@ -617,13 +622,13 @@ func showDoltConfig(testConnection bool) {
 	fmt.Println("Dolt Configuration")
 	fmt.Println("==================")
 	fmt.Printf("  Database: %s\n", cfg.GetDoltDatabase())
-	fmt.Printf("  Host:     %s\n", cfg.GetDoltServerHost())
-	fmt.Printf("  Port:     %d\n", cfg.GetDoltServerPort())
+	fmt.Printf("  Host:     %s\n", showHost)
+	fmt.Printf("  Port:     %d\n", showPort)
 	fmt.Printf("  User:     %s\n", cfg.GetDoltServerUser())
 
 	if testConnection {
 		fmt.Println()
-		if testServerConnection(cfg) {
+		if testServerConnection(showHost, showPort) {
 			fmt.Printf("  %s\n", ui.RenderPass("✓ Server connection OK"))
 		} else {
 			fmt.Printf("  %s\n", ui.RenderWarn("✗ Server not reachable"))
@@ -760,11 +765,11 @@ func testDoltConnection() {
 	}
 
 	host := cfg.GetDoltServerHost()
-	port := cfg.GetDoltServerPort()
+	port := doltserver.DefaultConfig(beadsDir).Port
 	addr := fmt.Sprintf("%s:%d", host, port)
 
 	if jsonOutput {
-		ok := testServerConnection(cfg)
+		ok := testServerConnection(host, port)
 		outputJSON(map[string]interface{}{
 			"host":          host,
 			"port":          port,
@@ -778,7 +783,7 @@ func testDoltConnection() {
 
 	fmt.Printf("Testing connection to %s...\n", addr)
 
-	if testServerConnection(cfg) {
+	if testServerConnection(host, port) {
 		fmt.Printf("%s\n", ui.RenderPass("✓ Connection successful"))
 	} else {
 		fmt.Printf("%s\n", ui.RenderWarn("✗ Connection failed"))
@@ -791,9 +796,7 @@ func testDoltConnection() {
 // Tests may reduce this to avoid slow unreachable-host hangs in CI.
 var serverDialTimeout = 3 * time.Second
 
-func testServerConnection(cfg *configfile.Config) bool {
-	host := cfg.GetDoltServerHost()
-	port := cfg.GetDoltServerPort()
+func testServerConnection(host string, port int) bool {
 	addr := net.JoinHostPort(host, strconv.Itoa(port))
 
 	conn, err := net.DialTimeout("tcp", addr, serverDialTimeout)
@@ -825,7 +828,7 @@ func openDoltServerConnection() (*sql.DB, func()) {
 	}
 
 	host := cfg.GetDoltServerHost()
-	port := cfg.GetDoltServerPort()
+	port := doltserver.DefaultConfig(beadsDir).Port
 	user := cfg.GetDoltServerUser()
 	password := os.Getenv("BEADS_DOLT_PASSWORD")
 

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -381,7 +381,7 @@ func TestTestServerConnection(t *testing.T) {
 		cfg.DoltServerHost = "192.0.2.1" // RFC 5737 TEST-NET, guaranteed unreachable
 		cfg.DoltServerPort = 3307
 
-		result := testServerConnection(cfg)
+		result := testServerConnection(cfg.DoltServerHost, cfg.DoltServerPort)
 		if result {
 			t.Error("expected connection to fail for unreachable host")
 		}
@@ -394,7 +394,7 @@ func TestTestServerConnection(t *testing.T) {
 		cfg.DoltServerHost = "127.0.0.1"
 		cfg.DoltServerPort = 59999 // Unlikely to be in use
 
-		result := testServerConnection(cfg)
+		result := testServerConnection(cfg.DoltServerHost, cfg.DoltServerPort)
 		if result {
 			t.Error("expected connection to fail for unused port")
 		}
@@ -405,7 +405,7 @@ func TestTestServerConnection(t *testing.T) {
 		cfg.DoltServerHost = "::1"
 		cfg.DoltServerPort = 59998 // Unlikely to be in use
 
-		result := testServerConnection(cfg)
+		result := testServerConnection(cfg.DoltServerHost, cfg.DoltServerPort)
 		if result {
 			t.Error("expected connection to fail for unused port on IPv6")
 		}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -632,7 +632,7 @@ environment variable.`,
 		}
 		port := serverPort
 		if port == 0 {
-			port = configfile.DefaultDoltServerPort
+			port = doltserver.DefaultConfig(beadsDir).Port
 		}
 		user := serverUser
 		if user == "" {

--- a/cmd/bd/migrate_auto.go
+++ b/cmd/bd/migrate_auto.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -94,7 +95,7 @@ func doAutoMigrateSQLiteToDolt(beadsDir string) {
 	}
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
 		doltCfg.ServerHost = cfg.GetDoltServerHost()
-		doltCfg.ServerPort = cfg.GetDoltServerPort()
+		doltCfg.ServerPort = doltserver.DefaultConfig(beadsDir).Port
 		doltCfg.ServerUser = cfg.GetDoltServerUser()
 		doltCfg.ServerPassword = cfg.GetDoltServerPassword()
 		doltCfg.ServerTLS = cfg.GetDoltServerTLS()
@@ -138,9 +139,8 @@ func doAutoMigrateSQLiteToDolt(beadsDir string) {
 	cfg.Backend = configfile.BackendDolt
 	cfg.Database = "dolt"
 	cfg.DoltDatabase = dbName
-	if cfg.DoltServerPort == 0 {
-		cfg.DoltServerPort = configfile.DefaultDoltServerPort
-	}
+	// Don't set DoltServerPort - let doltserver.DefaultConfig derive it
+	// from the project path at runtime.
 	if err := cfg.Save(beadsDir); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to update metadata.json: %v\n", err)
 	}

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -235,6 +235,11 @@ func (c *Config) GetDoltServerHost() string {
 	return DefaultDoltServerHost
 }
 
+// Deprecated: Use doltserver.DefaultConfig(beadsDir).Port instead.
+// This method falls back to 3307 which is wrong for standalone mode
+// (where the port is hash-derived from the project path).
+// Kept for backward compatibility with external consumers.
+//
 // GetDoltServerPort returns the Dolt server port.
 // Checks BEADS_DOLT_SERVER_PORT env var first, then config, then default.
 func (c *Config) GetDoltServerPort() int {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -213,11 +213,19 @@ func writePortFile(beadsDir string, port int) error {
 }
 
 // DefaultConfig returns config with sensible defaults.
-// Checks metadata.json for an explicit port first, falls back to DerivePort.
+// Priority: env var > metadata.json > Gas Town fixed port > hash-derived port.
 func DefaultConfig(beadsDir string) *Config {
 	cfg := &Config{
 		BeadsDir: beadsDir,
 		Host:     "127.0.0.1",
+	}
+
+	// Check env var override first (used by tests and manual overrides)
+	if p := os.Getenv("BEADS_DOLT_SERVER_PORT"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil {
+			cfg.Port = port
+			return cfg
+		}
 	}
 
 	// Check if user configured an explicit port


### PR DESCRIPTION
## Summary

Fixes #2112. Callers were using `configfile.GetDoltServerPort()` or hardcoded `3307` instead of `doltserver.DefaultConfig(beadsDir)` which correctly resolves all three cases: explicit config, Gas Town (3307), and hash-derived standalone ports (13307-14306).

- Add `BEADS_DOLT_SERVER_PORT` env var to `doltserver.DefaultConfig()` as highest-priority override (parity with `configfile.GetDoltServerPort`)
- Fix `testDoltConnection`, `testServerConnection`, `openDoltServerConnection` in `cmd/bd/dolt.go` to use resolved port
- Replace three hardcoded `3307` literals in `cmd/bd/doctor/perf_dolt.go`
- Fix `migrate_auto.go` connection port and remove 3307 persistence to metadata.json
- Fix `init.go` display output to show resolved port
- Update help text from "default: 3307" to "auto-detected"
- Deprecate `configfile.GetDoltServerPort()` with guidance comment
- Also fix `showDoltConfig` to display/test the resolved port

## Test plan

- [x] `go build -tags gms_pure_go ./cmd/bd/` - clean
- [x] `go vet -tags gms_pure_go ./...` - clean
- [x] `go test -tags gms_pure_go ./internal/doltserver/...` - pass
- [x] `go test -tags gms_pure_go ./cmd/bd/...` - pass (no regressions from this change)
- [ ] Manual: `bd dolt start` then `bd dolt test` on standalone project - connects to derived port
- [ ] Manual: `BEADS_DOLT_SERVER_PORT=9999 bd dolt test` - respects env var override