### PR TITLE
feat(create-form): add --parent flag for creating sub-issues

### DIFF
--- a/cmd/bd/create_form.go
+++ b/cmd/bd/create_form.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
@@ -43,6 +45,7 @@ type createFormValues struct {
 	AcceptanceCriteria string
 	ExternalRef        string
 	Dependencies       []string
+	ParentID           string // Parent issue ID for hierarchical child creation
 }
 
 // parseCreateFormInput parses raw form input into a createFormValues struct.
@@ -92,8 +95,26 @@ func parseCreateFormInput(raw *createFormRawInput) *createFormValues {
 
 // CreateIssueFromFormValues creates an issue from the given form values.
 // It returns the created issue and any error that occurred.
-// This function handles labels, dependencies, and source_repo inheritance.
+// This function handles parent-child relationships, labels, dependencies,
+// and source_repo inheritance.
 func CreateIssueFromFormValues(ctx context.Context, s *dolt.DoltStore, fv *createFormValues, actor string) (*types.Issue, error) {
+	// If parent is specified, validate it exists and generate child ID
+	var explicitID string
+	if fv.ParentID != "" {
+		_, err := s.GetIssue(ctx, fv.ParentID)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, fmt.Errorf("parent issue %s not found", fv.ParentID)
+			}
+			return nil, fmt.Errorf("failed to check parent issue: %w", err)
+		}
+		childID, err := s.GetNextChildID(ctx, fv.ParentID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate child ID: %w", err)
+		}
+		explicitID = childID
+	}
+
 	var externalRefPtr *string
 	if fv.ExternalRef != "" {
 		externalRefPtr = &fv.ExternalRef
@@ -110,6 +131,10 @@ func CreateIssueFromFormValues(ctx context.Context, s *dolt.DoltStore, fv *creat
 		Assignee:           fv.Assignee,
 		ExternalRef:        externalRefPtr,
 		CreatedBy:          getActorWithGit(), // GH#748: track who created the issue
+	}
+
+	if explicitID != "" {
+		issue.ID = explicitID
 	}
 
 	// Check if any dependencies are discovered-from type
@@ -145,6 +170,18 @@ func CreateIssueFromFormValues(ctx context.Context, s *dolt.DoltStore, fv *creat
 
 	if err := s.CreateIssue(ctx, issue, actor); err != nil {
 		return nil, fmt.Errorf("failed to create issue: %w", err)
+	}
+
+	// If parent was specified, add parent-child dependency (GH#1983)
+	if fv.ParentID != "" {
+		dep := &types.Dependency{
+			IssueID:     issue.ID,
+			DependsOnID: fv.ParentID,
+			Type:        types.DepParentChild,
+		}
+		if err := s.AddDependency(ctx, dep, actor); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to add parent-child dependency %s -> %s: %v\n", issue.ID, fv.ParentID, err)
+		}
 	}
 
 	// Add labels if specified
@@ -205,6 +242,9 @@ var createFormCmd = &cobra.Command{
 This command provides a user-friendly form interface for creating issues,
 with fields for title, description, type, priority, labels, and more.
 
+Use --parent to create a sub-issue under an existing parent issue.
+The child will get an auto-generated hierarchical ID (e.g., parent-id.1).
+
 The form uses keyboard navigation:
   - Tab/Shift+Tab: Move between fields
   - Enter: Submit the form (on the last field or submit button)
@@ -217,7 +257,8 @@ The form uses keyboard navigation:
 }
 
 func runCreateForm(cmd *cobra.Command) {
-	_ = cmd // cmd parameter required by cobra.Command.Run signature
+	parentID, _ := cmd.Flags().GetString("parent")
+
 	// Raw form input - will be populated by the form
 	raw := &createFormRawInput{}
 
@@ -338,6 +379,7 @@ func runCreateForm(cmd *cobra.Command) {
 
 	// Parse the form input
 	fv := parseCreateFormInput(raw)
+	fv.ParentID = parentID
 
 	// Direct mode - use the extracted creation function
 	issue, err := CreateIssueFromFormValues(rootCtx, store, fv, actor)
@@ -372,5 +414,6 @@ func printCreatedIssue(issue *types.Issue) {
 
 func init() {
 	// Note: --json flag is defined as a persistent flag in main.go
+	createFormCmd.Flags().String("parent", "", "Parent issue ID for creating a hierarchical child (e.g., 'bd-a3f8e9')")
 	rootCmd.AddCommand(createFormCmd)
 }

--- a/cmd/bd/create_form_test.go
+++ b/cmd/bd/create_form_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -529,6 +530,125 @@ func TestCreateIssueFromFormValues(t *testing.T) {
 			if issue.Priority != priority {
 				t.Errorf("expected priority %d, got %d", priority, issue.Priority)
 			}
+		}
+	})
+}
+
+func TestCreateIssueFromFormValues_WithParent(t *testing.T) {
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	s := newTestStore(t, testDB)
+	ctx := context.Background()
+
+	t.Run("ParentChildCreation", func(t *testing.T) {
+		// Create parent (epic) first
+		parentFv := &createFormValues{
+			Title:     "Epic parent issue",
+			Priority:  1,
+			IssueType: "epic",
+		}
+		parent, err := CreateIssueFromFormValues(ctx, s, parentFv, "test")
+		if err != nil {
+			t.Fatalf("failed to create parent: %v", err)
+		}
+
+		// Create child via --parent
+		childFv := &createFormValues{
+			Title:     "Child bug under epic",
+			Priority:  2,
+			IssueType: "bug",
+			ParentID:  parent.ID,
+		}
+		child, err := CreateIssueFromFormValues(ctx, s, childFv, "test")
+		if err != nil {
+			t.Fatalf("failed to create child: %v", err)
+		}
+
+		// Child ID should be hierarchical (parent.1)
+		if !strings.HasPrefix(child.ID, parent.ID+".") {
+			t.Errorf("child ID %q should start with parent ID %q + '.'", child.ID, parent.ID)
+		}
+
+		// Verify parent-child dependency was created
+		deps, err := s.GetDependencies(ctx, child.ID)
+		if err != nil {
+			t.Fatalf("failed to get dependencies: %v", err)
+		}
+
+		found := false
+		for _, d := range deps {
+			if d.ID == parent.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected parent-child dependency on %s, not found", parent.ID)
+		}
+	})
+
+	t.Run("ParentNotFound", func(t *testing.T) {
+		fv := &createFormValues{
+			Title:     "Orphan child",
+			Priority:  2,
+			IssueType: "task",
+			ParentID:  "nonexistent-id",
+		}
+		_, err := CreateIssueFromFormValues(ctx, s, fv, "test")
+		if err == nil {
+			t.Fatal("expected error for nonexistent parent, got nil")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' in error, got: %v", err)
+		}
+	})
+
+	t.Run("MultipleChildrenUnderSameParent", func(t *testing.T) {
+		// Create parent
+		parentFv := &createFormValues{
+			Title:     "Multi-child parent",
+			Priority:  1,
+			IssueType: "epic",
+		}
+		parent, err := CreateIssueFromFormValues(ctx, s, parentFv, "test")
+		if err != nil {
+			t.Fatalf("failed to create parent: %v", err)
+		}
+
+		// Create two children
+		child1Fv := &createFormValues{
+			Title:     "First child",
+			Priority:  2,
+			IssueType: "task",
+			ParentID:  parent.ID,
+		}
+		child1, err := CreateIssueFromFormValues(ctx, s, child1Fv, "test")
+		if err != nil {
+			t.Fatalf("failed to create child1: %v", err)
+		}
+
+		child2Fv := &createFormValues{
+			Title:     "Second child",
+			Priority:  2,
+			IssueType: "task",
+			ParentID:  parent.ID,
+		}
+		child2, err := CreateIssueFromFormValues(ctx, s, child2Fv, "test")
+		if err != nil {
+			t.Fatalf("failed to create child2: %v", err)
+		}
+
+		// Children should have distinct IDs
+		if child1.ID == child2.ID {
+			t.Errorf("children should have distinct IDs, both got %q", child1.ID)
+		}
+
+		// Both should be under the parent
+		if !strings.HasPrefix(child1.ID, parent.ID+".") {
+			t.Errorf("child1 ID %q should start with %q", child1.ID, parent.ID+".")
+		}
+		if !strings.HasPrefix(child2.ID, parent.ID+".") {
+			t.Errorf("child2 ID %q should start with %q", child2.ID, parent.ID+".")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Fixes #1983

Adds a `--parent` option to `bd create-form` so users can create hierarchical child issues directly from the interactive form, matching the existing `bd create --parent` capability.

## Changes

- Added `ParentID` field to `createFormValues` struct
- Added `--parent` flag to `createFormCmd` cobra command
- Extended `CreateIssueFromFormValues` to handle parent validation, child ID generation via `GetNextChildID`, and parent-child dependency creation
- Added test coverage: parent-child creation, nonexistent parent error, multiple children under same parent

## How it works

When `--parent <id>` is specified:
1. Validates the parent issue exists in the database
2. Auto-generates a hierarchical child ID (e.g., `parent-id.1`, `parent-id.2`)
3. Creates the issue with the generated ID
4. Adds a `parent-child` dependency relationship

This follows the same pattern used by `bd create --parent` (in `create.go`).

## Test plan

- [x] `TestCreateIssueFromFormValues_WithParent/ParentChildCreation` — verifies child ID format and dependency
- [x] `TestCreateIssueFromFormValues_WithParent/ParentNotFound` — verifies error on nonexistent parent
- [x] `TestCreateIssueFromFormValues_WithParent/MultipleChildrenUnderSameParent` — verifies distinct child IDs
- [x] All existing `TestParseFormInput` tests still pass
- [x] `go build`, `go vet`, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)