### PR TITLE
fix(doctor): skip server health checks when no Dolt server expected

### DIFF
--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -139,6 +139,27 @@ func RunDoltHealthChecksWithLock(path string, lockCheck DoctorCheck) []DoctorChe
 
 	conn, err := openDoltConn(beadsDir)
 	if err != nil {
+		// GH#2722: When no server is running and the mode is not external
+		// (i.e., no expectation of a persistent server), skip server-dependent
+		// checks gracefully instead of reporting false errors. The SharedStore-
+		// based embedded checks already validate data integrity; the server
+		// will auto-start on the next bd command.
+		serverMode := doltserver.DefaultConfig(beadsDir).Mode
+		if serverMode != doltserver.ServerModeExternal {
+			skipMsg := "Skipped (no server running; will auto-start on next bd command)"
+			return []DoctorCheck{
+				{Name: "Dolt Connection", Status: StatusOK, Message: skipMsg, Category: CategoryCore},
+				{Name: "Dolt Schema", Status: StatusOK, Message: skipMsg, Category: CategoryCore},
+				{Name: "Dolt Issue Count", Status: StatusOK, Message: skipMsg, Category: CategoryData},
+				{Name: "Dolt Status", Status: StatusOK, Message: skipMsg, Category: CategoryData},
+				lockCheck,
+				{Name: "Phantom Databases", Status: StatusOK, Message: skipMsg, Category: CategoryData},
+				checkSharedServerHealth(beadsDir),
+			}
+		}
+
+		// External/shared server mode: a server is expected to be running,
+		// so connection failure is a real error.
 		connErr := err.Error()
 		return []DoctorCheck{
 			{Name: "Dolt Connection", Status: StatusError, Message: "Failed to connect to Dolt server", Detail: connErr, Fix: "Ensure dolt sql-server is running, or check server host/port configuration", Category: CategoryCore},

--- a/cmd/bd/doctor/dolt_test.go
+++ b/cmd/bd/doctor/dolt_test.go
@@ -14,9 +14,53 @@ import (
 // (bd-yqpwy)
 
 func TestRunDoltHealthChecks_DoltBackendNoServer(t *testing.T) {
-	// Server-only mode: without a running dolt sql-server, the connection
-	// check should return StatusError and all 6 checks should be present
-	// (consistent return shape regardless of connection success/failure).
+	// GH#2722: In owned/embedded mode (non-external), when no server is
+	// running, server-dependent checks should be skipped gracefully (StatusOK)
+	// instead of reporting false errors. The embedded SharedStore checks
+	// already cover data integrity.
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("failed to create beads dir: %v", err)
+	}
+
+	// Write metadata.json marking this as dolt backend (no explicit server port → owned mode)
+	configContent := []byte(`{"backend":"dolt"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), configContent, 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	// No BEADS_DOLT_SERVER_PORT set → port 0 → no server running
+	// No BEADS_DOLT_SHARED_SERVER → owned mode (not external)
+	checks := RunDoltHealthChecks(tmpDir)
+	if len(checks) != 7 {
+		t.Fatalf("expected exactly 7 checks (consistent shape), got %d", len(checks))
+	}
+
+	// Verify check names are consistent
+	expectedNames := []string{"Dolt Connection", "Dolt Schema", "Dolt Issue Count", "Dolt Status", "Dolt Lock Health", "Phantom Databases", "Shared Server"}
+	for i, name := range expectedNames {
+		if checks[i].Name != name {
+			t.Errorf("checks[%d].Name = %q, want %q", i, checks[i].Name, name)
+		}
+	}
+
+	// Server-dependent checks should be OK (gracefully skipped), not errors
+	for _, idx := range []int{0, 1, 2, 3, 5} {
+		if checks[idx].Status != StatusOK {
+			t.Errorf("checks[%d] (%s): expected StatusOK (graceful skip), got %s: %s",
+				idx, checks[idx].Name, checks[idx].Status, checks[idx].Message)
+		}
+		if !strings.Contains(checks[idx].Message, "no server running") {
+			t.Errorf("checks[%d] (%s): expected skip message about no server, got %q",
+				idx, checks[idx].Name, checks[idx].Message)
+		}
+	}
+}
+
+func TestRunDoltHealthChecks_ExternalModeNoServer(t *testing.T) {
+	// In external/shared server mode, a server IS expected to be running,
+	// so connection failure should report real errors.
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
@@ -29,8 +73,9 @@ func TestRunDoltHealthChecks_DoltBackendNoServer(t *testing.T) {
 		t.Fatalf("failed to write config: %v", err)
 	}
 
-	// Point at a port nothing listens on to ensure connection fails
+	// Point at a port nothing listens on AND set server mode to external
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "59998")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "1")
 
 	checks := RunDoltHealthChecks(tmpDir)
 	if len(checks) != 7 {
@@ -41,15 +86,7 @@ func TestRunDoltHealthChecks_DoltBackendNoServer(t *testing.T) {
 		t.Errorf("expected first check to be 'Dolt Connection', got %q", checks[0].Name)
 	}
 	if checks[0].Status != StatusError {
-		t.Errorf("expected StatusError (no server running), got %s: %s", checks[0].Status, checks[0].Message)
-	}
-
-	// Verify placeholder checks for dimensions that require a connection
-	expectedNames := []string{"Dolt Connection", "Dolt Schema", "Dolt Issue Count", "Dolt Status", "Dolt Lock Health", "Phantom Databases", "Shared Server"}
-	for i, name := range expectedNames {
-		if checks[i].Name != name {
-			t.Errorf("checks[%d].Name = %q, want %q", i, checks[i].Name, name)
-		}
+		t.Errorf("expected StatusError (external server unreachable), got %s: %s", checks[0].Status, checks[0].Message)
 	}
 
 	// Schema, Issue Count, Status, and Phantom Databases should be StatusError with skip message
@@ -87,7 +124,7 @@ func TestRunDoltHealthChecks_CheckNameAndCategory(t *testing.T) {
 
 func TestServerMode_NoLockAcquired(t *testing.T) {
 	// Server-only mode never acquires advisory locks.
-	// We force a non-listening port so the connection always fails.
+	// We force a non-listening port in external mode so the connection always fails.
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	doltDir := filepath.Join(beadsDir, "dolt")
@@ -101,6 +138,7 @@ func TestServerMode_NoLockAcquired(t *testing.T) {
 	}
 
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "59999")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "1") // External mode: server expected
 
 	checks := RunDoltHealthChecks(tmpDir)
 	if len(checks) != 7 {


### PR DESCRIPTION
## Summary
- Fixes false Dolt health check errors when no server is running (#2722)
- Doctor now checks server mode before running server-dependent health checks
- In owned/embedded mode (non-external), server-dependent checks are gracefully skipped with StatusOK when no server is running, since SharedStore-based embedded checks already validate data integrity
- External/shared server mode still reports real errors when the expected server is unreachable

## Test plan
- [ ] `bd doctor` with no server running reports clean (no false errors)
- [ ] `bd doctor` with server running still reports server health correctly
- [ ] `bd doctor --fix` still works when server issues are real
- [x] Unit tests updated and pass: owned mode skips gracefully, external mode still errors

Closes #2722

🤖 Generated with [Claude Code](https://claude.com/claude-code)