### PR TITLE
[codex] Share epic DB setup in one suite

### DIFF
--- a/cmd/bd/epic_test.go
+++ b/cmd/bd/epic_test.go
@@ -9,90 +9,102 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/types"
 )
 
-func TestEpicCommand(t *testing.T) {
+type epicTestHelper struct {
+	s   *dolt.DoltStore
+	ctx context.Context
+	t   *testing.T
+}
+
+func newEpicTestHelper(t *testing.T) *epicTestHelper {
 	tmpDir := t.TempDir()
 	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
-	sqliteStore := newTestStore(t, testDB)
-	ctx := context.Background()
+	return &epicTestHelper{
+		s:   newTestStore(t, testDB),
+		ctx: context.Background(),
+		t:   t,
+	}
+}
 
-	// Create an epic with children
-	epic := &types.Issue{
-		ID:          "test-epic-1",
-		Title:       "Test Epic",
-		Description: "Epic description",
-		Status:      types.StatusOpen,
-		Priority:    1,
-		IssueType:   types.TypeEpic,
-		CreatedAt:   time.Now(),
+func (h *epicTestHelper) createIssue(issue *types.Issue) {
+	if err := h.s.CreateIssue(h.ctx, issue, "test"); err != nil {
+		h.t.Fatal(err)
 	}
+}
 
-	if err := sqliteStore.CreateIssue(ctx, epic, "test"); err != nil {
-		t.Fatal(err)
+func (h *epicTestHelper) addDependency(dep *types.Dependency) {
+	if err := h.s.AddDependency(h.ctx, dep, "test"); err != nil {
+		h.t.Fatal(err)
 	}
+}
 
-	// Create child tasks
-	child1 := &types.Issue{
-		Title:     "Child Task 1",
-		Status:    types.StatusClosed,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		CreatedAt: time.Now(),
-		ClosedAt:  ptrTime(time.Now()),
-	}
-
-	child2 := &types.Issue{
-		Title:     "Child Task 2",
-		Status:    types.StatusOpen,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		CreatedAt: time.Now(),
-	}
-
-	if err := sqliteStore.CreateIssue(ctx, child1, "test"); err != nil {
-		t.Fatal(err)
-	}
-	if err := sqliteStore.CreateIssue(ctx, child2, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add parent-child dependencies
-	dep1 := &types.Dependency{
-		IssueID:     child1.ID,
-		DependsOnID: epic.ID,
-		Type:        types.DepParentChild,
-	}
-	dep2 := &types.Dependency{
-		IssueID:     child2.ID,
-		DependsOnID: epic.ID,
-		Type:        types.DepParentChild,
-	}
-
-	if err := sqliteStore.AddDependency(ctx, dep1, "test"); err != nil {
-		t.Fatal(err)
-	}
-	if err := sqliteStore.AddDependency(ctx, dep2, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Test GetEpicsEligibleForClosure
-	store = sqliteStore
-
-	epics, err := sqliteStore.GetEpicsEligibleForClosure(ctx)
+func (h *epicTestHelper) getEpicStatus(epicID string) *types.EpicStatus {
+	epics, err := h.s.GetEpicsEligibleForClosure(h.ctx)
 	if err != nil {
-		t.Fatalf("GetEpicsEligibleForClosure failed: %v", err)
+		h.t.Fatalf("GetEpicsEligibleForClosure failed: %v", err)
 	}
 
-	if len(epics) != 1 {
-		t.Errorf("Expected 1 epic, got %d", len(epics))
+	for _, epic := range epics {
+		if epic.Epic.ID == epicID {
+			return epic
+		}
 	}
+	return nil
+}
 
-	if len(epics) > 0 {
-		epicStatus := epics[0]
-		if epicStatus.Epic.ID != "test-epic-1" {
-			t.Errorf("Expected epic ID test-epic-1, got %s", epicStatus.Epic.ID)
+func TestEpicSuite(t *testing.T) {
+	h := newEpicTestHelper(t)
+
+	t.Run("MixedChildrenNotEligible", func(t *testing.T) {
+		h.t = t
+
+		epic := &types.Issue{
+			ID:          "test-epic-1",
+			Title:       "Test Epic",
+			Description: "Epic description",
+			Status:      types.StatusOpen,
+			Priority:    1,
+			IssueType:   types.TypeEpic,
+			CreatedAt:   time.Now(),
+		}
+		h.createIssue(epic)
+
+		child1 := &types.Issue{
+			Title:     "Child Task 1",
+			Status:    types.StatusClosed,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			CreatedAt: time.Now(),
+			ClosedAt:  ptrTime(time.Now()),
+		}
+		child2 := &types.Issue{
+			Title:     "Child Task 2",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			CreatedAt: time.Now(),
+		}
+		h.createIssue(child1)
+		h.createIssue(child2)
+
+		h.addDependency(&types.Dependency{
+			IssueID:     child1.ID,
+			DependsOnID: epic.ID,
+			Type:        types.DepParentChild,
+		})
+		h.addDependency(&types.Dependency{
+			IssueID:     child2.ID,
+			DependsOnID: epic.ID,
+			Type:        types.DepParentChild,
+		})
+
+		store = h.s
+		epicStatus := h.getEpicStatus("test-epic-1")
+		if epicStatus == nil {
+			t.Fatal("Epic test-epic-1 not found in results")
 		}
 		if epicStatus.TotalChildren != 2 {
 			t.Errorf("Expected 2 total children, got %d", epicStatus.TotalChildren)
@@ -103,7 +115,112 @@ func TestEpicCommand(t *testing.T) {
 		if epicStatus.EligibleForClose {
 			t.Error("Epic should not be eligible for close with open children")
 		}
-	}
+	})
+
+	t.Run("OpenWispChildNotEligible", func(t *testing.T) {
+		h.t = t
+
+		epic := &types.Issue{
+			ID:          "test-epic-wisp",
+			Title:       "Epic with wisp child",
+			Description: "Tests that wisp children are counted for closure eligibility",
+			Status:      types.StatusOpen,
+			Priority:    1,
+			IssueType:   types.TypeEpic,
+			CreatedAt:   time.Now(),
+		}
+		h.createIssue(epic)
+
+		regularChild := &types.Issue{
+			Title:     "Regular child",
+			Status:    types.StatusClosed,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			CreatedAt: time.Now(),
+			ClosedAt:  ptrTime(time.Now()),
+		}
+		wispChild := &types.Issue{
+			Title:     "Wisp child",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+			CreatedAt: time.Now(),
+		}
+		h.createIssue(regularChild)
+		h.createIssue(wispChild)
+
+		h.addDependency(&types.Dependency{
+			IssueID:     regularChild.ID,
+			DependsOnID: epic.ID,
+			Type:        types.DepParentChild,
+		})
+		h.addDependency(&types.Dependency{
+			IssueID:     wispChild.ID,
+			DependsOnID: epic.ID,
+			Type:        types.DepParentChild,
+		})
+
+		epicStatus := h.getEpicStatus("test-epic-wisp")
+		if epicStatus == nil {
+			t.Fatal("Epic test-epic-wisp not found in results")
+		}
+		if epicStatus.TotalChildren != 2 {
+			t.Errorf("Expected 2 total children (1 regular + 1 wisp), got %d", epicStatus.TotalChildren)
+		}
+		if epicStatus.ClosedChildren != 1 {
+			t.Errorf("Expected 1 closed child, got %d", epicStatus.ClosedChildren)
+		}
+		if epicStatus.EligibleForClose {
+			t.Error("Epic should NOT be eligible for close with open wisp child")
+		}
+	})
+
+	t.Run("AllChildrenClosedEligible", func(t *testing.T) {
+		h.t = t
+
+		epic := &types.Issue{
+			ID:          "test-epic-2",
+			Title:       "Fully Completed Epic",
+			Description: "Epic description",
+			Status:      types.StatusOpen,
+			Priority:    1,
+			IssueType:   types.TypeEpic,
+			CreatedAt:   time.Now(),
+		}
+		h.createIssue(epic)
+
+		for i := 1; i <= 3; i++ {
+			child := &types.Issue{
+				Title:     fmt.Sprintf("Child Task %d", i),
+				Status:    types.StatusClosed,
+				Priority:  2,
+				IssueType: types.TypeTask,
+				CreatedAt: time.Now(),
+				ClosedAt:  ptrTime(time.Now()),
+			}
+			h.createIssue(child)
+			h.addDependency(&types.Dependency{
+				IssueID:     child.ID,
+				DependsOnID: epic.ID,
+				Type:        types.DepParentChild,
+			})
+		}
+
+		epicStatus := h.getEpicStatus("test-epic-2")
+		if epicStatus == nil {
+			t.Fatal("Epic test-epic-2 not found in results")
+		}
+		if epicStatus.TotalChildren != 3 {
+			t.Errorf("Expected 3 total children, got %d", epicStatus.TotalChildren)
+		}
+		if epicStatus.ClosedChildren != 3 {
+			t.Errorf("Expected 3 closed children, got %d", epicStatus.ClosedChildren)
+		}
+		if !epicStatus.EligibleForClose {
+			t.Error("Epic should be eligible for close when all children are closed")
+		}
+	})
 }
 
 func TestEpicCommandInit(t *testing.T) {
@@ -115,7 +232,6 @@ func TestEpicCommandInit(t *testing.T) {
 		t.Errorf("Expected Use='epic', got %q", epicCmd.Use)
 	}
 
-	// Check that subcommands exist
 	var hasStatusCmd bool
 	for _, cmd := range epicCmd.Commands() {
 		if cmd.Use == "status" {
@@ -125,171 +241,5 @@ func TestEpicCommandInit(t *testing.T) {
 
 	if !hasStatusCmd {
 		t.Error("epic command should have status subcommand")
-	}
-}
-
-func TestEpicEligibleForCloseWithWispChildren(t *testing.T) {
-	tmpDir := t.TempDir()
-	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
-	sqliteStore := newTestStore(t, testDB)
-	ctx := context.Background()
-
-	// Create an epic with one regular child and one wisp child.
-	epic := &types.Issue{
-		ID:          "test-epic-wisp",
-		Title:       "Epic with wisp child",
-		Description: "Tests that wisp children are counted for closure eligibility",
-		Status:      types.StatusOpen,
-		Priority:    1,
-		IssueType:   types.TypeEpic,
-		CreatedAt:   time.Now(),
-	}
-	if err := sqliteStore.CreateIssue(ctx, epic, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Regular child (closed)
-	regularChild := &types.Issue{
-		Title:     "Regular child",
-		Status:    types.StatusClosed,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		CreatedAt: time.Now(),
-		ClosedAt:  ptrTime(time.Now()),
-	}
-	if err := sqliteStore.CreateIssue(ctx, regularChild, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Wisp child (still open) — stored in wisps table
-	wispChild := &types.Issue{
-		Title:     "Wisp child",
-		Status:    types.StatusOpen,
-		Priority:  2,
-		IssueType: types.TypeTask,
-		Ephemeral: true,
-		CreatedAt: time.Now(),
-	}
-	if err := sqliteStore.CreateIssue(ctx, wispChild, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add parent-child dependencies
-	if err := sqliteStore.AddDependency(ctx, &types.Dependency{
-		IssueID:     regularChild.ID,
-		DependsOnID: epic.ID,
-		Type:        types.DepParentChild,
-	}, "test"); err != nil {
-		t.Fatal(err)
-	}
-	if err := sqliteStore.AddDependency(ctx, &types.Dependency{
-		IssueID:     wispChild.ID,
-		DependsOnID: epic.ID,
-		Type:        types.DepParentChild,
-	}, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Epic should NOT be eligible — wisp child is still open
-	epics, err := sqliteStore.GetEpicsEligibleForClosure(ctx)
-	if err != nil {
-		t.Fatalf("GetEpicsEligibleForClosure failed: %v", err)
-	}
-
-	var epicStatus *types.EpicStatus
-	for _, e := range epics {
-		if e.Epic.ID == "test-epic-wisp" {
-			epicStatus = e
-			break
-		}
-	}
-
-	if epicStatus == nil {
-		t.Fatal("Epic test-epic-wisp not found in results")
-	}
-	if epicStatus.TotalChildren != 2 {
-		t.Errorf("Expected 2 total children (1 regular + 1 wisp), got %d", epicStatus.TotalChildren)
-	}
-	if epicStatus.ClosedChildren != 1 {
-		t.Errorf("Expected 1 closed child, got %d", epicStatus.ClosedChildren)
-	}
-	if epicStatus.EligibleForClose {
-		t.Error("Epic should NOT be eligible for close with open wisp child")
-	}
-}
-
-func TestEpicEligibleForClose(t *testing.T) {
-	tmpDir := t.TempDir()
-	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
-	sqliteStore := newTestStore(t, testDB)
-	ctx := context.Background()
-
-	// Create an epic where all children are closed
-	epic := &types.Issue{
-		ID:          "test-epic-2",
-		Title:       "Fully Completed Epic",
-		Description: "Epic description",
-		Status:      types.StatusOpen,
-		Priority:    1,
-		IssueType:   types.TypeEpic,
-		CreatedAt:   time.Now(),
-	}
-
-	if err := sqliteStore.CreateIssue(ctx, epic, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create all closed children
-	for i := 1; i <= 3; i++ {
-		child := &types.Issue{
-			Title:     fmt.Sprintf("Child Task %d", i),
-			Status:    types.StatusClosed,
-			Priority:  2,
-			IssueType: types.TypeTask,
-			CreatedAt: time.Now(),
-			ClosedAt:  ptrTime(time.Now()),
-		}
-		if err := sqliteStore.CreateIssue(ctx, child, "test"); err != nil {
-			t.Fatal(err)
-		}
-
-		// Add parent-child dependency
-		dep := &types.Dependency{
-			IssueID:     child.ID,
-			DependsOnID: epic.ID,
-			Type:        types.DepParentChild,
-		}
-		if err := sqliteStore.AddDependency(ctx, dep, "test"); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	// Test GetEpicsEligibleForClosure
-	epics, err := sqliteStore.GetEpicsEligibleForClosure(ctx)
-	if err != nil {
-		t.Fatalf("GetEpicsEligibleForClosure failed: %v", err)
-	}
-
-	// Find our epic
-	var epicStatus *types.EpicStatus
-	for _, e := range epics {
-		if e.Epic.ID == "test-epic-2" {
-			epicStatus = e
-			break
-		}
-	}
-
-	if epicStatus == nil {
-		t.Fatal("Epic test-epic-2 not found in results")
-	}
-
-	if epicStatus.TotalChildren != 3 {
-		t.Errorf("Expected 3 total children, got %d", epicStatus.TotalChildren)
-	}
-	if epicStatus.ClosedChildren != 3 {
-		t.Errorf("Expected 3 closed children, got %d", epicStatus.ClosedChildren)
-	}
-	if !epicStatus.EligibleForClose {
-		t.Error("Epic should be eligible for close when all children are closed")
 	}
 }

--- a/cmd/bd/epic_test.go
+++ b/cmd/bd/epic_test.go
@@ -16,7 +16,6 @@ import (
 type epicTestHelper struct {
 	s   *dolt.DoltStore
 	ctx context.Context
-	t   *testing.T
 }
 
 func newEpicTestHelper(t *testing.T) *epicTestHelper {
@@ -25,26 +24,28 @@ func newEpicTestHelper(t *testing.T) *epicTestHelper {
 	return &epicTestHelper{
 		s:   newTestStore(t, testDB),
 		ctx: context.Background(),
-		t:   t,
 	}
 }
 
-func (h *epicTestHelper) createIssue(issue *types.Issue) {
+func (h *epicTestHelper) createIssue(t *testing.T, issue *types.Issue) {
+	t.Helper()
 	if err := h.s.CreateIssue(h.ctx, issue, "test"); err != nil {
-		h.t.Fatal(err)
+		t.Fatal(err)
 	}
 }
 
-func (h *epicTestHelper) addDependency(dep *types.Dependency) {
+func (h *epicTestHelper) addDependency(t *testing.T, dep *types.Dependency) {
+	t.Helper()
 	if err := h.s.AddDependency(h.ctx, dep, "test"); err != nil {
-		h.t.Fatal(err)
+		t.Fatal(err)
 	}
 }
 
-func (h *epicTestHelper) getEpicStatus(epicID string) *types.EpicStatus {
+func (h *epicTestHelper) getEpicStatus(t *testing.T, epicID string) *types.EpicStatus {
+	t.Helper()
 	epics, err := h.s.GetEpicsEligibleForClosure(h.ctx)
 	if err != nil {
-		h.t.Fatalf("GetEpicsEligibleForClosure failed: %v", err)
+		t.Fatalf("GetEpicsEligibleForClosure failed: %v", err)
 	}
 
 	for _, epic := range epics {
@@ -59,8 +60,6 @@ func TestEpicSuite(t *testing.T) {
 	h := newEpicTestHelper(t)
 
 	t.Run("MixedChildrenNotEligible", func(t *testing.T) {
-		h.t = t
-
 		epic := &types.Issue{
 			ID:          "test-epic-1",
 			Title:       "Test Epic",
@@ -70,7 +69,7 @@ func TestEpicSuite(t *testing.T) {
 			IssueType:   types.TypeEpic,
 			CreatedAt:   time.Now(),
 		}
-		h.createIssue(epic)
+		h.createIssue(t, epic)
 
 		child1 := &types.Issue{
 			Title:     "Child Task 1",
@@ -87,22 +86,22 @@ func TestEpicSuite(t *testing.T) {
 			IssueType: types.TypeTask,
 			CreatedAt: time.Now(),
 		}
-		h.createIssue(child1)
-		h.createIssue(child2)
+		h.createIssue(t, child1)
+		h.createIssue(t, child2)
 
-		h.addDependency(&types.Dependency{
+		h.addDependency(t, &types.Dependency{
 			IssueID:     child1.ID,
 			DependsOnID: epic.ID,
 			Type:        types.DepParentChild,
 		})
-		h.addDependency(&types.Dependency{
+		h.addDependency(t, &types.Dependency{
 			IssueID:     child2.ID,
 			DependsOnID: epic.ID,
 			Type:        types.DepParentChild,
 		})
 
 		store = h.s
-		epicStatus := h.getEpicStatus("test-epic-1")
+		epicStatus := h.getEpicStatus(t, "test-epic-1")
 		if epicStatus == nil {
 			t.Fatal("Epic test-epic-1 not found in results")
 		}
@@ -118,8 +117,6 @@ func TestEpicSuite(t *testing.T) {
 	})
 
 	t.Run("OpenWispChildNotEligible", func(t *testing.T) {
-		h.t = t
-
 		epic := &types.Issue{
 			ID:          "test-epic-wisp",
 			Title:       "Epic with wisp child",
@@ -129,7 +126,7 @@ func TestEpicSuite(t *testing.T) {
 			IssueType:   types.TypeEpic,
 			CreatedAt:   time.Now(),
 		}
-		h.createIssue(epic)
+		h.createIssue(t, epic)
 
 		regularChild := &types.Issue{
 			Title:     "Regular child",
@@ -147,21 +144,21 @@ func TestEpicSuite(t *testing.T) {
 			Ephemeral: true,
 			CreatedAt: time.Now(),
 		}
-		h.createIssue(regularChild)
-		h.createIssue(wispChild)
+		h.createIssue(t, regularChild)
+		h.createIssue(t, wispChild)
 
-		h.addDependency(&types.Dependency{
+		h.addDependency(t, &types.Dependency{
 			IssueID:     regularChild.ID,
 			DependsOnID: epic.ID,
 			Type:        types.DepParentChild,
 		})
-		h.addDependency(&types.Dependency{
+		h.addDependency(t, &types.Dependency{
 			IssueID:     wispChild.ID,
 			DependsOnID: epic.ID,
 			Type:        types.DepParentChild,
 		})
 
-		epicStatus := h.getEpicStatus("test-epic-wisp")
+		epicStatus := h.getEpicStatus(t, "test-epic-wisp")
 		if epicStatus == nil {
 			t.Fatal("Epic test-epic-wisp not found in results")
 		}
@@ -177,8 +174,6 @@ func TestEpicSuite(t *testing.T) {
 	})
 
 	t.Run("AllChildrenClosedEligible", func(t *testing.T) {
-		h.t = t
-
 		epic := &types.Issue{
 			ID:          "test-epic-2",
 			Title:       "Fully Completed Epic",
@@ -188,7 +183,7 @@ func TestEpicSuite(t *testing.T) {
 			IssueType:   types.TypeEpic,
 			CreatedAt:   time.Now(),
 		}
-		h.createIssue(epic)
+		h.createIssue(t, epic)
 
 		for i := 1; i <= 3; i++ {
 			child := &types.Issue{
@@ -199,15 +194,15 @@ func TestEpicSuite(t *testing.T) {
 				CreatedAt: time.Now(),
 				ClosedAt:  ptrTime(time.Now()),
 			}
-			h.createIssue(child)
-			h.addDependency(&types.Dependency{
+			h.createIssue(t, child)
+			h.addDependency(t, &types.Dependency{
 				IssueID:     child.ID,
 				DependsOnID: epic.ID,
 				Type:        types.DepParentChild,
 			})
 		}
 
-		epicStatus := h.getEpicStatus("test-epic-2")
+		epicStatus := h.getEpicStatus(t, "test-epic-2")
 		if epicStatus == nil {
 			t.Fatal("Epic test-epic-2 not found in results")
 		}


### PR DESCRIPTION
## Summary
- convert the DB-backed epic tests into a single `TestEpicSuite`
- add a small helper for shared store/context setup and repeated issue/dependency creation
- leave the init-only command registration test separate

## Why
This is the `bd-itp.5` follow-on from the refactor epic. The aim was to apply the shared-suite pattern only where it is actually low-risk and measurable.

`cmd/bd/epic_test.go` was a live pure-DB target with repeated `newTestStore()` setup and no integration-style global-state behavior. The change reduces repeated setup while preserving test intent and keeping the non-DB init test isolated.

## Validation
- `CGO_ENABLED=1 go test -tags gms_pure_go -run '^TestEpic' ./cmd/bd`

## Notes
- DB initializations in the file dropped from 3 to 1.
- Runtime improvement was modest in this environment, but the bigger payoff is lower repeated setup and a clearer template for similar pure-DB files.