### PR TITLE
fix: remove stale worktree guard in rename-prefix

### DIFF
--- a/cmd/bd/rename_prefix.go
+++ b/cmd/bd/rename_prefix.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
@@ -63,17 +62,6 @@ NOTE: This is a rare operation. Most users never need this command.`,
 		}
 
 		ctx := rootCtx
-
-		// Block rename-prefix in worktrees (same guard as init.go:168-186)
-		if isGitRepo() && git.IsWorktree() {
-			mainRepoRoot, _ := git.GetMainRepoRoot()
-			fmt.Fprintf(os.Stderr, "Error: cannot run 'bd rename-prefix' from a git worktree\n\n")
-			fmt.Fprintf(os.Stderr, "Worktrees share the .beads database from the main repository.\n\n")
-			fmt.Fprintf(os.Stderr, "Run this command from the main repository instead:\n")
-			fmt.Fprintf(os.Stderr, "  cd %s\n", mainRepoRoot)
-			fmt.Fprintf(os.Stderr, "  bd rename-prefix %s\n", newPrefix)
-			os.Exit(1)
-		}
 
 		// rename-prefix requires direct database access
 		if store == nil {

--- a/cmd/bd/rename_prefix_worktree_test.go
+++ b/cmd/bd/rename_prefix_worktree_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/git"
+)
+
+func setupWorktree(t *testing.T) (mainRepoDir, worktreeDir string) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "beads-worktree-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir = filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepoDir
+		if err := cmd.Run(); err != nil {
+			t.Skipf("git %v failed: %v", args, err)
+		}
+	}
+
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	worktreeDir = filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git worktree add failed: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	return mainRepoDir, worktreeDir
+}
+
+func TestRenamePrefix_WorktreeNotBlocked(t *testing.T) {
+	_, worktreeDir := setupWorktree(t)
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	if !isGitRepo() {
+		t.Fatal("expected isGitRepo() to return true")
+	}
+	if !git.IsWorktree() {
+		t.Fatal("expected git.IsWorktree() to return true")
+	}
+
+	// The worktree guard was removed: running from a worktree should not
+	// produce the old "cannot run 'bd rename-prefix' from a git worktree" error.
+	// We verify the preconditions that the old guard checked (isGitRepo && IsWorktree)
+	// are met, confirming the code path that used to block is now reachable.
+}
+
+func TestRenamePrefix_WorktreeResolvesMainRepoDB(t *testing.T) {
+	mainRepoDir, worktreeDir := setupWorktree(t)
+
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainBeadsDir, "metadata.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	os.RemoveAll(filepath.Join(worktreeDir, ".beads"))
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	if !git.IsWorktree() {
+		t.Fatal("expected git.IsWorktree() to return true")
+	}
+
+	found := beads.FindBeadsDir()
+	if found == "" {
+		t.Fatal("FindBeadsDir() returned empty — store initialization would fail")
+	}
+
+	actual, _ := filepath.EvalSymlinks(filepath.Clean(strings.TrimSpace(found)))
+	expected, _ := filepath.EvalSymlinks(filepath.Clean(mainBeadsDir))
+	if actual != expected {
+		t.Errorf("FindBeadsDir() = %q, want %q — rename-prefix would use wrong DB path", actual, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Remove stale `os.Exit(1)` block that prevented `bd rename-prefix` from running in git worktrees
- The worktree path resolution algorithm (FindBeadsDir → GetWorktreeFallbackBeadsDir) handles shared .beads correctly, making this explicit block unnecessary
- The comment referenced "same guard as init.go:168-186" but that guard was already removed

## Test plan
- [x] `TestRenamePrefix_WorktreeNotBlocked` — verifies worktree preconditions are met (isGitRepo && IsWorktree)
- [x] `TestRenamePrefix_WorktreeResolvesMainRepoDB` — verifies FindBeadsDir resolves to main repo's .beads
- [x] CI green on ubuntu-latest, macos-latest, Windows smoke