### PR TITLE
test: align auto-start precedence expectation

### DIFF
--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -71,11 +71,11 @@ func TestResolveAutoStart(t *testing.T) {
 			wantAutoStart: true,
 		},
 		{
-			// Caller option wins over config.yaml per NewFromConfigWithOptions contract.
-			name:             "caller true wins over config.yaml opt-out",
+			// Config opt-out must still win when callers pass current=true.
+			name:             "config.yaml opt-out wins over caller true",
 			currentValue:     true,
 			doltAutoStartCfg: "false",
-			wantAutoStart:    true,
+			wantAutoStart:    false,
 		},
 		{
 			name:          "test mode overrides caller true",


### PR DESCRIPTION
## Summary
- align `TestResolveAutoStart` with the `main` branch auto-start precedence change
- keep `dolt.auto-start: false` higher priority than caller-provided defaults
- fix the failing `internal/storage/dolt` test on `main`

## Verification
- `go test ./internal/storage/dolt -run 'TestResolveAutoStart|TestAutoStart_'`
- `go test ./internal/storage/dolt`

## CI context
This addresses the failing `main` CI run `24041657889` on commit `97fea942f6588dc5772ed92b5434281ad458727c`, where `TestResolveAutoStart/config.yaml opt-out precedence` was still expecting the pre-`#3058` behavior.
