### PR TITLE
refactor: remove dead sync mode scaffolding

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -434,14 +434,8 @@ func validateSyncConfig(repoPath string) []string {
 	}
 
 	// Get config from yaml
-	syncMode := v.GetString("sync.mode")
 	federationSov := v.GetString("federation.sovereignty")
 	federationRemote := v.GetString("federation.remote")
-
-	// Validate sync.mode
-	if syncMode != "" && !config.IsValidSyncMode(syncMode) {
-		issues = append(issues, fmt.Sprintf("sync.mode: %q is invalid (valid values: %s)", syncMode, strings.Join(config.ValidSyncModes(), ", ")))
-	}
 
 	// Validate federation.sovereignty
 	if federationSov != "" && !config.IsValidSovereignty(federationSov) {

--- a/cmd/bd/config_test.go
+++ b/cmd/bd/config_test.go
@@ -332,28 +332,6 @@ func TestValidateSyncConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid sync.mode", func(t *testing.T) {
-		configContent := `prefix: test
-sync:
-  mode: "invalid-mode"
-`
-		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
-			t.Fatalf("Failed to write config.yaml: %v", err)
-		}
-
-		issues := validateSyncConfig(tmpDir)
-		found := false
-		for _, issue := range issues {
-			if strings.Contains(issue, "sync.mode") {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected issue about sync.mode, got: %v", issues)
-		}
-	})
-
 	t.Run("invalid federation.sovereignty", func(t *testing.T) {
 		configContent := `prefix: test
 federation:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,9 +32,6 @@ Tool-level settings you can configure:
 |---------|------|---------------------|---------|-------------|
 | `json` | `--json` | `BD_JSON` | `false` | Output in JSON format |
 | `no-push` | `--no-push` | `BD_NO_PUSH` | `false` | Skip pushing to remote in `bd dolt push` |
-| `sync.mode` | - | `BD_SYNC_MODE` | `git-portable` | Sync mode (see below) |
-| `sync.export_on` | - | `BD_SYNC_EXPORT_ON` | `push` | When to export: `push`, `change` |
-| `sync.import_on` | - | `BD_SYNC_IMPORT_ON` | `pull` | When to import: `pull`, `change` |
 | `federation.remote` | - | `BD_FEDERATION_REMOTE` | (none) | Dolt remote URL for federation |
 | `federation.sovereignty` | - | `BD_FEDERATION_SOVEREIGNTY` | (none) | Data sovereignty tier: `T1`, `T2`, `T3`, `T4` |
 | `dolt.auto-commit` | `--dolt-auto-commit` | `BD_DOLT_AUTO_COMMIT` | `on` | (Dolt backend) Automatically create a Dolt commit after successful write commands |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,18 +13,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Sync trigger constants define when sync operations occur.
-const (
-	// SyncTriggerPush triggers sync on git push operations.
-	SyncTriggerPush = "push"
-
-	// SyncTriggerChange triggers sync on every database change.
-	SyncTriggerChange = "change"
-
-	// SyncTriggerPull triggers import on git pull operations.
-	SyncTriggerPull = "pull"
-)
-
 var v *viper.Viper
 
 // overriddenKeys tracks keys explicitly set via Set() at runtime, so
@@ -150,12 +138,6 @@ func Initialize() error {
 
 	// Sync configuration defaults (bd-4u8)
 	v.SetDefault("sync.require_confirmation_on_mass_delete", false)
-
-	// Sync mode configuration (hq-ew1mbr.3)
-	// See docs/CONFIG.md for detailed documentation
-	v.SetDefault("sync.mode", SyncModeDoltNative)
-	v.SetDefault("sync.export_on", SyncTriggerPush) // push | change
-	v.SetDefault("sync.import_on", SyncTriggerPull) // pull | change
 
 	// Federation configuration (optional Dolt remote)
 	v.SetDefault("federation.remote", "")      // e.g., dolthub://org/beads, gs://bucket/beads, s3://bucket/beads
@@ -718,22 +700,6 @@ func GetIdentity(flagValue string) string {
 	}
 
 	return "unknown"
-}
-
-// SyncConfig holds the sync mode configuration.
-type SyncConfig struct {
-	Mode     SyncMode // dolt-native (only supported mode)
-	ExportOn string   // push, change
-	ImportOn string   // pull, change
-}
-
-// GetSyncConfig returns the current sync configuration.
-func GetSyncConfig() SyncConfig {
-	return SyncConfig{
-		Mode:     GetSyncMode(),
-		ExportOn: GetString("sync.export_on"),
-		ImportOn: GetString("sync.import_on"),
-	}
 }
 
 // FederationConfig holds the federation (Dolt remote) configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1114,26 +1114,6 @@ validation:
 	}
 }
 
-// Tests for sync mode configuration (hq-ew1mbr.3)
-
-func TestSyncModeConstants(t *testing.T) {
-	if SyncModeDoltNative != "dolt-native" {
-		t.Errorf("SyncModeDoltNative = %q, want \"dolt-native\"", SyncModeDoltNative)
-	}
-}
-
-func TestSyncTriggerConstants(t *testing.T) {
-	if SyncTriggerPush != "push" {
-		t.Errorf("SyncTriggerPush = %q, want \"push\"", SyncTriggerPush)
-	}
-	if SyncTriggerChange != "change" {
-		t.Errorf("SyncTriggerChange = %q, want \"change\"", SyncTriggerChange)
-	}
-	if SyncTriggerPull != "pull" {
-		t.Errorf("SyncTriggerPull = %q, want \"pull\"", SyncTriggerPull)
-	}
-}
-
 func TestSovereigntyConstants(t *testing.T) {
 	if SovereigntyT1 != "T1" {
 		t.Errorf("SovereigntyT1 = %q, want \"T1\"", SovereigntyT1)
@@ -1146,34 +1126,6 @@ func TestSovereigntyConstants(t *testing.T) {
 	}
 	if SovereigntyT4 != "T4" {
 		t.Errorf("SovereigntyT4 = %q, want \"T4\"", SovereigntyT4)
-	}
-}
-
-func TestSyncConfigDefaults(t *testing.T) {
-	// Isolate from environment variables
-	restore := envSnapshot(t)
-	defer restore()
-
-	// Initialize config
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize() returned error: %v", err)
-	}
-
-	// Test sync mode default
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() = %q, want %q", got, SyncModeDoltNative)
-	}
-
-	// Test sync config defaults
-	cfg := GetSyncConfig()
-	if cfg.Mode != SyncModeDoltNative {
-		t.Errorf("GetSyncConfig().Mode = %q, want %q", cfg.Mode, SyncModeDoltNative)
-	}
-	if cfg.ExportOn != SyncTriggerPush {
-		t.Errorf("GetSyncConfig().ExportOn = %q, want %q", cfg.ExportOn, SyncTriggerPush)
-	}
-	if cfg.ImportOn != SyncTriggerPull {
-		t.Errorf("GetSyncConfig().ImportOn = %q, want %q", cfg.ImportOn, SyncTriggerPull)
 	}
 }
 
@@ -1198,17 +1150,12 @@ func TestFederationConfigDefaults(t *testing.T) {
 	}
 }
 
-func TestSyncConfigFromFile(t *testing.T) {
+func TestFederationConfigFromFile(t *testing.T) {
 	// Create a temporary directory for config file
 	tmpDir := t.TempDir()
 
-	// Create a config file with sync settings
+	// Create a config file with federation settings
 	configContent := `
-sync:
-  mode: dolt-native
-  export_on: change
-  import_on: change
-
 federation:
   remote: dolthub://myorg/beads
   sovereignty: T2
@@ -1231,18 +1178,6 @@ federation:
 		t.Fatalf("Initialize() returned error: %v", err)
 	}
 
-	// Test sync config
-	syncCfg := GetSyncConfig()
-	if syncCfg.Mode != SyncModeDoltNative {
-		t.Errorf("GetSyncConfig().Mode = %q, want %q", syncCfg.Mode, SyncModeDoltNative)
-	}
-	if syncCfg.ExportOn != SyncTriggerChange {
-		t.Errorf("GetSyncConfig().ExportOn = %q, want %q", syncCfg.ExportOn, SyncTriggerChange)
-	}
-	if syncCfg.ImportOn != SyncTriggerChange {
-		t.Errorf("GetSyncConfig().ImportOn = %q, want %q", syncCfg.ImportOn, SyncTriggerChange)
-	}
-
 	// Test federation config
 	fedCfg := GetFederationConfig()
 	if fedCfg.Remote != "dolthub://myorg/beads" {
@@ -1250,23 +1185,6 @@ federation:
 	}
 	if fedCfg.Sovereignty != SovereigntyT2 {
 		t.Errorf("GetFederationConfig().Sovereignty = %q, want %q", fedCfg.Sovereignty, SovereigntyT2)
-	}
-}
-
-func TestGetSyncModeInvalid(t *testing.T) {
-	// Isolate from environment variables
-	restore := envSnapshot(t)
-	defer restore()
-
-	// Initialize config
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize() returned error: %v", err)
-	}
-
-	// Set invalid mode - always returns dolt-native now
-	Set("sync.mode", "invalid-mode")
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() with invalid mode = %q, want %q", got, SyncModeDoltNative)
 	}
 }
 

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -25,31 +25,6 @@ func logConfigWarning(format string, args ...interface{}) {
 	}
 }
 
-// SyncMode represents the sync mode configuration
-type SyncMode string
-
-const (
-	// SyncModeDoltNative uses Dolt remote directly (the only supported mode)
-	SyncModeDoltNative SyncMode = "dolt-native"
-)
-
-// validSyncModes is the set of allowed sync mode values
-var validSyncModes = map[SyncMode]bool{
-	SyncModeDoltNative: true,
-}
-
-// ValidSyncModes returns the list of valid sync mode values.
-func ValidSyncModes() []string {
-	return []string{
-		string(SyncModeDoltNative),
-	}
-}
-
-// IsValidSyncMode returns true if the given string is a valid sync mode.
-func IsValidSyncMode(mode string) bool {
-	return validSyncModes[SyncMode(strings.ToLower(strings.TrimSpace(mode)))]
-}
-
 // Sovereignty represents the federation sovereignty tier
 type Sovereignty string
 
@@ -93,12 +68,6 @@ func IsValidSovereignty(sovereignty string) bool {
 	return validSovereigntyTiers[Sovereignty(strings.ToUpper(strings.TrimSpace(sovereignty)))]
 }
 
-// GetSyncMode always returns SyncModeDoltNative.
-// The sync mode config key is deprecated; Dolt-native is the only supported mode.
-func GetSyncMode() SyncMode {
-	return SyncModeDoltNative
-}
-
 // GetSovereignty retrieves the federation sovereignty tier configuration.
 // Returns the configured tier, or SovereigntyNone (empty, no restriction) if not set.
 // Returns SovereigntyT1 and logs a warning if an invalid non-empty value is configured.
@@ -120,11 +89,6 @@ func GetSovereignty() Sovereignty {
 	}
 
 	return tier
-}
-
-// String returns the string representation of the SyncMode.
-func (m SyncMode) String() string {
-	return string(m)
 }
 
 // String returns the string representation of the Sovereignty.

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -6,18 +6,6 @@ import (
 	"testing"
 )
 
-func TestGetSyncMode(t *testing.T) {
-	// GetSyncMode always returns dolt-native regardless of config
-	ResetForTesting()
-	if err := Initialize(); err != nil {
-		t.Fatalf("Initialize failed: %v", err)
-	}
-
-	if got := GetSyncMode(); got != SyncModeDoltNative {
-		t.Errorf("GetSyncMode() = %q, want %q", got, SyncModeDoltNative)
-	}
-}
-
 func TestGetSovereignty(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -155,26 +143,6 @@ func TestConfigWarningsToggle(t *testing.T) {
 	ConfigWarningWriter = oldWriter
 }
 
-func TestIsValidSyncMode(t *testing.T) {
-	tests := []struct {
-		mode  string
-		valid bool
-	}{
-		{"dolt-native", true},
-		{"Dolt-Native", true},          // case insensitive
-		{"git-portable", false},        // removed
-		{"belt-and-suspenders", false}, // removed
-		{"invalid", false},
-		{"", false},
-	}
-
-	for _, tt := range tests {
-		if got := IsValidSyncMode(tt.mode); got != tt.valid {
-			t.Errorf("IsValidSyncMode(%q) = %v, want %v", tt.mode, got, tt.valid)
-		}
-	}
-}
-
 func TestIsValidSovereignty(t *testing.T) {
 	tests := []struct {
 		sovereignty string
@@ -199,16 +167,6 @@ func TestIsValidSovereignty(t *testing.T) {
 	}
 }
 
-func TestValidSyncModes(t *testing.T) {
-	modes := ValidSyncModes()
-	if len(modes) != 1 {
-		t.Errorf("ValidSyncModes() returned %d modes, want 1", len(modes))
-	}
-	if modes[0] != "dolt-native" {
-		t.Errorf("ValidSyncModes()[0] = %q, want %q", modes[0], "dolt-native")
-	}
-}
-
 func TestValidSovereigntyTiers(t *testing.T) {
 	tiers := ValidSovereigntyTiers()
 	if len(tiers) != 4 {
@@ -219,12 +177,6 @@ func TestValidSovereigntyTiers(t *testing.T) {
 		if tier != expected[i] {
 			t.Errorf("ValidSovereigntyTiers()[%d] = %q, want %q", i, tier, expected[i])
 		}
-	}
-}
-
-func TestSyncModeString(t *testing.T) {
-	if got := SyncModeDoltNative.String(); got != "dolt-native" {
-		t.Errorf("SyncModeDoltNative.String() = %q, want %q", got, "dolt-native")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove `SyncMode` type, `SyncModeDoltNative` const, `validSyncModes`, `ValidSyncModes()`, `IsValidSyncMode()`, `GetSyncMode()`, and `SyncMode.String()` from `internal/config/sync.go`
- Remove `SyncConfig` struct, `GetSyncConfig()`, `SyncTrigger*` constants, and `sync.mode`/`export_on`/`import_on` defaults from `internal/config/config.go`
- Remove `sync.mode` validation block from `cmd/bd/config.go`
- Remove `sync.mode`, `sync.export_on`, `sync.import_on` rows from `docs/CONFIG.md`
- Remove all dead tests covering the removed infrastructure

Active code is unchanged: `ConflictStrategy`, `FieldStrategy`, Sovereignty tiers (T1-T4), federation system, push/pull routing.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/config/...` passes (all config tests green)
- [x] Remaining test failures (`TestOpen`, `TestOpenFromConfig_NoMetadata`, `internal/tracker` engine tests) are pre-existing Dolt infrastructure failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)