### PR TITLE
fix: hooks subcommands no longer trigger Dolt store init (SIGSEGV)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -379,12 +379,10 @@ var rootCmd = &cobra.Command{
 		cmdName := cmd.Name()
 		if cmd.Parent() != nil {
 			parentName := cmd.Parent().Name()
-			if parentName == "dolt" {
-				if slices.Contains(needsStoreDoltSubcommands, cmdName) {
-					// GH#2042: dolt push/pull/commit need the store — fall through to init
-				} else if slices.Contains(noDbCommands, parentName) {
-					return
-				}
+			if parentName == "dolt" && slices.Contains(needsStoreDoltSubcommands, cmdName) {
+				// GH#2042: dolt push/pull/commit need the store — fall through to init
+			} else if slices.Contains(noDbCommands, parentName) {
+				return
 			}
 		}
 		if slices.Contains(noDbCommands, cmdName) {


### PR DESCRIPTION
## Problem
`bd hooks run pre-commit` was crashing with a nil pointer dereference
(SIGSEGV) when a Dolt SQL server was already running on port 3307.
The `PersistentPreRun` parent-command check in `main.go` only exempted
subcommands of `"dolt"` from store initialization. The `"hooks"` parent
was in `noDbCommands` but its subcommands (including `"run"`) were never
checked against it, so `bd hooks run pre-commit` fell through to full
Dolt store init, which tried to open database files already locked by
the running server.
## Fix
Generalize the parent-command check so that ANY parent in `noDbCommands`
causes its subcommands to skip store initialization. The special-case for
`dolt push/pull/commit` (which do need the store) is preserved.
## Changes
- `cmd/bd/main.go`: restructure parent-command noDbCommands check to
  cover all parents, not only `"dolt"`
- `cmd/bd/dolt_test.go`: add `TestHooksSubcommandsSkipStore` regression
  test
## Testing
All existing tests pass. New regression test verifies `hooks run` is
registered under the `hooks` parent so the noDbCommands check fires.

Fixes [#2169](https://github.com/steveyegge/beads/issues/2169)