### PR TITLE
fix: stop auto-started dolt servers on DoltStore.Close()

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -434,6 +434,15 @@ func IsRunning(beadsDir string) (*State, error) {
 // This is the main auto-start entry point. Thread-safe via file lock.
 // Returns the port the server is listening on.
 func EnsureRunning(beadsDir string) (int, error) {
+	port, _, err := EnsureRunningDetailed(beadsDir)
+	return port, err
+}
+
+// EnsureRunningDetailed is like EnsureRunning but also reports whether a new
+// server was started (startedByUs=true) vs. an already-running server was
+// adopted (startedByUs=false). Callers that need to clean up auto-started
+// servers (e.g. test teardown) should use this variant.
+func EnsureRunningDetailed(beadsDir string) (port int, startedByUs bool, err error) {
 	serverDir := resolveServerDir(beadsDir)
 
 	// Inform when Gas Town is also running on this machine
@@ -443,18 +452,18 @@ func EnsureRunning(beadsDir string) (int, error) {
 
 	state, err := IsRunning(serverDir)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	if state.Running {
 		_ = EnsurePortFile(serverDir, state.Port)
-		return state.Port, nil
+		return state.Port, false, nil
 	}
 
 	s, err := Start(serverDir)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
-	return s.Port, nil
+	return s.Port, true, nil
 }
 
 // Start explicitly starts a dolt sql-server for the project.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -68,6 +68,40 @@ func isTestDatabaseName(name string) bool {
 	return false
 }
 
+// autoStartRefs tracks in-process reference counts for auto-started dolt
+// sql-server processes, keyed by resolved server directory. When the count
+// drops to zero, the server is stopped. This prevents test-started servers
+// from leaking (GH#2542) while allowing multiple stores to share one server.
+var autoStartRefs struct {
+	mu sync.Mutex
+	m  map[string]int
+}
+
+func autoStartAcquire(serverDir string) {
+	autoStartRefs.mu.Lock()
+	defer autoStartRefs.mu.Unlock()
+	if autoStartRefs.m == nil {
+		autoStartRefs.m = make(map[string]int)
+	}
+	autoStartRefs.m[serverDir]++
+}
+
+// autoStartRelease decrements the refcount for serverDir and stops the server
+// when it reaches zero. Returns any error from stopping the server.
+func autoStartRelease(serverDir string) error {
+	autoStartRefs.mu.Lock()
+	defer autoStartRefs.mu.Unlock()
+	if autoStartRefs.m == nil {
+		return nil
+	}
+	autoStartRefs.m[serverDir]--
+	if autoStartRefs.m[serverDir] <= 0 {
+		delete(autoStartRefs.m, serverDir)
+		return doltserver.Stop(serverDir)
+	}
+	return nil
+}
+
 // Compile-time interface check.
 var _ storage.DoltStorage = (*DoltStore)(nil)
 
@@ -110,6 +144,11 @@ type DoltStore struct {
 	remoteUser     string // Remote auth user for Hosted Dolt push/pull (optional)
 	remotePassword string // Remote auth password for Hosted Dolt push/pull (optional)
 	serverMode     bool   // true when connected to external dolt sql-server (not embedded)
+
+	// autoStartedServerDir is set when this store triggered a dolt sql-server
+	// auto-start. Close() uses it to stop the server when the last store
+	// referencing it is closed (tracked via testAutoStartRefs).
+	autoStartedServerDir string
 }
 
 // Config holds Dolt database configuration
@@ -581,6 +620,9 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		return nil, ErrCircuitOpen
 	}
 
+	// Tracks server dir if we auto-started a server (for cleanup in Close, GH#2542).
+	var autoStartedDir string
+
 	// Fail-fast TCP check before MySQL protocol initialization.
 	// This gives an immediate, clear error if the Dolt server isn't running,
 	// rather than waiting for MySQL driver timeouts.
@@ -593,12 +635,17 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			if beadsDir == "" {
 				beadsDir = filepath.Dir(cfg.Path) // fallback: cfg.Path is .beads/dolt → parent is .beads/
 			}
-			port, startErr := doltserver.EnsureRunning(beadsDir)
+			port, startedByUs, startErr := doltserver.EnsureRunningDetailed(beadsDir)
 			if startErr != nil {
 				return nil, fmt.Errorf("Dolt server unreachable at %s and auto-start failed: %w\n\n"+
 					"To start manually: bd dolt start\n"+
 					"To disable auto-start: set dolt.auto-start: false in .beads/config.yaml",
 					addr, startErr)
+			}
+			// Track auto-started servers so Close() can stop them (GH#2542).
+			if startedByUs {
+				autoStartedDir = doltserver.ResolveServerDir(beadsDir)
+				autoStartAcquire(autoStartedDir)
 			}
 			// Update port — EnsureRunning allocates an ephemeral port
 			if port != cfg.ServerPort {
@@ -613,6 +660,10 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			// Retry connection with longer timeout (server just started)
 			conn, dialErr = net.DialTimeout("tcp", addr, 2*time.Second)
 			if dialErr != nil {
+				// Release auto-start ref on connection failure
+				if autoStartedDir != "" {
+					_ = autoStartRelease(autoStartedDir)
+				}
 				breaker.RecordFailure()
 				return nil, fmt.Errorf("Dolt server auto-started but still unreachable at %s: %w\n\n"+
 					"Check logs: %s", addr, dialErr, doltserver.LogPath(beadsDir))
@@ -640,19 +691,20 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	}
 
 	store := &DoltStore{
-		db:             db,
-		dbPath:         cfg.Path,
-		database:       cfg.Database,
-		connStr:        connStr,
-		breaker:        breaker,
-		committerName:  cfg.CommitterName,
-		committerEmail: cfg.CommitterEmail,
-		remote:         cfg.Remote,
-		branch:         "main",
-		remoteUser:     cfg.RemoteUser,
-		remotePassword: cfg.RemotePassword,
-		serverMode:     true,
-		readOnly:       cfg.ReadOnly,
+		db:                   db,
+		dbPath:               cfg.Path,
+		database:             cfg.Database,
+		connStr:              connStr,
+		breaker:              breaker,
+		committerName:        cfg.CommitterName,
+		committerEmail:       cfg.CommitterEmail,
+		remote:               cfg.Remote,
+		branch:               "main",
+		remoteUser:           cfg.RemoteUser,
+		remotePassword:       cfg.RemotePassword,
+		serverMode:           true,
+		readOnly:             cfg.ReadOnly,
+		autoStartedServerDir: autoStartedDir,
 	}
 
 	// Schema initialization for server mode (idempotent).
@@ -1128,7 +1180,8 @@ func (s *DoltStore) IsClosed() bool {
 }
 
 // Close closes the database connection and removes any 0-byte noms LOCK files
-// left behind by the embedded Dolt engine.
+// left behind by the embedded Dolt engine. If this store auto-started a dolt
+// sql-server and is the last reference to it, the server is stopped (GH#2542).
 func (s *DoltStore) Close() error {
 	s.closed.Store(true)
 	s.mu.Lock()
@@ -1143,6 +1196,15 @@ func (s *DoltStore) Close() error {
 		}
 	}
 	s.db = nil
+
+	// Stop auto-started server when the last store referencing it closes.
+	if s.autoStartedServerDir != "" {
+		if stopErr := autoStartRelease(s.autoStartedServerDir); stopErr != nil {
+			// Best-effort: don't mask other errors
+			fmt.Fprintf(os.Stderr, "Warning: failed to stop auto-started dolt server: %v\n", stopErr)
+		}
+		s.autoStartedServerDir = ""
+	}
 
 	// Clean up 0-byte noms LOCK files. The Dolt engine creates these when
 	// opening a database; they should be removed on clean shutdown but may


### PR DESCRIPTION
Tests that auto-start a dolt sql-server via DoltStore's AutoStart path create detached background processes that are never cleaned up. Over time these accumulate, consuming CPU and memory.

**Changes:**
- Add `doltserver.EnsureRunningDetailed()` that reports whether a new server was actually started (vs adopting an existing one)
- Track auto-started server directories in `DoltStore` with in-process refcounting so multiple stores can share one auto-started server
- Stop the server in `DoltStore.Close()` when the last store referencing it closes
- Best-effort cleanup: stop errors are logged but don't mask other errors

The fix is at the library layer so downstream projects (e.g. Gas Town) benefit automatically without needing test-specific cleanup.

Fixes #2542