### PR TITLE
fix: add missing //go:build cgo tags to fix non-CGO builds

### DIFF
--- a/cmd/bd/backup_embedded_test.go
+++ b/cmd/bd/backup_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/blocked_embedded_test.go
+++ b/cmd/bd/blocked_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/bootstrap_embedded_test.go
+++ b/cmd/bd/bootstrap_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/branch_embedded_test.go
+++ b/cmd/bd/branch_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/children_embedded_test.go
+++ b/cmd/bd/children_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/close_embedded_test.go
+++ b/cmd/bd/close_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/comment_promote_embedded_test.go
+++ b/cmd/bd/comment_promote_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/comments_cli_embedded_test.go
+++ b/cmd/bd/comments_cli_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/compact_embedded_test.go
+++ b/cmd/bd/compact_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/config_embedded_test.go
+++ b/cmd/bd/config_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/context_embedded_test.go
+++ b/cmd/bd/context_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/count_embedded_test.go
+++ b/cmd/bd/count_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/defer_embedded_test.go
+++ b/cmd/bd/defer_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/delete_embedded_test.go
+++ b/cmd/bd/delete_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/diff_embedded_test.go
+++ b/cmd/bd/diff_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/doctor/federation_test.go
+++ b/cmd/bd/doctor/federation_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package doctor
 
 import (

--- a/cmd/bd/doctor/fix/migrate_import_test.go
+++ b/cmd/bd/doctor/fix/migrate_import_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package fix
 
 import (

--- a/cmd/bd/dolt_embedded_test.go
+++ b/cmd/bd/dolt_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/duplicate_embedded_test.go
+++ b/cmd/bd/duplicate_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/duplicates_embedded_test.go
+++ b/cmd/bd/duplicates_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/epic_embedded_test.go
+++ b/cmd/bd/epic_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/export_embedded_test.go
+++ b/cmd/bd/export_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/find_duplicates_embedded_test.go
+++ b/cmd/bd/find_duplicates_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/flatten_embedded_test.go
+++ b/cmd/bd/flatten_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/gate_embedded_test.go
+++ b/cmd/bd/gate_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/gc_embedded_test.go
+++ b/cmd/bd/gc_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/graph_embedded_test.go
+++ b/cmd/bd/graph_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/history_embedded_test.go
+++ b/cmd/bd/history_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/hooks_embedded_test.go
+++ b/cmd/bd/hooks_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/human_embedded_test.go
+++ b/cmd/bd/human_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/import_embedded_test.go
+++ b/cmd/bd/import_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/info_embedded_test.go
+++ b/cmd/bd/info_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/kv_embedded_test.go
+++ b/cmd/bd/kv_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/label_embedded_test.go
+++ b/cmd/bd/label_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/lint_embedded_test.go
+++ b/cmd/bd/lint_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/memory_embedded_test.go
+++ b/cmd/bd/memory_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/metadata_filter_test.go
+++ b/cmd/bd/metadata_filter_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/migrate_embedded_test.go
+++ b/cmd/bd/migrate_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/onboard_embedded_test.go
+++ b/cmd/bd/onboard_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/orphans_embedded_test.go
+++ b/cmd/bd/orphans_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/prime_embedded_test.go
+++ b/cmd/bd/prime_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/promote_embedded_test.go
+++ b/cmd/bd/promote_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/purge_embedded_test.go
+++ b/cmd/bd/purge_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/query_embedded_test.go
+++ b/cmd/bd/query_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/quick_embedded_test.go
+++ b/cmd/bd/quick_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/quickstart_embedded_test.go
+++ b/cmd/bd/quickstart_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/ready_embedded_test.go
+++ b/cmd/bd/ready_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/rename_prefix_embedded_test.go
+++ b/cmd/bd/rename_prefix_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/reopen_embedded_test.go
+++ b/cmd/bd/reopen_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/restore_embedded_test.go
+++ b/cmd/bd/restore_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/search_embedded_test.go
+++ b/cmd/bd/search_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/setup_embedded_test.go
+++ b/cmd/bd/setup_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/ship_embedded_test.go
+++ b/cmd/bd/ship_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/show_embedded_test.go
+++ b/cmd/bd/show_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/stale_embedded_test.go
+++ b/cmd/bd/stale_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/state_embedded_test.go
+++ b/cmd/bd/state_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/status_embedded_test.go
+++ b/cmd/bd/status_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/supersede_embedded_test.go
+++ b/cmd/bd/supersede_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/swarm_embedded_test.go
+++ b/cmd/bd/swarm_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/todo_embedded_test.go
+++ b/cmd/bd/todo_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/types_embedded_test.go
+++ b/cmd/bd/types_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/undefer_embedded_test.go
+++ b/cmd/bd/undefer_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/vc_embedded_test.go
+++ b/cmd/bd/vc_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/version_embedded_test.go
+++ b/cmd/bd/version_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/cmd/bd/where_embedded_test.go
+++ b/cmd/bd/where_embedded_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/internal/storage/embeddeddolt/child_id_test.go
+++ b/internal/storage/embeddeddolt/child_id_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package embeddeddolt_test
 
 import (

--- a/internal/storage/embeddeddolt/cmd/main.go
+++ b/internal/storage/embeddeddolt/cmd/main.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package main
 
 import (

--- a/internal/storage/embeddeddolt/concurrency_test.go
+++ b/internal/storage/embeddeddolt/concurrency_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package embeddeddolt_test
 
 import (

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package embeddeddolt_test
 
 import (

--- a/internal/storage/embeddeddolt/dependencies_test.go
+++ b/internal/storage/embeddeddolt/dependencies_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package embeddeddolt_test
 
 import (

--- a/internal/storage/embeddeddolt/get_issue_test.go
+++ b/internal/storage/embeddeddolt/get_issue_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package embeddeddolt_test
 
 import (

--- a/internal/storage/embeddeddolt/schema_test.go
+++ b/internal/storage/embeddeddolt/schema_test.go
@@ -1,3 +1,5 @@
+//go:build cgo
+
 package embeddeddolt_test
 
 import (


### PR DESCRIPTION
## Problem

Building with `CGO_ENABLED=0` (or on systems without CGO/ICU headers) fails with compilation errors:

- `go build ./...` fails because `internal/storage/embeddeddolt/cmd/main.go` calls `store.Close()` which doesn't exist on the non-CGO stub type
- `go vet ./...` and `go test ./...` fail because 77 test files reference methods (`Close`, `CreateIssue`, `GetIssue`, `GetStatistics`, etc.) that only exist on the CGO-enabled `EmbeddedDoltStore`, not the stub

## Root Cause

The `EmbeddedDoltStore` type has a full implementation (build-tagged `//go:build cgo`) and a minimal stub (`//go:build !cgo`). The stub only defines the struct and `New()` — it lacks all the methods the real type has.

Many test files and one `main.go` that use these CGO-only methods were missing the `//go:build cgo` constraint, so they failed to compile when CGO was disabled.

## Fix

Added `//go:build cgo` to 77 files:
- 67 `cmd/bd/*_embedded_test.go` files
- `cmd/bd/metadata_filter_test.go` (uses `newTestStore` from a cgo-tagged helper)
- `cmd/bd/doctor/federation_test.go` (uses `doctorTestServerPort`/`testSharedDB` from cgo-tagged files)
- `cmd/bd/doctor/fix/migrate_import_test.go` (uses `fixTestServerPort` from cgo-tagged file)
- 6 `internal/storage/embeddeddolt/*_test.go` files
- `internal/storage/embeddeddolt/cmd/main.go`

## Verification

```
CGO_ENABLED=0 go build ./...  # ✅ passes
CGO_ENABLED=0 go vet ./...    # ✅ passes
CGO_ENABLED=0 go test ./...   # ✅ compiles and runs (non-CGO tests pass)
```