### PR TITLE
feat: expose replication and VC interfaces in public API

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -11,6 +11,7 @@ import (
 	"context"
 
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -21,6 +22,40 @@ type Storage = beads.Storage
 // Transaction provides atomic multi-operation support within a database transaction.
 // Use Storage.RunInTransaction() to obtain a Transaction instance.
 type Transaction = beads.Transaction
+
+// RemoteStore provides dolt remote management and replication operations.
+// Use type assertion on a Storage value to access these methods:
+//
+//	if rs, ok := store.(beads.RemoteStore); ok {
+//	    rs.Push(ctx)
+//	}
+type RemoteStore = storage.RemoteStore
+
+// SyncStore provides high-level sync operations with peers.
+type SyncStore = storage.SyncStore
+
+// VersionControlReader provides read-only version control operations.
+// Write operations (Branch, Checkout, Merge, DeleteBranch) are not yet
+// part of the public API. If you need them, please open an issue.
+type VersionControlReader interface {
+	CurrentBranch(ctx context.Context) (string, error)
+	ListBranches(ctx context.Context) ([]string, error)
+	CommitExists(ctx context.Context, commitHash string) (bool, error)
+	GetCurrentCommit(ctx context.Context) (string, error)
+	Status(ctx context.Context) (*VCStatus, error)
+	Log(ctx context.Context, limit int) ([]CommitInfo, error)
+}
+
+// Replication and version control types from internal/storage
+type (
+	RemoteInfo  = storage.RemoteInfo
+	SyncResult  = storage.SyncResult
+	SyncStatus  = storage.SyncStatus
+	Conflict    = storage.Conflict
+	CommitInfo  = storage.CommitInfo
+	VCStatus    = storage.Status
+	StatusEntry = storage.StatusEntry
+)
 
 // Open opens a Dolt-backed beads database at the given path.
 // This always opens in embedded mode. Use OpenFromConfig to respect

--- a/beads_test.go
+++ b/beads_test.go
@@ -255,3 +255,80 @@ func TestConstants(t *testing.T) {
 		t.Errorf("DepRelated = %q, want %q", beads.DepRelated, "related")
 	}
 }
+
+func TestPublicAPITypeAssertions(t *testing.T) {
+	skipIfNoDoltServer(t)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test-dolt")
+
+	ctx := context.Background()
+	store, err := beads.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer store.Close()
+
+	t.Run("RemoteStore", func(t *testing.T) {
+		rs, ok := store.(beads.RemoteStore)
+		if !ok {
+			t.Fatal("store does not satisfy beads.RemoteStore")
+		}
+		// Verify a method is callable (no remotes configured, so empty list)
+		remotes, err := rs.ListRemotes(ctx)
+		if err != nil {
+			t.Fatalf("ListRemotes failed: %v", err)
+		}
+		_ = remotes
+	})
+
+	t.Run("SyncStore", func(t *testing.T) {
+		_, ok := store.(beads.SyncStore)
+		if !ok {
+			t.Fatal("store does not satisfy beads.SyncStore")
+		}
+	})
+
+	t.Run("VersionControlReader", func(t *testing.T) {
+		vcr, ok := store.(beads.VersionControlReader)
+		if !ok {
+			t.Fatal("store does not satisfy beads.VersionControlReader")
+		}
+
+		branch, err := vcr.CurrentBranch(ctx)
+		if err != nil {
+			t.Fatalf("CurrentBranch failed: %v", err)
+		}
+		if branch == "" {
+			t.Error("expected non-empty branch name")
+		}
+
+		commit, err := vcr.GetCurrentCommit(ctx)
+		if err != nil {
+			t.Fatalf("GetCurrentCommit failed: %v", err)
+		}
+		if commit == "" {
+			t.Error("expected non-empty commit hash")
+		}
+
+		exists, err := vcr.CommitExists(ctx, commit)
+		if err != nil {
+			t.Fatalf("CommitExists failed: %v", err)
+		}
+		if !exists {
+			t.Errorf("CommitExists(%s) = false, want true", commit)
+		}
+
+		status, err := vcr.Status(ctx)
+		if err != nil {
+			t.Fatalf("Status failed: %v", err)
+		}
+		_ = status
+
+		logs, err := vcr.Log(ctx, 5)
+		if err != nil {
+			t.Fatalf("Log failed: %v", err)
+		}
+		_ = logs
+	})
+}


### PR DESCRIPTION
## Summary
  - Exports RemoteStore (push/pull/fetch/remote management) and SyncStore (peer sync) as type aliases
  - Adds VersionControlReader — a new read-only interface for branch/log/status operations
  - Exports associated types: RemoteInfo, SyncResult, SyncStatus, Conflict, CommitInfo, VCStatus, StatusEntry
  - Adds TestPublicAPITypeAssertions smoke test

  ## Design decisions
  - No DoltStorage export: the full composite pulls in unexported argument types. Consumers type-assert to individual interfaces.
  - VersionControlReader is a new narrow interface, not an alias of internal VersionControl. Write ops omitted for now.

  ## Backwards compatibility
  Purely additive. No changes to existing behavior.

  Closes #2769