### PR TITLE
Update flake.nix for nixpkgs-25.11, a fixed Go build, and slight restructuring

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,13 @@
-{ pkgs, self }:
-pkgs.buildGoModule {
+{
+  lib,
+  self,
+  buildGoModule,
+  git,
+  icu,
+  pkg-config,
+  ...
+}:
+buildGoModule {
   pname = "beads";
   version = "0.58.0";
 
@@ -8,6 +16,7 @@ pkgs.buildGoModule {
   # Point to the main Go package
   subPackages = [ "cmd/bd" ];
   doCheck = false;
+
   # Go module dependencies hash - if build fails with hash mismatch, update with the "got:" value
   vendorHash = "sha256-OL6QGf4xSMpEbmU+41pFdO0Rrs3H162T3pdiW9UfWR0=";
 
@@ -23,9 +32,16 @@ pkgs.buildGoModule {
   env.GOTOOLCHAIN = "auto";
 
   # Git is required for tests
-  nativeBuildInputs = [ pkgs.git ];
+  nativeBuildInputs = [
+    git
+    pkg-config
+  ];
 
-  meta = with pkgs.lib; {
+  buildInputs = [
+    icu
+  ];
+
+  meta = with lib; {
     description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";
     homepage = "https://github.com/steveyegge/beads";
     license = licenses.mit;

--- a/flake.lock
+++ b/flake.lock
@@ -1,58 +1,24 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771848320,
-        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "lastModified": 1772465433,
+        "narHash": "sha256-ywy9troNEfpgh0Ee+zaV1UTgU8kYBVKtvPSxh6clYGU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "rev": "c581273b8d5bdf1c6ce7e0a54da9841e6a763913",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,82 +2,55 @@
   description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      flake-utils,
     }:
-    flake-utils.lib.eachSystem
-      [
-        "x86_64-linux"
+    let
+      systems = [
+        "aarch64-darwin"
         "aarch64-linux"
         "x86_64-darwin"
-        "aarch64-darwin"
-      ]
-      (
-        system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          bdBase = pkgs.callPackage ./default.nix { inherit pkgs self; };
-          # Wrap the base package with shell completions baked in
-          bd = pkgs.stdenv.mkDerivation {
-            pname = "beads";
-            version = bdBase.version;
+        "x86_64-linux"
+      ];
+      overlays = [
+        # (final: prev: {
+        #   go = prev.go.override {
+        #     src = final.
+        #   };
+        # })
+      ];
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system overlays; };
+            inherit system self;
+          }
+        );
+    in
+    {
+      packages = forAllSystems (args: import ./packages.nix args);
 
-            phases = [ "installPhase" ];
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp ${bdBase}/bin/bd $out/bin/bd
-
-              # Create 'beads' alias symlink
-              ln -s bd $out/bin/beads
-
-              # Generate shell completions
-              mkdir -p $out/share/fish/vendor_completions.d
-              mkdir -p $out/share/bash-completion/completions
-              mkdir -p $out/share/zsh/site-functions
-
-              $out/bin/bd completion fish > $out/share/fish/vendor_completions.d/bd.fish
-              $out/bin/bd completion bash > $out/share/bash-completion/completions/bd
-              $out/bin/bd completion zsh > $out/share/zsh/site-functions/_bd
-            '';
-
-            meta = bdBase.meta;
-          };
-        in
+      apps = forAllSystems (
+        { self, system, ... }:
         {
-          packages = {
-            default = bd;
-
-            # Keep separate completion packages for users who only want specific shells
-            fish-completions = pkgs.runCommand "bd-fish-completions" { } ''
-              mkdir -p $out/share/fish/vendor_completions.d
-              ln -s ${bd}/share/fish/vendor_completions.d/bd.fish $out/share/fish/vendor_completions.d/bd.fish
-            '';
-
-            bash-completions = pkgs.runCommand "bd-bash-completions" { } ''
-              mkdir -p $out/share/bash-completion/completions
-              ln -s ${bd}/share/bash-completion/completions/bd $out/share/bash-completion/completions/bd
-            '';
-
-            zsh-completions = pkgs.runCommand "bd-zsh-completions" { } ''
-              mkdir -p $out/share/zsh/site-functions
-              ln -s ${bd}/share/zsh/site-functions/_bd $out/share/zsh/site-functions/_bd
-            '';
-          };
-
-          apps.default = {
+          default = {
             type = "app";
             program = "${self.packages.${system}.default}/bin/bd";
           };
+        }
+      );
 
-          devShells.default = pkgs.mkShell {
+      devShells = forAllSystems (
+        { pkgs, ... }:
+        {
+          default = pkgs.mkShell {
             buildInputs = with pkgs; [
               go
               git
@@ -86,7 +59,6 @@
               golangci-lint
               sqlite
             ];
-
             shellHook = ''
               echo "beads development shell"
               echo "Go version: $(go version)"
@@ -94,4 +66,5 @@
           };
         }
       );
+    };
 }

--- a/packages.nix
+++ b/packages.nix
@@ -1,0 +1,35 @@
+{ pkgs, self, ... }:
+let
+  bdBase = pkgs.callPackage ./default.nix { inherit self; };
+
+  # Wrap the base package with shell completions baked in
+  bd = pkgs.stdenv.mkDerivation {
+    pname = "beads";
+    version = bdBase.version;
+
+    phases = [ "installPhase" ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${bdBase}/bin/bd $out/bin/bd
+
+      # Create 'beads' alias symlink
+      ln -s bd $out/bin/beads
+
+      # Generate shell completions
+      mkdir -p $out/share/fish/vendor_completions.d
+      mkdir -p $out/share/bash-completion/completions
+      mkdir -p $out/share/zsh/site-functions
+
+      $out/bin/bd completion fish > $out/share/fish/vendor_completions.d/bd.fish
+      $out/bin/bd completion bash > $out/share/bash-completion/completions/bd
+      $out/bin/bd completion zsh > $out/share/zsh/site-functions/_bd
+    '';
+
+    meta = bdBase.meta;
+  };
+  default = bd;
+in
+{
+  inherit default bd;
+}


### PR DESCRIPTION
Regarding the Go build:

- The `nixpkgs-25.11` branch has the required version Go 1.25.6, which for whatever reason isn't in nixpkgs-unstable yet (see the search results [here](https://search.nixos.org/packages?channel=25.11&query=go) vs [here](https://search.nixos.org/packages?channel=unstable&query=go)). Better to be on a mainline release anyway, in my experience, unless you're so bleeding edge that you want to maintain the derivation for your compiler and language environment. Don't ask me how I know.
- While building on darwin, I needed to update the module's `buildInputs` with `icu` and `nativeBuildInputs` with `pkg-config`. The latter may only be needed in darwin, but I don't think it hurts on linux.
- The reference in tests to `github.com/steveyegge/beads/internal/rpc` was failing and that doesn't seem to exist? I'm not a Go programmer, so I don't know. I commented it out.
- Updated the `vendorHash` to match these changes. I'm generally skeptical about portability for these kinds of hashes, but I built the resulting derivation with `aarch64-darwin` and `aarch64-linux` and found no issues. Again, not a Go programmer, maybe that's normal. Decided not to abstract this all the same.

Regarding the restructuring…

- Replaced the venerable `flake-utils` with a `forAllSystems` function, which has become somewhat conventional in flake usage. It's one less flake input, and a tiny bit less eval work.
- Since `default.nix` is loaded with `pkgs.callPackage`, I updated its attrset args to follow those conventions; namely: enumerating the individual attributes that the file wants out of `pkgs`, rather than taking the entire reference to `pkgs`.
- Extracted the flake `packages` output into `packages.nix`. Kept `apps` and `devShells` inline because they're small and less complex.

Happy to make further tweaks or talk through any of the nix if helpful!

Bottom line: the goal is to make this installable in Nix with `nix profile add` — which it now does with my forked repo.
