### PR TITLE
fix: batch wisp routing to eliminate N+1 queries over remote dolt

### DIFF
--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -53,13 +53,9 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 
 	result := make(map[string]int)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispStatusInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("partition wisp status: %w", err)
 	}
 
 	for _, pair := range []struct {

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -42,13 +42,9 @@ func GetDependencyRecordsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs
 
 	result := make(map[string][]*types.Dependency)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispStatusInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("partition wisp status: %w", err)
 	}
 
 	for _, pair := range []struct {
@@ -204,13 +200,9 @@ func GetBlockingInfoForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []st
 	}
 
 	// Partition into wisp and perm IDs for routing.
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispStatusInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("partition wisp status: %w", err)
 	}
 
 	// Process wisp IDs against wisp_dependencies.

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -45,13 +45,9 @@ func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) 
 
 	result := make(map[string][]string)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispStatusInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("partition wisp status: %w", err)
 	}
 
 	for _, pair := range []struct {

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -3,6 +3,7 @@ package issueops
 import (
 	"context"
 	"database/sql"
+	"strings"
 )
 
 // IsActiveWispInTx checks whether the given ID exists in the wisps table
@@ -13,6 +14,63 @@ func IsActiveWispInTx(ctx context.Context, tx *sql.Tx, id string) bool {
 	var exists int
 	err := tx.QueryRowContext(ctx, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1", id).Scan(&exists)
 	return err == nil
+}
+
+// PartitionByWispStatusInTx splits issue IDs into wisp and permanent (non-wisp)
+// groups using batch queries instead of per-ID lookups. This avoids N+1 query
+// patterns that are catastrophic over high-latency connections.
+func PartitionByWispStatusInTx(ctx context.Context, tx *sql.Tx, ids []string) (wispIDs, permIDs []string, err error) {
+	if len(ids) == 0 {
+		return nil, nil, nil
+	}
+
+	wispSet := make(map[string]bool, len(ids))
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]interface{}, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+
+		query := "SELECT id FROM wisps WHERE id IN (" + strings.Join(placeholders, ",") + ")"
+		rows, err := tx.QueryContext(ctx, query, args...)
+		if err != nil {
+			// If wisps table doesn't exist, all IDs are permanent.
+			if isTableNotExistError(err) {
+				return nil, ids, nil
+			}
+			return nil, nil, err
+		}
+
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return nil, nil, err
+			}
+			wispSet[id] = true
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	for _, id := range ids {
+		if wispSet[id] {
+			wispIDs = append(wispIDs, id)
+		} else {
+			permIDs = append(permIDs, id)
+		}
+	}
+	return wispIDs, permIDs, nil
 }
 
 // WispTableRouting returns the appropriate issue, label, event, and dependency


### PR DESCRIPTION
## Problem

`bd list` with v0.62.0 is ~100x slower over a remote dolt server compared to v0.60.0 and compared to localhost. A list of 50 beads takes 2+ minutes over Tailscale VPN (120ms RTT) but 0.5s on localhost.

## Root Cause

The `issueops` package refactor replaced v0.60.0's batch `batchWispExists()` with per-ID `IsActiveWispInTx()` calls. Three hot-path functions loop over all issue IDs and call `SELECT 1 FROM wisps WHERE id = ? LIMIT 1` for each:

- `GetLabelsForIssuesInTx` (labels.go:50)
- `GetDependencyRecordsForIssuesInTx` (dependency_queries.go:47)
- `GetBlockingInfoForIssuesInTx` (dependency_queries.go:209)
- `GetCommentCountsForIssuesInTx` (comments.go:58)

For N beads, this adds ~3-4N network round-trips. At 120ms RTT: 150 queries x 120ms = 18 seconds.

## Fix

Added `PartitionByWispStatusInTx()` that does `SELECT id FROM wisps WHERE id IN (...)` in batches of 200 (matching `queryBatchSize`). Replaced all four loop call sites. Total queries drops from ~3N+8 back to ~12 regardless of bead count.

## Testing

- `go build ./...` passes
- 4 files changed, 70 insertions, 28 deletions