### PR TITLE
Make sync remote-agnostic: add sync.remote, persist to config.yaml

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -13,7 +13,6 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
-	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/dolt"
@@ -93,7 +92,8 @@ var bootstrapCmd = &cobra.Command{
 Unlike 'bd init --force', bootstrap will never delete existing issues.
 
 Bootstrap auto-detects the right action:
-  • If sync.git-remote is configured: clones from the remote
+  • If sync.remote is configured: clones from the remote
+  • If git origin has Dolt data (refs/dolt/data): clones from git
   • If .beads/backup/*.jsonl exists: restores from backup
   • If .beads/issues.jsonl exists: imports from git-tracked JSONL
   • If no database exists: creates a fresh one
@@ -126,9 +126,11 @@ Examples:
 		beadsDir := beads.FindBeadsDir()
 		if beadsDir == "" {
 			// No .beads directory exists yet. Before giving up, probe the
-			// git remote for existing Beads data (refs/dolt/data). This is
-			// the "fresh second clone" case: clone1 pushed Beads state to
-			// origin, and clone2 needs to bootstrap from it. (GH#2792)
+			// git remote for Dolt data stored in git (refs/dolt/data). This
+			// is the "fresh second clone" case: clone1 pushed Beads state
+			// to a git remote, and clone2 needs to bootstrap from it.
+			// Only applies to git remotes — Dolt-native remotes (DoltHub,
+			// S3, etc.) should be configured via sync.remote. (GH#2792)
 			//
 			// If found, synthesize the theoretical .beads path and fall
 			// through to the normal detectBootstrapAction + executeBootstrapPlan
@@ -267,22 +269,24 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 		}
 	}
 
-	// Check sync.git-remote
-	syncRemote := config.GetString("sync.git-remote")
+	// Check sync.remote (primary) or sync.git-remote (deprecated fallback)
+	syncRemote := resolveSyncRemote()
 	if syncRemote != "" {
-		plan.SyncRemote = syncRemote
+		plan.SyncRemote = normalizeRemoteURL(syncRemote)
 		plan.Action = "sync"
-		plan.Reason = "sync.git-remote configured — will clone from " + syncRemote
+		plan.Reason = "sync.remote configured — will clone from " + syncRemote
 		return plan
 	}
 
-	// Auto-detect: probe origin for refs/dolt/data
+	// Auto-detect: probe git origin for Dolt data stored in git
+	// (refs/dolt/data). This only applies to git remotes — Dolt-native
+	// remotes (DoltHub, S3, etc.) must be configured via sync.remote.
 	if isGitRepo() && !isBareGitRepo() {
 		if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
 			if gitLsRemoteHasRef("origin", "refs/dolt/data") {
-				plan.SyncRemote = gitURLToDoltRemote(originURL)
+				plan.SyncRemote = normalizeRemoteURL(originURL)
 				plan.Action = "sync"
-				plan.Reason = "Found existing beads database on origin (refs/dolt/data) — will clone from " + originURL
+				plan.Reason = "Found Dolt data on git origin (refs/dolt/data) — will clone from " + originURL
 				return plan
 			}
 		}
@@ -482,9 +486,9 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	return cloneFromRemote(ctx, plan.BeadsDir, plan.SyncRemote, dbName)
 }
 
-// cloneFromRemote clones a Dolt database from a git remote URL.
+// cloneFromRemote clones a Dolt database from a remote URL.
 // In embedded mode, uses the embedded engine's DOLT_CLONE procedure.
-// In server mode, shells out to dolt clone via BootstrapFromGitRemoteWithDB.
+// In server mode, shells out to dolt clone via BootstrapFromRemoteWithDB.
 // Shared by bd init and bd bootstrap to keep clone logic in one place.
 func cloneFromRemote(ctx context.Context, beadsDir, remoteURL, dbName string) error {
 	if isEmbeddedMode() {
@@ -506,7 +510,7 @@ func cloneFromRemote(ctx context.Context, beadsDir, remoteURL, dbName string) er
 	}
 
 	doltDir := doltserver.ResolveDoltDir(beadsDir)
-	synced, err := dolt.BootstrapFromGitRemoteWithDB(ctx, doltDir, remoteURL, dbName)
+	synced, err := dolt.BootstrapFromRemoteWithDB(ctx, doltDir, remoteURL, dbName)
 	if err != nil {
 		return fmt.Errorf("sync from remote: %w", err)
 	}

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -479,46 +479,39 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	}
 
 	dbName := cfg.GetDoltDatabase()
+	return cloneFromRemote(ctx, plan.BeadsDir, plan.SyncRemote, dbName)
+}
 
+// cloneFromRemote clones a Dolt database from a git remote URL.
+// In embedded mode, uses the embedded engine's DOLT_CLONE procedure.
+// In server mode, shells out to dolt clone via BootstrapFromGitRemoteWithDB.
+// Shared by bd init and bd bootstrap to keep clone logic in one place.
+func cloneFromRemote(ctx context.Context, beadsDir, remoteURL, dbName string) error {
 	if isEmbeddedMode() {
-		// Embedded mode: open a connection to the embedded engine and use
-		// DOLT_CLONE to create the database from the remote URL.
-		dataDir := filepath.Join(plan.BeadsDir, "embeddeddolt")
+		dataDir := filepath.Join(beadsDir, "embeddeddolt")
 		if err := os.MkdirAll(dataDir, 0o750); err != nil {
 			return fmt.Errorf("create embeddeddolt directory: %w", err)
 		}
-
-		// Open a connection without specifying a database (clone creates it).
 		db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, "", "")
 		if err != nil {
 			return fmt.Errorf("open embedded engine for clone: %w", err)
 		}
 		defer func() { _ = cleanup() }()
 
-		if err := versioncontrolops.DoltClone(ctx, db, plan.SyncRemote, dbName); err != nil {
+		if err := versioncontrolops.DoltClone(ctx, db, remoteURL, dbName); err != nil {
 			return fmt.Errorf("clone from remote: %w", err)
 		}
-
-		// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
-		// directory — including noms/LOCK files. These are Dolt-internal files.
-		// Removing them WILL cause unrecoverable data corruption and data loss.
-		// Dolt manages these files itself; external interference is never safe.
-
-		fmt.Fprintf(os.Stderr, "Synced database from %s\n", plan.SyncRemote)
+		fmt.Fprintf(os.Stderr, "Synced database from %s\n", remoteURL)
 		return nil
 	}
 
-	doltDir := doltserver.ResolveDoltDir(plan.BeadsDir)
-	synced, err := dolt.BootstrapFromGitRemoteWithDB(ctx, doltDir, plan.SyncRemote, dbName)
+	doltDir := doltserver.ResolveDoltDir(beadsDir)
+	synced, err := dolt.BootstrapFromGitRemoteWithDB(ctx, doltDir, remoteURL, dbName)
 	if err != nil {
 		return fmt.Errorf("sync from remote: %w", err)
 	}
 	if synced {
-		// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
-		// directory — including noms/LOCK files. These are Dolt-internal files.
-		// Removing them WILL cause unrecoverable data corruption and data loss.
-		// Dolt manages these files itself; external interference is never safe.
-		fmt.Fprintf(os.Stderr, "Synced database from %s\n", plan.SyncRemote)
+		fmt.Fprintf(os.Stderr, "Synced database from %s\n", remoteURL)
 	}
 	return nil
 }

--- a/cmd/bd/context_cmd.go
+++ b/cmd/bd/context_cmd.go
@@ -12,21 +12,22 @@ import (
 
 // ContextInfo contains the effective backend identity and repository context.
 type ContextInfo struct {
-	BeadsDir     string `json:"beads_dir"`
-	RepoRoot     string `json:"repo_root"`
-	CWDRepoRoot  string `json:"cwd_repo_root,omitempty"`
-	IsRedirected bool   `json:"is_redirected"`
-	IsWorktree   bool   `json:"is_worktree"`
-	Backend      string `json:"backend"`
-	DoltMode     string `json:"dolt_mode"`
-	ServerHost   string `json:"server_host,omitempty"`
-	ServerPort   int    `json:"server_port,omitempty"`
-	Database     string `json:"database"`
-	DataDir      string `json:"data_dir,omitempty"`
-	ProjectID    string `json:"project_id,omitempty"`
-	SyncRemote   string `json:"sync_remote,omitempty"`
-	Role         string `json:"role,omitempty"`
-	BdVersion    string `json:"bd_version"`
+	BeadsDir      string `json:"beads_dir"`
+	RepoRoot      string `json:"repo_root"`
+	CWDRepoRoot   string `json:"cwd_repo_root,omitempty"`
+	IsRedirected  bool   `json:"is_redirected"`
+	IsWorktree    bool   `json:"is_worktree"`
+	Backend       string `json:"backend"`
+	DoltMode      string `json:"dolt_mode"`
+	ServerHost    string `json:"server_host,omitempty"`
+	ServerPort    int    `json:"server_port,omitempty"`
+	Database      string `json:"database"`
+	DataDir       string `json:"data_dir,omitempty"`
+	ProjectID     string `json:"project_id,omitempty"`
+	SyncRemote    string `json:"sync_remote,omitempty"`
+	SyncGitRemote string `json:"sync_git_remote,omitempty"` // Deprecated: use sync_remote
+	Role          string `json:"role,omitempty"`
+	BdVersion     string `json:"bd_version"`
 }
 
 var contextCmd = &cobra.Command{
@@ -104,6 +105,7 @@ Examples:
 		// Read sync remote from the selected repo's config.yaml.
 		if remote := resolveSyncRemoteFromDir(rc.BeadsDir); remote != "" {
 			info.SyncRemote = remote
+			info.SyncGitRemote = remote // Deprecated: kept for backwards compat
 		}
 
 		if jsonOutput {

--- a/cmd/bd/context_cmd.go
+++ b/cmd/bd/context_cmd.go
@@ -6,28 +6,27 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
-	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 )
 
 // ContextInfo contains the effective backend identity and repository context.
 type ContextInfo struct {
-	BeadsDir      string `json:"beads_dir"`
-	RepoRoot      string `json:"repo_root"`
-	CWDRepoRoot   string `json:"cwd_repo_root,omitempty"`
-	IsRedirected  bool   `json:"is_redirected"`
-	IsWorktree    bool   `json:"is_worktree"`
-	Backend       string `json:"backend"`
-	DoltMode      string `json:"dolt_mode"`
-	ServerHost    string `json:"server_host,omitempty"`
-	ServerPort    int    `json:"server_port,omitempty"`
-	Database      string `json:"database"`
-	DataDir       string `json:"data_dir,omitempty"`
-	ProjectID     string `json:"project_id,omitempty"`
-	SyncGitRemote string `json:"sync_git_remote,omitempty"`
-	Role          string `json:"role,omitempty"`
-	BdVersion     string `json:"bd_version"`
+	BeadsDir     string `json:"beads_dir"`
+	RepoRoot     string `json:"repo_root"`
+	CWDRepoRoot  string `json:"cwd_repo_root,omitempty"`
+	IsRedirected bool   `json:"is_redirected"`
+	IsWorktree   bool   `json:"is_worktree"`
+	Backend      string `json:"backend"`
+	DoltMode     string `json:"dolt_mode"`
+	ServerHost   string `json:"server_host,omitempty"`
+	ServerPort   int    `json:"server_port,omitempty"`
+	Database     string `json:"database"`
+	DataDir      string `json:"data_dir,omitempty"`
+	ProjectID    string `json:"project_id,omitempty"`
+	SyncRemote   string `json:"sync_remote,omitempty"`
+	Role         string `json:"role,omitempty"`
+	BdVersion    string `json:"bd_version"`
 }
 
 var contextCmd = &cobra.Command{
@@ -102,9 +101,9 @@ Examples:
 			info.DataDir = dataDir
 		}
 
-		// Read sync.git-remote from the selected repo's config.yaml.
-		if remote := config.GetStringFromDir(rc.BeadsDir, "sync.git-remote"); remote != "" {
-			info.SyncGitRemote = remote
+		// Read sync remote from the selected repo's config.yaml.
+		if remote := resolveSyncRemoteFromDir(rc.BeadsDir); remote != "" {
+			info.SyncRemote = remote
 		}
 
 		if jsonOutput {
@@ -153,10 +152,10 @@ func printContextText(info ContextInfo) {
 	}
 
 	// Sync
-	if info.SyncGitRemote != "" {
+	if info.SyncRemote != "" {
 		fmt.Println()
 		fmt.Println("Sync:")
-		fmt.Printf("  git remote:   %s\n", info.SyncGitRemote)
+		fmt.Printf("  remote:       %s\n", info.SyncRemote)
 	}
 }
 

--- a/cmd/bd/doctor/agent.go
+++ b/cmd/bd/doctor/agent.go
@@ -309,10 +309,10 @@ func enrichFreshClone(dc DoctorCheck) agentEnrichment {
 	commands := []string{"bd bootstrap"}
 	explanation := fmt.Sprintf("Fresh clone detected: %s. The .beads/ directory exists (committed to git) but the local database has not been recovered yet. Run bd bootstrap as the safe existing-project recovery entry point.", dc.Message)
 
-	// When the message mentions sync.git-remote, include it in the suggested commands.
-	if strings.Contains(dc.Message, "sync.git-remote") {
-		explanation = fmt.Sprintf("Fresh clone detected: %s. The .beads/ directory exists (committed to git) but the database is not found on the configured server. Run bd bootstrap as the safe entry point; if bootstrap cannot find the expected remote automatically, then set sync.git-remote in .beads/config.yaml and rerun bd bootstrap.", dc.Message)
-		commands = []string{"bd bootstrap", "Set sync.git-remote in .beads/config.yaml if bootstrap cannot find the expected remote"}
+	// When the message mentions sync.remote, include it in the suggested commands.
+	if strings.Contains(dc.Message, "sync.remote") {
+		explanation = fmt.Sprintf("Fresh clone detected: %s. The .beads/ directory exists (committed to git) but the database is not found on the configured server. Run bd bootstrap as the safe entry point; if bootstrap cannot find the expected remote automatically, then set sync.remote in .beads/config.yaml and rerun bd bootstrap.", dc.Message)
+		commands = []string{"bd bootstrap", "Set sync.remote in .beads/config.yaml if bootstrap cannot find the expected remote"}
 	}
 
 	return agentEnrichment{

--- a/cmd/bd/doctor/agent_test.go
+++ b/cmd/bd/doctor/agent_test.go
@@ -24,7 +24,7 @@ func TestEnrichFreshClone_UsesBootstrapFirstGuidance(t *testing.T) {
 }
 
 func TestEnrichFreshClone_WithSyncRemoteMentionsBootstrapAndFallback(t *testing.T) {
-	dc := DoctorCheck{Name: "Fresh Clone", Message: "sync.git-remote is configured but database not found"}
+	dc := DoctorCheck{Name: "Fresh Clone", Message: "sync.remote is configured but database not found"}
 	enrichment := enrichFreshClone(dc)
 
 	if !strings.Contains(enrichment.explanation, "bd bootstrap") {
@@ -33,7 +33,7 @@ func TestEnrichFreshClone_WithSyncRemoteMentionsBootstrapAndFallback(t *testing.
 	if len(enrichment.commands) != 2 || enrichment.commands[0] != "bd bootstrap" {
 		t.Fatalf("expected bootstrap-first command list, got %#v", enrichment.commands)
 	}
-	if !strings.Contains(enrichment.commands[1], "sync.git-remote") {
-		t.Fatalf("expected sync.git-remote fallback command, got %#v", enrichment.commands)
+	if !strings.Contains(enrichment.commands[1], "sync.remote") {
+		t.Fatalf("expected sync.remote fallback command, got %#v", enrichment.commands)
 	}
 }

--- a/cmd/bd/doctor/fix/database_integrity.go
+++ b/cmd/bd/doctor/fix/database_integrity.go
@@ -56,7 +56,7 @@ func doltIntegrityRecovery(path, beadsDir string) error {
 	}
 
 	// Reinitialize: bd init --force -q
-	// bd init will clone from remote if sync.git-remote is configured.
+	// bd init will clone from remote if sync.remote is configured.
 	fmt.Printf("  Reinitializing Dolt database (will clone from remote if configured)\n")
 	initCmd := newBdCmd(bdBinary, "init", "--force", "-q", "--skip-hooks")
 	initCmd.Dir = path

--- a/cmd/bd/doctor/fresh_clone_server.go
+++ b/cmd/bd/doctor/fresh_clone_server.go
@@ -75,10 +75,10 @@ func checkFreshCloneDB(host string, port int, user, password, dbName string, tls
 //
 // When dbExists is true, returns StatusOK (FR-021).
 // When dbExists is false and syncGitRemote is empty, returns StatusWarning
-// suggesting the user set sync.git-remote (FR-020).
+// suggesting the user set sync.remote (FR-020).
 // When dbExists is false and syncGitRemote is set, returns StatusWarning
 // suggesting bd init to bootstrap from the remote.
-func freshCloneServerResult(dbExists bool, dbName, host string, port int, syncGitRemote string) DoctorCheck {
+func freshCloneServerResult(dbExists bool, dbName, host string, port int, syncRemote string) DoctorCheck {
 	if dbExists {
 		return DoctorCheck{
 			Name:    "Fresh Clone",
@@ -91,11 +91,11 @@ func freshCloneServerResult(dbExists bool, dbName, host string, port int, syncGi
 	fmt.Fprintf(&msg, "Fresh clone detected: database %q not found on server at %s:%d.", dbName, host, port)
 
 	fix := "bd bootstrap"
-	if syncGitRemote == "" {
-		msg.WriteString(" Run bd bootstrap first as the safe recovery entry point. It may recover existing state or initialize if no prior state can be found. If bootstrap cannot find the expected remote automatically, then set sync.git-remote in .beads/config.yaml and rerun bd bootstrap.")
+	if syncRemote == "" {
+		msg.WriteString(" Run bd bootstrap first as the safe recovery entry point. It may recover existing state or initialize if no prior state can be found. If bootstrap cannot find the expected remote automatically, then set sync.remote in .beads/config.yaml and rerun bd bootstrap.")
 		fix = "bd bootstrap"
 	} else {
-		fmt.Fprintf(&msg, " sync.git-remote is configured (%s) — run bd bootstrap to recover from the remote, or use --dry-run to inspect the plan first.", syncGitRemote)
+		fmt.Fprintf(&msg, " sync.remote is configured (%s) — run bd bootstrap to recover from the remote, or use --dry-run to inspect the plan first.", syncRemote)
 	}
 
 	return DoctorCheck{

--- a/cmd/bd/doctor/fresh_clone_server_test.go
+++ b/cmd/bd/doctor/fresh_clone_server_test.go
@@ -13,7 +13,7 @@ func TestFreshCloneServerResult(t *testing.T) {
 		dbName         string
 		host           string
 		port           int
-		syncGitRemote  string
+		syncRemote     string
 		wantStatus     string
 		wantContains   []string
 		wantNotContain []string
@@ -29,41 +29,41 @@ func TestFreshCloneServerResult(t *testing.T) {
 				"Database exists on server",
 			},
 		},
-		"DB missing, no sync.git-remote returns Warning (FR-020)": {
-			dbExists:      false,
-			dbName:        "acf_beads",
-			host:          "127.0.0.1",
-			port:          3309,
-			syncGitRemote: "",
-			wantStatus:    StatusWarning,
+		"DB missing, no sync.remote returns Warning (FR-020)": {
+			dbExists:   false,
+			dbName:     "acf_beads",
+			host:       "127.0.0.1",
+			port:       3309,
+			syncRemote: "",
+			wantStatus: StatusWarning,
 			wantContains: []string{
 				`"acf_beads"`,
 				"not found on server",
 				"127.0.0.1:3309",
-				"sync.git-remote",
+				"sync.remote",
 				".beads/config.yaml",
 			},
 			wantNotContain: []string{
-				"sync.git-remote is configured",
+				"sync.remote is configured",
 			},
 			wantFix: "bd bootstrap",
 		},
-		"DB missing, sync.git-remote IS configured returns Warning with remote hint": {
-			dbExists:      false,
-			dbName:        "beads_kc",
-			host:          "192.168.1.50",
-			port:          3307,
-			syncGitRemote: "https://doltremoteapi.dolthub.com/myorg/beads",
-			wantStatus:    StatusWarning,
+		"DB missing, sync.remote IS configured returns Warning with remote hint": {
+			dbExists:   false,
+			dbName:     "beads_kc",
+			host:       "192.168.1.50",
+			port:       3307,
+			syncRemote: "https://doltremoteapi.dolthub.com/myorg/beads",
+			wantStatus: StatusWarning,
 			wantContains: []string{
 				`"beads_kc"`,
 				"not found on server",
-				"sync.git-remote is configured",
+				"sync.remote is configured",
 				"https://doltremoteapi.dolthub.com/myorg/beads",
 				"bd bootstrap",
 			},
 			wantNotContain: []string{
-				"Set sync.git-remote in .beads/config.yaml",
+				"Set sync.remote in .beads/config.yaml",
 			},
 			wantFix: "bd bootstrap",
 		},
@@ -71,7 +71,7 @@ func TestFreshCloneServerResult(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			check := freshCloneServerResult(tt.dbExists, tt.dbName, tt.host, tt.port, tt.syncGitRemote)
+			check := freshCloneServerResult(tt.dbExists, tt.dbName, tt.host, tt.port, tt.syncRemote)
 
 			if check.Name != "Fresh Clone" {
 				t.Errorf("expected Name %q, got %q", "Fresh Clone", check.Name)

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -314,8 +314,11 @@ func CheckFreshClone(repoPath string) DoctorCheck {
 			dbName := cfg.GetDoltDatabase()
 			result := checkFreshCloneDB(host, port, user, password, dbName, cfg.GetDoltServerTLS())
 			if result.Reachable {
-				syncGitRemote := config.GetStringFromDir(beadsDir, "sync.git-remote")
-				return freshCloneServerResult(result.Exists, dbName, host, port, syncGitRemote)
+				syncRemote := config.GetStringFromDir(beadsDir, "sync.remote")
+				if syncRemote == "" {
+					syncRemote = config.GetStringFromDir(beadsDir, "sync.git-remote")
+				}
+				return freshCloneServerResult(result.Exists, dbName, host, port, syncRemote)
 			}
 			// Server unreachable — fall through to existing behavior (FR-030).
 		}

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -686,7 +686,9 @@ var doltRemoteAddCmd = &cobra.Command{
 		}
 		cliURL := doltutil.FindCLIRemote(dbPath, name)
 
-		// Prompt for overwrite if either surface already has this remote
+		// Prompt for overwrite if either surface already has this remote.
+		// In embedded mode SQL and CLI share the same directory, so only
+		// prompt once — the SQL remove handles both.
 		if sqlURL != "" && sqlURL != url {
 			if !confirmOverwrite("SQL server", name, sqlURL, url) {
 				fmt.Println("Canceled.")
@@ -698,18 +700,14 @@ var doltRemoteAddCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
-		if cliURL != "" && cliURL != url {
+		if !isEmbeddedMode() && cliURL != "" && cliURL != url {
 			if !confirmOverwrite("CLI (filesystem)", name, cliURL, url) {
 				fmt.Println("Canceled.")
 				return
 			}
-			// In embedded mode, SQL and CLI share the same directory,
-			// so the SQL remove above already deleted the remote config.
-			if !isEmbeddedMode() {
-				if err := doltutil.RemoveCLIRemote(dbPath, name); err != nil {
-					fmt.Fprintf(os.Stderr, "Error removing existing CLI remote: %v\n", err)
-					os.Exit(1)
-				}
+			if err := doltutil.RemoveCLIRemote(dbPath, name); err != nil {
+				fmt.Fprintf(os.Stderr, "Error removing existing CLI remote: %v\n", err)
+				os.Exit(1)
 			}
 		}
 
@@ -736,6 +734,19 @@ var doltRemoteAddCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "Warning: SQL remote added but CLI remote failed: %v\n", err)
 				fmt.Fprintf(os.Stderr, "Run: cd %s && dolt remote add %s %s\n",
 					doltutil.ShellQuote(dbPath), doltutil.ShellQuote(name), doltutil.ShellQuote(url))
+			}
+		}
+
+		// Persist the origin remote URL to config.yaml as sync.remote
+		// so fresh clones can bootstrap from it (the Dolt database is
+		// gitignored and won't survive clone).
+		if name == "origin" {
+			if err := config.SetYamlConfig("sync.remote", url); err != nil {
+				FatalError("failed to persist sync.remote to config.yaml: %v", err)
+			}
+			// Auto-commit the config change so it's not left dirty.
+			if isGitRepo() {
+				commitBeadsConfig("bd: update sync.remote")
 			}
 		}
 
@@ -940,6 +951,19 @@ var doltRemoteRemoveCmd = &cobra.Command{
 		if sqlURL == "" && cliURL == "" {
 			fmt.Fprintf(os.Stderr, "Error: remote %q not found on either surface\n", name)
 			os.Exit(1)
+		}
+
+		// Clear sync.remote from config.yaml if the origin remote was removed,
+		// so fresh clones don't try to bootstrap from a stale URL.
+		if name == "origin" {
+			if current := config.GetYamlConfig("sync.remote"); current != "" {
+				if err := config.UnsetYamlConfig("sync.remote"); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to clear sync.remote from config.yaml: %v\n", err)
+				}
+				if isGitRepo() {
+					commitBeadsConfig("bd: clear sync.remote")
+				}
+			}
 		}
 
 		suffix := "(SQL + CLI)"

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -460,28 +460,32 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 
 		// Auto-bootstrap from git remote if sync.git-remote is configured
 		// or origin has refs/dolt/data. This makes bd init and bd bootstrap
+		// Auto-bootstrap from remote if sync.remote (or deprecated
+		// sync.git-remote) is configured, or git origin has Dolt data
+		// (refs/dolt/data). This makes bd init and bd bootstrap
 		// interchangeable — both clone from the remote when one exists.
-		gitRemoteURL := config.GetString("sync.git-remote")
+		syncURL := resolveSyncRemote()
 		bootstrappedFromRemote := false
 		syncFromRemote := false
-		if gitRemoteURL != "" {
+		if syncURL != "" {
+			syncURL = normalizeRemoteURL(syncURL)
 			syncFromRemote = true
 		} else if isGitRepo() && !isBareGitRepo() {
 			if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
-				gitRemoteURL = gitURLToDoltRemote(originURL)
+				syncURL = normalizeRemoteURL(originURL)
 				if !force && gitLsRemoteHasRef("origin", "refs/dolt/data") {
 					syncFromRemote = true
 				}
 			}
 		}
 		if syncFromRemote {
-			if err := cloneFromRemote(ctx, beadsDir, gitRemoteURL, dbName); err != nil {
+			if err := cloneFromRemote(ctx, beadsDir, syncURL, dbName); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
 			bootstrappedFromRemote = true
 			if !quiet {
-				fmt.Printf("  %s Bootstrapped from git remote: %s\n", ui.RenderPass("✓"), gitRemoteURL)
+				fmt.Printf("  %s Bootstrapped from remote: %s\n", ui.RenderPass("✓"), syncURL)
 			}
 		}
 
@@ -565,18 +569,18 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			os.Exit(1)
 		}
 
-		// Configure the git remote in the Dolt store so bd dolt push/pull
+		// Configure the remote in the Dolt store so bd dolt push/pull
 		// work immediately after bootstrap. Also add the remote when
-		// sync.git-remote is configured but bootstrap was skipped (DB already
+		// sync.remote is configured but bootstrap was skipped (DB already
 		// existed) — ensures the remote is always wired up.
-		if gitRemoteURL != "" {
+		if syncURL != "" {
 			hasRemote, _ := store.HasRemote(ctx, "origin")
 			if !hasRemote {
-				if err := store.AddRemote(ctx, "origin", gitRemoteURL); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to add git remote 'origin': %v\n", err)
+				if err := store.AddRemote(ctx, "origin", syncURL); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to add remote 'origin': %v\n", err)
 					// Non-fatal — user can add manually with: bd dolt remote add origin <url>
 				} else if !quiet {
-					fmt.Printf("  %s Configured Dolt remote: origin → %s\n", ui.RenderPass("✓"), gitRemoteURL)
+					fmt.Printf("  %s Configured Dolt remote: origin → %s\n", ui.RenderPass("✓"), syncURL)
 				}
 			}
 		}
@@ -723,6 +727,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			if err := createConfigYaml(beadsDir, false, ""); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to create config.yaml: %v\n", err)
 				// Non-fatal - continue anyway
+			}
+
+			// Persist sync.remote to config.yaml so fresh clones can
+			// bootstrap from it (the Dolt database is gitignored).
+			// Must run AFTER createConfigYaml which creates the file.
+			if syncURL != "" {
+				if existing := config.GetYamlConfig("sync.remote"); existing == "" {
+					if err := config.SetYamlConfig("sync.remote", syncURL); err != nil {
+						FatalError("failed to persist sync.remote to config.yaml: %v", err)
+					}
+				}
 			}
 
 			// Enable shared server mode if requested via flag OR env var (GH#2377).

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -458,34 +458,30 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
-		// Auto-bootstrap from git remote if sync.git-remote is configured.
-		// This enables the new-machine story: set sync.git-remote in config.yaml,
-		// run bd init, and the Dolt database is cloned from the git remote
-		// automatically — no manual dolt clone needed.
+		// Auto-bootstrap from git remote if sync.git-remote is configured
+		// or origin has refs/dolt/data. This makes bd init and bd bootstrap
+		// interchangeable — both clone from the remote when one exists.
 		gitRemoteURL := config.GetString("sync.git-remote")
 		bootstrappedFromRemote := false
+		syncFromRemote := false
 		if gitRemoteURL != "" {
-			cloned, bootstrapErr := dolt.BootstrapFromGitRemoteWithDB(ctx, storagePath, gitRemoteURL, dbName)
-			if bootstrapErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to bootstrap from git remote %s: %v\n", gitRemoteURL, bootstrapErr)
-				fmt.Fprintf(os.Stderr, "  Continuing with fresh database initialization.\n")
-				// Non-fatal: fall through to normal init
-			} else if cloned {
-				bootstrappedFromRemote = true
-				if !quiet {
-					fmt.Printf("  %s Bootstrapped from git remote: %s\n", ui.RenderPass("✓"), gitRemoteURL)
-				}
-			}
+			syncFromRemote = true
 		} else if isGitRepo() && !isBareGitRepo() {
-			// Auto-detect git origin and use it as the Dolt remote.
-			// This enables push/pull against the git remote by default.
 			if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
 				gitRemoteURL = gitURLToDoltRemote(originURL)
 				if !force && gitLsRemoteHasRef("origin", "refs/dolt/data") {
-					fmt.Fprintf(os.Stderr, "Note: origin has an existing beads database (refs/dolt/data).\n")
-					fmt.Fprintf(os.Stderr, "  Run 'bd bootstrap' instead to clone it.\n")
-					fmt.Fprintf(os.Stderr, "  Continuing with fresh database initialization.\n\n")
+					syncFromRemote = true
 				}
+			}
+		}
+		if syncFromRemote {
+			if err := cloneFromRemote(ctx, beadsDir, gitRemoteURL, dbName); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			bootstrappedFromRemote = true
+			if !quiet {
+				fmt.Printf("  %s Bootstrapped from git remote: %s\n", ui.RenderPass("✓"), gitRemoteURL)
 			}
 		}
 

--- a/cmd/bd/init_guard.go
+++ b/cmd/bd/init_guard.go
@@ -84,7 +84,7 @@ func checkDatabaseOnServer(host string, port int, user, password, dbName string,
 // that command destroys all existing issue data.  An AI agent running inside a
 // git hook blindly followed the previous suggestion and wiped a production
 // database.  Instead we guide the user toward safe diagnostic commands.
-func initGuardServerMessage(dbName, host string, port int, prefix, syncGitRemote string) error {
+func initGuardServerMessage(dbName, host string, port int, prefix, syncRemote string) error {
 	var b strings.Builder
 	fmt.Fprintf(&b, "\n%s Database %q not found on server at %s:%d.\n", ui.RenderWarn("⚠"), dbName, host, port)
 	b.WriteString("The server is running but this database hasn't been created yet.\n")
@@ -97,13 +97,13 @@ func initGuardServerMessage(dbName, host string, port int, prefix, syncGitRemote
 	b.WriteString("  bd bootstrap\n")
 	b.WriteString("This is the safe entry point for existing-project recovery and may recover or initialize depending on detected state.\n")
 
-	if syncGitRemote != "" {
-		fmt.Fprintf(&b, "\nTip: sync.git-remote is configured (%s).\n", syncGitRemote)
+	if syncRemote != "" {
+		fmt.Fprintf(&b, "\nTip: sync.remote is configured (%s).\n", syncRemote)
 		b.WriteString("Run bd bootstrap to recover from the configured remote, or use --dry-run to inspect the plan first.\n")
 	} else {
 		b.WriteString("\nIf this is a brand-new project, create the database with:\n")
 		fmt.Fprintf(&b, "  bd init --prefix %s\n", prefix)
-		b.WriteString("\nIf bd bootstrap cannot find the expected remote automatically, set sync.git-remote\n")
+		b.WriteString("\nIf bd bootstrap cannot find the expected remote automatically, set sync.remote\n")
 		b.WriteString("in .beads/config.yaml and re-run bd bootstrap.\n")
 	}
 

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -14,16 +14,16 @@ func TestInitGuardServerMessage(t *testing.T) {
 		host           string
 		port           int
 		prefix         string
-		syncGitRemote  string
+		syncRemote     string
 		wantContains   []string
 		wantNotContain []string
 	}{
-		"DB missing, no sync.git-remote configured (FR-010, FR-011)": {
-			dbName:        "acf_beads",
-			host:          "127.0.0.1",
-			port:          3309,
-			prefix:        "acf",
-			syncGitRemote: "",
+		"DB missing, no sync.remote configured (FR-010, FR-011)": {
+			dbName:     "acf_beads",
+			host:       "127.0.0.1",
+			port:       3309,
+			prefix:     "acf",
+			syncRemote: "",
 			wantContains: []string{
 				`"acf_beads"`,
 				"127.0.0.1:3309",
@@ -31,23 +31,23 @@ func TestInitGuardServerMessage(t *testing.T) {
 				"bd doctor",
 				"bd dolt status",
 				"bd bootstrap",
-				"set sync.git-remote",
+				"set sync.remote",
 				".beads/config.yaml",
 				"Aborting",
 				"--force destroys ALL existing issues",
 			},
 			wantNotContain: []string{
-				"sync.git-remote is configured",
+				"sync.remote is configured",
 				// GH#2363: must NOT suggest --force as the primary action
 				"bd init --force --prefix",
 			},
 		},
-		"DB missing, sync.git-remote IS configured (FR-010, FR-011)": {
-			dbName:        "beads_kc",
-			host:          "192.168.1.50",
-			port:          3307,
-			prefix:        "kc",
-			syncGitRemote: "https://doltremoteapi.dolthub.com/myorg/beads",
+		"DB missing, sync.remote IS configured (FR-010, FR-011)": {
+			dbName:     "beads_kc",
+			host:       "192.168.1.50",
+			port:       3307,
+			prefix:     "kc",
+			syncRemote: "https://doltremoteapi.dolthub.com/myorg/beads",
 			wantContains: []string{
 				`"beads_kc"`,
 				"192.168.1.50:3307",
@@ -55,12 +55,12 @@ func TestInitGuardServerMessage(t *testing.T) {
 				"bd doctor",
 				"bd dolt status",
 				"bd bootstrap",
-				"sync.git-remote is configured",
+				"sync.remote is configured",
 				"https://doltremoteapi.dolthub.com/myorg/beads",
 				"--force destroys ALL existing issues",
 			},
 			wantNotContain: []string{
-				"set sync.git-remote",
+				"set sync.remote",
 				// GH#2363: must NOT suggest --force as the primary action
 				"bd init --force --prefix",
 				"bd init --force to bootstrap",
@@ -70,7 +70,7 @@ func TestInitGuardServerMessage(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := initGuardServerMessage(tt.dbName, tt.host, tt.port, tt.prefix, tt.syncGitRemote)
+			err := initGuardServerMessage(tt.dbName, tt.host, tt.port, tt.prefix, tt.syncRemote)
 			if err == nil {
 				t.Fatal("expected non-nil error")
 			}

--- a/cmd/bd/kv_test.go
+++ b/cmd/bd/kv_test.go
@@ -196,7 +196,7 @@ func TestValidateKVKey(t *testing.T) {
 		{"empty key", "", true, "cannot be empty"},
 		{"whitespace only", "   ", true, "cannot be only whitespace"},
 		{"kv prefix", "kv.nested", true, "cannot start with 'kv.'"},
-		{"sync prefix", "sync.git-remote", true, "reserved prefix"},
+		{"sync prefix", "sync.remote", true, "reserved prefix"},
 		{"conflict prefix", "conflict.strategy", true, "reserved prefix"},
 		{"federation prefix", "federation.remote", true, "reserved prefix"},
 		{"jira prefix", "jira.url", true, "reserved prefix"},

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -733,7 +733,7 @@ var rootCmd = &cobra.Command{
 			// Log so silent fallback to default DB is visible.
 			fmt.Fprintf(os.Stderr, "warning: no beads configuration found in %s; database name may default incorrectly\n", beadsDir)
 		}
-		doltCfg.SyncGitRemote = config.GetString("sync.git-remote")
+		doltCfg.SyncRemote = resolveSyncRemote()
 
 		// Keep standalone CLI auto-start behavior centralized so doctor and
 		// other helper paths stay in lockstep with the main command path.

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -40,7 +40,7 @@ func commitBeadsConfig(msg string) {
 	if err := addCmd.Run(); err != nil {
 		return
 	}
-	commitCmd := exec.Command("git", "commit", "-m", msg)
+	commitCmd := exec.Command("git", "commit", "-m", msg) //nolint:gosec // G702: msg is from internal callers only, not user input
 	if out, err := commitCmd.CombinedOutput(); err != nil {
 		// "nothing to commit" is normal if the file was already staged
 		if !strings.Contains(string(out), "nothing to commit") {

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// resolveSyncRemote returns the effective sync remote URL.
+// Resolution order:
+//  1. sync.remote (primary — any Dolt-compatible remote URL)
+//  2. sync.git-remote (deprecated fallback)
+//  3. "" (not configured)
+func resolveSyncRemote() string {
+	if v := config.GetString("sync.remote"); v != "" {
+		return v
+	}
+	return config.GetString("sync.git-remote")
+}
+
+// resolveSyncRemoteFromDir is like resolveSyncRemote but reads from a
+// specific beads directory's config.yaml. Used by context_cmd, doctor,
+// and other paths that operate on a resolved beads dir rather than CWD.
+func resolveSyncRemoteFromDir(beadsDir string) string {
+	if v := config.GetStringFromDir(beadsDir, "sync.remote"); v != "" {
+		return v
+	}
+	return config.GetStringFromDir(beadsDir, "sync.git-remote")
+}
+
+// commitBeadsConfig stages .beads/config.yaml and commits it.
+// Silently no-ops if the file is clean or the commit fails (e.g. hooks,
+// nothing to commit). Used by bd dolt remote add/remove to keep the
+// working tree clean after persisting sync.remote.
+func commitBeadsConfig(msg string) {
+	addCmd := exec.Command("git", "add", ".beads/config.yaml")
+	if err := addCmd.Run(); err != nil {
+		return
+	}
+	commitCmd := exec.Command("git", "commit", "-m", msg)
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		// "nothing to commit" is normal if the file was already staged
+		if !strings.Contains(string(out), "nothing to commit") {
+			fmt.Fprintf(os.Stderr, "Warning: failed to commit config change: %v\n", err)
+		}
+	}
+}
+
+// doltNativeSchemes are URL schemes that Dolt understands natively
+// and should not be converted through gitURLToDoltRemote.
+var doltNativeSchemes = []string{
+	"dolthub://",
+	"file://",
+	"aws://",
+	"gs://",
+	"git+https://",
+	"git+ssh://",
+	"git+http://",
+}
+
+// normalizeRemoteURL converts a remote URL to a Dolt-compatible format.
+// Dolt-native URLs (dolthub://, file://, aws://, gs://, git+...) are
+// returned as-is. Git URLs (https://, ssh://, git@...) are converted
+// via gitURLToDoltRemote. Unknown schemes are returned as-is and let
+// dolt clone decide.
+func normalizeRemoteURL(url string) string {
+	for _, scheme := range doltNativeSchemes {
+		if strings.HasPrefix(url, scheme) {
+			return url
+		}
+	}
+	// Git-style URLs need conversion to dolt remote format
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") ||
+		strings.HasPrefix(url, "ssh://") {
+		return gitURLToDoltRemote(url)
+	}
+	// SCP-style git@host:path
+	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") && strings.Contains(url, "@") {
+		return gitURLToDoltRemote(url)
+	}
+	// Unknown scheme — return as-is, let dolt handle it
+	return url
+}

--- a/cmd/bd/sync_remote_test.go
+++ b/cmd/bd/sync_remote_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestNormalizeRemoteURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Dolt-native schemes — returned as-is
+		{"dolthub://myorg/beads", "dolthub://myorg/beads"},
+		{"file:///tmp/doltdb", "file:///tmp/doltdb"},
+		{"aws://[dolt-table:us-east-1]/mydb", "aws://[dolt-table:us-east-1]/mydb"},
+		{"gs://my-bucket/mydb", "gs://my-bucket/mydb"},
+		{"git+https://github.com/org/repo.git", "git+https://github.com/org/repo.git"},
+		{"git+ssh://git@github.com/org/repo.git", "git+ssh://git@github.com/org/repo.git"},
+		{"git+http://example.com/repo.git", "git+http://example.com/repo.git"},
+
+		// Git URLs — converted to dolt remote format
+		{"https://github.com/org/repo.git", "git+https://github.com/org/repo.git"},
+		{"http://github.com/org/repo.git", "git+http://github.com/org/repo.git"},
+		{"ssh://git@github.com/org/repo.git", "git+ssh://git@github.com/org/repo.git"},
+		{"git@github.com:org/repo.git", "git+ssh://git@github.com/org/repo.git"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeRemoteURL(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeRemoteURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -244,9 +244,10 @@ When someone clones a repository that uses Dolt backend:
 - Clones the Dolt database from the remote (instead of creating a fresh one)
 - Configures the Dolt remote for future `bd dolt push`/`pull`
 
-If `sync.git-remote` is set in `.beads/config.yaml`, that takes precedence
-over auto-detection. `bd init` will warn if it detects `refs/dolt/data` on
-origin and suggest using `bd bootstrap` instead.
+If `sync.remote` is set in `.beads/config.yaml`, that takes precedence
+over auto-detection. Any Dolt-compatible remote URL is supported (DoltHub,
+S3, GCS, file, or git). `bd init` will warn if it detects `refs/dolt/data`
+on origin and suggest using `bd bootstrap` instead.
 
 ### Verifying Bootstrap Worked
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -673,7 +673,7 @@ bd dolt push
 bd dolt pull
 
 # Check sync configuration
-bd config get sync.git-remote
+bd config get sync.remote
 ```
 
 ## Ready Work and Dependencies

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -35,7 +35,8 @@ var YamlOnlyKeys = map[string]bool{
 	"no-git-ops":      true, // Disable git ops in bd prime session close protocol (GH#593)
 
 	// Sync settings
-	"sync.git-remote":                          true,
+	"sync.remote":     true, // Primary: any Dolt-compatible remote URL
+	"sync.git-remote": true, // Deprecated: falls back from sync.remote
 	"sync.require_confirmation_on_mass_delete": true,
 
 	// Routing settings

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -790,11 +790,11 @@ func TestInitLoadsCustomTypeMapFromAllConfig(t *testing.T) {
 func TestInitLoadsCustomPriorityMapFromAllConfig(t *testing.T) {
 	store := &configStore{
 		data: map[string]string{
-			"jira.url":              "https://example.atlassian.net",
-			"jira.project":          "PROJ",
-			"jira.api_token":        "token123",
-			"jira.priority_map.0":   "Critical",
-			"jira.priority_map.2":   "Normal",
+			"jira.url":            "https://example.atlassian.net",
+			"jira.project":        "PROJ",
+			"jira.api_token":      "token123",
+			"jira.priority_map.0": "Critical",
+			"jira.priority_map.2": "Normal",
 		},
 	}
 
@@ -826,11 +826,11 @@ func TestPriorityToTrackerUsesCustomMap(t *testing.T) {
 		priority int
 		want     string
 	}{
-		{0, "Critical"},  // from custom map
-		{1, "High"},      // not in map → default
-		{2, "Normal"},    // from custom map
-		{3, "Low"},       // not in map → default
-		{4, "Lowest"},    // not in map → default
+		{0, "Critical"}, // from custom map
+		{1, "High"},     // not in map → default
+		{2, "Normal"},   // from custom map
+		{3, "Low"},      // not in map → default
+		{4, "Lowest"},   // not in map → default
 	}
 	for _, tt := range tests {
 		got, _ := mapper.PriorityToTracker(tt.priority).(string)
@@ -852,11 +852,11 @@ func TestPriorityToBeadsUsesCustomMap(t *testing.T) {
 		name string
 		want int
 	}{
-		{"Critical", 0},  // from custom map
-		{"Normal", 2},    // from custom map
-		{"High", 1},      // not in map → default
-		{"Low", 3},       // not in map → default
-		{"Lowest", 4},    // not in map → default
+		{"Critical", 0}, // from custom map
+		{"Normal", 2},   // from custom map
+		{"High", 1},     // not in map → default
+		{"Low", 3},      // not in map → default
+		{"Lowest", 4},   // not in map → default
 	}
 	for _, tt := range tests {
 		got := mapper.PriorityToBeads(tt.name)

--- a/internal/storage/dolt/bootstrap.go
+++ b/internal/storage/dolt/bootstrap.go
@@ -17,28 +17,33 @@ import (
 // Bootstrap operations should complete well within this window.
 const staleLockAge = 5 * time.Minute
 
-// BootstrapFromGitRemote clones a Dolt database from a git remote URL.
+// BootstrapFromRemote clones a Dolt database from a remote URL.
 // This is used when no local .beads/dolt/ exists but config.yaml has
-// sync.git-remote configured, enabling cold-start from a git remote
-// that already contains Dolt data on refs/dolt/data.
+// sync.remote configured, enabling cold-start from any Dolt-compatible
+// remote (git, DoltHub, S3, GCS, file, etc.).
 //
 // dolt clone creates <target>/.dolt/ directly (no database subdirectory),
 // but the embedded driver expects <doltDir>/<database>/.dolt/. To reconcile,
 // we clone into <doltDir>/<database>/ so the embedded driver finds it.
-// Uses the default database name ("beads"). Prefer BootstrapFromGitRemoteWithDB
+// Uses the default database name ("beads"). Prefer BootstrapFromRemoteWithDB
 // when a configured database name is available.
 //
 // Returns true if the clone was performed, false if skipped (dolt dir already exists).
-func BootstrapFromGitRemote(ctx context.Context, doltDir, gitRemoteURL string) (bool, error) {
-	return BootstrapFromGitRemoteWithDB(ctx, doltDir, gitRemoteURL, configfile.DefaultDoltDatabase)
+func BootstrapFromRemote(ctx context.Context, doltDir, remoteURL string) (bool, error) {
+	return BootstrapFromRemoteWithDB(ctx, doltDir, remoteURL, configfile.DefaultDoltDatabase)
 }
 
-// BootstrapFromGitRemoteWithDB is like BootstrapFromGitRemote but allows
+// BootstrapFromGitRemote is deprecated. Use BootstrapFromRemote instead.
+func BootstrapFromGitRemote(ctx context.Context, doltDir, gitRemoteURL string) (bool, error) {
+	return BootstrapFromRemote(ctx, doltDir, gitRemoteURL)
+}
+
+// BootstrapFromRemoteWithDB is like BootstrapFromRemote but allows
 // specifying the database name (used by the embedded driver for the
 // subdirectory structure). The database parameter must not be empty;
 // callers should use cfg.GetDoltDatabase() which applies the fallback chain
 // (env var → config → default).
-func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, database string) (bool, error) {
+func BootstrapFromRemoteWithDB(ctx context.Context, doltDir, remoteURL, database string) (bool, error) {
 	// Skip if Dolt database already exists
 	if doltExists(doltDir) {
 		return false, nil
@@ -50,7 +55,7 @@ func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, da
 
 	// Verify dolt CLI is available
 	if _, err := exec.LookPath("dolt"); err != nil {
-		return false, fmt.Errorf("dolt CLI not found (required for git remote bootstrap): %w", err)
+		return false, fmt.Errorf("dolt CLI not found (required for remote bootstrap): %w", err)
 	}
 
 	// Create the parent dolt directory
@@ -61,13 +66,18 @@ func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, da
 	// Clone into <doltDir>/<database>/ so the embedded driver can find it.
 	// `dolt clone <url> <target>` creates <target>/.dolt/ directly.
 	cloneTarget := filepath.Join(doltDir, database)
-	cmd := exec.CommandContext(ctx, "dolt", "clone", gitRemoteURL, cloneTarget)
+	cmd := exec.CommandContext(ctx, "dolt", "clone", remoteURL, cloneTarget)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("dolt clone failed: %w\nOutput: %s", err, output)
 	}
 
-	fmt.Fprintf(os.Stderr, "Bootstrapped from git remote: %s\n", gitRemoteURL)
+	fmt.Fprintf(os.Stderr, "Bootstrapped from remote: %s\n", remoteURL)
 	return true, nil
+}
+
+// BootstrapFromGitRemoteWithDB is deprecated. Use BootstrapFromRemoteWithDB instead.
+func BootstrapFromGitRemoteWithDB(ctx context.Context, doltDir, gitRemoteURL, database string) (bool, error) {
+	return BootstrapFromRemoteWithDB(ctx, doltDir, gitRemoteURL, database)
 }
 
 // doltExists checks if a Dolt database directory exists

--- a/internal/storage/dolt/bootstrap_test.go
+++ b/internal/storage/dolt/bootstrap_test.go
@@ -6,12 +6,61 @@ import (
 	"testing"
 )
 
-// TestBootstrapFromGitRemoteWithDB_RejectsEmptyDatabase verifies that
-// BootstrapFromGitRemoteWithDB returns an error when called with an
+// TestBootstrapFromRemoteWithDB_RejectsEmptyDatabase verifies that
+// BootstrapFromRemoteWithDB returns an error when called with an
 // empty database name. Callers should use cfg.GetDoltDatabase() which
 // applies the fallback chain (env var -> config -> default). A silent
 // fallback to "beads" here previously masked misconfiguration (GH#3029).
-func TestBootstrapFromGitRemoteWithDB_RejectsEmptyDatabase(t *testing.T) {
+func TestBootstrapFromRemoteWithDB_RejectsEmptyDatabase(t *testing.T) {
+	doltDir := t.TempDir()
+
+	_, err := BootstrapFromRemoteWithDB(context.Background(), doltDir, "file:///dev/null", "")
+	if err == nil {
+		t.Fatal("expected error for empty database name, got nil")
+	}
+	if !strings.Contains(err.Error(), "database name must not be empty") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestBootstrapFromRemoteWithDB_RejectsWhitespaceDatabase verifies that
+// whitespace-only database names are also rejected (defense-in-depth).
+func TestBootstrapFromRemoteWithDB_RejectsWhitespaceDatabase(t *testing.T) {
+	doltDir := t.TempDir()
+
+	_, err := BootstrapFromRemoteWithDB(context.Background(), doltDir, "file:///dev/null", "   ")
+	if err == nil {
+		t.Fatal("expected error for whitespace-only database name, got nil")
+	}
+	if !strings.Contains(err.Error(), "database name must not be empty") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// TestBootstrapFromRemote_UsesDefaultDatabase verifies that the
+// convenience wrapper BootstrapFromRemote explicitly passes the
+// default database name rather than an empty string.
+func TestBootstrapFromRemote_UsesDefaultDatabase(t *testing.T) {
+	// Create a doltDir that already contains a database so the function
+	// returns early (skips clone) without needing the dolt CLI.
+	doltDir := t.TempDir()
+
+	// BootstrapFromRemote should not error with "database name must not be empty"
+	// because it passes configfile.DefaultDoltDatabase explicitly.
+	// It will return false (skipped) because doltExists returns false for an
+	// empty dir, then it will fail trying to run dolt clone — but the error
+	// should be about dolt CLI, not about empty database name.
+	_, err := BootstrapFromRemote(context.Background(), doltDir, "file:///dev/null")
+	if err != nil && strings.Contains(err.Error(), "database name must not be empty") {
+		t.Fatal("BootstrapFromRemote should pass an explicit database name, not empty string")
+	}
+	// Any other error (dolt CLI not found, clone failure) is fine — we only care
+	// that the empty-database guard didn't fire.
+}
+
+// TestBootstrapFromGitRemoteWithDB_DeprecatedWrapper verifies that the
+// deprecated BootstrapFromGitRemoteWithDB wrapper delegates correctly.
+func TestBootstrapFromGitRemoteWithDB_DeprecatedWrapper(t *testing.T) {
 	doltDir := t.TempDir()
 
 	_, err := BootstrapFromGitRemoteWithDB(context.Background(), doltDir, "file:///dev/null", "")
@@ -21,39 +70,4 @@ func TestBootstrapFromGitRemoteWithDB_RejectsEmptyDatabase(t *testing.T) {
 	if !strings.Contains(err.Error(), "database name must not be empty") {
 		t.Errorf("unexpected error message: %v", err)
 	}
-}
-
-// TestBootstrapFromGitRemoteWithDB_RejectsWhitespaceDatabase verifies that
-// whitespace-only database names are also rejected (defense-in-depth).
-func TestBootstrapFromGitRemoteWithDB_RejectsWhitespaceDatabase(t *testing.T) {
-	doltDir := t.TempDir()
-
-	_, err := BootstrapFromGitRemoteWithDB(context.Background(), doltDir, "file:///dev/null", "   ")
-	if err == nil {
-		t.Fatal("expected error for whitespace-only database name, got nil")
-	}
-	if !strings.Contains(err.Error(), "database name must not be empty") {
-		t.Errorf("unexpected error message: %v", err)
-	}
-}
-
-// TestBootstrapFromGitRemote_UsesDefaultDatabase verifies that the
-// convenience wrapper BootstrapFromGitRemote explicitly passes the
-// default database name rather than an empty string.
-func TestBootstrapFromGitRemote_UsesDefaultDatabase(t *testing.T) {
-	// Create a doltDir that already contains a database so the function
-	// returns early (skips clone) without needing the dolt CLI.
-	doltDir := t.TempDir()
-
-	// BootstrapFromGitRemote should not error with "database name must not be empty"
-	// because it passes configfile.DefaultDoltDatabase explicitly.
-	// It will return false (skipped) because doltExists returns false for an
-	// empty dir, then it will fail trying to run dolt clone — but the error
-	// should be about dolt CLI, not about empty database name.
-	_, err := BootstrapFromGitRemote(context.Background(), doltDir, "file:///dev/null")
-	if err != nil && strings.Contains(err.Error(), "database name must not be empty") {
-		t.Fatal("BootstrapFromGitRemote should pass an explicit database name, not empty string")
-	}
-	// Any other error (dolt CLI not found, clone failure) is fine — we only care
-	// that the empty-database guard didn't fire.
 }

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -97,7 +97,7 @@ func wrapExecError(op string, err error) error {
 }
 
 // databaseNotFoundError builds the "database not found" error with a config-aware
-// hint about sync.git-remote and backup recovery. Extracted from openServerConnection
+// hint about sync.remote and backup recovery. Extracted from openServerConnection
 // for testability.
 func databaseNotFoundError(cfg *Config) error {
 	var b strings.Builder
@@ -123,11 +123,11 @@ func databaseNotFoundError(cfg *Config) error {
 	b.WriteString("  bd doctor                  # Check server and database health\n")
 	b.WriteString("  bd dolt status             # Show which data directory the server is using")
 
-	if cfg.SyncGitRemote != "" {
-		fmt.Fprintf(&b, "\n\nTip: sync.git-remote is configured (%s).\nRun bd bootstrap to recover from the remote or confirm what bootstrap will do with --dry-run.", cfg.SyncGitRemote)
+	if cfg.SyncRemote != "" {
+		fmt.Fprintf(&b, "\n\nTip: sync.remote is configured (%s).\nRun bd bootstrap to recover from the remote or confirm what bootstrap will do with --dry-run.", cfg.SyncRemote)
 	} else {
 		b.WriteString("\n\nTip: If this is an existing project, fresh clone, or shared-server recovery, run bd bootstrap first.\n")
-		b.WriteString("If bootstrap cannot find the expected remote automatically, set sync.git-remote\nin .beads/config.yaml and re-run bd bootstrap.\n")
+		b.WriteString("If bootstrap cannot find the expected remote automatically, set sync.remote\nin .beads/config.yaml and re-run bd bootstrap.\n")
 		b.WriteString("Use bd bootstrap --dry-run if you need to confirm the plan before it initializes anything.\n")
 		b.WriteString("Use bd init only when creating a brand-new project with no existing .beads data.")
 	}

--- a/internal/storage/dolt/errors_test.go
+++ b/internal/storage/dolt/errors_test.go
@@ -100,15 +100,15 @@ func TestDatabaseNotFoundHint(t *testing.T) {
 		ServerPort: 3309,
 	}
 
-	t.Run("hint suggests setting sync.git-remote when empty", func(t *testing.T) {
-		cfg := baseCfg // SyncGitRemote is empty by default
+	t.Run("hint suggests setting sync.remote when empty", func(t *testing.T) {
+		cfg := baseCfg // SyncRemote is empty by default
 		err := databaseNotFoundError(&cfg)
 
 		msg := err.Error()
 
 		// FR-001: Must contain the setup hint (line-wrapped in output)
-		if !strings.Contains(msg, "set sync.git-remote") {
-			t.Errorf("expected hint to set sync.git-remote, got:\n%s", msg)
+		if !strings.Contains(msg, "set sync.remote") {
+			t.Errorf("expected hint to set sync.remote, got:\n%s", msg)
 		}
 		if !strings.Contains(msg, ".beads/config.yaml") {
 			t.Errorf("expected .beads/config.yaml reference, got:\n%s", msg)
@@ -134,15 +134,15 @@ func TestDatabaseNotFoundHint(t *testing.T) {
 		}
 	})
 
-	t.Run("hint mentions configured sync.git-remote when set", func(t *testing.T) {
+	t.Run("hint mentions configured sync.remote when set", func(t *testing.T) {
 		cfg := baseCfg
-		cfg.SyncGitRemote = "https://doltremoteapi.dolthub.com/myorg/beads"
+		cfg.SyncRemote = "https://doltremoteapi.dolthub.com/myorg/beads"
 		err := databaseNotFoundError(&cfg)
 
 		msg := err.Error()
 
 		// FR-002: Must mention it's configured and show the URL
-		if !strings.Contains(msg, "sync.git-remote is configured") {
+		if !strings.Contains(msg, "sync.remote is configured") {
 			t.Errorf("expected configured hint, got:\n%s", msg)
 		}
 		if !strings.Contains(msg, "https://doltremoteapi.dolthub.com/myorg/beads") {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -219,9 +219,9 @@ type Config struct {
 	RemoteUser     string // Hosted Dolt remote user (set via DOLT_REMOTE_USER env var)
 	RemotePassword string // Hosted Dolt remote password (set via DOLT_REMOTE_PASSWORD env var)
 
-	// SyncGitRemote holds the sync.git-remote config value (if any).
-	// Used to provide context-aware hints in "database not found" errors.
-	SyncGitRemote string
+	// SyncRemote holds the effective sync remote URL (from sync.remote
+	// or deprecated sync.git-remote). Used for context-aware error hints.
+	SyncRemote string
 
 	// CreateIfMissing allows CREATE DATABASE when the target database does not
 	// exist on the server. Only explicit initialization, migration, or new-board


### PR DESCRIPTION
## Summary

- **Add `sync.remote` config key** as the primary remote URL for bootstrap/clone, supporting any Dolt-compatible remote (DoltHub, S3, GCS, file, git). `sync.git-remote` remains as a deprecated fallback.
- **Persist `sync.remote` to config.yaml** when adding a Dolt remote via `bd dolt remote add origin <url>` or during `bd init` auto-detect. This ensures the remote URL survives `git clone` (since the Dolt database is gitignored).
- **Auto-commit config.yaml** after `bd dolt remote add/remove origin` so the change isn't left dirty in the working tree.
- **Fix bootstrap for non-git remotes** — previously, `bd bootstrap` on a fresh clone would fall through to "create fresh database" when the remote was DoltHub or another non-git remote, because the only detection paths were `sync.git-remote` config and git origin `refs/dolt/data` probing.
- **Fix double overwrite prompt** in embedded mode — `bd dolt remote add` no longer prompts separately for SQL and CLI when they share the same directory.
- **Rename internal APIs** — `BootstrapFromGitRemote*` → `BootstrapFromRemote*`, `Config.SyncGitRemote` → `Config.SyncRemote`. Old names kept as deprecated wrappers.
- **Add `normalizeRemoteURL()`** — detects Dolt-native schemes (dolthub://, file://, aws://, gs://) and passes them through unchanged; only converts git URLs (https://, ssh://, git@) to dolt format.

## Test plan

- [x] `TestNormalizeRemoteURL` — all Dolt-native and git URL schemes
- [x] `TestBootstrapFromRemoteWithDB` — empty/whitespace database rejection
- [x] `TestBootstrapFromRemote_UsesDefaultDatabase` — convenience wrapper
- [x] `TestBootstrapFromGitRemoteWithDB_DeprecatedWrapper` — backwards compat
- [x] `TestDatabaseNotFoundHint` — error messages reference `sync.remote`
- [x] `TestInitGuardServerMessage` — guard messages reference `sync.remote`
- [x] `TestFreshCloneServerResult` — doctor check messages updated
- [x] `TestEnrichFreshClone_WithSyncRemoteMentionsBootstrapAndFallback`
- [ ] Manual: `bd init` in repo with git origin that has `refs/dolt/data` → `sync.remote` persisted to config.yaml
- [ ] Manual: `bd dolt remote add origin dolthub://org/db` → `sync.remote` written and committed
- [ ] Manual: clone repo, `bd bootstrap` → detects `sync.remote` and clones from DoltHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)