### PR TITLE
probe(GH#3260): instrument memory concurrent race for CI

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -70,7 +70,15 @@ func maybeAutoExport(ctx context.Context) {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to get current commit: %v\n", err)
 		return
 	}
+	probe := os.Getenv("BD_PROBE_3260") == "1"
+	if probe {
+		fmt.Fprintf(os.Stderr, "PROBE3260 autoexport pid=%d step=begin currentCommit=%s lastCommit=%s\n",
+			os.Getpid(), currentCommit, state.LastDoltCommit)
+	}
 	if currentCommit == state.LastDoltCommit && state.LastDoltCommit != "" {
+		if probe {
+			fmt.Fprintf(os.Stderr, "PROBE3260 autoexport pid=%d step=skip-nochange\n", os.Getpid())
+		}
 		debug.Logf("auto-export: no changes since last export\n")
 		return
 	}
@@ -91,6 +99,10 @@ func maybeAutoExport(ctx context.Context) {
 
 	debug.Logf("auto-export: wrote %d issues and %d memories to %s\n",
 		issueCount, memoryCount, fullPath)
+	if probe {
+		fmt.Fprintf(os.Stderr, "PROBE3260 autoexport pid=%d step=wrote issues=%d memories=%d\n",
+			os.Getpid(), issueCount, memoryCount)
+	}
 
 	// Don't prime the throttle on an empty export (e.g. immediately after
 	// `bd init`). Saving state here would block the first real `bd create`

--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -88,11 +88,22 @@ Examples:
 			verb = "Updated"
 		}
 
+		probe := os.Getenv("BD_PROBE_3260") == "1"
+		var hashBefore string
+		if probe {
+			hashBefore, _ = store.GetCurrentCommit(ctx)
+		}
 		if err := store.SetConfig(ctx, storageKey, insight); err != nil {
 			FatalErrorRespectJSON("storing memory: %v", err)
 		}
-		if _, err := store.CommitPending(ctx, getActor()); err != nil {
+		committed, err := store.CommitPending(ctx, getActor())
+		if err != nil {
 			WarnError("failed to commit memory: %v", err)
+		}
+		if probe {
+			hashAfter, _ := store.GetCurrentCommit(ctx)
+			fmt.Fprintf(os.Stderr, "PROBE3260 remember=%s pid=%d committed=%v parent=%s hash=%s\n",
+				key, os.Getpid(), committed, hashBefore, hashAfter)
 		}
 
 		if jsonOutput {
@@ -138,6 +149,16 @@ Examples:
 				userKey := strings.TrimPrefix(k, fullPrefix)
 				memories[userKey] = v
 			}
+		}
+		if os.Getenv("BD_PROBE_3260") == "1" {
+			hash, _ := store.GetCurrentCommit(ctx)
+			keys := make([]string, 0, len(memories))
+			for k := range memories {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			fmt.Fprintf(os.Stderr, "PROBE3260 memories pid=%d hash=%s count=%d keys=%v\n",
+				os.Getpid(), hash, len(memories), keys)
 		}
 
 		// Apply search filter if provided
@@ -230,11 +251,30 @@ Examples:
 			os.Exit(1)
 		}
 
+		// PROBE GH#3260
+		probe := os.Getenv("BD_PROBE_3260") == "1"
+		if probe {
+			hashBefore, _ := store.GetCurrentCommit(ctx)
+			fmt.Fprintf(os.Stderr, "PROBE3260 forget=%s pid=%d step=pre-delete hash=%s existing_len=%d\n",
+				key, os.Getpid(), hashBefore, len(existing))
+		}
 		if err := store.DeleteConfig(ctx, storageKey); err != nil {
 			FatalErrorRespectJSON("forgetting memory: %v", err)
 		}
-		if _, err := store.CommitPending(ctx, getActor()); err != nil {
+		if probe {
+			v, _ := store.GetConfig(ctx, storageKey)
+			fmt.Fprintf(os.Stderr, "PROBE3260 forget=%s pid=%d step=post-delete-pre-commit getconfig_len=%d\n",
+				key, os.Getpid(), len(v))
+		}
+		committed, err := store.CommitPending(ctx, getActor())
+		if err != nil {
 			WarnError("failed to commit forget: %v", err)
+		}
+		if probe {
+			hashAfter, _ := store.GetCurrentCommit(ctx)
+			v, _ := store.GetConfig(ctx, storageKey)
+			fmt.Fprintf(os.Stderr, "PROBE3260 forget=%s pid=%d step=post-commit committed=%v hash=%s getconfig_len=%d\n",
+				key, os.Getpid(), committed, hashAfter, len(v))
 		}
 
 		if jsonOutput {

--- a/cmd/bd/memory_embedded_test.go
+++ b/cmd/bd/memory_embedded_test.go
@@ -224,11 +224,11 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 	const numWorkers = 8
 
 	type workerResult struct {
-		worker     int
-		err        error
+		worker      int
+		err         error
 		rememberOut []string
-		forgetOut  string
-		memOut     string
+		forgetOut   string
+		memOut      string
 	}
 
 	results := make([]workerResult, numWorkers)

--- a/cmd/bd/memory_embedded_test.go
+++ b/cmd/bd/memory_embedded_test.go
@@ -216,22 +216,19 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 	bd := buildEmbeddedBD(t)
 	dir, _, _ := bdInit(t, bd, "--prefix", "mx")
 
-	// Disable auto-export: this test exercises concurrent memory
-	// flock contention, not export behavior. With export.auto=true
-	// (the default since GH#2973), 8 concurrent writers also trigger
-	// post-write read paths that race with in-flight commits.
-	disableAutoExport := exec.Command(bd, "config", "set", "export.auto", "false")
-	disableAutoExport.Dir = dir
-	disableAutoExport.Env = bdEnv(dir)
-	if out, err := disableAutoExport.CombinedOutput(); err != nil {
-		t.Fatalf("disable export.auto: %v\n%s", err, out)
-	}
+	// PROBE GH#3260: keep auto-export enabled (default) so the race
+	// against post-write read paths is exercised in CI. Targeted debug
+	// output is gated by BD_PROBE_3260=1 in each worker's env and
+	// captured into workerResult for dumping on failure.
 
 	const numWorkers = 8
 
 	type workerResult struct {
-		worker int
-		err    error
+		worker     int
+		err        error
+		rememberOut []string
+		forgetOut  string
+		memOut     string
 	}
 
 	results := make([]workerResult, numWorkers)
@@ -243,6 +240,8 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 			defer wg.Done()
 			r := workerResult{worker: worker}
 
+			probeEnv := append(bdEnv(dir), "BD_PROBE_3260=1")
+
 			// Each worker stores memories with unique keys
 			for i := 0; i < 3; i++ {
 				key := fmt.Sprintf("w%d-mem%d", worker, i)
@@ -250,8 +249,9 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 
 				cmd := exec.Command(bd, "remember", content, "--key", key)
 				cmd.Dir = dir
-				cmd.Env = bdEnv(dir)
+				cmd.Env = probeEnv
 				out, err := cmd.CombinedOutput()
+				r.rememberOut = append(r.rememberOut, string(out))
 				if err != nil {
 					r.err = fmt.Errorf("remember %s: %v\n%s", key, err, out)
 					results[worker] = r
@@ -266,7 +266,7 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 
 				cmd := exec.Command(bd, "recall", key)
 				cmd.Dir = dir
-				cmd.Env = bdEnv(dir)
+				cmd.Env = probeEnv
 				out, err := cmd.CombinedOutput()
 				if err != nil {
 					r.err = fmt.Errorf("recall %s: %v\n%s", key, err, out)
@@ -284,8 +284,9 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 			forgetKey := fmt.Sprintf("w%d-mem0", worker)
 			cmd := exec.Command(bd, "forget", forgetKey)
 			cmd.Dir = dir
-			cmd.Env = bdEnv(dir)
+			cmd.Env = probeEnv
 			out, err := cmd.CombinedOutput()
+			r.forgetOut = string(out)
 			if err != nil {
 				r.err = fmt.Errorf("forget %s: %v\n%s", forgetKey, err, out)
 				results[worker] = r
@@ -295,8 +296,9 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 			// List memories
 			cmd = exec.Command(bd, "memories")
 			cmd.Dir = dir
-			cmd.Env = bdEnv(dir)
+			cmd.Env = probeEnv
 			out, err = cmd.CombinedOutput()
+			r.memOut = string(out)
 			if err != nil {
 				r.err = fmt.Errorf("memories: %v\n%s", err, out)
 				results[worker] = r
@@ -316,7 +318,14 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 
 	// Verify memories only for workers that succeeded (err==nil).
 	// With exclusive flock, some workers may fail with "one writer at a time".
-	out := bdMemories(t, bd, dir)
+	finalCmd := exec.Command(bd, "memories")
+	finalCmd.Dir = dir
+	finalCmd.Env = append(bdEnv(dir), "BD_PROBE_3260=1")
+	finalOut, finalErr := finalCmd.CombinedOutput()
+	if finalErr != nil {
+		t.Fatalf("final bd memories failed: %v\n%s", finalErr, finalOut)
+	}
+	out := string(finalOut)
 	var successCount int
 	for _, r := range results {
 		if r.err != nil {
@@ -326,7 +335,8 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 		w := r.worker
 		forgottenKey := fmt.Sprintf("w%d-mem0", w)
 		if strings.Contains(out, forgottenKey) {
-			t.Errorf("expected %s to be forgotten", forgottenKey)
+			t.Errorf("expected %s to be forgotten\n--- worker %d remembers ---\n%s\n--- forget ---\n%s\n--- worker own memories ---\n%s\n--- final memories ---\n%s",
+				forgottenKey, w, strings.Join(r.rememberOut, "---\n"), r.forgetOut, r.memOut, out)
 		}
 		for i := 1; i < 3; i++ {
 			key := fmt.Sprintf("w%d-mem%d", w, i)


### PR DESCRIPTION
## Purpose

Not for merge. CI-only probe branch to diagnose GH#3260.

Locally reproduced the race on laptop with these probes in place: workers' \`bd forget\` returns success and reports a post-commit HEAD hash (e.g. \`p4uegn7m...\`), but the follow-up \`bd memories\` reads a different HEAD (\`bff00uvf...\`) that still contains the supposedly-forgotten key. Some subsequent writer committed a HEAD that is not descended from the forget commit - lost HEAD update.

## What this does

- Reverts the \`export.auto=false\` workaround in TestEmbeddedMemoryConcurrent (commit 5f833e84e) so the race is exercised.
- Adds \`BD_PROBE_3260=1\`-gated stderr logging in:
  - \`bd remember\` and \`bd forget\` (pre/post hash, existing length, committed)
  - \`maybeAutoExport\` (current vs last commit, wrote counts)
  - \`bd memories\` (hash + sorted key list)
- Captures each worker's subprocess stderr in the test and dumps on failure.

## Expected CI output on failure

Probe lines prefixed with \`PROBE3260\` will be interleaved with the t.Errorf output. The key line to examine is whether the final \`bd memories\` HEAD hash differs from the worker's \`forget post-commit\` hash, and whether the final HEAD is a descendant of the forget commit.

## Next step

Use CI evidence to confirm hypothesis: Dolt's engine shutdown via \`BackgroundThreads.Shutdown\` (see \`internal/storage/embeddeddolt/open.go:64\`, which filters \`context.Canceled\`) may return before the branch HEAD update is fully fsynced. The next subprocess then reads a stale HEAD.

Once confirmed, revert this branch and land a real fix (either wait for persistence on shutdown, or hold one long-lived engine for the store's lifetime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)