### PR TITLE
fix: reject empty database name in bootstrap clone (GH#3029)

### DIFF
--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -446,6 +446,133 @@ func TestBootstrapFreshCloneNoRemoteData(t *testing.T) {
 
 // TestBootstrapExistingBeadsDirUnchanged verifies that when .beads already
 // exists, the normal bootstrap flow is unaffected by the fresh-clone fix.
+// TestDetectBootstrapAction_PlanUsesConfiguredDatabaseName verifies that
+// detectBootstrapAction carries the configured dolt_database into the plan,
+// rather than silently falling back to the default "beads". This is the
+// core regression test for GH#3029.
+func TestDetectBootstrapAction_PlanUsesConfiguredDatabaseName(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	cfg.DoltDatabase = "my_project_db"
+
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Database != "my_project_db" {
+		t.Errorf("plan.Database = %q, want %q; bootstrap must use the configured database name, not the default",
+			plan.Database, "my_project_db")
+	}
+}
+
+// TestDetectBootstrapAction_PlanDefaultDatabaseWhenNotConfigured verifies
+// that the default "beads" is used when no dolt_database is configured.
+func TestDetectBootstrapAction_PlanDefaultDatabaseWhenNotConfigured(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Database != configfile.DefaultDoltDatabase {
+		t.Errorf("plan.Database = %q, want %q (default)", plan.Database, configfile.DefaultDoltDatabase)
+	}
+}
+
+// TestDetectBootstrapAction_ServerModePlanUsesConfiguredDatabaseName verifies
+// that in server mode, the plan carries the configured database name for
+// both the plan.Database field and the server probe. This is the specific
+// failure mode reported in GH#3029: when FindBeadsDir resolved to the wrong
+// .beads/, the config had no dolt_database, and the plan fell back to "beads".
+func TestDetectBootstrapAction_ServerModePlanUsesConfiguredDatabaseName(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a dolt data dir with a subdirectory so the existing-DB check fires.
+	// Use BEADS_DOLT_DATA_DIR (not shared server mode) so ResolveDoltDir
+	// returns our test directory instead of ~/.beads/shared-server/dolt/.
+	doltDataDir := filepath.Join(tmpDir, "dolt-data")
+	if err := os.MkdirAll(filepath.Join(doltDataDir, "myrig"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DOLT_DATA_DIR", doltDataDir)
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	cfg.DoltMode = configfile.DoltModeServer
+	cfg.DoltDatabase = "myrig"
+	cfg.DoltDataDir = doltDataDir
+
+	var probedDBName string
+	origCheck := checkBootstrapServerDB
+	checkBootstrapServerDB = func(probeCfg bootstrapServerProbeConfig) bootstrapServerDBCheck {
+		probedDBName = probeCfg.database
+		return bootstrapServerDBCheck{Exists: false, Reachable: true}
+	}
+	defer func() { checkBootstrapServerDB = origCheck }()
+
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Database != "myrig" {
+		t.Errorf("plan.Database = %q, want %q", plan.Database, "myrig")
+	}
+	if probedDBName != "myrig" {
+		t.Errorf("server probe used database %q, want %q; bootstrap must probe the configured database, not the default",
+			probedDBName, "myrig")
+	}
+}
+
 func TestBootstrapExistingBeadsDirUnchanged(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")

--- a/internal/storage/dolt/bootstrap.go
+++ b/internal/storage/dolt/bootstrap.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -43,7 +44,7 @@ func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, da
 		return false, nil
 	}
 
-	if database == "" {
+	if strings.TrimSpace(database) == "" {
 		return false, fmt.Errorf("database name must not be empty; use cfg.GetDoltDatabase() to resolve the configured name")
 	}
 

--- a/internal/storage/dolt/bootstrap.go
+++ b/internal/storage/dolt/bootstrap.go
@@ -24,16 +24,19 @@ const staleLockAge = 5 * time.Minute
 // dolt clone creates <target>/.dolt/ directly (no database subdirectory),
 // but the embedded driver expects <doltDir>/<database>/.dolt/. To reconcile,
 // we clone into <doltDir>/<database>/ so the embedded driver finds it.
-// If database is empty, "beads" is used.
+// Uses the default database name ("beads"). Prefer BootstrapFromGitRemoteWithDB
+// when a configured database name is available.
 //
 // Returns true if the clone was performed, false if skipped (dolt dir already exists).
 func BootstrapFromGitRemote(ctx context.Context, doltDir, gitRemoteURL string) (bool, error) {
-	return BootstrapFromGitRemoteWithDB(ctx, doltDir, gitRemoteURL, "")
+	return BootstrapFromGitRemoteWithDB(ctx, doltDir, gitRemoteURL, configfile.DefaultDoltDatabase)
 }
 
 // BootstrapFromGitRemoteWithDB is like BootstrapFromGitRemote but allows
 // specifying the database name (used by the embedded driver for the
-// subdirectory structure).
+// subdirectory structure). The database parameter must not be empty;
+// callers should use cfg.GetDoltDatabase() which applies the fallback chain
+// (env var → config → default).
 func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, database string) (bool, error) {
 	// Skip if Dolt database already exists
 	if doltExists(doltDir) {
@@ -41,7 +44,7 @@ func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, da
 	}
 
 	if database == "" {
-		database = configfile.DefaultDoltDatabase
+		return false, fmt.Errorf("database name must not be empty; use cfg.GetDoltDatabase() to resolve the configured name")
 	}
 
 	// Verify dolt CLI is available

--- a/internal/storage/dolt/bootstrap_test.go
+++ b/internal/storage/dolt/bootstrap_test.go
@@ -23,6 +23,20 @@ func TestBootstrapFromGitRemoteWithDB_RejectsEmptyDatabase(t *testing.T) {
 	}
 }
 
+// TestBootstrapFromGitRemoteWithDB_RejectsWhitespaceDatabase verifies that
+// whitespace-only database names are also rejected (defense-in-depth).
+func TestBootstrapFromGitRemoteWithDB_RejectsWhitespaceDatabase(t *testing.T) {
+	doltDir := t.TempDir()
+
+	_, err := BootstrapFromGitRemoteWithDB(context.Background(), doltDir, "file:///dev/null", "   ")
+	if err == nil {
+		t.Fatal("expected error for whitespace-only database name, got nil")
+	}
+	if !strings.Contains(err.Error(), "database name must not be empty") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
 // TestBootstrapFromGitRemote_UsesDefaultDatabase verifies that the
 // convenience wrapper BootstrapFromGitRemote explicitly passes the
 // default database name rather than an empty string.

--- a/internal/storage/dolt/bootstrap_test.go
+++ b/internal/storage/dolt/bootstrap_test.go
@@ -1,0 +1,45 @@
+package dolt
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestBootstrapFromGitRemoteWithDB_RejectsEmptyDatabase verifies that
+// BootstrapFromGitRemoteWithDB returns an error when called with an
+// empty database name. Callers should use cfg.GetDoltDatabase() which
+// applies the fallback chain (env var -> config -> default). A silent
+// fallback to "beads" here previously masked misconfiguration (GH#3029).
+func TestBootstrapFromGitRemoteWithDB_RejectsEmptyDatabase(t *testing.T) {
+	doltDir := t.TempDir()
+
+	_, err := BootstrapFromGitRemoteWithDB(context.Background(), doltDir, "file:///dev/null", "")
+	if err == nil {
+		t.Fatal("expected error for empty database name, got nil")
+	}
+	if !strings.Contains(err.Error(), "database name must not be empty") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestBootstrapFromGitRemote_UsesDefaultDatabase verifies that the
+// convenience wrapper BootstrapFromGitRemote explicitly passes the
+// default database name rather than an empty string.
+func TestBootstrapFromGitRemote_UsesDefaultDatabase(t *testing.T) {
+	// Create a doltDir that already contains a database so the function
+	// returns early (skips clone) without needing the dolt CLI.
+	doltDir := t.TempDir()
+
+	// BootstrapFromGitRemote should not error with "database name must not be empty"
+	// because it passes configfile.DefaultDoltDatabase explicitly.
+	// It will return false (skipped) because doltExists returns false for an
+	// empty dir, then it will fail trying to run dolt clone — but the error
+	// should be about dolt CLI, not about empty database name.
+	_, err := BootstrapFromGitRemote(context.Background(), doltDir, "file:///dev/null")
+	if err != nil && strings.Contains(err.Error(), "database name must not be empty") {
+		t.Fatal("BootstrapFromGitRemote should pass an explicit database name, not empty string")
+	}
+	// Any other error (dolt CLI not found, clone failure) is fine — we only care
+	// that the empty-database guard didn't fire.
+}


### PR DESCRIPTION
## Summary

- **Defense-in-depth fix for GH#3029**: `BootstrapFromGitRemoteWithDB` now rejects empty database names with a clear error instead of silently falling back to `"beads"`. This prevents misconfiguration from propagating silently during bootstrap.
- `BootstrapFromGitRemote` now passes `configfile.DefaultDoltDatabase` explicitly rather than empty string.
- 5 regression tests added covering: empty database rejection, default database usage, configured database propagation, and server-mode database naming.

## Key files changed

- `internal/storage/dolt/bootstrap.go` — reject empty database name, update convenience wrapper
- `internal/storage/dolt/bootstrap_test.go` — 2 unit tests for the bootstrap functions
- `cmd/bd/bootstrap_test.go` — 3 integration tests for `detectBootstrapAction` plan database naming

## Test plan

- [x] `go test ./internal/storage/dolt/...` — all pass
- [x] `go vet` on changed packages — clean
- [x] Rebased on latest `origin/main` — no conflicts
- [x] `cmd/bd` tests have pre-existing ICU header build issue (unrelated to this PR)