### PR TITLE
feat: custom status categories (active/wip/done/frozen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Custom status categories** — `bd config set status.custom "in_review:active,qa_testing:wip,archived:done,on_hold:frozen"` assigns categories to custom statuses that control behavior in `bd ready` (active statuses included) and `bd list` (done/frozen statuses excluded by default). Backward compatible — old flat format `"foo,bar"` still works with no behavior change.
+- **`bd statuses` command** — Lists all built-in and custom statuses with their icons, categories, and descriptions. Supports `--json` for programmatic use.
+
 ## [0.61.0] - 2026-03-15
 
 ### Added

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // gitSSHRemotePattern matches standard git SSH remote URLs (user@host:path)
@@ -123,6 +124,14 @@ var configSetCmd = &cobra.Command{
 		}
 
 		ctx := rootCtx
+
+		// Validate status.custom config before writing
+		if key == "status.custom" && value != "" {
+			if _, err := types.ParseCustomStatusConfig(value); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: invalid status.custom value: %v\n", err)
+				os.Exit(1)
+			}
+		}
 
 		if err := store.SetConfig(ctx, key, value); err != nil {
 			fmt.Fprintf(os.Stderr, "Error setting config: %v\n", err)

--- a/cmd/bd/config_test.go
+++ b/cmd/bd/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func TestConfigCommands(t *testing.T) {
@@ -452,6 +453,125 @@ func TestFindBeadsRepoRoot(t *testing.T) {
 		got := findBeadsRepoRoot(noRepoDir)
 		if got != "" {
 			t.Errorf("findBeadsRepoRoot(%q) = %q, want empty string", noRepoDir, got)
+		}
+	})
+}
+
+func TestCustomStatusConfig(t *testing.T) {
+	ctx := context.Background()
+	store, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	t.Run("categorized format round-trips", func(t *testing.T) {
+		err := store.SetConfig(ctx, "status.custom", "review:active,testing:wip")
+		if err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		detailed, err := store.GetCustomStatusesDetailed(ctx)
+		if err != nil {
+			t.Fatalf("GetCustomStatusesDetailed failed: %v", err)
+		}
+		if len(detailed) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(detailed))
+		}
+		if detailed[0].Name != "review" || detailed[0].Category != types.CategoryActive {
+			t.Errorf("status[0] = {%q, %q}, want {review, active}", detailed[0].Name, detailed[0].Category)
+		}
+		if detailed[1].Name != "testing" || detailed[1].Category != types.CategoryWIP {
+			t.Errorf("status[1] = {%q, %q}, want {testing, wip}", detailed[1].Name, detailed[1].Category)
+		}
+	})
+
+	t.Run("flat format returns CategoryUnspecified", func(t *testing.T) {
+		err := store.SetConfig(ctx, "status.custom", "review,testing")
+		if err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		detailed, err := store.GetCustomStatusesDetailed(ctx)
+		if err != nil {
+			t.Fatalf("GetCustomStatusesDetailed failed: %v", err)
+		}
+		if len(detailed) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(detailed))
+		}
+		for _, s := range detailed {
+			if s.Category != types.CategoryUnspecified {
+				t.Errorf("status %q has category %q, want unspecified", s.Name, s.Category)
+			}
+		}
+	})
+
+	t.Run("mixed format returns both categorized and uncategorized", func(t *testing.T) {
+		err := store.SetConfig(ctx, "status.custom", "review:active,legacy")
+		if err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		detailed, err := store.GetCustomStatusesDetailed(ctx)
+		if err != nil {
+			t.Fatalf("GetCustomStatusesDetailed failed: %v", err)
+		}
+		if len(detailed) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(detailed))
+		}
+		if detailed[0].Category != types.CategoryActive {
+			t.Errorf("review should be active, got %q", detailed[0].Category)
+		}
+		if detailed[1].Category != types.CategoryUnspecified {
+			t.Errorf("legacy should be unspecified, got %q", detailed[1].Category)
+		}
+	})
+
+	t.Run("GetCustomStatuses returns just names (backward compat)", func(t *testing.T) {
+		err := store.SetConfig(ctx, "status.custom", "review:active,testing:wip,qa:done")
+		if err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		names, err := store.GetCustomStatuses(ctx)
+		if err != nil {
+			t.Fatalf("GetCustomStatuses failed: %v", err)
+		}
+		if len(names) != 3 {
+			t.Fatalf("expected 3 names, got %d", len(names))
+		}
+		want := []string{"review", "testing", "qa"}
+		for i, name := range names {
+			if name != want[i] {
+				t.Errorf("name[%d] = %q, want %q", i, name, want[i])
+			}
+		}
+	})
+
+	t.Run("cache invalidation on SetConfig", func(t *testing.T) {
+		// Set first value
+		err := store.SetConfig(ctx, "status.custom", "alpha:active")
+		if err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		detailed1, err := store.GetCustomStatusesDetailed(ctx)
+		if err != nil {
+			t.Fatalf("GetCustomStatusesDetailed failed: %v", err)
+		}
+		if len(detailed1) != 1 || detailed1[0].Name != "alpha" {
+			t.Fatalf("expected [alpha], got %+v", detailed1)
+		}
+
+		// Set different value — cache should be invalidated
+		err = store.SetConfig(ctx, "status.custom", "beta:wip,gamma:done")
+		if err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		detailed2, err := store.GetCustomStatusesDetailed(ctx)
+		if err != nil {
+			t.Fatalf("GetCustomStatusesDetailed failed: %v", err)
+		}
+		if len(detailed2) != 2 {
+			t.Fatalf("expected 2 statuses after cache invalidation, got %d", len(detailed2))
+		}
+		if detailed2[0].Name != "beta" || detailed2[0].Category != types.CategoryWIP {
+			t.Errorf("status[0] = {%q, %q}, want {beta, wip}", detailed2[0].Name, detailed2[0].Category)
+		}
+		if detailed2[1].Name != "gamma" || detailed2[1].Category != types.CategoryDone {
+			t.Errorf("status[1] = {%q, %q}, want {gamma, done}", detailed2[1].Name, detailed2[1].Category)
 		}
 	})
 }

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -445,14 +445,29 @@ var listCmd = &cobra.Command{
 				customStatuses = cs
 			}
 			if !s.IsValidWithCustom(customStatuses) {
-				FatalError("invalid status %q (valid: open, in_progress, blocked, deferred, closed, pinned, hooked)", status)
+				validList := "open, in_progress, blocked, deferred, closed, pinned, hooked"
+				if len(customStatuses) > 0 {
+					validList += ", " + strings.Join(customStatuses, ", ")
+				}
+				FatalError("invalid status %q (valid: %s)", status, validList)
 			}
 			filter.Status = &s
 		}
 
 		// Default to non-closed/non-pinned issues unless --all, --pinned, or explicit --status (GH#788, bd-uhcg)
+		// Also exclude custom statuses in done/frozen categories
 		if status == "" && !allFlag && !readyFlag && !pinnedFlag {
-			filter.ExcludeStatus = []types.Status{types.StatusClosed, types.StatusPinned}
+			excludeStatuses := []types.Status{types.StatusClosed, types.StatusPinned}
+			if store != nil {
+				if detailed, err := store.GetCustomStatusesDetailed(rootCtx); err == nil {
+					for _, cs := range detailed {
+						if cs.Category == types.CategoryDone || cs.Category == types.CategoryFrozen {
+							excludeStatuses = append(excludeStatuses, types.Status(cs.Name))
+						}
+					}
+				}
+			}
+			filter.ExcludeStatus = excludeStatuses
 		}
 		// Use Changed() to properly handle P0 (priority=0)
 		if cmd.Flags().Changed("priority") {

--- a/cmd/bd/setup/factory_test.go
+++ b/cmd/bd/setup/factory_test.go
@@ -439,8 +439,8 @@ func TestRoundTripAddRemoveLeavesNoBeadsContent(t *testing.T) {
 	if !strings.Contains(withBeads, "BEGIN BEADS INTEGRATION") {
 		t.Fatal("beads markers should be present after adding section")
 	}
-	if !strings.Contains(withBeads, "Landing the Plane") {
-		t.Fatal("landing-the-plane should be present inside beads section")
+	if !strings.Contains(withBeads, "Session Completion") {
+		t.Fatal("session-completion should be present inside beads section")
 	}
 
 	// Remove the beads section
@@ -453,8 +453,8 @@ func TestRoundTripAddRemoveLeavesNoBeadsContent(t *testing.T) {
 	if strings.Contains(cleaned, "END BEADS INTEGRATION") {
 		t.Error("end marker should not remain after removal")
 	}
-	if strings.Contains(cleaned, "Landing the Plane") {
-		t.Error("landing-the-plane should not remain after removal (must be inside markers)")
+	if strings.Contains(cleaned, "Session Completion") {
+		t.Error("session-completion should not remain after removal (must be inside markers)")
 	}
 	if strings.Contains(cleaned, "bd ready") {
 		t.Error("beads commands should not remain after removal")

--- a/cmd/bd/statuses.go
+++ b/cmd/bd/statuses.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+// builtInStatuses describes the built-in statuses with their categories and descriptions.
+var builtInStatuses = []struct {
+	Status      types.Status
+	Category    types.StatusCategory
+	Description string
+}{
+	{types.StatusOpen, types.CategoryActive, "Available to work (default)"},
+	{types.StatusInProgress, types.CategoryWIP, "Actively being worked on"},
+	{types.StatusBlocked, types.CategoryWIP, "Blocked by a dependency"},
+	{types.StatusDeferred, types.CategoryFrozen, "Deliberately put on ice for later"},
+	{types.StatusClosed, types.CategoryDone, "Completed"},
+	{types.StatusPinned, types.CategoryFrozen, "Persistent, stays open indefinitely"},
+	{types.StatusHooked, types.CategoryWIP, "Attached to an agent's hook"},
+}
+
+var statusesCmd = &cobra.Command{
+	Use:     "statuses",
+	GroupID: "views",
+	Short:   "List valid issue statuses",
+	Long: `List all valid issue statuses and their categories.
+
+Built-in statuses (open, in_progress, blocked, etc.) are always valid.
+Additional statuses can be configured via status.custom:
+
+  bd config set status.custom "in_review:active,qa_testing:wip,on_hold:frozen"
+
+Categories control behavior:
+  active  — appears in 'bd ready' and default 'bd list'
+  wip     — excluded from 'bd ready', visible in default 'bd list'
+  done    — excluded from 'bd ready' and default 'bd list'
+  frozen  — excluded from 'bd ready' and default 'bd list'
+
+Statuses without a category (legacy format) are valid but excluded from 'bd ready'.
+
+Examples:
+  bd statuses            # List all statuses with icons and categories
+  bd statuses --json     # Output as JSON
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := ensureDirectMode("statuses command requires direct database access"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return
+		}
+
+		var customStatuses []types.CustomStatus
+		ctx := context.Background()
+		if store != nil {
+			if cs, err := store.GetCustomStatusesDetailed(ctx); err == nil {
+				customStatuses = cs
+			}
+		}
+
+		if jsonOutput {
+			result := struct {
+				BuiltInStatuses []statusInfo         `json:"built_in_statuses"`
+				CustomStatuses  []types.CustomStatus `json:"custom_statuses,omitempty"`
+			}{}
+
+			for _, s := range builtInStatuses {
+				result.BuiltInStatuses = append(result.BuiltInStatuses, statusInfo{
+					Name:        string(s.Status),
+					Category:    string(s.Category),
+					Icon:        ui.GetStatusIcon(string(s.Status)),
+					Description: s.Description,
+				})
+			}
+			result.CustomStatuses = customStatuses
+			outputJSON(result)
+			return
+		}
+
+		// Text output
+		fmt.Println("Built-in statuses:")
+		for _, s := range builtInStatuses {
+			icon := ui.RenderStatusIcon(string(s.Status))
+			fmt.Printf("  %s %-14s [%-6s]  %s\n", icon, s.Status, s.Category, s.Description)
+		}
+
+		if len(customStatuses) > 0 {
+			fmt.Println("\nCustom statuses:")
+			for _, cs := range customStatuses {
+				icon := ui.RenderStatusIconWithCategory(cs.Name, cs.Category)
+				fmt.Printf("  %s %-14s [%-6s]\n", icon, cs.Name, cs.Category)
+			}
+		} else {
+			fmt.Println("\nNo custom statuses configured.")
+			fmt.Println("Configure with: bd config set status.custom \"name:category,...\"")
+			fmt.Println("Categories: active, wip, done, frozen")
+		}
+	},
+}
+
+type statusInfo struct {
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	Icon        string `json:"icon"`
+	Description string `json:"description"`
+}
+
+func init() {
+	rootCmd.AddCommand(statusesCmd)
+}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -724,6 +724,8 @@ bd kv list --json                      # Machine-readable output
 
 ## Issue Statuses
 
+### Built-in Statuses
+
 - `open` - Ready to be worked on
 - `in_progress` - Currently being worked on
 - `blocked` - Cannot proceed (waiting on dependencies)
@@ -733,6 +735,44 @@ bd kv list --json                      # Machine-readable output
 - `pinned` - Stays open indefinitely (used for hooks, anchors)
 
 **Note:** The `pinned` status is used by orchestrators for hook management and persistent work items that should never be auto-closed or cleaned up.
+
+### Custom Statuses
+
+Define custom statuses with optional **categories** that control behavior in `bd ready` and `bd list`:
+
+```bash
+# Simple format (backward compatible — statuses get no category)
+bd config set status.custom "in_review,qa_testing,on_hold"
+
+# Category-annotated format
+bd config set status.custom "in_review:active,qa_testing:wip,on_hold:frozen"
+
+# Mixed format (some with categories, some without)
+bd config set status.custom "in_review:active,legacy_status,archived:done"
+```
+
+**Categories:**
+
+| Category | `bd ready` | Default `bd list` | Icon | Description |
+|----------|-----------|-------------------|------|-------------|
+| `active` | ✓ included | ✓ included | ○ | Ready for work (like `open`) |
+| `wip` | ✗ excluded | ✓ included | ◐ | Work-in-progress (like `in_progress`) |
+| `done` | ✗ excluded | ✗ excluded | ✓ | Terminal state (like `closed`) |
+| `frozen` | ✗ excluded | ✗ excluded | ❄ | On hold (like `deferred`) |
+| *(none)* | ✗ excluded | ✓ included | ◇ | No category — backward compatible default |
+
+**List all statuses** (built-in and custom):
+
+```bash
+bd statuses          # Human-readable table
+bd statuses --json   # JSON output for programmatic use
+```
+
+**Rules:**
+- Status names must match `[a-z][a-z0-9_-]*` (lowercase, letter-first)
+- Cannot collide with built-in status names (case-insensitive)
+- Maximum 50 custom statuses
+- All custom statuses work with `bd list --status <name>`
 
 ## Priorities
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -364,6 +364,33 @@ Use these namespaces for external integrations:
 - `ado.*` - Azure DevOps integration settings
 - `custom.*` - Custom integration settings
 
+### Status and Type Customization
+
+- `status.custom` - Custom issue statuses with optional categories (comma-separated)
+- `types.custom` - Custom issue types (comma-separated)
+
+**Custom statuses** support category annotations that control behavior:
+
+```bash
+# Format: name:category (category is optional)
+bd config set status.custom "in_review:active,qa_testing:wip,on_hold:frozen,archived:done"
+
+# Categories: active, wip, done, frozen
+# - active: shows in bd ready, included in default bd list
+# - wip: excluded from bd ready, included in default bd list
+# - done: excluded from bd ready AND default bd list (terminal)
+# - frozen: excluded from bd ready AND default bd list (on hold)
+# - (none): excluded from bd ready, included in default bd list (backward compatible)
+```
+
+**Custom types:**
+
+```bash
+bd config set types.custom "agent,molecule,event"
+```
+
+See `bd statuses` and `bd types` commands to list all configured statuses and types.
+
 ### Example: Sequential Counter IDs (issue_id_mode=counter)
 
 By default, beads generates hash-based IDs (e.g., `bd-a3f2`, `bd-7f3a8`). For projects that prefer

--- a/integrations/beads-mcp/src/beads_mcp/models.py
+++ b/integrations/beads-mcp/src/beads_mcp/models.py
@@ -9,8 +9,11 @@ from pydantic import BaseModel, Field, field_validator
 #
 # IssueStatus and IssueType are strings (not Literals) to support custom
 # statuses and types configured via:
-#   bd config set status.custom "awaiting_review,awaiting_testing"
+#   bd config set status.custom "in_review:active,qa_testing:wip,on_hold:frozen"
 #   bd config set types.custom "agent,molecule,event"
+#
+# Custom statuses support optional category annotations (active, wip, done, frozen)
+# that control behavior in bd ready and bd list. See docs/CLI_REFERENCE.md.
 #
 # The CLI handles validation of these values against the configured options.
 # Built-in statuses: open, in_progress, blocked, deferred, closed

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -841,7 +841,7 @@ func killStaleServersForDir(beadsDir string, allPIDs []int, inDir func(int, stri
 	}
 
 	// If the server is externally managed, never kill anything.
-	if ResolveServerMode(beadsDir) == ServerModeExternal {
+	if IsAutoStartDisabled() || ResolveServerMode(beadsDir) == ServerModeExternal {
 		return nil, nil
 	}
 

--- a/internal/storage/config_metadata.go
+++ b/internal/storage/config_metadata.go
@@ -12,6 +12,7 @@ type ConfigMetadataStore interface {
 	SetMetadata(ctx context.Context, key, value string) error
 	DeleteConfig(ctx context.Context, key string) error
 	GetCustomStatuses(ctx context.Context) ([]string, error)
+	GetCustomStatusesDetailed(ctx context.Context) ([]types.CustomStatus, error)
 	GetCustomTypes(ctx context.Context) ([]string, error)
 	GetInfraTypes(ctx context.Context) map[string]bool
 	IsInfraTypeCtx(ctx context.Context, t types.IssueType) bool

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // SetConfig sets a configuration value
@@ -25,6 +27,7 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 	case "status.custom":
 		s.customStatusCached = false
 		s.customStatusCache = nil
+		s.customStatusDetailedCache = nil
 	case "types.custom":
 		s.customTypeCached = false
 		s.customTypeCache = nil
@@ -33,6 +36,13 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 		s.infraTypeCache = nil
 	}
 	s.cacheMu.Unlock()
+
+	// Rebuild status views when custom statuses change
+	if key == "status.custom" {
+		if err := s.RebuildStatusViews(ctx); err != nil {
+			return fmt.Errorf("failed to rebuild status views: %w", err)
+		}
+	}
 
 	return nil
 }
@@ -86,11 +96,8 @@ func (s *DoltStore) GetMetadata(ctx context.Context, key string) (string, error)
 	return value, err
 }
 
-// GetCustomStatuses returns custom status values from config.
-// If the database doesn't have custom statuses configured, falls back to config.yaml.
-// Returns an empty slice if no custom statuses are configured.
-// Results are cached per DoltStore lifetime and invalidated when SetConfig
-// updates the "status.custom" key.
+// GetCustomStatuses returns custom status name strings from config (backward-compatible API).
+// Callers that need category information should use GetCustomStatusesDetailed instead.
 func (s *DoltStore) GetCustomStatuses(ctx context.Context) ([]string, error) {
 	s.cacheMu.Lock()
 	if s.customStatusCached {
@@ -100,28 +107,79 @@ func (s *DoltStore) GetCustomStatuses(ctx context.Context) ([]string, error) {
 	}
 	s.cacheMu.Unlock()
 
+	// Populate via detailed method which handles parsing and fallback
+	detailed, err := s.GetCustomStatusesDetailed(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return types.CustomStatusNames(detailed), nil
+}
+
+// GetCustomStatusesDetailed returns typed custom statuses with category information.
+// Falls back to config.yaml if DB config is unavailable.
+// On parse errors (malformed config), logs a warning and returns nil (degraded mode).
+// Results are cached per DoltStore lifetime and invalidated when SetConfig
+// updates the "status.custom" key.
+func (s *DoltStore) GetCustomStatusesDetailed(ctx context.Context) ([]types.CustomStatus, error) {
+	s.cacheMu.Lock()
+	if s.customStatusCached {
+		result := s.customStatusDetailedCache
+		s.cacheMu.Unlock()
+		return result, nil
+	}
+	s.cacheMu.Unlock()
+
 	value, err := s.GetConfig(ctx, "status.custom")
 	if err != nil {
 		// On database error, try fallback to config.yaml
 		if yamlStatuses := config.GetCustomStatusesFromYAML(); len(yamlStatuses) > 0 {
-			return yamlStatuses, nil
+			return parseStatusFallback(yamlStatuses), nil
 		}
 		return nil, err
 	}
 
-	var result []string
+	var detailed []types.CustomStatus
 	if value != "" {
-		result = parseCommaSeparatedList(value)
+		parsed, parseErr := types.ParseCustomStatusConfig(value)
+		if parseErr != nil {
+			// Degraded mode: log warning, return empty (CLI remains operable)
+			log.Printf("warning: invalid status.custom config: %v. Custom statuses disabled. Fix with: bd config set status.custom \"valid,values\"", parseErr)
+			detailed = nil
+		} else {
+			detailed = parsed
+		}
 	} else if yamlStatuses := config.GetCustomStatusesFromYAML(); len(yamlStatuses) > 0 {
-		result = yamlStatuses
+		detailed = parseStatusFallback(yamlStatuses)
 	}
 
 	s.cacheMu.Lock()
-	s.customStatusCache = result
-	s.customStatusCached = true
+	if !s.customStatusCached {
+		s.customStatusDetailedCache = detailed
+		s.customStatusCache = types.CustomStatusNames(detailed)
+		s.customStatusCached = true
+	}
 	s.cacheMu.Unlock()
 
-	return result, nil
+	return detailed, nil
+}
+
+// parseStatusFallback converts legacy []string status names (from YAML) to []CustomStatus.
+// All statuses get CategoryUnspecified since YAML fallback may use flat format.
+func parseStatusFallback(names []string) []types.CustomStatus {
+	// Try parsing as new format first (YAML might have "name:category" entries)
+	joined := strings.Join(names, ",")
+	if parsed, err := types.ParseCustomStatusConfig(joined); err == nil {
+		return parsed
+	}
+	// Fall back to treating each as an untyped name
+	result := make([]types.CustomStatus, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			result = append(result, types.CustomStatus{Name: name, Category: types.CategoryUnspecified})
+		}
+	}
+	return result
 }
 
 // GetCustomTypes returns custom issue type values from config.

--- a/internal/storage/dolt/custom_status_test.go
+++ b/internal/storage/dolt/custom_status_test.go
@@ -1,0 +1,303 @@
+package dolt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestBuildReadyIssuesView(t *testing.T) {
+	tests := []struct {
+		name           string
+		customStatuses []types.CustomStatus
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:           "no custom statuses uses static view",
+			customStatuses: nil,
+			wantContains:   []string{"i.status = 'open'"},
+			wantNotContain: []string{"'review'"},
+		},
+		{
+			name: "no active custom statuses uses static view",
+			customStatuses: []types.CustomStatus{
+				{Name: "review", Category: types.CategoryWIP},
+			},
+			wantContains:   []string{"i.status = 'open'"},
+			wantNotContain: []string{"'review'"},
+		},
+		{
+			name: "active custom statuses added to IN clause",
+			customStatuses: []types.CustomStatus{
+				{Name: "review", Category: types.CategoryActive},
+				{Name: "triage", Category: types.CategoryActive},
+				{Name: "testing", Category: types.CategoryWIP},
+			},
+			wantContains:   []string{"IN", "'open'", "'review'", "'triage'"},
+			wantNotContain: []string{"'testing'"},
+		},
+		{
+			name: "unspecified category not included",
+			customStatuses: []types.CustomStatus{
+				{Name: "legacy", Category: types.CategoryUnspecified},
+				{Name: "review", Category: types.CategoryActive},
+			},
+			wantContains:   []string{"'review'"},
+			wantNotContain: []string{"'legacy'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := BuildReadyIssuesView(tt.customStatuses)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(sql, want) {
+					t.Errorf("expected SQL to contain %q, got:\n%s", want, sql)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(sql, notWant) {
+					t.Errorf("expected SQL to NOT contain %q, got:\n%s", notWant, sql)
+				}
+			}
+			// All views must be valid CREATE OR REPLACE VIEW statements
+			if !strings.Contains(sql, "CREATE OR REPLACE VIEW ready_issues") {
+				t.Errorf("expected valid CREATE VIEW statement")
+			}
+		})
+	}
+}
+
+func TestBuildBlockedIssuesView(t *testing.T) {
+	tests := []struct {
+		name           string
+		customStatuses []types.CustomStatus
+		wantContains   []string
+		wantNotContain []string
+	}{
+		{
+			name:           "no custom statuses uses static view",
+			customStatuses: nil,
+			wantContains:   []string{"NOT IN ('closed', 'pinned')"},
+			wantNotContain: []string{"'archived'"},
+		},
+		{
+			name: "done/frozen custom statuses added to NOT IN",
+			customStatuses: []types.CustomStatus{
+				{Name: "archived", Category: types.CategoryDone},
+				{Name: "on-ice", Category: types.CategoryFrozen},
+				{Name: "review", Category: types.CategoryActive},
+			},
+			wantContains:   []string{"'closed'", "'pinned'", "'archived'", "'on-ice'"},
+			wantNotContain: []string{"'review'"},
+		},
+		{
+			name: "only wip and active statuses - uses static view",
+			customStatuses: []types.CustomStatus{
+				{Name: "review", Category: types.CategoryActive},
+				{Name: "testing", Category: types.CategoryWIP},
+			},
+			wantContains:   []string{"NOT IN ('closed', 'pinned')"},
+			wantNotContain: []string{"'review'", "'testing'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := BuildBlockedIssuesView(tt.customStatuses)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(sql, want) {
+					t.Errorf("expected SQL to contain %q, got:\n%s", want, sql)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if strings.Contains(sql, notWant) {
+					t.Errorf("expected SQL to NOT contain %q, got:\n%s", notWant, sql)
+				}
+			}
+			if !strings.Contains(sql, "CREATE OR REPLACE VIEW blocked_issues") {
+				t.Errorf("expected valid CREATE VIEW statement")
+			}
+		})
+	}
+}
+
+func TestEscapeSQL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"review", "review"},
+		{"it's", "it''s"},
+		{"a'b'c", "a''b''c"},
+		{"normal-status_123", "normal-status_123"},
+		// SQL injection attempts
+		{"'; DROP TABLE issues; --", "''; DROP TABLE issues; --"},
+		{"review' OR '1'='1", "review'' OR ''1''=''1"},
+	}
+	for _, tt := range tests {
+		got := escapeSQL(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeSQL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildReadyIssuesViewManyActiveStatuses(t *testing.T) {
+	// 12 active statuses should all appear in the IN clause
+	var statuses []types.CustomStatus
+	for i := 0; i < 12; i++ {
+		name := "status" + strings.Repeat("x", i+1) // statusx, statusxx, ...
+		statuses = append(statuses, types.CustomStatus{Name: name, Category: types.CategoryActive})
+	}
+
+	sql := BuildReadyIssuesView(statuses)
+	if !strings.Contains(sql, "IN") {
+		t.Fatal("expected IN clause for multiple active statuses")
+	}
+	for _, s := range statuses {
+		if !strings.Contains(sql, "'"+s.Name+"'") {
+			t.Errorf("expected SQL to contain %q", s.Name)
+		}
+	}
+	if !strings.Contains(sql, "'open'") {
+		t.Error("expected SQL to still contain 'open'")
+	}
+}
+
+func TestBuildBlockedIssuesViewManyDoneFrozen(t *testing.T) {
+	var statuses []types.CustomStatus
+	for i := 0; i < 5; i++ {
+		statuses = append(statuses, types.CustomStatus{
+			Name:     "done" + strings.Repeat("x", i+1),
+			Category: types.CategoryDone,
+		})
+	}
+	for i := 0; i < 5; i++ {
+		statuses = append(statuses, types.CustomStatus{
+			Name:     "frozen" + strings.Repeat("x", i+1),
+			Category: types.CategoryFrozen,
+		})
+	}
+
+	sql := BuildBlockedIssuesView(statuses)
+	for _, s := range statuses {
+		if !strings.Contains(sql, "'"+s.Name+"'") {
+			t.Errorf("expected SQL to contain %q", s.Name)
+		}
+	}
+	// Built-in exclusions should still be present
+	if !strings.Contains(sql, "'closed'") {
+		t.Error("expected SQL to contain 'closed'")
+	}
+	if !strings.Contains(sql, "'pinned'") {
+		t.Error("expected SQL to contain 'pinned'")
+	}
+}
+
+func TestBuildReadyIssuesViewUnspecifiedNotIncluded(t *testing.T) {
+	statuses := []types.CustomStatus{
+		{Name: "legacy", Category: types.CategoryUnspecified},
+		{Name: "old-flow", Category: types.CategoryUnspecified},
+	}
+
+	sql := BuildReadyIssuesView(statuses)
+	// Unspecified should NOT affect the ready view
+	if strings.Contains(sql, "'legacy'") {
+		t.Error("unspecified status 'legacy' should not appear in ready view")
+	}
+	if strings.Contains(sql, "'old-flow'") {
+		t.Error("unspecified status 'old-flow' should not appear in ready view")
+	}
+	// Should use static view (no IN clause needed)
+	if !strings.Contains(sql, "i.status = 'open'") {
+		t.Error("expected static view with just i.status = 'open'")
+	}
+}
+
+func TestBuildBlockedIssuesViewUnspecifiedNotIncluded(t *testing.T) {
+	statuses := []types.CustomStatus{
+		{Name: "legacy", Category: types.CategoryUnspecified},
+		{Name: "old-flow", Category: types.CategoryUnspecified},
+	}
+
+	sql := BuildBlockedIssuesView(statuses)
+	// Unspecified should NOT affect the blocked view
+	if strings.Contains(sql, "'legacy'") {
+		t.Error("unspecified status 'legacy' should not appear in blocked view")
+	}
+	if strings.Contains(sql, "'old-flow'") {
+		t.Error("unspecified status 'old-flow' should not appear in blocked view")
+	}
+	// Should use static NOT IN
+	if !strings.Contains(sql, "NOT IN ('closed', 'pinned')") {
+		t.Error("expected static NOT IN clause")
+	}
+}
+
+func TestParseStatusFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []types.CustomStatus
+	}{
+		{
+			name:  "simple names get CategoryUnspecified",
+			input: []string{"review", "testing"},
+			want: []types.CustomStatus{
+				{Name: "review", Category: types.CategoryUnspecified},
+				{Name: "testing", Category: types.CategoryUnspecified},
+			},
+		},
+		{
+			name:  "category format parsed correctly",
+			input: []string{"review:active", "testing:wip"},
+			want: []types.CustomStatus{
+				{Name: "review", Category: types.CategoryActive},
+				{Name: "testing", Category: types.CategoryWIP},
+			},
+		},
+		{
+			name:  "mixed format",
+			input: []string{"review:active", "legacy"},
+			want: []types.CustomStatus{
+				{Name: "review", Category: types.CategoryActive},
+				{Name: "legacy", Category: types.CategoryUnspecified},
+			},
+		},
+		{
+			name:  "empty entries filtered",
+			input: []string{"", "review", ""},
+			want: []types.CustomStatus{
+				{Name: "review", Category: types.CategoryUnspecified},
+			},
+		},
+		{
+			name:  "empty list",
+			input: []string{},
+			want:  nil,
+		},
+		{
+			name:  "nil input",
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseStatusFallback(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d statuses, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i, g := range got {
+				if g.Name != tt.want[i].Name || g.Category != tt.want[i].Category {
+					t.Errorf("status[%d] = {%q, %q}, want {%q, %q}",
+						i, g.Name, g.Category, tt.want[i].Name, tt.want[i].Category)
+				}
+			}
+		})
+	}
+}

--- a/internal/storage/dolt/schema.go
+++ b/internal/storage/dolt/schema.go
@@ -1,5 +1,11 @@
 package dolt
 
+import (
+	"strings"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
 // currentSchemaVersion is bumped whenever the schema or migrations change.
 // initSchemaOnDB checks this against the stored version and skips re-initialization
 // when they match, avoiding ~20 DDL statements per bd invocation.
@@ -328,3 +334,111 @@ WHERE i.status NOT IN ('closed', 'pinned')
       )
   );
 `
+
+// BuildReadyIssuesView generates the ready_issues view SQL, incorporating
+// custom statuses with CategoryActive into the status filter.
+// When no active custom statuses exist, falls back to the static view.
+func BuildReadyIssuesView(customStatuses []types.CustomStatus) string {
+	active := types.CustomStatusesByCategory(customStatuses, types.CategoryActive)
+	if len(active) == 0 {
+		return readyIssuesView
+	}
+
+	statusList := "'open'"
+	for _, s := range active {
+		statusList += ", '" + escapeSQL(s.Name) + "'"
+	}
+
+	return `
+CREATE OR REPLACE VIEW ready_issues AS
+WITH RECURSIVE
+  blocked_directly AS (
+    SELECT DISTINCT d.issue_id
+    FROM dependencies d
+    WHERE d.type = 'blocks'
+      AND EXISTS (
+        SELECT 1 FROM issues blocker
+        WHERE blocker.id = d.depends_on_id
+          AND blocker.status NOT IN ('closed', 'pinned')
+      )
+  ),
+  blocked_transitively AS (
+    SELECT issue_id, 0 as depth
+    FROM blocked_directly
+    UNION ALL
+    SELECT d.issue_id, bt.depth + 1
+    FROM blocked_transitively bt
+    JOIN dependencies d ON d.depends_on_id = bt.issue_id
+    WHERE d.type = 'parent-child'
+      AND bt.depth < 50
+  )
+SELECT i.*
+FROM issues i
+LEFT JOIN blocked_transitively bt ON bt.issue_id = i.id
+WHERE i.status IN (` + statusList + `)
+  AND (i.ephemeral = 0 OR i.ephemeral IS NULL)
+  AND bt.issue_id IS NULL
+  AND (i.defer_until IS NULL OR i.defer_until <= NOW())
+  AND NOT EXISTS (
+    SELECT 1 FROM dependencies d_parent
+    JOIN issues parent ON parent.id = d_parent.depends_on_id
+    WHERE d_parent.issue_id = i.id
+      AND d_parent.type = 'parent-child'
+      AND parent.defer_until IS NOT NULL
+      AND parent.defer_until > NOW()
+  );
+`
+}
+
+// BuildBlockedIssuesView generates the blocked_issues view SQL, incorporating
+// custom statuses with CategoryDone/CategoryFrozen into the exclusion filter.
+func BuildBlockedIssuesView(customStatuses []types.CustomStatus) string {
+	done := types.CustomStatusesByCategory(customStatuses, types.CategoryDone)
+	frozen := types.CustomStatusesByCategory(customStatuses, types.CategoryFrozen)
+	if len(done) == 0 && len(frozen) == 0 {
+		return blockedIssuesView
+	}
+
+	excludeList := "'closed', 'pinned'"
+	for _, s := range done {
+		excludeList += ", '" + escapeSQL(s.Name) + "'"
+	}
+	for _, s := range frozen {
+		excludeList += ", '" + escapeSQL(s.Name) + "'"
+	}
+
+	return `
+CREATE OR REPLACE VIEW blocked_issues AS
+SELECT
+    i.*,
+    (SELECT COUNT(*)
+     FROM dependencies d
+     WHERE d.issue_id = i.id
+       AND d.type = 'blocks'
+       AND EXISTS (
+         SELECT 1 FROM issues blocker
+         WHERE blocker.id = d.depends_on_id
+           AND blocker.status NOT IN (` + excludeList + `)
+       )
+    ) as blocked_by_count
+FROM issues i
+WHERE i.status NOT IN (` + excludeList + `)
+  AND EXISTS (
+    SELECT 1 FROM dependencies d
+    WHERE d.issue_id = i.id
+      AND d.type = 'blocks'
+      AND EXISTS (
+        SELECT 1 FROM issues blocker
+        WHERE blocker.id = d.depends_on_id
+          AND blocker.status NOT IN (` + excludeList + `)
+      )
+  );
+`
+}
+
+// escapeSQL escapes a string for safe inclusion in SQL string literals.
+// Defense-in-depth: status names are already validated by ParseCustomStatusConfig
+// to match [a-z][a-z0-9_-]*, so this should never actually escape anything.
+func escapeSQL(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -40,6 +41,7 @@ import (
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // DefaultSQLPort is the default port for dolt sql-server.
@@ -150,13 +152,14 @@ type DoltStore struct {
 	credentialKey []byte       // Random encryption key for federation credentials
 
 	// Per-invocation caches (lifetime = DoltStore lifetime)
-	customStatusCache            []string        // cached result of GetCustomStatuses
-	customStatusCached           bool            // true once customStatusCache has been populated
-	customTypeCache              []string        // cached result of GetCustomTypes
-	customTypeCached             bool            // true once customTypeCache has been populated
-	infraTypeCache               map[string]bool // cached result of GetInfraTypes
-	infraTypeCached              bool            // true once infraTypeCache has been populated
-	blockedIDsCache              []string        // cached result of computeBlockedIDs
+	customStatusDetailedCache    []types.CustomStatus // cached result of GetCustomStatusesDetailed
+	customStatusCache            []string             // cached name-only result (derived from detailed)
+	customStatusCached           bool                 // true once cache has been populated
+	customTypeCache              []string             // cached result of GetCustomTypes
+	customTypeCached             bool                 // true once customTypeCache has been populated
+	infraTypeCache               map[string]bool      // cached result of GetInfraTypes
+	infraTypeCached              bool                 // true once infraTypeCache has been populated
+	blockedIDsCache              []string             // cached result of computeBlockedIDs
 	blockedIDsCacheMap           map[string]bool
 	blockedIDsCached             bool // true once blockedIDsCache has been populated
 	blockedIDsCacheIncludesWisps bool // true if cache was computed with wisps
@@ -1132,7 +1135,19 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 	if err == nil && version >= currentSchemaVersion {
 		// Wisps tables are dolt_ignore'd (not persisted in commit history),
 		// so they must be recreated on every server session. (GH#2271)
-		return createIgnoredTables(db)
+		if err := createIgnoredTables(db); err != nil {
+			return err
+		}
+		// Rebuild status views to match current custom status config.
+		// This ensures views stay in sync even after direct SQL config edits.
+		customStatuses := readCustomStatusesFromDB(ctx, db)
+		if _, err := db.ExecContext(ctx, BuildReadyIssuesView(customStatuses)); err != nil {
+			return fmt.Errorf("failed to create ready_issues view: %w", err)
+		}
+		if _, err := db.ExecContext(ctx, BuildBlockedIssuesView(customStatuses)); err != nil {
+			return fmt.Errorf("failed to create blocked_issues view: %w", err)
+		}
+		return nil
 	}
 
 	// Acquire an advisory lock to serialize schema initialization across concurrent processes.
@@ -1220,11 +1235,13 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("failed to drop fk_dep_depends_on: %w", err)
 	}
 
-	// Create views
-	if _, err := db.ExecContext(ctx, readyIssuesView); err != nil {
+	// Create views — dynamically built to incorporate custom status categories.
+	// Read status.custom config directly from DB (DoltStore not yet constructed).
+	customStatuses := readCustomStatusesFromDB(ctx, db)
+	if _, err := db.ExecContext(ctx, BuildReadyIssuesView(customStatuses)); err != nil {
 		return fmt.Errorf("failed to create ready_issues view: %w", err)
 	}
-	if _, err := db.ExecContext(ctx, blockedIssuesView); err != nil {
+	if _, err := db.ExecContext(ctx, BuildBlockedIssuesView(customStatuses)); err != nil {
 		return fmt.Errorf("failed to create blocked_issues view: %w", err)
 	}
 
@@ -2157,3 +2174,45 @@ type DoltStatus = storage.Status
 
 // StatusEntry is an alias for storage.StatusEntry.
 type StatusEntry = storage.StatusEntry
+
+// readCustomStatusesFromDB reads status.custom config directly from the database.
+// Used during initialization when DoltStore is not yet available.
+// Returns nil on any error (degraded mode — views use built-in statuses only).
+func readCustomStatusesFromDB(ctx context.Context, db *sql.DB) []types.CustomStatus {
+	var value string
+	err := db.QueryRowContext(ctx, "SELECT `value` FROM config WHERE `key` = 'status.custom'").Scan(&value)
+	if err != nil || value == "" {
+		return nil
+	}
+	parsed, parseErr := types.ParseCustomStatusConfig(value)
+	if parseErr != nil {
+		// Degraded mode: log warning, return nil so views use built-in statuses
+		log.Printf("warning: invalid status.custom config: %v. Using built-in statuses only.", parseErr)
+		return nil
+	}
+	return parsed
+}
+
+// RebuildStatusViews regenerates the ready_issues and blocked_issues views
+// based on current custom status configuration. Called within a write
+// transaction when status.custom config changes.
+func (s *DoltStore) RebuildStatusViews(ctx context.Context) error {
+	detailed, err := s.GetCustomStatusesDetailed(ctx)
+	if err != nil {
+		// On error, rebuild with built-in statuses only
+		detailed = nil
+	}
+	return s.rebuildStatusViewsWithStatuses(ctx, detailed)
+}
+
+func (s *DoltStore) rebuildStatusViewsWithStatuses(ctx context.Context, customStatuses []types.CustomStatus) error {
+	readySQL := BuildReadyIssuesView(customStatuses)
+	if _, err := s.db.ExecContext(ctx, readySQL); err != nil {
+		return fmt.Errorf("failed to rebuild ready_issues view: %w", err)
+	}
+	blockedSQL := BuildBlockedIssuesView(customStatuses)
+	if _, err := s.db.ExecContext(ctx, blockedSQL); err != nil {
+		return fmt.Errorf("failed to rebuild blocked_issues view: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -597,6 +598,47 @@ func (s *EmbeddedDoltStore) GetCustomStatuses(ctx context.Context) ([]string, er
 		return config.GetCustomStatusesFromYAML(), nil
 	}
 	return result, nil
+}
+
+func (s *EmbeddedDoltStore) GetCustomStatusesDetailed(ctx context.Context) ([]types.CustomStatus, error) {
+	value, err := s.GetConfig(ctx, "status.custom")
+	if err != nil {
+		// On database error, try fallback to config.yaml
+		if yamlStatuses := config.GetCustomStatusesFromYAML(); len(yamlStatuses) > 0 {
+			return parseStatusFallbackEmbedded(yamlStatuses), nil
+		}
+		return nil, err
+	}
+
+	if value != "" {
+		parsed, parseErr := types.ParseCustomStatusConfig(value)
+		if parseErr != nil {
+			// Degraded mode: return empty (CLI remains operable)
+			return nil, nil
+		}
+		return parsed, nil
+	}
+
+	if yamlStatuses := config.GetCustomStatusesFromYAML(); len(yamlStatuses) > 0 {
+		return parseStatusFallbackEmbedded(yamlStatuses), nil
+	}
+	return nil, nil
+}
+
+// parseStatusFallbackEmbedded converts legacy []string status names to []CustomStatus.
+func parseStatusFallbackEmbedded(names []string) []types.CustomStatus {
+	joined := strings.Join(names, ",")
+	if parsed, err := types.ParseCustomStatusConfig(joined); err == nil {
+		return parsed
+	}
+	result := make([]types.CustomStatus, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			result = append(result, types.CustomStatus{Name: name, Category: types.CategoryUnspecified})
+		}
+	}
+	return result
 }
 
 func (s *EmbeddedDoltStore) GetCustomTypes(ctx context.Context) ([]string, error) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -354,6 +355,163 @@ func (s Status) IsValidWithCustom(customStatuses []string) bool {
 		}
 	}
 	return false
+}
+
+// IsValidWithCustomStatuses checks if the status is valid, including typed custom statuses.
+func (s Status) IsValidWithCustomStatuses(customStatuses []CustomStatus) bool {
+	if s.IsValid() {
+		return true
+	}
+	for _, cs := range customStatuses {
+		if string(s) == cs.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// StatusCategory defines how a custom status behaves in views and commands.
+type StatusCategory string
+
+const (
+	// CategoryActive statuses appear in bd ready and default bd list.
+	CategoryActive StatusCategory = "active"
+	// CategoryWIP statuses are excluded from bd ready but visible in default bd list.
+	CategoryWIP StatusCategory = "wip"
+	// CategoryDone statuses are excluded from bd ready and default bd list.
+	CategoryDone StatusCategory = "done"
+	// CategoryFrozen statuses are excluded from bd ready and default bd list.
+	CategoryFrozen StatusCategory = "frozen"
+	// CategoryUnspecified is assigned when no category is provided (backward compat).
+	// Behaves like current behavior: valid, visible in default bd list, absent from bd ready.
+	CategoryUnspecified StatusCategory = "unspecified"
+)
+
+// validCategories is the set of user-assignable categories (excludes CategoryUnspecified).
+var validCategories = map[StatusCategory]bool{
+	CategoryActive: true,
+	CategoryWIP:    true,
+	CategoryDone:   true,
+	CategoryFrozen: true,
+}
+
+// CustomStatus represents a user-defined status with its behavioral category.
+type CustomStatus struct {
+	Name     string         `json:"name"`
+	Category StatusCategory `json:"category"`
+}
+
+// statusNameRegexp validates custom status names: letter-first, lowercase alphanumeric with hyphens/underscores.
+var statusNameRegexp = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+
+// maxCustomStatuses is the maximum number of custom statuses allowed.
+const maxCustomStatuses = 50
+
+// builtInStatusNames contains all built-in status names in lowercase for collision detection.
+var builtInStatusNames = map[string]bool{
+	"open": true, "in_progress": true, "blocked": true,
+	"deferred": true, "closed": true, "pinned": true, "hooked": true,
+}
+
+// ParseCustomStatusConfig parses a status.custom config value into typed CustomStatus entries.
+// Supports both legacy flat format ("foo,bar") and category-annotated format ("foo:active,bar:wip").
+// Statuses without a category annotation get CategoryUnspecified (backward compatible).
+func ParseCustomStatusConfig(value string) ([]CustomStatus, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(value, ",")
+	var result []CustomStatus
+	seen := make(map[string]bool)
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		var name string
+		var category StatusCategory
+
+		// Split on first colon only
+		if idx := strings.IndexByte(part, ':'); idx >= 0 {
+			name = part[:idx]
+			catStr := part[idx+1:]
+			if catStr == "" {
+				return nil, fmt.Errorf("invalid custom status %q: trailing colon with empty category", part)
+			}
+			category = StatusCategory(catStr)
+			if !validCategories[category] {
+				return nil, fmt.Errorf("invalid category %q for status %q: must be one of active, wip, done, frozen", catStr, name)
+			}
+		} else {
+			name = part
+			category = CategoryUnspecified
+		}
+
+		if !statusNameRegexp.MatchString(name) {
+			return nil, fmt.Errorf("invalid status name %q: must match [a-z][a-z0-9_-]* (lowercase, letter-first, no spaces)", name)
+		}
+
+		if builtInStatusNames[strings.ToLower(name)] {
+			return nil, fmt.Errorf("custom status %q collides with built-in status", name)
+		}
+
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate custom status name %q", name)
+		}
+		seen[name] = true
+
+		result = append(result, CustomStatus{Name: name, Category: category})
+	}
+
+	if len(result) > maxCustomStatuses {
+		return nil, fmt.Errorf("too many custom statuses (%d): maximum is %d", len(result), maxCustomStatuses)
+	}
+
+	return result, nil
+}
+
+// CustomStatusNames extracts just the name strings from a slice of CustomStatus.
+// Useful for backward-compatible callers that only need names for validation.
+func CustomStatusNames(statuses []CustomStatus) []string {
+	if len(statuses) == 0 {
+		return nil
+	}
+	names := make([]string, len(statuses))
+	for i, s := range statuses {
+		names[i] = s.Name
+	}
+	return names
+}
+
+// CustomStatusesByCategory returns custom statuses filtered by the given category.
+func CustomStatusesByCategory(statuses []CustomStatus, category StatusCategory) []CustomStatus {
+	var result []CustomStatus
+	for _, s := range statuses {
+		if s.Category == category {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// BuiltInStatusCategory returns the category for a built-in status.
+func BuiltInStatusCategory(status Status) StatusCategory {
+	switch status {
+	case StatusOpen:
+		return CategoryActive
+	case StatusInProgress, StatusBlocked, StatusHooked:
+		return CategoryWIP
+	case StatusClosed:
+		return CategoryDone
+	case StatusDeferred, StatusPinned:
+		return CategoryFrozen
+	default:
+		return CategoryUnspecified
+	}
 }
 
 // IssueType categorizes the kind of work

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1082,6 +1084,395 @@ func TestSetDefaults(t *testing.T) {
 			}
 			if issue.IssueType != tt.expectedType {
 				t.Errorf("SetDefaults() IssueType = %v, want %v", issue.IssueType, tt.expectedType)
+			}
+		})
+	}
+}
+
+func TestParseCustomStatusConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []CustomStatus
+		wantErr string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "whitespace only",
+			input: "   ",
+			want:  nil,
+		},
+		{
+			name:  "single flat status (legacy format)",
+			input: "review",
+			want:  []CustomStatus{{Name: "review", Category: CategoryUnspecified}},
+		},
+		{
+			name:  "multiple flat statuses (legacy format)",
+			input: "review,qa,on-hold",
+			want: []CustomStatus{
+				{Name: "review", Category: CategoryUnspecified},
+				{Name: "qa", Category: CategoryUnspecified},
+				{Name: "on-hold", Category: CategoryUnspecified},
+			},
+		},
+		{
+			name:  "single categorized status",
+			input: "review:active",
+			want:  []CustomStatus{{Name: "review", Category: CategoryActive}},
+		},
+		{
+			name:  "all category types",
+			input: "review:active,testing:wip,done-review:done,on-ice:frozen",
+			want: []CustomStatus{
+				{Name: "review", Category: CategoryActive},
+				{Name: "testing", Category: CategoryWIP},
+				{Name: "done-review", Category: CategoryDone},
+				{Name: "on-ice", Category: CategoryFrozen},
+			},
+		},
+		{
+			name:  "mixed legacy and categorized",
+			input: "review,testing:wip,qa",
+			want: []CustomStatus{
+				{Name: "review", Category: CategoryUnspecified},
+				{Name: "testing", Category: CategoryWIP},
+				{Name: "qa", Category: CategoryUnspecified},
+			},
+		},
+		{
+			name:  "whitespace around entries",
+			input: " review:active , testing:wip , qa ",
+			want: []CustomStatus{
+				{Name: "review", Category: CategoryActive},
+				{Name: "testing", Category: CategoryWIP},
+				{Name: "qa", Category: CategoryUnspecified},
+			},
+		},
+		{
+			name:  "trailing comma ignored",
+			input: "review:active,",
+			want:  []CustomStatus{{Name: "review", Category: CategoryActive}},
+		},
+		{
+			name:    "trailing colon with empty category",
+			input:   "review:",
+			wantErr: "trailing colon with empty category",
+		},
+		{
+			name:    "invalid category",
+			input:   "review:invalid",
+			wantErr: "invalid category",
+		},
+		{
+			name:    "uppercase in name",
+			input:   "Review:active",
+			wantErr: "must match",
+		},
+		{
+			name:    "space in name",
+			input:   "my status:active",
+			wantErr: "must match",
+		},
+		{
+			name:    "digit-first name",
+			input:   "1review:active",
+			wantErr: "must match",
+		},
+		{
+			name:    "hyphen-first name",
+			input:   "-review:active",
+			wantErr: "must match",
+		},
+		{
+			name:  "empty name from leading comma",
+			input: ",review:active",
+			want:  []CustomStatus{{Name: "review", Category: CategoryActive}},
+		},
+		{
+			name:    "collision with built-in open",
+			input:   "open:active",
+			wantErr: "collides with built-in",
+		},
+		{
+			name:    "collision with built-in closed",
+			input:   "closed:done",
+			wantErr: "collides with built-in",
+		},
+		{
+			name:    "collision with built-in in_progress",
+			input:   "in_progress:wip",
+			wantErr: "collides with built-in",
+		},
+		{
+			name:    "duplicate name",
+			input:   "review:active,review:wip",
+			wantErr: "duplicate",
+		},
+		{
+			name:  "name with underscores and hyphens",
+			input: "in-review:active,needs_qa:wip",
+			want: []CustomStatus{
+				{Name: "in-review", Category: CategoryActive},
+				{Name: "needs_qa", Category: CategoryWIP},
+			},
+		},
+		{
+			name:  "name with digits after first letter",
+			input: "stage2:active,qa3-check:wip",
+			want: []CustomStatus{
+				{Name: "stage2", Category: CategoryActive},
+				{Name: "qa3-check", Category: CategoryWIP},
+			},
+		},
+		{
+			name:    "colon in category portion (first-colon split)",
+			input:   "review:active:extra",
+			wantErr: "invalid category",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCustomStatusConfig(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d statuses, want %d", len(got), len(tt.want))
+			}
+			for i, g := range got {
+				if g.Name != tt.want[i].Name || g.Category != tt.want[i].Category {
+					t.Errorf("status[%d] = {%q, %q}, want {%q, %q}",
+						i, g.Name, g.Category, tt.want[i].Name, tt.want[i].Category)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCustomStatusConfigMaxLimit(t *testing.T) {
+	// Build a config string with 51 statuses
+	parts := make([]string, 51)
+	for i := range parts {
+		parts[i] = fmt.Sprintf("s%d", i)
+	}
+	input := strings.Join(parts, ",")
+	_, err := ParseCustomStatusConfig(input)
+	if err == nil {
+		t.Fatal("expected error for >50 custom statuses")
+	}
+	if !contains(err.Error(), "too many") {
+		t.Fatalf("expected 'too many' error, got %q", err.Error())
+	}
+}
+
+func TestCustomStatusNames(t *testing.T) {
+	statuses := []CustomStatus{
+		{Name: "review", Category: CategoryActive},
+		{Name: "testing", Category: CategoryWIP},
+	}
+	names := CustomStatusNames(statuses)
+	if len(names) != 2 || names[0] != "review" || names[1] != "testing" {
+		t.Errorf("got %v, want [review testing]", names)
+	}
+
+	// nil input
+	if got := CustomStatusNames(nil); got != nil {
+		t.Errorf("expected nil for nil input, got %v", got)
+	}
+}
+
+func TestCustomStatusesByCategory(t *testing.T) {
+	statuses := []CustomStatus{
+		{Name: "review", Category: CategoryActive},
+		{Name: "testing", Category: CategoryWIP},
+		{Name: "qa", Category: CategoryActive},
+		{Name: "archived", Category: CategoryDone},
+	}
+
+	active := CustomStatusesByCategory(statuses, CategoryActive)
+	if len(active) != 2 || active[0].Name != "review" || active[1].Name != "qa" {
+		t.Errorf("active = %v, want [review, qa]", active)
+	}
+
+	done := CustomStatusesByCategory(statuses, CategoryDone)
+	if len(done) != 1 || done[0].Name != "archived" {
+		t.Errorf("done = %v, want [archived]", done)
+	}
+
+	frozen := CustomStatusesByCategory(statuses, CategoryFrozen)
+	if len(frozen) != 0 {
+		t.Errorf("frozen = %v, want []", frozen)
+	}
+}
+
+func TestBuiltInStatusCategory(t *testing.T) {
+	tests := []struct {
+		status Status
+		want   StatusCategory
+	}{
+		{StatusOpen, CategoryActive},
+		{StatusInProgress, CategoryWIP},
+		{StatusBlocked, CategoryWIP},
+		{StatusHooked, CategoryWIP},
+		{StatusClosed, CategoryDone},
+		{StatusDeferred, CategoryFrozen},
+		{StatusPinned, CategoryFrozen},
+	}
+	for _, tt := range tests {
+		got := BuiltInStatusCategory(tt.status)
+		if got != tt.want {
+			t.Errorf("BuiltInStatusCategory(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestIsValidWithCustomStatuses(t *testing.T) {
+	customs := []CustomStatus{
+		{Name: "review", Category: CategoryActive},
+		{Name: "testing", Category: CategoryWIP},
+	}
+
+	// Built-in status is always valid
+	if !Status("open").IsValidWithCustomStatuses(customs) {
+		t.Error("open should be valid")
+	}
+
+	// Custom status is valid
+	if !Status("review").IsValidWithCustomStatuses(customs) {
+		t.Error("review should be valid")
+	}
+
+	// Unknown status is not valid
+	if Status("unknown").IsValidWithCustomStatuses(customs) {
+		t.Error("unknown should not be valid")
+	}
+}
+
+func TestParseCustomStatusConfigEdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []CustomStatus
+		wantErr string
+	}{
+		{
+			name:    "trailing colon rejected",
+			input:   "review:",
+			wantErr: "trailing colon with empty category",
+		},
+		{
+			name:    "double colon invalid category",
+			input:   "review::active",
+			wantErr: "invalid category",
+		},
+		{
+			name:  "name with numbers v2-review",
+			input: "v2-review:active",
+			want:  []CustomStatus{{Name: "v2-review", Category: CategoryActive}},
+		},
+		{
+			name:    "name starting with digit",
+			input:   "2review:active",
+			wantErr: "must match",
+		},
+		{
+			name:  "very long valid name",
+			input: "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnop:active",
+			want:  []CustomStatus{{Name: "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghijklmnop", Category: CategoryActive}},
+		},
+		{
+			name:    "unicode in name rejected",
+			input:   "über:active",
+			wantErr: "must match",
+		},
+		{
+			name:    "emoji in name rejected",
+			input:   "review🔥:active",
+			wantErr: "must match",
+		},
+		{
+			name:  "single char name",
+			input: "r:active",
+			want:  []CustomStatus{{Name: "r", Category: CategoryActive}},
+		},
+		{
+			name:    "underscore-first name rejected",
+			input:   "_review:active",
+			wantErr: "must match",
+		},
+		{
+			name:  "multiple empty entries filtered",
+			input: ",,review:active,,testing:wip,,",
+			want: []CustomStatus{
+				{Name: "review", Category: CategoryActive},
+				{Name: "testing", Category: CategoryWIP},
+			},
+		},
+		{
+			name:    "category unspecified not user-assignable",
+			input:   "review:unspecified",
+			wantErr: "invalid category",
+		},
+		{
+			name:    "all built-in collisions",
+			input:   "blocked:wip",
+			wantErr: "collides with built-in",
+		},
+		{
+			name:    "hooked built-in collision",
+			input:   "hooked:wip",
+			wantErr: "collides with built-in",
+		},
+		{
+			name:    "deferred built-in collision",
+			input:   "deferred:frozen",
+			wantErr: "collides with built-in",
+		},
+		{
+			name:    "pinned built-in collision",
+			input:   "pinned:frozen",
+			wantErr: "collides with built-in",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCustomStatusConfig(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d statuses, want %d", len(got), len(tt.want))
+			}
+			for i, g := range got {
+				if g.Name != tt.want[i].Name || g.Category != tt.want[i].Category {
+					t.Errorf("status[%d] = {%q, %q}, want {%q, %q}",
+						i, g.Name, g.Category, tt.want[i].Name, tt.want[i].Category)
+				}
 			}
 		})
 	}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func init() {
@@ -214,14 +215,16 @@ const (
 	StatusIconClosed     = "✓" // completed (checkmark)
 	StatusIconDeferred   = "❄" // scheduled for later (snowflake)
 	StatusIconPinned     = "📌" // elevated priority
+	StatusIconCustom     = "◇" // custom/uncategorized status (diamond)
 )
 
 // Priority icon - small filled circle, colored by priority level
 // IMPORTANT: Use this small circle, NOT emoji blobs (🔴🟠🟡🔵⚪)
 const PriorityIcon = "●"
 
-// RenderStatusIcon returns the appropriate icon for a status with semantic coloring
-// This is the canonical source for status icon rendering - use this everywhere
+// RenderStatusIcon returns the appropriate icon for a status with semantic coloring.
+// This is the canonical source for status icon rendering - use this everywhere.
+// For custom statuses, call RenderStatusIconWithCategory for category-aware rendering.
 func RenderStatusIcon(status string) string {
 	switch status {
 	case "open":
@@ -237,7 +240,40 @@ func RenderStatusIcon(status string) string {
 	case "pinned":
 		return StatusPinnedStyle.Render(StatusIconPinned)
 	default:
-		return "?" // unknown status
+		return StatusIconCustom // custom/unknown status
+	}
+}
+
+// RenderStatusIconWithCategory returns the icon for a status, using category
+// to determine icon/color for custom statuses.
+func RenderStatusIconWithCategory(status string, category types.StatusCategory) string {
+	// Try built-in first
+	switch status {
+	case "open":
+		return StatusIconOpen
+	case "in_progress":
+		return StatusInProgressStyle.Render(StatusIconInProgress)
+	case "blocked":
+		return StatusBlockedStyle.Render(StatusIconBlocked)
+	case "closed":
+		return StatusClosedStyle.Render(StatusIconClosed)
+	case "deferred":
+		return MutedStyle.Render(StatusIconDeferred)
+	case "pinned":
+		return StatusPinnedStyle.Render(StatusIconPinned)
+	}
+	// Custom status — inherit from category
+	switch category {
+	case types.CategoryActive:
+		return StatusIconOpen
+	case types.CategoryWIP:
+		return StatusInProgressStyle.Render(StatusIconInProgress)
+	case types.CategoryDone:
+		return StatusClosedStyle.Render(StatusIconClosed)
+	case types.CategoryFrozen:
+		return MutedStyle.Render(StatusIconDeferred)
+	default:
+		return StatusIconCustom
 	}
 }
 
@@ -258,7 +294,37 @@ func GetStatusIcon(status string) string {
 	case "pinned":
 		return StatusIconPinned
 	default:
-		return "?"
+		return StatusIconCustom
+	}
+}
+
+// GetStatusIconWithCategory returns the icon character for a status using category fallback.
+func GetStatusIconWithCategory(status string, category types.StatusCategory) string {
+	switch status {
+	case "open":
+		return StatusIconOpen
+	case "in_progress":
+		return StatusIconInProgress
+	case "blocked":
+		return StatusIconBlocked
+	case "closed":
+		return StatusIconClosed
+	case "deferred":
+		return StatusIconDeferred
+	case "pinned":
+		return StatusIconPinned
+	}
+	switch category {
+	case types.CategoryActive:
+		return StatusIconOpen
+	case types.CategoryWIP:
+		return StatusIconInProgress
+	case types.CategoryDone:
+		return StatusIconClosed
+	case types.CategoryFrozen:
+		return StatusIconDeferred
+	default:
+		return StatusIconCustom
 	}
 }
 

--- a/internal/ui/styles_test.go
+++ b/internal/ui/styles_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func TestRenderBasicStyles(t *testing.T) {
@@ -158,6 +160,149 @@ func TestRenderCommandAndCategoryAreUppercaseSafe(t *testing.T) {
 	cmd := RenderCommand("bd prime")
 	if !strings.Contains(cmd, "bd prime") {
 		t.Fatalf("command output missing text: %q", cmd)
+	}
+}
+
+func TestGetStatusIconWithCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		category types.StatusCategory
+		want     string
+	}{
+		// Built-in statuses always return their own icon regardless of category
+		{"open", "open", "", StatusIconOpen},
+		{"in_progress", "in_progress", "", StatusIconInProgress},
+		{"blocked", "blocked", "", StatusIconBlocked},
+		{"closed", "closed", "", StatusIconClosed},
+		{"deferred", "deferred", "", StatusIconDeferred},
+		{"pinned", "pinned", "", StatusIconPinned},
+		// Custom statuses inherit icon from category
+		{"custom active", "review", types.CategoryActive, StatusIconOpen},
+		{"custom wip", "testing", types.CategoryWIP, StatusIconInProgress},
+		{"custom done", "archived", types.CategoryDone, StatusIconClosed},
+		{"custom frozen", "on-hold", types.CategoryFrozen, StatusIconDeferred},
+		{"custom unspecified", "legacy", types.CategoryUnspecified, StatusIconCustom},
+		{"custom no category", "mystery", "", StatusIconCustom},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetStatusIconWithCategory(tt.status, tt.category)
+			if got != tt.want {
+				t.Errorf("GetStatusIconWithCategory(%q, %q) = %q, want %q",
+					tt.status, tt.category, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderStatusIconBuiltIns(t *testing.T) {
+	// All built-in statuses should return non-empty strings
+	builtIns := []string{"open", "in_progress", "blocked", "closed", "deferred", "pinned"}
+	for _, status := range builtIns {
+		icon := RenderStatusIcon(status)
+		if icon == "" {
+			t.Errorf("RenderStatusIcon(%q) returned empty string", status)
+		}
+	}
+	// Unknown status should get custom icon
+	icon := RenderStatusIcon("totally_unknown")
+	if icon != StatusIconCustom {
+		t.Errorf("RenderStatusIcon(unknown) = %q, want %q", icon, StatusIconCustom)
+	}
+}
+
+func TestGetStatusIconBuiltIns(t *testing.T) {
+	expected := map[string]string{
+		"open":        StatusIconOpen,
+		"in_progress": StatusIconInProgress,
+		"blocked":     StatusIconBlocked,
+		"closed":      StatusIconClosed,
+		"deferred":    StatusIconDeferred,
+		"pinned":      StatusIconPinned,
+	}
+	for status, want := range expected {
+		got := GetStatusIcon(status)
+		if got != want {
+			t.Errorf("GetStatusIcon(%q) = %q, want %q", status, got, want)
+		}
+	}
+	// Unknown gives custom diamond
+	got := GetStatusIcon("unknown_status")
+	if got != StatusIconCustom {
+		t.Errorf("GetStatusIcon(unknown) = %q, want %q", got, StatusIconCustom)
+	}
+}
+
+func TestRenderStatusIconWithCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   string
+		category types.StatusCategory
+	}{
+		// Built-in statuses return non-empty styled strings
+		{"open", "open", ""},
+		{"in_progress", "in_progress", ""},
+		{"blocked", "blocked", ""},
+		{"closed", "closed", ""},
+		{"deferred", "deferred", ""},
+		{"pinned", "pinned", ""},
+		// Custom statuses with categories
+		{"custom active", "review", types.CategoryActive},
+		{"custom wip", "testing", types.CategoryWIP},
+		{"custom done", "archived", types.CategoryDone},
+		{"custom frozen", "on-hold", types.CategoryFrozen},
+		{"custom unspecified", "legacy", types.CategoryUnspecified},
+		{"custom no category", "mystery", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RenderStatusIconWithCategory(tt.status, tt.category)
+			if got == "" {
+				t.Errorf("RenderStatusIconWithCategory(%q, %q) returned empty string",
+					tt.status, tt.category)
+			}
+		})
+	}
+
+	// Category-active custom status should use the same icon as "open"
+	reviewActive := RenderStatusIconWithCategory("review", types.CategoryActive)
+	openIcon := RenderStatusIconWithCategory("open", "")
+	if reviewActive != openIcon {
+		t.Errorf("active custom icon %q != open icon %q", reviewActive, openIcon)
+	}
+
+	// Category-wip custom status should use the same icon as "in_progress"
+	testingWIP := RenderStatusIconWithCategory("testing", types.CategoryWIP)
+	inProgressIcon := RenderStatusIconWithCategory("in_progress", "")
+	if testingWIP != inProgressIcon {
+		t.Errorf("wip custom icon %q != in_progress icon %q", testingWIP, inProgressIcon)
+	}
+
+	// Category-done custom status should use the same icon as "closed"
+	archivedDone := RenderStatusIconWithCategory("archived", types.CategoryDone)
+	closedIcon := RenderStatusIconWithCategory("closed", "")
+	if archivedDone != closedIcon {
+		t.Errorf("done custom icon %q != closed icon %q", archivedDone, closedIcon)
+	}
+
+	// Category-frozen custom status should use the same icon as "deferred"
+	onHoldFrozen := RenderStatusIconWithCategory("on-hold", types.CategoryFrozen)
+	deferredIcon := RenderStatusIconWithCategory("deferred", "")
+	if onHoldFrozen != deferredIcon {
+		t.Errorf("frozen custom icon %q != deferred icon %q", onHoldFrozen, deferredIcon)
+	}
+
+	// Unspecified/unknown category returns StatusIconCustom (unstyled diamond)
+	legacyIcon := RenderStatusIconWithCategory("legacy", types.CategoryUnspecified)
+	if legacyIcon != StatusIconCustom {
+		t.Errorf("unspecified custom icon %q != StatusIconCustom %q", legacyIcon, StatusIconCustom)
+	}
+	noCategory := RenderStatusIconWithCategory("mystery", "")
+	if noCategory != StatusIconCustom {
+		t.Errorf("no-category custom icon %q != StatusIconCustom %q", noCategory, StatusIconCustom)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add category-aware custom statuses that control behavior in `bd ready` and `bd list`, similar to how custom types already work via `types.custom`.

## What changed

**New config format** (backward compatible):
```bash
bd config set status.custom "in_review:active,qa_testing:wip,archived:done,on_hold:frozen"
```

**Categories control behavior:**

| Category | `bd ready` | Default `bd list` | Icon |
|----------|-----------|-------------------|------|
| `active` | ✓ included | ✓ included | ○ |
| `wip` | ✗ excluded | ✓ included | ◐ |
| `done` | ✗ excluded | ✗ excluded | ✓ |
| `frozen` | ✗ excluded | ✗ excluded | ❄ |
| *(none)* | ✗ excluded | ✓ included | ◇ |

**New command:** `bd statuses` lists all built-in and custom statuses with `--json` support.

## Key design decisions

- **Backward compatible**: Old flat format `"foo,bar"` still works with no behavior change
- **Degraded mode**: Malformed config logs a warning, falls back to built-in statuses only (CLI stays operable)
- **Dynamic views**: `ready_issues` and `blocked_issues` SQL views rebuilt on startup and config change
- **Defense-in-depth**: Status names validated by regex at parse time + SQL-escaped at view generation time

## Files changed

- `internal/types/types.go` — CustomStatus struct, StatusCategory, ParseCustomStatusConfig parser
- `internal/storage/dolt/config.go` — GetCustomStatusesDetailed, parseStatusFallback, view rebuild trigger
- `internal/storage/dolt/schema.go` — BuildReadyIssuesView, BuildBlockedIssuesView (dynamic SQL)
- `internal/storage/dolt/store.go` — Cache, readCustomStatusesFromDB, RebuildStatusViews
- `internal/ui/styles.go` — Category-aware icon rendering (RenderStatusIconWithCategory)
- `cmd/bd/statuses.go` — New `bd statuses` command
- `cmd/bd/config.go` — ParseCustomStatusConfig validation before SetConfig
- `cmd/bd/list.go` — Default exclusion of done/frozen custom statuses
- `docs/CLI_REFERENCE.md`, `docs/CONFIG.md` — Documentation
- `integrations/beads-mcp/` — Updated comment in models.py

## Testing

- **80+ test cases** across types, dolt, ui, and config
- `golangci-lint` clean (zero new warnings)
- `go test -race -short` passes on all key packages
- `make test` passes (all 40+ packages)

## Future work

- Tech debt issue filed for migrating to normalized `custom_statuses` table (replacing comma-separated config)