### PR TITLE
fix: update steveyegge references in claude-plugin layer

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -6,9 +6,9 @@
     "name": "Steve Yegge",
     "url": "https://github.com/steveyegge"
   },
-  "repository": "https://github.com/steveyegge/beads",
+  "repository": "https://github.com/gastownhall/beads",
   "license": "MIT",
-  "homepage": "https://github.com/steveyegge/beads",
+  "homepage": "https://github.com/gastownhall/beads",
   "keywords": [
     "issue-tracker",
     "task-management",

--- a/claude-plugin/commands/quickstart.md
+++ b/claude-plugin/commands/quickstart.md
@@ -3,7 +3,7 @@ description: Quick start guide for bd workflows (deprecated)
 argument-hint: []
 ---
 
-**Note:** The `bd quickstart` command is deprecated. See the [Quick Start](https://steveyegge.github.io/beads/getting-started/quickstart) on the documentation site, or the repo pointer [docs/QUICKSTART.md](../docs/QUICKSTART.md).
+**Note:** The `bd quickstart` command is deprecated. See the [Quick Start](https://gastownhall.github.io/beads/getting-started/quickstart) on the documentation site, or the repo pointer [docs/QUICKSTART.md](../docs/QUICKSTART.md).
 
 The quickstart documentation covers:
 - Getting started with bd

--- a/claude-plugin/commands/version.md
+++ b/claude-plugin/commands/version.md
@@ -19,7 +19,7 @@ Display:
 - Compatibility status (✓ compatible or ⚠️ update needed)
 
 If versions are mismatched, provide instructions:
-- Update bd CLI: `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash`
+- Update bd CLI: `curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash`
 - Update plugin: `/plugin update beads`
 - Restart Claude Code after updating
 

--- a/claude-plugin/commands/workflow.md
+++ b/claude-plugin/commands/workflow.md
@@ -55,4 +55,4 @@ Use these via the beads MCP server:
 - `dep` (manage dependencies), `blocked`, `stats`
 - `init` (initialize bd in a project)
 
-For more details, see the beads README at: https://github.com/steveyegge/beads
+For more details, see the beads README at: https://github.com/gastownhall/beads

--- a/claude-plugin/skills/beads/README.md
+++ b/claude-plugin/skills/beads/README.md
@@ -1,6 +1,6 @@
 # Beads Skill for Claude Code
 
-A comprehensive skill for using [beads](https://github.com/steveyegge/beads) (bd) issue tracking with Claude Code.
+A comprehensive skill for using [beads](https://github.com/gastownhall/beads) (bd) issue tracking with Claude Code.
 
 ## What This Skill Does
 
@@ -91,7 +91,7 @@ NEXT: Implement rate limiting"
 
 ## Requirements
 
-- [bd CLI](https://github.com/steveyegge/beads) installed (`brew install beads`)
+- [bd CLI](https://github.com/gastownhall/beads) installed (`brew install beads`)
 - A git repository (bd requires git for sync)
 - Initialized database (`bd init` in project root)
 
@@ -111,7 +111,7 @@ NEXT: Implement rate limiting"
 
 ## Contributing
 
-This skill is maintained at [github.com/steveyegge/beads](https://github.com/steveyegge/beads) in the `claude-plugin/skills/beads/` directory.
+This skill is maintained at [github.com/gastownhall/beads](https://github.com/gastownhall/beads) in the `claude-plugin/skills/beads/` directory.
 
 Issues and PRs welcome for:
 - Documentation improvements

--- a/claude-plugin/skills/beads/resources/TROUBLESHOOTING.md
+++ b/claude-plugin/skills/beads/resources/TROUBLESHOOTING.md
@@ -57,7 +57,7 @@ brew upgrade beads
 go install github.com/steveyegge/beads/cmd/bd@latest
 
 # Via package manager
-# See https://github.com/steveyegge/beads#installing
+# See https://github.com/gastownhall/beads#installing
 ```
 
 **3. Restart Dolt server after upgrade:**
@@ -416,7 +416,7 @@ bd sql "SELECT * FROM dependencies" --json | head -50
 
 If problems persist:
 
-1. **Check existing issues:** https://github.com/steveyegge/beads/issues
+1. **Check existing issues:** https://github.com/gastownhall/beads/issues
 2. **Create new issue** with:
    - bd version (`bd version`)
    - Operating system
@@ -456,4 +456,4 @@ If the **bd-issue-tracking skill** provides incorrect guidance:
 - [CLI Reference](CLI_REFERENCE.md) - Complete command documentation
 - [Dependencies Guide](DEPENDENCIES.md) - Understanding dependency types
 - [Workflows](WORKFLOWS.md) - Step-by-step workflow guides
-- [beads GitHub](https://github.com/steveyegge/beads) - Official documentation
+- [beads GitHub](https://github.com/gastownhall/beads) - Official documentation

--- a/claude-plugin/skills/beads/resources/WORKTREES.md
+++ b/claude-plugin/skills/beads/resources/WORKTREES.md
@@ -85,10 +85,10 @@ Multi-clone, multi-branch workflows:
 
 - Hash-based IDs (`bd-abc`) eliminate collision across clones
 - Each clone syncs independently via git
-- See [WORKTREES.md](https://github.com/steveyegge/beads/blob/main/docs/WORKTREES.md) for comprehensive guide
+- See [WORKTREES.md](https://github.com/gastownhall/beads/blob/main/docs/WORKTREES.md) for comprehensive guide
 
 ## External References
 
-- **Official Docs**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
-- **Sync Branch**: [PROTECTED_BRANCHES.md](https://github.com/steveyegge/beads/blob/main/docs/PROTECTED_BRANCHES.md)
-- **Worktrees**: [WORKTREES.md](https://github.com/steveyegge/beads/blob/main/docs/WORKTREES.md)
+- **Official Docs**: [github.com/gastownhall/beads/docs](https://github.com/gastownhall/beads/tree/main/docs)
+- **Sync Branch**: [PROTECTED_BRANCHES.md](https://github.com/gastownhall/beads/blob/main/docs/PROTECTED_BRANCHES.md)
+- **Worktrees**: [WORKTREES.md](https://github.com/gastownhall/beads/blob/main/docs/WORKTREES.md)


### PR DESCRIPTION
updates all `steveyegge/beads` references to `gastownhall/beads` in the claude-plugin directory. this is the user-facing plugin layer that ships to the claude code marketplace.

## changes

7 files, 15 replacements across:
- `plugin.json` - repository and homepage URLs
- `commands/version.md` - install script URL
- `commands/quickstart.md` - github pages URL
- `commands/workflow.md` - repo link
- `skills/beads/README.md` - 3 repo links
- `skills/beads/resources/TROUBLESHOOTING.md` - issues link, install link
- `skills/beads/resources/WORKTREES.md` - 4 documentation links

## intentionally kept

- `plugin.json` author URL (`https://github.com/steveyegge`) - personal profile, not a repo ref
- `TROUBLESHOOTING.md` go install path - tied to go.mod module path, needs to change when module path changes

## context

fixes #3059 (claude-plugin layer scope)