### PR TITLE
fix: make --title, --title-contains, --desc-contains case-insensitive

### DIFF
--- a/internal/storage/dolt/filters.go
+++ b/internal/storage/dolt/filters.go
@@ -60,24 +60,24 @@ func buildIssueFilterClauses(query string, filter types.IssueFilter, tables filt
 	}
 
 	if filter.TitleSearch != "" {
-		whereClauses = append(whereClauses, "title LIKE ?")
-		args = append(args, "%"+filter.TitleSearch+"%")
+		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.TitleSearch)+"%")
 	}
 	if filter.TitleContains != "" {
-		whereClauses = append(whereClauses, "title LIKE ?")
-		args = append(args, "%"+filter.TitleContains+"%")
+		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.TitleContains)+"%")
 	}
 	if filter.DescriptionContains != "" {
-		whereClauses = append(whereClauses, "description LIKE ?")
-		args = append(args, "%"+filter.DescriptionContains+"%")
+		whereClauses = append(whereClauses, "LOWER(description) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.DescriptionContains)+"%")
 	}
 	if filter.NotesContains != "" {
-		whereClauses = append(whereClauses, "notes LIKE ?")
-		args = append(args, "%"+filter.NotesContains+"%")
+		whereClauses = append(whereClauses, "LOWER(notes) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.NotesContains)+"%")
 	}
 	if filter.ExternalRefContains != "" {
-		whereClauses = append(whereClauses, "external_ref LIKE ?")
-		args = append(args, "%"+filter.ExternalRefContains+"%")
+		whereClauses = append(whereClauses, "LOWER(external_ref) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.ExternalRefContains)+"%")
 	}
 
 	// Status filters

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -254,24 +254,24 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 	}
 
 	if filter.TitleSearch != "" {
-		whereClauses = append(whereClauses, "title LIKE ?")
-		args = append(args, "%"+filter.TitleSearch+"%")
+		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.TitleSearch)+"%")
 	}
 	if filter.TitleContains != "" {
-		whereClauses = append(whereClauses, "title LIKE ?")
-		args = append(args, "%"+filter.TitleContains+"%")
+		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.TitleContains)+"%")
 	}
 	if filter.DescriptionContains != "" {
-		whereClauses = append(whereClauses, "description LIKE ?")
-		args = append(args, "%"+filter.DescriptionContains+"%")
+		whereClauses = append(whereClauses, "LOWER(description) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.DescriptionContains)+"%")
 	}
 	if filter.NotesContains != "" {
-		whereClauses = append(whereClauses, "notes LIKE ?")
-		args = append(args, "%"+filter.NotesContains+"%")
+		whereClauses = append(whereClauses, "LOWER(notes) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.NotesContains)+"%")
 	}
 	if filter.ExternalRefContains != "" {
-		whereClauses = append(whereClauses, "external_ref LIKE ?")
-		args = append(args, "%"+filter.ExternalRefContains+"%")
+		whereClauses = append(whereClauses, "LOWER(external_ref) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.ExternalRefContains)+"%")
 	}
 
 	// Status


### PR DESCRIPTION
Use `LOWER()` and `strings.ToLower()` for TitleSearch, TitleContains, DescriptionContains, NotesContains, and ExternalRefContains filters, matching the existing case-insensitive behavior of the text query filter.

Both `filters.go` and `transaction.go` had the same bug — the text query path correctly used `LOWER(title) LIKE ?` but the dedicated filter flags used bare `title LIKE ?`.

Fixes #2553