### PR TITLE
fix: add missing dolt runtime files to gitignore template

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -41,6 +41,9 @@ ephemeral.sqlite3-shm
 dolt-server.pid
 dolt-server.log
 dolt-server.lock
+dolt-server.port
+dolt-server.activity
+dolt-monitor.pid
 
 # Legacy files (from pre-Dolt versions)
 *.db
@@ -84,6 +87,9 @@ var requiredPatterns = []string{
 	"dolt-server.pid",
 	"dolt-server.log",
 	"dolt-server.lock",
+	"dolt-server.port",
+	"dolt-server.activity",
+	"dolt-monitor.pid",
 }
 
 // CheckGitignore checks if .beads/.gitignore is up to date.


### PR DESCRIPTION
## Summary

- Add `dolt-server.port`, `dolt-server.activity`, and `dolt-monitor.pid` to the `.beads/.gitignore` template and required patterns list
- These runtime files were introduced with Dolt server management but missed in the gitignore template, causing them to show as untracked after upgrading to v0.57.0

Closes #2256

## Test plan

- [x] Existing gitignore doctor tests pass
- [ ] `bd init` in a fresh directory produces `.beads/.gitignore` containing all three new patterns
- [ ] `bd doctor` no longer reports outdated gitignore for repos missing these patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)