### PR TITLE
fix(list): make --tree the default display mode for bd list

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -54,6 +54,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[nvim-beads](https://github.com/joeblubaugh/nvim-beads)** - Neovim plugin for managing beads. Built by [@joeblubaugh](https://github.com/joeblubaugh). (Lua)
 
+- **[nvim-beads](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons).
+
 - **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)
 
 ## Native Apps


### PR DESCRIPTION
## Summary

Makes \--tree\ the default display mode for \d list\, as suggested in #1017.

## Changes

- Changed \--tree\ flag default from \alse\ to \	rue\
- Added \--flat\ flag to explicitly disable tree mode and get the legacy flat list output
- \--flat\ takes precedence over \--tree\ when both are specified

## Usage

\\\ash
# Tree output is now the default
bd list

# Explicitly use flat/legacy output
bd list --flat

# Explicitly disable tree (same as --flat)
bd list --tree=false
\\\

Closes #1017