### PR TITLE
fix: bd list ready rejects bare keyword with hint to use --ready (GH#2532)

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -223,10 +223,35 @@ func sortIssues(issues []*types.Issue, sortBy string, reverse bool) {
 	})
 }
 
+// knownListFlags maps bare words that users might pass as positional args
+// but are actually flag names. Each maps to a hint for the error message.
+var knownListFlags = map[string]string{
+	"ready":   "--ready",
+	"tree":    "--tree",
+	"flat":    "--flat",
+	"all":     "--all",
+	"long":    "--long",
+	"watch":   "--watch",
+	"pretty":  "--pretty",
+	"pinned":  "--pinned",
+	"overdue": "--overdue",
+}
+
 var listCmd = &cobra.Command{
 	Use:     "list",
 	GroupID: "issues",
 	Short:   "List issues",
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return nil
+		}
+		for _, arg := range args {
+			if hint, ok := knownListFlags[arg]; ok {
+				return fmt.Errorf("unknown argument %q; did you mean %q or 'bd %s'?", arg, hint, arg)
+			}
+		}
+		return fmt.Errorf("bd list does not accept positional arguments; use flags instead (see bd list --help)")
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		status, _ := cmd.Flags().GetString("status")
 		// --state is alias for --status (desire path: bd-9h3w)

--- a/cmd/bd/simple_helpers_test.go
+++ b/cmd/bd/simple_helpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -41,6 +42,57 @@ func TestParseLabelArgs(t *testing.T) {
 
 			if label != tt.expectLabel {
 				t.Errorf("Expected label %q, got %q", tt.expectLabel, label)
+			}
+		})
+	}
+}
+
+func TestListRejectsPositionalArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:    "no args is fine",
+			args:    []string{},
+			wantErr: false,
+		},
+		{
+			name:      "ready is rejected with hint",
+			args:      []string{"ready"},
+			wantErr:   true,
+			errSubstr: `did you mean "--ready"`,
+		},
+		{
+			name:      "tree is rejected with hint",
+			args:      []string{"tree"},
+			wantErr:   true,
+			errSubstr: `did you mean "--tree"`,
+		},
+		{
+			name:      "unknown arg is rejected generically",
+			args:      []string{"foobar"},
+			wantErr:   true,
+			errSubstr: "does not accept positional arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := listCmd.Args(listCmd, tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Expected error for args %v, got nil", tt.args)
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("Error %q should contain %q", err.Error(), tt.errSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for args %v: %v", tt.args, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`bd list ready` silently ignores the positional arg and returns an unfiltered list, while `bd list --ready` works correctly. This is confusing and error-prone in scripts.

## Fix

Added an `Args` validator to `listCmd` that:
- Catches common bare-word mistakes (`ready`, `tree`, `flat`, `all`, etc.) and prints a targeted hint: `unknown argument "ready"; did you mean "--ready" or 'bd ready'?`
- Rejects any other positional args with: `bd list does not accept positional arguments; use flags instead`

## Tests

4 new test cases in `TestListRejectsPositionalArgs`: no args (ok), `ready` (hint), `tree` (hint), unknown word (generic error).

Closes #2532