### PR TITLE
fix(dolt): auto-recover from corrupt manifest on startup (GH#3290)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -711,102 +711,128 @@ func Start(beadsDir string) (*State, error) {
 		return nil, fmt.Errorf("configuring dolt identity: %w", err)
 	}
 
-	// Ensure dolt database directory is initialized
-	if err := ensureDoltInit(doltDir); err != nil {
-		return nil, fmt.Errorf("initializing dolt database: %w", err)
-	}
-
-	// Rotate the log if it has grown past the configured ceiling. This is a
-	// startup-only check — dolt owns the fd directly once launched, so we can
-	// only intervene between runs. See logrotate.go for the caveat discussion.
-	maybeRotateLog(beadsDir)
-
-	// Open log file
-	logFile, err := os.OpenFile(logPath(beadsDir), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec // G304: logPath derives from user-configured beadsDir
-	if err != nil {
-		return nil, fmt.Errorf("opening log file: %w", err)
-	}
-
-	// Resolve the port to use. Explicit ports (env/config) go through
-	// reclaimPort for conflict detection. Port 0 means ephemeral — allocate
-	// a fresh port from the OS with retry for TOCTOU races.
-	actualPort := cfg.Port
-	explicitPort := actualPort > 0
-
-	if explicitPort {
-		// Explicit port: check for conflicts and adopt existing servers.
-		adoptPID, reclaimErr := reclaimPort(cfg.Host, actualPort, beadsDir)
-		if reclaimErr != nil {
-			_ = logFile.Close()
-			return nil, fmt.Errorf("cannot start dolt server on port %d: %w", actualPort, reclaimErr)
+	// Launch dolt sql-server, retrying once after an automatic corrupt-
+	// manifest recovery (GH#3290).
+	var (
+		pid               int
+		actualPort        int
+		lastErr           error
+		attempts          int
+		recoveryAttempted bool
+	)
+startupLoop:
+	for {
+		// Ensure dolt database directory is initialized
+		if err := ensureDoltInit(doltDir); err != nil {
+			return nil, fmt.Errorf("initializing dolt database: %w", err)
 		}
-		if adoptPID > 0 {
-			_ = logFile.Close()
-			_ = os.WriteFile(pidPath(beadsDir), []byte(strconv.Itoa(adoptPID)), 0600)
-			_ = writePortFile(beadsDir, actualPort)
-			return &State{Running: true, PID: adoptPID, Port: actualPort, DataDir: doltDir}, nil
+
+		// Rotate the log if it has grown past the configured ceiling. This is a
+		// startup-only check — dolt owns the fd directly once launched, so we can
+		// only intervene between runs. See logrotate.go for the caveat discussion.
+		maybeRotateLog(beadsDir)
+
+		// Open log file
+		logFile, err := os.OpenFile(logPath(beadsDir), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec // G304: logPath derives from user-configured beadsDir
+		if err != nil {
+			return nil, fmt.Errorf("opening log file: %w", err)
 		}
-	}
 
-	// Start dolt sql-server, with retry loop for ephemeral port TOCTOU.
-	var pid int
-	var lastErr error
-	attempts := 1
-	if !explicitPort {
-		attempts = maxEphemeralPortAttempts
-	}
+		// Resolve the port to use. Explicit ports (env/config) go through
+		// reclaimPort for conflict detection. Port 0 means ephemeral — allocate
+		// a fresh port from the OS with retry for TOCTOU races.
+		actualPort = cfg.Port
+		explicitPort := actualPort > 0
 
-	for i := range attempts {
-		if !explicitPort {
-			p, allocErr := allocateEphemeralPort(cfg.Host)
-			if allocErr != nil {
-				lastErr = allocErr
-				continue
+		if explicitPort {
+			// Explicit port: check for conflicts and adopt existing servers.
+			adoptPID, reclaimErr := reclaimPort(cfg.Host, actualPort, beadsDir)
+			if reclaimErr != nil {
+				_ = logFile.Close()
+				return nil, fmt.Errorf("cannot start dolt server on port %d: %w", actualPort, reclaimErr)
 			}
-			actualPort = p
-		}
-
-		cmd := exec.Command(doltBin, buildDoltServerArgs(cfg.Host, actualPort)...) //nolint:gosec // doltBin is resolved from PATH, not user input
-		cmd.Dir = doltDir
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
-		cmd.Stdin = nil
-		cmd.SysProcAttr = procAttrDetached()
-		cmd.Env = os.Environ()
-
-		if startErr := cmd.Start(); startErr != nil {
-			lastErr = startErr
-			if !explicitPort {
-				continue // retry with a new ephemeral port
+			if adoptPID > 0 {
+				_ = logFile.Close()
+				_ = os.WriteFile(pidPath(beadsDir), []byte(strconv.Itoa(adoptPID)), 0600)
+				_ = writePortFile(beadsDir, actualPort)
+				return &State{Running: true, PID: adoptPID, Port: actualPort, DataDir: doltDir}, nil
 			}
-			_ = logFile.Close()
-			return nil, fmt.Errorf("starting dolt sql-server: %w", startErr)
 		}
 
-		pid = cmd.Process.Pid
-		_ = cmd.Process.Release()
-
-		// Quick check: did the process exit immediately (bind failure)?
-		// Give it a moment to fail on port bind before proceeding.
-		time.Sleep(200 * time.Millisecond)
-		if !isProcessAlive(pid) {
-			lastErr = fmt.Errorf("dolt sql-server exited immediately on port %d (attempt %d/%d)", actualPort, i+1, attempts)
-			pid = 0
-			if !explicitPort {
-				continue
-			}
-			_ = logFile.Close()
-			return nil, lastErr
-		}
-
+		// Start dolt sql-server, with retry loop for ephemeral port TOCTOU.
+		pid = 0
 		lastErr = nil
-		break
-	}
-	_ = logFile.Close()
+		attempts = 1
+		if !explicitPort {
+			attempts = maxEphemeralPortAttempts
+		}
 
-	if lastErr != nil {
-		return nil, fmt.Errorf("failed to start dolt server after %d attempts: %w\nCheck logs: %s",
-			attempts, lastErr, logPath(beadsDir))
+		for i := range attempts {
+			if !explicitPort {
+				p, allocErr := allocateEphemeralPort(cfg.Host)
+				if allocErr != nil {
+					lastErr = allocErr
+					continue
+				}
+				actualPort = p
+			}
+
+			cmd := exec.Command(doltBin, buildDoltServerArgs(cfg.Host, actualPort)...) //nolint:gosec // doltBin is resolved from PATH, not user input
+			cmd.Dir = doltDir
+			cmd.Stdout = logFile
+			cmd.Stderr = logFile
+			cmd.Stdin = nil
+			cmd.SysProcAttr = procAttrDetached()
+			cmd.Env = os.Environ()
+
+			if startErr := cmd.Start(); startErr != nil {
+				lastErr = startErr
+				if !explicitPort {
+					continue // retry with a new ephemeral port
+				}
+				break
+			}
+
+			pid = cmd.Process.Pid
+			_ = cmd.Process.Release()
+
+			// Quick check: did the process exit immediately (bind failure)?
+			// Give it a moment to fail on port bind before proceeding.
+			time.Sleep(200 * time.Millisecond)
+			if !isProcessAlive(pid) {
+				lastErr = fmt.Errorf("dolt sql-server exited immediately on port %d (attempt %d/%d)", actualPort, i+1, attempts)
+				pid = 0
+				if !explicitPort {
+					continue
+				}
+				break
+			}
+
+			lastErr = nil
+			break
+		}
+		_ = logFile.Close()
+
+		if lastErr != nil {
+			// GH#3290: detect unclean-shutdown manifest corruption and auto-
+			// recover when the journal is empty (no data to lose). Recovery
+			// backs up the corrupt .dolt/ with a timestamped suffix and
+			// reinitializes in place, then the outer loop retries startup.
+			if !recoveryAttempted {
+				recoveryAttempted = true
+				if backups, recErr := recoverCorruptManifest(beadsDir, doltDir); recErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: corrupt manifest recovery failed: %v\n", recErr)
+				} else if len(backups) > 0 {
+					for _, b := range backups {
+						fmt.Fprintf(os.Stderr, "Info: backed up corrupt dolt database to %s and reinitialized (GH#3290)\n", filepath.Base(b))
+					}
+					continue startupLoop
+				}
+			}
+			return nil, fmt.Errorf("failed to start dolt server after %d attempts: %w\nCheck logs: %s",
+				attempts, lastErr, logPath(beadsDir))
+		}
+		break
 	}
 
 	// Write PID and port files

--- a/internal/doltserver/manifest_recovery.go
+++ b/internal/doltserver/manifest_recovery.go
@@ -1,0 +1,193 @@
+package doltserver
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// corruptManifestSignature is the error emitted by dolt sql-server when its
+// manifest references a root hash that was never flushed to disk (typically
+// after an unclean shutdown). See GH#3290.
+const corruptManifestSignature = "root hash doesn't exist"
+
+// logTailBytes is the size of the tail scanned when looking for the corrupt
+// manifest signature in the dolt server log. 64 KiB comfortably covers the
+// last few startup attempts without loading huge log files into memory.
+const logTailBytes = 64 * 1024
+
+// logHasCorruptManifestError returns true if the tail of the dolt server log
+// contains the corrupt-manifest signature.
+func logHasCorruptManifestError(logPath string) (bool, error) {
+	f, err := os.Open(logPath) //nolint:gosec // G304: path derived from beadsDir
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return false, err
+	}
+
+	start := int64(0)
+	if info.Size() > logTailBytes {
+		start = info.Size() - logTailBytes
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return false, err
+	}
+
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(string(buf), corruptManifestSignature), nil
+}
+
+// findCorruptNomsDirs walks doltDir and returns the paths of every
+// .dolt/noms/ directory whose contents look like a corrupt manifest with no
+// recoverable data: journal.idx is empty (or missing), every journal file is
+// at most a bare header, and oldgen/ holds no chunk data.
+//
+// The "no data to lose" guard is intentionally conservative: recovery only
+// fires when we can prove there is nothing the user would want to keep.
+func findCorruptNomsDirs(doltDir string) ([]string, error) {
+	var matches []string
+	err := filepath.Walk(doltDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // best-effort scan; skip unreadable subtrees
+		}
+		if !info.IsDir() || filepath.Base(path) != "noms" {
+			return nil
+		}
+		if filepath.Base(filepath.Dir(path)) != ".dolt" {
+			return nil
+		}
+		corrupt, checkErr := nomsDirLooksCorrupt(path)
+		if checkErr == nil && corrupt {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return matches, nil
+}
+
+// nomsDirLooksCorrupt returns true if the .dolt/noms directory has a
+// manifest but no recoverable chunk data. See findCorruptNomsDirs for the
+// exact conditions.
+func nomsDirLooksCorrupt(nomsDir string) (bool, error) {
+	manifestPath := filepath.Join(nomsDir, "manifest")
+	if _, err := os.Stat(manifestPath); err != nil {
+		return false, err // no manifest = not the shape we're recovering
+	}
+
+	if info, err := os.Stat(filepath.Join(nomsDir, "journal.idx")); err == nil {
+		if info.Size() > 0 {
+			return false, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	entries, err := os.ReadDir(nomsDir)
+	if err != nil {
+		return false, err
+	}
+	for _, e := range entries {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		// Dolt journal files have a 32-char name (all 'v' until rotated).
+		name := e.Name()
+		if len(name) == 32 && isLowerAlphaName(name) {
+			info, err := e.Info()
+			if err != nil {
+				return false, err
+			}
+			// Journal header is 40 bytes; anything larger may contain data.
+			if info.Size() > 64 {
+				return false, nil
+			}
+		}
+	}
+
+	oldgen := filepath.Join(nomsDir, "oldgen")
+	if oldgenEntries, err := os.ReadDir(oldgen); err == nil {
+		for _, e := range oldgenEntries {
+			if e.Type().IsRegular() && e.Name() != "manifest" && e.Name() != "LOCK" {
+				if info, infoErr := e.Info(); infoErr == nil && info.Size() > 0 {
+					return false, nil
+				}
+			}
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func isLowerAlphaName(s string) bool {
+	for _, r := range s {
+		if r < 'a' || r > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// recoverCorruptManifest detects the GH#3290 corrupt-manifest condition by
+// scanning the dolt server log for the "root hash doesn't exist" signature
+// and confirming that every affected database has no recoverable data. If
+// both conditions hold, each corrupt .dolt/ directory is backed up with a
+// timestamped suffix and the database is reinitialized in place.
+//
+// Returns the list of backup paths created. If the preconditions do not
+// hold, returns (nil, nil) so the caller can surface the original start
+// failure.
+func recoverCorruptManifest(beadsDir, doltDir string) ([]string, error) {
+	hasErr, err := logHasCorruptManifestError(logPath(beadsDir))
+	if err != nil || !hasErr {
+		return nil, err
+	}
+
+	nomsDirs, err := findCorruptNomsDirs(doltDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(nomsDirs) == 0 {
+		return nil, nil
+	}
+
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	var backups []string
+	for _, nomsDir := range nomsDirs {
+		dotDolt := filepath.Dir(nomsDir) // .../X/.dolt
+		dbDir := filepath.Dir(dotDolt)   // .../X
+		backupPath := dotDolt + "." + ts + ".corrupt.backup"
+
+		if err := os.Rename(dotDolt, backupPath); err != nil {
+			return backups, fmt.Errorf("backing up corrupt dolt database at %s: %w", dotDolt, err)
+		}
+		backups = append(backups, backupPath)
+
+		if err := ensureDoltInit(dbDir); err != nil {
+			// Best-effort restore so the user is no worse off than before.
+			_ = os.RemoveAll(dotDolt)
+			_ = os.Rename(backupPath, dotDolt)
+			return backups[:len(backups)-1], fmt.Errorf("reinitializing dolt database at %s: %w", dbDir, err)
+		}
+	}
+	return backups, nil
+}

--- a/internal/doltserver/manifest_recovery_test.go
+++ b/internal/doltserver/manifest_recovery_test.go
@@ -1,0 +1,143 @@
+package doltserver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLogHasCorruptManifestError(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "dolt-server.log")
+
+	// Missing log file is not an error.
+	got, err := logHasCorruptManifestError(logPath)
+	if err != nil || got {
+		t.Fatalf("missing log: got (%v, %v), want (false, nil)", got, err)
+	}
+
+	// Log without the signature.
+	if err := os.WriteFile(logPath, []byte("starting server\nlistening on :3306\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = logHasCorruptManifestError(logPath)
+	if err != nil || got {
+		t.Fatalf("clean log: got (%v, %v), want (false, nil)", got, err)
+	}
+
+	// Log with the signature.
+	content := "starting\n" + strings.Repeat("noise\n", 100) +
+		"error: root hash doesn't exist: abc123\nexit\n"
+	if err := os.WriteFile(logPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err = logHasCorruptManifestError(logPath)
+	if err != nil || !got {
+		t.Fatalf("corrupt log: got (%v, %v), want (true, nil)", got, err)
+	}
+}
+
+// writeNomsDir creates a .dolt/noms/ shape under root and returns its path.
+// If journalSize >= 0, a 32-char journal file is written with that size.
+// If idxSize >= 0, a journal.idx file is written with that size.
+// If oldgenChunkSize > 0, a chunk file is created in oldgen/.
+func writeNomsDir(t *testing.T, root string, journalSize, idxSize, oldgenChunkSize int64) string {
+	t.Helper()
+	nomsDir := filepath.Join(root, ".dolt", "noms")
+	if err := os.MkdirAll(filepath.Join(nomsDir, "oldgen"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nomsDir, "manifest"), []byte("manifest-stub"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if idxSize >= 0 {
+		writeSized(t, filepath.Join(nomsDir, "journal.idx"), idxSize)
+	}
+	if journalSize >= 0 {
+		name := strings.Repeat("v", 32)
+		writeSized(t, filepath.Join(nomsDir, name), journalSize)
+	}
+	if oldgenChunkSize > 0 {
+		writeSized(t, filepath.Join(nomsDir, "oldgen", "chunk1"), oldgenChunkSize)
+	}
+	return nomsDir
+}
+
+func writeSized(t *testing.T, path string, size int64) {
+	t.Helper()
+	f, err := os.Create(path) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if size > 0 {
+		if err := f.Truncate(size); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestNomsDirLooksCorrupt(t *testing.T) {
+	tests := []struct {
+		name            string
+		journalSize     int64
+		idxSize         int64
+		oldgenChunkSize int64
+		want            bool
+	}{
+		{"empty journal + empty idx + empty oldgen", 40, 0, 0, true},
+		{"no journal file, empty idx, empty oldgen", -1, 0, 0, true},
+		{"journal has data", 8192, 0, 0, false},
+		{"idx has data", 40, 4096, 0, false},
+		{"oldgen has chunk", 40, 0, 2048, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			nomsDir := writeNomsDir(t, dir, tc.journalSize, tc.idxSize, tc.oldgenChunkSize)
+			got, err := nomsDirLooksCorrupt(nomsDir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindCorruptNomsDirs(t *testing.T) {
+	root := t.TempDir()
+	doltDir := filepath.Join(root, "dolt")
+
+	// Corrupt database
+	writeNomsDir(t, filepath.Join(doltDir, "bd"), 40, 0, 0)
+	// Healthy database (has oldgen data)
+	writeNomsDir(t, filepath.Join(doltDir, "other"), 40, 0, 2048)
+
+	matches, err := findCorruptNomsDirs(doltDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1: %v", len(matches), matches)
+	}
+	if !strings.Contains(matches[0], filepath.Join("bd", ".dolt", "noms")) {
+		t.Errorf("unexpected match: %s", matches[0])
+	}
+}
+
+func TestRecoverCorruptManifest_NoLogSignatureNoop(t *testing.T) {
+	beadsDir := t.TempDir()
+	doltDir := filepath.Join(beadsDir, "dolt")
+	writeNomsDir(t, filepath.Join(doltDir, "bd"), 40, 0, 0)
+
+	backups, err := recoverCorruptManifest(beadsDir, doltDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 0 {
+		t.Errorf("expected no backups without log signature, got %v", backups)
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #3290. On unclean shutdown, the dolt manifest can reference a root hash that was never flushed, causing every subsequent startup to exit immediately with `root hash doesn't exist: <hash>`. The existing stale-LOCK cleanup can't help because the corruption is in the manifest itself.
- After the dolt server fails to start, scan the tail of the dolt log for that signature. If found AND every affected `.dolt/noms/` has no recoverable data (empty `journal.idx`, journal file at bare header size, empty `oldgen/`), back up the `.dolt/` directory with a timestamped `.corrupt.backup` suffix and reinitialize in place, then retry startup once.
- The empty-journal guard is deliberately conservative: recovery only fires when we can prove there is nothing to lose. Each cycle produces a distinct timestamped backup, so repeated corruption events preserve forensic evidence rather than overwriting it.

## Scope note

Detection is string-matched on `root hash doesn't exist` — the exact signature from #3290. I attempted to reproduce the issue locally by planting a manifest with a bogus-but-valid-format root hash and a 40-byte-header-only journal. On my current dolt version the same underlying corruption surfaced differently: the sql-server started fine and the failure appeared later at query time as `cannot resolve default branch head for database 'X': 'main'`. That path bypasses this hook.

That means this PR covers @azanar's reported signature but does not auto-recover every manifestation of the same underlying corruption on every dolt version. A follow-up could widen detection or add a second hook in the SQL-client failure path if we gather more field reports — keeping this PR narrow to avoid false-positive wipes.

## Test plan

- [x] `go test -tags gms_pure_go ./internal/doltserver/` — all pass including new `TestLogHasCorruptManifestError`, `TestNomsDirLooksCorrupt`, `TestFindCorruptNomsDirs`, `TestRecoverCorruptManifest_NoLogSignatureNoop`
- [x] `go test -tags gms_pure_go -short ./...` — no new failures; one pre-existing worktree/HEAD failure in `TestInstallHooksBeads_WorktreeAccess` reproduces on `main` and is unrelated
- [x] Manual: planted GH#3290-shape corruption (empty journal.idx, 40-byte journal, bogus manifest root) in a fresh `bd init --server` workspace. Confirmed the journal-state detection logic is correct via unit tests; confirmed via log inspection that on my current dolt version the failure surfaces via a different error string (see Scope note) so the full end-to-end recovery path could not be exercised in this environment.

Reported by @azanar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)