### PR TITLE
fix: move circuit breaker files to subdirectory to avoid scanning /tmp

### DIFF
--- a/internal/storage/dolt/circuit.go
+++ b/internal/storage/dolt/circuit.go
@@ -75,14 +75,20 @@ func maybeNewCircuitBreaker(host string, port int) *circuitBreaker {
 	return newCircuitBreaker(host, port)
 }
 
+// circuitBreakerDir is the dedicated directory for circuit breaker state files.
+// Using a subdirectory avoids scanning all of /tmp (which may contain millions
+// of entries) when cleaning up stale breaker files on startup.
+const circuitBreakerDir = "/tmp/beads-circuit"
+
 // newCircuitBreaker creates a circuit breaker for the given Dolt server host:port.
 func newCircuitBreaker(host string, port int) *circuitBreaker {
 	// Sanitize host for use in filename (replace dots/colons with dashes)
 	safeHost := strings.NewReplacer(".", "-", ":", "-").Replace(host)
+	_ = os.MkdirAll(circuitBreakerDir, 0755)
 	return &circuitBreaker{
 		host:     host,
 		port:     port,
-		filePath: fmt.Sprintf("/tmp/beads-dolt-circuit-%s-%d.json", safeHost, port),
+		filePath: filepath.Join(circuitBreakerDir, fmt.Sprintf("beads-dolt-circuit-%s-%d.json", safeHost, port)),
 	}
 }
 
@@ -287,14 +293,20 @@ func (cb *circuitBreaker) writeState(state circuitState) {
 	_ = os.Rename(tmp, cb.filePath)
 }
 
-// CleanStaleCircuitBreakerFiles removes stale circuit breaker files from /tmp.
+// CleanStaleCircuitBreakerFiles removes stale circuit breaker files.
 // This cleans up leftover files that could poison fresh inits:
 //   - Legacy port-0 files (beads-dolt-circuit-0.json) from before the port-0 fix
 //   - Any breaker file whose open/half-open state is older than circuitStaleTTL
 //
 // Called during init to ensure a clean starting state (GH#2598).
 func CleanStaleCircuitBreakerFiles() {
-	cleanStaleCircuitBreakerFilesIn("/tmp")
+	// Remove legacy files that lived directly in /tmp (before the subdirectory move).
+	// Direct path removal — no directory scan needed.
+	_ = os.Remove("/tmp/beads-dolt-circuit-0.json")
+
+	// Clean stale files in the dedicated subdirectory (fast — typically 0-2 files).
+	_ = os.MkdirAll(circuitBreakerDir, 0755)
+	cleanStaleCircuitBreakerFilesIn(circuitBreakerDir)
 }
 
 // cleanStaleCircuitBreakerFilesIn is the testable implementation of

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -378,6 +378,24 @@ func TestCleanStaleCircuitBreakerFiles(t *testing.T) {
 	}
 }
 
+func TestCircuitBreakerDir_UsesSubdirectory(t *testing.T) {
+	// Verify that circuit breaker files are created in the dedicated
+	// subdirectory, not directly in /tmp (which can have millions of entries).
+	cb := newCircuitBreaker("127.0.0.1", 44444)
+	t.Cleanup(func() { os.Remove(cb.filePath) })
+
+	if filepath.Dir(cb.filePath) != circuitBreakerDir {
+		t.Errorf("circuit breaker file should be in %s, got dir %s",
+			circuitBreakerDir, filepath.Dir(cb.filePath))
+	}
+
+	// Write state and verify file lands in the subdirectory
+	cb.writeState(circuitState{State: circuitClosed})
+	if _, err := os.Stat(cb.filePath); err != nil {
+		t.Errorf("circuit breaker file should exist at %s: %v", cb.filePath, err)
+	}
+}
+
 func TestIsConnectionError(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Circuit breaker cleanup (`CleanStaleCircuitBreakerFiles`) calls `filepath.Glob` on `/tmp` to find stale breaker files. On machines where `/tmp` has millions of entries (e.g. ~4M on a busy CI/dev server), this adds **~3 seconds** of startup overhead to every `bd` command — even trivial ones like `bd config get`.
- Moves breaker state files from `/tmp/beads-dolt-circuit-*.json` to a dedicated `/tmp/beads-circuit/` subdirectory so the glob only scans a tiny directory (typically 0-2 files).
- Legacy port-0 files in `/tmp` are removed by direct path (no glob needed).

## Profiling evidence

`go tool pprof` on `bd ready` showed ~95% of sampled CPU time in `filepath.Glob` → `os.(*File).Readdirnames` → directory scanning/sorting at `circuit.go:304`. The root cause is `/tmp` having ~4M entries.

## Changes

- `circuit.go`: New `circuitBreakerDir` constant (`/tmp/beads-circuit/`), `newCircuitBreaker` creates files there, `CleanStaleCircuitBreakerFiles` scans only the subdirectory
- `circuit_test.go`: New `TestCircuitBreakerDir_UsesSubdirectory` test; existing tests still pass

## Test plan

- [x] All existing circuit breaker tests pass (`go test ./internal/storage/dolt/ -run TestCircuitBreaker -v`)
- [x] `TestCleanStaleCircuitBreakerFiles` still validates stale/fresh/legacy file cleanup
- [x] New test verifies files are created in `/tmp/beads-circuit/`, not `/tmp/`
- [ ] Manual verification: `time bd config get status.custom` drops from ~3s to <0.1s after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)