### PR TITLE
fix(list): emit informative truncation hint in all output modes (GH#3212)

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -461,6 +461,12 @@ var listCmd = &cobra.Command{
 			sqlLimit = 0
 		}
 
+		// Fetch one extra row so we can distinguish "exactly N matches" from
+		// "N+ matches truncated" without running a second count query (GH#3212).
+		if sqlLimit > 0 {
+			sqlLimit++
+		}
+
 		filter := types.IssueFilter{
 			Limit: sqlLimit,
 		}
@@ -834,8 +840,10 @@ var listCmd = &cobra.Command{
 		// Apply sorting
 		sortIssues(issues, sortBy, reverse)
 
-		// Apply limit after sorting when --sort deferred it from SQL (GH#1237)
-		if sortBy != "" && effectiveLimit > 0 && len(issues) > effectiveLimit {
+		// Detect truncation (GH#3212). We fetched effectiveLimit+1 above, so any
+		// overflow means more matches exist than we're displaying.
+		truncated := effectiveLimit > 0 && len(issues) > effectiveLimit
+		if truncated {
 			issues = issues[:effectiveLimit]
 		}
 
@@ -872,10 +880,7 @@ var listCmd = &cobra.Command{
 			// Best effort: display gracefully degrades with empty data
 			allDeps, _ := activeStore.GetAllDependencyRecords(ctx)
 			displayPrettyListWithDeps(issues, false, allDeps)
-			// Show truncation hint if we hit the limit (GH#788)
-			if effectiveLimit > 0 && len(issues) == effectiveLimit {
-				fmt.Fprintf(os.Stderr, "\nShowing %d issues (use --limit 0 for all)\n", effectiveLimit)
-			}
+			printTruncationHint(truncated, effectiveLimit)
 			return
 		}
 
@@ -884,6 +889,7 @@ var listCmd = &cobra.Command{
 			if err := outputFormattedList(ctx, activeStore, issues, formatStr); err != nil {
 				FatalError("%v", err)
 			}
+			printTruncationHint(truncated, effectiveLimit)
 			return
 		}
 
@@ -929,6 +935,7 @@ var listCmd = &cobra.Command{
 				}
 			}
 			outputJSON(issuesWithCounts)
+			printTruncationHint(truncated, effectiveLimit)
 			return
 		}
 
@@ -957,6 +964,7 @@ var listCmd = &cobra.Command{
 				formatAgentIssue(&buf, issue, blockedByMap[issue.ID], blocksMap[issue.ID], parentMap[issue.ID])
 			}
 			fmt.Print(buf.String())
+			printTruncationHint(truncated, effectiveLimit)
 			return
 		} else if longFormat {
 			// Long format: multi-line with details
@@ -980,10 +988,7 @@ var listCmd = &cobra.Command{
 			}
 		}
 
-		// Show truncation hint if we hit the limit (GH#788)
-		if effectiveLimit > 0 && len(issues) == effectiveLimit {
-			fmt.Fprintf(os.Stderr, "\nShowing %d issues (use --limit 0 for all)\n", effectiveLimit)
-		}
+		printTruncationHint(truncated, effectiveLimit)
 
 		// Show tip after successful list (direct mode only)
 		maybeShowTip(store)

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -151,14 +151,19 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 	displayPrettyListWithDeps(issues, true, allDeps)
 }
 
-func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, parentID string, sortBy string, reverse bool) {
+func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, parentID string, sortBy string, reverse bool, effectiveLimit int) {
 	// Initial display
 	issues, err := loadWatchedIssues(ctx, store, filter, parentID, sortBy, reverse)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error querying issues: %v\n", err)
 		return
 	}
+	truncated := effectiveLimit > 0 && len(issues) > effectiveLimit
+	if truncated {
+		issues = issues[:effectiveLimit]
+	}
 	displayWatchedIssueList(ctx, store, issues)
+	printTruncationHint(truncated, effectiveLimit)
 	lastSnapshot := issueSnapshot(issues)
 
 	fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
@@ -183,10 +188,15 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 				fmt.Fprintf(os.Stderr, "Error refreshing issues: %v\n", err)
 				continue
 			}
+			truncated := effectiveLimit > 0 && len(issues) > effectiveLimit
+			if truncated {
+				issues = issues[:effectiveLimit]
+			}
 			snap := issueSnapshot(issues)
 			if snap != lastSnapshot {
 				lastSnapshot = snap
 				displayWatchedIssueList(ctx, store, issues)
+				printTruncationHint(truncated, effectiveLimit)
 				fmt.Fprintf(os.Stderr, "\nWatching for changes... (Press Ctrl+C to exit)\n")
 			}
 		}
@@ -849,7 +859,7 @@ var listCmd = &cobra.Command{
 
 		// Handle watch mode (GH#654) - must be before other output modes
 		if watchMode {
-			watchIssues(ctx, activeStore, filter, parentID, sortBy, reverse)
+			watchIssues(ctx, activeStore, filter, parentID, sortBy, reverse, effectiveLimit)
 			return
 		}
 

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -36,12 +37,14 @@ func bdListJSON(t *testing.T, bd, dir string, args ...string) []*types.IssueWith
 	cmd := exec.Command(bd, fullArgs...)
 	cmd.Dir = dir
 	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("bd list --json %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd list --json %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
-	// Find the JSON array in the output (skip any non-JSON preamble)
-	s := string(out)
+	// Parse stdout only; hints/warnings (e.g. truncation) go to stderr (GH#3212).
+	s := stdout.String()
 	start := strings.Index(s, "[")
 	if start < 0 {
 		// Empty list returns "[]" or possibly "null"
@@ -55,6 +58,22 @@ func bdListJSON(t *testing.T, bd, dir string, args ...string) []*types.IssueWith
 		t.Fatalf("failed to parse JSON list output: %v\nraw: %s", err, s[start:])
 	}
 	return issues
+}
+
+// bdListCapture runs "bd list" and returns (stdout, stderr) separately.
+func bdListCapture(t *testing.T, bd, dir string, args ...string) (string, string) {
+	t.Helper()
+	fullArgs := append([]string{"list"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd list %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), stderr.String()
 }
 
 // bdListFail runs "bd list" expecting failure.
@@ -181,6 +200,31 @@ func TestEmbeddedList(t *testing.T) {
 		issues := bdListJSON(t, bd, dir, "--limit", "2")
 		if len(issues) != 2 {
 			t.Errorf("expected 2 issues with --limit 2, got %d", len(issues))
+		}
+	})
+
+	t.Run("limit_truncation_hint", func(t *testing.T) {
+		// Truncated: --limit < seeded count should emit stderr hint (GH#3212).
+		stdout, stderr := bdListCapture(t, bd, dir, "--limit", "2")
+		if !strings.Contains(stderr, "more results matched") {
+			t.Errorf("expected truncation hint on stderr, got:\nstderr: %q\nstdout: %q", stderr, stdout)
+		}
+		// The hint must go to stderr only, not stdout, so JSON consumers can parse stdout cleanly.
+		if strings.Contains(stdout, "more results matched") {
+			t.Errorf("truncation hint leaked into stdout:\n%s", stdout)
+		}
+
+		// Not truncated: --limit 0 (unlimited) must not emit the hint.
+		_, stderrAll := bdListCapture(t, bd, dir, "--limit", "0")
+		if strings.Contains(stderrAll, "more results matched") {
+			t.Errorf("unexpected truncation hint with --limit 0:\n%s", stderrAll)
+		}
+
+		// Not truncated: exact count match (we seed 12 issues, closed ones excluded by default).
+		// Use a generous --limit that exceeds any default view.
+		_, stderrHigh := bdListCapture(t, bd, dir, "--limit", "1000")
+		if strings.Contains(stderrHigh, "more results matched") {
+			t.Errorf("false-positive truncation hint when under limit:\n%s", stderrHigh)
 		}
 	})
 

--- a/cmd/bd/list_output.go
+++ b/cmd/bd/list_output.go
@@ -4,11 +4,22 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"text/template"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// printTruncationHint emits a one-line notice to stderr when the list output
+// was truncated by --limit, so users and agents can't mistake a partial view
+// for a complete one (GH#3212, GH#788).
+func printTruncationHint(truncated bool, effectiveLimit int) {
+	if !truncated || effectiveLimit <= 0 {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "\nShowing %d issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.\n", effectiveLimit)
+}
 
 // outputDotFormat outputs issues in Graphviz DOT format
 func outputDotFormat(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) error {


### PR DESCRIPTION
## Summary
- Fetch `effectiveLimit+1` rows so we can distinguish "exactly N matches" from "N+ matches truncated" without a second count query
- Emit a clearer truncation hint to stderr across all output modes, including `--json`, `--format`, pretty/tree, and agent mode — closing the silent-data-loss gap called out in GH#3212

## Motivation
`bd list` defaults to `--limit 50` and previously:
- Only hinted at truncation when `len(issues) == limit`, which false-positives when exactly N issues match
- Never hinted at all in `--json` mode, so agents consuming JSON couldn't tell a truncated view from a complete one

New hint:
```
Showing 50 issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.
```

Closes #3212.

## Test plan
- [x] `make build`
- [x] `go test -tags gms_pure_go ./cmd/bd/ -run TestList` passes
- [x] Smoke: 60 issues created, `bd list` shows hint; `bd list --json` shows hint on stderr; `--limit 100`, `--limit 0`, and exact-count runs emit no hint (no false positives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)