### PR TITLE
Remove vestigial SyncMode scaffolding (w-bd-004)

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -287,7 +287,7 @@ func showConfigYAMLOverrides(dbConfig map[string]string) {
 	yamlKeys := []string{
 		"no-db", "json", "actor", "identity",
 		"routing.mode", "routing.default", "routing.maintainer", "routing.contributor",
-		"sync.mode", "sync.git-remote", "no-push", "no-git-ops",
+		"sync.git-remote", "no-push", "no-git-ops",
 		"git.author", "git.no-gpg-sign",
 		"create.require-description",
 		"validation.on-create", "validation.on-sync",
@@ -354,9 +354,8 @@ var configValidateCmd = &cobra.Command{
 	Long: `Validate sync-related configuration settings.
 
 Checks:
-  - sync.mode is a valid value (dolt-native)
   - federation.sovereignty is valid (T1, T2, T3, T4, or empty)
-  - federation.remote is set when sync.mode requires it
+  - federation.remote is set (required for Dolt sync)
   - Remote URL format is valid (dolthub://, gs://, s3://, file://)
   - routing.mode is valid (auto, maintainer, contributor, explicit)
 
@@ -434,14 +433,8 @@ func validateSyncConfig(repoPath string) []string {
 	}
 
 	// Get config from yaml
-	syncMode := v.GetString("sync.mode")
 	federationSov := v.GetString("federation.sovereignty")
 	federationRemote := v.GetString("federation.remote")
-
-	// Validate sync.mode
-	if syncMode != "" && !config.IsValidSyncMode(syncMode) {
-		issues = append(issues, fmt.Sprintf("sync.mode: %q is invalid (valid values: %s)", syncMode, strings.Join(config.ValidSyncModes(), ", ")))
-	}
 
 	// Validate federation.sovereignty
 	if federationSov != "" && !config.IsValidSovereignty(federationSov) {

--- a/cmd/bd/config_test.go
+++ b/cmd/bd/config_test.go
@@ -332,29 +332,6 @@ func TestValidateSyncConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid sync.mode", func(t *testing.T) {
-		configContent := `prefix: test
-sync:
-  mode: "invalid-mode"
-`
-		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
-			t.Fatalf("Failed to write config.yaml: %v", err)
-		}
-
-		issues := validateSyncConfig(tmpDir)
-		found := false
-		for _, issue := range issues {
-			if strings.Contains(issue, "sync.mode") {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected issue about sync.mode, got: %v", issues)
-		}
-	})
-
-
 	t.Run("invalid federation.sovereignty", func(t *testing.T) {
 		configContent := `prefix: test
 federation:
@@ -377,10 +354,8 @@ federation:
 		}
 	})
 
-	t.Run("dolt-native mode without remote", func(t *testing.T) {
+	t.Run("missing remote", func(t *testing.T) {
 		configContent := `prefix: test
-sync:
-  mode: "dolt-native"
 `
 		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
 			t.Fatalf("Failed to write config.yaml: %v", err)
@@ -423,8 +398,6 @@ federation:
 
 	t.Run("valid sync config", func(t *testing.T) {
 		configContent := `prefix: test
-sync:
-  mode: "dolt-native"
 conflict:
   strategy: "newest"
 federation:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,7 +32,6 @@ Tool-level settings you can configure:
 |---------|------|---------------------|---------|-------------|
 | `json` | `--json` | `BD_JSON` | `false` | Output in JSON format |
 | `no-push` | `--no-push` | `BD_NO_PUSH` | `false` | Skip pushing to remote in bd sync |
-| `sync.mode` | - | `BD_SYNC_MODE` | `git-portable` | Sync mode (see below) |
 | `sync.export_on` | - | `BD_SYNC_EXPORT_ON` | `push` | When to export: `push`, `change` |
 | `sync.import_on` | - | `BD_SYNC_IMPORT_ON` | `pull` | When to import: `pull`, `change` |
 | `federation.remote` | - | `BD_FEDERATION_REMOTE` | (none) | Dolt remote URL for federation |
@@ -146,13 +145,9 @@ To override, set `BD_ACTOR` in your shell profile:
 export BD_ACTOR="my-github-handle"
 ```
 
-### Sync Mode Configuration
+### Sync Configuration
 
-The sync mode controls how beads synchronizes data with git and/or Dolt remotes.
-
-#### Sync Mode
-
-Beads uses `dolt-native` sync mode exclusively. Dolt remotes handle sync directly with cell-level merge. Manual `bd import` / `bd export` are available for migration and portability.
+Beads uses Dolt-native sync exclusively. Dolt remotes handle sync directly with cell-level merge. Manual `bd import` / `bd export` are available for migration and portability.
 
 #### Sync Triggers
 

--- a/docs/DOLT-BACKEND.md
+++ b/docs/DOLT-BACKEND.md
@@ -41,13 +41,9 @@ bd init
 # For legacy SQLite installations, see Migration from SQLite below
 ```
 
-### 3. Configure Sync Mode
+### 3. Configure Sync
 
-```yaml
-# .beads/config.yaml
-sync:
-  mode: dolt-native  # Default: use Dolt remotes
-```
+Beads uses Dolt-native sync by default — no sync mode configuration needed.
 
 ## Server Mode (Recommended)
 
@@ -92,13 +88,9 @@ bd doctor
 kill $(cat .beads/dolt/sql-server.pid)
 ```
 
-## Sync Modes
+## Sync
 
-Dolt supports multiple sync strategies:
-
-### Sync Mode
-
-Beads uses `dolt-native` sync mode exclusively:
+Beads uses Dolt-native sync exclusively:
 
 - Uses Dolt remotes (DoltHub, S3, GCS, etc.)
 - Native database-level sync with cell-level merge
@@ -298,7 +290,6 @@ dolt blame issues
 backend: dolt
 
 sync:
-  mode: dolt-native
   auto_dolt_commit: true   # Auto-commit after sync (default: true)
   auto_dolt_push: false    # Auto-push after sync (default: false)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,9 +151,8 @@ func Initialize() error {
 	// Sync configuration defaults (bd-4u8)
 	v.SetDefault("sync.require_confirmation_on_mass_delete", false)
 
-	// Sync mode configuration (hq-ew1mbr.3)
+	// Sync trigger configuration (hq-ew1mbr.3)
 	// See docs/CONFIG.md for detailed documentation
-	v.SetDefault("sync.mode", SyncModeDoltNative)
 	v.SetDefault("sync.export_on", SyncTriggerPush) // push | change
 	v.SetDefault("sync.import_on", SyncTriggerPull) // pull | change
 
@@ -720,17 +719,16 @@ func GetIdentity(flagValue string) string {
 	return "unknown"
 }
 
-// SyncConfig holds the sync mode configuration.
+// SyncConfig holds the sync trigger configuration.
+// Beads uses dolt-native sync exclusively; there is no mode selection.
 type SyncConfig struct {
-	Mode     SyncMode // dolt-native (only supported mode)
-	ExportOn string   // push, change
-	ImportOn string   // pull, change
+	ExportOn string // push, change
+	ImportOn string // pull, change
 }
 
 // GetSyncConfig returns the current sync configuration.
 func GetSyncConfig() SyncConfig {
 	return SyncConfig{
-		Mode:     GetSyncMode(),
 		ExportOn: GetString("sync.export_on"),
 		ImportOn: GetString("sync.import_on"),
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1114,13 +1114,7 @@ validation:
 	}
 }
 
-// Tests for sync mode configuration (hq-ew1mbr.3)
-
-func TestSyncModeConstants(t *testing.T) {
-	if SyncModeDoltNative != "dolt-native" {
-		t.Errorf("SyncModeDoltNative = %q, want \"dolt-native\"", SyncModeDoltNative)
-	}
-}
+// Tests for sync trigger configuration (hq-ew1mbr.3)
 
 func TestSyncTriggerConstants(t *testing.T) {
 	if SyncTriggerPush != "push" {
@@ -1159,16 +1153,8 @@ func TestSyncConfigDefaults(t *testing.T) {
 		t.Fatalf("Initialize() returned error: %v", err)
 	}
 
-	// Test sync mode default
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() = %q, want %q", got, SyncModeDoltNative)
-	}
-
 	// Test sync config defaults
 	cfg := GetSyncConfig()
-	if cfg.Mode != SyncModeDoltNative {
-		t.Errorf("GetSyncConfig().Mode = %q, want %q", cfg.Mode, SyncModeDoltNative)
-	}
 	if cfg.ExportOn != SyncTriggerPush {
 		t.Errorf("GetSyncConfig().ExportOn = %q, want %q", cfg.ExportOn, SyncTriggerPush)
 	}
@@ -1205,7 +1191,6 @@ func TestSyncConfigFromFile(t *testing.T) {
 	// Create a config file with sync settings
 	configContent := `
 sync:
-  mode: dolt-native
   export_on: change
   import_on: change
 
@@ -1233,9 +1218,6 @@ federation:
 
 	// Test sync config
 	syncCfg := GetSyncConfig()
-	if syncCfg.Mode != SyncModeDoltNative {
-		t.Errorf("GetSyncConfig().Mode = %q, want %q", syncCfg.Mode, SyncModeDoltNative)
-	}
 	if syncCfg.ExportOn != SyncTriggerChange {
 		t.Errorf("GetSyncConfig().ExportOn = %q, want %q", syncCfg.ExportOn, SyncTriggerChange)
 	}
@@ -1253,22 +1235,6 @@ federation:
 	}
 }
 
-func TestGetSyncModeInvalid(t *testing.T) {
-	// Isolate from environment variables
-	restore := envSnapshot(t)
-	defer restore()
-
-	// Initialize config
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize() returned error: %v", err)
-	}
-
-	// Set invalid mode - always returns dolt-native now
-	Set("sync.mode", "invalid-mode")
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() with invalid mode = %q, want %q", got, SyncModeDoltNative)
-	}
-}
 
 func TestGetSovereigntyInvalid(t *testing.T) {
 	// Isolate from environment variables

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -7,8 +7,12 @@ import (
 	"strings"
 )
 
-// Sync mode configuration values (from hq-ew1mbr.3)
-// These control how Dolt syncs with remotes.
+// NOTE: Sync mode scaffolding (SyncMode type, GetSyncMode, IsValidSyncMode,
+// ValidSyncModes) was removed in this cleanup. Beads uses dolt-native sync
+// exclusively; there is no mode selection.
+
+// Sync configuration values (from hq-ew1mbr.3)
+// Config warnings and sovereignty tiers for federation.
 
 // ConfigWarnings controls whether warnings are logged for invalid config values.
 // Set to false to suppress warnings (useful for tests or scripts).
@@ -25,30 +29,6 @@ func logConfigWarning(format string, args ...interface{}) {
 	}
 }
 
-// SyncMode represents the sync mode configuration
-type SyncMode string
-
-const (
-	// SyncModeDoltNative uses Dolt remote directly (the only supported mode)
-	SyncModeDoltNative SyncMode = "dolt-native"
-)
-
-// validSyncModes is the set of allowed sync mode values
-var validSyncModes = map[SyncMode]bool{
-	SyncModeDoltNative: true,
-}
-
-// ValidSyncModes returns the list of valid sync mode values.
-func ValidSyncModes() []string {
-	return []string{
-		string(SyncModeDoltNative),
-	}
-}
-
-// IsValidSyncMode returns true if the given string is a valid sync mode.
-func IsValidSyncMode(mode string) bool {
-	return validSyncModes[SyncMode(strings.ToLower(strings.TrimSpace(mode)))]
-}
 
 // Sovereignty represents the federation sovereignty tier
 type Sovereignty string
@@ -93,11 +73,6 @@ func IsValidSovereignty(sovereignty string) bool {
 	return validSovereigntyTiers[Sovereignty(strings.ToUpper(strings.TrimSpace(sovereignty)))]
 }
 
-// GetSyncMode always returns SyncModeDoltNative.
-// The sync mode config key is deprecated; Dolt-native is the only supported mode.
-func GetSyncMode() SyncMode {
-	return SyncModeDoltNative
-}
 
 // GetSovereignty retrieves the federation sovereignty tier configuration.
 // Returns the configured tier, or SovereigntyNone (empty, no restriction) if not set.
@@ -122,10 +97,6 @@ func GetSovereignty() Sovereignty {
 	return tier
 }
 
-// String returns the string representation of the SyncMode.
-func (m SyncMode) String() string {
-	return string(m)
-}
 
 // String returns the string representation of the Sovereignty.
 func (s Sovereignty) String() string {

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -6,17 +6,6 @@ import (
 	"testing"
 )
 
-func TestGetSyncMode(t *testing.T) {
-	// GetSyncMode always returns dolt-native regardless of config
-	ResetForTesting()
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize failed: %v", err)
-	}
-
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() = %q, want %q", got, SyncModeDoltNative)
-	}
-}
 
 func TestGetSovereignty(t *testing.T) {
 	tests := []struct {
@@ -155,25 +144,6 @@ func TestConfigWarningsToggle(t *testing.T) {
 	ConfigWarningWriter = oldWriter
 }
 
-func TestIsValidSyncMode(t *testing.T) {
-	tests := []struct {
-		mode  string
-		valid bool
-	}{
-		{"dolt-native", true},
-		{"Dolt-Native", true},          // case insensitive
-		{"git-portable", false},        // removed
-		{"belt-and-suspenders", false}, // removed
-		{"invalid", false},
-		{"", false},
-	}
-
-	for _, tt := range tests {
-		if got := IsValidSyncMode(tt.mode); got != tt.valid {
-			t.Errorf("IsValidSyncMode(%q) = %v, want %v", tt.mode, got, tt.valid)
-		}
-	}
-}
 
 func TestIsValidSovereignty(t *testing.T) {
 	tests := []struct {
@@ -199,15 +169,6 @@ func TestIsValidSovereignty(t *testing.T) {
 	}
 }
 
-func TestValidSyncModes(t *testing.T) {
-	modes := ValidSyncModes()
-	if len(modes) != 1 {
-		t.Errorf("ValidSyncModes() returned %d modes, want 1", len(modes))
-	}
-	if modes[0] != "dolt-native" {
-		t.Errorf("ValidSyncModes()[0] = %q, want %q", modes[0], "dolt-native")
-	}
-}
 
 func TestValidSovereigntyTiers(t *testing.T) {
 	tiers := ValidSovereigntyTiers()
@@ -222,11 +183,6 @@ func TestValidSovereigntyTiers(t *testing.T) {
 	}
 }
 
-func TestSyncModeString(t *testing.T) {
-	if got := SyncModeDoltNative.String(); got != "dolt-native" {
-		t.Errorf("SyncModeDoltNative.String() = %q, want %q", got, "dolt-native")
-	}
-}
 
 func TestSovereigntyString(t *testing.T) {
 	if got := SovereigntyT1.String(); got != "T1" {


### PR DESCRIPTION
## Summary

- Removes ~130 lines of vestigial `SyncMode` scaffolding left over from the multi-mode sync era (v0.50–v0.56)
- `git-portable`, `realtime`, and `belt-and-suspenders` modes were already removed; only `dolt-native` remains hardcoded
- The `SyncMode` type, const, validation functions, config default, and `Mode` field on `SyncConfig` were dead weight

## Changes

- **internal/config/sync.go**: Removed `SyncMode` type, `SyncModeDoltNative` const, `validSyncModes` map, `ValidSyncModes()`, `IsValidSyncMode()`, `GetSyncMode()`, `SyncMode.String()`
- **internal/config/config.go**: Removed `sync.mode` config default, removed `Mode` field from `SyncConfig`
- **cmd/bd/config.go**: Removed `sync.mode` from yamlKeys list, removed sync.mode validation, updated help text
- **internal/config/sync_test.go**: Removed `TestGetSyncMode`, `TestIsValidSyncMode`, `TestValidSyncModes`, `TestSyncModeString`
- **internal/config/config_test.go**: Removed `TestSyncModeConstants`, `TestGetSyncModeInvalid`, removed `.Mode` assertions
- **cmd/bd/config_test.go**: Removed "invalid sync.mode" test, cleaned up test config YAMLs
- **docs/CONFIG.md**: Removed `sync.mode` row from settings table, simplified sync section
- **docs/DOLT-BACKEND.md**: Removed `sync.mode` from config examples, simplified headings

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] `go test ./internal/config/...` passes (sovereignty tests unaffected)
- [ ] `go test ./cmd/bd/...` passes (config validation tests updated)
- [ ] Existing `sync.export_on` / `sync.import_on` config still works

## Wasteland

Completion for wanted item `w-bd-004` ("Audit sync mode complexity"), posted by @steveyegge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)