### PR TITLE
fix(docs): correct misleading examples in QUICKSTART.md

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -84,15 +84,6 @@ git config --get beads.role
 
 **Note:** Issue IDs are hash-based (e.g., `bd-a1b2`, `bd-f14c`) to prevent collisions when multiple agents/branches work concurrently.
 
-**Dependency visibility:** When issues have blocking dependencies, `bd list` shows them inline:
-```
-○ bd-a1b2 [P1] [task] - Set up database
-○ bd-f14c [P2] [feature] - Create API (blocked by: bd-a1b2)
-○ bd-g25d [P2] [feature] - Add authentication (blocked by: bd-f14c)
-```
-
-This makes dependencies unmissable when reviewing epic subtasks.
-
 ## Hierarchical Issues (Epics)
 
 For large features, use hierarchical IDs to organize work:
@@ -103,9 +94,9 @@ For large features, use hierarchical IDs to organize work:
 # Returns: bd-a3f8e9
 
 # Create child tasks (automatically get .1, .2, .3 suffixes)
-./bd create "Design login UI" -p 1       # bd-a3f8e9.1
-./bd create "Backend validation" -p 1    # bd-a3f8e9.2
-./bd create "Integration tests" -p 1     # bd-a3f8e9.3
+./bd create "Design login UI" -p 1 --parent bd-a3f8e9       # bd-a3f8e9.1
+./bd create "Backend validation" -p 1 --parent bd-a3f8e9    # bd-a3f8e9.2
+./bd create "Integration tests" -p 1 --parent bd-a3f8e9     # bd-a3f8e9.3
 
 # View hierarchy
 ./bd dep tree bd-a3f8e9
@@ -141,6 +132,13 @@ Output:
 → bd-3: Add authentication [P2] (open)
   → bd-2: Create API [P2] (open)
     → bd-1: Set up database [P1] (open)
+```
+
+**Dependency visibility:** `bd list` shows blocking dependencies inline:
+```
+○ bd-a1b2 [P1] [task] - Set up database
+○ bd-f14c [P2] [feature] - Create API (blocked by: bd-a1b2)
+○ bd-g25d [P2] [feature] - Add authentication (blocked by: bd-f14c)
 ```
 
 ## Find Ready Work


### PR DESCRIPTION
## Summary

Two inaccuracies in `docs/QUICKSTART.md`:

1. **Missing `--parent` flag in epic child creation** — The "Hierarchical Issues" section shows child tasks being created without specifying which epic they belong to. Without the `--parent` flag, these are created as standalone issues with random IDs, not as children with `.1`, `.2`, `.3` suffixes. Added `--parent bd-a3f8e9` to each child creation command.

2. **Dependency visibility example shown before dependencies exist** — The `bd list` output showing `(blocked by: ...)` annotations was placed in the "Your First Issues" section, immediately after creating issues with no dependencies. Moved it after the "Add Dependencies" section where the dependencies are actually established.

Both issues were verified by building `bd` from source and testing the commands.

## Test plan

- [x] Built `bd` and created an epic
- [x] Confirmed `bd create "child" -p 1` (without `--parent`) creates a standalone issue
- [x] Confirmed `bd create "child" -p 1 --parent <epic-id>` creates a hierarchical child with `.N` suffix
- [x] Verified `bd children <epic-id>` lists the children correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)