### PR TITLE
Replace hash-derived dolt ports with OS-assigned ephemeral ports

### DIFF
--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -30,11 +30,13 @@ func openDoltDB(beadsDir string) (*sql.DB, *configfile.Config, error) {
 	database := configfile.DefaultDoltDatabase
 	password := os.Getenv("BEADS_DOLT_PASSWORD")
 
-	// Use doltserver.DefaultConfig for port resolution (env > config > Gas Town > DerivePort).
-	// cfg.GetDoltServerPort() is deprecated — it falls back to 3307 which is wrong
-	// for standalone mode where the port is hash-derived from the project path.
+	// Use doltserver.DefaultConfig for port resolution (env > port file > config.yaml).
+	// Port 0 means no server running yet.
 	dsCfg := doltserver.DefaultConfig(beadsDir)
 	port := dsCfg.Port
+	if port == 0 {
+		return nil, nil, fmt.Errorf("no Dolt server port configured and no server running; run any bd command to auto-start")
+	}
 
 	if cfg != nil {
 		host = cfg.GetDoltServerHost()

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -308,7 +308,7 @@ func CheckFreshClone(repoPath string) DoctorCheck {
 		if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil && cfg.IsDoltServerMode() {
 			host := cfg.GetDoltServerHost()
 			// Use DefaultConfig (not deprecated GetDoltServerPort) to resolve
-			// the correct port for standalone server mode (hash-derived).
+			// the correct port for standalone server mode (ephemeral).
 			port := doltserver.DefaultConfig(beadsDir).Port
 			user := cfg.GetDoltServerUser()
 			password := cfg.GetDoltServerPassword()

--- a/cmd/bd/doctor/perf_dolt.go
+++ b/cmd/bd/doctor/perf_dolt.go
@@ -56,7 +56,7 @@ func RunDoltPerformanceDiagnostics(path string, enableProfiling bool) (*DoltPerf
 		GoVersion: runtime.Version(),
 	}
 
-	// Resolve server config (handles standalone hash-derived ports)
+	// Resolve server config (handles standalone ephemeral ports)
 	dsCfg := doltserver.DefaultConfig(beadsDir)
 
 	// Check server status

--- a/cmd/bd/doctor/server.go
+++ b/cmd/bd/doctor/server.go
@@ -84,9 +84,18 @@ func RunServerHealthChecks(path string) ServerHealthResult {
 
 	// Server mode is configured - run health checks
 	host := cfg.GetDoltServerHost()
-	// Use doltserver.DefaultConfig for port resolution (env > config > DerivePort).
-	// cfg.GetDoltServerPort() falls back to 3307 which is wrong for standalone mode.
+	// Use doltserver.DefaultConfig for port resolution (env > port file > config.yaml).
+	// Port 0 means server not yet started — report that clearly.
 	port := doltserver.DefaultConfig(beadsDir).Port
+	if port == 0 {
+		result.Checks = append(result.Checks, DoctorCheck{
+			Name:     "Server port",
+			Status:   StatusWarning,
+			Message:  "No Dolt server port configured and no server running. Run any bd command to auto-start.",
+			Category: CategoryFederation,
+		})
+		return result
+	}
 
 	// Check 1: Server reachability (TCP connect)
 	reachCheck := checkServerReachable(host, port)

--- a/cmd/bd/doctor_health.go
+++ b/cmd/bd/doctor_health.go
@@ -36,9 +36,18 @@ func runCheckHealth(path string) {
 		return
 	}
 
-	// Try connecting to Dolt server for config/version checks
+	// Try connecting to Dolt server for config/version checks.
+	// Use doltserver.DefaultConfig for port resolution — GetDoltServerPort
+	// falls back to 3307 which is wrong for ephemeral ports.
 	host := cfg.GetDoltServerHost()
 	port := doltserver.DefaultConfig(beadsDir).Port
+	if port == 0 {
+		// No server running yet — skip DB checks, only check hooks.
+		if issue := doctor.CheckHooksQuick(Version); issue != "" {
+			printCheckHealthHint([]string{issue})
+		}
+		return
+	}
 	database := cfg.GetDoltDatabase()
 
 	var issues []string

--- a/cmd/bd/info.go
+++ b/cmd/bd/info.go
@@ -285,7 +285,7 @@ var versionChanges = []VersionChange{
 			"NEW: Linear Project sync support",
 			"FIX: Shadow database prevention — no more silent CREATE DATABASE",
 			"FIX: Reparented child no longer appears under old parent",
-			"FIX: Dolt port resolution uses hash-derived port (not hardcoded 3307)",
+			"FIX: Dolt port resolution uses ephemeral port (not hardcoded 3307)",
 			"FIX: Doctor checks respect dolt-data-dir config",
 			"FIX: AUTO_INCREMENT reset after DOLT_PULL",
 			"FIX: Windows compatibility (Makefile, connectex, doltserver)",

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -379,10 +379,8 @@ environment variable.`,
 		// AutoStart is always enabled during init — we need a server to initialize the database.
 		//
 		// Use doltserver.DefaultConfig to resolve the port via the standard chain
-		// (env var → port file → config.yaml → DerivePort). Without this, the
-		// store's applyConfigDefaults falls back to DefaultSQLPort (3307), which
-		// may belong to a DIFFERENT project's server, causing cross-project data
-		// leakage (GH#2372).
+		// (env var → port file → config.yaml). Port 0 means auto-start will
+		// allocate an ephemeral port (GH#2098, GH#2372).
 		doltDefaults := doltserver.DefaultConfig(beadsDir)
 		doltCfg := &dolt.Config{
 			Path:            storagePath,

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -497,10 +497,8 @@ var rootCmd = &cobra.Command{
 			doltCfg.Database = cfg.GetDoltDatabase()
 
 			doltCfg.ServerHost = cfg.GetDoltServerHost()
-			// cfg.GetDoltServerPort() falls back to 3307 which is wrong for
-			// standalone mode where the port is hash-derived from the beadsDir
-			// path. Use doltserver.DefaultConfig() which checks metadata.json,
-			// env vars, and falls back to the hash-derived port.
+			// Use doltserver.DefaultConfig for port resolution (env > port file >
+			// config.yaml). Port 0 is fine here — auto-start will resolve it.
 			doltCfg.ServerPort = doltserver.DefaultConfig(beadsDir).Port
 			doltCfg.ServerUser = cfg.GetDoltServerUser()
 			doltCfg.ServerPassword = cfg.GetDoltServerPassword()

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -254,7 +254,7 @@ func (c *Config) GetDoltServerHost() string {
 
 // Deprecated: Use doltserver.DefaultConfig(beadsDir).Port instead.
 // This method falls back to 3307 which is wrong for standalone mode
-// (where the port is hash-derived from the project path).
+// (where the port is an OS-assigned ephemeral port).
 // Kept for backward compatibility with external consumers.
 //
 // GetDoltServerPort returns the Dolt server port.

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2,25 +2,23 @@
 // It provides transparent auto-start so that `bd init` and `bd <command>` work
 // without manual server management.
 //
-// The default port is 3307 (configfile.DefaultDoltServerPort),
-// matching shared Homebrew Dolt servers. If another project's Dolt server already
-// occupies port 3307, Start falls back to DerivePort for per-project isolation
-// (hash-derived, range 13307–14306). Users with explicit port config in
-// metadata.json or BEADS_DOLT_SERVER_PORT env var always use that port instead.
+// Port assignment uses OS-assigned ephemeral ports by default. When no explicit
+// port is configured (env var, config.yaml, metadata.json), Start() asks the OS
+// for a free port via net.Listen(":0"), passes it to dolt sql-server, and writes
+// the actual port to dolt-server.port. This eliminates the birthday-problem
+// collisions that plagued the old hash-derived port scheme (GH#2098, GH#2372).
 //
-// Anti-proliferation: the server enforces one-server-one-port. If the canonical
-// port is busy, the server identifies and handles the occupant rather than
-// silently starting on another port.
+// Users with explicit port config via BEADS_DOLT_SERVER_PORT env var or
+// config.yaml always use that port instead, with conflict detection via
+// reclaimPort.
 //
-// Server state files (PID, log, lock) live in the .beads/ directory.
+// Server state files (PID, port, log, lock) live in the .beads/ directory.
 package doltserver
 
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
-	"hash/fnv"
 	"net"
 	"os"
 	"os/exec"
@@ -36,11 +34,9 @@ import (
 	"github.com/steveyegge/beads/internal/lockfile"
 )
 
-// Port range for auto-derived ports.
-const (
-	portRangeBase = 13307
-	portRangeSize = 1000
-)
+// maxEphemeralPortAttempts is the number of times Start() retries ephemeral
+// port allocation when the TOCTOU race causes a bind failure.
+const maxEphemeralPortAttempts = 10
 
 // resolveServerDir returns the canonical server directory for dolt state files.
 // Returns beadsDir unchanged.
@@ -83,7 +79,7 @@ func ResolveDoltDir(beadsDir string) string {
 // Config holds the server configuration.
 type Config struct {
 	BeadsDir string // Path to .beads/ directory
-	Port     int    // MySQL protocol port (0 = use DefaultDoltServerPort 3307)
+	Port     int    // MySQL protocol port (0 = allocate ephemeral port on Start)
 	Host     string // Bind address (default: 127.0.0.1)
 }
 
@@ -111,35 +107,18 @@ func maxDoltServers() int {
 	return 3
 }
 
-// ErrPortOccupiedByOtherProject is returned by reclaimPort when the canonical
-// port is held by another beads project's Dolt server (different data dir).
-// Start uses this to fall back to DerivePort for per-project isolation.
-var ErrPortOccupiedByOtherProject = fmt.Errorf("port occupied by another project's dolt server")
-
-// fallbackPort returns the DerivePort value for a beadsDir, used when the
-// default port (3307) is occupied by another project's Dolt server.
-func fallbackPort(beadsDir string) int {
-	return DerivePort(beadsDir)
-}
-
-// DerivePort computes a stable port from the beadsDir path.
-// Maps to range 13307–14306 (1000 ports) to avoid common service ports.
-// The port is deterministic: same path always yields the same port.
-//
-// The 1000-port hash space means collisions become likely around 9+
-// concurrent projects (~3.9% probability via the birthday paradox with
-// fnv32a % 1000). This is acceptable because reclaimPort() in Start()
-// detects when another project's server already occupies the derived
-// port and falls back gracefully — hash collisions cause a retry, not
-// a failure.
-func DerivePort(beadsDir string) int {
-	abs, err := filepath.Abs(beadsDir)
+// allocateEphemeralPort asks the OS for a free TCP port on host.
+// It binds to port 0, reads the assigned port, and closes the listener.
+// The caller should pass the returned port to dolt sql-server promptly
+// to minimize the TOCTOU window.
+func allocateEphemeralPort(host string) (int, error) {
+	ln, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
 	if err != nil {
-		abs = beadsDir
+		return 0, fmt.Errorf("allocating ephemeral port: %w", err)
 	}
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(abs))
-	return portRangeBase + int(h.Sum32()%uint32(portRangeSize))
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port, nil
 }
 
 // isPortAvailable checks if a TCP port is available for binding.
@@ -153,11 +132,12 @@ func isPortAvailable(host string, port int) bool {
 	return true
 }
 
-// reclaimPort ensures the canonical port is available for use.
+// reclaimPort ensures an explicit (user-configured) port is available for use.
+// Only called for explicit ports (env var, config.yaml, metadata.json).
 // If the port is busy:
 //   - If our dolt server (same data dir) → return its PID for adoption
 //   - If a stale/orphan dolt sql-server holds it → kill it and reclaim
-//   - If a non-dolt process holds it → return error (don't silently use another port)
+//   - If another project's dolt or a non-dolt process → return error
 //
 // Returns (adoptPID, nil) when an existing server should be adopted.
 // Returns (0, nil) when the port is free for a new server.
@@ -194,8 +174,7 @@ func reclaimPort(host string, port int, beadsDir string) (adoptPID int, err erro
 	}
 
 	// Another beads project's Dolt server is on this port.
-	// Don't kill it — return a sentinel so Start can fall back to DerivePort.
-	return 0, ErrPortOccupiedByOtherProject
+	return 0, fmt.Errorf("port %d is in use by another project's dolt server (PID %d).\n\nFree the port or use a different one with: bd dolt set port <port>", port, pid)
 }
 
 // countDoltProcesses returns the number of running dolt sql-server processes.
@@ -244,13 +223,13 @@ func EnsurePortFile(beadsDir string, port int) error {
 }
 
 // DefaultConfig returns config with sensible defaults.
-// Priority: env var > metadata.json > config.yaml / global config > port file > DerivePort.
+// Priority: env var > port file > config.yaml / global config > metadata.json.
+// Returns port 0 when no source provides a port, meaning Start() should
+// allocate an ephemeral port from the OS.
 //
 // The port file (dolt-server.port) is written by Start() with the actual port
 // the server is listening on. Consulting it here ensures that commands
-// connecting to an already-running server use the correct port — even when
-// Start() fell back to DerivePort because another project occupied the default
-// port.
+// connecting to an already-running server use the correct port.
 func DefaultConfig(beadsDir string) *Config {
 	cfg := &Config{
 		BeadsDir: beadsDir,
@@ -300,9 +279,10 @@ func DefaultConfig(beadsDir string) *Config {
 		}
 	}
 
-	if cfg.Port == 0 {
-		cfg.Port = DerivePort(beadsDir)
-	}
+	// Port 0 means "no configured port" — Start() will allocate an
+	// ephemeral port from the OS. This replaces the old DerivePort
+	// hash-based fallback that suffered from birthday-problem collisions
+	// (GH#2098, GH#2372).
 
 	return cfg
 }
@@ -340,11 +320,25 @@ func IsRunning(beadsDir string) (*State, error) {
 		return &State{Running: false}, nil
 	}
 
-	// Read actual port from port file; fall back to config-derived port
+	// Read actual port from port file; fall back to config-derived port.
 	port := readPortFile(beadsDir)
 	if port == 0 {
 		cfg := DefaultConfig(beadsDir)
 		port = cfg.Port
+	}
+	if port == 0 {
+		// Server is running but we can't determine its port (port file
+		// missing, no explicit config). Stop the orphan so that callers
+		// (EnsureRunning) trigger a fresh Start() with a new port file.
+		fmt.Fprintf(os.Stderr, "Dolt server (PID %d) running but port unknown; stopping for restart\n", pid)
+		if err := gracefulStop(pid, 5*time.Second); err != nil {
+			// Best-effort kill
+			if proc, findErr := os.FindProcess(pid); findErr == nil {
+				_ = proc.Kill()
+			}
+		}
+		_ = os.Remove(pidPath(beadsDir))
+		return &State{Running: false}, nil
 	}
 	return &State{
 		Running: true,
@@ -448,73 +442,109 @@ func Start(beadsDir string) (*State, error) {
 		return nil, fmt.Errorf("opening log file: %w", err)
 	}
 
-	// Reclaim the canonical port. If another project's Dolt holds it,
-	// fall back to a hash-derived port for per-project isolation.
+	// Resolve the port to use. Explicit ports (env/config) go through
+	// reclaimPort for conflict detection. Port 0 means ephemeral — allocate
+	// a fresh port from the OS with retry for TOCTOU races.
 	actualPort := cfg.Port
-	adoptPID, reclaimErr := reclaimPort(cfg.Host, actualPort, beadsDir)
-	if reclaimErr != nil {
-		if errors.Is(reclaimErr, ErrPortOccupiedByOtherProject) {
-			// Another project's Dolt server is on the default port —
-			// use a hash-derived port for this project instead.
-			fmt.Fprintf(os.Stderr, "Port %d occupied by another project's Dolt server; falling back to port %d\n", actualPort, fallbackPort(beadsDir))
-			actualPort = fallbackPort(beadsDir)
-			adoptPID, reclaimErr = reclaimPort(cfg.Host, actualPort, beadsDir)
-			if reclaimErr != nil {
-				_ = logFile.Close()
-				return nil, fmt.Errorf("cannot start dolt server on fallback port %d: %w", actualPort, reclaimErr)
-			}
-		} else {
+	explicitPort := 0 < actualPort
+
+	if explicitPort {
+		// Explicit port: check for conflicts and adopt existing servers.
+		adoptPID, reclaimErr := reclaimPort(cfg.Host, actualPort, beadsDir)
+		if reclaimErr != nil {
 			_ = logFile.Close()
 			return nil, fmt.Errorf("cannot start dolt server on port %d: %w", actualPort, reclaimErr)
 		}
-	}
-	if adoptPID > 0 {
-		// Existing server is ours (same data dir) — adopt it
-		_ = logFile.Close()
-		_ = os.WriteFile(pidPath(beadsDir), []byte(strconv.Itoa(adoptPID)), 0600)
-		_ = writePortFile(beadsDir, actualPort)
-		touchActivity(beadsDir)
-		forkIdleMonitor(beadsDir)
-		return &State{Running: true, PID: adoptPID, Port: actualPort, DataDir: doltDir}, nil
+		if adoptPID > 0 {
+			_ = logFile.Close()
+			_ = os.WriteFile(pidPath(beadsDir), []byte(strconv.Itoa(adoptPID)), 0600)
+			_ = writePortFile(beadsDir, actualPort)
+			touchActivity(beadsDir)
+			forkIdleMonitor(beadsDir)
+			return &State{Running: true, PID: adoptPID, Port: actualPort, DataDir: doltDir}, nil
+		}
 	}
 
-	// Start dolt sql-server
-	cmd := exec.Command(doltBin, "sql-server", //nolint:gosec // G702: doltBin is resolved from PATH, not user input
-		"-H", cfg.Host,
-		"-P", strconv.Itoa(actualPort),
-	)
-	cmd.Dir = doltDir
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-	cmd.Stdin = nil
-	// New process group so server survives bd exit
-	cmd.SysProcAttr = procAttrDetached()
+	// Start dolt sql-server, with retry loop for ephemeral port TOCTOU.
+	var pid int
+	var lastErr error
+	attempts := 1
+	if !explicitPort {
+		attempts = maxEphemeralPortAttempts
+	}
 
-	if err := cmd.Start(); err != nil {
-		_ = logFile.Close()
-		return nil, fmt.Errorf("starting dolt sql-server: %w", err)
+	for i := range attempts {
+		if !explicitPort {
+			p, allocErr := allocateEphemeralPort(cfg.Host)
+			if allocErr != nil {
+				lastErr = allocErr
+				continue
+			}
+			actualPort = p
+		}
+
+		cmd := exec.Command(doltBin, "sql-server",
+			"-H", cfg.Host,
+			"-P", strconv.Itoa(actualPort),
+		)
+		cmd.Dir = doltDir
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+		cmd.Stdin = nil
+		cmd.SysProcAttr = procAttrDetached()
+
+		if startErr := cmd.Start(); startErr != nil {
+			lastErr = startErr
+			if !explicitPort {
+				continue // retry with a new ephemeral port
+			}
+			_ = logFile.Close()
+			return nil, fmt.Errorf("starting dolt sql-server: %w", startErr)
+		}
+
+		pid = cmd.Process.Pid
+		_ = cmd.Process.Release()
+
+		// Quick check: did the process exit immediately (bind failure)?
+		// Give it a moment to fail on port bind before proceeding.
+		time.Sleep(200 * time.Millisecond)
+		if !isProcessAlive(pid) {
+			lastErr = fmt.Errorf("dolt sql-server exited immediately on port %d (attempt %d/%d)", actualPort, i+1, attempts)
+			pid = 0
+			if !explicitPort {
+				continue
+			}
+			_ = logFile.Close()
+			return nil, lastErr
+		}
+
+		lastErr = nil
+		break
 	}
 	_ = logFile.Close()
 
-	pid := cmd.Process.Pid
+	if lastErr != nil {
+		return nil, fmt.Errorf("failed to start dolt server after %d attempts: %w\nCheck logs: %s",
+			attempts, lastErr, logPath(beadsDir))
+	}
 
 	// Write PID and port files
 	if err := os.WriteFile(pidPath(beadsDir), []byte(strconv.Itoa(pid)), 0600); err != nil {
-		_ = cmd.Process.Kill()
+		if proc, findErr := os.FindProcess(pid); findErr == nil {
+			_ = proc.Kill()
+		}
 		return nil, fmt.Errorf("writing PID file: %w", err)
 	}
 	if err := writePortFile(beadsDir, actualPort); err != nil {
-		_ = cmd.Process.Kill()
+		if proc, findErr := os.FindProcess(pid); findErr == nil {
+			_ = proc.Kill()
+		}
 		_ = os.Remove(pidPath(beadsDir))
 		return nil, fmt.Errorf("writing port file: %w", err)
 	}
 
-	// Release the process handle so it outlives us
-	_ = cmd.Process.Release()
-
 	// Wait for server to accept connections
 	if err := waitForReady(cfg.Host, actualPort, 10*time.Second); err != nil {
-		// Server started but not responding — clean up
 		if proc, findErr := os.FindProcess(pid); findErr == nil {
 			_ = proc.Kill()
 		}

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -13,36 +13,42 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 )
 
-func TestDerivePort(t *testing.T) {
-	// Deterministic: same path gives same port
-	port1 := DerivePort("/home/user/project/.beads")
-	port2 := DerivePort("/home/user/project/.beads")
-	if port1 != port2 {
-		t.Errorf("same path gave different ports: %d vs %d", port1, port2)
+func TestAllocateEphemeralPort(t *testing.T) {
+	// Should return a valid port in the ephemeral range
+	port, err := allocateEphemeralPort("127.0.0.1")
+	if err != nil {
+		t.Fatalf("allocateEphemeralPort: %v", err)
+	}
+	if port < 1024 || 65535 < port {
+		t.Errorf("port %d outside valid range [1024, 65535]", port)
 	}
 
-	// Different paths give different ports (with high probability)
-	port3 := DerivePort("/home/user/other-project/.beads")
-	if port1 == port3 {
-		t.Logf("warning: different paths gave same port (possible but unlikely): %d", port1)
+	// Multiple calls should return different ports (with very high probability)
+	port2, err := allocateEphemeralPort("127.0.0.1")
+	if err != nil {
+		t.Fatalf("allocateEphemeralPort (2nd call): %v", err)
+	}
+	if port == port2 {
+		t.Logf("warning: two consecutive allocations returned the same port %d (unlikely)", port)
+	}
+
+	// The returned port should be available for binding
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port2)))
+	if err != nil {
+		t.Logf("warning: allocated port %d not immediately bindable (TOCTOU): %v", port2, err)
+	} else {
+		_ = ln.Close()
 	}
 }
 
-func TestDerivePortRange(t *testing.T) {
-	// Test many paths to verify range
-	paths := []string{
-		"/a", "/b", "/c", "/tmp/foo", "/home/user/project",
-		"/var/data/repo", "/opt/work/beads", "/Users/test/.beads",
-		"/very/long/path/to/a/project/directory/.beads",
-		"/another/unique/path",
+func TestAllocateEphemeralPortIPv6(t *testing.T) {
+	// Should work with IPv6 loopback if available
+	port, err := allocateEphemeralPort("::1")
+	if err != nil {
+		t.Skipf("IPv6 loopback not available: %v", err)
 	}
-
-	for _, p := range paths {
-		port := DerivePort(p)
-		if port < portRangeBase || port >= portRangeBase+portRangeSize {
-			t.Errorf("DerivePort(%q) = %d, outside range [%d, %d)",
-				p, port, portRangeBase, portRangeBase+portRangeSize)
-		}
+	if port < 1024 || 65535 < port {
+		t.Errorf("port %d outside valid range [1024, 65535]", port)
 	}
 }
 
@@ -179,24 +185,22 @@ func TestIsRunningCorruptPID(t *testing.T) {
 }
 
 func TestDefaultConfig(t *testing.T) {
-	dir := t.TempDir()
-
-	t.Run("standalone", func(t *testing.T) {
-		// Clear both env vars to test pure standalone behavior
+	t.Run("standalone_returns_zero_port", func(t *testing.T) {
+		// Clear env vars to test pure standalone behavior
 		t.Setenv("GT_ROOT", "")
 		t.Setenv("BEADS_DOLT_SERVER_PORT", "")
 
-		cfg := DefaultConfig(dir)
+		freshDir := t.TempDir()
+		cfg := DefaultConfig(freshDir)
 		if cfg.Host != "127.0.0.1" {
 			t.Errorf("expected host 127.0.0.1, got %s", cfg.Host)
 		}
-		// Standalone mode defaults to DerivePort (hash-based, per-project)
-		expected := DerivePort(dir)
-		if cfg.Port != expected {
-			t.Errorf("expected DerivePort %d, got %d", expected, cfg.Port)
+		// No configured port source → port 0 (ephemeral allocation on Start)
+		if cfg.Port != 0 {
+			t.Errorf("expected port 0 (ephemeral) when no port source configured, got %d", cfg.Port)
 		}
-		if cfg.BeadsDir != dir {
-			t.Errorf("expected BeadsDir=%s, got %s", dir, cfg.BeadsDir)
+		if cfg.BeadsDir != freshDir {
+			t.Errorf("expected BeadsDir=%s, got %s", freshDir, cfg.BeadsDir)
 		}
 	})
 
@@ -227,19 +231,17 @@ func TestDefaultConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("no_config_uses_derive_port", func(t *testing.T) {
-		// When no env var, no metadata port, no port file, and no GT_ROOT,
-		// DefaultConfig should use DerivePort for per-project isolation.
+	t.Run("no_config_returns_zero_port", func(t *testing.T) {
+		// When no env var, no metadata port, no port file, and no config.yaml,
+		// DefaultConfig should return port 0 (ephemeral allocation on Start).
 		t.Setenv("GT_ROOT", "")
 		t.Setenv("BEADS_DOLT_SERVER_PORT", "")
 
 		freshDir := t.TempDir()
 		cfg := DefaultConfig(freshDir)
 
-		expected := DerivePort(freshDir)
-		if cfg.Port != expected {
-			t.Errorf("expected DefaultConfig to use DerivePort (%d), got %d",
-				expected, cfg.Port)
+		if cfg.Port != 0 {
+			t.Errorf("expected port 0 (ephemeral) when no port source, got %d", cfg.Port)
 		}
 	})
 
@@ -481,6 +483,35 @@ func TestIsRunningReadsPortFile(t *testing.T) {
 	}
 }
 
+// --- IsRunning port-zero orphan recovery ---
+
+func TestIsRunningOrphanNoPortFile(t *testing.T) {
+	// When PID file exists but process is dead and no port file,
+	// IsRunning should clean up and return Running=false.
+	// (The orphan kill path for *live* processes requires a real dolt server,
+	// but the dead-PID cleanup path exercises the same code structure.)
+	dir := t.TempDir()
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	// Write PID file with dead PID, no port file
+	if err := os.WriteFile(pidPath(dir), []byte("99999999"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := IsRunning(dir)
+	if err != nil {
+		t.Fatalf("IsRunning error: %v", err)
+	}
+	if state.Running {
+		t.Error("expected Running=false for dead PID with no port file")
+	}
+	// PID file should be cleaned up
+	if _, err := os.Stat(pidPath(dir)); !os.IsNotExist(err) {
+		t.Error("expected PID file to be removed")
+	}
+}
+
 // --- Activity tracking tests ---
 
 func TestTouchAndReadActivity(t *testing.T) {
@@ -602,55 +633,45 @@ func TestIsDoltProcessSelf(t *testing.T) {
 	}
 }
 
-// --- Multi-project port fallback tests ---
+// --- Ephemeral port tests ---
 
-func TestReclaimPortOccupiedByOtherProject(t *testing.T) {
-	// When a Dolt server is running on our port but serving a DIFFERENT data dir,
-	// reclaimPort should return ErrPortOccupiedByOtherProject instead of killing it.
-	// This allows Start() to fall back to DerivePort for per-project isolation.
-	//
-	// We can't easily fake a real Dolt process in a unit test, but we can verify
-	// the sentinel error exists and is used correctly by the Start fallback logic.
-	if ErrPortOccupiedByOtherProject == nil {
-		t.Fatal("ErrPortOccupiedByOtherProject sentinel must be defined")
-	}
-}
-
-func TestStartFallsBackToDerivePortOnCollision(t *testing.T) {
-	// When Start() finds another project's Dolt server on the DerivePort,
-	// it should fall back gracefully rather than killing the other server.
-	dir := t.TempDir()
-
-	t.Setenv("GT_ROOT", "")
-	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
-
-	cfg := DefaultConfig(dir)
-	expected := DerivePort(dir)
-	if cfg.Port != expected {
-		t.Fatalf("expected DerivePort %d, got %d", expected, cfg.Port)
-	}
-
-	// The fallback port should be a DerivePort value (13307-14306 range)
-	fallback := fallbackPort(dir)
-	if fallback < portRangeBase || fallback >= portRangeBase+portRangeSize {
-		t.Errorf("fallbackPort(%q) = %d, expected in DerivePort range [%d, %d)",
-			dir, fallback, portRangeBase, portRangeBase+portRangeSize)
-	}
-}
-
-func TestDefaultConfigReturnsDerivePortForStandalone(t *testing.T) {
-	// DefaultConfig must return DerivePort for standalone mode so that each
-	// project gets an isolated port. This prevents multi-project setups from
-	// all trying to connect to the same port (3307).
+func TestDefaultConfigReturnsZeroForStandalone(t *testing.T) {
+	// DefaultConfig must return port 0 for standalone mode (no configured
+	// port source). Start() will allocate an ephemeral port from the OS,
+	// giving each project a unique port without hash collisions (GH#2098).
 	t.Setenv("GT_ROOT", "")
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
 
 	dir := t.TempDir()
 	cfg := DefaultConfig(dir)
-	expected := DerivePort(dir)
-	if cfg.Port != expected {
-		t.Errorf("DefaultConfig should return DerivePort (%d) for standalone, got %d",
-			expected, cfg.Port)
+	if cfg.Port != 0 {
+		t.Errorf("DefaultConfig should return port 0 (ephemeral) for standalone, got %d",
+			cfg.Port)
+	}
+}
+
+func TestDefaultConfigEnvVarOverridesEphemeral(t *testing.T) {
+	// Explicit env var should always take precedence over ephemeral.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "15000")
+	dir := t.TempDir()
+	cfg := DefaultConfig(dir)
+	if cfg.Port != 15000 {
+		t.Errorf("expected env var port 15000, got %d", cfg.Port)
+	}
+}
+
+func TestDefaultConfigPortFileTakesPrecedence(t *testing.T) {
+	// Port file (written by Start) should take precedence over ephemeral.
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	dir := t.TempDir()
+	if err := writePortFile(dir, 14567); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig(dir)
+	if cfg.Port != 14567 {
+		t.Errorf("expected port file port 14567, got %d", cfg.Port)
 	}
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -517,10 +517,13 @@ func applyConfigDefaults(cfg *Config) {
 		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
 			cfg.ServerPort = p
 		}
-	} else if cfg.ServerPort == 0 {
-		cfg.ServerPort = DefaultSQLPort
 	}
-	// Test mode guard: if we'd hit production, force port 1 instead.
+	// Port 0 means "not yet resolved" — auto-start (EnsureRunning) will
+	// allocate an ephemeral port. Don't default to 3307 as that caused
+	// cross-project data leakage (GH#2098, GH#2372).
+	//
+	// Test mode guard: force port 1 (immediate fail) if we'd hit production
+	// or have no port, to prevent test databases leaking onto production.
 	if os.Getenv("BEADS_TEST_MODE") == "1" {
 		if cfg.ServerPort == 0 || cfg.ServerPort == DefaultSQLPort {
 			cfg.ServerPort = 1
@@ -596,7 +599,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 					"To disable auto-start: set dolt.auto-start: false in .beads/config.yaml",
 					addr, startErr)
 			}
-			// Update port in case EnsureRunning used a derived port
+			// Update port — EnsureRunning allocates an ephemeral port
 			if port != cfg.ServerPort {
 				cfg.ServerPort = port
 				addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))

--- a/internal/storage/dolt/store_unit_test.go
+++ b/internal/storage/dolt/store_unit_test.go
@@ -320,7 +320,8 @@ func TestApplyConfigDefaults_EnvOverridesConfig(t *testing.T) {
 }
 
 // TestApplyConfigDefaults_ProductionFallback verifies that without
-// BEADS_TEST_MODE, ServerPort falls back to DefaultSQLPort normally.
+// BEADS_TEST_MODE and no env port, ServerPort stays 0 (ephemeral).
+// Auto-start (EnsureRunning) will allocate the port at connection time.
 func TestApplyConfigDefaults_ProductionFallback(t *testing.T) {
 	origTestMode := os.Getenv("BEADS_TEST_MODE")
 	origPort := os.Getenv("BEADS_DOLT_PORT")
@@ -343,8 +344,8 @@ func TestApplyConfigDefaults_ProductionFallback(t *testing.T) {
 	cfg := &Config{}
 	applyConfigDefaults(cfg)
 
-	if cfg.ServerPort != DefaultSQLPort {
-		t.Errorf("expected ServerPort=%d (DefaultSQLPort), got %d", DefaultSQLPort, cfg.ServerPort)
+	if cfg.ServerPort != 0 {
+		t.Errorf("expected ServerPort=0 (ephemeral, resolved by auto-start), got %d", cfg.ServerPort)
 	}
 }
 


### PR DESCRIPTION
### Summary

Replace `DerivePort()` (FNV-32a hash of beadsDir path mapped to a 1000-port range) with OS-assigned ephemeral ports via `net.Listen(":0")`. This eliminates the birthday-problem port collisions described in #2098 and partially addresses the cross-project data leakage described in #2372.

Since this PR was opened, Layer 2 (database identity verification via `verifyProjectIdentity()`) has been merged to main in commit c6e41803. That makes this PR **complementary defense-in-depth**: ephemeral ports prevent collisions proactively (Layer 1), identity verification catches anything that slips through (Layer 2). Neither layer alone is sufficient — together they cover the full threat model.

### Current state of main (as of 2026-03-09)

`DerivePort()` is still the final fallback in `DefaultConfig()` on trunk. The birthday problem remains: FNV-32a hash into a 1000-port range (13307–14306) with ~40 projects gives >50% collision probability. Worse, the fallback cascade is broken — when `reclaimPort()` detects a collision, `Start()` falls back to `DerivePort()` again, which returns the *same* hash-derived port every time.

The identity verification in `verifyProjectIdentity()` (merged via c6e41803) catches mismatches *after* connecting, but only when both sides have a `project_id`. Existing projects without a `project_id` silently skip verification — there is no migration path or `bd doctor --fix` backfill yet. Ephemeral ports prevent the collision from occurring in the first place, making them valuable even with Layer 2 in place.

### Problem

The old `DerivePort` function hashed the `.beads/` directory path into a 1000-port range (13307–14306). With ~40 concurrent projects, the birthday paradox made collisions likely. When collisions occurred:

- Two projects could end up on the same port
- If the port file was missing, `DerivePort` could connect a project to the *wrong* project's dolt server — silently querying another project's database
- One repo was found to contain 244 foreign-prefix issues leaked via shared port collision (#2372)

The fallback cascade (`reclaimPort` → `ErrPortOccupiedByOtherProject` → `DerivePort`) added complexity without eliminating the root cause.

### Approach

Instead of hashing paths into a fixed port range, let the OS assign a guaranteed-free port:

1. `allocateEphemeralPort(host)` calls `net.Listen("tcp", host+":0")`, reads the assigned port, closes the listener
2. `Start()` passes the port to `dolt sql-server -P <port>` with a retry loop (up to 10 attempts) to handle the TOCTOU race between closing the listener and dolt binding
3. The actual port is written to `dolt-server.port` (gitignored, local-only) — this is how all clients discover the server

Explicit port configuration (env var `BEADS_DOLT_SERVER_PORT`, `config.yaml` `dolt.port`, deprecated `metadata.json` `dolt_server_port`) is preserved unchanged with conflict detection via `reclaimPort`.

### Relationship to #2372 proposals and subsequent fixes

#2372 proposed a two-layer fix. Since this PR was opened, significant work has landed on main:

**Layer 1 (Port Isolation)** — This PR:
- Replaces `DerivePort()` with OS-assigned ephemeral ports — strictly better (no hash collisions, guaranteed-free at allocation time)
- Port file as primary source: already done on main (prior release)
- gitignore port file: already done on main (prior release)
- metadata.json deprecation: preserved existing deprecation warning

**Layer 2 (Database Identity Verification)** — Already merged on main (c6e41803):
- `verifyProjectIdentity()` in `store.go` checks `project_id` in metadata.json against `_project_id` in the database on every connection
- Generates UUID via `generateProjectID()` during `bd init`
- **Gap**: only protects newly-initialized projects. Existing projects without `project_id` silently skip verification. No `bd doctor --fix` backfill exists yet.

**Other fixes already on main:**
- `58f5989b` — `bd init --force` requires confirmation; refuses in non-interactive/AI mode
- `feaee93e` — use DefaultConfig for port resolution during init
- `14df21b6` — Fix repo-local Dolt ports across doctor paths
- Versions v0.56.1–v0.58.0 pulled from Homebrew

**TOCTOU concern (raised by PabloLION on this PR):** The deeper TOCTOU — client reads port file, but server behind that port has changed — is now addressed by Layer 2's identity verification on main. The ephemeral port retry loop in this PR handles the narrower allocation TOCTOU (OS assigns port, small window before dolt binds it). Both concerns are covered.

### What changed

**Core (`internal/doltserver/doltserver.go`):**
- Added `allocateEphemeralPort()` with `net.JoinHostPort` for IPv6 safety
- Refactored `Start()` — ephemeral port retry loop (10 attempts), narrowly scoped to bind failures
- Simplified `reclaimPort()` — only for explicit ports, removed `ErrPortOccupiedByOtherProject` sentinel
- Updated `DefaultConfig()` — port 0 as final fallback (was `DerivePort`)
- Updated `IsRunning()` — kills orphan servers when port is unknown
- Removed: `DerivePort`, `fallbackPort`, `portRangeBase`/`portRangeSize`, `hash/fnv` import

**Store (`internal/storage/dolt/store.go`):**
- `applyConfigDefaults` no longer defaults port 0 → 3307
- Port 0 means "resolved by auto-start via EnsureRunning"
- Note: `open.go` changes from the original PR were absorbed by main's `applyResolvedConfig()` refactor, which already uses `doltserver.DefaultConfig(beadsDir).Port`

**Doctor (`cmd/bd/doctor/{server,dolt}.go`, `doctor_health.go`):**
- `server.go`: warns and returns early when port is 0 (server not running)
- `dolt.go`: returns a hard error when port is 0 — `bd doctor` will report "no Dolt server port configured" rather than attempting to dial port 0. This is intentional: doctor checks require a running server to be meaningful
- Fixed `doctor_health.go` to use `beadsDir` not repo root for port resolution

**Release notes (`cmd/bd/info.go`):**
- Updated user-facing release note string from "hash-derived" to "ephemeral"

**Comments/docs** across `cmd/bd/init.go`, `cmd/bd/main.go`, `cmd/bd/doctor/legacy.go`, `cmd/bd/doctor/perf_dolt.go`, `internal/configfile/configfile.go` updated for new semantics.

### Migration

- Existing servers with port files: **no change** — port file is already the primary source
- Servers without port files: next restart gets an ephemeral port instead of hash-derived (seamless, no user action needed)
- Users with explicit ports (env/config): **no change** — explicit path preserved with conflict detection

### Redirect workflows

No impact. `.beads/redirect` is resolved by `FindBeadsDir()` before any doltserver code runs. Each topic gets its own ephemeral port in its own port file. This is actually the best case — zero chance of cross-topic collision.

### Test plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [x] `go test ./internal/doltserver/` — 34 tests pass
- [x] `go test ./internal/storage/dolt/` — passes
- [ ] `go test ./cmd/bd/...` and `./cmd/bd/doctor/...` — not validated (pre-existing failures on this machine unrelated to this change)
- [x] New tests: `TestAllocateEphemeralPort`, `TestAllocateEphemeralPortIPv6`, `TestDefaultConfigReturnsZeroForStandalone`, `TestDefaultConfigEnvVarOverridesEphemeral`, `TestDefaultConfigPortFileTakesPrecedence`, `TestIsRunningOrphanNoPortFile`
- [ ] Integration test: multi-project concurrent usage with ephemeral ports
- [ ] Integration test: upgrade from hash-derived to ephemeral (port file continuity)
- [ ] Integration test: redirect-based workflow with topic switching
- [x] Rebase onto main and resolve conflicts (3 conflicts: `doctor_health.go`, `doltserver.go`, `open.go`)
- [x] Lint/format: `go vet` and `go build` pass; `golangci-lint` panics on Go version mismatch (pre-existing on main)

### CI status

`go build`, `go vet`, and tests pass locally. `golangci-lint` has a pre-existing panic on main due to a Go 1.26 vs 1.25 toolchain mismatch — not caused by this change.

Closes #2098. Partially addresses #2372 (Layer 1 — port isolation; Layer 2 is now independently merged on main).
