### PR TITLE
fix(ci): memoize bd test binary to avoid macOS 10m timeout

### DIFF
--- a/cmd/bd/explicit_db_nodb_test.go
+++ b/cmd/bd/explicit_db_nodb_test.go
@@ -10,24 +10,56 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
 )
 
+// buildBDUnderTest builds the bd binary once per test process and returns the path.
+// Previously each caller built a fresh binary in t.TempDir(), which on slow runners
+// (macOS arm64) took 30-240s each and blew the 10m package timeout when many
+// buildBDUnderTest-using tests ran together.
+var (
+	buildBDOnce sync.Once
+	buildBDPath string
+	buildBDErr  error
+	buildBDDir  string
+)
+
 func buildBDUnderTest(t *testing.T) string {
 	t.Helper()
+	buildBDOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "bd-testbin-*")
+		if err != nil {
+			buildBDErr = err
+			return
+		}
+		buildBDDir = dir
+		binName := "bd"
+		if runtime.GOOS == "windows" {
+			binName = "bd.exe"
+		}
+		buildBDPath = filepath.Join(dir, binName)
+		buildCmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", buildBDPath, ".")
+		if out, err := buildCmd.CombinedOutput(); err != nil {
+			buildBDErr = &buildBDError{err: err, output: out}
+			return
+		}
+	})
+	if buildBDErr != nil {
+		t.Fatalf("go build failed: %v", buildBDErr)
+	}
+	return buildBDPath
+}
 
-	binName := "bd"
-	if runtime.GOOS == "windows" {
-		binName = "bd.exe"
-	}
-	binPath := filepath.Join(t.TempDir(), binName)
-	buildCmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", binPath, ".")
-	if out, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("go build failed: %v\n%s", err, out)
-	}
-	return binPath
+type buildBDError struct {
+	err    error
+	output []byte
+}
+
+func (e *buildBDError) Error() string {
+	return e.err.Error() + "\n" + string(e.output)
 }
 
 func initGitRepo(t *testing.T, dir string) {


### PR DESCRIPTION
## Problem

`Test (macos-latest)` on `upstream/main` is failing with a 10-minute package timeout in `cmd/bd`:

```
panic: test timed out after 10m0s
	running tests:
		TestDoltShowUsesSelectedRepoConfigForNoDBCommand (19s)
```

[Failing run (#3206 merge)](https://github.com/gastownhall/beads/actions/runs/24410542592/job/71305797026)

## Root Cause

`buildBDUnderTest` in `cmd/bd/explicit_db_nodb_test.go` rebuilds the `bd` binary for each of its 12 callers. On macOS arm64 runners (slower than ubuntu) with `-race`:

- First (cold) build: `TestContextUsesExplicitDBFlagForNoDBCommand` took **238.65s**
- Subsequent builds: 37-67s each

By the 10th caller the job had already consumed ~620s; `TestDoltShowUsesSelectedRepoConfigForNoDBCommand` was merely the one holding the baton when the 10m alarm fired. ubuntu-latest passes because its cold build is fast enough that 12 rebuilds still fit.

## Fix

Memoize the build via `sync.Once` so the binary is compiled exactly once per test process and reused by all callers.

Local verification (`-tags gms_pure_go`):

| Run | Before (estimate) | After |
|---|---|---|
| 1st test | ~90s | 93.01s |
| 2nd test | ~90s | 3.35s |
| 3rd test | ~90s | 3.41s |

For the full set of 12 callers this drops cumulative build time from ~11min to ~1.5min, well inside the 10m window.

## Notes

- Preserves the `-tags gms_pure_go` build tag introduced in #3259.
- Binary is written to a package-level `os.MkdirTemp` dir; the ephemeral CI runners clean this up, and locally it's a one-off ~20MB leak per `go test` invocation.
- `sync.Once` captures a shared error so a failed build surfaces in every caller (verified locally).