### PR TITLE
fix: remove ICU runtime dependency from linux-amd64 binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install cross-compilation toolchains and signing tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode libicu-dev
+          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode
 
       - name: Install go-winres for Windows PE resource embedding
         run: go install github.com/tc-hib/go-winres@latest
@@ -52,6 +52,18 @@ jobs:
           # Windows code signing (optional - signing is skipped if not set)
           WINDOWS_SIGNING_CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_PFX_BASE64 }}
           WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
+
+      - name: Verify no ICU runtime dependency on Linux binaries
+        run: |
+          for bin in dist/bd-linux-*/bd; do
+            [ -f "$bin" ] || continue
+            if ldd "$bin" 2>/dev/null | grep -qi icu; then
+              echo "ERROR: $bin has unexpected ICU runtime dependency" >&2
+              ldd "$bin" >&2
+              exit 1
+            fi
+            echo "OK: $bin has no ICU runtime dependency"
+          done
 
   goreleaser-macos:
     # Build macOS binaries with CGO_ENABLED=1 for embedded Dolt support.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
       - CGO_ENABLED=1
       - CC=gcc
       - CXX=g++
+    tags:
+      - gms_pure_go
     goos:
       - linux
     goarch:


### PR DESCRIPTION
## Summary

- Add `gms_pure_go` build tag to `bd-linux-amd64` in `.goreleaser.yml`, matching all other CGO-enabled targets (linux-arm64, darwin-arm64, darwin-amd64). This switches from C FFI ICU regex to pure-Go stdlib regexp, eliminating the dynamic `libicui18n.so` dependency while keeping CGO enabled for embedded Dolt.
- Remove `libicu-dev` from release workflow apt install (no longer needed).
- Add post-build `ldd` check to verify no Linux binary has ICU runtime deps (mirrors the existing macOS `otool` check).

Fixes #2986

## Test plan

- [ ] CI passes — build with `gms_pure_go` tag compiles cleanly (verified locally)
- [ ] New `ldd` verification step catches any ICU linkage regression
- [ ] Smoke test confirms embedded Dolt still works without ICU

🤖 Generated with [Claude Code](https://claude.com/claude-code)