### PR TITLE
feat(labels): inherit parent labels on child creation (GH#2100)

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -441,7 +441,8 @@ var createCmd = &cobra.Command{
 			FatalError("cannot specify both --id and --parent flags")
 		}
 
-		// If parent is specified, generate child ID
+		// If parent is specified, generate child ID and optionally inherit labels
+		var inheritedLabels []string
 		if parentID != "" {
 			ctx := rootCtx
 			// Validate parent exists before generating child ID
@@ -457,6 +458,12 @@ var createCmd = &cobra.Command{
 				FatalError("%v", err)
 			}
 			explicitID = childID // Set as explicit ID for the rest of the flow
+
+			// Inherit parent labels unless --no-inherit-labels is set (GH#2100)
+			noInheritLabels, _ := cmd.Flags().GetBool("no-inherit-labels")
+			if !noInheritLabels {
+				inheritedLabels, _ = store.GetLabels(ctx, parentID)
+			}
 		}
 
 		// Validate explicit ID format if provided
@@ -581,6 +588,19 @@ var createCmd = &cobra.Command{
 				WarnError("failed to add parent-child dependency %s -> %s: %v", issue.ID, parentID, err)
 			} else {
 				postCreateWrites = true
+			}
+		}
+
+		// Merge inherited parent labels with user-specified labels (GH#2100)
+		if len(inheritedLabels) > 0 {
+			seen := make(map[string]bool)
+			for _, l := range labels {
+				seen[l] = true
+			}
+			for _, l := range inheritedLabels {
+				if !seen[l] {
+					labels = append(labels, l)
+				}
 			}
 		}
 
@@ -768,6 +788,7 @@ func init() {
 	_ = createCmd.Flags().MarkHidden("label") // Only fails if flag missing (caught in tests)
 	createCmd.Flags().String("id", "", "Explicit issue ID (e.g., 'bd-42' for partitioning)")
 	createCmd.Flags().String("parent", "", "Parent issue ID for hierarchical child (e.g., 'bd-a3f8e9')")
+	createCmd.Flags().Bool("no-inherit-labels", false, "Don't inherit labels from parent issue")
 	createCmd.Flags().StringSlice("deps", []string{}, "Dependencies in format 'type:id' or 'id' (e.g., 'discovered-from:bd-20,blocks:bd-15' or 'bd-20')")
 	createCmd.Flags().String("waits-for", "", "Spawner issue ID to wait for (creates waits-for dependency for fanout gate)")
 	createCmd.Flags().String("waits-for-gate", "all-children", "Gate type: all-children (wait for all) or any-children (wait for first)")


### PR DESCRIPTION
## Summary

When creating child issues via `bd create --parent`, labels from the parent are
now automatically inherited. This removes friction in multi-worktree setups
where `branch:` labels must be manually re-applied to every child after
breaking down an epic. A new `bd label propagate` command allows pushing
labels to existing children retroactively.

## Changes

- **`cmd/bd/create.go`**: After validating the parent and generating the child
  ID, fetch parent labels and merge them (deduplicated) with user-specified
  labels. Added `--no-inherit-labels` flag to skip inheritance.
- **`cmd/bd/label.go`**: Added `bd label propagate <parent-id> <label>`
  subcommand. Finds direct children via `ParentID` filter, adds the label
  to each in a single transaction. Relies on AddLabel's existing idempotency.

## Test plan

- [x] Manual E2E: create epic with 2 labels, create child (inherits both),
  add label without propagate (child unchanged), add label with propagate
  (child gets it), verify final counts (4 on epic, 3 on child)
- [x] `go test -race -short ./cmd/bd/...` passes
- [x] `golangci-lint run ./cmd/bd/...` clean (no new warnings)

Closes #2100