### PR TITLE
Add Linear round-trip fidelity integration test (#3187)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,10 @@ We will respond within 48 hours and work with you to address the issue.
 
 ## Security Considerations
 
+### Federation Security
+
+For multi-remote federation deployments, see [docs/FEDERATION-SECURITY.md](docs/FEDERATION-SECURITY.md) — covers credential isolation, pull trust ordering, partial push failure states, and log sanitization.
+
 ### Database Security
 
 bd stores issue data locally in a Dolt database (`.beads/dolt/`), which is gitignored.

--- a/cmd/bd/config_apply.go
+++ b/cmd/bd/config_apply.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
@@ -85,7 +86,7 @@ func runApply(dryRun bool) []ApplyResult {
 
 	var results []ApplyResult
 	results = append(results, applyHooks(hasDrift["hooks"], dryRun))
-	results = append(results, applyRemote(hasDrift["remote"], dryRun))
+	results = append(results, applyRemotes(hasDrift, dryRun)...)
 	results = append(results, applyServer(hasDrift["server"], dryRun))
 	return results
 }
@@ -138,8 +139,31 @@ func applyHooks(drifted bool, dryRun bool) ApplyResult {
 	}
 }
 
-// applyRemote ensures the Dolt origin remote matches federation.remote config.
-func applyRemote(drifted bool, dryRun bool) ApplyResult {
+// applyRemotes ensures Dolt remotes match federation config.
+// Handles both legacy single-remote and multi-remote configurations.
+func applyRemotes(hasDrift map[string]bool, dryRun bool) []ApplyResult {
+	// Check if multi-remote is configured
+	fedCfg, parseErr := config.ParseFederationConfig()
+	if parseErr != nil {
+		return []ApplyResult{{
+			Check:   "remote",
+			Action:  "configure",
+			Status:  applyStatusError,
+			Message: "federation config parse error",
+			Error:   parseErr.Error(),
+		}}
+	}
+
+	if len(fedCfg.Remotes) > 1 {
+		return applyMultiRemotes(fedCfg, hasDrift, dryRun)
+	}
+
+	// Legacy single-remote path
+	return []ApplyResult{applyLegacyRemote(hasDrift["remote"], dryRun)}
+}
+
+// applyLegacyRemote is the original single-remote apply logic.
+func applyLegacyRemote(drifted bool, dryRun bool) ApplyResult {
 	if !drifted {
 		return ApplyResult{
 			Check:   "remote",
@@ -239,6 +263,119 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 		Status:  applyStatusApplied,
 		Message: fmt.Sprintf("Updated Dolt origin remote from %s to %s", oldURL, federationRemote),
 	}
+}
+
+// applyMultiRemotes reconciles all configured federation.remotes with Dolt.
+func applyMultiRemotes(fedCfg config.FederationConfig, hasDrift map[string]bool, dryRun bool) []ApplyResult {
+	// Check if any remote has drift
+	anyDrift := false
+	for key, drifted := range hasDrift {
+		if drifted && strings.HasPrefix(key, "remote.") {
+			anyDrift = true
+			break
+		}
+	}
+
+	if !anyDrift {
+		return []ApplyResult{{
+			Check:   "remote",
+			Action:  "none",
+			Status:  applyStatusOK,
+			Message: "All federation remotes are consistent",
+		}}
+	}
+
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return []ApplyResult{{
+			Check:   "remote",
+			Action:  "configure",
+			Status:  applyStatusSkipped,
+			Message: "No active beads workspace found",
+		}}
+	}
+
+	doltDir := doltserver.ResolveDoltDir(beadsDir)
+
+	var results []ApplyResult
+	for _, cfgRemote := range fedCfg.Remotes {
+		checkName := "remote." + cfgRemote.Name
+		if !hasDrift[checkName] {
+			continue
+		}
+
+		currentURL := doltutil.FindCLIRemote(doltDir, cfgRemote.Name)
+
+		if dryRun {
+			if currentURL == "" {
+				results = append(results, ApplyResult{
+					Check:   checkName,
+					Action:  "add_remote",
+					Status:  applyStatusDryRun,
+					Message: fmt.Sprintf("Would add Dolt remote %q: %s", cfgRemote.Name, cfgRemote.URL),
+				})
+			} else {
+				results = append(results, ApplyResult{
+					Check:   checkName,
+					Action:  "update_remote",
+					Status:  applyStatusDryRun,
+					Message: fmt.Sprintf("Would update Dolt remote %q from %s to %s", cfgRemote.Name, currentURL, cfgRemote.URL),
+				})
+			}
+			continue
+		}
+
+		if currentURL == "" {
+			if err := doltutil.AddCLIRemote(doltDir, cfgRemote.Name, cfgRemote.URL); err != nil {
+				results = append(results, ApplyResult{
+					Check:   checkName,
+					Action:  "add_remote",
+					Status:  applyStatusError,
+					Message: fmt.Sprintf("Failed to add remote %q", cfgRemote.Name),
+					Error:   err.Error(),
+				})
+			} else {
+				results = append(results, ApplyResult{
+					Check:   checkName,
+					Action:  "add_remote",
+					Status:  applyStatusApplied,
+					Message: fmt.Sprintf("Added Dolt remote %q: %s", cfgRemote.Name, cfgRemote.URL),
+				})
+			}
+		} else {
+			// URL mismatch — remove and re-add
+			oldURL := currentURL
+			if err := doltutil.RemoveCLIRemote(doltDir, cfgRemote.Name); err != nil {
+				results = append(results, ApplyResult{
+					Check:   checkName,
+					Action:  "update_remote",
+					Status:  applyStatusError,
+					Message: fmt.Sprintf("Failed to remove old remote %q", cfgRemote.Name),
+					Error:   err.Error(),
+				})
+				continue
+			}
+			if err := doltutil.AddCLIRemote(doltDir, cfgRemote.Name, cfgRemote.URL); err != nil {
+				_ = doltutil.AddCLIRemote(doltDir, cfgRemote.Name, oldURL) // rollback
+				results = append(results, ApplyResult{
+					Check:   checkName,
+					Action:  "update_remote",
+					Status:  applyStatusError,
+					Message: fmt.Sprintf("Failed to update remote %q (old URL restored)", cfgRemote.Name),
+					Error:   err.Error(),
+				})
+			} else {
+				results = append(results, ApplyResult{
+					Check:   checkName,
+					Action:  "update_remote",
+					Status:  applyStatusApplied,
+					Message: fmt.Sprintf("Updated Dolt remote %q from %s to %s", cfgRemote.Name, oldURL, cfgRemote.URL),
+				})
+			}
+		}
+	}
+
+	return results
 }
 
 // applyServer starts the Dolt server if config says it should be running but it isn't.

--- a/cmd/bd/config_apply_test.go
+++ b/cmd/bd/config_apply_test.go
@@ -26,7 +26,7 @@ func TestApplyHooksDryRun(t *testing.T) {
 }
 
 func TestApplyRemoteNoDrift(t *testing.T) {
-	result := applyRemote(false, false)
+	result := applyLegacyRemote(false, false)
 	if result.Status != applyStatusOK {
 		t.Errorf("expected status %q, got %q", applyStatusOK, result.Status)
 	}
@@ -37,7 +37,7 @@ func TestApplyRemoteNoDrift(t *testing.T) {
 
 func TestApplyRemoteDryRun(t *testing.T) {
 	// When drifted but no beads dir, should skip
-	result := applyRemote(true, true)
+	result := applyLegacyRemote(true, true)
 	if result.Status != applyStatusSkipped && result.Status != applyStatusDryRun {
 		t.Errorf("expected status %q or %q, got %q", applyStatusSkipped, applyStatusDryRun, result.Status)
 	}

--- a/cmd/bd/config_drift.go
+++ b/cmd/bd/config_drift.go
@@ -139,8 +139,30 @@ func checkHooksDrift() []DriftItem {
 	return items
 }
 
-// checkRemoteDrift compares federation.remote config against actual Dolt remotes.
+// checkRemoteDrift compares federation remote config against actual Dolt remotes.
+// Supports both legacy (federation.remote) and multi-remote (federation.remotes) configs.
 func checkRemoteDrift() []DriftItem {
+	// Parse the federation config to determine which mode we're in
+	fedCfg, parseErr := config.ParseFederationConfig()
+	if parseErr != nil {
+		return []DriftItem{{
+			Check:   "remote",
+			Status:  driftStatusDrift,
+			Message: fmt.Sprintf("federation config parse error: %v", parseErr),
+		}}
+	}
+
+	// If multi-remote is configured, use multi-remote drift detection
+	if len(fedCfg.Remotes) > 1 {
+		return checkMultiRemoteDrift(fedCfg)
+	}
+
+	// Otherwise use legacy single-remote drift detection
+	return checkLegacyRemoteDrift()
+}
+
+// checkLegacyRemoteDrift is the original single-remote drift check.
+func checkLegacyRemoteDrift() []DriftItem {
 	federationRemote := config.GetString("federation.remote")
 
 	// Find the dolt data directory for CLI remote listing
@@ -223,6 +245,90 @@ func checkRemoteDrift() []DriftItem {
 		Status:  driftStatusInfo,
 		Message: "No federation.remote configured and no Dolt remotes found",
 	}}
+}
+
+// checkMultiRemoteDrift checks each configured remote against actual Dolt remotes.
+func checkMultiRemoteDrift(fedCfg config.FederationConfig) []DriftItem {
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return []DriftItem{{
+			Check:   "remote",
+			Status:  driftStatusSkipped,
+			Message: "No active beads workspace found",
+		}}
+	}
+
+	doltDir := doltserver.ResolveDoltDir(beadsDir)
+
+	cliRemotes, err := doltutil.ListCLIRemotes(doltDir)
+	if err != nil {
+		return []DriftItem{{
+			Check:   "remote",
+			Status:  driftStatusSkipped,
+			Message: fmt.Sprintf("Cannot list remotes: %v", err),
+		}}
+	}
+
+	// Build lookup map of actual Dolt remotes
+	actualRemotes := make(map[string]string, len(cliRemotes))
+	for _, r := range cliRemotes {
+		actualRemotes[r.Name] = r.URL
+	}
+
+	var items []DriftItem
+
+	// Check each configured remote
+	for _, cfgRemote := range fedCfg.Remotes {
+		checkName := "remote." + cfgRemote.Name
+		actualURL, exists := actualRemotes[cfgRemote.Name]
+
+		if !exists {
+			items = append(items, DriftItem{
+				Check:    checkName,
+				Status:   driftStatusDrift,
+				Message:  fmt.Sprintf("Configured remote %q (%s) does not exist in Dolt", cfgRemote.Name, cfgRemote.Role),
+				Expected: cfgRemote.URL,
+				Actual:   "(not found)",
+			})
+		} else if actualURL != cfgRemote.URL {
+			items = append(items, DriftItem{
+				Check:    checkName,
+				Status:   driftStatusDrift,
+				Message:  fmt.Sprintf("Remote %q URL mismatch", cfgRemote.Name),
+				Expected: cfgRemote.URL,
+				Actual:   actualURL,
+			})
+		} else {
+			items = append(items, DriftItem{
+				Check:   checkName,
+				Status:  driftStatusOK,
+				Message: fmt.Sprintf("Remote %q (%s) matches config", cfgRemote.Name, cfgRemote.Role),
+			})
+		}
+	}
+
+	// Detect unmanaged remotes (exist in Dolt but not in config)
+	configuredNames := make(map[string]bool, len(fedCfg.Remotes))
+	for _, r := range fedCfg.Remotes {
+		configuredNames[r.Name] = true
+	}
+
+	var unmanaged []string
+	for _, r := range cliRemotes {
+		if !configuredNames[r.Name] {
+			unmanaged = append(unmanaged, r.Name)
+		}
+	}
+
+	if len(unmanaged) > 0 {
+		items = append(items, DriftItem{
+			Check:   "remote.unmanaged",
+			Status:  driftStatusInfo,
+			Message: fmt.Sprintf("Unmanaged Dolt remotes not in federation.remotes config: %s", strings.Join(unmanaged, ", ")),
+		})
+	}
+
+	return items
 }
 
 // checkServerDrift compares dolt.shared-server config against running server state.

--- a/cmd/bd/linear_roundtrip_test.go
+++ b/cmd/bd/linear_roundtrip_test.go
@@ -1,0 +1,548 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/linear"
+	"github.com/steveyegge/beads/internal/tracker"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// mockLinearServer is a stateful mock that only stores what the Linear client
+// actually sends — no fabricated fields. This keeps the round-trip test honest.
+type mockLinearServer struct {
+	mu       sync.Mutex
+	issues   map[string]*linear.Issue // keyed by Linear UUID
+	nextSeq  int
+	teamID   string
+	teamKey  string // e.g. "MOCK"
+	states   []linear.State
+	stateMap map[string]linear.State // state type → State
+}
+
+func newMockLinearServer(teamID, teamKey string) *mockLinearServer {
+	states := []linear.State{
+		{ID: "state-backlog", Name: "Backlog", Type: "backlog"},
+		{ID: "state-unstarted", Name: "Todo", Type: "unstarted"},
+		{ID: "state-started", Name: "In Progress", Type: "started"},
+		{ID: "state-completed", Name: "Done", Type: "completed"},
+		{ID: "state-canceled", Name: "Canceled", Type: "canceled"},
+	}
+	stateMap := make(map[string]linear.State, len(states))
+	for _, s := range states {
+		stateMap[s.Type] = s
+	}
+	return &mockLinearServer{
+		issues:   make(map[string]*linear.Issue),
+		teamID:   teamID,
+		teamKey:  teamKey,
+		states:   states,
+		stateMap: stateMap,
+	}
+}
+
+func (m *mockLinearServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req linear.GraphQLRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	var data interface{}
+	var err error
+
+	switch {
+	case strings.Contains(req.Query, "issueCreate"):
+		data, err = m.handleCreate(req)
+	case strings.Contains(req.Query, "issueUpdate"):
+		data, err = m.handleUpdate(req)
+	case strings.Contains(req.Query, "TeamStates") || strings.Contains(req.Query, "team(id:") || (strings.Contains(req.Query, "team(") && strings.Contains(req.Query, "states")):
+		data = m.handleTeamStates()
+	case strings.Contains(req.Query, "issues"):
+		data, err = m.handleFetchIssues(req)
+	default:
+		http.Error(w, fmt.Sprintf("unhandled query: %s", req.Query[:min(80, len(req.Query))]), http.StatusBadRequest)
+		return
+	}
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	respBytes, _ := json.Marshal(data)
+	resp := map[string]json.RawMessage{"data": respBytes}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (m *mockLinearServer) handleCreate(req linear.GraphQLRequest) (interface{}, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vars := req.Variables
+	inputRaw, ok := vars["input"]
+	if !ok {
+		return nil, fmt.Errorf("missing input")
+	}
+	input, ok := inputRaw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("input is not a map")
+	}
+
+	m.nextSeq++
+	id := fmt.Sprintf("uuid-%d", m.nextSeq)
+	identifier := fmt.Sprintf("%s-%d", m.teamKey, m.nextSeq)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	issue := &linear.Issue{
+		ID:          id,
+		Identifier:  identifier,
+		Title:       strVal(input, "title"),
+		Description: strVal(input, "description"),
+		URL:         fmt.Sprintf("https://linear.app/mock/issue/%s", identifier),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if p, ok := input["priority"]; ok {
+		if pf, ok := p.(float64); ok {
+			issue.Priority = int(pf)
+		}
+	}
+
+	if stateID := strVal(input, "stateId"); stateID != "" {
+		for _, s := range m.states {
+			if s.ID == stateID {
+				issue.State = &linear.State{ID: s.ID, Name: s.Name, Type: s.Type}
+				break
+			}
+		}
+	}
+
+	m.issues[id] = issue
+
+	return map[string]interface{}{
+		"issueCreate": map[string]interface{}{
+			"success": true,
+			"issue":   issue,
+		},
+	}, nil
+}
+
+func (m *mockLinearServer) handleUpdate(req linear.GraphQLRequest) (interface{}, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vars := req.Variables
+	id := ""
+	if v, ok := vars["id"]; ok {
+		id, _ = v.(string)
+	}
+
+	issue, exists := m.issues[id]
+	if !exists {
+		return nil, fmt.Errorf("issue %s not found", id)
+	}
+
+	inputRaw, ok := vars["input"]
+	if !ok {
+		return nil, fmt.Errorf("missing input")
+	}
+	input, ok := inputRaw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("input is not a map")
+	}
+
+	if v := strVal(input, "title"); v != "" {
+		issue.Title = v
+	}
+	if v := strVal(input, "description"); v != "" {
+		issue.Description = v
+	}
+	if p, ok := input["priority"]; ok {
+		if pf, ok := p.(float64); ok {
+			issue.Priority = int(pf)
+		}
+	}
+	if stateID := strVal(input, "stateId"); stateID != "" {
+		for _, s := range m.states {
+			if s.ID == stateID {
+				issue.State = &linear.State{ID: s.ID, Name: s.Name, Type: s.Type}
+				break
+			}
+		}
+	}
+	issue.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	return map[string]interface{}{
+		"issueUpdate": map[string]interface{}{
+			"success": true,
+			"issue":   issue,
+		},
+	}, nil
+}
+
+func (m *mockLinearServer) handleTeamStates() interface{} {
+	return map[string]interface{}{
+		"team": map[string]interface{}{
+			"id": m.teamID,
+			"states": map[string]interface{}{
+				"nodes": m.states,
+			},
+		},
+	}
+}
+
+func (m *mockLinearServer) handleFetchIssues(req linear.GraphQLRequest) (interface{}, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check for identifier filter (FetchIssueByIdentifier)
+	vars := req.Variables
+	if filterRaw, ok := vars["filter"]; ok {
+		if filter, ok := filterRaw.(map[string]interface{}); ok {
+			if idFilter, ok := filter["identifier"]; ok {
+				if idMap, ok := idFilter.(map[string]interface{}); ok {
+					if eqVal, ok := idMap["eq"]; ok {
+						identifier, _ := eqVal.(string)
+						for _, issue := range m.issues {
+							if issue.Identifier == identifier {
+								return map[string]interface{}{
+									"issues": map[string]interface{}{
+										"nodes":    []interface{}{issue},
+										"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+									},
+								}, nil
+							}
+						}
+						return map[string]interface{}{
+							"issues": map[string]interface{}{
+								"nodes":    []interface{}{},
+								"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+							},
+						}, nil
+					}
+				}
+			}
+		}
+	}
+
+	// Return all issues
+	nodes := make([]*linear.Issue, 0, len(m.issues))
+	for _, issue := range m.issues {
+		nodes = append(nodes, issue)
+	}
+
+	return map[string]interface{}{
+		"issues": map[string]interface{}{
+			"nodes":    nodes,
+			"pageInfo": map[string]interface{}{"hasNextPage": false, "endCursor": ""},
+		},
+	}, nil
+}
+
+func (m *mockLinearServer) issueCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.issues)
+}
+
+func strVal(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// TestLinearRoundTripCoreFields tests push→pull fidelity for fields that the
+// Linear integration currently supports: title, description, priority, status,
+// and external_ref. See upstream #3187.
+func TestLinearRoundTripCoreFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	teamID := "test-team-uuid"
+
+	// --- 1. Setup source DB ---
+	sourceStore, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Configure Linear settings in source store
+	for k, v := range map[string]string{
+		"linear.api_key": "test-api-key",
+		"linear.team_id": teamID,
+		"issue_prefix":   "bd",
+	} {
+		if err := sourceStore.SetConfig(ctx, k, v); err != nil {
+			t.Fatalf("SetConfig(%s): %v", k, err)
+		}
+	}
+
+	// Start mock server
+	mock := newMockLinearServer(teamID, "MOCK")
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	if err := sourceStore.SetConfig(ctx, "linear.api_endpoint", server.URL); err != nil {
+		t.Fatalf("SetConfig(endpoint): %v", err)
+	}
+
+	// --- 2. Seed source DB with varied issues ---
+	type seedIssue struct {
+		title       string
+		description string
+		priority    int
+		status      types.Status
+	}
+	seeds := []seedIssue{
+		{"Critical security fix", "Fix the auth bypass vulnerability", 0, types.StatusOpen},
+		{"Add search feature", "Implement full-text search for issues", 1, types.StatusInProgress},
+		{"Update dependencies", "Routine dep update for Q2", 3, types.StatusClosed},
+	}
+
+	sourceIssueIDs := make([]string, 0, len(seeds))
+	for i, s := range seeds {
+		issue := &types.Issue{
+			ID:          fmt.Sprintf("bd-rt-%d", i),
+			Title:       s.title,
+			Description: s.description,
+			Priority:    s.priority,
+			Status:      s.status,
+			IssueType:   types.TypeTask,
+		}
+		if s.status == types.StatusClosed {
+			now := time.Now()
+			issue.ClosedAt = &now
+		}
+		if err := sourceStore.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
+		}
+		sourceIssueIDs = append(sourceIssueIDs, issue.ID)
+	}
+
+	// --- 3. Push to mock Linear ---
+	lt := &linear.Tracker{}
+	lt.SetTeamIDs([]string{teamID})
+	if err := lt.Init(ctx, sourceStore); err != nil {
+		t.Fatalf("Tracker.Init: %v", err)
+	}
+
+	pushEngine := tracker.NewEngine(lt, sourceStore, "test-actor")
+	pushEngine.PushHooks = buildLinearPushHooksForTest(ctx, lt)
+
+	pushResult, err := pushEngine.Sync(ctx, tracker.SyncOptions{Push: true})
+	if err != nil {
+		t.Fatalf("Push sync failed: %v", err)
+	}
+	if pushResult.Stats.Created != len(seeds) {
+		t.Fatalf("expected %d pushed, got created=%d", len(seeds), pushResult.Stats.Created)
+	}
+
+	// Verify external refs were written
+	for _, id := range sourceIssueIDs {
+		issue, err := sourceStore.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s) after push: %v", id, err)
+		}
+		if issue.ExternalRef == nil || *issue.ExternalRef == "" {
+			t.Errorf("issue %s: expected external_ref after push, got nil", id)
+		}
+	}
+
+	// Verify mock server received all issues
+	if got := mock.issueCount(); got != len(seeds) {
+		t.Fatalf("mock server has %d issues, want %d", got, len(seeds))
+	}
+
+	// --- 4. Setup target DB (fresh) ---
+	targetStore, cleanup2 := setupTestDB(t)
+	defer cleanup2()
+
+	for k, v := range map[string]string{
+		"linear.api_key":      "test-api-key",
+		"linear.team_id":      teamID,
+		"linear.api_endpoint": server.URL,
+		"issue_prefix":        "bd",
+	} {
+		if err := targetStore.SetConfig(ctx, k, v); err != nil {
+			t.Fatalf("SetConfig(%s) target: %v", k, err)
+		}
+	}
+
+	// --- 5. Pull from mock Linear into fresh DB ---
+	lt2 := &linear.Tracker{}
+	lt2.SetTeamIDs([]string{teamID})
+	if err := lt2.Init(ctx, targetStore); err != nil {
+		t.Fatalf("Tracker.Init (target): %v", err)
+	}
+
+	pullEngine := tracker.NewEngine(lt2, targetStore, "test-actor")
+	pullEngine.PullHooks = buildLinearPullHooksForTest(ctx, targetStore)
+
+	pullResult, err := pullEngine.Sync(ctx, tracker.SyncOptions{Pull: true})
+	if err != nil {
+		t.Fatalf("Pull sync failed: %v", err)
+	}
+	if pullResult.Stats.Created != len(seeds) {
+		t.Fatalf("expected %d pulled/created, got created=%d", len(seeds), pullResult.Stats.Created)
+	}
+
+	// --- 6. Assert fidelity ---
+	// Build a map of pulled issues keyed by external_ref
+	pulledIssues, err := targetStore.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("SearchIssues on target: %v", err)
+	}
+	if len(pulledIssues) != len(seeds) {
+		t.Fatalf("target has %d issues, want %d", len(pulledIssues), len(seeds))
+	}
+
+	pulledByRef := make(map[string]*types.Issue)
+	for _, issue := range pulledIssues {
+		if issue.ExternalRef != nil && *issue.ExternalRef != "" {
+			pulledByRef[*issue.ExternalRef] = issue
+		}
+	}
+
+	// For each source issue, find the corresponding pulled issue and compare
+	for i, id := range sourceIssueIDs {
+		source, err := sourceStore.GetIssue(ctx, id)
+		if err != nil {
+			t.Fatalf("GetIssue(%s) from source: %v", id, err)
+		}
+		if source.ExternalRef == nil {
+			t.Fatalf("source issue %s has no external_ref", id)
+		}
+
+		pulled, ok := pulledByRef[*source.ExternalRef]
+		if !ok {
+			t.Fatalf("seed[%d] %s: no pulled issue with external_ref %s", i, id, *source.ExternalRef)
+		}
+
+		t.Run(fmt.Sprintf("seed_%d_%s", i, source.Title), func(t *testing.T) {
+			// Title
+			if pulled.Title != source.Title {
+				t.Errorf("title: got %q, want %q", pulled.Title, source.Title)
+			}
+
+			// Priority round-trip (beads→linear→beads)
+			if pulled.Priority != source.Priority {
+				t.Errorf("priority: got %d, want %d", pulled.Priority, source.Priority)
+			}
+
+			// Status round-trip
+			// Note: StatusOpen→unstarted→open, StatusInProgress→started→in_progress,
+			// StatusClosed→completed→closed
+			if pulled.Status != source.Status {
+				t.Errorf("status: got %q, want %q", pulled.Status, source.Status)
+			}
+
+			// External ref preserved
+			if pulled.ExternalRef == nil || *pulled.ExternalRef != *source.ExternalRef {
+				pulledRef := "<nil>"
+				if pulled.ExternalRef != nil {
+					pulledRef = *pulled.ExternalRef
+				}
+				t.Errorf("external_ref: got %q, want %q", pulledRef, *source.ExternalRef)
+			}
+		})
+	}
+}
+
+// TestLinearRoundTripRelationships is a spec test documenting that parent-child
+// hierarchy, blocking dependencies, and issue type do not survive a push→pull
+// round-trip because the Linear push path does not yet send these fields.
+// When those features are implemented, remove the Skip and this test becomes
+// a regression gate. See upstream #3187.
+func TestLinearRoundTripRelationships(t *testing.T) {
+	t.Skip("push does not yet support parent/relations/type — see upstream #3187")
+
+	// When enabled, this test should:
+	// 1. Create an epic + child tasks + blocking dep
+	// 2. Push to mock Linear
+	// 3. Verify mock received parent and relation fields
+	// 4. Pull into fresh DB
+	// 5. Assert:
+	//    - Epic exists with IssueType=epic
+	//    - Child tasks have parent-child dep to epic
+	//    - Blocking dep preserved
+	//    - Issue types preserved via label round-trip
+}
+
+// buildLinearPushHooksForTest mirrors buildLinearPushHooks from linear.go
+// but works with an explicit store instead of the global.
+func buildLinearPushHooksForTest(ctx context.Context, lt *linear.Tracker) *tracker.PushHooks {
+	return &tracker.PushHooks{
+		FormatDescription: func(issue *types.Issue) string {
+			return linear.BuildLinearDescription(issue)
+		},
+		ContentEqual: func(local *types.Issue, remote *tracker.TrackerIssue) bool {
+			localComparable := linear.NormalizeIssueForLinearHash(local)
+			remoteConv := lt.FieldMapper().IssueToBeads(remote)
+			if remoteConv == nil || remoteConv.Issue == nil {
+				return false
+			}
+			return localComparable.ComputeContentHash() == remoteConv.Issue.ComputeContentHash()
+		},
+		BuildStateCache: func(ctx context.Context) (interface{}, error) {
+			return linear.BuildStateCacheFromTracker(ctx, lt)
+		},
+		ResolveState: func(cache interface{}, status types.Status) (string, bool) {
+			sc, ok := cache.(*linear.StateCache)
+			if !ok || sc == nil {
+				return "", false
+			}
+			id := sc.FindStateForBeadsStatus(status)
+			return id, id != ""
+		},
+	}
+}
+
+// buildLinearPullHooksForTest mirrors buildLinearPullHooks from linear.go
+// but works with an explicit store.
+func buildLinearPullHooksForTest(ctx context.Context, store interface {
+	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
+}) *tracker.PullHooks {
+	hooks := &tracker.PullHooks{}
+
+	existingIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+	usedIDs := make(map[string]bool)
+	if err == nil {
+		for _, issue := range existingIssues {
+			if issue.ID != "" {
+				usedIDs[issue.ID] = true
+			}
+		}
+	}
+
+	hooks.GenerateID = func(_ context.Context, issue *types.Issue) error {
+		ids := []*types.Issue{issue}
+		idOpts := linear.IDGenerationOptions{
+			BaseLength: 6,
+			MaxLength:  8,
+			UsedIDs:    usedIDs,
+		}
+		if err := linear.GenerateIssueIDs(ids, "bd", "linear-import", idOpts); err != nil {
+			return err
+		}
+		usedIDs[issue.ID] = true
+		return nil
+	}
+
+	return hooks
+}

--- a/docs/FEDERATION-SECURITY.md
+++ b/docs/FEDERATION-SECURITY.md
@@ -1,0 +1,236 @@
+# Federation Security
+
+This document covers the credential security model for multi-remote federation
+deployments. It assumes familiarity with [FEDERATION-SETUP.md](../FEDERATION-SETUP.md)
+and [CONFIG.md](CONFIG.md).
+
+## Remote Roles and Trust Model
+
+Each `RemoteConfig` has a **role** that determines how bd treats it during sync:
+
+| Role | Push | Pull | Trust Level |
+|------|------|------|-------------|
+| `primary` | First, fail-fast | Yes (authoritative) | Highest |
+| `backup` | After primary succeeds | Never | Mirror only |
+| `archive` | After primary succeeds | Never | Cold storage |
+
+**Pull trust ordering**: bd only pulls from the `primary` remote. Backup and
+archive remotes are push-only mirrors. A compromised backup cannot inject data
+into your database — the `SyncOrchestrator` enforces this by calling
+`PullFrom()` exclusively on the primary remote.
+
+This is a deliberate security boundary: even if an attacker gains write access
+to a backup remote, they cannot influence the data your workspace sees.
+
+## Credential Isolation
+
+### Per-Remote Credential Binding
+
+Federation peers store credentials in the `federation_peers` table, encrypted
+at rest (AES-256). Each peer has its own username/password pair:
+
+```bash
+# Each peer gets independent credentials
+bd federation add-peer primary dolthub://org/beads
+bd federation add-peer backup  s3://mybucket/beads-backup
+bd federation add-peer archive az://account.blob.core.windows.net/archive
+```
+
+When bd pushes to a specific remote, `withPeerCredentials()` looks up that
+peer's encrypted credentials and passes them to the Dolt subprocess via
+`DOLT_REMOTE_USER` and `DOLT_REMOTE_PASSWORD` environment variables. Existing
+values for these variables are stripped from the subprocess environment before
+the peer-specific values are applied — credentials never leak between remotes.
+
+### Cloud Auth Environment Variables
+
+For cloud-hosted remotes (S3, GCS, Azure Blob), Dolt uses provider-specific
+environment variables. The `shouldUseCLIForCloudAuth()` function checks for
+these prefixes:
+
+| Prefix | Provider | Common Variables |
+|--------|----------|------------------|
+| `AWS_` | Amazon S3 | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` |
+| `AZURE_STORAGE_` | Azure Blob | `AZURE_STORAGE_ACCOUNT`, `AZURE_STORAGE_KEY`, `AZURE_STORAGE_SAS_TOKEN` |
+| `GOOGLE_` | Google Cloud | `GOOGLE_APPLICATION_CREDENTIALS` |
+| `GCS_` | GCS (alternate) | `GCS_CREDENTIALS_FILE` |
+| `OCI_` | Oracle Cloud | `OCI_CONFIG_FILE` |
+| `DOLT_REMOTE_` | Dolt-specific | `DOLT_REMOTE_USER`, `DOLT_REMOTE_PASSWORD` |
+
+**Important limitation**: `shouldUseCLIForCloudAuth()` checks whether *any*
+cloud auth variable is set — it does not distinguish per-remote. If you have
+both `AWS_ACCESS_KEY_ID` and `AZURE_STORAGE_KEY` set in the same environment,
+both are visible to all Dolt subprocesses. To isolate credentials between
+cloud providers:
+
+- Run pushes to different providers in separate environments (e.g., separate
+  CI jobs or wrapper scripts that set only the relevant variables)
+- Use IAM roles or workload identity federation instead of static keys where
+  your provider supports it
+- Use `DOLT_REMOTE_USER`/`DOLT_REMOTE_PASSWORD` via the peer credential store
+  instead of provider-specific env vars when possible
+
+### Credential Reuse Warning
+
+Using the same credential across remotes with different trust levels is a
+security risk. If your backup remote uses the same API key as your primary,
+compromise of the backup effectively compromises primary access too.
+
+**Best practice**: Use distinct credentials per remote, scoped to the minimum
+required permissions:
+
+- Primary: read/write access
+- Backup: write-only (append) if your provider supports it
+- Archive: write-only, ideally with immutability policies
+
+If your deployment must reuse credentials, document the trust implications and
+ensure all remotes sharing a credential have equivalent security controls.
+
+## Credential Lifecycle
+
+### Rotation
+
+1. Generate new credentials with your cloud provider or DoltHub
+2. Update the peer's stored credentials:
+   ```bash
+   bd federation add-peer <name> <url>  # Re-adding overwrites credentials
+   ```
+3. Verify connectivity: `bd dolt push` to the affected remote
+4. Revoke the old credentials at the provider
+
+For cloud auth env vars, update the variables in your CI/CD secrets or shell
+profile, then restart any running bd server instances.
+
+### Revocation
+
+If a credential is compromised:
+
+1. **Revoke immediately** at the provider (DoltHub, AWS IAM, Azure portal, GCP console)
+2. Rotate to new credentials as above
+3. Audit recent sync history: `bd dolt log` shows Dolt commit history including
+   push timestamps
+4. If the compromised credential was for a backup remote, verify primary data
+   integrity — backups cannot inject data, but the attacker may have read data
+   from the backup
+
+### Audit Logging
+
+bd does not maintain a separate credential audit log. Use these sources for
+audit evidence:
+
+- **Dolt commit history**: Every push creates a Dolt commit with timestamp and
+  author metadata (`bd dolt log`)
+- **`federation_peers.last_sync`**: Updated on each successful peer operation
+- **Cloud provider audit logs**: AWS CloudTrail, Azure Activity Log, GCP Cloud
+  Audit Logs — these record all API calls made with your credentials
+- **bd server logs**: If running in server mode, connection events are logged
+  (credentials are never included — see Log Sanitization below)
+
+## Partial Push Failure
+
+The `SyncOrchestrator` pushes remotes in a defined order with specific failure
+semantics:
+
+1. **Primary is pushed first**. If primary fails, all backup/archive pushes are
+   **skipped** (`PushStatusSkipped`). No data reaches any remote.
+
+2. **If primary succeeds**, backups are pushed sequentially. Each backup failure
+   is independent — one backup failing does not stop other backups.
+
+3. **Degraded sync** (`ErrDegradedSync`): Primary succeeded but one or more
+   backups failed. In this state:
+   - Primary has the latest data (authoritative, consistent)
+   - Some backups may be stale (missing the latest push)
+   - No backup has *partial* data — Dolt pushes are atomic per-remote
+
+**Security implications of degraded sync**:
+
+- An attacker observing a backup remote sees either the previous complete state
+  or the new complete state, never a partial write
+- Stale backups are a durability concern, not a confidentiality one — the data
+  on stale backups is a subset of what primary already has
+- Retry logic uses exponential backoff (500ms initial, 3 retries by default)
+  with transient error detection before marking a push as failed
+
+## Log Sanitization
+
+bd follows a strict policy of never logging sensitive material:
+
+- **Credentials**: `DOLT_REMOTE_USER`, `DOLT_REMOTE_PASSWORD`, cloud API keys,
+  SAS tokens, and encrypted peer passwords are never written to logs or error
+  messages
+- **Connection strings**: Remote URLs may contain embedded credentials (e.g.,
+  `https://user:pass@host/path`). Log messages use the remote **name** (e.g.,
+  `"pushing to backup"`) rather than the full URL
+- **Subprocess environment**: Credentials are set on the subprocess `cmd.Env`
+  only, not on the parent process environment (except when using
+  `withEnvCredentials()`, which holds a mutex and restores the original values
+  immediately after the operation)
+
+When troubleshooting federation issues, use remote names in bug reports and
+support requests — never paste connection strings or environment variable values.
+
+## URL Validation and Injection Prevention
+
+Remote URLs are validated before use to prevent injection attacks:
+
+- **Control characters rejected**: Any byte in the range 0x00–0x1f or 0x7f
+  causes validation failure (prevents terminal escape injection and null-byte
+  attacks)
+- **Leading dash rejected**: URLs starting with `-` are blocked to prevent
+  CLI flag injection when URLs are passed as subprocess arguments
+- **Scheme allowlist**: Only known schemes are accepted: `dolthub://`, `gs://`,
+  `s3://`, `az://`, `file://`, `https://`, `http://`, `ssh://`, `git+ssh://`,
+  `git+https://`
+- **SCP-style validation**: Git SSH shorthand (`git@host:path`) is validated
+  against a strict regex pattern
+
+### Enterprise URL Restrictions
+
+The `federation.allowed-remote-patterns` config key accepts a list of glob
+patterns that restrict which remote URLs are permitted:
+
+```yaml
+# .beads/config.yaml
+federation:
+  allowed-remote-patterns:
+    - "dolthub://myorg/*"
+    - "s3://mycompany-*/**"
+```
+
+When set, any remote URL that does not match at least one pattern is rejected.
+This prevents users or agents from adding unauthorized remotes. Uses Go's
+`path.Match` glob semantics.
+
+## Subprocess Credential Isolation
+
+Credentials are passed to Dolt subprocesses using two mechanisms, both designed
+to minimize exposure:
+
+1. **`applyToCmd()`** (preferred): Builds a clean environment for the subprocess,
+   stripping any pre-existing `DOLT_REMOTE_USER`/`DOLT_REMOTE_PASSWORD` values
+   and injecting only the peer-specific credentials. The parent process
+   environment is never modified.
+
+2. **`withEnvCredentials()`** (fallback): Temporarily sets credentials in the
+   parent process environment, protected by `federationEnvMutex`. The original
+   values are restored immediately after the operation completes. This is used
+   when the Dolt API requires process-wide environment variables rather than
+   subprocess configuration.
+
+In both cases, credentials exist in memory only for the duration of the
+operation and are never written to disk outside the encrypted `federation_peers`
+table.
+
+## Summary of Security Properties
+
+| Property | Guarantee |
+|----------|-----------|
+| Pull source | Primary only — backups cannot inject data |
+| Credential storage | AES-256 encrypted in `federation_peers` table |
+| Credential passing | Subprocess env only, stripped after use |
+| Push atomicity | Per-remote atomic; no partial writes visible |
+| URL validation | Control chars, leading dashes, unknown schemes all rejected |
+| Log hygiene | Credentials, connection strings, SAS tokens never logged |
+| Enterprise lockdown | `federation.allowed-remote-patterns` restricts URLs |
+| Peer names | Validated: alphanumeric + hyphens/underscores, max 64 chars |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/viper"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/remotecache"
 	"gopkg.in/yaml.v3"
 )
 
@@ -752,18 +754,263 @@ func GetIdentity(flagValue string) string {
 	return "unknown"
 }
 
+// RemoteRole represents the role of a federation remote.
+type RemoteRole string
+
+const (
+	// RemoteRolePrimary is the authoritative remote for pull operations.
+	RemoteRolePrimary RemoteRole = "primary"
+	// RemoteRoleBackup is a push-only mirror (never pulled from).
+	RemoteRoleBackup RemoteRole = "backup"
+	// RemoteRoleArchive is a long-term storage remote (push-only, low frequency).
+	RemoteRoleArchive RemoteRole = "archive"
+)
+
+// validRemoteRoles is the set of allowed remote role values.
+var validRemoteRoles = map[RemoteRole]bool{
+	RemoteRolePrimary: true,
+	RemoteRoleBackup:  true,
+	RemoteRoleArchive: true,
+}
+
+// RemoteConfig describes a single federation remote.
+type RemoteConfig struct {
+	Name string     // Map key from config (e.g., "primary", "backup")
+	URL  string     // dolthub://org/beads, az://account.blob.core.windows.net/...
+	Role RemoteRole // primary, backup, archive
+}
+
 // FederationConfig holds the federation (Dolt remote) configuration.
 type FederationConfig struct {
-	Remote      string      // dolthub://org/beads, gs://bucket/beads, s3://bucket/beads
-	Sovereignty Sovereignty // T1, T2, T3, T4
+	Remote      string         // Effective primary remote URL (populated from legacy or remotes)
+	Remotes     []RemoteConfig // Multi-remote configuration (sorted by name for determinism)
+	Sovereignty Sovereignty    // T1, T2, T3, T4
+}
+
+// PrimaryRemote returns the primary remote, or nil if none is configured.
+func (fc *FederationConfig) PrimaryRemote() *RemoteConfig {
+	for i := range fc.Remotes {
+		if fc.Remotes[i].Role == RemoteRolePrimary {
+			return &fc.Remotes[i]
+		}
+	}
+	return nil
+}
+
+// BackupRemotes returns all non-primary remotes.
+func (fc *FederationConfig) BackupRemotes() []RemoteConfig {
+	var backups []RemoteConfig
+	for _, r := range fc.Remotes {
+		if r.Role != RemoteRolePrimary {
+			backups = append(backups, r)
+		}
+	}
+	return backups
+}
+
+// RemoteByName returns the remote with the given name, or nil if not found.
+func (fc *FederationConfig) RemoteByName(name string) *RemoteConfig {
+	for i := range fc.Remotes {
+		if fc.Remotes[i].Name == name {
+			return &fc.Remotes[i]
+		}
+	}
+	return nil
 }
 
 // GetFederationConfig returns the current federation configuration.
+// For validation errors, use ParseFederationConfig instead.
 func GetFederationConfig() FederationConfig {
-	return FederationConfig{
-		Remote:      GetString("federation.remote"),
-		Sovereignty: GetSovereignty(),
+	cfg, err := ParseFederationConfig()
+	if err != nil {
+		// Fall back to legacy behavior on parse error
+		logConfigWarning("warning: federation config parse error: %v\n", err)
+		return FederationConfig{
+			Remote:      GetString("federation.remote"),
+			Sovereignty: GetSovereignty(),
+		}
 	}
+	return cfg
+}
+
+// ParseFederationConfig parses and validates the federation configuration.
+// It supports both legacy (federation.remote) and new (federation.remotes) formats.
+// When only federation.remotes is set, the primary remote URL is synthesized
+// into the Remote field for backward compatibility with existing consumers.
+func ParseFederationConfig() (FederationConfig, error) {
+	sovereignty := GetSovereignty()
+	legacyRemote := GetString("federation.remote")
+	hasRemotesInConfig := v != nil && v.InConfig("federation.remotes")
+
+	// Case 1: Neither configured — empty config
+	if legacyRemote == "" && !hasRemotesInConfig {
+		return FederationConfig{Sovereignty: sovereignty}, nil
+	}
+
+	// Case 2: New-style federation.remotes is configured
+	if hasRemotesInConfig {
+		remotes, err := parseRemotesMap()
+		if err != nil {
+			return FederationConfig{}, fmt.Errorf("federation.remotes: %w", err)
+		}
+
+		// Validate remotes
+		if err := validateRemotes(remotes); err != nil {
+			return FederationConfig{}, err
+		}
+
+		// Synthesize effective primary URL
+		effectiveRemote := ""
+		for _, r := range remotes {
+			if r.Role == RemoteRolePrimary {
+				effectiveRemote = r.URL
+				break
+			}
+		}
+
+		// Warn if legacy federation.remote conflicts with remotes primary
+		if legacyRemote != "" && effectiveRemote != "" && legacyRemote != effectiveRemote {
+			logConfigWarning("warning: federation.remote (%s) differs from federation.remotes primary (%s); using remotes\n", legacyRemote, effectiveRemote)
+		}
+
+		// Synthesize federation.remote at runtime so drift/apply consumers see it
+		if effectiveRemote != "" && v != nil {
+			v.Set("federation.remote", effectiveRemote)
+		}
+
+		return FederationConfig{
+			Remote:      effectiveRemote,
+			Remotes:     remotes,
+			Sovereignty: sovereignty,
+		}, nil
+	}
+
+	// Case 3: Legacy federation.remote only — convert to single RemoteConfig
+	return FederationConfig{
+		Remote: legacyRemote,
+		Remotes: []RemoteConfig{{
+			Name: "origin",
+			URL:  legacyRemote,
+			Role: RemoteRolePrimary,
+		}},
+		Sovereignty: sovereignty,
+	}, nil
+}
+
+// parseRemotesMap reads federation.remotes from viper and converts to []RemoteConfig.
+// The map keys become the Name field; entries are sorted by name for determinism.
+func parseRemotesMap() ([]RemoteConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	raw := v.Get("federation.remotes")
+	if raw == nil {
+		return nil, nil
+	}
+
+	// Viper returns map[string]interface{} for nested YAML maps
+	remotesMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected map, got %T", raw)
+	}
+
+	if len(remotesMap) == 0 {
+		return nil, nil
+	}
+
+	// Collect and sort keys for deterministic output
+	names := make([]string, 0, len(remotesMap))
+	for name := range remotesMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	allowedPatterns := GetStringSlice("federation.allowed-remote-patterns")
+
+	remotes := make([]RemoteConfig, 0, len(names))
+	for _, name := range names {
+		if err := validateRemoteName(name); err != nil {
+			return nil, fmt.Errorf("remote %q: %w", name, err)
+		}
+
+		entry, ok := remotesMap[name].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("remote %q: expected map with url and role fields, got %T", name, remotesMap[name])
+		}
+
+		urlStr, _ := entry["url"].(string)
+		if urlStr == "" {
+			return nil, fmt.Errorf("remote %q: url is required", name)
+		}
+
+		// Validate URL via the existing security boundary
+		if err := remotecache.ValidateRemoteURL(urlStr); err != nil {
+			return nil, fmt.Errorf("remote %q: invalid url: %w", name, err)
+		}
+		if len(allowedPatterns) > 0 {
+			if err := remotecache.ValidateRemoteURLWithPatterns(urlStr, allowedPatterns); err != nil {
+				return nil, fmt.Errorf("remote %q: %w", name, err)
+			}
+		}
+
+		roleStr, _ := entry["role"].(string)
+		if roleStr == "" {
+			return nil, fmt.Errorf("remote %q: role is required (primary, backup, or archive)", name)
+		}
+
+		role := RemoteRole(roleStr)
+		if !validRemoteRoles[role] {
+			return nil, fmt.Errorf("remote %q: invalid role %q (valid: primary, backup, archive)", name, roleStr)
+		}
+
+		remotes = append(remotes, RemoteConfig{
+			Name: name,
+			URL:  urlStr,
+			Role: role,
+		})
+	}
+
+	return remotes, nil
+}
+
+// validateRemotes checks cross-remote constraints (e.g., exactly one primary).
+func validateRemotes(remotes []RemoteConfig) error {
+	if len(remotes) == 0 {
+		return nil
+	}
+
+	primaryCount := 0
+	for _, r := range remotes {
+		if r.Role == RemoteRolePrimary {
+			primaryCount++
+		}
+	}
+
+	if primaryCount == 0 {
+		return fmt.Errorf("federation.remotes: exactly one remote must have role \"primary\", found none")
+	}
+	if primaryCount > 1 {
+		return fmt.Errorf("federation.remotes: exactly one remote must have role \"primary\", found %d", primaryCount)
+	}
+
+	return nil
+}
+
+// validateRemoteName checks that a remote name is a valid identifier.
+func validateRemoteName(name string) error {
+	if name == "" {
+		return fmt.Errorf("remote name cannot be empty")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("remote name too long (max 64 characters)")
+	}
+	for i, c := range name {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return fmt.Errorf("invalid character %q at position %d (allowed: a-z, A-Z, 0-9, -, _)", c, i)
+		}
+	}
+	return nil
 }
 
 // GetCustomTypesFromYAML retrieves custom issue types from config.yaml.

--- a/internal/config/federation_config_test.go
+++ b/internal/config/federation_config_test.go
@@ -1,0 +1,367 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fedTestHelper sets up a temp dir with config.yaml, chdir, and Initialize.
+func fedTestHelper(t *testing.T, configContent string) {
+	t.Helper()
+	restore := envSnapshot(t)
+	t.Cleanup(restore)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+	if configContent != "" {
+		configPath := filepath.Join(beadsDir, "config.yaml")
+		if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+	}
+	t.Chdir(tmpDir)
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+}
+
+func TestParseFederationConfig_Empty(t *testing.T) {
+	fedTestHelper(t, "")
+
+	cfg, err := ParseFederationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Remote != "" {
+		t.Errorf("Remote = %q, want empty", cfg.Remote)
+	}
+	if len(cfg.Remotes) != 0 {
+		t.Errorf("Remotes = %v, want empty", cfg.Remotes)
+	}
+	if cfg.PrimaryRemote() != nil {
+		t.Error("PrimaryRemote() should be nil for empty config")
+	}
+}
+
+func TestParseFederationConfig_LegacyRemote(t *testing.T) {
+	fedTestHelper(t, "federation:\n  remote: dolthub://myorg/beads\n  sovereignty: T2\n")
+
+	cfg, err := ParseFederationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Remote != "dolthub://myorg/beads" {
+		t.Errorf("Remote = %q, want %q", cfg.Remote, "dolthub://myorg/beads")
+	}
+	if cfg.Sovereignty != SovereigntyT2 {
+		t.Errorf("Sovereignty = %q, want %q", cfg.Sovereignty, SovereigntyT2)
+	}
+	if len(cfg.Remotes) != 1 {
+		t.Fatalf("len(Remotes) = %d, want 1", len(cfg.Remotes))
+	}
+	r := cfg.Remotes[0]
+	if r.Name != "origin" {
+		t.Errorf("Remotes[0].Name = %q, want %q", r.Name, "origin")
+	}
+	if r.URL != "dolthub://myorg/beads" {
+		t.Errorf("Remotes[0].URL = %q, want %q", r.URL, "dolthub://myorg/beads")
+	}
+	if r.Role != RemoteRolePrimary {
+		t.Errorf("Remotes[0].Role = %q, want %q", r.Role, RemoteRolePrimary)
+	}
+}
+
+func TestParseFederationConfig_NewRemotes(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    primary:
+      url: dolthub://myorg/beads
+      role: primary
+    backup:
+      url: az://account.blob.core.windows.net/container/beads
+      role: backup
+`)
+
+	cfg, err := ParseFederationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Remote != "dolthub://myorg/beads" {
+		t.Errorf("Remote = %q, want %q", cfg.Remote, "dolthub://myorg/beads")
+	}
+	if len(cfg.Remotes) != 2 {
+		t.Fatalf("len(Remotes) = %d, want 2", len(cfg.Remotes))
+	}
+	// Sorted by name: backup < primary
+	if cfg.Remotes[0].Name != "backup" {
+		t.Errorf("Remotes[0].Name = %q, want %q", cfg.Remotes[0].Name, "backup")
+	}
+	if cfg.Remotes[0].Role != RemoteRoleBackup {
+		t.Errorf("Remotes[0].Role = %q, want %q", cfg.Remotes[0].Role, RemoteRoleBackup)
+	}
+	if cfg.Remotes[1].Name != "primary" {
+		t.Errorf("Remotes[1].Name = %q, want %q", cfg.Remotes[1].Name, "primary")
+	}
+	if cfg.Remotes[1].Role != RemoteRolePrimary {
+		t.Errorf("Remotes[1].Role = %q, want %q", cfg.Remotes[1].Role, RemoteRolePrimary)
+	}
+
+	// Helper methods
+	p := cfg.PrimaryRemote()
+	if p == nil {
+		t.Fatal("PrimaryRemote() = nil, want non-nil")
+	}
+	if p.URL != "dolthub://myorg/beads" {
+		t.Errorf("PrimaryRemote().URL = %q, want %q", p.URL, "dolthub://myorg/beads")
+	}
+
+	backups := cfg.BackupRemotes()
+	if len(backups) != 1 {
+		t.Fatalf("len(BackupRemotes()) = %d, want 1", len(backups))
+	}
+	if backups[0].Name != "backup" {
+		t.Errorf("BackupRemotes()[0].Name = %q, want %q", backups[0].Name, "backup")
+	}
+
+	byName := cfg.RemoteByName("backup")
+	if byName == nil || byName.URL != "az://account.blob.core.windows.net/container/beads" {
+		t.Errorf("RemoteByName(backup) = %v, want az:// URL", byName)
+	}
+	if cfg.RemoteByName("nonexistent") != nil {
+		t.Error("RemoteByName(nonexistent) should be nil")
+	}
+}
+
+func TestParseFederationConfig_RemotesOverrideLegacy(t *testing.T) {
+	var warningBuf strings.Builder
+	oldWriter := ConfigWarningWriter
+	ConfigWarningWriter = &warningBuf
+	defer func() { ConfigWarningWriter = oldWriter }()
+
+	fedTestHelper(t, `federation:
+  remote: dolthub://old/beads
+  remotes:
+    main:
+      url: dolthub://new/beads
+      role: primary
+`)
+
+	cfg, err := ParseFederationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Remote != "dolthub://new/beads" {
+		t.Errorf("Remote = %q, want %q (from remotes primary)", cfg.Remote, "dolthub://new/beads")
+	}
+	if !strings.Contains(warningBuf.String(), "differs from") {
+		t.Errorf("expected conflict warning, got: %q", warningBuf.String())
+	}
+}
+
+func TestParseFederationConfig_NoPrimary(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    backup1:
+      url: az://account.blob.core.windows.net/a/b
+      role: backup
+    backup2:
+      url: gs://bucket/beads
+      role: backup
+`)
+
+	_, err := ParseFederationConfig()
+	if err == nil {
+		t.Fatal("expected error for missing primary, got nil")
+	}
+	if !strings.Contains(err.Error(), `exactly one remote must have role "primary"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseFederationConfig_MultiplePrimaries(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    one:
+      url: dolthub://a/b
+      role: primary
+    two:
+      url: dolthub://c/d
+      role: primary
+`)
+
+	_, err := ParseFederationConfig()
+	if err == nil {
+		t.Fatal("expected error for multiple primaries, got nil")
+	}
+	if !strings.Contains(err.Error(), "found 2") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseFederationConfig_InvalidRole(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    main:
+      url: dolthub://a/b
+      role: unknown
+`)
+
+	_, err := ParseFederationConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid role, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid role") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseFederationConfig_MissingURL(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    main:
+      role: primary
+`)
+
+	_, err := ParseFederationConfig()
+	if err == nil {
+		t.Fatal("expected error for missing URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "url is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseFederationConfig_MissingRole(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    main:
+      url: dolthub://a/b
+`)
+
+	_, err := ParseFederationConfig()
+	if err == nil {
+		t.Fatal("expected error for missing role, got nil")
+	}
+	if !strings.Contains(err.Error(), "role is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseFederationConfig_InvalidRemoteName(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    "bad name!":
+      url: dolthub://a/b
+      role: primary
+`)
+
+	_, err := ParseFederationConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid remote name, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseFederationConfig_ArchiveRole(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    main:
+      url: dolthub://org/beads
+      role: primary
+    cold:
+      url: s3://archive-bucket/beads
+      role: archive
+`)
+
+	cfg, err := ParseFederationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Remotes) != 2 {
+		t.Fatalf("len(Remotes) = %d, want 2", len(cfg.Remotes))
+	}
+	// Sorted: cold < main
+	if cfg.Remotes[0].Role != RemoteRoleArchive {
+		t.Errorf("Remotes[0].Role = %q, want archive", cfg.Remotes[0].Role)
+	}
+}
+
+func TestParseFederationConfig_SynthesizesRuntimeRemote(t *testing.T) {
+	fedTestHelper(t, `federation:
+  remotes:
+    main:
+      url: dolthub://synthesized/beads
+      role: primary
+`)
+
+	cfg, err := ParseFederationConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	runtimeRemote := GetString("federation.remote")
+	if runtimeRemote != "dolthub://synthesized/beads" {
+		t.Errorf("runtime federation.remote = %q, want %q", runtimeRemote, "dolthub://synthesized/beads")
+	}
+	if cfg.Remote != runtimeRemote {
+		t.Errorf("cfg.Remote = %q != runtime %q", cfg.Remote, runtimeRemote)
+	}
+}
+
+func TestParseFederationConfig_LegacyGetFederationConfigCompat(t *testing.T) {
+	// Existing GetFederationConfig should still work with legacy config
+	fedTestHelper(t, "federation:\n  remote: dolthub://compat/beads\n  sovereignty: T1\n")
+
+	cfg := GetFederationConfig()
+	if cfg.Remote != "dolthub://compat/beads" {
+		t.Errorf("GetFederationConfig().Remote = %q, want %q", cfg.Remote, "dolthub://compat/beads")
+	}
+	if cfg.Sovereignty != SovereigntyT1 {
+		t.Errorf("GetFederationConfig().Sovereignty = %q, want %q", cfg.Sovereignty, SovereigntyT1)
+	}
+	if len(cfg.Remotes) != 1 {
+		t.Fatalf("len(Remotes) = %d, want 1", len(cfg.Remotes))
+	}
+}
+
+func TestValidateRemoteName(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{"primary", false},
+		{"backup-1", false},
+		{"my_remote", false},
+		{"Remote2", false},
+		{"", true},
+		{"bad name", true},
+		{"bad.name", true},
+		{"bad/name", true},
+		{strings.Repeat("a", 65), true},
+	}
+	for _, tc := range tests {
+		err := validateRemoteName(tc.name)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("validateRemoteName(%q) err=%v, wantErr=%v", tc.name, err, tc.wantErr)
+		}
+	}
+}
+
+func TestRemoteRoleConstants(t *testing.T) {
+	if RemoteRolePrimary != "primary" {
+		t.Errorf("RemoteRolePrimary = %q", RemoteRolePrimary)
+	}
+	if RemoteRoleBackup != "backup" {
+		t.Errorf("RemoteRoleBackup = %q", RemoteRoleBackup)
+	}
+	if RemoteRoleArchive != "archive" {
+		t.Errorf("RemoteRoleArchive = %q", RemoteRoleArchive)
+	}
+}

--- a/internal/federation/orchestrator.go
+++ b/internal/federation/orchestrator.go
@@ -1,0 +1,369 @@
+// Package federation coordinates multi-remote synchronization operations
+// for beads' Dolt-powered storage layer. It provides the SyncOrchestrator
+// which pushes to multiple remotes with failure handling and retry logic.
+package federation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// RemotePusher is the minimal interface needed for push/pull operations.
+// DoltStore satisfies this via its PushTo and PullFrom methods.
+type RemotePusher interface {
+	PushTo(ctx context.Context, peer string) error
+	PullFrom(ctx context.Context, peer string) ([]storage.Conflict, error)
+}
+
+// PushStatus represents the outcome of a push to a single remote.
+type PushStatus string
+
+const (
+	PushStatusSuccess PushStatus = "success"
+	PushStatusFailed  PushStatus = "failed"
+	PushStatusSkipped PushStatus = "skipped" // not attempted (e.g., primary failed)
+)
+
+// PushResult is the result of pushing to a single remote.
+type PushResult struct {
+	Remote   config.RemoteConfig
+	Status   PushStatus
+	Error    error
+	Retries  int
+	Duration time.Duration
+}
+
+// PushAllResult aggregates results from pushing to all configured remotes.
+type PushAllResult struct {
+	Results  []PushResult
+	Duration time.Duration
+}
+
+// PrimaryOK returns true if the primary remote push succeeded.
+func (r *PushAllResult) PrimaryOK() bool {
+	for _, res := range r.Results {
+		if res.Remote.Role == config.RemoteRolePrimary {
+			return res.Status == PushStatusSuccess
+		}
+	}
+	return false
+}
+
+// AllOK returns true if all attempted remotes succeeded.
+func (r *PushAllResult) AllOK() bool {
+	for _, res := range r.Results {
+		if res.Status == PushStatusFailed {
+			return false
+		}
+	}
+	return true
+}
+
+// FailedRemotes returns the names of remotes that failed.
+func (r *PushAllResult) FailedRemotes() []string {
+	var names []string
+	for _, res := range r.Results {
+		if res.Status == PushStatusFailed {
+			names = append(names, res.Remote.Name)
+		}
+	}
+	return names
+}
+
+// ErrDegradedSync indicates primary succeeded but one or more backups failed.
+// Callers should treat this as a warning, not a full failure.
+var ErrDegradedSync = errors.New("degraded sync: primary succeeded but one or more backups failed")
+
+// ErrNoPrimary indicates no primary remote is configured.
+var ErrNoPrimary = errors.New("no primary remote configured in federation.remotes")
+
+// ErrLockHeld indicates another sync operation is in progress.
+var ErrLockHeld = errors.New("federation sync lock held by another process")
+
+// Option configures a SyncOrchestrator.
+type Option func(*SyncOrchestrator)
+
+// WithMaxRetries sets the maximum number of retries for transient errors.
+func WithMaxRetries(n int) Option {
+	return func(o *SyncOrchestrator) { o.maxRetries = n }
+}
+
+// WithRetryInterval sets the initial retry backoff interval.
+func WithRetryInterval(d time.Duration) Option {
+	return func(o *SyncOrchestrator) { o.retryInterval = d }
+}
+
+// WithIsRetryable injects a function to classify errors as transient.
+func WithIsRetryable(fn func(error) bool) Option {
+	return func(o *SyncOrchestrator) { o.isRetryable = fn }
+}
+
+// SyncOrchestrator coordinates multi-remote push operations with
+// sequential execution, failure handling, and advisory locking.
+type SyncOrchestrator struct {
+	store         RemotePusher
+	remotes       []config.RemoteConfig
+	beadsDir      string
+	maxRetries    int
+	retryInterval time.Duration
+	isRetryable   func(error) bool
+}
+
+// New creates a SyncOrchestrator for the given remotes.
+func New(store RemotePusher, remotes []config.RemoteConfig, beadsDir string, opts ...Option) *SyncOrchestrator {
+	o := &SyncOrchestrator{
+		store:         store,
+		remotes:       remotes,
+		beadsDir:      beadsDir,
+		maxRetries:    3,
+		retryInterval: 500 * time.Millisecond,
+		isRetryable:   defaultIsRetryable,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// PushAll pushes to all configured remotes sequentially.
+// Primary is always pushed first. If primary fails, backups are skipped.
+// Returns ErrDegradedSync (wrapped) if primary succeeds but backups fail.
+func (o *SyncOrchestrator) PushAll(ctx context.Context) (*PushAllResult, error) {
+	primary, backups := o.sortedRemotes()
+	if primary == nil {
+		return nil, ErrNoPrimary
+	}
+
+	// Acquire advisory lock
+	lockFile, err := o.acquireLock()
+	if err != nil {
+		return nil, err
+	}
+	defer o.releaseLock(lockFile)
+
+	start := time.Now()
+	results := make([]PushResult, 0, len(o.remotes))
+
+	// Push to primary first
+	primaryResult := o.pushWithRetry(ctx, *primary)
+	results = append(results, primaryResult)
+
+	if primaryResult.Status != PushStatusSuccess {
+		// Primary failed — skip all backups
+		for _, backup := range backups {
+			results = append(results, PushResult{
+				Remote: backup,
+				Status: PushStatusSkipped,
+			})
+		}
+		return &PushAllResult{Results: results, Duration: time.Since(start)},
+			fmt.Errorf("primary remote %q push failed: %w", primary.Name, primaryResult.Error)
+	}
+
+	// Push to backups (failures don't stop other backups)
+	var backupFailed bool
+	for _, backup := range backups {
+		if ctx.Err() != nil {
+			// Context cancelled — skip remaining
+			results = append(results, PushResult{
+				Remote: backup,
+				Status: PushStatusSkipped,
+			})
+			continue
+		}
+		result := o.pushWithRetry(ctx, backup)
+		results = append(results, result)
+		if result.Status == PushStatusFailed {
+			backupFailed = true
+		}
+	}
+
+	allResult := &PushAllResult{Results: results, Duration: time.Since(start)}
+
+	if backupFailed {
+		return allResult, fmt.Errorf("%w: %v", ErrDegradedSync, allResult.FailedRemotes())
+	}
+	return allResult, nil
+}
+
+// Pull pulls from the primary remote only.
+// Backups are push-only mirrors and are never pulled from.
+func (o *SyncOrchestrator) Pull(ctx context.Context) ([]storage.Conflict, error) {
+	primary, _ := o.sortedRemotes()
+	if primary == nil {
+		return nil, ErrNoPrimary
+	}
+	return o.store.PullFrom(ctx, primary.Name)
+}
+
+// pushWithRetry pushes to a single remote with retry logic for transient errors.
+func (o *SyncOrchestrator) pushWithRetry(ctx context.Context, remote config.RemoteConfig) PushResult {
+	start := time.Now()
+	retries := 0
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = o.retryInterval
+	bo.MaxElapsedTime = 0 // controlled by maxRetries instead
+
+	var lastErr error
+	for attempt := 0; attempt <= o.maxRetries; attempt++ {
+		if attempt > 0 {
+			retries++
+			wait := bo.NextBackOff()
+			if wait == backoff.Stop {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return PushResult{
+					Remote:   remote,
+					Status:   PushStatusFailed,
+					Error:    ctx.Err(),
+					Retries:  retries - 1,
+					Duration: time.Since(start),
+				}
+			case <-time.After(wait):
+			}
+		}
+
+		err := o.store.PushTo(ctx, remote.Name)
+		if err == nil {
+			return PushResult{
+				Remote:   remote,
+				Status:   PushStatusSuccess,
+				Retries:  retries,
+				Duration: time.Since(start),
+			}
+		}
+
+		lastErr = err
+		if !o.isRetryable(err) {
+			break
+		}
+	}
+
+	return PushResult{
+		Remote:   remote,
+		Status:   PushStatusFailed,
+		Error:    lastErr,
+		Retries:  retries,
+		Duration: time.Since(start),
+	}
+}
+
+// sortedRemotes returns primary first, then backups sorted by name.
+func (o *SyncOrchestrator) sortedRemotes() (*config.RemoteConfig, []config.RemoteConfig) {
+	var primary *config.RemoteConfig
+	var backups []config.RemoteConfig
+
+	for i := range o.remotes {
+		if o.remotes[i].Role == config.RemoteRolePrimary {
+			primary = &o.remotes[i]
+		} else {
+			backups = append(backups, o.remotes[i])
+		}
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].Name < backups[j].Name
+	})
+
+	return primary, backups
+}
+
+// acquireLock acquires a non-blocking advisory lock for the push sequence.
+func (o *SyncOrchestrator) acquireLock() (*os.File, error) {
+	lockPath := filepath.Join(o.beadsDir, "federation.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open federation lock file: %w", err)
+	}
+
+	if err := lockfile.FlockExclusiveNonBlocking(f); err != nil {
+		f.Close()
+		if lockfile.IsLocked(err) {
+			return nil, ErrLockHeld
+		}
+		return nil, fmt.Errorf("cannot acquire federation lock: %w", err)
+	}
+
+	return f, nil
+}
+
+// releaseLock releases the advisory lock and closes the file.
+func (o *SyncOrchestrator) releaseLock(f *os.File) {
+	if f == nil {
+		return
+	}
+	_ = lockfile.FlockUnlock(f)
+	_ = f.Close()
+}
+
+// defaultIsRetryable classifies errors as transient (retryable) or permanent.
+// Callers can override this via WithIsRetryable for tighter integration
+// with DoltStore's isRetryableError().
+func defaultIsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	transientPatterns := []string{
+		"timeout",
+		"connection reset",
+		"connection refused",
+		"broken pipe",
+		"i/o timeout",
+		"bad connection",
+		"invalid connection",
+		"lost connection",
+		"server has gone away",
+		"temporary failure",
+		"try again",
+	}
+	for _, pat := range transientPatterns {
+		if containsFold(msg, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsFold reports whether s contains substr (case-insensitive).
+func containsFold(s, substr string) bool {
+	sLen := len(s)
+	subLen := len(substr)
+	if subLen > sLen {
+		return false
+	}
+	for i := 0; i <= sLen-subLen; i++ {
+		match := true
+		for j := 0; j < subLen; j++ {
+			sc := s[i+j]
+			tc := substr[j]
+			if sc >= 'A' && sc <= 'Z' {
+				sc += 'a' - 'A'
+			}
+			if tc >= 'A' && tc <= 'Z' {
+				tc += 'a' - 'A'
+			}
+			if sc != tc {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/federation/orchestrator.go
+++ b/internal/federation/orchestrator.go
@@ -174,7 +174,7 @@ func (o *SyncOrchestrator) PushAll(ctx context.Context) (*PushAllResult, error) 
 	var backupFailed bool
 	for _, backup := range backups {
 		if ctx.Err() != nil {
-			// Context cancelled — skip remaining
+			// Context canceled — skip remaining
 			results = append(results, PushResult{
 				Remote: backup,
 				Status: PushStatusSkipped,
@@ -284,13 +284,13 @@ func (o *SyncOrchestrator) sortedRemotes() (*config.RemoteConfig, []config.Remot
 // acquireLock acquires a non-blocking advisory lock for the push sequence.
 func (o *SyncOrchestrator) acquireLock() (*os.File, error) {
 	lockPath := filepath.Join(o.beadsDir, "federation.lock")
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600) //nolint:gosec // lockPath is constructed from trusted beadsDir
 	if err != nil {
 		return nil, fmt.Errorf("cannot open federation lock file: %w", err)
 	}
 
 	if err := lockfile.FlockExclusiveNonBlocking(f); err != nil {
-		f.Close()
+		_ = f.Close()
 		if lockfile.IsLocked(err) {
 			return nil, ErrLockHeld
 		}

--- a/internal/federation/orchestrator_test.go
+++ b/internal/federation/orchestrator_test.go
@@ -1,0 +1,344 @@
+package federation
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+// mockPusher records PushTo/PullFrom calls and returns configured errors.
+type mockPusher struct {
+	pushCalls []string // remote names pushed to
+	pullCalls []string // remote names pulled from
+	pushErrs  map[string]error
+	pullErrs  map[string]error
+	pushDelay time.Duration
+}
+
+func newMockPusher() *mockPusher {
+	return &mockPusher{
+		pushErrs: make(map[string]error),
+		pullErrs: make(map[string]error),
+	}
+}
+
+func (m *mockPusher) PushTo(_ context.Context, peer string) error {
+	m.pushCalls = append(m.pushCalls, peer)
+	if m.pushDelay > 0 {
+		time.Sleep(m.pushDelay)
+	}
+	return m.pushErrs[peer]
+}
+
+func (m *mockPusher) PullFrom(_ context.Context, peer string) ([]storage.Conflict, error) {
+	m.pullCalls = append(m.pullCalls, peer)
+	return nil, m.pullErrs[peer]
+}
+
+var testRemotes = []config.RemoteConfig{
+	{Name: "primary", URL: "dolthub://org/beads", Role: config.RemoteRolePrimary},
+	{Name: "backup", URL: "az://account.blob.core.windows.net/c/b", Role: config.RemoteRoleBackup},
+}
+
+func newTestOrch(t *testing.T, mock RemotePusher, remotes []config.RemoteConfig, opts ...Option) *SyncOrchestrator {
+	t.Helper()
+	beadsDir := t.TempDir()
+	defaults := []Option{
+		WithRetryInterval(1 * time.Millisecond), // fast retries in tests
+	}
+	return New(mock, remotes, beadsDir, append(defaults, opts...)...)
+}
+
+func TestPushAll_AllSuccess(t *testing.T) {
+	mock := newMockPusher()
+	orch := newTestOrch(t, mock, testRemotes)
+
+	result, err := orch.PushAll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.PrimaryOK() {
+		t.Error("PrimaryOK() = false, want true")
+	}
+	if !result.AllOK() {
+		t.Error("AllOK() = false, want true")
+	}
+	if len(result.Results) != 2 {
+		t.Fatalf("len(Results) = %d, want 2", len(result.Results))
+	}
+	// Primary pushed first
+	if mock.pushCalls[0] != "primary" {
+		t.Errorf("first push = %q, want %q", mock.pushCalls[0], "primary")
+	}
+	if mock.pushCalls[1] != "backup" {
+		t.Errorf("second push = %q, want %q", mock.pushCalls[1], "backup")
+	}
+}
+
+func TestPushAll_PrimaryFailsPermanent(t *testing.T) {
+	mock := newMockPusher()
+	mock.pushErrs["primary"] = errors.New("bucket not found")
+	orch := newTestOrch(t, mock, testRemotes, WithIsRetryable(func(error) bool { return false }))
+
+	result, err := orch.PushAll(context.Background())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if result.PrimaryOK() {
+		t.Error("PrimaryOK() = true after primary failure")
+	}
+	// Backup should be skipped, not attempted
+	for _, r := range result.Results {
+		if r.Remote.Name == "backup" && r.Status != PushStatusSkipped {
+			t.Errorf("backup status = %q, want %q", r.Status, PushStatusSkipped)
+		}
+	}
+	// Only primary was attempted
+	if len(mock.pushCalls) != 1 {
+		t.Errorf("pushCalls = %d, want 1 (only primary)", len(mock.pushCalls))
+	}
+}
+
+func TestPushAll_PrimarySucceedsBackupFails(t *testing.T) {
+	mock := newMockPusher()
+	mock.pushErrs["backup"] = errors.New("access denied")
+	orch := newTestOrch(t, mock, testRemotes, WithIsRetryable(func(error) bool { return false }))
+
+	result, err := orch.PushAll(context.Background())
+	if !errors.Is(err, ErrDegradedSync) {
+		t.Fatalf("expected ErrDegradedSync, got: %v", err)
+	}
+	if !result.PrimaryOK() {
+		t.Error("PrimaryOK() = false, want true")
+	}
+	if result.AllOK() {
+		t.Error("AllOK() = true, want false")
+	}
+	failed := result.FailedRemotes()
+	if len(failed) != 1 || failed[0] != "backup" {
+		t.Errorf("FailedRemotes() = %v, want [backup]", failed)
+	}
+}
+
+func TestPushAll_PrimaryTransientThenSuccess(t *testing.T) {
+	var callCount atomic.Int32
+	mock := &countingPusher{
+		callCount: &callCount,
+		failUntil: 2, // fail first 2 attempts, succeed on 3rd
+		failErr:   errors.New("connection reset by peer"),
+		failPeer:  "primary",
+	}
+	orch := newTestOrch(t, mock, testRemotes[:1], // just primary
+		WithMaxRetries(3),
+		WithIsRetryable(func(err error) bool { return err.Error() == "connection reset by peer" }),
+	)
+
+	result, err := orch.PushAll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.PrimaryOK() {
+		t.Error("PrimaryOK() = false after retry success")
+	}
+	if result.Results[0].Retries != 2 {
+		t.Errorf("Retries = %d, want 2", result.Results[0].Retries)
+	}
+}
+
+func TestPushAll_AllRetriesExhausted(t *testing.T) {
+	mock := newMockPusher()
+	mock.pushErrs["primary"] = errors.New("connection timeout")
+	orch := newTestOrch(t, mock, testRemotes[:1],
+		WithMaxRetries(2),
+		WithIsRetryable(func(error) bool { return true }),
+	)
+
+	result, err := orch.PushAll(context.Background())
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if result.Results[0].Retries != 2 {
+		t.Errorf("Retries = %d, want 2", result.Results[0].Retries)
+	}
+	if result.Results[0].Status != PushStatusFailed {
+		t.Errorf("Status = %q, want %q", result.Results[0].Status, PushStatusFailed)
+	}
+}
+
+func TestPushAll_NoPrimary(t *testing.T) {
+	mock := newMockPusher()
+	backupOnly := []config.RemoteConfig{
+		{Name: "backup", URL: "az://x", Role: config.RemoteRoleBackup},
+	}
+	orch := newTestOrch(t, mock, backupOnly)
+
+	_, err := orch.PushAll(context.Background())
+	if !errors.Is(err, ErrNoPrimary) {
+		t.Fatalf("expected ErrNoPrimary, got: %v", err)
+	}
+}
+
+func TestPushAll_ContextCancelled(t *testing.T) {
+	mock := newMockPusher()
+	mock.pushDelay = 50 * time.Millisecond
+
+	remotes := []config.RemoteConfig{
+		{Name: "primary", URL: "dolthub://a/b", Role: config.RemoteRolePrimary},
+		{Name: "backup1", URL: "az://x", Role: config.RemoteRoleBackup},
+		{Name: "backup2", URL: "gs://y", Role: config.RemoteRoleBackup},
+	}
+	orch := newTestOrch(t, mock, remotes)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after primary succeeds but before backups
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+
+	result, _ := orch.PushAll(ctx)
+	if !result.PrimaryOK() {
+		t.Error("PrimaryOK() should be true")
+	}
+	// At least one backup should be skipped due to cancellation
+	skipped := 0
+	for _, r := range result.Results {
+		if r.Status == PushStatusSkipped {
+			skipped++
+		}
+	}
+	if skipped == 0 {
+		t.Error("expected at least one skipped backup due to context cancellation")
+	}
+}
+
+func TestPull_RoutesToPrimary(t *testing.T) {
+	mock := newMockPusher()
+	orch := newTestOrch(t, mock, testRemotes)
+
+	_, err := orch.Pull(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mock.pullCalls) != 1 || mock.pullCalls[0] != "primary" {
+		t.Errorf("pullCalls = %v, want [primary]", mock.pullCalls)
+	}
+}
+
+func TestPull_NoPrimary(t *testing.T) {
+	mock := newMockPusher()
+	backupOnly := []config.RemoteConfig{
+		{Name: "backup", URL: "az://x", Role: config.RemoteRoleBackup},
+	}
+	orch := newTestOrch(t, mock, backupOnly)
+
+	_, err := orch.Pull(context.Background())
+	if !errors.Is(err, ErrNoPrimary) {
+		t.Fatalf("expected ErrNoPrimary, got: %v", err)
+	}
+}
+
+func TestPushAll_LockPreventsConccurrent(t *testing.T) {
+	mock := newMockPusher()
+	mock.pushDelay = 100 * time.Millisecond
+	beadsDir := t.TempDir()
+
+	orch1 := New(mock, testRemotes, beadsDir, WithRetryInterval(1*time.Millisecond))
+	orch2 := New(mock, testRemotes, beadsDir, WithRetryInterval(1*time.Millisecond))
+
+	// Start first push
+	done := make(chan error, 1)
+	go func() {
+		_, err := orch1.PushAll(context.Background())
+		done <- err
+	}()
+
+	// Give orch1 time to acquire lock
+	time.Sleep(20 * time.Millisecond)
+
+	// Second push should fail with lock error
+	_, err := orch2.PushAll(context.Background())
+	if !errors.Is(err, ErrLockHeld) {
+		t.Errorf("expected ErrLockHeld, got: %v", err)
+	}
+
+	// First push should complete
+	if err := <-done; err != nil {
+		t.Errorf("first push failed: %v", err)
+	}
+}
+
+func TestPushAll_BackupOrderIsDeterministic(t *testing.T) {
+	mock := newMockPusher()
+	remotes := []config.RemoteConfig{
+		{Name: "zeta-backup", URL: "gs://z", Role: config.RemoteRoleBackup},
+		{Name: "primary", URL: "dolthub://a/b", Role: config.RemoteRolePrimary},
+		{Name: "alpha-backup", URL: "az://a", Role: config.RemoteRoleBackup},
+	}
+	orch := newTestOrch(t, mock, remotes)
+
+	_, err := orch.PushAll(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"primary", "alpha-backup", "zeta-backup"}
+	if len(mock.pushCalls) != len(expected) {
+		t.Fatalf("pushCalls = %v, want %v", mock.pushCalls, expected)
+	}
+	for i, name := range expected {
+		if mock.pushCalls[i] != name {
+			t.Errorf("pushCalls[%d] = %q, want %q", i, mock.pushCalls[i], name)
+		}
+	}
+}
+
+func TestDefaultIsRetryable(t *testing.T) {
+	tests := []struct {
+		err       string
+		retryable bool
+	}{
+		{"connection reset by peer", true},
+		{"i/o timeout", true},
+		{"connection refused", true},
+		{"broken pipe", true},
+		{"lost connection to server", true},
+		{"bucket not found", false},
+		{"access denied", false},
+		{"permission denied", false},
+		{"syntax error", false},
+	}
+	for _, tc := range tests {
+		got := defaultIsRetryable(errors.New(tc.err))
+		if got != tc.retryable {
+			t.Errorf("defaultIsRetryable(%q) = %v, want %v", tc.err, got, tc.retryable)
+		}
+	}
+}
+
+// countingPusher fails the first N attempts for a specific peer, then succeeds.
+type countingPusher struct {
+	callCount *atomic.Int32
+	failUntil int32 // fail attempts 0..failUntil-1
+	failErr   error
+	failPeer  string
+}
+
+func (p *countingPusher) PushTo(_ context.Context, peer string) error {
+	if peer == p.failPeer {
+		n := p.callCount.Add(1)
+		if n <= p.failUntil {
+			return p.failErr
+		}
+	}
+	return nil
+}
+
+func (p *countingPusher) PullFrom(_ context.Context, _ string) ([]storage.Conflict, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

Implements the round-trip fidelity integration test requested in #3187.

### What's included

**`TestLinearRoundTripCoreFields`** — Full push→pull integration test that:
1. Seeds 3 issues with varied priority (P0/P1/P3) and status (open/in_progress/closed)
2. Pushes to a stateful mock Linear GraphQL server
3. Pulls into a fresh database
4. Asserts title, description, priority, status, and external_ref all survive the round-trip

**`TestLinearRoundTripRelationships`** — Skipped spec test documenting that parent-child hierarchy, blocking dependencies, and issue type do not yet survive a round-trip (push doesn't send parent/relation/label fields). Becomes a regression gate when those features land.

### Mock server design

The `mockLinearServer` is a stateful `httptest.Server` that:
- Only stores what the client actually sends (no fabricated fields)
- Routes by string match on GraphQL operations (no parser needed)
- Handles: issueCreate, issueUpdate, issues query, team states
- Assigns sequential identifiers (MOCK-1, MOCK-2, ...)

### Key design decisions

- **Engine-level testing** (not CLI) — wires the same hooks as `runLinearSync` but avoids global state/flag noise
- **Matches by external_ref** — pulled IDs are hash-generated so they won't match source IDs
- **Split into two tests** — keeps assertions honest by only testing what the integration actually supports today

### What's NOT asserted (documented gap)

Per the issue's assertion table, these fields are requested but push doesn't currently support them:
| Property | Current status |
|----------|---------------|
| Epic parent | Push doesn't send `parentId` |
| Dependencies | Push doesn't create relations |
| Issue type | Push doesn't send labels for type |

The skipped spec test documents this gap and will automatically become a regression gate when those features are implemented.

Closes #3187