### PR TITLE
fix: suppress auto-backup address conflict warning when default backu…

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -591,6 +591,15 @@ func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	// Register as a backup remote (idempotent — remove first if exists).
 	_ = versioncontrolops.BackupRemove(ctx, s.db, backupName)
 	if err := versioncontrolops.BackupAdd(ctx, s.db, backupName, backupURL); err != nil {
+		// Another backup (e.g. "default" registered by `bd backup init`) may
+		// already point to this URL. In that case, sync using the existing
+		// remote name rather than failing.
+		if conflict := versioncontrolops.ExtractAddressConflictName(err); conflict != "" {
+			if syncErr := versioncontrolops.BackupSync(ctx, s.db, conflict); syncErr != nil {
+				return fmt.Errorf("sync to backup: %w", syncErr)
+			}
+			return nil
+		}
 		return fmt.Errorf("register backup remote: %w", err)
 	}
 	if err := versioncontrolops.BackupSync(ctx, s.db, backupName); err != nil {

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -290,6 +290,15 @@ func (s *EmbeddedDoltStore) BackupDatabase(ctx context.Context, dir string) erro
 		// Register as a backup remote (idempotent — remove first if exists).
 		_ = versioncontrolops.BackupRemove(ctx, db, backupName)
 		if err := versioncontrolops.BackupAdd(ctx, db, backupName, backupURL); err != nil {
+			// Another backup (e.g. "default" registered by `bd backup init`) may
+			// already point to this URL. In that case, sync using the existing
+			// remote name rather than failing.
+			if conflict := versioncontrolops.ExtractAddressConflictName(err); conflict != "" {
+				if syncErr := versioncontrolops.BackupSync(ctx, db, conflict); syncErr != nil {
+					return fmt.Errorf("sync to backup: %w", syncErr)
+				}
+				return nil
+			}
 			return fmt.Errorf("register backup remote: %w", err)
 		}
 		if err := versioncontrolops.BackupSync(ctx, db, backupName); err != nil {

--- a/internal/storage/versioncontrolops/backup.go
+++ b/internal/storage/versioncontrolops/backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // BackupAdd registers a Dolt backup destination.
@@ -53,4 +54,33 @@ func DirToFileURL(dir string) (string, error) {
 		return "", fmt.Errorf("resolve absolute path: %w", err)
 	}
 	return "file://" + abs, nil
+}
+
+// ExtractAddressConflictName parses the conflicting remote name from a Dolt
+// "address conflict with a remote" error.
+//
+// Dolt returns errors of the form:
+//
+//	Error 1105: address conflict with a remote: 'name' -> url
+//
+// When BackupAdd fails because another remote (e.g. "default", registered by
+// `bd backup init`) already points to the same URL, the caller can use the
+// conflicting name to sync directly rather than treating it as a hard error.
+// Returns "" if the error is not an address conflict.
+func ExtractAddressConflictName(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := err.Error()
+	const marker = "address conflict with a remote: '"
+	idx := strings.Index(s, marker)
+	if idx == -1 {
+		return ""
+	}
+	s = s[idx+len(marker):]
+	end := strings.Index(s, "'")
+	if end == -1 {
+		return ""
+	}
+	return s[:end]
 }


### PR DESCRIPTION
…p is configured

When a user runs `bd backup init <path>` it registers a Dolt backup named "default". The auto-backup system also calls BackupDatabase() which registers its own remote named "backup_export" pointing to the same .beads/backup/ directory. Dolt returns "Error 1105: address conflict with a remote: 'default'" because two remotes cannot share a URL, causing a noisy warning on every write:

  Warning: auto-backup failed: register backup remote: add backup backup_export: \
  Error 1105: address conflict with a remote: 'default' -> file://.../backup

Fix: when BackupAdd fails with an address conflict, extract the name of the already-registered remote from the error message and sync using that name instead. The backup still runs — it just reuses the existing remote.

Adds ExtractAddressConflictName() to versioncontrolops for parsing the conflicting name out of the Dolt error. Applies the fix to both the EmbeddedDoltStore and DoltStore implementations of BackupDatabase().