### PR TITLE
fix(gitlab): wire issue link dependencies into sync pull (GH#2645)

### DIFF
--- a/internal/gitlab/mapping.go
+++ b/internal/gitlab/mapping.go
@@ -154,9 +154,12 @@ func GitLabIssueToBeads(gl *Issue, config *MappingConfig) *IssueConversion {
 		issue.UpdatedAt = *gl.UpdatedAt
 	}
 
+	// Convert issue links to dependencies if available.
+	deps := issueLinksToDependencies(gl.IID, gl.IssueLinksData, config)
+
 	return &IssueConversion{
 		Issue:        issue,
-		Dependencies: []DependencyInfo{},
+		Dependencies: deps,
 	}
 }
 

--- a/internal/gitlab/tracker.go
+++ b/internal/gitlab/tracker.go
@@ -150,6 +150,16 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 		return nil, err
 	}
 
+	// Enrich each issue with its links (dependencies).
+	for i := range issues {
+		links, err := t.client.GetIssueLinks(ctx, issues[i].IID)
+		if err != nil {
+			// Non-fatal: issue may lack link permissions or be in a different project.
+			continue
+		}
+		issues[i].IssueLinksData = links
+	}
+
 	result := make([]tracker.TrackerIssue, 0, len(issues))
 	for _, gl := range issues {
 		result = append(result, gitlabToTrackerIssue(&gl))

--- a/internal/gitlab/types.go
+++ b/internal/gitlab/types.go
@@ -82,6 +82,10 @@ type Issue struct {
 
 	// Links contains related URLs (populated in some API responses)
 	Links *IssueLinks `json:"links,omitempty"`
+
+	// IssueLinksData holds related issue links fetched via the /issues/:iid/links API.
+	// Not part of the standard issue response; populated separately during sync.
+	IssueLinksData []IssueLink `json:"-"`
 }
 
 // IssueLinks contains related URLs for an issue.


### PR DESCRIPTION
Wires existing but disconnected GitLab issue link code into the sync pull flow.

**Problem:** bd gitlab sync has GetIssueLinks() and issueLinksToDependencies() but neither is called. GitLabIssueToBeads() always returns empty deps.

**Fix (3 files, 18 lines):**
1. types.go - Add IssueLinksData field to Issue struct
2. tracker.go - Fetch links per issue in FetchIssues()
3. mapping.go - Pass links through existing issueLinksToDependencies()

Adds N API calls (one per issue, no bulk endpoint). Errors non-fatal. All 41 GitLab tests pass.

Closes #2645