### PR TITLE
feat: add --non-interactive flag to bd bootstrap for CI

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -38,13 +38,23 @@ This is the recommended command for:
   • Recovering after moving to a new machine
   • Repairing a broken database configuration
 
+Non-interactive mode (--non-interactive, --yes/-y, or BD_NON_INTERACTIVE=1):
+  Skips the confirmation prompt before executing the bootstrap plan.
+  Also auto-detected when stdin is not a terminal or CI=true is set.
+
 Examples:
   bd bootstrap              # Auto-detect and set up
   bd bootstrap --dry-run    # Show what would be done
   bd bootstrap --json       # Output plan as JSON
+  bd bootstrap --yes        # Skip confirmation prompt
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		nonInteractiveFlag, _ := cmd.Flags().GetBool("non-interactive")
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+
+		// Resolve non-interactive mode: flag > env var > CI env > terminal detection.
+		nonInteractive := isNonInteractiveBootstrap(nonInteractiveFlag || yesFlag)
 
 		// Find beads directory
 		beadsDir := beads.FindBeadsDir()
@@ -109,7 +119,7 @@ Examples:
 		}
 
 		// Execute the plan
-		if err := executeBootstrapPlan(plan, cfg); err != nil {
+		if err := executeBootstrapPlan(plan, cfg, nonInteractive); err != nil {
 			FatalError("Bootstrap failed: %v", err)
 		}
 	},
@@ -222,9 +232,12 @@ func printBootstrapPlan(plan BootstrapPlan) {
 	}
 }
 
-// confirmPrompt asks the user to confirm an action. Returns true if the user
-// confirms or if stdin is not a terminal (non-interactive/CI contexts).
-func confirmPrompt(message string) bool {
+// confirmPrompt asks the user to confirm an action. Returns true if
+// nonInteractive is set, stdin is not a terminal, or the user confirms.
+func confirmPrompt(message string, nonInteractive bool) bool {
+	if nonInteractive {
+		return true
+	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return true
 	}
@@ -235,8 +248,8 @@ func confirmPrompt(message string) bool {
 	return line == "" || line == "y" || line == "yes"
 }
 
-func executeBootstrapPlan(plan BootstrapPlan, cfg *configfile.Config) error {
-	if !confirmPrompt("Proceed?") {
+func executeBootstrapPlan(plan BootstrapPlan, cfg *configfile.Config, nonInteractive bool) error {
+	if !confirmPrompt("Proceed?", nonInteractive) {
 		fmt.Fprintf(os.Stderr, "Aborted.\n")
 		return nil
 	}
@@ -412,7 +425,24 @@ func inferPrefix(cfg *configfile.Config) string {
 	return filepath.Base(cwd)
 }
 
+// isNonInteractiveBootstrap returns true if bootstrap should skip confirmation prompts.
+// Precedence: explicit flag > BD_NON_INTERACTIVE env > CI env > terminal detection.
+func isNonInteractiveBootstrap(flagValue bool) bool {
+	if flagValue {
+		return true
+	}
+	if v := os.Getenv("BD_NON_INTERACTIVE"); v == "1" || v == "true" {
+		return true
+	}
+	if v := os.Getenv("CI"); v == "true" || v == "1" {
+		return true
+	}
+	return !term.IsTerminal(int(os.Stdin.Fd()))
+}
+
 func init() {
 	bootstrapCmd.Flags().Bool("dry-run", false, "Show what would be done without doing it")
+	bootstrapCmd.Flags().BoolP("non-interactive", "y", false, "Skip confirmation prompt (auto-detected in CI or non-TTY environments)")
+	bootstrapCmd.Flags().Bool("yes", false, "Alias for --non-interactive")
 	rootCmd.AddCommand(bootstrapCmd)
 }

--- a/cmd/bd/bootstrap_noninteractive_test.go
+++ b/cmd/bd/bootstrap_noninteractive_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestIsNonInteractiveBootstrap tests the non-interactive detection logic for bootstrap.
+func TestIsNonInteractiveBootstrap(t *testing.T) {
+	origCI := os.Getenv("CI")
+	origBDNI := os.Getenv("BD_NON_INTERACTIVE")
+	defer func() {
+		os.Setenv("CI", origCI)
+		os.Setenv("BD_NON_INTERACTIVE", origBDNI)
+	}()
+
+	tests := []struct {
+		name      string
+		flagValue bool
+		envCI     string
+		envBDNI   string
+		want      bool
+	}{
+		{
+			name:      "flag true overrides everything",
+			flagValue: true,
+			envCI:     "",
+			envBDNI:   "",
+			want:      true,
+		},
+		{
+			name:      "BD_NON_INTERACTIVE=1",
+			flagValue: false,
+			envCI:     "",
+			envBDNI:   "1",
+			want:      true,
+		},
+		{
+			name:      "BD_NON_INTERACTIVE=true",
+			flagValue: false,
+			envCI:     "",
+			envBDNI:   "true",
+			want:      true,
+		},
+		{
+			name:      "CI=true",
+			flagValue: false,
+			envCI:     "true",
+			envBDNI:   "",
+			want:      true,
+		},
+		{
+			name:      "CI=1",
+			flagValue: false,
+			envCI:     "1",
+			envBDNI:   "",
+			want:      true,
+		},
+		{
+			name:      "no flag no env falls back to terminal detection",
+			flagValue: false,
+			envCI:     "",
+			envBDNI:   "",
+			// In test environment, stdin is piped (not a TTY), so non-interactive
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("CI", tt.envCI)
+			os.Setenv("BD_NON_INTERACTIVE", tt.envBDNI)
+
+			got := isNonInteractiveBootstrap(tt.flagValue)
+			if got != tt.want {
+				t.Errorf("isNonInteractiveBootstrap(%v) with CI=%q BD_NON_INTERACTIVE=%q = %v, want %v",
+					tt.flagValue, tt.envCI, tt.envBDNI, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsNonInteractiveBootstrapPrecedence tests that flag takes precedence over env vars.
+func TestIsNonInteractiveBootstrapPrecedence(t *testing.T) {
+	origCI := os.Getenv("CI")
+	origBDNI := os.Getenv("BD_NON_INTERACTIVE")
+	defer func() {
+		os.Setenv("CI", origCI)
+		os.Setenv("BD_NON_INTERACTIVE", origBDNI)
+	}()
+
+	// Flag true should always win
+	os.Setenv("CI", "")
+	os.Setenv("BD_NON_INTERACTIVE", "")
+	if !isNonInteractiveBootstrap(true) {
+		t.Error("flag=true should always return true regardless of env")
+	}
+
+	// BD_NON_INTERACTIVE should take precedence over CI
+	os.Setenv("BD_NON_INTERACTIVE", "1")
+	os.Setenv("CI", "")
+	if !isNonInteractiveBootstrap(false) {
+		t.Error("BD_NON_INTERACTIVE=1 should return true")
+	}
+}
+
+// TestConfirmPromptNonInteractive verifies that confirmPrompt returns true
+// when nonInteractive is set, without reading stdin.
+func TestConfirmPromptNonInteractive(t *testing.T) {
+	if !confirmPrompt("Proceed?", true) {
+		t.Error("confirmPrompt should return true when nonInteractive=true")
+	}
+}


### PR DESCRIPTION
## Summary

Add `--non-interactive` / `--yes` / `-y` flag to `bd bootstrap`, matching the pattern already used by `bd init`. Also supports `BD_NON_INTERACTIVE=1` environment variable.

## Changes
- Add `--non-interactive` flag (with `--yes` and `-y` aliases) to bootstrap command
- Support `BD_NON_INTERACTIVE=1` and `CI=true` env vars for CI
- Update `confirmPrompt()` to accept non-interactive parameter
- Add `isNonInteractiveBootstrap()` with same precedence as init: flag > env > CI > TTY detection
- Add tests for non-interactive behavior

Fixes harry-miller-trimble/beads#19
Bead: bd-2qj