### PR TITLE
fix: post-checkout hook warns when database is missing (GH#2327)

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -13,6 +13,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/git"
 )
 
@@ -851,6 +852,40 @@ func runPostCheckoutHook(args []string) int {
 	if exitCode := runChainedHook("post-checkout", args); exitCode != 0 {
 		return exitCode
 	}
+
+	// Only check on branch checkout (flag=1), not file checkout (flag=0)
+	if len(args) >= 3 && args[2] == "1" {
+		// Check if a beads workspace exists here but the database is missing.
+		// This happens on fresh clones or new branches where .beads/metadata.json
+		// is committed but the Dolt data directory is gitignored.
+		// Note: FindBeadsDir() takes no arguments — uses cwd and BEADS_DIR env.
+		beadsDir := beads.FindBeadsDir()
+		if beadsDir != "" {
+			// Workspace found — check if the database is actually usable
+			metadataPath := filepath.Join(beadsDir, "metadata.json")
+			if _, metaErr := os.Stat(metadataPath); metaErr == nil {
+				cfg, cfgErr := configfile.Load(beadsDir)
+				if cfgErr != nil {
+					// Can't load config — skip warning to avoid false positives
+				} else if cfg != nil && cfg.IsDoltServerMode() {
+					// Server mode — database is remote, no local dir needed
+				} else {
+					var dbPath string
+					if cfg != nil {
+						dbPath = cfg.DatabasePath(beadsDir)
+					} else {
+						dbPath = filepath.Join(beadsDir, "dolt")
+					}
+					if _, doltErr := os.Stat(dbPath); os.IsNotExist(doltErr) {
+						fmt.Fprintf(os.Stderr, "beads: database not initialized on this branch.\n")
+						fmt.Fprintf(os.Stderr, "  Run 'bd init' to set up your local database.\n")
+						fmt.Fprintf(os.Stderr, "  Run 'bd doctor' to diagnose issues.\n")
+					}
+				}
+			}
+		}
+	}
+
 	return 0
 }
 

--- a/cmd/bd/hooks_test.go
+++ b/cmd/bd/hooks_test.go
@@ -1,0 +1,70 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPostCheckoutHook_NoWarningInServerMode(t *testing.T) {
+	// In Dolt server mode, .beads/dolt/ doesn't exist locally — that's expected.
+	// The hook should NOT print a warning.
+	tmpDir := newGitRepo(t)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	// metadata.json with server mode
+	meta := `{"dolt_mode":"server","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(meta), 0644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+	// No .beads/dolt/ — this is expected in server mode
+
+	runInDir(t, tmpDir, func() {
+		output := captureStderr(t, func() {
+			exitCode := runPostCheckoutHook([]string{"abc1234", "def5678", "1"})
+			if exitCode != 0 {
+				t.Errorf("post-checkout exit code = %d, want 0", exitCode)
+			}
+		})
+
+		if strings.Contains(output, "bd init") {
+			t.Errorf("post-checkout should NOT warn in server mode, but got: %q", output)
+		}
+	})
+}
+
+func TestPostCheckoutHook_PrintsWarningWhenDBMissing(t *testing.T) {
+	// runPostCheckoutHook should return 0 (never block git)
+	// but when it detects no database, it should print a helpful message
+	// to stderr so the user knows to run bd init.
+	tmpDir := newGitRepo(t)
+
+	// Create .beads/ with metadata.json so FindBeadsDir() recognizes workspace
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+	// Do NOT create .beads/dolt/ — simulates missing database
+
+	runInDir(t, tmpDir, func() {
+		output := captureStderr(t, func() {
+			exitCode := runPostCheckoutHook([]string{"abc1234", "def5678", "1"})
+			if exitCode != 0 {
+				t.Errorf("post-checkout exit code = %d, want 0 (must never block git)", exitCode)
+			}
+		})
+
+		if !strings.Contains(output, "bd init") {
+			t.Errorf("post-checkout warning should mention 'bd init', got: %q", output)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Post-checkout hook now detects missing Dolt database on branch checkout
- Prints actionable warning to stderr: suggests `bd init` and `bd doctor`
- Never blocks git operations (always returns exit 0)
- Only triggers on branch checkout (flag=1), not file checkout (flag=0)
- Properly handles Dolt server mode and custom `dolt_data_dir` (no false positives)
- Partially addresses #2327 (adds detection/warning; auto-recovery not yet implemented)

## Test plan
- [x] Test: warning printed when DB missing on branch checkout (`TestPostCheckoutHook_PrintsWarningWhenDBMissing`)
- [x] Test: no warning in Dolt server mode (`TestPostCheckoutHook_NoWarningInServerMode`)
- [x] Test: exit code is always 0
- [x] Test: warning mentions `bd init`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>