### PR TITLE
fix: load .beads/.env before noDbCommands early return (GH#2677)

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -62,6 +62,9 @@ dolt-server.port
 # Backup data (auto-exported JSONL, local-only)
 backup/
 
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
 # Legacy files (from pre-Dolt versions)
 *.db
 *.db?*
@@ -89,6 +92,7 @@ const projectGitignoreComment = "# Dolt database files (added by bd init)"
 // requiredPatterns are patterns that MUST be in .beads/.gitignore
 var requiredPatterns = []string{
 	"*.db?*",
+	".env",
 	"redirect",
 	"last-touched",
 	"bd.sock.startlock",

--- a/cmd/bd/envfile_test.go
+++ b/cmd/bd/envfile_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadBeadsEnvFile(t *testing.T) {
+	t.Run("loads env vars from .env file", func(t *testing.T) {
+		dir := t.TempDir()
+		envFile := filepath.Join(dir, ".env")
+		if err := os.WriteFile(envFile, []byte("BEADS_TEST_LOAD_VAR=hello_from_env\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BEADS_TEST_LOAD_VAR", "") // clear
+		os.Unsetenv("BEADS_TEST_LOAD_VAR")
+
+		loadBeadsEnvFile(dir)
+
+		if got := os.Getenv("BEADS_TEST_LOAD_VAR"); got != "hello_from_env" {
+			t.Errorf("expected BEADS_TEST_LOAD_VAR=hello_from_env, got %q", got)
+		}
+	})
+
+	t.Run("shell env takes precedence over .env", func(t *testing.T) {
+		dir := t.TempDir()
+		envFile := filepath.Join(dir, ".env")
+		if err := os.WriteFile(envFile, []byte("BEADS_TEST_PRECEDENCE=from_file\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BEADS_TEST_PRECEDENCE", "from_shell")
+
+		loadBeadsEnvFile(dir)
+
+		if got := os.Getenv("BEADS_TEST_PRECEDENCE"); got != "from_shell" {
+			t.Errorf("expected shell env to win, got %q", got)
+		}
+	})
+
+	t.Run("no-op when .env does not exist", func(t *testing.T) {
+		dir := t.TempDir()
+		// Should not panic or error
+		loadBeadsEnvFile(dir)
+	})
+}

--- a/cmd/bd/find_duplicates.go
+++ b/cmd/bd/find_duplicates.go
@@ -379,7 +379,7 @@ func findAIDuplicates(ctx context.Context, issues []*types.Issue, threshold floa
 		}
 		batch := candidates[i:end]
 
-		results := analyzeWithAI(ctx, client, anthropic.Model(model), batch)
+		results := analyzeWithAI(ctx, client, model, batch)
 		for _, r := range results {
 			if r.Similarity >= threshold {
 				pairs = append(pairs, r)
@@ -431,7 +431,7 @@ func analyzeWithAI(ctx context.Context, client anthropic.Client, model anthropic
 	tracer := telemetry.Tracer("github.com/steveyegge/beads/ai")
 	aiCtx, aiSpan := tracer.Start(ctx, "anthropic.messages.new")
 	aiSpan.SetAttributes(
-		attribute.String("bd.ai.model", string(model)),
+		attribute.String("bd.ai.model", model),
 		attribute.String("bd.ai.operation", "find_duplicates"),
 		attribute.Int("bd.ai.batch_size", len(candidates)),
 	)

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/subosito/gotenv"
+
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -115,6 +117,17 @@ var readOnlyCommands = map[string]bool{
 // that would trigger file watchers. See GH#804.
 func isReadOnlyCommand(cmdName string) bool {
 	return readOnlyCommands[cmdName]
+}
+
+// loadBeadsEnvFile loads .beads/.env into process environment for per-project
+// Dolt credentials (GH#2520). Uses gotenv.Load which is non-overriding —
+// existing shell env vars always take precedence.
+func loadBeadsEnvFile(beadsDir string) {
+	envFile := filepath.Join(beadsDir, ".env")
+	if _, err := os.Stat(envFile); err != nil {
+		return
+	}
+	_ = gotenv.Load(envFile)
 }
 
 // resolveCommandBeadsDir maps a discovered Dolt data path back to the owning
@@ -364,6 +377,14 @@ var rootCmd = &cobra.Command{
 		// Validate Dolt auto-commit mode early so all commands fail fast on invalid config.
 		if _, err := getDoltAutoCommitMode(); err != nil {
 			FatalError("%v", err)
+		}
+
+		// GH#2677: Load .beads/.env before the noDbCommands early return so that
+		// commands like "bd doctor --server" pick up per-project Dolt credentials.
+		// FindBeadsDir is lightweight (no git subprocesses) and beadsDir resolution
+		// only needs the filesystem walk that has already been cached.
+		if earlyBeadsDir := beads.FindBeadsDir(); earlyBeadsDir != "" {
+			loadBeadsEnvFile(earlyBeadsDir)
 		}
 
 		// GH#1093: Check noDbCommands BEFORE expensive operations

--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
-	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/subosito/gotenv v1.6.0
 	github.com/tealeg/xlsx v1.0.5 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -66,7 +66,7 @@ func newHaikuClient(apiKey string) (*haikuClient, error) {
 
 	return &haikuClient{
 		client:         client,
-		model:          anthropic.Model(config.DefaultAIModel()),
+		model:          config.DefaultAIModel(),
 		tier1Template:  tier1Tmpl,
 		maxRetries:     maxRetries,
 		initialBackoff: initialBackoff,
@@ -87,7 +87,7 @@ func (h *haikuClient) SummarizeTier1(ctx context.Context, issue *types.Issue) (s
 			Kind:     "llm_call",
 			Actor:    h.auditActor,
 			IssueID:  issue.ID,
-			Model:    string(h.model),
+			Model:    h.model,
 			Prompt:   prompt,
 			Response: resp,
 		}
@@ -129,7 +129,7 @@ func (h *haikuClient) callWithRetry(ctx context.Context, prompt string) (string,
 	ctx, span := tracer.Start(ctx, "anthropic.messages.new")
 	defer span.End()
 	span.SetAttributes(
-		attribute.String("bd.ai.model", string(h.model)),
+		attribute.String("bd.ai.model", h.model),
 		attribute.String("bd.ai.operation", "compact"),
 	)
 
@@ -158,7 +158,7 @@ func (h *haikuClient) callWithRetry(ctx context.Context, prompt string) (string,
 
 		if err == nil {
 			// Record token usage and latency.
-			modelAttr := attribute.String("bd.ai.model", string(h.model))
+			modelAttr := attribute.String("bd.ai.model", h.model)
 			if aiMetrics.inputTokens != nil {
 				aiMetrics.inputTokens.Add(ctx, message.Usage.InputTokens, metric.WithAttributes(modelAttr))
 				aiMetrics.outputTokens.Add(ctx, message.Usage.OutputTokens, metric.WithAttributes(modelAttr))


### PR DESCRIPTION
## Summary
- Moves `loadBeadsEnvFile()` call above the `noDbCommands` early return in `PersistentPreRunE`, so `bd doctor --server` (and other noDbCommands) pick up per-project Dolt credentials from `.beads/.env`
- Uses `beads.FindBeadsDir()` which is lightweight (filesystem walk, no git subprocesses) and already cached by the time this runs
- Adds `.env` to `.beads/.gitignore` template and `requiredPatterns` to prevent accidental credential commits

## Context
PR #2640 adds `.beads/.env` loading for per-project Dolt credentials (GH#2520), but places the `loadBeadsEnvFile()` call after the `noDbCommands` early return at line ~420. Since `doctor` is in `noDbCommands`, `PersistentPreRunE` returns before `.env` is loaded. When `bd doctor --server` later calls `cfg.GetDoltServerHost()` → `os.Getenv("BEADS_DOLT_SERVER_HOST")`, the env var is empty, causing it to fall back to `127.0.0.1` and auto-start a local Dolt server instead of connecting to the configured VPS.

## Test plan
- [x] `TestLoadBeadsEnvFile` — verifies loading, shell precedence, and no-op on missing file
- [x] Existing `TestGitignoreTemplate_*` and `TestDoctor*` tests pass
- [ ] Manual: create `.beads/.env` with `BEADS_DOLT_SERVER_HOST=<vps>`, run `bd doctor --server`, verify it connects to VPS

Fixes #2677

🤖 Generated with [Claude Code](https://claude.com/claude-code)