### PR TITLE
fix: include convoy-type formulas in bd formula list text output

### DIFF
--- a/cmd/bd/formula.go
+++ b/cmd/bd/formula.go
@@ -56,7 +56,7 @@ Examples:
   bd formula list
   bd formula list --json
   bd formula list --type workflow
-  bd formula list --type aspect`,
+  bd formula list --type convoy`,
 	Run: runFormulaList,
 }
 
@@ -157,8 +157,8 @@ func runFormulaList(cmd *cobra.Command, args []string) {
 		byType[e.Type] = append(byType[e.Type], e)
 	}
 
-	// Print in type order: workflow, expansion, aspect
-	typeOrder := []string{"workflow", "expansion", "aspect"}
+	// Print in type order: workflow, expansion, aspect, convoy
+	typeOrder := []string{"workflow", "expansion", "aspect", "convoy"}
 	for _, t := range typeOrder {
 		typeEntries := byType[t]
 		if len(typeEntries) == 0 {
@@ -430,6 +430,8 @@ func getTypeIcon(t string) string {
 		return "📐"
 	case "aspect":
 		return "🎯"
+	case "convoy":
+		return "🚐"
 	default:
 		return "📜"
 	}
@@ -757,7 +759,7 @@ func fixIntegerFields(m map[string]interface{}) {
 }
 
 func init() {
-	formulaListCmd.Flags().String("type", "", "Filter by type (workflow, expansion, aspect)")
+	formulaListCmd.Flags().String("type", "", "Filter by type (workflow, expansion, aspect, convoy)")
 	formulaConvertCmd.Flags().BoolVar(&convertAll, "all", false, "Convert all JSON formulas")
 	formulaConvertCmd.Flags().BoolVar(&convertDelete, "delete", false, "Delete JSON file after conversion")
 	formulaConvertCmd.Flags().BoolVar(&convertStdout, "stdout", false, "Print TOML to stdout instead of file")

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -604,6 +604,7 @@ func TestFormulaType_IsValid(t *testing.T) {
 		{TypeWorkflow, true},
 		{TypeExpansion, true},
 		{TypeAspect, true},
+		{TypeConvoy, true},
 		{"invalid", false},
 		{"", false},
 	}

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -46,12 +46,16 @@ const (
 	// TypeAspect is a cross-cutting concern that can be applied to other formulas.
 	// Examples: add logging steps, add approval gates.
 	TypeAspect FormulaType = "aspect"
+
+	// TypeConvoy is a multi-agent workflow that coordinates parallel workers.
+	// Examples: code review with multiple reviewers, design review sessions.
+	TypeConvoy FormulaType = "convoy"
 )
 
 // IsValid checks if the formula type is recognized.
 func (t FormulaType) IsValid() bool {
 	switch t {
-	case TypeWorkflow, TypeExpansion, TypeAspect:
+	case TypeWorkflow, TypeExpansion, TypeAspect, TypeConvoy:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

- Add `TypeConvoy` as a recognized `FormulaType` in `internal/formula/types.go`
- Add `"convoy"` to the `typeOrder` slice in `runFormulaList` so convoy formulas render in text output
- Add 🚐 icon for convoy type in `getTypeIcon`
- Update `--type` flag help and command examples to include convoy

## Test plan

- [x] `TestFormulaType_IsValid` updated and passing (includes `TypeConvoy`)
- [x] All `./internal/formula/` tests passing
- [x] `go vet ./internal/formula/` clean

Fixes #2825