### PR TITLE
fix: include comment bodies in bd export and fix same-second dedup on import

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -139,6 +139,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
 	allDeps, _ := store.GetDependencyRecordsForIssues(ctx, issueIDs)
+	allComments, _ := store.GetCommentsForIssues(ctx, issueIDs)
 	commentCounts, _ := store.GetCommentCounts(ctx, issueIDs)
 	depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
 
@@ -146,6 +147,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 	for _, issue := range issues {
 		issue.Labels = labelsMap[issue.ID]
 		issue.Dependencies = allDeps[issue.ID]
+		issue.Comments = allComments[issue.ID]
 	}
 
 	// Write JSONL: one JSON object per line

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -300,8 +300,8 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) error 
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
 			SELECT COUNT(*) FROM %s
-			WHERE issue_id = ? AND author = ? AND created_at = ?
-		`, commentTable), issue.ID, comment.Author, createdAt).Scan(&exists); err != nil {
+			WHERE issue_id = ? AND author = ? AND created_at = ? AND text = ?
+		`, commentTable), issue.ID, comment.Author, createdAt, comment.Text).Scan(&exists); err != nil {
 			return fmt.Errorf("failed to check comment existence for %s: %w", issue.ID, err)
 		}
 		if exists > 0 {


### PR DESCRIPTION
## summary

`bd export` included `comment_count` on each issue but the `comments` array was always empty. this means `bd export | bd import` silently loses all comment history.

also found that `PersistComments` dedup check only matches on `issue_id + author + created_at`, so two different comments posted in the same second by the same author are treated as duplicates - the second one is dropped.

## changes

### 1. export comment bodies (`cmd/bd/export.go`)

added `store.GetCommentsForIssues()` call alongside the existing `GetLabelsForIssues()` and `GetDependencyRecordsForIssues()` bulk-loading calls. populates `issue.Comments` before marshaling to JSONL.

### 2. fix same-second comment dedup (`internal/storage/issueops/create.go`)

added `AND text = ?` to the existence check in `PersistComments`. the dedup was matching on `issue_id + author + created_at` only, which meant two different comments posted within the same second were treated as duplicates.

## test plan

- [x] `bd export` now includes comment bodies in the `comments` array (verified: 3 comments with 2 in same second all exported)
- [x] `bd import` preserves all comments including same-second ones (verified: full round-trip)
- [x] `make install-force` compiles clean with `gms_pure_go` tag
- [x] dedup still prevents true duplicates on re-import (same text + same timestamp = skip)

fixes #3007