### PR TITLE
fix(init): reset git caches after auto-init and skip .beads/dolt/ in embedded mode

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -337,6 +337,9 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.`,
 			if output, err := gitInitCmd.CombinedOutput(); err != nil {
 				FatalError("failed to initialize git repository: %v\n%s", err, output)
 			}
+			// Clear cached git context so subsequent operations (e.g. hook
+			// installation) see the newly-created repository (GH#2899).
+			git.ResetCaches()
 			if !quiet {
 				fmt.Printf("  %s Initialized git repository\n", ui.RenderPass("✓"))
 			}
@@ -345,8 +348,12 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.`,
 		// Ensure storage directory exists (.beads/dolt).
 		// In server mode, dolt.New() connects via TCP and doesn't create local directories,
 		// so we create the marker directory explicitly.
-		if err := os.MkdirAll(initDBPath, 0750); err != nil {
-			FatalError("failed to create storage directory %s: %v", initDBPath, err)
+		// In embedded mode the engine creates its own directories under .beads/embeddeddolt/,
+		// so skip this to avoid leaving an empty .beads/dolt/ artifact (GH#2903).
+		if initServerMode {
+			if err := os.MkdirAll(initDBPath, 0750); err != nil {
+				FatalError("failed to create storage directory %s: %v", initDBPath, err)
+			}
 		}
 
 		ctx := rootCtx

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1450,12 +1450,11 @@ func TestInit_WithBEADS_DIR_DoltBackend(t *testing.T) {
 		t.Fatalf("Init with BEADS_DIR and Dolt backend failed: %v", err)
 	}
 
-	// Verify Dolt database was created at BEADS_DIR
-	expectedDoltPath := filepath.Join(beadsDirPath, "dolt")
-	if info, err := os.Stat(expectedDoltPath); os.IsNotExist(err) {
-		t.Errorf("Dolt database was not created at BEADS_DIR path: %s", expectedDoltPath)
-	} else if !info.IsDir() {
-		t.Errorf("Expected Dolt path to be a directory: %s", expectedDoltPath)
+	// In embedded mode (default), the engine creates .beads/embeddeddolt/ —
+	// .beads/dolt/ should NOT be created (GH#2903).
+	unexpectedDoltPath := filepath.Join(beadsDirPath, "dolt")
+	if _, err := os.Stat(unexpectedDoltPath); err == nil {
+		t.Errorf("Empty .beads/dolt/ should not be created in embedded mode: %s", unexpectedDoltPath)
 	}
 
 	// Verify database was NOT created at CWD


### PR DESCRIPTION
## Summary

Fixes two init-flow friction points:

### #2899: Git hooks installation fails after auto-created git repo

After `bd init` auto-creates a git repo via `git init`, the `internal/git` package's `sync.Once` cache still holds a stale "not a git repository" error from before the repo existed. Subsequent hook installation calls `git.GetRepoRoot()` which returns the cached error, causing "failed to configure git hooks path: not in a git repository".

**Fix:** Call `git.ResetCaches()` immediately after successful `git init` to clear the stale cached context.

### #2903: Empty `.beads/dolt/` directory created in embedded mode

`bd init` unconditionally creates `.beads/dolt/` even in embedded mode where the actual database lives under `.beads/embeddeddolt/`. The empty directory is a server-mode artifact that confuses users.

**Fix:** Only create the server storage directory when `--server` is passed. The embedded Dolt engine creates its own directories.

## Changes

- `cmd/bd/init.go`: Added `git.ResetCaches()` after `git init`; gated `MkdirAll(initDBPath)` on `initServerMode`
- `cmd/bd/init_test.go`: Updated `TestInit_WithBEADS_DIR_DoltBackend` to assert `.beads/dolt/` is NOT created in embedded mode

Closes #2899
Closes #2903