### PR TITLE
preflight: make lint skipping explicit

### DIFF
--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -28,6 +28,8 @@ type PreflightResult struct {
 	Summary string        `json:"summary"`
 }
 
+const preflightSkipLintEnv = "BD_PREFLIGHT_SKIP_LINT"
+
 var preflightCmd = &cobra.Command{
 	Use:     "preflight",
 	GroupID: "maint",
@@ -44,6 +46,9 @@ Examples:
   bd preflight              # Show checklist
   bd preflight --check      # Run checks automatically
   bd preflight --check --json  # JSON output for programmatic use
+
+Skip lint (explicit, temporary):
+  BD_PREFLIGHT_SKIP_LINT=1 bd preflight --check
 `,
 	Run: runPreflight,
 }
@@ -199,11 +204,27 @@ func runLintCheck() CheckResult {
 
 	// Check if golangci-lint is available
 	if _, err := exec.LookPath("golangci-lint"); err != nil {
+		if envFlagEnabled(preflightSkipLintEnv) {
+			return CheckResult{
+				Name:    "Lint passes",
+				Passed:  false,
+				Skipped: true,
+				Warning: true,
+				Output: fmt.Sprintf(
+					"lint check explicitly skipped by %s=1",
+					preflightSkipLintEnv,
+				),
+				Command: command,
+			}
+		}
+
 		return CheckResult{
-			Name:    "Lint passes",
-			Passed:  false,
-			Skipped: true,
-			Output:  "golangci-lint not found in PATH",
+			Name:   "Lint passes",
+			Passed: false,
+			Output: fmt.Sprintf(
+				"golangci-lint not found in PATH (install it or explicitly skip lint with %s=1)",
+				preflightSkipLintEnv,
+			),
 			Command: command,
 		}
 	}
@@ -333,4 +354,9 @@ func truncateOutput(s string, maxLen int) string {
 		return strings.TrimSpace(s)
 	}
 	return strings.TrimSpace(s[:maxLen]) + "\n... (truncated)"
+}
+
+func envFlagEnabled(name string) bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv(name)))
+	return v == "1" || v == "true" || v == "yes" || v == "on"
 }

--- a/cmd/bd/preflight_test.go
+++ b/cmd/bd/preflight_test.go
@@ -183,3 +183,38 @@ func TestTruncateOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestRunLintCheck_MissingCommandFailsByDefault(t *testing.T) {
+	t.Setenv("PATH", "")
+	t.Setenv(preflightSkipLintEnv, "")
+
+	result := runLintCheck()
+	if result.Passed {
+		t.Fatalf("expected lint check to fail when golangci-lint is missing")
+	}
+	if result.Skipped {
+		t.Fatalf("expected missing lint to be a hard failure, not skipped")
+	}
+	if !strings.Contains(result.Output, "not found in PATH") {
+		t.Fatalf("expected missing command message, got: %q", result.Output)
+	}
+}
+
+func TestRunLintCheck_MissingCommandBypass(t *testing.T) {
+	t.Setenv("PATH", "")
+	t.Setenv(preflightSkipLintEnv, "1")
+
+	result := runLintCheck()
+	if result.Passed {
+		t.Fatalf("expected bypassed check to remain non-passing")
+	}
+	if !result.Skipped {
+		t.Fatalf("expected bypassed lint check to be marked skipped")
+	}
+	if !result.Warning {
+		t.Fatalf("expected bypassed lint check to be warning")
+	}
+	if !strings.Contains(result.Output, preflightSkipLintEnv) {
+		t.Fatalf("expected output to mention bypass env var, got: %q", result.Output)
+	}
+}


### PR DESCRIPTION
## Summary
- Make missing `golangci-lint` a hard preflight failure by default.
- Add an explicit temporary bypass: `BD_PREFLIGHT_SKIP_LINT=1`.
- Keep skipped lint visible as a warning/skip with a clear reason.
- Add tests for both default-fail and explicit-skip behavior.

## Why
A recent PR only failed lint in CI because local preflight treated missing `golangci-lint` as skipped. A maintainer had to address fallout in follow-up work. This change keeps that responsibility in our own tooling by failing early unless the contributor explicitly opts to skip lint.

## Behavior change
- Before:
  - Missing `golangci-lint` => check marked skipped.
  - `bd preflight --check` could pass without lint actually running.
- After:
  - Missing `golangci-lint` => hard failure with install/skip guidance.
  - `BD_PREFLIGHT_SKIP_LINT=1` => explicit skip path (warning + skipped status).

## Validation
- `go test ./cmd/bd -run 'TestRunLintCheck_MissingCommandFailsByDefault|TestRunLintCheck_MissingCommandBypass' -count=1`
