### PR TITLE
fix(queries): fall through on empty wisps results for ephemeral filter

### DIFF
--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -17,7 +17,7 @@ func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types
 	// Route ephemeral-only queries to wisps table, falling through to
 	// issues table if wisps table doesn't exist (pre-migration databases).
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		if results, err := s.searchWisps(ctx, query, filter); err == nil {
+		if results, err := s.searchWisps(ctx, query, filter); err == nil && len(results) > 0 {
 			return results, nil
 		}
 		// Fall through: query issues table with ephemeral filter instead


### PR DESCRIPTION
## Summary

- Align ephemeral filter fallback with the allEphemeral(IDs) path: also check `len(results) > 0` before returning wisps results
- Without this, an empty wisps table would short-circuit the fallback to the issues table (where ephemeral rows may live on pre-migration databases)

Follow-up to #2161.

## Test plan

- [x] Existing tests pass (1-line change, consistent with adjacent path)
- [ ] `bd list --ephemeral` finds ephemeral issues when wisps table exists but is empty


🤖 Generated with [Claude Code](https://claude.com/claude-code)