### PR TITLE
fix(admin,dolt): allow admin + dolt show/status in embedded mode

### DIFF
--- a/cmd/bd/admin.go
+++ b/cmd/bd/admin.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -10,12 +8,6 @@ var adminCmd = &cobra.Command{
 	Use:     "admin",
 	GroupID: "advanced",
 	Short:   "Administrative commands for database maintenance",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if isEmbeddedMode() {
-			return fmt.Errorf("'bd admin' is not yet supported in embedded mode")
-		}
-		return nil
-	},
 	Long: `Administrative commands for beads database maintenance.
 
 These commands are for advanced users and should be used carefully:

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -75,10 +75,6 @@ var doltShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show current Dolt configuration with connection status",
 	Run: func(cmd *cobra.Command, args []string) {
-		if isEmbeddedMode() {
-			fmt.Fprintln(os.Stderr, "Error: 'bd dolt show' is not supported in embedded mode (no Dolt server)")
-			os.Exit(1)
-		}
 		showDoltConfig(true)
 	},
 }
@@ -445,21 +441,23 @@ on the next bd command unless auto-start is disabled.`,
 
 var doltStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Show Dolt server status",
-	Long: `Show the status of the dolt sql-server for the current project.
+	Short: "Show Dolt engine status",
+	Long: `Show the status of the Dolt engine for the current project.
 
-For beads-managed (local) servers, displays PID, port, and data directory
-from the local PID file. For externally-hosted servers (dolt_mode=server
-with a remote dolt_server_host), pings the configured endpoint via SQL and
-reports reachability, server version, and database.`,
+In embedded mode, reports that the Dolt engine runs in-process and shows
+the on-disk data directory. For beads-managed (local) servers, displays
+PID, port, and data directory from the local PID file. For externally-
+hosted servers (dolt_mode=server with a remote dolt_server_host), pings
+the configured endpoint via SQL and reports reachability, server version,
+and database.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if isEmbeddedMode() {
-			fmt.Fprintln(os.Stderr, "Error: 'bd dolt status' is not supported in embedded mode (no Dolt server)")
-			os.Exit(1)
-		}
 		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
 			FatalErrorWithHint(activeWorkspaceNotFoundError(), diagHint())
+		}
+		if isEmbeddedMode() {
+			showEmbeddedDoltStatus(beadsDir)
+			return
 		}
 
 		// For externally-hosted Dolt servers (non-local host with
@@ -594,6 +592,33 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 	}
 	if connErr != nil {
 		fmt.Printf("  Error:    %v\n", connErr)
+	}
+}
+
+// showEmbeddedDoltStatus reports Dolt engine status when running in
+// embedded mode. There is no separate server process; the engine runs
+// in-process and data lives at .beads/embeddeddolt/.
+func showEmbeddedDoltStatus(beadsDir string) {
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	dataDirExists := false
+	if info, err := os.Stat(dataDir); err == nil && info.IsDir() {
+		dataDirExists = true
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]interface{}{
+			"mode":            "embedded",
+			"running":         false,
+			"data_dir":        dataDir,
+			"data_dir_exists": dataDirExists,
+		})
+		return
+	}
+
+	fmt.Println("Dolt engine: embedded (in-process, no server)")
+	fmt.Printf("  Data: %s\n", dataDir)
+	if !dataDirExists {
+		fmt.Printf("  %s\n", ui.RenderWarn("Data directory does not exist — run 'bd init' to create it"))
 	}
 }
 
@@ -1192,11 +1217,13 @@ func showDoltConfig(testConnection bool) {
 	}
 
 	backend := cfg.GetBackend()
+	embedded := isEmbeddedMode()
 
 	// Resolve actual server port for connection testing
 	showHost := cfg.GetDoltServerHost()
 	dsCfg := doltserver.DefaultConfig(beadsDir)
 	showPort := dsCfg.Port
+	embeddedDataDir := filepath.Join(beadsDir, "embeddeddolt")
 
 	if jsonOutput {
 		result := map[string]interface{}{
@@ -1204,12 +1231,17 @@ func showDoltConfig(testConnection bool) {
 		}
 		if backend == configfile.BackendDolt {
 			result["database"] = cfg.GetDoltDatabase()
-			result["host"] = showHost
-			result["port"] = showPort
-			result["user"] = cfg.GetDoltServerUser()
-			result["shared_server"] = doltserver.IsSharedServerMode()
-			if testConnection {
-				result["connection_ok"] = testServerConnection(showHost, showPort)
+			result["embedded"] = embedded
+			if embedded {
+				result["data_dir"] = embeddedDataDir
+			} else {
+				result["host"] = showHost
+				result["port"] = showPort
+				result["user"] = cfg.GetDoltServerUser()
+				result["shared_server"] = doltserver.IsSharedServerMode()
+				if testConnection {
+					result["connection_ok"] = testServerConnection(showHost, showPort)
+				}
 			}
 		}
 		outputJSON(result)
@@ -1224,31 +1256,40 @@ func showDoltConfig(testConnection bool) {
 	fmt.Println("Dolt Configuration")
 	fmt.Println("==================")
 	fmt.Printf("  Database: %s\n", cfg.GetDoltDatabase())
-	fmt.Printf("  Host:     %s\n", showHost)
-	fmt.Printf("  Port:     %d\n", showPort)
-	fmt.Printf("  User:     %s\n", cfg.GetDoltServerUser())
-	if doltserver.IsSharedServerMode() {
-		fmt.Println("  Mode:     shared server")
-		if sharedDir, err := doltserver.SharedServerDir(); err == nil {
-			fmt.Printf("  Server:   %s\n", sharedDir)
-		}
+	if embedded {
+		fmt.Println("  Mode:     embedded (in-process Dolt engine)")
+		fmt.Printf("  Data:     %s\n", embeddedDataDir)
 	} else {
-		fmt.Println("  Mode:     per-project")
-	}
-
-	if testConnection {
-		fmt.Println()
-		if testServerConnection(showHost, showPort) {
-			fmt.Printf("  %s\n", ui.RenderPass("✓ Server connection OK"))
+		fmt.Printf("  Host:     %s\n", showHost)
+		fmt.Printf("  Port:     %d\n", showPort)
+		fmt.Printf("  User:     %s\n", cfg.GetDoltServerUser())
+		if doltserver.IsSharedServerMode() {
+			fmt.Println("  Mode:     shared server")
+			if sharedDir, err := doltserver.SharedServerDir(); err == nil {
+				fmt.Printf("  Server:   %s\n", sharedDir)
+			}
 		} else {
-			fmt.Printf("  %s\n", ui.RenderWarn("✗ Server not reachable"))
+			fmt.Println("  Mode:     per-project")
+		}
+
+		if testConnection {
+			fmt.Println()
+			if testServerConnection(showHost, showPort) {
+				fmt.Printf("  %s\n", ui.RenderPass("✓ Server connection OK"))
+			} else {
+				fmt.Printf("  %s\n", ui.RenderWarn("✗ Server not reachable"))
+			}
 		}
 	}
 
 	// Show remotes from both surfaces
-	doltDir := doltserver.ResolveDoltDir(beadsDir)
 	dbName := cfg.GetDoltDatabase()
-	dbDir := filepath.Join(doltDir, dbName)
+	var dbDir string
+	if embedded {
+		dbDir = filepath.Join(embeddedDataDir, dbName)
+	} else {
+		dbDir = filepath.Join(doltserver.ResolveDoltDir(beadsDir), dbName)
+	}
 	fmt.Println("\nRemotes:")
 	ctx := context.Background()
 	st := getStore()

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -607,8 +607,11 @@ func showEmbeddedDoltStatus(beadsDir string) {
 
 	if jsonOutput {
 		outputJSON(map[string]interface{}{
-			"mode":            "embedded",
-			"running":         false,
+			"mode": "embedded",
+			// Embedded mode has an active in-process engine, but no
+			// separate server process. Use a server-specific field so
+			// clients do not read running=false as "Dolt is unavailable".
+			"server_running":  false,
 			"data_dir":        dataDir,
 			"data_dir_exists": dataDirExists,
 		})

--- a/cmd/bd/dolt_embedded_test.go
+++ b/cmd/bd/dolt_embedded_test.go
@@ -50,15 +50,16 @@ func TestEmbeddedDolt(t *testing.T) {
 
 	// ===== Server-only commands must fail in embedded mode =====
 
+	// status and show are intentionally NOT in this list: they report
+	// embedded-mode state rather than erroring out. See the
+	// embedded_status/embedded_show subtests below.
 	serverOnlyCmds := []struct {
 		name string
 		args []string
 	}{
 		{"start", []string{"start"}},
 		{"stop", []string{"stop"}},
-		{"status", []string{"status"}},
 		{"test", []string{"test"}},
-		{"show", []string{"show"}},
 		{"set", []string{"set", "host", "127.0.0.1"}},
 		{"killall", []string{"killall"}},
 		{"clean-databases", []string{"clean-databases"}},
@@ -72,6 +73,22 @@ func TestEmbeddedDolt(t *testing.T) {
 			}
 		})
 	}
+
+	// ===== Embedded-mode inspection commands succeed with embedded-mode output =====
+
+	t.Run("embedded_status", func(t *testing.T) {
+		out := bdDolt(t, bd, dir, "status")
+		if !strings.Contains(out, "embedded") {
+			t.Errorf("expected embedded-mode status output to mention 'embedded': %s", out)
+		}
+	})
+
+	t.Run("embedded_show", func(t *testing.T) {
+		out := bdDolt(t, bd, dir, "show")
+		if !strings.Contains(out, "Mode:") || !strings.Contains(out, "embedded") {
+			t.Errorf("expected embedded-mode show output to contain 'Mode:' and 'embedded': %s", out)
+		}
+	})
 
 	// ===== Working commands =====
 

--- a/cmd/bd/dolt_embedded_test.go
+++ b/cmd/bd/dolt_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -80,6 +81,23 @@ func TestEmbeddedDolt(t *testing.T) {
 		out := bdDolt(t, bd, dir, "status")
 		if !strings.Contains(out, "embedded") {
 			t.Errorf("expected embedded-mode status output to mention 'embedded': %s", out)
+		}
+	})
+
+	t.Run("embedded_status_json", func(t *testing.T) {
+		out := bdDolt(t, bd, dir, "status", "--json")
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(out), &result); err != nil {
+			t.Fatalf("status --json returned invalid JSON: %v\n%s", err, out)
+		}
+		if result["mode"] != "embedded" {
+			t.Errorf("mode = %v, want embedded", result["mode"])
+		}
+		if result["server_running"] != false {
+			t.Errorf("server_running = %v, want false", result["server_running"])
+		}
+		if _, ok := result["running"]; ok {
+			t.Errorf("running should be omitted for embedded mode; use server_running instead: %v", result["running"])
 		}
 	})
 

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -79,8 +79,10 @@ func TestDoltShowConfigDefaultMode(t *testing.T) {
 		if !containsAny(output, "testdb", "Database") {
 			t.Errorf("output should show database name: %s", output)
 		}
-		if !containsAny(output, "Host", "Port", "User") {
-			t.Errorf("output should show server connection info: %s", output)
+		// Default mode is embedded; show embedded engine info instead of
+		// server connection details.
+		if !containsAny(output, "embedded", "Data") {
+			t.Errorf("output should show embedded mode info: %s", output)
 		}
 	})
 
@@ -105,6 +107,9 @@ func TestDoltShowConfigDefaultMode(t *testing.T) {
 		}
 		if result["database"] != "testdb" {
 			t.Errorf("expected database 'testdb', got %v", result["database"])
+		}
+		if embedded, ok := result["embedded"].(bool); !ok || !embedded {
+			t.Errorf("expected embedded=true in JSON output, got %v", result["embedded"])
 		}
 		// mode field should no longer be present
 		if _, ok := result["mode"]; ok {


### PR DESCRIPTION
## Summary

Unblocks `bd admin cleanup/compact/reset` and `bd dolt show/status` in embedded mode. None of these commands need a running Dolt sql-server:

- **`bd admin reset`** only removes files on disk.
- **`bd admin cleanup`** uses generic `SearchIssues` + `deleteBatch`.
- **`bd admin compact`** uses `CheckEligibility`, `GetTier{1,2}Candidates`, and `ApplyCompaction`, all implemented on `EmbeddedDoltStore` (see `internal/storage/embeddeddolt/store.go`).
- **`bd dolt show`** now reports embedded mode clearly: `Mode: embedded (in-process Dolt engine)`, plus the `.beads/embeddeddolt/` data directory, and still lists configured remotes.
- **`bd dolt status`** now reports `Dolt engine: embedded (in-process, no server)` with the data directory, instead of erroring out with "no Dolt server".

Server-only `bd dolt` commands (`set`, `test`, `start`, `stop`, `killall`, `clean-databases`) remain blocked — they genuinely require a sql-server process.

## Origin of the original `bd admin` block

The `PersistentPreRunE` that rejected embedded mode was introduced in commit [`a49f32ad`](https://github.com/gastownhall/beads/commit/a49f32ad) ("/cmd/bd: skip admin, update repo"), landed via PR #2839 during the `EmbeddedDoltStore` integration. It was a defensive placeholder added while the embedded store was being stabilized — the commit message reads "skip admin" and the PR's review summary describes it as a guardrail "preventing unsupported `bd admin` maintenance commands from running in embedded mode." No specific failure or bug was cited; the follow-up to revisit it once the embedded store stabilized simply never landed.

The same placeholder pattern ("not yet supported in embedded mode") shows up on `bd dolt show`/`status` for the same reason.

## Why this matters

The embedded store has been the default for a while now and these maintenance paths all exercise methods that are fully implemented and tested on `EmbeddedDoltStore`. The block forces embedded-mode users to drop to raw SQL against a running dolt-sql-server to do routine Dolt maintenance, which bypasses the bd audit trail. The `bd dolt show/status` errors are an active footgun: in embedded-mode projects with an auto-wired `git+ssh://` Dolt remote, `bd dolt push` works and data lands on the remote, but `bd dolt status` says "no Dolt server" — leading users to think their sync is broken when it isn't.

## Related issues

- Closes #3313 — `bd admin cleanup`/`bd admin compact` "not yet supported in embedded mode"
- Also addresses the follow-up raised in [#3313 (comment)](https://github.com/gastownhall/beads/issues/3313) extending the fix to `bd dolt show`/`bd dolt status`
- Precedent: #2900 — `bd doctor unsupported in embedded mode` (closed; same "not yet supported in embedded mode" pattern, resolved separately)
- Adjacent: #3218 — `bd dolt status`/`show` misreport in server mode with an external Dolt server. Different root cause (probe logic doesn't check external servers), but the same two commands. This PR only touches the embedded-mode path; #3218's server-mode misreport remains open and is unaffected.

## Test plan

- [x] `make build` succeeds
- [x] `go test -tags gms_pure_go ./cmd/bd/ -run "Dolt|Admin|Cleanup|Compact|Reset"` passes
- [x] Fresh embedded-mode repo: `bd admin cleanup --dry-run`, `bd admin compact --stats`, `bd admin compact --analyze --dry-run`, `bd admin reset` all work
- [x] Real embedded-mode repo with a `git+ssh://` Dolt remote: `bd dolt show` lists the remote correctly and reports embedded mode; `bd dolt status` reports in-process engine and data dir
- [x] Server-only commands (`bd dolt test`/`start`/`killall`) still correctly reject embedded mode
- [x] Updated `TestDoltShowConfigDefaultMode` to reflect that the "default mode" case is now embedded (its Host/Port/User expectations were stale after the embedded-by-default transition)