### PR TITLE
fix: linear tracker reads yaml-only config keys from config.yaml

### DIFF
--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
@@ -284,7 +285,23 @@ func (t *Tracker) PrimaryClient() *Client {
 }
 
 // getConfig reads a config value from storage, falling back to env var.
+// For yaml-only keys (e.g. linear.api_key), reads from config.yaml first
+// to match the behavior of cmd/bd/linear.go:getLinearConfig().
 func (t *Tracker) getConfig(ctx context.Context, key, envVar string) (string, error) {
+	// Secret keys are stored in config.yaml, not the Dolt database,
+	// to avoid leaking secrets when pushing to remotes.
+	if config.IsYamlOnlyKey(key) {
+		if val := config.GetString(key); val != "" {
+			return val, nil
+		}
+		if envVar != "" {
+			if envVal := os.Getenv(envVar); envVal != "" {
+				return envVal, nil
+			}
+		}
+		return "", nil
+	}
+
 	val, err := t.store.GetConfig(ctx, key)
 	if err == nil && val != "" {
 		return val, nil


### PR DESCRIPTION
## Summary
- `bd linear sync --pull` failed to find the Linear API key set via `bd config set linear.api_key`, because `Tracker.getConfig()` in `internal/linear/tracker.go` only checked the Dolt database and environment variables
- The API key is a yaml-only key (written to `config.yaml` to avoid leaking secrets in Dolt remotes), but the tracker never consulted `config.yaml`
- Added a `config.IsYamlOnlyKey()` check at the top of `Tracker.getConfig()` that reads from `config.GetString()` first, mirroring the existing logic in `cmd/bd/linear.go:getLinearConfig()`

## Test plan
- [x] `bd linear sync --pull --dry-run --verbose` now finds the API key and lists issues (previously failed with "Linear API key not configured")
- [x] `go test ./internal/linear/... -short -count=1 -tags gms_pure_go` passes
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)