### PR TITLE
fix: remove ICU runtime dependency from release binaries

### DIFF
--- a/.buildflags
+++ b/.buildflags
@@ -1,14 +1,9 @@
-# This file is sourced by scripts to provide standard build flags
-# Mirrors Makefile CGO configuration for consistency
+# This file is sourced by scripts to provide standard build flags.
+# Mirrors Makefile CGO configuration for consistency.
+#
+# NOTE: ICU flags are NOT set here. The gms_pure_go build tag (used by
+# goreleaser and `make build`) tells go-mysql-server to use Go's stdlib
+# regex, eliminating the ICU runtime dependency. Only test scripts that
+# explicitly need ICU (test-cgo.sh) should set ICU flags.
 
 export CGO_ENABLED=1
-
-# ICU configuration (Homebrew or system)
-ICU_PREFIX=$(brew --prefix icu4c 2>/dev/null || true)
-if [ -n "$ICU_PREFIX" ]; then
-  export CGO_CFLAGS="-I${ICU_PREFIX}/include"
-  export CGO_LDFLAGS="-L${ICU_PREFIX}/lib"
-else
-  export CGO_CFLAGS="-I/usr/include"
-  export CGO_LDFLAGS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata"
-fi

--- a/Makefile
+++ b/Makefile
@@ -40,30 +40,19 @@ ifneq ($(GO_VERSION),)
 export GOTOOLCHAIN := go$(GO_VERSION)
 endif
 
-# ICU4C is keg-only in Homebrew (not symlinked into the prefix).
-# Dolt's go-icu-regex dependency needs these paths to compile and link.
-# This handles both macOS (brew --prefix icu4c) and Linux/Linuxbrew.
-# On Windows, ICU is not needed (pure-Go regex via gms_pure_go + regex_windows.go).
-ifneq ($(OS),Windows_NT)
-ICU_PREFIX := $(shell brew --prefix icu4c 2>/dev/null)
-ifneq ($(ICU_PREFIX),)
-export CGO_CFLAGS   += -I$(ICU_PREFIX)/include
-export CGO_CPPFLAGS += -I$(ICU_PREFIX)/include
-export CGO_LDFLAGS  += -L$(ICU_PREFIX)/lib
-# Linuxbrew gcc doesn't install a 'c++' symlink; point CGO at g++
-ifeq ($(shell uname),Linux)
-export CXX ?= g++
-endif
-endif
-endif
+# gms_pure_go tells go-mysql-server to use Go's stdlib regex instead of
+# ICU-backed go-icu-regex.  This eliminates the ICU shared-library runtime
+# dependency, making release binaries portable across Linux distros.
+# ICU flags are only needed for test-cgo.sh (which exercises the ICU path).
+BUILD_TAGS := gms_pure_go
 
 # Build the bd binary
 build:
 	@echo "Building bd..."
 ifeq ($(OS),Windows_NT)
-	go build -tags gms_pure_go -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd
+	go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd.exe ./cmd/bd
 else
-	go build -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd ./cmd/bd
+	go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd ./cmd/bd
 ifeq ($(shell uname),Darwin)
 	@codesign -s - -f $(BUILD_DIR)/bd 2>/dev/null || true
 	@echo "Signed bd for macOS"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -542,7 +542,7 @@ build_from_source() {
         cd beads
         log_info "Building binary..."
 
-        if CGO_ENABLED=1 go build -o bd ./cmd/bd; then
+        if CGO_ENABLED=1 go build -tags gms_pure_go -o bd ./cmd/bd; then
             if ! verify_binary_has_cgo "./bd" "source build"; then
                 cd - > /dev/null || cd "$HOME"
                 rm -rf "$tmp_dir"

--- a/scripts/verify-cgo.sh
+++ b/scripts/verify-cgo.sh
@@ -27,4 +27,16 @@ if strings "$binary_path" | awk '/^build[[:space:]]+CGO_ENABLED=0$/ { found=1 } 
     exit 1
 fi
 
+# On Linux (ELF binaries), verify no ICU shared-library dependency.
+# The gms_pure_go build tag should eliminate this; if it appears, the build
+# environment leaked ICU flags onto the link line.
+if command -v readelf >/dev/null 2>&1; then
+    if readelf -d "$binary_path" 2>/dev/null | grep -qi 'libicu'; then
+        echo "ERROR: $binary_path has unexpected ICU runtime dependency" >&2
+        readelf -d "$binary_path" | grep -i 'libicu' >&2
+        echo "Ensure the binary is built with -tags gms_pure_go and without ICU CGO_LDFLAGS" >&2
+        exit 1
+    fi
+fi
+
 echo "OK: $binary_path has CGO support"


### PR DESCRIPTION
## Problem

Released Linux binaries depend on a specific ICU shared-library version (e.g., `libicui18n.so.74`), making them non-portable across Linux distros. A system with ICU 77 cannot run a binary built against ICU 74.

## Root Cause

The `gms_pure_go` build tag (already used in goreleaser) tells go-mysql-server to use Go's stdlib regex instead of ICU-backed `go-icu-regex`. However, `.buildflags` and the Makefile were **unconditionally injecting ICU linker flags** — including explicit `-licui18n -licuuc -licudata` on Linux — which re-introduced the ICU dependency at link time, defeating the build tag.

## Fix

- **`.buildflags`**: Remove ICU flag injection; only export `CGO_ENABLED=1`
- **`Makefile`**: Replace ICU detection block with `BUILD_TAGS := gms_pure_go`; apply the tag on all platforms (previously only Windows used it)
- **`scripts/verify-cgo.sh`**: Add `readelf` check to catch ICU shared-library dependencies in ELF binaries — acts as a CI guardrail
- **`scripts/install.sh`**: Add `-tags gms_pure_go` to `build_from_source()`

## What's preserved

- `CGO_ENABLED=1` — still required for embedded Dolt (file locking, in-process SQL engine)
- `test-cgo.sh` / `test.sh` — ICU flags remain for macOS test scripts (these exercise the ICU code path locally)
- Release workflow ICU checks — already existed, now aligned with build config

## Trade-off

`gms_pure_go` uses Go's `regexp` instead of ICU for SQL regex functions (`REGEXP_LIKE`, etc.), which is slightly less MySQL-compatible. However, bd does not use SQL `REGEXP` functions, so this has no practical impact.

## Verification

```
$ make build
Building bd...
go build -tags "gms_pure_go" ...

$ readelf -d bd | grep -i icu
(nothing)

$ ./scripts/verify-cgo.sh ./bd
OK: ./bd has CGO support
```

All tests pass.