### PR TITLE
fix: include children of blocked parents in bd blocked (GH#1495)

### DIFF
--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -343,6 +343,20 @@ func (s *DoltStore) GetBlockedIssues(ctx context.Context, filter types.WorkFilte
 		blockedSet[id] = true
 	}
 
+	// Step 2b: Include children of blocked parents (GH#1495).
+	// Mirrors GetReadyWork() exclusion: if a parent is blocked, its children
+	// are excluded from ready work and should appear in blocked output.
+	childToParent, childErr := s.getChildrenWithParents(ctx, blockedIDList)
+	if childErr == nil {
+		for childID := range childToParent {
+			// Only include active children not already directly blocked
+			if activeIDs[childID] && !blockedSet[childID] {
+				blockedSet[childID] = true
+				blockedIDList = append(blockedIDList, childID)
+			}
+		}
+	}
+
 	// Step 3: Get blocking + waits-for + conditional-blocks deps to build BlockedBy lists
 	// Scan both dependencies and wisp_dependencies tables (bd-w2w)
 	blockerMap := make(map[string][]string)
@@ -370,6 +384,18 @@ func (s *DoltStore) GetBlockedIssues(ctx context.Context, filter types.WorkFilte
 		_ = depRows.Close() // Redundant close for safety (rows already iterated)
 		if err := depRows.Err(); err != nil {
 			return nil, wrapQueryError("get blocked issues: dependency rows", err)
+		}
+	}
+
+	// Step 3b: Add transitively blocked children to blockerMap (GH#1495).
+	// Children of blocked parents have their parent as the "blocker".
+	if childErr == nil {
+		for childID, parentID := range childToParent {
+			if activeIDs[childID] && blockedSet[childID] {
+				if _, hasDirectBlocker := blockerMap[childID]; !hasDirectBlocker {
+					blockerMap[childID] = []string{parentID}
+				}
+			}
 		}
 	}
 
@@ -931,6 +957,41 @@ func (s *DoltStore) getChildrenOfIssues(ctx context.Context, parentIDs []string)
 		children = append(children, childID)
 	}
 	return children, rows.Err()
+}
+
+// getChildrenWithParents returns a map of childID -> parentID for direct children
+// (parent-child deps) of the given parent IDs. Used by GetBlockedIssues to show
+// transitively blocked children with their parent as the reason (GH#1495).
+func (s *DoltStore) getChildrenWithParents(ctx context.Context, parentIDs []string) (map[string]string, error) {
+	if len(parentIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(parentIDs))
+	args := make([]interface{}, len(parentIDs))
+	for i, id := range parentIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	// nolint:gosec // G201: placeholders are generated values, data passed via args
+	query := fmt.Sprintf(`
+		SELECT issue_id, depends_on_id FROM dependencies
+		WHERE type = 'parent-child' AND depends_on_id IN (%s)
+	`, strings.Join(placeholders, ","))
+	rows, err := s.queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, wrapQueryError("get children with parents", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var childID, parentID string
+		if err := rows.Scan(&childID, &parentID); err != nil {
+			return nil, wrapScanError("get children with parents", err)
+		}
+		result[childID] = parentID
+	}
+	return result, rows.Err()
 }
 
 // GetMoleculeProgress returns progress stats for a molecule

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -603,6 +603,98 @@ func TestGetBlockedIssues_MultipleBlockers(t *testing.T) {
 	}
 }
 
+func TestGetBlockedIssues_IncludesChildrenOfBlockedParents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	blocker := &types.Issue{
+		ID:        "bi-preblocker",
+		Title:     "Prerequisite",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	epic := &types.Issue{
+		ID:        "bi-epic",
+		Title:     "Gated Epic",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	child := &types.Issue{
+		ID:        "bi-epic.1",
+		Title:     "Child Task",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+
+	for _, iss := range []*types.Issue{blocker, epic, child} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("failed to create issue %s: %v", iss.ID, err)
+		}
+	}
+
+	// Block the epic
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     epic.ID,
+		DependsOnID: blocker.ID,
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("failed to add blocking dep: %v", err)
+	}
+
+	// Make child a child of the epic
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: epic.ID,
+		Type:        types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("failed to add parent-child dep: %v", err)
+	}
+
+	// Child should NOT be in ready work (parent is blocked)
+	ready, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	for _, iss := range ready {
+		if iss.ID == child.ID {
+			t.Error("child of blocked parent should NOT be in ready work")
+		}
+	}
+
+	// Child SHOULD appear in blocked issues (GH#1495)
+	blocked, err := store.GetBlockedIssues(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetBlockedIssues: %v", err)
+	}
+
+	epicFound := false
+	childFound := false
+	for _, bi := range blocked {
+		if bi.Issue.ID == epic.ID {
+			epicFound = true
+		}
+		if bi.Issue.ID == child.ID {
+			childFound = true
+			// Child should show parent as the blocker
+			if bi.BlockedByCount != 1 || len(bi.BlockedBy) == 0 || bi.BlockedBy[0] != epic.ID {
+				t.Errorf("child blocked-by should be [%s], got %v", epic.ID, bi.BlockedBy)
+			}
+		}
+	}
+	if !epicFound {
+		t.Error("epic should be in blocked list")
+	}
+	if !childFound {
+		t.Error("child of blocked parent should appear in blocked list (GH#1495)")
+	}
+}
+
 // =============================================================================
 // SearchIssues tests
 // =============================================================================


### PR DESCRIPTION
## Summary

- Children whose parent is blocked were excluded from `bd ready` but **not** shown in `bd blocked`, making them invisible to users
- `GetBlockedIssues` now includes transitive children with their blocked parent listed as the reason
- Adds `getChildrenWithParents()` helper to map child→parent for parent-child deps

Closes #1495

## Test plan

- [x] New test `TestGetBlockedIssues_IncludesChildrenOfBlockedParents` — verifies child appears in blocked list with parent as blocker
- [x] All existing `TestGetBlockedIssues_*` tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)