### PR TITLE
fix: disable dolt auto-start when GT_ROOT is set

### DIFF
--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -63,13 +63,14 @@ func NewFromConfigWithOptions(ctx context.Context, beadsDir string, cfg *Config)
 //
 // Priority (highest to lowest):
 //  1. BEADS_TEST_MODE=1                    → always false (tests own the server lifecycle)
-//  2. BEADS_DOLT_AUTO_START=0              → always false (explicit env opt-out)
-//  3. explicitPort == true                 → always false (metadata.json has explicit port;
+//  2. GT_ROOT set                          → always false (Gas Town daemon manages the server)
+//  3. BEADS_DOLT_AUTO_START=0              → always false (explicit env opt-out)
+//  4. explicitPort == true                 → always false (metadata.json has explicit port;
 //     auto-starting a different server would create shadow databases)
-//  4. current == true                      → true  (caller option wins over config file,
+//  5. current == true                      → true  (caller option wins over config file,
 //     per NewFromConfigWithOptions contract)
-//  5. doltAutoStartCfg == "false"/"0"/"off" → false (config.yaml opt-out)
-//  6. default                              → true  (standalone user; safe default)
+//  6. doltAutoStartCfg == "false"/"0"/"off" → false (config.yaml opt-out)
+//  7. default                              → true  (standalone user; safe default)
 //
 // doltAutoStartCfg is the raw value of the "dolt.auto-start" key from config.yaml
 // (pass config.GetString("dolt.auto-start") at the call site).
@@ -80,6 +81,12 @@ func NewFromConfigWithOptions(ctx context.Context, beadsDir string, cfg *Config)
 // config-file overrides above.
 func resolveAutoStart(current bool, doltAutoStartCfg string, explicitPort bool) bool {
 	if os.Getenv("BEADS_TEST_MODE") == "1" {
+		return false
+	}
+	// Gas Town manages its own Dolt server via the daemon. Agents must not
+	// auto-start their own servers — that creates orphaned processes on
+	// derived ports (e.g. boot triage spawning servers on port 13852).
+	if os.Getenv("GT_ROOT") != "" {
 		return false
 	}
 	if os.Getenv("BEADS_DOLT_AUTO_START") == "0" {

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -16,6 +16,7 @@ func TestResolveAutoStart(t *testing.T) {
 	tests := []struct {
 		name             string
 		testMode         string // BEADS_TEST_MODE to set; "" leaves it unset/empty
+		gtRoot           string // GT_ROOT to set; "" leaves it unset/empty
 		autoStartEnv     string // BEADS_DOLT_AUTO_START to set; "" leaves it unset/empty
 		doltAutoStartCfg string // raw value of "dolt.auto-start" from config.yaml
 		currentValue     bool   // AutoStart value supplied by caller
@@ -28,6 +29,17 @@ func TestResolveAutoStart(t *testing.T) {
 		{
 			name:          "disabled when BEADS_TEST_MODE=1",
 			testMode:      "1",
+			wantAutoStart: false,
+		},
+		{
+			name:          "disabled under Gas Town (GT_ROOT set)",
+			gtRoot:        "/home/dan/gt",
+			wantAutoStart: false,
+		},
+		{
+			name:          "GT_ROOT wins over caller true",
+			gtRoot:        "/home/dan/gt",
+			currentValue:  true,
 			wantAutoStart: false,
 		},
 		{
@@ -90,6 +102,7 @@ func TestResolveAutoStart(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("BEADS_TEST_MODE", tc.testMode)
+			t.Setenv("GT_ROOT", tc.gtRoot)
 			t.Setenv("BEADS_DOLT_AUTO_START", tc.autoStartEnv)
 
 			got := resolveAutoStart(tc.currentValue, tc.doltAutoStartCfg, false)


### PR DESCRIPTION
## Summary

`resolveAutoStart()` has a comment claiming auto-start is "Disabled under Gas Town (GT_ROOT set)" but the `GT_ROOT` check was never implemented. This causes Gas Town agents (boot triage, witnesses, etc.) to spawn orphaned dolt servers on derived ports (13307–14306 range) that outlive their sessions.

The fix adds the missing `GT_ROOT` environment variable check to `resolveAutoStart()`, at priority 2 (after `BEADS_TEST_MODE`, before `BEADS_DOLT_AUTO_START`). When `GT_ROOT` is set, auto-start is unconditionally disabled — Gas Town manages its own shared Dolt server via its daemon.

**No impact on standalone Beads users** — `GT_ROOT` is only set inside Gas Town environments.

## Changes

- `internal/storage/dolt/open.go`: Add `GT_ROOT` check to `resolveAutoStart()`, update priority docs
- `internal/storage/dolt/open_test.go`: Add `gtRoot` field to test struct, 2 new test cases ("disabled under Gas Town", "GT_ROOT wins over caller true"), wire `GT_ROOT` into `t.Setenv`

## Root cause

When a Gas Town agent initializes beads storage and the shared server on port 3307 is momentarily unreachable:

1. `DoltStore.New()` → `newServerMode()` → `doltserver.EnsureRunning(beadsDir)`
2. `EnsureRunning` calls `Start()`, which spawns `dolt sql-server` on a `DerivePort()` hash (13307–14306)
3. The server is detached via `cmd.Process.Release()` so it survives the parent
4. When the agent session dies, the orphaned server runs forever

## Related issues

| Issue | Relevance |
|-------|-----------|
| **#2542** — "Beads runs many dolt sql-servers" | Direct match. Showed 11+ orphaned test servers + 4 on derived ports. Closed with refcounting fix for `DoltStore.Close()`, but that doesn't prevent auto-start under Gas Town. |
| **#2636** — "bd doctor infinite restart loop with zombie dolt processes" | Related. Start-use-stop lifecycle regression from the #2542 fix creates similar zombie accumulation. |
| **#2641** — "server lifecycle incompatible with externally-managed dolt" | Related theme. `KillStaleServers` kills systemd-managed servers — Beads assuming it owns the server lifecycle. |
| **#2598** — "Fresh standalone init can fail on shared port-0 circuit breaker" | Tangentially related auto-start edge case on cold start. |

## Test plan

- [x] All 14 `TestResolveAutoStart` subtests pass (including 2 new GT_ROOT cases)
- [x] Existing `TestAutoStart_DisabledWithExplicitPort` and `TestAutoStart_ExplicitPort_CallerOverrideIgnored` unaffected (they clear GT_ROOT)
- [ ] Verify no orphaned dolt processes accumulate during Gas Town boot triage cycles
- [ ] Verify standalone `bd` (no GT_ROOT) still auto-starts correctly

Prepared with Claude Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)