### PR TITLE
fix: add no_history column to embedded Dolt schemas

### DIFF
--- a/internal/storage/embeddeddolt/schema/0001_create_issues.up.sql
+++ b/internal/storage/embeddeddolt/schema/0001_create_issues.up.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS issues (
     original_size INT,
     sender VARCHAR(255) DEFAULT '',
     ephemeral TINYINT(1) DEFAULT 0,
+    no_history TINYINT(1) DEFAULT 0,
     wisp_type VARCHAR(32) DEFAULT '',
     pinned TINYINT(1) DEFAULT 0,
     is_template TINYINT(1) DEFAULT 0,

--- a/internal/storage/embeddeddolt/schema/0020_create_wisps.up.sql
+++ b/internal/storage/embeddeddolt/schema/0020_create_wisps.up.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS wisps (
     original_size INT,
     sender VARCHAR(255) DEFAULT '',
     ephemeral TINYINT(1) DEFAULT 0,
+    no_history TINYINT(1) DEFAULT 0,
     wisp_type VARCHAR(32) DEFAULT '',
     pinned TINYINT(1) DEFAULT 0,
     is_template TINYINT(1) DEFAULT 0,


### PR DESCRIPTION
## Summary
- Add missing no_history TINYINT(1) DEFAULT 0 column to 0001_create_issues.up.sql
- Add missing no_history TINYINT(1) DEFAULT 0 column to 0020_create_wisps.up.sql
- Fixes CI failure where embedded Dolt INSERTs fail with Error 1054: Unknown column 'no_history'