### PR TITLE
fix: explicitly disable TLS in Dolt connections when not configured

### DIFF
--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -48,6 +48,7 @@ func openDoltDB(beadsDir string) (*sql.DB, *configfile.Config, error) {
 		User:     user,
 		Password: password,
 		Database: database,
+		TLS:      cfg.GetDoltServerTLS(),
 	}.String()
 
 	db, err := sql.Open("mysql", connStr)

--- a/cmd/bd/doctor/fix/remotes.go
+++ b/cmd/bd/doctor/fix/remotes.go
@@ -98,6 +98,7 @@ func openFixDB(beadsDir string, cfg *configfile.Config) (*sql.DB, error) {
 		User:     user,
 		Password: password,
 		Database: database,
+		TLS:      cfg.GetDoltServerTLS(),
 	}.String()
 	return sql.Open("mysql", connStr)
 }

--- a/cmd/bd/doctor/fresh_clone_server.go
+++ b/cmd/bd/doctor/fresh_clone_server.go
@@ -24,12 +24,13 @@ type freshCloneDBCheck struct {
 // whether the named database exists via SHOW DATABASES. The connection is
 // closed before returning. Returns Reachable=false when the server cannot be
 // reached, so the caller can skip the server-mode check (FR-030).
-func checkFreshCloneDB(host string, port int, user, password, dbName string) freshCloneDBCheck {
+func checkFreshCloneDB(host string, port int, user, password, dbName string, tls bool) freshCloneDBCheck {
 	dsn := doltutil.ServerDSN{
 		Host:     host,
 		Port:     port,
 		User:     user,
 		Password: password,
+		TLS:      tls,
 	}.String()
 
 	db, err := sql.Open("mysql", dsn)

--- a/cmd/bd/doctor/fresh_clone_server_test.go
+++ b/cmd/bd/doctor/fresh_clone_server_test.go
@@ -103,7 +103,7 @@ func TestFreshCloneServerResult(t *testing.T) {
 func TestCheckFreshCloneDB_ServerUnreachable(t *testing.T) {
 	// FR-030: When server is unreachable, should return Reachable=false
 	// so caller skips the server-mode check without panic.
-	result := checkFreshCloneDB("127.0.0.1", 1, "root", "", "nonexistent_db")
+	result := checkFreshCloneDB("127.0.0.1", 1, "root", "", "nonexistent_db", false)
 	if result.Reachable {
 		t.Fatal("expected Reachable=false for connection refused")
 	}

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -312,7 +312,7 @@ func CheckFreshClone(repoPath string) DoctorCheck {
 			user := cfg.GetDoltServerUser()
 			password := cfg.GetDoltServerPassword()
 			dbName := cfg.GetDoltDatabase()
-			result := checkFreshCloneDB(host, port, user, password, dbName)
+			result := checkFreshCloneDB(host, port, user, password, dbName, cfg.GetDoltServerTLS())
 			if result.Reachable {
 				syncGitRemote := config.GetStringFromDir(beadsDir, "sync.git-remote")
 				return freshCloneServerResult(result.Exists, dbName, host, port, syncGitRemote)

--- a/cmd/bd/doctor/perf_dolt.go
+++ b/cmd/bd/doctor/perf_dolt.go
@@ -109,8 +109,10 @@ func runDoltServerDiagnostics(metrics *DoltPerfMetrics, host string, port int, d
 	// Resolve credentials from config and environment, matching openDoltDB behavior.
 	user := configfile.DefaultDoltServerUser
 	password := os.Getenv("BEADS_DOLT_PASSWORD")
+	var tls bool
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
 		user = cfg.GetDoltServerUser()
+		tls = cfg.GetDoltServerTLS()
 	}
 
 	dsn := doltutil.ServerDSN{
@@ -119,6 +121,7 @@ func runDoltServerDiagnostics(metrics *DoltPerfMetrics, host string, port int, d
 		User:     user,
 		Password: password,
 		Database: dbName,
+		TLS:      tls,
 	}.String()
 
 	// Measure connection time

--- a/cmd/bd/doctor/server.go
+++ b/cmd/bd/doctor/server.go
@@ -301,6 +301,7 @@ func checkDoltVersion(cfg *configfile.Config, beadsDir string) (DoctorCheck, *sq
 		Port:     port,
 		User:     user,
 		Password: password,
+		TLS:      cfg.GetDoltServerTLS(),
 	}.String()
 
 	db, err := sql.Open("mysql", connStr)

--- a/cmd/bd/doctor_health.go
+++ b/cmd/bd/doctor_health.go
@@ -60,6 +60,7 @@ func runCheckHealth(path string) {
 		User:     cfg.GetDoltServerUser(),
 		Database: database,
 		Timeout:  2 * time.Second,
+		TLS:      cfg.GetDoltServerTLS(),
 	}.String()
 	db, err := sql.Open("mysql", dsn)
 	if err == nil {

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1482,6 +1482,7 @@ func openDoltServerConnection() (*sql.DB, func()) {
 		Port:     port,
 		User:     user,
 		Password: password,
+		TLS:      cfg.GetDoltServerTLS(),
 	}.String()
 
 	db, err := sql.Open("mysql", connStr)

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1277,7 +1277,7 @@ Aborting.`, ui.RenderWarn("⚠"), location, ui.RenderAccent("bd list"), prefix)
 				password := cfg.GetDoltServerPassword()
 				user := cfg.GetDoltServerUser()
 
-				result := checkDatabaseOnServer(host, port, user, password, dbName)
+				result := checkDatabaseOnServer(host, port, user, password, dbName, cfg.GetDoltServerTLS())
 				if result.Reachable && !result.Exists && result.Err == nil {
 					// Server is up but DB doesn't exist. Since we also know
 					// doltDirExists==false, this is a fresh clone — there's no

--- a/cmd/bd/init_guard.go
+++ b/cmd/bd/init_guard.go
@@ -28,12 +28,13 @@ type initGuardDBCheck struct {
 //
 // Returns Reachable=false when the server cannot be reached (FR-030), so the
 // caller can fall through to existing "already initialized" behavior.
-func checkDatabaseOnServer(host string, port int, user, password, dbName string) initGuardDBCheck {
+func checkDatabaseOnServer(host string, port int, user, password, dbName string, tls bool) initGuardDBCheck {
 	dsn := doltutil.ServerDSN{
 		Host:     host,
 		Port:     port,
 		User:     user,
 		Password: password,
+		TLS:      tls,
 	}.String()
 
 	db, err := sql.Open("mysql", dsn)

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -131,7 +131,7 @@ func TestInitGuardDBCheck_ServerUnreachable(t *testing.T) {
 	// FR-030: When server is unreachable, should return Reachable=false
 	// so caller falls through to existing error path without panic.
 
-	result := checkDatabaseOnServer("127.0.0.1", 1, "root", "", "nonexistent_db")
+	result := checkDatabaseOnServer("127.0.0.1", 1, "root", "", "nonexistent_db", false)
 	if result.Reachable {
 		t.Fatal("expected Reachable=false for connection refused")
 	}

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -40,6 +40,12 @@ func (d ServerDSN) String() string {
 	}
 	if d.TLS {
 		cfg.TLSConfig = "true"
+	} else {
+		// go-sql-driver/mysql v1.8+ defaults to tls=preferred when TLSConfig
+		// is empty. Dolt servers without TLS reject preferred-mode negotiation
+		// with "TLS requested but server does not support TLS". Explicitly
+		// disable TLS so connections work against non-TLS Dolt instances.
+		cfg.TLSConfig = "false"
 	}
 
 	return cfg.FormatDSN()

--- a/internal/storage/doltutil/dsn_test.go
+++ b/internal/storage/doltutil/dsn_test.go
@@ -1,0 +1,38 @@
+package doltutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestServerDSN_TLSExplicitlyDisabledByDefault(t *testing.T) {
+	dsn := ServerDSN{
+		Host: "dolt.example.com",
+		Port: 3307,
+		User: "root",
+	}.String()
+
+	// go-sql-driver/mysql v1.8+ defaults to tls=preferred when TLSConfig
+	// is empty. Dolt servers without TLS reject this, so we must explicitly
+	// disable TLS when not requested. The formatted DSN should contain
+	// tls=false (or the equivalent).
+	if !strings.Contains(dsn, "tls=false") {
+		t.Errorf("DSN should contain tls=false when TLS is not enabled; got %q", dsn)
+	}
+}
+
+func TestServerDSN_TLSEnabledWhenRequested(t *testing.T) {
+	dsn := ServerDSN{
+		Host: "hosted.doltdb.com",
+		Port: 3307,
+		User: "myuser",
+		TLS:  true,
+	}.String()
+
+	if !strings.Contains(dsn, "tls=true") {
+		t.Errorf("DSN should contain tls=true when TLS is enabled; got %q", dsn)
+	}
+	if strings.Contains(dsn, "tls=false") {
+		t.Errorf("DSN should not contain tls=false when TLS is enabled; got %q", dsn)
+	}
+}


### PR DESCRIPTION
## Summary

- `go-sql-driver/mysql` v1.8+ changed the default TLS mode from `false` to `preferred`, causing all Dolt connections to attempt TLS negotiation
- Dolt servers without TLS configured reject this with "TLS requested but server does not support TLS" instead of gracefully declining (unlike standard MySQL which just doesn't advertise TLS capability)
- `ServerDSN.String()` now explicitly sets `tls=false` when `TLS` is not enabled, making the default behavior explicit rather than relying on the driver's implicit default
- All `ServerDSN` call sites (init guard, doctor checks, health checks, diagnostics, perf) now plumb the TLS flag from config so that Hosted Dolt users with `BEADS_DOLT_SERVER_TLS=1` get TLS on every code path

## Affected code paths

| Call site | Had TLS? | Fix |
|-----------|----------|-----|
| `doltutil.ServerDSN.String()` | Only set on true | Added explicit `tls=false` else branch |
| `store.go` `buildServerDSN()` | Yes (via `cfg.ServerTLS`) | No change needed |
| `bootstrap.go` | Yes (via `probeCfg.tls`) | No change needed |
| `init_guard.go` | No | Added `tls bool` param, plumbed from config |
| `doctor_health.go` | No | Added `cfg.GetDoltServerTLS()` |
| `dolt.go` | No | Added `cfg.GetDoltServerTLS()` |
| `doctor/server.go` | No | Added `cfg.GetDoltServerTLS()` |
| `doctor/dolt.go` | No | Added `cfg.GetDoltServerTLS()` |
| `doctor/perf_dolt.go` | No | Added `cfg.GetDoltServerTLS()` |
| `doctor/fresh_clone_server.go` | No | Added `tls bool` param, plumbed from config |
| `doctor/fix/remotes.go` | No | Added `cfg.GetDoltServerTLS()` |