### PR TITLE
fix(doctor,dolt): improve embedded mode and push error guidance

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -186,8 +186,14 @@ Examples:
   bd doctor --migration=pre --json  # Machine-parseable migration validation`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if isEmbeddedMode() {
-			fmt.Fprintln(os.Stderr, "Error: 'bd doctor' is not yet supported in embedded mode")
-			os.Exit(1)
+			fmt.Fprintln(os.Stderr, "Note: 'bd doctor' is not yet supported in embedded mode.")
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "For embedded mode troubleshooting:")
+			fmt.Fprintln(os.Stderr, "  • Verify database exists:  ls -la .beads/embeddeddolt/")
+			fmt.Fprintln(os.Stderr, "  • Check bd version:        bd version")
+			fmt.Fprintln(os.Stderr, "  • Reinitialize if needed:  bd init --force")
+			fmt.Fprintln(os.Stderr, "  • Switch to server mode:   bd init --server")
+			os.Exit(0)
 		}
 		// Use global jsonOutput set by PersistentPreRun
 

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -170,9 +170,19 @@ uncommitted changes in its working set).`,
 			if err := st.ForcePush(ctx); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				if isRemoteNotFoundErr(err) {
-					fmt.Fprintf(os.Stderr, "Hint: use 'bd dolt remote add <name> <url>' (not 'dolt remote add').\n")
-					fmt.Fprintf(os.Stderr, "  Running 'dolt remote add' directly may add the remote to the wrong directory.\n")
-					fmt.Fprintf(os.Stderr, "  Use 'bd dolt remote list' to check for discrepancies.\n")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "No remote is configured for this database.")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "For solo use, pushing is optional — your issues are stored locally")
+					fmt.Fprintln(os.Stderr, "in .beads/ and versioned by Dolt automatically.")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "To set up remote sync (for backup or team sharing):")
+					fmt.Fprintln(os.Stderr, "  bd dolt remote add origin <url>")
+					fmt.Fprintln(os.Stderr, "  bd dolt push")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "Supported remote URLs:")
+					fmt.Fprintln(os.Stderr, "  • GitHub (via git):   git+ssh://git@github.com/org/repo.git")
+					fmt.Fprintln(os.Stderr, "  • DoltHub:            https://doltremoteapi.dolthub.com/org/repo")
 				}
 				os.Exit(1)
 			}
@@ -180,9 +190,19 @@ uncommitted changes in its working set).`,
 			if err := st.Push(ctx); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				if isRemoteNotFoundErr(err) {
-					fmt.Fprintf(os.Stderr, "Hint: use 'bd dolt remote add <name> <url>' (not 'dolt remote add').\n")
-					fmt.Fprintf(os.Stderr, "  Running 'dolt remote add' directly may add the remote to the wrong directory.\n")
-					fmt.Fprintf(os.Stderr, "  Use 'bd dolt remote list' to check for discrepancies.\n")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "No remote is configured for this database.")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "For solo use, pushing is optional — your issues are stored locally")
+					fmt.Fprintln(os.Stderr, "in .beads/ and versioned by Dolt automatically.")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "To set up remote sync (for backup or team sharing):")
+					fmt.Fprintln(os.Stderr, "  bd dolt remote add origin <url>")
+					fmt.Fprintln(os.Stderr, "  bd dolt push")
+					fmt.Fprintln(os.Stderr, "")
+					fmt.Fprintln(os.Stderr, "Supported remote URLs:")
+					fmt.Fprintln(os.Stderr, "  • GitHub (via git):   git+ssh://git@github.com/org/repo.git")
+					fmt.Fprintln(os.Stderr, "  • DoltHub:            https://doltremoteapi.dolthub.com/org/repo")
 				}
 				os.Exit(1)
 			}


### PR DESCRIPTION
## Summary

- **bd doctor** (#2900): Replace terse "not yet supported in embedded mode" error with actionable troubleshooting steps (verify database, check version, reinitialize, switch to server mode). Exit 0 instead of 1 since this is informational guidance, not an error condition.

- **bd dolt push** (#2901): When no remote is configured, explain that pushing is optional for solo use and show how to set up remote sync with example URLs. The previous hint assumed the user had a misconfigured remote, which confused new users following the getting-started workflow.

Closes #2900
Closes #2901