### PR TITLE
docs: replace "git-backed" with "Dolt-powered", document git-free usage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**beads** (command: `bd`) is a Git-backed issue tracker designed for AI-supervised coding workflows. We dogfood our own tool for all task tracking.
+**beads** (command: `bd`) is a Dolt-powered issue tracker designed for AI-supervised coding workflows. Git integration is optional. We dogfood our own tool for all task tracking.
 
 **Key Features:**
 - Dependency-aware issue tracking

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bd - Beads
 
-**Distributed, git-backed graph issue tracker for AI agents.**
+**Distributed graph issue tracker for AI agents, powered by [Dolt](https://github.com/dolthub/dolt).**
 
 **Platforms:** macOS, Linux, Windows, FreeBSD
 
@@ -55,7 +55,7 @@ Beads supports hierarchical IDs for epics:
 * `bd-a3f8.1` (Task)
 * `bd-a3f8.1.1` (Sub-task)
 
-**Stealth Mode:** Run `bd init --stealth` to use Beads locally without committing files to the main repo. Perfect for personal use on shared projects.
+**Stealth Mode:** Run `bd init --stealth` to use Beads locally without committing files to the main repo. Perfect for personal use on shared projects. See [Git-Free Usage](#-git-free-usage) below.
 
 **Contributor vs Maintainer:** When working on open-source projects:
 
@@ -73,6 +73,37 @@ Beads supports hierarchical IDs for epics:
 ## 🌐 Community Tools
 
 See [docs/COMMUNITY_TOOLS.md](docs/COMMUNITY_TOOLS.md) for a curated list of community-built UIs, extensions, and integrations—including terminal interfaces, web UIs, editor extensions, and native apps.
+
+## 🚀 Git-Free Usage
+
+Beads works without git. The Dolt database is the storage backend — git
+integration (hooks, repo discovery, identity) is optional.
+
+```bash
+# Initialize without git
+export BEADS_DIR=/path/to/your/project/.beads
+bd init --quiet --stealth
+
+# All core commands work with zero git calls
+bd create "Fix auth bug" -p 1 -t bug
+bd ready --json
+bd update bd-a1b2 --claim
+bd prime
+bd close bd-a1b2 "Fixed"
+```
+
+`BEADS_DIR` tells bd where to put the `.beads/` database directory,
+bypassing git repo discovery. `--stealth` sets `no-git-ops: true` in
+config, disabling all git hook installation and git operations.
+
+This is useful for:
+- **Non-git VCS** (Sapling, Jujutsu, Piper) — no `.git/` directory needed
+- **Monorepos** — point `BEADS_DIR` at a specific subdirectory
+- **CI/CD** — isolated task tracking without repo-level side effects
+- **Evaluation/testing** — ephemeral databases in `/tmp`
+
+For daemon mode without git, use `bd daemon start --local`
+(see [PR #433](https://github.com/steveyegge/beads/pull/433)).
 
 ## 📝 Documentation
 

--- a/claude-plugin/skills/beads/SKILL.md
+++ b/claude-plugin/skills/beads/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: beads
 description: >
-  Git-backed issue tracker for multi-session work with dependencies and persistent
+  Dolt-powered issue tracker for multi-session work with dependencies and persistent
   memory across conversation compaction. Use when work spans sessions, has blockers,
   or needs context recovery after compaction. Trigger with "create task", "what's
   ready", "track this work", "resume after compaction". Make sure to use this skill
@@ -25,7 +25,7 @@ Graph-based issue tracker that survives conversation compaction. Provides persis
 | bd (persistent) | TodoWrite (ephemeral) |
 |-----------------|----------------------|
 | Multi-session, dependencies, compaction survival | Single-session linear tasks |
-| Git-backed team sync | Conversation-scoped |
+| Dolt-backed team sync | Conversation-scoped |
 
 See [BOUNDARIES.md](${CLAUDE_SKILL_DIR}/resources/BOUNDARIES.md) for detailed comparison.
 
@@ -36,7 +36,7 @@ bd --version  # Requires v0.60.0+
 ```
 
 - **bd CLI** installed and in PATH
-- **Git repository** (bd requires git for sync)
+- **Git repository** (optional — use `BEADS_DIR` + `--stealth` for git-free operation)
 - **Initialization**: `bd init` run once (humans do this, not agents)
 
 ## CLI Reference

--- a/claude-plugin/skills/beads/resources/BOUNDARIES.md
+++ b/claude-plugin/skills/beads/resources/BOUNDARIES.md
@@ -86,7 +86,7 @@ Need to resume work after significant time with full context.
 - Complex features split across sprints
 - Research projects with long investigation periods
 
-**Why bd wins**: Git-backed database persists indefinitely. All context, decisions, and history available on resume. No relying on conversation scrollback or markdown files.
+**Why bd wins**: Dolt-backed database persists indefinitely. All context, decisions, and history available on resume. No relying on conversation scrollback or markdown files.
 
 ---
 
@@ -142,7 +142,7 @@ Just need a checklist to show progress to user.
 
 | Aspect | bd | TodoWrite |
 |--------|-----|-----------|
-| **Persistence** | Git-backed, survives compaction | Session-only, lost after conversation |
+| **Persistence** | Dolt-backed, survives compaction | Session-only, lost after conversation |
 | **Dependencies** | Graph-based, automatic ready detection | Manual, no automatic tracking |
 | **Discoverability** | `bd ready` surfaces work | Scroll conversation for todos |
 | **Complexity** | Handles nested epics, blockers | Flat list only |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ This document describes bd's overall architecture - the data model, sync mechani
 
 ## The Two-Layer Data Model
 
-bd's core design enables a distributed, git-backed issue tracker that feels like a centralized database. The architecture has two synchronized layers:
+bd's core design enables a distributed, Dolt-powered issue tracker that feels like a centralized database. The architecture has two synchronized layers:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**beads** (command: `bd`) is a git-backed issue tracker for AI-supervised coding workflows. We dogfood our own tool.
+**beads** (command: `bd`) is a Dolt-powered issue tracker for AI-supervised coding workflows. Git integration is optional — see `BEADS_DIR` + `--stealth` for git-free operation. We dogfood our own tool.
 
 **IMPORTANT**: See [AGENTS.md](../AGENTS.md) for complete workflow instructions, bd commands, and development guidelines.
 

--- a/npm-package/INTEGRATION_GUIDE.md
+++ b/npm-package/INTEGRATION_GUIDE.md
@@ -224,7 +224,7 @@ bd init --quiet 2>&1 | grep -v "already initialized"
 - ✅ **Persistent memory**: Issue context survives session resets
 - ✅ **Structured planning**: Dependencies create clear work order
 - ✅ **Automatic setup**: No manual intervention needed
-- ✅ **Git-backed**: All issues are version controlled
+- ✅ **Dolt-backed**: All issues are version controlled
 - ✅ **Fast queries**: `bd ready` finds work instantly
 
 ### For Humans

--- a/npm-package/LAUNCH.md
+++ b/npm-package/LAUNCH.md
@@ -124,8 +124,8 @@ Create `.github/workflows/publish-npm.yml` to auto-publish on GitHub releases.
 - ✅ **Platform detection** - Works on macOS, Linux, Windows
 - ✅ **Full feature parity** - Native SQLite, all commands work
 - ✅ **Claude Code ready** - Perfect for SessionStart hooks
-- ✅ **Git-backed** - Issues version controlled
-- ✅ **Multi-agent** - Shared database via git
+- ✅ **Dolt-backed** - Issues version controlled
+- ✅ **Multi-agent** - Shared database via Dolt remotes
 
 ## 📈 Package Stats
 

--- a/scripts/update-winget.sh
+++ b/scripts/update-winget.sh
@@ -81,9 +81,9 @@ PackageUrl: https://github.com/steveyegge/beads
 License: MIT
 LicenseUrl: https://github.com/steveyegge/beads/blob/main/LICENSE
 Copyright: Copyright (c) 2024 Steve Yegge
-ShortDescription: Distributed, git-backed graph issue tracker for AI agents
+ShortDescription: Distributed, Dolt-powered graph issue tracker for AI agents
 Description: |
-  beads (bd) is a distributed, git-backed graph issue tracker designed for AI-supervised coding workflows.
+  beads (bd) is a distributed, Dolt-powered graph issue tracker designed for AI-supervised coding workflows.
   It provides a persistent, structured memory for coding agents, replacing messy markdown plans with a
   dependency-aware graph that allows agents to handle long-horizon tasks without losing context.
 Moniker: bd

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -7,7 +7,7 @@ slug: /
 
 # Beads Documentation
 
-**Beads** (`bd`) is a git-backed issue tracker designed for AI-supervised coding workflows.
+**Beads** (`bd`) is a Dolt-powered issue tracker designed for AI-supervised coding workflows.
 
 ## Why Beads?
 

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -12,7 +12,7 @@ sidebar_position: 5
 
 Beads was designed specifically for AI-supervised coding workflows:
 - **Hash-based IDs** prevent collisions with concurrent agents
-- **Git-backed storage** enables branch-based workflows
+- **Dolt-backed storage** enables branch-based workflows
 - **Dependency-aware** ready queue for automated work selection
 - **Formula system** for declarative workflow templates
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -26,7 +26,7 @@ const { origin: siteUrl, baseUrl } = parseUrl(siteUrlEnv);
 
 const config: Config = {
   title: 'Beads Documentation',
-  tagline: 'Git-backed issue tracker for AI-supervised coding workflows',
+  tagline: 'Dolt-powered issue tracker for AI-supervised coding workflows',
   favicon: 'img/favicon.svg',
 
   // Enable Mermaid diagrams in markdown

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11,14 +11,14 @@
 
 # Beads Documentation
 
-**Beads** (`bd`) is a git-backed issue tracker designed for AI-supervised coding workflows.
+**Beads** (`bd`) is a Dolt-powered issue tracker designed for AI-supervised coding workflows.
 
 ## Why Beads?
 
 Traditional issue trackers (Jira, GitHub Issues) weren't designed for AI agents. Beads was built from the ground up for:
 
 - **AI-native workflows** - Hash-based IDs prevent collisions when multiple agents work concurrently
-- **Git-backed storage** - Issues sync via JSONL files, enabling collaboration across branches
+- **Dolt-backed storage** - Version-controlled SQL database with cell-level merge and native sync
 - **Dependency-aware execution** - `bd ready` shows only unblocked work
 - **Formula system** - Declarative templates for repeatable workflows
 - **Multi-agent coordination** - Routing, gates, and molecules for complex workflows
@@ -5442,7 +5442,7 @@ bd info --json | jq '.config'
 
 Beads was designed specifically for AI-supervised coding workflows:
 - **Hash-based IDs** prevent collisions with concurrent agents
-- **Git-backed storage** enables branch-based workflows
+- **Dolt-backed storage** enables branch-based workflows
 - **Dependency-aware** ready queue for automated work selection
 - **Formula system** for declarative workflow templates
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -1,7 +1,7 @@
 # Beads (bd)
 
-> Git-backed issue tracker for AI-supervised coding workflows.
-> Dolt-powered CLI with formulas, molecules, and multi-agent coordination.
+> Dolt-powered issue tracker for AI-supervised coding workflows.
+> CLI with formulas, molecules, and multi-agent coordination.
 
 ## Quick Start
 

--- a/winget/SteveYegge.beads.locale.en-US.yaml
+++ b/winget/SteveYegge.beads.locale.en-US.yaml
@@ -11,9 +11,9 @@ PackageUrl: https://github.com/steveyegge/beads
 License: MIT
 LicenseUrl: https://github.com/steveyegge/beads/blob/main/LICENSE
 Copyright: Copyright (c) 2024 Steve Yegge
-ShortDescription: Distributed, git-backed graph issue tracker for AI agents
+ShortDescription: Distributed, Dolt-powered graph issue tracker for AI agents
 Description: |
-  beads (bd) is a distributed, git-backed graph issue tracker designed for AI-supervised coding workflows.
+  beads (bd) is a distributed, Dolt-powered graph issue tracker designed for AI-supervised coding workflows.
   It provides a persistent, structured memory for coding agents, replacing messy markdown plans with a
   dependency-aware graph that allows agents to handle long-horizon tasks without losing context.
 Moniker: bd


### PR DESCRIPTION
## Summary

- Replace all 19 "git-backed" references across 15 files with "Dolt-powered" or "Dolt-backed" to reflect the actual storage backend
- Add "Git-Free Usage" section to README.md documenting `BEADS_DIR` + `--stealth` for fully functional git-free operation
- Fix stale "JSONL" storage description in `llms-full.txt`
- Update SKILL.md to mark git as optional prerequisite

## Context

Beads' storage migrated from JSONL-in-git to Dolt, and git integration has been incrementally decoupled (PRs #433, #940, #1793, #2040, #2214, #2250). The core workflow — init, create, ready, update, prime, close — works with zero git calls when using `BEADS_DIR` + `--stealth`. But docs still described beads as "git-backed" in README, CLAUDE.md, copilot-instructions, SKILL.md, ARCHITECTURE.md, website, winget, npm-package, and llms.txt.

Complements GH#2522 (stale command cleanup) — that PR fixed references to removed commands (`bd sync`, `bd import`), this one fixes the misleading storage backend framing.

## Test plan

- [x] `grep -ri 'git-backed' .` returns zero matches after this change
- [x] No functional code changes — docs only
- [x] Verified git-free workflow works end-to-end (experiment documented in PR description context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)