### PR TITLE
fix: strip absolute dolt_data_dir from metadata.json on save (GH#2251)

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1083,6 +1083,12 @@ func setDoltConfig(key, value string, updateConfig bool) {
 				os.Exit(1)
 			}
 			cfg.DoltDataDir = value
+			// Absolute paths are machine-specific and won't be persisted to
+			// metadata.json (which is committed to git). Use the env var for
+			// persistence across sessions. (GH#2251)
+			fmt.Fprintf(os.Stderr, "Note: absolute paths are not saved to metadata.json (it propagates via git).\n")
+			fmt.Fprintf(os.Stderr, "For persistence, add to your shell profile:\n")
+			fmt.Fprintf(os.Stderr, "  export BEADS_DOLT_DATA_DIR=%s\n", value)
 		}
 		yamlKey = "dolt.data-dir"
 

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -98,7 +98,16 @@ func Load(beadsDir string) (*Config, error) {
 func (c *Config) Save(beadsDir string) error {
 	configPath := ConfigPath(beadsDir)
 
-	data, err := json.MarshalIndent(c, "", "  ")
+	// Strip absolute dolt_data_dir before saving — metadata.json is committed
+	// to git and propagates to other clones, but absolute paths are
+	// machine-specific and cause data-loss on other machines (GH#2251).
+	// Users should set absolute paths via BEADS_DOLT_DATA_DIR env var instead.
+	saved := *c
+	if filepath.IsAbs(saved.DoltDataDir) {
+		saved.DoltDataDir = ""
+	}
+
+	data, err := json.MarshalIndent(&saved, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #2251 — `metadata.json` is committed to git and propagates to all clones. When `dolt_data_dir` contains an absolute path (e.g. `/home/user/.cache/beads-dolt`), other clones inherit that path and may silently use a non-existent or wrong directory, causing data loss.

### Changes

- **`configfile.Save()`**: Strips absolute `dolt_data_dir` before writing to `metadata.json`. The in-memory config retains the value for the current process; only the persisted file is sanitized.
- **`bd dolt set data-dir`**: When an absolute path is set, prints a warning explaining that it won't be saved to `metadata.json` and recommends using the `BEADS_DOLT_DATA_DIR` environment variable for persistence.

### Design rationale

Absolute paths are inherently machine-specific. Since `metadata.json` propagates via git, persisting them causes cross-clone breakage. The `BEADS_DOLT_DATA_DIR` env var already exists as the correct mechanism for machine-specific overrides (checked first in `GetDoltDataDir()`), so this change nudges users toward it.

Relative paths in `dolt_data_dir` are left unchanged since they resolve relative to `.beads/` and are portable across clones.

## Test plan

- [x] `go build ./cmd/bd/` compiles
- [x] `go test ./internal/configfile/...` passes
- [ ] Manual: `bd dolt set data-dir /tmp/test` → verify warning printed, metadata.json does not contain the absolute path
- [ ] Manual: `bd dolt set data-dir relative/path` → verify it IS saved to metadata.json