### PR TITLE
Feat: copilot cli integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,5 +171,5 @@ For daemon mode without git, use `bd daemon start --local`
 
 ## 📝 Documentation
 
-* [Documentation site](https://gastownhall.github.io/beads/) (versioned) | [Installing](docs/INSTALLING.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot Setup](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
+* [Documentation site](https://gastownhall.github.io/beads/) (versioned) | [Installing](docs/INSTALLING.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot CLI Setup](docs/COPILOT_CLI_INTEGRATION.md) | [Copilot VS Code MCP](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
 * [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/gastownhall/beads)

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -612,17 +612,34 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, claudeHookCheck)
 	// Don't fail overall check for incomplete hooks, just warn
 
-	// Check 11c: bd prime output verification
+	// Check 11c: Copilot CLI integration
+	copilotCheck := convertWithCategory(doctor.CheckCopilot(path), doctor.CategoryIntegration)
+	result.Checks = append(result.Checks, copilotCheck)
+	// Don't fail overall check for missing Copilot integration, just warn on broken installs
+
+	// Check 11d: Copilot hook file health
+	copilotHooksHealthCheck := convertWithCategory(doctor.CheckCopilotHooksHealth(path), doctor.CategoryIntegration)
+	result.Checks = append(result.Checks, copilotHooksHealthCheck)
+	if copilotHooksHealthCheck.Status == statusError {
+		result.OverallOK = false
+	}
+
+	// Check 11e: Copilot hook completeness (sessionStart + preCompact)
+	copilotHookCheck := convertWithCategory(doctor.CheckCopilotHookCompleteness(path), doctor.CategoryIntegration)
+	result.Checks = append(result.Checks, copilotHookCheck)
+	// Don't fail overall check for incomplete hooks, just warn
+
+	// Check 11f: bd prime output verification
 	bdPrimeOutputCheck := convertWithCategory(doctor.VerifyPrimeOutput(path), doctor.CategoryIntegration)
 	result.Checks = append(result.Checks, bdPrimeOutputCheck)
 	// Don't fail overall check for prime output issues, just warn
 
-	// Check 11e: bd in PATH (needed for Claude hooks to work)
+	// Check 11g: bd in PATH (needed for Claude/Copilot hooks to work)
 	bdPathCheck := convertWithCategory(doctor.CheckBdInPath(), doctor.CategoryIntegration)
 	result.Checks = append(result.Checks, bdPathCheck)
 	// Don't fail overall check for missing bd in PATH, just warn
 
-	// Check 11f: Documentation bd prime references match installed version
+	// Check 11h: Documentation bd prime references match installed version
 	bdPrimeDocsCheck := convertWithCategory(doctor.CheckDocumentationBdPrimeReference(path), doctor.CategoryIntegration)
 	result.Checks = append(result.Checks, bdPrimeDocsCheck)
 	// Don't fail overall check for doc mismatch, just warn

--- a/cmd/bd/doctor/copilot.go
+++ b/cmd/bd/doctor/copilot.go
@@ -1,0 +1,256 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	copilotInstructionsFile = ".github/copilot-instructions.md"
+	copilotHooksFile        = ".github/hooks/beads-copilot.json"
+	copilotMinVersion       = "1.0.5"
+)
+
+var (
+	copilotLookPath = exec.LookPath
+	copilotVersion  = func() ([]byte, error) {
+		return exec.Command("copilot", "--version").Output()
+	}
+	copilotVersionPattern = regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
+)
+
+type copilotHookCommand struct {
+	Type       string `json:"type"`
+	Bash       string `json:"bash,omitempty"`
+	PowerShell string `json:"powershell,omitempty"`
+}
+
+type copilotHooksConfig struct {
+	Version int                             `json:"version"`
+	Hooks   map[string][]copilotHookCommand `json:"hooks"`
+}
+
+func CheckCopilot(repoPath string) DoctorCheck {
+	instructionsPath := filepath.Join(repoPath, copilotInstructionsFile)
+	hooksPath := filepath.Join(repoPath, copilotHooksFile)
+
+	hasInstructions := hasBeadsSection(instructionsPath)
+	hasHooks := copilotFileExists(hooksPath)
+
+	if !hasInstructions && !hasHooks {
+		if _, err := copilotLookPath("copilot"); err == nil {
+			return DoctorCheck{
+				Name:    "Copilot CLI Integration",
+				Status:  "ok",
+				Message: "GitHub Copilot CLI available but not configured",
+				Detail:  "Run 'bd setup copilot' to install repository instructions and hooks",
+			}
+		}
+		return DoctorCheck{
+			Name:    "Copilot CLI Integration",
+			Status:  "ok",
+			Message: "GitHub Copilot CLI integration not configured",
+			Detail:  "Run 'bd setup copilot' if you want Copilot CLI to load bd prime hooks",
+		}
+	}
+
+	if hasInstructions != hasHooks {
+		missing := copilotInstructionsFile
+		if hasInstructions {
+			missing = copilotHooksFile
+		}
+		return DoctorCheck{
+			Name:    "Copilot CLI Integration",
+			Status:  "warning",
+			Message: "GitHub Copilot CLI integration is partially installed",
+			Detail:  fmt.Sprintf("Missing %s. Run 'bd setup copilot' to repair the integration.", missing),
+		}
+	}
+
+	version, installed, err := detectCopilotVersion()
+	switch {
+	case err != nil:
+		return DoctorCheck{
+			Name:    "Copilot CLI Integration",
+			Status:  "warning",
+			Message: "GitHub Copilot CLI integration installed",
+			Detail:  fmt.Sprintf("Could not determine installed Copilot CLI version: %v", err),
+		}
+	case !installed:
+		return DoctorCheck{
+			Name:    "Copilot CLI Integration",
+			Status:  "warning",
+			Message: "GitHub Copilot CLI integration installed",
+			Detail:  fmt.Sprintf("Repository hooks are configured, but 'copilot' is not in PATH. Copilot CLI %s or newer is required.", copilotMinVersion),
+		}
+	case CompareVersions(version, copilotMinVersion) < 0:
+		return DoctorCheck{
+			Name:    "Copilot CLI Integration",
+			Status:  "warning",
+			Message: "GitHub Copilot CLI is too old for preCompact hooks",
+			Detail:  fmt.Sprintf("Detected Copilot CLI %s, but %s or newer is required.", version, copilotMinVersion),
+			Fix:     "Upgrade GitHub Copilot CLI, then restart your session.",
+		}
+	default:
+		return DoctorCheck{
+			Name:    "Copilot CLI Integration",
+			Status:  "ok",
+			Message: "GitHub Copilot CLI integration installed",
+			Detail:  fmt.Sprintf("Instructions and hooks are installed; Copilot CLI %s supports preCompact.", version),
+		}
+	}
+}
+
+func CheckCopilotHooksHealth(repoPath string) DoctorCheck {
+	path := filepath.Join(repoPath, copilotHooksFile)
+	if !copilotFileExists(path) {
+		return DoctorCheck{
+			Name:    "Copilot Hooks Health",
+			Status:  "ok",
+			Message: "Copilot hook file not installed",
+		}
+	}
+
+	data, err := os.ReadFile(path) // #nosec G304 - controlled path from repoPath
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Copilot Hooks Health",
+			Status:  "error",
+			Message: "Could not read Copilot hook file",
+			Detail:  err.Error(),
+		}
+	}
+	if _, err := parseCopilotHooks(data); err != nil {
+		return DoctorCheck{
+			Name:    "Copilot Hooks Health",
+			Status:  "error",
+			Message: "Copilot hook file contains invalid JSON",
+			Detail:  err.Error(),
+			Fix:     "Run 'bd setup copilot' to rewrite the hook file.",
+		}
+	}
+
+	return DoctorCheck{
+		Name:    "Copilot Hooks Health",
+		Status:  "ok",
+		Message: "Copilot hook file is valid JSON",
+	}
+}
+
+func CheckCopilotHookCompleteness(repoPath string) DoctorCheck {
+	path := filepath.Join(repoPath, copilotHooksFile)
+	if !copilotFileExists(path) {
+		return DoctorCheck{
+			Name:    "Copilot Hooks",
+			Status:  "ok",
+			Message: "Copilot hook file not installed",
+		}
+	}
+
+	data, err := os.ReadFile(path) // #nosec G304 - controlled path from repoPath
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Copilot Hooks",
+			Status:  "error",
+			Message: "Could not read Copilot hook file",
+			Detail:  err.Error(),
+		}
+	}
+	cfg, err := parseCopilotHooks(data)
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Copilot Hooks",
+			Status:  "error",
+			Message: "Could not parse Copilot hook file",
+			Detail:  err.Error(),
+		}
+	}
+
+	missing := make([]string, 0, 2)
+	if !hasCopilotHookEvent(cfg, "sessionStart") {
+		missing = append(missing, "sessionStart")
+	}
+	if !hasCopilotHookEvent(cfg, "preCompact") {
+		missing = append(missing, "preCompact")
+	}
+	if len(missing) > 0 {
+		return DoctorCheck{
+			Name:    "Copilot Hooks",
+			Status:  "warning",
+			Message: "Copilot hooks are incomplete",
+			Detail:  fmt.Sprintf("Missing bd prime hooks for: %s", strings.Join(missing, ", ")),
+			Fix:     "Run 'bd setup copilot' to reinstall both hooks.",
+		}
+	}
+
+	return DoctorCheck{
+		Name:    "Copilot Hooks",
+		Status:  "ok",
+		Message: "Copilot hooks include sessionStart and preCompact",
+	}
+}
+
+func detectCopilotVersion() (string, bool, error) {
+	if _, err := copilotLookPath("copilot"); err != nil {
+		return "", false, nil
+	}
+	out, err := copilotVersion()
+	if err != nil {
+		return "", true, err
+	}
+	version := extractCopilotVersion(string(out))
+	if version == "" {
+		return "", true, fmt.Errorf("could not parse version from output %q", strings.TrimSpace(string(out)))
+	}
+	return version, true, nil
+}
+
+func extractCopilotVersion(output string) string {
+	match := copilotVersionPattern.FindStringSubmatch(output)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
+}
+
+func parseCopilotHooks(data []byte) (copilotHooksConfig, error) {
+	var cfg copilotHooksConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return copilotHooksConfig{}, err
+	}
+	return cfg, nil
+}
+
+func hasCopilotHookEvent(cfg copilotHooksConfig, event string) bool {
+	commands, ok := cfg.Hooks[event]
+	if !ok {
+		return false
+	}
+	for _, cmd := range commands {
+		if cmd.Type != "command" {
+			continue
+		}
+		if cmd.Bash == "bd prime" || cmd.Bash == "bd prime --stealth" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasBeadsSection(path string) bool {
+	data, err := os.ReadFile(path) // #nosec G304 - controlled path from repoPath
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "BEGIN BEADS INTEGRATION")
+}
+
+func copilotFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/cmd/bd/doctor/copilot_test.go
+++ b/cmd/bd/doctor/copilot_test.go
@@ -1,0 +1,160 @@
+package doctor
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func stubCopilotVersion(t *testing.T, lookPath func(string) (string, error), version func() ([]byte, error)) {
+	t.Helper()
+	origLookPath := copilotLookPath
+	origVersion := copilotVersion
+	copilotLookPath = lookPath
+	copilotVersion = version
+	t.Cleanup(func() {
+		copilotLookPath = origLookPath
+		copilotVersion = origVersion
+	})
+}
+
+func TestCheckCopilotNotConfigured(t *testing.T) {
+	tmpDir := t.TempDir()
+	stubCopilotVersion(t,
+		func(string) (string, error) { return "", errors.New("not found") },
+		func() ([]byte, error) { return nil, errors.New("should not run") },
+	)
+
+	check := CheckCopilot(tmpDir)
+	if check.Status != StatusOK {
+		t.Fatalf("expected ok, got %s", check.Status)
+	}
+	if check.Name != "Copilot CLI Integration" {
+		t.Fatalf("unexpected check name: %s", check.Name)
+	}
+}
+
+func TestCheckCopilotConfigured(t *testing.T) {
+	tmpDir := t.TempDir()
+	stubCopilotVersion(t,
+		func(string) (string, error) { return "/usr/local/bin/copilot", nil },
+		func() ([]byte, error) { return []byte("copilot 1.0.5\n"), nil },
+	)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".github", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, copilotInstructionsFile), []byte("<!-- BEGIN BEADS INTEGRATION profile:minimal hash:abc -->\n<!-- END BEADS INTEGRATION -->\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, copilotHooksFile), []byte(`{"version":1,"hooks":{"sessionStart":[{"type":"command","bash":"bd prime"}],"preCompact":[{"type":"command","bash":"bd prime"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckCopilot(tmpDir)
+	if check.Status != StatusOK {
+		t.Fatalf("expected ok, got %s: %s", check.Status, check.Message)
+	}
+}
+
+func TestCheckCopilotPartialInstall(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".github"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, copilotInstructionsFile), []byte("<!-- BEGIN BEADS INTEGRATION -->\n<!-- END BEADS INTEGRATION -->\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckCopilot(tmpDir)
+	if check.Status != StatusWarning {
+		t.Fatalf("expected warning, got %s", check.Status)
+	}
+}
+
+func TestCheckCopilotOldVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+	stubCopilotVersion(t,
+		func(string) (string, error) { return "/usr/local/bin/copilot", nil },
+		func() ([]byte, error) { return []byte("copilot 1.0.4\n"), nil },
+	)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".github", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, copilotInstructionsFile), []byte("<!-- BEGIN BEADS INTEGRATION -->\n<!-- END BEADS INTEGRATION -->\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, copilotHooksFile), []byte(`{"version":1,"hooks":{"sessionStart":[{"type":"command","bash":"bd prime"}],"preCompact":[{"type":"command","bash":"bd prime"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckCopilot(tmpDir)
+	if check.Status != StatusWarning {
+		t.Fatalf("expected warning, got %s", check.Status)
+	}
+}
+
+func TestCheckCopilotHooksHealth(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".github", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, copilotHooksFile), []byte(`not json`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckCopilotHooksHealth(tmpDir)
+	if check.Status != StatusError {
+		t.Fatalf("expected error, got %s", check.Status)
+	}
+}
+
+func TestCheckCopilotHookCompleteness(t *testing.T) {
+	t.Run("both hooks present", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(tmpDir, ".github", "hooks"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, copilotHooksFile), []byte(`{"version":1,"hooks":{"sessionStart":[{"type":"command","bash":"bd prime"}],"preCompact":[{"type":"command","bash":"bd prime --stealth"}]}}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		check := CheckCopilotHookCompleteness(tmpDir)
+		if check.Status != StatusOK {
+			t.Fatalf("expected ok, got %s", check.Status)
+		}
+	})
+
+	t.Run("missing preCompact", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(tmpDir, ".github", "hooks"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, copilotHooksFile), []byte(`{"version":1,"hooks":{"sessionStart":[{"type":"command","bash":"bd prime"}]}}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		check := CheckCopilotHookCompleteness(tmpDir)
+		if check.Status != StatusWarning {
+			t.Fatalf("expected warning, got %s", check.Status)
+		}
+	})
+}
+
+func TestCheckDocumentationBdPrimeReferenceIncludesCopilotInstructions(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".github"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, copilotInstructionsFile), []byte("Run bd prime for workflow context."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckDocumentationBdPrimeReference(tmpDir)
+	if check.Status != StatusOK && check.Status != StatusWarning {
+		t.Fatalf("expected ok or warning, got %s", check.Status)
+	}
+}

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -21,6 +21,7 @@ func agentDocFiles(repoPath string) []string {
 	files := []string{
 		filepath.Join(repoPath, agentsFile),
 		filepath.Join(repoPath, "CLAUDE.md"),
+		filepath.Join(repoPath, ".github", "copilot-instructions.md"),
 		filepath.Join(repoPath, ".claude", "CLAUDE.md"),
 		// Local-only variants (not committed to repo)
 		filepath.Join(repoPath, "claude.local.md"),

--- a/cmd/bd/doctor_test.go
+++ b/cmd/bd/doctor_test.go
@@ -68,6 +68,40 @@ func TestDoctorWithBeadsDir(t *testing.T) {
 	}
 }
 
+func TestDoctorIncludesCopilotChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".github", "hooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".github", "copilot-instructions.md"), []byte("<!-- BEGIN BEADS INTEGRATION -->\n<!-- END BEADS INTEGRATION -->\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".github", "hooks", "beads-copilot.json"), []byte(`{"version":1,"hooks":{"sessionStart":[{"type":"command","bash":"bd prime"}],"preCompact":[{"type":"command","bash":"bd prime"}]}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := runDiagnostics(tmpDir)
+
+	var names []string
+	for _, check := range result.Checks {
+		names = append(names, check.Name)
+	}
+	joined := strings.Join(names, "\n")
+	for _, want := range []string{
+		"Copilot CLI Integration",
+		"Copilot Hooks Health",
+		"Copilot Hooks",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected %q in doctor checks, got:\n%s", want, joined)
+		}
+	}
+}
+
 func TestDoctorWithBeadsDir_DoesNotPolluteCallerBeadsDir(t *testing.T) {
 	// Simulate a caller context that has its own valid .beads directory.
 	callerDir := t.TempDir()

--- a/cmd/bd/setup.go
+++ b/cmd/bd/setup.go
@@ -32,10 +32,12 @@ var setupCmd = &cobra.Command{
 	Long: `Setup integration files for AI editors and coding assistants.
 
 Recipes define where beads workflow instructions are written. Built-in recipes
-include cursor, claude, gemini, aider, factory, codex, mux, opencode, junie, windsurf, cody, and kilocode.
+include cursor, claude, copilot, gemini, aider, factory, codex, mux, opencode, junie, windsurf, cody, and kilocode.
 
 Examples:
   bd setup cursor          # Install Cursor IDE integration
+  bd setup copilot         # Install Copilot CLI global instructions
+  bd setup copilot --project  # Install Copilot CLI project hooks + instructions
   bd setup mux --project   # Install Mux workspace layer (.mux/AGENTS.md)
   bd setup mux --global    # Install Mux global layer (~/.mux/AGENTS.md)
   bd setup mux --project --global  # Install both Mux layers
@@ -204,6 +206,9 @@ func runRecipe(name string) {
 	case "claude":
 		runClaudeRecipe()
 		return
+	case "copilot":
+		runCopilotRecipe()
+		return
 	case "gemini":
 		runGeminiRecipe()
 		return
@@ -309,6 +314,18 @@ func runClaudeRecipe() {
 	setup.InstallClaude(setupGlobal, setupStealth)
 }
 
+func runCopilotRecipe() {
+	if setupCheck {
+		setup.CheckCopilot(setupProject, setupGlobal)
+		return
+	}
+	if setupRemove {
+		setup.RemoveCopilot(setupProject, setupGlobal)
+		return
+	}
+	setup.InstallCopilot(setupProject, setupGlobal, setupStealth)
+}
+
 func runGeminiRecipe() {
 	if setupCheck {
 		setup.CheckGemini()
@@ -405,7 +422,7 @@ func init() {
 	setupCmd.Flags().BoolVar(&setupRemove, "remove", false, "Remove the integration")
 	setupCmd.Flags().BoolVar(&setupProject, "project", false, "Install for this project only (gemini/mux)")
 	setupCmd.Flags().BoolVar(&setupGlobal, "global", false, "Install globally (claude/mux; writes to ~/.claude/settings.json or ~/.mux/AGENTS.md)")
-	setupCmd.Flags().BoolVar(&setupStealth, "stealth", false, "Use stealth mode (claude/gemini)")
+	setupCmd.Flags().BoolVar(&setupStealth, "stealth", false, "Use stealth mode (claude/copilot/gemini)")
 
 	rootCmd.AddCommand(setupCmd)
 }

--- a/cmd/bd/setup/copilot.go
+++ b/cmd/bd/setup/copilot.go
@@ -1,0 +1,483 @@
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/templates/agents"
+)
+
+var (
+	copilotEnvProvider     = defaultCopilotEnv
+	errCopilotHooksMissing = errors.New("copilot hooks not installed")
+	errCopilotVersionOld   = errors.New("copilot cli version too old for preCompact hooks")
+)
+
+const (
+	copilotProjectInstructionsFile = ".github/copilot-instructions.md"
+	copilotGlobalInstructionsFile  = ".copilot/copilot-instructions.md"
+	copilotGlobalHooksFile         = ".copilot/hooks/beads-copilot.json"
+	copilotHooksFile               = ".github/hooks/beads-copilot.json"
+	copilotMinVersion              = "1.0.5"
+	copilotHookComment             = "Installed by bd setup copilot"
+)
+
+var (
+	copilotProjectIntegration = agentsIntegration{
+		name:         "GitHub Copilot CLI (project)",
+		setupCommand: "bd setup copilot --project",
+		readHint:     "Copilot CLI reads .github/copilot-instructions.md and loads repository hooks from .github/hooks/. Restart Copilot CLI if it is already running.",
+		profile:      agents.ProfileMinimal,
+	}
+
+	copilotGlobalIntegration = agentsIntegration{
+		name:         "GitHub Copilot CLI (global)",
+		setupCommand: "bd setup copilot",
+		readHint:     "Copilot CLI also reads $HOME/.copilot/copilot-instructions.md and $HOME/.copilot/hooks/ for global defaults.",
+		profile:      agents.ProfileMinimal,
+	}
+)
+
+type copilotEnv struct {
+	stdout     io.Writer
+	stderr     io.Writer
+	projectDir string
+	homeDir    string
+	ensureDir  func(string, os.FileMode) error
+	readFile   func(string) ([]byte, error)
+	writeFile  func(string, []byte) error
+	lookPath   func(string) (string, error)
+	runCommand func(string, ...string) ([]byte, error)
+}
+
+type copilotHookCommand struct {
+	Type       string `json:"type"`
+	Bash       string `json:"bash,omitempty"`
+	PowerShell string `json:"powershell,omitempty"`
+	Cwd        string `json:"cwd,omitempty"`
+	TimeoutSec int    `json:"timeoutSec,omitempty"`
+	Comment    string `json:"comment,omitempty"`
+}
+
+type copilotHooksConfig struct {
+	Version int                             `json:"version"`
+	Hooks   map[string][]copilotHookCommand `json:"hooks"`
+}
+
+func defaultCopilotEnv() (copilotEnv, error) {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return copilotEnv{}, fmt.Errorf("working directory: %w", err)
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return copilotEnv{}, fmt.Errorf("home directory: %w", err)
+	}
+	return copilotEnv{
+		stdout:     os.Stdout,
+		stderr:     os.Stderr,
+		projectDir: workDir,
+		homeDir:    homeDir,
+		ensureDir:  EnsureDir,
+		readFile:   os.ReadFile,
+		writeFile: func(path string, data []byte) error {
+			return atomicWriteFile(path, data)
+		},
+		lookPath: exec.LookPath,
+		runCommand: func(name string, args ...string) ([]byte, error) {
+			return exec.Command(name, args...).Output()
+		},
+	}, nil
+}
+
+func copilotProjectInstructionsPath(base string) string {
+	return filepath.Join(base, filepath.FromSlash(copilotProjectInstructionsFile))
+}
+
+func copilotGlobalInstructionsPath(homeDir string) string {
+	return filepath.Join(homeDir, filepath.FromSlash(copilotGlobalInstructionsFile))
+}
+
+func copilotGlobalHooksPath(homeDir string) string {
+	return filepath.Join(homeDir, filepath.FromSlash(copilotGlobalHooksFile))
+}
+
+func copilotHooksPath(base string) string {
+	return filepath.Join(base, filepath.FromSlash(copilotHooksFile))
+}
+
+func copilotAgentsEnv(path string, env copilotEnv) agentsEnv {
+	return agentsEnv{
+		agentsPath: path,
+		stdout:     env.stdout,
+		stderr:     env.stderr,
+	}
+}
+
+// InstallCopilot installs GitHub Copilot CLI integration.
+func InstallCopilot(project bool, global bool, stealth bool) {
+	env, err := copilotEnvProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		setupExit(1)
+		return
+	}
+	if err := installCopilot(env, project, global, stealth); err != nil {
+		setupExit(1)
+	}
+}
+
+func installCopilot(env copilotEnv, project bool, global bool, stealth bool) error {
+	project, global = resolveCopilotScopes(project, global)
+
+	if project || global {
+		if err := validateCopilotVersion(env, true); err != nil {
+			return err
+		}
+	}
+
+	if global {
+		if err := ensureCopilotInstructionsScaffold(env, copilotGlobalInstructionsPath(env.homeDir), false); err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Error: prepare global instructions file: %v\n", err)
+			return err
+		}
+		if err := installAgents(copilotAgentsEnv(copilotGlobalInstructionsPath(env.homeDir), env), copilotGlobalIntegration); err != nil {
+			return err
+		}
+		if err := installCopilotHooksAtPath(env, copilotGlobalHooksPath(env.homeDir), stealth); err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Error: install global hooks: %v\n", err)
+			return err
+		}
+		_, _ = fmt.Fprintln(env.stdout, "\n✓ GitHub Copilot CLI global instructions installed")
+		_, _ = fmt.Fprintf(env.stdout, "  Instructions: %s\n", copilotGlobalInstructionsPath(env.homeDir))
+		_, _ = fmt.Fprintf(env.stdout, "  Hooks: %s\n", copilotGlobalHooksPath(env.homeDir))
+	}
+
+	if project {
+		if err := ensureCopilotInstructionsScaffold(env, copilotProjectInstructionsPath(env.projectDir), true); err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Error: prepare project instructions file: %v\n", err)
+			return err
+		}
+		if err := installAgents(copilotAgentsEnv(copilotProjectInstructionsPath(env.projectDir), env), copilotProjectIntegration); err != nil {
+			return err
+		}
+		if err := installCopilotHooksAtPath(env, copilotHooksPath(env.projectDir), stealth); err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Error: install hooks: %v\n", err)
+			return err
+		}
+		_, _ = fmt.Fprintln(env.stdout, "\n✓ GitHub Copilot CLI project integration installed")
+		_, _ = fmt.Fprintf(env.stdout, "  Instructions: %s\n", copilotProjectInstructionsPath(env.projectDir))
+		_, _ = fmt.Fprintf(env.stdout, "  Hooks: %s\n", copilotHooksPath(env.projectDir))
+		_, _ = fmt.Fprintf(env.stdout, "  Requires Copilot CLI %s or newer for preCompact hooks.\n", copilotMinVersion)
+	}
+
+	_, _ = fmt.Fprintln(env.stdout, "\nRestart Copilot CLI for changes to take effect.")
+	return nil
+}
+
+func resolveCopilotScopes(project bool, global bool) (bool, bool) {
+	if !project && !global {
+		return false, true
+	}
+	return project, global
+}
+
+func ensureCopilotInstructionsScaffold(env copilotEnv, path string, project bool) error {
+	if _, err := env.readFile(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := env.ensureDir(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	content := `# GitHub Copilot Instructions
+
+`
+	if project {
+		content += "This file provides project-specific instructions for GitHub Copilot CLI.\n"
+	} else {
+		content += "This file provides default instructions for GitHub Copilot CLI across repositories.\n"
+	}
+	return env.writeFile(path, []byte(content))
+}
+
+func installCopilotHooksAtPath(env copilotEnv, path string, stealth bool) error {
+	if err := env.ensureDir(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	if data, err := env.readFile(path); err == nil {
+		cfg, err := parseCopilotHooks(data)
+		if err != nil {
+			return fmt.Errorf("parse existing hooks file: %w", err)
+		}
+		if !isManagedCopilotHooks(cfg) {
+			return fmt.Errorf("%s exists and is not managed by bd setup copilot", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	command := "bd prime"
+	if stealth {
+		command = "bd prime --stealth"
+	}
+	cfg := generateCopilotHooks(command)
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return env.writeFile(path, data)
+}
+
+// CheckCopilot checks if GitHub Copilot CLI integration is installed.
+func CheckCopilot(project bool, global bool) {
+	env, err := copilotEnvProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		setupExit(1)
+		return
+	}
+	if err := checkCopilot(env, project, global); err != nil {
+		setupExit(1)
+	}
+}
+
+func checkCopilot(env copilotEnv, project bool, global bool) error {
+	project, global = resolveCopilotScopes(project, global)
+
+	var checkErr error
+	if global {
+		if err := checkCopilotHooksAtPath(env, copilotGlobalHooksPath(env.homeDir), "bd setup copilot"); err != nil {
+			checkErr = err
+		}
+		if err := checkAgents(copilotAgentsEnv(copilotGlobalInstructionsPath(env.homeDir), env), copilotGlobalIntegration); err != nil {
+			checkErr = err
+		}
+	}
+	if project {
+		if err := checkCopilotHooksAtPath(env, copilotHooksPath(env.projectDir), "bd setup copilot --project"); err != nil {
+			checkErr = err
+		}
+		if err := validateCopilotVersion(env, false); err != nil {
+			checkErr = err
+		}
+		if err := checkAgents(copilotAgentsEnv(copilotProjectInstructionsPath(env.projectDir), env), copilotProjectIntegration); err != nil {
+			checkErr = err
+		}
+	}
+	return checkErr
+}
+
+func checkCopilotHooksAtPath(env copilotEnv, path string, setupCommand string) error {
+	data, err := env.readFile(path)
+	if os.IsNotExist(err) {
+		_, _ = fmt.Fprintln(env.stdout, "✗ No hooks installed")
+		_, _ = fmt.Fprintf(env.stdout, "  Run: %s\n", setupCommand)
+		return errCopilotHooksMissing
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(env.stderr, "Error: read hooks file: %v\n", err)
+		return err
+	}
+	cfg, err := parseCopilotHooks(data)
+	if err != nil {
+		_, _ = fmt.Fprintf(env.stderr, "Error: parse hooks file: %v\n", err)
+		return err
+	}
+	if !hasCopilotHookEvent(cfg, "sessionStart") || !hasCopilotHookEvent(cfg, "preCompact") {
+		_, _ = fmt.Fprintf(env.stdout, "⚠ Incomplete hooks installed: %s\n", path)
+		_, _ = fmt.Fprintf(env.stdout, "  Run: %s\n", setupCommand)
+		return errCopilotHooksMissing
+	}
+	_, _ = fmt.Fprintf(env.stdout, "✓ Hooks installed: %s\n", path)
+	return nil
+}
+
+func validateCopilotVersion(env copilotEnv, warnIfMissing bool) error {
+	version, installed, err := detectCopilotVersion(env)
+	switch {
+	case err != nil:
+		_, _ = fmt.Fprintf(env.stderr, "Warning: unable to determine Copilot CLI version: %v\n", err)
+		return nil
+	case !installed:
+		if warnIfMissing {
+			_, _ = fmt.Fprintf(env.stdout, "  ℹ Copilot CLI not found in PATH; project hooks require Copilot CLI %s or newer.\n", copilotMinVersion)
+		}
+		return nil
+	case compareSetupVersions(version, copilotMinVersion) < 0:
+		_, _ = fmt.Fprintf(env.stderr, "Error: Copilot CLI %s detected, but %s or newer is required for preCompact hooks.\n", version, copilotMinVersion)
+		return errCopilotVersionOld
+	default:
+		_, _ = fmt.Fprintf(env.stdout, "✓ Copilot CLI version %s supports preCompact hooks\n", version)
+		return nil
+	}
+}
+
+func detectCopilotVersion(env copilotEnv) (string, bool, error) {
+	if _, err := env.lookPath("copilot"); err != nil {
+		return "", false, nil
+	}
+	out, err := env.runCommand("copilot", "--version")
+	if err != nil {
+		return "", true, err
+	}
+	version := extractVersion(string(out))
+	if version == "" {
+		return "", true, fmt.Errorf("could not parse version from output: %q", strings.TrimSpace(string(out)))
+	}
+	return version, true, nil
+}
+
+var semverPattern = regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
+
+func extractVersion(output string) string {
+	match := semverPattern.FindStringSubmatch(output)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
+}
+
+func compareSetupVersions(v1, v2 string) int {
+	parts1 := strings.Split(v1, ".")
+	parts2 := strings.Split(v2, ".")
+	maxLen := len(parts1)
+	if len(parts2) > maxLen {
+		maxLen = len(parts2)
+	}
+	for i := 0; i < maxLen; i++ {
+		var p1, p2 int
+		if i < len(parts1) {
+			_, _ = fmt.Sscanf(parts1[i], "%d", &p1)
+		}
+		if i < len(parts2) {
+			_, _ = fmt.Sscanf(parts2[i], "%d", &p2)
+		}
+		if p1 < p2 {
+			return -1
+		}
+		if p1 > p2 {
+			return 1
+		}
+	}
+	return 0
+}
+
+func generateCopilotHooks(command string) copilotHooksConfig {
+	hook := copilotHookCommand{
+		Type:       "command",
+		Bash:       command,
+		PowerShell: command,
+		Cwd:        ".",
+		TimeoutSec: 30,
+		Comment:    copilotHookComment,
+	}
+	return copilotHooksConfig{
+		Version: 1,
+		Hooks: map[string][]copilotHookCommand{
+			"sessionStart": {hook},
+			"preCompact":   {hook},
+		},
+	}
+}
+
+func parseCopilotHooks(data []byte) (copilotHooksConfig, error) {
+	var cfg copilotHooksConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return copilotHooksConfig{}, err
+	}
+	return cfg, nil
+}
+
+func hasCopilotHookEvent(cfg copilotHooksConfig, event string) bool {
+	commands, ok := cfg.Hooks[event]
+	if !ok {
+		return false
+	}
+	for _, cmd := range commands {
+		if cmd.Type != "command" {
+			continue
+		}
+		if cmd.Bash == "bd prime" || cmd.Bash == "bd prime --stealth" {
+			return true
+		}
+	}
+	return false
+}
+
+func isManagedCopilotHooks(cfg copilotHooksConfig) bool {
+	return cfg.Version == 1 && hasCopilotHookEvent(cfg, "sessionStart") && hasCopilotHookEvent(cfg, "preCompact")
+}
+
+// RemoveCopilot removes GitHub Copilot CLI integration.
+func RemoveCopilot(project bool, global bool) {
+	env, err := copilotEnvProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		setupExit(1)
+		return
+	}
+	if err := removeCopilot(env, project, global); err != nil {
+		setupExit(1)
+	}
+}
+
+func removeCopilot(env copilotEnv, project bool, global bool) error {
+	project, global = resolveCopilotScopes(project, global)
+
+	var removeErr error
+	if project {
+		if err := removeCopilotHooksAtPath(env, copilotHooksPath(env.projectDir)); err != nil {
+			removeErr = err
+		}
+		if err := removeAgents(copilotAgentsEnv(copilotProjectInstructionsPath(env.projectDir), env), copilotProjectIntegration); err != nil {
+			removeErr = err
+		}
+	}
+	if global {
+		if err := removeCopilotHooksAtPath(env, copilotGlobalHooksPath(env.homeDir)); err != nil {
+			removeErr = err
+		}
+		if err := removeAgents(copilotAgentsEnv(copilotGlobalInstructionsPath(env.homeDir), env), copilotGlobalIntegration); err != nil {
+			removeErr = err
+		}
+	}
+	return removeErr
+}
+
+func removeCopilotHooksAtPath(env copilotEnv, path string) error {
+	data, err := env.readFile(path)
+	switch {
+	case os.IsNotExist(err):
+		_, _ = fmt.Fprintln(env.stdout, "No Copilot hook file found")
+		return nil
+	case err != nil:
+		_, _ = fmt.Fprintf(env.stderr, "Error: read hooks file: %v\n", err)
+		return err
+	default:
+		cfg, err := parseCopilotHooks(data)
+		if err != nil {
+			_, _ = fmt.Fprintf(env.stderr, "Error: parse hooks file: %v\n", err)
+			return err
+		}
+		if isManagedCopilotHooks(cfg) {
+			if err := os.Remove(path); err != nil {
+				_, _ = fmt.Fprintf(env.stderr, "Error: remove hooks file: %v\n", err)
+				return err
+			}
+			_, _ = fmt.Fprintf(env.stdout, "✓ Removed Copilot hooks: %s\n", path)
+		} else {
+			_, _ = fmt.Fprintf(env.stdout, "ℹ Kept existing custom Copilot hooks file: %s\n", path)
+		}
+		return nil
+	}
+}

--- a/cmd/bd/setup/copilot_test.go
+++ b/cmd/bd/setup/copilot_test.go
@@ -1,0 +1,328 @@
+package setup
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newCopilotTestEnv(t *testing.T) (copilotEnv, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "project")
+	homeDir := filepath.Join(root, "home")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project: %v", err)
+	}
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	env := copilotEnv{
+		stdout:     stdout,
+		stderr:     stderr,
+		projectDir: projectDir,
+		homeDir:    homeDir,
+		ensureDir:  EnsureDir,
+		readFile:   os.ReadFile,
+		writeFile: func(path string, data []byte) error {
+			return atomicWriteFile(path, data)
+		},
+		lookPath: func(string) (string, error) {
+			return "/usr/local/bin/copilot", nil
+		},
+		runCommand: func(string, ...string) ([]byte, error) {
+			return []byte("copilot 1.0.5\n"), nil
+		},
+	}
+	return env, stdout, stderr
+}
+
+func readCopilotHooks(t *testing.T, path string) copilotHooksConfig {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hooks: %v", err)
+	}
+	cfg, err := parseCopilotHooks(data)
+	if err != nil {
+		t.Fatalf("parse hooks: %v", err)
+	}
+	return cfg
+}
+
+func TestResolveCopilotScopes(t *testing.T) {
+	tests := []struct {
+		name        string
+		project     bool
+		global      bool
+		wantProject bool
+		wantGlobal  bool
+	}{
+		{"default is global", false, false, false, true},
+		{"project only", true, false, true, false},
+		{"global only", false, true, false, true},
+		{"both", true, true, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProject, gotGlobal := resolveCopilotScopes(tt.project, tt.global)
+			if gotProject != tt.wantProject || gotGlobal != tt.wantGlobal {
+				t.Fatalf("resolveCopilotScopes(%v, %v) = (%v, %v), want (%v, %v)", tt.project, tt.global, gotProject, gotGlobal, tt.wantProject, tt.wantGlobal)
+			}
+		})
+	}
+}
+
+func TestInstallCopilotDefaultGlobal(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, false, false, false); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+
+	instructionsPath := copilotGlobalInstructionsPath(env.homeDir)
+	instructions, err := os.ReadFile(instructionsPath)
+	if err != nil {
+		t.Fatalf("read instructions: %v", err)
+	}
+	if !strings.Contains(string(instructions), "# GitHub Copilot Instructions") {
+		t.Fatalf("expected copilot instructions header in %s", instructionsPath)
+	}
+	if !strings.Contains(string(instructions), "profile:minimal") {
+		t.Fatalf("expected minimal beads section in %s", instructionsPath)
+	}
+	cfg := readCopilotHooks(t, copilotGlobalHooksPath(env.homeDir))
+	if !hasCopilotHookEvent(cfg, "sessionStart") || !hasCopilotHookEvent(cfg, "preCompact") {
+		t.Fatalf("expected global hooks to be installed")
+	}
+	if _, err := os.Stat(copilotHooksPath(env.projectDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected no project hooks for default global install, got err=%v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "global instructions installed") {
+		t.Fatalf("expected global success output, got: %s", out)
+	}
+}
+
+func TestInstallCopilotProject(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, true, false, false); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+
+	instructionsPath := copilotProjectInstructionsPath(env.projectDir)
+	instructions, err := os.ReadFile(instructionsPath)
+	if err != nil {
+		t.Fatalf("read instructions: %v", err)
+	}
+	if !strings.Contains(string(instructions), "# GitHub Copilot Instructions") {
+		t.Fatalf("expected copilot instructions header in %s", instructionsPath)
+	}
+	if !strings.Contains(string(instructions), "profile:minimal") {
+		t.Fatalf("expected minimal beads section in %s", instructionsPath)
+	}
+
+	cfg := readCopilotHooks(t, copilotHooksPath(env.projectDir))
+	if !hasCopilotHookEvent(cfg, "sessionStart") {
+		t.Fatal("expected sessionStart hook")
+	}
+	if !hasCopilotHookEvent(cfg, "preCompact") {
+		t.Fatal("expected preCompact hook")
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "project integration installed") {
+		t.Fatalf("expected project success output, got: %s", out)
+	}
+}
+
+func TestInstallCopilotBothScopes(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, true, true, false); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+
+	if _, err := os.Stat(copilotGlobalInstructionsPath(env.homeDir)); err != nil {
+		t.Fatalf("expected global instructions: %v", err)
+	}
+	if _, err := os.Stat(copilotGlobalHooksPath(env.homeDir)); err != nil {
+		t.Fatalf("expected global hooks: %v", err)
+	}
+	if _, err := os.Stat(copilotProjectInstructionsPath(env.projectDir)); err != nil {
+		t.Fatalf("expected project instructions: %v", err)
+	}
+	if _, err := os.Stat(copilotHooksPath(env.projectDir)); err != nil {
+		t.Fatalf("expected project hooks: %v", err)
+	}
+}
+
+func TestInstallCopilotProjectStealth(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, true, false, true); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+
+	cfg := readCopilotHooks(t, copilotHooksPath(env.projectDir))
+	for _, event := range []string{"sessionStart", "preCompact"} {
+		commands := cfg.Hooks[event]
+		if len(commands) != 1 {
+			t.Fatalf("expected one %s hook, got %d", event, len(commands))
+		}
+		if commands[0].Bash != "bd prime --stealth" {
+			t.Fatalf("expected stealth command for %s, got %q", event, commands[0].Bash)
+		}
+	}
+}
+
+func TestInstallCopilotProjectIdempotent(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, true, false, false); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := installCopilot(env, true, false, false); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	cfg := readCopilotHooks(t, copilotHooksPath(env.projectDir))
+	for _, event := range []string{"sessionStart", "preCompact"} {
+		if got := len(cfg.Hooks[event]); got != 1 {
+			t.Fatalf("expected one %s hook after reinstall, got %d", event, got)
+		}
+	}
+}
+
+func TestInstallCopilotProjectRejectsUnmanagedHookFile(t *testing.T) {
+	env, _, stderr := newCopilotTestEnv(t)
+
+	hooksPath := copilotHooksPath(env.projectDir)
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+	if err := os.WriteFile(hooksPath, []byte(`{"version":1,"hooks":{"sessionStart":[{"type":"command","bash":"echo custom"}]}}`), 0o644); err != nil {
+		t.Fatalf("write hooks file: %v", err)
+	}
+
+	err := installCopilot(env, true, false, false)
+	if err == nil {
+		t.Fatal("expected installCopilot to fail for unmanaged hook file")
+	}
+	if !strings.Contains(stderr.String(), "install hooks") {
+		t.Fatalf("expected hook installation error, got: %s", stderr.String())
+	}
+}
+
+func TestCheckCopilotGlobal(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, false, true, false); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+	stdout.Reset()
+
+	if err := checkCopilot(env, false, true); err != nil {
+		t.Fatalf("checkCopilot: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Hooks installed") {
+		t.Fatalf("expected global hooks check output, got: %s", out)
+	}
+	if !strings.Contains(out, "GitHub Copilot CLI (global) integration installed") {
+		t.Fatalf("expected global check output, got: %s", out)
+	}
+}
+
+func TestCheckCopilotProject(t *testing.T) {
+	env, stdout, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, true, false, false); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+	stdout.Reset()
+
+	if err := checkCopilot(env, true, false); err != nil {
+		t.Fatalf("checkCopilot: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Hooks installed") {
+		t.Fatalf("expected hooks check output, got: %s", out)
+	}
+	if !strings.Contains(out, "GitHub Copilot CLI (project) integration installed") {
+		t.Fatalf("expected instructions check output, got: %s", out)
+	}
+}
+
+func TestRemoveCopilotGlobal(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, false, true, false); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+	if err := removeCopilot(env, false, true); err != nil {
+		t.Fatalf("removeCopilot: %v", err)
+	}
+
+	instructions, err := os.ReadFile(copilotGlobalInstructionsPath(env.homeDir))
+	if err != nil {
+		t.Fatalf("read instructions: %v", err)
+	}
+	if strings.Contains(string(instructions), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("expected beads section to be removed from global instructions")
+	}
+	if _, err := os.Stat(copilotGlobalHooksPath(env.homeDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected global hooks to be removed, got err=%v", err)
+	}
+}
+
+func TestRemoveCopilotProject(t *testing.T) {
+	env, _, _ := newCopilotTestEnv(t)
+
+	if err := installCopilot(env, true, false, false); err != nil {
+		t.Fatalf("installCopilot: %v", err)
+	}
+	if err := removeCopilot(env, true, false); err != nil {
+		t.Fatalf("removeCopilot: %v", err)
+	}
+
+	if _, err := os.Stat(copilotHooksPath(env.projectDir)); !os.IsNotExist(err) {
+		t.Fatalf("expected hooks file to be removed, got err=%v", err)
+	}
+
+	instructions, err := os.ReadFile(copilotProjectInstructionsPath(env.projectDir))
+	if err != nil {
+		t.Fatalf("read instructions: %v", err)
+	}
+	if strings.Contains(string(instructions), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("expected beads section to be removed from instructions")
+	}
+	if !strings.Contains(string(instructions), "# GitHub Copilot Instructions") {
+		t.Fatalf("expected scaffold to remain after removing integration")
+	}
+}
+
+func TestCheckCopilotOldVersion(t *testing.T) {
+	env, _, stderr := newCopilotTestEnv(t)
+	env.runCommand = func(string, ...string) ([]byte, error) {
+		return []byte("copilot 1.0.4\n"), nil
+	}
+
+	err := installCopilot(env, true, false, false)
+	if !errors.Is(err, errCopilotVersionOld) {
+		t.Fatalf("expected errCopilotVersionOld, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "1.0.4") {
+		t.Fatalf("expected version error in stderr, got: %s", stderr.String())
+	}
+}

--- a/cmd/bd/setup_test.go
+++ b/cmd/bd/setup_test.go
@@ -104,6 +104,9 @@ func TestListRecipes_NoWorkspaceShowsBuiltinOnlyNote(t *testing.T) {
 	if !strings.Contains(out, "cursor") {
 		t.Fatalf("expected built-in recipes in output, got:\n%s", out)
 	}
+	if !strings.Contains(out, "copilot") {
+		t.Fatalf("expected copilot recipe in output, got:\n%s", out)
+	}
 	if strings.Contains(out, "myeditor") {
 		t.Fatalf("unexpected orphan custom recipe in output:\n%s", out)
 	}
@@ -183,5 +186,68 @@ func TestRunRecipe_BuiltinFileRecipeWorksWithoutWorkspace(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(tmpDir, ".beads")); !os.IsNotExist(err) {
 		t.Fatalf("expected no local .beads directory to be created, got err=%v", err)
+	}
+}
+
+func TestRunRecipe_CopilotGlobalWorksWithoutWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	homeDir := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	resetSetupResolutionCaches(t)
+	resetSetupGlobals(t)
+
+	out := captureStdout(t, func() error {
+		runRecipe("copilot")
+		return nil
+	})
+
+	if !strings.Contains(out, "global instructions installed") {
+		t.Fatalf("expected global copilot install output, got:\n%s", out)
+	}
+
+	if _, err := os.Stat(filepath.Join(homeDir, ".copilot", "copilot-instructions.md")); err != nil {
+		t.Fatalf("expected global copilot instructions: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(homeDir, ".copilot", "hooks", "beads-copilot.json")); err != nil {
+		t.Fatalf("expected global copilot hooks: %v", err)
+	}
+}
+
+func TestRunRecipe_CopilotProjectWorksWithoutWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	homeDir := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	resetSetupResolutionCaches(t)
+	resetSetupGlobals(t)
+	setupProject = true
+
+	out := captureStdout(t, func() error {
+		runRecipe("copilot")
+		return nil
+	})
+
+	if !strings.Contains(out, "project integration installed") {
+		t.Fatalf("expected project copilot install output, got:\n%s", out)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, ".github", "copilot-instructions.md")); err != nil {
+		t.Fatalf("expected project copilot instructions: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, ".github", "hooks", "beads-copilot.json")); err != nil {
+		t.Fatalf("expected project copilot hooks: %v", err)
 	}
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -910,6 +910,7 @@ bd setup factory  # Factory.ai Droid - creates/updates AGENTS.md (universal stan
 bd setup codex    # Codex CLI - creates/updates AGENTS.md
 bd setup mux      # Mux - creates/updates AGENTS.md
 bd setup claude   # Claude Code - installs hooks + manages CLAUDE.md (minimal profile)
+bd setup copilot  # GitHub Copilot CLI - installs global ~/.copilot/copilot-instructions.md + ~/.copilot/hooks/
 bd setup gemini   # Gemini CLI - installs hooks + manages GEMINI.md (minimal profile)
 bd setup cursor   # Cursor IDE - creates .cursor/rules/beads.mdc
 bd setup aider    # Aider - creates .aider.conf.yml
@@ -919,6 +920,8 @@ bd setup factory --check
 bd setup codex --check
 bd setup mux --check
 bd setup claude --check
+bd setup copilot --check
+bd setup copilot --project --check
 bd setup gemini --check
 bd setup cursor --check
 bd setup aider --check
@@ -928,6 +931,8 @@ bd setup factory --remove
 bd setup codex --remove
 bd setup mux --remove
 bd setup claude --remove
+bd setup copilot --remove
+bd setup copilot --project --remove
 bd setup gemini --remove
 bd setup cursor --remove
 bd setup aider --remove
@@ -938,6 +943,10 @@ bd setup aider --remove
 bd setup claude              # Install globally (~/.claude/settings.json)
 bd setup claude --project    # Install for this project only
 bd setup claude --stealth    # Use stealth mode (flush only, no git operations)
+bd setup copilot             # Install global ~/.copilot/copilot-instructions.md + ~/.copilot/hooks/beads-copilot.json
+bd setup copilot --global    # Same as default
+bd setup copilot --project   # Install .github/copilot-instructions.md + .github/hooks/beads-copilot.json
+bd setup copilot --project --stealth  # Use stealth mode for project hooks
 bd setup gemini              # Install globally (~/.gemini/settings.json)
 bd setup gemini --project    # Install for this project only
 bd setup gemini --stealth    # Use stealth mode (flush only, no git operations)
@@ -950,6 +959,7 @@ bd setup mux --global        # Also install ~/.mux/AGENTS.md global layer
 - **Codex CLI** (`bd setup codex`): Creates or updates AGENTS.md with beads workflow instructions for Codex (full profile)
 - **Mux** (`bd setup mux`): Creates or updates AGENTS.md with beads workflow instructions for Mux workspaces (full profile)
 - **Claude Code** (`bd setup claude`): Adds hooks to Claude Code's settings.json that run `bd prime` on SessionStart and PreCompact events and manages a minimal-profile beads section in `CLAUDE.md`
+- **GitHub Copilot CLI** (`bd setup copilot`, `bd setup copilot --project`): Default install manages global defaults in `~/.copilot/copilot-instructions.md` and `~/.copilot/hooks/beads-copilot.json`. Project mode manages a minimal-profile beads section in `.github/copilot-instructions.md` and repository-local hooks in `.github/hooks/beads-copilot.json` that run `bd prime` on `sessionStart` and `preCompact`
 - **Gemini CLI** (`bd setup gemini`): Adds hooks to Gemini's settings.json that run `bd prime` on SessionStart and PreCompress events and manages a minimal-profile beads section in `GEMINI.md`
 - **Cursor** (`bd setup cursor`): Creates `.cursor/rules/beads.mdc` with workflow instructions
 - **Aider** (`bd setup aider`): Creates `.aider.conf.yml` with bd workflow instructions
@@ -960,6 +970,7 @@ See also:
 - [INSTALLING.md](INSTALLING.md#ide-and-editor-integrations) - Installation guide
 - [AIDER_INTEGRATION.md](AIDER_INTEGRATION.md) - Detailed Aider guide
 - [CLAUDE_INTEGRATION.md](CLAUDE_INTEGRATION.md) - Claude integration design
+- [COPILOT_CLI_INTEGRATION.md](COPILOT_CLI_INTEGRATION.md) - Copilot CLI integration guide
 
 ## See Also
 

--- a/docs/COPILOT_CLI_INTEGRATION.md
+++ b/docs/COPILOT_CLI_INTEGRATION.md
@@ -1,0 +1,133 @@
+# GitHub Copilot CLI Integration Design
+
+This document explains design decisions for GitHub Copilot CLI integration in beads.
+
+For **VS Code + MCP**, see [COPILOT_INTEGRATION.md](COPILOT_INTEGRATION.md).
+
+## Integration Approach
+
+**Recommended: Copilot CLI + Hooks** - Beads uses Copilot CLI's native instruction files and hook system:
+- `bd prime` command for context injection (~1-2k tokens)
+- Personal hooks in `~/.copilot/hooks/` for global workflow defaults
+- Repository hooks in `.github/hooks/` for project-specific workflow refresh
+- Direct CLI commands with `--json` flags
+
+**Alternative: VS Code MCP** - For Copilot Chat in the editor:
+- Native tool calling through MCP
+- Higher context overhead from tool schemas
+- Use when you want editor-native tool access instead of terminal-first workflow
+
+## Why Copilot CLI + Hooks Over MCP?
+
+**Context efficiency still matters**, even with large context windows:
+
+1. **Compute cost scales with tokens** - Every token in context is processed on every inference
+2. **Latency increases with context** - Smaller prompts keep the CLI more responsive
+3. **Energy consumption** - Lean prompts are more sustainable over long sessions
+4. **Attention quality** - Models generally perform better with tighter, more relevant context
+
+**The math:**
+- MCP tool schemas can add 10-50k tokens to context
+- `bd prime` adds ~1-2k tokens of workflow context
+- That is an order-of-magnitude reduction in overhead
+
+**When context size matters less:**
+- You specifically want Copilot Chat tool calls inside VS Code
+- You are in a workflow where terminal hooks are not the right integration point
+
+**When to prefer Copilot CLI + hooks:**
+- Terminal-first coding sessions
+- Long-running implementation work
+- Projects where you want automatic `bd prime` refresh without MCP setup
+- Workflows that span multiple editors or shells
+
+## Why Global + Project Scopes?
+
+**Decision: Beads supports both personal and repository-local Copilot CLI integration**
+
+### Reasons
+
+1. **Copilot CLI supports both surfaces**
+   - Global instructions live in `~/.copilot/copilot-instructions.md`
+   - Personal hooks live in `~/.copilot/hooks/`
+   - Repository-local instructions and hooks live under `.github/`
+
+2. **Global defaults are convenient**
+   - `bd setup copilot` gives you a personal baseline once
+   - Useful when you work across many repositories
+   - Keeps your common workflow available everywhere
+
+3. **Project hooks remain important**
+   - Repository-local hooks let a project opt into Beads explicitly
+   - Team repositories can commit `.github/hooks/*.json` and `.github/copilot-instructions.md`
+   - Local project setup stays self-contained and reviewable
+
+4. **Beads stays explicit**
+   - Global mode handles personal defaults
+   - Project mode handles repository behavior
+   - Users can choose one or both instead of getting hidden behavior
+
+### Current behavior
+
+- `bd setup copilot` or `bd setup copilot --global`
+  - installs `~/.copilot/copilot-instructions.md`
+  - installs `~/.copilot/hooks/beads-copilot.json`
+
+- `bd setup copilot --project`
+  - installs `.github/copilot-instructions.md`
+  - installs `.github/hooks/beads-copilot.json`
+
+### Version policy
+
+Beads requires **Copilot CLI 1.0.5 or newer** for the `preCompact` hook. The integration intentionally targets full parity with the Claude-style hook model instead of shipping a weaker partial setup.
+
+## Installation
+
+```bash
+# Install Copilot CLI defaults globally
+bd setup copilot
+
+# Same as above, but explicit
+bd setup copilot --global
+
+# Install for this project only
+bd setup copilot --project
+
+# Use stealth mode for project hooks
+bd setup copilot --project --stealth
+
+# Check installation status
+bd setup copilot --check
+bd setup copilot --project --check
+
+# Remove integration
+bd setup copilot --remove
+bd setup copilot --project --remove
+```
+
+**What it installs:**
+- `sessionStart` hook: Runs `bd prime` when Copilot CLI starts a session
+- `preCompact` hook: Runs `bd prime` before context compaction to preserve workflow instructions
+- Minimal-profile Beads instructions in Copilot's instruction files
+
+## Stealth Mode
+
+Stealth mode is only relevant for **project hooks**:
+
+```bash
+bd setup copilot --project --stealth
+```
+
+This changes the project hook command from `bd prime` to `bd prime --stealth`.
+
+## Related Files
+
+- `cmd/bd/setup/copilot.go` - Copilot setup/check/remove logic
+- `cmd/bd/setup/copilot_test.go` - Copilot setup tests
+- `cmd/bd/doctor/copilot.go` - Repository-level Copilot verification
+- `docs/COPILOT_INTEGRATION.md` - VS Code MCP integration
+
+## References
+
+- [GitHub Copilot CLI docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+- [Copilot hooks documentation](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks)

--- a/docs/COPILOT_INTEGRATION.md
+++ b/docs/COPILOT_INTEGRATION.md
@@ -1,6 +1,8 @@
-# GitHub Copilot Integration Guide
+# GitHub Copilot VS Code MCP Integration Guide
 
-This guide explains how to use beads with GitHub Copilot in VS Code.
+This guide explains how to use beads with GitHub Copilot in **VS Code via MCP**.
+
+For the **GitHub Copilot CLI** integration installed by `bd setup copilot`, see [COPILOT_CLI_INTEGRATION.md](COPILOT_CLI_INTEGRATION.md).
 
 ## Overview
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -260,6 +260,7 @@ bd init --quiet
 
 # 3. Setup editor integration (choose one)
 bd setup claude   # Claude Code - installs SessionStart/PreCompact hooks
+bd setup copilot  # GitHub Copilot CLI - installs global ~/.copilot/copilot-instructions.md + ~/.copilot/hooks/
 bd setup cursor   # Cursor IDE - creates .cursor/rules/beads.mdc
 bd setup aider    # Aider - creates .aider.conf.yml
 bd setup codex    # Codex CLI - creates/updates AGENTS.md
@@ -281,6 +282,8 @@ bd setup mux      # Mux - creates/updates AGENTS.md
 **Verify installation:**
 ```bash
 bd setup claude --check   # Check Claude Code integration
+bd setup copilot --check  # Check global GitHub Copilot CLI instructions
+bd setup copilot --project --check  # Check project GitHub Copilot CLI hooks + instructions
 bd setup cursor --check   # Check Cursor integration
 bd setup aider --check    # Check Aider integration
 bd setup codex --check    # Check Codex integration
@@ -351,6 +354,21 @@ For VS Code with GitHub Copilot:
 4. **Reload VS Code**
 
 See [COPILOT_INTEGRATION.md](COPILOT_INTEGRATION.md) for complete setup guide.
+
+### GitHub Copilot CLI
+
+For the GitHub Copilot CLI terminal integration:
+
+```bash
+bd setup copilot           # Global instructions
+bd setup copilot --project # Project instructions + hooks
+```
+
+The default command manages `~/.copilot/copilot-instructions.md` and `~/.copilot/hooks/beads-copilot.json`.
+
+Project mode manages `.github/copilot-instructions.md` and installs repository-local hooks in `.github/hooks/beads-copilot.json`.
+
+See [COPILOT_CLI_INTEGRATION.md](COPILOT_CLI_INTEGRATION.md) for the full guide.
 
 ### MCP Server (Alternative - for MCP-only environments)
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -13,14 +13,14 @@ The `bd setup` command uses a **recipe-based architecture** to configure beads i
 
 ### Profiles
 
-Each integration uses one of two **profiles** that control how much content is written to tool instruction files (`AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`):
+Each integration uses one of two **profiles** that control how much content is written to tool instruction files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or `.github/copilot-instructions.md`):
 
 | Profile | Used By | Content |
 |---------|---------|---------|
 | `full` | Factory, Codex, Mux, OpenCode | Complete command reference, issue types, priorities, workflow |
-| `minimal` | Claude Code, Gemini CLI | Pointer to `bd prime`, quick reference only (~60% smaller) |
+| `minimal` | Claude Code, GitHub Copilot CLI, Gemini CLI | Pointer to `bd prime`, quick reference only (~60% smaller) |
 
-Hook-enabled agents (Claude, Gemini) use the `minimal` profile because `bd prime` injects full context at session start. Hookless agents need the `full` profile because their instruction file is their only source of instructions.
+Hook-enabled agents (Claude, Copilot CLI, Gemini) use the `minimal` profile because `bd prime` injects full context at session start. Hookless agents need the `full` profile because their instruction file is their only source of instructions.
 
 **Profile precedence:** If a file already has a `full` profile section and a `minimal` profile tool installs to the same file (e.g., via symlinks), the `full` profile is preserved to avoid information loss.
 
@@ -33,6 +33,7 @@ Hook-enabled agents (Claude, Gemini) use the `minimal` profile because `bd prime
 | `cody` | `.cody/rules/beads.md` | Rules file |
 | `kilocode` | `.kilocode/rules/beads.md` | Rules file |
 | `claude` | `~/.claude/settings.json` + `CLAUDE.md` | SessionStart/PreCompact hooks + minimal section |
+| `copilot` | `~/.copilot/copilot-instructions.md` + `~/.copilot/hooks/beads-copilot.json` or `.github/hooks/beads-copilot.json` + `.github/copilot-instructions.md` | global hooks + instructions or project hooks + minimal section |
 | `gemini` | `~/.gemini/settings.json` + `GEMINI.md` | SessionStart/PreCompress hooks + minimal section |
 | `factory` | `AGENTS.md` | Marked section |
 | `codex` | `AGENTS.md` | Marked section |
@@ -50,6 +51,8 @@ bd setup cursor     # Cursor IDE
 bd setup windsurf   # Windsurf
 bd setup kilocode   # Kilo Code
 bd setup claude     # Claude Code
+bd setup copilot    # GitHub Copilot CLI global instructions
+bd setup copilot --project  # GitHub Copilot CLI project hooks + instructions
 bd setup gemini     # Gemini CLI
 bd setup factory    # Factory.ai Droid
 bd setup codex      # Codex CLI

--- a/internal/recipes/recipes.go
+++ b/internal/recipes/recipes.go
@@ -78,6 +78,13 @@ var BuiltinRecipes = map[string]Recipe{
 		GlobalPath:  "~/.gemini/settings.json",
 		ProjectPath: ".gemini/settings.json",
 	},
+	"copilot": {
+		Name:        "GitHub Copilot CLI",
+		Type:        TypeHooks,
+		Description: "Copilot CLI global instructions or project hooks + instructions",
+		GlobalPath:  "~/.copilot/copilot-instructions.md",
+		ProjectPath: ".github/copilot-instructions.md",
+	},
 	"factory": {
 		Name:        "Factory.ai (Droid)",
 		Path:        "AGENTS.md",


### PR DESCRIPTION
Summary

Adds first-class GitHub Copilot CLI integration to bd setup and bd doctor.

This introduces a new copilot setup target that manages Copilot instruction files and hooks, similar to the existing Claude and Gemini integrations, while staying separate from the existing VS Code MCP documentation.

What changed

Setup support

 - Added bd setup copilot
 - Added bd setup copilot --global
 - Added bd setup copilot --project
 - Added bd setup copilot --check
 - Added bd setup copilot --remove
 - Added bd setup copilot --project --stealth

Installed files

Global mode

 - ~/.copilot/copilot-instructions.md
 - ~/.copilot/hooks/beads-copilot.json

Project mode

 - .github/copilot-instructions.md
 - .github/hooks/beads-copilot.json

Hook behavior

Installs Copilot hooks for:

 - sessionStart → bd prime
 - preCompact → bd prime

Project mode also supports:

 - bd prime --stealth

Doctor support

Added Copilot-specific doctor checks for:

 - integration presence
 - hook JSON health
 - hook completeness
 - documentation discovery for Copilot instruction files

Docs

 - Added docs/COPILOT_CLI_INTEGRATION.md
 - Updated setup/install/reference docs
 - Clarified separation between:
  - Copilot CLI integration
  - VS Code Copilot MCP integration

Tests

Added/updated tests for:

 - Copilot setup install/check/remove behavior
 - global vs project scope
 - stealth mode
 - version gating
 - unmanaged hook protection
 - doctor integration checks
 - setup/doctor command wiring