### PR TITLE
fix: bd init --stealth sets no-git-ops: true in config (#2159)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -473,6 +473,14 @@ environment variable.`,
 				// Non-fatal - continue anyway
 			}
 
+			// In stealth mode, persist no-git-ops: true so bd prime
+			// automatically uses stealth session-close protocol (GH#2159)
+			if stealth {
+				if err := config.SaveConfigValue("no-git-ops", true, beadsDir); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to set no-git-ops in config: %v\n", err)
+				}
+			}
+
 			// Create README.md
 			if err := createReadme(beadsDir); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to create README.md: %v\n", err)


### PR DESCRIPTION
## Summary

When running `bd init --stealth`, persist `no-git-ops: true` in `.beads/config.yaml` so that `bd prime` automatically detects stealth repos and uses the stealth session-close protocol.

## Problem

`bd init --stealth` configured `.git/info/exclude` but didn't set `no-git-ops: true` in config. Users had to manually run `bd config set no-git-ops true` for `bd prime` to recognize stealth mode.

## Fix

After creating `config.yaml` during init, if `--stealth` is set, call `config.SaveConfigValue("no-git-ops", true, beadsDir)` to persist the setting.

This is a one-line logical change (8 lines with error handling and comment). Uses the existing `SaveConfigValue` API.

Fixes #2159