### PR TITLE
fix(ci): add write permissions to update-flake-lock workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-flake-lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The update-flake-lock workflow needs contents:write (push branch) and pull-requests:write (create PR). Without these, the default GITHUB_TOKEN causes 403 errors. Fixes #2630