### PR TITLE
fix(flake): Go 1.25.8 overlay + vendorHash for nix build and devShell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ buildGoModule {
   doCheck = false;
 
   # Go module dependencies hash - if build fails with hash mismatch, update with the "got:" value
-  vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  vendorHash = "sha256-1BJsEPP5SYZFGCWHLn532IUKlzcGDg5nhrqGWylEHgY=";
 
   # Relax go.mod version for Nix: nixpkgs Go may lag behind the latest
   # patch release, and GOTOOLCHAIN=auto can't download in the Nix sandbox.

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       # Go 1.25.8: go.mod requires it, nixpkgs has 1.25.7
       # Remove when nixpkgs ships Go >= 1.25.8
       goOverlay = final: prev: {
-        go = prev.go.overrideAttrs {
+        go_1_25 = prev.go_1_25.overrideAttrs {
           version = "1.25.8";
           src = prev.fetchurl {
             url = "https://go.dev/dl/go1.25.8.src.tar.gz";


### PR DESCRIPTION
## Summary

- `go.mod` requires Go 1.25.8 but nixpkgs (nixos-25.11) ships 1.25.7
- `nix develop` fails: Go refuses to build bd with a toolchain older than what `go.mod` declares
- `nix build` fails: vendorHash in `default.nix` was a placeholder (`sha256-AAA...`)

### Changes

1. **Go overlay** targeting `go_1_25` (not `go`, because `buildGoModule` references `go_1_25` directly on nixos-25.11)
2. **vendorHash** updated from placeholder to correct value

The overlay can be removed once nixpkgs ships Go >= 1.25.8.

## Test plan

- [x] `nix develop --command go version` → `go1.25.8`
- [x] `nix develop --command go build ./cmd/bd` → builds clean
- [x] `nix build .#default` → produces working bd binary