### PR TITLE
fix: use ExtractIssuePrefix for hash extraction in ResolvePartialID

### DIFF
--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -112,9 +112,12 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 
 		// Extract hash from each issue, regardless of its prefix
 		// This handles cross-prefix matching (e.g., "3d0" matching "offlinebrew-3d0")
+		// Use ExtractIssuePrefix to correctly handle multi-dash prefixes
+		// (e.g., "hacker-news-ko4" → hash "ko4", not "news-ko4")
 		var issueHash string
-		if idx := strings.Index(issue.ID, "-"); idx >= 0 {
-			issueHash = issue.ID[idx+1:]
+		issuePrefix := ExtractIssuePrefix(issue.ID)
+		if issuePrefix != "" && len(issue.ID) > len(issuePrefix)+1 {
+			issueHash = issue.ID[len(issuePrefix)+1:] // +1 for the hyphen
 		} else {
 			issueHash = issue.ID
 		}
@@ -149,8 +152,9 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 					return w.ID, nil
 				}
 				var wHash string
-				if idx := strings.Index(w.ID, "-"); idx >= 0 {
-					wHash = w.ID[idx+1:]
+				wPrefix := ExtractIssuePrefix(w.ID)
+				if wPrefix != "" && len(w.ID) > len(wPrefix)+1 {
+					wHash = w.ID[len(wPrefix)+1:] // +1 for the hyphen
 				} else {
 					wHash = w.ID
 				}

--- a/internal/utils/id_parser_test.go
+++ b/internal/utils/id_parser_test.go
@@ -694,6 +694,79 @@ func TestResolvePartialID_CrossPrefix(t *testing.T) {
 	}
 }
 
+// TestResolvePartialID_MultiDashPrefix verifies that partial ID resolution
+// correctly extracts the hash from issues with multi-dash prefixes.
+// Previously, strings.Index split on the first hyphen, so "hacker-news-ko4"
+// yielded hash "news-ko4" instead of "ko4".
+func TestResolvePartialID_MultiDashPrefix(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	hackerNews := &types.Issue{
+		ID:        "hacker-news-ko4",
+		Title:     "Hacker News item",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	pyToolkit := &types.Issue{
+		ID:        "me-py-toolkit-abcd",
+		Title:     "Python toolkit issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+
+	if err := store.CreateIssue(ctx, hackerNews, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateIssue(ctx, pyToolkit, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", "bd"); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "short hash resolves multi-dash prefix (ko4 -> hacker-news-ko4)",
+			input:    "ko4",
+			expected: "hacker-news-ko4",
+		},
+		{
+			name:     "short hash resolves multi-dash prefix (abcd -> me-py-toolkit-abcd)",
+			input:    "abcd",
+			expected: "me-py-toolkit-abcd",
+		},
+		{
+			name:     "full multi-dash ID resolves exactly",
+			input:    "hacker-news-ko4",
+			expected: "hacker-news-ko4",
+		},
+		{
+			name:     "full multi-dash ID resolves exactly (toolkit)",
+			input:    "me-py-toolkit-abcd",
+			expected: "me-py-toolkit-abcd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolvePartialID(ctx, store, tt.input)
+			if err != nil {
+				t.Errorf("ResolvePartialID(%q) unexpected error: %v", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("ResolvePartialID(%q) = %q; want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 // TestResolvePartialID_Wisp verifies that wisps (ephemeral issues) are resolvable
 // by partial ID. This exercises the explicit wisp fallback in ResolvePartialID.
 func TestResolvePartialID_Wisp(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix bug where `ResolvePartialID` splits on the first hyphen when checking database issues, which breaks partial matching for multi-dash IDs (e.g., extracting `news-ko4` instead of `ko4` from `hacker-news-ko4`)
- Replace `strings.Index(issue.ID, "-")` with `ExtractIssuePrefix` to accurately separate the prefix from the hash, in both the main loop and the wisp fallback block
- Add `TestResolvePartialID_MultiDashPrefix` with test cases for `hacker-news-ko4` and `me-py-toolkit-abcd`

### What improves
Users can now use short hashes (e.g., `ko4`) to resolve issues that have multi-dash prefixes (e.g., `hacker-news-ko4`). Previously, the system incorrectly thought the hash was `news-ko4`.

### Edge cases
If a user has a legacy issue ID that intentionally uses a word-like suffix (e.g., `vc-baseline-test`), `ExtractIssuePrefix` will correctly identify `vc` as the prefix and `baseline-test` as the hash. This is actually more correct, but it changes the behavior from the old buggy `Index` split.

## Test plan
- [ ] Verify `ko4` resolves to `hacker-news-ko4` in test
- [ ] Verify `abcd` resolves to `me-py-toolkit-abcd` in test
- [ ] Verify existing cross-prefix and wisp tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)