### PR TITLE
fix: respect BD_BACKUP_ENABLED=false to suppress backup commits (GH#2534)

### DIFF
--- a/cmd/bd/backup_auto_test.go
+++ b/cmd/bd/backup_auto_test.go
@@ -14,19 +14,19 @@ func TestIsBackupAutoEnabled(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		envVal     string // "" = not set (use default), "true"/"false" = explicit
+		envVal     string // "\x00" = not set, "" = set to empty, "true"/"false"/"0" = explicit
 		hasRemote  bool
 		wantResult bool
 	}{
 		{
 			name:       "default + git remote → enabled",
-			envVal:     "",
+			envVal:     "\x00",
 			hasRemote:  true,
 			wantResult: true,
 		},
 		{
 			name:       "default + no git remote → disabled",
-			envVal:     "",
+			envVal:     "\x00",
 			hasRemote:  false,
 			wantResult: false,
 		},
@@ -42,6 +42,18 @@ func TestIsBackupAutoEnabled(t *testing.T) {
 			hasRemote:  true,
 			wantResult: false,
 		},
+		{
+			name:       "explicit 0 + remote → disabled",
+			envVal:     "0",
+			hasRemote:  true,
+			wantResult: false,
+		},
+		{
+			name:       "empty string + remote → disabled (env set = explicit)",
+			envVal:     "",
+			hasRemote:  true,
+			wantResult: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -51,12 +63,12 @@ func TestIsBackupAutoEnabled(t *testing.T) {
 			primeHasGitRemote = func() bool { return tt.hasRemote }
 			t.Cleanup(func() { primeHasGitRemote = orig })
 
-			// Set env var if needed (simulates explicit config)
-			if tt.envVal != "" {
-				t.Setenv("BD_BACKUP_ENABLED", tt.envVal)
-			} else {
+			// Set env var: "\x00" = unset, anything else = set to that value
+			if tt.envVal == "\x00" {
 				os.Unsetenv("BD_BACKUP_ENABLED")
 				t.Cleanup(func() { os.Unsetenv("BD_BACKUP_ENABLED") })
+			} else {
+				t.Setenv("BD_BACKUP_ENABLED", tt.envVal)
 			}
 
 			config.ResetForTesting()
@@ -78,20 +90,20 @@ func TestIsBackupGitPushEnabled(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		envVal     string // "" = not set (use default), "true"/"false" = explicit
+		envVal     string // "\x00" = not set, "" = set to empty, "true"/"false" = explicit
 		hasRemote  bool
 		noGitOps   bool // simulate stealth mode
 		wantResult bool
 	}{
 		{
 			name:       "default + git remote → disabled (git-push requires explicit opt-in)",
-			envVal:     "",
+			envVal:     "\x00",
 			hasRemote:  true,
 			wantResult: false,
 		},
 		{
 			name:       "default + no remote → disabled",
-			envVal:     "",
+			envVal:     "\x00",
 			hasRemote:  false,
 			wantResult: false,
 		},
@@ -109,7 +121,7 @@ func TestIsBackupGitPushEnabled(t *testing.T) {
 		},
 		{
 			name:       "stealth mode overrides default + remote",
-			envVal:     "",
+			envVal:     "\x00",
 			hasRemote:  true,
 			noGitOps:   true,
 			wantResult: false,
@@ -130,12 +142,12 @@ func TestIsBackupGitPushEnabled(t *testing.T) {
 			primeHasGitRemote = func() bool { return tt.hasRemote }
 			t.Cleanup(func() { primeHasGitRemote = orig })
 
-			// Set env var if needed (simulates explicit config)
-			if tt.envVal != "" {
-				t.Setenv("BD_BACKUP_GIT_PUSH", tt.envVal)
-			} else {
+			// Set env var: "\x00" = unset, anything else = set to that value
+			if tt.envVal == "\x00" {
 				os.Unsetenv("BD_BACKUP_GIT_PUSH")
 				t.Cleanup(func() { os.Unsetenv("BD_BACKUP_GIT_PUSH") })
+			} else {
+				t.Setenv("BD_BACKUP_GIT_PUSH", tt.envVal)
 			}
 			// Also clear the backup.enabled env to not interfere
 			os.Unsetenv("BD_BACKUP_ENABLED")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,17 +272,18 @@ func GetValueSource(key string) ConfigSource {
 		return SourceDefault
 	}
 
-	// Check if value is set from environment variable
-	// Viper's IsSet returns true if the key is set from any source (env, config, or default)
-	// We need to check specifically for env var by looking at the env var directly
+	// Check if value is set from environment variable.
+	// Use LookupEnv (not Getenv) so that explicitly-set-but-empty vars like
+	// BD_BACKUP_ENABLED= are recognized as "set by the user" rather than
+	// falling through to the default/auto-detect path.
 	envKey := "BD_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
-	if os.Getenv(envKey) != "" {
+	if _, ok := os.LookupEnv(envKey); ok {
 		return SourceEnvVar
 	}
 
 	// Check BEADS_ prefixed env vars for legacy compatibility
 	beadsEnvKey := "BEADS_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
-	if os.Getenv(beadsEnvKey) != "" {
+	if _, ok := os.LookupEnv(beadsEnvKey); ok {
 		return SourceEnvVar
 	}
 
@@ -343,18 +344,15 @@ func CheckOverrides(flagOverrides map[string]struct {
 		for _, key := range v.AllKeys() {
 			envSource := GetValueSource(key)
 			if envSource == SourceEnvVar && v.InConfig(key) {
-				// Env var is overriding config file value
-				// Get the config file value by temporarily unsetting the env
+				// Env var is overriding config file value.
+				// Use LookupEnv to detect presence — empty-string env vars
+				// are still intentional overrides.
 				envKey := "BD_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
-				envValue := os.Getenv(envKey)
-				if envValue == "" {
+				if _, ok := os.LookupEnv(envKey); !ok {
 					envKey = "BEADS_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
-					envValue = os.Getenv(envKey)
-				}
-
-				// Skip if no env var actually set (shouldn't happen but be safe)
-				if envValue == "" {
-					continue
+					if _, ok := os.LookupEnv(envKey); !ok {
+						continue
+					}
 				}
 
 				overrides = append(overrides, ConfigOverride{


### PR DESCRIPTION
## Summary

`BD_BACKUP_ENABLED=false` was ignored — backup commits still appeared because `GetValueSource()` used `os.Getenv(envKey) != ""` which can't distinguish "not set" from "set to empty/falsy value".

## Root Cause

`os.Getenv` returns `""` for both unset and empty-string values. When the env var was set to `false`, `0`, or empty, `GetValueSource` fell through to `SourceDefault`, causing `isBackupAutoEnabled()` to use the auto-detect path (`primeHasGitRemote()`) which enables backup when a remote exists.

## Fix

Replaced `os.Getenv(envKey) != ""` with `os.LookupEnv(envKey)` in both `GetValueSource()` and `CheckOverrides()`. `LookupEnv` returns a boolean indicating whether the variable exists, regardless of value.

## Tests

Added 2 new test cases to `TestIsBackupAutoEnabled`:
- `BD_BACKUP_ENABLED=0` + remote → disabled ✅
- `BD_BACKUP_ENABLED=` (empty) + remote → disabled ✅

All 8 backup-auto + 6 backup-git-push + 57 config tests pass.

Closes #2534