### PR TITLE
Support ai.api_key config for Anthropic API key

### DIFF
--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/compact"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -45,7 +46,7 @@ actively referenced. This is permanent graceful decay - original content is disc
 Modes:
   - Analyze: Export candidates for agent review (no API key needed)
   - Apply: Accept agent-provided summary (no API key needed)
-  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY, legacy)
+  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY or ai.api_key, legacy)
   - Dolt: Run Dolt garbage collection (for Dolt-backend repositories)
 
 Tiers:
@@ -166,8 +167,11 @@ Examples:
 
 			// Direct mode
 			apiKey := os.Getenv("ANTHROPIC_API_KEY")
+			if apiKey == "" {
+				apiKey = config.GetString("ai.api_key")
+			}
 			if apiKey == "" && !compactDryRun {
-				fmt.Fprintf(os.Stderr, "Error: --auto mode requires ANTHROPIC_API_KEY environment variable\n")
+				fmt.Fprintf(os.Stderr, "Error: --auto mode requires ANTHROPIC_API_KEY environment variable or ai.api_key in config\n")
 				os.Exit(1)
 			}
 

--- a/cmd/bd/find_duplicates.go
+++ b/cmd/bd/find_duplicates.go
@@ -36,7 +36,7 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may
@@ -93,8 +93,8 @@ func runFindDuplicates(cmd *cobra.Command, _ []string) {
 
 	// AI method requires API key
 	if method == "ai" {
-		if os.Getenv("ANTHROPIC_API_KEY") == "" {
-			FatalError("--method ai requires ANTHROPIC_API_KEY environment variable")
+		if os.Getenv("ANTHROPIC_API_KEY") == "" && config.GetString("ai.api_key") == "" {
+			FatalError("--method ai requires ANTHROPIC_API_KEY environment variable or ai.api_key in config")
 		}
 	}
 
@@ -363,6 +363,9 @@ func findAIDuplicates(ctx context.Context, issues []*types.Issue, threshold floa
 	fmt.Fprintf(os.Stderr, "Analyzing %d candidate pairs with AI...\n", len(candidates))
 
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		apiKey = config.GetString("ai.api_key")
+	}
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))
 
 	var pairs []duplicatePair

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -42,14 +42,17 @@ type haikuClient struct {
 	auditActor     string
 }
 
-// newHaikuClient creates a new Haiku API client. Env var ANTHROPIC_API_KEY takes precedence over explicit apiKey.
+// newHaikuClient creates a new Haiku API client.
+// API key resolution order: ANTHROPIC_API_KEY env var > ai.api_key config > explicit apiKey parameter.
 func newHaikuClient(apiKey string) (*haikuClient, error) {
 	envKey := os.Getenv("ANTHROPIC_API_KEY")
 	if envKey != "" {
 		apiKey = envKey
+	} else if configKey := config.GetString("ai.api_key"); configKey != "" {
+		apiKey = configKey
 	}
 	if apiKey == "" {
-		return nil, fmt.Errorf("%w: set ANTHROPIC_API_KEY environment variable or provide via config", errAPIKeyRequired)
+		return nil, fmt.Errorf("%w: set ANTHROPIC_API_KEY environment variable or ai.api_key in config", errAPIKeyRequired)
 	}
 
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))


### PR DESCRIPTION
## Summary
- The Anthropic API key could only be set via `ANTHROPIC_API_KEY` env var, with no config-based alternative (despite the error message claiming "or provide via config")
- Added `ai.api_key` config support so users can set it via `bd config set ai.api_key "sk-ant-..."`, consistent with the existing `ai.model` config key
- Updated all 3 callsites: `haiku.go` (core client), `compact.go` (`--auto` mode), `find_duplicates.go` (`--method ai`)

## Test plan
- [ ] Verify `bd compact --auto` works with `ai.api_key` set in config.yaml and no `ANTHROPIC_API_KEY` env var
- [ ] Verify `bd find-duplicates --method ai` works with config-based key
- [ ] Verify `ANTHROPIC_API_KEY` env var still takes precedence over config
- [ ] Verify existing unit tests pass (config is uninitialized in compact tests, so `GetString` returns `""`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)