### PR TITLE
fix(linear): include stateId in push updates to sync status changes

### DIFF
--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -126,6 +126,15 @@ func (t *Tracker) UpdateIssue(ctx context.Context, externalID string, issue *typ
 	mapper := t.FieldMapper()
 	updates := mapper.IssueToTracker(issue)
 
+	// Resolve and include state so status changes are pushed to Linear.
+	stateID, err := t.findStateID(ctx, issue.Status)
+	if err != nil {
+		return nil, fmt.Errorf("finding state for status %s: %w", issue.Status, err)
+	}
+	if stateID != "" {
+		updates["stateId"] = stateID
+	}
+
 	updated, err := t.client.UpdateIssue(ctx, externalID, updates)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
UpdateIssue was only pushing title, description, and priority to Linear, omitting the stateId. This meant `bd close` followed by `bd linear sync --push` left the Linear issue in its original state instead of marking it as Done.

Resolve the workflow state ID (via the existing findStateID helper) and add it to the update payload, mirroring what CreateIssue already does.

Fixes #2046