### PR TITLE
fix(dolt): resolve shared-server CLI dir from shared root

### DIFF
--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -400,6 +400,89 @@ func TestCredentialCLIRoutingNoRemote(t *testing.T) {
 	}
 }
 
+func TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping shared-server credential routing test")
+	}
+
+	sharedRoot := t.TempDir()
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedRoot)
+
+	database := "shared_credentials_db"
+	cliDir := filepath.Join(sharedRoot, "dolt", database)
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("dolt", "init")
+	cmd.Dir = cliDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt init failed: %s: %v", out, err)
+	}
+
+	cmd = exec.Command("dolt", "remote", "add", "origin", "https://example.com/repo")
+	cmd.Dir = cliDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt remote add failed: %s: %v", out, err)
+	}
+
+	store := &DoltStore{
+		remoteUser:     "user",
+		remotePassword: "pass",
+		serverMode:     true,
+		beadsDir:       filepath.Join(t.TempDir(), ".beads"),
+		dbPath:         filepath.Join(t.TempDir(), ".beads", "dolt"),
+		database:       database,
+		remote:         "origin",
+	}
+
+	if !store.shouldUseCLIForCredentials(context.Background()) {
+		t.Fatalf("expected shared-server credential routing to resolve CLI remote via %q, got CLIDir %q", cliDir, store.CLIDir())
+	}
+}
+
+func TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping shared-server cloud-auth routing test")
+	}
+
+	sharedRoot := t.TempDir()
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedRoot)
+	t.Setenv("AZURE_STORAGE_ACCOUNT", "myaccount")
+
+	database := "shared_cloud_auth_db"
+	cliDir := filepath.Join(sharedRoot, "dolt", database)
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("dolt", "init")
+	cmd.Dir = cliDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt init failed: %s: %v", out, err)
+	}
+
+	cmd = exec.Command("dolt", "remote", "add", "origin", "https://example.com/repo")
+	cmd.Dir = cliDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt remote add failed: %s: %v", out, err)
+	}
+
+	store := &DoltStore{
+		serverMode: true,
+		beadsDir:   filepath.Join(t.TempDir(), ".beads"),
+		dbPath:     filepath.Join(t.TempDir(), ".beads", "dolt"),
+		database:   database,
+		remote:     "origin",
+	}
+
+	if !store.shouldUseCLIForCloudAuth() {
+		t.Fatalf("expected shared-server cloud-auth routing to resolve CLI remote via %q, got CLIDir %q", cliDir, store.CLIDir())
+	}
+}
+
 // TestFederationCredentialCLIRouting verifies the shouldUseCLIForPeerCredentials guard
 // that controls CLI subprocess routing for federation PushTo, PullFrom, and Fetch
 // when peer credentials are resolved from the federation_peers table.

--- a/internal/storage/dolt/git_remote_shared_server_test.go
+++ b/internal/storage/dolt/git_remote_shared_server_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/testutil"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestCredentialCLIRoutingE2ESharedServer verifies that shared-server mode can
+// route credential-bearing pushes through the shared Dolt root even when the
+// per-project dbPath is stale and lacks the remote.
+func TestCredentialCLIRoutingE2ESharedServer(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping test")
+	}
+	skipIfNoGit(t)
+
+	baseDir, err := os.MkdirTemp("", "credential-cli-routing-shared-server-e2e-*")
+	if err != nil {
+		t.Fatalf("failed to create base dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(baseDir) })
+
+	remoteDir := filepath.Join(baseDir, "remote.git")
+	runCmd(t, baseDir, "git", "init", "--bare", "-b", "main", remoteDir)
+
+	seedDir := filepath.Join(baseDir, "seed")
+	if err := os.MkdirAll(seedDir, 0o755); err != nil {
+		t.Fatalf("failed to create seed dir: %v", err)
+	}
+	runCmd(t, seedDir, "git", "init", "-b", "main")
+	runCmd(t, seedDir, "git", "commit", "--allow-empty", "-m", "init")
+	runCmd(t, seedDir, "git", "remote", "add", "origin", remoteDir)
+	runCmd(t, seedDir, "git", "push", "-u", "origin", "main")
+
+	remoteURL := "file://" + remoteDir
+
+	sharedServerDir := filepath.Join(baseDir, "shared-server")
+	sharedDoltDir := filepath.Join(sharedServerDir, "dolt")
+	if err := os.MkdirAll(sharedDoltDir, 0o755); err != nil {
+		t.Fatalf("failed to create shared dolt dir: %v", err)
+	}
+	runCmd(t, sharedDoltDir, "dolt", "init", "--name", "test", "--email", "test@test.com")
+
+	sharedTestdbDir := filepath.Join(sharedDoltDir, "testdb")
+	if err := os.MkdirAll(sharedTestdbDir, 0o755); err != nil {
+		t.Fatalf("failed to create shared testdb dir: %v", err)
+	}
+	runCmd(t, sharedTestdbDir, "dolt", "init", "--name", "test", "--email", "test@test.com")
+	runCmd(t, sharedTestdbDir, "dolt", "remote", "add", "origin", remoteURL)
+
+	initSchemaSQL := schema.AllMigrationsSQL() + "\nCALL DOLT_ADD('.');\nCALL DOLT_COMMIT('-Am', 'Genesis: schema and config');"
+	runDoltSQL(t, sharedTestdbDir, initSchemaSQL)
+
+	port, err := testutil.FindFreePort()
+	if err != nil {
+		t.Fatalf("failed to find free port: %v", err)
+	}
+	serverCmd := exec.Command("dolt", "sql-server",
+		"-H", "127.0.0.1",
+		"-P", fmt.Sprintf("%d", port),
+	)
+	serverCmd.Dir = sharedDoltDir
+	if err := serverCmd.Start(); err != nil {
+		t.Fatalf("failed to start dolt sql-server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = serverCmd.Process.Kill()
+		_ = serverCmd.Wait()
+	})
+
+	if !testutil.WaitForServer(port, 15*time.Second) {
+		t.Fatal("dolt sql-server did not become ready within timeout")
+	}
+
+	projectBeadsDir := filepath.Join(baseDir, "project", ".beads")
+	clientDataDir := filepath.Join(projectBeadsDir, "dolt")
+	clientTestdbDir := filepath.Join(clientDataDir, "testdb")
+	if err := os.MkdirAll(clientTestdbDir, 0o755); err != nil {
+		t.Fatalf("failed to create client testdb dir: %v", err)
+	}
+	runCmd(t, clientTestdbDir, "dolt", "init", "--name", "test", "--email", "test@test.com")
+
+	cmd := exec.Command("dolt", "remote", "-v")
+	cmd.Dir = clientTestdbDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dolt remote -v failed in stale client dir: %v\n%s", err, output)
+	}
+	require.NotContains(t, string(output), "origin", "stale per-project CLI dir should not contain the shared remote")
+
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedServerDir)
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+	t.Setenv("BEADS_TEST_MODE", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	store, err := New(ctx, &Config{
+		Path:            clientDataDir,
+		BeadsDir:        projectBeadsDir,
+		Database:        "testdb",
+		ServerHost:      "127.0.0.1",
+		ServerPort:      port,
+		ServerUser:      "root",
+		CommitterName:   "test",
+		CommitterEmail:  "test@test.com",
+		AutoStart:       false,
+		CreateIfMissing: false,
+		Remote:          "origin",
+		RemoteUser:      "testuser",
+		RemotePassword:  "testpassword",
+	})
+	if err != nil {
+		t.Fatalf("failed to create DoltStore: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("SetConfig(issue_prefix) failed: %v", err)
+	}
+
+	require.Equal(t, filepath.Join(sharedDoltDir, "testdb"), store.CLIDir(), "shared-server CLIDir should resolve to shared Dolt root")
+	require.True(t, store.shouldUseCLIForCredentials(ctx), "shared-server mode should route credentials via the shared CLI remote")
+
+	issue := &types.Issue{
+		ID:        "shared-route-001",
+		Title:     "Shared server routed push",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+	if err := store.Commit(ctx, "Add shared-route-001"); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("Push failed: %v", err)
+	}
+
+	cloneDir := filepath.Join(baseDir, "clone-shared-routing")
+	doltClone(t, remoteURL, cloneDir)
+
+	rows := queryCSV(t, cloneDir, "SELECT id, title FROM issues WHERE id = 'shared-route-001'")
+	if len(rows) == 0 {
+		t.Fatal("clone: expected shared-route-001 to exist after shared-server push")
+	}
+	if rows[0]["title"] != "Shared server routed push" {
+		t.Errorf("clone: title = %q, want %q", rows[0]["title"], "Shared server routed push")
+	}
+}

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -102,6 +103,41 @@ func TestResolveAutoStart(t *testing.T) {
 					tc.currentValue, tc.doltAutoStartCfg, got, tc.wantAutoStart)
 			}
 		})
+	}
+}
+
+func TestCLIDirUsesSharedDoltRootInSharedServerMode(t *testing.T) {
+	sharedRoot := t.TempDir()
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedRoot)
+
+	store := &DoltStore{
+		serverMode: true,
+		beadsDir:   filepath.Join(t.TempDir(), ".beads"),
+		dbPath:     filepath.Join(t.TempDir(), ".beads", "dolt"),
+		database:   "shared_db",
+	}
+
+	want := filepath.Join(sharedRoot, "dolt", "shared_db")
+	if got := store.CLIDir(); got != want {
+		t.Fatalf("CLIDir() = %q, want %q", got, want)
+	}
+}
+
+func TestCLIDirUsesDbPathOutsideSharedServerMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+
+	dbPath := filepath.Join(t.TempDir(), ".beads", "dolt")
+	store := &DoltStore{
+		serverMode: true,
+		beadsDir:   filepath.Join(t.TempDir(), ".beads"),
+		dbPath:     dbPath,
+		database:   "local_db",
+	}
+
+	want := filepath.Join(dbPath, "local_db")
+	if got := store.CLIDir(); got != want {
+		t.Fatalf("CLIDir() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1501,6 +1501,9 @@ func (s *DoltStore) Path() string {
 // Use this instead of Path() when running dolt CLI commands that target the
 // actual database (e.g., remote add/remove, push, pull).
 func (s *DoltStore) CLIDir() string {
+	if s.serverMode && doltserver.IsSharedServerMode() && s.beadsDir != "" {
+		return filepath.Join(doltserver.ResolveDoltDir(s.beadsDir), s.database)
+	}
 	if s.dbPath == "" {
 		return ""
 	}


### PR DESCRIPTION
## Summary

In shared-server mode, `CLIDir()` can resolve from the authoritative shared Dolt root instead of the per-project `.beads/dolt/<db>` path.

This change is intentionally limited to shared-server mode. It does not change generic external-server behavior.

## What changed

- update `internal/storage/dolt/store.go`
  - when `serverMode` is true and `IsSharedServerMode()` is true, resolve `CLIDir()` via `doltserver.ResolveDoltDir(beadsDir)`
  - preserve the old `dbPath` behavior everywhere else
- add direct path-resolution coverage in `internal/storage/dolt/open_test.go`
- add shared-server routing-guard coverage in `internal/storage/dolt/credentials_test.go`
- add a workflow-style integration regression in `internal/storage/dolt/git_remote_shared_server_test.go`

## Why this scope

Shared-server mode has a local, authoritative Dolt root. Generic external-server mode does not necessarily have that property, so this PR avoids changing that behavior.

The goal here is to fix the shared-server CLI path case without claiming to solve the broader external-server path-authority problem.

## Verification

- `CGO_ENABLED=0 go test ./internal/storage/dolt -run 'TestCLIDirUsesSharedDoltRootInSharedServerMode|TestCLIDirUsesDbPathOutsideSharedServerMode|TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot|TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot'`
- `CGO_ENABLED=0 go test -count=1 -tags integration ./internal/storage/dolt -run 'TestCredentialCLIRoutingE2ESharedServer|TestCredentialCLIRoutingE2E|TestGitRemoteExternalServerRouting'`

Both passed in a clean branch containing only this scoped slice.

Closes #3219