### PR TITLE
fix(init): sanitize dots in metadata.json DoltDatabase and add early validation (#3128)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -438,6 +438,25 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if database != "" {
 			dbName = database
 		}
+
+		// Validate the auto-derived database name early so we can surface a clear,
+		// actionable error instead of a cryptic failure from the storage layer.
+		// The --database flag is already validated above; this catches cases where
+		// the directory name produces an invalid identifier after sanitization
+		// (e.g. spaces, '@', '!' that survive the hyphen/dot replacement).
+		// Skip when dbName came from an existing config — it was valid when stored.
+		if database == "" {
+			if existingCfg, _ := configfile.Load(beadsDir); existingCfg == nil || existingCfg.DoltDatabase == "" {
+				if err := dolt.ValidateDatabaseName(dbName); err != nil {
+					dirName := filepath.Base(cwd)
+					fmt.Fprintf(os.Stderr, "Error: directory name %q produces an invalid database name %q.\n", dirName, dbName)
+					fmt.Fprintf(os.Stderr, "Re-run with a valid prefix: bd init --prefix <name>\n")
+					fmt.Fprintf(os.Stderr, "(Database names must start with a letter or underscore and contain only letters, digits, underscores, or hyphens.)\n")
+					os.Exit(1)
+				}
+			}
+		}
+
 		// Auto-bootstrap from git remote if sync.git-remote is configured.
 		// This enables the new-machine story: set sync.git-remote in config.yaml,
 		// run bd init, and the Dolt database is cloned from the git remote
@@ -662,8 +681,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				if database != "" {
 					cfg.DoltDatabase = database
 				} else if cfg.DoltDatabase == "" && prefix != "" {
-					// Sanitize hyphens to underscores for SQL-idiomatic names (GH#2142).
+					// Sanitize hyphens and dots to underscores for SQL-idiomatic names (GH#2142).
+					// Must match the sanitization applied to dbName above (lines 430-431),
+					// otherwise init creates a database with one name but metadata.json
+					// records a different name, causing reopens to fail.
 					cfg.DoltDatabase = strings.ReplaceAll(prefix, "-", "_")
+					cfg.DoltDatabase = strings.ReplaceAll(cfg.DoltDatabase, ".", "_")
 				}
 
 				// Persist the connection mode matching this build.

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -596,6 +596,47 @@ func TestEmbeddedInit(t *testing.T) {
 			t.Errorf("sanitized issue_prefix: got %q, want %q", val, "bd_001")
 		}
 	})
+
+	t.Run("invalid_dirname_errors_early", func(t *testing.T) {
+		// A directory name like "my project" (space) survives hyphen/dot sanitization
+		// and produces an invalid Dolt database name. The init command should exit
+		// non-zero with a human-readable error rather than a cryptic storage failure.
+		parent := t.TempDir()
+		dir := filepath.Join(parent, "my project")
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		initGitRepoAt(t, dir)
+		cmd := exec.Command(bd, "init", "--quiet")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatal("bd init should have failed for directory with invalid name")
+		}
+		outStr := string(out)
+		if !strings.Contains(outStr, "invalid database name") && !strings.Contains(outStr, "produces an invalid") {
+			t.Errorf("expected actionable error message, got: %s", outStr)
+		}
+	})
+
+	t.Run("prefix_dot_sanitized", func(t *testing.T) {
+		// A Julia package repo like GPUPolynomials.jl passes --prefix GPUPolynomials.jl.
+		// The dot must be replaced with underscore in both the Dolt database name and
+		// metadata.json DoltDatabase, otherwise reopens fail with a name mismatch.
+		_, beadsDir, _ := bdInit(t, bd, "--prefix", "GPUPolynomials.jl")
+		cfg, err := configfile.Load(beadsDir)
+		if err != nil {
+			t.Fatalf("failed to load metadata.json: %v", err)
+		}
+		const want = "GPUPolynomials_jl"
+		if cfg.DoltDatabase != want {
+			t.Errorf("DoltDatabase: got %q, want %q", cfg.DoltDatabase, want)
+		}
+		if val := readBack(t, beadsDir, want, "issue_prefix", false); val != "GPUPolynomials_jl" {
+			t.Errorf("issue_prefix: got %q, want %q", val, "GPUPolynomials_jl")
+		}
+	})
 }
 
 // TestEmbeddedInitConcurrent verifies the exclusive flock prevents concurrent

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -584,6 +584,39 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("auto_detect_dotted_dirname", func(t *testing.T) {
+		// bd init in a directory named like "MyPkg.jl" (common in Julia repos)
+		// must sanitize the dot when auto-detecting the prefix: metadata.json
+		// DoltDatabase must match the actual Dolt database name so that reopens
+		// succeed and bd list works immediately after init.
+		parent := t.TempDir()
+		dir := filepath.Join(parent, "MyPkg.jl")
+		if err := os.MkdirAll(dir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		initGitRepoAt(t, dir)
+		runBDInit(t, bd, dir)
+
+		beadsDir := filepath.Join(dir, ".beads")
+		cfg, err := configfile.Load(beadsDir)
+		if err != nil {
+			t.Fatalf("failed to load metadata.json: %v", err)
+		}
+		const want = "MyPkg_jl"
+		if cfg.DoltDatabase != want {
+			t.Errorf("DoltDatabase: got %q, want %q (dot must be sanitized)", cfg.DoltDatabase, want)
+		}
+
+		// Verify bd list succeeds — confirms the database name in metadata.json
+		// matches the actual Dolt database created during init.
+		listCmd := exec.Command(bd, "list", "--json")
+		listCmd.Dir = dir
+		listCmd.Env = bdEnv(dir)
+		if out, err := listCmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd list failed after init in dotted dirname: %v\n%s", err, out)
+		}
+	})
+
 	t.Run("prefix_numeric_sanitized", func(t *testing.T) {
 		parent := t.TempDir()
 		dir := filepath.Join(parent, "001")


### PR DESCRIPTION
## Summary

Fixes #3128 — `bd init` in a directory with dots in its name (e.g. `GPUPolynomials.jl`, common in Julia development) silently produced a broken installation: the database was created under one name but `metadata.json` recorded a different name, causing every subsequent `bd` command to fail with a cryptic `invalid database name` error.

## Root Cause

Two bugs in `cmd/bd/init.go`:

**Bug 1 — metadata.json mismatch:**
`dbName` sanitized both hyphens and dots → underscores (lines 430–431), but `cfg.DoltDatabase` (written to `metadata.json`) only sanitized hyphens (line 666). The comment above line 430 explicitly warns these must match — they didn't.

**Bug 2 — unclear error for unsanitizable characters:**
Characters like spaces, `@`, `!` that survive all sanitization caused an error deep inside the storage layer with no actionable guidance.

## Changes

- `cmd/bd/init.go` line 666: add dot → underscore replacement to `cfg.DoltDatabase` to match `dbName` sanitization
- `cmd/bd/init.go` after line 440: add early `dolt.ValidateDatabaseName` check with clear error message and `--prefix` hint when the auto-derived name is invalid

## Before / After

**Before:**
```bash
$ cd GPUPolynomials.jl && bd init --quiet && bd list
Error: failed to open database: invalid database name "GPUPolynomials.jl"
```

**After (dots — silently fixed):**
```bash
$ cd GPUPolynomials.jl && bd init --quiet && bd list
No issues found.
```

**After (unsanitizable chars — clear error):**
```bash
$ cd "my project" && bd init --quiet
Error: directory name "my project" produces an invalid database name "my project".
Re-run with a valid prefix: bd init --prefix <name>
(Database names must start with a letter or underscore and contain only letters, digits, underscores, or hyphens.)
```

## Test Plan

- [ ] `bd init` in a `*.jl` directory succeeds and `bd list` works after
- [ ] `metadata.json` `dolt_database` field contains no dots after init in dotted directory
- [ ] `bd init` in a directory with a space fails immediately with message containing `--prefix`
- [ ] Existing `--database` flag validation path unaffected
- [ ] `bd init --prefix myname` in any directory still works as before

---

*Note: this is JJ's first time making a PR to beads with an AI agent, so if anything is wrong, we would appreciate feedback!*

🤖 Generated with [Claude Code](https://claude.com/claude-code)