### PR TITLE
Stabilize BEADS_DIR paths from detached commit worktrees

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -10,7 +10,9 @@ package beads
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -67,8 +69,9 @@ func FollowRedirect(beadsDir string) string {
 		target = filepath.Join(projectRoot, target)
 	}
 
-	// Canonicalize the target path
-	target = utils.CanonicalizePath(target)
+	// Canonicalize the target path and prefer a stable branch worktree when the
+	// redirect points at a detached snapshot checkout.
+	target = canonicalizeBeadsDirPath(target)
 
 	// Verify the target exists and is a directory
 	info, err := os.Stat(target)
@@ -89,6 +92,130 @@ func FollowRedirect(beadsDir string) string {
 	}
 
 	return target
+}
+
+func canonicalizeBeadsDirPath(beadsDir string) string {
+	canonical := utils.CanonicalizePath(beadsDir)
+	if stable := preferStableBranchWorktreeBeadsDir(canonical); stable != "" {
+		return stable
+	}
+	return canonical
+}
+
+type worktreeInfo struct {
+	Path     string
+	Head     string
+	Branch   string
+	Detached bool
+	Bare     bool
+}
+
+func preferStableBranchWorktreeBeadsDir(beadsDir string) string {
+	if filepath.Base(beadsDir) != ".beads" {
+		return ""
+	}
+
+	repoRoot := filepath.Dir(beadsDir)
+	if !isDetachedCommitWorktreePath(repoRoot) {
+		return ""
+	}
+
+	branch, err := gitOutput(repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil || branch != "HEAD" {
+		return ""
+	}
+
+	head, err := gitOutput(repoRoot, "rev-parse", "HEAD")
+	if err != nil || head == "" {
+		return ""
+	}
+
+	worktrees, err := listWorktrees(repoRoot)
+	if err != nil {
+		return ""
+	}
+
+	var candidates []worktreeInfo
+	for _, wt := range worktrees {
+		if wt.Bare || wt.Detached || wt.Branch == "" {
+			continue
+		}
+		if wt.Head != head || utils.PathsEqual(wt.Path, repoRoot) {
+			continue
+		}
+		candidates = append(candidates, wt)
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		iStable := !isDetachedCommitWorktreePath(candidates[i].Path)
+		jStable := !isDetachedCommitWorktreePath(candidates[j].Path)
+		if iStable != jStable {
+			return iStable
+		}
+		return candidates[i].Path < candidates[j].Path
+	})
+
+	stableBeadsDir := filepath.Join(candidates[0].Path, ".beads")
+	if info, err := os.Stat(stableBeadsDir); err == nil && info.IsDir() {
+		return utils.CanonicalizePath(stableBeadsDir)
+	}
+
+	return ""
+}
+
+func isDetachedCommitWorktreePath(path string) bool {
+	return strings.Contains(filepath.ToSlash(path), "/refs/commits/")
+}
+
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func listWorktrees(repoRoot string) ([]worktreeInfo, error) {
+	output, err := gitOutput(repoRoot, "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+
+	var worktrees []worktreeInfo
+	var current *worktreeInfo
+
+	for _, line := range strings.Split(output, "\n") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			if current != nil {
+				worktrees = append(worktrees, *current)
+			}
+			current = &worktreeInfo{
+				Path: strings.TrimPrefix(line, "worktree "),
+			}
+		case current == nil:
+			continue
+		case strings.HasPrefix(line, "HEAD "):
+			current.Head = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch refs/heads/"):
+			current.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+		case line == "detached":
+			current.Detached = true
+		case line == "bare":
+			current.Bare = true
+		}
+	}
+
+	if current != nil {
+		worktrees = append(worktrees, *current)
+	}
+
+	return worktrees, nil
 }
 
 // RedirectInfo contains information about a beads directory redirect.
@@ -172,7 +299,7 @@ func findLocalBdsDirInRepo() string {
 func findLocalBeadsDir() string {
 	// Check BEADS_DIR environment variable first
 	if beadsDir := os.Getenv("BEADS_DIR"); beadsDir != "" {
-		return utils.CanonicalizePath(beadsDir)
+		return canonicalizeBeadsDirPath(beadsDir)
 	}
 
 	// For worktrees, check worktree-local redirect first (per-worktree override).
@@ -277,7 +404,7 @@ func FindDatabasePath() string {
 	// 1. Check BEADS_DIR environment variable (preferred)
 	if beadsDir := os.Getenv("BEADS_DIR"); beadsDir != "" {
 		// Canonicalize the path to prevent nested .beads directories
-		absBeadsDir := utils.CanonicalizePath(beadsDir)
+		absBeadsDir := canonicalizeBeadsDirPath(beadsDir)
 
 		// Follow redirect if present
 		absBeadsDir = FollowRedirect(absBeadsDir)
@@ -351,7 +478,7 @@ func hasBeadsProjectFiles(beadsDir string) bool {
 func FindBeadsDir() string {
 	// 1. Check BEADS_DIR environment variable (preferred)
 	if beadsDir := os.Getenv("BEADS_DIR"); beadsDir != "" {
-		absBeadsDir := utils.CanonicalizePath(beadsDir)
+		absBeadsDir := canonicalizeBeadsDirPath(beadsDir)
 
 		// Follow redirect if present
 		absBeadsDir = FollowRedirect(absBeadsDir)

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/git"
@@ -308,6 +309,59 @@ func TestFindBeadsDirValidatesBeadsDirEnv(t *testing.T) {
 	}
 }
 
+func TestFindBeadsDirPrefersBranchWorktreeForDetachedCommitBEADS_DIR(t *testing.T) {
+	originalEnv := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("BEADS_DIR", originalEnv)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+
+	detachedBeadsDir, mainBeadsDir, _ := setupDetachedCommitBeadsWorktree(t)
+	os.Setenv("BEADS_DIR", detachedBeadsDir)
+
+	result := FindBeadsDir()
+
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	mainResolved, _ := filepath.EvalSymlinks(mainBeadsDir)
+
+	if resultResolved != mainResolved {
+		t.Errorf("FindBeadsDir() = %q, want stable branch worktree %q", result, mainBeadsDir)
+	}
+}
+
+func TestFindDatabasePathPrefersBranchWorktreeForDetachedCommitBEADS_DIR(t *testing.T) {
+	originalEnvDir := os.Getenv("BEADS_DIR")
+	originalEnvDB := os.Getenv("BEADS_DB")
+	defer func() {
+		if originalEnvDir != "" {
+			os.Setenv("BEADS_DIR", originalEnvDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+		if originalEnvDB != "" {
+			os.Setenv("BEADS_DB", originalEnvDB)
+		} else {
+			os.Unsetenv("BEADS_DB")
+		}
+	}()
+	os.Unsetenv("BEADS_DB")
+
+	detachedBeadsDir, _, mainDoltDir := setupDetachedCommitBeadsWorktree(t)
+	os.Setenv("BEADS_DIR", detachedBeadsDir)
+
+	result := FindDatabasePath()
+
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	mainResolved, _ := filepath.EvalSymlinks(mainDoltDir)
+
+	if resultResolved != mainResolved {
+		t.Errorf("FindDatabasePath() = %q, want stable branch worktree db %q", result, mainDoltDir)
+	}
+}
+
 func TestFindDatabasePathHomeDefault(t *testing.T) {
 	// This test verifies that if no database is found, it falls back to home directory
 	// We can't reliably test this without modifying the home directory, so we'll skip
@@ -340,6 +394,63 @@ func TestFindDatabasePathHomeDefault(t *testing.T) {
 	if result != "" && !filepath.IsAbs(result) {
 		t.Errorf("Expected absolute path or empty string, got '%s'", result)
 	}
+}
+
+func setupDetachedCommitBeadsWorktree(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	storeDir := filepath.Join(tmpDir, "store")
+	bareDir := filepath.Join(storeDir, ".bare")
+	mainWorktreeDir := filepath.Join(storeDir, "refs", "heads", "main")
+
+	if err := os.MkdirAll(filepath.Dir(mainWorktreeDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("git", "init", "--bare", bareDir)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	runGitInDir(t, tmpDir, "--git-dir", bareDir, "worktree", "add", "-b", "main", mainWorktreeDir)
+	runGitInDir(t, mainWorktreeDir, "config", "user.email", "test@example.com")
+	runGitInDir(t, mainWorktreeDir, "config", "user.name", "Test User")
+
+	mainBeadsDir := filepath.Join(mainWorktreeDir, ".beads")
+	mainDoltDir := filepath.Join(mainBeadsDir, "dolt")
+	if err := os.MkdirAll(mainDoltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainWorktreeDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGitInDir(t, mainWorktreeDir, "add", "-A")
+	runGitInDir(t, mainWorktreeDir, "commit", "-m", "Initial commit")
+
+	head := runGitInDir(t, mainWorktreeDir, "rev-parse", "HEAD")
+	detachedWorktreeDir := filepath.Join(storeDir, "refs", "commits", head)
+	if err := os.MkdirAll(filepath.Dir(detachedWorktreeDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGitInDir(t, tmpDir, "--git-dir", bareDir, "worktree", "add", "--detach", detachedWorktreeDir, head)
+
+	return filepath.Join(detachedWorktreeDir, ".beads"), mainBeadsDir, mainDoltDir
+}
+
+func runGitInDir(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed in %s: %v\n%s", args, dir, err, output)
+	}
+
+	return strings.TrimSpace(string(output))
 }
 
 // TestFollowRedirect tests the redirect file functionality


### PR DESCRIPTION
This fixes a discovery gap when external tooling sets `BEADS_DIR` to a detached worktree path such as `refs/commits/<sha>/.beads`.

Today `beads` canonicalizes the path, but it preserves the detached worktree identity. In megarepo-style stores that causes the same logical beads repo to appear under multiple physical paths, which in turn destabilizes server identity and repo routing.

What this changes:
- keep normal path canonicalization behavior
- when `BEADS_DIR` points at a detached `refs/commits/.../.beads` worktree, ask Git for sibling worktrees
- if a branch worktree exists at the same commit, prefer that branch worktree's `.beads` directory as the stable identity
- apply the same normalization when following redirect targets

Validation:
- added regression tests in `internal/beads` covering detached commit worktree -> branch worktree normalization for both `FindBeadsDir` and `FindDatabasePath`
- `env -u BEADS_DIR -u BEADS_DB -u BEADS_PRIMARY_REF go test ./internal/beads`
- `env -u BEADS_DIR -u BEADS_DB -u BEADS_PRIMARY_REF go test ./cmd/bd -run TestBEADS_DIRPrecedence`
- built `bd` from this branch and verified that a real `BEADS_DIR=/.../refs/commits/<sha>/.beads` resolves to `/.../refs/heads/main/.beads`

Scope note: this intentionally fixes path identity only. I still see a separate external-store/server-mode inconsistency that currently requires a downstream wrapper to pin `--db`; I did not fold that into this PR.

---
<sub>Filed by an AI assistant on behalf of @schickling</sub>