### PR TITLE
fix(nocgo): correct --mode flag in error messages

### DIFF
--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -22,7 +22,7 @@ func isEmbeddedMode() bool {
 // available without CGO.
 func newDoltStore(ctx context.Context, cfg *dolt.Config, _ ...embeddeddolt.Option) (storage.DoltStorage, error) {
 	if !cfg.ServerMode {
-		return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --mode server)")
+		return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
 	}
 	return dolt.New(ctx, cfg)
 }
@@ -38,7 +38,7 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfig(ctx, beadsDir)
 	}
-	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --mode server)")
+	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
 }
 
 // newReadOnlyStoreFromConfig creates a read-only server-mode storage backend.
@@ -47,5 +47,5 @@ func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.D
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	}
-	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --mode server)")
+	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
 }


### PR DESCRIPTION
## Summary

Three error messages in `cmd/bd/store_factory_nocgo.go` (lines 25, 41, 50) incorrectly suggest `bd init --mode server` as the fix for a CGO-unavailable error.

The `--mode` flag does not exist on `bd init`. The correct flag is `--server`.

Without this fix, a user hitting the CGO error gets bad advice that leads to a second error, creating a confusing cascade.

## Changes

- `store_factory_nocgo.go`: 3 string replacements, `--mode server` → `--server`

## Test plan
- [ ] Build with `CGO_ENABLED=0` and verify error messages are correct
- [ ] `go test ./cmd/bd/...` passes