### PR TITLE
fix(doctor): detect server-backed runtime for concurrency check

### DIFF
--- a/cmd/bd/doctor/embedded_concurrency.go
+++ b/cmd/bd/doctor/embedded_concurrency.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltserver"
 )
 
 // CheckEmbeddedModeConcurrency detects when a project is using Dolt embedded
@@ -13,7 +14,7 @@ import (
 // processes). Recommends switching to server mode for multi-agent workflows.
 // Addresses GH#2086.
 func CheckEmbeddedModeConcurrency(path string) DoctorCheck {
-	beadsDir := filepath.Join(path, ".beads")
+	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
 
 	cfg, err := configfile.Load(beadsDir)
 	if err != nil || cfg == nil {
@@ -25,7 +26,7 @@ func CheckEmbeddedModeConcurrency(path string) DoctorCheck {
 		}
 	}
 
-	if cfg.IsDoltServerMode() {
+	if isServerBackedRuntime(beadsDir, cfg) {
 		return DoctorCheck{
 			Name:     "Embedded Mode Concurrency",
 			Status:   StatusOK,
@@ -81,6 +82,27 @@ func CheckEmbeddedModeConcurrency(path string) DoctorCheck {
 		Fix:      "Start the Dolt server: bd dolt start",
 		Category: CategoryRuntime,
 	}
+}
+
+// isServerBackedRuntime reports whether this repo is using Beads' server-backed
+// Dolt runtime, even when older metadata.json files omit dolt_mode.
+func isServerBackedRuntime(beadsDir string, cfg *configfile.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.IsDoltServerMode() || doltserver.IsSharedServerMode() {
+		return true
+	}
+	if cfg.DoltServerPort > 0 {
+		return true
+	}
+	if os.Getenv("BEADS_DOLT_SERVER_PORT") != "" || os.Getenv("BEADS_DOLT_PORT") != "" {
+		return true
+	}
+
+	serverDir := doltserver.ResolveServerDir(beadsDir)
+	state, err := doltserver.IsRunning(serverDir)
+	return err == nil && state != nil && state.Running
 }
 
 // joinIssues joins issue strings with semicolons.

--- a/cmd/bd/doctor/embedded_concurrency_test.go
+++ b/cmd/bd/doctor/embedded_concurrency_test.go
@@ -1,0 +1,157 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func TestCheckEmbeddedModeConcurrency_ExplicitServerPortWithoutDoltMode(t *testing.T) {
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	writeEmbeddedConcurrencyConfig(t, beadsDir, &configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltServerPort: 3308,
+	})
+	writeEmbeddedConcurrencyLock(t, beadsDir)
+
+	check := CheckEmbeddedModeConcurrency(tmpDir)
+	if check.Status != StatusOK {
+		t.Fatalf("expected StatusOK for explicit server-backed config, got %s: %s", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Message, "Using server mode") {
+		t.Fatalf("expected server mode message, got %q", check.Message)
+	}
+}
+
+func TestCheckEmbeddedModeConcurrency_ServerRunningWithoutDoltMode(t *testing.T) {
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	writeEmbeddedConcurrencyConfig(t, beadsDir, &configfile.Config{
+		Backend: configfile.BackendDolt,
+	})
+	writeEmbeddedConcurrencyLock(t, beadsDir)
+
+	pid := startFakeDoltSQLServer(t)
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.pid"), []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("13508"), 0o600); err != nil {
+		t.Fatalf("write port file: %v", err)
+	}
+
+	check := CheckEmbeddedModeConcurrency(tmpDir)
+	if check.Status != StatusOK {
+		t.Fatalf("expected StatusOK for running server-backed runtime, got %s: %s", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Message, "Using server mode") {
+		t.Fatalf("expected server mode message, got %q", check.Message)
+	}
+}
+
+func TestCheckEmbeddedModeConcurrency_WarnsForEmbeddedLocks(t *testing.T) {
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	writeEmbeddedConcurrencyConfig(t, beadsDir, &configfile.Config{
+		Backend: configfile.BackendDolt,
+	})
+	writeEmbeddedConcurrencyLock(t, beadsDir)
+
+	check := CheckEmbeddedModeConcurrency(tmpDir)
+	if check.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning for embedded lock indicators, got %s: %s", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Detail, "noms LOCK") {
+		t.Fatalf("expected detail to mention noms LOCK, got %q", check.Detail)
+	}
+}
+
+func writeEmbeddedConcurrencyConfig(t *testing.T, beadsDir string, cfg *configfile.Config) {
+	t.Helper()
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func writeEmbeddedConcurrencyLock(t *testing.T, beadsDir string) {
+	t.Helper()
+	lockDir := filepath.Join(beadsDir, "dolt", ".dolt", "noms")
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		t.Fatalf("mkdir lock dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(lockDir, "LOCK"), []byte(""), 0o600); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+}
+
+func startFakeDoltSQLServer(t *testing.T) int {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake dolt process helper is unix-only")
+	}
+
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+
+	cmd := exec.Command(bash, "-lc", `exec -a "dolt sql-server" sleep 60`)
+	if err := cmd.Start(); err != nil {
+		t.Skipf("start fake dolt process: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	})
+
+	pid := cmd.Process.Pid
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
+		if err == nil {
+			cmdline := strings.TrimSpace(string(out))
+			if strings.Contains(cmdline, "dolt") && strings.Contains(cmdline, "sql-server") {
+				return pid
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Skip("fake dolt process did not expose the expected command line")
+	return 0
+}


### PR DESCRIPTION
Fixes #2606.

## Summary

- treat server-backed runtime/config as server mode in `Embedded Mode Concurrency`
- preserve the warning for real embedded-mode lock indicators
- add regression coverage for legacy metadata without `dolt_mode`

## Why

Today `origin/main` can report all three of these on the same live repo/server state:

- `Dolt Connection Connected successfully`
- `Dolt Mode Server mode (connected)`
- `Embedded Mode Concurrency Embedded mode with 1 lock indicator(s)`

That last line is a false positive for older repos whose `metadata.json` omits `dolt_mode` even though the runtime is already server-backed.

## Testing

- `go test ./cmd/bd/doctor -run 'TestCheckEmbeddedModeConcurrency_'`

## Comparative verification

Against the same live `/Users/gary/AI` repo and the same live Dolt server:

- upstream `1ce765ee` still warns `Embedded Mode Concurrency Embedded mode with 1 lock indicator(s)`
- patched `ebff84de` reports `Embedded Mode Concurrency Using server mode (multi-writer supported)`
