### PR TITLE
fix(init): warn when server host defaults to localhost

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -903,6 +903,12 @@ environment variable.`,
 			}
 			fmt.Printf("  Mode: %s\n", ui.RenderAccent("server"))
 			fmt.Printf("  Server: %s\n", ui.RenderAccent(fmt.Sprintf("%s@%s:%d", user, host, port)))
+			// Warn when using the default localhost — this is the #1 misconfiguration
+			// for setups where Dolt runs on a remote machine (e.g., over Tailscale).
+			if serverHost == "" && os.Getenv("BEADS_DOLT_SERVER_HOST") == "" {
+				fmt.Fprintf(os.Stderr, "\n  %s Server host defaulted to %s.\n", ui.RenderWarn("⚠"), configfile.DefaultDoltServerHost)
+				fmt.Fprintf(os.Stderr, "    If your Dolt server is remote, set BEADS_DOLT_SERVER_HOST or pass --server-host.\n")
+			}
 		}
 		fmt.Printf("  Database: %s\n", ui.RenderAccent(dbName))
 		fmt.Printf("  Issue prefix: %s\n", ui.RenderAccent(prefix))


### PR DESCRIPTION
## Summary

- Warns at `bd init` time when the Dolt server host defaults to `127.0.0.1`
- Points users to `BEADS_DOLT_SERVER_HOST` env var or `--server-host` flag

## How the Dolt host flows through the system

```
~/.zshenv
  export GT_DOLT_HOST=100.111.197.110
       │
       ▼
  gt up / gt daemon start
  └─ doltserver.DefaultConfig() reads GT_DOLT_HOST
  └─ os.Setenv("BEADS_DOLT_SERVER_HOST", host)   ← gastown PR #2827
       │
       ▼
  AgentEnv → spawned agent sessions
       │
       ▼
  bd init (this code)
  └─ if --server-host flag → use it
  └─ elif BEADS_DOLT_SERVER_HOST env → use it
  └─ else → 127.0.0.1 + WARN USER   ← THIS PR ADDS THE WARNING
       │
       ▼
  bd runtime (store.go:540)
  └─ if BEADS_DOLT_SERVER_HOST set → use it
  └─ else → 127.0.0.1 (silent failure on remote setups)
```

**Companion PR**: steveyegge/gastown#2827 fixes the propagation from gt → bd. This PR catches the case where propagation fails or gt isn't involved (standalone bd usage).

## Problem

`bd init --server` silently writes `127.0.0.1` as the server host when no `--server-host` or `BEADS_DOLT_SERVER_HOST` is provided. For setups where Dolt runs on a remote machine (e.g., over Tailscale), this creates a config that fails at runtime with no indication of why.

The env var override (`BEADS_DOLT_SERVER_HOST`) already exists and works, but there's no signal at init time that the default might be wrong. Users only discover the problem later when `bd` commands fail or silently connect to nothing.

## Example output

```
✓ bd initialized successfully!

  Backend: dolt
  Mode: server
  Server: root@127.0.0.1:3307

  ⚠ Server host defaulted to 127.0.0.1.
    If your Dolt server is remote, set BEADS_DOLT_SERVER_HOST or pass --server-host.
```

## Test plan

- [x] `go build ./cmd/bd/` — compiles clean
- [ ] Manual: `bd init --prefix test --server` without BEADS_DOLT_SERVER_HOST — shows warning
- [ ] Manual: `BEADS_DOLT_SERVER_HOST=10.0.0.1 bd init --prefix test --server` — no warning
- [ ] Manual: `bd init --prefix test --server --server-host=10.0.0.1` — no warning