### PR TITLE
fix(ci): drop ICU linkage from test jobs, use -tags gms_pure_go everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install ICU4C
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
-
       - name: Build bd
-        run: go build -o bd ./cmd/bd/
+        run: go build -tags gms_pure_go -o bd ./cmd/bd/
 
       - name: Validate docs against CLI
         run: ./scripts/check-doc-flags.sh ./bd
@@ -97,22 +91,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install ICU4C (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
-
-      - name: Install ICU4C (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install icu4c
-          dir="$(brew --prefix icu4c)"
-          echo "CGO_CPPFLAGS=-I$dir/include" >> "$GITHUB_ENV"
-          echo "CGO_LDFLAGS=-L$dir/lib -Wl,-rpath,$dir/lib" >> "$GITHUB_ENV"
-          echo "PKG_CONFIG_PATH=$dir/lib/pkgconfig" >> "$GITHUB_ENV"
-
       - name: Configure Git
         run: |
           git config --global user.name "CI Bot"
@@ -123,7 +101,7 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
 
       - name: Build
-        run: go build -v ./cmd/bd
+        run: go build -v -tags gms_pure_go ./cmd/bd
 
       - name: Test (with coverage + JUnit XML)
         if: matrix.coverage
@@ -131,11 +109,11 @@ jobs:
           gotestsum \
             --junitfile junit.xml \
             --format testdox \
-            -- -race -short -coverprofile=coverage.out -skip '^TestEmbedded' ./...
+            -- -tags gms_pure_go -race -short -coverprofile=coverage.out -skip '^TestEmbedded' ./...
 
       - name: Test
         if: ${{ !matrix.coverage }}
-        run: go test ${{ matrix.test-flags }} -skip '^TestEmbedded' ./...
+        run: go test -tags gms_pure_go ${{ matrix.test-flags }} -skip '^TestEmbedded' ./...
 
       - name: Upload coverage to Codecov
         if: matrix.coverage && !cancelled()
@@ -170,20 +148,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install ICU4C
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
-
       - name: Build embedded bd binary
-        run: go build -race -o /tmp/bd-embedded-test ./cmd/bd/
+        run: go build -tags gms_pure_go -race -o /tmp/bd-embedded-test ./cmd/bd/
 
       - name: Build embedded storage test binary
-        run: go test -race -c -o /tmp/embeddeddolt-test ./internal/storage/embeddeddolt/
+        run: go test -tags gms_pure_go -race -c -o /tmp/embeddeddolt-test ./internal/storage/embeddeddolt/
 
       - name: Build embedded cmd test binary
-        run: go test -race -c -o /tmp/bd-cmd-test ./cmd/bd/
+        run: go test -tags gms_pure_go -race -c -o /tmp/bd-cmd-test ./cmd/bd/
 
       - name: Upload binaries
         uses: actions/upload-artifact@v7
@@ -201,12 +173,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install ICU4C
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
 
       - name: Download binaries
         uses: actions/download-artifact@v8
@@ -238,12 +204,6 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install ICU4C
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
 
       - name: Download binaries
         uses: actions/download-artifact@v8
@@ -321,17 +281,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install ICU4C (Linux)
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-          args: --timeout=5m
+          args: --timeout=5m --build-tags=gms_pure_go
 
   test-nix:
     name: Test Nix Flake

--- a/.github/workflows/cross-version-smoke.yml
+++ b/.github/workflows/cross-version-smoke.yml
@@ -39,12 +39,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install ICU4C
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
-
       - name: Configure Git
         run: |
           git config --global user.name "CI Bot"
@@ -57,7 +51,7 @@ jobs:
           key: smoke-binaries-${{ matrix.prev_version }}-${{ runner.os }}
 
       - name: Build candidate binary
-        run: go build -o /tmp/bd-candidate ./cmd/bd
+        run: go build -tags gms_pure_go -o /tmp/bd-candidate ./cmd/bd
 
       - name: Run upgrade smoke tests
         env:

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libicu-dev jq sqlite3
+          sudo apt-get install -y jq sqlite3
 
       - name: Install Dolt
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,12 +19,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install ICU4C
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.list
-          sudo apt-get update
-          sudo apt-get install -y libicu-dev
-
       - name: Install Dolt
         run: |
           curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
@@ -37,7 +31,7 @@ jobs:
           dolt config --global --add user.email "ci@beads.test"
 
       - name: Build
-        run: go build -v ./cmd/bd
+        run: go build -v -tags gms_pure_go ./cmd/bd
 
       - name: Full Test Suite (including integration tests)
         env:
@@ -45,7 +39,7 @@ jobs:
           # GitHub Actions (known issue, see scripts/repro-dolt-hang/).
           # Non-Docker integration tests still run via the installed dolt binary.
           BEADS_TEST_SKIP: dolt
-        run: go test -v -race -tags=integration -coverprofile=coverage.out -timeout=30m ./...
+        run: go test -v -race -tags=integration,gms_pure_go -coverprofile=coverage.out -timeout=30m ./...
 
       - name: Check coverage threshold
         run: |

--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -777,7 +777,7 @@ func init() {
 		panic(err)
 	}
 	testBD = filepath.Join(tmpDir, bdBinary)
-	cmd := exec.Command("go", "build", "-o", testBD, ".")
+	cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", testBD, ".")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		panic(string(out))
 	}

--- a/cmd/bd/doctor/dolt_e2e_test.go
+++ b/cmd/bd/doctor/dolt_e2e_test.go
@@ -145,7 +145,7 @@ func buildTestBD(t *testing.T) string {
 
 		// Build from cmd/bd relative to the module root.
 		// The test runs from cmd/bd/doctor/, so module root is ../../../
-		cmd := exec.Command("go", "build", "-o", testBDPath, "./cmd/bd")
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", testBDPath, "./cmd/bd")
 
 		// Find the module root by looking for go.mod
 		modRoot := findModuleRoot(t)

--- a/cmd/bd/doctor_repair_test.go
+++ b/cmd/bd/doctor_repair_test.go
@@ -17,7 +17,7 @@ func buildBDForTest(t *testing.T) string {
 
 	binDir := t.TempDir()
 	exe := filepath.Join(binDir, exeName)
-	cmd := exec.Command("go", "build", "-o", exe, ".")
+	cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", exe, ".")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("go build failed: %v\n%s", err, string(out))

--- a/cmd/bd/dolt_autostart_lifecycle_integration_test.go
+++ b/cmd/bd/dolt_autostart_lifecycle_integration_test.go
@@ -131,7 +131,7 @@ func buildLifecycleTestBinary(t *testing.T) string {
 		t.Fatalf("getwd: %v", err)
 	}
 	bdBinary := filepath.Join(t.TempDir(), "bd")
-	cmd := exec.Command("go", "build", "-o", bdBinary, ".")
+	cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", bdBinary, ".")
 	cmd.Dir = pkgDir
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/bd/explicit_db_nodb_test.go
+++ b/cmd/bd/explicit_db_nodb_test.go
@@ -23,7 +23,7 @@ func buildBDUnderTest(t *testing.T) string {
 		binName = "bd.exe"
 	}
 	binPath := filepath.Join(t.TempDir(), binName)
-	buildCmd := exec.Command("go", "build", "-o", binPath, ".")
+	buildCmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", binPath, ".")
 	if out, err := buildCmd.CombinedOutput(); err != nil {
 		t.Fatalf("go build failed: %v\n%s", err, out)
 	}

--- a/cmd/bd/import_prefix_test.go
+++ b/cmd/bd/import_prefix_test.go
@@ -27,7 +27,7 @@ func TestCLI_Import_PrefixValidation_E2E(t *testing.T) {
 	}
 	bdBinary := filepath.Join(tmpDir, bdName)
 
-	buildCmd := exec.Command("go", "build", "-o", bdBinary, ".")
+	buildCmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", bdBinary, ".")
 	if out, err := buildCmd.CombinedOutput(); err != nil {
 		t.Fatalf("Failed to build bd: %v\nOutput: %s", err, out)
 	}

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -50,7 +50,7 @@ func buildEmbeddedBD(t *testing.T) string {
 			name = "bd.exe"
 		}
 		embeddedBD = filepath.Join(tmpDir, name)
-		cmd := exec.Command("go", "build", "-o", embeddedBD, ".")
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", embeddedBD, ".")
 		if out, err := cmd.CombinedOutput(); err != nil {
 			embeddedBDErr = fmt.Errorf("go build failed: %v\n%s", err, out)
 		}

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1708,7 +1708,7 @@ func buildBDForInitTests(t *testing.T) string {
 			return
 		}
 		initTestBD = filepath.Join(tmpDir, bdBinary)
-		cmd := exec.Command("go", "build", "-o", initTestBD, ".")
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", initTestBD, ".")
 		if out, err := cmd.CombinedOutput(); err != nil {
 			initTestBDErr = fmt.Errorf("go build failed: %v\n%s", err, out)
 		}

--- a/cmd/bd/main_test.go
+++ b/cmd/bd/main_test.go
@@ -244,7 +244,7 @@ func TestListUsesRepoBeadsDirWhenDoltDataDirEscapesDotBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
 	}
-	buildCmd := exec.Command("go", "build", "-o", binPath, ".")
+	buildCmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", binPath, ".")
 	buildCmd.Dir = packageDir
 	buildOut, err := buildCmd.CombinedOutput()
 	if err != nil {

--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -83,8 +83,8 @@ func runPreflight(cmd *cobra.Command, args []string) {
 	// Static checklist mode
 	fmt.Println("PR Readiness Checklist:")
 	fmt.Println()
-	fmt.Println("[ ] Tests pass: go test -short ./...")
-	fmt.Println("[ ] Lint passes: golangci-lint run ./...")
+	fmt.Println("[ ] Tests pass: go test -tags gms_pure_go -short ./...")
+	fmt.Println("[ ] Lint passes: golangci-lint run --build-tags=gms_pure_go ./...")
 	fmt.Println("[ ] Formatting: gofmt -l .")
 	fmt.Println("[ ] No beads pollution: check .beads/issues.jsonl diff")
 	fmt.Println("[ ] Nix hash current: go.sum unchanged or vendorHash updated")
@@ -198,8 +198,8 @@ func runChecks(jsonOutput, skipLint bool) {
 
 // runTestCheck runs go test -short ./... and returns the result.
 func runTestCheck() CheckResult {
-	command := "go test -short ./..."
-	cmd := exec.Command("go", "test", "-short", "./...")
+	command := "go test -tags gms_pure_go -short ./..."
+	cmd := exec.Command("go", "test", "-tags", "gms_pure_go", "-short", "./...")
 	output, err := cmd.CombinedOutput()
 
 	return CheckResult{
@@ -212,7 +212,7 @@ func runTestCheck() CheckResult {
 
 // runLintCheck runs golangci-lint and returns the result.
 func runLintCheck(skipLint bool) CheckResult {
-	command := "golangci-lint run ./..."
+	command := "golangci-lint run --build-tags=gms_pure_go ./..."
 	if skipLint {
 		return CheckResult{
 			Name:    "Lint passes",
@@ -234,7 +234,7 @@ func runLintCheck(skipLint bool) CheckResult {
 		}
 	}
 
-	cmd := exec.Command("golangci-lint", "run", "./...")
+	cmd := exec.Command("golangci-lint", "run", "--build-tags=gms_pure_go", "./...")
 	output, err := cmd.CombinedOutput()
 
 	return CheckResult{

--- a/cmd/bd/protocol/helpers_test.go
+++ b/cmd/bd/protocol/helpers_test.go
@@ -83,7 +83,7 @@ func buildBD(t *testing.T) string {
 		bdPath = filepath.Join(dir, bin)
 
 		modRoot := findModuleRoot(t)
-		cmd := exec.Command("go", "build", "-o", bdPath, "./cmd/bd")
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", bdPath, "./cmd/bd")
 		cmd.Dir = modRoot
 		cmd.Env = buildEnv()
 

--- a/cmd/bd/scripttest_test.go
+++ b/cmd/bd/scripttest_test.go
@@ -26,7 +26,7 @@ func TestScripts(t *testing.T) {
 	exeName := "bd"
 	binDir := t.TempDir()
 	exe := filepath.Join(binDir, exeName)
-	if err := exec.Command("go", "build", "-o", exe, ".").Run(); err != nil {
+	if err := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", exe, ".").Run(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/bd/shared_server_integration_test.go
+++ b/cmd/bd/shared_server_integration_test.go
@@ -619,7 +619,7 @@ func buildSharedServerTestBinary(t *testing.T) string {
 			return
 		}
 		bdBin := filepath.Join(buildDir, "bd")
-		cmd := exec.Command("go", "build", "-o", bdBin, ".")
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", bdBin, ".")
 		cmd.Dir = pkgDir
 		cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
 		out, err := cmd.CombinedOutput()

--- a/docs/ICU-POLICY.md
+++ b/docs/ICU-POLICY.md
@@ -52,19 +52,19 @@ Every build path that produces a binary for users must include `-tags gms_pure_g
 | Release builds | `.goreleaser.yml` (all build targets) |
 | Install script | `scripts/install.sh` |
 | Windows installer | `install.ps1` |
-| CI (Windows) | `.github/workflows/ci.yml` |
+| CI test matrix | `.github/workflows/ci.yml` (Linux, macOS, Windows) |
 | macOS release | `.github/workflows/release.yml` |
 | Migration tests | `.github/workflows/migration-test.yml` |
+| Nightly tests | `.github/workflows/nightly.yml` |
+| Cross-version smoke | `.github/workflows/cross-version-smoke.yml` |
 
 ## Where `gms_pure_go` Is Intentionally Omitted
 
-The CI test matrix and `scripts/test-cgo.sh` omit `gms_pure_go` to exercise
-the ICU code path in `go-mysql-server`. This ensures we don't ship bugs
-in the upstream ICU integration even though our release binaries don't use it.
-
-These test environments install ICU headers explicitly:
-- Linux CI: `sudo apt-get install -y libicu-dev`
-- macOS CI: `brew install icu4c` + CGO flag exports
+`scripts/test-cgo.sh` omits `gms_pure_go` as a local developer tool for
+exercising the ICU code path in `go-mysql-server` on demand. CI no longer
+does this: upstream confirmed (dolthub/go-mysql-server#3506) that
+`-tags=gms_pure_go` is the sanctioned escape hatch, so we test the
+configuration we ship.
 
 ## Post-Build Verification
 

--- a/docs/ICU-POLICY.md
+++ b/docs/ICU-POLICY.md
@@ -95,8 +95,10 @@ Once the upstream PR merges, remove the `replace` directive from `go.mod`.
 2. **Removing `gms_pure_go` from a build target** -- this re-introduces
    ICU linkage. The post-build checks will catch it, but don't do it.
 
-3. **Installing `libicu-dev` in release workflows** -- only needed in test
-   workflows. Release builds must not depend on ICU being installed.
+3. **Installing `libicu-dev` in release or CI test workflows** -- only
+   needed for local, on-demand developer testing via `scripts/test-cgo.sh`.
+   Neither release builds nor the CI test matrix link ICU; both must not
+   depend on ICU being installed.
 
 4. **Confusing CGO with ICU** -- CGO is required (for Dolt). ICU is not.
    They are independent. `CGO_ENABLED=1` does not imply ICU.

--- a/internal/beads/beads_hash_multiclone_test.go
+++ b/internal/beads/beads_hash_multiclone_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 	modRoot := strings.TrimSpace(string(modRootOut))
 
 	testBDBinary = filepath.Join(tmpDir, binName)
-	cmd := exec.Command("go", "build", "-o", testBDBinary, "./cmd/bd")
+	cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", testBDBinary, "./cmd/bd")
 	cmd.Dir = modRoot // Build from module root where ./cmd/bd exists
 	if out, err := cmd.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to build bd binary: %v\n%s\n", err, out)

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -115,7 +115,7 @@ func findModuleRoot() string {
 
 func buildCandidate(outPath string) error {
 	modRoot := findModuleRoot()
-	cmd := exec.Command("go", "build", "-o", outPath, "./cmd/bd")
+	cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", outPath, "./cmd/bd")
 	cmd.Dir = modRoot
 	cmd.Env = buildEnv()
 


### PR DESCRIPTION
## Summary

Aligns the CI test matrix with the configuration we actually ship. Release artifacts and install scripts already use `-tags gms_pure_go` (disables the ICU regex dependency in go-mysql-server), and the Windows test job did too — but macOS and Linux test jobs were still `brew install icu4c` / `apt-get install libicu-dev` and linking against real ICU. We were burning CI minutes testing a configuration no user installs.

Context: [dolthub/go-mysql-server#3506](https://github.com/dolthub/go-mysql-server/issues/3506) — upstream confirmed they won't change defaults, but `-tags=gms_pure_go` is the sanctioned escape hatch.

## Changes

**Workflows** (commit 1):
- `.github/workflows/ci.yml` — Removed 5 `Install ICU4C` steps (Linux+macOS matrix, build-embedded, test-embedded-storage, test-embedded-cmd, lint, check-doc-flags). Added `-tags gms_pure_go` to all Go build/test invocations; golangci-lint now passes `--build-tags=gms_pure_go`. Removed macOS `CGO_CPPFLAGS`/`CGO_LDFLAGS`/`PKG_CONFIG_PATH` brew wiring.
- `.github/workflows/migration-test.yml` — Dropped `libicu-dev` from apt-get.
- `.github/workflows/nightly.yml` — Dropped ICU install; added tag to build and integration tests.
- `.github/workflows/cross-version-smoke.yml` — Dropped ICU install; added tag to candidate build.
- `docs/ICU-POLICY.md` — Updated policy table to reflect full CI matrix; narrowed `libicu-dev` to local-only `scripts/test-cgo.sh`.

**Test helpers** (commit 2):
Fifteen `*_test.go` files shell out to `go build ./cmd/bd` as a subprocess. The outer `go test -tags gms_pure_go` does not propagate into those exec subprocesses, so nightly's new `go test -tags 'integration gms_pure_go' -run '^$' ./...` still failed in `internal/beads` with `unicode/uregex.h: No such file or directory`. All 15 now pass `-tags gms_pure_go` to the inner `go build`.

**`bd preflight`** (commit 3):
`cmd/bd/preflight.go` is a beads-specific maintainer pre-PR tool (its checks include `.beads/issues.jsonl` pollution, nix vendorHash, and beads' own version.go/default.nix sync). On a no-ICU dev machine, `bd preflight --check` would fail the `go test -short ./...` step with the same ICU error. Added `-tags gms_pure_go` to the shelled `go test` and `--build-tags=gms_pure_go` to the shelled `golangci-lint run`, plus updated the static checklist strings so copy-paste commands work.

**Not touched** (verified intentional):
- `.github/workflows/release.yml` / `.goreleaser.yml` — already consistent; goreleaser-macos uses `-tags "gms_pure_go netgo"` and verifies via `otool -L`.
- `scripts/test-cgo.sh` — local developer tool for intentionally exercising the ICU code path.
- `cmd/bd/preflight.go` `exec.Command("git"|"bash"|"gofmt", ...)` calls — don't need the tag.

## Test plan

- [x] `go build -tags gms_pure_go -o /tmp/bd ./cmd/bd` succeeds
- [x] `go test -tags 'integration gms_pure_go' -run '^$' ./...` completes with no FAIL lines (previously failed in `internal/beads`)
- [ ] CI on this PR: Linux/macOS/Windows test jobs all green without ICU installs
- [ ] nightly.yml next run: no `unicode/uregex.h` errors

Closes bd-sz5.