### PR TITLE
feat: add --claim-next to close and --skills/--context to create

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -65,6 +65,8 @@ create, update, show, or close operation).`,
 		noAuto, _ := cmd.Flags().GetBool("no-auto")
 		suggestNext, _ := cmd.Flags().GetBool("suggest-next")
 
+		claimNext, _ := cmd.Flags().GetBool("claim-next")
+
 		// Get session ID from flag or environment variable
 		session, _ := cmd.Flags().GetString("session")
 		if session == "" {
@@ -277,8 +279,44 @@ create, update, show, or close operation).`,
 			}
 		}
 
+		// Handle --claim-next flag
+		var claimedNextIssue *types.Issue
+		if claimNext && closedCount > 0 && !continueFlag {
+			readyIssues, err := store.GetReadyWork(ctx, types.WorkFilter{
+				Status:     "open",
+				Limit:      1,
+				SortPolicy: types.SortPolicy("priority"),
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not get ready issues: %v\n", err)
+			} else if len(readyIssues) > 0 {
+				nextIssue := readyIssues[0]
+				err := store.ClaimIssue(ctx, nextIssue.ID, actor)
+				if err == nil {
+					claimedNextIssue = nextIssue
+					if jsonOutput {
+						// JSON handled below
+					} else {
+						fmt.Printf("%s Auto-claimed next ready issue: %s (P%d)\n", ui.RenderPass("✓"), formatFeedbackID(nextIssue.ID, nextIssue.Title), nextIssue.Priority)
+					}
+					SetLastTouchedID(nextIssue.ID)
+				} else {
+					fmt.Fprintf(os.Stderr, "Warning: could not claim next issue %s: %v\n", nextIssue.ID, err)
+				}
+			} else if !jsonOutput {
+				fmt.Printf("\n%s No ready issues available to claim.\n", ui.RenderWarn("✨"))
+			}
+		}
+
 		if jsonOutput && len(closedIssues) > 0 {
-			outputJSON(closedIssues)
+			if claimedNextIssue != nil {
+				outputJSON(map[string]interface{}{
+					"closed":  closedIssues,
+					"claimed": claimedNextIssue,
+				})
+			} else {
+				outputJSON(closedIssues)
+			}
 		}
 
 		// Exit non-zero if no issues were actually closed (close guard
@@ -302,6 +340,7 @@ func init() {
 	closeCmd.Flags().Bool("continue", false, "Auto-advance to next step in molecule")
 	closeCmd.Flags().Bool("no-auto", false, "With --continue, show next step but don't claim it")
 	closeCmd.Flags().Bool("suggest-next", false, "Show newly unblocked issues after closing")
+	closeCmd.Flags().Bool("claim-next", false, "Automatically claim the next highest priority available issue")
 	closeCmd.Flags().String("session", "", "Claude Code session ID (or set CLAUDE_SESSION_ID env var)")
 	closeCmd.ValidArgsFunction = issueIDCompletion
 	rootCmd.AddCommand(closeCmd)

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -86,6 +86,22 @@ var createCmd = &cobra.Command{
 		// Get field values
 		description, _ := getDescriptionFlag(cmd)
 
+		skills, _ := cmd.Flags().GetString("skills")
+		if skills != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "## Required Skills\n" + skills
+		}
+
+		ctxStr, _ := cmd.Flags().GetString("context")
+		if ctxStr != "" {
+			if description != "" {
+				description += "\n\n"
+			}
+			description += "## Context\n" + ctxStr
+		}
+
 		// Check if description is required by config
 		if description == "" && !isTestIssue(title) {
 			if config.GetBool("create.require-description") {
@@ -794,6 +810,8 @@ func init() {
 	registerCommonIssueFlags(createCmd)
 	createCmd.Flags().String("spec-id", "", "Link to specification document")
 	createCmd.Flags().StringSliceP("labels", "l", []string{}, "Labels (comma-separated)")
+	createCmd.Flags().String("skills", "", "Required skills for this issue")
+	createCmd.Flags().String("context", "", "Additional context for the issue")
 	createCmd.Flags().StringSlice("label", []string{}, "Alias for --labels")
 	_ = createCmd.Flags().MarkHidden("label") // Only fails if flag missing (caught in tests)
 	createCmd.Flags().String("id", "", "Explicit issue ID (e.g., 'bd-42' for partitioning)")


### PR DESCRIPTION
## Problem

### Workflow Interruption
After an agent finishes a task via `bd close`, it currently has to perform several steps (`bd ready`, determine priority, `bd update --claim`) before it can resume work. This causes polling latency and complicates orchestrator logic.

### Lost Context
When a new agent picks up a task, they lack the original architectural clues and skill requirements, wasting API tokens scanning the codebase to re-discover what the creator already knew.

## Solution

### `bd close --claim-next`
* Atomically claims the next highest priority available issue upon closing an active one.
* Returns the newly claimed task, bridging the gap between completing work and starting the next without polling.

**Workflow: Task Completion & Next Assignment**

*Before:*
```mermaid
sequenceDiagram
    participant Agent
    participant BD as bd
    
    Agent->>BD: bd close bd-123
    note right of Agent: What's next?
    Agent->>BD: bd ready
    BD-->>Agent: Returns list of ready work
    Agent->>Agent: Determine highest priority
    Agent->>BD: bd update bd-124 --claim
```

*After:* (Atomic execution)
```mermaid
sequenceDiagram
    participant Agent
    participant BD as bd
    
    Agent->>BD: bd close bd-123 --claim-next
    note over BD: 1. Closes bd-123<br/>2. Finds highest P ready issue<br/>3. Atomically claims bd-124
    BD-->>Agent: Returns "Closed bd-123. Auto-claimed bd-124 (P1)"
    note right of Agent: Immediately begins work on bd-124.
```

### `bd create --skills` and `--context`
* Embeds AI-parsable context directly into the newly created task's description as Markdown sections (`## Required Skills` and `## Context`).
* Ensures the agent undertaking the task has immediate access to critical architectural clues and required toolsets.

**Workflow: Task Creation & Handoff**

*Before:*
```mermaid
sequenceDiagram
    participant AgentA as Agent A
    participant BD as bd
    participant AgentB as Agent B
    
    AgentA->>BD: bd create "Implement X" --description "X is..."
    note over AgentB: Later...
    AgentB->>BD: bd claim
    AgentB-->>BD: bd show
    note right of AgentB: Reads description.<br/>Spends time scanning codebase<br/>to understand context/skills.
```

*After:* (Context and prerequisites injected immediately)
```mermaid
sequenceDiagram
    participant AgentA as Agent A
    participant BD as bd
    participant AgentB as Agent B
    
    AgentA->>BD: bd create "Implement X" --skills "go,db"<br/>--context "See table Y"
    note over AgentB: Later...
    AgentB->>BD: bd claim
    AgentB-->>BD: bd show
    note right of AgentB: Parses `## Required Skills` & `## Context`.<br/>Immediately readies Go tools and DB<br/>inspector. No wasted discovery time.
```

## Testing
- Verified `bd create` injects markdown accurately.
- Verified `bd close --claim-next` correctly picks the top priority ready issue and changes its status/assignee automatically.
- Validated JSON output support.
- `make test` passing.
