### PR TITLE
feat(dolt): add read-only cross-project queries via peer Dolt databases

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -715,6 +716,34 @@ var listCmd = &cobra.Command{
 			}
 		}
 
+		// Handle --repo flag: query a peer repository's database directly
+		repoOverride, _ := cmd.Flags().GetString("repo")
+		if repoOverride != "" {
+			// Expand ~ to home directory
+			if repoOverride[0] == '~' {
+				home, err := os.UserHomeDir()
+				if err == nil {
+					repoOverride = filepath.Join(home, repoOverride[1:])
+				}
+			}
+
+			peerBackend, err := dolt.DetectPeerBackend(repoOverride)
+			if err != nil {
+				FatalError("%v", err)
+			}
+
+			if peerBackend != dolt.PeerBackendDolt {
+				FatalError("peer at %s uses %s backend; --repo requires a Dolt-backed repository", repoOverride, peerBackend)
+			}
+
+			repoStore, err := dolt.OpenPeerStore(ctx, repoOverride)
+			if err != nil {
+				FatalError("%v", err)
+			}
+			defer func() { _ = repoStore.Close() }() // Best effort cleanup
+			activeStore = repoStore
+		}
+
 		// Direct mode
 		issues, err := activeStore.SearchIssues(ctx, "", filter)
 		if err != nil {
@@ -972,6 +1001,9 @@ func init() {
 
 	// Cross-rig routing: query a different rig's database (bd-rgdjr)
 	listCmd.Flags().String("rig", "", "Query a different rig's database (e.g., --rig gastown, --rig gt-, --rig gt)")
+
+	// Cross-repo routing: query a peer repository's Dolt database (bd-lb9)
+	listCmd.Flags().String("repo", "", "Query issues from a peer repository (path to peer's root, e.g., --repo ~/other-project)")
 
 	// Note: --json flag is defined as a persistent flag in main.go, not here
 	rootCmd.AddCommand(listCmd)

--- a/cmd/bd/list_repo_test.go
+++ b/cmd/bd/list_repo_test.go
@@ -1,0 +1,122 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestListRepoPeerQuery tests the --repo flag for querying peer Dolt databases.
+func TestListRepoPeerQuery(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Create a peer store with test issues via the test server
+	peerDir := t.TempDir()
+	peerDBPath := filepath.Join(peerDir, ".beads", "dolt")
+	peerStore := newTestStoreWithPrefix(t, peerDBPath, "peer")
+
+	peerIssue := &types.Issue{
+		Title:     "Peer visible issue",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if err := peerStore.CreateIssue(ctx, peerIssue, "test"); err != nil {
+		t.Fatalf("failed to create peer issue: %v", err)
+	}
+
+	t.Run("DetectPeerBackend finds dolt", func(t *testing.T) {
+		backend, err := dolt.DetectPeerBackend(peerDir)
+		if err != nil {
+			t.Fatalf("DetectPeerBackend failed: %v", err)
+		}
+		if backend != dolt.PeerBackendDolt {
+			t.Errorf("expected dolt backend, got %s", backend)
+		}
+	})
+
+	t.Run("DetectPeerBackend rejects missing beads dir", func(t *testing.T) {
+		emptyDir := t.TempDir()
+		_, err := dolt.DetectPeerBackend(emptyDir)
+		if err == nil {
+			t.Fatal("expected error for directory without .beads")
+		}
+	})
+
+	t.Run("DetectPeerBackend finds jsonl", func(t *testing.T) {
+		jsonlDir := t.TempDir()
+		beadsDir := filepath.Join(jsonlDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		backend, err := dolt.DetectPeerBackend(jsonlDir)
+		if err != nil {
+			t.Fatalf("DetectPeerBackend failed: %v", err)
+		}
+		if backend != dolt.PeerBackendJSONL {
+			t.Errorf("expected jsonl backend, got %s", backend)
+		}
+	})
+
+	// QueryPeerIssues and OpenPeerStore need their own server for the peer.
+	// Since the test server is shared and the peer database is on it,
+	// we test the detection and error paths here, and test the full
+	// query/hydration flow in the integration tests (multirepo_test.go).
+
+	t.Run("QueryPeerIssues rejects nonexistent path", func(t *testing.T) {
+		_, err := dolt.QueryPeerIssues(ctx, "/nonexistent/path/to/repo", types.IssueFilter{})
+		if err == nil {
+			t.Fatal("expected error for nonexistent peer path")
+		}
+	})
+}
+
+// TestListRepoHydration tests HydrateFromPeerDolt error paths.
+func TestListRepoHydration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Create local store
+	localDir := t.TempDir()
+	localDBPath := filepath.Join(localDir, ".beads", "dolt")
+	localStore := newTestStoreWithPrefix(t, localDBPath, "local")
+
+	t.Run("hydrate rejects jsonl peer", func(t *testing.T) {
+		jsonlDir := t.TempDir()
+		beadsDir := filepath.Join(jsonlDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := localStore.HydrateFromPeerDolt(ctx, jsonlDir)
+		if err == nil {
+			t.Fatal("expected error for JSONL peer")
+		}
+	})
+
+	t.Run("hydrate rejects nonexistent peer", func(t *testing.T) {
+		_, err := localStore.HydrateFromPeerDolt(ctx, "/nonexistent/path")
+		if err == nil {
+			t.Fatal("expected error for nonexistent peer")
+		}
+	})
+}

--- a/cmd/bd/repo.go
+++ b/cmd/bd/repo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -208,9 +210,9 @@ var repoSyncCmd = &cobra.Command{
 	Short: "Manually trigger multi-repo sync",
 	Long: `Synchronize issues from all configured additional repositories.
 
-Reads issues.jsonl from each additional repository and imports them into
-the primary database with their original prefixes and source_repo set.
-Uses mtime caching to skip repos whose JSONL hasn't changed.
+Detects each peer's storage backend and uses the appropriate sync method:
+  - Dolt peers: native Dolt server query (faster, no JSONL needed)
+  - JSONL peers: reads issues.jsonl with mtime caching
 
 Also triggers Dolt push/pull if a remote is configured.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -232,83 +234,58 @@ Also triggers Dolt push/pull if a remote is configured.`,
 			return fmt.Errorf("failed to load repo config: %w", err)
 		}
 
+		var doltSynced, jsonlSynced int
+		var syncErrors []string
 		totalImported := 0
-		totalSkipped := 0
 
-		// Hydrate issues from each additional repository
+		// Sync each additional repo using the appropriate backend
 		for _, repoPath := range repos.Additional {
-			// Expand tilde
+			// Expand ~ to home directory
 			expandedPath := repoPath
 			if len(repoPath) > 0 && repoPath[0] == '~' {
-				home, err := os.UserHomeDir()
-				if err == nil {
+				home, homeErr := os.UserHomeDir()
+				if homeErr == nil {
 					expandedPath = filepath.Join(home, repoPath[1:])
 				}
 			}
 
-			// Resolve to absolute path for consistent mtime caching
-			absPath, err := filepath.Abs(expandedPath)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to resolve path %s: %v\n", repoPath, err)
-				continue
-			}
-
-			jsonlPath := filepath.Join(absPath, ".beads", "issues.jsonl")
-			info, err := os.Stat(jsonlPath)
-			if err != nil {
+			// Detect peer backend type
+			backend, detectErr := dolt.DetectPeerBackend(expandedPath)
+			if detectErr != nil {
+				// Fall back to JSONL path detection if backend detection fails
 				if verbose {
-					fmt.Fprintf(os.Stderr, "Skipping %s: no issues.jsonl found\n", repoPath)
+					fmt.Fprintf(os.Stderr, "Backend detection failed for %s: %v, trying JSONL\n", repoPath, detectErr)
 				}
-				continue
+				backend = dolt.PeerBackendJSONL
 			}
 
-			// Check mtime cache — skip if JSONL hasn't changed
-			currentMtime := info.ModTime().UnixNano()
-			cachedMtime, _ := store.GetRepoMtime(ctx, absPath)
-			if cachedMtime == currentMtime {
-				if verbose {
-					fmt.Fprintf(os.Stderr, "Skipping %s: JSONL unchanged\n", repoPath)
+			switch backend {
+			case dolt.PeerBackendDolt:
+				// Use native Dolt hydration (read-only server access)
+				result, hydrateErr := store.HydrateFromPeerDolt(ctx, expandedPath)
+				if hydrateErr != nil {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", repoPath, hydrateErr))
+					continue
 				}
-				totalSkipped++
-				continue
-			}
-
-			// Parse issues from JSONL
-			issues, err := parseIssuesFromJSONL(jsonlPath)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to parse %s: %v\n", jsonlPath, err)
-				continue
-			}
-
-			if len(issues) == 0 {
-				if verbose {
-					fmt.Fprintf(os.Stderr, "Skipping %s: no issues in JSONL\n", repoPath)
+				doltSynced++
+				totalImported += result.Imported
+				if verbose && !jsonOutput {
+					fmt.Printf("  %s: %d imported, %d skipped (Dolt native)\n",
+						repoPath, result.Imported, result.Skipped)
 				}
-				continue
-			}
 
-			// Set source_repo on all imported issues
-			for _, issue := range issues {
-				issue.SourceRepo = repoPath
-			}
+			case dolt.PeerBackendJSONL:
+				// Fall back to JSONL import with mtime caching
+				imported, err := syncPeerViaJSONL(ctx, repoPath, expandedPath, verbose)
+				if err != nil {
+					syncErrors = append(syncErrors, fmt.Sprintf("%s: %v", repoPath, err))
+					continue
+				}
+				jsonlSynced++
+				totalImported += imported
 
-			// Import with prefix validation skipped (cross-prefix hydration)
-			if err := store.CreateIssuesWithFullOptions(ctx, issues, "repo-sync", storage.BatchCreateOptions{
-				OrphanHandling:       storage.OrphanAllow,
-				SkipPrefixValidation: true,
-			}); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to import from %s: %v\n", repoPath, err)
-				continue
-			}
-
-			// Update mtime cache
-			if err := store.SetRepoMtime(ctx, absPath, jsonlPath, currentMtime); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to update mtime cache for %s: %v\n", repoPath, err)
-			}
-
-			totalImported += len(issues)
-			if verbose {
-				fmt.Fprintf(os.Stderr, "Imported %d issue(s) from %s\n", len(issues), repoPath)
+			default:
+				syncErrors = append(syncErrors, fmt.Sprintf("%s: unknown backend %s", repoPath, backend))
 			}
 		}
 
@@ -318,23 +295,95 @@ Also triggers Dolt push/pull if a remote is configured.`,
 		if jsonOutput {
 			result := map[string]interface{}{
 				"synced":          true,
-				"repos_synced":    len(repos.Additional) - totalSkipped,
-				"repos_skipped":   totalSkipped,
+				"dolt_synced":     doltSynced,
+				"jsonl_synced":    jsonlSynced,
 				"issues_imported": totalImported,
+				"errors":          syncErrors,
 			}
 			return json.NewEncoder(os.Stdout).Encode(result)
 		}
 
+		if len(syncErrors) > 0 {
+			fmt.Fprintf(os.Stderr, "\nSync errors:\n")
+			for _, e := range syncErrors {
+				fmt.Fprintf(os.Stderr, "  - %s\n", e)
+			}
+		}
+
 		if totalImported > 0 {
-			fmt.Printf("Multi-repo sync complete: imported %d issue(s) from %d repo(s)\n",
-				totalImported, len(repos.Additional)-totalSkipped)
-		} else if totalSkipped == len(repos.Additional) {
-			fmt.Println("Multi-repo sync complete: all repos up to date")
+			fmt.Printf("Multi-repo sync complete: %d imported (%d Dolt, %d JSONL)\n",
+				totalImported, doltSynced, jsonlSynced)
 		} else {
-			fmt.Println("Multi-repo sync complete")
+			fmt.Println("Multi-repo sync complete: all repos up to date")
 		}
 		return nil
 	},
+}
+
+// syncPeerViaJSONL syncs a peer repository using JSONL import with mtime caching.
+// Returns the number of issues imported.
+func syncPeerViaJSONL(ctx context.Context, repoPath, expandedPath string, verbose bool) (int, error) {
+	// Resolve to absolute path for consistent mtime caching
+	absPath, err := filepath.Abs(expandedPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	jsonlPath := filepath.Join(absPath, ".beads", "issues.jsonl")
+	info, err := os.Stat(jsonlPath)
+	if err != nil {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Skipping %s: no issues.jsonl found\n", repoPath)
+		}
+		return 0, nil
+	}
+
+	// Check mtime cache — skip if JSONL hasn't changed
+	currentMtime := info.ModTime().UnixNano()
+	cachedMtime, _ := store.GetRepoMtime(ctx, absPath)
+	if cachedMtime == currentMtime {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Skipping %s: JSONL unchanged\n", repoPath)
+		}
+		return 0, nil
+	}
+
+	// Parse issues from JSONL
+	issues, err := parseIssuesFromJSONL(jsonlPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse JSONL: %w", err)
+	}
+
+	if len(issues) == 0 {
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Skipping %s: no issues in JSONL\n", repoPath)
+		}
+		return 0, nil
+	}
+
+	// Set source_repo on all imported issues
+	for _, issue := range issues {
+		issue.SourceRepo = repoPath
+	}
+
+	// Import with prefix validation skipped (cross-prefix hydration)
+	if err := store.CreateIssuesWithFullOptions(ctx, issues, "repo-sync", storage.BatchCreateOptions{
+		OrphanHandling:       storage.OrphanAllow,
+		SkipPrefixValidation: true,
+	}); err != nil {
+		return 0, fmt.Errorf("failed to import: %w", err)
+	}
+
+	// Update mtime cache
+	if err := store.SetRepoMtime(ctx, absPath, jsonlPath, currentMtime); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to update mtime cache for %s: %v\n", repoPath, err)
+	}
+
+	if verbose && !jsonOutput {
+		fmt.Fprintf(os.Stderr, "Imported %d issue(s) from %s (JSONL)\n", len(issues), repoPath)
+	}
+
+	return len(issues), nil
 }
 
 // parseIssuesFromJSONL reads and parses issues from a JSONL file.

--- a/internal/storage/dolt/multirepo.go
+++ b/internal/storage/dolt/multirepo.go
@@ -1,0 +1,194 @@
+//go:build cgo
+
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// PeerBackend represents the detected storage backend of a peer repository.
+type PeerBackend string
+
+const (
+	// PeerBackendDolt indicates the peer uses a Dolt database.
+	PeerBackendDolt PeerBackend = "dolt"
+	// PeerBackendJSONL indicates the peer uses JSONL file storage.
+	PeerBackendJSONL PeerBackend = "jsonl"
+	// PeerBackendUnknown indicates the peer backend could not be determined.
+	PeerBackendUnknown PeerBackend = "unknown"
+)
+
+// DetectPeerBackend determines the storage backend type of a peer repository.
+// peerRepoPath is the root directory of the peer repository (containing .beads/).
+// Returns the detected backend type or an error if the path is invalid.
+func DetectPeerBackend(peerRepoPath string) (PeerBackend, error) {
+	beadsDir := filepath.Join(peerRepoPath, ".beads")
+	info, err := os.Stat(beadsDir)
+	if err != nil {
+		return PeerBackendUnknown, fmt.Errorf("no .beads directory at %s: %w", peerRepoPath, err)
+	}
+	if !info.IsDir() {
+		return PeerBackendUnknown, fmt.Errorf(".beads at %s is not a directory", peerRepoPath)
+	}
+
+	// Check for Dolt database directory
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if info, err := os.Stat(doltDir); err == nil && info.IsDir() {
+		return PeerBackendDolt, nil
+	}
+
+	// Check for JSONL file
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if _, err := os.Stat(jsonlPath); err == nil {
+		return PeerBackendJSONL, nil
+	}
+
+	// Check metadata.json for backend hint
+	cfg, err := configfile.Load(beadsDir)
+	if err == nil && cfg != nil {
+		if cfg.GetBackend() == configfile.BackendDolt {
+			return PeerBackendDolt, nil
+		}
+	}
+
+	return PeerBackendUnknown, fmt.Errorf("could not determine backend for peer at %s", peerRepoPath)
+}
+
+// OpenPeerStore opens a read-only DoltStore for a peer repository.
+// peerRepoPath is the root directory of the peer repository (containing .beads/).
+// Uses AutoStart to spin up a temporary Dolt server if one isn't running for the peer.
+// The caller must close the returned store when done.
+func OpenPeerStore(ctx context.Context, peerRepoPath string) (*DoltStore, error) {
+	beadsDir := filepath.Join(peerRepoPath, ".beads")
+
+	// Verify the beads directory exists
+	if _, err := os.Stat(beadsDir); err != nil {
+		return nil, fmt.Errorf("peer repository not found at %s: %w", peerRepoPath, err)
+	}
+
+	// Open in read-only mode with AutoStart to spin up a server if needed.
+	// Each beads directory gets its own Dolt server on a derived port.
+	peerStore, err := NewFromConfigWithOptions(ctx, beadsDir, &Config{
+		ReadOnly:  true,
+		AutoStart: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open peer database at %s: %w", peerRepoPath, err)
+	}
+
+	return peerStore, nil
+}
+
+// QueryPeerIssues queries issues from a peer Dolt database with the given filter.
+// Results are tagged with the SourceRepo field set to peerRepoPath.
+// This is a read-only operation that opens a temporary connection to the peer database.
+func QueryPeerIssues(ctx context.Context, peerRepoPath string, filter types.IssueFilter) ([]*types.Issue, error) {
+	peerStore, err := OpenPeerStore(ctx, peerRepoPath)
+	if err != nil {
+		return nil, err
+	}
+	defer peerStore.Close()
+
+	issues, err := peerStore.SearchIssues(ctx, "", filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query peer issues at %s: %w", peerRepoPath, err)
+	}
+
+	// Tag all results with the source repository path
+	for _, issue := range issues {
+		issue.SourceRepo = peerRepoPath
+	}
+
+	return issues, nil
+}
+
+// HydrateFromPeerDolt imports issues from a peer Dolt database into the local store.
+// Opens the peer database via a read-only Dolt server, queries all issues, and creates
+// them locally with source_repo set to the peer path.
+//
+// The operation is idempotent: existing issues with matching IDs are skipped.
+func (s *DoltStore) HydrateFromPeerDolt(ctx context.Context, peerRepoPath string) (*HydrationResult, error) {
+	if s.readOnly {
+		return nil, fmt.Errorf("cannot hydrate: store is read-only")
+	}
+
+	// Resolve absolute path for the peer
+	absPath, err := filepath.Abs(peerRepoPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve peer path: %w", err)
+	}
+
+	// Detect peer backend
+	backend, err := DetectPeerBackend(absPath)
+	if err != nil {
+		return nil, err
+	}
+	if backend != PeerBackendDolt {
+		return nil, fmt.Errorf("peer at %s uses %s backend, not Dolt", absPath, backend)
+	}
+
+	result := &HydrationResult{
+		PeerPath: absPath,
+	}
+
+	// Query peer issues directly via read-only store open
+	peerStore, err := OpenPeerStore(ctx, absPath)
+	if err != nil {
+		return nil, err
+	}
+	defer peerStore.Close()
+
+	// Fetch all issues from peer (no filter = all statuses)
+	peerIssues, err := peerStore.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query peer issues: %w", err)
+	}
+	result.TotalPeerIssues = len(peerIssues)
+
+	// Batch check which IDs already exist locally
+	peerIDs := make([]string, len(peerIssues))
+	for i, issue := range peerIssues {
+		peerIDs[i] = issue.ID
+	}
+	existingIssues, err := s.GetIssuesByIDs(ctx, peerIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check existing issues: %w", err)
+	}
+	existingSet := make(map[string]bool, len(existingIssues))
+	for _, existing := range existingIssues {
+		existingSet[existing.ID] = true
+	}
+
+	// Import issues that don't exist locally
+	for _, issue := range peerIssues {
+		if existingSet[issue.ID] {
+			result.Skipped++
+			continue
+		}
+
+		issue.SourceRepo = peerRepoPath
+
+		if err := s.CreateIssue(ctx, issue, "hydrate"); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("failed to import %s: %v", issue.ID, err))
+			continue
+		}
+		result.Imported++
+	}
+
+	return result, nil
+}
+
+// HydrationResult contains the outcome of a HydrateFromPeerDolt operation.
+type HydrationResult struct {
+	PeerPath        string   // Absolute path to the peer repository
+	TotalPeerIssues int      // Total issues found in peer
+	Imported        int      // Issues successfully imported
+	Skipped         int      // Issues skipped (already exist locally)
+	Errors          []string // Non-fatal import errors
+}

--- a/internal/storage/dolt/multirepo_nocgo.go
+++ b/internal/storage/dolt/multirepo_nocgo.go
@@ -1,0 +1,53 @@
+//go:build !cgo
+
+package dolt
+
+import (
+	"context"
+	"errors"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+var errNoCGO = errors.New("peer database queries require CGO (Dolt database)")
+
+// PeerBackend represents the detected storage backend of a peer repository.
+type PeerBackend string
+
+const (
+	// PeerBackendDolt indicates the peer uses a Dolt database.
+	PeerBackendDolt PeerBackend = "dolt"
+	// PeerBackendJSONL indicates the peer uses JSONL file storage.
+	PeerBackendJSONL PeerBackend = "jsonl"
+	// PeerBackendUnknown indicates the peer backend could not be determined.
+	PeerBackendUnknown PeerBackend = "unknown"
+)
+
+// HydrationResult contains the outcome of a HydrateFromPeerDolt operation.
+type HydrationResult struct {
+	PeerPath        string
+	TotalPeerIssues int
+	Imported        int
+	Skipped         int
+	Errors          []string
+}
+
+// DetectPeerBackend determines the storage backend type of a peer repository.
+func DetectPeerBackend(_ string) (PeerBackend, error) {
+	return PeerBackendUnknown, errNoCGO
+}
+
+// OpenPeerStore opens a read-only DoltStore for a peer repository.
+func OpenPeerStore(_ context.Context, _ string) (*DoltStore, error) {
+	return nil, errNoCGO
+}
+
+// QueryPeerIssues queries issues from a peer Dolt database with the given filter.
+func QueryPeerIssues(_ context.Context, _ string, _ types.IssueFilter) ([]*types.Issue, error) {
+	return nil, errNoCGO
+}
+
+// HydrateFromPeerDolt imports issues from a peer Dolt database into the local store.
+func (s *DoltStore) HydrateFromPeerDolt(_ context.Context, _ string) (*HydrationResult, error) {
+	return nil, errNoCGO
+}

--- a/internal/storage/dolt/multirepo_test.go
+++ b/internal/storage/dolt/multirepo_test.go
@@ -1,0 +1,593 @@
+//go:build cgo && integration
+
+package dolt
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestDetectPeerBackend(t *testing.T) {
+	skipIfNoDolt(t)
+
+	t.Run("dolt backend detected", func(t *testing.T) {
+		dir := t.TempDir()
+		beadsDir := filepath.Join(dir, ".beads")
+		doltDir := filepath.Join(beadsDir, "dolt")
+		if err := os.MkdirAll(doltDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		backend, err := DetectPeerBackend(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if backend != PeerBackendDolt {
+			t.Errorf("expected dolt backend, got %s", backend)
+		}
+	})
+
+	t.Run("jsonl backend detected", func(t *testing.T) {
+		dir := t.TempDir()
+		beadsDir := filepath.Join(dir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		backend, err := DetectPeerBackend(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if backend != PeerBackendJSONL {
+			t.Errorf("expected jsonl backend, got %s", backend)
+		}
+	})
+
+	t.Run("no beads directory", func(t *testing.T) {
+		dir := t.TempDir()
+
+		_, err := DetectPeerBackend(dir)
+		if err == nil {
+			t.Fatal("expected error for missing .beads directory")
+		}
+	})
+
+	t.Run("empty beads directory", func(t *testing.T) {
+		dir := t.TempDir()
+		beadsDir := filepath.Join(dir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := DetectPeerBackend(dir)
+		if err == nil {
+			t.Fatal("expected error for empty .beads directory")
+		}
+	})
+
+	t.Run("dolt preferred over jsonl", func(t *testing.T) {
+		dir := t.TempDir()
+		beadsDir := filepath.Join(dir, ".beads")
+		doltDir := filepath.Join(beadsDir, "dolt")
+		if err := os.MkdirAll(doltDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Also create JSONL file
+		jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		backend, err := DetectPeerBackend(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if backend != PeerBackendDolt {
+			t.Errorf("expected dolt backend (preferred), got %s", backend)
+		}
+	})
+}
+
+func TestQueryPeerIssues(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	baseDir := t.TempDir()
+
+	// Setup peer store with test issues
+	peerDir := filepath.Join(baseDir, "peer-repo")
+	peerStore, peerCleanup := setupFederationStore(t, ctx, peerDir, "peer")
+	defer peerCleanup()
+
+	// Create test issues in peer
+	issues := []*types.Issue{
+		{
+			ID:        "peer-001",
+			Title:     "Peer issue one",
+			IssueType: types.TypeTask,
+			Status:    types.StatusOpen,
+			Priority:  1,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+		{
+			ID:        "peer-002",
+			Title:     "Peer issue two",
+			IssueType: types.TypeBug,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+	}
+
+	for _, issue := range issues {
+		if err := peerStore.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("failed to create peer issue %s: %v", issue.ID, err)
+		}
+	}
+	if err := peerStore.Commit(ctx, "Create test issues"); err != nil {
+		t.Logf("commit: %v", err)
+	}
+
+	// Close peer store before querying (single-process Dolt access)
+	peerStore.Close()
+
+	// Create a .beads directory structure that DetectPeerBackend expects
+	// The peer store was created at peerDir (which is the dolt path),
+	// but we need the repo root to have .beads/dolt/
+	peerRepoRoot := filepath.Join(baseDir, "peer-root")
+	peerBeadsDir := filepath.Join(peerRepoRoot, ".beads")
+	if err := os.MkdirAll(peerBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink the dolt directory
+	if err := os.Symlink(peerDir, filepath.Join(peerBeadsDir, "dolt")); err != nil {
+		t.Fatal(err)
+	}
+	// Create metadata.json
+	if err := os.WriteFile(filepath.Join(peerBeadsDir, "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("query all issues", func(t *testing.T) {
+		result, err := QueryPeerIssues(ctx, peerRepoRoot, types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("QueryPeerIssues failed: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("expected 2 issues, got %d", len(result))
+		}
+		// Verify source_repo is set
+		for _, issue := range result {
+			if issue.SourceRepo != peerRepoRoot {
+				t.Errorf("expected SourceRepo=%s, got %s", peerRepoRoot, issue.SourceRepo)
+			}
+		}
+	})
+
+	t.Run("query with filter", func(t *testing.T) {
+		bugType := types.TypeBug
+		result, err := QueryPeerIssues(ctx, peerRepoRoot, types.IssueFilter{
+			IssueType: &bugType,
+		})
+		if err != nil {
+			t.Fatalf("QueryPeerIssues with filter failed: %v", err)
+		}
+		if len(result) != 1 {
+			t.Errorf("expected 1 bug issue, got %d", len(result))
+		}
+		if len(result) > 0 && result[0].ID != "peer-002" {
+			t.Errorf("expected peer-002, got %s", result[0].ID)
+		}
+	})
+
+	t.Run("query nonexistent peer", func(t *testing.T) {
+		_, err := QueryPeerIssues(ctx, "/nonexistent/path", types.IssueFilter{})
+		if err == nil {
+			t.Fatal("expected error for nonexistent peer")
+		}
+	})
+}
+
+func TestHydrateFromPeerDolt(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	baseDir := t.TempDir()
+
+	// Setup peer store with test issues
+	peerDoltDir := filepath.Join(baseDir, "peer-dolt")
+	peerStore, peerCleanup := setupFederationStore(t, ctx, peerDoltDir, "peer")
+	defer peerCleanup()
+
+	// Create test issues in peer
+	peerIssue := &types.Issue{
+		ID:        "peer-h01",
+		Title:     "Hydration test issue",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if err := peerStore.CreateIssue(ctx, peerIssue, "test"); err != nil {
+		t.Fatalf("failed to create peer issue: %v", err)
+	}
+	if err := peerStore.Commit(ctx, "Create hydration test issue"); err != nil {
+		t.Logf("commit: %v", err)
+	}
+	peerStore.Close()
+
+	// Create peer repo root with .beads/dolt/ structure
+	peerRepoRoot := filepath.Join(baseDir, "peer-repo-root")
+	peerBeadsDir := filepath.Join(peerRepoRoot, ".beads")
+	if err := os.MkdirAll(peerBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(peerDoltDir, filepath.Join(peerBeadsDir, "dolt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(peerBeadsDir, "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup local store
+	localDir := filepath.Join(baseDir, "local-dolt")
+	localStore, localCleanup := setupFederationStore(t, ctx, localDir, "local")
+	defer localCleanup()
+
+	t.Run("hydrate imports peer issues", func(t *testing.T) {
+		result, err := localStore.HydrateFromPeerDolt(ctx, peerRepoRoot)
+		if err != nil {
+			t.Fatalf("HydrateFromPeerDolt failed: %v", err)
+		}
+		if result.TotalPeerIssues != 1 {
+			t.Errorf("expected 1 total peer issue, got %d", result.TotalPeerIssues)
+		}
+		if result.Imported != 1 {
+			t.Errorf("expected 1 imported, got %d", result.Imported)
+		}
+		if result.Skipped != 0 {
+			t.Errorf("expected 0 skipped, got %d", result.Skipped)
+		}
+
+		// Verify the issue exists locally
+		local, err := localStore.GetIssue(ctx, "peer-h01")
+		if err != nil {
+			t.Fatalf("failed to get imported issue: %v", err)
+		}
+		if local == nil {
+			t.Fatal("imported issue not found locally")
+		}
+		if local.SourceRepo != peerRepoRoot {
+			t.Errorf("expected SourceRepo=%s, got %s", peerRepoRoot, local.SourceRepo)
+		}
+	})
+
+	t.Run("hydrate is idempotent", func(t *testing.T) {
+		result, err := localStore.HydrateFromPeerDolt(ctx, peerRepoRoot)
+		if err != nil {
+			t.Fatalf("second HydrateFromPeerDolt failed: %v", err)
+		}
+		if result.Imported != 0 {
+			t.Errorf("expected 0 imported on second run, got %d", result.Imported)
+		}
+		if result.Skipped != 1 {
+			t.Errorf("expected 1 skipped on second run, got %d", result.Skipped)
+		}
+	})
+
+	t.Run("hydrate rejects non-dolt peer", func(t *testing.T) {
+		// Create a JSONL-only peer
+		jsonlPeer := filepath.Join(baseDir, "jsonl-peer")
+		jsonlBeads := filepath.Join(jsonlPeer, ".beads")
+		if err := os.MkdirAll(jsonlBeads, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(jsonlBeads, "issues.jsonl"), []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := localStore.HydrateFromPeerDolt(ctx, jsonlPeer)
+		if err == nil {
+			t.Fatal("expected error for JSONL peer")
+		}
+	})
+
+	t.Run("hydrate rejects nonexistent peer", func(t *testing.T) {
+		_, err := localStore.HydrateFromPeerDolt(ctx, "/nonexistent/path")
+		if err == nil {
+			t.Fatal("expected error for nonexistent peer")
+		}
+	})
+}
+
+func TestOpenPeerStore(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	baseDir := t.TempDir()
+
+	// Setup a peer store
+	peerDoltDir := filepath.Join(baseDir, "peer-dolt")
+	peerStore, peerCleanup := setupFederationStore(t, ctx, peerDoltDir, "peer")
+	defer peerCleanup()
+
+	// Create a test issue
+	issue := &types.Issue{
+		ID:        "peer-open-01",
+		Title:     "Open peer test",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if err := peerStore.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+	if err := peerStore.Commit(ctx, "Create test issue"); err != nil {
+		t.Logf("commit: %v", err)
+	}
+	peerStore.Close()
+
+	// Create repo root structure
+	peerRepoRoot := filepath.Join(baseDir, "peer-root")
+	peerBeadsDir := filepath.Join(peerRepoRoot, ".beads")
+	if err := os.MkdirAll(peerBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(peerDoltDir, filepath.Join(peerBeadsDir, "dolt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(peerBeadsDir, "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("opens read-only store", func(t *testing.T) {
+		opened, err := OpenPeerStore(ctx, peerRepoRoot)
+		if err != nil {
+			t.Fatalf("OpenPeerStore failed: %v", err)
+		}
+		defer opened.Close()
+
+		// Verify we can read
+		got, err := opened.GetIssue(ctx, "peer-open-01")
+		if err != nil {
+			t.Fatalf("failed to get issue from peer store: %v", err)
+		}
+		if got == nil {
+			t.Fatal("issue not found in peer store")
+		}
+		if got.Title != "Open peer test" {
+			t.Errorf("expected title 'Open peer test', got %q", got.Title)
+		}
+	})
+
+	t.Run("rejects nonexistent path", func(t *testing.T) {
+		_, err := OpenPeerStore(ctx, "/nonexistent/path")
+		if err == nil {
+			t.Fatal("expected error for nonexistent path")
+		}
+	})
+}
+
+func TestDetectPeerBackend_SymlinkDolt(t *testing.T) {
+	skipIfNoDolt(t)
+
+	// Verify detection works through symlinks (common in test setups)
+	baseDir := t.TempDir()
+	realDolt := filepath.Join(baseDir, "real-dolt")
+	if err := os.MkdirAll(realDolt, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoRoot := filepath.Join(baseDir, "repo")
+	beadsDir := filepath.Join(repoRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDolt, filepath.Join(beadsDir, "dolt")); err != nil {
+		t.Fatal(err)
+	}
+
+	backend, err := DetectPeerBackend(repoRoot)
+	if err != nil {
+		t.Fatalf("unexpected error with symlinked dolt dir: %v", err)
+	}
+	if backend != PeerBackendDolt {
+		t.Errorf("expected dolt backend through symlink, got %s", backend)
+	}
+}
+
+func TestDetectPeerBackend_NotADirectory(t *testing.T) {
+	skipIfNoDolt(t)
+
+	dir := t.TempDir()
+	// Create .beads as a file, not a directory
+	beadsPath := filepath.Join(dir, ".beads")
+	if err := os.WriteFile(beadsPath, []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := DetectPeerBackend(dir)
+	if err == nil {
+		t.Fatal("expected error when .beads is a file, not a directory")
+	}
+}
+
+func TestHydrateFromPeerDolt_SourceRepoPersistence(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	baseDir := t.TempDir()
+
+	// Setup peer with an issue
+	peerDoltDir := filepath.Join(baseDir, "peer-dolt")
+	peerStore, peerCleanup := setupFederationStore(t, ctx, peerDoltDir, "peer")
+	defer peerCleanup()
+
+	peerIssue := &types.Issue{
+		ID:        "peer-persist-01",
+		Title:     "Persistence test",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	if err := peerStore.CreateIssue(ctx, peerIssue, "test"); err != nil {
+		t.Fatalf("failed to create peer issue: %v", err)
+	}
+	if err := peerStore.Commit(ctx, "Create persistence test issue"); err != nil {
+		t.Logf("commit: %v", err)
+	}
+	peerStore.Close()
+
+	// Create peer repo root structure
+	peerRepoRoot := filepath.Join(baseDir, "peer-root")
+	peerBeadsDir := filepath.Join(peerRepoRoot, ".beads")
+	if err := os.MkdirAll(peerBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(peerDoltDir, filepath.Join(peerBeadsDir, "dolt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(peerBeadsDir, "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup local store, hydrate, close, reopen, verify source_repo persists
+	localDir := filepath.Join(baseDir, "local-dolt")
+	localStore, localCleanup := setupFederationStore(t, ctx, localDir, "local")
+
+	_, err := localStore.HydrateFromPeerDolt(ctx, peerRepoRoot)
+	if err != nil {
+		t.Fatalf("HydrateFromPeerDolt failed: %v", err)
+	}
+
+	// Commit and close
+	if err := localStore.Commit(ctx, "Hydrate from peer"); err != nil {
+		t.Logf("commit: %v", err)
+	}
+	localCleanup()
+
+	// Reopen the store and verify source_repo survived the round-trip
+	reopened, reopenCleanup := setupFederationStore(t, ctx, localDir, "local")
+	defer reopenCleanup()
+
+	got, err := reopened.GetIssue(ctx, "peer-persist-01")
+	if err != nil {
+		t.Fatalf("failed to get issue after reopen: %v", err)
+	}
+	if got == nil {
+		t.Fatal("issue not found after reopen")
+	}
+	// Note: source_repo may not persist through Dolt storage if the field
+	// is not stored in the issues table. This test documents the behavior.
+	t.Logf("source_repo after round-trip: %q", got.SourceRepo)
+}
+
+func TestHydrateFromPeerDolt_ReadOnlyStoreRejects(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	baseDir := t.TempDir()
+
+	// Setup a peer
+	peerDoltDir := filepath.Join(baseDir, "peer-dolt")
+	_, peerCleanup := setupFederationStore(t, ctx, peerDoltDir, "peer")
+	defer peerCleanup()
+
+	peerRepoRoot := filepath.Join(baseDir, "peer-root")
+	peerBeadsDir := filepath.Join(peerRepoRoot, ".beads")
+	if err := os.MkdirAll(peerBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(peerDoltDir, filepath.Join(peerBeadsDir, "dolt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(peerBeadsDir, "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open a read-only store and verify hydration is rejected
+	roStore, err := OpenPeerStore(ctx, peerRepoRoot)
+	if err != nil {
+		t.Fatalf("OpenPeerStore failed: %v", err)
+	}
+	defer roStore.Close()
+
+	_, err = roStore.HydrateFromPeerDolt(ctx, peerRepoRoot)
+	if err == nil {
+		t.Fatal("expected error when hydrating from a read-only store")
+	}
+	if !strings.Contains(err.Error(), "read-only") {
+		t.Errorf("expected 'read-only' in error message, got: %v", err)
+	}
+}
+
+func TestQueryPeerIssues_EmptyPeer(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	baseDir := t.TempDir()
+
+	// Setup peer with no issues
+	peerDoltDir := filepath.Join(baseDir, "empty-peer")
+	peerStore, peerCleanup := setupFederationStore(t, ctx, peerDoltDir, "empty")
+	defer peerCleanup()
+	if err := peerStore.Commit(ctx, "Initialize empty peer"); err != nil {
+		t.Logf("commit: %v", err)
+	}
+	peerStore.Close()
+
+	peerRepoRoot := filepath.Join(baseDir, "empty-root")
+	peerBeadsDir := filepath.Join(peerRepoRoot, ".beads")
+	if err := os.MkdirAll(peerBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(peerDoltDir, filepath.Join(peerBeadsDir, "dolt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(peerBeadsDir, "metadata.json"),
+		[]byte(`{"database":"dolt","backend":"dolt"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := QueryPeerIssues(ctx, peerRepoRoot, types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("QueryPeerIssues on empty peer failed: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected 0 issues from empty peer, got %d", len(result))
+	}
+}


### PR DESCRIPTION
## Summary

Multi-repo sync (`bd repo sync`) currently reads `issues.jsonl` from peer repositories. This adds native Dolt-to-Dolt peer queries, eliminating the JSONL intermediary for Dolt-backed peers.

New functions in `internal/storage/dolt/multirepo.go`:
- `DetectPeerBackend()` — identifies peer storage type (dolt/jsonl/unknown)
- `OpenPeerStore()` — opens a read-only connection to a peer Dolt database (auto-starts server if needed)
- `QueryPeerIssues()` — queries peer issues with filter support and `source_repo` tagging
- `HydrateFromPeerDolt()` — idempotent import of peer issues into the local store

## Changes

- Add `internal/storage/dolt/multirepo.go` with peer detection, query, and hydration functions
- Add `internal/storage/dolt/multirepo_nocgo.go` with no-CGO stubs
- Add `--repo` flag to `bd list` for direct peer database queries (mirrors `--rig` pattern)
- Update `bd repo sync` to detect Dolt peers and use native hydration, with JSONL fallback
- Extract `syncPeerViaJSONL()` helper from the existing JSONL sync logic
- Add CLI-level tests in `cmd/bd/list_repo_test.go`
- Add integration tests in `internal/storage/dolt/multirepo_test.go`

## Test plan

- [x] `make build` passes
- [x] `go test -short ./...` passes
- [x] `gofmt` clean on all changed files
- [x] CLI tests: `DetectPeerBackend` (dolt, jsonl, missing), `QueryPeerIssues` error paths, `HydrateFromPeerDolt` error paths
- [x] Integration tests: peer query with filters, hydration with idempotency, read-only store rejection, symlink detection, empty peer handling
- [x] No-CGO stubs compile without CGO