### PR TITLE
Avoid port-0 circuit poisoning during cold standalone init

### DIFF
--- a/internal/storage/dolt/circuit.go
+++ b/internal/storage/dolt/circuit.go
@@ -56,6 +56,16 @@ type circuitBreaker struct {
 // ErrCircuitOpen is returned when the circuit breaker is open and rejecting requests.
 var ErrCircuitOpen = fmt.Errorf("dolt circuit breaker is open: server appears down, failing fast (cooldown %s)", circuitCooldown)
 
+// maybeNewCircuitBreaker returns a file-backed circuit breaker only for a
+// concrete port. Port 0 means "not yet resolved" during standalone auto-start,
+// and sharing breaker state on port 0 poisons every fresh init on the machine.
+func maybeNewCircuitBreaker(port int) *circuitBreaker {
+	if port <= 0 {
+		return nil
+	}
+	return newCircuitBreaker(port)
+}
+
 // newCircuitBreaker creates a circuit breaker for the given Dolt server port.
 func newCircuitBreaker(port int) *circuitBreaker {
 	return &circuitBreaker{

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -16,6 +16,12 @@ func TestCircuitBreaker_InitiallyAllows(t *testing.T) {
 	}
 }
 
+func TestMaybeNewCircuitBreaker_PortZeroDisabled(t *testing.T) {
+	if cb := maybeNewCircuitBreaker(0); cb != nil {
+		t.Fatalf("maybeNewCircuitBreaker(0) = %#v, want nil", cb)
+	}
+}
+
 func TestCircuitBreaker_TripsAfterThreshold(t *testing.T) {
 	t.Setenv("BEADS_TEST_MODE", "") // need real breaker behavior
 	cb := newTestCircuitBreaker(t)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -612,10 +612,10 @@ func New(ctx context.Context, cfg *Config) (*DoltStore, error) {
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
-	breaker := newCircuitBreaker(cfg.ServerPort)
+	breaker := maybeNewCircuitBreaker(cfg.ServerPort)
 
 	// Circuit breaker: fail-fast if the server is known to be down.
-	if !breaker.Allow() {
+	if breaker != nil && !breaker.Allow() {
 		doltMetrics.circuitRejected.Add(ctx, 1)
 		return nil, ErrCircuitOpen
 	}
@@ -656,6 +656,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 				}
 				cfg.ServerPort = port
 				addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
+				breaker = maybeNewCircuitBreaker(cfg.ServerPort)
 			}
 			// Retry connection with longer timeout (server just started)
 			conn, dialErr = net.DialTimeout("tcp", addr, 2*time.Second)
@@ -664,19 +665,25 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 				if autoStartedDir != "" {
 					_ = autoStartRelease(autoStartedDir)
 				}
-				breaker.RecordFailure()
+				if breaker != nil {
+					breaker.RecordFailure()
+				}
 				return nil, fmt.Errorf("Dolt server auto-started but still unreachable at %s: %w\n\n"+
 					"Check logs: %s", addr, dialErr, doltserver.LogPath(beadsDir))
 			}
 		} else {
-			breaker.RecordFailure()
+			if breaker != nil {
+				breaker.RecordFailure()
+			}
 			return nil, fmt.Errorf("Dolt server unreachable at %s: %w\n\nThe Dolt server may not be running. Try:\n  bd dolt start",
 				addr, dialErr)
 		}
 	}
 	_ = conn.Close()
 	// TCP dial succeeded — record success to reset the breaker
-	breaker.RecordSuccess()
+	if breaker != nil {
+		breaker.RecordSuccess()
+	}
 
 	// Server mode: connect via MySQL protocol to dolt sql-server
 	db, connStr, err := openServerConnection(ctx, cfg)
@@ -1843,7 +1850,6 @@ func (s *DoltStore) tryAutoResolveMetadataConflicts(ctx context.Context, tx *sql
 
 	return true, nil
 }
-
 
 // Branch creates a new branch
 func (s *DoltStore) Branch(ctx context.Context, name string) (retErr error) {


### PR DESCRIPTION
Fixes #2598.

## Summary

- skip the shared file-backed circuit breaker while the Dolt server port is still unresolved (`ServerPort == 0`)
- create the breaker only after auto-start resolves a concrete port
- add a regression test for the port-0 case

## Why

Fresh standalone init goes through server mode with `AutoStart=true`, but it used to create/check a circuit breaker before auto-start had resolved a real port. That made every cold init share `/tmp/beads-dolt-circuit-0.json`, so one stale open state could fail-fast every new repo before `EnsureRunning` got a chance to allocate an ephemeral port.

## Validation

- `go test ./internal/storage/dolt -run 'TestMaybeNewCircuitBreaker_PortZeroDisabled|TestCircuitBreaker_InitiallyAllows|TestCircuitBreaker_TripsAfterThreshold' -count=1`
- `go test ./cmd/bd -run 'TestDoltShowConfig(DefaultMode|ServerMode)$' -count=1`
- validated the equivalent local build end-to-end in a fresh temp repo:
  - `bd init --setup-exclude` succeeded
  - `bd doctor --dry-run` succeeded
  - `.beads/metadata.json` was written
- repeated the same cold-start flow under a one-shot LaunchAgent and saw the same success there

## Notes

A broader `go test ./internal/storage/dolt/...` run in this checkout hit an unrelated pre-existing failure in `TestClosePromotedWisp`, so I'm not claiming that full package sweep is green from this branch.
