### PR TITLE
fix: worktree-aware path resolution in config validate and preflight

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -11,7 +11,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/steveyegge/beads/cmd/bd/doctor"
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/remotecache"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -522,10 +524,18 @@ func findBeadsRepoRoot(startPath string) string {
 		}
 		parent := filepath.Dir(path)
 		if parent == path {
-			return ""
+			break
 		}
 		path = parent
 	}
+
+	if isGitRepo() && git.IsWorktree() {
+		if fallbackDir := beads.GetWorktreeFallbackBeadsDir(); fallbackDir != "" {
+			return filepath.Dir(fallbackDir)
+		}
+	}
+
+	return ""
 }
 
 var configSetManyCmd = &cobra.Command{

--- a/cmd/bd/config_worktree_test.go
+++ b/cmd/bd/config_worktree_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/git"
+)
+
+func TestFindBeadsRepoRoot_WorktreeFallback(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-worktree-cfg-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(dir string, args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run(mainRepoDir, "init")
+	run(mainRepoDir, "config", "user.email", "test@example.com")
+	run(mainRepoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run(mainRepoDir, "add", "README.md")
+	run(mainRepoDir, "commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add failed: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		cleanupCmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cleanupCmd.Dir = mainRepoDir
+		_ = cleanupCmd.Run()
+	})
+
+	if err := os.MkdirAll(filepath.Join(mainRepoDir, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	worktreeBeads := filepath.Join(worktreeDir, ".beads")
+	os.RemoveAll(worktreeBeads)
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	got := findBeadsRepoRoot(worktreeDir)
+	if got == "" {
+		t.Fatal("findBeadsRepoRoot returned empty string; expected main repo dir")
+	}
+
+	gotClean := filepath.Clean(strings.TrimSpace(got))
+	wantClean := filepath.Clean(strings.TrimSpace(mainRepoDir))
+
+	gotEval, err := filepath.EvalSymlinks(gotClean)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", gotClean, err)
+	}
+	wantEval, err := filepath.EvalSymlinks(wantClean)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", wantClean, err)
+	}
+
+	if gotEval != wantEval {
+		t.Errorf("findBeadsRepoRoot = %q, want %q", gotEval, wantEval)
+	}
+}
+
+func TestBeadsPollutionCheck_WorktreeSkips(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "beads-worktree-preflight-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(dir string, args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run(mainRepoDir, "init")
+	run(mainRepoDir, "config", "user.email", "test@example.com")
+	run(mainRepoDir, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run(mainRepoDir, "add", "README.md")
+	run(mainRepoDir, "commit", "-m", "Initial commit")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	cmd := exec.Command("git", "worktree", "add", worktreeDir, "HEAD")
+	cmd.Dir = mainRepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add failed: %v\n%s", err, out)
+	}
+	t.Cleanup(func() {
+		cleanupCmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cleanupCmd.Dir = mainRepoDir
+		_ = cleanupCmd.Run()
+	})
+
+	if err := os.MkdirAll(filepath.Join(mainRepoDir, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.RemoveAll(filepath.Join(worktreeDir, ".beads"))
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	result := runBeadsPollutionCheck()
+	if !result.Passed {
+		t.Errorf("runBeadsPollutionCheck() in worktree: Passed=%v, want true (should skip when .beads is outside worktree)", result.Passed)
+	}
+}

--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/beads"
 )
 
 // CheckResult represents the result of a single preflight check.
@@ -289,7 +291,34 @@ func runFmtCheck() CheckResult {
 func runBeadsPollutionCheck() CheckResult {
 	command := "git diff -- .beads/issues.jsonl"
 
-	// Determine current branch
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return CheckResult{
+			Name:    "No beads pollution",
+			Passed:  true,
+			Command: command,
+		}
+	}
+
+	// git diff requires a path relative to the worktree root.
+	// If beadsDir points outside the worktree (shared .beads in a
+	// worktree setup), convert to a relative path. When the path is
+	// outside the worktree, the pollution check is skipped since git
+	// cannot diff paths outside the working tree.
+	issuesPath := filepath.Join(beadsDir, "issues.jsonl")
+	if filepath.IsAbs(issuesPath) {
+		cwd, _ := os.Getwd()
+		rel, err := filepath.Rel(cwd, issuesPath)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return CheckResult{
+				Name:    "No beads pollution",
+				Passed:  true,
+				Command: command,
+			}
+		}
+		issuesPath = rel
+	}
+
 	branchCmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
 	branchOut, err := branchCmd.Output()
 	if err != nil {
@@ -305,14 +334,12 @@ func runBeadsPollutionCheck() CheckResult {
 
 	var diffOutput []byte
 	if branch != "main" && branch != "HEAD" {
-		// Feature branch: diff against merge base with origin/main
-		cmd := exec.Command("git", "diff", "origin/main...HEAD", "--", ".beads/issues.jsonl")
+		cmd := exec.Command("git", "diff", "origin/main...HEAD", "--", issuesPath)
 		diffOutput, _ = cmd.Output()
 	} else {
-		// On main or detached HEAD: check staged + unstaged changes
-		cmd := exec.Command("git", "diff", "HEAD", "--", ".beads/issues.jsonl")
+		cmd := exec.Command("git", "diff", "HEAD", "--", issuesPath)
 		out1, _ := cmd.Output()
-		cmd2 := exec.Command("git", "diff", "--cached", "--", ".beads/issues.jsonl")
+		cmd2 := exec.Command("git", "diff", "--cached", "--", issuesPath)
 		out2, _ := cmd2.Output()
 		diffOutput = append(out1, out2...)
 	}

--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/git"
 )
 
 // CheckResult represents the result of a single preflight check.
@@ -307,13 +308,21 @@ func runBeadsPollutionCheck() CheckResult {
 	// cannot diff paths outside the working tree.
 	issuesPath := filepath.Join(beadsDir, "issues.jsonl")
 	if filepath.IsAbs(issuesPath) {
-		cwd, _ := os.Getwd()
-		rel, err := filepath.Rel(cwd, issuesPath)
-		if err != nil || strings.HasPrefix(rel, "..") {
+		repoRoot := git.GetRepoRoot()
+		if repoRoot == "" {
 			return CheckResult{
 				Name:    "No beads pollution",
 				Passed:  true,
 				Command: command,
+			}
+		}
+		rel, err := filepath.Rel(repoRoot, issuesPath)
+		if err != nil || isPathOutsideRepo(rel) {
+			return CheckResult{
+				Name:    "No beads pollution",
+				Passed:  true,
+				Command: command,
+				Output:  "Skipped: .beads is outside working tree (worktree setup)",
 			}
 		}
 		issuesPath = rel
@@ -358,6 +367,19 @@ func runBeadsPollutionCheck() CheckResult {
 		Passed:  true,
 		Command: command,
 	}
+}
+
+// isPathOutsideRepo checks if a relative path (from filepath.Rel) points
+// outside the base directory by inspecting the first path segment.
+func isPathOutsideRepo(rel string) bool {
+	if rel == "" {
+		return false
+	}
+	first := rel
+	if i := strings.IndexAny(rel, "/\\"); i > 0 {
+		first = rel[:i]
+	}
+	return first == ".."
 }
 
 // runNixHashCheck checks if go.sum has uncommitted changes that may require vendorHash update.


### PR DESCRIPTION
## Summary
- `findBeadsRepoRoot()` now falls back to `GetWorktreeFallbackBeadsDir()` for sibling worktrees
- `runBeadsPollutionCheck()` resolves beads dir via `FindBeadsDir()` instead of hardcoded relative path
- When `.beads` is outside the worktree (shared setup), the pollution check is skipped since `git diff` cannot reference paths outside the working tree
- Fixes `bd config validate` and `bd preflight` in worktree contexts

## Files
- `cmd/bd/config.go` — `findBeadsRepoRoot()` worktree fallback
- `cmd/bd/preflight.go` — `runBeadsPollutionCheck()` with absolute-to-relative path conversion and `isPathOutsideRepo()` helper

## Test plan
- [x] `TestFindBeadsRepoRoot_WorktreeFallback` — verifies findBeadsRepoRoot returns main repo dir
- [x] `TestBeadsPollutionCheck_WorktreeSkips` — verifies pollution check skips when .beads is outside worktree
- [x] CI green on ubuntu-latest, macos-latest, Windows smoke