### PR TITLE
fix(init): run embedded post-init diagnostics

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
 
@@ -845,6 +847,15 @@ func runInitDiagnostics(path string) doctorResult {
 		OverallOK:  true,
 	}
 
+	var embeddedReadOnlyStore storeHolder
+	if isEmbeddedMode() {
+		store, err := newReadOnlyStoreFromConfig(context.Background(), doctor.ResolveBeadsDirForRepo(path))
+		if err == nil {
+			embeddedReadOnlyStore = store
+			defer embeddedReadOnlyStore.Close()
+		}
+	}
+
 	// Check 1: Installation (.beads/ directory)
 	installCheck := convertWithCategory(doctor.CheckInstallation(path), doctor.CategoryCore)
 	result.Checks = append(result.Checks, installCheck)
@@ -862,6 +873,9 @@ func runInitDiagnostics(path string) doctorResult {
 
 	// Check 2: Database version
 	dbCheck := convertWithCategory(doctor.CheckDatabaseVersion(path, Version), doctor.CategoryCore)
+	if embeddedReadOnlyStore != nil {
+		dbCheck = initEmbeddedDatabaseVersionCheck(embeddedReadOnlyStore)
+	}
 	result.Checks = append(result.Checks, dbCheck)
 	if dbCheck.Status == statusError {
 		result.OverallOK = false
@@ -869,6 +883,9 @@ func runInitDiagnostics(path string) doctorResult {
 
 	// Check 3: Schema compatibility
 	schemaCheck := convertWithCategory(doctor.CheckSchemaCompatibility(path), doctor.CategoryCore)
+	if embeddedReadOnlyStore != nil {
+		schemaCheck = initEmbeddedSchemaCompatibilityCheck(embeddedReadOnlyStore)
+	}
 	result.Checks = append(result.Checks, schemaCheck)
 	if schemaCheck.Status == statusError {
 		result.OverallOK = false
@@ -883,6 +900,9 @@ func runInitDiagnostics(path string) doctorResult {
 
 	// Check 5: Dolt connection — validates init actually created a working DB
 	doltConnCheck := convertDoctorCheck(doctor.CheckDoltConnection(path))
+	if embeddedReadOnlyStore != nil {
+		doltConnCheck = initEmbeddedConnectionCheck(embeddedReadOnlyStore)
+	}
 	result.Checks = append(result.Checks, doltConnCheck)
 	if doltConnCheck.Status == statusError {
 		result.OverallOK = false
@@ -890,12 +910,127 @@ func runInitDiagnostics(path string) doctorResult {
 
 	// Check 6: Dolt schema — validates tables were created
 	doltSchemaCheck := convertDoctorCheck(doctor.CheckDoltSchema(path))
+	if embeddedReadOnlyStore != nil {
+		doltSchemaCheck = initEmbeddedDoltSchemaCheck(embeddedReadOnlyStore)
+	}
 	result.Checks = append(result.Checks, doltSchemaCheck)
 	if doltSchemaCheck.Status == statusError {
 		result.OverallOK = false
 	}
 
 	return result
+}
+
+type storeHolder interface {
+	Close() error
+	GetStatistics(ctx context.Context) (*types.Statistics, error)
+	GetMetadata(ctx context.Context, key string) (string, error)
+}
+
+func initEmbeddedDatabaseVersionCheck(store storeHolder) doctorCheck {
+	ctx := context.Background()
+	dbVersion, err := store.GetMetadata(ctx, "bd_version")
+	if err != nil {
+		return doctorCheck{
+			Name:     "Database",
+			Status:   statusError,
+			Message:  "Unable to read database version",
+			Detail:   fmt.Sprintf("Storage: Dolt\n\nError: %v", err),
+			Fix:      "Database may be corrupted. Run 'bd doctor --fix' to recover",
+			Category: doctor.CategoryCore,
+		}
+	}
+	if dbVersion == "" {
+		return doctorCheck{
+			Name:     "Database",
+			Status:   statusWarning,
+			Message:  "Database missing version metadata",
+			Detail:   "Storage: Dolt",
+			Fix:      "Run 'bd doctor --fix' to repair metadata",
+			Category: doctor.CategoryCore,
+		}
+	}
+	if dbVersion != Version {
+		return doctorCheck{
+			Name:     "Database",
+			Status:   statusWarning,
+			Message:  fmt.Sprintf("version %s (CLI: %s)", dbVersion, Version),
+			Detail:   "Storage: Dolt",
+			Fix:      "Update bd CLI and re-run (dolt metadata will be updated automatically)",
+			Category: doctor.CategoryCore,
+		}
+	}
+
+	return doctorCheck{
+		Name:     "Database",
+		Status:   statusOK,
+		Message:  fmt.Sprintf("version %s", dbVersion),
+		Detail:   "Storage: Dolt",
+		Category: doctor.CategoryCore,
+	}
+}
+
+func initEmbeddedSchemaCompatibilityCheck(store storeHolder) doctorCheck {
+	ctx := context.Background()
+	if _, err := store.GetStatistics(ctx); err != nil {
+		return doctorCheck{
+			Name:     "Schema Compatibility",
+			Status:   statusError,
+			Message:  "Database schema is incomplete or incompatible",
+			Detail:   fmt.Sprintf("Storage: Dolt\n\nError: %v", err),
+			Fix:      "Run 'bd doctor --fix' to attempt repair. If schema is incompatible, export data first with 'bd export'",
+			Category: doctor.CategoryCore,
+		}
+	}
+
+	return doctorCheck{
+		Name:     "Schema Compatibility",
+		Status:   statusOK,
+		Message:  "Basic queries succeeded",
+		Detail:   "Storage: Dolt",
+		Category: doctor.CategoryCore,
+	}
+}
+
+func initEmbeddedConnectionCheck(store storeHolder) doctorCheck {
+	if store == nil {
+		return doctorCheck{
+			Name:     "Dolt Connection",
+			Status:   statusError,
+			Message:  "Failed to open database",
+			Detail:   "Unable to open Dolt database",
+			Category: doctor.CategoryCore,
+		}
+	}
+
+	return doctorCheck{
+		Name:     "Dolt Connection",
+		Status:   statusOK,
+		Message:  "Connected successfully",
+		Detail:   "Storage: Dolt (embedded mode)",
+		Category: doctor.CategoryCore,
+	}
+}
+
+func initEmbeddedDoltSchemaCheck(store storeHolder) doctorCheck {
+	schemaCheck := initEmbeddedSchemaCompatibilityCheck(store)
+	if schemaCheck.Status != statusOK {
+		return doctorCheck{
+			Name:     "Dolt Schema",
+			Status:   schemaCheck.Status,
+			Message:  schemaCheck.Message,
+			Detail:   schemaCheck.Detail,
+			Fix:      schemaCheck.Fix,
+			Category: doctor.CategoryCore,
+		}
+	}
+
+	return doctorCheck{
+		Name:     "Dolt Schema",
+		Status:   statusOK,
+		Message:  "All required tables present",
+		Category: doctor.CategoryCore,
+	}
 }
 
 // convertDoctorCheck converts doctor package check to main package check

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1180,28 +1180,22 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			fmt.Printf("      %s\n\n", ui.RenderAccent("bd backup restore"))
 		}
 
-		// Run limited diagnostics to verify init succeeded.
-		// Skipped in embedded mode: diagnostics use dolt.NewFromConfigWithOptions
-		// which auto-starts a dolt sql-server. Embedded init already validates
-		// the database via initSchema.
-		if !isEmbeddedMode() {
-			doctorResult := runInitDiagnostics(cwd)
-			hasIssues := false
+		doctorResult := runInitDiagnostics(cwd)
+		hasIssues := false
+		for _, check := range doctorResult.Checks {
+			if check.Status != statusOK {
+				hasIssues = true
+				break
+			}
+		}
+		if hasIssues {
+			fmt.Printf("%s Setup incomplete. Some issues were detected:\n", ui.RenderWarn("⚠"))
 			for _, check := range doctorResult.Checks {
 				if check.Status != statusOK {
-					hasIssues = true
-					break
+					fmt.Printf("  • %s: %s\n", check.Name, check.Message)
 				}
 			}
-			if hasIssues {
-				fmt.Printf("%s Setup incomplete. Some issues were detected:\n", ui.RenderWarn("⚠"))
-				for _, check := range doctorResult.Checks {
-					if check.Status != statusOK {
-						fmt.Printf("  • %s: %s\n", check.Name, check.Message)
-					}
-				}
-				fmt.Printf("\nRun %s to see details and fix these issues.\n\n", ui.RenderAccent("bd doctor --fix"))
-			}
+			fmt.Printf("\nRun %s to see details and fix these issues.\n\n", ui.RenderAccent("bd doctor --fix"))
 		}
 	},
 }

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -503,6 +503,21 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("post_init_diagnostics_are_clean", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "diag")
+
+		result := runInitDiagnostics(dir)
+		if !result.OverallOK {
+			t.Fatalf("expected embedded init diagnostics to pass, got overall_ok=false: %+v", result.Checks)
+		}
+
+		for _, check := range result.Checks {
+			if check.Status != statusOK {
+				t.Fatalf("expected check %q to be ok after embedded init, got %s: %s", check.Name, check.Status, check.Message)
+			}
+		}
+	})
+
 	t.Run("metadata_json", func(t *testing.T) {
 		_, beadsDir, _ := bdInit(t, bd, "--prefix", "mj")
 		cfg, err := configfile.Load(beadsDir)


### PR DESCRIPTION
## Summary
- run the post-init verification path after `bd init` in embedded mode as well as server mode
- validate embedded init against the real read-only embedded/app store instead of the server-only doctor path to avoid false setup failures
- add regression coverage for embedded init diagnostics so fresh embedded repos stay green

## Validation
- `go test ./cmd/bd/doctor -run 'TestRunDoltHealthChecks_DoltBackendNoServer|TestSharedStore_WithStoreChecks_NoDatabase'`
- `go test ./cmd/bd -run 'TestInitCommand|TestInitAlreadyInitialized'`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run 'TestEmbeddedInit/post_init_diagnostics_are_clean' -count=1`