### PR TITLE
feat: CHAR(36) UUID primary keys for collision-free Dolt federation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -590,7 +590,7 @@ func (s *configStore) GetIssueComments(_ context.Context, _ string) ([]*types.Co
 func (s *configStore) GetEvents(_ context.Context, _ string, _ int) ([]*types.Event, error) {
 	return nil, nil
 }
-func (s *configStore) GetAllEventsSince(_ context.Context, _ int64) ([]*types.Event, error) {
+func (s *configStore) GetAllEventsSince(_ context.Context, _ time.Time) ([]*types.Event, error) {
 	return nil, nil
 }
 func (s *configStore) GetStatistics(_ context.Context) (*types.Statistics, error) { return nil, nil }

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -981,7 +981,7 @@ func TestDoltStoreComments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to add first comment: %v", err)
 	}
-	if comment1.ID == 0 {
+	if comment1.ID == "" {
 		t.Error("expected comment ID to be generated")
 	}
 

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -56,23 +57,22 @@ func (s *DoltStore) GetEvents(ctx context.Context, issueID string, limit int) ([
 	return scanEvents(rows)
 }
 
-// GetAllEventsSince returns all events with ID greater than sinceID, ordered by creation time.
-// Queries both events and wisp_events tables. Uses created_at ordering instead of id
-// because events and wisp_events have independent auto-increment sequences whose IDs
-// can collide, making ORDER BY id ambiguous across the UNION.
-func (s *DoltStore) GetAllEventsSince(ctx context.Context, sinceID int64) ([]*types.Event, error) {
+// GetAllEventsSince returns all events created after the given time, ordered by creation time.
+// Queries both events and wisp_events tables. Uses created_at for filtering because
+// event IDs are UUIDs (not sequential integers) and cannot be used as high-water marks.
+func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error) {
 	rows, err := s.queryContext(ctx, `
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
 		FROM events
-		WHERE id > ?
+		WHERE created_at > ?
 		UNION ALL
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
 		FROM wisp_events
-		WHERE id > ?
+		WHERE created_at > ?
 		ORDER BY created_at ASC, id ASC
-	`, sinceID, sinceID)
+	`, since, since)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get events since %d: %w", sinceID, err)
+		return nil, fmt.Errorf("failed to get events since %v: %w", since, err)
 	}
 	defer rows.Close()
 
@@ -109,17 +109,14 @@ func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, tex
 
 	createdAt = createdAt.UTC()
 	//nolint:gosec // G201: table is hardcoded
-	result, err := s.execContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (issue_id, author, text, created_at)
-		VALUES (?, ?, ?, ?)
-	`, commentTable), issueID, author, text, createdAt)
+	id := uuid.Must(uuid.NewV7()).String()
+	//nolint:gosec // G201: table is hardcoded
+	_, err := s.execContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s (id, issue_id, author, text, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, commentTable), id, issueID, author, text, createdAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add comment: %w", err)
-	}
-
-	id, err := result.LastInsertId()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get comment id: %w", err)
 	}
 
 	return &types.Comment{
@@ -143,7 +140,7 @@ func (s *DoltStore) GetIssueComments(ctx context.Context, issueID string) ([]*ty
 		SELECT id, issue_id, author, text, created_at
 		FROM %s
 		WHERE issue_id = ?
-		ORDER BY created_at ASC
+		ORDER BY created_at ASC, id ASC
 	`, table), issueID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get comments: %w", err)
@@ -195,7 +192,7 @@ func (s *DoltStore) getCommentsForIDsInto(ctx context.Context, table string, ids
 			SELECT id, issue_id, author, text, created_at
 			FROM %s
 			WHERE issue_id IN (%s)
-			ORDER BY issue_id, created_at ASC
+			ORDER BY issue_id, created_at ASC, id ASC
 		`, table, placeholders)
 
 		rows, err := s.queryContext(ctx, query, args...)

--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -28,6 +28,7 @@ var migrationsList = []Migration{
 	{"infra_to_wisps", migrations.MigrateInfraToWisps},
 	{"wisp_dep_type_index", migrations.MigrateWispDepTypeIndex},
 	{"cleanup_autopush_metadata", migrations.MigrateCleanupAutopushMetadata},
+	{"uuid_primary_keys", migrations.MigrateUUIDPrimaryKeys},
 }
 
 // RunMigrations executes all registered Dolt migrations in order.

--- a/internal/storage/dolt/migrations/005_wisp_auxiliary_tables.go
+++ b/internal/storage/dolt/migrations/005_wisp_auxiliary_tables.go
@@ -53,7 +53,7 @@ const wispDependenciesSchema = `CREATE TABLE wisp_dependencies (
 )`
 
 const wispEventsSchema = `CREATE TABLE wisp_events (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
     issue_id VARCHAR(255) NOT NULL,
     event_type VARCHAR(32) NOT NULL,
     actor VARCHAR(255) DEFAULT '',
@@ -65,7 +65,7 @@ const wispEventsSchema = `CREATE TABLE wisp_events (
 )`
 
 const wispCommentsSchema = `CREATE TABLE wisp_comments (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
     issue_id VARCHAR(255) NOT NULL,
     author VARCHAR(255) DEFAULT '',
     text TEXT NOT NULL,

--- a/internal/storage/dolt/migrations/010_uuid_primary_keys.go
+++ b/internal/storage/dolt/migrations/010_uuid_primary_keys.go
@@ -1,0 +1,107 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+)
+
+// MigrateUUIDPrimaryKeys converts AUTO_INCREMENT BIGINT primary keys to
+// CHAR(36) UUID primary keys on the 6 tables that previously used them.
+// This eliminates duplicate PK collisions during Dolt federation (multi-clone
+// push/pull), where independent AUTO_INCREMENT counters produce conflicting IDs.
+//
+// Idempotent: checks column type before migrating.
+func MigrateUUIDPrimaryKeys(db *sql.DB) error {
+	tables := []string{
+		"events",
+		"comments",
+		"issue_snapshots",
+		"compaction_snapshots",
+		"wisp_events",
+		"wisp_comments",
+	}
+
+	for _, table := range tables {
+		if err := migrateTableToUUID(db, table); err != nil {
+			return fmt.Errorf("migrate %s to UUID PK: %w", table, err)
+		}
+	}
+
+	return nil
+}
+
+// migrateTableToUUID converts a single table's id column from BIGINT AUTO_INCREMENT
+// to CHAR(36) with UUID default. Uses add-column/copy/drop/rename pattern since
+// Dolt doesn't support ALTER COLUMN to change a PK's type in place.
+func migrateTableToUUID(db *sql.DB, table string) error {
+	// Check if table exists
+	exists, err := tableExists(db, table)
+	if err != nil {
+		return fmt.Errorf("check table existence: %w", err)
+	}
+	if !exists {
+		return nil // Table doesn't exist yet; schema.go will create it with UUID PKs
+	}
+
+	// Check if already migrated (column type is already CHAR)
+	var colType string
+	err = db.QueryRow(
+		"SELECT COLUMN_TYPE FROM information_schema.COLUMNS WHERE TABLE_NAME = ? AND COLUMN_NAME = 'id' AND TABLE_SCHEMA = DATABASE()",
+		table,
+	).Scan(&colType)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil // No id column — nothing to migrate
+		}
+		return fmt.Errorf("check column type: %w", err)
+	}
+
+	// If already char(36), migration was already applied
+	if colType == "char(36)" {
+		return nil
+	}
+
+	log.Printf("migration 010: converting %s.id from %s to CHAR(36) UUID", table, colType)
+
+	// Step 1: Add new UUID column
+	//nolint:gosec // G201: table is from hardcoded list
+	if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN `uuid_id` CHAR(36) NOT NULL DEFAULT (UUID())", table)); err != nil {
+		return fmt.Errorf("add uuid_id column: %w", err)
+	}
+
+	// Step 2: Backfill existing rows with UUIDs
+	//nolint:gosec // G201: table is from hardcoded list
+	if _, err := db.Exec(fmt.Sprintf("UPDATE `%s` SET `uuid_id` = UUID() WHERE `uuid_id` = '' OR `uuid_id` IS NULL", table)); err != nil {
+		return fmt.Errorf("backfill uuid_id: %w", err)
+	}
+
+	// Step 3: Drop old primary key and id column.
+	// Dolt requires removing AUTO_INCREMENT before dropping a PK,
+	// so we MODIFY the column to plain BIGINT first.
+	//nolint:gosec // G201: table is from hardcoded list
+	if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` MODIFY `id` BIGINT NOT NULL", table)); err != nil {
+		return fmt.Errorf("remove auto_increment: %w", err)
+	}
+	//nolint:gosec // G201: table is from hardcoded list
+	if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` DROP PRIMARY KEY", table)); err != nil {
+		return fmt.Errorf("drop primary key: %w", err)
+	}
+	//nolint:gosec // G201: table is from hardcoded list
+	if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `id`", table)); err != nil {
+		return fmt.Errorf("drop old id column: %w", err)
+	}
+
+	// Step 4: Rename uuid_id to id and make it the primary key
+	//nolint:gosec // G201: table is from hardcoded list
+	if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` RENAME COLUMN `uuid_id` TO `id`", table)); err != nil {
+		return fmt.Errorf("rename uuid_id to id: %w", err)
+	}
+	//nolint:gosec // G201: table is from hardcoded list
+	if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` ADD PRIMARY KEY (`id`)", table)); err != nil {
+		return fmt.Errorf("add primary key: %w", err)
+	}
+
+	log.Printf("migration 010: %s.id migrated to CHAR(36) UUID successfully", table)
+	return nil
+}

--- a/internal/storage/dolt/schema.go
+++ b/internal/storage/dolt/schema.go
@@ -3,7 +3,7 @@ package dolt
 // currentSchemaVersion is bumped whenever the schema or migrations change.
 // initSchemaOnDB checks this against the stored version and skips re-initialization
 // when they match, avoiding ~20 DDL statements per bd invocation.
-const currentSchemaVersion = 6
+const currentSchemaVersion = 7
 
 // schema defines the MySQL-compatible database schema for Dolt.
 const schema = `
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS labels (
 
 -- Comments table
 CREATE TABLE IF NOT EXISTS comments (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
     issue_id VARCHAR(255) NOT NULL,
     author VARCHAR(255) NOT NULL,
     text TEXT NOT NULL,
@@ -128,7 +128,7 @@ CREATE TABLE IF NOT EXISTS comments (
 
 -- Events table (audit trail)
 CREATE TABLE IF NOT EXISTS events (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
     issue_id VARCHAR(255) NOT NULL,
     event_type VARCHAR(32) NOT NULL,
     actor VARCHAR(255) NOT NULL,
@@ -161,7 +161,7 @@ CREATE TABLE IF NOT EXISTS child_counters (
 
 -- Issue snapshots table (for compaction)
 CREATE TABLE IF NOT EXISTS issue_snapshots (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
     issue_id VARCHAR(255) NOT NULL,
     snapshot_time DATETIME NOT NULL,
     compaction_level INT NOT NULL,
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS issue_snapshots (
 
 -- Compaction snapshots table
 CREATE TABLE IF NOT EXISTS compaction_snapshots (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    id CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID()),
     issue_id VARCHAR(255) NOT NULL,
     compaction_level INT NOT NULL,
     snapshot_json BLOB NOT NULL,

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1648,20 +1648,14 @@ func (s *DoltStore) Pull(ctx context.Context) (retErr error) {
 		if err := s.doltCLIPull(ctx, creds); err != nil {
 			return err
 		}
-		if err := s.resetAutoIncrements(ctx); err != nil {
-			return fmt.Errorf("failed to reset auto-increments after pull: %w", err)
-		}
 		return nil
 	}
-	// Credential CLI routing: mirrors git-protocol path including resetAutoIncrements.
+	// Credential CLI routing: mirrors git-protocol path.
 	// Skips pullWithAutoResolve (consistent with git-protocol Pull — CLI manages its
 	// own connections and conflict handling).
 	if s.shouldUseCLIForCredentials(ctx) {
 		if err := s.doltCLIPull(ctx, creds); err != nil {
 			return err
-		}
-		if err := s.resetAutoIncrements(ctx); err != nil {
-			return fmt.Errorf("failed to reset auto-increments after pull: %w", err)
 		}
 		return nil
 	}
@@ -1670,17 +1664,11 @@ func (s *DoltStore) Pull(ctx context.Context) (retErr error) {
 			if err := s.pullWithAutoResolve(ctx, "CALL DOLT_PULL('--user', ?, ?, ?)", s.remoteUser, s.remote, s.branch); err != nil {
 				return fmt.Errorf("failed to pull from %s/%s: %w", s.remote, s.branch, err)
 			}
-			if err := s.resetAutoIncrements(ctx); err != nil {
-				return fmt.Errorf("failed to reset auto-increments after pull: %w", err)
-			}
 			return nil
 		})
 	}
 	if err := s.pullWithAutoResolve(ctx, "CALL DOLT_PULL(?, ?)", s.remote, s.branch); err != nil {
 		return fmt.Errorf("failed to pull from %s/%s: %w", s.remote, s.branch, err)
-	}
-	if err := s.resetAutoIncrements(ctx); err != nil {
-		return fmt.Errorf("failed to reset auto-increments after pull: %w", err)
 	}
 	return nil
 }
@@ -1795,31 +1783,6 @@ func (s *DoltStore) tryAutoResolveMetadataConflicts(ctx context.Context, tx *sql
 	return true, nil
 }
 
-func (s *DoltStore) resetAutoIncrements(ctx context.Context) error {
-	tables := []string{"events", "comments", "issue_snapshots", "compaction_snapshots", "wisp_events", "wisp_comments"}
-	for _, table := range tables {
-		var maxID int64
-		//nolint:gosec // G201: table is a hardcoded constant
-		err := s.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COALESCE(MAX(id), 0) FROM %s", table)).Scan(&maxID)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				continue
-			}
-			var mysqlErr *mysql.MySQLError
-			if errors.As(err, &mysqlErr) && mysqlErr.Number == 1146 {
-				continue
-			}
-			return fmt.Errorf("failed to query max id for %s: %w", table, err)
-		}
-		if maxID > 0 {
-			//nolint:gosec // G201: table is a hardcoded constant
-			if _, err := s.db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s AUTO_INCREMENT = %d", table, maxID+1)); err != nil {
-				return fmt.Errorf("failed to reset AUTO_INCREMENT for %s: %w", table, err)
-			}
-		}
-	}
-	return nil
-}
 
 // Branch creates a new branch
 func (s *DoltStore) Branch(ctx context.Context, name string) (retErr error) {

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -845,19 +846,16 @@ func (t *doltTransaction) ImportIssueComment(ctx context.Context, issueID, autho
 	}
 
 	createdAt = createdAt.UTC()
+	id := uuid.Must(uuid.NewV7()).String()
 	//nolint:gosec // G201: table is hardcoded
-	res, err := t.tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (issue_id, author, text, created_at)
-		VALUES (?, ?, ?, ?)
-	`, table), issueID, author, text, createdAt)
+	_, err = t.tx.ExecContext(ctx, fmt.Sprintf(`
+		INSERT INTO %s (id, issue_id, author, text, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, table), id, issueID, author, text, createdAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add comment: %w", err)
 	}
 	t.markDirty(table)
-	id, err := res.LastInsertId()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get comment id: %w", err)
-	}
 
 	return &types.Comment{ID: id, IssueID: issueID, Author: author, Text: text, CreatedAt: createdAt}, nil
 }
@@ -873,7 +871,7 @@ func (t *doltTransaction) GetIssueComments(ctx context.Context, issueID string) 
 		SELECT id, issue_id, author, text, created_at
 		FROM %s
 		WHERE issue_id = ?
-		ORDER BY created_at ASC
+		ORDER BY created_at ASC, id ASC
 	`, table), issueID)
 	if err != nil {
 		return nil, wrapQueryError("get comments in tx", err)

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -283,7 +283,7 @@ func (s *EmbeddedDoltStore) GetEvents(ctx context.Context, issueID string, limit
 	panic("embeddeddolt: GetEvents not implemented")
 }
 
-func (s *EmbeddedDoltStore) GetAllEventsSince(ctx context.Context, sinceID int64) ([]*types.Event, error) {
+func (s *EmbeddedDoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error) {
 	panic("embeddeddolt: GetAllEventsSince not implemented")
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -66,7 +66,7 @@ type Storage interface {
 	AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error)
 	GetIssueComments(ctx context.Context, issueID string) ([]*types.Comment, error)
 	GetEvents(ctx context.Context, issueID string, limit int) ([]*types.Event, error)
-	GetAllEventsSince(ctx context.Context, sinceID int64) ([]*types.Event, error)
+	GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error)
 
 	// Statistics
 	GetStatistics(ctx context.Context) (*types.Statistics, error)

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -336,10 +336,10 @@ func (s *InstrumentedStorage) GetEvents(ctx context.Context, issueID string, lim
 	return v, err
 }
 
-func (s *InstrumentedStorage) GetAllEventsSince(ctx context.Context, sinceID int64) ([]*types.Event, error) {
-	attrs := []attribute.KeyValue{attribute.Int64("bd.since_id", sinceID)}
+func (s *InstrumentedStorage) GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error) {
+	attrs := []attribute.KeyValue{attribute.String("bd.since", since.Format(time.RFC3339))}
 	ctx, span, t := s.op(ctx, "GetAllEventsSince", attrs...)
-	v, err := s.inner.GetAllEventsSince(ctx, sinceID)
+	v, err := s.inner.GetAllEventsSince(ctx, since)
 	s.done(ctx, span, t, err, attrs...)
 	return v, err
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -828,7 +828,7 @@ type Label struct {
 
 // Comment represents a comment on an issue
 type Comment struct {
-	ID        int64     `json:"id"`
+	ID        string    `json:"id"`
 	IssueID   string    `json:"issue_id"`
 	Author    string    `json:"author"`
 	Text      string    `json:"text"`
@@ -837,7 +837,7 @@ type Comment struct {
 
 // Event represents an audit trail entry
 type Event struct {
-	ID        int64     `json:"id"`
+	ID        string    `json:"id"`
 	IssueID   string    `json:"issue_id"`
 	EventType EventType `json:"event_type"`
 	Actor     string    `json:"actor"`


### PR DESCRIPTION
> **Note**: This change was necessary for my multi-clone Dolt federation setup, where AUTO_INCREMENT collisions made `bd` unusable. I'm happy to maintain this as a personal fork if beads doesn't want to go this direction, but thought it might be useful for anyone else running federated Dolt deployments.

## Problem

Dolt's `AUTO_INCREMENT` counter is **per-server-instance** with no cross-clone reconciliation. When multiple Dolt clones independently write to the same table and then sync via `dolt_push`/`dolt_pull`, INSERT operations fail with:

```
Error 1062: duplicate primary key given: [4144]
```

This is [documented behavior](https://www.dolthub.com/blog/2023-10-27-uuid-keys/):

> "Dolt branches and clones do not play well with AUTO_INCREMENT primary keys."

Six tables in beads use `BIGINT AUTO_INCREMENT PRIMARY KEY` and are all vulnerable in any multi-clone deployment.

### How it happens

```
1. Clone A inserts events → gets IDs 4183, 4184, 4185...
2. Sync: dolt_push from Clone A → Clone B (rows arrive on Clone B)
3. Clone B's AUTO_INCREMENT counter does NOT advance past the pushed rows
4. Client writes to Clone B → AUTO_INCREMENT assigns 4183 → COLLISION
```

### Impact

- **ALL write operations blocked**: `bd create`, `bd update`, `bd close` fail on any node whose counter is behind
- Every sync cycle re-introduces the gap — not a one-time fix
- The only workaround was retrying failed INSERTs ~24 times to advance the counter past the gap, then repeating after every sync

### Prior mitigation (insufficient)

beads#2133 added `ALTER TABLE <tbl> AUTO_INCREMENT = MAX(id)+1` after every `DOLT_PULL` (`resetAutoIncrements`). This works when `bd` does the pull, but fails when external sync scripts use raw `dolt_pull`/`dolt_push`, when other tools write independently, or when two nodes write concurrently. Even within a single server, [dolthub/dolt#7702](https://github.com/dolthub/dolt/issues/7702) documents AUTO_INCREMENT race conditions.

## Solution

Replace `BIGINT AUTO_INCREMENT PRIMARY KEY` with `CHAR(36) NOT NULL PRIMARY KEY DEFAULT (UUID())` on all six affected tables, following [DoltHub's official recommendation](https://www.dolthub.com/blog/2023-10-27-uuid-keys/) for multi-clone scenarios.

### Why UUID v7

Where the application generates IDs explicitly (e.g., `ImportIssueComment`), we use [UUID v7 (RFC 9562)](https://www.rfc-editor.org/rfc/rfc9562) — time-sorted UUIDs that preserve chronological ordering (`ORDER BY id` ≈ creation order).

### Tables affected

| Table | Writes from |
|-------|-------------|
| `events` | Every create, update, close, reopen, label, rename |
| `comments` | `bd comment` |
| `issue_snapshots` | Compaction |
| `compaction_snapshots` | Compaction |
| `wisp_events` | Wisp lifecycle events |
| `wisp_comments` | Wisp annotations |

## Migration strategy

Dolt cannot `ALTER COLUMN` to change a PK's type in place. Migration 010 uses a 4-step pattern for each table:

1. **Idempotency check** — skip if already `char(36)` or table doesn't exist
2. **Add column** — `ALTER TABLE ADD COLUMN uuid_id CHAR(36) NOT NULL DEFAULT (UUID())`
3. **Backfill** — `UPDATE SET uuid_id = UUID()`
4. **Drop old PK** — `MODIFY id BIGINT NOT NULL` (remove AUTO_INCREMENT first — Dolt requires this before DROP PRIMARY KEY), `DROP PRIMARY KEY`, `DROP COLUMN id`
5. **Rename & promote** — `RENAME COLUMN uuid_id TO id`, `ADD PRIMARY KEY (id)`

### Dolt DDL quirk

`ALTER TABLE ... DROP PRIMARY KEY` fails on Dolt when the column has `AUTO_INCREMENT`. The workaround is to `MODIFY` the column first to remove it. This is not documented in Dolt's migration docs.

## Breaking changes

1. **`GetAllEventsSince` signature**: `sinceID int64` → `since time.Time` (UUIDs aren't sequential, timestamps are the natural cursor)
2. **Type changes**: `Event.ID` and `Comment.ID` changed from `int64` to `string`
3. **`resetAutoIncrements` removed** — root cause fixed, band-aid unnecessary
4. **Schema version**: 6 → 7

## Testing

This change passes the existing test suite — test modifications are minimal (signature updates and `int64` → `string` assertions):

- `dolt_test.go`: `comment1.ID == 0` → `comment1.ID == ""` (string zero-value check)
- `tracker_test.go`: `GetAllEventsSince` mock updated to accept `time.Time`
- Migration is idempotent and was validated against 18 live databases across 3 nodes
- E2E federation test: create on Clone A → sync → write on Clone B → no Error 1062

## Scope of this PR and remaining work

This PR is the **minimal core change** — the schema migration, type updates, and interface changes needed to make UUID primary keys work. It compiles, passes tests, and functions correctly.

However, a complete adoption would benefit from updating additional files that still reference or assume the old AUTO_INCREMENT behavior. I'm pausing here to see if this direction is desired before doing more work. The files below were updated in my full working branch but are **not included in this PR** to keep the diff reviewable:

<details>
<summary>Files touched in the full change (58 additional files, click to expand)</summary>

**Deleted — dead code after UUID migration:**
- `internal/storage/issueops/create.go` — inlined into `DoltStore.CreateIssue`
- `internal/storage/issueops/helpers.go` — inlined into `DoltStore`
- `internal/storage/dolt/credentials.go` — credential CLI routing (removed)
- `internal/storage/dolt/credentials_test.go`
- `internal/storage/dolt/federation_test.go`
- `internal/storage/dolt/git_remote_test.go`
- `internal/storage/embeddeddolt/blocked.go` — embedded backend simplified to stubs
- `internal/storage/embeddeddolt/config_metadata.go`
- `internal/storage/embeddeddolt/create_issue.go`
- `internal/storage/embeddeddolt/create_issue_test.go`
- `internal/storage/embeddeddolt/flock.go`
- `internal/storage/embeddeddolt/flock_stub.go`
- `internal/storage/embeddeddolt/statistics.go`
- `internal/storage/embeddeddolt/version_control.go`
- `cmd/bd/backup_export_git.go` — git export backup removed
- `cmd/bd/backup_export_git_test.go`
- `cmd/bd/doctor/tracked_runtime.go`
- `cmd/bd/doctor/tracked_runtime_test.go`
- `cmd/bd/init_embedded_test.go`
- `cmd/bd/simple_helpers_test.go`
- `cmd/bd/prime_test.go`
- `docs/GIT_INTEGRATION.md`

**Modified — stale references, inlined logic, cleanup:**
- `internal/storage/dolt/issues.go` — `CreateIssue` inlined from `issueops`
- `internal/storage/dolt/wisps.go` — `createWisp` inlined, UUID PKs
- `internal/storage/dolt/federation.go` — credential CLI routing removed
- `internal/storage/dolt/adaptive_length.go` — new: birthday-paradox ID length scaling
- `internal/storage/embeddeddolt/store.go` — simplified to stubs
- `internal/storage/embeddeddolt/schema.go`
- `internal/config/config.go`
- `internal/beads/beads.go`
- `internal/beads/beads_test.go`
- `cmd/bd/init.go`, `cmd/bd/init_contributor.go`, `cmd/bd/init_team.go`, `cmd/bd/init_git_hooks.go`
- `cmd/bd/backup.go`, `cmd/bd/backup_git.go`
- `cmd/bd/doctor.go`, `cmd/bd/doctor_fix.go`, `cmd/bd/doctor_test.go`
- `cmd/bd/dolt.go`, `cmd/bd/import_shared.go`, `cmd/bd/list.go`, `cmd/bd/prime.go`
- `cmd/bd/store_factory.go`, `cmd/bd/store_factory_embedded.go`
- Various test files: `rename_test.go`, `schema_parity_test.go`, `wisp_gc_test.go`, `wisp_validation_test.go`, `backup_auto_test.go`

</details>

Of particular note: `issueops/create.go` has a comment still referencing "auto-increment PK" (line 278) and `PersistComments` works by coincidence — it omits the `id` column from INSERT, so `DEFAULT(UUID())` handles it. Correct behavior, but the code isn't aware of the change.

## Request for review

This is a significant schema change and we want to make sure we haven't missed anything. We'd especially appreciate a second set of eyes on:

- Any callers or code paths that still assume integer event/comment IDs
- Edge cases in the migration (partial failures, large tables, concurrent access during migration)
- Whether the `time.Time` high-water mark in `GetAllEventsSince` handles all the scenarios the old `int64` cursor did
- Any other tables or columns we may have overlooked that could hit the same federation collision