### PR TITLE
fix: suppress gosec G702 false positive on internal git helper

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -178,7 +178,7 @@ func isDetachedCommitWorktreePath(path string) bool {
 func gitOutput(dir string, args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...) //nolint:gosec // args are from internal callers, not user input
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Summary
- Adds `//nolint:gosec` to `gitOutput()` in `internal/beads/beads.go:181`
- The function only receives args from internal callers, not user input
- Unblocks CI lint for all open PRs

## Test plan
- [x] `golangci-lint run ./internal/beads/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)