### PR TITLE
fix: suppress git upstream warning for repos with no remotes

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -610,9 +610,11 @@ environment variable.`,
 			addAgentsInstructions(!quiet, agentsTemplate)
 		}
 
-		// Check for missing git upstream and warn if not configured
+		// Check for missing git upstream and warn if not configured.
+		// Only warn when remotes exist (has origin but no upstream).
+		// Skip for brand-new repos with no remotes — the warning is noise there.
 		if isGitRepo() && !quiet {
-			if !gitHasUpstream() {
+			if gitHasAnyRemotes() && !gitHasUpstream() {
 				fmt.Fprintf(os.Stderr, "\n%s Git upstream not configured\n", ui.RenderWarn("⚠"))
 				fmt.Fprintf(os.Stderr, "  For sync workflows, set your upstream with:\n")
 				fmt.Fprintf(os.Stderr, "  %s\n\n", ui.RenderAccent("git remote add upstream <repo-url>"))

--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -39,6 +39,23 @@ func gitHasUpstream() bool {
 	return gitBranchHasUpstream(branch)
 }
 
+// gitHasAnyRemotes returns true if the git repository has any remotes configured.
+// Used to distinguish between "new repo with no remotes" and "repo with origin but no upstream".
+func gitHasAnyRemotes() bool {
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		return false
+	}
+
+	ctx := context.Background()
+	remoteCmd := rc.GitCmd(ctx, "remote")
+	output, err := remoteCmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) != ""
+}
+
 // gitBranchHasUpstream checks if a specific branch has an upstream configured.
 // Unlike gitHasUpstream(), this works even when HEAD is detached (e.g., jj/jujutsu).
 // Uses RepoContext to ensure git commands run in the correct repository.


### PR DESCRIPTION
## Summary

Brand-new repos with no remotes now skip the "Git upstream not configured" warning during `bd init`. The warning only appears when remotes exist (has origin but no upstream), where it is actionable.

### Changes

- **`cmd/bd/sync_git.go`**: Add `gitHasAnyRemotes()` function that checks if any git remotes are configured, using `RepoContext` for consistency.
- **`cmd/bd/init.go`**: Guard the upstream warning with `gitHasAnyRemotes()` so brand-new repos don't get a noisy, unactionable warning.

Complements PR #1915 which fixes the same issue in the `bd doctor` layer.

Extracted from #2060 per code review feedback — this is the standalone useful fix from that larger PR.
