### PR TITLE
feat: support global ~/.config/beads/PRIME.md fallback (GH#2330)

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -23,6 +23,26 @@ var (
 	primeExportMode  bool
 )
 
+// resolveGlobalPrimePath returns the path to ~/.config/beads/PRIME.md if it
+// exists. configDirOverride is used for testing; pass "" for production.
+func resolveGlobalPrimePath(configDirOverride string) string {
+	var configDir string
+	if configDirOverride != "" {
+		configDir = configDirOverride
+	} else {
+		var err error
+		configDir, err = os.UserConfigDir()
+		if err != nil {
+			return ""
+		}
+	}
+	p := filepath.Join(configDir, "beads", "PRIME.md")
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	return ""
+}
+
 var primeCmd = &cobra.Command{
 	Use:     "prime",
 	GroupID: "setup",
@@ -85,6 +105,14 @@ Workflow customization:
 			if content, err := os.ReadFile(redirectedPrimePath); err == nil {
 				fmt.Print(string(content))
 				return
+			}
+			// Fall back to global config (~/.config/beads/PRIME.md)
+			// #nosec G304 -- path constructed from UserConfigDir which we control
+			if globalPath := resolveGlobalPrimePath(""); globalPath != "" {
+				if content, err := os.ReadFile(globalPath); err == nil {
+					fmt.Print(string(content))
+					return
+				}
 			}
 		}
 

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -185,5 +187,42 @@ func stubPrimeHasGitRemote(hasRemote bool) func() {
 	}
 	return func() {
 		primeHasGitRemote = original
+	}
+}
+
+func TestPrimeGlobalFallback(t *testing.T) {
+	// Create a temp directory to act as config dir
+	tmpDir := t.TempDir()
+	beadsConfigDir := filepath.Join(tmpDir, "beads")
+	if err := os.MkdirAll(beadsConfigDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	content := "# Global PRIME override\nCustom instructions here.\n"
+	if err := os.WriteFile(filepath.Join(beadsConfigDir, "PRIME.md"), []byte(content), 0644); err != nil {
+		t.Fatalf("write PRIME.md: %v", err)
+	}
+
+	// Call the helper that resolves the global prime path
+	got := resolveGlobalPrimePath(tmpDir)
+	if got == "" {
+		t.Fatal("resolveGlobalPrimePath returned empty, want path to global PRIME.md")
+	}
+
+	data, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", got, err)
+	}
+	if string(data) != content {
+		t.Errorf("content = %q, want %q", string(data), content)
+	}
+}
+
+func TestPrimeGlobalFallback_Missing(t *testing.T) {
+	// When no global PRIME.md exists, should return empty string
+	tmpDir := t.TempDir()
+	got := resolveGlobalPrimePath(tmpDir)
+	if got != "" {
+		t.Errorf("resolveGlobalPrimePath = %q, want empty for missing file", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `~/.config/beads/PRIME.md` as third fallback in the PRIME.md resolution chain
- Fallback order: local `.beads/PRIME.md` → redirected `beadsDir/PRIME.md` → global `~/.config/beads/PRIME.md` → default output
- Uses `os.UserConfigDir()` for cross-platform config directory resolution
- Closes #2330

## Test plan
- [x] Test: global PRIME.md found and returned (`TestPrimeGlobalFallback`)
- [x] Test: missing global PRIME.md returns empty (`TestPrimeGlobalFallback_Missing`)
- [x] All existing prime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>