### PR TITLE
fix: use main repo root for hooks path in worktrees

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -553,7 +553,15 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 		hooksDir = filepath.Join(beadsDir, "hooks")
 	} else if shared {
 		// Use versioned directory for shared hooks
-		hooksDir = ".beads-hooks"
+		if git.IsWorktree() {
+			if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
+				hooksDir = filepath.Join(mainRoot, ".beads-hooks")
+			} else {
+				hooksDir = ".beads-hooks"
+			}
+		} else {
+			hooksDir = ".beads-hooks"
+		}
 	} else {
 		// Use common git directory for hooks (shared across worktrees)
 		var err error
@@ -666,6 +674,11 @@ func preservePreexistingHooks(targetDir string) {
 
 	// If current dir is already a beads-managed directory, skip.
 	repoRoot := git.GetRepoRoot()
+	if git.IsWorktree() {
+		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
+			repoRoot = mainRoot
+		}
+	}
 	if repoRoot != "" {
 		absBeadsHooks, _ := filepath.Abs(filepath.Join(repoRoot, ".beads", "hooks"))
 		absSharedHooks, _ := filepath.Abs(filepath.Join(repoRoot, ".beads-hooks"))
@@ -718,8 +731,12 @@ func configureSharedHooksPath() error {
 	// Set git config core.hooksPath to an absolute path pointing to .beads-hooks.
 	// Using an absolute path is critical for git worktrees (GH#2414):
 	// git resolves relative core.hooksPath relative to the working tree root.
-	// Note: This may run before .beads exists, so it uses git.GetRepoRoot() directly.
 	repoRoot := git.GetRepoRoot()
+	if git.IsWorktree() {
+		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
+			repoRoot = mainRoot
+		}
+	}
 	if repoRoot == "" {
 		return fmt.Errorf("not in a git repository")
 	}
@@ -739,6 +756,11 @@ func configureBeadsHooksPath() error {
 	// so in a worktree ".beads/hooks" would resolve to <worktree>/.beads/hooks/
 	// which doesn't exist — the hooks live in the main repo's .beads/hooks/.
 	repoRoot := git.GetRepoRoot()
+	if git.IsWorktree() {
+		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
+			repoRoot = mainRoot
+		}
+	}
 	if repoRoot == "" {
 		return fmt.Errorf("not in a git repository")
 	}
@@ -818,6 +840,11 @@ func uninstallHooks() error {
 // beads-managed hooks directory (.beads/hooks or .beads-hooks).
 func resetHooksPathIfBeadsManaged() error {
 	repoRoot := git.GetRepoRoot()
+	if git.IsWorktree() {
+		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
+			repoRoot = mainRoot
+		}
+	}
 	if repoRoot == "" {
 		return nil // not in a git repo
 	}

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -553,12 +553,8 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 		hooksDir = filepath.Join(beadsDir, "hooks")
 	} else if shared {
 		// Use versioned directory for shared hooks
-		if git.IsWorktree() {
-			if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
-				hooksDir = filepath.Join(mainRoot, ".beads-hooks")
-			} else {
-				hooksDir = ".beads-hooks"
-			}
+		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
+			hooksDir = filepath.Join(mainRoot, ".beads-hooks")
 		} else {
 			hooksDir = ".beads-hooks"
 		}
@@ -673,11 +669,9 @@ func preservePreexistingHooks(targetDir string) {
 	}
 
 	// If current dir is already a beads-managed directory, skip.
-	repoRoot := git.GetRepoRoot()
-	if git.IsWorktree() {
-		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
-			repoRoot = mainRoot
-		}
+	repoRoot, _ := git.GetMainRepoRoot()
+	if repoRoot == "" {
+		repoRoot = git.GetRepoRoot()
 	}
 	if repoRoot != "" {
 		absBeadsHooks, _ := filepath.Abs(filepath.Join(repoRoot, ".beads", "hooks"))
@@ -731,11 +725,9 @@ func configureSharedHooksPath() error {
 	// Set git config core.hooksPath to an absolute path pointing to .beads-hooks.
 	// Using an absolute path is critical for git worktrees (GH#2414):
 	// git resolves relative core.hooksPath relative to the working tree root.
-	repoRoot := git.GetRepoRoot()
-	if git.IsWorktree() {
-		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
-			repoRoot = mainRoot
-		}
+	repoRoot, _ := git.GetMainRepoRoot()
+	if repoRoot == "" {
+		repoRoot = git.GetRepoRoot()
 	}
 	if repoRoot == "" {
 		return fmt.Errorf("not in a git repository")
@@ -755,11 +747,9 @@ func configureBeadsHooksPath() error {
 	// git resolves relative core.hooksPath relative to the working tree root,
 	// so in a worktree ".beads/hooks" would resolve to <worktree>/.beads/hooks/
 	// which doesn't exist — the hooks live in the main repo's .beads/hooks/.
-	repoRoot := git.GetRepoRoot()
-	if git.IsWorktree() {
-		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
-			repoRoot = mainRoot
-		}
+	repoRoot, _ := git.GetMainRepoRoot()
+	if repoRoot == "" {
+		repoRoot = git.GetRepoRoot()
 	}
 	if repoRoot == "" {
 		return fmt.Errorf("not in a git repository")
@@ -839,11 +829,9 @@ func uninstallHooks() error {
 // resetHooksPathIfBeadsManaged unsets core.hooksPath if it points to a
 // beads-managed hooks directory (.beads/hooks or .beads-hooks).
 func resetHooksPathIfBeadsManaged() error {
-	repoRoot := git.GetRepoRoot()
-	if git.IsWorktree() {
-		if mainRoot, err := git.GetMainRepoRoot(); err == nil && mainRoot != "" {
-			repoRoot = mainRoot
-		}
+	repoRoot, _ := git.GetMainRepoRoot()
+	if repoRoot == "" {
+		repoRoot = git.GetRepoRoot()
 	}
 	if repoRoot == "" {
 		return nil // not in a git repo

--- a/cmd/bd/hooks_worktree_test.go
+++ b/cmd/bd/hooks_worktree_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/git"
+)
+
+func TestConfigureBeadsHooksPath_WorktreeUsesMainRepo(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-hooks-worktree-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepoDir
+		if err := cmd.Run(); err != nil {
+			t.Skipf("git %v failed: %v", args, err)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git worktree add failed: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	if err := os.MkdirAll(filepath.Join(mainRepoDir, ".beads", "hooks"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	if !git.IsWorktree() {
+		t.Fatal("expected git.IsWorktree() to return true")
+	}
+
+	if err := configureBeadsHooksPath(); err != nil {
+		t.Fatalf("configureBeadsHooksPath failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "config", "--get", "core.hooksPath")
+	cmd.Dir = mainRepoDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git config --get core.hooksPath failed: %v", err)
+	}
+	hooksPath := filepath.Clean(strings.TrimSpace(string(out)))
+	expected := filepath.Join(mainRepoDir, ".beads", "hooks")
+	hooksPath, _ = filepath.EvalSymlinks(hooksPath)
+	expected, _ = filepath.EvalSymlinks(expected)
+	if hooksPath != expected {
+		t.Errorf("core.hooksPath = %q, want %q", hooksPath, expected)
+	}
+}
+
+func TestConfigureSharedHooksPath_WorktreeUsesMainRepo(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-shared-hooks-worktree-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepoDir
+		if err := cmd.Run(); err != nil {
+			t.Skipf("git %v failed: %v", args, err)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git worktree add failed: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	if err := os.MkdirAll(filepath.Join(mainRepoDir, ".beads-hooks"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	if !git.IsWorktree() {
+		t.Fatal("expected git.IsWorktree() to return true")
+	}
+
+	if err := configureSharedHooksPath(); err != nil {
+		t.Fatalf("configureSharedHooksPath failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "config", "--get", "core.hooksPath")
+	cmd.Dir = mainRepoDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git config --get core.hooksPath failed: %v", err)
+	}
+	hooksPath := filepath.Clean(strings.TrimSpace(string(out)))
+	expected := filepath.Join(mainRepoDir, ".beads-hooks")
+	hooksPath, _ = filepath.EvalSymlinks(hooksPath)
+	expected, _ = filepath.EvalSymlinks(expected)
+	if hooksPath != expected {
+		t.Errorf("core.hooksPath = %q, want %q", hooksPath, expected)
+	}
+}
+
+func TestResetHooksPathIfBeadsManaged_Worktree(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-reset-hooks-worktree-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepoDir
+		if err := cmd.Run(); err != nil {
+			t.Skipf("git %v failed: %v", args, err)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git worktree add failed: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	})
+
+	if err := os.MkdirAll(filepath.Join(mainRepoDir, ".beads", "hooks"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	hooksPathToSet := filepath.Join(mainRepoDir, ".beads", "hooks")
+	evaluated, _ := filepath.EvalSymlinks(hooksPathToSet)
+	if evaluated != "" {
+		hooksPathToSet = evaluated
+	}
+	cmd = exec.Command("git", "config", "core.hooksPath", hooksPathToSet)
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git config core.hooksPath failed: %v", err)
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	if !git.IsWorktree() {
+		t.Fatal("expected git.IsWorktree() to return true")
+	}
+
+	if err := resetHooksPathIfBeadsManaged(); err != nil {
+		t.Fatalf("resetHooksPathIfBeadsManaged failed: %v", err)
+	}
+
+	cmd = exec.Command("git", "config", "--get", "core.hooksPath")
+	cmd.Dir = mainRepoDir
+	out, _ := cmd.Output()
+	if strings.TrimSpace(string(out)) != "" {
+		t.Errorf("core.hooksPath = %q after reset, want empty", strings.TrimSpace(string(out)))
+	}
+}
+
+func TestConfigureBeadsHooksPath_NormalRepoUnchanged(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-hooks-normal-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	repoDir := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if err := cmd.Run(); err != nil {
+			t.Skipf("git %v failed: %v", args, err)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Initial commit")
+
+	if err := os.MkdirAll(filepath.Join(repoDir, ".beads", "hooks"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(repoDir)
+	git.ResetCaches()
+
+	if git.IsWorktree() {
+		t.Fatal("expected git.IsWorktree() to return false in normal repo")
+	}
+
+	if err := configureBeadsHooksPath(); err != nil {
+		t.Fatalf("configureBeadsHooksPath failed: %v", err)
+	}
+
+	cmd := exec.Command("git", "config", "--get", "core.hooksPath")
+	cmd.Dir = repoDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git config --get core.hooksPath failed: %v", err)
+	}
+	hooksPath := filepath.Clean(strings.TrimSpace(string(out)))
+	expected := filepath.Join(repoDir, ".beads", "hooks")
+	hooksPath, _ = filepath.EvalSymlinks(hooksPath)
+	expected, _ = filepath.EvalSymlinks(expected)
+	if hooksPath != expected {
+		t.Errorf("core.hooksPath = %q, want %q", hooksPath, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `bd hooks install` and `bd hooks install --shared` to use main repo root when running from a git worktree
- `git.GetRepoRoot()` returns the worktree root, causing `core.hooksPath` to point to a non-existent path
- Use `git.GetMainRepoRoot()` in worktrees so hooks resolve to the correct shared location

## Affected functions
- `configureBeadsHooksPath()`
- `configureSharedHooksPath()`
- `resetHooksPathIfBeadsManaged()`
- `preservePreexistingHooks()`
- `--shared` hooks directory resolution in `installHooksWithOptions()`

## Test plan
- [x] `TestConfigureBeadsHooksPath_WorktreeUsesMainRepo` — verifies core.hooksPath points to main repo
- [x] `TestConfigureSharedHooksPath_WorktreeUsesMainRepo` — verifies shared hooks in main repo
- [x] `TestResetHooksPathIfBeadsManaged_Worktree` — verifies reset works from worktree
- [x] `TestConfigureBeadsHooksPath_NormalRepoUnchanged` — regression guard for normal repos
- [x] CI green on ubuntu-latest, macos-latest, Windows smoke