### PR TITLE
fix: include comment bodies in bd export output

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -19,7 +19,7 @@ var exportCmd = &cobra.Command{
 	Long: `Export all issues to JSONL (newline-delimited JSON) format.
 
 Each line is a complete JSON object representing one issue, including its
-labels, dependencies, and comment count.
+labels, dependencies, and comments.
 
 This command is for issue export, migration, and interoperability. It does
 not produce the JSONL backup snapshot used by 'bd backup restore'. For
@@ -139,6 +139,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 	labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
 	allDeps, _ := store.GetDependencyRecordsForIssues(ctx, issueIDs)
+	commentsMap, _ := store.GetCommentsForIssues(ctx, issueIDs)
 	commentCounts, _ := store.GetCommentCounts(ctx, issueIDs)
 	depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
 
@@ -146,6 +147,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 	for _, issue := range issues {
 		issue.Labels = labelsMap[issue.ID]
 		issue.Dependencies = allDeps[issue.ID]
+		issue.Comments = commentsMap[issue.ID]
 	}
 
 	// Write JSONL: one JSON object per line

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -161,12 +161,14 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 		}
 		labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
 		allDeps, _ := store.GetDependencyRecordsForIssues(ctx, issueIDs)
+		commentsMap, _ := store.GetCommentsForIssues(ctx, issueIDs)
 		commentCounts, _ := store.GetCommentCounts(ctx, issueIDs)
 		depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
 
 		for _, issue := range issues {
 			issue.Labels = labelsMap[issue.ID]
 			issue.Dependencies = allDeps[issue.ID]
+			issue.Comments = commentsMap[issue.ID]
 		}
 
 		// Write issues


### PR DESCRIPTION
## Summary

- `bd export` called `GetCommentCounts()` to populate `comment_count` but never called `GetCommentsForIssues()`, so the `comments` array was always empty in the exported JSONL
- Added `GetCommentsForIssues()` call and populates `issue.Comments` in both `export.go` (manual export) and `export_auto.go` (auto-export)
- This fixes `bd export | bd import` silently losing all comment history

Fixes #3007

## Test plan

- [ ] `bd create "test" && bd comment <id> "hello" && bd export -o test.jsonl` — verify `comments` array in JSONL contains the comment body
- [ ] `bd export -o backup.jsonl && bd import backup.jsonl` — verify comments survive the round-trip
- [ ] Existing `TestCommentsRoundTrip` regression test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)