### PR TITLE
fix: EnsureRunning skips Start() when explicit port indicates external server

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -433,6 +433,12 @@ func IsRunning(beadsDir string) (*State, error) {
 // EnsureRunning starts the server if it is not already running.
 // This is the main auto-start entry point. Thread-safe via file lock.
 // Returns the port the server is listening on.
+//
+// When metadata.json specifies an explicit dolt_server_port (indicating an
+// external/shared server, e.g. managed by systemd), EnsureRunning will NOT
+// start a new server. The external server's lifecycle is not bd's
+// responsibility — starting a per-project server would conflict with (or
+// kill) the shared server. See GH#2554.
 func EnsureRunning(beadsDir string) (int, error) {
 	serverDir := resolveServerDir(beadsDir)
 
@@ -450,11 +456,38 @@ func EnsureRunning(beadsDir string) (int, error) {
 		return state.Port, nil
 	}
 
+	// Check whether the server is externally managed before starting.
+	// If metadata.json has an explicit dolt_server_port, the user has
+	// configured a shared/external server (e.g. systemd-managed). Do not
+	// start a per-project server — it would conflict with the external one.
+	if hasExplicitPort(beadsDir) {
+		cfg := DefaultConfig(beadsDir)
+		return 0, fmt.Errorf("Dolt server is not running on port %d, and auto-start is suppressed "+
+			"because an explicit server port is configured (external/shared server).\n\n"+
+			"Start the external server, or remove the explicit port configuration to allow auto-start.\n"+
+			"  To start manually: bd dolt start\n"+
+			"  To check status: bd dolt status", cfg.Port)
+	}
+
 	s, err := Start(serverDir)
 	if err != nil {
 		return 0, err
 	}
 	return s.Port, nil
+}
+
+// hasExplicitPort returns true if beadsDir's metadata.json has an explicit
+// dolt_server_port configured, indicating the server is externally managed.
+func hasExplicitPort(beadsDir string) bool {
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if _, err := os.Stat(metadataPath); err != nil {
+		return false
+	}
+	fileCfg, err := configfile.Load(beadsDir)
+	if err != nil || fileCfg == nil {
+		return false
+	}
+	return fileCfg.DoltServerPort > 0
 }
 
 // Start explicitly starts a dolt sql-server for the project.

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -900,6 +900,78 @@ func TestDefaultSharedServerPort_DiffersFromDefault(t *testing.T) {
 	}
 }
 
+// TestHasExplicitPort verifies that hasExplicitPort correctly detects
+// when metadata.json has an explicit dolt_server_port configured.
+func TestHasExplicitPort(t *testing.T) {
+	t.Run("no_metadata_file", func(t *testing.T) {
+		dir := t.TempDir()
+		if hasExplicitPort(dir) {
+			t.Error("expected false when metadata.json doesn't exist")
+		}
+	})
+
+	t.Run("metadata_without_port", func(t *testing.T) {
+		dir := t.TempDir()
+		// Write metadata.json without dolt_server_port
+		if err := os.WriteFile(filepath.Join(dir, "metadata.json"),
+			[]byte(`{"backend":"dolt"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if hasExplicitPort(dir) {
+			t.Error("expected false when metadata.json has no dolt_server_port")
+		}
+	})
+
+	t.Run("metadata_with_explicit_port", func(t *testing.T) {
+		dir := t.TempDir()
+		// Write metadata.json with explicit dolt_server_port
+		if err := os.WriteFile(filepath.Join(dir, "metadata.json"),
+			[]byte(`{"backend":"dolt","dolt_server_port":13446}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if !hasExplicitPort(dir) {
+			t.Error("expected true when metadata.json has dolt_server_port")
+		}
+	})
+
+	t.Run("metadata_with_zero_port", func(t *testing.T) {
+		dir := t.TempDir()
+		// Write metadata.json with dolt_server_port=0 (not a real explicit port)
+		if err := os.WriteFile(filepath.Join(dir, "metadata.json"),
+			[]byte(`{"backend":"dolt","dolt_server_port":0}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if hasExplicitPort(dir) {
+			t.Error("expected false when dolt_server_port is 0")
+		}
+	})
+}
+
+// TestEnsureRunning_ExplicitPortSuppressesStart verifies that EnsureRunning
+// does not start a server when metadata.json has an explicit dolt_server_port,
+// indicating the server is externally managed (e.g. systemd). GH#2554.
+func TestEnsureRunning_ExplicitPortSuppressesStart(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("GT_ROOT", "")
+
+	dir := t.TempDir()
+	// Write metadata.json with explicit port (simulating systemd-managed server)
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"),
+		[]byte(`{"backend":"dolt","dolt_server_port":13446}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := EnsureRunning(dir)
+	if err == nil {
+		t.Fatal("expected error when server not running and explicit port configured")
+	}
+	if !strings.Contains(err.Error(), "auto-start is suppressed") {
+		t.Errorf("expected 'auto-start is suppressed' in error, got: %v", err)
+	}
+}
+
 func TestDefaultConfig_SharedModeBeadsDir(t *testing.T) {
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "")


### PR DESCRIPTION
When `metadata.json` has `dolt_server_port` set, the Dolt server is externally managed (e.g. by systemd). `EnsureRunning` now checks for this before calling `Start()`, preventing it from launching a conflicting per-project server that would kill or shadow the shared server.

Adds `hasExplicitPort()` helper that checks `metadata.json` for a non-zero `dolt_server_port` value, mirroring the `explicitPort` check already used by `resolveAutoStart()` in `open.go`.

Fixes #2554