### PR TITLE
Add side-effect hints for config set/unset commands

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -86,6 +86,7 @@ var configSetCmd = &cobra.Command{
 			} else {
 				fmt.Printf("Set %s = %s (in config.yaml)\n", key, value)
 			}
+			printConfigSideEffects(checkConfigSetSideEffects(key, value))
 			return
 		}
 
@@ -146,6 +147,7 @@ var configSetCmd = &cobra.Command{
 		} else {
 			fmt.Printf("Set %s = %s\n", key, value)
 		}
+		printConfigSideEffects(checkConfigSetSideEffects(key, value))
 	},
 }
 
@@ -352,6 +354,7 @@ var configUnsetCmd = &cobra.Command{
 			} else {
 				fmt.Printf("Unset %s (in config.yaml)\n", key)
 			}
+			printConfigSideEffects(checkConfigUnsetSideEffects(key))
 			return
 		}
 
@@ -395,6 +398,7 @@ var configUnsetCmd = &cobra.Command{
 		} else {
 			fmt.Printf("Unset %s\n", key)
 		}
+		printConfigSideEffects(checkConfigUnsetSideEffects(key))
 	},
 }
 

--- a/cmd/bd/config_side_effects.go
+++ b/cmd/bd/config_side_effects.go
@@ -36,10 +36,10 @@ func checkConfigSetSideEffects(key, value string) []configSideEffect {
 		})
 
 	case key == "routing.mode":
-		validModes := map[string]bool{"maintainer": true, "contributor": true, "auto": true}
+		validModes := map[string]bool{"maintainer": true, "contributor": true, "auto": true, "explicit": true}
 		if !validModes[value] {
 			effects = append(effects, configSideEffect{
-				Message: fmt.Sprintf("Unknown routing mode %q. Valid values: maintainer, contributor, auto", value),
+				Message: fmt.Sprintf("Unknown routing mode %q. Valid values: auto, maintainer, contributor, explicit", value),
 			})
 		}
 

--- a/cmd/bd/config_side_effects.go
+++ b/cmd/bd/config_side_effects.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// configSideEffect describes a hint or warning to show after a config change.
+type configSideEffect struct {
+	Message string `json:"message"`
+	Command string `json:"command,omitempty"` // suggested command to run
+}
+
+// checkConfigSetSideEffects returns any hints/warnings for a config key being set.
+func checkConfigSetSideEffects(key, value string) []configSideEffect {
+	var effects []configSideEffect
+
+	switch {
+	case key == "federation.remote":
+		effects = append(effects, configSideEffect{
+			Message: fmt.Sprintf("To activate, ensure a Dolt remote matches this URL: %s", value),
+			Command: fmt.Sprintf("bd dolt remote add origin %s", value),
+		})
+
+	case key == "dolt.shared-server" && strings.EqualFold(value, "true"):
+		effects = append(effects, configSideEffect{
+			Message: "Shared server mode enabled. Start the server to activate.",
+			Command: "bd dolt server start",
+		})
+
+	case key == "dolt.shared-server" && !strings.EqualFold(value, "true"):
+		effects = append(effects, configSideEffect{
+			Message: "Shared server mode disabled. Stop any running server if no longer needed.",
+			Command: "bd dolt server stop",
+		})
+
+	case key == "routing.mode":
+		validModes := map[string]bool{"maintainer": true, "contributor": true, "auto": true}
+		if !validModes[value] {
+			effects = append(effects, configSideEffect{
+				Message: fmt.Sprintf("Unknown routing mode %q. Valid values: maintainer, contributor, auto", value),
+			})
+		}
+
+	case key == "backup.enabled" && strings.EqualFold(value, "true"):
+		effects = append(effects, configSideEffect{
+			Message: "Backups enabled. Backups run automatically on issue writes.",
+		})
+
+	case key == "sync.git-remote":
+		effects = append(effects, configSideEffect{
+			Message: fmt.Sprintf("Git sync remote set to %q. Ensure this git remote exists.", value),
+			Command: fmt.Sprintf("git remote -v | grep %s", value),
+		})
+	}
+
+	return effects
+}
+
+// checkConfigUnsetSideEffects returns any hints/warnings for a config key being unset.
+func checkConfigUnsetSideEffects(key string) []configSideEffect {
+	var effects []configSideEffect
+
+	switch key {
+	case "federation.remote":
+		effects = append(effects, configSideEffect{
+			Message: "Federation remote removed from config. The Dolt remote still exists and can be removed manually.",
+			Command: "bd dolt remote remove origin",
+		})
+
+	case "dolt.shared-server":
+		effects = append(effects, configSideEffect{
+			Message: "Shared server config removed. Stop any running server if no longer needed.",
+			Command: "bd dolt server stop",
+		})
+
+	case "backup.enabled":
+		effects = append(effects, configSideEffect{
+			Message: "Backup config removed. Automatic backups will no longer run.",
+		})
+	}
+
+	return effects
+}
+
+// printConfigSideEffects displays side-effect hints to stderr (so they don't
+// interfere with --json stdout output).
+func printConfigSideEffects(effects []configSideEffect) {
+	if len(effects) == 0 {
+		return
+	}
+
+	for _, e := range effects {
+		fmt.Fprintf(os.Stderr, "\nHint: %s\n", e.Message)
+		if e.Command != "" {
+			fmt.Fprintf(os.Stderr, "  → %s\n", e.Command)
+		}
+	}
+}

--- a/cmd/bd/config_side_effects_test.go
+++ b/cmd/bd/config_side_effects_test.go
@@ -46,9 +46,11 @@ func TestCheckConfigSetSideEffects_RoutingModeInvalid(t *testing.T) {
 }
 
 func TestCheckConfigSetSideEffects_RoutingModeValid(t *testing.T) {
-	effects := checkConfigSetSideEffects("routing.mode", "maintainer")
-	if len(effects) != 0 {
-		t.Errorf("expected 0 effects for valid routing mode, got %d", len(effects))
+	for _, mode := range []string{"auto", "maintainer", "contributor", "explicit"} {
+		effects := checkConfigSetSideEffects("routing.mode", mode)
+		if len(effects) != 0 {
+			t.Errorf("expected 0 effects for valid routing mode %q, got %d", mode, len(effects))
+		}
 	}
 }
 
@@ -107,8 +109,9 @@ func TestCheckConfigUnsetSideEffects_UnknownKey(t *testing.T) {
 func TestPrintConfigSideEffects(t *testing.T) {
 	// Redirect stderr to avoid test noise
 	old := os.Stderr
-	os.Stderr, _ = os.Open(os.DevNull)
-	defer func() { os.Stderr = old }()
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	defer func() { w.Close(); r.Close(); os.Stderr = old }()
 
 	// Should not panic with empty, single, or multiple effects
 	printConfigSideEffects(nil)

--- a/cmd/bd/config_side_effects_test.go
+++ b/cmd/bd/config_side_effects_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCheckConfigSetSideEffects_FederationRemote(t *testing.T) {
+	effects := checkConfigSetSideEffects("federation.remote", "dolthub://org/proj")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+	if effects[0].Command == "" {
+		t.Error("expected a suggested command")
+	}
+}
+
+func TestCheckConfigSetSideEffects_SharedServerTrue(t *testing.T) {
+	effects := checkConfigSetSideEffects("dolt.shared-server", "true")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+	if effects[0].Command != "bd dolt server start" {
+		t.Errorf("expected 'bd dolt server start', got %q", effects[0].Command)
+	}
+}
+
+func TestCheckConfigSetSideEffects_SharedServerFalse(t *testing.T) {
+	effects := checkConfigSetSideEffects("dolt.shared-server", "false")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+	if effects[0].Command != "bd dolt server stop" {
+		t.Errorf("expected 'bd dolt server stop', got %q", effects[0].Command)
+	}
+}
+
+func TestCheckConfigSetSideEffects_RoutingModeInvalid(t *testing.T) {
+	effects := checkConfigSetSideEffects("routing.mode", "bogus")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+	if effects[0].Command != "" {
+		t.Error("invalid routing mode should not suggest a command")
+	}
+}
+
+func TestCheckConfigSetSideEffects_RoutingModeValid(t *testing.T) {
+	effects := checkConfigSetSideEffects("routing.mode", "maintainer")
+	if len(effects) != 0 {
+		t.Errorf("expected 0 effects for valid routing mode, got %d", len(effects))
+	}
+}
+
+func TestCheckConfigSetSideEffects_BackupEnabled(t *testing.T) {
+	effects := checkConfigSetSideEffects("backup.enabled", "true")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+}
+
+func TestCheckConfigSetSideEffects_SyncGitRemote(t *testing.T) {
+	effects := checkConfigSetSideEffects("sync.git-remote", "origin")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+}
+
+func TestCheckConfigSetSideEffects_UnknownKey(t *testing.T) {
+	effects := checkConfigSetSideEffects("some.random.key", "value")
+	if len(effects) != 0 {
+		t.Errorf("expected 0 effects for unknown key, got %d", len(effects))
+	}
+}
+
+func TestCheckConfigUnsetSideEffects_FederationRemote(t *testing.T) {
+	effects := checkConfigUnsetSideEffects("federation.remote")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+	if effects[0].Command != "bd dolt remote remove origin" {
+		t.Errorf("expected 'bd dolt remote remove origin', got %q", effects[0].Command)
+	}
+}
+
+func TestCheckConfigUnsetSideEffects_SharedServer(t *testing.T) {
+	effects := checkConfigUnsetSideEffects("dolt.shared-server")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+}
+
+func TestCheckConfigUnsetSideEffects_BackupEnabled(t *testing.T) {
+	effects := checkConfigUnsetSideEffects("backup.enabled")
+	if len(effects) != 1 {
+		t.Fatalf("expected 1 effect, got %d", len(effects))
+	}
+}
+
+func TestCheckConfigUnsetSideEffects_UnknownKey(t *testing.T) {
+	effects := checkConfigUnsetSideEffects("some.random.key")
+	if len(effects) != 0 {
+		t.Errorf("expected 0 effects for unknown key, got %d", len(effects))
+	}
+}
+
+func TestPrintConfigSideEffects(t *testing.T) {
+	// Redirect stderr to avoid test noise
+	old := os.Stderr
+	os.Stderr, _ = os.Open(os.DevNull)
+	defer func() { os.Stderr = old }()
+
+	// Should not panic with empty, single, or multiple effects
+	printConfigSideEffects(nil)
+	printConfigSideEffects([]configSideEffect{})
+	printConfigSideEffects([]configSideEffect{
+		{Message: "test hint", Command: "bd test"},
+	})
+	printConfigSideEffects([]configSideEffect{
+		{Message: "no command hint"},
+		{Message: "with command", Command: "bd apply"},
+	})
+}


### PR DESCRIPTION
## Summary

Implements **bd-9qv**: when `bd config set` or `bd config unset` changes a key with system-level side effects, print actionable hints to help users activate the change.

## Problem

Setting config like `bd config set federation.remote "dolthub://org/proj"` updates the config file but doesn't actually add the Dolt remote. Users have to know to run a separate command. This closes that gap.

## Solution

After a successful set/unset, check if the key has known side effects and print a hint to stderr:

```
$ bd config set federation.remote "dolthub://org/proj"
Set federation.remote = dolthub://org/proj (in config.yaml)

Hint: To activate, ensure a Dolt remote matches this URL: dolthub://org/proj
  → bd dolt remote add origin dolthub://org/proj
```

```
$ bd config unset federation.remote
Unset federation.remote (in config.yaml)

Hint: Federation remote removed from config. The Dolt remote still exists and can be removed manually.
  → bd dolt remote remove origin
```

## Covered Keys

| Key | Set hint | Unset hint |
|-----|----------|------------|
| `federation.remote` | Suggest adding Dolt remote | Warn about orphaned remote |
| `dolt.shared-server` | Suggest starting/stopping server | Suggest stopping server |
| `routing.mode` | Warn on invalid values | — |
| `backup.enabled` | Note about automatic backups | Note backups disabled |
| `sync.git-remote` | Suggest verifying git remote | — |

## Design

- Hints go to **stderr** so they don't interfere with `--json` stdout
- Each key handler is a small, independently testable function
- Non-blocking: hints are informational, never prevent the set/unset from succeeding
- Extensible: new keys can be added with a simple case in the switch

## Testing

- 13 unit tests covering all key handlers and edge cases
- Full `cmd/bd` test suite passes (190s)
- `golangci-lint` + `gofmt` clean

Closes bd-9qv