### PR TITLE
chore(gitignore): ignore .codex marker and .claude/*.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ pkg/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/*.log
+.claude/*.lock
+
+# Codex CLI - local marker
+.codex
 
 
 # OS


### PR DESCRIPTION
Both are local-tool state files with no business in the repo:

- `.codex` — zero-byte marker dropped by the Codex CLI
- `.claude/scheduled_tasks.lock` — Claude Code session lock

Existing `.claude/` entries already covered `settings.local.json`, `worktrees/`, and `*.log`; extending the pattern to `*.lock` and adding the separate `.codex` entry.

Surfaced while cleaning up after GH#3303's three PRs merged.