### PR TITLE
Harden install trust model and clarify security guidance (GH#1857)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Beads supports hierarchical IDs for epics:
 
 Before trusting any downloaded binary, verify its checksum against the release `checksums.txt`.
 
-On macOS, Gatekeeper behavior depends on the signature state of the binary. If you use the install script, review `scripts/install.sh` and prefer explicit verification steps before first run.
+The install scripts verify release checksums before install. For manual installs, do this verification yourself before first run.
+
+On macOS, `scripts/install.sh` preserves the downloaded signature by default. Local ad-hoc re-signing is explicit opt-in via `BEADS_INSTALL_RESIGN_MACOS=1`.
 
 See [docs/ANTIVIRUS.md](docs/ANTIVIRUS.md) for Windows AV false-positive guidance and verification workflow.
 

--- a/docs/ANTIVIRUS.md
+++ b/docs/ANTIVIRUS.md
@@ -4,6 +4,8 @@
 
 Some antivirus software may flag beads (`bd` or `bd.exe`) as malicious. This is a **false positive** - beads is a legitimate, open-source command-line tool for issue tracking.
 
+Beads release installers now verify downloaded archives against release `checksums.txt` before installation. For users who manually install binaries, checksum verification should be the first trust step before running `bd` or creating antivirus exclusions.
+
 ## Why This Happens
 
 Go binaries (including beads) are sometimes flagged by antivirus software due to:
@@ -26,7 +28,27 @@ Kaspersky's PDM (Proactive Defense Module) uses behavioral analysis that commonl
 
 ## Solutions for Users
 
-### Option 1: Add Exclusion (Recommended)
+### Option 1: Verify File Integrity (Recommended First)
+
+Before running a downloaded binary or adding antivirus exclusions, verify the file is legitimate:
+
+1. Download beads from the [official GitHub releases](https://github.com/steveyegge/beads/releases)
+2. Verify the SHA256 checksum matches the `checksums.txt` file in the release
+3. If a release includes code signing, verify that signature too
+
+**Verify checksum (Windows PowerShell):**
+```powershell
+Get-FileHash bd.exe -Algorithm SHA256
+```
+
+**Verify checksum (macOS/Linux):**
+```bash
+shasum -a 256 bd
+```
+
+Compare the output with the checksum in `checksums.txt` from the release page.
+
+### Option 2: Add Exclusion (After Verification)
 
 Add beads to your antivirus exclusion list:
 
@@ -46,26 +68,6 @@ Add beads to your antivirus exclusion list:
 **Other antivirus software:**
 - Look for "Exclusions", "Whitelist", or "Trusted Applications" settings
 - Add the beads installation directory or executable
-
-### Option 2: Verify File Integrity
-
-Before adding an exclusion, verify the downloaded file is legitimate:
-
-1. Download beads from the [official GitHub releases](https://github.com/steveyegge/beads/releases)
-2. Verify the SHA256 checksum matches the `checksums.txt` file in the release
-3. Check the file is signed (future releases will include code signing)
-
-**Verify checksum (Windows PowerShell):**
-```powershell
-Get-FileHash bd.exe -Algorithm SHA256
-```
-
-**Verify checksum (macOS/Linux):**
-```bash
-shasum -a 256 bd
-```
-
-Compare the output with the checksum in `checksums.txt` from the release page.
 
 ### Option 3: Report False Positive
 
@@ -150,7 +152,7 @@ However, results vary by antivirus vendor and version.
 
 Yes. Beads is:
 - Open source (all code is auditable on [GitHub](https://github.com/steveyegge/beads))
-- Signed releases include checksums for verification
+- Releases include checksums for verification
 - Used by developers worldwide
 - A simple CLI tool for issue tracking
 
@@ -178,9 +180,9 @@ False positives may still occur with new releases until the certificate builds r
 ### Should I disable my antivirus?
 
 **No.** Instead:
-1. Add beads to your antivirus exclusions (safe and recommended)
+1. Verify release checksums before first run
 2. Keep your antivirus enabled for other threats
-3. Verify checksums of downloaded files before adding exclusions
+3. Add beads to your antivirus exclusions only after verification if detections persist
 
 ## Reporting Issues
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -79,9 +79,16 @@ curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/insta
 
 The installer will:
 - Detect your platform (macOS/Linux/FreeBSD, amd64/arm64)
+- Verify downloaded release archives against release `checksums.txt`
 - Install via `go install` if Go is available
 - Fall back to building from source if needed
 - Guide you through PATH setup if necessary
+
+On macOS, the script preserves the downloaded binary signature by default. If you explicitly want ad-hoc local re-signing, opt in:
+
+```bash
+BEADS_INSTALL_RESIGN_MACOS=1 curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+```
 
 ### Comparison of Installation Methods
 
@@ -199,7 +206,7 @@ Beads now ships with native Windows support—no MSYS or MinGW required.
 irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 ```
 
-The script installs a prebuilt Windows release if available. Go is only required for `go install` or building from source.
+The script installs a prebuilt Windows release if available and verifies the downloaded ZIP checksum against release `checksums.txt`. Go is only required for `go install` or building from source.
 
 **Dolt backend on Windows:** Supported via pure-Go regex backend. Windows builds automatically use Go's stdlib `regexp` instead of ICU regex to avoid CGO/header dependencies. If you need full ICU regex semantics, use Linux/macOS (or WSL) with ICU installed.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -202,11 +202,7 @@ If you installed via Homebrew, this shouldn't be necessary as the formula alread
 
 **Solutions**:
 
-1. **Add bd to antivirus exclusions** (recommended):
-   - Add the bd installation directory to your antivirus exclusion list
-   - This is safe - beads is open source and checksums are provided
-
-2. **Verify file integrity before excluding**:
+1. **Verify file integrity first**:
    ```bash
    # Windows PowerShell
    Get-FileHash bd.exe -Algorithm SHA256
@@ -215,6 +211,10 @@ If you installed via Homebrew, this shouldn't be necessary as the formula alread
    shasum -a 256 bd
    ```
    Compare with checksums from the [GitHub release page](https://github.com/steveyegge/beads/releases)
+
+2. **Add bd to antivirus exclusions only after verification**:
+   - Add the bd installation directory to your antivirus exclusion list
+   - Keep antivirus enabled for everything else
 
 3. **Report the false positive**:
    - Help improve detection by reporting to your antivirus vendor
@@ -967,6 +967,10 @@ bd init -v
 ### macOS: Gatekeeper blocking execution
 
 If macOS blocks bd:
+
+1. Verify the downloaded binary checksum matches the release `checksums.txt`.
+2. If you used `scripts/install.sh`, note that macOS ad-hoc re-signing is now **opt-in** (`BEADS_INSTALL_RESIGN_MACOS=1`).
+3. Use one of the approval paths below.
 
 ```bash
 # Remove quarantine attribute

--- a/install.ps1
+++ b/install.ps1
@@ -136,6 +136,43 @@ function Get-WindowsArch {
     }
 }
 
+function Get-ExpectedReleaseChecksum {
+    param(
+        [Parameter(Mandatory)]$Release,
+        [Parameter(Mandatory)][string]$AssetName,
+        [Parameter(Mandatory)][string]$TempRoot
+    )
+
+    $checksumsAsset = $Release.assets | Where-Object { $_.name -eq "checksums.txt" } | Select-Object -First 1
+    if (-not $checksumsAsset) {
+        Write-WarningMsg "Release does not include checksums.txt; refusing unverified install."
+        return $null
+    }
+
+    $checksumsPath = Join-Path $TempRoot "checksums.txt"
+    try {
+        Invoke-WebRequest -Uri $checksumsAsset.browser_download_url -OutFile $checksumsPath
+    } catch {
+        Write-WarningMsg "Failed to download checksums.txt: $_"
+        return $null
+    }
+
+    foreach ($line in Get-Content -Path $checksumsPath) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq "") {
+            continue
+        }
+
+        $parts = $trimmed -split '\s+'
+        if ($parts.Count -ge 2 -and $parts[1].TrimStart("*") -eq $AssetName) {
+            return $parts[0].ToLowerInvariant()
+        }
+    }
+
+    Write-WarningMsg "No checksum entry found for $AssetName in checksums.txt"
+    return $null
+}
+
 function Install-FromRelease {
     Write-Info "Installing bd from GitHub releases..."
 
@@ -174,6 +211,20 @@ function Install-FromRelease {
     try {
         Write-Info "Downloading $assetName..."
         Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath
+
+        Write-Info "Verifying release checksum..."
+        $expectedChecksum = Get-ExpectedReleaseChecksum -Release $release -AssetName $assetName -TempRoot $tempRoot
+        if (-not $expectedChecksum) {
+            return $false
+        }
+
+        $actualChecksum = (Get-FileHash -Path $zipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualChecksum -ne $expectedChecksum) {
+            Write-WarningMsg "Checksum mismatch for $assetName; refusing to install."
+            return $false
+        }
+
+        Write-Success "Checksum verified for $assetName"
 
         Write-Info "Extracting archive..."
         Microsoft.PowerShell.Archive\Expand-Archive -Path $zipPath -DestinationPath $tempRoot -Force

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,13 +45,101 @@ release_has_asset() {
     return 1
 }
 
-# Re-sign binary for macOS to avoid slow Gatekeeper checks
-# See: https://github.com/steveyegge/beads/issues/466
+download_file() {
+    local url=$1
+    local output_path=$2
+
+    if command -v curl &> /dev/null; then
+        curl -fsSL -o "$output_path" "$url"
+        return $?
+    fi
+
+    if command -v wget &> /dev/null; then
+        wget -q -O "$output_path" "$url"
+        return $?
+    fi
+
+    log_error "Neither curl nor wget found. Please install one of them."
+    return 1
+}
+
+sha256_file() {
+    local file_path=$1
+
+    if command -v sha256sum &> /dev/null; then
+        sha256sum "$file_path" | awk '{print $1}'
+        return 0
+    fi
+
+    if command -v shasum &> /dev/null; then
+        shasum -a 256 "$file_path" | awk '{print $1}'
+        return 0
+    fi
+
+    if command -v openssl &> /dev/null; then
+        openssl dgst -sha256 "$file_path" | awk '{print $2}'
+        return 0
+    fi
+
+    return 1
+}
+
+verify_release_checksum() {
+    local release_json=$1
+    local version=$2
+    local archive_name=$3
+    local archive_path=$4
+
+    local checksums_name="checksums.txt"
+    local checksums_url="https://github.com/steveyegge/beads/releases/download/${version}/${checksums_name}"
+
+    if ! release_has_asset "$release_json" "$checksums_name"; then
+        log_error "Release metadata is missing ${checksums_name}; refusing to install unverified binary"
+        return 1
+    fi
+
+    if ! download_file "$checksums_url" "$checksums_name"; then
+        log_error "Failed to download ${checksums_name}; refusing to install unverified binary"
+        return 1
+    fi
+
+    local expected
+    expected=$(awk -v target="$archive_name" '{name=$2; sub(/^\*/, "", name); if (name == target) {print $1; exit}}' "$checksums_name")
+    if [ -z "$expected" ]; then
+        log_error "No checksum entry found for ${archive_name} in ${checksums_name}"
+        return 1
+    fi
+
+    local actual
+    actual=$(sha256_file "$archive_path") || {
+        log_error "No SHA256 tool found (need one of: sha256sum, shasum, openssl)"
+        return 1
+    }
+
+    if [ "$expected" != "$actual" ]; then
+        log_error "Checksum mismatch for ${archive_name}; refusing to install"
+        return 1
+    fi
+
+    log_success "Checksum verified for ${archive_name}"
+    return 0
+}
+
+# Re-sign binary for macOS only when explicitly requested.
+# This replaces the upstream signature with a local ad-hoc signature.
 resign_for_macos() {
     local binary_path=$1
 
     # Only run on macOS
     if [[ "$(uname -s)" != "Darwin" ]]; then
+        return 0
+    fi
+
+    # Keep re-signing opt-in so users can decide whether to preserve
+    # the release signature/Gatekeeper behavior.
+    if [ "${BEADS_INSTALL_RESIGN_MACOS:-0}" != "1" ]; then
+        log_info "Skipping macOS ad-hoc re-signing (default)"
+        log_info "Set BEADS_INSTALL_RESIGN_MACOS=1 to opt in"
         return 0
     fi
 
@@ -61,7 +149,7 @@ resign_for_macos() {
         return 0
     fi
 
-    log_info "Re-signing binary for macOS..."
+    log_warning "Opt-in macOS re-sign enabled: replacing release signature with local ad-hoc signature"
     codesign --remove-signature "$binary_path" 2>/dev/null || true
     if codesign --force --sign - "$binary_path"; then
         log_success "Binary re-signed for this machine"
@@ -202,20 +290,18 @@ install_from_release() {
     log_info "Downloading $archive_name..."
     
     cd "$tmp_dir"
-    if command -v curl &> /dev/null; then
-        if ! curl -fsSL -o "$archive_name" "$download_url"; then
-            log_error "Download failed"
-            cd - > /dev/null || cd "$HOME"
-            rm -rf "$tmp_dir"
-            return 1
-        fi
-    elif command -v wget &> /dev/null; then
-        if ! wget -q -O "$archive_name" "$download_url"; then
-            log_error "Download failed"
-            cd - > /dev/null || cd "$HOME"
-            rm -rf "$tmp_dir"
-            return 1
-        fi
+    if ! download_file "$download_url" "$archive_name"; then
+        log_error "Download failed"
+        cd - > /dev/null || cd "$HOME"
+        rm -rf "$tmp_dir"
+        return 1
+    fi
+
+    log_info "Verifying release checksum..."
+    if ! verify_release_checksum "$release_json" "$version" "$archive_name" "$archive_name"; then
+        cd - > /dev/null || cd "$HOME"
+        rm -rf "$tmp_dir"
+        return 1
     fi
 
     # Extract archive
@@ -243,7 +329,7 @@ install_from_release() {
         sudo mv bd "$install_dir/"
     fi
 
-    # Re-sign for macOS to avoid Gatekeeper delays
+    # Optional local ad-hoc re-sign for macOS (off by default)
     resign_for_macos "$install_dir/bd"
 
     # Create 'beads' alias symlink
@@ -339,7 +425,7 @@ install_with_go() {
             return 1
         fi
 
-        # Re-sign for macOS to avoid Gatekeeper delays
+        # Optional local ad-hoc re-sign for macOS (off by default)
         resign_for_macos "$bin_dir/bd"
 
         # Create 'beads' alias symlink
@@ -399,7 +485,7 @@ build_from_source() {
                 sudo mv bd "$install_dir/"
             fi
 
-            # Re-sign for macOS to avoid Gatekeeper delays
+            # Optional local ad-hoc re-sign for macOS (off by default)
             resign_for_macos "$install_dir/bd"
 
             # Create 'beads' alias symlink
@@ -588,7 +674,8 @@ main() {
     echo ""
     echo "Manual installation:"
     echo "  1. Download from https://github.com/steveyegge/beads/releases/latest"
-    echo "  2. Extract and move 'bd' to your PATH"
+    echo "  2. Verify SHA256 checksum against checksums.txt"
+    echo "  3. Extract and move 'bd' to your PATH"
     echo ""
     echo "Or install from source:"
     echo "  1. Install Go from https://go.dev/dl/"


### PR DESCRIPTION
## Summary
- Enforces release checksum verification in both install scripts before extraction/install.
- Makes macOS ad-hoc re-signing explicit opt-in in `scripts/install.sh` via `BEADS_INSTALL_RESIGN_MACOS=1`.
- Updates README and install/security docs to make the trust model explicit and verification-first.
- Posts an issue-thread update to close the communication loop while implementation is in progress.

## Changes
- `scripts/install.sh`
  - adds shared download helper + SHA256 helpers
  - verifies downloaded archives against release `checksums.txt`
  - defaults macOS to **no ad-hoc re-signing** unless `BEADS_INSTALL_RESIGN_MACOS=1`
- `install.ps1`
  - downloads `checksums.txt` and verifies ZIP SHA256 before extraction
- Docs
  - updates `README.md`, `docs/INSTALLING.md`, `docs/ANTIVIRUS.md`, `docs/TROUBLESHOOTING.md` for explicit trust and verification guidance

## Validation
- `bash -n scripts/install.sh`
- `make test`
- PowerShell parser check could not run in this Linux environment (`pwsh` is unavailable)

## Issue Link
- Refs #1857
