### PR TITLE
fix: bd children includes closed children by default

### DIFF
--- a/cmd/bd/children.go
+++ b/cmd/bd/children.go
@@ -5,17 +5,20 @@ import (
 )
 
 // childrenCmd lists child beads of a parent.
-// This is a convenience alias for 'bd list --parent <id>'.
+// This is a convenience alias for 'bd list --parent <id> --status all'.
+// Unlike plain 'bd list', children includes closed issues by default (GH#2477).
 var childrenCmd = &cobra.Command{
 	Use:     "children <parent-id>",
 	GroupID: "issues",
 	Short:   "List child beads of a parent",
 	Long: `List all beads that are children of the specified parent bead.
 
-This is a convenience alias for 'bd list --parent <id>'.
+This is a convenience alias for 'bd list --parent <id> --status all'.
+Unlike plain 'bd list', children includes closed issues by default,
+since the primary use case is inspecting all work under a parent.
 
 Examples:
-  bd children hq-abc123        # List children of hq-abc123
+  bd children hq-abc123        # List all children of hq-abc123
   bd children hq-abc123 --json # List children in JSON format
   bd children hq-abc123 --pretty # Show children in tree format`,
 	Args: cobra.ExactArgs(1),
@@ -25,6 +28,11 @@ Examples:
 		// Set the parent flag on listCmd, run it, then reset
 		_ = listCmd.Flags().Set("parent", parentID)
 		defer func() { _ = listCmd.Flags().Set("parent", "") }()
+
+		// Include all statuses by default so closed children are visible (GH#2477).
+		_ = listCmd.Flags().Set("status", "all")
+		defer func() { _ = listCmd.Flags().Set("status", "") }()
+
 		listCmd.Run(listCmd, []string{})
 	},
 }

--- a/cmd/bd/children_test.go
+++ b/cmd/bd/children_test.go
@@ -1,0 +1,101 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestChildrenIncludesClosedIssues verifies that the children command's
+// behavior of setting status=all works correctly by testing the underlying
+// list filter behavior. When a parent is specified, closed children should
+// be included in results (GH#2477).
+func TestChildrenIncludesClosedIssues(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	s := newTestStore(t, testDB)
+
+	// Create parent epic
+	parent := &types.Issue{
+		Title:     "Parent Epic",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateIssue(ctx, parent, "test"); err != nil {
+		t.Fatalf("Failed to create parent: %v", err)
+	}
+
+	// Create two child tasks
+	child1 := &types.Issue{
+		Title:     "Child 1",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now(),
+	}
+	child2 := &types.Issue{
+		Title:     "Child 2",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now(),
+	}
+
+	for _, child := range []*types.Issue{child1, child2} {
+		if err := s.CreateIssue(ctx, child, "test"); err != nil {
+			t.Fatalf("Failed to create child: %v", err)
+		}
+		if err := s.AddDependency(ctx, &types.Dependency{
+			IssueID:     child.ID,
+			DependsOnID: parent.ID,
+			Type:        types.DepParentChild,
+		}, "test"); err != nil {
+			t.Fatalf("Failed to add parent-child dep: %v", err)
+		}
+	}
+
+	// Close both children
+	for _, child := range []*types.Issue{child1, child2} {
+		if err := s.CloseIssue(ctx, child.ID, "done", "test-actor", "test-session"); err != nil {
+			t.Fatalf("Failed to close %s: %v", child.ID, err)
+		}
+	}
+
+	t.Run("DefaultFilterExcludesClosedChildren", func(t *testing.T) {
+		// Default list filter excludes closed issues — this is the bug behavior
+		filter := types.IssueFilter{
+			ParentID:      &parent.ID,
+			ExcludeStatus: []types.Status{types.StatusClosed, types.StatusPinned},
+		}
+		issues, err := s.SearchIssues(ctx, "", filter)
+		if err != nil {
+			t.Fatalf("SearchIssues failed: %v", err)
+		}
+		if len(issues) != 0 {
+			t.Errorf("Default filter returned %d issues, want 0 (closed children should be excluded by default filter)", len(issues))
+		}
+	})
+
+	t.Run("AllStatusFilterIncludesClosedChildren", func(t *testing.T) {
+		// When status=all (no ExcludeStatus), closed children should appear
+		filter := types.IssueFilter{
+			ParentID: &parent.ID,
+		}
+		issues, err := s.SearchIssues(ctx, "", filter)
+		if err != nil {
+			t.Fatalf("SearchIssues failed: %v", err)
+		}
+		if len(issues) != 2 {
+			t.Errorf("All-status filter returned %d issues, want 2 (closed children should be included)", len(issues))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes #2477: `bd children` returned empty on closed epics because the default list filter excludes closed issues
- Root cause: `childrenCmd` delegates to `listCmd` which applies `ExcludeStatus: [closed, pinned]` by default
- Fix: sets `--status=all` before delegating to `listCmd`, since inspecting all children (including completed work) is the primary use case

## Test plan

- [x] New test `TestChildrenIncludesClosedIssues` — verifies default filter excludes closed children, and all-status filter includes them
- [x] Build passes with `go build ./cmd/bd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)