### PR TITLE
feat: export WispFilter type from root package

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -121,6 +121,7 @@ type (
 	IssueWithDependencyMetadata = types.IssueWithDependencyMetadata
 	SortPolicy                  = types.SortPolicy
 	EpicStatus                  = types.EpicStatus
+	WispFilter                  = types.WispFilter
 )
 
 // Status constants


### PR DESCRIPTION
## Summary
Export `WispFilter` as a type alias from the root `beads` package. The type already exists in `internal/types` — this one-line change makes it importable by gt.

## Motivation
gt PR steveyegge/gastown#3166 migrates from bd CLI shell-outs to the Go module Storage API. `ListWisps` takes a `WispFilter` parameter, but the type wasn't exported from the root package.

## Test plan
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)