### PR TITLE
Fix GetCustomTypes swallowing DB errors, breaking bd update --type

### DIFF
--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -193,7 +193,7 @@ func (s *DoltStore) GetCustomTypes(ctx context.Context) ([]string, error) {
 		if yamlTypes := config.GetCustomTypesFromYAML(); len(yamlTypes) > 0 {
 			return yamlTypes, nil
 		}
-		return nil, nil
+		return nil, err
 	}
 
 	s.cacheMu.Lock()

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -740,7 +740,7 @@ func (s *EmbeddedDoltStore) GetCustomTypes(ctx context.Context) ([]string, error
 		if yamlTypes := config.GetCustomTypesFromYAML(); len(yamlTypes) > 0 {
 			return yamlTypes, nil
 		}
-		return nil, nil
+		return nil, err
 	}
 	return result, nil
 }


### PR DESCRIPTION
## Summary

- `GetCustomTypes` in both `DoltStore` and `EmbeddedDoltStore` returns `(nil, nil)` when the DB read fails and no YAML fallback is available, silently discarding the error
- This causes `bd update --type=<custom-type>` to reject valid custom types (e.g. `agent`) because the caller sees an empty custom type list
- `bd create --type=<custom-type>` is unaffected because it validates inside the storage layer transaction where the DB read succeeds

The fix changes `return nil, nil` to `return nil, err` in both store implementations so the error propagates to callers. The `update` command already has an error handler at `cmd/bd/update.go:146` that logs a warning and falls through to the YAML fallback — it just never fires because the error was swallowed.

### Reproducer

\`\`\`bash
bd config set types.custom "agent"
bd create "test" --type=agent    # works
bd update <id> --type=agent      # fails: "invalid issue type"
\`\`\`

### Files changed

- \`internal/storage/dolt/config.go\` — \`DoltStore.GetCustomTypes\`: \`return nil, nil\` → \`return nil, err\`
- \`internal/storage/embeddeddolt/store.go\` — \`EmbeddedDoltStore.GetCustomTypes\`: same fix

### Note

The same \`return nil, nil\` pattern exists in \`GetCustomStatuses\` in both files. Those may have the same latent bug but I haven't hit them in practice, so keeping this PR scoped to the one I can reproduce per contribution guidelines.

## Test plan

- [x] Verified fix locally: \`bd update <id> --type=agent\` succeeds with patched binary
- [x] Verified \`bd create --type=agent\` still works
- [x] \`go test -short ./internal/storage/...\` all pass
- [ ] CI test suite passes

Generated with [Claude Code](https://claude.com/claude-code)