### PR TITLE
ci: add merge_group support and cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Fast check to ensure all version files are in sync


### PR DESCRIPTION
## Summary
- add merge_group to the CI workflow so merge queue candidates are validated
- add workflow concurrency so newer runs cancel stale ones
- keep the change workflow-only and leave branch protection policy to repository settings

## Validation
- python YAML parse check on .github/workflows/ci.yml
- git diff --check

## Context
This is the follow-up to issue #3068.
