### PR TITLE
fix: remove idle monitor and activity signal daemon infrastructure

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -42,8 +42,6 @@ dolt-server.pid
 dolt-server.log
 dolt-server.lock
 dolt-server.port
-dolt-server.activity
-dolt-monitor.pid
 
 # Backup data (auto-exported JSONL, local-only)
 backup/
@@ -87,8 +85,6 @@ var requiredPatterns = []string{
 	"dolt-server.log",
 	"dolt-server.lock",
 	"dolt-server.port",
-	"dolt-server.activity",
-	"dolt-monitor.pid",
 }
 
 // CheckGitignore checks if .beads/.gitignore is up to date.

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -347,48 +345,6 @@ Displays whether the server is running, its PID, port, and data directory.`,
 		fmt.Printf("  Port: %d\n", state.Port)
 		fmt.Printf("  Data: %s\n", state.DataDir)
 		fmt.Printf("  Logs: %s\n", doltserver.LogPath(serverDir))
-	},
-}
-
-var doltIdleMonitorCmd = &cobra.Command{
-	Use:    "idle-monitor",
-	Short:  "Run idle monitor (internal, not for direct use)",
-	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
-		beadsDir, _ := cmd.Flags().GetString("beads-dir")
-		if beadsDir == "" {
-			beadsDir = beads.FindBeadsDir()
-		}
-		if beadsDir == "" {
-			os.Exit(1)
-		}
-
-		// PID file and lock management is handled inside RunIdleMonitor
-		// to ensure single-instance enforcement (GH#2367).
-
-		// Parse idle timeout from config
-		idleTimeout := doltserver.DefaultIdleTimeout
-		if v := config.GetYamlConfig("dolt.idle-timeout"); v != "" {
-			if v == "0" {
-				// Disabled
-				return
-			}
-			if d, err := time.ParseDuration(v); err == nil {
-				idleTimeout = d
-			}
-		}
-
-		// Handle SIGTERM gracefully — clean up PID file on signal
-		pidFile := filepath.Join(beadsDir, "dolt-monitor.pid")
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-		go func() {
-			<-sigCh
-			_ = os.Remove(pidFile)
-			os.Exit(0)
-		}()
-
-		doltserver.RunIdleMonitor(beadsDir, idleTimeout)
 	},
 }
 
@@ -879,7 +835,6 @@ func init() {
 	doltStopCmd.Flags().Bool("force", false, "Force stop the server")
 	doltPushCmd.Flags().Bool("force", false, "Force push (overwrite remote changes)")
 	doltCommitCmd.Flags().StringP("message", "m", "", "Commit message (default: auto-generated)")
-	doltIdleMonitorCmd.Flags().String("beads-dir", "", "Path to .beads directory")
 	doltCleanDatabasesCmd.Flags().Bool("dry-run", false, "Show what would be dropped without dropping")
 	doltRemoteRemoveCmd.Flags().Bool("force", false, "Force remove even when SQL and CLI URLs conflict")
 	doltRemoteCmd.AddCommand(doltRemoteAddCmd)
@@ -894,7 +849,6 @@ func init() {
 	doltCmd.AddCommand(doltStartCmd)
 	doltCmd.AddCommand(doltStopCmd)
 	doltCmd.AddCommand(doltStatusCmd)
-	doltCmd.AddCommand(doltIdleMonitorCmd)
 	doltCmd.AddCommand(doltKillallCmd)
 	doltCmd.AddCommand(doltCleanDatabasesCmd)
 	doltCmd.AddCommand(doltRemoteCmd)

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -96,14 +96,10 @@ type State struct {
 }
 
 // file paths within .beads/
-func pidPath(beadsDir string) string      { return filepath.Join(beadsDir, "dolt-server.pid") }
-func logPath(beadsDir string) string      { return filepath.Join(beadsDir, "dolt-server.log") }
-func lockPath(beadsDir string) string     { return filepath.Join(beadsDir, "dolt-server.lock") }
-func portPath(beadsDir string) string     { return filepath.Join(beadsDir, "dolt-server.port") }
-func activityPath(beadsDir string) string { return filepath.Join(beadsDir, "dolt-server.activity") }
-func monitorPidPath(beadsDir string) string {
-	return filepath.Join(beadsDir, "dolt-monitor.pid")
-}
+func pidPath(beadsDir string) string  { return filepath.Join(beadsDir, "dolt-server.pid") }
+func logPath(beadsDir string) string  { return filepath.Join(beadsDir, "dolt-server.log") }
+func lockPath(beadsDir string) string { return filepath.Join(beadsDir, "dolt-server.lock") }
+func portPath(beadsDir string) string { return filepath.Join(beadsDir, "dolt-server.port") }
 
 // MaxDoltServers is the hard ceiling on concurrent dolt sql-server processes.
 // Allows up to 3 (e.g., multiple projects).
@@ -352,8 +348,6 @@ func EnsureRunning(beadsDir string) (int, error) {
 		return 0, err
 	}
 	if state.Running {
-		// Touch activity file so idle monitor knows we're active
-		touchActivity(serverDir)
 		return state.Port, nil
 	}
 
@@ -361,13 +355,7 @@ func EnsureRunning(beadsDir string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	touchActivity(serverDir)
 	return s.Port, nil
-}
-
-// touchActivity updates the activity file timestamp.
-func touchActivity(beadsDir string) {
-	_ = os.WriteFile(activityPath(beadsDir), []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0600)
 }
 
 // Start explicitly starts a dolt sql-server for the project.
@@ -459,8 +447,6 @@ func Start(beadsDir string) (*State, error) {
 		_ = logFile.Close()
 		_ = os.WriteFile(pidPath(beadsDir), []byte(strconv.Itoa(adoptPID)), 0600)
 		_ = writePortFile(beadsDir, actualPort)
-		touchActivity(beadsDir)
-		forkIdleMonitor(beadsDir)
 		return &State{Running: true, PID: adoptPID, Port: actualPort, DataDir: doltDir}, nil
 	}
 
@@ -509,10 +495,6 @@ func Start(beadsDir string) (*State, error) {
 		return nil, fmt.Errorf("server started (PID %d) but not accepting connections on port %d: %w\nCheck logs: %s",
 			pid, actualPort, err, logPath(beadsDir))
 	}
-
-	// Touch activity and fork idle monitor
-	touchActivity(beadsDir)
-	forkIdleMonitor(beadsDir)
 
 	return &State{
 		Running: true,
@@ -638,8 +620,6 @@ func StopWithForce(beadsDir string, force bool) error {
 func cleanupStateFiles(beadsDir string) {
 	_ = os.Remove(pidPath(beadsDir))
 	_ = os.Remove(portPath(beadsDir))
-	_ = os.Remove(activityPath(beadsDir))
-	stopIdleMonitor(beadsDir)
 }
 
 // LogPath returns the path to the server log file.
@@ -823,214 +803,3 @@ func IsPreV56DoltDir(doltDir string) bool {
 	return os.IsNotExist(err)
 }
 
-// --- Idle monitor ---
-
-// DefaultIdleTimeout is the default duration before the idle monitor stops the server.
-const DefaultIdleTimeout = 30 * time.Minute
-
-// MonitorCheckInterval is how often the idle monitor checks activity.
-const MonitorCheckInterval = 60 * time.Second
-
-// stopServerProcess stops the Dolt server process without touching the idle
-// monitor's own state. This is used by the idle monitor to avoid killing itself
-// when shutting down an idle server. It flushes the working set, gracefully
-// stops the server, and removes server state files (PID, port) but leaves the
-// monitor PID file and activity file intact so the monitor can continue running
-// as a watchdog.
-func stopServerProcess(beadsDir string) error {
-	state, err := IsRunning(beadsDir)
-	if err != nil {
-		return err
-	}
-	if !state.Running {
-		return nil // already stopped
-	}
-
-	// Flush uncommitted working set changes before stopping.
-	cfg := DefaultConfig(beadsDir)
-	if flushErr := FlushWorkingSet(cfg.Host, state.Port); flushErr != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not flush working set before stop: %v\n", flushErr)
-	}
-
-	if err := gracefulStop(state.PID, 5*time.Second); err != nil {
-		_ = os.Remove(pidPath(beadsDir))
-		_ = os.Remove(portPath(beadsDir))
-		return err
-	}
-	_ = os.Remove(pidPath(beadsDir))
-	_ = os.Remove(portPath(beadsDir))
-	return nil
-}
-
-// forkIdleMonitor starts the idle monitor as a detached process.
-// It runs `bd dolt idle-monitor --beads-dir=<dir>` in the background.
-func forkIdleMonitor(beadsDir string) {
-	// Don't fork if there's already a monitor running
-	if isMonitorRunning(beadsDir) {
-		return
-	}
-
-	bdBin, err := os.Executable()
-	if err != nil {
-		return // best effort
-	}
-
-	cmd := exec.Command(bdBin, "dolt", "idle-monitor", "--beads-dir", beadsDir)
-	cmd.Stdin = nil
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	cmd.SysProcAttr = procAttrDetached()
-
-	if err := cmd.Start(); err != nil {
-		return // best effort
-	}
-
-	// Write monitor PID file
-	_ = os.WriteFile(monitorPidPath(beadsDir), []byte(strconv.Itoa(cmd.Process.Pid)), 0600)
-	_ = cmd.Process.Release()
-}
-
-// isMonitorRunning checks if the idle monitor process is alive.
-func isMonitorRunning(beadsDir string) bool {
-	data, err := os.ReadFile(monitorPidPath(beadsDir))
-	if err != nil {
-		return false
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return false
-	}
-	return isProcessAlive(pid)
-}
-
-// stopIdleMonitor kills the idle monitor process if running.
-func stopIdleMonitor(beadsDir string) {
-	data, err := os.ReadFile(monitorPidPath(beadsDir))
-	if err != nil {
-		return
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		_ = os.Remove(monitorPidPath(beadsDir))
-		return
-	}
-	if process, err := os.FindProcess(pid); err == nil {
-		_ = process.Kill()
-	}
-	_ = os.Remove(monitorPidPath(beadsDir))
-}
-
-// ReadActivityTime reads the last activity timestamp from the activity file.
-// Returns zero time if the file doesn't exist or is unreadable.
-func ReadActivityTime(beadsDir string) time.Time {
-	data, err := os.ReadFile(activityPath(beadsDir))
-	if err != nil {
-		return time.Time{}
-	}
-	ts, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
-	if err != nil {
-		return time.Time{}
-	}
-	return time.Unix(ts, 0)
-}
-
-// RunIdleMonitor is the main loop for the idle monitor sidecar process.
-// It checks the activity file periodically and stops the server if idle
-// for longer than the configured timeout. After stopping an idle server,
-// the monitor continues running as a watchdog: if new activity appears
-// (e.g. a bd command calls EnsureRunning and touches the activity file),
-// the monitor restarts the server. The monitor only exits after an
-// additional full idle timeout passes with no new activity.
-//
-// If the server crashed but activity is recent, the monitor restarts it
-// (watchdog behavior).
-//
-// idleTimeout of 0 means monitoring is disabled (exits immediately).
-func RunIdleMonitor(beadsDir string, idleTimeout time.Duration) {
-	if idleTimeout == 0 {
-		return
-	}
-
-	// Single-instance enforcement: acquire an exclusive lock on the monitor
-	// lock file. If another monitor is already running, exit immediately.
-	// This prevents the accumulation bug (GH#2367) where Start() called from
-	// within the monitor's watchdog restart would fork yet another monitor.
-	monitorLockPath := monitorPidPath(beadsDir) + ".lock"
-	var monitorLock *os.File
-	if f, err := os.OpenFile(monitorLockPath, os.O_CREATE|os.O_RDWR, 0600); err == nil { //nolint:gosec // G304: path derived from trusted beadsDir
-		if lockErr := lockfile.FlockExclusiveNonBlocking(f); lockErr != nil {
-			_ = f.Close()
-			return // another monitor holds the lock — exit silently
-		}
-		monitorLock = f
-	}
-	// Keep lock held for lifetime of this process. Clean up on exit.
-	defer func() {
-		_ = os.Remove(monitorPidPath(beadsDir))
-		if monitorLock != nil {
-			_ = lockfile.FlockUnlock(monitorLock)
-			_ = monitorLock.Close()
-			_ = os.Remove(monitorLockPath)
-		}
-	}()
-
-	// Write our PID now that we hold the lock
-	_ = os.WriteFile(monitorPidPath(beadsDir), []byte(strconv.Itoa(os.Getpid())), 0600)
-
-	// Tracks when we stopped the server for idle timeout. Zero means we
-	// haven't performed an idle shutdown (or the server was restarted since).
-	var idleShutdownAt time.Time
-
-	for {
-		time.Sleep(MonitorCheckInterval)
-
-		state, err := IsRunning(beadsDir)
-		if err != nil {
-			continue
-		}
-
-		lastActivity := ReadActivityTime(beadsDir)
-		idleDuration := time.Since(lastActivity)
-
-		if state.Running {
-			idleShutdownAt = time.Time{} // server is up, clear idle-shutdown tracking
-
-			// Server is running — check if idle
-			if !lastActivity.IsZero() && idleDuration > idleTimeout {
-				// Idle too long — stop the server but keep monitoring.
-				// Use stopServerProcess (not Stop) to avoid killing ourselves.
-				_ = stopServerProcess(beadsDir)
-				idleShutdownAt = time.Now()
-			}
-		} else {
-			// Server is NOT running
-			if !idleShutdownAt.IsZero() {
-				// We stopped it for idle timeout. Check for new activity
-				// (e.g. EnsureRunning touched the activity file).
-				if !lastActivity.IsZero() && lastActivity.After(idleShutdownAt) {
-					// New activity since we stopped — restart
-					_, _ = Start(beadsDir)
-					idleShutdownAt = time.Time{}
-					continue
-				}
-				// No new activity yet. If we've been waiting longer than
-				// another full idle timeout since shutdown, give up and exit.
-				if time.Since(idleShutdownAt) > idleTimeout {
-					_ = os.Remove(monitorPidPath(beadsDir))
-					return
-				}
-				// Keep waiting for new activity
-				continue
-			}
-
-			// Server is down but we didn't stop it (crash or external stop)
-			if lastActivity.IsZero() || idleDuration > idleTimeout {
-				// No recent activity — just exit
-				_ = os.Remove(monitorPidPath(beadsDir))
-				return
-			}
-			// Recent activity but server crashed — restart
-			_, _ = Start(beadsDir)
-		}
-	}
-}

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -5,10 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/steveyegge/beads/internal/config"
 )
@@ -443,27 +441,6 @@ func TestIsRunningReadsPortFile(t *testing.T) {
 	}
 }
 
-// --- Activity tracking tests ---
-
-func TestTouchAndReadActivity(t *testing.T) {
-	dir := t.TempDir()
-
-	// No file yet
-	if ts := ReadActivityTime(dir); !ts.IsZero() {
-		t.Errorf("expected zero time for missing activity file, got %v", ts)
-	}
-
-	// Touch and read
-	touchActivity(dir)
-	ts := ReadActivityTime(dir)
-	if ts.IsZero() {
-		t.Fatal("expected non-zero activity time after touch")
-	}
-	if time.Since(ts) > 5*time.Second {
-		t.Errorf("activity timestamp too old: %v", ts)
-	}
-}
-
 func TestCleanupStateFiles(t *testing.T) {
 	dir := t.TempDir()
 
@@ -471,7 +448,6 @@ func TestCleanupStateFiles(t *testing.T) {
 	for _, path := range []string{
 		pidPath(dir),
 		portPath(dir),
-		activityPath(dir),
 	} {
 		if err := os.WriteFile(path, []byte("test"), 0600); err != nil {
 			t.Fatal(err)
@@ -483,30 +459,10 @@ func TestCleanupStateFiles(t *testing.T) {
 	for _, path := range []string{
 		pidPath(dir),
 		portPath(dir),
-		activityPath(dir),
 	} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Errorf("expected %s to be removed", filepath.Base(path))
 		}
-	}
-}
-
-// --- Idle monitor tests ---
-
-func TestRunIdleMonitorDisabled(t *testing.T) {
-	// idleTimeout=0 should return immediately
-	dir := t.TempDir()
-	done := make(chan struct{})
-	go func() {
-		RunIdleMonitor(dir, 0)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// good — returned immediately
-	case <-time.After(2 * time.Second):
-		t.Fatal("RunIdleMonitor(0) should return immediately")
 	}
 }
 
@@ -518,35 +474,6 @@ func TestFlushWorkingSetUnreachable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not reachable") {
 		t.Errorf("expected 'not reachable' in error, got: %v", err)
-	}
-}
-
-func TestMonitorPidLifecycle(t *testing.T) {
-	dir := t.TempDir()
-
-	// No monitor running
-	if isMonitorRunning(dir) {
-		t.Error("expected no monitor running initially")
-	}
-
-	// Write our own PID as monitor (we know we're alive)
-	_ = os.WriteFile(monitorPidPath(dir), []byte(strconv.Itoa(os.Getpid())), 0600)
-	if !isMonitorRunning(dir) {
-		t.Error("expected monitor to be detected as running")
-	}
-
-	// Don't call stopIdleMonitor with our own PID (it sends SIGTERM).
-	// Instead test with a dead PID.
-	_ = os.Remove(monitorPidPath(dir))
-	_ = os.WriteFile(monitorPidPath(dir), []byte("99999999"), 0600)
-	if isMonitorRunning(dir) {
-		t.Error("expected dead PID to not be detected as running")
-	}
-
-	// stopIdleMonitor should clean up the PID file
-	stopIdleMonitor(dir)
-	if _, err := os.Stat(monitorPidPath(dir)); !os.IsNotExist(err) {
-		t.Error("expected monitor PID file to be removed")
 	}
 }
 
@@ -757,89 +684,3 @@ func TestEnsureDoltInit_WritesMarker(t *testing.T) {
 	}
 }
 
-// --- stopServerProcess tests ---
-
-func TestStopServerProcessPreservesMonitorAndActivity(t *testing.T) {
-	// stopServerProcess must leave the monitor PID file and activity file
-	// intact. This is the core fix for GH#2324: the idle monitor calls
-	// stopServerProcess (not Stop) to avoid killing itself via
-	// cleanupStateFiles → stopIdleMonitor.
-	dir := t.TempDir()
-	t.Setenv("GT_ROOT", "")
-
-	// Write activity and monitor PID files
-	touchActivity(dir)
-	monitorPID := os.Getpid()
-	_ = os.WriteFile(monitorPidPath(dir), []byte(strconv.Itoa(monitorPID)), 0600)
-
-	// No server PID file → stopServerProcess returns immediately (already stopped)
-	if err := stopServerProcess(dir); err != nil {
-		t.Fatalf("stopServerProcess: %v", err)
-	}
-
-	// Activity file must be preserved
-	if _, err := os.Stat(activityPath(dir)); os.IsNotExist(err) {
-		t.Error("stopServerProcess must preserve activity file")
-	}
-	// Monitor PID file must be preserved
-	if _, err := os.Stat(monitorPidPath(dir)); os.IsNotExist(err) {
-		t.Error("stopServerProcess must preserve monitor PID file")
-	}
-	// Monitor PID should still contain our PID (not corrupted)
-	data, err := os.ReadFile(monitorPidPath(dir))
-	if err != nil {
-		t.Fatalf("reading monitor PID file: %v", err)
-	}
-	if pid, _ := strconv.Atoi(strings.TrimSpace(string(data))); pid != monitorPID {
-		t.Errorf("monitor PID file changed: want %d, got %d", monitorPID, pid)
-	}
-}
-
-func TestStopServerProcessRemovesPidAndPort(t *testing.T) {
-	// When the server is running (simulated with a stale PID that IsRunning
-	// will clean up), stopServerProcess should remove PID and port files
-	// but leave activity and monitor files intact.
-	dir := t.TempDir()
-	t.Setenv("GT_ROOT", "")
-
-	// Write all state files
-	_ = os.WriteFile(pidPath(dir), []byte("99999999"), 0600) // dead PID
-	_ = writePortFile(dir, 13500)
-	touchActivity(dir)
-	_ = os.WriteFile(monitorPidPath(dir), []byte(strconv.Itoa(os.Getpid())), 0600)
-
-	// stopServerProcess: IsRunning sees dead PID → returns Running=false →
-	// stopServerProcess returns nil (already stopped).
-	_ = stopServerProcess(dir)
-
-	// PID file was cleaned up by IsRunning (stale PID detection)
-	if _, err := os.Stat(pidPath(dir)); !os.IsNotExist(err) {
-		t.Error("expected server PID file to be removed")
-	}
-
-	// Activity and monitor PID files must survive
-	if _, err := os.Stat(activityPath(dir)); os.IsNotExist(err) {
-		t.Error("stopServerProcess must preserve activity file")
-	}
-	if _, err := os.Stat(monitorPidPath(dir)); os.IsNotExist(err) {
-		t.Error("stopServerProcess must preserve monitor PID file")
-	}
-}
-
-func TestRunIdleMonitorZeroTimeoutExitsImmediately(t *testing.T) {
-	// With zero timeout, the monitor should exit immediately.
-	dir := t.TempDir()
-
-	done := make(chan struct{})
-	go func() {
-		RunIdleMonitor(dir, 0)
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// good — exited immediately with zero timeout
-	case <-time.After(2 * time.Second):
-		t.Fatal("RunIdleMonitor should exit immediately with zero timeout")
-	}
-}


### PR DESCRIPTION
## Summary

- Removes the idle monitor sidecar process (`bd dolt idle-monitor`) and associated activity file mechanism (`dolt-server.activity`, `dolt-monitor.pid`)
- Eliminates `forkIdleMonitor`, `isMonitorRunning`, `stopIdleMonitor`, `RunIdleMonitor`, `stopServerProcess`, `touchActivity`, `ReadActivityTime`, `activityPath`, `monitorPidPath`, `DefaultIdleTimeout`, `MonitorCheckInterval`
- Removes `dolt-server.activity` and `dolt-monitor.pid` from `.beads/.gitignore` template and `requiredPatterns`
- Removes corresponding tests for deleted infrastructure

## Motivation

The idle monitor was part of the old beads daemon architecture where beads managed its own Dolt server lifecycle with an auto-shutdown-on-idle behavior. In Gas Town and other external Dolt server setups, the Dolt server is managed externally (not by bd), making this daemon infrastructure unnecessary.

The idle monitor spawned a background `bd dolt idle-monitor` process on every `bd` command, contributing to:
- Background Dolt connections held open by the monitor
- Periodic parallel query patterns (ReadActivityTime polling) that contribute to CLOSE_WAIT DoS under concurrent polecat load (Gas Town issue)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/doltserver/...` passes
- [x] `go test ./cmd/bd/doctor/...` passes
- [x] Verified `bd dolt start`, `bd dolt stop`, `bd dolt status` still work (server lifecycle unaffected)

Closes wasteland item w-bd-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)