### PR TITLE
fix: respect stealth mode (no-git-ops) in backup git push

### DIFF
--- a/cmd/bd/backup_auto.go
+++ b/cmd/bd/backup_auto.go
@@ -23,7 +23,11 @@ func isBackupAutoEnabled() bool {
 // isBackupGitPushEnabled returns whether git push should run after backup.
 // If user explicitly configured backup.git-push, use that.
 // Otherwise, enable when backup is auto-enabled.
+// Stealth mode (no-git-ops) always disables git push regardless of config.
 func isBackupGitPushEnabled() bool {
+	if config.GetBool("no-git-ops") {
+		return false
+	}
 	if config.GetValueSource("backup.git-push") != config.SourceDefault {
 		return config.GetBool("backup.git-push")
 	}

--- a/cmd/bd/backup_auto_test.go
+++ b/cmd/bd/backup_auto_test.go
@@ -80,6 +80,7 @@ func TestIsBackupGitPushEnabled(t *testing.T) {
 		name       string
 		envVal     string // "" = not set (use default), "true"/"false" = explicit
 		hasRemote  bool
+		noGitOps   bool // simulate stealth mode
 		wantResult bool
 	}{
 		{
@@ -106,6 +107,20 @@ func TestIsBackupGitPushEnabled(t *testing.T) {
 			hasRemote:  true,
 			wantResult: false,
 		},
+		{
+			name:       "stealth mode overrides default + remote",
+			envVal:     "",
+			hasRemote:  true,
+			noGitOps:   true,
+			wantResult: false,
+		},
+		{
+			name:       "stealth mode overrides explicit true",
+			envVal:     "true",
+			hasRemote:  true,
+			noGitOps:   true,
+			wantResult: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -124,6 +139,13 @@ func TestIsBackupGitPushEnabled(t *testing.T) {
 			}
 			// Also clear the backup.enabled env to not interfere
 			os.Unsetenv("BD_BACKUP_ENABLED")
+
+			// Stealth mode
+			if tt.noGitOps {
+				t.Setenv("BD_NO_GIT_OPS", "true")
+			} else {
+				os.Unsetenv("BD_NO_GIT_OPS")
+			}
 
 			config.ResetForTesting()
 			t.Cleanup(func() { config.ResetForTesting() })


### PR DESCRIPTION
## Summary

Fixes #2290.

- `isBackupGitPushEnabled()` did not check `no-git-ops` config, so `bd ready` (and all other commands) in stealth mode would auto-backup and push commits to the git remote
- Added early return in `isBackupGitPushEnabled()` when `no-git-ops` is true — this gates the entire `gitBackup()` path (git add, commit, push)
- JSONL export to local `.beads/backup/` still works in stealth mode; only the git push is suppressed

## Test plan

- [x] Two new test cases: stealth mode overrides both default auto-enable and explicit `backup.git-push=true`
- [x] All existing `TestIsBackupAutoEnabled` and `TestIsBackupGitPushEnabled` tests pass
- [ ] Manual: `bd init --stealth --from-jsonl && bd ready` should not create git commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)