### PR TITLE
fix(migrate): skip auto-migration when backend is already Dolt

### DIFF
--- a/cmd/bd/migrate_auto.go
+++ b/cmd/bd/migrate_auto.go
@@ -34,6 +34,8 @@ func autoMigrateSQLiteToDolt() {
 // After a successful migration, beads.db is renamed to beads.db.migrated.
 //
 // Edge cases handled:
+//   - beads.db is 0 bytes → not a real database, remove it
+//   - metadata.json backend already "dolt" → stale leftover, rename to .migrated
 //   - beads.db.migrated already exists → migration already completed, skip
 //   - beads.db + dolt/ both exist → leftover SQLite, rename it
 //   - Dolt directory already exists → no migration needed
@@ -49,6 +51,29 @@ func doAutoMigrateSQLiteToDolt(beadsDir string) {
 	// Skip backup/migrated files
 	base := filepath.Base(sqlitePath)
 	if strings.Contains(base, ".backup") || strings.Contains(base, ".migrated") {
+		return
+	}
+
+	// Guard: if the file is empty (0 bytes), it's not a real SQLite database.
+	// This happens when a process creates beads.db but crashes before writing.
+	// Remove the empty file to prevent repeated failed migration attempts.
+	if info, err := os.Stat(sqlitePath); err == nil && info.Size() == 0 {
+		debug.Logf("auto-migrate-sqlite: removing empty %s (not a valid database)", base)
+		_ = os.Remove(sqlitePath)
+		return
+	}
+
+	// Guard: if metadata.json already indicates Dolt backend, the beads.db is stale
+	// leftover — not a database that needs migrating. This covers dolt-server mode
+	// where there is no local dolt/ directory (data is stored remotely on the Dolt
+	// SQL server), so the dolt/ directory check below would miss it.
+	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil && cfg.Backend == configfile.BackendDolt {
+		migratedPath := sqlitePath + ".migrated"
+		if _, err := os.Stat(migratedPath); err != nil {
+			if err := os.Rename(sqlitePath, migratedPath); err == nil {
+				debug.Logf("auto-migrate-sqlite: renamed stale %s (backend already dolt)", base)
+			}
+		}
 		return
 	}
 

--- a/cmd/bd/migrate_auto_test.go
+++ b/cmd/bd/migrate_auto_test.go
@@ -331,6 +331,120 @@ func TestAutoMigrate_Idempotent(t *testing.T) {
 	doAutoMigrateSQLiteToDolt(beadsDir)
 }
 
+func TestAutoMigrate_SkipsWhenBackendAlreadyDolt(t *testing.T) {
+	// When metadata.json already says backend=dolt (dolt-server mode, no local dolt/ dir),
+	// a stale beads.db should be cleaned up without attempting SQLite extraction.
+	// This is the exact scenario from the gastown rig: dolt-server mode stores data
+	// remotely, so there's no local dolt/ directory. The migration code was incorrectly
+	// trying to extract from the (empty) beads.db because it only checked for dolt/ dir,
+	// not the configured backend.
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write metadata.json indicating dolt backend with server mode (no local dolt/ dir)
+	cfg := &configfile.Config{
+		Backend:        configfile.BackendDolt,
+		Database:       "dolt",
+		DoltMode:       configfile.DoltModeServer,
+		DoltDatabase:   "gastown",
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 3307,
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	// Create a stale beads.db with some content (non-zero, simulates a leftover
+	// SQLite file that's not empty but is not a valid database either)
+	sqlitePath := filepath.Join(beadsDir, "beads.db")
+	if err := os.WriteFile(sqlitePath, []byte("not-a-real-database"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run auto-migration — should NOT attempt SQLite extraction
+	doAutoMigrateSQLiteToDolt(beadsDir)
+
+	// beads.db should be renamed to .migrated (cleaned up)
+	if _, err := os.Stat(sqlitePath); !os.IsNotExist(err) {
+		t.Error("beads.db should have been renamed to .migrated when backend is already dolt")
+	}
+	if _, err := os.Stat(sqlitePath + ".migrated"); err != nil {
+		t.Errorf("beads.db.migrated should exist: %v", err)
+	}
+
+	// metadata.json should be UNCHANGED (not overwritten by migration)
+	updatedCfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("failed to reload config: %v", err)
+	}
+	if updatedCfg.DoltDatabase != "gastown" {
+		t.Errorf("dolt_database should still be 'gastown', got %q (migration overwrote config)", updatedCfg.DoltDatabase)
+	}
+	if updatedCfg.DoltMode != configfile.DoltModeServer {
+		t.Errorf("dolt_mode should still be 'server', got %q", updatedCfg.DoltMode)
+	}
+}
+
+func TestAutoMigrate_SkipsWhenBackendDoltEmbedded(t *testing.T) {
+	// Same as above but for embedded mode where dolt/ dir DOES exist.
+	// Even with a stale beads.db, if metadata says dolt, skip extraction.
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configfile.Config{
+		Backend:  configfile.BackendDolt,
+		Database: "dolt",
+		DoltMode: configfile.DoltModeEmbedded,
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	sqlitePath := filepath.Join(beadsDir, "beads.db")
+	if err := os.WriteFile(sqlitePath, []byte("fake-sqlite-data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	doAutoMigrateSQLiteToDolt(beadsDir)
+
+	// beads.db should be renamed (the existing dolt/ check handles this,
+	// but the metadata check should also catch it independently)
+	if _, err := os.Stat(sqlitePath); !os.IsNotExist(err) {
+		t.Error("beads.db should have been renamed")
+	}
+}
+
+func TestAutoMigrate_ZeroByteBeadsDB(t *testing.T) {
+	// A 0-byte beads.db is not a valid SQLite database. The migration should
+	// clean it up without attempting extraction (which would fail with
+	// "no such table: issues" and print a confusing warning).
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// No metadata.json, no dolt/ — just a bare 0-byte beads.db
+	sqlitePath := filepath.Join(beadsDir, "beads.db")
+	if err := os.WriteFile(sqlitePath, []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	doAutoMigrateSQLiteToDolt(beadsDir)
+
+	// 0-byte file should be removed (not a real database)
+	if _, err := os.Stat(sqlitePath); !os.IsNotExist(err) {
+		t.Error("0-byte beads.db should have been removed")
+	}
+	// Should NOT create a dolt/ directory
+	if _, err := os.Stat(filepath.Join(beadsDir, "dolt")); !os.IsNotExist(err) {
+		t.Error("dolt/ should not be created for a 0-byte SQLite file")
+	}
+}
+
 // Verify the migrated metadata.json is valid JSON
 func TestAutoMigrate_MetadataJSONValid(t *testing.T) {
 	if testDoltServerPort == 0 {


### PR DESCRIPTION
## Summary

- Skip SQLite-to-Dolt auto-migration when metadata.json already indicates `backend: dolt` (covers dolt-server mode where no local `dolt/` directory exists)
- Remove 0-byte `beads.db` files immediately instead of attempting extraction (prevents "no such table: issues" warnings on every `bd` command)
- Apply same guards to both `migrate_auto.go` (CGO path) and `migrate_shim.go` (sqlite3 CLI path)

## Problem

In dolt-server mode, data lives on a remote SQL server — there is no local `.beads/dolt/` directory. The migration code's only guard was checking for that directory, so a stale `beads.db` (even 0 bytes) triggered a migration attempt on every `bd` command, producing:

```
Migrating SQLite database to Dolt...
Warning: SQLite auto-migration failed (extract): failed to query issues: sqlite3: SQL logic error: no such table: issues
Hint: run 'bd migrate dolt' manually, or remove beads.db to skip
```

## Testing

3 new tests:
- `TestAutoMigrate_SkipsWhenBackendAlreadyDolt` — dolt-server mode with stale beads.db
- `TestAutoMigrate_SkipsWhenBackendDoltEmbedded` — embedded mode with stale beads.db  
- `TestAutoMigrate_ZeroByteBeadsDB` — 0-byte file cleanup without migration attempt