### PR TITLE
feat: add bd config show with unified provenance view

### DIFF
--- a/cmd/bd/config_show.go
+++ b/cmd/bd/config_show.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// configEntry represents a single configuration key with its effective value and source.
+type configEntry struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source"`
+}
+
+var configShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show all effective configuration with provenance",
+	Long: `Display a unified view of all effective configuration across all sources
+with annotations showing where each value comes from.
+
+Sources (by precedence for Viper-managed keys):
+  - env          Environment variable (BD_* or BEADS_*)
+  - config.yaml  Project config file (.beads/config.yaml)
+  - default      Built-in default value
+
+Additional sources:
+  - metadata     Connection settings from .beads/metadata.json
+  - database     Integration config stored in the Dolt database
+  - git          Git config (e.g., beads.role)
+
+Examples:
+  bd config show
+  bd config show --json
+  bd config show --source config.yaml`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		sourceFilter, _ := cmd.Flags().GetString("source")
+
+		entries := collectConfigEntries()
+
+		if sourceFilter != "" {
+			entries = filterBySource(entries, sourceFilter)
+		}
+
+		if jsonOutput {
+			outputJSON(entries)
+			return
+		}
+
+		if len(entries) == 0 {
+			fmt.Println("No configuration found")
+			return
+		}
+
+		printConfigEntries(entries)
+	},
+}
+
+func init() {
+	configShowCmd.Flags().String("source", "", "Filter by source (e.g., config.yaml, env, default, metadata, database, git)")
+	configCmd.AddCommand(configShowCmd)
+}
+
+// collectConfigEntries gathers configuration from all sources into a unified list.
+func collectConfigEntries() []configEntry {
+	var entries []configEntry
+
+	// 1. Viper-managed keys (config.yaml + defaults + env vars)
+	entries = append(entries, collectViperEntries()...)
+
+	// 2. metadata.json fields
+	entries = append(entries, collectMetadataEntries()...)
+
+	// 3. Database-stored config (best-effort)
+	entries = append(entries, collectDatabaseEntries()...)
+
+	// 4. Git config (beads.role)
+	entries = append(entries, collectGitConfigEntries()...)
+
+	// Sort by key for stable output
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Key < entries[j].Key
+	})
+
+	return entries
+}
+
+// collectViperEntries returns entries from all Viper-registered keys.
+// Skips keys with empty default values that haven't been explicitly set.
+func collectViperEntries() []configEntry {
+	var entries []configEntry
+
+	keys := config.AllKeys()
+	if keys == nil {
+		return entries
+	}
+
+	// Track which keys we've already added to avoid duplicates
+	seen := make(map[string]bool)
+
+	for _, key := range keys {
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		// Skip map-type keys that Viper flattens into individual dotted paths.
+		// These are container keys (directory.labels, external_projects, repos)
+		// whose individual sub-keys are already included.
+		if isContainerKey(key) {
+			continue
+		}
+
+		value := formatViperValue(config.GetString(key))
+		source := config.GetValueSource(key)
+
+		sourceLabel := viperSourceLabel(key, source)
+
+		// Skip empty defaults — they add noise without information
+		if source == config.SourceDefault && value == "" {
+			continue
+		}
+
+		entries = append(entries, configEntry{
+			Key:    key,
+			Value:  value,
+			Source: sourceLabel,
+		})
+	}
+
+	return entries
+}
+
+// isContainerKey returns true for keys that are map/struct containers
+// (e.g., "directory.labels", "external_projects") rather than scalar values.
+func isContainerKey(key string) bool {
+	containers := []string{"directory.labels", "external_projects", "repos"}
+	for _, c := range containers {
+		if key == c {
+			return true
+		}
+	}
+	return false
+}
+
+// formatViperValue converts a Viper value to a display string.
+func formatViperValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	return value
+}
+
+// viperSourceLabel returns a human-readable source label for a Viper key.
+func viperSourceLabel(key string, source config.ConfigSource) string {
+	switch source {
+	case config.SourceEnvVar:
+		if envName := config.EnvVarName(key); envName != "" {
+			return "env: " + envName
+		}
+		return "env"
+	case config.SourceConfigFile:
+		return "config.yaml"
+	default:
+		return "default"
+	}
+}
+
+// collectMetadataEntries reads .beads/metadata.json and returns entries for its fields.
+func collectMetadataEntries() []configEntry {
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return nil
+	}
+
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		return nil
+	}
+
+	var entries []configEntry
+
+	add := func(key, value string) {
+		if value != "" {
+			entries = append(entries, configEntry{Key: key, Value: value, Source: "metadata"})
+		}
+	}
+	addInt := func(key string, value int) {
+		if value != 0 {
+			entries = append(entries, configEntry{Key: key, Value: fmt.Sprintf("%d", value), Source: "metadata"})
+		}
+	}
+	addBool := func(key string, value bool) {
+		if value {
+			entries = append(entries, configEntry{Key: key, Value: "true", Source: "metadata"})
+		}
+	}
+
+	add("dolt_mode", cfg.DoltMode)
+	add("dolt_server_host", cfg.DoltServerHost)
+	addInt("dolt_server_port", cfg.DoltServerPort)
+	add("dolt_server_user", cfg.DoltServerUser)
+	add("dolt_database", cfg.DoltDatabase)
+	addBool("dolt_server_tls", cfg.DoltServerTLS)
+	add("dolt_data_dir", cfg.DoltDataDir)
+	addInt("dolt_remotesapi_port", cfg.DoltRemotesAPIPort)
+	add("project_id", cfg.ProjectID)
+	addInt("deletions_retention_days", cfg.DeletionsRetentionDays)
+	addInt("stale_closed_issues_days", cfg.StaleClosedIssuesDays)
+
+	return entries
+}
+
+// collectDatabaseEntries attempts to load database-stored config.
+// Returns nil if the database is unavailable (graceful degradation).
+func collectDatabaseEntries() []configEntry {
+	if err := ensureDirectMode("config show"); err != nil {
+		return nil
+	}
+
+	s := getStore()
+	if s == nil {
+		return nil
+	}
+
+	ctx := getRootContext()
+	dbConfig, err := s.GetAllConfig(ctx)
+	if err != nil {
+		return nil
+	}
+
+	var entries []configEntry
+	for key, value := range dbConfig {
+		entries = append(entries, configEntry{Key: key, Value: value, Source: "database"})
+	}
+
+	return entries
+}
+
+// collectGitConfigEntries reads beads-related values from git config.
+func collectGitConfigEntries() []configEntry {
+	var entries []configEntry
+
+	// beads.role is the only git config key currently
+	cmd := exec.Command("git", "config", "--get", "beads.role")
+	output, err := cmd.Output()
+	if err == nil {
+		value := strings.TrimSpace(string(output))
+		if value != "" {
+			entries = append(entries, configEntry{Key: "beads.role", Value: value, Source: "git"})
+		}
+	}
+
+	return entries
+}
+
+// filterBySource returns only entries matching the given source prefix.
+func filterBySource(entries []configEntry, source string) []configEntry {
+	var filtered []configEntry
+	for _, e := range entries {
+		if strings.HasPrefix(e.Source, source) {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+// printConfigEntries renders entries in human-readable format with aligned columns.
+func printConfigEntries(entries []configEntry) {
+	// Calculate alignment widths
+	maxKeyLen := 0
+	maxValueLen := 0
+	for _, e := range entries {
+		if len(e.Key) > maxKeyLen {
+			maxKeyLen = len(e.Key)
+		}
+		if len(e.Value) > maxValueLen {
+			maxValueLen = len(e.Value)
+		}
+	}
+
+	// Cap value column width to avoid absurdly wide lines
+	if maxValueLen > 60 {
+		maxValueLen = 60
+	}
+
+	for _, e := range entries {
+		displayValue := e.Value
+		if len(displayValue) > 60 {
+			displayValue = displayValue[:57] + "..."
+		}
+		fmt.Fprintf(os.Stdout, "  %-*s = %-*s  (%s)\n", maxKeyLen, e.Key, maxValueLen, displayValue, e.Source)
+	}
+}

--- a/cmd/bd/config_show_test.go
+++ b/cmd/bd/config_show_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// TestViperSourceLabel verifies source label formatting for different config sources.
+func TestViperSourceLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		source config.ConfigSource
+		want   string
+	}{
+		{
+			name:   "default source",
+			key:    "backup.enabled",
+			source: config.SourceDefault,
+			want:   "default",
+		},
+		{
+			name:   "config file source",
+			key:    "git-remote",
+			source: config.SourceConfigFile,
+			want:   "config.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := viperSourceLabel(tt.key, tt.source)
+			if got != tt.want {
+				t.Errorf("viperSourceLabel(%q, %v) = %q, want %q", tt.key, tt.source, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestViperSourceLabelEnvVar verifies env var source includes the variable name.
+func TestViperSourceLabelEnvVar(t *testing.T) {
+	t.Setenv("BD_ACTOR", "test-bot")
+
+	got := viperSourceLabel("actor", config.SourceEnvVar)
+	if got != "env: BD_ACTOR" {
+		t.Errorf("viperSourceLabel with env var = %q, want %q", got, "env: BD_ACTOR")
+	}
+}
+
+// TestIsContainerKey verifies container key detection.
+func TestIsContainerKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"directory.labels", true},
+		{"external_projects", true},
+		{"repos", true},
+		{"actor", false},
+		{"backup.enabled", false},
+		{"directory.labels.frontend", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			if got := isContainerKey(tt.key); got != tt.want {
+				t.Errorf("isContainerKey(%q) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFilterBySource verifies source filtering logic.
+func TestFilterBySource(t *testing.T) {
+	entries := []configEntry{
+		{Key: "a", Value: "1", Source: "config.yaml"},
+		{Key: "b", Value: "2", Source: "default"},
+		{Key: "c", Value: "3", Source: "database"},
+		{Key: "d", Value: "4", Source: "env: BD_ACTOR"},
+		{Key: "e", Value: "5", Source: "config.yaml"},
+		{Key: "f", Value: "6", Source: "metadata"},
+		{Key: "g", Value: "7", Source: "git"},
+	}
+
+	tests := []struct {
+		source string
+		want   int
+	}{
+		{"config.yaml", 2},
+		{"default", 1},
+		{"database", 1},
+		{"env", 1},
+		{"metadata", 1},
+		{"git", 1},
+		{"nonexistent", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			filtered := filterBySource(entries, tt.source)
+			if len(filtered) != tt.want {
+				t.Errorf("filterBySource(%q) returned %d entries, want %d", tt.source, len(filtered), tt.want)
+			}
+		})
+	}
+}
+
+// TestCollectMetadataEntries verifies metadata.json field collection.
+func TestCollectMetadataEntries(t *testing.T) {
+	// Create a temp directory with a metadata.json
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads dir: %v", err)
+	}
+
+	metadataJSON := `{
+  "database": "beads.db",
+  "dolt_mode": "embedded",
+  "project_id": "abc-123",
+  "dolt_server_port": 3307,
+  "dolt_server_tls": true
+}`
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if err := os.WriteFile(metadataPath, []byte(metadataJSON), 0600); err != nil {
+		t.Fatalf("Failed to write metadata.json: %v", err)
+	}
+
+	// Change to temp dir so FindBeadsDir can find it
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	entries := collectMetadataEntries()
+
+	// Verify expected entries exist
+	entryMap := make(map[string]configEntry)
+	for _, e := range entries {
+		entryMap[e.Key] = e
+	}
+
+	if e, ok := entryMap["dolt_mode"]; !ok {
+		t.Error("expected dolt_mode in metadata entries")
+	} else if e.Value != "embedded" {
+		t.Errorf("dolt_mode = %q, want %q", e.Value, "embedded")
+	} else if e.Source != "metadata" {
+		t.Errorf("dolt_mode source = %q, want %q", e.Source, "metadata")
+	}
+
+	if e, ok := entryMap["project_id"]; !ok {
+		t.Error("expected project_id in metadata entries")
+	} else if e.Value != "abc-123" {
+		t.Errorf("project_id = %q, want %q", e.Value, "abc-123")
+	}
+
+	if e, ok := entryMap["dolt_server_port"]; !ok {
+		t.Error("expected dolt_server_port in metadata entries")
+	} else if e.Value != "3307" {
+		t.Errorf("dolt_server_port = %q, want %q", e.Value, "3307")
+	}
+
+	if e, ok := entryMap["dolt_server_tls"]; !ok {
+		t.Error("expected dolt_server_tls in metadata entries")
+	} else if e.Value != "true" {
+		t.Errorf("dolt_server_tls = %q, want %q", e.Value, "true")
+	}
+}
+
+// TestCollectMetadataEntriesNoBeadsDir verifies graceful handling when no .beads exists.
+func TestCollectMetadataEntriesNoBeadsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	entries := collectMetadataEntries()
+	if len(entries) != 0 {
+		t.Errorf("expected no metadata entries without .beads dir, got %d", len(entries))
+	}
+}
+
+// TestCollectViperEntries verifies that Viper key collection works with initialized config.
+func TestCollectViperEntries(t *testing.T) {
+	// Create a temp dir with config.yaml
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("git-remote: \"https://example.com/repo\"\n"), 0600); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	// Re-initialize config to pick up our test config.yaml
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	config.ResetForTesting()
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize() failed: %v", err)
+	}
+	defer func() {
+		config.ResetForTesting()
+		// Re-initialize with original config
+		os.Chdir(origDir) //nolint:errcheck
+		_ = config.Initialize()
+	}()
+
+	entries := collectViperEntries()
+
+	// Check that we got some entries
+	if len(entries) == 0 {
+		t.Fatal("expected at least some Viper entries")
+	}
+
+	// Check git-remote is present with config.yaml source
+	found := false
+	for _, e := range entries {
+		if e.Key == "git-remote" {
+			found = true
+			if e.Value != "https://example.com/repo" {
+				t.Errorf("git-remote value = %q, want %q", e.Value, "https://example.com/repo")
+			}
+			if e.Source != "config.yaml" {
+				t.Errorf("git-remote source = %q, want %q", e.Source, "config.yaml")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected git-remote key in Viper entries")
+	}
+
+	// Verify defaults with non-empty values are included
+	foundDefault := false
+	for _, e := range entries {
+		if e.Source == "default" && e.Value != "" {
+			foundDefault = true
+			break
+		}
+	}
+	if !foundDefault {
+		t.Error("expected at least one default entry with a non-empty value")
+	}
+
+	// Verify empty defaults are excluded
+	for _, e := range entries {
+		if e.Source == "default" && e.Value == "" {
+			t.Errorf("empty default %q should be excluded", e.Key)
+		}
+	}
+}
+
+// TestCollectViperEntriesWithEnvOverride verifies env var source detection.
+func TestCollectViperEntriesWithEnvOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create .beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("actor: from-config\n"), 0600); err != nil {
+		t.Fatalf("Failed to write config.yaml: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	t.Setenv("BD_ACTOR", "env-bot")
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	config.ResetForTesting()
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize() failed: %v", err)
+	}
+	defer func() {
+		config.ResetForTesting()
+		os.Chdir(origDir) //nolint:errcheck
+		_ = config.Initialize()
+	}()
+
+	entries := collectViperEntries()
+
+	for _, e := range entries {
+		if e.Key == "actor" {
+			if e.Source != "env: BD_ACTOR" {
+				t.Errorf("actor source = %q, want %q", e.Source, "env: BD_ACTOR")
+			}
+			return
+		}
+	}
+	t.Error("expected actor key in Viper entries")
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -627,9 +627,13 @@ var rootCmd = &cobra.Command{
 				// - import: auto-initializes database if missing
 				// - setup: creates editor integration files (no DB needed)
 				// - config set/get for yaml-only keys: writes to config.yaml, not db (GH#536)
+				// - config show/validate: read-only diagnostics, degrade gracefully (bd-934)
 				isYamlOnlyConfigOp := false
-				if (cmd.Name() == "set" || cmd.Name() == "get") && cmd.Parent() != nil && cmd.Parent().Name() == "config" {
-					if len(args) > 0 && config.IsYamlOnlyKey(args[0]) {
+				if cmd.Parent() != nil && cmd.Parent().Name() == "config" {
+					if (cmd.Name() == "set" || cmd.Name() == "get") && len(args) > 0 && config.IsYamlOnlyKey(args[0]) {
+						isYamlOnlyConfigOp = true
+					}
+					if cmd.Name() == "show" || cmd.Name() == "validate" {
 						isYamlOnlyConfigOp = true
 					}
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -310,6 +310,21 @@ func GetValueSource(key string) ConfigSource {
 	return SourceDefault
 }
 
+// EnvVarName returns the environment variable name that would override the given
+// config key, if one is set. Returns the BD_ or BEADS_ prefixed name, or empty
+// string if no env var is set for this key.
+func EnvVarName(key string) string {
+	envKey := "BD_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
+	if _, ok := os.LookupEnv(envKey); ok {
+		return envKey
+	}
+	beadsEnvKey := "BEADS_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
+	if _, ok := os.LookupEnv(beadsEnvKey); ok {
+		return beadsEnvKey
+	}
+	return ""
+}
+
 // CheckOverrides checks for configuration overrides and returns a list of detected overrides.
 // This is useful for informing users when env vars or flags override config file values.
 // flagOverrides is a map of key -> (flagValue, flagWasSet) for flags that were explicitly set.
@@ -562,6 +577,15 @@ func AllSettings() map[string]interface{} {
 		return map[string]interface{}{}
 	}
 	return v.AllSettings()
+}
+
+// AllKeys returns all keys in the viper registry (defaults + config file + env).
+// Keys are returned in lowercase dot-notation (e.g., "federation.remote").
+func AllKeys() []string {
+	if v == nil {
+		return nil
+	}
+	return v.AllKeys()
 }
 
 // ConfigFileUsed returns the path to the config file that was loaded.


### PR DESCRIPTION
## Summary

Adds `bd config show` — a unified view of all effective configuration across all sources with provenance annotations.

Closes bd-934.

## What it does

Displays every config key, its effective value, and where it came from:

```
  git-remote      = az://stlistabead.blob.core.windows.net/dolt/beads-fork  (config.yaml)
  dolt_mode       = server                                                  (metadata)
  beads.role      = maintainer                                              (git)
  ai.model        = claude-haiku-4-5-20251001                               (default)
  issue_prefix    = bd                                                      (database)
```

**Sources tracked:**
- `config.yaml` — project YAML settings via Viper
- `metadata` — connection settings from `.beads/metadata.json`
- `database` — integration config stored in Dolt
- `env: BD_*` — environment variable overrides (shows var name)
- `git` — git config values (`beads.role`)
- `default` — built-in defaults (non-empty only)

**Flags:**
- `--json` — structured output for programmatic use
- `--source <filter>` — filter by provenance (e.g., `--source config.yaml`)

## Changes

| File | Change |
|------|--------|
| `cmd/bd/config_show.go` | New command implementation |
| `cmd/bd/config_show_test.go` | Unit tests for all helpers |
| `internal/config/config.go` | Export `AllKeys()` and `EnvVarName()` |
| `cmd/bd/main.go` | Allow `config show`/`validate` without DB |

## Design notes

- **Graceful degradation** — works without initialized database (shows yaml/metadata/env/git)
- **No mutations** — purely read-only command
- **Empty defaults suppressed** — reduces noise while still showing non-empty defaults
- **Env var provenance** — shows the actual variable name (e.g., `env: BD_ACTOR`)

## Testing

- Unit tests for source labeling, filtering, metadata collection, env override detection
- Full `go test -short ./cmd/bd/` passes
- `golangci-lint` clean