### PR TITLE
[fix: resolve beads dir correctly with custom dolt data dir

### DIFF
--- a/cmd/bd/beads_dir.go
+++ b/cmd/bd/beads_dir.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/beads"
+)
+
+// getBeadsDir returns the active .beads directory.
+//
+// Do not derive this from dbPath alone: when BEADS_DOLT_DATA_DIR points at a
+// shared/custom Dolt data directory, dbPath points outside .beads and
+// filepath.Dir(dbPath) becomes the workspace root instead of the .beads
+// directory.
+func getBeadsDir() string {
+	if beadsDir := beads.FindBeadsDir(); beadsDir != "" {
+		return beadsDir
+	}
+	if dbPath != "" {
+		return filepath.Dir(dbPath)
+	}
+	return ""
+}

--- a/cmd/bd/beads_dir_test.go
+++ b/cmd/bd/beads_dir_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/utils"
+)
+
+func TestGetBeadsDirPrefersBeadsDiscoveryOverCustomDoltDataDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	cfg.Backend = configfile.BackendDolt
+	cfg.DoltMode = configfile.DoltModeServer
+	cfg.DoltDatabase = "hq"
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	customDataDir := filepath.Join(tmpDir, "shared-dolt-data")
+	if err := os.MkdirAll(customDataDir, 0o755); err != nil {
+		t.Fatalf("failed to create custom dolt data dir: %v", err)
+	}
+	t.Setenv("BEADS_DOLT_DATA_DIR", customDataDir)
+
+	oldDBPath := dbPath
+	oldCwd, _ := os.Getwd()
+	dbPath = customDataDir
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() {
+		dbPath = oldDBPath
+		_ = os.Chdir(oldCwd)
+	}()
+
+	if got := getBeadsDir(); got != utils.CanonicalizePath(beadsDir) {
+		t.Fatalf("getBeadsDir() = %q, want %q", got, utils.CanonicalizePath(beadsDir))
+	}
+}
+
+func TestGetBeadsDirFallsBackToDBPathParent(t *testing.T) {
+	oldDBPath := dbPath
+	dbPath = "/tmp/example/.beads/dolt"
+	defer func() { dbPath = oldDBPath }()
+
+	// Ensure discovery path is unavailable.
+	t.Setenv("BEADS_DIR", "")
+	oldCwd, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldCwd) }()
+
+	if got := getBeadsDir(); got != "/tmp/example/.beads" {
+		t.Fatalf("getBeadsDir() fallback = %q, want %q", got, "/tmp/example/.beads")
+	}
+}

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -14,14 +13,6 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
-
-// getBeadsDir returns the .beads directory path, derived from the global dbPath.
-func getBeadsDir() string {
-	if dbPath != "" {
-		return filepath.Dir(dbPath)
-	}
-	return ""
-}
 
 // resolveIDWithRouting resolves a partial issue ID using prefix-based routing.
 // It returns the resolved full ID and the store that contains the issue.

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -476,7 +476,7 @@ var rootCmd = &cobra.Command{
 		// opens its own store connection, writes the version metadata, commits it,
 		// and closes BEFORE the main store is opened. This ensures bd doctor and
 		// read-only commands see the correct version after a CLI upgrade.
-		beadsDir := filepath.Dir(dbPath)
+		beadsDir := getBeadsDir()
 
 		autoMigrateOnVersionBump(beadsDir)
 
@@ -556,8 +556,7 @@ var rootCmd = &cobra.Command{
 
 		// Initialize hook runner
 		// dbPath is .beads/something.db, so workspace root is parent of .beads
-		if dbPath != "" {
-			beadsDir := filepath.Dir(dbPath)
+		if beadsDir := getBeadsDir(); beadsDir != "" {
 			hookRunner = hooks.NewRunner(filepath.Join(beadsDir, "hooks"))
 		}
 
@@ -568,7 +567,7 @@ var rootCmd = &cobra.Command{
 		// Templates are loaded after auto-import to ensure the database is up-to-date.
 		// Skip for import command to avoid conflicts during import operations.
 		if cmd.Name() != "import" && store != nil {
-			beadsDir := filepath.Dir(dbPath)
+			beadsDir := getBeadsDir()
 			loader := molecules.NewLoader(store)
 			if result, err := loader.LoadAll(rootCtx, beadsDir); err != nil {
 				debug.Logf("warning: failed to load molecules: %v", err)

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/routing"
@@ -76,7 +75,7 @@ func resolveAndGetIssueWithRouting(ctx context.Context, localStore *dolt.DoltSto
 	}
 
 	// Check if this ID routes to a different beads directory.
-	beadsDir := filepath.Dir(dbPath)
+	beadsDir := getBeadsDir()
 	targetDir, routed, routeErr := routing.ResolveBeadsDirForID(ctx, id, beadsDir)
 	routesDifferently := routeErr == nil && routed && targetDir != beadsDir
 
@@ -202,7 +201,7 @@ func getIssueWithRouting(ctx context.Context, localStore *dolt.DoltStore, id str
 	}
 
 	// Check if this ID routes to a different beads directory.
-	beadsDir := filepath.Dir(dbPath)
+	beadsDir := getBeadsDir()
 	targetDir, routed, routeErr := routing.ResolveBeadsDirForID(ctx, id, beadsDir)
 	routesDifferently := routeErr == nil && routed && targetDir != beadsDir
 
@@ -257,7 +256,7 @@ func getRoutedStoreForID(ctx context.Context, id string) (*routing.RoutedStorage
 		return nil, nil
 	}
 
-	beadsDir := filepath.Dir(dbPath)
+	beadsDir := getBeadsDir()
 	// Use GetRoutedStorageWithOpener with dolt to respect backend configuration (bd-m2jr)
 	return routing.GetRoutedStorageWithOpener(ctx, id, beadsDir, dolt.NewFromConfig)
 }
@@ -269,7 +268,7 @@ func needsRouting(id string) bool {
 		return false
 	}
 
-	beadsDir := filepath.Dir(dbPath)
+	beadsDir := getBeadsDir()
 	targetDir, routed, err := routing.ResolveBeadsDirForID(context.Background(), id, beadsDir)
 	if err != nil || !routed {
 		return false


### PR DESCRIPTION
## Summary

  This fixes `bd` and `gt sling` behavior when `BEADS_DOLT_DATA_DIR` points at a shared / custom Dolt data directory.

  Previously, several `bd` code paths derived the active `.beads` directory from `dbPath`. When `dbPath` pointed at a shared Dolt data dir outside `.beads`, that resolved to the
  wrong directory, causing config lookup to miss `metadata.json` and fall back to the default `beads` database name instead of the configured project database.

  This patch:
  - adds a shared `getBeadsDir()` helper that prefers beads discovery over `dbPath`
  - updates startup and routing paths to use the resolved `.beads` directory
  - adds regression coverage for the custom-data-dir case

  ## Problem

  In Gas Town, `BEADS_DOLT_DATA_DIR` points at a shared Dolt data directory. In that setup:
  - `bd` could resolve the wrong `.beads` directory
  - config loading could miss `metadata.json`
  - the DB name could fall back to `beads`
  - routed lookups and formula attachment could fail with `database not found: beads`

  ## Fix

  Use the actual discovered `.beads` directory for:
  - startup / migration setup
  - hook runner initialization
  - molecule loader setup
  - routing and routed store resolution

  This keeps the configured Dolt database name (`hq`, `ai_tooling`, etc.) intact even when the Dolt data directory lives outside `.beads`.

  ## Testing

- `go test ./cmd/bd -run 'TestGetBeadsDir|TestDoltShowConfig'`