### PR TITLE
Remove vestigial sync mode scaffolding

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -287,7 +287,7 @@ func showConfigYAMLOverrides(dbConfig map[string]string) {
 	yamlKeys := []string{
 		"no-db", "json", "actor", "identity",
 		"routing.mode", "routing.default", "routing.maintainer", "routing.contributor",
-		"sync.mode", "sync.git-remote", "no-push", "no-git-ops",
+		"sync.git-remote", "no-push", "no-git-ops",
 		"git.author", "git.no-gpg-sign",
 		"create.require-description",
 		"validation.on-create", "validation.on-sync",
@@ -434,14 +434,8 @@ func validateSyncConfig(repoPath string) []string {
 	}
 
 	// Get config from yaml
-	syncMode := v.GetString("sync.mode")
 	federationSov := v.GetString("federation.sovereignty")
 	federationRemote := v.GetString("federation.remote")
-
-	// Validate sync.mode
-	if syncMode != "" && !config.IsValidSyncMode(syncMode) {
-		issues = append(issues, fmt.Sprintf("sync.mode: %q is invalid (valid values: %s)", syncMode, strings.Join(config.ValidSyncModes(), ", ")))
-	}
 
 	// Validate federation.sovereignty
 	if federationSov != "" && !config.IsValidSovereignty(federationSov) {

--- a/cmd/bd/config_test.go
+++ b/cmd/bd/config_test.go
@@ -332,29 +332,6 @@ func TestValidateSyncConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid sync.mode", func(t *testing.T) {
-		configContent := `prefix: test
-sync:
-  mode: "invalid-mode"
-`
-		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
-			t.Fatalf("Failed to write config.yaml: %v", err)
-		}
-
-		issues := validateSyncConfig(tmpDir)
-		found := false
-		for _, issue := range issues {
-			if strings.Contains(issue, "sync.mode") {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected issue about sync.mode, got: %v", issues)
-		}
-	})
-
-
 	t.Run("invalid federation.sovereignty", func(t *testing.T) {
 		configContent := `prefix: test
 federation:
@@ -377,10 +354,8 @@ federation:
 		}
 	})
 
-	t.Run("dolt-native mode without remote", func(t *testing.T) {
+	t.Run("missing federation remote", func(t *testing.T) {
 		configContent := `prefix: test
-sync:
-  mode: "dolt-native"
 `
 		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
 			t.Fatalf("Failed to write config.yaml: %v", err)
@@ -421,10 +396,8 @@ federation:
 		}
 	})
 
-	t.Run("valid sync config", func(t *testing.T) {
+	t.Run("valid federation config", func(t *testing.T) {
 		configContent := `prefix: test
-sync:
-  mode: "dolt-native"
 conflict:
   strategy: "newest"
 federation:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,18 +13,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Sync trigger constants define when sync operations occur.
-const (
-	// SyncTriggerPush triggers sync on git push operations.
-	SyncTriggerPush = "push"
-
-	// SyncTriggerChange triggers sync on every database change.
-	SyncTriggerChange = "change"
-
-	// SyncTriggerPull triggers import on git pull operations.
-	SyncTriggerPull = "pull"
-)
-
 var v *viper.Viper
 
 // overriddenKeys tracks keys explicitly set via Set() at runtime, so
@@ -150,12 +138,6 @@ func Initialize() error {
 
 	// Sync configuration defaults (bd-4u8)
 	v.SetDefault("sync.require_confirmation_on_mass_delete", false)
-
-	// Sync mode configuration (hq-ew1mbr.3)
-	// See docs/CONFIG.md for detailed documentation
-	v.SetDefault("sync.mode", SyncModeDoltNative)
-	v.SetDefault("sync.export_on", SyncTriggerPush) // push | change
-	v.SetDefault("sync.import_on", SyncTriggerPull) // pull | change
 
 	// Federation configuration (optional Dolt remote)
 	v.SetDefault("federation.remote", "")      // e.g., dolthub://org/beads, gs://bucket/beads, s3://bucket/beads
@@ -718,22 +700,6 @@ func GetIdentity(flagValue string) string {
 	}
 
 	return "unknown"
-}
-
-// SyncConfig holds the sync mode configuration.
-type SyncConfig struct {
-	Mode     SyncMode // dolt-native (only supported mode)
-	ExportOn string   // push, change
-	ImportOn string   // pull, change
-}
-
-// GetSyncConfig returns the current sync configuration.
-func GetSyncConfig() SyncConfig {
-	return SyncConfig{
-		Mode:     GetSyncMode(),
-		ExportOn: GetString("sync.export_on"),
-		ImportOn: GetString("sync.import_on"),
-	}
 }
 
 // FederationConfig holds the federation (Dolt remote) configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1114,26 +1114,6 @@ validation:
 	}
 }
 
-// Tests for sync mode configuration (hq-ew1mbr.3)
-
-func TestSyncModeConstants(t *testing.T) {
-	if SyncModeDoltNative != "dolt-native" {
-		t.Errorf("SyncModeDoltNative = %q, want \"dolt-native\"", SyncModeDoltNative)
-	}
-}
-
-func TestSyncTriggerConstants(t *testing.T) {
-	if SyncTriggerPush != "push" {
-		t.Errorf("SyncTriggerPush = %q, want \"push\"", SyncTriggerPush)
-	}
-	if SyncTriggerChange != "change" {
-		t.Errorf("SyncTriggerChange = %q, want \"change\"", SyncTriggerChange)
-	}
-	if SyncTriggerPull != "pull" {
-		t.Errorf("SyncTriggerPull = %q, want \"pull\"", SyncTriggerPull)
-	}
-}
-
 func TestSovereigntyConstants(t *testing.T) {
 	if SovereigntyT1 != "T1" {
 		t.Errorf("SovereigntyT1 = %q, want \"T1\"", SovereigntyT1)
@@ -1146,34 +1126,6 @@ func TestSovereigntyConstants(t *testing.T) {
 	}
 	if SovereigntyT4 != "T4" {
 		t.Errorf("SovereigntyT4 = %q, want \"T4\"", SovereigntyT4)
-	}
-}
-
-func TestSyncConfigDefaults(t *testing.T) {
-	// Isolate from environment variables
-	restore := envSnapshot(t)
-	defer restore()
-
-	// Initialize config
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize() returned error: %v", err)
-	}
-
-	// Test sync mode default
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() = %q, want %q", got, SyncModeDoltNative)
-	}
-
-	// Test sync config defaults
-	cfg := GetSyncConfig()
-	if cfg.Mode != SyncModeDoltNative {
-		t.Errorf("GetSyncConfig().Mode = %q, want %q", cfg.Mode, SyncModeDoltNative)
-	}
-	if cfg.ExportOn != SyncTriggerPush {
-		t.Errorf("GetSyncConfig().ExportOn = %q, want %q", cfg.ExportOn, SyncTriggerPush)
-	}
-	if cfg.ImportOn != SyncTriggerPull {
-		t.Errorf("GetSyncConfig().ImportOn = %q, want %q", cfg.ImportOn, SyncTriggerPull)
 	}
 }
 
@@ -1198,17 +1150,12 @@ func TestFederationConfigDefaults(t *testing.T) {
 	}
 }
 
-func TestSyncConfigFromFile(t *testing.T) {
+func TestFederationConfigFromFile(t *testing.T) {
 	// Create a temporary directory for config file
 	tmpDir := t.TempDir()
 
-	// Create a config file with sync settings
+	// Create a config file with federation settings
 	configContent := `
-sync:
-  mode: dolt-native
-  export_on: change
-  import_on: change
-
 federation:
   remote: dolthub://myorg/beads
   sovereignty: T2
@@ -1231,18 +1178,6 @@ federation:
 		t.Fatalf("Initialize() returned error: %v", err)
 	}
 
-	// Test sync config
-	syncCfg := GetSyncConfig()
-	if syncCfg.Mode != SyncModeDoltNative {
-		t.Errorf("GetSyncConfig().Mode = %q, want %q", syncCfg.Mode, SyncModeDoltNative)
-	}
-	if syncCfg.ExportOn != SyncTriggerChange {
-		t.Errorf("GetSyncConfig().ExportOn = %q, want %q", syncCfg.ExportOn, SyncTriggerChange)
-	}
-	if syncCfg.ImportOn != SyncTriggerChange {
-		t.Errorf("GetSyncConfig().ImportOn = %q, want %q", syncCfg.ImportOn, SyncTriggerChange)
-	}
-
 	// Test federation config
 	fedCfg := GetFederationConfig()
 	if fedCfg.Remote != "dolthub://myorg/beads" {
@@ -1250,23 +1185,6 @@ federation:
 	}
 	if fedCfg.Sovereignty != SovereigntyT2 {
 		t.Errorf("GetFederationConfig().Sovereignty = %q, want %q", fedCfg.Sovereignty, SovereigntyT2)
-	}
-}
-
-func TestGetSyncModeInvalid(t *testing.T) {
-	// Isolate from environment variables
-	restore := envSnapshot(t)
-	defer restore()
-
-	// Initialize config
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize() returned error: %v", err)
-	}
-
-	// Set invalid mode - always returns dolt-native now
-	Set("sync.mode", "invalid-mode")
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() with invalid mode = %q, want %q", got, SyncModeDoltNative)
 	}
 }
 

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -1,3 +1,5 @@
+// ABOUTME: Federation sovereignty tier configuration and config warning utilities.
+// ABOUTME: Defines T1-T4 sovereignty tiers for federation access control.
 package config
 
 import (
@@ -6,9 +8,6 @@ import (
 	"os"
 	"strings"
 )
-
-// Sync mode configuration values (from hq-ew1mbr.3)
-// These control how Dolt syncs with remotes.
 
 // ConfigWarnings controls whether warnings are logged for invalid config values.
 // Set to false to suppress warnings (useful for tests or scripts).
@@ -23,31 +22,6 @@ func logConfigWarning(format string, args ...interface{}) {
 	if ConfigWarnings && ConfigWarningWriter != nil {
 		_, _ = fmt.Fprintf(ConfigWarningWriter, format, args...) // Best effort: warning output should not cause failures
 	}
-}
-
-// SyncMode represents the sync mode configuration
-type SyncMode string
-
-const (
-	// SyncModeDoltNative uses Dolt remote directly (the only supported mode)
-	SyncModeDoltNative SyncMode = "dolt-native"
-)
-
-// validSyncModes is the set of allowed sync mode values
-var validSyncModes = map[SyncMode]bool{
-	SyncModeDoltNative: true,
-}
-
-// ValidSyncModes returns the list of valid sync mode values.
-func ValidSyncModes() []string {
-	return []string{
-		string(SyncModeDoltNative),
-	}
-}
-
-// IsValidSyncMode returns true if the given string is a valid sync mode.
-func IsValidSyncMode(mode string) bool {
-	return validSyncModes[SyncMode(strings.ToLower(strings.TrimSpace(mode)))]
 }
 
 // Sovereignty represents the federation sovereignty tier
@@ -93,12 +67,6 @@ func IsValidSovereignty(sovereignty string) bool {
 	return validSovereigntyTiers[Sovereignty(strings.ToUpper(strings.TrimSpace(sovereignty)))]
 }
 
-// GetSyncMode always returns SyncModeDoltNative.
-// The sync mode config key is deprecated; Dolt-native is the only supported mode.
-func GetSyncMode() SyncMode {
-	return SyncModeDoltNative
-}
-
 // GetSovereignty retrieves the federation sovereignty tier configuration.
 // Returns the configured tier, or SovereigntyNone (empty, no restriction) if not set.
 // Returns SovereigntyT1 and logs a warning if an invalid non-empty value is configured.
@@ -122,13 +90,7 @@ func GetSovereignty() Sovereignty {
 	return tier
 }
 
-// String returns the string representation of the SyncMode.
-func (m SyncMode) String() string {
-	return string(m)
-}
-
 // String returns the string representation of the Sovereignty.
 func (s Sovereignty) String() string {
 	return string(s)
 }
-

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -6,18 +6,6 @@ import (
 	"testing"
 )
 
-func TestGetSyncMode(t *testing.T) {
-	// GetSyncMode always returns dolt-native regardless of config
-	ResetForTesting()
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize failed: %v", err)
-	}
-
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() = %q, want %q", got, SyncModeDoltNative)
-	}
-}
-
 func TestGetSovereignty(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -155,26 +143,6 @@ func TestConfigWarningsToggle(t *testing.T) {
 	ConfigWarningWriter = oldWriter
 }
 
-func TestIsValidSyncMode(t *testing.T) {
-	tests := []struct {
-		mode  string
-		valid bool
-	}{
-		{"dolt-native", true},
-		{"Dolt-Native", true},          // case insensitive
-		{"git-portable", false},        // removed
-		{"belt-and-suspenders", false}, // removed
-		{"invalid", false},
-		{"", false},
-	}
-
-	for _, tt := range tests {
-		if got := IsValidSyncMode(tt.mode); got != tt.valid {
-			t.Errorf("IsValidSyncMode(%q) = %v, want %v", tt.mode, got, tt.valid)
-		}
-	}
-}
-
 func TestIsValidSovereignty(t *testing.T) {
 	tests := []struct {
 		sovereignty string
@@ -199,16 +167,6 @@ func TestIsValidSovereignty(t *testing.T) {
 	}
 }
 
-func TestValidSyncModes(t *testing.T) {
-	modes := ValidSyncModes()
-	if len(modes) != 1 {
-		t.Errorf("ValidSyncModes() returned %d modes, want 1", len(modes))
-	}
-	if modes[0] != "dolt-native" {
-		t.Errorf("ValidSyncModes()[0] = %q, want %q", modes[0], "dolt-native")
-	}
-}
-
 func TestValidSovereigntyTiers(t *testing.T) {
 	tiers := ValidSovereigntyTiers()
 	if len(tiers) != 4 {
@@ -222,12 +180,6 @@ func TestValidSovereigntyTiers(t *testing.T) {
 	}
 }
 
-func TestSyncModeString(t *testing.T) {
-	if got := SyncModeDoltNative.String(); got != "dolt-native" {
-		t.Errorf("SyncModeDoltNative.String() = %q, want %q", got, "dolt-native")
-	}
-}
-
 func TestSovereigntyString(t *testing.T) {
 	if got := SovereigntyT1.String(); got != "T1" {
 		t.Errorf("SovereigntyT1.String() = %q, want %q", got, "T1")
@@ -236,4 +188,3 @@ func TestSovereigntyString(t *testing.T) {
 		t.Errorf("SovereigntyNone.String() = %q, want %q", got, "")
 	}
 }
-


### PR DESCRIPTION
## Summary

- Removes the `SyncMode` type, `SyncModeDoltNative` constant, `validSyncModes` map, `ValidSyncModes()`, `IsValidSyncMode()`, `GetSyncMode()`, and `SyncMode.String()` — all dead code since v0.51 hardcoded dolt-native as the only mode
- Removes `SyncConfig` struct, `GetSyncConfig()`, and `SyncTrigger*` constants (`push`/`change`/`pull`) — zero runtime consumers outside tests
- Removes `sync.mode` config default and validation in `cmd/bd/config.go`
- Removes ~240 lines of dead code and tests
- Preserves all active code: sovereignty tiers, federation config, conflict resolution, `ConfigWarnings` infrastructure

Builds clean and all remaining tests pass.

## Context

Addresses wanted item `w-bd-004` ("Audit sync mode complexity") from the [HOP Wasteland commons](https://www.dolthub.com/repositories/hop/wl-commons). The existing audit doc at `docs/audit-sync-mode-complexity.md` identified this scaffolding as vestigial; this PR completes the cleanup.

## Test plan

- [x] `go build ./internal/config/` — clean
- [x] `go build ./cmd/bd/` — clean
- [x] `go test ./internal/config/` — all pass
- [x] `go test ./cmd/bd/ -run TestValidateSyncConfig` — all pass
- [x] Verified zero remaining references to removed symbols via `grep`