### PR TITLE
fix: remove unnecessary type conversions (unconvert lint)

### DIFF
--- a/cmd/bd/find_duplicates.go
+++ b/cmd/bd/find_duplicates.go
@@ -379,7 +379,7 @@ func findAIDuplicates(ctx context.Context, issues []*types.Issue, threshold floa
 		}
 		batch := candidates[i:end]
 
-		results := analyzeWithAI(ctx, client, anthropic.Model(model), batch)
+		results := analyzeWithAI(ctx, client, model, batch)
 		for _, r := range results {
 			if r.Similarity >= threshold {
 				pairs = append(pairs, r)
@@ -431,7 +431,7 @@ func analyzeWithAI(ctx context.Context, client anthropic.Client, model anthropic
 	tracer := telemetry.Tracer("github.com/steveyegge/beads/ai")
 	aiCtx, aiSpan := tracer.Start(ctx, "anthropic.messages.new")
 	aiSpan.SetAttributes(
-		attribute.String("bd.ai.model", string(model)),
+		attribute.String("bd.ai.model", model),
 		attribute.String("bd.ai.operation", "find_duplicates"),
 		attribute.Int("bd.ai.batch_size", len(candidates)),
 	)

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -66,7 +66,7 @@ func newHaikuClient(apiKey string) (*haikuClient, error) {
 
 	return &haikuClient{
 		client:         client,
-		model:          anthropic.Model(config.DefaultAIModel()),
+		model:          config.DefaultAIModel(),
 		tier1Template:  tier1Tmpl,
 		maxRetries:     maxRetries,
 		initialBackoff: initialBackoff,
@@ -87,7 +87,7 @@ func (h *haikuClient) SummarizeTier1(ctx context.Context, issue *types.Issue) (s
 			Kind:     "llm_call",
 			Actor:    h.auditActor,
 			IssueID:  issue.ID,
-			Model:    string(h.model),
+			Model:    h.model,
 			Prompt:   prompt,
 			Response: resp,
 		}
@@ -129,7 +129,7 @@ func (h *haikuClient) callWithRetry(ctx context.Context, prompt string) (string,
 	ctx, span := tracer.Start(ctx, "anthropic.messages.new")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("bd.ai.model", string(h.model)),
+		attribute.String("bd.ai.model", h.model),
 		attribute.String("bd.ai.operation", "compact"),
 	)
 
@@ -158,7 +158,7 @@ func (h *haikuClient) callWithRetry(ctx context.Context, prompt string) (string,
 
 		if err == nil {
 			// Record token usage and latency.
-			modelAttr := attribute.String("bd.ai.model", string(h.model))
+			modelAttr := attribute.String("bd.ai.model", h.model)
 			if aiMetrics.inputTokens != nil {
 				aiMetrics.inputTokens.Add(ctx, message.Usage.InputTokens, metric.WithAttributes(modelAttr))
 				aiMetrics.outputTokens.Add(ctx, message.Usage.OutputTokens, metric.WithAttributes(modelAttr))


### PR DESCRIPTION
## Summary
- Remove unnecessary `anthropic.Model()` and `string()` type conversions flagged by golangci-lint `unconvert`
- `anthropic.Model` is a type alias (`type Model = string`), making these conversions no-ops

## Changes
- **`internal/compact/haiku.go`**: 3 unnecessary conversions removed (lines 69, 90, 132)
- **`cmd/bd/find_duplicates.go`**: 2 unnecessary conversions removed (lines 382, 434)

## Test plan
- [x] `go build ./...` passes
- [x] golangci-lint unconvert: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)