### PR TITLE
fix: quote dotted metadata keys in JSON path expressions

### DIFF
--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -138,7 +138,7 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 			return nil, err
 		}
 		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
-		args = append(args, "$."+filter.HasMetadataKey)
+		args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
 	}
 
 	// Metadata field equality filters (GH#1406)
@@ -153,7 +153,7 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 				return nil, err
 			}
 			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
-			args = append(args, "$."+k, filter.MetadataFields[k])
+			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
 		}
 	}
 

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -459,7 +459,7 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 			return nil, err
 		}
 		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
-		args = append(args, "$."+filter.HasMetadataKey)
+		args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
 	}
 
 	// Metadata field equality filters
@@ -474,7 +474,7 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 				return nil, err
 			}
 			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
-			args = append(args, "$."+k, filter.MetadataFields[k])
+			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
 		}
 	}
 

--- a/internal/storage/issueops/filters.go
+++ b/internal/storage/issueops/filters.go
@@ -247,7 +247,7 @@ func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables Filt
 			return nil, nil, err
 		}
 		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
-		args = append(args, "$."+filter.HasMetadataKey)
+		args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
 	}
 	if len(filter.MetadataFields) > 0 {
 		metaKeys := make([]string, 0, len(filter.MetadataFields))
@@ -260,7 +260,7 @@ func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables Filt
 				return nil, nil, err
 			}
 			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
-			args = append(args, "$."+k, filter.MetadataFields[k])
+			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
 		}
 	}
 

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -124,7 +124,7 @@ func GetReadyWorkInTx(
 				return nil, err
 			}
 			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
-			args = append(args, "$."+k, filter.MetadataFields[k])
+			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
 		}
 	}
 

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 // NormalizeMetadataValue converts metadata values to a validated JSON string.
@@ -216,4 +217,15 @@ func ValidateMetadataKey(key string) error {
 		return fmt.Errorf("invalid metadata key %q: must match [a-zA-Z_][a-zA-Z0-9_.]*", key)
 	}
 	return nil
+}
+
+// JSONMetadataPath returns a MySQL/Dolt JSON path expression for the given
+// metadata key. Keys containing dots are quoted so that "gc.routed_to"
+// produces '$."gc.routed_to"' instead of '$.gc.routed_to' (which dolt
+// interprets as a nested path: {gc: {routed_to: ...}}).
+func JSONMetadataPath(key string) string {
+	if strings.Contains(key, ".") {
+		return `$."` + key + `"`
+	}
+	return "$." + key
 }

--- a/internal/storage/metadata_jsonpath_test.go
+++ b/internal/storage/metadata_jsonpath_test.go
@@ -1,0 +1,35 @@
+package storage
+
+import "testing"
+
+func TestJSONMetadataPathSimpleKey(t *testing.T) {
+	got := JSONMetadataPath("status")
+	want := "$.status"
+	if got != want {
+		t.Errorf("JSONMetadataPath(%q) = %q, want %q", "status", got, want)
+	}
+}
+
+func TestJSONMetadataPathDottedKey(t *testing.T) {
+	got := JSONMetadataPath("gc.routed_to")
+	want := `$."gc.routed_to"`
+	if got != want {
+		t.Errorf("JSONMetadataPath(%q) = %q, want %q", "gc.routed_to", got, want)
+	}
+}
+
+func TestJSONMetadataPathMultipleDots(t *testing.T) {
+	got := JSONMetadataPath("gc.scope.ref")
+	want := `$."gc.scope.ref"`
+	if got != want {
+		t.Errorf("JSONMetadataPath(%q) = %q, want %q", "gc.scope.ref", got, want)
+	}
+}
+
+func TestJSONMetadataPathUnderscoredKey(t *testing.T) {
+	got := JSONMetadataPath("my_field")
+	want := "$.my_field"
+	if got != want {
+		t.Errorf("JSONMetadataPath(%q) = %q, want %q", "my_field", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- `--metadata-field` and `--has-metadata-key` filters with dotted keys (e.g., `gc.routed_to`, `gc.kind`) were silently returning zero results
- Root cause: `"$."+key` produces `$.gc.routed_to` which Dolt interprets as nested JSON path `{gc: {routed_to: ...}}` instead of flat key `"gc.routed_to"`
- Fix: new `storage.JSONMetadataPath()` helper quotes dotted keys as `$."gc.routed_to"`
- Applied to all 6 call sites: `queries.go`, `transaction.go`, `filters.go`, `ready_work.go`

## Test plan

- [x] Unit tests for `JSONMetadataPath` covering simple keys, single dot, multiple dots
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Verified fix against live dolt database: `bd ready --metadata-field gc.routed_to=gascity/claude` now returns matching beads

🤖 Generated with [Claude Code](https://claude.com/claude-code)