### PR TITLE
fix: contributor mode embedded tests + ensureBeadsDirForPath metadata.json

### DIFF
--- a/cmd/bd/contributor_embedded_test.go
+++ b/cmd/bd/contributor_embedded_test.go
@@ -1,0 +1,167 @@
+//go:build cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+)
+
+// TestEmbeddedContributorCreate exercises the full contributor mode flow in
+// embedded Dolt: init → contributor wizard → create. This is the exact
+// scenario that triggered GH#2988 ("no database selected" when the planning
+// repo's .beads directory has no metadata.json).
+func TestEmbeddedContributorCreate(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt contributor tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("create_routes_to_planning_repo", func(t *testing.T) {
+		dir, planningDir := initContributor(t, bd, "cr")
+
+		// Create an issue — should route to the planning repo, not the project.
+		issue := bdCreate(t, bd, dir, "Contributor issue")
+		if issue.ID == "" {
+			t.Fatal("expected issue ID")
+		}
+		if !strings.HasPrefix(issue.ID, "cr-") {
+			t.Errorf("ID should have prefix cr-, got %q", issue.ID)
+		}
+
+		// Verify the issue landed in the planning repo's embedded store.
+		// The planning store database name is the sanitized prefix (same as source).
+		planningBeadsDir := filepath.Join(planningDir, ".beads")
+		assertIssueInStore(t, planningBeadsDir, "cr", issue.ID)
+
+		// Verify the issue is NOT in the project's store.
+		projectBeadsDir := filepath.Join(dir, ".beads")
+		assertIssueNotInStore(t, projectBeadsDir, "cr", issue.ID)
+	})
+
+	t.Run("show_reads_routed_issue", func(t *testing.T) {
+		dir, _ := initContributor(t, bd, "sh")
+
+		issue := bdCreate(t, bd, dir, "Show me")
+		shown := bdShow(t, bd, dir, issue.ID)
+		if shown.Title != "Show me" {
+			t.Errorf("title: got %q, want %q", shown.Title, "Show me")
+		}
+	})
+
+	t.Run("multiple_creates_succeed", func(t *testing.T) {
+		dir, planningDir := initContributor(t, bd, "mc")
+
+		ids := make(map[string]bool)
+		for i := 0; i < 3; i++ {
+			issue := bdCreate(t, bd, dir, fmt.Sprintf("Issue %d", i))
+			if issue.ID == "" {
+				t.Fatalf("create %d: expected issue ID", i)
+			}
+			if ids[issue.ID] {
+				t.Fatalf("create %d: duplicate ID %q", i, issue.ID)
+			}
+			ids[issue.ID] = true
+		}
+
+		// All three should be in the planning store.
+		planningBeadsDir := filepath.Join(planningDir, ".beads")
+		for id := range ids {
+			assertIssueInStore(t, planningBeadsDir, "mc", id)
+		}
+	})
+}
+
+// initContributor sets up a project with contributor mode enabled and returns
+// the project dir and planning dir paths. The contributor wizard runs via
+// subprocess with stdin piped to answer the interactive prompts.
+func initContributor(t *testing.T, bd, prefix string) (projectDir, planningDir string) {
+	t.Helper()
+
+	projectDir = t.TempDir()
+	planningDir = filepath.Join(t.TempDir(), "planning")
+	initGitRepoAt(t, projectDir)
+
+	// Run bd init with --contributor flag.
+	// The wizard prompts (no upstream remote):
+	//   1. "Continue with contributor setup? [y/N]:" → "y"
+	//   2. "Planning repo path [press Enter for default]:" → planningDir
+	args := []string{"init", "--quiet", "--prefix", prefix, "--contributor"}
+	cmd := exec.Command(bd, args...)
+	cmd.Dir = projectDir
+	cmd.Env = append(bdEnv(projectDir), "BD_NON_INTERACTIVE=0")
+	cmd.Stdin = strings.NewReader("y\n" + planningDir + "\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bd init --contributor failed: %v\n%s", err, out)
+	}
+
+	// Sanity: planning .beads dir should exist (created by wizard).
+	planningBeadsDir := filepath.Join(planningDir, ".beads")
+	requireFile(t, planningBeadsDir)
+
+	// Sanity: beads.role should be "contributor".
+	roleCmd := exec.Command("git", "config", "beads.role")
+	roleCmd.Dir = projectDir
+	roleOut, err := roleCmd.Output()
+	if err != nil {
+		t.Fatalf("git config beads.role failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(roleOut)); got != "contributor" {
+		t.Fatalf("beads.role: got %q, want %q", got, "contributor")
+	}
+
+	return projectDir, planningDir
+}
+
+// assertIssueInStore verifies that an issue with the given ID exists in the
+// embedded Dolt store at beadsDir.
+func assertIssueInStore(t *testing.T, beadsDir, database, issueID string) {
+	t.Helper()
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, database, "main")
+	if err != nil {
+		t.Fatalf("OpenSQL(%s, %s): %v", beadsDir, database, err)
+	}
+	defer cleanup()
+
+	var count int
+	err = db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", issueID).Scan(&count)
+	if err != nil {
+		t.Fatalf("query issues for %s: %v", issueID, err)
+	}
+	if count == 0 {
+		t.Errorf("expected issue %s in store at %s, not found", issueID, beadsDir)
+	}
+}
+
+// assertIssueNotInStore verifies that an issue with the given ID does NOT
+// exist in the embedded Dolt store at beadsDir.
+func assertIssueNotInStore(t *testing.T, beadsDir, database, issueID string) {
+	t.Helper()
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, database, "main")
+	if err != nil {
+		t.Fatalf("OpenSQL(%s, %s): %v", beadsDir, database, err)
+	}
+	defer cleanup()
+
+	var count int
+	err = db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM issues WHERE id = ?", issueID).Scan(&count)
+	if err != nil {
+		t.Fatalf("query issues for %s: %v", issueID, err)
+	}
+	if count != 0 {
+		t.Errorf("issue %s should NOT be in store at %s, but found %d rows", issueID, beadsDir, count)
+	}
+}

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/remotecache"
 	"github.com/steveyegge/beads/internal/routing"
@@ -827,12 +828,15 @@ func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore s
 	if sourceStore != nil {
 		sourcePrefix, err := sourceStore.GetConfig(ctx, "issue_prefix")
 		if err == nil && sourcePrefix != "" {
+			// Sanitize prefix for SQL database name (same as bd init).
+			dbName := strings.ReplaceAll(sourcePrefix, "-", "_")
+
 			// Open target store temporarily to set prefix.
 			// Use newDoltStore with explicit config since the target .beads
 			// directory was just created and has no metadata.json yet.
 			tempStore, err := newDoltStore(ctx, &dolt.Config{
 				BeadsDir:        beadsDir,
-				Database:        sourcePrefix,
+				Database:        dbName,
 				CreateIfMissing: true,
 			})
 			if err != nil {
@@ -844,6 +848,17 @@ func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore s
 			}
 			if err := tempStore.Close(); err != nil {
 				return fmt.Errorf("failed to close target store: %w", err)
+			}
+
+			// Write metadata.json so newDoltStoreFromConfig can find the
+			// correct database name on subsequent opens (GH#2988).
+			cfg := configfile.DefaultConfig()
+			cfg.Backend = configfile.BackendDolt
+			cfg.DoltDatabase = dbName
+			cfg.DoltMode = configfile.DoltModeEmbedded
+			cfg.ProjectID = configfile.GenerateProjectID()
+			if err := cfg.Save(beadsDir); err != nil {
+				return fmt.Errorf("failed to write metadata.json: %w", err)
 			}
 		}
 	}

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -65,7 +65,7 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfig(ctx, beadsDir)
 	}
-	database := ""
+	database := configfile.DefaultDoltDatabase
 	if cfg != nil {
 		database = cfg.GetDoltDatabase()
 	}

--- a/cmd/bd/store_factory_test.go
+++ b/cmd/bd/store_factory_test.go
@@ -1,0 +1,38 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// TestNewDoltStoreFromConfig_NoMetadata verifies that newDoltStoreFromConfig
+// succeeds when the beads directory has no metadata.json (fresh project).
+// Regression test for GH#2988: "no database selected" error.
+func TestNewDoltStoreFromConfig_NoMetadata(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+
+	beadsDir := t.TempDir()
+
+	// Confirm no config exists.
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+	if cfg != nil {
+		t.Fatal("expected nil config for empty dir")
+	}
+
+	// This should succeed using the default database name, not fail with
+	// "no database selected".
+	store, err := newDoltStoreFromConfig(t.Context(), beadsDir)
+	if err != nil {
+		t.Fatalf("newDoltStoreFromConfig failed: %v", err)
+	}
+	defer store.Close()
+}


### PR DESCRIPTION
## Summary

- Adds embedded Dolt contributor mode smoke tests that exercise the full `bd init --contributor` → `bd create` → `bd show` flow
- Fixes `ensureBeadsDirForPath` to write `metadata.json` after initializing the target store, so `newDoltStoreFromConfig` can find the correct database name on subsequent opens
- Sanitizes prefix for SQL database names (hyphens → underscores) in `ensureBeadsDirForPath`, matching `bd init` behavior
- Includes the `store_factory.go` default database fix from #2989

Closes #2988 (supersedes #2989 with the additional `ensureBeadsDirForPath` fix and tests)

## Context

Issue #2988 reported that `bd create` fails with "no database selected" in a fresh contributor project. The root cause had two layers:

1. **`newDoltStoreFromConfig`** defaulted `database` to `""` when `metadata.json` was missing (fixed in #2989)
2. **`ensureBeadsDirForPath`** created the embedded database but never wrote `metadata.json`, so subsequent opens via `newDoltStoreFromConfig` couldn't find the database name

This PR fixes both issues and adds embedded-mode contributor tests that would catch regressions in the contributor routing → target store creation path.

## Test plan

- [x] `TestNewDoltStoreFromConfig_NoMetadata` — unit regression for #2988
- [x] `TestEmbeddedContributorCreate/create_routes_to_planning_repo` — full E2E: init contributor → create → verify in planning store + not in project store
- [x] `TestEmbeddedContributorCreate/show_reads_routed_issue` — bd show can read back routed issues
- [x] `TestEmbeddedContributorCreate/multiple_creates_succeed` — sequential creates all route correctly
- [x] Existing non-CGO build compiles cleanly (`CGO_ENABLED=0 go vet`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)