### PR TITLE
fix: sanitize hyphens to underscores in dolt_database name

### DIFF
--- a/cmd/bd/doctor/server.go
+++ b/cmd/bd/doctor/server.go
@@ -355,14 +355,20 @@ func checkDatabaseExists(db *sql.DB, database string) DoctorCheck {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Validate database name (alphanumeric and underscore only)
+	// Validate database name
 	if !isValidIdentifier(database) {
-		return DoctorCheck{
-			Name:     "Database Exists",
-			Status:   StatusError,
-			Message:  fmt.Sprintf("Invalid database name '%s'", database),
-			Detail:   "Database name must be alphanumeric with underscores only",
-			Category: CategoryFederation,
+		// Check if it's just hyphens (legacy names from before GH#2142 fix)
+		if strings.ContainsRune(database, '-') && isValidIdentifier(strings.ReplaceAll(database, "-", "_")) {
+			// Hyphenated name — functional but not recommended.
+			// Continue with the check but we'll add a warning after.
+		} else {
+			return DoctorCheck{
+				Name:     "Database Exists",
+				Status:   StatusError,
+				Message:  fmt.Sprintf("Invalid database name '%s'", database),
+				Detail:   "Database name must be alphanumeric with underscores only",
+				Category: CategoryFederation,
+			}
 		}
 	}
 
@@ -403,14 +409,26 @@ func checkDatabaseExists(db *sql.DB, database string) DoctorCheck {
 	}
 
 	// Switch to the database
-	// Note: USE cannot use parameterized queries, but we validated the identifier above
-	_, err = db.ExecContext(ctx, "USE "+database) // #nosec G201 - database validated by isValidIdentifier
+	// Note: USE cannot use parameterized queries, but we validated the identifier above.
+	// Backtick-quote to support hyphenated legacy names (GH#2142).
+	_, err = db.ExecContext(ctx, "USE `"+database+"`") // #nosec G201 - database validated by isValidIdentifier
 	if err != nil {
 		return DoctorCheck{
 			Name:     "Database Exists",
 			Status:   StatusError,
 			Message:  fmt.Sprintf("Cannot access database '%s'", database),
 			Detail:   err.Error(),
+			Category: CategoryFederation,
+		}
+	}
+
+	// Warn about hyphenated names — functional but new projects use underscores
+	if strings.ContainsRune(database, '-') {
+		return DoctorCheck{
+			Name:     "Database Exists",
+			Status:   StatusWarning,
+			Message:  fmt.Sprintf("Database '%s' uses hyphens (legacy naming)", database),
+			Detail:   "New projects use underscores. To migrate: export data, run 'bd init --force', re-import.",
 			Category: CategoryFederation,
 		}
 	}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -391,7 +391,8 @@ environment variable.`,
 				if database != "" {
 					cfg.DoltDatabase = database
 				} else if cfg.DoltDatabase == "" && prefix != "" {
-					cfg.DoltDatabase = prefix
+					// Sanitize hyphens to underscores for SQL-idiomatic names (GH#2142).
+					cfg.DoltDatabase = strings.ReplaceAll(prefix, "-", "_")
 				}
 
 				// Always server mode


### PR DESCRIPTION
## Summary

Fixes #2142. `bd init` derives `dolt_database` from the directory name without sanitizing hyphens, producing names like `personal-ansible` that require backtick quoting and fail `bd doctor --server` validation.

## Changes

- **init.go**: `strings.ReplaceAll(prefix, "-", "_")` before setting `cfg.DoltDatabase` — new projects get SQL-idiomatic names (`my_project` not `my-project`)
- **doctor/server.go**: Hyphenated database names now warn (not error) with migration guidance
- **doctor/server.go**: Backtick-quote `USE` statement to support legacy hyphenated names

## Test plan

- [ ] `bd init` in a hyphenated directory produces underscore database name
- [ ] `bd doctor --server` warns (not errors) for existing hyphenated databases
- [ ] `TestIsValidIdentifier` passes (verified locally)
- [ ] Existing underscore-named databases unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)