### PR TITLE
fix(config): write config values to the correct store

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -301,7 +301,8 @@ func showConfigYAMLOverrides(dbConfig map[string]string) {
 		"create.require-description",
 		"validation.on-create", "validation.on-close", "validation.on-sync",
 		"hierarchy.max-depth",
-		"dolt.idle-timeout",
+		"backup.enabled", "backup.interval", "backup.git-push", "backup.git-repo",
+		"dolt.idle-timeout", "dolt.shared-server",
 	}
 
 	var yamlOverrides []string
@@ -333,13 +334,50 @@ var configUnsetCmd = &cobra.Command{
 	Short: "Delete a configuration value",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// Config operations work in direct mode only
+		key := args[0]
+
+		// Check if this is a yaml-only key (startup settings like backup.*, routing.*, etc.)
+		// These must be removed from config.yaml, not the database. (GH#2727)
+		if config.IsYamlOnlyKey(key) {
+			if err := config.UnsetYamlConfig(key); err != nil {
+				fmt.Fprintf(os.Stderr, "Error unsetting config: %v\n", err)
+				os.Exit(1)
+			}
+
+			if jsonOutput {
+				outputJSON(map[string]interface{}{
+					"key":      key,
+					"location": "config.yaml",
+				})
+			} else {
+				fmt.Printf("Unset %s (in config.yaml)\n", key)
+			}
+			return
+		}
+
+		// beads.role is stored in git config, not the database (GH#1531).
+		if key == "beads.role" {
+			gitCmd := exec.Command("git", "config", "--unset", "beads.role")
+			if err := gitCmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error unsetting beads.role in git config: %v\n", err)
+				os.Exit(1)
+			}
+			if jsonOutput {
+				outputJSON(map[string]interface{}{
+					"key":      key,
+					"location": "git config",
+				})
+			} else {
+				fmt.Printf("Unset %s (in git config)\n", key)
+			}
+			return
+		}
+
+		// Database-stored config requires direct mode
 		if err := ensureDirectMode("config unset requires direct database access"); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-
-		key := args[0]
 
 		ctx := rootCtx
 		if err := store.DeleteConfig(ctx, key); err != nil {

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -148,6 +148,30 @@ func GetYamlConfig(key string) string {
 	return v.GetString(normalizedKey)
 }
 
+// UnsetYamlConfig removes a configuration value from the project's config.yaml file.
+// The key line is commented out (prefixed with "# ") to preserve it as documentation.
+func UnsetYamlConfig(key string) error {
+	configPath, err := findProjectConfigYaml()
+	if err != nil {
+		return err
+	}
+
+	normalizedKey := normalizeYamlKey(key)
+
+	content, err := os.ReadFile(configPath) //nolint:gosec // configPath is from findProjectConfigYaml
+	if err != nil {
+		return fmt.Errorf("failed to read config.yaml: %w", err)
+	}
+
+	newContent := commentOutYamlKey(string(content), normalizedKey)
+
+	if err := os.WriteFile(configPath, []byte(newContent), 0600); err != nil { //nolint:gosec // configPath is validated
+		return fmt.Errorf("failed to write config.yaml: %w", err)
+	}
+
+	return nil
+}
+
 // findProjectConfigYaml finds the project's .beads/config.yaml file.
 func findProjectConfigYaml() (string, error) {
 	cwd, err := os.Getwd()
@@ -211,6 +235,32 @@ func updateYamlKey(content, key, value string) (string, error) {
 	}
 
 	return strings.Join(result, "\n"), nil
+}
+
+// commentOutYamlKey comments out a key in yaml content by prefixing the line with "# ".
+// If the key is already commented or not found, the content is returned unchanged.
+func commentOutYamlKey(content, key string) string {
+	// Match the key line (not already commented)
+	keyPattern := regexp.MustCompile(`^(\s*)` + regexp.QuoteMeta(key) + `\s*:`)
+
+	var result []string
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if keyPattern.MatchString(line) {
+			matches := keyPattern.FindStringSubmatch(line)
+			indent := ""
+			if len(matches) > 1 {
+				indent = matches[1]
+			}
+			// Comment out the line, preserving indentation
+			result = append(result, indent+"# "+strings.TrimLeft(line, " \t"))
+		} else {
+			result = append(result, line)
+		}
+	}
+
+	return strings.Join(result, "\n")
 }
 
 // formatYamlValue formats a value appropriately for YAML.

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -298,3 +298,95 @@ func TestValidateYamlConfigValue_SharedServer(t *testing.T) {
 		t.Error("expected '1' to be invalid (not a boolean string)")
 	}
 }
+
+func TestCommentOutYamlKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		key      string
+		expected string
+	}{
+		{
+			name:     "comment out existing key",
+			content:  "backup.enabled: false\nother: value",
+			key:      "backup.enabled",
+			expected: "# backup.enabled: false\nother: value",
+		},
+		{
+			name:     "already commented - no change",
+			content:  "# backup.enabled: false\nother: value",
+			key:      "backup.enabled",
+			expected: "# backup.enabled: false\nother: value",
+		},
+		{
+			name:     "key not found - no change",
+			content:  "other: value",
+			key:      "backup.enabled",
+			expected: "other: value",
+		},
+		{
+			name:     "preserve indentation",
+			content:  "  backup.enabled: true\nother: value",
+			key:      "backup.enabled",
+			expected: "  # backup.enabled: true\nother: value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := commentOutYamlKey(tt.content, tt.key)
+			if got != tt.expected {
+				t.Errorf("commentOutYamlKey() =\n%q\nwant:\n%q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUnsetYamlConfig(t *testing.T) {
+	// Create a temp directory with .beads/config.yaml
+	tmpDir, err := os.MkdirTemp("", "beads-yaml-unset-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads dir: %v", err)
+	}
+
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	initialConfig := `# Beads Config
+backup.enabled: false
+other-setting: value
+`
+	if err := os.WriteFile(configPath, []byte(initialConfig), 0644); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	// Change to temp directory for the test
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer os.Chdir(oldWd)
+
+	// Test UnsetYamlConfig
+	if err := UnsetYamlConfig("backup.enabled"); err != nil {
+		t.Fatalf("UnsetYamlConfig() error = %v", err)
+	}
+
+	// Read back and verify
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config.yaml: %v", err)
+	}
+
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "# backup.enabled: false") {
+		t.Errorf("config.yaml should contain commented-out backup.enabled, got:\n%s", contentStr)
+	}
+	if !strings.Contains(contentStr, "other-setting: value") {
+		t.Errorf("config.yaml should preserve other settings, got:\n%s", contentStr)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes `bd config set` silently writing to the wrong store (#2727)
- Adds `UnsetYamlConfig()` so `bd config unset` routes yaml-only keys (backup.*, routing.*, etc.) to config.yaml instead of the database
- Routes `beads.role` unset to git config for consistency with set/get
- Adds backup.* and dolt.shared-server to `config list` yaml override display

## Test plan
- [ ] `bd config set backup.enabled false` actually disables backup
- [ ] `bd config get backup.enabled` returns the set value
- [ ] `bd config unset backup.enabled` comments out the key in config.yaml
- [ ] `bd config list` shows backup.* keys under "Also set in config.yaml"
- [ ] Config values survive restart

Closes #2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)