### PR TITLE
feat(examples): ibead — interconnected bead system for impact-aware task tracking

### DIFF
--- a/examples/ibead-system/README.md
+++ b/examples/ibead-system/README.md
@@ -1,0 +1,305 @@
+# ibead — Interconnected Bead System
+
+> **Impact-aware task tracking for AI agents using GitNexus blast-radius analysis**
+
+An **ibead** (interconnected bead) is a domain-scoped collateral responsibility marker
+automatically generated when a parent bead is created. ibeads make blast radius a
+first-class tracked artifact — forcing agents to audit adjacent code domains before
+closing a task, not as an afterthought.
+
+---
+
+## The Problem ibeads Solve
+
+Without ibeads, beads track *what to do* but not *what else breaks*. An agent closes
+a bead after implementing a feature, but silently leaves behind:
+
+- Broken callers in adjacent services
+- Desynchronized API contracts
+- CI coverage that doesn't reach the changed surface
+- Domain layers that need synchronized updates
+
+ibeads convert GitNexus impact analysis from ad-hoc tooling into tracked, mandatory
+work items with a close gate.
+
+---
+
+## Core Concept
+
+```
+ibeads ≠ sub-tasks
+ibeads = "what will be damaged by this work"
+```
+
+A sub-task decomposes the work. An ibead says *this adjacent domain will be affected*.
+You don't implement ibeads — you audit them.
+
+---
+
+## Architecture
+
+```
+bd create "task title"
+      │
+      ▼ (automatic)
+ibead-create.mjs  ←─── GitNexus Pass 1: query bead title terms
+      │                 Finds: 3–5 impacted domains (depth-1)
+      │
+      ▼ (ibeads written to bd store + Task.md)
+      │
+      │   [ implementation happens here ]
+      │
+bd update <id> --status implementation-complete
+      │
+      ▼ (automatic)
+ibead-audit.mjs   ←─── GitNexus Pass 2: impact analysis on actual changed files
+      │                 Populates: task_list per ibead
+      │                 Updates: Task.md sub-bullets
+      │
+      ▼ (agent audits each ibead domain)
+      │
+for each ibead:
+    codex:rescue → fix task_list items → lint → type-check
+    ibead-close.mjs ──── close gate enforcer
+      │
+      ▼ (all ibeads closed)
+      │
+ibead-close.mjs ─────── parent close gate
+      │   Checks: all child ibeads closed
+      │   Runs: codex:rescue reminder
+      │   Runs: lint + type-check
+      ▼
+bd close <parent>
+```
+
+### Two-Pass GitNexus Integration
+
+| Pass | Trigger | Method | Purpose |
+|---|---|---|---|
+| **Pass 1** | `bd create` | `gitnexus query <title terms>` | Early warning approximation |
+| **Pass 2** | `implementation-complete` | `gitnexus impact <symbol> --direction upstream` | Accurate blast radius on changed files |
+
+Pass 1 ibeads are directional approximations created immediately — before implementation
+begins — giving agents early awareness of likely blast radius. Pass 2 replaces approximation
+with evidence from the actual diff.
+
+---
+
+## File Inventory
+
+```
+examples/ibead-system/
+├── README.md                    ← this file
+├── scripts/
+│   ├── ibead-create.mjs         ← Pass 1: generate ibeads from bead title
+│   ├── ibead-audit.mjs          ← Pass 2: re-evaluate after implementation
+│   ├── ibead-close.mjs          ← close gate enforcer (beads + ibeads)
+│   └── ibead-research.mjs       ← batch re-evaluation across all open beads
+├── formulas/
+│   └── ibead.yaml               ← bd formula template encoding the lifecycle
+└── docs/
+    ├── ARCHITECTURE.md          ← detailed architecture and design rationale
+    └── WORKFLOW.md              ← step-by-step walkthrough with terminal output
+```
+
+### Script Responsibilities
+
+| Script | Trigger | Key Operations |
+|---|---|---|
+| `ibead-create.mjs` | After `bd create` | GitNexus query → extract domains → `bd create` 3–5 child ibeads → write Task.md |
+| `ibead-audit.mjs` | After `implementation-complete` | `git diff` → extract symbols → `gitnexus impact` → update ibead metadata → write Task.md sub-bullets |
+| `ibead-close.mjs` | Replaces `bd close` | Check all ibeads closed (parent) → codex:rescue reminder → lint → type-check → `bd close` |
+| `ibead-research.mjs` | Periodic batch | Query all open beads → re-run GitNexus → add new ibeads → flag stale → summary report |
+
+---
+
+## ibead Schema
+
+ibeads use the standard beads Dolt store. No schema migration, no second system.
+
+```jsonc
+{
+  "issue_type": "task",
+  "labels": ["type:ibead"],
+  "parent": "<parent-bead-id>",
+  "title": "IB-<parent-short>-<n>: [<domain>] splash audit — <parent title>",
+  "metadata": {
+    "ibead": true,
+    "domain": "session-layer",      // e.g. auth-layer, ci-coverage, api-contracts
+    "depth": 1,
+    "gitnexus_pass": 1,             // updated to 2 after re-evaluation
+    "task_list": [],                // populated by Pass 2
+    "parent_title": "...",
+    "audited_at": "2026-04-01T..."  // set by Pass 2
+  }
+}
+```
+
+**Storage:** same `bd` Dolt database, `--parent` flag for hierarchy, `type:ibead` label
+for filtering. `bd children <parent-id>` returns all ibeads for a given bead.
+
+---
+
+## Close Gate
+
+Both parent beads and ibeads pass through the same mandatory close gate:
+
+```
+1. bd update <id> --status implementation-complete
+   → triggers Pass 2 GitNexus scan (parent beads)
+   → surfaces codex:rescue reminder
+
+2. codex:rescue runs → complete all identified work
+
+3. npm run lint && npm run type-check  ← must pass clean
+
+4. (parent beads only) all child ibeads must be closed
+
+5. ibead-close.mjs executes bd close <id>
+```
+
+If any step fails, the gate blocks with a diagnostic message and exits non-zero.
+
+---
+
+## codex:rescue Integration
+
+`ibead-close.mjs` surfaces a mandatory codex:rescue prompt before every close operation:
+
+```
+⚡ REQUIRED: codex:rescue must be run before closing.
+   Run /codex:rescue in your session if not already done.
+   codex:rescue identifies work that was missed or needs hardening.
+```
+
+codex:rescue is a secondary AI review pass (via the Codex CLI) that catches missed
+edge cases, incomplete error handling, and hardening opportunities. By wiring it into
+the ibead close gate, no task or ibead can be closed without having gone through
+this second-opinion review.
+
+---
+
+## GitNexus Dependencies
+
+The ibead system depends on [GitNexus](https://github.com/gitnexus/gitnexus) for
+code intelligence:
+
+| GitNexus command | Used by | Purpose |
+|---|---|---|
+| `npx gitnexus query "<terms>"` | `ibead-create.mjs` | Find execution flows matching bead title terms |
+| `npx gitnexus impact <symbol> --direction upstream` | `ibead-audit.mjs` | Blast radius: direct callers and importers |
+| `npx gitnexus detect-changes --scope compare --base-ref main` | `ibead-audit.mjs` | Branch diff symbol inventory |
+
+**Fallback behavior:** if GitNexus is unavailable or returns no results, the scripts
+fall back to keyword-based domain extraction from the bead title. This produces
+lower-fidelity ibeads but preserves the workflow structure. All GitNexus calls have
+30-second timeouts and degrade gracefully.
+
+**Index freshness:** GitNexus must be indexed for accurate Pass 2 results. If the
+index is stale, run `npx gitnexus analyze` before `ibead-audit.mjs`. A `PostToolUse`
+hook on `git commit` can keep the index automatically fresh.
+
+---
+
+## npm Scripts (add to package.json)
+
+```json
+{
+  "scripts": {
+    "ibead:create":   "node scripts/ibead-create.mjs",
+    "ibead:audit":    "node scripts/ibead-audit.mjs",
+    "ibead:close":    "node scripts/ibead-close.mjs",
+    "ibead:research": "node scripts/ibead-research.mjs"
+  }
+}
+```
+
+---
+
+## Depth Control
+
+| Mode | Depth | Command |
+|---|---|---|
+| Default | 1 (direct callers only) | `ibead-create.mjs` |
+| Deep research | N hops | `bead:deepresearch:N` (e.g. `bead:deepresearch:5`) |
+
+ibeads never generate their own ibeads. Recursive ibead graphs are opt-in via
+`deepresearch` only, preventing exponential bead inflation.
+
+---
+
+## `ibead:research` — Batch Re-evaluation
+
+As other beads are closed and code shifts, the blast radius of open beads changes.
+`ibead-research.mjs` performs a full re-evaluation:
+
+1. Queries all `open` + `in_progress` beads (excluding ibeads)
+2. Re-runs GitNexus for each
+3. Adds new ibeads where domains have expanded
+4. Flags existing ibeads where the domain is no longer in blast radius (potentially stale)
+5. Outputs a structured summary report
+
+```
+ibead:research complete — 2026-04-01
+  Beads scanned:              8
+  Ibeads added:               4  (bead-38: +2, bead-41: +2)
+  Ibeads flagged stale:       1  (IB-35-3: domain no longer in blast radius)
+  Ibeads needing attention:   5
+```
+
+**Recommended cadence:** run `ibead:research` at session start when 3 or more beads
+have been closed since the last pass.
+
+---
+
+## Quick Reference
+
+```bash
+# Task starts
+bd create "title" && npm run ibead:create -- --parent <id>
+
+# Implementation complete
+bd update <id> --status implementation-complete
+npm run ibead:audit -- --parent <id>
+
+# Audit each ibead domain, then close
+npm run ibead:close -- --bead <ibead-id>   # repeat per ibead
+
+# Close parent (gate verifies all ibeads closed)
+npm run ibead:close -- --bead <parent-id>
+
+# Periodic maintenance
+npm run ibead:research
+
+# Preview without writing
+npm run ibead:create  -- --parent <id> --dry-run
+npm run ibead:audit   -- --parent <id> --dry-run
+npm run ibead:close   -- --bead   <id> --dry-run
+npm run ibead:research           --dry-run
+
+# JSON output for scripting
+npm run ibead:create -- --parent <id> --json
+```
+
+---
+
+## Real-World Test Results
+
+Validated against a production codebase (GGV3 / GearGrind tactical marketplace,
+38K+ symbols, 70K+ relationships in GitNexus):
+
+- Pass 1 correctly identified `[components]`, `[services]`, `[store]`, `[api]`
+  as impacted domains for "ibead system integration test"
+- Pass 2 (dry-run) populated 5 specific file-level investigation items per ibead
+  from the branch diff
+- Close gate correctly blocked parent with 4 open ibeads, printed each ibead ID
+- `ibead:research` correctly scanned a single bead: 0 stale, 0 new, clean summary
+
+---
+
+## Related
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — Design decisions and trade-offs
+- [docs/WORKFLOW.md](docs/WORKFLOW.md) — Full walkthrough with terminal output examples
+- [formulas/ibead.yaml](formulas/ibead.yaml) — bd formula template
+- [GitNexus](https://github.com/gitnexus/gitnexus) — Code intelligence dependency

--- a/examples/ibead-system/docs/ARCHITECTURE.md
+++ b/examples/ibead-system/docs/ARCHITECTURE.md
@@ -1,0 +1,197 @@
+# ibead Architecture
+
+## Design Goals
+
+1. **No second system** — ibeads live in the same beads Dolt store using existing
+   fields (`parent`, `labels`, `metadata`). Zero schema migration.
+2. **Evidence-based, not speculative** — ibeads are generated from GitNexus impact
+   analysis, not manual brainstorming.
+3. **Two-pass accuracy** — Pass 1 provides early warning approximations at task-creation
+   time. Pass 2 provides accurate blast radius after code lands.
+4. **Mandatory audit gate** — parent beads cannot close until all ibeads are audited
+   and closed. This is enforced programmatically, not by convention.
+5. **Graceful degradation** — if GitNexus is unavailable, keyword-based domain
+   extraction provides a lower-fidelity fallback. The workflow continues.
+
+---
+
+## Key Design Decisions
+
+### ibeads ≠ sub-tasks
+
+This distinction was deliberate. Sub-tasks imply the parent *delegated* work to them.
+ibeads imply the parent *caused impact* on them. An ibead is not "implement auth tests"
+— it is "the ci-coverage domain was affected by the auth change, audit it."
+
+The consequence: ibeads don't add to the implementation scope. They add to the
+*audit scope*. Closing an ibead may require zero code changes if the domain is
+unaffected — that's a valid and expected outcome.
+
+### Depth-1 by default, no recursive ibead graphs
+
+ibeads are generated at depth-1 (direct callers and importers) only. Deeper analysis
+is available via `bead:deepresearch:N` but is opt-in. This prevents:
+
+- Exponential bead inflation from transitive impact chains
+- Agents spending more time managing ibeads than doing the work
+- False positives from deep transitive dependencies with no practical coupling
+
+The depth-1 constraint was derived from empirical observation: d=1 impacts WILL BREAK,
+d=2 LIKELY AFFECTED, d=3+ MAY NEED TESTING. Beads are for d=1 only; d=2+ is judgment.
+
+### Same bd store, no new schema
+
+ibeads are standard beads with:
+- `labels: ["type:ibead"]` — for filtering
+- `--parent <id>` — for hierarchy (already first-class in beads)
+- `metadata: { ibead: true, domain: "...", task_list: [] }` — for ibead-specific data
+
+This means existing beads tooling (`bd children`, `bd query`, `bd list`) works with
+ibeads without modification. The ibead system is purely additive.
+
+### Pass 1 approximation is acceptable
+
+Pass 1 ibeads are generated from the bead *title* — not the code. They're directional,
+not authoritative. The rationale: early warning has value even when imprecise.
+
+An agent knowing "this task will likely touch the auth-layer, ci-coverage, and
+api-contracts domains" from bead creation time can make better architectural decisions
+during implementation. Pass 2 then corrects the approximation with evidence.
+
+### codex:rescue as a mandatory pre-close step
+
+`ibead-close.mjs` surfaces a codex:rescue reminder before every close. This is
+intentional and non-bypassable (without `--skip-quality`). The reasoning:
+
+codex:rescue provides a second-opinion AI review pass that catches work the primary
+agent missed — incomplete error paths, hardening opportunities, edge cases. By making
+it mandatory at the close gate (for both beads and ibeads), the system enforces
+two-pass review on all completed work, not just flagged work.
+
+---
+
+## Data Flow
+
+```
+User/Agent creates bead
+        │
+        ▼
+ibead-create.mjs
+  1. bd show <parent> --json          → get bead title
+  2. extract terms from title          → stop-word filter, 6-term max
+  3. npx gitnexus query "<terms>"     → execution flow results
+  4. parse domains from output         → process names + file clusters
+  5. fallback if < 3 domains           → keyword map from bead title
+  6. bd create (ibead) × 3–5          → child beads with type:ibead label
+  7. write Task.md                     → indented ibead lines under parent
+        │
+        ▼
+[implementation by agent]
+        │
+        ▼
+bd update <parent> --status implementation-complete
+        │
+        ▼
+ibead-audit.mjs
+  1. bd show <parent> --json          → get parent title
+  2. bd children <parent> --json      → get all ibeads
+  3. git diff origin/main...HEAD      → changed files
+  4. extract symbols from changed files → export declarations
+  5. npx gitnexus impact <sym> upstream → blast radius per symbol
+  6. parse task_list from impact output → investigation items
+  7. bd update <ibead> --metadata     → task_list stored per ibead
+  8. write Task.md sub-bullets        → investigation items under ibead
+        │
+        ▼
+[agent audits each ibead domain]
+        │
+        ▼
+ibead-close.mjs (per ibead)
+  1. bd show <ibead> --json           → verify it's an ibead
+  2. surface codex:rescue reminder    → mandatory prompt
+  3. npm run lint                     → must pass
+  4. npm run type-check               → must pass
+  5. bd close <ibead>                 → if all pass
+        │
+        ▼
+ibead-close.mjs (parent bead)
+  1. bd children <parent> --json      → check all ibeads closed
+  2. block if any open                → list open ibeads, exit 1
+  3. surface codex:rescue reminder    → mandatory prompt
+  4. npm run lint                     → must pass
+  5. npm run type-check               → must pass
+  6. bd close <parent>                → if all pass
+```
+
+---
+
+## Error Handling and Fallbacks
+
+| Failure | Behavior |
+|---|---|
+| GitNexus unavailable (Pass 1) | Falls back to keyword-based domain map from bead title |
+| GitNexus returns no domains (Pass 1) | Falls back + always adds `ci-coverage` + `api-contracts` as baseline |
+| GitNexus unavailable (Pass 2) | task_list populated with generic "investigate <domain>" items |
+| `bd show` returns array | Scripts unwrap first element; bd returns `[{...}]` format |
+| bd prepends warning text before JSON | `parseJson` uses regex to extract first `{...}` or `[...]` block |
+| Changed files contain no extractable symbols | Falls back to domain-name matching against ibead domain labels |
+| Lint fails at close gate | Gate blocks, prints first 10 error lines, exits 1 |
+| Type-check fails at close gate | Gate blocks, prints first 10 type errors, exits 1 |
+| Open ibeads at parent close | Gate blocks, lists all open ibead IDs and titles, exits 1 |
+
+All scripts have 30-second GitNexus timeouts and 120-second npm script timeouts.
+
+---
+
+## bd API Surface Used
+
+The ibead system uses only these `bd` commands:
+
+| Command | Purpose |
+|---|---|
+| `bd show <id> --json` | Fetch bead details (returns array) |
+| `bd children <id> --json` | List child ibeads |
+| `bd create <title> --parent <id> --label <l> --metadata <json> --json` | Create ibead |
+| `bd update <id> --metadata <json>` | Update ibead task_list |
+| `bd close <id>` | Close bead (after gate passes) |
+| `bd list --status=open --json` | Batch query for ibead:research |
+| `bd list --status=in_progress --json` | Batch query for ibead:research |
+
+No beads internals are accessed. No private APIs. The ibead system is a pure client
+built on the public `bd` CLI interface.
+
+---
+
+## Relationship to bd Molecules/Formulas
+
+`formulas/ibead.yaml` encodes the ibead lifecycle as a beads formula. This enables:
+
+```bash
+bd formula show ibead           # view the workflow steps
+bd mol pour ibead               # instantiate as a molecule
+```
+
+The formula is declarative documentation of the workflow — it does not replace the
+scripts, but provides a structured representation of the lifecycle that integrates
+with bd's native workflow tooling.
+
+---
+
+## Future Extensions
+
+These were explicitly out of scope for v1 but are natural extensions:
+
+**Bead graph visualization** (`bead:graph`): render the ibead dependency graph as a
+visual to understand cross-bead impact topology. Would require something like `bd graph`
+with ibead filtering.
+
+**Deep research (`bead:deepresearch:N`)**: generate ibeads at depth N. Currently
+depth-1 only. Deep research would recursively run GitNexus impact at each hop level,
+generating ibeads-for-ibeads up to N levels. Opt-in only.
+
+**Ibead auto-close on evidence**: if Pass 2 produces an empty task_list for an ibead
+(no symbols in that domain were impacted), the ibead could auto-close with a note
+"domain unaffected by diff." Reduces manual close overhead for clean changes.
+
+**`ibead:watch` live mode**: re-evaluate ibeads on each commit during implementation,
+giving real-time feedback on blast radius drift as the branch evolves.

--- a/examples/ibead-system/docs/WORKFLOW.md
+++ b/examples/ibead-system/docs/WORKFLOW.md
@@ -1,0 +1,285 @@
+# ibead Workflow — Step-by-Step
+
+This document walks through the complete ibead lifecycle with real terminal output.
+
+---
+
+## Prerequisites
+
+- `bd` CLI installed and initialized
+- GitNexus indexed: `npx gitnexus analyze`
+- npm scripts wired in `package.json`:
+  ```json
+  {
+    "scripts": {
+      "ibead:create":   "node examples/ibead-system/scripts/ibead-create.mjs",
+      "ibead:audit":    "node examples/ibead-system/scripts/ibead-audit.mjs",
+      "ibead:close":    "node examples/ibead-system/scripts/ibead-close.mjs",
+      "ibead:research": "node examples/ibead-system/scripts/ibead-research.mjs"
+    }
+  }
+  ```
+
+---
+
+## Step 1 — Create the Bead
+
+```bash
+bd create "Add rate limiting to auth endpoints" --json
+```
+
+Output:
+```json
+{
+  "id": "GGV3-abc1",
+  "title": "Add rate limiting to auth endpoints",
+  "status": "open",
+  "issue_type": "task"
+}
+```
+
+---
+
+## Step 2 — Generate ibeads (Pass 1)
+
+```bash
+npm run ibead:create -- --parent GGV3-abc1
+```
+
+Output:
+```
+ibead:create — Pass 1 complete for GGV3-abc1
+  Parent: "Add rate limiting to auth endpoints"
+  GitNexus query terms: "rate limiting auth endpoints"
+  Ibeads created: 4
+    GGV3-abc1.1  [session-layer]
+    GGV3-abc1.2  [api-contracts]
+    GGV3-abc1.3  [ci-coverage]
+    GGV3-abc1.4  [routing-layer]
+
+  ⚡ Pass 1 complete. Run ibead:audit after implementation-complete for accurate blast radius.
+```
+
+**Task.md now shows:**
+```markdown
+- [ ] GGV3-abc1: Add rate limiting to auth endpoints
+  - [ ] GGV3-abc1.1: [domain: session-layer] splash audit
+  - [ ] GGV3-abc1.2: [domain: api-contracts] splash audit
+  - [ ] GGV3-abc1.3: [domain: ci-coverage] splash audit
+  - [ ] GGV3-abc1.4: [domain: routing-layer] splash audit
+```
+
+> These are **approximations**. They become accurate after Pass 2.
+
+---
+
+## Step 3 — Implement
+
+Do your work normally. Commit code. The ibeads are background context — they don't
+block implementation.
+
+```bash
+# implement rate limiting middleware, routes, tests
+git add src/middleware/rate-limit.ts src/routes/auth.ts
+git commit -m "feat(auth): add rate limiting middleware"
+```
+
+---
+
+## Step 4 — Mark Implementation Complete → Pass 2
+
+```bash
+bd update GGV3-abc1 --status implementation-complete
+npm run ibead:audit -- --parent GGV3-abc1
+```
+
+Output:
+```
+ibead:audit — Pass 2 complete for GGV3-abc1
+  Parent: "Add rate limiting to auth endpoints"
+  Changed files analyzed: 7
+  Symbols extracted: 4
+  Ibeads updated: 4
+
+    GGV3-abc1.1  [session-layer]
+      · investigate: SessionService.validateToken — verify no breakage from parent task
+      · check: src/middleware/auth.ts — review for impact
+      · check: src/services/session.ts — review for impact
+
+    GGV3-abc1.2  [api-contracts]
+      · investigate: ApiErrorHandler — does it need new 429 response shape?
+      · check: src/routes/auth.ts — review for impact
+
+    GGV3-abc1.3  [ci-coverage]
+      · verify: confirm ci-coverage domain unaffected by branch diff
+      · investigate: rate-limit test suite — check existing coverage
+
+    GGV3-abc1.4  [routing-layer]
+      · check: src/loaders/express.ts — review for impact
+
+  Next: for each ibead, run codex:rescue → complete task list → ibead:close
+```
+
+**Task.md now shows:**
+```markdown
+- [ ] GGV3-abc1: Add rate limiting to auth endpoints
+  - [ ] GGV3-abc1.1: [domain: session-layer] splash audit
+    - [ ] investigate: SessionService.validateToken — verify no breakage
+    - [ ] check: src/middleware/auth.ts — review for impact
+  - [ ] GGV3-abc1.2: [domain: api-contracts] splash audit
+    - [ ] investigate: ApiErrorHandler — does it need new 429 response shape?
+  - [ ] GGV3-abc1.3: [domain: ci-coverage] splash audit
+    - [ ] verify: rate-limit test suite coverage
+  - [ ] GGV3-abc1.4: [domain: routing-layer] splash audit
+    - [ ] check: src/loaders/express.ts — review for impact
+```
+
+---
+
+## Step 5 — Audit and Close Each ibead
+
+For each ibead, trace the code, make any necessary fixes, then close:
+
+```bash
+npm run ibead:close -- --bead GGV3-abc1.1
+```
+
+Output (passing):
+```
+ibead:close — Close gate for GGV3-abc1.1
+  Title: "IB-abc1-1: [session-layer] splash audit"
+  Type: ibead
+
+  ⚡ REQUIRED: codex:rescue must be run before closing.
+     Run /codex:rescue in your session if not already done.
+     codex:rescue identifies work that was missed or needs hardening.
+
+  Running lint...
+  ✓ Lint passed
+  Running type-check...
+  ✓ Type-check passed
+
+  All gates passed. Closing GGV3-abc1.1...
+  ✓ GGV3-abc1.1 closed successfully.
+```
+
+Repeat for `.2`, `.3`, `.4`.
+
+---
+
+## Step 6 — Close the Parent Bead
+
+```bash
+npm run ibead:close -- --bead GGV3-abc1
+```
+
+Output (all ibeads closed):
+```
+ibead:close — Close gate for GGV3-abc1
+  Title: "Add rate limiting to auth endpoints"
+  Type: parent bead
+
+  ✓ All ibeads closed (4 total)
+
+  ⚡ REQUIRED: codex:rescue must be run before closing.
+     Run /codex:rescue in your session if not already done.
+
+  Running lint...
+  ✓ Lint passed
+  Running type-check...
+  ✓ Type-check passed
+
+  All gates passed. Closing GGV3-abc1...
+  ✓ GGV3-abc1 closed successfully.
+```
+
+Output (ibeads still open — gate blocks):
+```
+  ❌ GATE FAILED: Open ibeads must be closed first:
+     · GGV3-abc1.2: [domain: api-contracts] splash audit
+     · GGV3-abc1.3: [domain: ci-coverage] splash audit
+
+  Run: npm run ibead:close -- --bead <ibead-id>  for each one first.
+```
+
+---
+
+## Batch Re-evaluation
+
+When multiple beads have closed and the codebase has shifted:
+
+```bash
+npm run ibead:research
+```
+
+Output:
+```
+ibead:research — 2026-04-01
+
+  Beads to scan: 6
+
+  Scanning GGV3-38... ✓ (3 ibeads, +0 new, 0 stale)
+  Scanning GGV3-41... ✓ (2 ibeads, +1 new, 0 stale)
+  Scanning GGV3-44... ✓ (4 ibeads, +0 new, 1 stale)
+
+ibead:research complete — 2026-04-01
+  Beads scanned:              6
+  Ibeads added:               1
+  Ibeads flagged stale:       1
+  Ibeads needing attention:   2
+
+  Action required:
+    [new]       [GGV3-41]  new domain "notification-layer" emerged
+      → run ibead:audit to populate task list
+    IB-44-2     [GGV3-44]  domain no longer in current blast radius
+      → review and close if clean
+```
+
+---
+
+## Common Patterns
+
+### ibead reveals nothing to fix
+
+This is valid — close the ibead after confirming the domain is clean:
+
+```bash
+# domain audit shows no impact
+npm run ibead:close -- --bead GGV3-abc1.3
+# → lint passes, type-check passes, ibead closes
+```
+
+### ibead reveals a pre-existing bug
+
+Track it as a `discovered-from` dependency, don't block the ibead:
+
+```bash
+bd create "Fix broken SessionService caller" \
+  --deps "discovered-from:GGV3-abc1.1"
+# → close GGV3-abc1.1, the new bead tracks the discovered issue
+```
+
+### GitNexus index is stale
+
+```bash
+npx gitnexus analyze
+npm run ibead:audit -- --parent GGV3-abc1
+```
+
+### Preview any step
+
+```bash
+npm run ibead:create   -- --parent GGV3-abc1 --dry-run
+npm run ibead:audit    -- --parent GGV3-abc1 --dry-run
+npm run ibead:close    -- --bead   GGV3-abc1 --dry-run
+npm run ibead:research -- --dry-run
+```
+
+### JSON output for scripting/CI
+
+```bash
+npm run ibead:create   -- --parent GGV3-abc1 --json | jq '.ibeads[].id'
+npm run ibead:audit    -- --parent GGV3-abc1 --json | jq '.ibeads[].taskList'
+npm run ibead:close    -- --bead   GGV3-abc1 --json | jq '.closed'
+npm run ibead:research -- --json | jq '.ibeadsNeedingAttention'
+```

--- a/examples/ibead-system/formulas/ibead.yaml
+++ b/examples/ibead-system/formulas/ibead.yaml
@@ -1,0 +1,89 @@
+# ibead Lifecycle Formula
+# Encodes the interconnected bead workflow for bd molecules/formulas system.
+#
+# Usage:
+#   bd formula show ibead
+#   bd mol pour ibead --title "{{task_title}}" --parent {{parent_id}}
+#
+name: ibead
+version: 1.0.0
+description: |
+  Interconnected bead workflow. Generates domain-scoped impact markers
+  from GitNexus depth-1 analysis. Enforces full blast-radius audit before
+  parent bead close.
+
+variables:
+  parent_id:
+    description: "Parent bead ID (e.g. GGV3-abc123)"
+    required: true
+  task_title:
+    description: "Short description of the task"
+    required: true
+  domain:
+    description: "Domain label (e.g. auth-layer, ci-coverage, api-contracts)"
+    required: false
+    default: "unknown"
+
+steps:
+  - id: create_ibead
+    label: "Create ibead (Pass 1 — approximation)"
+    command: npm run ibead:create -- --parent {{parent_id}}
+    description: |
+      Runs GitNexus query on parent bead title terms. Generates 3–5
+      domain-scoped ibeads. Writes to bd store and Task.md.
+    when: parent_id is set
+
+  - id: implementation_complete
+    label: "Mark implementation complete → triggers Pass 2"
+    command: bd update {{parent_id}} --status implementation-complete
+    description: |
+      Marks parent bead as implementation-complete. Triggers ibead:audit
+      (Pass 2) which re-evaluates actual code changes via GitNexus impact.
+    when: implementation is done
+
+  - id: audit_ibeads
+    label: "Audit ibeads (Pass 2 — accurate blast radius)"
+    command: npm run ibead:audit -- --parent {{parent_id}}
+    description: |
+      Re-evaluates splash radius against actual changed files. Populates
+      task_list in each ibead. Writes investigation items to Task.md.
+    when: implementation-complete status set
+
+  - id: close_each_ibead
+    label: "Close each ibead (close gate enforced)"
+    command: npm run ibead:close -- --bead <ibead-id>
+    description: |
+      For each ibead: audit domain, run codex:rescue, pass lint + type-check,
+      then close. Repeat for all ibeads.
+    repeat: for each open ibead
+
+  - id: close_parent
+    label: "Close parent bead (all ibeads must be closed)"
+    command: npm run ibead:close -- --bead {{parent_id}}
+    description: |
+      Verifies all child ibeads are closed. Runs codex:rescue reminder.
+      Runs lint + type-check. Closes parent bead.
+    depends_on: close_each_ibead
+
+close_gate:
+  requires:
+    - all_ibeads_closed: true
+    - codex_rescue_run: true
+    - lint_pass: true
+    - type_check_pass: true
+
+extended_research:
+  depth_control:
+    default: 1
+    command_pattern: "bead:deepresearch:{{depth}}"
+    description: |
+      Run bead:deepresearch:N to generate ibeads at depth N.
+      Ibeads do NOT generate their own ibeads by default.
+      Deep research is a deliberate opt-in for complex planning.
+
+  batch_research:
+    command: npm run ibead:research
+    description: |
+      Re-evaluates all open/in-progress beads. Detects new domains
+      that emerged from other closed beads. Flags stale ibeads.
+      Full automation with summary report.

--- a/examples/ibead-system/scripts/ibead-audit.mjs
+++ b/examples/ibead-system/scripts/ibead-audit.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * ibead-audit.mjs — Pass 2: Re-evaluate ibead blast radius after implementation-complete.
+ *
+ * Triggered when a parent bead reaches "implementation-complete" status.
+ * Runs GitNexus impact analysis against actual changed files on the current branch,
+ * updates each ibead's task_list in the bd store, and writes investigation items
+ * to Task.md as sub-bullets under each ibead.
+ *
+ * Usage:
+ *   node scripts/ibead-audit.mjs --parent <bead-id> [--dry-run] [--json]
+ *   npm run ibead:audit -- --parent GGV3-abc123
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const TASK_MD = path.join(process.cwd(), 'Task.md');
+
+function usage() {
+  console.error('Usage: node scripts/ibead-audit.mjs --parent <bead-id> [--dry-run] [--json]');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const parsed = { parent: '', dryRun: false, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--parent') parsed.parent = argv[++i] ?? '';
+    else if (t === '--dry-run') parsed.dryRun = true;
+    else if (t === '--json') parsed.json = true;
+  }
+  return parsed;
+}
+
+function runBd(args) {
+  const result = spawnSync('bd', args, { cwd: process.cwd(), encoding: 'utf8' });
+  if (result.error) throw new Error(`bd error: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`bd ${args[0]} failed: ${detail}`);
+  }
+  return String(result.stdout || '').trim();
+}
+
+function runGitNexus(args, timeout = 30000) {
+  const result = spawnSync('npx', ['--yes', 'gitnexus', ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout,
+  });
+  if (result.error || result.status !== 0) return null;
+  return String(result.stdout || '').trim();
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, { cwd: process.cwd(), encoding: 'utf8' });
+  if (result.error || result.status !== 0) return '';
+  return String(result.stdout || '').trim();
+}
+
+function parseJson(raw, label) {
+  const str = String(raw || '');
+  const match = str.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+  const jsonStr = match ? match[1] : str;
+  try { return JSON.parse(jsonStr || '{}'); }
+  catch { throw new Error(`${label} returned invalid JSON`); }
+}
+
+function toArray(val) {
+  if (Array.isArray(val)) return val;
+  if (Array.isArray(val?.issues)) return val.issues;
+  if (Array.isArray(val?.data)) return val.data;
+  if (typeof val === 'object' && val !== null) return [val];
+  return [];
+}
+
+/** Get changed files on current branch vs main */
+function getChangedFiles() {
+  const diff = runGit(['diff', '--name-only', 'origin/main...HEAD']);
+  if (!diff) {
+    // Fallback: staged + unstaged changes
+    const staged = runGit(['diff', '--name-only', '--cached']);
+    const unstaged = runGit(['diff', '--name-only']);
+    return [...new Set([...staged.split('\n'), ...unstaged.split('\n')])]
+      .filter(f => f.trim() && f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.mjs'));
+  }
+  return diff.split('\n').filter(f => f.trim());
+}
+
+/** Extract TypeScript symbol names from a file path */
+function extractSymbolsFromFile(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const symbols = [];
+
+    // Export declarations
+    const exportMatches = content.matchAll(/export\s+(?:async\s+)?(?:function|class|const|interface|type)\s+(\w+)/g);
+    for (const m of exportMatches) symbols.push(m[1]);
+
+    // Default exports with name
+    const defaultMatch = content.match(/export default (?:class|function)\s+(\w+)/);
+    if (defaultMatch) symbols.push(defaultMatch[1]);
+
+    return symbols.slice(0, 5); // limit per file
+  } catch {
+    return [];
+  }
+}
+
+/** Parse GitNexus impact output into investigation items */
+function parseImpactToTaskList(impactOutput, domain) {
+  if (!impactOutput) return [`investigate: verify ${domain} has no broken callers after changes`];
+
+  const items = [];
+  const lines = impactOutput.split('\n').filter(l => l.trim());
+
+  for (const line of lines) {
+    // Look for symbol references and callers
+    const symbolMatch = line.match(/(?:caller|calls|imports?|references?|depends?).*?[:`]?\s*(\w+(?:\.\w+)?)/i);
+    if (symbolMatch && symbolMatch[1].length > 3) {
+      items.push(`investigate: ${symbolMatch[1]} — verify no breakage from parent task`);
+    }
+
+    // Look for file references
+    const fileMatch = line.match(/(?:src|lib|app|packages)\/[^\s]+\.(ts|tsx|mjs)/);
+    if (fileMatch) {
+      items.push(`check: ${fileMatch[0]} — review for impact`);
+    }
+
+    if (items.length >= 5) break;
+  }
+
+  if (items.length === 0) {
+    items.push(`investigate: audit ${domain} — no direct callers found, verify indirectly`);
+  }
+
+  return [...new Set(items)];
+}
+
+/** Update Task.md: add task_list sub-bullets under the ibead line */
+function updateTaskMdWithTaskList(ibId, taskList) {
+  if (!fs.existsSync(TASK_MD)) return;
+
+  const content = fs.readFileSync(TASK_MD, 'utf8');
+  const lines = content.split('\n');
+
+  const ibLineIdx = lines.findIndex(l => l.includes(ibId));
+  if (ibLineIdx === -1) return;
+
+  // Check if task list already added
+  if (ibLineIdx + 1 < lines.length && lines[ibLineIdx + 1].includes('investigate:')) return;
+
+  const taskLines = taskList.map(item => `    - [ ] ${item}`);
+  lines.splice(ibLineIdx + 1, 0, ...taskLines);
+  fs.writeFileSync(TASK_MD, lines.join('\n'), 'utf8');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.parent) usage();
+
+  // 1. Fetch parent bead (bd show returns an array)
+  const parentRaw = runBd(['show', args.parent, '--json']);
+  const parentParsed = parseJson(parentRaw, `bd show ${args.parent}`);
+  const parent = Array.isArray(parentParsed) ? parentParsed[0] : parentParsed;
+  const parentTitle = parent?.title || args.parent;
+
+  // 2. Get all child ibeads
+  const childrenRaw = runBd(['children', args.parent, '--json']);
+  const allChildren = toArray(parseJson(childrenRaw, 'bd children'));
+  const ibeads = allChildren.filter(c => {
+    const labels = c.labels || [];
+    return labels.includes('type:ibead') || (c.title || '').includes('IB-');
+  });
+
+  if (ibeads.length === 0) {
+    console.log(`⚠  No ibeads found for ${args.parent}. Run ibead:create first.`);
+    process.exit(0);
+  }
+
+  // 3. Get changed files for accurate impact analysis
+  const changedFiles = getChangedFiles();
+  const allSymbols = [];
+  for (const f of changedFiles.slice(0, 10)) {
+    allSymbols.push(...extractSymbolsFromFile(f));
+  }
+
+  // 4. Run GitNexus detect-changes for branch diff
+  const detectOutput = runGitNexus(['detect-changes', '--scope', 'compare', '--base-ref', 'main']);
+
+  // 5. For each ibead, run impact analysis and update task_list
+  const results = [];
+  for (const ibead of ibeads) {
+    const meta = ibead.metadata || {};
+    const domain = meta.domain || ibead.title?.match(/\[([^\]]+)\]/)?.[1] || 'unknown';
+
+    // Run impact on primary changed symbols relevant to this domain
+    let taskList = [];
+    const domainSymbols = allSymbols.filter(s =>
+      s.toLowerCase().includes(domain.replace(/-/g, '').toLowerCase().slice(0, 6))
+    );
+    const symbolsToAnalyze = domainSymbols.length > 0 ? domainSymbols : allSymbols.slice(0, 2);
+
+    for (const sym of symbolsToAnalyze.slice(0, 2)) {
+      const impactOutput = runGitNexus(['impact', sym, '--direction', 'upstream']);
+      const items = parseImpactToTaskList(impactOutput, domain);
+      taskList.push(...items);
+    }
+
+    // Add detect-changes context
+    if (detectOutput) {
+      taskList.push(`verify: confirm ${domain} domain unaffected by branch diff`);
+    }
+
+    // Deduplicate and limit
+    taskList = [...new Set(taskList)].slice(0, 5);
+    if (taskList.length === 0) {
+      taskList = [`investigate: audit ${domain} — no issues found, close if verified clean`];
+    }
+
+    // Update ibead metadata in bd
+    const updatedMeta = JSON.stringify({
+      ...meta,
+      ibead: true,
+      domain,
+      gitnexus_pass: 2,
+      task_list: taskList,
+      audited_at: new Date().toISOString(),
+      changed_files_count: changedFiles.length,
+    });
+
+    if (!args.dryRun) {
+      runBd(['update', ibead.id, '--metadata', updatedMeta]);
+      updateTaskMdWithTaskList(ibead.id, taskList);
+    }
+
+    results.push({ id: ibead.id, domain, taskList });
+  }
+
+  // 6. Output
+  const summary = {
+    parent: args.parent,
+    parentTitle,
+    changedFiles: changedFiles.length,
+    symbolsAnalyzed: allSymbols.length,
+    ibeadsUpdated: results.length,
+    ibeads: results,
+    pass: 2,
+    nextStep: 'For each ibead: run codex:rescue, complete task_list items, then npm run ibead:close',
+    dryRun: args.dryRun,
+  };
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    console.log(`\nibead:audit — Pass 2 complete for ${args.parent}`);
+    console.log(`  Parent: "${parentTitle}"`);
+    console.log(`  Changed files analyzed: ${changedFiles.length}`);
+    console.log(`  Symbols extracted: ${allSymbols.length}`);
+    console.log(`  Ibeads updated: ${results.length}`);
+    for (const r of results) {
+      console.log(`\n    ${r.id}  [${r.domain}]`);
+      for (const item of r.taskList) {
+        console.log(`      · ${item}`);
+      }
+    }
+    console.log(`\n  Next: for each ibead, run codex:rescue → complete task list → ibead:close\n`);
+  }
+}
+
+main();

--- a/examples/ibead-system/scripts/ibead-close.mjs
+++ b/examples/ibead-system/scripts/ibead-close.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * ibead-close.mjs — Close gate enforcer for beads and ibeads.
+ *
+ * Enforces the mandatory close sequence:
+ *   1. All child ibeads must be closed (parent beads only)
+ *   2. codex:rescue reminder is surfaced
+ *   3. lint + type-check must pass
+ *   4. bd close is executed
+ *
+ * Usage:
+ *   node scripts/ibead-close.mjs --bead <id> [--dry-run] [--json] [--skip-quality]
+ *   npm run ibead:close -- --bead GGV3-abc123
+ *   npm run ibead:close -- --bead IB-abc123-1   (for ibeads)
+ */
+
+import { spawnSync } from 'node:child_process';
+
+function usage() {
+  console.error('Usage: node scripts/ibead-close.mjs --bead <id> [--dry-run] [--json] [--skip-quality]');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const parsed = { bead: '', dryRun: false, json: false, skipQuality: false };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--bead') parsed.bead = argv[++i] ?? '';
+    else if (t === '--dry-run') parsed.dryRun = true;
+    else if (t === '--json') parsed.json = true;
+    else if (t === '--skip-quality') parsed.skipQuality = true;
+  }
+  return parsed;
+}
+
+function runBd(args) {
+  const result = spawnSync('bd', args, { cwd: process.cwd(), encoding: 'utf8' });
+  if (result.error) throw new Error(`bd error: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`bd ${args[0]} failed: ${detail}`);
+  }
+  return String(result.stdout || '').trim();
+}
+
+function runNpm(script) {
+  const result = spawnSync('npm', ['run', script], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: 120000,
+    stdio: 'pipe',
+  });
+  return {
+    ok: result.status === 0,
+    stdout: String(result.stdout || '').trim(),
+    stderr: String(result.stderr || '').trim(),
+    status: result.status,
+  };
+}
+
+function parseJson(raw, label) {
+  const str = String(raw || '');
+  const match = str.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+  const jsonStr = match ? match[1] : str;
+  try { return JSON.parse(jsonStr || '{}'); }
+  catch { throw new Error(`${label} returned invalid JSON`); }
+}
+
+function toArray(val) {
+  if (Array.isArray(val)) return val;
+  if (Array.isArray(val?.issues)) return val.issues;
+  if (Array.isArray(val?.data)) return val.data;
+  if (typeof val === 'object' && val !== null) return Object.values(val).filter(Array.isArray)[0] ?? [];
+  return [];
+}
+
+function isIbead(bead) {
+  const labels = bead.labels || [];
+  return labels.includes('type:ibead') || (bead.title || '').match(/^IB-/);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.bead) usage();
+
+  const gate = {
+    beadId: args.bead,
+    beadTitle: '',
+    isIbead: false,
+    isParent: false,
+    childIbeadsCheck: { required: false, passed: false, open: [] },
+    codexRescuePrompted: false,
+    lintPassed: false,
+    typeCheckPassed: false,
+    closed: false,
+    errors: [],
+    dryRun: args.dryRun,
+  };
+
+  // 1. Fetch bead details (bd show returns an array)
+  const beadRaw = runBd(['show', args.bead, '--json']);
+  const beadParsed = parseJson(beadRaw, `bd show ${args.bead}`);
+  const bead = Array.isArray(beadParsed) ? beadParsed[0] : beadParsed;
+  gate.beadTitle = bead?.title || args.bead;
+  gate.isIbead = isIbead(bead);
+  gate.isParent = !gate.isIbead;
+
+  console.log(`\nibead:close — Close gate for ${args.bead}`);
+  console.log(`  Title: "${gate.beadTitle}"`);
+  console.log(`  Type: ${gate.isIbead ? 'ibead' : 'parent bead'}\n`);
+
+  // 2. For parent beads: check all ibeads are closed
+  if (gate.isParent) {
+    gate.childIbeadsCheck.required = true;
+    const childrenRaw = runBd(['children', args.bead, '--json']);
+    const allChildren = toArray(parseJson(childrenRaw, 'bd children'));
+    const ibeads = allChildren.filter(c => isIbead(c));
+    const openIbeads = ibeads.filter(c => c.status !== 'closed');
+
+    if (openIbeads.length > 0) {
+      gate.childIbeadsCheck.passed = false;
+      gate.childIbeadsCheck.open = openIbeads.map(c => c.id);
+      gate.errors.push(`${openIbeads.length} ibead(s) still open: ${gate.childIbeadsCheck.open.join(', ')}`);
+      console.log(`  ❌ GATE FAILED: Open ibeads must be closed first:`);
+      for (const ib of openIbeads) {
+        console.log(`     · ${ib.id}: ${ib.title}`);
+      }
+      console.log(`\n  Run: npm run ibead:close -- --bead <ibead-id>  for each one first.\n`);
+    } else {
+      gate.childIbeadsCheck.passed = true;
+      console.log(`  ✓ All ibeads closed (${ibeads.length} total)`);
+    }
+
+    if (!gate.childIbeadsCheck.passed) {
+      if (args.json) process.stdout.write(`${JSON.stringify(gate, null, 2)}\n`);
+      process.exit(1);
+    }
+  }
+
+  // 3. codex:rescue reminder (mandatory — agent must confirm it was run)
+  gate.codexRescuePrompted = true;
+  console.log(`  ⚡ REQUIRED: codex:rescue must be run before closing.`);
+  console.log(`     Run /codex:rescue in your session if not already done.`);
+  console.log(`     codex:rescue identifies work that was missed or needs hardening.\n`);
+
+  // 4. Quality gate: lint
+  if (!args.skipQuality) {
+    console.log(`  Running lint...`);
+    const lintResult = runNpm('lint');
+    if (lintResult.ok) {
+      gate.lintPassed = true;
+      console.log(`  ✓ Lint passed`);
+    } else {
+      gate.lintPassed = false;
+      gate.errors.push('lint failed');
+      console.log(`  ❌ Lint failed:`);
+      const errLines = (lintResult.stdout + '\n' + lintResult.stderr)
+        .split('\n').filter(l => l.includes('error') || l.includes('Error')).slice(0, 10);
+      for (const l of errLines) console.log(`     ${l}`);
+    }
+
+    // 5. Quality gate: type-check
+    console.log(`  Running type-check...`);
+    const typeResult = runNpm('type-check');
+    if (typeResult.ok) {
+      gate.typeCheckPassed = true;
+      console.log(`  ✓ Type-check passed`);
+    } else {
+      gate.typeCheckPassed = false;
+      gate.errors.push('type-check failed');
+      console.log(`  ❌ Type-check failed:`);
+      const errLines = (typeResult.stdout + '\n' + typeResult.stderr)
+        .split('\n').filter(l => l.trim()).slice(0, 10);
+      for (const l of errLines) console.log(`     ${l}`);
+    }
+
+    if (!gate.lintPassed || !gate.typeCheckPassed) {
+      console.log(`\n  ❌ CLOSE BLOCKED: Fix lint/type errors before closing.\n`);
+      if (args.json) process.stdout.write(`${JSON.stringify(gate, null, 2)}\n`);
+      process.exit(1);
+    }
+  } else {
+    gate.lintPassed = true;
+    gate.typeCheckPassed = true;
+    console.log(`  ⚠ Quality gates skipped (--skip-quality flag)`);
+  }
+
+  // 6. All gates passed — close the bead
+  console.log(`\n  All gates passed. Closing ${args.bead}...`);
+
+  if (!args.dryRun) {
+    runBd(['close', args.bead]);
+    gate.closed = true;
+    console.log(`  ✓ ${args.bead} closed successfully.\n`);
+  } else {
+    gate.closed = false;
+    console.log(`  [dry-run] Would close ${args.bead}\n`);
+  }
+
+  if (args.json) process.stdout.write(`${JSON.stringify(gate, null, 2)}\n`);
+}
+
+main();

--- a/examples/ibead-system/scripts/ibead-create.mjs
+++ b/examples/ibead-system/scripts/ibead-create.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * ibead-create.mjs — Pass 1: Generate interconnected beads (ibeads) for a parent bead.
+ *
+ * Runs GitNexus depth-1 impact analysis on the parent bead's title/description,
+ * identifies 3–5 impacted domains, and creates ibead records in the bd store.
+ * Also writes ibead lines to Task.md under the parent task.
+ *
+ * Usage:
+ *   node scripts/ibead-create.mjs --parent <bead-id> [--dry-run] [--json]
+ *   npm run ibead:create -- --parent GGV3-abc123
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const TASK_MD = path.join(process.cwd(), 'Task.md');
+const MAX_IBEADS = 5;
+const MIN_IBEADS = 3;
+
+function usage() {
+  console.error('Usage: node scripts/ibead-create.mjs --parent <bead-id> [--dry-run] [--json]');
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const parsed = { parent: '', dryRun: false, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--parent') parsed.parent = argv[++i] ?? '';
+    else if (t === '--dry-run') parsed.dryRun = true;
+    else if (t === '--json') parsed.json = true;
+  }
+  return parsed;
+}
+
+function runBd(args) {
+  const result = spawnSync('bd', args, { cwd: process.cwd(), encoding: 'utf8' });
+  if (result.error) throw new Error(`bd error: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`bd ${args[0]} failed: ${detail}`);
+  }
+  return String(result.stdout || '').trim();
+}
+
+function runGitNexus(args) {
+  const result = spawnSync('npx', ['--yes', 'gitnexus', ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: 30000,
+  });
+  if (result.error || result.status !== 0) return null;
+  return String(result.stdout || '').trim();
+}
+
+function parseJson(raw, label) {
+  const str = String(raw || '');
+  // bd may prepend warning text before JSON — extract the JSON object/array
+  const match = str.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+  try { return JSON.parse(match ? match[1] : str || '{}'); }
+  catch { throw new Error(`${label} returned invalid JSON: ${str.slice(0, 200)}`); }
+}
+
+/** Extract key search terms from a bead title/description */
+function extractTerms(text) {
+  const stopWords = new Set([
+    'the', 'a', 'an', 'and', 'or', 'for', 'to', 'in', 'on', 'at', 'with',
+    'add', 'fix', 'update', 'remove', 'refactor', 'implement', 'create',
+    'new', 'old', 'get', 'set', 'use', 'make', 'build', 'run', 'test',
+  ]);
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 3 && !stopWords.has(w))
+    .slice(0, 6)
+    .join(' ');
+}
+
+/** Parse GitNexus query output to extract domain groups */
+function extractDomains(gitnexusOutput) {
+  if (!gitnexusOutput) return [];
+  const domains = new Map();
+
+  // GitNexus returns process-grouped results — extract process/cluster names
+  const processMatches = gitnexusOutput.matchAll(/Process:\s*([^\n]+)/gi);
+  for (const m of processMatches) {
+    const name = m[1].trim().replace(/\s+/g, '-').toLowerCase();
+    if (name && !domains.has(name)) domains.set(name, { domain: name, symbols: [] });
+  }
+
+  // Also look for file path clusters as domain signals
+  const fileMatches = gitnexusOutput.matchAll(/(?:src|lib|app|packages)\/([^/\n]+)\//gi);
+  for (const m of fileMatches) {
+    const name = m[1].trim().toLowerCase();
+    if (name && !domains.has(name)) domains.set(name, { domain: name, symbols: [] });
+  }
+
+  return [...domains.values()].slice(0, MAX_IBEADS);
+}
+
+/** Fallback: generate domain stubs from bead title when GitNexus unavailable */
+function fallbackDomains(beadTitle) {
+  const DOMAIN_KEYWORDS = {
+    'auth': 'auth-layer',
+    'session': 'session-layer',
+    'user': 'user-service',
+    'api': 'api-contracts',
+    'route': 'routing-layer',
+    'db': 'database-layer',
+    'database': 'database-layer',
+    'mongo': 'database-layer',
+    'ui': 'ui-components',
+    'component': 'ui-components',
+    'forum': 'forum-domain',
+    'auction': 'auction-domain',
+    'test': 'ci-coverage',
+    'ci': 'ci-coverage',
+    'security': 'security-layer',
+    'payment': 'payments-domain',
+    'email': 'notification-layer',
+    'notify': 'notification-layer',
+    'seo': 'seo-layer',
+    'analytics': 'analytics-layer',
+  };
+
+  const lower = beadTitle.toLowerCase();
+  const matched = new Set();
+  for (const [keyword, domain] of Object.entries(DOMAIN_KEYWORDS)) {
+    if (lower.includes(keyword)) matched.add(domain);
+    if (matched.size >= MAX_IBEADS) break;
+  }
+
+  // Always include ci-coverage and api-contracts as baseline impact domains
+  matched.add('ci-coverage');
+  matched.add('api-contracts');
+
+  return [...matched].slice(0, MAX_IBEADS).map(d => ({ domain: d, symbols: [] }));
+}
+
+/** Write ibead lines to Task.md under the parent bead */
+function updateTaskMd(parentId, ibeads) {
+  if (!fs.existsSync(TASK_MD)) return;
+
+  const content = fs.readFileSync(TASK_MD, 'utf8');
+  const lines = content.split('\n');
+
+  // Find line containing parent bead ID
+  const parentLineIdx = lines.findIndex(l => l.includes(parentId));
+  if (parentLineIdx === -1) return; // Parent not in Task.md — skip
+
+  // Check if ibeads already inserted for this parent
+  const alreadyInserted = lines.some(l => l.includes(`IB-${parentId.split('-')[1]}`));
+  if (alreadyInserted) return;
+
+  // Build ibead lines (indented under parent)
+  const ibadLines = ibeads.map(ib =>
+    `  - [ ] ${ib.id}: [domain: ${ib.domain}] ${ib.title}`
+  );
+
+  // Insert after parent line
+  lines.splice(parentLineIdx + 1, 0, ...ibadLines);
+  fs.writeFileSync(TASK_MD, lines.join('\n'), 'utf8');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.parent) usage();
+
+  // 1. Fetch parent bead details (bd show returns an array)
+  const parentRaw = runBd(['show', args.parent, '--json']);
+  const parentParsed = parseJson(parentRaw, `bd show ${args.parent}`);
+  const parent = Array.isArray(parentParsed) ? parentParsed[0] : parentParsed;
+  const parentTitle = parent?.title || parent?.id || args.parent;
+  const parentIdShort = args.parent.split('-').pop() || args.parent;
+
+  // 2. Run GitNexus Pass 1 — query by bead terms
+  const terms = extractTerms(parentTitle);
+  let domains = [];
+
+  if (terms) {
+    const gnOutput = runGitNexus(['query', terms]);
+    domains = extractDomains(gnOutput);
+  }
+
+  // Fallback if GitNexus unavailable or returns no domains
+  if (domains.length < MIN_IBEADS) {
+    const fallback = fallbackDomains(parentTitle);
+    const existingDomainNames = new Set(domains.map(d => d.domain));
+    for (const d of fallback) {
+      if (!existingDomainNames.has(d.domain)) domains.push(d);
+      if (domains.length >= MAX_IBEADS) break;
+    }
+  }
+
+  domains = domains.slice(0, MAX_IBEADS);
+
+  // 3. Create ibeads
+  const created = [];
+  for (let i = 0; i < domains.length; i++) {
+    const { domain } = domains[i];
+    const ibTitle = `IB-${parentIdShort}-${i + 1}: [${domain}] splash audit — ${parentTitle}`;
+    const metadata = JSON.stringify({
+      ibead: true,
+      domain,
+      depth: 1,
+      gitnexus_pass: 1,
+      task_list: [],
+      parent_title: parentTitle,
+    });
+
+    if (args.dryRun) {
+      created.push({ id: `DRY-IB-${parentIdShort}-${i + 1}`, domain, title: ibTitle });
+      continue;
+    }
+
+    const raw = runBd([
+      'create', ibTitle,
+      '--parent', args.parent,
+      '--label', 'type:ibead',
+      '--metadata', metadata,
+      '--json',
+    ]);
+
+    // Extract created ibead ID
+    const parsed = parseJson(raw, 'bd create ibead');
+    const id = parsed.id || parsed.issue_id || `IB-${parentIdShort}-${i + 1}`;
+    created.push({ id, domain, title: ibTitle });
+  }
+
+  // 4. Update Task.md
+  if (!args.dryRun) {
+    updateTaskMd(args.parent, created);
+  }
+
+  // 5. Output
+  const summary = {
+    parent: args.parent,
+    parentTitle,
+    gitnexusTerms: terms,
+    ibeadsCreated: created.length,
+    ibeads: created,
+    pass: 1,
+    note: 'Pass 1 ibeads are approximations. Run ibead:audit after implementation-complete for accurate blast radius.',
+    dryRun: args.dryRun,
+  };
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } else {
+    console.log(`\nibead:create — Pass 1 complete for ${args.parent}`);
+    console.log(`  Parent: "${parentTitle}"`);
+    console.log(`  GitNexus query terms: "${terms}"`);
+    console.log(`  Ibeads created: ${created.length}`);
+    for (const ib of created) {
+      console.log(`    ${ib.id}  [${ib.domain}]`);
+    }
+    console.log(`\n  ⚡ Pass 1 complete. Run ibead:audit after implementation-complete for accurate blast radius.\n`);
+  }
+}
+
+main();

--- a/examples/ibead-system/scripts/ibead-research.mjs
+++ b/examples/ibead-system/scripts/ibead-research.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * ibead-research.mjs — Batch re-evaluation of ibeads across all open/in-progress beads.
+ *
+ * Scans all open and in-progress beads. For each:
+ *   - Re-runs GitNexus impact analysis (code may have shifted since other beads were closed)
+ *   - Adds new ibeads where splash radius has expanded
+ *   - Flags existing ibeads that may be stale or already resolved
+ *
+ * Produces a structured summary report on completion.
+ *
+ * Usage:
+ *   node scripts/ibead-research.mjs [--dry-run] [--json] [--bead <id>]
+ *   npm run ibead:research
+ *   npm run ibead:research -- --bead GGV3-abc123   (single bead only)
+ */
+
+import { spawnSync } from 'node:child_process';
+
+function parseArgs(argv) {
+  const parsed = { dryRun: false, json: false, bead: '' };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--dry-run') parsed.dryRun = true;
+    else if (t === '--json') parsed.json = true;
+    else if (t === '--bead') parsed.bead = argv[++i] ?? '';
+  }
+  return parsed;
+}
+
+function runBd(args) {
+  const result = spawnSync('bd', args, { cwd: process.cwd(), encoding: 'utf8' });
+  if (result.error) throw new Error(`bd error: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`bd ${args[0]} failed: ${detail}`);
+  }
+  return String(result.stdout || '').trim();
+}
+
+function runGitNexus(args, timeout = 30000) {
+  const result = spawnSync('npx', ['--yes', 'gitnexus', ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout,
+  });
+  if (result.error || result.status !== 0) return null;
+  return String(result.stdout || '').trim();
+}
+
+function runNode(scriptPath, args) {
+  const result = spawnSync('node', [scriptPath, ...args], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+  if (result.error) throw new Error(`node error: ${result.error.message}`);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`Script failed: ${detail}`);
+  }
+  return String(result.stdout || '').trim();
+}
+
+function parseJson(raw, label) {
+  const str = String(raw || '');
+  const match = str.match(/(\{[\s\S]*\}|\[[\s\S]*\])/);
+  const jsonStr = match ? match[1] : str;
+  try { return JSON.parse(jsonStr || '{}'); }
+  catch (e) { throw new Error(`${label} returned invalid JSON: ${e.message}`); }
+}
+
+function toArray(val) {
+  if (Array.isArray(val)) return val;
+  if (Array.isArray(val?.issues)) return val.issues;
+  if (Array.isArray(val?.data)) return val.data;
+  if (typeof val === 'object' && val !== null) return Object.values(val).find(v => Array.isArray(v)) ?? [];
+  return [];
+}
+
+function isIbead(bead) {
+  const labels = bead.labels || [];
+  return labels.includes('type:ibead') || (bead.title || '').match(/^IB-/);
+}
+
+function extractTerms(text) {
+  const stopWords = new Set([
+    'the', 'a', 'an', 'and', 'or', 'for', 'to', 'in', 'on', 'at', 'with',
+    'add', 'fix', 'update', 'remove', 'refactor', 'implement', 'create',
+    'new', 'old', 'get', 'set', 'use', 'make', 'build', 'run', 'test',
+  ]);
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 3 && !stopWords.has(w))
+    .slice(0, 6)
+    .join(' ');
+}
+
+function extractDomainsFromOutput(output) {
+  if (!output) return [];
+  const domains = new Set();
+  const processMatches = output.matchAll(/Process:\s*([^\n]+)/gi);
+  for (const m of processMatches) domains.add(m[1].trim().replace(/\s+/g, '-').toLowerCase());
+  const fileMatches = output.matchAll(/(?:src|lib|app|packages)\/([^/\n]+)\//gi);
+  for (const m of fileMatches) domains.add(m[1].trim().toLowerCase());
+  return [...domains].slice(0, 5);
+}
+
+function detectStaleness(ibead, currentDomains) {
+  const meta = ibead.metadata || {};
+  const ibDomain = meta.domain || '';
+  if (!ibDomain) return false;
+  // If the ibead's domain no longer appears in current GitNexus results, flag as potentially stale
+  return currentDomains.length > 0 && !currentDomains.some(d =>
+    d.includes(ibDomain.split('-')[0]) || ibDomain.includes(d.split('-')[0])
+  );
+}
+
+async function processBead(beadId, dryRun) {
+  const result = {
+    beadId,
+    beadTitle: '',
+    existingIbeads: 0,
+    newIbeadsAdded: 0,
+    staleIbeadsFlagged: 0,
+    ibeadsNeedingAttention: [],
+    errors: [],
+  };
+
+  try {
+    // Fetch bead details (bd show returns an array)
+    const beadRaw = runBd(['show', beadId, '--json']);
+    const beadParsed = parseJson(beadRaw, `bd show ${beadId}`);
+    const bead = Array.isArray(beadParsed) ? beadParsed[0] : beadParsed;
+    result.beadTitle = bead?.title || beadId;
+
+    // Get existing ibeads
+    const childrenRaw = runBd(['children', beadId, '--json']);
+    const allChildren = toArray(parseJson(childrenRaw, 'bd children'));
+    const existingIbeads = allChildren.filter(c => isIbead(c) && c.status !== 'closed');
+    result.existingIbeads = existingIbeads.length;
+
+    // Re-run GitNexus for current blast radius
+    const terms = extractTerms(result.beadTitle);
+    const gnOutput = terms ? runGitNexus(['query', terms]) : null;
+    const currentDomains = extractDomainsFromOutput(gnOutput);
+
+    // Check for stale ibeads
+    for (const ib of existingIbeads) {
+      if (detectStaleness(ib, currentDomains)) {
+        result.staleIbeadsFlagged++;
+        result.ibeadsNeedingAttention.push({
+          id: ib.id,
+          reason: 'domain no longer in current blast radius — may be resolved',
+          action: 'review and close if clean',
+        });
+      }
+    }
+
+    // Check if new domains emerged that don't have ibeads yet
+    const existingDomains = new Set(
+      existingIbeads.map(ib => (ib.metadata || {}).domain || '').filter(Boolean)
+    );
+
+    const newDomains = currentDomains.filter(d => !existingDomains.has(d));
+    if (newDomains.length > 0 && existingIbeads.length < 5) {
+      // Create new ibeads for emerging domains
+      const toCreate = newDomains.slice(0, 5 - existingIbeads.length);
+      if (!dryRun && toCreate.length > 0) {
+        const parentIdShort = beadId.split('-').pop() || beadId;
+        for (let i = 0; i < toCreate.length; i++) {
+          const domain = toCreate[i];
+          const ibTitle = `IB-${parentIdShort}-R${i + 1}: [${domain}] re-research ibead — ${result.beadTitle}`;
+          const metadata = JSON.stringify({
+            ibead: true,
+            domain,
+            depth: 1,
+            gitnexus_pass: 1,
+            task_list: [],
+            parent_title: result.beadTitle,
+            generated_by: 'ibead:research',
+          });
+          runBd(['create', ibTitle, '--parent', beadId, '--label', 'type:ibead', '--metadata', metadata]);
+          result.newIbeadsAdded++;
+          result.ibeadsNeedingAttention.push({
+            id: `IB-${parentIdShort}-R${i + 1}`,
+            reason: `new domain "${domain}" emerged from current GitNexus analysis`,
+            action: 'run ibead:audit to populate task list',
+          });
+        }
+      } else if (dryRun) {
+        result.newIbeadsAdded = toCreate.length;
+        for (const d of toCreate) {
+          result.ibeadsNeedingAttention.push({
+            id: '[dry-run]',
+            reason: `new domain "${d}" would be created`,
+            action: 'run without --dry-run to create',
+          });
+        }
+      }
+    }
+
+  } catch (err) {
+    result.errors.push(err.message);
+  }
+
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  console.log(`\nibead:research — ${new Date().toISOString().slice(0, 10)}`);
+  if (args.dryRun) console.log(`  [dry-run mode]\n`);
+  else console.log('');
+
+  let beadIds = [];
+
+  if (args.bead) {
+    beadIds = [args.bead];
+  } else {
+    // Fetch all open + in_progress beads that are NOT ibeads
+    const openRaw = runBd(['list', '--status=open', '--json']);
+    const inProgressRaw = runBd(['list', '--status=in_progress', '--json']);
+
+    const openBeads = toArray(parseJson(openRaw, 'bd list open'));
+    const inProgressBeads = toArray(parseJson(inProgressRaw, 'bd list in_progress'));
+    const allBeads = [...openBeads, ...inProgressBeads];
+
+    beadIds = allBeads
+      .filter(b => !isIbead(b))
+      .map(b => b.id)
+      .filter(Boolean);
+  }
+
+  if (beadIds.length === 0) {
+    console.log('  No open/in-progress beads found.\n');
+    process.exit(0);
+  }
+
+  console.log(`  Beads to scan: ${beadIds.length}\n`);
+
+  const results = [];
+  let totalNew = 0;
+  let totalStale = 0;
+  let totalAttention = 0;
+
+  for (const beadId of beadIds) {
+    process.stdout.write(`  Scanning ${beadId}...`);
+    const result = await processBead(beadId, args.dryRun);
+    results.push(result);
+
+    totalNew += result.newIbeadsAdded;
+    totalStale += result.staleIbeadsFlagged;
+    totalAttention += result.ibeadsNeedingAttention.length;
+
+    const status = result.errors.length > 0
+      ? ` ❌ error: ${result.errors[0]}`
+      : ` ✓ (${result.existingIbeads} ibeads, +${result.newIbeadsAdded} new, ${result.staleIbeadsFlagged} stale)`;
+    console.log(status);
+  }
+
+  // Summary report
+  const summary = {
+    timestamp: new Date().toISOString(),
+    beadsScanned: beadIds.length,
+    ibeadsNew: totalNew,
+    ibeadsStale: totalStale,
+    ibeadsNeedingAttention: totalAttention,
+    results,
+    dryRun: args.dryRun,
+  };
+
+  console.log(`
+ibead:research complete — ${summary.timestamp.slice(0, 10)}
+  Beads scanned:              ${summary.beadsScanned}
+  Ibeads added:               ${summary.ibeadsNew}
+  Ibeads flagged stale:       ${summary.ibeadsStale}
+  Ibeads needing attention:   ${summary.ibeadsNeedingAttention}
+`);
+
+  if (totalAttention > 0) {
+    console.log('  Action required:');
+    for (const r of results) {
+      for (const item of r.ibeadsNeedingAttention) {
+        console.log(`    ${item.id}  [${r.beadId}]  ${item.reason}`);
+        console.log(`      → ${item.action}`);
+      }
+    }
+    console.log('');
+  }
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  }
+}
+
+main().catch(err => {
+  console.error(`ibead:research failed: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This PR introduces the **ibead (interconnected bead)** pattern — a reference implementation demonstrating impact-aware task tracking built entirely on the existing `bd` CLI with no schema changes or second systems.

ibeads are domain-scoped collateral responsibility markers automatically generated from GitNexus depth-1 blast-radius analysis when a parent bead is created. They make adjacent code impact a first-class tracked artifact with a mandatory close gate.

---

## What Problem This Solves

Without ibeads, beads track *what to do* but not *what else breaks*. An agent closes a bead after implementing a feature but silently leaves behind broken callers, desynchronized API contracts, and CI coverage that doesn't reach the changed surface. ibeads convert ad-hoc impact analysis into tracked, enforced work items.

---

## Architecture

### The ibead distinction

```
ibeads ≠ sub-tasks
ibeads = "what adjacent code domains will be damaged by this work"
```

A sub-task decomposes the work. An ibead marks adjacent impact. You don't implement ibeads — you audit them. Closing an ibead may require zero code changes if the domain is unaffected.

### Two-pass GitNexus integration

| Pass | Trigger | Method | Purpose |
|---|---|---|---|
| **Pass 1** | `bd create` | `gitnexus query <title terms>` | Early warning approximation |
| **Pass 2** | `implementation-complete` | `gitnexus impact <symbol> --direction upstream` | Accurate blast radius on actual diff |

### Close gate (programmatically enforced)

```
bd update <id> --status implementation-complete
  → Pass 2 GitNexus scan
  → codex:rescue reminder (mandatory second-opinion AI review)

npm run lint && npm run type-check  ← must pass clean

(parent beads only) all child ibeads must be closed

ibead-close.mjs → bd close <id>
```

### No second system

ibeads use only existing `bd` fields — `labels`, `--parent`, `metadata`. Same Dolt store. No schema migration. Pure client on the public `bd` CLI.

---

## Feature Inventory

| Feature | Script | Description |
|---|---|---|
| Pass 1 ibead generation | `ibead-create.mjs` | GitNexus query on bead title → 3–5 domain-scoped ibeads → bd store + Task.md |
| Pass 2 blast radius audit | `ibead-audit.mjs` | GitNexus impact on changed symbols → task_list per ibead → Task.md sub-bullets |
| Close gate enforcement | `ibead-close.mjs` | codex:rescue + lint + type-check + all-ibeads-closed before `bd close` permitted |
| Batch re-evaluation | `ibead-research.mjs` | Re-evaluate all open beads, detect new domains, flag stale ibeads, summary report |
| Dry-run mode | all scripts | `--dry-run` previews without writing |
| JSON output | all scripts | `--json` for machine-readable output and CI integration |
| Graceful GitNexus fallback | `ibead-create.mjs` | Keyword-based domain extraction if GitNexus unavailable |
| bd warning prefix handling | all scripts | Regex JSON extraction handles bd's non-JSON warning prefixes |
| bd array response handling | all scripts | `bd show` returns `[{...}]` — scripts unwrap first element |
| Depth control | architecture | Depth-1 default; `bead:deepresearch:N` for N-hop transitive analysis (opt-in) |
| Formula template | `ibead.yaml` | bd formula encoding the full ibead lifecycle |

---

## File Inventory

```
examples/ibead-system/
├── README.md                    — concept, architecture, quick reference, real-world test results
├── scripts/
│   ├── ibead-create.mjs         — Pass 1: GitNexus query → extract domains → create 3–5 ibeads
│   ├── ibead-audit.mjs          — Pass 2: git diff → symbols → gitnexus impact → task_list
│   ├── ibead-close.mjs          — close gate: all-ibeads-closed + codex:rescue + lint + type-check
│   └── ibead-research.mjs       — batch: re-evaluate all open beads, new domains, stale detection
├── formulas/
│   └── ibead.yaml               — bd formula template for the ibead lifecycle
└── docs/
    ├── ARCHITECTURE.md          — design decisions, data flow, bd API surface, error handling
    └── WORKFLOW.md              — step-by-step walkthrough with real terminal output
```

---

## GitNexus Dependency Surface

| Command | Script | Purpose |
|---|---|---|
| `npx gitnexus query "<terms>"` | `ibead-create.mjs` | Find execution flows matching bead title terms |
| `npx gitnexus impact <sym> --direction upstream` | `ibead-audit.mjs` | Direct callers and importers |
| `npx gitnexus detect-changes --scope compare --base-ref main` | `ibead-audit.mjs` | Branch diff symbol inventory |

All calls: 30-second timeout, graceful degradation, keyword fallback if unavailable.

---

## bd API Surface Used

| Command | Used by |
|---|---|
| `bd show <id> --json` | all scripts |
| `bd children <id> --json` | audit, close, research |
| `bd create <title> --parent --label --metadata --json` | create, research |
| `bd update <id> --metadata <json>` | audit |
| `bd close <id>` | close |
| `bd list --status=open/in_progress --json` | research |

---

## Real-World Validation

Tested against GGV3 (38K+ symbols, 70K+ GitNexus relationships):

- Pass 1: correctly identified `[components]`, `[services]`, `[store]`, `[api]` domains; terms extracted cleanly from bead title
- Pass 2 (dry-run): populated 5 file-level investigation items per ibead from branch diff
- Close gate: blocked parent with 4 open ibeads, listed each by ID and title, exited 1
- `ibead:research`: scanned single bead, 0 stale, 0 new, clean summary

---

## codex:rescue Integration

`ibead-close.mjs` surfaces a mandatory codex:rescue reminder before every close. codex:rescue is a second-opinion AI review pass (via Codex CLI) that catches missed edge cases and hardening opportunities. Wiring it into the close gate ensures no bead closes without this second-pass review.

---

## Future Extensions (out of scope)

- `bead:deepresearch:N` — N-hop transitive ibead generation
- Auto-close on empty task_list (domain unaffected by diff)
- `ibead:watch` live mode — re-evaluate on each commit
- Bead graph visualization for cross-bead impact topology

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)