### PR TITLE
fix: handle BEADS_DB pointing to directory instead of file

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -426,7 +426,16 @@ func FindDatabasePath() string {
 
 	// 2. Check BEADS_DB environment variable (deprecated but still supported)
 	if envDB := os.Getenv("BEADS_DB"); envDB != "" {
-		return utils.CanonicalizePath(envDB)
+		absDB := utils.CanonicalizePath(envDB)
+		// If BEADS_DB points to a directory rather than a file, treat it
+		// like BEADS_DIR to avoid filepath.Dir() resolving one level too
+		// high in the caller (cmd/bd/main.go). See GH#2548.
+		if info, err := os.Stat(absDB); err == nil && info.IsDir() {
+			if dbPath := findDatabaseInBeadsDir(absDB, false); dbPath != "" {
+				return dbPath
+			}
+		}
+		return absDB
 	}
 
 	// 3. Search for .beads/*.db in current directory and ancestors

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -141,6 +141,128 @@ func TestFindDatabasePathNotFound(t *testing.T) {
 	_ = result
 }
 
+// TestFindDatabasePath_BEADS_DB_Directory tests that FindDatabasePath behaves
+// correctly when BEADS_DB points to a directory (like .beads/) rather than a
+// .db file. This is a regression test for a bug where main.go:476 does
+// beadsDir := filepath.Dir(dbPath), which resolves one level too high when
+// dbPath is a directory.
+//
+// With BEADS_DIR, FindDatabasePath returns .beads/dolt (a path inside .beads/),
+// so filepath.Dir() correctly yields .beads/. But with BEADS_DB pointing to
+// .beads/, it returns .beads/ itself, so filepath.Dir() yields the parent —
+// causing stray dolt/ directories and broken server connections.
+func TestFindDatabasePath_BEADS_DB_Directory(t *testing.T) {
+	// Save original env vars
+	originalDB := os.Getenv("BEADS_DB")
+	originalDir := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalDB != "" {
+			os.Setenv("BEADS_DB", originalDB)
+		} else {
+			os.Unsetenv("BEADS_DB")
+		}
+		if originalDir != "" {
+			os.Setenv("BEADS_DIR", originalDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+
+	// Create a .beads/ directory with dolt/ inside, mimicking a real project
+	tmpDir, err := os.MkdirTemp("", "beads-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o750); err != nil {
+		t.Fatalf("Failed to create dolt dir: %v", err)
+	}
+
+	// Resolve symlinks for comparison (macOS /var → /private/var)
+	beadsDirResolved, err := filepath.EvalSymlinks(beadsDir)
+	if err != nil {
+		beadsDirResolved = beadsDir
+	}
+
+	// Test with BEADS_DIR — this works correctly
+	os.Unsetenv("BEADS_DB")
+	os.Setenv("BEADS_DIR", beadsDir)
+	resultDir := FindDatabasePath()
+	resultDirResolved, _ := filepath.EvalSymlinks(resultDir)
+	derivedFromDir := filepath.Dir(resultDirResolved)
+	if derivedFromDir != beadsDirResolved {
+		t.Errorf("BEADS_DIR: filepath.Dir(FindDatabasePath()) = %q, want %q",
+			derivedFromDir, beadsDirResolved)
+	}
+
+	// Test with BEADS_DB pointing to the same directory — this is the bug.
+	// FindDatabasePath returns .beads/ itself (not .beads/dolt), so
+	// filepath.Dir() yields the parent directory instead of .beads/.
+	os.Unsetenv("BEADS_DIR")
+	os.Setenv("BEADS_DB", beadsDir)
+	resultDB := FindDatabasePath()
+	resultDBResolved, _ := filepath.EvalSymlinks(resultDB)
+	derivedFromDB := filepath.Dir(resultDBResolved)
+	if derivedFromDB != beadsDirResolved {
+		t.Errorf("BEADS_DB (directory): filepath.Dir(FindDatabasePath()) = %q, want %q\n"+
+			"FindDatabasePath returned %q — should return a path inside .beads/, not .beads/ itself",
+			derivedFromDB, beadsDirResolved, resultDBResolved)
+	}
+}
+
+// TestFindDatabasePath_BEADS_DB_DirectoryTrailingSlash verifies that a
+// trailing slash on BEADS_DB doesn't change the outcome — path canonicalization
+// strips it, so the same filepath.Dir() bug applies.
+func TestFindDatabasePath_BEADS_DB_DirectoryTrailingSlash(t *testing.T) {
+	originalDB := os.Getenv("BEADS_DB")
+	originalDir := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalDB != "" {
+			os.Setenv("BEADS_DB", originalDB)
+		} else {
+			os.Unsetenv("BEADS_DB")
+		}
+		if originalDir != "" {
+			os.Setenv("BEADS_DIR", originalDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+
+	tmpDir, err := os.MkdirTemp("", "beads-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o750); err != nil {
+		t.Fatalf("Failed to create dolt dir: %v", err)
+	}
+
+	beadsDirResolved, err := filepath.EvalSymlinks(beadsDir)
+	if err != nil {
+		beadsDirResolved = beadsDir
+	}
+
+	// Set BEADS_DB with trailing slash
+	os.Unsetenv("BEADS_DIR")
+	os.Setenv("BEADS_DB", beadsDir+string(filepath.Separator))
+
+	result := FindDatabasePath()
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	derived := filepath.Dir(resultResolved)
+	if derived != beadsDirResolved {
+		t.Errorf("BEADS_DB (trailing slash): filepath.Dir(FindDatabasePath()) = %q, want %q\n"+
+			"FindDatabasePath returned %q",
+			derived, beadsDirResolved, resultResolved)
+	}
+}
+
 // TestHasBeadsProjectFiles verifies that hasBeadsProjectFiles correctly
 // distinguishes between project directories and daemon-only directories (bd-420)
 func TestHasBeadsProjectFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `FindDatabasePath()` to detect when `BEADS_DB` points to a directory and delegate to `findDatabaseInBeadsDir()`, matching `BEADS_DIR` behavior
- Add regression tests for the directory and trailing-slash cases

Fixes #2548

## Problem

When `BEADS_DB` is set to a directory path (like `.beads/`), `FindDatabasePath()` returns the directory itself. The caller at `main.go:476` does `beadsDir := filepath.Dir(dbPath)`, which strips one level too many — yielding the parent of `.beads/` instead of `.beads/`. This causes:

- `ResolveDoltDir()` to create a stray `dolt/` directory at the parent level
- A second dolt server to start in the wrong location
- "database not found" errors on all subsequent commands

The `BEADS_DIR` code path works correctly because `findDatabaseInBeadsDir()` returns `.beads/dolt` (a path *inside* `.beads/`), so `filepath.Dir()` yields `.beads/`.

## Fix

When `BEADS_DB` points to a directory (not a file), treat it like `BEADS_DIR` by calling `findDatabaseInBeadsDir()` to look for the database inside it. This is a 6-line change in `internal/beads/beads.go`.

## Test plan

- [x] `TestFindDatabasePath_BEADS_DB_Directory` — verifies `filepath.Dir(FindDatabasePath())` resolves to `.beads/` for both `BEADS_DIR` and `BEADS_DB`-as-directory (failed before fix, passes after)
- [x] `TestFindDatabasePath_BEADS_DB_DirectoryTrailingSlash` — verifies trailing slash doesn't bypass the fix
- [x] All existing `FindDatabasePath` tests pass (`-short` mode)
- [x] `golangci-lint` passes with 0 issues