### PR TITLE
Fix jira.priority_map.* config not read on push/pull

### DIFF
--- a/internal/jira/fieldmapper.go
+++ b/internal/jira/fieldmapper.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/tracker"
@@ -9,13 +10,23 @@ import (
 
 // jiraFieldMapper implements tracker.FieldMapper for Jira.
 type jiraFieldMapper struct {
-	apiVersion string            // "2" or "3" (default: "3")
-	statusMap  map[string]string // beads status → Jira status name (from jira.status_map.* config)
-	typeMap    map[string]string // beads type → Jira type (from jira.type_map.* config)
+	apiVersion  string            // "2" or "3" (default: "3")
+	statusMap   map[string]string // beads status → Jira status name (from jira.status_map.* config)
+	typeMap     map[string]string // beads type → Jira type (from jira.type_map.* config)
+	priorityMap map[string]string // beads priority (as string "0"-"4") → Jira priority name (from jira.priority_map.* config)
 }
 
 func (m *jiraFieldMapper) PriorityToBeads(trackerPriority interface{}) int {
 	if name, ok := trackerPriority.(string); ok {
+		// Check custom map first (inverted: Jira name → beads priority).
+		for beadsPri, jiraName := range m.priorityMap {
+			if strings.EqualFold(name, jiraName) {
+				if v, err := strconv.Atoi(beadsPri); err == nil && v >= 0 && v <= 4 {
+					return v
+				}
+			}
+		}
+		// Jira defaults.
 		switch name {
 		case "Highest":
 			return 0
@@ -33,6 +44,14 @@ func (m *jiraFieldMapper) PriorityToBeads(trackerPriority interface{}) int {
 }
 
 func (m *jiraFieldMapper) PriorityToTracker(beadsPriority int) interface{} {
+	// Check custom map first (beads priority as string key → Jira name).
+	if m.priorityMap != nil {
+		key := strconv.Itoa(beadsPriority)
+		if name, ok := m.priorityMap[key]; ok {
+			return name
+		}
+	}
+	// Jira defaults.
 	switch beadsPriority {
 	case 0:
 		return "Highest"

--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/debug"
@@ -27,6 +28,7 @@ type Tracker struct {
 	apiVersion  string            // "2" or "3" (default: "3")
 	statusMap   map[string]string // beads status → Jira status name (from jira.status_map.* config)
 	typeMap     map[string]string // beads type → Jira type (from jira.type_map.* config)
+	priorityMap map[string]string // beads priority → Jira priority name (from jira.priority_map.* config)
 }
 
 // SetProjectKeys sets project keys before Init(). When set, Init() uses these
@@ -110,6 +112,17 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 		if len(typeMap) > 0 {
 			t.typeMap = typeMap
 		}
+
+		const priorityPrefix = "jira.priority_map."
+		priorityMap := make(map[string]string)
+		for key, val := range allConfig {
+			if strings.HasPrefix(key, priorityPrefix) && val != "" {
+				priorityMap[strings.TrimPrefix(key, priorityPrefix)] = val
+			}
+		}
+		if len(priorityMap) > 0 {
+			t.priorityMap = priorityMap
+		}
 	}
 
 	return nil
@@ -164,7 +177,7 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 
 	result := make([]tracker.TrackerIssue, 0, len(issues))
 	for i := range issues {
-		result = append(result, jiraToTrackerIssue(&issues[i]))
+		result = append(result, jiraToTrackerIssue(&issues[i], t.priorityMap))
 	}
 	return result, nil
 }
@@ -177,7 +190,7 @@ func (t *Tracker) FetchIssue(ctx context.Context, identifier string) (*tracker.T
 	if issue == nil {
 		return nil, nil
 	}
-	ti := jiraToTrackerIssue(issue)
+	ti := jiraToTrackerIssue(issue, t.priorityMap)
 	return &ti, nil
 }
 
@@ -193,7 +206,7 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 		return nil, err
 	}
 
-	ti := jiraToTrackerIssue(created)
+	ti := jiraToTrackerIssue(created, t.priorityMap)
 	return &ti, nil
 }
 
@@ -229,7 +242,7 @@ func (t *Tracker) UpdateIssue(ctx context.Context, externalID string, issue *typ
 		}
 	}
 
-	ti := jiraToTrackerIssue(current)
+	ti := jiraToTrackerIssue(current, t.priorityMap)
 	return &ti, nil
 }
 
@@ -259,7 +272,7 @@ func (t *Tracker) applyTransition(ctx context.Context, key string, status types.
 }
 
 func (t *Tracker) FieldMapper() tracker.FieldMapper {
-	return &jiraFieldMapper{apiVersion: t.apiVersion, statusMap: t.statusMap, typeMap: t.typeMap}
+	return &jiraFieldMapper{apiVersion: t.apiVersion, statusMap: t.statusMap, typeMap: t.typeMap, priorityMap: t.priorityMap}
 }
 
 func (t *Tracker) IsExternalRef(ref string) bool {
@@ -289,7 +302,8 @@ func (t *Tracker) getConfig(ctx context.Context, key, envVar string) (string, er
 }
 
 // jiraToTrackerIssue converts a Jira API Issue to the generic TrackerIssue format.
-func jiraToTrackerIssue(ji *Issue) tracker.TrackerIssue {
+// priorityMap is optional (nil uses hardcoded defaults).
+func jiraToTrackerIssue(ji *Issue, priorityMap map[string]string) tracker.TrackerIssue {
 	ti := tracker.TrackerIssue{
 		ID:         ji.ID,
 		Identifier: ji.Key,
@@ -304,7 +318,7 @@ func jiraToTrackerIssue(ji *Issue) tracker.TrackerIssue {
 
 	// Priority
 	if ji.Fields.Priority != nil {
-		ti.Priority = jiraPriorityToNumeric(ji.Fields.Priority.Name)
+		ti.Priority = jiraPriorityToNumeric(ji.Fields.Priority.Name, priorityMap)
 	}
 
 	// State
@@ -344,7 +358,20 @@ func jiraToTrackerIssue(ji *Issue) tracker.TrackerIssue {
 }
 
 // jiraPriorityToNumeric converts a Jira priority name to a numeric value (0=highest, 4=lowest).
-func jiraPriorityToNumeric(name string) int {
+// If priorityMap is non-nil, it checks the custom mapping first (inverted: find which beads
+// priority key maps to a Jira name matching the input).
+func jiraPriorityToNumeric(name string, priorityMap map[string]string) int {
+	// Check custom map first (inverted lookup: find beads key whose value matches name).
+	if priorityMap != nil {
+		for beadsKey, jiraName := range priorityMap {
+			if strings.EqualFold(name, jiraName) {
+				if v, err := strconv.Atoi(beadsKey); err == nil && v >= 0 && v <= 4 {
+					return v
+				}
+			}
+		}
+	}
+	// Hardcoded defaults.
 	switch strings.ToLower(name) {
 	case "highest":
 		return 0

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -97,7 +97,7 @@ func TestJiraToTrackerIssue(t *testing.T) {
 		},
 	}
 
-	ti := jiraToTrackerIssue(ji)
+	ti := jiraToTrackerIssue(ji, nil)
 
 	if ti.ID != "10001" {
 		t.Errorf("ID = %q, want %q", ti.ID, "10001")
@@ -214,7 +214,7 @@ func TestFieldMapperIssueToBeads(t *testing.T) {
 		},
 	}
 
-	ti := jiraToTrackerIssue(ji)
+	ti := jiraToTrackerIssue(ji, nil)
 	mapper := &jiraFieldMapper{}
 	conv := mapper.IssueToBeads(&ti)
 
@@ -784,5 +784,109 @@ func TestInitLoadsCustomTypeMapFromAllConfig(t *testing.T) {
 	gotTracker, _ = mapper.TypeToTracker(types.TypeEpic).(string)
 	if gotTracker != "Epic" {
 		t.Errorf("TypeToTracker(epic) = %q, want %q", gotTracker, "Epic")
+	}
+}
+
+func TestInitLoadsCustomPriorityMapFromAllConfig(t *testing.T) {
+	store := &configStore{
+		data: map[string]string{
+			"jira.url":              "https://example.atlassian.net",
+			"jira.project":          "PROJ",
+			"jira.api_token":        "token123",
+			"jira.priority_map.0":   "Critical",
+			"jira.priority_map.2":   "Normal",
+		},
+	}
+
+	tr := &Tracker{}
+	if err := tr.Init(context.Background(), store); err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+
+	if tr.priorityMap == nil {
+		t.Fatal("priorityMap should not be nil after Init with jira.priority_map.* config")
+	}
+	if tr.priorityMap["0"] != "Critical" {
+		t.Errorf("priorityMap[\"0\"] = %q, want %q", tr.priorityMap["0"], "Critical")
+	}
+	if tr.priorityMap["2"] != "Normal" {
+		t.Errorf("priorityMap[\"2\"] = %q, want %q", tr.priorityMap["2"], "Normal")
+	}
+}
+
+func TestPriorityToTrackerUsesCustomMap(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		priorityMap: map[string]string{
+			"0": "Critical",
+			"2": "Normal",
+		},
+	}
+
+	tests := []struct {
+		priority int
+		want     string
+	}{
+		{0, "Critical"},  // from custom map
+		{1, "High"},      // not in map → default
+		{2, "Normal"},    // from custom map
+		{3, "Low"},       // not in map → default
+		{4, "Lowest"},    // not in map → default
+	}
+	for _, tt := range tests {
+		got, _ := mapper.PriorityToTracker(tt.priority).(string)
+		if got != tt.want {
+			t.Errorf("PriorityToTracker(%d) = %q, want %q", tt.priority, got, tt.want)
+		}
+	}
+}
+
+func TestPriorityToBeadsUsesCustomMap(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		priorityMap: map[string]string{
+			"0": "Critical",
+			"2": "Normal",
+		},
+	}
+
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"Critical", 0},  // from custom map
+		{"Normal", 2},    // from custom map
+		{"High", 1},      // not in map → default
+		{"Low", 3},       // not in map → default
+		{"Lowest", 4},    // not in map → default
+	}
+	for _, tt := range tests {
+		got := mapper.PriorityToBeads(tt.name)
+		if got != tt.want {
+			t.Errorf("PriorityToBeads(%q) = %d, want %d", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestPriorityMapCaseInsensitiveMatch(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		priorityMap: map[string]string{
+			"0": "Critical",
+		},
+	}
+
+	// PriorityToBeads should match case-insensitively
+	tests := []struct {
+		name string
+		want int
+	}{
+		{"Critical", 0},
+		{"critical", 0},
+		{"CRITICAL", 0},
+		{"CrItIcAl", 0},
+	}
+	for _, tt := range tests {
+		got := mapper.PriorityToBeads(tt.name)
+		if got != tt.want {
+			t.Errorf("PriorityToBeads(%q) = %d, want %d", tt.name, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3154

## Problem

`jira.priority_map.*` config keys are accepted by `bd config set` but never read during Jira sync. `PriorityToTracker`, `PriorityToBeads`, and `jiraPriorityToNumeric` all use hardcoded mappings (Highest/High/Medium/Low/Lowest) regardless of config.

This causes sync failures on Jira instances using non-standard priority names. For example, a project using "Normal" instead of "Medium" gets:

```
jira API returned 400: {"errors":{"priority":"Specify the Priority (name) in the string format"}}
```

P0 and P1 sync correctly (Jira IDs 0 and 1 happen to map), but P2+ fails because the hardcoded name doesn't match the Jira instance.

## Fix

Add `priorityMap` support following the existing `statusMap`/`typeMap` pattern:

1. Added `priorityMap` field to `jiraFieldMapper` struct
2. Load `jira.priority_map.*` config in `Init()` (same pattern as `jira.status_map.*` and `jira.type_map.*`)
3. Check `priorityMap` before hardcoded defaults in `PriorityToTracker`, `PriorityToBeads`, and `jiraPriorityToNumeric`
4. Pass `priorityMap` to `jiraToTrackerIssue` so the tracker-layer conversion is also config-aware
5. Added 4 tests matching `statusMap`/`typeMap` test coverage

## Config example

```bash
bd config set jira.priority_map.0 "Critical"
bd config set jira.priority_map.1 "High"
bd config set jira.priority_map.2 "Normal"
bd config set jira.priority_map.3 "Low"
bd config set jira.priority_map.4 "Low"
```

## Testing

- All 18 existing + new Jira tests pass (`go test ./internal/jira/ -v`)
- Tested end-to-end: P2 issues now sync to Jira with "Normal" priority on a project that previously rejected "Medium"
- Custom map entries override defaults; unmapped priorities fall through to hardcoded defaults

## Files changed

- `internal/jira/fieldmapper.go` — priority mapping logic
- `internal/jira/tracker.go` — config loading + `jiraPriorityToNumeric` fix
- `internal/jira/tracker_test.go` — 4 new tests