### PR TITLE
fix: move machine-local metadata to local file to prevent merge conflicts

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -26,6 +26,10 @@ last-touched
 # Must not be committed as paths would be wrong in other clones
 redirect
 
+# Machine-local state (auto-push tracking, tip timestamps)
+# These values are per-clone and must not enter Dolt history (GH#2466)
+local-state.json
+
 # Sync state (local-only, per-machine)
 # These files are machine-specific and should not be shared across clones
 .sync.lock
@@ -77,6 +81,7 @@ var requiredPatterns = []string{
 	"*.db?*",
 	"redirect",
 	"last-touched",
+	"local-state.json",
 	"bd.sock.startlock",
 	".sync.lock",
 	"export-state/",

--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/localstate"
 )
 
 // isDoltAutoPushEnabled returns whether auto-push to Dolt remote should run.
@@ -32,6 +33,12 @@ func isDoltAutoPushEnabled(ctx context.Context) bool {
 
 // maybeAutoPush pushes to the Dolt remote if enabled and the debounce interval has passed.
 // Called from PersistentPostRun after auto-commit and auto-backup.
+//
+// Push tracking state (last push time and commit hash) is stored in a local file
+// (.beads/local-state.json) instead of the Dolt metadata table. This prevents
+// merge conflicts when multiple machines push/pull the same remote, because
+// these machine-local values would otherwise diverge and cause cell-level
+// conflicts during Dolt's three-way merge. See GH#2466.
 func maybeAutoPush(ctx context.Context) {
 	if isSandboxMode() {
 		debug.Logf("dolt auto-push: skipped (sandbox mode)\n")
@@ -46,16 +53,23 @@ func maybeAutoPush(ctx context.Context) {
 		return
 	}
 
+	beadsDir := getBeadsDir()
+	if beadsDir == "" {
+		debug.Logf("dolt auto-push: skipped (no beads dir)\n")
+		return
+	}
+	ls := localstate.New(beadsDir)
+
 	// Debounce: skip if we pushed recently
 	interval := config.GetDuration("dolt.auto-push-interval")
 	if interval == 0 {
 		interval = 5 * time.Minute
 	}
 
-	lastPushStr, err := st.GetMetadata(ctx, "dolt_auto_push_last")
+	lastPushStr, err := ls.Get("dolt_auto_push_last")
 	if err != nil {
 		debug.Logf("dolt auto-push: failed to get last push time: %v\n", err)
-		return
+		// Fall through — treat as never pushed
 	}
 	if lastPushStr != "" {
 		lastPush, err := time.Parse(time.RFC3339, lastPushStr)
@@ -72,7 +86,7 @@ func maybeAutoPush(ctx context.Context) {
 		debug.Logf("dolt auto-push: failed to get current commit: %v\n", err)
 		return
 	}
-	lastPushedCommit, _ := st.GetMetadata(ctx, "dolt_auto_push_commit")
+	lastPushedCommit, _ := ls.Get("dolt_auto_push_commit")
 	if currentCommit == lastPushedCommit && lastPushedCommit != "" {
 		debug.Logf("dolt auto-push: no changes since last push\n")
 		return
@@ -85,12 +99,12 @@ func maybeAutoPush(ctx context.Context) {
 		return
 	}
 
-	// Record last push time and commit
+	// Record last push time and commit in local state (not Dolt metadata)
 	now := time.Now().UTC().Format(time.RFC3339)
-	if err := st.SetMetadata(ctx, "dolt_auto_push_last", now); err != nil {
+	if err := ls.Set("dolt_auto_push_last", now); err != nil {
 		debug.Logf("dolt auto-push: failed to record push time: %v\n", err)
 	}
-	if err := st.SetMetadata(ctx, "dolt_auto_push_commit", currentCommit); err != nil {
+	if err := ls.Set("dolt_auto_push_commit", currentCommit); err != nil {
 		debug.Logf("dolt auto-push: failed to record push commit: %v\n", err)
 	}
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -77,15 +77,6 @@ var (
 	// This prevents a redundant auto-commit attempt in PersistentPostRun.
 	commandDidExplicitDoltCommit bool
 
-	// commandDidWriteTipMetadata is set when a command records a tip as "shown" by writing
-	// metadata (tip_*_last_shown). This will be used to create a separate Dolt commit for
-	// tip writes, even when the main command is read-only.
-	commandDidWriteTipMetadata bool
-
-	// commandTipIDsShown tracks which tip IDs were shown in this command (deduped).
-	// This is used for tip-commit message formatting.
-	commandTipIDsShown map[string]struct{}
-
 	// commandSpan is the root OTel span for the current command execution.
 	// All storage and AI spans are nested as children of this span.
 	commandSpan oteltrace.Span
@@ -229,8 +220,6 @@ var rootCmd = &cobra.Command{
 		// Reset per-command write tracking (used by Dolt auto-commit).
 		commandDidWrite.Store(false)
 		commandDidExplicitDoltCommit = false
-		commandDidWriteTipMetadata = false
-		commandTipIDsShown = make(map[string]struct{})
 
 		// Set up signal-aware context with batch commit flush on shutdown.
 		// Unlike signal.NotifyContext, this also handles SIGHUP and flushes
@@ -590,32 +579,8 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		// Tip metadata auto-commit: if a tip was shown, create a separate Dolt commit for the
-		// tip_*_last_shown metadata updates. This may happen even for otherwise read-only commands.
-		if commandDidWriteTipMetadata && len(commandTipIDsShown) > 0 {
-			// Only applies when dolt auto-commit is enabled and backend is versioned (Dolt).
-			if mode, err := getDoltAutoCommitMode(); err != nil {
-				FatalError("dolt tip auto-commit failed: %v", err)
-			} else if mode == doltAutoCommitOn {
-				// Apply tip metadata writes now (deferred in recordTipShown for Dolt).
-				for tipID := range commandTipIDsShown {
-					key := fmt.Sprintf("tip_%s_last_shown", tipID)
-					value := time.Now().Format(time.RFC3339)
-					if err := store.SetMetadata(rootCtx, key, value); err != nil {
-						FatalError("dolt tip auto-commit failed: %v", err)
-					}
-				}
-
-				ids := make([]string, 0, len(commandTipIDsShown))
-				for tipID := range commandTipIDsShown {
-					ids = append(ids, tipID)
-				}
-				msg := formatDoltAutoCommitMessage("tip", getActor(), ids)
-				if err := maybeAutoCommit(rootCtx, doltAutoCommitParams{Command: "tip", MessageOverride: msg}); err != nil {
-					FatalError("dolt tip auto-commit failed: %v", err)
-				}
-			}
-		}
+		// Tip metadata is now stored in local state (.beads/local-state.json) instead of the
+		// Dolt metadata table, so no Dolt auto-commit is needed for tips. See GH#2466.
 
 		// Auto-backup: export JSONL to .beads/backup/ if enabled and due
 		maybeAutoBackup(rootCtx)

--- a/cmd/bd/tips.go
+++ b/cmd/bd/tips.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/steveyegge/beads/internal/localstate"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -132,53 +133,52 @@ func selectNextTip(store *dolt.DoltStore) *Tip {
 	return nil // No tips won probability roll
 }
 
-// getLastShown retrieves the timestamp when a tip was last shown
-// Returns zero time if never shown
+// getLastShown retrieves the timestamp when a tip was last shown.
+// Returns zero time if never shown.
+// Tip timestamps are stored in local state (.beads/local-state.json) to avoid
+// merge conflicts in multi-machine setups (GH#2466).
 func getLastShown(store *dolt.DoltStore, tipID string) time.Time {
 	key := fmt.Sprintf("tip_%s_last_shown", tipID)
+
+	// Try local state first (new location)
+	beadsDir := getBeadsDir()
+	if beadsDir != "" {
+		ls := localstate.New(beadsDir)
+		if value, err := ls.Get(key); err == nil && value != "" {
+			if t, err := time.Parse(time.RFC3339, value); err == nil {
+				return t
+			}
+		}
+	}
+
+	// Fall back to Dolt metadata for existing installations that haven't
+	// migrated yet. Once a tip is shown again, the new value goes to local state.
 	value, err := store.GetMetadata(context.Background(), key)
 	if err != nil || value == "" {
 		return time.Time{}
 	}
-
-	// Parse RFC3339 timestamp
 	t, err := time.Parse(time.RFC3339, value)
 	if err != nil {
 		return time.Time{}
 	}
-
 	return t
 }
 
-// recordTipShown records the timestamp when a tip was shown
+// recordTipShown records the timestamp when a tip was shown.
+// Writes to local state (.beads/local-state.json) to avoid merge conflicts
+// in multi-machine setups (GH#2466).
 func recordTipShown(store *dolt.DoltStore, tipID string) {
 	if store == nil || tipID == "" {
-		return
-	}
-
-	// If dolt auto-commit is enabled, defer the metadata write so it can be
-	// committed as a separate Dolt commit in PostRun.
-	// This avoids tip metadata getting bundled into the main command commit.
-	if mode, err := getDoltAutoCommitMode(); err == nil && mode == doltAutoCommitOn {
-		commandDidWriteTipMetadata = true
-		if commandTipIDsShown == nil {
-			commandTipIDsShown = make(map[string]struct{})
-		}
-		commandTipIDsShown[tipID] = struct{}{}
 		return
 	}
 
 	key := fmt.Sprintf("tip_%s_last_shown", tipID)
 	value := time.Now().Format(time.RFC3339)
 
-	// Non-critical metadata, ok to fail silently.
-	// If it succeeds, track the write for tip auto-commit behavior.
-	if err := store.SetMetadata(context.Background(), key, value); err == nil {
-		commandDidWriteTipMetadata = true
-		if commandTipIDsShown == nil {
-			commandTipIDsShown = make(map[string]struct{})
-		}
-		commandTipIDsShown[tipID] = struct{}{}
+	beadsDir := getBeadsDir()
+	if beadsDir != "" {
+		ls := localstate.New(beadsDir)
+		_ = ls.Set(key, value) // Non-critical metadata, ok to fail silently
 	}
 }
 

--- a/cmd/bd/tips_test.go
+++ b/cmd/bd/tips_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/beads/internal/localstate"
 )
 
 func TestTipSelection(t *testing.T) {
@@ -193,7 +195,13 @@ func TestRecordTipShown(t *testing.T) {
 	doltAutoCommit = ""
 	t.Cleanup(func() { doltAutoCommit = oldDoltAutoCommit })
 
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	tmpDir := t.TempDir()
+	store := newTestStoreWithPrefix(t, filepath.Join(tmpDir, "test.db"), "test")
+
+	// Set global dbPath so getBeadsDir() returns the temp dir for local-state.json
+	oldDbPath := dbPath
+	dbPath = filepath.Join(tmpDir, "test.db")
+	t.Cleanup(func() { dbPath = oldDbPath })
 
 	recordTipShown(store, "test_tip")
 
@@ -249,7 +257,13 @@ func TestTipFrequency(t *testing.T) {
 	doltAutoCommit = ""
 	t.Cleanup(func() { doltAutoCommit = oldDoltAutoCommit })
 
-	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+	tmpDir := t.TempDir()
+	store := newTestStoreWithPrefix(t, filepath.Join(tmpDir, "test.db"), "test")
+
+	// Set global dbPath so getBeadsDir() returns the temp dir for local-state.json
+	oldDbPath := dbPath
+	dbPath = filepath.Join(tmpDir, "test.db")
+	t.Cleanup(func() { dbPath = oldDbPath })
 
 	tipsMutex.Lock()
 	tips = []Tip{
@@ -279,9 +293,10 @@ func TestTipFrequency(t *testing.T) {
 		t.Errorf("Expected nil due to frequency limit, got %v", tip)
 	}
 
-	// Manually set last shown to past (simulate time passing)
+	// Manually set last shown to past (simulate time passing) via local state
 	past := time.Now().Add(-10 * time.Second)
-	_ = store.SetMetadata(context.Background(), "tip_frequent_tip_last_shown", past.Format(time.RFC3339))
+	ls := localstate.New(tmpDir)
+	_ = ls.Set("tip_frequent_tip_last_shown", past.Format(time.RFC3339))
 
 	// Should show again now
 	tip = selectNextTip(store)

--- a/internal/localstate/localstate.go
+++ b/internal/localstate/localstate.go
@@ -1,0 +1,86 @@
+// Package localstate manages machine-local key-value state stored outside the
+// Dolt-versioned database. This prevents merge conflicts when multiple machines
+// push/pull the same Dolt remote, since machine-local values (like auto-push
+// timestamps and tip-shown timestamps) differ per clone and cause cell-level
+// conflicts in Dolt's three-way merge.
+//
+// See https://github.com/steveyegge/beads/issues/2466
+package localstate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const fileName = "local-state.json"
+
+// Store provides thread-safe read/write access to machine-local state.
+// State is persisted as a JSON file in the .beads/ directory.
+type Store struct {
+	path string
+	mu   sync.Mutex
+}
+
+// New creates a Store that reads/writes local-state.json in beadsDir.
+func New(beadsDir string) *Store {
+	return &Store{path: filepath.Join(beadsDir, fileName)}
+}
+
+// Get retrieves a value by key. Returns "" if the key does not exist.
+func (s *Store) Get(key string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := s.load()
+	if err != nil {
+		return "", err
+	}
+	return data[key], nil
+}
+
+// Set stores a key-value pair, creating the file if it doesn't exist.
+func (s *Store) Set(key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := s.load()
+	if err != nil {
+		return err
+	}
+	data[key] = value
+	return s.save(data)
+}
+
+// load reads the state file. Returns an empty map if the file doesn't exist.
+func (s *Store) load() (map[string]string, error) {
+	raw, err := os.ReadFile(s.path) // #nosec G304 - controlled path
+	if os.IsNotExist(err) {
+		return make(map[string]string), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading local state: %w", err)
+	}
+	var data map[string]string
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("parsing local state: %w", err)
+	}
+	if data == nil {
+		data = make(map[string]string)
+	}
+	return data, nil
+}
+
+// save writes the state map to disk atomically.
+func (s *Store) save(data map[string]string) error {
+	raw, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling local state: %w", err)
+	}
+	if err := os.WriteFile(s.path, raw, 0o600); err != nil {
+		return fmt.Errorf("writing local state: %w", err)
+	}
+	return nil
+}

--- a/internal/localstate/localstate_test.go
+++ b/internal/localstate/localstate_test.go
@@ -1,0 +1,60 @@
+package localstate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStoreGetSet(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	// Get on missing key returns ""
+	v, err := s.Get("no_such_key")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v != "" {
+		t.Fatalf("expected empty, got %q", v)
+	}
+
+	// Set and read back
+	if err := s.Set("foo", "bar"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	v, err = s.Get("foo")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v != "bar" {
+		t.Fatalf("expected bar, got %q", v)
+	}
+
+	// Overwrite
+	if err := s.Set("foo", "baz"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	v, _ = s.Get("foo")
+	if v != "baz" {
+		t.Fatalf("expected baz, got %q", v)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(filepath.Join(dir, fileName)); err != nil {
+		t.Fatalf("state file not created: %v", err)
+	}
+}
+
+func TestStoreCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	// Write corrupt JSON
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte("{corrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := New(dir)
+	_, err := s.Get("key")
+	if err == nil {
+		t.Fatal("expected error on corrupt file")
+	}
+}

--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -27,6 +27,7 @@ var migrationsList = []Migration{
 	{"issue_counter_table", migrations.MigrateIssueCounterTable},
 	{"infra_to_wisps", migrations.MigrateInfraToWisps},
 	{"wisp_dep_type_index", migrations.MigrateWispDepTypeIndex},
+	{"metadata_local_state", migrations.MigrateMetadataToLocalState},
 }
 
 // RunMigrations executes all registered Dolt migrations in order.

--- a/internal/storage/dolt/migrations/009_metadata_local_state.go
+++ b/internal/storage/dolt/migrations/009_metadata_local_state.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// MigrateMetadataToLocalState removes machine-local metadata keys from the
+// Dolt-versioned metadata table. These keys (dolt_auto_push_* and tip_*_last_shown)
+// differ per clone and cause merge conflicts when multiple machines push/pull
+// the same remote.
+//
+// After this migration, these values are stored in .beads/local-state.json
+// which is gitignored and never enters Dolt history. See GH#2466.
+func MigrateMetadataToLocalState(db *sql.DB) error {
+	// Delete auto-push tracking keys
+	for _, key := range []string{"dolt_auto_push_last", "dolt_auto_push_commit"} {
+		_, err := db.Exec("DELETE FROM metadata WHERE `key` = ?", key)
+		if err != nil {
+			return fmt.Errorf("failed to delete metadata key %q: %w", key, err)
+		}
+	}
+
+	// Delete tip-shown tracking keys (pattern: tip_*_last_shown)
+	_, err := db.Exec("DELETE FROM metadata WHERE `key` LIKE 'tip_%_last_shown'")
+	if err != nil {
+		return fmt.Errorf("failed to delete tip metadata keys: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Problem

`bd dolt pull` fails with merge conflicts on the `metadata` table when multiple machines push/pull the same Dolt remote.

The metadata table stores machine-local values (`dolt_auto_push_commit`, `dolt_auto_push_last`, `tip_*_last_shown`) that differ per clone. With `dolt.auto-commit: on` (the default), every `bd` write command creates a Dolt commit that includes these rows. When two machines each push, they write different values to the same primary keys, so the next `bd dolt pull` triggers a cell-level merge conflict:

```
Error 1105 (HY000): Merge conflict detected, @autocommit transaction rolled back...
```

## Root Cause

The three-way merge detects that both sides modified the same rows (`key='dolt_auto_push_last'`, `key='dolt_auto_push_commit'`) with different values. These are inherently machine-local values that have no business being version-controlled.

## Fix

Store machine-local state in `.beads/local-state.json` (a gitignored local file) instead of the Dolt-versioned metadata table. This is **Option 4** from the issue: move push tracking outside Dolt.

### Changes

1. **New `internal/localstate` package** — Simple thread-safe JSON key-value store for machine-local state
2. **`maybeAutoPush`** — Reads/writes `dolt_auto_push_last` and `dolt_auto_push_commit` from `local-state.json` instead of `st.GetMetadata`/`st.SetMetadata`
3. **Tips system** — `recordTipShown` writes to local state; `getLastShown` checks local state first, falls back to Dolt metadata for backward compatibility
4. **Removed tip auto-commit** — Since tips no longer write to Dolt, the `commandDidWriteTipMetadata` / `commandTipIDsShown` machinery and the separate tip Dolt commit in `PersistentPostRun` are no longer needed
5. **Migration 009** — Cleans up old `dolt_auto_push_*` and `tip_*_last_shown` keys from the metadata table so they don't cause conflicts on existing installations
6. **Gitignore** — Added `local-state.json` to the `.beads/.gitignore` template and required patterns

### Backward Compatibility

- `getLastShown` falls back to reading from Dolt metadata if the key isn't found in local state, so existing tip timestamps are preserved until the tip is shown again
- Migration 009 removes the conflicting keys from Dolt, so existing installations won't see conflicts after upgrading
- The `localstate` package creates the file on first write, so no initialization step is needed

Fixes #2466