### PR TITLE
fix: honor BEADS_DOLT_SERVER_PORT and BEADS_DOLT_SERVER_HOST in store

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -416,15 +416,25 @@ func applyConfigDefaults(cfg *Config) {
 
 	// Server connection defaults (always applied — server mode is the only mode)
 	if cfg.ServerHost == "" {
-		cfg.ServerHost = "127.0.0.1"
+		// Host resolution: BEADS_DOLT_SERVER_HOST env > default 127.0.0.1.
+		if h := os.Getenv("BEADS_DOLT_SERVER_HOST"); h != "" {
+			cfg.ServerHost = h
+		} else {
+			cfg.ServerHost = "127.0.0.1"
+		}
 	}
-	// Port resolution: BEADS_DOLT_PORT env > BEADS_TEST_MODE guard > metadata config > default.
+	// Port resolution: BEADS_DOLT_SERVER_PORT env (or legacy BEADS_DOLT_PORT) >
+	// BEADS_TEST_MODE guard > metadata config > default.
 	// CRITICAL: BEADS_TEST_MODE=1 forces port 1 (immediate fail) if the resolved port
 	// is the production port (DefaultSQLPort). This prevents test databases from leaking
-	// onto production even when BEADS_DOLT_PORT is set to 3307 by Gas Town's beads module.
-	// Only an explicit non-production BEADS_DOLT_PORT (e.g., 43211 for a test server)
+	// onto production even when the port env var is set to 3307 by Gas Town's beads module.
+	// Only an explicit non-production port (e.g., 43211 for a test server)
 	// overrides test mode — that's a deliberate test server assignment.
-	if envPort := os.Getenv("BEADS_DOLT_PORT"); envPort != "" {
+	envPort := os.Getenv("BEADS_DOLT_SERVER_PORT")
+	if envPort == "" {
+		envPort = os.Getenv("BEADS_DOLT_PORT") // legacy fallback
+	}
+	if envPort != "" {
 		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
 			cfg.ServerPort = p
 		}
@@ -465,11 +475,11 @@ func New(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 	// Hard guard: tests must NEVER connect to the production Dolt server.
 	// If BEADS_TEST_MODE=1 and we're about to hit the default prod port,
-	// something upstream forgot to set BEADS_DOLT_PORT. Panic immediately
+	// something upstream forgot to set BEADS_DOLT_SERVER_PORT. Panic immediately
 	// so the test fails loudly instead of silently polluting prod.
 	if os.Getenv("BEADS_TEST_MODE") == "1" && cfg.ServerPort == DefaultSQLPort {
 		panic(fmt.Sprintf(
-			"BEADS_TEST_MODE=1 but connecting to prod port %d — set BEADS_DOLT_PORT or use test helpers (database=%q, path=%q)",
+			"BEADS_TEST_MODE=1 but connecting to prod port %d — set BEADS_DOLT_SERVER_PORT or use test helpers (database=%q, path=%q)",
 			DefaultSQLPort, cfg.Database, cfg.Path,
 		))
 	}


### PR DESCRIPTION
## Summary
Fixes #2141

The store connection layer (`applyConfigDefaults` in `store.go`) only checked the legacy `BEADS_DOLT_PORT` env var, while the config layer (`configfile.go`), server layer (`doltserver.go`), and documentation (`DOLT.md`, `DOLT-BACKEND.md`) all use `BEADS_DOLT_SERVER_PORT` / `BEADS_DOLT_SERVER_HOST`.

Users who set the documented env vars (e.g., for container deployments) were silently ignored for the actual DB connection — the store fell back to the default port/host.

## Changes
- `applyConfigDefaults` now checks `BEADS_DOLT_SERVER_PORT` first, with `BEADS_DOLT_PORT` as a legacy fallback
- `applyConfigDefaults` now checks `BEADS_DOLT_SERVER_HOST` env var for the server host (needed for container setups where the Dolt server is on a different host)
- Updated panic message and comments to reference the canonical env var names

## Test plan
- [ ] Existing tests pass (they use `BEADS_DOLT_PORT` which still works via legacy fallback)
- [ ] Setting `BEADS_DOLT_SERVER_PORT=3308` is now honored by the store connection
- [ ] Setting `BEADS_DOLT_SERVER_HOST=dolt-server` is now honored for container deployments

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)