### PR TITLE
fix(doctor): fail closed for server-mode integrity recovery

### DIFF
--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -181,6 +181,14 @@ func CheckDatabaseIntegrity(path string) DoctorCheck {
 	ctx := context.Background()
 	store, err := dolt.NewFromConfigWithCLIOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	if err != nil {
+		if manualDetail := serverModeIntegrityManualRecoveryDetail(beadsDir); manualDetail != "" {
+			return DoctorCheck{
+				Name:    "Database Integrity",
+				Status:  StatusError,
+				Message: "Failed to open configured server-mode database",
+				Detail:  fmt.Sprintf("Storage: Dolt\n\nError: %v\n\n%s", err, manualDetail),
+			}
+		}
 		return DoctorCheck{
 			Name:    "Database Integrity",
 			Status:  StatusError,
@@ -215,6 +223,24 @@ func CheckDatabaseIntegrity(path string) DoctorCheck {
 		Message: "Basic query check passed",
 		Detail:  "Storage: Dolt",
 	}
+}
+
+func serverModeIntegrityManualRecoveryDetail(beadsDir string) string {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil || !cfg.IsDoltServerMode() {
+		return ""
+	}
+
+	dbName := cfg.GetDoltDatabase()
+	if dbName == "" {
+		dbName = configfile.DefaultDoltDatabase
+	}
+
+	return fmt.Sprintf(
+		"Automatic integrity recovery is disabled for server-mode repos because it can replace the wrong Dolt root.\nPreserve the Dolt root at %s and verify the configured database %q manually before any reinitialization.",
+		getDatabasePath(beadsDir),
+		dbName,
+	)
 }
 
 // CheckProjectIdentity detects missing project_id in metadata.json and/or

--- a/cmd/bd/doctor/database_test.go
+++ b/cmd/bd/doctor/database_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
 )
 
 func TestCheckDatabaseIntegrity(t *testing.T) {
@@ -52,6 +54,40 @@ func TestCheckDatabaseIntegrity(t *testing.T) {
 				t.Errorf("expected message %q, got %q", tt.expectMessage, check.Message)
 			}
 		})
+	}
+}
+
+func TestServerModeIntegrityManualRecoveryDetail(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 1,
+		DoltDatabase:   "doctest_missing_server_db",
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	detail := serverModeIntegrityManualRecoveryDetail(beadsDir)
+	if detail == "" {
+		t.Fatal("expected server-mode manual recovery detail")
+	}
+	if !strings.Contains(detail, "Automatic integrity recovery is disabled for server-mode repos") {
+		t.Fatalf("detail missing manual recovery guidance:\n%s", detail)
+	}
+	if !strings.Contains(detail, "doctest_missing_server_db") {
+		t.Fatalf("detail missing configured database name:\n%s", detail)
+	}
+	if !strings.Contains(detail, doltDir) {
+		t.Fatalf("detail missing dolt root path:\n%s", detail)
 	}
 }
 

--- a/cmd/bd/doctor/fix/database_integrity.go
+++ b/cmd/bd/doctor/fix/database_integrity.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/steveyegge/beads/internal/configfile"
 )
 
 // DatabaseIntegrity attempts to recover from database corruption by:
@@ -26,6 +28,10 @@ func DatabaseIntegrity(path string) error {
 
 // doltIntegrityRecovery backs up the corrupted Dolt database and reinitializes.
 func doltIntegrityRecovery(path, beadsDir string) error {
+	if err := serverModeIntegrityRecoveryGuard(beadsDir); err != nil {
+		return err
+	}
+
 	doltPath := getDatabasePath(beadsDir)
 
 	// Check if dolt directory exists
@@ -68,4 +74,22 @@ func doltIntegrityRecovery(path, beadsDir string) error {
 	fmt.Printf("  Recovered Dolt database\n")
 	fmt.Printf("  Corrupted database preserved at: %s\n", filepath.Base(backupPath))
 	return nil
+}
+
+func serverModeIntegrityRecoveryGuard(beadsDir string) error {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil || !cfg.IsDoltServerMode() {
+		return nil
+	}
+
+	dbName := cfg.GetDoltDatabase()
+	if dbName == "" {
+		dbName = configfile.DefaultDoltDatabase
+	}
+
+	return fmt.Errorf(
+		"automatic integrity recovery is disabled for server-mode repos because it can replace the wrong Dolt root; preserve %s and verify the configured database %q manually before reinitializing",
+		getDatabasePath(beadsDir),
+		dbName,
+	)
 }

--- a/cmd/bd/doctor/fix/database_integrity_test.go
+++ b/cmd/bd/doctor/fix/database_integrity_test.go
@@ -1,0 +1,81 @@
+package fix
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func TestDatabaseIntegrity_ServerModeFailsClosedBeforeBackup(t *testing.T) {
+	dir := setupTestWorkspace(t)
+	beadsDir := filepath.Join(dir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+
+	cfg := &configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 49617,
+		DoltDatabase:   "beads_AI",
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	err := DatabaseIntegrity(dir)
+	if err == nil {
+		t.Fatal("expected server-mode integrity recovery to fail closed")
+	}
+	if strings.Contains(err.Error(), ErrTestBinary.Error()) {
+		t.Fatalf("expected server-mode guard before bd binary lookup, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "automatic integrity recovery is disabled for server-mode repos") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "beads_AI") {
+		t.Fatalf("error %q does not mention configured database", err)
+	}
+
+	if _, statErr := os.Stat(doltDir); statErr != nil {
+		t.Fatalf("expected dolt dir to remain in place, got %v", statErr)
+	}
+	backupPaths, globErr := filepath.Glob(doltDir + ".*.corrupt.backup")
+	if globErr != nil {
+		t.Fatalf("glob backup paths: %v", globErr)
+	}
+	if len(backupPaths) != 0 {
+		t.Fatalf("expected no corrupt backup path, got %v", backupPaths)
+	}
+}
+
+func TestDatabaseIntegrity_NonServerModeRestoresRootOnTestBinaryError(t *testing.T) {
+	dir := setupTestWorkspace(t)
+	beadsDir := filepath.Join(dir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+
+	err := DatabaseIntegrity(dir)
+	if !errors.Is(err, ErrTestBinary) {
+		t.Fatalf("expected ErrTestBinary, got %v", err)
+	}
+
+	if _, statErr := os.Stat(doltDir); statErr != nil {
+		t.Fatalf("expected dolt dir to be restored, got %v", statErr)
+	}
+	backupPaths, globErr := filepath.Glob(doltDir + ".*.corrupt.backup")
+	if globErr != nil {
+		t.Fatalf("glob backup paths: %v", globErr)
+	}
+	if len(backupPaths) != 0 {
+		t.Fatalf("expected no leftover corrupt backup path, got %v", backupPaths)
+	}
+}


### PR DESCRIPTION
This PR fixes an unsafe `bd doctor --fix --yes` integrity-recovery path for server-mode multi-db repos.

This PR is intentionally separate from the runtime-manager refactor stack tracked by #2685. It does not extend or correct an omitted refactor slice; it fixes a different bug in the `bd doctor --fix --yes` integrity-recovery path for server-mode multi-db repos.

## What This PR Changes

- Fails closed in `DatabaseIntegrity` before the destructive backup-and-reinit path can run for server-mode repos.
- Stops advertising `Database Integrity` as auto-fixable when the configured database is missing in the server-mode case.
- Adds focused regression coverage for the fail-closed server-mode behavior and the preserved non-server-mode recovery behavior.

## Relationship To Runtime-Manager Refactor

- Orthogonal to #2685 and its stacked PRs.
- Triggered during refactor publication work, but not caused by that refactor.
- Fixes the deployed doctor integrity-recovery path, which was outside the refactor’s changed surface.

## Validation

- `go test ./cmd/bd/doctor/fix -run '^(TestDatabaseIntegrity_ServerModeFailsClosedBeforeBackup|TestDatabaseIntegrity_NonServerModeRestoresRootOnTestBinaryError)$' -count=1`
- `go test ./cmd/bd/doctor/database.go ./cmd/bd/doctor/database_test.go ./cmd/bd/doctor/backend.go ./cmd/bd/doctor/types.go ./cmd/bd/doctor/resolve.go -run '^(TestCheckDatabaseIntegrity|TestServerModeIntegrityManualRecoveryDetail)$' -count=1`
- `git diff --check`

Closes #2692
