### PR TITLE
fix: add contributor auto-routing fallback to show/update/close (GH#2345)

### DIFF
--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -97,8 +97,23 @@ func resolveAndGetIssueWithRouting(ctx context.Context, localStore *dolt.DoltSto
 		return result, nil
 	}
 
-	// No cross-database routing — use local store.
-	return resolveAndGetFromStore(ctx, localStore, id, false)
+	// No cross-database routing — try local store first.
+	result, err := resolveAndGetFromStore(ctx, localStore, id, false)
+	if err == nil {
+		return result, nil
+	}
+
+	// If not found locally, try contributor auto-routing as fallback (GH#2345).
+	// Commands like show/update/close use this function but previously never
+	// checked the auto-routed store, so issues created via contributor
+	// auto-routing were invisible to them.
+	if isNotFoundErr(err) {
+		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
+			return autoResult, nil
+		}
+	}
+
+	return nil, err
 }
 
 // resolveAndGetFromStore resolves a partial ID and gets the issue from a specific store.
@@ -121,6 +136,24 @@ func resolveAndGetFromStore(ctx context.Context, s *dolt.DoltStore, id string, r
 		Routed:     routed,
 		ResolvedID: resolvedID,
 	}, nil
+}
+
+// resolveViaAutoRouting attempts to find an issue using contributor auto-routing.
+// This is the fallback when prefix-based routing and local store both fail (GH#2345).
+// Returns a RoutedResult if the issue is found in the auto-routed store.
+func resolveViaAutoRouting(ctx context.Context, localStore *dolt.DoltStore, id string) (*RoutedResult, error) {
+	routedStore, routed, err := openRoutedReadStore(ctx, localStore)
+	if err != nil || !routed {
+		return nil, fmt.Errorf("no auto-routed store available")
+	}
+
+	result, err := resolveAndGetFromStore(ctx, routedStore, id, true)
+	if err != nil {
+		_ = routedStore.Close()
+		return nil, err
+	}
+	result.closeFn = func() { _ = routedStore.Close() }
+	return result, nil
 }
 
 // openStoreForRig opens a read-only storage connection to a different rig's database.
@@ -195,17 +228,25 @@ func getIssueWithRouting(ctx context.Context, localStore *dolt.DoltStore, id str
 		}, nil
 	}
 
-	// No cross-database routing — use local store.
+	// No cross-database routing — try local store first.
 	issue, err := localStore.GetIssue(ctx, id)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		return &RoutedResult{
+			Issue:      issue,
+			Store:      localStore,
+			Routed:     false,
+			ResolvedID: id,
+		}, nil
 	}
-	return &RoutedResult{
-		Issue:      issue,
-		Store:      localStore,
-		Routed:     false,
-		ResolvedID: id,
-	}, nil
+
+	// If not found locally, try contributor auto-routing as fallback (GH#2345).
+	if isNotFoundErr(err) {
+		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
+			return autoResult, nil
+		}
+	}
+
+	return nil, err
 }
 
 // getRoutedStoreForID returns a storage connection for an issue ID if routing is needed.


### PR DESCRIPTION
## Summary
- Add contributor auto-routing fallback to bd show, bd update, and bd close
- When an issue is not found via prefix-based routing, these commands now fall back to openRoutedReadStore/determineAutoRoutedRepoPath
- Fixes GH#2345: bd show/update/close fail to find issues created via contributor auto-routing

## Test plan
- bd create + bd show works with routing.mode = auto
- bd update works with auto-routed issues
- bd close works with auto-routed issues
- Non-auto-routed workflows unchanged