### PR TITLE
docs: teach agents to use stdin for descriptions (#1376)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ bd update <id> --title "new title"
 bd update <id> --design "design notes"
 bd update <id> --notes "additional notes"
 bd update <id> --acceptance "acceptance criteria"
+
+# Use stdin for descriptions with special characters (backticks, !, nested quotes)
+echo 'Description with `backticks` and "quotes"' | bd create "Title" --description=-
+echo 'Updated text' | bd update <id> --description=-
 ```
 
 ## Testing Commands (No Ambiguity)
@@ -118,6 +122,9 @@ bd ready --json
 ```bash
 bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
 bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
+
+# Use stdin for descriptions with special characters (backticks, !, nested quotes)
+echo 'Description with `backticks` and "quotes"' | bd create "Title" --description=- --json
 ```
 
 **Claim and update:**

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -187,6 +187,16 @@ bd update <id> --notes "additional notes"
 bd update <id> --acceptance "acceptance criteria"
 ```
 
+**Use stdin for descriptions with special characters** (backticks, `!`, nested quotes):
+```bash
+# Pipe via stdin to avoid shell escaping issues
+echo 'Description with `backticks` and "quotes"' | bd create "Title" --description=-
+echo 'Updated description with $variables' | bd update <id> --description=-
+
+# Or use --body-file for longer content
+bd create "Title" --body-file=description.md
+```
+
 **Example agent session:**
 
 ```bash

--- a/claude-plugin/skills/beads/resources/CLI_REFERENCE.md
+++ b/claude-plugin/skills/beads/resources/CLI_REFERENCE.md
@@ -113,6 +113,13 @@ bd stale --limit 20 --json                   # Limit results
 # IMPORTANT: Always quote titles and descriptions with double quotes
 bd create "Issue title" -t bug|feature|task -p 0-4 -d "Description" --json
 
+# Use stdin for descriptions with special characters (backticks, !, nested quotes)
+echo 'Description with `backticks` and "quotes"' | bd create "Title" -t task -p 1 --description=- --json
+echo 'Updated text with $variables' | bd update <id> --description=-
+
+# Or use --body-file for longer content from a file
+bd create "Title" --body-file=description.md --json
+
 # Create with explicit ID (for parallel workers)
 bd create "Issue title" --id worker1-100 -p 1 --json
 


### PR DESCRIPTION
## Problem

`bd create --description "..."` fails when content has backticks, `!`, or nested quotes. The shell mangles arguments before `bd` sees them. Agents hit escaping failures, retry without description, then patch with `bd update`. Pointless churn.

## Fix

`bd` already supports `--description=-` (stdin) and `--body-file` via `flags.go` — but agent instructions and plugin skills don't mention them. This PR surfaces the stdin pattern in:

- **AGENT_INSTRUCTIONS.md** — adds stdin section after the `bd update` flags reference
- **AGENTS.md** — adds stdin examples in the update flags section
- **CLI_REFERENCE.md** (CC plugin skill) — adds stdin and `--body-file` examples at the top of the Create Issues section

### Recommended pattern for agents:

```bash
echo 'Description with \`backticks\` and "quotes"' | bd create "Title" --description=-
echo 'Updated text' | bd update <id> --description=-
```

Closes #1376