### PR TITLE
fix: detached commit worktree test fails when default branch is not main

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -543,6 +543,9 @@ func setupDetachedCommitBeadsWorktree(t *testing.T) (string, string, string) {
 	emptyTree := runGitInDir(t, tmpDir, "--git-dir", bareDir, "hash-object", "-t", "tree", "/dev/null")
 	initCommit := runGitInDir(t, tmpDir, "--git-dir", bareDir, "commit-tree", "-m", "Initial commit", emptyTree)
 	runGitInDir(t, tmpDir, "--git-dir", bareDir, "update-ref", "HEAD", initCommit)
+	// Explicitly create refs/heads/main so the worktree add works
+	// regardless of the system's init.defaultBranch setting.
+	runGitInDir(t, tmpDir, "--git-dir", bareDir, "update-ref", "refs/heads/main", initCommit)
 
 	runGitInDir(t, tmpDir, "--git-dir", bareDir, "worktree", "add", mainWorktreeDir, "main")
 


### PR DESCRIPTION
## Summary

Follow-up to PR #2551. The `setupDetachedCommitBeadsWorktree` test helper fails on systems where `init.defaultBranch` is `master` (e.g., Ubuntu CI) because `git worktree add <path> main` can't find a branch named `main`.

Fix: explicitly create `refs/heads/main` via `update-ref` after the initial commit, so the branch exists regardless of the system's default branch setting.

## Test plan

- [x] `go test ./internal/beads/ -run "DetachedCommit" -v` passes with default branch `main`
- [x] Same test passes with `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=master`
- [x] Full `go test ./internal/beads/` passes

Fixes #2550

🤖 Generated with [Claude Code](https://claude.com/claude-code)