### PR TITLE
Fix bd list watch hierarchy consistency

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -120,6 +120,26 @@ type watchListDependencyStore interface {
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
 }
 
+func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, parentID string, sortBy string, reverse bool) ([]*types.Issue, error) {
+	if parentID != "" {
+		issues, err := getHierarchicalChildren(ctx, store, "", parentID)
+		if err != nil {
+			return nil, err
+		}
+		// getHierarchicalChildren builds its result from a map, so normalize the
+		// slice before snapshot comparison to avoid spurious redraws.
+		sortIssues(issues, "id", false)
+		return issues, nil
+	}
+
+	issues, err := store.SearchIssues(ctx, "", filter)
+	if err != nil {
+		return nil, err
+	}
+	sortIssues(issues, sortBy, reverse)
+	return issues, nil
+}
+
 func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue) {
 	var allDeps map[string][]*types.Dependency
 	if store != nil {
@@ -131,14 +151,13 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 	displayPrettyListWithDeps(issues, true, allDeps)
 }
 
-func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, sortBy string, reverse bool) {
+func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, parentID string, sortBy string, reverse bool) {
 	// Initial display
-	issues, err := store.SearchIssues(ctx, "", filter)
+	issues, err := loadWatchedIssues(ctx, store, filter, parentID, sortBy, reverse)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error querying issues: %v\n", err)
 		return
 	}
-	sortIssues(issues, sortBy, reverse)
 	displayWatchedIssueList(ctx, store, issues)
 	lastSnapshot := issueSnapshot(issues)
 
@@ -159,12 +178,11 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 			fmt.Fprintf(os.Stderr, "\nStopped watching.\n")
 			return
 		case <-ticker.C:
-			issues, err := store.SearchIssues(ctx, "", filter)
+			issues, err := loadWatchedIssues(ctx, store, filter, parentID, sortBy, reverse)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error refreshing issues: %v\n", err)
 				continue
 			}
-			sortIssues(issues, sortBy, reverse)
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
@@ -823,7 +841,7 @@ var listCmd = &cobra.Command{
 
 		// Handle watch mode (GH#654) - must be before other output modes
 		if watchMode {
-			watchIssues(ctx, activeStore, filter, sortBy, reverse)
+			watchIssues(ctx, activeStore, filter, parentID, sortBy, reverse)
 			return
 		}
 

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -116,6 +116,21 @@ func findAllDescendants(ctx context.Context, store storage.DoltStorage, dbPath s
 // watchIssues polls for changes and re-displays (GH#654)
 // Uses polling instead of fsnotify because Dolt stores data in a server-side
 // database, not files — file watchers never fire.
+type watchListDependencyStore interface {
+	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
+}
+
+func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore, issues []*types.Issue) {
+	var allDeps map[string][]*types.Dependency
+	if store != nil {
+		deps, err := store.GetAllDependencyRecords(ctx)
+		if err == nil {
+			allDeps = deps
+		}
+	}
+	displayPrettyListWithDeps(issues, true, allDeps)
+}
+
 func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, sortBy string, reverse bool) {
 	// Initial display
 	issues, err := store.SearchIssues(ctx, "", filter)
@@ -124,7 +139,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 		return
 	}
 	sortIssues(issues, sortBy, reverse)
-	displayPrettyList(issues, true)
+	displayWatchedIssueList(ctx, store, issues)
 	lastSnapshot := issueSnapshot(issues)
 
 	fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
@@ -153,7 +168,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
-				displayPrettyList(issues, true)
+				displayWatchedIssueList(ctx, store, issues)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
 		}

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"context"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -252,5 +254,70 @@ func TestDisplayWatchedIssueList_UsesDependencyHierarchy(t *testing.T) {
 	}
 	if strings.Contains(out, "\nbd-achild ") || strings.HasPrefix(out, "bd-achild ") {
 		t.Fatalf("expected child not to render as a root in watch output, got:\n%s", out)
+	}
+}
+
+func TestLoadWatchedIssues_WithParentIncludesHierarchyAndStableOrder(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	store := newTestStore(t, testDB)
+
+	createIssue := func(title string, issueType types.IssueType) *types.Issue {
+		issue := &types.Issue{
+			Title:     title,
+			Priority:  2,
+			IssueType: issueType,
+			Status:    types.StatusOpen,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-user"); err != nil {
+			t.Fatalf("Failed to create issue %s: %v", title, err)
+		}
+		return issue
+	}
+
+	addParentChild := func(child, parent *types.Issue) {
+		dep := &types.Dependency{
+			IssueID:     child.ID,
+			DependsOnID: parent.ID,
+			Type:        types.DepParentChild,
+			CreatedAt:   time.Now(),
+			CreatedBy:   "test-user",
+		}
+		if err := store.AddDependency(ctx, dep, "test-user"); err != nil {
+			t.Fatalf("Failed to add dependency %s -> %s: %v", child.ID, parent.ID, err)
+		}
+	}
+
+	parent := createIssue("Parent epic", types.TypeEpic)
+	child := createIssue("Child task", types.TypeTask)
+	grandchild := createIssue("Grandchild task", types.TypeTask)
+	addParentChild(child, parent)
+	addParentChild(grandchild, child)
+
+	filter := types.IssueFilter{ParentID: &parent.ID}
+	first, err := loadWatchedIssues(ctx, store, filter, parent.ID, "", false)
+	if err != nil {
+		t.Fatalf("loadWatchedIssues first call failed: %v", err)
+	}
+	second, err := loadWatchedIssues(ctx, store, filter, parent.ID, "", false)
+	if err != nil {
+		t.Fatalf("loadWatchedIssues second call failed: %v", err)
+	}
+
+	if len(first) != 3 {
+		t.Fatalf("expected parent path to include parent and descendants, got %d issues", len(first))
+	}
+
+	firstIDs := []string{first[0].ID, first[1].ID, first[2].ID}
+	secondIDs := []string{second[0].ID, second[1].ID, second[2].ID}
+	if !slices.Equal(firstIDs, secondIDs) {
+		t.Fatalf("expected stable watched issue ordering, got %v then %v", firstIDs, secondIDs)
+	}
+
+	wantIDs := []string{parent.ID, child.ID, grandchild.ID}
+	slices.Sort(wantIDs)
+	if !slices.Equal(firstIDs, wantIDs) {
+		t.Fatalf("expected watched issues to be normalized by id for snapshot stability, got %v want %v", firstIDs, wantIDs)
 	}
 }

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -3,12 +3,22 @@
 package main
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
+
+type watchListDependencyStoreStub struct {
+	allDeps map[string][]*types.Dependency
+	err     error
+}
+
+func (s watchListDependencyStoreStub) GetAllDependencyRecords(_ context.Context) (map[string][]*types.Dependency, error) {
+	return s.allDeps, s.err
+}
 
 func TestListParseTimeFlag(t *testing.T) {
 	cases := []string{
@@ -213,5 +223,34 @@ func TestListDisplayPrettyList(t *testing.T) {
 	})
 	if !strings.Contains(out, "bd-1") || !strings.Contains(out, "bd-1.1") || !strings.Contains(out, "Total:") {
 		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestDisplayWatchedIssueList_UsesDependencyHierarchy(t *testing.T) {
+	parent := &types.Issue{ID: "bd-zparent", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "bd-achild", Title: "Child", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask}
+	store := watchListDependencyStoreStub{
+		allDeps: map[string][]*types.Dependency{
+			child.ID: {
+				{IssueID: child.ID, DependsOnID: parent.ID, Type: types.DepParentChild},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() error {
+		displayWatchedIssueList(context.Background(), store, []*types.Issue{child, parent})
+		return nil
+	})
+
+	parentLine := strings.Index(out, "bd-zparent")
+	childLine := strings.Index(out, "└──")
+	if parentLine == -1 || childLine == -1 {
+		t.Fatalf("expected parent root and child connector in output, got:\n%s", out)
+	}
+	if childLine < parentLine {
+		t.Fatalf("expected child to render under parent in watch output, got:\n%s", out)
+	}
+	if strings.Contains(out, "\nbd-achild ") || strings.HasPrefix(out, "bd-achild ") {
+		t.Fatalf("expected child not to render as a root in watch output, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Compared with main
- make `bd list --watch` reuse the dependency-aware tree renderer so watch and non-watch output keep the same hierarchy
- honor `--parent` in watch mode by loading the same parent plus descendant tree as non-watch output instead of showing only direct children
- normalize the watched issue order before snapshot comparison and add regression tests for both the generic watch path and the `--parent` watch path

## Testing
- `./scripts/test.sh -run 'Test(ListBuildIssueTree_ParentChildByDotID|ListBuildIssueTree_NoDuplicateChildrenFromMultipleDeps|ListDisplayPrettyList|DisplayWatchedIssueList_UsesDependencyHierarchy|LoadWatchedIssues_WithParentIncludesHierarchyAndStableOrder)$' ./cmd/bd`
- `make build`
