### PR TITLE
fix: add missing created_at index on wisp_events

### DIFF
--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -32,6 +32,7 @@ var migrationsList = []Migration{
 	{"add_no_history_column", migrations.MigrateAddNoHistoryColumn},
 	{"drop_hop_columns", migrations.MigrateDropHOPColumns},
 	{"drop_child_counters_fk", migrations.MigrateDropChildCountersFK},
+	{"wisp_events_created_at_index", migrations.MigrateWispEventsCreatedAtIndex},
 }
 
 // RunMigrations executes all registered Dolt migrations in order.

--- a/internal/storage/dolt/migrations/005_wisp_auxiliary_tables.go
+++ b/internal/storage/dolt/migrations/005_wisp_auxiliary_tables.go
@@ -54,7 +54,8 @@ const wispEventsSchema = `CREATE TABLE IF NOT EXISTS wisp_events (
     new_value TEXT DEFAULT '',
     comment TEXT DEFAULT '',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    INDEX idx_wisp_events_issue (issue_id)
+    INDEX idx_wisp_events_issue (issue_id),
+    INDEX idx_wisp_events_created_at (created_at)
 )`
 
 const wispCommentsSchema = `CREATE TABLE IF NOT EXISTS wisp_comments (

--- a/internal/storage/dolt/migrations/014_wisp_events_created_at_index.go
+++ b/internal/storage/dolt/migrations/014_wisp_events_created_at_index.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// MigrateWispEventsCreatedAtIndex adds an index on wisp_events.created_at to
+// match the idx_events_created_at index on the events table.
+//
+// Without this index, GetAllEventsSince's UNION ALL query performs a full table
+// scan on wisp_events for the WHERE created_at > ? predicate. The events table
+// already has this index (added in the original schema), but wisp_events was
+// created in migration 005 without it.
+//
+// This also prevents the Dolt +Inf cast error described in GH#2760: when the
+// optimizer lacks an index on the comparison column, it may choose a code path
+// that implicitly casts CHAR(36) UUID values to float64, causing overflow on
+// UUIDs that resemble scientific notation (e.g. 001e914b... → 1e914 → +Inf).
+func MigrateWispEventsCreatedAtIndex(db *sql.DB) error {
+	exists, err := tableExists(db, "wisp_events")
+	if err != nil {
+		return fmt.Errorf("checking wisp_events: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+
+	if indexExists(db, "wisp_events", "idx_wisp_events_created_at") {
+		return nil
+	}
+
+	_, err = db.Exec("CREATE INDEX idx_wisp_events_created_at ON wisp_events (created_at)")
+	if err != nil {
+		return fmt.Errorf("creating idx_wisp_events_created_at: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds migration 014 to create `idx_wisp_events_created_at` index on existing `wisp_events` tables
- Updates the base schema in migration 005 so new databases include the index from the start
- The `events` table already has `idx_events_created_at` but `wisp_events` was missing it, causing full table scans on `WHERE created_at > ?` in `GetAllEventsSince`

The core type mismatch bug (`WHERE id > ?` with `int64` on `CHAR(36)`) was already resolved by the UUID primary keys migration (PR #2597), which changed `GetAllEventsSince` to use `WHERE created_at > ?` with `time.Time`. This PR adds the missing index to ensure the query uses an efficient execution path and avoids the optimizer code path that triggered the `+Inf` cast error.

Fixes #2760

## Test plan

- [x] Verify migration 014 is idempotent (safe to run multiple times)
- [x] Verify `GetAllEventsSince` returns events from both tables after migration
- [x] Verify new database creation includes `idx_wisp_events_created_at`