### PR TITLE
fix(doltserver): rotate dolt-server.log at startup to cap size

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -652,6 +652,11 @@ func Start(beadsDir string) (*State, error) {
 		return nil, fmt.Errorf("initializing dolt database: %w", err)
 	}
 
+	// Rotate the log if it has grown past the configured ceiling. This is a
+	// startup-only check — dolt owns the fd directly once launched, so we can
+	// only intervene between runs. See logrotate.go for the caveat discussion.
+	maybeRotateLog(beadsDir)
+
 	// Open log file
 	logFile, err := os.OpenFile(logPath(beadsDir), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec // G304: logPath derives from user-configured beadsDir
 	if err != nil {

--- a/internal/doltserver/logrotate.go
+++ b/internal/doltserver/logrotate.go
@@ -1,0 +1,118 @@
+// Rotation for dolt-server.log.
+//
+// Background: dolt sql-server writes stdout/stderr straight into
+// .beads/dolt-server.log. There is no streaming goroutine — the child process
+// owns the file descriptor directly — so we cannot interpose a size-limiting
+// writer without fundamentally changing how the log is captured. This file
+// implements the simplest thing that works: a startup-time size check that
+// rotates the file if it exceeds a configurable ceiling.
+//
+// Policy:
+//   - At Start() time, if .beads/dolt-server.log is larger than maxLogBytes,
+//     rename it to .beads/dolt-server.log.1 (overwriting any existing .log.1)
+//     and allow the subsequent OpenFile to create a fresh empty file.
+//   - The threshold defaults to DefaultMaxLogBytes (50 MB) and may be
+//     overridden with the BEADS_DOLT_LOG_MAX_BYTES env var (bytes).
+//   - Rotation failures are non-fatal: if we can't rotate, we log a debug
+//     message and fall through to the existing open path so the server still
+//     starts. Running with an oversized log is better than refusing to start.
+//
+// CAVEAT: This is a startup-only rotation. A long-running server whose log
+// crosses the threshold while it is up will not be rotated until the next
+// restart. Implementing true runtime rotation would require either
+// (a) a streaming goroutine owning the pipe, or (b) copy-truncate, which
+// races with the child's append writes. Both are out of scope for this fix.
+
+package doltserver
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/steveyegge/beads/internal/debug"
+)
+
+// DefaultMaxLogBytes is the default size ceiling for dolt-server.log before
+// rotation kicks in. 50 MB matches the issue requirements and is large enough
+// to hold a meaningful history while far below the 379 MB field report.
+const DefaultMaxLogBytes int64 = 50 * 1024 * 1024
+
+// EnvMaxLogBytes is the environment variable that overrides DefaultMaxLogBytes.
+// Value is interpreted as a decimal integer number of bytes.
+const EnvMaxLogBytes = "BEADS_DOLT_LOG_MAX_BYTES"
+
+// maxLogBytes returns the effective size ceiling, honoring the env override.
+// An unset, empty, or unparseable value falls back to the default. A value
+// <= 0 disables rotation (returns 0).
+func maxLogBytes() int64 {
+	v := os.Getenv(EnvMaxLogBytes)
+	if v == "" {
+		return DefaultMaxLogBytes
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return DefaultMaxLogBytes
+	}
+	return n
+}
+
+// rotatedLogPath returns the path of the single retained rotated log.
+// We keep exactly one rotation slot — prior .log.1 is overwritten on each
+// rotation. Field reports don't warrant multi-generation retention.
+func rotatedLogPath(primary string) string {
+	return primary + ".1"
+}
+
+// rotateLogIfOversized checks primary's size and, if it is strictly greater
+// than maxBytes, renames it to <primary>.1 (overwriting any existing file).
+// It returns (rotated, err) where rotated is true only when a rename actually
+// happened.
+//
+// Behavior:
+//   - maxBytes <= 0: rotation disabled, returns (false, nil).
+//   - primary missing: returns (false, nil). Nothing to rotate.
+//   - primary size <= maxBytes: returns (false, nil). Leave alone.
+//   - primary size > maxBytes: rename to <primary>.1 and return (true, nil).
+//   - rename fails: returns (false, err).
+//
+// The caller should treat errors as non-fatal and proceed to open the log.
+func rotateLogIfOversized(primary string, maxBytes int64) (bool, error) {
+	if maxBytes <= 0 {
+		return false, nil
+	}
+	info, err := os.Stat(primary)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat %s: %w", primary, err)
+	}
+	if info.Size() <= maxBytes {
+		return false, nil
+	}
+	rotated := rotatedLogPath(primary)
+	// os.Rename overwrites the destination on both Unix and Windows (Go's
+	// Rename wraps MoveFileEx with MOVEFILE_REPLACE_EXISTING on Windows).
+	if err := os.Rename(primary, rotated); err != nil {
+		return false, fmt.Errorf("rotating %s -> %s: %w", primary, rotated, err)
+	}
+	return true, nil
+}
+
+// maybeRotateLog is the convenience wrapper used by Start(). It rotates the
+// dolt-server log if it is oversized and emits a debug message on both
+// rotation and error paths. It never returns an error — rotation is
+// best-effort and must not block server startup.
+func maybeRotateLog(beadsDir string) {
+	primary := logPath(beadsDir)
+	max := maxLogBytes()
+	rotated, err := rotateLogIfOversized(primary, max)
+	if err != nil {
+		debug.Logf("doltserver: log rotation failed for %s: %v", primary, err)
+		return
+	}
+	if rotated {
+		debug.Logf("doltserver: rotated %s -> %s (exceeded %d bytes)", primary, rotatedLogPath(primary), max)
+	}
+}

--- a/internal/doltserver/logrotate_test.go
+++ b/internal/doltserver/logrotate_test.go
@@ -1,0 +1,234 @@
+package doltserver
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFileSize creates path with content of exactly size bytes. Uses a
+// repeating byte pattern so the contents are verifiable when the test asserts
+// the rotated file received the original data.
+func writeFileSize(t *testing.T, path string, size int, pattern byte) {
+	t.Helper()
+	buf := bytes.Repeat([]byte{pattern}, size)
+	if err := os.WriteFile(path, buf, 0600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// mustStat returns os.Stat info, failing the test on error.
+func mustStat(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return info
+}
+
+// TestRotateLogIfOversized_RotatesWhenOverThreshold verifies the core happy
+// path: a file larger than the cap is renamed to <name>.1 and the primary
+// path becomes available for a fresh file.
+func TestRotateLogIfOversized_RotatesWhenOverThreshold(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "dolt-server.log")
+	writeFileSize(t, primary, 1024, 'A')
+
+	rotated, err := rotateLogIfOversized(primary, 512)
+	if err != nil {
+		t.Fatalf("rotateLogIfOversized: %v", err)
+	}
+	if !rotated {
+		t.Fatal("expected rotated=true when file exceeds threshold")
+	}
+
+	// Primary must no longer exist (it was renamed out of the way).
+	if _, err := os.Stat(primary); !os.IsNotExist(err) {
+		t.Fatalf("expected primary to be gone after rotation, got err=%v", err)
+	}
+
+	// Rotated file must exist and carry the original contents.
+	rotatedPath := primary + ".1"
+	data, err := os.ReadFile(rotatedPath)
+	if err != nil {
+		t.Fatalf("reading rotated: %v", err)
+	}
+	if len(data) != 1024 {
+		t.Fatalf("rotated size = %d, want 1024", len(data))
+	}
+	if data[0] != 'A' || data[len(data)-1] != 'A' {
+		t.Fatalf("rotated contents corrupted: first=%q last=%q", data[0], data[len(data)-1])
+	}
+}
+
+// TestRotateLogIfOversized_LeavesSmallFileAlone verifies a file at or below
+// the cap is left in place and no rotated file is created.
+func TestRotateLogIfOversized_LeavesSmallFileAlone(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "dolt-server.log")
+	writeFileSize(t, primary, 100, 'B')
+
+	rotated, err := rotateLogIfOversized(primary, 1024)
+	if err != nil {
+		t.Fatalf("rotateLogIfOversized: %v", err)
+	}
+	if rotated {
+		t.Fatal("expected rotated=false when file is under threshold")
+	}
+
+	// Primary must still exist, untouched.
+	info := mustStat(t, primary)
+	if info.Size() != 100 {
+		t.Fatalf("primary size changed: got %d, want 100", info.Size())
+	}
+
+	// No rotated file should have appeared.
+	if _, err := os.Stat(primary + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("expected no .1 file, got err=%v", err)
+	}
+}
+
+// TestRotateLogIfOversized_LeavesExactThresholdAlone verifies the boundary:
+// a file whose size equals the threshold is not rotated. Only strictly
+// greater triggers rotation, matching the documented policy.
+func TestRotateLogIfOversized_LeavesExactThresholdAlone(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "dolt-server.log")
+	writeFileSize(t, primary, 512, 'C')
+
+	rotated, err := rotateLogIfOversized(primary, 512)
+	if err != nil {
+		t.Fatalf("rotateLogIfOversized: %v", err)
+	}
+	if rotated {
+		t.Fatal("expected rotated=false when file size equals threshold")
+	}
+	if info := mustStat(t, primary); info.Size() != 512 {
+		t.Fatalf("primary size changed: got %d, want 512", info.Size())
+	}
+}
+
+// TestRotateLogIfOversized_OverwritesExistingRotated verifies that a prior
+// .log.1 is silently overwritten when a new rotation happens. This is the
+// single-generation retention contract.
+func TestRotateLogIfOversized_OverwritesExistingRotated(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "dolt-server.log")
+	rotatedPath := primary + ".1"
+
+	// Pre-existing rotated file from a previous cycle — should be clobbered.
+	writeFileSize(t, rotatedPath, 200, 'X')
+	// Current primary is over threshold and carries fresh content.
+	writeFileSize(t, primary, 2000, 'Y')
+
+	rotated, err := rotateLogIfOversized(primary, 1024)
+	if err != nil {
+		t.Fatalf("rotateLogIfOversized: %v", err)
+	}
+	if !rotated {
+		t.Fatal("expected rotated=true")
+	}
+
+	data, err := os.ReadFile(rotatedPath)
+	if err != nil {
+		t.Fatalf("reading rotated: %v", err)
+	}
+	if len(data) != 2000 {
+		t.Fatalf("rotated size = %d, want 2000 (old .1 should have been overwritten)", len(data))
+	}
+	if data[0] != 'Y' {
+		t.Fatalf("rotated contents = %q, want 'Y' (old 'X' content should be gone)", data[0])
+	}
+}
+
+// TestRotateLogIfOversized_MissingPrimaryIsNoop verifies that a missing
+// primary log file is treated as "nothing to do" rather than an error. This
+// is the first-run case.
+func TestRotateLogIfOversized_MissingPrimaryIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "dolt-server.log")
+
+	rotated, err := rotateLogIfOversized(primary, 1024)
+	if err != nil {
+		t.Fatalf("rotateLogIfOversized: %v", err)
+	}
+	if rotated {
+		t.Fatal("expected rotated=false for missing file")
+	}
+	if _, err := os.Stat(primary + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("expected no .1 file, got err=%v", err)
+	}
+}
+
+// TestRotateLogIfOversized_DisabledWhenMaxBytesZero verifies that passing
+// maxBytes <= 0 disables rotation entirely, even for huge files. This is the
+// escape hatch for users who want unlimited logs.
+func TestRotateLogIfOversized_DisabledWhenMaxBytesZero(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "dolt-server.log")
+	writeFileSize(t, primary, 4096, 'Z')
+
+	rotated, err := rotateLogIfOversized(primary, 0)
+	if err != nil {
+		t.Fatalf("rotateLogIfOversized: %v", err)
+	}
+	if rotated {
+		t.Fatal("expected rotated=false when maxBytes <= 0")
+	}
+	if info := mustStat(t, primary); info.Size() != 4096 {
+		t.Fatalf("primary size changed: got %d, want 4096", info.Size())
+	}
+}
+
+// TestMaybeRotateLog_EndToEnd exercises the higher-level wrapper used by
+// Start(), ensuring it consults logPath() under the given beadsDir and
+// rotates correctly. The env-var override path is also covered.
+func TestMaybeRotateLog_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	primary := logPath(dir) // use the production path helper
+	writeFileSize(t, primary, 10*1024, 'E')
+
+	// Force a very small threshold via the env override so we don't need to
+	// materialize a 50 MB file.
+	t.Setenv(EnvMaxLogBytes, "1024")
+
+	maybeRotateLog(dir)
+
+	if _, err := os.Stat(primary); !os.IsNotExist(err) {
+		t.Fatalf("expected primary rotated away, got err=%v", err)
+	}
+	if info := mustStat(t, primary+".1"); info.Size() != 10*1024 {
+		t.Fatalf("rotated size = %d, want %d", info.Size(), 10*1024)
+	}
+}
+
+// TestMaxLogBytes_EnvOverride verifies the env-var parsing contract: valid
+// ints override the default, invalid values fall back to the default.
+func TestMaxLogBytes_EnvOverride(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv(EnvMaxLogBytes, "")
+		if got := maxLogBytes(); got != DefaultMaxLogBytes {
+			t.Fatalf("got %d, want %d", got, DefaultMaxLogBytes)
+		}
+	})
+	t.Run("valid override", func(t *testing.T) {
+		t.Setenv(EnvMaxLogBytes, "2048")
+		if got := maxLogBytes(); got != 2048 {
+			t.Fatalf("got %d, want 2048", got)
+		}
+	})
+	t.Run("invalid falls back to default", func(t *testing.T) {
+		t.Setenv(EnvMaxLogBytes, "not-a-number")
+		if got := maxLogBytes(); got != DefaultMaxLogBytes {
+			t.Fatalf("got %d, want %d", got, DefaultMaxLogBytes)
+		}
+	})
+	t.Run("zero disables", func(t *testing.T) {
+		t.Setenv(EnvMaxLogBytes, "0")
+		if got := maxLogBytes(); got != 0 {
+			t.Fatalf("got %d, want 0", got)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

\`dolt-server.log\` grows unbounded with no rotation. Field report: 379 MB at one site (with verbose connection logging — even after that's reduced, the log still needs a hard cap).

## Fix

Startup-only rotation. At each \`Start()\`, if \`dolt-server.log\` exceeds the threshold, rotate it to \`dolt-server.log.1\` (overwriting any previous rotated file) and open a fresh log.

- Default cap: **50 MB**
- Override via \`BEADS_DOLT_LOG_MAX_BYTES\` env var (bytes)
- Set to 0 or negative to disable rotation entirely
- Single-generation retention (only \`.log.1\` is kept)
- Rotation failures are logged but non-fatal — the server always proceeds to open the log, preferring a running server with an oversized log over a startup abort

Why startup-only: true runtime rotation would require either a streaming goroutine owning the dolt server stdout/stderr pipe (significant restructuring) or copy-truncate (which races with the child's append writes). Startup rotation is sufficient for the field report's needs and documented at the top of \`logrotate.go\`.

## Tests

- \`TestRotateLogIfOversized_RotatesWhenOverThreshold\`
- \`TestRotateLogIfOversized_LeavesSmallFileAlone\`
- \`TestRotateLogIfOversized_LeavesExactThresholdAlone\` (boundary)
- \`TestRotateLogIfOversized_OverwritesExistingRotated\`
- \`TestRotateLogIfOversized_MissingPrimaryIsNoop\`
- \`TestRotateLogIfOversized_DisabledWhenMaxBytesZero\`
- \`TestMaybeRotateLog_EndToEnd\`
- \`TestMaxLogBytes_EnvOverride\` (default / valid / invalid / zero)

All passing. \`go vet\` clean. \`gofmt\` clean.