### PR TITLE
fix: add _type discriminator to issue lines in bd export JSONL

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -174,6 +174,9 @@ func runExport(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal issue %s: %w", issue.ID, err)
 		}
+		// Prepend _type discriminator so every JSONL line is self-describing (GH#3271).
+		// Memory lines already have _type; this makes issue lines consistent.
+		data = append([]byte(`{"_type":"issue",`), data[1:]...)
 		if _, err := w.Write(data); err != nil {
 			return fmt.Errorf("failed to write: %w", err)
 		}

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -50,6 +50,14 @@ var (
 	exportNoMemories   bool
 )
 
+// exportIssueRecord wraps IssueWithCounts with a "_type":"issue" discriminator so every
+// JSONL line in bd export is self-describing (GH#3271). Using an embedded struct lets the
+// encoder handle the field natively rather than splicing bytes into the marshaled output.
+type exportIssueRecord struct {
+	RecordType string `json:"_type"`
+	*types.IssueWithCounts
+}
+
 func init() {
 	exportCmd.Flags().StringVarP(&exportOutput, "output", "o", "", "Output file path (default: stdout)")
 	exportCmd.Flags().BoolVar(&exportAll, "all", false, "Include all records (infra, templates, gates)")
@@ -170,13 +178,10 @@ func runExport(cmd *cobra.Command, args []string) error {
 			CommentCount:    commentCounts[issue.ID],
 		}
 
-		data, err := json.Marshal(record)
+		data, err := json.Marshal(exportIssueRecord{RecordType: "issue", IssueWithCounts: record})
 		if err != nil {
 			return fmt.Errorf("failed to marshal issue %s: %w", issue.ID, err)
 		}
-		// Prepend _type discriminator so every JSONL line is self-describing (GH#3271).
-		// Memory lines already have _type; this makes issue lines consistent.
-		data = append([]byte(`{"_type":"issue",`), data[1:]...)
 		if _, err := w.Write(data); err != nil {
 			return fmt.Errorf("failed to write: %w", err)
 		}

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -200,7 +200,7 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 				DependentCount:  counts.DependentCount,
 				CommentCount:    commentCounts[issue.ID],
 			}
-			if err := enc.Encode(record); err != nil {
+			if err := enc.Encode(exportIssueRecord{RecordType: "issue", IssueWithCounts: record}); err != nil {
 				return 0, 0, fmt.Errorf("failed to write issue %s: %w", issue.ID, err)
 			}
 			issueCount++


### PR DESCRIPTION
Fixes #3271. Added `_type` discriminator field to each JSONL line in `bd export` output so consumers can distinguish record types without inspecting field presence heuristically.

Memory lines already had `"_type":"memory"` — issue lines now consistently include `"_type":"issue"`, making every JSONL record self-describing. This is a non-breaking additive change.

I maintain [PRISM](https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code — CLAUDE.md adherence analysis and session health scoring. PRISM also parses JSONL files so clean type discriminators matter to me.