### PR TITLE
fix(linear): harden push against data clobbering

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -191,9 +191,10 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 
 	ctx := rootCtx
 	teamIDs := getLinearTeamIDs(ctx, cliTeams)
+	willPush := push || (!pull && !push)
 
 	// Require explicit --team for push when multiple teams are configured.
-	if push && len(teamIDs) > 1 && len(cliTeams) == 0 {
+	if willPush && len(teamIDs) > 1 && len(cliTeams) == 0 {
 		FatalError("push requires explicit --team flag when multiple teams are configured\n" +
 			"Use: bd linear sync --push --team <TEAM_ID>")
 	}
@@ -204,6 +205,11 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	if err := lt.Init(ctx, store); err != nil {
 		FatalError("initializing Linear tracker: %v", err)
 	}
+	if willPush {
+		if err := lt.ValidatePushStateMappings(ctx); err != nil {
+			FatalError("%v", err)
+		}
+	}
 
 	// Create the sync engine
 	engine := tracker.NewEngine(lt, store, actor)
@@ -212,9 +218,6 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 
 	// Set up Linear-specific pull hooks
 	engine.PullHooks = buildLinearPullHooks(ctx)
-
-	// Set up Linear-specific push hooks
-	engine.PushHooks = buildLinearPushHooks(ctx, lt)
 
 	// Build sync options from CLI flags
 	opts := tracker.SyncOptions{
@@ -239,6 +242,10 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	if err := applySelectiveSyncFlags(cmd, &opts, push); err != nil {
 		FatalError("%v", err)
 	}
+	allowProjectCreates := opts.ParentID != "" || len(opts.IssueIDs) > 0
+
+	// Set up Linear-specific push hooks
+	engine.PushHooks = buildLinearPushHooks(ctx, lt, allowProjectCreates)
 
 	// Map conflict resolution
 	if preferLocal {
@@ -336,18 +343,18 @@ func buildLinearPullHooks(ctx context.Context) *tracker.PullHooks {
 }
 
 // buildLinearPushHooks creates PushHooks for Linear-specific push behavior.
-func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker) *tracker.PushHooks {
+func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectCreates bool) *tracker.PushHooks {
+	config := lt.MappingConfig()
 	return &tracker.PushHooks{
 		FormatDescription: func(issue *types.Issue) string {
 			return linear.BuildLinearDescription(issue)
 		},
 		ContentEqual: func(local *types.Issue, remote *tracker.TrackerIssue) bool {
-			localComparable := linear.NormalizeIssueForLinearHash(local)
-			remoteConv := lt.FieldMapper().IssueToBeads(remote)
-			if remoteConv == nil || remoteConv.Issue == nil {
+			remoteIssue, ok := remote.Raw.(*linear.Issue)
+			if !ok || remoteIssue == nil {
 				return false
 			}
-			return localComparable.ComputeContentHash() == remoteConv.Issue.ComputeContentHash()
+			return linear.PushFieldsEqual(local, remoteIssue, config)
 		},
 		BuildStateCache: func(ctx context.Context) (interface{}, error) {
 			return linear.BuildStateCacheFromTracker(ctx, lt)
@@ -361,6 +368,14 @@ func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker) *tracker.Push
 			return id, id != ""
 		},
 		ShouldPush: func(issue *types.Issue) bool {
+			if projectID, _ := store.GetConfig(ctx, "linear.project_id"); projectID != "" {
+				if issue.ExternalRef == nil || strings.TrimSpace(*issue.ExternalRef) == "" {
+					if !allowProjectCreates {
+						return false
+					}
+				}
+			}
+
 			// Apply push prefix filtering if configured
 			pushPrefix, _ := store.GetConfig(ctx, "linear.push_prefix")
 			if pushPrefix == "" {

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -191,7 +191,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 
 	ctx := rootCtx
 	teamIDs := getLinearTeamIDs(ctx, cliTeams)
-	willPush := push || (!pull && !push)
+	willPush := push || !pull
 
 	// Require explicit --team for push when multiple teams are configured.
 	if willPush && len(teamIDs) > 1 && len(cliTeams) == 0 {
@@ -351,10 +351,14 @@ func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectC
 		},
 		ContentEqual: func(local *types.Issue, remote *tracker.TrackerIssue) bool {
 			remoteIssue, ok := remote.Raw.(*linear.Issue)
-			if !ok || remoteIssue == nil {
+			if ok && remoteIssue != nil {
+				return linear.PushFieldsEqual(local, remoteIssue, config)
+			}
+			remoteConv := lt.FieldMapper().IssueToBeads(remote)
+			if remoteConv == nil || remoteConv.Issue == nil {
 				return false
 			}
-			return linear.PushFieldsEqual(local, remoteIssue, config)
+			return linear.PushFieldsEqualToBeads(local, remoteConv.Issue)
 		},
 		BuildStateCache: func(ctx context.Context) (interface{}, error) {
 			return linear.BuildStateCacheFromTracker(ctx, lt)

--- a/cmd/bd/sync_push_pull.go
+++ b/cmd/bd/sync_push_pull.go
@@ -395,17 +395,23 @@ func runLinearPush(cmd *cobra.Command, args []string) {
 
 	ctx := rootCtx
 	teamIDs := getLinearTeamIDs(ctx, nil)
+	if len(teamIDs) > 1 {
+		FatalError("linear push does not support multiple configured teams\nUse: bd linear sync --push --team <TEAM_ID>")
+	}
 
 	lt := &linear.Tracker{}
 	lt.SetTeamIDs(teamIDs)
 	if err := lt.Init(ctx, store); err != nil {
 		FatalError("initializing Linear tracker: %v", err)
 	}
+	if err := lt.ValidatePushStateMappings(ctx); err != nil {
+		FatalError("%v", err)
+	}
 
 	engine := tracker.NewEngine(lt, store, actor)
 	engine.OnMessage = func(msg string) { fmt.Println("  " + msg) }
 	engine.OnWarning = func(msg string) { fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
-	engine.PushHooks = buildLinearPushHooks(ctx, lt)
+	engine.PushHooks = buildLinearPushHooks(ctx, lt, len(args) > 0)
 
 	result, err := engine.Sync(ctx, tracker.SyncOptions{
 		Push:             true,

--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -16,6 +16,8 @@ type IDGenerationOptions struct {
 	UsedIDs    map[string]bool // Pre-populated set to avoid collisions (e.g., DB IDs)
 }
 
+const missingExplicitStateMapMessage = "linear.state_map is not configured.\nRun 'bd linear link' to configure status mapping first."
+
 // BuildLinearDescription formats a Beads issue for Linear's description field.
 // This mirrors the payload used during push to keep hash comparisons consistent.
 func BuildLinearDescription(issue *types.Issue) string {
@@ -329,7 +331,7 @@ func ResolveStateIDForBeadsStatus(cache *StateCache, status types.Status, config
 		return "", fmt.Errorf("no workflow states found")
 	}
 	if config == nil || len(config.ExplicitStateMap) == 0 {
-		return "", fmt.Errorf("linear.state_map is not configured.\nRun 'bd linear link' to configure status mapping first.")
+		return "", fmt.Errorf("%s", missingExplicitStateMapMessage)
 	}
 
 	var nameMatches []State
@@ -421,6 +423,24 @@ func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) b
 		return false
 	}
 	return StateToBeadsStatus(remote.State, config) == local.Status
+}
+
+// PushFieldsEqualToBeads is a fallback comparator for cases where Linear's raw
+// payload is unavailable and only the normalized beads form remains.
+func PushFieldsEqualToBeads(local, remote *types.Issue) bool {
+	if local == nil || remote == nil {
+		return false
+	}
+	if local.Title != remote.Title {
+		return false
+	}
+	if BuildLinearDescription(local) != remote.Description {
+		return false
+	}
+	if local.Priority != remote.Priority {
+		return false
+	}
+	return local.Status == remote.Status
 }
 
 // LabelToIssueType infers issue type from label names.

--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -130,6 +130,11 @@ type MappingConfig struct {
 	// Key is lowercase state type or name, value is Beads status string.
 	StateMap map[string]string
 
+	// ExplicitStateMap contains only user-configured linear.state_map.* entries.
+	// Defaults are intentionally excluded so push can distinguish safe explicit
+	// mappings from type-based fallbacks.
+	ExplicitStateMap map[string]string
+
 	// LabelTypeMap maps Linear label names to Beads issue types.
 	// Key is lowercase label name, value is Beads issue type.
 	LabelTypeMap map[string]string
@@ -159,6 +164,7 @@ func DefaultMappingConfig() *MappingConfig {
 			"completed": "closed",
 			"canceled":  "closed",
 		},
+		ExplicitStateMap: make(map[string]string),
 		// Label patterns for issue type inference
 		LabelTypeMap: map[string]string{
 			"bug":         "bug",
@@ -220,6 +226,7 @@ func LoadMappingConfig(loader ConfigLoader) *MappingConfig {
 		if strings.HasPrefix(key, "linear.state_map.") {
 			stateKey := strings.ToLower(strings.TrimPrefix(key, "linear.state_map."))
 			config.StateMap[stateKey] = value
+			config.ExplicitStateMap[stateKey] = value
 		}
 
 		// Parse label-to-type mappings: linear.label_type_map.<label_name>
@@ -301,6 +308,69 @@ func StateToBeadsStatus(state *State, config *MappingConfig) types.Status {
 	return types.StatusOpen
 }
 
+func stateMapMatchesStatus(mapped string, status types.Status) bool {
+	normalizedMapped := strings.ToLower(strings.TrimSpace(mapped))
+	normalizedStatus := strings.ToLower(strings.TrimSpace(string(status)))
+	if normalizedMapped == normalizedStatus {
+		return true
+	}
+	if status.IsValid() && ParseBeadsStatus(mapped) == status {
+		return true
+	}
+	return false
+}
+
+// ResolveStateIDForBeadsStatus returns the unique Linear workflow state ID to
+// use when pushing the given beads status. Push only trusts explicit
+// linear.state_map.* entries; defaults are safe for pull but too ambiguous for
+// mutation.
+func ResolveStateIDForBeadsStatus(cache *StateCache, status types.Status, config *MappingConfig) (string, error) {
+	if cache == nil || len(cache.States) == 0 {
+		return "", fmt.Errorf("no workflow states found")
+	}
+	if config == nil || len(config.ExplicitStateMap) == 0 {
+		return "", fmt.Errorf("linear.state_map is not configured.\nRun 'bd linear link' to configure status mapping first.")
+	}
+
+	var nameMatches []State
+	for _, state := range cache.States {
+		mapped, ok := config.ExplicitStateMap[strings.ToLower(strings.TrimSpace(state.Name))]
+		if ok && stateMapMatchesStatus(mapped, status) {
+			nameMatches = append(nameMatches, state)
+		}
+	}
+	if len(nameMatches) == 1 {
+		return nameMatches[0].ID, nil
+	}
+	if len(nameMatches) > 1 {
+		names := make([]string, 0, len(nameMatches))
+		for _, state := range nameMatches {
+			names = append(names, state.Name)
+		}
+		return "", fmt.Errorf("linear.state_map maps beads status %q to multiple Linear states: %s", status, strings.Join(names, ", "))
+	}
+
+	var typeMatches []State
+	for _, state := range cache.States {
+		mapped, ok := config.ExplicitStateMap[strings.ToLower(strings.TrimSpace(state.Type))]
+		if ok && stateMapMatchesStatus(mapped, status) {
+			typeMatches = append(typeMatches, state)
+		}
+	}
+	if len(typeMatches) == 1 {
+		return typeMatches[0].ID, nil
+	}
+	if len(typeMatches) > 1 {
+		names := make([]string, 0, len(typeMatches))
+		for _, state := range typeMatches {
+			names = append(names, state.Name)
+		}
+		return "", fmt.Errorf("linear.state_map type fallback is ambiguous for beads status %q across Linear states: %s", status, strings.Join(names, ", "))
+	}
+
+	return "", fmt.Errorf("linear.state_map has no configured Linear state for beads status %q", status)
+}
+
 // ParseBeadsStatus converts a status string to types.Status.
 func ParseBeadsStatus(s string) types.Status {
 	switch strings.ToLower(s) {
@@ -332,6 +402,25 @@ func StatusToLinearStateType(status types.Status) string {
 	default:
 		return "unstarted"
 	}
+}
+
+// PushFieldsEqual compares only the fields that a Linear push can actually
+// mutate. This avoids repeated updates caused by local-only fields such as
+// issue type, metadata, or labels that are preserved elsewhere.
+func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) bool {
+	if local == nil || remote == nil {
+		return false
+	}
+	if local.Title != remote.Title {
+		return false
+	}
+	if BuildLinearDescription(local) != remote.Description {
+		return false
+	}
+	if PriorityToLinear(local.Priority, config) != remote.Priority {
+		return false
+	}
+	return StateToBeadsStatus(remote.State, config) == local.Status
 }
 
 // LabelToIssueType infers issue type from label names.

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -1,6 +1,7 @@
 package linear
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -614,7 +615,7 @@ func TestResolveStateIDForBeadsStatusRequiresExplicitMappings(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing explicit state map to fail")
 	}
-	if err.Error() != "linear.state_map is not configured.\nRun 'bd linear link' to configure status mapping first." {
+	if !strings.Contains(err.Error(), "linear.state_map is not configured") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -633,7 +634,7 @@ func TestResolveStateIDForBeadsStatusRejectsAmbiguousTypeFallback(t *testing.T) 
 	if err == nil {
 		t.Fatal("expected ambiguous completed mapping to fail")
 	}
-	if got := err.Error(); got != "linear.state_map type fallback is ambiguous for beads status \"closed\" across Linear states: Done, Monitoring" {
+	if got := err.Error(); !strings.Contains(got, "type fallback is ambiguous") || !strings.Contains(got, "Done, Monitoring") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -677,5 +678,29 @@ func TestPushFieldsEqualIgnoresLocalOnlyDifferences(t *testing.T) {
 
 	if !PushFieldsEqual(local, remote, config) {
 		t.Fatal("expected push fields to compare equal despite local-only issue type and labels")
+	}
+}
+
+func TestPushFieldsEqualToBeads(t *testing.T) {
+	local := &types.Issue{
+		Title:       "Ship the fix",
+		Description: "Main body",
+		Notes:       "Local-only notes",
+		Status:      types.StatusInProgress,
+		Priority:    1,
+		IssueType:   types.TypeFeature,
+		Labels:      []string{"customer-visible"},
+	}
+	remote := &types.Issue{
+		Title:       "Ship the fix",
+		Description: "Main body\n\n## Notes\nLocal-only notes",
+		Status:      types.StatusInProgress,
+		Priority:    1,
+		IssueType:   types.TypeTask,
+		Labels:      []string{"ignored"},
+	}
+
+	if !PushFieldsEqualToBeads(local, remote) {
+		t.Fatal("expected beads-form fallback comparison to ignore local-only fields")
 	}
 }

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -533,6 +533,9 @@ func TestLoadMappingConfig(t *testing.T) {
 	if config.StateMap["custom"] != "in_progress" {
 		t.Errorf("StateMap[custom] = %s, want in_progress", config.StateMap["custom"])
 	}
+	if config.ExplicitStateMap["custom"] != "in_progress" {
+		t.Errorf("ExplicitStateMap[custom] = %s, want in_progress", config.ExplicitStateMap["custom"])
+	}
 
 	// Check custom label type mapping
 	if config.LabelTypeMap["story"] != "feature" {
@@ -597,5 +600,82 @@ func TestBuildLinearDescription(t *testing.T) {
 				t.Errorf("BuildLinearDescription() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveStateIDForBeadsStatusRequiresExplicitMappings(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-1", Name: "Todo", Type: "unstarted"},
+		},
+	}
+
+	_, err := ResolveStateIDForBeadsStatus(cache, types.StatusOpen, DefaultMappingConfig())
+	if err == nil {
+		t.Fatal("expected missing explicit state map to fail")
+	}
+	if err.Error() != "linear.state_map is not configured.\nRun 'bd linear link' to configure status mapping first." {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusRejectsAmbiguousTypeFallback(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-1", Name: "Done", Type: "completed"},
+			{ID: "state-2", Name: "Monitoring", Type: "completed"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["completed"] = "closed"
+
+	_, err := ResolveStateIDForBeadsStatus(cache, types.StatusClosed, config)
+	if err == nil {
+		t.Fatal("expected ambiguous completed mapping to fail")
+	}
+	if got := err.Error(); got != "linear.state_map type fallback is ambiguous for beads status \"closed\" across Linear states: Done, Monitoring" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusPrefersExplicitStateName(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-1", Name: "Done", Type: "completed"},
+			{ID: "state-2", Name: "Monitoring", Type: "completed"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["done"] = "closed"
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusClosed, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus() error = %v", err)
+	}
+	if got != "state-1" {
+		t.Fatalf("ResolveStateIDForBeadsStatus() = %q, want state-1", got)
+	}
+}
+
+func TestPushFieldsEqualIgnoresLocalOnlyDifferences(t *testing.T) {
+	config := DefaultMappingConfig()
+	local := &types.Issue{
+		Title:       "Ship the fix",
+		Description: "Main body",
+		Notes:       "Local-only notes",
+		Status:      types.StatusInProgress,
+		Priority:    1,
+		IssueType:   types.TypeFeature,
+		Labels:      []string{"customer-visible"},
+	}
+	remote := &Issue{
+		Title:       "Ship the fix",
+		Description: "Main body\n\n## Notes\nLocal-only notes",
+		Priority:    2,
+		State:       &State{ID: "state-3", Name: "In Progress", Type: "started"},
+	}
+
+	if !PushFieldsEqual(local, remote, config) {
+		t.Fatal("expected push fields to compare equal despite local-only issue type and labels")
 	}
 }

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/beads/internal/config"
@@ -203,6 +204,11 @@ func (t *Tracker) FieldMapper() tracker.FieldMapper {
 	return &linearFieldMapper{config: t.config}
 }
 
+// MappingConfig returns the resolved Linear mapping configuration.
+func (t *Tracker) MappingConfig() *MappingConfig {
+	return t.config
+}
+
 func (t *Tracker) IsExternalRef(ref string) bool {
 	return IsLinearExternalRef(ref)
 }
@@ -221,26 +227,44 @@ func (t *Tracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
 	return fmt.Sprintf("https://linear.app/issue/%s", issue.Identifier)
 }
 
+// ValidatePushStateMappings ensures push has explicit, non-ambiguous status
+// mappings for every configured team before any mutation occurs.
+func (t *Tracker) ValidatePushStateMappings(ctx context.Context) error {
+	if t.config == nil || len(t.config.ExplicitStateMap) == 0 {
+		return fmt.Errorf("linear.state_map is not configured.\nRun 'bd linear link' to configure status mapping first.")
+	}
+	for _, teamID := range t.teamIDs {
+		client := t.clients[teamID]
+		if client == nil {
+			continue
+		}
+		cache, err := BuildStateCache(ctx, client)
+		if err != nil {
+			return fmt.Errorf("fetching workflow states for team %s: %w", teamID, err)
+		}
+		for _, status := range []types.Status{types.StatusOpen, types.StatusInProgress, types.StatusBlocked, types.StatusClosed} {
+			if _, err := ResolveStateIDForBeadsStatus(cache, status, t.config); err != nil {
+				// Only fail for statuses the config explicitly tries to map or when
+				// mappings are entirely absent. Missing blocked mappings are allowed
+				// until a blocked issue is actually pushed.
+				if status == types.StatusBlocked && strings.Contains(err.Error(), "has no configured Linear state") {
+					continue
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // findStateID looks up the Linear workflow state ID for a beads status
 // using the given per-team client.
 func (t *Tracker) findStateID(ctx context.Context, client *Client, status types.Status) (string, error) {
-	targetType := StatusToLinearStateType(status)
-
-	states, err := client.GetTeamStates(ctx)
+	cache, err := BuildStateCache(ctx, client)
 	if err != nil {
 		return "", err
 	}
-
-	for _, s := range states {
-		if s.Type == targetType {
-			return s.ID, nil
-		}
-	}
-
-	if len(states) > 0 {
-		return states[0].ID, nil
-	}
-	return "", fmt.Errorf("no workflow states found")
+	return ResolveStateIDForBeadsStatus(cache, status, t.config)
 }
 
 // primaryClient returns the client for the first configured team.

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -231,7 +231,7 @@ func (t *Tracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
 // mappings for every configured team before any mutation occurs.
 func (t *Tracker) ValidatePushStateMappings(ctx context.Context) error {
 	if t.config == nil || len(t.config.ExplicitStateMap) == 0 {
-		return fmt.Errorf("linear.state_map is not configured.\nRun 'bd linear link' to configure status mapping first.")
+		return fmt.Errorf("%s", missingExplicitStateMapMessage)
 	}
 	for _, teamID := range t.teamIDs {
 		client := t.clients[teamID]

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -1665,6 +1665,51 @@ func TestEnginePushWithParentFilterBasic(t *testing.T) {
 	}
 }
 
+func TestEnginePushWithParentFilterDoesNotUpdateOrphanExternalIssues(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	parent := &types.Issue{ID: "bd-par-orphan", Title: "Parent", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2}
+	child := &types.Issue{ID: "bd-child-orphan", Title: "Canceled upstream title", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2}
+	for _, issue := range []*types.Issue{parent, child} {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", issue.ID, err)
+		}
+	}
+	dep := &types.Dependency{IssueID: "bd-child-orphan", DependsOnID: "bd-par-orphan", Type: types.DepParentChild}
+	if err := store.AddDependency(ctx, dep, "test-actor"); err != nil {
+		t.Fatalf("AddDependency error: %v", err)
+	}
+
+	// Simulate an orphan external issue with an overlapping title. Current push
+	// must ignore it because no local Linear external_ref claims ownership.
+	tk := newMockTracker("linear")
+	tk.issues = []TrackerIssue{
+		{
+			ID:         "linear-1",
+			Identifier: "LIN-1",
+			Title:      "Canceled upstream title",
+			UpdatedAt:  time.Now().UTC(),
+		},
+	}
+
+	engine := NewEngine(tk, store, "test-actor")
+	result, err := engine.Sync(ctx, SyncOptions{Push: true, ParentID: "bd-par-orphan"})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tk.updated) != 0 {
+		t.Fatalf("updated %d external issues, want 0", len(tk.updated))
+	}
+	if len(tk.created) != 2 {
+		t.Fatalf("created %d issues, want 2 (parent + child)", len(tk.created))
+	}
+}
+
 func TestEnginePushWithParentFilterDeep(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)


### PR DESCRIPTION
Fixes #3289
Fixes #3309
Fixes #3252
Fixes #3253

## Summary

Hardens the Linear push path so `bd linear sync` stops making unsafe guesses that can clobber Linear state.

This patch does four things:

- requires explicit `linear.state_map.*` configuration before push
- rejects ambiguous type-based state resolution when multiple Linear workflow states share the same type
- narrows push dedup to the fields we actually mutate in Linear, so local-only differences do not trigger endless updates
- prevents unscoped project-filtered push from creating every unlinked local bead unless the user also scopes the local side with `--parent` or `--issues`
- adds a regression test proving parent-filtered push does not update orphan external issues with overlapping titles when Beads has not claimed them via `external_ref`

## Intended Issues

This PR is intended to address the Linear sync corruption cluster around:

- #3289
- #3309
- #3252
- #3253

More specifically:

- #3289: push now refuses to proceed without explicit `linear.state_map.*` config, and it errors on ambiguous state resolution instead of silently picking the first matching Linear state
- #3309: push dedup now compares only fields we actually mutate in Linear, which removes one major cause of repeated whole-database updates and remote clobbering
- #3252: when `linear.project_id` is configured, unscoped push no longer creates every unlinked local bead by default; new creates now require explicit local scoping via `--parent` or `--issues`
- #3253: this PR adds a regression test for the current ownership invariant: parent-filtered push must not update orphan external issues that Beads has not explicitly claimed via `external_ref`, even when titles overlap

## Not In Scope

This PR does not add a persisted last-sync watermark for Linear sync.

## Why

The current push behavior is too eager and too broad:

- status push can silently map to the wrong Linear state when `state_map` is missing or ambiguous
- repeated updates can happen when only non-pushable local fields differ from Linear
- `linear.project_id` filters pull, but push can still create unrelated local issues unless the user manually scopes the operation
- the ownership boundary for updates needs an explicit regression test so stale reports of orphan updates can be confidently closed

Those behaviors create real data-clobbering risk in the Linear sync path.

## Impact

Users now get a hard error instead of a silent status rewrite when Linear state mapping is unsafe.

Project-scoped push becomes conservative by default: already-linked issues can still update, but new issue creation requires explicit local scoping.

The PR also makes the ownership rule test-backed: push updates require a Beads-managed external link, not just a title overlap.

## Validation

- `GOCACHE=/tmp/beads-gocache GOMODCACHE=/tmp/beads-gomodcache go test ./internal/linear -count=1`
- `CGO_ENABLED=1 GOCACHE=/tmp/beads-gocache GOMODCACHE=/tmp/beads-gomodcache go test -tags gms_pure_go -run '^$' ./cmd/bd`
- `GOCACHE=/tmp/beads-gocache GOMODCACHE=/tmp/beads-gomodcache go test ./internal/tracker -run '^TestEnginePushWithParentFilterDoesNotUpdateOrphanExternalIssues$' -count=1`
