### PR TITLE
fix: suppress auto-push/backup warnings in quiet and JSON modes

### DIFF
--- a/cmd/bd/backup_auto.go
+++ b/cmd/bd/backup_auto.go
@@ -100,7 +100,10 @@ func maybeAutoBackup(ctx context.Context) {
 	// Run the export (force=true since we already checked change detection above)
 	newState, err := runBackupExport(ctx, true)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: auto-backup failed: %v\n", err)
+		if !isQuiet() && !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Warning: auto-backup failed: %v\n", err)
+		}
+		debug.Logf("backup: export error: %v\n", err)
 		return
 	}
 
@@ -112,7 +115,10 @@ func maybeAutoBackup(ctx context.Context) {
 		if branch, err := currentGitBranch(); err == nil && !isDefaultBranch(branch) {
 			debug.Logf("backup: skipping git commit — on branch %q (not default)\n", branch)
 		} else if err := gitBackup(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: backup git push failed: %v\n", err)
+			if !isQuiet() && !jsonOutput {
+				fmt.Fprintf(os.Stderr, "Warning: backup git push failed: %v\n", err)
+			}
+			debug.Logf("backup: git push error: %v\n", err)
 		}
 	}
 }

--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -140,7 +140,10 @@ func maybeAutoPush(ctx context.Context) {
 	// Push
 	debug.Logf("dolt auto-push: pushing to origin...\n")
 	if err := st.Push(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: dolt auto-push failed: %v\n", err)
+		if !isQuiet() && !jsonOutput {
+			fmt.Fprintf(os.Stderr, "Warning: dolt auto-push failed: %v\n", err)
+		}
+		debug.Logf("dolt auto-push: push error: %v\n", err)
 		return
 	}
 


### PR DESCRIPTION
## Problem

Auto-push and auto-backup warning messages (e.g., `Warning: dolt auto-push failed`) were always printed to stderr, even when using `--quiet` or `--json`. In agent workflows with frequent writes, these warnings create noise that agents may misinterpret as errors.

## Fix

Suppress warning messages from `maybeAutoPush` and `maybeAutoBackup` when `--quiet` or `--json` mode is active. Errors are still logged via `debug.Logf` for troubleshooting with `BD_DEBUG=1`.

**Affected messages:**
- `Warning: dolt auto-push failed: <err>`
- `Warning: auto-backup failed: <err>`
- `Warning: backup git push failed: <err>`

**Note:** The throttle messages (`dolt auto-push: throttled...`, `backup: throttled...`) were already debug-only — they only appear with `BD_DEBUG=1` or `--verbose`.

## Changes

- `cmd/bd/dolt_autopush.go`: Guard push failure warning with `!isQuiet() && !jsonOutput`
- `cmd/bd/backup_auto.go`: Guard backup failure + git push warnings similarly

## Backward Compatibility

- Normal mode (no flags): warnings still print to stderr as before
- `--quiet` / `--json`: warnings suppressed (new behavior)
- `BD_DEBUG=1`: all messages still visible via `debug.Logf`

Closes harry-miller-trimble/beads#9