### PR TITLE
fix: make bd setup claude project-local by default and auto-setup in bd init

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/cmd/bd/doctor"
+	"github.com/steveyegge/beads/cmd/bd/setup"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -946,6 +947,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
+		// Auto-setup Claude hooks for project (writes to .claude/settings.json)
+		// so bd prime runs automatically. Skip in stealth mode or when agents are skipped.
+		if !stealth && !skipAgents && !isBareGitRepo() {
+			if err := setup.InstallClaudeProject(stealth); err != nil {
+				if !quiet {
+					fmt.Fprintf(os.Stderr, "Warning: failed to setup Claude hooks: %v\n", err)
+				}
+				// Non-fatal - continue with init
+			}
+		}
+
 		// Auto-stage and commit beads files so bd doctor doesn't warn about
 		// untracked files or dirty working tree in a clean room setup.
 		// Only runs when not stealth, in a git repo, and using local storage.
@@ -957,6 +969,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				if _, statErr := os.Stat(agentsFileToStage); statErr == nil {
 					agentsCmd := exec.Command("git", "add", agentsFileToStage)
 					_ = agentsCmd.Run()
+				}
+				// Also stage Claude settings if created by init
+				claudeSettingsPath := filepath.Join(".claude", "settings.json")
+				if _, statErr := os.Stat(claudeSettingsPath); statErr == nil {
+					claudeCmd := exec.Command("git", "add", claudeSettingsPath)
+					_ = claudeCmd.Run()
+				}
+				// Also stage CLAUDE.md if created by setup
+				if _, statErr := os.Stat("CLAUDE.md"); statErr == nil {
+					claudeMdCmd := exec.Command("git", "add", "CLAUDE.md")
+					_ = claudeMdCmd.Run()
 				}
 				// Also stage .gitignore if modified by EnsureProjectGitignore
 				if _, statErr := os.Stat(".gitignore"); statErr == nil {

--- a/cmd/bd/setup.go
+++ b/cmd/bd/setup.go
@@ -266,10 +266,10 @@ func runClaudeRecipe() {
 		return
 	}
 	if setupRemove {
-		setup.RemoveClaude(setupProject)
+		setup.RemoveClaude(setupGlobal)
 		return
 	}
-	setup.InstallClaude(setupProject, setupStealth)
+	setup.InstallClaude(setupGlobal, setupStealth)
 }
 
 func runGeminiRecipe() {
@@ -366,8 +366,8 @@ func init() {
 	// Per-recipe flags
 	setupCmd.Flags().BoolVar(&setupCheck, "check", false, "Check if integration is installed")
 	setupCmd.Flags().BoolVar(&setupRemove, "remove", false, "Remove the integration")
-	setupCmd.Flags().BoolVar(&setupProject, "project", false, "Install for this project only (claude/gemini/mux)")
-	setupCmd.Flags().BoolVar(&setupGlobal, "global", false, "Install globally (mux only; writes ~/.mux/AGENTS.md)")
+	setupCmd.Flags().BoolVar(&setupProject, "project", false, "Install for this project only (gemini/mux)")
+	setupCmd.Flags().BoolVar(&setupGlobal, "global", false, "Install globally (claude/mux; writes to ~/.claude/settings.json or ~/.mux/AGENTS.md)")
 	setupCmd.Flags().BoolVar(&setupStealth, "stealth", false, "Use stealth mode (claude/gemini)")
 
 	rootCmd.AddCommand(setupCmd)

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -57,6 +57,10 @@ func defaultClaudeEnv() (claudeEnv, error) {
 }
 
 func projectSettingsPath(base string) string {
+	return filepath.Join(base, ".claude", "settings.json")
+}
+
+func legacyProjectSettingsPath(base string) string {
 	return filepath.Join(base, ".claude", "settings.local.json")
 }
 
@@ -73,26 +77,36 @@ func claudeAgentsEnv(env claudeEnv) agentsEnv {
 }
 
 // InstallClaude installs Claude Code hooks
-func InstallClaude(project bool, stealth bool) {
+func InstallClaude(global bool, stealth bool) {
 	env, err := claudeEnvProvider()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		setupExit(1)
 		return
 	}
-	if err := installClaude(env, project, stealth); err != nil {
+	if err := installClaude(env, global, stealth); err != nil {
 		setupExit(1)
 	}
 }
 
-func installClaude(env claudeEnv, project bool, stealth bool) error {
+// InstallClaudeProject installs project-local Claude hooks, returning an error
+// instead of exiting. Used by bd init to integrate Claude setup automatically.
+func InstallClaudeProject(stealth bool) error {
+	env, err := claudeEnvProvider()
+	if err != nil {
+		return err
+	}
+	return installClaude(env, false, stealth)
+}
+
+func installClaude(env claudeEnv, global bool, stealth bool) error {
 	var settingsPath string
-	if project {
-		settingsPath = projectSettingsPath(env.projectDir)
-		_, _ = fmt.Fprintln(env.stdout, "Installing Claude hooks for this project...")
-	} else {
+	if global {
 		settingsPath = globalSettingsPath(env.homeDir)
 		_, _ = fmt.Fprintln(env.stdout, "Installing Claude hooks globally...")
+	} else {
+		settingsPath = projectSettingsPath(env.projectDir)
+		_, _ = fmt.Fprintln(env.stdout, "Installing Claude hooks for this project...")
 	}
 
 	if err := env.ensureDir(filepath.Dir(settingsPath), 0o755); err != nil {
@@ -145,6 +159,29 @@ func installClaude(env claudeEnv, project bool, stealth bool) error {
 		return err
 	}
 
+	// Migrate legacy hooks: remove beads hooks from settings.local.json if present
+	if !global {
+		legacyPath := legacyProjectSettingsPath(env.projectDir)
+		if hasBeadsHooks(legacyPath) {
+			if legacyData, readErr := env.readFile(legacyPath); readErr == nil {
+				var legacySettings map[string]interface{}
+				if json.Unmarshal(legacyData, &legacySettings) == nil {
+					if legacyHooks, ok := legacySettings["hooks"].(map[string]interface{}); ok {
+						removeHookCommand(legacyHooks, "SessionStart", "bd prime")
+						removeHookCommand(legacyHooks, "PreCompact", "bd prime")
+						removeHookCommand(legacyHooks, "SessionStart", "bd prime --stealth")
+						removeHookCommand(legacyHooks, "PreCompact", "bd prime --stealth")
+						if migrated, marshalErr := json.MarshalIndent(legacySettings, "", "  "); marshalErr == nil {
+							if writeErr := env.writeFile(legacyPath, migrated); writeErr == nil {
+								_, _ = fmt.Fprintf(env.stdout, "✓ Migrated hooks from %s\n", legacyPath)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// Install minimal beads section in CLAUDE.md.
 	// Hooks handle the heavy lifting via bd prime; CLAUDE.md just needs a pointer.
 	if err := installAgents(claudeAgentsEnv(env), claudeAgentsIntegration); err != nil {
@@ -172,14 +209,18 @@ func CheckClaude() {
 }
 
 func checkClaude(env claudeEnv) error {
-	globalSettings := globalSettingsPath(env.homeDir)
 	projectSettings := projectSettingsPath(env.projectDir)
+	globalSettings := globalSettingsPath(env.homeDir)
+	legacySettings := legacyProjectSettingsPath(env.projectDir)
 
 	switch {
-	case hasBeadsHooks(globalSettings):
-		_, _ = fmt.Fprintf(env.stdout, "✓ Global hooks installed: %s\n", globalSettings)
 	case hasBeadsHooks(projectSettings):
 		_, _ = fmt.Fprintf(env.stdout, "✓ Project hooks installed: %s\n", projectSettings)
+	case hasBeadsHooks(globalSettings):
+		_, _ = fmt.Fprintf(env.stdout, "✓ Global hooks installed: %s\n", globalSettings)
+	case hasBeadsHooks(legacySettings):
+		_, _ = fmt.Fprintf(env.stdout, "✓ Project hooks installed (legacy): %s\n", legacySettings)
+		_, _ = fmt.Fprintf(env.stdout, "  Consider running 'bd setup claude' to migrate to .claude/settings.json\n")
 	default:
 		_, _ = fmt.Fprintln(env.stdout, "✗ No hooks installed")
 		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup claude")
@@ -190,26 +231,26 @@ func checkClaude(env claudeEnv) error {
 }
 
 // RemoveClaude removes Claude Code hooks
-func RemoveClaude(project bool) {
+func RemoveClaude(global bool) {
 	env, err := claudeEnvProvider()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		setupExit(1)
 		return
 	}
-	if err := removeClaude(env, project); err != nil {
+	if err := removeClaude(env, global); err != nil {
 		setupExit(1)
 	}
 }
 
-func removeClaude(env claudeEnv, project bool) error {
+func removeClaude(env claudeEnv, global bool) error {
 	var settingsPath string
-	if project {
-		settingsPath = projectSettingsPath(env.projectDir)
-		_, _ = fmt.Fprintln(env.stdout, "Removing Claude hooks from project...")
-	} else {
+	if global {
 		settingsPath = globalSettingsPath(env.homeDir)
 		_, _ = fmt.Fprintln(env.stdout, "Removing Claude hooks globally...")
+	} else {
+		settingsPath = projectSettingsPath(env.projectDir)
+		_, _ = fmt.Fprintln(env.stdout, "Removing Claude hooks from project...")
 	}
 
 	data, err := env.readFile(settingsPath)
@@ -240,6 +281,25 @@ func removeClaude(env claudeEnv, project bool) error {
 			if err := env.writeFile(settingsPath, data); err != nil {
 				_, _ = fmt.Fprintf(env.stderr, "Error: write settings: %v\n", err)
 				return err
+			}
+		}
+	}
+
+	// Also clean legacy settings.local.json when removing project hooks
+	if !global {
+		legacyPath := legacyProjectSettingsPath(env.projectDir)
+		if legacyData, readErr := env.readFile(legacyPath); readErr == nil {
+			var legacySettings map[string]interface{}
+			if json.Unmarshal(legacyData, &legacySettings) == nil {
+				if legacyHooks, ok := legacySettings["hooks"].(map[string]interface{}); ok {
+					removeHookCommand(legacyHooks, "SessionStart", "bd prime")
+					removeHookCommand(legacyHooks, "PreCompact", "bd prime")
+					removeHookCommand(legacyHooks, "SessionStart", "bd prime --stealth")
+					removeHookCommand(legacyHooks, "PreCompact", "bd prime --stealth")
+					if migrated, marshalErr := json.MarshalIndent(legacySettings, "", "  "); marshalErr == nil {
+						_ = env.writeFile(legacyPath, migrated)
+					}
+				}
 			}
 		}
 	}

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -323,7 +323,8 @@ func TestInstallClaudeCleanupNullHooks(t *testing.T) {
 	env, stdout, _ := newClaudeTestEnv(t)
 
 	// Create settings file with null hooks (simulating the bug)
-	settingsPath := globalSettingsPath(env.homeDir)
+	// Use project settings path (default install target)
+	settingsPath := projectSettingsPath(env.projectDir)
 	writeSettings(t, settingsPath, map[string]interface{}{
 		"hooks": map[string]interface{}{
 			"SessionStart": nil,
@@ -331,7 +332,7 @@ func TestInstallClaudeCleanupNullHooks(t *testing.T) {
 		},
 	})
 
-	// Install should clean up null values and add proper hooks
+	// Install should clean up null values and add proper hooks (global=false → project)
 	err := installClaude(env, false, false)
 	if err != nil {
 		t.Fatalf("install failed: %v", err)
@@ -555,7 +556,8 @@ func TestIdempotencyWithStealth(t *testing.T) {
 
 func TestInstallClaudeProject(t *testing.T) {
 	env, stdout, stderr := newClaudeTestEnv(t)
-	if err := installClaude(env, true, false); err != nil {
+	// global=false means project-local (the new default)
+	if err := installClaude(env, false, false); err != nil {
 		t.Fatalf("installClaude: %v", err)
 	}
 	data, err := os.ReadFile(projectSettingsPath(env.projectDir))
@@ -587,7 +589,8 @@ func TestInstallClaudeProject(t *testing.T) {
 
 func TestInstallClaudeGlobalStealth(t *testing.T) {
 	env, stdout, _ := newClaudeTestEnv(t)
-	if err := installClaude(env, false, true); err != nil {
+	// global=true, stealth=true
+	if err := installClaude(env, true, true); err != nil {
 		t.Fatalf("installClaude: %v", err)
 	}
 	data, err := os.ReadFile(globalSettingsPath(env.homeDir))
@@ -616,7 +619,8 @@ func TestInstallClaudeErrors(t *testing.T) {
 		if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
 			t.Fatalf("write file: %v", err)
 		}
-		if err := installClaude(env, true, false); err == nil {
+		// global=false → project-local, should hit the invalid json
+		if err := installClaude(env, false, false); err == nil {
 			t.Fatal("expected parse error")
 		}
 		if !strings.Contains(stderr.String(), "failed to parse") {
@@ -627,7 +631,8 @@ func TestInstallClaudeErrors(t *testing.T) {
 	t.Run("ensure dir error", func(t *testing.T) {
 		env, _, _ := newClaudeTestEnv(t)
 		env.ensureDir = func(string, os.FileMode) error { return errors.New("boom") }
-		if err := installClaude(env, true, false); err == nil {
+		// global=false → project-local
+		if err := installClaude(env, false, false); err == nil {
 			t.Fatal("expected ensureDir error")
 		}
 	})
@@ -738,7 +743,8 @@ func TestRemoveClaudeScenarios(t *testing.T) {
 		if err := os.WriteFile(instructionsPath, []byte(agents.RenderSection(agents.ProfileMinimal)), 0o644); err != nil {
 			t.Fatalf("seed %s: %v", claudeInstructionsFile, err)
 		}
-		if err := removeClaude(env, false); err != nil {
+		// global=true → remove from global settings
+		if err := removeClaude(env, true); err != nil {
 			t.Fatalf("removeClaude: %v", err)
 		}
 		data, err := os.ReadFile(path)
@@ -762,7 +768,8 @@ func TestRemoveClaudeScenarios(t *testing.T) {
 
 	t.Run("missing file", func(t *testing.T) {
 		env, stdout, _ := newClaudeTestEnv(t)
-		if err := removeClaude(env, true); err != nil {
+		// global=false → project-local (default)
+		if err := removeClaude(env, false); err != nil {
 			t.Fatalf("removeClaude: %v", err)
 		}
 		if !strings.Contains(stdout.String(), "No settings file found") {
@@ -779,7 +786,8 @@ func TestRemoveClaudeScenarios(t *testing.T) {
 		if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
 			t.Fatalf("write file: %v", err)
 		}
-		if err := removeClaude(env, true); err == nil {
+		// global=false → project-local
+		if err := removeClaude(env, false); err == nil {
 			t.Fatal("expected parse error")
 		}
 		if !strings.Contains(stderr.String(), "failed to parse") {
@@ -803,7 +811,8 @@ func TestClaudeWrappersExit(t *testing.T) {
 		env, _, _ := newClaudeTestEnv(t)
 		env.ensureDir = func(string, os.FileMode) error { return errors.New("boom") }
 		stubClaudeEnvProvider(t, env, nil)
-		InstallClaude(true, false)
+		// global=false → project-local (default)
+		InstallClaude(false, false)
 		if !cap.called || cap.code != 1 {
 			t.Fatal("InstallClaude should exit when installClaude fails")
 		}
@@ -822,7 +831,8 @@ func TestClaudeWrappersExit(t *testing.T) {
 	t.Run("remove parse error", func(t *testing.T) {
 		cap := stubSetupExit(t)
 		env, _, _ := newClaudeTestEnv(t)
-		path := globalSettingsPath(env.homeDir)
+		// Write invalid JSON to project settings path (default target)
+		path := projectSettingsPath(env.projectDir)
 		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 			t.Fatalf("mkdir: %v", err)
 		}
@@ -830,6 +840,7 @@ func TestClaudeWrappersExit(t *testing.T) {
 			t.Fatalf("write file: %v", err)
 		}
 		stubClaudeEnvProvider(t, env, nil)
+		// global=false → project-local (default)
 		RemoveClaude(false)
 		if !cap.called || cap.code != 1 {
 			t.Fatal("RemoveClaude should exit on parse error")


### PR DESCRIPTION
Fixes #2935

## Problem

- `bd setup claude` (without flags) installed globally to `~/.claude/settings.json` — surprising for project setup
- `bd setup --project claude` wrote to `.claude/settings.local.json` — but users wanted `.claude/settings.json` (shared/team file) so all collaborators get the prime hooks
- `bd init` didn't set up Claude hooks at all — users expected it to do everything needed

## Changes

### Default scope flipped to project-local
- `bd setup claude` → now writes to `.claude/settings.json` (shared/team file, committed to repo)
- `bd setup claude --global` → explicitly installs to `~/.claude/settings.json`

### `bd init` auto-configures Claude
- `bd init` now automatically runs Claude hook setup (project-local) unless `--stealth` or `--skip-agents` is set
- Claude settings (`.claude/settings.json`, `CLAUDE.md`) are auto-staged in git

### Legacy migration
- Installing to project automatically migrates beads hooks from legacy `.claude/settings.local.json`
- `bd setup claude --check` detects legacy installs with a migration hint
- `bd setup claude --remove` cleans both `.claude/settings.json` and legacy `.claude/settings.local.json`

## Files changed
- `cmd/bd/setup/claude.go` — Core behavior change, legacy migration, new `InstallClaudeProject` export
- `cmd/bd/setup.go` — Wire `--global` flag for claude recipe, update flag descriptions
- `cmd/bd/init.go` — Auto-run Claude setup, stage Claude files in git
- `cmd/bd/setup/claude_test.go` — Updated tests for new semantics