### PR TITLE
feat: SearchIssues bulk dependency hydration

### DIFF
--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -1187,6 +1187,99 @@ func TestSearchIssues_IssueTypeFilter(t *testing.T) {
 	}
 }
 
+func TestSearchIssues_IncludeDependencies(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{
+		ID:        "si-dep-parent",
+		Title:     "DepHydration Parent",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	child := &types.Issue{
+		ID:        "si-dep-child",
+		Title:     "DepHydration Child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	standalone := &types.Issue{
+		ID:        "si-dep-standalone",
+		Title:     "DepHydration Standalone",
+		Status:    types.StatusOpen,
+		Priority:  3,
+		IssueType: types.TypeTask,
+	}
+	for _, iss := range []*types.Issue{parent, child, standalone} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("failed to create issue %s: %v", iss.ID, err)
+		}
+	}
+
+	dep := &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: parent.ID,
+		Type:        types.DepBlocks,
+	}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("failed to add dependency: %v", err)
+	}
+
+	t.Run("false_by_default", func(t *testing.T) {
+		results, err := store.SearchIssues(ctx, "DepHydration", types.IssueFilter{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, iss := range results {
+			if len(iss.Dependencies) > 0 {
+				t.Errorf("issue %s has Dependencies populated without IncludeDependencies", iss.ID)
+			}
+		}
+	})
+
+	t.Run("true_hydrates_deps", func(t *testing.T) {
+		results, err := store.SearchIssues(ctx, "DepHydration", types.IssueFilter{
+			IncludeDependencies: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 3 {
+			t.Fatalf("expected 3 results, got %d", len(results))
+		}
+
+		depsByID := make(map[string][]*types.Dependency)
+		for _, iss := range results {
+			depsByID[iss.ID] = iss.Dependencies
+		}
+
+		// child should have one dependency on parent
+		childDeps := depsByID[child.ID]
+		if len(childDeps) != 1 {
+			t.Fatalf("child expected 1 dependency, got %d", len(childDeps))
+		}
+		if childDeps[0].DependsOnID != parent.ID {
+			t.Errorf("child dep.DependsOnID = %s, want %s", childDeps[0].DependsOnID, parent.ID)
+		}
+		if childDeps[0].Type != types.DepBlocks {
+			t.Errorf("child dep.Type = %s, want %s", childDeps[0].Type, types.DepBlocks)
+		}
+
+		// parent and standalone should have no dependencies
+		if len(depsByID[parent.ID]) != 0 {
+			t.Errorf("parent expected 0 dependencies, got %d", len(depsByID[parent.ID]))
+		}
+		if len(depsByID[standalone.ID]) != 0 {
+			t.Errorf("standalone expected 0 dependencies, got %d", len(depsByID[standalone.ID]))
+		}
+	})
+}
+
 // =============================================================================
 // GetStatistics tests
 // =============================================================================

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -109,6 +109,19 @@ func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 				issue.Labels = labels
 			}
 		}
+
+		// Optionally hydrate dependencies in bulk (same batched pattern as labels).
+		if filter.IncludeDependencies {
+			depMap, depErr := GetDependencyRecordsForIssuesInTx(ctx, tx, ids)
+			if depErr != nil {
+				return nil, fmt.Errorf("search %s: hydrate dependencies: %w", tables.Main, depErr)
+			}
+			for _, issue := range issues {
+				if deps, ok := depMap[issue.ID]; ok {
+					issue.Dependencies = deps
+				}
+			}
+		}
 	}
 
 	return issues, nil

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1066,6 +1066,10 @@ type IssueFilter struct {
 	// Metadata field filtering (GH#1406)
 	MetadataFields map[string]string // Top-level key=value equality; AND semantics (all must match)
 	HasMetadataKey string            // Existence check: issue has this top-level key set (non-null)
+
+	// Hydration options — control which relational data is populated on returned issues.
+	// Labels are always hydrated. Dependencies are not by default (for performance).
+	IncludeDependencies bool // When true, populate Issue.Dependencies with []*Dependency records
 }
 
 // SortPolicy determines how ready work is ordered


### PR DESCRIPTION
## Summary
  - Adds IncludeDependencies bool to IssueFilter for opt-in bulk dependency loading
  - When set, SearchIssuesInTx populates Issue.Dependencies with []*Dependency records using existing batched GetDependencyRecordsForIssuesInTx loader
  - Adds TestSearchIssues_IncludeDependencies covering default (no deps) and hydrated cases

  ## Motivation
  Library consumers building board/kanban views need issues + blocking dependencies in one call. Without this, they hit N+1 GetDependencies per issue or fall back to bd CLI subprocess.

  ## Backwards compatibility
  Adding a field to IssueFilter is a source-compat break for unkeyed composite literals, but the struct has 30+ fields so unkeyed usage is impractical. Zero-value preserves current behavior.

  ## Known test gap
  Persistent-only coverage. Mixed wisp+persistent hydration path is sound (reviewer-verified routing logic) but not exercised in tests yet.

  Closes #2768