### PR TITLE
feat: make CGO_ENABLED=0 the blessed go install path (GH#3303 option D)

### DIFF
--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -22,7 +22,7 @@ func isEmbeddedMode() bool {
 // available without CGO.
 func newDoltStore(ctx context.Context, cfg *dolt.Config, _ ...embeddeddolt.Option) (storage.DoltStorage, error) {
 	if !cfg.ServerMode {
-		return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
+		return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 	}
 	return dolt.New(ctx, cfg)
 }
@@ -38,7 +38,7 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfig(ctx, beadsDir)
 	}
-	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
+	return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 }
 
 // newReadOnlyStoreFromConfig creates a read-only server-mode storage backend.
@@ -47,5 +47,23 @@ func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.D
 	if err == nil && cfg != nil && cfg.IsDoltServerMode() {
 		return dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
 	}
-	return nil, fmt.Errorf("embedded Dolt requires CGO; use server mode (bd init --server)")
+	return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 }
+
+// nocgoEmbeddedErrMsg guides the user either to server mode (no rebuild
+// needed) or to an embedded-capable install path. It intentionally enumerates
+// the canonical install paths so users don't have to hunt through docs.
+const nocgoEmbeddedErrMsg = `embedded Dolt requires a CGO build, but this bd binary was built with CGO_ENABLED=0.
+
+Two options:
+
+  1. Use server mode (no reinstall needed):
+       bd init --server
+     Requires a running 'dolt sql-server'. See docs/DOLT.md.
+
+  2. Reinstall with embedded-mode support:
+       brew install beads                              # macOS / Linux
+       npm install -g @beads/bd                        # any platform with Node
+       curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+See docs/INSTALLING.md for the full comparison.`

--- a/docs/ICU-POLICY.md
+++ b/docs/ICU-POLICY.md
@@ -76,16 +76,24 @@ Release builds are verified to be ICU-free:
 
 If ICU linkage is detected, the release build fails.
 
-## The Upstream Fork
+## The Upstream Fork (historical)
 
-`go.mod` has a `replace` directive pointing `go-mysql-server` to a fork
-(`maphew/go-mysql-server`) that adds `!windows` to the CGO regex build
-constraint. This ensures `go install` works on Windows without ICU headers.
+Beads used to carry a `replace github.com/dolthub/go-mysql-server => github.com/maphew/go-mysql-server ...` directive in `go.mod`, added in PR #3112 to try to make `go install` work on Windows without ICU headers. It was removed in PR #3306 (see GH#3303) after empirical testing confirmed that **`replace` directives are not honored by `go install pkg@version`** — the mechanism never worked for its stated purpose, and having the directive actively broke `go install` on every platform with a confusing error.
 
-Upstream PR: https://github.com/dolthub/go-mysql-server/pull/3504
-Tracking issue: https://github.com/dolthub/go-mysql-server/issues/3506
+Upstream PR (closed, declined): https://github.com/dolthub/go-mysql-server/pull/3504
+Upstream issue (closed, declined): https://github.com/dolthub/go-mysql-server/issues/3506
 
-Once the upstream PR merges, remove the `replace` directive from `go.mod`.
+The dolthub maintainers have made clear the upstream default will not flip: *"We want our software to work as intended with the default settings. If users want to circumvent certain features with build tags or other build-time or run-time configuration, that's fine. Changing the default is not aligned with what we are actually trying to do."*
+
+### How `go install` is handled now
+
+Two supported modes, documented in [INSTALLING.md](INSTALLING.md):
+
+1. **`CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest`** produces a **server-mode-only** binary. Works on any Go-capable box with no C compiler. Users must run an external `dolt sql-server` and use `bd init --server`.
+
+2. **`CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install ...`** produces an embedded-capable binary. Requires a C compiler but NOT libicu.
+
+No fork, no replace directive, no upstream patch required. The tradeoff is that `go install` users who want embedded mode have to pass an explicit `GOFLAGS`; those who don't care can use the shorter nocgo form.
 
 ## Common Mistakes to Avoid
 
@@ -100,8 +108,12 @@ Once the upstream PR merges, remove the `replace` directive from `go.mod`.
    Neither release builds nor the CI test matrix link ICU; both must not
    depend on ICU being installed.
 
-4. **Confusing CGO with ICU** -- CGO is required (for Dolt). ICU is not.
-   They are independent. `CGO_ENABLED=1` does not imply ICU.
+4. **Confusing CGO with ICU** -- CGO is required for embedded Dolt mode
+   (NBS chunk compression via `gozstd`). ICU is independent. `CGO_ENABLED=1`
+   does not imply ICU linkage as long as `-tags gms_pure_go` is present.
+   beads also supports `CGO_ENABLED=0` builds via nocgo stubs: the binary
+   runs in server-mode only (no embedded Dolt backend), which is the
+   blessed `go install` path for users without a C toolchain.
 
 ## Trade-offs
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -98,11 +98,21 @@ BEADS_INSTALL_RESIGN_MACOS=1 curl -fsSL https://raw.githubusercontent.com/stevey
 | **npm** | JS/Node.js projects | `npm update -g @beads/bd` | Node.js | Convenient if npm is your ecosystem |
 | **bun** | JS/Bun.js projects | `bun install -g --trust @beads/bd` | Bun.js | Convenient if bun is your ecosystem |
 | **Install script** | Quick setup, CI/CD | Re-run script | curl, bash | Good for automation and one-liners |
-| **go install** | Contributors / Go developers | Re-run command | Go 1.24+ | Builds from source, always latest |
+| **go install (nocgo)** | Go developers, simplest install | Re-run command | Go 1.24+ | **Server-mode only** (no embedded Dolt) |
+| **go install (cgo)** | Go developers wanting embedded mode | Re-run command | Go 1.24+, C compiler | Full embedded-Dolt support |
 | **From source** | Contributors only | `git pull && go build` | Go, git | Full control, can modify code |
 | **AUR (Arch)** | Arch Linux users | `yay -Syu` | yay/paru | Community-maintained |
 
 **TL;DR:** Use Homebrew if available. Use npm if you're in a Node.js environment. Use the script for quick one-off installs or CI.
+
+### A note on `go install` capability
+
+`go install` supports **two build modes** that give different capabilities:
+
+- **Nocgo (simplest, default in this doc):** `CGO_ENABLED=0 go install ...`. Works on any machine with a Go toolchain, no C compiler needed. Produces a **server-mode-only** binary — you must run an external `dolt sql-server` and use `bd init --server`. See [DOLT.md](DOLT.md) for server-mode setup.
+- **Cgo (embedded-capable):** `CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install ...`. Requires a C compiler (gcc/clang on Unix, MinGW on Windows). Produces a binary with the default embedded-Dolt backend — `bd init` Just Works.
+
+If you don't have a preference, `brew install beads` / `install.sh` give you the embedded-capable build with no fuss.
 
 ## Platform-Specific Installation
 
@@ -113,16 +123,22 @@ BEADS_INSTALL_RESIGN_MACOS=1 curl -fsSL https://raw.githubusercontent.com/stevey
 brew install beads
 ```
 
-**Via go install**:
+**Via go install** (server-mode only, simplest):
 ```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
+CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest
+# Then: bd init --server   (requires a running dolt sql-server)
+```
+
+**Via go install** (embedded-capable, needs Xcode CLI tools):
+```bash
+CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/cmd/bd@latest
 ```
 
 **From source**:
 ```bash
 git clone https://github.com/steveyegge/beads
 cd beads
-go build -o bd ./cmd/bd
+make build   # uses gms_pure_go tag and CGO
 sudo mv bd /usr/local/bin/
 ```
 
@@ -143,16 +159,22 @@ paru -S beads-git
 
 Thanks to [@v4rgas](https://github.com/v4rgas) for maintaining the AUR package!
 
-**Via go install**:
+**Via go install** (server-mode only, simplest):
 ```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
+CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest
+# Then: bd init --server   (requires a running dolt sql-server)
+```
+
+**Via go install** (embedded-capable, needs gcc):
+```bash
+CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/cmd/bd@latest
 ```
 
 **From source**:
 ```bash
 git clone https://github.com/steveyegge/beads
 cd beads
-go build -o bd ./cmd/bd
+make build   # uses gms_pure_go tag and CGO
 sudo mv bd /usr/local/bin/
 ```
 
@@ -163,9 +185,9 @@ sudo mv bd /usr/local/bin/
 curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
 ```
 
-**Via go install**:
+**Via go install** (server-mode only, simplest):
 ```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
+CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest
 ```
 
 ### Windows 11
@@ -183,28 +205,33 @@ irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
 
 The script installs a prebuilt Windows release if available and verifies the downloaded ZIP checksum against release `checksums.txt`. Go is only required for `go install` or building from source.
 
-**Dolt backend on Windows:** Supported via pure-Go regex backend. Windows builds automatically use Go's stdlib `regexp` instead of ICU regex to avoid CGO/header dependencies. If you need full ICU regex semantics, use Linux/macOS (or WSL) with ICU installed.
-
-**Via go install**:
+**Via go install** (server-mode only, simplest):
 ```pwsh
+$env:CGO_ENABLED=0
+go install github.com/steveyegge/beads/cmd/bd@latest
+# Then: bd init --server   (requires a running dolt sql-server)
+```
+
+This produces a server-mode-only binary with no C compiler requirement — the fastest path to a working `bd` on Windows.
+
+**Via go install** (embedded-capable, needs MinGW):
+```pwsh
+$env:CGO_ENABLED=1
+$env:GOFLAGS="-tags=gms_pure_go"
 go install github.com/steveyegge/beads/cmd/bd@latest
 ```
 
-ICU is **not required** on Windows. The regex backend uses pure Go automatically.
+Requires MinGW-w64 gcc on your PATH. ICU is **not** required — `gms_pure_go` selects Go's stdlib `regexp`.
 
 **From source**:
 ```pwsh
 git clone https://github.com/steveyegge/beads
 cd beads
-make build
-# Or without Make:
-go build -tags gms_pure_go -o bd.exe ./cmd/bd
+make build   # uses gms_pure_go tag and CGO
 Move-Item bd.exe $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\
 ```
 
 The `-tags gms_pure_go` flag tells go-mysql-server to use Go's stdlib regexp instead of ICU.
-Additionally, the vendored go-icu-regex library has a Windows-specific pure-Go implementation
-(`regex_windows.go`) that avoids ICU entirely. No C compiler or ICU libraries are needed.
 
 **Verify installation**:
 ```pwsh
@@ -422,8 +449,8 @@ go list -f {{.Target}} github.com/steveyegge/beads/cmd/bd
 # Add Go bin to PATH (add to ~/.bashrc or ~/.zshrc)
 export PATH="$PATH:$(go env GOPATH)/bin"
 
-# Or reinstall
-go install github.com/steveyegge/beads/cmd/bd@latest
+# Or reinstall (server-mode only, no C compiler needed)
+CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest
 ```
 
 ### `zsh: killed bd` or crashes on macOS
@@ -514,8 +541,14 @@ bun install -g --trust @beads/bd
 
 ### go install
 
+Use whichever mode you installed with originally:
+
 ```bash
-go install github.com/steveyegge/beads/cmd/bd@latest
+# Server-mode only
+CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest
+
+# Embedded-capable
+CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/cmd/bd@latest
 ```
 
 ### From source

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -465,49 +465,59 @@ verify_binary_has_cgo() {
     return 0
 }
 
-# Install using go install (fallback)
+# Install using go install (fallback).
+#
+# Tries CGO_ENABLED=1 first for an embedded-capable binary. If that fails
+# (host lacks C toolchain or transitive Dolt deps' headers), falls back to
+# CGO_ENABLED=0 which yields a server-mode-only binary that still works on
+# any Go-capable box. See docs/ICU-POLICY.md and docs/INSTALLING.md.
 install_with_go() {
     log_info "Installing bd using 'go install'..."
 
-    if CGO_ENABLED=1 GOFLAGS="${GOFLAGS:+$GOFLAGS }-tags=gms_pure_go" go install github.com/gastownhall/beads/cmd/bd@latest; then
-        log_success "bd installed successfully via go install"
+    local gobin bin_dir
+    gobin=$(go env GOBIN 2>/dev/null || true)
+    if [ -n "$gobin" ]; then
+        bin_dir="$gobin"
+    else
+        bin_dir="$(go env GOPATH)/bin"
+    fi
 
-        # Record where we expect the binary to have been installed
-        # Prefer GOBIN if set, otherwise GOPATH/bin
-        local gobin
-        gobin=$(go env GOBIN 2>/dev/null || true)
-        if [ -n "$gobin" ]; then
-            bin_dir="$gobin"
-        else
-            bin_dir="$(go env GOPATH)/bin"
-        fi
+    if CGO_ENABLED=1 GOFLAGS="${GOFLAGS:+$GOFLAGS }-tags=gms_pure_go" go install github.com/gastownhall/beads/cmd/bd@latest; then
+        log_success "bd installed via go install (embedded-capable)"
         LAST_INSTALL_PATH="$bin_dir/bd"
 
         if ! verify_binary_has_cgo "$LAST_INSTALL_PATH" "go install"; then
             return 1
         fi
-
-        # Optional local ad-hoc re-sign for macOS (off by default)
-        resign_for_macos "$bin_dir/bd"
-
-        # Create 'beads' alias symlink
-        create_beads_alias "$bin_dir"
-
-        # Check if GOPATH/bin (or GOBIN) is in PATH
-        if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
-            log_warning "$bin_dir is not in your PATH"
-            echo ""
-            echo "Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
-            echo "  export PATH=\"\$PATH:$bin_dir\""
-            echo ""
-        fi
-
-        return 0
     else
-        log_error "go install failed"
-        print_missing_build_deps_help
-        return 1
+        log_warning "go install with CGO failed; retrying without CGO (server-mode-only binary)"
+        if CGO_ENABLED=0 go install github.com/gastownhall/beads/cmd/bd@latest; then
+            log_success "bd installed via go install (CGO_ENABLED=0, server mode only)"
+            log_warning "This bd cannot use embedded Dolt. Run 'bd init --server' to use an external dolt sql-server, or reinstall with a C toolchain for embedded mode."
+            LAST_INSTALL_PATH="$bin_dir/bd"
+        else
+            log_error "go install failed both with and without CGO"
+            print_missing_build_deps_help
+            return 1
+        fi
     fi
+
+    # Optional local ad-hoc re-sign for macOS (off by default)
+    resign_for_macos "$bin_dir/bd"
+
+    # Create 'beads' alias symlink
+    create_beads_alias "$bin_dir"
+
+    # Check if GOPATH/bin (or GOBIN) is in PATH
+    if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
+        log_warning "$bin_dir is not in your PATH"
+        echo ""
+        echo "Add this to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
+        echo "  export PATH=\"\$PATH:$bin_dir\""
+        echo ""
+    fi
+
+    return 0
 }
 
 # Build from source (last resort)


### PR DESCRIPTION
## Summary

Implements option D from GH#3303: **route \`go install\` users through \`CGO_ENABLED=0\` by default**, trading the embedded Dolt backend for an install path that works on any Go-capable machine without a C toolchain.

This is the structural answer to the ICU/cgo sprinkle problem now that GH#3303 has empirically confirmed:

1. \`replace\` directives don't work for \`go install pkg@version\` (#3306 removes the broken directive)
2. \`gms_pure_go\` strips ICU but gozstd still requires cgo for embedded Dolt
3. dolthub has firmly declined to flip the upstream default

With those three facts in hand, the only remaining way to make \`go install\` Just Work is to not ask for cgo in the first place — which is legitimate because beads maintains a full set of nocgo stubs that fall back to server-mode.

## Changes

### \`cmd/bd/store_factory_nocgo.go\`
Replace the terse \`embedded Dolt requires CGO; use server mode (bd init --server)\` error with a detailed message:

\`\`\`
embedded Dolt requires a CGO build, but this bd binary was built with CGO_ENABLED=0.

Two options:

  1. Use server mode (no reinstall needed):
       bd init --server
     Requires a running 'dolt sql-server'. See docs/DOLT.md.

  2. Reinstall with embedded-mode support:
       brew install beads                              # macOS / Linux
       npm install -g @beads/bd                        # any platform with Node
       curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash

See docs/INSTALLING.md for the full comparison.
\`\`\`

Existing tests that assert \`bd init --server\` substring still pass.

### \`scripts/install.sh\`
\`install_with_go()\` now falls back to \`CGO_ENABLED=0 go install\` when the cgo+tag attempt fails, with a clear warning that the resulting binary is server-mode only. Before this change, a failed cgo install was a dead-end; users had to read docs to figure out why.

### \`docs/INSTALLING.md\`
Document two go-install modes side-by-side in every platform section (nocgo for simplest install, cgo+tag for embedded capability). Add a TL;DR subsection explaining the capability difference so users can pick deliberately.

### \`docs/ICU-POLICY.md\`
Rewrite "The Upstream Fork" section to reflect:
- The replace directive is gone (#3306)
- Dolthub declined to flip the default in #3506 (with quote from the maintainer)
- The new two-mode \`go install\` story

Update the "CGO != ICU" guidance to note that CGO is required **specifically** for embedded Dolt (via gozstd), not for beads as a whole.

## What does NOT change

- \`brew install beads\` — still embedded-capable
- \`npm install -g @beads/bd\` — still embedded-capable
- Install script (prebuilt binary path) — still embedded-capable
- goreleaser release builds — still embedded-capable
- \`make build\` — still embedded-capable

Users following the documented paths get exactly the bd they had before. The only new path is "simplest possible \`go install\`" which trades embedded for zero-C-toolchain.

## Test plan

- [x] \`make build\` succeeds (embedded-capable binary)
- [x] \`CGO_ENABLED=0 go build -tags gms_pure_go\` succeeds (nocgo binary)
- [x] Nocgo binary runs; \`bd init\` hits the new detailed error message with the correct guidance
- [x] Nocgo tests \`TestNocgoNewDoltStore_ErrorSuggestsCorrectFlag\` etc. still pass
- [x] \`install.sh\` syntax-check clean (\`bash -n\`)
- [ ] CI full matrix
- [ ] Manual \`go install\` test on Windows (once a commit with these changes ships to a tag)

## Related

- Tracking: GH#3303
- Depends on: #3306 (removes broken replace directive); independently mergeable but the user story is cleanest if #3306 lands first
- Companion: #3304 (codified sprinkle); orthogonal — both are wanted

## Sequencing suggestion for maintainers

1. Merge #3306 first (removes the directive that currently breaks \`go install\` for everyone)
2. Merge this PR (establishes the blessed nocgo path)
3. Merge #3304 (convergence + CI guard)