### PR TITLE
fix: prevent dolt journal corruption from concurrent server starts

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -439,13 +439,6 @@ func EnsureRunning(beadsDir string) (int, error) {
 		return state.Port, nil
 	}
 
-	// Clean up orphaned dolt sql-server processes before starting a new one.
-	// Without this, servers accumulate when parent processes crash or are
-	// force-killed without graceful shutdown (GH#2372).
-	if killed, err := KillStaleServers(serverDir); err == nil && len(killed) > 0 {
-		fmt.Fprintf(os.Stderr, "Info: cleaned up %d orphaned dolt sql-server process(es)\n", len(killed))
-	}
-
 	s, err := Start(serverDir)
 	if err != nil {
 		return 0, err
@@ -493,6 +486,15 @@ func Start(beadsDir string) (*State, error) {
 	// Re-check after acquiring lock (double-check pattern)
 	if state, _ := IsRunning(beadsDir); state != nil && state.Running {
 		return state, nil
+	}
+
+	// Clean up orphaned dolt sql-server processes INSIDE the lock.
+	// This MUST happen under the lock to prevent a race where one process
+	// kills a server that another process is in the middle of starting
+	// (PID file not yet written). Without this, concurrent bd processes
+	// can cause journal corruption (GH#2430).
+	if killed, killErr := KillStaleServers(beadsDir); killErr == nil && len(killed) > 0 {
+		fmt.Fprintf(os.Stderr, "Info: cleaned up %d orphaned dolt sql-server process(es)\n", len(killed))
 	}
 
 	// Ensure dolt binary exists


### PR DESCRIPTION
## Summary

- Fixes a race condition where `KillStaleServers()` ran outside the flock in `EnsureRunning()`, allowing one `bd` process to kill a server that another process was actively starting (PID file not yet written)
- Moves `KillStaleServers()` inside `Start()` after the exclusive flock is acquired, making orphan cleanup and server start atomic
- Root cause of journal corruption reported in GH#2430: concurrent `dolt sql-server` instances writing to the same journal file

## Test plan

- [x] `go build ./internal/doltserver/` compiles
- [x] `go test ./internal/doltserver/` passes
- [ ] Verify with concurrent `bd` commands that only one server starts (manual test with multiple terminals)

Fixes #2430

🤖 Generated with [Claude Code](https://claude.com/claude-code)