### PR TITLE
fix(mcp): widen DependencyType to str so all bd dep types validate

### DIFF
--- a/integrations/beads-mcp/CHANGELOG.md
+++ b/integrations/beads-mcp/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to beads-mcp will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `mcp__beads__show()` no longer crashes with `pydantic literal_error` when an
+  issue has dependency types beyond the original four (`blocks`, `related`,
+  `parent-child`, `discovered-from`). `DependencyType` is now `str`, matching
+  the pattern already used for `IssueStatus` and `IssueType`. The bd CLI
+  remains the source of truth for validation. (GH#3133)
+
 ## [0.41.0] - 2024-12-30
 
 ### Changed

--- a/integrations/beads-mcp/src/beads_mcp/models.py
+++ b/integrations/beads-mcp/src/beads_mcp/models.py
@@ -7,20 +7,28 @@ from pydantic import BaseModel, Field, field_validator
 
 # Type aliases for issue statuses, types, and dependencies
 #
-# IssueStatus and IssueType are strings (not Literals) to support custom
-# statuses and types configured via:
+# IssueStatus, IssueType, and DependencyType are strings (not Literals) so the
+# MCP layer doesn't have to be kept in lockstep with every dep type / status /
+# issue type the bd CLI emits. The CLI is the source of truth and validates
+# these values against the configured (or built-in) options.
+#
+# Custom statuses and types are configured via:
 #   bd config set status.custom "in_review:active,qa_testing:wip,on_hold:frozen"
 #   bd config set types.custom "agent,molecule,event"
 #
 # Custom statuses support optional category annotations (active, wip, done, frozen)
 # that control behavior in bd ready and bd list. See docs/CLI_REFERENCE.md.
 #
-# The CLI handles validation of these values against the configured options.
 # Built-in statuses: open, in_progress, blocked, deferred, closed
 # Built-in types: bug, feature, task, epic, chore, decision
+# Built-in dependency types (see internal/types/types.go):
+#   blocks, parent-child, conditional-blocks, waits-for, related,
+#   discovered-from, replies-to, relates-to, duplicates, supersedes,
+#   authored-by, assigned-to, approved-by, attests, tracks, until,
+#   caused-by, validates, delegated-from
 IssueStatus = str
 IssueType = str
-DependencyType = Literal["blocks", "related", "parent-child", "discovered-from"]
+DependencyType = str
 OperationAction = Literal["created", "updated", "claimed", "closed", "reopened"]
 
 

--- a/integrations/beads-mcp/src/beads_mcp/server.py
+++ b/integrations/beads-mcp/src/beads_mcp/server.py
@@ -1142,8 +1142,10 @@ async def reopen_issue(
 
 @mcp.tool(
     name="dep",
-    description="""Add a dependency between issues. Types: blocks (hard blocker),
-related (soft link), parent-child (epic/subtask), discovered-from (found during work).""",
+    description="""Add a dependency between issues. Common types: blocks (hard blocker),
+related (soft link), parent-child (epic/subtask), discovered-from (found during work).
+The full set of supported dep types lives in internal/types/types.go and is
+validated by the bd CLI; pass any of them as a string.""",
 )
 @with_workspace
 @require_context

--- a/integrations/beads-mcp/src/beads_mcp/tools.py
+++ b/integrations/beads-mcp/src/beads_mcp/tools.py
@@ -561,16 +561,21 @@ async def beads_add_dependency(
     depends_on_id: Annotated[str, "Issue that issue_id depends on (e.g., bd-1)"],
     dep_type: Annotated[
         DependencyType,
-        "Dependency type: blocks, related, parent-child, or discovered-from",
+        "Dependency type. Common: blocks, related, parent-child, discovered-from. "
+        "Full set validated by bd CLI (see internal/types/types.go).",
     ] = DEFAULT_DEPENDENCY_TYPE,
 ) -> str:
     """Add a dependency relationship between two issues.
 
-    Types:
+    Common types:
     - blocks: depends_on_id must complete before issue_id can start
     - related: Soft connection, doesn't block progress
     - parent-child: Epic/subtask hierarchical relationship
     - discovered-from: Track that issue_id was discovered while working on depends_on_id
+
+    Other supported types include relates-to, replies-to, duplicates, supersedes,
+    caused-by, validates, and more. The bd CLI is the source of truth for the
+    full list — see internal/types/types.go.
 
     Use 'discovered-from' when you find new work during your session.
     """


### PR DESCRIPTION
## Problem

`integrations/beads-mcp/src/beads_mcp/models.py:23` defines:

```python
DependencyType = Literal["blocks", "related", "parent-child", "discovered-from"]
```

But the `bd` CLI emits ~19 dependency types (see `internal/types/types.go:769-805`):

> `blocks`, `parent-child`, `conditional-blocks`, `waits-for`, `related`, `discovered-from`, `replies-to`, `relates-to`, `duplicates`, `supersedes`, `authored-by`, `assigned-to`, `approved-by`, `attests`, `tracks`, `until`, `caused-by`, `validates`, `delegated-from`

Any `mcp__beads__show()` call on an issue with a non-whitelisted dep edge crashes with `pydantic literal_error`. Repro from a real session today:

```
beads - show (MCP)(issue_id: "tn-b77d", brief: true, brief_deps: true)
  ⎿  Error: 1 validation error for Issue
     dependencies.0.dependency_type
       Input should be 'blocks', 'related', 'parent-child' or 'discovered-from'
     [type=literal_error, input_value='relates-to', input_type=str]
```

`brief=true` doesn't help — `BriefDep` reuses the same `Literal`. The CLI (`bd show`) is unaffected because it doesn't go through Pydantic.

This blocks any agent workflow that uses `mcp__beads__show()` over a knowledge graph that has `relates-to`, `replies-to`, `duplicates`, `supersedes`, etc. edges. PR #1469 added CLI display support for `relates-to` back in February — the MCP layer just never caught up.

Related: #1750 (MCP Pydantic validation error on `list` when issues have dependencies — same class of bug, different call site).

## Fix

Change `DependencyType` from a `Literal` to a plain `str`, mirroring how `IssueStatus` and `IssueType` are already handled in the same file (lines 21-22). The `bd` CLI is the source of truth and validates dep types itself (`DependencyType.IsValid()` in `internal/types/types.go:805`); the MCP layer doesn't need a redundant whitelist that drifts from the CLI.

Also updated the user-facing docstrings in `server.py` and `tools.py` to stop claiming only 4 dep types exist — they now mention the common four and point to `internal/types/types.go` for the full list.

## Verification

Synthesizing an `Issue` with a `relates-to` `LinkedIssue` now validates cleanly:

```python
from beads_mcp.models import LinkedIssue, Issue
import datetime
now = datetime.datetime.now(datetime.timezone.utc)
linked = LinkedIssue(
    id='tn-test', title='test', status='open', priority=2, issue_type='task',
    created_at=now, updated_at=now, dependency_type='relates-to'
)
Issue(
    id='tn-parent', title='parent', status='open', priority=2, issue_type='task',
    created_at=now, updated_at=now, dependencies=[linked]
)
# OK — no validation error
```

Test suite: **141 unit tests pass, 7 model/dep-specific tests pass.** Note: there are 4 pre-existing failures in `tests/test_compaction_config.py` that hardcode `/Users/stevey/src/dave/beads/...` paths — unrelated to this change, fail on any non-Steve machine.

## Why a `str` and not an expanded `Literal`?

I considered listing all 19 types in the `Literal`, but:

1. New dep types get added to `internal/types/types.go` over time (e.g., `delegated-from` is recent). A `Literal` will drift again.
2. The MCP layer can't validate semantic correctness anyway — only the Go-side `IsValid()` method knows the live set.
3. `IssueStatus` and `IssueType` already made the same call (and for the same reason — custom statuses/types via `bd config set`), so this is internally consistent.

If you'd prefer the literal approach for type safety / IDE autocomplete, happy to switch.