### PR TITLE
fix: replace stale 'bd sync' references in CLI help, setup generators, and docs (GH#2435)

### DIFF
--- a/cmd/bd/doctor/agent.go
+++ b/cmd/bd/doctor/agent.go
@@ -411,7 +411,7 @@ func enrichDoltStatus(dc DoctorCheck) agentEnrichment {
 		explanation: fmt.Sprintf("Dolt database status: %s. Reports uncommitted changes, dirty working set, or other Dolt-specific state issues.", dc.Message),
 		observed:    dc.Message + "\n" + dc.Detail,
 		expected:    "Dolt working set is clean (no uncommitted changes)",
-		commands:    []string{"bd sync"},
+		commands:    []string{"bd dolt commit"},
 		sourceFiles: []string{"cmd/bd/doctor/dolt.go:CheckDoltStatus"},
 	}
 }
@@ -543,7 +543,7 @@ func enrichKVSync(dc DoctorCheck) agentEnrichment {
 		explanation: fmt.Sprintf("KV store sync status: %s. The key-value store may be out of sync with the main database.", dc.Message),
 		observed:    dc.Message + "\n" + dc.Detail,
 		expected:    "KV store is in sync with main database",
-		commands:    []string{"bd sync"},
+		commands:    []string{"bd dolt push"},
 		sourceFiles: []string{"cmd/bd/doctor/kv.go:CheckKVSyncStatus"},
 	}
 }

--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -36,7 +36,7 @@ type doltAutoCommitParams struct {
 // Semantics:
 //   - Only applies when dolt auto-commit is "on" AND the active store is versioned (Dolt).
 //   - In "batch" mode, commits are deferred — changes accumulate in the working set
-//     until an explicit commit point (bd sync, bd dolt commit).
+//     until an explicit commit point (bd dolt commit).
 //   - Uses Dolt's "commit all" behavior under the hood (DOLT_COMMIT -Am).
 //   - Treats "nothing to commit" as a no-op.
 func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
@@ -45,7 +45,7 @@ func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
 		return err
 	}
 	// In batch mode, skip per-command commits. Changes stay in the working set
-	// and are committed at logical boundaries (bd sync, bd dolt commit).
+	// and are committed at logical boundaries (bd dolt commit).
 	if mode != doltAutoCommitOn {
 		return nil
 	}

--- a/cmd/bd/init_contributor.go
+++ b/cmd/bd/init_contributor.go
@@ -236,7 +236,7 @@ Created by: bd init --contributor
 	fmt.Println("  Issues from planning repo will appear in 'bd list'")
 
 	// If this is a fork, configure sync to pull beads from upstream (bd-bx9)
-	// This ensures `bd sync` gets the latest issues from the source repo,
+	// This ensures `bd dolt pull` gets the latest issues from the source repo,
 	// not from the fork's potentially outdated origin/main
 	if isFork {
 		if err := store.SetConfig(ctx, "sync.remote", "upstream"); err != nil {

--- a/cmd/bd/init_git_hooks.go
+++ b/cmd/bd/init_git_hooks.go
@@ -304,7 +304,7 @@ func printJJAliasInstructions() {
 	fmt.Printf("Jujutsu doesn't support hooks yet. To auto-export beads on push,\n")
 	fmt.Printf("add this alias to your jj config (~/.config/jj/config.toml):\n\n")
 	fmt.Printf("  %s\n", ui.RenderAccent("[aliases]"))
-	fmt.Printf("  %s\n", ui.RenderAccent(`push = ["util", "exec", "--", "sh", "-c", "bd sync --flush-only && jj git push \"$@\"", ""]`))
+	fmt.Printf("  %s\n", ui.RenderAccent(`push = ["util", "exec", "--", "sh", "-c", "bd dolt commit && bd dolt push && jj git push \"$@\"", ""]`))
 	fmt.Printf("\nThen use %s instead of %s\n\n", ui.RenderAccent("jj push"), ui.RenderAccent("jj git push"))
 	fmt.Printf("For more details, see: https://github.com/steveyegge/beads/blob/main/docs/JUJUTSU.md\n\n")
 }

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -188,7 +188,7 @@ func init() {
 		fmt.Fprintf(os.Stderr, "warning: failed to hide allow-stale flag: %v\n", err)
 	}
 	rootCmd.PersistentFlags().BoolVar(&readonlyMode, "readonly", false, "Read-only mode: block write operations (for worker sandboxes)")
-	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd sync / bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: off. Override via config key dolt.auto-commit")
+	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: off. Override via config key dolt.auto-commit")
 	rootCmd.PersistentFlags().BoolVar(&profileEnabled, "profile", false, "Generate CPU profile for performance analysis")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose/debug output")
 	rootCmd.PersistentFlags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress non-essential output (errors only)")

--- a/cmd/bd/setup/aider.go
+++ b/cmd/bd/setup/aider.go
@@ -23,7 +23,7 @@ This project uses **Beads (bd)** for issue tracking. Aider requires explicit com
 1. **Track ALL work in bd** (never use markdown TODOs or comment-based task lists)
 2. **Suggest 'bd ready'** to find available work
 3. **Suggest 'bd create'** for new issues/tasks/bugs
-4. **Suggest 'bd sync'** at end of session
+4. **Suggest 'bd dolt push'** at end of session
 5. **ALWAYS suggest commands** - user will run them via /run
 
 ## Quick Command Reference (suggest these to user)
@@ -34,7 +34,7 @@ This project uses **Beads (bd)** for issue tracking. Aider requires explicit com
 - ` + "`bd update <id> --claim`" + ` - Claim work atomically
 - ` + "`bd close <id>`" + ` - Mark complete
 - ` + "`bd dep add <issue> <depends-on>`" + ` - Add dependency (issue depends on depends-on)
-- ` + "`bd sync`" + ` - Sync with git remote
+- ` + "`bd dolt push`" + ` - Push changes to Dolt remote
 
 ## Workflow Pattern to Suggest
 
@@ -42,7 +42,7 @@ This project uses **Beads (bd)** for issue tracking. Aider requires explicit com
 2. **Claim task**: "Run ` + "`/run bd update <id> --claim`" + ` to claim it atomically"
 3. **Do the work**
 4. **Complete**: "Run ` + "`/run bd close <id>`" + ` when done"
-5. **Sync**: "Run ` + "`/run bd sync`" + ` to push changes"
+5. **Sync**: "Run ` + "`/run bd dolt push`" + ` to push changes"
 
 ## Context Loading
 
@@ -69,7 +69,7 @@ Suggest ` + "`/run bd prime`" + ` for complete workflow documentation (~1-2k tok
 - **Always use /run prefix** - Aider requires explicit command execution
 - **Link discovered work** - Use ` + "`--deps discovered-from:<parent-id>`" + ` when creating issues found during work
 - **Include descriptions** - Always provide meaningful context when creating issues
-- **End session with sync** - Remind user to run ` + "`/run bd sync`" + ` before ending session
+- **End session with sync** - Remind user to run ` + "`/run bd dolt push`" + ` before ending session
 
 For detailed docs: see AGENTS.md, QUICKSTART.md, or run ` + "`bd --help`" + `
 `
@@ -107,7 +107,7 @@ The AI will **suggest** bd commands, but you must confirm them.
 
 5. Sync at end of session:
    ` + "```bash" + `
-   /run bd sync
+   /run bd dolt push
    ` + "```" + `
 
 ## Configuration

--- a/cmd/bd/setup/aider_test.go
+++ b/cmd/bd/setup/aider_test.go
@@ -22,7 +22,7 @@ func TestAiderBeadsInstructions(t *testing.T) {
 		"bd create",
 		"bd update",
 		"bd close",
-		"bd sync",
+		"bd dolt push",
 		"/run",
 		"bug",
 		"feature",
@@ -44,7 +44,7 @@ func TestAiderReadmeTemplate(t *testing.T) {
 		"bd ready",
 		"bd create",
 		"bd close",
-		"bd sync",
+		"bd dolt push",
 	}
 
 	for _, req := range requiredContent {
@@ -365,8 +365,8 @@ func TestAiderInstructionsWorkflowPattern(t *testing.T) {
 	if !strings.Contains(instructions, "/run bd ready") {
 		t.Error("Should mention /run bd ready")
 	}
-	if !strings.Contains(instructions, "/run bd sync") {
-		t.Error("Should mention /run bd sync")
+	if !strings.Contains(instructions, "/run bd dolt push") {
+		t.Error("Should mention /run bd dolt push")
 	}
 
 	// Should explain that Aider requires explicit commands

--- a/cmd/bd/setup/cursor.go
+++ b/cmd/bd/setup/cursor.go
@@ -16,7 +16,7 @@ This project uses [Beads (bd)](https://github.com/steveyegge/beads) for issue tr
 - Track ALL work in bd (never use markdown TODOs or comment-based task lists)
 - Use ` + "`bd ready`" + ` to find available work
 - Use ` + "`bd create`" + ` to track new issues/tasks/bugs
-- Use ` + "`bd sync`" + ` at end of session to sync with git remote
+- Use ` + "`bd dolt push`" + ` at end of session to sync with git remote
 - Git hooks auto-sync on commit/merge
 
 ## Quick Reference
@@ -28,7 +28,7 @@ bd create --title="..." --type=task  # Create new issue
 bd update <id> --claim               # Claim work atomically
 bd close <id>                         # Mark complete
 bd dep add <issue> <depends-on>       # Add dependency (issue depends on depends-on)
-bd sync                               # Sync with git remote
+bd dolt push                               # Sync with git remote
 ` + "```" + `
 
 ## Workflow
@@ -36,7 +36,7 @@ bd sync                               # Sync with git remote
 2. Claim an issue atomically: ` + "`bd update <id> --claim`" + `
 3. Do the work
 4. Mark complete: ` + "`bd close <id>`" + `
-5. Sync: ` + "`bd sync`" + ` (or let git hooks handle it)
+5. Sync: ` + "`bd dolt push`" + ` (or let git hooks handle it)
 
 ## Context Loading
 Run ` + "`bd prime`" + ` to get complete workflow documentation in AI-optimized format (~1-2k tokens).

--- a/cmd/bd/setup/cursor_test.go
+++ b/cmd/bd/setup/cursor_test.go
@@ -15,7 +15,7 @@ func TestCursorRulesTemplate(t *testing.T) {
 		"bd create",
 		"bd update",
 		"bd close",
-		"bd sync",
+		"bd dolt push",
 		"BEADS INTEGRATION",
 	}
 

--- a/cmd/bd/setup/junie.go
+++ b/cmd/bd/setup/junie.go
@@ -16,7 +16,7 @@ This project uses **Beads (bd)** for issue tracking. Use the bd CLI or MCP tools
 2. **Check ready work first** - Run ` + "`bd ready`" + ` to find unblocked issues
 3. **Always include descriptions** - Provide meaningful context when creating issues
 4. **Link discovered work** - Use ` + "`discovered-from`" + ` dependencies for issues found during work
-5. **Sync at session end** - Run ` + "`bd sync`" + ` before ending your session
+5. **Sync at session end** - Run ` + "`bd dolt push`" + ` before ending your session
 
 ## Quick Command Reference
 
@@ -49,7 +49,7 @@ bd dep add <issue> <depends-on> --type=related  # Soft link
 
 ### Syncing
 ` + "```bash" + `
-bd sync  # ALWAYS run at session end - commits and pushes changes
+bd dolt push  # ALWAYS run at session end - commits and pushes changes
 ` + "```" + `
 
 ## Issue Types
@@ -87,7 +87,7 @@ If the MCP server is configured, you can use these tools directly:
 - ✅ Always use ` + "`--json`" + ` flag for programmatic use
 - ✅ Link discovered work with ` + "`discovered-from`" + ` dependencies
 - ✅ Check ` + "`bd ready`" + ` before asking "what should I work on?"
-- ✅ Run ` + "`bd sync`" + ` at end of session
+- ✅ Run ` + "`bd dolt push`" + ` at end of session
 - ❌ Do NOT create markdown TODO lists
 - ❌ Do NOT use external issue trackers
 - ❌ Do NOT duplicate tracking systems

--- a/cmd/bd/setup/junie_test.go
+++ b/cmd/bd/setup/junie_test.go
@@ -13,7 +13,7 @@ func TestJunieGuidelinesTemplate(t *testing.T) {
 		"bd create",
 		"bd update",
 		"bd close",
-		"bd sync",
+		"bd dolt push",
 		"mcp_beads_ready",
 		"mcp_beads_list",
 		"mcp_beads_create",
@@ -490,8 +490,8 @@ func TestJunieGuidelinesWorkflowPattern(t *testing.T) {
 	if !strings.Contains(guidelines, "bd ready") {
 		t.Error("Should mention bd ready")
 	}
-	if !strings.Contains(guidelines, "bd sync") {
-		t.Error("Should mention bd sync")
+	if !strings.Contains(guidelines, "bd dolt push") {
+		t.Error("Should mention bd dolt push")
 	}
 
 	// Should explain MCP tools

--- a/cmd/bd/setup/mux.go
+++ b/cmd/bd/setup/mux.go
@@ -33,7 +33,7 @@ set -euo pipefail
 # Claude PreCompact approximation for Mux: keep beads metadata synced after file edits.
 if [ "${MUX_TOOL:-}" = "file_edit_replace_string" ] || [ "${MUX_TOOL:-}" = "file_edit_insert" ]; then
   if command -v bd >/dev/null 2>&1; then
-    bd sync >/dev/null 2>&1 || true
+    bd dolt push >/dev/null 2>&1 || true
   elif [ -x "$HOME/bin/bd" ]; then
     "$HOME/bin/bd" sync >/dev/null 2>&1 || true
   fi

--- a/docs/COPILOT_INTEGRATION.md
+++ b/docs/COPILOT_INTEGRATION.md
@@ -86,7 +86,7 @@ Run `bd prime` for workflow context.
 - `bd ready` - Find unblocked work
 - `bd create "Title" --type task --priority 2` - Create issue
 - `bd close <id>` - Complete work
-- `bd sync` - Sync with git (run at session end)
+- `bd dolt push` - Push changes to remote (run at session end)
 ```
 
 ### Step 5: Restart VS Code
@@ -117,7 +117,7 @@ With MCP configured, ask Copilot Chat:
 | `beads_show` | Show issue details | "Show bd-42 details" |
 | `beads_update` | Update issue fields | "Set bd-42 to in progress" |
 | `beads_close` | Close an issue | "Complete bd-42" |
-| `beads_sync` | Sync to git | "Sync my changes" |
+| `beads_dolt_push` | Push changes to remote | "Push my changes" |
 | `beads_dep_add` | Add dependency | "bd-99 blocks bd-42" |
 | `beads_dep_tree` | Show dependency tree | "What depends on bd-42?" |
 
@@ -151,10 +151,10 @@ You: Done with bd-42. Close it with reason "Fixed timeout handling"
 Copilot: [Calls beads_close]
 Closed bd-42: Fixed timeout handling
 
-You: Sync everything to git
+You: Push my changes to the remote
 
-Copilot: [Calls beads_sync]
-Synced: 2 issues updated, committed to git.
+Copilot: [Calls beads_dolt_push]
+Pushed: 2 issues updated, synced to Dolt remote.
 ```
 
 ## CLI vs MCP: When to Use Each
@@ -206,13 +206,13 @@ bd init --quiet
 
 ### Changes not persisting
 
-Run sync at end of session:
+Push changes at end of session:
 
 ```bash
-bd sync
+bd dolt push
 ```
 
-Or ask Copilot: "Sync my beads changes to git"
+Or ask Copilot: "Push my beads changes to the remote"
 
 ### Organization policies blocking MCP
 


### PR DESCRIPTION
## Summary
- Replace all `bd sync` references with `bd dolt commit` / `bd dolt push` in CLI help text, agent setup generators (aider, cursor, junie, mux), doctor agent commands, code comments, and Copilot integration docs
- `bd sync` was removed but references persisted in 13 files, causing agents to generate incorrect workflows

## Changes

**CLI help text:**
- `--dolt-auto-commit` flag description no longer mentions `bd sync`

**Code comments:**
- `dolt_autocommit.go`: batch mode comments updated
- `init_contributor.go`: fork sync comment updated

**Agent setup generators:**
- `setup/aider.go`: instructions + README template → `bd dolt push`
- `setup/cursor.go`: rules template → `bd dolt push`
- `setup/junie.go`: guidelines template → `bd dolt push`
- `setup/mux.go`: tool_post hook → `bd dolt push`

**Doctor agent:**
- `doctor/agent.go`: remediation commands → `bd dolt commit` / `bd dolt push`

**Other:**
- `init_git_hooks.go`: jujutsu push alias → `bd dolt commit && bd dolt push`
- `docs/COPILOT_INTEGRATION.md`: quick reference, MCP tools table, example workflow, troubleshooting

**Tests:** Updated assertions in `aider_test.go`, `cursor_test.go`, `junie_test.go`

## Scope

Covers the **embedded CLI/help text + setup generators + Copilot docs** portion of GH#2435. Complements #2389 (config/sync.mode) and #2419 (command removal).

Remaining stale references in other docs (CLI_REFERENCE.md, WORKTREES.md, TROUBLESHOOTING.md, etc.) are tracked in GH#2435 for follow-up.

## Test plan
- [x] `go build ./cmd/bd/` passes
- [x] `go test -short ./cmd/bd/setup/` passes
- [x] `go test -short ./cmd/bd/doctor/` passes