### PR TITLE
Preserve repo-local Dolt servers during stale cleanup

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -364,13 +364,15 @@ var doltKillallCmd = &cobra.Command{
 	Use:   "killall",
 	Short: "Kill all orphan Dolt server processes",
 	Long: `Find and kill orphan dolt sql-server processes not tracked by the
-canonical PID file.
+canonical PID file for the current repo's Dolt data directory.
 
 Under Gas Town, the canonical server lives at $GT_ROOT/.beads/. Any other
-dolt sql-server processes are considered orphans and will be killed.
+dolt sql-server processes using that shared data directory are considered
+orphans and will be killed.
 
-In standalone mode, all dolt sql-server processes are killed except the
-one tracked by the current project's PID file.`,
+In standalone mode, only dolt sql-server processes using the current
+project's Dolt data directory are eligible for cleanup. Other projects'
+servers are preserved.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		beadsDir := beads.FindBeadsDir()
 		if beadsDir == "" {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -382,15 +382,17 @@ func IsRunning(beadsDir string) (*State, error) {
 
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
-		// Corrupt PID file — clean up
+		// Corrupt PID file implies stale state; clear the port file too.
 		_ = os.Remove(pidPath(beadsDir))
+		_ = os.Remove(portPath(beadsDir))
 		return &State{Running: false}, nil
 	}
 
 	// Check if process is alive
 	if !isProcessAlive(pid) {
-		// Process is dead — stale PID file
+		// Process is dead — clear all tracked state for this server.
 		_ = os.Remove(pidPath(beadsDir))
+		_ = os.Remove(portPath(beadsDir))
 		return &State{Running: false}, nil
 	}
 
@@ -813,16 +815,15 @@ func LogPath(beadsDir string) string {
 	return logPath(beadsDir)
 }
 
-// KillStaleServers finds and kills orphan dolt sql-server processes
-// not tracked by the canonical PID file.
-// Returns the PIDs of killed processes.
-func KillStaleServers(beadsDir string) ([]int, error) {
-	allPIDs := listDoltProcessPIDs()
+// killStaleServersForDir finds and kills orphan dolt sql-server processes for
+// the current repo's Dolt data directory that are not tracked by the canonical
+// PID file. Servers owned by other repos are preserved.
+func killStaleServersForDir(beadsDir string, allPIDs []int, inDir func(int, string) bool, kill func(int) error) ([]int, error) {
 	if len(allPIDs) == 0 {
 		return nil, nil
 	}
 
-	// Collect canonical PIDs (ones we should NOT kill)
+	// Collect canonical PIDs (ones we should NOT kill).
 	canonicalPIDs := make(map[int]bool)
 	serverDir := resolveServerDir(beadsDir)
 	if serverDir != "" {
@@ -833,6 +834,8 @@ func KillStaleServers(beadsDir string) ([]int, error) {
 		}
 	}
 
+	ownedDoltDir := ResolveDoltDir(serverDir)
+
 	var killed []int
 	for _, pid := range allPIDs {
 		if pid == os.Getpid() {
@@ -841,12 +844,33 @@ func KillStaleServers(beadsDir string) ([]int, error) {
 		if canonicalPIDs[pid] {
 			continue // preserve canonical server
 		}
-		if proc, findErr := os.FindProcess(pid); findErr == nil {
-			_ = proc.Kill()
+		if !inDir(pid, ownedDoltDir) {
+			continue // preserve other repos' Dolt servers
+		}
+		if err := kill(pid); err == nil {
 			killed = append(killed, pid)
 		}
 	}
 	return killed, nil
+}
+
+// KillStaleServers finds and kills orphan dolt sql-server processes for the
+// current repo's Dolt data directory that are not tracked by the canonical PID
+// file. Returns the PIDs of killed processes.
+func KillStaleServers(beadsDir string) ([]int, error) {
+	allPIDs := listDoltProcessPIDs()
+	return killStaleServersForDir(
+		beadsDir,
+		allPIDs,
+		isProcessInDir,
+		func(pid int) error {
+			proc, err := os.FindProcess(pid)
+			if err != nil {
+				return err
+			}
+			return proc.Kill()
+		},
+	)
 }
 
 // waitForReady polls TCP until the server accepts connections.

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -153,6 +153,28 @@ func TestIsRunningStalePID(t *testing.T) {
 	}
 }
 
+func TestIsRunningStalePIDRemovesPortFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(pidPath(dir), []byte("99999999"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePortFile(dir, 14567); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := IsRunning(dir)
+	if err != nil {
+		t.Fatalf("IsRunning error: %v", err)
+	}
+	if state.Running {
+		t.Error("expected Running=false for stale PID")
+	}
+	if _, err := os.Stat(portPath(dir)); !os.IsNotExist(err) {
+		t.Error("expected stale port file to be removed")
+	}
+}
+
 func TestIsRunningCorruptPID(t *testing.T) {
 	dir := t.TempDir()
 
@@ -181,6 +203,28 @@ func TestIsRunningCorruptPID(t *testing.T) {
 	// PID file should have been cleaned up
 	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
 		t.Error("expected corrupt PID file to be removed")
+	}
+}
+
+func TestIsRunningCorruptPIDRemovesPortFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(pidPath(dir), []byte("not-a-number"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePortFile(dir, 14567); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := IsRunning(dir)
+	if err != nil {
+		t.Fatalf("IsRunning error: %v", err)
+	}
+	if state.Running {
+		t.Error("expected Running=false for corrupt PID file")
+	}
+	if _, err := os.Stat(portPath(dir)); !os.IsNotExist(err) {
+		t.Error("expected stale port file to be removed")
 	}
 }
 
@@ -533,6 +577,70 @@ func TestCleanupStateFiles(t *testing.T) {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Errorf("expected %s to be removed", filepath.Base(path))
 		}
+	}
+}
+
+func TestKillStaleServersPreservesOtherRepoServers(t *testing.T) {
+	dir := t.TempDir()
+	canonicalPID := 111
+	sameRepoOrphanPID := 222
+	otherRepoPID := 333
+
+	if err := os.WriteFile(pidPath(dir), []byte(strconv.Itoa(canonicalPID)), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var killed []int
+	got, err := killStaleServersForDir(
+		dir,
+		[]int{canonicalPID, sameRepoOrphanPID, otherRepoPID},
+		func(pid int, doltDir string) bool {
+			if doltDir != ResolveDoltDir(dir) {
+				t.Fatalf("unexpected dolt dir: got %q want %q", doltDir, ResolveDoltDir(dir))
+			}
+			return pid == canonicalPID || pid == sameRepoOrphanPID
+		},
+		func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("killStaleServersForDir error: %v", err)
+	}
+	if len(got) != 1 || got[0] != sameRepoOrphanPID {
+		t.Fatalf("killed=%v, want [%d]", got, sameRepoOrphanPID)
+	}
+	if len(killed) != 1 || killed[0] != sameRepoOrphanPID {
+		t.Fatalf("kill callback got %v, want [%d]", killed, sameRepoOrphanPID)
+	}
+}
+
+func TestKillStaleServersWithoutCanonicalPIDOnlyKillsOwnedDir(t *testing.T) {
+	dir := t.TempDir()
+	sameRepoOrphanPID := 222
+	otherRepoPID := 333
+
+	var killed []int
+	got, err := killStaleServersForDir(
+		dir,
+		[]int{sameRepoOrphanPID, otherRepoPID},
+		func(pid int, _ string) bool {
+			return pid == sameRepoOrphanPID
+		},
+		func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("killStaleServersForDir error: %v", err)
+	}
+	if len(got) != 1 || got[0] != sameRepoOrphanPID {
+		t.Fatalf("killed=%v, want [%d]", got, sameRepoOrphanPID)
+	}
+	if len(killed) != 1 || killed[0] != sameRepoOrphanPID {
+		t.Fatalf("kill callback got %v, want [%d]", killed, sameRepoOrphanPID)
 	}
 }
 


### PR DESCRIPTION
Fixes #2595.

## Summary

- scope stale Dolt-server cleanup to the current repo's Dolt data directory instead of sweeping every `dolt sql-server` on the machine
- preserve other repos' healthy servers during `bd dolt start` and `bd dolt killall`
- clear stale port files when `IsRunning()` finds a dead or corrupt PID

## Validation

- `go test ./internal/doltserver/...`
- `go test ./cmd/bd -run 'TestDoltShowConfig(DefaultMode|ServerMode)$' -count=1`
- local two-repo repro with a freshly built `bd`: both repos stayed `running: true` after the second `bd dolt start`
- one-shot LaunchAgent repro with minimal `PATH`: both repos kept live Dolt servers, confirming the fix is not Codex-harness-specific

## Notes

Before this patch, the same LaunchAgent repro killed repo A's server when repo B started and left repo A with a stale `.beads/dolt-server.port` after `bd dolt status` cleaned up the dead PID.
