### PR TITLE
fix(dolt): reject empty database name in embeddeddolt.New

### DIFF
--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -779,6 +779,53 @@ func TestEmbeddedCreateCrossRepoWithParent(t *testing.T) {
 	assertDepExists(t, targetBeadsDir, "tgt", child.ID, parent.ID)
 }
 
+// TestEmbeddedCreateCrossRepoUninit verifies that bd create --repo works when
+// the target directory has NOT been initialized with bd init. This is a
+// regression test for be-sy8 / GH#2988: newDoltStoreFromConfig used to pass
+// an empty database name to the embedded Dolt engine, causing "no database
+// selected" during schema init.
+func TestEmbeddedCreateCrossRepoUninit(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// Set up primary repo (source — initialized)
+	dir, _, _ := bdInit(t, bd, "--prefix", "src")
+
+	// Set up target repo WITHOUT bd init — just a bare git repo
+	targetDir := filepath.Join(dir, "uninit-target")
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, targetDir)
+
+	// This should succeed: ensureBeadsDirForPath creates .beads,
+	// and newDoltStoreFromConfig defaults to database "beads".
+	issue := bdCreate(t, bd, dir, "Issue in uninit target", "--repo", targetDir)
+	if issue.ID == "" {
+		t.Fatal("expected issue ID")
+	}
+
+	// Verify issue exists in the target store
+	targetBeadsDir := filepath.Join(targetDir, ".beads")
+	tgtStore, err := newDoltStoreFromConfig(t.Context(), targetBeadsDir)
+	if err != nil {
+		t.Fatalf("failed to open target store: %v", err)
+	}
+	defer tgtStore.Close()
+
+	got, err := tgtStore.GetIssue(t.Context(), issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssue in target: %v", err)
+	}
+	if got.Title != "Issue in uninit target" {
+		t.Errorf("title: got %q, want %q", got.Title, "Issue in uninit target")
+	}
+}
+
 // TestEmbeddedCreateWithGitRemote verifies bd create works end-to-end when a
 // git remote exists (which enables auto-backup in PersistentPostRun). This
 // catches panics from unimplemented methods called after the create succeeds.

--- a/cmd/bd/store_factory_test.go
+++ b/cmd/bd/store_factory_test.go
@@ -4,9 +4,11 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 )
 
 // TestNewDoltStoreFromConfig_NoMetadata verifies that newDoltStoreFromConfig
@@ -35,4 +37,18 @@ func TestNewDoltStoreFromConfig_NoMetadata(t *testing.T) {
 		t.Fatalf("newDoltStoreFromConfig failed: %v", err)
 	}
 	defer store.Close()
+}
+
+// TestEmbeddedNew_EmptyDatabaseRejected verifies that embeddeddolt.New fails
+// with a clear error when called with an empty database name, rather than
+// deferring to a confusing "no database selected" SQL error.
+// Belt-and-suspenders defense for be-sy8 / GH#2988.
+func TestEmbeddedNew_EmptyDatabaseRejected(t *testing.T) {
+	_, err := embeddeddolt.New(t.Context(), t.TempDir(), "", "main")
+	if err == nil {
+		t.Fatal("expected error for empty database name")
+	}
+	if !strings.Contains(err.Error(), "database name must not be empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
 }

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -78,6 +78,10 @@ func WithLock(lock Unlocker) Option {
 // (GH#2571). The lock is released when Close is called, unless a pre-acquired
 // lock was supplied via WithLock (in which case the caller is responsible for it).
 func New(ctx context.Context, beadsDir, database, branch string, opts ...Option) (*EmbeddedDoltStore, error) {
+	if database == "" {
+		return nil, fmt.Errorf("embeddeddolt: database name must not be empty (caller should default to %q)", "beads")
+	}
+
 	var o options
 	for _, fn := range opts {
 		fn(&o)


### PR DESCRIPTION
## Summary

- Adds early validation in `embeddeddolt.New()` to reject empty database names with a clear error instead of failing deep in schema migrations with "no database selected"
- Includes unit test for the guard and end-to-end regression test for `bd create --repo` with an uninitialized target directory

Cherry-picked from #3113 — thank you @thejosephstevens!

## What was left out

The prefix-based routing via `routes.jsonl` from #3113 was intentionally excluded. That's a new feature (not a fix) and introduces orchestration-layer concepts (`GT_ROOT`) that belong above beads, not in it. We'd welcome a separate PR for cross-rig routing if it can be designed without coupling beads to a specific orchestrator.

## Test plan
- [x] `CGO_ENABLED=0 go build ./...` passes
- [x] `TestEmbeddedNew_EmptyDatabaseRejected` — verifies clear error on empty db name
- [x] `TestEmbeddedCreateCrossRepoUninit` — e2e regression for `bd create --repo` with uninit target

🤖 Generated with [Claude Code](https://claude.com/claude-code)