### PR TITLE
fix: read jira.pull_jql config during FetchIssues

### DIFF
--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -93,6 +93,11 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 	// Build JQL query
 	jql := fmt.Sprintf("project = %q", t.projectKey)
 
+	// User-configured pull_jql filter (e.g. 'labels = "agent-ready"')
+	if pullJQL, _ := t.getConfig(ctx, "jira.pull_jql", "JIRA_PULL_JQL"); pullJQL != "" {
+		jql += " AND " + pullJQL
+	}
+
 	// State filter
 	switch opts.State {
 	case "open":

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -599,6 +599,88 @@ func (s *configStore) RunInTransaction(_ context.Context, _ string, _ func(tx st
 }
 func (s *configStore) Close() error { return nil }
 
+func TestFetchIssuesIncludesPullJQLInQuery(t *testing.T) {
+	var capturedJQL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/search/jql" {
+			capturedJQL = r.URL.Query().Get("jql")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"issues":     []Issue{},
+				"total":      0,
+				"maxResults": 50,
+				"startAt":    0,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	store := &configStore{
+		data: map[string]string{
+			"jira.pull_jql": `labels = "agent-ready"`,
+		},
+	}
+
+	tr := &Tracker{
+		client:     newTestClient(srv.URL, "3"),
+		store:      store,
+		projectKey: "TEST",
+		apiVersion: "3",
+	}
+
+	_, err := tr.FetchIssues(context.Background(), tracker.FetchOptions{State: "open"})
+	if err != nil {
+		t.Fatalf("FetchIssues error: %v", err)
+	}
+
+	if !strings.Contains(capturedJQL, `labels = "agent-ready"`) {
+		t.Errorf("JQL should contain pull_jql filter, got: %s", capturedJQL)
+	}
+}
+
+func TestFetchIssuesWithoutPullJQLOmitsExtraFilter(t *testing.T) {
+	var capturedJQL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rest/api/3/search/jql" {
+			capturedJQL = r.URL.Query().Get("jql")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"issues":     []Issue{},
+				"total":      0,
+				"maxResults": 50,
+				"startAt":    0,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	store := &configStore{
+		data: map[string]string{},
+	}
+
+	tr := &Tracker{
+		client:     newTestClient(srv.URL, "3"),
+		store:      store,
+		projectKey: "TEST",
+		apiVersion: "3",
+	}
+
+	_, err := tr.FetchIssues(context.Background(), tracker.FetchOptions{State: "open"})
+	if err != nil {
+		t.Fatalf("FetchIssues error: %v", err)
+	}
+
+	if strings.Contains(capturedJQL, "agent-ready") {
+		t.Errorf("JQL should NOT contain pull_jql filter when unconfigured, got: %s", capturedJQL)
+	}
+}
+
 func TestInitLoadsCustomStatusMapFromAllConfig(t *testing.T) {
 	store := &configStore{
 		data: map[string]string{


### PR DESCRIPTION
## Summary

- Reads `jira.pull_jql` config (or `JIRA_PULL_JQL` env var) in `FetchIssues` and ANDs it into the JQL query
- Previously, `jira.pull_jql` was accepted by `bd config set` but never referenced by the sync code
- Allows users to filter which Jira issues are pulled during sync

## Example

```bash
bd config set jira.pull_jql 'labels = "agent-ready" AND labels = "my-team"'
bd jira sync --pull
# JQL: project = "PROJ" AND labels = "agent-ready" AND labels = "my-team" AND statusCategory != Done ORDER BY updated DESC
```

## Test plan

- [x] Unit test: `TestFetchIssuesIncludesPullJQLInQuery` — verifies pull_jql is AND'd into JQL when configured
- [x] Unit test: `TestFetchIssuesWithoutPullJQLOmitsExtraFilter` — verifies no extra filter when pull_jql is unset
- [x] All existing jira tests pass (`go test ./internal/jira/...`)
- [x] Tested against live Jira Cloud instance with per-rig label filtering

Fixes #2589