### PR TITLE
feat: v0.59.0 — deprecation warnings for legacy backends before v0.60.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "beads",
       "source": "./claude-plugin",
       "description": "AI-supervised issue tracker for coding workflows",
-      "version": "0.58.0"
+      "version": "0.59.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.0] - 2026-03-04
+
+### Deprecated
+
+- **Embedded Dolt mode** — `dolt_mode: "embedded"` in metadata.json is deprecated. Server mode is the only supported mode. Remove the field or set to `"server"`.
+- **SQLite backend config** — `backend: "sqlite"` in metadata.json. Dolt is the only backend.
+- **`BEADS_DOLT_SERVER_MODE` env var** — Server mode is always on. Remove from environment.
+- **Legacy JSONL/SQLite artifacts** — `issues.jsonl`, `beads.jsonl`, `beads.db` files in `.beads/` are unused. Run `bd doctor --check=artifacts --clean` to remove.
+
+All deprecated items will be **removed in v1.0.0**. Run `bd doctor` for personalized migration guidance.
+
+### Fixed
+
+- `GetDoltMode()` now defaults to `"server"` instead of `"embedded"`, matching the actual runtime behavior since v0.56.0.
+
 ## [0.58.0] - 2026-03-02
 
 ### Added

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beads",
   "description": "AI-supervised issue tracker for coding workflows. Manage tasks, discover work, and maintain context with simple CLI commands.",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "author": {
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/deprecation"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -543,6 +544,12 @@ func runDiagnostics(path string) doctorResult {
 	doltModeCheck := convertWithCategory(doctor.CheckDoltServerModeMismatch(path), doctor.CategoryFederation)
 	result.Checks = append(result.Checks, doltModeCheck)
 
+	// Check 8i: Deprecated configuration (v0.59.0 → removed in v1.0.0)
+	for _, dc := range checkDeprecatedConfig(beadsDir) {
+		result.Checks = append(result.Checks, dc)
+		// Don't fail overall for deprecation warnings, just warn
+	}
+
 	// Check 9: Permissions
 	permCheck := convertWithCategory(doctor.CheckPermissions(path), doctor.CategoryCore)
 	result.Checks = append(result.Checks, permCheck)
@@ -787,6 +794,26 @@ func runDiagnostics(path string) doctorResult {
 	}
 
 	return result
+}
+
+// checkDeprecatedConfig converts deprecation.Check() warnings into doctorCheck entries.
+func checkDeprecatedConfig(beadsDir string) []doctorCheck {
+	warnings := deprecation.Check(beadsDir)
+	if len(warnings) == 0 {
+		return nil
+	}
+	var checks []doctorCheck
+	for _, w := range warnings {
+		checks = append(checks, doctorCheck{
+			Name:     "Deprecated: " + w.Summary,
+			Status:   statusWarning,
+			Message:  w.Detail,
+			Detail:   w.ID,
+			Fix:      w.Action,
+			Category: doctor.CategoryMaintenance,
+		})
+	}
+	return checks
 }
 
 // runInitDiagnostics runs a limited subset of diagnostics appropriate for a

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -210,6 +210,14 @@ type VersionChange struct {
 // versionChanges contains agent-actionable changes for recent versions
 var versionChanges = []VersionChange{
 	{
+		Version: "0.59.0",
+		Date:    "2026-03-04",
+		Changes: []string{
+			"DEPRECATION: Embedded Dolt mode, SQLite config fields, BEADS_DOLT_SERVER_MODE env var, and legacy JSONL/SQLite artifacts will be removed in v1.0.0. Run 'bd doctor' for migration guidance.",
+			"FIX: GetDoltMode() default changed from embedded to server to match reality",
+		},
+	},
+	{
 		Version: "0.58.0",
 		Date:    "2026-03-02",
 		Changes: []string{

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/deprecation"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/hooks"
 	"github.com/steveyegge/beads/internal/molecules"
@@ -466,6 +467,9 @@ var rootCmd = &cobra.Command{
 		// Best-effort tracking - failures are silent
 		trackBdVersion()
 
+		// Show deprecation warnings for legacy config (v0.59.0 → removed in v1.0.0)
+		maybeShowDeprecationWarnings()
+
 		// Check if this is a read-only command (GH#804)
 		// Read-only commands open the store in read-only mode to avoid modifying
 		// the database (which breaks file watchers).
@@ -681,6 +685,24 @@ var rootCmd = &cobra.Command{
 			rootCancel()
 		}
 	},
+}
+
+// deprecationChecked prevents duplicate deprecation warnings within a session.
+var deprecationChecked = false
+
+// maybeShowDeprecationWarnings checks for deprecated configs and warns the user.
+// Runs once per session, before store init (no DB access needed).
+func maybeShowDeprecationWarnings() {
+	if deprecationChecked {
+		return
+	}
+	deprecationChecked = true
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return
+	}
+	warnings := deprecation.Check(beadsDir)
+	deprecation.PrintWarnings(warnings, jsonOutput)
 }
 
 // blockedEnvVars lists environment variables that must not be set because they

--- a/cmd/bd/version.go
+++ b/cmd/bd/version.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// Version is the current version of bd (overridden by ldflags at build time)
-	Version = "0.58.0"
+	Version = "0.59.0"
 	// Build can be set via ldflags at compile time
 	Build = "dev"
 	// Commit and branch the git revision the binary was built from (optional ldflag)

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "beads-mcp"
-version = "0.58.0"
+version = "0.59.0"
 description = "MCP server for beads issue tracker."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/beads-mcp/src/beads_mcp/__init__.py
+++ b/integrations/beads-mcp/src/beads_mcp/__init__.py
@@ -4,4 +4,4 @@ This package provides an MCP (Model Context Protocol) server that exposes
 beads (bd) issue tracker functionality to MCP Clients.
 """
 
-__version__ = "0.58.0"
+__version__ = "0.59.0"

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -230,7 +230,7 @@ func (c *Config) IsDoltServerMode() bool {
 // GetDoltMode returns the Dolt connection mode, defaulting to server.
 func (c *Config) GetDoltMode() string {
 	if c.DoltMode == "" {
-		return DoltModeEmbedded
+		return DoltModeServer
 	}
 	return c.DoltMode
 }

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -193,7 +193,7 @@ func TestDoltServerMode(t *testing.T) {
 			{
 				name: "dolt default mode",
 				cfg:  &Config{Backend: BackendDolt},
-				want: false, // Default is embedded
+				want: false, // DoltMode field is empty; IsDoltServerMode checks raw field
 			},
 		}
 
@@ -214,9 +214,9 @@ func TestDoltServerMode(t *testing.T) {
 			want string
 		}{
 			{
-				name: "empty defaults to embedded",
+				name: "empty defaults to server",
 				cfg:  &Config{},
-				want: DoltModeEmbedded,
+				want: DoltModeServer,
 			},
 			{
 				name: "explicit embedded",

--- a/internal/deprecation/check.go
+++ b/internal/deprecation/check.go
@@ -1,0 +1,138 @@
+package deprecation
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Warning describes a deprecated configuration that will be removed in v1.0.0.
+type Warning struct {
+	ID      string // machine key: "embedded-mode", "sqlite-backend", etc.
+	Summary string // one-line headline
+	Detail  string // explanation
+	Action  string // what user should do
+}
+
+// Check scans a .beads directory for deprecated configurations.
+// It reads only filesystem/env/config — no DB access.
+// Returns nil if beadsDir doesn't exist or no deprecations found.
+func Check(beadsDir string) []Warning {
+	if beadsDir == "" {
+		return nil
+	}
+	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+		return nil
+	}
+
+	var warnings []Warning
+	warnings = append(warnings, checkEmbeddedMode(beadsDir)...)
+	warnings = append(warnings, checkSQLiteBackend(beadsDir)...)
+	warnings = append(warnings, checkSQLiteArtifacts(beadsDir)...)
+	warnings = append(warnings, checkServerModeEnv()...)
+	warnings = append(warnings, checkJSONLSyncFiles(beadsDir)...)
+	return warnings
+}
+
+// metadataFields loads metadata.json and returns the raw JSON map.
+func metadataFields(beadsDir string) map[string]json.RawMessage {
+	data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json")) // #nosec G304
+	if err != nil {
+		return nil
+	}
+	var m map[string]json.RawMessage
+	if json.Unmarshal(data, &m) != nil {
+		return nil
+	}
+	return m
+}
+
+func checkEmbeddedMode(beadsDir string) []Warning {
+	m := metadataFields(beadsDir)
+	if m == nil {
+		return nil
+	}
+	raw, ok := m["dolt_mode"]
+	if !ok {
+		return nil // absent = defaults to server, no warning needed
+	}
+	var mode string
+	if json.Unmarshal(raw, &mode) != nil {
+		return nil
+	}
+	if mode != "embedded" {
+		return nil
+	}
+	return []Warning{{
+		ID:      "embedded-mode",
+		Summary: "Embedded Dolt mode is deprecated",
+		Detail:  "Server mode is the only supported mode. Embedded mode will be removed in v1.0.0.",
+		Action:  "Remove the \"dolt_mode\" field from .beads/metadata.json or set it to \"server\".",
+	}}
+}
+
+func checkSQLiteBackend(beadsDir string) []Warning {
+	m := metadataFields(beadsDir)
+	if m == nil {
+		return nil
+	}
+	raw, ok := m["backend"]
+	if !ok {
+		return nil
+	}
+	var backend string
+	if json.Unmarshal(raw, &backend) != nil {
+		return nil
+	}
+	if backend != "sqlite" {
+		return nil
+	}
+	return []Warning{{
+		ID:      "sqlite-backend",
+		Summary: "SQLite backend was removed",
+		Detail:  "Dolt is the only supported backend. Verify your migration to Dolt completed.",
+		Action:  "Run 'bd doctor' to verify, then remove the \"backend\" field from .beads/metadata.json.",
+	}}
+}
+
+func checkSQLiteArtifacts(beadsDir string) []Warning {
+	patterns := []string{"beads.db", "*.db-wal", "*.db-shm"}
+	for _, pat := range patterns {
+		matches, _ := filepath.Glob(filepath.Join(beadsDir, pat))
+		if len(matches) > 0 {
+			return []Warning{{
+				ID:      "sqlite-artifacts",
+				Summary: "Legacy SQLite database files detected",
+				Detail:  "SQLite files in .beads/ are no longer used. Data is stored in Dolt.",
+				Action:  "Run 'bd doctor --check=artifacts --clean' to remove legacy files.",
+			}}
+		}
+	}
+	return nil
+}
+
+func checkServerModeEnv() []Warning {
+	if os.Getenv("BEADS_DOLT_SERVER_MODE") != "" {
+		return []Warning{{
+			ID:      "server-mode-env",
+			Summary: "BEADS_DOLT_SERVER_MODE env var is deprecated",
+			Detail:  "Server mode is always on. This env var has no effect and will be ignored in v1.0.0.",
+			Action:  "Remove BEADS_DOLT_SERVER_MODE from your environment.",
+		}}
+	}
+	return nil
+}
+
+func checkJSONLSyncFiles(beadsDir string) []Warning {
+	for _, name := range []string{"issues.jsonl", "beads.jsonl"} {
+		if _, err := os.Stat(filepath.Join(beadsDir, name)); err == nil {
+			return []Warning{{
+				ID:      "jsonl-sync-files",
+				Summary: "Legacy JSONL sync files detected",
+				Detail:  "JSONL sync files are no longer used. All data is in Dolt.",
+				Action:  "Run 'bd doctor --check=artifacts --clean' to remove legacy files.",
+			}}
+		}
+	}
+	return nil
+}

--- a/internal/deprecation/check_test.go
+++ b/internal/deprecation/check_test.go
@@ -1,0 +1,147 @@
+package deprecation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheck_CleanConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{"database": "dolt"}`)
+
+	warnings := Check(dir)
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for clean config, got %d: %v", len(warnings), warnings)
+	}
+}
+
+func TestCheck_ExplicitEmbeddedMode(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{"dolt_mode": "embedded"}`)
+
+	warnings := Check(dir)
+	if !hasWarning(warnings, "embedded-mode") {
+		t.Errorf("expected embedded-mode warning, got %v", ids(warnings))
+	}
+}
+
+func TestCheck_MissingDoltMode_NoWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{"database": "dolt"}`)
+
+	warnings := Check(dir)
+	if hasWarning(warnings, "embedded-mode") {
+		t.Error("missing dolt_mode should NOT produce warning (defaults to server)")
+	}
+}
+
+func TestCheck_SQLiteBackend(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{"backend": "sqlite"}`)
+
+	warnings := Check(dir)
+	if !hasWarning(warnings, "sqlite-backend") {
+		t.Errorf("expected sqlite-backend warning, got %v", ids(warnings))
+	}
+}
+
+func TestCheck_DoltBackend_NoWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{"backend": "dolt"}`)
+
+	warnings := Check(dir)
+	if hasWarning(warnings, "sqlite-backend") {
+		t.Error("dolt backend should NOT produce sqlite-backend warning")
+	}
+}
+
+func TestCheck_SQLiteArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{}`)
+	if err := os.WriteFile(filepath.Join(dir, "beads.db"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := Check(dir)
+	if !hasWarning(warnings, "sqlite-artifacts") {
+		t.Errorf("expected sqlite-artifacts warning, got %v", ids(warnings))
+	}
+}
+
+func TestCheck_ServerModeEnv(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{}`)
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "1")
+
+	warnings := Check(dir)
+	if !hasWarning(warnings, "server-mode-env") {
+		t.Errorf("expected server-mode-env warning, got %v", ids(warnings))
+	}
+}
+
+func TestCheck_JSONLSyncFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeMetadata(t, dir, `{}`)
+	if err := os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte{}, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := Check(dir)
+	if !hasWarning(warnings, "jsonl-sync-files") {
+		t.Errorf("expected jsonl-sync-files warning, got %v", ids(warnings))
+	}
+}
+
+func TestCheck_NonExistentDir(t *testing.T) {
+	warnings := Check("/nonexistent/path/that/does/not/exist")
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for nonexistent dir, got %d", len(warnings))
+	}
+}
+
+func TestCheck_EmptyDir(t *testing.T) {
+	warnings := Check("")
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for empty dir, got %d", len(warnings))
+	}
+}
+
+func TestPrintWarnings_Suppressed_JSON(t *testing.T) {
+	warnings := []Warning{{ID: "test", Summary: "test"}}
+	if PrintWarnings(warnings, true) {
+		t.Error("expected false when jsonMode=true")
+	}
+}
+
+func TestPrintWarnings_Empty(t *testing.T) {
+	if PrintWarnings(nil, false) {
+		t.Error("expected false for nil warnings")
+	}
+}
+
+// helpers
+
+func writeMetadata(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasWarning(warnings []Warning, id string) bool {
+	for _, w := range warnings {
+		if w.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func ids(warnings []Warning) []string {
+	var out []string
+	for _, w := range warnings {
+		out = append(out, w.ID)
+	}
+	return out
+}

--- a/internal/deprecation/print.go
+++ b/internal/deprecation/print.go
@@ -1,0 +1,30 @@
+package deprecation
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+// PrintWarnings outputs deprecation warnings to stderr.
+// Returns true if any warnings were printed.
+// Suppressed when jsonMode is true.
+func PrintWarnings(warnings []Warning, jsonMode bool) bool {
+	if len(warnings) == 0 || jsonMode {
+		return false
+	}
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, ui.RenderWarn("WARNING")+": Deprecated configuration detected (will be removed in v1.0.0):")
+	fmt.Fprintln(os.Stderr)
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "  - %s\n", w.Summary)
+		fmt.Fprintf(os.Stderr, "    %s\n", w.Detail)
+		fmt.Fprintf(os.Stderr, "    Fix: %s\n", w.Action)
+		fmt.Fprintln(os.Stderr)
+	}
+	fmt.Fprintln(os.Stderr, "Run 'bd doctor' for full diagnostics.")
+	fmt.Fprintln(os.Stderr)
+	return true
+}

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beads/bd",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Beads issue tracker - lightweight memory system for coding agents with native binary support",
   "main": "bin/bd.js",
   "bin": {


### PR DESCRIPTION
## Summary

- New `internal/deprecation/` package detects deprecated configs and warns on stderr
- Warns about: embedded Dolt mode, SQLite backend config, `BEADS_DOLT_SERVER_MODE` env var, SQLite artifacts, JSONL sync files
- Integrated into `bd doctor` as maintenance checks
- `GetDoltMode()` default changed from `"embedded"` to `"server"` to match runtime reality since v0.56.0
- Version bump to 0.59.0

**Maintainers**: Please release v0.59.0 after merging. The v0.60.0 PR (#2350) will follow with dead code removal after a deprecation period.

Supersedes #2343. Refs: wasteland w-gt-001.

## Test plan

- [x] `go build ./...` — compiles
- [x] `go test ./internal/deprecation/` — 12 tests pass
- [x] `go test ./internal/configfile/` — all pass
- [x] `go test ./cmd/bd/doctor/` — all pass
- [x] `scripts/check-versions.sh` — version consistency
- [x] Manual: `dolt_mode: "embedded"` in metadata.json → warning on stderr
- [x] Manual: `bd list --json` → no warning in output
- [x] Manual: `bd doctor` → deprecation checks appear
- [x] `scripts/test-deprecation-manual.sh` — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)