### PR TITLE
fix: server→embedded migration loses all data (#3071)

### DIFF
--- a/scripts/migration-test/recipes/server_to_embedded.sh
+++ b/scripts/migration-test/recipes/server_to_embedded.sh
@@ -8,9 +8,9 @@
 #
 # Strategy:
 #   1. Stop any running Dolt server
-#   2. Clear stale server metadata
-#   3. Init with candidate (will detect dolt/ data and convert to embedded)
-#   4. If that fails, export JSONL with old binary and reimport
+#   2. Export all data via old binary (which auto-starts its own server)
+#   3. Stop server, clear stale metadata, init with candidate
+#   4. If candidate DB is empty, reimport from JSONL export
 #
 # User-facing instructions:
 #   If upgrading from a Dolt-server version (v0.50–v0.58):
@@ -27,37 +27,70 @@ recipe_server_to_embedded() {
 
     echo "  Trying server→embedded recipe..."
 
-    # Step 1: Stop any running server
+    # Step 1: Stop any running server (we'll restart via old binary as needed)
     stop_dolt_server "$ws"
 
-    # Step 2: Clear stale server metadata that causes TCP connect attempts
-    rm -f "$ws/.beads/metadata.json" 2>/dev/null || true
-    rm -f "$ws/.beads/dolt-server.pid" 2>/dev/null || true
-    rm -f "$ws/.beads/dolt-server.lock" 2>/dev/null || true
-
-    # Step 3: Try candidate init (may auto-detect dolt/ and convert)
-    if bd_in "$ws" "$cand_bin" init --quiet --non-interactive </dev/null >/dev/null 2>&1; then
-        echo "  candidate init succeeded after clearing server metadata"
-        return 0
-    fi
-
-    # Step 4: Fallback — export via old binary and reimport
-    echo "  direct init failed, trying JSONL export fallback..."
-
-    # Start old server briefly to export
+    # Step 2: Export data via old binary BEFORE clearing metadata.
+    # The old binary needs metadata.json to know it's in server mode and
+    # to auto-start its Dolt server. Removing metadata first (as was done
+    # previously) makes the old binary unable to find its data. (GH#3071)
+    echo "  exporting data via old binary..."
+    local export_ok=false
     if bd_in "$ws" "$old_bin" list --json -n 0 --all > "$ws/.beads/issues.jsonl.tmp" 2>/dev/null; then
         if [ -s "$ws/.beads/issues.jsonl.tmp" ]; then
             jq -c '.[]' "$ws/.beads/issues.jsonl.tmp" > "$ws/.beads/issues.jsonl" 2>/dev/null || true
+            rm -f "$ws/.beads/issues.jsonl.tmp"
+            if [ -s "$ws/.beads/issues.jsonl" ]; then
+                local export_count
+                export_count=$(wc -l < "$ws/.beads/issues.jsonl" 2>/dev/null) || export_count=0
+                echo "  exported $export_count items to JSONL"
+                export_ok=true
+            fi
+        else
             rm -f "$ws/.beads/issues.jsonl.tmp"
         fi
     fi
     stop_dolt_server "$ws"
 
-    if [ -s "$ws/.beads/issues.jsonl" ]; then
-        if bd_in "$ws" "$cand_bin" init --from-jsonl --quiet --non-interactive </dev/null >/dev/null 2>&1; then
-            echo "  candidate init --from-jsonl succeeded (JSONL fallback)"
+    # Step 3: Clear stale server metadata that causes TCP connect attempts,
+    # then try candidate init.
+    rm -f "$ws/.beads/metadata.json" 2>/dev/null || true
+    rm -f "$ws/.beads/dolt-server.pid" 2>/dev/null || true
+    rm -f "$ws/.beads/dolt-server.lock" 2>/dev/null || true
+
+    if bd_in "$ws" "$cand_bin" init --quiet --non-interactive </dev/null >/dev/null 2>&1; then
+        # Verify candidate actually has data — init may succeed but create
+        # an empty database if it didn't detect the old dolt/ data. (GH#3071)
+        local verify_out
+        verify_out=$(bd_in "$ws" "$cand_bin" list --json -n 0 --all 2>/dev/null) || true
+        if [ -n "$verify_out" ] && [ "$verify_out" != "[]" ] && [ "$verify_out" != "null" ]; then
+            echo "  candidate init succeeded with data intact"
             return 0
         fi
+        echo "  candidate init returned 0 but database is empty"
+    fi
+
+    # Step 4: Candidate init produced an empty DB (or failed).
+    # Move old storage directories out of the way so checkExistingBeadsData
+    # doesn't block --from-jsonl. The old dolt/ is server-era data; the
+    # embeddeddolt/ (if any) was just created empty by step 3.
+    stop_dolt_server "$ws"
+    for old_dir in "$ws/.beads/dolt" "$ws/.beads/embeddeddolt"; do
+        [ -d "$old_dir" ] && mv "$old_dir" "${old_dir}.pre-migration" 2>/dev/null || true
+    done
+    rm -f "$ws/.beads/metadata.json" 2>/dev/null || true
+    rm -f "$ws/.beads/config.json" 2>/dev/null || true
+
+    # Reimport from the JSONL export captured in step 2.
+    if $export_ok && [ -s "$ws/.beads/issues.jsonl" ]; then
+        echo "  reimporting from JSONL export..."
+        if bd_in "$ws" "$cand_bin" init --from-jsonl --quiet --non-interactive </dev/null >/dev/null 2>&1; then
+            echo "  candidate init --from-jsonl succeeded"
+            return 0
+        fi
+        echo "  init --from-jsonl failed"
+    else
+        echo "  no JSONL export available for reimport"
     fi
 
     echo "  FAILED: could not migrate from server mode"


### PR DESCRIPTION
## Summary

- Fixed data loss in the `server_to_embedded` migration recipe where removing `metadata.json` before exporting data made the old binary unable to locate its Dolt server, resulting in an empty export
- Reordered recipe to export data via old binary (which auto-starts its server using metadata.json) **before** clearing server metadata
- Added post-init verification: after candidate `init` returns 0, checks that `bd list` actually returns data before declaring success

## Root cause

The recipe's step ordering was:
1. Stop server
2. **Delete metadata.json** (the old binary's config for server mode)
3. Try candidate init (creates empty DB since no config found)
4. Try JSONL fallback (old binary can't export — metadata.json is gone)

Step 2 destroyed the information the old binary needed to find its data, and step 3 silently created an empty database (returning exit 0).

## Fix

New ordering:
1. Stop server
2. **Export via old binary** while metadata.json still exists (old binary auto-starts its server)
3. Stop server, then clear metadata
4. Try candidate init, **verify data exists** after init
5. If empty, reimport from the JSONL captured in step 2

Fixes #3071

## Test plan

- [ ] Run `./scripts/migration-test/run.sh v0.57.0` to verify the v0.57.0 → candidate path no longer loses data
- [ ] Run full migration suite `./scripts/migration-test/run.sh` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)