### PR TITLE
test: add regression tests for nocgo --server flag suggestion

### DIFF
--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -22,7 +22,7 @@ func isEmbeddedMode() bool {
 // available without CGO.
 func newDoltStore(ctx context.Context, cfg *dolt.Config, _ ...embeddeddolt.Option) (storage.DoltStorage, error) {
 	if !cfg.ServerMode {
-		return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --mode server)")
+		return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
 	}
 	return dolt.New(ctx, cfg)
 }
@@ -38,7 +38,7 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfig(ctx, beadsDir)
 	}
-	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --mode server)")
+	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
 }
 
 // newReadOnlyStoreFromConfig creates a read-only server-mode storage backend.
@@ -47,5 +47,5 @@ func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.D
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	}
-	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --mode server)")
+	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
 }

--- a/cmd/bd/store_factory_nocgo_test.go
+++ b/cmd/bd/store_factory_nocgo_test.go
@@ -1,0 +1,64 @@
+//go:build !cgo
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+// TestNocgoNewDoltStore_ErrorSuggestsCorrectFlag verifies that newDoltStore
+// suggests "bd init --server" (not the old "--mode server") when ServerMode
+// is false.
+func TestNocgoNewDoltStore_ErrorSuggestsCorrectFlag(t *testing.T) {
+	cfg := &dolt.Config{ServerMode: false}
+	_, err := newDoltStore(t.Context(), cfg)
+	if err == nil {
+		t.Fatal("expected error when ServerMode is false")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "bd init --server") {
+		t.Errorf("error should suggest 'bd init --server', got: %s", msg)
+	}
+	if strings.Contains(msg, "--mode") {
+		t.Errorf("error should NOT contain '--mode' (old flag), got: %s", msg)
+	}
+}
+
+// TestNocgoNewDoltStoreFromConfig_ErrorSuggestsCorrectFlag verifies that
+// newDoltStoreFromConfig suggests "bd init --server" when no server-mode
+// config exists.
+func TestNocgoNewDoltStoreFromConfig_ErrorSuggestsCorrectFlag(t *testing.T) {
+	beadsDir := t.TempDir() // empty dir — no config.json
+	_, err := newDoltStoreFromConfig(t.Context(), beadsDir)
+	if err == nil {
+		t.Fatal("expected error for empty beads dir without server config")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "bd init --server") {
+		t.Errorf("error should suggest 'bd init --server', got: %s", msg)
+	}
+	if strings.Contains(msg, "--mode") {
+		t.Errorf("error should NOT contain '--mode' (old flag), got: %s", msg)
+	}
+}
+
+// TestNocgoNewReadOnlyStoreFromConfig_ErrorSuggestsCorrectFlag verifies that
+// newReadOnlyStoreFromConfig suggests "bd init --server" when no server-mode
+// config exists.
+func TestNocgoNewReadOnlyStoreFromConfig_ErrorSuggestsCorrectFlag(t *testing.T) {
+	beadsDir := t.TempDir() // empty dir — no config.json
+	_, err := newReadOnlyStoreFromConfig(t.Context(), beadsDir)
+	if err == nil {
+		t.Fatal("expected error for empty beads dir without server config")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "bd init --server") {
+		t.Errorf("error should suggest 'bd init --server', got: %s", msg)
+	}
+	if strings.Contains(msg, "--mode") {
+		t.Errorf("error should NOT contain '--mode' (old flag), got: %s", msg)
+	}
+}


### PR DESCRIPTION
Test companion to #3010 (landed as #3037). Adds regression tests confirming error messages suggest --server instead of the old --mode flag.

Stacked on top of fix/nocgo-mode-flag-3010.

The tests verify that when nocgo mode is active and ServerMode is false, all three store factory functions suggest the correct "bd init --server" flag and do NOT contain the old "--mode server" suggestion.

Co-Authored-By: obsidian <trillium@trilliumsmith.com>