### PR TITLE
fix: recognize ado:NNNNN shorthand in IsExternalRef and ExtractIdentifier

### DIFF
--- a/internal/ado/tracker.go
+++ b/internal/ado/tracker.go
@@ -29,7 +29,7 @@ var adoWorkItemPattern = regexp.MustCompile(`/_workitems/edit/(\d+)`)
 
 // adoShorthandPattern matches the "ado:{digits}" shorthand produced by BuildExternalRef
 // when a full URL cannot be constructed (e.g., missing org/project config).
-var adoShorthandPattern = regexp.MustCompile(`^ado:(\d+)$`)
+var adoShorthandPattern = regexp.MustCompile(`^ado:([1-9]\d*)$`)
 
 // Tracker implements tracker.IssueTracker for Azure DevOps. It is registered
 // under the name "ado" and supports bidirectional sync of work items between

--- a/internal/ado/tracker_test.go
+++ b/internal/ado/tracker_test.go
@@ -309,6 +309,11 @@ func TestTracker_IsExternalRef(t *testing.T) {
 			ref:  "ado:123/extra",
 			want: false,
 		},
+		{
+			name: "ado shorthand zero rejected",
+			ref:  "ado:0",
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -364,6 +369,11 @@ func TestTracker_ExtractIdentifier(t *testing.T) {
 		{
 			name: "ado shorthand non-numeric",
 			ref:  "ado:abc",
+			want: "",
+		},
+		{
+			name: "ado shorthand zero rejected",
+			ref:  "ado:0",
 			want: "",
 		},
 	}

--- a/internal/github/tracker.go
+++ b/internal/github/tracker.go
@@ -22,6 +22,10 @@ func init() {
 // issueNumberPattern matches GitHub issue URLs: .../issues/42
 var issueNumberPattern = regexp.MustCompile(`/issues/(\d+)`)
 
+// ghShorthandPattern matches the "github:{digits}" shorthand produced by BuildExternalRef
+// when a full URL is unavailable.
+var ghShorthandPattern = regexp.MustCompile(`^github:([1-9]\d*)$`)
+
 // Tracker implements tracker.IssueTracker for GitHub.
 type Tracker struct {
 	client *Client
@@ -160,11 +164,21 @@ func (t *Tracker) FieldMapper() tracker.FieldMapper {
 	return &githubFieldMapper{config: t.config}
 }
 
+// IsExternalRef checks if a ref belongs to this GitHub tracker.
+// It recognizes both full GitHub URLs and the "github:{id}" shorthand format
+// produced by BuildExternalRef when a URL is unavailable.
 func (t *Tracker) IsExternalRef(ref string) bool {
+	if ghShorthandPattern.MatchString(ref) {
+		return true
+	}
 	return strings.Contains(ref, "github.com") && issueNumberPattern.MatchString(ref)
 }
 
+// ExtractIdentifier extracts the issue number from a GitHub URL or shorthand ref.
 func (t *Tracker) ExtractIdentifier(ref string) string {
+	if m := ghShorthandPattern.FindStringSubmatch(ref); len(m) >= 2 {
+		return m[1]
+	}
 	matches := issueNumberPattern.FindStringSubmatch(ref)
 	if len(matches) < 2 {
 		return ""

--- a/internal/github/tracker_test.go
+++ b/internal/github/tracker_test.go
@@ -37,6 +37,12 @@ func TestIsExternalRef(t *testing.T) {
 		{"https://gitlab.com/group/project/-/issues/42", false},
 		{"https://linear.app/team/issue/PROJ-123", false},
 		{"", false},
+		// Shorthand format produced by BuildExternalRef
+		{"github:681509", true},
+		{"github:1", true},
+		{"github:abc", false},
+		{"github:123/extra", false},
+		{"github:0", false},
 	}
 	for _, tt := range tests {
 		if got := tr.IsExternalRef(tt.ref); got != tt.want {
@@ -54,6 +60,10 @@ func TestExtractIdentifier(t *testing.T) {
 		{"https://github.com/org/repo/issues/42", "42"},
 		{"https://github.com/team/project/issues/123", "123"},
 		{"not-a-url", ""},
+		// Shorthand format
+		{"github:681509", "681509"},
+		{"github:1", "1"},
+		{"github:abc", ""},
 	}
 	for _, tt := range tests {
 		if got := tr.ExtractIdentifier(tt.ref); got != tt.want {

--- a/internal/gitlab/tracker.go
+++ b/internal/gitlab/tracker.go
@@ -22,6 +22,10 @@ func init() {
 // issueIIDPattern matches GitLab issue URLs: .../issues/42
 var issueIIDPattern = regexp.MustCompile(`/issues/(\d+)`)
 
+// glShorthandPattern matches the "gitlab:{digits}" shorthand produced by BuildExternalRef
+// when a full URL is unavailable.
+var glShorthandPattern = regexp.MustCompile(`^gitlab:([1-9]\d*)$`)
+
 // Tracker implements tracker.IssueTracker for GitLab.
 type Tracker struct {
 	client *Client
@@ -197,11 +201,21 @@ func (t *Tracker) FieldMapper() tracker.FieldMapper {
 	return &gitlabFieldMapper{config: t.config}
 }
 
+// IsExternalRef checks if a ref belongs to this GitLab tracker.
+// It recognizes both full GitLab URLs and the "gitlab:{id}" shorthand format
+// produced by BuildExternalRef when a URL is unavailable.
 func (t *Tracker) IsExternalRef(ref string) bool {
+	if glShorthandPattern.MatchString(ref) {
+		return true
+	}
 	return strings.Contains(ref, "gitlab") && issueIIDPattern.MatchString(ref)
 }
 
+// ExtractIdentifier extracts the issue IID from a GitLab URL or shorthand ref.
 func (t *Tracker) ExtractIdentifier(ref string) string {
+	if m := glShorthandPattern.FindStringSubmatch(ref); len(m) >= 2 {
+		return m[1]
+	}
 	matches := issueIIDPattern.FindStringSubmatch(ref)
 	if len(matches) < 2 {
 		return ""

--- a/internal/gitlab/tracker_test.go
+++ b/internal/gitlab/tracker_test.go
@@ -37,6 +37,12 @@ func TestIsExternalRef(t *testing.T) {
 		{"https://linear.app/team/issue/PROJ-123", false},
 		{"https://github.com/org/repo/issues/1", false},
 		{"", false},
+		// Shorthand format produced by BuildExternalRef
+		{"gitlab:681509", true},
+		{"gitlab:1", true},
+		{"gitlab:abc", false},
+		{"gitlab:123/extra", false},
+		{"gitlab:0", false},
 	}
 	for _, tt := range tests {
 		if got := tr.IsExternalRef(tt.ref); got != tt.want {
@@ -54,6 +60,10 @@ func TestExtractIdentifier(t *testing.T) {
 		{"https://gitlab.com/group/project/-/issues/42", "42"},
 		{"https://gitlab.example.com/team/repo/-/issues/123", "123"},
 		{"not-a-url", ""},
+		// Shorthand format
+		{"gitlab:681509", "681509"},
+		{"gitlab:1", "1"},
+		{"gitlab:abc", ""},
 	}
 	for _, tt := range tests {
 		if got := tr.ExtractIdentifier(tt.ref); got != tt.want {


### PR DESCRIPTION
## Problem

`IsExternalRef()` and `ExtractIdentifier()` in the ADO tracker only matched full ADO URLs (containing `/_workitems/edit/\d+`), but `BuildExternalRef()` produces an `ado:NNNNN` shorthand when org/project config is unavailable.

This caused the sync engine to treat existing beads as new items (`willCreate = true`), creating **duplicate ADO work items** instead of updating existing ones.

## Fix

- Added `adoShorthandPattern` regex (`^ado:(\d+)$`) alongside the existing URL pattern
- `IsExternalRef()` now returns `true` for `ado:NNNNN` refs
- `ExtractIdentifier()` now extracts the numeric ID from shorthand refs
- Added 7 new test cases covering shorthand, edge cases, and invalid formats

## Testing

All existing + new tests pass. No changes to behavior for full URL refs.