### PR TITLE
fix(circuit): reduce cooldown to 5s and add active TCP health probe

### DIFF
--- a/internal/storage/dolt/circuit.go
+++ b/internal/storage/dolt/circuit.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -28,7 +29,8 @@ const (
 	circuitFailureWindow = 60 * time.Second
 
 	// circuitCooldown is how long to stay open before allowing a half-open probe.
-	circuitCooldown = 30 * time.Second
+	// Keep this short — planned restarts (e.g. gt dolt sync) only take 2-3s.
+	circuitCooldown = 5 * time.Second
 )
 
 // circuitState is the shared file-based circuit breaker state.
@@ -65,6 +67,11 @@ func newCircuitBreaker(port int) *circuitBreaker {
 // Allow checks whether a request should be allowed through.
 // Returns true if the circuit is closed or half-open (probe allowed).
 // Returns false if the circuit is open and cooldown hasn't elapsed.
+//
+// When the cooldown elapses, Allow performs an active TCP health probe
+// rather than passively waiting for the next request to succeed or fail.
+// If the probe succeeds, the breaker resets to closed immediately. This
+// avoids the half-open→open re-trip race that can leave the breaker stuck.
 func (cb *circuitBreaker) Allow() bool {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
@@ -73,20 +80,52 @@ func (cb *circuitBreaker) Allow() bool {
 	switch state.State {
 	case circuitOpen:
 		if time.Since(state.TrippedAt) >= circuitCooldown {
-			// Cooldown elapsed — transition to half-open, allow one probe
-			state.State = circuitHalfOpen
+			// Cooldown elapsed — actively probe the server
+			if cb.probe() {
+				state.State = circuitClosed
+				state.Failures = 0
+				state.FirstFailure = time.Time{}
+				cb.writeState(state)
+				log.Printf("[circuit-breaker] port %d: open → closed (active probe succeeded)", cb.port)
+				return true
+			}
+			// Probe failed — stay open, reset the tripped timer
+			state.TrippedAt = time.Now()
 			cb.writeState(state)
-			log.Printf("[circuit-breaker] port %d: open → half-open (cooldown elapsed, allowing probe)", cb.port)
-			return true
+			log.Printf("[circuit-breaker] port %d: open → open (active probe failed, cooldown reset)", cb.port)
+			return false
 		}
 		return false
 	case circuitHalfOpen:
-		// Only one probe at a time — reject additional requests while probing.
-		// The probe caller will call RecordSuccess or RecordFailure.
+		// Legacy state from older breaker versions — treat as open with
+		// immediate probe since we no longer use half-open passively.
+		if cb.probe() {
+			state.State = circuitClosed
+			state.Failures = 0
+			state.FirstFailure = time.Time{}
+			cb.writeState(state)
+			log.Printf("[circuit-breaker] port %d: half-open → closed (active probe succeeded)", cb.port)
+			return true
+		}
+		state.State = circuitOpen
+		state.TrippedAt = time.Now()
+		cb.writeState(state)
+		log.Printf("[circuit-breaker] port %d: half-open → open (active probe failed)", cb.port)
 		return false
 	default:
 		return true
 	}
+}
+
+// probe performs a quick TCP dial to check if the Dolt server is reachable.
+func (cb *circuitBreaker) probe() bool {
+	addr := fmt.Sprintf("127.0.0.1:%d", cb.port)
+	conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 // RecordSuccess records a successful connection. Resets the breaker to closed.

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -2,6 +2,7 @@ package dolt
 
 import (
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,7 +73,7 @@ func TestCircuitBreaker_SuccessResets(t *testing.T) {
 	}
 }
 
-func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
+func TestCircuitBreaker_ActiveProbeAfterCooldown_NoServer(t *testing.T) {
 	cb := newTestCircuitBreaker(t)
 
 	// Trip the breaker
@@ -90,66 +91,73 @@ func TestCircuitBreaker_HalfOpenAfterCooldown(t *testing.T) {
 	cb.writeState(state)
 	cb.mu.Unlock()
 
-	// Should transition to half-open and allow one probe
-	if !cb.Allow() {
-		t.Fatal("breaker should allow probe after cooldown")
-	}
-	if cb.State() != circuitHalfOpen {
-		t.Fatalf("expected half-open, got %q", cb.State())
-	}
-
-	// Second request in half-open should be rejected
+	// With no server listening, active probe fails — stays open
 	if cb.Allow() {
-		t.Fatal("half-open breaker should reject non-probe requests")
+		t.Fatal("breaker should reject when active probe fails (no server)")
+	}
+	if cb.State() != circuitOpen {
+		t.Fatalf("expected open after failed probe, got %q", cb.State())
 	}
 }
 
-func TestCircuitBreaker_HalfOpenProbeSuccess(t *testing.T) {
-	cb := newTestCircuitBreaker(t)
+func TestCircuitBreaker_ActiveProbeAfterCooldown_ServerUp(t *testing.T) {
+	// Start a TCP listener to simulate a healthy server
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
 
-	// Trip and simulate cooldown
+	cb := newTestCircuitBreakerOnPort(t, port)
+
+	// Trip the breaker
 	for i := 0; i < circuitFailureThreshold; i++ {
 		cb.RecordFailure()
 	}
+
+	// Simulate cooldown
 	cb.mu.Lock()
 	state := cb.readState()
 	state.TrippedAt = time.Now().Add(-circuitCooldown - time.Second)
 	cb.writeState(state)
 	cb.mu.Unlock()
 
-	// Allow probe
-	cb.Allow()
-	// Probe succeeds
-	cb.RecordSuccess()
-
+	// Active probe should succeed — transitions directly to closed
+	if !cb.Allow() {
+		t.Fatal("breaker should allow after successful active probe")
+	}
 	if cb.State() != circuitClosed {
 		t.Fatalf("expected closed after successful probe, got %q", cb.State())
 	}
-	if !cb.Allow() {
-		t.Fatal("should allow requests after probe success")
-	}
 }
 
-func TestCircuitBreaker_HalfOpenProbeFailure(t *testing.T) {
-	cb := newTestCircuitBreaker(t)
-
-	// Trip and simulate cooldown
-	for i := 0; i < circuitFailureThreshold; i++ {
-		cb.RecordFailure()
+func TestCircuitBreaker_LegacyHalfOpenState(t *testing.T) {
+	// If a state file has half-open from an older version, the breaker
+	// should handle it gracefully via active probe.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
 	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cb := newTestCircuitBreakerOnPort(t, port)
+
+	// Manually write a half-open state (simulating old breaker)
 	cb.mu.Lock()
-	state := cb.readState()
-	state.TrippedAt = time.Now().Add(-circuitCooldown - time.Second)
-	cb.writeState(state)
+	cb.writeState(circuitState{
+		State:    circuitHalfOpen,
+		Failures: circuitFailureThreshold,
+	})
 	cb.mu.Unlock()
 
-	// Allow probe
-	cb.Allow()
-	// Probe fails — should re-trip
-	cb.RecordFailure()
-
-	if cb.State() != circuitOpen {
-		t.Fatalf("expected open after failed probe, got %q", cb.State())
+	// With server up, probe succeeds → closed
+	if !cb.Allow() {
+		t.Fatal("legacy half-open with server up should allow via active probe")
+	}
+	if cb.State() != circuitClosed {
+		t.Fatalf("expected closed, got %q", cb.State())
 	}
 }
 
@@ -246,11 +254,22 @@ func TestIsConnectionError(t *testing.T) {
 }
 
 // newTestCircuitBreaker creates a circuit breaker with a temp file for testing.
+// Uses port 99999 which has no listener, so active probes will fail.
 func newTestCircuitBreaker(t *testing.T) *circuitBreaker {
 	t.Helper()
 	dir := t.TempDir()
 	return &circuitBreaker{
 		port:     99999,
+		filePath: filepath.Join(dir, "circuit.json"),
+	}
+}
+
+// newTestCircuitBreakerOnPort creates a circuit breaker targeting a specific port.
+func newTestCircuitBreakerOnPort(t *testing.T, port int) *circuitBreaker {
+	t.Helper()
+	dir := t.TempDir()
+	return &circuitBreaker{
+		port:     port,
 		filePath: filepath.Join(dir, "circuit.json"),
 	}
 }


### PR DESCRIPTION
## Summary

- Reduce circuit breaker cooldown from 30s to 5s — the previous value was too punishing for planned server restarts (e.g. `gt dolt sync` takes ~2-3s)
- Replace passive half-open state with an active TCP dial probe when cooldown elapses, avoiding the half-open→open re-trip race that can leave the breaker permanently stuck
- Handle legacy half-open state files gracefully (active probe instead of passive wait)

## Changes

- `internal/storage/dolt/circuit.go`: Reduce `circuitCooldown` constant, add `probe()` method, rewrite `Allow()` to use active probing
- `internal/storage/dolt/circuit_test.go`: Updated tests for active probe behavior, added server-up/server-down probe tests

## Test plan

- [x] All circuit breaker tests pass (`go test ./internal/storage/dolt/ -run TestCircuit`)
- [x] Build passes (`CGO_ENABLED=0 go build ./cmd/bd/`)
- [x] golangci-lint passes (0 issues)
- [ ] Manual verification: trip breaker during `gt dolt sync`, confirm recovery in ~5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)