### PR TITLE
fix(config): route backup.* keys to config.yaml so overrides are respected

### DIFF
--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -55,6 +55,12 @@ var YamlOnlyKeys = map[string]bool{
 	// Hierarchy settings (GH#995)
 	"hierarchy.max-depth": true,
 
+	// Backup settings (must be in yaml so GetValueSource can detect overrides)
+	"backup.enabled":  true,
+	"backup.interval": true,
+	"backup.git-push": true,
+	"backup.git-repo": true,
+
 	// Dolt server settings
 	"dolt.idle-timeout": true, // Idle auto-stop timeout (default "30m", "0" disables)
 }
@@ -68,7 +74,7 @@ func IsYamlOnlyKey(key string) bool {
 	}
 
 	// Check prefix matches for nested keys
-	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "dolt.", "federation."}
+	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "backup.", "dolt.", "federation."}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(key, prefix) {
 			return true

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -30,6 +30,13 @@ func TestIsYamlOnlyKey(t *testing.T) {
 		{"hierarchy.max-depth", true},
 		{"hierarchy.custom_setting", true}, // prefix match
 
+		// Backup settings (GH#2358)
+		{"backup.enabled", true},
+		{"backup.interval", true},
+		{"backup.git-push", true},
+		{"backup.git-repo", true},
+		{"backup.future-key", true}, // prefix match
+
 		// Non-yaml keys (should return false)
 		{"jira.url", false},
 		{"jira.project", false},


### PR DESCRIPTION
## Summary

Fixes #2358. 

`bd config set backup-enabled false` stored the value in the Dolt database, but `isBackupAutoEnabled()` checks `config.GetValueSource("backup.enabled")` which only inspects Viper sources (env vars, config.yaml) — never the DB. User overrides were invisible to the backup auto-enable logic.

- Add `backup.enabled`, `backup.interval`, `backup.git-push`, `backup.git-repo` to `YamlOnlyKeys` explicit entries
- Add `backup.` to the prefix list in `IsYamlOnlyKey()` for future backup config keys
- Now `bd config set backup-enabled false` writes to config.yaml where `GetValueSource` can detect it as `SourceConfigFile` (not `SourceDefault`)

## Test plan

- [x] Added test cases for all backup keys in `TestIsYamlOnlyKey` (exact match + prefix match)
- [x] All existing `TestIsYamlOnlyKey` tests pass
- [x] `golangci-lint` passes
- [ ] Manual: `bd config set backup-enabled false` → `bd backup status` should show `enabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)