### PR TITLE
feat(wisp): add --root-only flag to bd mol wisp create

### DIFF
--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -144,6 +144,7 @@ func runWispCreate(cmd *cobra.Command, args []string) {
 	}
 
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	rootOnly, _ := cmd.Flags().GetBool("root-only")
 	varFlags, _ := cmd.Flags().GetStringArray("var")
 
 	// Parse variables
@@ -253,7 +254,13 @@ func runWispCreate(cmd *cobra.Command, args []string) {
 
 	// Spawn as ephemeral in main database (Ephemeral=true, not synced via git)
 	// Use wisp prefix for distinct visual recognition (see types.IDPrefixWisp)
-	result, err := spawnMolecule(ctx, store, subgraph, vars, "", actor, true, types.IDPrefixWisp)
+	result, err := spawnMoleculeWithOptions(ctx, store, subgraph, CloneOptions{
+		Vars:      vars,
+		Actor:     actor,
+		Ephemeral: true,
+		Prefix:    types.IDPrefixWisp,
+		RootOnly:  rootOnly,
+	})
 	if err != nil {
 		FatalError("creating wisp: %v", err)
 	}
@@ -724,10 +731,12 @@ func init() {
 	// Wisp command flags (for direct create: bd mol wisp <proto>)
 	wispCmd.Flags().StringArray("var", []string{}, "Variable substitution (key=value)")
 	wispCmd.Flags().Bool("dry-run", false, "Preview what would be created")
+	wispCmd.Flags().Bool("root-only", false, "Create only the root issue (no child step issues)")
 
 	// Wisp create command flags (kept for backwards compat: bd mol wisp create <proto>)
 	wispCreateCmd.Flags().StringArray("var", []string{}, "Variable substitution (key=value)")
 	wispCreateCmd.Flags().Bool("dry-run", false, "Preview what would be created")
+	wispCreateCmd.Flags().Bool("root-only", false, "Create only the root issue (no child step issues)")
 
 	wispListCmd.Flags().Bool("all", false, "Include closed wisps")
 


### PR DESCRIPTION
## Summary

- Add `--root-only` flag to `bd mol wisp create` and `bd mol wisp <proto>` commands
- When set, only the root issue is created — child step issues are skipped
- Add `RootOnly bool` field to `CloneOptions` in `template.go` with filtering in `cloneSubgraph`

## Motivation

`gt patrol new` calls `bd mol wisp create <proto> --root-only` to create patrol wisps where steps are inlined at prime time rather than tracked as individual beads. Without this flag, `gt patrol new` fails with an "unknown flag: --root-only" error, breaking the patrol workflow for witness and refinery agents.

The workaround has been to call `bd mol wisp mol-refinery-patrol` followed by `bd update --status=hooked` directly, but the proper fix is to support the flag in `bd`.

## Test plan

- [ ] `bd mol wisp create mol-witness-patrol --root-only` creates only the root issue
- [ ] `bd mol wisp mol-witness-patrol --root-only` (direct form) also creates only the root
- [ ] Without `--root-only`, behavior is unchanged — all child step issues are created
- [ ] `gt patrol new --role refinery` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)