### PR TITLE
cmd/bd: teach bd prime to use --claim

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -442,7 +442,7 @@ git push                    # Push to remote
 ### Creating & Updating
 - ` + "`bd create --title=\"Summary of this issue\" --description=\"Why this issue exists and what needs to be done\" --type=task|bug|feature --priority=2`" + ` - New issue
   - Priority: 0-4 or P0-P4 (0=critical, 2=medium, 4=backlog). NOT "high"/"medium"/"low"
-- ` + "`bd update <id> --status=in_progress`" + ` - Claim work
+- ` + "`bd update <id> --claim`" + ` - Claim work
 - ` + "`bd update <id> --assignee=username`" + ` - Assign to someone
 - ` + "`bd update <id> --title/--description/--notes/--design`" + ` - Update fields inline
 - ` + "`bd close <id>`" + ` - Mark complete
@@ -468,7 +468,7 @@ git push                    # Push to remote
 ` + "```bash" + `
 bd ready           # Find available work
 bd show <id>       # Review issue details
-bd update <id> --status=in_progress  # Claim it
+bd update <id> --claim  # Claim it
 ` + "```" + `
 
 ` + completingWorkflow + `

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -156,6 +156,24 @@ func TestOutputContextFunction(t *testing.T) {
 	}
 }
 
+func TestPrimeClaimGuidanceUsesAtomicClaim(t *testing.T) {
+	defer stubIsEphemeralBranch(false)()
+	defer stubPrimeHasGitRemote(true)()
+
+	var buf bytes.Buffer
+	if err := outputPrimeContext(&buf, false, false); err != nil {
+		t.Fatalf("outputPrimeContext failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "bd update <id> --claim") {
+		t.Fatal("prime output should teach bd update <id> --claim")
+	}
+	if strings.Contains(output, "bd update <id> --status=in_progress") {
+		t.Fatal("prime output should not teach bd update <id> --status=in_progress")
+	}
+}
+
 // stubIsEphemeralBranch temporarily replaces isEphemeralBranch
 // with a stub returning returnValue.
 //


### PR DESCRIPTION
## Summary
- update `bd prime` to teach `bd update <id> --claim` in the command reference and starting-work example
- add a regression test so stale `--status=in_progress` guidance does not come back

## Why
`bd update --help`, `README.md`, and other command surfaces already teach atomic claim syntax, but `cmd/bd/prime.go` still told users to use `--status=in_progress`.

Related: #2007

## Validation
- `go test -count=1 ./cmd/bd` passed 3 consecutive runs on clean `origin/main` (`a5827cb2`)
- `go test -count=1 ./cmd/bd` passed 3 consecutive runs on `codex/bd-prime-atomic-claim`
- `go test -count=1 ./cmd/bd/doctor ./internal/utils` matches on both sides: `cmd/bd/doctor` passes and `internal/utils` fails in `TestResolvePartialID_Wisp`
- `go test ./cmd/bd -run 'TestOnboardCommand|TestOutputContextFunction|TestPrimeClaimGuidanceUsesAtomicClaim'`
- `golangci-lint run ./cmd/bd/...`

## Repo-level test baseline
`make test` is currently red on latest `origin/main`, and it is also red on this branch. The reruns above are included to show that this patch does not worsen the changed package and that the unchanged noisy packages line up with upstream baseline behavior.