### PR TITLE
Add prefix routing to bd edit and bd reopen

### DIFF
--- a/cmd/bd/edit.go
+++ b/cmd/bd/edit.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/ui"
-	"github.com/steveyegge/beads/internal/utils"
 )
 
 var editCmd = &cobra.Command{
@@ -33,12 +31,14 @@ Examples:
 		id := args[0]
 		ctx := rootCtx
 
-		// Resolve partial ID
-		fullID, err := utils.ResolvePartialID(ctx, store, id)
+		// Resolve ID with prefix routing (supports cross-rig edits like `bd edit xe-5ls`)
+		result, err := resolveAndGetIssueWithRouting(ctx, store, id)
 		if err != nil {
 			FatalErrorRespectJSON("resolving %s: %v", id, err)
 		}
-		id = fullID
+		defer result.Close()
+		id = result.ResolvedID
+		issueStore := result.Store
 
 		// Determine which field to edit
 		fieldToEdit := "description"
@@ -70,14 +70,7 @@ Examples:
 			FatalErrorRespectJSON("no editor found. Set $EDITOR or $VISUAL environment variable")
 		}
 
-		// Get the current issue
-		issue, err := store.GetIssue(ctx, id)
-		if err != nil {
-			if errors.Is(err, storage.ErrNotFound) {
-				FatalErrorRespectJSON("issue %s not found", id)
-			}
-			FatalErrorRespectJSON("fetching issue %s: %v", id, err)
-		}
+		issue := result.Issue
 
 		// Get the current field value
 		var currentValue string
@@ -149,22 +142,23 @@ Examples:
 
 		// Update the issue — retry once if the DB connection went stale
 		// during a long editor session (GH-2267).
+		// Use the routed store for cross-rig mutations.
 		updates := map[string]interface{}{
 			fieldToEdit: newValue,
 		}
 
-		err = store.UpdateIssue(ctx, id, updates, actor)
+		err = issueStore.UpdateIssue(ctx, id, updates, actor)
 		if err != nil {
 			// Connection may have gone stale while the editor was open.
 			// Ping to force the pool to discard dead connections, then retry.
-			if accessor, ok := store.(storage.RawDBAccessor); ok {
+			if accessor, ok := issueStore.(storage.RawDBAccessor); ok {
 				if pingErr := accessor.DB().PingContext(ctx); pingErr != nil {
 					// Ping failed — try to force a fresh connection via sql.DB pool reset.
 					accessor.DB().SetConnMaxIdleTime(0)
 					_ = accessor.DB().PingContext(ctx)
 				}
 			}
-			err = store.UpdateIssue(ctx, id, updates, actor)
+			err = issueStore.UpdateIssue(ctx, id, updates, actor)
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Your edits are preserved in: %s\n", tmpPath)
@@ -172,9 +166,9 @@ Examples:
 		}
 		editSaved = true
 
-		// Embedded mode: flush Dolt commit.
-		if isEmbeddedDolt {
-			if _, err := store.CommitPending(ctx, actor); err != nil {
+		// Embedded mode: flush Dolt commit (only for non-routed stores).
+		if isEmbeddedDolt && !result.Routed {
+			if _, err := issueStore.CommitPending(ctx, actor); err != nil {
 				FatalErrorRespectJSON("failed to commit: %v", err)
 			}
 		}

--- a/cmd/bd/reopen.go
+++ b/cmd/bd/reopen.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
-	"github.com/steveyegge/beads/internal/utils"
 )
 
 var reopenCmd = &cobra.Command{
@@ -20,57 +19,51 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("reopen")
 		reason, _ := cmd.Flags().GetString("reason")
-		// Use global jsonOutput set by PersistentPreRun
 		ctx := rootCtx
-		// Resolve partial IDs
-		_, err := utils.ResolvePartialIDs(ctx, store, args)
-		if err != nil {
-			FatalError("%v", err)
-		}
+
 		reopenedIssues := []*types.Issue{}
-		// Direct storage access
 		if store == nil {
 			FatalErrorWithHint("database not initialized",
 				"run 'bd doctor' to diagnose, or 'bd init' to create a new database")
 		}
 		for _, id := range args {
-			fullID, err := utils.ResolvePartialID(ctx, store, id)
+			// Resolve with prefix routing (supports cross-rig reopens like `bd reopen xe-5ls`)
+			result, err := resolveAndGetIssueWithRouting(ctx, store, id)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
 				continue
 			}
+			fullID := result.ResolvedID
+			issueStore := result.Store
+			issue := result.Issue
+
 			// Skip if already open — avoid false "Reopened" message
-			issue, err := store.GetIssue(ctx, fullID)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error getting %s: %v\n", fullID, err)
-				continue
-			}
 			if issue.Status == types.StatusOpen {
 				fmt.Fprintf(os.Stderr, "%s is already open\n", fullID)
+				result.Close()
 				continue
 			}
 			// UpdateIssue automatically clears closed_at when status changes from closed.
 			// Also clear defer_until so the issue appears in bd ready immediately.
-			// Without this, a deferred issue that was closed and reopened stays
-			// hidden from bd ready despite being "open".
 			updates := map[string]interface{}{
 				"status":      string(types.StatusOpen),
 				"defer_until": nil,
 			}
-			if err := store.UpdateIssue(ctx, fullID, updates, actor); err != nil {
+			if err := issueStore.UpdateIssue(ctx, fullID, updates, actor); err != nil {
 				fmt.Fprintf(os.Stderr, "Error reopening %s: %v\n", fullID, err)
+				result.Close()
 				continue
 			}
 			// Add reason as a comment if provided
 			if reason != "" {
-				if err := store.AddComment(ctx, fullID, actor, reason); err != nil {
+				if err := issueStore.AddComment(ctx, fullID, actor, reason); err != nil {
 					fmt.Fprintf(os.Stderr, "Warning: failed to add comment to %s: %v\n", fullID, err)
 				}
 			}
 			if jsonOutput {
-				issue, _ := store.GetIssue(ctx, fullID)
-				if issue != nil {
-					reopenedIssues = append(reopenedIssues, issue)
+				updated, _ := issueStore.GetIssue(ctx, fullID)
+				if updated != nil {
+					reopenedIssues = append(reopenedIssues, updated)
 				}
 			} else {
 				reasonMsg := ""
@@ -79,6 +72,7 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 				}
 				fmt.Printf("%s Reopened %s%s\n", ui.RenderAccent("↻"), fullID, reasonMsg)
 			}
+			result.Close()
 		}
 
 		// Embedded mode: flush Dolt commit.


### PR DESCRIPTION
## Summary

- `bd show` uses `resolveAndGetIssueWithRouting()` which resolves bead IDs via prefix routing (e.g., `xe-5ls` routes to xeval/.beads)
- `bd edit` and `bd reopen` used `utils.ResolvePartialID()` which only searches the local store, causing 'no issue found' errors for cross-rig beads
- Replace `ResolvePartialID()` with `resolveAndGetIssueWithRouting()` in both commands, using `result.Store` for mutations so edits and reopens go to the correct database
- Skip embedded Dolt commits for routed (remote) stores since the remote server handles its own commits

## Test plan

- [ ] `bd edit xe-5ls` resolves and opens editor for cross-rig bead
- [ ] `bd reopen xe-5ls` reopens cross-rig bead
- [ ] `bd edit local-id` still works for local beads
- [ ] `bd reopen local-id` still works for local beads
- [ ] Embedded Dolt commit only fires for non-routed stores