### PR TITLE
fix(init): stealth mode no longer creates Claude-specific settings

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -36,8 +36,8 @@ has already created the database.
 
 With --stealth: configures per-repository git settings for invisible beads usage:
   • .git/info/exclude to prevent beads files from being committed
-  • Claude Code settings with bd onboard instruction
   Perfect for personal use without affecting repo collaborators.
+  To set up a specific AI tool, run: bd setup <claude|cursor|aider|...> --stealth
 
 Beads requires a running dolt sql-server for database operations. If a server is detected
 on port 3307 or 3306, it is used automatically. Set connection details with --server-host,

--- a/cmd/bd/init_stealth.go
+++ b/cmd/bd/init_stealth.go
@@ -11,7 +11,9 @@ import (
 	"github.com/steveyegge/beads/internal/ui"
 )
 
-// setupStealthMode configures git settings for stealth operation
+// setupStealthMode configures git settings for stealth operation.
+// Only configures git-level invisibility (.git/info/exclude).
+// Tool-specific setup (Claude, Cursor, etc.) is handled by `bd setup <tool>`.
 // Uses .git/info/exclude (per-repository) instead of global gitignore because:
 // - Global gitignore doesn't support absolute paths (GitHub #704)
 // - .git/info/exclude is designed for user-specific, repo-local ignores
@@ -22,16 +24,11 @@ func setupStealthMode(verbose bool) error {
 		return fmt.Errorf("failed to setup git exclude: %w", err)
 	}
 
-	// Setup claude settings
-	if err := setupClaudeSettings(verbose); err != nil {
-		return fmt.Errorf("failed to setup claude settings: %w", err)
-	}
-
 	if verbose {
 		fmt.Printf("\n%s Stealth mode configured successfully!\n\n", ui.RenderPass("✓"))
 		fmt.Printf("  Git exclude: %s\n", ui.RenderAccent(".git/info/exclude configured"))
-		fmt.Printf("  Claude settings: %s\n\n", ui.RenderAccent("configured with bd onboard instruction"))
-		fmt.Printf("Your beads setup is now %s - other repo collaborators won't see any beads-related files.\n\n", ui.RenderAccent("invisible"))
+		fmt.Printf("\nYour beads setup is now %s - other repo collaborators won't see any beads-related files.\n", ui.RenderAccent("invisible"))
+		fmt.Printf("To set up a specific AI tool, run: %s\n\n", ui.RenderAccent("bd setup <claude|cursor|aider|...> --stealth"))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Remove `setupClaudeSettings` call from `setupStealthMode` so `bd init --stealth` no longer creates `.claude/settings.local.json`
- Update `--stealth` help text to guide users toward `bd setup <tool> --stealth` for tool-specific configuration
- Stealth mode now focuses solely on git-level invisibility (`.git/info/exclude`)

Fixes #2121

## Test plan

- [x] `go build ./cmd/bd/` compiles cleanly
- [x] `go test ./cmd/bd/ -run "TestSetup|TestStealth|TestInit"` — all tests pass
- [ ] Manual: `bd init --stealth` in a fresh repo no longer creates `.claude/` directory
- [ ] Manual: `bd setup claude --stealth` still creates Claude settings as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)