### PR TITLE
Add unit tests for internal/storage/issueops pure functions

### DIFF
--- a/internal/storage/issueops/batching_test.go
+++ b/internal/storage/issueops/batching_test.go
@@ -1,0 +1,72 @@
+package issueops
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsTableNotExistError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+		{
+			name: "doesn't exist lowercase",
+			err:  errors.New("table 'foo' doesn't exist"),
+			want: true,
+		},
+		{
+			name: "doesn't exist mixed case",
+			err:  errors.New("Table 'foo' Doesn't Exist"),
+			want: true,
+		},
+		{
+			name: "does not exist lowercase",
+			err:  errors.New("table 'bar' does not exist"),
+			want: true,
+		},
+		{
+			name: "does not exist mixed case",
+			err:  errors.New("Table 'bar' Does Not Exist"),
+			want: true,
+		},
+		{
+			name: "error 1146",
+			err:  errors.New("Error 1146 (42S02): Table 'db.tbl' doesn't exist"),
+			want: true,
+		},
+		{
+			name: "error 1146 alone",
+			err:  errors.New("error 1146"),
+			want: true,
+		},
+		{
+			name: "different mysql error code",
+			err:  errors.New("Error 1045: Access denied"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isTableNotExistError(tt.err)
+			if got != tt.want {
+				t.Errorf("isTableNotExistError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/storage/issueops/filters_test.go
+++ b/internal/storage/issueops/filters_test.go
@@ -1,0 +1,328 @@
+package issueops
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestLooksLikeIssueID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{name: "standard issue ID", query: "bd-abc123", want: true},
+		{name: "dotted child ID", query: "bd-abc123.1", want: true},
+		{name: "wisp ID", query: "bd-wisp-xyz", want: true},
+		{name: "numeric suffix only", query: "proj-42", want: true},
+		{name: "plain word", query: "hello", want: false},
+		{name: "has spaces", query: "bd abc", want: false},
+		{name: "empty string", query: "", want: false},
+		{name: "just a dash", query: "-", want: false},
+		{name: "leading dash", query: "-abc", want: false},
+		{name: "trailing dash", query: "abc-", want: false},
+		{name: "special characters", query: "bd-abc@123", want: false},
+		{name: "uppercase letters", query: "BD-ABC123", want: true},
+		{name: "single char prefix", query: "a-1", want: true},
+		{name: "multiple dashes", query: "a-b-c", want: true},
+		{name: "unicode characters", query: "bd-café", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := LooksLikeIssueID(tt.query)
+			if got != tt.want {
+				t.Errorf("LooksLikeIssueID(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildIssueFilterClauses_EmptyFilter(t *testing.T) {
+	t.Parallel()
+
+	clauses, args, err := BuildIssueFilterClauses("", types.IssueFilter{}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 0 {
+		t.Errorf("expected no clauses for empty filter, got %d: %v", len(clauses), clauses)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args for empty filter, got %d: %v", len(args), args)
+	}
+}
+
+func TestBuildIssueFilterClauses_QueryAsIssueID(t *testing.T) {
+	t.Parallel()
+
+	clauses, args, err := BuildIssueFilterClauses("bd-abc123", types.IssueFilter{}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause, got %d", len(clauses))
+	}
+	// ID-like query produces 4 args: exact match, prefix, title LIKE, external_ref LIKE
+	if len(args) != 4 {
+		t.Errorf("expected 4 args for ID-like query, got %d: %v", len(args), args)
+	}
+}
+
+func TestBuildIssueFilterClauses_QueryAsText(t *testing.T) {
+	t.Parallel()
+
+	clauses, args, err := BuildIssueFilterClauses("fix the bug", types.IssueFilter{}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause, got %d", len(clauses))
+	}
+	// Text query produces 2 args: title LIKE, id LIKE
+	if len(args) != 2 {
+		t.Errorf("expected 2 args for text query, got %d: %v", len(args), args)
+	}
+}
+
+func TestBuildIssueFilterClauses_StatusFilter(t *testing.T) {
+	t.Parallel()
+
+	status := types.StatusOpen
+	clauses, args, err := BuildIssueFilterClauses("", types.IssueFilter{Status: &status}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause, got %d", len(clauses))
+	}
+	if clauses[0] != "status = ?" {
+		t.Errorf("unexpected clause: %s", clauses[0])
+	}
+	if len(args) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(args))
+	}
+}
+
+func TestBuildIssueFilterClauses_ExcludeStatus(t *testing.T) {
+	t.Parallel()
+
+	filter := types.IssueFilter{
+		ExcludeStatus: []types.Status{types.StatusClosed, types.StatusOpen},
+	}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause, got %d", len(clauses))
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args for 2 excluded statuses, got %d", len(args))
+	}
+}
+
+func TestBuildIssueFilterClauses_PriorityRange(t *testing.T) {
+	t.Parallel()
+
+	min, max := 1, 3
+	filter := types.IssueFilter{PriorityMin: &min, PriorityMax: &max}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 2 {
+		t.Fatalf("expected 2 clauses, got %d", len(clauses))
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(args))
+	}
+}
+
+func TestBuildIssueFilterClauses_Labels(t *testing.T) {
+	t.Parallel()
+
+	filter := types.IssueFilter{Labels: []string{"bug", "urgent"}}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Each AND label produces a separate IN subquery clause
+	if len(clauses) != 2 {
+		t.Fatalf("expected 2 clauses for 2 AND labels, got %d", len(clauses))
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(args))
+	}
+}
+
+func TestBuildIssueFilterClauses_LabelsAny(t *testing.T) {
+	t.Parallel()
+
+	filter := types.IssueFilter{LabelsAny: []string{"bug", "feature", "docs"}}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// OR labels produce a single IN clause
+	if len(clauses) != 1 {
+		t.Fatalf("expected 1 clause for OR labels, got %d", len(clauses))
+	}
+	if len(args) != 3 {
+		t.Errorf("expected 3 args for 3 OR labels, got %d", len(args))
+	}
+}
+
+func TestBuildIssueFilterClauses_DateFilters(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+	filter := types.IssueFilter{
+		CreatedAfter:  &yesterday,
+		CreatedBefore: &now,
+	}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 2 {
+		t.Fatalf("expected 2 clauses, got %d", len(clauses))
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 args, got %d", len(args))
+	}
+}
+
+func TestBuildIssueFilterClauses_BooleanFilters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		filter types.IssueFilter
+	}{
+		{name: "empty description", filter: types.IssueFilter{EmptyDescription: true}},
+		{name: "no assignee", filter: types.IssueFilter{NoAssignee: true}},
+		{name: "no labels", filter: types.IssueFilter{NoLabels: true}},
+		{name: "no parent", filter: types.IssueFilter{NoParent: true}},
+		{name: "deferred", filter: types.IssueFilter{Deferred: true}},
+		{name: "overdue", filter: types.IssueFilter{Overdue: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			clauses, _, err := BuildIssueFilterClauses("", tt.filter, IssuesFilterTables)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(clauses) == 0 {
+				t.Errorf("expected at least 1 clause for %s filter", tt.name)
+			}
+		})
+	}
+}
+
+func TestBuildIssueFilterClauses_PinnedFilter(t *testing.T) {
+	t.Parallel()
+
+	pinTrue := true
+	pinFalse := false
+
+	tests := []struct {
+		name     string
+		pinned   *bool
+		wantSQL  string
+	}{
+		{name: "pinned=true", pinned: &pinTrue, wantSQL: "pinned = 1"},
+		{name: "pinned=false", pinned: &pinFalse, wantSQL: "(pinned = 0 OR pinned IS NULL)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			clauses, _, err := BuildIssueFilterClauses("", types.IssueFilter{Pinned: tt.pinned}, IssuesFilterTables)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(clauses) != 1 || clauses[0] != tt.wantSQL {
+				t.Errorf("got clause %v, want %q", clauses, tt.wantSQL)
+			}
+		})
+	}
+}
+
+func TestBuildIssueFilterClauses_IDFilters(t *testing.T) {
+	t.Parallel()
+
+	filter := types.IssueFilter{
+		IDs:      []string{"bd-1", "bd-2", "bd-3"},
+		IDPrefix: "bd-",
+	}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clauses) != 2 {
+		t.Fatalf("expected 2 clauses (IDs + IDPrefix), got %d", len(clauses))
+	}
+	// 3 args for IDs IN clause + 1 for IDPrefix LIKE
+	if len(args) != 4 {
+		t.Errorf("expected 4 args, got %d", len(args))
+	}
+}
+
+func TestBuildIssueFilterClauses_WispsTables(t *testing.T) {
+	t.Parallel()
+
+	// Verify that wisps tables produce different SQL than issues tables
+	filter := types.IssueFilter{NoParent: true}
+
+	issuesClauses, _, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wispsClauses, _, err := BuildIssueFilterClauses("", filter, WispsFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(issuesClauses) != 1 || len(wispsClauses) != 1 {
+		t.Fatalf("expected 1 clause each, got issues=%d wisps=%d", len(issuesClauses), len(wispsClauses))
+	}
+	if issuesClauses[0] == wispsClauses[0] {
+		t.Error("expected different table names in issues vs wisps clauses")
+	}
+}
+
+func TestBuildIssueFilterClauses_CombinedFilters(t *testing.T) {
+	t.Parallel()
+
+	status := types.StatusOpen
+	priority := 2
+	now := time.Now()
+	filter := types.IssueFilter{
+		Status:       &status,
+		Priority:     &priority,
+		Labels:       []string{"bug"},
+		CreatedAfter: &now,
+		NoAssignee:   true,
+	}
+	clauses, args, err := BuildIssueFilterClauses("search term", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// query(1) + status(1) + priority(1) + labels(1) + created_after(1) + no_assignee(1) = 6
+	if len(clauses) != 6 {
+		t.Errorf("expected 6 clauses for combined filter, got %d: %v", len(clauses), clauses)
+	}
+	// query text(2) + status(1) + priority(1) + label(1) + created_after(1) = 6
+	if len(args) != 6 {
+		t.Errorf("expected 6 args, got %d", len(args))
+	}
+}

--- a/internal/storage/issueops/helpers_test.go
+++ b/internal/storage/issueops/helpers_test.go
@@ -1,0 +1,306 @@
+package issueops
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestNullString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		isNil  bool
+		expect string
+	}{
+		{name: "empty string returns nil", input: "", isNil: true},
+		{name: "non-empty string returns value", input: "hello", isNil: false, expect: "hello"},
+		{name: "whitespace is not empty", input: " ", isNil: false, expect: " "},
+		{name: "tab is not empty", input: "\t", isNil: false, expect: "\t"},
+		{name: "newline is not empty", input: "\n", isNil: false, expect: "\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := NullString(tc.input)
+			if tc.isNil {
+				if got != nil {
+					t.Errorf("NullString(%q) = %v, want nil", tc.input, got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("NullString(%q) = nil, want %q", tc.input, tc.expect)
+				}
+				if got.(string) != tc.expect {
+					t.Errorf("NullString(%q) = %q, want %q", tc.input, got, tc.expect)
+				}
+			}
+		})
+	}
+}
+
+func TestNullStringPtr(t *testing.T) {
+	t.Parallel()
+
+	strVal := "hello"
+	emptyStr := ""
+
+	tests := []struct {
+		name   string
+		input  *string
+		isNil  bool
+		expect string
+	}{
+		{name: "nil pointer returns nil", input: nil, isNil: true},
+		{name: "pointer to non-empty string returns value", input: &strVal, isNil: false, expect: "hello"},
+		{name: "pointer to empty string returns empty string", input: &emptyStr, isNil: false, expect: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := NullStringPtr(tc.input)
+			if tc.isNil {
+				if got != nil {
+					t.Errorf("NullStringPtr() = %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("NullStringPtr() = nil, want %q", tc.expect)
+				}
+				if got.(string) != tc.expect {
+					t.Errorf("NullStringPtr() = %q, want %q", got, tc.expect)
+				}
+			}
+		})
+	}
+}
+
+func TestNullInt(t *testing.T) {
+	t.Parallel()
+
+	zero := 0
+	positive := 42
+	negative := -1
+
+	tests := []struct {
+		name   string
+		input  *int
+		isNil  bool
+		expect int
+	}{
+		{name: "nil pointer returns nil", input: nil, isNil: true},
+		{name: "pointer to zero returns zero", input: &zero, isNil: false, expect: 0},
+		{name: "pointer to positive returns value", input: &positive, isNil: false, expect: 42},
+		{name: "pointer to negative returns value", input: &negative, isNil: false, expect: -1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := NullInt(tc.input)
+			if tc.isNil {
+				if got != nil {
+					t.Errorf("NullInt() = %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("NullInt() = nil, want %d", tc.expect)
+				}
+				if got.(int) != tc.expect {
+					t.Errorf("NullInt() = %d, want %d", got, tc.expect)
+				}
+			}
+		})
+	}
+}
+
+func TestNullIntVal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  int
+		isNil  bool
+		expect int
+	}{
+		{name: "zero returns nil", input: 0, isNil: true},
+		{name: "positive returns value", input: 42, isNil: false, expect: 42},
+		{name: "negative returns value", input: -1, isNil: false, expect: -1},
+		{name: "one returns value", input: 1, isNil: false, expect: 1},
+		{name: "large value returns value", input: 999999, isNil: false, expect: 999999},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := NullIntVal(tc.input)
+			if tc.isNil {
+				if got != nil {
+					t.Errorf("NullIntVal(%d) = %v, want nil", tc.input, got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("NullIntVal(%d) = nil, want %d", tc.input, tc.expect)
+				}
+				if got.(int) != tc.expect {
+					t.Errorf("NullIntVal(%d) = %d, want %d", tc.input, got, tc.expect)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []byte
+		expect string
+	}{
+		{name: "nil returns empty object", input: nil, expect: "{}"},
+		{name: "empty slice returns empty object", input: []byte{}, expect: "{}"},
+		{name: "valid json object returned as-is", input: []byte(`{"key":"value"}`), expect: `{"key":"value"}`},
+		{name: "valid empty json object", input: []byte(`{}`), expect: `{}`},
+		{name: "valid json array", input: []byte(`[1,2,3]`), expect: `[1,2,3]`},
+		{name: "invalid json returns empty object", input: []byte(`{bad json`), expect: "{}"},
+		{name: "plain string is invalid json", input: []byte(`hello`), expect: "{}"},
+		{name: "nested valid json", input: []byte(`{"a":{"b":1}}`), expect: `{"a":{"b":1}}`},
+		{name: "valid json number", input: []byte(`42`), expect: `42`},
+		{name: "valid json boolean", input: []byte(`true`), expect: `true`},
+		{name: "valid json null", input: []byte(`null`), expect: `null`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := JSONMetadata(tc.input)
+			if got != tc.expect {
+				t.Errorf("JSONMetadata(%q) = %q, want %q", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestFormatJSONStringArray(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []string
+		expect string
+	}{
+		{name: "nil returns empty string", input: nil, expect: ""},
+		{name: "empty slice returns empty string", input: []string{}, expect: ""},
+		{name: "single element", input: []string{"a"}, expect: `["a"]`},
+		{name: "multiple elements", input: []string{"a", "b", "c"}, expect: `["a","b","c"]`},
+		{name: "elements with special chars", input: []string{"hello world", "foo\"bar"}, expect: `["hello world","foo\"bar"]`},
+		{name: "elements with unicode", input: []string{"\u00e9"}, expect: `["é"]`},
+		{name: "empty strings in array", input: []string{""}, expect: `[""]`},
+		{name: "mixed empty and non-empty", input: []string{"", "a", ""}, expect: `["","a",""]`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatJSONStringArray(tc.input)
+			if got != tc.expect {
+				t.Errorf("FormatJSONStringArray(%v) = %q, want %q", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestIsWisp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		issue     *types.Issue
+		expectVal bool
+	}{
+		{
+			name:      "neither ephemeral nor no_history",
+			issue:     &types.Issue{Ephemeral: false, NoHistory: false},
+			expectVal: false,
+		},
+		{
+			name:      "ephemeral only",
+			issue:     &types.Issue{Ephemeral: true, NoHistory: false},
+			expectVal: true,
+		},
+		{
+			name:      "no_history only",
+			issue:     &types.Issue{Ephemeral: false, NoHistory: true},
+			expectVal: true,
+		},
+		{
+			name:      "both ephemeral and no_history",
+			issue:     &types.Issue{Ephemeral: true, NoHistory: true},
+			expectVal: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := IsWisp(tc.issue)
+			if got != tc.expectVal {
+				t.Errorf("IsWisp() = %v, want %v", got, tc.expectVal)
+			}
+		})
+	}
+}
+
+func TestTableRouting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		issue       *types.Issue
+		wantIssue   string
+		wantEvent   string
+	}{
+		{
+			name:      "regular issue routes to issues/events",
+			issue:     &types.Issue{Ephemeral: false, NoHistory: false},
+			wantIssue: "issues",
+			wantEvent: "events",
+		},
+		{
+			name:      "ephemeral routes to wisps/wisp_events",
+			issue:     &types.Issue{Ephemeral: true},
+			wantIssue: "wisps",
+			wantEvent: "wisp_events",
+		},
+		{
+			name:      "no_history routes to wisps/wisp_events",
+			issue:     &types.Issue{NoHistory: true},
+			wantIssue: "wisps",
+			wantEvent: "wisp_events",
+		},
+		{
+			name:      "both flags routes to wisps/wisp_events",
+			issue:     &types.Issue{Ephemeral: true, NoHistory: true},
+			wantIssue: "wisps",
+			wantEvent: "wisp_events",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotIssue, gotEvent := TableRouting(tc.issue)
+			if gotIssue != tc.wantIssue {
+				t.Errorf("TableRouting() issueTable = %q, want %q", gotIssue, tc.wantIssue)
+			}
+			if gotEvent != tc.wantEvent {
+				t.Errorf("TableRouting() eventTable = %q, want %q", gotEvent, tc.wantEvent)
+			}
+		})
+	}
+}

--- a/internal/storage/issueops/ready_work_test.go
+++ b/internal/storage/issueops/ready_work_test.go
@@ -1,0 +1,58 @@
+package issueops
+
+import (
+	"testing"
+)
+
+func TestBuildSQLInClause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		ids             []string
+		wantPlaceholders string
+		wantArgs        []interface{}
+	}{
+		{
+			name:            "single ID",
+			ids:             []string{"42"},
+			wantPlaceholders: "?",
+			wantArgs:        []interface{}{"42"},
+		},
+		{
+			name:            "multiple IDs",
+			ids:             []string{"1", "2", "3"},
+			wantPlaceholders: "?,?,?",
+			wantArgs:        []interface{}{"1", "2", "3"},
+		},
+		{
+			name:            "empty slice",
+			ids:             []string{},
+			wantPlaceholders: "",
+			wantArgs:        []interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotPlaceholders, gotArgs := buildSQLInClause(tt.ids)
+
+			if gotPlaceholders != tt.wantPlaceholders {
+				t.Errorf("placeholders = %q, want %q", gotPlaceholders, tt.wantPlaceholders)
+			}
+
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Fatalf("args length = %d, want %d", len(gotArgs), len(tt.wantArgs))
+			}
+
+			for i := range gotArgs {
+				if gotArgs[i] != tt.wantArgs[i] {
+					t.Errorf("args[%d] = %v, want %v", i, gotArgs[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The issueops package has 34 source files with 6,500+ lines of core business logic but zero direct tests. This adds tests for all pure functions that don't require a database connection:

- filters_test.go: BuildIssueFilterClauses, LooksLikeIssueID
- helpers_test.go: NullString, NullStringPtr, NullInt, NullIntVal, JSONMetadata, FormatJSONStringArray, IsWisp, TableRouting
- batching_test.go: isTableNotExistError
- ready_work_test.go: buildSQLInClause

https://claude.ai/code/session_01ESW3XvdoVy3rWMnHB6FT1o