### PR TITLE
fix(update): set status=deferred when --defer is provided (GH#3233)

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -218,6 +218,11 @@ create, update, show, or close operation).`,
 					fmt.Fprintf(os.Stderr, "  Did you mean a future date? Use --defer=+1h or --defer=tomorrow\n")
 				}
 				updates["defer_until"] = t
+				// Also set status=deferred for consistency with `bd defer`
+				// (GH#3233). Skip if user explicitly set --status to something else.
+				if _, ok := updates["status"]; !ok {
+					updates["status"] = string(types.StatusDeferred)
+				}
 			}
 		}
 		// Ephemeral/persistent flags

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -40,6 +40,10 @@ create, update, show, or close operation).`,
 		}
 
 		updates := make(map[string]interface{})
+		// clearDeferStatus: set per-issue in the update loop when --defer=""
+		// was given without an explicit --status, to flip status=deferred back
+		// to open (matches the help text's "show in bd ready immediately").
+		var clearDeferStatus bool
 
 		if cmd.Flags().Changed("status") {
 			status, _ := cmd.Flags().GetString("status")
@@ -204,23 +208,30 @@ create, update, show, or close operation).`,
 		if cmd.Flags().Changed("defer") {
 			deferStr, _ := cmd.Flags().GetString("defer")
 			if deferStr == "" {
-				// Empty string clears the defer_until
+				// Empty string clears the defer_until and restores ready-work
+				// visibility (GH#3233). Explicit --status still wins.
 				updates["defer_until"] = nil
+				if _, ok := updates["status"]; !ok {
+					clearDeferStatus = true
+				}
 			} else {
 				t, err := timeparsing.ParseRelativeTime(deferStr, time.Now())
 				if err != nil {
 					FatalErrorRespectJSON("invalid --defer format %q. Examples: +1h, tomorrow, next monday, 2025-01-15", deferStr)
 				}
 				// Warn if defer date is in the past (user probably meant future)
-				if t.Before(time.Now()) && !jsonOutput {
+				inPast := t.Before(time.Now())
+				if inPast && !jsonOutput {
 					fmt.Fprintf(os.Stderr, "%s Defer date %q is in the past. Issue will appear in bd ready immediately.\n",
 						ui.RenderWarn("!"), t.Format("2006-01-02 15:04"))
 					fmt.Fprintf(os.Stderr, "  Did you mean a future date? Use --defer=+1h or --defer=tomorrow\n")
 				}
 				updates["defer_until"] = t
-				// Also set status=deferred for consistency with `bd defer`
-				// (GH#3233). Skip if user explicitly set --status to something else.
-				if _, ok := updates["status"]; !ok {
+				// Align with `bd defer`: set status=deferred so the ❄ icon
+				// shows and the issue leaves the ready queue (GH#3233).
+				// Skip for past dates so the "appears in bd ready immediately"
+				// warning stays truthful, and skip if --status was set explicitly.
+				if _, ok := updates["status"]; !ok && !inPast {
 					updates["status"] = string(types.StatusDeferred)
 				}
 			}
@@ -340,6 +351,12 @@ create, update, show, or close operation).`,
 					k != "_set_metadata" && k != "_unset_metadata" {
 					regularUpdates[k] = v
 				}
+			}
+			// GH#3233: --defer="" restores ready visibility only if the issue
+			// was actually deferred. Other statuses (blocked, in_progress, …)
+			// shouldn't be clobbered just because defer_until was stale.
+			if clearDeferStatus && issue.Status == types.StatusDeferred {
+				regularUpdates["status"] = string(types.StatusOpen)
 			}
 
 			// Handle --metadata: merge with existing metadata instead of replacing

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -307,6 +307,33 @@ func TestEmbeddedUpdate(t *testing.T) {
 		if got.DeferUntil != nil {
 			t.Error("expected defer_until to be cleared")
 		}
+		// GH#3233: clearing defer on a deferred issue must restore ready visibility
+		if string(got.Status) != "open" {
+			t.Errorf("expected status=open after clearing defer, got %q", got.Status)
+		}
+	})
+
+	t.Run("update_defer_past_date_keeps_status_open", func(t *testing.T) {
+		// GH#3233: past-date --defer shouldn't flip status to deferred, because
+		// the warning promises the issue "will appear in bd ready immediately".
+		issue := bdCreate(t, bd, dir, "Past defer test", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--defer", "2000-01-01")
+		got := bdShow(t, bd, dir, issue.ID)
+		if string(got.Status) == "deferred" {
+			t.Errorf("past --defer should not set status=deferred, got %q", got.Status)
+		}
+	})
+
+	t.Run("update_defer_clear_preserves_non_deferred_status", func(t *testing.T) {
+		// GH#3233: clearing defer_until shouldn't clobber a non-deferred status
+		// that was set independently (e.g. in_progress).
+		issue := bdCreate(t, bd, dir, "Defer clear keep status test", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--status", "in_progress")
+		bdUpdate(t, bd, dir, issue.ID, "--defer", "")
+		got := bdShow(t, bd, dir, issue.ID)
+		if string(got.Status) != "in_progress" {
+			t.Errorf("expected status=in_progress to be preserved, got %q", got.Status)
+		}
 	})
 
 	t.Run("update_await_id", func(t *testing.T) {

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -283,6 +283,20 @@ func TestEmbeddedUpdate(t *testing.T) {
 		if got.DeferUntil == nil {
 			t.Error("expected defer_until to be set")
 		}
+		// GH#3233: --defer should also set status=deferred for consistency with `bd defer`
+		if string(got.Status) != "deferred" {
+			t.Errorf("expected status=deferred, got %q", got.Status)
+		}
+	})
+
+	t.Run("update_defer_respects_explicit_status", func(t *testing.T) {
+		// GH#3233: explicit --status should win over the implicit deferred set by --defer
+		issue := bdCreate(t, bd, dir, "Defer+status test", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--defer", "2099-01-15", "--status", "in_progress")
+		got := bdShow(t, bd, dir, issue.ID)
+		if string(got.Status) != "in_progress" {
+			t.Errorf("expected explicit status=in_progress to win, got %q", got.Status)
+		}
 	})
 
 	t.Run("update_defer_clear", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `bd update --defer <date>` now also sets `status=deferred`, matching `bd defer`'s behavior so the ❄ icon (driven by the status field) renders correctly in `bd list`.
- Explicit `--status` in the same invocation still wins.

Fixes #3233.

## Test plan
- [x] Added `update_defer` assertion that status becomes `deferred`
- [x] Added `update_defer_respects_explicit_status` covering the precedence case
- [x] CI runs embedded tests (local env lacks libicu-dev for CGO build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)