### PR TITLE
fix: set FS_NOCOW_FL on .beads/ at init to avoid btrfs kworker thrashing

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -787,6 +787,14 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, classicArtifactsCheck)
 	// Don't fail overall check for classic artifacts, just warn
 
+	// Check 34: Linux btrfs NoCOW on .beads/ (GH nocow-beads-dolt-init)
+	// Warns when the dolt data directory sits on btrfs without FS_NOCOW_FL,
+	// which causes kworker thrashing on the hot append-only write path. Safe
+	// no-op on non-Linux and non-btrfs filesystems.
+	btrfsNoCowCheck := convertDoctorCheck(doctor.CheckBtrfsNoCOW(path))
+	result.Checks = append(result.Checks, btrfsNoCowCheck)
+	// Don't fail overall check for btrfs NoCOW, just warn
+
 	// GH#1095: Filter out suppressed checks (doctor.suppress.<slug> = true)
 	suppressed := doctor.GetSuppressedChecksWithStore(sharedStore)
 	if len(suppressed) > 0 {

--- a/cmd/bd/doctor/nocow.go
+++ b/cmd/bd/doctor/nocow.go
@@ -1,0 +1,176 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// CheckBtrfsNoCOW verifies that FS_NOCOW_FL is set on the dolt data
+// directory under .beads/ when running on Linux btrfs. Without this flag,
+// dolt's append-only write path triggers kworker thrashing because every
+// small append forces btrfs to read-modify-write-recompress an existing
+// compressed extent.
+//
+// On non-Linux platforms the check short-circuits to StatusOK because the
+// flag does not exist outside Linux. On Linux but non-btrfs filesystems
+// the check also returns StatusOK because the flag is a no-op there.
+//
+// The check reports a warning when the flag is missing on a btrfs dolt
+// directory, along with a fix suggestion. `bd doctor --fix` (via
+// FixBtrfsNoCOW) applies the flag but also warns that existing files inside
+// need to be rewritten to pick it up.
+func CheckBtrfsNoCOW(path string) DoctorCheck {
+	const name = "Btrfs NoCOW (dolt)"
+
+	if runtime.GOOS != "linux" {
+		return DoctorCheck{
+			Name:     name,
+			Status:   StatusOK,
+			Message:  "Not applicable (non-Linux platform)",
+			Category: CategoryPerformance,
+		}
+	}
+
+	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
+	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+		return DoctorCheck{
+			Name:     name,
+			Status:   StatusOK,
+			Message:  "No .beads directory to check",
+			Category: CategoryPerformance,
+		}
+	}
+
+	// The dolt data directory is what actually matters for the hot write
+	// path, but FS_NOCOW_FL on .beads/ itself is enough because new subdirs
+	// inherit it. We check both: the ancestor (`.beads/`) is the one init
+	// sets, and any existing dolt data dir is what dolt is actively writing
+	// to. If either is missing the flag, warn.
+	targets := []string{beadsDir}
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if _, err := os.Stat(doltDir); err == nil {
+		targets = append(targets, doltDir)
+	}
+	embeddedDir := filepath.Join(beadsDir, "embeddeddolt")
+	if _, err := os.Stat(embeddedDir); err == nil {
+		targets = append(targets, embeddedDir)
+	}
+
+	// Only warn for paths that live on btrfs — the flag is meaningless on
+	// ext4/xfs/tmpfs and reporting would just be noise.
+	var missing []string
+	anyBtrfs := false
+	for _, t := range targets {
+		onBtrfs, err := isBtrfs(t)
+		if err != nil || !onBtrfs {
+			continue
+		}
+		anyBtrfs = true
+		set, err := hasNoCOW(t)
+		if err != nil {
+			// Real ioctl failure (not "unsupported"). Report as warning so
+			// the user knows something is off, but don't error out.
+			return DoctorCheck{
+				Name:     name,
+				Status:   StatusWarning,
+				Message:  fmt.Sprintf("Failed to read FS_NOCOW_FL on %s", t),
+				Detail:   err.Error(),
+				Category: CategoryPerformance,
+			}
+		}
+		if !set {
+			missing = append(missing, t)
+		}
+	}
+
+	if !anyBtrfs {
+		return DoctorCheck{
+			Name:     name,
+			Status:   StatusOK,
+			Message:  "Not on btrfs (no action needed)",
+			Category: CategoryPerformance,
+		}
+	}
+
+	if len(missing) == 0 {
+		return DoctorCheck{
+			Name:     name,
+			Status:   StatusOK,
+			Message:  "FS_NOCOW_FL set on dolt data directory",
+			Category: CategoryPerformance,
+		}
+	}
+
+	detail := "btrfs transparent compression causes kworker thrashing on dolt's\n" +
+		"append-only write path. Affected paths:\n"
+	for _, m := range missing {
+		detail += "  " + m + "\n"
+	}
+	detail += "\nNote: setting the flag only affects newly-created files. Existing\n" +
+		"files inside the directory must be rewritten (e.g. mv away and back)\n" +
+		"to pick up the new flag."
+
+	return DoctorCheck{
+		Name:     name,
+		Status:   StatusWarning,
+		Message:  fmt.Sprintf("FS_NOCOW_FL missing on %d btrfs dolt path(s)", len(missing)),
+		Detail:   detail,
+		Fix:      "Run 'bd doctor --fix' to apply the flag; then 'mv .beads/dolt /tmp/d && mv /tmp/d .beads/dolt' to rewrite existing files.",
+		Category: CategoryPerformance,
+	}
+}
+
+// FixBtrfsNoCOW applies FS_NOCOW_FL to the .beads/ directory and to any
+// existing dolt data subdirectories. Returns a human-readable summary of
+// what was done, plus a warning that existing files inside still need to
+// be relocated (via mv-to-tmp; mv-back) to actually pick up the new flag —
+// the inode attribute only influences new files created after it is set.
+//
+// On non-Linux or non-btrfs this is a no-op and returns a message to that
+// effect.
+func FixBtrfsNoCOW(path string) (string, error) {
+	if runtime.GOOS != "linux" {
+		return "FS_NOCOW_FL fix skipped: not on Linux", nil
+	}
+
+	beadsDir := resolveBeadsDir(filepath.Join(path, ".beads"))
+	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+		return "", fmt.Errorf(".beads directory not found at %s", beadsDir)
+	}
+
+	onBtrfs, err := isBtrfs(beadsDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to statfs %s: %w", beadsDir, err)
+	}
+	if !onBtrfs {
+		return "FS_NOCOW_FL fix skipped: not on btrfs", nil
+	}
+
+	targets := []string{beadsDir}
+	for _, sub := range []string{"dolt", "embeddeddolt"} {
+		p := filepath.Join(beadsDir, sub)
+		if _, err := os.Stat(p); err == nil {
+			targets = append(targets, p)
+		}
+	}
+
+	var applied []string
+	for _, t := range targets {
+		if err := applyNoCOW(t); err != nil {
+			return "", fmt.Errorf("failed to set FS_NOCOW_FL on %s: %w", t, err)
+		}
+		applied = append(applied, t)
+	}
+
+	msg := fmt.Sprintf("Applied FS_NOCOW_FL to %d path(s):\n", len(applied))
+	for _, a := range applied {
+		msg += "  " + a + "\n"
+	}
+	msg += "\nWARNING: existing files inside these directories still carry the\n" +
+		"old compression state. To fully benefit, relocate and restore the data:\n" +
+		"  mv .beads/dolt /tmp/beads-dolt-reloc && mv /tmp/beads-dolt-reloc .beads/dolt\n" +
+		"Stop the dolt server first if it is running."
+	return msg, nil
+}

--- a/cmd/bd/doctor/nocow_linux.go
+++ b/cmd/bd/doctor/nocow_linux.go
@@ -1,0 +1,114 @@
+//go:build linux
+
+package doctor
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// FS_NOCOW_FL is the "no copy-on-write" inode attribute set by `chattr +C`.
+// On btrfs it disables both copy-on-write and transparent compression for
+// new files created under the directory. See cmd/bd/nocow_linux.go for the
+// full rationale — doctor has its own copy because subpackages cannot
+// import from the main package. Both copies must stay in sync.
+const fsNoCowFL = 0x00800000
+
+// getInodeFlags wraps FS_IOC_GETFLAGS. The ioctl uses a platform-sized
+// long on the kernel side (8 bytes on amd64) so we must pass an int*, not
+// an int32* — the unix.IoctlSetPointerInt helper truncates to int32 and
+// would produce wrong results on 64-bit systems.
+func getInodeFlags(fd int) (int, error) {
+	var flags int
+	// nolint:gosec // G103: unsafe.Pointer required for ioctl syscall argument
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(fd),
+		uintptr(unix.FS_IOC_GETFLAGS),
+		uintptr(unsafe.Pointer(&flags)),
+	)
+	if errno != 0 {
+		return 0, errno
+	}
+	return flags, nil
+}
+
+// setInodeFlags wraps FS_IOC_SETFLAGS with a platform-sized flags value.
+func setInodeFlags(fd int, flags int) error {
+	// nolint:gosec // G103: unsafe.Pointer required for ioctl syscall argument
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(fd),
+		uintptr(unix.FS_IOC_SETFLAGS),
+		uintptr(unsafe.Pointer(&flags)),
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// applyNoCOW attempts to set FS_NOCOW_FL on path. Best-effort: returns
+// nil on non-btrfs filesystems so the caller can treat the call as a
+// no-op. On btrfs the ioctl error (if any) is propagated.
+func applyNoCOW(path string) error {
+	onBtrfs, err := isBtrfs(path)
+	if err != nil || !onBtrfs {
+		return nil
+	}
+
+	// nolint:gosec // G304: path is the caller-provided .beads/ dolt directory
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	flags, err := getInodeFlags(int(f.Fd()))
+	if err != nil {
+		return err
+	}
+
+	if flags&fsNoCowFL != 0 {
+		return nil
+	}
+
+	return setInodeFlags(int(f.Fd()), flags|fsNoCowFL)
+}
+
+// hasNoCOW reports whether FS_NOCOW_FL is set on path. Returns (false, nil)
+// on non-btrfs filesystems where the flag does not apply.
+func hasNoCOW(path string) (bool, error) {
+	onBtrfs, err := isBtrfs(path)
+	if err != nil || !onBtrfs {
+		return false, nil
+	}
+
+	// nolint:gosec // G304: path is the caller-provided .beads/ dolt directory
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	flags, err := getInodeFlags(int(f.Fd()))
+	if err != nil {
+		return false, err
+	}
+	return flags&fsNoCowFL != 0, nil
+}
+
+// isBtrfs reports whether path lives on a btrfs filesystem. Used to gate
+// warnings so we only complain on filesystems where FS_NOCOW_FL actually
+// matters for performance.
+func isBtrfs(path string) (bool, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return false, err
+	}
+	const btrfsMagic = 0x9123683e
+	return st.Type == btrfsMagic, nil
+}

--- a/cmd/bd/doctor/nocow_other.go
+++ b/cmd/bd/doctor/nocow_other.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package doctor
+
+// applyNoCOW is a no-op on non-Linux platforms: FS_NOCOW_FL is a
+// Linux-specific inode attribute.
+func applyNoCOW(path string) error {
+	return nil
+}
+
+// hasNoCOW always returns false on non-Linux because the flag does not
+// exist there. Doctor checks short-circuit to StatusOK before calling this
+// on non-Linux, but we keep the symbol defined for the build.
+func hasNoCOW(path string) (bool, error) {
+	return false, nil
+}
+
+// isBtrfs always returns false on non-Linux since btrfs is Linux-only.
+func isBtrfs(path string) (bool, error) {
+	return false, nil
+}

--- a/cmd/bd/doctor/nocow_test.go
+++ b/cmd/bd/doctor/nocow_test.go
@@ -1,0 +1,195 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCheckBtrfsNoCOW_NonLinux ensures the check short-circuits to OK on
+// non-Linux platforms. The flag doesn't exist there so there is nothing to
+// report.
+func TestCheckBtrfsNoCOW_NonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("non-Linux short-circuit only applies off Linux")
+	}
+	result := CheckBtrfsNoCOW(t.TempDir())
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK on non-Linux, got %q: %s", result.Status, result.Message)
+	}
+}
+
+// TestCheckBtrfsNoCOW_MissingBeadsDir reports OK when there is no
+// .beads/ directory to check — the check has nothing to examine.
+func TestCheckBtrfsNoCOW_MissingBeadsDir(t *testing.T) {
+	result := CheckBtrfsNoCOW(t.TempDir())
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when .beads/ is missing, got %q: %s", result.Status, result.Message)
+	}
+}
+
+// TestCheckBtrfsNoCOW_NotBtrfs ensures we report OK when the .beads/ dir
+// exists but lives on a non-btrfs filesystem. We don't want to nag users
+// on ext4/xfs/tmpfs where the flag is a no-op.
+func TestCheckBtrfsNoCOW_NotBtrfs(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only filesystem detection")
+	}
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	onBtrfs, err := isBtrfs(beadsDir)
+	if err != nil {
+		t.Fatalf("isBtrfs: %v", err)
+	}
+	if onBtrfs {
+		t.Skip("temp dir is on btrfs; this test targets non-btrfs")
+	}
+	result := CheckBtrfsNoCOW(root)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK on non-btrfs, got %q: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "btrfs") && !strings.Contains(result.Message, "non-Linux") {
+		// Accept any of the OK messages; this is a weak check but
+		// documents intent.
+		t.Logf("non-btrfs OK message: %s", result.Message)
+	}
+}
+
+// TestCheckBtrfsNoCOW_BtrfsMissingFlag verifies that on a btrfs dolt
+// directory without the flag, the check reports a warning. Skipped unless
+// the test environment is actually on btrfs.
+func TestCheckBtrfsNoCOW_BtrfsMissingFlag(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only")
+	}
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	onBtrfs, err := isBtrfs(beadsDir)
+	if err != nil {
+		t.Fatalf("isBtrfs: %v", err)
+	}
+	if !onBtrfs {
+		t.Skip("test requires btrfs")
+	}
+
+	// Freshly-created subdir should NOT have the flag (unless inherited
+	// from a parent that already had it set).
+	set, err := hasNoCOW(beadsDir)
+	if err != nil {
+		t.Fatalf("hasNoCOW: %v", err)
+	}
+	if set {
+		t.Skip("temp .beads dir inherited FS_NOCOW_FL from parent; can't test missing state")
+	}
+
+	result := CheckBtrfsNoCOW(root)
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning when flag is missing on btrfs, got %q: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Fix, "doctor --fix") {
+		t.Errorf("expected fix hint to mention 'doctor --fix', got %q", result.Fix)
+	}
+}
+
+// TestCheckBtrfsNoCOW_BtrfsFlagSet verifies that after applying the flag
+// to a btrfs .beads/ directory, the check reports OK. Skipped unless the
+// test environment is actually on btrfs.
+func TestCheckBtrfsNoCOW_BtrfsFlagSet(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only")
+	}
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	onBtrfs, err := isBtrfs(beadsDir)
+	if err != nil {
+		t.Fatalf("isBtrfs: %v", err)
+	}
+	if !onBtrfs {
+		t.Skip("test requires btrfs")
+	}
+
+	if err := applyNoCOW(beadsDir); err != nil {
+		t.Fatalf("applyNoCOW: %v", err)
+	}
+
+	result := CheckBtrfsNoCOW(root)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after applying flag, got %q: %s", result.Status, result.Message)
+	}
+}
+
+// TestFixBtrfsNoCOW_NonLinux verifies FixBtrfsNoCOW is a no-op off Linux.
+func TestFixBtrfsNoCOW_NonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("non-Linux branch only")
+	}
+	msg, err := FixBtrfsNoCOW(t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "not on Linux") {
+		t.Errorf("expected skip message, got %q", msg)
+	}
+}
+
+// TestFixBtrfsNoCOW_MissingBeadsDir returns an error when there is no
+// .beads/ to fix.
+func TestFixBtrfsNoCOW_MissingBeadsDir(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only")
+	}
+	_, err := FixBtrfsNoCOW(t.TempDir())
+	if err == nil {
+		t.Errorf("expected error for missing .beads directory, got nil")
+	}
+}
+
+// TestFixBtrfsNoCOW_Btrfs verifies the fix path applies the flag and
+// returns a warning about relocating existing files. Skipped off btrfs.
+func TestFixBtrfsNoCOW_Btrfs(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only")
+	}
+	root := t.TempDir()
+	beadsDir := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	onBtrfs, err := isBtrfs(beadsDir)
+	if err != nil {
+		t.Fatalf("isBtrfs: %v", err)
+	}
+	if !onBtrfs {
+		t.Skip("test requires btrfs")
+	}
+
+	msg, err := FixBtrfsNoCOW(root)
+	if err != nil {
+		t.Fatalf("FixBtrfsNoCOW: %v", err)
+	}
+	if !strings.Contains(msg, "FS_NOCOW_FL") {
+		t.Errorf("expected fix message to mention FS_NOCOW_FL, got %q", msg)
+	}
+	if !strings.Contains(msg, "WARNING") {
+		t.Errorf("expected fix message to warn about existing files, got %q", msg)
+	}
+
+	set, err := hasNoCOW(beadsDir)
+	if err != nil {
+		t.Fatalf("hasNoCOW: %v", err)
+	}
+	if !set {
+		t.Errorf("expected FS_NOCOW_FL to be set after fix")
+	}
+}

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -342,6 +342,19 @@ func applyFixList(path string, fixes []doctorCheck) {
 			err = fix.ConfigValues(path)
 		case "Classic Artifacts":
 			err = fix.ClassicArtifacts(path)
+		case "Btrfs NoCOW (dolt)":
+			// Applies FS_NOCOW_FL to .beads/ and any existing dolt data
+			// subdirs. Prints the returned message (which includes the
+			// "relocate existing files" warning) so the user sees why the
+			// fix is incomplete on its own.
+			var msg string
+			msg, err = doctor.FixBtrfsNoCOW(path)
+			if err == nil && msg != "" {
+				fmt.Print(msg)
+				if !strings.HasSuffix(msg, "\n") {
+					fmt.Println()
+				}
+			}
 		case "Project Identity":
 			err = fix.FixProjectIdentity(path)
 		case "Remote Consistency":

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -348,6 +348,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				FatalError("failed to create .beads directory: %v", err)
 			}
 
+			// On Linux btrfs, disable transparent compression on .beads/ so that
+			// dolt's hot append-only write path (under .beads/dolt/ or
+			// .beads/embeddeddolt/) does not trigger kworker thrashing from
+			// read-modify-write-recompress cycles. New files created inside this
+			// directory inherit FS_NOCOW_FL automatically, so setting it here —
+			// before dolt writes anything — covers both server and embedded modes.
+			// No-op on non-Linux and non-btrfs filesystems (GH nocow-beads-dolt-init).
+			if err := applyNoCOW(beadsDir); err != nil && !quiet {
+				fmt.Fprintf(os.Stderr, "Warning: failed to set FS_NOCOW_FL on %s: %v\n", beadsDir, err)
+			}
+
 			// Create/update .gitignore in .beads directory (only if missing or outdated)
 			gitignorePath := filepath.Join(beadsDir, ".gitignore")
 			check := doctor.CheckGitignore(cwd)
@@ -410,6 +421,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if initServerMode {
 			if err := os.MkdirAll(initDBPath, config.BeadsDirPerm); err != nil {
 				FatalError("failed to create storage directory %s: %v", initDBPath, err)
+			}
+			// Linux btrfs: disable compression on the dolt data dir to avoid
+			// kworker thrashing on the append-only write path. Best-effort; a
+			// non-btrfs filesystem returns nil from applyNoCOW.
+			if err := applyNoCOW(initDBPath); err != nil && !quiet {
+				fmt.Fprintf(os.Stderr, "Warning: failed to set FS_NOCOW_FL on %s: %v\n", initDBPath, err)
 			}
 		}
 

--- a/cmd/bd/nocow_linux.go
+++ b/cmd/bd/nocow_linux.go
@@ -1,0 +1,148 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// FS_NOCOW_FL is the "no copy-on-write" inode attribute. This is the flag
+// that `chattr +C` sets. On btrfs it disables both copy-on-write AND
+// transparent compression for the inode — new files created inside a
+// directory with this flag inherit it automatically.
+//
+// We apply this to the .beads/ directory (and its dolt data subdirs) to
+// avoid pathological kworker thrashing on dolt's hot append-only write
+// path: with btrfs compression enabled, each small append forces a
+// read-modify-write-recompress of the existing compressed extent. Setting
+// NOCOW/+C disables both behaviors for new files and eliminates the
+// thrashing.
+//
+// Note: the kernel also defines a separate `FS_NOCOMP_FL` (0x400) flag,
+// but in practice FS_IOC_SETFLAGS returns EOPNOTSUPP for it on btrfs.
+// FS_NOCOW_FL (0x00800000) is the flag the `chattr(1)` tool uses and the
+// one btrfs actually honors at the inode level for this workload.
+//
+// On non-btrfs filesystems the ioctl may fail with ENOTTY/EOPNOTSUPP/
+// EINVAL/EPERM. We suppress these so the optimization stays best-effort.
+const fsNoCowFL = 0x00800000
+
+// getInodeFlags wraps the FS_IOC_GETFLAGS ioctl. The kernel interface uses
+// `long` (platform word size) — on amd64 that's 8 bytes — so we must pass
+// an `int` (Go's platform-sized signed integer) pointer rather than int32.
+// The IoctlSetPointerInt helper in golang.org/x/sys/unix narrows to int32
+// which is incorrect on 64-bit platforms for this ioctl.
+func getInodeFlags(fd int) (int, error) {
+	var flags int
+	// nolint:gosec // G103: unsafe.Pointer required for ioctl syscall argument
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(fd),
+		uintptr(unix.FS_IOC_GETFLAGS),
+		uintptr(unsafe.Pointer(&flags)),
+	)
+	if errno != 0 {
+		return 0, errno
+	}
+	return flags, nil
+}
+
+// setInodeFlags wraps the FS_IOC_SETFLAGS ioctl. Same word-size caveat as
+// getInodeFlags applies — we pass a pointer to a platform-sized int.
+func setInodeFlags(fd int, flags int) error {
+	// nolint:gosec // G103: unsafe.Pointer required for ioctl syscall argument
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(fd),
+		uintptr(unix.FS_IOC_SETFLAGS),
+		uintptr(unsafe.Pointer(&flags)),
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// applyNoCOW attempts to set FS_NOCOW_FL on the directory at path.
+//
+// This is a best-effort optimization for btrfs. On non-btrfs filesystems
+// we short-circuit to a no-op rather than attempting the ioctl at all,
+// because (a) the flag is meaningless outside btrfs and (b) different
+// filesystems return different errors (ENOTTY/EOPNOTSUPP/EINVAL/EPERM)
+// and we'd rather not try to classify them all.
+//
+// Note: setting FS_NOCOW_FL on an already-populated directory only affects
+// files created *after* the flag is set. Existing files retain their prior
+// compression state and must be rewritten (e.g. via `mv` away and back) to
+// pick up the new flag. The bd doctor check surfaces this caveat.
+func applyNoCOW(path string) error {
+	onBtrfs, err := isBtrfs(path)
+	if err != nil || !onBtrfs {
+		// Not btrfs (or statfs failed): nothing to do. We deliberately
+		// don't propagate statfs errors because this is a best-effort
+		// optimization — a failure here must not break `bd init`.
+		return nil
+	}
+
+	// nolint:gosec // G304: path is the .beads/ dolt directory owned by the caller
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	flags, err := getInodeFlags(int(f.Fd()))
+	if err != nil {
+		return err
+	}
+
+	if flags&fsNoCowFL != 0 {
+		return nil // Already set; no work to do.
+	}
+
+	return setInodeFlags(int(f.Fd()), flags|fsNoCowFL)
+}
+
+// hasNoCOW reports whether FS_NOCOW_FL is set on the directory at path.
+//
+// Returns (false, nil) when the filesystem is not btrfs, so callers can
+// treat "not applicable" as "nothing to check" rather than an error.
+func hasNoCOW(path string) (bool, error) {
+	onBtrfs, err := isBtrfs(path)
+	if err != nil || !onBtrfs {
+		return false, nil
+	}
+
+	// nolint:gosec // G304: path is the .beads/ dolt directory owned by the caller
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	flags, err := getInodeFlags(int(f.Fd()))
+	if err != nil {
+		return false, err
+	}
+	return flags&fsNoCowFL != 0, nil
+}
+
+// isBtrfs reports whether the given path lives on a btrfs filesystem.
+//
+// Only on btrfs does FS_NOCOW_FL have a meaningful effect on performance;
+// on other filesystems the flag is a no-op (or unsupported). We use this
+// helper so the init path can skip doing work that would be pointless, and
+// so doctor checks can report accurate guidance.
+func isBtrfs(path string) (bool, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return false, err
+	}
+	// BTRFS_SUPER_MAGIC
+	const btrfsMagic = 0x9123683e
+	return st.Type == btrfsMagic, nil
+}

--- a/cmd/bd/nocow_linux_test.go
+++ b/cmd/bd/nocow_linux_test.go
@@ -1,0 +1,69 @@
+//go:build linux
+
+package main
+
+import (
+	"testing"
+)
+
+// TestApplyNoCOW_Linux verifies that applyNoCOW sets FS_NOCOW_FL on a
+// directory when the underlying filesystem is btrfs. On non-btrfs
+// temp-dirs the call must succeed as a silent no-op, because the ioctl
+// is unsupported there. We skip the flag-set assertion unless we're
+// actually on btrfs.
+func TestApplyNoCOW_Linux(t *testing.T) {
+	dir := t.TempDir()
+
+	// applyNoCOW must not error on any filesystem (btrfs sets the flag,
+	// ext4/tmpfs/etc. are no-ops).
+	if err := applyNoCOW(dir); err != nil {
+		t.Fatalf("applyNoCOW returned unexpected error: %v", err)
+	}
+
+	onBtrfs, err := isBtrfs(dir)
+	if err != nil {
+		t.Fatalf("isBtrfs: %v", err)
+	}
+	if !onBtrfs {
+		t.Skipf("temp dir %s is not on btrfs; skipping flag-set assertion", dir)
+	}
+
+	set, err := hasNoCOW(dir)
+	if err != nil {
+		t.Fatalf("hasNoCOW: %v", err)
+	}
+	if !set {
+		t.Errorf("expected FS_NOCOW_FL to be set on %s after applyNoCOW", dir)
+	}
+}
+
+// TestApplyNoCOW_Idempotent verifies that calling applyNoCOW twice is
+// safe and does not error on the second invocation. This matters because
+// `bd doctor --fix` may re-apply the flag.
+func TestApplyNoCOW_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := applyNoCOW(dir); err != nil {
+		t.Fatalf("first applyNoCOW: %v", err)
+	}
+	if err := applyNoCOW(dir); err != nil {
+		t.Fatalf("second applyNoCOW: %v", err)
+	}
+}
+
+// TestHasNoCOW_UnsetOnFreshTempDir sanity-checks that a fresh temp dir
+// does NOT have FS_NOCOW_FL set until we apply it. If the temp dir lives
+// on a non-btrfs filesystem, hasNoCOW returns (false, nil) via the
+// unsupported-error shim, which also satisfies this test.
+func TestHasNoCOW_UnsetOnFreshTempDir(t *testing.T) {
+	dir := t.TempDir()
+	set, err := hasNoCOW(dir)
+	if err != nil {
+		t.Fatalf("hasNoCOW: %v", err)
+	}
+	if set {
+		// It's technically possible for a temp dir to inherit the flag
+		// from a parent directory that already had it set — skip in that
+		// case rather than fail.
+		t.Skipf("temp dir %s already has FS_NOCOW_FL inherited from parent", dir)
+	}
+}

--- a/cmd/bd/nocow_other.go
+++ b/cmd/bd/nocow_other.go
@@ -1,0 +1,22 @@
+//go:build !linux
+
+package main
+
+// applyNoCOW is a no-op on non-Linux platforms. FS_NOCOW_FL is a
+// Linux-specific inode attribute and has no analog elsewhere — btrfs
+// compression thrashing only affects Linux hosts running dolt on btrfs.
+func applyNoCOW(path string) error {
+	return nil
+}
+
+// hasNoCOW always reports false on non-Linux platforms because the flag
+// does not exist there. Doctor checks treat "!linux" as "nothing to check".
+func hasNoCOW(path string) (bool, error) {
+	return false, nil
+}
+
+// isBtrfs always reports false on non-Linux. btrfs is a Linux-only
+// filesystem, so we short-circuit the check on other platforms.
+func isBtrfs(path string) (bool, error) {
+	return false, nil
+}

--- a/cmd/bd/nocow_test.go
+++ b/cmd/bd/nocow_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestApplyNoCOW_NonLinuxNoError verifies applyNoCOW is a safe no-op on
+// non-Linux platforms. On Linux this is covered by nocow_linux_test.go.
+func TestApplyNoCOW_NonLinuxNoError(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("Linux-specific behavior tested in nocow_linux_test.go")
+	}
+	dir := t.TempDir()
+	if err := applyNoCOW(dir); err != nil {
+		t.Fatalf("applyNoCOW on non-Linux should return nil, got %v", err)
+	}
+	ok, err := hasNoCOW(dir)
+	if err != nil {
+		t.Fatalf("hasNoCOW on non-Linux should return nil error, got %v", err)
+	}
+	if ok {
+		t.Errorf("hasNoCOW on non-Linux should report false, got true")
+	}
+	onBtrfs, err := isBtrfs(dir)
+	if err != nil {
+		t.Fatalf("isBtrfs on non-Linux should return nil error, got %v", err)
+	}
+	if onBtrfs {
+		t.Errorf("isBtrfs on non-Linux should report false, got true")
+	}
+}


### PR DESCRIPTION
## Problem

On Linux btrfs with default zstd compression, dolt's hot append-only write path (\`.beads/dolt/.../noms/*.darc\`) causes pathological kworker thrashing: each small append forces the kernel to read the existing compressed extent, decompress it, modify, recompress, and write a new extent (CoW). In one production incident this generated continuous \`btrfs-compressed-write\`/\`btrfs-endio-write\`/\`flush-btrfs-1\` activity that competed with UI frame scheduling.

## Fix

At \`bd init\` time on Linux, apply \`FS_NOCOW_FL\` (the inode flag \`chattr +C\` sets) to the \`.beads/\` directory. New files created inside inherit the flag and skip both copy-on-write and compression.

### Notes on the kernel interface

- The kernel also defines a separate \`FS_NOCOMP_FL\` (0x400) flag, but \`FS_IOC_SETFLAGS\` returns \`EOPNOTSUPP\` for it on btrfs in practice. \`FS_NOCOW_FL\` (0x00800000) is what \`chattr(1)\` actually uses and what btrfs honors at the inode level for this workload.
- \`golang.org/x/sys/unix.IoctlSetPointerInt\` narrows its argument to \`int32\`; \`FS_IOC_SETFLAGS\` on amd64 expects a platform-sized \`long\`. We use a raw \`syscall.SYS_IOCTL\` with a Go \`int\` pointer instead.
- Skips silently on non-btrfs filesystems (checks \`statfs\` magic) and non-Linux platforms.

### Migration for existing installs

Setting the flag on a directory only affects **newly created** files. A new \`bd doctor\` check (\`CheckBtrfsNoCOW\`) warns when \`.beads/\` is on btrfs without the flag set. \`bd doctor --fix\` applies the flag to the directory and prints a notice that existing files inside need to be relocated (\`mv\` to a different filesystem and back) to actually pick up NOCOW.

## Tests

- \`TestApplyNoCOW_NonLinuxNoError\`
- \`TestApplyNoCOW_Linux\`, \`TestApplyNoCOW_Idempotent\`, \`TestHasNoCOW_UnsetOnFreshTempDir\`
- \`TestCheckBtrfsNoCOW_*\` (NonLinux/MissingBeadsDir/NotBtrfs/BtrfsMissingFlag/BtrfsFlagSet)
- \`TestFixBtrfsNoCOW_*\` (NonLinux/MissingBeadsDir/Btrfs)

Verified on real btrfs (TMPDIR set to a btrfs path): \`applyNoCOW\` actually sets the flag, \`hasNoCOW\` reads it, and the doctor check/fix round-trip works end-to-end. Tests auto-skip the btrfs assertions when the temp dir is on a non-btrfs filesystem.