### PR TITLE
fix(dolt): add BEADS_DOLT_IDLE_MONITOR env var to disable idle monitor

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -864,7 +864,11 @@ func stopServerProcess(beadsDir string) error {
 
 // forkIdleMonitor starts the idle monitor as a detached process.
 // It runs `bd dolt idle-monitor --beads-dir=<dir>` in the background.
+// Skipped when BEADS_DOLT_IDLE_MONITOR=0 (e.g., external server manager).
 func forkIdleMonitor(beadsDir string) {
+	if os.Getenv("BEADS_DOLT_IDLE_MONITOR") == "0" {
+		return
+	}
 	// Don't fork if there's already a monitor running
 	if isMonitorRunning(beadsDir) {
 		return
@@ -946,8 +950,12 @@ func ReadActivityTime(beadsDir string) time.Time {
 // (watchdog behavior).
 //
 // idleTimeout of 0 means monitoring is disabled (exits immediately).
+// Also disabled when BEADS_DOLT_IDLE_MONITOR=0 (e.g., external server manager).
 func RunIdleMonitor(beadsDir string, idleTimeout time.Duration) {
 	if idleTimeout == 0 {
+		return
+	}
+	if os.Getenv("BEADS_DOLT_IDLE_MONITOR") == "0" {
 		return
 	}
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -826,6 +826,39 @@ func TestStopServerProcessRemovesPidAndPort(t *testing.T) {
 	}
 }
 
+func TestRunIdleMonitorEnvDisabled(t *testing.T) {
+	// BEADS_DOLT_IDLE_MONITOR=0 should cause RunIdleMonitor to exit immediately
+	// even with a non-zero timeout.
+	t.Setenv("BEADS_DOLT_IDLE_MONITOR", "0")
+	dir := t.TempDir()
+
+	done := make(chan struct{})
+	go func() {
+		RunIdleMonitor(dir, 5*time.Minute)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good — exited immediately
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunIdleMonitor should exit immediately when BEADS_DOLT_IDLE_MONITOR=0")
+	}
+}
+
+func TestForkIdleMonitorEnvDisabled(t *testing.T) {
+	// BEADS_DOLT_IDLE_MONITOR=0 should prevent forkIdleMonitor from spawning.
+	t.Setenv("BEADS_DOLT_IDLE_MONITOR", "0")
+	dir := t.TempDir()
+
+	forkIdleMonitor(dir)
+
+	// No monitor PID file should be written
+	if _, err := os.Stat(monitorPidPath(dir)); !os.IsNotExist(err) {
+		t.Error("forkIdleMonitor should not spawn when BEADS_DOLT_IDLE_MONITOR=0")
+	}
+}
+
 func TestRunIdleMonitorZeroTimeoutExitsImmediately(t *testing.T) {
 	// With zero timeout, the monitor should exit immediately.
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

When an external process manages the Dolt server lifecycle (e.g., a daemon, container orchestrator, or shared server), the embedded idle monitor is counterproductive — it can stop or restart the shared server unexpectedly, or spawn rogue server processes on random ports.

- Add `BEADS_DOLT_IDLE_MONITOR=0` env var check to `forkIdleMonitor()` — prevents spawning monitor processes
- Add same check to `RunIdleMonitor()` — exits immediately if invoked directly via `bd dolt idle-monitor`

### The bug

`forkIdleMonitor()` is called unconditionally from `Start()`. In environments where an external process manages the Dolt server, this creates rogue idle monitors that can:
1. Stop the shared server after an idle timeout
2. Restart it on a random port via the watchdog loop
3. Cascade — `Start()` called from the watchdog forks yet another monitor

Setting `BEADS_DOLT_IDLE_MONITOR=0` in the environment prevents all of this.

## Test plan

- [x] `TestRunIdleMonitorEnvDisabled` — verifies `RunIdleMonitor` exits immediately when env var set
- [x] `TestForkIdleMonitorEnvDisabled` — verifies `forkIdleMonitor` does not spawn when env var set
- [x] Full `internal/doltserver` test suite passes
- [x] Existing idle monitor tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)