### PR TITLE
fix: allow external contributors to create PRs via block-gh-watch hook

### DIFF
--- a/.claude/hooks/block-gh-watch.sh
+++ b/.claude/hooks/block-gh-watch.sh
@@ -17,9 +17,22 @@ if echo "$COMMAND" | grep -qE 'gh run watch|gh run list.*--watch'; then
   exit 0
 fi
 
-# Block PR creation. Crew workers push directly to main, never make PRs.
-# PRs are for external contributors. Crew work lands via `git push` to main.
+# Block PR creation for crew/maintainers. Crew workers push directly to main.
+# External contributors (beads.role=contributor or fork origin) need PRs.
 if echo "$COMMAND" | grep -qE 'gh pr create'; then
+  ROLE=$(git config --get beads.role 2>/dev/null || echo "")
+  ORIGIN=$(git config --get remote.origin.url 2>/dev/null || echo "")
+
+  # Allow if role is explicitly contributor
+  if [ "$ROLE" = "contributor" ]; then
+    exit 0
+  fi
+
+  # Allow if origin points to a fork (not the upstream repo)
+  if [ -n "$ORIGIN" ] && echo "$ORIGIN" | grep -qvE 'steveyegge/beads'; then
+    exit 0
+  fi
+
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",


### PR DESCRIPTION
## Summary

- Check `beads.role` git config before blocking `gh pr create` — if set to `contributor`, allow through
- Check `origin` remote URL — if it points to a fork (not `steveyegge/beads`), allow through
- Crew/maintainer behavior unchanged: still blocked with guidance to push directly to main

Both checks use infrastructure that already exists in the repo (see `internal/beads/context.go` Role() method).

## Test plan

- [x] Verified grep logic: upstream origin blocked, fork origin allowed, contributor role allowed
- [x] Empty origin edge case handled (defaults to blocked)
- [x] `gh run watch` blocking unchanged

Fixes #2739