### PR TITLE
fix: bootstrap respects shared-server mode for database path

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -215,12 +215,13 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 	}
 
 	// Check for existing database (path differs between server and embedded mode).
-	// Use cfg.GetDoltMode() rather than the global isEmbeddedMode() so that
-	// the detection logic respects the config object passed in by the caller
-	// (important for tests and for cases where the global serverMode flag
-	// has not been set yet).
+	// Use cfg.IsDoltServerMode() (which checks metadata.json + env vars) plus
+	// doltserver.IsSharedServerMode() (which also checks config.yaml) so that
+	// shared-server mode configured via dolt.shared-server: true in config.yaml
+	// correctly resolves the database path. (GH#30)
+	isServer := cfg.IsDoltServerMode() || doltserver.IsSharedServerMode()
 	var dbPath string
-	if cfg.GetDoltMode() == configfile.DoltModeServer {
+	if isServer {
 		dbPath = doltserver.ResolveDoltDir(beadsDir)
 	} else {
 		dbPath = filepath.Join(beadsDir, "embeddeddolt")
@@ -228,7 +229,7 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 	if info, err := os.Stat(dbPath); err == nil && info.IsDir() {
 		entries, _ := os.ReadDir(dbPath)
 		if len(entries) > 0 {
-			if cfg.GetDoltMode() == configfile.DoltModeServer {
+			if isServer {
 				resolved := doltserver.DefaultConfig(beadsDir)
 				probeCfg := bootstrapServerProbeConfig{
 					host:     cfg.GetDoltServerHost(),

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -469,3 +469,65 @@ func TestBootstrapExistingBeadsDirUnchanged(t *testing.T) {
 		t.Errorf("action = %q, want %q for existing empty .beads", plan.Action, "init")
 	}
 }
+
+// TestDetectBootstrapAction_SharedServerEnvUsesSharedPath verifies that when
+// BEADS_DOLT_SHARED_SERVER=1 is set but cfg.DoltMode is the default (embedded),
+// detectBootstrapAction looks in the shared-server directory — not embeddeddolt/.
+// This is the root cause of GH#30.
+func TestDetectBootstrapAction_SharedServerEnvUsesSharedPath(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override HOME so SharedDoltDir() resolves to our temp directory
+	// instead of the real ~/.beads/shared-server/dolt/.
+	t.Setenv("HOME", tmpDir)
+
+	// Create a database directory at the shared-server location.
+	// SharedDoltDir() returns $HOME/.beads/shared-server/dolt/.
+	sharedDoltDir := filepath.Join(tmpDir, ".beads", "shared-server", "dolt")
+	if err := os.MkdirAll(filepath.Join(sharedDoltDir, "beads"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Shared server enabled, but cfg.DoltMode is default (embedded).
+	// Before the fix, this would look in embeddeddolt/ and miss the
+	// existing shared-server database.
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	cfg := configfile.DefaultConfig()
+	// Deliberately do NOT set cfg.DoltMode = configfile.DoltModeServer.
+	// This reproduces the bug: shared-server via env var with default DoltMode.
+
+	// The server probe stub: report the DB exists so we get action=none.
+	origCheck := checkBootstrapServerDB
+	checkBootstrapServerDB = func(probeCfg bootstrapServerProbeConfig) bootstrapServerDBCheck {
+		return bootstrapServerDBCheck{Exists: true, Reachable: true}
+	}
+	defer func() { checkBootstrapServerDB = origCheck }()
+
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Action != "none" {
+		t.Fatalf("expected action=none (existing shared-server DB detected), got %q: %s", plan.Action, plan.Reason)
+	}
+	if !plan.HasExisting {
+		t.Error("HasExisting = false, want true")
+	}
+}


### PR DESCRIPTION
## Problem

When `dolt.shared-server: true` is configured in `.beads/config.yaml`, `bd bootstrap` clones the database into `.beads/embeddeddolt/` instead of `~/.beads/shared-server/dolt/`. The shared Dolt server can't find the database, and all subsequent `bd` commands fail with:

```
Error: failed to open database: database "" not found on Dolt server at 127.0.0.1:3308
```

## Root Cause

In `detectBootstrapAction()`, the condition `cfg.GetDoltMode() == configfile.DoltModeServer` only checks the `dolt_mode` field in metadata.json. It doesn't account for shared-server mode configured via `dolt.shared-server: true` in config.yaml or the `BEADS_DOLT_SHARED_SERVER` environment variable.

When `dolt_mode` isn't explicitly set to `server` in metadata.json (the common case for shared-server setups), the detection falls through to the embedded path and looks in `embeddeddolt/` instead of the shared-server directory.

## Fix

Replace the narrow `cfg.GetDoltMode()` check with `cfg.IsDoltServerMode() || doltserver.IsSharedServerMode()`, which covers:
- `dolt_mode=server` in metadata.json
- `BEADS_DOLT_SERVER_MODE=1` env var
- `BEADS_DOLT_SHARED_SERVER=1` env var
- `dolt.shared-server: true` in config.yaml

## Testing

Added `TestDetectBootstrapAction_SharedServerEnvUsesSharedPath` which reproduces the exact bug scenario: `BEADS_DOLT_SHARED_SERVER=1` set with default (embedded) `DoltMode`, verifying the detection correctly resolves the shared-server path.

Fixes harry-miller-trimble/beads#30