### PR TITLE
fix: add town root fallback for wisp ID lookups

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,8 +17,10 @@ GOLANGCI_LINT="go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.
 echo "$staged_go_files" | xargs gofmt -w
 echo "$staged_go_files" | xargs git add
 
-# Lint changed code with auto-fix; block on remaining issues
-$GOLANGCI_LINT run --new-from-rev=HEAD --fix || exit 1
+# Lint changed code with auto-fix; block on remaining issues.
+# CGO_ENABLED=0 avoids typecheck failures from CGO-only dependencies
+# (e.g., dolthub/go-icu-regex) that require system headers not always present.
+CGO_ENABLED=0 $GOLANGCI_LINT run --new-from-rev=HEAD --fix || exit 1
 
 # Re-stage any auto-fixes from the linter
 echo "$staged_go_files" | xargs git add

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,10 +17,8 @@ GOLANGCI_LINT="go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.
 echo "$staged_go_files" | xargs gofmt -w
 echo "$staged_go_files" | xargs git add
 
-# Lint changed code with auto-fix; block on remaining issues.
-# CGO_ENABLED=0 avoids typecheck failures from CGO-only dependencies
-# (e.g., dolthub/go-icu-regex) that require system headers not always present.
-CGO_ENABLED=0 $GOLANGCI_LINT run --new-from-rev=HEAD --fix || exit 1
+# Lint changed code with auto-fix; block on remaining issues
+$GOLANGCI_LINT run --new-from-rev=HEAD --fix || exit 1
 
 # Re-stage any auto-fixes from the linter
 echo "$staged_go_files" | xargs git add

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -42,6 +42,10 @@ func (r *RoutedResult) Close() {
 
 // resolveAndGetIssueWithRouting resolves a partial ID and gets the issue.
 // Tries the local store first, then falls back to contributor auto-routing.
+// For ephemeral/wisp IDs (containing "-wisp-"), also checks the town root
+// database as a fallback, since wisps are stored in the database where they
+// were created (typically HQ) but their prefix may match a different rig's
+// route (e.g., sh-wisp-xxx has "sh-" prefix but lives in hq.wisps).
 //
 // Returns a RoutedResult containing the issue, resolved ID, and the store to use.
 // The caller MUST call result.Close() when done to release any routed storage.
@@ -50,6 +54,16 @@ func resolveAndGetIssueWithRouting(ctx context.Context, localStore storage.DoltS
 	result, err := resolveAndGetFromStore(ctx, localStore, id, false)
 	if err == nil {
 		return result, nil
+	}
+
+	// For ephemeral/wisp IDs, try the town root database before prefix-based
+	// routing. Wisps are created in the town context (HQ database) regardless
+	// of their ID prefix, so prefix-based routing would misroute them to the
+	// wrong database (e.g., sh-wisp-xxx routes to shipyard but lives in hq).
+	if isNotFoundErr(err) && strings.Contains(id, "-wisp-") {
+		if townResult, townErr := resolveViaWispTownFallback(ctx, localStore, id); townErr == nil {
+			return townResult, nil
+		}
 	}
 
 	// If not found locally, try contributor auto-routing as fallback (GH#2345).
@@ -102,8 +116,31 @@ func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, 
 	return result, nil
 }
 
+// resolveViaWispTownFallback attempts to find a wisp in the town root database.
+// Wisps are always stored in the database where they were created (typically HQ/town),
+// but their ID prefix may match a different rig's route in routes.jsonl. For example,
+// sh-wisp-xxx has "sh-" prefix (routes to shipyard) but was created and stored in hq.wisps.
+//
+// This fallback walks up from the current beads directory to find the town root's
+// .beads directory and opens a read-only store to check for the wisp there.
+func resolveViaWispTownFallback(ctx context.Context, _ storage.DoltStorage, id string) (*RoutedResult, error) {
+	townStore, err := openTownRootReadStore(ctx)
+	if err != nil || townStore == nil {
+		return nil, fmt.Errorf("no town root store available for wisp fallback")
+	}
+
+	result, err := resolveAndGetFromStore(ctx, townStore, id, true)
+	if err != nil {
+		_ = townStore.Close()
+		return nil, err
+	}
+	result.closeFn = func() { _ = townStore.Close() }
+	return result, nil
+}
+
 // getIssueWithRouting gets an issue by exact ID.
-// Tries the local store first, then falls back to contributor auto-routing.
+// Tries the local store first, then falls back to town root for wisps,
+// then to contributor auto-routing.
 //
 // Returns a RoutedResult containing the issue and the store to use for related queries.
 // The caller MUST call result.Close() when done to release any routed storage.
@@ -117,6 +154,15 @@ func getIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id
 			Routed:     false,
 			ResolvedID: id,
 		}, nil
+	}
+
+	// For ephemeral/wisp IDs, try the town root database before prefix-based
+	// routing. Wisps live in the creating database (typically HQ), not where
+	// their prefix routes to.
+	if isNotFoundErr(err) && strings.Contains(id, "-wisp-") {
+		if townResult, townErr := resolveViaWispTownFallback(ctx, localStore, id); townErr == nil {
+			return townResult, nil
+		}
 	}
 
 	// If not found locally, try contributor auto-routing as fallback (GH#2345).

--- a/cmd/bd/routing_read.go
+++ b/cmd/bd/routing_read.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -84,4 +85,53 @@ func openRoutedReadStore(ctx context.Context, store storage.DoltStorage) (storag
 		return nil, false, fmt.Errorf("failed to open routed store at %s: %w", targetRepoPath, err)
 	}
 	return targetStore, true, nil
+}
+
+// openTownRootReadStore opens a read-only store for the town root database.
+// This is used as a fallback when looking up wisp IDs that may have been created
+// in the town/HQ context but whose prefix routes to a different rig's database.
+//
+// The town root is found by walking up from the current beads directory (dbPath)
+// to find a parent directory containing .beads/routes.jsonl — the presence of
+// routes.jsonl indicates a multi-rig orchestrator root (the town).
+//
+// Returns nil if no town root is found, or if the town root is the same as the
+// current database (no need to open a second store).
+func openTownRootReadStore(ctx context.Context) (storage.DoltStorage, error) {
+	if dbPath == "" {
+		return nil, fmt.Errorf("no database path available")
+	}
+
+	// Resolve the current beads directory from dbPath.
+	currentBeadsDir := filepath.Dir(dbPath)
+
+	// Walk up from the current beads directory's parent to find the town root.
+	// The town root contains .beads/routes.jsonl (multi-rig routing config).
+	dir := filepath.Dir(currentBeadsDir) // parent of .beads
+	for dir != "" && dir != filepath.Dir(dir) {
+		candidateBeadsDir := filepath.Join(dir, ".beads")
+		candidateRoutes := filepath.Join(candidateBeadsDir, "routes.jsonl")
+
+		if _, err := os.Stat(candidateRoutes); err == nil {
+			// Found a town root with routes.jsonl.
+			// Skip if it's the same as our current beads directory.
+			absCandidate, _ := filepath.Abs(candidateBeadsDir)
+			absCurrent, _ := filepath.Abs(currentBeadsDir)
+			if absCandidate == absCurrent {
+				debug.Logf("wisp town fallback: town root is same as current store, skipping")
+				return nil, fmt.Errorf("town root is same as current store")
+			}
+
+			debug.Logf("wisp town fallback: found town root at %s", candidateBeadsDir)
+			townStore, err := newReadOnlyStoreFromConfig(ctx, candidateBeadsDir)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open town root store at %s: %w", candidateBeadsDir, err)
+			}
+			return townStore, nil
+		}
+
+		dir = filepath.Dir(dir)
+	}
+
+	return nil, fmt.Errorf("no town root found (no routes.jsonl in ancestor directories)")
 }


### PR DESCRIPTION
## Summary

- Wisps created in town context (HQ database) get `sh-wisp-xxx` IDs. The `sh-` prefix routes lookups to shipyard via routes.jsonl, but the wisp lives in `hq.wisps`.
- Add a wisp-specific fallback: when a `-wisp-` ID is not found locally, walk up to find the town root (identified by routes.jsonl) and check its wisps table.
- Routing order is now: local store -> town root (for wisp IDs only) -> prefix-based auto-routing.

Split from upstream #2976: the pre-commit hook `CGO_ENABLED=0` fix is valid but unrelated to wisp routing and will be submitted separately.

## Test plan
- [x] `bd show sh-wisp-xxx` works from town root
- [x] `bd show sh-wisp-xxx` works with `BEADS_DIR` pointing to shipyard
- [x] `bd show sh-xxx` (regular beads) still works normally
- [x] `go vet ./cmd/bd/...` passes
- [x] `CGO_ENABLED=0 go build ./...` passes
- [x] Existing routing tests pass (`TestConfigSetManyMixedKeyRouting`)
- [x] Pre-existing test failure (`TestInitGuard_FreshCloneWithMetadataJSON`) is unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)