### PR TITLE
backup: add fetch-git and clean up JSONL backup docs

### DIFF
--- a/cmd/bd/backup.go
+++ b/cmd/bd/backup.go
@@ -19,21 +19,25 @@ var backupCmd = &cobra.Command{
 Without a subcommand, exports all tables to JSONL files in .beads/backup/.
 Events are exported incrementally using a high-water mark.
 
-For Dolt-native backups (preserves full commit history, faster for large databases):
+JSONL backup commands (portable snapshot for backup/restore transport):
+  bd backup                Export the current JSONL backup snapshot
+  bd backup status         Show JSONL + Dolt backup status
+  bd backup export-git     Publish the JSONL snapshot to a git branch
+  bd backup fetch-git      Fetch a backup snapshot from a git branch and restore it
+  bd backup restore [path] Restore from JSONL backup files
+
+Dolt-native backup commands (preserve full commit history, faster for large databases):
   bd backup init <path>     Set up a backup destination (filesystem or DoltHub)
   bd backup sync            Push to configured backup destination
-
-Other subcommands:
-  bd backup status          Show backup status (JSONL + Dolt)
-  bd backup export-git      Export the current JSONL snapshot to a git branch
-  bd backup restore [path]  Restore from JSONL backup files
 
 DoltHub is recommended for cloud backup:
   bd backup init https://doltremoteapi.dolthub.com/<user>/<repo>
   Set DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD for authentication.
 
-Note: Git-protocol remotes are NOT recommended for Dolt backups — push times
-exceed 20 minutes, cache grows unboundedly, and force-push is needed after recovery.`,
+Note: The git-protocol remote warning below applies to Dolt-native backups,
+not to 'bd backup export-git'. Git-protocol remotes are NOT recommended for
+Dolt backups — push times exceed 20 minutes, cache grows unboundedly, and
+force-push is needed after recovery.`,
 	GroupID: "sync",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		state, err := runBackupExport(rootCtx, backupForce)
@@ -107,6 +111,8 @@ var backupStatusCmd = &cobra.Command{
 			fmt.Println()
 			fmt.Println("JSONL backup (portable):")
 			fmt.Println("  bd backup                Run JSONL export now")
+			fmt.Println("  bd backup export-git     Publish snapshot to a git branch")
+			fmt.Println("  bd backup fetch-git      Restore from a backup git branch")
 			fmt.Println("  Auto-backup runs every 15m when a git remote is detected")
 			fmt.Println()
 			fmt.Println("Dolt backup (preserves history, faster for large databases):")

--- a/cmd/bd/backup_export.go
+++ b/cmd/bd/backup_export.go
@@ -24,18 +24,20 @@ type dbQuerier interface {
 }
 
 // backupState tracks watermarks for incremental backup.
+type backupCounts struct {
+	Issues       int `json:"issues"`
+	Events       int `json:"events"`
+	Comments     int `json:"comments"`
+	Dependencies int `json:"dependencies"`
+	Labels       int `json:"labels"`
+	Config       int `json:"config"`
+}
+
 type backupState struct {
-	LastDoltCommit string    `json:"last_dolt_commit"`
-	LastEventID    int64     `json:"last_event_id"`
-	Timestamp      time.Time `json:"timestamp"`
-	Counts         struct {
-		Issues       int `json:"issues"`
-		Events       int `json:"events"`
-		Comments     int `json:"comments"`
-		Dependencies int `json:"dependencies"`
-		Labels       int `json:"labels"`
-		Config       int `json:"config"`
-	} `json:"counts"`
+	LastDoltCommit string       `json:"last_dolt_commit"`
+	LastEventID    int64        `json:"last_event_id"`
+	Timestamp      time.Time    `json:"timestamp"`
+	Counts         backupCounts `json:"counts"`
 }
 
 // backupDir returns the backup directory path, creating it if needed.

--- a/cmd/bd/backup_export_git.go
+++ b/cmd/bd/backup_export_git.go
@@ -5,18 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 const (
-	backupExportGitDefaultBranch = "beads-backup"
-	backupExportGitDefaultRemote = "origin"
-	backupExportGitPathspec      = ".beads/backup"
 	backupExportGitCommitMessage = "bd backup export-git"
 )
 
@@ -83,8 +77,8 @@ change primary storage or Dolt remote configuration.`,
 }
 
 func init() {
-	backupExportGitCmd.Flags().String("branch", backupExportGitDefaultBranch, "Target git branch for backup artifacts")
-	backupExportGitCmd.Flags().String("remote", backupExportGitDefaultRemote, "Git remote to push")
+	backupExportGitCmd.Flags().String("branch", backupGitDefaultBranch, "Target git branch for backup artifacts")
+	backupExportGitCmd.Flags().String("remote", backupGitDefaultRemote, "Git remote to push")
 	backupExportGitCmd.Flags().Bool("dry-run", false, "Show what would happen without creating a worktree, committing, or pushing")
 	backupExportGitCmd.Flags().Bool("force", false, "Force a fresh backup export before comparing and copying")
 	backupCmd.AddCommand(backupExportGitCmd)
@@ -122,19 +116,19 @@ func runBackupExportGit(ctx context.Context, opts backupExportGitOptions) (_ *ba
 		return result, nil
 	}
 
-	if _, err := runBackupExport(ctx, opts.Force); err != nil {
+	state, err := runBackupExport(ctx, opts.Force)
+	if err != nil {
 		return nil, err
 	}
 	result.Exported = true
 
-	tempRoot, err := os.MkdirTemp("", "bd-backup-export-git-*")
+	tempRoot, worktreeDir, err := createTempBackupGitWorktree("bd-backup-export-git-*")
 	if err != nil {
-		return nil, fmt.Errorf("create temp worktree dir: %w", err)
+		return nil, err
 	}
-	worktreeDir := filepath.Join(tempRoot, "worktree")
 	worktreeAdded := false
 	defer func() {
-		cleanupErr := cleanupBackupExportGitWorktree(repoRoot, worktreeDir, tempRoot, worktreeAdded)
+		cleanupErr := cleanupTempBackupGitWorktree(repoRoot, worktreeDir, tempRoot, worktreeAdded)
 		if cleanupErr != nil {
 			if retErr != nil {
 				retErr = errors.Join(retErr, cleanupErr)
@@ -144,21 +138,24 @@ func runBackupExportGit(ctx context.Context, opts backupExportGitOptions) (_ *ba
 		}
 	}()
 
-	if err := addBackupExportGitWorktree(ctx, repoRoot, opts.Remote, opts.Branch, worktreeDir); err != nil {
+	if err := addBackupBranchWorktree(ctx, repoRoot, opts.Remote, opts.Branch, worktreeDir); err != nil {
 		return nil, err
 	}
 	worktreeAdded = true
 
-	dstBackupDir := filepath.Join(worktreeDir, filepath.FromSlash(backupExportGitPathspec))
+	dstBackupDir := filepath.Join(worktreeDir, filepath.FromSlash(backupGitPathspec))
 	if err := syncBackupSnapshot(backupDirPath, dstBackupDir); err != nil {
 		return nil, fmt.Errorf("copy backup snapshot: %w", err)
 	}
-
-	if err := gitExecInDir(ctx, worktreeDir, "add", "-A", "-f", "--", backupExportGitPathspec); err != nil {
-		return nil, fmt.Errorf("git add %s: %w", backupExportGitPathspec, err)
+	if err := writeBackupGitManifest(dstBackupDir, state); err != nil {
+		return nil, fmt.Errorf("write backup manifest: %w", err)
 	}
 
-	changed, err := gitHasCachedChanges(ctx, worktreeDir, backupExportGitPathspec)
+	if err := gitExecInDir(ctx, worktreeDir, "add", "-A", "-f", "--", backupGitPathspec); err != nil {
+		return nil, fmt.Errorf("git add %s: %w", backupGitPathspec, err)
+	}
+
+	changed, err := gitHasCachedChanges(ctx, worktreeDir, backupGitPathspec)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +164,7 @@ func runBackupExportGit(ctx context.Context, opts backupExportGitOptions) (_ *ba
 		return result, nil
 	}
 
-	if err := gitExecInDir(ctx, worktreeDir, "commit", "-m", backupExportGitCommitMessage, "--", backupExportGitPathspec); err != nil {
+	if err := gitExecInDir(ctx, worktreeDir, "commit", "-m", backupExportGitCommitMessage, "--", backupGitPathspec); err != nil {
 		return result, fmt.Errorf("git commit: %w", err)
 	}
 	result.Committed = true
@@ -182,14 +179,8 @@ func runBackupExportGit(ctx context.Context, opts backupExportGitOptions) (_ *ba
 }
 
 func normalizeBackupExportGitOptions(opts backupExportGitOptions) backupExportGitOptions {
-	opts.Branch = strings.TrimSpace(opts.Branch)
-	if opts.Branch == "" {
-		opts.Branch = backupExportGitDefaultBranch
-	}
-	opts.Remote = strings.TrimSpace(opts.Remote)
-	if opts.Remote == "" {
-		opts.Remote = backupExportGitDefaultRemote
-	}
+	opts.Branch = normalizeBackupGitRef(opts.Branch, backupGitDefaultBranch)
+	opts.Remote = normalizeBackupGitRef(opts.Remote, backupGitDefaultRemote)
 	return opts
 }
 
@@ -197,7 +188,7 @@ func printBackupExportGitResult(result *backupExportGitResult) {
 	if result.DryRun {
 		fmt.Printf("Dry run: would export backup snapshot to git branch %s\n", result.Branch)
 		fmt.Printf("  Remote: %s\n", result.Remote)
-		fmt.Printf("  Would copy: %s/\n", backupExportGitPathspec)
+		fmt.Printf("  Would copy: %s/\n", backupGitPathspec)
 		fmt.Println("  Would commit if changed")
 		fmt.Println("  Would push to remote")
 		return
@@ -212,7 +203,7 @@ func printBackupExportGitResult(result *backupExportGitResult) {
 
 	fmt.Printf("Exported backup snapshot to git branch %s\n", result.Branch)
 	fmt.Printf("  Remote: %s\n", result.Remote)
-	fmt.Printf("  Path: %s/\n", backupExportGitPathspec)
+	fmt.Printf("  Path: %s/\n", backupGitPathspec)
 	fmt.Println("  Commit: created")
 	fmt.Println("  Push: complete")
 }
@@ -240,134 +231,4 @@ func marshalBackupExportGitResultJSON(result *backupExportGitResult) ([]byte, er
 		payload["commit_message"] = result.CommitMessage
 	}
 	return json.MarshalIndent(payload, "", "  ")
-}
-
-func addBackupExportGitWorktree(ctx context.Context, repoRoot, remote, branch, worktreeDir string) error {
-	localExists, err := gitRefExists(ctx, repoRoot, "refs/heads/"+branch)
-	if err != nil {
-		return err
-	}
-	if localExists {
-		if err := gitExecInDir(ctx, repoRoot, "worktree", "add", worktreeDir, branch); err != nil {
-			return fmt.Errorf("git worktree add %s: %w", branch, err)
-		}
-		return nil
-	}
-
-	remoteRef := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
-	remoteExists, err := gitRefExists(ctx, repoRoot, remoteRef)
-	if err != nil {
-		return err
-	}
-	if remoteExists {
-		if err := gitExecInDir(ctx, repoRoot, "worktree", "add", "-b", branch, worktreeDir, remote+"/"+branch); err != nil {
-			return fmt.Errorf("git worktree add %s from %s/%s: %w", branch, remote, branch, err)
-		}
-		return nil
-	}
-
-	if err := gitExecInDir(ctx, repoRoot, "worktree", "add", "-b", branch, worktreeDir); err != nil {
-		return fmt.Errorf("git worktree add -b %s: %w", branch, err)
-	}
-	return nil
-}
-
-func cleanupBackupExportGitWorktree(repoRoot, worktreeDir, tempRoot string, worktreeAdded bool) error {
-	var errs []error
-	if worktreeAdded {
-		if err := gitExecInDir(context.Background(), repoRoot, "worktree", "remove", "--force", worktreeDir); err != nil {
-			errs = append(errs, fmt.Errorf("remove temp worktree: %w", err))
-		}
-	}
-	if tempRoot != "" {
-		if err := os.RemoveAll(tempRoot); err != nil {
-			errs = append(errs, fmt.Errorf("remove temp worktree dir: %w", err))
-		}
-	}
-	return errors.Join(errs...)
-}
-
-func gitRefExists(ctx context.Context, dir, ref string) (bool, error) {
-	exitCode, err := gitExitCodeInDir(ctx, dir, "show-ref", "--verify", "--quiet", ref)
-	if err != nil {
-		return false, fmt.Errorf("git show-ref %s: %w", ref, err)
-	}
-	if exitCode == 1 {
-		return false, nil
-	}
-	if exitCode != 0 {
-		return false, fmt.Errorf("git show-ref %s exited with code %d", ref, exitCode)
-	}
-	return true, nil
-}
-
-func gitHasCachedChanges(ctx context.Context, dir, pathspec string) (bool, error) {
-	exitCode, err := gitExitCodeInDir(ctx, dir, "diff", "--cached", "--quiet", "--", pathspec)
-	if err != nil {
-		return false, fmt.Errorf("git diff --cached %s: %w", pathspec, err)
-	}
-	if exitCode == 1 {
-		return true, nil
-	}
-	if exitCode != 0 {
-		return false, fmt.Errorf("git diff --cached %s exited with code %d", pathspec, exitCode)
-	}
-	return false, nil
-}
-
-func syncBackupSnapshot(srcDir, dstDir string) error {
-	if err := os.RemoveAll(dstDir); err != nil {
-		return fmt.Errorf("clear destination backup dir: %w", err)
-	}
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
-		return fmt.Errorf("create destination backup dir: %w", err)
-	}
-	return copyDirContents(srcDir, dstDir)
-}
-
-func copyDirContents(srcDir, dstDir string) error {
-	entries, err := os.ReadDir(srcDir)
-	if err != nil {
-		return fmt.Errorf("read source backup dir: %w", err)
-	}
-	for _, entry := range entries {
-		srcPath := filepath.Join(srcDir, entry.Name())
-		dstPath := filepath.Join(dstDir, entry.Name())
-		info, err := entry.Info()
-		if err != nil {
-			return fmt.Errorf("stat %s: %w", srcPath, err)
-		}
-		if entry.IsDir() {
-			if err := os.MkdirAll(dstPath, info.Mode().Perm()); err != nil {
-				return fmt.Errorf("create %s: %w", dstPath, err)
-			}
-			if err := copyDirContents(srcPath, dstPath); err != nil {
-				return err
-			}
-			continue
-		}
-		if err := copyFileContents(srcPath, dstPath, info.Mode().Perm()); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func copyFileContents(srcPath, dstPath string, mode os.FileMode) error {
-	src, err := os.Open(srcPath) //nolint:gosec // source path is internal backup output
-	if err != nil {
-		return fmt.Errorf("open %s: %w", srcPath, err)
-	}
-	defer src.Close()
-
-	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode) //nolint:gosec // destination path is a temp worktree path constructed by the command
-	if err != nil {
-		return fmt.Errorf("create %s: %w", dstPath, err)
-	}
-	defer dst.Close()
-
-	if _, err := io.Copy(dst, src); err != nil {
-		return fmt.Errorf("copy %s: %w", srcPath, err)
-	}
-	return nil
 }

--- a/cmd/bd/backup_export_git_test.go
+++ b/cmd/bd/backup_export_git_test.go
@@ -4,23 +4,26 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
 
 var expectedBackupSnapshotFiles = []string{
-	".beads/backup/issues.jsonl",
-	".beads/backup/events.jsonl",
-	".beads/backup/comments.jsonl",
-	".beads/backup/dependencies.jsonl",
-	".beads/backup/labels.jsonl",
-	".beads/backup/config.jsonl",
 	".beads/backup/backup_state.json",
+	".beads/backup/comments.jsonl",
+	".beads/backup/config.jsonl",
+	".beads/backup/dependencies.jsonl",
+	".beads/backup/events.jsonl",
+	".beads/backup/labels.jsonl",
+	".beads/backup/issues.jsonl",
+	".beads/backup/manifest.json",
 }
 
 type backupExportGitHarness struct {
@@ -42,8 +45,8 @@ func TestBackupExportGitCreatesBranchAndPushesSnapshot(t *testing.T) {
 		t.Fatalf("unexpected result: %+v", result)
 	}
 	assertCurrentBranch(t, h.repoDir, "main")
-	assertBranchHasExpectedBackupFiles(t, h.repoDir, backupExportGitDefaultBranch)
-	assertRemoteBranchExists(t, h.remoteDir, backupExportGitDefaultBranch)
+	assertBranchHasExpectedBackupFiles(t, h.repoDir, backupGitDefaultBranch)
+	assertRemoteBranchExists(t, h.remoteDir, backupGitDefaultBranch)
 }
 
 func TestBackupExportGitUpdatesExistingBranch(t *testing.T) {
@@ -53,14 +56,14 @@ func TestBackupExportGitUpdatesExistingBranch(t *testing.T) {
 	if _, err := runBackupExportGit(h.ctx, backupExportGitOptions{}); err != nil {
 		t.Fatalf("first runBackupExportGit: %v", err)
 	}
-	firstHead := gitOutput(t, h.repoDir, "rev-parse", backupExportGitDefaultBranch)
+	firstHead := gitOutput(t, h.repoDir, "rev-parse", backupGitDefaultBranch)
 
 	insertBackupExportGitIssue(t, h.ctx, "upd-2", "Second export")
 	result, err := runBackupExportGit(h.ctx, backupExportGitOptions{})
 	if err != nil {
 		t.Fatalf("second runBackupExportGit: %v", err)
 	}
-	secondHead := gitOutput(t, h.repoDir, "rev-parse", backupExportGitDefaultBranch)
+	secondHead := gitOutput(t, h.repoDir, "rev-parse", backupGitDefaultBranch)
 
 	if !result.Changed || !result.Committed || !result.Pushed {
 		t.Fatalf("unexpected result: %+v", result)
@@ -68,7 +71,7 @@ func TestBackupExportGitUpdatesExistingBranch(t *testing.T) {
 	if secondHead == firstHead {
 		t.Fatalf("backup branch head did not change: %s", secondHead)
 	}
-	content := gitShowFile(t, h.repoDir, backupExportGitDefaultBranch, ".beads/backup/issues.jsonl")
+	content := gitShowFile(t, h.repoDir, backupGitDefaultBranch, ".beads/backup/issues.jsonl")
 	if !strings.Contains(content, `"title":"Second export"`) {
 		t.Fatalf("issues.jsonl missing updated issue:\n%s", content)
 	}
@@ -82,19 +85,55 @@ func TestBackupExportGitNoChangesSkipsCommitAndPush(t *testing.T) {
 	if _, err := runBackupExportGit(h.ctx, backupExportGitOptions{}); err != nil {
 		t.Fatalf("first runBackupExportGit: %v", err)
 	}
-	firstHead := gitOutput(t, h.repoDir, "rev-parse", backupExportGitDefaultBranch)
+	firstHead := gitOutput(t, h.repoDir, "rev-parse", backupGitDefaultBranch)
 
 	result, err := runBackupExportGit(h.ctx, backupExportGitOptions{})
 	if err != nil {
 		t.Fatalf("second runBackupExportGit: %v", err)
 	}
-	secondHead := gitOutput(t, h.repoDir, "rev-parse", backupExportGitDefaultBranch)
+	secondHead := gitOutput(t, h.repoDir, "rev-parse", backupGitDefaultBranch)
 
 	if result.Changed || result.Committed || result.Pushed {
 		t.Fatalf("expected no-op result, got %+v", result)
 	}
 	if firstHead != secondHead {
 		t.Fatalf("expected backup branch head to stay at %s, got %s", firstHead, secondHead)
+	}
+}
+
+func TestBackupExportGitWritesManifest(t *testing.T) {
+	h := setupBackupExportGitHarness(t)
+	insertBackupExportGitIssue(t, h.ctx, "manifest-1", "Manifest issue")
+
+	result, err := runBackupExportGit(h.ctx, backupExportGitOptions{})
+	if err != nil {
+		t.Fatalf("runBackupExportGit: %v", err)
+	}
+
+	manifestPath := filepath.Join(result.BackupDir, backupGitManifestFilename)
+	if _, err := os.Stat(manifestPath); !os.IsNotExist(err) {
+		t.Fatalf("local backup dir should not contain %s", backupGitManifestFilename)
+	}
+
+	content := gitShowFile(t, h.repoDir, backupGitDefaultBranch, filepath.ToSlash(filepath.Join(backupGitPathspec, backupGitManifestFilename)))
+	var manifest backupGitManifest
+	if err := json.Unmarshal([]byte(content), &manifest); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if manifest.Format != "bd-backup-git-manifest-v1" {
+		t.Fatalf("manifest format = %q", manifest.Format)
+	}
+	if manifest.BDVersion != Version {
+		t.Fatalf("manifest bd_version = %q, want %q", manifest.BDVersion, Version)
+	}
+	if manifest.LastDoltCommit == "" {
+		t.Fatal("manifest missing dolt commit")
+	}
+	if manifest.Counts.Issues != 1 {
+		t.Fatalf("manifest issues = %d, want 1", manifest.Counts.Issues)
+	}
+	if manifest.SnapshotTimestamp.IsZero() {
+		t.Fatal("manifest snapshot timestamp is zero")
 	}
 }
 
@@ -110,11 +149,11 @@ func TestBackupExportGitDryRunHasNoSideEffects(t *testing.T) {
 	if !result.DryRun || !result.WouldExport || !result.WouldCopy || !result.WouldCommit || !result.WouldPush {
 		t.Fatalf("unexpected dry-run result: %+v", result)
 	}
-	if gitRefExistsForTest(t, h.repoDir, "refs/heads/"+backupExportGitDefaultBranch) {
-		t.Fatalf("dry-run should not create local branch %s", backupExportGitDefaultBranch)
+	if gitRefExistsForTest(t, h.repoDir, "refs/heads/"+backupGitDefaultBranch) {
+		t.Fatalf("dry-run should not create local branch %s", backupGitDefaultBranch)
 	}
-	if gitRefExistsForTest(t, h.remoteDir, "refs/heads/"+backupExportGitDefaultBranch, "--git-dir") {
-		t.Fatalf("dry-run should not create remote branch %s", backupExportGitDefaultBranch)
+	if gitRefExistsForTest(t, h.remoteDir, "refs/heads/"+backupGitDefaultBranch, "--git-dir") {
+		t.Fatalf("dry-run should not create remote branch %s", backupGitDefaultBranch)
 	}
 	assertCurrentBranch(t, h.repoDir, "main")
 }
@@ -137,12 +176,12 @@ func TestBackupExportGitLeavesUnrelatedWorkingTreeChangesUntouched(t *testing.T)
 		t.Fatalf("expected README.md to remain modified, got:\n%s", status)
 	}
 
-	changedFiles := nonEmptyLines(gitOutput(t, h.repoDir, "show", "--name-only", "--pretty=format:", backupExportGitDefaultBranch))
+	changedFiles := nonEmptyLines(gitOutput(t, h.repoDir, "show", "--name-only", "--pretty=format:", backupGitDefaultBranch))
 	if len(changedFiles) == 0 {
 		t.Fatal("expected committed files on backup branch")
 	}
 	for _, changed := range changedFiles {
-		if !strings.HasPrefix(changed, backupExportGitPathspec+"/") {
+		if !strings.HasPrefix(changed, backupGitPathspec+"/") {
 			t.Fatalf("backup branch committed unrelated path %q", changed)
 		}
 	}
@@ -228,13 +267,16 @@ func insertBackupExportGitIssue(t *testing.T, ctx context.Context, id, title str
 
 func assertBranchHasExpectedBackupFiles(t *testing.T, repoDir, branch string) {
 	t.Helper()
-	got := nonEmptyLines(gitOutput(t, repoDir, "ls-tree", "-r", "--name-only", branch, "--", backupExportGitPathspec))
-	if len(got) != len(expectedBackupSnapshotFiles) {
-		t.Fatalf("backup branch files = %v, want %v", got, expectedBackupSnapshotFiles)
+	got := nonEmptyLines(gitOutput(t, repoDir, "ls-tree", "-r", "--name-only", branch, "--", backupGitPathspec))
+	slices.Sort(got)
+	want := append([]string(nil), expectedBackupSnapshotFiles...)
+	slices.Sort(want)
+	if len(got) != len(want) {
+		t.Fatalf("backup branch files = %v, want %v", got, want)
 	}
-	for i, want := range expectedBackupSnapshotFiles {
-		if got[i] != want {
-			t.Fatalf("backup branch file[%d] = %q, want %q", i, got[i], want)
+	for i, expected := range want {
+		if got[i] != expected {
+			t.Fatalf("backup branch file[%d] = %q, want %q", i, got[i], expected)
 		}
 	}
 }

--- a/cmd/bd/backup_fetch_git.go
+++ b/cmd/bd/backup_fetch_git.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+type backupFetchGitOptions struct {
+	Branch string
+	Remote string
+	DryRun bool
+}
+
+type backupFetchGitResult struct {
+	Branch       string `json:"branch"`
+	Remote       string `json:"remote"`
+	Fetched      bool   `json:"fetched,omitempty"`
+	Restored     bool   `json:"restored,omitempty"`
+	Issues       int    `json:"issues,omitempty"`
+	Comments     int    `json:"comments,omitempty"`
+	Dependencies int    `json:"dependencies,omitempty"`
+	Labels       int    `json:"labels,omitempty"`
+	Events       int    `json:"events,omitempty"`
+	Config       int    `json:"config,omitempty"`
+	Warnings     int    `json:"warnings,omitempty"`
+	DryRun       bool   `json:"dry_run,omitempty"`
+	WouldFetch   bool   `json:"would_fetch,omitempty"`
+	WouldRestore bool   `json:"would_restore,omitempty"`
+}
+
+var backupFetchGitCmd = &cobra.Command{
+	Use:   "fetch-git",
+	Short: "Fetch a JSONL backup snapshot from a git branch and restore it",
+	Long: `Fetch a JSONL backup snapshot from a git branch and restore it using
+the existing bd backup restore flow.
+
+This command is intended as the companion to 'bd backup export-git'. It uses
+a temporary git worktree, restores from .beads/backup/ in that snapshot, and
+leaves your current branch and working tree untouched.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		branch, _ := cmd.Flags().GetString("branch")
+		remote, _ := cmd.Flags().GetString("remote")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		result, err := runBackupFetchGit(rootCtx, store, backupFetchGitOptions{
+			Branch: branch,
+			Remote: remote,
+			DryRun: dryRun,
+		})
+		if err != nil {
+			return err
+		}
+
+		if jsonOutput {
+			outputJSON(result)
+			return nil
+		}
+
+		printBackupFetchGitResult(result)
+		return nil
+	},
+}
+
+func init() {
+	backupFetchGitCmd.Flags().String("branch", backupGitDefaultBranch, "Git branch to fetch backup artifacts from")
+	backupFetchGitCmd.Flags().String("remote", backupGitDefaultRemote, "Git remote to fetch from")
+	backupFetchGitCmd.Flags().Bool("dry-run", false, "Show what would happen without fetching or restoring")
+	backupCmd.AddCommand(backupFetchGitCmd)
+}
+
+func runBackupFetchGit(ctx context.Context, s *dolt.DoltStore, opts backupFetchGitOptions) (_ *backupFetchGitResult, retErr error) {
+	opts = normalizeBackupFetchGitOptions(opts)
+
+	repoRoot, err := findGitRoot(".")
+	if err != nil {
+		return nil, fmt.Errorf("not in a git repository")
+	}
+
+	result := &backupFetchGitResult{
+		Branch: opts.Branch,
+		Remote: opts.Remote,
+	}
+
+	if opts.DryRun {
+		result.DryRun = true
+		result.WouldFetch = true
+		result.WouldRestore = true
+		return result, nil
+	}
+
+	tempRoot, worktreeDir, err := createTempBackupGitWorktree("bd-backup-fetch-git-*")
+	if err != nil {
+		return nil, err
+	}
+	worktreeAdded := false
+	defer func() {
+		cleanupErr := cleanupTempBackupGitWorktree(repoRoot, worktreeDir, tempRoot, worktreeAdded)
+		if cleanupErr != nil {
+			if retErr != nil {
+				retErr = errors.Join(retErr, cleanupErr)
+			} else {
+				retErr = cleanupErr
+			}
+		}
+	}()
+
+	if err := addBackupFetchWorktree(ctx, repoRoot, opts.Remote, opts.Branch, worktreeDir); err != nil {
+		return nil, err
+	}
+	worktreeAdded = true
+	result.Fetched = true
+
+	snapshotDir := filepath.Join(worktreeDir, filepath.FromSlash(backupGitPathspec))
+	if err := validateBackupRestoreDir(snapshotDir); err != nil {
+		return nil, err
+	}
+
+	restoreResult, err := runBackupRestore(ctx, s, snapshotDir, false)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Restored = true
+	result.Issues = restoreResult.Issues
+	result.Comments = restoreResult.Comments
+	result.Dependencies = restoreResult.Dependencies
+	result.Labels = restoreResult.Labels
+	result.Events = restoreResult.Events
+	result.Config = restoreResult.Config
+	result.Warnings = restoreResult.Warnings
+
+	return result, nil
+}
+
+func normalizeBackupFetchGitOptions(opts backupFetchGitOptions) backupFetchGitOptions {
+	opts.Branch = normalizeBackupGitRef(opts.Branch, backupGitDefaultBranch)
+	opts.Remote = normalizeBackupGitRef(opts.Remote, backupGitDefaultRemote)
+	return opts
+}
+
+func printBackupFetchGitResult(result *backupFetchGitResult) {
+	if result.DryRun {
+		fmt.Printf("Dry run: would fetch backup snapshot from git branch %s\n", result.Branch)
+		fmt.Printf("  Remote: %s\n", result.Remote)
+		fmt.Printf("  Would restore: %s/\n", backupGitPathspec)
+		return
+	}
+
+	fmt.Printf("Fetched backup snapshot from git branch %s and restored local database\n", result.Branch)
+	fmt.Printf("  Remote: %s\n", result.Remote)
+	fmt.Printf("  Issues: %d\n", result.Issues)
+	fmt.Printf("  Comments: %d\n", result.Comments)
+	fmt.Printf("  Dependencies: %d\n", result.Dependencies)
+	fmt.Printf("  Labels: %d\n", result.Labels)
+	fmt.Printf("  Events: %d\n", result.Events)
+	fmt.Printf("  Config: %d\n", result.Config)
+	if result.Warnings > 0 {
+		fmt.Printf("  Warnings: %d\n", result.Warnings)
+	}
+}

--- a/cmd/bd/backup_fetch_git_test.go
+++ b/cmd/bd/backup_fetch_git_test.go
@@ -1,0 +1,115 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBackupFetchGitRestoresSnapshotFromRemoteBranch(t *testing.T) {
+	source := setupBackupExportGitHarness(t)
+	insertBackupExportGitIssue(t, source.ctx, "fetch-1", "Fetch Git Issue")
+
+	if _, err := runBackupExportGit(source.ctx, backupExportGitOptions{}); err != nil {
+		t.Fatalf("runBackupExportGit: %v", err)
+	}
+
+	targetRepo := newBackupFetchGitTargetRepo(t, source.remoteDir)
+	targetStore := newTestStore(t, filepath.Join(targetRepo, ".beads", "dolt"))
+
+	t.Chdir(targetRepo)
+
+	result, err := runBackupFetchGit(context.Background(), targetStore, backupFetchGitOptions{})
+	if err != nil {
+		t.Fatalf("runBackupFetchGit: %v", err)
+	}
+
+	if !result.Fetched || !result.Restored {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.Issues != 1 {
+		t.Fatalf("issues restored = %d, want 1", result.Issues)
+	}
+	if !gitRefExistsForTest(t, targetRepo, "refs/remotes/origin/"+backupGitDefaultBranch) {
+		t.Fatalf("expected fetched remote ref for %s", backupGitDefaultBranch)
+	}
+	assertCurrentBranch(t, targetRepo, "main")
+
+	issue, err := targetStore.GetIssue(context.Background(), "fetch-1")
+	if err != nil {
+		t.Fatalf("GetIssue fetch-1: %v", err)
+	}
+	if issue.Title != "Fetch Git Issue" {
+		t.Fatalf("issue title = %q, want %q", issue.Title, "Fetch Git Issue")
+	}
+}
+
+func TestBackupFetchGitDryRunHasNoSideEffects(t *testing.T) {
+	source := setupBackupExportGitHarness(t)
+	insertBackupExportGitIssue(t, source.ctx, "fetch-dry-1", "Fetch dry run issue")
+
+	if _, err := runBackupExportGit(source.ctx, backupExportGitOptions{}); err != nil {
+		t.Fatalf("runBackupExportGit: %v", err)
+	}
+
+	targetRepo := newBackupFetchGitTargetRepo(t, source.remoteDir)
+	targetStore := newTestStore(t, filepath.Join(targetRepo, ".beads", "dolt"))
+
+	t.Chdir(targetRepo)
+
+	result, err := runBackupFetchGit(context.Background(), targetStore, backupFetchGitOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("runBackupFetchGit dry-run: %v", err)
+	}
+
+	if !result.DryRun || !result.WouldFetch || !result.WouldRestore {
+		t.Fatalf("unexpected dry-run result: %+v", result)
+	}
+	if gitRefExistsForTest(t, targetRepo, "refs/remotes/origin/"+backupGitDefaultBranch) {
+		t.Fatalf("dry-run should not fetch remote branch %s", backupGitDefaultBranch)
+	}
+	assertCurrentBranch(t, targetRepo, "main")
+
+	if _, err := targetStore.GetIssue(context.Background(), "fetch-dry-1"); err == nil {
+		t.Fatal("dry-run should not restore issues")
+	}
+}
+
+func TestBackupFetchGitNotInGitRepo(t *testing.T) {
+	initConfigForTest(t)
+	saveAndRestoreGlobals(t)
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	_, err := runBackupFetchGit(context.Background(), nil, backupFetchGitOptions{})
+	if err == nil {
+		t.Fatal("expected error outside git repo")
+	}
+	if !strings.Contains(err.Error(), "not in a git repository") {
+		t.Fatalf("expected not-in-git-repo error, got %v", err)
+	}
+}
+
+func newBackupFetchGitTargetRepo(t *testing.T, remoteDir string) string {
+	t.Helper()
+
+	repoDir := newGitRepo(t)
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("backup fetch git test\n"), 0644); err != nil {
+		t.Fatalf("WriteFile README.md: %v", err)
+	}
+	if err := runCommandInDir(repoDir, "git", "add", "README.md"); err != nil {
+		t.Fatalf("git add README.md: %v", err)
+	}
+	if err := runCommandInDir(repoDir, "git", "commit", "-m", "initial"); err != nil {
+		t.Fatalf("git commit initial: %v", err)
+	}
+	if err := runCommandInDir(repoDir, "git", "remote", "add", "origin", remoteDir); err != nil {
+		t.Fatalf("git remote add origin: %v", err)
+	}
+	return repoDir
+}

--- a/cmd/bd/backup_git_transport.go
+++ b/cmd/bd/backup_git_transport.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	backupGitDefaultBranch    = "beads-backup"
+	backupGitDefaultRemote    = "origin"
+	backupGitPathspec         = ".beads/backup"
+	backupGitManifestFilename = "manifest.json"
+)
+
+type backupGitManifest struct {
+	Format            string       `json:"format"`
+	BDVersion         string       `json:"bd_version"`
+	SnapshotTimestamp time.Time    `json:"snapshot_timestamp"`
+	LastDoltCommit    string       `json:"last_dolt_commit"`
+	Counts            backupCounts `json:"counts"`
+}
+
+func normalizeBackupGitRef(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func createTempBackupGitWorktree(prefix string) (string, string, error) {
+	tempRoot, err := os.MkdirTemp("", prefix)
+	if err != nil {
+		return "", "", fmt.Errorf("create temp worktree dir: %w", err)
+	}
+	return tempRoot, filepath.Join(tempRoot, "worktree"), nil
+}
+
+func cleanupTempBackupGitWorktree(repoRoot, worktreeDir, tempRoot string, worktreeAdded bool) error {
+	var errs []error
+	if worktreeAdded {
+		if err := gitExecInDir(context.Background(), repoRoot, "worktree", "remove", "--force", worktreeDir); err != nil {
+			errs = append(errs, fmt.Errorf("remove temp worktree: %w", err))
+		}
+	}
+	if tempRoot != "" {
+		if err := os.RemoveAll(tempRoot); err != nil {
+			errs = append(errs, fmt.Errorf("remove temp worktree dir: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func addBackupBranchWorktree(ctx context.Context, repoRoot, remote, branch, worktreeDir string) error {
+	localExists, err := gitRefExists(ctx, repoRoot, "refs/heads/"+branch)
+	if err != nil {
+		return err
+	}
+	if localExists {
+		if err := gitExecInDir(ctx, repoRoot, "worktree", "add", worktreeDir, branch); err != nil {
+			return fmt.Errorf("git worktree add %s: %w", branch, err)
+		}
+		return nil
+	}
+
+	remoteRef := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
+	remoteExists, err := gitRefExists(ctx, repoRoot, remoteRef)
+	if err != nil {
+		return err
+	}
+	if remoteExists {
+		if err := gitExecInDir(ctx, repoRoot, "worktree", "add", "-b", branch, worktreeDir, remote+"/"+branch); err != nil {
+			return fmt.Errorf("git worktree add %s from %s/%s: %w", branch, remote, branch, err)
+		}
+		return nil
+	}
+
+	if err := gitExecInDir(ctx, repoRoot, "worktree", "add", "-b", branch, worktreeDir); err != nil {
+		return fmt.Errorf("git worktree add -b %s: %w", branch, err)
+	}
+	return nil
+}
+
+func addBackupFetchWorktree(ctx context.Context, repoRoot, remote, branch, worktreeDir string) error {
+	if err := gitExecInDir(ctx, repoRoot, "fetch", remote, branch); err != nil {
+		return fmt.Errorf("git fetch %s %s: %w", remote, branch, err)
+	}
+	if err := gitExecInDir(ctx, repoRoot, "worktree", "add", "--detach", worktreeDir, "FETCH_HEAD"); err != nil {
+		return fmt.Errorf("git worktree add FETCH_HEAD: %w", err)
+	}
+	return nil
+}
+
+func gitRefExists(ctx context.Context, dir, ref string) (bool, error) {
+	exitCode, err := gitExitCodeInDir(ctx, dir, "show-ref", "--verify", "--quiet", ref)
+	if err != nil {
+		return false, fmt.Errorf("git show-ref %s: %w", ref, err)
+	}
+	if exitCode == 1 {
+		return false, nil
+	}
+	if exitCode != 0 {
+		return false, fmt.Errorf("git show-ref %s exited with code %d", ref, exitCode)
+	}
+	return true, nil
+}
+
+func gitHasCachedChanges(ctx context.Context, dir, pathspec string) (bool, error) {
+	exitCode, err := gitExitCodeInDir(ctx, dir, "diff", "--cached", "--quiet", "--", pathspec)
+	if err != nil {
+		return false, fmt.Errorf("git diff --cached %s: %w", pathspec, err)
+	}
+	if exitCode == 1 {
+		return true, nil
+	}
+	if exitCode != 0 {
+		return false, fmt.Errorf("git diff --cached %s exited with code %d", pathspec, exitCode)
+	}
+	return false, nil
+}
+
+func syncBackupSnapshot(srcDir, dstDir string) error {
+	if err := os.RemoveAll(dstDir); err != nil {
+		return fmt.Errorf("clear destination backup dir: %w", err)
+	}
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return fmt.Errorf("create destination backup dir: %w", err)
+	}
+	return copyDirContents(srcDir, dstDir)
+}
+
+func copyDirContents(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return fmt.Errorf("read source backup dir: %w", err)
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcDir, entry.Name())
+		dstPath := filepath.Join(dstDir, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", srcPath, err)
+		}
+		if entry.IsDir() {
+			if err := os.MkdirAll(dstPath, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("create %s: %w", dstPath, err)
+			}
+			if err := copyDirContents(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := copyFileContents(srcPath, dstPath, info.Mode().Perm()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFileContents(srcPath, dstPath string, mode os.FileMode) error {
+	src, err := os.Open(srcPath) //nolint:gosec // source path is internal backup output
+	if err != nil {
+		return fmt.Errorf("open %s: %w", srcPath, err)
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode) //nolint:gosec // destination path is a temp worktree path constructed by the command
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dstPath, err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return fmt.Errorf("copy %s: %w", srcPath, err)
+	}
+	return nil
+}
+
+func writeBackupGitManifest(dstDir string, state *backupState) error {
+	if state == nil {
+		return fmt.Errorf("backup state is required")
+	}
+
+	manifest := backupGitManifest{
+		Format:            "bd-backup-git-manifest-v1",
+		BDVersion:         Version,
+		SnapshotTimestamp: state.Timestamp,
+		LastDoltCommit:    state.LastDoltCommit,
+		Counts:            state.Counts,
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal backup manifest: %w", err)
+	}
+	data = append(data, '\n')
+
+	return atomicWriteFile(filepath.Join(dstDir, backupGitManifestFilename), data)
+}

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -33,6 +33,9 @@ This command:
 Use this after losing your Dolt database (machine crash, new clone, etc.)
 when you have JSONL backups on disk or in git.
 
+If your backup snapshots are stored in a git branch, use 'bd backup fetch-git'
+to fetch that branch into a temporary worktree and restore from it.
+
 The database must already be initialized (run 'bd init' first if needed).
 To initialize and restore in one step, use: bd init && bd backup restore`,
 	Args: cobra.MaximumNArgs(1),
@@ -50,20 +53,8 @@ To initialize and restore in one step, use: bd init && bd backup restore`,
 			}
 		}
 
-		// Verify backup directory exists and has files
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			return fmt.Errorf("backup directory not found: %s\nRun 'bd backup' first to create a backup", dir)
-		}
-
-		// Check for issues.jsonl as minimum requirement
-		issuesPath := filepath.Join(dir, "issues.jsonl")
-		if _, err := os.Stat(issuesPath); os.IsNotExist(err) {
-			return fmt.Errorf("no issues.jsonl found in %s\nThis doesn't look like a valid backup directory", dir)
-		}
-
-		// Validate schema of issues.jsonl before proceeding (GH#2492)
-		if err := validateIssueJSONLSchema(issuesPath); err != nil {
-			return fmt.Errorf("backup validation failed: %w", err)
+		if err := validateBackupRestoreDir(dir); err != nil {
+			return err
 		}
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
@@ -121,6 +112,10 @@ type restoreResult struct {
 // runBackupRestore imports all JSONL backup tables into the Dolt store.
 // Order matters: config first (sets prefix), then issues, then related tables.
 func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun bool) (*restoreResult, error) {
+	if s == nil {
+		return nil, fmt.Errorf("database is not initialized. Run 'bd init' first")
+	}
+
 	result := &restoreResult{}
 	db := s.DB()
 
@@ -197,6 +192,23 @@ func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun
 	}
 
 	return result, nil
+}
+
+func validateBackupRestoreDir(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("backup directory not found: %s\nRun 'bd backup' first to create a backup", dir)
+	}
+
+	issuesPath := filepath.Join(dir, "issues.jsonl")
+	if _, err := os.Stat(issuesPath); os.IsNotExist(err) {
+		return fmt.Errorf("no issues.jsonl found in %s\nThis doesn't look like a valid backup directory", dir)
+	}
+
+	if err := validateIssueJSONLSchema(issuesPath); err != nil {
+		return fmt.Errorf("backup validation failed: %w", err)
+	}
+
+	return nil
 }
 
 // restoreConfig reads config.jsonl and sets each key-value pair.

--- a/cmd/bd/doctor_pollution.go
+++ b/cmd/bd/doctor_pollution.go
@@ -136,7 +136,7 @@ func runPollutionCheck(_ string, clean bool, yes bool) {
 	}
 
 	fmt.Printf("%s Deleted %d test issues\n", ui.RenderPass("✓"), deleted)
-	fmt.Printf("\nCleanup complete. To restore, run: bd import %s\n", backupPath)
+	fmt.Printf("\nCleanup complete. To restore, run: bd init --from-jsonl %s\n", backupPath)
 }
 
 func init() {

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -18,8 +18,12 @@ var exportCmd = &cobra.Command{
 	Long: `Export all issues to JSONL (newline-delimited JSON) format.
 
 Each line is a complete JSON object representing one issue, including its
-labels, dependencies, and comment count. The output is compatible with
-'bd import' for round-trip backup and restore.
+labels, dependencies, and comment count.
+
+This command is for issue export, migration, and interoperability. It does
+not produce the JSONL backup snapshot used by 'bd backup restore'. For
+supported backup/restore flows, use 'bd backup', 'bd backup export-git',
+and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
 like agents, rigs, roles, and messages). Use --all to include everything.

--- a/cmd/bd/tips.go
+++ b/cmd/bd/tips.go
@@ -383,7 +383,7 @@ func initDefaultTips() {
 	// This is a proactive health check that trumps educational tips (ox-cli pattern)
 	InjectTip(
 		"sync_conflict",
-		"Run 'bd sync' to resolve sync conflict",
+		"Run 'bd dolt pull' to resolve sync conflict",
 		200, // Higher than Claude setup - sync issues are urgent
 		0,   // No frequency limit - always show when applicable
 		1.0, // 100% probability - always show when condition is true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,7 +49,7 @@ bd's core design enables a distributed, git-backed issue tracker that feels like
 
 **Dolt for distribution:** Native push/pull to Dolt remotes (DoltHub, S3, GCS). No special sync server needed. Issues travel with your code. Offline work just works.
 
-**Export for portability:** `bd export` outputs JSONL format for data migration and interoperability. Use `bd init --from-jsonl` to bootstrap a new database from an export.
+**Export and backup:** `bd export` outputs issue JSONL for data migration and interoperability. Use `bd backup` and `bd backup restore` for supported JSONL backup snapshots, and `bd backup export-git` / `bd backup fetch-git` when you want those snapshots stored in a git branch.
 
 ## Write Path
 
@@ -85,7 +85,8 @@ All queries run directly against the local Dolt database:
 2. **Sync:** Use `bd dolt pull` to fetch updates from Dolt remotes
 
 Key implementation:
-- Import (for bootstrapping/migration): `cmd/bd/import.go`
+- JSONL backup restore: `cmd/bd/backup_restore.go`
+- Issue bootstrap/migration: `cmd/bd/init.go`
 - Dolt storage: `internal/storage/dolt/`
 
 ## Hash-Based Collision Prevention
@@ -296,7 +297,8 @@ Each issue in the Dolt database (and in JSONL exports via `bd export`) has the f
 | Dolt implementation | `internal/storage/dolt/` |
 | RPC protocol | `internal/rpc/protocol.go`, `server_*.go` |
 | Export logic (portability) | `cmd/bd/export.go` |
-| Import logic (migration) | `cmd/bd/import.go` |
+| JSONL backup restore | `cmd/bd/backup_restore.go` |
+| Issue bootstrap/migration | `cmd/bd/init.go` |
 
 ## Wisps and Molecules
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -561,13 +561,19 @@ bd gate add-waiter <gate-id> <waiter>
 
 ## Database Management
 
-### Export / Bootstrap
+### Export / Backup / Bootstrap
 
 ```bash
-# Export issues to JSONL
+# Export issues to issue JSONL
 bd export -o issues.jsonl
 
-# Bootstrap a new database from an export
+# Write or restore the supported JSONL backup snapshot
+bd backup
+bd backup restore
+bd backup export-git
+bd backup fetch-git
+
+# Bootstrap a new database from an issue export
 bd init --from-jsonl                            # Reads .beads/issues.jsonl
 
 # Configure orphan handling for pulls and bootstrapping

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -151,7 +151,7 @@ The sync mode controls how beads synchronizes data with git and/or Dolt remotes.
 
 #### Sync Mode
 
-Beads uses `dolt-native` sync mode exclusively. Dolt remotes handle sync directly with cell-level merge. Use `bd export` for data portability and `bd init --from-jsonl` to bootstrap a new database from an export.
+Beads uses `dolt-native` sync mode exclusively. Dolt remotes handle sync directly with cell-level merge. Use `bd export` for issue portability, `bd backup` / `bd backup restore` for supported JSONL backup snapshots, and `bd backup export-git` / `bd backup fetch-git` to move those snapshots through a git branch.
 
 #### Sync Triggers
 

--- a/docs/DOLT-BACKEND.md
+++ b/docs/DOLT-BACKEND.md
@@ -123,7 +123,7 @@ Beads uses `dolt-native` sync mode exclusively:
 - Uses Dolt remotes (DoltHub, S3, GCS, etc.)
 - Native database-level sync with cell-level merge
 - Supports branching and merging
-- `bd export` available for data portability; `bd init --from-jsonl` for bootstrapping from exports
+- `bd export` available for issue portability; `bd backup` / `bd backup restore` for JSONL backup snapshots
 
 ## Dolt Remotes
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -198,7 +198,7 @@ bd dolt push    # Push changes to Dolt remote
 bd dolt pull    # Pull changes from Dolt remote
 ```
 
-The `bd export` command exists for data portability (e.g., backing up data), and `bd init --from-jsonl` can bootstrap a new database from an export. These are not needed for day-to-day sync.
+The `bd export` command exists for issue portability and interchange. For supported backup and restore flows, use `bd backup` to write JSONL backup snapshots, `bd backup restore` to restore them, and `bd backup export-git` / `bd backup fetch-git` if you want those snapshots published to a git branch. None of these are needed for day-to-day Dolt sync.
 
 ### What if my database feels stale after a colleague pushes changes?
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -443,12 +443,14 @@ bd config set sync.branch ""  # Disable sync branch feature
 For **physical database corruption** (disk failures, power loss, filesystem errors):
 
 ```bash
-# If corrupted, rebuild from a Dolt remote or from an export backup
+# If corrupted, rebuild from a Dolt remote or from a backup snapshot
 mv .beads/dolt .beads/dolt.backup
 bd init
 bd dolt pull    # Pull from Dolt remote if configured
-# Or re-initialize from a backup export:
-# bd init --from-jsonl
+# Or restore from a local backup snapshot:
+# bd backup restore
+# Or fetch one from a backup branch:
+# bd backup fetch-git
 ```
 
 For **logical consistency issues** (ID collisions from branch merges, parallel workers):

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -34,7 +34,7 @@ flowchart TD
 :::info Source of Truth
 **Dolt** is the source of truth. Every write auto-commits to Dolt history, providing full version control, branching, and merge capabilities at the database level.
 
-Recovery is straightforward: pull from a Dolt remote with `bd dolt pull`, or use `bd init --from-jsonl` to bootstrap from a JSONL backup.
+Recovery is straightforward: pull from a Dolt remote with `bd dolt pull`, restore a local JSONL backup snapshot with `bd backup restore`, or fetch one from a git branch with `bd backup fetch-git`.
 :::
 
 ### Why Dolt?
@@ -139,7 +139,7 @@ See [Sync Failures Recovery](/recovery/sync-failures) for sync race condition tr
 Dolt's version control makes recovery straightforward:
 
 1. **Lost database?** → Pull from Dolt remote: `bd dolt pull`
-2. **Have a JSONL backup?** → Bootstrap from it: `bd init --from-jsonl backup.jsonl`
+2. **Have a JSONL backup snapshot?** → Restore it: `bd backup restore`
 3. **Merge conflicts?** → Dolt handles cell-level merge natively
 
 ### Universal Recovery Sequence

--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -124,7 +124,11 @@ bd migrate
 If you need to restore from a JSONL backup:
 
 ```bash
-bd init --from-jsonl backup.jsonl
+bd init
+bd backup restore
+
+# Or fetch the latest snapshot from a backup git branch
+bd backup fetch-git
 ```
 
 Or pull from a Dolt remote:

--- a/website/docs/reference/troubleshooting.md
+++ b/website/docs/reference/troubleshooting.md
@@ -69,8 +69,11 @@ bd doctor --fix
 # Or pull from Dolt remote
 bd dolt pull
 
-# Or bootstrap from a JSONL backup if available
-bd init --from-jsonl backup.jsonl
+# Or restore from a local JSONL backup snapshot
+bd backup restore
+
+# Or fetch the latest snapshot from a backup git branch
+bd backup fetch-git
 ```
 
 ## Dolt Server Issues
@@ -113,8 +116,11 @@ bd hooks status
 ### Recovery from backup
 
 ```bash
-# Bootstrap from JSONL backup
-bd init --from-jsonl backup.jsonl
+# Restore from a local JSONL backup snapshot
+bd backup restore
+
+# Or fetch the latest snapshot from a backup git branch
+bd backup fetch-git
 
 # Or pull from Dolt remote
 bd dolt pull

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -24,7 +24,8 @@ bd show bd-42 --json                      # Show details
 bd update bd-42 --claim                   # Start work
 bd close bd-42 --reason "Done"            # Close issue
 bd ready --json                           # Show unblocked work
-bd sync                                   # Sync to git
+bd dolt push                              # Push to Dolt remote
+bd backup export-git                      # Publish backup snapshot to a git branch
 ```
 
 ## For AI Agents
@@ -32,7 +33,8 @@ bd sync                                   # Sync to git
 - Always use `--json` for programmatic access
 - Always include `--description` when creating issues
 - Use `--deps discovered-from:<id>` to link found issues
-- Run `bd sync` at end of every session
+- Use `bd dolt push` / `bd dolt pull` for Dolt remotes
+- Use `bd backup` / `bd backup export-git` for portable backups
 
 ## Key Concepts
 
@@ -41,27 +43,27 @@ bd sync                                   # Sync to git
 - **Formulas**: Declarative workflow templates (TOML/JSON)
 - **Molecules**: Work graphs from formulas
 - **Gates**: Async coordination (human/timer/github)
-- **Wisps**: Ephemeral workflows (don't sync to git)
+- **Wisps**: Ephemeral workflows (excluded from JSONL backups)
 
 ## Recovery
 
 Quick fixes for common issues:
 
-- Database Corruption: `git checkout HEAD~1 -- .beads/`
-- Merge Conflicts: Resolve JSONL conflicts, then `bd sync`
+- Database Recovery: `bd backup restore` or `bd backup fetch-git`
+- Merge Conflicts: Use Dolt merge/recovery tools, then `bd dolt pull`
 - Circular Dependencies: `bd doctor` (diagnose only, NEVER --fix)
-- Sync Failures: `bd sync --import-only`
+- Sync Failures: `bd dolt pull`
 
 Full runbooks: https://steveyegge.github.io/beads/recovery/
 
 ## Session Close Protocol
 
 Before ending any AI session:
-1. `bd sync` - push changes to git
-2. `bd status` - verify clean state
+1. `bd dolt push` - if using a Dolt remote
+2. `git push` - publish your code changes
 3. Resolve conflicts before closing
 
-WARNING: Skipping sync causes data loss in multi-agent workflows.
+WARNING: Skipping sync or backup publication causes stale state in multi-agent workflows.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- add bd backup fetch-git as the restore-side companion to bd backup export-git
- add a stable manifest.json to git-published backup snapshots and share the git/worktree helpers between backup git commands
- clean up backup/export/help text and key docs to distinguish bd export from bd backup and document the git backup workflow

## Testing
- GOTOOLCHAIN=auto ./scripts/test-cgo.sh -run '^(TestBackupExportGit|TestBackupFetchGit|TestBackupExport|TestBackupRestore.*)$' ./cmd/bd
- GOTOOLCHAIN=auto golangci-lint run ./cmd/bd/...
- ./scripts/check-doc-flags.sh