### PR TITLE
fix(doctor): clean cruft in redirect-expected dirs even without redirect file

### DIFF
--- a/cmd/bd/doctor/artifacts.go
+++ b/cmd/bd/doctor/artifacts.go
@@ -298,7 +298,7 @@ func scanCruftBeadsDir(beadsDir string, hasRedirect bool, report *ArtifactReport
 		Path:        beadsDir,
 		Type:        "cruft-beads",
 		Description: desc,
-		SafeDelete:  hasRedirect, // Safe only if redirect is already in place
+		SafeDelete:  true, // Safe: location is redirect-expected, extra files are cruft
 	})
 }
 

--- a/cmd/bd/doctor/artifacts_test.go
+++ b/cmd/bd/doctor/artifacts_test.go
@@ -111,7 +111,9 @@ func TestScanForArtifacts_CruftBeadsDir(t *testing.T) {
 }
 
 func TestScanForArtifacts_CruftBeadsDirNoRedirect(t *testing.T) {
-	// Cruft dir without redirect should be detected but NOT safe to delete
+	// Cruft dir without redirect should be detected AND safe to delete.
+	// The location being redirect-expected is sufficient — stale cruft files
+	// are what prevent the redirect from being created in the first place.
 	dir := t.TempDir()
 	polecatsDir := filepath.Join(dir, "polecats", "testpolecat")
 	beadsDir := filepath.Join(polecatsDir, ".beads")
@@ -126,12 +128,12 @@ func TestScanForArtifacts_CruftBeadsDirNoRedirect(t *testing.T) {
 
 	report := ScanForArtifacts(dir)
 
-	// Should be detected as cruft (it's in a polecat location) but NOT safe to delete
+	// Should be detected as cruft (it's in a polecat location) and safe to delete
 	if len(report.CruftBeadsDirs) != 1 {
 		t.Errorf("expected 1 cruft beads dir, got %d", len(report.CruftBeadsDirs))
 	}
-	if len(report.CruftBeadsDirs) > 0 && report.CruftBeadsDirs[0].SafeDelete {
-		t.Error("cruft beads dir without redirect should NOT be safe to delete")
+	if len(report.CruftBeadsDirs) > 0 && !report.CruftBeadsDirs[0].SafeDelete {
+		t.Error("cruft beads dir in redirect-expected location should be safe to delete")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `bd doctor --fix` now cleans stale cruft files from redirect-expected `.beads` directories (e.g., `.git/beads-worktrees/*/.beads/`) even when the `redirect` file is missing
- Previously required both `isRedirectExpected AND hasRedirect`, which skipped cleanup in the most common case: upgrading from pre-dolt where no redirect was ever created
- Marks cruft in redirect-expected locations as `SafeDelete: true` in scan reports regardless of redirect file presence

## Test plan

- [x] New regression test `TestClassicArtifacts_CleansCruftWithoutRedirectFile` verifies 6 typical stale files (config.yaml, metadata.json, README.md, issues.jsonl, .gitignore, .local_version) are removed from `.git/beads-worktrees/master/.beads/` when no redirect file exists
- [x] Updated `TestScanForArtifacts_CruftBeadsDirNoRedirect` to match new `SafeDelete: true` behavior
- [x] All existing artifact tests pass (both fix and detection packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)