### PR TITLE
feat: include memories in export/import round-trip

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -28,11 +29,15 @@ and 'bd backup restore'.
 By default, exports only regular issues (excluding infrastructure beads
 like agents, rigs, roles, and messages). Use --all to include everything.
 
+Memories (from 'bd remember') are included by default. Use --no-memories
+to exclude them.
+
 EXAMPLES:
-  bd export                          # Export to stdout
-  bd export -o backup.jsonl          # Export to file
-  bd export --all -o full.jsonl      # Include infra + templates + gates
-  bd export --scrub -o clean.jsonl   # Exclude test/pollution records`,
+  bd export                              # Export issues + memories to stdout
+  bd export -o backup.jsonl              # Export to file
+  bd export --no-memories                # Export issues only
+  bd export --all -o full.jsonl          # Include infra + templates + gates
+  bd export --scrub -o clean.jsonl       # Exclude test/pollution records`,
 	GroupID: "sync",
 	RunE:    runExport,
 }
@@ -42,6 +47,7 @@ var (
 	exportAll          bool
 	exportIncludeInfra bool
 	exportScrub        bool
+	exportNoMemories   bool
 )
 
 func init() {
@@ -49,6 +55,7 @@ func init() {
 	exportCmd.Flags().BoolVar(&exportAll, "all", false, "Include all records (infra, templates, gates)")
 	exportCmd.Flags().BoolVar(&exportIncludeInfra, "include-infra", false, "Include infrastructure beads (agents, rigs, roles, messages)")
 	exportCmd.Flags().BoolVar(&exportScrub, "scrub", false, "Exclude test/pollution records")
+	exportCmd.Flags().BoolVar(&exportNoMemories, "no-memories", false, "Exclude persistent memories from the export")
 	rootCmd.AddCommand(exportCmd)
 }
 
@@ -117,7 +124,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 		issues = filterOutPollution(issues)
 	}
 
-	if len(issues) == 0 {
+	if len(issues) == 0 && exportNoMemories {
 		if exportOutput != "" {
 			fmt.Fprintln(os.Stderr, "No issues to export.")
 		}
@@ -174,6 +181,38 @@ func runExport(cmd *cobra.Command, args []string) error {
 		count++
 	}
 
+	// Export memories if not excluded
+	memoryCount := 0
+	if !exportNoMemories {
+		allConfig, err := store.GetAllConfig(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to read config for memories: %w", err)
+		}
+		fullPrefix := kvPrefix + memoryPrefix
+		for k, v := range allConfig {
+			if !strings.HasPrefix(k, fullPrefix) {
+				continue
+			}
+			userKey := strings.TrimPrefix(k, fullPrefix)
+			record := map[string]string{
+				"_type": "memory",
+				"key":   userKey,
+				"value": v,
+			}
+			data, err := json.Marshal(record)
+			if err != nil {
+				return fmt.Errorf("failed to marshal memory %s: %w", userKey, err)
+			}
+			if _, err := w.Write(data); err != nil {
+				return fmt.Errorf("failed to write: %w", err)
+			}
+			if _, err := w.Write([]byte{'\n'}); err != nil {
+				return fmt.Errorf("failed to write newline: %w", err)
+			}
+			memoryCount++
+		}
+	}
+
 	// Sync to disk if writing to file
 	if f, ok := w.(*os.File); ok && f != os.Stdout {
 		if err := f.Sync(); err != nil {
@@ -183,7 +222,11 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	// Print summary to stderr (not stdout, to avoid mixing with JSONL)
 	if exportOutput != "" {
-		fmt.Fprintf(os.Stderr, "Exported %d issues to %s\n", count, exportOutput)
+		if memoryCount > 0 {
+			fmt.Fprintf(os.Stderr, "Exported %d issues and %d memories to %s\n", count, memoryCount, exportOutput)
+		} else {
+			fmt.Fprintf(os.Stderr, "Exported %d issues to %s\n", count, exportOutput)
+		}
 	}
 
 	return nil

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -18,6 +18,10 @@ If no file is specified, imports from .beads/issues.jsonl (the git-tracked
 export). This is the incremental counterpart to 'bd export': new issues are
 created and existing issues are updated (upsert semantics).
 
+Memory records (lines with "_type":"memory") are automatically detected and
+imported as persistent memories (equivalent to 'bd remember'). This makes
+'bd export | bd import' a full round-trip for both issues and memories.
+
 This command makes the git-tracked JSONL portable again — after 'git pull'
 brings new issues, 'bd import' loads them into the local Dolt database.
 
@@ -74,15 +78,24 @@ func runImport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no database — run 'bd init' or 'bd bootstrap' first")
 	}
 
-	count, err := importFromLocalJSONL(ctx, store, jsonlPath)
+	result, err := importFromLocalJSONLFull(ctx, store, jsonlPath)
 	if err != nil {
 		return fmt.Errorf("import failed: %w", err)
 	}
 
-	if err := store.Commit(ctx, fmt.Sprintf("bd import: %d issues from %s", count, filepath.Base(jsonlPath))); err != nil {
+	commitMsg := fmt.Sprintf("bd import: %d issues", result.Issues)
+	if result.Memories > 0 {
+		commitMsg += fmt.Sprintf(", %d memories", result.Memories)
+	}
+	commitMsg += fmt.Sprintf(" from %s", filepath.Base(jsonlPath))
+	if err := store.Commit(ctx, commitMsg); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Imported %d issues from %s\n", count, jsonlPath)
+	if result.Memories > 0 {
+		fmt.Fprintf(os.Stderr, "Imported %d issues and %d memories from %s\n", result.Issues, result.Memories, jsonlPath)
+	} else {
+		fmt.Fprintf(os.Stderr, "Imported %d issues from %s\n", result.Issues, jsonlPath)
+	}
 	return nil
 }

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -61,30 +61,77 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 	return &ImportResult{Created: len(issues)}, nil
 }
 
-// importFromLocalJSONL imports issues from a local JSONL file on disk into the Dolt store.
-// Unlike git-based import, this reads from the current working tree, preserving
-// any manual cleanup done to the JSONL file (e.g., via bd compact --purge-tombstones).
-// Returns the number of issues imported and any error.
+// importLocalResult holds counts from a local JSONL import.
+type importLocalResult struct {
+	Issues   int
+	Memories int
+}
+
+// memoryRecord represents a memory entry in the JSONL export.
+type memoryRecord struct {
+	Type  string `json:"_type"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// importFromLocalJSONL imports issues (and memories) from a local JSONL file on disk
+// into the Dolt store. Returns the number of issues imported and any error.
+// This is a convenience wrapper around importFromLocalJSONLFull.
 func importFromLocalJSONL(ctx context.Context, store storage.DoltStorage, localPath string) (int, error) {
+	result, err := importFromLocalJSONLFull(ctx, store, localPath)
+	if err != nil {
+		return 0, err
+	}
+	return result.Issues, nil
+}
+
+// importFromLocalJSONLFull imports issues and memories from a local JSONL file.
+// It detects memory records (lines with "_type":"memory") and imports them
+// via SetConfig, while routing regular issue records through the normal path.
+func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, localPath string) (*importLocalResult, error) {
 	//nolint:gosec // G304: path from user-provided CLI argument
 	data, err := os.ReadFile(localPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read JSONL file %s: %w", localPath, err)
+		return nil, fmt.Errorf("failed to read JSONL file %s: %w", localPath, err)
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	// Allow up to 64MB per line for large descriptions
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 	var issues []*types.Issue
+	var memories []memoryRecord
 
 	for scanner.Scan() {
 		line := scanner.Text()
 		if line == "" {
 			continue
 		}
+
+		// Peek at the record to check for _type field
+		var peek map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &peek); err != nil {
+			return nil, fmt.Errorf("failed to parse JSONL line: %w", err)
+		}
+
+		// Check if this is a memory record
+		if rawType, ok := peek["_type"]; ok {
+			var typeStr string
+			if err := json.Unmarshal(rawType, &typeStr); err == nil && typeStr == "memory" {
+				var mem memoryRecord
+				if err := json.Unmarshal([]byte(line), &mem); err != nil {
+					return nil, fmt.Errorf("failed to parse memory record: %w", err)
+				}
+				if mem.Key != "" && mem.Value != "" {
+					memories = append(memories, mem)
+				}
+				continue
+			}
+		}
+
+		// Regular issue record
 		var issue types.Issue
 		if err := json.Unmarshal([]byte(line), &issue); err != nil {
-			return 0, fmt.Errorf("failed to parse issue from JSONL: %w", err)
+			return nil, fmt.Errorf("failed to parse issue from JSONL: %w", err)
 		}
 		// Skip tombstone entries: these are deleted issues exported by older
 		// versions (pre-v0.50) with status "tombstone" and deleted_at set.
@@ -96,31 +143,42 @@ func importFromLocalJSONL(ctx context.Context, store storage.DoltStorage, localP
 		issues = append(issues, &issue)
 	}
 	if err := scanner.Err(); err != nil {
-		return 0, fmt.Errorf("failed to scan JSONL: %w", err)
+		return nil, fmt.Errorf("failed to scan JSONL: %w", err)
 	}
 
-	if len(issues) == 0 {
-		return 0, nil
+	result := &importLocalResult{}
+
+	// Import memories
+	for _, mem := range memories {
+		storageKey := kvPrefix + memoryPrefix + mem.Key
+		if err := store.SetConfig(ctx, storageKey, mem.Value); err != nil {
+			return nil, fmt.Errorf("failed to import memory %q: %w", mem.Key, err)
+		}
+		result.Memories++
 	}
 
-	// Auto-detect prefix from first issue if not already configured
-	configuredPrefix, err := store.GetConfig(ctx, "issue_prefix")
-	if err == nil && strings.TrimSpace(configuredPrefix) == "" {
-		firstPrefix := utils.ExtractIssuePrefix(issues[0].ID)
-		if firstPrefix != "" {
-			if err := store.SetConfig(ctx, "issue_prefix", firstPrefix); err != nil {
-				return 0, fmt.Errorf("failed to set issue_prefix from imported issues: %w", err)
+	// Import issues
+	if len(issues) > 0 {
+		// Auto-detect prefix from first issue if not already configured
+		configuredPrefix, err := store.GetConfig(ctx, "issue_prefix")
+		if err == nil && strings.TrimSpace(configuredPrefix) == "" {
+			firstPrefix := utils.ExtractIssuePrefix(issues[0].ID)
+			if firstPrefix != "" {
+				if err := store.SetConfig(ctx, "issue_prefix", firstPrefix); err != nil {
+					return nil, fmt.Errorf("failed to set issue_prefix from imported issues: %w", err)
+				}
 			}
 		}
+
+		opts := ImportOptions{
+			SkipPrefixValidation: true,
+		}
+		_, err = importIssuesCore(ctx, "", store, issues, opts)
+		if err != nil {
+			return nil, err
+		}
+		result.Issues = len(issues)
 	}
 
-	opts := ImportOptions{
-		SkipPrefixValidation: true,
-	}
-	_, err = importIssuesCore(ctx, "", store, issues, opts)
-	if err != nil {
-		return 0, err
-	}
-
-	return len(issues), nil
+	return result, nil
 }


### PR DESCRIPTION
## Summary

`bd export` / `bd import` were not a full round-trip — persistent memories (from `bd remember`) were silently dropped. This matters when moving between machines without a Dolt remote configured.

**Changes:**
- `export.go`: append memory records after issues as `{"_type":"memory","key":"...","value":"..."}` JSONL lines. Add `--no-memories` flag to opt out.
- `import_shared.go`: add `importFromLocalJSONLFull` that detects the `_type` field and routes memory vs issue records. Memory records are restored via `SetConfig`.
- `import.go`: switch to `importFromLocalJSONLFull` for memory-aware reporting.

`bd export | bd import` is now a lossless round-trip for both issues and memories.

## Test plan

- [ ] `bd export` output includes `{"_type":"memory",...}` lines for each stored memory
- [ ] `bd export --no-memories` output contains no memory lines
- [ ] `bd import` on an export with memories restores all memories via `bd recall`
- [ ] Re-import is idempotent (no duplicate memories)
- [ ] Issues-only JSONL still imports correctly (no `_type` field)

Depends on `bd import` command (already merged via #2570). Extracted from #2625 per maintainer guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)