### PR TITLE
doctor: block --fix at Gas Town town root

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -202,6 +202,16 @@ Examples:
 			FatalError("failed to resolve path: %v", err)
 		}
 
+		// Guardrail: never run mutating bd doctor fix from Gas Town town root.
+		// Town-level repair must go through `gt doctor --fix` because town roots
+		// have additional invariants beyond beads-only repos.
+		if doctorFix && isGasTownTownRoot(absPath) {
+			FatalErrorWithHint(
+				"refusing to run 'bd doctor --fix' at Gas Town town root",
+				"Use 'gt doctor --fix' from town root, or run 'bd doctor --fix' inside a specific rig clone (e.g. <rig>/mayor/rig)",
+			)
+		}
+
 		// Run performance diagnostics if --perf flag is set
 		if perfMode {
 			if err := doctor.RunPerformanceDiagnostics(absPath); err != nil {

--- a/cmd/bd/doctor_gastown_guard.go
+++ b/cmd/bd/doctor_gastown_guard.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// isGasTownTownRoot returns true when path looks like a Gas Town HQ root.
+//
+// We require both:
+//  1. mayor/town.json (town identity/config), and
+//  2. .beads/routes.jsonl (town-level routing config)
+//
+// This keeps detection strict and avoids blocking normal repos that merely
+// contain a .beads directory.
+func isGasTownTownRoot(path string) bool {
+	if path == "" {
+		return false
+	}
+
+	townConfig := filepath.Join(path, "mayor", "town.json")
+	routes := filepath.Join(path, ".beads", "routes.jsonl")
+
+	if _, err := os.Stat(townConfig); err != nil {
+		return false
+	}
+	if _, err := os.Stat(routes); err != nil {
+		return false
+	}
+
+	return true
+}

--- a/cmd/bd/doctor_gastown_guard_test.go
+++ b/cmd/bd/doctor_gastown_guard_test.go
@@ -1,0 +1,69 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsGasTownTownRoot_TrueWhenTownMarkersPresent(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(root, "mayor"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".beads"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "mayor", "town.json"), []byte(`{"name":"gt"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".beads", "routes.jsonl"), []byte(`{"prefix":"hq-","path":"."}`+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isGasTownTownRoot(root) {
+		t.Fatalf("expected %s to be detected as Gas Town root", root)
+	}
+}
+
+func TestIsGasTownTownRoot_FalseWhenMarkersMissing(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupTown  bool
+		setupRoute bool
+	}{
+		{name: "missing both", setupTown: false, setupRoute: false},
+		{name: "missing routes", setupTown: true, setupRoute: false},
+		{name: "missing town", setupTown: false, setupRoute: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(root, "mayor"), 0750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Join(root, ".beads"), 0750); err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.setupTown {
+				if err := os.WriteFile(filepath.Join(root, "mayor", "town.json"), []byte(`{"name":"gt"}`), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tc.setupRoute {
+				if err := os.WriteFile(filepath.Join(root, ".beads", "routes.jsonl"), []byte(`{"prefix":"hq-","path":"."}`+"\n"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if isGasTownTownRoot(root) {
+				t.Fatalf("expected %s to NOT be detected as Gas Town root", root)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary

 This PR adds a safety guard to prevent running mutating bd doctor --fix at a Gas Town HQ root (town root).
 At town root, repair should be done with gt doctor --fix, not bd doctor --fix.

 Problem

 Gas Town town roots are multi-rig orchestrator workspaces with additional invariants (mayor/town.json, .beads/routes.jsonl, daemon/patrol/hook wiring).
 bd doctor --fix is repo-centric and can misinterpret valid Gas Town town-root state as artifacts, causing destructive cleanup or state drift.

 This led to recurring incidents where town-root beads metadata/routing was mutated incorrectly and required manual recovery.

 What changed

 ### 1) New Gas Town town-root detector

 Added:
 - cmd/bd/doctor_gastown_guard.go

 New helper:
 - isGasTownTownRoot(path string) bool

 Detection is intentionally strict and requires both:
 - mayor/town.json
 - .beads/routes.jsonl

 This minimizes false positives in normal repos.

 ### 2) Guard in bd doctor execution path

 Updated:
 - cmd/bd/doctor.go

 Behavior:
 - If --fix is set and target path is detected as Gas Town town root:
     - fail fast
     - show actionable guidance:
           - use gt doctor --fix at town root
           - or run bd doctor --fix inside a rig clone (e.g. <rig>/mayor/rig)

 Non-mutating bd doctor remains unchanged.

 ### 3) Tests

 Added:
 - cmd/bd/doctor_gastown_guard_test.go

 Covers:
 - positive detection when town markers exist
 - negative detection when markers are missing

 Why this is correct

 - Preserves bd behavior for normal repositories and rig clones.
 - Prevents known destructive path at Gas Town town root.
 - Makes operator/agent behavior deterministic and safe by enforcing tool ownership boundary:
     - town root fix → gt doctor --fix
     - repo/rig fix → bd doctor --fix

 Validation performed

 - go test ./cmd/bd -run "TestIsGasTownTownRoot|TestDoctorNoBeadsDir" -count=1
 - go test ./cmd/bd -count=1
 - Built and installed locally via make install
 - Manual runtime check from Gas Town root:
     - bd doctor --fix --yes now refuses with clear hint
     - bd doctor still works as read-only diagnostics

 User impact

 - Prevents accidental town-root corruption from bd doctor --fix
 - Improves operator UX with explicit remediation guidance
 - No change for standard beads repos or rig-level usage
