### PR TITLE
fix: close --quiet bypass in bd init --force safety guard

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -143,9 +143,6 @@ environment variable.`,
 					expectedToken := fmt.Sprintf("DESTROY-%s", prefix)
 					if destroyToken == expectedToken {
 						fmt.Fprintf(os.Stderr, "Destroy token accepted. Proceeding with re-initialization.\n")
-					} else if quiet {
-						// Legacy --quiet behavior (deprecated path)
-						fmt.Fprintf(os.Stderr, "Warning: --force --quiet bypasses safety checks. Use --destroy-token=%s instead.\n", expectedToken)
 					} else {
 						fmt.Fprintf(os.Stderr, "Refusing to destroy %d issues in non-interactive mode.\n", count)
 						fmt.Fprintf(os.Stderr, "To proceed, use: bd init --force --destroy-token=%s\n", expectedToken)


### PR DESCRIPTION
## Summary
- `bd init --force --quiet` previously printed a warning but **continued anyway**, silently destroying the database
- Now it refuses like the default non-interactive path and requires `--destroy-token=DESTROY-<prefix>` to proceed
- 3-line fix: remove the `--quiet` special case that bypassed the safety guard

This is the root cause of two data loss incidents where `bd init --force` destroyed rig identity beads, agent state, and issue history.

## Test plan
- [x] `go build ./...` compiles clean
- [ ] `bd init --force --quiet` in a repo with issues → refuses (was: silent destruction)
- [ ] `bd init --force --destroy-token=DESTROY-<prefix>` → proceeds as before
- [ ] `bd init --force` in interactive terminal → prompts "Type 'destroy N issues'" as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)