### PR TITLE
feat: Add optional group-level GitLab issue sync

### DIFF
--- a/cmd/bd/gitlab.go
+++ b/cmd/bd/gitlab.go
@@ -78,6 +78,12 @@ var (
 	gitlabPreferLocal  bool
 	gitlabPreferGitLab bool
 	gitlabPreferNewer  bool
+
+	// Filter flags for sync
+	gitlabFilterLabel     string
+	gitlabFilterProject   string
+	gitlabFilterMilestone string
+	gitlabFilterAssignee  string
 )
 
 // issueIDCounter is used to generate unique issue IDs.
@@ -175,6 +181,12 @@ func init() {
 	gitlabSyncCmd.Flags().BoolVar(&gitlabPreferGitLab, "prefer-gitlab", false, "On conflict, use GitLab version")
 	gitlabSyncCmd.Flags().BoolVar(&gitlabPreferNewer, "prefer-newer", false, "On conflict, use most recent version (default)")
 
+	// Filter flags (override config defaults)
+	gitlabSyncCmd.Flags().StringVar(&gitlabFilterLabel, "label", "", "Filter by labels (comma-separated, AND logic)")
+	gitlabSyncCmd.Flags().StringVar(&gitlabFilterProject, "project", "", "Filter to issues from this project ID (group mode)")
+	gitlabSyncCmd.Flags().StringVar(&gitlabFilterMilestone, "milestone", "", "Filter by milestone title")
+	gitlabSyncCmd.Flags().StringVar(&gitlabFilterAssignee, "assignee", "", "Filter by assignee username")
+
 	// Register gitlab command with root
 	rootCmd.AddCommand(gitlabCmd)
 }
@@ -236,6 +248,14 @@ func gitlabConfigToEnvVar(key string) string {
 		return "GITLAB_GROUP_ID"
 	case "gitlab.default_project_id":
 		return "GITLAB_DEFAULT_PROJECT_ID"
+	case "gitlab.filter_labels":
+		return "GITLAB_FILTER_LABELS"
+	case "gitlab.filter_project":
+		return "GITLAB_FILTER_PROJECT"
+	case "gitlab.filter_milestone":
+		return "GITLAB_FILTER_MILESTONE"
+	case "gitlab.filter_assignee":
+		return "GITLAB_FILTER_ASSIGNEE"
 	default:
 		return ""
 	}
@@ -302,6 +322,28 @@ func runGitLabStatus(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		_, _ = fmt.Fprintf(out, "Sync Mode:  project\n")
+	}
+
+	// Show configured filters
+	ctx := context.Background()
+	filterLabels := getGitLabConfigValue(ctx, "gitlab.filter_labels")
+	filterProject := getGitLabConfigValue(ctx, "gitlab.filter_project")
+	filterMilestone := getGitLabConfigValue(ctx, "gitlab.filter_milestone")
+	filterAssignee := getGitLabConfigValue(ctx, "gitlab.filter_assignee")
+	if filterLabels != "" || filterProject != "" || filterMilestone != "" || filterAssignee != "" {
+		_, _ = fmt.Fprintf(out, "\nFilters:\n")
+		if filterLabels != "" {
+			_, _ = fmt.Fprintf(out, "  Labels:    %s\n", filterLabels)
+		}
+		if filterProject != "" {
+			_, _ = fmt.Fprintf(out, "  Project:   %s\n", filterProject)
+		}
+		if filterMilestone != "" {
+			_, _ = fmt.Fprintf(out, "  Milestone: %s\n", filterMilestone)
+		}
+		if filterAssignee != "" {
+			_, _ = fmt.Fprintf(out, "  Assignee:  %s\n", filterAssignee)
+		}
 	}
 
 	// Validate configuration
@@ -383,6 +425,11 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("initializing GitLab tracker: %w", err)
 	}
 
+	// Apply CLI filter overrides (take precedence over config defaults)
+	if cliFilter := buildCLIFilter(); cliFilter != nil {
+		gt.SetFilter(cliFilter)
+	}
+
 	// Create the sync engine
 	engine := tracker.NewEngine(gt, store, actor)
 	engine.OnMessage = func(msg string) { _, _ = fmt.Fprintln(out, "  "+msg) }
@@ -443,6 +490,26 @@ func runGitLabSync(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// buildCLIFilter constructs an IssueFilter from CLI flags.
+// Returns nil if no filter flags were provided.
+func buildCLIFilter() *gitlab.IssueFilter {
+	if gitlabFilterLabel == "" && gitlabFilterProject == "" &&
+		gitlabFilterMilestone == "" && gitlabFilterAssignee == "" {
+		return nil
+	}
+	filter := &gitlab.IssueFilter{
+		Labels:    gitlabFilterLabel,
+		Milestone: gitlabFilterMilestone,
+		Assignee:  gitlabFilterAssignee,
+	}
+	if gitlabFilterProject != "" {
+		if pid, err := strconv.Atoi(gitlabFilterProject); err == nil {
+			filter.ProjectID = pid
+		}
+	}
+	return filter
 }
 
 // buildGitLabPullHooks creates PullHooks for GitLab-specific pull behavior.

--- a/cmd/bd/gitlab_test.go
+++ b/cmd/bd/gitlab_test.go
@@ -148,6 +148,10 @@ func TestGitLabConfigEnvVar(t *testing.T) {
 		{"gitlab.project_id", "GITLAB_PROJECT_ID"},
 		{"gitlab.group_id", "GITLAB_GROUP_ID"},
 		{"gitlab.default_project_id", "GITLAB_DEFAULT_PROJECT_ID"},
+		{"gitlab.filter_labels", "GITLAB_FILTER_LABELS"},
+		{"gitlab.filter_project", "GITLAB_FILTER_PROJECT"},
+		{"gitlab.filter_milestone", "GITLAB_FILTER_MILESTONE"},
+		{"gitlab.filter_assignee", "GITLAB_FILTER_ASSIGNEE"},
 		{"gitlab.unknown", ""},
 	}
 
@@ -254,5 +258,89 @@ func TestGitLabCmdRegistration(t *testing.T) {
 	}
 	if !hasProjects {
 		t.Error("gitlabCmd missing 'projects' subcommand")
+	}
+}
+
+// TestBuildCLIFilter_NoFlags verifies nil when no flags set.
+func TestBuildCLIFilter_NoFlags(t *testing.T) {
+	// Save and restore global flag state
+	savedLabel, savedProject, savedMilestone, savedAssignee := gitlabFilterLabel, gitlabFilterProject, gitlabFilterMilestone, gitlabFilterAssignee
+	t.Cleanup(func() {
+		gitlabFilterLabel, gitlabFilterProject, gitlabFilterMilestone, gitlabFilterAssignee = savedLabel, savedProject, savedMilestone, savedAssignee
+	})
+
+	gitlabFilterLabel = ""
+	gitlabFilterProject = ""
+	gitlabFilterMilestone = ""
+	gitlabFilterAssignee = ""
+
+	filter := buildCLIFilter()
+	if filter != nil {
+		t.Errorf("buildCLIFilter() = %+v, want nil when no flags set", filter)
+	}
+}
+
+// TestBuildCLIFilter_WithFlags verifies filter is built from flags.
+func TestBuildCLIFilter_WithFlags(t *testing.T) {
+	savedLabel, savedProject, savedMilestone, savedAssignee := gitlabFilterLabel, gitlabFilterProject, gitlabFilterMilestone, gitlabFilterAssignee
+	t.Cleanup(func() {
+		gitlabFilterLabel, gitlabFilterProject, gitlabFilterMilestone, gitlabFilterAssignee = savedLabel, savedProject, savedMilestone, savedAssignee
+	})
+
+	gitlabFilterLabel = "bug,backend"
+	gitlabFilterProject = "42"
+	gitlabFilterMilestone = "Sprint 1"
+	gitlabFilterAssignee = "kyriakos"
+
+	filter := buildCLIFilter()
+	if filter == nil {
+		t.Fatal("buildCLIFilter() = nil, want non-nil")
+	}
+	if filter.Labels != "bug,backend" {
+		t.Errorf("Labels = %q, want %q", filter.Labels, "bug,backend")
+	}
+	if filter.ProjectID != 42 {
+		t.Errorf("ProjectID = %d, want 42", filter.ProjectID)
+	}
+	if filter.Milestone != "Sprint 1" {
+		t.Errorf("Milestone = %q, want %q", filter.Milestone, "Sprint 1")
+	}
+	if filter.Assignee != "kyriakos" {
+		t.Errorf("Assignee = %q, want %q", filter.Assignee, "kyriakos")
+	}
+}
+
+// TestBuildCLIFilter_PartialFlags verifies filter works with some flags.
+func TestBuildCLIFilter_PartialFlags(t *testing.T) {
+	savedLabel, savedProject, savedMilestone, savedAssignee := gitlabFilterLabel, gitlabFilterProject, gitlabFilterMilestone, gitlabFilterAssignee
+	t.Cleanup(func() {
+		gitlabFilterLabel, gitlabFilterProject, gitlabFilterMilestone, gitlabFilterAssignee = savedLabel, savedProject, savedMilestone, savedAssignee
+	})
+
+	gitlabFilterLabel = "frontend"
+	gitlabFilterProject = ""
+	gitlabFilterMilestone = ""
+	gitlabFilterAssignee = ""
+
+	filter := buildCLIFilter()
+	if filter == nil {
+		t.Fatal("buildCLIFilter() = nil, want non-nil")
+	}
+	if filter.Labels != "frontend" {
+		t.Errorf("Labels = %q, want %q", filter.Labels, "frontend")
+	}
+	if filter.ProjectID != 0 {
+		t.Errorf("ProjectID = %d, want 0", filter.ProjectID)
+	}
+}
+
+// TestSyncCmdHasFilterFlags verifies filter flags are registered on sync command.
+func TestSyncCmdHasFilterFlags(t *testing.T) {
+	flags := []string{"label", "project", "milestone", "assignee"}
+	for _, name := range flags {
+		f := gitlabSyncCmd.Flags().Lookup(name)
+		if f == nil {
+			t.Errorf("sync command missing --%s flag", name)
+		}
 	}
 }

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -166,9 +166,46 @@ func (c *Client) doRequest(ctx context.Context, method, urlStr string, body inte
 	return nil, nil, fmt.Errorf("max retries (%d) exceeded: %w", MaxRetries+1, lastErr)
 }
 
-// FetchIssues retrieves issues from GitLab with optional filtering by state.
+// applyFilter adds IssueFilter fields as query parameters to the params map.
+// ProjectID filtering is done client-side (not supported by GitLab API on group endpoints).
+func applyFilter(params map[string]string, filter *IssueFilter) {
+	if filter == nil {
+		return
+	}
+	if filter.Labels != "" {
+		params["labels"] = filter.Labels
+	}
+	if filter.Milestone != "" {
+		params["milestone"] = filter.Milestone
+	}
+	if filter.Assignee != "" {
+		params["assignee_username"] = filter.Assignee
+	}
+}
+
+// filterByProject removes issues that don't match the filter's ProjectID.
+// Returns the input slice unmodified if filter is nil or ProjectID is 0.
+func filterByProject(issues []Issue, filter *IssueFilter) []Issue {
+	if filter == nil || filter.ProjectID == 0 {
+		return issues
+	}
+	filtered := make([]Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.ProjectID == filter.ProjectID {
+			filtered = append(filtered, issue)
+		}
+	}
+	return filtered
+}
+
+// FetchIssues retrieves issues from GitLab with optional filtering by state and IssueFilter.
 // state can be: "opened", "closed", or "all".
-func (c *Client) FetchIssues(ctx context.Context, state string) ([]Issue, error) {
+func (c *Client) FetchIssues(ctx context.Context, state string, filters ...*IssueFilter) ([]Issue, error) {
+	var filter *IssueFilter
+	if len(filters) > 0 {
+		filter = filters[0]
+	}
+
 	var allIssues []Issue
 	page := 1
 
@@ -187,6 +224,7 @@ func (c *Client) FetchIssues(ctx context.Context, state string) ([]Issue, error)
 		if state != "" && state != "all" {
 			params["state"] = state
 		}
+		applyFilter(params, filter)
 
 		urlStr := c.buildURL(c.issuesBasePath(), params)
 		respBody, headers, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
@@ -214,12 +252,17 @@ func (c *Client) FetchIssues(ctx context.Context, state string) ([]Issue, error)
 		}
 	}
 
-	return allIssues, nil
+	return filterByProject(allIssues, filter), nil
 }
 
 // FetchIssuesSince retrieves issues from GitLab that have been updated since the given time.
 // This enables incremental sync by only fetching issues modified after the last sync.
-func (c *Client) FetchIssuesSince(ctx context.Context, state string, since time.Time) ([]Issue, error) {
+func (c *Client) FetchIssuesSince(ctx context.Context, state string, since time.Time, filters ...*IssueFilter) ([]Issue, error) {
+	var filter *IssueFilter
+	if len(filters) > 0 {
+		filter = filters[0]
+	}
+
 	var allIssues []Issue
 	page := 1
 
@@ -241,6 +284,7 @@ func (c *Client) FetchIssuesSince(ctx context.Context, state string, since time.
 		if state != "" && state != "all" {
 			params["state"] = state
 		}
+		applyFilter(params, filter)
 
 		urlStr := c.buildURL(c.issuesBasePath(), params)
 		respBody, headers, err := c.doRequest(ctx, http.MethodGet, urlStr, nil)
@@ -268,7 +312,7 @@ func (c *Client) FetchIssuesSince(ctx context.Context, state string, since time.
 		}
 	}
 
-	return allIssues, nil
+	return filterByProject(allIssues, filter), nil
 }
 
 // CreateIssue creates a new issue in GitLab.

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -1096,3 +1096,205 @@ func TestCreateIssue_StillUsesProject(t *testing.T) {
 		t.Errorf("CreateIssue URL path = %s, want to contain /projects/456/issues", capturedPath)
 	}
 }
+
+// TestFetchIssues_WithLabelFilter verifies labels filter is passed as query param.
+func TestFetchIssues_WithLabelFilter(t *testing.T) {
+	var capturedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", server.URL, "123")
+	ctx := context.Background()
+
+	filter := &IssueFilter{Labels: "bug,backend"}
+	_, err := client.FetchIssues(ctx, "opened", filter)
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if !strings.Contains(capturedURL, "labels=bug%2Cbackend") && !strings.Contains(capturedURL, "labels=bug,backend") {
+		t.Errorf("URL = %s, want to contain labels param", capturedURL)
+	}
+}
+
+// TestFetchIssues_WithMilestoneFilter verifies milestone filter is passed as query param.
+func TestFetchIssues_WithMilestoneFilter(t *testing.T) {
+	var capturedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", server.URL, "123")
+	ctx := context.Background()
+
+	filter := &IssueFilter{Milestone: "Sprint 1"}
+	_, err := client.FetchIssues(ctx, "all", filter)
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if !strings.Contains(capturedURL, "milestone=") {
+		t.Errorf("URL = %s, want to contain milestone param", capturedURL)
+	}
+}
+
+// TestFetchIssues_WithAssigneeFilter verifies assignee filter is passed as query param.
+func TestFetchIssues_WithAssigneeFilter(t *testing.T) {
+	var capturedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", server.URL, "123")
+	ctx := context.Background()
+
+	filter := &IssueFilter{Assignee: "kyriakos"}
+	_, err := client.FetchIssues(ctx, "all", filter)
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if !strings.Contains(capturedURL, "assignee_username=kyriakos") {
+		t.Errorf("URL = %s, want to contain assignee_username=kyriakos", capturedURL)
+	}
+}
+
+// TestFetchIssues_WithProjectFilter verifies client-side project filtering.
+func TestFetchIssues_WithProjectFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 1, IID: 1, ProjectID: 10, Title: "Project 10 issue"},
+			{ID: 2, IID: 2, ProjectID: 20, Title: "Project 20 issue"},
+			{ID: 3, IID: 3, ProjectID: 10, Title: "Another project 10 issue"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", server.URL, "123").WithGroupID("mygroup")
+	ctx := context.Background()
+
+	filter := &IssueFilter{ProjectID: 10}
+	issues, err := client.FetchIssues(ctx, "all", filter)
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if len(issues) != 2 {
+		t.Errorf("FetchIssues() returned %d issues, want 2 (filtered to project 10)", len(issues))
+	}
+	for _, issue := range issues {
+		if issue.ProjectID != 10 {
+			t.Errorf("issue.ProjectID = %d, want 10", issue.ProjectID)
+		}
+	}
+}
+
+// TestFetchIssues_NilFilter verifies nil filter doesn't affect behavior.
+func TestFetchIssues_NilFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{{ID: 1, IID: 1, Title: "Issue"}})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", server.URL, "123")
+	ctx := context.Background()
+
+	// No filter arg
+	issues, err := client.FetchIssues(ctx, "all")
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Errorf("FetchIssues() returned %d issues, want 1", len(issues))
+	}
+
+	// Explicit nil filter
+	issues, err = client.FetchIssues(ctx, "all", nil)
+	if err != nil {
+		t.Fatalf("FetchIssues(nil) error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Errorf("FetchIssues(nil) returned %d issues, want 1", len(issues))
+	}
+}
+
+// TestFetchIssuesSince_WithFilter verifies filters work on FetchIssuesSince too.
+func TestFetchIssuesSince_WithFilter(t *testing.T) {
+	var capturedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{
+			{ID: 1, IID: 1, ProjectID: 10, Title: "Match"},
+			{ID: 2, IID: 2, ProjectID: 20, Title: "No match"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", server.URL, "123").WithGroupID("mygroup")
+	ctx := context.Background()
+
+	filter := &IssueFilter{Labels: "backend", Assignee: "user1", ProjectID: 10}
+	issues, err := client.FetchIssuesSince(ctx, "all", time.Now().Add(-24*time.Hour), filter)
+	if err != nil {
+		t.Fatalf("FetchIssuesSince() error = %v", err)
+	}
+
+	// API params should be set
+	if !strings.Contains(capturedURL, "labels=backend") {
+		t.Errorf("URL = %s, want to contain labels=backend", capturedURL)
+	}
+	if !strings.Contains(capturedURL, "assignee_username=user1") {
+		t.Errorf("URL = %s, want to contain assignee_username=user1", capturedURL)
+	}
+	// Client-side project filter
+	if len(issues) != 1 {
+		t.Errorf("FetchIssuesSince() returned %d issues, want 1 (filtered to project 10)", len(issues))
+	}
+}
+
+// TestFetchIssues_CombinedFilters verifies multiple filters compose correctly.
+func TestFetchIssues_CombinedFilters(t *testing.T) {
+	var capturedURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]Issue{})
+	}))
+	defer server.Close()
+
+	client := NewClient("token", server.URL, "123")
+	ctx := context.Background()
+
+	filter := &IssueFilter{
+		Labels:    "bug,critical",
+		Milestone: "v1.0",
+		Assignee:  "dev1",
+	}
+	_, err := client.FetchIssues(ctx, "opened", filter)
+	if err != nil {
+		t.Fatalf("FetchIssues() error = %v", err)
+	}
+
+	if !strings.Contains(capturedURL, "milestone=v1.0") {
+		t.Errorf("URL = %s, want to contain milestone=v1.0", capturedURL)
+	}
+	if !strings.Contains(capturedURL, "assignee_username=dev1") {
+		t.Errorf("URL = %s, want to contain assignee_username=dev1", capturedURL)
+	}
+	if !strings.Contains(capturedURL, "state=opened") {
+		t.Errorf("URL = %s, want to contain state=opened", capturedURL)
+	}
+}

--- a/internal/gitlab/tracker.go
+++ b/internal/gitlab/tracker.go
@@ -27,6 +27,7 @@ type Tracker struct {
 	client *Client
 	config *MappingConfig
 	store  storage.Storage
+	filter *IssueFilter // Optional filters for issue fetching
 }
 
 func (t *Tracker) Name() string         { return "gitlab" }
@@ -69,7 +70,42 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 		t.client = t.client.WithGroupID(groupID)
 	}
 	t.config = DefaultMappingConfig()
+
+	// Load optional filter config
+	t.filter = t.loadFilterConfig(ctx)
+
 	return nil
+}
+
+// loadFilterConfig reads filter configuration from store/env.
+// Returns nil if no filters are configured.
+func (t *Tracker) loadFilterConfig(ctx context.Context) *IssueFilter {
+	labels, _ := t.getConfig(ctx, "gitlab.filter_labels", "GITLAB_FILTER_LABELS")
+	projectStr, _ := t.getConfig(ctx, "gitlab.filter_project", "GITLAB_FILTER_PROJECT")
+	milestone, _ := t.getConfig(ctx, "gitlab.filter_milestone", "GITLAB_FILTER_MILESTONE")
+	assignee, _ := t.getConfig(ctx, "gitlab.filter_assignee", "GITLAB_FILTER_ASSIGNEE")
+
+	if labels == "" && projectStr == "" && milestone == "" && assignee == "" {
+		return nil
+	}
+
+	filter := &IssueFilter{
+		Labels:    labels,
+		Milestone: milestone,
+		Assignee:  assignee,
+	}
+	if projectStr != "" {
+		if pid, err := strconv.Atoi(projectStr); err == nil {
+			filter.ProjectID = pid
+		}
+	}
+	return filter
+}
+
+// SetFilter overrides the tracker's issue filter.
+// CLI flags use this to override config-based defaults.
+func (t *Tracker) SetFilter(filter *IssueFilter) {
+	t.filter = filter
 }
 
 func (t *Tracker) Validate() error {
@@ -95,9 +131,9 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 	}
 
 	if opts.Since != nil {
-		issues, err = t.client.FetchIssuesSince(ctx, state, *opts.Since)
+		issues, err = t.client.FetchIssuesSince(ctx, state, *opts.Since, t.filter)
 	} else {
-		issues, err = t.client.FetchIssues(ctx, state)
+		issues, err = t.client.FetchIssues(ctx, state, t.filter)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/gitlab/types.go
+++ b/internal/gitlab/types.go
@@ -35,6 +35,15 @@ const (
 	MaxPages = 1000
 )
 
+// IssueFilter holds optional filters for fetching issues.
+// All fields are optional; zero values mean "no filter".
+type IssueFilter struct {
+	Labels    string // Comma-separated label names (AND logic)
+	ProjectID int    // Filter to issues from this project (client-side, group mode only)
+	Milestone string // Milestone title
+	Assignee  string // Assignee username
+}
+
 // Client provides methods to interact with the GitLab REST API.
 type Client struct {
 	Token      string       // GitLab personal access token or OAuth token


### PR DESCRIPTION
## Summary
- Adds `gitlab.group_id` and `gitlab.default_project_id` config keys for group-level GitLab issue syncing
- When `group_id` is set, `FetchIssues`/`FetchIssuesSince` use `/groups/:id/issues` API endpoint to aggregate issues across all projects in the group
- Issue creation still uses the project endpoint (backward compatible)
- Existing project-level sync is completely unchanged when `group_id` is not set

## Config
```
gitlab.group_id          / GITLAB_GROUP_ID               - GitLab group ID or path
gitlab.default_project_id / GITLAB_DEFAULT_PROJECT_ID    - Project for creating new issues in group mode
```

## Files changed
- `internal/gitlab/types.go` — Added `GroupID` field to `Client` struct
- `internal/gitlab/client.go` — `WithGroupID()` builder, `issuesBasePath()` helper, updated fetch methods
- `internal/gitlab/tracker.go` — Config loading for new keys, group-aware client initialization
- `cmd/bd/gitlab.go` — CLI config struct, env var mapping, validation, status display
- `internal/gitlab/client_test.go` — Tests for group endpoint routing, path encoding, builder preservation
- `cmd/bd/gitlab_test.go` — Tests for config validation, env vars, client creation with group

## Test plan
- [x] All existing tests pass (backward compatibility)
- [x] New tests verify group endpoint is used for FetchIssues/FetchIssuesSince
- [x] New tests verify CreateIssue still uses project endpoint in group mode
- [x] New tests verify group path URL encoding
- [x] New tests verify config validation accepts group_id without project_id
- [x] New tests verify env var mapping for new config keys