### PR TITLE
fix(dolt): keep repo-local auto-started servers alive

### DIFF
--- a/cmd/bd/dolt_autostart_lifecycle_integration_test.go
+++ b/cmd/bd/dolt_autostart_lifecycle_integration_test.go
@@ -1,0 +1,144 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow integration test in short mode")
+	}
+	if runtime.GOOS == windowsOS {
+		t.Skip("repo-local dolt lifecycle integration test not supported on windows")
+	}
+
+	bdBinary := buildLifecycleTestBinary(t)
+	tmpDir := t.TempDir()
+	if err := runCommandInDir(tmpDir, "git", "init"); err != nil {
+		t.Fatalf("git init failed: %v", err)
+	}
+	_ = runCommandInDir(tmpDir, "git", "config", "user.email", "test@example.com")
+	_ = runCommandInDir(tmpDir, "git", "config", "user.name", "Test User")
+	_ = runCommandInDir(tmpDir, "git", "config", "remote.origin.url", "https://github.com/test/repo.git")
+
+	env := append(os.Environ(),
+		"BEADS_TEST_MODE=",
+		"GT_ROOT=",
+		"BEADS_DOLT_AUTO_START=",
+		"BEADS_DOLT_SERVER_PORT=",
+		"BEADS_DOLT_PORT=",
+		"BEADS_DOLT_SHARED_SERVER=",
+	)
+
+	initOut, initErr := runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "init", "--backend", "dolt", "--prefix", "test", "--quiet")
+	if initErr != nil {
+		lower := strings.ToLower(initOut)
+		if strings.Contains(lower, "dolt") && (strings.Contains(lower, "not supported") || strings.Contains(lower, "not available") || strings.Contains(lower, "unknown")) {
+			t.Skipf("dolt backend not available: %s", initOut)
+		}
+		t.Fatalf("bd init --backend dolt failed: %v\n%s", initErr, initOut)
+	}
+
+	createOut, createErr := runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "create", "auto-start persists", "--json")
+	if createErr != nil {
+		t.Fatalf("bd create failed: %v\n%s", createErr, createOut)
+	}
+	var created map[string]any
+	createJSON := createOut
+	if jsonStart := strings.Index(createOut, "{"); jsonStart >= 0 {
+		createJSON = createOut[jsonStart:]
+	}
+	if err := json.Unmarshal([]byte(createJSON), &created); err != nil {
+		t.Fatalf("parse create json: %v\n%s", err, createOut)
+	}
+	issueID, _ := created["id"].(string)
+	if issueID == "" {
+		t.Fatalf("expected created issue id, got: %#v", created["id"])
+	}
+
+	statusOut, _ := runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "dolt", "status")
+	if strings.Contains(statusOut, "Dolt server: running") {
+		stopOut, stopErr := runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "dolt", "stop")
+		if stopErr != nil {
+			t.Fatalf("bd dolt stop failed: %v\n%s", stopErr, stopOut)
+		}
+	}
+
+	statusOut, statusErr := runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "dolt", "status")
+	if statusErr != nil {
+		t.Fatalf("bd dolt status before auto-start failed: %v\n%s", statusErr, statusOut)
+	}
+	if !strings.Contains(statusOut, "Dolt server: not running") {
+		t.Fatalf("expected stopped baseline before show; output:\n%s", statusOut)
+	}
+
+	showOut, showErr := runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "show", issueID, "--json")
+	if showErr != nil {
+		t.Fatalf("bd show failed: %v\n%s", showErr, showOut)
+	}
+
+	statusOut, statusErr = runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "dolt", "status")
+	if statusErr != nil {
+		t.Fatalf("bd dolt status after auto-start failed: %v\n%s", statusErr, statusOut)
+	}
+	if !strings.Contains(statusOut, "Dolt server: running") {
+		t.Fatalf("expected auto-started server to remain running after bd show; output:\n%s", statusOut)
+	}
+	if strings.Contains(statusOut, "Expected port: 0") {
+		t.Fatalf("expected live tracked server after bd show, got stale endpoint bookkeeping:\n%s", statusOut)
+	}
+
+	portBytes, err := os.ReadFile(filepath.Join(tmpDir, ".beads", "dolt-server.port"))
+	if err != nil {
+		t.Fatalf("read dolt-server.port: %v", err)
+	}
+	port := strings.TrimSpace(string(portBytes))
+	if port == "" {
+		t.Fatal("expected non-empty dolt-server.port after auto-start")
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", port), 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("expected auto-started server to keep listening on %s: %v", port, err)
+	}
+	_ = conn.Close()
+
+	stopOut, stopErr := runBDExecAllowErrorWithEnv(t, bdBinary, tmpDir, env, "dolt", "stop")
+	if stopErr != nil {
+		t.Fatalf("bd dolt stop cleanup failed: %v\n%s", stopErr, stopOut)
+	}
+}
+
+func buildLifecycleTestBinary(t *testing.T) string {
+	t.Helper()
+	pkgDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	bdBinary := filepath.Join(t.TempDir(), "bd")
+	cmd := exec.Command("go", "build", "-o", bdBinary, ".")
+	cmd.Dir = pkgDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return bdBinary
+}
+
+func runBDExecAllowErrorWithEnv(t *testing.T, bdBinary string, dir string, env []string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(bdBinary, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -72,6 +72,9 @@ func isTestDatabaseName(name string) bool {
 // sql-server processes, keyed by resolved server directory. When the count
 // drops to zero, the server is stopped. This prevents test-started servers
 // from leaking (GH#2542) while allowing multiple stores to share one server.
+// Normal repo-local auto-starts are intentionally not tracked here: those
+// servers should stay up like an explicit `bd dolt start`, rather than being
+// torn down at the end of each command.
 var autoStartRefs struct {
 	mu sync.Mutex
 	m  map[string]int
@@ -84,6 +87,20 @@ func autoStartAcquire(serverDir string) {
 		autoStartRefs.m = make(map[string]int)
 	}
 	autoStartRefs.m[serverDir]++
+}
+
+// autoStartAcquireExisting increments the refcount for serverDir only when the
+// current process is already tracking that auto-started server. This lets later
+// stores share the same test-owned server without taking ownership of servers
+// started by other processes.
+func autoStartAcquireExisting(serverDir string) bool {
+	autoStartRefs.mu.Lock()
+	defer autoStartRefs.mu.Unlock()
+	if autoStartRefs.m == nil || autoStartRefs.m[serverDir] <= 0 {
+		return false
+	}
+	autoStartRefs.m[serverDir]++
+	return true
 }
 
 // autoStartRelease decrements the refcount for serverDir and stops the server
@@ -100,6 +117,17 @@ func autoStartRelease(serverDir string) error {
 		return doltserver.Stop(serverDir)
 	}
 	return nil
+}
+
+// shouldStopAutoStartedServerOnClose reports whether an auto-started server
+// should be treated as test-owned cleanup state instead of a normal repo-local
+// server. In real repos, auto-start should behave like a persistent helper
+// server, not a single-command subprocess.
+func shouldStopAutoStartedServerOnClose(cfg *Config) bool {
+	if os.Getenv("BEADS_TEST_MODE") == "1" {
+		return true
+	}
+	return isTestDatabaseName(cfg.Database)
 }
 
 // Compile-time interface check.
@@ -666,6 +694,12 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 	// Tracks server dir if we auto-started a server (for cleanup in Close, GH#2542).
 	var autoStartedDir string
+	trackAutoStartedServer := shouldStopAutoStartedServerOnClose(cfg)
+	resolvedBeadsDir := cfg.BeadsDir
+	if resolvedBeadsDir == "" {
+		resolvedBeadsDir = filepath.Dir(cfg.Path) // fallback: cfg.Path is .beads/dolt → parent is .beads/
+	}
+	serverDir := doltserver.ResolveServerDir(resolvedBeadsDir)
 
 	// Fail-fast TCP check before MySQL protocol initialization.
 	// This gives an immediate, clear error if the Dolt server isn't running,
@@ -675,20 +709,18 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	if dialErr != nil {
 		// Auto-start: if enabled and connecting to localhost, start a server
 		if cfg.AutoStart && isLocalHost(cfg.ServerHost) && cfg.Path != "" {
-			beadsDir := cfg.BeadsDir
-			if beadsDir == "" {
-				beadsDir = filepath.Dir(cfg.Path) // fallback: cfg.Path is .beads/dolt → parent is .beads/
-			}
-			port, startedByUs, startErr := doltserver.EnsureRunningDetailed(beadsDir)
+			port, startedByUs, startErr := doltserver.EnsureRunningDetailed(resolvedBeadsDir)
 			if startErr != nil {
 				return nil, fmt.Errorf("Dolt server unreachable at %s and auto-start failed: %w\n\n"+
 					"To start manually: bd dolt start\n"+
 					"To disable auto-start: set dolt.auto-start: false in .beads/config.yaml",
 					addr, startErr)
 			}
-			// Track auto-started servers so Close() can stop them (GH#2542).
-			if startedByUs {
-				autoStartedDir = doltserver.ResolveServerDir(beadsDir)
+			// Only tests should stop auto-started servers on Close(). In normal
+			// repo-local server mode, leaving the server up avoids endpoint churn
+			// and circuit-breaker trips between commands.
+			if startedByUs && trackAutoStartedServer {
+				autoStartedDir = serverDir
 				autoStartAcquire(autoStartedDir)
 			}
 			// Update port — EnsureRunning allocates an ephemeral port
@@ -713,7 +745,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 					breaker.RecordFailure()
 				}
 				return nil, fmt.Errorf("Dolt server auto-started but still unreachable at %s: %w\n\n"+
-					"Check logs: %s", addr, dialErr, doltserver.LogPath(beadsDir))
+					"Check logs: %s", addr, dialErr, doltserver.LogPath(resolvedBeadsDir))
 			}
 		} else {
 			if breaker != nil {
@@ -724,6 +756,14 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		}
 	}
 	_ = conn.Close()
+
+	// If this process already owns a test-started auto-start server, later
+	// stores sharing it must participate in the refcount so one Close() does
+	// not stop the server out from under another open store.
+	if autoStartedDir == "" && trackAutoStartedServer && autoStartAcquireExisting(serverDir) {
+		autoStartedDir = serverDir
+	}
+
 	// TCP dial succeeded — record success to reset the breaker
 	if breaker != nil {
 		breaker.RecordSuccess()

--- a/internal/storage/dolt/store_unit_test.go
+++ b/internal/storage/dolt/store_unit_test.go
@@ -378,3 +378,35 @@ func TestExecWithLongTimeoutDSNRewrite(t *testing.T) {
 		t.Errorf("expected readTimeout=5m, got %v", reParsed.ReadTimeout)
 	}
 }
+
+func TestShouldStopAutoStartedServerOnClose(t *testing.T) {
+	origTestMode := os.Getenv("BEADS_TEST_MODE")
+	defer func() {
+		if origTestMode == "" {
+			os.Unsetenv("BEADS_TEST_MODE")
+		} else {
+			os.Setenv("BEADS_TEST_MODE", origTestMode)
+		}
+	}()
+
+	t.Run("normal repo local server stays up", func(t *testing.T) {
+		os.Unsetenv("BEADS_TEST_MODE")
+		if shouldStopAutoStartedServerOnClose(&Config{Database: "op_broker"}) {
+			t.Fatal("expected normal repo-local auto-start to persist after Close")
+		}
+	})
+
+	t.Run("test mode still owns cleanup", func(t *testing.T) {
+		os.Setenv("BEADS_TEST_MODE", "1")
+		if !shouldStopAutoStartedServerOnClose(&Config{Database: "op_broker"}) {
+			t.Fatal("expected BEADS_TEST_MODE to keep auto-start cleanup enabled")
+		}
+	})
+
+	t.Run("test database names still clean up", func(t *testing.T) {
+		os.Unsetenv("BEADS_TEST_MODE")
+		if !shouldStopAutoStartedServerOnClose(&Config{Database: "testdb_abcdef"}) {
+			t.Fatal("expected test database names to keep auto-start cleanup enabled")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Keep repo-local auto-started Dolt servers alive across ordinary command close paths instead of treating them like test-owned cleanup.

## Why

This is a narrower fix for the same lifecycle family tracked in #2636.

In the ordinary repo-local command path, starting from a stopped baseline:

1. `bd show <issue> --json` succeeds
2. the repo-local Dolt server it auto-started gets torn down at command close
3. `bd dolt status` falls back to `Expected port: 0` / not-running instead of showing the live tracked server

The root cause is that `DoltStore.Close()` still stops repo-local auto-started `dolt sql-server` processes outside test-only ownership cases.

## What changed

- keep repo-local auto-started servers alive on normal close paths
- preserve stop-on-close only for test-owned auto-start cases
- add unit coverage for the ownership boundary
- add an end-to-end CLI regression proving an ordinary repo-local command leaves the tracked server running

## Validation

- `go test ./internal/storage/dolt -run '^(TestShouldStopAutoStartedServerOnClose|TestApplyConfigDefaults_TestModeUseSentinelPort|TestApplyConfigDefaults_ProductionFallback)$' -count=1`
- `go test ./cmd/bd -run '^TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands$' -count=1`

## Live proof

On a real repo-local setup, after a stopped baseline, `bd show ... --json` now leaves `bd dolt status` running on a live port instead of reverting to `Expected port: 0`.

Related to #2636.
