### PR TITLE
fix(autopush): bound auto-push and throttle failed attempts

### DIFF
--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -137,9 +137,17 @@ func maybeAutoPush(ctx context.Context) {
 		return
 	}
 
-	// Push
-	debug.Logf("dolt auto-push: pushing to origin...\n")
-	if err := st.Push(ctx); err != nil {
+	// Push. Bound with a short timeout so a hanging remote (e.g. unreachable
+	// host, corrupted chunk store) doesn't block bd from exiting. The write is
+	// already committed locally; auto-push is best-effort sync.
+	pushTimeout := config.GetDuration("dolt.auto-push-timeout")
+	if pushTimeout == 0 {
+		pushTimeout = 30 * time.Second
+	}
+	pushCtx, pushCancel := context.WithTimeout(ctx, pushTimeout)
+	defer pushCancel()
+	debug.Logf("dolt auto-push: pushing to origin (timeout %s)...\n", pushTimeout)
+	if err := st.Push(pushCtx); err != nil {
 		if !isQuiet() && !jsonOutput {
 			fmt.Fprintf(os.Stderr, "Warning: dolt auto-push failed: %v\n", err)
 			if isDivergedHistoryErr(err) {
@@ -147,6 +155,17 @@ func maybeAutoPush(ctx context.Context) {
 			}
 		}
 		debug.Logf("dolt auto-push: push error: %v\n", err)
+		// Throttle retries after failure so a hanging remote doesn't make every
+		// subsequent bd command pay the push timeout. We record the attempt
+		// timestamp but NOT a new LastCommit, so when the remote recovers the
+		// change-detection check (currentCommit != LastCommit) still triggers.
+		if ps == nil {
+			ps = &pushState{}
+		}
+		ps.LastPush = time.Now().UTC().Format(time.RFC3339)
+		if saveErr := savePushState(ps); saveErr != nil {
+			debug.Logf("dolt auto-push: failed to save push state after error: %v\n", saveErr)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Problem

`maybeAutoPush` in `cmd/bd/dolt_autopush.go` calls `store.Push(ctx)` with the root command context, which has no timeout. For git-protocol remotes (`git+ssh://`, `git+https://`), `DoltStore.Push` ultimately calls `doltCLIPush`, which uses `cliExecTimeout = 5 * time.Minute`. This means a hanging remote can block `bd`'s `PersistentPostRun` for up to five minutes per write command.

Two downstream symptoms I hit in practice:

1. **Parent wrappers kill bd long before the push timeout.** My toolchain wraps bd with a 60s process timeout, so a hanging auto-push produces `signal: killed` warnings on the user-visible path, even though the write itself committed locally. The warning reads like a delivery failure; it isn't.
2. **Every subsequent bd write pays the timeout.** On a persistently unhealthy remote (here: a Dolt chunk store with missing blobs), `st.Push` fails, but failure is not recorded in `push-state.json`. `LastPush` stays empty, so the 5-minute debounce never kicks in and each new bd command takes the full timeout again.

## Change

Two small edits in `cmd/bd/dolt_autopush.go`:

1. **Bound auto-push with a short timeout.** New config key `dolt.auto-push-timeout` (default 30s) wraps the push context. User-invoked `bd dolt push` is unaffected — this only touches the automatic path.
2. **Record a push-state timestamp on failure.** `LastPush` is written even when `st.Push` returns an error, so subsequent commands in the debounce window skip the attempt. `LastCommit` is **not** written on failure, so change-detection (`currentCommit != LastCommit`) still triggers a retry after the window, which correctly recovers once the remote heals.

## Not in scope

- Not retrying automatically in the background. Out of scope for auto-push; user can run `bd dolt push` directly.
- Not special-casing known-transient errors vs. persistent ones. The timestamp-on-failure pattern handles both gracefully.

## Testing

Manually verified on a local environment with a deliberately broken Dolt remote:

- Before: `bd` write commands visibly hang for ~30-60s and are SIGKILL'd by wrappers. Auto-push warning prints after the kill.
- After: first `bd` write per 5-min window takes ~30s (push times out, warning prints, process exits cleanly). Subsequent writes complete in 1-3s because the failure throttle is in effect.

Once the remote is repaired (verified by a successful `dolt clone` round-trip), the next `bd` write pushes cleanly because `LastCommit` was never bumped.

Happy to add a unit test for the throttle-on-failure path if useful — let me know the preferred style in the repo.