### PR TITLE
fix: handle NULL created_by in issue scan

### DIFF
--- a/internal/storage/dolt/issue_scan.go
+++ b/internal/storage/dolt/issue_scan.go
@@ -35,6 +35,7 @@ func scanIssueFrom(s issueScanner) (*types.Issue, error) {
 	var createdAtStr, updatedAtStr sql.NullString // TEXT columns - must parse manually
 	var closedAt, compactedAt, lastActivity, dueAt, deferUntil sql.NullTime
 	var estimatedMinutes, originalSize, timeoutNs sql.NullInt64
+	var createdBy sql.NullString
 	var assignee, externalRef, specID, compactedAtCommit, owner sql.NullString
 	var contentHash, sourceRepo, closeReason sql.NullString
 	var workType, sourceSystem sql.NullString
@@ -49,7 +50,7 @@ func scanIssueFrom(s issueScanner) (*types.Issue, error) {
 		&issue.ID, &contentHash, &issue.Title, &issue.Description, &issue.Design,
 		&issue.AcceptanceCriteria, &issue.Notes, &issue.Status,
 		&issue.Priority, &issue.IssueType, &assignee, &estimatedMinutes,
-		&createdAtStr, &issue.CreatedBy, &owner, &updatedAtStr, &closedAt, &externalRef, &specID,
+		&createdAtStr, &createdBy, &owner, &updatedAtStr, &closedAt, &externalRef, &specID,
 		&issue.CompactionLevel, &compactedAt, &compactedAtCommit, &originalSize, &sourceRepo, &closeReason,
 		&sender, &ephemeral, &wispType, &pinned, &isTemplate, &crystallizes,
 		&awaitType, &awaitID, &timeoutNs, &waiters,
@@ -82,6 +83,9 @@ func scanIssueFrom(s issueScanner) (*types.Issue, error) {
 	}
 	if assignee.Valid {
 		issue.Assignee = assignee.String
+	}
+	if createdBy.Valid {
+		issue.CreatedBy = createdBy.String
 	}
 	if owner.Valid {
 		issue.Owner = owner.String


### PR DESCRIPTION
## Summary
- `bd duplicates` crashes with scan error on column index 13 when `created_by` is NULL
- `scanIssueFrom()` scanned `created_by` directly into `issue.CreatedBy` (a plain `string`), which panics on NULL
- Fix: use `sql.NullString` + conditional assignment, matching the existing pattern for `assignee`, `owner`, and other nullable string columns

## Root Cause
`issue_scan.go:52` had `&issue.CreatedBy` in the Scan call. When a row has NULL in the `created_by` column, Go's `database/sql` cannot scan NULL into a `string` destination, causing a crash.

## Test Plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/storage/dolt/...` — all pass
- [x] `bd duplicates` — no longer crashes, reports "No duplicates found!"

Fixes: bd-c03