### PR TITLE
fix(init): replace 'bd onboard' with 'bd prime' in AGENTS.md

### DIFF
--- a/cmd/bd/@AGENTS.md
+++ b/cmd/bd/@AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
 
 ## Quick Reference
 

--- a/cmd/bd/AGENTS.md
+++ b/cmd/bd/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
 
 ## Quick Reference
 

--- a/cmd/bd/init_agent.go
+++ b/cmd/bd/init_agent.go
@@ -151,27 +151,32 @@ func setupClaudeSettings(verbose bool) error {
 		existingSettings = make(map[string]interface{})
 	}
 
-	// Add or update the prompt with onboard instruction
-	onboardPrompt := "Before starting any work, run 'bd onboard' to understand the current project state and available issues."
+	// Add or update the prompt with prime instruction
+	primePrompt := "Before starting any work, run 'bd prime' to understand the current project state and available issues."
 
-	// Check if prompt already contains onboard instruction
+	// Check if prompt already contains prime or onboard instruction
 	if promptValue, exists := existingSettings["prompt"]; exists {
 		if promptStr, ok := promptValue.(string); ok {
-			if strings.Contains(promptStr, "bd onboard") {
+			if strings.Contains(promptStr, "bd prime") {
 				if verbose {
-					fmt.Printf("Claude settings already configured with bd onboard instruction\n")
+					fmt.Printf("Claude settings already configured with bd prime instruction\n")
 				}
 				return nil
 			}
-			// Update existing prompt to include onboard instruction
-			existingSettings["prompt"] = promptStr + "\n\n" + onboardPrompt
+			// Migrate legacy "bd onboard" references to "bd prime"
+			if strings.Contains(promptStr, "bd onboard") {
+				existingSettings["prompt"] = strings.ReplaceAll(promptStr, "bd onboard", "bd prime")
+			} else {
+				// Update existing prompt to include prime instruction
+				existingSettings["prompt"] = promptStr + "\n\n" + primePrompt
+			}
 		} else {
 			// Existing prompt is not a string, replace it
-			existingSettings["prompt"] = onboardPrompt
+			existingSettings["prompt"] = primePrompt
 		}
 	} else {
-		// Add new prompt with onboard instruction
-		existingSettings["prompt"] = onboardPrompt
+		// Add new prompt with prime instruction
+		existingSettings["prompt"] = primePrompt
 	}
 
 	// Write updated settings
@@ -186,7 +191,7 @@ func setupClaudeSettings(verbose bool) error {
 	}
 
 	if verbose {
-		fmt.Printf("Configured Claude settings with bd onboard instruction\n")
+		fmt.Printf("Configured Claude settings with bd prime instruction\n")
 	}
 
 	return nil

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -428,8 +428,8 @@ func TestSetupClaudeSettings_InvalidJSON(t *testing.T) {
 		t.Error("Original file content should be preserved")
 	}
 
-	if strings.Contains(string(content), "bd onboard") {
-		t.Error("File should NOT contain bd onboard prompt after error")
+	if strings.Contains(string(content), "bd prime") {
+		t.Error("File should NOT contain bd prime prompt after error")
 	}
 }
 
@@ -476,8 +476,8 @@ func TestSetupClaudeSettings_ValidJSON(t *testing.T) {
 	contentStr := string(content)
 
 	// Should contain the new prompt
-	if !strings.Contains(contentStr, "bd onboard") {
-		t.Error("File should contain bd onboard prompt")
+	if !strings.Contains(contentStr, "bd prime") {
+		t.Error("File should contain bd prime prompt")
 	}
 
 	// Should preserve existing permissions
@@ -516,8 +516,8 @@ func TestSetupClaudeSettings_NoExistingFile(t *testing.T) {
 		t.Fatalf("Failed to read settings file: %v", err)
 	}
 
-	if !strings.Contains(string(content), "bd onboard") {
-		t.Error("File should contain bd onboard prompt")
+	if !strings.Contains(string(content), "bd prime") {
+		t.Error("File should contain bd prime prompt")
 	}
 }
 

--- a/internal/templates/agents/agents_test.go
+++ b/internal/templates/agents/agents_test.go
@@ -15,7 +15,7 @@ func TestEmbeddedDefault(t *testing.T) {
 	required := []string{
 		"# Agent Instructions",
 		"## Quick Reference",
-		"bd onboard",
+		"bd prime",
 		"BEGIN BEADS INTEGRATION",
 		"END BEADS INTEGRATION",
 		"## Session Completion",

--- a/internal/templates/agents/defaults/agents.md.tmpl
+++ b/internal/templates/agents/defaults/agents.md.tmpl
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

- Replace "Run `bd onboard` to get started" with "Run `bd prime` for full workflow context" in the AGENTS.md template and project AGENTS.md files
- Update Claude settings setup (`init_agent.go`) to inject `bd prime` instead of `bd onboard`, with backward-compatible migration of existing `bd onboard` references
- Update tests to match

Fixes #2902

## Context

`bd init` creates a complete AGENTS.md with a full Beads Integration section, then tells users to "Run `bd onboard` to get started." Running `bd onboard` suggests adding a *different*, shorter snippet to AGENTS.md — confusing users about which content is authoritative and whether onboard is even needed after init.

`bd prime` is the correct entry point: it provides dynamic workflow context and is what the Beads Integration section itself already references.

## Test plan

- [x] `go build ./cmd/bd/` compiles cleanly
- [x] `go test ./internal/templates/agents/ -run TestEmbedded` passes
- [x] `go test ./cmd/bd/ -run TestSetupClaudeSettings` passes
- [x] End-to-end: `bd init` in fresh repo produces AGENTS.md with `bd prime` (not `bd onboard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)