### PR TITLE
feat(config): add central server config library

### DIFF
--- a/internal/configfile/central_config.go
+++ b/internal/configfile/central_config.go
@@ -1,0 +1,46 @@
+package configfile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// CentralConfigFileName is the filename for the central/global server config.
+const CentralConfigFileName = "server.json"
+
+// DefaultCentralConfigPath returns the platform-appropriate path for the
+// central beads server config.
+// Linux/macOS: ~/.config/beads/server.json
+// Windows: %APPDATA%\beads\server.json
+//
+// This follows the same convention as DefaultCredentialsPath.
+func DefaultCentralConfigPath() string {
+	if runtime.GOOS == "windows" {
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			return filepath.Join(appdata, "beads", CentralConfigFileName)
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "beads", CentralConfigFileName)
+}
+
+// LoadCentralConfig reads the central server config from the given path.
+// Returns (nil, nil) if the file does not exist (graceful skip).
+// Returns an error only if the file exists but cannot be parsed.
+func LoadCentralConfig(path string) (*Config, error) {
+	return nil, nil
+}
+
+// ApplyCentralDefaults merges server-related fields from the central config
+// into the per-project config, but only for fields that are at their zero
+// value in the project config. Non-server fields (Database, DoltDatabase,
+// DoltDataDir, ProjectID, etc.) are never inherited from the central config
+// because they are inherently per-project.
+//
+// This is a no-op if central is nil.
+func ApplyCentralDefaults(project *Config, central *Config) {
+}

--- a/internal/configfile/central_config.go
+++ b/internal/configfile/central_config.go
@@ -1,6 +1,8 @@
 package configfile
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,7 +34,19 @@ func DefaultCentralConfigPath() string {
 // Returns (nil, nil) if the file does not exist (graceful skip).
 // Returns an error only if the file exists but cannot be parsed.
 func LoadCentralConfig(path string) (*Config, error) {
-	return nil, nil
+	data, err := os.ReadFile(path) // #nosec G304 - path from DefaultCentralConfigPath or env
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading central config: %w", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing central config %s: %w", path, err)
+	}
+	return &cfg, nil
 }
 
 // ApplyCentralDefaults merges server-related fields from the central config
@@ -43,4 +57,30 @@ func LoadCentralConfig(path string) (*Config, error) {
 //
 // This is a no-op if central is nil.
 func ApplyCentralDefaults(project *Config, central *Config) {
+	if central == nil {
+		return
+	}
+
+	// Server connection fields only — these are the fields that are
+	// typically identical across all projects on a machine.
+	if project.DoltMode == "" && central.DoltMode != "" {
+		project.DoltMode = central.DoltMode
+	}
+	if project.DoltServerHost == "" && central.DoltServerHost != "" {
+		project.DoltServerHost = central.DoltServerHost
+	}
+	if project.DoltServerPort == 0 && central.DoltServerPort != 0 {
+		project.DoltServerPort = central.DoltServerPort
+	}
+	if project.DoltServerUser == "" && central.DoltServerUser != "" {
+		project.DoltServerUser = central.DoltServerUser
+	}
+	// Note: DoltServerTLS is a bool — zero value (false) is indistinguishable
+	// from "not set". We only apply central TLS=true when project has TLS=false,
+	// which means central can enable TLS but project cannot explicitly disable it
+	// via the zero value. To disable TLS when central enables it, use the
+	// BEADS_DOLT_SERVER_TLS=0 env var.
+	if !project.DoltServerTLS && central.DoltServerTLS {
+		project.DoltServerTLS = central.DoltServerTLS
+	}
 }

--- a/internal/configfile/central_config_test.go
+++ b/internal/configfile/central_config_test.go
@@ -1,0 +1,225 @@
+package configfile
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCentralConfig writes a Config as JSON to the given path.
+func writeCentralConfig(t *testing.T, path string, cfg *Config) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("failed to create central config dir: %v", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal central config: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("failed to write central config: %v", err)
+	}
+}
+
+func TestLoadCentralConfig_FileExists(t *testing.T) {
+	tmpHome := t.TempDir()
+	centralPath := filepath.Join(tmpHome, ".config", "beads", "server.json")
+
+	writeCentralConfig(t, centralPath, &Config{
+		DoltMode:       DoltModeServer,
+		DoltServerHost: "central.example.com",
+		DoltServerPort: 3308,
+		DoltServerUser: "centraluser",
+		DoltServerTLS:  true,
+	})
+
+	cfg, err := LoadCentralConfig(centralPath)
+	if err != nil {
+		t.Fatalf("LoadCentralConfig() error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("LoadCentralConfig() returned nil, want non-nil config")
+	}
+	if cfg.DoltServerHost != "central.example.com" {
+		t.Errorf("DoltServerHost = %q, want central.example.com", cfg.DoltServerHost)
+	}
+	if cfg.DoltServerPort != 3308 {
+		t.Errorf("DoltServerPort = %d, want 3308", cfg.DoltServerPort)
+	}
+	if cfg.DoltServerUser != "centraluser" {
+		t.Errorf("DoltServerUser = %q, want centraluser", cfg.DoltServerUser)
+	}
+	if cfg.DoltMode != DoltModeServer {
+		t.Errorf("DoltMode = %q, want %q", cfg.DoltMode, DoltModeServer)
+	}
+	if !cfg.DoltServerTLS {
+		t.Error("DoltServerTLS = false, want true")
+	}
+}
+
+func TestLoadCentralConfig_FileNotExists(t *testing.T) {
+	cfg, err := LoadCentralConfig("/nonexistent/path/server.json")
+	if err != nil {
+		t.Fatalf("LoadCentralConfig() error: %v, want nil (graceful skip)", err)
+	}
+	if cfg != nil {
+		t.Errorf("LoadCentralConfig() = %v, want nil for missing file", cfg)
+	}
+}
+
+func TestLoadCentralConfig_InvalidJSON(t *testing.T) {
+	tmpHome := t.TempDir()
+	centralPath := filepath.Join(tmpHome, ".config", "beads", "server.json")
+	if err := os.MkdirAll(filepath.Dir(centralPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(centralPath, []byte("{bad json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadCentralConfig(centralPath)
+	if err == nil {
+		t.Error("LoadCentralConfig() with invalid JSON should return error")
+	}
+}
+
+func TestApplyCentralDefaults_FillsEmptyFields(t *testing.T) {
+	central := &Config{
+		DoltMode:       DoltModeServer,
+		DoltServerHost: "central.example.com",
+		DoltServerPort: 3308,
+		DoltServerUser: "centraluser",
+		DoltServerTLS:  true,
+	}
+	project := &Config{
+		Database: "mydb",
+	}
+
+	ApplyCentralDefaults(project, central)
+
+	if project.DoltMode != DoltModeServer {
+		t.Errorf("DoltMode = %q, want %q", project.DoltMode, DoltModeServer)
+	}
+	if project.DoltServerHost != "central.example.com" {
+		t.Errorf("DoltServerHost = %q, want central.example.com", project.DoltServerHost)
+	}
+	if project.DoltServerPort != 3308 {
+		t.Errorf("DoltServerPort = %d, want 3308", project.DoltServerPort)
+	}
+	if project.DoltServerUser != "centraluser" {
+		t.Errorf("DoltServerUser = %q, want centraluser", project.DoltServerUser)
+	}
+	if !project.DoltServerTLS {
+		t.Error("DoltServerTLS = false, want true")
+	}
+}
+
+func TestApplyCentralDefaults_ProjectOverridesCentral(t *testing.T) {
+	central := &Config{
+		DoltMode:       DoltModeServer,
+		DoltServerHost: "central.example.com",
+		DoltServerPort: 3308,
+		DoltServerUser: "centraluser",
+		DoltServerTLS:  true,
+	}
+	project := &Config{
+		DoltMode:       DoltModeEmbedded,
+		DoltServerHost: "project.local",
+		DoltServerPort: 3309,
+		DoltServerUser: "projuser",
+		DoltServerTLS:  false, // zero value — cannot override to false
+	}
+
+	ApplyCentralDefaults(project, central)
+
+	if project.DoltMode != DoltModeEmbedded {
+		t.Errorf("DoltMode = %q, want %q (project override)", project.DoltMode, DoltModeEmbedded)
+	}
+	if project.DoltServerHost != "project.local" {
+		t.Errorf("DoltServerHost = %q, want project.local (project override)", project.DoltServerHost)
+	}
+	if project.DoltServerPort != 3309 {
+		t.Errorf("DoltServerPort = %d, want 3309 (project override)", project.DoltServerPort)
+	}
+	if project.DoltServerUser != "projuser" {
+		t.Errorf("DoltServerUser = %q, want projuser (project override)", project.DoltServerUser)
+	}
+}
+
+func TestApplyCentralDefaults_EnvVarsOverrideBoth(t *testing.T) {
+	// Central config provides defaults
+	central := &Config{
+		DoltServerHost: "central.example.com",
+		DoltServerPort: 3308,
+	}
+	project := &Config{}
+
+	// Apply central defaults first
+	ApplyCentralDefaults(project, central)
+
+	// Now set env vars — the getter methods should pick these up
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "env.override.com")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "9999")
+
+	// Env vars should override the central config values via getter methods
+	if got := project.GetDoltServerHost(); got != "env.override.com" {
+		t.Errorf("GetDoltServerHost() = %q, want env.override.com", got)
+	}
+	if got := project.GetDoltServerPort(); got != 9999 {
+		t.Errorf("GetDoltServerPort() = %d, want 9999", got)
+	}
+}
+
+func TestApplyCentralDefaults_NonServerFieldsNotInherited(t *testing.T) {
+	central := &Config{
+		Database:     "central-db-name",
+		DoltDatabase: "central-dolt-db",
+		DoltDataDir:  "/central/data/dir",
+		ProjectID:    "central-project-id",
+	}
+	project := &Config{}
+
+	ApplyCentralDefaults(project, central)
+
+	// Non-server fields must NOT be inherited from central config
+	if project.Database != "" {
+		t.Errorf("Database = %q, want empty (not inherited)", project.Database)
+	}
+	if project.DoltDatabase != "" {
+		t.Errorf("DoltDatabase = %q, want empty (not inherited)", project.DoltDatabase)
+	}
+	if project.DoltDataDir != "" {
+		t.Errorf("DoltDataDir = %q, want empty (not inherited)", project.DoltDataDir)
+	}
+	if project.ProjectID != "" {
+		t.Errorf("ProjectID = %q, want empty (not inherited)", project.ProjectID)
+	}
+}
+
+func TestApplyCentralDefaults_NilCentralIsNoOp(t *testing.T) {
+	project := &Config{
+		DoltServerHost: "project.local",
+	}
+
+	ApplyCentralDefaults(project, nil)
+
+	if project.DoltServerHost != "project.local" {
+		t.Errorf("DoltServerHost = %q, want project.local (nil central should be no-op)", project.DoltServerHost)
+	}
+}
+
+func TestDefaultCentralConfigPath(t *testing.T) {
+	path := DefaultCentralConfigPath()
+	if path == "" {
+		t.Fatal("DefaultCentralConfigPath() returned empty string")
+	}
+	// Should end with the expected path components
+	if filepath.Base(path) != "server.json" {
+		t.Errorf("DefaultCentralConfigPath() = %q, want filename server.json", path)
+	}
+	dir := filepath.Base(filepath.Dir(path))
+	if dir != "beads" {
+		t.Errorf("DefaultCentralConfigPath() parent dir = %q, want beads", dir)
+	}
+}

--- a/internal/storage/dolt/central_config_integration_test.go
+++ b/internal/storage/dolt/central_config_integration_test.go
@@ -1,0 +1,101 @@
+package dolt
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// TestApplyCentralConfigDefaults_WiresIntoOpenPath verifies that the
+// applyCentralConfigDefaults glue function loads a central config file
+// and merges its server fields into the per-project config.
+func TestApplyCentralConfigDefaults_WiresIntoOpenPath(t *testing.T) {
+	// Create a temp central config file.
+	tmpDir := t.TempDir()
+	centralPath := filepath.Join(tmpDir, "server.json")
+	central := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "central.example.com",
+		DoltServerPort: 3308,
+		DoltServerUser: "centraluser",
+	}
+	data, err := json.MarshalIndent(central, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal central config: %v", err)
+	}
+	if err := os.WriteFile(centralPath, data, 0o600); err != nil {
+		t.Fatalf("write central config: %v", err)
+	}
+
+	// Point to our temp central config.
+	t.Setenv("BEADS_CENTRAL_CONFIG", centralPath)
+
+	// Start with an empty project config (no server fields set).
+	fileCfg := configfile.DefaultConfig()
+
+	applyCentralConfigDefaults(fileCfg)
+
+	if fileCfg.DoltMode != configfile.DoltModeServer {
+		t.Errorf("DoltMode = %q, want %q", fileCfg.DoltMode, configfile.DoltModeServer)
+	}
+	if fileCfg.DoltServerHost != "central.example.com" {
+		t.Errorf("DoltServerHost = %q, want central.example.com", fileCfg.DoltServerHost)
+	}
+	if fileCfg.DoltServerPort != 3308 {
+		t.Errorf("DoltServerPort = %d, want 3308", fileCfg.DoltServerPort)
+	}
+	if fileCfg.DoltServerUser != "centraluser" {
+		t.Errorf("DoltServerUser = %q, want centraluser", fileCfg.DoltServerUser)
+	}
+}
+
+// TestApplyCentralConfigDefaults_MissingFileIsNoOp verifies that a
+// missing central config file does not error or modify the project config.
+func TestApplyCentralConfigDefaults_MissingFileIsNoOp(t *testing.T) {
+	t.Setenv("BEADS_CENTRAL_CONFIG", "/nonexistent/path/server.json")
+
+	fileCfg := configfile.DefaultConfig()
+	fileCfg.DoltServerHost = "project.local"
+
+	applyCentralConfigDefaults(fileCfg)
+
+	if fileCfg.DoltServerHost != "project.local" {
+		t.Errorf("DoltServerHost = %q, want project.local (should be unchanged)", fileCfg.DoltServerHost)
+	}
+}
+
+// TestApplyCentralConfigDefaults_ProjectOverrides verifies that non-zero
+// project fields are not overwritten by central defaults.
+func TestApplyCentralConfigDefaults_ProjectOverrides(t *testing.T) {
+	tmpDir := t.TempDir()
+	centralPath := filepath.Join(tmpDir, "server.json")
+	central := &configfile.Config{
+		DoltServerHost: "central.example.com",
+		DoltServerPort: 3308,
+	}
+	data, err := json.MarshalIndent(central, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal central config: %v", err)
+	}
+	if err := os.WriteFile(centralPath, data, 0o600); err != nil {
+		t.Fatalf("write central config: %v", err)
+	}
+
+	t.Setenv("BEADS_CENTRAL_CONFIG", centralPath)
+
+	fileCfg := configfile.DefaultConfig()
+	fileCfg.DoltServerHost = "project.local"
+	fileCfg.DoltServerPort = 9999
+
+	applyCentralConfigDefaults(fileCfg)
+
+	if fileCfg.DoltServerHost != "project.local" {
+		t.Errorf("DoltServerHost = %q, want project.local (project override)", fileCfg.DoltServerHost)
+	}
+	if fileCfg.DoltServerPort != 9999 {
+		t.Errorf("DoltServerPort = %d, want 9999 (project override)", fileCfg.DoltServerPort)
+	}
+}

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -56,6 +56,11 @@ func NewFromConfigWithCLIOptions(ctx context.Context, beadsDir string, cfg *Conf
 		fileCfg = configfile.DefaultConfig()
 	}
 
+	// Apply central server config as defaults for any server fields not
+	// set in the per-project metadata.json. This eliminates the need to
+	// duplicate host/port/user across 30+ project configs.
+	applyCentralConfigDefaults(fileCfg)
+
 	if cfg == nil {
 		cfg = &Config{}
 	}
@@ -75,6 +80,10 @@ func NewFromConfigWithOptions(ctx context.Context, beadsDir string, cfg *Config)
 	if fileCfg == nil {
 		fileCfg = configfile.DefaultConfig()
 	}
+
+	// Apply central server config as defaults for any server fields not
+	// set in the per-project metadata.json.
+	applyCentralConfigDefaults(fileCfg)
 
 	// Build config from metadata.json, allowing overrides from caller
 	if cfg == nil {
@@ -226,4 +235,20 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 // applies its server fields as defaults to the per-project config.
 // A missing central config file is silently ignored.
 func applyCentralConfigDefaults(fileCfg *configfile.Config) {
+	centralPath := os.Getenv("BEADS_CENTRAL_CONFIG")
+	if centralPath == "" {
+		centralPath = configfile.DefaultCentralConfigPath()
+	}
+	if centralPath == "" {
+		return
+	}
+
+	centralCfg, err := configfile.LoadCentralConfig(centralPath)
+	if err != nil {
+		// Log but don't fail — a broken central config shouldn't block operations.
+		fmt.Fprintf(os.Stderr, "Warning: failed to load central config %s: %v\n", centralPath, err)
+		return
+	}
+
+	configfile.ApplyCentralDefaults(fileCfg, centralCfg)
 }

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -220,3 +220,10 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 		}
 	}
 }
+
+// applyCentralConfigDefaults loads the central server config from
+// ~/.config/beads/server.json (or BEADS_CENTRAL_CONFIG env var) and
+// applies its server fields as defaults to the per-project config.
+// A missing central config file is silently ignored.
+func applyCentralConfigDefaults(fileCfg *configfile.Config) {
+}


### PR DESCRIPTION
# Overview

Eliminates the need to duplicate server connection settings (host, port, user, mode, TLS) across 30+ per-project `metadata.json` files by introducing a central config library that can load machine-wide defaults from `~/.config/beads/server.json`.

## Changes

- Add `LoadCentralConfig()`, `DefaultCentralConfigPath()`, and `ApplyCentralDefaults()` to the configfile package
- Wire `applyCentralConfigDefaults()` into `NewFromConfigWithOptions` and `NewFromConfigWithCLIOptions` in `internal/storage/dolt/open.go`

## Design decisions

- Only server connection fields are inherited from central config — per-project fields (database, data-dir, project-id) are never inherited
- Per-project values always override central defaults
- Missing central config is a silent no-op
- Central config path overridable via `BEADS_CENTRAL_CONFIG` env var

## Test plan

Run `go test ./internal/configfile/ -run TestLoadCentral -v` and `go test ./internal/configfile/ -run TestApplyCentral -v` to validate the library, and `go test ./internal/storage/dolt/ -run TestApplyCentralConfigDefaults -v` to validate the integration wiring:

- Loading a valid central config file returns the expected fields
- Missing file returns `(nil, nil)` — no error, graceful skip
- Invalid JSON returns a parse error
- Empty project fields are filled from central defaults
- Non-zero project fields are preserved over central values
- Env vars (`BEADS_DOLT_SERVER_HOST`, etc.) override both project and central via getter methods
- Per-project-only fields (database, data-dir, project-id) are never inherited
- `nil` central config is a no-op
- `DefaultCentralConfigPath()` returns a path ending in `beads/server.json`
- `applyCentralConfigDefaults` loads and applies central config to per-project config
- Missing central config file is a no-op in the wiring path
- Project fields override central defaults through the wiring path

## Commits

1. **`test(config): add specs for central server config library`** — Stub implementations + full test suite. Three tests fail (`LoadCentralConfig_FileExists`, `LoadCentralConfig_InvalidJSON`, `ApplyCentralDefaults_FillsEmptyFields`), defining expected behavior before implementation.
2. **`feat(config): implement central server config library`** — Fill in `LoadCentralConfig` (read + parse JSON, graceful skip on missing file) and `ApplyCentralDefaults` (merge server-only fields at zero values). All 9 tests pass.
3. **`test(config): add integration specs for central config wiring`** — Stub `applyCentralConfigDefaults` in `open.go` + integration tests. One test fails (`WiresIntoOpenPath`), proving the glue function doesn't yet load/apply the central config.
4. **`feat(config): wire central config into store open paths`** — Implement `applyCentralConfigDefaults` and call it in both `NewFromConfigWithOptions` and `NewFromConfigWithCLIOptions`. All integration tests pass.