### PR TITLE
fix(doctor): skip remotesapi check when no federation peers configured

### DIFF
--- a/cmd/bd/doctor/federation.go
+++ b/cmd/bd/doctor/federation.go
@@ -107,7 +107,35 @@ func CheckFederationRemotesAPI(path string) DoctorCheck {
 		}
 	}
 
-	// Server is running - check if remotesapi port is accessible.
+	// Server is running - check if any federation peers are configured before
+	// probing the remotesapi port. Without peers, remotesapi is irrelevant.
+	{
+		ctx := context.Background()
+		store, err := dolt.New(ctx, doltServerConfig(beadsDir, doltPath))
+		if err == nil {
+			remotes, err := store.ListRemotes(ctx)
+			_ = store.Close()
+			if err == nil {
+				hasPeers := false
+				for _, r := range remotes {
+					if r.Name != "origin" {
+						hasPeers = true
+						break
+					}
+				}
+				if !hasPeers {
+					return DoctorCheck{
+						Name:     "Federation remotesapi",
+						Status:   StatusOK,
+						Message:  "N/A (no federation peers configured)",
+						Category: CategoryFederation,
+					}
+				}
+			}
+		}
+	}
+
+	// Server is running and peers are configured - check if remotesapi port is accessible.
 	// Read port from config instead of hardcoding 8080.
 	remotesAPIPort := configfile.DefaultDoltRemotesAPIPort
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {


### PR DESCRIPTION
## Summary

- `bd doctor` federation remotesapi check probes port 8080 even when zero federation peers are configured, producing a false error for anyone running Dolt server without federation
- Added peer check before remotesapi port probe: when server is running, enumerate remotes and skip the port check if no peers (excluding "origin") exist

## Root Cause

`CheckFederationRemotesAPI()` in `cmd/bd/doctor/federation.go` had an asymmetry: when the server is NOT running, it correctly short-circuits with OK if no peers exist (lines 76-97). But when the server IS running, it skipped straight to probing port 8080 without checking peers first.

## Files Changed
- `cmd/bd/doctor/federation.go` — add peer check in the server-running path

## Test plan
- [x] `go build ./cmd/bd/...` — compiles cleanly
- [x] `go test ./cmd/bd/doctor/...` — all tests pass
- [x] `bd doctor` with Dolt server running + zero peers → no longer reports remotesapi error