### PR TITLE
fix: make KillStaleServers respect server ownership

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -815,25 +815,56 @@ func LogPath(beadsDir string) string {
 	return logPath(beadsDir)
 }
 
+// isAutoStartDisabled returns true when the user has opted out of beads
+// auto-starting dolt servers (e.g. because a systemd unit manages the server).
+func isAutoStartDisabled() bool {
+	v := os.Getenv("BEADS_DOLT_AUTO_START")
+	return v == "0" || strings.EqualFold(v, "false")
+}
+
 // killStaleServersForDir finds and kills orphan dolt sql-server processes for
 // the current repo's Dolt data directory that are not tracked by the canonical
-// PID file. Servers owned by other repos are preserved.
+// PID file. Only processes that beads started (tracked via the PID file) are
+// eligible for cleanup. Externally-managed servers are never killed.
+//
+// A process is considered "external" (never kill) when any of:
+//   - hasExplicitPort() returns true (metadata.json has explicit port config)
+//   - BEADS_DOLT_AUTO_START=0 is set
+//   - No PID file exists (beads has no record of starting a server)
 func killStaleServersForDir(beadsDir string, allPIDs []int, inDir func(int, string) bool, kill func(int) error) ([]int, error) {
 	if len(allPIDs) == 0 {
 		return nil, nil
 	}
 
-	// Collect canonical PIDs (ones we should NOT kill).
-	canonicalPIDs := make(map[int]bool)
-	serverDir := resolveServerDir(beadsDir)
-	if serverDir != "" {
-		if data, readErr := os.ReadFile(pidPath(serverDir)); readErr == nil {
-			if pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil && pid > 0 {
-				canonicalPIDs[pid] = true
-			}
-		}
+	// If the server is externally managed, never kill anything.
+	if hasExplicitPort(beadsDir) {
+		return nil, nil
+	}
+	if isAutoStartDisabled() {
+		return nil, nil
 	}
 
+	serverDir := resolveServerDir(beadsDir)
+
+	// Read the canonical PID from the PID file. If there is no PID file,
+	// beads has no record of having started a server for this directory,
+	// so there is nothing stale to clean up. This prevents killing
+	// externally-started servers (systemd, other repos sharing a data dir).
+	var canonicalPID int
+	if data, readErr := os.ReadFile(pidPath(serverDir)); readErr == nil {
+		if pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil && pid > 0 {
+			canonicalPID = pid
+		}
+	}
+	if canonicalPID == 0 {
+		// No valid PID file → no beads-owned server to compare against.
+		// Nothing is stale from our perspective.
+		return nil, nil
+	}
+
+	// The canonical PID itself is alive and tracked — never kill it.
+	// Only kill OTHER dolt processes in our data dir (orphans from a
+	// previous beads-started server that lost its PID file tracking).
 	ownedDoltDir := ResolveDoltDir(serverDir)
 
 	var killed []int
@@ -841,7 +872,7 @@ func killStaleServersForDir(beadsDir string, allPIDs []int, inDir func(int, stri
 		if pid == os.Getpid() {
 			continue
 		}
-		if canonicalPIDs[pid] {
+		if pid == canonicalPID {
 			continue // preserve canonical server
 		}
 		if !inDir(pid, ownedDoltDir) {

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -616,7 +616,10 @@ func TestKillStaleServersPreservesOtherRepoServers(t *testing.T) {
 	}
 }
 
-func TestKillStaleServersWithoutCanonicalPIDOnlyKillsOwnedDir(t *testing.T) {
+func TestKillStaleServersWithoutCanonicalPIDIsNoop(t *testing.T) {
+	// Without a PID file, beads has no record of starting a server.
+	// killStaleServersForDir should be a no-op to avoid killing
+	// externally-managed servers (systemd, other repos, etc).
 	dir := t.TempDir()
 	sameRepoOrphanPID := 222
 	otherRepoPID := 333
@@ -636,11 +639,101 @@ func TestKillStaleServersWithoutCanonicalPIDOnlyKillsOwnedDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("killStaleServersForDir error: %v", err)
 	}
-	if len(got) != 1 || got[0] != sameRepoOrphanPID {
-		t.Fatalf("killed=%v, want [%d]", got, sameRepoOrphanPID)
+	if len(got) != 0 {
+		t.Fatalf("killed=%v, want [] (no PID file means nothing is stale)", got)
 	}
-	if len(killed) != 1 || killed[0] != sameRepoOrphanPID {
-		t.Fatalf("kill callback got %v, want [%d]", killed, sameRepoOrphanPID)
+	if len(killed) != 0 {
+		t.Fatalf("kill callback got %v, want [] (no PID file means nothing is stale)", killed)
+	}
+}
+
+func TestKillStaleServersSkipsExplicitPort(t *testing.T) {
+	// When metadata.json has an explicit port, the server is externally
+	// managed and killStaleServersForDir should be a complete no-op.
+	dir := t.TempDir()
+
+	// Write a metadata.json with an explicit port
+	metadataPath := filepath.Join(dir, "metadata.json")
+	if err := os.WriteFile(metadataPath, []byte(`{"dolt_server_port": 3307}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a PID file (would normally trigger stale cleanup)
+	canonicalPID := 111
+	if err := os.WriteFile(pidPath(dir), []byte(strconv.Itoa(canonicalPID)), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	orphanPID := 222
+	var killed []int
+	got, err := killStaleServersForDir(
+		dir,
+		[]int{canonicalPID, orphanPID},
+		func(pid int, _ string) bool { return true },
+		func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("killStaleServersForDir error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("killed=%v, want [] (explicit port = externally managed)", got)
+	}
+}
+
+func TestKillStaleServersSkipsAutoStartDisabled(t *testing.T) {
+	// When BEADS_DOLT_AUTO_START=0, the server is externally managed
+	// and killStaleServersForDir should be a complete no-op.
+	dir := t.TempDir()
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+
+	// Write a PID file
+	canonicalPID := 111
+	if err := os.WriteFile(pidPath(dir), []byte(strconv.Itoa(canonicalPID)), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	orphanPID := 222
+	var killed []int
+	got, err := killStaleServersForDir(
+		dir,
+		[]int{canonicalPID, orphanPID},
+		func(pid int, _ string) bool { return true },
+		func(pid int) error {
+			killed = append(killed, pid)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("killStaleServersForDir error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("killed=%v, want [] (auto-start disabled = externally managed)", got)
+	}
+}
+
+func TestIsAutoStartDisabled(t *testing.T) {
+	tests := []struct {
+		envVal string
+		want   bool
+	}{
+		{"0", true},
+		{"false", true},
+		{"FALSE", true},
+		{"False", true},
+		{"1", false},
+		{"true", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run("env="+tt.envVal, func(t *testing.T) {
+			t.Setenv("BEADS_DOLT_AUTO_START", tt.envVal)
+			if got := isAutoStartDisabled(); got != tt.want {
+				t.Errorf("isAutoStartDisabled() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds three ownership gates to `killStaleServersForDir` so it only kills processes beads started
- Skips kill when `hasExplicitPort()` is true (externally-managed server via metadata.json)
- Skips kill when `BEADS_DOLT_AUTO_START=0` (user opted out)
- Skips kill when no PID file exists (beads never started a server, nothing can be "stale")
- Adds `isAutoStartDisabled()` helper

## Test plan
- [x] All 50 existing doltserver tests pass
- [x] New `TestKillStaleServersSkipsExplicitPort`
- [x] New `TestKillStaleServersSkipsAutoStartDisabled`
- [x] New `TestIsAutoStartDisabled` (table-driven)
- [ ] Manual: Start dolt server on port 3308, configure metadata.json, run `bd init` — server NOT killed
- [ ] Manual: Start via `bd`, kill bd, run `bd` again — stale server IS killed

Closes #2641
Closes #2655

🤖 Generated with [Claude Code](https://claude.com/claude-code)