### PR TITLE
feat: add hk (hk.jdx.dev) as supported git hook manager

### DIFF
--- a/cmd/bd/doctor/fix/hooks_test.go
+++ b/cmd/bd/doctor/fix/hooks_test.go
@@ -81,6 +81,31 @@ func TestDetectExternalHookManagers(t *testing.T) {
 			expected: []string{"pre-commit"},
 		},
 		{
+			name: "hk.pkl",
+			setup: func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "hk.pkl"), []byte("hooks {\n}\n"), 0644)
+			},
+			expected: []string{"hk"},
+		},
+		{
+			name: ".config/hk.pkl",
+			setup: func(dir string) error {
+				configDir := filepath.Join(dir, ".config")
+				if err := os.MkdirAll(configDir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(configDir, "hk.pkl"), []byte("hooks {\n}\n"), 0644)
+			},
+			expected: []string{"hk"},
+		},
+		{
+			name: "hk.local.pkl",
+			setup: func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "hk.local.pkl"), []byte("hooks {\n}\n"), 0644)
+			},
+			expected: []string{"hk"},
+		},
+		{
 			name: ".overcommit.yml",
 			setup: func(dir string) error {
 				return os.WriteFile(filepath.Join(dir, ".overcommit.yml"), []byte("PreCommit:\n"), 0644)
@@ -274,6 +299,193 @@ pre-commit:
 
 			if status == nil {
 				t.Fatal("expected non-nil status")
+			}
+
+			if status.Configured != tt.expectConfigured {
+				t.Errorf("Configured: expected %v, got %v", tt.expectConfigured, status.Configured)
+			}
+
+			if !slicesEqual(status.HooksWithBd, tt.expectHooksWithBd) {
+				t.Errorf("HooksWithBd: expected %v, got %v", tt.expectHooksWithBd, status.HooksWithBd)
+			}
+
+			if !slicesEqual(status.HooksWithoutBd, tt.expectHooksWithoutBd) {
+				t.Errorf("HooksWithoutBd: expected %v, got %v", tt.expectHooksWithoutBd, status.HooksWithoutBd)
+			}
+
+			if !slicesEqual(status.HooksNotInConfig, tt.expectNotInConfig) {
+				t.Errorf("HooksNotInConfig: expected %v, got %v", tt.expectNotInConfig, status.HooksNotInConfig)
+			}
+		})
+	}
+}
+
+func TestCheckHkBdIntegration(t *testing.T) {
+	tests := []struct {
+		name                 string
+		configFile           string
+		configContent        string
+		expectNil            bool
+		expectConfigured     bool
+		expectHooksWithBd    []string
+		expectHooksWithoutBd []string
+		expectNotInConfig    []string
+	}{
+		{
+			name:      "no config",
+			expectNil: true,
+		},
+		{
+			name:       "all recommended hooks with bd",
+			configFile: "hk.pkl",
+			configContent: `amends "package://github.com/jdx/hk/releases/download/v1.36.0/hk@1.36.0#/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["bd-pre-commit"] {
+                check = "bd hooks run pre-commit"
+            }
+        }
+    }
+    ["post-merge"] {
+        steps {
+            ["bd-post-merge"] {
+                check = "bd hooks run post-merge"
+            }
+        }
+    }
+    ["pre-push"] {
+        steps {
+            ["bd-pre-push"] {
+                check = "bd hooks run pre-push \"$@\""
+            }
+        }
+    }
+}
+`,
+			expectConfigured:  true,
+			expectHooksWithBd: []string{"pre-commit", "post-merge", "pre-push"},
+		},
+		{
+			name:       "partial bd integration",
+			configFile: "hk.pkl",
+			configContent: `hooks {
+    ["pre-commit"] {
+        steps {
+            ["bd-pre-commit"] {
+                check = "bd hooks run pre-commit"
+            }
+            ["lint"] {
+                glob = "*.go"
+                check = "golangci-lint run {{files}}"
+            }
+        }
+    }
+    ["post-merge"] {
+        steps {
+            ["notify"] {
+                check = "echo merged"
+            }
+        }
+    }
+}
+`,
+			expectConfigured:     true,
+			expectHooksWithBd:    []string{"pre-commit"},
+			expectHooksWithoutBd: []string{"post-merge"},
+			expectNotInConfig:    []string{"pre-push"},
+		},
+		{
+			name:       "no bd at all",
+			configFile: "hk.pkl",
+			configContent: `hooks {
+    ["pre-commit"] {
+        steps {
+            ["lint"] {
+                glob = "*.go"
+                check = "golangci-lint run {{files}}"
+            }
+        }
+    }
+}
+`,
+			expectConfigured:     false,
+			expectHooksWithoutBd: []string{"pre-commit"},
+			expectNotInConfig:    []string{"post-merge", "pre-push"},
+		},
+		{
+			name:       ".config/hk.pkl location",
+			configFile: ".config/hk.pkl",
+			configContent: `hooks {
+    ["pre-commit"] {
+        steps {
+            ["bd-sync"] {
+                check = "bd hooks run pre-commit"
+            }
+        }
+    }
+}
+`,
+			expectConfigured:  true,
+			expectHooksWithBd: []string{"pre-commit"},
+			expectNotInConfig: []string{"post-merge", "pre-push"},
+		},
+		{
+			name:       "hk.local.pkl only",
+			configFile: "hk.local.pkl",
+			configContent: `hooks {
+    ["pre-commit"] {
+        steps {
+            ["bd-sync"] {
+                check = "bd hooks run pre-commit"
+            }
+        }
+    }
+}
+`,
+			expectConfigured:  true,
+			expectHooksWithBd: []string{"pre-commit"},
+			expectNotInConfig: []string{"post-merge", "pre-push"},
+		},
+		{
+			name:              "empty config",
+			configFile:        "hk.pkl",
+			configContent:     ``,
+			expectConfigured:  false,
+			expectNotInConfig: []string{"pre-commit", "post-merge", "pre-push"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			if tt.configFile != "" {
+				configPath := filepath.Join(dir, tt.configFile)
+				if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+					t.Fatalf("failed to create config dir: %v", err)
+				}
+				if err := os.WriteFile(configPath, []byte(tt.configContent), 0644); err != nil {
+					t.Fatalf("failed to write config: %v", err)
+				}
+			}
+
+			status := CheckHkBdIntegration(dir)
+
+			if tt.expectNil {
+				if status != nil {
+					t.Errorf("expected nil status, got %+v", status)
+				}
+				return
+			}
+
+			if status == nil {
+				t.Fatal("expected non-nil status")
+			}
+
+			if status.Manager != "hk" {
+				t.Errorf("Manager: expected 'hk', got %q", status.Manager)
 			}
 
 			if status.Configured != tt.expectConfigured {
@@ -571,6 +783,11 @@ func TestDetectActiveHookManager(t *testing.T) {
 		hookContent string
 		expected    string
 	}{
+		{
+			name:        "hk signature",
+			hookContent: "#!/bin/sh\ntest \"${HK:-1}\" = \"0\" || exec hk run pre-commit \"$@\"\n",
+			expected:    "hk",
+		},
 		{
 			name:        "lefthook signature",
 			hookContent: "#!/bin/sh\n# lefthook\nexec lefthook run pre-commit\n",
@@ -1027,6 +1244,16 @@ func TestCheckManagerBdIntegration(t *testing.T) {
 			},
 			expectNil:     false,
 			expectManager: "husky",
+		},
+		{
+			name:        "hk integration",
+			managerName: "hk",
+			setup: func(dir string) error {
+				config := "hooks {\n    [\"pre-commit\"] {\n        steps {\n            [\"bd\"] {\n                check = \"bd hooks run pre-commit\"\n            }\n        }\n    }\n}\n"
+				return os.WriteFile(filepath.Join(dir, "hk.pkl"), []byte(config), 0644)
+			},
+			expectNil:     false,
+			expectManager: "hk",
 		},
 	}
 

--- a/docs/GIT_INTEGRATION.md
+++ b/docs/GIT_INTEGRATION.md
@@ -84,6 +84,50 @@ See [PROTECTED_BRANCHES.md](PROTECTED_BRANCHES.md) for complete setup guide, tro
 
 ## Git Hooks
 
+### External Hook Manager Support
+
+bd detects and integrates with these external git hook managers:
+
+- **[lefthook](https://lefthook.dev/)** — YAML/TOML/JSON config
+- **[husky](https://typicode.github.io/husky/)** — `.husky/` directory scripts
+- **[pre-commit](https://pre-commit.com/)** — `.pre-commit-config.yaml`
+- **[prek](https://prek.j178.dev/)** — Rust-based pre-commit alternative (same config)
+- **[hk](https://hk.jdx.dev/)** — Fast hook manager using Pkl config
+- **[overcommit](https://github.com/sds/overcommit)** — Ruby-based (detection only)
+- **[simple-git-hooks](https://github.com/toplenboren/simple-git-hooks)** — Lightweight JS (detection only)
+
+When an external hook manager is detected, `bd hooks install` uses `--chain` to preserve existing hooks.
+
+#### hk Integration Example
+
+Add bd hooks to your `hk.pkl`:
+
+```pkl
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["bd-pre-commit"] {
+                check = "bd hooks run pre-commit"
+            }
+        }
+    }
+    ["post-merge"] {
+        steps {
+            ["bd-post-merge"] {
+                check = "bd hooks run post-merge"
+            }
+        }
+    }
+    ["pre-push"] {
+        steps {
+            ["bd-pre-push"] {
+                check = "bd hooks run pre-push \"$@\""
+            }
+        }
+    }
+}
+```
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
[`hk`](https://hk.jdx.dev/) is a fast git hook manager by @jdx (the mise author) that uses [`Pkl`](https://github.com/apple/pkl) configuration. This PR adds it as a first-class integration in the three places where beads recognizes external hook managers.

## Changes

### Config file detection

`hk.pkl`, `.config/hk.pkl`, `hk.local.pkl`, and `.config/hk.local.pkl` are now recognized in hookManagerConfigs. When present, `bd hooks install` will use `--chain` to preserve existing hk hooks.

### Active hook detection

Added `\bhk\s+run\b` pattern to hookManagerPatterns so beads can identify hk-installed hooks from git hook file content (hk shims look like `exec hk run pre-commit "$@"`). Placed before lefthook to avoid any pattern overlap.

### Config integration check

New `CheckHkBdIntegration()` scans the Pkl config file for `bd hooks run <hookname>` per recommended hook, with section presence detection via `["hookname"]` to distinguish "hook configured without bd" from "hook not configured at all".

## Tests 

227 lines covering all three layers: config file detection variants, active hook shim matching, full/partial/no bd integration, `.config/` path, `hk.local.pkl`, and empty config.

## Docs

Updated `GIT_INTEGRATION.md` with the full supported manager list and an `hk` Pkl config example.

Example `hk.pkl`:
```
hooks {
    ["pre-commit"] {
        steps {
            ["bd-pre-commit"] {
                check = "bd hooks run pre-commit"
            }
        }
    }
    ["post-merge"] {
        steps {
            ["bd-post-merge"] {
                check = "bd hooks run post-merge"
            }
        }
    }
}
```