### PR TITLE
fix: avoid nil-pointer panic in bd dolt pull (embedded mode)

### DIFF
--- a/internal/storage/versioncontrolops/remotes.go
+++ b/internal/storage/versioncontrolops/remotes.go
@@ -3,6 +3,7 @@ package versioncontrolops
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/storage"
 )
@@ -58,10 +59,22 @@ func ForcePush(ctx context.Context, db DBConn, remote, branch string) error {
 	return nil
 }
 
-// Pull pulls changes from the named remote.
+// Pull pulls changes from the named remote by fetching the branch and merging
+// the remote tracking ref. This is equivalent to DOLT_PULL(remote, branch) but
+// avoids a nil-pointer panic in embedded Dolt when upstream branch tracking is
+// not configured in repo_state.json (GH#3144).
 func Pull(ctx context.Context, db DBConn, remote, branch string) error {
-	if _, err := db.ExecContext(ctx, "CALL DOLT_PULL(?, ?)", remote, branch); err != nil {
-		return fmt.Errorf("pull from %s: %w", remote, err)
+	if _, err := db.ExecContext(ctx, "CALL DOLT_FETCH(?, ?)", remote, branch); err != nil {
+		return fmt.Errorf("fetch from %s/%s: %w", remote, branch, err)
+	}
+	trackingRef := remote + "/" + branch
+	if _, err := db.ExecContext(ctx, "CALL DOLT_MERGE(?)", trackingRef); err != nil {
+		// DOLT_MERGE returns "Already up to date." when there is nothing
+		// to merge; DOLT_PULL swallows this internally, so we do the same.
+		if strings.Contains(err.Error(), "up to date") {
+			return nil
+		}
+		return fmt.Errorf("merge %s: %w", trackingRef, err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Replaces `CALL DOLT_PULL(remote, branch)` with the equivalent two-step `DOLT_FETCH` + `DOLT_MERGE` to work around a nil-pointer dereference in Dolt's `doDoltPull` when branch tracking is not configured in `repo_state.json`.

## Root Cause

In embedded mode, when `repo_state.json` has `"branches": {}` (no upstream tracking), Dolt's internal `doDoltPull` (at `dolt_pull.go:154`) dereferences a nil pointer trying to resolve the merge target branch. Push works fine because it doesn't go through this code path.

## Fix

`git pull` is defined as `git fetch` + `git merge`, and Dolt documents the same equivalence. By splitting into `DOLT_FETCH(remote, branch)` followed by `DOLT_MERGE(remote/branch)`, we get identical semantics while avoiding the buggy code path.

Also handles the "Already up to date" message that `DOLT_MERGE` returns as an error (which `DOLT_PULL` swallowed internally).

## Upstream Bug

Filed as https://github.com/dolthub/dolt/issues/10839

Fixes #3144