### PR TITLE
fix: prevent resolveCommandBeadsDir from falling back to CWD-based discovery

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -157,25 +157,24 @@ func resolveCommandBeadsDir(dbPath string) string {
 		return ""
 	}
 
-	guessedBeadsDir := filepath.Dir(dbPath)
-
 	// BEADS_DB is an explicit database override, so preserve its legacy
 	// filepath.Dir behavior instead of trying to rediscover a repo-local .beads.
 	if os.Getenv("BEADS_DB") != "" {
-		return guessedBeadsDir
+		return filepath.Dir(dbPath)
 	}
 
-	if cfg, err := configfile.Load(guessedBeadsDir); err == nil && cfg != nil {
-		if utils.PathsEqual(cfg.DatabasePath(guessedBeadsDir), dbPath) {
-			return guessedBeadsDir
-		}
+	// Use the same validated candidate logic as the helper/reopen path
+	// (GH#2627). This checks filepath.Dir, canonicalized paths, AND
+	// FindBeadsDir — but only returns a candidate whose metadata.json
+	// actually points to dbPath, preventing CWD discovery from overriding
+	// an explicit --db flag.
+	if beadsDir := resolveBeadsDirForDBPath(dbPath); beadsDir != "" {
+		return beadsDir
 	}
 
-	if discoveredBeadsDir := beads.FindBeadsDir(); discoveredBeadsDir != "" {
-		return discoveredBeadsDir
-	}
-
-	return guessedBeadsDir
+	// No candidate matched — fall back to parent directory of the db path.
+	// This handles bootstrap/init where no metadata.json exists yet.
+	return filepath.Dir(dbPath)
 }
 
 // getActorWithGit returns the actor for audit trails with git config fallback.

--- a/cmd/bd/store_reopen_test.go
+++ b/cmd/bd/store_reopen_test.go
@@ -103,6 +103,53 @@ func TestIssueIDCompletion_UsesMetadataWhenStoreNil(t *testing.T) {
 	}
 }
 
+func TestResolveCommandBeadsDir_NoCWDFallbackForExplicitPath(t *testing.T) {
+	// Set up project A with metadata so FindBeadsDir() discovers it from CWD.
+	projectA := t.TempDir()
+	beadsDirA := filepath.Join(projectA, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDirA, "dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir beads dir A: %v", err)
+	}
+	cfgA := &configfile.Config{
+		Database:     "dolt",
+		Backend:      configfile.BackendDolt,
+		DoltDatabase: "project_a_db",
+	}
+	if err := cfgA.Save(beadsDirA); err != nil {
+		t.Fatalf("save metadata A: %v", err)
+	}
+
+	// Project B: .beads/dolt exists but metadata.json is missing.
+	// This triggers the bug: filepath.Dir(dbPath) gives the correct
+	// .beads dir but configfile.Load returns nil, so the old code falls
+	// through to FindBeadsDir() which discovers project A instead.
+	projectB := t.TempDir()
+	beadsDirB := filepath.Join(projectB, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDirB, "dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir beads dir B: %v", err)
+	}
+
+	// CWD is inside project A so FindBeadsDir() discovers A
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectA); err != nil {
+		t.Fatalf("chdir to project A: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// Simulate --db pointing to project B's database path
+	dbPathB := filepath.Join(beadsDirB, "dolt")
+	got := resolveCommandBeadsDir(dbPathB)
+
+	// Must resolve to project B's .beads, NOT project A's.
+	// The old code falls back to FindBeadsDir() and returns beadsDirA.
+	if !utils.PathsEqual(got, beadsDirB) {
+		t.Fatalf("resolveCommandBeadsDir(%q) = %q, want %q", dbPathB, got, beadsDirB)
+	}
+}
+
 func TestGetGitHubConfigValue_UsesMetadataWhenStoreNil(t *testing.T) {
 	originalStore := store
 	originalDBPath := dbPath


### PR DESCRIPTION
When --db points to a different project, resolveCommandBeadsDir() would fall back to beads.FindBeadsDir() if filepath.Dir(dbPath) didn't have a matching metadata.json. FindBeadsDir() walks from CWD and discovers the local project's .beads/ directory, causing the wrong database name to be used in the Dolt DSN.

Delegate to resolveBeadsDirForDBPath() (introduced in GH#2627 for helper paths), which validates all candidates against dbPath before returning. This ensures CWD-based discovery only wins if its config actually points to the given database path.

What would happen before this fix is:

```shell
~/workspace/bjornstack $ bd list --db ~/workspace/inbox/.beads/
○ bs-4e7 ● P1 [epic] (EPIC) Implement all strategies and protocols
# … cut
# shows the beads from the ~/workspace/bjornstack project
```

But with the change in place it lists the beads in the other DB:

```shell
~/workspace/bjornstack $ bd list --db ~/workspace/inbox/.beads/
○ in-12b ● P1 [epic] Define breadcrumb workflow
# … cut
# as expected, shows the beads from the inbox project

~/workspace/bjornstack $ bd list
○ bs-4e7 ● P1 [epic] (EPIC) Implement all strategies and protocols
# … cut
```