### PR TITLE
fix: custom status validation falls back to config when table is empty

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -441,8 +441,14 @@ var listCmd = &cobra.Command{
 			statusParts := strings.Split(status, ",")
 			var customStatuses []string
 			if store != nil {
-				cs, _ := store.GetCustomStatuses(rootCtx)
-				customStatuses = cs
+				cs, err := store.GetCustomStatuses(rootCtx)
+				if err != nil {
+					if !jsonOutput {
+						fmt.Fprintf(os.Stderr, "⚠ Failed to load custom statuses: %v\n", err)
+					}
+				} else {
+					customStatuses = cs
+				}
 			}
 			if len(statusParts) == 1 {
 				s := types.Status(strings.TrimSpace(statusParts[0]))

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -71,9 +71,12 @@ func ResolveCustomStatusesDetailedInTx(ctx context.Context, tx *sql.Tx) ([]types
 		if err := rows.Err(); err != nil {
 			return nil, fmt.Errorf("reading custom_statuses: %w", err)
 		}
-		// Table query succeeded — return result even if empty.
-		// Only fall through to config string when the table doesn't exist (query error above).
-		return result, nil
+		if len(result) > 0 {
+			return result, nil
+		}
+		// Table exists but is empty — fall through to config string.
+		// This handles the case where schema migration created the table
+		// but didn't populate it from the existing status.custom config.
 	}
 
 	// Fallback: table doesn't exist (pre-migration) — read from config string
@@ -119,9 +122,12 @@ func ResolveCustomTypesInTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
 		if err := rows.Err(); err != nil {
 			return nil, fmt.Errorf("reading custom_types: %w", err)
 		}
-		// Table query succeeded — return result even if empty.
-		// Only fall through to config string when the table doesn't exist (query error above).
-		return result, nil
+		if len(result) > 0 {
+			return result, nil
+		}
+		// Table exists but is empty — fall through to config string.
+		// This handles the case where schema migration created the table
+		// but didn't populate it from the existing types.custom config.
 	}
 
 	// Fallback: table doesn't exist (pre-migration) — read from config string


### PR DESCRIPTION
## Summary

Fixes #2984

- `ResolveCustomStatusesDetailedInTx` now falls through to the `status.custom` config string when the `custom_statuses` table exists but is empty (e.g. after schema v11 migration)
- `list.go` now logs `GetCustomStatuses` errors instead of silently discarding them, matching `update.go`'s pattern

## Root Cause

Schema v11 migration creates the `custom_statuses` table but doesn't populate it from the existing `status.custom` config value. The query function returned empty when the table existed (even with no rows), bypassing the config string fallback.

## Test Plan

- [x] `bd list --status=in_review` now works when `status.custom` includes `in_review` but `custom_statuses` table is empty
- [x] `bd config get status.custom` correctly returns configured values
- [x] Build passes (`make build`)
- [ ] Existing tests pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>