### PR TITLE
feat(init): allow bd init from git worktrees

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -46,7 +46,10 @@ With --stealth: configures per-repository git settings for invisible beads usage
 Beads requires a running dolt sql-server for database operations. If a server is detected
 on port 3307 or 3306, it is used automatically. Set connection details with --server-host,
 --server-port, and --server-user. Password should be set via BEADS_DOLT_PASSWORD
-environment variable.`,
+environment variable.
+
+When run from a git worktree, bd initializes the shared canonical .beads
+location and writes a local .beads/redirect in the calling worktree.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		prefix, _ := cmd.Flags().GetString("prefix")
 		quiet, _ := cmd.Flags().GetBool("quiet")
@@ -180,31 +183,6 @@ environment variable.`,
 			prefix = "bd_" + prefix
 		}
 
-		// Determine beadsDir first (used for all storage path calculations).
-		// BEADS_DIR takes precedence, otherwise use CWD/.beads (with redirect support).
-		// This must be computed BEFORE initDBPath to ensure consistent path resolution
-		// (avoiding macOS /var -> /private/var symlink issues when directory creation
-		// happens between path computations).
-		var beadsDirForInit string
-		if envBeadsDir := os.Getenv("BEADS_DIR"); envBeadsDir != "" {
-			beadsDirForInit = utils.CanonicalizePath(envBeadsDir)
-		} else {
-			localBeadsDir := filepath.Join(".", ".beads")
-			beadsDirForInit = beads.FollowRedirect(localBeadsDir)
-		}
-
-		// Determine storage path.
-		//
-		// Precedence: --db > BEADS_DIR > default (.beads/dolt)
-		// If there's a redirect file, use the redirect target (GH#bd-0qel)
-		initDBPath := dbPath
-		if initDBPath == "" {
-			// Dolt backend: respect dolt_data_dir config / BEADS_DOLT_DATA_DIR env
-			initDBPath = doltserver.ResolveDoltDir(beadsDirForInit)
-		}
-
-		// Determine if we should create .beads/ directory in CWD or main repo root
-		// For worktrees, .beads should always be in the main repository root
 		cwd, err := os.Getwd()
 		if err != nil {
 			FatalError("failed to get current directory: %v", err)
@@ -218,30 +196,31 @@ environment variable.`,
 		if isGitRepo() {
 			isWorktree = git.IsWorktree()
 		}
-
-		// Prevent initialization from within a worktree (unless BEADS_DIR is
-		// explicitly set, which means the caller already knows where to init)
-		if isWorktree && !hasExplicitBeadsDir {
-			mainRepoRoot, err := git.GetMainRepoRoot()
-			if err != nil {
-				FatalError("failed to get main repository root: %v", err)
-			}
-
-			fmt.Fprintf(os.Stderr, "Error: cannot run 'bd init' from within a git worktree\n\n")
-			fmt.Fprintf(os.Stderr, "Git worktrees share the .beads database from the main repository.\n")
-			fmt.Fprintf(os.Stderr, "To fix this:\n\n")
-			fmt.Fprintf(os.Stderr, "  1. Initialize beads in the main repository:\n")
-			fmt.Fprintf(os.Stderr, "     cd %s\n", mainRepoRoot)
-			fmt.Fprintf(os.Stderr, "     bd init\n\n")
-			fmt.Fprintf(os.Stderr, "  2. Then create worktrees with beads support:\n")
-			fmt.Fprintf(os.Stderr, "     bd worktree create <path> --branch <branch-name>\n\n")
-			fmt.Fprintf(os.Stderr, "For more information, see: https://github.com/steveyegge/beads/blob/main/docs/WORKTREES.md\n")
-			os.Exit(1)
+		initLocation, err := resolveInitLocation(cwd, hasExplicitBeadsDir, isWorktree)
+		if err != nil {
+			FatalError("failed to resolve init location: %v", err)
 		}
 
-		// Use the beadsDir computed earlier (before any directory creation)
-		// to ensure consistent path representation.
-		beadsDir := beadsDirForInit
+		beadsDir := initLocation.CanonicalBeadsDir
+
+		attachOnly := false
+		if !force {
+			if initLocation.NeedsRedirect {
+				canonicalExists, err := beadsDatabaseExists(beadsDir)
+				if err != nil {
+					FatalError("failed to inspect canonical beads database: %v", err)
+				}
+				if canonicalExists {
+					attachOnly = true
+				} else if err := checkExistingBeadsDataAt(beadsDir, prefix); err != nil {
+					FatalError("%v", err)
+				}
+			} else {
+				if err := checkExistingBeadsDataAt(beadsDir, prefix); err != nil {
+					FatalError("%v", err)
+				}
+			}
+		}
 
 		// Prevent nested .beads directories
 		// Check if current working directory is inside a .beads directory
@@ -251,6 +230,52 @@ environment variable.`,
 			fmt.Fprintf(os.Stderr, "Current directory: %s\n", cwd)
 			fmt.Fprintf(os.Stderr, "Please run 'bd init' from outside the .beads directory.\n")
 			os.Exit(1)
+		}
+
+		if initLocation.NeedsRedirect {
+			if err := ensureWorktreeRedirectSafety(initLocation.WorktreeBeadsDir); err != nil {
+				FatalError("%v", err)
+			}
+		}
+
+		if attachOnly {
+			if err := ensureWorktreeRedirect(initLocation.WorktreeBeadsDir, beadsDir); err != nil {
+				FatalError("failed to create worktree redirect: %v", err)
+			}
+			if quiet {
+				return
+			}
+			fmt.Printf("\n%s Attached worktree to shared beads database.\n\n", ui.RenderPass("✓"))
+			fmt.Printf("  Shared .beads: %s\n", ui.RenderAccent(beadsDir))
+			fmt.Printf("  Worktree redirect: %s\n\n", ui.RenderAccent(initLocation.WorktreeBeadsDir))
+			doctorResult := runInitDiagnostics(cwd)
+			hasIssues := false
+			for _, check := range doctorResult.Checks {
+				if check.Status != statusOK {
+					hasIssues = true
+					break
+				}
+			}
+			if hasIssues {
+				fmt.Printf("%s Setup incomplete. Some issues were detected:\n", ui.RenderWarn("⚠"))
+				for _, check := range doctorResult.Checks {
+					if check.Status != statusOK {
+						fmt.Printf("  • %s: %s\n", check.Name, check.Message)
+					}
+				}
+				fmt.Printf("\nRun %s to see details and fix these issues.\n\n", ui.RenderAccent("bd doctor --fix"))
+			}
+			return
+		}
+
+		// Determine storage path.
+		//
+		// Precedence: --db > BEADS_DIR > default (.beads/dolt)
+		// If there's a redirect file, use the redirect target (GH#bd-0qel)
+		initDBPath := dbPath
+		if initDBPath == "" {
+			// Dolt backend: respect dolt_data_dir config / BEADS_DOLT_DATA_DIR env
+			initDBPath = doltserver.ResolveDoltDir(beadsDir)
 		}
 
 		initDBDir := filepath.Dir(initDBPath)
@@ -306,6 +331,12 @@ environment variable.`,
 					fmt.Fprintf(os.Stderr, "Warning: failed to create interactions.jsonl: %v\n", err)
 					// Non-fatal - continue anyway
 				}
+			}
+		}
+
+		if initLocation.NeedsRedirect {
+			if err := ensureWorktreeRedirect(initLocation.WorktreeBeadsDir, beadsDir); err != nil {
+				FatalError("failed to create worktree redirect: %v", err)
 			}
 		}
 
@@ -853,6 +884,147 @@ environment variable.`,
 			fmt.Printf("\nRun %s to see details and fix these issues.\n\n", ui.RenderAccent("bd doctor --fix"))
 		}
 	},
+}
+
+type initLocation struct {
+	CanonicalBeadsDir string
+	WorktreeBeadsDir  string
+	NeedsRedirect     bool
+	SharedRepoBare    bool
+}
+
+func resolveInitLocation(cwd string, hasExplicitBeadsDir bool, isWorktree bool) (initLocation, error) {
+	if hasExplicitBeadsDir {
+		return initLocation{
+			CanonicalBeadsDir: utils.CanonicalizePath(os.Getenv("BEADS_DIR")),
+		}, nil
+	}
+
+	if !isGitRepo() || !isWorktree {
+		return initLocation{
+			CanonicalBeadsDir: beads.FollowRedirect(filepath.Join(cwd, ".beads")),
+		}, nil
+	}
+
+	worktreeRoot := git.GetRepoRoot()
+	if worktreeRoot == "" {
+		return initLocation{}, fmt.Errorf("failed to determine worktree root")
+	}
+
+	commonDir, err := git.GetGitCommonDir()
+	if err != nil {
+		return initLocation{}, err
+	}
+
+	sharedRepoBare := isBareGitDir(commonDir)
+	canonicalBeadsDir := ""
+	if sharedRepoBare {
+		canonicalBeadsDir = filepath.Join(commonDir, ".beads")
+	} else {
+		mainRepoRoot, err := git.GetMainRepoRoot()
+		if err != nil {
+			return initLocation{}, err
+		}
+		canonicalBeadsDir = filepath.Join(mainRepoRoot, ".beads")
+	}
+
+	return initLocation{
+		CanonicalBeadsDir: utils.CanonicalizePath(canonicalBeadsDir),
+		WorktreeBeadsDir:  filepath.Join(worktreeRoot, ".beads"),
+		NeedsRedirect:     true,
+		SharedRepoBare:    sharedRepoBare,
+	}, nil
+}
+
+func isBareGitDir(gitDir string) bool {
+	cmd := exec.Command("git", "--git-dir", gitDir, "rev-parse", "--is-bare-repository")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == "true"
+}
+
+func ensureWorktreeRedirectSafety(worktreeBeadsDir string) error {
+	info, err := os.Stat(worktreeBeadsDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect worktree .beads directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("worktree .beads path is not a directory: %s", worktreeBeadsDir)
+	}
+
+	entries, err := os.ReadDir(worktreeBeadsDir)
+	if err != nil {
+		return fmt.Errorf("failed to read worktree .beads directory: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		switch name {
+		case ".gitignore", ".gitkeep", beads.RedirectFileName:
+			continue
+		default:
+			return fmt.Errorf("refusing to replace existing worktree .beads contents at %s; found %s", worktreeBeadsDir, name)
+		}
+	}
+	return nil
+}
+
+func ensureWorktreeRedirect(worktreeBeadsDir, targetBeadsDir string) error {
+	if err := os.MkdirAll(worktreeBeadsDir, 0750); err != nil {
+		return err
+	}
+	redirectPath := filepath.Join(worktreeBeadsDir, beads.RedirectFileName)
+	redirectTarget := redirectTargetForWorktree(worktreeBeadsDir, targetBeadsDir)
+	if err := os.WriteFile(redirectPath, []byte(redirectTarget+"\n"), 0644); err != nil {
+		return err
+	}
+	gitignorePath := filepath.Join(worktreeBeadsDir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(doctor.GitignoreTemplate), 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func beadsDatabaseExists(beadsDir string) (bool, error) {
+	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil && cfg.GetBackend() == configfile.BackendDolt {
+		doltPath := doltserver.ResolveDoltDir(beadsDir)
+		if info, err := os.Stat(doltPath); err == nil && info.IsDir() {
+			return true, nil
+		}
+		if cfg.IsDoltServerMode() {
+			result := checkDatabaseOnServer(
+				cfg.GetDoltServerHost(),
+				doltserver.DefaultConfig(beadsDir).Port,
+				cfg.GetDoltServerUser(),
+				cfg.GetDoltServerPassword(),
+				cfg.GetDoltDatabase(),
+			)
+			if result.Reachable && result.Exists && result.Err == nil {
+				return true, nil
+			}
+			return false, nil
+		}
+		return false, nil
+	}
+
+	redirectTarget := beads.FollowRedirect(beadsDir)
+	if redirectTarget != beadsDir {
+		return beadsDatabaseExists(redirectTarget)
+	}
+
+	dbPath := filepath.Join(beadsDir, beads.CanonicalDatabaseName)
+	if _, err := os.Stat(dbPath); err == nil {
+		return true, nil
+	}
+	return false, nil
 }
 
 func init() {

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -185,6 +185,166 @@ func TestInitCommand(t *testing.T) {
 	}
 }
 
+func TestInitWorktreeAutoRedirect(t *testing.T) {
+	skipIfNoDolt(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping worktree test on Windows")
+	}
+
+	resetState := func(t *testing.T) {
+		t.Helper()
+		origDBPath := dbPath
+		origStore := store
+		origBeadsDir := os.Getenv("BEADS_DIR")
+		t.Cleanup(func() {
+			dbPath = origDBPath
+			store = origStore
+			if origBeadsDir != "" {
+				os.Setenv("BEADS_DIR", origBeadsDir)
+			} else {
+				os.Unsetenv("BEADS_DIR")
+			}
+			beads.ResetCaches()
+			git.ResetCaches()
+		})
+		dbPath = ""
+		store = nil
+		os.Unsetenv("BEADS_DIR")
+		initCmd.Flags().Set("prefix", "")
+		initCmd.Flags().Set("quiet", "false")
+		initCmd.Flags().Set("force", "false")
+		initCmd.Flags().Set("skip-hooks", "false")
+	}
+
+	runGit := func(t *testing.T, dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s failed: %v\n%s", args, dir, err, out)
+		}
+	}
+
+	makeMainRepo := func(t *testing.T, root string) string {
+		t.Helper()
+		repo := filepath.Join(root, "main-repo")
+		if err := os.MkdirAll(repo, 0755); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, repo, "init")
+		runGit(t, repo, "config", "user.email", "test@test.com")
+		runGit(t, repo, "config", "user.name", "Test")
+		runGit(t, repo, "commit", "--allow-empty", "-m", "initial")
+		return repo
+	}
+
+	t.Run("NonBareParentInitializesCanonicalBeads", func(t *testing.T) {
+		resetState(t)
+		tmpDir := t.TempDir()
+		mainRepo := makeMainRepo(t, tmpDir)
+		worktreeDir := filepath.Join(tmpDir, "my-worktree")
+		runGit(t, mainRepo, "worktree", "add", worktreeDir, "-b", "test-wt")
+		beads.ResetCaches()
+		git.ResetCaches()
+
+		t.Chdir(worktreeDir)
+		rootCmd.SetArgs([]string{"init", "--prefix", "wt-auto", "--skip-hooks", "--quiet"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init from worktree failed: %v", err)
+		}
+
+		canonicalDBPath := filepath.Join(mainRepo, ".beads", "dolt")
+		if _, err := os.Stat(canonicalDBPath); os.IsNotExist(err) {
+			t.Fatalf("canonical Dolt dir missing: %s", canonicalDBPath)
+		}
+		redirectPath := filepath.Join(worktreeDir, ".beads", beads.RedirectFileName)
+		if _, err := os.Stat(redirectPath); os.IsNotExist(err) {
+			t.Fatalf("worktree redirect missing: %s", redirectPath)
+		}
+		worktreeDBPath := filepath.Join(worktreeDir, ".beads", "dolt")
+		if _, err := os.Stat(worktreeDBPath); err == nil {
+			t.Fatalf("worktree should not have local dolt dir: %s", worktreeDBPath)
+		}
+		got := beads.FollowRedirect(filepath.Join(worktreeDir, ".beads"))
+		want := filepath.Join(mainRepo, ".beads")
+		if got != want {
+			t.Fatalf("redirect target = %s, want %s", got, want)
+		}
+	})
+
+	t.Run("ExistingCanonicalDBAttachesWorktree", func(t *testing.T) {
+		resetState(t)
+		tmpDir := t.TempDir()
+		mainRepo := makeMainRepo(t, tmpDir)
+
+		t.Chdir(mainRepo)
+		rootCmd.SetArgs([]string{"init", "--prefix", "parent", "--skip-hooks", "--quiet"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init in main repo failed: %v", err)
+		}
+
+		worktreeDir := filepath.Join(tmpDir, "attach-worktree")
+		runGit(t, mainRepo, "worktree", "add", worktreeDir, "-b", "attach-wt")
+		beads.ResetCaches()
+		git.ResetCaches()
+
+		t.Chdir(worktreeDir)
+		rootCmd.SetArgs([]string{"init", "--prefix", "different", "--skip-hooks", "--quiet"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("attach init from worktree failed: %v", err)
+		}
+
+		got := beads.FollowRedirect(filepath.Join(worktreeDir, ".beads"))
+		want := filepath.Join(mainRepo, ".beads")
+		if got != want {
+			t.Fatalf("redirect target = %s, want %s", got, want)
+		}
+
+		store, err := openExistingTestDB(t, filepath.Join(mainRepo, ".beads", "dolt"))
+		if err != nil {
+			t.Fatalf("open canonical db failed: %v", err)
+		}
+		defer store.Close()
+
+		prefix, err := store.GetConfig(context.Background(), "issue_prefix")
+		if err != nil {
+			t.Fatalf("get prefix failed: %v", err)
+		}
+		if prefix != "parent" {
+			t.Fatalf("issue_prefix = %q, want %q", prefix, "parent")
+		}
+	})
+
+	t.Run("BareParentInitializesCommonDirBeads", func(t *testing.T) {
+		resetState(t)
+		tmpDir := t.TempDir()
+		sourceRepo := makeMainRepo(t, tmpDir)
+		bareRepo := filepath.Join(tmpDir, "origin.git")
+		runGit(t, tmpDir, "clone", "--bare", sourceRepo, bareRepo)
+		worktreeDir := filepath.Join(tmpDir, "bare-worktree")
+		runGit(t, bareRepo, "worktree", "add", worktreeDir, "master")
+		beads.ResetCaches()
+		git.ResetCaches()
+
+		t.Chdir(worktreeDir)
+		rootCmd.SetArgs([]string{"init", "--prefix", "barewt", "--skip-hooks", "--quiet"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init from bare-backed worktree failed: %v", err)
+		}
+
+		canonicalBeads := filepath.Join(bareRepo, ".beads")
+		canonicalDBPath := filepath.Join(canonicalBeads, "dolt")
+		if _, err := os.Stat(canonicalDBPath); os.IsNotExist(err) {
+			t.Fatalf("bare canonical Dolt dir missing: %s", canonicalDBPath)
+		}
+		got := beads.FollowRedirect(filepath.Join(worktreeDir, ".beads"))
+		if got != canonicalBeads {
+			t.Fatalf("redirect target = %s, want %s", got, canonicalBeads)
+		}
+	})
+}
+
 // Note: Error case testing is omitted because the init command calls os.Exit()
 // on errors, which makes it difficult to test in a unit test context.
 

--- a/cmd/bd/worktree_cmd.go
+++ b/cmd/bd/worktree_cmd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/ui"
-	"github.com/steveyegge/beads/internal/utils"
 )
 
 // WorktreeInfo contains information about a git worktree
@@ -205,17 +204,7 @@ func runWorktreeCreate(cmd *cobra.Command, args []string) error {
 
 	// Create redirect file
 	redirectPath := filepath.Join(worktreeBeadsDir, beads.RedirectFileName)
-	// Ensure mainBeadsDir is absolute for correct filepath.Rel() computation (GH#1098)
-	// beads.FindBeadsDir() may return a relative path in some contexts
-	absMainBeadsDir := utils.CanonicalizeIfRelative(mainBeadsDir)
-	// Compute relative path from worktree root (not .beads dir) because
-	// FollowRedirect resolves paths relative to the parent of .beads
-	worktreeRoot := filepath.Dir(worktreeBeadsDir)
-	relPath, err := filepath.Rel(worktreeRoot, absMainBeadsDir)
-	if err != nil {
-		// Fall back to absolute path
-		relPath = absMainBeadsDir
-	}
+	relPath := redirectTargetForWorktree(worktreeBeadsDir, mainBeadsDir)
 	// #nosec G306 - redirect file needs to be readable
 	if err := os.WriteFile(redirectPath, []byte(relPath+"\n"), 0644); err != nil {
 		cleanupWorktree()

--- a/cmd/bd/worktree_redirect.go
+++ b/cmd/bd/worktree_redirect.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/utils"
+)
+
+func redirectTargetForWorktree(localBeadsDir, targetBeadsDir string) string {
+	absTarget := utils.CanonicalizeIfRelative(targetBeadsDir)
+	worktreeRoot := filepath.Dir(localBeadsDir)
+	relPath, err := filepath.Rel(worktreeRoot, absTarget)
+	if err != nil {
+		return absTarget
+	}
+	return relPath
+}

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -162,6 +162,11 @@ When agents discover duplicate issues, they should:
 
 Git worktrees work with bd. Each worktree can have its own `.beads` directory, or worktrees can share a database via redirects (see [Database Redirects](#database-redirects)).
 
+Running `bd init` inside a worktree now bootstraps the shared canonical store automatically:
+- non-bare parent: canonical location is the parent repo's `.beads/`
+- bare parent: canonical location is `$(git rev-parse --git-common-dir)/.beads/`
+- the calling worktree gets a local `.beads/redirect` pointing at that canonical store
+
 **With Dolt backend:** Each worktree operates directly on the database — no special coordination needed. Use `bd dolt push` to sync with Dolt remotes when ready.
 
 **With Dolt server mode:** Multiple worktrees can connect to the same Dolt server for concurrent access without conflicts.


### PR DESCRIPTION
I use a bare-repo + git-worktree workflow daily, and this updates `bd init` so worktree-local initialization behaves the way that workflow expects.

## Problem

Running `bd init` inside a git worktree currently hard-fails and tells the user to go initialize beads somewhere else first. That is especially awkward for bare-repo + worktree setups, where the shared git storage is already known and beads could infer the canonical store automatically.

## Changes

1. `bd init` no longer rejects worktree execution by default
2. In non-bare setups, worktree init now resolves the canonical store to the parent repo's `.beads/`
3. In bare-backed setups, worktree init now resolves the canonical store to `$(git rev-parse --git-common-dir)/.beads/`
4. If the canonical store already exists, `bd init` treats the worktree as an attach case and only creates or repairs `.beads/redirect`
5. Redirect path generation is shared between `bd init` and `bd worktree create`
6. Added regression tests for non-bare worktrees, bare-backed worktrees, and attach-to-existing-canonical-db behavior
7. Updated advanced docs and init help text to describe the new worktree bootstrap behavior

## User impact

For worktree-heavy setups, especially bare-repo + worktree:

- `bd init` works directly inside a worktree
- the canonical shared beads store is chosen automatically
- the current worktree gets a local `.beads/redirect`
- rerunning init from another worktree attaches cleanly instead of trying to reinitialize the DB

## Validation

Passing:
- `go test ./cmd/bd -run 'TestInit|TestWorktree' -count=1`

Also run:
- `make test`

Current environment issues during `make test`:
- missing cached Docker image for `dolthub/dolt-sql-server:1.83.0`, so some Dolt-backed tests are skipped or fail in this environment
- existing unrelated failures in `cmd/bd/doctor`, `cmd/bd/protocol`, `internal/beads`, and `internal/tracker` not caused by this change
