### PR TITLE
feat: add --exclude-type flag to bd ready and bd list

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -310,6 +310,9 @@ var listCmd = &cobra.Command{
 		// Infra type filtering: exclude agent/rig/role/message by default
 		includeInfra, _ := cmd.Flags().GetBool("include-infra")
 
+		// Explicit type exclusion (--exclude-type)
+		excludeTypeStrs, _ := cmd.Flags().GetStringSlice("exclude-type")
+
 		// Parent filtering (--filter-parent is alias for --parent)
 		parentID, _ := cmd.Flags().GetString("parent")
 		if parentID == "" {
@@ -632,6 +635,16 @@ var listCmd = &cobra.Command{
 		if !includeInfra && !isInfra(issueType) {
 			for _, t := range infraTypes {
 				filter.ExcludeTypes = append(filter.ExcludeTypes, types.IssueType(t))
+			}
+		}
+
+		// Explicit type exclusion from --exclude-type flag.
+		for _, raw := range excludeTypeStrs {
+			for _, t := range strings.Split(raw, ",") {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					filter.ExcludeTypes = append(filter.ExcludeTypes, types.IssueType(utils.NormalizeIssueType(t)))
+				}
 			}
 		}
 
@@ -967,6 +980,9 @@ func init() {
 
 	// Infra type filtering: exclude agent/rig/role/message by default
 	listCmd.Flags().Bool("include-infra", false, "Include infrastructure beads (agent/rig/role/message) in output")
+
+	// Explicit type exclusion
+	listCmd.Flags().StringSlice("exclude-type", nil, "Exclude issue types from results (comma-separated or repeatable, e.g., --exclude-type=convoy,epic)")
 
 	// Parent filtering: filter children by parent issue
 	listCmd.Flags().String("parent", "", "Filter by parent issue ID (shows children of specified issue)")

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -61,6 +61,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		plainFormat, _ := cmd.Flags().GetBool("plain")
 		includeDeferred, _ := cmd.Flags().GetBool("include-deferred")
 		includeEphemeral, _ := cmd.Flags().GetBool("include-ephemeral")
+		excludeTypeStrs, _ := cmd.Flags().GetStringSlice("exclude-type")
 		rigOverride, _ := cmd.Flags().GetString("rig")
 		var molType *types.MolType
 		if molTypeStr != "" {
@@ -83,6 +84,16 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			}
 		}
 
+		// Normalize --exclude-type values.
+		var excludeTypes []types.IssueType
+		for _, raw := range excludeTypeStrs {
+			for _, t := range strings.Split(raw, ",") {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					excludeTypes = append(excludeTypes, types.IssueType(utils.NormalizeIssueType(t)))
+				}
+			}
+		}
 		filter := types.WorkFilter{
 			Status:           "open", // Only show open issues, not in_progress (matches bd list --ready)
 			Type:             issueType,
@@ -93,6 +104,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			LabelsAny:        labelsAny,
 			IncludeDeferred:  includeDeferred,  // GH#820: respect --include-deferred flag
 			IncludeEphemeral: includeEphemeral, // bd-i5k5x: allow ephemeral issues (e.g., merge-requests)
+			ExcludeTypes:     excludeTypes,
 		}
 		// Use Changed() to properly handle P0 (priority=0)
 		if cmd.Flags().Changed("priority") {
@@ -540,6 +552,7 @@ func init() {
 	readyCmd.Flags().Bool("include-deferred", false, "Include issues with future defer_until timestamps")
 	readyCmd.Flags().Bool("include-ephemeral", false, "Include ephemeral issues (wisps) in results")
 	readyCmd.Flags().Bool("gated", false, "Find molecules ready for gate-resume dispatch")
+	readyCmd.Flags().StringSlice("exclude-type", nil, "Exclude issue types from results (comma-separated or repeatable, e.g., --exclude-type=convoy,epic)")
 	readyCmd.Flags().String("rig", "", "Query a different rig's database (e.g., --rig gastown, --rig gt-, --rig gt)")
 	// Metadata filtering (GH#1406)
 	readyCmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -151,6 +151,10 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 		// - role: agent role definitions (reference metadata)
 		// - rig: rig identity beads (reference metadata)
 		excludeTypes := []string{"merge-request", "gate", "molecule", "message", "agent", "role", "rig"}
+		// Append caller-supplied exclusions (e.g., from --exclude-type flag).
+		for _, t := range filter.ExcludeTypes {
+			excludeTypes = append(excludeTypes, string(t))
+		}
 		placeholders := make([]string, len(excludeTypes))
 		for i, t := range excludeTypes {
 			placeholders[i] = "?"

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1059,6 +1059,11 @@ type WorkFilter struct {
 	// Set to true to include them (e.g., for merge-request processing).
 	IncludeEphemeral bool
 
+	// Type exclusion: exclude issues with these types from results.
+	// Appended to the default exclusion list (merge-request, gate, molecule, etc.).
+	// When Type is set, ExcludeTypes is ignored (explicit type inclusion wins).
+	ExcludeTypes []IssueType
+
 	// Metadata field filtering (GH#1406)
 	MetadataFields map[string]string // Top-level key=value equality; AND semantics (all must match)
 	HasMetadataKey string            // Existence check: issue has this top-level key set (non-null)


### PR DESCRIPTION
## Summary
- Add `--exclude-type` flag to `bd ready` and `bd list` commands
- Add `ExcludeTypes []IssueType` field to `WorkFilter` struct
- Wire caller-supplied exclusions into `GetReadyWork()` query, appended to the existing hardcoded exclusion list

## Motivation

Gas City's orchestration system shells out to `bd ready --label=pool:X` and `bd ready --assignee=$SESSION` to find work for agents. The default exclusion list in `GetReadyWork()` covers most infrastructure types (merge-request, gate, molecule, message, agent, role, rig), but convoy and epic beads can still leak through if they happen to have matching labels or assignees.

The `IssueFilter` already has an `ExcludeTypes` field used internally by `--include-gates` and `--include-infra`, but there was no way for users to add custom type exclusions via CLI flags. This PR exposes that capability.

## Usage

```bash
# Exclude convoy and epic from ready work
bd ready --exclude-type=convoy,epic

# Repeatable flag form
bd ready --exclude-type=convoy --exclude-type=epic

# Works with bd list too
bd list --exclude-type=convoy,epic

# Aliases are supported (mr→merge-request, feat→feature, etc.)
bd ready --exclude-type=mr
```

When `--type` is set, `--exclude-type` is ignored (explicit type inclusion wins over exclusion). When `--type` is not set, the exclusions are appended to the hardcoded default exclusion list.

## Files changed
- `internal/types/types.go` — Add `ExcludeTypes` to `WorkFilter`
- `internal/storage/dolt/queries.go` — Append caller exclusions in `GetReadyWork()`
- `cmd/bd/ready.go` — Add `--exclude-type` flag, wire to filter
- `cmd/bd/list.go` — Add `--exclude-type` flag, wire to filter