### PR TITLE
fix: remove nonexistent -i flag from bd import references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ git commit -m "Your message"
 
 # After pull
 git pull
-bd import -i .beads/issues.jsonl  # Sync SQLite cache
+bd import .beads/issues.jsonl  # Sync Dolt database
 ```
 
 Or use the git hooks in `examples/git-hooks/` for automation.

--- a/cmd/bd/testdata/export.txt
+++ b/cmd/bd/testdata/export.txt
@@ -5,6 +5,6 @@ bd export -o export.jsonl
 exists export.jsonl
 
 # Verify the exported file contains the issue
-bd import -i export.jsonl
+bd import export.jsonl
 bd list
 stdout 'Test issue'

--- a/cmd/bd/testdata/import.txt
+++ b/cmd/bd/testdata/import.txt
@@ -1,6 +1,6 @@
 # Test bd import command
 bd init --prefix test
-bd import -i import.jsonl
+bd import import.jsonl
 bd show test-99
 stdout 'Imported issue'
 


### PR DESCRIPTION
## Summary

The `bd import` command takes a positional file argument, not a `-i` flag. Three files referenced the nonexistent flag, causing the post-merge hook to fail silently and then tell users to run a command that also fails.

## Changes

- `cmd/bd/testdata/import.txt` — `bd import -i import.jsonl` → `bd import import.jsonl`
- `cmd/bd/testdata/export.txt` — `bd import -i export.jsonl` → `bd import export.jsonl`
- `CLAUDE.md` — `bd import -i .beads/issues.jsonl` → `bd import .beads/issues.jsonl`, also updated comment from 'SQLite cache' to 'Dolt database'

## Context

After `git pull`, the old post-merge hook (which used `bd import -i`) would fail with:
```
Warning: Failed to import bd changes after merge
Run 'bd import -i .beads/issues.jsonl' manually to see the error
```

Running the suggested command gives:
```
Error: unknown shorthand flag: 'i' in -i
```

The current managed hooks (`bd hooks install`) don't have this problem, but the testdata fixtures and docs still referenced the old syntax.