### PR TITLE
fix: serialize concurrent initSchemaOnDB with GET_LOCK to prevent journal corruption (#2672)

### DIFF
--- a/internal/storage/dolt/initschema_concurrent_test.go
+++ b/internal/storage/dolt/initschema_concurrent_test.go
@@ -1,0 +1,122 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// TestConcurrentInitSchema verifies that concurrent initSchemaOnDB calls on a
+// fresh database do not corrupt the Dolt journal. Without the GET_LOCK advisory
+// lock, 20+ concurrent processes running DDL simultaneously on a fresh DB
+// reliably produce CRC/journal corruption (see GH#2672).
+func TestConcurrentInitSchema(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Create a fresh database that has never been initialized.
+	dbName := uniqueTestDBName(t)
+	initDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/", testServerPort)
+	initDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("open init connection: %v", err)
+	}
+	defer initDB.Close()
+
+	if _, err := initDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	t.Cleanup(func() {
+		// Skip DROP — rapid create/drop cycles can crash the Dolt container.
+		// The orphan is cleaned up when the container terminates.
+	})
+
+	// Open N independent sql.DB pools pointing at the fresh database.
+	// Each simulates a separate bd process connecting simultaneously.
+	const numConcurrent = 20
+	dsn := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true", testServerPort, dbName)
+
+	tmpDir, err := os.MkdirTemp("", "dolt-concurrent-init-*")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	var wg sync.WaitGroup
+	errs := make(chan error, numConcurrent)
+
+	// All goroutines are created before any of them open their connection, to
+	// maximize the chance they all arrive at initSchemaOnDB simultaneously.
+	ready := make(chan struct{})
+	for i := 0; i < numConcurrent; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+
+			db, err := sql.Open("mysql", dsn)
+			if err != nil {
+				errs <- fmt.Errorf("goroutine %d: open: %w", n, err)
+				return
+			}
+			defer db.Close()
+			db.SetMaxOpenConns(2)
+
+			<-ready // wait for all goroutines to be ready
+
+			if err := initSchemaOnDB(ctx, db); err != nil {
+				errs <- fmt.Errorf("goroutine %d: initSchemaOnDB: %w", n, err)
+			}
+		}(i)
+	}
+
+	// Release all goroutines simultaneously to maximize contention.
+	close(ready)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent init error: %v", err)
+	}
+
+	// Verify the schema was correctly initialized: check schema_version and
+	// a representative set of tables.
+	verifyDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open verify connection: %v", err)
+	}
+	defer verifyDB.Close()
+
+	var version int
+	if err := verifyDB.QueryRowContext(ctx, "SELECT `value` FROM config WHERE `key` = 'schema_version'").Scan(&version); err != nil {
+		t.Fatalf("schema_version not found after concurrent init: %v", err)
+	}
+	if version != currentSchemaVersion {
+		t.Errorf("schema_version = %d, want %d", version, currentSchemaVersion)
+	}
+
+	for _, table := range []string{"issues", "dependencies", "config", "comments"} {
+		var count int
+		query := fmt.Sprintf("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '%s' AND table_name = '%s'", dbName, table)
+		if err := verifyDB.QueryRowContext(ctx, query).Scan(&count); err != nil {
+			t.Errorf("checking table %s: %v", table, err)
+			continue
+		}
+		if count == 0 {
+			t.Errorf("table %s missing after concurrent init", table)
+		}
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1083,6 +1083,33 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		return createIgnoredTables(db)
 	}
 
+	// Acquire an advisory lock to serialize schema initialization across concurrent processes.
+	// On a fresh database, all processes fail the fast path and race to execute ~20 DDL
+	// statements simultaneously, corrupting the Dolt journal. GET_LOCK serializes entry
+	// to the slow path. The lock is connection-scoped: we hold a dedicated connection so
+	// the lock persists across the DDL sequence and is released on conn.Close().
+	const schemaInitLock = "bd_schema_init"
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection for schema init lock: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck
+
+	var locked int
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 30)", schemaInitLock).Scan(&locked); err != nil {
+		return fmt.Errorf("failed to acquire schema init lock: %w", err)
+	}
+	if locked != 1 {
+		return fmt.Errorf("failed to acquire schema init lock: timeout after 30s (another process holds it)")
+	}
+	defer conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", schemaInitLock) //nolint:errcheck
+
+	// Double-check: another process may have completed initialization while we waited.
+	var versionAfterLock int
+	if err := conn.QueryRowContext(ctx, "SELECT `value` FROM config WHERE `key` = 'schema_version'").Scan(&versionAfterLock); err == nil && versionAfterLock >= currentSchemaVersion {
+		return createIgnoredTables(db)
+	}
+
 	// Execute schema creation - split into individual statements
 	// because MySQL/Dolt doesn't support multiple statements in one Exec
 	for _, stmt := range splitStatements(schema) {


### PR DESCRIPTION
## Summary

On a fresh Dolt database, all concurrent `bd` processes fail the schema-version fast path and race to execute ~20 DDL statements simultaneously. This causes CRC/journal corruption when 20+ processes hit the DDL path at once — reliably reproducible with the 30-process stress script in #2672.

**Root cause**: `initSchemaOnDB` had no distributed lock for the server-mode DDL path. The embedded mode has `acquireBootstrapLock()` (flock-based), but server mode relied only on `CREATE TABLE IF NOT EXISTS` idempotency — insufficient when 30 processes execute the full DDL migration path simultaneously on a fresh DB.

## Fix

Acquire a session-scoped advisory lock (`GET_LOCK('bd_schema_init', 30)`) on a dedicated connection before running DDL. Double-checked locking pattern: re-check `schema_version` after acquiring the lock so processes that waited skip DDL if another process already initialized.

The lock is connection-scoped: automatically released when the connection closes, so no cleanup needed on crash.

```go
// Dedicated connection holds the advisory lock for the duration of DDL.
conn, err := db.Conn(ctx)
// ...
var locked int
conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 30)", "bd_schema_init").Scan(&locked)
defer conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", "bd_schema_init")

// Double-check after acquiring lock
if versionAfterLock >= currentSchemaVersion {
    return createIgnoredTables(db) // another process already initialized
}
// ... run DDL
```

## Test

`TestConcurrentInitSchema`: 20 goroutines call `initSchemaOnDB` simultaneously on a fresh database. Verifies `schema_version` is set correctly and all expected tables are present after completion.

## Test plan
- [x] `go build ./internal/storage/dolt/...` — clean
- [x] `go vet ./internal/storage/dolt/...` — clean
- [ ] `TestConcurrentInitSchema` passes with Dolt container
- [ ] Existing schema tests pass

Fixes #2672

🤖 Generated with [Claude Code](https://claude.com/claude-code)