### PR TITLE
fix: init guard allows fresh clones with committed metadata.json (GH#2433)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -974,8 +974,15 @@ func checkExistingBeadsDataAt(beadsDir string, prefix string) error {
 					gitRemote := config.GetString("sync.git-remote")
 					return initGuardServerMessage(dbName, host, port, prefix, gitRemote)
 				}
-				// If server unreachable (FR-030) or DB exists (FR-012) or
-				// error during check: fall through to existing behavior.
+				if result.Reachable && result.Exists {
+					// Server up and DB exists — fall through to "already initialized" error.
+				} else {
+					// Server unreachable or error during check: this is a fresh clone
+					// with committed metadata.json but no local dolt/ directory.
+					// Allow init to proceed so the user can bootstrap the database
+					// (e.g. via --from-jsonl). (GH#2433)
+					return nil
+				}
 			}
 
 			location := doltPath

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -125,4 +128,87 @@ func TestInitGuardDBCheck_ServerUnreachable(t *testing.T) {
 		t.Fatal("expected non-nil error for connection refused")
 	}
 	// Key assertion: no panic occurred — FR-030 satisfied.
+}
+
+func TestInitGuard_FreshCloneWithMetadataJSON(t *testing.T) {
+	// GH#2433: On a fresh clone, metadata.json is committed (tracked by git)
+	// but dolt/ directory is gitignored. The init guard should recognize this
+	// as a fresh clone and allow init to proceed.
+
+	t.Run("server_mode_metadata_no_dolt_dir_allows_init", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write metadata.json as it would be on a fresh clone:
+		// DoltMode=server, DoltDatabase set, but no dolt/ directory.
+		metadata := map[string]interface{}{
+			"database":      "dolt",
+			"backend":       "dolt",
+			"dolt_mode":     "server",
+			"dolt_database": "myproject",
+		}
+		data, _ := json.Marshal(metadata)
+		metadataPath := filepath.Join(beadsDir, "metadata.json")
+		if err := os.WriteFile(metadataPath, data, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// No dolt/ directory — simulates fresh clone with gitignored dolt/.
+		// No server running — simulates machine B with no local server.
+		err := checkExistingBeadsDataAt(beadsDir, "myproject")
+		if err != nil {
+			t.Errorf("fresh clone with metadata.json should allow init, got: %v", err)
+		}
+	})
+
+	t.Run("server_mode_with_dolt_dir_blocks_init", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write metadata.json with server mode
+		metadata := map[string]interface{}{
+			"database":      "dolt",
+			"backend":       "dolt",
+			"dolt_mode":     "server",
+			"dolt_database": "myproject",
+		}
+		data, _ := json.Marshal(metadata)
+		if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create dolt/ directory — this is NOT a fresh clone
+		doltDir := filepath.Join(beadsDir, "dolt")
+		if err := os.MkdirAll(doltDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := checkExistingBeadsDataAt(beadsDir, "myproject")
+		if err == nil {
+			t.Error("existing dolt directory should block init")
+		}
+		if err != nil && !strings.Contains(err.Error(), "already initialized") {
+			t.Errorf("expected 'already initialized' message, got: %v", err)
+		}
+	})
+
+	t.Run("no_metadata_json_allows_init", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// No metadata.json, no dolt/ — fresh project, never initialized
+		err := checkExistingBeadsDataAt(beadsDir, "test")
+		if err != nil {
+			t.Errorf("empty beads dir should allow init, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #2433 — `bd init --from-jsonl` fails on fresh clone with "database not found" or "already initialized" error.

**Root cause:** `metadata.json` is tracked by git (not gitignored), so a fresh `git clone` includes it with `dolt_mode: "server"`. The init guard at `checkExistingBeadsDataAt()` sees `IsDoltServerMode() == true` and enters the server-mode check block. When no server is running on the new machine (expected for a fresh clone), the check falls through to the "Found existing Dolt database" error, blocking init entirely.

**Fix:** When `IsDoltServerMode()` is true, the `dolt/` directory is absent (gitignored), and the server is unreachable, recognize this as a fresh clone and return nil (allow init to proceed). The existing `CreateIfMissing: true` flag in `bd init` then correctly creates the database during server startup.

## Changes

- `cmd/bd/init.go`: Modified `checkExistingBeadsDataAt()` to return nil (allow init) when server-mode metadata exists but both the dolt directory and server are absent — indicating a fresh clone
- `cmd/bd/init_guard_test.go`: Added 3 test cases covering the fresh clone scenario:
  - `server_mode_metadata_no_dolt_dir_allows_init` — the bug fix case
  - `server_mode_with_dolt_dir_blocks_init` — ensures existing installations still block
  - `no_metadata_json_allows_init` — baseline: empty .beads dir allows init

## Test plan

- [x] `go test -run TestInitGuard ./cmd/bd/ -v` — all 7 tests pass
- [x] `go test ./cmd/bd/ -count=1` — full cmd/bd suite passes
- [x] Verified the fix handles all three init guard outcomes:
  - Server reachable + DB missing → refined error message (unchanged)
  - Server reachable + DB exists → "already initialized" error (unchanged)
  - Server unreachable + no dolt dir → fresh clone, allow init (NEW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)