### PR TITLE
Fix DOLT_PULL merge conflict under autocommit

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -783,6 +783,11 @@ func buildServerDSN(cfg *Config, database string) string {
 // execWithLongTimeout opens a one-shot database connection with readTimeout=5m
 // and executes the given query. Push/pull operations can exceed the default
 // readTimeout when the server performs network I/O to git remotes.
+//
+// The query is wrapped in an explicit transaction (BEGIN/COMMIT) so that
+// DOLT_PULL merge operations succeed even when the server runs with
+// autocommit=1. Without this, Dolt rejects merges under autocommit because
+// it cannot expose conflict-resolution tables to the caller.
 func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args ...any) error {
 	cfg, err := mysql.ParseDSN(s.connStr)
 	if err != nil {
@@ -795,8 +800,15 @@ func (s *DoltStore) execWithLongTimeout(ctx context.Context, query string, args 
 	}
 	defer db.Close()
 	db.SetMaxOpenConns(1)
-	_, err = db.ExecContext(ctx, query, args...)
-	return err
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	return tx.Commit()
 }
 
 // openServerConnection opens a connection to a dolt sql-server via MySQL protocol


### PR DESCRIPTION
## Summary

- `bd dolt pull` fails with "Merge conflict detected, @autocommit transaction rolled back" when the remote has diverged, even for clean merges
- Root cause: `execWithLongTimeout` runs `CALL DOLT_PULL` with autocommit=1 (server default). Dolt requires autocommit off for merge operations
- Fix: wrap the query in an explicit `BEGIN`/`COMMIT` transaction, matching how `execContext` already handles writes

## Reproduction

Use two machines pushing to the same Dolt remote (HTTP remotesapi). After both push independently, the next `bd dolt pull` on either machine fails:

```
Error: failed to pull from origin/main: Error 1105 (HY000): Merge conflict detected,
@autocommit transaction rolled back.
```

Workaround before fix: `cd .beads/dolt && dolt sql -q "SET autocommit = 0; CALL dolt_pull('origin', 'main');"`

## Test plan

- [x] `go build ./...` passes
- [x] `TestExecWithLongTimeoutDSNRewrite` passes
- [ ] Manual test: two machines pushing/pulling to same remote no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)