### PR TITLE
fix: deterministic ordering in SearchIssues and GetReadyWork

### DIFF
--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -63,7 +63,7 @@ func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types
 	querySQL := fmt.Sprintf(`
 		SELECT id FROM issues
 		%s
-		ORDER BY priority ASC, created_at DESC
+		ORDER BY priority ASC, created_at DESC, id ASC
 		%s
 	`, whereSQL, limitSQL)
 
@@ -260,18 +260,18 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 	var orderBySQL string
 	switch filter.SortPolicy {
 	case types.SortPolicyOldest:
-		orderBySQL = "ORDER BY created_at ASC"
+		orderBySQL = "ORDER BY created_at ASC, id ASC"
 	case types.SortPolicyPriority:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC"
+		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
 	case types.SortPolicyHybrid, "": // hybrid is the default
 		// Recent issues (created within 48 hours) are sorted by priority;
 		// older issues are sorted by age (oldest first) to prevent starvation.
 		orderBySQL = `ORDER BY
 			CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 48 HOUR) THEN 0 ELSE 1 END ASC,
 			CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 48 HOUR) THEN priority ELSE 999 END ASC,
-			created_at ASC`
+			created_at ASC, id ASC`
 	default:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC"
+		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
 	}
 
 	// nolint:gosec // G201: whereSQL contains column comparisons with ?, limitSQL is a safe integer

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -2,6 +2,7 @@ package dolt
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1905,5 +1906,58 @@ func TestCounterMode_AlreadySeeded(t *testing.T) {
 	}
 	if next.ID != "test-21" {
 		t.Errorf("expected test-21 (counter must not re-seed over existing row), got %q", next.ID)
+	}
+}
+
+// TestSearchIssues_StableOrdering verifies that SearchIssues returns
+// deterministic ordering when multiple issues share the same priority
+// and created_at timestamp. The id column acts as a tiebreaker.
+func TestSearchIssues_StableOrdering(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	now := time.Now()
+	// Create issues with identical priority and created_at but different IDs.
+	for _, id := range []string{"stable-c", "stable-a", "stable-b"} {
+		iss := &types.Issue{
+			ID:        id,
+			Title:     "Stable Ordering Test",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			CreatedAt: now,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("failed to create issue %s: %v", id, err)
+		}
+	}
+
+	// Run the query multiple times and verify identical ordering each time.
+	var firstOrder string
+	for i := 0; i < 5; i++ {
+		results, err := store.SearchIssues(ctx, "Stable Ordering", types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("run %d: unexpected error: %v", i, err)
+		}
+		if len(results) != 3 {
+			t.Fatalf("run %d: expected 3 results, got %d", i, len(results))
+		}
+		var ids []string
+		for _, r := range results {
+			ids = append(ids, r.ID)
+		}
+		order := strings.Join(ids, ",")
+		if i == 0 {
+			firstOrder = order
+			// With id ASC tiebreaker, expect alphabetical: a, b, c.
+			if ids[0] != "stable-a" || ids[1] != "stable-b" || ids[2] != "stable-c" {
+				t.Errorf("expected [stable-a, stable-b, stable-c], got %v", ids)
+			}
+		} else if order != firstOrder {
+			t.Errorf("run %d: ordering changed from %q to %q", i, firstOrder, order)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add `id ASC` as a tertiary sort key to all ORDER BY clauses in `SearchIssues` and `GetReadyWork`
- When multiple issues share the same priority and `created_at` timestamp, the order was non-deterministic between calls
- Matches the stable ordering pattern already used by `buildIssueTree`'s `compareIssuesByPriority`

## Motivation
Automation that queries `bd list --assignee=X` across agent restarts needs deterministic ordering to reliably identify assigned work. Without the `id` tiebreaker, ties in priority+created_at produce unpredictable results.

## Test plan
- [x] Added `TestSearchIssues_StableOrdering` — creates 3 issues with identical priority and created_at, verifies consistent alphabetical ID ordering across 5 repeated queries
- [x] `go build ./...` and `go vet ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)