### PR TITLE
fix: drop id from ORDER BY in GetAllEventsSince UNION ALL query

### DIFF
--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -60,6 +60,9 @@ func (s *DoltStore) GetEvents(ctx context.Context, issueID string, limit int) ([
 // GetAllEventsSince returns all events created after the given time, ordered by creation time.
 // Queries both events and wisp_events tables. Uses created_at for filtering because
 // event IDs are UUIDs (not sequential integers) and cannot be used as high-water marks.
+// Note: ORDER BY uses only created_at (not id) because Dolt's query planner attempts to
+// cast UUID char(36) ids to double for sorting in UNION ALL queries, which fails with
+// "+Inf is not a valid value for double".
 func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error) {
 	rows, err := s.queryContext(ctx, `
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
@@ -69,7 +72,7 @@ func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at
 		FROM wisp_events
 		WHERE created_at > ?
-		ORDER BY created_at ASC, id ASC
+		ORDER BY created_at ASC
 	`, since, since)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get events since %v: %w", since, err)

--- a/internal/storage/dolt/events_test.go
+++ b/internal/storage/dolt/events_test.go
@@ -1,0 +1,95 @@
+package dolt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestGetAllEventsSince_UnionBothTables verifies that GetAllEventsSince returns
+// events from both the events table (permanent issues) and wisp_events table
+// (ephemeral/wisp issues), ordered by created_at.
+func TestGetAllEventsSince_UnionBothTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	since := time.Now().UTC().Add(-1 * time.Second)
+
+	// Create a permanent issue (events go to 'events' table)
+	perm := &types.Issue{
+		ID:        "test-ev-perm",
+		Title:     "Permanent Issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, perm, "tester"); err != nil {
+		t.Fatalf("failed to create permanent issue: %v", err)
+	}
+
+	// Create an ephemeral issue (events go to 'wisp_events' table)
+	wisp := &types.Issue{
+		ID:        "test-ev-wisp",
+		Title:     "Wisp Issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("failed to create wisp issue: %v", err)
+	}
+
+	// Query events since before both were created
+	events, err := store.GetAllEventsSince(ctx, since)
+	if err != nil {
+		t.Fatalf("GetAllEventsSince failed: %v", err)
+	}
+
+	// Should have events from both tables (at least one 'created' event each)
+	permFound, wispFound := false, false
+	for _, e := range events {
+		if e.IssueID == perm.ID {
+			permFound = true
+		}
+		if e.IssueID == wisp.ID {
+			wispFound = true
+		}
+	}
+	if !permFound {
+		t.Error("expected event from permanent issue (events table), not found")
+	}
+	if !wispFound {
+		t.Error("expected event from wisp issue (wisp_events table), not found")
+	}
+
+	// Verify chronological ordering
+	for i := 1; i < len(events); i++ {
+		if events[i].CreatedAt.Before(events[i-1].CreatedAt) {
+			t.Errorf("events not in chronological order: [%d] %v > [%d] %v",
+				i-1, events[i-1].CreatedAt, i, events[i].CreatedAt)
+		}
+	}
+}
+
+// TestGetAllEventsSince_EmptyStore verifies that GetAllEventsSince returns an
+// empty slice (not an error) when no events exist after the given time.
+func TestGetAllEventsSince_EmptyStore(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	events, err := store.GetAllEventsSince(ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events from empty store, got %d", len(events))
+	}
+}


### PR DESCRIPTION
## Summary

- Remove `id ASC` from the `ORDER BY` clause in the `GetAllEventsSince` UNION ALL query
- Add test coverage for `GetAllEventsSince` (previously untested)

## Problem

Dolt's query planner attempts to cast UUID `char(36)` values to `double` when sorting a UNION ALL result set that includes the `id` column in `ORDER BY`. This produces:

```
Error 1366 (HY000): error: '+Inf' is not a valid value for 'double'
```

This breaks any downstream consumer that polls events via `GetAllEventsSince`, such as the Gas Town daemon's convoy event poller, which fails on every poll cycle across all rig databases.

## Root cause

The `events` and `wisp_events` tables use `char(36)` UUID primary keys. When these are combined via `UNION ALL` and sorted with `ORDER BY created_at ASC, id ASC`, Dolt internally tries to compare the UUID strings as doubles for the `id` sort key. Certain UUID values produce `+Inf` during this coercion, which Dolt then rejects.

## Fix

Drop `id ASC` from the ORDER BY — `created_at ASC` alone provides sufficient chronological ordering for event polling. Sub-second deterministic ordering between concurrent events is not required by any consumer of this API.

## Test plan

- [x] Verified fix against live Dolt server with ~9000 events across both tables
- [x] Confirmed old query reproduces the `+Inf` error on UNION ALL
- [x] Confirmed new query returns correct results ordered by `created_at`
- [x] Added `TestGetAllEventsSince_UnionBothTables` and `TestGetAllEventsSince_EmptyStore`
- [x] `go build ./...` passes cleanly
- [ ] Note: Dolt container tests have a pre-existing `initSchemaOnDB` deadlock in TestMain (not related to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)