### PR TITLE
fix(doctor): update gitignore with missing required patterns

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -58,6 +58,7 @@ dolt-server.pid
 dolt-server.log
 dolt-server.lock
 dolt-server.port
+dolt-server.activity
 
 # Corrupt backup directories (created by bd doctor --fix recovery)
 *.corrupt.backup/
@@ -109,6 +110,7 @@ var requiredPatterns = []string{
 	"dolt-server.log",
 	"dolt-server.lock",
 	"dolt-server.port",
+	"dolt-server.activity",
 	"daemon.*",
 	"interactions.jsonl",
 	"*.lock",

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -202,8 +202,10 @@ func applyFixesInteractive(path string, issues []doctorCheck) {
 func applyFixList(path string, fixes []doctorCheck) {
 	// Apply fixes in a dependency-aware order.
 	// Rough dependency chain:
-	// permissions/lock cleanup → config sanity → DB integrity/migrations.
+	// gitignore (fast, security-critical) → permissions/lock cleanup → config sanity → DB integrity/migrations.
 	order := []string{
+		"Gitignore",
+		"Project Gitignore",
 		"Metadata Config",
 		"Lock Files",
 		"Permissions",


### PR DESCRIPTION
## Summary
- Adds `dolt-server.activity` to gitignore template and required patterns so stale files from the removed idle monitor are properly ignored (#2723)
- Moves Gitignore and Project Gitignore fixes to top of `--fix` priority order so they run before DB migrations that may timeout (#2722), preventing the security-critical `.beads-credential-key` pattern from being missed

## Test plan
- [x] `go build ./cmd/bd/` compiles cleanly
- [x] All gitignore-related tests pass (`TestFixGitignore*`, `TestCheckGitignore*`)
- [ ] New `bd init` includes `dolt-server.activity` in .gitignore
- [ ] `bd doctor` detects missing `dolt-server.activity` pattern in outdated .gitignore
- [ ] `bd doctor --fix` adds missing patterns to existing .gitignore before running migrations

Closes #2723

🤖 Generated with [Claude Code](https://claude.com/claude-code)