### PR TITLE
fix: export JSONL in pre-commit hook for atomic code+issues commits

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -902,7 +904,70 @@ func runPreCommitHook() int {
 	if exitCode := runChainedHook("pre-commit", nil); exitCode != 0 {
 		return exitCode
 	}
+
+	// GH#2489, GH#1863: Export JSONL before commit so issue state lands in
+	// the same commit as code changes.  maybeAutoExport() skips when
+	// BD_GIT_HOOK=1, so we invoke `bd export` as a subprocess instead.
+	exportJSONLForCommit()
+
 	return 0
+}
+
+// exportJSONLForCommit exports Dolt issue state to the git-tracked JSONL file
+// when export.auto is enabled. Called from the pre-commit hook so that the
+// exported file can be staged and included in the pending commit.
+//
+// Errors are logged as warnings but never block the commit.
+func exportJSONLForCommit() {
+	if !config.GetBool("export.auto") {
+		return
+	}
+
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return
+	}
+
+	exportPath := config.GetString("export.path")
+	if exportPath == "" {
+		exportPath = "export.jsonl"
+	}
+	fullPath := filepath.Join(beadsDir, exportPath)
+
+	debug.Logf("pre-commit: exporting JSONL to %s\n", fullPath)
+
+	// Shell out to `bd export` which initialises its own store.
+	// Clear BD_GIT_HOOK from the subprocess env so that its
+	// PersistentPostRun auto-export path does not also fire.
+	cmd := exec.Command("bd", "export", "-o", fullPath)
+	cmd.Dir = beadsDir
+	cmd.Env = filterEnv(os.Environ(), "BD_GIT_HOOK")
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "beads: pre-commit export warning: %v\n", err)
+		return
+	}
+
+	// Stage the exported file if configured.
+	if config.GetBool("export.git-add") {
+		addCmd := exec.Command("git", "add", fullPath)
+		addCmd.Dir = filepath.Dir(fullPath)
+		if err := addCmd.Run(); err != nil {
+			debug.Logf("pre-commit: git add failed: %v\n", err)
+		}
+	}
+}
+
+// filterEnv returns a copy of env with entries matching the given key removed.
+func filterEnv(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // runPostMergeHook runs chained hooks after merge.

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -936,7 +936,7 @@ func exportJSONLForCommit() {
 
 	debug.Logf("pre-commit: exporting JSONL to %s\n", fullPath)
 
-	// Shell out to `bd export` which initialises its own store.
+	// Shell out to `bd export` which initializes its own store.
 	// Clear BD_GIT_HOOK from the subprocess env so that its
 	// PersistentPostRun auto-export path does not also fire.
 	cmd := exec.Command("bd", "export", "-o", fullPath)


### PR DESCRIPTION
## Summary
- Adds explicit JSONL export in the pre-commit hook, restoring the atomic code+issues-in-same-commit workflow broken by the Dolt migration
- Shells out to `bd export` as a subprocess with `BD_GIT_HOOK` cleared to avoid the circular skip in `maybeAutoExport()`
- Only runs when `export.auto` is enabled; optionally stages the file when `export.git-add` is set
- Errors warn on stderr but never block the commit

## Context
Fixes the core complaint in GH#2489: after migrating to Dolt, issue state changes no longer land in the same git commit as code changes. The pre-commit hook is the natural integration point — it runs before every commit and can export+stage the JSONL snapshot so both code and issue state are captured atomically.

Also addresses GH#1863 (pre-commit hook export broken on Dolt backend).

## Test plan
- [ ] Enable `export.auto` and `export.git-add` in beads config
- [ ] Make an issue change (`bd create --title test`), then `git commit` — verify the JSONL file is included in the commit
- [ ] Disable `export.auto` — verify no export runs during commit
- [ ] Verify existing chained pre-commit hooks still run first

🤖 Generated with [Claude Code](https://claude.com/claude-code)