### PR TITLE
fix: make bd update --claim idempotent for same user

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -613,7 +613,7 @@ func init() {
 	updateCmd.Flags().StringSlice("remove-label", nil, "Remove labels (repeatable)")
 	updateCmd.Flags().StringSlice("set-labels", nil, "Set labels, replacing all existing (repeatable)")
 	updateCmd.Flags().String("parent", "", "New parent issue ID (reparents the issue, use empty string to remove parent)")
-	updateCmd.Flags().Bool("claim", false, "Atomically claim the issue (sets assignee to you, status to in_progress; fails if already claimed)")
+	updateCmd.Flags().Bool("claim", false, "Atomically claim the issue (sets assignee to you, status to in_progress; idempotent if already claimed by you)")
 	updateCmd.Flags().String("session", "", "Claude Code session ID for status=closed (or set CLAUDE_SESSION_ID env var)")
 	// Time-based scheduling flags (GH#820)
 	// Examples:

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -19,7 +19,9 @@ type ClaimResult struct {
 
 // ClaimIssueInTx atomically claims an issue using compare-and-swap semantics.
 // It sets the assignee to actor and status to "in_progress" only if the issue
-// currently has no assignee. Returns storage.ErrAlreadyClaimed if already claimed.
+// currently has no assignee. Returns storage.ErrAlreadyClaimed if already
+// claimed by a different user. Idempotent: re-claiming by the same actor is
+// a no-op success (supports agent retry workflows).
 // Routes to the correct table (issues/wisps) automatically.
 // The caller is responsible for Dolt versioning (DOLT_ADD/COMMIT) if needed.
 //
@@ -58,6 +60,12 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 			`SELECT assignee FROM %s WHERE id = ?`, issueTable), id).Scan(&currentAssignee)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get current assignee: %w", err)
+		}
+		// Idempotent: if already claimed by the same actor, treat as success.
+		// This supports agent retry workflows where claim may be called multiple
+		// times after transient failures (GH#8).
+		if currentAssignee == actor {
+			return &ClaimResult{OldIssue: oldIssue, IsWisp: isWisp}, nil
 		}
 		return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, currentAssignee)
 	}

--- a/tests/regression/discovery_test.go
+++ b/tests/regression/discovery_test.go
@@ -516,7 +516,6 @@ func TestProtocol_DeferExcludesFromReady(t *testing.T) {
 }
 
 // TestProtocol_ClaimSemantics verifies atomic claim behavior.
-// NOTE: Second claim error prints to stderr but returns exit 0 (BUG-10).
 func TestProtocol_ClaimSemantics(t *testing.T) {
 	w := newCandidateWorkspace(t)
 
@@ -529,10 +528,10 @@ func TestProtocol_ClaimSemantics(t *testing.T) {
 		t.Errorf("claimed issue should be in_progress, got: %v", data[0]["status"])
 	}
 
-	// Second claim should fail (BUG-10: returns exit 0, so check stderr text)
+	// Second claim by same user should be idempotent (no error).
 	out := w.run("update", a, "--claim")
-	if !strings.Contains(out, "already claimed") {
-		t.Errorf("second claim should report 'already claimed', got: %s", out)
+	if strings.Contains(out, "already claimed") {
+		t.Errorf("re-claim by same user should be idempotent, got: %s", out)
 	}
 }
 


### PR DESCRIPTION
## Problem

`bd update <id> --claim` returns an error if the issue is already claimed, even when the current user is the one who claimed it. This breaks idempotent agent retry workflows where a claim operation may be retried after transient failures.

## Fix

When `rowsAffected == 0` (assignee not empty), check if the current assignee matches the claiming actor. If so, return success instead of `ErrAlreadyClaimed`.

**Before:** `bd update bd-42 --claim` → `Error claiming bd-42: issue already claimed by alice` (even if you ARE alice)
**After:** `bd update bd-42 --claim` → success (no-op, already yours)

Claiming by a **different** user still fails with the existing error.

## Changes

- `internal/storage/issueops/claim.go`: Same-actor check before returning `ErrAlreadyClaimed`
- `cmd/bd/update.go`: Updated `--claim` flag description
- `tests/regression/discovery_test.go`: Updated `TestProtocol_ClaimSemantics` to verify idempotent behavior

## Backward Compatibility

- Only changes behavior for same-user re-claims (error → no-op success)
- Different-user claims still fail identically
- No schema changes

Closes harry-miller-trimble/beads#8