### PR TITLE
fix: use type molecule for formula root beads instead of epic

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -442,14 +442,14 @@ func cookFormulaToSubgraph(f *formula.Formula, protoID string) (*TemplateSubgrap
 		rootDesc = "{{desc}}"
 	}
 
-	// Create root proto epic
+	// Create root proto molecule
 	rootIssue := &types.Issue{
 		ID:          protoID,
 		Title:       rootTitle,
 		Description: rootDesc,
 		Status:      types.StatusOpen,
 		Priority:    2,
-		IssueType:   types.TypeEpic,
+		IssueType:   types.TypeMolecule,
 		IsTemplate:  true,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
@@ -812,14 +812,14 @@ func cookFormula(ctx context.Context, s storage.DoltStorage, f *formula.Formula,
 		rootDesc = "{{desc}}"
 	}
 
-	// Create root proto epic using provided protoID (may include prefix)
+	// Create root proto molecule using provided protoID (may include prefix)
 	rootIssue := &types.Issue{
 		ID:          protoID,
 		Title:       rootTitle,
 		Description: rootDesc,
 		Status:      types.StatusOpen,
 		Priority:    2,
-		IssueType:   types.TypeEpic,
+		IssueType:   types.TypeMolecule,
 		IsTemplate:  true,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),

--- a/cmd/bd/cook_test.go
+++ b/cmd/bd/cook_test.go
@@ -543,12 +543,12 @@ func TestCookFormulaToSubgraph_StandaloneExpansion(t *testing.T) {
 		}
 	}
 
-	// Root epic
+	// Root molecule
 	if subgraph.Root.ID != "rule-of-five" {
 		t.Errorf("Root.ID = %q, want %q", subgraph.Root.ID, "rule-of-five")
 	}
-	if subgraph.Root.IssueType != types.TypeEpic {
-		t.Errorf("Root.IssueType = %q, want %q", subgraph.Root.IssueType, types.TypeEpic)
+	if subgraph.Root.IssueType != types.TypeMolecule {
+		t.Errorf("Root.IssueType = %q, want %q", subgraph.Root.IssueType, types.TypeMolecule)
 	}
 
 	// Verify child issue IDs


### PR DESCRIPTION
## Summary

- `cookFormulaToSubgraph` created formula root issues with `TypeEpic`, but formula roots are molecules — the "molecule" custom type exists for exactly this purpose
- Both root creation paths in `cook.go` updated from `TypeEpic` to `TypeMolecule`
- Swarm code already handles both types equivalently (lines 182, 659, 927 of `swarm.go`), so this is safe
- Companion PR in gascity: gastownhall/gascity (same branch name)

## Test plan

- [x] `TestCookFormulaToSubgraph_StandaloneExpansion` updated and passes
- [x] `TestGraphApply` and `TestSwarm` tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)