### PR TITLE
test: restore OpenBestAvailable tests from bgjackma's PR #3143

### DIFF
--- a/beads_cgo.go
+++ b/beads_cgo.go
@@ -1,0 +1,60 @@
+//go:build cgo
+
+package beads
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+)
+
+// OpenBestAvailable opens a beads database using the best available backend
+// for the given .beads directory. It reads metadata.json to determine the
+// configured mode:
+//
+//   - Embedded mode (default): Opens via the CGo embedded Dolt engine with an
+//     exclusive flock to prevent corruption from concurrent access. This matches
+//     the behavior of the bd CLI.
+//   - Server mode: Connects to an external dolt sql-server via OpenFromConfig.
+//
+// The returned Storage must be closed when no longer needed. In embedded mode
+// the caller must also defer the Unlocker returned by the flock; pass nil-safe
+// patterns such as:
+//
+//	store, lock, err := beads.OpenBestAvailable(ctx, beadsDir)
+//	if err != nil { ... }
+//	defer lock.Unlock()
+//	defer store.Close()
+//
+// beadsDir is the path to the .beads directory.
+func OpenBestAvailable(ctx context.Context, beadsDir string) (Storage, embeddeddolt.Unlocker, error) {
+	cfg, err := configfile.Load(beadsDir)
+	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
+		store, err := dolt.NewFromConfig(ctx, beadsDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		return store, embeddeddolt.NoopLock{}, nil
+	}
+
+	// Embedded mode: acquire exclusive flock first.
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	lock, err := embeddeddolt.TryLock(dataDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	database := configfile.DefaultDoltDatabase
+	if cfg != nil {
+		database = cfg.GetDoltDatabase()
+	}
+	store, err := embeddeddolt.New(ctx, beadsDir, database, "main", embeddeddolt.WithLock(lock))
+	if err != nil {
+		lock.Unlock()
+		return nil, nil, err
+	}
+	return store, lock, nil
+}

--- a/beads_nocgo.go
+++ b/beads_nocgo.go
@@ -1,0 +1,29 @@
+//go:build !cgo
+
+package beads
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+)
+
+// OpenBestAvailable opens a beads database using the best available backend
+// for the given .beads directory. In non-CGO builds, only server mode is
+// supported; embedded mode returns an error directing the user to server mode.
+//
+// beadsDir is the path to the .beads directory.
+func OpenBestAvailable(ctx context.Context, beadsDir string) (Storage, embeddeddolt.Unlocker, error) {
+	cfg, err := configfile.Load(beadsDir)
+	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
+		store, err := dolt.NewFromConfig(ctx, beadsDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		return store, embeddeddolt.NoopLock{}, nil
+	}
+	return nil, nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
+}

--- a/beads_test.go
+++ b/beads_test.go
@@ -208,6 +208,72 @@ func TestOpenFromConfig_NoMetadata(t *testing.T) {
 	}
 }
 
+func TestOpenBestAvailable_ServerMode(t *testing.T) {
+	skipIfNoDoltServer(t)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+
+	metadata := fmt.Sprintf(`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_server_host":"127.0.0.1","dolt_server_port":%d}`, testServerPort)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	ctx := context.Background()
+	store, lock, err := beads.OpenBestAvailable(ctx, beadsDir)
+	if err != nil {
+		t.Fatalf("OpenBestAvailable (server mode) failed: %v", err)
+	}
+	defer lock.Unlock()
+	defer store.Close()
+
+	if store == nil {
+		t.Error("expected non-nil storage")
+	}
+}
+
+func TestOpenBestAvailable_ServerMode_FailsWithoutServer(t *testing.T) {
+	// OpenBestAvailable in server mode should propagate the fail-fast error.
+	if prev := os.Getenv("BEADS_DOLT_PORT"); prev != "" {
+		os.Unsetenv("BEADS_DOLT_PORT")
+		t.Cleanup(func() { os.Setenv("BEADS_DOLT_PORT", prev) })
+	}
+	if prev := os.Getenv("BEADS_TEST_MODE"); prev != "" {
+		os.Unsetenv("BEADS_TEST_MODE")
+		t.Cleanup(func() { os.Setenv("BEADS_TEST_MODE", prev) })
+	}
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	freePort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	metadata := fmt.Sprintf(`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_server_host":"127.0.0.1","dolt_server_port":%d}`, freePort)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	ctx := context.Background()
+	_, _, openErr := beads.OpenBestAvailable(ctx, beadsDir)
+	if openErr == nil {
+		t.Fatal("OpenBestAvailable (server mode) should fail when no server is running")
+	}
+	if !strings.Contains(openErr.Error(), "unreachable") {
+		t.Errorf("expected 'unreachable' in error, got: %v", openErr)
+	}
+}
+
 func TestFindAllDatabases(t *testing.T) {
 	// This scans the file system, just verify it doesn't panic
 	dbs := beads.FindAllDatabases()

--- a/open_nocgo_test.go
+++ b/open_nocgo_test.go
@@ -1,0 +1,95 @@
+//go:build !cgo
+
+package beads_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads"
+)
+
+func TestOpenBestAvailable_NoCGO_EmbeddedMode_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+
+	metadata := `{"backend":"dolt","database":"dolt","dolt_mode":"embedded"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	ctx := context.Background()
+	_, _, err := beads.OpenBestAvailable(ctx, beadsDir)
+	if err == nil {
+		t.Fatal("expected error for embedded mode without CGO")
+	}
+	if !strings.Contains(err.Error(), "CGO") {
+		t.Errorf("expected error to mention CGO, got: %v", err)
+	}
+}
+
+func TestOpenBestAvailable_NoCGO_NoMetadata_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+	// No metadata.json — embedded is the default, CGO required.
+
+	ctx := context.Background()
+	_, _, err := beads.OpenBestAvailable(ctx, beadsDir)
+	if err == nil {
+		t.Fatal("expected error for embedded mode without CGO")
+	}
+	if !strings.Contains(err.Error(), "CGO") {
+		t.Errorf("expected error to mention CGO, got: %v", err)
+	}
+}
+
+func TestOpenBestAvailable_NoCGO_ServerMode_FailsWithoutServer(t *testing.T) {
+	// Even in !cgo builds, server mode should delegate to OpenFromConfig and
+	// return the fail-fast error when no server is listening.
+	if prev := os.Getenv("BEADS_DOLT_PORT"); prev != "" {
+		os.Unsetenv("BEADS_DOLT_PORT")
+		t.Cleanup(func() { os.Setenv("BEADS_DOLT_PORT", prev) })
+	}
+	if prev := os.Getenv("BEADS_TEST_MODE"); prev != "" {
+		os.Unsetenv("BEADS_TEST_MODE")
+		t.Cleanup(func() { os.Setenv("BEADS_TEST_MODE", prev) })
+	}
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	freePort := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	metadata := fmt.Sprintf(`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_server_host":"127.0.0.1","dolt_server_port":%d}`, freePort)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0644); err != nil {
+		t.Fatalf("failed to write metadata.json: %v", err)
+	}
+
+	ctx := context.Background()
+	_, _, openErr := beads.OpenBestAvailable(ctx, beadsDir)
+	if openErr == nil {
+		t.Fatal("OpenBestAvailable (server mode) should fail when no server is running")
+	}
+	if !strings.Contains(openErr.Error(), "unreachable") {
+		t.Errorf("expected 'unreachable' in error, got: %v", openErr)
+	}
+}


### PR DESCRIPTION
Restores test coverage that was dropped when PR #3149 reimplemented the OpenBestAvailable feature without carrying over @bgjackma's tests from the original PR #3143.

**What was lost:**
- `TestOpenBestAvailable_ServerMode` — verifies server-mode routing works
- `TestOpenBestAvailable_ServerMode_FailsWithoutServer` — verifies fail-fast without a server
- `TestOpenBestAvailable_NoCGO_EmbeddedMode_ReturnsError` — verifies clear error in !cgo embedded mode
- `TestOpenBestAvailable_NoCGO_NoMetadata_ReturnsError` — verifies default (no metadata) requires CGO
- `TestOpenBestAvailable_NoCGO_ServerMode_FailsWithoutServer` — verifies server mode works without CGO

Tests are adapted from Brock's original for the current `(Storage, Unlocker, error)` return signature.

Co-authored-by: Brock Jackman <brockj@lyft.com>