### PR TITLE
fix: route auto-backup queries through retry-wrapped DoltStore methods

### DIFF
--- a/cmd/bd/backup_export.go
+++ b/cmd/bd/backup_export.go
@@ -15,6 +15,13 @@ import (
 	"github.com/steveyegge/beads/internal/debug"
 )
 
+// dbQuerier abstracts query execution so callers can use a retry-wrapped
+// DoltStore.QueryContext instead of a raw *sql.DB.  Both *sql.DB and
+// *dolt.DoltStore satisfy this interface.
+type dbQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
 // backupState tracks watermarks for incremental backup.
 type backupState struct {
 	LastDoltCommit string    `json:"last_dolt_commit"`
@@ -142,8 +149,7 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 		}
 	}
 
-	db := store.DB()
-	hasWisps := tableExistsCheck(ctx, db, "wisps")
+	hasWisps := tableExistsCheck(ctx, store, "wisps")
 
 	// Export each table. Use SELECT * so we capture all columns (schema has 50+
 	// fields and grows over time). The dynamic column scanner handles this automatically.
@@ -151,14 +157,14 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 	if hasWisps {
 		issuesQuery = "SELECT * FROM issues UNION ALL SELECT * FROM wisps ORDER BY id"
 	}
-	n, err := exportTable(ctx, db, dir, "issues.jsonl", issuesQuery)
+	n, err := exportTable(ctx, store, dir, "issues.jsonl", issuesQuery)
 	if err != nil {
 		return nil, fmt.Errorf("backup issues: %w", err)
 	}
 	state.Counts.Issues = n
 
 	// Events: incremental append
-	n, err = exportEventsIncremental(ctx, db, dir, state, hasWisps)
+	n, err = exportEventsIncremental(ctx, store, dir, state, hasWisps)
 	if err != nil {
 		return nil, fmt.Errorf("backup events: %w", err)
 	}
@@ -171,7 +177,7 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 			"SELECT id, issue_id, author, text, created_at FROM wisp_comments " +
 			"ORDER BY id"
 	}
-	n, err = exportTable(ctx, db, dir, "comments.jsonl", commentsQuery)
+	n, err = exportTable(ctx, store, dir, "comments.jsonl", commentsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("backup comments: %w", err)
 	}
@@ -184,7 +190,7 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 			"SELECT issue_id, depends_on_id, type, created_at, created_by FROM wisp_dependencies " +
 			"ORDER BY issue_id, depends_on_id"
 	}
-	n, err = exportTable(ctx, db, dir, "dependencies.jsonl", depsQuery)
+	n, err = exportTable(ctx, store, dir, "dependencies.jsonl", depsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("backup dependencies: %w", err)
 	}
@@ -197,13 +203,13 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 			"SELECT issue_id, label FROM wisp_labels " +
 			"ORDER BY issue_id, label"
 	}
-	n, err = exportTable(ctx, db, dir, "labels.jsonl", labelsQuery)
+	n, err = exportTable(ctx, store, dir, "labels.jsonl", labelsQuery)
 	if err != nil {
 		return nil, fmt.Errorf("backup labels: %w", err)
 	}
 	state.Counts.Labels = n
 
-	n, err = exportTable(ctx, db, dir, "config.jsonl",
+	n, err = exportTable(ctx, store, dir, "config.jsonl",
 		"SELECT `key`, value FROM config ORDER BY `key`")
 	if err != nil {
 		return nil, fmt.Errorf("backup config: %w", err)
@@ -226,10 +232,13 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 }
 
 // tableExistsCheck returns true if the named table exists in the database.
-func tableExistsCheck(ctx context.Context, db *sql.DB, table string) bool {
-	var name string
-	err := db.QueryRowContext(ctx, "SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_NAME = ?", table).Scan(&name)
-	return err == nil
+func tableExistsCheck(ctx context.Context, q dbQuerier, table string) bool {
+	rows, err := q.QueryContext(ctx, "SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_NAME = ?", table)
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	return rows.Next()
 }
 
 // truncateHash returns the first 8 characters of a hash, or the full string if shorter.
@@ -242,8 +251,8 @@ func truncateHash(h string) string {
 
 // exportTable runs a query and writes each row as a JSON object to a JSONL file.
 // Returns the number of rows exported.
-func exportTable(ctx context.Context, db *sql.DB, dir, filename, query string) (int, error) {
-	rows, err := db.QueryContext(ctx, query)
+func exportTable(ctx context.Context, q dbQuerier, dir, filename, query string) (int, error) {
+	rows, err := q.QueryContext(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("query failed: %w", err)
 	}
@@ -291,7 +300,7 @@ func exportTable(ctx context.Context, db *sql.DB, dir, filename, query string) (
 
 // exportEventsIncremental appends new events since the last high-water mark.
 // On first export (lastEventID=0), dumps all events as a full snapshot.
-func exportEventsIncremental(ctx context.Context, db *sql.DB, dir string, state *backupState, hasWisps bool) (int, error) {
+func exportEventsIncremental(ctx context.Context, q dbQuerier, dir string, state *backupState, hasWisps bool) (int, error) {
 	query := "SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at " +
 		"FROM events WHERE id > ? ORDER BY id ASC"
 	args := []interface{}{state.LastEventID}
@@ -306,7 +315,7 @@ func exportEventsIncremental(ctx context.Context, db *sql.DB, dir string, state 
 		args = []interface{}{state.LastEventID, state.LastEventID}
 	}
 
-	rows, err := db.QueryContext(ctx, query, args...)
+	rows, err := q.QueryContext(ctx, query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("query failed: %w", err)
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -385,6 +385,13 @@ func (s *DoltStore) DB() *sql.DB {
 	return s.db
 }
 
+// QueryContext wraps s.db.QueryContext with retry for transient errors.
+// Exported so callers (e.g. backup) can run ad-hoc queries with retry
+// instead of going through the raw *sql.DB.
+func (s *DoltStore) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return s.queryContext(ctx, query, args...)
+}
+
 // queryContext wraps s.db.QueryContext with retry for transient errors.
 func (s *DoltStore) queryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	if s.closed.Load() {

--- a/internal/storage/dolt/versioned.go
+++ b/internal/storage/dolt/versioned.go
@@ -2,6 +2,7 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -160,7 +161,9 @@ func (s *DoltStore) ListBranches(ctx context.Context) ([]string, error) {
 // Implements storage.VersionedStorage.
 func (s *DoltStore) GetCurrentCommit(ctx context.Context) (string, error) {
 	var hash string
-	err := s.db.QueryRowContext(ctx, "SELECT DOLT_HASHOF('HEAD')").Scan(&hash)
+	err := s.queryRowContext(ctx, func(row *sql.Row) error {
+		return row.Scan(&hash)
+	}, "SELECT DOLT_HASHOF('HEAD')")
 	if err != nil {
 		return "", fmt.Errorf("failed to get current commit: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Auto-backup path (`PersistentPostRun`) was calling `store.DB()` to get a raw `*sql.DB` and querying directly, bypassing `DoltStore.withRetry()`. Stale pool connections caused `invalid connection` errors with no retry.
- `GetCurrentCommit()` also called `s.db.QueryRowContext()` directly, skipping the retry wrapper.
- Added exported `DoltStore.QueryContext()` and introduced a `dbQuerier` interface so backup functions use retry-wrapped queries instead of the raw connection pool.

## Changes

- **`internal/storage/dolt/store.go`** — Export `QueryContext()` as public retry-wrapped query method
- **`internal/storage/dolt/versioned.go`** — Fix `GetCurrentCommit()` to use `s.queryRowContext()` with retry
- **`cmd/bd/backup_export.go`** — Introduce `dbQuerier` interface; pass `store` (retry-wrapped) instead of `store.DB()` (raw) to all backup query functions

## Test plan

- [x] `go build ./internal/storage/dolt/ ./cmd/bd/` passes
- [x] `go vet ./internal/storage/dolt/` clean
- [x] `go test ./internal/storage/dolt/...` passes
- [x] `go test ./cmd/bd/ -run Backup` — all backup tests pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)