### PR TITLE
fix: add embeddeddolt/ to .beads/.gitignore template

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -11,6 +11,7 @@ import (
 // GitignoreTemplate is the canonical .beads/.gitignore content
 const GitignoreTemplate = `# Dolt database (managed by Dolt, not git)
 dolt/
+embeddeddolt/
 
 # Runtime files
 bd.sock
@@ -105,6 +106,7 @@ var requiredPatterns = []string{
 	"export-state/",
 	"export-state.json",
 	"dolt/",
+	"embeddeddolt/",
 	"ephemeral.sqlite3",
 	"dolt-server.pid",
 	"dolt-server.log",


### PR DESCRIPTION
## Summary

- Adds `embeddeddolt/` to the `.beads/.gitignore` template in `cmd/bd/doctor/gitignore.go`
- Adds `embeddeddolt/` to the `requiredPatterns` slice so `bd doctor` detects stale gitignore files missing this entry

Fixes #2994

## Context

The embedded Dolt engine (used since v0.56+) stores its data in `embeddeddolt/` within `.beads/`, but this directory was not included in the gitignore template. Users upgrading from older versions see `embeddeddolt/` as untracked in git status.

## Test plan

- [x] `go build ./cmd/bd/doctor/...` compiles cleanly
- [x] `go test ./cmd/bd/doctor/... -run Gitignore` — all gitignore tests pass
- [x] `go test ./cmd/bd/doctor/fix/...` — all fix tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)