### PR TITLE
Fix child counter overwrite after bd init --from-jsonl

### DIFF
--- a/cmd/bd/import_from_jsonl_test.go
+++ b/cmd/bd/import_from_jsonl_test.go
@@ -159,6 +159,59 @@ func TestImportFromLocalJSONL(t *testing.T) {
 		}
 	})
 
+	t.Run("child counter reconciled after JSONL import prevents overwrites", func(t *testing.T) {
+		// Regression test: bd create --parent after bd init --from-jsonl
+		// must not overwrite existing child issues. The child_counters table
+		// must be reconciled from imported hierarchical IDs.
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "dolt")
+		store := newTestStore(t, dbPath)
+
+		// Import an epic with two existing children via JSONL
+		jsonlContent := `{"id":"test-epic1","title":"Epic","type":"epic","status":"open","priority":1,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+{"id":"test-epic1.1","title":"Child 1","type":"task","status":"open","priority":2,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+{"id":"test-epic1.2","title":"Child 2","type":"task","status":"open","priority":2,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+`
+		jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(jsonlContent), 0644); err != nil {
+			t.Fatalf("Failed to write JSONL file: %v", err)
+		}
+
+		ctx := context.Background()
+		count, err := importFromLocalJSONL(ctx, store, jsonlPath)
+		if err != nil {
+			t.Fatalf("importFromLocalJSONL failed: %v", err)
+		}
+		if count != 3 {
+			t.Errorf("Expected 3 issues imported, got %d", count)
+		}
+
+		// Now request the next child ID for the epic — this MUST be .3, not .1
+		nextID, err := store.GetNextChildID(ctx, "test-epic1")
+		if err != nil {
+			t.Fatalf("GetNextChildID failed: %v", err)
+		}
+		if nextID != "test-epic1.3" {
+			t.Errorf("Expected next child ID 'test-epic1.3', got %q (would overwrite existing child!)", nextID)
+		}
+
+		// Verify original children are still intact
+		child1, err := store.GetIssue(ctx, "test-epic1.1")
+		if err != nil {
+			t.Fatalf("Failed to get child 1: %v", err)
+		}
+		if child1.Title != "Child 1" {
+			t.Errorf("Child 1 title changed unexpectedly: got %q", child1.Title)
+		}
+		child2, err := store.GetIssue(ctx, "test-epic1.2")
+		if err != nil {
+			t.Fatalf("Failed to get child 2: %v", err)
+		}
+		if child2.Title != "Child 2" {
+			t.Errorf("Child 2 title changed unexpectedly: got %q", child2.Title)
+		}
+	})
+
 	t.Run("sets prefix from first issue when not configured", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		dbPath := filepath.Join(tmpDir, "dolt")

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -358,6 +358,25 @@ func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*t
 		}
 	}
 
+	// Reconcile child_counters for imported hierarchical IDs
+	childMaxMap := make(map[string]int)
+	for _, issue := range issues {
+		if parentID, childNum, ok := parseHierarchicalID(issue.ID); ok {
+			if childNum > childMaxMap[parentID] {
+				childMaxMap[parentID] = childNum
+			}
+		}
+	}
+	for parentID, maxChild := range childMaxMap {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?)
+			ON DUPLICATE KEY UPDATE last_child = GREATEST(last_child, ?)
+		`, parentID, maxChild, maxChild)
+		if err != nil {
+			return fmt.Errorf("failed to reconcile child counter for %s: %w", parentID, err)
+		}
+	}
+
 	// DOLT_COMMIT inside transaction — atomic with the writes
 	commitMsg := fmt.Sprintf("bd: create %d issue(s)", len(issues))
 	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-Am', ?, '--author', ?)",

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -1283,13 +1283,27 @@ func (s *DoltStore) GetNextChildID(ctx context.Context, parentID string) (string
 	}
 	defer tx.Rollback()
 
-	// Get or create counter
 	var lastChild int
 	err = tx.QueryRowContext(ctx, "SELECT last_child FROM child_counters WHERE parent_id = ?", parentID).Scan(&lastChild)
 	if err == sql.ErrNoRows {
 		lastChild = 0
 	} else if err != nil {
 		return "", wrapQueryError("get next child ID: read counter", err)
+	}
+
+	// Check existing children to prevent overwrites after import
+	var maxExisting sql.NullInt64
+	err = tx.QueryRowContext(ctx, `
+		SELECT MAX(CAST(SUBSTRING_INDEX(id, '.', -1) AS UNSIGNED))
+		FROM issues
+		WHERE id LIKE CONCAT(?, '.%')
+		  AND id NOT LIKE CONCAT(?, '.%.%')
+	`, parentID, parentID).Scan(&maxExisting)
+	if err != nil {
+		return "", wrapQueryError("get next child ID: scan existing children", err)
+	}
+	if maxExisting.Valid && int(maxExisting.Int64) > lastChild {
+		lastChild = int(maxExisting.Int64)
 	}
 
 	nextChild := lastChild + 1


### PR DESCRIPTION
## Problem

bd create --parent silently overwrites existing child issues after a bd init --from-jsonl restore. When issues are imported via JSONL, the child_counters table is never populated — so the next call to GetNextChildID() starts from 0 and assigns .1, .2, etc., overwriting whatever was already there. No warning, no error, data is gone.

## Root cause
CreateIssuesWithFullOptions() inserts hierarchical issues (e.g. proj-abc.1, proj-abc.2) but never touches child_counters. On a fresh restore, the table is empty, so the counter reads as 0 and produces a colliding ID.

## Fix
Two-part defense-in-depth:
1. GetNextChildID() now also queries the issues table for the highest existing child number and uses MAX(counter, max_existing) before incrementing. This prevents collisions regardless of how issues entered the DB.
2. CreateIssuesWithFullOptions() now reconciles child_counters for any imported hierarchical IDs using GREATEST(last_child, ?), keeping the counter table correct proactively.
Testing
Added a regression test in TestImportFromLocalJSONL that imports an epic with two children via JSONL, then asserts GetNextChildID() returns .3 rather than .1.

Fixes [2166](https://github.com/steveyegge/beads/issues/2166)