### PR TITLE
fix(audit): use atomic write to prevent torn lines under concurrent O_APPEND

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,7 +1,7 @@
 package audit
 
 import (
-	"bufio"
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -112,14 +112,17 @@ func Append(e *Entry) (string, error) {
 	}
 	defer func() { _ = f.Close() }() // Best effort: file close in defer after flush
 
-	bw := bufio.NewWriter(f)
-	enc := json.NewEncoder(bw)
+	// Marshal to a single byte slice and write atomically.
+	// Using bufio.NewWriter could split into multiple write() syscalls,
+	// which interleave under concurrent O_APPEND and corrupt lines.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
 	if err := enc.Encode(e); err != nil {
-		return "", fmt.Errorf("failed to write interactions log entry: %w", err)
+		return "", fmt.Errorf("failed to marshal interactions log entry: %w", err)
 	}
-	if err := bw.Flush(); err != nil {
-		return "", fmt.Errorf("failed to flush interactions log: %w", err)
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		return "", fmt.Errorf("failed to write interactions log entry: %w", err)
 	}
 
 	return e.ID, nil


### PR DESCRIPTION
## Summary

Replaces `bufio.NewWriter` with `bytes.Buffer` + single `f.Write()` call in `audit.Append()`.

### Problem

`bufio.NewWriter` may split a single JSON line into multiple `write()` syscalls. Under concurrent `O_APPEND` writers, these can interleave, producing torn/corrupt lines in the interactions log.

### Fix

Marshal to a `bytes.Buffer` first, then issue a single `f.Write(buf.Bytes())` call. POSIX guarantees atomicity for `O_APPEND` writes up to `PIPE_BUF` (at least 4096 bytes), which comfortably covers individual audit log entries.

### Changes

- `internal/audit/audit.go`: Replace `bufio.NewWriter` → `bytes.Buffer` for atomic write
- Updated error messages to reflect the new write path

Split out from #3255 to keep that PR focused on the Linear round-trip test.