### PR TITLE
fix: use default database name when metadata.json is missing

### DIFF
--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -65,7 +65,7 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfig(ctx, beadsDir)
 	}
-	database := ""
+	database := configfile.DefaultDoltDatabase
 	if cfg != nil {
 		database = cfg.GetDoltDatabase()
 	}

--- a/cmd/bd/store_factory_test.go
+++ b/cmd/bd/store_factory_test.go
@@ -1,0 +1,38 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// TestNewDoltStoreFromConfig_NoMetadata verifies that newDoltStoreFromConfig
+// succeeds when the beads directory has no metadata.json (fresh project).
+// Regression test for GH#2988: "no database selected" error.
+func TestNewDoltStoreFromConfig_NoMetadata(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+
+	beadsDir := t.TempDir()
+
+	// Confirm no config exists.
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("expected nil config for empty dir")
+	}
+
+	// This should succeed using the default database name, not fail with
+	// "no database selected".
+	store, err := newDoltStoreFromConfig(t.Context(), beadsDir)
+	if err != nil {
+		t.Fatalf("newDoltStoreFromConfig failed: %v", err)
+	}
+	defer store.Close()
+}


### PR DESCRIPTION
## Summary

- Fixes #2988: `bd create` in a fresh project fails with "no database selected"
- When `.beads/metadata.json` doesn't exist yet, `configfile.Load` returns nil, causing `newDoltStoreFromConfig` to pass an empty database name to the embedded Dolt engine
- The engine then skips `CREATE DATABASE` and `USE`, so the first SQL statement (`CREATE TABLE schema_migrations`) fails with `Error 1105: no database selected`
- Fix: default to `configfile.DefaultDoltDatabase` ("beads") when config is nil

## Test plan

- [x] Added `TestNewDoltStoreFromConfig_NoMetadata` regression test
- [x] Verified test fails without the fix (exact error from #2988)
- [x] Verified test passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)