### PR TITLE
feat: add GitHub Issues integration (tracker plugin)

### DIFF
--- a/cmd/bd/github.go
+++ b/cmd/bd/github.go
@@ -1,0 +1,444 @@
+// Package main provides the bd CLI commands.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/github"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// GitHubConfig holds GitHub connection configuration.
+type GitHubConfig struct {
+	Token      string // Personal access token
+	Owner      string // Repository owner (user or organization)
+	Repo       string // Repository name
+	Repository string // Combined "owner/repo" format
+	URL        string // Custom API URL (for GitHub Enterprise)
+}
+
+// githubCmd is the root command for GitHub operations.
+var githubCmd = &cobra.Command{
+	Use:   "github",
+	Short: "GitHub integration commands",
+	Long: `Commands for syncing issues between beads and GitHub.
+
+Configuration can be set via 'bd config' or environment variables:
+  github.token / GITHUB_TOKEN           - Personal access token
+  github.owner / GITHUB_OWNER           - Repository owner
+  github.repo / GITHUB_REPO             - Repository name
+  github.repository / GITHUB_REPOSITORY - Combined "owner/repo" format
+  github.url / GITHUB_API_URL           - Custom API URL (GitHub Enterprise)`,
+}
+
+// githubSyncCmd synchronizes issues between beads and GitHub.
+var githubSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync issues with GitHub",
+	Long: `Synchronize issues between beads and GitHub.
+
+By default, performs bidirectional sync:
+- Pulls new/updated issues from GitHub to beads
+- Pushes local beads issues to GitHub
+
+Use --pull-only or --push-only to limit direction.`,
+	RunE: runGitHubSync,
+}
+
+// githubStatusCmd displays GitHub configuration and sync status.
+var githubStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show GitHub sync status",
+	Long:  `Display current GitHub configuration and sync status.`,
+	RunE:  runGitHubStatus,
+}
+
+// githubReposCmd lists accessible GitHub repositories.
+var githubReposCmd = &cobra.Command{
+	Use:   "repos",
+	Short: "List accessible GitHub repositories",
+	Long:  `List GitHub repositories that the configured token has access to.`,
+	RunE:  runGitHubRepos,
+}
+
+var (
+	githubSyncDryRun   bool
+	githubSyncPullOnly bool
+	githubSyncPushOnly bool
+	githubPreferLocal  bool
+	githubPreferGitHub bool
+	githubPreferNewer  bool
+)
+
+// GitHubConflictStrategy defines how to resolve conflicts between local and GitHub versions.
+type GitHubConflictStrategy string
+
+const (
+	// GitHubConflictPreferNewer uses the most recently updated version (default).
+	GitHubConflictPreferNewer GitHubConflictStrategy = "prefer-newer"
+	// GitHubConflictPreferLocal always keeps the local beads version.
+	GitHubConflictPreferLocal GitHubConflictStrategy = "prefer-local"
+	// GitHubConflictPreferGitHub always uses the GitHub version.
+	GitHubConflictPreferGitHub GitHubConflictStrategy = "prefer-github"
+)
+
+// getGitHubConflictStrategy determines the conflict strategy from flag values.
+// Returns error if multiple conflicting flags are set.
+func getGitHubConflictStrategy(preferLocal, preferGitHub, preferNewer bool) (GitHubConflictStrategy, error) {
+	flagsSet := 0
+	if preferLocal {
+		flagsSet++
+	}
+	if preferGitHub {
+		flagsSet++
+	}
+	if preferNewer {
+		flagsSet++
+	}
+	if flagsSet > 1 {
+		return "", fmt.Errorf("cannot use multiple conflict resolution flags")
+	}
+
+	if preferLocal {
+		return GitHubConflictPreferLocal, nil
+	}
+	if preferGitHub {
+		return GitHubConflictPreferGitHub, nil
+	}
+	return GitHubConflictPreferNewer, nil
+}
+
+// parseGitHubSourceSystem parses a source system string like "github:https://...:42"
+// Returns the issue number and ok (whether it's a valid GitHub source).
+func parseGitHubSourceSystem(sourceSystem string) (number int, ok bool) {
+	if !strings.HasPrefix(sourceSystem, "github:") {
+		return 0, false
+	}
+
+	// Find last ":" and parse the number after it
+	lastColon := strings.LastIndex(sourceSystem, ":")
+	if lastColon == -1 || lastColon == len(sourceSystem)-1 {
+		return 0, false
+	}
+
+	var err error
+	number, err = strconv.Atoi(sourceSystem[lastColon+1:])
+	if err != nil {
+		return 0, false
+	}
+
+	return number, true
+}
+
+func init() {
+	// Add subcommands to github
+	githubCmd.AddCommand(githubSyncCmd)
+	githubCmd.AddCommand(githubStatusCmd)
+	githubCmd.AddCommand(githubReposCmd)
+
+	// Add flags to sync command
+	githubSyncCmd.Flags().BoolVar(&githubSyncDryRun, "dry-run", false, "Show what would be synced without making changes")
+	githubSyncCmd.Flags().BoolVar(&githubSyncPullOnly, "pull-only", false, "Only pull issues from GitHub")
+	githubSyncCmd.Flags().BoolVar(&githubSyncPushOnly, "push-only", false, "Only push issues to GitHub")
+
+	// Conflict resolution flags (mutually exclusive)
+	githubSyncCmd.Flags().BoolVar(&githubPreferLocal, "prefer-local", false, "On conflict, keep local beads version")
+	githubSyncCmd.Flags().BoolVar(&githubPreferGitHub, "prefer-github", false, "On conflict, use GitHub version")
+	githubSyncCmd.Flags().BoolVar(&githubPreferNewer, "prefer-newer", false, "On conflict, use most recent version (default)")
+
+	// Register github command with root
+	rootCmd.AddCommand(githubCmd)
+}
+
+// getGitHubConfig returns GitHub configuration from bd config or environment.
+func getGitHubConfig() GitHubConfig {
+	ctx := context.Background()
+	config := GitHubConfig{}
+
+	config.Token = getGitHubConfigValue(ctx, "github.token")
+	config.Owner = getGitHubConfigValue(ctx, "github.owner")
+	config.Repo = getGitHubConfigValue(ctx, "github.repo")
+	config.Repository = getGitHubConfigValue(ctx, "github.repository")
+	config.URL = getGitHubConfigValue(ctx, "github.url")
+
+	// Parse combined owner/repo format if individual fields are empty
+	if (config.Owner == "" || config.Repo == "") && config.Repository != "" {
+		parts := strings.SplitN(config.Repository, "/", 2)
+		if len(parts) == 2 {
+			if config.Owner == "" {
+				config.Owner = parts[0]
+			}
+			if config.Repo == "" {
+				config.Repo = parts[1]
+			}
+		}
+	}
+
+	return config
+}
+
+// getGitHubConfigValue reads a GitHub configuration value from store or environment.
+func getGitHubConfigValue(ctx context.Context, key string) string {
+	// Try to read from store (works in direct mode)
+	if store != nil {
+		value, _ := store.GetConfig(ctx, key)
+		if value != "" {
+			return value
+		}
+	} else if dbPath != "" {
+		tempStore, err := dolt.New(ctx, &dolt.Config{Path: dbPath})
+		if err == nil {
+			defer func() { _ = tempStore.Close() }()
+			value, _ := tempStore.GetConfig(ctx, key)
+			if value != "" {
+				return value
+			}
+		}
+	}
+
+	// Fall back to environment variable
+	envKey := githubConfigToEnvVar(key)
+	if envKey != "" {
+		if value := os.Getenv(envKey); value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+// githubConfigToEnvVar maps GitHub config keys to their environment variable names.
+func githubConfigToEnvVar(key string) string {
+	switch key {
+	case "github.token":
+		return "GITHUB_TOKEN"
+	case "github.owner":
+		return "GITHUB_OWNER"
+	case "github.repo":
+		return "GITHUB_REPO"
+	case "github.repository":
+		return "GITHUB_REPOSITORY"
+	case "github.url":
+		return "GITHUB_API_URL"
+	default:
+		return ""
+	}
+}
+
+// validateGitHubConfig checks that required configuration is present.
+func validateGitHubConfig(config GitHubConfig) error {
+	if config.Token == "" {
+		return fmt.Errorf("github.token is not configured. Set via 'bd config github.token <token>' or GITHUB_TOKEN environment variable")
+	}
+	if config.Owner == "" {
+		return fmt.Errorf("github.owner is not configured. Set via 'bd config github.owner <owner>' or GITHUB_OWNER environment variable")
+	}
+	if config.Repo == "" {
+		return fmt.Errorf("github.repo is not configured. Set via 'bd config github.repo <repo>' or GITHUB_REPO environment variable")
+	}
+	return nil
+}
+
+// maskGitHubToken masks a token for safe display.
+// Shows only the first 4 characters to aid identification without
+// revealing enough to reduce brute-force entropy.
+func maskGitHubToken(token string) string {
+	if token == "" {
+		return "(not set)"
+	}
+	if len(token) <= 4 {
+		return "****"
+	}
+	return token[:4] + "****"
+}
+
+// getGitHubClient creates a GitHub client from the current configuration.
+func getGitHubClient(config GitHubConfig) *github.Client {
+	client := github.NewClient(config.Token, config.Owner, config.Repo)
+	if config.URL != "" {
+		client = client.WithBaseURL(config.URL)
+	}
+	return client
+}
+
+// runGitHubStatus implements the github status command.
+func runGitHubStatus(cmd *cobra.Command, args []string) error {
+	config := getGitHubConfig()
+
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, "GitHub Configuration")
+	_, _ = fmt.Fprintln(out, "====================")
+	_, _ = fmt.Fprintf(out, "Token:      %s\n", maskGitHubToken(config.Token))
+	_, _ = fmt.Fprintf(out, "Owner:      %s\n", config.Owner)
+	_, _ = fmt.Fprintf(out, "Repository: %s\n", config.Repo)
+	if config.URL != "" {
+		_, _ = fmt.Fprintf(out, "API URL:    %s\n", config.URL)
+	}
+
+	// Validate configuration
+	if err := validateGitHubConfig(config); err != nil {
+		_, _ = fmt.Fprintf(out, "\nStatus: ❌ Not configured\n")
+		_, _ = fmt.Fprintf(out, "Error: %v\n", err)
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(out, "\nStatus: ✓ Configured\n")
+	return nil
+}
+
+// runGitHubRepos implements the github repos command.
+func runGitHubRepos(cmd *cobra.Command, args []string) error {
+	config := getGitHubConfig()
+	if config.Token == "" {
+		return fmt.Errorf("github.token is not configured. Set via 'bd config github.token <token>' or GITHUB_TOKEN environment variable")
+	}
+
+	out := cmd.OutOrStdout()
+	client := getGitHubClient(config)
+	ctx := context.Background()
+
+	repos, err := client.ListRepositories(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch repositories: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(out, "Accessible GitHub Repositories")
+	_, _ = fmt.Fprintln(out, "==============================")
+	for _, r := range repos {
+		_, _ = fmt.Fprintf(out, "  %s\n", r.FullName)
+		if r.Description != "" {
+			_, _ = fmt.Fprintf(out, "    %s\n", r.Description)
+		}
+		_, _ = fmt.Fprintf(out, "    %s\n", r.HTMLURL)
+		_, _ = fmt.Fprintln(out)
+	}
+
+	if len(repos) == 0 {
+		_, _ = fmt.Fprintln(out, "No repositories found")
+	}
+
+	return nil
+}
+
+// runGitHubSync implements the github sync command.
+// Uses the tracker.Engine for all sync operations.
+func runGitHubSync(cmd *cobra.Command, args []string) error {
+	config := getGitHubConfig()
+	if err := validateGitHubConfig(config); err != nil {
+		return err
+	}
+
+	if !githubSyncDryRun {
+		CheckReadonly("github sync")
+	}
+
+	if githubSyncPullOnly && githubSyncPushOnly {
+		return fmt.Errorf("cannot use both --pull-only and --push-only")
+	}
+
+	// Validate conflict flags
+	conflictStrategy, err := getGitHubConflictStrategy(githubPreferLocal, githubPreferGitHub, githubPreferNewer)
+	if err != nil {
+		return fmt.Errorf("%w (--prefer-local, --prefer-github, --prefer-newer)", err)
+	}
+
+	if err := ensureStoreActive(); err != nil {
+		return fmt.Errorf("database not available: %w", err)
+	}
+
+	out := cmd.OutOrStdout()
+	ctx := context.Background()
+
+	// Create and initialize the GitHub tracker
+	gt := &github.Tracker{}
+	if err := gt.Init(ctx, store); err != nil {
+		return fmt.Errorf("initializing GitHub tracker: %w", err)
+	}
+
+	// Create the sync engine
+	engine := tracker.NewEngine(gt, store, actor)
+	engine.OnMessage = func(msg string) { _, _ = fmt.Fprintln(out, "  "+msg) }
+	engine.OnWarning = func(msg string) { _, _ = fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
+
+	// Set up GitHub-specific pull hooks
+	engine.PullHooks = buildGitHubPullHooks(ctx)
+
+	// Build sync options from CLI flags
+	pull := !githubSyncPushOnly
+	push := !githubSyncPullOnly
+
+	opts := tracker.SyncOptions{
+		Pull:   pull,
+		Push:   push,
+		DryRun: githubSyncDryRun,
+	}
+
+	// Map conflict resolution
+	switch conflictStrategy {
+	case GitHubConflictPreferLocal:
+		opts.ConflictResolution = tracker.ConflictLocal
+	case GitHubConflictPreferGitHub:
+		opts.ConflictResolution = tracker.ConflictExternal
+	default:
+		opts.ConflictResolution = tracker.ConflictTimestamp
+	}
+
+	if githubSyncDryRun {
+		_, _ = fmt.Fprintln(out, "Dry run mode - no changes will be made")
+		_, _ = fmt.Fprintln(out)
+	}
+
+	// Run sync
+	result, err := engine.Sync(ctx, opts)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return err
+	}
+
+	// Output results
+	if !githubSyncDryRun {
+		if result.Stats.Pulled > 0 {
+			_, _ = fmt.Fprintf(out, "✓ Pulled %d issues (%d created, %d updated)\n",
+				result.Stats.Pulled, result.Stats.Created, result.Stats.Updated)
+		}
+		if result.Stats.Pushed > 0 {
+			_, _ = fmt.Fprintf(out, "✓ Pushed %d issues\n", result.Stats.Pushed)
+		}
+		if result.Stats.Conflicts > 0 {
+			_, _ = fmt.Fprintf(out, "→ Resolved %d conflicts\n", result.Stats.Conflicts)
+		}
+	}
+
+	if githubSyncDryRun {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out, "Run without --dry-run to apply changes")
+	}
+
+	return nil
+}
+
+// buildGitHubPullHooks creates PullHooks for GitHub-specific pull behavior.
+func buildGitHubPullHooks(ctx context.Context) *tracker.PullHooks {
+	prefix := "bd"
+	if store != nil {
+		if p, err := store.GetConfig(ctx, "issue_prefix"); err == nil && p != "" {
+			prefix = p
+		}
+	}
+
+	return &tracker.PullHooks{
+		GenerateID: func(_ context.Context, issue *types.Issue) error {
+			if issue.ID == "" {
+				issue.ID = generateIssueID(prefix)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,389 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// linkNextPattern matches the "next" relation in GitHub Link headers.
+var linkNextPattern = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
+
+// NewClient creates a new GitHub client with the given token, owner, and repo.
+func NewClient(token, owner, repo string) *Client {
+	return &Client{
+		Token:   token,
+		BaseURL: DefaultBaseURL,
+		Owner:   owner,
+		Repo:    repo,
+		HTTPClient: &http.Client{
+			Timeout: DefaultTimeout,
+		},
+	}
+}
+
+// WithHTTPClient returns a new client configured to use the specified HTTP client.
+// This is useful for testing or customizing timeouts and transport settings.
+func (c *Client) WithHTTPClient(httpClient *http.Client) *Client {
+	return &Client{
+		Token:      c.Token,
+		BaseURL:    c.BaseURL,
+		Owner:      c.Owner,
+		Repo:       c.Repo,
+		HTTPClient: httpClient,
+	}
+}
+
+// WithBaseURL returns a new client configured to use a custom API base URL.
+// This is useful for testing with mock servers or GitHub Enterprise instances.
+func (c *Client) WithBaseURL(baseURL string) *Client {
+	return &Client{
+		Token:      c.Token,
+		BaseURL:    strings.TrimSuffix(baseURL, "/"),
+		Owner:      c.Owner,
+		Repo:       c.Repo,
+		HTTPClient: c.HTTPClient,
+	}
+}
+
+// repoPath returns the /repos/{owner}/{repo} path prefix for API calls.
+func (c *Client) repoPath() string {
+	return "/repos/" + c.Owner + "/" + c.Repo
+}
+
+// doRequest performs an HTTP request with authentication and retry logic.
+func (c *Client) doRequest(ctx context.Context, method, urlStr string, body interface{}) ([]byte, http.Header, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonBody)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= MaxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, method, urlStr, reqBody)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("request failed (attempt %d/%d): %w", attempt+1, MaxRetries+1, err)
+			continue
+		}
+
+		// Limit response body to 50MB to prevent OOM from malformed responses.
+		const maxResponseSize = 50 * 1024 * 1024
+		respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		_ = resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("failed to read response (attempt %d/%d): %w", attempt+1, MaxRetries+1, err)
+			continue
+		}
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return respBody, resp.Header, nil
+		}
+
+		// Retry on rate-limiting and server errors with exponential backoff.
+		retriable := resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode == http.StatusForbidden || // GitHub returns 403 for secondary rate limits
+			resp.StatusCode == http.StatusInternalServerError ||
+			resp.StatusCode == http.StatusBadGateway ||
+			resp.StatusCode == http.StatusServiceUnavailable ||
+			resp.StatusCode == http.StatusGatewayTimeout
+
+		if retriable {
+			delay := RetryDelay * time.Duration(1<<attempt)
+
+			// Use Retry-After header if present (GitHub rate limiting)
+			if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
+				if seconds, err := strconv.Atoi(retryAfter); err == nil {
+					delay = time.Duration(seconds) * time.Second
+				}
+			}
+
+			lastErr = fmt.Errorf("transient error %d (attempt %d/%d)", resp.StatusCode, attempt+1, MaxRetries+1)
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			case <-time.After(delay):
+				// Reset body reader for retry
+				if body != nil {
+					jsonBody, err := json.Marshal(body)
+					if err != nil {
+						lastErr = fmt.Errorf("retry marshal failed: %w", err)
+						continue
+					}
+					reqBody = bytes.NewReader(jsonBody)
+				}
+				continue
+			}
+		}
+
+		return nil, nil, fmt.Errorf("API error: %s (status %d)", string(respBody), resp.StatusCode)
+	}
+
+	return nil, nil, fmt.Errorf("max retries (%d) exceeded: %w", MaxRetries+1, lastErr)
+}
+
+// nextPageURL extracts the next page URL from GitHub's Link header.
+// Returns empty string if there is no next page.
+func nextPageURL(headers http.Header) string {
+	link := headers.Get("Link")
+	if link == "" {
+		return ""
+	}
+	matches := linkNextPattern.FindStringSubmatch(link)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+// FetchIssues retrieves issues from GitHub with optional filtering by state.
+// state can be: "open", "closed", or "all".
+// Filters out pull requests (GitHub's Issues API includes PRs).
+func (c *Client) FetchIssues(ctx context.Context, state string) ([]Issue, error) {
+	var allIssues []Issue
+	page := 1
+
+	for {
+		select {
+		case <-ctx.Done():
+			return allIssues, ctx.Err()
+		default:
+		}
+
+		urlStr := fmt.Sprintf("%s%s/issues?per_page=%d&page=%d&state=%s&direction=asc",
+			c.BaseURL, c.repoPath(), MaxPerPage, page, state)
+
+		respBody, headers, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch issues: %w", err)
+		}
+
+		var issues []Issue
+		if err := json.Unmarshal(respBody, &issues); err != nil {
+			return nil, fmt.Errorf("failed to parse issues response: %w", err)
+		}
+
+		// Filter out pull requests
+		for i := range issues {
+			if !issues[i].IsPullRequest() {
+				allIssues = append(allIssues, issues[i])
+			}
+		}
+
+		// Check for next page
+		if nextPageURL(headers) == "" {
+			break
+		}
+		page++
+
+		if page > MaxPages {
+			return nil, fmt.Errorf("pagination limit exceeded: stopped after %d pages", MaxPages)
+		}
+	}
+
+	return allIssues, nil
+}
+
+// FetchIssuesSince retrieves issues from GitHub that have been updated since the given time.
+// This enables incremental sync by only fetching issues modified after the last sync.
+func (c *Client) FetchIssuesSince(ctx context.Context, state string, since time.Time) ([]Issue, error) {
+	var allIssues []Issue
+	page := 1
+
+	sinceStr := since.UTC().Format(time.RFC3339)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return allIssues, ctx.Err()
+		default:
+		}
+
+		urlStr := fmt.Sprintf("%s%s/issues?per_page=%d&page=%d&state=%s&since=%s&direction=asc",
+			c.BaseURL, c.repoPath(), MaxPerPage, page, state, sinceStr)
+
+		respBody, headers, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch issues since %s: %w", sinceStr, err)
+		}
+
+		var issues []Issue
+		if err := json.Unmarshal(respBody, &issues); err != nil {
+			return nil, fmt.Errorf("failed to parse issues response: %w", err)
+		}
+
+		// Filter out pull requests
+		for i := range issues {
+			if !issues[i].IsPullRequest() {
+				allIssues = append(allIssues, issues[i])
+			}
+		}
+
+		if nextPageURL(headers) == "" {
+			break
+		}
+		page++
+
+		if page > MaxPages {
+			return nil, fmt.Errorf("pagination limit exceeded: stopped after %d pages", MaxPages)
+		}
+	}
+
+	return allIssues, nil
+}
+
+// CreateIssue creates a new issue in GitHub.
+func (c *Client) CreateIssue(ctx context.Context, title, body string, labels []string) (*Issue, error) {
+	reqBody := map[string]interface{}{
+		"title": title,
+		"body":  body,
+	}
+	if len(labels) > 0 {
+		reqBody["labels"] = labels
+	}
+
+	urlStr := fmt.Sprintf("%s%s/issues", c.BaseURL, c.repoPath())
+	respBody, _, err := c.doRequest(ctx, http.MethodPost, urlStr, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue: %w", err)
+	}
+
+	var issue Issue
+	if err := json.Unmarshal(respBody, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse create response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+// UpdateIssue updates an existing issue in GitHub.
+func (c *Client) UpdateIssue(ctx context.Context, number int, updates map[string]interface{}) (*Issue, error) {
+	urlStr := fmt.Sprintf("%s%s/issues/%d", c.BaseURL, c.repoPath(), number)
+	respBody, _, err := c.doRequest(ctx, http.MethodPatch, urlStr, updates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update issue: %w", err)
+	}
+
+	var issue Issue
+	if err := json.Unmarshal(respBody, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse update response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+// FetchIssueByNumber retrieves a single issue by its repository-scoped number.
+func (c *Client) FetchIssueByNumber(ctx context.Context, number int) (*Issue, error) {
+	urlStr := fmt.Sprintf("%s%s/issues/%d", c.BaseURL, c.repoPath(), number)
+	respBody, _, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch issue #%d: %w", number, err)
+	}
+
+	var issue Issue
+	if err := json.Unmarshal(respBody, &issue); err != nil {
+		return nil, fmt.Errorf("failed to parse issue response: %w", err)
+	}
+
+	return &issue, nil
+}
+
+// ListRepositories retrieves repositories accessible to the authenticated user.
+func (c *Client) ListRepositories(ctx context.Context) ([]Repository, error) {
+	var allRepos []Repository
+	page := 1
+
+	for {
+		select {
+		case <-ctx.Done():
+			return allRepos, ctx.Err()
+		default:
+		}
+
+		urlStr := fmt.Sprintf("%s/user/repos?per_page=%d&page=%d&sort=updated", c.BaseURL, MaxPerPage, page)
+		respBody, headers, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list repositories: %w", err)
+		}
+
+		var repos []Repository
+		if err := json.Unmarshal(respBody, &repos); err != nil {
+			return nil, fmt.Errorf("failed to parse repositories response: %w", err)
+		}
+
+		allRepos = append(allRepos, repos...)
+
+		if nextPageURL(headers) == "" {
+			break
+		}
+		page++
+
+		if page > MaxPages {
+			break
+		}
+	}
+
+	return allRepos, nil
+}
+
+// AddLabels adds labels to an existing issue.
+func (c *Client) AddLabels(ctx context.Context, number int, labels []string) error {
+	urlStr := fmt.Sprintf("%s%s/issues/%d/labels", c.BaseURL, c.repoPath(), number)
+	body := map[string]interface{}{
+		"labels": labels,
+	}
+	_, _, err := c.doRequest(ctx, http.MethodPost, urlStr, body)
+	if err != nil {
+		return fmt.Errorf("failed to add labels to issue #%d: %w", number, err)
+	}
+	return nil
+}
+
+// RemoveLabel removes a label from an existing issue.
+func (c *Client) RemoveLabel(ctx context.Context, number int, label string) error {
+	urlStr := fmt.Sprintf("%s%s/issues/%d/labels/%s", c.BaseURL, c.repoPath(), number, label)
+	_, _, err := c.doRequest(ctx, http.MethodDelete, urlStr, nil)
+	if err != nil {
+		return fmt.Errorf("failed to remove label %q from issue #%d: %w", label, number, err)
+	}
+	return nil
+}
+
+// GetAuthenticatedUser returns the authenticated user's information.
+func (c *Client) GetAuthenticatedUser(ctx context.Context) (*User, error) {
+	urlStr := c.BaseURL + "/user"
+	respBody, _, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get authenticated user: %w", err)
+	}
+
+	var user User
+	if err := json.Unmarshal(respBody, &user); err != nil {
+		return nil, fmt.Errorf("failed to parse user response: %w", err)
+	}
+
+	return &user, nil
+}

--- a/internal/github/fieldmapper.go
+++ b/internal/github/fieldmapper.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// githubFieldMapper implements tracker.FieldMapper for GitHub.
+type githubFieldMapper struct {
+	config *MappingConfig
+}
+
+func (m *githubFieldMapper) PriorityToBeads(trackerPriority interface{}) int {
+	// GitHub uses label-based priority (string), not numeric
+	if label, ok := trackerPriority.(string); ok {
+		if p, exists := m.config.PriorityMap[label]; exists {
+			return p
+		}
+	}
+	return 2
+}
+
+func (m *githubFieldMapper) PriorityToTracker(beadsPriority int) interface{} {
+	// Inverse lookup: find the label for this priority
+	for label, p := range m.config.PriorityMap {
+		if p == beadsPriority {
+			return label
+		}
+	}
+	return "medium"
+}
+
+func (m *githubFieldMapper) StatusToBeads(trackerState interface{}) types.Status {
+	if state, ok := trackerState.(string); ok {
+		if status, exists := m.config.StateMap[state]; exists {
+			return types.Status(status)
+		}
+		// GitHub-specific defaults
+		switch state {
+		case "open":
+			return types.StatusOpen
+		case "closed":
+			return types.StatusClosed
+		}
+	}
+	return types.StatusOpen
+}
+
+func (m *githubFieldMapper) StatusToTracker(beadsStatus types.Status) interface{} {
+	switch beadsStatus {
+	case types.StatusClosed:
+		return "closed"
+	default:
+		return "open"
+	}
+}
+
+func (m *githubFieldMapper) TypeToBeads(trackerType interface{}) types.IssueType {
+	if t, ok := trackerType.(string); ok {
+		if issueType, exists := m.config.LabelTypeMap[t]; exists {
+			return types.IssueType(issueType)
+		}
+	}
+	return types.TypeTask
+}
+
+func (m *githubFieldMapper) TypeToTracker(beadsType types.IssueType) interface{} {
+	return string(beadsType)
+}
+
+func (m *githubFieldMapper) IssueToBeads(ti *tracker.TrackerIssue) *tracker.IssueConversion {
+	gh, ok := ti.Raw.(*Issue)
+	if !ok {
+		return nil
+	}
+
+	conv := GitHubIssueToBeads(gh, m.config)
+	if conv == nil {
+		return nil
+	}
+
+	// Convert github.DependencyInfo to tracker.DependencyInfo
+	var deps []tracker.DependencyInfo
+	for _, d := range conv.Dependencies {
+		deps = append(deps, tracker.DependencyInfo{
+			FromExternalID: fmt.Sprintf("%d", d.FromGitHubNumber),
+			ToExternalID:   fmt.Sprintf("%d", d.ToGitHubNumber),
+			Type:           d.Type,
+		})
+	}
+
+	return &tracker.IssueConversion{
+		Issue:        conv.Issue,
+		Dependencies: deps,
+	}
+}
+
+func (m *githubFieldMapper) IssueToTracker(issue *types.Issue) map[string]interface{} {
+	return BeadsIssueToGitHubFields(issue, m.config)
+}

--- a/internal/github/mapping.go
+++ b/internal/github/mapping.go
@@ -1,0 +1,228 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// MappingConfig configures how GitHub fields map to beads fields.
+type MappingConfig struct {
+	PriorityMap  map[string]int    // priority label value -> beads priority (0-4)
+	StateMap     map[string]string // GitHub state -> beads status
+	LabelTypeMap map[string]string // type label value -> beads issue type
+}
+
+// DefaultMappingConfig returns the default mapping configuration.
+// Uses exported mapping constants from types.go as the single source of truth.
+func DefaultMappingConfig() *MappingConfig {
+	// Copy PriorityMapping to avoid external modification
+	priorityMap := make(map[string]int, len(PriorityMapping))
+	for k, v := range PriorityMapping {
+		priorityMap[k] = v
+	}
+
+	// Copy typeMapping to avoid external modification
+	labelTypeMap := make(map[string]string, len(typeMapping))
+	for k, v := range typeMapping {
+		labelTypeMap[k] = v
+	}
+
+	return &MappingConfig{
+		PriorityMap: priorityMap,
+		// StateMap maps GitHub states to beads statuses
+		StateMap: map[string]string{
+			"open":   StatusMapping["open"],
+			"closed": StatusMapping["closed"],
+		},
+		LabelTypeMap: labelTypeMap,
+	}
+}
+
+// priorityFromLabels extracts priority from GitHub labels.
+// Returns default priority (2 = medium) if no priority label found.
+func priorityFromLabels(labels []string, config *MappingConfig) int {
+	for _, label := range labels {
+		prefix, value := parseLabelPrefix(label)
+		if prefix == "priority" {
+			if p, ok := config.PriorityMap[strings.ToLower(value)]; ok {
+				return p
+			}
+		}
+	}
+	return 2 // Default to medium
+}
+
+// statusFromLabelsAndState determines beads status from GitHub labels and state.
+// GitHub's closed state takes precedence over status labels.
+func statusFromLabelsAndState(labels []string, state string, config *MappingConfig) string {
+	// Closed state always wins
+	if state == "closed" {
+		return "closed"
+	}
+
+	// Check for status label
+	for _, label := range labels {
+		prefix, value := parseLabelPrefix(label)
+		if prefix == "status" {
+			normalized := strings.ToLower(value)
+			if normalized == "in_progress" {
+				return "in_progress"
+			}
+			if normalized == "blocked" {
+				return "blocked"
+			}
+			if normalized == "deferred" {
+				return "deferred"
+			}
+		}
+	}
+
+	// Default: map GitHub state to beads status
+	if s, ok := config.StateMap[state]; ok {
+		return s
+	}
+	return "open"
+}
+
+// typeFromLabels extracts issue type from GitHub labels.
+// Checks both scoped (type::bug) and bare (bug) labels.
+// Returns "task" if no type label found.
+func typeFromLabels(labels []string, config *MappingConfig) string {
+	for _, label := range labels {
+		prefix, value := parseLabelPrefix(label)
+		if prefix == "type" {
+			if t, ok := config.LabelTypeMap[strings.ToLower(value)]; ok {
+				return t
+			}
+		}
+		// Also check bare labels (no prefix)
+		if prefix == "" {
+			if t, ok := config.LabelTypeMap[strings.ToLower(value)]; ok {
+				return t
+			}
+		}
+	}
+	return "task" // Default to task
+}
+
+// GitHubIssueToBeads converts a GitHub Issue to a beads Issue.
+func GitHubIssueToBeads(gh *Issue, config *MappingConfig) *IssueConversion {
+	htmlURL := gh.HTMLURL
+	sourceSystem := fmt.Sprintf("github:%s:%d", gh.HTMLURL, gh.Number)
+	// Use a cleaner source system format if HTMLURL is not available
+	if htmlURL == "" {
+		sourceSystem = fmt.Sprintf("github:%d:%d", gh.ID, gh.Number)
+	}
+
+	labelNames := gh.LabelNames()
+
+	issue := &types.Issue{
+		Title:        gh.Title,
+		Description:  gh.Body,
+		ExternalRef:  &htmlURL,
+		SourceSystem: sourceSystem,
+		IssueType:    types.IssueType(typeFromLabels(labelNames, config)),
+		Priority:     priorityFromLabels(labelNames, config),
+		Status:       types.Status(statusFromLabelsAndState(labelNames, gh.State, config)),
+		Labels:       filterNonScopedLabels(labelNames),
+	}
+
+	// Set assignee from GitHub user
+	if gh.Assignee != nil {
+		issue.Assignee = gh.Assignee.Login
+	}
+
+	// Set timestamps
+	if gh.CreatedAt != nil {
+		issue.CreatedAt = *gh.CreatedAt
+	}
+	if gh.UpdatedAt != nil {
+		issue.UpdatedAt = *gh.UpdatedAt
+	}
+
+	return &IssueConversion{
+		Issue:        issue,
+		Dependencies: []DependencyInfo{},
+	}
+}
+
+// BeadsIssueToGitHubFields converts a beads Issue to GitHub API update fields.
+func BeadsIssueToGitHubFields(issue *types.Issue, config *MappingConfig) map[string]interface{} {
+	fields := map[string]interface{}{
+		"title": issue.Title,
+		"body":  issue.Description,
+	}
+
+	// Build labels from type, priority, and status
+	var labels []string
+
+	// Add type label
+	if issue.IssueType != "" {
+		labels = append(labels, "type::"+string(issue.IssueType))
+	}
+
+	// Add priority label
+	priorityLabel := priorityToLabel(issue.Priority)
+	if priorityLabel != "" {
+		labels = append(labels, "priority::"+priorityLabel)
+	}
+
+	// Add status label (if not open or closed - those are handled by state)
+	if issue.Status == types.StatusInProgress {
+		labels = append(labels, "status::in_progress")
+	} else if issue.Status == types.StatusBlocked {
+		labels = append(labels, "status::blocked")
+	} else if issue.Status == types.StatusDeferred {
+		labels = append(labels, "status::deferred")
+	}
+
+	// Add any existing non-scoped labels
+	labels = append(labels, issue.Labels...)
+
+	fields["labels"] = labels
+
+	// Set state for closed issues
+	if issue.Status == types.StatusClosed {
+		fields["state"] = "closed"
+	} else {
+		fields["state"] = "open"
+	}
+
+	return fields
+}
+
+// priorityToLabel converts beads priority (0-4) to GitHub priority label value.
+func priorityToLabel(priority int) string {
+	switch priority {
+	case 0:
+		return "critical"
+	case 1:
+		return "high"
+	case 2:
+		return "medium"
+	case 3:
+		return "low"
+	case 4:
+		return "none"
+	default:
+		return "medium"
+	}
+}
+
+// filterNonScopedLabels returns only labels without scoped prefixes.
+// Removes priority::*, status::*, and type::* labels.
+func filterNonScopedLabels(labels []string) []string {
+	var filtered []string
+	for _, label := range labels {
+		prefix, _ := parseLabelPrefix(label)
+		// Skip scoped labels that we handle specially
+		if prefix == "priority" || prefix == "status" || prefix == "type" {
+			continue
+		}
+		filtered = append(filtered, label)
+	}
+	return filtered
+}

--- a/internal/github/mapping_test.go
+++ b/internal/github/mapping_test.go
@@ -1,0 +1,456 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestDefaultGitHubMappingConfig verifies the default configuration has proper mappings.
+func TestDefaultGitHubMappingConfig(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	// Verify priority mappings exist
+	if len(config.PriorityMap) == 0 {
+		t.Error("PriorityMap is empty, want default priority mappings")
+	}
+	if p, ok := config.PriorityMap["high"]; !ok || p != 1 {
+		t.Errorf("PriorityMap[\"high\"] = %d, want 1", p)
+	}
+
+	// Verify state mappings exist
+	if len(config.StateMap) == 0 {
+		t.Error("StateMap is empty, want default state mappings")
+	}
+	if s, ok := config.StateMap["open"]; !ok || s != "open" {
+		t.Errorf("StateMap[\"open\"] = %q, want \"open\"", s)
+	}
+	if s, ok := config.StateMap["closed"]; !ok || s != "closed" {
+		t.Errorf("StateMap[\"closed\"] = %q, want \"closed\"", s)
+	}
+
+	// Verify type mappings exist
+	if len(config.LabelTypeMap) == 0 {
+		t.Error("LabelTypeMap is empty, want default type mappings")
+	}
+	if typ, ok := config.LabelTypeMap["bug"]; !ok || typ != "bug" {
+		t.Errorf("LabelTypeMap[\"bug\"] = %q, want \"bug\"", typ)
+	}
+}
+
+// TestPriorityFromLabels verifies parsing priority::* labels.
+func TestPriorityFromLabels(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	tests := []struct {
+		name         string
+		labels       []string
+		wantPriority int
+	}{
+		{
+			name:         "priority::critical",
+			labels:       []string{"priority::critical", "bug"},
+			wantPriority: 0,
+		},
+		{
+			name:         "priority::high",
+			labels:       []string{"priority::high"},
+			wantPriority: 1,
+		},
+		{
+			name:         "priority::medium",
+			labels:       []string{"priority::medium", "type::feature"},
+			wantPriority: 2,
+		},
+		{
+			name:         "priority::low",
+			labels:       []string{"priority::low"},
+			wantPriority: 3,
+		},
+		{
+			name:         "no priority label defaults to medium",
+			labels:       []string{"bug", "backend"},
+			wantPriority: 2,
+		},
+		{
+			name:         "empty labels defaults to medium",
+			labels:       []string{},
+			wantPriority: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := priorityFromLabels(tt.labels, config)
+			if got != tt.wantPriority {
+				t.Errorf("priorityFromLabels(%v) = %d, want %d", tt.labels, got, tt.wantPriority)
+			}
+		})
+	}
+}
+
+// TestStatusFromLabelsAndState verifies status determination from labels and GitHub state.
+func TestStatusFromLabelsAndState(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	tests := []struct {
+		name       string
+		labels     []string
+		state      string
+		wantStatus string
+	}{
+		{
+			name:       "status::in_progress overrides open state",
+			labels:     []string{"status::in_progress"},
+			state:      "open",
+			wantStatus: "in_progress",
+		},
+		{
+			name:       "status::blocked",
+			labels:     []string{"status::blocked", "bug"},
+			state:      "open",
+			wantStatus: "blocked",
+		},
+		{
+			name:       "status::deferred",
+			labels:     []string{"status::deferred"},
+			state:      "open",
+			wantStatus: "deferred",
+		},
+		{
+			name:       "closed state wins over status labels",
+			labels:     []string{"status::in_progress"},
+			state:      "closed",
+			wantStatus: "closed",
+		},
+		{
+			name:       "open state without status label",
+			labels:     []string{"bug"},
+			state:      "open",
+			wantStatus: "open",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusFromLabelsAndState(tt.labels, tt.state, config)
+			if got != tt.wantStatus {
+				t.Errorf("statusFromLabelsAndState(%v, %q) = %q, want %q", tt.labels, tt.state, got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// TestTypeFromLabels verifies parsing type::* labels.
+func TestTypeFromLabels(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	tests := []struct {
+		name     string
+		labels   []string
+		wantType string
+	}{
+		{
+			name:     "type::bug",
+			labels:   []string{"type::bug", "priority::high"},
+			wantType: "bug",
+		},
+		{
+			name:     "type::feature",
+			labels:   []string{"type::feature"},
+			wantType: "feature",
+		},
+		{
+			name:     "type::task",
+			labels:   []string{"type::task"},
+			wantType: "task",
+		},
+		{
+			name:     "type::epic",
+			labels:   []string{"type::epic"},
+			wantType: "epic",
+		},
+		{
+			name:     "type::chore",
+			labels:   []string{"type::chore"},
+			wantType: "chore",
+		},
+		{
+			name:     "enhancement maps to feature",
+			labels:   []string{"type::enhancement"},
+			wantType: "feature",
+		},
+		{
+			name:     "bare bug label (no prefix)",
+			labels:   []string{"bug"},
+			wantType: "bug",
+		},
+		{
+			name:     "no type label defaults to task",
+			labels:   []string{"priority::high"},
+			wantType: "task",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := typeFromLabels(tt.labels, config)
+			if got != tt.wantType {
+				t.Errorf("typeFromLabels(%v) = %q, want %q", tt.labels, got, tt.wantType)
+			}
+		})
+	}
+}
+
+// TestGitHubIssueToBeads verifies full conversion from GitHub Issue to beads Issue.
+func TestGitHubIssueToBeads(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	createdAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2024, 1, 16, 14, 0, 0, 0, time.UTC)
+
+	ghIssue := &Issue{
+		ID:     123456,
+		Number: 42,
+		Title:  "Fix authentication bug",
+		Body:   "Users cannot log in with SSO",
+		State:  "open",
+		Labels: []Label{
+			{Name: "type::bug"},
+			{Name: "priority::high"},
+			{Name: "status::in_progress"},
+		},
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+		Assignee: &User{
+			ID:    101,
+			Login: "jdoe",
+			Name:  "John Doe",
+		},
+		User: &User{
+			ID:    102,
+			Login: "alice",
+			Name:  "Alice Smith",
+		},
+		HTMLURL: "https://github.com/org/repo/issues/42",
+	}
+
+	conversion := GitHubIssueToBeads(ghIssue, config)
+	if conversion == nil {
+		t.Fatal("GitHubIssueToBeads returned nil")
+	}
+
+	issue := conversion.Issue
+	if issue == nil {
+		t.Fatal("conversion.Issue is nil")
+	}
+
+	// Verify basic fields
+	if issue.Title != "Fix authentication bug" {
+		t.Errorf("Title = %q, want %q", issue.Title, "Fix authentication bug")
+	}
+	if issue.Description != "Users cannot log in with SSO" {
+		t.Errorf("Description = %q, want %q", issue.Description, "Users cannot log in with SSO")
+	}
+
+	// Verify external reference
+	if issue.ExternalRef == nil || *issue.ExternalRef != "https://github.com/org/repo/issues/42" {
+		t.Errorf("ExternalRef = %v, want GitHub URL", issue.ExternalRef)
+	}
+
+	// Verify mapped fields
+	if issue.IssueType != types.TypeBug {
+		t.Errorf("IssueType = %q, want %q", issue.IssueType, types.TypeBug)
+	}
+	if issue.Priority != 1 {
+		t.Errorf("Priority = %d, want 1 (high)", issue.Priority)
+	}
+	if issue.Status != types.StatusInProgress {
+		t.Errorf("Status = %q, want %q", issue.Status, types.StatusInProgress)
+	}
+
+	// Verify assignee
+	if issue.Assignee != "jdoe" {
+		t.Errorf("Assignee = %q, want \"jdoe\"", issue.Assignee)
+	}
+}
+
+// TestGitHubIssueToBeads_ClosedIssue verifies closed issues are converted correctly.
+func TestGitHubIssueToBeads_ClosedIssue(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	closedAt := time.Date(2024, 1, 17, 10, 0, 0, 0, time.UTC)
+	ghIssue := &Issue{
+		ID:       100,
+		Number:   10,
+		Title:    "Closed task",
+		State:    "closed",
+		ClosedAt: &closedAt,
+		Labels:   []Label{{Name: "status::in_progress"}}, // Should be overridden by closed state
+		HTMLURL:  "https://github.com/org/repo/issues/10",
+	}
+
+	conversion := GitHubIssueToBeads(ghIssue, config)
+	issue := conversion.Issue
+	if issue == nil {
+		t.Fatal("conversion.Issue is nil")
+	}
+
+	if issue.Status != types.StatusClosed {
+		t.Errorf("Status = %q, want %q (closed state overrides labels)", issue.Status, types.StatusClosed)
+	}
+}
+
+// TestBeadsIssueToGitHubFields verifies conversion from beads Issue to GitHub update fields.
+func TestBeadsIssueToGitHubFields(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	beadsIssue := &types.Issue{
+		Title:       "New feature request",
+		Description: "Add dark mode support",
+		IssueType:   types.TypeFeature,
+		Priority:    1, // High
+		Status:      types.StatusInProgress,
+		Assignee:    "jdoe",
+	}
+
+	fields := BeadsIssueToGitHubFields(beadsIssue, config)
+
+	// Verify title and body
+	if fields["title"] != "New feature request" {
+		t.Errorf("fields[\"title\"] = %v, want \"New feature request\"", fields["title"])
+	}
+	if fields["body"] != "Add dark mode support" {
+		t.Errorf("fields[\"body\"] = %v, want \"Add dark mode support\"", fields["body"])
+	}
+
+	// Verify labels include type, priority, and status
+	labels, ok := fields["labels"].([]string)
+	if !ok {
+		t.Fatalf("fields[\"labels\"] is not []string")
+	}
+
+	hasType := false
+	hasPriority := false
+	hasStatus := false
+	for _, l := range labels {
+		if l == "type::feature" {
+			hasType = true
+		}
+		if l == "priority::high" {
+			hasPriority = true
+		}
+		if l == "status::in_progress" {
+			hasStatus = true
+		}
+	}
+	if !hasType {
+		t.Errorf("labels missing type::feature, got %v", labels)
+	}
+	if !hasPriority {
+		t.Errorf("labels missing priority::high, got %v", labels)
+	}
+	if !hasStatus {
+		t.Errorf("labels missing status::in_progress, got %v", labels)
+	}
+
+	// Verify state is "open" for in-progress
+	if fields["state"] != "open" {
+		t.Errorf("fields[\"state\"] = %v, want \"open\"", fields["state"])
+	}
+}
+
+// TestBeadsIssueToGitHubFields_ClosedState verifies state is set for closed issues.
+func TestBeadsIssueToGitHubFields_ClosedState(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	closedIssue := &types.Issue{
+		Title:  "Completed task",
+		Status: types.StatusClosed,
+	}
+
+	fields := BeadsIssueToGitHubFields(closedIssue, config)
+
+	if fields["state"] != "closed" {
+		t.Errorf("fields[\"state\"] = %v, want \"closed\"", fields["state"])
+	}
+}
+
+// TestFilterNonScopedLabels verifies that non-scoped labels are preserved.
+func TestFilterNonScopedLabels(t *testing.T) {
+	labels := []string{
+		"type::bug",
+		"priority::high",
+		"status::in_progress",
+		"backend",
+		"needs-review",
+		"urgent",
+	}
+
+	filtered := filterNonScopedLabels(labels)
+
+	expected := []string{"backend", "needs-review", "urgent"}
+	if len(filtered) != len(expected) {
+		t.Fatalf("filterNonScopedLabels returned %d labels, want %d", len(filtered), len(expected))
+	}
+
+	for i, l := range filtered {
+		if l != expected[i] {
+			t.Errorf("filtered[%d] = %q, want %q", i, l, expected[i])
+		}
+	}
+}
+
+// TestPriorityToLabel verifies conversion from beads priority to GitHub label value.
+func TestPriorityToLabel(t *testing.T) {
+	tests := []struct {
+		priority int
+		want     string
+	}{
+		{0, "critical"},
+		{1, "high"},
+		{2, "medium"},
+		{3, "low"},
+		{4, "none"},
+		{-1, "medium"},
+		{5, "medium"},
+		{100, "medium"},
+	}
+
+	for _, tt := range tests {
+		got := priorityToLabel(tt.priority)
+		if got != tt.want {
+			t.Errorf("priorityToLabel(%d) = %q, want %q", tt.priority, got, tt.want)
+		}
+	}
+}
+
+// TestMappingConfigUsesTypesConstants verifies that DefaultMappingConfig uses
+// the exported mapping constants from types.go, ensuring single source of truth.
+func TestMappingConfigUsesTypesConstants(t *testing.T) {
+	config := DefaultMappingConfig()
+
+	// Priority mappings should match types.go PriorityMapping
+	for key, want := range PriorityMapping {
+		if got := config.PriorityMap[key]; got != want {
+			t.Errorf("PriorityMap[%q] = %d, want %d (from PriorityMapping)", key, got, want)
+		}
+	}
+
+	// Status mappings should match types.go StatusMapping
+	if s := config.StateMap["open"]; s != StatusMapping["open"] {
+		t.Errorf("StateMap[\"open\"] = %q, want %q", s, StatusMapping["open"])
+	}
+	if s := config.StateMap["closed"]; s != StatusMapping["closed"] {
+		t.Errorf("StateMap[\"closed\"] = %q, want %q", s, StatusMapping["closed"])
+	}
+
+	// Type mappings should match types.go typeMapping
+	for key, want := range typeMapping {
+		if got := config.LabelTypeMap[key]; got != want {
+			t.Errorf("LabelTypeMap[%q] = %q, want %q (from typeMapping)", key, got, want)
+		}
+	}
+}

--- a/internal/github/tracker.go
+++ b/internal/github/tracker.go
@@ -1,0 +1,228 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func init() {
+	tracker.Register("github", func() tracker.IssueTracker {
+		return &Tracker{}
+	})
+}
+
+// issueNumberPattern matches GitHub issue URLs: .../issues/42
+var issueNumberPattern = regexp.MustCompile(`/issues/(\d+)`)
+
+// Tracker implements tracker.IssueTracker for GitHub.
+type Tracker struct {
+	client *Client
+	config *MappingConfig
+	store  storage.Storage
+}
+
+func (t *Tracker) Name() string         { return "github" }
+func (t *Tracker) DisplayName() string  { return "GitHub" }
+func (t *Tracker) ConfigPrefix() string { return "github" }
+
+func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
+	t.store = store
+
+	token, err := t.getConfig(ctx, "github.token", "GITHUB_TOKEN")
+	if err != nil || token == "" {
+		return fmt.Errorf("GitHub token not configured (set github.token or GITHUB_TOKEN)")
+	}
+
+	owner, _ := t.getConfig(ctx, "github.owner", "GITHUB_OWNER")
+	repo, _ := t.getConfig(ctx, "github.repo", "GITHUB_REPO")
+
+	// Try combined owner/repo format: "owner/repo"
+	if owner == "" || repo == "" {
+		ownerRepo, _ := t.getConfig(ctx, "github.repository", "GITHUB_REPOSITORY")
+		if ownerRepo != "" {
+			parts := strings.SplitN(ownerRepo, "/", 2)
+			if len(parts) == 2 {
+				owner = parts[0]
+				repo = parts[1]
+			}
+		}
+	}
+
+	if owner == "" {
+		return fmt.Errorf("GitHub owner not configured (set github.owner or GITHUB_OWNER)")
+	}
+	if repo == "" {
+		return fmt.Errorf("GitHub repo not configured (set github.repo or GITHUB_REPO)")
+	}
+
+	t.client = NewClient(token, owner, repo)
+
+	// Allow custom base URL for GitHub Enterprise
+	baseURL, _ := t.getConfig(ctx, "github.url", "GITHUB_API_URL")
+	if baseURL != "" {
+		t.client = t.client.WithBaseURL(baseURL)
+	}
+
+	t.config = DefaultMappingConfig()
+	return nil
+}
+
+func (t *Tracker) Validate() error {
+	if t.client == nil {
+		return fmt.Errorf("GitHub tracker not initialized")
+	}
+	return nil
+}
+
+func (t *Tracker) Close() error { return nil }
+
+func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([]tracker.TrackerIssue, error) {
+	var issues []Issue
+	var err error
+
+	state := opts.State
+	if state == "" {
+		state = "all"
+	}
+
+	if opts.Since != nil {
+		issues, err = t.client.FetchIssuesSince(ctx, state, *opts.Since)
+	} else {
+		issues, err = t.client.FetchIssues(ctx, state)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]tracker.TrackerIssue, 0, len(issues))
+	for _, gh := range issues {
+		result = append(result, githubToTrackerIssue(&gh))
+	}
+	return result, nil
+}
+
+func (t *Tracker) FetchIssue(ctx context.Context, identifier string) (*tracker.TrackerIssue, error) {
+	number, err := strconv.Atoi(identifier)
+	if err != nil {
+		return nil, fmt.Errorf("invalid GitHub issue number %q: %w", identifier, err)
+	}
+
+	gh, err := t.client.FetchIssueByNumber(ctx, number)
+	if err != nil {
+		return nil, err
+	}
+	if gh == nil {
+		return nil, nil
+	}
+
+	ti := githubToTrackerIssue(gh)
+	return &ti, nil
+}
+
+func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	fields := BeadsIssueToGitHubFields(issue, t.config)
+	labels, _ := fields["labels"].([]string)
+
+	created, err := t.client.CreateIssue(ctx, issue.Title, issue.Description, labels)
+	if err != nil {
+		return nil, err
+	}
+
+	ti := githubToTrackerIssue(created)
+	return &ti, nil
+}
+
+func (t *Tracker) UpdateIssue(ctx context.Context, externalID string, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	number, err := strconv.Atoi(externalID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid GitHub issue number %q: %w", externalID, err)
+	}
+
+	updates := BeadsIssueToGitHubFields(issue, t.config)
+	updated, err := t.client.UpdateIssue(ctx, number, updates)
+	if err != nil {
+		return nil, err
+	}
+
+	ti := githubToTrackerIssue(updated)
+	return &ti, nil
+}
+
+func (t *Tracker) FieldMapper() tracker.FieldMapper {
+	return &githubFieldMapper{config: t.config}
+}
+
+func (t *Tracker) IsExternalRef(ref string) bool {
+	return strings.Contains(ref, "github.com") && issueNumberPattern.MatchString(ref)
+}
+
+func (t *Tracker) ExtractIdentifier(ref string) string {
+	matches := issueNumberPattern.FindStringSubmatch(ref)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func (t *Tracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
+	if issue.URL != "" {
+		return issue.URL
+	}
+	return fmt.Sprintf("github:%s", issue.Identifier)
+}
+
+// getConfig reads a config value from storage, falling back to env var.
+func (t *Tracker) getConfig(ctx context.Context, key, envVar string) (string, error) {
+	val, err := t.store.GetConfig(ctx, key)
+	if err == nil && val != "" {
+		return val, nil
+	}
+	if envVar != "" {
+		if envVal := os.Getenv(envVar); envVal != "" {
+			return envVal, nil
+		}
+	}
+	return "", nil
+}
+
+// githubToTrackerIssue converts a github.Issue to a tracker.TrackerIssue.
+func githubToTrackerIssue(gh *Issue) tracker.TrackerIssue {
+	ti := tracker.TrackerIssue{
+		ID:          strconv.Itoa(gh.ID),
+		Identifier:  strconv.Itoa(gh.Number),
+		URL:         gh.HTMLURL,
+		Title:       gh.Title,
+		Description: gh.Body,
+		Labels:      gh.LabelNames(),
+		Raw:         gh,
+	}
+
+	if gh.State != "" {
+		ti.State = gh.State
+	}
+
+	if gh.Assignee != nil {
+		ti.Assignee = gh.Assignee.Login
+		ti.AssigneeID = strconv.Itoa(gh.Assignee.ID)
+	}
+
+	if gh.CreatedAt != nil {
+		ti.CreatedAt = *gh.CreatedAt
+	}
+	if gh.UpdatedAt != nil {
+		ti.UpdatedAt = *gh.UpdatedAt
+	}
+	if gh.ClosedAt != nil {
+		ti.CompletedAt = gh.ClosedAt
+	}
+
+	return ti
+}

--- a/internal/github/tracker_test.go
+++ b/internal/github/tracker_test.go
@@ -1,0 +1,257 @@
+package github
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestRegistered(t *testing.T) {
+	factory := tracker.Get("github")
+	if factory == nil {
+		t.Fatal("github tracker not registered")
+	}
+	tr := factory()
+	if tr.Name() != "github" {
+		t.Errorf("Name() = %q, want %q", tr.Name(), "github")
+	}
+	if tr.DisplayName() != "GitHub" {
+		t.Errorf("DisplayName() = %q, want %q", tr.DisplayName(), "GitHub")
+	}
+	if tr.ConfigPrefix() != "github" {
+		t.Errorf("ConfigPrefix() = %q, want %q", tr.ConfigPrefix(), "github")
+	}
+}
+
+func TestIsExternalRef(t *testing.T) {
+	tr := &Tracker{}
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"https://github.com/org/repo/issues/42", true},
+		{"https://github.com/team/project/issues/123", true},
+		{"https://gitlab.com/group/project/-/issues/42", false},
+		{"https://linear.app/team/issue/PROJ-123", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := tr.IsExternalRef(tt.ref); got != tt.want {
+			t.Errorf("IsExternalRef(%q) = %v, want %v", tt.ref, got, tt.want)
+		}
+	}
+}
+
+func TestExtractIdentifier(t *testing.T) {
+	tr := &Tracker{}
+	tests := []struct {
+		ref  string
+		want string
+	}{
+		{"https://github.com/org/repo/issues/42", "42"},
+		{"https://github.com/team/project/issues/123", "123"},
+		{"not-a-url", ""},
+	}
+	for _, tt := range tests {
+		if got := tr.ExtractIdentifier(tt.ref); got != tt.want {
+			t.Errorf("ExtractIdentifier(%q) = %q, want %q", tt.ref, got, tt.want)
+		}
+	}
+}
+
+func TestBuildExternalRef(t *testing.T) {
+	tr := &Tracker{}
+	ti := &tracker.TrackerIssue{
+		URL:        "https://github.com/org/repo/issues/42",
+		Identifier: "42",
+	}
+	ref := tr.BuildExternalRef(ti)
+	if ref != ti.URL {
+		t.Errorf("BuildExternalRef() = %q, want %q", ref, ti.URL)
+	}
+
+	// Without URL, should use fallback
+	ti2 := &tracker.TrackerIssue{
+		Identifier: "42",
+	}
+	ref2 := tr.BuildExternalRef(ti2)
+	if ref2 != "github:42" {
+		t.Errorf("BuildExternalRef() = %q, want %q", ref2, "github:42")
+	}
+}
+
+func TestFieldMapperStatus(t *testing.T) {
+	m := &githubFieldMapper{config: DefaultMappingConfig()}
+
+	if got := m.StatusToBeads("open"); got != types.StatusOpen {
+		t.Errorf("StatusToBeads(open) = %q, want %q", got, types.StatusOpen)
+	}
+	if got := m.StatusToBeads("closed"); got != types.StatusClosed {
+		t.Errorf("StatusToBeads(closed) = %q, want %q", got, types.StatusClosed)
+	}
+}
+
+func TestFieldMapperPriority(t *testing.T) {
+	m := &githubFieldMapper{config: DefaultMappingConfig()}
+
+	if got := m.PriorityToBeads("critical"); got != 0 {
+		t.Errorf("PriorityToBeads(critical) = %d, want 0", got)
+	}
+	if got := m.PriorityToBeads("high"); got != 1 {
+		t.Errorf("PriorityToBeads(high) = %d, want 1", got)
+	}
+	if got := m.PriorityToBeads("low"); got != 3 {
+		t.Errorf("PriorityToBeads(low) = %d, want 3", got)
+	}
+}
+
+func TestFieldMapperType(t *testing.T) {
+	m := &githubFieldMapper{config: DefaultMappingConfig()}
+
+	if got := m.TypeToBeads("bug"); got != types.TypeBug {
+		t.Errorf("TypeToBeads(bug) = %q, want %q", got, types.TypeBug)
+	}
+	if got := m.TypeToBeads("feature"); got != types.TypeFeature {
+		t.Errorf("TypeToBeads(feature) = %q, want %q", got, types.TypeFeature)
+	}
+	if got := m.TypeToBeads("unknown"); got != types.TypeTask {
+		t.Errorf("TypeToBeads(unknown) = %q, want %q (default)", got, types.TypeTask)
+	}
+}
+
+func TestGitHubToTrackerIssue(t *testing.T) {
+	now := time.Now()
+	gh := &Issue{
+		ID:      100,
+		Number:  42,
+		Title:   "Fix pipeline",
+		Body:    "CI is broken",
+		State:   "open",
+		HTMLURL: "https://github.com/org/repo/issues/42",
+		Labels: []Label{
+			{Name: "bug"},
+			{Name: "priority::high"},
+		},
+		CreatedAt: &now,
+		UpdatedAt: &now,
+		Assignee:  &User{ID: 5, Login: "bob"},
+	}
+
+	ti := githubToTrackerIssue(gh)
+
+	if ti.ID != "100" {
+		t.Errorf("ID = %q, want %q", ti.ID, "100")
+	}
+	if ti.Identifier != "42" {
+		t.Errorf("Identifier = %q, want %q", ti.Identifier, "42")
+	}
+	if ti.Assignee != "bob" {
+		t.Errorf("Assignee = %q, want %q", ti.Assignee, "bob")
+	}
+	if ti.AssigneeID != strconv.Itoa(5) {
+		t.Errorf("AssigneeID = %q, want %q", ti.AssigneeID, "5")
+	}
+	if ti.Raw != gh {
+		t.Error("Raw should reference original github.Issue")
+	}
+	if len(ti.Labels) != 2 {
+		t.Errorf("Labels count = %d, want 2", len(ti.Labels))
+	}
+	if ti.URL != "https://github.com/org/repo/issues/42" {
+		t.Errorf("URL = %q, want GitHub URL", ti.URL)
+	}
+}
+
+func TestGitHubToTrackerIssue_ClosedWithTimestamp(t *testing.T) {
+	now := time.Now()
+	closedAt := now.Add(-time.Hour)
+	gh := &Issue{
+		ID:        200,
+		Number:    99,
+		Title:     "Closed issue",
+		State:     "closed",
+		CreatedAt: &now,
+		UpdatedAt: &now,
+		ClosedAt:  &closedAt,
+		HTMLURL:   "https://github.com/org/repo/issues/99",
+	}
+
+	ti := githubToTrackerIssue(gh)
+
+	if ti.CompletedAt == nil {
+		t.Fatal("CompletedAt is nil for closed issue, want non-nil")
+	}
+	if !ti.CompletedAt.Equal(closedAt) {
+		t.Errorf("CompletedAt = %v, want %v", ti.CompletedAt, closedAt)
+	}
+}
+
+func TestFieldMapperIssueToBeads(t *testing.T) {
+	m := &githubFieldMapper{config: DefaultMappingConfig()}
+
+	now := time.Now()
+	gh := &Issue{
+		ID:     100,
+		Number: 42,
+		Title:  "Test issue",
+		Body:   "Test body",
+		State:  "open",
+		Labels: []Label{
+			{Name: "type::bug"},
+			{Name: "priority::high"},
+		},
+		CreatedAt: &now,
+		UpdatedAt: &now,
+		HTMLURL:   "https://github.com/org/repo/issues/42",
+	}
+
+	ti := &tracker.TrackerIssue{
+		ID:         "100",
+		Identifier: "42",
+		Title:      "Test issue",
+		Raw:        gh,
+	}
+
+	conv := m.IssueToBeads(ti)
+	if conv == nil {
+		t.Fatal("IssueToBeads returned nil")
+	}
+	if conv.Issue == nil {
+		t.Fatal("IssueToBeads returned nil issue")
+	}
+	if conv.Issue.Title != "Test issue" {
+		t.Errorf("Issue.Title = %q, want %q", conv.Issue.Title, "Test issue")
+	}
+	if conv.Issue.IssueType != types.TypeBug {
+		t.Errorf("Issue.IssueType = %q, want %q", conv.Issue.IssueType, types.TypeBug)
+	}
+}
+
+func TestFieldMapperIssueToBeads_NilRaw(t *testing.T) {
+	m := &githubFieldMapper{config: DefaultMappingConfig()}
+
+	ti := &tracker.TrackerIssue{
+		ID:  "100",
+		Raw: nil, // Not a *github.Issue
+	}
+
+	conv := m.IssueToBeads(ti)
+	if conv != nil {
+		t.Error("IssueToBeads with nil Raw should return nil")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tr := &Tracker{}
+	if err := tr.Validate(); err == nil {
+		t.Error("Validate() on uninitialized tracker should return error")
+	}
+
+	tr.client = &Client{} // Set client
+	if err := tr.Validate(); err != nil {
+		t.Errorf("Validate() on initialized tracker returned error: %v", err)
+	}
+}

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -1,0 +1,272 @@
+// Package github provides client and data types for the GitHub REST API.
+//
+// This package handles all interactions with GitHub's issue tracking system,
+// including fetching, creating, and updating issues. It provides bidirectional
+// mapping between GitHub's data model and Beads' internal types.
+package github
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// API configuration constants.
+const (
+	// DefaultBaseURL is the GitHub API v3 base URL.
+	DefaultBaseURL = "https://api.github.com"
+
+	// DefaultTimeout is the default HTTP request timeout.
+	DefaultTimeout = 30 * time.Second
+
+	// MaxRetries is the maximum number of retries for rate-limited requests.
+	MaxRetries = 3
+
+	// RetryDelay is the base delay between retries (exponential backoff).
+	RetryDelay = time.Second
+
+	// MaxPerPage is the maximum number of issues to fetch per page.
+	MaxPerPage = 100
+
+	// MaxPages is the maximum number of pages to fetch before stopping.
+	// This prevents infinite loops from malformed Link headers.
+	MaxPages = 1000
+)
+
+// Client provides methods to interact with the GitHub REST API.
+type Client struct {
+	Token      string       // GitHub personal access token
+	BaseURL    string       // GitHub API base URL (e.g., "https://api.github.com")
+	Owner      string       // Repository owner (user or organization)
+	Repo       string       // Repository name
+	HTTPClient *http.Client // Optional custom HTTP client
+}
+
+// Issue represents an issue from the GitHub API.
+type Issue struct {
+	ID        int        `json:"id"`     // Global issue ID
+	Number    int        `json:"number"` // Repository-scoped issue number
+	Title     string     `json:"title"`
+	Body      string     `json:"body"`
+	State     string     `json:"state"` // "open", "closed"
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
+	ClosedAt  *time.Time `json:"closed_at,omitempty"`
+	Labels    []Label    `json:"labels"`
+	Assignee  *User      `json:"assignee,omitempty"`
+	Assignees []User     `json:"assignees,omitempty"`
+	User      *User      `json:"user,omitempty"` // Issue author
+	Milestone *Milestone `json:"milestone,omitempty"`
+	HTMLURL   string     `json:"html_url"`
+	Locked    bool       `json:"locked"`
+
+	// PullRequest is non-nil if this issue is actually a pull request.
+	// Used to filter PRs out of issue listings.
+	PullRequest *PullRequestRef `json:"pull_request,omitempty"`
+}
+
+// PullRequestRef is a minimal reference indicating an issue is a PR.
+type PullRequestRef struct {
+	URL string `json:"url,omitempty"`
+}
+
+// IsPullRequest returns true if this issue is actually a pull request.
+func (i *Issue) IsPullRequest() bool {
+	return i.PullRequest != nil
+}
+
+// LabelNames returns the names of all labels on this issue.
+func (i *Issue) LabelNames() []string {
+	names := make([]string, 0, len(i.Labels))
+	for _, l := range i.Labels {
+		names = append(names, l.Name)
+	}
+	return names
+}
+
+// User represents a GitHub user.
+type User struct {
+	ID        int    `json:"id"`
+	Login     string `json:"login"`
+	Name      string `json:"name,omitempty"`
+	Email     string `json:"email,omitempty"`
+	AvatarURL string `json:"avatar_url,omitempty"`
+	HTMLURL   string `json:"html_url,omitempty"`
+	Type      string `json:"type,omitempty"` // "User", "Organization", "Bot"
+}
+
+// Label represents a GitHub label.
+type Label struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Color       string `json:"color,omitempty"`
+	Description string `json:"description,omitempty"`
+	Default     bool   `json:"default,omitempty"`
+}
+
+// Milestone represents a GitHub milestone.
+type Milestone struct {
+	ID          int        `json:"id"`
+	Number      int        `json:"number"`
+	Title       string     `json:"title"`
+	Description string     `json:"description,omitempty"`
+	State       string     `json:"state"` // "open", "closed"
+	DueOn       *time.Time `json:"due_on,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+	HTMLURL     string     `json:"html_url,omitempty"`
+}
+
+// Repository represents a GitHub repository.
+type Repository struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	FullName      string `json:"full_name"` // "owner/repo"
+	Description   string `json:"description,omitempty"`
+	HTMLURL       string `json:"html_url"`
+	DefaultBranch string `json:"default_branch,omitempty"`
+	Private       bool   `json:"private"`
+	Owner         *User  `json:"owner,omitempty"`
+}
+
+// SyncStats tracks statistics for a GitHub sync operation.
+type SyncStats struct {
+	Pulled    int `json:"pulled"`
+	Pushed    int `json:"pushed"`
+	Created   int `json:"created"`
+	Updated   int `json:"updated"`
+	Skipped   int `json:"skipped"`
+	Errors    int `json:"errors"`
+	Conflicts int `json:"conflicts"`
+}
+
+// SyncResult represents the result of a GitHub sync operation.
+type SyncResult struct {
+	Success  bool      `json:"success"`
+	Stats    SyncStats `json:"stats"`
+	LastSync string    `json:"last_sync,omitempty"`
+	Error    string    `json:"error,omitempty"`
+	Warnings []string  `json:"warnings,omitempty"`
+}
+
+// PullStats tracks pull operation statistics.
+type PullStats struct {
+	Created     int
+	Updated     int
+	Skipped     int
+	Incremental bool     // Whether this was an incremental sync
+	SyncedSince string   // Timestamp we synced since (if incremental)
+	Warnings    []string // Non-fatal warnings encountered during pull
+}
+
+// PushStats tracks push operation statistics.
+type PushStats struct {
+	Created int
+	Updated int
+	Skipped int
+	Errors  int
+}
+
+// Conflict represents a conflict between local and GitHub versions.
+// A conflict occurs when both the local and GitHub versions have been modified
+// since the last sync.
+type Conflict struct {
+	IssueID           string    // Beads issue ID
+	LocalUpdated      time.Time // When the local version was last modified
+	GitHubUpdated     time.Time // When the GitHub version was last modified
+	GitHubExternalRef string    // URL to the GitHub issue
+	GitHubNumber      int       // GitHub issue number (repository-scoped)
+	GitHubID          int       // GitHub's global issue ID
+}
+
+// IssueConversion holds the result of converting a GitHub issue to Beads.
+// It includes the issue and any dependencies that should be created.
+type IssueConversion struct {
+	Issue        *types.Issue
+	Dependencies []DependencyInfo
+}
+
+// DependencyInfo represents a dependency to be created after issue import.
+// Stored separately since we need all issues imported before linking dependencies.
+type DependencyInfo struct {
+	FromGitHubNumber int    // GitHub number of the dependent issue
+	ToGitHubNumber   int    // GitHub number of the dependency target
+	Type             string // Beads dependency type (blocks, related, parent-child)
+}
+
+// Valid GitHub issue states.
+var validStates = map[string]bool{
+	"open":   true,
+	"closed": true,
+	"all":    true,
+}
+
+// isValidState checks if a GitHub state string is valid.
+func isValidState(state string) bool {
+	return validStates[state]
+}
+
+// parseLabelPrefix splits a label into prefix and value.
+// Labels like "priority::high" are split into ("priority", "high").
+// Labels without "::" return empty prefix and the original label as value.
+func parseLabelPrefix(label string) (prefix, value string) {
+	parts := strings.SplitN(label, "::", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", label
+}
+
+// PriorityMapping maps priority label values to beads priority (0-4).
+// This is the single source of truth for priority mappings.
+var PriorityMapping = map[string]int{
+	"critical": 0, // P0
+	"high":     1, // P1
+	"medium":   2, // P2
+	"low":      3, // P3
+	"none":     4, // P4
+}
+
+// StatusMapping maps status label values to beads status strings.
+// This is the single source of truth for status mappings.
+var StatusMapping = map[string]string{
+	"open":        "open",
+	"in_progress": "in_progress",
+	"blocked":     "blocked",
+	"deferred":    "deferred",
+	"closed":      "closed",
+}
+
+// typeMapping maps type label values to beads issue type strings.
+// This is the single source of truth for type mappings.
+var typeMapping = map[string]string{
+	"bug":         "bug",
+	"feature":     "feature",
+	"task":        "task",
+	"epic":        "epic",
+	"chore":       "chore",
+	"enhancement": "feature",
+}
+
+// getPriorityFromLabel returns the beads priority for a priority label value.
+// Returns -1 if the value is not recognized.
+func getPriorityFromLabel(value string) int {
+	if p, ok := PriorityMapping[strings.ToLower(value)]; ok {
+		return p
+	}
+	return -1
+}
+
+// getStatusFromLabel returns the beads status for a status label value.
+// Returns empty string if the value is not recognized.
+func getStatusFromLabel(value string) string {
+	return StatusMapping[strings.ToLower(value)]
+}
+
+// getTypeFromLabel returns the beads issue type for a type label value.
+// Returns empty string if the value is not recognized.
+func getTypeFromLabel(value string) string {
+	return typeMapping[strings.ToLower(value)]
+}

--- a/internal/github/types_test.go
+++ b/internal/github/types_test.go
@@ -1,0 +1,330 @@
+// Package github provides client and data types for the GitHub REST API.
+package github
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestIssueJSONUnmarshal verifies that GitHub API JSON responses
+// can be correctly unmarshaled into our Issue type.
+func TestIssueJSONUnmarshal(t *testing.T) {
+	jsonData := `{
+		"id": 123456,
+		"number": 42,
+		"title": "Fix authentication bug",
+		"body": "Users cannot log in with SSO",
+		"state": "open",
+		"created_at": "2024-01-15T10:30:00Z",
+		"updated_at": "2024-01-16T14:45:00Z",
+		"closed_at": null,
+		"labels": [
+			{"id": 1, "name": "bug", "color": "d73a4a"},
+			{"id": 2, "name": "priority::high", "color": "e11d48"}
+		],
+		"assignee": {
+			"id": 101,
+			"login": "jdoe",
+			"name": "John Doe",
+			"email": "jdoe@example.com"
+		},
+		"user": {
+			"id": 102,
+			"login": "alice",
+			"name": "Alice Smith"
+		},
+		"milestone": {
+			"id": 5,
+			"number": 1,
+			"title": "Sprint 5"
+		},
+		"html_url": "https://github.com/org/repo/issues/42"
+	}`
+
+	var issue Issue
+	err := json.Unmarshal([]byte(jsonData), &issue)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal issue: %v", err)
+	}
+
+	if issue.ID != 123456 {
+		t.Errorf("ID = %d, want 123456", issue.ID)
+	}
+	if issue.Number != 42 {
+		t.Errorf("Number = %d, want 42", issue.Number)
+	}
+	if issue.Title != "Fix authentication bug" {
+		t.Errorf("Title = %q, want %q", issue.Title, "Fix authentication bug")
+	}
+	if issue.Body != "Users cannot log in with SSO" {
+		t.Errorf("Body = %q, want %q", issue.Body, "Users cannot log in with SSO")
+	}
+	if issue.State != "open" {
+		t.Errorf("State = %q, want %q", issue.State, "open")
+	}
+	if issue.HTMLURL != "https://github.com/org/repo/issues/42" {
+		t.Errorf("HTMLURL = %q, want %q", issue.HTMLURL, "https://github.com/org/repo/issues/42")
+	}
+
+	// Verify labels
+	if len(issue.Labels) != 2 {
+		t.Errorf("Labels count = %d, want 2", len(issue.Labels))
+	}
+	if issue.Labels[0].Name != "bug" {
+		t.Errorf("Labels[0].Name = %q, want %q", issue.Labels[0].Name, "bug")
+	}
+
+	// Verify assignee
+	if issue.Assignee == nil {
+		t.Fatal("Assignee is nil, want non-nil")
+	}
+	if issue.Assignee.Login != "jdoe" {
+		t.Errorf("Assignee.Login = %q, want %q", issue.Assignee.Login, "jdoe")
+	}
+
+	// Verify author
+	if issue.User == nil {
+		t.Fatal("User is nil, want non-nil")
+	}
+	if issue.User.Login != "alice" {
+		t.Errorf("User.Login = %q, want %q", issue.User.Login, "alice")
+	}
+
+	// Verify milestone
+	if issue.Milestone == nil {
+		t.Fatal("Milestone is nil, want non-nil")
+	}
+	if issue.Milestone.Title != "Sprint 5" {
+		t.Errorf("Milestone.Title = %q, want %q", issue.Milestone.Title, "Sprint 5")
+	}
+}
+
+// TestIsPullRequest verifies that issues with pull_request field are detected.
+func TestIsPullRequest(t *testing.T) {
+	issue := &Issue{Number: 1}
+	if issue.IsPullRequest() {
+		t.Error("IsPullRequest() = true for regular issue, want false")
+	}
+
+	issue.PullRequest = &PullRequestRef{URL: "https://api.github.com/repos/org/repo/pulls/1"}
+	if !issue.IsPullRequest() {
+		t.Error("IsPullRequest() = false for PR, want true")
+	}
+}
+
+// TestLabelNames verifies label name extraction.
+func TestLabelNames(t *testing.T) {
+	issue := &Issue{
+		Labels: []Label{
+			{Name: "bug"},
+			{Name: "priority::high"},
+			{Name: "help wanted"},
+		},
+	}
+
+	names := issue.LabelNames()
+	if len(names) != 3 {
+		t.Fatalf("LabelNames() returned %d names, want 3", len(names))
+	}
+	if names[0] != "bug" {
+		t.Errorf("names[0] = %q, want %q", names[0], "bug")
+	}
+	if names[1] != "priority::high" {
+		t.Errorf("names[1] = %q, want %q", names[1], "priority::high")
+	}
+}
+
+// TestClientConfig verifies client configuration defaults.
+func TestClientConfig(t *testing.T) {
+	client := &Client{
+		Token:   "test-token",
+		BaseURL: "https://api.github.com",
+		Owner:   "myorg",
+		Repo:    "myrepo",
+	}
+
+	if client.Token != "test-token" {
+		t.Errorf("Token = %q, want %q", client.Token, "test-token")
+	}
+	if client.BaseURL != "https://api.github.com" {
+		t.Errorf("BaseURL = %q, want %q", client.BaseURL, "https://api.github.com")
+	}
+	if client.Owner != "myorg" {
+		t.Errorf("Owner = %q, want %q", client.Owner, "myorg")
+	}
+	if client.Repo != "myrepo" {
+		t.Errorf("Repo = %q, want %q", client.Repo, "myrepo")
+	}
+}
+
+// TestSyncStatsZeroValue verifies SyncStats initializes correctly.
+func TestSyncStatsZeroValue(t *testing.T) {
+	stats := SyncStats{}
+	if stats.Pulled != 0 {
+		t.Errorf("Pulled = %d, want 0", stats.Pulled)
+	}
+	if stats.Pushed != 0 {
+		t.Errorf("Pushed = %d, want 0", stats.Pushed)
+	}
+}
+
+// TestConflictFields verifies Conflict type has required fields.
+func TestConflictFields(t *testing.T) {
+	now := time.Now()
+	conflict := Conflict{
+		IssueID:           "bd-abc123",
+		LocalUpdated:      now,
+		GitHubUpdated:     now.Add(time.Hour),
+		GitHubExternalRef: "https://github.com/org/repo/issues/42",
+		GitHubNumber:      42,
+		GitHubID:          123456,
+	}
+
+	if conflict.IssueID != "bd-abc123" {
+		t.Errorf("IssueID = %q, want %q", conflict.IssueID, "bd-abc123")
+	}
+	if conflict.GitHubNumber != 42 {
+		t.Errorf("GitHubNumber = %d, want 42", conflict.GitHubNumber)
+	}
+}
+
+// TestStateMapping verifies GitHub states map to expected values.
+func TestStateMapping(t *testing.T) {
+	tests := []struct {
+		state     string
+		wantValid bool
+	}{
+		{"open", true},
+		{"closed", true},
+		{"all", true},
+		{"invalid", false},
+		{"opened", false}, // GitHub doesn't use "opened"
+	}
+
+	for _, tt := range tests {
+		got := isValidState(tt.state)
+		if got != tt.wantValid {
+			t.Errorf("isValidState(%q) = %v, want %v", tt.state, got, tt.wantValid)
+		}
+	}
+}
+
+// TestLabelParsing verifies label prefix parsing for priority/status mapping.
+func TestLabelParsing(t *testing.T) {
+	tests := []struct {
+		label      string
+		wantPrefix string
+		wantValue  string
+	}{
+		{"priority::high", "priority", "high"},
+		{"status::in_progress", "status", "in_progress"},
+		{"type::bug", "type", "bug"},
+		{"simple-label", "", "simple-label"},
+		{"no-prefix", "", "no-prefix"},
+	}
+
+	for _, tt := range tests {
+		prefix, value := parseLabelPrefix(tt.label)
+		if prefix != tt.wantPrefix {
+			t.Errorf("parseLabelPrefix(%q) prefix = %q, want %q", tt.label, prefix, tt.wantPrefix)
+		}
+		if value != tt.wantValue {
+			t.Errorf("parseLabelPrefix(%q) value = %q, want %q", tt.label, value, tt.wantValue)
+		}
+	}
+}
+
+// TestGetPriorityFromLabel verifies priority label value to beads priority mapping.
+func TestGetPriorityFromLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		want  int
+	}{
+		{"critical", 0},
+		{"CRITICAL", 0},
+		{"high", 1},
+		{"High", 1},
+		{"medium", 2},
+		{"low", 3},
+		{"none", 4},
+		{"invalid", -1},
+		{"", -1},
+	}
+
+	for _, tt := range tests {
+		got := getPriorityFromLabel(tt.value)
+		if got != tt.want {
+			t.Errorf("getPriorityFromLabel(%q) = %d, want %d", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestGetStatusFromLabel verifies status label value to beads status mapping.
+func TestGetStatusFromLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"open", "open"},
+		{"OPEN", "open"},
+		{"in_progress", "in_progress"},
+		{"blocked", "blocked"},
+		{"deferred", "deferred"},
+		{"closed", "closed"},
+		{"invalid", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := getStatusFromLabel(tt.value)
+		if got != tt.want {
+			t.Errorf("getStatusFromLabel(%q) = %q, want %q", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestGetTypeFromLabel verifies type label value to beads issue type mapping.
+func TestGetTypeFromLabel(t *testing.T) {
+	tests := []struct {
+		value string
+		want  string
+	}{
+		{"bug", "bug"},
+		{"BUG", "bug"},
+		{"feature", "feature"},
+		{"task", "task"},
+		{"epic", "epic"},
+		{"chore", "chore"},
+		{"enhancement", "feature"},
+		{"invalid", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := getTypeFromLabel(tt.value)
+		if got != tt.want {
+			t.Errorf("getTypeFromLabel(%q) = %q, want %q", tt.value, got, tt.want)
+		}
+	}
+}
+
+// TestIssueConversion verifies IssueConversion struct field access.
+func TestIssueConversion(t *testing.T) {
+	conversion := &IssueConversion{
+		Issue: &types.Issue{
+			Title:       "Test issue",
+			Description: "Test description",
+		},
+		Dependencies: []DependencyInfo{},
+	}
+
+	if conversion.Issue == nil {
+		t.Fatal("Issue field is nil, want *types.Issue")
+	}
+	if conversion.Issue.Title != "Test issue" {
+		t.Errorf("Issue.Title = %q, want %q", conversion.Issue.Title, "Test issue")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the `tracker.IssueTracker` and `tracker.FieldMapper` interfaces for GitHub Issues, following the existing GitLab integration pattern
- Adds `bd github sync/status/repos` CLI commands for bidirectional issue synchronization
- Uses scoped labels (`priority::high`, `type::bug`, `status::in_progress`) for field mapping, consistent with the GitLab approach

## New Files

### `internal/github/` package
| File | Description |
|------|-------------|
| `types.go` | GitHub API types (Issue, User, Label, Milestone, Repository), constants, and label parsing helpers |
| `client.go` | REST API client with pagination (Link header), retry with exponential backoff, rate-limit handling (Retry-After), PR filtering |
| `mapping.go` | `MappingConfig`, `GitHubIssueToBeads()`, `BeadsIssueToGitHubFields()`, label extraction functions |
| `fieldmapper.go` | `githubFieldMapper` implementing `tracker.FieldMapper` for bidirectional priority/status/type conversion |
| `tracker.go` | `Tracker` implementing `tracker.IssueTracker` with `tracker.Register("github", ...)` auto-registration |

### `cmd/bd/github.go` - CLI commands
| Command | Description |
|---------|-------------|
| `bd github sync` | Bidirectional sync with `--pull-only`, `--push-only`, `--dry-run`, `--prefer-local/--prefer-github/--prefer-newer` |
| `bd github status` | Show GitHub configuration and connection status |
| `bd github repos` | List accessible repositories for the configured token |

## Configuration

```bash
bd config github.token <token>       # or GITHUB_TOKEN env var
bd config github.owner <owner>       # or GITHUB_OWNER env var
bd config github.repo <repo>         # or GITHUB_REPO env var
bd config github.repository owner/repo  # or GITHUB_REPOSITORY (combined format)
bd config github.url <url>           # GitHub Enterprise API URL (optional)
```

## Design Decisions

- **Mirrors GitLab pattern exactly**: Same interface implementations, same label-based mapping approach, same CLI flag structure
- **PR filtering**: GitHub's Issues API includes pull requests; the client filters them out automatically
- **GitHub Enterprise support**: Optional `github.url` config for custom API base URLs
- **Combined owner/repo**: Supports both separate `github.owner`/`github.repo` and combined `github.repository` (owner/repo) format

## Test plan

- [x] `go vet ./internal/github/... ./cmd/bd/...` passes
- [x] 32 unit tests pass covering types, mapping, field mapper, tracker, and CLI
- [x] Existing GitLab tests unaffected
- [x] Tracker registry test confirms `tracker.Get("github")` returns the factory
- [ ] Manual integration test with a real GitHub repository (requires token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)