### PR TITLE
docs: correct DeepWiki link to gastownhall/beads

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,4 +170,4 @@ For daemon mode without git, use `bd daemon start --local`
 ## 📝 Documentation
 
 * [Installing](docs/INSTALLING.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot Setup](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
-* [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/steveyegge/beads)
+* [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/gastownhall/beads)


### PR DESCRIPTION
Extracted from PR #2978: update the DeepWiki reference from steveyegge/beads to gastownhall/beads.

This is the unique delta from PR #2978 not covered by PR #3036 (which adds the hosted docs link in a different location).