### PR TITLE
fix: skip E2E test that requires Dolt server in embedded mode

### DIFF
--- a/cmd/bd/dolt_autostart_lifecycle_integration_test.go
+++ b/cmd/bd/dolt_autostart_lifecycle_integration_test.go
@@ -18,6 +18,9 @@ func TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow integration test in short mode")
 	}
+	if isEmbeddedDolt {
+		t.Skip("skipping: bd dolt status not supported in embedded mode")
+	}
 	if runtime.GOOS == windowsOS {
 		t.Skip("repo-local dolt lifecycle integration test not supported on windows")
 	}


### PR DESCRIPTION
## Summary

- `TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands` calls `bd dolt status`, which is not supported in embedded mode (no Dolt server process)
- Added an early `t.Skip` when `isEmbeddedDolt` is true, matching the pattern used elsewhere in the package (e.g. `dolt_autocommit_integration_test.go` skips when `testDoltServerPort == 0`)
- Only the one test function was changed; no other files were modified

## Test plan

- [ ] Verify `go vet ./cmd/bd/...` passes (done locally, no output)
- [ ] Verify CI passes with `embeddeddolt` build tag: test is now skipped instead of failing
- [ ] Verify CI passes without `embeddeddolt` build tag: test still runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)