### PR TITLE
Preserve all hooks when overriding core.hooksPath

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -569,7 +569,7 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 	// core.hooksPath or the default .git/hooks). Without this, setting a local
 	// core.hooksPath silently shadows the global one and those hooks stop running.
 	if beadsHooks || shared {
-		preservePreexistingHooks(hooksDir, hookNames)
+		preservePreexistingHooks(hooksDir)
 	}
 
 	// Install each hook using section markers (GH#1380).
@@ -638,7 +638,7 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 // hooks directory into targetDir. This prevents hooks from a global
 // core.hooksPath (or the default .git/hooks/) from being silently lost when
 // beads sets a local core.hooksPath override.
-func preservePreexistingHooks(targetDir string, hookNames []string) {
+func preservePreexistingHooks(targetDir string) {
 	// Get the hooks directory git would currently use (before we override it).
 	currentDir, err := git.GetGitHooksDir()
 	if err != nil {
@@ -670,12 +670,22 @@ func preservePreexistingHooks(targetDir string, hookNames []string) {
 		}
 	}
 
-	for _, hookName := range hookNames {
-		srcPath := filepath.Join(currentDir, hookName)
+	// Copy all hooks from the source directory, not just managed ones.
+	entries, err := os.ReadDir(currentDir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || strings.HasSuffix(entry.Name(), ".sample") {
+			continue
+		}
+
+		srcPath := filepath.Join(currentDir, entry.Name())
 		// #nosec G304 -- hook path constrained to known hooks directories
 		content, err := os.ReadFile(srcPath)
 		if err != nil {
-			continue // hook doesn't exist in the source dir
+			continue
 		}
 
 		contentStr := string(content)
@@ -686,17 +696,17 @@ func preservePreexistingHooks(targetDir string, hookNames []string) {
 		}
 
 		// Don't overwrite existing files in target
-		dstPath := filepath.Join(targetDir, hookName)
+		dstPath := filepath.Join(targetDir, entry.Name())
 		if _, err := os.Stat(dstPath); err == nil {
 			continue
 		}
 
 		// #nosec G306 -- git hooks must be executable
 		if err := os.WriteFile(dstPath, content, 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to preserve %s hook from %s: %v\n", hookName, currentDir, err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to preserve %s hook from %s: %v\n", entry.Name(), currentDir, err)
 			continue
 		}
-		fmt.Printf("  Preserving existing %s hook from %s\n", hookName, currentDir)
+		fmt.Printf("  Preserving existing %s hook from %s\n", entry.Name(), currentDir)
 	}
 }
 

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -873,8 +873,8 @@ func TestInstallHooksBeads_PreservesGlobalHooks(t *testing.T) {
 }
 
 // TestInstallHooksBeads_PreservesDefaultGitHooks verifies that hooks in the
-// default .git/hooks/ directory are preserved when beads redirects
-// core.hooksPath to .beads/hooks/.
+// default .git/hooks/ directory (both managed and non-managed) are preserved
+// when beads redirects core.hooksPath to .beads/hooks/.
 func TestInstallHooksBeads_PreservesDefaultGitHooks(t *testing.T) {
 	repoDir := newGitRepo(t)
 	runInDir(t, repoDir, func() {
@@ -883,6 +883,9 @@ func TestInstallHooksBeads_PreservesDefaultGitHooks(t *testing.T) {
 			t.Fatalf("failed to create .git/hooks: %v", err)
 		}
 		if err := os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte("#!/bin/sh\necho custom-default-hook\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(hooksDir, "commit-msg"), []byte("#!/bin/sh\necho commit-msg-hook\n"), 0755); err != nil {
 			t.Fatal(err)
 		}
 
@@ -895,17 +898,26 @@ func TestInstallHooksBeads_PreservesDefaultGitHooks(t *testing.T) {
 			t.Fatalf("installHooksWithOptions(beads=true) failed: %v", err)
 		}
 
+		// Managed hook: should be preserved with beads section injected.
 		content, err := os.ReadFile(filepath.Join(beadsDir, "hooks", "pre-commit"))
 		if err != nil {
 			t.Fatalf("failed to read .beads/hooks/pre-commit: %v", err)
 		}
 		contentStr := string(content)
-
 		if !strings.Contains(contentStr, "echo custom-default-hook") {
 			t.Errorf(".git/hooks/pre-commit content not preserved.\nGot:\n%s", contentStr)
 		}
 		if !strings.Contains(contentStr, hookSectionBeginPrefix) {
 			t.Errorf("beads section marker missing.\nGot:\n%s", contentStr)
+		}
+
+		// Non-managed hook: should be copied as-is.
+		cmContent, err := os.ReadFile(filepath.Join(beadsDir, "hooks", "commit-msg"))
+		if err != nil {
+			t.Fatalf("non-managed hook commit-msg not copied to .beads/hooks/: %v", err)
+		}
+		if !strings.Contains(string(cmContent), "echo commit-msg-hook") {
+			t.Errorf("Unmanaged hook content not preserved.\nGot:\n%s", string(cmContent))
 		}
 	})
 }


### PR DESCRIPTION
Follow-up to #2729: preserve all hooks (not just managed ones) when overriding
  core.hooksPath. Skips .sample files.