### PR TITLE
fix: restore sandbox guard in maybeAutoPush (#2192)

### DIFF
--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -33,6 +33,10 @@ func isDoltAutoPushEnabled(ctx context.Context) bool {
 // maybeAutoPush pushes to the Dolt remote if enabled and the debounce interval has passed.
 // Called from PersistentPostRun after auto-commit and auto-backup.
 func maybeAutoPush(ctx context.Context) {
+	if isSandboxMode() {
+		debug.Logf("dolt auto-push: skipped (sandbox mode)\n")
+		return
+	}
 	if !isDoltAutoPushEnabled(ctx) {
 		return
 	}


### PR DESCRIPTION
## Problem

`maybeAutoPush` in `cmd/bd/dolt_autopush.go` was missing a sandbox mode check, allowing network operations (Dolt remote push) in sandboxed contexts (CI, tests, `--sandbox` flag workflows).

This was flagged by Copilot review on PR #2188 as a pre-existing issue in upstream.

## Fix

Add `isSandboxMode()` guard at the top of `maybeAutoPush` to skip network operations in sandbox mode. This is the minimal fix — the `isDoltAutoPushEnabled()` config check that follows handles the normal enable/disable logic, but doesn't account for the sandbox override.

## Note on #2191

Issue #2191 reports that `maybeAutoPush` runs on read-only commands. After review, this is intentional: auto-push uses debounced catch-up to push previously-committed-but-not-yet-pushed changes. The change detection at line 72 (`currentCommit == lastPushedCommit`) already efficiently skips when nothing needs pushing. Metadata writes only occur after a successful push, not on every invocation.

Fixes #2192