### PR TITLE
Keep regular epics open after the last child closes

### DIFF
--- a/claude-plugin/skills/beads/resources/DEPENDENCIES.md
+++ b/claude-plugin/skills/beads/resources/DEPENDENCIES.md
@@ -360,7 +360,7 @@ blocks: Shows they must be done in order
 Epic with no ordering between children:
 All children show in bd ready immediately.
 Work on any child in any order.
-Close epic when all children complete.
+Close the epic explicitly once all children complete and the parent outcome is done.
 ```
 
 **Pattern: Epic with Sequential Subtasks**

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -357,9 +357,10 @@ func checkGateSatisfaction(issue *types.Issue) error {
 	return fmt.Errorf("gate condition not satisfied: %s (use --force to override)", reason)
 }
 
-// autoCloseCompletedMolecule checks if closing a step completed a parent molecule,
-// and if so, auto-closes the molecule root. This prevents stale wisps that are
-// complete but never explicitly closed (e.g., deacon patrol wisps).
+// autoCloseCompletedMolecule checks if closing a step completed an auto-closing
+// parent molecule, and if so, closes the molecule root. Ordinary epics remain
+// open when all children finish so they can become explicitly close-eligible
+// instead of being closed as a side effect of the final child close.
 func autoCloseCompletedMolecule(ctx context.Context, s storage.DoltStorage, closedStepID, actorName, session string) {
 	moleculeID := findParentMolecule(ctx, s, closedStepID)
 	if moleculeID == "" {
@@ -368,7 +369,7 @@ func autoCloseCompletedMolecule(ctx context.Context, s storage.DoltStorage, clos
 
 	// Check if molecule root is already closed
 	root, err := s.GetIssue(ctx, moleculeID)
-	if err != nil || root == nil || root.Status == types.StatusClosed {
+	if err != nil || root == nil || root.Status == types.StatusClosed || !shouldAutoCloseCompletedRoot(root) {
 		return
 	}
 
@@ -391,6 +392,32 @@ func autoCloseCompletedMolecule(ctx context.Context, s storage.DoltStorage, clos
 	if !jsonOutput {
 		fmt.Printf("%s Auto-closed completed molecule %s\n", ui.RenderPass("✓"), formatFeedbackID(moleculeID, root.Title))
 	}
+}
+
+// shouldAutoCloseCompletedRoot returns true for molecule roots that should
+// auto-close when their final step closes. Regular epics stay open and become
+// explicit close-eligible work, while ephemeral wisps, template-driven
+// molecules, and molecule-type coordination roots keep their cleanup behavior.
+func shouldAutoCloseCompletedRoot(root *types.Issue) bool {
+	if root == nil {
+		return false
+	}
+
+	if root.IssueType == types.TypeMolecule || root.Ephemeral {
+		return true
+	}
+
+	if root.IssueType != types.TypeEpic {
+		return false
+	}
+
+	for _, label := range root.Labels {
+		if label == BeadsTemplateLabel {
+			return true
+		}
+	}
+
+	return false
 }
 
 // countEpicOpenChildren returns the number of open (non-closed) children for an epic.

--- a/cmd/bd/close_embedded_test.go
+++ b/cmd/bd/close_embedded_test.go
@@ -264,6 +264,19 @@ func TestEmbeddedClose(t *testing.T) {
 		_ = child
 	})
 
+	t.Run("close_last_child_keeps_regular_epic_open", func(t *testing.T) {
+		epic := bdCreate(t, bd, dir, "Epic stays open", "--type", "epic")
+		child := bdCreate(t, bd, dir, "Epic closing child", "--type", "task")
+		bdDepAdd(t, bd, dir, child.ID, epic.ID, "--type", "parent-child")
+
+		bdClose(t, bd, dir, child.ID)
+
+		got := bdShow(t, bd, dir, epic.ID)
+		if got.Status != types.StatusOpen {
+			t.Errorf("expected regular epic to stay open after its last child closes, got %s", got.Status)
+		}
+	})
+
 	// ===== Blocker and Suggest-Next Behavior =====
 
 	t.Run("close_unblocks_dependent", func(t *testing.T) {

--- a/cmd/bd/epic_embedded_test.go
+++ b/cmd/bd/epic_embedded_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // bdEpic runs "bd epic" with the given args and returns raw stdout.
@@ -85,9 +87,7 @@ func TestEmbeddedEpic(t *testing.T) {
 	})
 
 	t.Run("status_eligible_only", func(t *testing.T) {
-		// When all children are closed, the epic is auto-closed by bd close.
-		// So --eligible-only may find nothing if auto-close already happened.
-		// Just verify the flag doesn't crash and filters correctly.
+		// --eligible-only should only show epics with all children complete.
 		out := bdEpic(t, bd, dir, "status", "--eligible-only")
 		// epic1 has open children — should NOT appear
 		if strings.Contains(out, epic1.ID) {
@@ -122,24 +122,28 @@ func TestEmbeddedEpic(t *testing.T) {
 		if strings.Contains(out, epic1.ID) {
 			t.Errorf("epic1 (not eligible) should not appear in dry-run: %s", out)
 		}
-		// Just verify no crash — auto-close may have already closed eligible epics
 	})
 
 	t.Run("close_eligible_closes_epics", func(t *testing.T) {
-		// Note: bd close auto-closes the parent epic when the last child closes.
-		// So by the time we run close-eligible, the epic is already closed.
-		// Verify close-eligible handles this gracefully (no epics to close).
 		dir3, _, _ := bdInit(t, bd, "--prefix", "ep3")
 		e := bdCreate(t, bd, dir3, "Close me epic", "--type", "epic")
 		ch := bdCreate(t, bd, dir3, "Close me child", "--type", "task")
 		bdDep(t, bd, dir3, "add", ch.ID, e.ID, "--type", "parent-child")
-		bdClose(t, bd, dir3, ch.ID) // This auto-closes the epic
+		bdClose(t, bd, dir3, ch.ID)
+
+		got := bdShow(t, bd, dir3, e.ID)
+		if got.Status != types.StatusOpen {
+			t.Fatalf("expected epic to remain open until close-eligible runs, got %s", got.Status)
+		}
 
 		out := bdEpic(t, bd, dir3, "close-eligible")
-		// Epic already auto-closed — close-eligible finds nothing or reports already closed
-		_ = e
 		if strings.Contains(out, "Error") {
 			t.Errorf("unexpected error: %s", out)
+		}
+
+		got = bdShow(t, bd, dir3, e.ID)
+		if got.Status != types.StatusClosed {
+			t.Errorf("expected close-eligible to close the epic, got %s", got.Status)
 		}
 	})
 
@@ -148,7 +152,7 @@ func TestEmbeddedEpic(t *testing.T) {
 		e := bdCreate(t, bd, dir4, "JSON close epic", "--type", "epic")
 		ch := bdCreate(t, bd, dir4, "JSON close child", "--type", "task")
 		bdDep(t, bd, dir4, "add", ch.ID, e.ID, "--type", "parent-child")
-		bdClose(t, bd, dir4, ch.ID) // auto-closes epic
+		bdClose(t, bd, dir4, ch.ID)
 		_ = e
 
 		fullArgs := []string{"epic", "close-eligible", "--json"}

--- a/docs/MOLECULES.md
+++ b/docs/MOLECULES.md
@@ -115,6 +115,9 @@ bd mol bond A B --type conditional # B runs only if A fails
 
 This is how orchestrators run autonomous workflows - agents follow the dependency graph, handing off between sessions, until all work closes.
 
+Ordinary epics stay open when the last child closes. They become close-eligible
+work that can be closed explicitly once the parent outcome is actually done.
+
 ## Phase Metaphor (Templates)
 
 For reusable workflows, beads uses a chemistry metaphor:

--- a/internal/doltserver/doltserver_unix.go
+++ b/internal/doltserver/doltserver_unix.go
@@ -83,7 +83,9 @@ func listDoltProcessPIDs() []int {
 // Uses lsof to look up the CWD, which is more reliable than checking command-line
 // args since dolt sql-server is started with cmd.Dir (not a --data-dir flag).
 func isProcessInDir(pid int, dir string) bool {
-	out, err := exec.Command("lsof", "-p", strconv.Itoa(pid), "-d", "cwd", "-Fn").Output()
+	// On macOS, lsof requires -a to AND selectors together; without it,
+	// "-p <pid>" and "-d cwd" can yield cwd entries from unrelated processes.
+	out, err := exec.Command("lsof", "-a", "-p", strconv.Itoa(pid), "-d", "cwd", "-Fn").Output()
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Summary
- stop auto-closing ordinary epics when the final child closes
- keep auto-close for ephemeral or template-driven molecule roots
- update embedded tests and docs to reflect explicit epic close-eligibility

## Verification
- `go test -tags regression ./tests/regression -run ^TestProtocol_EpicLifecycle$`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run ^(TestEmbeddedClose|TestEmbeddedEpic)$`
