### PR TITLE
fix: handle Windows connectex syscall in verifyServerTarget ECONNREFUSED check

### DIFF
--- a/cmd/bd/migrate_safety.go
+++ b/cmd/bd/migrate_safety.go
@@ -106,7 +106,8 @@ func verifyServerTarget(expectedDBName string, port int) error {
 		// But timeouts or other errors = unknown state = warn and abort.
 		if opErr, ok := err.(*net.OpError); ok {
 			if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
-				if sysErr.Syscall == "connect" {
+				// On POSIX the syscall is "connect"; on Windows it's "connectex".
+				if sysErr.Syscall == "connect" || sysErr.Syscall == "connectex" {
 					// ECONNREFUSED — no server, safe
 					return nil
 				}


### PR DESCRIPTION
## Summary

Fix `verifyServerTarget()` failing on Windows with "unknown error" when no Dolt server is running.

## Problem

On Windows, `net.DialTimeout` wraps connection-refused errors with syscall name `"connectex"` (Winsock API), not `"connect"` (POSIX). The existing check only matched `"connect"`, so ECONNREFUSED was misidentified as an unknown error on Windows, causing the SQLite auto-migration to fail with:

```
server check failed: cannot verify server on port 14055 (unknown error, not safe to proceed):
  dial tcp 127.0.0.1:14055: connectex: No connection could be made because the target machine actively refused it.
```

## Fix

One-line change: also match `"connectex"` in the syscall name check.

```go
// Before
if sysErr.Syscall == "connect" {

// After
if sysErr.Syscall == "connect" || sysErr.Syscall == "connectex" {
```

## Testing

- `TestVerifyServerTarget_NoServerRunning` passes on Windows (confirms the fix)
- All `TestVerifyServerTarget_*` tests pass

Fixes #2170
