### PR TITLE
fix: bd update --type honors custom types (fixes #3030)

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/audit"
-	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/timeparsing"
 	"github.com/steveyegge/beads/internal/types"
@@ -138,32 +137,10 @@ create, update, show, or close operation).`,
 		}
 		if cmd.Flags().Changed("type") {
 			issueType, _ := cmd.Flags().GetString("type")
-			// Normalize aliases (e.g., "enhancement" -> "feature") before validating
+			// Normalize aliases (e.g., "enhancement" -> "feature") before validating.
+			// Type validation (including custom types) is handled by the storage
+			// layer inside the transaction, matching the create path. (GH#3030)
 			issueType = utils.NormalizeIssueType(issueType)
-			var customTypes []string
-			if store != nil {
-				ct, err := store.GetCustomTypes(cmd.Context())
-				if err != nil {
-					// Log DB error but continue with YAML fallback (GH#1499 bd-2ll)
-					if !jsonOutput {
-						fmt.Fprintf(os.Stderr, "%s Failed to get custom types from DB: %v (falling back to config.yaml)\n",
-							ui.RenderWarn("!"), err)
-					}
-				} else {
-					customTypes = ct
-				}
-			}
-			// Fallback to config.yaml when store returns no custom types.
-			if len(customTypes) == 0 {
-				customTypes = config.GetCustomTypesFromYAML()
-			}
-			if !types.IssueType(issueType).IsValidWithCustom(customTypes) {
-				validTypes := "bug, feature, task, epic, chore, decision"
-				if len(customTypes) > 0 {
-					validTypes += ", " + joinStrings(customTypes, ", ")
-				}
-				FatalErrorRespectJSON("invalid issue type %q. Valid types: %s", issueType, validTypes)
-			}
 			updates["issue_type"] = issueType
 		}
 		if cmd.Flags().Changed("add-label") {

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -185,6 +185,35 @@ func TestEmbeddedUpdate(t *testing.T) {
 		}
 	})
 
+	t.Run("update_type_custom", func(t *testing.T) {
+		// Register "agent" as a custom type via bd config (GH#3030).
+		// This writes to Dolt only, NOT to .beads/config.yaml.
+		cfgCmd := exec.Command(bd, "config", "set", "types.custom", "agent,spike")
+		cfgCmd.Dir = dir
+		cfgCmd.Env = bdEnv(dir)
+		if out, err := cfgCmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd config set types.custom failed: %v\n%s", err, out)
+		}
+
+		issue := bdCreate(t, bd, dir, "Custom type update", "--type", "task")
+		// Before the fix (GH#3030), this would fail with "invalid issue type"
+		// because the CLI-level validation could not read custom types from Dolt.
+		bdUpdate(t, bd, dir, issue.ID, "--type", "agent")
+		got := bdShow(t, bd, dir, issue.ID)
+		if string(got.IssueType) != "agent" {
+			t.Errorf("expected type agent, got %s", got.IssueType)
+		}
+	})
+
+	t.Run("update_type_invalid_rejected", func(t *testing.T) {
+		// Verify that truly invalid types are still rejected by the storage layer.
+		issue := bdCreate(t, bd, dir, "Invalid type test", "--type", "task")
+		out := bdUpdateFail(t, bd, dir, issue.ID, "--type", "banana")
+		if !strings.Contains(out, "invalid issue type") {
+			t.Errorf("expected 'invalid issue type' error, got: %s", out)
+		}
+	})
+
 	t.Run("update_design", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Design test", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--design", "Design notes here")

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -107,6 +107,22 @@ func UpdateIssueInTx(ctx context.Context, tx *sql.Tx, id string, updates map[str
 		return nil, fmt.Errorf("failed to get issue for update: %w", err)
 	}
 
+	// Validate issue_type against built-in + custom types (GH#3030).
+	// This mirrors the create path (PrepareIssueForInsert → ValidateWithCustom)
+	// and reads custom types from the same transaction, so it works reliably
+	// even in subprocess contexts where the CLI-level store may be unavailable.
+	if rawType, ok := updates["issue_type"]; ok {
+		if issueType, ok := rawType.(string); ok {
+			customTypes, err := ResolveCustomTypesInTx(ctx, tx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get custom types for validation: %w", err)
+			}
+			if !types.IssueType(issueType).IsValidWithCustom(customTypes) {
+				return nil, fmt.Errorf("invalid issue type: %s", issueType)
+			}
+		}
+	}
+
 	// Build SET clauses.
 	setClauses := []string{"updated_at = ?"}
 	args := []interface{}{time.Now().UTC()}


### PR DESCRIPTION
## Summary

- **Removed flaky CLI-level type validation** from `cmd/bd/update.go` (lines 139-168) that rejected custom types like `agent` when `GetCustomTypes()` was unavailable (subprocess context, circuit breaker) and `.beads/config.yaml` lacked `types.custom` (because `bd config set` only writes to Dolt, not YAML)
- **Added type validation in the storage layer** (`internal/storage/issueops/update.go` `UpdateIssueInTx`) that reads custom types within the same transaction via `ResolveCustomTypesInTx`, matching the reliable pattern used by `bd create` (`PrepareIssueForInsert` → `ValidateWithCustom`)
- **Added tests** for both the positive case (custom type accepted) and negative case (invalid type still rejected)

## Root Cause

`bd create --type=agent` worked because `create` has NO CLI-level type validation — it delegates entirely to the storage layer's `PrepareIssueForInsert()` → `ValidateWithCustom()`, which reads custom types from the database inside the transaction.

`bd update --type=agent` failed because `update.go` performed CLI-level type validation that depended on `store.GetCustomTypes()` succeeding (which fails in subprocess contexts, circuit breaker open, etc.) and then fell back to `config.GetCustomTypesFromYAML()` (which returns nothing because `bd config set` writes to Dolt, not YAML). With no custom types found, validation rejected anything that wasn't a built-in type.

The fix aligns `update` with `create` by moving type validation to `UpdateIssueInTx` in the storage layer, where it reads custom types within the same database transaction.

## Test plan

- [x] `go build ./cmd/bd` — builds clean
- [x] `go vet ./cmd/bd/... ./internal/storage/issueops/...` — no issues
- [x] `go test ./internal/storage/issueops/...` — passes
- [x] `go test ./internal/types/...` — passes
- [x] Added `update_type_custom` test: sets custom type config, creates task, updates to `agent`, verifies success
- [x] Added `update_type_invalid_rejected` test: verifies `--type=banana` is still rejected by the storage layer
- [ ] CI: embedded dolt integration tests (`BEADS_TEST_EMBEDDED_DOLT=1`)

Fixes #3030

🤖 Generated with [Claude Code](https://claude.com/claude-code)