### PR TITLE
perf: batch wisp routing and enable InterpolateParams to eliminate remote bd latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Batched wisp routing in bulk helpers** — Added `ActiveWispIDsInTx` / `PartitionByWispInTx` in `internal/storage/issueops/wisp_routing.go` and rewrote seven call sites (`dependencies.go`, `labels.go`, `comments.go`, `bulk_ops.go`, `dependency_queries.go`, `delete.go`) to batch wisp-membership probes. Eliminates a per-ID N+1 that issued 2,285 `SELECT 1 FROM wisps WHERE id = ?` probes on a 457-issue `bd export`. Remote wall time on a 15 ms-RTT LAN drops from ~208 s to ~3 s (>60×). Single-ID call sites and embedded mode are unaffected.
+- **`InterpolateParams=true` on server-mode DSN** — Set in `internal/storage/doltutil/dsn.go`. `go-sql-driver/mysql` quotes arguments client-side, collapsing each parameterized query from the 3-RT `PREPARE`+`EXECUTE`+`CLOSE` binary protocol to a single round-trip. Combined with the batched wisp routing, remote `bd export` drops from 208 s to 0.514 s (~405×) and `bd doctor` from 91 s to 3.3 s (~28×). Safety audit (no `Prepare`/`sql.Stmt` reuse in non-test code, no custom `driver.Valuer`, `[]byte` only on already-hex-escaped federation password paths) is documented in the PR body; round-trip parity test covers JSON, DATETIME fractional seconds, and SQL-metacharacter strings. Embedded mode is unaffected.
+
 ## [1.0.2] - 2026-04-15
 
 ### Fixed

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -732,6 +732,40 @@ Remember: Different dependency types have different meanings:
 
 ## Performance Issues
 
+### Remote bd commands are slow (connecting to a central Dolt server)
+
+If `bd export`, `bd list`, `bd doctor`, or pre-commit hooks take tens of seconds to minutes when the Dolt server is on a different machine than the one running `bd`, follow the measurement-first sequence below. **Do not reach for VPNs, SSH tunnels, WireGuard, or network-layer fixes until you have ruled out query-count amplification.** The 2026-04-18 investigation showed a 208s `bd export` was ~99% a single N+1 pattern in bd itself, ~1% Dolt — tunneling would have been wasted effort.
+
+**Step 1 — measure warm MySQL RTT from the slow machine:**
+
+```bash
+# Host and port come from .beads/metadata.json
+mysql -h <host> -P <port> -u <user> -e "SELECT 1;" >/dev/null   # prime the connection
+time mysql -h <host> -P <port> -u <user> -e "SELECT 1;"
+```
+
+- Warm RTT < 20 ms → network is fine; the bottleneck is bd's query count or connection churn. Go to step 2.
+- Warm RTT 20-50 ms → enable WSL2 `networkingMode=mirrored` on the client (`%USERPROFILE%\.wslconfig` → `[wsl2] networkingMode=mirrored`, then `wsl --shutdown`). Reversible, unilateral, no hostA coordination.
+- Warm RTT > 100 ms → something is broken (DNS inspection, firewall, flaky LAN). Fix that first; don't build tunnels on top.
+
+**Step 2 — capture a per-query trace.** Apply the SQL-trace driver-wrapper patch documented in `docs/design/remote-latency-perf-design.md` Appendix B on a scratch branch. Run the slow command with `BD_SQL_LOG=/tmp/bd-sql.log`, then analyze:
+
+```bash
+jq -s 'group_by(.q) | map({q: .[0].q, n: length}) | sort_by(.n) | reverse | .[:10]' /tmp/bd-sql.log
+```
+
+Any single query shape with count >> the number of rows in the project is an N+1.
+
+**Step 3 — check the handshake-storm signature.** Any two of the following on a hot path explains 10-100× remote slowdown: `SetMaxOpenConns(1)`, short `SetConnMaxLifetime` (≤ 30 s), default `InterpolateParams=false` in the MySQL DSN. The main server-mode pool in `internal/storage/dolt/store.go:1257 applyPoolLimits` is already 10/5/1h; if the slow command goes through it, the pool is not the issue.
+
+**Step 4 — disable `export.auto` for unrelated commands.** bd's auto-export runs in `PersistentPostRun` for every non-export command. On a slow remote link, that silently adds the export cost to `bd list`, `bd show`, `bd ready`, `bd doctor`, etc. The pre-commit hook runs its own export regardless, so disabling auto-export does not hurt commit behavior:
+
+```bash
+bd config set export.auto false
+```
+
+For the full case study and the reproducibility patch that produced the 2,285-probe count, see `docs/design/remote-latency-perf-design.md` and `docs/design/remote-latency-perf-plan.md`.
+
 ### Export/import is slow
 
 For large databases (10k+ issues):

--- a/docs/design/remote-latency-perf-design.md
+++ b/docs/design/remote-latency-perf-design.md
@@ -1,0 +1,508 @@
+# Remote-Latency Performance Fixes — Design
+
+- Date: 2026-04-18
+- Branch: `alexmsu`
+- Status: Draft, pending review
+- Structure: 1 spec + 1 implementation plan, 3 independently-revertable commits on `alexmsu`
+
+## 1. Why — Motivation and User Impact
+
+### The observed pain
+
+On a remote developer workstation connected to the team's central `dolt sql-server` over a healthy LAN (15 ms MySQL RTT), every `git commit` in a bd-managed project takes **3 minutes 29 seconds**. The delay comes from bd's pre-commit hook, which exports the issue database to JSONL on every commit. What should feel instant instead blocks every commit for minutes.
+
+### Who this hurts
+
+- **Remote developers** on any bd project hosted on a LAN-central Dolt server — the author has twelve such projects. Anyone working from a different machine than the Dolt host experiences this.
+- **AI agents and automation** that run `bd list`, `bd ready`, or `bd doctor` on a loop — each invocation pays the same latency tax. A polling agent can burn tens of minutes of wall time per hour on nothing but query round-trips.
+- **Pre-commit UX** for the whole team once more developers switch to remote workflows. Hooks that take minutes train users to skip them (`--no-verify`), which defeats the reason hooks exist.
+
+### Concrete cost
+
+Assuming an active developer commits ten times per workday:
+- Current: 10 commits × 3m29s = **~35 minutes/day blocked on bd export**.
+- After fix: 10 commits × ≤15 s = **≤2.5 minutes/day**.
+
+Across `bd list`, `bd ready`, `bd doctor`, and pre-commit combined, a remote developer today loses roughly one hour per day to bd latency alone. The fix recovers essentially all of it.
+
+### Why the central Dolt server topology is the right one to support
+
+The `dolt-setup.md` memory captures the rationale for a single central `dolt sql-server` serving all project DBs: multi-client consistency, one source of truth, simple NAS-based disaster recovery, no per-project server sprawl. We do not want to abandon that topology. Alternatives considered and rejected:
+
+- **Local embedded-clone mirror on every developer machine.** Adds sync lag, splits the write path, and complicates team freshness guarantees.
+- **Move bd execution to the Dolt host via SSH exec.** Awkward for git workflows, requires project mirroring, and surfaces a new class of hook failures.
+- **Network-layer tunneling (WireGuard, Tailscale, stunnel).** Measurement proved network RTT is not the dominant cost (see Section 2). No tunnel can recover work that isn't on the wire.
+
+### Why now
+
+1. **We have direct evidence.** A throw-away SQL-tracing driver wrapper proved that one specific N+1 pattern accounts for 99% of the remote cost — 2,285 per-ID `SELECT 1 FROM wisps WHERE id = ? LIMIT 1` probes per `bd export`. The fix target is unambiguous.
+2. **The fix is cheap.** One new helper (~25 lines), seven mechanical call-site rewrites with identical shape, one DSN flag flip. Low blast radius, easy to review, easy to revert.
+3. **It compounds.** Every future remote bd command — not just the ones measured — benefits from the same batching and the same DSN fix. The investment pays back on every invocation going forward.
+4. **Left alone, the pressure grows.** As the issue database grows (one of the busier bd-managed projects already has 457 issues), the N+1 gets proportionally worse. The 208 s number is today's cost; it will increase linearly.
+
+### What "done" looks like
+
+A remote developer runs `git commit` and the hook finishes in under 15 seconds. `bd list`, `bd ready`, and `bd doctor` feel indistinguishable from localhost. No new cross-project coordination is required, no new infrastructure is introduced, and the change is revertable commit-by-commit if any regression surfaces.
+
+## 2. Problem Statement
+
+On a remote client (hostB, WSL2 mirrored-networking) connected over a trusted LAN to a central `dolt sql-server` (hostA, `192.0.2.10:3308`), `bd hooks run pre-commit` hangs for roughly 3m29s. The pre-commit hook spawns `bd export`, which itself takes **208s** end-to-end on the remote but only **2.2s** on hostA localhost — a 95× slowdown that cannot be explained by raw network RTT.
+
+### Measured evidence
+
+| Metric | Value |
+|---|---|
+| Warm `SELECT 1;` over `mysql` client (hostB → hostA) | 15 ms |
+| `bd export` wall time, local on hostA | 2.2 s |
+| `bd export` wall time, remote on hostB | 208 s |
+| Total SQL round-trips issued by `bd export` | 2,316 |
+| Distinct MySQL connections opened during one `bd export` | 2 |
+| Queries matching the `IsActiveWispInTx` per-ID probe (`SELECT 1 FROM wisps WHERE id = ? LIMIT 1`) | **2,285** |
+| Remaining bulk/batched queries | 31 |
+
+Measured via a throw-away `database/sql` driver wrapper that logged each `Query`/`Exec` with `query`, `args`, and duration. The wrapper was reverted after measurement.
+
+### Root cause
+
+bd partitions IDs into `wisps` vs `issues` by calling `IsActiveWispInTx` in a per-ID loop inside **seven** bulk helpers:
+
+1. `internal/storage/issueops/dependencies.go:212-218` (`GetIssuesByIDsInTx`)
+2. `internal/storage/issueops/labels.go:48-55` (`GetLabelsForIssuesInTx`)
+3. `internal/storage/issueops/comments.go:56-63` (`GetCommentCountsInTx`)
+4. `internal/storage/issueops/bulk_ops.go:113-120` (`GetCommentsForIssuesInTx`)
+5. `internal/storage/issueops/dependency_queries.go:45-52` (`GetDependencyRecordsForIssuesInTx`)
+6. `internal/storage/issueops/dependency_queries.go:207-214` (`GetBlockingInfoForIssuesInTx`)
+7. `internal/storage/issueops/delete.go:77-84` (`DeleteIssuesInTx`)
+
+Each call site iterates N IDs and issues one `SELECT 1 FROM wisps WHERE id = ? LIMIT 1` per ID. For 457 issues × 5 bulk helpers invoked by `bd export` that's ~2,285 per-ID probes. Because the DSN does not set `InterpolateParams`, each parameterized `Query`/`QueryRow` under go-sql-driver/mysql uses the server-side binary protocol (PREPARE + EXECUTE + CLOSE; driver source: `github.com/go-sql-driver/mysql@v1.9.3/connection.go:239-410`) — multiple round-trips per query. At 15 ms RTT × (conservatively) 3 RTs × 2,285 probes = **~103 s lower bound**; measured wall-clock is **~200 s** of the 208 s total. The remaining ~100 s is not captured at protocol level in this measurement — plausible sources include per-query server-side work (point lookups add microseconds each, but `SELECT 1`-style probes may still pay a minimum per-statement floor), TCP Nagle / delayed-ACK interactions with the 3-RT sequence, and WSL2 mirrored-mode vSwitch processing. The count-proportional 103 s dominates, which is sufficient to justify the fix regardless of the unattributed overhead — see §9 success criteria which are framed on attributable savings, not the unexplained remainder.
+
+The SQL-trace wrapper patch used to gather this evidence is preserved in **Appendix B** so reviewers can re-run the measurement without guesswork.
+
+### Attribution
+
+| Source | Count | Remote cost | Category |
+|---|---:|---:|---|
+| `IsActiveWispInTx` N+1 | 2,285 | ~200 s | **bd** — fixable in this repo |
+| Legit bulk SELECTs (IN batches) | 25 | ~2.2 s | protocol |
+| Dolt-specific (`DOLT_HASHOF`, `SHOW DATABASES`, metadata) | 6 | ~0.5 s | dolt |
+| Go/Cobra/JSON overhead | — | ~2 s | bd (fixed) |
+
+Roughly **99% bd, 1% Dolt**. No upstream Dolt change is required.
+
+## 3. Goals
+
+- Reduce remote `bd export` from **208 s → ≤ 10 s** (2 orders of magnitude).
+- Apply the same proportional speed-up to every bulk-helper-consuming command: `bd list --json`, `bd ready --json`, `bd show`, `bd doctor`.
+- Land each change as an independently-revertable commit on branch `alexmsu`.
+- No behavior change for embedded mode, long-timeout merge isolation, or short-lived admin helpers.
+
+## 4. Non-Goals
+
+- Persistent bd daemon / RPC (out of scope; separate future design).
+- Dolt-side patches (not required; 1% attribution).
+- Local embedded-clone mirroring (an alternative discussed but avoided to keep the central-server topology).
+- Any change to embedded-mode pool configuration (`MaxOpenConns=1` there is a correctness invariant).
+- `dolt-concurrency.md` orchestrator work; that migration is already landed.
+
+## 5. Approach — Three Commits
+
+### Commit 1 — `perf(storage): batch wisp routing probes in bulk helpers`
+
+**Scope.** Add a bulk partitioner in `internal/storage/issueops/wisp_routing.go`, then replace all seven per-ID loops.
+
+**New API — two helpers in `wisp_routing.go`.**
+
+```go
+// ActiveWispIDsInTx returns the subset of ids that exist in the active wisps
+// table, batched at queryBatchSize. Primitive — intended for callers that need
+// a set to probe membership for arbitrary IDs.
+func ActiveWispIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]bool, error)
+
+// PartitionByWispInTx splits ids into wispIDs and permIDs by running one batched
+// membership probe. The returned slices preserve the input order within each
+// partition, so callers using the result for deterministic iteration (e.g.,
+// JSON export ordering) remain stable. Implemented on top of ActiveWispIDsInTx.
+func PartitionByWispInTx(ctx context.Context, tx *sql.Tx, ids []string) (wispIDs, permIDs []string, err error)
+```
+
+Both APIs ship in the same commit:
+- `ActiveWispIDsInTx` is the primitive. Unit-tested directly.
+- `PartitionByWispInTx` is a thin wrapper used by all seven bulk call sites.
+
+`map[string]bool` matches the overwhelming bd convention (326 occurrences vs 17 for `map[string]struct{}` — code review response documents this).
+
+**Call-site rewrite pattern** (identical across all 7 sites):
+
+```go
+// before
+var wispIDs, permIDs []string
+for _, id := range ids {
+    if IsActiveWispInTx(ctx, tx, id) {
+        wispIDs = append(wispIDs, id)
+    } else {
+        permIDs = append(permIDs, id)
+    }
+}
+
+// after — the wrapper collapses ~8 lines to 4 and preserves input ordering
+wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, ids)
+if err != nil {
+    return nil, err
+}
+```
+
+Preserving input ordering removes a known footgun: any future caller that ranges a `map[string]bool` would see Go's randomized iteration. `PartitionByWispInTx` iterates the input slice internally, so the returned `[]string` slices are always input-ordered.
+
+**Non-targets.** The ~20 single-call sites of `IsActiveWispInTx` (e.g., `close.go`, `update.go`, `claim.go`, `promote.go`, `delete.go:24`, `get_issue.go`, `events.go`, `molecule.go`) are **not** an N+1 — each operates on one ID. Leave them alone.
+
+**Expected impact.** 2,285 per-ID probes → ~3 batched `IN (?)` queries. Alone this drops remote `bd export` from 208 s to **~8 s**.
+
+### Commit 2 — `perf(dolt): enable InterpolateParams to collapse prepared-statement round-trips`
+
+**Scope.** Set `InterpolateParams: true` in `internal/storage/doltutil/dsn.go`. The go-sql-driver/mysql driver then performs parameter interpolation client-side, collapsing each parameterized query from the multi-RT binary protocol to a single round-trip.
+
+**Driver-behavior audit — enumerated.** `InterpolateParams` disables server-side prepared statements and does client-side quoting. The following was verified against the actual bd codebase (not just driver source). Full evidence lives in the commit message:
+
+| Arg type observed on write paths | File:line (sample) | Interpolation behavior | Risk |
+|---|---|---|---|
+| `string` | `internal/storage/issueops/helpers.go:46-97` (47 arg insert), `bulk_ops.go:94,201` | Driver quotes with `'…'`, escapes `'`, `\`, NUL per MySQL standard | None — identical to server-side PREPARE behavior |
+| `int`, `int64` | `helpers.go:46-97`, `compaction.go:91` | Numeric literal | None |
+| `bool` | `helpers.go:46-97` | `1`/`0` | None |
+| `time.Time` | `helpers.go:46-97`, `compaction.go:91` | `'YYYY-MM-DD HH:MM:SS[.fraction]'` via `utils.go:268 appendDateTime`, respects `ParseTime=true` | None — schema is second-precision |
+| `*time.Time` (nullable) | `helpers.go:46-97` | Dereference or `NULL` | None |
+| `nil` (from `NullString` helper) | `helpers.go:46-97` | Literal `NULL` | None |
+| `[]byte` | **only** `federation.go:32-46`, `credentials.go:166,258-265` (password_encrypted) | Hex literal `_binary 0x…` via `connection.go:306-317` | None — already round-tripped by binary protocol today |
+| JSON as `string` | `helpers.go:548 JSONMetadata()`, `queries.go:140 JSON_EXTRACT` parameters | Quoted as ordinary string, server parses JSON on read | None — bd never passes `json.RawMessage` directly |
+
+**What bd does NOT have that would be at risk:**
+- No `db.Prepare()` / `tx.Prepare()` / `sql.Stmt` reuse anywhere in non-test code (`grep` returned zero hits). Reviewer concern about reused prepared statements silently degrading to per-call quoting does not apply.
+- No custom `driver.Valuer` implementations in `internal/types/` (0 matches).
+- No `json.RawMessage` arguments passed to `Exec`/`Query` — JSON always pre-serialized to `string`.
+
+**`MultiStatements=true` interaction.** The driver's `Exec`/`Query` paths (`connection.go:340-410`) do not branch on `MultiStatements` when interpolating; the flag only affects whether the server tokenizes `;` in the query body. Orthogonal.
+
+**Coverage.** Applies everywhere `ServerDSN.String()` is consumed, which is every server-mode connection (`store.go:openServerConnection`, doctor, dolt subcommands, admin helpers). Embedded mode uses a different DSN builder and is unaffected.
+
+**Observability upside.** Dolt's query log will now show the final interpolated SQL instead of the parameterized skeleton, which is strictly better for `EXPLAIN` / post-mortem debugging. Called out in the commit message.
+
+**Expected impact.** Additional reduction on the remaining 25-31 parameterized queries and on **all** future remote bd commands. Combined with Commit 1, projected `bd export` remote is within the ≤ 10 s success criterion (§9); tighter projections intentionally not stated to avoid over-claiming.
+
+### Commit 3 — `perf(dolt): tune connection-pool settings in auxiliary paths`
+
+**Scope.** Narrow. The main server pool (`store.go:1257 applyPoolLimits`) already uses `MaxOpenConns=10 / MaxIdleConns=5 / ConnMaxLifetime=1h` — designed for long-lived daemons, not part of this fix. The remaining `MaxOpenConns(1)` sites are audited and selectively widened only where they serve no correctness role.
+
+| File:line | Current | Action | Rationale |
+|---|---|---|---|
+| `internal/storage/embeddeddolt/open.go:51-54` | `MaxOpenConns=1, ConnMaxLifetime=0` | **No change** | Single-writer invariant of embedded mode |
+| `internal/storage/dolt/store.go:1238` (`execWithLongTimeout`) | `MaxOpenConns=1` | **No change** | Deliberately isolated 5-minute ops (merge/conflict) |
+| `internal/storage/dolt/store.go:2066` | `MaxOpenConns=1` | Audit & leave if it's an isolation barrier | Verify before touching |
+| `internal/doltserver/doltserver.go:894,932` (admin helpers) | `MaxOpenConns=1, ConnMaxLifetime=10s` | **No change** | Short-lived, one-shot ops |
+| `cmd/bd/dolt.go:1518-1520` (dolt subcommands — only reached from `bd dolt clean-databases`; fans out to `SHOW DATABASES` + `DROP DATABASE`, no `DOLT_CHECKOUT`) | `MaxOpenConns=2 / Idle=1 / Lifetime=30s` | Widen to `5 / 2 / 60s` via named constants | No isolation requirement; reviewer-proposed 60s cap adopted as defense-in-depth |
+| `cmd/bd/doctor/server.go:320-322` (only reached from `checkConnectionWithDB`, `checkSchemaWithDB`, `checkIssueCountWithDB` — all read-only) | `MaxOpenConns=2 / Idle=1 / Lifetime=30s` | Widen to `5 / 2 / 60s` via named constants | Read-only diagnostic path, no session state |
+| `cmd/bd/doctor/dolt.go:59-61` (same read-only fan-out via `checkPhantomDatabases`) | `MaxOpenConns=2 / Idle=1 / Lifetime=30s` | Widen to `5 / 2 / 60s` via named constants | Same as above |
+
+**Named constants.** To make future audits trivial, extract the three tuples into package-level constants in a new file `cmd/bd/doctor/pool_config.go`:
+
+```go
+package doctor
+
+import "time"
+
+// DiagnosticPoolMaxOpenConns caps concurrent diagnostic probes. Wider than the
+// historical 2 so doctor runs faster; narrower than the daemon pool (10) so
+// idle socket count stays small on the shared Dolt server.
+const DiagnosticPoolMaxOpenConns = 5
+
+// DiagnosticPoolMaxIdleConns = keep 2 warm for burst checks.
+const DiagnosticPoolMaxIdleConns = 2
+
+// DiagnosticPoolMaxLifetime = 60s caps connection reuse to a value safely
+// smaller than any plausible branch-state-affecting window, while still
+// avoiding the reconnect storm of the previous 30s setting.
+const DiagnosticPoolMaxLifetime = 60 * time.Second
+```
+
+All three call sites reference the same constants.
+
+**Branch-switching audit (addresses review concern).** A connection reused across a `DOLT_CHECKOUT` / branch switch could return wrong-branch rows. Verified: none of the three widened call sites reach `DOLT_CHECKOUT`. Actual `DOLT_CHECKOUT` sites are `internal/storage/versioncontrolops/branches.go:54`, `compact.go:30,47,64`, `flatten.go:55,58` — none reachable from `cmd/bd/dolt.go:1518`'s `clean-databases` path or from `cmd/bd/doctor/*`. The `60 s` lifetime is still chosen as defense-in-depth and is safely below any plausible server-state-volatility window.
+
+**Expected impact.** Minor for `bd export` (≈0). Moderate for `bd doctor` and `bd dolt clean-databases` (≈1-3 s per invocation).
+
+**Explicit non-touch list** (all correctness-load-bearing):
+
+- `internal/storage/embeddeddolt/open.go`
+- `internal/storage/dolt/store.go:1238` (`execWithLongTimeout`)
+- `internal/doltserver/doltserver.go:894,932` (`EnsureGlobalDatabase`, `FlushWorkingSet`)
+- Any test-only tuning in `*_test.go`
+
+## 6. Testing Strategy
+
+### Unit tests
+
+- **Commit 1.** New `wisp_routing_test.go` covering:
+  - Empty input → empty map, no query issued.
+  - All permanent IDs → empty map.
+  - Mixed set → correct wisp IDs only.
+  - Batching: set `queryBatchSize=2`, feed 5 mixed IDs, expect 3 queries via `sqlmock`.
+  - Matches existing semantics: for every partitioning scenario, the result is bit-identical to the per-ID loop.
+  - `PartitionByWispInTx` ordering: verify the returned `wispIDs` and `permIDs` slices preserve input order within each partition, so consumers relying on deterministic iteration are safe.
+- **Commit 2.** New `dsn_test.go` in `internal/storage/doltutil/`: confirm DSN string contains `interpolateParams=true` and that the previously-set flags (`parseTime`, `multiStatements`, `allowNativePasswords`, `tls=false`) are preserved.
+- **Commit 3.** Add `cmd/bd/doctor/pool_config_test.go` asserting the three named constants are used by all widened sites. Existing `connection_pool_test.go` must stay green.
+
+### Integration tests
+
+- Existing integration tests under `cmd/bd/testdata/*.txt` must pass unchanged.
+- **New test — semantic-equal export (Commit 1, mandatory):** `internal/storage/issueops/wisp_routing_export_parity_test.go`. Fixture database with ~20 permanent issues + ~20 explicit-ID wisps. Produce two JSONL streams:
+  1. Export using the pre-refactor `IsActiveWispInTx` per-ID loop (retained in a `testOnlyLegacyPartition` helper).
+  2. Export using the new `PartitionByWispInTx`.
+  Assertion: after parsing each line to an `IssueWithCounts` and sorting by ID, both streams are deep-equal. This is stronger than byte-identical diff (immune to cosmetic JSON whitespace / field-order noise) and tighter than a smoke test (detects any actual data-shape regression).
+- **New test — Dolt-specific InterpolateParams round-trip (Commit 2, mandatory):** `internal/storage/dolt/interpolate_params_test.go`. Real in-process Dolt (via existing `testmain_test.go` harness). Two DB handles — one with `InterpolateParams=false`, one with `=true`. For each, insert + retrieve:
+  - JSON column (`issues.metadata`): `{"a":null,"emoji":"\u00e9","nested":{"k":[1,2,3]}}`
+  - DATETIME column (`issues.created_at`): `time.Date(2026, 4, 18, 12, 0, 0, 123456789, time.UTC)` (sub-microsecond input, second-precision schema)
+  - String with SQL metacharacters: `O'Brien\\n"quote"`
+  Assertion: `scanResult(false) == scanResult(true)` byte-for-byte. Closes reviewer BLOCKER 3. BLOB intentionally excluded — bd has no BLOB in parameterized write paths beyond `federation_peers.password_encrypted`, which is already covered by existing federation tests.
+- Run full `go test ./...` to confirm no regression in `issueops/*_test.go`.
+
+### Performance regression guard (Commit 1, mandatory — promoted from optional)
+
+New benchmark `BenchmarkBulkPartitioning` in `wisp_routing_test.go`. Simulate N=500 IDs against an in-process Dolt using existing `dolt_benchmark_test.go` harness. In addition to timing, wrap the `*sql.Tx` with a counting driver and **fail** the benchmark if it issues more than `ceil(N / queryBatchSize) + 1` queries. A future engineer reintroducing an N+1 fails CI.
+
+### Manual verification
+
+On branch `alexmsu`, after each commit:
+
+```bash
+# From hostB (remote client):
+cd ~/src/<bd-project>
+time bd export -o /tmp/probe.jsonl
+
+# Expected after Commit 1: ≈ 8s
+# Expected after Commit 2: ≈ 4s
+# Expected after Commit 3: ≈ 4s (unchanged for export; see doctor)
+time bd doctor
+# Expected after Commit 3: noticeable drop (from 91s → ~60-70s)
+```
+
+## 7. Risks & Mitigations
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| `PartitionByWispInTx` returns different set than per-ID loop due to NULL / case-sensitivity / whitespace | Low | Correctness | Parity unit test + mandatory `wisp_routing_export_parity_test.go` semantic-equal integration test |
+| Future caller ranges over the `ActiveWispIDsInTx` set directly, relying on non-deterministic iteration order | Low | Subtle ordering bug | `PartitionByWispInTx` is the call-site API and returns input-ordered `[]string`; doc comment warns about direct map iteration |
+| `InterpolateParams=true` changes `time.Time` / binary / JSON rendering | Low | Data corruption on writes | Enumerated audit in §5 Commit 2 + mandatory Dolt-specific round-trip test (`interpolate_params_test.go`) exercising JSON, DATETIME, SQL-metacharacter strings |
+| `InterpolateParams` interacts with `MultiStatements` in unexpected ways | Very low | Query parse errors | Driver source audit confirms `Exec`/`Query` paths don't branch on `MultiStatements` when interpolating (`connection.go:340-410`); full test suite runs |
+| Hidden prepared-statement reuse silently regresses under InterpolateParams | None (confirmed) | n/a | Zero `Prepare`/`Stmt` hits in non-test code; recorded in commit-2 message |
+| Widened pool in `cmd/bd/doctor/*` triggers concurrency bug narrow setting hid | Low | Flaky doctor | Cap conservative (5/2/60s); no branch-switch reachable from widened call sites (audited in §5 Commit 3) |
+| Connection reuse across `DOLT_CHECKOUT` returns wrong-branch rows | None (confirmed) | Correctness | Widened call sites verified read-only (dolt `SHOW DATABASES`/`DROP DATABASE` + doctor probes); no `DOLT_CHECKOUT` reachable; 60s lifetime as defense-in-depth |
+| Commit 3 inadvertently touches a correctness-load-bearing `MaxOpenConns(1)` | Low | Stale data / hangs | Explicit non-touch list above; review diff against it |
+| Remote timing varies run-to-run under Windows firewall inspection | Med | Misleading benchmark | Run each timing 3× and report median; capture `dolt-server.log` line count |
+| Attribution gap: fixing query count recovers only the count-proportional ~103 s, leaves ~100 s unexplained overhead | Med | Target may slip | §9 target is 10 s (2× margin over the ~103 s recoverable); overhead ~100 s likely per-query (vanishes with fix) but not fully characterized; if the 10 s target is missed we revisit before proceeding to T2 |
+
+## 8. Rollout
+
+All three commits land on branch `alexmsu` in this repo. Sequence:
+
+1. Branch is already `alexmsu`; confirm clean tree.
+2. Implement Commit 1, run `go test ./... && golangci-lint run ./...`, verify manual remote time.
+3. Implement Commit 2, same verification.
+4. Implement Commit 3, same verification.
+5. Run `make install` locally to refresh `~/.local/bin/bd`.
+6. On hostB, re-measure `time git commit --allow-empty -m "post-fix smoke"` and compare to the 3m29s baseline.
+7. Upstream PR authoring is out of scope for this spec; covered in a follow-up.
+
+## 9. Success Criteria
+
+- Remote `bd export` ≤ 10 s (baseline 208 s). No tighter projection asserted; see §2 for the unattributed-overhead caveat.
+- Remote `git commit --allow-empty` via pre-commit hook ≤ 15 s (baseline 3m29s).
+- `go test ./...` green.
+- `golangci-lint run ./...` no new warnings above baseline.
+- `bd doctor` passes with zero new errors.
+- Export output is **semantically equal** (per-issue deep-equal after sort-by-ID) before vs after on a fixture DB — validated by `wisp_routing_export_parity_test.go`. Byte-identical guarantee is intentionally relaxed to avoid brittleness to cosmetic JSON-serialization noise.
+
+## 10. Out of Scope / Follow-ups
+
+- **`bd daemon`** — persistent local agent for true zero-startup command latency. Separate design.
+- **`RunCompatMigrations` fast-path skip** — save ~20 RTs on every write command; separate issue.
+- **`cmd/bd/doctor/perf_dolt.go` connection tuning** — already uses wider pool (5/2); out of scope here.
+- **Observability around bulk helpers** — reviewer suggested a `debug.Logf` counter in `ActiveWispIDsInTx` that would emit batch count + size, making future N+1 regressions visible without re-running the SQL-trace wrapper. Valuable but orthogonal to the perf fix. Deferred out of this PR to keep review surface focused; re-raise if a future investigation needs it.
+- **Local embedded clone on hostB (`Option T2` from discussion)** — alternative topology not required if the fixes above meet the target.
+- **Upstream PRs to `steveyegge/beads`** — deferred; authored after `alexmsu` commits are validated in production use.
+- **Commit 3 (auxiliary pool tuning) — descoped 2026-04-18.** Commit 3 in §5 was sized against a 91 s `bd doctor` baseline. After Commits 1 + 2 landed, the measured numbers were `bd export` 0.514 s, `bd doctor` 3.285 s, `bd dolt clean-databases --dry-run` 0.062 s. The pool-widening from 2/1/30s → 5/2/60s was designed to shave 1–3 s off commands that now complete in under 3.3 s. The marginal wall-clock gain does not justify the review surface (branch-switch reachability audit, `ConnMaxLifetime` semantics, potential `cmd/bd` → `cmd/bd/doctor` import-cycle fallback). The original `MaxOpenConns=2 / Idle=1 / Lifetime=30s` values stay. Revisit only if future workload surfaces pool starvation with fresh measurements.
+
+## 11. Appendix A — File Inventory
+
+### Files touched by Commit 1
+
+- `internal/storage/issueops/wisp_routing.go` (add `ActiveWispIDsInTx` and `PartitionByWispInTx`)
+- `internal/storage/issueops/wisp_routing_test.go` (new)
+- `internal/storage/issueops/wisp_routing_export_parity_test.go` (new — semantic-equal export parity test)
+- `internal/storage/issueops/dependencies.go` (lines 211-218)
+- `internal/storage/issueops/labels.go` (lines 48-55)
+- `internal/storage/issueops/comments.go` (lines 56-63)
+- `internal/storage/issueops/bulk_ops.go` (lines 113-120)
+- `internal/storage/issueops/dependency_queries.go` (lines 45-52 and 207-214)
+- `internal/storage/issueops/delete.go` (lines 77-84)
+
+### Files touched by Commit 2
+
+- `internal/storage/doltutil/dsn.go`
+- `internal/storage/doltutil/dsn_test.go` (new)
+- `internal/storage/dolt/interpolate_params_test.go` (new — Dolt-specific JSON+DATETIME+string round-trip)
+
+### Files touched by Commit 3
+
+- `cmd/bd/dolt.go` (lines 1518-1520)
+- `cmd/bd/doctor/server.go` (lines 320-322)
+- `cmd/bd/doctor/dolt.go` (lines 59-61)
+- `cmd/bd/doctor/pool_config.go` (new — named constants)
+- `cmd/bd/doctor/pool_config_test.go` (new — asserts call sites use the constants)
+
+### Explicit non-changes
+
+- `internal/storage/embeddeddolt/open.go`
+- `internal/storage/dolt/store.go:1238` (`execWithLongTimeout`)
+- `internal/doltserver/doltserver.go:894,932`
+- `internal/storage/dolt/store.go:1257` (`applyPoolLimits`, already correct)
+- All `*_test.go` pool configurations
+
+## 12. Appendix B — SQL-Trace Driver Wrapper (Reproducibility)
+
+This is the throw-away instrumentation used to produce the 2,285-probe count in §2. It is **not** committed; reviewers can apply it on a scratch worktree to re-verify the baseline measurement and confirm the post-fix count.
+
+### How to use
+
+1. `git checkout -b perf-measure-tmp alexmsu`
+2. Apply the patch below (create `internal/storage/dolt/sqltrace_probe.go`, edit `store.go:1284-1303`).
+3. `make install`
+4. `BD_SQL_LOG=/tmp/bd-sql.log bd export -o /tmp/export.jsonl` from hostB.
+5. `jq -s 'group_by(.query) | map({q: .[0].query, n: length}) | sort_by(.n) | reverse | .[:10]' /tmp/bd-sql.log` to see the top-10 queries by count.
+6. After measurement: `git checkout alexmsu && git branch -D perf-measure-tmp`.
+
+### Patch — `internal/storage/dolt/sqltrace_probe.go` (new file)
+
+```go
+//go:build tracesql
+// +build tracesql
+
+package dolt
+
+import (
+    "context"
+    "database/sql"
+    "database/sql/driver"
+    "encoding/json"
+    "io"
+    "os"
+    "strings"
+    "sync"
+    "time"
+
+    mysqldrv "github.com/go-sql-driver/mysql"
+)
+
+var (
+    traceOnce sync.Once
+    traceOut  io.Writer
+    traceMu   sync.Mutex
+)
+
+func initTrace() {
+    path := os.Getenv("BD_SQL_LOG")
+    if path == "" {
+        traceOut = io.Discard
+        return
+    }
+    f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+    if err != nil {
+        traceOut = io.Discard
+        return
+    }
+    traceOut = f
+}
+
+type traceDriver struct{ inner driver.Driver }
+
+func (d *traceDriver) Open(dsn string) (driver.Conn, error) {
+    traceOnce.Do(initTrace)
+    c, err := d.inner.Open(dsn)
+    if err != nil {
+        return nil, err
+    }
+    return &traceConn{inner: c}, nil
+}
+
+type traceConn struct{ inner driver.Conn }
+
+func (c *traceConn) Prepare(q string) (driver.Stmt, error) { return c.inner.Prepare(q) }
+func (c *traceConn) Close() error                          { return c.inner.Close() }
+func (c *traceConn) Begin() (driver.Tx, error)             { return c.inner.Begin() }
+
+func (c *traceConn) QueryContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Rows, error) {
+    t0 := time.Now()
+    qc, ok := c.inner.(driver.QueryerContext)
+    if !ok {
+        return nil, driver.ErrSkip
+    }
+    rows, err := qc.QueryContext(ctx, q, args)
+    log(q, args, time.Since(t0), err)
+    return rows, err
+}
+
+func (c *traceConn) ExecContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Result, error) {
+    t0 := time.Now()
+    ec, ok := c.inner.(driver.ExecerContext)
+    if !ok {
+        return nil, driver.ErrSkip
+    }
+    r, err := ec.ExecContext(ctx, q, args)
+    log(q, args, time.Since(t0), err)
+    return r, err
+}
+
+func log(q string, args []driver.NamedValue, d time.Duration, err error) {
+    traceMu.Lock()
+    defer traceMu.Unlock()
+    rec := map[string]any{
+        "q":   strings.TrimSpace(q),
+        "dur": d.Microseconds(),
+        "n":   len(args),
+    }
+    if err != nil {
+        rec["err"] = err.Error()
+    }
+    b, _ := json.Marshal(rec)
+    _, _ = traceOut.Write(append(b, '\n'))
+}
+
+// init replaces the standard "mysql" driver with the tracing wrapper when
+// built with -tags tracesql. No runtime overhead when built without the tag.
+func init() {
+    sql.Register("mysql-trace", &traceDriver{inner: mysqldrv.MySQLDriver{}})
+}
+```
+
+### Patch — `internal/storage/dolt/store.go`
+
+Change the driver name in `openServerConnection` under the tracesql build:
+
+```go
+// Replace: db, err := sql.Open("mysql", connStr)
+// With:    db, err := sql.Open("mysql-trace", connStr)
+// (only under `-tags tracesql` builds; default build unchanged)
+```
+
+Or simpler: keep as-is and add `BD_SQL_DRIVER` env lookup:
+
+```go
+drv := "mysql"
+if os.Getenv("BD_SQL_LOG") != "" {
+    drv = "mysql-trace"
+}
+db, err := sql.Open(drv, connStr)
+```
+
+Build with `go build -tags tracesql -o ~/.local/bin/bd ./cmd/bd` to enable; the default build has zero cost. The instrumentation file compiles only under the build tag.
+
+### Interpreting the output
+
+Each line is a JSON record with `q`, `args`-count, `dur` (µs), optional `err`. Sum durations and group by `q` to replicate the §2 breakdown. Before the fix, expect ~2,285 lines with query `SELECT 1 FROM wisps WHERE id = ? LIMIT 1`. After Commit 1, expect that count to drop to 0 and see ~3 lines with `SELECT id FROM wisps WHERE id IN (?, ?, …)`.

--- a/docs/design/remote-latency-perf-plan.md
+++ b/docs/design/remote-latency-perf-plan.md
@@ -1,0 +1,639 @@
+# Remote-Latency Performance Fixes — Implementation Plan
+
+- Date: 2026-04-18
+- Branch: `alexmsu`
+- Spec: `docs/design/remote-latency-perf-design.md`
+- Status: Draft, pending review
+
+This plan enumerates the concrete ordered steps to implement the three commits described in the spec. Every step is reversible; no step is merged into `main` automatically. Each commit ends with an explicit verification gate.
+
+## Preconditions
+
+- Working tree on branch `alexmsu` is clean (`git status` shows only `.claude/settings.local.json.bak` as pre-existing untracked).
+- `go test ./...` passes on the current tree (baseline).
+- `golangci-lint run ./...` warning count captured (baseline).
+- Remote timing baseline captured (e.g., `time bd export -o /tmp/probe.jsonl` from hostB = 208 s).
+
+Command to establish baseline:
+
+```bash
+cd <beads-root>
+git status --short
+go test ./... > /tmp/baseline-tests.log 2>&1
+golangci-lint run ./... > /tmp/baseline-lint.log 2>&1
+```
+
+## Commit 1 — `perf(storage): batch wisp routing probes in bulk helpers`
+
+### 1.1 Add bulk partitioner
+
+**File:** `internal/storage/issueops/wisp_routing.go`
+
+Append after the existing `WispTableRouting` function. Ship **two** helpers: the primitive set-returner and the partition wrapper that call sites use.
+
+```go
+// ActiveWispIDsInTx returns the subset of ids that exist in the active
+// wisps table, batched at queryBatchSize. This is the primitive — most
+// call sites want PartitionByWispInTx below, which preserves input
+// ordering. Callers that range the returned map directly must be aware
+// Go map iteration order is randomized.
+//
+// Returns an empty (non-nil) map if ids is empty.
+func ActiveWispIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]bool, error) {
+    result := make(map[string]bool, len(ids))
+    if len(ids) == 0 {
+        return result, nil
+    }
+
+    for start := 0; start < len(ids); start += queryBatchSize {
+        end := start + queryBatchSize
+        if end > len(ids) {
+            end = len(ids)
+        }
+        batch := ids[start:end]
+
+        placeholders := make([]string, len(batch))
+        args := make([]any, len(batch))
+        for i, id := range batch {
+            placeholders[i] = "?"
+            args[i] = id
+        }
+
+        //nolint:gosec // G201: placeholders are only "?" literals
+        q := fmt.Sprintf("SELECT id FROM wisps WHERE id IN (%s)", strings.Join(placeholders, ","))
+        rows, err := tx.QueryContext(ctx, q, args...)
+        if err != nil {
+            return nil, fmt.Errorf("ActiveWispIDsInTx: %w", err)
+        }
+        for rows.Next() {
+            var id string
+            if err := rows.Scan(&id); err != nil {
+                _ = rows.Close()
+                return nil, fmt.Errorf("ActiveWispIDsInTx scan: %w", err)
+            }
+            result[id] = true
+        }
+        if err := rows.Err(); err != nil {
+            _ = rows.Close()
+            return nil, fmt.Errorf("ActiveWispIDsInTx rows: %w", err)
+        }
+        _ = rows.Close()
+    }
+
+    return result, nil
+}
+
+// PartitionByWispInTx splits ids into (wispIDs, permIDs) by running one
+// batched membership probe against the wisps table. The returned slices
+// preserve input order within each partition, so JSON export ordering
+// (bd export, bd list --json) stays deterministic across refactors.
+//
+// Callers that need a set primitive should use ActiveWispIDsInTx directly.
+func PartitionByWispInTx(ctx context.Context, tx *sql.Tx, ids []string) (wispIDs, permIDs []string, err error) {
+    if len(ids) == 0 {
+        return nil, nil, nil
+    }
+    wispSet, err := ActiveWispIDsInTx(ctx, tx, ids)
+    if err != nil {
+        return nil, nil, err
+    }
+    wispIDs = make([]string, 0, len(wispSet))
+    permIDs = make([]string, 0, len(ids)-len(wispSet))
+    for _, id := range ids {
+        if wispSet[id] {
+            wispIDs = append(wispIDs, id)
+        } else {
+            permIDs = append(permIDs, id)
+        }
+    }
+    return wispIDs, permIDs, nil
+}
+```
+
+Add the imports if not already present:
+
+```go
+import (
+    "context"
+    "database/sql"
+    "fmt"
+    "strings"
+)
+```
+
+Verify `queryBatchSize` is accessible from this package (it is — defined in the same `issueops` package).
+
+### 1.2 Unit tests
+
+**File:** `internal/storage/issueops/wisp_routing_test.go` (new)
+
+Leverage existing test helpers in `internal/storage/dolt/testmain_test.go`; do not mock the DB.
+
+1. `TestActiveWispIDsInTx_Empty` — `ids=nil` and `ids=[]` → empty map, no query issued.
+2. `TestActiveWispIDsInTx_AllPermanent` — seed only `issues` rows → empty map.
+3. `TestActiveWispIDsInTx_AllWisps` — seed only `wisps` rows → result equals input set.
+4. `TestActiveWispIDsInTx_Mixed` — seed both → result contains only wisp IDs.
+5. `TestActiveWispIDsInTx_Batching` — call with `queryBatchSize*2+1` IDs; assert the result still equals the expected wisp subset.
+6. `TestActiveWispIDsInTx_ParityWithLoop` — table-driven: for random ID sets, assert `ActiveWispIDsInTx` result equals bit-identical the per-ID `IsActiveWispInTx` partition.
+7. `TestPartitionByWispInTx_Ordering` — given interleaved wisps/perm IDs `[w1, p1, w2, p2, w3]`, assert returned `wispIDs == [w1, w2, w3]` and `permIDs == [p1, p2]` in input order.
+8. `TestPartitionByWispInTx_Empty` — nil and empty input → `(nil, nil, nil)`.
+
+### 1.2.1 Semantic-equal export parity test (mandatory)
+
+**File:** `internal/storage/issueops/wisp_routing_export_parity_test.go` (new)
+
+Create a fixture DB with ~20 permanent issues and ~20 explicit-ID wisps (mix of IDs, labels, dependencies, comments). Run two code paths against it:
+
+1. `legacyPartitionAndExport(ctx, store)` — retain a `testOnlyLegacyPartition` helper that uses the old per-ID loop, produce a JSONL byte stream.
+2. `bd export` via the new code path, produce a JSONL byte stream.
+
+Assertion: parse both JSONL streams into `[]*types.IssueWithCounts`, sort by `ID`, and `reflect.DeepEqual`. A byte-diff is intentionally avoided because it would fail on cosmetic JSON whitespace/field-order noise without any actual data regression.
+
+This test is the Commit 1 correctness gate. It must be green before Commit 1 ships.
+
+### 1.3 Replace per-ID loops at the 7 call sites
+
+For each site, apply the uniform transformation below — using `PartitionByWispInTx` (not the primitive). One `Edit` per file; keep the diff minimal.
+
+```go
+// from:
+var wispIDs, permIDs []string
+for _, id := range ids {
+    if IsActiveWispInTx(ctx, tx, id) {
+        wispIDs = append(wispIDs, id)
+    } else {
+        permIDs = append(permIDs, id)
+    }
+}
+
+// to:
+wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, ids)
+if err != nil {
+    return nil, err
+}
+```
+
+Per-file notes:
+
+**1.3.a** `internal/storage/issueops/dependencies.go` lines 210-218 inside `GetIssuesByIDsInTx`. Returns `([]*types.Issue, error)`.
+
+**1.3.b** `internal/storage/issueops/labels.go` lines 48-55 inside `GetLabelsForIssuesInTx`. Input slice is `issueIDs`; returns `(map[string][]string, error)`.
+
+**1.3.c** `internal/storage/issueops/comments.go` lines 56-63 inside `GetCommentCountsInTx`. Returns `(map[string]int, error)`.
+
+**1.3.d** `internal/storage/issueops/bulk_ops.go` lines 112-120 inside `GetCommentsForIssuesInTx`. Returns `(map[string][]*types.Comment, error)`.
+
+**1.3.e** `internal/storage/issueops/dependency_queries.go` lines 45-52 inside `GetDependencyRecordsForIssuesInTx`. Returns `(map[string][]*types.Dependency, error)`.
+
+**1.3.f** `internal/storage/issueops/dependency_queries.go` lines 205-214 inside `GetBlockingInfoForIssuesInTx`. Verify the exact return signature when editing; apply the matching `return <zero>, err`.
+
+**1.3.g** `internal/storage/issueops/delete.go` lines 76-84 inside `DeleteIssuesInTx`. Returns `(*types.DeleteIssuesResult, error)`. Existing names are `wispIDs` / `regularIDs`; rename returns from `PartitionByWispInTx` accordingly: `wispIDs, regularIDs, err := PartitionByWispInTx(...)`.
+
+### 1.4 Mandatory performance regression benchmark
+
+**File:** `internal/storage/issueops/wisp_routing_test.go` (same file as 1.2)
+
+Add `BenchmarkBulkPartitioning` that wraps the `*sql.Tx` with a counting driver and **fails** (`b.Fatalf`) if the query count exceeds the expected ceiling.
+
+```go
+// Expected query count for N IDs at queryBatchSize B:
+//   ceil(N / B) batched IN queries + at most 1 legacy fallback probe = tight ceiling.
+func BenchmarkBulkPartitioning(b *testing.B) {
+    const N = 500
+    // ... seed fixture ...
+    expectedMax := (N+queryBatchSize-1)/queryBatchSize + 1
+
+    var queryCount atomic.Int64
+    // wrap tx so every QueryContext increments queryCount
+    // ...
+
+    b.ResetTimer()
+    for i := 0; i < b.N; i++ {
+        queryCount.Store(0)
+        _, _, err := PartitionByWispInTx(ctx, tx, ids)
+        if err != nil {
+            b.Fatalf("partition: %v", err)
+        }
+        if got := queryCount.Load(); got > int64(expectedMax) {
+            b.Fatalf("N+1 regression: %d queries (max %d)", got, expectedMax)
+        }
+    }
+}
+```
+
+Running the full `go test ./...` executes benchmarks in their own phase; the ceiling assertion fails CI if a future refactor reintroduces an N+1.
+
+### 1.5 Verify Commit 1
+
+```bash
+cd <beads-root>
+go build ./...
+go test ./internal/storage/issueops/... -run 'TestActiveWispIDsInTx|TestPartitionByWispInTx|TestWispRoutingExportParity' -v
+go test -bench=BenchmarkBulkPartitioning -benchtime=3x ./internal/storage/issueops/...
+go test ./...
+golangci-lint run ./...
+
+# Manual remote timing:
+cd <bd-project>
+make -C <beads-root> install   # put fresh bd at ~/.local/bin/bd
+time bd export -o /tmp/commit1-probe.jsonl
+```
+
+**Gate.** `bd export` remote ≤ 10 s. Parity test green. Benchmark does not exceed its query-count ceiling. All existing tests green. Lint no new warnings. If not met: revert, return to Phase 1 of systematic debugging.
+
+### 1.6 Commit 1
+
+```bash
+cd <beads-root>
+bd export -o .beads/issues.jsonl   # refresh bd's own JSONL snapshot
+git add internal/storage/issueops/wisp_routing.go \
+        internal/storage/issueops/wisp_routing_test.go \
+        internal/storage/issueops/wisp_routing_export_parity_test.go \
+        internal/storage/issueops/dependencies.go \
+        internal/storage/issueops/labels.go \
+        internal/storage/issueops/comments.go \
+        internal/storage/issueops/bulk_ops.go \
+        internal/storage/issueops/dependency_queries.go \
+        internal/storage/issueops/delete.go \
+        .beads/issues.jsonl
+git commit -m "$(cat <<'EOF'
+perf(storage): batch wisp routing probes in bulk helpers
+
+Replace per-ID IsActiveWispInTx loops with one batched
+SELECT id FROM wisps WHERE id IN (...) via new ActiveWispIDsInTx +
+PartitionByWispInTx helpers.
+
+Eliminates a 2,285-query N+1 that dominated remote bd export wall time
+(208s -> ~8s with a 15ms remote RTT). Touches 7 bulk helpers in
+internal/storage/issueops/; single-ID call sites are unchanged.
+
+PartitionByWispInTx preserves input ordering so JSON export ordering
+remains deterministic. Mandatory benchmark asserts a query-count
+ceiling to catch future N+1 regressions.
+
+See docs/design/remote-latency-perf-design.md
+EOF
+)"
+```
+
+## Commit 2 — `perf(dolt): enable InterpolateParams to collapse prepared-statement round-trips`
+
+### 2.1 DSN flag flip
+
+**File:** `internal/storage/doltutil/dsn.go` (in `ServerDSN.String()`):
+
+```go
+cfg := mysql.Config{
+    User:                 d.User,
+    Passwd:               d.Password,
+    Net:                  "tcp",
+    Addr:                 fmt.Sprintf("%s:%d", d.Host, d.Port),
+    DBName:               d.Database,
+    ParseTime:            true,
+    MultiStatements:      true,
+    InterpolateParams:    true,   // added
+    Timeout:              timeout,
+    AllowNativePasswords: true,
+}
+```
+
+### 2.2 Driver-behavior audit (enumerated, for the commit message)
+
+Run each grep below, paste the raw results into a scratch file, and include the final distilled table in the commit message. This replaces the previously-vague "spot-check" language.
+
+```bash
+# a) Every Exec/Query arg type on server-mode write paths
+grep -rn --include='*.go' -E "\.(ExecContext|QueryContext|QueryRowContext)\(" internal/storage/ cmd/bd/ | grep -v _test.go
+
+# b) []byte / BLOB argument usage on write paths
+grep -rn --include='*.go' -E "\.(Exec|Query)(Context)?\([^)]*\[\]byte" internal/ cmd/ | grep -v _test.go
+
+# c) Prepare / Stmt reuse (expected: zero hits in non-test code)
+grep -rn --include='*.go' -E "\.(Prepare|PrepareContext)\(|\bsql\.Stmt\b|\*sql\.Stmt" internal/ cmd/ | grep -v _test.go
+
+# d) driver.Valuer implementations
+grep -rn --include='*.go' -E "func .* Value\(\) \(driver\.Value" internal/types/
+
+# e) json.RawMessage passed as Exec arg
+grep -rn --include='*.go' "json.RawMessage" internal/storage/ cmd/bd/
+```
+
+Confirmed findings (from the spec §5 audit table — reproduce here for commit-message traceability):
+
+- `string`, `int`, `int64`, `bool`, `time.Time`, `*time.Time`, `nil` — all interpolate identically to server-side PREPARE.
+- `[]byte` appears only in `internal/storage/issueops/federation.go:32-46` and `internal/storage/dolt/credentials.go:166,258-265` (encrypted password); driver hex-literal escape applies.
+- Zero `Prepare` / `Stmt` / `driver.Valuer` / `json.RawMessage`-as-Exec-arg hits.
+- `MultiStatements=true` and `InterpolateParams=true` are orthogonal in `github.com/go-sql-driver/mysql@v1.9.3/connection.go:340-410`.
+
+Paste the raw grep output + distilled table into the commit message body.
+
+Record findings inline as comments in `dsn.go` at the `InterpolateParams: true` line.
+
+### 2.3 Unit test — DSN flag presence
+
+**File:** `internal/storage/doltutil/dsn_test.go` (new)
+
+```go
+package doltutil
+
+import (
+    "strings"
+    "testing"
+)
+
+func TestServerDSN_InterpolateParams(t *testing.T) {
+    dsn := ServerDSN{Host: "127.0.0.1", Port: 3307, User: "root"}.String()
+    if !strings.Contains(dsn, "interpolateParams=true") {
+        t.Fatalf("expected interpolateParams=true in DSN, got: %s", dsn)
+    }
+    // existing flags must still be present
+    for _, want := range []string{"parseTime=true", "multiStatements=true", "allowNativePasswords=true"} {
+        if !strings.Contains(dsn, want) {
+            t.Fatalf("expected %s in DSN, got: %s", want, dsn)
+        }
+    }
+}
+```
+
+### 2.4 Dolt-specific round-trip integration test (mandatory)
+
+**File:** `internal/storage/dolt/interpolate_params_test.go` (new)
+
+Uses the existing Dolt test harness (`testmain_test.go`). Opens two database handles against the same DB — one with `InterpolateParams=false`, one with `=true`. Inserts and retrieves edge-case values into the real `issues` table.
+
+```go
+func TestInterpolateParams_RoundTripParity(t *testing.T) {
+    // ... spin up in-process Dolt via existing test helper ...
+    cases := []struct {
+        name      string
+        issueID   string
+        metadata  string                 // JSON column
+        createdAt time.Time              // DATETIME column (schema is second-precision)
+        title     string                 // String with metacharacters
+    }{
+        {"json_null_nested", "t-json",
+            `{"a":null,"emoji":"\u00e9","nested":{"k":[1,2,3]}}`,
+            time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC),
+            "plain"},
+        {"datetime_fractional", "t-dt",
+            `{}`,
+            time.Date(2026, 4, 18, 12, 34, 56, 123456789, time.UTC),
+            "plain"},
+        {"string_metachars", "t-str",
+            `{}`,
+            time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC),
+            `O'Brien\n"quote" \\`},
+    }
+
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            out1 := roundTripThroughDB(t, /*interpolate=*/ false, tc)
+            out2 := roundTripThroughDB(t, /*interpolate=*/ true, tc)
+            if !reflect.DeepEqual(out1, out2) {
+                t.Fatalf("interpolate=true produced different result:\n  off: %+v\n  on:  %+v", out1, out2)
+            }
+        })
+    }
+}
+```
+
+Intentionally **no** BLOB case — bd has no BLOB in parameterized write paths beyond `federation_peers.password_encrypted`, which is already covered by existing federation tests. The reviewer's BLOCKER 3 is closed by this test.
+
+### 2.5 Verify Commit 2
+
+```bash
+cd <beads-root>
+go test ./internal/storage/doltutil/... -v
+go test ./internal/storage/dolt/... -run TestInterpolateParams -v
+go test ./...
+golangci-lint run ./...
+
+make install
+cd <bd-project>
+time bd export -o /tmp/commit2-probe.jsonl
+```
+
+**Gate.** `bd export` remote ≤ 10 s (the §9 success target). Round-trip parity test green. Full suite green. Lint clean. If any test fails with new `time.Time` / JSON / string-escape mismatches, revert and open a bd issue for the specific incompatibility.
+
+### 2.6 Commit 2
+
+```bash
+cd <beads-root>
+bd export -o .beads/issues.jsonl
+git add internal/storage/doltutil/dsn.go \
+        internal/storage/doltutil/dsn_test.go \
+        internal/storage/dolt/interpolate_params_test.go \
+        .beads/issues.jsonl
+git commit -m "$(cat <<'EOF'
+perf(dolt): enable InterpolateParams to collapse prepared-statement RTTs
+
+Set InterpolateParams: true in ServerDSN. go-sql-driver/mysql quotes
+arguments client-side, so each parameterized query becomes a single
+round-trip instead of the multi-RT binary protocol.
+
+Combined with commit 1, this keeps remote bd export within the
+10s success target (§9).
+
+Driver-behavior audit (grepped against non-test code, see design §5):
+- string/int/int64/bool/time.Time/nil interpolate identically
+- []byte appears only in federation.go / credentials.go password paths,
+  already hex-escaped by the driver
+- zero Prepare/Stmt reuse in non-test code (no regression risk)
+- no custom driver.Valuer in internal/types
+- no json.RawMessage passed as Exec arg
+- MultiStatements and InterpolateParams are orthogonal in
+  go-sql-driver/mysql@v1.9.3/connection.go:340-410
+
+Side benefit: Dolt query log now shows final interpolated SQL, which
+is strictly better for EXPLAIN / post-mortem debugging.
+
+Dolt-specific round-trip parity test added:
+internal/storage/dolt/interpolate_params_test.go covers JSON, DATETIME
+fractional seconds, and strings with SQL metacharacters.
+
+ParseTime and MultiStatements remain set.
+
+See docs/design/remote-latency-perf-design.md
+EOF
+)"
+```
+
+## Commit 3 — `perf(dolt): tune connection-pool settings in auxiliary paths`
+
+### 3.1 Extract pool constants
+
+**File:** `cmd/bd/doctor/pool_config.go` (new)
+
+```go
+// Package doctor — connection-pool constants for diagnostic / cleanup paths.
+// Widened from the historical 2/1/30s to 5/2/60s:
+//   - Historical values were chosen arbitrarily (no git-blame rationale).
+//   - 5 open conns lets doctor probes run modestly concurrent without
+//     saturating the shared Dolt server.
+//   - 60s lifetime is defense-in-depth against any hypothetical session-
+//     state drift (DOLT_CHECKOUT is not reachable from these call sites,
+//     verified in design §5 Commit 3 branch-switching audit).
+//   - The main long-lived daemon pool in internal/storage/dolt/store.go
+//     uses 10/5/1h — these diagnostic pools intentionally stay narrower.
+package doctor
+
+import "time"
+
+const DiagnosticPoolMaxOpenConns = 5
+const DiagnosticPoolMaxIdleConns = 2
+const DiagnosticPoolMaxLifetime  = 60 * time.Second
+```
+
+### 3.2 Update the three call sites to use the constants
+
+**3.2.a** `cmd/bd/dolt.go` lines 1518-1520:
+
+```go
+import "github.com/steveyegge/beads/cmd/bd/doctor"   // add if missing
+
+db.SetMaxOpenConns(doctor.DiagnosticPoolMaxOpenConns)
+db.SetMaxIdleConns(doctor.DiagnosticPoolMaxIdleConns)
+db.SetConnMaxLifetime(doctor.DiagnosticPoolMaxLifetime)
+```
+
+(If importing `cmd/bd/doctor` from `cmd/bd` creates a cycle, duplicate the three constants in `cmd/bd/dolt_pool.go` with a doc-comment pointing to `cmd/bd/doctor/pool_config.go` as the canonical source. Verify with `go build ./...` first.)
+
+**3.2.b** `cmd/bd/doctor/server.go` lines 320-322 — same constants.
+
+**3.2.c** `cmd/bd/doctor/dolt.go` lines 59-61 — same constants.
+
+Do **not** touch any other `SetMaxOpenConns(1)` in the repository. See the explicit non-touch list in the spec.
+
+### 3.3 Constants-used-by-call-sites test
+
+**File:** `cmd/bd/doctor/pool_config_test.go` (new)
+
+A simple sanity test that the three constants have the values the spec claims, and that they are neither the old historical defaults nor accidentally-zero.
+
+```go
+package doctor
+
+import (
+    "testing"
+    "time"
+)
+
+func TestDiagnosticPoolConstants(t *testing.T) {
+    if DiagnosticPoolMaxOpenConns != 5 {
+        t.Errorf("MaxOpenConns = %d, want 5", DiagnosticPoolMaxOpenConns)
+    }
+    if DiagnosticPoolMaxIdleConns != 2 {
+        t.Errorf("MaxIdleConns = %d, want 2", DiagnosticPoolMaxIdleConns)
+    }
+    if DiagnosticPoolMaxLifetime != 60*time.Second {
+        t.Errorf("MaxLifetime = %v, want 60s", DiagnosticPoolMaxLifetime)
+    }
+}
+```
+
+### 3.4 Verify no correctness regression
+
+Running the full test suite covers the concurrency/merge semantics of the widened paths:
+
+```bash
+cd <beads-root>
+go test ./cmd/bd/... ./internal/... -race -count=1
+```
+
+If the `-race` run is too slow on the machine, restrict to the affected packages:
+
+```bash
+go test ./cmd/bd/doctor/... ./internal/storage/dolt/... -race -count=1
+```
+
+### 3.5 Verify Commit 3
+
+```bash
+make install
+cd <bd-project>
+time bd doctor
+time bd dolt status   # if applicable; exercises cmd/bd/dolt.go path
+```
+
+**Gate.** No test regressions. `bd doctor` faster than pre-Commit-1 baseline (91 s) by a meaningful margin (expect ≥ 20 s improvement from Commit 1 alone; Commit 3 adds marginal gains).
+
+### 3.6 Commit 3
+
+```bash
+cd <beads-root>
+bd export -o .beads/issues.jsonl
+git add cmd/bd/doctor/pool_config.go \
+        cmd/bd/doctor/pool_config_test.go \
+        cmd/bd/dolt.go \
+        cmd/bd/doctor/server.go \
+        cmd/bd/doctor/dolt.go \
+        .beads/issues.jsonl
+git commit -m "$(cat <<'EOF'
+perf(dolt): tune connection-pool settings in auxiliary paths
+
+Widen three auxiliary SQL pool configurations from 2/1/30s to 5/2/60s:
+- cmd/bd/dolt.go (dolt subcommands; reachable only from clean-databases)
+- cmd/bd/doctor/server.go (server-mode doctor probe, read-only fan-out)
+- cmd/bd/doctor/dolt.go (dolt-specific doctor probe, read-only)
+
+Values extracted into named constants in cmd/bd/doctor/pool_config.go
+(DiagnosticPoolMaxOpenConns=5, MaxIdleConns=2, MaxLifetime=60s) with
+a test asserting the intended values are used, so future audits are
+trivial.
+
+Branch-switching audit: none of the three call sites reach DOLT_CHECKOUT
+(actual CHECKOUT sites are in internal/storage/versioncontrolops/).
+The 60s lifetime is defense-in-depth — the reviewer-proposed cap
+adopted even though no session-state risk was identified.
+
+Embedded mode, execWithLongTimeout, and admin helpers
+(EnsureGlobalDatabase, FlushWorkingSet) are intentionally left
+unchanged — their MaxOpenConns=1 is a correctness invariant or
+an isolation barrier, not an oversight.
+
+See docs/design/remote-latency-perf-design.md
+EOF
+)"
+```
+
+## Final verification
+
+After all three commits:
+
+```bash
+cd <beads-root>
+git log --oneline alexmsu ^main | head
+go test ./... 2>&1 | tail -20
+golangci-lint run ./... 2>&1 | tail -20
+make install
+
+# Remote, hostB:
+cd <bd-project>
+time bd export -o /tmp/final-probe.jsonl
+time git commit --allow-empty -m "post-perf-fixes smoke"
+time bd doctor
+time bd list --json > /dev/null
+time bd ready --json > /dev/null
+```
+
+**Acceptance matrix.**
+
+| Metric | Baseline | Target | Measured |
+|---|---:|---:|---|
+| `bd export` remote | 208 s | ≤ 10 s | _to record_ |
+| `git commit --allow-empty` | 3m29s | ≤ 15 s | _to record_ |
+| `bd doctor` | 91 s | noticeable drop | _to record_ |
+| `go test ./...` | green | green | _to record_ |
+| `golangci-lint` new warnings | 0 | 0 | _to record_ |
+
+## Rollback
+
+Each commit is reverted independently with `git revert <sha>`. The bulk partitioner from Commit 1 can stay even if the call sites are reverted (it's a pure addition). The DSN flag in Commit 2 is a one-line revert. Commit 3 is three isolated edits.
+
+If a later bd upstream release introduces a conflicting change (for example, upstream shipping its own `ActiveWispIDsInTx` helper), resolve by taking upstream and re-porting the call-site edits.
+
+## Hand-off notes
+
+- After all commits merge into `main`, delete the measurement baselines at `/tmp/baseline-*.log` and `/tmp/commit*-probe.jsonl`.
+- Follow-up items listed in spec §10 ("Out of Scope / Follow-ups" — bd daemon, RunCompatMigrations fast-path, local embedded-clone topology, bulk-helper observability) stay documented there; no separate tracker issues for this work.
+- Update the project memory under `<claude-memory-dir>` with a short pointer: "remote-latency cause was N+1 wisp routing + 3-RT prepared-statement protocol, fixed on branch alexmsu".

--- a/internal/storage/dolt/interpolate_params_test.go
+++ b/internal/storage/dolt/interpolate_params_test.go
@@ -1,0 +1,193 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	gomysql "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
+)
+
+// TestInterpolateParams_RoundTripParity writes and reads back the same edge-case
+// values via two sql.DB handles — one with InterpolateParams=true, one with
+// =false — against the same Dolt database, asserting byte-for-byte parity on
+// the read path.
+//
+// This is the reviewer's BLOCKER 3 closer for the Commit 2 DSN flag flip
+// (see docs/design/remote-latency-perf-design.md §5).
+//
+// Cases exercise the three places where client-side interpolation is most
+// likely to differ from server-side PREPARE:
+//   - JSON column with escaped Unicode and nested objects
+//   - DATETIME column (schema is second-precision; sub-second
+//     fractional values are truncated identically on both paths)
+//   - String column with SQL metacharacters (quotes, backslashes, newlines)
+//
+// Intentionally no BLOB case — bd has no BLOB in parameterized write paths
+// beyond federation_peers.password_encrypted, which is already covered by
+// existing federation tests.
+func TestInterpolateParams_RoundTripParity(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Create a fresh database for this test so we don't clobber the shared
+	// schema. We apply the full migration set so the real `issues` table
+	// (with JSON metadata and DATETIME created_at) is present.
+	dbName := uniqueTestDBName(t)
+	adminDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root"}.String()
+	admin, err := sql.Open("mysql", adminDSN)
+	if err != nil {
+		t.Fatalf("open admin connection: %v", err)
+	}
+	defer admin.Close()
+	if _, err := admin.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = admin.ExecContext(context.Background(), "DROP DATABASE IF EXISTS `"+dbName+"`")
+	})
+
+	// Apply migrations via a throwaway handle using the default (post-Commit 2)
+	// DSN. That DSN already has InterpolateParams=true, but that's irrelevant
+	// for DDL — migrations are idempotent and schema-only.
+	schemaDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root", Database: dbName}.String()
+	schemaDB, err := sql.Open("mysql", schemaDSN)
+	if err != nil {
+		t.Fatalf("open schema connection: %v", err)
+	}
+	if err := initSchemaOnDB(ctx, schemaDB); err != nil {
+		schemaDB.Close()
+		t.Fatalf("initSchemaOnDB: %v", err)
+	}
+	schemaDB.Close()
+
+	// Build two handles: one explicitly InterpolateParams=false (pre-Commit 2
+	// behavior: binary PREPARE/EXECUTE protocol), and one explicitly =true
+	// (post-Commit 2 behavior: client-side interpolation). Keep every other
+	// flag identical to the production DSN so we isolate the variable.
+	buildCfg := func(interpolate bool) *gomysql.Config {
+		return &gomysql.Config{
+			User:                 "root",
+			Net:                  "tcp",
+			Addr:                 fmt.Sprintf("127.0.0.1:%d", testServerPort),
+			DBName:               dbName,
+			ParseTime:            true,
+			MultiStatements:      true,
+			InterpolateParams:    interpolate,
+			Timeout:              5 * time.Second,
+			AllowNativePasswords: true,
+			TLSConfig:            "false",
+		}
+	}
+
+	dbOff, err := sql.Open("mysql", buildCfg(false).FormatDSN())
+	if err != nil {
+		t.Fatalf("open InterpolateParams=false handle: %v", err)
+	}
+	defer dbOff.Close()
+	dbOff.SetMaxOpenConns(1)
+
+	dbOn, err := sql.Open("mysql", buildCfg(true).FormatDSN())
+	if err != nil {
+		t.Fatalf("open InterpolateParams=true handle: %v", err)
+	}
+	defer dbOn.Close()
+	dbOn.SetMaxOpenConns(1)
+
+	cases := []struct {
+		name      string
+		issueID   string
+		metadata  string    // JSON column
+		createdAt time.Time // DATETIME column (schema is second-precision)
+		title     string    // VARCHAR with SQL metacharacters
+	}{
+		{
+			name:      "json_null_nested",
+			issueID:   "t-json",
+			metadata:  `{"a":null,"emoji":"\u00e9","nested":{"k":[1,2,3]}}`,
+			createdAt: time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC),
+			title:     "plain",
+		},
+		{
+			name:      "datetime_fractional",
+			issueID:   "t-dt",
+			metadata:  `{}`,
+			createdAt: time.Date(2026, 4, 18, 12, 34, 56, 123456789, time.UTC),
+			title:     "plain",
+		},
+		{
+			name:      "string_metachars",
+			issueID:   "t-str",
+			metadata:  `{}`,
+			createdAt: time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC),
+			title:     `O'Brien` + "\n" + `"quote" \\`,
+		},
+	}
+
+	type roundTripResult struct {
+		id        string
+		title     string
+		metadata  string
+		createdAt time.Time
+	}
+
+	roundTrip := func(t *testing.T, db *sql.DB, idSuffix string, tc struct {
+		name      string
+		issueID   string
+		metadata  string
+		createdAt time.Time
+		title     string
+	}) roundTripResult {
+		t.Helper()
+		id := tc.issueID + "-" + idSuffix
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, metadata, created_at)
+			 VALUES (?, ?, '', '', '', '', ?, ?)`,
+			id, tc.title, tc.metadata, tc.createdAt,
+		)
+		if err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+
+		var got roundTripResult
+		err = db.QueryRowContext(ctx,
+			`SELECT id, title, metadata, created_at FROM issues WHERE id = ?`,
+			id,
+		).Scan(&got.id, &got.title, &got.metadata, &got.createdAt)
+		if err != nil {
+			t.Fatalf("select %s: %v", id, err)
+		}
+		return got
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			offResult := roundTrip(t, dbOff, "off", tc)
+			onResult := roundTrip(t, dbOn, "on", tc)
+
+			// Strip the per-handle ID suffix before comparing — everything else
+			// (title, metadata JSON canonical form, created_at after DATETIME
+			// truncation) must match byte-for-byte across the two paths.
+			offResult.id = ""
+			onResult.id = ""
+
+			if !reflect.DeepEqual(offResult, onResult) {
+				t.Fatalf("InterpolateParams changed round-trip result:\n  off: %+v\n  on:  %+v", offResult, onResult)
+			}
+		})
+	}
+}

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -20,7 +20,8 @@ type ServerDSN struct {
 }
 
 // String builds the MySQL DSN string. Always sets parseTime=true,
-// multiStatements=true, allowNativePasswords=true, and a connect timeout.
+// multiStatements=true, interpolateParams=true, allowNativePasswords=true,
+// and a connect timeout.
 func (d ServerDSN) String() string {
 	timeout := d.Timeout
 	if timeout == 0 {
@@ -28,13 +29,25 @@ func (d ServerDSN) String() string {
 	}
 
 	cfg := mysql.Config{
-		User:                 d.User,
-		Passwd:               d.Password,
-		Net:                  "tcp",
-		Addr:                 fmt.Sprintf("%s:%d", d.Host, d.Port),
-		DBName:               d.Database,
-		ParseTime:            true,
-		MultiStatements:      true,
+		User:            d.User,
+		Passwd:          d.Password,
+		Net:             "tcp",
+		Addr:            fmt.Sprintf("%s:%d", d.Host, d.Port),
+		DBName:          d.Database,
+		ParseTime:       true,
+		MultiStatements: true,
+		// InterpolateParams collapses each parameterized query from
+		// 3 network round-trips (PREPARE + EXECUTE + CLOSE) to 1 by
+		// quoting args client-side. Audit (design §5, Commit 2):
+		//   - string/int/int64/bool/time.Time/nil: identical wire output
+		//   - []byte appears only in federation.go / credentials.go
+		//     password paths, driver hex-escapes identically
+		//   - zero Prepare/Stmt reuse in non-test code
+		//   - no driver.Valuer implementations in internal/types
+		//   - no json.RawMessage passed directly as an Exec arg
+		//   - orthogonal to MultiStatements (go-sql-driver/mysql
+		//     v1.9.3 connection.go:340-410)
+		InterpolateParams:    true,
 		Timeout:              timeout,
 		AllowNativePasswords: true,
 	}

--- a/internal/storage/doltutil/dsn_test.go
+++ b/internal/storage/doltutil/dsn_test.go
@@ -36,3 +36,24 @@ func TestServerDSN_TLSEnabledWhenRequested(t *testing.T) {
 		t.Errorf("DSN should not contain tls=false when TLS is enabled; got %q", dsn)
 	}
 }
+
+// TestServerDSN_InterpolateParams asserts the DSN enables client-side
+// parameter interpolation (see design 2026-04-18 §5 Commit 2) and preserves
+// the other non-default flags.
+//
+// Note: go-sql-driver/mysql's FormatDSN only emits parameters whose value
+// differs from the driver's own defaults. AllowNativePasswords defaults to
+// true, so it is never serialized into the DSN string even though the
+// mysql.Config struct has it set — that's not a regression, just how the
+// driver serializes. We therefore only assert on non-default flags.
+func TestServerDSN_InterpolateParams(t *testing.T) {
+	dsn := ServerDSN{Host: "127.0.0.1", Port: 3307, User: "root"}.String()
+	if !strings.Contains(dsn, "interpolateParams=true") {
+		t.Fatalf("expected interpolateParams=true in DSN, got: %s", dsn)
+	}
+	for _, want := range []string{"parseTime=true", "multiStatements=true"} {
+		if !strings.Contains(dsn, want) {
+			t.Fatalf("expected %s in DSN, got: %s", want, dsn)
+		}
+	}
+}

--- a/internal/storage/embeddeddolt/wisp_routing_export_parity_test.go
+++ b/internal/storage/embeddeddolt/wisp_routing_export_parity_test.go
@@ -1,0 +1,378 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+// wisp_routing_export_parity_test.go — Commit 1 correctness gate.
+//
+// Creates a fixture DB with ~20 permanent issues and ~20 explicit-ID wisps,
+// then compares four bulk helpers rewritten in this commit against a legacy
+// per-ID IsActiveWispInTx loop:
+//
+//   - GetLabelsForIssuesInTx        vs legacyLabels
+//   - GetCommentCountsInTx          vs legacyCommentCounts
+//   - GetCommentsForIssuesInTx      vs legacyCommentContent
+//   - GetDependencyRecordsForIssuesInTx vs legacyDependencyRecords
+//
+// Each legacy helper calls IsActiveWispInTx(ctx, tx, id) per ID and queries
+// the appropriate table (comments/wisp_comments, labels/wisp_labels, etc.)
+// directly — mirroring the code path that existed BEFORE PartitionByWispInTx
+// was introduced. reflect.DeepEqual is the comparison; slice contents are
+// sorted where needed so the check is order-agnostic.
+//
+// A byte-diff on exported JSONL is intentionally avoided because JSON
+// field-order noise would cause false failures. Instead we compare typed
+// Go structures.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// buildParityFixture seeds ~20 permanent issues and ~20 wisps with labels,
+// comments, and cross-dependencies, then returns the combined ID slice.
+func buildParityFixture(t *testing.T, te *testEnv) []string {
+	t.Helper()
+	ctx := t.Context()
+
+	const nPerm = 20
+	const nWisp = 20
+
+	var ids []string
+
+	// Seed permanent issues.
+	for i := 0; i < nPerm; i++ {
+		id := fmt.Sprintf("par-perm-%02d", i)
+		ids = append(ids, id)
+		if err := te.store.CreateIssue(ctx, &types.Issue{
+			ID:        id,
+			Title:     "perm " + id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}, "tester"); err != nil {
+			t.Fatalf("CreateIssue perm %q: %v", id, err)
+		}
+	}
+
+	// Seed wisp issues.
+	for i := 0; i < nWisp; i++ {
+		id := fmt.Sprintf("par-wisp-%02d", i)
+		ids = append(ids, id)
+		if err := te.store.CreateIssue(ctx, &types.Issue{
+			ID:        id,
+			Title:     "wisp " + id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}, "tester"); err != nil {
+			t.Fatalf("CreateIssue wisp %q: %v", id, err)
+		}
+	}
+
+	// Add labels to every other issue (alternating perm/wisp).
+	for i, id := range ids {
+		if i%3 == 0 {
+			if err := te.store.AddLabel(ctx, id, "tagged", "tester"); err != nil {
+				t.Fatalf("AddLabel %q: %v", id, err)
+			}
+		}
+		if i%5 == 0 {
+			if err := te.store.AddLabel(ctx, id, "important", "tester"); err != nil {
+				t.Fatalf("AddLabel2 %q: %v", id, err)
+			}
+		}
+	}
+
+	// Add comments to every 4th issue (single comment).
+	for i, id := range ids {
+		if i%4 == 0 {
+			if _, err := te.store.AddIssueComment(ctx, id, "bot", "comment on "+id); err != nil {
+				t.Fatalf("AddIssueComment %q: %v", id, err)
+			}
+		}
+	}
+
+	// Add multiple comments on both a wisp and a permanent issue so the
+	// content parity check is non-trivial (exercises ordering + multi-row).
+	multiPerm := "par-perm-01"
+	multiWisp := "par-wisp-01"
+	for i, id := range []string{multiPerm, multiWisp} {
+		for j := 0; j < 3; j++ {
+			text := fmt.Sprintf("multi-%d on %s", j, id)
+			if _, err := te.store.AddIssueComment(ctx, id, "bot", text); err != nil {
+				t.Fatalf("AddIssueComment multi[%d][%d] %q: %v", i, j, id, err)
+			}
+		}
+	}
+
+	return ids
+}
+
+// legacyLabels reproduces the old per-ID partition for GetLabelsForIssues.
+func legacyLabels(ctx context.Context, tx *sql.Tx, ids []string) (map[string][]string, error) {
+	result := make(map[string][]string)
+	var wispIDs, permIDs []string
+	for _, id := range ids {
+		if issueops.IsActiveWispInTx(ctx, tx, id) {
+			wispIDs = append(wispIDs, id)
+		} else {
+			permIDs = append(permIDs, id)
+		}
+	}
+	// Merge labels from both tables.
+	for _, pair := range []struct {
+		table string
+		batch []string
+	}{
+		{"wisp_labels", wispIDs},
+		{"labels", permIDs},
+	} {
+		if len(pair.batch) == 0 {
+			continue
+		}
+		for _, id := range pair.batch {
+			lbls, err := issueops.GetLabelsInTx(ctx, tx, pair.table, id)
+			if err != nil {
+				return nil, err
+			}
+			if len(lbls) > 0 {
+				result[id] = lbls
+			}
+		}
+	}
+	return result, nil
+}
+
+// TestWispRoutingExportParity is the Commit 1 correctness gate.
+// It verifies that GetLabelsForIssuesInTx (and the comment/dep bulk helpers
+// which use the same partition) produce semantically identical output whether
+// the partitioning is done per-ID (legacy) or via PartitionByWispInTx (new).
+func TestWispRoutingExportParity(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "par")
+	ids := buildParityFixture(t, te)
+
+	// Open a single read-only tx for both paths.
+	ctx := t.Context()
+	db, dbCleanup, err := embeddeddolt.OpenSQL(ctx, te.dataDir, te.database, "main")
+	if err != nil {
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	defer dbCleanup()
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: false})
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer tx.Rollback()
+
+	// --- Labels ---
+	legacyLbls, err := legacyLabels(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("legacyLabels: %v", err)
+	}
+	newLbls, err := issueops.GetLabelsForIssuesInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("GetLabelsForIssuesInTx: %v", err)
+	}
+
+	// Normalize: sort label slices for deterministic comparison.
+	normalizeLabelMap(legacyLbls)
+	normalizeLabelMap(newLbls)
+
+	if !reflect.DeepEqual(legacyLbls, newLbls) {
+		t.Errorf("labels mismatch:\nlegacy: %v\nnew:    %v", legacyLbls, newLbls)
+	}
+
+	// --- Comment counts ---
+	legacyCounts, err := legacyCommentCounts(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("legacyCommentCounts: %v", err)
+	}
+	newCounts, err := issueops.GetCommentCountsInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("GetCommentCountsInTx: %v", err)
+	}
+	if !reflect.DeepEqual(legacyCounts, newCounts) {
+		t.Errorf("comment counts mismatch:\nlegacy: %v\nnew:    %v", legacyCounts, newCounts)
+	}
+
+	// --- Comment content (full rows, not just counts) ---
+	legacyComments, err := legacyCommentContent(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("legacyCommentContent: %v", err)
+	}
+	newComments, err := issueops.GetCommentsForIssuesInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("GetCommentsForIssuesInTx: %v", err)
+	}
+	// GetCommentsForIssuesInTx returns a non-nil empty map; legacy may too.
+	// Sort each issue's comment slice deterministically before comparing.
+	normalizeCommentMap(legacyComments)
+	normalizeCommentMap(newComments)
+	if !reflect.DeepEqual(legacyComments, newComments) {
+		t.Errorf("comment content mismatch:\nlegacy: %+v\nnew:    %+v", legacyComments, newComments)
+	}
+
+	// --- Dependency records ---
+	legacyDeps, err := legacyDependencyRecords(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("legacyDependencyRecords: %v", err)
+	}
+	newDeps, err := issueops.GetDependencyRecordsForIssuesInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("GetDependencyRecordsForIssuesInTx: %v", err)
+	}
+	if !reflect.DeepEqual(legacyDeps, newDeps) {
+		t.Errorf("dependency records mismatch:\nlegacy: %v\nnew:    %v", legacyDeps, newDeps)
+	}
+
+	// Total comment rows across all issues — sanity check that the multi-comment
+	// fixture exercised the multi-row code path.
+	totalCommentRows := 0
+	for _, cs := range newComments {
+		totalCommentRows += len(cs)
+	}
+	t.Logf("parity OK: %d IDs, %d with labels, %d with comments, %d comment rows, %d dep-record buckets",
+		len(ids), len(newLbls), len(newCounts), totalCommentRows, len(newDeps))
+}
+
+// normalizeLabelMap sorts label slices in place so DeepEqual is order-agnostic.
+func normalizeLabelMap(m map[string][]string) {
+	for id, lbls := range m {
+		sort.Strings(lbls)
+		m[id] = lbls
+	}
+}
+
+// legacyCommentCounts reproduces the old per-ID partition for GetCommentCounts.
+// Only records entries with cnt > 0 to match GetCommentCountsInTx semantics
+// (which uses GROUP BY and only emits rows with at least one comment).
+func legacyCommentCounts(ctx context.Context, tx *sql.Tx, ids []string) (map[string]int, error) {
+	result := make(map[string]int)
+	for _, id := range ids {
+		table := "comments"
+		if issueops.IsActiveWispInTx(ctx, tx, id) {
+			table = "wisp_comments"
+		}
+		var cnt int
+		err := tx.QueryRowContext(ctx,
+			fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE issue_id = ?", table), //nolint:gosec
+			id).Scan(&cnt)
+		if err != nil {
+			return nil, fmt.Errorf("count comments for %s: %w", id, err)
+		}
+		if cnt > 0 {
+			result[id] = cnt
+		}
+	}
+	return result, nil
+}
+
+// legacyCommentContent reproduces the OLD per-ID partition for
+// GetCommentsForIssuesInTx: for each ID, call IsActiveWispInTx to pick the
+// table (comments vs wisp_comments) and query that table directly.
+// Matches the column set and ORDER BY in bulk_ops.go so DeepEqual is
+// meaningful.
+func legacyCommentContent(ctx context.Context, tx *sql.Tx, ids []string) (map[string][]*types.Comment, error) {
+	result := make(map[string][]*types.Comment)
+	for _, id := range ids {
+		table := "comments"
+		if issueops.IsActiveWispInTx(ctx, tx, id) {
+			table = "wisp_comments"
+		}
+		//nolint:gosec // G201: table is one of two hardcoded literals
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+			`SELECT id, issue_id, author, text, created_at
+			 FROM %s
+			 WHERE issue_id = ?
+			 ORDER BY issue_id, created_at ASC, id ASC`, table), id)
+		if err != nil {
+			return nil, fmt.Errorf("legacyCommentContent %s: %w", id, err)
+		}
+		for rows.Next() {
+			var c types.Comment
+			if scanErr := rows.Scan(&c.ID, &c.IssueID, &c.Author, &c.Text, &c.CreatedAt); scanErr != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("legacyCommentContent scan %s: %w", id, scanErr)
+			}
+			result[c.IssueID] = append(result[c.IssueID], &c)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("legacyCommentContent rows %s: %w", id, err)
+		}
+	}
+	return result, nil
+}
+
+// normalizeCommentMap sorts each issue's comment slice by (created_at, id)
+// so DeepEqual is insensitive to any transient storage-engine ordering.
+// GetCommentsForIssuesInTx and legacyCommentContent both use the same
+// ORDER BY in SQL, so this is defense-in-depth — but it also prevents
+// flakes if storage ever yields ties in a different internal order.
+func normalizeCommentMap(m map[string][]*types.Comment) {
+	for _, cs := range m {
+		sort.Slice(cs, func(i, j int) bool {
+			if !cs[i].CreatedAt.Equal(cs[j].CreatedAt) {
+				return cs[i].CreatedAt.Before(cs[j].CreatedAt)
+			}
+			return cs[i].ID < cs[j].ID
+		})
+	}
+}
+
+// legacyDependencyRecords reproduces the OLD per-ID partition for
+// GetDependencyRecords: for each ID, call IsActiveWispInTx to pick the
+// table (dependencies vs wisp_dependencies) and query that table directly.
+// This mirrors the code path that existed BEFORE the batch partitioner
+// was introduced, so it provides a genuine cross-check for the new code.
+func legacyDependencyRecords(ctx context.Context, tx *sql.Tx, ids []string) (map[string][]*types.Dependency, error) {
+	result := make(map[string][]*types.Dependency)
+	for _, id := range ids {
+		table := "dependencies"
+		if issueops.IsActiveWispInTx(ctx, tx, id) {
+			table = "wisp_dependencies"
+		}
+		//nolint:gosec // G201: table is one of two hardcoded literals
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+			`SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id
+			 FROM %s WHERE issue_id = ? ORDER BY issue_id`, table), id)
+		if err != nil {
+			return nil, fmt.Errorf("legacyDependencyRecords %s: %w", id, err)
+		}
+		for rows.Next() {
+			var dep types.Dependency
+			var createdAt sql.NullTime
+			var metadata, threadID sql.NullString
+			if scanErr := rows.Scan(&dep.IssueID, &dep.DependsOnID, &dep.Type, &createdAt, &dep.CreatedBy, &metadata, &threadID); scanErr != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("legacyDependencyRecords scan %s: %w", id, scanErr)
+			}
+			if createdAt.Valid {
+				dep.CreatedAt = createdAt.Time
+			}
+			if metadata.Valid {
+				dep.Metadata = metadata.String
+			}
+			if threadID.Valid {
+				dep.ThreadID = threadID.String
+			}
+			result[dep.IssueID] = append(result[dep.IssueID], &dep)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("legacyDependencyRecords rows %s: %w", id, err)
+		}
+	}
+	return result, nil
+}

--- a/internal/storage/embeddeddolt/wisp_routing_test.go
+++ b/internal/storage/embeddeddolt/wisp_routing_test.go
@@ -1,0 +1,539 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	doltembed "github.com/dolthub/driver"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// openTxForTest opens a raw SQL connection to the testEnv's store and begins
+// a read-only transaction. The caller must call cleanup() when done.
+func openTxForTest(t *testing.T, te *testEnv) (context.Context, *sql.Tx, func()) {
+	t.Helper()
+	ctx := t.Context()
+	db, dbCleanup, err := embeddeddolt.OpenSQL(ctx, te.dataDir, te.database, "main")
+	if err != nil {
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		_ = dbCleanup()
+		t.Fatalf("BeginTx: %v", err)
+	}
+	cleanup := func() {
+		_ = tx.Rollback()
+		_ = dbCleanup()
+	}
+	return ctx, tx, cleanup
+}
+
+// seedIssue creates a regular (permanent) issue via the store.
+func seedIssue(t *testing.T, te *testEnv, id string) {
+	t.Helper()
+	ctx := t.Context()
+	if err := te.store.CreateIssue(ctx, &types.Issue{
+		ID:        id,
+		Title:     "perm " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}, "tester"); err != nil {
+		t.Fatalf("CreateIssue(%q): %v", id, err)
+	}
+}
+
+// seedWisp creates an ephemeral (wisp) issue via the store.
+func seedWisp(t *testing.T, te *testEnv, id string) {
+	t.Helper()
+	ctx := t.Context()
+	if err := te.store.CreateIssue(ctx, &types.Issue{
+		ID:        id,
+		Title:     "wisp " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}, "tester"); err != nil {
+		t.Fatalf("CreateIssue wisp(%q): %v", id, err)
+	}
+}
+
+func TestActiveWispIDsInTx_Empty(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "aw1")
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	for _, ids := range [][]string{nil, {}} {
+		got, err := issueops.ActiveWispIDsInTx(ctx, tx, ids)
+		if err != nil {
+			t.Fatalf("ActiveWispIDsInTx(%v): %v", ids, err)
+		}
+		if got == nil {
+			t.Error("expected non-nil map, got nil")
+		}
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	}
+}
+
+func TestActiveWispIDsInTx_AllPermanent(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "aw2")
+	seedIssue(t, te, "aw2-1")
+	seedIssue(t, te, "aw2-2")
+
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	got, err := issueops.ActiveWispIDsInTx(ctx, tx, []string{"aw2-1", "aw2-2"})
+	if err != nil {
+		t.Fatalf("ActiveWispIDsInTx: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map for permanent issues, got %v", got)
+	}
+}
+
+func TestActiveWispIDsInTx_AllWisps(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "aw3")
+	seedWisp(t, te, "aw3-wisp-1")
+	seedWisp(t, te, "aw3-wisp-2")
+
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	ids := []string{"aw3-wisp-1", "aw3-wisp-2"}
+	got, err := issueops.ActiveWispIDsInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("ActiveWispIDsInTx: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 wisp IDs, got %d: %v", len(got), got)
+	}
+	for _, id := range ids {
+		if !got[id] {
+			t.Errorf("expected %q in result, missing", id)
+		}
+	}
+}
+
+func TestActiveWispIDsInTx_Mixed(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "aw4")
+	seedIssue(t, te, "aw4-perm-1")
+	seedWisp(t, te, "aw4-wisp-1")
+	seedIssue(t, te, "aw4-perm-2")
+	seedWisp(t, te, "aw4-wisp-2")
+
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	ids := []string{"aw4-perm-1", "aw4-wisp-1", "aw4-perm-2", "aw4-wisp-2"}
+	got, err := issueops.ActiveWispIDsInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("ActiveWispIDsInTx: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 wisp IDs, got %d: %v", len(got), got)
+	}
+	if !got["aw4-wisp-1"] {
+		t.Error("expected aw4-wisp-1 in result")
+	}
+	if !got["aw4-wisp-2"] {
+		t.Error("expected aw4-wisp-2 in result")
+	}
+	if got["aw4-perm-1"] {
+		t.Error("did not expect aw4-perm-1 in result")
+	}
+	if got["aw4-perm-2"] {
+		t.Error("did not expect aw4-perm-2 in result")
+	}
+}
+
+func TestActiveWispIDsInTx_Batching(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	// queryBatchSize is 200; use 2*200+1 = 401 IDs with half as wisps.
+	const n = 401
+	te := newTestEnv(t, "aw5")
+
+	wispSet := make(map[string]bool)
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("aw5-item-%03d", i)
+		ids[i] = id
+		if i%2 == 0 {
+			seedWisp(t, te, id)
+			wispSet[id] = true
+		} else {
+			seedIssue(t, te, id)
+		}
+	}
+
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	got, err := issueops.ActiveWispIDsInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("ActiveWispIDsInTx: %v", err)
+	}
+	if len(got) != len(wispSet) {
+		t.Fatalf("expected %d wisp IDs, got %d", len(wispSet), len(got))
+	}
+	for id := range wispSet {
+		if !got[id] {
+			t.Errorf("expected %q in result, missing", id)
+		}
+	}
+}
+
+func TestActiveWispIDsInTx_ParityWithLoop(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "aw6")
+	// Seed 10 wisps and 10 perm issues.
+	for i := 0; i < 10; i++ {
+		seedWisp(t, te, fmt.Sprintf("aw6-wisp-%02d", i))
+		seedIssue(t, te, fmt.Sprintf("aw6-perm-%02d", i))
+	}
+
+	ids := make([]string, 20)
+	for i := 0; i < 10; i++ {
+		ids[i*2] = fmt.Sprintf("aw6-wisp-%02d", i)
+		ids[i*2+1] = fmt.Sprintf("aw6-perm-%02d", i)
+	}
+
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	// Legacy: per-ID probe
+	legacySet := make(map[string]bool)
+	for _, id := range ids {
+		if issueops.IsActiveWispInTx(ctx, tx, id) {
+			legacySet[id] = true
+		}
+	}
+
+	// New: batch probe
+	got, err := issueops.ActiveWispIDsInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("ActiveWispIDsInTx: %v", err)
+	}
+
+	if len(got) != len(legacySet) {
+		t.Fatalf("result length mismatch: batch=%d legacy=%d", len(got), len(legacySet))
+	}
+	for id, v := range legacySet {
+		if got[id] != v {
+			t.Errorf("mismatch for %q: batch=%v legacy=%v", id, got[id], v)
+		}
+	}
+}
+
+func TestPartitionByWispInTx_Ordering(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "pw1")
+	seedWisp(t, te, "pw1-w1")
+	seedIssue(t, te, "pw1-p1")
+	seedWisp(t, te, "pw1-w2")
+	seedIssue(t, te, "pw1-p2")
+	seedWisp(t, te, "pw1-w3")
+
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	// Input order: w1, p1, w2, p2, w3
+	ids := []string{"pw1-w1", "pw1-p1", "pw1-w2", "pw1-p2", "pw1-w3"}
+	wispIDs, permIDs, err := issueops.PartitionByWispInTx(ctx, tx, ids)
+	if err != nil {
+		t.Fatalf("PartitionByWispInTx: %v", err)
+	}
+
+	wantWisps := []string{"pw1-w1", "pw1-w2", "pw1-w3"}
+	wantPerms := []string{"pw1-p1", "pw1-p2"}
+
+	if len(wispIDs) != len(wantWisps) {
+		t.Fatalf("wispIDs length: got %d, want %d", len(wispIDs), len(wantWisps))
+	}
+	for i, want := range wantWisps {
+		if wispIDs[i] != want {
+			t.Errorf("wispIDs[%d] = %q, want %q", i, wispIDs[i], want)
+		}
+	}
+
+	if len(permIDs) != len(wantPerms) {
+		t.Fatalf("permIDs length: got %d, want %d", len(permIDs), len(wantPerms))
+	}
+	for i, want := range wantPerms {
+		if permIDs[i] != want {
+			t.Errorf("permIDs[%d] = %q, want %q", i, permIDs[i], want)
+		}
+	}
+}
+
+func TestPartitionByWispInTx_Empty(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "pw2")
+	ctx, tx, cleanup := openTxForTest(t, te)
+	defer cleanup()
+
+	for _, ids := range [][]string{nil, {}} {
+		wispIDs, permIDs, err := issueops.PartitionByWispInTx(ctx, tx, ids)
+		if err != nil {
+			t.Fatalf("PartitionByWispInTx(%v): %v", ids, err)
+		}
+		if wispIDs != nil {
+			t.Errorf("expected nil wispIDs, got %v", wispIDs)
+		}
+		if permIDs != nil {
+			t.Errorf("expected nil permIDs, got %v", permIDs)
+		}
+	}
+}
+
+// --- test-only counting driver wrapper ---------------------------------
+//
+// The dolt driver does not implement driver.QueryerContext / ExecerContext
+// on its *DoltConn, so every *sql.Tx.QueryContext path in the sql package
+// flows through Conn.Prepare + Stmt.Query. Counting Prepare calls is
+// therefore equivalent to counting queries. We wrap the connector so
+// every driver connection's Prepare increments a shared atomic counter.
+
+type countingConnector struct {
+	inner driver.Connector
+	count *atomic.Int64
+}
+
+func (c *countingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	inner, err := c.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &countingConn{inner: inner, count: c.count}, nil
+}
+
+func (c *countingConnector) Driver() driver.Driver { return c.inner.Driver() }
+
+type countingConn struct {
+	inner driver.Conn
+	count *atomic.Int64
+}
+
+func (c *countingConn) Prepare(query string) (driver.Stmt, error) {
+	c.count.Add(1)
+	return c.inner.Prepare(query)
+}
+
+func (c *countingConn) Close() error              { return c.inner.Close() }
+func (c *countingConn) Begin() (driver.Tx, error) { return c.inner.Begin() } //nolint:staticcheck
+
+// BeginTx is implemented by DoltConn; delegate so tx semantics stay intact.
+func (c *countingConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if b, ok := c.inner.(driver.ConnBeginTx); ok {
+		return b.BeginTx(ctx, opts)
+	}
+	return c.inner.Begin() //nolint:staticcheck
+}
+
+// buildBenchDSN replicates the unexported buildDSN in open.go. Kept in
+// sync manually — the driver params below are public constants.
+func buildBenchDSN(dir, database string) string {
+	v := url.Values{}
+	v.Set(doltembed.CommitNameParam, "beads")
+	v.Set(doltembed.CommitEmailParam, "beads@local")
+	v.Set(doltembed.MultiStatementsParam, "true")
+	if strings.TrimSpace(database) != "" {
+		v.Set(doltembed.DatabaseParam, database)
+	}
+	path := dir
+	if os.PathSeparator == '\\' {
+		path = strings.ReplaceAll(path, `\`, `/`)
+	}
+	return "file://" + path + "?" + v.Encode()
+}
+
+// benchSQLStringLiteral mirrors the unexported sqlStringLiteral in open.go.
+// Inlined here because embeddeddolt does not export it; the benchmark
+// interpolates a branch name into a SET statement and must match the
+// production escape rules exactly.
+func benchSQLStringLiteral(s string) string {
+	return "'" + strings.ReplaceAll(strings.TrimSpace(s), "'", "''") + "'"
+}
+
+// openCountingDB builds a *sql.DB whose driver.Conn increments count on
+// every Prepare call. Mirrors embeddeddolt.OpenSQL so the benchmark uses
+// the same connection config (SetMaxOpenConns(1), explicit USE + branch).
+// The returned cleanup func logs any close error via tb.Logf but never
+// blocks cleanup — a failed close shouldn't poison subsequent iterations.
+func openCountingDB(ctx context.Context, tb testing.TB, dir, database, branch string) (*sql.DB, *atomic.Int64, func(), error) {
+	dsn := buildBenchDSN(dir, database)
+	cfg, err := doltembed.ParseDSN(dsn)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 0
+	bo.MaxInterval = 5 * time.Second
+	cfg.BackOff = bo
+
+	inner, err := doltembed.NewConnector(cfg)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	count := &atomic.Int64{}
+	wrapped := &countingConnector{inner: inner, count: count}
+	db := sql.OpenDB(wrapped)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxIdleTime(0)
+	db.SetConnMaxLifetime(0)
+
+	cleanup := func() {
+		if err := db.Close(); err != nil {
+			tb.Logf("counting db close: %v", err)
+		}
+		if err := inner.Close(); err != nil {
+			tb.Logf("counting connector close: %v", err)
+		}
+	}
+
+	if err := db.PingContext(ctx); err != nil {
+		cleanup()
+		return nil, nil, nil, err
+	}
+	if strings.TrimSpace(database) != "" {
+		if _, err := db.ExecContext(ctx, "USE `"+database+"`"); err != nil {
+			cleanup()
+			return nil, nil, nil, err
+		}
+		if strings.TrimSpace(branch) != "" {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				"SET @@%s_head_ref = %s", database, benchSQLStringLiteral(branch))); err != nil {
+				cleanup()
+				return nil, nil, nil, err
+			}
+		}
+	}
+	return db, count, cleanup, nil
+}
+
+func BenchmarkBulkPartitioning(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping embedded dolt benchmark in short mode")
+	}
+
+	const N = 500
+
+	ctx := b.Context()
+	beadsDir := b.TempDir() + "/.beads"
+	store, err := embeddeddolt.New(ctx, beadsDir, "bench", "main")
+	if err != nil {
+		b.Fatalf("New: %v", err)
+	}
+	if err := store.SetConfig(ctx, "issue_prefix", "bench"); err != nil {
+		b.Fatalf("SetConfig: %v", err)
+	}
+	if err := store.Commit(ctx, "bd init"); err != nil {
+		b.Fatalf("Commit: %v", err)
+	}
+
+	// Seed N issues: half wisps, half perm.
+	ids := make([]string, N)
+	for i := 0; i < N; i++ {
+		id := fmt.Sprintf("bench-item-%04d", i)
+		ids[i] = id
+		if i%2 == 0 {
+			if err := store.CreateIssue(ctx, &types.Issue{
+				ID: id, Title: "wisp", Status: types.StatusOpen,
+				Priority: 2, IssueType: types.TypeTask, Ephemeral: true,
+			}, "bench"); err != nil {
+				b.Fatalf("CreateIssue wisp: %v", err)
+			}
+		} else {
+			if err := store.CreateIssue(ctx, &types.Issue{
+				ID: id, Title: "perm", Status: types.StatusOpen,
+				Priority: 2, IssueType: types.TypeTask,
+			}, "bench"); err != nil {
+				b.Fatalf("CreateIssue perm: %v", err)
+			}
+		}
+	}
+
+	// The embedded Dolt driver holds an exclusive flock on the data directory.
+	// Close the store before opening the counting DB on the same path to avoid
+	// a deadlock on lock acquisition.
+	dataDir := beadsDir + "/embeddeddolt"
+	database := "bench"
+	if err := store.Close(); err != nil {
+		b.Fatalf("store.Close: %v", err)
+	}
+
+	// queryBatchSize = 200: ceil(500/200) = 3 batches.
+	//
+	// The plan and design doc quote the ceiling as `ceil(N/queryBatchSize) + 1`.
+	// We drop the `+1` here because our counter intercepts driver.Conn.Prepare
+	// only; BeginTx never invokes Prepare. The new PartitionByWispInTx issues
+	// exactly ceil(N/batchSize) SELECT statements — each one goes through
+	// Prepare — so the tight bound is the correct assertion.
+	const queryBatchSize = 200
+	expectedMax := (N + queryBatchSize - 1) / queryBatchSize
+
+	var lastObserved int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		db, count, dbCleanup, dbErr := openCountingDB(ctx, b, dataDir, database, "main")
+		if dbErr != nil {
+			b.Fatalf("openCountingDB: %v", dbErr)
+		}
+		tx, txErr := db.BeginTx(ctx, nil)
+		if txErr != nil {
+			dbCleanup()
+			b.Fatalf("BeginTx: %v", txErr)
+		}
+
+		before := count.Load()
+		_, _, partErr := issueops.PartitionByWispInTx(ctx, tx, ids)
+		after := count.Load()
+
+		_ = tx.Rollback()
+		dbCleanup()
+
+		if partErr != nil {
+			b.Fatalf("partition: %v", partErr)
+		}
+
+		delta := after - before
+		lastObserved = delta
+		if delta > int64(expectedMax) {
+			b.Fatalf("N+1 regression: %d queries (max %d) for N=%d batchSize=%d",
+				delta, expectedMax, N, queryBatchSize)
+		}
+	}
+	b.ReportMetric(float64(lastObserved), "observed_queries")
+	b.ReportMetric(float64(expectedMax), "max_batch_queries")
+}

--- a/internal/storage/issueops/bulk_ops.go
+++ b/internal/storage/issueops/bulk_ops.go
@@ -110,13 +110,9 @@ func GetCommentsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string
 	result := make(map[string][]*types.Comment)
 
 	// Partition IDs by wisp status.
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(permIDs) > 0 {

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -53,13 +53,9 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 
 	result := make(map[string]int)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, pair := range []struct {

--- a/internal/storage/issueops/delete.go
+++ b/internal/storage/issueops/delete.go
@@ -74,13 +74,9 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 	}
 
 	// Partition into wisps and regular issues.
-	var wispIDs, regularIDs []string
-	for _, id := range ids {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			regularIDs = append(regularIDs, id)
-		}
+	wispIDs, regularIDs, err := PartitionByWispInTx(ctx, tx, ids)
+	if err != nil {
+		return nil, err
 	}
 
 	// Delete wisps first.

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -208,13 +208,9 @@ func GetIssuesByIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) ([]*types
 	}
 
 	// Partition IDs by wisp status.
-	var wispIDs, permIDs []string
-	for _, id := range ids {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, ids)
+	if err != nil {
+		return nil, err
 	}
 
 	var allIssues []*types.Issue

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -42,13 +42,9 @@ func GetDependencyRecordsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs
 
 	result := make(map[string][]*types.Dependency)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, pair := range []struct {
@@ -204,13 +200,9 @@ func GetBlockingInfoForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []st
 	}
 
 	// Partition into wisp and perm IDs for routing.
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	// Process wisp IDs against wisp_dependencies.

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -45,13 +45,9 @@ func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) 
 
 	result := make(map[string][]string)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionByWispInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, pair := range []struct {

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -3,12 +3,19 @@ package issueops
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strings"
 )
 
 // IsActiveWispInTx checks whether the given ID exists in the wisps table
 // within an existing transaction. Returns true if the ID is found.
 // This handles both auto-generated wisp IDs (containing "-wisp-") and
 // ephemeral issues created with explicit IDs that were routed to wisps.
+//
+// For multi-ID callers, prefer PartitionByWispInTx or ActiveWispIDsInTx
+// below — this single-ID helper issues one round-trip per call and was
+// the source of a 2,285-query N+1 on remote bd export before the bulk
+// helpers were added.
 func IsActiveWispInTx(ctx context.Context, tx *sql.Tx, id string) bool {
 	var exists int
 	err := tx.QueryRowContext(ctx, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1", id).Scan(&exists)
@@ -23,4 +30,81 @@ func WispTableRouting(isWisp bool) (issueTable, labelTable, eventTable, depTable
 		return "wisps", "wisp_labels", "wisp_events", "wisp_dependencies"
 	}
 	return "issues", "labels", "events", "dependencies"
+}
+
+// ActiveWispIDsInTx returns the subset of ids that exist in the active
+// wisps table, batched at queryBatchSize. This is the primitive — most
+// call sites want PartitionByWispInTx below, which preserves input
+// ordering. Callers that range the returned map directly must be aware
+// Go map iteration order is randomized.
+//
+// Returns an empty (non-nil) map if ids is empty.
+func ActiveWispIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]bool, error) {
+	result := make(map[string]bool, len(ids))
+	if len(ids) == 0 {
+		return result, nil
+	}
+
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+
+		//nolint:gosec // G201: placeholders are only "?" literals
+		q := fmt.Sprintf("SELECT id FROM wisps WHERE id IN (%s)", strings.Join(placeholders, ","))
+		rows, err := tx.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("ActiveWispIDsInTx: %w", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("ActiveWispIDsInTx scan: %w", err)
+			}
+			result[id] = true
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("ActiveWispIDsInTx rows: %w", err)
+		}
+		_ = rows.Close()
+	}
+
+	return result, nil
+}
+
+// PartitionByWispInTx splits ids into (wispIDs, permIDs) by running one
+// batched membership probe against the wisps table. The returned slices
+// preserve input order within each partition, so JSON export ordering
+// (bd export, bd list --json) stays deterministic across refactors.
+//
+// Callers that need a set primitive should use ActiveWispIDsInTx directly.
+func PartitionByWispInTx(ctx context.Context, tx *sql.Tx, ids []string) (wispIDs, permIDs []string, err error) {
+	if len(ids) == 0 {
+		return nil, nil, nil
+	}
+	wispSet, err := ActiveWispIDsInTx(ctx, tx, ids)
+	if err != nil {
+		return nil, nil, err
+	}
+	wispIDs = make([]string, 0, len(wispSet))
+	permIDs = make([]string, 0, len(ids)-len(wispSet))
+	for _, id := range ids {
+		if wispSet[id] {
+			wispIDs = append(wispIDs, id)
+		} else {
+			permIDs = append(permIDs, id)
+		}
+	}
+	return wispIDs, permIDs, nil
 }


### PR DESCRIPTION
## Summary

Eliminate remote `bd` latency on LAN-central Dolt-server topologies. Two compounding fixes, one per commit, both motivated by the same investigation:

1. **`perf(storage)`** — Seven bulk helpers in `internal/storage/issueops/` called `IsActiveWispInTx` in a per-ID loop, issuing **2,285** `SELECT 1 FROM wisps WHERE id = ?` round-trips on a single `bd export` against a 457-issue DB. Classic N+1. Replaced with a batched `IN (?, ?, …)` partitioner.
2. **`perf(dolt)`** — `ServerDSN` did not set `InterpolateParams`, so every parameterized query paid 3 network round-trips (`PREPARE`+`EXECUTE`+`CLOSE`) under `go-sql-driver/mysql`'s binary protocol. Flipped to client-side interpolation for a single RT per query.

Measured on WSL2 mirrored-networking to a LAN-central `dolt sql-server` (15 ms MySQL RTT):

| Metric | Baseline | After Commit A | After Commit B |
|---|---:|---:|---:|
| `bd export` remote | **208 s** | ~3 s | **0.514 s** (~405×) |
| `bd doctor` remote | **91 s** | ~25 s | **3.3 s** (~28×) |
| `bd dolt clean-databases --dry-run` | — | — | 0.062 s |
| `git commit --allow-empty` (hook spawns `bd export`) | **3m29s** | ~5 s | ~1 s |

## Scope — why one PR, why two commits

`CONTRIBUTING.md` says one issue per PR. This is one regression ("remote `bd` is unusably slow") with two orthogonal causes discovered in the same SQL-trace investigation. Fix 1 alone takes `bd export` from 208 s to ~3 s. Fix 2 alone wouldn't help much without Fix 1. Combined they hit the user-visible target. Kept as two commits so a reviewer can revert either independently if something surfaces post-merge. Happy to split into two PRs if maintainers prefer.

## Pre-emptive reviewer FAQ

**Is `InterpolateParams=true` safe without a feature gate?**
Audit is enumerated in the Commit B body and the design doc §5. `grep` against non-test code confirms: zero `Prepare`/`sql.Stmt` reuse, no custom `driver.Valuer` in `internal/types/`, no `json.RawMessage` passed directly as `Exec` arg (metadata is normalized to `string` via `storage.NormalizeMetadataValue()` at `internal/storage/dolt/issues.go:134` before the SQL layer), and `[]byte` only on already-hex-escaped federation password paths. `internal/storage/dolt/interpolate_params_test.go` opens two `sql.DB` handles (one `InterpolateParams=false`, one `=true`) against the same Dolt DB and asserts `reflect.DeepEqual` on round-trip for JSON with nested objects + escaped Unicode, DATETIME with sub-second fractional input, and VARCHAR with SQL metacharacters. A `BD_INTERPOLATE_PARAMS` env-var gate was considered and rejected — it would be a config knob on a change that's safe-by-construction for bd's argument types. Happy to add one if upstream disagrees.

**Why isn't pool tuning (originally planned as a 3rd commit) in this PR?**
After Commits A + B landed, `bd doctor` runs in 3.3 s and `bd dolt clean-databases --dry-run` in 0.062 s. The pool-widening from 2/1/30s → 5/2/60s was sized against a 91 s `bd doctor` baseline that no longer exists; the marginal wall-clock gain (~0.5 s) did not justify the branch-switch reachability audit, `ConnMaxLifetime` semantics discussion, and potential `cmd/bd` → `cmd/bd/doctor` import-cycle fallback. See design doc §10. Filable as a follow-up if a future workload surfaces pool starvation with fresh measurements.

**Attribution gap in design §2?**
The 15 ms × 3 RT × 2,285 probes model predicted ~103 s of the 208 s measured. Post-fix wall time (0.514 s) proves the unexplained ~100 s was per-query overhead — plausibly TCP Nagle / delayed-ACK interactions with the 3-RT sequence and WSL2 vSwitch processing — that vanished once the N+1 disappeared. Model under-attributed; the fix recovered it anyway.

**Benchmark CI robustness?**
`BenchmarkBulkPartitioning` in `internal/storage/embeddeddolt/wisp_routing_test.go` asserts a **query-count** ceiling (`ceil(N/queryBatchSize) + 1`), not timing. Robust across CI environments. Requires the embedded-Dolt harness.

## Test plan

- [x] `go build -tags gms_pure_go ./...`
- [x] `go test -tags gms_pure_go -short ./internal/storage/issueops/... ./internal/storage/embeddeddolt/... ./internal/storage/doltutil/... ./internal/storage/dolt/...` — new tests green; no regressions beyond pre-existing baseline failures verified on clean tree
- [x] `golangci-lint run --build-tags=gms_pure_go ./...` — pre-commit hook reports `0 issues.` on both commits
- [x] `gofmt` clean (enforced by pre-commit)
- [x] Manual remote-timing verification on WSL2 client against LAN Dolt server: `time bd export`, `time bd doctor`, `time bd dolt clean-databases --dry-run` — numbers in the table above are real, not projected
- [ ] CI green (pending this PR)

## Files touched

**Commit A** (`perf(storage): batch wisp routing probes in bulk helpers`):
- `internal/storage/issueops/wisp_routing.go` — new `ActiveWispIDsInTx` + `PartitionByWispInTx` helpers; doc comment on `IsActiveWispInTx` now points multi-ID callers at the batched helpers
- `internal/storage/issueops/{dependencies,labels,comments,bulk_ops,dependency_queries,delete}.go` — 7 call-site rewrites
- `internal/storage/embeddeddolt/wisp_routing{,_export_parity}_test.go` — new tests + `BenchmarkBulkPartitioning` with a query-count ceiling
- `docs/design/remote-latency-perf-{design,plan}.md` — full investigation, evidence table, SQL-trace reproducibility patch in Appendix B
- `docs/TROUBLESHOOTING.md` — user-facing diagnosis playbook ("Remote bd commands are slow")
- `CHANGELOG.md` — `[Unreleased]` / `### Changed` entries

**Commit B** (`perf(dolt): enable InterpolateParams to collapse prepared-statement RTTs`):
- `internal/storage/doltutil/dsn.go` — `InterpolateParams: true`
- `internal/storage/doltutil/dsn_test.go` — asserts flag in DSN
- `internal/storage/dolt/interpolate_params_test.go` — JSON / DATETIME / SQL-metachar round-trip parity with two handles

## Explicit non-changes

- Embedded mode (`internal/storage/embeddeddolt/open.go`) — untouched; `MaxOpenConns=1` is a correctness invariant.
- `internal/storage/dolt/store.go:1238` (`execWithLongTimeout`) — untouched; deliberately isolated for 5-minute merge ops.
- `internal/doltserver/doltserver.go` admin helpers (`EnsureGlobalDatabase`, `FlushWorkingSet`) — untouched; short-lived one-shots.
- Single-ID call sites of `IsActiveWispInTx` (`close`, `update`, `claim`, `promote`, `get_issue`, `events`, `molecule`) — not an N+1, left alone.
- Main daemon pool `applyPoolLimits` (`10/5/1h`) — already correct for long-lived daemons.

## Rollback

Each commit is independently revertable via `git revert`. The batched helpers from Commit A remain useful on their own even if the call-site rewrites are reverted.