### PR TITLE
fix: add timeout and graceful DB-missing handling to git hook shims

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -42,17 +42,43 @@ func hookSectionEndLine() string {
 	return fmt.Sprintf("%s v%s ---", hookSectionEndPrefix, Version)
 }
 
+// hookTimeoutSeconds is the maximum time a beads hook is allowed to run before
+// being killed and allowing the git operation to proceed.  A bounded timeout
+// prevents `bd hooks run` from hanging `git push` indefinitely (GH#2453).
+// The value can be overridden via the BEADS_HOOK_TIMEOUT environment variable.
+const hookTimeoutSeconds = 30
+
 // generateHookSection returns the marked section content for a given hook name.
 // The section is self-contained: it checks for bd availability, runs the hook
 // via 'bd hooks run', and propagates exit codes — without preventing any user
 // content after the section from executing on success.
+//
+// Resilience (GH#2453, GH#2449):
+//   - A configurable timeout prevents hooks from hanging git operations.
+//   - If the beads database is not initialized (exit code 3), the hook exits
+//     successfully with a warning so that git operations are not blocked.
 func generateHookSection(hookName string) string {
 	return hookSectionBeginLine() + "\n" +
 		"# This section is managed by beads. Do not remove these markers.\n" +
 		"if command -v bd >/dev/null 2>&1; then\n" +
 		"  export BD_GIT_HOOK=1\n" +
-		"  bd hooks run " + hookName + " \"$@\"\n" +
-		"  _bd_exit=$?; if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi\n" +
+		"  _bd_timeout=${BEADS_HOOK_TIMEOUT:-" + fmt.Sprintf("%d", hookTimeoutSeconds) + "}\n" +
+		"  if command -v timeout >/dev/null 2>&1; then\n" +
+		"    timeout \"$_bd_timeout\" bd hooks run " + hookName + " \"$@\"\n" +
+		"    _bd_exit=$?\n" +
+		"    if [ $_bd_exit -eq 124 ]; then\n" +
+		"      echo >&2 \"beads: hook '" + hookName + "' timed out after ${_bd_timeout}s — continuing without beads\"\n" +
+		"      _bd_exit=0\n" +
+		"    fi\n" +
+		"  else\n" +
+		"    bd hooks run " + hookName + " \"$@\"\n" +
+		"    _bd_exit=$?\n" +
+		"  fi\n" +
+		"  if [ $_bd_exit -eq 3 ]; then\n" +
+		"    echo >&2 \"beads: database not initialized — skipping hook '" + hookName + "'\"\n" +
+		"    _bd_exit=0\n" +
+		"  fi\n" +
+		"  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi\n" +
 		"fi\n" +
 		hookSectionEndLine() + "\n"
 }

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,6 +191,65 @@ func TestGenerateHookSection(t *testing.T) {
 	expectedEnd := hookSectionEndLine()
 	if !strings.Contains(section, expectedEnd) {
 		t.Errorf("section missing versioned end marker %q\ngot:\n%s", expectedEnd, section)
+	}
+}
+
+// TestGenerateHookSection_Timeout verifies the timeout wrapper around bd hooks run (GH#2453).
+func TestGenerateHookSection_Timeout(t *testing.T) {
+	section := generateHookSection("pre-push")
+
+	// Must use shell timeout command with configurable duration
+	if !strings.Contains(section, "BEADS_HOOK_TIMEOUT") {
+		t.Error("section missing BEADS_HOOK_TIMEOUT env var")
+	}
+	if !strings.Contains(section, fmt.Sprintf("%d", hookTimeoutSeconds)) {
+		t.Errorf("section missing default timeout %d", hookTimeoutSeconds)
+	}
+	if !strings.Contains(section, "command -v timeout") {
+		t.Error("section missing timeout availability check")
+	}
+
+	// Timeout exit code (124) must be handled gracefully — continue, don't block git
+	if !strings.Contains(section, "_bd_exit -eq 124") {
+		t.Error("section missing timeout exit code handling")
+	}
+	if !strings.Contains(section, "timed out") {
+		t.Error("section missing timeout warning message")
+	}
+
+	// Fallback path when timeout command is not available (e.g. macOS without coreutils)
+	if !strings.Contains(section, "else") {
+		t.Error("section missing fallback for systems without timeout command")
+	}
+}
+
+// TestGenerateHookSection_DBNotInitialized verifies exit code 3 handling (GH#2449).
+func TestGenerateHookSection_DBNotInitialized(t *testing.T) {
+	section := generateHookSection("pre-commit")
+
+	// Exit code 3 = beads database not initialized; hook must continue gracefully
+	if !strings.Contains(section, "_bd_exit -eq 3") {
+		t.Error("section missing exit code 3 (DB not initialized) handling")
+	}
+	if !strings.Contains(section, "database not initialized") {
+		t.Error("section missing DB-not-initialized warning message")
+	}
+
+	// After handling exit code 3, the effective exit must be 0 (success)
+	// Verify the pattern: set _bd_exit=0 after detecting code 3
+	if !strings.Contains(section, "if [ $_bd_exit -eq 3 ]; then") {
+		t.Error("section missing exit code 3 conditional")
+	}
+}
+
+// TestGenerateHookSection_HookNameInMessages verifies hook name appears in warning messages.
+func TestGenerateHookSection_HookNameInMessages(t *testing.T) {
+	for _, hook := range managedHookNames {
+		section := generateHookSection(hook)
+		// Each hook's timeout and DB-missing messages should include the hook name
+		if !strings.Contains(section, "hook '"+hook+"'") {
+			t.Errorf("section for %q missing hook name in warning messages", hook)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Wraps `bd hooks run` in generated shell hook sections with a configurable `timeout` (default 30s, override via `BEADS_HOOK_TIMEOUT` env var) so a hung process cannot block `git push` indefinitely (GH#2453)
- Falls back to running without timeout on systems where `timeout` is not available (e.g. macOS without coreutils)
- Handles exit code 124 (timeout) and exit code 3 (database not initialized) as non-fatal: warns on stderr and lets the git operation proceed (GH#2449)
- Adds 4 new test cases covering timeout, DB-not-initialized, and hook-name-in-messages behavior

Closes #2453
Closes #2449

## Test plan

- [x] `go build -o /dev/null ./cmd/bd` — compiles clean
- [x] `go test -short ./cmd/bd/` — all tests pass (67s)
- [x] `TestGenerateHookSection_Timeout` — verifies timeout wrapper and exit code 124 handling
- [x] `TestGenerateHookSection_DBNotInitialized` — verifies exit code 3 handling
- [x] `TestGenerateHookSection_HookNameInMessages` — verifies hook name in all warning messages
- [x] Existing `TestGenerateHookSection` still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)