### PR TITLE
fix(dolt): complete schema_version upgrades

### DIFF
--- a/internal/storage/dolt/schema.go
+++ b/internal/storage/dolt/schema.go
@@ -3,7 +3,7 @@ package dolt
 // currentSchemaVersion is bumped whenever the schema or migrations change.
 // initSchemaOnDB checks this against the stored version and skips re-initialization
 // when they match, avoiding ~20 DDL statements per bd invocation.
-const currentSchemaVersion = 7
+const currentSchemaVersion = 8
 
 // schema defines the MySQL-compatible database schema for Dolt.
 const schema = `

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -24,6 +24,15 @@ func TestSchemaVersionSetAfterInit(t *testing.T) {
 	if version != currentSchemaVersion {
 		t.Errorf("schema_version = %d, want %d", version, currentSchemaVersion)
 	}
+
+	var stagedRows int
+	err = store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_status WHERE table_name = 'config'").Scan(&stagedRows)
+	if err != nil {
+		t.Fatalf("query dolt_status for config: %v", err)
+	}
+	if stagedRows != 0 {
+		t.Fatalf("config left staged in dolt_status after init: %d row(s)", stagedRows)
+	}
 }
 
 // TestSchemaVersionSkipsReinit verifies that initSchemaOnDB returns early
@@ -102,6 +111,53 @@ func TestSchemaVersionRunsInitWhenStale(t *testing.T) {
 	}
 	if version != currentSchemaVersion {
 		t.Errorf("schema_version = %d after re-init, want %d", version, currentSchemaVersion)
+	}
+}
+
+// TestSchemaVersionRunsLatestMigrationsWhenOneVersionBehind verifies that a
+// database marked one schema version behind re-enters initSchemaOnDB and picks
+// up the latest migration-backed columns.
+func TestSchemaVersionRunsLatestMigrationsWhenOneVersionBehind(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	for _, stmt := range []string{
+		"ALTER TABLE issues DROP COLUMN no_history",
+		"ALTER TABLE wisps DROP COLUMN no_history",
+	} {
+		if _, err := store.db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+
+	_, err := store.db.ExecContext(ctx,
+		"UPDATE config SET `value` = ? WHERE `key` = 'schema_version'",
+		currentSchemaVersion-1,
+	)
+	if err != nil {
+		t.Fatalf("failed to set prior schema_version: %v", err)
+	}
+
+	if err := initSchemaOnDB(ctx, store.db); err != nil {
+		t.Fatalf("initSchemaOnDB failed: %v", err)
+	}
+
+	for _, table := range []string{"issues", "wisps"} {
+		var count int
+		err := store.db.QueryRowContext(
+			ctx,
+			"SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'no_history'",
+			table,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("check %s.no_history: %v", table, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s.no_history missing after initSchemaOnDB", table)
+		}
 	}
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1121,6 +1121,12 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		"INSERT INTO config (`key`, `value`) VALUES ('schema_version', ?) "+
 			"ON DUPLICATE KEY UPDATE `value` = ?",
 		currentSchemaVersion, currentSchemaVersion)
+	_, _ = db.ExecContext(ctx, "CALL DOLT_ADD('config')")
+	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'schema: update schema_version')"); err != nil {
+		if !strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
+			return fmt.Errorf("failed to commit schema_version update: %w", err)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- bump the Dolt-backed `currentSchemaVersion` to `8` so repos one version behind actually re-run the latest migration-backed columns
- commit the final `config.schema_version` update so repos do not stay dirty in `dolt_status` after init/upgrade
- add regression coverage for both the one-version-behind migration case and the clean-working-set expectation

Fixes #2634.
Related overlap: #2632 covers embedded Dolt schema files only; this PR fixes the Dolt-backed repo upgrade path and schema-version bookkeeping.

## Validation
- `go test ./internal/storage/dolt -run '^(TestSchemaVersionSetAfterInit|TestSchemaVersionRunsLatestMigrationsWhenOneVersionBehind|TestSchemaVersionRunsInitWhenStale)$' -count=1`
