### PR TITLE
fix(export): add _type discriminator to JSONL issue lines

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -163,11 +163,14 @@ func runExport(cmd *cobra.Command, args []string) error {
 		// MarshalJSON to fail with "year outside of range [0,9999]". (GH#2488)
 		sanitizeZeroTime(issue)
 
-		record := &types.IssueWithCounts{
-			Issue:           issue,
-			DependencyCount: counts.DependencyCount,
-			DependentCount:  counts.DependentCount,
-			CommentCount:    commentCounts[issue.ID],
+		record := &exportIssueRecord{
+			RecordType: "issue",
+			IssueWithCounts: &types.IssueWithCounts{
+				Issue:           issue,
+				DependencyCount: counts.DependencyCount,
+				DependentCount:  counts.DependentCount,
+				CommentCount:    commentCounts[issue.ID],
+			},
 		}
 
 		data, err := json.Marshal(record)
@@ -232,6 +235,14 @@ func runExport(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// exportIssueRecord wraps IssueWithCounts with a _type discriminator so that
+// every line in the JSONL export is self-describing. Memory lines already
+// carry "_type":"memory"; this gives issue lines "_type":"issue". (GH#3271)
+type exportIssueRecord struct {
+	RecordType string `json:"_type"`
+	*types.IssueWithCounts
 }
 
 // sanitizeZeroTime replaces Go zero-value time.Time fields with Unix epoch.

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -194,11 +194,14 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 				counts = &types.DependencyCounts{}
 			}
 			sanitizeZeroTime(issue)
-			record := &types.IssueWithCounts{
-				Issue:           issue,
-				DependencyCount: counts.DependencyCount,
-				DependentCount:  counts.DependentCount,
-				CommentCount:    commentCounts[issue.ID],
+			record := &exportIssueRecord{
+				RecordType: "issue",
+				IssueWithCounts: &types.IssueWithCounts{
+					Issue:           issue,
+					DependencyCount: counts.DependencyCount,
+					DependentCount:  counts.DependentCount,
+					CommentCount:    commentCounts[issue.ID],
+				},
 			}
 			if err := enc.Encode(record); err != nil {
 				return 0, 0, fmt.Errorf("failed to write issue %s: %w", issue.ID, err)

--- a/cmd/bd/export_embedded_test.go
+++ b/cmd/bd/export_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,6 +49,38 @@ func TestEmbeddedExport(t *testing.T) {
 		for _, line := range lines {
 			if !strings.Contains(line, `"id"`) {
 				t.Errorf("expected JSON with 'id' field, got: %s", line)
+			}
+		}
+	})
+
+	t.Run("type_discriminator", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "extyp")
+		bdCreateSilent(t, bd, dir, "type discriminator test")
+
+		out := bdExport(t, bd, dir)
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		for _, line := range lines {
+			var record map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &record); err != nil {
+				t.Fatalf("invalid JSON line: %v\n%s", err, line)
+			}
+			typ, ok := record["_type"].(string)
+			if !ok {
+				t.Errorf("line missing _type field: %s", line)
+				continue
+			}
+			if typ != "issue" && typ != "memory" {
+				t.Errorf("unexpected _type=%q (want issue or memory): %s", typ, line)
+			}
+			// Issue lines must have "id"; memory lines must have "key"
+			if typ == "issue" {
+				if _, ok := record["id"]; !ok {
+					t.Errorf("issue line missing id field: %s", line)
+				}
+			} else if typ == "memory" {
+				if _, ok := record["key"]; !ok {
+					t.Errorf("memory line missing key field: %s", line)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
## Problem

`bd export` produces JSONL with two different schemas in the same file. Memory lines carry `"_type":"memory"` but issue lines have no `_type` field. Any downstream consumer that assumes a uniform schema crashes on the mixed output:

```python
for line in open("export.jsonl"):
    issue = json.loads(line)
    print(issue["status"])  # KeyError on memory lines
```

The `--no-memories` flag exists as a workaround, but memories are included by default and issue lines still lack a type discriminator even when used alone.

Discovered by an agent during a `bd export` + Python analysis workflow that hit `KeyError: "status"` on the memory entries.

## Root Cause

In `cmd/bd/export.go` (line ~166) and `cmd/bd/export_auto.go` (line ~193), issue records are marshaled directly from `types.IssueWithCounts` which has no `_type` field. Memory records at lines ~199/~216 use a `map[string]string` with `"_type":"memory"`, creating an asymmetry in the export format.

## Fix

Add an `exportIssueRecord` wrapper struct that embeds `*types.IssueWithCounts` and adds `"_type":"issue"` as the first JSON field:

```go
type exportIssueRecord struct {
    RecordType string `json:"_type"`
    *types.IssueWithCounts
}
```

Both export paths updated:
- `runExport()` in `export.go` (manual `bd export`)
- `exportToFile()` in `export_auto.go` (auto-export on commit)

The wrapper is local to the export package - `types.IssueWithCounts` and `types.Issue` are unchanged, so no other commands or serialization paths are affected.

## Test Plan

- [x] `go build` compiles clean
- [x] `bd export --no-memories | head -1` shows `"_type":"issue"` as first field
- [x] `bd export | tail -3` shows memory lines still have `"_type":"memory"`
- [x] Import side (`import_shared.go`) already handles `_type` correctly: peeks at the field, routes `"memory"` to memory import, falls through to issue unmarshal for everything else. The new `"_type":"issue"` field is silently ignored by `json.Unmarshal` into `types.Issue` since no struct tag matches.
- [ ] Unit tests skip without Dolt test server - existing `TestExportToFile`, `TestExportImportRoundTrip` would cover this

## Context

Closes #3271

This is an additive, non-breaking change. Existing consumers that don't check `_type` are unaffected. New consumers can now reliably filter by record type:

```python
record = json.loads(line)
if record["_type"] == "issue": ...
elif record["_type"] == "memory": ...
```