### PR TITLE
fix(backup): skip git commits during hook runs and on feature branches

### DIFF
--- a/cmd/bd/backup_auto.go
+++ b/cmd/bd/backup_auto.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/config"
@@ -37,6 +39,14 @@ func isBackupGitPushEnabled() bool {
 // maybeAutoBackup runs a JSONL backup if enabled and the throttle interval has passed.
 // Called from PersistentPostRun after auto-commit.
 func maybeAutoBackup(ctx context.Context) {
+	// Skip backup entirely when running as a git hook (post-checkout, post-merge, etc.).
+	// Git hooks call 'bd hooks run' which goes through PersistentPostRun — without this
+	// guard, every git checkout/merge/rebase triggers a backup commit on the current branch.
+	if os.Getenv("BD_GIT_HOOK") == "1" {
+		debug.Logf("backup: skipping — running as git hook\n")
+		return
+	}
+
 	if !isBackupAutoEnabled() {
 		return
 	}
@@ -88,10 +98,28 @@ func maybeAutoBackup(ctx context.Context) {
 	debug.Logf("backup: exported %d issues, %d events, %d comments\n",
 		newState.Counts.Issues, newState.Counts.Events, newState.Counts.Comments)
 
-	// Optional git push
+	// Optional git push — only on default branch to avoid polluting feature branches.
 	if isBackupGitPushEnabled() {
-		if err := gitBackup(ctx); err != nil {
+		if branch, err := currentGitBranch(); err == nil && !isDefaultBranch(branch) {
+			debug.Logf("backup: skipping git commit — on branch %q (not default)\n", branch)
+		} else if err := gitBackup(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: backup git push failed: %v\n", err)
 		}
 	}
+}
+
+// currentGitBranch returns the current git branch name.
+// Returns an error if not in a git repo or HEAD is detached.
+func currentGitBranch() (string, error) {
+	cmd := exec.Command("git", "symbolic-ref", "--short", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// isDefaultBranch returns true if the given branch name is a default/primary branch.
+func isDefaultBranch(branch string) bool {
+	return branch == "main" || branch == "master"
 }

--- a/cmd/bd/backup_auto_test.go
+++ b/cmd/bd/backup_auto_test.go
@@ -160,3 +160,28 @@ func TestIsBackupGitPushEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		branch string
+		want   bool
+	}{
+		{"main", true},
+		{"master", true},
+		{"feature/my-work", false},
+		{"fix/backup-bug", false},
+		{"develop", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.branch, func(t *testing.T) {
+			t.Parallel()
+			if got := isDefaultBranch(tt.branch); got != tt.want {
+				t.Errorf("isDefaultBranch(%q) = %v, want %v", tt.branch, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2364. Prevents auto-backup from polluting feature branches with `bd: backup <timestamp>` commits.

Two independent guards:

### 1. Skip backup during git hook execution
When git runs a hook (post-checkout, post-merge, etc.), the shim calls `bd hooks run <hook>`. This is a cobra command that goes through `PersistentPostRun` → `maybeAutoBackup` → `gitBackup`, creating a backup commit on whatever branch was just checked out to.

Fix: Check `BD_GIT_HOOK=1` (already set by hook shims) at the top of `maybeAutoBackup` and return early. The JSONL export is not needed during hook runs — the actual bd write command that triggered the data change already ran its own backup cycle.

### 2. Skip git commit/push on non-default branches
Even outside hook context, backup git commits should only go on `main`/`master`. Feature branches should stay clean for PRs.

Fix: Before calling `gitBackup`, check `currentGitBranch()` and skip if not `main` or `master`. The local JSONL export to `.beads/backup/` still runs (preserving the local safety net).

## Why BD_BACKUP_ENABLED=false didn't work

As reported by users, setting `BD_BACKUP_ENABLED=false` via environment doesn't always prevent backup commits. The root cause: git hooks spawn `bd` as a subprocess via `#!/usr/bin/env sh` shims. Depending on shell configuration, the parent process's environment variables may not propagate to the hook subprocess. The `BD_GIT_HOOK` guard is more reliable because it's set explicitly by the shim script itself.

## Related

- #2358 — Config overrides ignored (separate PR #2365 for the config routing fix)
- #2241 — bd: backups in git history
- #2290 — stealth mode backup push (already fixed on main)

## Test plan

- [x] New `TestIsDefaultBranch` test cases (main, master, feature branches)
- [x] Existing `TestIsBackupAutoEnabled` and `TestIsBackupGitPushEnabled` tests pass
- [x] `golangci-lint` passes (0 issues)
- [x] `go build ./cmd/bd/` succeeds
- [ ] Manual: `git checkout -b test-branch && bd create "test"` → no backup commit on test-branch
- [ ] Manual: `git checkout main && bd create "test"` → backup commit created normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)