### PR TITLE
fix(go.mod): remove broken replace directive that blocks go install (GH#3303)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -256,5 +256,3 @@ require (
 	gopkg.in/src-d/go-errors.v1 v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/dolthub/go-mysql-server => github.com/maphew/go-mysql-server v0.20.1-0.20260407202153-02d922453d4a

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/dolthub/fslock v0.0.3 h1:iLMpUIvJKMKm92+N1fmHVdxJP5NdyDK5bK7z7Ba2s2U=
 github.com/dolthub/fslock v0.0.3/go.mod h1:QWql+P17oAAMLnL4HGB5tiovtDuAjdDTPbuqx7bYfa0=
 github.com/dolthub/go-icu-regex v0.0.0-20250916051405-78a38d478790 h1:zxMsH7RLiG+dlZ/y0LgJHTV26XoiSJcuWq+em6t6VVc=
 github.com/dolthub/go-icu-regex v0.0.0-20250916051405-78a38d478790/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260325173633-83a7fba2790f h1:w94bo6kTYotpqmnp7NP+wwZAtlzIBJ8Mfu8bqmeSx84=
+github.com/dolthub/go-mysql-server v0.20.1-0.20260325173633-83a7fba2790f/go.mod h1:ZPKRptEeXSk9Ytb9LhB+8tB4BkltxuNYiYDFvIqXD/4=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63 h1:OAsXLAPL4du6tfbBgK0xXHZkOlos63RdKYS3Sgw/dfI=
 github.com/dolthub/gozstd v0.0.0-20240423170813-23a2903bca63/go.mod h1:lV7lUeuDhH5thVGDCKXbatwKy2KW80L4rMT46n+Y2/Q=
 github.com/dolthub/ishell v0.0.0-20240701202509-2b217167d718 h1:lT7hE5k+0nkBdj/1UOSFwjWpNxf+LCApbRHgnCA17XE=
@@ -802,8 +804,6 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/maphew/go-mysql-server v0.20.1-0.20260407202153-02d922453d4a h1:sR0dZuqov/qka6zebQfOrnFzTByBNNwwFy9h+i/ngQU=
-github.com/maphew/go-mysql-server v0.20.1-0.20260407202153-02d922453d4a/go.mod h1:SQws7iFFL5fNxjGbl6xyWNBz3DWTReGBegApANmnwhM=
 github.com/mark3labs/mcp-go v0.34.0 h1:eWy7WBGvhk6EyAAyVzivTCprE52iXJwNtvHV6Cv3bR0=
 github.com/mark3labs/mcp-go v0.34.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=


### PR DESCRIPTION
## Summary

PR #3112's `replace github.com/dolthub/go-mysql-server => github.com/maphew/go-mysql-server ...` directive has never done what it was supposed to. `go install pkg@version` refuses any module whose go.mod contains replace directives. Today, **`go install github.com/gastownhall/beads/cmd/bd@latest` fails for every user** on every platform, because of this directive.

This PR removes it.

Background and full findings in GH#3303.

## Evidence against v1.0.2

\`\`\`
\$ GOPATH=/tmp/gh3303-test GOFLAGS=-tags=gms_pure_go \\
    go install github.com/gastownhall/beads/cmd/bd@latest
go: github.com/gastownhall/beads/cmd/bd@latest (in github.com/gastownhall/beads@v1.0.2):
    The go.mod file for the module providing named packages contains one or
    more replace directives. It must not contain directives that would cause
    it to be interpreted differently than if it were the main module.
\`\`\`

Rule source: \`go help install\`, unchanged since Go 1.16 (golang/go#40276).

## Why this is a strict improvement

- **Before:** \`go install\` broken on Linux, macOS, and Windows with a confusing replace-directive error.
- **After:** \`go install\` works on Linux and macOS (users need \`libicu-dev\` / \`icu4c\`, same as before #3112 ever landed). Windows \`go install\` still fails, but with a clearer ICU-header error — and those users were already in the "broken" column.

Windows \`go install\` remains an open problem. The proposed structural fix is GH#3303 option D: route \`go install\` users through \`CGO_ENABLED=0\` to sidestep ICU (and cgo) entirely, trading embedded-Dolt capability for install simplicity. This PR doesn't depend on that landing; it just removes a no-op that's actively breaking the other platforms.

## What this does NOT change

Every shipped-binary path passes \`-tags gms_pure_go\`, which excludes \`regex_cgo.go\` regardless of whether the GMS source is the fork or upstream:

- goreleaser release builds
- \`scripts/install.sh\`
- \`make build\`
- CI workflows
- \`brew install beads\`
- \`npm install -g @beads/bd\`

All continue to produce ICU-free binaries. The fork's only actual delta from upstream is adding \`!windows\` to a build constraint — a constraint that's already satisfied by \`gms_pure_go\` on every platform we ship.

## Test plan

- [x] \`make build\` succeeds (linux/amd64)
- [x] Resulting binary has no \`libicu\` linkage (\`ldd\` shows only \`libc\` + \`ld-linux\`)
- [x] \`./scripts/test.sh ./internal/types/ ./internal/storage/dolt/\` passes
- [x] \`go mod tidy\` clean (go.sum updated to drop maphew fork entries, restore upstream GMS entries)
- [ ] CI full matrix (ubuntu / macos / windows)
- [ ] After merge: confirm \`go install github.com/gastownhall/beads/cmd/bd@latest\` works on a fresh Linux/macOS box with libicu-dev/icu4c installed

## Related

- Context: GH#3303 (convergence proposal, now including option D)
- Companion: #3304 (codifies the build-tag policy in-tree; unaffected by this PR)
- Introduced the broken directive: #3112