### PR TITLE
feat(prune): add `bd prune` for deleting closed non-ephemeral beads

### DIFF
--- a/cmd/bd/prune.go
+++ b/cmd/bd/prune.go
@@ -16,7 +16,7 @@ closed work has piled up and is bloating auto-export or slowing queries.
 
 Requires --older-than or --pattern. The flag is a safety gate — without
 it, a muscle-memory ` + "`--force`" + ` could wipe every closed bead in the repo.
-Use ` + "`--older-than 1d`" + ` if you really do want to sweep everything closed.
+Use ` + "`--pattern '*'`" + ` if you really do want to sweep everything closed.
 
 Deletes: issues, dependencies, labels, events, and comments for matching beads.
 Skips: pinned beads (protected), open/in-progress beads, and ephemeral beads.
@@ -24,17 +24,24 @@ Skips: pinned beads (protected), open/in-progress beads, and ephemeral beads.
 To delete closed ephemeral beads (wisps, transient molecules) use
 ` + "`bd purge`" + ` instead.
 
+For full Dolt storage reclaim after deleting many rows, follow with ` + "`bd flatten`" + `
+so history can be collapsed and old chunks can be garbage-collected.
+
 EXAMPLES:
   bd prune --older-than 30d              # Preview closed beads >30d old
   bd prune --older-than 30d --force      # Delete them
   bd prune --older-than 90d --dry-run    # Detailed preview with stats
+  bd prune --pattern "*" --force         # Delete all closed regular beads
   bd prune --pattern "gm-temp-*" --force # Scope to a pattern`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		runPurgeOrPrune(cmd, purgeScope{
-			cmdName:       "prune",
-			subjectNoun:   "closed bead",
-			ephemeralOnly: false,
-			requireFilter: true,
+			cmdName:        "prune",
+			pastTense:      "pruned",
+			countKey:       "pruned_count",
+			dryRunCountKey: "prune_count",
+			subjectNoun:    "closed bead",
+			ephemeralOnly:  false,
+			requireFilter:  true,
 		})
 	},
 }

--- a/cmd/bd/prune.go
+++ b/cmd/bd/prune.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var pruneCmd = &cobra.Command{
+	Use:     "prune",
+	GroupID: "maint",
+	Short:   "Delete old closed beads to reclaim space and shrink exports",
+	Long: `Permanently delete closed non-ephemeral beads and their associated data.
+
+Use this to trim closed regular beads (tasks, features, bugs, chores, etc.)
+that are no longer useful. The common case is a long-lived repo where
+closed work has piled up and is bloating auto-export or slowing queries.
+
+Requires --older-than or --pattern. The flag is a safety gate — without
+it, a muscle-memory ` + "`--force`" + ` could wipe every closed bead in the repo.
+Use ` + "`--older-than 1d`" + ` if you really do want to sweep everything closed.
+
+Deletes: issues, dependencies, labels, events, and comments for matching beads.
+Skips: pinned beads (protected), open/in-progress beads, and ephemeral beads.
+
+To delete closed ephemeral beads (wisps, transient molecules) use
+` + "`bd purge`" + ` instead.
+
+EXAMPLES:
+  bd prune --older-than 30d              # Preview closed beads >30d old
+  bd prune --older-than 30d --force      # Delete them
+  bd prune --older-than 90d --dry-run    # Detailed preview with stats
+  bd prune --pattern "gm-temp-*" --force # Scope to a pattern`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		runPurgeOrPrune(cmd, purgeScope{
+			cmdName:       "prune",
+			subjectNoun:   "closed bead",
+			ephemeralOnly: false,
+			requireFilter: true,
+		})
+	},
+}
+
+func init() {
+	pruneCmd.Flags().BoolP("force", "f", false, "Actually prune (without this, shows preview)")
+	pruneCmd.Flags().Bool("dry-run", false, "Preview what would be pruned with stats")
+	pruneCmd.Flags().String("older-than", "", "Only prune beads closed more than N ago (e.g., 30d, 2w, 60)")
+	pruneCmd.Flags().String("pattern", "", "Only prune beads matching ID glob pattern (e.g., 'gm-old-*')")
+	rootCmd.AddCommand(pruneCmd)
+}

--- a/cmd/bd/prune_embedded_test.go
+++ b/cmd/bd/prune_embedded_test.go
@@ -98,16 +98,12 @@ func TestEmbeddedPrune(t *testing.T) {
 		wispID := createAndCloseEphemeral(t, bd, dir, "Closed wisp")
 
 		out := bdPrune(t, bd, dir, "--pattern", "pw-*", "--force")
-		// Either "no beads to prune" or a pruned count of 0; the ephemeral
-		// must not appear.
+		// Prune's non-ephemeral scope must not match the wisp at all.
 		if strings.Contains(out, wispID) {
 			t.Errorf("prune wrongly touched ephemeral %s: %s", wispID, out)
 		}
-
-		// Double-check: the ephemeral still exists for `bd purge` to clean up.
-		out = bdPurge(t, bd, dir, "--pattern", "pw-*", "--dry-run")
-		if !strings.Contains(out, "Would purge 1") {
-			t.Errorf("expected purge dry-run to still see ephemeral %s after prune; got: %s", wispID, out)
+		if !strings.Contains(strings.ToLower(out), "no closed beads to prune") {
+			t.Errorf("expected prune to skip closed ephemeral %s; got: %s", wispID, out)
 		}
 	})
 

--- a/cmd/bd/prune_embedded_test.go
+++ b/cmd/bd/prune_embedded_test.go
@@ -1,0 +1,186 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// bdPrune runs "bd prune" with the given args and returns stdout.
+func bdPrune(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"prune"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bd prune %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// bdPruneFail runs "bd prune" expecting failure and returns combined output.
+func bdPruneFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"prune"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected bd prune %s to fail, got success:\n%s", strings.Join(args, " "), out)
+	}
+	return string(out)
+}
+
+// createAndClose creates a non-ephemeral task issue and closes it. Returns the ID.
+func createAndClose(t *testing.T, bd, dir, title string) string {
+	t.Helper()
+	issue := bdCreate(t, bd, dir, title)
+	bdClose(t, bd, dir, issue.ID)
+	return issue.ID
+}
+
+func TestEmbeddedPrune(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// ===== Safety gate =====
+
+	t.Run("prune_requires_older_than_or_pattern", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "pr")
+		createAndClose(t, bd, dir, "Some closed task")
+
+		// `bd prune --force` alone should fail — the gate blocks it.
+		out := bdPruneFail(t, bd, dir, "--force")
+		if !strings.Contains(out, "--older-than or --pattern") {
+			t.Errorf("expected safety-gate error to mention --older-than or --pattern, got: %s", out)
+		}
+
+		// Confirm the bead wasn't deleted.
+		listing := bdList(t, bd, dir, "--status=closed", "--json")
+		if !strings.Contains(listing, "Some closed task") {
+			t.Error("bd prune --force without a filter must be a no-op, but the bead was deleted")
+		}
+	})
+
+	// ===== Scope: non-ephemeral closed only =====
+
+	t.Run("prune_deletes_closed_non_ephemeral", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "pnx")
+		target := createAndClose(t, bd, dir, "Closed non-ephemeral task")
+
+		// --pattern is a scope filter AND the safety gate.
+		out := bdPrune(t, bd, dir, "--pattern", "pnx-*", "--force")
+		if !strings.Contains(out, "Pruned") && !strings.Contains(out, "pruned") {
+			t.Errorf("expected success message, got: %s", out)
+		}
+
+		// The target should be gone from the closed list.
+		listing := bdList(t, bd, dir, "--status=closed", "--json")
+		if strings.Contains(listing, target) {
+			t.Errorf("expected %s to be deleted, still present in: %s", target, listing)
+		}
+	})
+
+	// ===== Scope: must NOT touch ephemeral =====
+
+	t.Run("prune_leaves_closed_ephemeral_for_purge", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "pw")
+		wispID := createAndCloseEphemeral(t, bd, dir, "Closed wisp")
+
+		out := bdPrune(t, bd, dir, "--pattern", "pw-*", "--force")
+		// Either "no beads to prune" or a pruned count of 0; the ephemeral
+		// must not appear.
+		if strings.Contains(out, wispID) {
+			t.Errorf("prune wrongly touched ephemeral %s: %s", wispID, out)
+		}
+
+		// Double-check: the ephemeral still exists for `bd purge` to clean up.
+		// Use --ephemeral + --status=closed to surface wisps specifically.
+		listing := bdList(t, bd, dir, "--ephemeral", "--status=closed", "--json")
+		if !strings.Contains(listing, wispID) {
+			t.Errorf("expected ephemeral %s to survive bd prune, got: %s", wispID, listing)
+		}
+	})
+
+	// ===== Scope: must NOT touch open beads =====
+
+	t.Run("prune_leaves_open_beads_alone", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "po")
+		openID := bdCreate(t, bd, dir, "Still-open task").ID
+
+		out := bdPrune(t, bd, dir, "--pattern", "po-*", "--force")
+		if strings.Contains(out, openID) {
+			t.Errorf("prune wrongly touched open bead %s: %s", openID, out)
+		}
+	})
+
+	// ===== Dry-run shows stats, doesn't touch data =====
+
+	t.Run("prune_dry_run_reports_without_deleting", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "pd")
+		target := createAndClose(t, bd, dir, "For dry-run")
+
+		out := bdPrune(t, bd, dir, "--pattern", "pd-*", "--dry-run")
+		if !strings.Contains(out, "Would prune") {
+			t.Errorf("expected 'Would prune' in dry-run output, got: %s", out)
+		}
+
+		// The bead must still exist.
+		listing := bdList(t, bd, dir, "--status=closed", "--json")
+		if !strings.Contains(listing, target) {
+			t.Errorf("dry-run deleted %s; listing: %s", target, listing)
+		}
+	})
+
+	// ===== Preview mode (no --force) fails without deleting =====
+
+	t.Run("prune_preview_fails_without_force", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "pp")
+		target := createAndClose(t, bd, dir, "For preview")
+
+		// Passing a scope filter but no --force: preview-and-abort path.
+		out := bdPruneFail(t, bd, dir, "--pattern", "pp-*")
+		if !strings.Contains(out, "would prune") && !strings.Contains(out, "Found") {
+			t.Errorf("expected preview output, got: %s", out)
+		}
+
+		listing := bdList(t, bd, dir, "--status=closed", "--json")
+		if !strings.Contains(listing, target) {
+			t.Errorf("preview deleted %s; listing: %s", target, listing)
+		}
+	})
+
+	// ===== --older-than excludes recent beads =====
+
+	t.Run("prune_older_than_skips_recent", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "pot")
+		// Just-closed — should NOT match --older-than 30d.
+		target := createAndClose(t, bd, dir, "Recent close")
+
+		out := bdPrune(t, bd, dir, "--older-than", "30d", "--force")
+		if strings.Contains(out, target) {
+			t.Errorf("prune with --older-than 30d wrongly touched just-closed %s: %s", target, out)
+		}
+
+		// A "no beads to prune" message (or a zero-count result) is the
+		// expected outcome.
+		lower := strings.ToLower(out)
+		if !strings.Contains(lower, "no ") && !strings.Contains(lower, "0 ") {
+			// Not fatal — wording may vary. Ensure target survives.
+			listing := bdList(t, bd, dir, "--status=closed", "--json")
+			if !strings.Contains(listing, target) {
+				t.Errorf("--older-than 30d deleted recent bead %s; listing: %s", target, listing)
+			}
+		}
+	})
+}

--- a/cmd/bd/prune_embedded_test.go
+++ b/cmd/bd/prune_embedded_test.go
@@ -105,10 +105,9 @@ func TestEmbeddedPrune(t *testing.T) {
 		}
 
 		// Double-check: the ephemeral still exists for `bd purge` to clean up.
-		// Use --ephemeral + --status=closed to surface wisps specifically.
-		listing := bdList(t, bd, dir, "--ephemeral", "--status=closed", "--json")
-		if !strings.Contains(listing, wispID) {
-			t.Errorf("expected ephemeral %s to survive bd prune, got: %s", wispID, listing)
+		out = bdPurge(t, bd, dir, "--pattern", "pw-*", "--dry-run")
+		if !strings.Contains(out, "Would purge 1") {
+			t.Errorf("expected purge dry-run to still see ephemeral %s after prune; got: %s", wispID, out)
 		}
 	})
 

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -19,6 +19,12 @@ type purgeScope struct {
 	// cmdName is the user-visible command name (e.g. "purge", "prune").
 	// Used in messages and the suggested `--force` hint.
 	cmdName string
+	// pastTense is the user-visible completed action (e.g. "purged", "pruned").
+	pastTense string
+	// countKey is the JSON key used for the actual deletion count.
+	countKey string
+	// dryRunCountKey is the JSON key used for the dry-run deletion count.
+	dryRunCountKey string
 	// subjectNoun describes what's being purged, in singular form
 	// (e.g. "closed ephemeral bead", "closed bead"). "(s)" is appended by
 	// the printer when multiple items are involved.
@@ -49,6 +55,9 @@ Skips: pinned beads (protected).
 To delete closed non-ephemeral beads (regular tasks, features, bugs, etc.)
 use ` + "`bd prune`" + ` instead.
 
+For full Dolt storage reclaim after deleting many rows, follow with ` + "`bd flatten`" + `
+so history can be collapsed and old chunks can be garbage-collected.
+
 EXAMPLES:
   bd purge                           # Preview what would be purged
   bd purge --force                   # Delete all closed ephemeral beads
@@ -57,10 +66,13 @@ EXAMPLES:
   bd purge --dry-run                 # Detailed preview with stats`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		runPurgeOrPrune(cmd, purgeScope{
-			cmdName:       "purge",
-			subjectNoun:   "closed ephemeral bead",
-			ephemeralOnly: true,
-			requireFilter: false,
+			cmdName:        "purge",
+			pastTense:      "purged",
+			countKey:       "purged_count",
+			dryRunCountKey: "purge_count",
+			subjectNoun:    "closed ephemeral bead",
+			ephemeralOnly:  true,
+			requireFilter:  false,
 		})
 	},
 }
@@ -81,9 +93,9 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 	if scope.requireFilter && olderThan == "" && pattern == "" {
 		FatalErrorWithHint(
 			fmt.Sprintf("bd %s requires --older-than or --pattern", scope.cmdName),
-			"Protects against accidental bulk deletion. Use `--older-than 1d` to\n"+
-				"  include everything closed for at least one day, or `--pattern '<glob>'`\n"+
-				"  to scope by bead ID.")
+			"Protects against accidental bulk deletion. Use `--pattern '*'` to\n"+
+				"  include all closed beads in this scope, or `--older-than 1d`\n"+
+				"  / `--pattern '<glob>'` to narrow the deletion.")
 	}
 
 	if store == nil {
@@ -145,7 +157,7 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 	if len(closedIssues) == 0 {
 		if jsonOutput {
 			outputJSON(map[string]interface{}{
-				"purged_count": 0,
+				scope.countKey: 0,
 				"message":      fmt.Sprintf("No %ss to %s", scope.subjectNoun, scope.cmdName),
 			})
 		} else {
@@ -172,11 +184,11 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 		result, err := store.DeleteIssues(ctx, issueIDs, false, false, true)
 		if jsonOutput {
 			stats := map[string]interface{}{
-				"dry_run":      true,
-				"purge_count":  len(issueIDs),
-				"dependencies": 0,
-				"labels":       0,
-				"events":       0,
+				"dry_run":            true,
+				scope.dryRunCountKey: len(issueIDs),
+				"dependencies":       0,
+				"labels":             0,
+				"events":             0,
 			}
 			if err == nil {
 				stats["dependencies"] = result.DependenciesCount
@@ -230,7 +242,7 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 
 	if jsonOutput {
 		stats := map[string]interface{}{
-			"purged_count": result.DeletedCount,
+			scope.countKey: result.DeletedCount,
 			"dependencies": result.DependenciesCount,
 			"labels":       result.LabelsCount,
 			"events":       result.EventsCount,
@@ -240,8 +252,7 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 		}
 		outputJSON(stats)
 	} else {
-		past := strings.TrimSuffix(scope.cmdName, "e") + "ed" // purge→purged, prune→pruned
-		fmt.Printf("%s %s %d %s(s)\n", ui.RenderPass("✓"), capitalize(past), result.DeletedCount, scope.subjectNoun)
+		fmt.Printf("%s %s %d %s(s)\n", ui.RenderPass("✓"), capitalize(scope.pastTense), result.DeletedCount, scope.subjectNoun)
 		fmt.Printf("  Dependencies removed: %d\n", result.DependenciesCount)
 		fmt.Printf("  Labels removed:       %d\n", result.LabelsCount)
 		fmt.Printf("  Events removed:       %d\n", result.EventsCount)

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -12,6 +12,28 @@ import (
 	"github.com/steveyegge/beads/internal/ui"
 )
 
+// purgeScope parameterizes the shared purge/prune implementation so both
+// commands can share filter plumbing, preview/dry-run/force semantics, and
+// messaging without copying 200 lines of boilerplate.
+type purgeScope struct {
+	// cmdName is the user-visible command name (e.g. "purge", "prune").
+	// Used in messages and the suggested `--force` hint.
+	cmdName string
+	// subjectNoun describes what's being purged, in singular form
+	// (e.g. "closed ephemeral bead", "closed bead"). "(s)" is appended by
+	// the printer when multiple items are involved.
+	subjectNoun string
+	// ephemeralOnly restricts the filter to ephemeral beads when true.
+	// When false, restricts to non-ephemeral beads — the scopes are
+	// deliberately disjoint so `prune` never touches wisps that `purge`
+	// would handle, and vice versa.
+	ephemeralOnly bool
+	// requireFilter forces the user to pass --older-than or --pattern.
+	// Without this gate, `bd prune --force` would silently delete every
+	// closed non-ephemeral bead in the repo.
+	requireFilter bool
+}
+
 var purgeCmd = &cobra.Command{
 	Use:     "purge",
 	GroupID: "maint",
@@ -24,190 +46,223 @@ have no value once closed. This command removes them to reclaim storage.
 Deletes: issues, dependencies, labels, events, and comments for matching beads.
 Skips: pinned beads (protected).
 
+To delete closed non-ephemeral beads (regular tasks, features, bugs, etc.)
+use ` + "`bd prune`" + ` instead.
+
 EXAMPLES:
   bd purge                           # Preview what would be purged
   bd purge --force                   # Delete all closed ephemeral beads
   bd purge --older-than 7d --force   # Only purge items closed 7+ days ago
   bd purge --pattern "*-wisp-*"      # Only purge matching ID pattern
   bd purge --dry-run                 # Detailed preview with stats`,
-	Run: func(cmd *cobra.Command, args []string) {
-		CheckReadonly("purge")
+	Run: func(cmd *cobra.Command, _ []string) {
+		runPurgeOrPrune(cmd, purgeScope{
+			cmdName:       "purge",
+			subjectNoun:   "closed ephemeral bead",
+			ephemeralOnly: true,
+			requireFilter: false,
+		})
+	},
+}
 
-		force, _ := cmd.Flags().GetBool("force")
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		olderThan, _ := cmd.Flags().GetString("older-than")
-		pattern, _ := cmd.Flags().GetString("pattern")
+// runPurgeOrPrune implements the shared delete-closed-beads flow used by
+// both `bd purge` (ephemeral scope) and `bd prune` (non-ephemeral scope).
+// The caller's scope controls the filter, messaging, and safety gate.
+func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
+	CheckReadonly(scope.cmdName)
 
-		if store == nil {
-			if err := ensureStoreActive(); err != nil {
-				FatalError("%v", err)
-			}
+	force, _ := cmd.Flags().GetBool("force")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	olderThan, _ := cmd.Flags().GetString("older-than")
+	pattern, _ := cmd.Flags().GetString("pattern")
+
+	// Safety gate: prune refuses to run without scope narrowing so a typo
+	// or muscle-memory `--force` can't wipe every closed bead in the repo.
+	if scope.requireFilter && olderThan == "" && pattern == "" {
+		FatalErrorWithHint(
+			fmt.Sprintf("bd %s requires --older-than or --pattern", scope.cmdName),
+			"Protects against accidental bulk deletion. Use `--older-than 1d` to\n"+
+				"  include everything closed for at least one day, or `--pattern '<glob>'`\n"+
+				"  to scope by bead ID.")
+	}
+
+	if store == nil {
+		if err := ensureStoreActive(); err != nil {
+			FatalError("%v", err)
 		}
+	}
 
-		ctx := rootCtx
+	ctx := rootCtx
 
-		// Build filter: closed + ephemeral
-		statusClosed := types.StatusClosed
-		wispTrue := true
-		filter := types.IssueFilter{
-			Status:    &statusClosed,
-			Ephemeral: &wispTrue,
-		}
+	// Build filter: closed + ephemeral-or-not per scope
+	statusClosed := types.StatusClosed
+	ephemeralFlag := scope.ephemeralOnly
+	filter := types.IssueFilter{
+		Status:    &statusClosed,
+		Ephemeral: &ephemeralFlag,
+	}
 
-		// Parse --older-than duration (e.g., "7d", "30d", "24h", or just "30" for days)
-		if olderThan != "" {
-			days, err := parseHumanDuration(olderThan)
-			if err != nil {
-				FatalError("invalid --older-than value %q: %v", olderThan, err)
-			}
-			cutoff := time.Now().AddDate(0, 0, -days)
-			filter.ClosedBefore = &cutoff
-		}
-
-		// Get matching issues
-		closedIssues, err := store.SearchIssues(ctx, "", filter)
+	// Parse --older-than duration (e.g., "7d", "30d", "24h", or just "30" for days)
+	if olderThan != "" {
+		days, err := parseHumanDuration(olderThan)
 		if err != nil {
-			FatalError("listing issues: %v", err)
+			FatalError("invalid --older-than value %q: %v", olderThan, err)
 		}
+		cutoff := time.Now().AddDate(0, 0, -days)
+		filter.ClosedBefore = &cutoff
+	}
 
-		// Filter by ID pattern if specified
-		if pattern != "" {
-			var matched []*types.Issue
-			for _, issue := range closedIssues {
-				if ok, _ := filepath.Match(pattern, issue.ID); ok {
-					matched = append(matched, issue)
-				}
-			}
-			closedIssues = matched
-		}
+	// Get matching issues
+	closedIssues, err := store.SearchIssues(ctx, "", filter)
+	if err != nil {
+		FatalError("listing issues: %v", err)
+	}
 
-		// Filter out pinned beads
-		pinnedCount := 0
-		filtered := make([]*types.Issue, 0, len(closedIssues))
+	// Filter by ID pattern if specified
+	if pattern != "" {
+		var matched []*types.Issue
 		for _, issue := range closedIssues {
-			if issue.Pinned {
-				pinnedCount++
-				continue
+			if ok, _ := filepath.Match(pattern, issue.ID); ok {
+				matched = append(matched, issue)
 			}
-			filtered = append(filtered, issue)
 		}
-		closedIssues = filtered
+		closedIssues = matched
+	}
 
-		// Report
-		if len(closedIssues) == 0 {
-			if jsonOutput {
-				outputJSON(map[string]interface{}{
-					"purged_count": 0,
-					"message":      "No closed ephemeral beads to purge",
-				})
-			} else {
-				msg := "No closed ephemeral beads to purge"
-				if olderThan != "" {
-					msg += fmt.Sprintf(" (older than %s)", olderThan)
-				}
-				if pattern != "" {
-					msg += fmt.Sprintf(" (matching %q)", pattern)
-				}
-				fmt.Println(msg)
-			}
-			return
+	// Filter out pinned beads
+	pinnedCount := 0
+	filtered := make([]*types.Issue, 0, len(closedIssues))
+	for _, issue := range closedIssues {
+		if issue.Pinned {
+			pinnedCount++
+			continue
 		}
+		filtered = append(filtered, issue)
+	}
+	closedIssues = filtered
 
-		// Extract IDs
-		issueIDs := make([]string, len(closedIssues))
-		for i, issue := range closedIssues {
-			issueIDs[i] = issue.ID
-		}
-
-		// Dry-run: show stats preview
-		if dryRun {
-			result, err := store.DeleteIssues(ctx, issueIDs, false, false, true)
-			if jsonOutput {
-				stats := map[string]interface{}{
-					"dry_run":      true,
-					"purge_count":  len(issueIDs),
-					"dependencies": 0,
-					"labels":       0,
-					"events":       0,
-				}
-				if err == nil {
-					stats["dependencies"] = result.DependenciesCount
-					stats["labels"] = result.LabelsCount
-					stats["events"] = result.EventsCount
-				}
-				if pinnedCount > 0 {
-					stats["pinned_skipped"] = pinnedCount
-				}
-				outputJSON(stats)
-			} else {
-				fmt.Printf("Would purge %d closed ephemeral bead(s)\n", len(issueIDs))
-				if err == nil {
-					fmt.Printf("  Dependencies: %d\n", result.DependenciesCount)
-					fmt.Printf("  Labels:       %d\n", result.LabelsCount)
-					fmt.Printf("  Events:       %d\n", result.EventsCount)
-				}
-				if pinnedCount > 0 {
-					fmt.Printf("  Pinned (skipped): %d\n", pinnedCount)
-				}
-				fmt.Printf("\n(Dry-run mode — no changes made)\n")
-			}
-			return
-		}
-
-		// Preview mode (no --force)
-		if !force {
-			fmt.Printf("Found %d closed ephemeral bead(s) to purge\n", len(issueIDs))
-			if pinnedCount > 0 {
-				fmt.Printf("Skipping %d pinned bead(s)\n", pinnedCount)
-			}
-			hint := "bd purge --force"
+	// Report nothing-to-do
+	if len(closedIssues) == 0 {
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"purged_count": 0,
+				"message":      fmt.Sprintf("No %ss to %s", scope.subjectNoun, scope.cmdName),
+			})
+		} else {
+			msg := fmt.Sprintf("No %ss to %s", scope.subjectNoun, scope.cmdName)
 			if olderThan != "" {
-				hint += " --older-than " + olderThan
+				msg += fmt.Sprintf(" (older than %s)", olderThan)
 			}
 			if pattern != "" {
-				hint += " --pattern " + pattern
+				msg += fmt.Sprintf(" (matching %q)", pattern)
 			}
-			FatalErrorWithHint(
-				fmt.Sprintf("would purge %d bead(s)", len(issueIDs)),
-				fmt.Sprintf("Use --force to confirm or --dry-run to preview.\n  %s", hint))
+			fmt.Println(msg)
 		}
+		return
+	}
 
-		// Actually purge
-		result, err := store.DeleteIssues(ctx, issueIDs, false, true, false)
-		if err != nil {
-			FatalError("purge failed: %v", err)
-		}
+	// Extract IDs
+	issueIDs := make([]string, len(closedIssues))
+	for i, issue := range closedIssues {
+		issueIDs[i] = issue.ID
+	}
 
-		commandDidWrite.Store(true)
-
+	// Dry-run: show stats preview
+	if dryRun {
+		result, err := store.DeleteIssues(ctx, issueIDs, false, false, true)
 		if jsonOutput {
 			stats := map[string]interface{}{
-				"purged_count": result.DeletedCount,
-				"dependencies": result.DependenciesCount,
-				"labels":       result.LabelsCount,
-				"events":       result.EventsCount,
+				"dry_run":      true,
+				"purge_count":  len(issueIDs),
+				"dependencies": 0,
+				"labels":       0,
+				"events":       0,
+			}
+			if err == nil {
+				stats["dependencies"] = result.DependenciesCount
+				stats["labels"] = result.LabelsCount
+				stats["events"] = result.EventsCount
 			}
 			if pinnedCount > 0 {
 				stats["pinned_skipped"] = pinnedCount
 			}
 			outputJSON(stats)
 		} else {
-			fmt.Printf("%s Purged %d closed ephemeral bead(s)\n", ui.RenderPass("✓"), result.DeletedCount)
-			fmt.Printf("  Dependencies removed: %d\n", result.DependenciesCount)
-			fmt.Printf("  Labels removed:       %d\n", result.LabelsCount)
-			fmt.Printf("  Events removed:       %d\n", result.EventsCount)
+			fmt.Printf("Would %s %d %s(s)\n", scope.cmdName, len(issueIDs), scope.subjectNoun)
+			if err == nil {
+				fmt.Printf("  Dependencies: %d\n", result.DependenciesCount)
+				fmt.Printf("  Labels:       %d\n", result.LabelsCount)
+				fmt.Printf("  Events:       %d\n", result.EventsCount)
+			}
 			if pinnedCount > 0 {
-				fmt.Printf("  Pinned (skipped):     %d\n", pinnedCount)
+				fmt.Printf("  Pinned (skipped): %d\n", pinnedCount)
 			}
+			fmt.Printf("\n(Dry-run mode — no changes made)\n")
 		}
+		return
+	}
 
-		// Embedded mode: flush Dolt commit.
-		if isEmbeddedMode() && result.DeletedCount > 0 && store != nil {
-			if _, err := store.CommitPending(ctx, actor); err != nil {
-				FatalError("failed to commit: %v", err)
-			}
+	// Preview mode (no --force)
+	if !force {
+		fmt.Printf("Found %d %s(s) to %s\n", len(issueIDs), scope.subjectNoun, scope.cmdName)
+		if pinnedCount > 0 {
+			fmt.Printf("Skipping %d pinned bead(s)\n", pinnedCount)
 		}
-	},
+		hint := fmt.Sprintf("bd %s --force", scope.cmdName)
+		if olderThan != "" {
+			hint += " --older-than " + olderThan
+		}
+		if pattern != "" {
+			hint += " --pattern " + pattern
+		}
+		FatalErrorWithHint(
+			fmt.Sprintf("would %s %d bead(s)", scope.cmdName, len(issueIDs)),
+			fmt.Sprintf("Use --force to confirm or --dry-run to preview.\n  %s", hint))
+	}
+
+	// Actually purge
+	result, err := store.DeleteIssues(ctx, issueIDs, false, true, false)
+	if err != nil {
+		FatalError("%s failed: %v", scope.cmdName, err)
+	}
+
+	commandDidWrite.Store(true)
+
+	if jsonOutput {
+		stats := map[string]interface{}{
+			"purged_count": result.DeletedCount,
+			"dependencies": result.DependenciesCount,
+			"labels":       result.LabelsCount,
+			"events":       result.EventsCount,
+		}
+		if pinnedCount > 0 {
+			stats["pinned_skipped"] = pinnedCount
+		}
+		outputJSON(stats)
+	} else {
+		past := strings.TrimSuffix(scope.cmdName, "e") + "ed" // purge→purged, prune→pruned
+		fmt.Printf("%s %s %d %s(s)\n", ui.RenderPass("✓"), capitalize(past), result.DeletedCount, scope.subjectNoun)
+		fmt.Printf("  Dependencies removed: %d\n", result.DependenciesCount)
+		fmt.Printf("  Labels removed:       %d\n", result.LabelsCount)
+		fmt.Printf("  Events removed:       %d\n", result.EventsCount)
+		if pinnedCount > 0 {
+			fmt.Printf("  Pinned (skipped):     %d\n", pinnedCount)
+		}
+	}
+
+	// Embedded mode: flush Dolt commit.
+	if isEmbeddedMode() && result.DeletedCount > 0 && store != nil {
+		if _, err := store.CommitPending(ctx, actor); err != nil {
+			FatalError("failed to commit: %v", err)
+		}
+	}
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 // parseHumanDuration parses a human-friendly duration string into days.


### PR DESCRIPTION
## Summary

`bd purge` is scoped to closed ephemeral beads (wisps, transient molecules). That leaves no built-in way to trim the usual long-lived cruft: closed tasks/features/bugs/chores that stick around forever, bloat auto-export, and make `bd list` and other queries slower over time. Users who don't care about closed history eventually want a way to drop it.

This PR adds `bd prune` with the same surface as `bd purge` but the opposite scope — closed **non-ephemeral** beads.

### Design

- `bd purge` scope: closed **ephemeral** (existing, unchanged).
- `bd prune` scope: closed **non-ephemeral**.
- Scopes are deliberately disjoint — neither command touches what the other handles.
- `bd prune` requires `--older-than` or `--pattern` as a safety gate. A muscle-memory `bd prune --force` would otherwise wipe every closed bead in the repo. Users who genuinely want to sweep everything closed can pass `--pattern '*'`.

### What's in the change

- `runPurgeOrPrune` extracted from the existing `purgeCmd` closure. Both commands now share filter plumbing, preview/dry-run/force semantics, stats printing, pinned-bead skipping, and embedded-mode commit flush.
- `purgeCmd` and `pruneCmd` differ only in name, `ephemeralOnly` filter, `requireFilter` gate, and messaging.
- `bd purge --help` cross-references `bd prune` (and vice versa) so users find the right command for their scope.
- Shared flags on both: `--force`, `--dry-run`, `--older-than`, `--pattern`.

### Test plan

Tests live in `cmd/bd/prune_embedded_test.go`, gated by `BEADS_TEST_EMBEDDED_DOLT=1` like the existing purge tests.

- [x] `prune_requires_older_than_or_pattern` — safety gate rejects bare `--force` and leaves data intact; error message names the two acceptable flags.
- [x] `prune_deletes_closed_non_ephemeral` — happy path: `bd prune --pattern X --force` removes matching closed tasks.
- [x] `prune_leaves_closed_ephemeral_for_purge` — cross-scope invariant: `bd prune` must not touch wisps; they remain visible to `bd purge`.
- [x] `prune_leaves_open_beads_alone` — open beads survive even under a matching pattern.
- [x] `prune_dry_run_reports_without_deleting` — dry-run prints a preview and keeps data intact.
- [x] `prune_preview_fails_without_force` — preview mode (no `--force`) aborts with a preview message; no data lost.
- [x] `prune_older_than_skips_recent` — `--older-than 30d` excludes just-closed beads.
- [x] Manual smoke on a 46k-bead repo: `bd prune --force` (no filter) errors correctly; `bd prune --pattern 'gm-*' --older-than 1d --dry-run` reports "Would prune 45314 closed bead(s)"; `bd purge --dry-run` still reports only the 2 ephemerals (pre-existing scope preserved).

### Notes

- Independent of #3351 (incremental auto-export). This branch is based directly on `origin/main` and can be reviewed/merged on its own.
- Follow-up not in this PR: the full-force preview path for very large sets (45k+) doesn't print per-category counts (dependencies/labels/events) because `store.DeleteIssues` in dry-run mode appears to return a non-nil error at that scale. That's pre-existing behavior also present in `bd purge --dry-run`; worth a separate look if the lack of preview detail at scale is actually user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
