### PR TITLE
feat: add global beads_global database for shared-server mode

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -501,7 +501,25 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	// bootstrap action (init, restore, jsonl-import) writes these files via
 	// newDoltStore + createConfigYaml; the sync path historically did not.
 	// (GH#3201)
-	return finalizeSyncedBootstrap(plan.BeadsDir, plan.SyncRemote, cfg, dbName)
+	if err := finalizeSyncedBootstrap(plan.BeadsDir, plan.SyncRemote, cfg, dbName); err != nil {
+		return err
+	}
+
+	// Open and close the store to ensure dolt_ignore'd wisp tables are
+	// created in the working set. Clone does not include these tables
+	// (they are never committed), so they must be recreated after clone.
+	// Both embedded and server mode handle this in their store init paths.
+	warmupStore, err := newDoltStoreFromConfig(ctx, plan.BeadsDir)
+	if err != nil {
+		// Non-fatal: wisp tables will be created on the next command that
+		// opens the store. Warn so the user knows to retry if they hit
+		// "table not found: wisp_*" errors.
+		fmt.Fprintf(os.Stderr, "Warning: post-clone store init failed (wisp tables may be missing): %v\n", err)
+		return nil
+	}
+	_ = warmupStore.Close()
+
+	return nil
 }
 
 // finalizeSyncedBootstrap writes metadata.json and config.yaml after a

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -78,7 +78,11 @@ func maybeAutoExport(ctx context.Context) {
 	// Determine output path
 	exportPath := config.GetString("export.path")
 	if exportPath == "" {
-		exportPath = "issues.jsonl"
+		if globalFlag {
+			exportPath = "global-issues.jsonl"
+		} else {
+			exportPath = "issues.jsonl"
+		}
 	}
 	fullPath := filepath.Join(beadsDir, exportPath)
 

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -50,12 +50,16 @@ func runImport(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		jsonlPath = args[0]
 	} else {
-		// Default: .beads/issues.jsonl
+		// Default: .beads/issues.jsonl (or .beads/global-issues.jsonl with --global)
 		beadsDir := beads.FindBeadsDir()
 		if beadsDir == "" {
 			return fmt.Errorf("%s — %s", activeWorkspaceNotFoundError(), diagHint())
 		}
-		jsonlPath = filepath.Join(beadsDir, "issues.jsonl")
+		if globalFlag {
+			jsonlPath = filepath.Join(beadsDir, "global-issues.jsonl")
+		} else {
+			jsonlPath = filepath.Join(beadsDir, "issues.jsonl")
+		}
 	}
 
 	// Check file exists

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -587,12 +587,40 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					}
 				}
 			}
+
+			// Ensure the global beads_global database exists on the shared server.
+			// This is idempotent — safe to run on every init.
+			globalHost := configfile.DefaultDoltServerHost
+			if serverHost != "" {
+				globalHost = serverHost
+			}
+			globalPort := initPort
+			if globalPort == 0 {
+				globalPort = doltserver.DefaultSharedServerPort
+			}
+			globalUser := configfile.DefaultDoltServerUser
+			if serverUser != "" {
+				globalUser = serverUser
+			}
+			if err := doltserver.EnsureGlobalDatabase(globalHost, globalPort, globalUser, ""); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to create global database: %v\n", err)
+				// Non-fatal — project init should succeed even if global DB creation fails
+			} else if !quiet {
+				fmt.Printf("  %s Global database %s available\n", ui.RenderPass("✓"), doltserver.GlobalDatabaseName)
+			}
 		}
 
 		store, err := newDoltStore(ctx, doltCfg, embeddeddolt.WithLock(initLock))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to open Dolt store: %v\n", err)
 			os.Exit(1)
+		}
+
+		// Initialize global database schema and config in shared-server mode.
+		// Opens a separate store connection to beads_global with CreateIfMissing
+		// to trigger schema migration, then seeds the issue prefix and project ID.
+		if sharedServer || doltserver.IsSharedServerMode() {
+			initGlobalDatabaseConfig(ctx, doltCfg, quiet)
 		}
 
 		// Configure the remote in the Dolt store so bd dolt push/pull
@@ -721,6 +749,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					// records a different name, causing reopens to fail.
 					cfg.DoltDatabase = strings.ReplaceAll(prefix, "-", "_")
 					cfg.DoltDatabase = strings.ReplaceAll(cfg.DoltDatabase, ".", "_")
+				}
+
+				// Set global database name for shared-server mode projects.
+				// This gives each project the connection info to reach beads_global.
+				if sharedServer || doltserver.IsSharedServerMode() {
+					cfg.GlobalDoltDatabase = doltserver.GlobalDatabaseName
 				}
 
 				// Persist the connection mode matching this build.
@@ -1676,4 +1710,50 @@ func verifyMetadata(ctx context.Context, store storage.DoltStorage, key, value s
 		return false
 	}
 	return true
+}
+
+// initGlobalDatabaseConfig opens a store connection to the beads_global database
+// and seeds its configuration (issue prefix, project ID). The database must already
+// exist (created by EnsureGlobalDatabase). This function is idempotent — it only
+// sets config values that are not already present.
+func initGlobalDatabaseConfig(ctx context.Context, projectCfg *dolt.Config, quiet bool) {
+	globalCfg := &dolt.Config{
+		Path:            projectCfg.Path,
+		BeadsDir:        projectCfg.BeadsDir,
+		Database:        doltserver.GlobalDatabaseName,
+		ServerHost:      projectCfg.ServerHost,
+		ServerPort:      projectCfg.ServerPort,
+		ServerUser:      projectCfg.ServerUser,
+		ServerPassword:  projectCfg.ServerPassword,
+		ServerMode:      true,
+		CreateIfMissing: true,
+		AutoStart:       false, // server is already running
+	}
+
+	globalStore, err := newDoltStore(ctx, globalCfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to open global database: %v\n", err)
+		return
+	}
+	defer func() { _ = globalStore.Close() }()
+
+	// Set issue prefix (only if not already configured)
+	existing, _ := globalStore.GetConfig(ctx, "issue_prefix")
+	if existing == "" {
+		if err := globalStore.SetConfig(ctx, "issue_prefix", doltserver.GlobalIssuePrefix); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to set global issue prefix: %v\n", err)
+		}
+	}
+
+	// Set well-known project ID for the global database
+	existingID, _ := globalStore.GetMetadata(ctx, "_project_id")
+	if existingID == "" {
+		if err := globalStore.SetMetadata(ctx, "_project_id", doltserver.GlobalProjectID); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to set global project ID: %v\n", err)
+		}
+	}
+
+	if !quiet {
+		fmt.Printf("  %s Global database schema initialized\n", ui.RenderPass("✓"))
+	}
 }

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -58,6 +58,7 @@ var (
 )
 var (
 	sandboxMode     bool
+	globalFlag      bool               // Use the global shared-server database (beads_global)
 	serverMode      bool               // True when using external dolt sql-server (dolt_mode=server)
 	readonlyMode    bool               // Read-only mode: block write operations (for worker sandboxes)
 	storeIsReadOnly bool               // Track if store was opened read-only (for staleness checks)
@@ -398,6 +399,7 @@ func init() {
 	_ = rootCmd.PersistentFlags().MarkHidden("format") // Hidden alias for CLI ergonomics
 	rootCmd.PersistentFlags().BoolVar(&sandboxMode, "sandbox", false, "Sandbox mode: disables auto-sync")
 	rootCmd.PersistentFlags().BoolVar(&readonlyMode, "readonly", false, "Read-only mode: block write operations (for worker sandboxes)")
+	rootCmd.PersistentFlags().BoolVar(&globalFlag, "global", false, "Use the global shared-server database (beads_global)")
 	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: off. Override via config key dolt.auto-commit")
 	rootCmd.PersistentFlags().BoolVar(&profileEnabled, "profile", false, "Generate CPU profile for performance analysis")
 	rootCmd.PersistentFlags().BoolVarP(&verboseFlag, "verbose", "v", false, "Enable verbose/debug output")
@@ -766,6 +768,15 @@ var rootCmd = &cobra.Command{
 		}
 		doltCfg.SyncRemote = resolveSyncRemote()
 
+		// --global flag: switch to the global shared-server database.
+		// Must be in shared-server mode; errors otherwise.
+		if globalFlag {
+			if !doltserver.IsSharedServerMode() {
+				FatalError("--global requires shared-server mode (set BEADS_DOLT_SHARED_SERVER=1 or dolt.shared-server: true in config.yaml)")
+			}
+			doltCfg.Database = doltserver.GlobalDatabaseName
+		}
+
 		// Keep standalone CLI auto-start behavior centralized so doctor and
 		// other helper paths stay in lockstep with the main command path.
 		dolt.ApplyCLIAutoStart(beadsDir, doltCfg)
@@ -809,13 +820,15 @@ var rootCmd = &cobra.Command{
 		// Skip auto-import when the user is explicitly running "bd import" —
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
-		if store != nil && !useReadOnly && cmd.Name() != "import" {
+		if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" {
 			maybeAutoImportJSONL(rootCtx, store, beadsDir)
 		}
 
 		// Validate workspace identity for write commands (GH#2438, GH#2372)
-		// Skip for read-only commands since they can't corrupt data
-		if !useReadOnly && os.Getenv("BEADS_SKIP_IDENTITY_CHECK") != "1" {
+		// Skip for read-only commands since they can't corrupt data.
+		// Skip for --global: the global database uses a sentinel project ID
+		// that won't match any project's metadata.json.
+		if !useReadOnly && !globalFlag && os.Getenv("BEADS_SKIP_IDENTITY_CHECK") != "1" {
 			validateWorkspaceIdentity(rootCtx, beadsDir)
 		}
 

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -38,6 +38,11 @@ type Config struct {
 	// to the wrong Dolt server (GH#2372).
 	ProjectID string `json:"project_id,omitempty"`
 
+	// GlobalDoltDatabase is the SQL database name for the project-agnostic
+	// global issue database in shared-server mode. Set during bd init when
+	// shared-server mode is active. Empty means no global database available.
+	GlobalDoltDatabase string `json:"global_dolt_database,omitempty"`
+
 	// Stale closed issues check configuration
 	// 0 = disabled (default), positive = threshold in days
 	StaleClosedIssuesDays int `json:"stale_closed_issues_days,omitempty"`
@@ -315,6 +320,12 @@ func (c *Config) GetDoltDatabase() string {
 		return c.DoltDatabase
 	}
 	return DefaultDoltDatabase
+}
+
+// GetGlobalDoltDatabase returns the global database name for shared-server mode.
+// Returns empty string if no global database is configured.
+func (c *Config) GetGlobalDoltDatabase() string {
+	return c.GlobalDoltDatabase
 }
 
 // GetDoltServerPassword returns the Dolt server password.

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -3,6 +3,7 @@ package configfile
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -575,5 +576,60 @@ func TestIsDoltServerMode_NoEnvRespectsMetadata(t *testing.T) {
 	cfg := &Config{Backend: BackendDolt, DoltMode: DoltModeEmbedded}
 	if cfg.IsDoltServerMode() {
 		t.Error("IsDoltServerMode() = true with no env overrides + embedded metadata, want false")
+	}
+}
+
+func TestGlobalDoltDatabase_RoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.GlobalDoltDatabase = "beads_global"
+
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	loaded, err := Load(beadsDir)
+	if err != nil {
+		t.Fatalf("Load() failed: %v", err)
+	}
+	if loaded.GlobalDoltDatabase != "beads_global" {
+		t.Errorf("GlobalDoltDatabase = %q, want %q", loaded.GlobalDoltDatabase, "beads_global")
+	}
+	if loaded.GetGlobalDoltDatabase() != "beads_global" {
+		t.Errorf("GetGlobalDoltDatabase() = %q, want %q", loaded.GetGlobalDoltDatabase(), "beads_global")
+	}
+}
+
+func TestGlobalDoltDatabase_EmptyByDefault(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.GetGlobalDoltDatabase() != "" {
+		t.Errorf("GetGlobalDoltDatabase() = %q, want empty string for default config", cfg.GetGlobalDoltDatabase())
+	}
+}
+
+func TestGlobalDoltDatabase_OmittedFromJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("Save() failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(beadsDir, ConfigFileName))
+	if err != nil {
+		t.Fatalf("ReadFile() failed: %v", err)
+	}
+
+	if strings.Contains(string(data), "global_dolt_database") {
+		t.Error("global_dolt_database should be omitted from JSON when empty")
 	}
 }

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -88,6 +88,18 @@ const maxEphemeralPortAttempts = 10
 // Uses 3308 to avoid conflict with the orchestrator which uses 3307.
 const DefaultSharedServerPort = 3308
 
+// GlobalDatabaseName is the SQL database name for the project-agnostic
+// global issue database in shared-server mode.
+const GlobalDatabaseName = "beads_global"
+
+// GlobalIssuePrefix is the issue prefix used in the global database.
+const GlobalIssuePrefix = "global"
+
+// GlobalProjectID is the well-known sentinel UUID for the global database.
+// Used for project identity verification — the global DB doesn't belong to
+// any single project, so it uses this fixed value instead of a random UUID.
+const GlobalProjectID = "00000000-0000-0000-0000-000000000000"
+
 // IsSharedServerMode returns true if shared server mode is enabled.
 // Checks (in priority order):
 //  1. BEADS_DOLT_SHARED_SERVER env var ("1" or "true")
@@ -829,6 +841,48 @@ func Start(beadsDir string) (*State, error) {
 		Port:    actualPort,
 		DataDir: doltDir,
 	}, nil
+}
+
+// EnsureGlobalDatabase connects to the shared Dolt server and creates the
+// beads_global database if it doesn't already exist. This is idempotent and
+// safe to call on every shared server init. Schema initialization and config
+// seeding (issue prefix, project ID) are handled by the store layer when the
+// global database is first opened with CreateIfMissing=true.
+//
+// Returns nil if the database already exists or was successfully created.
+func EnsureGlobalDatabase(host string, port int, user, password string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dsn := doltutil.ServerDSN{
+		Host:     host,
+		Port:     port,
+		User:     user,
+		Password: password,
+	}.String()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return fmt.Errorf("ensure global db: failed to open connection: %w", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetConnMaxLifetime(10 * time.Second)
+
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("ensure global db: server not reachable: %w", err)
+	}
+
+	// CREATE DATABASE IF NOT EXISTS is idempotent — safe on every call.
+	// GlobalDatabaseName is a constant ("beads_global"), not user input.
+	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", GlobalDatabaseName)) //nolint:gosec // G201: constant database name
+	if err != nil {
+		errLower := strings.ToLower(err.Error())
+		if !strings.Contains(errLower, "database exists") && !strings.Contains(errLower, "1007") {
+			return fmt.Errorf("ensure global db: failed to create %s: %w", GlobalDatabaseName, err)
+		}
+	}
+
+	return nil
 }
 
 // FlushWorkingSet connects to the running Dolt server and commits any uncommitted

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1774,3 +1774,32 @@ func firstOrEmpty(s []string) string {
 	}
 	return s[0]
 }
+
+func TestGlobalDatabaseConstants(t *testing.T) {
+	if GlobalDatabaseName == "" {
+		t.Error("GlobalDatabaseName must not be empty")
+	}
+	if GlobalDatabaseName != "beads_global" {
+		t.Errorf("GlobalDatabaseName = %q, want %q", GlobalDatabaseName, "beads_global")
+	}
+	if GlobalIssuePrefix == "" {
+		t.Error("GlobalIssuePrefix must not be empty")
+	}
+	if GlobalIssuePrefix != "global" {
+		t.Errorf("GlobalIssuePrefix = %q, want %q", GlobalIssuePrefix, "global")
+	}
+	if GlobalProjectID == "" {
+		t.Error("GlobalProjectID must not be empty")
+	}
+	if GlobalProjectID != "00000000-0000-0000-0000-000000000000" {
+		t.Errorf("GlobalProjectID = %q, want sentinel UUID", GlobalProjectID)
+	}
+}
+
+func TestEnsureGlobalDatabase_ServerNotReachable(t *testing.T) {
+	// EnsureGlobalDatabase should return an error when the server is not reachable.
+	err := EnsureGlobalDatabase("127.0.0.1", 19999, "root", "")
+	if err == nil {
+		t.Error("expected error when server is not reachable")
+	}
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -128,6 +128,17 @@ func New(ctx context.Context, beadsDir, database, branch string, opts ...Option)
 		return nil, fmt.Errorf("embeddeddolt: init schema: %w", err)
 	}
 
+	// Ensure dolt_ignore'd wisp tables exist in the working set.
+	// After a clone or branch switch, these tables are absent because
+	// dolt_ignore prevents them from being committed. Server mode handles
+	// this in newServerMode(); embedded mode must do it here. (GH#3270)
+	if err := s.ensureIgnoredTables(ctx); err != nil {
+		if ownsLock {
+			lock.Unlock()
+		}
+		return nil, fmt.Errorf("embeddeddolt: ensure ignored tables: %w", err)
+	}
+
 	return s, nil
 }
 
@@ -257,6 +268,14 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 			}
 		}
 		return nil
+	})
+}
+
+// ensureIgnoredTables creates dolt_ignore'd wisp tables if they don't exist.
+// Uses withConn (not withRootConn) because the database is already created.
+func (s *EmbeddedDoltStore) ensureIgnoredTables(ctx context.Context) error {
+	return s.withConn(ctx, false, func(tx *sql.Tx) error {
+		return schema.EnsureIgnoredTables(ctx, tx)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds a project-agnostic `beads_global` database to shared-server mode, created automatically during `bd init --shared-server`
- New `--global` persistent flag on all CLI commands switches the target store from the project database to `beads_global`
- Each project's `metadata.json` gets a `global_dolt_database` field with connection info for the global DB
- Export/import default to `global-issues.jsonl` when `--global` is set
- `--global` errors cleanly when not in shared-server mode — fully additive, no breakage for existing users
- Fixes missing wisp tables after `bd bootstrap` clone (embedded mode never called `EnsureIgnoredTables` on store open)

## Key changes

| File | What |
|------|------|
| `internal/doltserver/doltserver.go` | Constants (`GlobalDatabaseName`, `GlobalIssuePrefix`, `GlobalProjectID`) + `EnsureGlobalDatabase()` |
| `internal/configfile/configfile.go` | `GlobalDoltDatabase` field + `GetGlobalDoltDatabase()` accessor |
| `cmd/bd/init.go` | Create global DB during shared server bootstrap, seed config, write to metadata.json |
| `cmd/bd/main.go` | `--global` persistent flag, store switching in PersistentPreRun, skip identity validation |
| `cmd/bd/export_auto.go` | Default to `global-issues.jsonl` with `--global` |
| `cmd/bd/import.go` | Default to `global-issues.jsonl` with `--global` |
| `internal/storage/embeddeddolt/store.go` | Add `EnsureIgnoredTables` call after `initSchema()` — fixes missing wisp tables after clone |
| `cmd/bd/bootstrap.go` | Post-clone store warmup to create wisp tables immediately after sync |

## Backfill fix: wisp tables missing after bootstrap clone

After `bd bootstrap` clones from a remote, `dolt_ignore`'d wisp tables (`wisps`, `wisp_dependencies`, `wisp_labels`, `wisp_events`, `wisp_comments`) were absent because they are never committed. This caused `table not found: wisp_dependencies` errors on commands like `bd delete`.

**Root cause**: Server mode called `EnsureIgnoredTables` on store open, but embedded mode did not.

| Mode | Store open called `EnsureIgnoredTables`? | After fix? |
|------|----------------------------------------|------------|
| Server | Yes (store.go:1097) | Yes |
| Embedded | **No** (gap) | **Yes** (new) |
| Shared server | Yes (same as server) | Yes |

**Two fixes**:
1. Add `EnsureIgnoredTables` to `embeddeddolt.New()` after `initSchema()` — matches server mode
2. Add post-clone store warmup in `executeSyncAction()` as belt-and-suspenders

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Unit tests: configfile round-trip, omitempty, constants, unreachable server error
- [x] All existing `configfile`, `doltserver`, and `embeddeddolt` tests pass
- [ ] Manual: `bd init --shared-server` creates `beads_global` on the shared server
- [ ] Manual: `bd create --global "Test issue"` creates issue in global DB
- [ ] Manual: `bd list --global` shows only global issues
- [ ] Manual: `bd export --global` writes to `global-issues.jsonl`
- [ ] Manual: `bd --global` without shared-server mode shows clear error
- [ ] Manual: `bd bootstrap` from remote → `bd delete` works without wisp table error

🤖 Generated with [Claude Code](https://claude.com/claude-code)