### PR TITLE
fix(formula): auto-register custom types used by formula gate steps

### DIFF
--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -478,11 +478,90 @@ func getRelativeID(oldID, rootID string) string {
 	return ""
 }
 
+// ensureSubgraphCustomTypes scans the template subgraph for issue types
+// that are not built-in and ensures they are registered as custom types
+// in the database. This is needed because formula cooking can produce
+// issues with types like "gate" (for async coordination beads) that are
+// not in the default type whitelist. Without this, cloneSubgraph fails
+// with "invalid issue type" on the first non-built-in bead. (GH#3213)
+func ensureSubgraphCustomTypes(ctx context.Context, s storage.DoltStorage, subgraph *TemplateSubgraph) error {
+	// Collect non-built-in types used by the subgraph.
+	needed := make(map[string]bool)
+	for _, issue := range subgraph.Issues {
+		t := issue.IssueType
+		if t == "" || t.IsValid() {
+			continue
+		}
+		needed[string(t)] = true
+	}
+	if len(needed) == 0 {
+		return nil
+	}
+
+	// Read the current custom types and check which are missing.
+	existing, err := s.GetConfig(ctx, "types.custom")
+	if err != nil {
+		existing = ""
+	}
+	var current []string
+	if existing != "" {
+		// parseTypesValue handles both JSON arrays and comma-separated.
+		// It's in issueops — but we don't import that package here, so
+		// do a simple comma split (good enough for the merge check).
+		for _, t := range strings.Split(strings.Trim(existing, "[] \""), ",") {
+			t = strings.Trim(t, " \"")
+			if t != "" {
+				current = append(current, t)
+			}
+		}
+	}
+	currentSet := make(map[string]bool, len(current))
+	for _, t := range current {
+		currentSet[t] = true
+	}
+
+	var toAdd []string
+	for t := range needed {
+		if !currentSet[t] {
+			toAdd = append(toAdd, t)
+		}
+	}
+	if len(toAdd) == 0 {
+		return nil
+	}
+
+	// Merge and write back. SetConfig triggers SyncCustomTypesTable
+	// which populates the normalized custom_types table used by
+	// PrepareIssueForInsert → ValidateWithCustom.
+	merged := append(current, toAdd...)
+	// Serialize as JSON array for consistency with bd config set.
+	var buf strings.Builder
+	buf.WriteString("[")
+	for i, t := range merged {
+		if i > 0 {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\"")
+		buf.WriteString(t)
+		buf.WriteString("\"")
+	}
+	buf.WriteString("]")
+	return s.SetConfig(ctx, "types.custom", buf.String())
+}
+
 // cloneSubgraph creates new issues from the template with variable substitution.
 // Uses CloneOptions to control all spawn/bond behavior including dynamic bonding.
 func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *TemplateSubgraph, opts CloneOptions) (*InstantiateResult, error) {
 	if s == nil {
 		return nil, fmt.Errorf("no database connection")
+	}
+
+	// Auto-register any non-built-in issue types used by the subgraph
+	// so that formula-generated beads (e.g., type "gate" for async
+	// coordination) pass type validation without requiring the operator
+	// to run `bd config set types.custom` manually first. See GH#3213.
+	if err := ensureSubgraphCustomTypes(ctx, s, subgraph); err != nil {
+		return nil, fmt.Errorf("registering custom types for subgraph: %w", err)
 	}
 
 	// Generate new IDs and create mapping

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -210,6 +210,29 @@ func parseTypesValue(value string) []string {
 	return ParseCommaSeparatedList(value)
 }
 
+// EnsureCustomTypeInTx registers name as a custom type if it is not
+// already a built-in type and not already in the custom_types table.
+// This is used by bd mol pour/wisp to auto-register types that the
+// formula system creates implicitly (e.g. "gate" for async coordination
+// beads) so that operators don't have to run bd config set types.custom
+// manually before pouring a formula with gate steps. See GH#3213.
+func EnsureCustomTypeInTx(ctx context.Context, tx *sql.Tx, name string) error {
+	if types.IssueType(name).IsValid() {
+		return nil
+	}
+	existing, err := ResolveCustomTypesInTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	for _, t := range existing {
+		if t == name {
+			return nil
+		}
+	}
+	_, err = tx.ExecContext(ctx, "INSERT INTO custom_types (name) VALUES (?)", name)
+	return err
+}
+
 // ResolveInfraTypesInTx reads infrastructure types from the database,
 // falling back to config.yaml then to hardcoded defaults.
 // Returns a map[string]bool for O(1) lookups.


### PR DESCRIPTION
## Summary

- `bd mol pour` fails with `invalid issue type: gate` when a formula has `gate = { type = "human" }` steps, because `gate` was removed from the built-in type whitelist and the formula-pour code doesn't ensure it's registered as a custom type.
- Add `ensureSubgraphCustomTypes()` in `cloneSubgraph` that scans template issues for non-built-in types and auto-registers any missing ones via `SetConfig("types.custom", ...)` before the clone transaction runs.
- Also adds `EnsureCustomTypeInTx` helper in `issueops/config_helpers.go` for callers that already hold a transaction.
- Applies to both `bd mol pour` and `bd mol wisp` since both go through `cloneSubgraph`.

## Context

This is the same class of issue as #3030 — the type `gate` is in the "orchestrator types" bucket that was deliberately moved to custom types (see the comment block at `types.go:542`), but the formula cook pipeline (`cook.go:509`) creates gate companion beads with `IssueType: "gate"` without ensuring the type exists. The current workaround is `bd config set types.custom '["gate"]'`, which is a papercut for first-time formula users.

Related: the gate embedded tests (`gate_embedded_test.go:84-86`) already do this registration explicitly before creating gate beads, confirming the expected pattern.

## Test plan

- [x] `make build` succeeds (pure Go, `gms_pure_go` tag)
- [x] `go vet ./cmd/bd/` clean
- [x] `TestCookFormulaToSubgraph_GateBeads` passes (gate companion beads cooked correctly)
- [x] `TestCookFormulaToSubgraph_GateDependencies` passes (gate deps wired correctly)
- [x] `TestCookFormulaToSubgraph_GateParentChild` passes
- [ ] Embedded-mode pour test with gate formula (requires ICU headers not available on this machine — CI should cover this)
- [ ] Manual verification: pour a formula with gate steps on a fresh db (no `types.custom` set) — should succeed without the workaround

Fixes #3213

🤖 Generated with [Claude Code](https://claude.com/claude-code)