### PR TITLE
bug(list): Fix silent truncation when there's no `--limit` override

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -426,6 +426,9 @@ var listCmd = &cobra.Command{
 		sqlLimit := effectiveLimit
 		if sortBy != "" {
 			sqlLimit = 0
+		} else if !limitChanged {
+			// Add one to the limit to detect truncation
+			sqlLimit = effectiveLimit + 1
 		}
 
 		filter := types.IssueFilter{
@@ -802,8 +805,9 @@ var listCmd = &cobra.Command{
 		sortIssues(issues, sortBy, reverse)
 
 		// Apply limit after sorting when --sort deferred it from SQL (GH#1237)
-		if sortBy != "" && effectiveLimit > 0 && len(issues) > effectiveLimit {
+		if (sortBy != "" || limitChanged) && effectiveLimit > 0 && len(issues) > effectiveLimit {
 			issues = issues[:effectiveLimit]
+			// Warn about truncation
 		}
 
 		// Handle watch mode (GH#654) - must be before other output modes


### PR DESCRIPTION
## Summary

When no `--limit` is passed, a default 50 is passed in. Detect when there's silent truncation by using `sqlLimit` to query for one more issue.

- Only apply to default `--limit`. A user-supplied limit implies user intent and awareness that there's truncation.
- This doesn't actually output a message yet. Need to define a JSON vs Human output as well as where to write the message (stderr?)

## Test plan

- [x] `make build` succeeds (pure Go, `gms_pure_go` tag)
- [ ] Manual integration test

Fixes #3212
