### PR TITLE
fix: epic closure eligibility misses wisp children

### DIFF
--- a/cmd/bd/epic_test.go
+++ b/cmd/bd/epic_test.go
@@ -128,6 +128,96 @@ func TestEpicCommandInit(t *testing.T) {
 	}
 }
 
+func TestEpicEligibleForCloseWithWispChildren(t *testing.T) {
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	sqliteStore := newTestStore(t, testDB)
+	ctx := context.Background()
+
+	// Create an epic with one regular child and one wisp child.
+	epic := &types.Issue{
+		ID:          "test-epic-wisp",
+		Title:       "Epic with wisp child",
+		Description: "Tests that wisp children are counted for closure eligibility",
+		Status:      types.StatusOpen,
+		Priority:    1,
+		IssueType:   types.TypeEpic,
+		CreatedAt:   time.Now(),
+	}
+	if err := sqliteStore.CreateIssue(ctx, epic, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Regular child (closed)
+	regularChild := &types.Issue{
+		Title:     "Regular child",
+		Status:    types.StatusClosed,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now(),
+		ClosedAt:  ptrTime(time.Now()),
+	}
+	if err := sqliteStore.CreateIssue(ctx, regularChild, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wisp child (still open) — stored in wisps table
+	wispChild := &types.Issue{
+		Title:     "Wisp child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+		CreatedAt: time.Now(),
+	}
+	if err := sqliteStore.CreateIssue(ctx, wispChild, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add parent-child dependencies
+	if err := sqliteStore.AddDependency(ctx, &types.Dependency{
+		IssueID:     regularChild.ID,
+		DependsOnID: epic.ID,
+		Type:        types.DepParentChild,
+	}, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqliteStore.AddDependency(ctx, &types.Dependency{
+		IssueID:     wispChild.ID,
+		DependsOnID: epic.ID,
+		Type:        types.DepParentChild,
+	}, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Epic should NOT be eligible — wisp child is still open
+	epics, err := sqliteStore.GetEpicsEligibleForClosure(ctx)
+	if err != nil {
+		t.Fatalf("GetEpicsEligibleForClosure failed: %v", err)
+	}
+
+	var epicStatus *types.EpicStatus
+	for _, e := range epics {
+		if e.Epic.ID == "test-epic-wisp" {
+			epicStatus = e
+			break
+		}
+	}
+
+	if epicStatus == nil {
+		t.Fatal("Epic test-epic-wisp not found in results")
+	}
+	if epicStatus.TotalChildren != 2 {
+		t.Errorf("Expected 2 total children (1 regular + 1 wisp), got %d", epicStatus.TotalChildren)
+	}
+	if epicStatus.ClosedChildren != 1 {
+		t.Errorf("Expected 1 closed child, got %d", epicStatus.ClosedChildren)
+	}
+	if epicStatus.EligibleForClose {
+		t.Error("Epic should NOT be eligible for close with open wisp child")
+	}
+}
+
 func TestEpicEligibleForClose(t *testing.T) {
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")

--- a/internal/storage/issueops/epic_closure.go
+++ b/internal/storage/issueops/epic_closure.go
@@ -38,31 +38,37 @@ func GetEpicsEligibleForClosureInTx(ctx context.Context, tx *sql.Tx) ([]*types.E
 		return nil, nil
 	}
 
-	// Step 2: Get parent-child dependencies (single-table scan)
-	depRows, err := tx.QueryContext(ctx, `
-		SELECT depends_on_id, issue_id FROM dependencies
-		WHERE type = 'parent-child'
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get parent-child deps: %w", err)
-	}
-	// Map: parent_id -> list of child IDs
+	// Step 2: Get parent-child dependencies from both tables (bd-w2w)
+	// Wisp children store their parent-child deps in wisp_dependencies,
+	// so we must check both tables to find all children of an epic.
 	epicChildMap := make(map[string][]string)
 	epicSet := make(map[string]bool, len(epicIDs))
 	for _, id := range epicIDs {
 		epicSet[id] = true
 	}
-	for depRows.Next() {
-		var parentID, childID string
-		if err := depRows.Scan(&parentID, &childID); err != nil {
-			depRows.Close()
-			return nil, fmt.Errorf("scan parent-child dep: %w", err)
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+			SELECT depends_on_id, issue_id FROM %s
+			WHERE type = 'parent-child'
+		`, depTable))
+		if err != nil {
+			if isTableNotExistError(err) {
+				continue // wisp_dependencies may not exist on pre-migration databases
+			}
+			return nil, fmt.Errorf("failed to get parent-child deps from %s: %w", depTable, err)
 		}
-		if epicSet[parentID] {
-			epicChildMap[parentID] = append(epicChildMap[parentID], childID)
+		for depRows.Next() {
+			var parentID, childID string
+			if err := depRows.Scan(&parentID, &childID); err != nil {
+				depRows.Close()
+				return nil, fmt.Errorf("scan parent-child dep from %s: %w", depTable, err)
+			}
+			if epicSet[parentID] {
+				epicChildMap[parentID] = append(epicChildMap[parentID], childID)
+			}
 		}
+		depRows.Close()
 	}
-	depRows.Close()
 
 	// Step 3: Batch-fetch statuses for all child issues across all epics
 	allChildIDs := make([]string, 0)


### PR DESCRIPTION
Step 2 only queries the dependencies table for parent-child relationships, missing wisp children whose deps are stored in wisp_dependencies. This causes epics with wisp children to either never appear as eligible (all-wisp case) or appear eligible prematurely (mixed case where only regular children are counted).

Queries both dependencies and wisp_dependencies in Step 2, matching the pattern already used in Step 3 for status lookups. Gracefully skips wisp_dependencies on pre-migration databases.

Added TestEpicEligibleForCloseWithWispChildren covering the mixed regular+wisp child case.