### PR TITLE
feat: phase 1 hook census and migration planning (#2217)

### DIFF
--- a/cmd/bd/doctor/hooks_migration.go
+++ b/cmd/bd/doctor/hooks_migration.go
@@ -1,0 +1,263 @@
+package doctor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	hookMarkerStateNone   = "none"
+	hookMarkerStateValid  = "valid"
+	hookMarkerStateBroken = "broken"
+
+	hookMarkerBeginToken = "BEGIN BEADS INTEGRATION"
+	hookMarkerEndToken   = "END BEADS INTEGRATION"
+)
+
+var managedHookNames = []string{
+	"pre-commit",
+	"post-merge",
+	"pre-push",
+	"post-checkout",
+	"prepare-commit-msg",
+}
+
+// HookMigrationHookPlan describes migration state for a single hook file.
+type HookMigrationHookPlan struct {
+	Name             string `json:"name"`
+	HookPath         string `json:"hook_path"`
+	Exists           bool   `json:"exists"`
+	MarkerState      string `json:"marker_state"`
+	LegacyBDHook     bool   `json:"legacy_bd_hook"`
+	HasOldSidecar    bool   `json:"has_old_sidecar"`
+	HasBackupSidecar bool   `json:"has_backup_sidecar"`
+	State            string `json:"state"`
+	NeedsMigration   bool   `json:"needs_migration"`
+	SuggestedAction  string `json:"suggested_action,omitempty"`
+	ReadError        string `json:"read_error,omitempty"`
+}
+
+// HookMigrationPlan summarizes migration state for all managed hooks.
+type HookMigrationPlan struct {
+	Path                string                  `json:"path"`
+	RepoRoot            string                  `json:"repo_root,omitempty"`
+	HooksDir            string                  `json:"hooks_dir,omitempty"`
+	IsGitRepo           bool                    `json:"is_git_repo"`
+	Hooks               []HookMigrationHookPlan `json:"hooks"`
+	TotalHooks          int                     `json:"total_hooks"`
+	NeedsMigrationCount int                     `json:"needs_migration_count"`
+	BrokenMarkerCount   int                     `json:"broken_marker_count"`
+}
+
+// PlanHookMigration builds a read-only migration plan for git hooks.
+func PlanHookMigration(path string) (HookMigrationPlan, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return HookMigrationPlan{}, fmt.Errorf("resolve path: %w", err)
+	}
+
+	plan := HookMigrationPlan{
+		Path:       absPath,
+		TotalHooks: len(managedHookNames),
+		Hooks:      make([]HookMigrationHookPlan, 0, len(managedHookNames)),
+	}
+
+	repoRoot, hooksDir, err := resolveGitHooksDir(absPath)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// Not a git repository (or no git metadata reachable from path).
+			return plan, nil
+		}
+		return HookMigrationPlan{}, err
+	}
+
+	plan.IsGitRepo = true
+	plan.RepoRoot = repoRoot
+	plan.HooksDir = hooksDir
+
+	for _, hookName := range managedHookNames {
+		hook := inspectHookMigration(hooksDir, hookName)
+		if hook.NeedsMigration {
+			plan.NeedsMigrationCount++
+		}
+		if hook.MarkerState == hookMarkerStateBroken {
+			plan.BrokenMarkerCount++
+		}
+		plan.Hooks = append(plan.Hooks, hook)
+	}
+
+	return plan, nil
+}
+
+func inspectHookMigration(hooksDir, hookName string) HookMigrationHookPlan {
+	hookPath := filepath.Join(hooksDir, hookName)
+	plan := HookMigrationHookPlan{
+		Name:             hookName,
+		HookPath:         hookPath,
+		HasOldSidecar:    fileExists(hookPath + ".old"),
+		HasBackupSidecar: fileExists(hookPath + ".backup"),
+		MarkerState:      hookMarkerStateNone,
+	}
+
+	content, err := os.ReadFile(hookPath) // #nosec G304 -- path is derived from git hooks dir + known hook names
+	if err == nil {
+		plan.Exists = true
+		contentStr := string(content)
+		plan.MarkerState = detectHookMarkerState(contentStr)
+		plan.LegacyBDHook = isLegacyBDHook(contentStr)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		plan.ReadError = err.Error()
+		plan.State = "read_error"
+		plan.SuggestedAction = "Inspect hook file permissions/content manually before migration."
+		return plan
+	}
+
+	classifyHookMigration(&plan)
+	return plan
+}
+
+func classifyHookMigration(hook *HookMigrationHookPlan) {
+	if hook.ReadError != "" {
+		return
+	}
+
+	switch hook.MarkerState {
+	case hookMarkerStateValid:
+		hook.State = "marker_managed"
+		return
+	case hookMarkerStateBroken:
+		hook.State = "marker_broken"
+		hook.NeedsMigration = true
+		hook.SuggestedAction = "Repair BEGIN/END marker mismatch, then rerun hook migration."
+		return
+	}
+
+	if hook.LegacyBDHook {
+		hook.NeedsMigration = true
+		switch {
+		case hook.HasOldSidecar && hook.HasBackupSidecar:
+			hook.State = "legacy_with_both_sidecars"
+			hook.SuggestedAction = "Prefer .old as preserved body, retain sidecars as migrated artifacts, inject managed section."
+		case hook.HasOldSidecar:
+			hook.State = "legacy_with_old_sidecar"
+			hook.SuggestedAction = "Restore preserved body from .old and inject managed section."
+		case hook.HasBackupSidecar:
+			hook.State = "legacy_with_backup_sidecar"
+			hook.SuggestedAction = "Restore preserved body from .backup and inject managed section."
+		default:
+			hook.State = "legacy_only"
+			hook.SuggestedAction = "Convert legacy hook in place to managed marker section."
+		}
+		return
+	}
+
+	if !hook.Exists {
+		switch {
+		case hook.HasOldSidecar && hook.HasBackupSidecar:
+			hook.State = "missing_with_both_sidecars"
+			hook.NeedsMigration = true
+			hook.SuggestedAction = "Recreate hook from sidecar content and inject managed section."
+		case hook.HasOldSidecar:
+			hook.State = "missing_with_old_sidecar"
+			hook.NeedsMigration = true
+			hook.SuggestedAction = "Recreate hook from .old sidecar and inject managed section."
+		case hook.HasBackupSidecar:
+			hook.State = "missing_with_backup_sidecar"
+			hook.NeedsMigration = true
+			hook.SuggestedAction = "Recreate hook from .backup sidecar and inject managed section."
+		default:
+			hook.State = "missing_no_artifacts"
+		}
+		return
+	}
+
+	if hook.HasOldSidecar || hook.HasBackupSidecar {
+		hook.State = "custom_with_sidecars"
+		hook.NeedsMigration = true
+		hook.SuggestedAction = "Preserve custom hook body, inject managed section, retire sidecar artifacts."
+		return
+	}
+
+	hook.State = "unmanaged_custom"
+}
+
+func detectHookMarkerState(content string) string {
+	hasBegin := strings.Contains(content, hookMarkerBeginToken)
+	hasEnd := strings.Contains(content, hookMarkerEndToken)
+
+	switch {
+	case hasBegin && hasEnd:
+		return hookMarkerStateValid
+	case hasBegin || hasEnd:
+		return hookMarkerStateBroken
+	default:
+		return hookMarkerStateNone
+	}
+}
+
+func isLegacyBDHook(content string) bool {
+	return strings.Contains(content, "# bd-shim") ||
+		strings.Contains(content, "bd-hooks-version:") ||
+		strings.Contains(content, "# bd (beads)")
+}
+
+func resolveGitHooksDir(path string) (repoRoot string, hooksDir string, err error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel", "--git-common-dir")
+	cmd.Dir = path
+	out, err := cmd.Output()
+	if err != nil {
+		return "", "", err
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return "", "", fmt.Errorf("unexpected git rev-parse output")
+	}
+
+	repoRoot = strings.TrimSpace(lines[0])
+	gitCommonDir := strings.TrimSpace(lines[1])
+	if !filepath.IsAbs(gitCommonDir) {
+		gitCommonDir = filepath.Join(repoRoot, gitCommonDir)
+	}
+
+	hooksDir = filepath.Join(gitCommonDir, "hooks")
+
+	hooksPathCmd := exec.Command("git", "config", "--get", "core.hooksPath")
+	hooksPathCmd.Dir = repoRoot
+	if hooksPathOut, hooksPathErr := hooksPathCmd.Output(); hooksPathErr == nil {
+		hooksPath := strings.TrimSpace(string(hooksPathOut))
+		if hooksPath != "" {
+			hooksPath = expandHookPathTilde(hooksPath)
+			if !filepath.IsAbs(hooksPath) {
+				hooksPath = filepath.Join(repoRoot, hooksPath)
+			}
+			hooksDir = hooksPath
+		}
+	}
+
+	return repoRoot, hooksDir, nil
+}
+
+func expandHookPathTilde(path string) string {
+	switch {
+	case strings.HasPrefix(path, "~/"), strings.HasPrefix(path, "~\\"):
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	case path == "~":
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+	}
+	return path
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cmd/bd/doctor/hooks_migration_test.go
+++ b/cmd/bd/doctor/hooks_migration_test.go
@@ -1,0 +1,182 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlanHookMigration_NotGitRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	plan, err := PlanHookMigration(tmpDir)
+	if err != nil {
+		t.Fatalf("PlanHookMigration returned error: %v", err)
+	}
+
+	if plan.IsGitRepo {
+		t.Fatalf("expected IsGitRepo=false, got true")
+	}
+	if plan.NeedsMigrationCount != 0 {
+		t.Fatalf("expected no migrations, got %d", plan.NeedsMigrationCount)
+	}
+}
+
+func TestPlanHookMigration_LegacyWithOldSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupGitRepoInDir(t, tmpDir)
+	forceRepoHooksPath(t, tmpDir)
+
+	_, hooksDir, err := resolveGitHooksDir(tmpDir)
+	if err != nil {
+		t.Fatalf("resolveGitHooksDir failed: %v", err)
+	}
+
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit"), "#!/bin/sh\n# bd-shim v2\n# bd-hooks-version: 0.56.1\nexec bd hooks run pre-commit \"$@\"\n")
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit.old"), "#!/bin/sh\necho legacy\n")
+
+	plan, err := PlanHookMigration(tmpDir)
+	if err != nil {
+		t.Fatalf("PlanHookMigration returned error: %v", err)
+	}
+
+	hook, ok := findHookPlan(plan, "pre-commit")
+	if !ok {
+		t.Fatalf("pre-commit hook not found in plan")
+	}
+
+	if !hook.NeedsMigration {
+		t.Fatalf("expected pre-commit to need migration")
+	}
+	if hook.State != "legacy_with_old_sidecar" {
+		t.Fatalf("expected state legacy_with_old_sidecar, got %q", hook.State)
+	}
+	if plan.NeedsMigrationCount != 1 {
+		t.Fatalf("expected 1 migration, got %d", plan.NeedsMigrationCount)
+	}
+}
+
+func TestPlanHookMigration_MarkerManaged(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupGitRepoInDir(t, tmpDir)
+	forceRepoHooksPath(t, tmpDir)
+
+	_, hooksDir, err := resolveGitHooksDir(tmpDir)
+	if err != nil {
+		t.Fatalf("resolveGitHooksDir failed: %v", err)
+	}
+
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit"), "#!/bin/sh\n# --- BEGIN BEADS INTEGRATION v0.57.0 ---\nbd hook pre-commit \"$@\"\n# --- END BEADS INTEGRATION v0.57.0 ---\n")
+
+	plan, err := PlanHookMigration(tmpDir)
+	if err != nil {
+		t.Fatalf("PlanHookMigration returned error: %v", err)
+	}
+
+	hook, ok := findHookPlan(plan, "pre-commit")
+	if !ok {
+		t.Fatalf("pre-commit hook not found in plan")
+	}
+
+	if hook.NeedsMigration {
+		t.Fatalf("expected pre-commit to be managed already")
+	}
+	if hook.State != "marker_managed" {
+		t.Fatalf("expected state marker_managed, got %q", hook.State)
+	}
+	if plan.NeedsMigrationCount != 0 {
+		t.Fatalf("expected no migrations, got %d", plan.NeedsMigrationCount)
+	}
+}
+
+func TestPlanHookMigration_BrokenMarker(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupGitRepoInDir(t, tmpDir)
+	forceRepoHooksPath(t, tmpDir)
+
+	_, hooksDir, err := resolveGitHooksDir(tmpDir)
+	if err != nil {
+		t.Fatalf("resolveGitHooksDir failed: %v", err)
+	}
+
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit"), "#!/bin/sh\n# --- BEGIN BEADS INTEGRATION v0.57.0 ---\nbd hook pre-commit \"$@\"\n")
+
+	plan, err := PlanHookMigration(tmpDir)
+	if err != nil {
+		t.Fatalf("PlanHookMigration returned error: %v", err)
+	}
+
+	hook, ok := findHookPlan(plan, "pre-commit")
+	if !ok {
+		t.Fatalf("pre-commit hook not found in plan")
+	}
+
+	if !hook.NeedsMigration {
+		t.Fatalf("expected pre-commit to need migration")
+	}
+	if hook.MarkerState != hookMarkerStateBroken {
+		t.Fatalf("expected marker state broken, got %q", hook.MarkerState)
+	}
+	if plan.BrokenMarkerCount != 1 {
+		t.Fatalf("expected BrokenMarkerCount=1, got %d", plan.BrokenMarkerCount)
+	}
+}
+
+func TestPlanHookMigration_MissingHookWithBackupSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupGitRepoInDir(t, tmpDir)
+	forceRepoHooksPath(t, tmpDir)
+
+	_, hooksDir, err := resolveGitHooksDir(tmpDir)
+	if err != nil {
+		t.Fatalf("resolveGitHooksDir failed: %v", err)
+	}
+
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit.backup"), "#!/bin/sh\necho backup\n")
+
+	plan, err := PlanHookMigration(tmpDir)
+	if err != nil {
+		t.Fatalf("PlanHookMigration returned error: %v", err)
+	}
+
+	hook, ok := findHookPlan(plan, "pre-commit")
+	if !ok {
+		t.Fatalf("pre-commit hook not found in plan")
+	}
+
+	if !hook.NeedsMigration {
+		t.Fatalf("expected pre-commit to need migration")
+	}
+	if hook.State != "missing_with_backup_sidecar" {
+		t.Fatalf("expected state missing_with_backup_sidecar, got %q", hook.State)
+	}
+}
+
+func writeHookFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create parent directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("failed to write hook file: %v", err)
+	}
+}
+
+func findHookPlan(plan HookMigrationPlan, name string) (HookMigrationHookPlan, bool) {
+	for _, hook := range plan.Hooks {
+		if hook.Name == name {
+			return hook, true
+		}
+	}
+	return HookMigrationHookPlan{}, false
+}
+
+func forceRepoHooksPath(t *testing.T, repoPath string) {
+	t.Helper()
+	cmd := exec.Command("git", "config", "core.hooksPath", ".git/hooks")
+	cmd.Dir = repoPath
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath for test repo: %v", err)
+	}
+}

--- a/cmd/bd/doctor/migration_hooks_test.go
+++ b/cmd/bd/doctor/migration_hooks_test.go
@@ -1,0 +1,62 @@
+package doctor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectPendingMigrations_Hooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupGitRepoInDir(t, tmpDir)
+	forceRepoHooksPath(t, tmpDir)
+
+	_, hooksDir, err := resolveGitHooksDir(tmpDir)
+	if err != nil {
+		t.Fatalf("resolveGitHooksDir failed: %v", err)
+	}
+
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit"), "#!/bin/sh\n# bd-shim v2\n# bd-hooks-version: 0.56.1\nexec bd hooks run pre-commit \"$@\"\n")
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit.old"), "#!/bin/sh\necho old\n")
+
+	pending := DetectPendingMigrations(tmpDir)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending migration, got %d", len(pending))
+	}
+
+	m := pending[0]
+	if m.Name != "hooks" {
+		t.Fatalf("expected migration name 'hooks', got %q", m.Name)
+	}
+	if m.Command != "bd migrate hooks --dry-run" {
+		t.Fatalf("expected command 'bd migrate hooks --dry-run', got %q", m.Command)
+	}
+	if m.Priority != 2 {
+		t.Fatalf("expected recommended priority 2, got %d", m.Priority)
+	}
+}
+
+func TestDetectPendingMigrations_HooksBrokenMarkerIsWarningInPhase1(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupGitRepoInDir(t, tmpDir)
+	forceRepoHooksPath(t, tmpDir)
+
+	_, hooksDir, err := resolveGitHooksDir(tmpDir)
+	if err != nil {
+		t.Fatalf("resolveGitHooksDir failed: %v", err)
+	}
+
+	writeHookFile(t, filepath.Join(hooksDir, "pre-commit"), "#!/bin/sh\n# --- BEGIN BEADS INTEGRATION v0.57.0 ---\nbd hook pre-commit \"$@\"\n")
+
+	pending := DetectPendingMigrations(tmpDir)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending migration, got %d", len(pending))
+	}
+	if pending[0].Priority != 2 {
+		t.Fatalf("expected warning priority 2 in phase 1, got %d", pending[0].Priority)
+	}
+
+	check := CheckPendingMigrations(tmpDir)
+	if check.Status != StatusWarning {
+		t.Fatalf("expected warning status for phase 1 planning-only migration, got %q", check.Status)
+	}
+}

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -26,6 +26,7 @@ Backend migration flags:
   --to-dolt     Migrate from SQLite to Dolt backend
 
 Subcommands:
+  hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
   sync        Set up sync.branch workflow for multi-clone setups
 `,
@@ -769,6 +770,10 @@ func init() {
 	migrateSyncCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
 	migrateSyncCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	migrateCmd.AddCommand(migrateSyncCmd)
+
+	migrateHooksCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
+	migrateHooksCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	migrateCmd.AddCommand(migrateHooksCmd)
 
 	rootCmd.AddCommand(migrateCmd)
 }

--- a/cmd/bd/migrate_hooks.go
+++ b/cmd/bd/migrate_hooks.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/cmd/bd/doctor"
+)
+
+const hookMigrationApplyTrackingIssue = "https://github.com/steveyegge/beads/issues/2218"
+
+var migrateHooksCmd = &cobra.Command{
+	Use:   "hooks [path]",
+	Short: "Plan git hook migration to marker-managed format",
+	Long: `Analyze git hook files and sidecar artifacts for migration to marker-managed format.
+
+This command is planning-only in phase 1. It does not modify hook files.
+
+Examples:
+  bd migrate hooks
+  bd migrate hooks --dry-run
+  bd migrate hooks --json`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		requestedDryRun, _ := cmd.Flags().GetBool("dry-run")
+		if err := validateHookMigrationDryRunRequested(requestedDryRun); err != nil {
+			FatalErrorRespectJSON("%v", err)
+		}
+
+		targetPath := "."
+		if len(args) == 1 {
+			targetPath = args[0]
+		}
+
+		absPath, err := filepath.Abs(targetPath)
+		if err != nil {
+			FatalErrorRespectJSON("resolving path: %v", err)
+		}
+
+		plan, err := doctor.PlanHookMigration(absPath)
+		if err != nil {
+			FatalErrorRespectJSON("building hook migration plan: %v", err)
+		}
+
+		if jsonOutput {
+			outputJSON(buildHookMigrationJSON(plan, requestedDryRun))
+			return
+		}
+
+		fmt.Println(strings.Join(formatHookMigrationPlan(plan, requestedDryRun), "\n"))
+	},
+}
+
+func validateHookMigrationDryRunRequested(requestedDryRun bool) error {
+	if requestedDryRun {
+		return nil
+	}
+	return errors.New(
+		"phase 1 is planning-only: --dry-run is required for 'bd migrate hooks'. " +
+			"Apply mode is tracked in #2218 and will be enabled once the PR resolving #2218 is merged: " +
+			hookMigrationApplyTrackingIssue,
+	)
+}
+
+func buildHookMigrationJSON(plan doctor.HookMigrationPlan, requestedDryRun bool) map[string]interface{} {
+	return map[string]interface{}{
+		"status":            "planning_only",
+		"planning_only":     true,
+		"requested_dry_run": requestedDryRun,
+		"dry_run":           true,
+		"plan":              plan,
+	}
+}
+
+func formatHookMigrationPlan(plan doctor.HookMigrationPlan, requestedDryRun bool) []string {
+	lines := []string{
+		"Hook migration plan (planning only)",
+	}
+
+	if !plan.IsGitRepo {
+		lines = append(lines, fmt.Sprintf("Path: %s", plan.Path))
+		lines = append(lines, "Result: not a git repository (no hook migration needed).")
+		return lines
+	}
+
+	lines = append(lines,
+		fmt.Sprintf("Repository: %s", plan.RepoRoot),
+		fmt.Sprintf("Hooks dir: %s", plan.HooksDir),
+		fmt.Sprintf("Needs migration: %d/%d", plan.NeedsMigrationCount, plan.TotalHooks),
+	)
+
+	if plan.BrokenMarkerCount > 0 {
+		lines = append(lines, fmt.Sprintf("Broken markers detected: %d", plan.BrokenMarkerCount))
+	}
+
+	for _, hook := range plan.Hooks {
+		decision := "no action"
+		if hook.NeedsMigration {
+			decision = "migrate"
+		}
+
+		lines = append(lines, fmt.Sprintf("- %s: %s [%s]", hook.Name, hook.State, decision))
+		if hook.SuggestedAction != "" {
+			lines = append(lines, fmt.Sprintf("  action: %s", hook.SuggestedAction))
+		}
+		if hook.ReadError != "" {
+			lines = append(lines, fmt.Sprintf("  read_error: %s", hook.ReadError))
+		}
+	}
+
+	if plan.NeedsMigrationCount > 0 {
+		lines = append(lines, "Next: run 'bd migrate hooks --dry-run --json' for machine-readable planning output.")
+	} else {
+		lines = append(lines, "No hook migration is required.")
+	}
+
+	return lines
+}

--- a/cmd/bd/migrate_hooks_test.go
+++ b/cmd/bd/migrate_hooks_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/cmd/bd/doctor"
+)
+
+func TestBuildHookMigrationJSON(t *testing.T) {
+	plan := doctor.HookMigrationPlan{
+		Path:                "/tmp/repo",
+		IsGitRepo:           true,
+		NeedsMigrationCount: 2,
+		TotalHooks:          5,
+	}
+
+	out := buildHookMigrationJSON(plan, false)
+
+	if status, ok := out["status"].(string); !ok || status != "planning_only" {
+		t.Fatalf("expected status planning_only, got %#v", out["status"])
+	}
+	if planningOnly, ok := out["planning_only"].(bool); !ok || !planningOnly {
+		t.Fatalf("expected planning_only=true, got %#v", out["planning_only"])
+	}
+	if dryRun, ok := out["dry_run"].(bool); !ok || !dryRun {
+		t.Fatalf("expected dry_run=true, got %#v", out["dry_run"])
+	}
+}
+
+func TestValidateHookMigrationDryRunRequested(t *testing.T) {
+	if err := validateHookMigrationDryRunRequested(true); err != nil {
+		t.Fatalf("expected no error for dry-run mode, got %v", err)
+	}
+
+	err := validateHookMigrationDryRunRequested(false)
+	if err == nil {
+		t.Fatalf("expected error when --dry-run is missing")
+	}
+	if !strings.Contains(err.Error(), "--dry-run is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "#2218") {
+		t.Fatalf("expected issue reference #2218, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "resolving #2218 is merged") {
+		t.Fatalf("expected merge condition note, got: %v", err)
+	}
+}
+
+func TestFormatHookMigrationPlan_NotGitRepo(t *testing.T) {
+	lines := formatHookMigrationPlan(doctor.HookMigrationPlan{
+		Path:      "/tmp/no-git",
+		IsGitRepo: false,
+	}, true)
+
+	rendered := strings.Join(lines, "\n")
+	if !strings.Contains(rendered, "not a git repository") {
+		t.Fatalf("expected non-git message, got: %s", rendered)
+	}
+}
+
+func TestFormatHookMigrationPlan_WithMigrations(t *testing.T) {
+	plan := doctor.HookMigrationPlan{
+		Path:                "/tmp/repo",
+		RepoRoot:            "/tmp/repo",
+		HooksDir:            "/tmp/repo/.git/hooks",
+		IsGitRepo:           true,
+		TotalHooks:          5,
+		NeedsMigrationCount: 1,
+		Hooks: []doctor.HookMigrationHookPlan{
+			{
+				Name:           "pre-commit",
+				State:          "legacy_with_old_sidecar",
+				NeedsMigration: true,
+			},
+		},
+	}
+
+	lines := formatHookMigrationPlan(plan, true)
+	rendered := strings.Join(lines, "\n")
+
+	if !strings.Contains(rendered, "Needs migration: 1/5") {
+		t.Fatalf("expected migration summary, got: %s", rendered)
+	}
+	if !strings.Contains(rendered, "- pre-commit: legacy_with_old_sidecar [migrate]") {
+		t.Fatalf("expected hook entry, got: %s", rendered)
+	}
+	if !strings.Contains(rendered, "Next: run 'bd migrate hooks --dry-run --json'") {
+		t.Fatalf("expected next-step hint, got: %s", rendered)
+	}
+}


### PR DESCRIPTION
Part of #1380
Closes #2217

## Summary
This PR implements Phase 1 (Hook Census) as a planning-only step.

It adds a read-only hook migration planner and surfaces pending hook migration through `bd migrate hooks --dry-run` and `bd doctor`.

## Why this should exist
- Gives users and automation a deterministic migration plan before any file mutation.
- Separates detection/planning from apply-mode to reduce migration risk.
- Makes legacy hook states visible (`.old` / `.backup`, legacy markers, broken marker pairs).
- Keeps cognitive load low by extending existing `migrate` and `doctor` surfaces.

## Behavior added
- New command: `bd migrate hooks [path] --dry-run [--json]`.
- `bd migrate hooks` without `--dry-run` now exits with a phase-1 guard message.
- New planner output includes per-hook state and suggested action.
- `bd doctor` `Pending Migrations` now reports hook migration needs and points to `bd migrate hooks --dry-run`.
- Broken marker states are warning-level in phase 1 (TODO in code to raise with apply-mode).

## Scope boundaries (intentional)
- No hook file mutation path in this PR.
- No changes to `bd init` / `bd hooks install` write behavior.
- No `bd doctor --fix` execution wiring for hook migration.

## Tests
- `go test ./cmd/bd/doctor -run 'TestPlanHookMigration|TestDetectPendingMigrations_Hooks|TestCheckPendingMigrations'`
- `go test ./cmd/bd -run 'TestBuildHookMigrationJSON|TestFormatHookMigrationPlan|TestValidateHookMigrationDryRunRequested'`
