### PR TITLE
fix: include _meta truncation indicator in bd list --json

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -944,7 +944,18 @@ var listCmd = &cobra.Command{
 					Parent:          parent,
 				}
 			}
-			outputJSON(issuesWithCounts)
+			if truncated {
+				outputJSON(map[string]interface{}{
+					"issues": issuesWithCounts,
+					"_meta": map[string]interface{}{
+						"truncated": true,
+						"limit":     effectiveLimit,
+						"hint":      "use --limit 0 for all results",
+					},
+				})
+			} else {
+				outputJSON(issuesWithCounts)
+			}
 			printTruncationHint(truncated, effectiveLimit)
 			return
 		}


### PR DESCRIPTION
Fixes #3280. Added `_meta` field to JSON output from `bd list --json` to indicate when results are truncated. Makes it easier to detect pagination needs programmatically.

When truncated, the response wraps from a bare array to:
```json
{
  "issues": [...],
  "_meta": {
    "truncated": true,
    "limit": 50,
    "hint": "use --limit 0 for all results"
  }
}
```

Non-truncated responses remain a bare array for backwards compatibility.

I maintain [PRISM](https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code — CLAUDE.md adherence analysis and session health scoring. Fixed this while integrating beads into my session analysis workflow.