### PR TITLE
docs: document Docker test environment variables

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -48,6 +48,30 @@ TEST_VERBOSE=1 ./scripts/test.sh
 TEST_RUN=TestCreate ./scripts/test.sh
 ```
 
+### Docker Environment Variables
+
+Tests that use Dolt containers require Docker Desktop and a locally cached
+image. These variables control Docker-related test behavior:
+
+```bash
+# Force-skip all Docker-based tests (useful offline or without Docker Desktop)
+BEADS_SKIP_DOCKER=1 go test ./cmd/bd/...
+
+# Reuse an existing Dolt test server instead of starting a new container
+BEADS_DOLT_PORT=3308 go test ./cmd/bd/...
+```
+
+Without `BEADS_SKIP_DOCKER`, Docker tests are skipped automatically when:
+
+- Docker daemon is not running
+- The required image (`dolthub/dolt-sql-server:1.43.0`) is not cached locally
+
+To cache the image for the first time:
+
+```bash
+docker pull dolthub/dolt-sql-server:1.43.0
+```
+
 ### Advanced Usage
 
 ```bash


### PR DESCRIPTION
## Summary

- Document `BEADS_SKIP_DOCKER=1` env var added in c2888b12 (GH#2277)
- Document `BEADS_DOLT_PORT` for reusing existing test servers
- Explain auto-skip behavior and how to cache the Dolt image

Complements the fix in c2888b12 — the code change landed but the user-facing docs weren't updated.

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] `BEADS_SKIP_DOCKER=1 go test ./cmd/bd/... -count=1` skips Docker tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)