### PR TITLE
/{cmd,internal}: add checkout suffix

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -118,6 +118,7 @@ Examples:
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		yesFlag, _ := cmd.Flags().GetBool("yes")
 		nonInteractiveFlag, _ := cmd.Flags().GetBool("non-interactive")
+		checkoutSuffixFlag, _ := cmd.Flags().GetString("checkout-suffix")
 
 		// Resolve non-interactive mode: flag > env var > CI env > terminal detection.
 		nonInteractive := isNonInteractiveBootstrap(yesFlag || nonInteractiveFlag)
@@ -193,7 +194,7 @@ Examples:
 		}
 
 		// Execute the plan
-		if err := executeBootstrapPlan(plan, cfg, nonInteractive); err != nil {
+		if err := executeBootstrapPlan(plan, cfg, nonInteractive, checkoutSuffixFlag); err != nil {
 			FatalError("Bootstrap failed: %v", err)
 		}
 	},
@@ -346,33 +347,52 @@ func confirmPrompt(message string, nonInteractive bool) bool {
 	}
 	fmt.Fprintf(os.Stderr, "%s [Y/n] ", message)
 	reader := bufio.NewReader(os.Stdin)
-	line, _ := reader.ReadString('\n')
+	line, err := readLineWithContext(getRootContext(), reader, os.Stdin)
+	if err != nil {
+		if isCanceled(err) {
+			exitCanceled()
+		}
+		return false
+	}
 	line = strings.TrimSpace(strings.ToLower(line))
 	return line == "" || line == "y" || line == "yes"
 }
 
-func executeBootstrapPlan(plan BootstrapPlan, cfg *configfile.Config, nonInteractive bool) error {
+func executeBootstrapPlan(plan BootstrapPlan, cfg *configfile.Config, nonInteractive bool, checkoutSuffixFlag string) error {
 	if !confirmPrompt("Proceed?", nonInteractive) {
 		fmt.Fprintf(os.Stderr, "Aborted.\n")
 		return nil
 	}
 
+	checkoutID := computeCheckoutID(plan.BeadsDir)
 	ctx := context.Background()
+
+	// Resolve checkout suffix. The interactive prompt fires for the "sync"
+	// action (cloning an existing DB where namespace collision is a real
+	// risk). For other actions, only apply if the flag was explicitly set.
+	var suffix string
+	if checkoutSuffixFlag != "" || plan.Action == "sync" {
+		var err error
+		suffix, err = resolveCheckoutSuffix(checkoutSuffixFlag, nonInteractive)
+		if err != nil {
+			return fmt.Errorf("checkout suffix: %w", err)
+		}
+	}
 
 	switch plan.Action {
 	case "sync":
-		return executeSyncAction(ctx, plan, cfg)
+		return executeSyncAction(ctx, plan, cfg, suffix, checkoutID)
 	case "restore":
-		return executeRestoreAction(ctx, plan, cfg)
+		return executeRestoreAction(ctx, plan, cfg, suffix, checkoutID)
 	case "jsonl-import":
-		return executeJSONLImportAction(ctx, plan, cfg)
+		return executeJSONLImportAction(ctx, plan, cfg, suffix, checkoutID)
 	case "init":
-		return executeInitAction(ctx, plan, cfg)
+		return executeInitAction(ctx, plan, cfg, suffix, checkoutID)
 	}
 	return nil
 }
 
-func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config) error {
+func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix, checkoutID string) error {
 	prefix := inferPrefix(cfg)
 	dbName := cfg.GetDoltDatabase()
 
@@ -390,6 +410,9 @@ func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
+	}
+	if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
+		return err
 	}
 	if err := s.Commit(ctx, "bd bootstrap"); err != nil {
 		return fmt.Errorf("commit: %w", err)
@@ -399,7 +422,7 @@ func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	return nil
 }
 
-func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config) error {
+func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix, checkoutID string) error {
 	prefix := inferPrefix(cfg)
 	dbName := cfg.GetDoltDatabase()
 
@@ -417,6 +440,9 @@ func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfi
 
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
+	}
+	if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
+		return err
 	}
 	if err := s.Commit(ctx, "bd bootstrap: init"); err != nil {
 		return fmt.Errorf("commit init: %w", err)
@@ -430,7 +456,7 @@ func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfi
 	return nil
 }
 
-func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config) error {
+func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix, checkoutID string) error {
 	prefix := inferPrefix(cfg)
 	dbName := cfg.GetDoltDatabase()
 
@@ -448,6 +474,9 @@ func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *conf
 
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
+	}
+	if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
+		return err
 	}
 	if err := s.Commit(ctx, "bd bootstrap: init"); err != nil {
 		return fmt.Errorf("commit init: %w", err)
@@ -466,7 +495,7 @@ func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *conf
 	return nil
 }
 
-func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config) error {
+func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix, checkoutID string) error {
 	// Ensure .beads directory exists — it may not in the "fresh clone"
 	// bootstrap path where we detected remote data before .beads was
 	// created. Deferred here to preserve --dry-run semantics. (GH#2792)
@@ -489,10 +518,16 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		if err != nil {
 			return fmt.Errorf("open embedded engine for clone: %w", err)
 		}
-		defer func() { _ = cleanup() }()
 
 		if err := versioncontrolops.DoltClone(ctx, db, plan.SyncRemote, dbName); err != nil {
+			_ = cleanup()
 			return fmt.Errorf("clone from remote: %w", err)
+		}
+
+		// Close the clone connection to release the exclusive flock before
+		// opening a new one scoped to the cloned database.
+		if err := cleanup(); err != nil {
+			return fmt.Errorf("close clone connection: %w", err)
 		}
 
 		// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
@@ -501,21 +536,55 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		// Dolt manages these files itself; external interference is never safe.
 
 		fmt.Fprintf(os.Stderr, "Synced database from %s\n", plan.SyncRemote)
-		return nil
+
+		// Apply checkout suffix via a fresh connection scoped to the cloned DB.
+		if suffix != "" {
+			db2, cleanup2, err := embeddeddolt.OpenSQL(ctx, dataDir, dbName, "")
+			if err != nil {
+				return fmt.Errorf("open cloned database for checkout suffix: %w", err)
+			}
+			defer func() { _ = cleanup2() }()
+
+			if err := applyCheckoutSuffixSQL(ctx, db2, suffix, checkoutID); err != nil {
+				return err
+			}
+		}
+	} else {
+		doltDir := doltserver.ResolveDoltDir(plan.BeadsDir)
+		synced, err := dolt.BootstrapFromGitRemoteWithDB(ctx, doltDir, plan.SyncRemote, dbName)
+		if err != nil {
+			return fmt.Errorf("sync from remote: %w", err)
+		}
+		if synced {
+			// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
+			// directory — including noms/LOCK files. These are Dolt-internal files.
+			// Removing them WILL cause unrecoverable data corruption and data loss.
+			// Dolt manages these files itself; external interference is never safe.
+			fmt.Fprintf(os.Stderr, "Synced database from %s\n", plan.SyncRemote)
+		}
+
+		// Apply checkout suffix via a store (non-embedded path has no lock conflict).
+		if suffix != "" {
+			s, err := newDoltStore(ctx, &dolt.Config{
+				Path:      doltserver.ResolveDoltDir(plan.BeadsDir),
+				Database:  dbName,
+				AutoStart: true,
+				BeadsDir:  plan.BeadsDir,
+			})
+			if err != nil {
+				return fmt.Errorf("open database for checkout suffix: %w", err)
+			}
+			defer func() { _ = s.Close() }()
+
+			if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
+				return err
+			}
+			if err := s.Commit(ctx, "bd bootstrap: set checkout suffix"); err != nil {
+				return fmt.Errorf("commit checkout suffix: %w", err)
+			}
+		}
 	}
 
-	doltDir := doltserver.ResolveDoltDir(plan.BeadsDir)
-	synced, err := dolt.BootstrapFromGitRemoteWithDB(ctx, doltDir, plan.SyncRemote, dbName)
-	if err != nil {
-		return fmt.Errorf("sync from remote: %w", err)
-	}
-	if synced {
-		// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
-		// directory — including noms/LOCK files. These are Dolt-internal files.
-		// Removing them WILL cause unrecoverable data corruption and data loss.
-		// Dolt manages these files itself; external interference is never safe.
-		fmt.Fprintf(os.Stderr, "Synced database from %s\n", plan.SyncRemote)
-	}
 	return nil
 }
 
@@ -577,5 +646,6 @@ func init() {
 	bootstrapCmd.Flags().Bool("dry-run", false, "Show what would be done without doing it")
 	bootstrapCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompts (for CI/automation)")
 	bootstrapCmd.Flags().Bool("non-interactive", false, "Alias for --yes")
+	bootstrapCmd.Flags().String("checkout-suffix", "", "Unique suffix for this checkout's issues (\"auto\" to generate, \"none\" to skip)")
 	rootCmd.AddCommand(bootstrapCmd)
 }

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -19,6 +19,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"golang.org/x/term"
 )
@@ -411,8 +412,8 @@ func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
 	}
-	if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
-		return err
+	if err := s.SetCheckoutSuffix(ctx, suffix); err != nil {
+		return fmt.Errorf("set checkout suffix: %w", err)
 	}
 	if err := s.Commit(ctx, "bd bootstrap"); err != nil {
 		return fmt.Errorf("commit: %w", err)
@@ -441,8 +442,8 @@ func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfi
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
 	}
-	if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
-		return err
+	if err := s.SetCheckoutSuffix(ctx, suffix); err != nil {
+		return fmt.Errorf("set checkout suffix: %w", err)
 	}
 	if err := s.Commit(ctx, "bd bootstrap: init"); err != nil {
 		return fmt.Errorf("commit init: %w", err)
@@ -475,8 +476,8 @@ func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *conf
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
 	}
-	if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
-		return err
+	if err := s.SetCheckoutSuffix(ctx, suffix); err != nil {
+		return fmt.Errorf("set checkout suffix: %w", err)
 	}
 	if err := s.Commit(ctx, "bd bootstrap: init"); err != nil {
 		return fmt.Errorf("commit init: %w", err)
@@ -545,9 +546,10 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 			}
 			defer func() { _ = cleanup2() }()
 
-			if err := applyCheckoutSuffixSQL(ctx, db2, suffix, checkoutID); err != nil {
-				return err
+			if err := issueops.SetCheckoutSuffixAndCommit(ctx, db2, checkoutID, suffix, "bd bootstrap: set checkout suffix"); err != nil {
+				return fmt.Errorf("set checkout suffix: %w", err)
 			}
+			fmt.Fprintf(os.Stderr, "Checkout suffix set to %q (checkout %s)\n", suffix, checkoutID)
 		}
 	} else {
 		doltDir := doltserver.ResolveDoltDir(plan.BeadsDir)
@@ -576,12 +578,13 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 			}
 			defer func() { _ = s.Close() }()
 
-			if err := applyCheckoutSuffix(ctx, s, suffix, checkoutID); err != nil {
-				return err
+			if err := s.SetCheckoutSuffix(ctx, suffix); err != nil {
+				return fmt.Errorf("set checkout suffix: %w", err)
 			}
 			if err := s.Commit(ctx, "bd bootstrap: set checkout suffix"); err != nil {
 				return fmt.Errorf("commit checkout suffix: %w", err)
 			}
+			fmt.Fprintf(os.Stderr, "Checkout suffix set to %q (checkout %s)\n", suffix, checkoutID)
 		}
 	}
 

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -384,16 +384,16 @@ func executeBootstrapPlan(plan BootstrapPlan, cfg *configfile.Config, nonInterac
 	case "sync":
 		return executeSyncAction(ctx, plan, cfg, suffix, checkoutID)
 	case "restore":
-		return executeRestoreAction(ctx, plan, cfg, suffix, checkoutID)
+		return executeRestoreAction(ctx, plan, cfg, suffix)
 	case "jsonl-import":
-		return executeJSONLImportAction(ctx, plan, cfg, suffix, checkoutID)
+		return executeJSONLImportAction(ctx, plan, cfg, suffix)
 	case "init":
-		return executeInitAction(ctx, plan, cfg, suffix, checkoutID)
+		return executeInitAction(ctx, plan, cfg, suffix)
 	}
 	return nil
 }
 
-func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix, checkoutID string) error {
+func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix string) error {
 	prefix := inferPrefix(cfg)
 	dbName := cfg.GetDoltDatabase()
 
@@ -423,7 +423,7 @@ func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	return nil
 }
 
-func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix, checkoutID string) error {
+func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix string) error {
 	prefix := inferPrefix(cfg)
 	dbName := cfg.GetDoltDatabase()
 
@@ -457,7 +457,7 @@ func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfi
 	return nil
 }
 
-func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix, checkoutID string) error {
+func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config, suffix string) error {
 	prefix := inferPrefix(cfg)
 	dbName := cfg.GetDoltDatabase()
 

--- a/cmd/bd/checkout_suffix.go
+++ b/cmd/bd/checkout_suffix.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"fmt"
+	"math/big"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"golang.org/x/term"
+)
+
+const base36Chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+// generateCheckoutSuffix returns a random 3-character base36 string
+// suitable for use as a checkout_suffix (e.g., "k9x", "a2m").
+func generateCheckoutSuffix() (string, error) {
+	var b strings.Builder
+	for i := 0; i < 3; i++ {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(base36Chars))))
+		if err != nil {
+			return "", fmt.Errorf("generate checkout suffix: %w", err)
+		}
+		b.WriteByte(base36Chars[idx.Int64()])
+	}
+	return b.String(), nil
+}
+
+// validateCheckoutSuffix checks that a user-supplied suffix is valid.
+// Rules: 1-8 characters, lowercase alphanumeric only.
+func validateCheckoutSuffix(suffix string) error {
+	suffix = strings.TrimSuffix(suffix, "-")
+	if suffix == "" {
+		return fmt.Errorf("checkout suffix cannot be empty")
+	}
+	if len(suffix) > 8 {
+		return fmt.Errorf("checkout suffix must be 1-8 characters, got %d", len(suffix))
+	}
+	matched, _ := regexp.MatchString(`^[a-z0-9]+$`, suffix)
+	if !matched {
+		return fmt.Errorf("checkout suffix must contain only lowercase letters and numbers: %s", suffix)
+	}
+	return nil
+}
+
+// resolveCheckoutSuffix determines the checkout suffix to apply based on
+// the --checkout-suffix flag value and interactivity. Returns "" if no suffix.
+//
+// Flag semantics:
+//   - "" (empty/unset): prompt interactively, or skip in non-interactive mode
+//   - "auto": generate a random suffix without prompting
+//   - "none": explicitly no suffix
+//   - any other value: use as the suffix (validated)
+func resolveCheckoutSuffix(flagValue string, nonInteractive bool) (string, error) {
+	switch flagValue {
+	case "none":
+		return "", nil
+	case "auto":
+		return generateCheckoutSuffix()
+	case "":
+		// No flag — prompt if interactive, skip otherwise
+		if nonInteractive || !term.IsTerminal(int(os.Stdin.Fd())) {
+			return "", nil
+		}
+		return promptCheckoutSuffix()
+	default:
+		// User-supplied value
+		suffix := strings.TrimSuffix(flagValue, "-")
+		if err := validateCheckoutSuffix(suffix); err != nil {
+			return "", err
+		}
+		return suffix, nil
+	}
+}
+
+// promptCheckoutSuffix asks the user whether to use a checkout suffix.
+// Uses readLineWithContext for proper context cancellation and clean
+// stdin handling, matching the pattern used by the init wizards.
+func promptCheckoutSuffix() (string, error) {
+	fmt.Fprintf(os.Stderr, "\nIsolate this checkout's issues with a unique suffix?\n")
+	fmt.Fprintf(os.Stderr, "  y     = generate random suffix (e.g., \"k9x\")\n")
+	fmt.Fprintf(os.Stderr, "  n     = shared namespace (default)\n")
+	fmt.Fprintf(os.Stderr, "  <str> = use custom suffix\n")
+	fmt.Fprintf(os.Stderr, "Checkout suffix [n]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, err := readLineWithContext(getRootContext(), reader, os.Stdin)
+	if err != nil {
+		if isCanceled(err) {
+			exitCanceled()
+		}
+		return "", fmt.Errorf("read checkout suffix: %w", err)
+	}
+	line = strings.TrimSpace(line)
+
+	if line == "" || strings.EqualFold(line, "n") || strings.EqualFold(line, "no") {
+		return "", nil
+	}
+	if strings.EqualFold(line, "y") || strings.EqualFold(line, "yes") {
+		return generateCheckoutSuffix()
+	}
+
+	// Treat as custom suffix
+	suffix := strings.TrimSuffix(strings.ToLower(line), "-")
+	if err := validateCheckoutSuffix(suffix); err != nil {
+		return "", err
+	}
+	return suffix, nil
+}
+
+// computeCheckoutID derives a deterministic 8-hex-char identifier from the
+// beads directory path. Delegates to storage.ComputeCheckoutID.
+func computeCheckoutID(beadsDir string) string {
+	return storage.ComputeCheckoutID(beadsDir)
+}
+
+// checkoutSuffixKey returns the config key for a checkout suffix.
+func checkoutSuffixKey(checkoutID string) string {
+	if checkoutID != "" {
+		return "checkout_suffix." + checkoutID
+	}
+	return "checkout_suffix"
+}
+
+// applyCheckoutSuffix sets the checkout_suffix config via a storage.Storage.
+// No-op when suffix is empty.
+func applyCheckoutSuffix(ctx context.Context, s storage.Storage, suffix, checkoutID string) error {
+	if suffix == "" {
+		return nil
+	}
+	if err := s.SetConfig(ctx, checkoutSuffixKey(checkoutID), suffix); err != nil {
+		return fmt.Errorf("set checkout suffix: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Checkout suffix set to %q (checkout %s)\n", suffix, checkoutID)
+	return nil
+}
+
+// applyCheckoutSuffixSQL sets the checkout suffix and commits using a raw
+// *sql.DB already scoped to the target database. Used by the embedded-mode
+// sync path where opening a second embedded engine would deadlock on the
+// exclusive flock.
+func applyCheckoutSuffixSQL(ctx context.Context, db *sql.DB, suffix, checkoutID string) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx for checkout suffix: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := issueops.SetConfigInTx(ctx, tx, checkoutSuffixKey(checkoutID), suffix); err != nil {
+		return fmt.Errorf("set checkout suffix: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+		return fmt.Errorf("dolt add: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", "bd bootstrap: set checkout suffix"); err != nil {
+		return fmt.Errorf("dolt commit: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Checkout suffix set to %q (checkout %s)\n", suffix, checkoutID)
+	return nil
+}

--- a/cmd/bd/checkout_suffix.go
+++ b/cmd/bd/checkout_suffix.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"bufio"
-	"context"
 	"crypto/rand"
-	"database/sql"
 	"fmt"
 	"math/big"
 	"os"
@@ -12,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/steveyegge/beads/internal/storage"
-	"github.com/steveyegge/beads/internal/storage/issueops"
 	"golang.org/x/term"
 )
 
@@ -118,53 +115,4 @@ func promptCheckoutSuffix() (string, error) {
 // beads directory path. Delegates to storage.ComputeCheckoutID.
 func computeCheckoutID(beadsDir string) string {
 	return storage.ComputeCheckoutID(beadsDir)
-}
-
-// checkoutSuffixKey returns the config key for a checkout suffix.
-func checkoutSuffixKey(checkoutID string) string {
-	if checkoutID != "" {
-		return "checkout_suffix." + checkoutID
-	}
-	return "checkout_suffix"
-}
-
-// applyCheckoutSuffix sets the checkout_suffix config via a storage.Storage.
-// No-op when suffix is empty.
-func applyCheckoutSuffix(ctx context.Context, s storage.Storage, suffix, checkoutID string) error {
-	if suffix == "" {
-		return nil
-	}
-	if err := s.SetConfig(ctx, checkoutSuffixKey(checkoutID), suffix); err != nil {
-		return fmt.Errorf("set checkout suffix: %w", err)
-	}
-	fmt.Fprintf(os.Stderr, "Checkout suffix set to %q (checkout %s)\n", suffix, checkoutID)
-	return nil
-}
-
-// applyCheckoutSuffixSQL sets the checkout suffix and commits using a raw
-// *sql.DB already scoped to the target database. Used by the embedded-mode
-// sync path where opening a second embedded engine would deadlock on the
-// exclusive flock.
-func applyCheckoutSuffixSQL(ctx context.Context, db *sql.DB, suffix, checkoutID string) error {
-	tx, err := db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx for checkout suffix: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if err := issueops.SetConfigInTx(ctx, tx, checkoutSuffixKey(checkoutID), suffix); err != nil {
-		return fmt.Errorf("set checkout suffix: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
-		return fmt.Errorf("dolt add: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", "bd bootstrap: set checkout suffix"); err != nil {
-		return fmt.Errorf("dolt commit: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit tx: %w", err)
-	}
-
-	fmt.Fprintf(os.Stderr, "Checkout suffix set to %q (checkout %s)\n", suffix, checkoutID)
-	return nil
 }

--- a/cmd/bd/checkout_suffix_test.go
+++ b/cmd/bd/checkout_suffix_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateCheckoutSuffix(t *testing.T) {
+	t.Parallel()
+
+	// Generate several suffixes and verify format
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		s, err := generateCheckoutSuffix()
+		if err != nil {
+			t.Fatalf("generateCheckoutSuffix() error: %v", err)
+		}
+		if len(s) != 3 {
+			t.Errorf("expected 3-char suffix, got %q (len %d)", s, len(s))
+		}
+		if err := validateCheckoutSuffix(s); err != nil {
+			t.Errorf("generated suffix %q failed validation: %v", s, err)
+		}
+		seen[s] = true
+	}
+	// With 46656 possible values and 100 samples, we should see at least 90 unique
+	if len(seen) < 90 {
+		t.Errorf("expected high uniqueness in 100 samples, got %d unique values", len(seen))
+	}
+}
+
+func TestComputeCheckoutID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deterministic", func(t *testing.T) {
+		t.Parallel()
+		id1 := computeCheckoutID("/home/user/project/.beads")
+		id2 := computeCheckoutID("/home/user/project/.beads")
+		if id1 != id2 {
+			t.Errorf("same path produced different IDs: %q vs %q", id1, id2)
+		}
+	})
+
+	t.Run("different paths produce different IDs", func(t *testing.T) {
+		t.Parallel()
+		id1 := computeCheckoutID("/home/user/project-a/.beads")
+		id2 := computeCheckoutID("/home/user/project-b/.beads")
+		if id1 == id2 {
+			t.Errorf("different paths produced same ID: %q", id1)
+		}
+	})
+
+	t.Run("8 hex chars", func(t *testing.T) {
+		t.Parallel()
+		id := computeCheckoutID("/some/path/.beads")
+		if len(id) != 8 {
+			t.Errorf("expected 8-char ID, got %q (len %d)", id, len(id))
+		}
+	})
+
+	t.Run("empty beadsDir returns empty", func(t *testing.T) {
+		t.Parallel()
+		if id := computeCheckoutID(""); id != "" {
+			t.Errorf("expected empty ID for empty beadsDir, got %q", id)
+		}
+	})
+
+	t.Run("uses parent directory", func(t *testing.T) {
+		t.Parallel()
+		// /home/user/project/.beads → parent is /home/user/project
+		// /home/user/project/.beads/sub → parent is /home/user/project/.beads
+		// These should differ because the parent differs
+		id1 := computeCheckoutID("/home/user/project/.beads")
+		id2 := computeCheckoutID(filepath.Join("/home/user/project/.beads", "sub"))
+		if id1 == id2 {
+			t.Errorf("different parent dirs produced same ID: %q", id1)
+		}
+	})
+}
+
+func TestValidateCheckoutSuffix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid 3-char", "k9x", false},
+		{"valid 1-char", "a", false},
+		{"valid 8-char", "abcd1234", false},
+		{"valid with trailing hyphen stripped", "k9x-", false},
+		{"valid starts with number", "9ax", false},
+
+		{"empty", "", true},
+		{"too long", "abcdefghi", true},
+		{"uppercase", "K9x", true},
+		{"contains hyphen", "k-x", true},
+		{"contains underscore", "k_x", true},
+		{"only hyphen", "-", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCheckoutSuffix(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCheckoutSuffix(%q) error = %v, wantErr = %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -70,6 +70,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		force, _ := cmd.Flags().GetBool("force")
 		nonInteractiveFlag, _ := cmd.Flags().GetBool("non-interactive")
 		roleFlag, _ := cmd.Flags().GetString("role")
+		checkoutSuffixFlag, _ := cmd.Flags().GetString("checkout-suffix")
 		fromJSONL, _ := cmd.Flags().GetBool("from-jsonl")
 		// Dolt server connection flags
 		backendFlag, _ := cmd.Flags().GetString("backend")
@@ -578,6 +579,20 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 				_ = store.Close()
 				FatalError("failed to set issue prefix: %v", err)
+			}
+		}
+
+		// Apply checkout suffix only if explicitly requested via flag.
+		// bd init creates a fresh database — no collision risk unless the
+		// user specifically wants isolation.
+		if checkoutSuffixFlag != "" {
+			checkoutID := computeCheckoutID(beadsDir)
+			if suffix, err := resolveCheckoutSuffix(checkoutSuffixFlag, nonInteractive); err != nil {
+				_ = store.Close()
+				FatalError("checkout suffix: %v", err)
+			} else if err := applyCheckoutSuffix(ctx, store, suffix, checkoutID); err != nil {
+				_ = store.Close()
+				FatalError("%v", err)
 			}
 		}
 
@@ -1143,6 +1158,7 @@ func init() {
 	// Non-interactive mode for CI/cloud agents
 	initCmd.Flags().Bool("non-interactive", false, "Skip all interactive prompts (auto-detected in CI or non-TTY environments)")
 	initCmd.Flags().String("role", "", "Set beads role without prompting: \"maintainer\" or \"contributor\"")
+	initCmd.Flags().String("checkout-suffix", "", "Unique suffix for this checkout's issues (\"auto\" to generate, \"none\" to skip)")
 
 	// Backend selection (dolt is the only supported backend; sqlite accepted for deprecation notice)
 	initCmd.Flags().String("backend", "", "Storage backend (default: dolt). --backend=sqlite prints deprecation notice.")

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -586,13 +586,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// bd init creates a fresh database — no collision risk unless the
 		// user specifically wants isolation.
 		if checkoutSuffixFlag != "" {
-			checkoutID := computeCheckoutID(beadsDir)
 			if suffix, err := resolveCheckoutSuffix(checkoutSuffixFlag, nonInteractive); err != nil {
 				_ = store.Close()
 				FatalError("checkout suffix: %v", err)
-			} else if err := applyCheckoutSuffix(ctx, store, suffix, checkoutID); err != nil {
+			} else if err := store.SetCheckoutSuffix(ctx, suffix); err != nil {
 				_ = store.Close()
-				FatalError("%v", err)
+				FatalError("set checkout suffix: %v", err)
 			}
 		}
 

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -617,6 +617,7 @@ func (s *configStore) SlotGet(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }
 func (s *configStore) SlotClear(_ context.Context, _, _, _ string) error { return nil }
+func (s *configStore) CheckoutID() string                                 { return "" }
 func (s *configStore) Close() error                                      { return nil }
 
 func TestFetchIssuesIncludesPullJQLInQuery(t *testing.T) {

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -616,9 +616,10 @@ func (s *configStore) SlotSet(_ context.Context, _, _, _, _ string) error    { r
 func (s *configStore) SlotGet(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }
-func (s *configStore) SlotClear(_ context.Context, _, _, _ string) error { return nil }
-func (s *configStore) CheckoutID() string                                 { return "" }
-func (s *configStore) Close() error                                      { return nil }
+func (s *configStore) SlotClear(_ context.Context, _, _, _ string) error   { return nil }
+func (s *configStore) CheckoutID() string                                  { return "" }
+func (s *configStore) SetCheckoutSuffix(_ context.Context, _ string) error { return nil }
+func (s *configStore) Close() error                                        { return nil }
 
 func TestFetchIssuesIncludesPullJQLInQuery(t *testing.T) {
 	var capturedJQL string

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -22,4 +22,7 @@ type BatchCreateOptions struct {
 	OrphanHandling OrphanHandling
 	// SkipPrefixValidation skips prefix validation for existing IDs (used during import)
 	SkipPrefixValidation bool
+	// CheckoutID is the deterministic identifier for this checkout, used to
+	// look up the namespaced checkout_suffix.<id> config key.
+	CheckoutID string
 }

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -12,6 +12,17 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// SetCheckoutSuffix persists the checkout suffix for this checkout.
+// Uses the store's own checkoutID. No-op when suffix is empty.
+func (s *DoltStore) SetCheckoutSuffix(ctx context.Context, suffix string) error {
+	if suffix == "" {
+		return nil
+	}
+	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		return issueops.SetCheckoutSuffixInTx(ctx, tx, s.checkoutID, suffix)
+	})
+}
+
 // SetConfig sets a configuration value
 func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -322,6 +324,125 @@ func TestSetConfigNormalizesIssuePrefix(t *testing.T) {
 	}
 	if value != "gt" {
 		t.Errorf("expected issue_prefix 'gt' (trailing hyphen stripped), got %q", value)
+	}
+}
+
+// TestSetConfigNormalizesCheckoutSuffix verifies that SetConfig strips trailing
+// hyphens from checkout_suffix.* keys, same as issue_prefix normalization.
+func TestSetConfigNormalizesCheckoutSuffix(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	key := "checkout_suffix." + store.CheckoutID()
+
+	// Set suffix WITH trailing hyphen — should be normalized
+	if err := store.SetConfig(ctx, key, "k9x-"); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+
+	value, err := store.GetConfig(ctx, key)
+	if err != nil {
+		t.Fatalf("GetConfig failed: %v", err)
+	}
+	if value != "k9x" {
+		t.Errorf("expected checkout_suffix 'k9x' (trailing hyphen stripped), got %q", value)
+	}
+}
+
+// TestReadEffectivePrefix verifies that ReadEffectivePrefix combines
+// issue_prefix and checkout_suffix.<checkoutID> correctly.
+func TestReadEffectivePrefix(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	cid := store.CheckoutID()
+	key := "checkout_suffix." + cid
+
+	readEffective := func() string {
+		var result string
+		err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+			var rErr error
+			result, rErr = issueops.ReadEffectivePrefix(ctx, tx, cid)
+			return rErr
+		})
+		if err != nil {
+			t.Fatalf("ReadEffectivePrefix: %v", err)
+		}
+		return result
+	}
+
+	prefix, _ := store.GetConfig(ctx, "issue_prefix")
+
+	// Case 1: no checkout_suffix — effective prefix equals issue_prefix
+	if got := readEffective(); got != prefix {
+		t.Errorf("no suffix: got %q, want %q", got, prefix)
+	}
+
+	// Case 2: set checkout_suffix.<id> — effective prefix is "prefix-suffix"
+	if err := store.SetConfig(ctx, key, "k9x"); err != nil {
+		t.Fatalf("SetConfig(%s): %v", key, err)
+	}
+	if got := readEffective(); got != prefix+"-k9x" {
+		t.Errorf("with suffix: got %q, want %q", got, prefix+"-k9x")
+	}
+
+	// Case 3: suffix with trailing hyphen is normalized on write
+	if err := store.SetConfig(ctx, key, "m2p-"); err != nil {
+		t.Fatalf("SetConfig(%s): %v", key, err)
+	}
+	if got := readEffective(); got != prefix+"-m2p" {
+		t.Errorf("suffix with hyphen: got %q, want %q", got, prefix+"-m2p")
+	}
+
+	// Case 4: empty checkoutID skips suffix lookup
+	var noSuffix string
+	err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		var rErr error
+		noSuffix, rErr = issueops.ReadEffectivePrefix(ctx, tx, "")
+		return rErr
+	})
+	if err != nil {
+		t.Fatalf("ReadEffectivePrefix (empty id): %v", err)
+	}
+	if noSuffix != prefix {
+		t.Errorf("empty checkoutID: got %q, want %q", noSuffix, prefix)
+	}
+}
+
+// TestCreateIssueWithCheckoutSuffix verifies that issue IDs include the
+// checkout_suffix when set (e.g., "test-k9x-XXXX" instead of "test-XXXX").
+func TestCreateIssueWithCheckoutSuffix(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	key := "checkout_suffix." + store.CheckoutID()
+	if err := store.SetConfig(ctx, key, "k9x"); err != nil {
+		t.Fatalf("SetConfig(%s): %v", key, err)
+	}
+
+	issue := &types.Issue{
+		Title:     "test with suffix",
+		Status:    types.StatusOpen,
+		Priority:  3,
+		IssueType: types.TypeBug,
+	}
+	if err := store.CreateIssue(ctx, issue, "test-user"); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+
+	prefix, _ := store.GetConfig(ctx, "issue_prefix")
+	expectedPrefix := prefix + "-k9x-"
+	if !strings.HasPrefix(issue.ID, expectedPrefix) {
+		t.Errorf("issue ID should start with %q, got %q", expectedPrefix, issue.ID)
 	}
 }
 

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -32,6 +32,7 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 		// not validate prefixes for explicit IDs.
 		bc, err := issueops.NewBatchContext(ctx, tx, storage.BatchCreateOptions{
 			SkipPrefixValidation: true,
+			CheckoutID:           s.checkoutID,
 		})
 		if err != nil {
 			return err
@@ -64,6 +65,11 @@ func (s *DoltStore) CreateIssues(ctx context.Context, issues []*types.Issue, act
 func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
 	if len(issues) == 0 {
 		return nil
+	}
+
+	// Ensure checkout ID is set for suffix-aware prefix resolution.
+	if opts.CheckoutID == "" {
+		opts.CheckoutID = s.checkoutID
 	}
 
 	// All-wisps fast path: individual transactions, no Dolt versioning.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -190,6 +190,7 @@ type DoltStore struct {
 	remoteUser     string // Remote auth user for Hosted Dolt push/pull (optional)
 	remotePassword string // Remote auth password for Hosted Dolt push/pull (optional)
 	serverMode     bool   // true when connected to external dolt sql-server (not embedded)
+	checkoutID     string // Deterministic ID for this checkout (from beadsDir path)
 
 	// autoStartedServerDir is set when this store triggered a dolt sql-server
 	// auto-start. Close() uses it to stop the server when the last store
@@ -596,6 +597,11 @@ func (s *DoltStore) DB() *sql.DB {
 	return s.db
 }
 
+// CheckoutID returns the deterministic identifier for this checkout.
+func (s *DoltStore) CheckoutID() string {
+	return s.checkoutID
+}
+
 // BackupAdd registers a Dolt backup destination.
 func (s *DoltStore) BackupAdd(ctx context.Context, name, url string) error {
 	return versioncontrolops.BackupAdd(ctx, s.db, name, url)
@@ -979,6 +985,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		serverMode:           true,
 		readOnly:             cfg.ReadOnly,
 		autoStartedServerDir: autoStartedDir,
+		checkoutID:           storage.ComputeCheckoutID(beadsDir),
 	}
 
 	// Schema initialization for server mode (idempotent).

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -124,16 +124,10 @@ func (t *doltTransaction) CreateIssue(ctx context.Context, issue *types.Issue, a
 
 	// Generate ID if not provided
 	if issue.ID == "" {
-		var configPrefix string
-		err := t.tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "issue_prefix").Scan(&configPrefix)
-		if err == sql.ErrNoRows || configPrefix == "" {
-			return fmt.Errorf("%w: issue_prefix config is missing", storage.ErrNotInitialized)
-		} else if err != nil {
-			return fmt.Errorf("failed to get config: %w", err)
+		configPrefix, err := issueops.ReadEffectivePrefix(ctx, t.tx, t.store.checkoutID)
+		if err != nil {
+			return err
 		}
-
-		// Normalize prefix: strip trailing hyphen to prevent double-hyphen IDs (bd-6uly)
-		configPrefix = strings.TrimSuffix(configPrefix, "-")
 
 		var prefix string
 		if issue.Ephemeral {

--- a/internal/storage/embeddeddolt/config_metadata.go
+++ b/internal/storage/embeddeddolt/config_metadata.go
@@ -13,6 +13,15 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+func (s *EmbeddedDoltStore) SetCheckoutSuffix(ctx context.Context, suffix string) error {
+	if suffix == "" {
+		return nil
+	}
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		return issueops.SetCheckoutSuffixInTx(ctx, tx, s.CheckoutID(), suffix)
+	})
+}
+
 func (s *EmbeddedDoltStore) SetConfig(ctx context.Context, key, value string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
 		if err := issueops.SetConfigInTx(ctx, tx, key, value); err != nil {

--- a/internal/storage/embeddeddolt/create_issue.go
+++ b/internal/storage/embeddeddolt/create_issue.go
@@ -26,6 +26,7 @@ func (s *EmbeddedDoltStore) CreateIssue(ctx context.Context, issue *types.Issue,
 		// validate prefixes for explicit IDs on the single-issue path.
 		bc, err := issueops.NewBatchContext(ctx, tx, storage.BatchCreateOptions{
 			SkipPrefixValidation: true,
+			CheckoutID:           s.CheckoutID(),
 		})
 		if err != nil {
 			return err
@@ -44,6 +45,11 @@ func (s *EmbeddedDoltStore) CreateIssues(ctx context.Context, issues []*types.Is
 func (s *EmbeddedDoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
 	if len(issues) == 0 {
 		return nil
+	}
+
+	// Ensure checkout ID is set for suffix-aware prefix resolution.
+	if opts.CheckoutID == "" {
+		opts.CheckoutID = s.CheckoutID()
 	}
 
 	// All-wisps fast path: create each wisp/no-history issue individually within

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -419,6 +419,11 @@ func (s *EmbeddedDoltStore) Close() error {
 	return nil
 }
 
+// CheckoutID returns the deterministic identifier for this checkout.
+func (s *EmbeddedDoltStore) CheckoutID() string {
+	return storage.ComputeCheckoutID(s.beadsDir)
+}
+
 // DoltGC runs Dolt garbage collection to reclaim disk space.
 func (s *EmbeddedDoltStore) DoltGC(ctx context.Context) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {

--- a/internal/storage/embeddeddolt/store_stub.go
+++ b/internal/storage/embeddeddolt/store_stub.go
@@ -22,6 +22,9 @@ func WithLock(_ Unlocker) Option {
 	return func(*struct{}) {}
 }
 
+// CheckoutID returns empty in the stub build.
+func (s *EmbeddedDoltStore) CheckoutID() string { return "" }
+
 // New returns an error when CGO is not enabled.
 func New(_ context.Context, _, _, _ string, _ ...Option) (*EmbeddedDoltStore, error) {
 	return nil, errors.New("embeddeddolt: requires CGO (build with CGO_ENABLED=1)")

--- a/internal/storage/embeddeddolt/store_stub.go
+++ b/internal/storage/embeddeddolt/store_stub.go
@@ -25,6 +25,9 @@ func WithLock(_ Unlocker) Option {
 // CheckoutID returns empty in the stub build.
 func (s *EmbeddedDoltStore) CheckoutID() string { return "" }
 
+// SetCheckoutSuffix is a no-op in the stub build.
+func (s *EmbeddedDoltStore) SetCheckoutSuffix(_ context.Context, _ string) error { return nil }
+
 // New returns an error when CGO is not enabled.
 func New(_ context.Context, _, _, _ string, _ ...Option) (*EmbeddedDoltStore, error) {
 	return nil, errors.New("embeddeddolt: requires CGO (build with CGO_ENABLED=1)")

--- a/internal/storage/issueops/config_metadata.go
+++ b/internal/storage/issueops/config_metadata.go
@@ -53,6 +53,48 @@ func GetAllConfigInTx(ctx context.Context, tx *sql.Tx) (map[string]string, error
 	return result, rows.Err()
 }
 
+// CheckoutSuffixKey returns the config key for a checkout suffix.
+func CheckoutSuffixKey(checkoutID string) string {
+	if checkoutID != "" {
+		return "checkout_suffix." + checkoutID
+	}
+	return "checkout_suffix"
+}
+
+// SetCheckoutSuffixInTx sets the checkout_suffix.<checkoutID> config key
+// within an existing transaction. No-op when suffix is empty.
+func SetCheckoutSuffixInTx(ctx context.Context, tx *sql.Tx, checkoutID, suffix string) error {
+	if suffix == "" {
+		return nil
+	}
+	return SetConfigInTx(ctx, tx, CheckoutSuffixKey(checkoutID), suffix)
+}
+
+// SetCheckoutSuffixAndCommit sets the checkout suffix and creates a dolt
+// commit in a single transaction. For use when only a raw *sql.DB is
+// available (e.g., embedded bootstrap sync path where no store is open).
+func SetCheckoutSuffixAndCommit(ctx context.Context, db *sql.DB, checkoutID, suffix, commitMsg string) error {
+	if suffix == "" {
+		return nil
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := SetCheckoutSuffixInTx(ctx, tx, checkoutID, suffix); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+		return fmt.Errorf("dolt add: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?)", commitMsg); err != nil {
+		return fmt.Errorf("dolt commit: %w", err)
+	}
+	return tx.Commit()
+}
+
 // SetMetadataInTx sets a metadata value within an existing transaction.
 func SetMetadataInTx(ctx context.Context, tx *sql.Tx, key, value string) error {
 	_, err := tx.ExecContext(ctx, "REPLACE INTO metadata (`key`, value) VALUES (?, ?)", key, value)

--- a/internal/storage/issueops/config_metadata.go
+++ b/internal/storage/issueops/config_metadata.go
@@ -8,9 +8,9 @@ import (
 )
 
 // SetConfigInTx sets a configuration value within an existing transaction.
-// Normalizes issue_prefix by stripping trailing hyphens.
+// Normalizes issue_prefix and checkout_suffix.* by stripping trailing hyphens.
 func SetConfigInTx(ctx context.Context, tx *sql.Tx, key, value string) error {
-	if key == "issue_prefix" {
+	if key == "issue_prefix" || strings.HasPrefix(key, "checkout_suffix") {
 		value = strings.TrimSuffix(value, "-")
 	}
 	_, err := tx.ExecContext(ctx, "REPLACE INTO config (`key`, value) VALUES (?, ?)", key, value)

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -30,17 +30,32 @@ func NewBatchContext(ctx context.Context, tx *sql.Tx, opts storage.BatchCreateOp
 	if err != nil {
 		return nil, fmt.Errorf("failed to get custom types: %w", err)
 	}
-	configPrefix, err := ReadConfigPrefix(ctx, tx)
+	basePrefix, err := ReadConfigPrefix(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	effectivePrefix, err := ReadEffectivePrefix(ctx, tx, opts.CheckoutID)
 	if err != nil {
 		return nil, err
 	}
 	var allowedPrefixes string
 	_ = tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "allowed_prefixes").Scan(&allowedPrefixes)
 
+	// If the effective prefix differs from the base (checkout_suffix is set),
+	// add the base prefix to allowed_prefixes so cross-checkout issues are
+	// accepted during prefix validation.
+	if effectivePrefix != basePrefix {
+		if allowedPrefixes == "" {
+			allowedPrefixes = basePrefix
+		} else {
+			allowedPrefixes = allowedPrefixes + "," + basePrefix
+		}
+	}
+
 	return &BatchContext{
 		CustomStatuses:  customStatuses,
 		CustomTypes:     customTypes,
-		ConfigPrefix:    configPrefix,
+		ConfigPrefix:    effectivePrefix,
 		AllowedPrefixes: allowedPrefixes,
 		Opts:            opts,
 	}, nil

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -507,6 +507,34 @@ func ReadConfigPrefix(ctx context.Context, tx *sql.Tx) (string, error) {
 	return strings.TrimSuffix(configPrefix, "-"), nil
 }
 
+// ReadEffectivePrefix reads issue_prefix and checkout_suffix.<checkoutID> from
+// the config table and returns the combined effective prefix for ID generation.
+// If checkoutID is empty, no suffix lookup is performed (backward compat).
+// Returns ErrNotInitialized if issue_prefix is missing.
+func ReadEffectivePrefix(ctx context.Context, tx *sql.Tx, checkoutID string) (string, error) {
+	prefix, err := ReadConfigPrefix(ctx, tx)
+	if err != nil {
+		return "", err
+	}
+
+	if checkoutID == "" {
+		return prefix, nil
+	}
+
+	var suffix string
+	key := "checkout_suffix." + checkoutID
+	sErr := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", key).Scan(&suffix)
+	if sErr != nil && sErr != sql.ErrNoRows {
+		return "", fmt.Errorf("failed to get %s: %w", key, sErr)
+	}
+	suffix = strings.TrimSuffix(suffix, "-")
+
+	if suffix != "" {
+		return prefix + "-" + suffix, nil
+	}
+	return prefix, nil
+}
+
 // ---------------------------------------------------------------------------
 // Nullable value helpers
 // ---------------------------------------------------------------------------

--- a/internal/storage/merge_slot.go
+++ b/internal/storage/merge_slot.go
@@ -30,6 +30,11 @@ func MergeSlotID(ctx context.Context, s Storage) string {
 	if p, err := s.GetConfig(ctx, "issue_prefix"); err == nil && p != "" {
 		prefix = strings.TrimSuffix(p, "-")
 	}
+	if cid := s.CheckoutID(); cid != "" {
+		if suffix, err := s.GetConfig(ctx, "checkout_suffix."+cid); err == nil && suffix != "" {
+			prefix = prefix + "-" + strings.TrimSuffix(suffix, "-")
+		}
+	}
 	return prefix + "-merge-slot"
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -109,6 +109,10 @@ type Storage interface {
 	// sharing a database don't collide.
 	CheckoutID() string
 
+	// SetCheckoutSuffix persists the checkout suffix for this checkout.
+	// Uses the store's own CheckoutID(). No-op when suffix is empty.
+	SetCheckoutSuffix(ctx context.Context, suffix string) error
+
 	// Transactions
 	RunInTransaction(ctx context.Context, commitMsg string, fn func(tx Transaction) error) error
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,12 +7,31 @@ package storage
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
+	"path/filepath"
 	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// ComputeCheckoutID derives a deterministic 8-hex-char identifier from the
+// beads directory path. The parent of beadsDir (the project/git root) is
+// used as the stable identity. Returns "" if beadsDir is empty.
+func ComputeCheckoutID(beadsDir string) string {
+	if beadsDir == "" {
+		return ""
+	}
+	root := filepath.Dir(beadsDir)
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		abs = root
+	}
+	hash := sha256.Sum256([]byte(abs))
+	return hex.EncodeToString(hash[:4])
+}
 
 // ErrAlreadyClaimed is returned when attempting to claim an issue that is already
 // claimed by another user. The error message contains the current assignee.
@@ -83,6 +102,12 @@ type Storage interface {
 	SetConfig(ctx context.Context, key, value string) error
 	GetConfig(ctx context.Context, key string) (string, error)
 	GetAllConfig(ctx context.Context) (map[string]string, error)
+
+	// CheckoutID returns a deterministic identifier for this checkout,
+	// derived from the beads directory path. Used to namespace per-checkout
+	// config keys (e.g., checkout_suffix.<id>) so parallel checkouts
+	// sharing a database don't collide.
+	CheckoutID() string
 
 	// Transactions
 	RunInTransaction(ctx context.Context, commitMsg string, fn func(tx Transaction) error) error

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -411,6 +411,10 @@ func (s *InstrumentedStorage) GetAllConfig(ctx context.Context) (map[string]stri
 	return v, err
 }
 
+func (s *InstrumentedStorage) CheckoutID() string {
+	return s.inner.CheckoutID()
+}
+
 // ── Transactions ─────────────────────────────────────────────────────────────
 
 func (s *InstrumentedStorage) RunInTransaction(ctx context.Context, commitMsg string, fn func(tx storage.Transaction) error) error {

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -415,6 +415,13 @@ func (s *InstrumentedStorage) CheckoutID() string {
 	return s.inner.CheckoutID()
 }
 
+func (s *InstrumentedStorage) SetCheckoutSuffix(ctx context.Context, suffix string) error {
+	ctx, span, t := s.op(ctx, "SetCheckoutSuffix")
+	err := s.inner.SetCheckoutSuffix(ctx, suffix)
+	s.done(ctx, span, t, err)
+	return err
+}
+
 // ── Transactions ─────────────────────────────────────────────────────────────
 
 func (s *InstrumentedStorage) RunInTransaction(ctx context.Context, commitMsg string, fn func(tx storage.Transaction) error) error {

--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -65,7 +65,18 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 	// Build known prefixes from config for deterministic multi-hyphen prefix handling.
 	// This avoids relying solely on looksLikePrefixedID heuristics when the repo
 	// explicitly declares which prefixes are valid.
-	knownPrefixes := []string{strings.TrimSuffix(prefix, "-")}
+	basePrefix := strings.TrimSuffix(prefix, "-")
+	knownPrefixes := []string{basePrefix}
+	if cid := store.CheckoutID(); cid != "" {
+		if suffix, sErr := store.GetConfig(ctx, "checkout_suffix."+cid); sErr == nil && suffix != "" {
+			suffix = strings.TrimSuffix(suffix, "-")
+			// Add the effective prefix (base + suffix) so IDs like "bd-k9x-a3f8"
+			// are correctly parsed as prefix="bd-k9x", hash="a3f8".
+			knownPrefixes = append(knownPrefixes, basePrefix+"-"+suffix)
+			// Update prefixWithHyphen to match the effective prefix for normalization.
+			prefixWithHyphen = basePrefix + "-" + suffix + "-"
+		}
+	}
 	if allowed, aErr := store.GetConfig(ctx, "allowed_prefixes"); aErr == nil && allowed != "" {
 		for _, p := range strings.Split(allowed, ",") {
 			p = strings.TrimSpace(p)

--- a/internal/utils/id_parser_test.go
+++ b/internal/utils/id_parser_test.go
@@ -970,6 +970,85 @@ func TestResolvePartialID_TitleFalsePositive(t *testing.T) {
 }
 
 // TestLooksLikePrefixedID tests the helper function for detecting prefixed IDs
+func TestResolvePartialID_CheckoutSuffix(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// Set checkout_suffix with namespaced key
+	key := "checkout_suffix." + store.CheckoutID()
+	if err := store.SetConfig(ctx, key, "k9x"); err != nil {
+		t.Fatalf("Failed to set %s: %v", key, err)
+	}
+
+	// Create an issue — it will get the suffixed prefix "bd-k9x-"
+	issue := &types.Issue{
+		Title:     "suffixed issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	fullID := issue.ID
+	if fullID == "" {
+		t.Fatal("issue ID is empty after creation")
+	}
+
+	// Also create an unsuffixed issue (simulating cross-checkout)
+	crossIssue := &types.Issue{
+		ID:        "bd-cross1",
+		Title:     "cross-checkout issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, crossIssue, "test"); err != nil {
+		t.Fatalf("CreateIssue cross: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		shouldError bool
+	}{
+		{
+			name:     "resolve full suffixed ID",
+			input:    fullID,
+			expected: fullID,
+		},
+		{
+			name:     "resolve cross-checkout issue by full ID",
+			input:    "bd-cross1",
+			expected: "bd-cross1",
+		},
+		{
+			name:     "resolve cross-checkout issue by bare hash",
+			input:    "cross1",
+			expected: "bd-cross1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolvePartialID(ctx, store, tt.input)
+			if tt.shouldError {
+				if err == nil {
+					t.Errorf("expected error, got %q", result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolvePartialID(%q) error: %v", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("ResolvePartialID(%q) = %q; want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestLooksLikePrefixedID(t *testing.T) {
 	tests := []struct {
 		input    string


### PR DESCRIPTION
## Summary

Adds per-checkout issue ID namespacing via a `checkout_suffix` config key. When multiple clones of the same repo share a database, each checkout can opt into a unique suffix so parallel agents don't claim or mutate each other's issues.

**Example:** base prefix `dustin_dolt`, suffix `k9x` → issue IDs become `dustin_dolt-k9x-4j9` instead of `dustin_dolt-4j9`.

## What changed

### New: checkout suffix feature (23 files, +749/-41)

- **`cmd/bd/checkout_suffix.go`** (new) — suffix generation, validation, interactive prompt, CLI flag resolution
- **`cmd/bd/checkout_suffix_test.go`** (new) — unit tests for generation, validation, suffix extraction
- **`cmd/bd/bootstrap.go`** — `--checkout-suffix` flag; sync action prompts interactively for suffix; embedded-mode sync closes clone connection before reopening scoped to the cloned DB (avoids flock deadlock)
- **`cmd/bd/init.go`** — `--checkout-suffix` flag support for `bd init`

### Storage layer

- **`internal/storage/storage.go`** — `ComputeCheckoutID(beadsDir)` derives deterministic 8-hex-char checkout ID from path; `CheckoutID()` and `SetCheckoutSuffix(ctx, suffix)` added to `Storage` interface
- **`internal/storage/batch.go`** — `CheckoutID` field on `BatchCreateOptions`
- **`internal/storage/issueops/config_metadata.go`** — `CheckoutSuffixKey()`, `SetCheckoutSuffixInTx()`, `SetCheckoutSuffixAndCommit()` (raw-SQL path for embedded bootstrap)
- **`internal/storage/issueops/helpers.go`** — `ReadEffectivePrefix(ctx, tx, checkoutID)` combines base prefix + suffix
- **`internal/storage/issueops/create.go`** — `NewBatchContext` uses effective prefix; adds base prefix to `allowed_prefixes` when suffix is active
- **`internal/storage/dolt/store.go`** — `checkoutID` field, `CheckoutID()` method
- **`internal/storage/dolt/config.go`** — `SetCheckoutSuffix()` implementation
- **`internal/storage/dolt/issues.go`** — passes `checkoutID` into `BatchCreateOptions` for both single and batch create
- **`internal/storage/dolt/transaction.go`** — uses `ReadEffectivePrefix` instead of raw SQL for prefix resolution
- **`internal/storage/embeddeddolt/store.go`** — `CheckoutID()` method
- **`internal/storage/embeddeddolt/config_metadata.go`** — `SetCheckoutSuffix()` implementation
- **`internal/storage/embeddeddolt/create_issue.go`** — passes `CheckoutID()` into `BatchCreateOptions`
- **`internal/storage/embeddeddolt/store_stub.go`** — stubs for non-CGO builds
- **`internal/storage/merge_slot.go`** — suffix-aware merge slot IDs (per-checkout merge slots)
- **`internal/telemetry/storage.go`** — `CheckoutID()` and `SetCheckoutSuffix()` passthroughs

### ID resolution

- **`internal/utils/id_parser.go`** — `ResolvePartialID` builds `knownPrefixes` including effective prefix; correctly parses multi-hyphen IDs like `dustin_dolt-k9x-4j9`
- **`internal/utils/id_parser_test.go`** — new tests for suffix-aware resolution

### Test fixes

- **`internal/jira/tracker_test.go`** — added `CheckoutID()` and `SetCheckoutSuffix()` to `configStore` mock
- **`internal/storage/dolt/dolt_test.go`** — new tests for checkout suffix behavior

## Key design decisions

1. **Suffix is opt-in** — repos without a suffix are completely unaffected (`ReadEffectivePrefix` returns base prefix when no suffix exists)
2. **Store owns its checkout ID** — callers just pass `suffix`, the store resolves `CheckoutID()` internally via `SetCheckoutSuffix(ctx, suffix)`
3. **Embedded bootstrap flock handling** — the clone connection must be closed before opening a new one for suffix application (embedded engine holds an exclusive flock)
4. **Pre-existing issues are unaffected** — base prefix stays in `knownPrefixes` so old IDs still parse correctly

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `cmd/bd` tests pass (checkout suffix generation, validation, ID extraction)
- [x] `internal/storage/issueops` tests pass
- [x] `internal/jira` tests pass (mock implements new interface methods)
- [x] `internal/storage/dolt` tests pass (new checkout suffix tests)
- [ ] Manual: `bd bootstrap` with sync + suffix prompt completes without hanging
- [ ] Manual: `bd create` produces suffixed IDs after bootstrap with suffix
- [ ] Manual: `bd list` resolves both suffixed and non-suffixed IDs