### PR TITLE
fix: make beads-mcp shared-worktree aware

### DIFF
--- a/integrations/beads-mcp/src/beads_mcp/server.py
+++ b/integrations/beads-mcp/src/beads_mcp/server.py
@@ -309,17 +309,17 @@ def _detect_backend(beads_dir: str) -> str:
 
 
 def _resolve_workspace_root(path: str) -> str:
-    """Resolve workspace root to git repo root if inside a git repo.
+    """Resolve workspace root to the repo that owns the active beads workspace.
     
     Args:
         path: Directory path to resolve
         
     Returns:
-        Git repo root if inside git repo, otherwise the original path
+        Active beads repo root if inside git repo, otherwise the original path
     """
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "rev-parse", "--show-toplevel", "--git-common-dir"],
             cwd=path,
             capture_output=True,
             text=True,
@@ -328,7 +328,35 @@ def _resolve_workspace_root(path: str) -> str:
             stdin=subprocess.DEVNULL,  # Prevent inheriting MCP's stdin
         )
         if result.returncode == 0:
-            return result.stdout.strip()
+            lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            if len(lines) >= 2:
+                worktree_root = lines[0]
+                common_dir = lines[1]
+
+                if not os.path.isabs(common_dir):
+                    common_dir = os.path.join(worktree_root, common_dir)
+                common_dir = os.path.realpath(common_dir)
+
+                main_repo_root = (
+                    os.path.dirname(common_dir)
+                    if os.path.basename(common_dir) == ".git"
+                    else common_dir
+                )
+                worktree_root = os.path.realpath(worktree_root)
+
+                local_beads = os.path.join(worktree_root, ".beads")
+                main_beads = os.path.join(main_repo_root, ".beads")
+                if (
+                    worktree_root != main_repo_root
+                    and not os.path.isdir(local_beads)
+                    and os.path.isdir(main_beads)
+                ):
+                    return main_repo_root
+
+                return worktree_root
+
+            if lines:
+                return os.path.realpath(lines[0])
     except Exception as e:
         logger.debug(f"Git detection failed for {path}: {e}")
         pass

--- a/integrations/beads-mcp/src/beads_mcp/tools.py
+++ b/integrations/beads-mcp/src/beads_mcp/tools.py
@@ -187,17 +187,17 @@ def _find_beads_db_in_tree(start_dir: str | None = None) -> str | None:
 
 
 def _resolve_workspace_root(path: str) -> str:
-    """Resolve workspace root to git repo root if inside a git repo.
+    """Resolve workspace root to the repo that owns the active beads workspace.
     
     Args:
         path: Directory path to resolve
         
     Returns:
-        Git repo root if inside git repo, otherwise the original path
+        Active beads repo root if inside git repo, otherwise the original path
     """
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "rev-parse", "--show-toplevel", "--git-common-dir"],
             cwd=path,
             capture_output=True,
             text=True,
@@ -206,7 +206,35 @@ def _resolve_workspace_root(path: str) -> str:
             stdin=subprocess.DEVNULL,  # Prevent inheriting MCP's stdin
         )
         if result.returncode == 0:
-            return result.stdout.strip()
+            lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            if len(lines) >= 2:
+                worktree_root = lines[0]
+                common_dir = lines[1]
+
+                if not os.path.isabs(common_dir):
+                    common_dir = os.path.join(worktree_root, common_dir)
+                common_dir = os.path.realpath(common_dir)
+
+                main_repo_root = (
+                    os.path.dirname(common_dir)
+                    if os.path.basename(common_dir) == ".git"
+                    else common_dir
+                )
+                worktree_root = os.path.realpath(worktree_root)
+
+                local_beads = os.path.join(worktree_root, ".beads")
+                main_beads = os.path.join(main_repo_root, ".beads")
+                if (
+                    worktree_root != main_repo_root
+                    and not os.path.isdir(local_beads)
+                    and os.path.isdir(main_beads)
+                ):
+                    return main_repo_root
+
+                return worktree_root
+
+            if lines:
+                return os.path.realpath(lines[0])
     except Exception as e:
         logger.debug(f"Git detection failed for {path}: {e}")
         pass

--- a/integrations/beads-mcp/tests/test_multi_project_switching.py
+++ b/integrations/beads-mcp/tests/test_multi_project_switching.py
@@ -258,11 +258,28 @@ class TestPathCanonicalization:
             
             with patch("beads_mcp.tools.subprocess.run") as mock_run:
                 mock_run.return_value.returncode = 0
-                mock_run.return_value.stdout = str(project)
+                mock_run.return_value.stdout = f"{project}\n{project / '.git'}\n"
                 
                 resolved = _resolve_workspace_root(str(project))
                 
-                assert resolved == str(project)
+                assert os.path.realpath(resolved) == os.path.realpath(str(project))
+
+    def test_resolve_workspace_root_shared_worktree_prefers_main_repo_with_beads(self):
+        """Test shared worktrees resolve to the main repo when only it owns .beads."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            main_repo = Path(tmpdir) / "main-repo"
+            worktree = Path(tmpdir) / "feature-worktree"
+            main_repo.mkdir()
+            worktree.mkdir()
+            (main_repo / ".beads").mkdir()
+
+            with patch("beads_mcp.tools.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                mock_run.return_value.stdout = f"{worktree}\n{main_repo / '.git'}\n"
+
+                resolved = _resolve_workspace_root(str(worktree))
+
+                assert resolved == os.path.realpath(str(main_repo))
     
     def test_resolve_workspace_root_not_git(self):
         """Test _resolve_workspace_root falls back to abspath if not git repo."""


### PR DESCRIPTION
## Summary
- resolve beads-mcp workspaces with both `git rev-parse --show-toplevel` and `--git-common-dir`
- prefer the main repo root when a linked worktree uses a shared `.beads` directory there
- add regression coverage for shared-worktree workspace resolution

## Testing
- `uv run pytest tests/test_multi_project_switching.py -k 'resolve_workspace_root or canonicalize_path'`\n- `uv run pytest tests/test_subprocess_stdin.py -k 'resolve_workspace_root'`\n- `git diff --check`