### PR TITLE
fix: bd bootstrap detects remote data in fresh clones

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -49,6 +49,30 @@ Examples:
 		// Find beads directory
 		beadsDir := beads.FindBeadsDir()
 		if beadsDir == "" {
+			// No .beads directory exists yet. Before giving up, probe the
+			// git remote for existing Beads data (refs/dolt/data). This is
+			// the "fresh second clone" case: clone1 pushed Beads state to
+			// origin, and clone2 needs to bootstrap from it. (GH#2792)
+			//
+			// If found, synthesize the theoretical .beads path and fall
+			// through to the normal detectBootstrapAction + executeBootstrapPlan
+			// flow. Actual directory creation is deferred to executeSyncAction
+			// to preserve --dry-run semantics.
+			if isGitRepo() && !isBareGitRepo() {
+				if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
+					if gitLsRemoteHasRef("origin", "refs/dolt/data") {
+						cwd, err := os.Getwd()
+						if err != nil {
+							FatalError("failed to get working directory: %v", err)
+						}
+						beadsDir = filepath.Join(cwd, ".beads")
+					}
+				}
+			}
+		}
+
+		if beadsDir == "" {
+			// No .beads and no remote data — nothing to bootstrap from.
 			if jsonOutput {
 				outputJSON(map[string]interface{}{
 					"action":     "none",
@@ -86,8 +110,7 @@ Examples:
 
 		// Execute the plan
 		if err := executeBootstrapPlan(plan, cfg); err != nil {
-			fmt.Fprintf(os.Stderr, "Bootstrap failed: %v\n", err)
-			os.Exit(1)
+			FatalError("Bootstrap failed: %v", err)
 		}
 	},
 }
@@ -328,6 +351,13 @@ func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *conf
 }
 
 func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config) error {
+	// Ensure .beads directory exists — it may not in the "fresh clone"
+	// bootstrap path where we detected remote data before .beads was
+	// created. Deferred here to preserve --dry-run semantics. (GH#2792)
+	if err := os.MkdirAll(plan.BeadsDir, 0o750); err != nil {
+		return fmt.Errorf("create beads directory: %w", err)
+	}
+
 	dbName := cfg.GetDoltDatabase()
 
 	if isEmbeddedMode() {

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -230,3 +230,140 @@ func runGitForBootstrapTest(t *testing.T, dir string, args ...string) {
 		t.Fatalf("git %v failed: %v\n%s", args, err, string(output))
 	}
 }
+
+// TestBootstrapFreshCloneDetectsRemote verifies that when .beads does NOT
+// exist but origin has refs/dolt/data, the bootstrap handler's remote-probe
+// logic synthesizes beadsDir and detectBootstrapAction produces a "sync"
+// plan instead of the handler exiting with "No .beads directory found".
+// This is the core fix for GH#2792.
+func TestBootstrapFreshCloneDetectsRemote(t *testing.T) {
+	// Create a bare repo and push a fake refs/dolt/data ref to it.
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+
+	sourceDir := t.TempDir()
+	runGitForBootstrapTest(t, sourceDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.email", "test@test.com")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
+	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
+	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
+
+	// Clone into a fresh directory — no .beads exists.
+	cloneDir := t.TempDir()
+	runGitForBootstrapTest(t, cloneDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, cloneDir, "remote", "add", "origin", bareDir)
+
+	// Verify .beads does NOT exist.
+	beadsDir := filepath.Join(cloneDir, ".beads")
+	if _, err := os.Stat(beadsDir); err == nil {
+		t.Fatal(".beads should not exist before bootstrap")
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(cloneDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Replicate the Run handler's remote-probe logic: when beadsDir is
+	// empty, check origin for refs/dolt/data and synthesize beadsDir.
+	// This exercises the same code path the handler uses before calling
+	// detectBootstrapAction.
+	if !isGitRepo() {
+		t.Fatal("expected to be in a git repo")
+	}
+	originURL, err := gitRemoteGetURL("origin")
+	if err != nil || originURL == "" {
+		t.Fatalf("expected origin URL, got err=%v url=%q", err, originURL)
+	}
+	if !gitLsRemoteHasRef("origin", "refs/dolt/data") {
+		t.Fatal("expected origin to have refs/dolt/data")
+	}
+
+	// Synthesize beadsDir the same way the handler does, then feed it
+	// through detectBootstrapAction — the single code path for plan building.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	synthesizedDir := filepath.Join(cwd, ".beads")
+	cfg := configfile.DefaultConfig()
+	plan := detectBootstrapAction(synthesizedDir, cfg)
+
+	if plan.Action != "sync" {
+		t.Errorf("action = %q, want %q", plan.Action, "sync")
+	}
+	if plan.SyncRemote == "" {
+		t.Error("SyncRemote should not be empty")
+	}
+	if plan.BeadsDir != synthesizedDir {
+		t.Errorf("BeadsDir = %q, want %q", plan.BeadsDir, synthesizedDir)
+	}
+}
+
+// TestBootstrapFreshCloneNoRemoteData verifies that when .beads does NOT exist
+// and origin has NO refs/dolt/data, bootstrap correctly reports no data found
+// (does not create .beads or crash).
+func TestBootstrapFreshCloneNoRemoteData(t *testing.T) {
+	// Create a bare repo WITHOUT refs/dolt/data.
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+
+	cloneDir := t.TempDir()
+	runGitForBootstrapTest(t, cloneDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, cloneDir, "remote", "add", "origin", bareDir)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(cloneDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// When no .beads and no remote data, the remote probe should return false.
+	if !isGitRepo() {
+		t.Fatal("expected to be in a git repo")
+	}
+	if gitLsRemoteHasRef("origin", "refs/dolt/data") {
+		t.Fatal("origin should NOT have refs/dolt/data")
+	}
+
+	// .beads should still not exist after detection.
+	beadsDir := filepath.Join(cloneDir, ".beads")
+	if _, err := os.Stat(beadsDir); err == nil {
+		t.Fatal(".beads should not be created when remote has no data")
+	}
+}
+
+// TestBootstrapExistingBeadsDirUnchanged verifies that when .beads already
+// exists, the normal bootstrap flow is unaffected by the fresh-clone fix.
+func TestBootstrapExistingBeadsDirUnchanged(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// With .beads present but empty, detectBootstrapAction should return "init".
+	cfg := configfile.DefaultConfig()
+	plan := detectBootstrapAction(beadsDir, cfg)
+	if plan.Action != "init" {
+		t.Errorf("action = %q, want %q for existing empty .beads", plan.Action, "init")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2792 — `bd bootstrap` now detects `refs/dolt/data` on the git remote in a fresh clone where `.beads` doesn't exist yet, enabling the expected clone1→push→clone2→bootstrap flow.

## Problem

`bd bootstrap` in a fresh second clone failed with:

```
No .beads directory found.
To create a new project, use: bd init
Bootstrap is for existing projects that need database setup.
```

Even though the origin had `refs/dolt/data` from clone1's `bd dolt push`.

**Root cause:** `bootstrap.go` called `beads.FindBeadsDir()` and exited immediately when it returned empty (line 48-62), before `detectBootstrapAction()` could run its remote detection logic (lines 132-142). Bootstrap required `.beads` to pre-exist — which defeats the purpose of bootstrapping a fresh clone.

## Changes

**`cmd/bd/bootstrap.go`:**
- When `.beads` doesn't exist, probe `origin` for `refs/dolt/data` before giving up
- If remote has Beads data: synthesize the theoretical `.beads` path, build a sync plan, and proceed
- `.beads` directory creation deferred to `executeSyncAction` (preserves `--dry-run` semantics)
- No `config.yaml` generation needed — the Dolt clone already carries canonical config
- If no remote data found: fall through to existing error message

**`cmd/bd/bootstrap_test.go`:**
- `TestBootstrapFreshCloneDetectsRemote` — fresh clone with `refs/dolt/data` on origin
- `TestBootstrapFreshCloneNoRemoteData` — fresh clone with no remote data (clean exit)
- `TestBootstrapExistingBeadsDirUnchanged` — existing `.beads` flow unaffected

## Design Decisions (per council review)

- **No filesystem writes during plan generation** — `--dry-run` and `--json` remain side-effect-free
- **No config.yaml needed** — Dolt clone carries config in internal tables
- **`.beads` created at 0750** in `executeSyncAction` only, matching existing permissions pattern
- **All existing bootstrap scenarios unchanged** — only the "no .beads + remote has data" path is new

## Checklist

- [x] Tests added (3 new: fresh clone with/without remote data, existing .beads unchanged)
- [x] `make test` passes (all packages)
- [x] `golangci-lint run` — 0 issues
- [x] Feature branch per contributing guidelines
