### PR TITLE
feat: multi-project support for Jira and ADO with shared infrastructure

### DIFF
--- a/cmd/bd/ado.go
+++ b/cmd/bd/ado.go
@@ -19,10 +19,11 @@ import (
 
 // ADOConfig holds Azure DevOps connection configuration.
 type ADOConfig struct {
-	PAT     string // Personal access token
-	Org     string // Organization name
-	Project string // Project name
-	URL     string // Custom base URL (for on-prem)
+	PAT      string // Personal access token
+	Org      string // Organization name
+	Project  string // Primary project name (backward compat)
+	Projects []string // All project names
+	URL      string // Custom base URL (for on-prem)
 }
 
 // adoCmd is the root command for Azure DevOps operations.
@@ -32,10 +33,11 @@ var adoCmd = &cobra.Command{
 	Long: `Commands for syncing issues between beads and Azure DevOps.
 
 Configuration can be set via 'bd config' or environment variables:
-  ado.org / AZURE_DEVOPS_ORG         - Organization name
-  ado.project / AZURE_DEVOPS_PROJECT - Project name
-  ado.pat / AZURE_DEVOPS_PAT         - Personal access token
-  ado.url / AZURE_DEVOPS_URL         - Custom base URL (on-prem)`,
+  ado.org / AZURE_DEVOPS_ORG              - Organization name
+  ado.project / AZURE_DEVOPS_PROJECT      - Project name (single)
+  ado.projects / AZURE_DEVOPS_PROJECTS    - Project names (comma-separated)
+  ado.pat / AZURE_DEVOPS_PAT              - Personal access token
+  ado.url / AZURE_DEVOPS_URL              - Custom base URL (on-prem)`,
 }
 
 // adoSyncCmd synchronizes issues between beads and Azure DevOps.
@@ -156,6 +158,7 @@ func init() {
 	adoSyncCmd.Flags().StringVar(&adoFilterIterationPath, "iteration-path", "", "Filter to ADO iteration path (e.g., \"Project\\Sprint 1\")")
 	adoSyncCmd.Flags().StringVar(&adoFilterTypes, "types", "", "Filter to work item types, comma-separated (e.g., \"Bug,Task,User Story\")")
 	adoSyncCmd.Flags().StringVar(&adoFilterStates, "states", "", "Filter to ADO states, comma-separated (e.g., \"New,Active,Resolved\")")
+	adoSyncCmd.Flags().StringSlice("project", nil, "Project name(s) to sync (overrides configured project/projects)")
 
 	// Register ado command with root
 	rootCmd.AddCommand(adoCmd)
@@ -168,8 +171,15 @@ func getADOConfig() ADOConfig {
 
 	cfg.PAT = getADOConfigValue(ctx, "ado.pat")
 	cfg.Org = getADOConfigValue(ctx, "ado.org")
-	cfg.Project = getADOConfigValue(ctx, "ado.project")
 	cfg.URL = getADOConfigValue(ctx, "ado.url")
+
+	// Resolve projects from all sources.
+	pluralVal := getADOConfigValue(ctx, "ado.projects")
+	singularVal := getADOConfigValue(ctx, "ado.project")
+	cfg.Projects = tracker.ResolveProjectIDs(nil, pluralVal, singularVal)
+	if len(cfg.Projects) > 0 {
+		cfg.Project = cfg.Projects[0]
+	}
 
 	return cfg
 }
@@ -213,6 +223,8 @@ func adoConfigToEnvVar(key string) string {
 		return "AZURE_DEVOPS_ORG"
 	case "ado.project":
 		return "AZURE_DEVOPS_PROJECT"
+	case "ado.projects":
+		return "AZURE_DEVOPS_PROJECTS"
 	case "ado.url":
 		return "AZURE_DEVOPS_URL"
 	default:
@@ -228,8 +240,8 @@ func validateADOConfig(cfg ADOConfig) error {
 	if cfg.Org == "" && cfg.URL == "" {
 		return fmt.Errorf("ado.org not configured: set via 'bd config ado.org <org>' or AZURE_DEVOPS_ORG env var")
 	}
-	if cfg.Project == "" {
-		return fmt.Errorf("ado.project not configured: set via 'bd config ado.project <project>' or AZURE_DEVOPS_PROJECT env var")
+	if len(cfg.Projects) == 0 {
+		return fmt.Errorf("no ADO project configured\nSet via 'bd config set ado.project <project>'\nOr:  'bd config set ado.projects \"proj1,proj2\"'\nOr: AZURE_DEVOPS_PROJECT env var")
 	}
 	return nil
 }
@@ -328,12 +340,13 @@ func buildADOPullFilters(ctx context.Context, cmd *cobra.Command) *ado.PullFilte
 
 // adoStatusResult holds the JSON output for the ado status command.
 type adoStatusResult struct {
-	Org        string `json:"org"`
-	Project    string `json:"project"`
-	HasToken   bool   `json:"has_token"`
-	URL        string `json:"url,omitempty"`
-	Configured bool   `json:"configured"`
-	Error      string `json:"error,omitempty"`
+	Org        string   `json:"org"`
+	Project    string   `json:"project"`
+	Projects   []string `json:"projects,omitempty"`
+	HasToken   bool     `json:"has_token"`
+	URL        string   `json:"url,omitempty"`
+	Configured bool     `json:"configured"`
+	Error      string   `json:"error,omitempty"`
 }
 
 // runADOStatus implements the ado status command.
@@ -344,6 +357,7 @@ func runADOStatus(cmd *cobra.Command, _ []string) error {
 		result := adoStatusResult{
 			Org:      cfg.Org,
 			Project:  cfg.Project,
+			Projects: cfg.Projects,
 			HasToken: cfg.PAT != "",
 			URL:      cfg.URL,
 		}
@@ -361,7 +375,11 @@ func runADOStatus(cmd *cobra.Command, _ []string) error {
 	_, _ = fmt.Fprintln(out, "Azure DevOps Configuration")
 	_, _ = fmt.Fprintln(out, "==========================")
 	_, _ = fmt.Fprintf(out, "Organization: %s\n", cfg.Org)
-	_, _ = fmt.Fprintf(out, "Project:      %s\n", cfg.Project)
+	if len(cfg.Projects) <= 1 {
+		_, _ = fmt.Fprintf(out, "Project:      %s\n", cfg.Project)
+	} else {
+		_, _ = fmt.Fprintf(out, "Projects:     %s (%d projects)\n", strings.Join(cfg.Projects, ", "), len(cfg.Projects))
+	}
 	_, _ = fmt.Fprintf(out, "PAT:          %s\n", maskADOToken(cfg.PAT))
 	if cfg.URL != "" {
 		_, _ = fmt.Fprintf(out, "Base URL:     %s\n", cfg.URL)
@@ -471,6 +489,10 @@ func runADOSync(cmd *cobra.Command, _ []string) error {
 
 	// Create and initialize the ADO tracker
 	at := &ado.Tracker{}
+	cliProjects, _ := cmd.Flags().GetStringSlice("project")
+	if len(cliProjects) > 0 {
+		at.SetProjects(tracker.DeduplicateStrings(cliProjects))
+	}
 	if err := at.Init(ctx, store); err != nil {
 		return fmt.Errorf("initializing Azure DevOps tracker: %w", err)
 	}

--- a/cmd/bd/ado_test.go
+++ b/cmd/bd/ado_test.go
@@ -71,26 +71,26 @@ func TestADOConfigValidation(t *testing.T) {
 	}{
 		{
 			name:      "missing PAT",
-			config:    ADOConfig{Org: "org", Project: "proj"},
+			config:    ADOConfig{Org: "org", Projects: []string{"proj"}},
 			wantError: "ado.pat",
 		},
 		{
 			name:      "missing org and URL",
-			config:    ADOConfig{PAT: "tok", Project: "proj"},
+			config:    ADOConfig{PAT: "tok", Projects: []string{"proj"}},
 			wantError: "ado.org",
 		},
 		{
 			name:      "missing project",
 			config:    ADOConfig{PAT: "tok", Org: "org"},
-			wantError: "ado.project",
+			wantError: "no ADO project",
 		},
 		{
 			name:   "all present",
-			config: ADOConfig{PAT: "tok", Org: "org", Project: "proj"},
+			config: ADOConfig{PAT: "tok", Org: "org", Project: "proj", Projects: []string{"proj"}},
 		},
 		{
 			name:   "URL substitutes for org",
-			config: ADOConfig{PAT: "tok", URL: "https://tfs.corp.com", Project: "proj"},
+			config: ADOConfig{PAT: "tok", URL: "https://tfs.corp.com", Project: "proj", Projects: []string{"proj"}},
 		},
 	}
 

--- a/cmd/bd/jira.go
+++ b/cmd/bd/jira.go
@@ -21,14 +21,16 @@ var jiraCmd = &cobra.Command{
 Configuration:
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
+  bd config set jira.projects "PROJ1,PROJ2"   # Multiple projects
   bd config set jira.api_token "YOUR_TOKEN"
   bd config set jira.username "your_email@company.com"  # For Jira Cloud
   bd config set jira.push_prefix "hippo"       # Only push hippo-* issues to Jira
   bd config set jira.push_prefix "proj1,proj2" # Multiple prefixes (comma-separated)
 
 Environment variables (alternative to config):
-  JIRA_API_TOKEN - Jira API token
-  JIRA_USERNAME  - Jira username/email
+  JIRA_API_TOKEN  - Jira API token
+  JIRA_USERNAME   - Jira username/email
+  JIRA_PROJECTS   - Comma-separated project keys
 
 Examples:
   bd jira sync --pull         # Import issues from Jira
@@ -80,6 +82,7 @@ func init() {
 	jiraSyncCmd.Flags().Bool("prefer-jira", false, "Prefer Jira version on conflicts")
 	jiraSyncCmd.Flags().Bool("create-only", false, "Only create new issues, don't update existing")
 	jiraSyncCmd.Flags().String("state", "all", "Issue state to sync: open, closed, all")
+	jiraSyncCmd.Flags().StringSlice("project", nil, "Project key(s) to sync (overrides configured project/projects)")
 
 	jiraCmd.AddCommand(jiraSyncCmd)
 	jiraCmd.AddCommand(jiraStatusCmd)
@@ -115,6 +118,10 @@ func runJiraSync(cmd *cobra.Command, args []string) {
 
 	// Create and initialize the Jira tracker
 	jt := &jira.Tracker{}
+	cliProjects, _ := cmd.Flags().GetStringSlice("project")
+	if len(cliProjects) > 0 {
+		jt.SetProjectKeys(tracker.DeduplicateStrings(cliProjects))
+	}
 	if err := jt.Init(ctx, store); err != nil {
 		FatalError("initializing Jira tracker: %v", err)
 	}
@@ -210,10 +217,14 @@ func runJiraStatus(cmd *cobra.Command, args []string) {
 	}
 
 	jiraURL, _ := store.GetConfig(ctx, "jira.url")
-	jiraProject, _ := store.GetConfig(ctx, "jira.project")
 	lastSync, _ := store.GetConfig(ctx, "jira.last_sync")
 
-	configured := jiraURL != "" && jiraProject != ""
+	// Resolve project keys from all config sources.
+	pluralProjects, _ := store.GetConfig(ctx, "jira.projects")
+	singularProject, _ := store.GetConfig(ctx, "jira.project")
+	projectKeys := tracker.ResolveProjectIDs(nil, pluralProjects, singularProject)
+
+	configured := jiraURL != "" && len(projectKeys) > 0
 
 	allIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
 	if err != nil {
@@ -231,10 +242,16 @@ func runJiraStatus(cmd *cobra.Command, args []string) {
 	}
 
 	if jsonOutput {
+		// Backward compat: include jira_project as first project, plus full list.
+		primaryProject := ""
+		if len(projectKeys) > 0 {
+			primaryProject = projectKeys[0]
+		}
 		outputJSON(map[string]interface{}{
 			"configured":    configured,
 			"jira_url":      jiraURL,
-			"jira_project":  jiraProject,
+			"jira_project":  primaryProject,
+			"jira_projects": projectKeys,
 			"last_sync":     lastSync,
 			"total_issues":  len(allIssues),
 			"with_jira_ref": withJiraRef,
@@ -253,13 +270,18 @@ func runJiraStatus(cmd *cobra.Command, args []string) {
 		fmt.Println("To configure Jira integration:")
 		fmt.Println("  bd config set jira.url \"https://company.atlassian.net\"")
 		fmt.Println("  bd config set jira.project \"PROJ\"")
+		fmt.Println("  bd config set jira.projects \"PROJ1,PROJ2\"  # multiple projects")
 		fmt.Println("  bd config set jira.api_token \"YOUR_TOKEN\"")
 		fmt.Println("  bd config set jira.username \"your@email.com\"")
 		return
 	}
 
 	fmt.Printf("Jira URL:     %s\n", jiraURL)
-	fmt.Printf("Project:      %s\n", jiraProject)
+	if len(projectKeys) == 1 {
+		fmt.Printf("Project:      %s\n", projectKeys[0])
+	} else {
+		fmt.Printf("Projects:     %s (%d projects)\n", strings.Join(projectKeys, ", "), len(projectKeys))
+	}
 	if lastSync != "" {
 		fmt.Printf("Last Sync:    %s\n", lastSync)
 	} else {
@@ -284,13 +306,17 @@ func validateJiraConfig() error {
 
 	ctx := rootCtx
 	jiraURL, _ := store.GetConfig(ctx, "jira.url")
-	jiraProject, _ := store.GetConfig(ctx, "jira.project")
 
 	if jiraURL == "" {
 		return fmt.Errorf("jira.url not configured\nRun: bd config set jira.url \"https://company.atlassian.net\"")
 	}
-	if jiraProject == "" {
-		return fmt.Errorf("jira.project not configured\nRun: bd config set jira.project \"PROJ\"")
+
+	// Check for project configuration (singular or plural).
+	pluralProjects, _ := store.GetConfig(ctx, "jira.projects")
+	singularProject, _ := store.GetConfig(ctx, "jira.project")
+	projectKeys := tracker.ResolveProjectIDs(nil, pluralProjects, singularProject)
+	if len(projectKeys) == 0 {
+		return fmt.Errorf("no Jira project configured\nRun: bd config set jira.project \"PROJ\"\nOr:  bd config set jira.projects \"PROJ1,PROJ2\"")
 	}
 
 	apiToken, _ := store.GetConfig(ctx, "jira.api_token")

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -630,6 +630,7 @@ bd config set sync.require_confirmation_on_mass_delete "true"
 # Configure Jira connection
 bd config set jira.url "https://company.atlassian.net"
 bd config set jira.project "PROJ"
+bd config set jira.projects "PROJ1,PROJ2"   # Multiple projects (comma-separated)
 bd config set jira.api_token "YOUR_TOKEN"
 
 # Map bd statuses to Jira statuses
@@ -775,7 +776,14 @@ bd config set ado.org "myorg"
 
 # Project name (can also use AZURE_DEVOPS_PROJECT environment variable)
 bd config set ado.project "MyProject"
+
+# Multiple projects (comma-separated; can also use AZURE_DEVOPS_PROJECTS env var)
+bd config set ado.projects "Project1,Project2"
 ```
+
+When `ado.projects` is set, `bd ado sync` fetches work items from all listed
+projects in a single WIQL query. The singular `ado.project` is still supported
+for backward compatibility.
 
 **Optional configuration:**
 
@@ -848,12 +856,13 @@ Priority mapping is not configurable — it is handled automatically.
 
 All ADO config keys have environment variable equivalents:
 
-| Config Key    | Environment Variable     |
-|---------------|--------------------------|
-| `ado.pat`     | `AZURE_DEVOPS_PAT`       |
-| `ado.org`     | `AZURE_DEVOPS_ORG`       |
-| `ado.project` | `AZURE_DEVOPS_PROJECT`   |
-| `ado.url`     | `AZURE_DEVOPS_URL`       |
+| Config Key     | Environment Variable     |
+|----------------|--------------------------|
+| `ado.pat`      | `AZURE_DEVOPS_PAT`       |
+| `ado.org`      | `AZURE_DEVOPS_ORG`       |
+| `ado.project`  | `AZURE_DEVOPS_PROJECT`   |
+| `ado.projects` | `AZURE_DEVOPS_PROJECTS`  |
+| `ado.url`      | `AZURE_DEVOPS_URL`       |
 
 Environment variables take effect when the corresponding `bd config` key is not set.
 

--- a/internal/ado/client.go
+++ b/internal/ado/client.go
@@ -336,8 +336,23 @@ func (c *Client) FetchWorkItems(ctx context.Context, ids []int) ([]WorkItem, err
 // buildPullWIQL constructs a safe WIQL query from validated filter fields.
 // All values are escaped via escapeWIQL before interpolation.
 func (c *Client) buildPullWIQL(since *time.Time, filters *PullFilters) string {
+	return c.buildPullWIQLMulti([]string{c.Project}, since, filters)
+}
+
+// buildPullWIQLMulti builds a WIQL query that can filter across multiple projects.
+func (c *Client) buildPullWIQLMulti(projects []string, since *time.Time, filters *PullFilters) string {
+	var projectClause string
+	if len(projects) == 1 {
+		projectClause = fmt.Sprintf("[System.TeamProject] = '%s'", escapeWIQL(projects[0]))
+	} else {
+		quoted := make([]string, len(projects))
+		for i, p := range projects {
+			quoted[i] = "'" + escapeWIQL(p) + "'"
+		}
+		projectClause = fmt.Sprintf("[System.TeamProject] IN (%s)", strings.Join(quoted, ", "))
+	}
 	clauses := []string{
-		fmt.Sprintf("[System.TeamProject] = '%s'", escapeWIQL(c.Project)),
+		projectClause,
 		"[System.IsDeleted] = false",
 	}
 	if since != nil {
@@ -410,24 +425,34 @@ func (c *Client) fetchWorkItemsByWIQL(ctx context.Context, query string) ([]Work
 // FetchWorkItemsSince retrieves work items changed since the given time using WIQL.
 // Pass nil for filters to fetch all work item types and states.
 func (c *Client) FetchWorkItemsSince(ctx context.Context, since time.Time, filters *PullFilters) ([]WorkItem, error) {
+	return c.FetchWorkItemsSinceMulti(ctx, since, []string{c.Project}, filters)
+}
+
+// FetchWorkItemsSinceMulti retrieves work items from multiple projects changed since the given time.
+func (c *Client) FetchWorkItemsSinceMulti(ctx context.Context, since time.Time, projects []string, filters *PullFilters) ([]WorkItem, error) {
 	if filters != nil {
 		if err := filters.Validate(); err != nil {
 			return nil, fmt.Errorf("invalid pull filters: %w", err)
 		}
 	}
-	query := c.buildPullWIQL(&since, filters)
+	query := c.buildPullWIQLMulti(projects, &since, filters)
 	return c.fetchWorkItemsByWIQL(ctx, query)
 }
 
 // FetchAllWorkItems retrieves all work items matching the given filters.
 // Used for initial sync or reconciliation.
 func (c *Client) FetchAllWorkItems(ctx context.Context, filters *PullFilters) ([]WorkItem, error) {
+	return c.FetchAllWorkItemsMulti(ctx, []string{c.Project}, filters)
+}
+
+// FetchAllWorkItemsMulti retrieves all work items from multiple projects.
+func (c *Client) FetchAllWorkItemsMulti(ctx context.Context, projects []string, filters *PullFilters) ([]WorkItem, error) {
 	if filters != nil {
 		if err := filters.Validate(); err != nil {
 			return nil, fmt.Errorf("invalid pull filters: %w", err)
 		}
 	}
-	query := c.buildPullWIQL(nil, filters)
+	query := c.buildPullWIQLMulti(projects, nil, filters)
 	return c.fetchWorkItemsByWIQL(ctx, query)
 }
 

--- a/internal/ado/tracker.go
+++ b/internal/ado/tracker.go
@@ -31,13 +31,32 @@ var adoWorkItemPattern = regexp.MustCompile(`/_workitems/edit/(\d+)`)
 // under the name "ado" and supports bidirectional sync of work items between
 // ADO and the local beads database.
 type Tracker struct {
-	client  *Client
-	store   storage.Storage
-	mapper  tracker.FieldMapper
-	baseURL string // Resolved base URL for external ref matching
-	org     string
-	project string
-	filters *PullFilters // Optional pull filters for WIQL queries
+	client   *Client
+	store    storage.Storage
+	mapper   tracker.FieldMapper
+	baseURL  string // Resolved base URL for external ref matching
+	org      string
+	projects []string     // one or more project names (first is primary)
+	filters  *PullFilters // Optional pull filters for WIQL queries
+}
+
+// SetProjects sets project names before Init(). When set, Init() uses these
+// instead of reading from config. This supports the --project CLI flag.
+func (t *Tracker) SetProjects(projects []string) {
+	t.projects = projects
+}
+
+// Projects returns the list of configured project names.
+func (t *Tracker) Projects() []string {
+	return t.projects
+}
+
+// PrimaryProject returns the first configured project name.
+func (t *Tracker) PrimaryProject() string {
+	if len(t.projects) == 0 {
+		return ""
+	}
+	return t.projects[0]
 }
 
 // Name returns the lowercase identifier for this tracker.
@@ -60,14 +79,20 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 	}
 
 	t.org = t.getConfig(ctx, "ado.org", "AZURE_DEVOPS_ORG")
-	t.project = t.getConfig(ctx, "ado.project", "AZURE_DEVOPS_PROJECT")
 	customURL := t.getConfig(ctx, "ado.url", "AZURE_DEVOPS_URL")
 
 	if t.org == "" && customURL == "" {
 		return fmt.Errorf("Azure DevOps organization not configured (set ado.org or AZURE_DEVOPS_ORG)")
 	}
-	if t.project == "" {
-		return fmt.Errorf("Azure DevOps project not configured (set ado.project or AZURE_DEVOPS_PROJECT)")
+
+	// Resolve projects: use pre-set projects (from CLI), or fall back to config.
+	if len(t.projects) == 0 {
+		pluralVal := t.getConfig(ctx, "ado.projects", "AZURE_DEVOPS_PROJECTS")
+		singularVal := t.getConfig(ctx, "ado.project", "AZURE_DEVOPS_PROJECT")
+		t.projects = tracker.ResolveProjectIDs(nil, pluralVal, singularVal)
+	}
+	if len(t.projects) == 0 {
+		return fmt.Errorf("Azure DevOps project not configured (set ado.project, ado.projects, or AZURE_DEVOPS_PROJECT)")
 	}
 
 	if t.org != "" {
@@ -75,8 +100,10 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 			return fmt.Errorf("invalid Azure DevOps organization: %w", err)
 		}
 	}
-	if err := ValidateProject(t.project); err != nil {
-		return fmt.Errorf("invalid Azure DevOps project: %w", err)
+	for _, p := range t.projects {
+		if err := ValidateProject(p); err != nil {
+			return fmt.Errorf("invalid Azure DevOps project %q: %w", p, err)
+		}
 	}
 
 	// Read custom state/type mappings from config.
@@ -86,7 +113,8 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 
 	t.mapper = NewFieldMapper(stateMap, typeMap)
 
-	t.client = NewClient(NewSecretString(pat), t.org, t.project)
+	// Create client with primary project for API URL construction.
+	t.client = NewClient(NewSecretString(pat), t.org, t.PrimaryProject())
 	if customURL != "" {
 		var err error
 		t.client, err = t.client.WithBaseURL(customURL)
@@ -134,9 +162,9 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 	var err error
 
 	if opts.Since != nil {
-		items, err = t.client.FetchWorkItemsSince(ctx, *opts.Since, t.filters)
+		items, err = t.client.FetchWorkItemsSinceMulti(ctx, *opts.Since, t.projects, t.filters)
 	} else {
-		items, err = t.client.FetchAllWorkItems(ctx, t.filters)
+		items, err = t.client.FetchAllWorkItemsMulti(ctx, t.projects, t.filters)
 	}
 	if err != nil {
 		return nil, err
@@ -242,13 +270,14 @@ func (t *Tracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
 	if issue.URL != "" {
 		return issue.URL
 	}
-	if t.org != "" && t.project != "" {
+	project := t.PrimaryProject()
+	if t.org != "" && project != "" {
 		return fmt.Sprintf("%s/%s/%s/_workitems/edit/%s",
-			DefaultBaseURL, url.PathEscape(t.org), url.PathEscape(t.project), issue.Identifier)
+			DefaultBaseURL, url.PathEscape(t.org), url.PathEscape(project), issue.Identifier)
 	}
-	if t.baseURL != "" && t.project != "" {
+	if t.baseURL != "" && project != "" {
 		return fmt.Sprintf("%s/%s/_workitems/edit/%s",
-			t.baseURL, url.PathEscape(t.project), issue.Identifier)
+			t.baseURL, url.PathEscape(project), issue.Identifier)
 	}
 	return fmt.Sprintf("ado:%s", issue.Identifier)
 }

--- a/internal/ado/tracker_test.go
+++ b/internal/ado/tracker_test.go
@@ -80,8 +80,8 @@ func TestTracker_InitFromEnv(t *testing.T) {
 	if tr.org != "myorg" {
 		t.Errorf("org = %q, want %q", tr.org, "myorg")
 	}
-	if tr.project != "myproject" {
-		t.Errorf("project = %q, want %q", tr.project, "myproject")
+	if tr.PrimaryProject() != "myproject" {
+		t.Errorf("project = %q, want %q", tr.PrimaryProject(), "myproject")
 	}
 	if tr.mapper == nil {
 		t.Fatal("Init() did not create field mapper")
@@ -102,8 +102,8 @@ func TestTracker_InitFromConfig(t *testing.T) {
 	if tr.org != "configorg" {
 		t.Errorf("org = %q, want %q", tr.org, "configorg")
 	}
-	if tr.project != "configproject" {
-		t.Errorf("project = %q, want %q", tr.project, "configproject")
+	if tr.PrimaryProject() != "configproject" {
+		t.Errorf("project = %q, want %q", tr.PrimaryProject(), "configproject")
 	}
 }
 
@@ -342,7 +342,7 @@ func TestTracker_BuildExternalRef(t *testing.T) {
 	}{
 		{
 			name:    "uses issue URL if set",
-			tracker: &Tracker{org: "myorg", project: "myproj"},
+			tracker: &Tracker{org: "myorg", projects: []string{"myproj"}},
 			issue: &tracker.TrackerIssue{
 				Identifier: "42",
 				URL:        "https://dev.azure.com/myorg/myproj/_workitems/edit/42",
@@ -351,13 +351,13 @@ func TestTracker_BuildExternalRef(t *testing.T) {
 		},
 		{
 			name:    "constructs cloud URL from org and project",
-			tracker: &Tracker{org: "myorg", project: "myproj"},
+			tracker: &Tracker{org: "myorg", projects: []string{"myproj"}},
 			issue:   &tracker.TrackerIssue{Identifier: "99"},
 			want:    "https://dev.azure.com/myorg/myproj/_workitems/edit/99",
 		},
 		{
 			name:    "constructs on-prem URL from baseURL",
-			tracker: &Tracker{baseURL: "https://tfs.corp.com/DefaultCollection", project: "proj"},
+			tracker: &Tracker{baseURL: "https://tfs.corp.com/DefaultCollection", projects: []string{"proj"}},
 			issue:   &tracker.TrackerIssue{Identifier: "55"},
 			want:    "https://tfs.corp.com/DefaultCollection/proj/_workitems/edit/55",
 		},
@@ -369,13 +369,13 @@ func TestTracker_BuildExternalRef(t *testing.T) {
 		},
 		{
 			name:    "URL-encodes project with spaces",
-			tracker: &Tracker{org: "myorg", project: "My Project"},
+			tracker: &Tracker{org: "myorg", projects: []string{"My Project"}},
 			issue:   &tracker.TrackerIssue{Identifier: "88"},
 			want:    "https://dev.azure.com/myorg/My%20Project/_workitems/edit/88",
 		},
 		{
 			name:    "URL-encodes on-prem project with spaces",
-			tracker: &Tracker{baseURL: "https://tfs.corp.com/col", project: "My Project"},
+			tracker: &Tracker{baseURL: "https://tfs.corp.com/col", projects: []string{"My Project"}},
 			issue:   &tracker.TrackerIssue{Identifier: "66"},
 			want:    "https://tfs.corp.com/col/My%20Project/_workitems/edit/66",
 		},
@@ -702,7 +702,7 @@ func newTestTracker(t *testing.T, handler http.Handler) (*Tracker, *httptest.Ser
 		mapper:  NewFieldMapper(nil, nil),
 		baseURL: server.URL,
 		org:     "testorg",
-		project: "testproject",
+		projects: []string{"testproject"},
 	}, server
 }
 

--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -20,13 +20,32 @@ func init() {
 
 // Tracker implements tracker.IssueTracker for Jira.
 type Tracker struct {
-	client     *Client
-	store      storage.Storage
-	jiraURL    string
-	projectKey string
-	apiVersion string            // "2" or "3" (default: "3")
-	statusMap  map[string]string // beads status → Jira status name (from jira.status_map.* config)
-	typeMap    map[string]string // beads type → Jira type (from jira.type_map.* config)
+	client      *Client
+	store       storage.Storage
+	jiraURL     string
+	projectKeys []string          // one or more project keys (first is primary)
+	apiVersion  string            // "2" or "3" (default: "3")
+	statusMap   map[string]string // beads status → Jira status name (from jira.status_map.* config)
+	typeMap     map[string]string // beads type → Jira type (from jira.type_map.* config)
+}
+
+// SetProjectKeys sets project keys before Init(). When set, Init() uses these
+// instead of reading from config. This supports the --project CLI flag.
+func (t *Tracker) SetProjectKeys(keys []string) {
+	t.projectKeys = keys
+}
+
+// ProjectKeys returns the list of configured project keys.
+func (t *Tracker) ProjectKeys() []string {
+	return t.projectKeys
+}
+
+// PrimaryProjectKey returns the first configured project key.
+func (t *Tracker) PrimaryProjectKey() string {
+	if len(t.projectKeys) == 0 {
+		return ""
+	}
+	return t.projectKeys[0]
 }
 
 func (t *Tracker) Name() string         { return "jira" }
@@ -42,11 +61,15 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 	}
 	t.jiraURL = jiraURL
 
-	projectKey, err := t.getConfig(ctx, "jira.project", "JIRA_PROJECT")
-	if err != nil || projectKey == "" {
-		return fmt.Errorf("Jira project not configured (set jira.project or JIRA_PROJECT)")
+	// Resolve project keys: use pre-set keys (from CLI), or fall back to config.
+	if len(t.projectKeys) == 0 {
+		pluralVal, _ := t.getConfig(ctx, "jira.projects", "JIRA_PROJECTS")
+		singularVal, _ := t.getConfig(ctx, "jira.project", "JIRA_PROJECT")
+		t.projectKeys = tracker.ResolveProjectIDs(nil, pluralVal, singularVal)
 	}
-	t.projectKey = projectKey
+	if len(t.projectKeys) == 0 {
+		return fmt.Errorf("Jira project not configured (set jira.project, jira.projects, or JIRA_PROJECT)")
+	}
 
 	username, _ := t.getConfig(ctx, "jira.username", "JIRA_USERNAME")
 	apiToken, err := t.getConfig(ctx, "jira.api_token", "JIRA_API_TOKEN")
@@ -102,8 +125,17 @@ func (t *Tracker) Validate() error {
 func (t *Tracker) Close() error { return nil }
 
 func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([]tracker.TrackerIssue, error) {
-	// Build JQL query
-	jql := fmt.Sprintf("project = %q", t.projectKey)
+	// Build JQL query — use IN clause for multi-project.
+	var jql string
+	if len(t.projectKeys) == 1 {
+		jql = fmt.Sprintf("project = %q", t.projectKeys[0])
+	} else {
+		quoted := make([]string, len(t.projectKeys))
+		for i, k := range t.projectKeys {
+			quoted[i] = fmt.Sprintf("%q", k)
+		}
+		jql = fmt.Sprintf("project IN (%s)", strings.Join(quoted, ", "))
+	}
 
 	// User-configured pull_jql filter (e.g. 'labels = "agent-ready"')
 	if pullJQL, _ := t.getConfig(ctx, "jira.pull_jql", "JIRA_PULL_JQL"); pullJQL != "" {
@@ -153,8 +185,8 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 	mapper := t.FieldMapper()
 	fields := mapper.IssueToTracker(issue)
 
-	// Set project
-	fields["project"] = map[string]string{"key": t.projectKey}
+	// Set project to primary (first) project key.
+	fields["project"] = map[string]string{"key": t.PrimaryProjectKey()}
 
 	created, err := t.client.CreateIssue(ctx, fields)
 	if err != nil {

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -627,7 +627,7 @@ func TestFetchIssuesIncludesPullJQLInQuery(t *testing.T) {
 	tr := &Tracker{
 		client:     newTestClient(srv.URL, "3"),
 		store:      store,
-		projectKey: "TEST",
+		projectKeys: []string{"TEST"},
 		apiVersion: "3",
 	}
 
@@ -667,7 +667,7 @@ func TestFetchIssuesWithoutPullJQLOmitsExtraFilter(t *testing.T) {
 	tr := &Tracker{
 		client:     newTestClient(srv.URL, "3"),
 		store:      store,
-		projectKey: "TEST",
+		projectKeys: []string{"TEST"},
 		apiVersion: "3",
 	}
 

--- a/internal/tracker/multiproject.go
+++ b/internal/tracker/multiproject.go
@@ -1,0 +1,49 @@
+package tracker
+
+import "strings"
+
+// ParseCommaSeparated splits a comma-separated string into trimmed, non-empty elements.
+// Used by trackers that support multiple project/team IDs via config.
+func ParseCommaSeparated(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// DeduplicateStrings returns a slice with duplicates removed, preserving order.
+func DeduplicateStrings(ss []string) []string {
+	seen := make(map[string]bool, len(ss))
+	result := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// ResolveProjectIDs resolves the effective project/team IDs from config sources.
+// It checks plural first, then singular, and deduplicates the result.
+// The cliOverride takes highest precedence when non-empty.
+func ResolveProjectIDs(cliOverride []string, pluralVal, singularVal string) []string {
+	if len(cliOverride) > 0 {
+		return DeduplicateStrings(cliOverride)
+	}
+	if pluralVal != "" {
+		parsed := ParseCommaSeparated(pluralVal)
+		if len(parsed) > 0 {
+			return DeduplicateStrings(parsed)
+		}
+	}
+	if singularVal != "" {
+		return []string{singularVal}
+	}
+	return nil
+}

--- a/internal/tracker/multiproject_test.go
+++ b/internal/tracker/multiproject_test.go
@@ -1,0 +1,85 @@
+package tracker
+
+import "testing"
+
+func TestParseCommaSeparated(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"single", "abc", []string{"abc"}},
+		{"two", "abc,def", []string{"abc", "def"}},
+		{"whitespace", " abc , def , ghi ", []string{"abc", "def", "ghi"}},
+		{"empty elements", "abc,,def,", []string{"abc", "def"}},
+		{"empty string", "", []string{}},
+		{"only commas", ",,,", []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseCommaSeparated(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseCommaSeparated(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDeduplicateStrings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{"no dupes", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"with dupes", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+		{"all same", []string{"x", "x", "x"}, []string{"x"}},
+		{"empty", []string{}, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DeduplicateStrings(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("DeduplicateStrings(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveProjectIDs(t *testing.T) {
+	tests := []struct {
+		name        string
+		cli         []string
+		plural      string
+		singular    string
+		wantLen     int
+		wantFirst   string
+	}{
+		{"cli override", []string{"X", "Y"}, "A,B", "C", 2, "X"},
+		{"plural config", nil, "A, B, C", "D", 3, "A"},
+		{"singular fallback", nil, "", "D", 1, "D"},
+		{"nothing", nil, "", "", 0, ""},
+		{"cli dedup", []string{"A", "B", "A"}, "", "", 2, "A"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveProjectIDs(tt.cli, tt.plural, tt.singular)
+			if len(got) != tt.wantLen {
+				t.Fatalf("got %v (len %d), want len %d", got, len(got), tt.wantLen)
+			}
+			if tt.wantLen > 0 && got[0] != tt.wantFirst {
+				t.Errorf("first = %q, want %q", got[0], tt.wantFirst)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds multi-project support to Jira and Azure DevOps trackers, with shared infrastructure to avoid duplicating logic across tracker integrations.

## Shared Infrastructure (`internal/tracker/multiproject.go`)

New reusable helpers that any tracker can compose:
- **`ParseCommaSeparated(s)`** — splits comma-separated config values, trims whitespace
- **`DeduplicateStrings(ss)`** — removes duplicates preserving order
- **`ResolveProjectIDs(cli, plural, singular)`** — config precedence: CLI flag > plural key > singular key

All three are covered by unit tests in `multiproject_test.go`.

## Jira Changes

**Config:**
- New: `jira.projects` (comma-separated) / `JIRA_PROJECTS` env var
- Existing `jira.project` / `JIRA_PROJECT` still works

**Tracker (`internal/jira/tracker.go`):**
- `projectKey string` → `projectKeys []string`
- `FetchIssues()`: Uses JQL `project IN ("PROJ1", "PROJ2")` — **single query**, no iteration needed
- `CreateIssue()`: Targets primary (first) project
- New: `SetProjectKeys()`, `ProjectKeys()`, `PrimaryProjectKey()`

**CLI (`cmd/bd/jira.go`):**
- `--project KEY1,KEY2` flag on `bd jira sync`
- Status shows all projects in JSON (`jira_projects` field) and text

## ADO Changes

**Config:**
- New: `ado.projects` (comma-separated) / `AZURE_DEVOPS_PROJECTS` env var
- Existing `ado.project` / `AZURE_DEVOPS_PROJECT` still works

**Client (`internal/ado/client.go`):**
- `buildPullWIQLMulti()`: WIQL query with `[System.TeamProject] IN (...)`
- `FetchAllWorkItemsMulti()` / `FetchWorkItemsSinceMulti()`: multi-project variants
- Original single-project methods delegate to multi variants (backward compat)

**Tracker (`internal/ado/tracker.go`):**
- `project string` → `projects []string`
- `FetchIssues()`: Uses multi-project WIQL query
- `CreateIssue()`: Targets primary (first) project
- New: `SetProjects()`, `Projects()`, `PrimaryProject()`

**CLI (`cmd/bd/ado.go`):**
- `--project PROJ1,PROJ2` flag on `bd ado sync`
- Status shows all projects in JSON (`projects` field) and text
- `ADOConfig` now has `Projects []string` alongside `Project string`

## Backward Compatibility
- All singular config keys continue to work unchanged
- Single-project users see zero behavioral change
- JSON output adds plural fields alongside existing singular fields
- ADO single-project `FetchAllWorkItems`/`FetchWorkItemsSince` still work (delegate to multi)