### PR TITLE
feat: add bd config set-many for batch config operations

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -522,8 +522,130 @@ func findBeadsRepoRoot(startPath string) string {
 	}
 }
 
+var configSetManyCmd = &cobra.Command{
+	Use:   "set-many <key=value>...",
+	Short: "Set multiple configuration values in one operation",
+	Long: `Set multiple configuration values at once with a single auto-commit and auto-push.
+
+Each argument must be in key=value format. All values are validated before
+any writes occur. This is faster and less noisy than separate 'bd config set'
+calls, especially in CI.
+
+Examples:
+  bd config set-many ado.state_map.open=New ado.state_map.closed=Closed
+  bd config set-many jira.url=https://example.atlassian.net jira.project=PROJ`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(_ *cobra.Command, args []string) {
+		// Phase 1: Parse all key=value pairs
+		type kvPair struct {
+			key, value string
+		}
+		pairs := make([]kvPair, 0, len(args))
+		for _, arg := range args {
+			idx := strings.Index(arg, "=")
+			if idx <= 0 {
+				fmt.Fprintf(os.Stderr, "Error: invalid argument %q (expected key=value format)\n", arg)
+				os.Exit(1)
+			}
+			pairs = append(pairs, kvPair{key: arg[:idx], value: arg[idx+1:]})
+		}
+
+		// Phase 2: Validate all pairs before writing any
+		for _, p := range pairs {
+			if p.key == "beads.role" {
+				validRoles := map[string]bool{"maintainer": true, "contributor": true}
+				if !validRoles[p.value] {
+					fmt.Fprintf(os.Stderr, "Error: invalid role %q (valid values: maintainer, contributor)\n", p.value)
+					os.Exit(1)
+				}
+			}
+			if p.key == "status.custom" && p.value != "" {
+				if _, err := types.ParseCustomStatusConfig(p.value); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: invalid status.custom value: %v\n", err)
+					os.Exit(1)
+				}
+			}
+		}
+
+		// Phase 3: Separate into categories
+		var yamlPairs, gitPairs, dbPairs []kvPair
+		for _, p := range pairs {
+			if config.IsYamlOnlyKey(p.key) {
+				yamlPairs = append(yamlPairs, p)
+			} else if p.key == "beads.role" {
+				gitPairs = append(gitPairs, p)
+			} else {
+				dbPairs = append(dbPairs, p)
+			}
+		}
+
+		// Phase 4: Write yaml-only keys
+		for _, p := range yamlPairs {
+			if err := config.SetYamlConfig(p.key, p.value); err != nil {
+				fmt.Fprintf(os.Stderr, "Error setting config %s: %v\n", p.key, err)
+				os.Exit(1)
+			}
+		}
+
+		// Phase 5: Write git config keys
+		for _, p := range gitPairs {
+			cmd := exec.Command("git", "config", "beads.role", p.value) //nolint:gosec // value is validated against allowlist above
+			if err := cmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error setting %s in git config: %v\n", p.key, err)
+				os.Exit(1)
+			}
+		}
+
+		// Phase 6: Write DB keys in batch
+		if len(dbPairs) > 0 {
+			if err := ensureDirectMode("config set-many requires direct database access"); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+
+			ctx := rootCtx
+			for _, p := range dbPairs {
+				if err := store.SetConfig(ctx, p.key, p.value); err != nil {
+					fmt.Fprintf(os.Stderr, "Error setting config %s: %v\n", p.key, err)
+					os.Exit(1)
+				}
+			}
+		}
+
+		// Phase 7: Output results
+		if jsonOutput {
+			results := make([]map[string]string, 0, len(pairs))
+			for _, p := range pairs {
+				location := "database"
+				if config.IsYamlOnlyKey(p.key) {
+					location = "config.yaml"
+				} else if p.key == "beads.role" {
+					location = "git config"
+				}
+				results = append(results, map[string]string{
+					"key":      p.key,
+					"value":    p.value,
+					"location": location,
+				})
+			}
+			outputJSON(results)
+		} else {
+			for _, p := range pairs {
+				location := ""
+				if config.IsYamlOnlyKey(p.key) {
+					location = " (in config.yaml)"
+				} else if p.key == "beads.role" {
+					location = " (in git config)"
+				}
+				fmt.Printf("Set %s = %s%s\n", p.key, p.value, location)
+			}
+		}
+	},
+}
+
 func init() {
 	configCmd.AddCommand(configSetCmd)
+	configCmd.AddCommand(configSetManyCmd)
 	configCmd.AddCommand(configGetCmd)
 	configCmd.AddCommand(configListCmd)
 	configCmd.AddCommand(configUnsetCmd)

--- a/cmd/bd/config_setmany_test.go
+++ b/cmd/bd/config_setmany_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// TestConfigSetManyArgParsing tests argument parsing for the set-many command.
+func TestConfigSetManyArgParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantKey string
+		wantVal string
+		wantErr bool
+	}{
+		{"simple", "key=value", "key", "value", false},
+		{"dotted key", "ado.state_map.open=New", "ado.state_map.open", "New", false},
+		{"value with equals", "key=val=ue", "key", "val=ue", false},
+		{"empty value", "key=", "key", "", false},
+		{"no equals", "keyvalue", "", "", true},
+		{"only equals", "=value", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := strings.Index(tt.arg, "=")
+			if idx <= 0 {
+				if !tt.wantErr {
+					t.Error("expected successful parse, got error")
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Error("expected error, got successful parse")
+				return
+			}
+			key := tt.arg[:idx]
+			value := tt.arg[idx+1:]
+			if key != tt.wantKey {
+				t.Errorf("key = %q, want %q", key, tt.wantKey)
+			}
+			if value != tt.wantVal {
+				t.Errorf("value = %q, want %q", value, tt.wantVal)
+			}
+		})
+	}
+}
+
+// TestConfigSetManyYamlKeyDetection tests that yaml-only keys are correctly identified
+// for routing in the set-many command.
+func TestConfigSetManyYamlKeyDetection(t *testing.T) {
+	yamlKeys := []string{"no-db", "json", "routing.mode", "routing.default", "no-push"}
+	for _, key := range yamlKeys {
+		if !config.IsYamlOnlyKey(key) {
+			t.Errorf("expected %q to be yaml-only", key)
+		}
+	}
+
+	dbKeys := []string{"ado.state_map.open", "jira.url", "status.custom", "test.key"}
+	for _, key := range dbKeys {
+		if config.IsYamlOnlyKey(key) {
+			t.Errorf("expected %q to NOT be yaml-only", key)
+		}
+	}
+}

--- a/cmd/bd/config_test.go
+++ b/cmd/bd/config_test.go
@@ -575,3 +575,90 @@ func TestCustomStatusConfig(t *testing.T) {
 		}
 	})
 }
+
+// TestConfigSetMany tests the batch config set functionality used by 'bd config set-many'.
+func TestConfigSetMany(t *testing.T) {
+	ctx := context.Background()
+	store, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	t.Run("batch set multiple DB keys", func(t *testing.T) {
+		pairs := map[string]string{
+			"ado.state_map.open":        "New",
+			"ado.state_map.in_progress": "Active",
+			"ado.state_map.closed":      "Closed",
+		}
+		for k, v := range pairs {
+			if err := store.SetConfig(ctx, k, v); err != nil {
+				t.Fatalf("SetConfig(%s) failed: %v", k, err)
+			}
+		}
+
+		// Verify all values were set correctly
+		for k, expected := range pairs {
+			got, err := store.GetConfig(ctx, k)
+			if err != nil {
+				t.Fatalf("GetConfig(%s) failed: %v", k, err)
+			}
+			if got != expected {
+				t.Errorf("GetConfig(%s) = %q, want %q", k, got, expected)
+			}
+		}
+
+		// Verify they appear in GetAllConfig
+		all, err := store.GetAllConfig(ctx)
+		if err != nil {
+			t.Fatalf("GetAllConfig failed: %v", err)
+		}
+		for k, expected := range pairs {
+			if all[k] != expected {
+				t.Errorf("GetAllConfig[%s] = %q, want %q", k, all[k], expected)
+			}
+		}
+	})
+
+	t.Run("batch set overwrites existing values", func(t *testing.T) {
+		// Set initial values
+		if err := store.SetConfig(ctx, "test.batch.a", "old-a"); err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		if err := store.SetConfig(ctx, "test.batch.b", "old-b"); err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+
+		// Overwrite with batch
+		updates := map[string]string{
+			"test.batch.a": "new-a",
+			"test.batch.b": "new-b",
+			"test.batch.c": "new-c",
+		}
+		for k, v := range updates {
+			if err := store.SetConfig(ctx, k, v); err != nil {
+				t.Fatalf("SetConfig(%s) failed: %v", k, err)
+			}
+		}
+
+		for k, expected := range updates {
+			got, err := store.GetConfig(ctx, k)
+			if err != nil {
+				t.Fatalf("GetConfig(%s) failed: %v", k, err)
+			}
+			if got != expected {
+				t.Errorf("GetConfig(%s) = %q, want %q", k, got, expected)
+			}
+		}
+	})
+
+	t.Run("batch set with empty value", func(t *testing.T) {
+		if err := store.SetConfig(ctx, "test.empty", ""); err != nil {
+			t.Fatalf("SetConfig failed: %v", err)
+		}
+		got, err := store.GetConfig(ctx, "test.empty")
+		if err != nil {
+			t.Fatalf("GetConfig failed: %v", err)
+		}
+		if got != "" {
+			t.Errorf("expected empty string, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Add `bd config set-many` command that accepts multiple `key=value` pairs and writes them in a single operation with one auto-commit and one auto-push.

## Usage
```bash
bd config set-many ado.state_map.open=New ado.state_map.in_progress=Active ado.state_map.closed=Closed
```

## Changes
- Add `config set-many` subcommand accepting `key=value` pairs
- Single process invocation, single auto-commit, single auto-push
- Validates all pairs before writing any (fail-fast)
- Supports yaml-only keys, git config keys, and DB keys
- Add `--json` flag support
- Add tests for argument parsing and key categorization

Fixes harry-miller-trimble/beads#22
Bead: bd-04w