### PR TITLE
fix: bd context reports actual runtime Dolt port instead of default 3307

### DIFF
--- a/cmd/bd/context_cmd.go
+++ b/cmd/bd/context_cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltserver"
 )
 
 // ContextInfo contains the effective backend identity and repository context.
@@ -86,7 +87,11 @@ Examples:
 
 		if cfg.IsDoltServerMode() {
 			info.ServerHost = cfg.GetDoltServerHost()
-			info.ServerPort = cfg.GetDoltServerPort()
+			// Use doltserver.DefaultConfig to resolve the actual runtime port
+			// (from port file, env var, etc.) instead of the static config default.
+			// This matches what "bd dolt show" does (GH#2555).
+			dsCfg := doltserver.DefaultConfig(rc.BeadsDir)
+			info.ServerPort = dsCfg.Port
 		}
 
 		if dataDir := cfg.GetDoltDataDir(); dataDir != "" {


### PR DESCRIPTION
## Problem

`bd context` reports the legacy/default Dolt port (3307) instead of the actual runtime server port. `bd dolt show` correctly reports the dynamic port (e.g. 51158).

## Root Cause

`context_cmd.go` was using `cfg.GetDoltServerPort()` which reads from `metadata.json` and returns the default port (3307). Meanwhile `bd dolt show` uses `doltserver.DefaultConfig(beadsDir)` which resolves the actual runtime port from the port file, env var, config.yaml, etc.

## Fix

Use the same `doltserver.DefaultConfig()` resolution in the context command so both commands report consistent port information.

Fixes #2555