### PR TITLE
docs: add ICU regex policy and update build deps (GH-3126)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ Thank you for your interest in contributing to bd! This document provides guidel
 
 - Go 1.24 or later
 - Git
+- A C compiler (CGO is required for the embedded Dolt database)
 - (Optional) golangci-lint for local linting
+- ICU headers are **not required** for building -- see [docs/ICU-POLICY.md](docs/ICU-POLICY.md)
 
 ### Getting Started
 
@@ -17,8 +19,8 @@ Thank you for your interest in contributing to bd! This document provides guidel
 git clone https://github.com/steveyegge/beads
 cd beads
 
-# Build the project
-go build -o bd ./cmd/bd
+# Build the project (uses gms_pure_go tag via Makefile)
+make build
 
 # Run tests
 go test ./...
@@ -27,7 +29,7 @@ go test ./...
 go test -race ./...
 
 # Build and install locally
-go install ./cmd/bd
+make install
 ```
 
 ## Project Structure
@@ -192,7 +194,13 @@ make test-full-cgo            # or: ./scripts/test-cgo.sh ./...
 ./scripts/test-cgo.sh -run '^TestMyFeature$' ./cmd/bd/...
 ```
 
-On macOS, always use the script or Make target for CGO tests — they configure the required ICU linker flags automatically.
+On macOS, always use the script or Make target for CGO tests -- they configure the required ICU linker flags automatically.
+
+### ICU and Build Tags
+
+All production builds use `-tags gms_pure_go` to avoid ICU runtime dependencies.
+**Do not add ICU linker flags to the Makefile or `.buildflags`.**
+See [docs/ICU-POLICY.md](docs/ICU-POLICY.md) for the full policy and rationale.
 
 ### Test Isolation with `t.TempDir()`
 

--- a/docs/ICU-POLICY.md
+++ b/docs/ICU-POLICY.md
@@ -1,0 +1,115 @@
+# ICU Regex Policy
+
+## The Rule
+
+**`bd` never ships with an ICU runtime dependency. All release binaries use
+Go's stdlib `regexp` via the `gms_pure_go` build tag.**
+
+This is non-negotiable. Do not remove, conditionally skip, or override
+`gms_pure_go` in any build target, release workflow, or install script.
+
+## Background
+
+ICU (International Components for Unicode) is a C library that provides
+MySQL-compatible regex via `go-icu-regex`. It enters our dependency tree
+through `go-mysql-server` (the embedded Dolt SQL engine). `bd` does not
+use SQL `REGEXP` functions, so ICU provides zero functional value while
+creating significant portability problems:
+
+| Platform | Problem without `gms_pure_go` |
+|----------|-------------------------------|
+| Linux | Binaries dynamically link a specific `libicui18n.so.NN` version; crash on distros with a different ICU version |
+| macOS | ICU is keg-only in Homebrew; `go install` fails without manual `CGO_CFLAGS`/`CGO_LDFLAGS` |
+| Windows | ICU C headers (`unicode/uregex.h`) not available; `go install` and CGO builds fail |
+| `go install` | Users cannot pass `-tags gms_pure_go` to `go install pkg@latest` |
+
+## How It Works
+
+```
+go-mysql-server
+  ├── (default)      → go-icu-regex → links libicu (BAD)
+  └── gms_pure_go    → Go stdlib regexp (GOOD)
+```
+
+The `gms_pure_go` build tag tells `go-mysql-server` to use Go's `regexp`
+package instead of `go-icu-regex`. This eliminates the ICU shared-library
+dependency at the binary level.
+
+**CGO stays enabled.** CGO is required for the embedded Dolt database
+(file locking, SQL engine). CGO and ICU are independent concerns:
+
+- `CGO_ENABLED=1` + `gms_pure_go` = Dolt works, no ICU (what we ship)
+- `CGO_ENABLED=1` without `gms_pure_go` = Dolt works, ICU linked (test-only)
+- `CGO_ENABLED=0` = no Dolt backend at all
+
+## Where `gms_pure_go` Must Be Set
+
+Every build path that produces a binary for users must include `-tags gms_pure_go`:
+
+| Location | File |
+|----------|------|
+| Local builds | `Makefile` (`BUILD_TAGS := gms_pure_go`) |
+| Release builds | `.goreleaser.yml` (all build targets) |
+| Install script | `scripts/install.sh` |
+| Windows installer | `install.ps1` |
+| CI (Windows) | `.github/workflows/ci.yml` |
+| macOS release | `.github/workflows/release.yml` |
+| Migration tests | `.github/workflows/migration-test.yml` |
+
+## Where `gms_pure_go` Is Intentionally Omitted
+
+The CI test matrix and `scripts/test-cgo.sh` omit `gms_pure_go` to exercise
+the ICU code path in `go-mysql-server`. This ensures we don't ship bugs
+in the upstream ICU integration even though our release binaries don't use it.
+
+These test environments install ICU headers explicitly:
+- Linux CI: `sudo apt-get install -y libicu-dev`
+- macOS CI: `brew install icu4c` + CGO flag exports
+
+## Post-Build Verification
+
+Release builds are verified to be ICU-free:
+
+- **Linux**: `readelf -d` and `ldd` check for `libicu` (must not appear)
+- **macOS**: `otool -L` check for `libicu` (must not appear)
+- **Script**: `scripts/verify-cgo.sh` runs these checks as a goreleaser post-hook
+
+If ICU linkage is detected, the release build fails.
+
+## The Upstream Fork
+
+`go.mod` has a `replace` directive pointing `go-mysql-server` to a fork
+(`maphew/go-mysql-server`) that adds `!windows` to the CGO regex build
+constraint. This ensures `go install` works on Windows without ICU headers.
+
+Upstream PR: https://github.com/dolthub/go-mysql-server/pull/3504
+Tracking issue: https://github.com/dolthub/go-mysql-server/issues/3506
+
+Once the upstream PR merges, remove the `replace` directive from `go.mod`.
+
+## Common Mistakes to Avoid
+
+1. **Adding ICU flags to `.buildflags` or `Makefile`** -- these were removed
+   in PR #3066. The `gms_pure_go` tag makes them unnecessary.
+
+2. **Removing `gms_pure_go` from a build target** -- this re-introduces
+   ICU linkage. The post-build checks will catch it, but don't do it.
+
+3. **Installing `libicu-dev` in release workflows** -- only needed in test
+   workflows. Release builds must not depend on ICU being installed.
+
+4. **Confusing CGO with ICU** -- CGO is required (for Dolt). ICU is not.
+   They are independent. `CGO_ENABLED=1` does not imply ICU.
+
+## Trade-offs
+
+- Go's `regexp` uses RE2 syntax, which is slightly less MySQL-compatible
+  than ICU regex (no backreferences, no lookahead/lookbehind)
+- `bd` does not use SQL `REGEXP` functions, so this has zero practical impact
+- If a future feature needs SQL `REGEXP`, revisit this policy then
+
+## See Also
+
+- [INSTALLING.md](INSTALLING.md) -- user-facing build dependency docs
+- [DOLT-BACKEND.md](DOLT-BACKEND.md) -- embedded Dolt architecture
+- [CONTRIBUTING.md](../CONTRIBUTING.md) -- contributor guidelines

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -217,30 +217,32 @@ bd version
 
 ## Build Dependencies (Contributors Only)
 
-> **Note:** These dependencies are only needed if you install via `go install` or build from source. If you installed via Homebrew, npm, or the install script, skip this section entirely.
+> **Note:** These dependencies are only needed if you build from source. If you installed via Homebrew, npm, or the install script, skip this section entirely.
 
-If you install via `go install` or build from source, you need system dependencies for CGO:
+Building from source requires a C compiler (for CGO / embedded Dolt). **ICU is
+not required** -- all builds use the `gms_pure_go` tag which selects Go's
+stdlib `regexp` instead of ICU regex. See [ICU-POLICY.md](ICU-POLICY.md) for
+details.
 
 macOS (Homebrew):
 ```bash
-brew install icu4c zstd
+brew install zstd
 ```
 
 Linux (Debian/Ubuntu):
 ```bash
-sudo apt-get install -y libicu-dev libzstd-dev
+sudo apt-get install -y libzstd-dev
 ```
 
 Linux (Fedora/RHEL):
 ```bash
-sudo dnf install -y libicu-devel libzstd-devel
+sudo dnf install -y libzstd-devel
 ```
 
-If you see `unicode/uregex.h` missing on macOS, `icu4c` is keg-only. Use:
-```bash
-ICU_PREFIX="$(brew --prefix icu4c)"
-CGO_CFLAGS="-I${ICU_PREFIX}/include" CGO_CPPFLAGS="-I${ICU_PREFIX}/include" CGO_LDFLAGS="-L${ICU_PREFIX}/lib" go install github.com/steveyegge/beads/cmd/bd@latest
-```
+> **For CI / test contributors only:** If you need to run `scripts/test-cgo.sh`
+> (which exercises the ICU code path), install ICU headers:
+> `brew install icu4c` (macOS) or `sudo apt-get install -y libicu-dev` (Linux).
+> This is not needed for normal development.
 
 ## IDE and Editor Integrations
 


### PR DESCRIPTION
## Summary

- Add `docs/ICU-POLICY.md` as the authoritative reference for ICU handling across all platforms
- Update `CONTRIBUTING.md` to note ICU is not required, link to policy, use `make build` instead of bare `go build`
- Update `docs/INSTALLING.md` to remove ICU from build dependencies (it's test-only)

Resolves confusion from overlapping PRs (#2991, #3066, #3112) where agents and contributors were doing/undoing each other's ICU fixes without a written policy.

## The policy in brief

- All release binaries use `-tags gms_pure_go` (Go stdlib regexp, no ICU)
- CGO stays enabled (needed for embedded Dolt, independent of ICU)
- ICU is a test-only dependency (exercised via `test-cgo.sh` and CI test matrix)
- Post-build verification catches ICU linkage regressions

Also opened upstream: https://github.com/dolthub/go-mysql-server/issues/3506

Closes #3126

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] Links between ICU-POLICY.md, CONTRIBUTING.md, and INSTALLING.md resolve
- [ ] No build/test impact (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)