### PR TITLE
fix: add retry loop for binary existence check after Windows zip extraction (GH#2741)

### DIFF
--- a/npm-package/scripts/postinstall.js
+++ b/npm-package/scripts/postinstall.js
@@ -172,7 +172,20 @@ async function extractZip(zipPath, destDir, binaryName) {
       // The binary should now be in destDir
       const extractedBinary = path.join(destDir, binaryName);
 
-      if (!fs.existsSync(extractedBinary)) {
+      // Windows NTFS metadata visibility lag: fs.existsSync may return false
+      // immediately after Expand-Archive returns (GH#2741, same class as #1683).
+      // Poll with short delay before concluding the binary is missing.
+      let found = fs.existsSync(extractedBinary);
+      if (!found && os.platform() === 'win32') {
+        for (let poll = 0; poll < 10; poll++) {
+          await sleep(200);
+          if (fs.existsSync(extractedBinary)) {
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) {
         throw new Error(`Binary not found after extraction: ${extractedBinary}`);
       }
 


### PR DESCRIPTION
## Problem

On Windows, `npm install -g @beads/bd` fails with:

```
Error installing bd: Failed to extract archive: Binary not found after extraction: ...\bd.exe
```

`Expand-Archive` succeeds and `bd.exe` is present on disk, but `fs.existsSync()` returns `false` immediately after `execSync` returns. This is the same class of NTFS metadata visibility lag as #1683 and #1252, but occurring at the post-extraction existence check in `extractZip`.

Fixes #2741.

## Fix

Add a poll-retry loop (10 attempts × 200ms = max 2s) for the binary existence check after zip extraction. Only activates on Windows (`os.platform() === 'win32'`). Reuses the existing `sleep()` helper already in the file.

This mirrors the `waitForFileAccess` pattern already used for the download→extract handoff in the same script.

## Testing

- On Linux/macOS: no behavior change (`fs.existsSync` returns immediately, retry loop is skipped)
- On Windows: if `existsSync` returns false after extraction, polls up to 2s before throwing