### PR TITLE
feat: support Unix domain sockets for Dolt server connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,16 @@ or environment variables:
 |------|---------|---------|
 | `--server-host` | `BEADS_DOLT_SERVER_HOST` | `127.0.0.1` |
 | `--server-port` | `BEADS_DOLT_SERVER_PORT` | `3307` |
+| `--server-socket` | `BEADS_DOLT_SERVER_SOCKET` | (none; uses TCP) |
 | `--server-user` | `BEADS_DOLT_SERVER_USER` | `root` |
 | | `BEADS_DOLT_PASSWORD` | (none) |
+
+**Unix domain sockets:** Use `--server-socket` to connect via a Unix socket
+instead of TCP. This avoids port conflicts between concurrent projects and
+is useful in sandboxed environments (e.g., Claude Code) where file-level
+access control is simpler than network allowlists. The Dolt server must be
+started with `dolt sql-server --socket <path>`. Auto-start is not supported
+in socket mode.
 
 ### Backup & Migration
 

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1349,6 +1349,11 @@ func setDoltConfig(key, value string, updateConfig bool) {
 		cfg.DoltServerPort = port
 		yamlKey = "dolt.port"
 
+	case "socket":
+		// Empty value clears the socket (reverts to TCP host/port).
+		cfg.DoltServerSocket = value
+		yamlKey = "dolt.socket"
+
 	case "user":
 		if value == "" {
 			fmt.Fprintf(os.Stderr, "Error: user cannot be empty\n")
@@ -1419,7 +1424,7 @@ func setDoltConfig(key, value string, updateConfig bool) {
 
 	default:
 		fmt.Fprintf(os.Stderr, "Error: unknown key '%s'\n", key)
-		fmt.Fprintf(os.Stderr, "Valid keys: database, host, port, user, data-dir, shared-server\n")
+		fmt.Fprintf(os.Stderr, "Valid keys: database, host, port, socket, user, data-dir, shared-server\n")
 		os.Exit(1)
 	}
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -82,6 +82,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		initServerMode, _ := cmd.Flags().GetBool("server")
 		serverHost, _ := cmd.Flags().GetString("server-host")
 		serverPort, _ := cmd.Flags().GetInt("server-port")
+		serverSocket, _ := cmd.Flags().GetString("server-socket")
 		serverUser, _ := cmd.Flags().GetString("server-user")
 		database, _ := cmd.Flags().GetString("database")
 		destroyToken, _ := cmd.Flags().GetString("destroy-token")
@@ -559,6 +560,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if serverPort != 0 {
 			doltCfg.ServerPort = serverPort
 		}
+		if serverSocket != "" {
+			doltCfg.ServerSocket = serverSocket
+		}
 		if serverUser != "" {
 			doltCfg.ServerUser = serverUser
 		}
@@ -778,6 +782,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				}
 				if serverPort != 0 {
 					cfg.DoltServerPort = serverPort
+				}
+				if serverSocket != "" {
+					cfg.DoltServerSocket = serverSocket
 				}
 				if serverUser != "" {
 					cfg.DoltServerUser = serverUser
@@ -1281,6 +1288,7 @@ func init() {
 	initCmd.Flags().Bool("server", false, "Use external dolt sql-server instead of embedded engine")
 	initCmd.Flags().String("server-host", "", "Dolt server host (default: 127.0.0.1)")
 	initCmd.Flags().Int("server-port", 0, "Dolt server port (default: 3307)")
+	initCmd.Flags().String("server-socket", "", "Unix domain socket path (overrides host/port)")
 	initCmd.Flags().String("server-user", "", "Dolt server MySQL user (default: root)")
 	initCmd.Flags().String("database", "", "Use existing server database name (overrides prefix-based naming)")
 	initCmd.Flags().Bool("shared-server", false, "Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)")

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -850,6 +850,7 @@ var rootCmd = &cobra.Command{
 			// Use doltserver.DefaultConfig for port resolution (env > port file >
 			// config.yaml). Port 0 is fine here — auto-start will resolve it.
 			doltCfg.ServerPort = doltserver.DefaultConfig(beadsDir).Port
+			doltCfg.ServerSocket = cfg.GetDoltServerSocket()
 			doltCfg.ServerUser = cfg.GetDoltServerUser()
 			// Use the resolved port for credential lookup — metadata.json port
 			// and runtime port can diverge (e.g., tunnel on 3308 vs local on 3307).

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -26,6 +26,7 @@ type Config struct {
 	DoltMode           string `json:"dolt_mode,omitempty"`            // "embedded" (default) or "server"
 	DoltServerHost     string `json:"dolt_server_host,omitempty"`     // Server host (default: 127.0.0.1)
 	DoltServerPort     int    `json:"dolt_server_port,omitempty"`     // Server port (default: 3307)
+	DoltServerSocket   string `json:"dolt_server_socket,omitempty"`   // Unix domain socket path (overrides host/port)
 	DoltServerUser     string `json:"dolt_server_user,omitempty"`     // MySQL user (default: root)
 	DoltDatabase       string `json:"dolt_database,omitempty"`        // SQL database name (default: beads)
 	DoltServerTLS      bool   `json:"dolt_server_tls,omitempty"`      // Enable TLS for server connections (required for Hosted Dolt)
@@ -296,6 +297,15 @@ func (c *Config) GetDoltServerPort() int {
 		return c.DoltServerPort
 	}
 	return DefaultDoltServerPort
+}
+
+// GetDoltServerSocket returns the Dolt server Unix domain socket path.
+// Checks BEADS_DOLT_SERVER_SOCKET env var first, then config. Empty means use TCP.
+func (c *Config) GetDoltServerSocket() string {
+	if s := os.Getenv("BEADS_DOLT_SERVER_SOCKET"); s != "" {
+		return s
+	}
+	return c.DoltServerSocket
 }
 
 // GetDoltServerUser returns the Dolt server MySQL user.

--- a/internal/doltserver/socket_integration_test.go
+++ b/internal/doltserver/socket_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration && !windows
+
+package doltserver_test
+
+import (
+	"database/sql"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/testutil/integration"
+)
+
+// TestUnixSocket_ConnectAndQuery starts a Dolt server with --socket,
+// connects via the unix socket DSN, and executes SQL to verify end-to-end
+// unix socket connectivity. Covers the full path from GH#2939.
+func TestUnixSocket_ConnectAndQuery(t *testing.T) {
+	doltBin := integration.RequireDolt(t)
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Initialize dolt database.
+	initCmd := exec.Command(doltBin, "init")
+	initCmd.Dir = doltDir
+	initCmd.Env = append(os.Environ(), "HOME="+tmpDir, "DOLT_ROOT_PATH="+tmpDir)
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt init: %v\n%s", err, out)
+	}
+
+	socketPath := filepath.Join(tmpDir, "dolt.sock")
+
+	// Start dolt sql-server with --socket and no TCP listener.
+	serverCmd := exec.Command(doltBin, "sql-server",
+		"--socket", socketPath,
+		"--loglevel=warning",
+		"-P", "0",
+	)
+	serverCmd.Dir = doltDir
+	serverCmd.Env = append(os.Environ(), "HOME="+tmpDir, "DOLT_ROOT_PATH="+tmpDir)
+	serverCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	logFile := filepath.Join(tmpDir, "dolt-server.log")
+	lf, err := os.Create(logFile)
+	if err != nil {
+		t.Fatalf("create log file: %v", err)
+	}
+	serverCmd.Stdout = lf
+	serverCmd.Stderr = lf
+
+	if err := serverCmd.Start(); err != nil {
+		lf.Close()
+		t.Fatalf("dolt sql-server start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = serverCmd.Process.Signal(syscall.SIGTERM)
+		_ = serverCmd.Wait()
+		lf.Close()
+	})
+
+	// Wait for the socket file to become connectable.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Connect via unix socket DSN.
+	dsn := doltutil.ServerDSN{
+		Socket: socketPath,
+		User:   "root",
+	}.String()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+
+	// Verify connectivity.
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := db.Ping(); err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err := db.Ping(); err != nil {
+		logs, _ := os.ReadFile(logFile)
+		t.Fatalf("db.Ping via socket failed: %v\nServer logs:\n%s", err, logs)
+	}
+
+	// Create, insert, query — prove the socket carries real MySQL traffic.
+	if _, err := db.Exec("CREATE TABLE socket_test (id INT PRIMARY KEY, val VARCHAR(100))"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO socket_test VALUES (1, 'socket-works')"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+
+	var val string
+	if err := db.QueryRow("SELECT val FROM socket_test WHERE id = 1").Scan(&val); err != nil {
+		t.Fatalf("SELECT: %v", err)
+	}
+	if val != "socket-works" {
+		t.Errorf("expected 'socket-works', got %q", val)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -208,6 +208,7 @@ type Config struct {
 	ReadOnly       bool   // Open in read-only mode (skip schema init)
 
 	// Server connection options
+	ServerSocket   string // Unix domain socket path (overrides Host/Port when set)
 	ServerHost     string // Server host (default: 127.0.0.1)
 	ServerPort     int    // Server port (default: 3307)
 	ServerUser     string // MySQL user (default: root)
@@ -847,6 +848,9 @@ func applyConfigDefaults(cfg *Config) {
 	}
 
 	// Server connection defaults (applied in server mode; embedded mode bypasses TCP)
+	if cfg.ServerSocket == "" {
+		cfg.ServerSocket = os.Getenv("BEADS_DOLT_SERVER_SOCKET")
+	}
 	if cfg.ServerHost == "" {
 		// Host resolution: BEADS_DOLT_SERVER_HOST env > default 127.0.0.1.
 		if h := os.Getenv("BEADS_DOLT_SERVER_HOST"); h != "" {
@@ -962,14 +966,27 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	}
 	serverDir := doltserver.ResolveServerDir(resolvedBeadsDir)
 
-	// Fail-fast TCP check before MySQL protocol initialization.
+	// Fail-fast connectivity check before MySQL protocol initialization.
 	// This gives an immediate, clear error if the Dolt server isn't running,
 	// rather than waiting for MySQL driver timeouts.
-	addr := net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
-	conn, dialErr := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	var addr string
+	var conn net.Conn
+	var dialErr error
+	if cfg.ServerSocket != "" {
+		addr = cfg.ServerSocket
+		conn, dialErr = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
+	} else {
+		addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
+		conn, dialErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	}
 	if dialErr != nil {
-		// Auto-start: if enabled and connecting to localhost, start a server
-		if cfg.AutoStart && isLocalHost(cfg.ServerHost) && cfg.Path != "" {
+		// Auto-start: if enabled and connecting locally via TCP, start a server.
+		// Socket mode is excluded — auto-start creates a TCP listener, not a
+		// unix socket, so the DSN would still fail. Socket users are expected
+		// to manage their own server lifecycle.
+		canAutoStart := cfg.AutoStart && cfg.Path != "" &&
+			cfg.ServerSocket == "" && isLocalHost(cfg.ServerHost)
+		if canAutoStart {
 			port, startedByUs, startErr := doltserver.EnsureRunningDetailed(resolvedBeadsDir)
 			if startErr != nil {
 				return nil, fmt.Errorf("Dolt server unreachable at %s and auto-start failed: %w\n\n"+
@@ -1012,10 +1029,18 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			if breaker != nil {
 				breaker.RecordFailure()
 			}
-			hint := "The Dolt server may not be running. Try:\n  bd dolt start"
-			if !cfg.AutoStart && doltserver.IsAutoStartDisabled() {
+			var hint string
+			if cfg.ServerSocket != "" {
+				hint = fmt.Sprintf("The Dolt server is not listening on socket %s.\n"+
+					"Ensure the server is started with --socket:\n"+
+					"  dolt sql-server --socket %s\n"+
+					"Auto-start is not supported in socket mode.",
+					cfg.ServerSocket, cfg.ServerSocket)
+			} else if !cfg.AutoStart && doltserver.IsAutoStartDisabled() {
 				hint = "Dolt server auto-start is disabled (dolt.auto-start: false).\n" +
 					"Start the server manually:\n  bd dolt start"
+			} else {
+				hint = "The Dolt server may not be running. Try:\n  bd dolt start"
 			}
 			return nil, fmt.Errorf("Dolt server unreachable at %s: %w\n\n%s",
 				addr, dialErr, hint)
@@ -1199,6 +1224,7 @@ func isLocalHost(host string) bool {
 // Adds ReadTimeout/WriteTimeout for long-lived connection pools.
 func buildServerDSN(cfg *Config, database string) string {
 	base := doltutil.ServerDSN{
+		Socket:   cfg.ServerSocket,
 		Host:     cfg.ServerHost,
 		Port:     cfg.ServerPort,
 		User:     cfg.ServerUser,

--- a/internal/storage/dolt/store_unit_test.go
+++ b/internal/storage/dolt/store_unit_test.go
@@ -349,6 +349,89 @@ func TestApplyConfigDefaults_ProductionFallback(t *testing.T) {
 	}
 }
 
+// TestApplyConfigDefaults_SocketFromEnv verifies that BEADS_DOLT_SERVER_SOCKET
+// populates ServerSocket when not already set.
+func TestApplyConfigDefaults_SocketFromEnv(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SERVER_SOCKET", "/tmp/test-dolt.sock")
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	cfg := &Config{}
+	applyConfigDefaults(cfg)
+
+	if cfg.ServerSocket != "/tmp/test-dolt.sock" {
+		t.Errorf("expected ServerSocket from env, got %q", cfg.ServerSocket)
+	}
+}
+
+// TestApplyConfigDefaults_SocketExplicitOverridesEnv verifies that an explicit
+// ServerSocket in Config takes precedence over the env var.
+func TestApplyConfigDefaults_SocketExplicitOverridesEnv(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SERVER_SOCKET", "/tmp/env-socket.sock")
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	cfg := &Config{ServerSocket: "/tmp/explicit.sock"}
+	applyConfigDefaults(cfg)
+
+	if cfg.ServerSocket != "/tmp/explicit.sock" {
+		t.Errorf("expected explicit socket to win, got %q", cfg.ServerSocket)
+	}
+}
+
+// TestBuildServerDSN_WithSocket verifies that buildServerDSN produces a unix
+// DSN when ServerSocket is configured.
+func TestBuildServerDSN_WithSocket(t *testing.T) {
+	cfg := &Config{
+		ServerSocket: "/tmp/dolt.sock",
+		ServerUser:   "root",
+		ServerHost:   "127.0.0.1",
+		ServerPort:   3307,
+		Database:     "testdb",
+	}
+	applyConfigDefaults(cfg)
+
+	dsn := buildServerDSN(cfg, cfg.Database)
+
+	parsed, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse DSN: %v\n  DSN: %s", err, dsn)
+	}
+	if parsed.Net != "unix" {
+		t.Errorf("expected Net=unix, got %q", parsed.Net)
+	}
+	if parsed.Addr != "/tmp/dolt.sock" {
+		t.Errorf("expected Addr=/tmp/dolt.sock, got %q", parsed.Addr)
+	}
+	// TLS defaults to false (no TLS requested), same as TCP.
+	if parsed.TLSConfig != "false" {
+		t.Errorf("expected tls=false (default), got %q", parsed.TLSConfig)
+	}
+}
+
+// TestBuildServerDSN_WithoutSocket verifies TCP DSN is unaffected.
+func TestBuildServerDSN_WithoutSocket(t *testing.T) {
+	cfg := &Config{
+		ServerUser: "root",
+		ServerHost: "127.0.0.1",
+		ServerPort: 3307,
+		Database:   "testdb",
+	}
+	applyConfigDefaults(cfg)
+
+	dsn := buildServerDSN(cfg, cfg.Database)
+
+	parsed, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse DSN: %v\n  DSN: %s", err, dsn)
+	}
+	if parsed.Net != "tcp" {
+		t.Errorf("expected Net=tcp, got %q", parsed.Net)
+	}
+}
+
 // TestExecWithLongTimeoutDSNRewrite verifies that execWithLongTimeout's
 // ParseDSN/FormatDSN rewrite produces a valid DSN with readTimeout=5m
 // given a DSN from buildServerDSN.

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -10,6 +10,7 @@ import (
 // ServerDSN holds connection parameters for building a MySQL DSN to a Dolt server.
 // All DSNs built with this struct set parseTime=true and multiStatements=true.
 type ServerDSN struct {
+	Socket   string // Unix domain socket path; when set, Net="unix" and Host/Port are ignored
 	Host     string
 	Port     int
 	User     string
@@ -27,11 +28,18 @@ func (d ServerDSN) String() string {
 		timeout = 5 * time.Second
 	}
 
+	net := "tcp"
+	addr := fmt.Sprintf("%s:%d", d.Host, d.Port)
+	if d.Socket != "" {
+		net = "unix"
+		addr = d.Socket
+	}
+
 	cfg := mysql.Config{
 		User:                 d.User,
 		Passwd:               d.Password,
-		Net:                  "tcp",
-		Addr:                 fmt.Sprintf("%s:%d", d.Host, d.Port),
+		Net:                  net,
+		Addr:                 addr,
 		DBName:               d.Database,
 		ParseTime:            true,
 		MultiStatements:      true,

--- a/internal/storage/doltutil/dsn_test.go
+++ b/internal/storage/doltutil/dsn_test.go
@@ -21,6 +21,66 @@ func TestServerDSN_TLSExplicitlyDisabledByDefault(t *testing.T) {
 	}
 }
 
+func TestServerDSN_UnixSocket(t *testing.T) {
+	dsn := ServerDSN{
+		Socket: "/tmp/dolt.sock",
+		Host:   "should-be-ignored",
+		Port:   9999,
+		User:   "root",
+	}.String()
+
+	if !strings.Contains(dsn, "unix") {
+		t.Errorf("DSN should use unix network; got %q", dsn)
+	}
+	if !strings.Contains(dsn, "/tmp/dolt.sock") {
+		t.Errorf("DSN should contain socket path; got %q", dsn)
+	}
+	// Host:Port should not appear in the DSN address
+	if strings.Contains(dsn, "should-be-ignored") || strings.Contains(dsn, "9999") {
+		t.Errorf("DSN should ignore Host/Port when Socket is set; got %q", dsn)
+	}
+}
+
+func TestServerDSN_UnixSocketHonorsTLS(t *testing.T) {
+	// TLS over unix sockets is valid (defense-in-depth, client certs).
+	// The DSN should respect the TLS setting regardless of transport.
+	dsn := ServerDSN{
+		Socket: "/tmp/dolt.sock",
+		User:   "root",
+		TLS:    true,
+	}.String()
+
+	if !strings.Contains(dsn, "tls=true") {
+		t.Errorf("DSN should honor TLS=true even for unix sockets; got %q", dsn)
+	}
+}
+
+func TestServerDSN_UnixSocketDefaultTLSOff(t *testing.T) {
+	dsn := ServerDSN{
+		Socket: "/tmp/dolt.sock",
+		User:   "root",
+	}.String()
+
+	if !strings.Contains(dsn, "tls=false") {
+		t.Errorf("DSN should default to tls=false for unix sockets; got %q", dsn)
+	}
+}
+
+func TestServerDSN_TCPFallbackWithoutSocket(t *testing.T) {
+	dsn := ServerDSN{
+		Host: "127.0.0.1",
+		Port: 3307,
+		User: "root",
+	}.String()
+
+	if strings.Contains(dsn, "unix") {
+		t.Errorf("DSN should use tcp when Socket is empty; got %q", dsn)
+	}
+	if !strings.Contains(dsn, "tcp") {
+		t.Errorf("DSN should contain tcp network; got %q", dsn)
+	}
+}
+
 func TestServerDSN_TLSEnabledWhenRequested(t *testing.T) {
 	dsn := ServerDSN{
 		Host: "hosted.doltdb.com",


### PR DESCRIPTION
Add ServerSocket config field and BEADS_DOLT_SERVER_SOCKET env var to connect to Dolt via unix sockets instead of TCP. This eliminates port conflicts between concurrent projects and simplifies sandbox integration.

- Wire --server-socket CLI flag through bd init and bd dolt set (dolt.socket)
- Add GetDoltServerSocket() to configfile with env var precedence
- Socket mode disables auto-start with socket-specific error hints
- TLS settings honored regardless of transport
- Integration test: starts dolt sql-server --socket, verifies end-to-end SQL
- Document in README.md server mode table

Closes #2939