### PR TITLE
fix: silence dolt sql-server NewConnection log spam

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -607,6 +607,36 @@ func EnsureRunningDetailed(beadsDir string) (port int, startedByUs bool, err err
 	return s.Port, true, nil
 }
 
+// doltServerLogLevel is the --loglevel value passed to `dolt sql-server`.
+//
+// Dolt's sql-server logs every new connection and connection close at INFO
+// level (`msg=NewConnection` / `msg=ConnectionClosed`). Because beads opens
+// a fresh MySQL connection for each `bd` invocation, a busy project can
+// produce millions of lines of connection churn noise, which in one field
+// report filled dolt-server.log with ~380 MB of useless entries, generated
+// significant btrfs write pressure, and buried real error signals.
+//
+// Raising the floor to `warning` silences that chatter while still surfacing
+// warnings, errors, and fatal messages. Valid dolt levels are:
+// trace, debug, info, warning, error, fatal.
+const doltServerLogLevel = "warning"
+
+// buildDoltServerArgs returns the argv passed to `dolt sql-server`
+// (excluding argv[0]/the binary itself). It is factored out of Start so it
+// can be asserted on in unit tests without spawning a real server.
+//
+// The `--loglevel` flag MUST be included here — see doltServerLogLevel for
+// the rationale. If you remove or reorder these args, update the tests in
+// doltserver_test.go accordingly.
+func buildDoltServerArgs(host string, port int) []string {
+	return []string{
+		"sql-server",
+		"-H", host,
+		"-P", strconv.Itoa(port),
+		"--loglevel=" + doltServerLogLevel,
+	}
+}
+
 // Start explicitly starts a dolt sql-server for the project.
 // Returns the State of the started server, or an error.
 func Start(beadsDir string) (*State, error) {
@@ -719,10 +749,7 @@ func Start(beadsDir string) (*State, error) {
 			actualPort = p
 		}
 
-		cmd := exec.Command(doltBin, "sql-server", //nolint:gosec // doltBin is resolved from PATH, not user input
-			"-H", cfg.Host,
-			"-P", strconv.Itoa(actualPort),
-		)
+		cmd := exec.Command(doltBin, buildDoltServerArgs(cfg.Host, actualPort)...) //nolint:gosec // doltBin is resolved from PATH, not user input
 		cmd.Dir = doltDir
 		cmd.Stdout = logFile
 		cmd.Stderr = logFile

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1572,6 +1572,104 @@ func TestReadyTimeout(t *testing.T) {
 	}
 }
 
+// TestBuildDoltServerArgs verifies the argv constructed for `dolt sql-server`
+// always includes a non-info --loglevel and the expected host/port. This
+// pins the fix for the field report where dolt-server.log ballooned to
+// hundreds of MB with `msg=NewConnection` / `msg=ConnectionClosed` spam
+// because dolt logs connection open/close at INFO by default.
+//
+// If this test fails because someone intentionally lowered verbosity back
+// to info/debug/trace, please instead pick a different mitigation (e.g.
+// dolt YAML config) and update doltServerLogLevel plus this test together.
+func TestBuildDoltServerArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		port     int
+		wantHost string
+		wantPort string
+	}{
+		{
+			name:     "loopback ipv4 with ephemeral-style port",
+			host:     "127.0.0.1",
+			port:     54321,
+			wantHost: "127.0.0.1",
+			wantPort: "54321",
+		},
+		{
+			name:     "localhost hostname with default dolt port",
+			host:     "localhost",
+			port:     3306,
+			wantHost: "localhost",
+			wantPort: "3306",
+		},
+		{
+			name:     "ipv6 loopback with low port",
+			host:     "::1",
+			port:     1024,
+			wantHost: "::1",
+			wantPort: "1024",
+		},
+	}
+
+	// Levels that MUST NOT appear — anything at or below info re-introduces
+	// the NewConnection/ConnectionClosed noise we are trying to suppress.
+	forbiddenLevels := []string{"trace", "debug", "info"}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildDoltServerArgs(tc.host, tc.port)
+
+			if len(args) == 0 || args[0] != "sql-server" {
+				t.Fatalf("args[0] = %q, want %q; full args: %v",
+					firstOrEmpty(args), "sql-server", args)
+			}
+
+			// -H <host>
+			hostIdx := indexOf(args, "-H")
+			if hostIdx < 0 || hostIdx+1 >= len(args) {
+				t.Fatalf("missing -H <host> in args: %v", args)
+			}
+			if got := args[hostIdx+1]; got != tc.wantHost {
+				t.Errorf("host = %q, want %q", got, tc.wantHost)
+			}
+
+			// -P <port>
+			portIdx := indexOf(args, "-P")
+			if portIdx < 0 || portIdx+1 >= len(args) {
+				t.Fatalf("missing -P <port> in args: %v", args)
+			}
+			if got := args[portIdx+1]; got != tc.wantPort {
+				t.Errorf("port = %q, want %q", got, tc.wantPort)
+			}
+
+			// --loglevel=<level> — the actual fix.
+			logLevel, ok := findLogLevel(args)
+			if !ok {
+				t.Fatalf("missing --loglevel flag in args; got: %v", args)
+			}
+			for _, bad := range forbiddenLevels {
+				if logLevel == bad {
+					t.Errorf("--loglevel=%s is too verbose; "+
+						"dolt logs NewConnection/ConnectionClosed at INFO, "+
+						"which caused the ~380MB dolt-server.log field report. "+
+						"Use warning/error/fatal instead.", logLevel)
+				}
+			}
+			// Sanity-check we're using a level dolt actually accepts.
+			validLevels := map[string]bool{
+				"trace": true, "debug": true, "info": true,
+				"warning": true, "error": true, "fatal": true,
+			}
+			if !validLevels[logLevel] {
+				t.Errorf("--loglevel=%s is not a valid dolt log level "+
+					"(valid: trace, debug, info, warning, error, fatal)",
+					logLevel)
+			}
+		})
+	}
+}
+
 func TestWaitForReady(t *testing.T) {
 	// Allocate an ephemeral port, then release it so we can re-bind later.
 	tmpListener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -1622,4 +1720,57 @@ func TestWaitForReady(t *testing.T) {
 			t.Errorf("expected nil error, got: %v", err)
 		}
 	})
+}
+
+// TestDoltServerLogLevelConstant pins doltServerLogLevel to a non-chatty
+// value. It complements TestBuildDoltServerArgs by guarding the constant
+// directly, so a refactor that stops calling buildDoltServerArgs cannot
+// silently regress the fix.
+func TestDoltServerLogLevelConstant(t *testing.T) {
+	switch doltServerLogLevel {
+	case "warning", "error", "fatal":
+		// ok — these all suppress INFO-level NewConnection noise.
+	default:
+		t.Errorf("doltServerLogLevel = %q; must be one of "+
+			"warning/error/fatal to suppress NewConnection/ConnectionClosed "+
+			"log spam (see dolt-connection-log-verbosity field report)",
+			doltServerLogLevel)
+	}
+}
+
+// indexOf returns the index of the first occurrence of needle in haystack,
+// or -1 if not found. Local helper to keep the test self-contained.
+func indexOf(haystack []string, needle string) int {
+	for i, s := range haystack {
+		if s == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// findLogLevel extracts the value of a --loglevel=<v> or --loglevel <v>
+// flag from argv. Returns the value and true if found.
+func findLogLevel(args []string) (string, bool) {
+	const prefix = "--loglevel="
+	for i, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return strings.TrimPrefix(a, prefix), true
+		}
+		if a == "--loglevel" && i+1 < len(args) {
+			return args[i+1], true
+		}
+		// Short form -l <level>
+		if a == "-l" && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+func firstOrEmpty(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	return s[0]
 }


### PR DESCRIPTION
## Problem

`dolt sql-server` logs every connection open/close at INFO level by default. In one production deployment this produced **3.87 million lines (379 MB)** of `dolt-server.log` filled almost entirely with:

```
msg=NewConnection DisableClientMultiStatements=false connectionID=3251
msg=ConnectionClosed connectionID=3251
```

The noise hides real signals and (on btrfs with compression) generates significant kworker write pressure.

## Fix

Pass `--loglevel=warning` when spawning the dolt sql-server. Investigated `dolt sql-server --help` first — picked the CLI flag over a YAML config file because it's the smallest possible change.

Refactored argv construction out of `Start()` into a new package-private `buildDoltServerArgs(host, port)` helper so the choice is unit-testable without spawning a real server. Added a `doltServerLogLevel` constant with a doc comment explaining the rationale so future maintainers don't silently turn it back to info.

## Tests

- \`TestBuildDoltServerArgs\` — table-driven (ipv4/localhost/ipv6), asserts argv contains \`-H\`/\`-P\` and a non-info \`--loglevel\`
- \`TestDoltServerLogLevelConstant\` — pins the constant so a refactor that bypasses \`buildDoltServerArgs\` cannot silently regress

\`go test -short ./internal/doltserver/...\` passes. \`go vet\` clean. \`gofmt\` clean.