### PR TITLE
fix: replace deprecated GetDoltServerPort() callers with doltserver.DefaultConfig()

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -870,7 +870,7 @@ func checkExistingBeadsDataAt(beadsDir string, prefix string) error {
 			location := doltPath
 			if cfg.IsDoltServerMode() {
 				host := cfg.GetDoltServerHost()
-				port := cfg.GetDoltServerPort()
+				port := doltserver.DefaultConfig(beadsDir).Port
 				location = fmt.Sprintf("dolt server at %s:%d", host, port)
 			}
 			return fmt.Errorf(`

--- a/cmd/bd/migrate_shim.go
+++ b/cmd/bd/migrate_shim.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -147,7 +148,7 @@ func doShimMigrate(beadsDir string) {
 	autoStart := os.Getenv("GT_ROOT") == "" && os.Getenv("BEADS_DOLT_AUTO_START") != "0"
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
 		resolvedHost = cfg.GetDoltServerHost()
-		resolvedPort = cfg.GetDoltServerPort()
+		resolvedPort = doltserver.DefaultConfig(beadsDir).Port
 		resolvedUser = cfg.GetDoltServerUser()
 		resolvedPassword = cfg.GetDoltServerPassword()
 		resolvedTLS = cfg.GetDoltServerTLS()


### PR DESCRIPTION
## Summary

- Two remaining call sites (`init.go`, `migrate_shim.go`) still used the deprecated `GetDoltServerPort()` which falls back to hardcoded port 3307
- In standalone mode (no explicit port in metadata.json, no `GT_ROOT`), the Dolt server listens on a hash-derived port (13307–14306), so these callers connected to the wrong port
- Replaced both with `doltserver.DefaultConfig(beadsDir).Port` which uses the correct resolution chain: env var > metadata.json > Gas Town port > hash-derived port

## Test plan

- [x] `go build ./cmd/bd/` compiles cleanly
- [x] `gofmt` passes on both changed files
- [x] `go test -short ./cmd/bd/` passes
- [x] `go test -short ./internal/configfile/` passes
- [x] `golangci-lint run ./cmd/bd/` reports no new issues on changed files
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)