### PR TITLE
fix: detect wrong-server scenario in database-not-found error

### DIFF
--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -92,21 +92,35 @@ func wrapExecError(op string, err error) error {
 
 // databaseNotFoundError builds the "database not found" error with a config-aware
 // hint about sync.git-remote. Extracted from openServerConnection for testability.
-func databaseNotFoundError(cfg *Config) error {
+// otherDBs lists the non-system databases the server IS serving (may be nil).
+func databaseNotFoundError(cfg *Config, otherDBs []string) error {
 	var b strings.Builder
 	fmt.Fprintf(&b, "database %q not found on Dolt server at %s:%d\n\n", cfg.Database, cfg.ServerHost, cfg.ServerPort)
-	b.WriteString("This usually means a server configuration problem, NOT a missing database.\n")
-	b.WriteString("Common causes:\n")
-	b.WriteString("  - The server is serving a different data directory than expected\n")
-	b.WriteString("  - The server was restarted and is using a different port\n")
-	b.WriteString("  - Another project's Dolt server is running on this port\n\n")
-	b.WriteString("To diagnose:\n")
-	b.WriteString("  bd doctor                  # Check server and database health\n")
-	b.WriteString("  bd dolt status             # Show which data directory the server is using")
+
+	// If the server has other user databases, this is a wrong-server scenario:
+	// another project's Dolt server is occupying this port. (GH#2445)
+	if len(otherDBs) > 0 {
+		fmt.Fprintf(&b, "The server on this port is serving database %q, not %q.\n", otherDBs[0], cfg.Database)
+		b.WriteString("Another project's Dolt server is running on this port.\n\n")
+		b.WriteString("To fix:\n")
+		b.WriteString("  Remove dolt_server_port from .beads/metadata.json\n")
+		b.WriteString("    (each project will get a unique auto-assigned port)\n")
+		b.WriteString("  Or set a different port:\n")
+		b.WriteString("    bd dolt set port <port>\n")
+	} else {
+		b.WriteString("This usually means a server configuration problem, NOT a missing database.\n")
+		b.WriteString("Common causes:\n")
+		b.WriteString("  - The server is serving a different data directory than expected\n")
+		b.WriteString("  - The server was restarted and is using a different port\n")
+		b.WriteString("  - Another project's Dolt server is running on this port\n\n")
+		b.WriteString("To diagnose:\n")
+		b.WriteString("  bd doctor                  # Check server and database health\n")
+		b.WriteString("  bd dolt status             # Show which data directory the server is using")
+	}
 
 	if cfg.SyncGitRemote != "" {
 		fmt.Fprintf(&b, "\n\nTip: sync.git-remote is configured (%s).\nRun bd init to bootstrap from the remote.", cfg.SyncGitRemote)
-	} else {
+	} else if len(otherDBs) == 0 {
 		b.WriteString("\n\nTip: To bootstrap from an existing Dolt remote, set sync.git-remote\nin .beads/config.yaml and re-run bd init.")
 	}
 

--- a/internal/storage/dolt/errors_test.go
+++ b/internal/storage/dolt/errors_test.go
@@ -100,7 +100,7 @@ func TestDatabaseNotFoundHint(t *testing.T) {
 
 	t.Run("hint suggests setting sync.git-remote when empty", func(t *testing.T) {
 		cfg := baseCfg // SyncGitRemote is empty by default
-		err := databaseNotFoundError(&cfg)
+		err := databaseNotFoundError(&cfg, nil)
 
 		msg := err.Error()
 
@@ -132,7 +132,7 @@ func TestDatabaseNotFoundHint(t *testing.T) {
 	t.Run("hint mentions configured sync.git-remote when set", func(t *testing.T) {
 		cfg := baseCfg
 		cfg.SyncGitRemote = "https://doltremoteapi.dolthub.com/myorg/beads"
-		err := databaseNotFoundError(&cfg)
+		err := databaseNotFoundError(&cfg, nil)
 
 		msg := err.Error()
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -854,7 +854,10 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	if !dbExists {
 		if !cfg.CreateIfMissing {
 			_ = db.Close()
-			return nil, "", databaseNotFoundError(cfg)
+			// Check what databases the server IS serving to detect wrong-server
+			// scenarios and give an actionable error message. (GH#2445)
+			otherDBs := listUserDatabases(ctx, initDB)
+			return nil, "", databaseNotFoundError(cfg, otherDBs)
 		}
 
 		_, err = initDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", cfg.Database)) //nolint:gosec // G201: cfg.Database validated by ValidateDatabaseName above
@@ -919,6 +922,28 @@ func databaseExistsOnServer(ctx context.Context, db *sql.DB, name string) (bool,
 		}
 	}
 	return false, rows.Err()
+}
+
+// listUserDatabases returns non-system database names from the server.
+// Used to provide context in wrong-server error messages. (GH#2445)
+func listUserDatabases(ctx context.Context, db *sql.DB) []string {
+	rows, err := db.QueryContext(ctx, "SHOW DATABASES")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+
+	var dbs []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			continue
+		}
+		if name != "information_schema" && name != "mysql" && name != "performance_schema" {
+			dbs = append(dbs, name)
+		}
+	}
+	return dbs
 }
 
 // initSchema creates all tables if they don't exist


### PR DESCRIPTION
## Summary

When two projects share the same `dolt_server_port`, the second project connects to the first's Dolt server and gets a confusing "database not found" error with generic troubleshooting hints. This PR detects the wrong-server scenario and tells the user exactly what's happening.

## Changes

3 files, +52/-13 lines. All in `internal/storage/dolt/`.

**`store.go`**: When a database isn't found, `openServerConnection` now calls `listUserDatabases()` to discover what the server IS serving, and passes that to the error builder.

**`errors.go`**: `databaseNotFoundError` now accepts the list of databases on the server. When another project's database is found, the error message changes from generic hints to:

```
database "test2" not found on Dolt server at 127.0.0.1:3307

The server on this port is serving database "test1", not "test2".
Another project's Dolt server is running on this port.

To fix:
  Remove dolt_server_port from .beads/metadata.json
    (each project will get a unique auto-assigned port)
  Or set a different port:
    bd dolt set port <port>
```

When no other user databases are found (empty server or server just started), the existing generic error message is preserved unchanged.

**`errors_test.go`**: Updated for new function signature.

## Why this is safe to merge

1. **Error path only.** The new code only runs when the database is already not found. No change to the success path.
2. **No behavior change.** Still returns an error. The only difference is the error message text when another project's database is detected.
3. **Fails gracefully.** `listUserDatabases` returns nil on any SQL error, falling through to the existing generic message.
4. **All tests pass.** Existing `TestDatabaseNotFoundHint` and `TestOpenFromConfig_ServerModeFailsWithoutServer` both pass.

Fixes #2445. Related: #2444.