### PR TITLE
fix: don't kill externally-managed dolt servers

### DIFF
--- a/cmd/bd/find_duplicates.go
+++ b/cmd/bd/find_duplicates.go
@@ -379,7 +379,7 @@ func findAIDuplicates(ctx context.Context, issues []*types.Issue, threshold floa
 		}
 		batch := candidates[i:end]
 
-		results := analyzeWithAI(ctx, client, anthropic.Model(model), batch)
+		results := analyzeWithAI(ctx, client, model, batch)
 		for _, r := range results {
 			if r.Similarity >= threshold {
 				pairs = append(pairs, r)
@@ -431,7 +431,7 @@ func analyzeWithAI(ctx context.Context, client anthropic.Client, model anthropic
 	tracer := telemetry.Tracer("github.com/steveyegge/beads/ai")
 	aiCtx, aiSpan := tracer.Start(ctx, "anthropic.messages.new")
 	aiSpan.SetAttributes(
-		attribute.String("bd.ai.model", string(model)),
+		attribute.String("bd.ai.model", model),
 		attribute.String("bd.ai.operation", "find_duplicates"),
 		attribute.Int("bd.ai.batch_size", len(candidates)),
 	)

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -66,7 +66,7 @@ func newHaikuClient(apiKey string) (*haikuClient, error) {
 
 	return &haikuClient{
 		client:         client,
-		model:          anthropic.Model(config.DefaultAIModel()),
+		model:          config.DefaultAIModel(),
 		tier1Template:  tier1Tmpl,
 		maxRetries:     maxRetries,
 		initialBackoff: initialBackoff,
@@ -87,7 +87,7 @@ func (h *haikuClient) SummarizeTier1(ctx context.Context, issue *types.Issue) (s
 			Kind:     "llm_call",
 			Actor:    h.auditActor,
 			IssueID:  issue.ID,
-			Model:    string(h.model),
+			Model:    h.model,
 			Prompt:   prompt,
 			Response: resp,
 		}
@@ -129,7 +129,7 @@ func (h *haikuClient) callWithRetry(ctx context.Context, prompt string) (string,
 	ctx, span := tracer.Start(ctx, "anthropic.messages.new")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("bd.ai.model", string(h.model)),
+		attribute.String("bd.ai.model", h.model),
 		attribute.String("bd.ai.operation", "compact"),
 	)
 
@@ -158,7 +158,7 @@ func (h *haikuClient) callWithRetry(ctx context.Context, prompt string) (string,
 
 		if err == nil {
 			// Record token usage and latency.
-			modelAttr := attribute.String("bd.ai.model", string(h.model))
+			modelAttr := attribute.String("bd.ai.model", h.model)
 			if aiMetrics.inputTokens != nil {
 				aiMetrics.inputTokens.Add(ctx, message.Usage.InputTokens, metric.WithAttributes(modelAttr))
 				aiMetrics.outputTokens.Add(ctx, message.Usage.OutputTokens, metric.WithAttributes(modelAttr))

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -57,6 +57,23 @@ func IsSharedServerMode() bool {
 	return config.GetBool("dolt.shared-server")
 }
 
+// IsAutoStartDisabled returns true if the dolt server should NOT be
+// auto-started or managed by bd. When true, KillStaleServers and
+// auto-start are suppressed — the server is externally managed (e.g.,
+// by systemd). Checks (in priority order):
+//  1. BEADS_DOLT_AUTO_START=0 env var → always disabled
+//  2. dolt.auto-start config value "false"/"0"/"off" → disabled
+//
+// This is used by KillStaleServers and Start to avoid killing or
+// interfering with externally-managed dolt processes (GH#2641).
+func IsAutoStartDisabled() bool {
+	if os.Getenv("BEADS_DOLT_AUTO_START") == "0" {
+		return true
+	}
+	v := config.GetString("dolt.auto-start")
+	return v == "false" || v == "0" || v == "off"
+}
+
 // SharedServerDir returns the directory for shared server state files.
 // Returns ~/.beads/shared-server/ (created on first use).
 func SharedServerDir() (string, error) {
@@ -468,14 +485,16 @@ func EnsureRunningDetailed(beadsDir string) (port int, startedByUs bool, err err
 	}
 
 	// Check whether the server is externally managed before starting.
-	// If metadata.json has an explicit dolt_server_port, the user has
-	// configured a shared/external server (e.g. systemd-managed). Do not
-	// start a per-project server — it would conflict with the external one.
-	if hasExplicitPort(beadsDir) {
+	// Auto-start is suppressed when:
+	//   1. BEADS_DOLT_AUTO_START=0 or dolt.auto-start: false (GH#2641)
+	//   2. metadata.json has an explicit dolt_server_port (GH#2554)
+	// In both cases, the dolt server is externally managed (e.g., systemd).
+	// Do not start a per-project server — it would conflict with the external one.
+	if IsAutoStartDisabled() || hasExplicitPort(beadsDir) {
 		cfg := DefaultConfig(beadsDir)
 		return 0, false, fmt.Errorf("Dolt server is not running on port %d, and auto-start is suppressed "+
-			"because an explicit server port is configured (external/shared server).\n\n"+
-			"Start the external server, or remove the explicit port configuration to allow auto-start.\n"+
+			"because the server is externally managed (dolt.auto-start: false or explicit port configured).\n\n"+
+			"Start the external server, or enable auto-start to allow bd to manage the server.\n"+
 			"  To start manually: bd dolt start\n"+
 			"  To check status: bd dolt status", cfg.Port)
 	}
@@ -857,7 +876,14 @@ func killStaleServersForDir(beadsDir string, allPIDs []int, inDir func(int, stri
 // KillStaleServers finds and kills orphan dolt sql-server processes for the
 // current repo's Dolt data directory that are not tracked by the canonical PID
 // file. Returns the PIDs of killed processes.
+//
+// When auto-start is disabled (BEADS_DOLT_AUTO_START=0 or dolt.auto-start:
+// false), this function is a no-op — the dolt server is externally managed
+// and must not be killed by bd (GH#2641).
 func KillStaleServers(beadsDir string) ([]int, error) {
+	if IsAutoStartDisabled() {
+		return nil, nil
+	}
 	allPIDs := listDoltProcessPIDs()
 	return killStaleServersForDir(
 		beadsDir,

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1018,3 +1018,96 @@ func TestDefaultConfig_SharedModeBeadsDir(t *testing.T) {
 		t.Errorf("DefaultConfig.BeadsDir = %q, want %q", cfg.BeadsDir, expected)
 	}
 }
+
+// --- External server lifecycle tests (GH#2641) ---
+
+func TestIsAutoStartDisabled_Default(t *testing.T) {
+	t.Setenv("BEADS_DOLT_AUTO_START", "")
+	config.ResetForTesting()
+	if IsAutoStartDisabled() {
+		t.Error("expected auto-start to be enabled by default")
+	}
+}
+
+func TestIsAutoStartDisabled_EnvVar0(t *testing.T) {
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	if !IsAutoStartDisabled() {
+		t.Error("expected auto-start to be disabled when BEADS_DOLT_AUTO_START=0")
+	}
+}
+
+func TestIsAutoStartDisabled_EnvVar1(t *testing.T) {
+	t.Setenv("BEADS_DOLT_AUTO_START", "1")
+	config.ResetForTesting()
+	if IsAutoStartDisabled() {
+		t.Error("expected auto-start to be enabled when BEADS_DOLT_AUTO_START=1")
+	}
+}
+
+func TestIsAutoStartDisabled_ConfigFalse(t *testing.T) {
+	t.Setenv("BEADS_DOLT_AUTO_START", "")
+	// Set up a config.yaml with dolt.auto-start: false
+	configDir := t.TempDir()
+	configYaml := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configYaml, []byte("dolt:\n  auto-start: \"false\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", configDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	t.Cleanup(config.ResetForTesting)
+
+	if !IsAutoStartDisabled() {
+		t.Error("expected auto-start to be disabled when config has dolt.auto-start: false")
+	}
+}
+
+func TestKillStaleServers_SkippedWhenAutoStartDisabled(t *testing.T) {
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	dir := t.TempDir()
+
+	// Even if there were dolt processes, KillStaleServers should be a no-op
+	killed, err := KillStaleServers(dir)
+	if err != nil {
+		t.Fatalf("KillStaleServers error: %v", err)
+	}
+	if len(killed) != 0 {
+		t.Errorf("expected no kills when auto-start disabled, got %v", killed)
+	}
+}
+
+func TestKillStaleServersForDir_SkippedWhenAutoStartDisabled(t *testing.T) {
+	// Verify that even with dolt processes present, KillStaleServers returns
+	// nil when auto-start is disabled (externally-managed server).
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	dir := t.TempDir()
+
+	// Write a PID file to simulate a tracked server
+	if err := os.WriteFile(pidPath(dir), []byte("12345"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	killed, err := KillStaleServers(dir)
+	if err != nil {
+		t.Fatalf("KillStaleServers error: %v", err)
+	}
+	if len(killed) != 0 {
+		t.Errorf("expected no kills when auto-start disabled, got %v", killed)
+	}
+}
+
+func TestEnsureRunningDetailed_ExternalServer_AutoStartDisabled(t *testing.T) {
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "13579")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	dir := t.TempDir()
+	_, _, err := EnsureRunningDetailed(dir)
+	if err == nil {
+		t.Fatal("expected error when auto-start is disabled and no server running")
+	}
+	if !strings.Contains(err.Error(), "externally managed") {
+		t.Errorf("error should mention externally managed server, got: %v", err)
+	}
+}

--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -90,8 +90,12 @@ func (s *DoltStore) initCredentialKey(ctx context.Context) error {
 		return fmt.Errorf("failed to migrate credential keys: %w", err)
 	}
 
-	// Write key file with owner-only permissions (0600)
-	// beadsDir (.beads/) always exists — no MkdirAll needed
+	// Write key file with owner-only permissions (0600).
+	// Ensure the directory exists first — when connecting to an external
+	// server without having run `bd init`, .beads/ may not exist yet (GH#2641).
+	if err := os.MkdirAll(s.beadsDir, 0750); err != nil {
+		return fmt.Errorf("failed to create beads directory %s: %w", s.beadsDir, err)
+	}
 	if err := os.WriteFile(keyPath, key, 0600); err != nil {
 		return fmt.Errorf("failed to write credential key file: %w", err)
 	}

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -265,6 +265,39 @@ func TestCredentialKeyNoGhostDir(t *testing.T) {
 	}
 }
 
+// TestCredentialKeyCreatesBeadsDir verifies that initCredentialKey creates the
+// .beads/ directory if it doesn't exist. This is needed for external server
+// setups where bd connects to a pre-existing dolt server without bd init (GH#2641).
+func TestCredentialKeyCreatesBeadsDir(t *testing.T) {
+	parentDir := t.TempDir()
+	beadsDir := filepath.Join(parentDir, ".beads") // does not exist yet
+
+	store := &DoltStore{dbPath: "", beadsDir: beadsDir}
+	if err := store.initCredentialKey(t.Context()); err != nil {
+		t.Fatalf("initCredentialKey failed when beadsDir doesn't exist: %v", err)
+	}
+
+	// Key should be generated
+	if len(store.credentialKey) != 32 {
+		t.Fatalf("credentialKey length = %d, want 32", len(store.credentialKey))
+	}
+
+	// .beads/ directory should have been created
+	info, err := os.Stat(beadsDir)
+	if err != nil {
+		t.Fatalf(".beads/ directory should have been created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal(".beads/ should be a directory")
+	}
+
+	// Key file should exist in the newly created directory
+	keyPath := filepath.Join(beadsDir, credentialKeyFile)
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key file should exist in newly created .beads/: %v", err)
+	}
+}
+
 // setupCredentialTestStore creates a DoltStore with a dolt-initialized CLI directory
 // and "origin" remote for credential routing tests. Requires dolt CLI.
 func setupCredentialTestStore(t *testing.T, remoteUser, remotePassword string, serverMode, setupRemote bool) *DoltStore {


### PR DESCRIPTION
## Summary
- `KillStaleServers` becomes a no-op when `BEADS_DOLT_AUTO_START=0` or `dolt.auto-start: false`
- `EnsureRunning` refuses to start when auto-start is disabled, with clear "externally managed" error
- `initCredentialKey` creates `.beads/` directory if needed (fixes credential-key chicken-and-egg)

## Changes
- **`internal/doltserver/doltserver.go`**: Added `IsAutoStartDisabled()`, guarded `KillStaleServers` and `EnsureRunningDetailed`
- **`internal/doltserver/doltserver_test.go`**: 7 new tests
- **`internal/storage/dolt/credentials.go`**: Added `os.MkdirAll` before credential key write
- **`internal/storage/dolt/credentials_test.go`**: Test for directory creation

## How it works
Set `BEADS_DOLT_AUTO_START=0` before `bd init` → KillStaleServers is no-op, EnsureRunning skips auto-start. Credential key now creates `.beads/` dir if missing.

## Test plan
- [x] All new tests pass
- [x] Build compiles cleanly

Fixes #2641

🤖 Generated with [Claude Code](https://claude.com/claude-code)