### PR TITLE
feat: add starter formula examples

### DIFF
--- a/examples/formulas/README.md
+++ b/examples/formulas/README.md
@@ -1,0 +1,34 @@
+# Starter Formulas
+
+Example `.formula.toml` files you can use as starting points.
+
+## Usage
+
+Copy formulas to your project or user-level directory:
+
+```bash
+# Project-level (available in this project only)
+cp *.formula.toml /path/to/project/.beads/formulas/
+
+# User-level (available in all projects)
+cp *.formula.toml ~/.beads/formulas/
+```
+
+Then list and use them:
+
+```bash
+bd formula list        # See available formulas
+bd mol pour release --var version=1.2.0   # Pour into a molecule
+```
+
+## Included Formulas
+
+| Formula | Description | Use as |
+|---------|-------------|--------|
+| `feature-workflow` | Design, implement, review, merge | Molecule (persistent) |
+| `release` | Bump version, test, tag, publish | Molecule (persistent) |
+| `quick-check` | Lint, test, build sanity check | Wisp (ephemeral) |
+
+## Creating Your Own
+
+See the [Formulas documentation](https://gastownhall.github.io/beads/docs/workflows/formulas) for the full reference.

--- a/examples/formulas/feature-workflow.formula.toml
+++ b/examples/formulas/feature-workflow.formula.toml
@@ -1,0 +1,39 @@
+formula = "feature-workflow"
+description = "Standard feature development workflow: design, implement, review, merge."
+version = 1
+type = "workflow"
+
+[vars.feature_name]
+description = "Name of the feature to implement"
+required = true
+
+[[steps]]
+id = "design"
+title = "Design {{feature_name}}"
+type = "human"
+description = "Create design document or spec. Define scope, approach, and acceptance criteria."
+
+[[steps]]
+id = "implement"
+title = "Implement {{feature_name}}"
+needs = ["design"]
+description = "Write the code. Create tests. Update docs if applicable."
+
+[[steps]]
+id = "test"
+title = "Run test suite"
+needs = ["implement"]
+description = "Run full test suite and linter. Fix any failures before proceeding."
+
+[[steps]]
+id = "review"
+title = "Code review"
+needs = ["test"]
+type = "human"
+description = "Open PR and get code review. Address feedback."
+
+[[steps]]
+id = "merge"
+title = "Merge to main"
+needs = ["review"]
+description = "Merge PR after approval. Delete feature branch."

--- a/examples/formulas/quick-check.formula.toml
+++ b/examples/formulas/quick-check.formula.toml
@@ -1,0 +1,25 @@
+formula = "quick-check"
+description = "Fast lint-test-build sanity check. Designed for use as a wisp."
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "lint"
+title = "Run linter"
+description = "Run project linter. Note warnings vs errors - errors block, warnings are informational."
+
+[[steps]]
+id = "test"
+title = "Run tests"
+description = "Run the project test suite. Record pass/fail count."
+
+[[steps]]
+id = "build"
+title = "Build project"
+description = "Run the build step. Verify output artifacts are created."
+
+[[steps]]
+id = "report"
+title = "Report results"
+needs = ["lint", "test", "build"]
+description = "Summarize: lint status, test pass rate, build success. Flag any issues found."

--- a/examples/formulas/release.formula.toml
+++ b/examples/formulas/release.formula.toml
@@ -1,0 +1,45 @@
+formula = "release"
+description = "Standard release workflow: bump version, test, tag, publish."
+version = 1
+type = "workflow"
+
+[vars.version]
+description = "Release version (e.g. 1.2.0)"
+required = true
+pattern = "^\\d+\\.\\d+\\.\\d+$"
+
+[[steps]]
+id = "bump-version"
+title = "Bump version to {{version}}"
+description = "Update version strings in source files and package manifests."
+
+[[steps]]
+id = "changelog"
+title = "Update CHANGELOG"
+needs = ["bump-version"]
+description = "Add release notes for {{version}}. Summarize changes since last release."
+
+[[steps]]
+id = "test"
+title = "Run full test suite"
+needs = ["changelog"]
+description = "Run all tests, linting, and build checks. Release must not proceed with failures."
+
+[[steps]]
+id = "build"
+title = "Build release artifacts"
+needs = ["test"]
+description = "Build binaries, packages, or other release artifacts."
+
+[[steps]]
+id = "tag"
+title = "Create git tag v{{version}}"
+needs = ["build"]
+description = "Tag the release commit. Push tag to origin."
+
+[[steps]]
+id = "publish"
+title = "Publish release"
+needs = ["tag"]
+type = "human"
+description = "Create GitHub release, publish packages, announce to users."


### PR DESCRIPTION
## Problem

`bd formula list` returns "No formulas found" on a fresh install. The formula system is powerful but no `.formula.toml` files ship with beads. All examples exist only as doc snippets, giving new users no starting point.

## Fix

Add `examples/formulas/` with 3 starter formulas:

- **feature-workflow** - design, implement, review, merge (standard feature development)
- **release** - bump version, test, tag, publish (standard release workflow)
- **quick-check** - lint, test, build (fast sanity check, designed as wisp)

Each formula uses features documented in the formulas guide: variables, step dependencies, human-type steps, and parallel-then-join patterns. A README explains how to copy them into project-level or user-level formula directories.

## Test Plan

- [ ] `bd formula list` shows all 3 formulas when copied to `.beads/formulas/`
- [ ] `bd mol pour feature-workflow --var feature_name=test --dry-run` previews correctly
- [ ] `bd mol pour release --var version=1.0.0 --dry-run` previews correctly
- [ ] TOML syntax valid (no parse errors)

## Context

Closes #3246. The formulas are based on examples already in the docs (`website/versioned_docs/version-1.0.0/workflows/formulas.md`) but fleshed out with step descriptions that make them immediately usable.