### PR TITLE
fix(dep): skip target existence check for cross-prefix dependencies

### DIFF
--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -10,6 +10,17 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// extractIDPrefix returns the prefix portion of a bead ID (everything before
+// the last hyphen-separated segment). For example, "hq-cv-vll" returns "hq",
+// "sh-jz0bqq" returns "sh". Returns empty string for IDs without a hyphen.
+func extractIDPrefix(id string) string {
+	idx := strings.Index(id, "-")
+	if idx <= 0 {
+		return ""
+	}
+	return id[:idx]
+}
+
 // AddDependency adds a dependency between two issues.
 // Uses an explicit transaction so writes persist when @@autocommit is OFF
 // (e.g. Dolt server started with --no-auto-commit).
@@ -21,8 +32,10 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 
 	// Pre-transaction: check if target is a wisp (must be done before opening tx
 	// to avoid connection pool deadlock with embedded dolt — bd-w2w)
+	// Skip wisp check for cross-prefix references (target lives in another rig's database)
 	targetIsWisp := false
-	if !strings.HasPrefix(dep.DependsOnID, "external:") {
+	isCrossPrefixRef := extractIDPrefix(dep.IssueID) != extractIDPrefix(dep.DependsOnID)
+	if !strings.HasPrefix(dep.DependsOnID, "external:") && !isCrossPrefixRef {
 		targetIsWisp = s.isActiveWisp(ctx, dep.DependsOnID)
 	}
 
@@ -46,9 +59,11 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		return fmt.Errorf("issue %s not found", dep.IssueID)
 	}
 
-	// Validate that the target issue exists (skip for external cross-rig references)
+	// Validate that the target issue exists (skip for external cross-rig references
+	// and cross-prefix references where the target lives in a different rig's database)
 	// Check wisps table if target is an active wisp (bd-w2w)
-	if !strings.HasPrefix(dep.DependsOnID, "external:") {
+	isCrossPrefix := extractIDPrefix(dep.IssueID) != extractIDPrefix(dep.DependsOnID)
+	if !strings.HasPrefix(dep.DependsOnID, "external:") && !isCrossPrefix {
 		var targetExists int
 		targetTable := "issues"
 		if targetIsWisp {


### PR DESCRIPTION
## Summary
- `AddDependency` validates that the target issue exists in the local database
- This fails for cross-rig references where the target has a different prefix (e.g., `hq-*` convoy tracking `sh-*` issues)
- Added `extractIDPrefix` helper to compare source and target prefixes
- Skip target existence validation and wisp check when prefixes differ (matching existing skip for `external:` references)

## Test plan
- [x] `bd dep add hq-cv-xxx sh-yyy --type=tracks` works from hq beads dir
- [x] `gt convoy stage sh-jz0bqq` succeeds end-to-end
- [x] `make install` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)