### PR TITLE
fix: suppress git auth prompts in test helpers

### DIFF
--- a/cmd/bd/dolt_autostart_lifecycle_integration_test.go
+++ b/cmd/bd/dolt_autostart_lifecycle_integration_test.go
@@ -38,6 +38,9 @@ func TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands(t *testing.T) {
 		"BEADS_DOLT_SERVER_PORT=",
 		"BEADS_DOLT_PORT=",
 		"BEADS_DOLT_SHARED_SERVER=",
+		"GIT_TERMINAL_PROMPT=0",
+		"SSH_ASKPASS=",
+		"GIT_ASKPASS=",
 	)
 
 	initOut, initErr := runBDExecWithBinary(t, bdBinary, tmpDir, env, "init", "--backend", "dolt", "--prefix", "test", "--quiet")

--- a/cmd/bd/test_helpers_test.go
+++ b/cmd/bd/test_helpers_test.go
@@ -373,6 +373,7 @@ func openExistingTestDB(t *testing.T, dbPath string) (*dolt.DoltStore, error) {
 func runCommandInDir(dir string, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
+	cmd.Env = testEnvNoPrompt()
 	return cmd.Run()
 }
 
@@ -380,11 +381,21 @@ func runCommandInDir(dir string, name string, args ...string) error {
 func runCommandInDirWithOutput(dir string, name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
+	cmd.Env = testEnvNoPrompt()
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// testEnvNoPrompt returns the current environment with git auth prompts
+// suppressed. Prevents ksshaskpass/SSH_ASKPASS popups during tests that
+// configure fake git remotes (e.g. github.com/test/repo.git).
+func testEnvNoPrompt() []string {
+	env := os.Environ()
+	env = append(env, "GIT_TERMINAL_PROMPT=0", "SSH_ASKPASS=", "GIT_ASKPASS=")
+	return env
 }
 
 // captureStderr captures stderr output from fn and returns it as a string.


### PR DESCRIPTION
## Summary
- Set `GIT_TERMINAL_PROMPT=0`, `SSH_ASKPASS=`, `GIT_ASKPASS=` in test command environments
- Prevents GUI auth popups (ksshaskpass on KDE, Credential Manager on Windows) when E2E tests configure fake git remotes like `github.com/test/repo.git`
- Cross-platform safe — these are git-native env vars

## Test plan
- [x] `go build ./...` compiles clean
- [x] No auth popups during E2E test execution on KDE/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)