### PR TITLE
fix: serialize schema init with GET_LOCK to prevent Dolt journal corruption

### DIFF
--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -66,7 +66,7 @@ func newHaikuClient(apiKey string) (*haikuClient, error) {
 
 	return &haikuClient{
 		client:         client,
-		model:          anthropic.Model(config.DefaultAIModel()),
+		model:          config.DefaultAIModel(),
 		tier1Template:  tier1Tmpl,
 		maxRetries:     maxRetries,
 		initialBackoff: initialBackoff,
@@ -87,7 +87,7 @@ func (h *haikuClient) SummarizeTier1(ctx context.Context, issue *types.Issue) (s
 			Kind:     "llm_call",
 			Actor:    h.auditActor,
 			IssueID:  issue.ID,
-			Model:    string(h.model),
+			Model:    h.model,
 			Prompt:   prompt,
 			Response: resp,
 		}
@@ -129,7 +129,7 @@ func (h *haikuClient) callWithRetry(ctx context.Context, prompt string) (string,
 	ctx, span := tracer.Start(ctx, "anthropic.messages.new")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("bd.ai.model", string(h.model)),
+		attribute.String("bd.ai.model", h.model),
 		attribute.String("bd.ai.operation", "compact"),
 	)
 


### PR DESCRIPTION
## Summary
- Use MySQL `GET_LOCK`/`RELEASE_LOCK` to serialize `initSchema()` in server mode
- Double-checked locking: re-check `schema_version` after acquiring lock so only one process runs DDL
- Prevents Dolt journal corruption when multiple `bd` processes hit a fresh database concurrently

## Root Cause
`initSchemaOnDB()` had no distributed lock in server mode. When N concurrent `bd` processes connect to a fresh database, all N run ~20+ DDL statements simultaneously, corrupting Dolt's journal (CRC checksum mismatch, invalid record lengths).

The embedded mode already had `acquireBootstrapLock()` (flock-based), but server mode relied solely on `CREATE TABLE IF NOT EXISTS` idempotency — insufficient under high concurrency.

## Reproduction
```bash
# Fresh beads DB on Dolt server, then:
for i in $(seq 1 30); do
  bd create "stress $i" --rig beads &
  bd list --limit=1 --flat &
done; wait
# Before fix: "corrupted journal" every time
# After fix: HEALTHY every time
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/storage/dolt/ -short` passes
- [x] Manual stress test: 30 concurrent writes + 30 reads on fresh DB — HEALTHY (2/2 runs)
- [x] Same stress test without fix corrupts DB reliably

Fixes #2672

🤖 Generated with [Claude Code](https://claude.com/claude-code)