### PR TITLE
fix(doctor): use target repo for fingerprint checks

### DIFF
--- a/cmd/bd/doctor/fix/metadata.go
+++ b/cmd/bd/doctor/fix/metadata.go
@@ -57,7 +57,7 @@ func FixMissingMetadata(path string, bdVersion string) error {
 
 	// Check and repair repo_id
 	if val, err := store.GetMetadata(ctx, "repo_id"); err == nil && val == "" {
-		repoID, err := beads.ComputeRepoID()
+		repoID, err := beads.ComputeRepoIDForPath(path)
 		if err != nil {
 			// Non-git environment: warn and skip (FR-015)
 			fmt.Printf("  Warning: could not compute repo_id (not in a git repo?): %v\n", err)
@@ -71,7 +71,7 @@ func FixMissingMetadata(path string, bdVersion string) error {
 
 	// Check and repair clone_id
 	if val, err := store.GetMetadata(ctx, "clone_id"); err == nil && val == "" {
-		cloneID, err := beads.GetCloneID()
+		cloneID, err := beads.GetCloneIDForPath(path)
 		if err != nil {
 			// Non-standard environment: warn and skip (FR-016)
 			fmt.Printf("  Warning: could not compute clone_id: %v\n", err)

--- a/cmd/bd/doctor/fix/repo_fingerprint.go
+++ b/cmd/bd/doctor/fix/repo_fingerprint.go
@@ -37,11 +37,11 @@ func readLineUnbuffered() (string, error) {
 
 // updateRepoIDInProcess updates the repo_id metadata directly in the Dolt store,
 // avoiding subprocess lock contention. (GH#1805)
-func updateRepoIDInProcess(beadsDir string, autoYes bool) error {
+func updateRepoIDInProcess(path string, beadsDir string, autoYes bool) error {
 	ctx := context.Background()
 
 	// Compute new repo ID
-	newRepoID, err := beads.ComputeRepoID()
+	newRepoID, err := beads.ComputeRepoIDForPath(path)
 	if err != nil {
 		return fmt.Errorf("failed to compute repository ID: %w", err)
 	}
@@ -111,7 +111,7 @@ func RepoFingerprint(path string, autoYes bool) error {
 	// In --yes mode, auto-select the recommended safe action [1].
 	if autoYes {
 		fmt.Println("  → Auto mode (--yes): updating repo ID in-process...")
-		return updateRepoIDInProcess(beadsDir, true)
+		return updateRepoIDInProcess(path, beadsDir, true)
 	}
 
 	// Prompt user for action
@@ -133,7 +133,7 @@ func RepoFingerprint(path string, autoYes bool) error {
 
 	switch response {
 	case "1":
-		return updateRepoIDInProcess(beadsDir, false)
+		return updateRepoIDInProcess(path, beadsDir, false)
 
 	case "2":
 		// Detect backend to determine what to remove

--- a/cmd/bd/doctor/integrity.go
+++ b/cmd/bd/doctor/integrity.go
@@ -325,7 +325,7 @@ func CheckRepoFingerprint(path string) DoctorCheck {
 		}
 	}
 
-	currentRepoID, err := beads.ComputeRepoID()
+	currentRepoID, err := beads.ComputeRepoIDForPath(path)
 	if err != nil {
 		if strings.Contains(err.Error(), "not a git repository") {
 			return DoctorCheck{

--- a/cmd/bd/doctor/integrity_path_cgo_test.go
+++ b/cmd/bd/doctor/integrity_path_cgo_test.go
@@ -1,0 +1,60 @@
+//go:build cgo
+
+package doctor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+func TestCheckRepoFingerprint_UsesTargetRepoOutsideCWD(t *testing.T) {
+	outerRepo := t.TempDir()
+	targetRepo := t.TempDir()
+
+	setupGitRepoInDir(t, outerRepo)
+	setupGitRepoInDir(t, targetRepo)
+
+	targetRepoID, err := beads.ComputeRepoIDForPath(targetRepo)
+	if err != nil {
+		t.Fatalf("ComputeRepoIDForPath(targetRepo) failed: %v", err)
+	}
+
+	beadsDir := filepath.Join(targetRepo, ".beads")
+	cfg := &configfile.Config{
+		Database: "dolt",
+		Backend:  configfile.BackendDolt,
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	ctx := context.Background()
+	store, err := dolt.New(ctx, &dolt.Config{
+		Path:     filepath.Join(beadsDir, "dolt"),
+		Database: "beads",
+	})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	if err := store.SetMetadata(ctx, "repo_id", targetRepoID); err != nil {
+		t.Fatalf("failed to set repo_id metadata: %v", err)
+	}
+
+	runInDir(t, outerRepo, func() {
+		check := CheckRepoFingerprint(targetRepo)
+
+		if check.Status != StatusOK {
+			t.Fatalf("Status = %q, want %q (message=%q detail=%q)", check.Status, StatusOK, check.Message, check.Detail)
+		}
+		if check.Message != "Verified ("+targetRepoID[:8]+")" {
+			t.Fatalf("Message = %q, want %q", check.Message, "Verified ("+targetRepoID[:8]+")")
+		}
+	})
+}

--- a/internal/beads/fingerprint.go
+++ b/internal/beads/fingerprint.go
@@ -13,27 +13,21 @@ import (
 
 // ComputeRepoID generates a unique identifier for this git repository
 func ComputeRepoID() (string, error) {
-	cmd := exec.Command("git", "config", "--get", "remote.origin.url")
-	output, err := cmd.Output()
+	return ComputeRepoIDForPath("")
+}
+
+// ComputeRepoIDForPath generates a unique identifier for the git repository
+// rooted at or containing repoPath. An empty repoPath uses the current cwd.
+func ComputeRepoIDForPath(repoPath string) (string, error) {
+	output, err := runGitInRepo(repoPath, "config", "--get", "remote.origin.url")
 	if err != nil {
-		cmd = exec.Command("git", "rev-parse", "--show-toplevel")
-		output, err = cmd.Output()
+		output, err = runGitInRepo(repoPath, "rev-parse", "--show-toplevel")
 		if err != nil {
 			return "", fmt.Errorf("not a git repository")
 		}
 
-		repoPath := strings.TrimSpace(string(output))
-		absPath, err := filepath.Abs(repoPath)
-		if err != nil {
-			absPath = repoPath
-		}
-
-		evalPath, err := filepath.EvalSymlinks(absPath)
-		if err != nil {
-			evalPath = absPath
-		}
-
-		normalized := filepath.ToSlash(evalPath)
+		repoRoot := strings.TrimSpace(string(output))
+		normalized := normalizedRepoPath(repoRoot)
 		hash := sha256.Sum256([]byte(normalized))
 		return hex.EncodeToString(hash[:16]), nil
 	}
@@ -115,21 +109,39 @@ func canonicalizeGitURL(rawURL string) (string, error) {
 
 // GetCloneID generates a unique ID for this specific clone (not shared with other clones)
 func GetCloneID() (string, error) {
+	return GetCloneIDForPath("")
+}
+
+// GetCloneIDForPath generates a unique ID for the specific clone rooted at or
+// containing repoPath. An empty repoPath uses the current cwd.
+func GetCloneIDForPath(repoPath string) (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return "", fmt.Errorf("failed to get hostname: %w", err)
 	}
 
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	output, err := cmd.Output()
+	output, err := runGitInRepo(repoPath, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", fmt.Errorf("not a git repository: %w", err)
 	}
 
-	repoRoot := strings.TrimSpace(string(output))
-	absPath, err := filepath.Abs(repoRoot)
+	normalizedPath := normalizedRepoPath(strings.TrimSpace(string(output)))
+	hash := sha256.Sum256([]byte(hostname + ":" + normalizedPath))
+	return hex.EncodeToString(hash[:8]), nil
+}
+
+func runGitInRepo(repoPath string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	if repoPath != "" {
+		cmd.Dir = repoPath
+	}
+	return cmd.Output()
+}
+
+func normalizedRepoPath(repoPath string) string {
+	absPath, err := filepath.Abs(repoPath)
 	if err != nil {
-		absPath = repoRoot
+		absPath = repoPath
 	}
 
 	evalPath, err := filepath.EvalSymlinks(absPath)
@@ -137,7 +149,5 @@ func GetCloneID() (string, error) {
 		evalPath = absPath
 	}
 
-	normalizedPath := filepath.ToSlash(evalPath)
-	hash := sha256.Sum256([]byte(hostname + ":" + normalizedPath))
-	return hex.EncodeToString(hash[:8]), nil
+	return filepath.ToSlash(evalPath)
 }

--- a/internal/beads/fingerprint_test.go
+++ b/internal/beads/fingerprint_test.go
@@ -6,6 +6,27 @@ import (
 	"testing"
 )
 
+func initFingerprintGitRepo(t *testing.T, dir string, remote string) {
+	t.Helper()
+
+	cmds := [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	}
+	if remote != "" {
+		cmds = append(cmds, []string{"git", "remote", "add", "origin", remote})
+	}
+
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("command %v failed: %v", args, err)
+		}
+	}
+}
+
 func TestCanonicalizeGitURL_HTTPS(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -162,20 +183,7 @@ func TestCanonicalizeGitURL_Whitespace(t *testing.T) {
 func TestComputeRepoID_WithRemote(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Init git repo and set remote origin
-	cmds := [][]string{
-		{"git", "init"},
-		{"git", "config", "user.email", "test@test.com"},
-		{"git", "config", "user.name", "Test"},
-		{"git", "remote", "add", "origin", "https://github.com/testuser/testrepo.git"},
-	}
-	for _, args := range cmds {
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = tmpDir
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("command %v failed: %v", args, err)
-		}
-	}
+	initFingerprintGitRepo(t, tmpDir, "https://github.com/testuser/testrepo.git")
 
 	t.Chdir(tmpDir)
 
@@ -203,12 +211,7 @@ func TestComputeRepoID_WithRemote(t *testing.T) {
 func TestComputeRepoID_WithoutRemote(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Init git repo WITHOUT remote
-	cmd := exec.Command("git", "init")
-	cmd.Dir = tmpDir
-	if err := cmd.Run(); err != nil {
-		t.Skipf("git not available: %v", err)
-	}
+	initFingerprintGitRepo(t, tmpDir, "")
 
 	t.Chdir(tmpDir)
 
@@ -238,11 +241,7 @@ func TestComputeRepoID_NotGitRepo(t *testing.T) {
 func TestGetCloneID(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	cmd := exec.Command("git", "init")
-	cmd.Dir = tmpDir
-	if err := cmd.Run(); err != nil {
-		t.Skipf("git not available: %v", err)
-	}
+	initFingerprintGitRepo(t, tmpDir, "")
 
 	t.Chdir(tmpDir)
 
@@ -283,11 +282,7 @@ func TestGetCloneID_DifferentClonesDifferentIDs(t *testing.T) {
 	tmpDir2 := t.TempDir()
 
 	for _, dir := range []string{tmpDir1, tmpDir2} {
-		cmd := exec.Command("git", "init")
-		cmd.Dir = dir
-		if err := cmd.Run(); err != nil {
-			t.Skipf("git not available: %v", err)
-		}
+		initFingerprintGitRepo(t, dir, "")
 	}
 
 	// Get ID from first repo
@@ -308,5 +303,53 @@ func TestGetCloneID_DifferentClonesDifferentIDs(t *testing.T) {
 
 	if id1 == id2 {
 		t.Errorf("different clones should have different IDs, both got %q", id1)
+	}
+}
+
+func TestComputeRepoIDForPath_UsesTargetRepoOutsideCWD(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	initFingerprintGitRepo(t, repoA, "https://github.com/testuser/repo-a.git")
+	initFingerprintGitRepo(t, repoB, "https://github.com/testuser/repo-b.git")
+
+	t.Chdir(repoB)
+	want, err := ComputeRepoID()
+	if err != nil {
+		t.Fatalf("ComputeRepoID() for target repo returned error: %v", err)
+	}
+
+	t.Chdir(repoA)
+	got, err := ComputeRepoIDForPath(repoB)
+	if err != nil {
+		t.Fatalf("ComputeRepoIDForPath() returned error: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("ComputeRepoIDForPath(%q) = %q, want %q", repoB, got, want)
+	}
+}
+
+func TestGetCloneIDForPath_UsesTargetRepoOutsideCWD(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	initFingerprintGitRepo(t, repoA, "")
+	initFingerprintGitRepo(t, repoB, "")
+
+	t.Chdir(repoB)
+	want, err := GetCloneID()
+	if err != nil {
+		t.Fatalf("GetCloneID() for target repo returned error: %v", err)
+	}
+
+	t.Chdir(repoA)
+	got, err := GetCloneIDForPath(repoB)
+	if err != nil {
+		t.Fatalf("GetCloneIDForPath() returned error: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("GetCloneIDForPath(%q) = %q, want %q", repoB, got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes `bd doctor /path/to/repo` so repo fingerprinting and adjacent repair paths use the target repo instead of the caller's cwd.

Closes #2615.

## Problem

`CheckRepoFingerprint(path)` was calling `beads.ComputeRepoID()` with no repo path, and `ComputeRepoID()` shells out to `git` without setting `cmd.Dir`.

That means running doctor against a target repo from outside it can compute the "current" repo fingerprint from the wrong repository.

In the confirmed repro:

- from `/Users/gary/AI`:
  - `bd doctor --dry-run /Users/gary/AI/vendor/beads-ui`
  - reported `stored: bb32bea3, current: 2b465a6c`
- from `/Users/gary/AI/vendor/beads-ui`:
  - `bd doctor --dry-run`
  - reported `Repo Fingerprint Verified (bb32bea3)`

The target DB itself was healthy and contained the expected `UI-*` issues, so this was not actual DB corruption.

## What Changed

- added path-aware helpers in `internal/beads/fingerprint.go`
  - `ComputeRepoIDForPath(repoPath string)`
  - `GetCloneIDForPath(repoPath string)`
- switched the doctor repo-fingerprint check to use the target path
- switched repo-fingerprint repair to compute the new repo ID from the target path
- switched missing-metadata backfill for `repo_id` / `clone_id` to use the target path too
- added regressions for the helper layer and the doctor check

## Validation

- `go test ./internal/beads -run '^(TestComputeRepoIDForPath_UsesTargetRepoOutsideCWD|TestGetCloneIDForPath_UsesTargetRepoOutsideCWD)$' -count=1`
- `./scripts/test-cgo.sh -run '^TestCheckRepoFingerprint_UsesTargetRepoOutsideCWD$' ./cmd/bd/doctor`
- `./scripts/test-cgo.sh -run '^(TestFixMissingMetadata_DoltRepair|TestFixMissingMetadata_DoltIdempotent|TestFixMissingMetadata_DoltPartialRepair|TestRepoFingerprint_AutoYesSkipsPrompt)$' ./cmd/bd/doctor/fix`
