### PR TITLE
[codex] Route duplicate commands through CommandContext accessors

### DIFF
--- a/cmd/bd/duplicate.go
+++ b/cmd/bd/duplicate.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/types"
@@ -61,7 +59,9 @@ func init() {
 func runDuplicate(cmd *cobra.Command, args []string) error {
 	CheckReadonly("duplicate")
 
-	ctx := rootCtx
+	ctx := getRootContext()
+	store := getStore()
+	actor := getActor()
 
 	// Resolve partial IDs
 	var duplicateID, canonicalID string
@@ -111,15 +111,13 @@ func runDuplicate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if jsonOutput {
-		result := map[string]interface{}{
+	if isJSONOutput() {
+		outputJSON(map[string]interface{}{
 			"duplicate": duplicateID,
 			"canonical": canonicalID,
 			"status":    "closed",
-		}
-		encoder := json.NewEncoder(os.Stdout)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(result)
+		})
+		return nil
 	}
 
 	fmt.Printf("%s Marked %s as duplicate of %s (closed)\n", ui.RenderPass("✓"), duplicateID, canonicalID)
@@ -129,7 +127,9 @@ func runDuplicate(cmd *cobra.Command, args []string) error {
 func runSupersede(cmd *cobra.Command, args []string) error {
 	CheckReadonly("supersede")
 
-	ctx := rootCtx
+	ctx := getRootContext()
+	store := getStore()
+	actor := getActor()
 
 	// Resolve partial IDs
 	var oldID, newID string
@@ -179,15 +179,13 @@ func runSupersede(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if jsonOutput {
-		result := map[string]interface{}{
+	if isJSONOutput() {
+		outputJSON(map[string]interface{}{
 			"superseded":  oldID,
 			"replacement": newID,
 			"status":      "closed",
-		}
-		encoder := json.NewEncoder(os.Stdout)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(result)
+		})
+		return nil
 	}
 
 	fmt.Printf("%s Marked %s as superseded by %s (closed)\n", ui.RenderPass("✓"), oldID, newID)


### PR DESCRIPTION
## Summary
- switch `duplicate` and `supersede` to use `getRootContext()`, `getStore()`, `getActor()`, and `isJSONOutput()`
- route JSON output through the existing `outputJSON(...)` helper
- remove direct package-global reads from `cmd/bd/duplicate.go`

## Why
This is the `bd-itp.2` pilot for the refactor epic. The goal is to test whether small, command-local CommandContext migration reduces hidden coupling without changing CLI behavior.

The target slice was deliberately narrow: both handlers in `cmd/bd/duplicate.go`. That let the change remove direct reads of `rootCtx`, `store`, `actor`, and `jsonOutput` without expanding into larger lifecycle or architecture work.

## Validation
- `CGO_ENABLED=1 go test -tags gms_pure_go -run '^(TestEmbeddedDuplicate|TestEmbeddedSupersede)$' ./cmd/bd/...`

## Notes
- This is intentionally a small structural refactor, not a behavior change.
- The pilot outcome was recorded in `bd-itp.3` as a narrow continue signal, not a blanket green light for broader cleanup.