### PR TITLE
fix: repair nightly test failures for TestInitCancel_E2E and dolt autostart

### DIFF
--- a/cmd/bd/dolt_autostart_lifecycle_integration_test.go
+++ b/cmd/bd/dolt_autostart_lifecycle_integration_test.go
@@ -43,7 +43,7 @@ func TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands(t *testing.T) {
 		"GIT_ASKPASS=",
 	)
 
-	initOut, initErr := runBDExecWithBinary(t, bdBinary, tmpDir, env, "init", "--backend", "dolt", "--prefix", "test", "--quiet")
+	initOut, initErr := runBDExecWithBinary(t, bdBinary, tmpDir, env, "init", "--backend", "dolt", "--server", "--prefix", "test", "--quiet")
 	if initErr != nil {
 		lower := strings.ToLower(initOut)
 		if strings.Contains(lower, "dolt") && (strings.Contains(lower, "not supported") || strings.Contains(lower, "not available") || strings.Contains(lower, "unknown")) {

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1370,12 +1370,19 @@ func checkExistingBeadsData(prefix string) error {
 
 // isNonInteractiveInit returns true if init should run without interactive prompts.
 // Precedence: explicit flag > BD_NON_INTERACTIVE env > CI env > terminal detection.
+// Setting BD_NON_INTERACTIVE=0 or BD_NON_INTERACTIVE=false explicitly forces
+// interactive mode, overriding CI detection and terminal checks.
 func isNonInteractiveInit(flagValue bool) bool {
 	if flagValue {
 		return true
 	}
-	if v := os.Getenv("BD_NON_INTERACTIVE"); v == "1" || v == "true" {
-		return true
+	if v := os.Getenv("BD_NON_INTERACTIVE"); v != "" {
+		if v == "1" || v == "true" {
+			return true
+		}
+		// Explicit BD_NON_INTERACTIVE=0/false forces interactive mode,
+		// overriding CI and terminal detection.
+		return false
 	}
 	if v := os.Getenv("CI"); v == "true" || v == "1" {
 		return true

--- a/cmd/bd/init_cancel_e2e_test.go
+++ b/cmd/bd/init_cancel_e2e_test.go
@@ -43,10 +43,12 @@ func TestInitCancel_E2E(t *testing.T) {
 	cmd.Stdin = stdinR
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stdoutW
-	cmd.Env = append(filteredEnv("BEADS_DB", "BEADS_DIR", "HOME", "XDG_CONFIG_HOME"),
+	cmd.Env = append(filteredEnv("BEADS_DB", "BEADS_DIR", "HOME", "XDG_CONFIG_HOME", "BD_NON_INTERACTIVE", "CI"),
 		"BEADS_DB=",
 		"HOME="+tmpDir,
 		"XDG_CONFIG_HOME="+filepath.Join(tmpDir, "xdg-config"),
+		"BD_NON_INTERACTIVE=0",
+		"CI=",
 	)
 
 	if err := cmd.Start(); err != nil {

--- a/cmd/bd/init_noninteractive_test.go
+++ b/cmd/bd/init_noninteractive_test.go
@@ -73,6 +73,20 @@ func TestIsNonInteractiveInit(t *testing.T) {
 			// In test environment, stdin is piped (not a TTY), so non-interactive
 			want: true,
 		},
+		{
+			name:      "BD_NON_INTERACTIVE=0 forces interactive",
+			flagValue: false,
+			envCI:     "true",
+			envBDNI:   "0",
+			want:      false,
+		},
+		{
+			name:      "BD_NON_INTERACTIVE=false forces interactive",
+			flagValue: false,
+			envCI:     "true",
+			envBDNI:   "false",
+			want:      false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Two nightly integration tests have been failing on main for 5+ consecutive days.

### TestInitCancel_E2E

Broken by 5e609618 which added `--non-interactive` auto-detection. The test runs `bd init --contributor` with a piped stdin, but `isNonInteractiveInit()` detects non-interactive mode (CI=true + non-TTY stdin) and rejects the `--contributor` flag.

**Fix:** Support `BD_NON_INTERACTIVE=0`/`false` to explicitly force interactive mode, overriding CI and terminal detection. The test sets this in its env.

### TestE2E_AutoStartedRepoLocalServerPersistsAcrossCommands

Broken by a35edfd2 which made embedded mode the default. The test needs server mode for `dolt status/start/stop` lifecycle testing, but init now defaults to embedded mode where those commands aren't supported.

**Fix:** Add `--server` flag to the `bd init` call in the test.

### Changes

- `cmd/bd/init.go`: `isNonInteractiveInit()` now treats `BD_NON_INTERACTIVE=0`/`false` as an explicit opt-in to interactive mode
- `cmd/bd/init_noninteractive_test.go`: Added unit tests for the new override behavior
- `cmd/bd/init_cancel_e2e_test.go`: Set `BD_NON_INTERACTIVE=0` and clear `CI` in test env
- `cmd/bd/dolt_autostart_lifecycle_integration_test.go`: Add `--server` to init args