### PR TITLE
fix(docs): repair broken links failing Deploy Documentation CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -56,6 +56,7 @@ jobs:
             --timeout 30
             --root-dir website/build
             --exclude-path 'website/build/search/**'
+            --remap '/beads/(.*) /$1'
             website/build
           fail: true
 

--- a/website/docs/architecture/index.md
+++ b/website/docs/architecture/index.md
@@ -14,7 +14,7 @@ Beads uses **Dolt** as its sole storage backend -- a version-controlled SQL data
 
 By default, Dolt runs in **embedded mode** (in-process, no separate server). For multi-writer
 setups (multiple agents, orchestrator), switch to **server mode** which connects to a
-running `dolt sql-server`. See [DOLT.md](/docs/DOLT.md) for details.
+running `dolt sql-server`. See the [Dolt Server Mode](#dolt-server-mode) section below for details.
 
 ```mermaid
 flowchart TD

--- a/website/docs/core-concepts/index.md
+++ b/website/docs/core-concepts/index.md
@@ -71,6 +71,6 @@ Declarative workflow templates:
 ## Navigation
 
 - [Issues & Dependencies](/core-concepts/issues)
-- [Dolt Server Mode](/core-concepts/dolt-server)
-- [Dolt Sync](/core-concepts/dolt-sync)
+- [Dolt Server Mode](#dolt-server-mode)
+- [Dolt Sync](#dolt-sync)
 - [Hash-based IDs](/core-concepts/hash-ids)

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -65,7 +65,7 @@ bd config set issue_id_mode hash
 | `counter` | `bd-1` | Single-writer, project-management UIs |
 
 Counter IDs are sequential and human-friendly. Hash IDs are collision-free across concurrent
-branches. See [docs/CONFIG.md](/docs/CONFIG.md) for migration guidance and full details.
+branches. See [CONFIG.md](https://github.com/gastownhall/beads/blob/main/docs/CONFIG.md) for migration guidance and full details.
 
 ### Import
 

--- a/website/versioned_docs/version-1.0.0/architecture/index.md
+++ b/website/versioned_docs/version-1.0.0/architecture/index.md
@@ -14,7 +14,7 @@ Beads uses **Dolt** as its sole storage backend -- a version-controlled SQL data
 
 By default, Dolt runs in **embedded mode** (in-process, no separate server). For multi-writer
 setups (multiple agents, orchestrator), switch to **server mode** which connects to a
-running `dolt sql-server`. See [DOLT.md](/docs/DOLT.md) for details.
+running `dolt sql-server`. See the [Dolt Server Mode](#dolt-server-mode) section below for details.
 
 ```mermaid
 flowchart TD

--- a/website/versioned_docs/version-1.0.0/core-concepts/index.md
+++ b/website/versioned_docs/version-1.0.0/core-concepts/index.md
@@ -71,6 +71,6 @@ Declarative workflow templates:
 ## Navigation
 
 - [Issues & Dependencies](/core-concepts/issues)
-- [Dolt Server Mode](/core-concepts/dolt-server)
-- [Dolt Sync](/core-concepts/dolt-sync)
+- [Dolt Server Mode](#dolt-server-mode)
+- [Dolt Sync](#dolt-sync)
 - [Hash-based IDs](/core-concepts/hash-ids)

--- a/website/versioned_docs/version-1.0.0/reference/configuration.md
+++ b/website/versioned_docs/version-1.0.0/reference/configuration.md
@@ -65,7 +65,7 @@ bd config set issue_id_mode hash
 | `counter` | `bd-1` | Single-writer, project-management UIs |
 
 Counter IDs are sequential and human-friendly. Hash IDs are collision-free across concurrent
-branches. See [docs/CONFIG.md](/docs/CONFIG.md) for migration guidance and full details.
+branches. See [CONFIG.md](https://github.com/gastownhall/beads/blob/main/docs/CONFIG.md) for migration guidance and full details.
 
 ### Import
 


### PR DESCRIPTION
## Problem

The **Deploy Documentation** workflow is failing on every push to main. Two root causes:

### 1. Broken Docusaurus links (4 links → 6 files)
Pages link to targets that don't exist:
- `/docs/DOLT.md` and `/docs/CONFIG.md` — repo-level files, not Docusaurus pages
- `/core-concepts/dolt-server` and `/core-concepts/dolt-sync` — pages that were never created

### 2. Lychee link checker vs `baseUrl: /beads/`
All internal navigation links use the `/beads/` prefix (required for GitHub Pages), but lychee resolves them against `website/build/` which doesn't have a `beads/` subdirectory — causing every single internal link to fail.

## Fix

- **architecture/index.md**: `/docs/DOLT.md` → `#dolt-server-mode` anchor (content already on-page)
- **core-concepts/index.md**: `/core-concepts/dolt-server` and `/dolt-sync` → same-page anchor links
- **reference/configuration.md**: `/docs/CONFIG.md` → GitHub source URL
- **versioned_docs/version-1.0.0**: same fixes applied
- **deploy-docs.yml**: added `--remap '/beads/(.*) /$1'` to strip baseUrl prefix for lychee resolution

## Testing

All broken link patterns eliminated:
```
grep -rn 'docs/DOLT.md\|docs/CONFIG.md\|core-concepts/dolt-server\|core-concepts/dolt-sync' website/docs/ website/versioned_docs/
# (no output)
```