### PR TITLE
fix(list): --json flag ignored when --tree defaults to true

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -330,7 +330,7 @@ var listCmd = &cobra.Command{
 		if flatFormat {
 			treeFormat = false
 		}
-		prettyFormat = prettyFormat || treeFormat // --tree is alias for --pretty
+		prettyFormat = (prettyFormat || treeFormat) && !jsonOutput // --tree is alias for --pretty; JSON wins
 		watchMode, _ := cmd.Flags().GetBool("watch")
 
 		// Pager control (bd-jdz3)


### PR DESCRIPTION
## Summary

- `bd list --json` produces human-readable tree output instead of JSON
- Root cause: `--tree` flag defaults to `true`, setting `prettyFormat=true`. The prettyFormat branch (line 743) returns before reaching the `jsonOutput` branch (line 783), so JSON is never output.
- Fix: exclude `jsonOutput` from the `prettyFormat` derivation so JSON always takes priority

## Impact

This broke `gt mail inbox` in Gas Town, which calls `bd list --json` as a subprocess and parses the output. Non-JSON text caused `json.Unmarshal` to fail silently, making the inbox always return 0 messages.

## Test plan

- [x] `bd list --json` now produces JSON output
- [x] `bd list` (no --json) still produces tree format
- [x] `bd list --flat` still works
- [x] `gt mail inbox` now shows messages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)