### PR TITLE
[codex] Default test/install helpers to gms_pure_go

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -324,9 +324,12 @@ bd create "Test issue" -p 1
 bd ready
 ```
 
-> **WARNING**: Do NOT use `go build -o bd ./cmd/bd` or `go install ./cmd/bd`.
-> These create stale binaries in the working directory or `~/go/bin/` that
-> shadow the canonical install at `~/.local/bin/bd`. Always use `make install`.
+> **WARNING**: Do NOT use `go build -o bd ./cmd/bd`, `go install ./cmd/bd`,
+> or raw `go run ./cmd/bd ...`.
+> These bypass the canonical build path, can create stale binaries in the
+> working directory or `~/go/bin/`, and raw `go run` may miss the required
+> `gms_pure_go` build tag. Always use `make install`, `./bd`, or
+> `go run -tags gms_pure_go ./cmd/bd ...` when you explicitly need `go run`.
 
 ## Version Management
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -34,80 +34,24 @@ log_error() {
     echo -e "${RED}Error:${NC} $1" >&2
 }
 
-append_env_flag() {
-    local var_name=$1
-    local flag_value=$2
-    local current_value
-
-    current_value=${!var_name:-}
-    if [ -n "$current_value" ]; then
-        export "$var_name=$current_value $flag_value"
-    else
-        export "$var_name=$flag_value"
-    fi
-}
-
-configure_cgo_build_env() {
+print_missing_build_deps_help() {
     local system
     system=$(uname -s)
 
     case "$system" in
         Darwin)
-            if command -v brew &> /dev/null; then
-                local icu_prefix
-                icu_prefix=$(brew --prefix icu4c 2>/dev/null || true)
-                if [ -n "$icu_prefix" ]; then
-                    append_env_flag CGO_CFLAGS "-I${icu_prefix}/include"
-                    append_env_flag CGO_CPPFLAGS "-I${icu_prefix}/include"
-                    append_env_flag CGO_LDFLAGS "-L${icu_prefix}/lib -Wl,-rpath,${icu_prefix}/lib"
-                    log_info "Configured CGO to use Homebrew icu4c at ${icu_prefix}"
-                fi
-            fi
-            ;;
-        Linux|FreeBSD)
-            if command -v pkg-config &> /dev/null && pkg-config --exists icu-i18n; then
-                local icu_cflags
-                local icu_libs
-                icu_cflags=$(pkg-config --cflags icu-i18n)
-                icu_libs=$(pkg-config --libs icu-i18n)
-                if [ -n "$icu_cflags" ]; then
-                    append_env_flag CGO_CFLAGS "$icu_cflags"
-                    append_env_flag CGO_CPPFLAGS "$icu_cflags"
-                fi
-                if [ -n "$icu_libs" ]; then
-                    append_env_flag CGO_LDFLAGS "$icu_libs"
-                fi
-                log_info "Configured CGO to use pkg-config ICU flags"
-            elif command -v brew &> /dev/null; then
-                local icu_prefix
-                icu_prefix=$(brew --prefix icu4c 2>/dev/null || true)
-                if [ -n "$icu_prefix" ]; then
-                    append_env_flag CGO_CFLAGS "-I${icu_prefix}/include"
-                    append_env_flag CGO_CPPFLAGS "-I${icu_prefix}/include"
-                    append_env_flag CGO_LDFLAGS "-L${icu_prefix}/lib -Wl,-rpath,${icu_prefix}/lib"
-                    log_info "Configured CGO to use Homebrew icu4c at ${icu_prefix}"
-                fi
-            fi
-            ;;
-    esac
-}
-
-print_missing_icu_help() {
-    local system
-    system=$(uname -s)
-
-    case "$system" in
-        Darwin)
-            log_warning "Missing ICU headers. Install them with: brew install icu4c zstd"
-            log_warning "If icu4c is already installed, rerun this installer; it now auto-detects Homebrew's keg-only prefix."
+            log_warning "Build from source requires CGO and a C toolchain."
+            log_warning "Install Xcode Command Line Tools: xcode-select --install"
             ;;
         Linux)
-            log_warning "Missing ICU headers. Install them with your package manager, for example:"
-            log_warning "  Debian/Ubuntu: sudo apt-get install -y libicu-dev libzstd-dev"
-            log_warning "  Fedora/RHEL: sudo dnf install -y libicu-devel libzstd-devel"
+            log_warning "Build from source requires CGO and a C toolchain."
+            log_warning "Install build tools with your package manager, for example:"
+            log_warning "  Debian/Ubuntu: sudo apt-get install -y build-essential pkg-config libzstd-dev"
+            log_warning "  Fedora/RHEL: sudo dnf install -y gcc gcc-c++ make pkgconf-pkg-config libzstd-devel"
             ;;
         FreeBSD)
-            log_warning "Missing ICU headers. Install them with: pkg install -y icu zstd"
+            log_warning "Build from source requires CGO and a C toolchain."
+            log_warning "Install them with: pkg install -y gcc gmake pkgconf zstd"
             ;;
     esac
 }
@@ -513,7 +457,7 @@ verify_binary_has_cgo() {
 
     if strings "$binary_path" | awk '/^build[[:space:]]+CGO_ENABLED=0$/ { found=1 } END { exit(found?0:1) }'; then
         log_error "Binary produced by ${install_method} was built without CGO support"
-        log_warning "CGO is required for some features. Install ICU headers and retry."
+        log_warning "CGO is required for some features. Install a working C toolchain and retry."
         return 1
     fi
 
@@ -524,9 +468,8 @@ verify_binary_has_cgo() {
 # Install using go install (fallback)
 install_with_go() {
     log_info "Installing bd using 'go install'..."
-    configure_cgo_build_env
 
-    if CGO_ENABLED=1 go install github.com/gastownhall/beads/cmd/bd@latest; then
+    if CGO_ENABLED=1 GOFLAGS="${GOFLAGS:+$GOFLAGS }-tags=gms_pure_go" go install github.com/gastownhall/beads/cmd/bd@latest; then
         log_success "bd installed successfully via go install"
 
         # Record where we expect the binary to have been installed
@@ -562,7 +505,7 @@ install_with_go() {
         return 0
     else
         log_error "go install failed"
-        print_missing_icu_help
+        print_missing_build_deps_help
         return 1
     fi
 }
@@ -570,7 +513,6 @@ install_with_go() {
 # Build from source (last resort)
 build_from_source() {
     log_info "Building bd from source..."
-    configure_cgo_build_env
 
     local tmp_dir
     tmp_dir=$(mktemp -d)
@@ -630,8 +572,8 @@ build_from_source() {
             return 0
         else
             log_error "Build failed"
-            print_missing_icu_help
-    cd - > /dev/null || cd "$HOME"
+            print_missing_build_deps_help
+            cd - > /dev/null || cd "$HOME"
             cd - > /dev/null
             rm -rf "$tmp_dir"
             return 1
@@ -805,4 +747,3 @@ main() {
 }
 
 main "$@"
-

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,16 +7,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SKIP_FILE="$REPO_ROOT/.test-skip"
 
-# ICU4C is keg-only on macOS (Homebrew doesn't symlink it into /opt/homebrew).
-# Dolt's go-icu-regex dependency needs these paths to compile and link.
-if [[ "$(uname)" == "Darwin" ]]; then
-    ICU_PREFIX="$(brew --prefix icu4c 2>/dev/null || true)"
-    if [[ -n "$ICU_PREFIX" ]]; then
-        export CGO_CFLAGS="${CGO_CFLAGS:+$CGO_CFLAGS }-I${ICU_PREFIX}/include"
-        export CGO_CPPFLAGS="${CGO_CPPFLAGS:+$CGO_CPPFLAGS }-I${ICU_PREFIX}/include"
-        export CGO_LDFLAGS="${CGO_LDFLAGS:+$CGO_LDFLAGS }-L${ICU_PREFIX}/lib"
-    fi
-fi
+# Default test path uses the same pure-Go regex build as user-facing binaries.
+# ICU coverage remains available via scripts/test-cgo.sh.
+export GOFLAGS="${GOFLAGS:+$GOFLAGS }-tags=gms_pure_go"
 
 # Build skip pattern from .test-skip file
 build_skip_pattern() {


### PR DESCRIPTION
## Summary
- default the standard test wrapper to `gms_pure_go` so ad hoc local test runs follow the same no-ICU build path as release binaries
- update the install script `go install` fallback to set `gms_pure_go` and replace stale ICU-specific failure guidance with general CGO/toolchain guidance
- document for agents that raw `go run ./cmd/bd ...` should either be avoided or invoked with `-tags gms_pure_go`

## Why
Ad hoc local commands were still taking the ICU-backed build path even after the project moved its main build and test recipes away from ICU. That left a sharp edge where `go run ./cmd/bd ...` or plain `go install` could fail on missing ICU headers despite the default project path no longer depending on ICU.

## Validation
- `bash -n scripts/test.sh`
- `bash -n scripts/install.sh`

## Impact
This keeps the default contributor and agent workflows aligned with the intended pure-Go regex build path while preserving `scripts/test-cgo.sh` as the explicit ICU-path validation entry point.
