### PR TITLE
fix: use Root().PersistentFlags() to check --json in PersistentPreRun

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -277,7 +277,7 @@ var rootCmd = &cobra.Command{
 		})
 
 		// If flag wasn't explicitly set, use viper value
-		if !cmd.Flags().Changed("json") {
+		if !cmd.Root().PersistentFlags().Changed("json") {
 			jsonOutput = config.GetBool("json")
 		} else {
 			flagOverrides["json"] = struct {


### PR DESCRIPTION
## Problem

`bd list --json` outputs plain text instead of JSON, silently ignoring the `--json` flag.

In `PersistentPreRun`, the check `cmd.Flags().Changed("json")` returns **false** for persistent flags — `--json` is registered on `rootCmd.PersistentFlags()`, so it never appears in `cmd.Flags()`. This causes the code to fall through to `config.GetBool("json")` which returns `false` by default, **overwriting** the `true` value already set by cobra's flag parsing.

## Fix

```go
// Before
if !cmd.Flags().Changed("json") {

// After  
if !cmd.Root().PersistentFlags().Changed("json") {
```

## Impact

Any call to `bd list --json`, `bd ready --json`, etc. ignores the flag and returns plain text. This breaks any tool that shells out to bd and parses JSON output — including the gastown scheduler, which uses `bd list --json --label=gt:sling-context` to find pending work items.

## Testing

```bash
# Before fix
bd list --json --limit=3   # outputs plain text

# After fix  
bd list --json --limit=3   # outputs JSON array
```