### PR TITLE
fix: correct bd human help text for adding comments (GH#2715)

### DIFF
--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -39,7 +39,7 @@ SUBCOMMANDS:
 		printCmd("update <id>", "Update an issue (--status, --priority, --assignee)")
 		printCmd("close <id>", "Close one or more issues")
 		printCmd("reopen <id>", "Reopen a closed issue")
-		printCmd("comment <id>", "Add a comment to an issue")
+		printCmd("note <id> <text>", "Add a note to an issue (or: comments add <id>)")
 		fmt.Println()
 
 		// Workflow


### PR DESCRIPTION
## Problem

`bd human` shows `comment <id>` under "Working With Issues", but `bd comment` does not exist:

```
$ bd comment bd-123
Error: unknown command "comment" for "bd"
```

The correct commands are `bd note <id> <text>` (new shorthand added in 5f2d433) or `bd comments add <id> <text>`.

Fixes #2715.

## Fix

Update `cmd/bd/human.go` to show `note <id> <text>` with a hint about `comments add` as an alternative.

## Before / After

| Before | After |
|--------|-------|
| `comment <id>  Add a comment to an issue` | `note <id> <text>  Add a note to an issue (or: comments add <id>)` |