### PR TITLE
Update nix install for v1.0.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,7 @@
   self,
   buildGoModule,
   git,
+  icu,
   ...
 }:
 buildGoModule {
@@ -16,25 +17,31 @@ buildGoModule {
   doCheck = false;
 
   # Go module dependencies hash - if build fails with hash mismatch, update with the "got:" value
-  vendorHash = "sha256-1BJsEPP5SYZFGCWHLn532IUKlzcGDg5nhrqGWylEHgY=";
+  vendorHash = "sha256-7eb7u47f4/OCnK/T56Zd6b5XUyV6vkBmissryBxANBU=";
 
   # Relax go.mod version for Nix: nixpkgs Go may lag behind the latest
   # patch release, and GOTOOLCHAIN=auto can't download in the Nix sandbox.
   postPatch = ''
     goVer="$(go env GOVERSION | sed 's/^go//')"
     go mod edit -go="$goVer"
+
+    env
   '';
 
   # Allow patch-level toolchain upgrades when a dependency's minimum Go patch
   # version is newer than nixpkgs' bundled patch version.
   env.GOTOOLCHAIN = "auto";
+  # Due to https://github.com/dolthub/go-icu-regex, which requires
+  # separate install of icu headers and library.
+  env.CGO_CPPFLAGS="-I${icu.dev}/include";
+  env.CGO_LDFLAGS="-L${icu}/lib";
 
   # Git is required for tests
   nativeBuildInputs = [ git ];
 
   meta = with lib; {
     description = "beads (bd) - An issue tracker designed for AI-supervised coding workflows";
-    homepage = "https://github.com/steveyegge/beads";
+    homepage = "https://github.com/gastownhall/beads";
     license = licenses.mit;
     mainProgram = "bd";
     maintainers = [ ];

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772465433,
-        "narHash": "sha256-ywy9troNEfpgh0Ee+zaV1UTgU8kYBVKtvPSxh6clYGU=",
+        "lastModified": 1775305101,
+        "narHash": "sha256-/74n1oQPtKG52Yw41cbToxspxHbYz6O3vi+XEw16Qe8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c581273b8d5bdf1c6ce7e0a54da9841e6a763913",
+        "rev": "36a601196c4ebf49e035270e10b2d103fe39076b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,18 +18,6 @@
         "x86_64-linux"
       ];
 
-      # Go 1.25.8: go.mod requires it, nixpkgs has 1.25.7
-      # Remove when nixpkgs ships Go >= 1.25.8
-      goOverlay = final: prev: {
-        go_1_25 = prev.go_1_25.overrideAttrs {
-          version = "1.25.8";
-          src = prev.fetchurl {
-            url = "https://go.dev/dl/go1.25.8.src.tar.gz";
-            hash = "sha256-6YjUokRqx/4/baoImljpk2pSo4E1Wt7ByJgyMKjWxZ4=";
-          };
-        };
-      };
-
       forAllSystems =
         f:
         nixpkgs.lib.genAttrs systems (
@@ -37,22 +25,22 @@
           f {
             pkgs = import nixpkgs {
               inherit system;
-              overlays = [ goOverlay ];
             };
             inherit system self;
           }
         );
-    in
-    {
-      packages = forAllSystems (args: import ./packages.nix args);
+    in rec {
+      icu = nixpkgs.icu77;
+      packages = forAllSystems (args: import ./packages.nix (args // { inherit icu; }));
 
       apps = forAllSystems (
         { self, system, ... }:
-        {
-          default = {
+        rec {
+          bd = {
             type = "app";
             program = "${self.packages.${system}.default}/bin/bd";
           };
+          default = bd;
         }
       );
 


### PR DESCRIPTION
* Beads / dolt requires ICU libraries and headers for https://github.com/dolthub/go-icu-regex - added
* Refactor nix slightly for ergonomics.
* Remove unnecessary overlay