### PR TITLE
feat: add bd setup copilot for GitHub Copilot CLI hooks

### DIFF
--- a/cmd/bd/setup.go
+++ b/cmd/bd/setup.go
@@ -32,7 +32,7 @@ var setupCmd = &cobra.Command{
 	Long: `Setup integration files for AI editors and coding assistants.
 
 Recipes define where beads workflow instructions are written. Built-in recipes
-include cursor, claude, gemini, aider, factory, codex, mux, opencode, junie, windsurf, cody, and kilocode.
+include copilot, cursor, claude, gemini, aider, factory, codex, mux, opencode, junie, windsurf, cody, and kilocode.
 
 Examples:
   bd setup cursor          # Install Cursor IDE integration
@@ -186,6 +186,9 @@ func runRecipe(name string) {
 		return
 	case "junie":
 		runJunieRecipe()
+		return
+	case "copilot":
+		runCopilotRecipe()
 		return
 	}
 
@@ -356,6 +359,18 @@ func runJunieRecipe() {
 	setup.InstallJunie()
 }
 
+func runCopilotRecipe() {
+	if setupCheck {
+		setup.CheckCopilot()
+		return
+	}
+	if setupRemove {
+		setup.RemoveCopilot()
+		return
+	}
+	setup.InstallCopilot(setupStealth)
+}
+
 func init() {
 	// Global flags for the setup command
 	setupCmd.Flags().BoolVar(&setupList, "list", false, "List all available recipes")
@@ -368,7 +383,7 @@ func init() {
 	setupCmd.Flags().BoolVar(&setupRemove, "remove", false, "Remove the integration")
 	setupCmd.Flags().BoolVar(&setupProject, "project", false, "Install for this project only (claude/gemini/mux)")
 	setupCmd.Flags().BoolVar(&setupGlobal, "global", false, "Install globally (mux only; writes ~/.mux/AGENTS.md)")
-	setupCmd.Flags().BoolVar(&setupStealth, "stealth", false, "Use stealth mode (claude/gemini)")
+	setupCmd.Flags().BoolVar(&setupStealth, "stealth", false, "Use stealth mode (claude/gemini/copilot)")
 
 	rootCmd.AddCommand(setupCmd)
 }

--- a/cmd/bd/setup/copilot.go
+++ b/cmd/bd/setup/copilot.go
@@ -1,0 +1,326 @@
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/templates/agents"
+)
+
+var (
+	copilotEnvProvider     = defaultCopilotEnv
+	errCopilotHooksMissing = errors.New("copilot hooks not installed")
+)
+
+const copilotInstructionsFile = ".github/copilot-instructions.md"
+
+var copilotAgentsIntegration = agentsIntegration{
+	name:         "GitHub Copilot",
+	setupCommand: "bd setup copilot",
+	profile:      agents.ProfileMinimal,
+}
+
+type copilotEnv struct {
+	stdout     io.Writer
+	stderr     io.Writer
+	projectDir string
+	ensureDir  func(string, os.FileMode) error
+	readFile   func(string) ([]byte, error)
+	writeFile  func(string, []byte) error
+}
+
+func defaultCopilotEnv() (copilotEnv, error) {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return copilotEnv{}, fmt.Errorf("working directory: %w", err)
+	}
+	return copilotEnv{
+		stdout:     os.Stdout,
+		stderr:     os.Stderr,
+		projectDir: workDir,
+		ensureDir:  EnsureDir,
+		readFile:   os.ReadFile,
+		writeFile: func(path string, data []byte) error {
+			return atomicWriteFile(path, data)
+		},
+	}, nil
+}
+
+func copilotHooksPath(base string) string {
+	return filepath.Join(base, ".github", "hooks", "beads.json")
+}
+
+func copilotAgentsEnv(env copilotEnv) agentsEnv {
+	return agentsEnv{
+		agentsPath: filepath.Join(env.projectDir, copilotInstructionsFile),
+		stdout:     env.stdout,
+		stderr:     env.stderr,
+	}
+}
+
+// InstallCopilot installs GitHub Copilot CLI hooks and instructions.
+func InstallCopilot(stealth bool) {
+	env, err := copilotEnvProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		setupExit(1)
+		return
+	}
+	if err := installCopilot(env, stealth); err != nil {
+		setupExit(1)
+	}
+}
+
+func installCopilot(env copilotEnv, stealth bool) error {
+	hooksPath := copilotHooksPath(env.projectDir)
+	_, _ = fmt.Fprintln(env.stdout, "Installing GitHub Copilot CLI hooks...")
+
+	if err := env.ensureDir(filepath.Dir(hooksPath), 0o755); err != nil {
+		_, _ = fmt.Fprintf(env.stderr, "Error: %v\n", err)
+		return err
+	}
+
+	// Read existing hooks file or start fresh
+	hooksConfig := make(map[string]interface{})
+	if data, err := env.readFile(hooksPath); err == nil {
+		if err := json.Unmarshal(data, &hooksConfig); err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Error: failed to parse %s: %v\n", hooksPath, err)
+			return err
+		}
+	}
+
+	// Ensure version field
+	hooksConfig["version"] = float64(1)
+
+	// Get or create hooks object
+	hooks, ok := hooksConfig["hooks"].(map[string]interface{})
+	if !ok {
+		hooks = make(map[string]interface{})
+		hooksConfig["hooks"] = hooks
+	}
+
+	command := "bd prime"
+	if stealth {
+		command = "bd prime --stealth"
+	}
+
+	if addCopilotHook(hooks, "sessionStart", command) {
+		_, _ = fmt.Fprintln(env.stdout, "✓ Registered sessionStart hook")
+	}
+
+	data, err := json.MarshalIndent(hooksConfig, "", "  ")
+	if err != nil {
+		_, _ = fmt.Fprintf(env.stderr, "Error: marshal hooks: %v\n", err)
+		return err
+	}
+
+	if err := env.writeFile(hooksPath, data); err != nil {
+		_, _ = fmt.Fprintf(env.stderr, "Error: write hooks: %v\n", err)
+		return err
+	}
+
+	// Install minimal beads section in copilot-instructions.md
+	if err := installAgents(copilotAgentsEnv(env), copilotAgentsIntegration); err != nil {
+		// Non-fatal: hooks are already installed
+		_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", copilotInstructionsFile, err)
+	}
+
+	_, _ = fmt.Fprintln(env.stdout, "\n✓ GitHub Copilot integration installed")
+	_, _ = fmt.Fprintf(env.stdout, "  Hooks: %s\n", hooksPath)
+	_, _ = fmt.Fprintf(env.stdout, "  Instructions: %s\n", copilotInstructionsFile)
+	_, _ = fmt.Fprintln(env.stdout, "\nCommit .github/hooks/beads.json to share hooks with your team.")
+	return nil
+}
+
+// CheckCopilot checks if GitHub Copilot integration is installed.
+func CheckCopilot() {
+	env, err := copilotEnvProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		setupExit(1)
+		return
+	}
+	if err := checkCopilot(env); err != nil {
+		setupExit(1)
+	}
+}
+
+func checkCopilot(env copilotEnv) error {
+	hooksPath := copilotHooksPath(env.projectDir)
+
+	if hasCopilotBeadsHooks(hooksPath) {
+		_, _ = fmt.Fprintf(env.stdout, "✓ Hooks installed: %s\n", hooksPath)
+	} else {
+		_, _ = fmt.Fprintln(env.stdout, "✗ No hooks installed")
+		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup copilot")
+		return errCopilotHooksMissing
+	}
+
+	return checkAgents(copilotAgentsEnv(env), copilotAgentsIntegration)
+}
+
+// RemoveCopilot removes GitHub Copilot CLI hooks and instructions.
+func RemoveCopilot() {
+	env, err := copilotEnvProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		setupExit(1)
+		return
+	}
+	if err := removeCopilot(env); err != nil {
+		setupExit(1)
+	}
+}
+
+func removeCopilot(env copilotEnv) error {
+	hooksPath := copilotHooksPath(env.projectDir)
+	_, _ = fmt.Fprintln(env.stdout, "Removing GitHub Copilot hooks...")
+
+	data, err := env.readFile(hooksPath)
+	if err != nil {
+		_, _ = fmt.Fprintln(env.stdout, "No hooks file found")
+	} else {
+		var hooksConfig map[string]interface{}
+		if err := json.Unmarshal(data, &hooksConfig); err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Error: failed to parse %s: %v\n", hooksPath, err)
+			return err
+		}
+
+		hooks, ok := hooksConfig["hooks"].(map[string]interface{})
+		if !ok {
+			_, _ = fmt.Fprintln(env.stdout, "No hooks found")
+		} else {
+			removeCopilotHook(hooks, "sessionStart", "bd prime")
+			removeCopilotHook(hooks, "sessionStart", "bd prime --stealth")
+
+			// If no hooks remain, remove the file entirely
+			if len(hooks) == 0 {
+				if err := os.Remove(hooksPath); err != nil && !os.IsNotExist(err) {
+					_, _ = fmt.Fprintf(env.stderr, "Error: remove hooks file: %v\n", err)
+					return err
+				}
+			} else {
+				data, err = json.MarshalIndent(hooksConfig, "", "  ")
+				if err != nil {
+					_, _ = fmt.Fprintf(env.stderr, "Error: marshal hooks: %v\n", err)
+					return err
+				}
+				if err := env.writeFile(hooksPath, data); err != nil {
+					_, _ = fmt.Fprintf(env.stderr, "Error: write hooks: %v\n", err)
+					return err
+				}
+			}
+		}
+	}
+
+	if err := removeAgents(copilotAgentsEnv(env), copilotAgentsIntegration); err != nil {
+		_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", copilotInstructionsFile, err)
+	}
+
+	_, _ = fmt.Fprintln(env.stdout, "✓ GitHub Copilot hooks removed")
+	return nil
+}
+
+// addCopilotHook adds a hook to the Copilot hooks config.
+// Copilot uses a different format than Claude/Gemini:
+//
+//	{"type": "command", "bash": "<cmd>", "powershell": "<cmd>", "timeoutSec": 10}
+//
+// Returns true if the hook was added, false if already present.
+func addCopilotHook(hooks map[string]interface{}, event, command string) bool {
+	eventHooks, ok := hooks[event].([]interface{})
+	if !ok {
+		eventHooks = []interface{}{}
+	}
+
+	// Check if already registered
+	for _, hook := range eventHooks {
+		hookMap, ok := hook.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if hookMap["bash"] == command {
+			fmt.Printf("✓ Hook already registered: %s\n", event)
+			return false
+		}
+	}
+
+	newHook := map[string]interface{}{
+		"type":       "command",
+		"bash":       command,
+		"powershell": command,
+		"timeoutSec": float64(10),
+	}
+
+	eventHooks = append(eventHooks, newHook)
+	hooks[event] = eventHooks
+	return true
+}
+
+// removeCopilotHook removes a hook command from a Copilot hooks event.
+func removeCopilotHook(hooks map[string]interface{}, event, command string) {
+	eventHooks, ok := hooks[event].([]interface{})
+	if !ok {
+		return
+	}
+
+	filtered := make([]interface{}, 0, len(eventHooks))
+	for _, hook := range eventHooks {
+		hookMap, ok := hook.(map[string]interface{})
+		if !ok {
+			filtered = append(filtered, hook)
+			continue
+		}
+		if hookMap["bash"] == command {
+			fmt.Printf("✓ Removed %s hook\n", event)
+			continue
+		}
+		filtered = append(filtered, hook)
+	}
+
+	if len(filtered) == 0 {
+		delete(hooks, event)
+	} else {
+		hooks[event] = filtered
+	}
+}
+
+// hasCopilotBeadsHooks checks if the hooks file has bd prime hooks.
+func hasCopilotBeadsHooks(hooksPath string) bool {
+	data, err := os.ReadFile(hooksPath) // #nosec G304 -- hooksPath is constructed from known safe project directory
+	if err != nil {
+		return false
+	}
+
+	var hooksConfig map[string]interface{}
+	if err := json.Unmarshal(data, &hooksConfig); err != nil {
+		return false
+	}
+
+	hooks, ok := hooksConfig["hooks"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	eventHooks, ok := hooks["sessionStart"].([]interface{})
+	if !ok {
+		return false
+	}
+
+	for _, hook := range eventHooks {
+		hookMap, ok := hook.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cmd, _ := hookMap["bash"].(string)
+		if cmd == "bd prime" || cmd == "bd prime --stealth" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/bd/setup/copilot_test.go
+++ b/cmd/bd/setup/copilot_test.go
@@ -1,0 +1,638 @@
+package setup
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newCopilotTestEnv(t *testing.T) (copilotEnv, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	env := copilotEnv{
+		stdout:     stdout,
+		stderr:     stderr,
+		projectDir: projectDir,
+		ensureDir:  EnsureDir,
+		readFile:   os.ReadFile,
+		writeFile: func(path string, data []byte) error {
+			return atomicWriteFile(path, data)
+		},
+	}
+	return env, stdout, stderr
+}
+
+func stubCopilotEnvProvider(t *testing.T, env copilotEnv, err error) {
+	t.Helper()
+	orig := copilotEnvProvider
+	copilotEnvProvider = func() (copilotEnv, error) {
+		if err != nil {
+			return copilotEnv{}, err
+		}
+		return env, nil
+	}
+	t.Cleanup(func() { copilotEnvProvider = orig })
+}
+
+func writeCopilotHooks(t *testing.T, path string, config map[string]interface{}) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal hooks: %v", err)
+	}
+	if err := atomicWriteFile(path, data); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+}
+
+func TestAddCopilotHook(t *testing.T) {
+	tests := []struct {
+		name      string
+		hooks     map[string]interface{}
+		event     string
+		command   string
+		wantAdded bool
+	}{
+		{
+			name:      "add hook to empty hooks",
+			hooks:     make(map[string]interface{}),
+			event:     "sessionStart",
+			command:   "bd prime",
+			wantAdded: true,
+		},
+		{
+			name:      "add stealth hook to empty hooks",
+			hooks:     make(map[string]interface{}),
+			event:     "sessionStart",
+			command:   "bd prime --stealth",
+			wantAdded: true,
+		},
+		{
+			name: "hook already exists",
+			hooks: map[string]interface{}{
+				"sessionStart": []interface{}{
+					map[string]interface{}{
+						"type":       "command",
+						"bash":       "bd prime",
+						"powershell": "bd prime",
+						"timeoutSec": float64(10),
+					},
+				},
+			},
+			event:     "sessionStart",
+			command:   "bd prime",
+			wantAdded: false,
+		},
+		{
+			name: "add alongside existing hook",
+			hooks: map[string]interface{}{
+				"sessionStart": []interface{}{
+					map[string]interface{}{
+						"type": "command",
+						"bash": "other command",
+					},
+				},
+			},
+			event:     "sessionStart",
+			command:   "bd prime",
+			wantAdded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addCopilotHook(tt.hooks, tt.event, tt.command)
+			if got != tt.wantAdded {
+				t.Errorf("addCopilotHook() = %v, want %v", got, tt.wantAdded)
+			}
+
+			eventHooks, ok := tt.hooks[tt.event].([]interface{})
+			if !ok {
+				t.Fatal("Event hooks not found")
+			}
+
+			found := false
+			for _, hook := range eventHooks {
+				hookMap := hook.(map[string]interface{})
+				if hookMap["bash"] == tt.command {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Hook command %q not found in event %q", tt.command, tt.event)
+			}
+		})
+	}
+}
+
+func TestRemoveCopilotHook(t *testing.T) {
+	tests := []struct {
+		name          string
+		hooks         map[string]interface{}
+		event         string
+		command       string
+		wantRemaining int
+	}{
+		{
+			name: "remove only hook",
+			hooks: map[string]interface{}{
+				"sessionStart": []interface{}{
+					map[string]interface{}{
+						"type": "command",
+						"bash": "bd prime",
+					},
+				},
+			},
+			event:         "sessionStart",
+			command:       "bd prime",
+			wantRemaining: 0,
+		},
+		{
+			name: "remove stealth hook",
+			hooks: map[string]interface{}{
+				"sessionStart": []interface{}{
+					map[string]interface{}{
+						"type": "command",
+						"bash": "bd prime --stealth",
+					},
+				},
+			},
+			event:         "sessionStart",
+			command:       "bd prime --stealth",
+			wantRemaining: 0,
+		},
+		{
+			name: "remove one of multiple hooks",
+			hooks: map[string]interface{}{
+				"sessionStart": []interface{}{
+					map[string]interface{}{
+						"type": "command",
+						"bash": "other command",
+					},
+					map[string]interface{}{
+						"type": "command",
+						"bash": "bd prime",
+					},
+				},
+			},
+			event:         "sessionStart",
+			command:       "bd prime",
+			wantRemaining: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			removeCopilotHook(tt.hooks, tt.event, tt.command)
+
+			eventHooks, ok := tt.hooks[tt.event].([]interface{})
+			if !ok && tt.wantRemaining > 0 {
+				t.Fatal("Event hooks not found")
+			}
+
+			if len(eventHooks) != tt.wantRemaining {
+				t.Errorf("Expected %d remaining hooks, got %d", tt.wantRemaining, len(eventHooks))
+			}
+
+			for _, hook := range eventHooks {
+				hookMap := hook.(map[string]interface{})
+				if hookMap["bash"] == tt.command {
+					t.Errorf("Hook command %q still present after removal", tt.command)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveCopilotHookDeletesEmptyKey(t *testing.T) {
+	hooks := map[string]interface{}{
+		"sessionStart": []interface{}{
+			map[string]interface{}{
+				"type": "command",
+				"bash": "bd prime",
+			},
+		},
+	}
+
+	removeCopilotHook(hooks, "sessionStart", "bd prime")
+
+	if _, exists := hooks["sessionStart"]; exists {
+		t.Error("Expected sessionStart key to be deleted after removing all hooks")
+	}
+
+	data, err := json.Marshal(hooks)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "null") {
+		t.Errorf("JSON contains null: %s", data)
+	}
+}
+
+func TestInstallCopilotFresh(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	err := installCopilot(env, false)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Registered sessionStart hook") {
+		t.Error("Expected sessionStart hook to be registered")
+	}
+	if !strings.Contains(stdout.String(), "GitHub Copilot integration installed") {
+		t.Error("Expected success message")
+	}
+
+	// Verify hooks file
+	hooksPath := copilotHooksPath(env.projectDir)
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse hooks: %v", err)
+	}
+
+	if config["version"] != float64(1) {
+		t.Errorf("Expected version 1, got %v", config["version"])
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+	sessionStart := hooks["sessionStart"].([]interface{})
+	if len(sessionStart) != 1 {
+		t.Fatalf("Expected 1 sessionStart hook, got %d", len(sessionStart))
+	}
+
+	hook := sessionStart[0].(map[string]interface{})
+	if hook["bash"] != "bd prime" {
+		t.Errorf("Expected bash command 'bd prime', got %v", hook["bash"])
+	}
+	if hook["powershell"] != "bd prime" {
+		t.Errorf("Expected powershell command 'bd prime', got %v", hook["powershell"])
+	}
+	if hook["timeoutSec"] != float64(10) {
+		t.Errorf("Expected timeoutSec 10, got %v", hook["timeoutSec"])
+	}
+}
+
+func TestInstallCopilotStealth(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	err := installCopilot(env, true)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	hooksPath := copilotHooksPath(env.projectDir)
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse hooks: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+	sessionStart := hooks["sessionStart"].([]interface{})
+	hook := sessionStart[0].(map[string]interface{})
+	if hook["bash"] != "bd prime --stealth" {
+		t.Errorf("Expected stealth command, got %v", hook["bash"])
+	}
+}
+
+func TestInstallCopilotIdempotent(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	// Install twice
+	if err := installCopilot(env, false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := installCopilot(env, false); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	// Should still have only one hook
+	hooksPath := copilotHooksPath(env.projectDir)
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse hooks: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+	sessionStart := hooks["sessionStart"].([]interface{})
+	if len(sessionStart) != 1 {
+		t.Errorf("Expected 1 hook after idempotent install, got %d", len(sessionStart))
+	}
+}
+
+func TestInstallCopilotPreservesExistingHooks(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	// Pre-populate with existing hooks
+	hooksPath := copilotHooksPath(env.projectDir)
+	writeCopilotHooks(t, hooksPath, map[string]interface{}{
+		"version": float64(1),
+		"hooks": map[string]interface{}{
+			"preToolUse": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "./scripts/security-check.sh",
+				},
+			},
+		},
+	})
+
+	if err := installCopilot(env, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse hooks: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+
+	// Existing preToolUse hook should be preserved
+	preToolUse, ok := hooks["preToolUse"].([]interface{})
+	if !ok || len(preToolUse) != 1 {
+		t.Error("Expected existing preToolUse hook to be preserved")
+	}
+
+	// New sessionStart hook should be added
+	sessionStart, ok := hooks["sessionStart"].([]interface{})
+	if !ok || len(sessionStart) != 1 {
+		t.Error("Expected sessionStart hook to be added")
+	}
+}
+
+func TestCheckCopilotInstalled(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	// Install first
+	if err := installCopilot(env, false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	stdout.Reset()
+
+	err := checkCopilot(env)
+	if err != nil {
+		t.Fatalf("check failed: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "✓ Hooks installed") {
+		t.Error("Expected hooks installed message")
+	}
+}
+
+func TestCheckCopilotNotInstalled(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	err := checkCopilot(env)
+	if err != errCopilotHooksMissing {
+		t.Errorf("Expected errCopilotHooksMissing, got %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "✗ No hooks installed") {
+		t.Error("Expected not-installed message")
+	}
+}
+
+func TestRemoveCopilotHooks(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	// Install then remove
+	if err := installCopilot(env, false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	stdout.Reset()
+
+	if err := removeCopilot(env); err != nil {
+		t.Fatalf("remove failed: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "GitHub Copilot hooks removed") {
+		t.Error("Expected removal message")
+	}
+
+	// Hooks file should be deleted (no other hooks remain)
+	hooksPath := copilotHooksPath(env.projectDir)
+	if FileExists(hooksPath) {
+		t.Error("Expected hooks file to be removed when empty")
+	}
+}
+
+func TestRemoveCopilotPreservesOtherHooks(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	// Create hooks file with both beads and user hooks
+	hooksPath := copilotHooksPath(env.projectDir)
+	writeCopilotHooks(t, hooksPath, map[string]interface{}{
+		"version": float64(1),
+		"hooks": map[string]interface{}{
+			"sessionStart": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "bd prime",
+				},
+			},
+			"preToolUse": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "./scripts/security-check.sh",
+				},
+			},
+		},
+	})
+
+	if err := removeCopilot(env); err != nil {
+		t.Fatalf("remove failed: %v", err)
+	}
+
+	// File should still exist with preToolUse hook
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatalf("parse hooks: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+	if _, exists := hooks["sessionStart"]; exists {
+		t.Error("Expected sessionStart to be removed")
+	}
+
+	preToolUse, ok := hooks["preToolUse"].([]interface{})
+	if !ok || len(preToolUse) != 1 {
+		t.Error("Expected preToolUse hook to be preserved")
+	}
+}
+
+func TestHasCopilotBeadsHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name   string
+		config map[string]interface{}
+		want   bool
+	}{
+		{
+			name: "has bd prime hook",
+			config: map[string]interface{}{
+				"version": float64(1),
+				"hooks": map[string]interface{}{
+					"sessionStart": []interface{}{
+						map[string]interface{}{
+							"type": "command",
+							"bash": "bd prime",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "has stealth hook",
+			config: map[string]interface{}{
+				"version": float64(1),
+				"hooks": map[string]interface{}{
+					"sessionStart": []interface{}{
+						map[string]interface{}{
+							"type": "command",
+							"bash": "bd prime --stealth",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no beads hooks",
+			config: map[string]interface{}{
+				"version": float64(1),
+				"hooks": map[string]interface{}{
+					"sessionStart": []interface{}{
+						map[string]interface{}{
+							"type": "command",
+							"bash": "other command",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty hooks",
+			config: map[string]interface{}{
+				"version": float64(1),
+				"hooks":   map[string]interface{}{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooksPath := filepath.Join(tmpDir, tt.name+".json")
+			writeCopilotHooks(t, hooksPath, tt.config)
+
+			got := hasCopilotBeadsHooks(hooksPath)
+			if got != tt.want {
+				t.Errorf("hasCopilotBeadsHooks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// Non-existent file
+	t.Run("file not found", func(t *testing.T) {
+		got := hasCopilotBeadsHooks(filepath.Join(tmpDir, "nonexistent.json"))
+		if got {
+			t.Error("Expected false for non-existent file")
+		}
+	})
+}
+
+func TestInstallCopilotPublicAPI(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+	stubCopilotEnvProvider(t, env, nil)
+	cap := stubSetupExit(t)
+
+	InstallCopilot(false)
+
+	if cap.called {
+		t.Errorf("Expected no exit, but setupExit was called with code %d", cap.code)
+	}
+
+	hooksPath := copilotHooksPath(env.projectDir)
+	if !FileExists(hooksPath) {
+		t.Error("Expected hooks file to be created")
+	}
+}
+
+func TestCheckCopilotPublicAPI(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+	stubCopilotEnvProvider(t, env, nil)
+	cap := stubSetupExit(t)
+
+	// Not installed — should call setupExit(1)
+	CheckCopilot()
+
+	if !cap.called || cap.code != 1 {
+		t.Error("Expected setupExit(1) when hooks not installed")
+	}
+}
+
+func TestRemoveCopilotPublicAPI(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+	stubCopilotEnvProvider(t, env, nil)
+	cap := stubSetupExit(t)
+
+	RemoveCopilot()
+
+	if cap.called {
+		t.Errorf("Expected no exit for remove on empty state, but got code %d", cap.code)
+	}
+}
+
+func TestCopilotEnvProviderError(t *testing.T) {
+	stubCopilotEnvProvider(t, copilotEnv{}, errors.New("env error"))
+	cap := stubSetupExit(t)
+
+	InstallCopilot(false)
+
+	if !cap.called || cap.code != 1 {
+		t.Error("Expected setupExit(1) on env provider error")
+	}
+}

--- a/internal/recipes/recipes.go
+++ b/internal/recipes/recipes.go
@@ -78,6 +78,12 @@ var BuiltinRecipes = map[string]Recipe{
 		GlobalPath:  "~/.gemini/settings.json",
 		ProjectPath: ".gemini/settings.json",
 	},
+	"copilot": {
+		Name:        "GitHub Copilot",
+		Type:        TypeHooks,
+		Description: "Copilot CLI hooks (sessionStart)",
+		ProjectPath: ".github/hooks/beads.json",
+	},
 	"factory": {
 		Name:        "Factory.ai (Droid)",
 		Path:        "AGENTS.md",


### PR DESCRIPTION
## Summary

Adds `bd setup copilot` command for GitHub Copilot CLI integration, following the same pattern as `bd setup claude` and `bd setup gemini`.

## What it does

- **`bd setup copilot`** — Creates `.github/hooks/beads.json` with a `sessionStart` hook that runs `bd prime`, plus manages `.github/copilot-instructions.md` via the agents.go section system
- **`bd setup copilot --stealth`** — Uses `bd prime --stealth` (no git ops)
- **`bd setup copilot --check`** — Verifies installation status
- **`bd setup copilot --remove`** — Uninstalls hooks and instructions

## Copilot CLI hook format

Copilot CLI uses a different hook format than Claude/Gemini:

```json
{
  "version": 1,
  "hooks": {
    "sessionStart": [{
      "type": "command",
      "bash": "bd prime",
      "powershell": "bd prime",
      "timeoutSec": 10
    }]
  }
}
```

Key differences:
- **Location**: `.github/hooks/*.json` (repo-level, committed to source) vs user settings files
- **Format**: `bash`/`powershell` keys with `timeoutSec` (not `command` key with `matcher`)
- **Events**: camelCase (`sessionStart`) vs PascalCase (`SessionStart`)
- **Ref**: https://docs.github.com/en/copilot/reference/hooks-configuration

## Changes

| File | Description |
|------|-------------|
| `cmd/bd/setup/copilot.go` | Install/Check/Remove + Copilot-specific hook helpers |
| `cmd/bd/setup/copilot_test.go` | 18 tests covering all operations |
| `cmd/bd/setup.go` | Wire up `copilot` recipe case + update descriptions |
| `internal/recipes/recipes.go` | Register copilot as built-in recipe |

## Testing

- 18 new tests all passing
- Full setup test suite passes
- Linter clean (0 issues)
- Build succeeds