### PR TITLE
feat(init): add --agents-file flag to customize agent instructions filename

### DIFF
--- a/cmd/bd/doctor/claude.go
+++ b/cmd/bd/doctor/claude.go
@@ -353,19 +353,12 @@ func CheckBdInPath() DoctorCheck {
 	}
 }
 
-// CheckDocumentationBdPrimeReference checks if AGENTS.md or CLAUDE.md reference 'bd prime'
+// CheckDocumentationBdPrimeReference checks if the agents file or CLAUDE.md reference 'bd prime'
 // and verifies the command exists. This helps catch version mismatches where docs
 // reference features not available in the installed version.
 // Also supports local-only variants (claude.local.md) that are gitignored.
 func CheckDocumentationBdPrimeReference(repoPath string) DoctorCheck {
-	docFiles := []string{
-		filepath.Join(repoPath, "AGENTS.md"),
-		filepath.Join(repoPath, "CLAUDE.md"),
-		filepath.Join(repoPath, ".claude", "CLAUDE.md"),
-		// Local-only variants (not committed to repo)
-		filepath.Join(repoPath, "claude.local.md"),
-		filepath.Join(repoPath, ".claude", "claude.local.md"),
-	}
+	docFiles := agentDocFiles(repoPath)
 
 	var filesWithBdPrime []string
 	for _, docFile := range docFiles {

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -14,20 +14,33 @@ import (
 	"github.com/steveyegge/beads/internal/doltserver"
 )
 
-// CheckLegacyBeadsSlashCommands detects old /beads:* slash commands in documentation
-// and recommends migration to bd prime hooks for better token efficiency.
-//
-// Old pattern: /beads:quickstart, /beads:ready (~10.5k tokens per session)
-// New pattern: bd prime hooks (~50-2k tokens per session)
-func CheckLegacyBeadsSlashCommands(repoPath string) DoctorCheck {
-	docFiles := []string{
-		filepath.Join(repoPath, "AGENTS.md"),
+// agentDocFiles returns the list of documentation files to check, including
+// the configured agents file (which may differ from the default AGENTS.md).
+func agentDocFiles(repoPath string) []string {
+	agentsFile := config.SafeAgentsFile()
+	files := []string{
+		filepath.Join(repoPath, agentsFile),
 		filepath.Join(repoPath, "CLAUDE.md"),
 		filepath.Join(repoPath, ".claude", "CLAUDE.md"),
 		// Local-only variants (not committed to repo)
 		filepath.Join(repoPath, "claude.local.md"),
 		filepath.Join(repoPath, ".claude", "claude.local.md"),
 	}
+	// If the configured file isn't the default, also check the default
+	// to catch legacy files that haven't been migrated.
+	if !strings.EqualFold(agentsFile, config.DefaultAgentsFile) {
+		files = append(files, filepath.Join(repoPath, config.DefaultAgentsFile))
+	}
+	return files
+}
+
+// CheckLegacyBeadsSlashCommands detects old /beads:* slash commands in documentation
+// and recommends migration to bd prime hooks for better token efficiency.
+//
+// Old pattern: /beads:quickstart, /beads:ready (~10.5k tokens per session)
+// New pattern: bd prime hooks (~50-2k tokens per session)
+func CheckLegacyBeadsSlashCommands(repoPath string) DoctorCheck {
+	docFiles := agentDocFiles(repoPath)
 
 	var filesWithLegacyCommands []string
 	legacyPattern := "/beads:"
@@ -61,7 +74,7 @@ func CheckLegacyBeadsSlashCommands(repoPath string) DoctorCheck {
 			"\n" +
 			"Migration Steps:\n" +
 			"  1. Run 'bd setup claude' to add SessionStart/PreCompact hooks\n" +
-			"  2. Update AGENTS.md/CLAUDE.md:\n" +
+			"  2. Update " + config.AgentsFile() + "/CLAUDE.md:\n" +
 			"     - Remove /beads:* slash command references\n" +
 			"     - Add: \"Run 'bd prime' for workflow context\" (for users without hooks)\n" +
 			"\n" +
@@ -81,14 +94,7 @@ func CheckLegacyBeadsSlashCommands(repoPath string) DoctorCheck {
 // Old pattern: Document MCP tool names for direct tool calls (~10.5k tokens per scan)
 // New pattern: bd prime hooks with CLI commands (~50-2k tokens)
 func CheckLegacyMCPToolReferences(repoPath string) DoctorCheck {
-	docFiles := []string{
-		filepath.Join(repoPath, "AGENTS.md"),
-		filepath.Join(repoPath, "CLAUDE.md"),
-		filepath.Join(repoPath, ".claude", "CLAUDE.md"),
-		// Local-only variants (not committed to repo)
-		filepath.Join(repoPath, "claude.local.md"),
-		filepath.Join(repoPath, ".claude", "claude.local.md"),
-	}
+	docFiles := agentDocFiles(repoPath)
 
 	mcpPatterns := []string{
 		"mcp__beads_beads__",
@@ -148,14 +154,7 @@ func CheckLegacyMCPToolReferences(repoPath string) DoctorCheck {
 // and recommends adding it if missing, suggesting bd onboard or bd setup claude.
 // Also supports local-only variants (claude.local.md) that are gitignored.
 func CheckAgentDocumentation(repoPath string) DoctorCheck {
-	docFiles := []string{
-		filepath.Join(repoPath, "AGENTS.md"),
-		filepath.Join(repoPath, "CLAUDE.md"),
-		filepath.Join(repoPath, ".claude", "CLAUDE.md"),
-		// Local-only variants (not committed to repo)
-		filepath.Join(repoPath, "claude.local.md"),
-		filepath.Join(repoPath, ".claude", "claude.local.md"),
-	}
+	docFiles := agentDocFiles(repoPath)
 
 	var foundDocs []string
 	for _, docFile := range docFiles {
@@ -176,10 +175,10 @@ func CheckAgentDocumentation(repoPath string) DoctorCheck {
 		Name:    "Agent Documentation",
 		Status:  StatusWarning,
 		Message: "No agent documentation found",
-		Detail: "Missing: AGENTS.md or CLAUDE.md\n" +
+		Detail: "Missing: " + config.AgentsFile() + " or CLAUDE.md\n" +
 			"  Documenting workflow helps AI agents work more effectively",
 		Fix: "Add agent documentation:\n" +
-			"  • Run 'bd onboard' to create AGENTS.md with workflow guidance\n" +
+			"  • Run 'bd onboard' to create " + config.AgentsFile() + " with workflow guidance\n" +
 			"  • Or run 'bd setup claude' to add Claude-specific documentation\n" +
 			"\n" +
 			"For local-only documentation (not committed to repo):\n" +

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -808,18 +808,37 @@ environment variable.`,
 			}
 		}
 
-		// Add agent instructions to AGENTS.md
+		// Add agent instructions to AGENTS.md (or custom filename via --agents-file)
 		// Skip in stealth mode (user wants invisible setup) or when explicitly skipped
 		if !stealth && !skipAgents {
 			agentsTemplate, _ := cmd.Flags().GetString("agents-template")
 			agentsProfileStr, _ := cmd.Flags().GetString("agents-profile")
 			agentsProfile := agents.Profile(agentsProfileStr)
+			agentsFile, _ := cmd.Flags().GetString("agents-file")
+
+			// Validate and persist custom agents filename
+			if agentsFile != "" {
+				if err := config.ValidateAgentsFile(agentsFile); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: invalid --agents-file: %v\n", err)
+					return
+				}
+				if err := config.SetYamlConfig("agents.file", agentsFile); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to persist agents.file to config: %v\n", err)
+				}
+			}
+
+			// Use flag value directly if provided (honoring user intent even if
+			// config persistence failed), otherwise read from config/default.
+			resolvedAgentsFile := agentsFile
+			if resolvedAgentsFile == "" {
+				resolvedAgentsFile = config.SafeAgentsFile()
+			}
 			if isBareGitRepo() {
 				if !quiet {
-					fmt.Printf("  Skipping AGENTS.md generation in bare repository\n")
+					fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
 				}
 			} else {
-				addAgentsInstructions(!quiet, agentsTemplate, agentsProfile)
+				addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile)
 			}
 		}
 
@@ -829,9 +848,10 @@ environment variable.`,
 		if !stealth && isGitRepo() && useLocalBeads {
 			gitAddCmd := exec.Command("git", "add", ".beads/")
 			if _, addErr := gitAddCmd.CombinedOutput(); addErr == nil {
-				// Also stage AGENTS.md if it exists
-				if _, statErr := os.Stat("AGENTS.md"); statErr == nil {
-					agentsCmd := exec.Command("git", "add", "AGENTS.md")
+				// Also stage the agents file if it exists
+				agentsFileToStage := config.SafeAgentsFile()
+				if _, statErr := os.Stat(agentsFileToStage); statErr == nil {
+					agentsCmd := exec.Command("git", "add", agentsFileToStage)
 					_ = agentsCmd.Run()
 				}
 				// Also stage .gitignore if modified by EnsureProjectGitignore
@@ -957,6 +977,7 @@ func init() {
 	initCmd.Flags().String("destroy-token", "", "Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')")
 	initCmd.Flags().String("agents-template", "", "Path to custom AGENTS.md template (overrides embedded default)")
 	initCmd.Flags().String("agents-profile", "", "AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)")
+	initCmd.Flags().String("agents-file", "", "Custom filename for agent instructions (default: AGENTS.md)")
 
 	// Backend selection (dolt is the only supported backend; sqlite accepted for deprecation notice)
 	initCmd.Flags().String("backend", "", "Storage backend (default: dolt). --backend=sqlite prints deprecation notice.")

--- a/cmd/bd/init_agent.go
+++ b/cmd/bd/init_agent.go
@@ -11,14 +11,14 @@ import (
 	"github.com/steveyegge/beads/internal/ui"
 )
 
-// addAgentsInstructions creates or updates AGENTS.md with embedded template content.
+// addAgentsInstructions creates or updates the agents file with embedded template content.
+// agentFile is the target filename (e.g. "AGENTS.md" or "BEADS.md").
 // If templatePath is non-empty, the custom template file is used instead of the embedded default.
 // profile controls which template variant to render (full or minimal); defaults to minimal.
-func addAgentsInstructions(verbose bool, templatePath string, profile agents.Profile) {
+func addAgentsInstructions(agentFile string, verbose bool, templatePath string, profile agents.Profile) {
 	if profile == "" {
 		profile = agents.ProfileMinimal
 	}
-	agentFile := "AGENTS.md"
 
 	if err := updateAgentFile(agentFile, verbose, templatePath, profile); err != nil {
 		// Non-fatal - continue with other files
@@ -35,7 +35,7 @@ func addAgentsInstructions(verbose bool, templatePath string, profile agents.Pro
 // profile is preserved to avoid information loss.
 func updateAgentFile(filename string, verbose bool, templatePath string, profile agents.Profile) error {
 	// Check if file exists
-	//nolint:gosec // G304: filename comes from hardcoded list in addAgentsInstructions
+	//nolint:gosec // G304: filename validated by config.ValidateAgentsFile or defaulted to AGENTS.md
 	content, err := os.ReadFile(filename)
 	if os.IsNotExist(err) {
 		// File doesn't exist - create from template

--- a/cmd/bd/onboard.go
+++ b/cmd/bd/onboard.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -53,7 +54,8 @@ func renderOnboardInstructions(w io.Writer) error {
 	if err := writef("\n%s\n\n", ui.RenderBold("bd Onboarding")); err != nil {
 		return err
 	}
-	if err := writeln("Add this minimal snippet to AGENTS.md (or create it):"); err != nil {
+	agentsFile := config.AgentsFile()
+	if err := writeln("Add this minimal snippet to " + agentsFile + " (or create it):"); err != nil {
 		return err
 	}
 	if err := writeBlank(); err != nil {
@@ -89,14 +91,14 @@ func renderOnboardInstructions(w io.Writer) error {
 	if err := writef("   • %s auto-injects bd prime at session start\n", ui.RenderAccent("bd hooks install")); err != nil {
 		return err
 	}
-	if err := writeln("   • AGENTS.md only needs this minimal pointer, not full instructions"); err != nil {
+	if err := writeln("   • " + agentsFile + " only needs this minimal pointer, not full instructions"); err != nil {
 		return err
 	}
 	if err := writeBlank(); err != nil {
 		return err
 	}
 
-	if err := writef("%s\n\n", ui.RenderPass("This keeps AGENTS.md lean while bd prime provides up-to-date workflow details.")); err != nil {
+	if err := writef("%s\n\n", ui.RenderPass("This keeps "+agentsFile+" lean while bd prime provides up-to-date workflow details.")); err != nil {
 		return err
 	}
 
@@ -106,14 +108,17 @@ func renderOnboardInstructions(w io.Writer) error {
 var onboardCmd = &cobra.Command{
 	Use:     "onboard",
 	GroupID: "setup",
-	Short:   "Display minimal snippet for AGENTS.md",
-	Long: `Display a minimal snippet to add to AGENTS.md for bd integration.
+	Short:   "Display minimal snippet for agent instructions file",
+	Long: `Display a minimal snippet to add to your agent instructions file for bd integration.
+
+By default, the agent instructions file is AGENTS.md. Use 'bd init --agents-file'
+to configure a different filename (e.g. BEADS.md).
 
 This outputs a small (~10 line) snippet that points to 'bd prime' for full
 workflow context. This is the same minimal profile that 'bd init' generates
 by default. This approach:
 
-  • Keeps AGENTS.md lean (doesn't bloat with instructions)
+  • Keeps your agent file lean (doesn't bloat with instructions)
   • bd prime provides dynamic, always-current workflow details
   • Hooks auto-inject bd prime at session start
 

--- a/cmd/bd/setup/agents.go
+++ b/cmd/bd/setup/agents.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/templates/agents"
 	"github.com/steveyegge/beads/internal/utils"
 )
@@ -45,7 +46,7 @@ type agentsIntegration struct {
 
 func defaultAgentsEnv() agentsEnv {
 	return agentsEnv{
-		agentsPath: "AGENTS.md",
+		agentsPath: config.SafeAgentsFile(),
 		stdout:     os.Stdout,
 		stderr:     os.Stderr,
 	}

--- a/internal/config/agents_file_test.go
+++ b/internal/config/agents_file_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAgentsFile(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		restore := envSnapshot(t)
+		defer restore()
+		if err := Initialize(); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		got := AgentsFile()
+		if got != DefaultAgentsFile {
+			t.Errorf("AgentsFile() = %q, want %q", got, DefaultAgentsFile)
+		}
+	})
+
+	t.Run("returns configured value", func(t *testing.T) {
+		restore := envSnapshot(t)
+		defer restore()
+		if err := Initialize(); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		Set("agents.file", "BEADS.md")
+		t.Cleanup(func() { Set("agents.file", "") })
+		got := AgentsFile()
+		if got != "BEADS.md" {
+			t.Errorf("AgentsFile() = %q, want %q", got, "BEADS.md")
+		}
+	})
+}
+
+func TestValidateAgentsFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "valid default", input: "AGENTS.md", wantErr: false},
+		{name: "valid custom", input: "BEADS.md", wantErr: false},
+		{name: "valid lowercase", input: "agents.md", wantErr: false},
+		{name: "valid with hyphens", input: "my-agents.md", wantErr: false},
+		{name: "valid with underscores", input: "my_agents.md", wantErr: false},
+		{name: "valid double dots in name", input: "foo..bar.md", wantErr: false},
+
+		{name: "empty", input: "", wantErr: true, errMsg: "must not be empty"},
+		{name: "absolute path", input: "/etc/passwd.md", wantErr: true, errMsg: "path separators"},
+		{name: "traversal", input: "../etc/agents.md", wantErr: true, errMsg: "path separators"},
+		{name: "forward slash", input: "docs/AGENTS.md", wantErr: true, errMsg: "path separators"},
+		{name: "backslash", input: "docs\\AGENTS.md", wantErr: true, errMsg: "path separators"},
+		{name: "wrong extension txt", input: "AGENTS.txt", wantErr: true, errMsg: ".md extension"},
+		{name: "wrong extension sh", input: "setup.sh", wantErr: true, errMsg: ".md extension"},
+		{name: "no extension", input: "AGENTS", wantErr: true, errMsg: ".md extension"},
+		{name: "too long", input: string(make([]byte, 256)) + ".md", wantErr: true, errMsg: "255 characters"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAgentsFile(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ValidateAgentsFile(%q) = nil, want error containing %q", tc.input, tc.errMsg)
+				}
+				if tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ValidateAgentsFile(%q) = %v, want nil", tc.input, err)
+				}
+			}
+		})
+	}
+}
+
+func TestSafeAgentsFile(t *testing.T) {
+	t.Run("returns default for invalid config", func(t *testing.T) {
+		restore := envSnapshot(t)
+		defer restore()
+		if err := Initialize(); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		// Simulate a maliciously edited config with path separators
+		Set("agents.file", "../evil.md")
+		t.Cleanup(func() { Set("agents.file", "") })
+		got := SafeAgentsFile()
+		if got != DefaultAgentsFile {
+			t.Errorf("SafeAgentsFile() = %q, want %q for invalid config", got, DefaultAgentsFile)
+		}
+	})
+
+	t.Run("returns valid custom value", func(t *testing.T) {
+		restore := envSnapshot(t)
+		defer restore()
+		if err := Initialize(); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		Set("agents.file", "BEADS.md")
+		t.Cleanup(func() { Set("agents.file", "") })
+		got := SafeAgentsFile()
+		if got != "BEADS.md" {
+			t.Errorf("SafeAgentsFile() = %q, want %q", got, "BEADS.md")
+		}
+	})
+
+	t.Run("returns default when unset", func(t *testing.T) {
+		restore := envSnapshot(t)
+		defer restore()
+		if err := Initialize(); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		got := SafeAgentsFile()
+		if got != DefaultAgentsFile {
+			t.Errorf("SafeAgentsFile() = %q, want %q", got, DefaultAgentsFile)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -788,6 +788,53 @@ func MetadataSchemaFields() map[string]interface{} {
 	return nil
 }
 
+// DefaultAgentsFile is the default filename for agent instructions.
+const DefaultAgentsFile = "AGENTS.md"
+
+// AgentsFile returns the configured agents instruction filename.
+// Returns DefaultAgentsFile ("AGENTS.md") if no custom value is set.
+// Note: Use SafeAgentsFile() when the value will be used for file I/O,
+// as config.yaml may be manually edited with invalid values.
+func AgentsFile() string {
+	if name := GetString("agents.file"); name != "" {
+		return name
+	}
+	return DefaultAgentsFile
+}
+
+// SafeAgentsFile returns the configured agents filename after validation.
+// If the stored config value is invalid (e.g. manually edited with traversal
+// paths), it falls back to DefaultAgentsFile and logs a warning.
+func SafeAgentsFile() string {
+	name := AgentsFile()
+	if err := ValidateAgentsFile(name); err != nil {
+		debug.Logf("config: agents.file %q failed validation (%v), using default", name, err)
+		return DefaultAgentsFile
+	}
+	return name
+}
+
+// ValidateAgentsFile checks that filename is safe to use as an agents file path.
+// It rejects absolute paths, path separators, names longer than 255 characters,
+// and non-markdown extensions. This is a pure string validation function — I/O
+// checks (e.g. symlink detection) are deferred to the file write layer.
+func ValidateAgentsFile(filename string) error {
+	if filename == "" {
+		return fmt.Errorf("agents file name must not be empty")
+	}
+	if len(filename) > 255 {
+		return fmt.Errorf("agents file name exceeds 255 characters")
+	}
+	if strings.ContainsAny(filename, "/\\") {
+		return fmt.Errorf("agents file must be a simple filename without path separators, got %q", filename)
+	}
+	ext := strings.ToLower(filepath.Ext(filename))
+	if ext != ".md" {
+		return fmt.Errorf("agents file must have .md extension, got %q", ext)
+	}
+	return nil
+}
+
 // getConfigList is a helper that retrieves a comma-separated list from config.yaml.
 func getConfigList(key string) []string {
 	if v == nil {


### PR DESCRIPTION
## Summary

Add `--agents-file` flag to `bd init` allowing users to specify a custom filename for agent instructions (default remains `AGENTS.md`). This addresses the use case where projects prefer different naming conventions (e.g. `BEADS.md`) without requiring a post-init rename.

Fixes #2737

## Changes

### Core Feature
- **`internal/config/config.go`** — `DefaultAgentsFile` constant, `AgentsFile()` accessor, `SafeAgentsFile()` with read-time validation, `ValidateAgentsFile()` (pure string validation: rejects path separators, non-`.md` extensions, >255 chars)
- **`cmd/bd/init.go`** — `--agents-file` flag registration, validation, persistence to `.beads/config.yaml` under `agents.file` key
- **`cmd/bd/init_agent.go`** — `addAgentsInstructions()` takes filename parameter instead of hardcoding

### Subsystem Ripple
- **`cmd/bd/setup/agents.go`** — `defaultAgentsEnv()` uses `config.SafeAgentsFile()` instead of hardcoded `"AGENTS.md"`
- **`cmd/bd/doctor/legacy.go`** — Shared `agentDocFiles()` helper with case-insensitive dedup; all 3 check functions use it
- **`cmd/bd/doctor/claude.go`** — Uses shared `agentDocFiles()` helper
- **`cmd/bd/onboard.go`** — Dynamic messaging references configured filename

### Tests
- **`internal/config/agents_file_test.go`** — 21 test cases: `AgentsFile()` default/custom, `ValidateAgentsFile()` 16 cases (valid + all rejection paths), `SafeAgentsFile()` 3 cases (invalid config fallback, valid custom, default)

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Config key | `agents.file` | Matches existing dotted config patterns |
| Flag name | `--agents-file` | Matches CLI conventions (`--config-file`, `--log-file`) |
| Validation | Pure string, no I/O | Avoids CWD assumptions; symlink checks deferred to write layer |
| Read safety | `SafeAgentsFile()` | Validates config on read to catch manual edits with malicious values |
| Dedup | `strings.EqualFold` | Case-insensitive comparison prevents duplicate entries on macOS/Windows |
| Persistence failure | Honor flag value | User's `--agents-file` value used for current run even if `SetYamlConfig` fails |

## Coverage

| Function | Coverage |
|----------|----------|
| `AgentsFile()` | 100% |
| `SafeAgentsFile()` | 100% |
| `ValidateAgentsFile()` | 100% |

## Usage

```bash
# Initialize with custom filename
bd init --agents-file BEADS.md

# Subsequent commands automatically use configured filename
bd setup claude    # writes to BEADS.md
bd doctor          # checks BEADS.md
bd onboard         # references BEADS.md
```

## Checklist
- [x] `gofmt` — no issues
- [x] `go vet` — clean
- [x] `golangci-lint` — 0 issues
- [x] Short tests — all pass
- [x] Full CGO tests — all pass
- [x] Race detector — no races
- [x] New functions at 100% coverage