### PR TITLE
fix: skip maybeAutoPush on read-only commands (#2191)

### DIFF
--- a/cmd/bd/dolt_autopush_test.go
+++ b/cmd/bd/dolt_autopush_test.go
@@ -81,6 +81,23 @@ func TestMaybeAutoPush_NilStore(t *testing.T) {
 	maybeAutoPush(context.Background())
 }
 
+func TestAutoPush_SkippedForReadOnlyCommands(t *testing.T) {
+	// Read-only commands should not trigger auto-push (GH#2191).
+	readOnly := []string{"list", "ready", "show", "stats", "blocked", "search", "graph"}
+	for _, cmd := range readOnly {
+		if !isReadOnlyCommand(cmd) {
+			t.Errorf("isReadOnlyCommand(%q) = false, want true", cmd)
+		}
+	}
+
+	writeCmds := []string{"create", "update", "close", "import"}
+	for _, cmd := range writeCmds {
+		if isReadOnlyCommand(cmd) {
+			t.Errorf("isReadOnlyCommand(%q) = true, want false", cmd)
+		}
+	}
+}
+
 func TestMaybeAutoPush_DisabledByConfig(t *testing.T) {
 	// When explicitly disabled, maybeAutoPush should be a no-op.
 	t.Setenv("BD_DOLT_AUTO_PUSH", "false")

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -660,8 +660,12 @@ var rootCmd = &cobra.Command{
 		// Auto-backup: export JSONL to .beads/backup/ if enabled and due
 		maybeAutoBackup(rootCtx)
 
-		// Auto-push: push to Dolt remote if enabled and due
-		maybeAutoPush(rootCtx)
+		// Auto-push: push to Dolt remote if enabled and due.
+		// Skip for read-only commands to avoid unnecessary network operations
+		// and metadata writes on commands like bd list/show/ready (GH#2191).
+		if !isReadOnlyCommand(cmd.Name()) {
+			maybeAutoPush(rootCtx)
+		}
 
 		// Signal that store is closing (prevents background flush from accessing closed store)
 		storeMutex.Lock()


### PR DESCRIPTION
## Problem

`maybeAutoPush` runs unconditionally in `PersistentPostRun`, meaning read-only commands like `bd list`, `bd show`, and `bd ready` trigger unnecessary DB reads (`HasRemote`, `GetMetadata`, `GetCurrentCommit`) and potential network operations.

## Fix

Guard `maybeAutoPush` with the existing `isReadOnlyCommand()` check, which already controls whether the store is opened in read-only mode. Write commands continue to trigger auto-push with existing debounce and change detection.

Read-only commands remain truly side-effect-free. Accumulated unpushed changes from prior writes will be pushed on the next write command or explicit `bd dolt push`.

## Test

Added `TestAutoPush_SkippedForReadOnlyCommands` verifying the guard classifies commands correctly.

Closes #2191