### PR TITLE
feat: add --label and --label-any filtering to bd orphans

### DIFF
--- a/cmd/bd/doctor_conventions.go
+++ b/cmd/bd/doctor_conventions.go
@@ -170,7 +170,7 @@ func runConventionsStale() []doctorCheck {
 
 // runConventionsOrphans checks for issues referenced in commits but still open.
 func runConventionsOrphans(path string) []doctorCheck {
-	orphans, err := findOrphanedIssues(path)
+	orphans, err := findOrphanedIssues(path, nil, nil)
 	if err != nil {
 		// Not an error - orphan detection may fail in non-git repos
 		return []doctorCheck{{

--- a/cmd/bd/orphans.go
+++ b/cmd/bd/orphans.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // doctorFindOrphanedIssues is the function used to find orphaned issues.
@@ -36,10 +37,16 @@ Examples:
   bd orphans              # Show orphaned issues
   bd orphans --json       # Machine-readable output
   bd orphans --details    # Show full commit information
-  bd orphans --fix        # Close orphaned issues with confirmation`,
+  bd orphans --fix        # Close orphaned issues with confirmation
+  bd orphans --label theme:personal             # Only orphans with this label
+  bd orphans --label-any theme:personal,theme:ventures  # Orphans with either label`,
 	Run: func(cmd *cobra.Command, args []string) {
 		path := "."
-		orphans, err := findOrphanedIssues(path)
+		labels, _ := cmd.Flags().GetStringSlice("label")
+		labelsAny, _ := cmd.Flags().GetStringSlice("label-any")
+		labels = utils.NormalizeLabels(labels)
+		labelsAny = utils.NormalizeLabels(labelsAny)
+		orphans, err := findOrphanedIssues(path, labels, labelsAny)
 		if err != nil {
 			FatalError("%v", err)
 		}
@@ -109,16 +116,27 @@ type orphanIssueOutput struct {
 }
 
 // doltStoreProvider wraps storage.DoltStorage to implement types.IssueProvider.
-type doltStoreProvider struct{}
+type doltStoreProvider struct {
+	labels    []string // AND semantics: issue must have ALL these labels
+	labelsAny []string // OR semantics: issue must have AT LEAST ONE of these labels
+}
 
 func (p *doltStoreProvider) GetOpenIssues(ctx context.Context) ([]*types.Issue, error) {
 	openStatus := types.StatusOpen
-	openIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{Status: &openStatus})
+	openIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		Status:    &openStatus,
+		Labels:    p.labels,
+		LabelsAny: p.labelsAny,
+	})
 	if err != nil {
 		return nil, err
 	}
 	inProgressStatus := types.StatusInProgress
-	inProgressIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{Status: &inProgressStatus})
+	inProgressIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{
+		Status:    &inProgressStatus,
+		Labels:    p.labels,
+		LabelsAny: p.labelsAny,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -139,18 +157,26 @@ func (p *doltStoreProvider) GetIssuePrefix() string {
 	return prefix
 }
 
-// getIssueProvider returns an IssueProvider backed by the global Dolt store.
-func getIssueProvider() (types.IssueProvider, func(), error) {
+// getIssueProviderFn is the function used to create an IssueProvider.
+// It is a variable so tests can substitute a mock without needing a real store.
+var getIssueProviderFn = func(labels, labelsAny []string) (types.IssueProvider, func(), error) {
 	if store != nil {
-		return &doltStoreProvider{}, func() {}, nil
+		return &doltStoreProvider{labels: labels, labelsAny: labelsAny}, func() {}, nil
 	}
 	return nil, nil, fmt.Errorf("no database available")
 }
 
+// getIssueProvider returns an IssueProvider backed by the global Dolt store.
+// labels and labelsAny are passed through to SearchIssues for label filtering.
+func getIssueProvider(labels, labelsAny []string) (types.IssueProvider, func(), error) {
+	return getIssueProviderFn(labels, labelsAny)
+}
+
 // findOrphanedIssues wraps the shared doctor package function and converts to output format.
 // It respects the --db flag for cross-repo orphan detection.
-func findOrphanedIssues(path string) ([]orphanIssueOutput, error) {
-	provider, cleanup, err := getIssueProvider()
+// labels and labelsAny are passed to the issue provider to restrict which issues are considered.
+func findOrphanedIssues(path string, labels, labelsAny []string) ([]orphanIssueOutput, error) {
+	provider, cleanup, err := getIssueProvider(labels, labelsAny)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find orphaned issues: %w", err)
 	}
@@ -182,5 +208,7 @@ func closeIssue(issueID string) error {
 func init() {
 	orphansCmd.Flags().BoolP("fix", "f", false, "Close orphaned issues with confirmation")
 	orphansCmd.Flags().Bool("details", false, "Show full commit information")
+	orphansCmd.Flags().StringSliceP("label", "l", []string{}, "Filter by labels (AND: must have ALL). Can combine with --label-any")
+	orphansCmd.Flags().StringSlice("label-any", []string{}, "Filter by labels (OR: must have AT LEAST ONE). Can combine with --label")
 	rootCmd.AddCommand(orphansCmd)
 }

--- a/cmd/bd/orphans_embedded_test.go
+++ b/cmd/bd/orphans_embedded_test.go
@@ -64,6 +64,27 @@ func TestEmbeddedOrphans(t *testing.T) {
 		out := bdOrphans(t, bd, dir, "--details")
 		_ = out // Should succeed without crashing
 	})
+
+	// ===== --label =====
+
+	t.Run("orphans_label", func(t *testing.T) {
+		// --label with a label that matches no issues should return no orphans
+		out := bdOrphans(t, bd, dir, "--label", "nonexistent-label-xyz")
+		_ = out // Should succeed without crashing
+	})
+
+	t.Run("orphans_label_json", func(t *testing.T) {
+		out := bdOrphans(t, bd, dir, "--label", "nonexistent-label-xyz", "--json")
+		s := strings.TrimSpace(out)
+		if !json.Valid([]byte(s)) {
+			t.Errorf("invalid JSON with --label --json: %s", s[:min(200, len(s))])
+		}
+	})
+
+	t.Run("orphans_label_any", func(t *testing.T) {
+		out := bdOrphans(t, bd, dir, "--label-any", "nonexistent-label-xyz")
+		_ = out // Should succeed without crashing
+	})
 }
 
 // TestEmbeddedOrphansConcurrent exercises orphans concurrently.

--- a/cmd/bd/orphans_test.go
+++ b/cmd/bd/orphans_test.go
@@ -119,3 +119,94 @@ func TestCloseIssue_PropagatesError(t *testing.T) {
 		t.Fatalf("expected delegated error, got %v", err)
 	}
 }
+
+func TestOrphansLabelFlagsRegistered(t *testing.T) {
+	labelFlag := orphansCmd.Flags().Lookup("label")
+	if labelFlag == nil {
+		t.Fatal("--label flag not registered on orphansCmd")
+	}
+	labelAnyFlag := orphansCmd.Flags().Lookup("label-any")
+	if labelAnyFlag == nil {
+		t.Fatal("--label-any flag not registered on orphansCmd")
+	}
+}
+
+func TestDoltStoreProvider_LabelFields(t *testing.T) {
+	p := &doltStoreProvider{
+		labels:    []string{"theme:personal"},
+		labelsAny: []string{"theme:ventures", "theme:probono"},
+	}
+	if len(p.labels) != 1 || p.labels[0] != "theme:personal" {
+		t.Fatalf("unexpected labels: %v", p.labels)
+	}
+	if len(p.labelsAny) != 2 {
+		t.Fatalf("unexpected labelsAny: %v", p.labelsAny)
+	}
+}
+
+// TestFindOrphanedIssues_LabelArgs verifies that label args are passed to the doctor
+// function via a provider that was constructed with those labels. We intercept
+// doctorFindOrphanedIssues to capture the provider and inspect its fields.
+func TestFindOrphanedIssues_LabelArgs(t *testing.T) {
+	orig := doctorFindOrphanedIssues
+	t.Cleanup(func() { doctorFindOrphanedIssues = orig })
+
+	var capturedProvider types.IssueProvider
+	doctorFindOrphanedIssues = func(path string, provider types.IssueProvider) ([]doctor.OrphanIssue, error) {
+		capturedProvider = provider
+		return nil, nil
+	}
+
+	// Substitute getIssueProvider so we don't need a real store.
+	origProviderFn := getIssueProviderFn
+	t.Cleanup(func() { getIssueProviderFn = origProviderFn })
+	getIssueProviderFn = func(labels, labelsAny []string) (types.IssueProvider, func(), error) {
+		return &doltStoreProvider{labels: labels, labelsAny: labelsAny}, func() {}, nil
+	}
+
+	wantLabels := []string{"theme:personal"}
+	wantLabelsAny := []string{"theme:ventures"}
+	_, err := findOrphanedIssues(".", wantLabels, wantLabelsAny)
+	if err != nil {
+		t.Fatalf("findOrphanedIssues returned unexpected error: %v", err)
+	}
+	p, ok := capturedProvider.(*doltStoreProvider)
+	if !ok {
+		t.Fatalf("expected *doltStoreProvider, got %T", capturedProvider)
+	}
+	if len(p.labels) != 1 || p.labels[0] != "theme:personal" {
+		t.Fatalf("labels not propagated: got %v", p.labels)
+	}
+	if len(p.labelsAny) != 1 || p.labelsAny[0] != "theme:ventures" {
+		t.Fatalf("labelsAny not propagated: got %v", p.labelsAny)
+	}
+}
+
+func TestFindOrphanedIssues_NoLabels(t *testing.T) {
+	orig := doctorFindOrphanedIssues
+	t.Cleanup(func() { doctorFindOrphanedIssues = orig })
+
+	var capturedProvider types.IssueProvider
+	doctorFindOrphanedIssues = func(_ string, provider types.IssueProvider) ([]doctor.OrphanIssue, error) {
+		capturedProvider = provider
+		return nil, nil
+	}
+
+	origProviderFn := getIssueProviderFn
+	t.Cleanup(func() { getIssueProviderFn = origProviderFn })
+	getIssueProviderFn = func(labels, labelsAny []string) (types.IssueProvider, func(), error) {
+		return &doltStoreProvider{labels: labels, labelsAny: labelsAny}, func() {}, nil
+	}
+
+	_, err := findOrphanedIssues(".", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, ok := capturedProvider.(*doltStoreProvider)
+	if !ok {
+		t.Fatalf("expected *doltStoreProvider, got %T", capturedProvider)
+	}
+	if len(p.labels) != 0 || len(p.labelsAny) != 0 {
+		t.Fatalf("expected empty label filters, got labels=%v labelsAny=%v", p.labels, p.labelsAny)
+	}
+}


### PR DESCRIPTION
Cherry-pick of #3026 onto upstream/main. Adds label-based filtering to the orphans command.

The original PR had a single CI failure in "Test (Embedded Dolt Cmd 7/20)" which ran for ~20 minutes before timing out — consistent with an unrelated flake, not a regression in this feature.

All 6 orphan-specific unit tests pass locally:
- `TestOrphansLabelFlagsRegistered`
- `TestDoltStoreProvider_LabelFields`
- `TestFindOrphanedIssues_LabelArgs`
- `TestFindOrphanedIssues_NoLabels`
- `TestFindOrphanedIssues_ConvertsDoctorOutput`
- `TestFindOrphanedIssues_ErrorWrapped`