### PR TITLE
fix(dep): enforce same-type blocking validation

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -41,6 +41,25 @@ func isChildOf(childID, parentID string) bool {
 	return strings.HasPrefix(childID, parentID+".")
 }
 
+// checkCrossTypeBlocking validates that blocking deps don't cross the epic/task
+// boundary. Tasks can only block tasks; epics can only block epics.
+func checkCrossTypeBlocking(ctx context.Context, s *dolt.DoltStore, fromID, toID string) {
+	sourceIssue, err := s.GetIssue(ctx, fromID)
+	if err != nil {
+		return // Let AddDependency handle existence errors
+	}
+	targetIssue, err := s.GetIssue(ctx, toID)
+	if err != nil {
+		return // Let AddDependency handle existence errors
+	}
+
+	sourceIsTask := sourceIssue.IssueType != types.TypeEpic
+	targetIsTask := targetIssue.IssueType != types.TypeEpic
+	if sourceIsTask != targetIsTask {
+		FatalErrorRespectJSON("tasks can only block other tasks. epics can only block other epics")
+	}
+}
+
 // warnIfCyclesExist checks for dependency cycles and prints a warning if found.
 func warnIfCyclesExist(s *dolt.DoltStore) {
 	if s == nil {
@@ -127,6 +146,9 @@ Examples:
 			if isChildOf(fromID, toID) {
 				FatalErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
 			}
+
+			// Cross-type blocking validation: tasks can only block tasks, epics only epics
+			checkCrossTypeBlocking(ctx, store, fromID, toID)
 
 			// Direct mode
 			dep := &types.Dependency{
@@ -265,6 +287,11 @@ Examples:
 		// This creates a deadlock: child can't start (parent open), parent can't close (children not done)
 		if isChildOf(fromID, toID) {
 			FatalErrorRespectJSON("cannot add dependency: %s is already a child of %s. Children inherit dependency on parent completion via hierarchy. Adding an explicit dependency would create a deadlock", fromID, toID)
+		}
+
+		// Cross-type blocking validation: tasks can only block tasks, epics only epics
+		if depType == "blocks" && !isExternalRef {
+			checkCrossTypeBlocking(ctx, store, fromID, toID)
 		}
 
 		// Validate dependency type

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -63,6 +63,37 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		}
 	}
 
+	// Cross-type blocking validation: tasks can only block tasks, epics can only
+	// block epics. Prevents nonsensical task↔epic blocking that causes deadlocks
+	// in ready work computation (GH#1495).
+	if dep.Type == types.DepBlocks && !strings.HasPrefix(dep.DependsOnID, "external:") {
+		var sourceType, targetType string
+		if err := tx.QueryRowContext(ctx,
+			`SELECT issue_type FROM issues WHERE id = ?`, dep.IssueID,
+		).Scan(&sourceType); err != nil {
+			return fmt.Errorf("failed to fetch issue type for %s: %w", dep.IssueID, err)
+		}
+		targetTable := "issues"
+		if targetIsWisp {
+			targetTable = "wisps"
+		}
+		//nolint:gosec // G201: targetTable is hardcoded to "issues" or "wisps"
+		if err := tx.QueryRowContext(ctx,
+			fmt.Sprintf(`SELECT issue_type FROM %s WHERE id = ?`, targetTable), dep.DependsOnID,
+		).Scan(&targetType); err != nil {
+			return fmt.Errorf("failed to fetch issue type for %s: %w", dep.DependsOnID, err)
+		}
+
+		sourceIsTask := sourceType != string(types.TypeEpic)
+		targetIsTask := targetType != string(types.TypeEpic)
+		if sourceIsTask != targetIsTask {
+			if sourceIsTask {
+				return fmt.Errorf("tasks can only block other tasks. epics can only block other epics")
+			}
+			return fmt.Errorf("epics can only block other epics. tasks can only block other tasks")
+		}
+	}
+
 	// Cycle detection for blocking dependency types: check if adding this edge
 	// would create a cycle by seeing if depends_on_id can already reach issue_id.
 	// UNIONs both dependencies and wisp_dependencies to detect cross-table cycles

--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -1,6 +1,7 @@
 package dolt
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -786,6 +787,213 @@ func TestAddDependency_MultipleExternalReferences(t *testing.T) {
 
 	if len(records) != len(externalRefs) {
 		t.Errorf("expected %d dependencies, got %d", len(externalRefs), len(records))
+	}
+}
+
+// =============================================================================
+// Cross-Type Blocking Validation Tests
+// =============================================================================
+
+func TestAddDependency_BlocksCrossType_TaskBlocksEpic(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	task := &types.Issue{
+		ID:        "ct-task-1",
+		Title:     "A task",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	epic := &types.Issue{
+		ID:        "ct-epic-1",
+		Title:     "An epic",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, task, "tester"); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+	if err := store.CreateIssue(ctx, epic, "tester"); err != nil {
+		t.Fatalf("failed to create epic: %v", err)
+	}
+
+	// Task blocks epic → should fail
+	dep := &types.Dependency{
+		IssueID:     "ct-epic-1",
+		DependsOnID: "ct-task-1",
+		Type:        types.DepBlocks,
+	}
+	err := store.AddDependency(ctx, dep, "tester")
+	if err == nil {
+		t.Fatal("expected error when task blocks epic, got nil")
+	}
+	if !strings.Contains(err.Error(), "tasks can only block other tasks") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestAddDependency_BlocksCrossType_EpicBlocksTask(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	task := &types.Issue{
+		ID:        "ct-task-2",
+		Title:     "A task",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	epic := &types.Issue{
+		ID:        "ct-epic-2",
+		Title:     "An epic",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, task, "tester"); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+	if err := store.CreateIssue(ctx, epic, "tester"); err != nil {
+		t.Fatalf("failed to create epic: %v", err)
+	}
+
+	// Epic blocks task → should fail
+	dep := &types.Dependency{
+		IssueID:     "ct-task-2",
+		DependsOnID: "ct-epic-2",
+		Type:        types.DepBlocks,
+	}
+	err := store.AddDependency(ctx, dep, "tester")
+	if err == nil {
+		t.Fatal("expected error when epic blocks task, got nil")
+	}
+	if !strings.Contains(err.Error(), "epics can only block other epics") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestAddDependency_BlocksSameType_TaskBlocksTask(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	task1 := &types.Issue{
+		ID:        "ct-task-3a",
+		Title:     "Task A",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	task2 := &types.Issue{
+		ID:        "ct-task-3b",
+		Title:     "Task B",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, task1, "tester"); err != nil {
+		t.Fatalf("failed to create task1: %v", err)
+	}
+	if err := store.CreateIssue(ctx, task2, "tester"); err != nil {
+		t.Fatalf("failed to create task2: %v", err)
+	}
+
+	// Task blocks task → should succeed
+	dep := &types.Dependency{
+		IssueID:     "ct-task-3b",
+		DependsOnID: "ct-task-3a",
+		Type:        types.DepBlocks,
+	}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("task blocking task should succeed: %v", err)
+	}
+}
+
+func TestAddDependency_BlocksSameType_EpicBlocksEpic(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic1 := &types.Issue{
+		ID:        "ct-epic-4a",
+		Title:     "Epic A",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	epic2 := &types.Issue{
+		ID:        "ct-epic-4b",
+		Title:     "Epic B",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, epic1, "tester"); err != nil {
+		t.Fatalf("failed to create epic1: %v", err)
+	}
+	if err := store.CreateIssue(ctx, epic2, "tester"); err != nil {
+		t.Fatalf("failed to create epic2: %v", err)
+	}
+
+	// Epic blocks epic → should succeed
+	dep := &types.Dependency{
+		IssueID:     "ct-epic-4b",
+		DependsOnID: "ct-epic-4a",
+		Type:        types.DepBlocks,
+	}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("epic blocking epic should succeed: %v", err)
+	}
+}
+
+func TestAddDependency_ParentChild_CrossType_Allowed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	task := &types.Issue{
+		ID:        "ct-task-5",
+		Title:     "A task",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	epic := &types.Issue{
+		ID:        "ct-epic-5",
+		Title:     "An epic",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, task, "tester"); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+	if err := store.CreateIssue(ctx, epic, "tester"); err != nil {
+		t.Fatalf("failed to create epic: %v", err)
+	}
+
+	// Parent-child between epic and task → should succeed (only blocks is restricted)
+	dep := &types.Dependency{
+		IssueID:     "ct-task-5",
+		DependsOnID: "ct-epic-5",
+		Type:        types.DepParentChild,
+	}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("parent-child cross-type should succeed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds validation in `AddDependency` (storage layer) and CLI (`bd dep add`, `bd dep --blocks`) to prevent `blocks` dependencies between tasks and epics
- Tasks can only block other tasks; epics can only block other epics
- Fixes deadlock in `bd ready` where epic blocked-by-children via redundant `blocks` deps caused GH#1495 logic to exclude all children from ready work

## Test plan
- [ ] `go build ./...` compiles
- [ ] New tests in `dependencies_extended_test.go`: task→epic blocked, epic→task blocked, task→task allowed, epic→epic allowed, parent-child cross-type allowed
- [ ] `bd dep add <task> <epic> --type=blocks` returns error
- [ ] `bd dep add <task1> <task2> --type=blocks` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)