### PR TITLE
fix: escape '#' in SQLite URI paths to prevent truncation

### DIFF
--- a/cmd/bd/doctor_health.go
+++ b/cmd/bd/doctor_health.go
@@ -39,7 +39,10 @@ func runCheckHealth(path string) {
 	}
 
 	// Open database once for all checks (single DB connection)
-	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
+	// Escape '#' in the path to prevent URI fragment truncation (GH#2115).
+	// In SQLite URI format, '#' starts a fragment that is silently discarded.
+	escapedPath := strings.ReplaceAll(dbPath, "#", "%23")
+	db, err := sql.Open("sqlite3", "file:"+escapedPath+"?mode=ro")
 	if err != nil {
 		// Can't open DB - only check hooks
 		if issue := doctor.CheckHooksQuick(Version); issue != "" {

--- a/cmd/bd/migrate_dolt.go
+++ b/cmd/bd/migrate_dolt.go
@@ -212,7 +212,9 @@ func hooksNeedDoltUpdate(beadsDir string) bool {
 // This is the CGO path — it reads SQLite directly via the ncruces/go-sqlite3 driver.
 // For non-CGO builds, see migrate_shim.go which uses the sqlite3 CLI instead.
 func extractFromSQLite(ctx context.Context, dbPath string) (*migrationData, error) {
-	db, err := sql.Open("sqlite3", "file:"+dbPath+"?mode=ro")
+	// Escape '#' in the path to prevent URI fragment truncation (GH#2115).
+	escapedPath := strings.ReplaceAll(dbPath, "#", "%23")
+	db, err := sql.Open("sqlite3", "file:"+escapedPath+"?mode=ro")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open SQLite database: %w", err)
 	}


### PR DESCRIPTION
## Summary
Fixes #2115

Paths containing `#` (e.g., `/workdir/#category/project`) were silently truncated by the SQLite URI parser because `#` starts a URI fragment per RFC 3986. This caused `bd list` and other commands to fail with:

```
Error: failed to open database: failed to enable WAL mode: sqlite3: unable to open database file
```

## Changes
- **`cmd/bd/doctor_health.go`**: Escape `#` as `%23` in the database path before constructing the SQLite URI
- **`cmd/bd/migrate_dolt.go`**: Same fix for the SQLite extraction path used during migration

## Root Cause
The SQLite URI `file:/path/#dir/db.sqlite?mode=ro` is parsed as:
- **Path**: `/path/` (truncated at `#`)
- **Fragment**: `dir/db.sqlite?mode=ro` (silently discarded)

After the fix: `file:/path/%23dir/db.sqlite?mode=ro` — the `#` is percent-encoded so the full path is preserved.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)