### PR TITLE
fix(dolt): exit 0 when push/pull finds no remote configured

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -160,6 +160,25 @@ func isDivergedHistoryErr(err error) bool {
 		strings.Contains(msg, "cannot find common ancestor")
 }
 
+// printNoRemoteGuidance prints an informational message (to stdout) when
+// push or pull is attempted but no Dolt remote is configured. Exits 0 because
+// the absence of a remote is a valid configuration — not an error.
+func printNoRemoteGuidance() {
+	fmt.Println("No remote is configured — skipping.")
+	fmt.Println("")
+	fmt.Println("For solo use, pushing is optional — your issues are stored locally")
+	fmt.Println("in .beads/ and versioned by Dolt automatically.")
+	fmt.Println("")
+	fmt.Println("To set up remote sync (for backup or team sharing):")
+	fmt.Println("  bd dolt remote add origin <url>")
+	fmt.Println("  bd dolt push")
+	fmt.Println("")
+	fmt.Println("Supported remote URLs:")
+	fmt.Println("  • GitHub (via git):   git+ssh://git@github.com/org/repo.git")
+	fmt.Println("  • DoltHub:            https://doltremoteapi.dolthub.com/org/repo")
+	fmt.Println("  • Azure Blob Storage: az://account.blob.core.windows.net/container/path")
+}
+
 // printDivergedHistoryGuidance prints recovery guidance when push/pull fails
 // due to diverged local and remote histories.
 func printDivergedHistoryGuidance(operation string) {
@@ -205,52 +224,27 @@ uncommitted changes in its working set).`,
 		}
 		force, _ := cmd.Flags().GetBool("force")
 		fmt.Println("Pushing to Dolt remote...")
+
+		var pushErr error
 		if force {
-			if err := st.ForcePush(ctx); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				if isRemoteNotFoundErr(err) {
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "No remote is configured for this database.")
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "For solo use, pushing is optional — your issues are stored locally")
-					fmt.Fprintln(os.Stderr, "in .beads/ and versioned by Dolt automatically.")
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "To set up remote sync (for backup or team sharing):")
-					fmt.Fprintln(os.Stderr, "  bd dolt remote add origin <url>")
-					fmt.Fprintln(os.Stderr, "  bd dolt push")
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "Supported remote URLs:")
-					fmt.Fprintln(os.Stderr, "  • GitHub (via git):   git+ssh://git@github.com/org/repo.git")
-					fmt.Fprintln(os.Stderr, "  • DoltHub:            https://doltremoteapi.dolthub.com/org/repo")
-					fmt.Fprintln(os.Stderr, "  • Azure Blob Storage: az://account.blob.core.windows.net/container/path")
-				} else if isDivergedHistoryErr(err) {
-					printDivergedHistoryGuidance("push --force")
-				}
-				os.Exit(1)
-			}
+			pushErr = st.ForcePush(ctx)
 		} else {
-			if err := st.Push(ctx); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				if isRemoteNotFoundErr(err) {
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "No remote is configured for this database.")
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "For solo use, pushing is optional — your issues are stored locally")
-					fmt.Fprintln(os.Stderr, "in .beads/ and versioned by Dolt automatically.")
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "To set up remote sync (for backup or team sharing):")
-					fmt.Fprintln(os.Stderr, "  bd dolt remote add origin <url>")
-					fmt.Fprintln(os.Stderr, "  bd dolt push")
-					fmt.Fprintln(os.Stderr, "")
-					fmt.Fprintln(os.Stderr, "Supported remote URLs:")
-					fmt.Fprintln(os.Stderr, "  • GitHub (via git):   git+ssh://git@github.com/org/repo.git")
-					fmt.Fprintln(os.Stderr, "  • DoltHub:            https://doltremoteapi.dolthub.com/org/repo")
-					fmt.Fprintln(os.Stderr, "  • Azure Blob Storage: az://account.blob.core.windows.net/container/path")
-				} else if isDivergedHistoryErr(err) {
-					printDivergedHistoryGuidance("push")
-				}
-				os.Exit(1)
+			pushErr = st.Push(ctx)
+		}
+		if pushErr != nil {
+			if isRemoteNotFoundErr(pushErr) {
+				printNoRemoteGuidance()
+				return
 			}
+			fmt.Fprintf(os.Stderr, "Error: %v\n", pushErr)
+			if isDivergedHistoryErr(pushErr) {
+				op := "push"
+				if force {
+					op = "push --force"
+				}
+				printDivergedHistoryGuidance(op)
+			}
+			os.Exit(1)
 		}
 		fmt.Println("Push complete.")
 	},
@@ -273,12 +267,12 @@ variables for authentication.`,
 		}
 		fmt.Println("Pulling from Dolt remote...")
 		if err := st.Pull(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			if isRemoteNotFoundErr(err) {
-				fmt.Fprintf(os.Stderr, "Hint: use 'bd dolt remote add <name> <url>' (not 'dolt remote add').\n")
-				fmt.Fprintf(os.Stderr, "  Running 'dolt remote add' directly may add the remote to the wrong directory.\n")
-				fmt.Fprintf(os.Stderr, "  Use 'bd dolt remote list' to check for discrepancies.\n")
-			} else if isDivergedHistoryErr(err) {
+				printNoRemoteGuidance()
+				return
+			}
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			if isDivergedHistoryErr(err) {
 				printDivergedHistoryGuidance("pull")
 			}
 			os.Exit(1)

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1038,6 +1038,32 @@ func TestIsRemoteNotFoundErr(t *testing.T) {
 	}
 }
 
+func TestPrintNoRemoteGuidance(t *testing.T) {
+	// Capture stdout output
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printNoRemoteGuidance()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, "No remote is configured") {
+		t.Error("expected guidance to mention 'No remote is configured'")
+	}
+	if !strings.Contains(output, "skipping") {
+		t.Error("expected guidance to indicate the operation was skipped, not failed")
+	}
+	if !strings.Contains(output, "bd dolt remote add") {
+		t.Error("expected guidance to mention how to add a remote")
+	}
+}
+
 func TestPrintDivergedHistoryGuidance(t *testing.T) {
 	// Capture stderr output
 	oldStderr := os.Stderr


### PR DESCRIPTION
## Summary

Fixes #3031. `bd dolt push` and `bd dolt pull` exit 1 when no Dolt remote is configured, causing agent session-close protocols to error out. This changes both commands to exit 0 with an informational message when the error is specifically "remote not found", since the absence of a remote is a valid configuration — not a failure.

### Changes Made

- **Added `printNoRemoteGuidance()` helper** in `cmd/bd/dolt.go` — prints the existing "no remote" guidance to stdout (not stderr) and returns without error. Replaces the duplicated guidance blocks in push and pull.
- **Changed `bd dolt push` exit behavior** — when `isRemoteNotFoundErr()` is true, calls `printNoRemoteGuidance()` and returns (exit 0) instead of `os.Exit(1)`. Other errors (diverged history, connection failures) still exit 1.
- **Changed `bd dolt pull` exit behavior** — same treatment: graceful exit 0 on remote-not-found, error exit on everything else.
- **Deduplicated push error handling** — the force-push and regular-push branches had identical 15-line "no remote" blocks; now both go through a single error-handling path.
- **Added `TestPrintNoRemoteGuidance`** — verifies the guidance mentions "No remote is configured", "skipping", and how to add a remote.

### Backward Compatibility

✅ **No behavioral change for configured remotes**: push/pull with a valid remote work exactly as before
✅ **No behavioral change for other errors**: diverged history, connection failures, auth errors still exit 1
✅ **Agents benefit immediately**: session close protocols that call `bd dolt push` will no longer fail on fresh workspaces

### Technical Details

The key behavioral changes:

| Scenario | Before | After |
|---|---|---|
| `bd dolt push` (no remote) | stderr + exit 1 | stdout + exit 0 |
| `bd dolt pull` (no remote) | stderr + exit 1 | stdout + exit 0 |
| `bd dolt push` (diverged) | stderr + exit 1 | stderr + exit 1 (unchanged) |
| `bd dolt push` (auth fail) | stderr + exit 1 | stderr + exit 1 (unchanged) |

The guidance text is written to stdout (not stderr) because it's informational, not an error condition.

### Size: Small ✓

Two-file change with a net reduction in code (deduplication removes ~20 lines of copy-pasted guidance).

🤖 Generated with [Claude Code](https://claude.ai/code)