### PR TITLE
fix: respect dolt.auto-start=false, prevent rogue server spawns

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -559,6 +559,18 @@ func EnsureRunningDetailed(beadsDir string) (port int, startedByUs bool, err err
 			"  To check status: bd dolt status", cfg.Port)
 	}
 
+	// Defense-in-depth: if dolt.auto-start is explicitly disabled in
+	// config.yaml or env, never spawn a server even if the caller
+	// somehow reached this point (e.g. stale AutoStart=true in config).
+	if IsAutoStartDisabled() {
+		cfg := DefaultConfig(beadsDir)
+		return 0, false, fmt.Errorf("Dolt server unreachable (port %d) and auto-start is disabled "+
+			"(dolt.auto-start: false in config.yaml or BEADS_DOLT_AUTO_START=0).\n\n"+
+			"Start the server manually or enable auto-start.\n"+
+			"  To start manually: bd dolt start\n"+
+			"  To check status: bd dolt status", cfg.Port)
+	}
+
 	s, err := Start(serverDir)
 	if err != nil {
 		return 0, false, err

--- a/internal/storage/dolt/autostart_test.go
+++ b/internal/storage/dolt/autostart_test.go
@@ -44,7 +44,7 @@ func TestAutoStart_ConfigFalse_OverridesCallerTrue(t *testing.T) {
 	t.Setenv("GT_ROOT", "")
 	t.Setenv("BEADS_DOLT_AUTO_START", "")
 
-	for _, cfgVal := range []string{"false", "0", "off"} {
+	for _, cfgVal := range []string{"false", "False", "FALSE", "0", "off", "Off", "OFF"} {
 		got := resolveAutoStart(true, cfgVal, ServerModeOwned)
 		if got != false {
 			t.Errorf("resolveAutoStart(true, %q, Owned) = true, want false: config.yaml opt-out must override caller", cfgVal)

--- a/internal/storage/dolt/autostart_test.go
+++ b/internal/storage/dolt/autostart_test.go
@@ -34,6 +34,38 @@ func TestAutoStart_ExternalMode_CallerOverrideIgnored(t *testing.T) {
 	}
 }
 
+// TestAutoStart_ConfigFalse_OverridesCallerTrue verifies that dolt.auto-start: false
+// in config.yaml takes precedence over a caller passing current=true. This is the
+// core fix for the auto-start bug where ApplyCLIAutoStart and bootstrap paths
+// hardcoded current=true, ignoring the user's config.yaml opt-out.
+func TestAutoStart_ConfigFalse_OverridesCallerTrue(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("BEADS_DOLT_AUTO_START", "")
+
+	for _, cfgVal := range []string{"false", "0", "off"} {
+		got := resolveAutoStart(true, cfgVal, ServerModeOwned)
+		if got != false {
+			t.Errorf("resolveAutoStart(true, %q, Owned) = true, want false: config.yaml opt-out must override caller", cfgVal)
+		}
+	}
+}
+
+// TestAutoStart_ConfigEmpty_CallerTrueWins verifies that when config.yaml
+// does not set dolt.auto-start, the caller's current=true is respected.
+func TestAutoStart_ConfigEmpty_CallerTrueWins(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("BEADS_DOLT_AUTO_START", "")
+
+	got := resolveAutoStart(true, "", ServerModeOwned)
+	if got != true {
+		t.Error("resolveAutoStart(true, \"\", Owned) should return true when config is not set")
+	}
+}
+
 // TestAutoStart_EnvOverrideStillWins verifies that BEADS_DOLT_AUTO_START=0
 // still takes precedence even in Owned mode (defense-in-depth).
 func TestAutoStart_EnvOverrideStillWins(t *testing.T) {

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -113,9 +113,10 @@ func NewFromConfigWithOptions(ctx context.Context, beadsDir string, cfg *Config)
 //  2. BEADS_DOLT_AUTO_START=0              → always false (explicit env opt-out)
 //  3. mode == ServerModeExternal           → always false (server is externally managed;
 //     auto-starting a different server would create shadow databases)
-//  4. current == true                      → true  (caller option wins over config file,
-//     per NewFromConfigWithOptions contract)
-//  5. doltAutoStartCfg == "false"/"0"/"off" → false (config.yaml opt-out)
+//  4. doltAutoStartCfg == "false"/"0"/"off" → false (config.yaml explicit opt-out;
+//     user intent to disable auto-start must be respected even when callers
+//     like ApplyCLIAutoStart or bootstrap pass current=true — GH#autostart-bug)
+//  5. current == true                      → true  (caller option wins over default)
 //  6. default                              → true  (standalone user; safe default)
 //
 // doltAutoStartCfg is the raw value of the "dolt.auto-start" key from config.yaml
@@ -138,12 +139,17 @@ func resolveAutoStart(current bool, doltAutoStartCfg string, mode ServerMode) bo
 	if mode == ServerModeExternal {
 		return false
 	}
-	// Caller option wins over config.yaml (NewFromConfigWithOptions contract).
-	if current {
-		return true
-	}
+	// Config.yaml explicit opt-out takes precedence over caller-provided
+	// current=true. Without this, ApplyCLIAutoStart (which passes current=true)
+	// and bootstrap paths (which hardcode AutoStart=true) would ignore the
+	// user's dolt.auto-start: false setting, spawning rogue dolt servers that
+	// overwrite port files and cause DB lock conflicts.
 	if doltAutoStartCfg == "false" || doltAutoStartCfg == "0" || doltAutoStartCfg == "off" {
 		return false
+	}
+	// Caller option wins over default.
+	if current {
+		return true
 	}
 	// Default: auto-start for standalone users.
 	return true

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -144,7 +145,7 @@ func resolveAutoStart(current bool, doltAutoStartCfg string, mode ServerMode) bo
 	// and bootstrap paths (which hardcode AutoStart=true) would ignore the
 	// user's dolt.auto-start: false setting, spawning rogue dolt servers that
 	// overwrite port files and cause DB lock conflicts.
-	if doltAutoStartCfg == "false" || doltAutoStartCfg == "0" || doltAutoStartCfg == "off" {
+	if strings.EqualFold(doltAutoStartCfg, "false") || doltAutoStartCfg == "0" || strings.EqualFold(doltAutoStartCfg, "off") {
 		return false
 	}
 	// Caller option wins over default.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -922,8 +922,13 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			if breaker != nil {
 				breaker.RecordFailure()
 			}
-			return nil, fmt.Errorf("Dolt server unreachable at %s: %w\n\nThe Dolt server may not be running. Try:\n  bd dolt start",
-				addr, dialErr)
+			hint := "The Dolt server may not be running. Try:\n  bd dolt start"
+			if !cfg.AutoStart && doltserver.IsAutoStartDisabled() {
+				hint = "Dolt server auto-start is disabled (dolt.auto-start: false).\n" +
+					"Start the server manually:\n  bd dolt start"
+			}
+			return nil, fmt.Errorf("Dolt server unreachable at %s: %w\n\n%s",
+				addr, dialErr, hint)
 		}
 	}
 	_ = conn.Close()


### PR DESCRIPTION
## Summary

- `resolveAutoStart` checked `current == true` (from caller) before the config.yaml `dolt.auto-start: false` check, so the config was never honored
- `ApplyCLIAutoStart` always passes `current=true`, and `bootstrap.go` hardcodes `AutoStart: true` in three places — both bypass the config check
- Reordered priority in `resolveAutoStart` so config.yaml explicit opt-out is checked first
- Added defense-in-depth guard in `EnsureRunningDetailed` via `IsAutoStartDisabled()`
- Improved error message when auto-start is disabled and server is unreachable

Fixes #3057

## Test plan

- [x] New unit tests: `TestAutoStart_ConfigFalse_OverridesCallerTrue` and `TestAutoStart_ConfigEmpty_CallerTrueWins`
- [x] Existing `autostart_test.go` tests pass
- [ ] Manual: set `dolt.auto-start: false` in config, stop dolt, run `bd list` — should get clear error, no server spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)