### PR TITLE
Speed up close-time template subgraph loading

### DIFF
--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -118,43 +118,31 @@ func loadDescendants(ctx context.Context, s *dolt.DoltStore, subgraph *TemplateS
 	// Track children we've already added to avoid duplicates
 	addedChildren := make(map[string]bool)
 
-	// Strategy 1: GetDependents returns issues that depend on parentID
-	dependents, err := s.GetDependents(ctx, parentID)
+	// Strategy 1: Get direct parent-child dependents with relationship metadata.
+	dependents, err := s.GetDependentsWithMetadata(ctx, parentID)
 	if err != nil {
 		return fmt.Errorf("failed to get dependents of %s: %w", parentID, err)
 	}
 
-	// Check each dependent to see if it's a child (has parent-child relationship)
+	// Only keep explicit parent-child relationships.
 	for _, dependent := range dependents {
+		if dependent.DependencyType != types.DepParentChild {
+			continue
+		}
+
 		if _, exists := subgraph.IssueMap[dependent.ID]; exists {
 			continue // Already in subgraph
 		}
 
-		// Check if this dependent has a parent-child relationship with parentID
-		depRecs, err := s.GetDependencyRecords(ctx, dependent.ID)
-		if err != nil {
-			continue
-		}
-
-		isChild := false
-		for _, depRec := range depRecs {
-			if depRec.DependsOnID == parentID && depRec.Type == types.DepParentChild {
-				isChild = true
-				break
-			}
-		}
-
-		if !isChild {
-			continue
-		}
+		child := dependent.Issue
 
 		// Add to subgraph
-		subgraph.Issues = append(subgraph.Issues, dependent)
-		subgraph.IssueMap[dependent.ID] = dependent
-		addedChildren[dependent.ID] = true
+		subgraph.Issues = append(subgraph.Issues, &child)
+		subgraph.IssueMap[child.ID] = &child
+		addedChildren[child.ID] = true
 
 		// Recurse to get children of this child
-		if err := loadDescendants(ctx, s, subgraph, dependent.ID); err != nil {
+		if err := loadDescendants(ctx, s, subgraph, child.ID); err != nil {
 			return err
 		}
 	}
@@ -193,26 +181,17 @@ func loadDescendants(ctx context.Context, s *dolt.DoltStore, subgraph *TemplateS
 // findHierarchicalChildren finds issues with IDs that match the pattern parentID.N
 // This catches hierarchical children that may be missing parent-child dependencies.
 func findHierarchicalChildren(ctx context.Context, s *dolt.DoltStore, parentID string) ([]*types.Issue, error) {
-	// Look for issues with IDs starting with "parentID."
-	// We need to query by ID pattern, which requires listing issues
 	pattern := parentID + "."
-
-	// Use the storage's search capability with a filter
-	allIssues, err := s.SearchIssues(ctx, "", types.IssueFilter{})
+	candidates, err := s.SearchIssues(ctx, "", types.IssueFilter{IDPrefix: pattern})
 	if err != nil {
 		return nil, err
 	}
 
 	var children []*types.Issue
-	for _, issue := range allIssues {
-		// Check if ID starts with pattern and is a direct child (no further dots after the pattern)
-		if len(issue.ID) > len(pattern) && issue.ID[:len(pattern)] == pattern {
-			// Check it's a direct child, not a grandchild
-			// e.g., "parent.1" is a child, "parent.1.2" is a grandchild
-			remaining := issue.ID[len(pattern):]
-			if !strings.Contains(remaining, ".") {
-				children = append(children, issue)
-			}
+	for _, issue := range candidates {
+		_, directParentID, depth := types.ParseHierarchicalID(issue.ID)
+		if depth > 0 && directParentID == parentID {
+			children = append(children, issue)
 		}
 	}
 

--- a/cmd/bd/template_test.go
+++ b/cmd/bd/template_test.go
@@ -4,12 +4,17 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/formula"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -132,6 +137,113 @@ func (h *templateTestHelper) createIssueWithID(id, title, description string, is
 		h.t.Fatalf("Failed to create issue with ID %s: %v", id, err)
 	}
 	return issue
+}
+
+func (h *templateTestHelper) createHierarchy(rootID string, descendantIDs ...string) {
+	h.createIssueWithID(rootID, rootID, "", types.TypeEpic, 1)
+	for _, id := range descendantIDs {
+		h.createIssueWithID(id, id, "", types.TypeTask, 2)
+	}
+}
+
+func issueIDs(issues []*types.Issue) []string {
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		ids = append(ids, issue.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func requireIssueIDs(t testing.TB, issues []*types.Issue, want ...string) {
+	t.Helper()
+
+	got := issueIDs(issues)
+	want = slices.Clone(want)
+	sort.Strings(want)
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("issue IDs = %v, want %v", got, want)
+	}
+}
+
+func newTemplateBenchmarkStore(b *testing.B) (*dolt.DoltStore, context.Context) {
+	b.Helper()
+
+	if testDoltServerPort == 0 {
+		b.Skip("Dolt test server not available, skipping")
+	}
+	if testutil.DoltContainerCrashed() {
+		b.Skipf("Dolt test server crashed: %v", testutil.DoltContainerCrashError())
+	}
+
+	ctx := context.Background()
+	testDB := filepath.Join(b.TempDir(), ".beads", "beads.db")
+	database := fmt.Sprintf("benchdb_%d", time.Now().UnixNano())
+
+	s, err := dolt.New(ctx, &dolt.Config{
+		Path:            testDB,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      testDoltServerPort,
+		Database:        database,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		b.Fatalf("Failed to create benchmark dolt store: %v", err)
+	}
+
+	b.Cleanup(func() {
+		s.Close()
+		dropTestDatabase(database, testDoltServerPort)
+	})
+
+	if err := s.SetConfig(ctx, "issue_prefix", "bench"); err != nil {
+		b.Fatalf("Failed to set issue_prefix: %v", err)
+	}
+	if err := s.SetConfig(ctx, "types.custom", "molecule,gate,convoy,merge-request,slot,agent,role,rig,event,message"); err != nil {
+		b.Fatalf("Failed to set types.custom: %v", err)
+	}
+
+	return s, ctx
+}
+
+func createBenchmarkIssue(b *testing.B, ctx context.Context, s *dolt.DoltStore, id string, priority int, issueType types.IssueType) {
+	b.Helper()
+
+	issue := &types.Issue{
+		ID:        id,
+		Title:     id,
+		Priority:  priority,
+		IssueType: issueType,
+		Status:    types.StatusOpen,
+	}
+	if err := s.CreateIssue(ctx, issue, "benchmark"); err != nil {
+		b.Fatalf("CreateIssue(%s): %v", id, err)
+	}
+}
+
+func seedHierarchicalTemplateGraph(b *testing.B, ctx context.Context, s *dolt.DoltStore, rootID string, directChildren, grandchildrenPerNode, unrelatedIssueCount int) int {
+	b.Helper()
+
+	createBenchmarkIssue(b, ctx, s, rootID, 1, types.TypeEpic)
+
+	expectedIssues := 1
+	for childIndex := 1; childIndex <= directChildren; childIndex++ {
+		childID := fmt.Sprintf("%s.%d", rootID, childIndex)
+		createBenchmarkIssue(b, ctx, s, childID, 2, types.TypeTask)
+		expectedIssues++
+
+		for grandchildIndex := 1; grandchildIndex <= grandchildrenPerNode; grandchildIndex++ {
+			createBenchmarkIssue(b, ctx, s, fmt.Sprintf("%s.%d", childID, grandchildIndex), 3, types.TypeTask)
+			expectedIssues++
+		}
+	}
+
+	for noiseIndex := 0; noiseIndex < unrelatedIssueCount; noiseIndex++ {
+		createBenchmarkIssue(b, ctx, s, fmt.Sprintf("bench-noise-%04d", noiseIndex), 4, types.TypeTask)
+	}
+
+	return expectedIssues
 }
 
 // TestTemplateSuite consolidates template loading, cloning, and variable extraction
@@ -650,6 +762,56 @@ func TestResolveProtoIDOrTitle(t *testing.T) {
 			t.Fatal("Expected error for non-proto ID, got nil")
 		}
 	})
+}
+
+func TestFindHierarchicalChildren_DirectChildrenOnly(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	s := newTestStore(t, testDB)
+	ctx := context.Background()
+	h := &templateTestHelper{s: s, ctx: ctx, t: t}
+
+	h.createHierarchy(
+		"test-tree",
+		"test-tree.1",
+		"test-tree.2",
+		"test-tree.1.1",
+		"test-tree.2.1",
+		"test-tree.2.1.1",
+	)
+	h.createIssueWithID("test-other.1", "test-other.1", "", types.TypeTask, 2)
+
+	children, err := findHierarchicalChildren(ctx, s, "test-tree")
+	if err != nil {
+		t.Fatalf("findHierarchicalChildren(root) failed: %v", err)
+	}
+	requireIssueIDs(t, children, "test-tree.1", "test-tree.2")
+
+	nestedChildren, err := findHierarchicalChildren(ctx, s, "test-tree.2")
+	if err != nil {
+		t.Fatalf("findHierarchicalChildren(child) failed: %v", err)
+	}
+	requireIssueIDs(t, nestedChildren, "test-tree.2.1")
+}
+
+func BenchmarkLoadTemplateSubgraph_HierarchicalChildren(b *testing.B) {
+	s, ctx := newTemplateBenchmarkStore(b)
+
+	expectedIssues := seedHierarchicalTemplateGraph(b, ctx, s, "bench-root", 150, 4, 3000)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		subgraph, loadErr := loadTemplateSubgraph(ctx, s, "bench-root")
+		if loadErr != nil {
+			b.Fatalf("loadTemplateSubgraph failed: %v", loadErr)
+		}
+		if len(subgraph.Issues) != expectedIssues {
+			b.Fatalf("Issues count = %d, want %d", len(subgraph.Issues), expectedIssues)
+		}
+	}
 }
 
 // TestExtractRequiredVariables_IgnoresUndeclaredVars tests that handlebars in


### PR DESCRIPTION
## Summary
`loadTemplateSubgraph` is doing too much work.

On larger hierarchies it pays twice for information it already has:
- it fetches dependents, then re-reads dependency records for each one just to find `parent-child` edges
- it scans the whole issue set for each parent when looking for dotted children like `parent.1`

This patch removes both costs.

## What changed
- `loadDescendants` now uses `GetDependentsWithMetadata` and filters `parent-child` edges directly
- `findHierarchicalChildren` now searches by `IDPrefix` and keeps only direct children via `ParseHierarchicalID`
- the test coverage stays focused on this path: one regression test for direct-child filtering, one benchmark for a synthetic hierarchy with unrelated noise

## Why it matters
The old code is correct, but it scales badly because the descendant walk keeps asking storage questions it does not need to ask.

That shows up as:
- repeated N+1 dependency lookups
- repeated repository-wide scans during hierarchical fallback

The fix is simple: ask storage for narrower data, then walk the tree.

## Validation
I checked this in Beads itself.

- targeted template-loading tests still pass
- `go test ./cmd/bd -count=1` still passes on the fix branch
- the benchmark below reproduces the problem on `main` and shows the change on this branch

On my machine with `-benchtime=1x`:
- `main`: about `33.86s/op`, `1.36 GB/op`, `27.55M allocs/op`
- this branch: about `0.94s/op`, `7.95 MB/op`, `127k allocs/op`

The exact numbers will move around. The gap does not.

<details>
<summary>Minimal reproducible benchmark</summary>

Drop this file in `cmd/bd/template_repro_test.go` and run:

```bash
go test ./cmd/bd -run '^$' -bench BenchmarkTemplateSubgraphRepro -benchmem -benchtime=1x
```

```go
//go:build cgo

package main

import (
    "context"
    "fmt"
    "path/filepath"
    "testing"
    "time"

    "github.com/steveyegge/beads/internal/storage/dolt"
    "github.com/steveyegge/beads/internal/testutil"
    "github.com/steveyegge/beads/internal/types"
)

func BenchmarkTemplateSubgraphRepro(b *testing.B) {
    if testDoltServerPort == 0 {
        b.Skip("Dolt test server not available, skipping")
    }
    if testutil.DoltContainerCrashed() {
        b.Skipf("Dolt test server crashed: %v", testutil.DoltContainerCrashError())
    }

    ctx := context.Background()
    testDB := filepath.Join(b.TempDir(), ".beads", "beads.db")
    database := fmt.Sprintf("benchdb_%d", time.Now().UnixNano())

    s, err := dolt.New(ctx, &dolt.Config{
        Path:            testDB,
        ServerHost:      "127.0.0.1",
        ServerPort:      testDoltServerPort,
        Database:        database,
        CreateIfMissing: true,
    })
    if err != nil {
        b.Fatalf("dolt.New: %v", err)
    }
    b.Cleanup(func() {
        s.Close()
        dropTestDatabase(database, testDoltServerPort)
    })

    if err := s.SetConfig(ctx, "issue_prefix", "bench"); err != nil {
        b.Fatalf("SetConfig(issue_prefix): %v", err)
    }
    if err := s.SetConfig(ctx, "types.custom", "molecule,gate,convoy,merge-request,slot,agent,role,rig,event,message"); err != nil {
        b.Fatalf("SetConfig(types.custom): %v", err)
    }

    create := func(id string, priority int, issueType types.IssueType) {
        issue := &types.Issue{ID: id, Title: id, Priority: priority, IssueType: issueType, Status: types.StatusOpen}
        if err := s.CreateIssue(ctx, issue, "benchmark"); err != nil {
            b.Fatalf("CreateIssue(%s): %v", id, err)
        }
    }

    create("bench-root", 1, types.TypeEpic)
    expectedIssues := 1
    for i := 1; i <= 60; i++ {
        childID := fmt.Sprintf("bench-root.%d", i)
        create(childID, 2, types.TypeTask)
        expectedIssues++
        for j := 1; j <= 3; j++ {
            create(fmt.Sprintf("%s.%d", childID, j), 3, types.TypeTask)
            expectedIssues++
        }
    }
    for i := 0; i < 1000; i++ {
        create(fmt.Sprintf("bench-noise-%04d", i), 4, types.TypeTask)
    }

    b.ResetTimer()
    for i := 0; i < b.N; i++ {
        subgraph, err := loadTemplateSubgraph(ctx, s, "bench-root")
        if err != nil {
            b.Fatalf("loadTemplateSubgraph: %v", err)
        }
        if len(subgraph.Issues) != expectedIssues {
            b.Fatalf("Issues count = %d, want %d", len(subgraph.Issues), expectedIssues)
        }
    }
}
```
</details>