### PR TITLE
fix: fall through to config when custom_statuses table is empty

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -441,8 +441,14 @@ var listCmd = &cobra.Command{
 			statusParts := strings.Split(status, ",")
 			var customStatuses []string
 			if store != nil {
-				cs, _ := store.GetCustomStatuses(rootCtx)
-				customStatuses = cs
+				cs, err := store.GetCustomStatuses(rootCtx)
+				if err != nil {
+					if !jsonOutput {
+						fmt.Fprintf(os.Stderr, "%s Failed to get custom statuses: %v\n", ui.RenderWarn("!"), err)
+					}
+				} else {
+					customStatuses = cs
+				}
 			}
 			if len(statusParts) == 1 {
 				s := types.Status(strings.TrimSpace(statusParts[0]))

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -71,12 +71,16 @@ func ResolveCustomStatusesDetailedInTx(ctx context.Context, tx *sql.Tx) ([]types
 		if err := rows.Err(); err != nil {
 			return nil, fmt.Errorf("reading custom_statuses: %w", err)
 		}
-		// Table query succeeded — return result even if empty.
-		// Only fall through to config string when the table doesn't exist (query error above).
-		return result, nil
+		// Table has rows — use them as the authoritative source.
+		// If the table is empty (e.g. schema migration created the table but
+		// failed to populate it from status.custom config), fall through to
+		// the config string so existing custom statuses aren't silently lost.
+		if len(result) > 0 {
+			return result, nil
+		}
 	}
 
-	// Fallback: table doesn't exist (pre-migration) — read from config string
+	// Fallback: table doesn't exist or is empty — read from config string
 	value, err := GetConfigInTx(ctx, tx, "status.custom")
 	if err != nil {
 		if yamlStatuses := config.GetCustomStatusesFromYAML(); len(yamlStatuses) > 0 {


### PR DESCRIPTION
## Summary

- `ResolveCustomStatusesDetailedInTx` returned an empty result when the `custom_statuses` table existed but had zero rows (e.g. after schema v11 migration failed to populate from `status.custom` config). Now it falls through to the config string fallback when the table is empty, restoring access to custom statuses.
- `bd list` silently discarded errors from `GetCustomStatuses()` with `cs, _ :=`. Now logs them to stderr like `bd update` already does.

Fixes #2984

## Test plan

- [ ] `bd config set status.custom "in_review,deploying"` with an empty `custom_statuses` table — verify `bd list --status=in_review` works
- [ ] With a populated `custom_statuses` table — verify table rows are used (not the config string)
- [ ] `bd list --status=bogus` — verify it still rejects invalid statuses
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)