### PR TITLE
docs: add Lista Beads VS Code extension to community tools

### DIFF
--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -27,6 +27,8 @@ A curated list of community-built UIs, extensions, and integrations for Beads. R
 
 - **[opencode-beads](https://github.com/joshuadavidthomas/opencode-beads)** - OpenCode plugin with automatic context injection, `/bd-*` slash commands, and autonomous task agent. Built by [@joshuadavidthomas](https://github.com/joshuadavidthomas). (Node.js)
 
+- **[Lista Beads](https://marketplace.visualstudio.com/items?itemName=ListaDev.lista-beads)** - Full-featured VS Code extension: filterable tree view, issue detail panel, dashboard with metrics, dependency graph, Dolt push/pull, CodeLens for bead references, wisps & formula support, stale issue management, and multi-tracker sync (Azure DevOps, GitHub, Jira, Linear, GitLab). Built by [@harry-miller-trimble](https://github.com/harry-miller-trimble). (TypeScript)
+
 - **[nvim-beads (fancypantalons)](https://github.com/fancypantalons/nvim-beads)** - Neovim plugin for managing Beads issues. By [@fancypantalons](https://github.com/fancypantalons). (Lua)
 
 - **[beads-manager](https://plugins.jetbrains.com/plugin/30089-beads-manager)** - Jetbrains IDE plugin to manage and view bead details. Maintained by [@developmeh](https://github.com/developmeh). (Kotlin)


### PR DESCRIPTION
Add [Lista Beads](https://marketplace.visualstudio.com/items?itemName=ListaDev.lista-beads) to the Editor Extensions section of `docs/COMMUNITY_TOOLS.md`.

## What is Lista Beads?

A full-featured VS Code extension for browsing, managing, and acting on beads issues without leaving the editor. Key features:

- **Tree view** with filtering, pagination, and inline actions
- **Issue detail panel** with full metadata
- **Dashboard** with metrics, velocity sparklines, and team overview
- **Dependency graph** visualization
- **Dolt sync** with push/pull controls
- **CodeLens** for bead references in code
- **Wisps & formulas** support
- **Stale issue management**
- **Multi-tracker sync** (Azure DevOps, GitHub, Jira, Linear, GitLab)

## Changes

- Added Lista Beads entry to Editor Extensions in `docs/COMMUNITY_TOOLS.md`
- Placed after existing established extensions (vscode-beads, opencode-beads)