### PR TITLE
Fix bd init overriding global core.hooksPath

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -564,6 +564,14 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 		return fmt.Errorf("failed to create hooks directory: %w", err)
 	}
 
+	// When setting a local core.hooksPath (beads or shared mode), preserve any
+	// hooks from the previously effective hooks directory (e.g. a global
+	// core.hooksPath or the default .git/hooks). Without this, setting a local
+	// core.hooksPath silently shadows the global one and those hooks stop running.
+	if beadsHooks || shared {
+		preservePreexistingHooks(hooksDir, hookNames)
+	}
+
 	// Install each hook using section markers (GH#1380).
 	// Only the content between markers is managed by beads; user content
 	// outside the markers is preserved across reinstalls and upgrades.
@@ -624,6 +632,72 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 	}
 
 	return nil
+}
+
+// preservePreexistingHooks copies non-beads hooks from the currently effective
+// hooks directory into targetDir. This prevents hooks from a global
+// core.hooksPath (or the default .git/hooks/) from being silently lost when
+// beads sets a local core.hooksPath override.
+func preservePreexistingHooks(targetDir string, hookNames []string) {
+	// Get the hooks directory git would currently use (before we override it).
+	currentDir, err := git.GetGitHooksDir()
+	if err != nil {
+		return
+	}
+
+	// Resolve to absolute paths for reliable comparison.
+	absTarget, err := filepath.Abs(targetDir)
+	if err != nil {
+		return
+	}
+	absCurrent, err := filepath.Abs(currentDir)
+	if err != nil {
+		return
+	}
+
+	// If the current dir is already our target, this is a re-install — skip.
+	if absTarget == absCurrent {
+		return
+	}
+
+	// If current dir is already a beads-managed directory, skip.
+	repoRoot := git.GetRepoRoot()
+	if repoRoot != "" {
+		absBeadsHooks, _ := filepath.Abs(filepath.Join(repoRoot, ".beads", "hooks"))
+		absSharedHooks, _ := filepath.Abs(filepath.Join(repoRoot, ".beads-hooks"))
+		if absCurrent == absBeadsHooks || absCurrent == absSharedHooks {
+			return
+		}
+	}
+
+	for _, hookName := range hookNames {
+		srcPath := filepath.Join(currentDir, hookName)
+		// #nosec G304 -- hook path constrained to known hooks directories
+		content, err := os.ReadFile(srcPath)
+		if err != nil {
+			continue // hook doesn't exist in the source dir
+		}
+
+		contentStr := string(content)
+		// Skip if it's already a beads hook
+		if strings.Contains(contentStr, hookSectionBeginPrefix) ||
+			strings.Contains(contentStr, inlineHookMarker) {
+			continue
+		}
+
+		// Don't overwrite existing files in target
+		dstPath := filepath.Join(targetDir, hookName)
+		if _, err := os.Stat(dstPath); err == nil {
+			continue
+		}
+
+		// #nosec G306 -- git hooks must be executable
+		if err := os.WriteFile(dstPath, content, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to preserve %s hook from %s: %v\n", hookName, currentDir, err)
+			continue
+		}
+		fmt.Printf("  Preserving existing %s hook from %s\n", hookName, currentDir)
+	}
 }
 
 func configureSharedHooksPath() error {

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -796,6 +796,120 @@ func TestInstallHooksBeads_WorktreeAccess(t *testing.T) {
 	})
 }
 
+// setupBeadsDir creates .beads/ with a minimal metadata.json so FindBeadsDir works.
+func setupBeadsDir(t *testing.T, repoDir string) string {
+	t.Helper()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("failed to create .beads/: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatalf("failed to create metadata.json: %v", err)
+	}
+	return beadsDir
+}
+
+// TestInstallHooksBeads_PreservesGlobalHooks is a regression test: bd init sets
+// a local core.hooksPath that shadows the global one, silently killing global
+// hooks. The fix copies hooks from the effective directory before overriding.
+func TestInstallHooksBeads_PreservesGlobalHooks(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(fakeHome, ".config"))
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(fakeHome, ".gitconfig"))
+
+	globalHooksDir := filepath.Join(fakeHome, "global-hooks")
+	if err := os.MkdirAll(globalHooksDir, 0755); err != nil {
+		t.Fatalf("failed to create global hooks dir: %v", err)
+	}
+	globalHookContent := "#!/bin/sh\necho global-hook-marker\n"
+	if err := os.WriteFile(filepath.Join(globalHooksDir, "pre-commit"), []byte(globalHookContent), 0755); err != nil {
+		t.Fatalf("failed to write global pre-commit hook: %v", err)
+	}
+
+	setGlobal := exec.Command("git", "config", "--global", "core.hooksPath", globalHooksDir)
+	if out, err := setGlobal.CombinedOutput(); err != nil {
+		t.Fatalf("failed to set global core.hooksPath: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Manual repo init (can't use newGitRepo which sets a local core.hooksPath).
+	repoDir := t.TempDir()
+	initCmd := exec.Command("git", "init", "--initial-branch=main")
+	initCmd.Dir = repoDir
+	if err := initCmd.Run(); err != nil {
+		t.Fatalf("git init failed: %v", err)
+	}
+	for _, args := range [][]string{
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test User"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git config %v failed: %v", args, err)
+		}
+	}
+
+	runInDir(t, repoDir, func() {
+		beadsDir := setupBeadsDir(t, repoDir)
+
+		if err := installHooksWithOptions(managedHookNames, false, false, false, true); err != nil {
+			t.Fatalf("installHooksWithOptions(beads=true) failed: %v", err)
+		}
+
+		content, err := os.ReadFile(filepath.Join(beadsDir, "hooks", "pre-commit"))
+		if err != nil {
+			t.Fatalf("failed to read .beads/hooks/pre-commit: %v", err)
+		}
+		contentStr := string(content)
+
+		if !strings.Contains(contentStr, "echo global-hook-marker") {
+			t.Errorf("global hook content not preserved in .beads/hooks/pre-commit.\nGot:\n%s", contentStr)
+		}
+		if !strings.Contains(contentStr, hookSectionBeginPrefix) {
+			t.Errorf("beads section marker missing.\nGot:\n%s", contentStr)
+		}
+	})
+}
+
+// TestInstallHooksBeads_PreservesDefaultGitHooks verifies that hooks in the
+// default .git/hooks/ directory are preserved when beads redirects
+// core.hooksPath to .beads/hooks/.
+func TestInstallHooksBeads_PreservesDefaultGitHooks(t *testing.T) {
+	repoDir := newGitRepo(t)
+	runInDir(t, repoDir, func() {
+		hooksDir := filepath.Join(repoDir, ".git", "hooks")
+		if err := os.MkdirAll(hooksDir, 0755); err != nil {
+			t.Fatalf("failed to create .git/hooks: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte("#!/bin/sh\necho custom-default-hook\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Unset the local core.hooksPath that newGitRepo sets so git falls back to .git/hooks/.
+		exec.Command("git", "config", "--unset", "core.hooksPath").Run()
+
+		beadsDir := setupBeadsDir(t, repoDir)
+
+		if err := installHooksWithOptions(managedHookNames, false, false, false, true); err != nil {
+			t.Fatalf("installHooksWithOptions(beads=true) failed: %v", err)
+		}
+
+		content, err := os.ReadFile(filepath.Join(beadsDir, "hooks", "pre-commit"))
+		if err != nil {
+			t.Fatalf("failed to read .beads/hooks/pre-commit: %v", err)
+		}
+		contentStr := string(content)
+
+		if !strings.Contains(contentStr, "echo custom-default-hook") {
+			t.Errorf(".git/hooks/pre-commit content not preserved.\nGot:\n%s", contentStr)
+		}
+		if !strings.Contains(contentStr, hookSectionBeginPrefix) {
+			t.Errorf("beads section marker missing.\nGot:\n%s", contentStr)
+		}
+	})
+}
+
 func TestHooksNeedUpdate(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
## Summary
- `bd init` sets a local `core.hooksPath = .beads/hooks/`, which silently overrides the user's global `core.hooksPath`, causing global hooks to stop running
- Added `preservePreexistingHooks()` that copies non-beads hooks from the currently effective hooks directory into the target directory before the local override is set
- Two regression tests that fail without the fix and pass with it: one for global `core.hooksPath`, one for default `.git/hooks/`

## Test plan
- [x] `go test ./cmd/bd/ -run TestInstallHooksBeads_Preserves -v` — both new tests pass
- [x] Reverting only `hooks.go` makes both tests fail (confirmed)
- [x] `go test ./cmd/bd/ -race` — all existing tests pass, no race conditions
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt` — no formatting issues