### PR TITLE
fix: unwrap HookFiringStore before optional interface assertions

### DIFF
--- a/cmd/bd/backup_auto.go
+++ b/cmd/bd/backup_auto.go
@@ -38,7 +38,7 @@ func maybeAutoBackup(ctx context.Context) {
 	if store == nil {
 		return
 	}
-	if lm, ok := store.(storage.LifecycleManager); ok && lm.IsClosed() {
+	if lm, ok := storage.UnwrapStore(store).(storage.LifecycleManager); ok && lm.IsClosed() {
 		return
 	}
 

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -55,7 +55,7 @@ After adding, run 'bd backup sync' to push your data.`,
 		// DoltHub URLs are passed through as-is.
 		backupURL := resolveDoltBackupURL(rawPath)
 
-		bs, ok := store.(storage.BackupStore)
+		bs, ok := storage.UnwrapStore(store).(storage.BackupStore)
 		if !ok {
 			return fmt.Errorf("storage backend does not support backup operations")
 		}
@@ -113,13 +113,13 @@ Run 'bd backup init <path>' first to configure a destination.`,
 			return fmt.Errorf("no store available")
 		}
 
-		bs, ok := store.(storage.BackupStore)
+		bs, ok := storage.UnwrapStore(store).(storage.BackupStore)
 		if !ok {
 			return fmt.Errorf("storage backend does not support backup operations")
 		}
 
 		// First, commit any pending changes so they're included in the backup
-		committer, ok := store.(storage.PendingCommitter)
+		committer, ok := storage.UnwrapStore(store).(storage.PendingCommitter)
 		if !ok {
 			return fmt.Errorf("storage backend does not support pending commits")
 		}
@@ -396,7 +396,7 @@ backup configuration. The backup data at the destination is not deleted.`,
 			return fmt.Errorf("no store available")
 		}
 
-		bs, ok := store.(storage.BackupStore)
+		bs, ok := storage.UnwrapStore(store).(storage.BackupStore)
 		if !ok {
 			return fmt.Errorf("storage backend does not support backup operations")
 		}

--- a/cmd/bd/backup_export.go
+++ b/cmd/bd/backup_export.go
@@ -133,7 +133,7 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 		}
 	}
 
-	bs, ok := store.(storage.BackupStore)
+	bs, ok := storage.UnwrapStore(store).(storage.BackupStore)
 	if !ok {
 		return nil, fmt.Errorf("storage backend does not support backup operations")
 	}

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -69,7 +69,7 @@ func runBackupRestore(ctx context.Context, s storage.DoltStorage, dir string, fo
 		return fmt.Errorf("database is not initialized. Run 'bd init' first")
 	}
 
-	bs, ok := s.(storage.BackupStore)
+	bs, ok := storage.UnwrapStore(s).(storage.BackupStore)
 	if !ok {
 		return fmt.Errorf("storage backend does not support backup operations")
 	}

--- a/cmd/bd/compact_dolt.go
+++ b/cmd/bd/compact_dolt.go
@@ -163,7 +163,7 @@ Examples:
 				oldCommits, len(recentHashes))
 		}
 
-		compactor, ok := store.(storage.Compactor)
+		compactor, ok := storage.UnwrapStore(store).(storage.Compactor)
 		if !ok {
 			FatalError("storage backend does not support compact")
 		}
@@ -173,7 +173,7 @@ Examples:
 		}
 
 		// Reclaim disk space from orphaned old history
-		if gc, ok := store.(storage.GarbageCollector); ok {
+		if gc, ok := storage.UnwrapStore(store).(storage.GarbageCollector); ok {
 			if err := gc.DoltGC(ctx); err != nil {
 				WarnError("dolt gc after compact failed: %v", err)
 			}

--- a/cmd/bd/doctor/migration_validation.go
+++ b/cmd/bd/doctor/migration_validation.go
@@ -537,7 +537,7 @@ func categorizeDoltExtras(ctx context.Context, store storage.DoltStorage, jsonlI
 	localPrefix, _ := store.GetConfig(ctx, "issue_prefix") // Best effort: empty prefix means no prefix-based validation
 
 	// Query all issue IDs from Dolt
-	accessor, ok := store.(storage.RawDBAccessor)
+	accessor, ok := storage.UnwrapStore(store).(storage.RawDBAccessor)
 	if !ok {
 		return 0, nil, 0
 	}

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -264,7 +264,7 @@ For more options (--stdin, custom messages), see: bd vc commit`,
 		if msg == "" {
 			// No explicit message — use CommitPending which generates a
 			// descriptive summary of accumulated changes.
-			pc, ok := st.(storage.PendingCommitter)
+			pc, ok := storage.UnwrapStore(st).(storage.PendingCommitter)
 			if !ok {
 				fmt.Fprintf(os.Stderr, "Error: storage backend does not support pending commits\n")
 				os.Exit(1)
@@ -621,7 +621,7 @@ var doltRemoteAddCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		name, url := args[0], args[1]
-		locator, ok := st.(storage.StoreLocator)
+		locator, ok := storage.UnwrapStore(st).(storage.StoreLocator)
 		if !ok {
 			fmt.Fprintf(os.Stderr, "Error: storage backend does not support store location\n")
 			os.Exit(1)
@@ -713,7 +713,7 @@ var doltRemoteListCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Error: no store available\n")
 			os.Exit(1)
 		}
-		locator, ok := st.(storage.StoreLocator)
+		locator, ok := storage.UnwrapStore(st).(storage.StoreLocator)
 		if !ok {
 			fmt.Fprintf(os.Stderr, "Error: storage backend does not support store location\n")
 			os.Exit(1)
@@ -833,7 +833,7 @@ var doltRemoteRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		name := args[0]
-		locator, ok := st.(storage.StoreLocator)
+		locator, ok := storage.UnwrapStore(st).(storage.StoreLocator)
 		if !ok {
 			fmt.Fprintf(os.Stderr, "Error: storage backend does not support store location\n")
 			os.Exit(1)

--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -54,7 +54,7 @@ func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
 	if st == nil {
 		return nil
 	}
-	if lm, ok := st.(storage.LifecycleManager); ok && lm.IsClosed() {
+	if lm, ok := storage.UnwrapStore(st).(storage.LifecycleManager); ok && lm.IsClosed() {
 		return nil
 	}
 

--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -73,7 +73,7 @@ func isDoltAutoPushEnabled(ctx context.Context) bool {
 	if st == nil {
 		return false
 	}
-	if lm, ok := st.(storage.LifecycleManager); ok && lm.IsClosed() {
+	if lm, ok := storage.UnwrapStore(st).(storage.LifecycleManager); ok && lm.IsClosed() {
 		return false
 	}
 	has, err := st.HasRemote(ctx, "origin")
@@ -99,7 +99,7 @@ func maybeAutoPush(ctx context.Context) {
 	if st == nil {
 		return
 	}
-	if lm, ok := st.(storage.LifecycleManager); ok && lm.IsClosed() {
+	if lm, ok := storage.UnwrapStore(st).(storage.LifecycleManager); ok && lm.IsClosed() {
 		return
 	}
 

--- a/cmd/bd/edit.go
+++ b/cmd/bd/edit.go
@@ -151,7 +151,7 @@ Examples:
 		if err != nil {
 			// Connection may have gone stale while the editor was open.
 			// Ping to force the pool to discard dead connections, then retry.
-			if accessor, ok := issueStore.(storage.RawDBAccessor); ok {
+			if accessor, ok := storage.UnwrapStore(issueStore).(storage.RawDBAccessor); ok {
 				if pingErr := accessor.DB().PingContext(ctx); pingErr != nil {
 					// Ping failed — try to force a fresh connection via sql.DB pool reset.
 					accessor.DB().SetConnMaxIdleTime(0)

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -43,7 +43,7 @@ func maybeAutoExport(ctx context.Context) {
 	if store == nil {
 		return
 	}
-	if lm, ok := store.(storage.LifecycleManager); ok && lm.IsClosed() {
+	if lm, ok := storage.UnwrapStore(store).(storage.LifecycleManager); ok && lm.IsClosed() {
 		return
 	}
 

--- a/cmd/bd/flatten.go
+++ b/cmd/bd/flatten.go
@@ -45,7 +45,7 @@ Examples:
 		ctx := rootCtx
 		start := time.Now()
 
-		flattener, ok := store.(storage.Flattener)
+		flattener, ok := storage.UnwrapStore(store).(storage.Flattener)
 		if !ok {
 			FatalError("storage backend does not support flatten")
 		}
@@ -114,7 +114,7 @@ Examples:
 		}
 
 		// Reclaim disk space from the now-orphaned old history.
-		if gc, ok := store.(storage.GarbageCollector); ok {
+		if gc, ok := storage.UnwrapStore(store).(storage.GarbageCollector); ok {
 			if err := gc.DoltGC(ctx); err != nil {
 				WarnError("dolt gc after flatten failed: %v", err)
 			}

--- a/cmd/bd/gc.go
+++ b/cmd/bd/gc.go
@@ -176,7 +176,7 @@ Examples:
 				fmt.Println("Phase 3/3: Dolt GC (reclaim disk space)")
 			}
 
-			gc, ok := store.(storage.GarbageCollector)
+			gc, ok := storage.UnwrapStore(store).(storage.GarbageCollector)
 			if !ok {
 				if !jsonOutput {
 					fmt.Println("  Storage backend does not support GC, skipping")

--- a/cmd/bd/notion.go
+++ b/cmd/bd/notion.go
@@ -620,7 +620,7 @@ func saveNotionTargetConfig(ctx context.Context, dataSourceID, viewURL string) e
 	}
 	viewURL = strings.TrimSpace(viewURL)
 	if viewURL == "" {
-		deleter, ok := store.(storage.ConfigMetadataStore)
+		deleter, ok := storage.UnwrapStore(store).(storage.ConfigMetadataStore)
 		if !ok {
 			return fmt.Errorf("store does not support config deletion")
 		}

--- a/cmd/bd/sql.go
+++ b/cmd/bd/sql.go
@@ -42,7 +42,7 @@ WARNING: Direct database access bypasses the storage layer. Use with caution.`,
 			FatalErrorRespectJSON("no database connection available (%s)", diagHint())
 		}
 
-		accessor, ok := store.(storage.RawDBAccessor)
+		accessor, ok := storage.UnwrapStore(store).(storage.RawDBAccessor)
 		if !ok {
 			FatalErrorRespectJSON("storage backend does not support raw DB access")
 		}

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -44,6 +44,18 @@ func NewHookFiringStore(store DoltStorage, runner *hooks.Runner) *HookFiringStor
 // (e.g., StoreLocator, RawDBAccessor).
 func (h *HookFiringStore) Inner() DoltStorage { return h.inner }
 
+// UnwrapStore returns the underlying concrete store if s is a
+// HookFiringStore decorator, otherwise returns s unchanged.
+// Use this before type assertions to optional interfaces
+// (StoreLocator, BackupStore, Flattener, etc.) so the assertion
+// reaches the concrete store rather than the decorator.
+func UnwrapStore(s DoltStorage) DoltStorage {
+	if h, ok := s.(*HookFiringStore); ok {
+		return h.inner
+	}
+	return s
+}
+
 // ── Issue mutations ─────────────────────────────────────────────────
 
 // CreateIssue creates an issue and fires on_create.


### PR DESCRIPTION
## Summary
- Fixes regression from #2891 where `HookFiringStore` decorator hid optional interfaces (`StoreLocator`, `BackupStore`, `Flattener`, `Compactor`, etc.) from type assertions
- All embedded Dolt tests for flatten, backup, compact, dolt remote ops were failing with "storage backend does not support X"
- Adds `storage.UnwrapStore()` helper and applies it at all 24 type-assertion callsites

## Test plan
- [ ] All embedded Dolt CI shards pass (flatten, backup, compact, dolt remote)
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] No regression in non-embedded tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)