### PR TITLE
fix(cmd/bd): honor explicit repo selection for no-db commands

### DIFF
--- a/cmd/bd/context_cmd.go
+++ b/cmd/bd/context_cmd.go
@@ -51,6 +51,10 @@ Examples:
 		}
 
 		// Resolve repo context (works without DB open)
+		if selected := selectedNoDBBeadsDir(); selected != "" {
+			prepareSelectedNoDBContext(selected)
+		}
+
 		rc, err := beads.GetRepoContext()
 		if err != nil {
 			if jsonOutput {
@@ -98,8 +102,8 @@ Examples:
 			info.DataDir = dataDir
 		}
 
-		// Read sync.git-remote from config.yaml
-		if remote := config.GetString("sync.git-remote"); remote != "" {
+		// Read sync.git-remote from the selected repo's config.yaml.
+		if remote := config.GetStringFromDir(rc.BeadsDir, "sync.git-remote"); remote != "" {
 			info.SyncGitRemote = remote
 		}
 

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
@@ -309,7 +308,7 @@ required. Use this command for explicit control or diagnostics.`,
 			fmt.Fprintln(os.Stderr, "Error: 'bd dolt start' is not supported in embedded mode (no Dolt server)")
 			os.Exit(1)
 		}
-		beadsDir := beads.FindBeadsDir()
+		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
 			fmt.Fprintf(os.Stderr, "Error: not in a beads repository (no .beads directory found)\n")
 			os.Exit(1)
@@ -347,7 +346,7 @@ on the next bd command unless auto-start is disabled.`,
 			fmt.Fprintln(os.Stderr, "Error: 'bd dolt stop' is not supported in embedded mode (no Dolt server)")
 			os.Exit(1)
 		}
-		beadsDir := beads.FindBeadsDir()
+		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
 			fmt.Fprintf(os.Stderr, "Error: not in a beads repository (no .beads directory found)\n")
 			os.Exit(1)
@@ -374,7 +373,7 @@ Displays whether the server is running, its PID, port, and data directory.`,
 			fmt.Fprintln(os.Stderr, "Error: 'bd dolt status' is not supported in embedded mode (no Dolt server)")
 			os.Exit(1)
 		}
-		beadsDir := beads.FindBeadsDir()
+		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
 			fmt.Fprintf(os.Stderr, "Error: not in a beads repository (no .beads directory found)\n")
 			os.Exit(1)
@@ -428,7 +427,7 @@ servers are preserved.`,
 			fmt.Fprintln(os.Stderr, "Error: 'bd dolt killall' is not supported in embedded mode (no Dolt server)")
 			os.Exit(1)
 		}
-		beadsDir := beads.FindBeadsDir()
+		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
 			beadsDir = "." // best effort
 		}
@@ -950,8 +949,17 @@ func init() {
 	rootCmd.AddCommand(doltCmd)
 }
 
+func selectedDoltBeadsDir() string {
+	beadsDir := selectedNoDBBeadsDir()
+	if beadsDir == "" {
+		return ""
+	}
+	prepareSelectedNoDBContext(beadsDir)
+	return beadsDir
+}
+
 func showDoltConfig(testConnection bool) {
-	beadsDir := beads.FindBeadsDir()
+	beadsDir := selectedDoltBeadsDir()
 	if beadsDir == "" {
 		fmt.Fprintf(os.Stderr, "Error: not in a beads repository (no .beads directory found)\n")
 		os.Exit(1)
@@ -1071,7 +1079,7 @@ func showDoltConfig(testConnection bool) {
 }
 
 func setDoltConfig(key, value string, updateConfig bool) {
-	beadsDir := beads.FindBeadsDir()
+	beadsDir := selectedDoltBeadsDir()
 	if beadsDir == "" {
 		fmt.Fprintf(os.Stderr, "Error: not in a beads repository (no .beads directory found)\n")
 		os.Exit(1)
@@ -1234,7 +1242,7 @@ func setDoltConfig(key, value string, updateConfig bool) {
 }
 
 func testDoltConnection() {
-	beadsDir := beads.FindBeadsDir()
+	beadsDir := selectedDoltBeadsDir()
 	if beadsDir == "" {
 		fmt.Fprintf(os.Stderr, "Error: not in a beads repository (no .beads directory found)\n")
 		os.Exit(1)
@@ -1403,7 +1411,7 @@ func testHTTPConnectivity(url string) bool {
 // initialized for dolt subcommands (beads-9vt). Connects without selecting a
 // database so callers can operate on all databases (SHOW DATABASES, DROP DATABASE).
 func openDoltServerConnection() (*sql.DB, func()) {
-	beadsDir := beads.FindBeadsDir()
+	beadsDir := selectedDoltBeadsDir()
 	if beadsDir == "" {
 		fmt.Fprintln(os.Stderr, "Error: not in a beads repository (no .beads directory found)")
 		os.Exit(1)

--- a/cmd/bd/explicit_db_nodb_test.go
+++ b/cmd/bd/explicit_db_nodb_test.go
@@ -1,0 +1,427 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func buildBDUnderTest(t *testing.T) string {
+	t.Helper()
+
+	binName := "bd"
+	if runtime.GOOS == "windows" {
+		binName = "bd.exe"
+	}
+	binPath := filepath.Join(t.TempDir(), binName)
+	buildCmd := exec.Command("go", "build", "-o", binPath, ".")
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return binPath
+}
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init %s: %v\n%s", dir, err, out)
+	}
+	writeFile(t, filepath.Join(dir, ".gitignore"), []byte(".beads/.env\n"))
+	commitCmd := exec.Command("git", "add", ".")
+	commitCmd.Dir = dir
+	_, _ = commitCmd.CombinedOutput()
+	commitCmd = exec.Command("git", "commit", "-q", "-m", "init")
+	commitCmd.Dir = dir
+	commitCmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	_, _ = commitCmd.CombinedOutput()
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir parent for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func writeServerRepo(t *testing.T, repoDir, database, host, syncRemote string, port int) string {
+	return writeServerRepoWithDataDir(t, repoDir, database, host, syncRemote, port, "")
+}
+
+func writeServerRepoWithDataDir(t *testing.T, repoDir, database, host, syncRemote string, port int, doltDataDir string) string {
+	t.Helper()
+	initGitRepo(t, repoDir)
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if doltDataDir != "" {
+		doltDir = filepath.Join(beadsDir, doltDataDir)
+	}
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatalf("mkdir dolt dir: %v", err)
+	}
+	cfg := &configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: host,
+		DoltDatabase:   database,
+	}
+	if doltDataDir != "" {
+		cfg.DoltDataDir = doltDataDir
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	writeFile(t, filepath.Join(beadsDir, "dolt-server.port"), []byte(strconv.Itoa(port)))
+	writeFile(t, filepath.Join(beadsDir, "config.yaml"), []byte("sync:\n  git-remote: "+syncRemote+"\n"))
+	writeFile(t, filepath.Join(beadsDir, ".env"), []byte("BEADS_DOLT_SERVER_HOST="+host+"\n"))
+	return beadsDir
+}
+
+func writeProjectConfig(t *testing.T, beadsDir string, syncRemote string, port int, shared bool) {
+	t.Helper()
+	sharedText := "false"
+	if shared {
+		sharedText = "true"
+	}
+	writeFile(t, filepath.Join(beadsDir, "config.yaml"), []byte(
+		"sync:\n  git-remote: "+syncRemote+"\n"+
+			"dolt:\n  port: "+strconv.Itoa(port)+"\n  shared-server: "+sharedText+"\n",
+	))
+}
+
+func decodeJSONOutput(t *testing.T, out []byte, target any) {
+	t.Helper()
+	trimmed := strings.TrimSpace(string(out))
+	idx := strings.Index(trimmed, "{")
+	if idx == -1 {
+		t.Fatalf("no JSON object found in output:\n%s", out)
+	}
+	if err := json.Unmarshal([]byte(trimmed[idx:]), target); err != nil {
+		t.Fatalf("unmarshal json: %v\n%s", err, out)
+	}
+}
+
+func runBDCommand(t *testing.T, binPath, dir string, extraEnv []string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command(binPath, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"XDG_CONFIG_HOME="+t.TempDir(),
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+		"BEADS_DIR=",
+		"BEADS_DB=",
+		"BEADS_DOLT_SERVER_DATABASE=",
+		"BEADS_DOLT_SERVER_HOST=",
+		"BEADS_DOLT_SERVER_PORT=",
+		"BEADS_DOLT_PORT=",
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%v failed: %v\n%s", args, err, out)
+	}
+	return out
+}
+
+func TestContextUsesExplicitDBFlagForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+
+	out := runBDCommand(t, binPath, repoA, nil, "--db", filepath.Join(beadsDirB, "dolt"), "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["beads_dir"] != beadsDirB {
+		t.Fatalf("beads_dir = %v, want %s", got["beads_dir"], beadsDirB)
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+	if got["server_host"] != "10.0.0.2" {
+		t.Fatalf("server_host = %v, want 10.0.0.2", got["server_host"])
+	}
+	if got["sync_git_remote"] != "origin-b" {
+		t.Fatalf("sync_git_remote = %v, want origin-b", got["sync_git_remote"])
+	}
+}
+
+func TestDoltShowUsesExplicitDBFlagForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+
+	out := runBDCommand(t, binPath, repoA, nil, "--db", filepath.Join(beadsDirB, "dolt"), "dolt", "show", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+	if got["host"] != "10.0.0.2" {
+		t.Fatalf("host = %v, want 10.0.0.2", got["host"])
+	}
+	if got["port"] != float64(3312) {
+		t.Fatalf("port = %v, want 3312", got["port"])
+	}
+}
+
+func TestContextUsesBEADSDBForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+
+	out := runBDCommand(t, binPath, repoA, []string{"BEADS_DB=" + filepath.Join(beadsDirB, "dolt")}, "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["beads_dir"] != beadsDirB {
+		t.Fatalf("beads_dir = %v, want %s", got["beads_dir"], beadsDirB)
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+}
+
+func TestContextUsesBEADSDBDirectoryForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+
+	out := runBDCommand(t, binPath, repoA, []string{"BEADS_DB=" + beadsDirB}, "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["beads_dir"] != beadsDirB {
+		t.Fatalf("beads_dir = %v, want %s", got["beads_dir"], beadsDirB)
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+}
+
+func TestContextUsesExplicitDBFlagForExternalDoltDataDir(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepoWithDataDir(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312, "../external-dolt")
+
+	out := runBDCommand(t, binPath, repoA, nil, "--db", filepath.Join(beadsDirB, "../external-dolt"), "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["beads_dir"] != beadsDirB {
+		t.Fatalf("beads_dir = %v, want %s", got["beads_dir"], beadsDirB)
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+	if got["server_host"] != "10.0.0.2" {
+		t.Fatalf("server_host = %v, want 10.0.0.2", got["server_host"])
+	}
+}
+
+func TestContextExplicitDBFlagOverridesBEADSDBForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	repoC := filepath.Join(root, "repo-c")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+	beadsDirC := writeServerRepo(t, repoC, "repo_c_db", "10.0.0.3", "origin-c", 3313)
+
+	out := runBDCommand(t, binPath, repoA, []string{"BEADS_DB=" + filepath.Join(beadsDirC, "dolt")}, "--db", filepath.Join(beadsDirB, "dolt"), "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["beads_dir"] != beadsDirB {
+		t.Fatalf("beads_dir = %v, want %s", got["beads_dir"], beadsDirB)
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+}
+
+func TestContextBEADSDBOverridesBDDBForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	repoC := filepath.Join(root, "repo-c")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+	beadsDirC := writeServerRepo(t, repoC, "repo_c_db", "10.0.0.3", "origin-c", 3313)
+
+	out := runBDCommand(t, binPath, repoA, []string{"BEADS_DB=" + filepath.Join(beadsDirB, "dolt"), "BD_DB=" + filepath.Join(beadsDirC, "dolt")}, "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["beads_dir"] != beadsDirB {
+		t.Fatalf("beads_dir = %v, want %s", got["beads_dir"], beadsDirB)
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+}
+
+func TestContextPreservesSourceDatabaseAcrossRedirectForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+	sharedBeadsDir := filepath.Join(repoB, "shared-beads")
+	if err := os.RemoveAll(beadsDirB); err != nil {
+		t.Fatalf("remove source beads dir: %v", err)
+	}
+	if err := os.MkdirAll(beadsDirB, 0o755); err != nil {
+		t.Fatalf("mkdir source beads dir: %v", err)
+	}
+	writeFile(t, filepath.Join(beadsDirB, "redirect"), []byte("../shared-beads\n"))
+	if err := (&configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "10.0.0.2",
+		DoltDatabase:   "repo_b_db",
+	}).Save(beadsDirB); err != nil {
+		t.Fatalf("save source metadata: %v", err)
+	}
+	writeFile(t, filepath.Join(beadsDirB, "dolt-server.port"), []byte("3312"))
+	if err := os.MkdirAll(filepath.Join(sharedBeadsDir, "dolt"), 0o755); err != nil {
+		t.Fatalf("mkdir shared dolt dir: %v", err)
+	}
+	if err := (&configfile.Config{
+		Backend:        configfile.BackendDolt,
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "10.0.0.9",
+		DoltDatabase:   "shared_db",
+	}).Save(sharedBeadsDir); err != nil {
+		t.Fatalf("save shared metadata: %v", err)
+	}
+	writeFile(t, filepath.Join(sharedBeadsDir, "dolt-server.port"), []byte("3399"))
+	writeFile(t, filepath.Join(sharedBeadsDir, "config.yaml"), []byte("sync:\n  git-remote: shared-origin\n"))
+	writeFile(t, filepath.Join(sharedBeadsDir, ".env"), []byte("BEADS_DOLT_SERVER_HOST=10.0.0.9\n"))
+
+	out := runBDCommand(t, binPath, repoA, nil, "--db", filepath.Join(beadsDirB, "dolt"), "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+}
+
+func TestDoltShowUsesSelectedRepoConfigForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	beadsDirA := writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+	if err := os.Remove(filepath.Join(beadsDirA, "dolt-server.port")); err != nil {
+		t.Fatalf("remove port file A: %v", err)
+	}
+	if err := os.Remove(filepath.Join(beadsDirB, "dolt-server.port")); err != nil {
+		t.Fatalf("remove port file B: %v", err)
+	}
+	writeProjectConfig(t, beadsDirA, "origin-a", 4401, true)
+	writeProjectConfig(t, beadsDirB, "origin-b", 4402, false)
+
+	out := runBDCommand(t, binPath, repoA, nil, "--db", filepath.Join(beadsDirB, "dolt"), "dolt", "show", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["host"] != "10.0.0.2" {
+		t.Fatalf("host = %v, want 10.0.0.2", got["host"])
+	}
+	if got["port"] != float64(4402) {
+		t.Fatalf("port = %v, want 4402", got["port"])
+	}
+	if got["shared_server"] != false {
+		t.Fatalf("shared_server = %v, want false", got["shared_server"])
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+}
+
+func TestContextPreservesShellEnvPrecedenceForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+
+	out := runBDCommand(t, binPath, repoA, []string{"BEADS_DOLT_SERVER_HOST=9.9.9.9"}, "--db", filepath.Join(beadsDirB, "dolt"), "context", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["server_host"] != "9.9.9.9" {
+		t.Fatalf("server_host = %v, want 9.9.9.9", got["server_host"])
+	}
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+}
+
+func TestDoltShowUsesBEADSDBForNoDBCommand(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	root := t.TempDir()
+	repoA := filepath.Join(root, "repo-a")
+	repoB := filepath.Join(root, "repo-b")
+	writeServerRepo(t, repoA, "repo_a_db", "10.0.0.1", "origin-a", 3311)
+	beadsDirB := writeServerRepo(t, repoB, "repo_b_db", "10.0.0.2", "origin-b", 3312)
+
+	out := runBDCommand(t, binPath, repoA, []string{"BEADS_DB=" + filepath.Join(beadsDirB, "dolt")}, "dolt", "show", "--json")
+
+	var got map[string]any
+	decodeJSONOutput(t, out, &got)
+	if got["database"] != "repo_b_db" {
+		t.Fatalf("database = %v, want repo_b_db", got["database"])
+	}
+	if got["host"] != "10.0.0.2" {
+		t.Fatalf("host = %v, want 10.0.0.2", got["host"])
+	}
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -171,18 +171,75 @@ func loadServerModeFromConfig() {
 	}
 }
 
+func preserveRedirectSourceDatabase(beadsDir string) {
+	if beadsDir == "" || os.Getenv("BEADS_DOLT_SERVER_DATABASE") != "" {
+		return
+	}
+
+	rInfo := beads.ResolveRedirect(beadsDir)
+	if rInfo.WasRedirected && rInfo.SourceDatabase != "" {
+		_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", rInfo.SourceDatabase)
+		if os.Getenv("BD_DEBUG_ROUTING") != "" {
+			fmt.Fprintf(os.Stderr, "[routing] Preserved source dolt_database %q across redirect\n", rInfo.SourceDatabase)
+		}
+	}
+}
+
+func selectedNoDBBeadsDir() string {
+	selectedDBPath := ""
+	if rootCmd.PersistentFlags().Changed("db") && dbPath != "" {
+		selectedDBPath = dbPath
+	} else if envDB := os.Getenv("BEADS_DB"); envDB != "" {
+		selectedDBPath = envDB
+	} else if envDB := os.Getenv("BD_DB"); envDB != "" {
+		selectedDBPath = envDB
+	} else {
+		selectedDBPath = dbPath
+	}
+	if selectedDBPath != "" {
+		if selectedBeadsDir := resolveCommandBeadsDir(selectedDBPath); selectedBeadsDir != "" {
+			return selectedBeadsDir
+		}
+	}
+	return beads.FindBeadsDir()
+}
+
+func isSelectedNoDBCommand(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	if cmd.Name() == "context" {
+		return true
+	}
+	if cmd.Parent() == nil || cmd.Parent().Name() != "dolt" {
+		return false
+	}
+	switch cmd.Name() {
+	case "push", "pull", "commit":
+		return false
+	default:
+		return true
+	}
+}
+
+func prepareSelectedNoDBContext(beadsDir string) {
+	if beadsDir == "" {
+		return
+	}
+	_ = os.Setenv("BEADS_DIR", beadsDir)
+	loadBeadsEnvFile(beadsDir)
+	preserveRedirectSourceDatabase(beadsDir)
+	if err := config.Initialize(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to reinitialize config for selected beads dir: %v\n", err)
+	}
+}
+
 // resolveCommandBeadsDir maps a discovered Dolt data path back to the owning
 // .beads directory. filepath.Dir(dbPath) only works when the Dolt data lives
 // under .beads/dolt; custom dolt_data_dir values can place it elsewhere.
 func resolveCommandBeadsDir(dbPath string) string {
 	if dbPath == "" {
 		return ""
-	}
-
-	// BEADS_DB is an explicit database override, so preserve its legacy
-	// filepath.Dir behavior instead of trying to rediscover a repo-local .beads.
-	if os.Getenv("BEADS_DB") != "" {
-		return filepath.Dir(dbPath)
 	}
 
 	// Use the same validated candidate logic as the helper/reopen path
@@ -192,6 +249,13 @@ func resolveCommandBeadsDir(dbPath string) string {
 	// an explicit --db flag.
 	if beadsDir := resolveBeadsDirForDBPath(dbPath); beadsDir != "" {
 		return beadsDir
+	}
+
+	for dir := filepath.Dir(dbPath); dir != "" && dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+		candidate := filepath.Join(dir, ".beads")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
 	}
 
 	// No candidate matched — fall back to parent directory of the db path.
@@ -421,7 +485,9 @@ var rootCmd = &cobra.Command{
 
 		// GH#2677: Load .beads/.env before the noDbCommands early return so that
 		// commands like "bd doctor --server" pick up per-project Dolt credentials.
-		loadEnvironment()
+		if !isSelectedNoDBCommand(cmd) {
+			loadEnvironment()
+		}
 
 		// Load storage mode (embedded vs server) early so that isEmbeddedMode()
 		// returns the correct value for all commands, including those that skip
@@ -520,21 +586,7 @@ var rootCmd = &cobra.Command{
 		// When .beads/redirect points to a shared directory with a different
 		// dolt_database, the source's database name would be lost. Capture it
 		// early and set BEADS_DOLT_SERVER_DATABASE so all store opens use it.
-		redirectInfo := beads.GetRedirectInfo()
-		var sourceDoltDatabase string
-		if redirectInfo.IsRedirected && redirectInfo.LocalDir != "" {
-			rInfo := beads.ResolveRedirect(redirectInfo.LocalDir)
-			sourceDoltDatabase = rInfo.SourceDatabase
-		}
-		// Set env var early so ALL store opens (main + routed) use the correct
-		// database. Redirects may resolve to a shared .beads dir that serves
-		// multiple databases; the env var ensures the right one is selected.
-		if sourceDoltDatabase != "" && os.Getenv("BEADS_DOLT_SERVER_DATABASE") == "" {
-			_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", sourceDoltDatabase)
-			if os.Getenv("BD_DEBUG_ROUTING") != "" {
-				fmt.Fprintf(os.Stderr, "[routing] Preserved source dolt_database %q across redirect\n", sourceDoltDatabase)
-			}
-		}
+		preserveRedirectSourceDatabase(beads.GetRedirectInfo().LocalDir)
 
 		// Initialize database path
 		if dbPath == "" {

--- a/cmd/bd/store_reopen.go
+++ b/cmd/bd/store_reopen.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/steveyegge/beads/internal/beads"
@@ -33,8 +34,18 @@ func openReadOnlyStoreForDBPath(ctx context.Context, dbPath string) (storage.Dol
 // non-default dolt_database names or custom dolt_data_dir locations.
 func resolveBeadsDirForDBPath(dbPath string) string {
 	actualDBPath := utils.CanonicalizePath(dbPath)
+	if parent := filepath.Dir(dbPath); filepath.Base(parent) == ".beads" {
+		if _, err := os.Stat(filepath.Join(parent, "metadata.json")); err == nil {
+			return parent
+		}
+	}
+	if parent := filepath.Dir(actualDBPath); filepath.Base(parent) == ".beads" {
+		if _, err := os.Stat(filepath.Join(parent, "metadata.json")); err == nil {
+			return parent
+		}
+	}
 	seen := map[string]struct{}{}
-	candidates := make([]string, 0, 4)
+	candidates := make([]string, 0, 16)
 
 	addCandidate := func(path string) {
 		if path == "" {
@@ -51,8 +62,26 @@ func resolveBeadsDirForDBPath(dbPath string) string {
 		candidates = append(candidates, path)
 	}
 
+	addAncestorCandidates := func(path string) {
+		for dir := path; dir != "" && dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+			addCandidate(filepath.Join(dir, ".beads"))
+			if filepath.Base(dir) == ".beads" {
+				addCandidate(dir)
+			}
+		}
+	}
+
+	if info, err := os.Stat(dbPath); err == nil && info.IsDir() {
+		addCandidate(dbPath)
+	}
+	if info, err := os.Stat(actualDBPath); err == nil && info.IsDir() {
+		addCandidate(actualDBPath)
+	}
+
 	addCandidate(filepath.Dir(dbPath))
 	addCandidate(filepath.Dir(actualDBPath))
+	addAncestorCandidates(filepath.Dir(dbPath))
+	addAncestorCandidates(filepath.Dir(actualDBPath))
 
 	if found := beads.FindBeadsDir(); found != "" {
 		addCandidate(found)
@@ -63,6 +92,9 @@ func resolveBeadsDirForDBPath(dbPath string) string {
 		cfg, err := configfile.Load(beadsDir)
 		if err != nil || cfg == nil {
 			continue
+		}
+		if utils.PathsEqual(beadsDir, dbPath) || utils.PathsEqual(beadsDir, actualDBPath) {
+			return beadsDir
 		}
 		if utils.PathsEqual(cfg.DatabasePath(beadsDir), dbPath) || utils.PathsEqual(cfg.DatabasePath(beadsDir), actualDBPath) {
 			return beadsDir


### PR DESCRIPTION
## Summary
- make `bd context` and no-store `bd dolt` commands honor explicit repo selection from `--db`, `BEADS_DB`, and `BD_DB`
- re-root no-db command config/env lookup to the selected repo, including redirect and custom `dolt_data_dir` cases
- add focused regressions covering explicit selection precedence, selected repo config/env, redirects, and external data-dir layouts

## Bug
Follow-on to `#2699` and the wrong-db fixes in `#2628` / `#2697`.

Before this change, no-db commands could still anchor to the current working directory repo even when the user explicitly selected another repo's Dolt path. That meant commands like `bd context --json` and `bd dolt show --json` could report the selected database name but still read host/port/config/env from the wrong repo.

This patch fixes the no-db path specifically:
- resolve the owning `.beads` dir from the explicit DB selection
- preserve redirect source database selection
- initialize config/env from the selected repo before no-db commands read context/config
- keep shell env precedence intact while avoiding CWD repo leakage

## Verification
- `go test ./cmd/bd -run 'Test(ContextUsesExplicitDBFlagForNoDBCommand|DoltShowUsesExplicitDBFlagForNoDBCommand|DoltShowUsesBEADSDBForNoDBCommand|ContextUsesBEADSDBForNoDBCommand|ContextUsesBEADSDBDirectoryForNoDBCommand|ContextUsesExplicitDBFlagForExternalDoltDataDir|ContextExplicitDBFlagOverridesBEADSDBForNoDBCommand|ContextBEADSDBOverridesBDDBForNoDBCommand|ContextPreservesSourceDatabaseAcrossRedirectForNoDBCommand|DoltShowUsesSelectedRepoConfigForNoDBCommand|ContextPreservesShellEnvPrecedenceForNoDBCommand|ResolveBeadsDirForDBPath_UsesRawBeadsDirForSymlinkedDBPath)$'`

## Notes
- This is a narrow follow-on for no-db command selection; it does not change store-init behavior for normal DB-opening commands.