### PR TITLE
fix(fetch): run GC after failed DOLT_FETCH to prevent tmp_pack_* accumulation

### DIFF
--- a/internal/storage/versioncontrolops/remotes.go
+++ b/internal/storage/versioncontrolops/remotes.go
@@ -36,8 +36,17 @@ func RemoveRemote(ctx context.Context, db DBConn, name string) error {
 }
 
 // Fetch fetches refs from a remote without merging.
+//
+// On failure, a best-effort GC is run to clean up any orphaned tmp_pack_*
+// files that DOLT_FETCH may have left in the git-remote-cache. These files
+// accumulate unboundedly across repeated failures and can consume hundreds of
+// gigabytes over time.
 func Fetch(ctx context.Context, db DBConn, peer string) error {
 	if _, err := db.ExecContext(ctx, "CALL DOLT_FETCH(?)", peer); err != nil {
+		// Best-effort: ignore GC errors — the original fetch error is what matters.
+		// DoltGC requires a non-transactional connection; if db is a tx it will
+		// fail silently here, which is acceptable.
+		_ = DoltGC(ctx, db)
 		return fmt.Errorf("fetch from %s: %w", peer, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Cherry-picks the valuable GC-on-fetch-failure fix from #3308 (authored by @athosmartins).

When `DOLT_FETCH` fails (network error, timeout, auth), Dolt leaves orphaned `tmp_pack_*` files in `.dolt/git-remote-cache/`. These accumulate unboundedly across repeated failures and are never cleaned up automatically. Observed impact on @athosmartins's machine: **194 GB** of `tmp_pack_*` debris after months of failed federation syncs.

Fix: call `DoltGC` best-effort after a failed `DOLT_FETCH` so orphaned pack temporaries are reclaimed before the error propagates. `DoltGC` requires a non-transactional connection; if `db` is a transaction the GC fails silently, which is fine — the original fetch error is still returned correctly.

## Why a separate PR?

#3308 bundled two unrelated changes plus a lint regression:
- The GC fix (this PR) - clearly valuable
- A migration re-adding the `crystallizes` column, which migration 012 explicitly dropped as Gas Town coupling (`don't belong in the beads schema`)
- Accidental deletion of a working `#nosec G304` directive in `cmd/bd/rules.go:99`, which broke lint CI

Rather than ask @athosmartins to rebase/split, cherry-picking the fix here lets us ship the disk-exhaustion fix quickly while closing #3308 with thanks.

Full attribution preserved via `Co-Authored-By`.

## Test plan

- [x] `go build -tags gms_pure_go ./...` clean
- [ ] Manual: run `bd federation sync` against an unreachable peer, confirm `.dolt/git-remote-cache/` stays small after repeated failures
- [ ] Manual: confirm `bd federation sync` against a reachable peer still works (GC only runs on error path)

Closes bd-fst. Supersedes #3308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)