### PR TITLE
docs: clarify --issues + --parent flag interaction in selective sync

### DIFF
--- a/cmd/bd/sync_flags.go
+++ b/cmd/bd/sync_flags.go
@@ -8,20 +8,35 @@ import (
 )
 
 // registerSelectiveSyncFlags adds --issues and --parent flags to a tracker sync command.
+// These two flags are mutually exclusive: use --issues to sync specific beads by ID,
+// or --parent to sync an entire subtree. Combining them is an error.
 func registerSelectiveSyncFlags(cmd *cobra.Command) {
-	cmd.Flags().String("issues", "", "Comma-separated bead IDs to sync selectively (e.g., bd-abc,bd-def)")
+	cmd.Flags().String("issues", "", "Comma-separated bead IDs to sync selectively (e.g., bd-abc,bd-def). Mutually exclusive with --parent.")
 	if cmd.Flags().Lookup("parent") == nil {
-		cmd.Flags().String("parent", "", "Limit push to this bead and its descendants")
+		cmd.Flags().String("parent", "", "Limit push to this bead and its descendants (push only). Mutually exclusive with --issues.")
 	}
 }
 
 // applySelectiveSyncFlags parses --issues and --parent from cmd and applies them to opts.
-// Returns an error if --parent is used without push.
+//
+// Rules:
+//   - --parent requires push mode (incompatible with --pull-only).
+//   - --issues and --parent are mutually exclusive: --issues targets specific beads by ID
+//     while --parent scopes by subtree. Combining them would produce confusing AND semantics
+//     (only issues that are BOTH in the ID list AND in the subtree would be synced).
+//     To sync a subtree plus additional individual issues, use --issues with all desired IDs.
 func applySelectiveSyncFlags(cmd *cobra.Command, opts *tracker.SyncOptions, push bool) error {
-	if issuesFlag, _ := cmd.Flags().GetString("issues"); issuesFlag != "" {
+	issuesFlag, _ := cmd.Flags().GetString("issues")
+	parentID, _ := cmd.Flags().GetString("parent")
+
+	if issuesFlag != "" && parentID != "" {
+		return fmt.Errorf("--issues and --parent are mutually exclusive: use --issues to target specific beads by ID, or --parent to sync a subtree")
+	}
+
+	if issuesFlag != "" {
 		opts.IssueIDs = splitCSV(issuesFlag)
 	}
-	if parentID, _ := cmd.Flags().GetString("parent"); parentID != "" {
+	if parentID != "" {
 		if !push {
 			return fmt.Errorf("--parent requires push (cannot use with --pull-only)")
 		}

--- a/cmd/bd/sync_parent_flag_test.go
+++ b/cmd/bd/sync_parent_flag_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/tracker"
 )
 
 // TestParentFlagRegistered verifies --parent flag exists on all tracker sync commands.
@@ -45,5 +46,31 @@ func TestParentFlagNotOnNotion(t *testing.T) {
 	// For now, we don't add it to Notion since Notion doesn't support parent-child deps.
 	if flag != nil {
 		t.Log("Notion sync has --parent flag (may be intentional for future use)")
+	}
+}
+
+// TestIssuesAndParentAreMutuallyExclusive verifies that specifying both --issues
+// and --parent on the same sync command returns an error.
+//
+// The two flags cannot be combined: --issues targets specific bead IDs while
+// --parent scopes by subtree. Silently ANDing them would produce confusing
+// results where only issues that appear in both sets are synced.
+func TestIssuesAndParentAreMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "test"}
+	registerSelectiveSyncFlags(cmd)
+
+	if err := cmd.Flags().Set("issues", "bd-123"); err != nil {
+		t.Fatalf("setting --issues: %v", err)
+	}
+	if err := cmd.Flags().Set("parent", "bd-456"); err != nil {
+		t.Fatalf("setting --parent: %v", err)
+	}
+
+	var opts tracker.SyncOptions
+	err := applySelectiveSyncFlags(cmd, &opts, true /* push */)
+	if err == nil {
+		t.Fatal("expected error when both --issues and --parent are set, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #2957 and #2975 — documents and fixes the undocumented interaction when both `--issues` and `--parent` flags are specified on tracker sync commands.

**Root cause found:** The engine applied the two filters sequentially with AND logic — `IssueIDs` narrowed the issues list first, then `descendantSet` (from `--parent`) filtered again. This meant only issues appearing in **both** sets would sync, silently dropping any `--issues` IDs that weren't descendants of the parent. This behavior was never documented and is almost certainly not what users expect.

## Changes

- **`cmd/bd/sync_flags.go`**: `applySelectiveSyncFlags` now returns a clear error when both `--issues` and `--parent` are set, declaring them mutually exclusive. Updated the function doc-comment to explain why (AND semantics are confusing; users who want a subtree + extra IDs should list all IDs in `--issues`). Updated flag descriptions to mention mutual exclusivity.
- **`cmd/bd/sync_parent_flag_test.go`**: Added `TestIssuesAndParentAreMutuallyExclusive` to prove the rejection.

No engine-level changes were needed — the fix is entirely at the CLI validation layer, which is the right place to catch this before confusing behavior reaches the user.

## Test plan

- [x] Build passes (`go build -tags gms_pure_go ./cmd/bd/`)
- [x] `TestIssuesAndParentAreMutuallyExclusive` passes and covers the new error path
- [x] All existing `TestIssues*` and `TestParent*` tests pass
- [x] `TestPushPullSubcommandsRegistered` passes (push/pull subcommands unaffected — they use positional args, not `--issues`/`--parent`)