### PR TITLE
fix(bootstrap): commit issue_prefix to config table (GH#3216)

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -404,7 +404,7 @@ func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
 	}
-	if err := s.Commit(ctx, "bd bootstrap"); err != nil {
+	if err := s.CommitWithConfig(ctx, "bd bootstrap"); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 
@@ -431,7 +431,7 @@ func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfi
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
 	}
-	if err := s.Commit(ctx, "bd bootstrap: init"); err != nil {
+	if err := s.CommitWithConfig(ctx, "bd bootstrap: init"); err != nil {
 		return fmt.Errorf("commit init: %w", err)
 	}
 
@@ -462,7 +462,7 @@ func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *conf
 	if err := s.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("set issue prefix: %w", err)
 	}
-	if err := s.Commit(ctx, "bd bootstrap: init"); err != nil {
+	if err := s.CommitWithConfig(ctx, "bd bootstrap: init"); err != nil {
 		return fmt.Errorf("commit init: %w", err)
 	}
 

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -48,6 +48,13 @@ func (s *EmbeddedDoltStore) Commit(ctx context.Context, message string) error {
 	})
 }
 
+// CommitWithConfig commits all working set changes including config.
+// EmbeddedDoltStore.Commit already includes config via DOLT_ADD('-A'),
+// so this is just an alias to satisfy the VersionControl interface (GH#3216).
+func (s *EmbeddedDoltStore) CommitWithConfig(ctx context.Context, message string) error {
+	return s.Commit(ctx, message)
+}
+
 func (s *EmbeddedDoltStore) AddRemote(ctx context.Context, name, url string) error {
 	return s.withConn(ctx, true, func(tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "CALL DOLT_REMOTE('add', ?, ?)", name, url)

--- a/internal/storage/version_control.go
+++ b/internal/storage/version_control.go
@@ -34,6 +34,10 @@ type VersionControl interface {
 	DeleteBranch(ctx context.Context, branch string) error
 	ListBranches(ctx context.Context) ([]string, error)
 	Commit(ctx context.Context, message string) error
+	// CommitWithConfig is like Commit but includes the config table.
+	// Use after intentional config writes (bd init, bd config set, bd rename-prefix).
+	// GH#3216: bootstrap paths must use this to commit issue_prefix.
+	CommitWithConfig(ctx context.Context, message string) error
 	CommitPending(ctx context.Context, actor string) (bool, error)
 	CommitExists(ctx context.Context, commitHash string) (bool, error)
 	GetCurrentCommit(ctx context.Context) (string, error)


### PR DESCRIPTION
## Summary

Fixes #3216. `bd init` / `bd restore` / `bd import` write `issue_prefix` via `SetConfig` but then call `Commit()`, which excludes the `config` table per GH#2455. The prefix row sits orphaned in the Dolt working set forever, causing `bd dolt pull` to fail with `cannot merge with uncommitted changes` on every fresh init and silently breaking sync.

This is the same class of bug as #3028 (fixed for `remember`/`forget`/`config set` by PR #3052) — the bootstrap path was not covered.

## Changes

- `cmd/bd/bootstrap.go`: switch the three post-`SetConfig` commits in `executeInitAction`, `executeRestoreAction`, and `executeJSONLImportAction` from `Commit` to `CommitWithConfig`.
- `internal/storage/version_control.go`: promote `CommitWithConfig` to the `VersionControl` interface so it's callable through the storage abstraction.
- `internal/storage/embeddeddolt/version_control.go`: add `CommitWithConfig` as an alias to `Commit` (embedded already includes config via `DOLT_ADD '-A'`).

## Test plan

- [x] `go build -tags gms_pure_go ./cmd/bd` passes
- [x] `go vet -tags gms_pure_go ./...` passes
- [x] `internal/storage/dolt` tests still pass (`TestCommitWithConfig_*`)
- [ ] Manual: fresh `bd init`, then `bd sql \"SELECT COUNT(*) FROM config\"` should match `... AS OF 'HEAD'` (no orphaned `issue_prefix` in working set)

Reported by @GraemeF — thanks for the thorough diagnosis and the pointer to the matching #3052 fix pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)