### PR TITLE
fix: store credential key in .beads/ to avoid ghost dolt directories

### DIFF
--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -48,21 +48,35 @@ func validatePeerName(name string) error {
 }
 
 // initCredentialKey loads or generates the credential encryption key.
-// If a key file exists at <dbPath>/.beads-credential-key, it is loaded.
-// Otherwise, a new random key is generated, any existing credentials are
-// migrated from the old dbPath-derived key, and the new key is saved.
+// The key file is stored in .beads/ (beadsDir), NOT in .beads/dolt/ (dbPath),
+// to avoid creating ghost directories in shared-server mode (GH bd-cby).
+// Falls back to the old dbPath location for transparent migration.
 func (s *DoltStore) initCredentialKey(ctx context.Context) error {
-	if s.dbPath == "" {
+	if s.beadsDir == "" {
 		return nil // No filesystem path — credential encryption unavailable
 	}
 
-	keyPath := filepath.Join(s.dbPath, credentialKeyFile)
+	keyPath := filepath.Join(s.beadsDir, credentialKeyFile)
 
-	// Try to load existing key file
-	key, err := os.ReadFile(keyPath) //nolint:gosec // G304: keyPath is derived from trusted dbPath, not user input
+	// Try to load from new location (.beads/)
+	key, err := os.ReadFile(keyPath) //nolint:gosec // G304: keyPath is derived from trusted beadsDir, not user input
 	if err == nil && len(key) == 32 {
 		s.credentialKey = key
 		return nil
+	}
+
+	// Migration: try old location (.beads/dolt/) and move to new location
+	if s.dbPath != "" {
+		oldKeyPath := filepath.Join(s.dbPath, credentialKeyFile)
+		oldKey, oldErr := os.ReadFile(oldKeyPath) //nolint:gosec // G304: oldKeyPath is derived from trusted dbPath
+		if oldErr == nil && len(oldKey) == 32 {
+			// Write to new location, then remove old file
+			if writeErr := os.WriteFile(keyPath, oldKey, 0600); writeErr == nil {
+				_ = os.Remove(oldKeyPath)
+			}
+			s.credentialKey = oldKey
+			return nil
+		}
 	}
 
 	// Generate new random 32-byte key (AES-256)
@@ -76,12 +90,8 @@ func (s *DoltStore) initCredentialKey(ctx context.Context) error {
 		return fmt.Errorf("failed to migrate credential keys: %w", err)
 	}
 
-	// Ensure the directory exists before writing the key file
-	if err := os.MkdirAll(s.dbPath, 0700); err != nil {
-		return fmt.Errorf("failed to create directory for credential key: %w", err)
-	}
-
 	// Write key file with owner-only permissions (0600)
+	// beadsDir (.beads/) always exists — no MkdirAll needed
 	if err := os.WriteFile(keyPath, key, 0600); err != nil {
 		return fmt.Errorf("failed to write credential key file: %w", err)
 	}

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -56,7 +56,7 @@ func TestEncryptDecryptWithWrongKey(t *testing.T) {
 func TestCredentialKeyFileGeneration(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	store := &DoltStore{dbPath: tmpDir}
+	store := &DoltStore{dbPath: tmpDir, beadsDir: tmpDir}
 
 	// Key file should not exist yet
 	keyPath := filepath.Join(tmpDir, credentialKeyFile)
@@ -97,13 +97,13 @@ func TestCredentialKeyFileReload(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// First store generates the key
-	store1 := &DoltStore{dbPath: tmpDir}
+	store1 := &DoltStore{dbPath: tmpDir, beadsDir: tmpDir}
 	if err := store1.initCredentialKey(t.Context()); err != nil {
 		t.Fatalf("initCredentialKey (store1) failed: %v", err)
 	}
 
 	// Second store should load the same key from file
-	store2 := &DoltStore{dbPath: tmpDir}
+	store2 := &DoltStore{dbPath: tmpDir, beadsDir: tmpDir}
 	if err := store2.initCredentialKey(t.Context()); err != nil {
 		t.Fatalf("initCredentialKey (store2) failed: %v", err)
 	}
@@ -117,12 +117,12 @@ func TestCredentialKeyNotPredictable(t *testing.T) {
 	tmpDir1 := t.TempDir()
 	tmpDir2 := t.TempDir()
 
-	store1 := &DoltStore{dbPath: tmpDir1}
+	store1 := &DoltStore{dbPath: tmpDir1, beadsDir: tmpDir1}
 	if err := store1.initCredentialKey(t.Context()); err != nil {
 		t.Fatalf("initCredentialKey (store1) failed: %v", err)
 	}
 
-	store2 := &DoltStore{dbPath: tmpDir2}
+	store2 := &DoltStore{dbPath: tmpDir2, beadsDir: tmpDir2}
 	if err := store2.initCredentialKey(t.Context()); err != nil {
 		t.Fatalf("initCredentialKey (store2) failed: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestCredentialKeyNotPredictable(t *testing.T) {
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {
 	tmpDir := t.TempDir()
-	store := &DoltStore{dbPath: tmpDir}
+	store := &DoltStore{dbPath: tmpDir, beadsDir: tmpDir}
 	if err := store.initCredentialKey(t.Context()); err != nil {
 		t.Fatalf("initCredentialKey failed: %v", err)
 	}
@@ -197,6 +197,71 @@ func TestInitCredentialKeyEmptyDbPath(t *testing.T) {
 	}
 	if store.credentialKey != nil {
 		t.Error("expected nil key when dbPath is empty")
+	}
+}
+
+func TestCredentialKeyMigrationFromDbPath(t *testing.T) {
+	// Simulate old layout: key file in .beads/dolt/ (dbPath)
+	beadsDir := t.TempDir()
+	dbPath := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(dbPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write key to old location
+	oldKey := make([]byte, 32)
+	for i := range oldKey {
+		oldKey[i] = byte(i)
+	}
+	oldKeyPath := filepath.Join(dbPath, credentialKeyFile)
+	if err := os.WriteFile(oldKeyPath, oldKey, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &DoltStore{dbPath: dbPath, beadsDir: beadsDir}
+	if err := store.initCredentialKey(t.Context()); err != nil {
+		t.Fatalf("initCredentialKey failed: %v", err)
+	}
+
+	// Key should be loaded from old location
+	if string(store.credentialKey) != string(oldKey) {
+		t.Error("migrated key does not match original")
+	}
+
+	// New location should now have the key
+	newKeyPath := filepath.Join(beadsDir, credentialKeyFile)
+	newKey, err := os.ReadFile(newKeyPath)
+	if err != nil {
+		t.Fatalf("key file should exist at new location: %v", err)
+	}
+	if string(newKey) != string(oldKey) {
+		t.Error("key at new location does not match original")
+	}
+
+	// Old location should be cleaned up
+	if _, err := os.Stat(oldKeyPath); err == nil {
+		t.Error("old key file should have been removed after migration")
+	}
+}
+
+func TestCredentialKeyNoGhostDir(t *testing.T) {
+	// In shared-server mode, dbPath (.beads/dolt/) should NOT be created
+	beadsDir := t.TempDir()
+	dbPath := filepath.Join(beadsDir, "dolt") // does not exist
+
+	store := &DoltStore{dbPath: dbPath, beadsDir: beadsDir}
+	if err := store.initCredentialKey(t.Context()); err != nil {
+		t.Fatalf("initCredentialKey failed: %v", err)
+	}
+
+	// The key should be written to beadsDir, not dbPath
+	if _, err := os.Stat(filepath.Join(beadsDir, credentialKeyFile)); err != nil {
+		t.Error("key file should exist in beadsDir")
+	}
+
+	// dbPath directory should NOT have been created
+	if _, err := os.Stat(dbPath); err == nil {
+		t.Error("dbPath directory should not be created in shared-server mode — ghost directory bug")
 	}
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -109,6 +109,7 @@ var _ storage.DoltStorage = (*DoltStore)(nil)
 type DoltStore struct {
 	db            *sql.DB
 	dbPath        string       // Path to Dolt data directory (server root, e.g. .beads/dolt/)
+	beadsDir      string       // Path to .beads directory (parent of dbPath)
 	database      string       // Database name (subdirectory under dbPath)
 	closed        atomic.Bool  // Tracks whether Close() has been called
 	connStr       string       // Connection string for reconnection
@@ -690,9 +691,15 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		return nil, fmt.Errorf("failed to ping Dolt database: %w", err)
 	}
 
+	beadsDir := cfg.BeadsDir
+	if beadsDir == "" && cfg.Path != "" {
+		beadsDir = filepath.Dir(cfg.Path) // cfg.Path is .beads/dolt → parent is .beads/
+	}
+
 	store := &DoltStore{
 		db:                   db,
 		dbPath:               cfg.Path,
+		beadsDir:             beadsDir,
 		database:             cfg.Database,
 		connStr:              connStr,
 		breaker:              breaker,
@@ -1843,7 +1850,6 @@ func (s *DoltStore) tryAutoResolveMetadataConflicts(ctx context.Context, tx *sql
 
 	return true, nil
 }
-
 
 // Branch creates a new branch
 func (s *DoltStore) Branch(ctx context.Context, name string) (retErr error) {


### PR DESCRIPTION
## Summary
- `initCredentialKey` was calling `os.MkdirAll(s.dbPath)` which creates `.beads/dolt/` even in shared-server mode where no local embedded database exists
- This caused false "may contain unmigrated data" warnings on `gt down/up`
- Move credential key file from `.beads/dolt/.beads-credential-key` to `.beads/.beads-credential-key`
- Transparent migration: reads from old location on first access, writes to new location, removes old file

## Test plan
- [x] Existing credential tests updated and passing
- [x] New `TestCredentialKeyMigrationFromDbPath` — verifies old→new location migration
- [x] New `TestCredentialKeyNoGhostDir` — verifies `.beads/dolt/` is NOT created in shared-server mode
- [x] `go vet` and `golangci-lint` clean

Fixes bd-cby

🤖 Generated with [Claude Code](https://claude.com/claude-code)