### PR TITLE
fix(init): add .beads-credential-key to generated .gitignore

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -83,14 +83,15 @@ bd.db
 `
 
 // ProjectGitignorePatterns are patterns that should be in the project-root .gitignore
-// to prevent accidentally committing Dolt database files.
+// to prevent accidentally committing Dolt database files and credential keys.
 var ProjectGitignorePatterns = []string{
 	".dolt/",
 	"*.db",
+	".beads-credential-key",
 }
 
 // projectGitignoreComment is the section header added to the project .gitignore
-const projectGitignoreComment = "# Dolt database files (added by bd init)"
+const projectGitignoreComment = "# Beads / Dolt files (added by bd init)"
 
 // requiredPatterns are patterns that MUST be in .beads/.gitignore
 var requiredPatterns = []string{
@@ -626,7 +627,7 @@ func FixLastTouchedTracking(repoPath string) error {
 }
 
 // CheckProjectGitignore checks if the project-root .gitignore contains patterns
-// to prevent accidentally committing Dolt database files (.dolt/ and *.db).
+// to prevent accidentally committing Dolt database files and credential keys.
 // repoPath is the project root directory.
 func CheckProjectGitignore(repoPath string) DoctorCheck {
 	gitignorePath := filepath.Join(repoPath, ".gitignore")
@@ -637,7 +638,7 @@ func CheckProjectGitignore(repoPath string) DoctorCheck {
 			return DoctorCheck{
 				Name:    "Project Gitignore",
 				Status:  StatusWarning,
-				Message: "No project .gitignore found — Dolt files may be committed accidentally",
+				Message: "No project .gitignore found — Dolt/credential files may be committed accidentally",
 				Fix:     "Run: bd init (safe to re-run) or bd doctor --fix",
 			}
 		}
@@ -660,7 +661,7 @@ func CheckProjectGitignore(repoPath string) DoctorCheck {
 		return DoctorCheck{
 			Name:    "Project Gitignore",
 			Status:  StatusWarning,
-			Message: "Project .gitignore missing Dolt exclusion patterns",
+			Message: "Project .gitignore missing required exclusion patterns",
 			Detail:  "Missing: " + strings.Join(missing, ", "),
 			Fix:     "Run: bd doctor --fix or bd init (safe to re-run)",
 		}
@@ -669,13 +670,14 @@ func CheckProjectGitignore(repoPath string) DoctorCheck {
 	return DoctorCheck{
 		Name:    "Project Gitignore",
 		Status:  StatusOK,
-		Message: "Dolt files excluded",
+		Message: "Dolt and credential files excluded",
 	}
 }
 
-// EnsureProjectGitignore adds .dolt/ and *.db patterns to the project-root
-// .gitignore if they are not already present. Creates the file if it doesn't exist.
-// This prevents users from accidentally committing Dolt database files.
+// EnsureProjectGitignore adds .dolt/, *.db, and .beads-credential-key patterns
+// to the project-root .gitignore if they are not already present. Creates the
+// file if it doesn't exist. This prevents users from accidentally committing
+// Dolt database files or the credential encryption key.
 // repoPath is the project root directory.
 func EnsureProjectGitignore(repoPath string) error {
 	gitignorePath := filepath.Join(repoPath, ".gitignore")

--- a/cmd/bd/doctor/gitignore_test.go
+++ b/cmd/bd/doctor/gitignore_test.go
@@ -1793,7 +1793,7 @@ func TestCheckProjectGitignore_AllPresent(t *testing.T) {
 		}
 	}()
 
-	content := "node_modules/\n.dolt/\n*.db\n"
+	content := "node_modules/\n.dolt/\n*.db\n.beads-credential-key\n"
 	if err := os.WriteFile(".gitignore", []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -2363,6 +2363,22 @@ func TestRequiredPatterns_ContainsCredentialKey(t *testing.T) {
 	}
 	if !found {
 		t.Error("requiredPatterns should include '.beads-credential-key'")
+	}
+}
+
+// TestProjectGitignorePatterns_ContainsCredentialKey verifies that the
+// project-root .gitignore patterns include .beads-credential-key to prevent
+// the credential encryption key from being committed even outside .beads/.
+func TestProjectGitignorePatterns_ContainsCredentialKey(t *testing.T) {
+	found := false
+	for _, pattern := range ProjectGitignorePatterns {
+		if pattern == ".beads-credential-key" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ProjectGitignorePatterns should include '.beads-credential-key'")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `.beads-credential-key` to the root .gitignore template generated by `bd init` (#2695)
- Prevents accidental commit of credential key file
- Updates `bd doctor` check messages to reflect the broader scope of patterns

## Test plan
- [ ] New `bd init` includes `.beads-credential-key` in root .gitignore
- [ ] Existing .gitignore not broken by the addition
- [ ] `bd doctor` detects missing `.beads-credential-key` in root .gitignore and offers fix

Closes #2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)