### PR TITLE
fix: include comment bodies in export and fix same-second dedup on import (#3009)

### DIFF
--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -300,8 +300,8 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) error 
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
 			SELECT COUNT(*) FROM %s
-			WHERE issue_id = ? AND author = ? AND created_at = ?
-		`, commentTable), issue.ID, comment.Author, createdAt).Scan(&exists); err != nil {
+			WHERE issue_id = ? AND author = ? AND created_at = ? AND text = ?
+		`, commentTable), issue.ID, comment.Author, createdAt, comment.Text).Scan(&exists); err != nil {
 			return fmt.Errorf("failed to check comment existence for %s: %w", issue.ID, err)
 		}
 		if exists > 0 {


### PR DESCRIPTION
Conflict-resolved fixup for #3009.

## Summary

- Exports now include comment bodies (fixes data-loss where comments array was always empty in JSONL output)
- Same-second import dedup now includes `AND text = ?` to prevent silent comment drops when multiple comments by same author land in the same second
- Conflict in `cmd/bd/export.go` resolved: upstream/main had independently added `GetCommentsForIssues()` using variable name `commentsMap`; PR #3009 used `allComments` — functionally identical. Resolved by keeping `commentsMap` (HEAD naming).
- Fix in `internal/storage/issueops/create.go` applied cleanly.

## Build & Test

- `go build -tags gms_pure_go ./cmd/bd/` — passes
- `CGO_ENABLED=0 go test ./internal/storage/... -count=1 -timeout 60s` — all pass

Closes #3007. Supersedes #3009 (which had a merge conflict).