### PR TITLE
fix: auto-commit config table writes in remember, forget, and config commands

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -134,6 +134,9 @@ var configSetCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Error setting config: %v\n", err)
 			os.Exit(1)
 		}
+		if _, err := store.CommitPending(ctx, getActor()); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to commit config change: %v\n", err)
+		}
 
 		if jsonOutput {
 			outputJSON(map[string]string{
@@ -381,6 +384,9 @@ var configUnsetCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Error deleting config: %v\n", err)
 			os.Exit(1)
 		}
+		if _, err := store.CommitPending(ctx, getActor()); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to commit config change: %v\n", err)
+		}
 
 		if jsonOutput {
 			outputJSON(map[string]string{
@@ -609,6 +615,9 @@ Examples:
 					fmt.Fprintf(os.Stderr, "Error setting config %s: %v\n", p.key, err)
 					os.Exit(1)
 				}
+			}
+			if _, err := store.CommitPending(ctx, getActor()); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to commit config changes: %v\n", err)
 			}
 		}
 

--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -91,6 +91,9 @@ Examples:
 		if err := store.SetConfig(ctx, storageKey, insight); err != nil {
 			FatalErrorRespectJSON("storing memory: %v", err)
 		}
+		if _, err := store.CommitPending(ctx, getActor()); err != nil {
+			WarnError("failed to commit memory: %v", err)
+		}
 
 		if jsonOutput {
 			outputJSON(map[string]string{
@@ -229,6 +232,9 @@ Examples:
 
 		if err := store.DeleteConfig(ctx, storageKey); err != nil {
 			FatalErrorRespectJSON("forgetting memory: %v", err)
+		}
+		if _, err := store.CommitPending(ctx, getActor()); err != nil {
+			WarnError("failed to commit forget: %v", err)
 		}
 
 		if jsonOutput {


### PR DESCRIPTION
## Summary

Fixes #3028

`bd remember`, `bd forget`, `bd config set`, `bd config unset`, and `bd config set-many` write to the Dolt config table via `store.SetConfig()` / `store.DeleteConfig()`, but none of them call `store.CommitPending()` afterward. This means the config changes are staged in the Dolt working set but never committed to Dolt history — they silently vanish on server restart or get clobbered by the next unrelated commit.

## Changes

- **cmd/bd/memory.go**: Add `CommitPending()` after `SetConfig` in `remember` and after `DeleteConfig` in `forget`
- **cmd/bd/config.go**: Add `CommitPending()` after `SetConfig` in `config set`, after `DeleteConfig` in `config unset`, and after the batch loop in `config set-many`

All commit failures are non-fatal warnings since the primary operation (set/delete) already succeeded.

## Test plan

- [x] `make build` passes
- [x] Relevant tests pass (`TestRemember`, `TestForget`, `TestConfig`)
- [x] `go vet ./...` passes
- [x] Pre-existing test failures in `cmd/bd` (timeout), `cmd/bd/doctor`, and `internal/configfile` are unrelated to these changes (caused by live Dolt server interference)