### PR TITLE
feat: Load .beads/.env for per-project Dolt credentials

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/subosito/gotenv"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -486,6 +487,14 @@ var rootCmd = &cobra.Command{
 		doltCfg := &dolt.Config{
 			ReadOnly: useReadOnly,
 			BeadsDir: beadsDir,
+		}
+
+		// Load per-project .env file (non-overriding: shell env wins).
+		// Enables per-project Dolt credentials without global env vars.
+		// See https://github.com/steveyegge/beads/issues/2520
+		envFile := filepath.Join(beadsDir, ".env")
+		if _, statErr := os.Stat(envFile); statErr == nil {
+			_ = gotenv.Load(envFile)
 		}
 
 		// Load config to get database name and server connection settings

--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
-	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/subosito/gotenv v1.6.0
 	github.com/tealeg/xlsx v1.0.5 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect


### PR DESCRIPTION
## Summary

- Load `.beads/.env` into process environment before reading Dolt connection settings
- Uses `gotenv.Load()` (already an indirect dependency via viper) - non-overriding, shell env always wins
- 10 lines changed across 2 files

## Problem

No per-project way to configure Dolt credentials. With a mix of local and remote projects:

```
project-a/  → remote Dolt on VPS (needs BEADS_DOLT_* vars)
project-b/  → remote Dolt on VPS (different database)
project-c/  → local embedded Dolt (no remote)
```

Global env vars break `project-c`. No env vars break `project-a` and `project-b`. External tools (direnv, shell wrappers) only work in interactive terminals - not in AI coding agents (Claude Code, Cursor), CI/CD, or any tool that spawns `bd` as a subprocess.

## Solution

Load `.beads/.env` in `PersistentPreRun` after `beadsDir` is resolved but before `configfile.Load()`:

```go
envFile := filepath.Join(beadsDir, ".env")
if _, statErr := os.Stat(envFile); statErr == nil {
    _ = gotenv.Load(envFile)
}
```

Projects with `.beads/.env` connect to their configured server. Projects without it use local embedded Dolt (unchanged behavior).

## Test plan

- [ ] `bd ready` with `.beads/.env` pointing to remote server - connects to remote
- [ ] `bd ready` without `.beads/.env` - uses local embedded Dolt (no regression)
- [ ] `BEADS_DOLT_PASSWORD=override bd ready` with `.beads/.env` - shell env wins over file
- [ ] `.beads/.env` with comments and quoted values - parsed correctly by gotenv

Fixes #2520