### PR TITLE
fix(create): remove description warning and gate test-issue warning on DB size

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -89,12 +89,15 @@ var createCmd = &cobra.Command{
 		// Get silent flag
 		silent, _ := cmd.Flags().GetBool("silent")
 
-		// Warn if creating a test issue in production database (unless silent mode)
+		// Warn if creating a test issue in a database with existing issues.
+		// A brand-new repo with zero issues is not a "production database" (#2898).
 		if isTestIssue(title) && !silent && !debug.IsQuiet() {
-			fmt.Fprintf(os.Stderr, "%s Creating test issue in production database\n", ui.RenderWarn("⚠"))
-			fmt.Fprintf(os.Stderr, "  Title: %q appears to be test data\n", title)
-			fmt.Fprintf(os.Stderr, "  Recommendation: Use isolated test database with --db\n")
-			fmt.Fprintf(os.Stderr, "    bd --db /tmp/test-beads create %q\n", title)
+			if stats, err := store.GetStatistics(context.Background()); err == nil && stats != nil && stats.TotalIssues >= 5 {
+				fmt.Fprintf(os.Stderr, "%s Creating test issue in production database\n", ui.RenderWarn("⚠"))
+				fmt.Fprintf(os.Stderr, "  Title: %q appears to be test data\n", title)
+				fmt.Fprintf(os.Stderr, "  Recommendation: Use isolated test database with --db\n")
+				fmt.Fprintf(os.Stderr, "    bd --db /tmp/test-beads create %q\n", title)
+			}
 		}
 
 		// Get field values
@@ -120,12 +123,6 @@ var createCmd = &cobra.Command{
 		if description == "" && !isTestIssue(title) {
 			if config.GetBool("create.require-description") {
 				FatalError("description is required (set create.require-description: false in config.yaml to disable)")
-			}
-			// Warn if creating an issue without a description (unless silent mode)
-			if !silent && !debug.IsQuiet() {
-				fmt.Fprintf(os.Stderr, "%s Creating issue without description.\n", ui.RenderWarn("⚠"))
-				fmt.Fprintf(os.Stderr, "  Issues without descriptions lack context for future work.\n")
-				fmt.Fprintf(os.Stderr, "  Consider adding --description=\"Why this issue exists and what needs to be done\"\n")
 			}
 		}
 


### PR DESCRIPTION
## Summary

Two UX fixes for `bd create` that reduce confusing warnings for new users:

### Remove description warning (#2897)

The "Creating issue without description" warning fires on the default happy path. The quickstart guide tells users to run `bd create "My first issue"` without a description — then they immediately see a warning. Descriptions are optional; teams that want to enforce them can use the `create.require-description` config option.

**Fix:** Remove the warning entirely. The `--description` flag and `create.require-description` config remain for those who want them.

### Gate test-issue warning on DB size (#2898)

The "Creating test issue in production database" warning fires on any title matching test patterns (from `detect_pollution.go`), even in a brand-new repo with zero issues. A new repo is not a "production database."

**Fix:** Only show this warning when the database already has ≥5 issues.

Closes #2897
Closes #2898