### PR TITLE
fix(ci): correct action versions in cross-version smoke workflow

### DIFF
--- a/.github/workflows/cross-version-smoke.yml
+++ b/.github/workflows/cross-version-smoke.yml
@@ -32,10 +32,10 @@ jobs:
     needs: versions
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
## Summary
- `actions/checkout@v6` and `actions/setup-go@v6` don't exist, causing the workflow to fail at parse time
- Fixed to `actions/checkout@v4` and `actions/setup-go@v5` (current latest versions)

## Test plan
- [ ] Verify cross-version-smoke workflow runs without "workflow file issue" error after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)