### PR TITLE
docs: replace stale bd sync references with bd dolt push/pull (GH#2442, GH#2435)

### DIFF
--- a/docs/AIDER_INTEGRATION.md
+++ b/docs/AIDER_INTEGRATION.md
@@ -114,7 +114,7 @@ Aider: Great! Mark it complete by running:
 /run bd close bd-42 --reason "Implemented login fix and added tests"
 
 Then sync to git:
-/run bd sync
+/run bd dolt push
 ```
 
 ## Configuration
@@ -128,7 +128,7 @@ The config file contains instructions for the AI:
 # 1. Track ALL work in bd (never use markdown TODOs)
 # 2. Suggest 'bd ready' to find available work
 # 3. Suggest 'bd create' for new issues/tasks/bugs
-# 4. Suggest 'bd sync' at end of session
+# 4. Suggest 'bd dolt push' at end of session
 # 5. ALWAYS suggest commands - user will run them via /run
 ```
 
@@ -175,7 +175,7 @@ You can customize this file to add project-specific instructions.
 /run bd close bd-abc --reason "Implemented and tested"
 
 # Sync to git
-/run bd sync
+/run bd dolt push
 ```
 
 ### Checking Status
@@ -243,7 +243,7 @@ Add to your shell config for faster commands:
 ```bash
 alias bdr='/run bd ready'
 alias bdc='/run bd create'
-alias bds='/run bd sync'
+alias bds='/run bd dolt push'
 ```
 
 Then in aider:
@@ -323,7 +323,7 @@ Aider handles git commits. bd tracks issues. They work together:
 2. Make changes with aider
 3. Aider commits changes
 4. Complete issue: `/run bd close bd-42`
-5. Sync issues: `/run bd sync`
+5. Sync issues: `/run bd dolt push`
 
 ## Example Session
 
@@ -366,7 +366,7 @@ Aider: Run:
 /run bd close bd-42 --reason "Fixed login bug - added input validation"
 
 Then sync:
-/run bd sync
+/run bd dolt push
 ```
 
 ## References

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -603,7 +603,7 @@ bd import -i issues.jsonl --orphan-handling strict     # Fail if parent is missi
 
 # Configure default orphan handling behavior
 bd config set import.orphan_handling "resurrect"
-bd sync  # Now uses resurrect mode by default
+bd dolt push  # Now uses resurrect mode by default
 ```
 
 **Orphan handling modes:**
@@ -685,7 +685,7 @@ bd migrate sync beads-sync --orphan                    # Delete and recreate as 
 
 **After setup:**
 
-- `bd sync` commits beads changes to the sync branch via worktree
+- `bd dolt push` commits beads changes to the sync branch via worktree
 - Your working branch stays clean of beads commits
 - Essential for multi-clone setups where clones work independently
 
@@ -698,14 +698,15 @@ bd migrate sync beads-sync --orphan                    # Delete and recreate as 
 ### Sync Operations
 
 ```bash
-# Manual sync (force immediate commit/push)
-bd sync
+# Manual sync (push changes to remote)
+bd dolt push
 
-# What it does:
-# 1. Commit pending changes to Dolt
-# 2. Pull from remote
-# 3. Merge any updates
-# 4. Push to remote
+# Pull changes from remote
+bd dolt pull
+
+# What these do:
+# bd dolt push - Commit pending changes to Dolt and push to remote
+# bd dolt pull - Pull from remote and merge any updates
 ```
 
 ### Key-Value Store
@@ -884,10 +885,10 @@ bd update bd-42 --claim --json
 # ... work ...
 
 # End of session (IMPORTANT!)
-bd sync  # Force immediate sync, bypass debounce
+bd dolt push  # Force immediate sync, bypass debounce
 ```
 
-**ALWAYS run `bd sync` at end of agent sessions** to ensure changes are committed/pushed immediately.
+**ALWAYS run `bd dolt push` at end of agent sessions** to ensure changes are committed/pushed immediately.
 
 ## Editor Integration
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -31,7 +31,7 @@ Tool-level settings you can configure:
 | Setting | Flag | Environment Variable | Default | Description |
 |---------|------|---------------------|---------|-------------|
 | `json` | `--json` | `BD_JSON` | `false` | Output in JSON format |
-| `no-push` | `--no-push` | `BD_NO_PUSH` | `false` | Skip pushing to remote in bd sync |
+| `no-push` | `--no-push` | `BD_NO_PUSH` | `false` | Skip pushing to remote in `bd dolt push` |
 | `sync.mode` | - | `BD_SYNC_MODE` | `git-portable` | Sync mode (see below) |
 | `sync.export_on` | - | `BD_SYNC_EXPORT_ON` | `push` | When to export: `push`, `change` |
 | `sync.import_on` | - | `BD_SYNC_IMPORT_ON` | `pull` | When to import: `pull`, `change` |
@@ -509,7 +509,7 @@ bd config set auto_export.error_policy "best-effort"
 
 **Context-specific behavior:**
 
-User-initiated exports (`bd sync`, manual export commands) use `export.error_policy` (default: `strict`).
+User-initiated exports (`bd dolt push`, manual export commands) use `export.error_policy` (default: `strict`).
 
 Auto-exports (git hook sync) use `auto_export.error_policy` (default: `best-effort`), falling back to `export.error_policy` if not set.
 
@@ -560,7 +560,7 @@ bd config set import.orphan_handling "allow"
 bd import -i issues.jsonl --orphan-handling strict
 
 # Auto-import (sync) uses config value
-bd sync  # Respects import.orphan_handling setting
+bd dolt pull  # Respects import.orphan_handling setting
 ```
 
 **When to use each mode:**
@@ -580,7 +580,7 @@ bd config set sync.branch beads-sync
 
 # Enable mass deletion protection (optional, default: false)
 # When enabled, if >50% of issues vanish during a merge AND more than 5
-# issues existed before the merge, bd sync will:
+# issues existed before the merge, bd dolt push will:
 # 1. Show forensic info about vanished issues
 # 2. Prompt for confirmation before pushing
 bd config set sync.require_confirmation_on_mass_delete "true"

--- a/docs/MULTI_REPO_AGENTS.md
+++ b/docs/MULTI_REPO_AGENTS.md
@@ -231,7 +231,7 @@ bd config get repos.additional
 bd config set repos.additional "~/repo1,~/repo2"
 
 # Force sync
-bd sync
+bd dolt push
 bd list --json
 ```
 
@@ -303,7 +303,7 @@ bd doctor quick # Validate local installation health
 
 ### Teams
 - ✅ Use `bd dolt push` to sync the shared Dolt database
-- ✅ Use `bd sync` to ensure changes are committed/pushed
+- ✅ Use `bd dolt push` to ensure changes are committed/pushed
 - ✅ Link related issues across repos with dependencies
 - ❌ Don't delete `.beads/` - you lose all issue data
 
@@ -317,7 +317,7 @@ bd doctor quick # Validate local installation health
 - ✅ Always use single MCP server (per-project Dolt servers)
 - ✅ Check routing config before filing issues
 - ✅ Use `bd info --json` to verify workspace state
-- ✅ Run `bd sync` at end of session
+- ✅ Run `bd dolt push` at end of session
 - ❌ Don't assume routing behavior - check config
 
 ## Backward Compatibility

--- a/docs/MULTI_REPO_MIGRATION.md
+++ b/docs/MULTI_REPO_MIGRATION.md
@@ -388,7 +388,7 @@ bd config get repos.additional
 bd config set repos.additional "~/repo1,~/repo2"
 
 # Verify hydration
-bd sync
+bd dolt push
 bd list --json
 ```
 

--- a/docs/PROTECTED_BRANCHES.md
+++ b/docs/PROTECTED_BRANCHES.md
@@ -133,7 +133,7 @@ When you update an issue:
 
 1. Issue is updated in the Dolt database (`.beads/dolt/`)
 2. Dolt automatically commits the change to its version history
-3. Changes are synced to remotes via `bd dolt push` or `bd sync`
+3. Changes are synced to remotes via `bd dolt push`
 4. Main branch stays untouched (no commits on `main`)
 
 ## Setup
@@ -172,7 +172,7 @@ For automatic commits to the sync branch, install git hooks:
 bd hooks install
 ```
 
-Git hooks help maintain sync consistency. Use `bd sync` for manual sync when needed.
+Git hooks help maintain sync consistency. Use `bd dolt push` for manual sync when needed.
 
 ### Environment Variables
 
@@ -224,10 +224,10 @@ bd dolt commit  # Commit pending changes
 
 ```bash
 # Pull updates from other collaborators
-bd sync --no-push
+bd dolt pull
 ```
 
-This pulls changes from the remote sync branch and imports them to your local database.
+This pulls changes from the remote and imports them to your local database.
 
 ## Merging Changes
 
@@ -368,7 +368,7 @@ Ensure all clones are configured the same way:
 bd config get sync.branch  # Should be the same (e.g., beads-sync)
 
 # Pull latest changes
-bd sync --no-push
+bd dolt pull
 
 # Check Dolt server is running
 bd dolt status
@@ -466,9 +466,9 @@ git worktree remove .git/beads-worktrees/beads-sync
 bd config set sync.branch ""
 ```
 
-### Does this work with `bd sync`?
+### Does this work with `bd dolt push`?
 
-Yes! `bd sync` works normally and includes special commands for the merge workflow:
+Yes! `bd dolt push` works normally. Related commands for the merge workflow:
 
 - `bd dolt show` - Show current Dolt configuration and connection status
 - `git merge beads-sync` - Merge sync branch to main
@@ -523,7 +523,7 @@ jobs:
       - name: Pull changes
         run: |
           git fetch origin beads-sync
-          bd sync --no-push
+          bd dolt pull
 
       - name: Merge to main (if changes)
         run: |

--- a/docs/REPO_CONTEXT.md
+++ b/docs/REPO_CONTEXT.md
@@ -68,7 +68,7 @@ CWD is inside the repository containing `.beads/`:
 └── README.md
 
 $ cd /project/src
-$ bd sync
+$ bd dolt push
 # GitCmd() runs in /project (correct)
 ```
 
@@ -79,7 +79,7 @@ User is in one repository but managing beads in another:
 ```
 $ cd /repo-a          # Has uncommitted changes
 $ export BEADS_DIR=/repo-b/.beads
-$ bd sync
+$ bd dolt push
 # GitCmd() runs in /repo-b (correct, not /repo-a)
 ```
 
@@ -100,7 +100,7 @@ User is in a worktree but `.beads/` lives in main repository:
 └── src/
 
 $ cd /project/.worktrees/feature-branch
-$ bd sync
+$ bd dolt push
 # GitCmd() runs in /project (main repo, where .beads lives)
 ```
 
@@ -111,7 +111,7 @@ Both worktree and BEADS_DIR can be active simultaneously:
 ```
 $ cd /repo-a/.worktrees/branch-x
 $ export BEADS_DIR=/repo-b/.beads
-$ bd sync
+$ bd dolt push
 # GitCmd() runs in /repo-b (BEADS_DIR takes precedence)
 ```
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -119,7 +119,7 @@ Factory Droid and other AGENTS.md-compatible tools automatically read `AGENTS.md
 The beads section teaches AI agents:
 - To use `bd ready` for finding work
 - To use `bd create` for tracking new issues
-- To use `bd sync` at session end
+- To use `bd dolt push` at session end
 - The complete workflow pattern and best practices
 
 ### Updating Existing AGENTS.md
@@ -348,7 +348,7 @@ bd setup cursor --remove
 Cursor reads `.cursor/rules/*.mdc` files and includes them in the AI's context. The beads rules file teaches the AI:
 - To use `bd ready` for finding work
 - To use `bd create` for tracking new issues
-- To use `bd sync` at session end
+- To use `bd dolt push` at session end
 - The basic workflow pattern
 
 ## Aider

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -55,7 +55,7 @@ bd list
 ```bash
 # Debug timestamp protection during sync
 export BD_DEBUG_SYNC=1
-bd sync
+bd dolt push
 
 # Example output:
 # [debug] Protected bd-123: local=2024-01-20T10:00:00Z >= incoming=2024-01-20T09:55:00Z
@@ -107,7 +107,7 @@ bd dolt start
 
 - **Capture debug output**: Redirect stderr to a file for analysis:
   ```bash
-  BD_DEBUG=1 bd sync 2> debug.log
+  BD_DEBUG=1 bd dolt push 2> debug.log
   ```
 
 - **Server logs**: `BD_DEBUG_FRESHNESS` output goes to server logs, not stderr:
@@ -837,7 +837,7 @@ bd --sandbox update bd-42 --claim
 **Note:** You'll need to manually sync when outside the sandbox:
 ```bash
 # After leaving sandbox, sync manually
-bd sync
+bd dolt push
 ```
 
 ---
@@ -900,7 +900,7 @@ bd import --force
 bd --allow-stale ready
 
 # Step 4: When back outside sandbox, sync normally
-bd sync
+bd dolt push
 ```
 
 ---

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -155,7 +155,7 @@ bd ready  # Auto-syncs to beads-sync branch
 cd feature-worktree
 bd create "Implement feature X" -t feature -p 1
 bd ready  # Uses embedded mode automatically
-bd sync   # Manual sync when needed
+bd dolt push   # Manual sync when needed
 ```
 
 ## Worktree-Aware Features
@@ -455,7 +455,7 @@ export BEADS_DIR=~/my-project-beads/.beads
 # All bd commands now use the separate repo
 bd create "My task" -t task
 bd list
-bd sync  # commits to ~/my-project-beads, pushes there
+bd dolt push  # commits to ~/my-project-beads, pushes there
 ```
 
 ### Making It Permanent
@@ -483,7 +483,7 @@ BEADS_DIR=~/my-project-beads/.beads exec bd "$@"
 
 When `BEADS_DIR` points to a different git repository than your current directory:
 
-1. `bd sync` detects "External BEADS_DIR"
+1. `bd dolt push` detects "External BEADS_DIR"
 2. Git operations (add, commit, push, pull) target the beads repo
 3. Your code repository is never touched
 

--- a/docs/audit-sync-mode-complexity.md
+++ b/docs/audit-sync-mode-complexity.md
@@ -50,7 +50,7 @@ v.SetDefault("sync.import_on", SyncTriggerPull)   // pull | change
 
 These config keys (`sync.export_on`, `sync.import_on`) still exist with two trigger values each (`push`/`change` for export, `pull`/`change` for import). They are read into `SyncConfig` via `GetSyncConfig()`.
 
-**Assessment:** These triggers remain meaningful for controlling when Dolt sync operations fire. However, since `bd sync` is now a no-op (v0.51 changelog), and Dolt handles persistence directly, it is worth verifying whether these triggers are still consumed by any runtime code path. If they are only used in the hook system (`internal/hooks/`), they may still be relevant. If not, they are dead config.
+**Assessment:** These triggers remain meaningful for controlling when Dolt sync operations fire. However, since `bd sync` was removed (v0.51+, replaced by `bd dolt push`/`bd dolt pull`), and Dolt handles persistence directly, it is worth verifying whether these triggers are still consumed by any runtime code path. If they are only used in the hook system (`internal/hooks/`), they may still be relevant. If not, they are dead config.
 
 **Recommendation: Audit callers.** If `sync.export_on` and `sync.import_on` have no runtime consumers, remove them. If they are consumed, document which code paths use them.
 
@@ -168,7 +168,7 @@ After every pull, `resetAutoIncrements()` iterates over 6 hardcoded tables and r
 The sync subsystem has undergone major simplification across v0.50-v0.53:
 
 - **v0.50.3**: Tracker sync code unified via shared SyncEngine (~800 lines removed)
-- **v0.51.0**: SQLite backend, JSONL sync, 3-way merge, tombstones, storage factory, daemon stubs removed. `bd sync` became a no-op.
+- **v0.51.0**: SQLite backend, JSONL sync, 3-way merge, tombstones, storage factory, daemon stubs removed. `bd sync` removed (replaced by `bd dolt push`/`bd dolt pull`).
 - **v0.52.0**: Dead git-portable sync functions removed (#1793)
 - **v0.53.0**: JSONL sync-branch pipeline removed (~11,000 lines). Daemon infrastructure and 3-way merge remnants removed.
 


### PR DESCRIPTION
## Summary

Fixes #2442, fixes #2435. The `bd sync` command was removed in v0.51+. Dolt handles sync natively via `bd dolt push` and `bd dolt pull`. However, ~42 references to `bd sync` remained across 12 documentation files, misleading users.

## Changes

12 doc files updated with context-appropriate replacements:

| File | Refs | Notes |
|------|------|-------|
| `docs/TROUBLESHOOTING.md` | 4 | Debug commands updated |
| `docs/CONFIG.md` | 4 | Config descriptions updated |
| `docs/AIDER_INTEGRATION.md` | 6 | Commands, aliases, workflow steps |
| `docs/SETUP.md` | 2 | Agent instruction descriptions |
| `docs/REPO_CONTEXT.md` | 4 | Example commands |
| `docs/COPILOT_INTEGRATION.md` | 2 | Quick reference + sync section |
| `docs/WORKTREES.md` | 3 | Workflow examples |
| `docs/MULTI_REPO_AGENTS.md` | 3 | Best practices checklists |
| `docs/PROTECTED_BRANCHES.md` | 6 | FAQ rewritten, `--no-push` → `bd dolt pull` |
| `docs/MULTI_REPO_MIGRATION.md` | 1 | Verification step |
| `docs/CLI_REFERENCE.md` | 5 | Sync operations section rewritten |
| `docs/audit-sync-mode-complexity.md` | 2 | Historical notes corrected |

### Replacement rules applied:
- `bd sync` (push context) → `bd dolt push`
- `bd sync --no-push` (pull context) → `bd dolt pull`
- Surrounding text adjusted for grammar where needed

### Not changed:
- Go test files (`cmd/bd/doctor/`) — those intentionally test detection of stale `bd sync` in legacy hooks

## Test plan

- [x] Documentation-only change, no code modified
- [x] All replacements verified for context-appropriate substitution