### PR TITLE
fix: recreate dolt_ignore'd wisps tables on schema fast-path (GH#2271)

### DIFF
--- a/cmd/bd/doctor/deep.go
+++ b/cmd/bd/doctor/deep.go
@@ -49,7 +49,7 @@ func RunDeepValidation(path string) DeepValidationResult {
 			Status:   StatusWarning,
 			Message:  "SQLite backend detected",
 			Category: CategoryMaintenance,
-			Fix:      "Run 'bd migrate --to-dolt' to upgrade to Dolt backend",
+			Fix:      "Run 'bd init' to set up Dolt backend",
 		}
 		result.AllChecks = append(result.AllChecks, check)
 		return result

--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -263,6 +263,29 @@ func checkSchemaWithDB(conn *doltConn) DoctorCheck {
 		}
 	}
 
+	// Check dolt_ignore'd tables (wisps) — these only exist in the working
+	// set and must be recreated each server session. (GH#2271)
+	wispTables := []string{"wisps", "wisp_labels", "wisp_dependencies", "wisp_events", "wisp_comments"}
+	var missingWispTables []string
+	for _, table := range wispTables {
+		var count int
+		err := conn.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s LIMIT 1", table)).Scan(&count)
+		if err != nil {
+			missingWispTables = append(missingWispTables, table)
+		}
+	}
+
+	if len(missingWispTables) > 0 {
+		return DoctorCheck{
+			Name:     "Dolt Schema",
+			Status:   StatusWarning,
+			Message:  fmt.Sprintf("Missing ephemeral tables: %v (will be recreated on next bd command)", missingWispTables),
+			Detail:   "Wisps tables are dolt_ignore'd and must be recreated each server session (GH#2271)",
+			Fix:      "Run any bd command to trigger automatic recreation, or restart the Dolt server",
+			Category: CategoryCore,
+		}
+	}
+
 	return DoctorCheck{
 		Name:     "Dolt Schema",
 		Status:   StatusOK,

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -877,7 +877,9 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 	var version int
 	err := db.QueryRowContext(ctx, "SELECT `value` FROM config WHERE `key` = 'schema_version'").Scan(&version)
 	if err == nil && version >= currentSchemaVersion {
-		return nil
+		// Wisps tables are dolt_ignore'd (not persisted in commit history),
+		// so they must be recreated on every server session. (GH#2271)
+		return createIgnoredTables(db)
 	}
 
 	// Execute schema creation - split into individual statements


### PR DESCRIPTION
## Summary

Fixes #2271 — `bd epic status` fails with `table not found: wisps` after upgrading to v0.57.0.

The `initSchemaOnDB` fast-path (triggered when `schema_version >= currentSchemaVersion`) returned `nil` immediately, skipping `createIgnoredTables()`. Since wisps tables are `dolt_ignore`'d and only exist in the working set (not committed to Dolt history), they vanish on server restart and must be recreated every session.

## Changes

1. **`internal/storage/dolt/store.go`** — Fast-path now calls `createIgnoredTables(db)` before returning. This is idempotent (CREATE TABLE IF NOT EXISTS) and adds negligible overhead (~5 DDL statements).

2. **`cmd/bd/doctor/dolt.go`** — `checkSchemaWithDB` now detects missing wisps tables and reports them as a warning (they'll be recreated on next `bd` command).

3. **`cmd/bd/doctor/deep.go`** — Fixed stale reference to removed `bd migrate --to-dolt` command (now points to `bd init`).

## Test plan

- [x] `go build ./cmd/bd/` compiles cleanly
- [x] `go test ./internal/storage/dolt/...` passes
- [x] `go test ./internal/storage/dolt/migrations/...` passes
- [ ] Doctor tests have pre-existing build failures on main (unrelated: `federation_test.go` undefined symbols)