### PR TITLE
fix: replace stale bd migrate --to-dolt with bd init --from-jsonl (GH#2333)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -72,8 +72,8 @@ environment variable.`,
 			fmt.Fprintf(os.Stderr, "Dolt is now the default (and only) storage backend for beads.\n")
 			fmt.Fprintf(os.Stderr, "To initialize with Dolt:\n")
 			fmt.Fprintf(os.Stderr, "  bd init\n\n")
-			fmt.Fprintf(os.Stderr, "To migrate an existing SQLite database to Dolt:\n")
-			fmt.Fprintf(os.Stderr, "  bd migrate --to-dolt\n\n")
+			fmt.Fprintf(os.Stderr, "To import issues from an existing JSONL export:\n")
+			fmt.Fprintf(os.Stderr, "  bd init --from-jsonl\n\n")
 			fmt.Fprintf(os.Stderr, "See: https://github.com/steveyegge/beads/blob/main/docs/DOLT-BACKEND.md\n")
 			os.Exit(1)
 		} else if backendFlag != "" && backendFlag != "dolt" {

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1883,7 +1883,7 @@ func TestInitBackendFlag(t *testing.T) {
 		if !strings.Contains(outStr, "SQLite backend has been removed") {
 			t.Errorf("Expected 'SQLite backend has been removed' message, got: %s", outStr)
 		}
-		if !strings.Contains(outStr, "bd migrate --to-dolt") {
+		if !strings.Contains(outStr, "bd init --from-jsonl") {
 			t.Errorf("Expected migration instructions, got: %s", outStr)
 		}
 

--- a/cmd/bd/migrate_test.go
+++ b/cmd/bd/migrate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestMigrateCommand removed: detectDatabases, getDBVersion, formatDBList, dbInfo
-// were removed in Dolt-native pruning. Migration is now handled by bd init --to-dolt.
+// were removed in Dolt-native pruning. Migration is now handled by bd init --from-jsonl.
 
 // TestFormatDBList removed: formatDBList and dbInfo types were removed.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,7 +39,7 @@ The wizard will:
 Notes:
 - Dolt is the default (and only) storage backend. Data is stored in `.beads/dolt/`.
 - Dolt uses a `dolt sql-server` for database operations.
-- To migrate from an older SQLite installation, run `bd migrate --to-dolt`.
+- To import issues from an older installation, run `bd init --from-jsonl`.
 
 ### Role Configuration
 


### PR DESCRIPTION
## Summary

Fixes #2333. The `bd migrate --to-dolt` command was removed in v0.58.0, but three places still referenced it:

- `cmd/bd/init.go` L75-76: deprecation message told users to run removed command
- `cmd/bd/init_test.go` L1886: test assertion matched old string
- `cmd/bd/migrate_test.go` L15: stale comment
- `docs/QUICKSTART.md` L42: quickstart guide recommended removed command

All updated to reference `bd init --from-jsonl`, the current migration path.

## Changes

- **cmd/bd/init.go**: Updated deprecation message from `bd migrate --to-dolt` → `bd init --from-jsonl`
- **cmd/bd/init_test.go**: Updated test assertion to match
- **cmd/bd/migrate_test.go**: Fixed stale comment
- **docs/QUICKSTART.md**: Updated quickstart migration instruction

## Test plan

- [x] `go build ./cmd/bd/` passes
- [x] `go vet ./cmd/bd/` passes
- [x] Relevant test updated to match new output