### PR TITLE
fix(bootstrap): clone via SQL server in external server mode

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -488,7 +488,7 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	}
 
 	dbName := cfg.GetDoltDatabase()
-	if err := cloneFromRemote(ctx, plan.BeadsDir, plan.SyncRemote, dbName); err != nil {
+	if err := cloneFromRemote(ctx, plan.BeadsDir, plan.SyncRemote, dbName, cfg); err != nil {
 		return err
 	}
 
@@ -534,10 +534,10 @@ func finalizeSyncedBootstrap(beadsDir, syncRemote string, cfg *configfile.Config
 	// required by configfile.Load consumers.
 	cfg.Backend = configfile.BackendDolt
 	cfg.DoltDatabase = dbName
-	if isEmbeddedMode() {
-		cfg.DoltMode = configfile.DoltModeEmbedded
-	} else {
+	if cfg.IsDoltServerMode() || doltserver.IsSharedServerMode() {
 		cfg.DoltMode = configfile.DoltModeServer
+	} else {
+		cfg.DoltMode = configfile.DoltModeEmbedded
 	}
 	// Mirror init's convention: metadata.json database points at the Dolt
 	// directory rather than the legacy "beads.db" placeholder.
@@ -566,27 +566,96 @@ func finalizeSyncedBootstrap(beadsDir, syncRemote string, cfg *configfile.Config
 
 // cloneFromRemote clones a Dolt database from a remote URL.
 // In embedded mode, uses the embedded engine's DOLT_CLONE procedure.
-// In server mode, shells out to dolt clone via BootstrapFromRemoteWithDB.
+// In external server mode, connects to the running server via MySQL and
+// executes DOLT_CLONE so the server places the database in its own data
+// directory. In owned-server mode, shells out to dolt clone via
+// BootstrapFromRemoteWithDB.
 // Shared by bd init and bd bootstrap to keep clone logic in one place.
-func cloneFromRemote(ctx context.Context, beadsDir, remoteURL, dbName string) error {
-	if isEmbeddedMode() {
-		dataDir := filepath.Join(beadsDir, "embeddeddolt")
-		if err := os.MkdirAll(dataDir, 0o750); err != nil {
-			return fmt.Errorf("create embeddeddolt directory: %w", err)
-		}
-		db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, "", "")
-		if err != nil {
-			return fmt.Errorf("open embedded engine for clone: %w", err)
-		}
-		defer func() { _ = cleanup() }()
+func cloneFromRemote(ctx context.Context, beadsDir, remoteURL, dbName string, cfg *configfile.Config) error {
+	mode := doltserver.ResolveServerMode(beadsDir)
 
-		if err := versioncontrolops.DoltClone(ctx, db, remoteURL, dbName); err != nil {
-			return fmt.Errorf("clone from remote: %w", err)
+	switch mode {
+	case doltserver.ServerModeEmbedded:
+		return cloneViaEmbedded(ctx, beadsDir, remoteURL, dbName)
+
+	case doltserver.ServerModeExternal:
+		if cfg == nil {
+			// Caller didn't provide config; fall back to loading from disk.
+			if loaded, err := configfile.Load(beadsDir); err == nil && loaded != nil {
+				cfg = loaded
+			}
 		}
-		fmt.Fprintf(os.Stderr, "Synced database from %s\n", remoteURL)
-		return nil
+		if cfg != nil {
+			return cloneViaServer(ctx, beadsDir, remoteURL, dbName, cfg)
+		}
+		// No config available — fall through to CLI clone.
+		fmt.Fprintf(os.Stderr, "Warning: server mode detected but no config available, falling back to CLI clone\n")
+		return cloneViaCLI(ctx, beadsDir, remoteURL, dbName)
+
+	default: // ServerModeOwned
+		return cloneViaCLI(ctx, beadsDir, remoteURL, dbName)
+	}
+}
+
+// cloneViaEmbedded clones using the embedded Dolt engine (CGO required).
+func cloneViaEmbedded(ctx context.Context, beadsDir, remoteURL, dbName string) error {
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+		return fmt.Errorf("create embeddeddolt directory: %w", err)
+	}
+	db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, "", "")
+	if err != nil {
+		return fmt.Errorf("open embedded engine for clone: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	if err := versioncontrolops.DoltClone(ctx, db, remoteURL, dbName); err != nil {
+		return fmt.Errorf("clone from remote: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Synced database from %s\n", remoteURL)
+	return nil
+}
+
+// cloneViaServer clones by connecting to the external Dolt server and
+// executing CALL DOLT_CLONE. The server places the database in its own
+// data directory, which is the correct behavior for externally managed
+// servers where bd does not know the filesystem layout.
+func cloneViaServer(ctx context.Context, beadsDir, remoteURL, dbName string, cfg *configfile.Config) error {
+	resolved := doltserver.DefaultConfig(beadsDir)
+	dsn := doltutil.ServerDSN{
+		Host:     cfg.GetDoltServerHost(),
+		Port:     resolved.Port,
+		User:     cfg.GetDoltServerUser(),
+		Password: cfg.GetDoltServerPasswordForPort(resolved.Port),
+		TLS:      cfg.GetDoltServerTLS(),
+		// No Database — DOLT_CLONE creates the database.
+	}.String()
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return fmt.Errorf("connect to dolt server for clone: %w", err)
+	}
+	defer db.Close()
+
+	cloneCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	if err := db.PingContext(cloneCtx); err != nil {
+		return fmt.Errorf("dolt server unreachable at %s:%d (is dolt sql-server running?): %w",
+			cfg.GetDoltServerHost(), resolved.Port, err)
 	}
 
+	if err := versioncontrolops.DoltClone(cloneCtx, db, remoteURL, dbName); err != nil {
+		return fmt.Errorf("clone from remote via server: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Synced database from %s (via server at %s:%d)\n",
+		remoteURL, cfg.GetDoltServerHost(), resolved.Port)
+	return nil
+}
+
+// cloneViaCLI clones by shelling out to the dolt CLI.
+// Used for owned-server mode where bd manages the server lifecycle.
+func cloneViaCLI(ctx context.Context, beadsDir, remoteURL, dbName string) error {
 	doltDir := doltserver.ResolveDoltDir(beadsDir)
 	synced, err := dolt.BootstrapFromRemoteWithDB(ctx, doltDir, remoteURL, dbName)
 	if err != nil {

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -1077,3 +1077,277 @@ func TestFinalizeSyncedBootstrapIsIdempotent(t *testing.T) {
 		t.Errorf("dolt_database drifted: got %q, want %q", loaded.GetDoltDatabase(), "beads_hq")
 	}
 }
+
+// TestFinalizeSyncedBootstrapServerModePreservesMode verifies that when
+// metadata.json already declares dolt_mode=server (tracked in git),
+// finalizeSyncedBootstrap preserves server mode instead of resetting to
+// embedded. This is the root cause of GH#3343.
+func TestFinalizeSyncedBootstrapServerModePreservesMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	// Simulate a workspace where metadata.json (tracked in git) declares
+	// server mode — the scenario from GH#3343.
+	cfg := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 3308,
+		DoltDatabase:   "beads_proj",
+	}
+
+	if err := finalizeSyncedBootstrap(beadsDir, "file:///tmp/fake.git", cfg, "beads_proj"); err != nil {
+		t.Fatalf("finalizeSyncedBootstrap failed: %v", err)
+	}
+
+	loaded, err := configfile.Load(beadsDir)
+	if err != nil || loaded == nil {
+		t.Fatalf("metadata.json missing: %v", err)
+	}
+	if loaded.GetDoltMode() != configfile.DoltModeServer {
+		t.Errorf("dolt_mode = %q, want %q — server mode was not preserved", loaded.GetDoltMode(), configfile.DoltModeServer)
+	}
+	if loaded.GetDoltDatabase() != "beads_proj" {
+		t.Errorf("dolt_database = %q, want %q", loaded.GetDoltDatabase(), "beads_proj")
+	}
+}
+
+// TestCloneFromRemoteRoutesToServerMode verifies that cloneFromRemote uses
+// the SQL server path (not filesystem clone) when ResolveServerMode
+// detects external server mode from metadata.json. GH#3343.
+func TestCloneFromRemoteRoutesToServerMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write metadata.json with server mode and explicit port — this makes
+	// ResolveServerMode return ServerModeExternal.
+	cfg := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 3308,
+		DoltDatabase:   "beads_proj",
+	}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+
+	// cloneFromRemote should attempt a server connection (not a filesystem
+	// clone). Since no server is running, we expect a connection error —
+	// NOT a "dolt clone failed" error, which would indicate the filesystem
+	// path was taken.
+	err := cloneFromRemote(t.Context(), beadsDir, "file:///tmp/nonexistent.git", "beads_proj", cfg)
+	if err == nil {
+		t.Fatal("expected error (no server running), got nil")
+	}
+	errMsg := err.Error()
+
+	// The error should indicate a server connection attempt, not a CLI clone.
+	if strings.Contains(errMsg, "dolt clone failed") {
+		t.Errorf("cloneFromRemote used filesystem clone path in server mode: %v", err)
+	}
+	if !strings.Contains(errMsg, "server") {
+		t.Errorf("expected server-related error, got: %v", err)
+	}
+
+	// Verify no local dolt directory was created.
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if _, err := os.Stat(doltDir); err == nil {
+		t.Errorf("local .beads/dolt/ directory was created — clone should have gone to server, not filesystem")
+	}
+}
+
+// TestCloneFromRemoteRoutesToServerModeViaEnv verifies that the
+// BEADS_DOLT_SERVER_MODE=1 env var triggers the server clone path,
+// even when metadata.json is absent.
+func TestCloneFromRemoteRoutesToServerModeViaEnv(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "1")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configfile.Config{
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 3309,
+		DoltDatabase:   "beads_env",
+	}
+
+	err := cloneFromRemote(t.Context(), beadsDir, "file:///tmp/nonexistent.git", "beads_env", cfg)
+	if err == nil {
+		t.Fatal("expected error (no server running), got nil")
+	}
+	if strings.Contains(err.Error(), "dolt clone failed") {
+		t.Errorf("cloneFromRemote used filesystem clone path despite BEADS_DOLT_SERVER_MODE=1: %v", err)
+	}
+	if !strings.Contains(err.Error(), "server") {
+		t.Errorf("expected server-related error, got: %v", err)
+	}
+}
+
+// TestCloneFromRemoteExternalNilCfgLoadsDisk verifies that when cfg is nil
+// in external server mode, cloneFromRemote falls back to loading config
+// from metadata.json on disk.
+func TestCloneFromRemoteExternalNilCfgLoadsDisk(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write metadata.json to disk with server mode — but pass nil cfg.
+	diskCfg := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 3310,
+		DoltDatabase:   "beads_disk",
+	}
+	if err := diskCfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+
+	// Pass nil cfg — cloneFromRemote should load from disk and still
+	// take the server path.
+	err := cloneFromRemote(t.Context(), beadsDir, "file:///tmp/nonexistent.git", "beads_disk", nil)
+	if err == nil {
+		t.Fatal("expected error (no server running), got nil")
+	}
+	if strings.Contains(err.Error(), "dolt clone failed") {
+		t.Errorf("nil-cfg path used filesystem clone despite server metadata on disk: %v", err)
+	}
+	if !strings.Contains(err.Error(), "server") {
+		t.Errorf("expected server-related error, got: %v", err)
+	}
+}
+
+// TestCloneFromRemoteOwnedModeUsesCLI verifies that owned-server mode
+// (the default when no metadata.json exists) uses the CLI clone path.
+func TestCloneFromRemoteOwnedModeUsesCLI(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// No metadata.json → ResolveServerMode returns ServerModeOwned → CLI path.
+	// The CLI path calls BootstrapFromRemoteWithDB, which requires dolt CLI.
+	// Since dolt may not be installed in CI, we accept either:
+	// - "dolt CLI not found" (no dolt binary)
+	// - "dolt clone failed" (dolt binary exists but remote is invalid)
+	// Both confirm the CLI path was taken, not the server path.
+	err := cloneFromRemote(t.Context(), beadsDir, "file:///tmp/nonexistent.git", "beads_owned", nil)
+	if err == nil {
+		// BootstrapFromRemoteWithDB returns (false, nil) if doltExists — skip.
+		return
+	}
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "dolt server unreachable") || strings.Contains(errMsg, "connect to dolt server") {
+		t.Errorf("owned-mode clone routed to server path: %v", err)
+	}
+}
+
+// TestCloneFromRemoteSharedServerModeUsesServer verifies that
+// BEADS_DOLT_SHARED_SERVER=1 triggers the server clone path.
+func TestCloneFromRemoteSharedServerModeUsesServer(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configfile.Config{
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 3311,
+		DoltDatabase:   "beads_shared",
+	}
+
+	err := cloneFromRemote(t.Context(), beadsDir, "file:///tmp/nonexistent.git", "beads_shared", cfg)
+	if err == nil {
+		t.Fatal("expected error (no server running), got nil")
+	}
+	if strings.Contains(err.Error(), "dolt clone failed") {
+		t.Errorf("shared-server mode used filesystem clone: %v", err)
+	}
+	if !strings.Contains(err.Error(), "server") {
+		t.Errorf("expected server-related error, got: %v", err)
+	}
+}
+
+// TestFinalizeSyncedBootstrapSharedServerSetsServerMode verifies that
+// finalizeSyncedBootstrap writes dolt_mode=server when shared-server
+// mode is active via env var.
+func TestFinalizeSyncedBootstrapSharedServerSetsServerMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+
+	cfg := configfile.DefaultConfig()
+	if err := finalizeSyncedBootstrap(beadsDir, "file:///tmp/fake.git", cfg, "beads_shared"); err != nil {
+		t.Fatalf("finalizeSyncedBootstrap failed: %v", err)
+	}
+
+	loaded, err := configfile.Load(beadsDir)
+	if err != nil || loaded == nil {
+		t.Fatalf("metadata.json missing: %v", err)
+	}
+	if loaded.GetDoltMode() != configfile.DoltModeServer {
+		t.Errorf("dolt_mode = %q, want %q — shared server should set server mode", loaded.GetDoltMode(), configfile.DoltModeServer)
+	}
+}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -505,7 +505,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 		if syncFromRemote {
-			if err := cloneFromRemote(ctx, beadsDir, syncURL, dbName); err != nil {
+			if err := cloneFromRemote(ctx, beadsDir, syncURL, dbName, nil); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
## Summary

When `dolt_mode=server` is configured in `.beads/metadata.json` (e.g. for an externally managed `dolt sql-server`), `bd bootstrap` was cloning to the local `.beads/dolt/` directory instead of letting the server handle the clone. The server never discovered the database, causing `bd ready` to return empty results.

## Root Cause

`cloneFromRemote()` used `isEmbeddedMode()` which checks runtime globals not yet initialized during bootstrap, defaulting to embedded mode. `finalizeSyncedBootstrap()` had the same issue, resetting `dolt_mode` back to `embedded`.

## Changes

- **`cloneFromRemote()`** now uses `doltserver.ResolveServerMode()` which reads `metadata.json` directly to determine the server lifecycle mode:
  - `ServerModeExternal`: connects to the running server via MySQL and executes `CALL DOLT_CLONE`, so the server places the database in its own data directory
  - `ServerModeEmbedded`: existing embedded engine clone path (unchanged)
  - `ServerModeOwned`: existing `dolt clone` CLI path (unchanged)
- **`finalizeSyncedBootstrap()`** uses `cfg.IsDoltServerMode()` to preserve the server mode from the loaded config, instead of `isEmbeddedMode()`
- **`init.go`** caller updated to pass `nil` config (falls back correctly)
- Added tests for server-mode clone routing and mode preservation

## Testing

- All existing bootstrap tests pass (88s suite)
- New `TestFinalizeSyncedBootstrapServerModePreservesMode`: verifies `dolt_mode: server` is preserved after finalize
- New `TestCloneFromRemoteRoutesToServerMode`: verifies server-mode metadata routes to SQL clone path (not filesystem)

Fixes #3343