### PR TITLE
fix: update gate_test.go for multi-rig removal and fix gofmt in issueops tests

### DIFF
--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -66,28 +65,11 @@ func TestCheckBeadGate_InvalidFormat(t *testing.T) {
 	tests := []struct {
 		name    string
 		awaitID string
-		wantErr string
 	}{
-		{
-			name:    "empty",
-			awaitID: "",
-			wantErr: "invalid await_id format",
-		},
-		{
-			name:    "no colon",
-			awaitID: "my-project-mp-abc",
-			wantErr: "invalid await_id format",
-		},
-		{
-			name:    "missing rig",
-			awaitID: ":gt-abc",
-			wantErr: "await_id missing rig name",
-		},
-		{
-			name:    "missing bead",
-			awaitID: "my-project:",
-			wantErr: "await_id missing rig name or bead ID",
-		},
+		{name: "empty", awaitID: ""},
+		{name: "no colon", awaitID: "my-project-mp-abc"},
+		{name: "missing rig", awaitID: ":gt-abc"},
+		{name: "missing bead", awaitID: "my-project:"},
 	}
 
 	for _, tt := range tests {
@@ -99,9 +81,8 @@ func TestCheckBeadGate_InvalidFormat(t *testing.T) {
 			if reason == "" {
 				t.Error("expected reason to be set")
 			}
-			// Just check the error message contains the expected substring
-			if tt.wantErr != "" && !gateTestContainsIgnoreCase(reason, tt.wantErr) {
-				t.Errorf("reason %q does not contain %q", reason, tt.wantErr)
+			if !gateTestContainsIgnoreCase(reason, "multi-rig routing removed") {
+				t.Errorf("reason %q does not contain %q", reason, "multi-rig routing removed")
 			}
 		})
 	}
@@ -110,19 +91,7 @@ func TestCheckBeadGate_InvalidFormat(t *testing.T) {
 func TestCheckBeadGate_RigNotFound(t *testing.T) {
 	ctx := context.Background()
 
-	// Create a temp directory with a minimal beads setup
-	tmpDir, err := os.MkdirTemp("", "gate_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Change to temp dir
-	origDir, _ := os.Getwd()
-	defer os.Chdir(origDir)
-	os.Chdir(tmpDir)
-
-	// Try to check a gate for a non-existent rig
+	// With multi-rig routing removed, all bead gates return the same message
 	satisfied, reason := checkBeadGate(ctx, "nonexistent:some-id")
 	if satisfied {
 		t.Error("expected not satisfied for non-existent rig")
@@ -130,9 +99,8 @@ func TestCheckBeadGate_RigNotFound(t *testing.T) {
 	if reason == "" {
 		t.Error("expected reason to be set")
 	}
-	// The error should mention the rig not being found
-	if !gateTestContainsIgnoreCase(reason, "not found") && !gateTestContainsIgnoreCase(reason, "could not find") {
-		t.Errorf("reason should mention not found: %q", reason)
+	if !gateTestContainsIgnoreCase(reason, "multi-rig routing removed") {
+		t.Errorf("reason %q does not contain %q", reason, "multi-rig routing removed")
 	}
 }
 

--- a/internal/storage/issueops/filters_test.go
+++ b/internal/storage/issueops/filters_test.go
@@ -235,9 +235,9 @@ func TestBuildIssueFilterClauses_PinnedFilter(t *testing.T) {
 	pinFalse := false
 
 	tests := []struct {
-		name     string
-		pinned   *bool
-		wantSQL  string
+		name    string
+		pinned  *bool
+		wantSQL string
 	}{
 		{name: "pinned=true", pinned: &pinTrue, wantSQL: "pinned = 1"},
 		{name: "pinned=false", pinned: &pinFalse, wantSQL: "(pinned = 0 OR pinned IS NULL)"},

--- a/internal/storage/issueops/helpers_test.go
+++ b/internal/storage/issueops/helpers_test.go
@@ -260,10 +260,10 @@ func TestTableRouting(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		issue       *types.Issue
-		wantIssue   string
-		wantEvent   string
+		name      string
+		issue     *types.Issue
+		wantIssue string
+		wantEvent string
 	}{
 		{
 			name:      "regular issue routes to issues/events",

--- a/internal/storage/issueops/ready_work_test.go
+++ b/internal/storage/issueops/ready_work_test.go
@@ -8,28 +8,28 @@ func TestBuildSQLInClause(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		ids             []string
+		name             string
+		ids              []string
 		wantPlaceholders string
-		wantArgs        []interface{}
+		wantArgs         []interface{}
 	}{
 		{
-			name:            "single ID",
-			ids:             []string{"42"},
+			name:             "single ID",
+			ids:              []string{"42"},
 			wantPlaceholders: "?",
-			wantArgs:        []interface{}{"42"},
+			wantArgs:         []interface{}{"42"},
 		},
 		{
-			name:            "multiple IDs",
-			ids:             []string{"1", "2", "3"},
+			name:             "multiple IDs",
+			ids:              []string{"1", "2", "3"},
 			wantPlaceholders: "?,?,?",
-			wantArgs:        []interface{}{"1", "2", "3"},
+			wantArgs:         []interface{}{"1", "2", "3"},
 		},
 		{
-			name:            "empty slice",
-			ids:             []string{},
+			name:             "empty slice",
+			ids:              []string{},
 			wantPlaceholders: "",
-			wantArgs:        []interface{}{},
+			wantArgs:         []interface{}{},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes CI failures affecting all open PRs caused by stale tests and formatting on main.

### Changes

1. **gate_test.go**: Updated `TestCheckBeadGate_InvalidFormat` and `TestCheckBeadGate_RigNotFound` to expect the `multi-rig routing removed` message, matching the current `checkBeadGate` implementation (which was simplified to a one-liner).

2. **gate_test.go**: Removed unused `"os"` import (caused build failure in PR #2878).

3. **issueops test files**: Fixed `gofmt` alignment in `filters_test.go`, `helpers_test.go`, `ready_work_test.go` (caused `Check formatting` CI failure in 5 PRs).

### PRs unblocked by this fix
- #2906, #2905, #2904, #2881, #2880, #2878 (after rebase)