### PR TITLE
fix: update workflow gates for org migration

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -84,7 +84,7 @@ jobs:
 
   deploy:
     # Guard: deploy should only run in the canonical repository (not in forks)
-    if: ${{ github.repository == 'steveyegge/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   goreleaser:
     # Guard: only run goreleaser in the canonical repository (not in forks)
-    if: ${{ github.repository == 'steveyegge/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
           version: '~> v2'
           args: >
             release --clean --parallelism 1
-            ${{ github.repository != 'steveyegge/beads' && '--skip=publish --skip=announce' || '' }}
+            ${{ github.repository != 'gastownhall/beads' && '--skip=publish --skip=announce' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Homebrew tap publishing (requires PAT with contents:write on homebrew-beads)
@@ -57,7 +57,7 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     needs: goreleaser
-    if: ${{ always() && github.repository == 'steveyegge/beads' }}
+    if: ${{ always() && github.repository == 'gastownhall/beads' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -86,7 +86,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: goreleaser
-    if: ${{ github.repository == 'steveyegge/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' }}
     permissions:
       contents: read
       id-token: write  # Required for npm provenance/trusted publishing

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test-publish:
     # Guard: only allow test PyPI publish runs in the canonical repository
-    if: ${{ github.repository == 'steveyegge/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Updates all `github.repository == 'steveyegge/beads'` guards to `'gastownhall/beads'` across 3 workflow files
- **release.yml**: 4 gates (goreleaser, goreleaser skip-publish fallback, publish-pypi, publish-npm)
- **deploy-docs.yml**: 1 gate (deploy job)
- **test-pypi.yml**: 1 gate (test-publish job)

Without this fix, releases, docs deploys, and package publishing silently skip after the org transfer.

## Test plan
- [ ] CI passes on this PR (workflow YAML is valid)
- [ ] Verify release workflow would fire on next tag push (gate evaluates true)
- [ ] Verify deploy-docs would fire on website changes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)