### PR TITLE
fix: replace blanket .claude/ gitignore with specific ignores (GH#3182)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,11 @@ pkg/
 
 # Agent local state (skills, settings, etc.)
 .amp/
-.claude/
+
+# Claude Code - local/runtime state
+.claude/settings.local.json
+.claude/worktrees/
+.claude/*.log
 
 
 # OS


### PR DESCRIPTION
## Summary

Thanks to @seanmartinsmith for diagnosing and clearly describing this issue in #3182!

- Replaces the blanket `.claude/` gitignore entry with specific ignores for local/runtime files only (`settings.local.json`, `worktrees/`, `*.log`)
- Project-level `.claude/` files (hooks, commands, skills, `settings.json`) are now visible to git, so contributors can see and track project conventions

## Why

The blanket `.claude/` ignore was hiding project-level configuration files that should be shared across the team. Contributors couldn't tell what was local runtime state vs intentional project conventions.

Closes #3182

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Sean Martin Smith <seanmartinsmith@users.noreply.github.com>