### PR TITLE
fix: include comment bodies in export and fix same-second dedup on import

### DIFF
--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -300,8 +300,8 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) error 
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
 			SELECT COUNT(*) FROM %s
-			WHERE issue_id = ? AND author = ? AND created_at = ?
-		`, commentTable), issue.ID, comment.Author, createdAt).Scan(&exists); err != nil {
+			WHERE issue_id = ? AND author = ? AND created_at = ? AND text = ?
+		`, commentTable), issue.ID, comment.Author, createdAt, comment.Text).Scan(&exists); err != nil {
 			return fmt.Errorf("failed to check comment existence for %s: %w", issue.ID, err)
 		}
 		if exists > 0 {


### PR DESCRIPTION
Cherry-pick of #3009 onto upstream/main. Fixes data-loss: exports now retain comment bodies, and import dedup includes comment text to prevent same-second collision.

**Note on export.go conflict:** upstream/main already had an equivalent `GetCommentsForIssues()` call added independently (using variable name `commentsMap`). The cherry-pick retained HEAD's version since it is functionally identical to the PR's `allComments` variant. The `create.go` dedup fix landed cleanly.

Fixes #3007