### PR TITLE
fix(dolt): serialize shared-server writes

### DIFF
--- a/internal/storage/dolt/concurrent_test.go
+++ b/internal/storage/dolt/concurrent_test.go
@@ -896,6 +896,43 @@ func TestConcurrentCommentAndCloseWithoutCallerRetry(t *testing.T) {
 	}
 }
 
+func TestServerWriteLockReleasedAfterWrite(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "lock-release",
+		Title:       "Lock release",
+		Description: "verify write lock is not leaked",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	conn, err := store.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("db.Conn: %v", err)
+	}
+	defer conn.Close()
+
+	var locked int
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", store.serverWriteLockName()).Scan(&locked); err != nil {
+		t.Fatalf("GET_LOCK: %v", err)
+	}
+	if locked != 1 {
+		t.Fatalf("expected GET_LOCK to succeed after write, got %d", locked)
+	}
+	if _, err := conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", store.serverWriteLockName()); err != nil {
+		t.Fatalf("RELEASE_LOCK: %v", err)
+	}
+}
+
 // =============================================================================
 // Test: Serialization Conflict Retry
 // 10 goroutines all add a label to the SAME issue concurrently, forcing Dolt

--- a/internal/storage/dolt/concurrent_test.go
+++ b/internal/storage/dolt/concurrent_test.go
@@ -933,6 +933,103 @@ func TestServerWriteLockReleasedAfterWrite(t *testing.T) {
 	}
 }
 
+func TestServerWriteLockSerializesAcrossStores(t *testing.T) {
+	storeA, storeB, cleanup := setupConcurrentPeerStores(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	if storeA.serverWriteLockName() != storeB.serverWriteLockName() {
+		t.Fatalf("expected peer stores to share advisory lock name, got %q vs %q", storeA.serverWriteLockName(), storeB.serverWriteLockName())
+	}
+
+	enterFinalize := make(chan struct{})
+	releaseFinalize := make(chan struct{})
+	storeA.commitVersionedWriteFn = func(context.Context, []string, string) error {
+		close(enterFinalize)
+		<-releaseFinalize
+		return nil
+	}
+
+	doneA := make(chan error, 1)
+	go func() {
+		doneA <- storeA.CreateIssue(ctx, &types.Issue{
+			ID:          "peer-lock-a",
+			Title:       "Peer lock A",
+			Description: "first peer holds shared advisory lock",
+			Status:      types.StatusOpen,
+			Priority:    2,
+			IssueType:   types.TypeTask,
+		}, "peer-a")
+	}()
+
+	<-enterFinalize
+
+	doneB := make(chan error, 1)
+	go func() {
+		doneB <- storeB.CreateIssue(ctx, &types.Issue{
+			ID:          "peer-lock-b",
+			Title:       "Peer lock B",
+			Description: "second peer must wait for advisory lock release",
+			Status:      types.StatusOpen,
+			Priority:    2,
+			IssueType:   types.TypeTask,
+		}, "peer-b")
+	}()
+
+	select {
+	case err := <-doneB:
+		t.Fatalf("expected second store write to wait for shared advisory lock, got %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(releaseFinalize)
+
+	if err := <-doneA; err != nil {
+		t.Fatalf("storeA CreateIssue: %v", err)
+	}
+	if err := <-doneB; err != nil {
+		t.Fatalf("storeB CreateIssue: %v", err)
+	}
+}
+
+func TestServerWriteLockReleasedAfterCanceledCallback(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := concurrentTestContext(t)
+	defer cancel()
+
+	err := store.withSerializedWrite(ctx, func() error {
+		cancel()
+		return ctx.Err()
+	})
+	if err == nil {
+		t.Fatal("expected canceled callback to return an error")
+	}
+
+	lockCtx, lockCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer lockCancel()
+
+	conn, err := store.db.Conn(lockCtx)
+	if err != nil {
+		t.Fatalf("db.Conn: %v", err)
+	}
+	defer conn.Close()
+
+	var locked int
+	if err := conn.QueryRowContext(lockCtx, "SELECT GET_LOCK(?, 0)", store.serverWriteLockName()).Scan(&locked); err != nil {
+		t.Fatalf("GET_LOCK after canceled callback: %v", err)
+	}
+	if locked != 1 {
+		t.Fatalf("expected lock to be released after canceled callback, got %d", locked)
+	}
+	if _, err := conn.ExecContext(lockCtx, "SELECT RELEASE_LOCK(?)", store.serverWriteLockName()); err != nil {
+		t.Fatalf("RELEASE_LOCK: %v", err)
+	}
+}
+
 // =============================================================================
 // Test: Serialization Conflict Retry
 // 10 goroutines all add a label to the SAME issue concurrently, forcing Dolt

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -46,6 +46,9 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 			if err := issueops.AddDependencyInTx(ctx, tx, dep, actor, opts); err != nil {
 				return err
 			}
+			// Blocked-ID cache follows committed SQL state, not Dolt history state.
+			// If finalize later returns PartialWriteError the dependency still exists,
+			// so keeping cache invalidation here avoids serving stale blockers.
 			s.invalidateBlockedIDsCache()
 			return nil
 		}); err != nil {
@@ -82,6 +85,8 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 			if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
 				return err
 			}
+			// See AddDependency: cache should track the SQL mutation even when
+			// the follow-up Dolt history commit needs later repair.
 			s.invalidateBlockedIDsCache()
 			return nil
 		}); err != nil {

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -35,23 +35,24 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		}
 	}
 
-	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		opts := issueops.AddDependencyOpts{
-			SourceTable:   "issues",
-			TargetTable:   targetTable,
-			WriteTable:    "dependencies",
-			IsCrossPrefix: isCrossPrefix,
-		}
-		if err := issueops.AddDependencyInTx(ctx, tx, dep, actor, opts); err != nil {
+	return s.withSerializedWrite(ctx, func() error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			opts := issueops.AddDependencyOpts{
+				SourceTable:   "issues",
+				TargetTable:   targetTable,
+				WriteTable:    "dependencies",
+				IsCrossPrefix: isCrossPrefix,
+			}
+			if err := issueops.AddDependencyInTx(ctx, tx, dep, actor, opts); err != nil {
+				return err
+			}
+			s.invalidateBlockedIDsCache()
+			return nil
+		}); err != nil {
 			return err
 		}
-		s.invalidateBlockedIDsCache()
-		return nil
-	}); err != nil {
-		return err
-	}
-	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
-	return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
+		return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
+	})
 }
 
 // RemoveDependency removes a dependency between two issues.
@@ -71,25 +72,23 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 		return wrapTransactionError("commit remove wisp dependency", tx.Commit())
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
-		return err
-	}
+		if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
+			return err
+		}
 
-	s.invalidateBlockedIDsCache()
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("sql commit: %w", err)
-	}
-	// GH#2455: Use explicit DOLT_ADD to avoid sweeping up stale config changes.
-	if err := s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: remove "+issueID+" -> "+dependsOnID); err != nil {
-		return err
-	}
-	return nil
+		s.invalidateBlockedIDsCache()
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("sql commit: %w", err)
+		}
+		return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: remove "+issueID+" -> "+dependsOnID)
+	})
 }
 
 // GetDependencies retrieves issues that this issue depends on

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -51,7 +51,12 @@ func (s *DoltStore) AddDependency(ctx context.Context, dep *types.Dependency, ac
 		}); err != nil {
 			return err
 		}
-		return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID)
+		return s.commitVersionedWrite(
+			ctx,
+			"add dependency",
+			[]string{"dependencies"},
+			"dependency: add "+string(dep.Type)+" "+dep.IssueID+" -> "+dep.DependsOnID,
+		)
 	})
 }
 
@@ -73,21 +78,21 @@ func (s *DoltStore) RemoveDependency(ctx context.Context, issueID, dependsOnID s
 	}
 
 	return s.withSerializedWrite(ctx, func() error {
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			if err := issueops.RemoveDependencyInTx(ctx, tx, issueID, dependsOnID); err != nil {
+				return err
+			}
+			s.invalidateBlockedIDsCache()
+			return nil
+		}); err != nil {
 			return err
 		}
-
-		s.invalidateBlockedIDsCache()
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("sql commit: %w", err)
-		}
-		return s.doltAddAndCommit(ctx, []string{"dependencies"}, "dependency: remove "+issueID+" -> "+dependsOnID)
+		return s.commitVersionedWrite(
+			ctx,
+			"remove dependency",
+			[]string{"dependencies"},
+			"dependency: remove "+issueID+" -> "+dependsOnID,
+		)
 	})
 }
 

--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -263,6 +263,55 @@ func TestDependencyHistoryAndPartialFailure(t *testing.T) {
 	}
 }
 
+func TestAddDependency_RetryAfterPartialWriteIsIdempotent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{ID: "dep-retry-parent", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask}
+	child := newVersionedTestIssue("dep-retry-child", "Child")
+	for _, issue := range []*types.Issue{parent, child} {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+
+	dep := &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: parent.ID,
+		Type:        types.DepBlocks,
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	err := store.AddDependency(ctx, dep, "tester")
+	requirePartialWriteError(t, err)
+	store.commitVersionedWriteFn = nil
+
+	beforeRetryHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before retry: %v", err)
+	}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("second AddDependency: %v", err)
+	}
+	afterRetryHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after retry: %v", err)
+	}
+	requireHeadChanged(t, beforeRetryHead, afterRetryHead, "retry AddDependency")
+
+	records, err := store.GetDependencyRecords(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords after retry: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected retry to reuse the existing dependency row, got %d records", len(records))
+	}
+}
+
 // =============================================================================
 // GetDependencyCounts Tests
 // =============================================================================

--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -191,6 +191,78 @@ func TestGetAllDependencyRecords(t *testing.T) {
 	}
 }
 
+func TestDependencyHistoryAndPartialFailure(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{ID: "dep-history-parent", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask}
+	child := newVersionedTestIssue("dep-history-child", "Child")
+	for _, issue := range []*types.Issue{parent, child} {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+
+	dep := &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: parent.ID,
+		Type:        types.DepBlocks,
+	}
+
+	beforeAdd, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before add: %v", err)
+	}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+	afterAdd, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after add: %v", err)
+	}
+	requireHeadChanged(t, beforeAdd, afterAdd, "AddDependency")
+
+	if err := store.RemoveDependency(ctx, child.ID, parent.ID, "tester"); err != nil {
+		t.Fatalf("RemoveDependency: %v", err)
+	}
+	afterRemove, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after remove: %v", err)
+	}
+	requireHeadChanged(t, afterAdd, afterRemove, "RemoveDependency")
+
+	beforePartialHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before partial add: %v", err)
+	}
+	beforeRecords, err := store.GetDependencyRecords(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords before partial add: %v", err)
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	err = store.AddDependency(ctx, dep, "tester")
+	requirePartialWriteError(t, err)
+
+	afterPartialHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after partial add: %v", err)
+	}
+	requireHeadUnchanged(t, beforePartialHead, afterPartialHead, "partial AddDependency")
+
+	afterRecords, err := store.GetDependencyRecords(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords after partial add: %v", err)
+	}
+	if len(afterRecords) != len(beforeRecords)+1 {
+		t.Fatalf("expected SQL dependency row to persist despite partial failure, before=%d after=%d", len(beforeRecords), len(afterRecords))
+	}
+}
+
 // =============================================================================
 // GetDependencyCounts Tests
 // =============================================================================

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -190,6 +190,78 @@ func setupConcurrentTestStore(t *testing.T) (*DoltStore, func()) {
 	return store, cleanup
 }
 
+// setupConcurrentPeerStores creates two stores that point at the same shared
+// server database through different local paths. This exercises the production
+// shared-server shape where separate worktrees/processes must still contend on
+// one advisory lock and one backing Dolt repo identity.
+func setupConcurrentPeerStores(t *testing.T) (*DoltStore, *DoltStore, func()) {
+	t.Helper()
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	dbName := uniqueTestDBName(t)
+	tmpDirA, err := os.MkdirTemp("", "dolt-concurrent-peer-a-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir A: %v", err)
+	}
+	tmpDirB, err := os.MkdirTemp("", "dolt-concurrent-peer-b-*")
+	if err != nil {
+		os.RemoveAll(tmpDirA)
+		t.Fatalf("failed to create temp dir B: %v", err)
+	}
+
+	newPeer := func(path, name string) (*DoltStore, error) {
+		store, err := New(ctx, &Config{
+			Path:            path,
+			CommitterName:   name,
+			CommitterEmail:  name + "@example.com",
+			Database:        dbName,
+			MaxOpenConns:    2,
+			CreateIfMissing: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		store.db.SetMaxIdleConns(0)
+		store.db.SetConnMaxIdleTime(time.Second)
+		return store, nil
+	}
+
+	storeA, err := newPeer(tmpDirA, "peer-a")
+	if err != nil {
+		os.RemoveAll(tmpDirA)
+		os.RemoveAll(tmpDirB)
+		t.Fatalf("failed to create store A: %v", err)
+	}
+	if err := storeA.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		storeA.Close()
+		os.RemoveAll(tmpDirA)
+		os.RemoveAll(tmpDirB)
+		t.Fatalf("failed to set prefix for store A: %v", err)
+	}
+
+	storeB, err := newPeer(tmpDirB, "peer-b")
+	if err != nil {
+		storeA.Close()
+		os.RemoveAll(tmpDirA)
+		os.RemoveAll(tmpDirB)
+		t.Fatalf("failed to create store B: %v", err)
+	}
+
+	cleanup := func() {
+		storeA.Close()
+		storeB.Close()
+		os.RemoveAll(tmpDirA)
+		os.RemoveAll(tmpDirB)
+	}
+
+	return storeA, storeB, cleanup
+}
+
 func TestNewDoltStore(t *testing.T) {
 	skipIfNoDolt(t)
 

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -10,7 +10,11 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// AddComment adds a comment event to an issue
+// AddComment adds a comment event to an issue.
+// If SQL commit succeeds but Dolt history finalization fails, it returns
+// PartialWriteError. Callers should not blindly retry that error because
+// comment events are not idempotent and replaying the operation will append a
+// second logical comment.
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
 	return s.withSerializedWrite(ctx, func() error {
 		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
@@ -52,6 +56,9 @@ func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text s
 
 // ImportIssueComment adds a comment during import, preserving the original timestamp.
 // This prevents comment timestamp drift across import/export cycles.
+// Like AddComment, PartialWriteError means the SQL row already committed, so
+// callers must not blindly retry unless they also deduplicate imported
+// comments.
 func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
 	var result *types.Comment
 	err := s.withSerializedWrite(ctx, func() error {

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -13,19 +13,12 @@ import (
 // AddComment adds a comment event to an issue
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
 	return s.withSerializedWrite(ctx, func() error {
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("begin tx: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			return issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment)
+		}); err != nil {
 			return err
 		}
-		if err := tx.Commit(); err != nil {
-			return wrapTransactionError("commit add comment event", err)
-		}
-		return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: event %s", issueID))
+		return s.commitVersionedWrite(ctx, "add comment event", []string{"events"}, fmt.Sprintf("bd: event %s", issueID))
 	})
 }
 
@@ -72,7 +65,7 @@ func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, tex
 		if s.isActiveWisp(ctx, issueID) {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID))
+		return s.commitVersionedWrite(ctx, "import issue comment", []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID))
 	})
 	return result, err
 }

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -12,16 +12,21 @@ import (
 
 // AddComment adds a comment event to an issue
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin tx: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
-		return err
-	}
-	return tx.Commit()
+		if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit add comment event", err)
+		}
+		return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: event %s", issueID))
+	})
 }
 
 // GetEvents retrieves events for an issue
@@ -56,10 +61,18 @@ func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text s
 // This prevents comment timestamp drift across import/export cycles.
 func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
 	var result *types.Comment
-	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		var err error
-		result, err = issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
-		return err
+	err := s.withSerializedWrite(ctx, func() error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			result, err = issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
+			return err
+		}); err != nil {
+			return err
+		}
+		if s.isActiveWisp(ctx, issueID) {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID))
 	})
 	return result, err
 }

--- a/internal/storage/dolt/events_test.go
+++ b/internal/storage/dolt/events_test.go
@@ -1,11 +1,62 @@
 package dolt
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
+
+func newVersionedTestIssue(id, title string) *types.Issue {
+	return &types.Issue{
+		ID:        id,
+		Title:     title,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+}
+
+func stubVersionedWriteFailure(t *testing.T, store *DoltStore) {
+	t.Helper()
+
+	store.commitVersionedWriteFn = func(context.Context, []string, string) error {
+		return errors.New("history finalize failed")
+	}
+	t.Cleanup(func() {
+		store.commitVersionedWriteFn = nil
+	})
+}
+
+func requirePartialWriteError(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected partial write error")
+	}
+	var partialErr *PartialWriteError
+	if !errors.As(err, &partialErr) {
+		t.Fatalf("expected PartialWriteError, got %T", err)
+	}
+}
+
+func requireHeadChanged(t *testing.T, before, after string, action string) {
+	t.Helper()
+
+	if before == after {
+		t.Fatalf("expected %s to advance Dolt HEAD", action)
+	}
+}
+
+func requireHeadUnchanged(t *testing.T, before, after string, action string) {
+	t.Helper()
+
+	if before != after {
+		t.Fatalf("expected %s to leave Dolt HEAD unchanged", action)
+	}
+}
 
 // TestGetAllEventsSince_UnionBothTables verifies that GetAllEventsSince returns
 // events from both the events table (permanent issues) and wisp_events table
@@ -91,5 +142,149 @@ func TestGetAllEventsSince_EmptyStore(t *testing.T) {
 	}
 	if len(events) != 0 {
 		t.Errorf("expected 0 events from empty store, got %d", len(events))
+	}
+}
+
+func TestAddComment_CommitsPermanentIssueHistory(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := newVersionedTestIssue("comment-history-perm", "Permanent comment history")
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	before, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before add: %v", err)
+	}
+	if err := store.AddComment(ctx, issue.ID, "tester", "hello history"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	after, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after add: %v", err)
+	}
+	requireHeadChanged(t, before, after, "AddComment on permanent issue")
+}
+
+func TestAddComment_PartialWriteLeavesCommittedSQLState(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := newVersionedTestIssue("comment-partial", "Comment partial failure")
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	beforeHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before add: %v", err)
+	}
+	beforeEvents, err := store.GetEvents(ctx, issue.ID, 20)
+	if err != nil {
+		t.Fatalf("GetEvents before add: %v", err)
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	err = store.AddComment(ctx, issue.ID, "tester", "hello partial")
+	requirePartialWriteError(t, err)
+
+	afterHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after add: %v", err)
+	}
+	requireHeadUnchanged(t, beforeHead, afterHead, "partial AddComment")
+
+	afterEvents, err := store.GetEvents(ctx, issue.ID, 20)
+	if err != nil {
+		t.Fatalf("GetEvents after add: %v", err)
+	}
+	if len(afterEvents) != len(beforeEvents)+1 {
+		t.Fatalf("expected SQL event row to persist despite partial failure, before=%d after=%d", len(beforeEvents), len(afterEvents))
+	}
+}
+
+func TestImportIssueComment_HistoryBehaviorAndPartialFailure(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	permanent := newVersionedTestIssue("import-comment-perm", "Permanent imported comment")
+	wisp := &types.Issue{
+		ID:        "import-comment-wisp",
+		Title:     "Wisp imported comment",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	for _, issue := range []*types.Issue{permanent, wisp} {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+
+	beforePerm, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before permanent import: %v", err)
+	}
+	if _, err := store.ImportIssueComment(ctx, permanent.ID, "tester", "perm", time.Now().UTC()); err != nil {
+		t.Fatalf("ImportIssueComment permanent: %v", err)
+	}
+	afterPerm, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after permanent import: %v", err)
+	}
+	requireHeadChanged(t, beforePerm, afterPerm, "permanent ImportIssueComment")
+
+	beforeWisp, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before wisp import: %v", err)
+	}
+	if _, err := store.ImportIssueComment(ctx, wisp.ID, "tester", "wisp", time.Now().UTC()); err != nil {
+		t.Fatalf("ImportIssueComment wisp: %v", err)
+	}
+	afterWisp, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after wisp import: %v", err)
+	}
+	requireHeadUnchanged(t, beforeWisp, afterWisp, "wisp ImportIssueComment")
+
+	beforePartialHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before partial import: %v", err)
+	}
+	beforeComments, err := store.GetIssueComments(ctx, permanent.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments before partial import: %v", err)
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	_, err = store.ImportIssueComment(ctx, permanent.ID, "tester", "perm-partial", time.Now().UTC())
+	requirePartialWriteError(t, err)
+
+	afterPartialHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after partial import: %v", err)
+	}
+	requireHeadUnchanged(t, beforePartialHead, afterPartialHead, "partial ImportIssueComment")
+
+	afterComments, err := store.GetIssueComments(ctx, permanent.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments after partial import: %v", err)
+	}
+	if len(afterComments) != len(beforeComments)+1 {
+		t.Fatalf("expected SQL comment row to persist despite partial failure, before=%d after=%d", len(beforeComments), len(afterComments))
 	}
 }

--- a/internal/storage/dolt/events_test.go
+++ b/internal/storage/dolt/events_test.go
@@ -212,6 +212,42 @@ func TestAddComment_PartialWriteLeavesCommittedSQLState(t *testing.T) {
 	}
 }
 
+func TestAddComment_RetryAfterPartialWriteDuplicatesLogicalWrite(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := newVersionedTestIssue("comment-partial-retry", "Comment partial retry")
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	beforeEvents, err := store.GetEvents(ctx, issue.ID, 20)
+	if err != nil {
+		t.Fatalf("GetEvents before retry: %v", err)
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	err = store.AddComment(ctx, issue.ID, "tester", "retry me")
+	requirePartialWriteError(t, err)
+	store.commitVersionedWriteFn = nil
+
+	if err := store.AddComment(ctx, issue.ID, "tester", "retry me"); err != nil {
+		t.Fatalf("second AddComment: %v", err)
+	}
+
+	afterEvents, err := store.GetEvents(ctx, issue.ID, 20)
+	if err != nil {
+		t.Fatalf("GetEvents after retry: %v", err)
+	}
+	if len(afterEvents) != len(beforeEvents)+2 {
+		t.Fatalf("expected blind retry to append a second comment event, before=%d after=%d", len(beforeEvents), len(afterEvents))
+	}
+}
+
 func TestImportIssueComment_HistoryBehaviorAndPartialFailure(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -286,5 +322,45 @@ func TestImportIssueComment_HistoryBehaviorAndPartialFailure(t *testing.T) {
 	}
 	if len(afterComments) != len(beforeComments)+1 {
 		t.Fatalf("expected SQL comment row to persist despite partial failure, before=%d after=%d", len(beforeComments), len(afterComments))
+	}
+}
+
+func TestImportIssueComment_RetryAfterPartialWriteDuplicatesLogicalWrite(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := newVersionedTestIssue("import-comment-retry", "Import retry")
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	beforeComments, err := store.GetIssueComments(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments before retry: %v", err)
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	createdAt := time.Now().UTC()
+	if _, err := store.ImportIssueComment(ctx, issue.ID, "tester", "retry me", createdAt); err == nil {
+		t.Fatal("expected partial write error")
+	} else {
+		requirePartialWriteError(t, err)
+	}
+	store.commitVersionedWriteFn = nil
+
+	if _, err := store.ImportIssueComment(ctx, issue.ID, "tester", "retry me", createdAt); err != nil {
+		t.Fatalf("second ImportIssueComment: %v", err)
+	}
+
+	afterComments, err := store.GetIssueComments(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssueComments after retry: %v", err)
+	}
+	if len(afterComments) != len(beforeComments)+2 {
+		t.Fatalf("expected blind retry to append a second imported comment, before=%d after=%d", len(beforeComments), len(afterComments))
 	}
 }

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -159,6 +159,9 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 			return err
 		}
 		if _, hasStatus := updates["status"]; hasStatus {
+			// Cache invalidation follows the committed SQL status change. A later
+			// PartialWriteError means Dolt history repair is still needed, but the
+			// issue's blocker state has already changed for readers.
 			s.invalidateBlockedIDsCache()
 		}
 		return s.commitVersionedWrite(ctx, "update issue", []string{"issues", "events"}, fmt.Sprintf("bd: update %s", id))
@@ -181,6 +184,8 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 		if err := s.claimIssueSQL(ctx, id, actor); err != nil {
 			return err
 		}
+		// Cache should reflect the SQL-visible assignee/status change even if the
+		// follow-up Dolt history finalize needs later repair.
 		s.invalidateBlockedIDsCache()
 		return s.commitVersionedWrite(ctx, "claim issue", []string{"issues", "events"}, fmt.Sprintf("bd: claim %s", id))
 	})
@@ -225,6 +230,8 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 		if err := s.closeIssueSQL(ctx, id, reason, actor, session); err != nil {
 			return err
 		}
+		// Keep blocker cache aligned with committed SQL state rather than waiting
+		// for Dolt history finalize, which may surface as PartialWriteError.
 		s.invalidateBlockedIDsCache()
 		return s.commitVersionedWrite(ctx, "close issue", []string{"issues", "events"}, fmt.Sprintf("bd: close %s", id))
 	})
@@ -241,6 +248,8 @@ func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 		if err := s.deleteIssueSQL(ctx, id); err != nil {
 			return err
 		}
+		// Deletion is logically complete once SQL commits, so cache invalidation
+		// stays here even if versioned history repair is deferred.
 		s.invalidateBlockedIDsCache()
 		return s.commitVersionedWrite(
 			ctx,
@@ -316,6 +325,8 @@ func (s *DoltStore) DeleteIssues(ctx context.Context, ids []string, cascade bool
 		if dryRun {
 			return nil
 		}
+		// Bulk deletes follow the same rule as single deletes: cache tracks the
+		// SQL-visible result, while Dolt history repair can be retried separately.
 		s.invalidateBlockedIDsCache()
 		return s.commitVersionedWrite(
 			ctx,

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -27,28 +27,27 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 		issue.Ephemeral = true // infra types get marked ephemeral (legacy behavior)
 	}
 
-	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		// SkipPrefixValidation matches legacy behavior: single-issue path does
-		// not validate prefixes for explicit IDs.
-		bc, err := issueops.NewBatchContext(ctx, tx, storage.BatchCreateOptions{
-			SkipPrefixValidation: true,
-		})
-		if err != nil {
+	return s.withSerializedWrite(ctx, func() error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			bc, err := issueops.NewBatchContext(ctx, tx, storage.BatchCreateOptions{
+				SkipPrefixValidation: true,
+			})
+			if err != nil {
+				return err
+			}
+			return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
+		}); err != nil {
 			return err
 		}
-		return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
-	}); err != nil {
-		return err
-	}
 
-	// Dolt versioning — wisps and no-history issues skip DOLT_COMMIT.
-	if !issue.Ephemeral && !issue.NoHistory {
-		if err := s.doltAddAndCommit(ctx, []string{"issues", "events"},
-			fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
-			return err
+		if !issue.Ephemeral && !issue.NoHistory {
+			if err := s.doltAddAndCommit(ctx, []string{"issues", "events"},
+				fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
+				return err
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // CreateIssues creates multiple issues in a single transaction
@@ -66,36 +65,35 @@ func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*t
 		return nil
 	}
 
-	// All-wisps fast path: individual transactions, no Dolt versioning.
-	// Covers both ephemeral issues and no-history issues (both skip DOLT_COMMIT).
-	if issueops.AllWisps(issues) {
-		for _, issue := range issues {
-			if !issue.NoHistory {
-				issue.Ephemeral = true
-			}
-			if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-				bc, err := issueops.NewBatchContext(ctx, tx, opts)
-				if err != nil {
+	return s.withSerializedWrite(ctx, func() error {
+		if issueops.AllWisps(issues) {
+			for _, issue := range issues {
+				if !issue.NoHistory {
+					issue.Ephemeral = true
+				}
+				if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+					bc, err := issueops.NewBatchContext(ctx, tx, opts)
+					if err != nil {
+						return err
+					}
+					return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
+				}); err != nil {
 					return err
 				}
-				return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
-			}); err != nil {
-				return err
 			}
+			return nil
 		}
-		return nil
-	}
 
-	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		return issueops.CreateIssuesInTx(ctx, tx, issues, actor, opts)
-	}); err != nil {
-		return err
-	}
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			return issueops.CreateIssuesInTx(ctx, tx, issues, actor, opts)
+		}); err != nil {
+			return err
+		}
 
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	return s.doltAddAndCommit(ctx,
-		[]string{"issues", "events", "labels", "comments", "dependencies", "child_counters"},
-		fmt.Sprintf("bd: create %d issue(s)", len(issues)))
+		return s.doltAddAndCommit(ctx,
+			[]string{"issues", "events", "labels", "comments", "dependencies", "child_counters"},
+			fmt.Sprintf("bd: create %d issue(s)", len(issues)))
+	})
 }
 
 // GetIssue retrieves an issue by ID.
@@ -155,37 +153,36 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 		return s.DemoteToWisp(ctx, id, updates, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	result, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
-	if err != nil {
-		return err
-	}
+		result, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
+		if err != nil {
+			return err
+		}
 
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: update %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: update %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit update issue", err)
-	}
-	// Status changes affect the active set used by blocked ID computation
-	if _, hasStatus := updates["status"]; hasStatus {
-		s.invalidateBlockedIDsCache()
-	}
-	_ = result // OldIssue available if needed for future cache invalidation
-	return nil
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit update issue", err)
+		}
+		if _, hasStatus := updates["status"]; hasStatus {
+			s.invalidateBlockedIDsCache()
+		}
+		_ = result
+		return nil
+	})
 }
 
 // ClaimIssue atomically claims an issue using compare-and-swap semantics.
@@ -200,33 +197,32 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 		return s.claimWisp(ctx, id, actor)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
-		return err
-	}
+		if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
+			return err
+		}
 
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: claim %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: claim %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit claim issue", err)
-	}
-	// Claiming changes status to in_progress, affecting blocked ID computation
-	s.invalidateBlockedIDsCache()
-	return nil
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit claim issue", err)
+		}
+		s.invalidateBlockedIDsCache()
+		return nil
+	})
 }
 
 // ReopenIssue reopens a closed issue, setting status to open and clearing
@@ -264,33 +260,32 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 		return s.closeWisp(ctx, id, reason, actor, session)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
-		return err
-	}
+		if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
+			return err
+		}
 
-	// Dolt versioning for permanent issues.
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: close %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		for _, table := range []string{"issues", "events"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: close %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return wrapTransactionError("commit close issue", err)
-	}
-	// Closing changes the active set, which affects blocked ID computation (GH#1495)
-	s.invalidateBlockedIDsCache()
-	return nil
+		if err := tx.Commit(); err != nil {
+			return wrapTransactionError("commit close issue", err)
+		}
+		s.invalidateBlockedIDsCache()
+		return nil
+	})
 }
 
 // DeleteIssue permanently removes an issue
@@ -300,31 +295,32 @@ func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 		return s.deleteWisp(ctx, id)
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }() // No-op after successful commit
+	return s.withSerializedWrite(ctx, func() error {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
 
-	if err := issueops.DeleteIssueInTx(ctx, tx, id); err != nil {
-		return err
-	}
+		if err := issueops.DeleteIssueInTx(ctx, tx, id); err != nil {
+			return err
+		}
 
-	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: delete %s", id)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
+		for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: delete %s", id)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	s.invalidateBlockedIDsCache()
-	return nil
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		s.invalidateBlockedIDsCache()
+		return nil
+	})
 }
 
 // DeleteIssues deletes multiple issues in a single transaction.
@@ -377,43 +373,50 @@ func (s *DoltStore) DeleteIssues(ctx context.Context, ids []string, cascade bool
 		return &types.DeleteIssuesResult{DeletedCount: wispDeleteCount}, nil
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Delegate core logic (cascade/force/dryRun, stats, batch deletion) to issueops.
-	result, err := issueops.DeleteIssuesInTx(ctx, tx, ids, cascade, force, dryRun)
-	if err != nil {
-		// Preserve partial result (e.g., OrphanedIssues) on error.
-		if result != nil {
-			result.DeletedCount += wispDeleteCount
+	var result *types.DeleteIssuesResult
+	err := s.withSerializedWrite(ctx, func() error {
+		tx, txErr := s.db.BeginTx(ctx, nil)
+		if txErr != nil {
+			return fmt.Errorf("failed to begin transaction: %w", txErr)
 		}
-		return result, err
-	}
-	result.DeletedCount += wispDeleteCount
+		defer func() { _ = tx.Rollback() }()
 
-	if dryRun {
-		return result, nil
-	}
+		// Delegate core logic (cascade/force/dryRun, stats, batch deletion) to issueops.
+		var opErr error
+		result, opErr = issueops.DeleteIssuesInTx(ctx, tx, ids, cascade, force, dryRun)
+		if opErr != nil {
+			if result != nil {
+				result.DeletedCount += wispDeleteCount
+			}
+			return opErr
+		}
+		result.DeletedCount += wispDeleteCount
 
-	// GH#2455: Stage only the tables this operation modified, then commit
-	// without -A.
-	for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
-		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-	}
-	commitMsg := fmt.Sprintf("bd: delete %d issue(s)", result.DeletedCount-wispDeleteCount)
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-		return nil, fmt.Errorf("dolt commit: %w", err)
-	}
+		if dryRun {
+			return nil
+		}
 
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("failed to commit transaction: %w", err)
-	}
+		for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
+			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+		}
+		commitMsg := fmt.Sprintf("bd: delete %d issue(s)", result.DeletedCount-wispDeleteCount)
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+			return fmt.Errorf("dolt commit: %w", err)
+		}
 
-	s.invalidateBlockedIDsCache()
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit transaction: %w", err)
+		}
+		s.invalidateBlockedIDsCache()
+		return nil
+	})
+	if err != nil {
+		if result != nil {
+			return result, err
+		}
+		return nil, err
+	}
 	return result, nil
 }
 

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -41,7 +41,7 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 		}
 
 		if !issue.Ephemeral && !issue.NoHistory {
-			if err := s.doltAddAndCommit(ctx, []string{"issues", "events"},
+			if err := s.commitVersionedWrite(ctx, "create issue", []string{"issues", "events"},
 				fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
 				return err
 			}
@@ -90,7 +90,8 @@ func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*t
 			return err
 		}
 
-		return s.doltAddAndCommit(ctx,
+		return s.commitVersionedWrite(ctx,
+			"create issues",
 			[]string{"issues", "events", "labels", "comments", "dependencies", "child_counters"},
 			fmt.Sprintf("bd: create %d issue(s)", len(issues)))
 	})

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -155,34 +155,13 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 	}
 
 	return s.withSerializedWrite(ctx, func() error {
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		result, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
-		if err != nil {
+		if err := s.updateIssueSQL(ctx, id, updates, actor); err != nil {
 			return err
-		}
-
-		for _, table := range []string{"issues", "events"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: update %s", id)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-
-		if err := tx.Commit(); err != nil {
-			return wrapTransactionError("commit update issue", err)
 		}
 		if _, hasStatus := updates["status"]; hasStatus {
 			s.invalidateBlockedIDsCache()
 		}
-		_ = result
-		return nil
+		return s.commitVersionedWrite(ctx, "update issue", []string{"issues", "events"}, fmt.Sprintf("bd: update %s", id))
 	})
 }
 
@@ -199,30 +178,11 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 	}
 
 	return s.withSerializedWrite(ctx, func() error {
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		if _, err := issueops.ClaimIssueInTx(ctx, tx, id, actor); err != nil {
+		if err := s.claimIssueSQL(ctx, id, actor); err != nil {
 			return err
 		}
-
-		for _, table := range []string{"issues", "events"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: claim %s", id)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-
-		if err := tx.Commit(); err != nil {
-			return wrapTransactionError("commit claim issue", err)
-		}
 		s.invalidateBlockedIDsCache()
-		return nil
+		return s.commitVersionedWrite(ctx, "claim issue", []string{"issues", "events"}, fmt.Sprintf("bd: claim %s", id))
 	})
 }
 
@@ -262,30 +222,11 @@ func (s *DoltStore) CloseIssue(ctx context.Context, id string, reason string, ac
 	}
 
 	return s.withSerializedWrite(ctx, func() error {
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		if _, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session); err != nil {
+		if err := s.closeIssueSQL(ctx, id, reason, actor, session); err != nil {
 			return err
 		}
-
-		for _, table := range []string{"issues", "events"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: close %s", id)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-
-		if err := tx.Commit(); err != nil {
-			return wrapTransactionError("commit close issue", err)
-		}
 		s.invalidateBlockedIDsCache()
-		return nil
+		return s.commitVersionedWrite(ctx, "close issue", []string{"issues", "events"}, fmt.Sprintf("bd: close %s", id))
 	})
 }
 
@@ -297,30 +238,16 @@ func (s *DoltStore) DeleteIssue(ctx context.Context, id string) error {
 	}
 
 	return s.withSerializedWrite(ctx, func() error {
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return fmt.Errorf("failed to begin transaction: %w", err)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		if err := issueops.DeleteIssueInTx(ctx, tx, id); err != nil {
-			return err
-		}
-
-		for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: delete %s", id)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-
-		if err := tx.Commit(); err != nil {
+		if err := s.deleteIssueSQL(ctx, id); err != nil {
 			return err
 		}
 		s.invalidateBlockedIDsCache()
-		return nil
+		return s.commitVersionedWrite(
+			ctx,
+			"delete issue",
+			[]string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"},
+			fmt.Sprintf("bd: delete %s", id),
+		)
 	})
 }
 
@@ -376,41 +303,26 @@ func (s *DoltStore) DeleteIssues(ctx context.Context, ids []string, cascade bool
 
 	var result *types.DeleteIssuesResult
 	err := s.withSerializedWrite(ctx, func() error {
-		tx, txErr := s.db.BeginTx(ctx, nil)
-		if txErr != nil {
-			return fmt.Errorf("failed to begin transaction: %w", txErr)
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		// Delegate core logic (cascade/force/dryRun, stats, batch deletion) to issueops.
-		var opErr error
-		result, opErr = issueops.DeleteIssuesInTx(ctx, tx, ids, cascade, force, dryRun)
-		if opErr != nil {
+		var err error
+		result, err = s.deleteIssuesSQL(ctx, ids, cascade, force, dryRun)
+		if err != nil {
 			if result != nil {
 				result.DeletedCount += wispDeleteCount
 			}
-			return opErr
+			return err
 		}
 		result.DeletedCount += wispDeleteCount
 
 		if dryRun {
 			return nil
 		}
-
-		for _, table := range []string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: delete %d issue(s)", result.DeletedCount-wispDeleteCount)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit: %w", err)
-		}
-
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("failed to commit transaction: %w", err)
-		}
 		s.invalidateBlockedIDsCache()
-		return nil
+		return s.commitVersionedWrite(
+			ctx,
+			"delete issues",
+			[]string{"issues", "dependencies", "labels", "comments", "events", "child_counters", "issue_snapshots", "compaction_snapshots"},
+			fmt.Sprintf("bd: delete %d issue(s)", result.DeletedCount-wispDeleteCount),
+		)
 	})
 	if err != nil {
 		if result != nil {
@@ -430,6 +342,43 @@ func doltBuildSQLInClause(ids []string) (string, []interface{}) {
 		args[i] = id
 	}
 	return strings.Join(placeholders, ","), args
+}
+
+func (s *DoltStore) updateIssueSQL(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+		_, err := issueops.UpdateIssueInTx(ctx, tx, id, updates, actor)
+		return err
+	})
+}
+
+func (s *DoltStore) claimIssueSQL(ctx context.Context, id string, actor string) error {
+	return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+		_, err := issueops.ClaimIssueInTx(ctx, tx, id, actor)
+		return err
+	})
+}
+
+func (s *DoltStore) closeIssueSQL(ctx context.Context, id string, reason string, actor string, session string) error {
+	return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+		_, err := issueops.CloseIssueInTx(ctx, tx, id, reason, actor, session)
+		return err
+	})
+}
+
+func (s *DoltStore) deleteIssueSQL(ctx context.Context, id string) error {
+	return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+		return issueops.DeleteIssueInTx(ctx, tx, id)
+	})
+}
+
+func (s *DoltStore) deleteIssuesSQL(ctx context.Context, ids []string, cascade bool, force bool, dryRun bool) (*types.DeleteIssuesResult, error) {
+	var result *types.DeleteIssuesResult
+	err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.DeleteIssuesInTx(ctx, tx, ids, cascade, force, dryRun)
+		return err
+	})
+	return result, err
 }
 
 // =============================================================================

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
@@ -11,9 +12,15 @@ import (
 // AddLabel adds a label to an issue
 func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
 	return s.withSerializedWrite(ctx, func() error {
-		return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
 			return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
-		})
+		}); err != nil {
+			return err
+		}
+		if s.isActiveWisp(ctx, issueID) {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"labels", "events"}, fmt.Sprintf("bd: label add %s", issueID))
 	})
 }
 
@@ -21,9 +28,15 @@ func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) 
 // Delegates SQL work to issueops.RemoveLabelInTx which handles wisp routing.
 func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
 	return s.withSerializedWrite(ctx, func() error {
-		return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+		if err := s.withWriteTx(ctx, func(tx *sql.Tx) error {
 			return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
-		})
+		}); err != nil {
+			return err
+		}
+		if s.isActiveWisp(ctx, issueID) {
+			return nil
+		}
+		return s.doltAddAndCommit(ctx, []string{"labels", "events"}, fmt.Sprintf("bd: label remove %s", issueID))
 	})
 }
 

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -10,16 +10,20 @@ import (
 
 // AddLabel adds a label to an issue
 func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+	return s.withSerializedWrite(ctx, func() error {
+		return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		})
 	})
 }
 
 // RemoveLabel removes a label from an issue.
 // Delegates SQL work to issueops.RemoveLabelInTx which handles wisp routing.
 func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+	return s.withSerializedWrite(ctx, func() error {
+		return s.withWriteTx(ctx, func(tx *sql.Tx) error {
+			return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
+		})
 	})
 }
 

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -20,7 +20,7 @@ func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) 
 		if s.isActiveWisp(ctx, issueID) {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"labels", "events"}, fmt.Sprintf("bd: label add %s", issueID))
+		return s.commitVersionedWrite(ctx, "add label", []string{"labels", "events"}, fmt.Sprintf("bd: label add %s", issueID))
 	})
 }
 
@@ -36,7 +36,7 @@ func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor strin
 		if s.isActiveWisp(ctx, issueID) {
 			return nil
 		}
-		return s.doltAddAndCommit(ctx, []string{"labels", "events"}, fmt.Sprintf("bd: label remove %s", issueID))
+		return s.commitVersionedWrite(ctx, "remove label", []string{"labels", "events"}, fmt.Sprintf("bd: label remove %s", issueID))
 	})
 }
 

--- a/internal/storage/dolt/labels_test.go
+++ b/internal/storage/dolt/labels_test.go
@@ -224,13 +224,7 @@ func TestAddLabel_CommitsPermanentIssueHistory(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	issue := &types.Issue{
-		ID:        "label-history-perm",
-		Title:     "Permanent label history",
-		Status:    types.StatusOpen,
-		Priority:  2,
-		IssueType: types.TypeTask,
-	}
+	issue := newVersionedTestIssue("label-history-perm", "Permanent label history")
 	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
 		t.Fatalf("failed to create issue: %v", err)
 	}
@@ -246,9 +240,7 @@ func TestAddLabel_CommitsPermanentIssueHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetCurrentCommit after add: %v", err)
 	}
-	if before == afterAdd {
-		t.Fatal("expected AddLabel on permanent issue to advance Dolt HEAD")
-	}
+	requireHeadChanged(t, before, afterAdd, "AddLabel on permanent issue")
 
 	if err := store.RemoveLabel(ctx, issue.ID, "history-check", "tester"); err != nil {
 		t.Fatalf("failed to remove label: %v", err)
@@ -257,9 +249,7 @@ func TestAddLabel_CommitsPermanentIssueHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetCurrentCommit after remove: %v", err)
 	}
-	if afterAdd == afterRemove {
-		t.Fatal("expected RemoveLabel on permanent issue to advance Dolt HEAD")
-	}
+	requireHeadChanged(t, afterAdd, afterRemove, "RemoveLabel on permanent issue")
 }
 
 func TestAddLabel_SkipsDoltCommitForWisp(t *testing.T) {
@@ -340,5 +330,48 @@ func TestAddLabel_Duplicate(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected exactly 1 instance of 'duplicate' label, got %d", count)
+	}
+}
+
+func TestAddLabel_PartialWriteLeavesCommittedSQLState(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "label-partial",
+		Title:     "Label partial failure",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	beforeHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before add: %v", err)
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	err = store.AddLabel(ctx, issue.ID, "partial", "tester")
+	requirePartialWriteError(t, err)
+
+	afterHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after add: %v", err)
+	}
+	requireHeadUnchanged(t, beforeHead, afterHead, "partial AddLabel")
+
+	labels, err := store.GetLabels(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetLabels after add: %v", err)
+	}
+	if len(labels) != 1 || labels[0] != "partial" {
+		t.Fatalf("expected SQL label row to persist despite partial failure, got %v", labels)
 	}
 }

--- a/internal/storage/dolt/labels_test.go
+++ b/internal/storage/dolt/labels_test.go
@@ -217,6 +217,87 @@ func TestAddAndRemoveLabel(t *testing.T) {
 	}
 }
 
+func TestAddLabel_CommitsPermanentIssueHistory(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "label-history-perm",
+		Title:     "Permanent label history",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("failed to create issue: %v", err)
+	}
+
+	before, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before add: %v", err)
+	}
+	if err := store.AddLabel(ctx, issue.ID, "history-check", "tester"); err != nil {
+		t.Fatalf("failed to add label: %v", err)
+	}
+	afterAdd, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after add: %v", err)
+	}
+	if before == afterAdd {
+		t.Fatal("expected AddLabel on permanent issue to advance Dolt HEAD")
+	}
+
+	if err := store.RemoveLabel(ctx, issue.ID, "history-check", "tester"); err != nil {
+		t.Fatalf("failed to remove label: %v", err)
+	}
+	afterRemove, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after remove: %v", err)
+	}
+	if afterAdd == afterRemove {
+		t.Fatal("expected RemoveLabel on permanent issue to advance Dolt HEAD")
+	}
+}
+
+func TestAddLabel_SkipsDoltCommitForWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "label-history-wisp",
+		Title:       "Wisp label history",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+		Ephemeral:   true,
+		Description: "wisp labels should remain no-history",
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("failed to create wisp: %v", err)
+	}
+
+	before, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before add: %v", err)
+	}
+	if err := store.AddLabel(ctx, issue.ID, "history-check", "tester"); err != nil {
+		t.Fatalf("failed to add label to wisp: %v", err)
+	}
+	after, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after add: %v", err)
+	}
+	if before != after {
+		t.Fatal("expected AddLabel on wisp to skip Dolt commit")
+	}
+}
+
 func TestAddLabel_Duplicate(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
 )
 
 func TestIsRetryableError(t *testing.T) {
@@ -178,6 +180,86 @@ func TestWithRetry_NonRetryableError(t *testing.T) {
 
 	if err == nil {
 		t.Error("expected error, got nil")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 call for non-retryable error, got %d", callCount)
+	}
+}
+
+func TestIsRetryableWriteError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "database is locked",
+			err:      errors.New("database is locked"),
+			expected: true,
+		},
+		{
+			name:     "serialization error",
+			err:      &mysql.MySQLError{Number: 1213, Message: "deadlock found when trying to get lock"},
+			expected: true,
+		},
+		{
+			name:     "database is read only",
+			err:      errors.New("cannot update manifest: database is read only"),
+			expected: true,
+		},
+		{
+			name:     "write lock timeout",
+			err:      errors.New("failed to acquire write lock: timeout after 2s"),
+			expected: true,
+		},
+		{
+			name:     "syntax error",
+			err:      errors.New("syntax error in SQL"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryableWriteError(tt.err)
+			if got != tt.expected {
+				t.Errorf("isRetryableWriteError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWithWriteRetry_RetryableError(t *testing.T) {
+	store := &DoltStore{}
+
+	callCount := 0
+	err := store.withWriteRetry(context.Background(), func() error {
+		callCount++
+		if callCount < 3 {
+			return errors.New("database is locked")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("expected 3 calls (2 retries + success), got %d", callCount)
+	}
+}
+
+func TestWithWriteRetry_NonRetryableError(t *testing.T) {
+	store := &DoltStore{}
+
+	callCount := 0
+	err := store.withWriteRetry(context.Background(), func() error {
+		callCount++
+		return errors.New("validation failed")
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
 	if callCount != 1 {
 		t.Errorf("expected 1 call for non-retryable error, got %d", callCount)

--- a/internal/storage/dolt/retry_test.go
+++ b/internal/storage/dolt/retry_test.go
@@ -2,7 +2,11 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -263,5 +267,81 @@ func TestWithWriteRetry_NonRetryableError(t *testing.T) {
 	}
 	if callCount != 1 {
 		t.Errorf("expected 1 call for non-retryable error, got %d", callCount)
+	}
+}
+
+func TestWithSerializedWrite_SkipsLockOutsideServerMode(t *testing.T) {
+	store := &DoltStore{serverMode: false}
+
+	called := false
+	err := store.withSerializedWrite(context.Background(), func() error {
+		called = true
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("withSerializedWrite returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected callback to run without server-mode lock")
+	}
+}
+
+func TestCommitVersionedWrite_WrapsPartialWriteError(t *testing.T) {
+	store := &DoltStore{
+		commitVersionedWriteFn: func(context.Context, []string, string) error {
+			return errors.New("commit failed")
+		},
+	}
+
+	err := store.commitVersionedWrite(context.Background(), "add label", []string{"labels"}, "bd: label add test-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var partialErr *PartialWriteError
+	if !errors.As(err, &partialErr) {
+		t.Fatalf("expected PartialWriteError, got %T", err)
+	}
+	if partialErr.Operation != "add label" {
+		t.Fatalf("expected operation to be recorded, got %q", partialErr.Operation)
+	}
+	if !strings.Contains(partialErr.Error(), "SQL write committed but Dolt history commit failed") {
+		t.Fatalf("expected repairable-state wording, got %q", partialErr.Error())
+	}
+}
+
+func TestReleaseServerWriteLock_LogsWarningOnFailure(t *testing.T) {
+	store := &DoltStore{
+		releaseServerWriteLockFn: func(context.Context, *sql.Conn, string) error {
+			return errors.New("release failed")
+		},
+	}
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = origStderr
+	})
+
+	store.releaseServerWriteLock(context.Background(), nil, "bd_write_testdb")
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close write pipe: %v", err)
+	}
+	output, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close read pipe: %v", err)
+	}
+
+	if !strings.Contains(string(output), `failed to release write lock "bd_write_testdb"`) {
+		t.Fatalf("expected release warning, got %q", string(output))
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -445,8 +445,9 @@ func (s *DoltStore) versionedWriteLockIdentity() string {
 	// each project gets its own Dolt database, and cross-project mismatches
 	// are rejected during verifyProjectIdentity. Prefer it for process-wide
 	// write serialization so all clients touching the same shared database
-	// contend on the same advisory lock. Fall back to local paths only when
-	// tests construct a store without a configured database.
+	// contend on the same advisory lock even when they come from different
+	// worktrees or store instances. Fall back to local paths only when tests
+	// construct a store without a configured database.
 	if s.database != "" {
 		return "db:" + s.database
 	}
@@ -547,7 +548,9 @@ func (s *DoltStore) withSerializedWrite(ctx context.Context, fn func() error) er
 // PartialWriteError reports the shared-server repairable state where SQL
 // changes committed successfully but the follow-up Dolt history commit failed.
 // Callers should assume the logical write took effect and the working set may
-// require a later repair/commit to restore versioned history.
+// require a later repair/commit to restore versioned history. Blind retries are
+// only safe for write paths that are idempotent at the SQL layer; non-idempotent
+// operations such as comment insertion may duplicate logical effects if replayed.
 type PartialWriteError struct {
 	Operation string
 	Err       error

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -195,6 +195,10 @@ type DoltStore struct {
 	// auto-start. Close() uses it to stop the server when the last store
 	// referencing it is closed (tracked via autoStartRefs).
 	autoStartedServerDir string
+
+	// Test-only hooks for write-finalization behavior. Nil in production.
+	commitVersionedWriteFn   func(context.Context, []string, string) error
+	releaseServerWriteLockFn func(context.Context, *sql.Conn, string) error
 }
 
 // Config holds Dolt database configuration
@@ -403,11 +407,12 @@ func isRetryableWriteError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if isRetryableError(err) || isLockError(err) || isSerializationError(err) {
+	if isLockError(err) || isSerializationError(err) {
 		return true
 	}
 	errStr := strings.ToLower(err.Error())
-	return strings.Contains(errStr, "failed to acquire write lock")
+	return strings.Contains(errStr, "failed to acquire write lock") ||
+		strings.Contains(errStr, "database is read only")
 }
 
 func writeLockName(database string) string {
@@ -435,8 +440,51 @@ func writeLockName(database string) string {
 	return prefix + strconv.FormatUint(h.Sum64(), 16)
 }
 
+func (s *DoltStore) versionedWriteLockIdentity() string {
+	// In shared-server mode the database name is the project identity:
+	// each project gets its own Dolt database, and cross-project mismatches
+	// are rejected during verifyProjectIdentity. Prefer it for process-wide
+	// write serialization so all clients touching the same shared database
+	// contend on the same advisory lock. Fall back to local paths only when
+	// tests construct a store without a configured database.
+	if s.database != "" {
+		return "db:" + s.database
+	}
+	if s.beadsDir != "" {
+		return "beads:" + filepath.Clean(s.beadsDir)
+	}
+	if s.dbPath != "" {
+		return "path:" + filepath.Clean(s.dbPath)
+	}
+	return "default"
+}
+
 func (s *DoltStore) serverWriteLockName() string {
-	return writeLockName(s.database)
+	return writeLockName(s.versionedWriteLockIdentity())
+}
+
+func defaultReleaseServerWriteLock(ctx context.Context, conn *sql.Conn, lockName string) error {
+	if conn == nil {
+		return fmt.Errorf("release write lock %q: nil connection", lockName)
+	}
+	var released sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released); err != nil {
+		return err
+	}
+	if !released.Valid || released.Int64 != 1 {
+		return fmt.Errorf("lock %q was not released cleanly", lockName)
+	}
+	return nil
+}
+
+func (s *DoltStore) releaseServerWriteLock(ctx context.Context, conn *sql.Conn, lockName string) {
+	releaseFn := s.releaseServerWriteLockFn
+	if releaseFn == nil {
+		releaseFn = defaultReleaseServerWriteLock
+	}
+	if err := releaseFn(ctx, conn, lockName); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to release write lock %q: %v\n", lockName, err)
+	}
 }
 
 func (s *DoltStore) withServerWriteLock(ctx context.Context, fn func() error) error {
@@ -456,7 +504,12 @@ func (s *DoltStore) withServerWriteLock(ctx context.Context, fn func() error) er
 	if locked != 1 {
 		return fmt.Errorf("failed to acquire write lock: timeout after %s (another process holds it)", serverWriteLockWait)
 	}
-	defer conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", s.serverWriteLockName()) //nolint:errcheck
+	lockName := s.serverWriteLockName()
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		s.releaseServerWriteLock(releaseCtx, conn, lockName)
+	}()
 
 	return fn()
 }
@@ -482,12 +535,48 @@ func (s *DoltStore) withWriteRetry(ctx context.Context, op func() error) error {
 }
 
 func (s *DoltStore) withSerializedWrite(ctx context.Context, fn func() error) error {
+	// Shared-server mode is the only place we need cross-process advisory
+	// locking. Embedded mode relies on the local Dolt/OS locking model and
+	// intentionally skips GET_LOCK-based serialization.
 	if !s.serverMode {
 		return fn()
 	}
-	return wrapLockError(s.withWriteRetry(ctx, func() error {
-		return s.withServerWriteLock(ctx, fn)
-	}))
+	return wrapLockError(s.withServerWriteLock(ctx, fn))
+}
+
+// PartialWriteError reports the shared-server repairable state where SQL
+// changes committed successfully but the follow-up Dolt history commit failed.
+// Callers should assume the logical write took effect and the working set may
+// require a later repair/commit to restore versioned history.
+type PartialWriteError struct {
+	Operation string
+	Err       error
+}
+
+func (e *PartialWriteError) Error() string {
+	return fmt.Sprintf("%s: SQL write committed but Dolt history commit failed: %v", e.Operation, e.Err)
+}
+
+func (e *PartialWriteError) Unwrap() error {
+	return e.Err
+}
+
+func (s *DoltStore) commitVersionedWrite(ctx context.Context, operation string, tables []string, commitMsg string) error {
+	// Only the Dolt history finalize step is retried. The SQL write has already
+	// committed by the time this helper runs, so retrying the whole operation
+	// would risk duplicating user-visible side effects.
+	commitFn := s.commitVersionedWriteFn
+	if commitFn == nil {
+		commitFn = func(ctx context.Context, tables []string, commitMsg string) error {
+			return s.doltAddAndCommit(ctx, tables, commitMsg)
+		}
+	}
+	if err := s.withWriteRetry(ctx, func() error {
+		return commitFn(ctx, tables, commitMsg)
+	}); err != nil {
+		return &PartialWriteError{Operation: operation, Err: err}
+	}
+	return nil
 }
 
 // withRetry executes an operation with retry for transient errors.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -550,7 +550,8 @@ func (s *DoltStore) withSerializedWrite(ctx context.Context, fn func() error) er
 // Callers should assume the logical write took effect and the working set may
 // require a later repair/commit to restore versioned history. Blind retries are
 // only safe for write paths that are idempotent at the SQL layer; non-idempotent
-// operations such as comment insertion may duplicate logical effects if replayed.
+// operations such as comment or event insertion may duplicate logical effects
+// if replayed.
 type PartialWriteError struct {
 	Operation string
 	Err       error

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -254,9 +254,21 @@ const cliExecTimeout = 5 * time.Minute
 // brief network issues, server restarts).
 const serverRetryMaxElapsed = 30 * time.Second
 
+// Write serialization configuration for shared-server mode.
+const serverWriteRetryMaxElapsed = 12 * time.Second
+const serverWriteLockWait = 2 * time.Second
+
 func newServerRetryBackoff() backoff.BackOff {
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = serverRetryMaxElapsed
+	return bo
+}
+
+func newServerWriteRetryBackoff() backoff.BackOff {
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 100 * time.Millisecond
+	bo.MaxInterval = time.Second
+	bo.MaxElapsedTime = serverWriteRetryMaxElapsed
 	return bo
 }
 
@@ -385,6 +397,97 @@ func lockProcessHint() string {
 		return fmt.Sprintf(" Process %s (bd/dolt) may be holding the lock.", holders[0])
 	}
 	return fmt.Sprintf(" Processes %s (bd/dolt) may be holding the lock.", strings.Join(holders, ", "))
+}
+
+func isRetryableWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isRetryableError(err) || isLockError(err) || isSerializationError(err) {
+		return true
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "failed to acquire write lock")
+}
+
+func writeLockName(database string) string {
+	const prefix = "bd_write_"
+	if database == "" {
+		database = "default"
+	}
+	var b strings.Builder
+	b.Grow(len(prefix) + len(database))
+	b.WriteString(prefix)
+	for _, r := range database {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-', r == ':':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	name := b.String()
+	if len(name) <= 64 {
+		return name
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(database))
+	return prefix + strconv.FormatUint(h.Sum64(), 16)
+}
+
+func (s *DoltStore) serverWriteLockName() string {
+	return writeLockName(s.database)
+}
+
+func (s *DoltStore) withServerWriteLock(ctx context.Context, fn func() error) error {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection for write lock: %w", err)
+	}
+	defer conn.Close()
+
+	start := time.Now()
+	var locked int
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", s.serverWriteLockName(), int(serverWriteLockWait/time.Second)).Scan(&locked); err != nil {
+		doltMetrics.lockWaitMs.Record(ctx, float64(time.Since(start).Milliseconds()))
+		return fmt.Errorf("failed to acquire write lock: %w", err)
+	}
+	doltMetrics.lockWaitMs.Record(ctx, float64(time.Since(start).Milliseconds()))
+	if locked != 1 {
+		return fmt.Errorf("failed to acquire write lock: timeout after %s (another process holds it)", serverWriteLockWait)
+	}
+	defer conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", s.serverWriteLockName()) //nolint:errcheck
+
+	return fn()
+}
+
+func (s *DoltStore) withWriteRetry(ctx context.Context, op func() error) error {
+	attempts := 0
+	bo := newServerWriteRetryBackoff()
+	err := backoff.Retry(func() error {
+		attempts++
+		err := op()
+		if err != nil && isRetryableWriteError(err) {
+			return err
+		}
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		return nil
+	}, backoff.WithContext(bo, ctx))
+	if attempts > 1 {
+		doltMetrics.retryCount.Add(ctx, int64(attempts-1))
+	}
+	return err
+}
+
+func (s *DoltStore) withSerializedWrite(ctx context.Context, fn func() error) error {
+	if !s.serverMode {
+		return fn()
+	}
+	return wrapLockError(s.withWriteRetry(ctx, func() error {
+		return s.withServerWriteLock(ctx, fn)
+	}))
 }
 
 // withRetry executes an operation with retry for transient errors.

--- a/internal/storage/dolt/versioned_test.go
+++ b/internal/storage/dolt/versioned_test.go
@@ -1,6 +1,7 @@
 package dolt
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -166,4 +167,78 @@ func TestCommitPending(t *testing.T) {
 			t.Fatalf("cleanup commit failed: %v", err)
 		}
 	})
+}
+
+func TestUpdateIssue_PartialWriteLeavesCommittedSQLState(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := newVersionedTestIssue("update-partial", "Update partial write")
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	beforeHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before update: %v", err)
+	}
+
+	stubVersionedWriteFailure(t, store)
+
+	err = store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"title": "Updated title"}, "tester")
+	requirePartialWriteError(t, err)
+
+	afterHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after update: %v", err)
+	}
+	requireHeadUnchanged(t, beforeHead, afterHead, "partial UpdateIssue")
+
+	updated, err := store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssue after partial update: %v", err)
+	}
+	if updated.Title != "Updated title" {
+		t.Fatalf("expected SQL issue row to persist despite partial failure, got title %q", updated.Title)
+	}
+}
+
+func TestUpdateIssue_CommitsPermanentIssueHistory(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := newVersionedTestIssue("update-history", "Update history")
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	beforeHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit before update: %v", err)
+	}
+	if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"title": "Updated title"}, "tester"); err != nil {
+		t.Fatalf("UpdateIssue: %v", err)
+	}
+	afterHead, err := store.GetCurrentCommit(ctx)
+	if err != nil {
+		t.Fatalf("GetCurrentCommit after update: %v", err)
+	}
+	requireHeadChanged(t, beforeHead, afterHead, "UpdateIssue")
+}
+
+func TestPartialWriteError_Unwrap(t *testing.T) {
+	root := errors.New("boom")
+	err := &PartialWriteError{Operation: "update issue", Err: root}
+	if !errors.Is(err, root) {
+		t.Fatal("expected PartialWriteError to unwrap to underlying error")
+	}
+	if !strings.Contains(err.Error(), "update issue") {
+		t.Fatalf("expected operation in error string, got %q", err.Error())
+	}
 }


### PR DESCRIPTION
## Problem
- shared-server mode still allowed multiple `bd` processes to overlap around Dolt write finalization, so callers could fail even though the underlying logical write should have been serialized
- lock acquisition retry was silent, which made long waits look like hangs to agents and invited unsafe fallback behavior
- some write paths were still outside the hardened partial-write flow, especially demotion to wisps and comment events on wisps
- delete previews were still routed through the shared write-lock path even when `--dry-run` only needed read-only statistics

## What Changed
- serialize shared-server writes behind the server advisory lock, and retry lock acquisition itself instead of failing immediately when another process holds it slightly longer than the initial wait
- emit short stderr wait hints while a process is retrying for the shared-server write lock, with rate limiting so contention is visible without becoming noisy
- keep SQL writes and Dolt history finalization separated behind `PartialWriteError`, so the repairable state is explicitly "SQL committed, history finalize failed"
- align permanent issue mutations with that contract, including the `no_history` / `wisp` demotion path
- skip versioned finalize for wisp comment events, because those writes only touch `dolt_ignored` tables and should not surface false partial-write failures
- route `DeleteIssues(..., dryRun=true)` through a read-only transaction so delete previews do not take the shared write lock or log write-wait hints
- add cross-store concurrency coverage plus partial-write / idempotency coverage for both idempotent and non-idempotent write paths, including the lock-wait visibility and dry-run preview cases

## Why This Is Good
- parallel `bd` usage from multiple agents or processes is much less likely to fail due to shared Dolt write contention
- long shared-server lock waits are now observable on stderr, so a waiting process looks busy rather than hung
- retry behavior is safer and easier to reason about: idempotent paths can recover, while non-idempotent paths surface a repairable partial-write state instead of encouraging blind retries
- `no_history` / wisp transitions now follow the same hardened write pipeline as the rest of the permanent issue mutations
- wisp comment writes no longer report bogus Dolt finalize failures for changes that never touched versioned tables
- delete dry-run previews stay read-only, so operator planning commands do not queue behind unrelated writers
