### PR TITLE
docs: add fancypantalons/nvim-beads to Community Tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -54,6 +54,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[nvim-beads](https://github.com/joeblubaugh/nvim-beads)** - Neovim plugin for managing beads. Built by [@joeblubaugh](https://github.com/joeblubaugh). (Lua)
 
+- **[nvim-beads](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons).
+
 - **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)
 
 ## Native Apps


### PR DESCRIPTION
Add [nvim-beads](https://github.com/fancypantalons/nvim-beads) by @fancypantalons to the Editor Extensions section of COMMUNITY_TOOLS.md.

Closes #482