### PR TITLE
test: add regression test for dolt remote store initialization (#2224)

### DIFF
--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -753,6 +753,65 @@ func TestDoltConfigSubcommandsSkipStore(t *testing.T) {
 	}
 }
 
+// TestDoltRemoteSubcommandsNeedStore verifies that bd dolt remote add/list/remove
+// reach store initialization despite "dolt" being in noDbCommands.
+//
+// These commands call getStore() but their Cobra parent is "remote" (not "dolt"),
+// so the needsStoreDoltSubcommands guard in PersistentPreRun doesn't apply to them.
+// They currently work because "remote" is not in noDbCommands, allowing them to
+// fall through to normal store initialization. This test encodes that implicit
+// dependency so regressions are caught if the guard logic changes.
+//
+// See: GH#2224
+func TestDoltRemoteSubcommandsNeedStore(t *testing.T) {
+	// Verify add, list, remove are registered under doltRemoteCmd
+	storeSubcommands := []string{"add", "list", "remove"}
+	for _, name := range storeSubcommands {
+		found := false
+		for _, cmd := range doltRemoteCmd.Commands() {
+			if cmd.Name() == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected dolt remote subcommand %q to be registered", name)
+		}
+	}
+
+	// Verify that "remote" is NOT in noDbCommands.
+	// This is the fragile assumption: remote subcommands reach store init
+	// only because their parent name ("remote") isn't in the skip list.
+	// If someone adds "remote" to noDbCommands, these commands will break
+	// with "no store available" errors.
+	//
+	// Note: We can't directly access noDbCommands (it's a local variable
+	// inside PersistentPreRun), so we verify the structural property:
+	// doltRemoteCmd's parent is doltCmd, and remote subcommands' parent
+	// is doltRemoteCmd (not doltCmd). This means the parentName == "dolt"
+	// check in PersistentPreRun won't match for remote subcommands.
+	if doltRemoteCmd.Parent() == nil {
+		t.Fatal("doltRemoteCmd should have a parent (doltCmd)")
+	}
+	if doltRemoteCmd.Parent().Name() != "dolt" {
+		t.Errorf("doltRemoteCmd parent should be 'dolt', got %q", doltRemoteCmd.Parent().Name())
+	}
+
+	// Verify that remote subcommands' parent is "remote", not "dolt".
+	// This confirms they bypass the dolt-specific guard in PersistentPreRun.
+	for _, name := range storeSubcommands {
+		for _, cmd := range doltRemoteCmd.Commands() {
+			if cmd.Name() == name {
+				if cmd.Parent().Name() != "remote" {
+					t.Errorf("dolt remote %s: parent should be 'remote', got %q",
+						name, cmd.Parent().Name())
+				}
+				break
+			}
+		}
+	}
+}
+
 func containsAny(s string, substrs ...string) bool {
 	for _, sub := range substrs {
 		if strings.Contains(s, sub) {

--- a/cmd/bd/migrate_hooks_test.go
+++ b/cmd/bd/migrate_hooks_test.go
@@ -52,7 +52,7 @@ func TestFormatHookMigrationPlan_NotGitRepo(t *testing.T) {
 	lines := formatHookMigrationPlan(doctor.HookMigrationPlan{
 		Path:      "/tmp/no-git",
 		IsGitRepo: false,
-	}, true)
+	})
 
 	rendered := strings.Join(lines, "\n")
 	if !strings.Contains(rendered, "not a git repository") {
@@ -77,7 +77,7 @@ func TestFormatHookMigrationPlan_WithMigrations(t *testing.T) {
 		},
 	}
 
-	lines := formatHookMigrationPlan(plan, true)
+	lines := formatHookMigrationPlan(plan)
 	rendered := strings.Join(lines, "\n")
 
 	if !strings.Contains(rendered, "Needs migration: 1/5") {


### PR DESCRIPTION
## Summary

Adds a regression test for `bd dolt remote add/list/remove` subcommands that call `getStore()` but bypass the `needsStoreDoltSubcommands` guard in `PersistentPreRun` via Cobra parent-name resolution. Also fixes a pre-existing build failure in `migrate_hooks_test.go`.

## Context

The [#2042](https://github.com/steveyegge/beads/issues/2042) fix ([da508e84](https://github.com/steveyegge/beads/commit/da508e84)) added a positive list so `push`, `pull`, and `commit` correctly reach store initialization. However, `remote add/list/remove` also need the store but weren't included — they work because Cobra resolves their parent as `"remote"` (not `"dolt"`), skipping the dolt-specific guard entirely.

This test encodes that implicit dependency so regressions are caught if the guard logic changes.

See #2224 for the full investigation.

## Changes

- **`cmd/bd/dolt_test.go`**: Add `TestDoltRemoteSubcommandsNeedStore` — verifies subcommand registration under `doltRemoteCmd` and validates the Cobra parent-name chain that allows store initialization
- **`cmd/bd/migrate_hooks_test.go`**: Fix pre-existing build failure where `formatHookMigrationPlan` was called with an extra bool argument removed from the function signature

## For Testers

```bash
# Store initialization tests
CGO_ENABLED=1 go test ./cmd/bd/ -run "TestDolt(RemoteSubcommands|PushPullCommit|ConfigSubcommands)" -v

# Verify migrate hooks fix compiles and passes
CGO_ENABLED=1 go test ./cmd/bd/ -run "TestFormatHookMigrationPlan" -v
```

All three store-related tests should pass:
- `TestDoltPushPullCommitNeedStore` (existing, [#2042](https://github.com/steveyegge/beads/issues/2042))
- `TestDoltConfigSubcommandsSkipStore` (existing, [#2042](https://github.com/steveyegge/beads/issues/2042))
- `TestDoltRemoteSubcommandsNeedStore` (new, #2224)

## Test plan

- [x] New test passes locally
- [x] Existing store-related tests still pass
- [x] Fixed `migrate_hooks_test.go` tests pass
- [ ] CI passes (pending)

