### PR TITLE
fix(worktree): skip .gitignore append when parent directory pattern already covers the entry

### DIFF
--- a/cmd/bd/worktree_cmd.go
+++ b/cmd/bd/worktree_cmd.go
@@ -691,11 +691,16 @@ func addToGitignore(ctx context.Context, repoRoot, entry string) error {
 		return err
 	}
 
-	// Check if already present
+	// Check if already present or covered by a parent-directory pattern.
+	// e.g. if ".worktrees" is in .gitignore, ".worktrees/my-branch" is already covered.
 	lines := strings.Split(string(content), "\n")
 	for _, line := range lines {
-		if strings.TrimSpace(line) == entry || strings.TrimSpace(line) == entry+"/" {
-			return nil // Already present
+		trimmed := strings.TrimSuffix(strings.TrimSpace(line), "/")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == entry || strings.HasPrefix(entry+"/", trimmed+"/") {
+			return nil // Already present or covered by a parent pattern
 		}
 	}
 


### PR DESCRIPTION
## Problem

`bd worktree create .worktrees/my-branch` appends `.worktrees/my-branch/` to `.gitignore` even when `.worktrees` (or `.worktrees/`) is already in `.gitignore`, making the append unnecessary noise.

`addToGitignore` has two safeguards:
1. `isIgnoredByGit` — runs `git check-ignore -q --no-index` to detect parent-pattern coverage
2. A string match loop — checks if the exact entry is already a line in `.gitignore`

When (1) fails silently (non-zero/non-one exit from git, or environment issues), (2) is the only fallback — but it only checks for an exact line match, so `.worktrees` in `.gitignore` never matches `.worktrees/my-branch`.

## Fix

Enhance the string match to also detect parent-directory coverage: strip trailing slashes from each existing line and check whether the new entry falls under that prefix.

```
.worktrees     → covers .worktrees/my-branch  ✓
.worktrees/    → covers .worktrees/my-branch  ✓
```

This is a deterministic fallback that doesn't rely on `git check-ignore` behaving consistently across git versions or environments.

## Before / After

**Before:** `.worktrees` in `.gitignore` → `bd worktree create .worktrees/foo` appends `.worktrees/foo/`

**After:** `.worktrees` in `.gitignore` → `bd worktree create .worktrees/foo` skips the append