### PR TITLE
feat(gate): add 'bd gate create' for ad-hoc blocking gates

### DIFF
--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -219,6 +219,117 @@ This is used by 'bd done --phase-complete' to register for gate wake notificatio
 	},
 }
 
+// gateCreateCmd creates an ad-hoc gate issue that blocks another issue
+var gateCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a gate that blocks an issue",
+	Long: `Create an ad-hoc gate issue that blocks another issue until resolved.
+
+The blocked issue will not appear in 'bd ready' until the gate is resolved
+via 'bd gate resolve'.
+
+Gate types:
+  human   - Requires manual 'bd gate resolve' (default)
+  timer   - Auto-resolves after --timeout duration
+  gh:run  - Waits for GitHub Actions workflow
+  gh:pr   - Waits for PR merge
+
+Examples:
+  bd gate create --blocks bd-abc
+  bd gate create --type=human --blocks bd-abc --reason="Need design review"
+  bd gate create --type=timer --blocks bd-abc --timeout=2h
+  bd gate create --type=gh:pr --blocks bd-abc --await-id=42`,
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("gate create")
+
+		blocksID, _ := cmd.Flags().GetString("blocks")
+		gateType, _ := cmd.Flags().GetString("type")
+		reason, _ := cmd.Flags().GetString("reason")
+		awaitID, _ := cmd.Flags().GetString("await-id")
+		timeoutStr, _ := cmd.Flags().GetString("timeout")
+
+		ctx := rootCtx
+
+		// Verify the target issue exists
+		targetIssue, err := store.GetIssue(ctx, blocksID)
+		if err != nil {
+			FatalError("issue not found: %s", blocksID)
+		}
+
+		// Parse timeout if specified
+		var timeout time.Duration
+		if timeoutStr != "" {
+			parsed, err := time.ParseDuration(timeoutStr)
+			if err != nil {
+				FatalError("invalid timeout: %v", err)
+			}
+			timeout = parsed
+		}
+
+		// Build gate title
+		title := fmt.Sprintf("Gate: %s", gateType)
+		if awaitID != "" {
+			title = fmt.Sprintf("Gate: %s %s", gateType, awaitID)
+		}
+
+		// Build description
+		desc := fmt.Sprintf("Ad-hoc gate blocking %s", targetIssue.ID)
+		if reason != "" {
+			desc = fmt.Sprintf("%s\n\nReason: %s", desc, reason)
+		}
+
+		// Create the gate issue
+		gate := &types.Issue{
+			Title:       title,
+			Description: desc,
+			Status:      types.StatusOpen,
+			Priority:    2,
+			IssueType:   types.IssueType("gate"),
+			AwaitType:   gateType,
+			AwaitID:     awaitID,
+			Timeout:     timeout,
+			CreatedBy:   getActorWithGit(),
+			Owner:       getOwner(),
+		}
+
+		if err := store.CreateIssue(ctx, gate, actor); err != nil {
+			FatalError("creating gate: %v", err)
+		}
+
+		// Add blocking dependency: target issue depends on gate
+		dep := &types.Dependency{
+			IssueID:     targetIssue.ID,
+			DependsOnID: gate.ID,
+			Type:        types.DepBlocks,
+		}
+		if err := store.AddDependency(ctx, dep, actor); err != nil {
+			FatalError("adding blocking dependency: %v", err)
+		}
+
+		// CreateIssue commits the issue row. AddDependency writes to the
+		// working set and needs a follow-up commit.
+		commitMsg := fmt.Sprintf("bd: create gate %s blocking %s", gate.ID, targetIssue.ID)
+		if err := store.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
+			FatalError("failed to commit: %v", err)
+		}
+
+		if jsonOutput {
+			outputJSON(gate)
+			return
+		}
+
+		fmt.Printf("%s Created gate %s (type: %s)\n", ui.RenderPass("✓"), ui.RenderID(gate.ID), gateType)
+		fmt.Printf("  Blocks: %s (%s)\n", targetIssue.ID, targetIssue.Title)
+		if reason != "" {
+			fmt.Printf("  Reason: %s\n", reason)
+		}
+		if timeout > 0 {
+			fmt.Printf("  Timeout: %s\n", timeout)
+		}
+		fmt.Printf("\nResolve with: bd gate resolve %s\n", gate.ID)
+	},
+}
+
 // gateShowCmd shows a gate issue
 var gateShowCmd = &cobra.Command{
 	Use:   "show <gate-id>",
@@ -779,13 +890,23 @@ func init() {
 	gateCheckCmd.Flags().BoolP("escalate", "e", false, "Escalate failed/expired gates")
 	gateCheckCmd.Flags().IntP("limit", "l", 100, "Limit results (default 100)")
 
+	// gate create flags
+	gateCreateCmd.Flags().String("blocks", "", "Issue ID to block (required)")
+	gateCreateCmd.Flags().StringP("type", "t", "human", "Gate type (human, timer, gh:run, gh:pr)")
+	gateCreateCmd.Flags().StringP("reason", "r", "", "Reason for the gate")
+	gateCreateCmd.Flags().String("await-id", "", "Condition identifier (run ID, PR number, etc.)")
+	gateCreateCmd.Flags().String("timeout", "", "Timeout duration (e.g., 2h, 30m)")
+	_ = gateCreateCmd.MarkFlagRequired("blocks")
+
 	// Issue ID completions
 	gateShowCmd.ValidArgsFunction = issueIDCompletion
 	gateResolveCmd.ValidArgsFunction = issueIDCompletion
 	gateAddWaiterCmd.ValidArgsFunction = issueIDCompletion
+	gateCreateCmd.ValidArgsFunction = issueIDCompletion
 
 	// Add subcommands
 	gateCmd.AddCommand(gateListCmd)
+	gateCmd.AddCommand(gateCreateCmd)
 	gateCmd.AddCommand(gateShowCmd)
 	gateCmd.AddCommand(gateResolveCmd)
 	gateCmd.AddCommand(gateCheckCmd)

--- a/cmd/bd/gate_embedded_test.go
+++ b/cmd/bd/gate_embedded_test.go
@@ -350,6 +350,240 @@ func TestEmbeddedGate(t *testing.T) {
 	})
 }
 
+// TestEmbeddedGateCreate exercises the "bd gate create" subcommand.
+func TestEmbeddedGateCreate(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gc")
+
+	// Register "gate" as a custom type so bd gate create works.
+	store := openStore(t, beadsDir, "gc")
+	if err := store.SetConfig(t.Context(), "types.custom", `["gate"]`); err != nil {
+		t.Fatalf("SetConfig types.custom: %v", err)
+	}
+	store.Close()
+
+	t.Run("create_default_human_gate", func(t *testing.T) {
+		task := bdCreate(t, bd, dir, "Task for human gate", "--type", "task")
+
+		out := bdGate(t, bd, dir, "create", "--blocks", task.ID)
+		if !strings.Contains(out, "Created gate") {
+			t.Errorf("expected 'Created gate' in output: %s", out)
+		}
+		if !strings.Contains(out, "type: human") {
+			t.Errorf("expected default type 'human' in output: %s", out)
+		}
+		if !strings.Contains(out, task.ID) {
+			t.Errorf("expected blocked issue ID in output: %s", out)
+		}
+	})
+
+	t.Run("create_gate_json_output", func(t *testing.T) {
+		task := bdCreate(t, bd, dir, "Task for JSON gate", "--type", "task")
+
+		cmd := exec.Command(bd, "gate", "create", "--blocks", task.ID, "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd gate create --json failed: %v\n%s", err, out)
+		}
+
+		var gate types.Issue
+		s := strings.TrimSpace(string(out))
+		start := strings.Index(s, "{")
+		if start < 0 {
+			t.Fatalf("no JSON in output: %s", s)
+		}
+		if err := json.Unmarshal([]byte(s[start:]), &gate); err != nil {
+			t.Fatalf("parse gate JSON: %v\n%s", err, s)
+		}
+		if gate.IssueType != types.IssueType("gate") {
+			t.Errorf("expected issue_type=gate, got %s", gate.IssueType)
+		}
+		if gate.AwaitType != "human" {
+			t.Errorf("expected await_type=human, got %s", gate.AwaitType)
+		}
+	})
+
+	t.Run("create_gate_with_type_and_reason", func(t *testing.T) {
+		task := bdCreate(t, bd, dir, "Task for timer gate", "--type", "task")
+
+		cmd := exec.Command(bd, "gate", "create", "--blocks", task.ID,
+			"--type", "timer", "--timeout", "2h", "--reason", "Wait for cooldown", "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd gate create --type=timer failed: %v\n%s", err, out)
+		}
+
+		var gate types.Issue
+		s := strings.TrimSpace(string(out))
+		start := strings.Index(s, "{")
+		if err := json.Unmarshal([]byte(s[start:]), &gate); err != nil {
+			t.Fatalf("parse gate JSON: %v\n%s", err, s)
+		}
+		if gate.AwaitType != "timer" {
+			t.Errorf("expected await_type=timer, got %s", gate.AwaitType)
+		}
+		if gate.Timeout != 2*60*60*1e9 { // 2h in nanoseconds
+			t.Errorf("expected timeout=2h, got %v", gate.Timeout)
+		}
+		if !strings.Contains(gate.Description, "Wait for cooldown") {
+			t.Errorf("expected reason in description: %s", gate.Description)
+		}
+	})
+
+	t.Run("create_gate_with_await_id", func(t *testing.T) {
+		task := bdCreate(t, bd, dir, "Task for PR gate", "--type", "task")
+
+		cmd := exec.Command(bd, "gate", "create", "--blocks", task.ID,
+			"--type", "gh:pr", "--await-id", "42", "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd gate create --type=gh:pr failed: %v\n%s", err, out)
+		}
+
+		var gate types.Issue
+		s := strings.TrimSpace(string(out))
+		start := strings.Index(s, "{")
+		if err := json.Unmarshal([]byte(s[start:]), &gate); err != nil {
+			t.Fatalf("parse gate JSON: %v\n%s", err, s)
+		}
+		if gate.AwaitType != "gh:pr" {
+			t.Errorf("expected await_type=gh:pr, got %s", gate.AwaitType)
+		}
+		if gate.AwaitID != "42" {
+			t.Errorf("expected await_id=42, got %s", gate.AwaitID)
+		}
+		if gate.Title != "Gate: gh:pr 42" {
+			t.Errorf("expected title 'Gate: gh:pr 42', got %s", gate.Title)
+		}
+	})
+
+	t.Run("create_gate_blocks_ready", func(t *testing.T) {
+		// Use a fresh db so ready output isn't polluted by other subtests
+		freshDir, freshBeads, _ := bdInit(t, bd, "--prefix", "gr")
+		fs := openStore(t, freshBeads, "gr")
+		if err := fs.SetConfig(t.Context(), "types.custom", `["gate"]`); err != nil {
+			t.Fatalf("SetConfig: %v", err)
+		}
+		fs.Close()
+
+		task := bdCreate(t, bd, freshDir, "Ready test task", "--type", "task")
+
+		// Verify task appears in ready
+		cmd := exec.Command(bd, "ready")
+		cmd.Dir = freshDir
+		cmd.Env = bdEnv(freshDir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd ready failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "Ready test task") {
+			t.Fatalf("task should appear in ready before gate: %s", out)
+		}
+
+		// Create gate blocking the task
+		bdGate(t, bd, freshDir, "create", "--blocks", task.ID)
+
+		// Verify task no longer in ready
+		cmd = exec.Command(bd, "ready")
+		cmd.Dir = freshDir
+		cmd.Env = bdEnv(freshDir)
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			// bd ready exits 0 even with no results
+			t.Fatalf("bd ready failed: %v\n%s", err, out)
+		}
+		if strings.Contains(string(out), "Ready test task") {
+			t.Errorf("task should NOT appear in ready while gate is open: %s", out)
+		}
+	})
+
+	t.Run("create_gate_resolve_unblocks_ready", func(t *testing.T) {
+		// Use a fresh db for clean ready output
+		freshDir, freshBeads, _ := bdInit(t, bd, "--prefix", "gu")
+		fs := openStore(t, freshBeads, "gu")
+		if err := fs.SetConfig(t.Context(), "types.custom", `["gate"]`); err != nil {
+			t.Fatalf("SetConfig: %v", err)
+		}
+		fs.Close()
+
+		task := bdCreate(t, bd, freshDir, "Unblock test task", "--type", "task")
+
+		// Create and then resolve the gate
+		gateOut := bdGate(t, bd, freshDir, "create", "--blocks", task.ID)
+
+		// Extract gate ID from output ("Created gate gc-xxx ...")
+		var gateID string
+		for _, word := range strings.Fields(gateOut) {
+			if strings.HasPrefix(word, "gu-") {
+				gateID = word
+				break
+			}
+		}
+		if gateID == "" {
+			t.Fatalf("could not extract gate ID from output: %s", gateOut)
+		}
+
+		// Resolve the gate
+		bdGate(t, bd, freshDir, "resolve", gateID)
+
+		// Verify task reappears in ready
+		cmd := exec.Command(bd, "ready")
+		cmd.Dir = freshDir
+		cmd.Env = bdEnv(freshDir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd ready failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "Unblock test task") {
+			t.Errorf("task should reappear in ready after gate resolved: %s", out)
+		}
+	})
+
+	t.Run("create_gate_missing_blocks_flag", func(t *testing.T) {
+		out := bdGateFail(t, bd, dir, "create")
+		if !strings.Contains(out, "blocks") {
+			t.Errorf("expected error about missing --blocks flag: %s", out)
+		}
+	})
+
+	t.Run("create_gate_nonexistent_target", func(t *testing.T) {
+		out := bdGateFail(t, bd, dir, "create", "--blocks", "gc-nonexistent999")
+		if !strings.Contains(out, "not found") {
+			t.Errorf("expected 'not found' error: %s", out)
+		}
+	})
+
+	t.Run("create_gate_appears_in_gate_list", func(t *testing.T) {
+		task := bdCreate(t, bd, dir, "Task for list check", "--type", "task")
+		bdGate(t, bd, dir, "create", "--blocks", task.ID)
+
+		results := bdGateListJSON(t, bd, dir)
+		found := false
+		for _, r := range results {
+			if awaitType, ok := r["await_type"]; ok && awaitType == "human" {
+				if desc, ok := r["description"].(string); ok && strings.Contains(desc, task.ID) {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Errorf("expected gate blocking %s in gate list", task.ID)
+		}
+	})
+}
+
 // TestEmbeddedGateConcurrent exercises gate operations concurrently.
 func TestEmbeddedGateConcurrent(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {


### PR DESCRIPTION
## Problem

Blocking gates can only be created through the formula/molecule system (via `[steps.gate]` in `.formula.toml` files). There is no CLI path to create a blocking gate on an arbitrary issue.

`bd human <id>` adds an advisory label but does not block the issue from `bd ready`. The actual blocking mechanism (`bd gate`) requires a formula to create gate issues.

## Root Cause

`cmd/bd/gate.go` has subcommands for `list`, `show`, `resolve`, `check`, and `add-waiter`, but no `create` subcommand. Gate issues can only be created through `createGateIssue()` in `cmd/bd/cook.go:478-520`, which is called during formula cooking.

## Fix

Add a `gateCreateCmd` to `cmd/bd/gate.go` that generalizes the cook.go gate creation pattern for ad-hoc use:

1. Creates a gate issue with `IssueType: "gate"`, `AwaitType`, `AwaitID`, and `Timeout`
2. Adds a `DepBlocks` dependency so the target issue is excluded from `bd ready`
3. Commits both the issue and dependency to Dolt

The command follows the same field patterns as `createGateIssue()` in cook.go but without requiring formula context.

### CLI

```
bd gate create --blocks <issue-id> [--type=human] [--reason="..."] [--timeout=2h] [--await-id=<id>]
```

- `--blocks` (required): Issue ID to block
- `--type` (default: `human`): Gate type (human, timer, gh:run, gh:pr)
- `--reason`: Why the gate exists (included in gate description)
- `--await-id`: Condition identifier (PR number, run ID, etc.)
- `--timeout`: Duration for timer gates (e.g., `2h`, `30m`)

## Test Plan

- [x] `bd gate create --blocks <id>` creates a gate issue with type=human (default)
- [x] Blocked issue no longer appears in `bd ready`
- [x] `bd gate resolve <gate-id>` unblocks the target issue
- [x] Target issue reappears in `bd ready` after gate resolved
- [x] `--type=timer --timeout=2h` sets AwaitType and Timeout correctly
- [x] `--type=gh:pr --await-id=42` sets AwaitType and AwaitID correctly
- [x] `--json` output returns the gate issue JSON
- [x] Missing `--blocks` flag produces clear error
- [x] `bd gate list` shows the created gate
- [x] `go build ./cmd/bd/` compiles cleanly
- [x] `golangci-lint run ./...` - no new warnings (only pre-existing `errcheck` in doltserver_windows.go)
- [x] `go test ./cmd/bd/...` - no new failures (only pre-existing Windows path separator issues in setup/mux_test.go)

## Context

Closes #3256

The gate type must be configured as a custom type (`bd config set types.custom gate`) for the command to work. This is consistent with formula-based gates, which also require the custom type.