### PR TITLE
fix(doctor): auto-start Dolt on cold standalone checks

### DIFF
--- a/cmd/bd/doctor/config_values.go
+++ b/cmd/bd/doctor/config_values.go
@@ -363,7 +363,7 @@ func checkDatabaseConfigValues(repoPath string) []string {
 
 	// Open Dolt store in read-only mode
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		issues = append(issues, fmt.Sprintf("database: failed to open Dolt store: %v", err))
 		return issues

--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -73,7 +73,7 @@ func CheckDatabaseVersion(path string, cliVersion string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Database",
@@ -136,7 +136,7 @@ func CheckSchemaCompatibility(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Schema Compatibility",
@@ -179,7 +179,7 @@ func CheckDatabaseIntegrity(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Database Integrity",
@@ -247,7 +247,7 @@ func CheckProjectIdentity(path string) DoctorCheck {
 
 	// Check database for _project_id
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		// Can't open DB — report based on metadata.json alone
 		if !hasLocalID {
@@ -367,7 +367,7 @@ func CheckDatabaseSize(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Large Database",

--- a/cmd/bd/doctor/federation.go
+++ b/cmd/bd/doctor/federation.go
@@ -37,6 +37,7 @@ func doltServerConfig(beadsDir, doltPath string) *dolt.Config {
 		cfg.ServerPort = doltserver.DefaultConfig(beadsDir).Port
 		cfg.ServerUser = bcfg.GetDoltServerUser()
 	}
+	dolt.ApplyCLIAutoStart(beadsDir, cfg)
 	return cfg
 }
 

--- a/cmd/bd/doctor/federation_test.go
+++ b/cmd/bd/doctor/federation_test.go
@@ -96,6 +96,58 @@ func TestCheckFederationRemotesAPI_ServerNotRunning(t *testing.T) {
 	}
 }
 
+func TestDoltServerConfig_EnablesCLIAutoStartWithConfiguredPort(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("BEADS_DOLT_AUTO_START", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltDatabase:   "beads_test",
+		DoltServerPort: 12345,
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := doltServerConfig(beadsDir, filepath.Join(beadsDir, "dolt"))
+	if !result.AutoStart {
+		t.Fatal("doltServerConfig should enable CLI auto-start even with a configured server port")
+	}
+}
+
+func TestDoltServerConfig_HonorsAutoStartOptOut(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltDatabase:   "beads_test",
+		DoltServerPort: 12345,
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := doltServerConfig(beadsDir, filepath.Join(beadsDir, "dolt"))
+	if result.AutoStart {
+		t.Fatal("doltServerConfig should honor BEADS_DOLT_AUTO_START=0")
+	}
+}
+
 func TestCheckFederationRemotesAPI_PidFileInBeadsDir(t *testing.T) {
 	// Isolate from Gas Town daemon which would be detected as a running server
 	t.Setenv("GT_ROOT", "")

--- a/cmd/bd/doctor/installation.go
+++ b/cmd/bd/doctor/installation.go
@@ -69,7 +69,7 @@ func CheckPermissions(path string) DoctorCheck {
 			}
 			// Try to open Dolt store read-only to verify accessibility
 			ctx := context.Background()
-			store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+			store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 			if err != nil {
 				return DoctorCheck{
 					Name:    "Permissions",

--- a/cmd/bd/doctor/integrity.go
+++ b/cmd/bd/doctor/integrity.go
@@ -29,7 +29,7 @@ func CheckIDFormat(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Issue IDs",
@@ -107,7 +107,7 @@ func CheckDependencyCycles(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Dependency Cycles",
@@ -294,7 +294,7 @@ func CheckRepoFingerprint(path string) DoctorCheck {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return DoctorCheck{
 			Name:    "Repo Fingerprint",

--- a/cmd/bd/doctor/maintenance.go
+++ b/cmd/bd/doctor/maintenance.go
@@ -524,7 +524,7 @@ func loadMaintenanceIssues(path string) ([]*types.Issue, error) {
 
 func loadMaintenanceIssuesFromDatabase(beadsDir string) ([]*types.Issue, error) {
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bd/doctor/multirepo.go
+++ b/cmd/bd/doctor/multirepo.go
@@ -118,7 +118,7 @@ func readTypesFromDB(beadsDir string) ([]string, error) {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func findUnknownTypesInHydratedIssues(repoPath string, multiRepo *config.MultiRe
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return nil
 	}

--- a/cmd/bd/doctor/role.go
+++ b/cmd/bd/doctor/role.go
@@ -96,7 +96,7 @@ func getRoleFromDatabase(path string) string {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return ""
 	}

--- a/cmd/bd/doctor/suppress.go
+++ b/cmd/bd/doctor/suppress.go
@@ -27,7 +27,7 @@ func GetSuppressedChecks(path string) map[string]bool {
 	}
 
 	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
 		return suppressed
 	}

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -26,7 +26,7 @@ EXAMPLES:
   bd import backup.jsonl           # Import from a specific file
   bd import --dry-run              # Show what would be imported`,
 	GroupID: "sync",
-	RunE:   runImport,
+	RunE:    runImport,
 }
 
 var (

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -505,15 +505,9 @@ var rootCmd = &cobra.Command{
 		}
 		doltCfg.SyncGitRemote = config.GetString("sync.git-remote")
 
-		// Auto-start: enabled by default.
-		// Can be disabled by explicit config or env var.
-		doltCfg.AutoStart = true
-		if os.Getenv("BEADS_DOLT_AUTO_START") == "0" {
-			doltCfg.AutoStart = false
-		}
-		if v := config.GetString("dolt.auto-start"); v == "false" || v == "0" || v == "off" {
-			doltCfg.AutoStart = false
-		}
+		// Keep standalone CLI auto-start behavior centralized so doctor and
+		// other helper paths stay in lockstep with the main command path.
+		dolt.ApplyCLIAutoStart(beadsDir, doltCfg)
 
 		// Server mode defaults auto-commit to OFF because the server handles
 		// commits via its own transaction lifecycle; firing DOLT_COMMIT after

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -10,10 +10,45 @@ import (
 	"github.com/steveyegge/beads/internal/doltserver"
 )
 
+// ApplyCLIAutoStart sets the same standalone auto-start policy used by the
+// normal CLI path. This intentionally ignores metadata.json explicit-port
+// suppression so doctor and other CLI helper paths behave the same way as
+// cmd/bd/main.go on cold repo-local standalone setups.
+func ApplyCLIAutoStart(beadsDir string, cfg *Config) {
+	autoStartCfg := config.GetString("dolt.auto-start")
+	if autoStartCfg == "" {
+		autoStartCfg = config.GetStringFromDir(beadsDir, "dolt.auto-start")
+	}
+	cfg.AutoStart = resolveAutoStart(true, autoStartCfg, false)
+}
+
 // NewFromConfig creates a DoltStore based on the metadata.json configuration.
 // beadsDir is the path to the .beads directory.
 func NewFromConfig(ctx context.Context, beadsDir string) (*DoltStore, error) {
 	return NewFromConfigWithOptions(ctx, beadsDir, nil)
+}
+
+// NewFromConfigWithCLIOptions creates a DoltStore using the standalone CLI
+// auto-start policy from cmd/bd/main.go instead of the explicit-port
+// suppression used by library-style config opens. This is for CLI helper paths
+// like `bd doctor` that should behave the same way as normal top-level CLI
+// commands on cold repo-local standalone setups.
+func NewFromConfigWithCLIOptions(ctx context.Context, beadsDir string, cfg *Config) (*DoltStore, error) {
+	fileCfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+	if fileCfg == nil {
+		fileCfg = configfile.DefaultConfig()
+	}
+
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	applyResolvedConfig(beadsDir, fileCfg, cfg)
+	ApplyCLIAutoStart(beadsDir, cfg)
+
+	return New(ctx, cfg)
 }
 
 // NewFromConfigWithOptions creates a DoltStore with options from metadata.json.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1844,7 +1844,6 @@ func (s *DoltStore) tryAutoResolveMetadataConflicts(ctx context.Context, tx *sql
 	return true, nil
 }
 
-
 // Branch creates a new branch
 func (s *DoltStore) Branch(ctx context.Context, name string) (retErr error) {
 	ctx, span := doltTracer.Start(ctx, "dolt.branch",


### PR DESCRIPTION
Fixes #2583.

## Summary

This makes cold `bd doctor --dry-run` behave like the normal standalone CLI path on repo-local Dolt setups.

The key change is that doctor was only partially using Beads' auto-start-aware opening logic:

- direct doctor helpers like `validation.go` / `federation.go` were opening Dolt without the CLI auto-start policy
- earlier read-only doctor checks were also using the library-style `NewFromConfigWithOptions(... ReadOnly: true)` path, which suppresses auto-start when deprecated metadata still carries an explicit `dolt_server_port`

This patch:

- centralizes the normal CLI standalone auto-start policy in `ApplyCLIAutoStart(...)`
- adds `NewFromConfigWithCLIOptions(...)` for CLI helper paths that should match `cmd/bd/main.go`
- aligns `cmd/bd/doctor/federation.go` with the same CLI auto-start policy
- switches doctor read-only opens in database/integrity/suppress/multirepo/role/installation/maintenance/config_values to the CLI-aware helper

## Why

On a cold stopped repo-local server, the detached repro showed:

- `bd status --json` auto-started Dolt and succeeded
- `bd doctor --dry-run` did not auto-start, dialed the dead configured port, tripped the circuit breaker, and failed

After this patch, the same detached cold `doctor` run exits `0`, recreates `dolt-server.port`, starts Dolt, and leaves the breaker closed.

## Validation

Passed:

- `go test ./internal/storage/dolt ./cmd/bd/doctor -run 'Test(ResolveAutoStart|DoltServerConfig_)'`
- detached cold-doctor repro against the patched binary

Also checked:

- `make test`

That full suite still fails on a pre-existing `origin/main` failure in `internal/utils`:

- `TestResolvePartialID_Wisp`

I reproduced that exact failure on a pristine `origin/main` worktree to confirm it is not introduced by this patch.
