### PR TITLE
fix: adopt existing project_id when init --database targets shared server

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -587,8 +587,23 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Generate project identity UUID if not already set (GH#2372).
 			// This UUID is stored in both metadata.json and the database,
 			// and verified on every connection to detect cross-project leakage.
+			//
+			// When --database is specified and the database already exists on the
+			// server, adopt the existing project_id instead of generating a new
+			// one. This prevents identity mismatch when a second user joins a
+			// shared remote Dolt server. (GH#2922)
 			if cfg.ProjectID == "" {
-				cfg.ProjectID = configfile.GenerateProjectID()
+				if database != "" && store != nil {
+					if existingID, err := store.GetMetadata(ctx, "_project_id"); err == nil && existingID != "" {
+						cfg.ProjectID = existingID
+						if !quiet {
+							fmt.Printf("  %s Adopted project identity from existing database\n", ui.RenderPass("✓"))
+						}
+					}
+				}
+				if cfg.ProjectID == "" {
+					cfg.ProjectID = configfile.GenerateProjectID()
+				}
 			}
 
 			// Always store backend explicitly in metadata.json

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -2082,3 +2082,98 @@ func TestInitBackendFlag(t *testing.T) {
 		}
 	})
 }
+
+// TestInitDatabaseAdoptsExistingProjectID verifies that bd init --database adopts
+// the _project_id from an existing server database instead of generating a new one.
+// This prevents PROJECT IDENTITY MISMATCH errors when multiple users connect to
+// a shared remote Dolt server. (GH#2922)
+func TestInitDatabaseAdoptsExistingProjectID(t *testing.T) {
+	skipIfNoDolt(t)
+
+	// Reset global state
+	origDBPath := dbPath
+	origStore := store
+	defer func() {
+		if store != nil && store != origStore {
+			store.Close()
+		}
+		store = origStore
+		dbPath = origDBPath
+	}()
+	dbPath = ""
+	store = nil
+
+	ctx := context.Background()
+
+	// Create a database with a known _project_id (simulates first user's init)
+	database := uniqueTestDBName(t)
+	firstBeadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(firstBeadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	doltNewMutex.Lock()
+	firstStore, err := dolt.New(ctx, &dolt.Config{
+		Path:            filepath.Join(firstBeadsDir, "dolt"),
+		BeadsDir:        firstBeadsDir,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      testDoltServerPort,
+		Database:        database,
+		CreateIfMissing: true,
+	})
+	doltNewMutex.Unlock()
+	if err != nil {
+		t.Fatalf("create first store: %v", err)
+	}
+
+	knownProjectID := "test-known-project-id-gh2922"
+	if err := firstStore.SetMetadata(ctx, "_project_id", knownProjectID); err != nil {
+		t.Fatalf("set _project_id: %v", err)
+	}
+	if err := firstStore.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("set issue_prefix: %v", err)
+	}
+	firstStore.Close()
+
+	t.Cleanup(func() {
+		dropTestDatabase(database, testDoltServerPort)
+	})
+
+	// Simulate second user — init with --database pointing at the existing DB
+	secondDir := t.TempDir()
+	t.Chdir(secondDir)
+
+	// Set up minimal git repo (init expects it for repo_id)
+	if err := exec.Command("git", "-C", secondDir, "init").Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	_ = exec.Command("git", "-C", secondDir, "config", "user.email", "test@test.com").Run()
+	_ = exec.Command("git", "-C", secondDir, "config", "user.name", "Test").Run()
+
+	rootCmd.SetArgs([]string{
+		"init",
+		"--server",
+		"--server-host", "127.0.0.1",
+		"--server-port", fmt.Sprintf("%d", testDoltServerPort),
+		"--database", database,
+		"--prefix", "second",
+		"--quiet",
+		"--skip-hooks",
+		"--skip-agents",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("second init failed: %v", err)
+	}
+
+	// Verify the second user's metadata.json adopted the existing project_id
+	secondBeadsDir := filepath.Join(secondDir, ".beads")
+	cfg, err := configfile.Load(secondBeadsDir)
+	if err != nil {
+		t.Fatalf("load metadata.json: %v", err)
+	}
+
+	if cfg.ProjectID != knownProjectID {
+		t.Errorf("ProjectID = %q, want %q (should adopt existing project_id from server)", cfg.ProjectID, knownProjectID)
+	}
+}


### PR DESCRIPTION
When a second user runs `bd init --database` against an existing remote Dolt server, the init now reads `_project_id` from the server and adopts it instead of generating a new one. Prevents `PROJECT IDENTITY MISMATCH` errors in team workflows where multiple users share a remote Dolt database.

Follows the same pattern used in `backup_restore.go:syncProjectIDFromDB`.

Fixes #2922