### PR TITLE
Preserve dependency metadata in JSONL backups (bd-upfkd)

### DIFF
--- a/cmd/bd/backup_export.go
+++ b/cmd/bd/backup_export.go
@@ -174,7 +174,7 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 	state.Counts.Comments = n
 
 	n, err = exportTable(ctx, store, dir, "dependencies.jsonl",
-		"SELECT issue_id, depends_on_id, type, created_at, created_by FROM dependencies ORDER BY issue_id, depends_on_id")
+		"SELECT issue_id, depends_on_id, type, created_at, created_by, metadata FROM dependencies ORDER BY issue_id, depends_on_id")
 	if err != nil {
 		return nil, fmt.Errorf("backup dependencies: %w", err)
 	}

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -361,11 +361,12 @@ func restoreDependencies(ctx context.Context, db *sql.DB, path string, dryRun bo
 	warnings := 0
 	for _, line := range lines {
 		var dep struct {
-			IssueID     string `json:"issue_id"`
-			DependsOnID string `json:"depends_on_id"`
-			Type        string `json:"type"`
-			CreatedAt   string `json:"created_at"`
-			CreatedBy   string `json:"created_by"`
+			IssueID     string  `json:"issue_id"`
+			DependsOnID string  `json:"depends_on_id"`
+			Type        string  `json:"type"`
+			CreatedAt   string  `json:"created_at"`
+			CreatedBy   string  `json:"created_by"`
+			Metadata    *string `json:"metadata"`
 		}
 		if err := json.Unmarshal(line, &dep); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: skipping invalid dependency line: %v\n", err)
@@ -377,10 +378,22 @@ func restoreDependencies(ctx context.Context, db *sql.DB, path string, dryRun bo
 		}
 		if !dryRun {
 			createdAt := parseTimeOrNow(dep.CreatedAt)
+			meta := "{}"
+			if dep.Metadata != nil {
+				raw := strings.TrimSpace(*dep.Metadata)
+				if raw != "" {
+					if !json.Valid([]byte(raw)) {
+						fmt.Fprintf(os.Stderr, "Warning: invalid dependency metadata for %s -> %s; defaulting to {}\n", dep.IssueID, dep.DependsOnID)
+						warnings++
+					} else {
+						meta = raw
+					}
+				}
+			}
 			_, err := db.ExecContext(ctx, `
 				INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata)
-				VALUES (?, ?, ?, ?, ?, '{}')
-			`, dep.IssueID, dep.DependsOnID, dep.Type, createdAt, dep.CreatedBy)
+				VALUES (?, ?, ?, ?, ?, ?)
+			`, dep.IssueID, dep.DependsOnID, dep.Type, createdAt, dep.CreatedBy, meta)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to restore dependency %s -> %s: %v\n", dep.IssueID, dep.DependsOnID, err)
 				warnings++

--- a/cmd/bd/backup_restore_test.go
+++ b/cmd/bd/backup_restore_test.go
@@ -75,8 +75,9 @@ func TestBackupRestoreRoundTrip(t *testing.T) {
 	if _, err := s.DB().ExecContext(ctx, `INSERT INTO comments (issue_id, author, text) VALUES (?, ?, ?)`, "rt-1", "tester", "first comment"); err != nil {
 		t.Fatalf("insert comment: %v", err)
 	}
-	if _, err := s.DB().ExecContext(ctx, `INSERT INTO dependencies (issue_id, depends_on_id, type, created_by, metadata) VALUES (?, ?, ?, ?, '{}')`,
-		"rt-2", "rt-1", "blocks", "tester"); err != nil {
+	depMetadata := `{"gate":"any-children","spawner_id":"rt-1"}`
+	if _, err := s.DB().ExecContext(ctx, `INSERT INTO dependencies (issue_id, depends_on_id, type, created_by, metadata) VALUES (?, ?, ?, ?, ?)`,
+		"rt-2", "rt-1", "blocks", "tester", depMetadata); err != nil {
 		t.Fatalf("insert dependency: %v", err)
 	}
 	if err := s.SetConfig(ctx, "issue_prefix", "rt"); err != nil {
@@ -159,6 +160,16 @@ func TestBackupRestoreRoundTrip(t *testing.T) {
 		t.Errorf("labels count = %d, want 2", len(labels))
 	}
 
+	var restoredMetadata string
+	if err := s2.DB().QueryRowContext(ctx,
+		`SELECT metadata FROM dependencies WHERE issue_id = ? AND depends_on_id = ?`,
+		"rt-2", "rt-1").Scan(&restoredMetadata); err != nil {
+		t.Fatalf("query restored dependency metadata: %v", err)
+	}
+	if restoredMetadata != depMetadata {
+		t.Errorf("restored dependency metadata = %q, want %q", restoredMetadata, depMetadata)
+	}
+
 	// Verify config was restored
 	prefix, err := s2.GetConfig(ctx, "issue_prefix")
 	if err != nil {
@@ -231,6 +242,74 @@ func TestBackupRestoreDryRun(t *testing.T) {
 	_, err = s.GetIssue(ctx, "dry-1")
 	if err == nil {
 		t.Error("dry-run should not have written issue to database")
+	}
+}
+
+func TestBackupRestoreDependenciesWithoutMetadataDefaultsToEmptyObject(t *testing.T) {
+	if testDoltServerPort == 0 {
+		t.Skip("Dolt test server not available")
+	}
+	if testutil.DoltContainerCrashed() {
+		t.Skipf("Dolt test server crashed: %v", testutil.DoltContainerCrashError())
+	}
+
+	ensureTestMode(t)
+	saved := saveAndRestoreGlobals(t)
+	_ = saved
+
+	tmpDir := t.TempDir()
+	backupPath := filepath.Join(tmpDir, "backup")
+	if err := os.MkdirAll(backupPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	issuesData := "" +
+		`{"id":"compat-1","title":"Compat Parent","status":"open","priority":2,"issue_type":"task"}` + "\n" +
+		`{"id":"compat-2","title":"Compat Child","status":"open","priority":2,"issue_type":"task"}` + "\n"
+	if err := os.WriteFile(filepath.Join(backupPath, "issues.jsonl"), []byte(issuesData), 0600); err != nil {
+		t.Fatal(err)
+	}
+	depsData := `{"issue_id":"compat-2","depends_on_id":"compat-1","type":"blocks","created_by":"tester"}` + "\n"
+	if err := os.WriteFile(filepath.Join(backupPath, "dependencies.jsonl"), []byte(depsData), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	dbName := uniqueTestDBName(t)
+	testDBPath := filepath.Join(t.TempDir(), "dolt")
+	writeTestMetadata(t, testDBPath, dbName)
+	s := newTestStore(t, testDBPath)
+	store = s
+	storeMutex.Lock()
+	storeActive = true
+	storeMutex.Unlock()
+	t.Cleanup(func() {
+		store = nil
+		storeMutex.Lock()
+		storeActive = false
+		storeMutex.Unlock()
+	})
+
+	ctx := context.Background()
+
+	result, err := runBackupRestore(ctx, s, backupPath, false)
+	if err != nil {
+		t.Fatalf("restore from old-format dependency backup: %v", err)
+	}
+	if result.Dependencies != 1 {
+		t.Fatalf("restored dependencies = %d, want 1", result.Dependencies)
+	}
+	if result.Warnings != 0 {
+		t.Fatalf("restore warnings = %d, want 0", result.Warnings)
+	}
+
+	var restoredMetadata string
+	if err := s.DB().QueryRowContext(ctx,
+		`SELECT metadata FROM dependencies WHERE issue_id = ? AND depends_on_id = ?`,
+		"compat-2", "compat-1").Scan(&restoredMetadata); err != nil {
+		t.Fatalf("query restored dependency metadata: %v", err)
+	}
+	if restoredMetadata != "{}" {
+		t.Errorf("restored dependency metadata = %q, want %q", restoredMetadata, "{}")
 	}
 }
 

--- a/cmd/bd/backup_test.go
+++ b/cmd/bd/backup_test.go
@@ -161,6 +161,12 @@ func TestBackupExport(t *testing.T) {
 		t.Fatalf("insert event: %v", err)
 	}
 
+	depMetadata := `{"gate":"any-children","spawner_id":"test-1"}`
+	if _, err := s.DB().ExecContext(ctx, `INSERT INTO dependencies (issue_id, depends_on_id, type, created_by, metadata) VALUES (?, ?, ?, ?, ?)`,
+		"test-2", "test-1", "blocks", "tester", depMetadata); err != nil {
+		t.Fatalf("insert dependency: %v", err)
+	}
+
 	// Commit so GetCurrentCommit returns something
 	if _, err := s.DB().ExecContext(ctx, "CALL DOLT_COMMIT('-Am', 'test data')"); err != nil {
 		t.Fatalf("dolt commit: %v", err)
@@ -181,13 +187,16 @@ func TestBackupExport(t *testing.T) {
 	if state.Counts.Events != 1 {
 		t.Errorf("events = %d, want 1", state.Counts.Events)
 	}
+	if state.Counts.Dependencies != 1 {
+		t.Errorf("dependencies = %d, want 1", state.Counts.Dependencies)
+	}
 	if state.LastDoltCommit == "" {
 		t.Error("expected non-empty dolt commit")
 	}
 
 	// Verify files exist
 	backupPath := filepath.Join(beadsDir, "backup")
-	for _, file := range []string{"issues.jsonl", "events.jsonl", "labels.jsonl", "config.jsonl", "backup_state.json"} {
+	for _, file := range []string{"issues.jsonl", "events.jsonl", "dependencies.jsonl", "labels.jsonl", "config.jsonl", "backup_state.json"} {
 		path := filepath.Join(backupPath, file)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			t.Errorf("expected file %s to exist", file)
@@ -202,6 +211,29 @@ func TestBackupExport(t *testing.T) {
 	lines := splitJSONL(issuesData)
 	if len(lines) != 2 {
 		t.Errorf("issues.jsonl has %d lines, want 2", len(lines))
+	}
+
+	depsData, err := os.ReadFile(filepath.Join(backupPath, "dependencies.jsonl"))
+	if err != nil {
+		t.Fatalf("read dependencies.jsonl: %v", err)
+	}
+	depLines := splitJSONL(depsData)
+	if len(depLines) != 1 {
+		t.Fatalf("dependencies.jsonl has %d lines, want 1", len(depLines))
+	}
+	var depRow struct {
+		IssueID     string `json:"issue_id"`
+		DependsOnID string `json:"depends_on_id"`
+		Metadata    string `json:"metadata"`
+	}
+	if err := json.Unmarshal(depLines[0], &depRow); err != nil {
+		t.Fatalf("unmarshal dependency row: %v", err)
+	}
+	if depRow.IssueID != "test-2" || depRow.DependsOnID != "test-1" {
+		t.Fatalf("dependency row = %s -> %s, want test-2 -> test-1", depRow.IssueID, depRow.DependsOnID)
+	}
+	if depRow.Metadata != depMetadata {
+		t.Errorf("dependency metadata = %q, want %q", depRow.Metadata, depMetadata)
 	}
 
 	// Second export with no changes should be a no-op


### PR DESCRIPTION
## Summary
- include dependency metadata in `dependencies.jsonl` backup export
- restore dependency metadata from JSONL with backward-compatible `{}` defaulting
- add regression coverage for export, round-trip restore, and old backups without metadata

## Testing
- `./scripts/test-cgo.sh -run '^(TestBackupExport|TestBackupRestoreRoundTrip|TestBackupRestoreDependenciesWithoutMetadataDefaultsToEmptyObject)$' ./cmd/bd`
- `golangci-lint run ./cmd/bd/...`
- `make test` (currently fails on unrelated baseline issues tracked in `bd-ea1kb`)
