### PR TITLE
fix: preserve source rig dolt_database across .beads/redirect

### DIFF
--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -26,7 +26,7 @@ EXAMPLES:
   bd import backup.jsonl           # Import from a specific file
   bd import --dry-run              # Show what would be imported`,
 	GroupID: "sync",
-	RunE:   runImport,
+	RunE:    runImport,
 }
 
 var (

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -412,6 +412,18 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		// Capture redirect info BEFORE FindDatabasePath() follows the redirect.
+		// This preserves the source rig's dolt_database across redirects (bd-tui).
+		// In Gas Town, each rig's .beads/metadata.json has dolt_database set to
+		// the rig name (e.g., "lola"), but following the redirect to the town root
+		// loads the target's metadata.json which has dolt_database: "hq".
+		redirectInfo := beads.GetRedirectInfo()
+		var sourceDoltDatabase string
+		if redirectInfo.IsRedirected && redirectInfo.LocalDir != "" {
+			rInfo := beads.ResolveRedirect(redirectInfo.LocalDir)
+			sourceDoltDatabase = rInfo.SourceDatabase
+		}
+
 		// Initialize database path
 		if dbPath == "" {
 			// Use public API to find database (same logic as extensions)
@@ -504,6 +516,19 @@ var rootCmd = &cobra.Command{
 			doltCfg.ServerTLS = cfg.GetDoltServerTLS()
 		}
 		doltCfg.SyncGitRemote = config.GetString("sync.git-remote")
+
+		// Preserve the source rig's dolt_database across redirects (bd-tui).
+		// When a redirect was followed, the config loaded above comes from the
+		// TARGET's metadata.json (e.g., dolt_database: "hq"). But the SOURCE
+		// rig's metadata.json had a different dolt_database (e.g., "lola").
+		// The env var BEADS_DOLT_SERVER_DATABASE takes highest priority, so
+		// only override if the env var is not set.
+		if sourceDoltDatabase != "" && os.Getenv("BEADS_DOLT_SERVER_DATABASE") == "" {
+			doltCfg.Database = sourceDoltDatabase
+			if os.Getenv("BD_DEBUG_ROUTING") != "" {
+				fmt.Fprintf(os.Stderr, "[routing] Preserved source dolt_database %q across redirect\n", sourceDoltDatabase)
+			}
+		}
 
 		// Auto-start: enabled by default.
 		// Can be disabled by explicit config or env var.

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -29,6 +29,61 @@ const CanonicalDatabaseName = "beads.db"
 // RedirectFileName is the name of the file that redirects to another .beads directory
 const RedirectFileName = "redirect"
 
+// SourceDatabaseInfo contains the dolt_database name from a source .beads/metadata.json,
+// preserved across a redirect so that the source rig's database identity is not lost
+// when the redirect target has a different dolt_database (e.g., "hq" vs "lola").
+//
+// Bug context (bd-tui): In Gas Town, each rig has .beads/redirect pointing to the
+// town root .beads/. The source rig's metadata.json has dolt_database set to the rig
+// name (e.g., "lola"), but following the redirect loads the TARGET's metadata.json
+// which has dolt_database: "hq". This struct preserves the source database name so
+// callers can restore it after redirect resolution.
+type SourceDatabaseInfo struct {
+	// SourceDir is the original .beads directory (before redirect)
+	SourceDir string
+	// TargetDir is the resolved .beads directory (after redirect)
+	TargetDir string
+	// WasRedirected is true if a redirect was followed
+	WasRedirected bool
+	// SourceDatabase is dolt_database from the source metadata.json (raw field,
+	// NOT the env-var-aware GetDoltDatabase()). Empty if no source metadata exists
+	// or the source has no dolt_database configured.
+	SourceDatabase string
+}
+
+// ResolveRedirect follows a .beads/redirect file and captures the source rig's
+// dolt_database from metadata.json BEFORE following the redirect. This preserves
+// the source database identity across redirects.
+//
+// The env var BEADS_DOLT_SERVER_DATABASE still takes highest priority (handled by
+// GetDoltDatabase() in callers). This function only captures the raw config field
+// so callers can use it as an override when the env var is not set.
+//
+// Returns SourceDatabaseInfo with WasRedirected=true if a redirect was followed,
+// and SourceDatabase set to the source's dolt_database (if any).
+func ResolveRedirect(beadsDir string) SourceDatabaseInfo {
+	info := SourceDatabaseInfo{
+		SourceDir: beadsDir,
+		TargetDir: beadsDir,
+	}
+
+	// Read source metadata BEFORE following redirect to capture dolt_database.
+	// Use the raw DoltDatabase field (not GetDoltDatabase) so that the env var
+	// BEADS_DOLT_SERVER_DATABASE retains highest priority in callers.
+	if sourceCfg, err := configfile.Load(beadsDir); err == nil && sourceCfg != nil {
+		info.SourceDatabase = sourceCfg.DoltDatabase
+	}
+
+	// Follow redirect
+	resolved := FollowRedirect(beadsDir)
+	if resolved != beadsDir {
+		info.WasRedirected = true
+		info.TargetDir = resolved
+	}
+
+	return info
+}
+
 // FollowRedirect checks if a .beads directory contains a redirect file and follows it.
 // If a redirect file exists, it returns the target .beads directory path.
 // If no redirect exists or there's an error, it returns the original path unchanged.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1,12 +1,14 @@
 package beads
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/git"
 )
 
@@ -1811,5 +1813,191 @@ func TestFindDatabasePath_WorktreeNoLocalDB(t *testing.T) {
 
 	if resultResolved != mainDoltResolved {
 		t.Errorf("FindDatabasePath() = %q, want main repo shared db %q", result, mainDoltDir)
+	}
+}
+
+// writeMetadataJSON writes a metadata.json file to the given .beads directory.
+func writeMetadataJSON(t *testing.T, beadsDir string, cfg *configfile.Config) {
+	t.Helper()
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal metadata.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+}
+
+// TestResolveRedirect_PreservesSourceDatabase tests that ResolveRedirect captures
+// the source rig's dolt_database from metadata.json before following a redirect.
+// This is the core fix for bd-tui: when a rig (e.g., "lola") has a redirect to the
+// town root (whose metadata says "hq"), the source database name "lola" must be preserved.
+func TestResolveRedirect_PreservesSourceDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Resolve symlinks for macOS /private/var path consistency
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	// Create source rig .beads with dolt_database: "lola"
+	sourceDir := filepath.Join(tmpDir, "lola", ".beads")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeMetadataJSON(t, sourceDir, &configfile.Config{
+		Database:     "beads.db",
+		DoltMode:     "server",
+		DoltDatabase: "lola",
+	})
+
+	// Create target town root .beads with dolt_database: "hq"
+	targetDir := filepath.Join(tmpDir, "town", ".beads")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeMetadataJSON(t, targetDir, &configfile.Config{
+		Database:     "beads.db",
+		DoltMode:     "server",
+		DoltDatabase: "hq",
+	})
+
+	// Write redirect from source to target
+	if err := os.WriteFile(filepath.Join(sourceDir, "redirect"), []byte(targetDir+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info := ResolveRedirect(sourceDir)
+
+	// Verify redirect was followed
+	if !info.WasRedirected {
+		t.Error("expected WasRedirected=true")
+	}
+
+	// Verify source database is preserved
+	if info.SourceDatabase != "lola" {
+		t.Errorf("SourceDatabase = %q, want %q", info.SourceDatabase, "lola")
+	}
+
+	// Verify source and target dirs are correct
+	sourceResolved, _ := filepath.EvalSymlinks(sourceDir)
+	targetResolved, _ := filepath.EvalSymlinks(targetDir)
+	infoSourceResolved, _ := filepath.EvalSymlinks(info.SourceDir)
+	infoTargetResolved, _ := filepath.EvalSymlinks(info.TargetDir)
+
+	if infoSourceResolved != sourceResolved {
+		t.Errorf("SourceDir = %q, want %q", info.SourceDir, sourceDir)
+	}
+	if infoTargetResolved != targetResolved {
+		t.Errorf("TargetDir = %q, want %q", info.TargetDir, targetDir)
+	}
+}
+
+// TestResolveRedirect_NoRedirect tests that ResolveRedirect works correctly when
+// there is no redirect file (source and target are the same).
+func TestResolveRedirect_NoRedirect(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeMetadataJSON(t, beadsDir, &configfile.Config{
+		Database:     "beads.db",
+		DoltDatabase: "mydb",
+	})
+
+	info := ResolveRedirect(beadsDir)
+
+	if info.WasRedirected {
+		t.Error("expected WasRedirected=false when no redirect file exists")
+	}
+	if info.SourceDatabase != "mydb" {
+		t.Errorf("SourceDatabase = %q, want %q", info.SourceDatabase, "mydb")
+	}
+
+	beadsDirResolved, _ := filepath.EvalSymlinks(beadsDir)
+	infoSourceResolved, _ := filepath.EvalSymlinks(info.SourceDir)
+	infoTargetResolved, _ := filepath.EvalSymlinks(info.TargetDir)
+
+	if infoSourceResolved != beadsDirResolved {
+		t.Errorf("SourceDir = %q, want %q", info.SourceDir, beadsDir)
+	}
+	if infoTargetResolved != beadsDirResolved {
+		t.Errorf("TargetDir = %q, want same as source %q when no redirect", info.TargetDir, beadsDir)
+	}
+}
+
+// TestResolveRedirect_NoSourceMetadata tests that ResolveRedirect handles a source
+// directory with no metadata.json (SourceDatabase should be empty).
+func TestResolveRedirect_NoSourceMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	sourceDir := filepath.Join(tmpDir, "rig", ".beads")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// No metadata.json in source
+
+	targetDir := filepath.Join(tmpDir, "town", ".beads")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeMetadataJSON(t, targetDir, &configfile.Config{
+		Database:     "beads.db",
+		DoltDatabase: "hq",
+	})
+
+	// Write redirect from source to target
+	if err := os.WriteFile(filepath.Join(sourceDir, "redirect"), []byte(targetDir+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info := ResolveRedirect(sourceDir)
+
+	if !info.WasRedirected {
+		t.Error("expected WasRedirected=true")
+	}
+	if info.SourceDatabase != "" {
+		t.Errorf("SourceDatabase = %q, want empty string when no source metadata", info.SourceDatabase)
+	}
+}
+
+// TestResolveRedirect_SourceHasNoDoltDatabase tests that ResolveRedirect handles
+// a source whose metadata.json exists but has no dolt_database field.
+func TestResolveRedirect_SourceHasNoDoltDatabase(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	sourceDir := filepath.Join(tmpDir, "rig", ".beads")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Source metadata has no dolt_database
+	writeMetadataJSON(t, sourceDir, &configfile.Config{
+		Database: "beads.db",
+	})
+
+	targetDir := filepath.Join(tmpDir, "town", ".beads")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeMetadataJSON(t, targetDir, &configfile.Config{
+		Database:     "beads.db",
+		DoltDatabase: "hq",
+	})
+
+	if err := os.WriteFile(filepath.Join(sourceDir, "redirect"), []byte(targetDir+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info := ResolveRedirect(sourceDir)
+
+	if !info.WasRedirected {
+		t.Error("expected WasRedirected=true")
+	}
+	// No dolt_database in source => SourceDatabase should be empty
+	// This means the target's dolt_database will be used (no override)
+	if info.SourceDatabase != "" {
+		t.Errorf("SourceDatabase = %q, want empty string when source has no dolt_database", info.SourceDatabase)
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1844,7 +1844,6 @@ func (s *DoltStore) tryAutoResolveMetadataConflicts(ctx context.Context, tx *sql
 	return true, nil
 }
 
-
 // Branch creates a new branch
 func (s *DoltStore) Branch(ctx context.Context, name string) (retErr error) {
 	ctx, span := doltTracer.Start(ctx, "dolt.branch",


### PR DESCRIPTION
## Summary
- When `bd` follows a `.beads/redirect` (rig → town root), it loaded `metadata.json` from the TARGET, losing the source rig's `dolt_database` name
- `bd list` from the lola rig showed HQ issues instead of lola's issues
- Fix: `ResolveRedirect()` captures the source rig's `dolt_database` before following the redirect; `main.go` restores it after config load

## Changes
- `internal/beads/beads.go`: Add `SourceDatabaseInfo` struct and `ResolveRedirect()` function
- `cmd/bd/main.go`: Capture source database before redirect, restore after config load (respects `BEADS_DOLT_SERVER_DATABASE` env var priority)
- `internal/beads/beads_test.go`: 4 tests covering redirect with different databases, no redirect, missing metadata, and missing dolt_database field

## Test plan
- [x] `go test ./internal/beads/ -run TestResolveRedirect` — all 4 tests pass
- [x] `make build` succeeds
- [ ] Manual: `bd list` from lola rig shows lola issues (not HQ)
- [ ] Manual: `BEADS_DOLT_SERVER_DATABASE=hq bd list` still overrides to HQ

Fixes bd-spc

🤖 Generated with [Claude Code](https://claude.com/claude-code)