### PR TITLE
feat(telemetry): add pool metrics for shared-server diagnosis (GH#3140)

### DIFF
--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -65,6 +65,7 @@ var YamlOnlyKeys = map[string]bool{
 	// Dolt server settings
 	"dolt.idle-timeout":  true, // Idle auto-stop timeout (default "30m", "0" disables)
 	"dolt.shared-server": true, // Shared Dolt server at ~/.beads/shared-server/ (GH#2377)
+	"dolt.max-conns":     true, // Connection pool size override (default 10, GH#3140)
 
 	// Secrets: tokens and API keys must NOT be stored in the Dolt database
 	// because that data is pushed to remotes, triggering secret-scanning

--- a/internal/storage/dolt/circuit.go
+++ b/internal/storage/dolt/circuit.go
@@ -52,12 +52,17 @@ type circuitState struct {
 	TrippedAt    time.Time `json:"tripped_at,omitempty"`
 }
 
-// circuitBreaker manages the circuit breaker for a specific Dolt server host:port.
+// circuitBreaker manages the circuit breaker for a specific Dolt server
+// host:port:database combination. Using per-database granularity prevents
+// degradation in one project from tripping the breaker for all worktrees
+// sharing the same server (GH#3140).
+//
 // It uses a file in /tmp for cross-process state sharing and an in-process
 // mutex for thread safety within a single process.
 type circuitBreaker struct {
 	host     string
 	port     int
+	database string
 	filePath string
 	mu       sync.Mutex
 }
@@ -68,11 +73,13 @@ var ErrCircuitOpen = fmt.Errorf("dolt circuit breaker is open: server appears do
 // maybeNewCircuitBreaker returns a file-backed circuit breaker only for a
 // concrete port. Port 0 means "not yet resolved" during standalone auto-start,
 // and sharing breaker state on port 0 poisons every fresh init on the machine.
-func maybeNewCircuitBreaker(host string, port int) *circuitBreaker {
+// The database parameter scopes the breaker to a specific project so that
+// degradation in one database doesn't trip the breaker for others (GH#3140).
+func maybeNewCircuitBreaker(host string, port int, database string) *circuitBreaker {
 	if port <= 0 {
 		return nil
 	}
-	return newCircuitBreaker(host, port)
+	return newCircuitBreaker(host, port, database)
 }
 
 // circuitBreakerDir is the dedicated directory for circuit breaker state files.
@@ -80,15 +87,32 @@ func maybeNewCircuitBreaker(host string, port int) *circuitBreaker {
 // of entries) when cleaning up stale breaker files on startup.
 const circuitBreakerDir = "/tmp/beads-circuit"
 
-// newCircuitBreaker creates a circuit breaker for the given Dolt server host:port.
-func newCircuitBreaker(host string, port int) *circuitBreaker {
-	// Sanitize host for use in filename (replace dots/colons with dashes)
-	safeHost := strings.NewReplacer(".", "-", ":", "-").Replace(host)
+// newCircuitBreaker creates a circuit breaker for the given Dolt server
+// host:port:database. The database name is included in the file path so each
+// project gets independent circuit breaker state on shared servers (GH#3140).
+func newCircuitBreaker(host string, port int, database string) *circuitBreaker {
+	// Sanitize host and database for use in filename
+	sanitize := strings.NewReplacer(".", "-", ":", "-", "/", "-")
+	safeHost := sanitize.Replace(host)
+	safeDB := sanitize.Replace(database)
+
+	// Include database in filename when non-empty. This keeps backward
+	// compatibility for callers that don't pass a database name (the old
+	// per-host:port files are still valid and will be cleaned up by
+	// CleanStaleCircuitBreakerFiles).
+	var filename string
+	if safeDB != "" {
+		filename = fmt.Sprintf("beads-dolt-circuit-%s-%d-%s.json", safeHost, port, safeDB)
+	} else {
+		filename = fmt.Sprintf("beads-dolt-circuit-%s-%d.json", safeHost, port)
+	}
+
 	_ = os.MkdirAll(circuitBreakerDir, 0755)
 	return &circuitBreaker{
 		host:     host,
 		port:     port,
-		filePath: filepath.Join(circuitBreakerDir, fmt.Sprintf("beads-dolt-circuit-%s-%d.json", safeHost, port)),
+		database: database,
+		filePath: filepath.Join(circuitBreakerDir, filename),
 	}
 }
 
@@ -121,13 +145,13 @@ func (cb *circuitBreaker) Allow() bool {
 				state.Failures = 0
 				state.FirstFailure = time.Time{}
 				cb.writeState(state)
-				log.Printf("[circuit-breaker] %s:%d: open → closed (active probe succeeded)", cb.host, cb.port)
+				log.Printf("[circuit-breaker] %s:%d/%s: open → closed (active probe succeeded)", cb.host, cb.port, cb.database)
 				return true
 			}
 			// Probe failed — stay open, reset the tripped timer
 			state.TrippedAt = time.Now()
 			cb.writeState(state)
-			log.Printf("[circuit-breaker] %s:%d: open → open (active probe failed, cooldown reset)", cb.host, cb.port)
+			log.Printf("[circuit-breaker] %s:%d/%s: open → open (active probe failed, cooldown reset)", cb.host, cb.port, cb.database)
 			return false
 		}
 		return false
@@ -139,13 +163,13 @@ func (cb *circuitBreaker) Allow() bool {
 			state.Failures = 0
 			state.FirstFailure = time.Time{}
 			cb.writeState(state)
-			log.Printf("[circuit-breaker] %s:%d: half-open → closed (active probe succeeded)", cb.host, cb.port)
+			log.Printf("[circuit-breaker] %s:%d/%s: half-open → closed (active probe succeeded)", cb.host, cb.port, cb.database)
 			return true
 		}
 		state.State = circuitOpen
 		state.TrippedAt = time.Now()
 		cb.writeState(state)
-		log.Printf("[circuit-breaker] %s:%d: half-open → open (active probe failed)", cb.host, cb.port)
+		log.Printf("[circuit-breaker] %s:%d/%s: half-open → open (active probe failed)", cb.host, cb.port, cb.database)
 		return false
 	default:
 		return true
@@ -170,7 +194,7 @@ func (cb *circuitBreaker) RecordSuccess() {
 
 	state := cb.readState()
 	if state.State == circuitHalfOpen {
-		log.Printf("[circuit-breaker] %s:%d: half-open → closed (probe succeeded)", cb.host, cb.port)
+		log.Printf("[circuit-breaker] %s:%d/%s: half-open → closed (probe succeeded)", cb.host, cb.port, cb.database)
 	}
 	// Reset to clean closed state
 	cb.writeState(circuitState{State: circuitClosed})
@@ -191,7 +215,7 @@ func (cb *circuitBreaker) RecordFailure() {
 		state.TrippedAt = now
 		state.LastFailure = now
 		cb.writeState(state)
-		log.Printf("[circuit-breaker] %s:%d: half-open → open (probe failed)", cb.host, cb.port)
+		log.Printf("[circuit-breaker] %s:%d/%s: half-open → open (probe failed)", cb.host, cb.port, cb.database)
 		return
 
 	case circuitOpen:
@@ -218,8 +242,8 @@ func (cb *circuitBreaker) RecordFailure() {
 			state.State = circuitOpen
 			state.TrippedAt = now
 			cb.writeState(state)
-			log.Printf("[circuit-breaker] %s:%d: closed → open (tripped after %d failures in %s)",
-				cb.host, cb.port, state.Failures, now.Sub(state.FirstFailure).Round(time.Millisecond))
+			log.Printf("[circuit-breaker] %s:%d/%s: closed → open (tripped after %d failures in %s)",
+				cb.host, cb.port, cb.database, state.Failures, now.Sub(state.FirstFailure).Round(time.Millisecond))
 			return
 		}
 
@@ -268,8 +292,8 @@ func (cb *circuitBreaker) readState() circuitState {
 			ref = state.LastFailure
 		}
 		if !ref.IsZero() && time.Since(ref) > circuitStaleTTL {
-			log.Printf("[circuit-breaker] %s:%d: stale %s state (age %s > TTL %s), auto-resetting to closed",
-				cb.host, cb.port, state.State, time.Since(ref).Round(time.Second), circuitStaleTTL)
+			log.Printf("[circuit-breaker] %s:%d/%s: stale %s state (age %s > TTL %s), auto-resetting to closed",
+				cb.host, cb.port, cb.database, state.State, time.Since(ref).Round(time.Second), circuitStaleTTL)
 			reset := circuitState{State: circuitClosed}
 			cb.writeState(reset)
 			return reset

--- a/internal/storage/dolt/circuit_test.go
+++ b/internal/storage/dolt/circuit_test.go
@@ -18,7 +18,7 @@ func TestCircuitBreaker_InitiallyAllows(t *testing.T) {
 }
 
 func TestMaybeNewCircuitBreaker_PortZeroDisabled(t *testing.T) {
-	if cb := maybeNewCircuitBreaker("127.0.0.1", 0); cb != nil {
+	if cb := maybeNewCircuitBreaker("127.0.0.1", 0, "test"); cb != nil {
 		t.Fatalf("maybeNewCircuitBreaker(0) = %#v, want nil", cb)
 	}
 }
@@ -219,8 +219,8 @@ func TestCircuitBreaker_DifferentHostsSeparateState(t *testing.T) {
 	t.Setenv("BEADS_TEST_MODE", "")
 	// Two breakers for the same port but different hosts should have independent state.
 	// This is the core fix: previously keyed on port only, which caused cross-host blocking.
-	cb1 := newCircuitBreaker("127.0.0.1", 99999)
-	cb2 := newCircuitBreaker("10.0.0.1", 99999)
+	cb1 := newCircuitBreaker("127.0.0.1", 99999, "")
+	cb2 := newCircuitBreaker("10.0.0.1", 99999, "")
 	t.Cleanup(func() {
 		os.Remove(cb1.filePath)
 		os.Remove(cb2.filePath)
@@ -229,6 +229,39 @@ func TestCircuitBreaker_DifferentHostsSeparateState(t *testing.T) {
 	// Verify different file paths
 	if cb1.filePath == cb2.filePath {
 		t.Fatalf("different hosts should have different file paths: %s vs %s", cb1.filePath, cb2.filePath)
+	}
+
+	// Trip cb1
+	for i := 0; i < circuitFailureThreshold; i++ {
+		cb1.RecordFailure()
+	}
+	if cb1.State() != circuitOpen {
+		t.Fatal("cb1 should be open")
+	}
+
+	// cb2 should be unaffected
+	if cb2.State() != circuitClosed {
+		t.Fatalf("cb2 should be closed (independent of cb1), got %q", cb2.State())
+	}
+	if !cb2.Allow() {
+		t.Fatal("cb2 should allow requests (independent of cb1)")
+	}
+}
+
+func TestCircuitBreaker_DifferentDatabasesSeparateState(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	// Two breakers for the same host:port but different databases should have
+	// independent state. This prevents one degraded project from tripping the
+	// breaker for all worktrees on a shared server (GH#3140).
+	cb1 := newCircuitBreaker("127.0.0.1", 99999, "project_alpha")
+	cb2 := newCircuitBreaker("127.0.0.1", 99999, "project_beta")
+	t.Cleanup(func() {
+		os.Remove(cb1.filePath)
+		os.Remove(cb2.filePath)
+	})
+
+	if cb1.filePath == cb2.filePath {
+		t.Fatalf("different databases should have different file paths: %s vs %s", cb1.filePath, cb2.filePath)
 	}
 
 	// Trip cb1
@@ -381,7 +414,7 @@ func TestCleanStaleCircuitBreakerFiles(t *testing.T) {
 func TestCircuitBreakerDir_UsesSubdirectory(t *testing.T) {
 	// Verify that circuit breaker files are created in the dedicated
 	// subdirectory, not directly in /tmp (which can have millions of entries).
-	cb := newCircuitBreaker("127.0.0.1", 44444)
+	cb := newCircuitBreaker("127.0.0.1", 44444, "")
 	t.Cleanup(func() { os.Remove(cb.filePath) })
 
 	if filepath.Dir(cb.filePath) != circuitBreakerDir {

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/config"
@@ -200,5 +201,22 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 	}
 	if cfg.ServerUser == "" {
 		cfg.ServerUser = fileCfg.GetDoltServerUser()
+	}
+
+	// Pool size: env var > config.yaml > caller override > default (10).
+	// Useful for shared-server setups with many worktrees (GH#3140).
+	if cfg.MaxOpenConns == 0 {
+		if v := os.Getenv("BEADS_DOLT_MAX_CONNS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.MaxOpenConns = n
+			}
+		}
+	}
+	if cfg.MaxOpenConns == 0 {
+		if v := config.GetString("dolt.max-conns"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				cfg.MaxOpenConns = n
+			}
+		}
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -924,7 +924,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// state from previous sessions poisoning fresh inits (GH#2598).
 	CleanStaleCircuitBreakerFiles()
 
-	breaker := maybeNewCircuitBreaker(cfg.ServerHost, cfg.ServerPort)
+	breaker := maybeNewCircuitBreaker(cfg.ServerHost, cfg.ServerPort, cfg.Database)
 
 	// Circuit breaker: fail-fast if the server is known to be down.
 	if breaker != nil && !breaker.Allow() {
@@ -972,7 +972,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 				}
 				cfg.ServerPort = port
 				addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
-				breaker = maybeNewCircuitBreaker(cfg.ServerHost, cfg.ServerPort)
+				breaker = maybeNewCircuitBreaker(cfg.ServerHost, cfg.ServerPort, cfg.Database)
 			}
 			// Retry connection with longer timeout (server just started)
 			conn, dialErr = net.DialTimeout("tcp", addr, 2*time.Second)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -437,10 +437,14 @@ var doltTracer = otel.Tracer("github.com/steveyegge/beads/storage/dolt")
 // Instruments are registered against the global delegating provider at init time,
 // so they automatically forward to the real provider once telemetry.Init() runs.
 var doltMetrics struct {
-	retryCount      metric.Int64Counter
-	lockWaitMs      metric.Float64Histogram
-	circuitTrips    metric.Int64Counter
-	circuitRejected metric.Int64Counter
+	retryCount          metric.Int64Counter
+	lockWaitMs          metric.Float64Histogram
+	circuitTrips        metric.Int64Counter
+	circuitRejected     metric.Int64Counter
+	serializationErrors metric.Int64Counter
+	connAcquireMs       metric.Float64Histogram
+	poolWaitCount       metric.Int64Counter
+	poolWaitMs          metric.Float64Histogram
 }
 
 func init() {
@@ -460,6 +464,63 @@ func init() {
 	doltMetrics.circuitRejected, _ = m.Int64Counter("bd.db.circuit_rejected",
 		metric.WithDescription("Requests rejected by open circuit breaker (fail-fast)"),
 		metric.WithUnit("{request}"),
+	)
+	doltMetrics.serializationErrors, _ = m.Int64Counter("bd.db.serialization_errors",
+		metric.WithDescription("Serialization failures (MySQL 1213/1205) before retry"),
+		metric.WithUnit("{error}"),
+	)
+	doltMetrics.connAcquireMs, _ = m.Float64Histogram("bd.db.conn_acquire_ms",
+		metric.WithDescription("Time to acquire a pooled connection for a Dolt transaction"),
+		metric.WithUnit("ms"),
+	)
+	doltMetrics.poolWaitCount, _ = m.Int64Counter("bd.db.pool_wait_count",
+		metric.WithDescription("Number of times a connection acquisition had to wait for the pool"),
+		metric.WithUnit("{wait}"),
+	)
+	doltMetrics.poolWaitMs, _ = m.Float64Histogram("bd.db.pool_wait_ms",
+		metric.WithDescription("Total time connections spent waiting due to pool exhaustion"),
+		metric.WithUnit("ms"),
+	)
+}
+
+// registerPoolGauges registers observable gauges that report sql.DB pool stats
+// on each OTel collection cycle. These are essential for diagnosing shared-server
+// degradation under multi-worktree load (GH#3140).
+func (s *DoltStore) registerPoolGauges() {
+	m := otel.Meter("github.com/steveyegge/beads/storage/dolt")
+	db := s.db
+
+	m.Int64ObservableGauge("bd.db.pool_open", //nolint:errcheck
+		metric.WithDescription("Current number of open connections (in-use + idle)"),
+		metric.WithUnit("{connection}"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			o.Observe(int64(db.Stats().OpenConnections))
+			return nil
+		}),
+	)
+	m.Int64ObservableGauge("bd.db.pool_in_use", //nolint:errcheck
+		metric.WithDescription("Connections currently in use"),
+		metric.WithUnit("{connection}"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			o.Observe(int64(db.Stats().InUse))
+			return nil
+		}),
+	)
+	m.Int64ObservableGauge("bd.db.pool_idle", //nolint:errcheck
+		metric.WithDescription("Idle connections in pool"),
+		metric.WithUnit("{connection}"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			o.Observe(int64(db.Stats().Idle))
+			return nil
+		}),
+	)
+	m.Int64ObservableGauge("bd.db.pool_max_open", //nolint:errcheck
+		metric.WithDescription("Maximum number of open connections (pool limit)"),
+		metric.WithUnit("{connection}"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			o.Observe(int64(db.Stats().MaxOpenConnections))
+			return nil
+		}),
 	)
 }
 
@@ -531,6 +592,7 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	return backoff.Retry(func() error {
 		err := s.withWriteTx(ctx, fn)
 		if err != nil && isSerializationError(err) {
+			doltMetrics.serializationErrors.Add(ctx, 1)
 			return err // retryable
 		}
 		if err != nil {
@@ -1047,6 +1109,10 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	if !cfg.ReadOnly {
 		store.syncCLIRemotesToSQL(ctx)
 	}
+
+	// Register observable pool gauges for diagnosing shared-server degradation (GH#3140).
+	// These report sql.DB.Stats() on each OTel scrape — no-op when telemetry is off.
+	store.registerPoolGauges()
 
 	return store, nil
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -490,7 +490,7 @@ func (s *DoltStore) registerPoolGauges() {
 	m := otel.Meter("github.com/steveyegge/beads/storage/dolt")
 	db := s.db
 
-	m.Int64ObservableGauge("bd.db.pool_open", //nolint:errcheck
+	m.Int64ObservableGauge("bd.db.pool_open", //nolint:errcheck,gosec
 		metric.WithDescription("Current number of open connections (in-use + idle)"),
 		metric.WithUnit("{connection}"),
 		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
@@ -498,7 +498,7 @@ func (s *DoltStore) registerPoolGauges() {
 			return nil
 		}),
 	)
-	m.Int64ObservableGauge("bd.db.pool_in_use", //nolint:errcheck
+	m.Int64ObservableGauge("bd.db.pool_in_use", //nolint:errcheck,gosec
 		metric.WithDescription("Connections currently in use"),
 		metric.WithUnit("{connection}"),
 		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
@@ -506,7 +506,7 @@ func (s *DoltStore) registerPoolGauges() {
 			return nil
 		}),
 	)
-	m.Int64ObservableGauge("bd.db.pool_idle", //nolint:errcheck
+	m.Int64ObservableGauge("bd.db.pool_idle", //nolint:errcheck,gosec
 		metric.WithDescription("Idle connections in pool"),
 		metric.WithUnit("{connection}"),
 		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
@@ -514,7 +514,7 @@ func (s *DoltStore) registerPoolGauges() {
 			return nil
 		}),
 	)
-	m.Int64ObservableGauge("bd.db.pool_max_open", //nolint:errcheck
+	m.Int64ObservableGauge("bd.db.pool_max_open", //nolint:errcheck,gosec
 		metric.WithDescription("Maximum number of open connections (pool limit)"),
 		metric.WithUnit("{connection}"),
 		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -581,6 +581,9 @@ func (s *DoltStore) withReadTx(ctx context.Context, fn func(tx *sql.Tx) error) e
 // (MySQL 1213 deadlock, 1205 lock wait timeout). These errors guarantee the
 // transaction was rolled back, so retrying is always safe.
 //
+// In shared-server mode the retry window is extended to 15s (from 5s) because
+// multiple worktrees sharing one server produce higher contention (GH#3140).
+//
 // Connection-level errors (broken pipe, bad connection) are NOT retried here
 // because they can occur after a successful commit, making retry unsafe for
 // non-idempotent operations. Callers that need connection-level retry should
@@ -589,6 +592,9 @@ func (s *DoltStore) withRetryTx(ctx context.Context, fn func(tx *sql.Tx) error) 
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 25 * time.Millisecond
 	bo.MaxElapsedTime = 5 * time.Second
+	if s.serverMode {
+		bo.MaxElapsedTime = 15 * time.Second
+	}
 	return backoff.Retry(func() error {
 		err := s.withWriteTx(ctx, fn)
 		if err != nil && isSerializationError(err) {

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -54,7 +54,26 @@ func (s *DoltStore) runDoltTransaction(ctx context.Context, commitMsg string, fn
 	// session. Each pool connection has an independent working set in Dolt
 	// SQL server mode, so mixing connections causes DOLT_COMMIT to see
 	// stale or unrelated changes. (GH#2455)
+
+	// Snapshot pool stats before acquisition to detect pool-wait events (GH#3140).
+	statsBefore := s.db.Stats()
+	acquireStart := time.Now()
+
 	conn, err := s.db.Conn(ctx)
+	acquireMs := float64(time.Since(acquireStart).Microseconds()) / 1000.0
+	doltMetrics.connAcquireMs.Record(ctx, acquireMs)
+
+	// Detect pool-wait: if WaitCount increased, the pool was exhausted and
+	// this caller had to wait for a connection to become available.
+	if err == nil {
+		statsAfter := s.db.Stats()
+		if statsAfter.WaitCount > statsBefore.WaitCount {
+			doltMetrics.poolWaitCount.Add(ctx, statsAfter.WaitCount-statsBefore.WaitCount)
+			waitMs := float64(statsAfter.WaitDuration-statsBefore.WaitDuration) / float64(time.Millisecond)
+			doltMetrics.poolWaitMs.Record(ctx, waitMs)
+		}
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to acquire connection: %w", err)
 	}


### PR DESCRIPTION
## Summary
Addresses shared-server degradation under multi-worktree load (GH#3140) with four changes:

- **Pool telemetry**: OTel metrics for connection acquisition time, pool exhaustion events, serialization failure counts, and observable pool utilization gauges
- **Configurable pool size**: `BEADS_DOLT_MAX_CONNS` env var and `dolt.max-conns` config.yaml key (default remains 10)
- **Extended serialization retry**: 5s → 15s in server mode, matching the higher contention from multiple worktrees
- **Per-database circuit breakers**: breaker files now include database name, so degradation in one project doesn't trip the breaker for all worktrees sharing a server

## Test plan
- [x] `go build -tags=nodolt ./internal/storage/dolt/...` compiles clean
- [x] `go test -tags=nodolt -short ./internal/storage/dolt/...` passes
- [x] `go vet -tags=nodolt ./internal/storage/dolt/...` clean
- [x] New test: `TestCircuitBreaker_DifferentDatabasesSeparateState`
- [x] Full test suite passes (excluding pre-existing embeddeddolt ICU issue)
- [ ] Enable telemetry export and verify gauges report under multi-worktree load

Closes #3140

🤖 Generated with [Claude Code](https://claude.com/claude-code)