### PR TITLE
feat: support multiple Linear team IDs in sync

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -26,11 +26,13 @@ var linearCmd = &cobra.Command{
 Configuration:
   bd config set linear.api_key "YOUR_API_KEY"
   bd config set linear.team_id "TEAM_ID"
+  bd config set linear.team_ids "TEAM_ID1,TEAM_ID2"  # Multiple teams (comma-separated)
   bd config set linear.project_id "PROJECT_ID"  # Optional: sync only this project
 
 Environment variables (alternative to config):
-  LINEAR_API_KEY - Linear API key
-  LINEAR_TEAM_ID - Linear team ID (UUID)
+  LINEAR_API_KEY  - Linear API key
+  LINEAR_TEAM_ID  - Linear team ID (UUID, singular)
+  LINEAR_TEAM_IDS - Linear team IDs (comma-separated UUIDs)
 
 Data Mapping (optional, sensible defaults provided):
   Priority mapping (Linear 0-4 to Beads 0-4):
@@ -81,6 +83,12 @@ Modes:
   --pull         Import issues from Linear into beads
   --push         Export issues from beads to Linear
   (no flags)     Bidirectional sync: pull then push, with conflict resolution
+
+Team Selection:
+  --team ID1,ID2  Override configured team IDs for this sync
+  Multiple teams can be configured via linear.team_ids (comma-separated).
+  Falls back to linear.team_id for backward compatibility.
+  Push requires explicit --team when multiple teams are configured.
 
 Type Filtering (--push only):
   --type task,feature       Only sync issues of these types
@@ -140,6 +148,7 @@ func init() {
 	linearSyncCmd.Flags().StringSlice("type", nil, "Only sync issues of these types (can be repeated)")
 	linearSyncCmd.Flags().StringSlice("exclude-type", nil, "Exclude issues of these types (can be repeated)")
 	linearSyncCmd.Flags().Bool("include-ephemeral", false, "Include ephemeral issues (wisps, etc.) when pushing to Linear")
+	linearSyncCmd.Flags().StringSlice("team", nil, "Team ID(s) to sync (overrides configured team_id/team_ids)")
 
 	linearCmd.AddCommand(linearSyncCmd)
 	linearCmd.AddCommand(linearStatusCmd)
@@ -158,6 +167,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	typeFilters, _ := cmd.Flags().GetStringSlice("type")
 	excludeTypes, _ := cmd.Flags().GetStringSlice("exclude-type")
 	includeEphemeral, _ := cmd.Flags().GetBool("include-ephemeral")
+	cliTeams, _ := cmd.Flags().GetStringSlice("team")
 
 	if !dryRun {
 		CheckReadonly("linear sync")
@@ -171,14 +181,22 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 		FatalError("database not available: %v", err)
 	}
 
-	if err := validateLinearConfig(); err != nil {
+	if err := validateLinearConfig(cliTeams); err != nil {
 		FatalError("%v", err)
 	}
 
 	ctx := rootCtx
+	teamIDs := getLinearTeamIDs(ctx, cliTeams)
+
+	// Require explicit --team for push when multiple teams are configured.
+	if push && len(teamIDs) > 1 && len(cliTeams) == 0 {
+		FatalError("push requires explicit --team flag when multiple teams are configured\n" +
+			"Use: bd linear sync --push --team <TEAM_ID>")
+	}
 
 	// Create and initialize the Linear tracker
 	lt := &linear.Tracker{}
+	lt.SetTeamIDs(teamIDs)
 	if err := lt.Init(ctx, store); err != nil {
 		FatalError("initializing Linear tracker: %v", err)
 	}
@@ -360,10 +378,10 @@ func runLinearStatus(cmd *cobra.Command, args []string) {
 	}
 
 	apiKey, _ := getLinearConfig(ctx, "linear.api_key")
-	teamID, _ := getLinearConfig(ctx, "linear.team_id")
+	teamIDs := getLinearTeamIDs(ctx, nil)
 	lastSync, _ := store.GetConfig(ctx, "linear.last_sync")
 
-	configured := apiKey != "" && teamID != ""
+	configured := apiKey != "" && len(teamIDs) > 0
 
 	allIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
 	if err != nil {
@@ -382,10 +400,16 @@ func runLinearStatus(cmd *cobra.Command, args []string) {
 
 	if jsonOutput {
 		hasAPIKey := apiKey != ""
+		// Backward compat: include team_id as first team, plus full list.
+		teamID := ""
+		if len(teamIDs) > 0 {
+			teamID = teamIDs[0]
+		}
 		outputJSON(map[string]interface{}{
 			"configured":      configured,
 			"has_api_key":     hasAPIKey,
 			"team_id":         teamID,
+			"team_ids":        teamIDs,
 			"last_sync":       lastSync,
 			"total_issues":    len(allIssues),
 			"with_linear_ref": withLinearRef,
@@ -404,6 +428,7 @@ func runLinearStatus(cmd *cobra.Command, args []string) {
 		fmt.Println("To configure Linear integration:")
 		fmt.Println("  bd config set linear.api_key \"YOUR_API_KEY\"")
 		fmt.Println("  bd config set linear.team_id \"TEAM_ID\"")
+		fmt.Println("  bd config set linear.team_ids \"TEAM_ID1,TEAM_ID2\"  # multiple teams")
 		fmt.Println()
 		fmt.Println("Or use environment variables:")
 		fmt.Println("  export LINEAR_API_KEY=\"YOUR_API_KEY\"")
@@ -411,7 +436,11 @@ func runLinearStatus(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	fmt.Printf("Team ID:      %s\n", teamID)
+	if len(teamIDs) == 1 {
+		fmt.Printf("Team ID:      %s\n", teamIDs[0])
+	} else {
+		fmt.Printf("Team IDs:     %s (%d teams)\n", strings.Join(teamIDs, ", "), len(teamIDs))
+	}
 	fmt.Printf("API Key:      %s\n", maskAPIKey(apiKey))
 	if lastSync != "" {
 		fmt.Printf("Last Sync:    %s\n", lastSync)
@@ -470,6 +499,7 @@ func runLinearTeams(cmd *cobra.Command, args []string) {
 	fmt.Println()
 	fmt.Println("To configure:")
 	fmt.Println("  bd config set linear.team_id \"<ID>\"")
+	fmt.Println("  bd config set linear.team_ids \"<ID1>,<ID2>\"  # multiple teams")
 }
 
 // uuidRegex matches valid UUID format (with or without hyphens).
@@ -480,7 +510,8 @@ func isValidUUID(s string) bool {
 }
 
 // validateLinearConfig checks that required Linear configuration is present.
-func validateLinearConfig() error {
+// cliTeams is the list of team IDs from the --team flag (may be nil).
+func validateLinearConfig(cliTeams []string) error {
 	if err := ensureStoreActive(); err != nil {
 		return fmt.Errorf("database not available: %w", err)
 	}
@@ -492,13 +523,15 @@ func validateLinearConfig() error {
 		return fmt.Errorf("Linear API key not configured\nRun: bd config set linear.api_key \"YOUR_API_KEY\"\nOr: export LINEAR_API_KEY=YOUR_API_KEY")
 	}
 
-	teamID, _ := getLinearConfig(ctx, "linear.team_id")
-	if teamID == "" {
-		return fmt.Errorf("linear.team_id not configured\nRun: bd config set linear.team_id \"TEAM_ID\"\nOr: export LINEAR_TEAM_ID=TEAM_ID")
+	teamIDs := getLinearTeamIDs(ctx, cliTeams)
+	if len(teamIDs) == 0 {
+		return fmt.Errorf("no Linear team ID configured\nRun: bd config set linear.team_id \"TEAM_ID\"\nOr:  bd config set linear.team_ids \"TEAM_ID1,TEAM_ID2\"\nOr: export LINEAR_TEAM_ID=TEAM_ID")
 	}
 
-	if !isValidUUID(teamID) {
-		return fmt.Errorf("linear.team_id appears invalid (expected UUID format like '12345678-1234-1234-1234-123456789abc')\nCurrent value: %s", teamID)
+	for _, id := range teamIDs {
+		if !isValidUUID(id) {
+			return fmt.Errorf("invalid Linear team ID (expected UUID format like '12345678-1234-1234-1234-123456789abc')\nInvalid value: %s", id)
+		}
 	}
 
 	return nil
@@ -552,24 +585,78 @@ func linearConfigToEnvVar(key string) string {
 		return "LINEAR_API_KEY"
 	case "linear.team_id":
 		return "LINEAR_TEAM_ID"
+	case "linear.team_ids":
+		return "LINEAR_TEAM_IDS"
 	default:
 		return ""
 	}
 }
 
+// getLinearTeamIDs resolves the effective team IDs from all config sources.
+// Precedence: cliTeams (--team flag) > linear.team_ids > LINEAR_TEAM_IDS > linear.team_id > LINEAR_TEAM_ID
+func getLinearTeamIDs(ctx context.Context, cliTeams []string) []string {
+	// CLI flag takes highest precedence.
+	if len(cliTeams) > 0 {
+		return deduplicateStrings(cliTeams)
+	}
+
+	// Try plural config key.
+	if ids, _ := getLinearConfig(ctx, "linear.team_ids"); ids != "" {
+		parsed := parseCommaSeparated(ids)
+		if len(parsed) > 0 {
+			return deduplicateStrings(parsed)
+		}
+	}
+
+	// Fall back to singular config key.
+	if id, _ := getLinearConfig(ctx, "linear.team_id"); id != "" {
+		return []string{id}
+	}
+
+	return nil
+}
+
+// parseCommaSeparated splits a comma-separated string, trimming whitespace and
+// filtering empty elements.
+func parseCommaSeparated(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// deduplicateStrings returns a slice with duplicates removed, preserving order.
+func deduplicateStrings(ss []string) []string {
+	seen := make(map[string]bool, len(ss))
+	result := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
 // getLinearClient creates a configured Linear client from beads config.
+// Uses the first configured team ID for operations that require a single team.
 func getLinearClient(ctx context.Context) (*linear.Client, error) {
 	apiKey, _ := getLinearConfig(ctx, "linear.api_key")
 	if apiKey == "" {
 		return nil, fmt.Errorf("Linear API key not configured")
 	}
 
-	teamID, _ := getLinearConfig(ctx, "linear.team_id")
-	if teamID == "" {
+	teamIDs := getLinearTeamIDs(ctx, nil)
+	if len(teamIDs) == 0 {
 		return nil, fmt.Errorf("Linear team ID not configured")
 	}
 
-	client := linear.NewClient(apiKey, teamID)
+	client := linear.NewClient(apiKey, teamIDs[0])
 
 	if store != nil {
 		if endpoint, _ := store.GetConfig(ctx, "linear.api_endpoint"); endpoint != "" {

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -1691,6 +1691,84 @@ func TestLinearClientFetchTeams(t *testing.T) {
 	}
 }
 
+func TestParseCommaSeparated(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"single value", "abc", []string{"abc"}},
+		{"two values", "abc,def", []string{"abc", "def"}},
+		{"whitespace trimmed", " abc , def , ghi ", []string{"abc", "def", "ghi"}},
+		{"empty elements filtered", "abc,,def,", []string{"abc", "def"}},
+		{"empty string", "", []string{}},
+		{"only commas", ",,,", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCommaSeparated(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseCommaSeparated(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseCommaSeparated(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDeduplicateStrings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"no duplicates", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"with duplicates", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+		{"all same", []string{"x", "x", "x"}, []string{"x"}},
+		{"empty", []string{}, []string{}},
+		{"single", []string{"a"}, []string{"a"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicateStrings(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("deduplicateStrings(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("deduplicateStrings(%v)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLinearConfigToEnvVar(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"linear.api_key", "LINEAR_API_KEY"},
+		{"linear.team_id", "LINEAR_TEAM_ID"},
+		{"linear.team_ids", "LINEAR_TEAM_IDS"},
+		{"linear.unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := linearConfigToEnvVar(tt.key)
+			if got != tt.want {
+				t.Errorf("linearConfigToEnvVar(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsValidUUID(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -655,7 +655,15 @@ bd config set linear.api_key "lin_api_YOUR_API_KEY"
 
 # Team ID (find in Linear team settings or URL)
 bd config set linear.team_id "team-uuid-here"
+
+# Multiple team IDs (comma-separated; can also use LINEAR_TEAM_IDS env var)
+bd config set linear.team_ids "uuid-team-1,uuid-team-2"
 ```
+
+When `linear.team_ids` is set, `bd linear sync` fetches issues from all listed
+teams. For push operations with multiple teams, use the `--team` flag to specify
+the target. The singular `linear.team_id` is still supported for backward
+compatibility.
 
 **Getting your Linear credentials:**
 

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -19,11 +20,17 @@ func init() {
 
 // Tracker implements tracker.IssueTracker for Linear.
 type Tracker struct {
-	client    *Client
+	clients   map[string]*Client // keyed by team ID
 	config    *MappingConfig
 	store     storage.Storage
-	teamID    string
+	teamIDs   []string // ordered list of configured team IDs
 	projectID string
+}
+
+// SetTeamIDs sets the team IDs before Init(). When set, Init() uses these
+// instead of reading from config. This supports the --team CLI flag.
+func (t *Tracker) SetTeamIDs(ids []string) {
+	t.teamIDs = ids
 }
 
 func (t *Tracker) Name() string         { return "linear" }
@@ -38,29 +45,56 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 		return fmt.Errorf("Linear API key not configured (set linear.api_key or LINEAR_API_KEY)")
 	}
 
-	teamID, err := t.getConfig(ctx, "linear.team_id", "LINEAR_TEAM_ID")
-	if err != nil || teamID == "" {
-		return fmt.Errorf("Linear team ID not configured (set linear.team_id or LINEAR_TEAM_ID)")
+	// Resolve team IDs: use pre-set IDs (from CLI), or fall back to config.
+	if len(t.teamIDs) == 0 {
+		// Try plural config first.
+		if ids, _ := t.getConfig(ctx, "linear.team_ids", "LINEAR_TEAM_IDS"); ids != "" {
+			for _, part := range strings.Split(ids, ",") {
+				trimmed := strings.TrimSpace(part)
+				if trimmed != "" {
+					t.teamIDs = append(t.teamIDs, trimmed)
+				}
+			}
+		}
+		// Fall back to singular config.
+		if len(t.teamIDs) == 0 {
+			teamID, err := t.getConfig(ctx, "linear.team_id", "LINEAR_TEAM_ID")
+			if err != nil || teamID == "" {
+				return fmt.Errorf("Linear team ID not configured (set linear.team_id, linear.team_ids, or LINEAR_TEAM_ID)")
+			}
+			t.teamIDs = []string{teamID}
+		}
 	}
-	t.teamID = teamID
 
-	client := NewClient(apiKey, teamID)
-
-	if endpoint, _ := store.GetConfig(ctx, "linear.api_endpoint"); endpoint != "" {
-		client = client.WithEndpoint(endpoint)
+	// Read optional endpoint and project ID.
+	var endpoint, projectID string
+	if store != nil {
+		endpoint, _ = store.GetConfig(ctx, "linear.api_endpoint")
+		projectID, _ = store.GetConfig(ctx, "linear.project_id")
+		if projectID != "" {
+			t.projectID = projectID
+		}
 	}
-	if projectID, _ := store.GetConfig(ctx, "linear.project_id"); projectID != "" {
-		client = client.WithProjectID(projectID)
-		t.projectID = projectID
+
+	// Create per-team clients upfront for O(1) routing.
+	t.clients = make(map[string]*Client, len(t.teamIDs))
+	for _, teamID := range t.teamIDs {
+		client := NewClient(apiKey, teamID)
+		if endpoint != "" {
+			client = client.WithEndpoint(endpoint)
+		}
+		if projectID != "" {
+			client = client.WithProjectID(projectID)
+		}
+		t.clients[teamID] = client
 	}
 
-	t.client = client
 	t.config = LoadMappingConfig(&configLoaderAdapter{ctx: ctx, store: store})
 	return nil
 }
 
 func (t *Tracker) Validate() error {
-	if t.client == nil {
+	if len(t.clients) == 0 {
 		return fmt.Errorf("Linear tracker not initialized")
 	}
 	return nil
@@ -69,51 +103,77 @@ func (t *Tracker) Validate() error {
 func (t *Tracker) Close() error { return nil }
 
 func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([]tracker.TrackerIssue, error) {
-	var issues []Issue
-	var err error
-
 	state := opts.State
 	if state == "" {
 		state = "all"
 	}
 
-	if opts.Since != nil {
-		issues, err = t.client.FetchIssuesSince(ctx, state, *opts.Since)
-	} else {
-		issues, err = t.client.FetchIssues(ctx, state)
-	}
-	if err != nil {
-		return nil, err
+	seen := make(map[string]bool)
+	var result []tracker.TrackerIssue
+
+	for _, teamID := range t.teamIDs {
+		client := t.clients[teamID]
+		if client == nil {
+			continue
+		}
+
+		var issues []Issue
+		var err error
+		if opts.Since != nil {
+			issues, err = client.FetchIssuesSince(ctx, state, *opts.Since)
+		} else {
+			issues, err = client.FetchIssues(ctx, state)
+		}
+		if err != nil {
+			return result, fmt.Errorf("fetching issues from team %s: %w", teamID, err)
+		}
+
+		for _, li := range issues {
+			if seen[li.ID] {
+				continue
+			}
+			seen[li.ID] = true
+			result = append(result, linearToTrackerIssue(&li))
+		}
 	}
 
-	result := make([]tracker.TrackerIssue, 0, len(issues))
-	for _, li := range issues {
-		result = append(result, linearToTrackerIssue(&li))
-	}
 	return result, nil
 }
 
 func (t *Tracker) FetchIssue(ctx context.Context, identifier string) (*tracker.TrackerIssue, error) {
-	li, err := t.client.FetchIssueByIdentifier(ctx, identifier)
-	if err != nil {
-		return nil, err
+	// Try the primary client first (first team), then others.
+	for _, teamID := range t.teamIDs {
+		client := t.clients[teamID]
+		if client == nil {
+			continue
+		}
+		li, err := client.FetchIssueByIdentifier(ctx, identifier)
+		if err != nil {
+			continue // Issue might belong to a different team.
+		}
+		if li != nil {
+			ti := linearToTrackerIssue(li)
+			return &ti, nil
+		}
 	}
-	if li == nil {
-		return nil, nil
-	}
-	ti := linearToTrackerIssue(li)
-	return &ti, nil
+	return nil, nil
 }
 
 func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	// Create on the primary (first) team.
+	client := t.primaryClient()
+	if client == nil {
+		return nil, fmt.Errorf("no Linear client available")
+	}
+
 	priority := PriorityToLinear(issue.Priority, t.config)
 
-	stateID, err := t.findStateID(ctx, issue.Status)
+	stateID, err := t.findStateID(ctx, client, issue.Status)
 	if err != nil {
 		return nil, fmt.Errorf("finding state for status %s: %w", issue.Status, err)
 	}
 
-	created, err := t.client.CreateIssue(ctx, issue.Title, issue.Description, priority, stateID, nil)
+	created, err := client.CreateIssue(ctx, issue.Title, issue.Description, priority, stateID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -123,11 +183,17 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 }
 
 func (t *Tracker) UpdateIssue(ctx context.Context, externalID string, issue *types.Issue) (*tracker.TrackerIssue, error) {
+	// Route to the correct team's client based on the external ID.
+	client := t.clientForExternalID(ctx, externalID)
+	if client == nil {
+		return nil, fmt.Errorf("cannot determine Linear team for issue %s", externalID)
+	}
+
 	mapper := t.FieldMapper()
 	updates := mapper.IssueToTracker(issue)
 
 	// Resolve and include state so status changes are pushed to Linear.
-	stateID, err := t.findStateID(ctx, issue.Status)
+	stateID, err := t.findStateID(ctx, client, issue.Status)
 	if err != nil {
 		return nil, fmt.Errorf("finding state for status %s: %w", issue.Status, err)
 	}
@@ -135,7 +201,7 @@ func (t *Tracker) UpdateIssue(ctx context.Context, externalID string, issue *typ
 		updates["stateId"] = stateID
 	}
 
-	updated, err := t.client.UpdateIssue(ctx, externalID, updates)
+	updated, err := client.UpdateIssue(ctx, externalID, updates)
 	if err != nil {
 		return nil, err
 	}
@@ -166,11 +232,12 @@ func (t *Tracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
 	return fmt.Sprintf("https://linear.app/issue/%s", issue.Identifier)
 }
 
-// findStateID looks up the Linear workflow state ID for a beads status.
-func (t *Tracker) findStateID(ctx context.Context, status types.Status) (string, error) {
+// findStateID looks up the Linear workflow state ID for a beads status
+// using the given per-team client.
+func (t *Tracker) findStateID(ctx context.Context, client *Client, status types.Status) (string, error) {
 	targetType := StatusToLinearStateType(status)
 
-	states, err := t.client.GetTeamStates(ctx)
+	states, err := client.GetTeamStates(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -185,6 +252,47 @@ func (t *Tracker) findStateID(ctx context.Context, status types.Status) (string,
 		return states[0].ID, nil
 	}
 	return "", fmt.Errorf("no workflow states found")
+}
+
+// primaryClient returns the client for the first configured team.
+func (t *Tracker) primaryClient() *Client {
+	if len(t.teamIDs) == 0 {
+		return nil
+	}
+	return t.clients[t.teamIDs[0]]
+}
+
+// clientForExternalID resolves which per-team client should handle an issue
+// identified by its Linear identifier (e.g., "TEAM-123").
+func (t *Tracker) clientForExternalID(ctx context.Context, externalID string) *Client {
+	if len(t.teamIDs) == 1 {
+		return t.primaryClient()
+	}
+
+	// Try to fetch the issue from each team's client to find the owner.
+	for _, teamID := range t.teamIDs {
+		client := t.clients[teamID]
+		if client == nil {
+			continue
+		}
+		li, err := client.FetchIssueByIdentifier(ctx, externalID)
+		if err == nil && li != nil {
+			return client
+		}
+	}
+
+	return t.primaryClient()
+}
+
+// TeamIDs returns the list of configured team IDs.
+func (t *Tracker) TeamIDs() []string {
+	return t.teamIDs
+}
+
+// PrimaryClient returns the client for the first configured team.
+// Exported for CLI code that needs direct client access (e.g., push hooks).
+func (t *Tracker) PrimaryClient() *Client {
+	return t.primaryClient()
 }
 
 // getConfig reads a config value from storage, falling back to env var.
@@ -250,13 +358,14 @@ func linearToTrackerIssue(li *Issue) tracker.TrackerIssue {
 	return ti
 }
 
-// BuildStateCacheFromTracker builds a StateCache using the tracker's internal client.
+// BuildStateCacheFromTracker builds a StateCache using the tracker's primary client.
 // This allows CLI code to set up PushHooks.BuildStateCache without accessing the client directly.
 func BuildStateCacheFromTracker(ctx context.Context, t *Tracker) (*StateCache, error) {
-	if t.client == nil {
+	client := t.primaryClient()
+	if client == nil {
 		return nil, fmt.Errorf("Linear tracker not initialized")
 	}
-	return BuildStateCache(ctx, t.client)
+	return BuildStateCache(ctx, client)
 }
 
 // configLoaderAdapter wraps storage.Storage to implement linear.ConfigLoader.

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -100,6 +100,69 @@ func TestFieldMapperStatus(t *testing.T) {
 	}
 }
 
+func TestTrackerMultiTeamValidate(t *testing.T) {
+	// Empty tracker should fail validation.
+	tr := &Tracker{}
+	if err := tr.Validate(); err == nil {
+		t.Error("expected Validate() to fail on uninitialized tracker")
+	}
+
+	// Tracker with clients should pass.
+	tr.clients = map[string]*Client{
+		"team-1": NewClient("key", "team-1"),
+	}
+	if err := tr.Validate(); err != nil {
+		t.Errorf("Validate() = %v, want nil", err)
+	}
+}
+
+func TestTrackerSetTeamIDs(t *testing.T) {
+	tr := &Tracker{}
+	ids := []string{"id-1", "id-2", "id-3"}
+	tr.SetTeamIDs(ids)
+
+	if len(tr.teamIDs) != 3 {
+		t.Fatalf("expected 3 team IDs, got %d", len(tr.teamIDs))
+	}
+	for i, want := range ids {
+		if tr.teamIDs[i] != want {
+			t.Errorf("teamIDs[%d] = %q, want %q", i, tr.teamIDs[i], want)
+		}
+	}
+}
+
+func TestTrackerTeamIDsAccessor(t *testing.T) {
+	tr := &Tracker{teamIDs: []string{"a", "b"}}
+	got := tr.TeamIDs()
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("TeamIDs() = %v, want [a b]", got)
+	}
+}
+
+func TestTrackerPrimaryClient(t *testing.T) {
+	tr := &Tracker{
+		teamIDs: []string{"team-1", "team-2"},
+		clients: map[string]*Client{
+			"team-1": NewClient("key", "team-1"),
+			"team-2": NewClient("key", "team-2"),
+		},
+	}
+
+	client := tr.PrimaryClient()
+	if client == nil {
+		t.Fatal("PrimaryClient() returned nil")
+	}
+	if client.TeamID != "team-1" {
+		t.Errorf("PrimaryClient().TeamID = %q, want %q", client.TeamID, "team-1")
+	}
+
+	// Empty tracker should return nil.
+	empty := &Tracker{}
+	if empty.PrimaryClient() != nil {
+		t.Error("PrimaryClient() should return nil for empty tracker")
+	}
+}
+
 func TestLinearToTrackerIssue(t *testing.T) {
 	li := &Issue{
 		ID:          "uuid-123",


### PR DESCRIPTION
## Summary

Adds support for syncing issues across multiple Linear teams via `linear.team_ids` config and `--team` CLI flag.

Closes #2791

## Changes

### Tracker (`internal/linear/tracker.go`)
- **Per-team clients**: `Tracker` now stores `map[string]*Client` keyed by team ID, created upfront in `Init()`
- **`FetchIssues`**: Iterates all teams, merges results, deduplicates by Linear issue ID
- **`FetchIssue`**: Tries each team's client until the issue is found
- **`CreateIssue`**: Routes to primary (first) team
- **`UpdateIssue`**: Routes to owning team by probing `FetchIssueByIdentifier`
- **`findStateID`**: Now takes a per-team client parameter (workflow states differ per team)
- Exported `TeamIDs()`, `PrimaryClient()`, `SetTeamIDs()` for CLI integration

### CLI (`cmd/bd/linear.go`)
- **`--team` flag**: `StringSlice` flag on `bd linear sync` to override configured teams
- **`getLinearTeamIDs()`**: Resolves team IDs with precedence: `--team` > `linear.team_ids` > `LINEAR_TEAM_IDS` > `linear.team_id` > `LINEAR_TEAM_ID`
- **`parseCommaSeparated()`** / **`deduplicateStrings()`**: Helper utilities
- **`validateLinearConfig()`**: Accepts plural config, validates each UUID
- **`runLinearStatus()`**: Shows all teams in JSON (`team_ids` field) and text output
- **Push safety**: Requires explicit `--team` when multiple teams configured

### Docs (`docs/CONFIG.md`)
- Documents `linear.team_ids` config and `LINEAR_TEAM_IDS` env var

### Tests
- `internal/linear/tracker_test.go`: Multi-team Validate, SetTeamIDs, TeamIDs, PrimaryClient
- `cmd/bd/linear_test.go`: parseCommaSeparated, deduplicateStrings, linearConfigToEnvVar

## Backward Compatibility
- Singular `linear.team_id` / `LINEAR_TEAM_ID` still works unchanged
- Single-team users see no behavioral differences
- JSON output adds `team_ids` array alongside existing `team_id` field