### PR TITLE
fix: gofmt formatting and remove dead test blocking CI

### DIFF
--- a/cmd/bd/doctor/migration_validation_test.go
+++ b/cmd/bd/doctor/migration_validation_test.go
@@ -228,36 +228,6 @@ func TestCheckMigrationCompletionResult_NotDoltBackend(t *testing.T) {
 	}
 }
 
-func TestCheckDoltLocks_NotDoltBackend(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "bd-migration-validation-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
-		t.Fatalf("failed to create .beads: %v", err)
-	}
-
-	// Write a non-Dolt metadata.json so IsDoltBackend returns false.
-	// Without this, GetBackendFromConfig defaults to "dolt" when no config exists,
-	// causing checkDoltLocks to run and fail with StatusWarning (no server).
-	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"sqlite"}`), 0644); err != nil {
-		t.Fatalf("failed to write metadata.json: %v", err)
-	}
-
-	check := CheckDoltLocks(tmpDir)
-
-	if check.Status != StatusOK {
-		t.Errorf("status = %q, want %q for non-Dolt backend", check.Status, StatusOK)
-	}
-
-	if check.Category != CategoryMaintenance {
-		t.Errorf("category = %q, want %q", check.Category, CategoryMaintenance)
-	}
-}
-
 func TestMigrationValidationResult_JSONSerialization(t *testing.T) {
 	result := MigrationValidationResult{
 		Phase:          "pre-migration",

--- a/cmd/bd/thanks.go
+++ b/cmd/bd/thanks.go
@@ -251,4 +251,3 @@ func printThanksWrappedList(label string, names []string, maxWidth int) {
 	}
 	fmt.Println()
 }
-

--- a/internal/storage/dolt/filters_test.go
+++ b/internal/storage/dolt/filters_test.go
@@ -14,22 +14,22 @@ func TestLooksLikeIssueID(t *testing.T) {
 		{"bd-a3f", true},
 		{"test-1", true},
 		{"beads-vscode-1", true},
-		{"bd-123.1", true},        // child ID
-		{"bd-123.1.2", true},      // grandchild ID
-		{"hq-wisp-nmxy", true},    // wisp ID
+		{"bd-123.1", true},     // child ID
+		{"bd-123.1.2", true},   // grandchild ID
+		{"hq-wisp-nmxy", true}, // wisp ID
 		{"si-searchbyid-xyz", true},
 
 		// Not issue IDs
-		{"authentication bug", false},   // has space
-		{"login", false},                // no hyphen
-		{"", false},                     // empty
-		{"-abc", false},                 // starts with hyphen
-		{"abc-", false},                 // ends with hyphen (suffix empty)
-		{"hello world", false},          // spaces
-		{"fix: something", false},       // colon
-		{"search query here", false},    // multiple words
-		{"bug_fix", false},              // underscore
-		{"feature/branch", false},       // slash
+		{"authentication bug", false}, // has space
+		{"login", false},              // no hyphen
+		{"", false},                   // empty
+		{"-abc", false},               // starts with hyphen
+		{"abc-", false},               // ends with hyphen (suffix empty)
+		{"hello world", false},        // spaces
+		{"fix: something", false},     // colon
+		{"search query here", false},  // multiple words
+		{"bug_fix", false},            // underscore
+		{"feature/branch", false},     // slash
 	}
 
 	for _, tt := range tests {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -79,17 +79,17 @@ type DoltStore struct {
 	credentialKey []byte       // Random encryption key for federation credentials
 
 	// Per-invocation caches (lifetime = DoltStore lifetime)
-	customStatusCache  []string        // cached result of GetCustomStatuses
-	customStatusCached bool            // true once customStatusCache has been populated
-	customTypeCache    []string        // cached result of GetCustomTypes
-	customTypeCached   bool            // true once customTypeCache has been populated
-	infraTypeCache     map[string]bool // cached result of GetInfraTypes
-	infraTypeCached    bool            // true once infraTypeCache has been populated
-	blockedIDsCache    []string        // cached result of computeBlockedIDs
-	blockedIDsCacheMap map[string]bool
-	blockedIDsCached   bool // true once blockedIDsCache has been populated
+	customStatusCache            []string        // cached result of GetCustomStatuses
+	customStatusCached           bool            // true once customStatusCache has been populated
+	customTypeCache              []string        // cached result of GetCustomTypes
+	customTypeCached             bool            // true once customTypeCache has been populated
+	infraTypeCache               map[string]bool // cached result of GetInfraTypes
+	infraTypeCached              bool            // true once infraTypeCache has been populated
+	blockedIDsCache              []string        // cached result of computeBlockedIDs
+	blockedIDsCacheMap           map[string]bool
+	blockedIDsCached             bool // true once blockedIDsCache has been populated
 	blockedIDsCacheIncludesWisps bool // true if cache was computed with wisps
-	cacheMu            sync.Mutex
+	cacheMu                      sync.Mutex
 
 	// OTel span attribute cache (avoids per-call allocation)
 	spanAttrsOnce  sync.Once


### PR DESCRIPTION
## Summary
- Fix gofmt alignment issues in 3 files (thanks.go, filters_test.go, store.go) that fail CI fmt-check on main
- Remove TestCheckDoltLocks_NotDoltBackend which became invalid after SQLite backend removal (87493ce) — GetBackend() always returns "dolt" now, so the test scenario can never occur
- These failures block all 7 open PRs from passing CI

## Root cause
- Formatting: comment alignment drifted from gofmt expectations (likely manual edits)
- Test: 87493ce hardcoded GetBackend() to always return BackendDolt, making the "non-Dolt backend" test impossible. Test passed locally (CGO connects to real Dolt) but failed in CI (no Dolt server available)

## Test plan
- [ ] CI fmt-check passes (was failing)
- [ ] CI tests pass on ubuntu-latest and macos-latest (TestCheckDoltLocks_NotDoltBackend was failing)
- [ ] Verified locally: `make fmt-check` passes, `go test ./cmd/bd/doctor/ -short` passes

Generated with [Claude Code](https://claude.com/claude-code)