### PR TITLE
fix: show blocked icon for dependency-blocked issues in bd list

### DIFF
--- a/cmd/bd/list_format.go
+++ b/cmd/bd/list_format.go
@@ -234,8 +234,11 @@ func formatIssueCompact(buf *strings.Builder, issue *types.Issue, labels []strin
 		depInfo = " " + depInfo
 	}
 
-	// Get styled status icon
+	// Get styled status icon — override to blocked when issue has open blockers (GH#2858)
 	statusIcon := renderStatusIcon(issue.Status)
+	if len(blockedBy) > 0 && issue.Status == types.StatusOpen {
+		statusIcon = renderStatusIcon(types.StatusBlocked)
+	}
 
 	if issue.Status == types.StatusClosed {
 		// Closed issues: entire line muted (fades visually)

--- a/cmd/bd/list_test.go
+++ b/cmd/bd/list_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
 )
 
@@ -969,6 +970,65 @@ func TestFormatIssueCompactWithDependencies(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFormatIssueCompactBlockedIcon verifies that dependency-blocked open issues
+// show the blocked icon (●) instead of the open icon (○) in compact list output. (GH#2858)
+func TestFormatIssueCompactBlockedIcon(t *testing.T) {
+	t.Parallel()
+
+	t.Run("open issue with blockers shows blocked icon", func(t *testing.T) {
+		issue := &types.Issue{
+			ID:        "test-blocked",
+			Title:     "Blocked by dependency",
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Status:    types.StatusOpen,
+		}
+		var buf strings.Builder
+		formatIssueCompact(&buf, issue, nil, []string{"blocker-1"}, nil, "")
+		result := buf.String()
+		// Should show blocked icon ● not open icon ○
+		if strings.Contains(result, ui.StatusIconOpen) {
+			t.Errorf("dependency-blocked issue should not show open icon ○, got: %q", result)
+		}
+		if !strings.Contains(result, ui.StatusIconBlocked) {
+			t.Errorf("dependency-blocked issue should show blocked icon ●, got: %q", result)
+		}
+	})
+
+	t.Run("open issue without blockers shows open icon", func(t *testing.T) {
+		issue := &types.Issue{
+			ID:        "test-open",
+			Title:     "Normal open issue",
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Status:    types.StatusOpen,
+		}
+		var buf strings.Builder
+		formatIssueCompact(&buf, issue, nil, nil, nil, "")
+		result := buf.String()
+		if !strings.Contains(result, ui.StatusIconOpen) {
+			t.Errorf("open issue without blockers should show open icon ○, got: %q", result)
+		}
+	})
+
+	t.Run("in_progress issue with blockers keeps in_progress icon", func(t *testing.T) {
+		issue := &types.Issue{
+			ID:        "test-wip",
+			Title:     "In progress with blocker",
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Status:    types.StatusInProgress,
+		}
+		var buf strings.Builder
+		formatIssueCompact(&buf, issue, nil, []string{"blocker-1"}, nil, "")
+		result := buf.String()
+		// Should keep in_progress icon, not override to blocked
+		if !strings.Contains(result, ui.StatusIconInProgress) {
+			t.Errorf("in_progress issue should keep its icon even with blockers, got: %q", result)
+		}
+	})
 }
 
 func TestParseTimeFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #2858

- `bd list` compact output now shows the `●` (blocked) icon for open issues that have unresolved dependencies, instead of `○` (open)
- Only overrides when stored status is `open` and issue has active blockers — `in_progress` and other statuses keep their own icon
- Adds tests verifying the icon behavior for blocked, open, and in-progress issues with dependencies

## Test plan

- [x] `bd list` shows `●` for issues with unresolved blockers
- [x] `bd list` shows `○` for open issues without blockers
- [x] `bd list` shows `◐` for in_progress issues even if they have blockers
- [x] New unit tests pass: `TestFormatIssueCompactBlockedIcon`