### PR TITLE
Fix formula search paths for worktree-aware beads dirs

### DIFF
--- a/cmd/bd/formula.go
+++ b/cmd/bd/formula.go
@@ -30,7 +30,7 @@ The Rig → Cook → Run lifecycle:
   - Run: Agents execute poured mols or wisps
 
 Search paths (in order):
-  1. .beads/formulas/ (project)
+  1. <resolved-beads-dir>/formulas/ (active project)
   2. ~/.beads/formulas/ (user)
   3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
@@ -46,7 +46,7 @@ var formulaListCmd = &cobra.Command{
 	Long: `List all formulas from search paths.
 
 Search paths (in order of priority):
-  1. .beads/formulas/ (project - highest priority)
+  1. <resolved-beads-dir>/formulas/ (active project - highest priority)
   2. ~/.beads/formulas/ (user)
   3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
@@ -349,24 +349,7 @@ func runFormulaShow(cmd *cobra.Command, args []string) {
 
 // getFormulaSearchPaths returns the formula search paths in priority order.
 func getFormulaSearchPaths() []string {
-	var paths []string
-
-	// Project-level formulas
-	if cwd, err := os.Getwd(); err == nil {
-		paths = append(paths, filepath.Join(cwd, ".beads", "formulas"))
-	}
-
-	// User-level formulas
-	if home, err := os.UserHomeDir(); err == nil {
-		paths = append(paths, filepath.Join(home, ".beads", "formulas"))
-	}
-
-	// Orchestrator formulas (via GT_ROOT)
-	if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {
-		paths = append(paths, filepath.Join(gtRoot, ".beads", "formulas"))
-	}
-
-	return paths
+	return formula.DefaultSearchPaths()
 }
 
 // scanFormulaDir scans a directory for formula files (both TOML and JSON).

--- a/cmd/bd/mol_distill.go
+++ b/cmd/bd/mol_distill.go
@@ -36,7 +36,7 @@ Variable syntax (both work - we detect which side is the concrete value):
   --var feature-auth=branch    Substitution-style: value=variable
 
 Output locations (first writable wins):
-  1. .beads/formulas/       (project-level, default)
+  1. <resolved-beads-dir>/formulas/ (project-level, default)
   2. ~/.beads/formulas/     (user-level, if project not writable)
 
 Examples:
@@ -156,7 +156,11 @@ func runMolDistill(cmd *cobra.Command, args []string) {
 		// Find first writable formula directory
 		outputPath = findWritableFormulaDir(formulaName)
 		if outputPath == "" {
-			FatalErrorWithHint("no writable formula directory found", "Try: mkdir -p .beads/formulas")
+			hint := "Try creating one of the formula search paths"
+			if searchPaths := getFormulaSearchPaths(); len(searchPaths) > 0 {
+				hint = fmt.Sprintf("Try: mkdir -p %s", searchPaths[0])
+			}
+			FatalErrorWithHint("no writable formula directory found", hint)
 		}
 	}
 

--- a/cmd/bd/mol_seed.go
+++ b/cmd/bd/mol_seed.go
@@ -17,7 +17,7 @@ and can be loaded. This is useful for verifying system health before
 attempting to spawn work from a formula.
 
 Formula search paths (checked in order):
-  1. .beads/formulas/ (project level)
+  1. <resolved-beads-dir>/formulas/ (active project)
   2. ~/.beads/formulas/ (user level)
   3. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
 

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/steveyegge/beads/internal/beads"
 )
 
 // Formula file extensions. TOML is preferred, JSON is legacy fallback.
@@ -39,11 +40,12 @@ type Parser struct {
 
 // NewParser creates a new formula parser.
 // searchPaths are directories to search for formulas when resolving extends.
-// Default paths are: .beads/formulas, ~/.beads/formulas, $GT_ROOT/.beads/formulas
+// Default paths are the active beads project's formulas dir, then user-level,
+// then GT_ROOT if configured.
 func NewParser(searchPaths ...string) *Parser {
 	paths := searchPaths
 	if len(paths) == 0 {
-		paths = defaultSearchPaths()
+		paths = DefaultSearchPaths()
 	}
 	return &Parser{
 		searchPaths:    paths,
@@ -53,23 +55,42 @@ func NewParser(searchPaths ...string) *Parser {
 	}
 }
 
-// defaultSearchPaths returns the default formula search paths.
-func defaultSearchPaths() []string {
+// DefaultSearchPaths returns the default formula search paths.
+//
+// The project-level path prefers the resolved beads directory so worktrees with
+// shared/main-repo .beads state search the same formula registry as the rest of
+// the command surface. If no beads project is resolved, fall back to cwd/.beads
+// so formula registries can still be used before a project is initialized.
+func DefaultSearchPaths() []string {
 	var paths []string
 
-	// Project-level formulas
-	if cwd, err := os.Getwd(); err == nil {
-		paths = append(paths, filepath.Join(cwd, ".beads", "formulas"))
+	addPath := func(path string) {
+		if path == "" {
+			return
+		}
+		for _, existing := range paths {
+			if existing == path {
+				return
+			}
+		}
+		paths = append(paths, path)
+	}
+
+	// Project-level formulas via resolved beads directory.
+	if beadsDir := beads.FindBeadsDir(); beadsDir != "" {
+		addPath(filepath.Join(beadsDir, "formulas"))
+	} else if cwd, err := os.Getwd(); err == nil {
+		addPath(filepath.Join(cwd, ".beads", "formulas"))
 	}
 
 	// User-level formulas
 	if home, err := os.UserHomeDir(); err == nil {
-		paths = append(paths, filepath.Join(home, ".beads", "formulas"))
+		addPath(filepath.Join(home, ".beads", "formulas"))
 	}
 
 	// Orchestrator formulas (via GT_ROOT)
 	if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {
-		paths = append(paths, filepath.Join(gtRoot, ".beads", "formulas"))
+		addPath(filepath.Join(gtRoot, ".beads", "formulas"))
 	}
 
 	return paths

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -3,10 +3,24 @@ package formula
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/git"
 )
+
+func runGitForFormulaTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	}
+}
 
 func TestParse_BasicFormula(t *testing.T) {
 	jsonData := `{
@@ -74,6 +88,122 @@ func TestParse_BasicFormula(t *testing.T) {
 	}
 	if formula.Steps[1].DependsOn[0] != "design" {
 		t.Errorf("Steps[1].DependsOn = %v, want [design]", formula.Steps[1].DependsOn)
+	}
+}
+
+func TestDefaultSearchPaths_UsesResolvedBeadsDirForWorktree(t *testing.T) {
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("GT_ROOT", "")
+	beads.ResetCaches()
+	git.ResetCaches()
+	t.Cleanup(func() {
+		beads.ResetCaches()
+		git.ResetCaches()
+	})
+
+	root := t.TempDir()
+	mainRepo := filepath.Join(root, "main-repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGitForFormulaTest(t, mainRepo, "init")
+	runGitForFormulaTest(t, mainRepo, "config", "user.email", "test@example.com")
+	runGitForFormulaTest(t, mainRepo, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(mainRepo, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForFormulaTest(t, mainRepo, "add", "README.md")
+	runGitForFormulaTest(t, mainRepo, "commit", "-m", "init")
+
+	worktreeDir := filepath.Join(root, "worktree")
+	runGitForFormulaTest(t, mainRepo, "worktree", "add", worktreeDir, "HEAD")
+	t.Cleanup(func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepo
+		_ = cmd.Run()
+	})
+
+	mainFormulaDir := filepath.Join(mainRepo, ".beads", "formulas")
+	if err := os.MkdirAll(filepath.Join(mainRepo, ".beads", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(mainFormulaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	formulaPath := filepath.Join(mainFormulaDir, "shared.formula.toml")
+	if err := os.WriteFile(formulaPath, []byte("formula = \"shared\"\ndescription = \"shared formula\"\n[[steps]]\nid = \"step1\"\ntitle = \"Step 1\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(worktreeDir)
+	beads.ResetCaches()
+	git.ResetCaches()
+
+	paths := DefaultSearchPaths()
+	if len(paths) == 0 {
+		t.Fatal("DefaultSearchPaths() returned no paths")
+	}
+
+	want := filepath.Join(mainRepo, ".beads", "formulas")
+	gotResolved, err := filepath.EvalSymlinks(filepath.Clean(paths[0]))
+	if err != nil {
+		gotResolved = filepath.Clean(paths[0])
+	}
+	wantResolved, err := filepath.EvalSymlinks(filepath.Clean(want))
+	if err != nil {
+		wantResolved = filepath.Clean(want)
+	}
+	if gotResolved != wantResolved {
+		t.Fatalf("DefaultSearchPaths()[0] = %q, want %q", gotResolved, wantResolved)
+	}
+
+	parser := NewParser()
+	f, err := parser.LoadByName("shared")
+	if err != nil {
+		t.Fatalf("LoadByName(shared) failed: %v", err)
+	}
+	if !strings.HasPrefix(f.Source, wantResolved) {
+		t.Fatalf("formula source = %q, want prefix %q", f.Source, wantResolved)
+	}
+}
+
+func TestDefaultSearchPaths_FallsBackToCwdFormulaDirWithoutBeadsProject(t *testing.T) {
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("GT_ROOT", "")
+	beads.ResetCaches()
+	git.ResetCaches()
+	t.Cleanup(func() {
+		beads.ResetCaches()
+		git.ResetCaches()
+	})
+
+	root := t.TempDir()
+	formulaDir := filepath.Join(root, ".beads", "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	formulaPath := filepath.Join(formulaDir, "local-only.formula.toml")
+	if err := os.WriteFile(formulaPath, []byte("formula = \"local-only\"\ndescription = \"cwd fallback\"\n[[steps]]\nid = \"step1\"\ntitle = \"Step 1\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(root)
+	beads.ResetCaches()
+	git.ResetCaches()
+
+	paths := DefaultSearchPaths()
+	if len(paths) == 0 {
+		t.Fatal("DefaultSearchPaths() returned no paths")
+	}
+	want := filepath.Join(root, ".beads", "formulas")
+	if filepath.Clean(paths[0]) != filepath.Clean(want) {
+		t.Fatalf("DefaultSearchPaths()[0] = %q, want %q", paths[0], want)
+	}
+
+	parser := NewParser()
+	if _, err := parser.LoadByName("local-only"); err != nil {
+		t.Fatalf("LoadByName(local-only) failed: %v", err)
 	}
 }
 

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 func runGitForFormulaTest(t *testing.T, dir string, args ...string) {
@@ -108,6 +109,9 @@ func TestDefaultSearchPaths_UsesResolvedBeadsDirForWorktree(t *testing.T) {
 	}
 
 	runGitForFormulaTest(t, mainRepo, "init")
+	if err := testutil.ForceRepoLocalHooksPath(mainRepo); err != nil {
+		t.Fatalf("force repo-local hooks path: %v", err)
+	}
 	runGitForFormulaTest(t, mainRepo, "config", "user.email", "test@example.com")
 	runGitForFormulaTest(t, mainRepo, "config", "user.name", "Test User")
 	if err := os.WriteFile(filepath.Join(mainRepo, "README.md"), []byte("# Test\n"), 0o644); err != nil {

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -13,6 +13,19 @@ import (
 	"github.com/steveyegge/beads/internal/testutil"
 )
 
+func resetFormulaSearchCaches() {
+	beads.ResetCaches()
+	git.ResetCaches()
+}
+
+func resetFormulaSearchTestContext(t *testing.T) {
+	t.Helper()
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("GT_ROOT", "")
+	resetFormulaSearchCaches()
+	t.Cleanup(resetFormulaSearchCaches)
+}
+
 func runGitForFormulaTest(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -21,6 +34,51 @@ func runGitForFormulaTest(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, output)
 	}
+}
+
+func initFormulaTestRepo(t *testing.T, repoDir string) {
+	t.Helper()
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGitForFormulaTest(t, repoDir, "init")
+	if err := testutil.ForceRepoLocalHooksPath(repoDir); err != nil {
+		t.Fatalf("force repo-local hooks path: %v", err)
+	}
+	runGitForFormulaTest(t, repoDir, "config", "user.email", "test@example.com")
+	runGitForFormulaTest(t, repoDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitForFormulaTest(t, repoDir, "add", "README.md")
+	runGitForFormulaTest(t, repoDir, "commit", "-m", "init")
+}
+
+func writeFormulaFixture(t *testing.T, dir, formulaName, description string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	formulaPath := filepath.Join(dir, formulaName+FormulaExtTOML)
+	content := fmt.Sprintf(
+		"formula = %q\ndescription = %q\n[[steps]]\nid = \"step1\"\ntitle = \"Step 1\"\n",
+		formulaName,
+		description,
+	)
+	if err := os.WriteFile(formulaPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return formulaPath
+}
+
+func canonicalTestPath(path string) string {
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(path))
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	return resolved
 }
 
 func TestParse_BasicFormula(t *testing.T) {
@@ -93,32 +151,11 @@ func TestParse_BasicFormula(t *testing.T) {
 }
 
 func TestDefaultSearchPaths_UsesResolvedBeadsDirForWorktree(t *testing.T) {
-	t.Setenv("BEADS_DIR", "")
-	t.Setenv("GT_ROOT", "")
-	beads.ResetCaches()
-	git.ResetCaches()
-	t.Cleanup(func() {
-		beads.ResetCaches()
-		git.ResetCaches()
-	})
+	resetFormulaSearchTestContext(t)
 
 	root := t.TempDir()
 	mainRepo := filepath.Join(root, "main-repo")
-	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	runGitForFormulaTest(t, mainRepo, "init")
-	if err := testutil.ForceRepoLocalHooksPath(mainRepo); err != nil {
-		t.Fatalf("force repo-local hooks path: %v", err)
-	}
-	runGitForFormulaTest(t, mainRepo, "config", "user.email", "test@example.com")
-	runGitForFormulaTest(t, mainRepo, "config", "user.name", "Test User")
-	if err := os.WriteFile(filepath.Join(mainRepo, "README.md"), []byte("# Test\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	runGitForFormulaTest(t, mainRepo, "add", "README.md")
-	runGitForFormulaTest(t, mainRepo, "commit", "-m", "init")
+	initFormulaTestRepo(t, mainRepo)
 
 	worktreeDir := filepath.Join(root, "worktree")
 	runGitForFormulaTest(t, mainRepo, "worktree", "add", worktreeDir, "HEAD")
@@ -132,32 +169,18 @@ func TestDefaultSearchPaths_UsesResolvedBeadsDirForWorktree(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(mainRepo, ".beads", "dolt"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(mainFormulaDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	formulaPath := filepath.Join(mainFormulaDir, "shared.formula.toml")
-	if err := os.WriteFile(formulaPath, []byte("formula = \"shared\"\ndescription = \"shared formula\"\n[[steps]]\nid = \"step1\"\ntitle = \"Step 1\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeFormulaFixture(t, mainFormulaDir, "shared", "shared formula")
 
 	t.Chdir(worktreeDir)
-	beads.ResetCaches()
-	git.ResetCaches()
+	resetFormulaSearchCaches()
 
 	paths := DefaultSearchPaths()
 	if len(paths) == 0 {
 		t.Fatal("DefaultSearchPaths() returned no paths")
 	}
 
-	want := filepath.Join(mainRepo, ".beads", "formulas")
-	gotResolved, err := filepath.EvalSymlinks(filepath.Clean(paths[0]))
-	if err != nil {
-		gotResolved = filepath.Clean(paths[0])
-	}
-	wantResolved, err := filepath.EvalSymlinks(filepath.Clean(want))
-	if err != nil {
-		wantResolved = filepath.Clean(want)
-	}
+	gotResolved := canonicalTestPath(paths[0])
+	wantResolved := canonicalTestPath(filepath.Join(mainRepo, ".beads", "formulas"))
 	if gotResolved != wantResolved {
 		t.Fatalf("DefaultSearchPaths()[0] = %q, want %q", gotResolved, wantResolved)
 	}
@@ -173,28 +196,14 @@ func TestDefaultSearchPaths_UsesResolvedBeadsDirForWorktree(t *testing.T) {
 }
 
 func TestDefaultSearchPaths_FallsBackToCwdFormulaDirWithoutBeadsProject(t *testing.T) {
-	t.Setenv("BEADS_DIR", "")
-	t.Setenv("GT_ROOT", "")
-	beads.ResetCaches()
-	git.ResetCaches()
-	t.Cleanup(func() {
-		beads.ResetCaches()
-		git.ResetCaches()
-	})
+	resetFormulaSearchTestContext(t)
 
 	root := t.TempDir()
 	formulaDir := filepath.Join(root, ".beads", "formulas")
-	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	formulaPath := filepath.Join(formulaDir, "local-only.formula.toml")
-	if err := os.WriteFile(formulaPath, []byte("formula = \"local-only\"\ndescription = \"cwd fallback\"\n[[steps]]\nid = \"step1\"\ntitle = \"Step 1\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeFormulaFixture(t, formulaDir, "local-only", "cwd fallback")
 
 	t.Chdir(root)
-	beads.ResetCaches()
-	git.ResetCaches()
+	resetFormulaSearchCaches()
 
 	paths := DefaultSearchPaths()
 	if len(paths) == 0 {


### PR DESCRIPTION
## Summary
- resolve formula project search paths through the active beads workspace instead of assuming `cwd/.beads/formulas`
- make `bd formula`, `bd mol distill`, and `bd mol seed` messaging match the same runtime resolution logic
- add regression coverage for shared worktree `.beads` resolution while preserving the local fallback outside initialized projects

## Problem
Formula resolution was still partially anchored to `cwd/.beads/formulas`.

In worktree or shared-`.beads` setups, beads already resolves the active workspace through `BEADS_DIR`, redirects, and main-repo fallback. But formula lookup and some related CLI messaging were still using the older cwd-based assumption.

That meant formula commands could behave as if no formulas existed even when the active workspace had a valid shared formula registry, and some help text still described the stale project-path contract.

## What changed
- centralize default formula search path resolution in `formula.DefaultSearchPaths()`
- prefer `<resolved-beads-dir>/formulas` when an active beads workspace exists
- keep `cwd/.beads/formulas` as a fallback only when no beads project resolves at all
- route CLI path reporting through the same shared helper so the displayed search paths reflect actual lookup behavior
- update `bd mol seed` help text to describe the resolved active workspace path instead of `./.beads/formulas`

## Impact
Worktree users now see the same formula registry that the rest of beads resolves for the active workspace.

This fixes a real lookup mismatch, not just a display issue, while keeping the old local fallback for directories that are not part of a beads project yet.

## Validation
- `go test ./internal/formula`
- `./scripts/test-cgo.sh -run '^$' ./cmd/bd/...`

