### PR TITLE
feat: add --design-file flag for reading design from files

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -99,7 +99,7 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		design, _ := cmd.Flags().GetString("design")
+		design, _ := getDesignFlag(cmd)
 		acceptance, _ := cmd.Flags().GetString("acceptance")
 		notes, _ := cmd.Flags().GetString("notes")
 		specID, _ := cmd.Flags().GetString("spec-id")

--- a/cmd/bd/flags.go
+++ b/cmd/bd/flags.go
@@ -26,6 +26,8 @@ func registerCommonIssueFlags(cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive("stdin", "body")
 	cmd.MarkFlagsMutuallyExclusive("stdin", "message")
 	cmd.Flags().String("design", "", "Design notes")
+	cmd.Flags().String("design-file", "", "Read design from file (use - for stdin)")
+	cmd.MarkFlagsMutuallyExclusive("design", "design-file")
 	cmd.Flags().String("acceptance", "", "Acceptance criteria")
 	cmd.Flags().String("notes", "", "Additional notes")
 	cmd.Flags().String("append-notes", "", "Append to existing notes (with newline separator)")
@@ -168,6 +170,27 @@ func getDescriptionFlag(cmd *cobra.Command) (string, bool) {
 	}
 
 	return desc, descChanged
+}
+
+// getDesignFlag retrieves the design value from --design-file or --design.
+// Returns the value, whether any flag was explicitly changed, and any error.
+func getDesignFlag(cmd *cobra.Command) (string, bool) {
+	if cmd.Flags().Changed("design-file") {
+		path, _ := cmd.Flags().GetString("design-file")
+		content, err := readBodyFile(path)
+		if err != nil {
+			FatalError("reading from stin: %v", err)
+		}
+
+		return content, true
+	}
+
+	if cmd.Flags().Changed("design") {
+		v, _ := cmd.Flags().GetString("design")
+		return v, true
+	}
+
+	return "", false
 }
 
 // readBodyFile reads the description content from a file.

--- a/cmd/bd/flags_test.go
+++ b/cmd/bd/flags_test.go
@@ -340,3 +340,107 @@ func TestGetDescriptionFlag(t *testing.T) {
 		}
 	})
 }
+
+func TestGetDesignFlag(t *testing.T) {
+	// Helper to create a cobra command with common issue flags registered
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use: "test",
+			Run: func(cmd *cobra.Command, args []string) {},
+		}
+		registerCommonIssueFlags(cmd)
+		return cmd
+	}
+
+	t.Run("InlineDesignFlag", func(t *testing.T) {
+		cmd := newCmd()
+		if err := cmd.ParseFlags([]string{"--design", "inline design content"}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		got, changed := getDesignFlag(cmd)
+		if !changed {
+			t.Error("expected changed=true")
+		}
+		if got != "inline design content" {
+			t.Errorf("expected 'inline design content', got %q", got)
+		}
+	})
+
+	t.Run("DesignFileFlag", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "design.md")
+		content := "## Architecture\n\nUse microservices.\n"
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+
+		cmd := newCmd()
+		if err := cmd.ParseFlags([]string{"--design-file", filePath}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		got, changed := getDesignFlag(cmd)
+		if !changed {
+			t.Error("expected changed=true")
+		}
+		if got != content {
+			t.Errorf("expected %q, got %q", content, got)
+		}
+	})
+
+	t.Run("DesignFileStdin", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("failed to create pipe: %v", err)
+		}
+		oldStdin := os.Stdin
+		os.Stdin = r
+		t.Cleanup(func() { os.Stdin = oldStdin })
+
+		content := "Design from stdin\nWith multiple lines\n"
+		go func() {
+			w.WriteString(content)
+			w.Close()
+		}()
+
+		cmd := newCmd()
+		if err := cmd.ParseFlags([]string{"--design-file", "-"}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		got, changed := getDesignFlag(cmd)
+		if !changed {
+			t.Error("expected changed=true")
+		}
+		if got != content {
+			t.Errorf("expected %q, got %q", content, got)
+		}
+	})
+
+	t.Run("NoFlagsSet", func(t *testing.T) {
+		cmd := newCmd()
+		if err := cmd.ParseFlags([]string{}); err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		got, changed := getDesignFlag(cmd)
+		if changed {
+			t.Error("expected changed=false when no flags set")
+		}
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("MutualExclusionRegistered", func(t *testing.T) {
+		cmd := newCmd()
+		// Verify both flags are registered
+		if cmd.Flags().Lookup("design") == nil {
+			t.Fatal("expected --design flag to be registered")
+		}
+		if cmd.Flags().Lookup("design-file") == nil {
+			t.Fatal("expected --design-file flag to be registered")
+		}
+	})
+}

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -94,8 +94,8 @@ create, update, show, or close operation).`,
 		if descChanged {
 			updates["description"] = description
 		}
-		if cmd.Flags().Changed("design") {
-			design, _ := cmd.Flags().GetString("design")
+		design, designChanged := getDesignFlag(cmd)
+		if designChanged {
 			updates["design"] = design
 		}
 		if cmd.Flags().Changed("notes") && cmd.Flags().Changed("append-notes") {

--- a/cmd/bd/update_edge_cases_test.go
+++ b/cmd/bd/update_edge_cases_test.go
@@ -390,6 +390,36 @@ func TestCLI_UpdateDesignField(t *testing.T) {
 	}
 }
 
+// TestCLI_UpdateDesignFile tests setting the design field via --design-file.
+func TestCLI_UpdateDesignFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow CLI test in short mode")
+	}
+	tmpDir := setupCLITestDB(t)
+
+	out := runBDInProcess(t, tmpDir, "create", "Design file test", "-p", "1", "--json")
+	var issue map[string]interface{}
+	json.Unmarshal([]byte(out), &issue)
+	id := issue["id"].(string)
+
+	// Write design content to a temp file
+	designText := "## Architecture\n\nUse microservices pattern with gRPC."
+	designFile := filepath.Join(tmpDir, "design.md")
+	if err := os.WriteFile(designFile, []byte(designText), 0644); err != nil {
+		t.Fatalf("failed to write design file: %v", err)
+	}
+
+	runBDInProcess(t, tmpDir, "update", id, "--design-file", designFile)
+
+	out = runBDInProcess(t, tmpDir, "show", id, "--json")
+	var updated []map[string]interface{}
+	json.Unmarshal([]byte(out), &updated)
+	got, _ := updated[0]["design"].(string)
+	if got != designText {
+		t.Errorf("Expected design=%q, got: %q", designText, got)
+	}
+}
+
 // TestCLI_UpdateAcceptanceCriteria tests the --acceptance flag.
 func TestCLI_UpdateAcceptanceCriteria(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Adds support for reading design content from files or stdin, making it easier to manage longer design notes. The new `--design-file` flag is mutually exclusive with the inline `--design` flag. Includes comprehensive tests for all code paths.