### PR TITLE
fix: reject empty database name in embeddeddolt.New

### DIFF
--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -779,6 +779,53 @@ func TestEmbeddedCreateCrossRepoWithParent(t *testing.T) {
 	assertDepExists(t, targetBeadsDir, "tgt", child.ID, parent.ID)
 }
 
+// TestEmbeddedCreateCrossRepoUninit verifies that bd create --repo works when
+// the target directory has NOT been initialized with bd init. This is a
+// regression test for be-sy8 / GH#2988: newDoltStoreFromConfig used to pass
+// an empty database name to the embedded Dolt engine, causing "no database
+// selected" during schema init.
+func TestEmbeddedCreateCrossRepoUninit(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// Set up primary repo (source — initialized)
+	dir, _, _ := bdInit(t, bd, "--prefix", "src")
+
+	// Set up target repo WITHOUT bd init — just a bare git repo
+	targetDir := filepath.Join(dir, "uninit-target")
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, targetDir)
+
+	// This should succeed: ensureBeadsDirForPath creates .beads,
+	// and newDoltStoreFromConfig defaults to database "beads".
+	issue := bdCreate(t, bd, dir, "Issue in uninit target", "--repo", targetDir)
+	if issue.ID == "" {
+		t.Fatal("expected issue ID")
+	}
+
+	// Verify issue exists in the target store
+	targetBeadsDir := filepath.Join(targetDir, ".beads")
+	tgtStore, err := newDoltStoreFromConfig(t.Context(), targetBeadsDir)
+	if err != nil {
+		t.Fatalf("failed to open target store: %v", err)
+	}
+	defer tgtStore.Close()
+
+	got, err := tgtStore.GetIssue(t.Context(), issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssue in target: %v", err)
+	}
+	if got.Title != "Issue in uninit target" {
+		t.Errorf("title: got %q, want %q", got.Title, "Issue in uninit target")
+	}
+}
+
 // TestEmbeddedCreateWithGitRemote verifies bd create works end-to-end when a
 // git remote exists (which enables auto-backup in PersistentPostRun). This
 // catches panics from unimplemented methods called after the create succeeds.

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -41,7 +41,8 @@ func (r *RoutedResult) Close() {
 }
 
 // resolveAndGetIssueWithRouting resolves a partial ID and gets the issue.
-// Tries the local store first, then falls back to contributor auto-routing.
+// Tries the local store first, then prefix-based routing via routes.jsonl,
+// then falls back to contributor auto-routing.
 //
 // Returns a RoutedResult containing the issue, resolved ID, and the store to use.
 // The caller MUST call result.Close() when done to release any routed storage.
@@ -52,8 +53,13 @@ func resolveAndGetIssueWithRouting(ctx context.Context, localStore storage.DoltS
 		return result, nil
 	}
 
-	// If not found locally, try contributor auto-routing as fallback (GH#2345).
 	if isNotFoundErr(err) {
+		// Try prefix-based routing via routes.jsonl (cross-rig lookups).
+		if prefixResult, prefixErr := resolveViaPrefixRouting(ctx, id); prefixErr == nil {
+			return prefixResult, nil
+		}
+
+		// Fall back to contributor auto-routing (GH#2345).
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil
 		}
@@ -103,7 +109,7 @@ func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, 
 }
 
 // getIssueWithRouting gets an issue by exact ID.
-// Tries the local store first, then falls back to contributor auto-routing.
+// Tries the local store first, then prefix routing, then contributor auto-routing.
 //
 // Returns a RoutedResult containing the issue and the store to use for related queries.
 // The caller MUST call result.Close() when done to release any routed storage.
@@ -119,8 +125,13 @@ func getIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id
 		}, nil
 	}
 
-	// If not found locally, try contributor auto-routing as fallback (GH#2345).
 	if isNotFoundErr(err) {
+		// Try prefix-based routing via routes.jsonl (cross-rig lookups).
+		if prefixResult, prefixErr := resolveViaPrefixRouting(ctx, id); prefixErr == nil {
+			return prefixResult, nil
+		}
+
+		// Fall back to contributor auto-routing (GH#2345).
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil
 		}

--- a/cmd/bd/routing_prefix.go
+++ b/cmd/bd/routing_prefix.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/debug"
+)
+
+// routeEntry represents a single prefix-to-path mapping from routes.jsonl.
+type routeEntry struct {
+	Prefix string `json:"prefix"`
+	Path   string `json:"path"`
+}
+
+// findRoutesFile locates the routes.jsonl file for prefix-based routing.
+// Checks GT_ROOT first (orchestrator mode), then walks up from CWD.
+func findRoutesFile() string {
+	if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {
+		routesPath := filepath.Join(gtRoot, ".beads", "routes.jsonl")
+		if _, err := os.Stat(routesPath); err == nil {
+			return routesPath
+		}
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for dir := cwd; ; dir = filepath.Dir(dir) {
+		routesPath := filepath.Join(dir, ".beads", "routes.jsonl")
+		if _, err := os.Stat(routesPath); err == nil {
+			return routesPath
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+	}
+	return ""
+}
+
+// loadRoutes parses a routes.jsonl file into route entries.
+// Each line is a JSON object with "prefix" and "path" fields.
+func loadRoutes(routesPath string) ([]routeEntry, error) {
+	f, err := os.Open(routesPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var routes []routeEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry routeEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry.Prefix != "" && entry.Path != "" {
+			routes = append(routes, entry)
+		}
+	}
+	return routes, scanner.Err()
+}
+
+// matchRouteForID finds the best matching route for an issue ID.
+// Handles both prefix formats: "ga" (no dash) and "gt-" (with dash).
+// Returns the longest matching route, or nil if no match.
+func matchRouteForID(routes []routeEntry, id string) *routeEntry {
+	var best *routeEntry
+	bestLen := 0
+	for i := range routes {
+		prefix := routes[i].Prefix
+		// Normalize: ensure we match prefix followed by dash
+		matchPrefix := prefix
+		if !strings.HasSuffix(matchPrefix, "-") {
+			matchPrefix += "-"
+		}
+		if strings.HasPrefix(id, matchPrefix) && len(matchPrefix) > bestLen {
+			best = &routes[i]
+			bestLen = len(matchPrefix)
+		}
+	}
+	return best
+}
+
+// resolveViaPrefixRouting attempts to find an issue using prefix-based routing
+// via routes.jsonl. Extracts the prefix from the issue ID, finds the matching
+// route, and opens the target rig's store.
+func resolveViaPrefixRouting(ctx context.Context, id string) (*RoutedResult, error) {
+	routesPath := findRoutesFile()
+	if routesPath == "" {
+		return nil, fmt.Errorf("no routes.jsonl found")
+	}
+
+	routes, err := loadRoutes(routesPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading routes: %w", err)
+	}
+
+	route := matchRouteForID(routes, id)
+	if route == nil {
+		return nil, fmt.Errorf("no route matches prefix for %q", id)
+	}
+
+	// Paths in routes.jsonl are relative to the town root.
+	// routes.jsonl lives at <town>/.beads/routes.jsonl
+	townRoot := filepath.Dir(filepath.Dir(routesPath))
+	targetPath := route.Path
+	if !filepath.IsAbs(targetPath) {
+		targetPath = filepath.Join(townRoot, targetPath)
+	}
+
+	// Skip if route points to current directory (already tried local store)
+	if targetPath == "." {
+		return nil, fmt.Errorf("route points to current directory")
+	}
+
+	targetBeadsDir := filepath.Join(targetPath, ".beads")
+	debug.Logf("prefix routing: %q matched prefix=%q -> %s\n", id, route.Prefix, targetBeadsDir)
+
+	routedStore, err := newReadOnlyStoreFromConfig(ctx, targetBeadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("opening routed store at %s: %w", targetPath, err)
+	}
+
+	result, err := resolveAndGetFromStore(ctx, routedStore, id, true)
+	if err != nil {
+		_ = routedStore.Close()
+		return nil, err
+	}
+	result.closeFn = func() { _ = routedStore.Close() }
+	return result, nil
+}

--- a/cmd/bd/routing_prefix_test.go
+++ b/cmd/bd/routing_prefix_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchRouteForID(t *testing.T) {
+	t.Parallel()
+
+	routes := []routeEntry{
+		{Prefix: "ga", Path: "../gascity"},
+		{Prefix: "be", Path: "../beads"},
+		{Prefix: "gt-", Path: "rig"},       // trailing dash format
+		{Prefix: "gc", Path: "."},           // self-referential
+		{Prefix: "gascity", Path: "../gas"}, // longer prefix to test longest-match
+	}
+
+	tests := []struct {
+		name       string
+		id         string
+		wantPrefix string
+		wantNil    bool
+	}{
+		{name: "match prefix without dash", id: "ga-ki2", wantPrefix: "ga"},
+		{name: "match prefix with dash", id: "gt-child1", wantPrefix: "gt-"},
+		{name: "match beads prefix", id: "be-nlc", wantPrefix: "be"},
+		{name: "no match", id: "xx-unknown", wantNil: true},
+		{name: "empty id", id: "", wantNil: true},
+		{name: "id without dash", id: "nodash", wantNil: true},
+		{name: "self-referential route", id: "gc-abc", wantPrefix: "gc"},
+		{name: "longest prefix wins", id: "gascity-abc", wantPrefix: "gascity"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := matchRouteForID(routes, tt.id)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.wantPrefix, result.Prefix)
+			}
+		})
+	}
+}
+
+func TestLoadRoutes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid routes file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		content := `{"prefix":"ga","path":"../gascity"}
+{"prefix":"be","path":"../beads"}
+{"prefix":"gt-","path":"rig"}
+`
+		routesPath := filepath.Join(dir, "routes.jsonl")
+		require.NoError(t, os.WriteFile(routesPath, []byte(content), 0644))
+
+		routes, err := loadRoutes(routesPath)
+		require.NoError(t, err)
+		assert.Len(t, routes, 3)
+		assert.Equal(t, "ga", routes[0].Prefix)
+		assert.Equal(t, "../gascity", routes[0].Path)
+	})
+
+	t.Run("skips malformed lines", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		content := `{"prefix":"ga","path":"../gascity"}
+not json
+{"prefix":"be","path":"../beads"}
+`
+		routesPath := filepath.Join(dir, "routes.jsonl")
+		require.NoError(t, os.WriteFile(routesPath, []byte(content), 0644))
+
+		routes, err := loadRoutes(routesPath)
+		require.NoError(t, err)
+		assert.Len(t, routes, 2)
+	})
+
+	t.Run("skips entries with empty prefix or path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		content := `{"prefix":"","path":"../gascity"}
+{"prefix":"ga","path":""}
+{"prefix":"be","path":"../beads"}
+`
+		routesPath := filepath.Join(dir, "routes.jsonl")
+		require.NoError(t, os.WriteFile(routesPath, []byte(content), 0644))
+
+		routes, err := loadRoutes(routesPath)
+		require.NoError(t, err)
+		assert.Len(t, routes, 1)
+		assert.Equal(t, "be", routes[0].Prefix)
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := loadRoutes("/nonexistent/routes.jsonl")
+		assert.Error(t, err)
+	})
+}
+
+func TestFindRoutesFile(t *testing.T) {
+	// Cannot run in parallel — uses os.Chdir and env vars
+
+	t.Run("finds via GT_ROOT", func(t *testing.T) {
+		dir := t.TempDir()
+		beadsDir := filepath.Join(dir, ".beads")
+		require.NoError(t, os.MkdirAll(beadsDir, 0755))
+		routesPath := filepath.Join(beadsDir, "routes.jsonl")
+		require.NoError(t, os.WriteFile(routesPath, []byte(`{"prefix":"ga","path":"."}`+"\n"), 0644))
+
+		t.Setenv("GT_ROOT", dir)
+		result := findRoutesFile()
+		assert.Equal(t, routesPath, result)
+	})
+
+	t.Run("finds via CWD walk-up", func(t *testing.T) {
+		dir := t.TempDir()
+		// Resolve symlinks (macOS: /var -> /private/var) so paths match os.Getwd()
+		dir, err := filepath.EvalSymlinks(dir)
+		require.NoError(t, err)
+
+		beadsDir := filepath.Join(dir, ".beads")
+		require.NoError(t, os.MkdirAll(beadsDir, 0755))
+		routesPath := filepath.Join(beadsDir, "routes.jsonl")
+		require.NoError(t, os.WriteFile(routesPath, []byte(`{"prefix":"ga","path":"."}`+"\n"), 0644))
+
+		// Create a subdirectory and cd into it
+		subDir := filepath.Join(dir, "rig", "sub")
+		require.NoError(t, os.MkdirAll(subDir, 0755))
+
+		oldWd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(subDir))
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+		t.Setenv("GT_ROOT", "") // clear GT_ROOT to test CWD fallback
+		result := findRoutesFile()
+		assert.Equal(t, routesPath, result)
+	})
+
+	t.Run("returns empty when no routes.jsonl exists", func(t *testing.T) {
+		dir := t.TempDir()
+		oldWd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(dir))
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+		t.Setenv("GT_ROOT", "")
+		result := findRoutesFile()
+		assert.Empty(t, result)
+	})
+}

--- a/cmd/bd/store_factory_test.go
+++ b/cmd/bd/store_factory_test.go
@@ -4,9 +4,11 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 )
 
 // TestNewDoltStoreFromConfig_NoMetadata verifies that newDoltStoreFromConfig
@@ -35,4 +37,18 @@ func TestNewDoltStoreFromConfig_NoMetadata(t *testing.T) {
 		t.Fatalf("newDoltStoreFromConfig failed: %v", err)
 	}
 	defer store.Close()
+}
+
+// TestEmbeddedNew_EmptyDatabaseRejected verifies that embeddeddolt.New fails
+// with a clear error when called with an empty database name, rather than
+// deferring to a confusing "no database selected" SQL error.
+// Belt-and-suspenders defense for be-sy8 / GH#2988.
+func TestEmbeddedNew_EmptyDatabaseRejected(t *testing.T) {
+	_, err := embeddeddolt.New(t.Context(), t.TempDir(), "", "main")
+	if err == nil {
+		t.Fatal("expected error for empty database name")
+	}
+	if !strings.Contains(err.Error(), "database name must not be empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
 }

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -78,6 +78,10 @@ func WithLock(lock Unlocker) Option {
 // (GH#2571). The lock is released when Close is called, unless a pre-acquired
 // lock was supplied via WithLock (in which case the caller is responsible for it).
 func New(ctx context.Context, beadsDir, database, branch string, opts ...Option) (*EmbeddedDoltStore, error) {
+	if database == "" {
+		return nil, fmt.Errorf("embeddeddolt: database name must not be empty (caller should default to %q)", "beads")
+	}
+
 	var o options
 	for _, fn := range opts {
 		fn(&o)


### PR DESCRIPTION
## Summary
- Adds early validation in `embeddeddolt.New()` to reject empty database names with a clear error instead of failing deep in schema migrations with "no database selected"
- Adds prefix-based routing via `routes.jsonl` for cross-rig `bd show`
- Includes end-to-end regression test for `bd create --repo` with uninitialized target

Fixes: `bd create --repo <rig>` failing with `embeddeddolt: init schema: creating schema_migrations table: Error 1105: no database selected`

## Test plan
- [x] Regression test added for `bd create --repo` with uninitialized target
- [ ] Manual verification: `bd create --repo gascity "test"` from monorepo agent dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)