### PR TITLE
fix: harden shared-server write bursts

### DIFF
--- a/internal/storage/dolt/concurrent_test.go
+++ b/internal/storage/dolt/concurrent_test.go
@@ -116,6 +116,165 @@ func TestConcurrentIssueCreation(t *testing.T) {
 	}
 }
 
+func TestConcurrentIssueCreationWithoutCallerRetry(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	errors := make(chan error, numGoroutines)
+	createdIDs := make(chan string, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			issue := &types.Issue{
+				Title:       fmt.Sprintf("No Retry Issue %d", n),
+				Description: fmt.Sprintf("Created by goroutine %d", n),
+				Status:      types.StatusOpen,
+				Priority:    2,
+				IssueType:   types.TypeTask,
+			}
+			if err := store.CreateIssue(ctx, issue, fmt.Sprintf("worker-%d", n)); err != nil {
+				errors <- fmt.Errorf("goroutine %d: %w", n, err)
+				return
+			}
+			createdIDs <- issue.ID
+		}(i)
+	}
+
+	wg.Wait()
+	close(errors)
+	close(createdIDs)
+
+	for err := range errors {
+		t.Errorf("creation error: %v", err)
+	}
+	if t.Failed() {
+		t.Fatal("concurrent create failed without caller retry")
+	}
+
+	ids := make(map[string]bool)
+	for id := range createdIDs {
+		if ids[id] {
+			t.Errorf("duplicate issue ID: %s", id)
+		}
+		ids[id] = true
+	}
+	if len(ids) != numGoroutines {
+		t.Fatalf("expected %d unique IDs, got %d", numGoroutines, len(ids))
+	}
+}
+
+func TestConcurrentCommentAndCloseWithoutCallerRetry(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	const numIssues = 8
+	issueIDs := make([]string, 0, numIssues)
+	for i := 0; i < numIssues; i++ {
+		issue := &types.Issue{
+			ID:          fmt.Sprintf("cc-%d", i),
+			Title:       fmt.Sprintf("Comment Close %d", i),
+			Description: "permanent issue for concurrent comment/close",
+			Status:      types.StatusOpen,
+			Priority:    2,
+			IssueType:   types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue(%d): %v", i, err)
+		}
+		issueIDs = append(issueIDs, issue.ID)
+	}
+
+	var wg sync.WaitGroup
+	errors := make(chan error, numIssues)
+	for i, issueID := range issueIDs {
+		wg.Add(1)
+		go func(n int, id string) {
+			defer wg.Done()
+			if _, err := store.AddIssueComment(ctx, id, fmt.Sprintf("author-%d", n), fmt.Sprintf("comment-%d", n)); err != nil {
+				errors <- fmt.Errorf("comment %s: %w", id, err)
+				return
+			}
+			if err := store.CloseIssue(ctx, id, "done", fmt.Sprintf("closer-%d", n), "test-session"); err != nil {
+				errors <- fmt.Errorf("close %s: %w", id, err)
+			}
+		}(i, issueID)
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("write error: %v", err)
+	}
+	if t.Failed() {
+		t.Fatal("concurrent comment/close failed without caller retry")
+	}
+
+	for _, issueID := range issueIDs {
+		issue, err := store.GetIssue(ctx, issueID)
+		if err != nil {
+			t.Fatalf("GetIssue(%s): %v", issueID, err)
+		}
+		if issue.Status != types.StatusClosed {
+			t.Fatalf("issue %s status = %s, want closed", issueID, issue.Status)
+		}
+		comments, err := store.GetIssueComments(ctx, issueID)
+		if err != nil {
+			t.Fatalf("GetIssueComments(%s): %v", issueID, err)
+		}
+		if len(comments) != 1 {
+			t.Fatalf("issue %s comment count = %d, want 1", issueID, len(comments))
+		}
+	}
+}
+
+func TestServerWriteLockReleasedAfterWrite(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "lock-release",
+		Title:       "Lock release",
+		Description: "verify write lock is not leaked",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("db.Conn: %v", err)
+	}
+	defer conn.Close()
+
+	var locked int
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", store.serverWriteLockName()).Scan(&locked); err != nil {
+		t.Fatalf("GET_LOCK: %v", err)
+	}
+	if locked != 1 {
+		t.Fatalf("expected GET_LOCK to succeed after write, got %d", locked)
+	}
+	if _, err := conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", store.serverWriteLockName()); err != nil {
+		t.Fatalf("RELEASE_LOCK: %v", err)
+	}
+}
+
 // =============================================================================
 // Test 2: Same-Issue Update Race
 // 10 goroutines update the same issue simultaneously.

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -35,23 +35,25 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		}
 	}
 
-	if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
-		opts := issueops.AddDependencyOpts{
-			SourceTable:   "issues",
-			TargetTable:   targetTable,
-			WriteTable:    "dependencies",
-			IsCrossPrefix: isCrossPrefix,
-		}
-		if err := issueops.AddDependencyInTx(ctx, tx, dep, actor, opts); err != nil {
+	return s.withSerializedWrite(ctx, func() error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			opts := issueops.AddDependencyOpts{
+				SourceTable:   "issues",
+				TargetTable:   targetTable,
+				WriteTable:    "dependencies",
+				IsCrossPrefix: isCrossPrefix,
+			}
+			if err := issueops.AddDependencyInTx(ctx, tx, dep, actor, opts); err != nil {
+				return err
+			}
+			s.invalidateBlockedIDsCache()
+			return nil
+		}); err != nil {
 			return err
 		}
-		s.invalidateBlockedIDsCache()
-		return nil
-	}); err != nil {
-		return err
-	}
-	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
-	return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
+		// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
+		return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
+	})
 }
 
 // RemoveDependency removes a dependency between two issues.
@@ -71,25 +73,27 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 		return wrapTransactionError("commit remove wisp dependency", tx.Commit())
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
-		return err
-	}
+		if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
+			return err
+		}
 
-	s.invalidateBlockedIDsCache()
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("sql commit: %w", err)
-	}
-	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
-	if err := s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: remove "+issueID+" -> "+dependsOnID); err != nil {
-		return err
-	}
-	return nil
+		s.invalidateBlockedIDsCache()
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("sql commit: %w", err)
+		}
+		// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
+		if err := s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: remove "+issueID+" -> "+dependsOnID); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 // GetDependencies retrieves issues that this issue depends on

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -12,16 +12,21 @@ import (
 
 // AddComment adds a comment event to an issue
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
-		return err
-	}
-	return tx.Commit()
+		if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit add comment event", err)
+		}
+		return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: event %s", issueID))
+	})
 }
 
 // GetEvents retrieves events for an issue
@@ -56,10 +61,18 @@ func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text s
 // This prevents comment timestamp drift across import/export cycles.
 func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
 	var result *types.Comment
-	err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
-		var err error
-		result, err = issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
-		return err
+	err := s.withSerializedWrite(ctx, func() error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			result, err = issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
+			return err
+		}); err != nil {
+			return err
+		}
+		if s.isActiveWisp(ctx, issueID) {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID))
 	})
 	return result, err
 }

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -27,28 +27,30 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 		issue.Ephemeral = true // infra types get marked ephemeral (legacy behavior)
 	}
 
-	if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
-		// SkipPrefixValidation matches legacy behavior: single-issue path does
-		// not validate prefixes for explicit IDs.
-		bc, err := issueops.NewBatchContext(ctx, tx, storage.BatchCreateOptions{
-			SkipPrefixValidation: true,
-		})
-		if err != nil {
+	return s.withSerializedWrite(ctx, func() error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			// SkipPrefixValidation matches legacy behavior: single-issue path does
+			// not validate prefixes for explicit IDs.
+			bc, err := issueops.NewBatchContext(ctx, tx, storage.BatchCreateOptions{
+				SkipPrefixValidation: true,
+			})
+			if err != nil {
+				return err
+			}
+			return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
+		}); err != nil {
 			return err
 		}
-		return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
-	}); err != nil {
-		return err
-	}
 
-	// Dolt versioning — wisps and no-history issues skip DOLT_COMMIT.
-	if !issue.Ephemeral && !issue.NoHistory {
-		if err := s.doltAddAndCommit(ctx, []string{"issues", "events"},
-			fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
-			return err
+		// Dolt versioning — wisps and no-history issues skip DOLT_COMMIT.
+		if !issue.Ephemeral && !issue.NoHistory {
+			if err := s.doltAddAndCommit(ctx, []string{"issues", "events"},
+				fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
+				return err
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // CreateIssues creates multiple issues in a single transaction
@@ -66,36 +68,38 @@ func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*t
 		return nil
 	}
 
-	// All-wisps fast path: individual transactions, no Dolt versioning.
-	// Covers both ephemeral issues and no-history issues (both skip DOLT_COMMIT).
-	if issueops.AllWisps(issues) {
-		for _, issue := range issues {
-			if !issue.NoHistory {
-				issue.Ephemeral = true
-			}
-			if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
-				bc, err := issueops.NewBatchContext(ctx, tx, opts)
-				if err != nil {
+	return s.withSerializedWrite(ctx, func() error {
+		// All-wisps fast path: individual transactions, no Dolt versioning.
+		// Covers both ephemeral issues and no-history issues (both skip DOLT_COMMIT).
+		if issueops.AllWisps(issues) {
+			for _, issue := range issues {
+				if !issue.NoHistory {
+					issue.Ephemeral = true
+				}
+				if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+					bc, err := issueops.NewBatchContext(ctx, tx, opts)
+					if err != nil {
+						return err
+					}
+					return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
+				}); err != nil {
 					return err
 				}
-				return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
-			}); err != nil {
-				return err
 			}
+			return nil
 		}
-		return nil
-	}
 
-	if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
-		return issueops.CreateIssuesInTx(ctx, tx, issues, actor, opts)
-	}); err != nil {
-		return err
-	}
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			return issueops.CreateIssuesInTx(ctx, tx, issues, actor, opts)
+		}); err != nil {
+			return err
+		}
 
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	return s.doltAddAndCommit(ctx,
-		[]string{"issues", "events", "labels", "comments", "dependencies", "child_counters"},
-		fmt.Sprintf("bd: create %d issue(s)", len(issues)))
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		return s.doltAddAndCommit(ctx,
+			[]string{"issues", "events", "labels", "comments", "dependencies", "child_counters"},
+			fmt.Sprintf("bd: create %d issue(s)", len(issues)))
+	})
 }
 
 // GetIssue retrieves an issue by ID.
@@ -155,37 +159,39 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 		return s.DemoteToWisp(ctx, id, updates, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	result, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
-	if err != nil {
-		return err
-	}
+		result, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
+		if err != nil {
+			return err
+		}
 
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: update %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: update %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit update issue", err)
-	}
-	// Status changes affect the active set used by blocked ID computation
-	if _, hasStatus := updates["status"]; hasStatus {
-		s.invalidateBlockedIDsCache()
-	}
-	_ = result // OldIssue available if needed for future cache invalidation
-	return nil
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit update issue", err)
+		}
+		// Status changes affect the active set used by blocked ID computation
+		if _, hasStatus := updates["status"]; hasStatus {
+			s.invalidateBlockedIDsCache()
+		}
+		_ = result // OldIssue available if needed for future cache invalidation
+		return nil
+	})
 }
 
 // ClaimIssue atomically claims an issue using compare-and-swap semantics.
@@ -200,33 +206,35 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 		return s.claimWisp(ctx, id, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
-		return err
-	}
+		if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
+			return err
+		}
 
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: claim %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: claim %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit claim issue", err)
-	}
-	// Claiming changes status to in_progress, affecting blocked ID computation
-	s.invalidateBlockedIDsCache()
-	return nil
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit claim issue", err)
+		}
+		// Claiming changes status to in_progress, affecting blocked ID computation
+		s.invalidateBlockedIDsCache()
+		return nil
+	})
 }
 
 // CloseIssue closes an issue with a reason.
@@ -239,33 +247,35 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 		return s.closeWisp(ctx, id, reason, actor, session)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
-		return err
-	}
+		if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
+			return err
+		}
 
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: close %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		// Dolt versioning for permanent issues.
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: close %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit close issue", err)
-	}
-	// Closing changes the active set, which affects blocked ID computation (GH#1495)
-	s.invalidateBlockedIDsCache()
-	return nil
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit close issue", err)
+		}
+		// Closing changes the active set, which affects blocked ID computation (GH#1495)
+		s.invalidateBlockedIDsCache()
+		return nil
+	})
 }
 
 // DeleteIssue permanently removes an issue
@@ -275,31 +285,33 @@ func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 		return s.deleteWisp(ctx, id)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }() // No-op after successful commit
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }() // No-op after successful commit
 
-	if err := issueops.DeleteIssueInTx(ctx, tx, id); err != nil {
-		return err
-	}
+		if err := issueops.DeleteIssueInTx(ctx, tx, id); err != nil {
+			return err
+		}
 
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: delete %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		// GH#2455: Stage only the tables we modified, then commit without -A.
+		for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: delete %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	s.invalidateBlockedIDsCache()
-	return nil
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		s.invalidateBlockedIDsCache()
+		return nil
+	})
 }
 
 // DeleteIssues deletes multiple issues in a single transaction.

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -10,16 +10,20 @@ import (
 
 // AddLabel adds a label to an issue
 func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withWriteTx(ctx, func(tx *sql.Tx) error {
-		return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+	return s.withSerializedWrite(ctx, func() error {
+		return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		})
 	})
 }
 
 // RemoveLabel removes a label from an issue.
 // Delegates SQL work to issueops.RemoveLabelInTx which handles wisp routing.
 func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withWriteTx(ctx, func(tx *sql.Tx) error {
-		return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+	return s.withSerializedWrite(ctx, func() error {
+		return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		})
 	})
 }
 

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
 )
 
 func TestIsRetryableError(t *testing.T) {
@@ -178,6 +180,86 @@ func TestWithRetry_NonRetryableError(t *testing.T) {
 
 	if err == nil {
 		t.Error("expected error, got nil")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call for non-retryable error, got %d", callCount)
+	}
+}
+
+func TestIsRetryableWriteError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "database is locked",
+			err:      errors.New("database is locked"),
+			expected: true,
+		},
+		{
+			name:     "serialization error",
+			err:      &mysql.MySQLError{Number: 1213, Message: "deadlock found when trying to get lock"},
+			expected: true,
+		},
+		{
+			name:     "database is read only",
+			err:      errors.New("cannot update manifest: database is read only"),
+			expected: true,
+		},
+		{
+			name:     "write lock timeout",
+			err:      errors.New("failed to acquire write lock: timeout after 2s"),
+			expected: true,
+		},
+		{
+			name:     "syntax error",
+			err:      errors.New("syntax error in SQL"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryableWriteError(tt.err)
+			if got != tt.expected {
+				t.Errorf("isRetryableWriteError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWithWriteRetry_RetryableError(t *testing.T) {
+	store := &DoltStore{}
+
+	callCount := 0
+	err := store.withWriteRetry(context.Background(), func() error {
+		callCount++
+		if callCount < 3 {
+			return errors.New("database is locked")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 calls (2 retries + success), got %d", callCount)
+	}
+}
+
+func TestWithWriteRetry_NonRetryableError(t *testing.T) {
+	store := &DoltStore{}
+
+	callCount := 0
+	err := store.withWriteRetry(context.Background(), func() error {
+		callCount++
+		return errors.New("validation failed")
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 	if callCount != 1 {
 		t.Errorf("expected 1 call for non-retryable error, got %d", callCount)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -247,10 +247,20 @@ const cliExecTimeout = 5 * time.Minute
 // Retry configuration for transient connection errors (stale pool connections,
 // brief network issues, server restarts).
 const serverRetryMaxElapsed = 30 * time.Second
+const serverWriteRetryMaxElapsed = 12 * time.Second
+const serverWriteLockWait = 2 * time.Second
 
 func newServerRetryBackoff() backoff.BackOff {
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = serverRetryMaxElapsed
+	return bo
+}
+
+func newServerWriteRetryBackoff() backoff.BackOff {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 100 * time.Millisecond
+	bo.MaxInterval = time.Second
+	bo.MaxElapsedTime = serverWriteRetryMaxElapsed
 	return bo
 }
 
@@ -316,6 +326,46 @@ func isRetryableError(err error) bool {
 	return false
 }
 
+func isRetryableWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isRetryableError(err) || isLockError(err) || isSerializationError(err) {
+		return true
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "failed to acquire write lock")
+}
+
+func writeLockName(database string) string {
+	const prefix = "bd_write_"
+	if database == "" {
+		database = "default"
+	}
+	var b strings.Builder
+	b.Grow(len(prefix) + len(database))
+	b.WriteString(prefix)
+	for _, r := range database {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-', r == ':':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	name := b.String()
+	if len(name) <= 64 {
+		return name
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(database))
+	return prefix + strconv.FormatUint(h.Sum64(), 16)
+}
+
+func (s *DoltStore) serverWriteLockName() string {
+	return writeLockName(s.database)
+}
+
 // isLockError returns true if the error indicates a Dolt lock contention problem.
 // These can occur when the Dolt server's storage layer is locked by another
 // process or a stale LOCK file was left behind by a crashed server.
@@ -339,6 +389,57 @@ func wrapLockError(err error) error {
 	return fmt.Errorf("%w\n\nThe Dolt database is locked. This usually means the Dolt server's "+
 		"storage is held by another process or a stale lock file exists.\n"+
 		"Try restarting the Dolt server, or run 'bd doctor --fix' to clean stale lock files.", err)
+}
+
+func (s *DoltStore) withServerWriteLock(ctx context.Context, fn func() error) error {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection for write lock: %w", err)
+	}
+	defer conn.Close()
+
+	start := time.Now()
+	var locked int
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", s.serverWriteLockName(), int(serverWriteLockWait/time.Second)).Scan(&locked); err != nil {
+		doltMetrics.lockWaitMs.Record(ctx, float64(time.Since(start).Milliseconds()))
+		return fmt.Errorf("failed to acquire write lock: %w", err)
+	}
+	doltMetrics.lockWaitMs.Record(ctx, float64(time.Since(start).Milliseconds()))
+	if locked != 1 {
+		return fmt.Errorf("failed to acquire write lock: timeout after %s (another process holds it)", serverWriteLockWait)
+	}
+	defer conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", s.serverWriteLockName()) //nolint:errcheck
+
+	return fn()
+}
+
+func (s *DoltStore) withWriteRetry(ctx context.Context, op func() error) error {
+	attempts := 0
+	bo := newServerWriteRetryBackoff()
+	err := backoff.Retry(func() error {
+		attempts++
+		err := op()
+		if err != nil && isRetryableWriteError(err) {
+			return err
+		}
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		return nil
+	}, backoff.WithContext(bo, ctx))
+	if attempts > 1 {
+		doltMetrics.retryCount.Add(ctx, int64(attempts-1))
+	}
+	return err
+}
+
+func (s *DoltStore) withSerializedWrite(ctx context.Context, fn func() error) error {
+	if !s.serverMode {
+		return fn()
+	}
+	return wrapLockError(s.withWriteRetry(ctx, func() error {
+		return s.withServerWriteLock(ctx, fn)
+	}))
 }
 
 // withRetry executes an operation with retry for transient errors.


### PR DESCRIPTION
## Summary

Recently, I have been seeing Beads become unstable more often under aggressive subagent-driven bursts of direct `bd` writes, especially in shared-server setups.

- serialize shared-server write operations with a database-scoped GET_LOCK in server mode
- add bounded retry with jitter for transient Dolt write failures such as lock, serialization, and read-only errors
- cover the new behavior with retry tests and concurrent write stress tests

## Testing

- go test ./internal/storage/dolt
- make test

## Notes

- manual shared-server stress check passed in an isolated database: 24 parallel `bd create`, then 24 parallel `bd comment`, then 24 parallel `bd close`
- final verification for that run: 24/24 issues closed and 24/24 issues retained exactly one comment

