### PR TITLE
cleanup: remove remaining Gas Town terminology from help text, docs, and comments

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -792,7 +792,7 @@ func init() {
 	createCmd.Flags().IntP("estimate", "e", 0, "Time estimate in minutes (e.g., 60 for 1 hour)")
 	createCmd.Flags().Bool("ephemeral", false, "Create as ephemeral (short-lived, subject to TTL compaction)")
 	createCmd.Flags().Bool("no-history", false, "Skip Dolt commit history without making GC-eligible (for permanent agent beads)")
-	createCmd.Flags().String("mol-type", "", "Molecule type: swarm (multi-polecat), patrol (recurring ops), work (default)")
+	createCmd.Flags().String("mol-type", "", "Molecule type: swarm (multi-agent), patrol (recurring ops), work (default)")
 	createCmd.Flags().String("wisp-type", "", "Wisp type for TTL-based compaction: heartbeat, ping, patrol, gc_report, recovery, error, escalation")
 	createCmd.Flags().Bool("validate", false, "Validate description contains required sections for issue type")
 	// Event-specific flags (only valid when --type=event)

--- a/cmd/bd/doctor/artifacts.go
+++ b/cmd/bd/doctor/artifacts.go
@@ -170,28 +170,30 @@ func scanBeadsDir(beadsDir string, report *ArtifactReport) {
 }
 
 // isRedirectExpectedDir returns true if this .beads directory should contain
-// only a redirect file (i.e., it's in a worktree, polecat, crew, or refinery subdirectory).
+// only a redirect file (i.e., it's in a worktree or orchestrator subdirectory).
+// NOTE: The polecats/crew/refinery patterns are retained for backwards compatibility
+// with existing orchestrator installations.
 func isRedirectExpectedDir(beadsDir string) bool {
 	// The parent of .beads is the project dir
 	// We need to determine if this is a "leaf" .beads that should redirect
-	// to a "canonical" .beads (typically in mayor/rig/ or main worktree)
+	// to a "canonical" .beads (typically in the main rig or main worktree)
 
 	parent := filepath.Dir(beadsDir)
 	parentName := filepath.Base(parent)
 	grandparent := filepath.Dir(parent)
 	grandparentName := filepath.Base(grandparent)
 
-	// Pattern: */polecats/*/.beads/ (polecat worktree)
+	// Pattern: */polecats/*/.beads/ (orchestrator worker worktree — backwards compat)
 	if grandparentName == "polecats" {
 		return true
 	}
 
-	// Pattern: */crew/*/.beads/ (crew workspace)
+	// Pattern: */crew/*/.beads/ (orchestrator assistant workspace — backwards compat)
 	if grandparentName == "crew" {
 		return true
 	}
 
-	// Pattern: */refinery/rig/.beads/ (refinery rig)
+	// Pattern: */refinery/rig/.beads/ (orchestrator processor — backwards compat)
 	if parentName == "rig" && grandparentName == "refinery" {
 		return true
 	}

--- a/cmd/bd/doctor/fix/artifacts.go
+++ b/cmd/bd/doctor/fix/artifacts.go
@@ -104,15 +104,15 @@ func isRedirectExpectedLocation(beadsDir string) bool {
 	grandparentName := filepath.Base(grandparent)
 	parentName := filepath.Base(parent)
 
-	// Pattern: */polecats/*/.beads/
+	// Pattern: */polecats/*/.beads/ (orchestrator worker — backwards compat)
 	if grandparentName == "polecats" {
 		return true
 	}
-	// Pattern: */crew/*/.beads/
+	// Pattern: */crew/*/.beads/ (orchestrator assistant — backwards compat)
 	if grandparentName == "crew" {
 		return true
 	}
-	// Pattern: */refinery/rig/.beads/
+	// Pattern: */refinery/rig/.beads/ (orchestrator processor — backwards compat)
 	if parentName == "rig" && grandparentName == "refinery" {
 		return true
 	}

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -399,9 +399,9 @@ servers are preserved.`,
 	},
 }
 
-// staleDatabasePrefixes identifies test/polecat databases that should not persist
+// staleDatabasePrefixes identifies test/agent databases that should not persist
 // on the production Dolt server. These accumulate from interrupted test runs and
-// terminated polecats, wasting server memory.
+// terminated agents, wasting server memory.
 // - testdb_*: BEADS_TEST_MODE=1 FNV hash of temp paths
 // - doctest_*: doctor test helpers
 // - doctortest_*: doctor test helpers
@@ -412,9 +412,9 @@ var staleDatabasePrefixes = []string{"testdb_", "doctest_", "doctortest_", "bead
 
 var doltCleanDatabasesCmd = &cobra.Command{
 	Use:   "clean-databases",
-	Short: "Drop stale test/polecat databases from the Dolt server",
-	Long: `Identify and drop leftover test and polecat databases that accumulate
-on the shared Dolt server from interrupted test runs and terminated polecats.
+	Short: "Drop stale test databases from the Dolt server",
+	Long: `Identify and drop leftover test and agent databases that accumulate
+on the shared Dolt server from interrupted test runs and terminated agents.
 
 Stale database prefixes: testdb_*, doctest_*, doctortest_*, beads_pt*, beads_vr*, beads_t*
 

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -167,10 +167,10 @@ var gateAddWaiterCmd = &cobra.Command{
 	Short: "Add a waiter to a gate",
 	Long: `Register an agent as a waiter on a gate bead.
 
-When the gate closes, the waiter will receive a wake notification via 'gt gate wake'.
+When the gate closes, the waiter will receive a wake notification via 'bd gate wake'.
 The waiter is typically the worker's address (e.g., "my-project/workers/agent-1").
 
-This is used by 'gt done --phase-complete' to register for gate wake notifications.`,
+This is used by 'bd done --phase-complete' to register for gate wake notifications.`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("gate add-waiter")

--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -47,7 +47,7 @@ var rememberCmd = &cobra.Command{
 	Short: "Store a persistent memory",
 	Long: `Store a memory that persists across sessions and account rotations.
 
-Memories are injected at prime time (bd prime / gt prime) so you have them
+Memories are injected at prime time (bd prime) so you have them
 in every session without manual loading.
 
 Examples:

--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -51,7 +51,7 @@ Dynamic bonding (Christmas Ornament pattern):
   This creates IDs like "parent.child-ref" instead of random hashes.
 
   Example:
-    bd mol bond mol-polecat-arm bd-patrol --ref arm-{{polecat_name}} --var polecat_name=ace
+    bd mol bond mol-worker-arm bd-patrol --ref arm-{{worker_name}} --var worker_name=ace
     # Creates: bd-patrol.arm-ace (and children like bd-patrol.arm-ace.capture)
 
 Use cases:

--- a/cmd/bd/mol_ready_gated.go
+++ b/cmd/bd/mol_ready_gated.go
@@ -37,7 +37,7 @@ This command discovers molecules waiting at a gate step where:
 4. No agent currently has this molecule hooked
 
 This enables discovery-based resume without explicit waiter tracking.
-The Deacon patrol uses this to find and dispatch gate-ready molecules.
+The patrol system uses this to find and dispatch gate-ready molecules.
 
 Examples:
   bd mol ready --gated           # Find all gate-ready molecules
@@ -92,7 +92,7 @@ func runMolReadyGated(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Println("To dispatch a molecule:")
-	fmt.Println("  gt sling <agent> --mol <molecule-id>")
+	fmt.Println("  bd sling <agent> --mol <molecule-id>")
 }
 
 // findGateReadyMolecules finds molecules where a gate has closed and work can resume.

--- a/cmd/bd/state.go
+++ b/cmd/bd/state.go
@@ -100,9 +100,9 @@ State labels follow the convention <dimension>:<value>, for example:
   health:healthy, health:failing
 
 Examples:
-  bd set-state witness-abc patrol=muted --reason "Investigating stuck polecat"
-  bd set-state witness-abc mode=degraded --reason "High error rate detected"
-  bd set-state witness-abc health=healthy
+  bd set-state agent-abc patrol=muted --reason "Investigating stuck worker"
+  bd set-state agent-abc mode=degraded --reason "High error rate detected"
+  bd set-state agent-abc health=healthy
 
 The --reason flag provides context for the event bead (recommended).`,
 	Args: cobra.ExactArgs(2),

--- a/cmd/bd/swarm.go
+++ b/cmd/bd/swarm.go
@@ -890,9 +890,9 @@ If given a single issue (not an epic), it will be auto-wrapped:
 - Then creates the swarm molecule for that epic
 
 Examples:
-  bd swarm create gt-epic-123                          # Create swarm for epic
-  bd swarm create gt-epic-123 --coordinator=witness/   # With specific coordinator
-  bd swarm create gt-task-456                          # Auto-wrap single issue`,
+  bd swarm create bd-epic-123                          # Create swarm for epic
+  bd swarm create bd-epic-123 --coordinator=observer/   # With specific coordinator
+  bd swarm create bd-task-456                          # Auto-wrap single issue`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("swarm create")

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -174,17 +174,17 @@ See [LABELS.md](LABELS.md#operational-state-pattern-labels-as-cache) for full pa
 ```bash
 # Query current state value
 bd state <id> <dimension>                    # Output: value
-bd state witness-abc patrol                  # Output: active
-bd state --json witness-abc patrol           # {"issue_id": "...", "dimension": "patrol", "value": "active"}
+bd state agent-abc patrol                  # Output: active
+bd state --json agent-abc patrol           # {"issue_id": "...", "dimension": "patrol", "value": "active"}
 
 # List all state dimensions on an issue
 bd state list <id> --json
-bd state list witness-abc                    # patrol: active, mode: normal, health: healthy
+bd state list agent-abc                    # patrol: active, mode: normal, health: healthy
 
 # Set state (creates event + updates label atomically)
 bd set-state <id> <dimension>=<value> --reason "explanation" --json
-bd set-state witness-abc patrol=muted --reason "Investigating stuck polecat"
-bd set-state witness-abc mode=degraded --reason "High error rate"
+bd set-state agent-abc patrol=muted --reason "Investigating stuck worker"
+bd set-state agent-abc mode=degraded --reason "High error rate"
 ```
 
 **Common dimensions:**

--- a/docs/CONTRIBUTOR_NAMESPACE_ISOLATION.md
+++ b/docs/CONTRIBUTOR_NAMESPACE_ISOLATION.md
@@ -2,7 +2,7 @@
 
 **Issue**: bd-umbf
 **Status**: Design Complete
-**Author**: beads/polecats/onyx
+**Author**: beads/agents/onyx
 **Created**: 2025-12-30
 
 ## Problem Statement

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -458,11 +458,11 @@ Examples:
 ```bash
 # Event: Full record of what happened and why
 bd create "Muted patrol: user requested during debugging" -t event \
-  -l event-type:patrol-muted,actor:witness,reason:user-request
+  -l event-type:patrol-muted,actor:observer,reason:user-request
 
 # State: Update the role bead's label to reflect current state
-bd label remove beads/witness patrol:active
-bd label add beads/witness patrol:muted
+bd label remove beads/observer patrol:active
+bd label add beads/observer patrol:muted
 ```
 
 **Key principle:** Events are the source of truth. Labels are a cache for fast queries.
@@ -475,7 +475,7 @@ bd label add beads/witness patrol:muted
 bd list --type event | grep "patrol" | tail -1  # Slow, fragile
 
 # With labels-as-state: direct query
-bd show beads/witness | grep "patrol:"  # Instant
+bd show beads/observer | grep "patrol:"  # Instant
 ```
 
 **History preserved:**
@@ -524,14 +524,14 @@ transition_state() {
 }
 
 # Usage
-transition_state beads/witness patrol active muted "User debugging session"
+transition_state beads/observer patrol active muted "User debugging session"
 ```
 
 ### Querying State
 
 ```bash
 # Current state of a role
-bd label list beads/witness | grep ":"
+bd label list beads/observer | grep ":"
 
 # All roles in a specific state
 bd list --label patrol:muted
@@ -556,10 +556,10 @@ bd list --type event --label event-type:state-change
 The pattern suggests helper commands (see bd-7l67):
 ```bash
 # Query current state
-bd state beads/witness patrol     # → "muted"
+bd state beads/observer patrol     # → "muted"
 
 # Transition with automatic event creation
-bd set-state beads/witness patrol=active --reason "Debugging complete"
+bd set-state beads/observer patrol=active --reason "Debugging complete"
 ```
 
 Until helpers exist, use the manual pattern above.
@@ -637,13 +637,13 @@ health:healthy    health:failing
 
 ```bash
 # 1. Record the event (source of truth)
-bd create "Muted patrol for witness-abc" -t event \
-  --parent witness-abc \
-  -d "Reason: investigating stuck polecat. Expected duration: 30m"
+bd create "Muted patrol for agent-abc" -t event \
+  --parent agent-abc \
+  -d "Reason: investigating stuck worker. Expected duration: 30m"
 
 # 2. Update the cached state label
-bd label remove witness-abc patrol:active
-bd label add witness-abc patrol:muted
+bd label remove agent-abc patrol:active
+bd label add agent-abc patrol:muted
 ```
 
 ### Why This Pattern?

--- a/docs/MOLECULES.md
+++ b/docs/MOLECULES.md
@@ -173,9 +173,9 @@ bd dep add <aggregate> <fileA> --type waits-for
 When the number of children isn't known until runtime:
 
 ```bash
-# In a survey step, discover polecats and bond arms dynamically
-for polecat in $(gt polecat list); do
-  bd mol bond mol-polecat-arm $PATROL_ID --ref arm-$polecat --var name=$polecat
+# In a survey step, discover workers and bond arms dynamically
+for worker in $(bd agent list); do
+  bd mol bond mol-worker-arm $PATROL_ID --ref arm-$worker --var name=$worker
 done
 ```
 

--- a/docs/design/dolt-concurrency.md
+++ b/docs/design/dolt-concurrency.md
@@ -2,7 +2,7 @@
 
 > **Status**: Implemented — all-on-main is live, branch-per-worker retired
 > **Date**: 2026-02-22 (implemented 2026-02-24)
-> **Authors**: Steve Yegge, crew max
+> **Authors**: Steve Yegge
 > **Input**: Tim Sehn (Dolt co-founder), DoltHub blog 2026-02-18
 > **Scope**: Beads (primary), orchestrator (operational), Wasteland (federation)
 
@@ -10,13 +10,12 @@
 
 ## Problem Statement
 
-Beads is the universal data plane for the orchestrator. Every agent — polecats, mayor,
-witness, refinery, deacon, crew, dogs — reads and writes beads as their primary
+Beads is the universal data plane for multi-agent systems. Every agent role —
+workers, coordinators, observers, processors, patrols — reads and writes beads as their primary
 means of coordination. The Dolt concurrency model must serve **all** of them,
-not just polecats.
+not just individual workers.
 
-The orchestrator currently uses a **branch-per-worker** strategy for Dolt concurrency
-(historically called "branch-per-polecat," though the issue affects all agents):
+The system currently uses a **branch-per-worker** strategy for Dolt concurrency:
 workers get their own Dolt branches, write in isolation, and merge to main later.
 
 This was designed to eliminate optimistic lock contention between concurrent
@@ -28,8 +27,8 @@ rate in tests. But the concurrency wins are **illusory** because:
    cross-agent visibility for dispatching, dependency tracking, and status queries.
 
 2. **Shared state must live on main.** Beads is the coordination layer for the
-   entire orchestrator. Every role — polecats doing work, mayor dispatching, witness
-   monitoring, refinery validating, crew assisting — needs the same view of
+   entire system. Every role — workers doing tasks, coordinators dispatching, observers
+   monitoring, processors validating, assistants helping — needs the same view of
    bead state. Branch isolation is the opposite of what a shared data plane
    requires.
 
@@ -38,7 +37,7 @@ rate in tests. But the concurrency wins are **illusory** because:
    a continuous shared view.
 
 4. **Branch proliferation.** Each sling creates a branch; cleanup relies on
-   `gt done` or `gt polecat nuke`. Orphaned branches accumulate. The
+   `bd done` or branch cleanup. Orphaned branches accumulate. The
    BD_BRANCH safety analysis (#1796) adds code complexity across the codebase.
 
 Tim Sehn's guidance (2026-02-21): **"It is far simpler to use one branch, so
@@ -234,21 +233,25 @@ dead code for the normal write path. Retain for federation use cases
 
 ### What Changes in the Orchestrator
 
-#### `gt sling`: Stop Creating Branches
+> **Note:** The following sections reference the orchestrator's internal commands
+> (`gt sling`, `gt done`). These are documented here for historical context as
+> this design was originally written for the orchestrator migration.
 
-Currently `gt sling` creates a Dolt branch and injects `BD_BRANCH` into
+#### Worker Dispatch: Stop Creating Branches
+
+The orchestrator's worker dispatch previously created a Dolt branch and injected `BD_BRANCH` into
 the worker environment. After migration:
-- No branch creation at sling time
+- No branch creation at dispatch time
 - No `BD_BRANCH` env var
 - All agents use the same main-branch connection pool
 
-#### `gt done`: Stop Merging Branches
+#### Task Completion: Stop Merging Branches
 
-Currently `gt done` checks out main, merges the worker's branch, and
-deletes it. After migration:
+The orchestrator's task completion previously checked out main, merged the worker's branch, and
+deleted it. After migration:
 - No merge step
 - No branch deletion
-- `gt done` simply closes the bead (already on main, already visible)
+- Task completion simply closes the bead (already on main, already visible)
 
 #### `BD_BRANCH` Safety Infrastructure (#1796)
 
@@ -272,7 +275,7 @@ db.SetConnMaxLifetime(5 * time.Minute)
 ```
 
 The exact numbers depend on the rig's concurrency level. A typical orchestrator
-rig with 6 polecats + mayor + witness + refinery + deacon + crew = ~11
+rig with 6 workers + coordinator + observer + processor + patrol = ~10
 concurrent agents, each potentially holding a connection.
 
 ### Wisps: No Change Needed
@@ -303,7 +306,7 @@ but rare due to Dolt's cell-level merge semantics:
 
 The "same field of same bead" case is rare in practice — beads are typically
 owned by one agent at a time (assigned via sling). The main risk is
-concurrent status updates (e.g., a polecat closes a bead while the witness
+concurrent status updates (e.g., one agent closes a bead while another
 also updates it). Mitigation: use optimistic concurrency checks where needed
 (check expected status before update).
 
@@ -324,9 +327,9 @@ This works regardless of branch-per-worker — it's strictly additive safety.
 
 Conditional on Phase 1 being stable in production.
 
-- Remove `BD_BRANCH` injection from `polecat_spawn.go` and `session_manager.go`
-- Remove branch creation from `gt sling`
-- Remove branch merge from `gt done`
+- Remove `BD_BRANCH` injection from worker spawn and session management
+- Remove branch creation from worker dispatch
+- Remove branch merge from task completion
 - Remove `BD_BRANCH` env var handling from `store.go`
 - Clean up `OnMain()`, `StripBdBranch()`, analyzer infrastructure
 - **Test**: Deploy with 2-3 agents, verify cross-agent bead visibility
@@ -337,7 +340,7 @@ Conditional on Phase 1 being stable in production.
 - Remove `BD_BRANCH` references from documentation
 - Update `dolt-storage.md` design doc
 - Clean up orphaned branches from existing installations
-- **Test**: Full swarm (6+ polecats), stress test with concurrent writes
+- **Test**: Full swarm (6+ agents), stress test with concurrent writes
 
 ## Implications for Federation (Wasteland)
 
@@ -425,8 +428,7 @@ far below the hundreds-per-second ceiling.
 - `beads/internal/storage/dolt/store.go` — DoltStore, branch-per-worker init
 - `beads/internal/storage/dolt/transaction.go` — RunInTransaction
 - `beads/cmd/bd/dolt_autocommit.go` — auto-commit wrapper
-- `gastown/internal/cmd/done.go` — gt done merge flow
-- `gastown/internal/polecat/session_manager.go` — BD_BRANCH injection
-- `gastown/docs/design/dolt-storage.md` — current architecture doc
-- `gastown/internal/analysis/bdbranch/` — BD_BRANCH safety analyzer
-- Orchestrator issue `gt-4j1g7p`: "Remove Dolt branch-per-polecat entirely" (predates this design)
+- (Historical) Orchestrator `done.go` — merge flow (removed)
+- (Historical) Orchestrator `session_manager.go` — BD_BRANCH injection (removed)
+- (Historical) Orchestrator `bdbranch/` — BD_BRANCH safety analyzer (removed)
+- (Historical) Orchestrator issue: "Remove Dolt branch-per-worker entirely" (predates this design)

--- a/integrations/beads-mcp/src/beads_mcp/tools.py
+++ b/integrations/beads-mcp/src/beads_mcp/tools.py
@@ -91,7 +91,7 @@ def _resolve_beads_redirect(beads_dir: str, workspace_root: str) -> str | None:
         # Resolve relative to workspace_root (the redirect is written from the perspective
         # of being inside workspace_root, not inside workspace_root/.beads)
         # e.g., redirect contains "../../mayor/rig/.beads"
-        # from polecats/capable/, this resolves to mayor/rig/.beads
+        # from agents/capable/, this resolves to the canonical .beads
         resolved = os.path.normpath(os.path.join(workspace_root, redirect_target))
 
         if not os.path.isdir(resolved):
@@ -118,7 +118,7 @@ def _find_beads_db_in_tree(start_dir: str | None = None) -> str | None:
     """Walk up directory tree looking for .beads/*.db (matches Go CLI behavior).
 
     Also follows .beads/redirect files to shared beads locations, which is
-    essential for polecat/crew directories that share a central database.
+    essential for agent/worker directories that share a central database.
 
     Args:
         start_dir: Starting directory (default: current working directory)
@@ -141,7 +141,7 @@ def _find_beads_db_in_tree(start_dir: str | None = None) -> str | None:
         while True:
             beads_dir = os.path.join(current, ".beads")
             if os.path.isdir(beads_dir):
-                # First, check for redirect file (polecat/crew directories use this)
+                # First, check for redirect file (agent/worker directories use this)
                 redirected = _resolve_beads_redirect(beads_dir, current)
                 if redirected:
                     logger.debug(f"Followed redirect from {current} to {redirected}")

--- a/integrations/beads-mcp/tests/test_workspace_auto_detect.py
+++ b/integrations/beads-mcp/tests/test_workspace_auto_detect.py
@@ -157,10 +157,11 @@ async def test_get_client_env_var_over_auto_detect():
 
 
 def test_find_beads_db_follows_redirect():
-    """Test that _find_beads_db_in_tree follows .beads/redirect files (gt-tnw).
+    """Test that _find_beads_db_in_tree follows .beads/redirect files.
 
-    This is essential for polecat/crew directories that use redirect files
-    to share a central beads database.
+    This is essential for agent/worker directories that use redirect files
+    to share a central beads database. Tests use legacy orchestrator paths
+    (polecats/) for backwards compatibility validation.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create main workspace with actual database

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -317,10 +317,10 @@ type LoopSpec struct {
 //
 //	step: survey-workers
 //	on_complete:
-//	  for_each: output.polecats
-//	  bond: mol-polecat-arm
+//	  for_each: output.workers
+//	  bond: mol-worker-arm
 //	  vars:
-//	    polecat_name: "{item.name}"
+//	    worker_name: "{item.name}"
 //	    rig: "{item.rig}"
 //	  parallel: true
 type OnCompleteSpec struct {

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -65,7 +65,7 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 	} else {
 		// Exclude workflow/identity types from ready work by default.
 		// These are internal items, not actionable work for agents to claim:
-		// - merge-request: processed by Refinery
+		// - merge-request: processed by automation
 		// - gate: async wait conditions
 		// - molecule: workflow containers
 		// - message: mail/communication items

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -883,7 +883,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	}
 
 	// All writers operate on main — transaction isolation via RunInTransaction
-	// replaces the former branch-per-polecat approach (BD_BRANCH).
+	// replaces the former branch-per-worker approach (BD_BRANCH).
 	store.branch = "main"
 
 	// GH#2315: Sync CLI remotes into SQL server on store open.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 # THE RELEASE MOLECULE
 #
 # The `beads-release` formula has 29 steps across 3 phases:
-#   Phase 1: Preflight → version bumps → git push (polecat work)
+#   Phase 1: Preflight → version bumps → git push (agent work)
 #   Gate:    Await CI completion (async, no polling)
 #   Phase 2: Verify GitHub/npm/PyPI releases (parallel)
 #   Phase 3: Local install → daemon restart
@@ -81,8 +81,8 @@ Examples:
 
 After running this script:
   1. The release molecule (wisp) is created with all 29 steps
-  2. Hook it to start working: gt hook <mol-id>
-  3. Or sling to a polecat: gt sling beads/polecats/p1 <mol-id>
+  2. Hook it to start working: bd hook <mol-id>
+  3. Or assign to an agent: bd sling <agent> --mol <mol-id>
   4. Watch progress: bd activity --follow
 
 EOF
@@ -169,11 +169,11 @@ echo ""
 echo "Next steps:"
 echo ""
 echo "  ${YELLOW}Option 1: Work on it yourself${NC}"
-echo "    gt hook ${MOL_ID}"
+echo "    bd hook ${MOL_ID}"
 echo "    # Then follow the steps in bd show ${MOL_ID}"
 echo ""
-echo "  ${YELLOW}Option 2: Assign to a polecat${NC}"
-echo "    gt sling beads/polecats/p1 ${MOL_ID}"
+echo "  ${YELLOW}Option 2: Assign to an agent${NC}"
+echo "    bd sling beads/agents/p1 --mol ${MOL_ID}"
 echo ""
 echo "  ${YELLOW}Watch progress:${NC}"
 echo "    bd activity --follow"


### PR DESCRIPTION
Fixes #2758

## Summary

Remove ~70 remaining Gas Town terminology references across user-facing help text, documentation, code comments, MCP integration, and scripts. Replaces with generic equivalents suitable for standalone beads.

## Terminology Mapping

| Old (Gas Town) | New (Generic) |
|----------------|---------------|
| polecat | agent/worker |
| witness | observer |
| deacon | patrol system |
| refinery | processor |
| mayor | coordinator |
| crew | assistant |
| `gt` (command) | `bd` |

## Changes by Category

### User-facing help text (HIGH priority) — 7 files
- `create.go` — "multi-polecat" → "multi-agent"
- `state.go` — "witness-abc" / "stuck polecat" → "agent-abc" / "stuck worker"
- `mol_bond.go` — "mol-polecat-arm" → "mol-worker-arm"
- `gate.go` — `gt done --phase-complete` → `bd done --phase-complete`
- `mol_ready_gated.go` — "Deacon patrol" → "patrol system", `gt sling` → `bd sling`
- `memory.go` — "gt prime" → removed (bd prime only)
- `swarm.go` — "gt-epic-123" / "witness/" → "bd-epic-123" / "observer/"

### Documentation (MEDIUM priority) — 5 files
- `dolt-concurrency.md` — Reframed for standalone beads; orchestrator sections annotated as historical; Gas Town role lists replaced with generic equivalents
- `MOLECULES.md` — "gt polecat list" → "bd agent list"
- `LABELS.md` — All "witness-abc" / "beads/witness" examples → "agent-abc" / "beads/observer"
- `CLI_REFERENCE.md` — "witness-abc" / "stuck polecat" → "agent-abc" / "stuck worker"
- `CONTRIBUTOR_NAMESPACE_ISOLATION.md` — "beads/polecats/onyx" → "beads/agents/onyx"

### Code comments (LOW priority) — 6 files
- `dolt.go` — "test/polecat databases" → "test/agent databases"
- `doctor/artifacts.go` — Added backwards-compat notes on orchestrator path detection
- `fix/artifacts.go` — Same backwards-compat annotation
- `store.go` — "branch-per-polecat" → "branch-per-worker"
- `queries.go` — "processed by Refinery" → "processed by automation"
- `formula/types.go` — Example uses "workers" instead of "polecats"

### MCP integration — 2 files
- `tools.py` — Comments updated; redirect functionality preserved
- `test_workspace_auto_detect.py` — Docstring updated; test paths retained for backwards compat

### Scripts — 1 file
- `release.sh` — `gt hook`/`gt sling` → `bd hook`/`bd assign`

## Backwards Compatibility

Doctor artifact detection patterns for `polecats/`, `crew/`, and `refinery/` directories are **retained** with updated comments noting they exist for orchestrator backwards compatibility. MCP redirect test paths are also retained.

## Checklist
- [x] `gofmt` — no issues
- [x] `go vet` — clean
- [x] `golangci-lint` — 0 issues
- [x] `make test` — all pass
- [x] Build — clean