### PR TITLE
fix: propagate notes field from formula steps to issues (#2155)

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -540,6 +540,7 @@ func processStepToIssue(step *formula.Step, parentID string) *types.Issue {
 		ID:             issueID,
 		Title:          step.Title, // Keep {{variables}} for substitution at pour time
 		Description:    step.Description,
+		Notes:          step.Notes,
 		Status:         types.StatusOpen,
 		Priority:       priority,
 		IssueType:      issueType,
@@ -1026,6 +1027,7 @@ func substituteStepVars(steps []*formula.Step, vars map[string]string) {
 	for _, step := range steps {
 		step.Title = substituteVariables(step.Title, vars)
 		step.Description = substituteVariables(step.Description, vars)
+		step.Notes = substituteVariables(step.Notes, vars)
 		if len(step.Children) > 0 {
 			substituteStepVars(step.Children, vars)
 		}

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -188,6 +188,9 @@ type Step struct {
 	// Description is the issue description (supports substitution).
 	Description string `json:"description,omitempty"`
 
+	// Notes are additional notes for the issue (supports substitution).
+	Notes string `json:"notes,omitempty"`
+
 	// Type is the issue type: task, bug, feature, epic, chore.
 	Type string `json:"type,omitempty"`
 


### PR DESCRIPTION
## Problem

Formula TOML `[[steps]]` can define a `notes` field, but it was silently discarded during pour because `formula.Step` had no `Notes` field. The `types.Issue` struct already has `Notes`, and `cloneSubgraph()` in `template.go` already does variable substitution on `Notes` — only the parsing/mapping was missing.

## Fix (3 lines across 2 files)

1. **`internal/formula/types.go`** — Add `Notes string` field to `Step` struct
2. **`cmd/bd/cook.go`** — Map `step.Notes` to `issue.Notes` in `processStepToIssue()`
3. **`cmd/bd/cook.go`** — Add `step.Notes` to variable substitution in `substituteStepVars()`

Fixes #2155