### PR TITLE
fix: use SHOW COLUMNS in uuid_primary_keys migration to avoid server-mode crash

### DIFF
--- a/internal/storage/dolt/migrations/010_uuid_primary_keys.go
+++ b/internal/storage/dolt/migrations/010_uuid_primary_keys.go
@@ -44,18 +44,28 @@ func migrateTableToUUID(db *sql.DB, table string) error {
 		return nil // Table doesn't exist yet; schema.go will create it with UUID PKs
 	}
 
-	// Check if already migrated (column type is already CHAR)
-	var colType string
-	err = db.QueryRow(
-		"SELECT COLUMN_TYPE FROM information_schema.COLUMNS WHERE TABLE_NAME = ? AND COLUMN_NAME = 'id' AND TABLE_SCHEMA = DATABASE()",
-		table,
-	).Scan(&colType)
+	// Check if already migrated (column type is already CHAR).
+	// Uses SHOW COLUMNS instead of information_schema to avoid
+	// "no root value found in session" errors in Dolt server mode
+	// when the session working set is not fully initialized (GH#2051).
+	//nolint:gosec // G202: table is from hardcoded list, not user input
+	rows, err := db.Query("SHOW COLUMNS FROM `" + table + "` WHERE Field = 'id'")
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return nil // No id column — nothing to migrate
+		if isTableNotFoundError(err) {
+			return nil
 		}
 		return fmt.Errorf("check column type: %w", err)
 	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil // No id column — nothing to migrate
+	}
+	var field, colType, nullable, key string
+	var defaultVal, extra sql.NullString
+	if err := rows.Scan(&field, &colType, &nullable, &key, &defaultVal, &extra); err != nil {
+		return fmt.Errorf("scan column info: %w", err)
+	}
+	_ = rows.Close()
 
 	// If already char(36), migration was already applied
 	if colType == "char(36)" {


### PR DESCRIPTION
## Problem

The `uuid_primary_keys` migration (010) queries `information_schema.COLUMNS` with `TABLE_SCHEMA = DATABASE()` to check whether the `id` column has already been migrated to `CHAR(36)`. In Dolt **server mode**, this query fails with:

```
Error 1105 (HY000): no root value found in session
```

This blocks **all bd write commands** (`bd update`, `bd close`, `bd stats`) because `RunMigrations()` runs on every database open. Read commands (`bd list`, `bd ready`, `bd show`) still work because they use a different code path.

The error occurs when the Dolt server session working set is not fully initialized — we observed this after a server restart under memory pressure (1.3GB/1.5GB limit).

## Root Cause

`DATABASE()` in an `information_schema` query requires a valid root value in the session, which is not guaranteed in server mode. This is the same class of failure that was fixed in `helpers.go` after GH#2051, where `SHOW COLUMNS`/`SHOW TABLES` were adopted as replacements for `information_schema` queries.

The migration 010 was not updated to use the same pattern.

## Fix

Replace the `information_schema.COLUMNS` query with `SHOW COLUMNS FROM ... WHERE Field = 'id'`, consistent with the existing `columnExists()` helper in `helpers.go`. The `SHOW COLUMNS` approach is inherently scoped to the current database and does not require `DATABASE()`.

## Testing

- Verified on Dolt 1.84.0 server mode with 96 databases
- `bd stats`, `bd update`, `bd close` all work after the fix
- Build and lint pass (`go build`, `go vet`, `golangci-lint`)