### PR TITLE
Remove stale sync mode documentation

### DIFF
--- a/FEDERATION-SETUP.md
+++ b/FEDERATION-SETUP.md
@@ -16,8 +16,7 @@ data between independent teams or locations. Key benefits:
 
 ## Prerequisites
 
-1. **Dolt backend**: Federation requires the Dolt storage backend
-2. **Sync mode**: Must use `dolt-native` or `belt-and-suspenders` sync mode
+1. **Dolt backend**: Federation requires the Dolt storage backend (the only supported backend)
 
 ## Configuration
 
@@ -26,9 +25,6 @@ data between independent teams or locations. Key benefits:
 Edit `.beads/config.yaml` or `~/.config/bd/config.yaml`:
 
 ```yaml
-sync:
-  mode: dolt-native                      # Required for federation
-
 federation:
   remote: dolthub://myorg/beads          # Primary remote (optional)
   sovereignty: T2                        # Data sovereignty tier
@@ -37,18 +33,9 @@ federation:
 Or via environment variables:
 
 ```bash
-export BD_SYNC_MODE="dolt-native"
 export BD_FEDERATION_REMOTE="dolthub://myorg/beads"
 export BD_FEDERATION_SOVEREIGNTY="T2"
 ```
-
-### Sync Modes
-
-| Mode | Description | Federation Support |
-|------|-------------|-------------------|
-| `dolt-native` | Dolt remotes (default) | Yes |
-| `git-portable` | Legacy JSONL export to git | No |
-| `belt-and-suspenders` | Dolt + JSONL backup | Yes |
 
 ### Data Sovereignty Tiers
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -151,13 +151,9 @@ export BD_ACTOR="my-github-handle"
 
 The sync mode controls how beads synchronizes data with git and/or Dolt remotes.
 
-#### Sync Modes
+#### Sync Mode
 
-| Mode | Description |
-|------|-------------|
-| `dolt-native` | (default) Use Dolt remotes directly for sync. Manual `bd import` / `bd export` still work for portability. |
-| `git-portable` | Legacy mode: Export JSONL on push, import on pull. For backward compatibility with older setups. |
-| `belt-and-suspenders` | Both Dolt remote AND JSONL backup. Maximum redundancy. |
+Beads uses `dolt-native` sync mode exclusively. Dolt remotes handle sync directly with cell-level merge. Manual `bd import` / `bd export` are available for migration and portability.
 
 #### Sync Triggers
 
@@ -179,8 +175,6 @@ When merging conflicting changes:
 
 #### Federation Configuration
 
-For Dolt-native or belt-and-suspenders modes:
-
 - `federation.remote`: Dolt remote URL (e.g., `dolthub://org/beads`, `gs://bucket/beads`, `s3://bucket/beads`)
 - `federation.sovereignty`: Data sovereignty tier:
   - `T1`: Full sovereignty - data never leaves controlled infrastructure
@@ -193,24 +187,17 @@ For Dolt-native or belt-and-suspenders modes:
 ```yaml
 # .beads/config.yaml
 sync:
-  mode: dolt-native     # dolt-native | git-portable | belt-and-suspenders
   export_on: push       # push | change
   import_on: pull       # pull | change
 
 conflict:
   strategy: newest      # newest | ours | theirs | manual
 
-# Optional: Dolt federation for dolt-native or belt-and-suspenders modes
+# Optional: Dolt federation
 federation:
   remote: dolthub://myorg/beads
   sovereignty: T2
 ```
-
-#### When to Use Each Mode
-
-- **dolt-native** (default): Best for most teams. Dolt handles sync natively with cell-level merge. `bd import`/`bd export` remain available for portability and migration.
-- **git-portable**: Legacy mode for backward compatibility. JSONL is committed to git, works with any git hosting.
-- **belt-and-suspenders**: Use for critical data where you want both Dolt sync AND JSONL backup.
 
 ### Example Config File
 

--- a/docs/DOLT-BACKEND.md
+++ b/docs/DOLT-BACKEND.md
@@ -97,37 +97,14 @@ kill $(cat .beads/dolt/sql-server.pid)
 
 Dolt supports multiple sync strategies:
 
-### `dolt-native` (Default)
+### Sync Mode
 
-```yaml
-sync:
-  mode: dolt-native
-```
+Beads uses `dolt-native` sync mode exclusively:
 
 - Uses Dolt remotes (DoltHub, S3, GCS, etc.)
-- Native database-level sync
+- Native database-level sync with cell-level merge
 - Supports branching and merging
-
-### `belt-and-suspenders`
-
-```yaml
-sync:
-  mode: belt-and-suspenders
-```
-
-- Uses BOTH Dolt remotes AND JSONL export
-- Maximum redundancy
-- Useful for migration periods
-
-### `git-portable` (Legacy)
-
-```yaml
-sync:
-  mode: git-portable
-```
-
-- Legacy JSONL-based sync for backward compatibility
-- Dolt provides local version history only
+- `bd import`/`bd export` available for migration and portability
 
 ## Dolt Remotes
 

--- a/internal/templates/agents/defaults/agents.md.tmpl
+++ b/internal/templates/agents/defaults/agents.md.tmpl
@@ -44,7 +44,7 @@ cp -rf source dest          # NOT: cp -r source dest
 ### Why bd?
 
 - Dependency-aware: Track blockers and relationships between issues
-- Git-friendly: Auto-syncs to JSONL for version control
+- Version-controlled: Built on Dolt with cell-level merge
 - Agent-optimized: JSON output, ready work detection, discovered-from links
 - Prevents duplicate tracking systems and confusion
 


### PR DESCRIPTION
## Summary
- Update docs to reflect that only `dolt-native` sync mode is supported
- Remove references to deprecated `git-portable` and `belt-and-suspenders` modes
- Fix template comment about JSONL sync (now Dolt)

The sync mode code was already cleaned up (only `SyncModeDoltNative` is valid), but documentation still referenced removed modes.

Addresses w-bd-004 (Audit sync mode complexity)

## Test plan
- [ ] Documentation renders correctly
- [ ] No broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)