### PR TITLE
fix(nix): update vendorHash after dependabot go.sum bumps (GH#3221)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ buildGoModule {
   doCheck = false;
 
   # Go module dependencies hash - if build fails with hash mismatch, update with the "got:" value
-  vendorHash = "sha256-7eb7u47f4/OCnK/T56Zd6b5XUyV6vkBmissryBxANBU=";
+  vendorHash = "sha256-7DJgqJX2HDa9gcGD8fLNHLIXvGAEivYeDYx3snCUyCE=";
 
   # Relax go.mod version for Nix: nixpkgs Go may lag behind the latest
   # patch release, and GOTOOLCHAIN=auto can't download in the Nix sandbox.


### PR DESCRIPTION
## Summary

- `default.nix`'s `vendorHash` went stale after several dependabot updates to `go.mod`/`go.sum` landed on `main` following PR #3064, causing `nix build` to fail with a hash mismatch.
- Updates `vendorHash` to `sha256-7DJgqJX2HDa9gcGD8fLNHLIXvGAEivYeDYx3snCUyCE=`, the value reported by Nix as "got" in @luccahuguet's failure output on #3221.
- The `v1.0.0` release tag itself is not affected; this only impacts builds of `main` (and any branch including the post-#3064 dependabot commits).

Credit to @luccahuguet for reporting the breakage and providing the correct hash value.

Fixes #3221

## Test plan

- [ ] `nix build` succeeds against `main` with the updated `vendorHash`