### PR TITLE
fix: unblock v0.62.0 migration test by allowing Dolt auto-start

### DIFF
--- a/scripts/migration-test/lib/features.sh
+++ b/scripts/migration-test/lib/features.sh
@@ -50,15 +50,24 @@ create_dataset() {
 
     # --- Core items (all versions) ---
 
-    # 1. Epic
+    # 1. Epic (optional — older server-era versions may fail if the Dolt
+    #    server hasn't finished starting).  Fall back to a plain task so the
+    #    dataset is still useful for upgrade-fidelity checks.
     local epic_id
     epic_id=$(bd_create "$ws" "$bin" --title "Migration epic" --type epic --priority 2 --description "Epic for migration testing") || true
-    if [ -z "${epic_id:-}" ]; then
-        echo "  FATAL: could not create epic" >&2
-        return 1
+    if [ -n "${epic_id:-}" ]; then
+        DATASET_IDS[epic]="$epic_id"
+        DATASET_FEATURES+=("epic")
+    else
+        echo "  WARN: epic creation failed, falling back to task" >&2
+        epic_id=$(bd_create "$ws" "$bin" --title "Migration epic (as task)" --type task --priority 2 --description "Epic for migration testing") || true
+        if [ -z "${epic_id:-}" ]; then
+            echo "  FATAL: could not create any issue — database may be unreachable" >&2
+            return 1
+        fi
+        DATASET_IDS[epic_fallback]="$epic_id"
+        DATASET_FEATURES+=("epic_fallback")
     fi
-    DATASET_IDS[epic]="$epic_id"
-    DATASET_FEATURES+=("epic")
 
     # 2. Task (will be child of epic if supported)
     local task_args=(--title "Migration task alpha" --type task --priority 1)

--- a/scripts/migration-test/lib/workspace.sh
+++ b/scripts/migration-test/lib/workspace.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 # Workspace helpers — create isolated git repos, run bd commands, cleanup.
 
-export BEADS_TEST_MODE="${BEADS_TEST_MODE:-1}"
+# NOTE: BEADS_TEST_MODE is intentionally NOT set to 1 here.
+# Setting it disables Dolt server auto-start and forces port 1 in server-era
+# versions (v0.50–v0.62), which makes every create/list command fail.
+# The migration harness runs in isolated temp-dir workspaces, so there is no
+# risk of polluting a production database.  Telemetry is opt-in (needs
+# BD_OTEL_METRICS_URL) and prompts are avoided by piping </dev/null.
+export BEADS_TEST_MODE="${BEADS_TEST_MODE:-0}"
 export GIT_CONFIG_NOSYSTEM="${GIT_CONFIG_NOSYSTEM:-1}"
 
 # Timeout for bd operations (seconds). Prevents hangs from dolt server
-# startup, embedded engine locks, etc.
+# startup, embedded engine locks, etc.  Server-era versions may need the
+# full 30 s for a cold Dolt auto-start.
 BD_OP_TIMEOUT="${BD_OP_TIMEOUT:-30}"
 
 new_workspace() {

--- a/scripts/migration-test/run.sh
+++ b/scripts/migration-test/run.sh
@@ -28,7 +28,7 @@ set -uo pipefail
 #
 # Environment:
 #   CANDIDATE_BIN      Path to prebuilt candidate binary (skip build)
-#   BEADS_TEST_MODE    Set to 1 to suppress telemetry/prompts (default: 1)
+#   BEADS_TEST_MODE    Set to 1 to disable Dolt auto-start (default: 0)
 #   GIT_CONFIG_NOSYSTEM  Set to 1 to ignore system git config (default: 1)
 #   BD_OP_TIMEOUT      Timeout in seconds for bd operations (default: 30)
 #   DOWNLOAD_TIMEOUT   Timeout in seconds for binary downloads (default: 60)


### PR DESCRIPTION
## Summary

- **Root cause:** `BEADS_TEST_MODE=1` (set in `workspace.sh`) disables Dolt server auto-start and forces port 1 in server-era versions (v0.50-v0.62). Every `bd create` / `bd list` command fails because the store can't connect to any server.
- **Fix 1:** Change `BEADS_TEST_MODE` default from `1` to `0` in the migration harness. The harness runs in isolated `/tmp` workspaces so there's no risk of polluting production data.
- **Fix 2 (defense-in-depth):** Make epic creation non-fatal in `create_dataset()` — falls back to creating a plain task, so the dataset is still useful for upgrade-fidelity checks even if epic type isn't supported by a given version.

Closes #3072

## Test plan

- [ ] Run `./scripts/migration-test/run.sh v0.62.0` and verify the path is no longer BLOCKED
- [ ] Run `./scripts/migration-test/run.sh --self-test` to confirm the harness still works for the candidate
- [ ] Verify that auto-started Dolt servers are cleaned up after each test (check for stale processes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)