### PR TITLE
fix(schema): drop child_counters FK that breaks set-state on agent beads

### DIFF
--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -31,6 +31,7 @@ var migrationsList = []Migration{
 	{"uuid_primary_keys", migrations.MigrateUUIDPrimaryKeys},
 	{"add_no_history_column", migrations.MigrateAddNoHistoryColumn},
 	{"drop_hop_columns", migrations.MigrateDropHOPColumns},
+	{"drop_child_counters_fk", migrations.MigrateDropChildCountersFK},
 }
 
 // RunMigrations executes all registered Dolt migrations in order.

--- a/internal/storage/dolt/migrations/013_drop_child_counters_fk.go
+++ b/internal/storage/dolt/migrations/013_drop_child_counters_fk.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// MigrateDropChildCountersFK removes the fk_counter_parent foreign key from
+// child_counters. This FK references issues(id), but since migration 007
+// (infra_to_wisps) moved agent beads to the wisps table, set-state on agent
+// beads fails with a FK violation — the parent_id exists in wisps, not issues.
+//
+// child_counters is a sequence counter cache (tracks the highest child ID per
+// parent). It is not a domain relationship — orphaned rows are harmless and
+// the FK's ON DELETE CASCADE provided no meaningful integrity guarantee.
+func MigrateDropChildCountersFK(db *sql.DB) error {
+	exists, err := constraintExists(db, "child_counters", "fk_counter_parent")
+	if err != nil {
+		return fmt.Errorf("checking fk_counter_parent: %w", err)
+	}
+	if !exists {
+		return nil // Already dropped or never existed
+	}
+
+	_, err = db.Exec("ALTER TABLE child_counters DROP FOREIGN KEY fk_counter_parent")
+	if err != nil {
+		return fmt.Errorf("dropping fk_counter_parent: %w", err)
+	}
+
+	return nil
+}

--- a/internal/storage/dolt/migrations/helpers.go
+++ b/internal/storage/dolt/migrations/helpers.go
@@ -59,6 +59,22 @@ func indexExists(db *sql.DB, table, indexName string) bool {
 	return rows.Next()
 }
 
+// constraintExists checks if a named constraint exists on a table.
+// Uses SHOW CREATE TABLE and string matching because Dolt doesn't support
+// information_schema.TABLE_CONSTRAINTS reliably.
+func constraintExists(db *sql.DB, table, constraint string) (bool, error) {
+	var tableName, createStmt string
+	//nolint:gosec // G202: table name is an internal constant
+	err := db.QueryRow("SHOW CREATE TABLE `" + table + "`").Scan(&tableName, &createStmt)
+	if err != nil {
+		if isTableNotFoundError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("SHOW CREATE TABLE %s: %w", table, err)
+	}
+	return strings.Contains(createStmt, constraint), nil
+}
+
 // tableExists checks if a table exists using SHOW TABLES.
 // Uses SHOW TABLES LIKE instead of information_schema to avoid crashes
 // when the Dolt server catalog contains stale database entries from

--- a/internal/storage/dolt/schema.go
+++ b/internal/storage/dolt/schema.go
@@ -150,10 +150,11 @@ CREATE TABLE IF NOT EXISTS metadata (
     value TEXT NOT NULL
 );
 -- Child counters table
+-- No FK constraint: parent_id may reference issues or wisps (agent beads were
+-- migrated to wisps in 007_infra_to_wisps but this FK was not updated).
 CREATE TABLE IF NOT EXISTS child_counters (
     parent_id VARCHAR(255) PRIMARY KEY,
-    last_child INT NOT NULL DEFAULT 0,
-    CONSTRAINT fk_counter_parent FOREIGN KEY (parent_id) REFERENCES issues(id) ON DELETE CASCADE
+    last_child INT NOT NULL DEFAULT 0
 );
 
 -- Issue snapshots table (for compaction)


### PR DESCRIPTION
## Problem

`bd set-state` fails on all infrastructure-type beads (agent, rig, role, message) with:

```
Error 1452: cannot add or update a child row - Foreign key violation on
fk: fk_counter_parent, table: child_counters, referenced table: issues
```

This affects every `bd set-state` call on beads whose type was migrated to wisps by migration 007.

## Root Cause

Migration 007 (`infra_to_wisps`) correctly moved infrastructure beads (agent, rig, role, message) from the `issues` table to the `wisps` table. However, `child_counters` has a foreign key constraint:

```sql
CONSTRAINT fk_counter_parent FOREIGN KEY (parent_id) REFERENCES issues(id) ON DELETE CASCADE
```

When `set-state` calls `GetNextChildID`, it tries to INSERT into `child_counters` with the bead ID as `parent_id`. The FK requires this ID to exist in `issues` — but after migration 007, it's in `wisps`. The FK was not updated as part of that migration.

## Impact

Any orchestration tool that calls `bd set-state` on agent beads hits this error. With retry logic, this adds minutes of wasted time per operation as retries exhaust against an unfixable FK violation.

## Fix

Drop the `fk_counter_parent` constraint. `child_counters` is a sequence counter cache (tracks the highest child ID per parent) — not a domain relationship. The FK's `ON DELETE CASCADE` provided negligible cleanup value: counter rows are one int per parent, and orphaned rows are never read.

### Changes

| File | Change |
|------|--------|
| `schema.go` | Remove FK from CREATE TABLE (new databases) |
| `migrations/013_drop_child_counters_fk.go` | ALTER TABLE DROP FOREIGN KEY (existing databases) |
| `migrations/helpers.go` | Add `constraintExists()` helper for idempotent check |
| `migrations.go` | Register migration 013 |

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/storage/dolt/migrations/...` passes
- [x] Manual: `bd set-state` on agent bead succeeds after migration runs
- [x] Manual: `bd set-state` on non-agent beads (task, bug, etc.) unaffected