### PR TITLE
fix: custom status validation falls back to config when table is empty

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -443,7 +443,9 @@ var listCmd = &cobra.Command{
 			if store != nil {
 				cs, err := store.GetCustomStatuses(rootCtx)
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s Could not load custom statuses from database: %v (falling back to config)\n", ui.RenderWarn("!"), err)
+					if !jsonOutput {
+						fmt.Fprintf(os.Stderr, "%s Could not load custom statuses from database: %v (falling back to config)\n", ui.RenderWarn("!"), err)
+					}
 				} else {
 					customStatuses = cs
 				}

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -123,9 +123,12 @@ func ResolveCustomTypesInTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
 		if err := rows.Err(); err != nil {
 			return nil, fmt.Errorf("reading custom_types: %w", err)
 		}
-		// Table query succeeded — return result even if empty.
-		// Only fall through to config string when the table doesn't exist (query error above).
-		return result, nil
+		if len(result) > 0 {
+			return result, nil
+		}
+		// Table exists but is empty — fall through to config string.
+		// This handles the case where schema migration created the table
+		// but didn't populate it from the existing types.custom config.
 	}
 
 	// Fallback: table doesn't exist (pre-migration) — read from config string


### PR DESCRIPTION
Cherry-pick of #2985 onto upstream/main. Fixes migration edge-case where empty custom_statuses table caused validation to reject valid statuses defined in config.

## Changes

- `internal/storage/issueops/config_helpers.go`: When `custom_statuses` or `custom_types` table exists but is empty (e.g. schema migration created the table but didn't populate it from the existing config), fall through to the config string rather than returning an empty result.
- `cmd/bd/list.go`: Handle `GetCustomStatuses` errors gracefully — suppress the warning in JSON output mode and fall back to config-defined statuses.

## Conflict resolution

Two minor conflicts with upstream/main were resolved:
1. `config_helpers.go`: HEAD had already partially implemented the empty-table fallback with slightly different comment wording — kept HEAD's comments (more explanatory).
2. `list.go`: Combined HEAD's descriptive `ui.RenderWarn` message style with the PR's `!jsonOutput` guard for correct behavior in JSON output mode.