### PR TITLE
fix: key circuit breaker on host:port instead of port only

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -519,7 +519,7 @@ This means bd found multiple `.beads` directories in your directory hierarchy. T
 
 **Symptom:** Every `bd` command fails with `dolt circuit breaker is open: server appears down, failing fast (cooldown 30s)`. This persists across repeated invocations.
 
-**Cause:** The circuit breaker tripped after repeated connection failures. Its state is stored in a file at `/tmp/beads-dolt-circuit-<port>.json` and shared across all `bd` processes. Once tripped, all commands are rejected until a successful probe resets it.
+**Cause:** The circuit breaker tripped after repeated connection failures. Its state is stored in a file at `/tmp/beads-dolt-circuit-<host>-<port>.json` (keyed on host:port) and shared across all `bd` processes. Once tripped, all commands to that specific host:port are rejected until a successful probe resets it.
 
 **Note:** `bd dolt status` checks the server's PID file, not whether the server is actually accepting connections. A "running" status does not guarantee the server is reachable on the expected port.
 

--- a/internal/storage/dolt/circuit.go
+++ b/internal/storage/dolt/circuit.go
@@ -44,10 +44,11 @@ type circuitState struct {
 	TrippedAt    time.Time `json:"tripped_at,omitempty"`
 }
 
-// circuitBreaker manages the circuit breaker for a specific Dolt server port.
+// circuitBreaker manages the circuit breaker for a specific Dolt server host:port.
 // It uses a file in /tmp for cross-process state sharing and an in-process
 // mutex for thread safety within a single process.
 type circuitBreaker struct {
+	host     string
 	port     int
 	filePath string
 	mu       sync.Mutex
@@ -56,11 +57,14 @@ type circuitBreaker struct {
 // ErrCircuitOpen is returned when the circuit breaker is open and rejecting requests.
 var ErrCircuitOpen = fmt.Errorf("dolt circuit breaker is open: server appears down, failing fast (cooldown %s)", circuitCooldown)
 
-// newCircuitBreaker creates a circuit breaker for the given Dolt server port.
-func newCircuitBreaker(port int) *circuitBreaker {
+// newCircuitBreaker creates a circuit breaker for the given Dolt server host:port.
+func newCircuitBreaker(host string, port int) *circuitBreaker {
+	// Sanitize host for use in filename (replace dots/colons with dashes)
+	safeHost := strings.NewReplacer(".", "-", ":", "-").Replace(host)
 	return &circuitBreaker{
+		host:     host,
 		port:     port,
-		filePath: fmt.Sprintf("/tmp/beads-dolt-circuit-%d.json", port),
+		filePath: fmt.Sprintf("/tmp/beads-dolt-circuit-%s-%d.json", safeHost, port),
 	}
 }
 
@@ -93,13 +97,13 @@ func (cb *circuitBreaker) Allow() bool {
 				state.Failures = 0
 				state.FirstFailure = time.Time{}
 				cb.writeState(state)
-				log.Printf("[circuit-breaker] port %d: open → closed (active probe succeeded)", cb.port)
+				log.Printf("[circuit-breaker] %s:%d: open → closed (active probe succeeded)", cb.host, cb.port)
 				return true
 			}
 			// Probe failed — stay open, reset the tripped timer
 			state.TrippedAt = time.Now()
 			cb.writeState(state)
-			log.Printf("[circuit-breaker] port %d: open → open (active probe failed, cooldown reset)", cb.port)
+			log.Printf("[circuit-breaker] %s:%d: open → open (active probe failed, cooldown reset)", cb.host, cb.port)
 			return false
 		}
 		return false
@@ -111,13 +115,13 @@ func (cb *circuitBreaker) Allow() bool {
 			state.Failures = 0
 			state.FirstFailure = time.Time{}
 			cb.writeState(state)
-			log.Printf("[circuit-breaker] port %d: half-open → closed (active probe succeeded)", cb.port)
+			log.Printf("[circuit-breaker] %s:%d: half-open → closed (active probe succeeded)", cb.host, cb.port)
 			return true
 		}
 		state.State = circuitOpen
 		state.TrippedAt = time.Now()
 		cb.writeState(state)
-		log.Printf("[circuit-breaker] port %d: half-open → open (active probe failed)", cb.port)
+		log.Printf("[circuit-breaker] %s:%d: half-open → open (active probe failed)", cb.host, cb.port)
 		return false
 	default:
 		return true
@@ -126,7 +130,7 @@ func (cb *circuitBreaker) Allow() bool {
 
 // probe performs a quick TCP dial to check if the Dolt server is reachable.
 func (cb *circuitBreaker) probe() bool {
-	addr := fmt.Sprintf("127.0.0.1:%d", cb.port)
+	addr := net.JoinHostPort(cb.host, fmt.Sprintf("%d", cb.port))
 	conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
 	if err != nil {
 		return false
@@ -142,7 +146,7 @@ func (cb *circuitBreaker) RecordSuccess() {
 
 	state := cb.readState()
 	if state.State == circuitHalfOpen {
-		log.Printf("[circuit-breaker] port %d: half-open → closed (probe succeeded)", cb.port)
+		log.Printf("[circuit-breaker] %s:%d: half-open → closed (probe succeeded)", cb.host, cb.port)
 	}
 	// Reset to clean closed state
 	cb.writeState(circuitState{State: circuitClosed})
@@ -163,7 +167,7 @@ func (cb *circuitBreaker) RecordFailure() {
 		state.TrippedAt = now
 		state.LastFailure = now
 		cb.writeState(state)
-		log.Printf("[circuit-breaker] port %d: half-open → open (probe failed)", cb.port)
+		log.Printf("[circuit-breaker] %s:%d: half-open → open (probe failed)", cb.host, cb.port)
 		return
 
 	case circuitOpen:
@@ -190,8 +194,8 @@ func (cb *circuitBreaker) RecordFailure() {
 			state.State = circuitOpen
 			state.TrippedAt = now
 			cb.writeState(state)
-			log.Printf("[circuit-breaker] port %d: closed → open (tripped after %d failures in %s)",
-				cb.port, state.Failures, now.Sub(state.FirstFailure).Round(time.Millisecond))
+			log.Printf("[circuit-breaker] %s:%d: closed → open (tripped after %d failures in %s)",
+				cb.host, cb.port, state.Failures, now.Sub(state.FirstFailure).Round(time.Millisecond))
 			return
 		}
 

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -191,8 +191,8 @@ func TestCircuitBreaker_SharedState(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "circuit.json")
 
-	cb1 := &circuitBreaker{port: 99999, filePath: path}
-	cb2 := &circuitBreaker{port: 99999, filePath: path}
+	cb1 := &circuitBreaker{host: "127.0.0.1", port: 99999, filePath: path}
+	cb2 := &circuitBreaker{host: "127.0.0.1", port: 99999, filePath: path}
 
 	// Trip via cb1
 	for i := 0; i < circuitFailureThreshold; i++ {
@@ -205,6 +205,39 @@ func TestCircuitBreaker_SharedState(t *testing.T) {
 	}
 	if cb2.Allow() {
 		t.Fatal("cb2 should reject when breaker is open")
+	}
+}
+
+func TestCircuitBreaker_DifferentHostsSeparateState(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	// Two breakers for the same port but different hosts should have independent state.
+	// This is the core fix: previously keyed on port only, which caused cross-host blocking.
+	cb1 := newCircuitBreaker("127.0.0.1", 99999)
+	cb2 := newCircuitBreaker("10.0.0.1", 99999)
+	t.Cleanup(func() {
+		os.Remove(cb1.filePath)
+		os.Remove(cb2.filePath)
+	})
+
+	// Verify different file paths
+	if cb1.filePath == cb2.filePath {
+		t.Fatalf("different hosts should have different file paths: %s vs %s", cb1.filePath, cb2.filePath)
+	}
+
+	// Trip cb1
+	for i := 0; i < circuitFailureThreshold; i++ {
+		cb1.RecordFailure()
+	}
+	if cb1.State() != circuitOpen {
+		t.Fatal("cb1 should be open")
+	}
+
+	// cb2 should be unaffected
+	if cb2.State() != circuitClosed {
+		t.Fatalf("cb2 should be closed (independent of cb1), got %q", cb2.State())
+	}
+	if !cb2.Allow() {
+		t.Fatal("cb2 should allow requests (independent of cb1)")
 	}
 }
 
@@ -264,6 +297,7 @@ func newTestCircuitBreaker(t *testing.T) *circuitBreaker {
 	t.Helper()
 	dir := t.TempDir()
 	return &circuitBreaker{
+		host:     "127.0.0.1",
 		port:     99999,
 		filePath: filepath.Join(dir, "circuit.json"),
 	}
@@ -274,6 +308,7 @@ func newTestCircuitBreakerOnPort(t *testing.T, port int) *circuitBreaker {
 	t.Helper()
 	dir := t.TempDir()
 	return &circuitBreaker{
+		host:     "127.0.0.1",
 		port:     port,
 		filePath: filepath.Join(dir, "circuit.json"),
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -612,7 +612,7 @@ func New(ctx context.Context, cfg *Config) (*DoltStore, error) {
 // newServerMode creates a DoltStore connected to a running dolt sql-server.
 // This path is pure Go and does not require CGO.
 func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
-	breaker := newCircuitBreaker(cfg.ServerPort)
+	breaker := newCircuitBreaker(cfg.ServerHost, cfg.ServerPort)
 
 	// Circuit breaker: fail-fast if the server is known to be down.
 	if !breaker.Allow() {


### PR DESCRIPTION
## Summary

The circuit breaker was keyed on port number only, causing a breaker tripped for one host (e.g. `localhost:3307`) to block connections to a completely different host on the same port (e.g. `100.111.197.110:3307`). This meant that if a local Dolt server went down, the breaker would also prevent connecting to any remote Dolt server on the same port.

## Changes

- Add `host` field to `circuitBreaker` struct
- `newCircuitBreaker` now takes host+port; the state file path includes the sanitized host so each host:port pair gets independent breaker state
- `probe()` dials the actual configured host:port instead of hardcoded `127.0.0.1`
- Log messages include host:port for better diagnostics

## Test plan

- Added test (`TestCircuitBreakerIndependentHosts`) verifying that different hosts maintain independent breaker state — tripping the breaker for one host does not affect another host on the same port