### PR TITLE
docs: trim getting-started docs ~3x per internal audit

### DIFF
--- a/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
@@ -4,85 +4,40 @@ title: IDE Setup
 sidebar_position: 3
 ---
 
-# IDE Setup for AI Agents
+# IDE Setup
 
-Configure your IDE for optimal beads integration.
+Configure your editor for beads integration. All integrations use `bd prime` to inject ~1-2k tokens of workflow context on session start.
 
 ## Claude Code
 
-The recommended approach for Claude Code:
-
 ```bash
-# Setup Claude Code integration
 bd setup claude
+bd setup claude --check  # Verify
 ```
 
-This installs:
-- **SessionStart hook** - Runs `bd prime` when Claude Code starts
-- **PreCompact hook** - Ensures `bd dolt push` before context compaction
-
-**How it works:**
-1. SessionStart hook runs `bd prime` automatically
-2. `bd prime` injects ~1-2k tokens of workflow context
-3. You use `bd` CLI commands directly
-4. Git hooks auto-sync the database
-
-**Verify installation:**
-```bash
-bd setup claude --check
-```
-
-### Manual Setup
-
-If you prefer manual configuration, add to your Claude Code hooks:
-
-```json
-{
-  "hooks": {
-    "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
-  }
-}
-```
+Installs SessionStart hook (`bd prime`) and PreCompact hook (`bd dolt push`).
 
 ## Cursor IDE
 
 ```bash
-# Setup Cursor integration
 bd setup cursor
+bd setup cursor --check  # Verify
 ```
 
-This creates `.cursor/rules/beads.mdc` with beads-aware rules.
-
-**Verify:**
-```bash
-bd setup cursor --check
-```
+Creates `.cursor/rules/beads.mdc` with beads-aware rules.
 
 ## Aider
 
 ```bash
-# Setup Aider integration
 bd setup aider
+bd setup aider --check  # Verify
 ```
 
-This creates/updates `.aider.conf.yml` with beads context.
+Creates/updates `.aider.conf.yml` with beads context.
 
-**Verify:**
-```bash
-bd setup aider --check
-```
+## GitHub Copilot (VS Code)
 
-## GitHub Copilot
-
-For VS Code with GitHub Copilot, use the MCP server:
-
-```bash
-# Install MCP server
-uv tool install beads-mcp
-```
-
-Create `.vscode/mcp.json` in your project:
+Use the MCP server. Install with `uv tool install beads-mcp`, then create `.vscode/mcp.json`:
 
 ```json
 {
@@ -94,78 +49,17 @@ Create `.vscode/mcp.json` in your project:
 }
 ```
 
-**For all projects:** Add to VS Code user-level MCP config:
+See [GitHub Copilot Integration](/integrations/github-copilot) for platform-specific paths and detailed setup.
 
-| Platform | Path |
-|----------|------|
-| macOS | `~/Library/Application Support/Code/User/mcp.json` |
-| Linux | `~/.config/Code/User/mcp.json` |
-| Windows | `%APPDATA%\Code\User\mcp.json` |
+## MCP Server (Claude Desktop, no shell)
 
-```json
-{
-  "servers": {
-    "beads": {
-      "command": "beads-mcp",
-      "args": []
-    }
-  }
-}
-```
-
-Initialize beads and reload VS Code:
+For environments without CLI access:
 
 ```bash
-bd init --quiet
-```
-
-See [GitHub Copilot Integration](/integrations/github-copilot) for detailed setup.
-
-## Context Injection with `bd prime`
-
-All integrations use `bd prime` to inject context:
-
-```bash
-bd prime
-```
-
-This outputs a compact (~1-2k tokens) workflow reference including:
-- Available commands
-- Current project status
-- Workflow patterns
-- Best practices
-
-**Why context efficiency matters:**
-- Compute cost scales with tokens
-- Latency increases with context size
-- Models attend better to smaller, focused contexts
-
-## MCP Server (Alternative)
-
-For MCP-only environments (Claude Desktop, no shell access):
-
-```bash
-# Install MCP server
 pip install beads-mcp
 ```
 
-Add to Claude Desktop config:
-```json
-{
-  "mcpServers": {
-    "beads": {
-      "command": "beads-mcp"
-    }
-  }
-}
-```
-
-**Trade-offs:**
-- Works in MCP-only environments
-- Higher context overhead (10-50k tokens for tool schemas)
-- Additional latency from MCP protocol
-
-See [MCP Server](/integrations/mcp-server) for detailed configuration.
+See [MCP Server](/integrations/mcp-server) for configuration.
 
 ## Git Hooks
 
@@ -173,32 +67,14 @@ Ensure git hooks are installed for auto-sync:
 
 ```bash
 bd hooks install
-```
-
-This installs:
-- **pre-commit** - Validates changes before commit
-- **post-merge** - Imports changes after pull
-- **pre-push** - Ensures sync before push
-
-**Check hook status:**
-```bash
 bd info  # Shows warnings if hooks are outdated
 ```
 
-## Verifying Your Setup
-
-Run a complete health check:
+## Verify Setup
 
 ```bash
-# Check version
 bd version
-
-# Check project health
 bd doctor
-
-# Check hooks
 bd hooks status
-
-# Check editor integration
-bd setup claude --check   # or cursor, aider
+bd setup claude --check  # or cursor, aider
 ```

--- a/website/versioned_docs/version-1.0.0/getting-started/installation.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/installation.md
@@ -6,8 +6,6 @@ sidebar_position: 1
 
 # Installing bd
 
-Complete installation guide for all platforms.
-
 ## Quick Install (Recommended)
 
 ### Homebrew (macOS/Linux)
@@ -16,246 +14,68 @@ Complete installation guide for all platforms.
 brew install beads
 ```
 
-**Why Homebrew?**
-- Simple one-command install
-- Automatic updates via `brew upgrade`
-- No need to install Go
-- Handles PATH setup automatically
-
-### Quick Install Script (All Platforms)
+### Install Script (macOS/Linux/FreeBSD)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
 ```
 
-The installer will:
-- Detect your platform (macOS/Linux/FreeBSD, amd64/arm64)
-- Install via `go install` if Go is available
-- Fall back to building from source if needed
-- Guide you through PATH setup if necessary
+### PowerShell (Windows)
 
-## Build Dependencies (go install / from source)
-
-If you install via `go install` or build from source, you need system dependencies for CGO:
-
-macOS (Homebrew):
-```bash
-brew install icu4c zstd
-```
-
-Linux (Debian/Ubuntu):
-```bash
-sudo apt-get install -y libicu-dev libzstd-dev
-```
-
-Linux (Fedora/RHEL):
-```bash
-sudo dnf install -y libicu-devel libzstd-devel
-```
-
-If you see `unicode/uregex.h` missing on macOS, `icu4c` is keg-only. Use:
-```bash
-ICU_PREFIX="$(brew --prefix icu4c)"
-CGO_CFLAGS="-I${ICU_PREFIX}/include" CGO_CPPFLAGS="-I${ICU_PREFIX}/include" CGO_LDFLAGS="-L${ICU_PREFIX}/lib" go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
-## Platform-Specific Installation
-
-### macOS
-
-**Via Homebrew** (recommended):
-```bash
-brew install beads
-```
-
-**Via go install**:
-```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
-**From source**:
-```bash
-git clone https://github.com/steveyegge/beads
-cd beads
-go build -o bd ./cmd/bd
-sudo mv bd /usr/local/bin/
-```
-
-### Linux
-
-**Via Homebrew** (works on Linux too):
-```bash
-brew install beads
-```
-
-**Arch Linux** (AUR):
-```bash
-# Install from AUR
-yay -S beads-git
-# or
-paru -S beads-git
-```
-
-**Via go install**:
-```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
-### FreeBSD
-
-**Via quick install script**:
-```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
-```
-
-**Via go install**:
-```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
-### Windows 11
-
-Beads ships with native Windows support—no MSYS or MinGW required.
-
-**Prerequisites:**
-- [Go 1.24+](https://go.dev/dl/) installed (add `%USERPROFILE%\go\bin` to your `PATH`)
-- Git for Windows
-
-**Via PowerShell script**:
 ```pwsh
 irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 ```
 
-The script installs a prebuilt Windows release if available. Go is only required for `go install` or building from source.
-
-**Via go install**:
-```pwsh
-go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
-If you see `unicode/uregex.h` missing while building, use the PowerShell install script instead.
-
-## IDE and Editor Integrations
-
-### CLI + Hooks (Recommended)
-
-The recommended approach for Claude Code, Cursor, Windsurf, and other editors with shell access:
+### npm
 
 ```bash
-# 1. Install bd CLI (see Quick Install above)
-brew install beads
-
-# 2. Initialize in your project
-cd your-project
-bd init --quiet
-
-# 3. Setup editor integration (choose one)
-bd setup claude   # Claude Code - installs SessionStart/PreCompact hooks
-bd setup cursor   # Cursor IDE - creates .cursor/rules/beads.mdc
-bd setup aider    # Aider - creates .aider.conf.yml
+npm install -g @beads/bd
 ```
 
-**How it works:**
-- Editor hooks/rules inject `bd prime` automatically on session start
-- `bd prime` provides ~1-2k tokens of workflow context
-- You use `bd` CLI commands directly
-- Git hooks (installed by `bd init`) auto-sync the database
+## Platform-Specific Notes
 
-**Why this is recommended:**
-- **Context efficient** - ~1-2k tokens vs 10-50k for MCP tool schemas
-- **Lower latency** - Direct CLI calls, no MCP protocol overhead
-- **Universal** - Works with any editor that has shell access
+### macOS
 
-### MCP Server (Alternative)
+Homebrew is recommended. Alternatively: `go install github.com/steveyegge/beads/cmd/bd@latest` (requires CGO dependencies - see [Building from source](#building-from-source) below).
 
-Use MCP only when CLI is unavailable (Claude Desktop, Sourcegraph Amp without shell):
+### Linux
 
-```bash
-# Using uv (recommended)
-uv tool install beads-mcp
+Homebrew works on Linux. For Arch Linux: `yay -S beads-git` or `paru -S beads-git` (AUR).
 
-# Or using pip
-pip install beads-mcp
-```
+### Windows
 
-**Configuration for Claude Desktop** (macOS):
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "beads": {
-      "command": "beads-mcp"
-    }
-  }
-}
-```
+Native Windows support - no MSYS or MinGW required. The PowerShell installer above is the recommended path. Go is only required for building from source.
 
 ## Verifying Installation
-
-After installing, verify bd is working:
 
 ```bash
 bd version
 bd help
 ```
 
-## Troubleshooting
+If you see `bd: command not found`, ensure your install location is in PATH. For Homebrew and npm this is automatic. For `go install`, add `$(go env GOPATH)/bin` to your PATH.
 
-### `bd: command not found`
+## Building from Source
 
-bd is not in your PATH:
+Building from source or using `go install` requires CGO dependencies:
 
-```bash
-# Check if installed
-go list -f {{.Target}} github.com/steveyegge/beads/cmd/bd
-
-# Add Go bin to PATH (add to ~/.bashrc or ~/.zshrc)
-export PATH="$PATH:$(go env GOPATH)/bin"
-```
-
-### `zsh: killed bd` or crashes on macOS
-
-This is typically caused by CGO/SQLite compatibility issues:
+| Platform | Command |
+|----------|---------|
+| macOS | `brew install icu4c zstd` |
+| Debian/Ubuntu | `sudo apt-get install -y libicu-dev libzstd-dev` |
+| Fedora/RHEL | `sudo dnf install -y libicu-devel libzstd-devel` |
 
 ```bash
-# Build with CGO enabled
-CGO_ENABLED=1 go install github.com/steveyegge/beads/cmd/bd@latest
+git clone https://github.com/steveyegge/beads
+cd beads
+go build -o bd ./cmd/bd
 ```
 
-## Updating bd
-
-### Quick install script (macOS/Linux/FreeBSD)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
-```
-
-### PowerShell installer (Windows)
-
-```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
-```
-
-### Homebrew
-
-```bash
-brew upgrade beads
-```
-
-### go install
-
-```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
-For post-upgrade steps (hooks, migrations), see [Upgrading](/getting-started/upgrading).
+See [CONTRIBUTING.md](https://github.com/steveyegge/beads/blob/main/CONTRIBUTING.md) for full developer setup.
 
 ## Next Steps
 
-After installation:
-
 1. **Initialize a project**: `cd your-project && bd init`
-2. **Learn the basics**: See [Quick Start](/getting-started/quickstart)
-3. **Configure your agent**: See [IDE Setup](/getting-started/ide-setup)
+2. **Learn the basics**: [Quick Start](/getting-started/quickstart)
+3. **Configure your editor**: [IDE Setup](/getting-started/ide-setup)
+4. **Upgrading later**: [Upgrading](/getting-started/upgrading)

--- a/website/versioned_docs/version-1.0.0/getting-started/quickstart.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/quickstart.md
@@ -6,21 +6,12 @@ sidebar_position: 2
 
 # Beads Quick Start
 
-Get up and running with Beads in a few minutes.
+Get up and running with beads in a few minutes.
 
 ## Why Beads?
 
-Flat issue trackers (GitHub Issues, Jira, etc.) show you a list of open items. You pick one. But if that item depends on something else that isn't done yet, you've wasted time. Multiply this across a team of AI agents and humans, and you get thrashing.
+Flat issue trackers show you all open items. You pick one - but if it depends on something else that isn't done yet, you've wasted time. Beads tracks **dependencies between issues** and computes a **ready queue** - only items with no active blockers appear.
 
-Beads tracks **dependencies between issues** and computes a **ready queue** — only items with no active blockers appear. Here's the difference:
-
-**Flat tracker (GitHub Issues):**
-```
-Open issues: Set up database, Create API, Add authentication
-→ An agent picks "Add authentication" and gets stuck immediately
-```
-
-**Beads:**
 ```bash
 $ bd ready
 1. [P1] [task] bd-1: Set up database
@@ -33,338 +24,92 @@ $ bd ready --explain --json | jq '.blocked[0]'
 }
 ```
 
-The agent picks the right task every time. No wasted cycles.
-
-## Installation
-
-Install `bd` using [the full installation guide](/getting-started/installation) (Homebrew, install script, npm, or `go install`).
-
-**Developing in a clone of this repository:** use `make install` so the binary gets correct build metadata and a consistent install path. Avoid ad-hoc `go build` / `go install` without the Makefile unless you know what you are doing — see the repository `README` and `AGENTS.md`.
-
-```bash
-bd --help
-```
+The agent picks the right task every time.
 
 ## Initialize
 
-First time in a repository:
-
 ```bash
-# Basic setup (prompts for contributor mode)
-bd init
-
-# For AI agents (non-interactive)
-bd init --quiet
-
-# OSS contributor (fork workflow with separate planning repo)
-bd init --contributor
-
-# Team member (branch workflow for collaboration)
-bd init --team
-
-# Protected main branch (GitHub/GitLab)
-# Note: Dolt stores data under refs/dolt/data, separate from
-# Git refs, so no --branch flag is needed.
+cd your-project
+bd init          # Interactive setup (prompts for role)
+bd init --quiet  # Non-interactive (for AI agents)
 ```
 
-The wizard will:
-- Create `.beads/` directory and embedded Dolt database
-- **Prompt for your role** (maintainer or contributor) unless a flag is provided
-- Import existing issues from git (if any)
-- Prompt to install git hooks (recommended)
-- Prompt to configure git merge driver (recommended)
+The wizard creates `.beads/`, sets up the embedded Dolt database, and optionally installs git hooks. During init, you'll be asked whether you're a maintainer or contributor - this determines how beads routes issues. You can change it later with `git config beads.role`.
 
-Notes:
-- Dolt is the default (and only) storage backend. Data is stored in `.beads/embeddeddolt/`.
-- By default, Dolt runs in **embedded mode** (in-process, no server needed).
-- For multi-writer setups, use `bd init --server` to connect to a `dolt sql-server` instead.
-- To import issues from an older installation, run `bd init --from-jsonl`.
-
-### Role configuration
-
-During `bd init`, you'll be asked: "Contributing to someone else's repo? [y/N]"
-
-- Answer **Y** if you're contributing to a fork (runs contributor wizard)
-- Answer **N** if you're the maintainer or have push access
-
-This sets `git config beads.role` which determines how beads routes issues:
-
-| Role | Use case | Issue storage |
-|------|----------|---------------|
-| `maintainer` | Repo owner, team with push access | In-repo `.beads/` |
-| `contributor` | Fork contributor, OSS contributor | Separate planning repo |
-
-You can also configure manually:
+## Create Issues and Dependencies
 
 ```bash
-# Set as contributor
-git config beads.role contributor
-
-# Set as maintainer
-git config beads.role maintainer
-
-# Check current role
-git config --get beads.role
-```
-
-**Note:** If `beads.role` is not configured, beads falls back to URL-based detection (deprecated). Run `bd doctor` to check configuration status.
-
-## Your first issues
-
-```bash
-# Create a few issues
+# Create issues
 bd create "Set up database" -p 1 -t task
 bd create "Create API" -p 2 -t feature
 bd create "Add authentication" -p 2 -t feature
 
-# List them
-bd list
-```
-
-**Note:** Issue IDs are hash-based (e.g., `bd-a1b2`, `bd-f14c`) to prevent collisions when multiple agents/branches work concurrently.
-
-## Hierarchical issues (epics)
-
-For large features, use hierarchical IDs to organize work:
-
-```bash
-# Create epic (generates parent hash ID)
-bd create "Auth System" -t epic -p 1
-# Returns: bd-a3f8e9
-
-# Create child tasks (use --parent to attach to the epic)
-bd create "Design login UI" -p 1 --parent bd-a3f8e9       # bd-a3f8e9.1
-bd create "Backend validation" -p 1 --parent bd-a3f8e9    # bd-a3f8e9.2
-bd create "Integration tests" -p 1 --parent bd-a3f8e9     # bd-a3f8e9.3
-
-# View hierarchy
-bd dep tree bd-a3f8e9
-```
-
-Output:
-```
-Dependency tree for bd-a3f8e9:
-
-> bd-a3f8e9: Auth System [epic] [P1] (open)
-  > bd-a3f8e9.1: Design login UI [P1] (open)
-  > bd-a3f8e9.2: Backend validation [P1] (open)
-  > bd-a3f8e9.3: Integration tests [P1] (open)
-```
-
-## Add dependencies
-
-```bash
-# API depends on database
+# Add dependencies (API needs database, auth needs API)
 bd dep add bd-2 bd-1
-
-# Auth depends on API
 bd dep add bd-3 bd-2
 
-# View the tree
+# View the dependency tree
 bd dep tree bd-3
 ```
 
-Output:
-```
-Dependency tree for bd-3:
+Issue IDs are hash-based (e.g., `bd-a1b2`) to prevent collisions when multiple agents work concurrently.
 
-> bd-3: Add authentication [P2] (open)
-  > bd-2: Create API [P2] (open)
-    > bd-1: Set up database [P1] (open)
-```
-
-**Dependency visibility:** `bd list` shows blocking dependencies inline:
-```
-○ bd-a1b2 [P1] [task] - Set up database
-○ bd-f14c [P2] [feature] - Create API (blocked by: bd-a1b2)
-○ bd-g25d [P2] [feature] - Add authentication (blocked by: bd-f14c)
-```
-
-## Find ready work
+## Find and Work the Ready Queue
 
 ```bash
+# What's unblocked right now?
 bd ready
-```
 
-Output:
-```
-Ready work (1 issues with no blockers):
-
-1. [P1] bd-1: Set up database
-```
-
-Only bd-1 is ready because bd-2 and bd-3 are blocked.
-
-**Understanding why:** Use `--explain` to see the full graph reasoning:
-
-```bash
+# Why is something blocked?
 bd ready --explain
-```
 
-Output:
-```
-Ready Work Explanation
-
-● Ready (1 issues):
-
-  bd-1 [P1] Set up database
-    Reason: no blocking dependencies
-    Unblocks: 1 issue(s)
-
-● Blocked (2 issues):
-
-  bd-2 [P2] Create API
-    ← blocked by bd-1: Set up database [open]
-
-  bd-3 [P2] Add authentication
-    ← blocked by bd-2: Create API [open]
-
-─ Summary: 1 ready, 2 blocked
-```
-
-**Note:** `bd ready` is not the same as `bd list --status open`. The `list` command shows all open issues regardless of blockers. The `ready` command computes the dependency graph and only shows truly unblocked work.
-
-## Work the queue
-
-```bash
-# Start working on bd-1
+# Claim and complete work
 bd update bd-1 --claim
-
-# Complete it
 bd close bd-1 --reason "Database setup complete"
 
-# Check ready work again
+# Now bd-2 is ready
 bd ready
 ```
 
-Now bd-2 is ready.
+`bd ready` is not the same as `bd list --status open` - the list command shows all open issues regardless of blockers. The ready command computes the dependency graph and only shows truly unblocked work.
 
-## Track progress
+## Epics
+
+Group related work under an epic:
 
 ```bash
-# See blocked issues
-bd blocked
-
-# View statistics
-bd stats
+bd create "Auth System" -t epic -p 1       # Returns: bd-a3f8e9
+bd create "Design login UI" -p 1 --parent bd-a3f8e9
+bd create "Backend validation" -p 1 --parent bd-a3f8e9
+bd dep tree bd-a3f8e9
 ```
 
-## Team sync
+## Team Sync
 
-Share issues with your team using Dolt remotes. Dolt stores data under `refs/dolt/data` on the same Git remote, separate from standard Git refs.
+Share issues using Dolt remotes (works over the same Git remote):
 
 ```bash
-# Add a remote (GitHub example — also supports DoltHub, S3, GCS, local paths)
 bd dolt remote add origin git+ssh://git@github.com/org/repo.git
-
-# Push your issues
 bd dolt push
-
-# Pull teammates' changes
 bd dolt pull
 ```
 
-When a teammate clones the repo, `bd bootstrap` auto-detects the existing database on `refs/dolt/data` and clones it — no manual remote setup needed.
+When a teammate clones the repo, `bd bootstrap` auto-detects the existing database. See [Sync](/cli-reference/sync) for details.
 
-See [Sync](/cli-reference/sync) for CLI details. For remote configuration and federation, see the repository docs [DOLT-BACKEND.md](https://github.com/steveyegge/beads/blob/main/docs/DOLT-BACKEND.md) and [FEDERATION-SETUP.md](https://github.com/steveyegge/beads/blob/main/FEDERATION-SETUP.md).
-
-## Optional: Notion sync
-
-If you keep project issues in Notion, save an integration token first:
+## Track Progress
 
 ```bash
-bd config set notion.token <your-token>
+bd blocked    # See blocked issues
+bd stats      # Project statistics
+bd list       # All issues
+bd doctor     # Health check
 ```
 
-Then either create a new Beads database under a parent page or connect to an existing target:
-
-```bash
-bd notion init --parent <page-id>
-# or
-bd notion connect --url <notion-database-or-data-source-url>
-```
-
-The same auth value can also come from `NOTION_TOKEN`. Directly setting `notion.data_source_id` remains available as an escape hatch for advanced setups.
-
-Check which auth source is active and whether the target schema is ready:
-
-```bash
-bd notion status
-bd notion status --json
-```
-
-Preview or run sync:
-
-```bash
-bd notion sync --dry-run
-bd notion sync
-bd notion sync --pull
-bd notion sync --push
-```
-
-## Database location
-
-By default (embedded mode), data is stored in `.beads/embeddeddolt/` within your repository.
-In server mode, data is managed by the external `dolt sql-server`.
-
-## Migrating databases
-
-After upgrading bd, use `bd migrate` to check for and migrate old database files:
-
-```bash
-# Inspect migration plan (AI agents)
-bd migrate --inspect --json
-
-# Check schema and config
-bd info --schema --json
-
-# Preview migration changes
-bd migrate --dry-run
-
-# Migrate old databases to beads.db
-bd migrate
-
-# Migrate and clean up old files
-bd migrate --cleanup --yes
-```
-
-**AI agents:** Use `--inspect` to analyze migration safety before running. The system verifies required config keys and data integrity invariants.
-
-## Database maintenance
-
-As your project accumulates closed issues, the database grows. Manage size with these commands:
-
-```bash
-# View compaction statistics
-bd admin compact --stats
-
-# Preview compaction candidates (30+ days closed)
-bd admin compact --analyze --json
-
-# Apply agent-generated summary
-bd admin compact --apply --id bd-42 --summary summary.txt
-
-# Immediately delete closed issues (CAUTION: permanent!)
-bd admin cleanup --force
-```
-
-**When to compact:**
-- Database file > 10MB with many old closed issues
-- After major project milestones when old issues are no longer relevant
-- Before archiving a project phase
-
-**Note:** Compaction is permanent graceful decay. Original content is discarded but viewable via `bd restore <id>` from git history.
-
-## Next steps
+## Next Steps
 
 - Add labels: `bd create "Task" -l "backend,urgent"`
 - Filter ready work: `bd ready --priority 1`
-- Explain the graph: `bd ready --explain`
 - Check graph integrity: `bd graph check`
-- Search issues: `bd list --status open`
-- Detect cycles: `bd dep cycles`
 - Gates for PR/CI sync: [Dependencies](/cli-reference/dependencies)
-- More sync scenarios: [Sync](/cli-reference/sync)
+- IDE integration: [IDE Setup](/getting-started/ide-setup)
 - Full command list: [CLI Reference](/cli-reference)
-
-See the [repository README](https://github.com/steveyegge/beads/blob/main/README.md) for an overview and links to deeper docs.

--- a/website/versioned_docs/version-1.0.0/getting-started/upgrading.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/upgrading.md
@@ -6,130 +6,34 @@ sidebar_position: 4
 
 # Upgrading bd
 
-How to upgrade bd and keep your projects in sync.
+## Upgrade Commands
 
-## Checking for Updates
+Use the command that matches your install method:
 
-```bash
-# Current version
-bd version
-
-# What's new in recent versions
-bd info --whats-new
-bd info --whats-new --json  # Machine-readable
-```
-
-## Upgrading
-
-Use the command that matches your install method.
-
-| Install method | Platforms | Command |
-|---|---|---|
-| Quick install script | macOS, Linux, FreeBSD | `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh \| bash` |
-| PowerShell installer | Windows | `irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 \| iex` |
-| Homebrew | macOS, Linux | `brew upgrade beads` |
-| go install | macOS, Linux, FreeBSD, Windows | `go install github.com/steveyegge/beads/cmd/bd@latest` |
-| npm | macOS, Linux, Windows | `npm update -g @beads/bd` |
-| bun | macOS, Linux, Windows | `bun install -g --trust @beads/bd` |
-| From source (Unix shell) | macOS, Linux, FreeBSD | `git pull && go build -o bd ./cmd/bd` |
-
-### Quick install script (macOS/Linux/FreeBSD)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
-```
-
-### PowerShell installer (Windows)
-
-```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
-```
-
-### Homebrew
-
-```bash
-brew upgrade beads
-```
-
-### go install
-
-```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
-```
-
-### From Source
-
-```bash
-cd beads
-git pull
-go build -o bd ./cmd/bd
-sudo mv bd /usr/local/bin/
-```
+| Install method | Command |
+|---|---|
+| Homebrew | `brew upgrade beads` |
+| Install script (macOS/Linux) | `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh \| bash` |
+| PowerShell (Windows) | `irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 \| iex` |
+| npm | `npm update -g @beads/bd` |
+| go install | `go install github.com/steveyegge/beads/cmd/bd@latest` |
 
 ## After Upgrading
 
-**Important:** After upgrading, update your hooks:
-
 ```bash
-# 1. Check what changed
-bd info --whats-new
-
-# 2. Update git hooks to match new version
-bd hooks install
-
-# 3. Check for any outdated hooks
-bd info  # Shows warnings if hooks are outdated
-
-# 4. If using Dolt backend, restart the server
-bd dolt stop && bd dolt start
+bd info --whats-new     # Check what changed
+bd hooks install        # Update git hooks to match new version
+bd migrate --dry-run    # Check for database migrations
+bd migrate              # Apply if needed
 ```
 
-**Why update hooks?** Git hooks are versioned with bd. Outdated hooks may miss new auto-sync features or bug fixes.
+Git hooks are versioned with bd - outdated hooks may miss auto-sync features. If using Dolt server mode, restart with `bd dolt stop && bd dolt start`.
 
-## Database Migrations
+## Recovery
 
-After major upgrades, check for database migrations:
-
-```bash
-# Inspect migration plan (AI agents)
-bd migrate --inspect --json
-
-# Preview migration changes
-bd migrate --dry-run
-
-# Apply migrations
-bd migrate
-
-# Migrate and clean up old files
-bd migrate --cleanup --yes
-```
-
-## Troubleshooting Upgrades
-
-### Hooks out of date
+If an upgrade causes issues:
 
 ```bash
-bd hooks install
-```
-
-### Database schema changed
-
-```bash
-bd migrate --dry-run
-bd migrate
-```
-
-### Recovery after upgrade
-
-If you need to restore from a backup:
-
-```bash
-bd init
-bd backup restore [path] --force
-```
-
-Or pull from a Dolt remote:
-
-```bash
-bd dolt pull
+bd dolt pull                        # Restore from remote
+bd backup restore [path] --force    # Or restore from backup
 ```


### PR DESCRIPTION
## Problem

`docs/GETTING_STARTED_ANALYSIS.md` (by @csells, 2026-04-05) found the getting-started docs are ~3x longer than needed. The analysis identified four categories: genuinely necessary content (~25%), useful reference (~22%), workarounds for fixable UX issues (~28%), and redundancy across files (~25%). The doc-only recommendations were never acted on.

## Fix

Applied the doc-change recommendations from the analysis. No tool changes - just trimming, consolidating, and relocating content that belongs elsewhere.

| File | Before | After | What changed |
|------|--------|-------|-------------|
| installation.md | 261 | 81 | Removed IDE section (duplicates ide-setup.md), removed updating section (duplicates upgrading.md), consolidated platform-specific installs, moved CGO/build deps below happy path |
| quickstart.md | 370 | 115 | Removed Notion sync, database maintenance, database migration, database location sections. Trimmed role config and init options. Core flow preserved: init, create, deps, ready, work, sync |
| ide-setup.md | 204 | 80 | Removed bd prime implementation details, trimmed MCP duplication, condensed per-editor sections to command + verify pattern |
| upgrading.md | 135 | 39 | Consolidated summary table with duplicate detailed sections, trimmed troubleshooting |
| **Total** | **970** | **315** | **3.1x reduction** |

Content removed from quickstart (Notion sync, db maintenance, db migration) belongs in integration docs and reference docs respectively - not in getting-started material.

## Test Plan

- [ ] All internal links resolve (no broken `/getting-started/` references)
- [ ] Core quickstart flow still covers: init, create, deps, ready, claim, close, sync
- [ ] Installation covers all platforms: macOS, Linux, FreeBSD, Windows
- [ ] IDE setup covers all editors: Claude Code, Cursor, Aider, Copilot, MCP
- [ ] Docusaurus build succeeds with trimmed docs

## Context

Closes #3245. Applies the "Immediate wins (doc changes only)" section from `docs/GETTING_STARTED_ANALYSIS.md`. The analysis also recommends tool-level fixes (better error messages, auto-clear circuit breaker, etc.) that would eliminate even more doc surface area - those are separate issues.