### PR TITLE
cleanup: remove 3-way merge engine remnants (w-bd-002)

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -669,12 +669,7 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, untrackedCheck)
 	// Don't fail overall check for untracked files, just warn
 
-	// Check 21: Merge artifacts (from bd clean)
-	mergeArtifactsCheck := convertDoctorCheck(doctor.CheckMergeArtifacts(path))
-	result.Checks = append(result.Checks, mergeArtifactsCheck)
-	// Don't fail overall check for merge artifacts, just warn
-
-	// Check 22: Orphaned dependencies (from bd repair-deps, bd validate)
+	// Check 21: Orphaned dependencies (from bd repair-deps, bd validate)
 	orphanedDepsCheck := convertDoctorCheck(doctor.CheckOrphanedDependencies(path))
 	result.Checks = append(result.Checks, orphanedDepsCheck)
 	// Don't fail overall check for orphaned deps, just warn

--- a/cmd/bd/doctor/agent.go
+++ b/cmd/bd/doctor/agent.go
@@ -120,7 +120,6 @@ var agentEnrichers = map[string]enricher{
 	"Test Pollution":               enrichTestPollution,
 	"Orphaned Dependencies":        enrichOrphanedDeps,
 	"Child-Parent Dependencies":    enrichChildParentDeps,
-	"Merge Artifacts":              enrichMergeArtifacts,
 	"Classic Artifacts":            enrichClassicArtifacts,
 	"Embedded Mode Concurrency":    enrichEmbeddedConcurrency,
 	"Pending Migrations":           enrichPendingMigrations,
@@ -490,17 +489,6 @@ func enrichChildParentDeps(dc DoctorCheck) agentEnrichment {
 		expected:    "No dependency edges between parent and child issues",
 		commands:    []string{"bd doctor --fix --fix-child-parent"},
 		sourceFiles: []string{"cmd/bd/doctor/validation.go:CheckChildParentDependencies"},
-	}
-}
-
-func enrichMergeArtifacts(dc DoctorCheck) agentEnrichment {
-	return agentEnrichment{
-		severity:    "advisory",
-		explanation: fmt.Sprintf("Merge artifacts found: %s. Git merge markers or backup files from conflict resolution are present in .beads/. These can be safely cleaned up.", dc.Message),
-		observed:    dc.Message + "\n" + dc.Detail,
-		expected:    "No merge artifacts in .beads/",
-		commands:    []string{"bd doctor --fix"},
-		sourceFiles: []string{"cmd/bd/doctor/validation.go:CheckMergeArtifacts"},
 	}
 }
 

--- a/cmd/bd/doctor/checks_nocgo.go
+++ b/cmd/bd/doctor/checks_nocgo.go
@@ -5,10 +5,6 @@ package doctor
 // Non-CGO stubs for doctor checks that require Dolt database access.
 // These checks are skipped in non-CGO builds.
 
-func CheckMergeArtifacts(_ string) DoctorCheck {
-	return DoctorCheck{Name: "Merge Artifacts", Status: StatusWarning, Message: "Skipped: requires CGO"}
-}
-
 func CheckOrphanedDependencies(_ string) DoctorCheck {
 	return DoctorCheck{Name: "Orphaned Dependencies", Status: StatusWarning, Message: "Skipped: requires CGO"}
 }

--- a/cmd/bd/doctor/fix/artifacts.go
+++ b/cmd/bd/doctor/fix/artifacts.go
@@ -139,7 +139,6 @@ func cleanJSONLArtifacts(beadsDir string) (removed, skipped, errCount int) {
 	// Safe to delete (not the primary data source)
 	safeFiles := []string{
 		"issues.jsonl.new",
-		"beads.left.jsonl",
 	}
 
 	for _, name := range safeFiles {

--- a/cmd/bd/doctor/fix/artifacts_test.go
+++ b/cmd/bd/doctor/fix/artifacts_test.go
@@ -100,7 +100,7 @@ func TestClassicArtifacts_CleansJSONLInDoltDir(t *testing.T) {
 	}
 
 	// Create safe-to-delete JSONL artifacts
-	for _, name := range []string{"issues.jsonl.new", "beads.left.jsonl"} {
+	for _, name := range []string{"issues.jsonl.new"} {
 		if err := os.WriteFile(filepath.Join(beadsDir, name), []byte(`{"id":"test"}`), 0644); err != nil {
 			t.Fatal(err)
 		}
@@ -122,7 +122,7 @@ func TestClassicArtifacts_CleansJSONLInDoltDir(t *testing.T) {
 	}
 
 	// Safe files should be removed
-	for _, name := range []string{"issues.jsonl.new", "beads.left.jsonl", "interactions.jsonl"} {
+	for _, name := range []string{"issues.jsonl.new", "interactions.jsonl"} {
 		if _, err := os.Stat(filepath.Join(beadsDir, name)); !os.IsNotExist(err) {
 			t.Errorf("%s should have been removed", name)
 		}

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -1,12 +1,10 @@
 package fix
 
 import (
-	"bufio"
 	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -21,92 +19,6 @@ func getDatabasePath(beadsDir string) string {
 		return filepath.Join(beadsDir, "dolt") // fallback to default
 	}
 	return cfg.DatabasePath(beadsDir)
-}
-
-// MergeArtifacts removes temporary git merge files from .beads directory.
-func MergeArtifacts(path string) error {
-	if err := validateBeadsWorkspace(path); err != nil {
-		return err
-	}
-
-	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
-
-	// Read patterns from .gitignore or use defaults
-	patterns, err := readMergeArtifactPatterns(beadsDir)
-	if err != nil {
-		patterns = []string{
-			"*.base.jsonl",
-			"*.left.jsonl",
-			"*.right.jsonl",
-			"*.meta.json",
-		}
-	}
-
-	// Find and delete matching files
-	var deleted int
-	var errors []string
-
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(filepath.Join(beadsDir, pattern))
-		if err != nil {
-			continue
-		}
-		for _, file := range matches {
-			if err := os.Remove(file); err != nil {
-				if !os.IsNotExist(err) {
-					errors = append(errors, fmt.Sprintf("%s: %v", filepath.Base(file), err))
-				}
-			} else {
-				deleted++
-				fmt.Printf("  Removed %s\n", filepath.Base(file))
-			}
-		}
-	}
-
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to remove some files: %s", strings.Join(errors, "; "))
-	}
-
-	if deleted == 0 {
-		fmt.Println("  No merge artifacts to remove")
-	} else {
-		fmt.Printf("  Removed %d merge artifact(s)\n", deleted)
-	}
-
-	return nil
-}
-
-// readMergeArtifactPatterns reads patterns from .beads/.gitignore merge section
-func readMergeArtifactPatterns(beadsDir string) ([]string, error) {
-	gitignorePath := filepath.Join(beadsDir, ".gitignore")
-	file, err := os.Open(gitignorePath) // #nosec G304 - path constructed from beadsDir
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var patterns []string
-	inMergeSection := false
-	scanner := bufio.NewScanner(file)
-
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-
-		if strings.Contains(line, "Merge artifacts") {
-			inMergeSection = true
-			continue
-		}
-
-		if inMergeSection && strings.HasPrefix(line, "#") {
-			break
-		}
-
-		if inMergeSection && line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "!") {
-			patterns = append(patterns, line)
-		}
-	}
-
-	return patterns, scanner.Err()
 }
 
 // OrphanedDependencies removes dependencies pointing to non-existent issues.

--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -3,7 +3,6 @@
 package doctor
 
 import (
-	"bufio"
 	"context"
 	"database/sql"
 	"fmt"
@@ -31,100 +30,6 @@ func openStoreDB(beadsDir string) (*sql.DB, *dolt.DoltStore, error) {
 		return nil, nil, fmt.Errorf("storage backend has no underlying database")
 	}
 	return db, store, nil
-}
-
-// CheckMergeArtifacts detects temporary git merge files in .beads directory.
-// These are created during git merges and should be cleaned up.
-func CheckMergeArtifacts(path string) DoctorCheck {
-	// Follow redirect to resolve actual beads directory (bd-tvus fix)
-	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
-
-	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
-		return DoctorCheck{
-			Name:    "Merge Artifacts",
-			Status:  "ok",
-			Message: "N/A (no .beads directory)",
-		}
-	}
-
-	// Read patterns from .beads/.gitignore (merge artifacts section)
-	patterns, err := readMergeArtifactPatterns(beadsDir)
-	if err != nil {
-		// No .gitignore or can't read it - use default patterns
-		patterns = []string{
-			"*.base.jsonl",
-			"*.left.jsonl",
-			"*.right.jsonl",
-			"*.meta.json",
-		}
-	}
-
-	// Find matching files
-	var artifacts []string
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(filepath.Join(beadsDir, pattern))
-		if err != nil {
-			continue
-		}
-		artifacts = append(artifacts, matches...)
-	}
-
-	if len(artifacts) == 0 {
-		return DoctorCheck{
-			Name:    "Merge Artifacts",
-			Status:  "ok",
-			Message: "No merge artifacts found",
-		}
-	}
-
-	// Build list of relative paths for display
-	var relPaths []string
-	for _, f := range artifacts {
-		if rel, err := filepath.Rel(beadsDir, f); err == nil {
-			relPaths = append(relPaths, rel)
-		}
-	}
-
-	return DoctorCheck{
-		Name:    "Merge Artifacts",
-		Status:  "warning",
-		Message: fmt.Sprintf("%d temporary merge file(s) found", len(artifacts)),
-		Detail:  strings.Join(relPaths, ", "),
-		Fix:     "Run 'bd doctor --fix' to remove merge artifacts",
-	}
-}
-
-// readMergeArtifactPatterns reads patterns from .beads/.gitignore merge section
-func readMergeArtifactPatterns(beadsDir string) ([]string, error) {
-	gitignorePath := filepath.Join(beadsDir, ".gitignore")
-	file, err := os.Open(gitignorePath) // #nosec G304 - path constructed from beadsDir
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var patterns []string
-	inMergeSection := false
-	scanner := bufio.NewScanner(file)
-
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-
-		if strings.Contains(line, "Merge artifacts") {
-			inMergeSection = true
-			continue
-		}
-
-		if inMergeSection && strings.HasPrefix(line, "#") {
-			break
-		}
-
-		if inMergeSection && line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "!") {
-			patterns = append(patterns, line)
-		}
-	}
-
-	return patterns, scanner.Err()
 }
 
 // CheckOrphanedDependencies detects dependencies pointing to non-existent issues.

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -283,8 +283,6 @@ func applyFixList(path string, fixes []doctorCheck) {
 		case "Untracked Files":
 			fmt.Printf("  ⚠ Untracked JSONL fix removed (Dolt-native storage)\n")
 			continue
-		case "Merge Artifacts":
-			err = fix.MergeArtifacts(path)
 		case "Orphaned Dependencies":
 			err = fix.OrphanedDependencies(path, doctorVerbose)
 		case "Child-Parent Dependencies":

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -351,7 +351,6 @@ var rootCmd = &cobra.Command{
 			"powershell",
 			"prime",
 			"quickstart",
-			"resolve-conflicts",
 			"setup",
 			"sync", // deprecated no-op, prints message only
 			"version",


### PR DESCRIPTION
## Summary

Removes dead code from the old JSONL 3-way merge engine. With Dolt handling merges natively, this entire subsystem is obsolete.

- Remove `CheckMergeArtifacts` / `readMergeArtifactPatterns` from `doctor/validation.go`
- Remove `CheckMergeArtifacts` stub from `doctor/checks_nocgo.go`
- Remove `fix.MergeArtifacts` / `readMergeArtifactPatterns` from `doctor/fix/validation.go`
- Remove `enrichMergeArtifacts` and its registration from `doctor/agent.go`
- Remove `CheckMergeArtifacts` call site from `doctor.go`
- Remove `case "Merge Artifacts"` dispatch from `doctor_fix.go`
- Remove `"resolve-conflicts"` from `noDbCommands` in `main.go` (command no longer exists)
- Remove `"beads.left.jsonl"` from `cleanJSONLArtifacts` safeFiles (left-side 3-way merge artifact)

Net: -211 lines

Wasteland: w-bd-002

🤖 Generated with [Claude Code](https://claude.com/claude-code)