### PR TITLE
fix: remove ICU runtime dependency from linux-amd64 binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install cross-compilation toolchains and signing tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode libicu-dev
+          sudo apt-get install -y gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu osslsigncode
 
       - name: Install go-winres for Windows PE resource embedding
         run: go install github.com/tc-hib/go-winres@latest
@@ -52,6 +52,18 @@ jobs:
           # Windows code signing (optional - signing is skipped if not set)
           WINDOWS_SIGNING_CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_PFX_BASE64 }}
           WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
+
+      - name: Verify no ICU runtime dependency on Linux binaries
+        run: |
+          for bin in dist/bd-linux-*/bd; do
+            [ -f "$bin" ] || continue
+            if ldd "$bin" 2>/dev/null | grep -qi icu; then
+              echo "ERROR: $bin has unexpected ICU runtime dependency" >&2
+              ldd "$bin" >&2
+              exit 1
+            fi
+            echo "OK: $bin has no ICU runtime dependency"
+          done
 
   goreleaser-macos:
     # Build macOS binaries with CGO_ENABLED=1 for embedded Dolt support.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
       - CGO_ENABLED=1
       - CC=gcc
       - CXX=g++
+    tags:
+      - gms_pure_go
     goos:
       - linux
     goarch:


### PR DESCRIPTION
Cherry-pick of #2991, rebased onto upstream/main. Validated build configuration.

## Changes

- Adds `gms_pure_go` build tag to `bd-linux-amd64` goreleaser build (matches the existing tag already on `bd-linux-arm64` and other targets)
- Removes now-unnecessary `libicu-dev` from `apt-get install` in release workflow
- Adds post-build `ldd` verification step to catch ICU linkage regressions

## Validation

- Single clean commit cherry-picked from #2991 onto current upstream/main (no conflicts)
- `go build -tags gms_pure_go ./...` succeeds
- `gms_pure_go` is a documented tag in `go-mysql-server` that switches the regex engine from CGO/ICU to pure Go; already used on all other targets

## Background

The linux-amd64 binary was the only CGO-enabled target missing this tag, causing it to dynamically link against `libicui18n.so.74` from the CI runner. Users on distros with newer ICU (e.g. Arch with ICU 78) got "cannot open shared object file" errors at runtime.

Fixes #2986