### PR TITLE
fix: pass parent env vars to dolt-sql-server child process

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -674,6 +674,7 @@ func Start(beadsDir string) (*State, error) {
 		cmd.Stderr = logFile
 		cmd.Stdin = nil
 		cmd.SysProcAttr = procAttrDetached()
+		cmd.Env = os.Environ()
 
 		if startErr := cmd.Start(); startErr != nil {
 			lastErr = startErr


### PR DESCRIPTION
## Summary
- When `bd dolt start` spawns `dolt-sql-server` as a detached process, environment variables from the parent shell are not inherited
- This breaks cloud storage remotes (Azure `az://`, AWS `s3://`) that rely on env vars like `AZURE_STORAGE_ACCOUNT` or `AWS_ACCESS_KEY_ID`
- Fix: explicitly set `cmd.Env = os.Environ()` before `cmd.Start()` to ensure env inheritance regardless of process group detachment

## Test plan
- [ ] Set cloud storage env vars in shell, run `bd dolt start`, verify child process has access to env vars
- [ ] Verify existing dolt-sql-server functionality is unaffected

Fixes #2812