### PR TITLE
Fix: scope backup/restore to current project prefix

### DIFF
--- a/cmd/bd/backup_export.go
+++ b/cmd/bd/backup_export.go
@@ -125,8 +125,25 @@ func atomicWriteFile(path string, data []byte) error {
 	return nil
 }
 
+// getBackupPrefix returns the issue prefix for the current project.
+// It checks the YAML config first (authoritative in shared-server mode),
+// then falls back to the database config table.
+func getBackupPrefix(ctx context.Context) string {
+	if yamlPrefix := config.GetString("issue-prefix"); yamlPrefix != "" {
+		return yamlPrefix
+	}
+	if store != nil {
+		if dbPrefix, err := store.GetConfig(ctx, "issue_prefix"); err == nil && dbPrefix != "" {
+			return dbPrefix
+		}
+	}
+	return ""
+}
+
 // runBackupExport exports all tables to JSONL files in .beads/backup/.
 // Returns the updated state.
+// When a project prefix is configured, only issues belonging to this project
+// are exported. This prevents cross-project contamination on shared Dolt servers.
 func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 	dir, err := backupDir()
 	if err != nil {
@@ -150,37 +167,77 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 		}
 	}
 
+	// Resolve the project prefix for scoping.
+	// On shared Dolt servers, the database contains issues from ALL projects.
+	// We must filter by prefix to avoid exporting (and later restoring) foreign issues.
+	prefix := getBackupPrefix(ctx)
+	prefixFilter := prefix + "-" // e.g. "Prosa-"
+
+	var n int
+
 	// Export issues only — wisps are ephemeral and excluded from backup.
 	// They can be regenerated from the database if needed for disaster recovery.
-	n, err := exportTable(ctx, store, dir, "issues.jsonl", "SELECT * FROM issues ORDER BY id")
+	if prefix != "" {
+		n, err = exportTable(ctx, store, dir, "issues.jsonl",
+			"SELECT * FROM issues WHERE id LIKE ? ORDER BY id", prefixFilter+"%")
+	} else {
+		n, err = exportTable(ctx, store, dir, "issues.jsonl",
+			"SELECT * FROM issues ORDER BY id")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("backup issues: %w", err)
 	}
 	state.Counts.Issues = n
 
-	n, err = exportTable(ctx, store, dir, "events.jsonl",
-		"SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at FROM events ORDER BY created_at ASC, id ASC")
+	if prefix != "" {
+		n, err = exportTable(ctx, store, dir, "events.jsonl",
+			"SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at FROM events WHERE issue_id LIKE ? ORDER BY created_at ASC, id ASC",
+			prefixFilter+"%")
+	} else {
+		n, err = exportTable(ctx, store, dir, "events.jsonl",
+			"SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at FROM events ORDER BY created_at ASC, id ASC")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("backup events: %w", err)
 	}
 	state.Counts.Events = n
 
-	n, err = exportTable(ctx, store, dir, "comments.jsonl",
-		"SELECT id, issue_id, author, text, created_at FROM comments ORDER BY id")
+	if prefix != "" {
+		n, err = exportTable(ctx, store, dir, "comments.jsonl",
+			"SELECT id, issue_id, author, text, created_at FROM comments WHERE issue_id LIKE ? ORDER BY id",
+			prefixFilter+"%")
+	} else {
+		n, err = exportTable(ctx, store, dir, "comments.jsonl",
+			"SELECT id, issue_id, author, text, created_at FROM comments ORDER BY id")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("backup comments: %w", err)
 	}
 	state.Counts.Comments = n
 
-	n, err = exportTable(ctx, store, dir, "dependencies.jsonl",
-		"SELECT issue_id, depends_on_id, type, created_at, created_by, metadata FROM dependencies ORDER BY issue_id, depends_on_id")
+	if prefix != "" {
+		// For dependencies, both issue_id and depends_on_id should belong to this project.
+		// We filter on issue_id (the dependent) having our prefix.
+		n, err = exportTable(ctx, store, dir, "dependencies.jsonl",
+			"SELECT issue_id, depends_on_id, type, created_at, created_by, metadata FROM dependencies WHERE issue_id LIKE ? ORDER BY issue_id, depends_on_id",
+			prefixFilter+"%")
+	} else {
+		n, err = exportTable(ctx, store, dir, "dependencies.jsonl",
+			"SELECT issue_id, depends_on_id, type, created_at, created_by, metadata FROM dependencies ORDER BY issue_id, depends_on_id")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("backup dependencies: %w", err)
 	}
 	state.Counts.Dependencies = n
 
-	n, err = exportTable(ctx, store, dir, "labels.jsonl",
-		"SELECT issue_id, label FROM labels ORDER BY issue_id, label")
+	if prefix != "" {
+		n, err = exportTable(ctx, store, dir, "labels.jsonl",
+			"SELECT issue_id, label FROM labels WHERE issue_id LIKE ? ORDER BY issue_id, label",
+			prefixFilter+"%")
+	} else {
+		n, err = exportTable(ctx, store, dir, "labels.jsonl",
+			"SELECT issue_id, label FROM labels ORDER BY issue_id, label")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("backup labels: %w", err)
 	}
@@ -218,8 +275,9 @@ func truncateHash(h string) string {
 
 // exportTable streams query results to a JSONL file using atomic write (temp file + rename).
 // Uses bounded memory regardless of result set size.
-func exportTable(ctx context.Context, q dbQuerier, dir, filename, query string) (int, error) {
-	rows, err := q.QueryContext(ctx, query)
+// Optional args are passed as query parameters (for WHERE clause filtering).
+func exportTable(ctx context.Context, q dbQuerier, dir, filename, query string, args ...any) (int, error) {
+	rows, err := q.QueryContext(ctx, query, args...)
 	if err != nil {
 		return 0, fmt.Errorf("query failed: %w", err)
 	}

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -120,9 +120,16 @@ type restoreResult struct {
 
 // runBackupRestore imports all JSONL backup tables into the Dolt store.
 // Order matters: config first (sets prefix), then issues, then related tables.
+// When a project prefix is configured, only entries belonging to this project
+// are imported. This prevents cross-project contamination on shared Dolt servers.
 func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun bool) (*restoreResult, error) {
 	result := &restoreResult{}
 	db := s.DB()
+
+	// Resolve the project prefix for scoping.
+	// Check YAML config first (authoritative in shared-server mode),
+	// then fall back to the database config table.
+	prefix := getBackupPrefix(ctx)
 
 	// 1. Restore config (sets issue_prefix and other settings)
 	configPath := filepath.Join(dir, "config.jsonl")
@@ -137,7 +144,7 @@ func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun
 
 	// 2. Restore issues (must come before comments/deps/labels which reference issue IDs)
 	issuesPath := filepath.Join(dir, "issues.jsonl")
-	n, err := restoreIssues(ctx, s, issuesPath, dryRun)
+	n, err := restoreIssues(ctx, s, issuesPath, dryRun, prefix)
 	if err != nil {
 		return nil, fmt.Errorf("restore issues: %w", err)
 	}
@@ -146,7 +153,7 @@ func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun
 	// 3. Restore comments
 	commentsPath := filepath.Join(dir, "comments.jsonl")
 	if _, err := os.Stat(commentsPath); err == nil {
-		n, warnings, err := restoreComments(ctx, db, commentsPath, dryRun)
+		n, warnings, err := restoreComments(ctx, db, commentsPath, dryRun, prefix)
 		if err != nil {
 			return nil, fmt.Errorf("restore comments: %w", err)
 		}
@@ -157,7 +164,7 @@ func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun
 	// 4. Restore dependencies
 	depsPath := filepath.Join(dir, "dependencies.jsonl")
 	if _, err := os.Stat(depsPath); err == nil {
-		n, warnings, err := restoreDependencies(ctx, db, depsPath, dryRun)
+		n, warnings, err := restoreDependencies(ctx, db, depsPath, dryRun, prefix)
 		if err != nil {
 			return nil, fmt.Errorf("restore dependencies: %w", err)
 		}
@@ -168,7 +175,7 @@ func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun
 	// 5. Restore labels
 	labelsPath := filepath.Join(dir, "labels.jsonl")
 	if _, err := os.Stat(labelsPath); err == nil {
-		n, warnings, err := restoreLabels(ctx, db, labelsPath, dryRun)
+		n, warnings, err := restoreLabels(ctx, db, labelsPath, dryRun, prefix)
 		if err != nil {
 			return nil, fmt.Errorf("restore labels: %w", err)
 		}
@@ -179,7 +186,7 @@ func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun
 	// 6. Restore events
 	eventsPath := filepath.Join(dir, "events.jsonl")
 	if _, err := os.Stat(eventsPath); err == nil {
-		n, warnings, err := restoreEvents(ctx, db, eventsPath, dryRun)
+		n, warnings, err := restoreEvents(ctx, db, eventsPath, dryRun, prefix)
 		if err != nil {
 			return nil, fmt.Errorf("restore events: %w", err)
 		}
@@ -197,6 +204,15 @@ func runBackupRestore(ctx context.Context, s *dolt.DoltStore, dir string, dryRun
 	}
 
 	return result, nil
+}
+
+// issueIDMatchesPrefix checks whether an issue ID belongs to the given project prefix.
+// Returns true if prefix is empty (no filtering) or if the ID starts with "prefix-".
+func issueIDMatchesPrefix(issueID, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	return strings.HasPrefix(issueID, prefix+"-")
 }
 
 // restoreConfig reads config.jsonl and sets each key-value pair.
@@ -240,16 +256,37 @@ func restoreConfig(ctx context.Context, s *dolt.DoltStore, path string, dryRun b
 // avoiding type mismatches between DB values (e.g., int 0/1 for booleans) and
 // Go struct types.
 //
+// When prefix is non-empty, only issues whose ID starts with "prefix-" are restored.
+// This prevents importing foreign-project issues from shared-server backups.
+//
 // The JSONL may contain denormalized data from `bd export` (labels, dependencies,
 // comment counts). These are extracted and inserted into their proper tables.
-func restoreIssues(ctx context.Context, s *dolt.DoltStore, path string, dryRun bool) (int, error) {
+func restoreIssues(ctx context.Context, s *dolt.DoltStore, path string, dryRun bool, prefix string) (int, error) {
 	lines, err := readJSONLFile(path)
 	if err != nil {
 		return 0, err
 	}
 
-	if dryRun || len(lines) == 0 {
-		return len(lines), nil
+	if len(lines) == 0 {
+		return 0, nil
+	}
+
+	// When doing a dry run, count only matching issues
+	if dryRun {
+		if prefix == "" {
+			return len(lines), nil
+		}
+		count := 0
+		for _, line := range lines {
+			var row map[string]interface{}
+			if err := json.Unmarshal(line, &row); err != nil {
+				continue
+			}
+			if id, ok := row["id"].(string); ok && issueIDMatchesPrefix(id, prefix) {
+				count++
+			}
+		}
+		return count, nil
 	}
 
 	db := s.DB()
@@ -281,6 +318,11 @@ func restoreIssues(ctx context.Context, s *dolt.DoltStore, path string, dryRun b
 		}
 
 		issueID, _ := row["id"].(string)
+
+		// Skip issues that don't belong to this project
+		if !issueIDMatchesPrefix(issueID, prefix) {
+			continue
+		}
 
 		// Extract denormalized relational data before SQL insertion.
 		// `bd export` embeds labels ([]string) and dependencies ([]*Dependency)
@@ -401,7 +443,8 @@ func restoreTableRow(ctx context.Context, db *sql.DB, table string, row map[stri
 // restoreComments reads comments.jsonl and inserts them via raw SQL.
 // Uses raw SQL to avoid side effects (the high-level API validates issue existence
 // and may fail for wisps that haven't been restored yet).
-func restoreComments(ctx context.Context, db *sql.DB, path string, dryRun bool) (int, int, error) {
+// When prefix is non-empty, only comments for matching issue IDs are restored.
+func restoreComments(ctx context.Context, db *sql.DB, path string, dryRun bool, prefix string) (int, int, error) {
 	lines, err := readJSONLFile(path)
 	if err != nil {
 		return 0, 0, err
@@ -425,6 +468,10 @@ func restoreComments(ctx context.Context, db *sql.DB, path string, dryRun bool) 
 		if comment.IssueID == "" {
 			continue
 		}
+		// Skip comments for issues that don't belong to this project
+		if !issueIDMatchesPrefix(comment.IssueID, prefix) {
+			continue
+		}
 		if !dryRun {
 			createdAt := parseTimeOrNow(comment.CreatedAt)
 			_, err := db.ExecContext(ctx, `
@@ -444,7 +491,8 @@ func restoreComments(ctx context.Context, db *sql.DB, path string, dryRun bool) 
 
 // restoreDependencies reads dependencies.jsonl and inserts them via raw SQL.
 // Uses raw SQL to avoid validation side effects (cycle detection, existence checks).
-func restoreDependencies(ctx context.Context, db *sql.DB, path string, dryRun bool) (int, int, error) {
+// When prefix is non-empty, only dependencies where issue_id matches are restored.
+func restoreDependencies(ctx context.Context, db *sql.DB, path string, dryRun bool, prefix string) (int, int, error) {
 	lines, err := readJSONLFile(path)
 	if err != nil {
 		return 0, 0, err
@@ -467,6 +515,10 @@ func restoreDependencies(ctx context.Context, db *sql.DB, path string, dryRun bo
 			continue
 		}
 		if dep.IssueID == "" || dep.DependsOnID == "" {
+			continue
+		}
+		// Skip dependencies where the issue doesn't belong to this project
+		if !issueIDMatchesPrefix(dep.IssueID, prefix) {
 			continue
 		}
 		if !dryRun {
@@ -500,7 +552,8 @@ func restoreDependencies(ctx context.Context, db *sql.DB, path string, dryRun bo
 
 // restoreLabels reads labels.jsonl and inserts them via raw SQL.
 // Uses raw SQL to avoid event creation side effects from AddLabel.
-func restoreLabels(ctx context.Context, db *sql.DB, path string, dryRun bool) (int, int, error) {
+// When prefix is non-empty, only labels for matching issue IDs are restored.
+func restoreLabels(ctx context.Context, db *sql.DB, path string, dryRun bool, prefix string) (int, int, error) {
 	lines, err := readJSONLFile(path)
 	if err != nil {
 		return 0, 0, err
@@ -521,6 +574,10 @@ func restoreLabels(ctx context.Context, db *sql.DB, path string, dryRun bool) (i
 		if label.IssueID == "" || label.Label == "" {
 			continue
 		}
+		// Skip labels for issues that don't belong to this project
+		if !issueIDMatchesPrefix(label.IssueID, prefix) {
+			continue
+		}
 		if !dryRun {
 			_, err := db.ExecContext(ctx, `
 				INSERT IGNORE INTO labels (issue_id, label) VALUES (?, ?)
@@ -537,7 +594,8 @@ func restoreLabels(ctx context.Context, db *sql.DB, path string, dryRun bool) (i
 }
 
 // restoreEvents reads events.jsonl and inserts them via raw SQL.
-func restoreEvents(ctx context.Context, db *sql.DB, path string, dryRun bool) (int, int, error) {
+// When prefix is non-empty, only events for matching issue IDs are restored.
+func restoreEvents(ctx context.Context, db *sql.DB, path string, dryRun bool, prefix string) (int, int, error) {
 	lines, err := readJSONLFile(path)
 	if err != nil {
 		return 0, 0, err
@@ -562,6 +620,10 @@ func restoreEvents(ctx context.Context, db *sql.DB, path string, dryRun bool) (i
 			continue
 		}
 		if event.IssueID == "" {
+			continue
+		}
+		// Skip events for issues that don't belong to this project
+		if !issueIDMatchesPrefix(event.IssueID, prefix) {
 			continue
 		}
 		if !dryRun {


### PR DESCRIPTION
## Summary

Fixes #2584. On shared Dolt servers with multiple projects, `bd backup` was exporting ALL issues across ALL projects, and `bd backup restore` was importing everything — contaminating the current project's database with foreign issues.

- Filter backup export queries by `issue-prefix` (SQL `WHERE id LIKE ?`)
- Filter restore imports by matching issue ID prefix
- Both sides are backward-compatible: no prefix configured = no filtering
- Config table is not filtered (it's project-scoped settings, not issue data)

## Tables affected

All five issue-related tables are scoped: `issues`, `events`, `comments`, `dependencies`, `labels`.

## Test plan

- [x] Verified on a shared server with 25 projects (4,032 cross-project issues)
- [x] Scoped export correctly returns 0 foreign issues
- [x] `--dry-run` restore correctly counts only matching issues
- [x] New issues created with correct prefix after clean init
- [x] Backward compatible when no prefix is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)