### PR TITLE
Fix orphan dependency doctor checks for tracks and wisps

### DIFF
--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -36,13 +36,20 @@ func OrphanedDependencies(path string, verbose bool) error {
 	}
 	defer db.Close()
 
-	// Find orphaned dependencies (exclude external: cross-rig tracking refs, #1593)
+	// Find orphaned dependencies.
+	// Exclude:
+	// - external: cross-rig tracking refs (#1593)
+	// - tracks deps, which intentionally point at work in other stores
+	// - wisp-backed deps, since formula molecules live in wisps, not issues
 	query := `
 		SELECT d.issue_id, d.depends_on_id
 		FROM dependencies d
 		LEFT JOIN issues i ON d.depends_on_id = i.id
+		LEFT JOIN wisps w ON d.depends_on_id = w.id
 		WHERE i.id IS NULL
+		  AND w.id IS NULL
 		  AND d.depends_on_id NOT LIKE 'external:%'
+		  AND d.type != 'tracks'
 	`
 	rows, err := db.Query(query)
 	if err != nil {

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -37,6 +37,9 @@ func OrphanedDependencies(path string, verbose bool) error {
 	defer db.Close()
 
 	// Find orphaned dependencies.
+	// Fork note: GT towns intentionally create cross-store tracks deps and
+	// wisp-backed molecule deps; treating them as ordinary orphans made doctor
+	// --fix delete valid orchestration edges.
 	// Exclude:
 	// - external: cross-rig tracking refs (#1593)
 	// - tracks deps, which intentionally point at work in other stores

--- a/cmd/bd/doctor/fix/validation_test.go
+++ b/cmd/bd/doctor/fix/validation_test.go
@@ -224,6 +224,58 @@ func TestChildParentDependencies_FixesBadDeps(t *testing.T) {
 	}
 }
 
+func TestOrphanedDependencies_IgnoresTracksAndWispDeps(t *testing.T) {
+	dir := t.TempDir()
+	store := newFixTestStore(t, dir, "bd")
+	ctx := context.Background()
+
+	issue := &types.Issue{
+		ID:        "bd-123",
+		Title:     "Issue bd-123",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		CreatedAt: time.Now(),
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	db := store.UnderlyingDB()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tx.Exec("INSERT INTO wisps (id, title) VALUES (?, ?)", "bd-wisp-1", "molecule")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tx.Exec("INSERT INTO dependencies (issue_id, depends_on_id, type, created_by) VALUES (?, ?, ?, ?)",
+		issue.ID, "foreign-456", "tracks", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tx.Exec("INSERT INTO dependencies (issue_id, depends_on_id, type, created_by) VALUES (?, ?, ?, ?)",
+		issue.ID, "bd-wisp-1", "blocks", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := OrphanedDependencies(dir, false); err != nil {
+		t.Fatalf("OrphanedDependencies failed: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM dependencies").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("expected both intentional deps to remain, got %d", count)
+	}
+}
+
 // TestChildParentDependencies_PreservesParentChildType verifies that legitimate
 // parent-child type dependencies are NOT removed (only blocking types are removed).
 func TestChildParentDependencies_PreservesParentChildType(t *testing.T) {

--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -55,15 +55,19 @@ func CheckOrphanedDependencies(path string) DoctorCheck {
 // checkOrphanedDependenciesDB is the core logic for CheckOrphanedDependencies.
 func checkOrphanedDependenciesDB(db *sql.DB) DoctorCheck {
 	// Query for orphaned dependencies.
-	// Exclude external: refs — these are synthetic cross-rig tracking deps
-	// injected by the JSONL exporter and intentionally reference issues not
-	// present in the local database (#1593).
+	// Exclude:
+	// - external: refs, which are synthetic cross-rig tracking deps
+	// - tracks deps, which intentionally point at work tracked in other stores
+	// - wisp-backed deps, since formula molecules live in wisps, not issues
 	query := `
 		SELECT d.issue_id, d.depends_on_id, d.type
 		FROM dependencies d
 		LEFT JOIN issues i ON d.depends_on_id = i.id
+		LEFT JOIN wisps w ON d.depends_on_id = w.id
 		WHERE i.id IS NULL
+		  AND w.id IS NULL
 		  AND d.depends_on_id NOT LIKE 'external:%'
+		  AND d.type != 'tracks'
 	`
 	rows, err := db.Query(query)
 	if err != nil {

--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -55,6 +55,9 @@ func CheckOrphanedDependencies(path string) DoctorCheck {
 // checkOrphanedDependenciesDB is the core logic for CheckOrphanedDependencies.
 func checkOrphanedDependenciesDB(db *sql.DB) DoctorCheck {
 	// Query for orphaned dependencies.
+	// Fork note: GT towns intentionally create cross-store tracks deps and
+	// wisp-backed molecule deps; treating them as ordinary orphans made doctor
+	// report false positives and suggest unsafe cleanup.
 	// Exclude:
 	// - external: refs, which are synthetic cross-rig tracking deps
 	// - tracks deps, which intentionally point at work tracked in other stores

--- a/cmd/bd/doctor_validate_test.go
+++ b/cmd/bd/doctor_validate_test.go
@@ -138,6 +138,57 @@ func TestValidateCheck_DetectsOrphanedDeps(t *testing.T) {
 	t.Error("Orphaned Dependencies check not found")
 }
 
+func TestValidateCheck_IgnoresTracksAndWispDeps(t *testing.T) {
+	tmpDir, store := setupValidateTestDB(t, "test")
+	ctx := context.Background()
+
+	issue := &types.Issue{
+		Title:     "Tracked issue",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("Failed to create issue: %v", err)
+	}
+
+	db := store.UnderlyingDB()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction: %v", err)
+	}
+	_, err = tx.Exec("INSERT INTO wisps (id, title) VALUES (?, ?)", "test-wisp-1", "molecule")
+	if err != nil {
+		t.Fatalf("Failed to insert wisp: %v", err)
+	}
+	_, err = tx.Exec("INSERT INTO dependencies (issue_id, depends_on_id, type, created_by) VALUES (?, ?, ?, ?)",
+		issue.ID, "foreign-123", "tracks", "test")
+	if err != nil {
+		t.Fatalf("Failed to insert tracks dep: %v", err)
+	}
+	_, err = tx.Exec("INSERT INTO dependencies (issue_id, depends_on_id, type, created_by) VALUES (?, ?, ?, ?)",
+		issue.ID, "test-wisp-1", "blocks", "test")
+	if err != nil {
+		t.Fatalf("Failed to insert wisp dep: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit deps: %v", err)
+	}
+	store.Close()
+
+	checks := collectValidateChecks(tmpDir)
+
+	for _, cr := range checks {
+		if cr.check.Name == "Orphaned Dependencies" {
+			if cr.check.Status != statusOK {
+				t.Fatalf("Orphaned Dependencies status = %q, want %q (message: %s, detail: %s)", cr.check.Status, statusOK, cr.check.Message, cr.check.Detail)
+			}
+			return
+		}
+	}
+	t.Error("Orphaned Dependencies check not found")
+}
+
 func TestValidateCheck_GitConflicts_DoltClean(t *testing.T) {
 	// Since GetBackend() always returns "dolt" (SQLite removed in 87493ce9),
 	// the Git Conflicts check now queries dolt_conflicts (GH-2249).

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -8,8 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
+	doltstorage "github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/utils"
 )
@@ -63,14 +65,194 @@ func sameBeadsDir(a, b string) bool {
 	return utils.NormalizePathForComparison(a) == utils.NormalizePathForComparison(b)
 }
 
+func findTownRootFromBeadsDir(beadsDir string) string {
+	current := filepath.Dir(beadsDir)
+	for {
+		if _, err := os.Stat(filepath.Join(current, "mayor", "town.json")); err == nil {
+			return current
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return filepath.Dir(beadsDir)
+		}
+		current = parent
+	}
+}
+
+func loadRoutePathFromStore(ctx context.Context, localStore storage.DoltStorage, prefix string) (string, bool) {
+	rawStore := storage.UnwrapStore(localStore)
+	rawDB, ok := rawStore.(storage.RawDBAccessor)
+	if !ok {
+		if os.Getenv("BD_DEBUG_ROUTING") != "" {
+			fmt.Fprintf(os.Stderr, "[routing] store %T does not expose RawDBAccessor after unwrap (%T)\n", localStore, rawStore)
+		}
+		return "", false
+	}
+
+	db := rawDB.UnderlyingDB()
+	if db == nil {
+		db = rawDB.DB()
+	}
+	if db == nil {
+		return "", false
+	}
+
+	var routePath string
+	if err := db.QueryRowContext(ctx, "SELECT path FROM routes WHERE prefix = ?", prefix).Scan(&routePath); err != nil {
+		if os.Getenv("BD_DEBUG_ROUTING") != "" {
+			fmt.Fprintf(os.Stderr, "[routing] routes table lookup for %q failed: %v\n", prefix, err)
+		}
+		return "", false
+	}
+	if os.Getenv("BD_DEBUG_ROUTING") != "" {
+		fmt.Fprintf(os.Stderr, "[routing] routes table matched %q -> %q\n", prefix, routePath)
+	}
+	return routePath, routePath != ""
+}
+
+func resolveRouteBeadsDirPath(townRoot, routePath string) string {
+	if routePath == "" {
+		return ""
+	}
+	if routePath == "." {
+		if townRoot == "" {
+			return ""
+		}
+		return filepath.Join(townRoot, ".beads")
+	}
+
+	resolved := routePath
+	if !filepath.IsAbs(resolved) {
+		if townRoot == "" {
+			return ""
+		}
+		resolved = filepath.Join(townRoot, resolved)
+	}
+	if filepath.Base(resolved) == ".beads" {
+		return resolved
+	}
+	return filepath.Join(resolved, ".beads")
+}
+
+func databaseCandidatesFromRoutePath(townRoot, routePath string) []string {
+	addCandidate := func(seen map[string]struct{}, candidates []string, candidate string) []string {
+		candidate = strings.TrimSpace(candidate)
+		switch candidate {
+		case "", ".", "..", ".beads", "mayor", "rig":
+			return candidates
+		}
+		if _, exists := seen[candidate]; exists {
+			return candidates
+		}
+		seen[candidate] = struct{}{}
+		return append(candidates, candidate)
+	}
+
+	cleaned := filepath.Clean(routePath)
+	seen := make(map[string]struct{})
+	candidates := make([]string, 0, 2)
+
+	if filepath.IsAbs(cleaned) && townRoot != "" {
+		if rel, err := filepath.Rel(townRoot, cleaned); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			parts := strings.Split(filepath.ToSlash(rel), "/")
+			if len(parts) > 0 {
+				candidates = addCandidate(seen, candidates, parts[0])
+			}
+		}
+	}
+
+	if !filepath.IsAbs(cleaned) {
+		parts := strings.Split(filepath.ToSlash(cleaned), "/")
+		if len(parts) > 0 {
+			candidates = addCandidate(seen, candidates, parts[0])
+		}
+	}
+
+	base := filepath.Base(cleaned)
+	if base == ".beads" {
+		base = filepath.Base(filepath.Dir(cleaned))
+	}
+	candidates = addCandidate(seen, candidates, base)
+
+	return candidates
+}
+
+func openNamedDatabaseStore(ctx context.Context, currentBeadsDir, verificationBeadsDir, database string) (storage.DoltStorage, error) {
+	cfg, err := configfile.Load(currentBeadsDir)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil || !cfg.IsDoltServerMode() {
+		return nil, fmt.Errorf("current workspace is not in dolt server mode")
+	}
+
+	return doltstorage.NewFromConfigWithOptions(ctx, currentBeadsDir, &doltstorage.Config{
+		Database: database,
+		BeadsDir: verificationBeadsDir,
+	})
+}
+
+func openRouteTableFallbackStore(ctx context.Context, localStore storage.DoltStorage, currentBeadsDir, id string) (storage.DoltStorage, bool) {
+	prefix := types.ExtractPrefix(id)
+	if prefix == "" {
+		return nil, false
+	}
+
+	routePath, ok := loadRoutePathFromStore(ctx, localStore, prefix)
+	if !ok {
+		return nil, false
+	}
+
+	townRoot := findTownRootFromBeadsDir(currentBeadsDir)
+	targetBeadsDir := resolveRouteBeadsDirPath(townRoot, routePath)
+	if targetBeadsDir != "" && !sameBeadsDir(targetBeadsDir, currentBeadsDir) {
+		if info, err := os.Stat(targetBeadsDir); err == nil && info.IsDir() {
+			cfg, cfgErr := configfile.Load(targetBeadsDir)
+			if cfgErr == nil && cfg != nil {
+				routedStore, err := newDoltStoreFromConfig(ctx, targetBeadsDir)
+				if err == nil {
+					return routedStore, true
+				}
+				if os.Getenv("BD_DEBUG_ROUTING") != "" {
+					fmt.Fprintf(os.Stderr, "[routing] routes table matched %q -> %q but open failed: %v\n", prefix, targetBeadsDir, err)
+				}
+			} else if os.Getenv("BD_DEBUG_ROUTING") != "" {
+				fmt.Fprintf(os.Stderr, "[routing] routes table matched %q -> %q but metadata is unavailable (cfg=%v err=%v); trying database fallback\n", prefix, targetBeadsDir, cfg != nil, cfgErr)
+			}
+		}
+	}
+
+	for _, database := range databaseCandidatesFromRoutePath(townRoot, routePath) {
+		routedStore, err := openNamedDatabaseStore(ctx, currentBeadsDir, targetBeadsDir, database)
+		if err == nil {
+			if os.Getenv("BD_DEBUG_ROUTING") != "" {
+				fmt.Fprintf(os.Stderr, "[routing] routes table matched %q -> database %q via %q\n", prefix, database, routePath)
+			}
+			return routedStore, true
+		}
+		if os.Getenv("BD_DEBUG_ROUTING") != "" {
+			fmt.Fprintf(os.Stderr, "[routing] routes table matched %q but database %q failed: %v\n", prefix, database, err)
+		}
+	}
+
+	return nil, false
+}
+
 // openPrefixRoutedStore reopens the authoritative store for a routed issue ID when
 // routes.jsonl says the bead lives in a different rig database.
-func openPrefixRoutedStore(ctx context.Context, id string) (storage.DoltStorage, bool, error) {
+func openPrefixRoutedStore(ctx context.Context, localStore storage.DoltStorage, id string) (storage.DoltStorage, bool, error) {
+	if os.Getenv("BD_DEBUG_ROUTING") != "" {
+		fmt.Fprintf(os.Stderr, "[routing] openPrefixRoutedStore id=%q dbPath=%q beadsDirOverride=%v store=%T\n", id, dbPath, beadsDirOverride(), localStore)
+	}
 	if dbPath == "" || beadsDirOverride() {
 		return nil, false, nil
 	}
 
 	currentBeadsDir := currentCommandBeadsDir()
+	if os.Getenv("BD_DEBUG_ROUTING") != "" {
+		fmt.Fprintf(os.Stderr, "[routing] current command beads dir=%q\n", currentBeadsDir)
+	}
 	if currentBeadsDir == "" {
 		return nil, false, nil
 	}
@@ -79,15 +261,19 @@ func openPrefixRoutedStore(ctx context.Context, id string) (storage.DoltStorage,
 	targetBeadsDir, routed, err := routing.ResolveBeadsDirForID(ctx, id, currentBeadsDir)
 	redirectedDatabase := os.Getenv("BEADS_DOLT_SERVER_DATABASE") != "" &&
 		os.Getenv("BEADS_DOLT_SERVER_DATABASE") != beforeDatabase
-	if err != nil || !routed || (!redirectedDatabase && sameBeadsDir(targetBeadsDir, currentBeadsDir)) {
-		return nil, false, err
+	if err == nil && routed && (redirectedDatabase || !sameBeadsDir(targetBeadsDir, currentBeadsDir)) {
+		routedStore, err := newDoltStoreFromConfig(ctx, targetBeadsDir)
+		if err != nil {
+			return nil, false, fmt.Errorf("opening routed store at %s: %w", targetBeadsDir, err)
+		}
+		return routedStore, true, nil
 	}
 
-	routedStore, err := newDoltStoreFromConfig(ctx, targetBeadsDir)
-	if err != nil {
-		return nil, false, fmt.Errorf("opening routed store at %s: %w", targetBeadsDir, err)
+	if fallbackStore, fallbackRouted := openRouteTableFallbackStore(ctx, localStore, currentBeadsDir, id); fallbackRouted {
+		return fallbackStore, true, nil
 	}
-	return routedStore, true, nil
+
+	return nil, false, err
 }
 
 // resolveAndGetIssueWithRouting resolves a partial ID and gets the issue.
@@ -97,7 +283,7 @@ func openPrefixRoutedStore(ctx context.Context, id string) (storage.DoltStorage,
 // Returns a RoutedResult containing the issue, resolved ID, and the store to use.
 // The caller MUST call result.Close() when done to release any routed storage.
 func resolveAndGetIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
-	if routedStore, routed, err := openPrefixRoutedStore(ctx, id); err != nil {
+	if routedStore, routed, err := openPrefixRoutedStore(ctx, localStore, id); err != nil {
 		return nil, err
 	} else if routed {
 		result, resolveErr := resolveAndGetFromStore(ctx, routedStore, id, true)
@@ -172,7 +358,7 @@ func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, 
 // Returns a RoutedResult containing the issue and the store to use for related queries.
 // The caller MUST call result.Close() when done to release any routed storage.
 func getIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
-	if routedStore, routed, err := openPrefixRoutedStore(ctx, id); err != nil {
+	if routedStore, routed, err := openPrefixRoutedStore(ctx, localStore, id); err != nil {
 		return nil, err
 	} else if routed {
 		issue, getErr := routedStore.GetIssue(ctx, id)

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -193,6 +193,10 @@ func openNamedDatabaseStore(ctx context.Context, currentBeadsDir, verificationBe
 	})
 }
 
+// Fork note: after rig recovery we saw towns where routes.jsonl had gone stale
+// while the authoritative routes table still knew which rig owned a prefix.
+// This fallback keeps routed lookups working instead of failing every cross-rig
+// show/update/dep operation until the projection is rebuilt.
 func openRouteTableFallbackStore(ctx context.Context, localStore storage.DoltStorage, currentBeadsDir, id string) (storage.DoltStorage, bool) {
 	prefix := types.ExtractPrefix(id)
 	if prefix == "" {

--- a/cmd/bd/routed.go
+++ b/cmd/bd/routed.go
@@ -1,17 +1,14 @@
 package main
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/steveyegge/beads/internal/beads"
-	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/utils"
@@ -30,6 +27,12 @@ func isNotFoundErr(err error) bool {
 	return false
 }
 
+// beadsDirOverride returns true if BEADS_DIR explicitly pins the active database.
+// When set, prefix routing must stay disabled and callers should use the local store.
+func beadsDirOverride() bool {
+	return os.Getenv("BEADS_DIR") != ""
+}
+
 // RoutedResult contains the result of a routed issue lookup
 type RoutedResult struct {
 	Issue      *types.Issue
@@ -46,29 +49,73 @@ func (r *RoutedResult) Close() {
 	}
 }
 
+func currentCommandBeadsDir() string {
+	if dbPath == "" {
+		return ""
+	}
+	if beadsDir := resolveCommandBeadsDir(dbPath); beadsDir != "" {
+		return beadsDir
+	}
+	return filepath.Dir(dbPath)
+}
+
+func sameBeadsDir(a, b string) bool {
+	return utils.NormalizePathForComparison(a) == utils.NormalizePathForComparison(b)
+}
+
+// openPrefixRoutedStore reopens the authoritative store for a routed issue ID when
+// routes.jsonl says the bead lives in a different rig database.
+func openPrefixRoutedStore(ctx context.Context, id string) (storage.DoltStorage, bool, error) {
+	if dbPath == "" || beadsDirOverride() {
+		return nil, false, nil
+	}
+
+	currentBeadsDir := currentCommandBeadsDir()
+	if currentBeadsDir == "" {
+		return nil, false, nil
+	}
+
+	beforeDatabase := os.Getenv("BEADS_DOLT_SERVER_DATABASE")
+	targetBeadsDir, routed, err := routing.ResolveBeadsDirForID(ctx, id, currentBeadsDir)
+	redirectedDatabase := os.Getenv("BEADS_DOLT_SERVER_DATABASE") != "" &&
+		os.Getenv("BEADS_DOLT_SERVER_DATABASE") != beforeDatabase
+	if err != nil || !routed || (!redirectedDatabase && sameBeadsDir(targetBeadsDir, currentBeadsDir)) {
+		return nil, false, err
+	}
+
+	routedStore, err := newDoltStoreFromConfig(ctx, targetBeadsDir)
+	if err != nil {
+		return nil, false, fmt.Errorf("opening routed store at %s: %w", targetBeadsDir, err)
+	}
+	return routedStore, true, nil
+}
+
 // resolveAndGetIssueWithRouting resolves a partial ID and gets the issue.
-// Tries the local store first, then prefix-based routing via routes.jsonl,
-// then falls back to contributor auto-routing.
+// Prefix-routed IDs reopen the owning rig store directly; otherwise this falls
+// back to the local store and contributor auto-routing.
 //
 // Returns a RoutedResult containing the issue, resolved ID, and the store to use.
 // The caller MUST call result.Close() when done to release any routed storage.
 func resolveAndGetIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
+	if routedStore, routed, err := openPrefixRoutedStore(ctx, id); err != nil {
+		return nil, err
+	} else if routed {
+		result, resolveErr := resolveAndGetFromStore(ctx, routedStore, id, true)
+		if resolveErr != nil {
+			_ = routedStore.Close()
+			return nil, resolveErr
+		}
+		result.closeFn = func() { _ = routedStore.Close() }
+		return result, nil
+	}
+
 	// Try local store first.
 	result, err := resolveAndGetFromStore(ctx, localStore, id, false)
 	if err == nil {
 		return result, nil
 	}
 
-	// If not found locally, try prefix-based routing via routes.jsonl.
-	// This handles cross-rig lookups where the ID's prefix maps to a different
-	// database (e.g., hr-8wn.1 routes to the herald rig's database).
-	if isNotFoundErr(err) {
-		if prefixResult, prefixErr := resolveViaPrefixRouting(ctx, id); prefixErr == nil {
-			return prefixResult, nil
-		}
-	}
-
-	// If not found via prefix routing, try contributor auto-routing as fallback (GH#2345).
+	// If not found locally, try contributor auto-routing as fallback (GH#2345).
 	if isNotFoundErr(err) {
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil
@@ -118,163 +165,30 @@ func resolveViaAutoRouting(ctx context.Context, localStore storage.DoltStorage, 
 	return result, nil
 }
 
-// prefixRoute represents a prefix-to-path routing rule from routes.jsonl.
-type prefixRoute struct {
-	Prefix string `json:"prefix"` // Issue ID prefix (e.g., "hr-")
-	Path   string `json:"path"`   // Relative path to rig directory from town root
-}
-
-// resolveViaPrefixRouting attempts to find an issue by looking up its prefix
-// in routes.jsonl and opening the target rig's database.
-//
-// This enables cross-rig lookups: when running from a redirected .beads directory
-// (e.g., crew/beercan → town/.beads with database "hq"), a bead ID like "hr-8wn.1"
-// can be resolved by following the "hr-" route to the herald rig's .beads directory,
-// which declares dolt_database="herald".
-func resolveViaPrefixRouting(ctx context.Context, id string) (*RoutedResult, error) {
-	// Extract prefix from the bead ID (e.g., "hr-" from "hr-8wn.1")
-	prefix := extractBeadPrefix(id)
-	if prefix == "" {
-		return nil, fmt.Errorf("no prefix in ID %q", id)
-	}
-
-	// Find the resolved beads directory (where routes.jsonl lives)
-	currentBeadsDir := resolveCommandBeadsDir(dbPath)
-	if currentBeadsDir == "" {
-		return nil, fmt.Errorf("no beads directory available")
-	}
-
-	// Load routes from routes.jsonl
-	routes, err := loadPrefixRoutes(currentBeadsDir)
-	if err != nil || len(routes) == 0 {
-		return nil, fmt.Errorf("no routes available")
-	}
-
-	// Find matching route for this prefix
-	var matchedRoute *prefixRoute
-	for i, r := range routes {
-		if r.Prefix == prefix {
-			matchedRoute = &routes[i]
-			break
-		}
-	}
-	if matchedRoute == nil {
-		return nil, fmt.Errorf("no route for prefix %q", prefix)
-	}
-
-	// Skip if the route points to current directory (town-level, already checked)
-	if matchedRoute.Path == "." {
-		return nil, fmt.Errorf("route points to current database")
-	}
-
-	// Derive the town root from the current beads dir.
-	// currentBeadsDir is typically <town_root>/.beads
-	townRoot := filepath.Dir(currentBeadsDir)
-
-	// Resolve the target rig's .beads directory
-	rigDir := filepath.Join(townRoot, matchedRoute.Path)
-	targetBeadsDir := beads.FollowRedirect(filepath.Join(rigDir, ".beads"))
-
-	// Check that the target has a different dolt_database
-	targetDB := readDoltDatabase(targetBeadsDir)
-	if targetDB == "" {
-		return nil, fmt.Errorf("target rig has no dolt_database configured")
-	}
-
-	debug.Logf("[routing] Prefix %q matched route to %s (database: %s)\n", prefix, matchedRoute.Path, targetDB)
-
-	// Open a read-only store for the target database.
-	// We need to temporarily override BEADS_DOLT_SERVER_DATABASE so the store
-	// connects to the correct database on the shared Dolt server.
-	origDB := os.Getenv("BEADS_DOLT_SERVER_DATABASE")
-	_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", targetDB)
-	targetStore, err := newReadOnlyStoreFromConfig(ctx, targetBeadsDir)
-	// Restore the original env var
-	if origDB != "" {
-		_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", origDB)
-	} else {
-		_ = os.Unsetenv("BEADS_DOLT_SERVER_DATABASE")
-	}
-	if err != nil {
-		return nil, fmt.Errorf("opening routed store for %s: %w", matchedRoute.Path, err)
-	}
-
-	result, err := resolveAndGetFromStore(ctx, targetStore, id, true)
-	if err != nil {
-		_ = targetStore.Close()
-		return nil, err
-	}
-	result.closeFn = func() { _ = targetStore.Close() }
-
-	if os.Getenv("BD_DEBUG_ROUTING") != "" {
-		fmt.Fprintf(os.Stderr, "[routing] Resolved %s via prefix route to %s (database: %s)\n", id, matchedRoute.Path, targetDB)
-	}
-
-	return result, nil
-}
-
-// extractBeadPrefix extracts the prefix from a bead ID.
-// For example, "hr-8wn.1" returns "hr-", "hq-cv-abc" returns "hq-".
-func extractBeadPrefix(beadID string) string {
-	if beadID == "" {
-		return ""
-	}
-	idx := strings.Index(beadID, "-")
-	if idx <= 0 {
-		return ""
-	}
-	return beadID[:idx+1]
-}
-
-// loadPrefixRoutes loads prefix-to-path routes from routes.jsonl in the beads directory.
-func loadPrefixRoutes(beadsDir string) ([]prefixRoute, error) {
-	routesPath := filepath.Join(beadsDir, "routes.jsonl")
-	file, err := os.Open(routesPath) //nolint:gosec // G304: path is constructed from trusted beads directory
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var routes []prefixRoute
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		var route prefixRoute
-		if err := json.Unmarshal([]byte(line), &route); err != nil {
-			continue
-		}
-		if route.Prefix != "" && route.Path != "" {
-			routes = append(routes, route)
-		}
-	}
-	return routes, scanner.Err()
-}
-
-// readDoltDatabase reads the dolt_database field from a .beads/metadata.json file.
-func readDoltDatabase(beadsDir string) string {
-	metadataPath := filepath.Join(beadsDir, "metadata.json")
-	data, err := os.ReadFile(metadataPath) //nolint:gosec // G304: path is constructed from trusted beads directory
-	if err != nil {
-		return ""
-	}
-	var meta struct {
-		DoltDatabase string `json:"dolt_database"`
-	}
-	if json.Unmarshal(data, &meta) != nil {
-		return ""
-	}
-	return meta.DoltDatabase
-}
-
 // getIssueWithRouting gets an issue by exact ID.
-// Tries the local store first, then prefix-based routing, then contributor auto-routing.
+// Prefix-routed IDs reopen the owning rig store directly; otherwise this falls
+// back to the local store and contributor auto-routing.
 //
 // Returns a RoutedResult containing the issue and the store to use for related queries.
 // The caller MUST call result.Close() when done to release any routed storage.
 func getIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id string) (*RoutedResult, error) {
+	if routedStore, routed, err := openPrefixRoutedStore(ctx, id); err != nil {
+		return nil, err
+	} else if routed {
+		issue, getErr := routedStore.GetIssue(ctx, id)
+		if getErr != nil {
+			_ = routedStore.Close()
+			return nil, getErr
+		}
+		return &RoutedResult{
+			Issue:      issue,
+			Store:      routedStore,
+			Routed:     true,
+			ResolvedID: id,
+			closeFn:    func() { _ = routedStore.Close() },
+		}, nil
+	}
+
 	// Try local store first.
 	issue, err := localStore.GetIssue(ctx, id)
 	if err == nil {
@@ -286,14 +200,7 @@ func getIssueWithRouting(ctx context.Context, localStore storage.DoltStorage, id
 		}, nil
 	}
 
-	// If not found locally, try prefix-based routing via routes.jsonl.
-	if isNotFoundErr(err) {
-		if prefixResult, prefixErr := resolveViaPrefixRouting(ctx, id); prefixErr == nil {
-			return prefixResult, nil
-		}
-	}
-
-	// If not found via prefix routing, try contributor auto-routing as fallback (GH#2345).
+	// If not found locally, try contributor auto-routing as fallback (GH#2345).
 	if isNotFoundErr(err) {
 		if autoResult, autoErr := resolveViaAutoRouting(ctx, localStore, id); autoErr == nil {
 			return autoResult, nil

--- a/cmd/bd/routed_routes_table_fallback_test.go
+++ b/cmd/bd/routed_routes_table_fallback_test.go
@@ -1,0 +1,112 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestResolveAndGetIssueWithRouting_FallsBackToRoutesTableDatabase(t *testing.T) {
+	ensureTestMode(t)
+
+	if testDoltServerPort == 0 {
+		t.Skip("Dolt test server not available, skipping")
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir town .beads: %v", err)
+	}
+
+	townDBPath := filepath.Join(townBeadsDir, "dolt")
+	townStore := newTestStoreIsolatedDB(t, townDBPath, "hq")
+
+	remoteDBName := uniqueTestDBName(t)
+	remoteDBPath := filepath.Join(tmpDir, "shadow", ".beads", "dolt")
+	writeTestMetadata(t, remoteDBPath, remoteDBName)
+
+	doltNewMutex.Lock()
+	remoteStore, err := dolt.New(ctx, &dolt.Config{
+		Path:            remoteDBPath,
+		ServerHost:      "127.0.0.1",
+		ServerPort:      testDoltServerPort,
+		Database:        remoteDBName,
+		CreateIfMissing: true,
+	})
+	doltNewMutex.Unlock()
+	if err != nil {
+		t.Fatalf("create remote store: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = remoteStore.Close()
+		dropTestDatabase(remoteDBName, testDoltServerPort)
+	})
+
+	if err := remoteStore.SetConfig(ctx, "issue_prefix", "gj"); err != nil {
+		t.Fatalf("set remote issue_prefix: %v", err)
+	}
+
+	issue := &types.Issue{
+		ID:        "gj-er8.10",
+		Title:     "Recovered from routes table",
+		Status:    types.StatusClosed,
+		Priority:  2,
+		IssueType: types.TypeFeature,
+	}
+	if err := remoteStore.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("create remote issue: %v", err)
+	}
+
+	// Simulate the stale projection bug: the authoritative routes table still has
+	// the prefix, but routes.jsonl no longer includes it.
+	staleRoutePath := filepath.Join(tmpDir, remoteDBName)
+	if _, err := townStore.DB().ExecContext(ctx, "INSERT INTO routes (prefix, path) VALUES (?, ?)", "gj-", staleRoutePath); err != nil {
+		t.Fatalf("insert routes row: %v", err)
+	}
+	routesJSONL := `{"prefix":"hq-","path":"."}` + "\n" + `{"prefix":"hq-cv-","path":"."}` + "\n"
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(routesJSONL), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	oldDBPath := dbPath
+	dbPath = townDBPath
+	t.Cleanup(func() { dbPath = oldDBPath })
+
+	wrappedTownStore := storage.NewHookFiringStore(townStore, nil)
+	result, err := resolveAndGetIssueWithRouting(ctx, wrappedTownStore, issue.ID)
+	if err != nil {
+		t.Fatalf("resolveAndGetIssueWithRouting: %v", err)
+	}
+	if result == nil {
+		t.Fatal("resolveAndGetIssueWithRouting returned nil result")
+	}
+	defer result.Close()
+
+	if !result.Routed {
+		t.Fatal("expected result.Routed to be true")
+	}
+	if result.ResolvedID != issue.ID {
+		t.Fatalf("ResolvedID = %q, want %q", result.ResolvedID, issue.ID)
+	}
+	if result.Issue.Title != issue.Title {
+		t.Fatalf("Issue.Title = %q, want %q", result.Issue.Title, issue.Title)
+	}
+
+	gotPrefix, err := result.Store.GetConfig(ctx, "issue_prefix")
+	if err != nil {
+		t.Fatalf("GetConfig(issue_prefix): %v", err)
+	}
+	if gotPrefix != "gj" {
+		t.Fatalf("issue_prefix = %q, want %q", gotPrefix, "gj")
+	}
+}

--- a/internal/routing/routes.go
+++ b/internal/routing/routes.go
@@ -55,9 +55,15 @@ func LoadRoutes(beadsDir string) ([]Route, error) {
 	return routes, scanner.Err()
 }
 
-// ResolveBeadsDirForID resolves the authoritative .beads directory for an issue ID
-// by consulting town-level prefix routes. When no route matches, it returns the
-// current beads dir with routed=false so callers can use their existing store.
+// ResolveBeadsDirForID resolves the authoritative .beads directory for an issue
+// ID by consulting town-level prefix routes.
+//
+// Fork note: multi-database GT towns can recover into a state where the nearest
+// local .beads directory is not the owning store for a prefix. Canonicalizing
+// redirects and walking back to the town routing table keeps cross-rig lookups
+// pointed at the authoritative rig database instead of the caller's local one.
+// When no route matches, it returns the current beads dir with routed=false so
+// callers can use their existing store.
 func ResolveBeadsDirForID(ctx context.Context, id, currentBeadsDir string) (string, bool, error) {
 	_ = ctx
 

--- a/internal/routing/routes.go
+++ b/internal/routing/routes.go
@@ -1,0 +1,208 @@
+package routing
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
+)
+
+// RoutesFileName is the town-level prefix routing table used by orchestrator setups.
+const RoutesFileName = "routes.jsonl"
+
+// Route maps an issue ID prefix to a rig path relative to the town root.
+type Route struct {
+	Prefix string `json:"prefix"`
+	Path   string `json:"path"`
+}
+
+// LoadRoutes loads prefix routes from a .beads/routes.jsonl file.
+// Missing files are treated as "no routes configured".
+func LoadRoutes(beadsDir string) ([]Route, error) {
+	routesPath := filepath.Join(beadsDir, RoutesFileName)
+	file, err := os.Open(routesPath) //nolint:gosec // Path is derived from a discovered .beads dir.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer file.Close()
+
+	var routes []Route
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		var route Route
+		if err := json.Unmarshal([]byte(line), &route); err != nil {
+			continue
+		}
+		if route.Prefix != "" && route.Path != "" {
+			routes = append(routes, route)
+		}
+	}
+
+	return routes, scanner.Err()
+}
+
+// ResolveBeadsDirForID resolves the authoritative .beads directory for an issue ID
+// by consulting town-level prefix routes. When no route matches, it returns the
+// current beads dir with routed=false so callers can use their existing store.
+func ResolveBeadsDirForID(ctx context.Context, id, currentBeadsDir string) (string, bool, error) {
+	_ = ctx
+
+	routes, townRoot := findTownRoutes(currentBeadsDir)
+	if len(routes) == 0 {
+		return currentBeadsDir, false, nil
+	}
+
+	prefix := types.ExtractPrefix(id)
+	if prefix == "" {
+		return currentBeadsDir, false, nil
+	}
+
+	for _, route := range routes {
+		if route.Prefix != prefix {
+			continue
+		}
+
+		var targetPath string
+		if route.Path == "." {
+			targetPath = filepath.Join(townRoot, ".beads")
+		} else {
+			targetPath = filepath.Join(townRoot, route.Path, ".beads")
+		}
+
+		redirectInfo := beads.ResolveRedirect(targetPath)
+		targetPath = redirectInfo.TargetDir
+		if redirectInfo.WasRedirected && redirectInfo.SourceDatabase != "" &&
+			os.Getenv("BEADS_DOLT_SERVER_DATABASE") == "" {
+			_ = os.Setenv("BEADS_DOLT_SERVER_DATABASE", redirectInfo.SourceDatabase)
+		}
+
+		if info, err := os.Stat(targetPath); err == nil && info.IsDir() {
+			return targetPath, true, nil
+		}
+	}
+
+	return currentBeadsDir, false, nil
+}
+
+func findTownRoot(startDir string) string {
+	current := startDir
+	for {
+		if _, err := os.Stat(filepath.Join(current, "mayor", "town.json")); err == nil {
+			return current
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+func canonicalizeRoutingBeadsDir(beadsDir string) string {
+	if beadsDir == "" {
+		return ""
+	}
+	return utils.NormalizePathForComparison(beads.ResolveRedirect(beadsDir).TargetDir)
+}
+
+func findTownRootForBeadsDirFromCWD(currentBeadsDir string) string {
+	targetBeadsDir := canonicalizeRoutingBeadsDir(currentBeadsDir)
+	if targetBeadsDir == "" {
+		return ""
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	current := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(current, "mayor", "town.json")); err == nil {
+			candidateBeadsDir := filepath.Join(current, ".beads")
+			if info, statErr := os.Stat(candidateBeadsDir); statErr == nil && info.IsDir() {
+				if canonicalizeRoutingBeadsDir(candidateBeadsDir) == targetBeadsDir {
+					return current
+				}
+			}
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+func findNearestTownRoutesFromPath(startDir string) ([]Route, string) {
+	if startDir == "" {
+		return nil, ""
+	}
+
+	current := startDir
+	for {
+		if _, err := os.Stat(filepath.Join(current, "mayor", "town.json")); err == nil {
+			townBeadsDir := filepath.Join(current, ".beads")
+			routes, loadErr := LoadRoutes(townBeadsDir)
+			if loadErr == nil && len(routes) > 0 {
+				return routes, current
+			}
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil, ""
+		}
+		current = parent
+	}
+}
+
+func findNearestTownRoutesFromCWD() ([]Route, string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, ""
+	}
+	return findNearestTownRoutesFromPath(cwd)
+}
+
+func findTownRoutes(currentBeadsDir string) ([]Route, string) {
+	if currentBeadsDir != "" {
+		routes, err := LoadRoutes(currentBeadsDir)
+		if err == nil && len(routes) > 0 {
+			if townRoot := findTownRootForBeadsDirFromCWD(currentBeadsDir); townRoot != "" {
+				return routes, townRoot
+			}
+			if townRoot := findTownRoot(filepath.Dir(currentBeadsDir)); townRoot != "" {
+				return routes, townRoot
+			}
+			return routes, filepath.Dir(currentBeadsDir)
+		}
+
+		if routes, townRoot := findNearestTownRoutesFromPath(filepath.Dir(currentBeadsDir)); len(routes) > 0 && townRoot != "" {
+			return routes, townRoot
+		}
+		return nil, ""
+	}
+
+	routes, townRoot := findNearestTownRoutesFromCWD()
+	if len(routes) == 0 || townRoot == "" {
+		return nil, ""
+	}
+	return routes, townRoot
+}


### PR DESCRIPTION
## Summary
- exclude `tracks` dependencies from orphan dependency validation and cleanup
- exclude dependencies that intentionally target wisps from orphan dependency validation and cleanup
- add regression coverage for both the validator and fixer

## Verification
- ICU_PREFIX=$(brew --prefix icu4c 2>/dev/null); export CGO_ENABLED=1
- export CGO_CFLAGS="-I$ICU_PREFIX/include" CGO_CPPFLAGS="-I$ICU_PREFIX/include" CGO_LDFLAGS="-L$ICU_PREFIX/lib"
- go test ./cmd/bd/doctor -run 'TestValidateCheck_(DetectsOrphanedDeps|IgnoresTracksAndWispDeps)$' -count=1\n- go test ./cmd/bd/doctor/fix -run 'TestOrphanedDependencies_IgnoresTracksAndWispDeps$' -count=1