### PR TITLE
fix: replace dangerous --force suggestion in init guard error message

### DIFF
--- a/cmd/bd/init_guard.go
+++ b/cmd/bd/init_guard.go
@@ -78,21 +78,34 @@ func checkDatabaseOnServer(host string, port int, user, password, dbName string)
 // initGuardServerMessage builds the error message for the init guard when the
 // server is reachable but the database does not exist (FR-010, FR-011).
 // Extracted as a pure function for unit testing without a real database.
+//
+// GH#2363: The message deliberately avoids suggesting `bd init --force` because
+// that command destroys all existing issue data.  An AI agent running inside a
+// git hook blindly followed the previous suggestion and wiped a production
+// database.  Instead we guide the user toward safe diagnostic commands.
 func initGuardServerMessage(dbName, host string, port int, prefix, syncGitRemote string) error {
 	var b strings.Builder
 	fmt.Fprintf(&b, "\n%s Database %q not found on server at %s:%d.\n", ui.RenderWarn("⚠"), dbName, host, port)
 	b.WriteString("The server is running but this database hasn't been created yet.\n")
 
-	fmt.Fprintf(&b, "\nTo create a fresh database:\n")
-	fmt.Fprintf(&b, "  bd init --force --prefix %s\n", prefix)
+	b.WriteString("\nDiagnose with:\n")
+	b.WriteString("  bd doctor          # check project health\n")
+	b.WriteString("  bd dolt status     # inspect Dolt server state\n")
 
 	if syncGitRemote != "" {
 		fmt.Fprintf(&b, "\nTip: sync.git-remote is configured (%s).\n", syncGitRemote)
-		b.WriteString("Run bd init --force to bootstrap from the remote.\n")
+		b.WriteString("If this is a fresh clone, run:\n")
+		fmt.Fprintf(&b, "  bd init --prefix %s\n", prefix)
+		b.WriteString("to bootstrap from the remote (existing data is preserved).\n")
 	} else {
-		b.WriteString("\nTip: To bootstrap from an existing Dolt remote, set sync.git-remote\n")
-		b.WriteString("in .beads/config.yaml and re-run bd init --force.\n")
+		b.WriteString("\nIf this is a brand-new project, create the database with:\n")
+		fmt.Fprintf(&b, "  bd init --prefix %s\n", prefix)
+		b.WriteString("\nTo bootstrap from an existing Dolt remote, set sync.git-remote\n")
+		b.WriteString("in .beads/config.yaml first, then run bd init.\n")
 	}
+
+	b.WriteString("\n⚠  Caution: bd init --force destroys ALL existing issues. Do not\n")
+	b.WriteString("use --force unless you are certain the database should be recreated.\n")
 
 	b.WriteString("\nAborting.")
 	return errors.New(b.String())

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -26,13 +26,18 @@ func TestInitGuardServerMessage(t *testing.T) {
 				"127.0.0.1:3309",
 				"not found on server",
 				"server is running but this database hasn't been created yet",
-				"bd init --force --prefix acf",
+				"bd doctor",
+				"bd dolt status",
+				"bd init --prefix acf",
 				"set sync.git-remote",
 				".beads/config.yaml",
 				"Aborting",
+				"--force destroys ALL existing issues",
 			},
 			wantNotContain: []string{
 				"sync.git-remote is configured",
+				// GH#2363: must NOT suggest --force as the primary action
+				"bd init --force --prefix",
 			},
 		},
 		"DB missing, sync.git-remote IS configured (FR-010, FR-011)": {
@@ -46,13 +51,19 @@ func TestInitGuardServerMessage(t *testing.T) {
 				"192.168.1.50:3307",
 				"not found on server",
 				"server is running but this database hasn't been created yet",
-				"bd init --force --prefix kc",
+				"bd doctor",
+				"bd dolt status",
+				"bd init --prefix kc",
 				"sync.git-remote is configured",
 				"https://doltremoteapi.dolthub.com/myorg/beads",
-				"bd init --force to bootstrap from the remote",
+				"existing data is preserved",
+				"--force destroys ALL existing issues",
 			},
 			wantNotContain: []string{
 				"set sync.git-remote",
+				// GH#2363: must NOT suggest --force as the primary action
+				"bd init --force --prefix",
+				"bd init --force to bootstrap",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Removes `bd init --force --prefix <x>` as the primary suggestion in the init guard error message when the database is not found on the Dolt server
- Replaces with safe diagnostic commands: `bd doctor` and `bd dolt status`
- Suggests `bd init --prefix <x>` (without `--force`) for fresh clones
- Adds explicit caution warning that `--force` destroys ALL existing issues
- Updates tests to verify `--force` is no longer suggested as the primary action

This addresses the root cause of GH#2363 where an AI agent running inside a git hook blindly followed the `bd init --force` suggestion and destroyed 247 issues.

Closes #2363

## Test plan

- [x] `go build -o /dev/null ./cmd/bd` — compiles clean
- [x] `go test -short ./cmd/bd/` — all tests pass (67s)
- [x] `TestInitGuardServerMessage` — both subtests updated and passing:
  - No sync.git-remote: verifies `bd doctor`, `bd dolt status`, no `--force --prefix`
  - With sync.git-remote: verifies safe bootstrap suggestion, no `--force` as primary
- [x] Both subtests verify the `--force destroys ALL existing issues` caution warning is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)