### PR TITLE
fix: replace CWD-only check with walk-up in FindBeadsDir (GH#3027)

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -555,13 +555,21 @@ func hasBeadsProjectFiles(beadsDir string) bool {
 
 // FindBeadsDir finds the .beads/ directory in the current directory tree.
 // Returns empty string if not found.
-// Stops at the git repository root to avoid finding unrelated directories.
-// Validates that the directory contains actual project files.
-// Redirect files are supported: if a .beads/redirect file exists, its contents
-// are used as the actual .beads directory path.
-// For worktrees, checks in order: worktree redirect, worktree's own .beads
-// (separate-DB mode), then main repository's .beads (shared-DB fallback).
-// This is useful for commands that need to detect beads projects without requiring a database.
+//
+// Resolution order:
+//  1. BEADS_DIR environment variable (highest priority)
+//  2. Walk up from CWD toward repo root boundary, checking each directory
+//     for .beads/ with valid project files. For worktrees, stops at the
+//     worktree root; for non-worktrees, stops at the git root.
+//  3. Worktree-specific fallback: per-worktree redirect, worktree's own
+//     .beads (separate-DB mode), shared .beads via git-common-dir.
+//  4. Extended walk from the boundary to the main repo root (worktrees)
+//     or checks the git root itself (non-worktrees).
+//
+// Validates that directories contain actual project files (metadata.json,
+// config.yaml, dolt/, embeddeddolt/, or *.db).
+// Redirect files are supported: if a .beads/redirect file exists, its
+// contents are used as the actual .beads directory path.
 func FindBeadsDir() string {
 	// 1. Check BEADS_DIR environment variable (preferred)
 	if beadsDir := os.Getenv("BEADS_DIR"); beadsDir != "" {
@@ -578,24 +586,60 @@ func FindBeadsDir() string {
 		}
 	}
 
-	// 1b. Check cwd for .beads/ before git-worktree resolution.
-	// This handles rigs (subdirectories with their own .beads/) inside a
-	// git repo that also has .beads/. Without this, step 2b grabs the
-	// git root's .beads/ and the rig's local one is never found.
-	if cwd, err := os.Getwd(); err == nil {
-		cwdBeadsDir := filepath.Join(cwd, ".beads")
-		if info, err := os.Stat(cwdBeadsDir); err == nil && info.IsDir() {
-			cwdBeadsDir = FollowRedirect(cwdBeadsDir)
-			if hasBeadsProjectFiles(cwdBeadsDir) {
-				return cwdBeadsDir
-			}
-		}
+	// 2. Walk up from CWD toward the repo root, checking each directory for .beads/.
+	// This replaces the former step 1b (CWD-only check) with a proper ancestor walk,
+	// fixing the case where CWD is a subdirectory within a rig (not the rig root itself).
+	// For worktrees, the walk stops at the worktree root boundary to avoid finding
+	// git-tracked .beads/ at the worktree root that has metadata but no database.
+	// The worktree-specific fallback logic (step 3) handles worktree root resolution.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
 	}
 
-	// 2. For worktrees, check worktree-local redirect first, then own .beads, then main repo
+	gitRoot := findGitRoot()
+
+	// Determine the walk-up boundary: worktree root for worktrees, git root otherwise.
+	// We stop BEFORE the boundary so worktree fallback logic can handle the root's .beads/.
+	isWt := git.IsWorktree()
+	walkBoundary := gitRoot
+	if isWt {
+		// For worktrees, stop the walk at the worktree root.
+		// The worktree root's .beads/ may be git-tracked metadata without a real database;
+		// the worktree fallback logic (step 3) handles this correctly.
+		walkBoundary = git.GetRepoRoot()
+	}
+
+	for dir := cwd; dir != "/" && dir != "."; {
+		// Stop at the walk boundary (exclusive — don't check this directory).
+		// For worktrees: stops before worktree root so step 3 handles it.
+		// For non-worktrees: stops before git root (which is checked below in the
+		// post-worktree walk, step 4).
+		if walkBoundary != "" && dir == walkBoundary {
+			break
+		}
+
+		beadsDir := filepath.Join(dir, ".beads")
+		if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
+			beadsDir = FollowRedirect(beadsDir)
+			if hasBeadsProjectFiles(beadsDir) {
+				return beadsDir
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// 3. Worktree-specific fallback: redirect, own .beads, shared .beads.
+	// This runs after the walk-up so that rig subdirectories win, but before
+	// the extended walk (step 4) so worktree-aware logic is preferred.
 	var mainRepoRoot string
-	if git.IsWorktree() {
-		// 2a. Per-worktree redirect override
+	if isWt {
+		// 3a. Per-worktree redirect override
 		if target := worktreeRedirectTarget(); target != "" {
 			if info, err := os.Stat(target); err == nil && info.IsDir() {
 				if hasBeadsProjectFiles(target) {
@@ -604,7 +648,7 @@ func FindBeadsDir() string {
 			}
 		}
 
-		// 2b. Worktree's own .beads (separate-DB mode, no redirect)
+		// 3b. Worktree's own .beads (separate-DB mode, no redirect)
 		if worktreeRoot := git.GetRepoRoot(); worktreeRoot != "" {
 			worktreeBeadsDir := filepath.Join(worktreeRoot, ".beads")
 			if info, err := os.Stat(worktreeBeadsDir); err == nil && info.IsDir() {
@@ -614,7 +658,7 @@ func FindBeadsDir() string {
 			}
 		}
 
-		// 2c. Fall back to the canonical shared .beads for this worktree.
+		// 3c. Fall back to the canonical shared .beads for this worktree.
 		if fallbackBeadsDir := GetWorktreeFallbackBeadsDir(); fallbackBeadsDir != "" {
 			if info, err := os.Stat(fallbackBeadsDir); err == nil && info.IsDir() {
 				fallbackBeadsDir = FollowRedirect(fallbackBeadsDir)
@@ -631,52 +675,37 @@ func FindBeadsDir() string {
 		}
 	}
 
-	// 3. Search for .beads/ in current directory and ancestors
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ""
-	}
+	// 4. Extended walk: from walk boundary to git/main-repo root.
+	// For non-worktrees, this checks the git root itself (the walk-up in step 2
+	// stopped before it). For worktrees, this walks from worktree root to main
+	// repo root, handling edge cases where .beads/ is between the two.
+	// Skip if there was no walk boundary (step 2 already searched everything).
+	if walkBoundary != "" {
+		extendedRoot := gitRoot
+		if isWt && mainRepoRoot != "" {
+			extendedRoot = mainRepoRoot
+		}
 
-	// Find git root to limit the search
-	gitRoot := findGitRoot()
-	worktreeRoot := gitRoot // save worktree-specific boundary
-	if git.IsWorktree() && mainRepoRoot != "" {
-		// For worktrees, extend search boundary to include main repo
-		gitRoot = mainRepoRoot
-	}
-
-	for dir := cwd; dir != "/" && dir != "."; {
-		beadsDir := filepath.Join(dir, ".beads")
-		if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
-			// Follow redirect if present
-			beadsDir = FollowRedirect(beadsDir)
-
-			// Validate directory contains actual project files
-			if hasBeadsProjectFiles(beadsDir) {
-				return beadsDir
+		for dir := walkBoundary; dir != "/" && dir != "."; {
+			beadsDir := filepath.Join(dir, ".beads")
+			if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
+				beadsDir = FollowRedirect(beadsDir)
+				if hasBeadsProjectFiles(beadsDir) {
+					return beadsDir
+				}
 			}
-		}
 
-		// Stop at git root to avoid finding unrelated directories
-		if gitRoot != "" && dir == gitRoot {
-			break
-		}
+			// Stop at the extended root
+			if extendedRoot != "" && dir == extendedRoot {
+				break
+			}
 
-		// Also stop at worktree root when it differs from main repo root
-		// This prevents escaping the worktree boundary into unrelated directories
-		if worktreeRoot != "" && worktreeRoot != gitRoot && dir == worktreeRoot {
-			break
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
 		}
-
-		// Move up one directory
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			// Reached filesystem root (works on both Unix and Windows)
-			// On Unix: filepath.Dir("/") returns "/"
-			// On Windows: filepath.Dir("C:\\") returns "C:\\"
-			break
-		}
-		dir = parent
 	}
 
 	return ""

--- a/internal/beads/cwd_priority_test.go
+++ b/internal/beads/cwd_priority_test.go
@@ -345,6 +345,253 @@ func TestFindBeadsDir_CwdEmptyBeadsDir_SkipsToCwdWalk(t *testing.T) {
 	}
 }
 
+// TestFindBeadsDir_RigSubdir_WalksUpToRigBeads verifies that when CWD is a
+// subdirectory within a rig, the walk-up finds the rig's .beads/ (not the
+// git root's .beads/). This is the primary fix for GH#3027 — the old step 1b
+// only checked CWD directly, missing rig subdirectories.
+func TestFindBeadsDir_RigSubdir_WalksUpToRigBeads(t *testing.T) {
+	origBeadsDir := os.Getenv("BEADS_DIR")
+	t.Cleanup(func() {
+		if origBeadsDir != "" {
+			os.Setenv("BEADS_DIR", origBeadsDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	})
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir := t.TempDir()
+
+	// Create a git repo (simulating the main repo root)
+	cmd := exec.Command("git", "init", tmpDir)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	// Create root-level .beads/ with project files (the "wrong" one)
+	rootBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(rootBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"root_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootBeadsDir, "config.yaml"), []byte("issue_prefix: root\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a rig subdirectory with its own .beads/ (the "right" one)
+	rigDir := filepath.Join(tmpDir, "my-rig")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"rig_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "config.yaml"), []byte("issue_prefix: rig\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a deep subdirectory within the rig (CWD will be here)
+	deepDir := filepath.Join(rigDir, "polecats", "furiosa", "src")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// cd into the deep subdirectory within the rig
+	t.Chdir(deepDir)
+
+	result := FindBeadsDir()
+
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	expectedResolved, _ := filepath.EvalSymlinks(rigBeadsDir)
+	if resultResolved != expectedResolved {
+		t.Errorf("FindBeadsDir() = %q, want %q (should walk up from rig subdir to find rig's .beads/)", result, rigBeadsDir)
+	}
+}
+
+// TestFindBeadsDir_DeepSubdir_NoRig_WalksToGitRoot verifies that when CWD is
+// a deep subdirectory with no rig .beads/ in between, the walk-up finds the
+// git root's .beads/.
+func TestFindBeadsDir_DeepSubdir_NoRig_WalksToGitRoot(t *testing.T) {
+	origBeadsDir := os.Getenv("BEADS_DIR")
+	t.Cleanup(func() {
+		if origBeadsDir != "" {
+			os.Setenv("BEADS_DIR", origBeadsDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	})
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir := t.TempDir()
+
+	// Create a git repo
+	cmd := exec.Command("git", "init", tmpDir)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	// Create root-level .beads/ only
+	rootBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(rootBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"root_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a deep subdirectory without any .beads/ in between
+	deepDir := filepath.Join(tmpDir, "a", "b", "c", "d")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(deepDir)
+
+	result := FindBeadsDir()
+
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	expectedResolved, _ := filepath.EvalSymlinks(rootBeadsDir)
+	if resultResolved != expectedResolved {
+		t.Errorf("FindBeadsDir() = %q, want %q (should walk up to git root's .beads/)", result, rootBeadsDir)
+	}
+}
+
+// TestFindBeadsDir_NestedRigs_FindsNearest verifies that with multiple nested
+// rigs, the walk-up finds the nearest (innermost) rig's .beads/.
+func TestFindBeadsDir_NestedRigs_FindsNearest(t *testing.T) {
+	origBeadsDir := os.Getenv("BEADS_DIR")
+	t.Cleanup(func() {
+		if origBeadsDir != "" {
+			os.Setenv("BEADS_DIR", origBeadsDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	})
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir := t.TempDir()
+
+	// Create a git repo
+	cmd := exec.Command("git", "init", tmpDir)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	// Root .beads/
+	rootBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(rootBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"root_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Outer rig .beads/
+	outerRigDir := filepath.Join(tmpDir, "outer-rig")
+	outerBeadsDir := filepath.Join(outerRigDir, ".beads")
+	if err := os.MkdirAll(outerBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outerBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"outer_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inner rig .beads/ (nested inside outer)
+	innerRigDir := filepath.Join(outerRigDir, "inner-rig")
+	innerBeadsDir := filepath.Join(innerRigDir, ".beads")
+	if err := os.MkdirAll(innerBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(innerBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"inner_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// CWD is a subdirectory of inner rig
+	deepDir := filepath.Join(innerRigDir, "src", "pkg")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(deepDir)
+
+	result := FindBeadsDir()
+
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	expectedResolved, _ := filepath.EvalSymlinks(innerBeadsDir)
+	if resultResolved != expectedResolved {
+		t.Errorf("FindBeadsDir() = %q, want %q (should find nearest/innermost rig's .beads/)", result, innerBeadsDir)
+	}
+}
+
+// TestFindBeadsDir_RigSubdirWithRedirect verifies that when CWD is a subdirectory
+// within a rig and the rig's .beads/ has a redirect, the redirect is followed.
+func TestFindBeadsDir_RigSubdirWithRedirect(t *testing.T) {
+	origBeadsDir := os.Getenv("BEADS_DIR")
+	t.Cleanup(func() {
+		if origBeadsDir != "" {
+			os.Setenv("BEADS_DIR", origBeadsDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	})
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir := t.TempDir()
+
+	// Create a git repo
+	cmd := exec.Command("git", "init", tmpDir)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+
+	// Create root-level .beads/
+	rootBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(rootBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rootBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"root_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create redirect target
+	targetBeadsDir := filepath.Join(tmpDir, "shared-beads")
+	if err := os.MkdirAll(targetBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetBeadsDir, "metadata.json"), []byte(`{"backend":"dolt","dolt_database":"shared_db"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rig with .beads/ that has a redirect
+	rigDir := filepath.Join(tmpDir, "my-rig")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "redirect"), []byte(targetBeadsDir), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// CWD is a subdirectory within the rig
+	subDir := filepath.Join(rigDir, "polecats", "nux")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(subDir)
+
+	result := FindBeadsDir()
+
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	expectedResolved, _ := filepath.EvalSymlinks(targetBeadsDir)
+	if resultResolved != expectedResolved {
+		t.Errorf("FindBeadsDir() = %q, want %q (should follow redirect from rig .beads/ found via walk-up)", result, targetBeadsDir)
+	}
+}
+
 // isUnder returns true if child is under parent in the directory tree.
 func isUnder(child, parent string) bool {
 	rel, err := filepath.Rel(parent, child)


### PR DESCRIPTION
## Summary

- Replaces the CWD-only `.beads/` check (former step 1b) with a proper walk-up from CWD toward the repo root boundary
- Fixes the case where CWD is a subdirectory within a rig (e.g., `my-rig/polecats/nux/src/`) — the old code only checked CWD directly and would miss the rig's `.beads/` one or more levels up
- Preserves existing resolution order: `BEADS_DIR` env var > walk-up > worktree fallback > extended walk to main repo root

## Changed files

- `internal/beads/beads.go` — `FindBeadsDir()` refactored: CWD-only check replaced with ancestor walk-up that stops at the repo root boundary (worktree root for worktrees, git root otherwise), followed by worktree-specific fallback, then an extended walk from boundary to main repo root
- `internal/beads/cwd_priority_test.go` — Four new test cases:
  - `TestFindBeadsDir_RigSubdir_WalksUpToRigBeads` — primary regression test for GH#3027
  - `TestFindBeadsDir_DeepSubdir_NoRig_WalksToGitRoot` — walk-up finds git root when no rig in between
  - `TestFindBeadsDir_NestedRigs_FindsNearest` — nested rigs resolve to innermost
  - `TestFindBeadsDir_RigSubdirWithRedirect` — walk-up respects redirect files

## Test plan

- [x] `go test ./internal/beads/...` — all tests pass (including 4 new tests)
- [x] `go vet ./internal/beads/...` — clean
- [ ] CI full test suite

Closes #3027