### PR TITLE
fix: warn on user-modified legacy hooks during migration (GH#2370)

### DIFF
--- a/cmd/bd/doctor/hooks_migration.go
+++ b/cmd/bd/doctor/hooks_migration.go
@@ -211,6 +211,79 @@ func isLegacyBDHook(content string) bool {
 		strings.Contains(content, "# bd (beads)")
 }
 
+// IsUnmodifiedLegacyHook returns true if content contains only known BD-managed
+// lines (shebang, shim markers, hook delegation, shell boilerplate). If the user
+// added custom logic to a legacy shim, this returns false.
+func IsUnmodifiedLegacyHook(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if isKnownLegacyHookLine(line) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// isKnownLegacyHookLine returns true for lines that appear in BD-generated
+// legacy hook shims (thin shim format and inline hook format).
+func isKnownLegacyHookLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+
+	// Empty lines and shebangs
+	if trimmed == "" || strings.HasPrefix(trimmed, "#!") {
+		return true
+	}
+
+	// Shell control flow and builtins used in hook templates
+	switch trimmed {
+	case "fi", "then", "else", "exit 0", "exit 1":
+		return true
+	}
+
+	// Any comment line containing BD/beads identifiers
+	if strings.HasPrefix(trimmed, "#") {
+		lower := strings.ToLower(trimmed)
+		for _, keyword := range []string{"bd", "beads", "hook", "shim"} {
+			if strings.Contains(lower, keyword) {
+				return true
+			}
+		}
+		// Generic template comments (PATH, Install, Warning)
+		for _, keyword := range []string{"PATH", "Install", "Warning"} {
+			if strings.Contains(trimmed, keyword) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Known executable lines from legacy hook templates
+	knownPrefixes := []string{
+		"exec bd hook",
+		"bd hooks run",
+		"export BD_GIT_HOOK",
+		"if ! command -v bd",
+		"if command -v bd",
+		"_bd_exit=$?",
+	}
+	for _, prefix := range knownPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+
+	// echo lines with BD-related content (warnings about bd not being installed)
+	if strings.HasPrefix(trimmed, "echo") {
+		lower := strings.ToLower(trimmed)
+		if strings.Contains(lower, "bd") || strings.Contains(lower, "beads") {
+			return true
+		}
+	}
+
+	return false
+}
+
 func resolveGitHooksDir(path string) (repoRoot string, hooksDir string, err error) {
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel", "--git-common-dir")
 	cmd.Dir = path

--- a/cmd/bd/migrate_hooks_apply.go
+++ b/cmd/bd/migrate_hooks_apply.go
@@ -152,6 +152,18 @@ func buildHookMigrationExecutionPlan(plan doctor.HookMigrationPlan) hookMigratio
 			continue
 		}
 
+		// For legacy hooks with sidecars, the migration discards the current hook
+		// file in favor of sidecar content. Check that the user hasn't added custom
+		// logic to the shim — if they have, block migration to avoid silent data loss.
+		if hook.LegacyBDHook && (hook.HasOldSidecar || hook.HasBackupSidecar) {
+			content, readErr := os.ReadFile(hook.HookPath) // #nosec G304 -- path from migration planner
+			if readErr == nil && !doctor.IsUnmodifiedLegacyHook(string(content)) {
+				execPlan.BlockingErrors = append(execPlan.BlockingErrors,
+					fmt.Sprintf("%s: legacy hook appears user-modified; review manually before migration (state: %s)", hook.Name, hook.State))
+				continue
+			}
+		}
+
 		sourceKind, sourcePath, err := chooseHookMigrationWriteSource(hook)
 		if err != nil {
 			execPlan.BlockingErrors = append(execPlan.BlockingErrors, err.Error())

--- a/cmd/bd/migrate_hooks_apply_test.go
+++ b/cmd/bd/migrate_hooks_apply_test.go
@@ -256,6 +256,78 @@ func TestApplyHookMigrationExecution_RetireCollisionFailsBeforeWrites(t *testing
 	}
 }
 
+func TestBuildExecutionPlan_ModifiedLegacyHookBlocks(t *testing.T) {
+	repoDir, hooksDir := setupHookMigrationRepo(t)
+	preCommitPath := filepath.Join(hooksDir, "pre-commit")
+
+	// Legacy shim with user-added custom logic
+	modifiedLegacy := "#!/usr/bin/env sh\n# bd-shim v2\n# bd-hooks-version: 0.56.1\nexec bd hooks run pre-commit \"$@\"\n\n# My custom linting\n./run-my-linter.sh\n"
+	writeHookMigrationFile(t, preCommitPath, modifiedLegacy)
+	writeHookMigrationFile(t, preCommitPath+".old", "#!/usr/bin/env sh\necho old-custom\n")
+
+	plan, err := doctor.PlanHookMigration(repoDir)
+	if err != nil {
+		t.Fatalf("PlanHookMigration failed: %v", err)
+	}
+	execPlan := buildHookMigrationExecutionPlan(plan)
+
+	if len(execPlan.BlockingErrors) == 0 {
+		t.Fatal("expected blocking error for user-modified legacy hook with sidecar")
+	}
+
+	found := false
+	for _, msg := range execPlan.BlockingErrors {
+		if strings.Contains(msg, "user-modified") && strings.Contains(msg, "pre-commit") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected blocking error mentioning user-modified pre-commit, got: %v", execPlan.BlockingErrors)
+	}
+
+	// No write ops should be emitted for the blocked hook
+	for _, op := range execPlan.WriteOps {
+		if op.HookName == "pre-commit" {
+			t.Fatal("expected no write op for blocked pre-commit hook")
+		}
+	}
+}
+
+func TestBuildExecutionPlan_UnmodifiedLegacyHookProceeds(t *testing.T) {
+	repoDir, hooksDir := setupHookMigrationRepo(t)
+	preCommitPath := filepath.Join(hooksDir, "pre-commit")
+
+	// Clean legacy shim — no user modifications
+	cleanLegacy := "#!/usr/bin/env sh\n# bd-shim v2\n# bd-hooks-version: 0.56.1\nexec bd hooks run pre-commit \"$@\"\n"
+	writeHookMigrationFile(t, preCommitPath, cleanLegacy)
+	writeHookMigrationFile(t, preCommitPath+".old", "#!/usr/bin/env sh\necho old-custom\n")
+
+	plan, err := doctor.PlanHookMigration(repoDir)
+	if err != nil {
+		t.Fatalf("PlanHookMigration failed: %v", err)
+	}
+	execPlan := buildHookMigrationExecutionPlan(plan)
+
+	if len(execPlan.BlockingErrors) > 0 {
+		t.Fatalf("expected no blocking errors for unmodified legacy hook, got: %v", execPlan.BlockingErrors)
+	}
+
+	foundWrite := false
+	for _, op := range execPlan.WriteOps {
+		if op.HookName == "pre-commit" {
+			foundWrite = true
+			if op.SourceKind != hookMigrationWriteFromOld {
+				t.Fatalf("expected source kind %q, got %q", hookMigrationWriteFromOld, op.SourceKind)
+			}
+			break
+		}
+	}
+	if !foundWrite {
+		t.Fatal("expected write op for unmodified legacy hook with .old sidecar")
+	}
+}
+
 func setupHookMigrationRepo(t *testing.T) (repoDir string, hooksDir string) {
 	t.Helper()
 	repoDir = newGitRepo(t)


### PR DESCRIPTION
## Summary
Cherry-pick of the warning logic from PR #2370, rebased onto main after #2382 landed.

- Adds IsUnmodifiedLegacyHook() whitelist check for BD-managed hook patterns
- Blocks migration with a clear error when legacy hooks have been user-modified and have sidecar backups
- Prevents silent data loss during hook migration

Supersedes #2370.

## Test plan
- TestBuildExecutionPlan_ModifiedLegacyHookBlocks
- TestBuildExecutionPlan_UnmodifiedLegacyHookProceeds