### PR TITLE
test: add multi-process concurrency and server lifecycle integration tests

### DIFF
--- a/internal/doltserver/dirty_state_test.go
+++ b/internal/doltserver/dirty_state_test.go
@@ -1,0 +1,303 @@
+//go:build integration && !windows
+
+package doltserver_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+)
+
+// TestDirtyState_StalePIDAliveNonDolt verifies that Start() recovers when the
+// PID file contains the PID of a live non-dolt process.
+// Would have caught: false-positive IsRunning when PID recycled to a different process.
+func TestDirtyState_StalePIDAliveNonDolt(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Start a non-dolt process.
+	sleepCmd := exec.Command("sleep", "120")
+	if err := sleepCmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sleepCmd.Process.Signal(syscall.SIGTERM)
+		_ = sleepCmd.Wait()
+	})
+
+	// Write its PID as the server PID.
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.WriteStalePID(sleepCmd.Process.Pid)
+	corruptor.WriteStalePort(13306)
+
+	// IsRunning should detect non-dolt process.
+	state, err := doltserver.IsRunning(beadsDir)
+	if err != nil {
+		t.Fatalf("IsRunning: %v", err)
+	}
+	if state.Running {
+		t.Error("IsRunning returned true for non-dolt PID")
+	}
+
+	// Start should succeed after cleaning up stale state.
+	startState, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !startState.Running {
+		t.Fatal("Start returned Running=false")
+	}
+	if p, err := os.FindProcess(startState.PID); err == nil {
+		reg.Register(p)
+	}
+
+	// Verify the sleep process was NOT killed (wrong process protection).
+	if !integration.IsProcessAlive(sleepCmd.Process.Pid) {
+		t.Error("sleep process was killed — Start should not kill non-dolt processes")
+	}
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(startState.PID)
+}
+
+// TestDirtyState_StalePIDDead verifies recovery when the PID file points
+// to a process that no longer exists.
+// Would have caught: GH#2559 (system restart breaks all Dolt connections).
+func TestDirtyState_StalePIDDead(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Write a PID that doesn't exist.
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.WriteStalePID(99999999)
+	corruptor.WriteStalePort(13306)
+
+	// IsRunning should return false and clean up.
+	state, err := doltserver.IsRunning(beadsDir)
+	if err != nil {
+		t.Fatalf("IsRunning: %v", err)
+	}
+	if state.Running {
+		t.Error("IsRunning returned true for dead PID")
+	}
+
+	// PID file should be cleaned up.
+	if integration.FileExists(corruptor.PIDFilePath()) {
+		t.Error("PID file not cleaned up after detecting dead PID")
+	}
+
+	// Start should succeed.
+	startState, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if p, err := os.FindProcess(startState.PID); err == nil {
+		reg.Register(p)
+	}
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(startState.PID)
+}
+
+// TestDirtyState_StalePortOnly verifies recovery when a port file exists
+// but no PID file is present.
+func TestDirtyState_StalePortOnly(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Write only a stale port file.
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.WriteStalePort(13306)
+
+	// Start should succeed.
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !state.Running {
+		t.Fatal("Start returned Running=false")
+	}
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}
+
+// TestDirtyState_CorruptPIDFile verifies recovery when the PID file contains
+// non-numeric content.
+func TestDirtyState_CorruptPIDFile(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.WriteCorruptPID()
+	corruptor.WriteStalePort(13306)
+
+	// IsRunning should return false and clean up corrupt files.
+	state, err := doltserver.IsRunning(beadsDir)
+	if err != nil {
+		t.Fatalf("IsRunning: %v", err)
+	}
+	if state.Running {
+		t.Error("IsRunning returned true for corrupt PID file")
+	}
+	if integration.FileExists(corruptor.PIDFilePath()) {
+		t.Error("corrupt PID file not cleaned up")
+	}
+	if integration.FileExists(corruptor.PortFilePath()) {
+		t.Error("port file not cleaned up alongside corrupt PID")
+	}
+}
+
+// TestDirtyState_TruncatedMetadata verifies that truncated metadata.json
+// does not cause a panic.
+func TestDirtyState_TruncatedMetadata(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.WriteTruncatedMetadata()
+
+	// Start should not panic. It may succeed (ignoring corrupt metadata)
+	// or return an error — either is acceptable.
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Logf("Start returned error (acceptable): %v", err)
+		return
+	}
+
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}
+
+// TestDirtyState_PortZero verifies recovery when port file contains "0".
+// Would have caught: GH#2598 (port 0 in state file poisons circuit breaker).
+func TestDirtyState_PortZero(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.WritePortZero()
+
+	// Start should succeed — port 0 is treated as "no port".
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if state.Port == 0 {
+		t.Error("Start returned port 0 — should have allocated a real port")
+	}
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}
+
+// TestDirtyState_CombinedStalePIDAndPort verifies recovery when both PID and
+// port files are stale (e.g., after an unclean system shutdown).
+// Would have caught: GH#2559 (init --force required after system restart).
+func TestDirtyState_CombinedStalePIDAndPort(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.CreateCombinedStaleState(99999999, 13306)
+
+	// Start should clean up and succeed.
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !state.Running {
+		t.Fatal("Start returned Running=false")
+	}
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	// Verify we can actually connect.
+	db := connectMySQL(t, state.Port)
+	if _, err := db.Exec("SELECT 1"); err != nil {
+		t.Errorf("server not connectable after dirty state recovery: %v", err)
+	}
+	_ = db.Close()
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}
+
+// TestDirtyState_OrphanNomsLock verifies that an orphaned 0-byte noms LOCK
+// file (from a power loss) does not prevent server startup.
+func TestDirtyState_OrphanNomsLock(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	doltDir := filepath.Join(beadsDir, "dolt")
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.CreateOrphanNomsLock(doltDir)
+
+	// Verify the lock file exists.
+	lockPath := filepath.Join(doltDir, "noms", "LOCK")
+	if !integration.FileExists(lockPath) {
+		t.Fatal("orphan LOCK file was not created")
+	}
+
+	// Start should succeed (dolt handles orphan LOCK files).
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		// Some dolt versions may fail here — log but don't hard-fail.
+		t.Logf("Start with orphan LOCK: %v (may be dolt version dependent)", err)
+		return
+	}
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	// Give server time to initialize.
+	time.Sleep(1 * time.Second)
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}

--- a/internal/doltserver/lifecycle_integration_test.go
+++ b/internal/doltserver/lifecycle_integration_test.go
@@ -1,0 +1,464 @@
+//go:build integration && !windows
+
+package doltserver_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+)
+
+// setupLifecycleTestDir creates a temp .beads directory with an initialized
+// dolt database. Returns the beadsDir path.
+func setupLifecycleTestDir(t *testing.T) string {
+	t.Helper()
+	integration.RequireDolt(t)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
+		t.Fatalf("failed to create beads dir: %v", err)
+	}
+
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0700); err != nil {
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+
+	cmd := exec.Command("dolt", "init")
+	cmd.Dir = doltDir
+	cmd.Env = append(os.Environ(), "HOME="+tmpDir, "DOLT_ROOT_PATH="+tmpDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt init failed: %v\n%s", err, out)
+	}
+
+	// Ensure no shared server mode interference.
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	t.Setenv("BEADS_DOLT_AUTO_START", "1")
+
+	return beadsDir
+}
+
+// connectMySQL opens a MySQL connection to the dolt server.
+// Caller is responsible for closing the returned *sql.DB.
+func connectMySQL(t *testing.T, port int) *sql.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("root@tcp(127.0.0.1:%d)/", port)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	return db
+}
+
+// TestLifecycle_StartStopCycle verifies the basic server lifecycle:
+// Start → verify state files → connect → execute SQL → Stop → verify cleanup.
+// Would have caught: GH#2542 (zombie servers not cleaning up state files).
+func TestLifecycle_StartStopCycle(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Start server.
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !state.Running {
+		t.Fatal("Start returned state.Running=false")
+	}
+	if state.PID == 0 {
+		t.Fatal("Start returned PID=0")
+	}
+	if state.Port == 0 {
+		t.Fatal("Start returned Port=0")
+	}
+	// Track for cleanup.
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	t.Logf("Server started: PID=%d Port=%d", state.PID, state.Port)
+
+	// Verify state files exist.
+	pidFile := filepath.Join(beadsDir, doltserver.PIDFileName)
+	portFile := filepath.Join(beadsDir, doltserver.PortFileName)
+	if !integration.FileExists(pidFile) {
+		t.Error("PID file does not exist after Start")
+	}
+	if !integration.FileExists(portFile) {
+		t.Error("port file does not exist after Start")
+	}
+
+	// Connect and execute SQL.
+	db := connectMySQL(t, state.Port)
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS lifecycle_test (id INT PRIMARY KEY, val VARCHAR(100))"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO lifecycle_test VALUES (1, 'hello')"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+	var val string
+	if err := db.QueryRow("SELECT val FROM lifecycle_test WHERE id = 1").Scan(&val); err != nil {
+		t.Fatalf("SELECT: %v", err)
+	}
+	if val != "hello" {
+		t.Fatalf("expected 'hello', got %q", val)
+	}
+	_ = db.Close()
+
+	// Stop server.
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+
+	// Verify process is dead.
+	time.Sleep(500 * time.Millisecond)
+	if integration.IsProcessAlive(state.PID) {
+		t.Errorf("process %d is still alive after Stop", state.PID)
+	}
+
+	// Verify state files removed.
+	if integration.FileExists(pidFile) {
+		t.Error("PID file still exists after Stop")
+	}
+	if integration.FileExists(portFile) {
+		t.Error("port file still exists after Stop")
+	}
+}
+
+// TestLifecycle_CrashRecovery verifies that after a forced kill (SIGKILL),
+// a new Start() cleans up stale state and the data survives.
+// Would have caught: GH#2636 (infinite restart loop with zombie processes).
+func TestLifecycle_CrashRecovery(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Start server and insert data.
+	state1, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start (first): %v", err)
+	}
+	if p, err := os.FindProcess(state1.PID); err == nil {
+		reg.Register(p)
+	}
+
+	db := connectMySQL(t, state1.Port)
+	if _, err := db.Exec("CREATE TABLE crash_test (id INT PRIMARY KEY, val VARCHAR(100))"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO crash_test VALUES (1, 'survive')"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+	// Commit the data so it persists.
+	if _, err := db.Exec("CALL DOLT_COMMIT('-Am', 'crash test data')"); err != nil {
+		t.Logf("DOLT_COMMIT: %v (may be expected if auto-commit is on)", err)
+	}
+	_ = db.Close()
+
+	// Force-kill the server (simulate crash).
+	proc, err := os.FindProcess(state1.PID)
+	if err != nil {
+		t.Fatalf("FindProcess: %v", err)
+	}
+	if err := proc.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL: %v", err)
+	}
+	_, _ = proc.Wait()
+	reg.Deregister(state1.PID)
+
+	t.Logf("Server PID %d killed, stale state files left behind", state1.PID)
+
+	// Verify stale PID file still exists (crash didn't clean up).
+	pidFile := filepath.Join(beadsDir, doltserver.PIDFileName)
+	if !integration.FileExists(pidFile) {
+		t.Log("PID file was already cleaned up (unexpected but not fatal)")
+	}
+
+	// Start server again — should clean up stale state and work.
+	state2, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start (second): %v", err)
+	}
+	if !state2.Running {
+		t.Fatal("second Start returned Running=false")
+	}
+	if state2.PID == state1.PID {
+		t.Error("second Start reused the same PID (unexpected)")
+	}
+	if p, err := os.FindProcess(state2.PID); err == nil {
+		reg.Register(p)
+	}
+
+	t.Logf("Server restarted: PID=%d Port=%d", state2.PID, state2.Port)
+
+	// Verify data survived the crash.
+	db2 := connectMySQL(t, state2.Port)
+	var val string
+	err = db2.QueryRow("SELECT val FROM crash_test WHERE id = 1").Scan(&val)
+	if err != nil {
+		t.Fatalf("SELECT after crash recovery: %v", err)
+	}
+	if val != "survive" {
+		t.Fatalf("expected 'survive', got %q", val)
+	}
+	_ = db2.Close()
+
+	// Clean stop.
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Fatalf("Stop (cleanup): %v", err)
+	}
+	reg.Deregister(state2.PID)
+}
+
+// TestLifecycle_RestartDataPersistence verifies data persists across clean
+// Stop → Start cycles.
+// Would have caught: GH#2756 (cold-start regression losing working set).
+func TestLifecycle_RestartDataPersistence(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Start, write data, stop.
+	state1, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start (first): %v", err)
+	}
+	if p, err := os.FindProcess(state1.PID); err == nil {
+		reg.Register(p)
+	}
+
+	db := connectMySQL(t, state1.Port)
+	if _, err := db.Exec("CREATE TABLE persist_test (id INT PRIMARY KEY, val VARCHAR(100))"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO persist_test VALUES (42, 'persistent')"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+	if _, err := db.Exec("CALL DOLT_COMMIT('-Am', 'persistence test')"); err != nil {
+		t.Logf("DOLT_COMMIT: %v (may be expected)", err)
+	}
+	_ = db.Close()
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	reg.Deregister(state1.PID)
+
+	// Restart and verify data.
+	state2, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start (second): %v", err)
+	}
+	if p, err := os.FindProcess(state2.PID); err == nil {
+		reg.Register(p)
+	}
+
+	db2 := connectMySQL(t, state2.Port)
+	var val string
+	if err := db2.QueryRow("SELECT val FROM persist_test WHERE id = 42").Scan(&val); err != nil {
+		t.Fatalf("SELECT after restart: %v", err)
+	}
+	if val != "persistent" {
+		t.Fatalf("expected 'persistent', got %q", val)
+	}
+	_ = db2.Close()
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Fatalf("Stop (cleanup): %v", err)
+	}
+	reg.Deregister(state2.PID)
+}
+
+// TestLifecycle_MultiRepoIsolation verifies that KillStaleServers for repo A
+// does not affect repo B's server.
+// Would have caught: GH#2595 (stale cleanup kills healthy servers from other repos).
+func TestLifecycle_MultiRepoIsolation(t *testing.T) {
+	beadsDirA := setupLifecycleTestDir(t)
+	beadsDirB := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diagA := integration.NewDiagnostics(t, beadsDirA)
+	diagA.CaptureOnFailure()
+	diagB := integration.NewDiagnostics(t, beadsDirB)
+	diagB.CaptureOnFailure()
+
+	// Start both servers.
+	stateA, err := doltserver.Start(beadsDirA)
+	if err != nil {
+		t.Fatalf("Start(A): %v", err)
+	}
+	if p, err := os.FindProcess(stateA.PID); err == nil {
+		reg.Register(p)
+	}
+	t.Logf("Repo A: PID=%d Port=%d", stateA.PID, stateA.Port)
+
+	stateB, err := doltserver.Start(beadsDirB)
+	if err != nil {
+		t.Fatalf("Start(B): %v", err)
+	}
+	if p, err := os.FindProcess(stateB.PID); err == nil {
+		reg.Register(p)
+	}
+	t.Logf("Repo B: PID=%d Port=%d", stateB.PID, stateB.Port)
+
+	// KillStaleServers on repo A.
+	killed, err := doltserver.KillStaleServers(beadsDirA)
+	if err != nil {
+		t.Fatalf("KillStaleServers(A): %v", err)
+	}
+	t.Logf("KillStaleServers(A) killed %d processes: %v", len(killed), killed)
+
+	// Verify B's server is still alive.
+	time.Sleep(500 * time.Millisecond)
+	if !integration.IsProcessAlive(stateB.PID) {
+		t.Errorf("repo B's server (PID %d) was killed by KillStaleServers(A)", stateB.PID)
+	}
+
+	// Verify B is still connectable.
+	dbB := connectMySQL(t, stateB.Port)
+	if _, err := dbB.Exec("SELECT 1"); err != nil {
+		t.Errorf("repo B's server not connectable after KillStaleServers(A): %v", err)
+	}
+	_ = dbB.Close()
+
+	// Cleanup both.
+	_ = doltserver.Stop(beadsDirA)
+	reg.Deregister(stateA.PID)
+	_ = doltserver.Stop(beadsDirB)
+	reg.Deregister(stateB.PID)
+}
+
+// TestLifecycle_ConcurrentIsRunningStart verifies that concurrent IsRunning()
+// calls during a Start() don't cause data races or incorrect state.
+// Would have caught: TOCTOU bugs in PID file reads during server startup.
+func TestLifecycle_ConcurrentIsRunningStart(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	var wg sync.WaitGroup
+	var startState atomic.Pointer[doltserver.State]
+	var startErr atomic.Pointer[error]
+	ready := make(chan struct{})
+
+	// Goroutine 1: Start the server.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ready
+		state, err := doltserver.Start(beadsDir)
+		if err != nil {
+			startErr.Store(&err)
+			return
+		}
+		startState.Store(state)
+	}()
+
+	// Goroutines 2-6: Concurrent IsRunning checks.
+	const readers = 5
+	isRunningErrors := make(chan error, readers)
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ready
+			for j := 0; j < 20; j++ {
+				state, err := doltserver.IsRunning(beadsDir)
+				if err != nil {
+					isRunningErrors <- err
+					return
+				}
+				// state.Running can be true or false — either is valid during startup.
+				_ = state
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+	}
+
+	// Release all goroutines.
+	close(ready)
+	wg.Wait()
+	close(isRunningErrors)
+
+	// Check for Start errors.
+	if ep := startErr.Load(); ep != nil {
+		t.Fatalf("Start failed: %v", *ep)
+	}
+
+	state := startState.Load()
+	if state == nil {
+		t.Fatal("Start returned nil state")
+	}
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	// Check for IsRunning errors (panics, data races).
+	for err := range isRunningErrors {
+		t.Errorf("IsRunning error during concurrent access: %v", err)
+	}
+
+	// Cleanup.
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}
+
+// TestLifecycle_PIDReuseDetection verifies that IsRunning returns false when
+// the PID file points to a non-dolt process (PID was reused by the OS).
+// Would have caught: False-positive IsRunning when PID recycled.
+func TestLifecycle_PIDReuseDetection(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Start a non-dolt process (sleep) and write its PID to the PID file.
+	sleepCmd := exec.Command("sleep", "60")
+	if err := sleepCmd.Start(); err != nil {
+		t.Fatalf("failed to start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sleepCmd.Process.Signal(syscall.SIGTERM)
+		_ = sleepCmd.Wait()
+	})
+
+	sleepPID := sleepCmd.Process.Pid
+	t.Logf("sleep process PID: %d", sleepPID)
+
+	// Write the sleep PID as if it were the dolt server.
+	corruptor := integration.NewStateCorruptor(t, beadsDir)
+	corruptor.WriteStalePID(sleepPID)
+	corruptor.WriteStalePort(3306) // Arbitrary port.
+
+	// IsRunning should detect this is NOT a dolt process and return false.
+	state, err := doltserver.IsRunning(beadsDir)
+	if err != nil {
+		t.Fatalf("IsRunning: %v", err)
+	}
+	if state.Running {
+		t.Error("IsRunning returned true for a non-dolt PID — isDoltProcess check failed")
+	}
+
+	// Verify stale state files were cleaned up.
+	if integration.FileExists(corruptor.PIDFilePath()) {
+		t.Error("PID file not cleaned up after detecting non-dolt PID")
+	}
+}

--- a/internal/doltserver/port_race_test.go
+++ b/internal/doltserver/port_race_test.go
@@ -1,0 +1,222 @@
+//go:build integration && !windows
+
+package doltserver_test
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+)
+
+// TestPortRace_ConcurrentStart verifies that when two goroutines call Start()
+// simultaneously on the same beadsDir, exactly one succeeds due to flock
+// serialization, and both end up with a healthy server.
+func TestPortRace_ConcurrentStart(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	const numStarters = 3
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+	var mu sync.Mutex
+	states := make([]*doltserver.State, numStarters)
+	errs := make([]error, numStarters)
+	ready := make(chan struct{})
+
+	for i := 0; i < numStarters; i++ {
+		idx := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-ready
+			state, err := doltserver.Start(beadsDir)
+			mu.Lock()
+			states[idx] = state
+			errs[idx] = err
+			mu.Unlock()
+			if err == nil && state.Running {
+				successCount.Add(1)
+			}
+		}()
+	}
+
+	close(ready)
+	wg.Wait()
+
+	// All should succeed (flock serializes — first starts, others detect running).
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d failed: %v", i, err)
+		}
+	}
+
+	if successCount.Load() == 0 {
+		t.Fatal("no goroutine succeeded in starting the server")
+	}
+	t.Logf("Concurrent Start: %d/%d succeeded", successCount.Load(), numStarters)
+
+	// All returned states should reference the same PID (same server).
+	var firstPID int
+	for _, s := range states {
+		if s != nil && s.PID != 0 {
+			if firstPID == 0 {
+				firstPID = s.PID
+			} else if s.PID != firstPID {
+				t.Errorf("multiple servers started: PID %d and PID %d", firstPID, s.PID)
+			}
+		}
+	}
+
+	if firstPID != 0 {
+		if p, err := os.FindProcess(firstPID); err == nil {
+			reg.Register(p)
+		}
+	}
+
+	// Cleanup.
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	if firstPID != 0 {
+		reg.Deregister(firstPID)
+	}
+}
+
+// TestPortRace_EphemeralPortRetry verifies that the ephemeral port allocation
+// retry loop works when a port is already in use.
+func TestPortRace_EphemeralPortRetry(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	// Bind a port to simulate it being in use.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind: %v", err)
+	}
+	occupiedPort := listener.Addr().(*net.TCPAddr).Port
+	t.Logf("Occupied port %d to test retry logic", occupiedPort)
+	t.Cleanup(func() { listener.Close() })
+
+	// Start() uses ephemeral port allocation (port 0) by default.
+	// It should succeed even with one port occupied because it retries.
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if state.Port == occupiedPort {
+		t.Errorf("Start allocated the occupied port %d", occupiedPort)
+	}
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	t.Logf("Server started on port %d (occupied port was %d)", state.Port, occupiedPort)
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}
+
+// TestPortRace_LoopbackBinding verifies that the dolt server binds to
+// 127.0.0.1 (loopback) and is not accessible from other interfaces.
+func TestPortRace_LoopbackBinding(t *testing.T) {
+	beadsDir := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+	diag := integration.NewDiagnostics(t, beadsDir)
+	diag.CaptureOnFailure()
+
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+
+	// Verify loopback connection works.
+	loopConn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", portStr(state.Port)))
+	if err != nil {
+		t.Fatalf("loopback connection failed: %v", err)
+	}
+	loopConn.Close()
+	t.Log("Loopback connection succeeded")
+
+	// Check the dolt server config confirms 127.0.0.1 binding.
+	cfg := doltserver.DefaultConfig(beadsDir)
+	if cfg.Host != "127.0.0.1" && cfg.Host != "localhost" && cfg.Host != "" {
+		t.Errorf("server config host is %q, expected 127.0.0.1 or localhost", cfg.Host)
+	}
+
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop: %v", err)
+	}
+	reg.Deregister(state.PID)
+}
+
+// TestPortRace_MultiRepoPortCollision verifies that two repos don't collide
+// on the same ephemeral port.
+func TestPortRace_MultiRepoPortCollision(t *testing.T) {
+	beadsDirA := setupLifecycleTestDir(t)
+	beadsDirB := setupLifecycleTestDir(t)
+	reg := integration.NewProcessRegistry(t)
+
+	// Start both servers concurrently.
+	var wg sync.WaitGroup
+	var stateA, stateB *doltserver.State
+	var errA, errB error
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		stateA, errA = doltserver.Start(beadsDirA)
+	}()
+	go func() {
+		defer wg.Done()
+		stateB, errB = doltserver.Start(beadsDirB)
+	}()
+	wg.Wait()
+
+	if errA != nil {
+		t.Fatalf("Start(A): %v", errA)
+	}
+	if errB != nil {
+		t.Fatalf("Start(B): %v", errB)
+	}
+
+	if stateA.PID != 0 {
+		if p, err := os.FindProcess(stateA.PID); err == nil {
+			reg.Register(p)
+		}
+	}
+	if stateB.PID != 0 {
+		if p, err := os.FindProcess(stateB.PID); err == nil {
+			reg.Register(p)
+		}
+	}
+
+	// Verify different ports.
+	if stateA.Port == stateB.Port {
+		t.Errorf("both repos got the same port %d — port collision", stateA.Port)
+	}
+	t.Logf("Repo A: port %d, Repo B: port %d", stateA.Port, stateB.Port)
+
+	_ = doltserver.Stop(beadsDirA)
+	reg.Deregister(stateA.PID)
+	_ = doltserver.Stop(beadsDirB)
+	reg.Deregister(stateB.PID)
+}
+
+func portStr(port int) string {
+	return fmt.Sprintf("%d", port)
+}

--- a/internal/storage/dolt/initschema_multiprocess_test.go
+++ b/internal/storage/dolt/initschema_multiprocess_test.go
@@ -1,0 +1,300 @@
+//go:build integration && !windows
+
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestHelperSchemaInit is the subprocess entry point for multi-process schema
+// init tests. It is only executed when BEADS_SCHEMA_INIT_HELPER=1 is set.
+// Each subprocess connects to the dolt server and calls initSchemaOnDB.
+func TestHelperSchemaInit(t *testing.T) {
+	if os.Getenv("BEADS_SCHEMA_INIT_HELPER") != "1" {
+		return // Not a subprocess — skip.
+	}
+
+	port := os.Getenv("BEADS_SCHEMA_INIT_PORT")
+	dbName := os.Getenv("BEADS_SCHEMA_INIT_DB")
+	procID := os.Getenv("BEADS_SCHEMA_INIT_PROC_ID")
+
+	if port == "" || dbName == "" {
+		fmt.Fprintf(os.Stderr, "FATAL: missing BEADS_SCHEMA_INIT_PORT or BEADS_SCHEMA_INIT_DB\n")
+		os.Exit(1)
+	}
+
+	dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/%s?parseTime=true", port, dbName)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: sql.Open: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(2)
+	db.SetMaxIdleConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: ping: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = initSchemaOnDB(ctx, db)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: initSchemaOnDB: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Report which path was taken. The parent test asserts exactly 1 slow path.
+	// We detect the path by checking if schema_version existed before our init.
+	// Since initSchemaOnDB is idempotent, we can't truly distinguish from here,
+	// but the important thing is all subprocesses succeed without corruption.
+	fmt.Fprintf(os.Stdout, "OK proc=%s\n", procID)
+}
+
+// TestMultiProcessSchemaInit spawns N subprocesses that all call initSchemaOnDB
+// on the same fresh database simultaneously. Verifies no journal corruption
+// and schema integrity after concurrent initialization.
+// Would have caught: GH#2672 (concurrent initSchemaOnDB corrupts fresh DB).
+func TestMultiProcessSchemaInit(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	modRoot := integration.ModuleRoot(t)
+	diag := integration.NewDiagnostics(t, ".")
+	diag.CaptureOnFailure()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Build the test binary once.
+	runner := integration.NewSubprocessRunner(modRoot, "./internal/storage/dolt/")
+	testBin := runner.Build(t)
+
+	// Create a fresh database.
+	dbName := uniqueTestDBName(t)
+	initDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/", testServerPort)
+	initDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("open init connection: %v", err)
+	}
+	defer initDB.Close()
+
+	if _, err := initDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	t.Cleanup(func() {
+		// Skip DROP — rapid cycles can crash the Dolt container.
+	})
+
+	// Spawn N subprocesses.
+	const numProcs = 8
+	portStr := strconv.Itoa(testServerPort)
+
+	var successCount atomic.Int32
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	for i := 0; i < numProcs; i++ {
+		procID := strconv.Itoa(i)
+		eg.Go(func() error {
+			subCtx, subCancel := context.WithTimeout(egCtx, 30*time.Second)
+			defer subCancel()
+
+			cmd := exec.CommandContext(subCtx, testBin,
+				"-test.run=^TestHelperSchemaInit$",
+				"-test.v",
+			)
+			cmd.Env = integration.FilterEnv(os.Environ())
+			cmd.Env = append(cmd.Env,
+				"BEADS_SCHEMA_INIT_HELPER=1",
+				"BEADS_SCHEMA_INIT_PORT="+portStr,
+				"BEADS_SCHEMA_INIT_DB="+dbName,
+				"BEADS_SCHEMA_INIT_PROC_ID="+procID,
+				"BEADS_TEST_MODE=1",
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("subprocess %s failed: %v\noutput: %s", procID, err, out)
+			}
+			if strings.Contains(string(out), "OK proc=") {
+				successCount.Add(1)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("subprocess error: %v", err)
+	}
+
+	if int(successCount.Load()) != numProcs {
+		t.Fatalf("expected %d successful subprocesses, got %d", numProcs, successCount.Load())
+	}
+	t.Logf("All %d subprocesses completed successfully", numProcs)
+
+	// Verify schema integrity.
+	verifyDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true", testServerPort, dbName)
+	verifyDB, err := sql.Open("mysql", verifyDSN)
+	if err != nil {
+		t.Fatalf("open verify connection: %v", err)
+	}
+	defer verifyDB.Close()
+
+	verifyCtx, verifyCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer verifyCancel()
+
+	// Check schema_version exists and is current.
+	var version int
+	err = verifyDB.QueryRowContext(verifyCtx, "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").Scan(&version)
+	if err != nil {
+		t.Fatalf("schema_version query failed: %v", err)
+	}
+	if version == 0 {
+		t.Error("schema_version is 0 after concurrent init")
+	}
+	t.Logf("schema_version: %d", version)
+
+	// Verify core tables exist.
+	requiredTables := []string{"issues", "dependencies", "comments", "schema_version"}
+	for _, table := range requiredTables {
+		var count int
+		err := verifyDB.QueryRowContext(verifyCtx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", dbName, table).Scan(&count)
+		if err != nil {
+			t.Errorf("checking table %s: %v", table, err)
+		} else if count == 0 {
+			t.Errorf("required table %s is missing after concurrent init", table)
+		}
+	}
+}
+
+// TestMultiProcessSchemaInit_DoltVerify runs dolt verify on the data directory
+// after concurrent schema initialization to detect journal corruption.
+// Would have caught: GH#2430 (journal corruption after concurrent DDL).
+func TestMultiProcessSchemaInit_DoltVerify(t *testing.T) {
+	skipIfNoDolt(t)
+
+	// This test requires a local dolt data directory, not a Docker container.
+	// It starts its own server, runs concurrent inits, then runs dolt verify.
+	doltPath := integration.RequireDolt(t)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0700); err != nil {
+		t.Fatalf("mkdir dolt: %v", err)
+	}
+
+	initCmd := exec.Command(doltPath, "init")
+	initCmd.Dir = doltDir
+	initCmd.Env = append(os.Environ(), "HOME="+tmpDir, "DOLT_ROOT_PATH="+tmpDir)
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt init: %v\n%s", err, out)
+	}
+
+	// Start a local server.
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	t.Setenv("BEADS_DOLT_AUTO_START", "1")
+
+	state, err := doltserver.Start(beadsDir)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	reg := integration.NewProcessRegistry(t)
+	if p, err := os.FindProcess(state.PID); err == nil {
+		reg.Register(p)
+	}
+	t.Cleanup(func() {
+		_ = doltserver.Stop(beadsDir)
+		reg.Deregister(state.PID)
+	})
+
+	// Create a fresh database on the local server.
+	dbName := uniqueTestDBName(t)
+	adminDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/", state.Port)
+	adminDB, err := sql.Open("mysql", adminDSN)
+	if err != nil {
+		t.Fatalf("admin connect: %v", err)
+	}
+	defer adminDB.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	// Run concurrent schema inits (in-process, since we need dolt verify after).
+	const numConcurrent = 10
+	dsn := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true", state.Port, dbName)
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	ready := make(chan struct{})
+	for i := 0; i < numConcurrent; i++ {
+		eg.Go(func() error {
+			db, err := sql.Open("mysql", dsn)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			db.SetMaxOpenConns(2)
+			<-ready
+			return initSchemaOnDB(egCtx, db)
+		})
+	}
+	close(ready)
+
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("concurrent initSchemaOnDB: %v", err)
+	}
+
+	// Stop server before running dolt verify (verify needs exclusive access).
+	if err := doltserver.Stop(beadsDir); err != nil {
+		t.Logf("Stop before verify: %v", err)
+	}
+	reg.Deregister(state.PID)
+
+	// Run dolt verify on the database directory.
+	dbDir := filepath.Join(doltDir, dbName)
+	if _, err := os.Stat(dbDir); os.IsNotExist(err) {
+		// Database may be in the dolt root if not using multi-DB mode.
+		dbDir = doltDir
+	}
+
+	verifyCmd := exec.Command(doltPath, "verify")
+	verifyCmd.Dir = dbDir
+	verifyCmd.Env = append(os.Environ(), "HOME="+tmpDir, "DOLT_ROOT_PATH="+tmpDir)
+	verifyOut, verifyErr := verifyCmd.CombinedOutput()
+	if verifyErr != nil {
+		t.Errorf("dolt verify FAILED (journal corruption detected): %v\n%s", verifyErr, verifyOut)
+	} else {
+		t.Logf("dolt verify passed: %s", strings.TrimSpace(string(verifyOut)))
+	}
+}

--- a/internal/storage/dolt/multistore_multiprocess_test.go
+++ b/internal/storage/dolt/multistore_multiprocess_test.go
@@ -1,0 +1,423 @@
+//go:build integration && !windows
+
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestHelperMultiStore is the subprocess entry point for multi-DoltStore tests.
+// Only executed when BEADS_MULTISTORE_HELPER=1 is set.
+func TestHelperMultiStore(t *testing.T) {
+	if os.Getenv("BEADS_MULTISTORE_HELPER") != "1" {
+		return
+	}
+
+	port := os.Getenv("BEADS_MULTISTORE_PORT")
+	dbName := os.Getenv("BEADS_MULTISTORE_DB")
+	procID := os.Getenv("BEADS_MULTISTORE_PROC_ID")
+	opsStr := os.Getenv("BEADS_MULTISTORE_OPS")
+
+	if port == "" || dbName == "" || procID == "" {
+		fmt.Fprintf(os.Stderr, "FATAL: missing required env vars\n")
+		os.Exit(1)
+	}
+
+	numOps := 5
+	if opsStr != "" {
+		if n, err := strconv.Atoi(opsStr); err == nil {
+			numOps = n
+		}
+	}
+
+	dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/%s?parseTime=true", port, dbName)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: sql.Open: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(5)
+	db.SetMaxIdleConns(2)
+	db.SetConnMaxLifetime(2 * time.Minute)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: ping: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create issues, mimicking how multiple bd processes would work.
+	var created int
+	for i := 0; i < numOps; i++ {
+		issueID := fmt.Sprintf("mp-%s-%d", procID, i)
+		title := fmt.Sprintf("Issue from proc %s op %d", procID, i)
+
+		var inserted bool
+		for retry := 0; retry < 5; retry++ {
+			_, err := db.ExecContext(ctx,
+				"INSERT INTO issues (id, title, status, priority, issue_type, created_at, updated_at) VALUES (?, ?, 'open', 2, 'task', NOW(6), NOW(6))",
+				issueID, title,
+			)
+			if err == nil {
+				inserted = true
+				break
+			}
+			if isSerializationError(err) {
+				time.Sleep(time.Duration(50*(retry+1)) * time.Millisecond)
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "ERROR: INSERT %s: %v\n", issueID, err)
+			break
+		}
+		if inserted {
+			created++
+		}
+	}
+
+	// Read back to verify.
+	var count int
+	prefix := fmt.Sprintf("mp-%s-%%", procID)
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id LIKE ?", prefix).Scan(&count); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: count: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stdout, "OK proc=%s created=%d verified=%d\n", procID, created, count)
+}
+
+// TestMultiStoreConcurrent_InProcess tests multiple independent DoltStore
+// connections (same process, separate sql.DB pools) performing concurrent
+// operations. This is Layer 1 — fast API invariant checks.
+func TestMultiStoreConcurrent_InProcess(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Create a fresh database with schema.
+	dbName := uniqueTestDBName(t)
+	initDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/", testServerPort)
+	adminDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("admin connect: %v", err)
+	}
+	defer adminDB.Close()
+	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	// Initialize schema once.
+	schemaDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true", testServerPort, dbName)
+	schemaDB, err := sql.Open("mysql", schemaDSN)
+	if err != nil {
+		t.Fatalf("schema connect: %v", err)
+	}
+	if err := initSchemaOnDB(ctx, schemaDB); err != nil {
+		t.Fatalf("initSchemaOnDB: %v", err)
+	}
+	schemaDB.Close()
+
+	// Open 5 independent connection pools — each simulates a separate bd process.
+	const numStores = 5
+	const opsPerStore = 10
+	dbs := make([]*sql.DB, numStores)
+	for i := 0; i < numStores; i++ {
+		db, err := sql.Open("mysql", schemaDSN)
+		if err != nil {
+			t.Fatalf("open pool %d: %v", i, err)
+		}
+		db.SetMaxOpenConns(3)
+		db.SetMaxIdleConns(1)
+		db.SetConnMaxLifetime(2 * time.Minute)
+		dbs[i] = db
+		t.Cleanup(func() { db.Close() })
+	}
+
+	// Concurrent creates across all pools.
+	var totalCreated atomic.Int32
+	eg, egCtx := errgroup.WithContext(ctx)
+	for storeIdx := 0; storeIdx < numStores; storeIdx++ {
+		db := dbs[storeIdx]
+		idx := storeIdx
+		eg.Go(func() error {
+			for op := 0; op < opsPerStore; op++ {
+				id := fmt.Sprintf("ms-%d-%d", idx, op)
+				title := fmt.Sprintf("Multi-store issue %d-%d", idx, op)
+				_, err := db.ExecContext(egCtx,
+					"INSERT INTO issues (id, title, status, priority, issue_type, created_at, updated_at) VALUES (?, ?, 'open', 2, 'task', NOW(6), NOW(6))",
+					id, title,
+				)
+				if err != nil {
+					if isSerializationError(err) {
+						continue // Expected under contention.
+					}
+					return fmt.Errorf("store %d op %d: %w", idx, op, err)
+				}
+				totalCreated.Add(1)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("concurrent operations: %v", err)
+	}
+
+	// Verify all issues exist.
+	var totalCount int
+	verifyDB := dbs[0]
+	if err := verifyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id LIKE 'ms-%'").Scan(&totalCount); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+
+	t.Logf("Created %d issues, verified %d in database", totalCreated.Load(), totalCount)
+	if totalCount == 0 {
+		t.Error("no issues found — concurrent creates all failed")
+	}
+	// At least 80% of acknowledged writes should be present.
+	// Some loss is expected from serialization errors, but massive loss
+	// indicates a real concurrency bug.
+	minExpected := int(float64(totalCreated.Load()) * 0.8)
+	if totalCount < minExpected {
+		t.Errorf("data integrity: only %d/%d acknowledged writes found in DB (min %d expected)", totalCount, totalCreated.Load(), minExpected)
+	}
+
+	// Concurrent read while one pool writes.
+	var readErrors atomic.Int32
+	eg2, egCtx2 := errgroup.WithContext(ctx)
+
+	// Writer: updates existing issues.
+	eg2.Go(func() error {
+		for i := 0; i < 10; i++ {
+			_, _ = dbs[0].ExecContext(egCtx2,
+				"UPDATE issues SET priority = ? WHERE id LIKE 'ms-0-%' LIMIT 1",
+				i%5,
+			)
+			time.Sleep(10 * time.Millisecond)
+		}
+		return nil
+	})
+
+	// Readers: concurrent reads.
+	for r := 1; r < numStores; r++ {
+		db := dbs[r]
+		eg2.Go(func() error {
+			for i := 0; i < 20; i++ {
+				var c int
+				if err := db.QueryRowContext(egCtx2, "SELECT COUNT(*) FROM issues").Scan(&c); err != nil {
+					readErrors.Add(1)
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+			return nil
+		})
+	}
+
+	if err := eg2.Wait(); err != nil {
+		t.Fatalf("read/write mix: %v", err)
+	}
+	if readErrors.Load() > 0 {
+		t.Logf("Warning: %d read errors during concurrent writes (may be expected under contention)", readErrors.Load())
+	}
+}
+
+// TestMultiStoreConcurrent_Subprocess is Layer 2 — true multi-process test.
+// Spawns N subprocesses, each with its own sql.DB pool, all hitting the same
+// database. Verifies no data loss or corruption.
+// Would have caught: GH#2430 (journal corruption from multi-process writes).
+func TestMultiStoreConcurrent_Subprocess(t *testing.T) {
+	skipIfNoDolt(t)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	modRoot := integration.ModuleRoot(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	runner := integration.NewSubprocessRunner(modRoot, "./internal/storage/dolt/")
+	testBin := runner.Build(t)
+
+	// Create a fresh database with schema.
+	dbName := uniqueTestDBName(t)
+	initDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/", testServerPort)
+	adminDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("admin connect: %v", err)
+	}
+	defer adminDB.Close()
+	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	schemaDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true", testServerPort, dbName)
+	schemaDB, err := sql.Open("mysql", schemaDSN)
+	if err != nil {
+		t.Fatalf("schema connect: %v", err)
+	}
+	if err := initSchemaOnDB(ctx, schemaDB); err != nil {
+		t.Fatalf("initSchemaOnDB: %v", err)
+	}
+	schemaDB.Close()
+
+	// Spawn subprocesses.
+	const numProcs = 5
+	const opsPerProc = 5
+	portStr := strconv.Itoa(testServerPort)
+
+	var successCount atomic.Int32
+	eg, egCtx := errgroup.WithContext(ctx)
+
+	for i := 0; i < numProcs; i++ {
+		procID := strconv.Itoa(i)
+		eg.Go(func() error {
+			subCtx, subCancel := context.WithTimeout(egCtx, 30*time.Second)
+			defer subCancel()
+
+			cmd := exec.CommandContext(subCtx, testBin,
+				"-test.run=^TestHelperMultiStore$",
+				"-test.v",
+			)
+			cmd.Env = integration.FilterEnv(os.Environ())
+			cmd.Env = append(cmd.Env,
+				"BEADS_MULTISTORE_HELPER=1",
+				"BEADS_MULTISTORE_PORT="+portStr,
+				"BEADS_MULTISTORE_DB="+dbName,
+				"BEADS_MULTISTORE_PROC_ID="+procID,
+				"BEADS_MULTISTORE_OPS="+strconv.Itoa(opsPerProc),
+				"BEADS_TEST_MODE=1",
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("subprocess %s: %v\noutput: %s", procID, err, out)
+			}
+			if strings.Contains(string(out), "OK proc=") {
+				successCount.Add(1)
+			}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("subprocess error: %v", err)
+	}
+	t.Logf("All %d subprocesses completed (%d successful)", numProcs, successCount.Load())
+
+	// Verify total issue count.
+	verifyDB, err := sql.Open("mysql", schemaDSN)
+	if err != nil {
+		t.Fatalf("verify connect: %v", err)
+	}
+	defer verifyDB.Close()
+
+	var totalIssues int
+	if err := verifyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id LIKE 'mp-%'").Scan(&totalIssues); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	t.Logf("Total issues in database: %d (expected up to %d)", totalIssues, numProcs*opsPerProc)
+
+	if totalIssues == 0 {
+		t.Error("no issues found — all subprocess writes failed")
+	}
+
+	// Check for duplicates.
+	var dupeCount int
+	if err := verifyDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM (SELECT id, COUNT(*) c FROM issues WHERE id LIKE 'mp-%' GROUP BY id HAVING c > 1) dupes").Scan(&dupeCount); err != nil {
+		t.Fatalf("dupe check: %v", err)
+	}
+	if dupeCount > 0 {
+		t.Errorf("found %d duplicate issue IDs", dupeCount)
+	}
+}
+
+// closeStore is a helper to test that closing one connection pool doesn't
+// cause cascade failures in other pools.
+func TestMultiStoreConcurrent_CloseIsolation(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dbName := uniqueTestDBName(t)
+	initDSN := fmt.Sprintf("root@tcp(127.0.0.1:%d)/", testServerPort)
+	adminDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("admin connect: %v", err)
+	}
+	defer adminDB.Close()
+	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	dsn := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true", testServerPort, dbName)
+
+	// Open two pools.
+	db1, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open db1: %v", err)
+	}
+	db2, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open db2: %v", err)
+	}
+	t.Cleanup(func() { db2.Close() })
+
+	// Start a query on db2.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	db2Ready := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		close(db2Ready)
+		for i := 0; i < 10; i++ {
+			_, _ = db2.ExecContext(ctx, "SELECT 1")
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+
+	<-db2Ready
+	time.Sleep(50 * time.Millisecond)
+
+	// Close db1 while db2 is active.
+	db1.Close()
+
+	// db2 should continue working without errors.
+	wg.Wait()
+
+	// Verify db2 is still functional.
+	if _, err := db2.ExecContext(ctx, "SELECT 1"); err != nil {
+		t.Errorf("db2 broken after db1.Close(): %v", err)
+	}
+}

--- a/internal/testutil/integration/corruption.go
+++ b/internal/testutil/integration/corruption.go
@@ -1,0 +1,101 @@
+//go:build integration && !windows
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// StateCorruptor creates dirty server state for testing recovery scenarios.
+type StateCorruptor struct {
+	BeadsDir string
+	t        *testing.T
+}
+
+// NewStateCorruptor creates a corruptor targeting the given .beads directory.
+func NewStateCorruptor(t *testing.T, beadsDir string) *StateCorruptor {
+	t.Helper()
+	return &StateCorruptor{BeadsDir: beadsDir, t: t}
+}
+
+// WriteStalePID writes a PID file containing the given PID.
+func (c *StateCorruptor) WriteStalePID(pid int) {
+	c.t.Helper()
+	path := filepath.Join(c.BeadsDir, "dolt-server.pid")
+	if err := os.WriteFile(path, []byte(fmt.Sprintf("%d", pid)), 0600); err != nil {
+		c.t.Fatalf("WriteStalePID: %v", err)
+	}
+}
+
+// WriteStalePort writes a port file containing the given port number.
+func (c *StateCorruptor) WriteStalePort(port int) {
+	c.t.Helper()
+	path := filepath.Join(c.BeadsDir, "dolt-server.port")
+	if err := os.WriteFile(path, []byte(fmt.Sprintf("%d", port)), 0600); err != nil {
+		c.t.Fatalf("WriteStalePort: %v", err)
+	}
+}
+
+// WriteCorruptPID writes a non-numeric value to the PID file.
+func (c *StateCorruptor) WriteCorruptPID() {
+	c.t.Helper()
+	path := filepath.Join(c.BeadsDir, "dolt-server.pid")
+	if err := os.WriteFile(path, []byte("not-a-pid"), 0600); err != nil {
+		c.t.Fatalf("WriteCorruptPID: %v", err)
+	}
+}
+
+// WriteTruncatedMetadata writes partial (invalid) JSON to metadata.json.
+func (c *StateCorruptor) WriteTruncatedMetadata() {
+	c.t.Helper()
+	path := filepath.Join(c.BeadsDir, "metadata.json")
+	if err := os.WriteFile(path, []byte(`{"backend": "dolt", "dolt_da`), 0600); err != nil {
+		c.t.Fatalf("WriteTruncatedMetadata: %v", err)
+	}
+}
+
+// WritePortZero writes "0" to the port file (GH#2598 regression).
+func (c *StateCorruptor) WritePortZero() {
+	c.t.Helper()
+	c.WriteStalePort(0)
+}
+
+// CreateOrphanNomsLock creates a zero-byte LOCK file at .dolt/noms/LOCK
+// to simulate a power-loss scenario.
+func (c *StateCorruptor) CreateOrphanNomsLock(doltDataDir string) {
+	c.t.Helper()
+	nomsDir := filepath.Join(doltDataDir, "noms")
+	if err := os.MkdirAll(nomsDir, 0700); err != nil {
+		c.t.Fatalf("CreateOrphanNomsLock: mkdir: %v", err)
+	}
+	lockPath := filepath.Join(nomsDir, "LOCK")
+	if err := os.WriteFile(lockPath, nil, 0600); err != nil {
+		c.t.Fatalf("CreateOrphanNomsLock: write: %v", err)
+	}
+}
+
+// CreateCombinedStaleState writes both stale PID and stale port files.
+func (c *StateCorruptor) CreateCombinedStaleState(pid, port int) {
+	c.t.Helper()
+	c.WriteStalePID(pid)
+	c.WriteStalePort(port)
+}
+
+// PIDFilePath returns the expected PID file path.
+func (c *StateCorruptor) PIDFilePath() string {
+	return filepath.Join(c.BeadsDir, "dolt-server.pid")
+}
+
+// PortFilePath returns the expected port file path.
+func (c *StateCorruptor) PortFilePath() string {
+	return filepath.Join(c.BeadsDir, "dolt-server.port")
+}
+
+// FileExists returns true if the given path exists.
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/testutil/integration/diagnostics.go
+++ b/internal/testutil/integration/diagnostics.go
@@ -1,0 +1,88 @@
+//go:build integration && !windows
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Diagnostics captures state information for debugging test failures.
+type Diagnostics struct {
+	t        *testing.T
+	beadsDir string
+}
+
+// NewDiagnostics creates a diagnostics collector for the given .beads directory.
+func NewDiagnostics(t *testing.T, beadsDir string) *Diagnostics {
+	return &Diagnostics{t: t, beadsDir: beadsDir}
+}
+
+// CaptureOnFailure registers a t.Cleanup that dumps diagnostic info if the
+// test has failed. Call early in the test setup.
+func (d *Diagnostics) CaptureOnFailure() {
+	d.t.Helper()
+	d.t.Cleanup(func() {
+		if !d.t.Failed() {
+			return
+		}
+		d.t.Log("=== DIAGNOSTICS (test failed) ===")
+		d.dumpStateFiles()
+		d.dumpProcessList()
+	})
+}
+
+// dumpStateFiles logs the content of PID and port files if they exist.
+func (d *Diagnostics) dumpStateFiles() {
+	for _, name := range []string{"dolt-server.pid", "dolt-server.port", "dolt-server.log"} {
+		path := filepath.Join(d.beadsDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			d.t.Logf("  %s: not found", name)
+			continue
+		}
+		content := strings.TrimSpace(string(data))
+		if len(content) > 500 {
+			content = content[:500] + "... (truncated)"
+		}
+		d.t.Logf("  %s: %s", name, content)
+	}
+}
+
+// dumpProcessList logs any dolt processes visible via /proc or ps.
+func (d *Diagnostics) dumpProcessList() {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		d.t.Log("  /proc: not available")
+		return
+	}
+	var doltProcs []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		// Only numeric directories (PIDs).
+		pid := entry.Name()
+		if pid[0] < '0' || pid[0] > '9' {
+			continue
+		}
+		cmdline, err := os.ReadFile(filepath.Join("/proc", pid, "cmdline"))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(cmdline), "dolt") {
+			doltProcs = append(doltProcs, fmt.Sprintf("PID %s: %s", pid, strings.ReplaceAll(string(cmdline), "\x00", " ")))
+		}
+	}
+	if len(doltProcs) == 0 {
+		d.t.Log("  dolt processes: none found")
+	} else {
+		d.t.Logf("  dolt processes (%d):", len(doltProcs))
+		for _, p := range doltProcs {
+			d.t.Logf("    %s", p)
+		}
+	}
+}

--- a/internal/testutil/integration/harness.go
+++ b/internal/testutil/integration/harness.go
@@ -1,0 +1,317 @@
+//go:build integration && !windows
+
+// Package integration provides shared test infrastructure for multi-process
+// integration tests (GH#2763). It offers process lifecycle management,
+// subprocess orchestration, and environment filtering for tests that validate
+// real dolt server behavior under production-like concurrency.
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// ProcessRegistry tracks spawned processes and ensures cleanup via t.Cleanup.
+// Each registered process gets SIGTERM → 5s grace → SIGKILL escalation.
+type ProcessRegistry struct {
+	mu    sync.Mutex
+	procs map[int]*os.Process
+	t     *testing.T
+}
+
+// NewProcessRegistry creates a registry that automatically kills all tracked
+// processes when the test completes.
+func NewProcessRegistry(t *testing.T) *ProcessRegistry {
+	t.Helper()
+	r := &ProcessRegistry{
+		procs: make(map[int]*os.Process),
+		t:     t,
+	}
+	t.Cleanup(r.killAll)
+	return r
+}
+
+// Register adds a process to the registry for lifecycle tracking.
+func (r *ProcessRegistry) Register(p *os.Process) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.procs[p.Pid] = p
+}
+
+// Deregister removes a process from the registry (e.g., after clean Stop).
+func (r *ProcessRegistry) Deregister(pid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.procs, pid)
+}
+
+// killAll sends SIGTERM, waits 5s, then SIGKILL to all tracked processes.
+func (r *ProcessRegistry) killAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for pid, p := range r.procs {
+		r.t.Logf("ProcessRegistry: cleaning up PID %d", pid)
+		if err := p.Signal(syscall.SIGTERM); err != nil {
+			// Process may already be dead.
+			continue
+		}
+		done := make(chan struct{})
+		go func() {
+			// Wait() only works for child processes. If it fails (ECHILD),
+			// fall back to polling IsProcessAlive.
+			if _, err := p.Wait(); err != nil {
+				for i := 0; i < 50; i++ {
+					if !IsProcessAlive(pid) {
+						break
+					}
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+			close(done)
+		}()
+		select {
+		case <-done:
+			// Clean exit after SIGTERM.
+		case <-time.After(5 * time.Second):
+			r.t.Logf("ProcessRegistry: PID %d did not exit after SIGTERM, sending SIGKILL", pid)
+			_ = p.Signal(syscall.SIGKILL)
+			<-done
+		}
+	}
+	r.procs = make(map[int]*os.Process)
+}
+
+// SubprocessRunner builds a test binary once and spawns subprocesses from it.
+// The binary is compiled with the integration build tag.
+type SubprocessRunner struct {
+	once     sync.Once
+	testBin  string
+	buildErr error
+	modRoot  string
+	pkg      string
+	tags     string
+}
+
+// NewSubprocessRunner creates a runner that will compile the given package.
+// modRoot is the Go module root, pkg is the package path (e.g., "./internal/storage/dolt/").
+func NewSubprocessRunner(modRoot, pkg string) *SubprocessRunner {
+	return &SubprocessRunner{
+		modRoot: modRoot,
+		pkg:     pkg,
+		tags:    "integration",
+	}
+}
+
+// Build compiles the test binary (once). Returns the path to the binary.
+func (r *SubprocessRunner) Build(t *testing.T) string {
+	t.Helper()
+	r.once.Do(func() {
+		r.testBin = filepath.Join(t.TempDir(), "integration.test")
+		t.Logf("SubprocessRunner: building test binary: go test -tags %s -c -o %s %s", r.tags, r.testBin, r.pkg)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		build := exec.CommandContext(ctx, "go", "test",
+			"-tags", r.tags,
+			"-c",
+			"-o", r.testBin,
+			r.pkg,
+		)
+		build.Dir = r.modRoot
+		build.Env = append(os.Environ(), "CGO_ENABLED=1")
+		var stderr bytes.Buffer
+		build.Stderr = &stderr
+		if err := build.Run(); err != nil {
+			r.buildErr = fmt.Errorf("failed to build test binary: %w\nstderr: %s", err, stderr.String())
+		}
+		if err := os.Chmod(r.testBin, 0700); err != nil {
+			r.buildErr = fmt.Errorf("failed to chmod test binary: %w", err)
+		}
+	})
+	if r.buildErr != nil {
+		t.Fatalf("SubprocessRunner: %v", r.buildErr)
+	}
+	return r.testBin
+}
+
+// Spawn starts a subprocess running the given test helper function.
+// The sentinel env var (e.g., BEADS_SCHEMA_INIT_HELPER=1) triggers the helper.
+// Extra env vars are merged with the filtered base environment.
+// Uses process groups for reliable cleanup.
+func (r *SubprocessRunner) Spawn(ctx context.Context, t *testing.T, helperTest string, env map[string]string) *exec.Cmd {
+	t.Helper()
+	bin := r.Build(t)
+
+	// Per-subprocess timeout (30s default, or context deadline).
+	subCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	t.Cleanup(cancel)
+
+	cmd := exec.CommandContext(subCtx, bin, "-test.run=^"+helperTest+"$", "-test.v")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Env = FilterEnv(os.Environ())
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	return cmd
+}
+
+// safeEnvKeys is an allowlist of environment variable prefixes that are safe
+// to pass to test subprocesses.
+var safeEnvKeys = []string{
+	"PATH=",
+	"HOME=",
+	"TMPDIR=",
+	"LANG=",
+	"USER=",
+	"SHELL=",
+	"GOPATH=",
+	"GOROOT=",
+	"GOMODCACHE=",
+	"GOCACHE=",
+	"GOFLAGS=",
+	"CGO_ENABLED=",
+	"CGO_CFLAGS=",
+	"CGO_LDFLAGS=",
+	"CGO_CPPFLAGS=",
+	"CC=",
+	"CXX=",
+	"PKG_CONFIG_PATH=",
+	"LD_LIBRARY_PATH=",
+	"DYLD_LIBRARY_PATH=",
+	"BEADS_", // All BEADS_ test control vars.
+	"DOLT_",  // Dolt configuration.
+	"TZ=",
+	"LC_",
+	"XDG_",
+	"TERM=",
+}
+
+// FilterEnv returns a filtered copy of the environment, keeping only safe
+// variables. This prevents leaking credentials to test subprocesses.
+func FilterEnv(environ []string) []string {
+	var filtered []string
+	for _, e := range environ {
+		for _, prefix := range safeEnvKeys {
+			if strings.HasPrefix(e, prefix) {
+				filtered = append(filtered, e)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// RequireDolt skips the test if the dolt binary is not available on PATH.
+func RequireDolt(t *testing.T) string {
+	t.Helper()
+	doltPath, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skip("dolt binary not found on PATH, skipping integration test")
+	}
+	return doltPath
+}
+
+// InitDoltDir initializes a fresh dolt data directory in dir.
+// Returns the path to the dolt database directory.
+func InitDoltDir(t *testing.T, dir string) string {
+	t.Helper()
+	RequireDolt(t)
+
+	doltDir := filepath.Join(dir, "dolt")
+	if err := os.MkdirAll(doltDir, 0700); err != nil {
+		t.Fatalf("failed to create dolt dir: %v", err)
+	}
+
+	cmd := exec.Command("dolt", "init")
+	cmd.Dir = doltDir
+	cmd.Env = append(os.Environ(),
+		"DOLT_ROOT_PATH="+dir,
+		"HOME="+dir,
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("dolt init failed: %v\nstderr: %s", err, stderr.String())
+	}
+	return doltDir
+}
+
+// ModuleRoot finds the Go module root by searching for go.mod.
+func ModuleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find go.mod in any parent directory")
+		}
+		dir = parent
+	}
+}
+
+// IsProcessAlive checks if a process with the given PID exists and is alive.
+func IsProcessAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+// WaitForPort polls until a TCP connection to host:port succeeds or timeout expires.
+func WaitForPort(t *testing.T, host string, port int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("WaitForPort: %s not reachable after %v", addr, timeout)
+}
+
+// ReadPIDFile reads and parses a PID file, returning 0 if missing or corrupt.
+func ReadPIDFile(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+// ReadPortFile reads and parses a port file, returning 0 if missing or corrupt.
+func ReadPortFile(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return port
+}


### PR DESCRIPTION
## Summary

Closes #2763

Adds 25 integration tests across 5 test groups targeting production failure modes that single-process tests cannot reproduce. These tests use real dolt binaries and actual subprocesses to exercise the same code paths that caused journal corruption (#2430), zombie servers (#2542), and cold-start regressions (#2756).

## Test Groups

### T1: Server Lifecycle (6 tests)
`internal/doltserver/lifecycle_integration_test.go`
- Start/stop cycle, crash recovery, restart data persistence
- Multi-repo isolation, concurrent IsRunning+Start, PID reuse detection

### T2: Multi-Process Schema Init (3 tests)
`internal/storage/dolt/initschema_multiprocess_test.go`
- 8 concurrent subprocesses racing to initialize schema
- Verifies exactly-once schema creation and dolt data integrity

### T3: Multi-DoltStore Operations (4 tests)
`internal/storage/dolt/multistore_multiprocess_test.go`
- In-process (Layer 1) and subprocess (Layer 2) concurrent issue creation
- Data integrity assertions (≥80% acknowledged writes persisted)
- Close isolation (closing one store doesn't affect others)

### T4: Dirty State Recovery (8 tests)
`internal/doltserver/dirty_state_test.go`
- Stale PID (alive non-dolt, dead process), stale port, corrupt PID file
- Truncated metadata, port zero, combined stale state, orphan noms lock

### T5: Port Allocation Race (4 tests)
`internal/doltserver/port_race_test.go`
- Concurrent Start() with mutex-protected state tracking
- Ephemeral port retry, loopback binding, multi-repo port collision

## Shared Infrastructure

`internal/testutil/integration/` — importable harness package:
- **harness.go**: ProcessRegistry (SIGTERM→SIGKILL escalation with Wait() fallback), SubprocessRunner, EnvFilter (allowlist), RequireDolt, WaitForPort, ReadPIDFile/ReadPortFile
- **corruption.go**: StateCorruptor with 7 dirty-state fixture helpers
- **diagnostics.go**: CaptureOnFailure (dumps state files + dolt process list)

## Build & Test


```bash
# Run just the new tests
go test -tags integration -v ./internal/doltserver/ ./internal/storage/dolt/ -run 'Test(Lifecycle|DirtyState|PortRace|MultiProcess|MultiStore)'
```
