### PR TITLE
feat: search external_ref in bd search

### DIFF
--- a/cmd/bd/search.go
+++ b/cmd/bd/search.go
@@ -79,6 +79,7 @@ Examples:
 		// Pattern matching flags
 		descContains, _ := cmd.Flags().GetString("desc-contains")
 		notesContains, _ := cmd.Flags().GetString("notes-contains")
+		externalContains, _ := cmd.Flags().GetString("external-contains")
 
 		// Empty/null check flags
 		emptyDesc, _ := cmd.Flags().GetBool("empty-description")
@@ -128,6 +129,9 @@ Examples:
 		}
 		if notesContains != "" {
 			filter.NotesContains = notesContains
+		}
+		if externalContains != "" {
+			filter.ExternalRefContains = externalContains
 		}
 
 		// Empty/null checks
@@ -365,6 +369,7 @@ func init() {
 	// Pattern matching flags
 	searchCmd.Flags().String("desc-contains", "", "Filter by description substring (case-insensitive)")
 	searchCmd.Flags().String("notes-contains", "", "Filter by notes substring (case-insensitive)")
+	searchCmd.Flags().String("external-contains", "", "Filter by external ref substring (case-insensitive)")
 
 	// Empty/null check flags
 	searchCmd.Flags().Bool("empty-description", false, "Filter issues with empty or missing description")

--- a/internal/storage/dolt/filters.go
+++ b/internal/storage/dolt/filters.go
@@ -43,10 +43,11 @@ func buildIssueFilterClauses(query string, filter types.IssueFilter, tables filt
 		lowerQuery := strings.ToLower(query)
 		if looksLikeIssueID(query) {
 			// ID-like query: use exact match + prefix match on indexed id column,
-			// plus title LIKE as fallback for cases where the query appears in titles.
+			// plus title LIKE and external_ref LIKE as fallbacks (e.g. Linear IDs
+			// like "BE-1521" stored in external_ref).
 			// IDs are always lowercase, so no LOWER() needed for id columns.
-			whereClauses = append(whereClauses, "(id = ? OR id LIKE ? OR LOWER(title) LIKE ?)")
-			args = append(args, lowerQuery, lowerQuery+"%", "%"+lowerQuery+"%")
+			whereClauses = append(whereClauses, "(id = ? OR id LIKE ? OR LOWER(title) LIKE ? OR LOWER(external_ref) LIKE ?)")
+			args = append(args, lowerQuery, lowerQuery+"%", "%"+lowerQuery+"%", "%"+lowerQuery+"%")
 		} else {
 			// Text query: search title and id (skip description — it's large and
 			// LIKE %% on TEXT columns causes the worst prolly-tree scan behavior).
@@ -73,6 +74,10 @@ func buildIssueFilterClauses(query string, filter types.IssueFilter, tables filt
 	if filter.NotesContains != "" {
 		whereClauses = append(whereClauses, "notes LIKE ?")
 		args = append(args, "%"+filter.NotesContains+"%")
+	}
+	if filter.ExternalRefContains != "" {
+		whereClauses = append(whereClauses, "external_ref LIKE ?")
+		args = append(args, "%"+filter.ExternalRefContains+"%")
 	}
 
 	// Status filters

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -790,6 +790,64 @@ func TestSearchIssues_ByDescription(t *testing.T) {
 	}
 }
 
+// TestSearchIssues_ByExternalRef verifies two things:
+//  1. A free-text query like "BE-1521" (which looksLikeIssueID returns true for)
+//     matches an issue whose external_ref contains that string.
+//  2. The ExternalRefContains filter works for explicit substring search.
+func TestSearchIssues_ByExternalRef(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	linearURL := "https://linear.app/example-org/issue/BE-1521"
+	issue := &types.Issue{
+		ID:          "si-extref-xyz",
+		Title:       "Migrate EmailUtils across all services",
+		ExternalRef: &linearURL,
+		Status:      types.StatusOpen,
+		Priority:    3,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+
+	// Free-text ID-like query should match via external_ref LIKE.
+	results, err := store.SearchIssues(ctx, "BE-1521", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("free-text search for external ref id: expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != issue.ID {
+		t.Errorf("expected %s, got %s", issue.ID, results[0].ID)
+	}
+
+	// ExternalRefContains filter should also find it.
+	results, err = store.SearchIssues(ctx, "", types.IssueFilter{ExternalRefContains: "BE-1521"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("ExternalRefContains filter: expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != issue.ID {
+		t.Errorf("expected %s, got %s", issue.ID, results[0].ID)
+	}
+
+	// Unrelated query should not match.
+	results, err = store.SearchIssues(ctx, "BE-9999", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results for unrelated external ref, got %d", len(results))
+	}
+}
+
 func TestSearchIssues_ByID(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/schema_parity_test.go
+++ b/internal/storage/dolt/schema_parity_test.go
@@ -233,10 +233,12 @@ func TestSearchWispsFilterParity(t *testing.T) {
 	now := time.Now().UTC()
 	past := now.Add(-24 * time.Hour)
 	future := now.Add(24 * time.Hour)
+	externalRef := "https://linear.app/example-org/issue/EX-1"
 	wisp := &types.Issue{
 		Title:       "test wisp for filter parity",
 		Description: "description text here",
 		Notes:       "some notes content",
+		ExternalRef: &externalRef,
 		Status:      types.StatusOpen,
 		Priority:    2,
 		IssueType:   "task",
@@ -293,6 +295,7 @@ func TestSearchWispsFilterParity(t *testing.T) {
 	search("TitleContains", types.IssueFilter{TitleContains: "parity"})
 	search("DescriptionContains", types.IssueFilter{DescriptionContains: "description"})
 	search("NotesContains", types.IssueFilter{NotesContains: "notes"})
+	search("ExternalRefContains", types.IssueFilter{ExternalRefContains: "linear"})
 	search("Labels", types.IssueFilter{Labels: []string{"test-label"}})
 	search("LabelsAny", types.IssueFilter{LabelsAny: []string{"test-label", "other"}})
 	search("Pinned true", types.IssueFilter{Pinned: &boolTrue})

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -231,6 +231,10 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 		whereClauses = append(whereClauses, "notes LIKE ?")
 		args = append(args, "%"+filter.NotesContains+"%")
 	}
+	if filter.ExternalRefContains != "" {
+		whereClauses = append(whereClauses, "external_ref LIKE ?")
+		args = append(args, "%"+filter.ExternalRefContains+"%")
+	}
 
 	// Status
 	if filter.Status != nil {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -930,6 +930,7 @@ type IssueFilter struct {
 	TitleContains       string
 	DescriptionContains string
 	NotesContains       string
+	ExternalRefContains string
 
 	// Date ranges
 	CreatedAfter  *time.Time


### PR DESCRIPTION
Free-text ID-like queries (e.g. "BE-1521") now also match against external_ref, so issues linked to Linear tickets can be found without knowing their beads ID. Adds --external-contains flag for explicit substring search. Patches the duplicate filter block in transaction.go and adds integration tests.

```
[greg@Gregorys-MacBook-Pro:~/work] [main]  [12:49PM]
λ bd search BE-1521
No issues found matching 'BE-1521'
[greg@Gregorys-MacBook-Pro:~/work] [main]  [12:49PM]
λ ~/git/beads/bd search BE-1521
Found 1 issues matching 'BE-1521':
be-f8eckh [P3] [task] in_progress @gregory.collins@XXXXXXXXX.com - Migrate EmailUtils across all services
```