### PR TITLE
fix(bootstrap): write metadata.json and config.yaml after sync clone

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage/dolt"
@@ -487,7 +488,65 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	}
 
 	dbName := cfg.GetDoltDatabase()
-	return cloneFromRemote(ctx, plan.BeadsDir, plan.SyncRemote, dbName)
+	if err := cloneFromRemote(ctx, plan.BeadsDir, plan.SyncRemote, dbName); err != nil {
+		return err
+	}
+
+	// Finalize the bootstrapped workspace so subsequent bd commands can open
+	// the cloned database. Without metadata.json and config.yaml,
+	// configfile.Load() returns nil, callers fall back to the default
+	// dolt_database name, and bd loses track of the cloned database —
+	// producing "no beads configuration found" and "Error 1105: no database
+	// selected" on bd status / bd dolt push in fresh clones. Every other
+	// bootstrap action (init, restore, jsonl-import) writes these files via
+	// newDoltStore + createConfigYaml; the sync path historically did not.
+	// (GH#3201)
+	return finalizeSyncedBootstrap(plan.BeadsDir, plan.SyncRemote, cfg, dbName)
+}
+
+// finalizeSyncedBootstrap writes metadata.json and config.yaml after a
+// successful sync clone, matching the on-disk layout that bd init produces.
+// It is idempotent: re-running over an already-finalized workspace leaves
+// existing files intact (createConfigYaml skips if config.yaml exists; the
+// metadata.json write is a full rewrite that preserves caller fields).
+func finalizeSyncedBootstrap(beadsDir, syncRemote string, cfg *configfile.Config, dbName string) error {
+	// Start from the caller's cfg (which may be DefaultConfig when
+	// metadata.json was absent, or a parent workspace config propagated by
+	// findParentConfig). Preserve whatever upstream fields were already set,
+	// then fill in the bits required by configfile.Load consumers.
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+	cfg.Backend = configfile.BackendDolt
+	cfg.DoltDatabase = dbName
+	if isEmbeddedMode() {
+		cfg.DoltMode = configfile.DoltModeEmbedded
+	} else {
+		cfg.DoltMode = configfile.DoltModeServer
+	}
+	// Mirror init's convention: metadata.json database points at the Dolt
+	// directory rather than the legacy "beads.db" placeholder.
+	if cfg.Database == "" || cfg.Database == beads.CanonicalDatabaseName {
+		cfg.Database = "dolt"
+	}
+
+	if err := cfg.Save(beadsDir); err != nil {
+		return fmt.Errorf("write metadata.json: %w", err)
+	}
+
+	if err := createConfigYaml(beadsDir, false, ""); err != nil {
+		return fmt.Errorf("create config.yaml: %w", err)
+	}
+
+	// Persist sync.remote so subsequent fresh clones (and bd bootstrap
+	// retries) can rediscover the remote without re-probing origin refs.
+	if syncRemote != "" {
+		if err := config.SetYamlConfig("sync.remote", syncRemote); err != nil {
+			return fmt.Errorf("persist sync.remote to config.yaml: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // cloneFromRemote clones a Dolt database from a remote URL.

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -945,3 +945,135 @@ func TestDetectBootstrapAction_SharedServerEnvUsesSharedPath(t *testing.T) {
 		t.Error("HasExisting = false, want true")
 	}
 }
+
+// TestFinalizeSyncedBootstrapWritesConfigFiles verifies that after a sync
+// clone, finalizeSyncedBootstrap writes the metadata.json and config.yaml
+// files bd needs to reopen the cloned database. This is the regression
+// guard for GH#3201: executeSyncAction previously left the workspace
+// without these files, causing "no beads configuration found" and
+// "Error 1105: no database selected" on every subsequent bd command.
+func TestFinalizeSyncedBootstrapWritesConfigFiles(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a post-clone workspace: cloneFromRemote created the
+	// embeddeddolt directory but no metadata.json / config.yaml exists.
+	if err := os.MkdirAll(filepath.Join(beadsDir, "embeddeddolt"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point findProjectConfigYaml at the test workspace instead of walking
+	// up from CWD, so the sync.remote write lands in the right file even
+	// when the test runs from an unrelated directory.
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	const dbName = "beads_hq"
+	const syncRemote = "file:///tmp/fake-origin.git"
+
+	cfg := configfile.DefaultConfig()
+	if err := finalizeSyncedBootstrap(beadsDir, syncRemote, cfg, dbName); err != nil {
+		t.Fatalf("finalizeSyncedBootstrap failed: %v", err)
+	}
+
+	// metadata.json must exist and record the database name bd needs to
+	// reopen the cloned data. Without this, GetDoltDatabase() falls back to
+	// DefaultDoltDatabase ("beads") and the cloned DB is unreachable.
+	loaded, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("configfile.Load after finalize failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("configfile.Load returned nil; metadata.json was not written")
+	}
+	if loaded.GetDoltDatabase() != dbName {
+		t.Errorf("dolt_database = %q, want %q", loaded.GetDoltDatabase(), dbName)
+	}
+	if loaded.GetDoltMode() != configfile.DoltModeEmbedded {
+		t.Errorf("dolt_mode = %q, want %q", loaded.GetDoltMode(), configfile.DoltModeEmbedded)
+	}
+	if loaded.GetBackend() != configfile.BackendDolt {
+		t.Errorf("backend = %q, want %q", loaded.GetBackend(), configfile.BackendDolt)
+	}
+
+	// config.yaml must exist so GetYamlConfig / SetYamlConfig and other
+	// yaml-backed settings (sync.remote, dolt.shared-server, etc.) work.
+	configYamlPath := filepath.Join(beadsDir, "config.yaml")
+	yamlBytes, err := os.ReadFile(configYamlPath)
+	if err != nil {
+		t.Fatalf("config.yaml missing after finalize: %v", err)
+	}
+	yaml := string(yamlBytes)
+
+	// sync.remote must be persisted so subsequent fresh clones (and
+	// bootstrap retries) can rediscover the remote without re-probing
+	// origin refs.
+	if !strings.Contains(yaml, "sync.remote: ") && !strings.Contains(yaml, "sync-remote: ") {
+		t.Errorf("config.yaml does not contain sync.remote entry:\n%s", yaml)
+	}
+	if !strings.Contains(yaml, syncRemote) {
+		t.Errorf("config.yaml does not contain sync remote URL %q:\n%s", syncRemote, yaml)
+	}
+}
+
+// TestFinalizeSyncedBootstrapIsIdempotent verifies that re-running the
+// finalize step over an already-finalized workspace is a no-op — the
+// clone retry path relies on this.
+func TestFinalizeSyncedBootstrapIsIdempotent(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "embeddeddolt"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	cfg := configfile.DefaultConfig()
+	if err := finalizeSyncedBootstrap(beadsDir, "file:///tmp/a.git", cfg, "beads_hq"); err != nil {
+		t.Fatalf("first finalize failed: %v", err)
+	}
+
+	firstYaml, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config.yaml after first finalize: %v", err)
+	}
+
+	if err := finalizeSyncedBootstrap(beadsDir, "file:///tmp/a.git", cfg, "beads_hq"); err != nil {
+		t.Fatalf("second finalize failed: %v", err)
+	}
+
+	secondYaml, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read config.yaml after second finalize: %v", err)
+	}
+
+	// createConfigYaml skips existing files, so the template portion must
+	// be unchanged. SetYamlConfig rewrites in place but should produce the
+	// same output for the same value.
+	if string(firstYaml) != string(secondYaml) {
+		t.Errorf("config.yaml changed on second finalize.\nfirst:\n%s\nsecond:\n%s", firstYaml, secondYaml)
+	}
+
+	// metadata.json must still load cleanly.
+	loaded, err := configfile.Load(beadsDir)
+	if err != nil || loaded == nil {
+		t.Fatalf("metadata.json missing after second finalize: %v", err)
+	}
+	if loaded.GetDoltDatabase() != "beads_hq" {
+		t.Errorf("dolt_database drifted: got %q, want %q", loaded.GetDoltDatabase(), "beads_hq")
+	}
+}


### PR DESCRIPTION
## Summary

`executeSyncAction` created `.beads/` and cloned remote Dolt data but never wrote `metadata.json` or `config.yaml`, leaving the workspace in a broken state where `bd status`, `bd where`, and `bd dolt push` all failed with `no beads configuration found` and `Error 1105: no database selected`. This broke the documented session-close protocol (`git pull --rebase` → `bd dolt push` → `git push`) on every fresh clone and worktree.

Every other bootstrap action path (init, restore, jsonl-import) writes these files through `newDoltStore` + `createConfigYaml`. The sync path was a "just clone the data" shortcut that never received the post-clone setup steps.

This PR adds a `finalizeSyncedBootstrap` helper that runs after `cloneFromRemote` and mirrors what init does: save cfg as `metadata.json`, create the `config.yaml` template, and persist `sync.remote`. The helper is idempotent so bootstrap retries remain safe.

Fixes gastownhall/gascity#561

## Root Cause

`cmd/bd/bootstrap.go:executeSyncAction` previously:

```go
func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.Config) error {
    if err := os.MkdirAll(plan.BeadsDir, 0o750); err != nil {
        return fmt.Errorf("create beads directory: %w", err)
    }
    dbName := cfg.GetDoltDatabase()
    return cloneFromRemote(ctx, plan.BeadsDir, plan.SyncRemote, dbName)
}
```

It returned immediately after `cloneFromRemote`, leaving no `metadata.json` or `config.yaml`. On the next command, `configfile.Load()` returned `nil`, `cfg.GetDoltDatabase()` fell back to the default, and opening the embedded database failed.

## Changes

- `cmd/bd/bootstrap.go`: new `finalizeSyncedBootstrap` helper called at the end of `executeSyncAction`. Writes `metadata.json` (with `dolt_database`, `dolt_mode`, `backend`, `database`), creates the `config.yaml` template via `createConfigYaml`, and persists `sync.remote` via `config.SetYamlConfig`.
- `cmd/bd/bootstrap_test.go`: two new regression tests:
  - `TestFinalizeSyncedBootstrapWritesConfigFiles` — verifies `metadata.json` records the cloned dolt_database name, `config.yaml` exists, and `sync.remote` persists.
  - `TestFinalizeSyncedBootstrapIsIdempotent` — verifies re-running the finalize step over an already-finalized workspace is a no-op.

The helper is idempotent by design: `createConfigYaml` skips existing files, and `metadata.json` is a safe rewrite that preserves upstream cfg fields.

## Test plan

- [x] `go test -tags gms_pure_go -run TestFinalizeSyncedBootstrap ./cmd/bd` — new tests pass
- [x] `go test -tags gms_pure_go -run 'TestBootstrap|TestDetectBootstrapAction|TestFinalizeSyncedBootstrap' ./cmd/bd` — all bootstrap tests pass
- [x] `go test -tags gms_pure_go -short ./cmd/bd` — full `cmd/bd` short suite passes
- [x] `go vet -tags gms_pure_go ./...` clean
- [x] `golangci-lint run --timeout=5m --build-tags=gms_pure_go ./...` — 0 issues
- [x] End-to-end manual repro: built `bd-main` and `bd-fixed`, created a source project + bare git remote, `dolt push`-ed, and bootstrapped into a fresh clone with each binary:
  - `bd-main`: reproduced the bug — `.beads/` only contained `embeddeddolt/`; `bd status` / `bd dolt push` failed with "no beads configuration found" / "Error 1105".
  - `bd-fixed`: `.beads/` contained `metadata.json` + `config.yaml` + `embeddeddolt/`; `bd status`, `bd list`, and `bd dolt push` all succeeded.

## Related

- Predecessor: gastownhall/beads#2792 (same class of "fresh clone bootstrap" bug, addressed for the directory-creation side)
- Adjacent: gastownhall/beads#3180 (config.yaml persistence for `bd init` and `bd dolt remote add`, but did not cover the sync path)