### PR TITLE
fix(ado): apply --types/--states/--no-create filters to push operations

### DIFF
--- a/cmd/bd/ado.go
+++ b/cmd/bd/ado.go
@@ -52,8 +52,11 @@ By default, performs bidirectional sync:
 
 Use --pull-only or --push-only to limit direction.
 
-Pull filters (--area-path, --iteration-path, --types, --states) restrict
-which ADO work items are fetched. Filters can also be persisted via config:
+Filters (--area-path, --iteration-path, --types, --states) restrict
+which work items are synced. On pull, they limit the WIQL query. On push,
+--types and --states filter local beads before pushing to ADO. Use
+--no-create with push to skip creating new ADO work items (only update
+existing linked items). Filters can also be persisted via config:
   ado.filter.area_path, ado.filter.iteration_path,
   ado.filter.types, ado.filter.states
 CLI flags override config values when both are set.`,
@@ -150,7 +153,7 @@ func init() {
 
 	// Additional sync options
 	adoSyncCmd.Flags().BoolVar(&adoBootstrapMatch, "bootstrap-match", false, "Enable heuristic matching for first sync")
-	adoSyncCmd.Flags().BoolVar(&adoNoCreate, "no-create", false, "Pull-only mode: never create issues in ADO")
+	adoSyncCmd.Flags().BoolVar(&adoNoCreate, "no-create", false, "Never create new items in either direction (pull or push)")
 	adoSyncCmd.Flags().BoolVar(&adoReconcile, "reconcile", false, "Force reconciliation scan for deleted items")
 
 	// Pull filter flags (override config keys ado.filter.*)
@@ -521,6 +524,9 @@ func runADOSync(cmd *cobra.Command, _ []string) error {
 	var bootstrapMatched int
 	engine.PullHooks = buildADOPullHooks(ctx, at, adoBootstrapMatch, adoNoCreate, &bootstrapMatched, engine.OnWarning)
 
+	// Set up ADO-specific push hooks (type/state/no-create filtering for push)
+	engine.PushHooks = buildADOPushHooks(at.FieldMapper(), at.IsExternalRef, filters, adoNoCreate)
+
 	// Build sync options from CLI flags
 	pull := !adoSyncPushOnly
 	push := !adoSyncPullOnly
@@ -880,4 +886,51 @@ func buildADOPullHooks(ctx context.Context, at *ado.Tracker, bootstrapMatch, noC
 	}
 
 	return hooks
+}
+
+// buildADOPushHooks creates PushHooks for ADO-specific push filtering.
+// When --types or --states are set, local beads are filtered before pushing
+// to ADO by mapping the ADO filter values to beads types/statuses.
+// When noCreate is true, only issues already linked to ADO work items
+// are pushed (no new work items are created).
+func buildADOPushHooks(mapper tracker.FieldMapper, isExternalRef func(string) bool, filters *ado.PullFilters, noCreate bool) *tracker.PushHooks {
+	var allowedTypes map[types.IssueType]bool
+	var allowedStatuses map[types.Status]bool
+
+	if filters != nil && len(filters.WorkItemTypes) > 0 {
+		allowedTypes = make(map[types.IssueType]bool, len(filters.WorkItemTypes))
+		for _, adoType := range filters.WorkItemTypes {
+			beadsType := mapper.TypeToBeads(adoType)
+			allowedTypes[beadsType] = true
+		}
+	}
+
+	if filters != nil && len(filters.States) > 0 {
+		allowedStatuses = make(map[types.Status]bool, len(filters.States))
+		for _, adoState := range filters.States {
+			beadsStatus := mapper.StatusToBeads(adoState)
+			allowedStatuses[beadsStatus] = true
+		}
+	}
+
+	if allowedTypes == nil && allowedStatuses == nil && !noCreate {
+		return nil
+	}
+
+	return &tracker.PushHooks{
+		ShouldPush: func(issue *types.Issue) bool {
+			if allowedTypes != nil && !allowedTypes[issue.IssueType] {
+				return false
+			}
+			if allowedStatuses != nil && !allowedStatuses[issue.Status] {
+				return false
+			}
+			if noCreate {
+				if issue.ExternalRef == nil || *issue.ExternalRef == "" || !isExternalRef(*issue.ExternalRef) {
+					return false
+				}
+			}
+			return true
+		},
+	}
 }

--- a/cmd/bd/ado_test.go
+++ b/cmd/bd/ado_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/ado"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // adoStdioMutex serializes tests that redirect os.Stdout/os.Stderr.
@@ -865,3 +867,148 @@ func captureADOStdout(t *testing.T, fn func()) string {
 
 	return buf.String()
 }
+
+// TestBuildADOPushHooks_NoFilters verifies nil is returned when no filters are set.
+func TestBuildADOPushHooks_NoFilters(t *testing.T) {
+	mapper := ado.NewFieldMapper(nil, nil)
+	hooks := buildADOPushHooks(mapper, func(string) bool { return false }, nil, false)
+	if hooks != nil {
+		t.Error("expected nil PushHooks when no filters are set")
+	}
+}
+
+// TestBuildADOPushHooks_TypeFilter verifies --types filtering on push.
+func TestBuildADOPushHooks_TypeFilter(t *testing.T) {
+	mapper := ado.NewFieldMapper(nil, nil)
+	filters := &ado.PullFilters{WorkItemTypes: []string{"Bug", "Task"}}
+	hooks := buildADOPushHooks(mapper, func(string) bool { return false }, filters, false)
+	if hooks == nil || hooks.ShouldPush == nil {
+		t.Fatal("expected non-nil PushHooks with ShouldPush")
+	}
+
+	tests := []struct {
+		name     string
+		issueTyp types.IssueType
+		want     bool
+	}{
+		{"bug allowed", types.TypeBug, true},
+		{"task allowed", types.TypeTask, true},
+		{"feature excluded", types.TypeFeature, false},
+		{"epic excluded", types.TypeEpic, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &types.Issue{IssueType: tt.issueTyp, Status: types.StatusOpen}
+			if got := hooks.ShouldPush(issue); got != tt.want {
+				t.Errorf("ShouldPush(%s) = %v, want %v", tt.issueTyp, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildADOPushHooks_StateFilter verifies --states filtering on push.
+func TestBuildADOPushHooks_StateFilter(t *testing.T) {
+	mapper := ado.NewFieldMapper(nil, nil)
+	// "Active" maps to StatusInProgress, "New" maps to StatusOpen
+	filters := &ado.PullFilters{States: []string{"Active", "New"}}
+	hooks := buildADOPushHooks(mapper, func(string) bool { return false }, filters, false)
+	if hooks == nil || hooks.ShouldPush == nil {
+		t.Fatal("expected non-nil PushHooks with ShouldPush")
+	}
+
+	tests := []struct {
+		name   string
+		status types.Status
+		want   bool
+	}{
+		{"open allowed (maps from New)", types.StatusOpen, true},
+		{"in_progress allowed (maps from Active)", types.StatusInProgress, true},
+		{"closed excluded", types.StatusClosed, false},
+		{"deferred excluded", types.StatusDeferred, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &types.Issue{IssueType: types.TypeTask, Status: tt.status}
+			if got := hooks.ShouldPush(issue); got != tt.want {
+				t.Errorf("ShouldPush(status=%s) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildADOPushHooks_NoCreate verifies --no-create filtering on push.
+func TestBuildADOPushHooks_NoCreate(t *testing.T) {
+	mapper := ado.NewFieldMapper(nil, nil)
+	isADORef := func(ref string) bool {
+		return strings.Contains(ref, "dev.azure.com") || strings.Contains(ref, "_workitems/edit/")
+	}
+	hooks := buildADOPushHooks(mapper, isADORef, nil, true)
+	if hooks == nil || hooks.ShouldPush == nil {
+		t.Fatal("expected non-nil PushHooks with ShouldPush")
+	}
+
+	adoRef := "https://dev.azure.com/org/proj/_workitems/edit/123"
+	ghRef := "https://github.com/owner/repo/issues/1"
+
+	tests := []struct {
+		name string
+		ref  *string
+		want bool
+	}{
+		{"nil ref skipped", nil, false},
+		{"empty ref skipped", strPtr(""), false},
+		{"non-ADO ref skipped", &ghRef, false},
+		{"ADO ref allowed", &adoRef, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &types.Issue{IssueType: types.TypeTask, Status: types.StatusOpen, ExternalRef: tt.ref}
+			if got := hooks.ShouldPush(issue); got != tt.want {
+				t.Errorf("ShouldPush(ref=%v) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildADOPushHooks_Combined verifies combined type + state + no-create filters.
+func TestBuildADOPushHooks_Combined(t *testing.T) {
+	mapper := ado.NewFieldMapper(nil, nil)
+	isADORef := func(ref string) bool {
+		return strings.Contains(ref, "_workitems/edit/")
+	}
+	filters := &ado.PullFilters{
+		WorkItemTypes: []string{"Bug"},
+		States:        []string{"Active"},
+	}
+	hooks := buildADOPushHooks(mapper, isADORef, filters, true)
+	if hooks == nil || hooks.ShouldPush == nil {
+		t.Fatal("expected non-nil PushHooks with ShouldPush")
+	}
+
+	adoRef := "https://dev.azure.com/org/proj/_workitems/edit/42"
+
+	tests := []struct {
+		name     string
+		issueTyp types.IssueType
+		status   types.Status
+		ref      *string
+		want     bool
+	}{
+		{"bug+active+linked", types.TypeBug, types.StatusInProgress, &adoRef, true},
+		{"task+active+linked (wrong type)", types.TypeTask, types.StatusInProgress, &adoRef, false},
+		{"bug+closed+linked (wrong state)", types.TypeBug, types.StatusClosed, &adoRef, false},
+		{"bug+active+unlinked (no-create)", types.TypeBug, types.StatusInProgress, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &types.Issue{IssueType: tt.issueTyp, Status: tt.status, ExternalRef: tt.ref}
+			if got := hooks.ShouldPush(issue); got != tt.want {
+				t.Errorf("ShouldPush() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// strPtr returns a pointer to s. Duplicated locally so the test file
+// compiles without depending on internal/tracker (unexported helper).
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary

When using `--push-only`, the `--types`, `--states`, and `--no-create` filters were ignored because they only applied to pull operations. This change applies these filters to push operations as well.

## Changes
- Add push-side filtering for `--types` and `--states` flags
- Make `--no-create` apply to push operations (skip creating new ADO work items)
- Add tests for push-side filtering

Fixes harry-miller-trimble/beads#15
Bead: bd-2ks