### PR TITLE
Stabilize hook tests by forcing repo-local core.hooksPath

### DIFF
--- a/cmd/bd/doctor/fix/hooks_test.go
+++ b/cmd/bd/doctor/fix/hooks_test.go
@@ -842,6 +842,13 @@ func TestDetectActiveHookManager(t *testing.T) {
 			if err := copyGitDir(gitTemplateDir, dir); err != nil {
 				t.Fatalf("failed to copy git template: %v", err)
 			}
+			// Test isolation: force repo-local hooks path so global git config
+			// does not redirect detection to an unrelated directory.
+			setHooksPathCmd := exec.Command("git", "config", "core.hooksPath", ".git/hooks")
+			setHooksPathCmd.Dir = dir
+			if err := setHooksPathCmd.Run(); err != nil {
+				t.Fatalf("failed to set core.hooksPath: %v", err)
+			}
 
 			// Write hook file
 			if tt.hookContent != "" {
@@ -870,6 +877,12 @@ func TestDetectActiveHookManager_CustomHooksPath(t *testing.T) {
 	}
 	if err := copyGitDir(gitTemplateDir, dir); err != nil {
 		t.Fatalf("failed to copy git template: %v", err)
+	}
+	// Start from repo-local hooks for test isolation; override below.
+	setHooksPathCmd := exec.Command("git", "config", "core.hooksPath", ".git/hooks")
+	setHooksPathCmd.Dir = dir
+	if err := setHooksPathCmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath: %v", err)
 	}
 
 	// Create custom hooks directory outside .git

--- a/cmd/bd/doctor/git_hygiene_test.go
+++ b/cmd/bd/doctor/git_hygiene_test.go
@@ -44,6 +44,8 @@ func initRepo(t *testing.T, dir string, branch string) {
 	runGit(t, dir, "init", "-b", branch)
 	runGit(t, dir, "config", "user.email", "test@test.com")
 	runGit(t, dir, "config", "user.name", "Test User")
+	// Ensure test repos don't inherit global hooksPath and run external hooks.
+	runGit(t, dir, "config", "core.hooksPath", ".git/hooks")
 }
 
 func commitFile(t *testing.T, dir, name, content, msg string) {

--- a/cmd/bd/doctor/git_test.go
+++ b/cmd/bd/doctor/git_test.go
@@ -139,6 +139,14 @@ func setupGitRepoInDir(t *testing.T, dir string) {
 	if err := copyGitDir(gitTemplateDir, dir); err != nil {
 		t.Fatalf("failed to copy git template: %v", err)
 	}
+
+	// Force repo-local hooks path for test isolation. This prevents global
+	// core.hooksPath from affecting hook detection behavior in tests.
+	cmd := exec.Command("git", "config", "core.hooksPath", ".git/hooks")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to set core.hooksPath for test repo: %v", err)
+	}
 }
 
 // Edge case tests for CheckGitHooks


### PR DESCRIPTION
## Summary
This PR hardens git test isolation by forcing repo-local `core.hooksPath=.git/hooks` in test repo setup helpers.

## Why
On machines with global `core.hooksPath`, temp test repos can execute external/global hooks and read from global hook directories, causing flaky or incorrect test behavior.

Observed failures addressed:
- `TestCheckGitWorkingTree_RedirectWorktree/redirect_deletions_suppressed`
- `TestCheckGitHooks_CorruptedHookFiles/outdated_bd_hook_versions_are_flagged`
- `TestDetectActiveHookManager` subcases

## Changes
- `cmd/bd/doctor/git_test.go`
- `cmd/bd/doctor/git_hygiene_test.go`
- `cmd/bd/doctor/fix/hooks_test.go`

Each setup now sets:
- `git config core.hooksPath .git/hooks`

## Verification
- `go test ./cmd/bd/doctor -run 'TestCheckGitWorkingTree_RedirectWorktree|TestCheckGitHooks_CorruptedHookFiles' -count=1`
- `go test ./cmd/bd/doctor/fix -run 'TestDetectActiveHookManager' -count=1`
- `go test -race -short ./...`
- `make fmt-check`
- `golangci-lint run --timeout=5m`

## Follow-up
Tracked in `bd-d9j`: consolidate this isolation invariant into shared test helpers + add a dedicated regression guard.
