### PR TITLE
Teach bd doctor to parse section-marker hook format

### DIFF
--- a/cmd/bd/doctor/git.go
+++ b/cmd/bd/doctor/git.go
@@ -30,6 +30,12 @@ const bdInlineHookMarker = "# bd (beads)"
 // bdHooksRunPattern matches hooks that call bd hooks run
 var bdHooksRunPattern = regexp.MustCompile(`\bbd\s+hooks\s+run\b`)
 
+// bdSectionMarkerPrefix identifies section-marker hooks (GH#1380)
+const bdSectionMarkerPrefix = "# --- BEGIN BEADS INTEGRATION"
+
+// bdSectionMarkerVersionRe extracts the version from a section marker line.
+var bdSectionMarkerVersionRe = regexp.MustCompile(`^# --- BEGIN BEADS INTEGRATION v(\S+)\s+---`)
+
 // CheckGitHooks verifies that recommended git hooks are installed.
 func CheckGitHooks(cliVersion string) DoctorCheck {
 	// Check if we're in a git repository using worktree-aware detection
@@ -221,14 +227,23 @@ func findOutdatedBDHookVersions(
 	return outdated, oldest
 }
 
-// isBdHookContent checks if hook content is a bd hook (shim, inline, or calls bd hooks run).
+// isBdHookContent checks if hook content is a bd hook (shim, inline, section-marker, or calls bd hooks run).
 func isBdHookContent(content string) bool {
 	return strings.Contains(content, bdShimMarker) ||
 		strings.Contains(content, bdInlineHookMarker) ||
+		strings.Contains(content, bdSectionMarkerPrefix) ||
 		bdHooksRunPattern.MatchString(content)
 }
 
 func parseBDHookVersion(content string) (string, bool) {
+	// Try section-marker format first: # --- BEGIN BEADS INTEGRATION v0.57.0 --- (GH#1380)
+	for _, line := range strings.Split(content, "\n") {
+		if m := bdSectionMarkerVersionRe.FindStringSubmatch(line); m != nil {
+			return m[1], true
+		}
+	}
+
+	// Legacy format: # bd-hooks-version: 0.57.0
 	if !strings.Contains(content, "bd-hooks-version:") {
 		return "", false
 	}
@@ -625,6 +640,15 @@ func CheckGitHooksDoltCompatibility(path string) DoctorCheck {
 			Name:    "Git Hooks Dolt Compatibility",
 			Status:  StatusOK,
 			Message: "Shim hooks (Dolt handled by bd hook command)",
+		}
+	}
+
+	// Section-marker hooks (GH#1380) delegate to 'bd hooks run' which handles Dolt correctly
+	if strings.Contains(contentStr, bdSectionMarkerPrefix) {
+		return DoctorCheck{
+			Name:    "Git Hooks Dolt Compatibility",
+			Status:  StatusOK,
+			Message: "Section-marker hooks (Dolt handled by bd hooks run)",
 		}
 	}
 

--- a/cmd/bd/doctor/git_test.go
+++ b/cmd/bd/doctor/git_test.go
@@ -272,6 +272,108 @@ func TestCheckGitHooks_CorruptedHookFiles(t *testing.T) {
 	}
 }
 
+func TestParseBDHookVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantVersion string
+		wantOK      bool
+	}{
+		{
+			name:        "legacy format",
+			content:     "#!/bin/sh\n# bd-hooks-version: 0.55.0\nbd hooks run pre-commit\n",
+			wantVersion: "0.55.0",
+			wantOK:      true,
+		},
+		{
+			name:        "section marker format",
+			content:     "#!/usr/bin/env sh\n# --- BEGIN BEADS INTEGRATION v0.57.0 ---\nif command -v bd >/dev/null 2>&1; then\n  bd hooks run pre-commit \"$@\"\nfi\n# --- END BEADS INTEGRATION ---\n",
+			wantVersion: "0.57.0",
+			wantOK:      true,
+		},
+		{
+			name:        "section marker with user content around it",
+			content:     "#!/bin/sh\n# my custom pre-commit stuff\necho hello\n# --- BEGIN BEADS INTEGRATION v0.56.1 ---\nbd hooks run pre-commit\n# --- END BEADS INTEGRATION ---\necho done\n",
+			wantVersion: "0.56.1",
+			wantOK:      true,
+		},
+		{
+			name:    "no version marker at all",
+			content: "#!/bin/sh\necho hello\n",
+			wantOK:  false,
+		},
+		{
+			name:    "empty content",
+			content: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, ok := parseBDHookVersion(tt.content)
+			if ok != tt.wantOK {
+				t.Errorf("parseBDHookVersion() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if version != tt.wantVersion {
+				t.Errorf("parseBDHookVersion() version = %q, want %q", version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestCheckGitHooks_SectionMarkerFormat(t *testing.T) {
+	t.Run("current section-marker hooks are accepted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupGitRepoInDir(t, tmpDir)
+		gitDir := filepath.Join(tmpDir, ".git")
+		hooksDir := filepath.Join(gitDir, "hooks")
+		os.MkdirAll(hooksDir, 0755)
+
+		hook := "#!/usr/bin/env sh\n# --- BEGIN BEADS INTEGRATION v0.49.6 ---\n" +
+			"if command -v bd >/dev/null 2>&1; then\n  bd hooks run pre-commit \"$@\"\nfi\n" +
+			"# --- END BEADS INTEGRATION ---\n"
+		os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte(hook), 0755)
+		os.WriteFile(filepath.Join(hooksDir, "post-merge"), []byte(hook), 0755)
+		os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(hook), 0755)
+
+		runInDir(t, tmpDir, func() {
+			check := CheckGitHooks("0.49.6")
+			if check.Status != "ok" {
+				t.Errorf("expected status %q, got %q (message: %s)", "ok", check.Status, check.Message)
+			}
+			if !strings.Contains(check.Message, "All recommended hooks installed") {
+				t.Errorf("expected 'All recommended hooks installed', got %q", check.Message)
+			}
+		})
+	})
+
+	t.Run("outdated section-marker hooks are flagged", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		setupGitRepoInDir(t, tmpDir)
+		gitDir := filepath.Join(tmpDir, ".git")
+		hooksDir := filepath.Join(gitDir, "hooks")
+		os.MkdirAll(hooksDir, 0755)
+
+		hook := "#!/usr/bin/env sh\n# --- BEGIN BEADS INTEGRATION v0.40.0 ---\n" +
+			"if command -v bd >/dev/null 2>&1; then\n  bd hooks run pre-commit \"$@\"\nfi\n" +
+			"# --- END BEADS INTEGRATION ---\n"
+		os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte(hook), 0755)
+		os.WriteFile(filepath.Join(hooksDir, "post-merge"), []byte(hook), 0755)
+		os.WriteFile(filepath.Join(hooksDir, "pre-push"), []byte(hook), 0755)
+
+		runInDir(t, tmpDir, func() {
+			check := CheckGitHooks("0.49.6")
+			if check.Status != "warning" {
+				t.Errorf("expected status %q, got %q (message: %s)", "warning", check.Status, check.Message)
+			}
+			if !strings.Contains(check.Message, "outdated") {
+				t.Errorf("expected 'outdated' in message, got %q", check.Message)
+			}
+		})
+	})
+}
+
 // Edge case tests for CheckMergeDriver
 
 func TestCheckMergeDriver_PartiallyConfigured(t *testing.T) {


### PR DESCRIPTION
## Summary

- `parseBDHookVersion()` in `cmd/bd/doctor/git.go` only recognised the legacy `# bd-hooks-version:` comment, but hooks installed since GH#1380 use `# --- BEGIN BEADS INTEGRATION vX.Y.Z ---` section markers. This caused `bd doctor` to report all current hooks as `@unknown` / version `0.0.0`.
- Updated `parseBDHookVersion()` to try the section-marker format first, falling back to legacy.
- Updated `CheckGitHooksDoltCompatibility()` to recognise section-marker hooks as Dolt-compatible (they delegate to `bd hooks run`).
- Added `isBdHookContent()` recognition for the section-marker prefix.

## Test plan

- [x] Unit tests for `parseBDHookVersion` covering both legacy and section-marker formats
- [x] Integration tests for `CheckGitHooks` with section-marker hooks (current version accepted, outdated version flagged)
- [x] Existing hook tests pass without regression
- [x] `golangci-lint run ./cmd/bd/doctor/` — 0 issues
- [x] `go test -race ./cmd/bd/doctor/` — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)