### PR TITLE
docs(test): breadcrumb to GH#3260 near memory race workaround

### DIFF
--- a/cmd/bd/memory_embedded_test.go
+++ b/cmd/bd/memory_embedded_test.go
@@ -220,6 +220,15 @@ func TestEmbeddedMemoryConcurrent(t *testing.T) {
 	// flock contention, not export behavior. With export.auto=true
 	// (the default since GH#2973), 8 concurrent writers also trigger
 	// post-write read paths that race with in-flight commits.
+	//
+	// The underlying race is not flock-level (flock already serializes
+	// bd subprocesses) but engine-shutdown-level: Dolt's working-set
+	// persistence can lag behind flock release, so the next subprocess
+	// sometimes commits with a stale view and overwrites a prior forget.
+	// See GH#3260 for the investigation (PR #3269 was the CI probe).
+	// Fix would require synchronous flush on engine close or a long-lived
+	// engine per store; both are substantial work. Until then, this
+	// workaround keeps the test deterministic.
 	disableAutoExport := exec.Command(bd, "config", "set", "export.auto", "false")
 	disableAutoExport.Dir = dir
 	disableAutoExport.Env = bdEnv(dir)


### PR DESCRIPTION
## Summary

- Adds a comment near the `export.auto=false` workaround in `TestEmbeddedMemoryConcurrent` pointing to the GH#3260 investigation and PR #3269 probe.
- No behavior change.

## Why

Probe PR #3269 confirmed the race that made the workaround necessary is engine-shutdown-level (Dolt working-set persistence can lag flock release), not flock-level. Without a breadcrumb, future readers will try to "fix" the workaround by tightening flock and repeat the same investigation.

## Test plan

- [ ] Comment-only change; existing tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)