### PR TITLE
fix: avoid false shared-server bootstrap no-op for synthesized worktrees

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -228,51 +229,22 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 		Database: cfg.GetDoltDatabase(),
 	}
 
+	// When bootstrap synthesized a fallback beadsDir for a fresh clone or
+	// worktree recovery, the path may not exist yet. In that case we must let
+	// sync.remote / refs/dolt/data detection run before treating an existing
+	// shared-server database as "nothing to do", otherwise an unrelated default
+	// "beads" database can mask the real recovery path.
+	beadsDirExists := false
+	if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
+		beadsDirExists = true
+	}
+
 	// Check for existing database (path differs between server and embedded mode).
-	// Use cfg.IsDoltServerMode() (which checks metadata.json + env vars) plus
-	// doltserver.IsSharedServerMode() (which also checks config.yaml) so that
-	// shared-server mode configured via dolt.shared-server: true in config.yaml
-	// correctly resolves the database path. (GH#30)
-	isServer := cfg.IsDoltServerMode() || doltserver.IsSharedServerMode()
-	var dbPath string
-	if isServer {
-		dbPath = doltserver.ResolveDoltDir(beadsDir)
-	} else {
-		dbPath = filepath.Join(beadsDir, "embeddeddolt")
-	}
-	if info, err := os.Stat(dbPath); err == nil && info.IsDir() {
-		entries, _ := os.ReadDir(dbPath)
-		if len(entries) > 0 {
-			if isServer {
-				resolved := doltserver.DefaultConfig(beadsDir)
-				probeCfg := bootstrapServerProbeConfig{
-					host:     cfg.GetDoltServerHost(),
-					port:     resolved.Port,
-					user:     cfg.GetDoltServerUser(),
-					pass:     cfg.GetDoltServerPassword(),
-					database: cfg.GetDoltDatabase(),
-					tls:      cfg.GetDoltServerTLS(),
-				}
-				result := checkBootstrapServerDB(probeCfg)
-				if result.Err != nil {
-					plan.Action = "none"
-					plan.Reason = fmt.Sprintf("Could not verify existing server database %s: %v", cfg.GetDoltDatabase(), result.Err)
-					return plan
-				}
-				if result.Exists {
-					plan.HasExisting = true
-					plan.Action = "none"
-					plan.Reason = fmt.Sprintf("Database %s already exists on server at %s:%d", probeCfg.database, probeCfg.host, probeCfg.port)
-					return plan
-				}
-			} else {
-				plan.HasExisting = true
-				plan.Action = "none"
-				plan.Reason = "Database already exists at " + dbPath
-				return plan
-			}
-		}
-	}
+	// Determine server/shared-server mode from the target workspace itself
+	// (metadata.json, env vars, and the target config.yaml when present) rather
+	// than unrelated global config loaded from the caller's current repo.
+	isSharedServer := bootstrapSharedServerMode(beadsDir)
+	isServer := cfg.IsDoltServerMode() || isSharedServer
 
 	// Check sync.remote (primary) or sync.git-remote (deprecated fallback)
 	syncRemote := resolveSyncRemote()
@@ -294,6 +266,15 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 				plan.Reason = "Found Dolt data on git origin (refs/dolt/data) — will clone from " + originURL
 				return plan
 			}
+		}
+	}
+
+	if dbAction, ok := existingBootstrapDBPlan(beadsDir, cfg, isServer, isSharedServer); ok {
+		// If the local beadsDir does not exist yet, prefer recovering via sync
+		// first. This avoids false "nothing to do" results when the default
+		// shared-server database name happens to exist for another project.
+		if beadsDirExists || dbAction.Action != "none" {
+			return dbAction
 		}
 	}
 
@@ -320,6 +301,114 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 	plan.Action = "init"
 	plan.Reason = "No existing database, remote, or backup — will create fresh database"
 	return plan
+}
+
+func existingBootstrapDBPlan(beadsDir string, cfg *configfile.Config, isServer, isSharedServer bool) (BootstrapPlan, bool) {
+	plan := BootstrapPlan{
+		BeadsDir: beadsDir,
+		Database: cfg.GetDoltDatabase(),
+	}
+
+	var dbPath string
+	if isServer {
+		dbPath = bootstrapServerDoltDir(beadsDir, cfg, isSharedServer)
+	} else {
+		dbPath = filepath.Join(beadsDir, "embeddeddolt")
+	}
+	if info, err := os.Stat(dbPath); err != nil || !info.IsDir() {
+		return BootstrapPlan{}, false
+	}
+
+	entries, _ := os.ReadDir(dbPath)
+	if len(entries) == 0 {
+		return BootstrapPlan{}, false
+	}
+
+	if isServer {
+		probeCfg := bootstrapServerProbeConfig{
+			host:     cfg.GetDoltServerHost(),
+			port:     bootstrapServerPort(beadsDir, cfg, isSharedServer),
+			user:     cfg.GetDoltServerUser(),
+			pass:     cfg.GetDoltServerPassword(),
+			database: cfg.GetDoltDatabase(),
+			tls:      cfg.GetDoltServerTLS(),
+		}
+		result := checkBootstrapServerDB(probeCfg)
+		if result.Err != nil {
+			plan.Action = "none"
+			plan.Reason = fmt.Sprintf("Could not verify existing server database %s: %v", cfg.GetDoltDatabase(), result.Err)
+			return plan, true
+		}
+		if result.Exists {
+			plan.HasExisting = true
+			plan.Action = "none"
+			plan.Reason = fmt.Sprintf("Database %s already exists on server at %s:%d", probeCfg.database, probeCfg.host, probeCfg.port)
+			return plan, true
+		}
+		return BootstrapPlan{}, false
+	}
+
+	plan.HasExisting = true
+	plan.Action = "none"
+	plan.Reason = "Database already exists at " + dbPath
+	return plan, true
+}
+
+func bootstrapSharedServerMode(beadsDir string) bool {
+	if v := os.Getenv("BEADS_DOLT_SHARED_SERVER"); v == "1" || strings.EqualFold(v, "true") {
+		return true
+	}
+	return strings.EqualFold(config.GetStringFromDir(beadsDir, "dolt.shared-server"), "true")
+}
+
+func bootstrapServerDoltDir(beadsDir string, cfg *configfile.Config, isSharedServer bool) string {
+	if isSharedServer {
+		if dir, err := doltserver.SharedDoltDir(); err == nil {
+			return dir
+		}
+	}
+
+	if d := cfg.GetDoltDataDir(); d != "" {
+		if filepath.IsAbs(d) {
+			return d
+		}
+		return filepath.Join(beadsDir, d)
+	}
+
+	return filepath.Join(beadsDir, "dolt")
+}
+
+func bootstrapServerPort(beadsDir string, cfg *configfile.Config, isSharedServer bool) int {
+	if p := os.Getenv("BEADS_DOLT_SERVER_PORT"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port
+		}
+	}
+
+	if isSharedServer {
+		if sharedDir, err := doltserver.SharedServerDir(); err == nil {
+			if port := doltserver.ReadPortFile(sharedDir); port > 0 {
+				return port
+			}
+		}
+		return doltserver.DefaultSharedServerPort
+	}
+
+	if port := doltserver.ReadPortFile(beadsDir); port > 0 {
+		return port
+	}
+
+	if p := config.GetStringFromDir(beadsDir, "dolt.port"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port
+		}
+	}
+
+	if cfg.DoltServerPort > 0 {
+		return cfg.DoltServerPort
+	}
+
+	return configfile.DefaultDoltServerPort
 }
 
 func printBootstrapPlan(plan BootstrapPlan) {

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -276,6 +276,11 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 		if beadsDirExists || dbAction.Action != "none" {
 			return dbAction
 		}
+		// For synthesized paths with no local workspace directory yet, defer the
+		// existing-db no-op until we've ruled out all other recovery paths.
+		// This preserves the sync-precedence fix without downgrading the
+		// legitimate "database already exists" case into a fresh init.
+		plan = dbAction
 	}
 
 	// Check for backup JSONL files (must be non-empty to be useful)
@@ -294,6 +299,10 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 		plan.JSONLFile = gitJSONL
 		plan.Action = "jsonl-import"
 		plan.Reason = "Git-tracked issues.jsonl found — will import from " + gitJSONL
+		return plan
+	}
+
+	if plan.Action == "none" {
 		return plan
 	}
 

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -1031,6 +1031,60 @@ func TestDetectBootstrapAction_WorktreeSynthesizedDirPrefersSyncOverDefaultShare
 	}
 }
 
+func TestDetectBootstrapAction_SynthesizedDirWithoutRecoveryStillUsesExistingSharedDB(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	worktreeDir := filepath.Join(t.TempDir(), "worktree")
+	if err := os.MkdirAll(worktreeDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(worktreeDir); err != nil {
+		t.Fatal(err)
+	}
+
+	sharedDoltDir := filepath.Join(homeDir, ".beads", "shared-server", "dolt")
+	if err := os.MkdirAll(filepath.Join(sharedDoltDir, "project_existing"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	synthesizedDir := filepath.Join(worktreeDir, ".beads")
+	cfg := configfile.DefaultConfig()
+	cfg.DoltMode = configfile.DoltModeServer
+	cfg.DoltDatabase = "project_existing"
+
+	origCheck := checkBootstrapServerDB
+	checkBootstrapServerDB = func(probeCfg bootstrapServerProbeConfig) bootstrapServerDBCheck {
+		if probeCfg.database != "project_existing" {
+			t.Fatalf("probeCfg.database = %q, want %q", probeCfg.database, "project_existing")
+		}
+		return bootstrapServerDBCheck{Exists: true, Reachable: true}
+	}
+	defer func() { checkBootstrapServerDB = origCheck }()
+
+	plan := detectBootstrapAction(synthesizedDir, cfg)
+
+	if plan.Action != "none" {
+		t.Fatalf("expected action=%q, got %q: %s", "none", plan.Action, plan.Reason)
+	}
+	if !plan.HasExisting {
+		t.Fatal("expected HasExisting to be true when configured shared-server DB already exists")
+	}
+}
+
 // TestFinalizeSyncedBootstrapWritesConfigFiles verifies that after a sync
 // clone, finalizeSyncedBootstrap writes the metadata.json and config.yaml
 // files bd needs to reopen the cloned database. This is the regression

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestDetectBootstrapAction_NoneWhenDatabaseExists(t *testing.T) {
 	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
@@ -189,6 +190,7 @@ func TestDetectBootstrapAction_ServerModeMissingConfiguredDBDoesNotReturnNone(t 
 
 func TestDetectBootstrapAction_ServerModeProbeErrorStopsWithReason(t *testing.T) {
 	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
 	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
 	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
@@ -943,6 +945,89 @@ func TestDetectBootstrapAction_SharedServerEnvUsesSharedPath(t *testing.T) {
 	}
 	if !plan.HasExisting {
 		t.Error("HasExisting = false, want true")
+	}
+}
+
+// TestDetectBootstrapAction_WorktreeSynthesizedDirPrefersSyncOverDefaultSharedDB
+// verifies that when bootstrap is running from a worktree whose fallback
+// .beads path lives under a bare/common git directory, remote recovery via
+// refs/dolt/data wins over an unrelated default "beads" database already
+// present on the shared server.
+func TestDetectBootstrapAction_WorktreeSynthesizedDirPrefersSyncOverDefaultSharedDB(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	originBare := filepath.Join(t.TempDir(), "origin.git")
+	runGitForBootstrapTest(t, "", "init", "--bare", "--initial-branch=main", originBare)
+
+	sourceDir := t.TempDir()
+	runGitForBootstrapTest(t, sourceDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.email", "test@test.com")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
+	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
+	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", originBare)
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
+
+	localBare := filepath.Join(t.TempDir(), "local-bare.git")
+	runGitForBootstrapTest(t, "", "clone", "--bare", originBare, localBare)
+
+	worktreeDir := filepath.Join(t.TempDir(), "worktree")
+	runGitForBootstrapTest(t, "", "--git-dir="+localBare, "worktree", "add", worktreeDir, "main")
+
+	sharedDoltDir := filepath.Join(homeDir, ".beads", "shared-server", "dolt")
+	if err := os.MkdirAll(filepath.Join(sharedDoltDir, "beads"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(worktreeDir); err != nil {
+		t.Fatal(err)
+	}
+
+	synthesizedDir := filepath.Join(localBare, ".beads")
+	cfg, cfgErr := configfile.Load(synthesizedDir)
+	if cfgErr != nil || cfg == nil {
+		cfg = findParentConfig(synthesizedDir)
+	}
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+
+	if got := cfg.GetDoltDatabase(); got != "beads" {
+		t.Fatalf("GetDoltDatabase() = %q, want %q (default expected without local metadata)", got, "beads")
+	}
+
+	origCheck := checkBootstrapServerDB
+	checkBootstrapServerDB = func(probeCfg bootstrapServerProbeConfig) bootstrapServerDBCheck {
+		if probeCfg.database != "beads" {
+			t.Fatalf("probeCfg.database = %q, want %q", probeCfg.database, "beads")
+		}
+		return bootstrapServerDBCheck{Exists: true, Reachable: true}
+	}
+	defer func() { checkBootstrapServerDB = origCheck }()
+
+	plan := detectBootstrapAction(synthesizedDir, cfg)
+
+	if plan.Action != "sync" {
+		t.Fatalf("expected action=%q, got %q: %s", "sync", plan.Action, plan.Reason)
+	}
+	if plan.SyncRemote == "" {
+		t.Fatal("expected SyncRemote to be populated from origin refs/dolt/data detection")
+	}
+	if plan.Database != "beads" {
+		t.Errorf("plan.Database = %q, want %q (default metadata-free value should still recover via sync)", plan.Database, "beads")
 	}
 }
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +19,8 @@ const (
 	FileName = "interactions.jsonl"
 	idPrefix = "int-"
 )
+
+var ensureFileBeforeCreateHook func(string)
 
 // Entry is a generic append-only audit event. It is intentionally flexible:
 // use Kind + typed fields for common cases, and Extra for everything else.
@@ -65,15 +68,17 @@ func EnsureFile() (string, error) {
 	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
 		return "", fmt.Errorf("failed to create .beads directory: %w", err)
 	}
-	_, statErr := os.Stat(p)
-	if statErr == nil {
+	if ensureFileBeforeCreateHook != nil {
+		ensureFileBeforeCreateHook(p)
+	}
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644) // nolint:gosec // JSONL is intended to be shared via git across clones/tools.
+	if err == nil {
+		if closeErr := f.Close(); closeErr != nil {
+			return "", fmt.Errorf("failed to close interactions log: %w", closeErr)
+		}
 		return p, nil
 	}
-	if !os.IsNotExist(statErr) {
-		return "", fmt.Errorf("failed to stat interactions log: %w", statErr)
-	}
-	// nolint:gosec // JSONL is intended to be shared via git across clones/tools.
-	if err := os.WriteFile(p, []byte{}, 0644); err != nil {
+	if !errors.Is(err, os.ErrExist) {
 		return "", fmt.Errorf("failed to create interactions log: %w", err)
 	}
 	return p, nil

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -2,8 +2,10 @@ package audit
 
 import (
 	"bufio"
+	"bytes"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -50,5 +52,45 @@ func TestAppend_CreatesFileAndWritesJSONL(t *testing.T) {
 	}
 	if lines != 2 {
 		t.Fatalf("expected 2 lines, got %d", lines)
+	}
+}
+
+func TestEnsureFile_DoesNotTruncateWhenConcurrentCreatorWins(t *testing.T) {
+	tmp := t.TempDir()
+	beadsDir := filepath.Join(tmp, ".beads")
+	if err := os.MkdirAll(beadsDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if err := os.WriteFile(metadataPath, []byte(`{"backend":"dolt"}`), 0644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	wantContents := []byte("{\"id\":\"seed\"}\n")
+
+	oldHook := ensureFileBeforeCreateHook
+	defer func() { ensureFileBeforeCreateHook = oldHook }()
+
+	var once sync.Once
+	ensureFileBeforeCreateHook = func(path string) {
+		once.Do(func() {
+			if err := os.WriteFile(path, wantContents, 0644); err != nil {
+				t.Fatalf("seed interactions log: %v", err)
+			}
+		})
+	}
+
+	gotPath, err := EnsureFile()
+	if err != nil {
+		t.Fatalf("EnsureFile: %v", err)
+	}
+
+	gotContents, err := os.ReadFile(gotPath)
+	if err != nil {
+		t.Fatalf("read interactions log: %v", err)
+	}
+	if !bytes.Equal(gotContents, wantContents) {
+		t.Fatalf("EnsureFile truncated seeded content: got %q, want %q", gotContents, wantContents)
 	}
 }


### PR DESCRIPTION
## Summary
- prefer sync-based recovery over a shared-server existing-db no-op when bootstrap synthesized a fallback `.beads` path that does not exist yet
- preserve the existing-db `none` fallback once sync, backup, and jsonl recovery paths are exhausted, so a real shared-server database is not reclassified as fresh init work
- resolve shared-server probe paths from the target workspace context instead of unrelated caller config state
- add regression coverage for both the bare/common-dir worktree sync-precedence case and the synthesized no-recovery existing-db case

## Testing
- `env -u GOOGLE_API_KEY -u BEADS_DOLT_SHARED_SERVER -u BEADS_DOLT_SERVER_MODE -u BEADS_DOLT_SERVER_DATABASE -u BEADS_DOLT_SERVER_HOST -u BEADS_DOLT_SERVER_PORT -u BEADS_DOLT_DATA_DIR make test`
- `env GOFLAGS=-tags=gms_pure_go go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...`
- `env -u GOOGLE_API_KEY -u BEADS_DOLT_SHARED_SERVER -u BEADS_DOLT_SERVER_MODE -u BEADS_DOLT_SERVER_DATABASE -u BEADS_DOLT_SERVER_HOST -u BEADS_DOLT_SERVER_PORT -u BEADS_DOLT_DATA_DIR CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestDetectBootstrapAction_(WorktreeSynthesizedDirPrefersSyncOverDefaultSharedDB|SynthesizedDirWithoutRecoveryStillUsesExistingSharedDB)$'`

## Context
- local tracker: `beads-36lv` Fix bootstrap false no-op in shared-server worktrees without local `.beads` metadata
- follow-up tracker: `beads-hwf6` Preserve shared-server no-op when synthesized bootstrap has no recovery path

