### PR TITLE
fix: use derived port in migrate_shim and init instead of hardcoded 3307

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -869,7 +869,7 @@ func checkExistingBeadsDataAt(beadsDir string, prefix string) error {
 			location := doltPath
 			if cfg.IsDoltServerMode() {
 				host := cfg.GetDoltServerHost()
-				port := cfg.GetDoltServerPort()
+				port := doltserver.DefaultConfig(beadsDir).Port
 				location = fmt.Sprintf("dolt server at %s:%d", host, port)
 			}
 			return fmt.Errorf(`

--- a/cmd/bd/migrate_shim.go
+++ b/cmd/bd/migrate_shim.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -147,7 +148,7 @@ func doShimMigrate(beadsDir string) {
 	autoStart := os.Getenv("GT_ROOT") == "" && os.Getenv("BEADS_DOLT_AUTO_START") != "0"
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
 		resolvedHost = cfg.GetDoltServerHost()
-		resolvedPort = cfg.GetDoltServerPort()
+		resolvedPort = doltserver.DefaultConfig(beadsDir).Port
 		resolvedUser = cfg.GetDoltServerUser()
 		resolvedPassword = cfg.GetDoltServerPassword()
 		resolvedTLS = cfg.GetDoltServerTLS()


### PR DESCRIPTION
## Summary
- Replace `cfg.GetDoltServerPort()` with `doltserver.DefaultConfig(beadsDir).Port` in `migrate_shim.go` (SQLite→Dolt migration connection) and `init.go` (error message display)
- Follows the same pattern established in doctor/dolt.go by commits 2c206f19 and 3d62376a
- These were the last two production call sites using the deprecated fallback-to-3307 path

## Test plan
- [x] `go build ./cmd/bd/` passes
- [x] `go vet ./cmd/bd/` passes
- [x] Grep confirms no remaining production `GetDoltServerPort()` call sites

Fixes #2172

🤖 Generated with [Claude Code](https://claude.com/claude-code)