### PR TITLE
fix: use FindBeadsDir for worktree-aware reset

### DIFF
--- a/cmd/bd/reset.go
+++ b/cmd/bd/reset.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -54,8 +55,8 @@ func runReset(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	// Check if .beads directory exists
-	beadsDir := ".beads"
+	// Resolve .beads directory (worktree-aware)
+	beadsDir := beads.FindBeadsDir()
 	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
 		if jsonOutput {
 			outputJSON(map[string]interface{}{

--- a/cmd/bd/reset.go
+++ b/cmd/bd/reset.go
@@ -57,6 +57,18 @@ func runReset(cmd *cobra.Command, args []string) {
 
 	// Resolve .beads directory (worktree-aware)
 	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"message": "beads not initialized",
+				"reset":   false,
+			})
+		} else {
+			fmt.Println("Beads is not initialized in this repository.")
+			fmt.Println("Nothing to reset.")
+		}
+		return
+	}
 	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
 		if jsonOutput {
 			outputJSON(map[string]interface{}{

--- a/cmd/bd/reset.go
+++ b/cmd/bd/reset.go
@@ -69,18 +69,6 @@ func runReset(cmd *cobra.Command, args []string) {
 		}
 		return
 	}
-	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
-		if jsonOutput {
-			outputJSON(map[string]interface{}{
-				"message": "beads not initialized",
-				"reset":   false,
-			})
-		} else {
-			fmt.Println("Beads is not initialized in this repository.")
-			fmt.Println("Nothing to reset.")
-		}
-		return
-	}
 
 	// Collect what would be deleted
 	items := collectResetItems(gitCommonDir, beadsDir)

--- a/cmd/bd/reset_worktree_test.go
+++ b/cmd/bd/reset_worktree_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/git"
+)
+
+func TestReset_WorktreeFindsBeadsDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-reset-worktree-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add failed: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainBeadsDir, "metadata.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	worktreeBeadsDir := filepath.Join(worktreeDir, ".beads")
+	os.RemoveAll(worktreeBeadsDir)
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	if !isGitRepo() {
+		t.Fatal("expected isGitRepo() to return true")
+	}
+	if !git.IsWorktree() {
+		t.Fatal("expected git.IsWorktree() to return true")
+	}
+
+	found := beads.FindBeadsDir()
+	if found == "" {
+		t.Fatal("FindBeadsDir() returned empty string")
+	}
+
+	expected, err := filepath.EvalSymlinks(mainBeadsDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q) failed: %v", mainBeadsDir, err)
+	}
+	actual, err := filepath.EvalSymlinks(found)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q) failed: %v", found, err)
+	}
+
+	expected = filepath.Clean(strings.TrimSpace(expected))
+	actual = filepath.Clean(strings.TrimSpace(actual))
+
+	if actual != expected {
+		t.Errorf("FindBeadsDir() = %q, want %q", actual, expected)
+	}
+
+	if _, err := os.Stat(actual); err != nil {
+		t.Errorf("os.Stat(FindBeadsDir()) failed: %v — runReset would report \"not initialized\"", err)
+	}
+}
+
+func TestReset_WorktreeNoBeadsReturnsEmpty(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-reset-no-beads-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add failed: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	found := beads.FindBeadsDir()
+	if found != "" {
+		t.Errorf("FindBeadsDir() = %q, want empty string when no .beads exists anywhere", found)
+	}
+}
+
+func TestReset_WorktreeSubdirFindsBeadsDir(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-reset-subdir-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add failed: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.RemoveAll(filepath.Join(worktreeDir, ".beads"))
+
+	subDir := filepath.Join(worktreeDir, "sub", "dir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(subDir)
+	git.ResetCaches()
+
+	found := beads.FindBeadsDir()
+	if found != "" {
+		actual, _ := filepath.EvalSymlinks(found)
+		expected, _ := filepath.EvalSymlinks(mainBeadsDir)
+		if filepath.Clean(actual) != filepath.Clean(expected) {
+			t.Errorf("FindBeadsDir() from subdirectory = %q, want %q", actual, expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `.beads` path with `beads.FindBeadsDir()` in `bd reset`
- Fixes false "Beads is not initialized" when running from a git worktree
- The rest of reset.go already uses `git.GetGitCommonDir()` correctly

## Test plan
- [x] `TestReset_WorktreeFindsBeadsDir` — verifies FindBeadsDir resolves to main repo's .beads
- [x] `TestReset_WorktreeNoBeadsReturnsEmpty` — verifies empty string when no .beads exists
- [x] `TestReset_WorktreeSubdirFindsBeadsDir` — verifies resolution from nested subdirectory
- [x] CI green on ubuntu-latest, macos-latest, Windows smoke