### PR TITLE
refactor: remove --allow-stale no-op flag and stale docs

### DIFF
--- a/claude-plugin/skills/beads/resources/CLI_REFERENCE.md
+++ b/claude-plugin/skills/beads/resources/CLI_REFERENCE.md
@@ -389,32 +389,6 @@ bd --no-auto-flush --no-auto-import <command>
 
 **When to use:** Sandboxed environments where the Dolt server can't be controlled (permission restrictions), or when auto-detection doesn't trigger.
 
-### Staleness Control
-
-```bash
-# Skip staleness check (emergency escape hatch)
-bd --allow-stale <command>
-
-# Example: access database even if it appears out of sync
-bd --allow-stale ready --json
-bd --allow-stale list --status open --json
-```
-
-**Shows:** `⚠️  Staleness check skipped (--allow-stale), data may be out of sync`
-
-**⚠️ Caution:** May show stale or incomplete data. Use only when stuck and other options fail.
-
-### Force Import
-
-```bash
-# Force metadata update even when DB appears synced
-bd import --force -i .beads/issues.jsonl
-```
-
-**When to use:** `bd import` reports "0 created, 0 updated" but staleness errors persist.
-
-**Shows:** `Metadata updated (database already in sync)`
-
 ### Other Global Flags
 
 ```bash

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -183,10 +183,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&actor, "actor", "", "Actor name for audit trail (default: $BD_ACTOR, git user.name, $USER)")
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	rootCmd.PersistentFlags().BoolVar(&sandboxMode, "sandbox", false, "Sandbox mode: disables auto-sync")
-	rootCmd.PersistentFlags().Bool("allow-stale", false, "No-op (kept for gt compatibility)")
-	if err := rootCmd.PersistentFlags().MarkHidden("allow-stale"); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to hide allow-stale flag: %v\n", err)
-	}
 	rootCmd.PersistentFlags().BoolVar(&readonlyMode, "readonly", false, "Read-only mode: block write operations (for worker sandboxes)")
 	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: off. Override via config key dolt.auto-commit")
 	rootCmd.PersistentFlags().BoolVar(&profileEnabled, "profile", false, "Generate CPU profile for performance analysis")

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -295,32 +295,6 @@ bd --sandbox <command>
 
 **When to use:** Sandboxed environments where the Dolt server can't be controlled (permission restrictions), or when auto-detection doesn't trigger.
 
-### Staleness Control
-
-```bash
-# Skip staleness check (emergency escape hatch)
-bd --allow-stale <command>
-
-# Example: access database even if it appears out of sync
-bd --allow-stale ready --json
-bd --allow-stale list --status open --json
-```
-
-**Shows:** `⚠️  Staleness check skipped (--allow-stale), data may be out of sync`
-
-**⚠️ Caution:** May show stale or incomplete data. Use only when stuck and other options fail.
-
-### Force Import
-
-```bash
-# Force metadata update even when DB appears synced
-bd import --force -i .beads/issues.jsonl
-```
-
-**When to use:** `bd import` reports "0 created, 0 updated" but staleness errors persist.
-
-**Shows:** `Metadata updated (database already in sync)`
-
 ### Other Global Flags
 
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -807,9 +807,8 @@ See [integrations/beads-mcp/README.md](../integrations/beads-mcp/README.md) for 
 - "Database out of sync" errors that persist after running `bd import`
 - `bd dolt stop` fails with "operation not permitted"
 - Hash mismatch warnings (bd-160)
-- Commands intermittently fail with staleness errors
 
-**Root cause:** The sandbox can't signal/kill the existing Dolt server process, so the DB stays stale.
+**Root cause:** The sandbox can't signal/kill the existing Dolt server process.
 
 ---
 
@@ -860,22 +859,7 @@ bd import --force
 
 **Shows:** `Metadata updated (database already in sync)`
 
-**2. Skip staleness check (`--allow-stale` global flag)**
-
-Emergency escape hatch to bypass staleness validation:
-
-```bash
-# Allow operations on potentially stale data
-bd --allow-stale ready
-bd --allow-stale list --status open
-
-# Shows warning:
-# ⚠️  Staleness check skipped (--allow-stale), data may be out of sync
-```
-
-**⚠️ Caution:** Use sparingly - you may see incomplete or outdated data.
-
-**3. Use sandbox mode (preferred)**
+**2. Use sandbox mode (preferred)**
 
 ```bash
 # Most reliable for sandboxed environments
@@ -896,10 +880,7 @@ bd --sandbox ready
 # Step 2: If you get staleness errors, force import
 bd import --force
 
-# Step 3: If still blocked, use allow-stale (emergency only)
-bd --allow-stale ready
-
-# Step 4: When back outside sandbox, sync normally
+# Step 3: When back outside sandbox, sync normally
 bd dolt push
 ```
 
@@ -911,7 +892,6 @@ bd dolt push
 |------|---------|-------------|------|
 | `--sandbox` | Use embedded mode, disable auto-sync | Sandboxed environments (Codex, containers) | Low - safe for sandboxes |
 | `--force` (import) | Force metadata update | Stuck "0 created, 0 updated" loop | Low - updates metadata only |
-| `--allow-stale` | Skip staleness validation | Emergency access to database | **High** - may show stale data |
 
 **Related:**
 - See [Claude Code sandboxing documentation](https://www.anthropic.com/engineering/claude-code-sandboxing) for more about sandbox restrictions


### PR DESCRIPTION
## Summary

- Remove hidden no-op `--allow-stale` flag from `cmd/bd/main.go` — last remnant of the defunct 3-way JSONL merge engine's staleness-checking system
- Remove "Staleness Control" and "Force Import" sections from `docs/CLI_REFERENCE.md` and `claude-plugin/skills/beads/resources/CLI_REFERENCE.md`  
- Remove `--allow-stale` escape hatch guidance from `docs/TROUBLESHOOTING.md`, update flags table, clean up staleness symptom language

The core staleness engine (`staleness.go`, `AllowStale` flag logic) was removed in PR #2369. The `ConflictStrategy`/`FieldStrategy` config types were removed in GH#2353. This PR removes the final surface-level remnants: the hidden flag shim and the docs that still instructed users to use it.

Closes w-bd-002 (Wasteland: Remove 3-way merge engine remnants)

## Test plan

- [x] `go build ./cmd/bd/` passes
- [x] `go test ./cmd/bd/ -run TestConfig` passes  
- [x] No remaining `--allow-stale` references in Go source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)