### PR TITLE
fix: allow colons in unquoted query identifier values

### DIFF
--- a/internal/query/lexer.go
+++ b/internal/query/lexer.go
@@ -321,8 +321,10 @@ func isIdentStart(r rune) bool {
 }
 
 // isIdentChar returns true if r can be part of an identifier.
+// Colons are allowed so that namespaced labels (e.g., gt:merge-request) can
+// be used unquoted in query expressions like "label=gt:merge-request".
 func isIdentChar(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.' || r == ':'
 }
 
 // isDurationSuffix returns true if r is a valid duration suffix.

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -75,6 +75,12 @@ func TestLexer(t *testing.T) {
 			values:   []string{"title", "=", "hello world", ""},
 		},
 		{
+			name:     "compound expression with colon in label value",
+			input:    "ephemeral=true AND label=gt:merge-request AND status=open",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenAnd, TokenIdent, TokenEquals, TokenIdent, TokenAnd, TokenIdent, TokenEquals, TokenIdent, TokenEOF},
+			values:   []string{"ephemeral", "=", "true", "AND", "label", "=", "gt:merge-request", "AND", "status", "=", "open", ""},
+		},
+		{
 			name:     "case insensitive keywords",
 			input:    "status=open and priority>1 or type=bug",
 			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenAnd, TokenIdent, TokenGreater, TokenNumber, TokenOr, TokenIdent, TokenEquals, TokenIdent, TokenEOF},
@@ -101,6 +107,12 @@ func TestLexer(t *testing.T) {
 			name:     "quoted string with colon",
 			input:    `label="gt:merge-request"`,
 			expected: []TokenType{TokenIdent, TokenEquals, TokenString, TokenEOF},
+			values:   []string{"label", "=", "gt:merge-request", ""},
+		},
+		{
+			name:     "unquoted identifier with colon",
+			input:    "label=gt:merge-request",
+			expected: []TokenType{TokenIdent, TokenEquals, TokenIdent, TokenEOF},
 			values:   []string{"label", "=", "gt:merge-request", ""},
 		},
 	}
@@ -311,6 +323,13 @@ func TestEvaluatorSimpleQueries(t *testing.T) {
 		{
 			name:  "label with colon (quoted)",
 			query: `label="gt:merge-request"`,
+			expectFilter: func(f *types.IssueFilter) bool {
+				return len(f.Labels) == 1 && f.Labels[0] == "gt:merge-request"
+			},
+		},
+		{
+			name:  "label with colon (unquoted)",
+			query: "label=gt:merge-request",
 			expectFilter: func(f *types.IssueFilter) bool {
 				return len(f.Labels) == 1 && f.Labels[0] == "gt:merge-request"
 			},


### PR DESCRIPTION
## Summary

- Add `:` to `isIdentChar` in the query lexer so that namespaced labels like `gt:merge-request` can be used unquoted in `bd query` expressions
- Previously `bd query 'label=gt:merge-request'` failed with `unexpected character ':' at position 27`
- Quoted form (`label="gt:merge-request"`) continues to work unchanged

## Test plan

- [x] Added lexer test for unquoted identifier with colon
- [x] Added lexer test for compound expression with colon in label value
- [x] Added evaluator test for unquoted colon label filter
- [x] All existing query tests pass
- [x] Rebuilt `bd` and verified the exact failing command now parses successfully

Fixes: mo-qki