### PR TITLE
fix: config-aware prefix detection in ResolvePartialID

### DIFF
--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -62,15 +62,33 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 		prefixWithHyphen = prefix + "-"
 	}
 
+	// Build known prefixes from config for deterministic multi-hyphen prefix handling.
+	// This avoids relying solely on looksLikePrefixedID heuristics when the repo
+	// explicitly declares which prefixes are valid.
+	knownPrefixes := []string{strings.TrimSuffix(prefix, "-")}
+	if allowed, aErr := store.GetConfig(ctx, "allowed_prefixes"); aErr == nil && allowed != "" {
+		for _, p := range strings.Split(allowed, ",") {
+			p = strings.TrimSpace(p)
+			p = strings.TrimSuffix(p, "-")
+			if p != "" {
+				knownPrefixes = append(knownPrefixes, p)
+			}
+		}
+	}
+
 	// Normalize input:
 	// 1. If it has the full prefix with hyphen (bd-a3f8e9), use as-is
-	// 2. If it has ANY prefix (different from configured), use as-is for cross-prefix lookup
-	// 3. Otherwise, add prefix with hyphen (handles both bare hashes and prefix-without-hyphen cases)
+	// 2. If it starts with any known/allowed prefix, use as-is (config-aware cross-prefix)
+	// 3. If it has ANY prefix (heuristic fallback), use as-is for cross-prefix lookup
+	// 4. Otherwise, add prefix with hyphen (handles both bare hashes and prefix-without-hyphen cases)
 
 	var normalizedID string
 
 	if strings.HasPrefix(input, prefixWithHyphen) {
 		// Already has configured prefix with hyphen: "bd-a3f8e9"
+		normalizedID = input
+	} else if hasKnownPrefix(input, knownPrefixes) {
+		// Starts with a known/allowed prefix (e.g., "hacker-news-ko4" when allowed_prefixes includes "hacker-news")
 		normalizedID = input
 	} else if looksLikePrefixedID(input) {
 		// Has a different prefix (e.g., "aap-4ar" when configured prefix is "hq-")
@@ -110,11 +128,12 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 			break
 		}
 
-		// Extract hash from each issue, regardless of its prefix
-		// This handles cross-prefix matching (e.g., "3d0" matching "offlinebrew-3d0")
+		// Extract hash from each issue using config-aware prefix extraction.
+		// This correctly handles multi-hyphen prefixes (e.g., "hacker-news-ko4"
+		// yields hash "ko4", not "news-ko4" from naive first-hyphen split).
 		var issueHash string
-		if idx := strings.Index(issue.ID, "-"); idx >= 0 {
-			issueHash = issue.ID[idx+1:]
+		if p := ExtractIssuePrefixKnown(issue.ID, knownPrefixes); p != "" && strings.HasPrefix(issue.ID, p+"-") {
+			issueHash = issue.ID[len(p)+1:]
 		} else {
 			issueHash = issue.ID
 		}
@@ -149,8 +168,8 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 					return w.ID, nil
 				}
 				var wHash string
-				if idx := strings.Index(w.ID, "-"); idx >= 0 {
-					wHash = w.ID[idx+1:]
+				if p := ExtractIssuePrefixKnown(w.ID, knownPrefixes); p != "" && strings.HasPrefix(w.ID, p+"-") {
+					wHash = w.ID[len(p)+1:]
 				} else {
 					wHash = w.ID
 				}
@@ -223,4 +242,16 @@ func looksLikePrefixedID(input string) bool {
 	}
 
 	return true
+}
+
+// hasKnownPrefix checks if input starts with any of the known prefixes followed
+// by a hyphen. Used to detect already-prefixed input before falling back to the
+// looksLikePrefixedID heuristic.
+func hasKnownPrefix(input string, knownPrefixes []string) bool {
+	for _, p := range knownPrefixes {
+		if p != "" && strings.HasPrefix(input, p+"-") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/utils/id_parser_test.go
+++ b/internal/utils/id_parser_test.go
@@ -517,6 +517,80 @@ func TestExtractIssuePrefix(t *testing.T) {
 	}
 }
 
+func TestExtractIssuePrefixKnown(t *testing.T) {
+	tests := []struct {
+		name          string
+		issueID       string
+		knownPrefixes []string
+		expected      string
+	}{
+		{
+			name:          "known prefix matches multi-dash",
+			issueID:       "me-py-toolkit-abcd",
+			knownPrefixes: []string{"me-py-toolkit"},
+			expected:      "me-py-toolkit",
+		},
+		{
+			name:          "overlapping prefixes: longest wins",
+			issueID:       "hq-cv-test",
+			knownPrefixes: []string{"hq", "hq-cv"},
+			expected:      "hq-cv",
+		},
+		{
+			name:          "overlapping prefixes reversed order: longest still wins",
+			issueID:       "hq-cv-test",
+			knownPrefixes: []string{"hq-cv", "hq"},
+			expected:      "hq-cv",
+		},
+		{
+			name:          "no known prefix: falls back to heuristic",
+			issueID:       "vc-baseline-test",
+			knownPrefixes: []string{"bd"},
+			expected:      "vc", // heuristic: word-like suffix falls back to first hyphen
+		},
+		{
+			name:          "known prefix with trailing hyphen is normalized",
+			issueID:       "hacker-news-ko4",
+			knownPrefixes: []string{"hacker-news-"},
+			expected:      "hacker-news",
+		},
+		{
+			name:          "known prefix with whitespace is normalized",
+			issueID:       "hacker-news-ko4",
+			knownPrefixes: []string{" hacker-news "},
+			expected:      "hacker-news",
+		},
+		{
+			name:          "empty known prefixes: falls back to heuristic",
+			issueID:       "bd-a3f8e9",
+			knownPrefixes: nil,
+			expected:      "bd", // heuristic result
+		},
+		{
+			name:          "simple known prefix",
+			issueID:       "bd-a3f8e9",
+			knownPrefixes: []string{"bd"},
+			expected:      "bd",
+		},
+		{
+			name:          "known prefix among several",
+			issueID:       "hacker-news-ko4",
+			knownPrefixes: []string{"bd", "gt", "hacker-news"},
+			expected:      "hacker-news",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractIssuePrefixKnown(tt.issueID, tt.knownPrefixes)
+			if result != tt.expected {
+				t.Errorf("ExtractIssuePrefixKnown(%q, %v) = %q; want %q",
+					tt.issueID, tt.knownPrefixes, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestExtractIssueNumber(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -689,6 +763,105 @@ func TestResolvePartialID_CrossPrefix(t *testing.T) {
 				if result != tt.expected {
 					t.Errorf("ResolvePartialID(%q) = %q; want %q", tt.input, result, tt.expected)
 				}
+			}
+		})
+	}
+}
+
+// TestResolvePartialID_AllowedPrefixes verifies that config-aware prefix detection
+// in ResolvePartialID correctly handles multi-hyphen prefixes when allowed_prefixes
+// is set. This exercises both the normalization path (hasKnownPrefix) and the
+// hash extraction path (ExtractIssuePrefixKnown).
+func TestResolvePartialID_AllowedPrefixes(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Create issues with multi-hyphen prefixes
+	hackerNews := &types.Issue{
+		ID:        "hacker-news-ko4",
+		Title:     "Hacker News item",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	pyToolkit := &types.Issue{
+		ID:        "me-py-toolkit-a1b",
+		Title:     "Python toolkit issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	hqCvIssue := &types.Issue{
+		ID:        "hq-cv-7x2",
+		Title:     "HQ CV issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+
+	if err := store.CreateIssue(ctx, hackerNews, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateIssue(ctx, pyToolkit, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateIssue(ctx, hqCvIssue, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure primary prefix and allowed prefixes
+	if err := store.SetConfig(ctx, "issue_prefix", "hq"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetConfig(ctx, "allowed_prefixes", "hacker-news, me-py-toolkit, hq-cv"); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "short hash resolves multi-dash prefix (ko4 -> hacker-news-ko4)",
+			input:    "ko4",
+			expected: "hacker-news-ko4",
+		},
+		{
+			name:     "short hash resolves multi-dash prefix (a1b -> me-py-toolkit-a1b)",
+			input:    "a1b",
+			expected: "me-py-toolkit-a1b",
+		},
+		{
+			name:     "full multi-dash ID is not mangled (hacker-news-ko4)",
+			input:    "hacker-news-ko4",
+			expected: "hacker-news-ko4",
+		},
+		{
+			name:     "full allowed-prefix ID resolves as-is (me-py-toolkit-a1b)",
+			input:    "me-py-toolkit-a1b",
+			expected: "me-py-toolkit-a1b",
+		},
+		{
+			name:     "overlapping prefix: hq-cv-7x2 not mangled to hq-hq-cv-7x2",
+			input:    "hq-cv-7x2",
+			expected: "hq-cv-7x2",
+		},
+		{
+			name:     "short hash with overlapping prefix (7x2 -> hq-cv-7x2)",
+			input:    "7x2",
+			expected: "hq-cv-7x2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolvePartialID(ctx, store, tt.input)
+			if err != nil {
+				t.Errorf("ResolvePartialID(%q) unexpected error: %v", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("ResolvePartialID(%q) = %q; want %q", tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/internal/utils/issue_id.go
+++ b/internal/utils/issue_id.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -95,6 +96,41 @@ func isLikelyHash(s string) bool {
 		}
 	}
 	return hasDigit
+}
+
+// ExtractIssuePrefixKnown extracts the prefix from an issue ID using a list of
+// known-valid prefixes before falling back to the heuristic ExtractIssuePrefix.
+//
+// When the valid prefixes are known from config (issue_prefix + allowed_prefixes),
+// this gives deterministic results for multi-hyphen prefixes that the heuristic
+// might misclassify (e.g., "me-py-toolkit-abcd" where "abcd" looks word-like).
+//
+// Prefixes are checked longest-first so overlapping entries (e.g., "hq" and "hq-cv")
+// resolve to the most specific match.
+func ExtractIssuePrefixKnown(issueID string, knownPrefixes []string) string {
+	// Normalize: trim whitespace, strip trailing hyphens, drop empties
+	var cleaned []string
+	for _, p := range knownPrefixes {
+		p = strings.TrimSpace(p)
+		p = strings.TrimSuffix(p, "-")
+		if p != "" {
+			cleaned = append(cleaned, p)
+		}
+	}
+
+	// Sort by length descending so longest match wins
+	sort.Slice(cleaned, func(i, j int) bool {
+		return len(cleaned[i]) > len(cleaned[j])
+	})
+
+	for _, p := range cleaned {
+		if strings.HasPrefix(issueID, p+"-") {
+			return p
+		}
+	}
+
+	// No known prefix matched; fall back to heuristic
+	return ExtractIssuePrefix(issueID)
 }
 
 // ExtractIssueNumber extracts the number from an issue ID like "bd-123" -> 123


### PR DESCRIPTION
## Summary

Make issue ID resolution config-aware by using `issue_prefix` + `allowed_prefixes` as ground truth for prefix detection, instead of relying solely on heuristics.

- **Add `ExtractIssuePrefixKnown()`** in `issue_id.go`: deterministic prefix extraction that checks known prefixes (longest-first) before falling back to the existing heuristic `ExtractIssuePrefix()`
- **Add `hasKnownPrefix()`** in `id_parser.go`: checks if input starts with any known/allowed prefix
- **Modify `ResolvePartialID()`** to read `allowed_prefixes` from config and use config-aware detection in both normalization (preventing accidental prefix prepending) and hash extraction (correct prefix boundary for multi-hyphen prefixes)
- **No changes** to `looksLikePrefixedID()` or `ExtractIssuePrefix()` — existing heuristic behavior is preserved as fallback

### What improves

1. **Partial ID resolution works for multi-hyphen prefixes**
   - DB contains: `hacker-news-ko4`
   - User runs: `bd show ko4`
   - Before: may fail to "exact hash match" because code treated hash as `news-ko4`
   - After: correctly recognizes hash `ko4` and resolves to `hacker-news-ko4`

2. **Allowed prefixes prevent accidental prefix-prepending**
   - Config: `issue_prefix=hq`, `allowed_prefixes=hq-cv,gt`
   - User inputs: `hq-cv-test`
   - After: recognized as already prefixed because it starts with an allowed prefix; won't be mangled into `hq-hq-cv-test`

### What could get worse (edge cases)

- If `allowed_prefixes` includes a short prefix (e.g., `hq`) and a user types some non-issue token starting with `hq-...`, resolution will more consistently treat it as "already prefixed." This is usually desirable, and in practice `looksLikePrefixedID` already caused similar behavior for many `xxx-yyy` strings, but it's still a behavior change in some corner inputs.

### Explicit non-goals

- No changes to `internal/validation/bead.go` (`ValidateIDFormat` / `ValidateIDPrefixAllowed`)
- No changes to `cmd/bd/create.go` or other commands
- No changes to `looksLikePrefixedID()` rules/limits

## Test plan

- [ ] Unit tests for `ExtractIssuePrefixKnown`: known prefix match, overlapping prefixes (longest wins), heuristic fallback, normalization of trailing hyphens/whitespace
- [ ] Integration test `TestResolvePartialID_AllowedPrefixes`: creates issues with multi-hyphen prefixes, sets `allowed_prefixes` config, verifies short hash resolution (`ko4` → `hacker-news-ko4`) and full ID pass-through
- [ ] Existing tests unchanged: `looksLikePrefixedID`, `ExtractIssuePrefix`, cross-prefix, wisp tests all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)