### PR TITLE
fix(storage): reject cross-type wisp↔issue bonds with typed ErrCrossTypeBond

### DIFF
--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -32,6 +32,21 @@ func (t *doltTransaction) isActiveWisp(ctx context.Context, id string) bool {
 	return err == nil
 }
 
+// classifyBondSides reports whether each side of a dependency is an active wisp.
+// Both sides are queried within the transaction so uncommitted wisps are seen.
+// Used by AddDependency to detect cross-type bonds before INSERT.
+func (t *doltTransaction) classifyBondSides(ctx context.Context, leftID, rightID string) (leftIsWisp, rightIsWisp bool) {
+	return t.isActiveWisp(ctx, leftID), t.isActiveWisp(ctx, rightID)
+}
+
+// bondKindLabel returns "wisp" or "issue" for use in error messages.
+func bondKindLabel(isWisp bool) string {
+	if isWisp {
+		return "wisp"
+	}
+	return "issue"
+}
+
 // CreateIssueImport is the import-friendly issue creation hook.
 // Dolt does not enforce prefix validation at the storage layer, so this delegates to CreateIssue.
 func (t *doltTransaction) CreateIssueImport(ctx context.Context, issue *types.Issue, actor string, skipPrefixValidation bool) error {
@@ -630,9 +645,24 @@ func (t *doltTransaction) DeleteIssue(ctx context.Context, id string) error {
 
 // AddDependency adds a dependency within the transaction.
 // Checks for existing pairs to prevent silent type overwrites.
+//
+// Cross-type bonds are rejected: both sides must be the same kind (both
+// active wisps or both non-wisp issues). Mixed bonds return
+// storage.ErrCrossTypeBond because the dependencies and wisp_dependencies
+// tables are routed by left-side type, and a wisp↔issue pair would either
+// trip the dependencies.issue_id foreign key or insert a row that points
+// out of the wisp_dependencies graph.
 func (t *doltTransaction) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	leftIsWisp, rightIsWisp := t.classifyBondSides(ctx, dep.IssueID, dep.DependsOnID)
+	if leftIsWisp != rightIsWisp {
+		return fmt.Errorf("%w: %s (%s) -> %s (%s)",
+			storage.ErrCrossTypeBond,
+			dep.IssueID, bondKindLabel(leftIsWisp),
+			dep.DependsOnID, bondKindLabel(rightIsWisp))
+	}
+
 	table := "dependencies"
-	if t.isActiveWisp(ctx, dep.IssueID) {
+	if leftIsWisp {
 		table = "wisp_dependencies"
 	}
 

--- a/internal/storage/dolt/transaction_cross_type_test.go
+++ b/internal/storage/dolt/transaction_cross_type_test.go
@@ -1,0 +1,123 @@
+package dolt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestAddDependency_CrossTypeBondRejection verifies that AddDependency rejects
+// dependencies whose two sides are different kinds (one wisp, one non-wisp
+// issue), returning a typed storage.ErrCrossTypeBond.
+//
+// Background: AddDependency routes its INSERT to dependencies vs
+// wisp_dependencies based on the left-side type only (isActiveWisp(IssueID)).
+// Without the cross-type check, a wisp↔issue bond either trips fk_dep_issue
+// at INSERT time with an opaque Dolt 1452, or silently inserts an
+// orphan-pointing row into wisp_dependencies that breaks downstream joins.
+// The typed-error contract lets callers recover deliberately instead of
+// pattern-matching on Dolt's FK error string.
+func TestAddDependency_CrossTypeBondRejection(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Create two distinct issues (so the issue→issue happy path is a
+	// real INSERT, not an idempotency short-circuit).
+	issueA := &types.Issue{
+		Title:     "issue side A",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issueA, "tester"); err != nil {
+		t.Fatalf("CreateIssue (issueA) failed: %v", err)
+	}
+	issueB := &types.Issue{
+		Title:     "issue side B",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issueB, "tester"); err != nil {
+		t.Fatalf("CreateIssue (issueB) failed: %v", err)
+	}
+
+	// Create two distinct wisps (same reasoning).
+	wispA := &types.Issue{
+		Title:     "wisp side A",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, wispA, "tester"); err != nil {
+		t.Fatalf("CreateIssue (wispA) failed: %v", err)
+	}
+	wispB := &types.Issue{
+		Title:     "wisp side B",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, wispB, "tester"); err != nil {
+		t.Fatalf("CreateIssue (wispB) failed: %v", err)
+	}
+
+	// Sanity-check the routing precondition: wisps must be active
+	// (in the wisps table), issues must NOT be.
+	if !store.isActiveWisp(ctx, wispA.ID) {
+		t.Fatalf("precondition: wispA expected to be active wisp, isActiveWisp=false (id=%s)", wispA.ID)
+	}
+	if !store.isActiveWisp(ctx, wispB.ID) {
+		t.Fatalf("precondition: wispB expected to be active wisp, isActiveWisp=false (id=%s)", wispB.ID)
+	}
+	if store.isActiveWisp(ctx, issueA.ID) {
+		t.Fatalf("precondition: issueA must not be an active wisp (id=%s)", issueA.ID)
+	}
+	if store.isActiveWisp(ctx, issueB.ID) {
+		t.Fatalf("precondition: issueB must not be an active wisp (id=%s)", issueB.ID)
+	}
+
+	cases := []struct {
+		name        string
+		left, right string
+		wantErr     error // nil = success expected
+	}{
+		{"issue->issue", issueA.ID, issueB.ID, nil},
+		{"wisp->wisp", wispA.ID, wispB.ID, nil},
+		{"wisp->issue", wispA.ID, issueA.ID, storage.ErrCrossTypeBond},
+		{"issue->wisp", issueA.ID, wispA.ID, storage.ErrCrossTypeBond},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := store.RunInTransaction(ctx, "test: cross-type bond", func(tx storage.Transaction) error {
+				return tx.AddDependency(ctx, &types.Dependency{
+					IssueID:     tc.left,
+					DependsOnID: tc.right,
+					Type:        types.DepRelated,
+				}, "tester")
+			})
+
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected success, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected %v, got nil", tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected errors.Is(err, %v) to be true, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -28,6 +28,16 @@ var ErrNotInitialized = errors.New("database not initialized")
 // ErrPrefixMismatch is returned when an issue ID does not match the configured prefix.
 var ErrPrefixMismatch = errors.New("prefix mismatch")
 
+// ErrCrossTypeBond is returned when AddDependency is called with a Dependency
+// whose IssueID and DependsOnID are not the same kind: one is an active wisp
+// and the other is a non-wisp issue. The dependencies and wisp_dependencies
+// tables are routed by the left-side type, so cross-type bonds either trip
+// fk_dep_issue (when the left side is a non-wisp issue and the right side is
+// a wisp not present in the issues table) or insert orphan-pointing rows into
+// wisp_dependencies. Callers that need cross-kind references should use a
+// non-storage edge (e.g. metadata pointer) or promote/demote first.
+var ErrCrossTypeBond = errors.New("cross-type bond rejected: wisp and issue cannot be bonded directly")
+
 // Storage is the interface satisfied by *dolt.DoltStore.
 // Consumers depend on this interface rather than on the concrete type so that
 // alternative implementations (mocks, proxies, etc.) can be substituted.


### PR DESCRIPTION
Closes #3226.

## Problem

`doltTransaction.AddDependency` routes its INSERT to `dependencies` vs
`wisp_dependencies` based on the *left* side type only. The right side
is never type-checked, so a wisp↔issue bond either trips `fk_dep_issue`
with an opaque Dolt 1452 or silently inserts an orphan-pointing row into
`wisp_dependencies` that breaks downstream joins.

Full repro and impact in #3226.

> Terminology note: "type" in `ErrCrossTypeBond` refers to *storage kind*
> (wisp vs non-wisp issue), distinct from `IssueType` (epic vs task) used
> by the existing `TestAddDependency_BlocksCrossType_*` tests. Those tests
> are about a different dimension and remain unaffected by this PR.

## Fix

1. New typed error `storage.ErrCrossTypeBond` (comparable via `errors.Is`).
2. New helper `doltTransaction.classifyBondSides(ctx, leftID, rightID)` next
   to `isActiveWisp`.
3. `AddDependency` validates both sides before routing; mismatched kinds
   return a wrapped `ErrCrossTypeBond` with both IDs and their detected
   kinds in the message.
4. New `transaction_cross_type_test.go` covers all four cases:
   - `issue->issue` ✓ (distinct issues to avoid idempotency short-circuit)
   - `wisp->wisp` ✓ (same)
   - `wisp->issue` → `ErrCrossTypeBond`
   - `issue->wisp` → `ErrCrossTypeBond`

## Behavior changes

- Same-kind bonds (both wisps, both non-wisp issues) are unchanged.
- Cross-kind bonds now return `storage.ErrCrossTypeBond` instead of an
  opaque Dolt FK error or a silent insert.
- No schema changes, no data migration. Pre-existing rows in either table
  remain queryable; the new check fires only on new `AddDependency` calls.

## Out of scope

- Re-adding `fk_dep_depends_on` (deliberately dropped at startup in
  `store.go` to allow external references).
- Auto-promoting one side to match the other (explicit rejection is safer).
- Adding a CHECK constraint on `wisp_dependencies` (Dolt CHECK support is
  uneven; runtime check is portable).

## Design context (downstream consumer)

This bug surfaced via Gas Town's molecule/wisp pipeline, where a workflow
formula is bonded to a work bead. The downstream model uses Kanban *lanes*
(`planning` / `working` / `reviewing` / `deploying`) as labels on top of
the existing vanilla beads status enum, rather than as new built-in
statuses. The lane is a noun describing the worker action, and stays in
`labels`; the bead status (`open` / `working` / `blocked` / `closed`) stays
on the bead as upstream defines it. This PR is the storage-layer hardening
that lets that lane-overlay model proceed against vanilla beads — no
custom statuses needed, just a contract that wisp↔issue bonds get a clean
typed error instead of an opaque FK violation.

## Audit query (for reviewers)

Defensive query to find any pre-existing cross-kind rows on a deployed
DB before merging. Likely zero in well-behaved deployments — included for
completeness:

```sql
-- Rows in dependencies whose depends_on_id is actually a wisp:
SELECT d.issue_id, d.depends_on_id, d.type
FROM dependencies d
JOIN wisps w ON d.depends_on_id = w.id;

-- Rows in wisp_dependencies whose depends_on_id is actually a non-wisp issue:
SELECT wd.issue_id, wd.depends_on_id, wd.type
FROM wisp_dependencies wd
JOIN issues i ON wd.depends_on_id = i.id;
```

Pre-existing rows (if any) remain queryable; the new check does not affect
reads.

## Test plan

Local:
```bash
docker pull dolthub/dolt-sql-server:1.86.0
go test ./internal/storage/dolt/ -run TestAddDependency_CrossTypeBondRejection -v
go test ./internal/storage/dolt/ -run "TestAddDependency|TestGetDependenc|TestDetectCycles|TestRemoveDep" -v
```

Both runs pass on `crew/emmett/cross-type-bond-rejection` against base
commit `dfd1add6`. The new test covers all 4 routing combinations; the
broader dependency-test sweep covers the regression surface (idempotency,
self-reference, parent-child, blocks, external references, cycle
detection).

Pre-existing flakes/failures unaffected by this PR (verified by running
the same tests on pristine `origin/main` with the new file removed):
- `TestUpdateIssueIDUpdatesWispTables` (deterministically fails on
  `dfd1add6` — unrelated to dependency routing; happy to file separately
  if useful)

## Diff size

3 files changed, +164 / -1.

| File | Lines | Purpose |
|---|---|---|
| `internal/storage/storage.go` | +10 / -0 | Add `ErrCrossTypeBond` next to other `Err*` declarations |
| `internal/storage/dolt/transaction.go` | +31 / -1 | Add `classifyBondSides` + `bondKindLabel` helpers; type-validate in `AddDependency` |
| `internal/storage/dolt/transaction_cross_type_test.go` | +123 (new file) | 4-case parameterized test |

## Notes for reviewers

- No fork-attribution comments. Pure upstream contribution.
- The downstream incident report is private (Gas Town internal), but the
  reproduction in #3226 is fully self-contained against vanilla beads.
- I'm happy to rebase / split / rename if the maintainers prefer a
  different shape. The minimal change is the validation in
  `AddDependency` + the typed error; everything else (helper, kind label)
  is for readability.