### PR TITLE
fix: route auto-backup queries through retry-wrapped DoltStore methods

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -392,6 +392,13 @@ func (s *DoltStore) DB() *sql.DB {
 	return s.db
 }
 
+// QueryContext wraps s.db.QueryContext with retry for transient errors.
+// Exported so callers (e.g. backup) can run ad-hoc queries with retry
+// instead of going through the raw *sql.DB.
+func (s *DoltStore) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return s.queryContext(ctx, query, args...)
+}
+
 // queryContext wraps s.db.QueryContext with retry for transient errors.
 func (s *DoltStore) queryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	if s.closed.Load() {


### PR DESCRIPTION
## Summary

- Backup export called `store.DB()` for a raw `*sql.DB`, bypassing DoltStore retry logic on transient connection errors
- This caused auto-backup to trip the circuit breaker on brief server hiccups
- Add exported `DoltStore.QueryContext()` wrapping the existing retry-aware `queryContext()`
- Introduce `dbQuerier` interface so backup functions accept either `*sql.DB` or `*DoltStore`

Clean rebase of #2186 onto current main — that PR had merge conflicts from #2188 and #2197 landing first. Supersedes #2186.

Credit: @seanbearden (original fix)

## Test plan

- [x] `go build ./cmd/bd/` compiles clean
- [x] `go test ./cmd/bd/ -run Backup` — all pass
- [x] CI (via push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)