### PR TITLE
fix(ci): add write permissions to update-flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-flake-lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `contents: write` and `pull-requests: write` permissions to the `update-flake-lock` workflow
- The workflow uses `peter-evans/create-pull-request` and `DeterminateSystems/update-flake-lock`, both need to push a branch and open a PR

## Test plan
- [ ] Manually trigger the workflow after merge to verify it succeeds

Fixes #2630

🤖 Generated with [Claude Code](https://claude.com/claude-code)