### PR TITLE
Allow BEADS_DOLT_READY_TIMEOUT to override waitForReady timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`BEADS_DOLT_READY_TIMEOUT` env var** — `bd init --shared-server` now respects `BEADS_DOLT_READY_TIMEOUT` (positive integer seconds, default 10) so that slower hardware, where Dolt's first-run SQL engine bootstrap exceeds the 10-second budget, can opt into a longer `waitForReady` timeout. Default behavior is unchanged. ([GH#3142](https://github.com/gastownhall/beads/issues/3142))
+
 ## [1.0.0] - 2026-04-02
 
 ### 1.0 — Stable Release

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -135,6 +135,28 @@ func isFalsyBool(s string) bool {
 	return err == nil && !b
 }
 
+// readyTimeout returns the timeout used by waitForReady when starting the
+// dolt sql-server. Defaults to 10 seconds, but can be overridden via the
+// BEADS_DOLT_READY_TIMEOUT environment variable (positive integer seconds).
+// First-run Dolt SQL engine initialization can take ~60s on slower hardware
+// where the privileges.db, stats subrepo, and other bootstrap work must
+// happen before the MySQL listener accepts queries. See GH#3142.
+func readyTimeout() time.Duration {
+	const defaultTimeout = 10 * time.Second
+	v := strings.TrimSpace(os.Getenv("BEADS_DOLT_READY_TIMEOUT"))
+	if v == "" {
+		return defaultTimeout
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs < 1 {
+		fmt.Fprintf(os.Stderr,
+			"warning: BEADS_DOLT_READY_TIMEOUT=%q is not a positive integer; using default %s\n",
+			v, defaultTimeout)
+		return defaultTimeout
+	}
+	return time.Duration(secs) * time.Second
+}
+
 // SharedServerDir returns the directory for shared server state files.
 // Returns ~/.beads/shared-server/ (created on first use).
 // Override with BEADS_SHARED_SERVER_DIR env var for testing or custom layouts.
@@ -759,7 +781,7 @@ func Start(beadsDir string) (*State, error) {
 	}
 
 	// Wait for server to accept connections
-	if err := waitForReady(cfg.Host, actualPort, 10*time.Second); err != nil {
+	if err := waitForReady(cfg.Host, actualPort, readyTimeout()); err != nil {
 		if proc, findErr := os.FindProcess(pid); findErr == nil {
 			_ = proc.Kill()
 		}

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
@@ -1534,4 +1535,83 @@ func TestResolveServerMode_EmbeddedHonoredWithoutServerEnv(t *testing.T) {
 	if got != ServerModeEmbedded {
 		t.Errorf("ResolveServerMode with no server env = %v, want ServerModeEmbedded", got)
 	}
+}
+
+func TestReadyTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		want     time.Duration
+	}{
+		{"unset defaults to 10s", "", false, 10 * time.Second},
+		{"empty string defaults to 10s", "", true, 10 * time.Second},
+		{"valid integer seconds", "120", true, 120 * time.Second},
+		{"whitespace is trimmed", "  60  ", true, 60 * time.Second},
+		{"invalid string falls back", "notanumber", true, 10 * time.Second},
+		{"zero falls back", "0", true, 10 * time.Second},
+		{"negative falls back", "-5", true, 10 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv("BEADS_DOLT_READY_TIMEOUT", tt.envValue)
+			} else {
+				_ = os.Unsetenv("BEADS_DOLT_READY_TIMEOUT")
+			}
+			got := readyTimeout()
+			if got != tt.want {
+				t.Errorf("readyTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitForReady(t *testing.T) {
+	// Allocate an ephemeral port, then release it so we can re-bind later.
+	tmpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not allocate ephemeral port: %v", err)
+	}
+	addr := tmpListener.Addr().(*net.TCPAddr)
+	host := "127.0.0.1"
+	port := addr.Port
+	if err := tmpListener.Close(); err != nil {
+		t.Fatalf("could not release ephemeral port: %v", err)
+	}
+
+	// Spawn a goroutine that delays binding the port. This simulates a
+	// "slow server" -- the TCP listener is not yet bound when waitForReady
+	// is first called.
+	bindAfter := 200 * time.Millisecond
+	listenerReady := make(chan net.Listener, 1)
+	go func() {
+		time.Sleep(bindAfter)
+		ln, listenErr := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+		if listenErr != nil {
+			close(listenerReady)
+			return
+		}
+		listenerReady <- ln
+	}()
+	t.Cleanup(func() {
+		ln, ok := <-listenerReady
+		if ok && ln != nil {
+			_ = ln.Close()
+		}
+	})
+
+	t.Run("times out when server not ready in time", func(t *testing.T) {
+		// 50ms is well under the 200ms bind delay, so this MUST time out.
+		if err := waitForReady(host, port, 50*time.Millisecond); err == nil {
+			t.Errorf("expected timeout error, got nil")
+		}
+	})
+
+	t.Run("succeeds when server becomes ready in time", func(t *testing.T) {
+		// 2 seconds is well over the remaining bind delay; gives comfortable margin.
+		if err := waitForReady(host, port, 2*time.Second); err != nil {
+			t.Errorf("expected nil error, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Fixes #3142. Adds `BEADS_DOLT_READY_TIMEOUT` environment variable to override the hardcoded 10-second `waitForReady` budget at the dolt sql-server start path.

On slower hardware (Windows 11 with Dolt 1.85.0 here), first-run Dolt SQL engine initialization — `root@localhost` superuser creation, `privileges.db`, stats subrepo — takes ~42 seconds before the MySQL listener is query-ready. The current 10-second budget causes `bd init --shared-server` to kill the dolt child mid-bootstrap, leaving "Creating root@localhost superuser" as the last log line and reporting "server started but not accepting connections."

## What this PR does

This is **option 1** from #3142 (env var override), per @maphew's accept on the issue. It does NOT touch options 2 (longer first-run default) or 3 (progressive log polling) — those remain open for the maintainers to design.

- New unexported helper `readyTimeout()` in `internal/doltserver/doltserver.go`. Reads `BEADS_DOLT_READY_TIMEOUT` (positive integer seconds), validates, returns the parsed value or falls back to the 10-second default with a stderr warning on invalid input.
- One call-site change in `Start()`: `waitForReady(..., readyTimeout())` instead of the literal `10*time.Second`.
- `TestReadyTimeout` unit test covering unset, empty, whitespace, valid, non-numeric, zero, and negative cases.
- `TestWaitForReady` direct regression test using a delayed-bind fake listener. This closes a pre-existing coverage gap — there was no direct test of `waitForReady` in the suite, only transitive coverage through the lifecycle integration tests. It's included here not as cleanup but because it closes our verification chain: `readyTimeout()` parses → call site threads it through → `waitForReady` honors it.
- `CHANGELOG.md` entry under `[Unreleased] / Fixed`.

**Default behavior is unchanged.** Users who don't set `BEADS_DOLT_READY_TIMEOUT` get exactly the same 10-second budget as before. The fix is opt-in.

## Verification

Three layers of evidence:

1. **Unit + synthetic tests** — `TestReadyTimeout` proves env var parsing and fallback behavior; `TestWaitForReady` proves `waitForReady` respects the timeout parameter we're now threading through it. Together they give a complete chain of evidence a reader can trace in the diff.

2. **`go test -short ./...` zero regressions** — full short test suite passes with exactly the same four pre-existing Windows-portability failures in `internal/storage/dolt` and `internal/utils` as the baseline before my change. Our diff introduces zero new failures. `golangci-lint run --new-from-rev=HEAD` reports `0 issues.`.

3. **Manual verification on the affected hardware** — Windows 11, Dolt 1.85.0, the same machine that originally reproduced #3142:
   - **Baseline reproduction** (upstream `main`, env var unset, clean scratch directory): fails at 10s with the documented signature — `dolt-server.log` has exactly "Creating root@localhost superuser" and nothing after. Confirms the from-source build reproduces the bug.
   - **Default preserved** (fix branch, env var unset): still fails at 10s. Proves users who don't set the knob see no change.
   - **Fix applied** (fix branch, `BEADS_DOLT_READY_TIMEOUT=120`): succeeds. `dolt-server.log` now shows `"Server ready. Accepting connections."` 42 seconds after "Creating root@localhost superuser"; bd connects and continues the init flow.

## Out of scope

- **Option 2** (longer first-run default): would require adding cold/warm path detection. Bigger change, deserves its own design discussion.
- **Option 3** (progressive log polling): @maphew noted on the issue "still thinking about" this. A separate PR is the right path once a design is settled.
- **Config-file twin** (`dolt.ready-timeout` in TOML): other `BEADS_DOLT_*` env vars do have config-file twins, but the issue acceptance was specifically for "env var override." Happy to add this in a follow-up if requested.
- **Go duration string parsing** (`2m`, `120s`): the issue body committed to integer seconds.
- **Root cause of the Windows slowness** (@maphew's curiosity in the issue thread): being discussed separately in the issue comments — working hypothesis is antivirus real-time file scanning during Dolt's first-run bootstrap. See the gist I linked in the issue thread for the Malwarebytes-on-my-machine data; @maphew's Windows Defender setup is likely hitting the same pattern.

## Author note

This is my first PR to beads, so apologies in advance for any local convention I missed. Happy to revise commit message format, branch name, code style, or anything else to match the project's standards.
