### PR TITLE
fix: unexport DefaultInfraTypes to prevent mutation inconsistency (#2193)

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -78,7 +78,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if len(infraTypes) == 0 {
-			infraTypes = dolt.DefaultInfraTypes
+			infraTypes = dolt.DefaultInfraTypes()
 		}
 		for _, t := range infraTypes {
 			filter.ExcludeTypes = append(filter.ExcludeTypes, types.IssueType(t))

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -565,7 +565,7 @@ var listCmd = &cobra.Command{
 		// Infra type filtering: exclude configured infra types by default.
 		// These types live in the wisps table after migration 007.
 		// Use --include-infra or --type=agent to show infra beads.
-		infraTypes := dolt.DefaultInfraTypes
+		infraTypes := dolt.DefaultInfraTypes()
 		if store != nil {
 			infraSet := store.GetInfraTypes(rootCtx)
 			infraTypes = make([]string, 0, len(infraSet))

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -222,7 +222,7 @@ func (s *DoltStore) GetInfraTypes(ctx context.Context) map[string]bool {
 	}
 
 	if len(types) == 0 {
-		types = DefaultInfraTypes
+		types = defaultInfraTypes
 	}
 
 	result := make(map[string]bool, len(types))

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -15,14 +15,22 @@ func IsEphemeralID(id string) bool {
 	return strings.Contains(id, "-wisp-")
 }
 
-// DefaultInfraTypes are the built-in infrastructure types routed to the wisps table.
+// defaultInfraTypes are the built-in infrastructure types routed to the wisps table.
 // Override via DB config "types.infra" or config.yaml types.infra.
-var DefaultInfraTypes = []string{"agent", "rig", "role", "message"}
+// Unexported to prevent external mutation; use DefaultInfraTypes() for a safe copy.
+var defaultInfraTypes = []string{"agent", "rig", "role", "message"}
 
-// defaultInfraSet is the set form of DefaultInfraTypes for IsInfraType lookups.
+// DefaultInfraTypes returns a copy of the built-in infrastructure types.
+func DefaultInfraTypes() []string {
+	out := make([]string, len(defaultInfraTypes))
+	copy(out, defaultInfraTypes)
+	return out
+}
+
+// defaultInfraSet is the set form of defaultInfraTypes for IsInfraType lookups.
 var defaultInfraSet = func() map[string]bool {
-	m := make(map[string]bool, len(DefaultInfraTypes))
-	for _, t := range DefaultInfraTypes {
+	m := make(map[string]bool, len(defaultInfraTypes))
+	for _, t := range defaultInfraTypes {
 		m[t] = true
 	}
 	return m


### PR DESCRIPTION
## Problem

`DefaultInfraTypes` in `internal/storage/dolt/ephemeral_routing.go` is an exported mutable slice, while `defaultInfraSet` is computed once at init() time. If external code modifies the slice after init, `IsInfraType()` silently becomes inconsistent with the actual default types.

## Fix

- Unexport the slice as `defaultInfraTypes`
- Add `DefaultInfraTypes()` function that returns a defensive copy
- Internal (same-package) callers in `config.go` use the unexported var directly
- External callers in `export.go` and `list.go` now call the function, getting a safe copy

Minimal change — no behavior difference for correct usage, prevents a class of subtle bugs.

Fixes #2193