### PR TITLE
Update untrue comment

### DIFF
--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -61,9 +61,6 @@ func (s *DoltStore) GetEvents(ctx context.Context, issueID string, limit int) ([
 // GetAllEventsSince returns all events created after the given time, ordered by creation time.
 // Queries both events and wisp_events tables. Uses created_at for filtering because
 // event IDs are UUIDs (not sequential integers) and cannot be used as high-water marks.
-// Note: ORDER BY uses only created_at (not id) because Dolt's query planner attempts to
-// cast UUID char(36) ids to double for sorting in UNION ALL queries, which fails with
-// "+Inf is not a valid value for double".
 func (s *DoltStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error) {
 	rows, err := s.queryContext(ctx, `
 		SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at


### PR DESCRIPTION
This comment is not true. Dolt never attempts to cast UUID char(36) ids to doubles when sorting. The original query from #2691 runs perfectly fine on a sql dump that @olofj provided to me. While we were able to find the issue mentioned in dolthub/dolt#10710, the issue has nothing to do with the original query from #2691. It must've been a different query that triggered the error.