### PR TITLE
fix: wisp create --dry-run reports wrong count when rootOnly overridden

### DIFF
--- a/cmd/bd/wisp.go
+++ b/cmd/bd/wisp.go
@@ -243,21 +243,33 @@ func runWispCreate(cmd *cobra.Command, args []string) {
 		)
 	}
 
-	if dryRun {
-		fmt.Printf("\nDry run: would create wisp with %d issues from proto %s\n\n", len(subgraph.Issues), protoID)
-		fmt.Printf("Storage: main database (ephemeral=true, not synced via git)\n\n")
-		for _, issue := range subgraph.Issues {
-			newTitle := substituteVariables(issue.Title, vars)
-			fmt.Printf("  - %s (from %s)\n", newTitle, issue.ID)
-		}
-		return
-	}
-
 	// Wisps are vapor (ephemeral) by default — only create the root issue.
 	// Materializing child step issues is the "pour" path (bd pour), not wisps.
 	// Formulas that explicitly set pour=true get children even as wisps.
 	if !rootOnly && subgraph != nil && !subgraph.Pour {
 		rootOnly = true
+	}
+
+	if dryRun {
+		if rootOnly {
+			skipped := len(subgraph.Issues) - 1
+			fmt.Printf("\nDry run: would create wisp with 1 issue (root only) from proto %s\n", protoID)
+			if skipped > 0 {
+				fmt.Printf("  Note: %d child step(s) skipped — set pour=true in formula to materialize them\n", skipped)
+			}
+		} else {
+			fmt.Printf("\nDry run: would create wisp with %d issues from proto %s\n\n", len(subgraph.Issues), protoID)
+		}
+		fmt.Printf("Storage: main database (ephemeral=true, not synced via git)\n\n")
+		issuesToShow := subgraph.Issues
+		if rootOnly && len(issuesToShow) > 0 {
+			issuesToShow = issuesToShow[:1]
+		}
+		for _, issue := range issuesToShow {
+			newTitle := substituteVariables(issue.Title, vars)
+			fmt.Printf("  - %s (from %s)\n", newTitle, issue.ID)
+		}
+		return
 	}
 
 	// Spawn as ephemeral in main database (Ephemeral=true, not synced via git)


### PR DESCRIPTION
## Summary

Fixes #2725 — `bd wisp create --dry-run` now reports the correct issue count when `rootOnly` is overridden (formula without `pour=true`).

## Problem

The `--dry-run` early return was executing **before** the `rootOnly` override logic, causing dry-run to report all N issues would be created while the actual run only creates 1 (root only).

## Changes

- **`cmd/bd/wisp.go`** — Move `rootOnly` override block above the `dryRun` check so both paths see the same `rootOnly` value
- Update dry-run output to show `1 issue (root only)` with a note explaining how many child steps were skipped and how to enable them via `pour=true` in the formula
- For `pour=true` formulas, dry-run still reports all issues as before

## Checklist

- [x] Fixes the reported behavioral mismatch between dry-run and actual run
- [x] No test changes needed (behavioral fix only)