### PR TITLE
fix(hooks): increase shim timeout for chained pre-commit hooks

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -45,8 +45,11 @@ func hookSectionEndLine() string {
 // hookTimeoutSeconds is the maximum time a beads hook is allowed to run before
 // being killed and allowing the git operation to proceed.  A bounded timeout
 // prevents `bd hooks run` from hanging `git push` indefinitely (GH#2453).
+// The default is 300 seconds (5 minutes) to accommodate chained hooks — e.g.
+// pre-commit framework pipelines that run linters, type-checkers, and builds
+// inside `bd hooks run` via the `.old` hook chain (GH#2732).
 // The value can be overridden via the BEADS_HOOK_TIMEOUT environment variable.
-const hookTimeoutSeconds = 30
+const hookTimeoutSeconds = 300
 
 // generateHookSection returns the marked section content for a given hook name.
 // The section is self-contained: it checks for bd availability, runs the hook

--- a/docs/GIT_INTEGRATION.md
+++ b/docs/GIT_INTEGRATION.md
@@ -191,6 +191,22 @@ bd hooks install --beads
 **post-merge hook:**
 - Ensures Dolt database is current after pull/merge operations
 
+### Hook Timeout
+
+The beads hook shim wraps `bd hooks run` with an OS-level `timeout` to prevent hooks from hanging git operations indefinitely. The default timeout is **300 seconds** (5 minutes), which accommodates repos with chained pre-commit pipelines (e.g., eslint, prettier, TypeScript compilation).
+
+If your chained hooks need more time, override the timeout with the `BEADS_HOOK_TIMEOUT` environment variable:
+
+```bash
+# Set a longer timeout (in seconds)
+export BEADS_HOOK_TIMEOUT=600  # 10 minutes
+
+# Or set it per-invocation
+BEADS_HOOK_TIMEOUT=600 git commit -m "..."
+```
+
+When the timeout is reached, beads prints a warning and allows the git operation to proceed (the commit/push is not blocked).
+
 ### Hook Implementation Details
 
 #### Hook Installation (`cmd/bd/hooks.go`)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -589,6 +589,21 @@ bd vc conflicts
 
 See [ADVANCED.md#handling-git-merge-conflicts](ADVANCED.md#handling-git-merge-conflicts) for details.
 
+### Hook timeout kills chained pre-commit hooks
+
+**Symptom:** After `bd hooks install`, chained pre-commit hooks (eslint, prettier, ruff, etc.) stop running. You see: `beads: hook 'pre-commit' timed out after 300s -- continuing without beads`.
+
+**Cause:** The beads hook shim wraps `bd hooks run` with an OS-level `timeout`. Since `bd hooks run` chains to your original hook (`.git/hooks/pre-commit.old`) internally, the timeout covers both beads' own work and your entire hook pipeline.
+
+**Fix:** Increase the timeout via the `BEADS_HOOK_TIMEOUT` environment variable:
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export BEADS_HOOK_TIMEOUT=600  # 10 minutes (in seconds)
+```
+
+The default timeout is 300 seconds (5 minutes). For repos with very heavy pre-commit pipelines, you may need to increase this further.
+
 ### Permission denied on git hooks
 
 Git hooks need execute permissions:


### PR DESCRIPTION
## Summary
- Increases default hook shim timeout from 30s to 300s (5 minutes) to accommodate chained pre-commit pipelines (eslint, prettier, ruff, TypeScript, etc.) that run inside `bd hooks run` via the `.old` hook chain
- Documents the `BEADS_HOOK_TIMEOUT` environment variable in GIT_INTEGRATION.md and TROUBLESHOOTING.md so users can discover and adjust the timeout

Fixes #2732

## Test plan
- [x] All existing hook tests pass (TestGenerateHookSection_Timeout, TestInjectHookSection, etc.)
- [x] `go build ./cmd/bd/` compiles cleanly
- [ ] Chained pre-commit hooks with >30s pipelines complete without being killed
- [ ] Single hooks still have reasonable timeout protection (300s default)
- [ ] `BEADS_HOOK_TIMEOUT` override continues to work for custom values

🤖 Generated with [Claude Code](https://claude.com/claude-code)