### PR TITLE
Fix git-remote-cache tmp_pack file leak in embedded mode

### DIFF
--- a/internal/storage/embeddeddolt/cache_cleanup.go
+++ b/internal/storage/embeddeddolt/cache_cleanup.go
@@ -1,0 +1,89 @@
+//go:build cgo
+
+package embeddeddolt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// cleanGitRemoteCacheGarbage removes orphaned tmp_pack_* files from the
+// Dolt git-remote-cache. These files are created by `git fetch` (invoked
+// by Dolt's GitBlobstore) and should be renamed to final .pack/.idx files
+// on success or deleted on failure. In practice, failed or interrupted
+// fetches leave them behind indefinitely, and Dolt's built-in periodic
+// git gc (maybeRunGC, gated to once per 24h) either never runs or cannot
+// keep up with the accumulation rate.
+//
+// On a real machine with normal beads usage, this leak consumed 102 GB
+// (412 files) in 7 days. See https://github.com/gastownhall/beads/issues/3354
+//
+// This function is safe to call concurrently and is rate-limited to avoid
+// unnecessary filesystem walks on hot paths.
+func (s *EmbeddedDoltStore) cleanGitRemoteCacheGarbage() {
+	if !cacheCleanupThrottle.shouldRun() {
+		return
+	}
+
+	cacheBase := filepath.Join(s.dataDir, s.database, ".dolt", "git-remote-cache")
+	if _, err := os.Stat(cacheBase); os.IsNotExist(err) {
+		return
+	}
+
+	cutoff := time.Now().Add(-tmpPackMinAge)
+
+	_ = filepath.WalkDir(cacheBase, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // best-effort: skip unreadable entries
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasPrefix(name, "tmp_pack_") && !strings.HasPrefix(name, "tmp_idx_") {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.ModTime().Before(cutoff) {
+			_ = os.Remove(path)
+		}
+		return nil
+	})
+}
+
+const (
+	// tmpPackMinAge is the minimum age before a tmp_pack file is considered
+	// garbage. Files younger than this may belong to an in-progress fetch.
+	tmpPackMinAge = 5 * time.Minute
+
+	// cacheCleanupInterval is how often cleanGitRemoteCacheGarbage actually
+	// walks the filesystem when called repeatedly.
+	cacheCleanupInterval = 10 * time.Minute
+)
+
+// throttle gates a function to run at most once per interval.
+type throttle struct {
+	mu       sync.Mutex
+	interval time.Duration
+	lastRun  time.Time
+}
+
+func (t *throttle) shouldRun() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if time.Since(t.lastRun) < t.interval {
+		return false
+	}
+	t.lastRun = time.Now()
+	return true
+}
+
+// cacheCleanupThrottle is a package-level throttle shared across all
+// EmbeddedDoltStore instances in the same process.
+var cacheCleanupThrottle = &throttle{interval: cacheCleanupInterval}

--- a/internal/storage/embeddeddolt/cache_cleanup_test.go
+++ b/internal/storage/embeddeddolt/cache_cleanup_test.go
@@ -1,0 +1,118 @@
+package embeddeddolt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCleanGitRemoteCacheGarbage(t *testing.T) {
+	// Reset the throttle so the test always runs the cleanup.
+	cacheCleanupThrottle.mu.Lock()
+	cacheCleanupThrottle.lastRun = time.Time{}
+	cacheCleanupThrottle.mu.Unlock()
+
+	tmpDir := t.TempDir()
+	packDir := filepath.Join(tmpDir, "testdb", ".dolt", "git-remote-cache", "abc123", "repo.git", "objects", "pack")
+	if err := os.MkdirAll(packDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	staleFile := filepath.Join(packDir, "tmp_pack_STALE1")
+	if err := os.WriteFile(staleFile, []byte("stale data"), 0444); err != nil {
+		t.Fatal(err)
+	}
+	// Backdate the file well past the min age.
+	old := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(staleFile, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	staleIdx := filepath.Join(packDir, "tmp_idx_STALE2")
+	if err := os.WriteFile(staleIdx, []byte("stale idx"), 0444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(staleIdx, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	recentFile := filepath.Join(packDir, "tmp_pack_RECENT")
+	if err := os.WriteFile(recentFile, []byte("in progress"), 0444); err != nil {
+		t.Fatal(err)
+	}
+
+	finalPack := filepath.Join(packDir, "pack-abc123.pack")
+	if err := os.WriteFile(finalPack, []byte("real pack"), 0444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(finalPack, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &EmbeddedDoltStore{
+		dataDir:  tmpDir,
+		database: "testdb",
+	}
+	s.cleanGitRemoteCacheGarbage()
+
+	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
+		t.Errorf("stale tmp_pack file should have been deleted, but still exists")
+	}
+	if _, err := os.Stat(staleIdx); !os.IsNotExist(err) {
+		t.Errorf("stale tmp_idx file should have been deleted, but still exists")
+	}
+	if _, err := os.Stat(recentFile); err != nil {
+		t.Errorf("recent tmp_pack file should NOT have been deleted: %v", err)
+	}
+	if _, err := os.Stat(finalPack); err != nil {
+		t.Errorf("finalized pack file should NOT have been deleted: %v", err)
+	}
+}
+
+func TestCleanGitRemoteCacheGarbage_Throttled(t *testing.T) {
+	// Reset then immediately mark as just-run.
+	cacheCleanupThrottle.mu.Lock()
+	cacheCleanupThrottle.lastRun = time.Now()
+	cacheCleanupThrottle.mu.Unlock()
+
+	tmpDir := t.TempDir()
+	packDir := filepath.Join(tmpDir, "testdb", ".dolt", "git-remote-cache", "abc123", "repo.git", "objects", "pack")
+	if err := os.MkdirAll(packDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	staleFile := filepath.Join(packDir, "tmp_pack_STALE1")
+	if err := os.WriteFile(staleFile, []byte("stale"), 0444); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(staleFile, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &EmbeddedDoltStore{
+		dataDir:  tmpDir,
+		database: "testdb",
+	}
+	s.cleanGitRemoteCacheGarbage()
+
+	if _, err := os.Stat(staleFile); os.IsNotExist(err) {
+		t.Errorf("throttled cleanup should NOT have deleted the file, but it was deleted")
+	}
+}
+
+func TestCleanGitRemoteCacheGarbage_NoCacheDir(t *testing.T) {
+	// Reset throttle.
+	cacheCleanupThrottle.mu.Lock()
+	cacheCleanupThrottle.lastRun = time.Time{}
+	cacheCleanupThrottle.mu.Unlock()
+
+	tmpDir := t.TempDir()
+	s := &EmbeddedDoltStore{
+		dataDir:  tmpDir,
+		database: "testdb",
+	}
+	// Should not panic when the cache directory doesn't exist.
+	s.cleanGitRemoteCacheGarbage()
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -434,14 +434,16 @@ func (s *EmbeddedDoltStore) GetAllEventsSince(ctx context.Context, since time.Ti
 
 // RunInTransaction is implemented in transaction.go.
 
-// Close marks the store as closed and releases the exclusive flock on the data
-// directory (if the store owns it). Subsequent method calls will return errClosed.
+// Close marks the store as closed, cleans up orphaned git-remote-cache
+// garbage, and releases the exclusive flock on the data directory (if the
+// store owns it). Subsequent method calls will return errClosed.
 // It is safe to call multiple times. When the lock was supplied by the caller
 // via WithLock, Close does NOT release it — the caller retains ownership.
 func (s *EmbeddedDoltStore) Close() error {
 	// Use CompareAndSwap so we only unlock once even if Close is called
 	// multiple times (the Lock.Unlock method panics on double-unlock).
 	if s.closed.CompareAndSwap(false, true) {
+		s.cleanGitRemoteCacheGarbage()
 		if s.lock != nil && s.ownsLock {
 			s.lock.Unlock()
 		}

--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -31,6 +31,9 @@ func (s *EmbeddedDoltStore) withDBConn(ctx context.Context, fn func(db versionco
 	}
 	defer func() {
 		err = errors.Join(err, cleanup())
+		// Best-effort cleanup of orphaned tmp_pack_* files left by git
+		// fetch in the Dolt git-remote-cache. Rate-limited internally.
+		s.cleanGitRemoteCacheGarbage()
 	}()
 
 	return fn(db)


### PR DESCRIPTION
## Summary

- Add `cleanGitRemoteCacheGarbage()` to `EmbeddedDoltStore` that removes orphaned `tmp_pack_*`/`tmp_idx_*` files older than 5 minutes from the Dolt git-remote-cache
- Wire it into `Close()` and `withDBConn()` deferred cleanup so it runs on store teardown and after fetch/push operations
- Rate-limit to once per 10 minutes to avoid filesystem thrashing

## Problem

Failed or interrupted `git fetch` operations (invoked by Dolt's `GitBlobstore.syncForRead`) leave `tmp_pack_*` files in `.dolt/git-remote-cache/*/repo.git/objects/pack/`. Dolt's built-in `maybeRunGC` (gated to once per 24h via `.dolt-gc-last` marker) either never fires in embedded mode or cannot keep pace with the accumulation rate.

On a real machine with normal beads usage across ~10 workspaces, this accumulated **102 GB (412 files) in 7 days**, filling the disk to capacity and causing cascading failures (swap exhaustion, shell temp file creation errors, app crashes).

Root cause investigation found:
- The bare cache repo had **zero finalized pack files** and **no refs** -- every fetch was failing
- The `.dolt-gc-last` marker did not exist, meaning `GitBlobstore.Close()` -> `maybeRunGC()` was never being reached
- `CALL DOLT_GC()` (SQL-level GC) does not clean the git-remote-cache -- that requires `git gc --prune=now` on the bare repo, which only Dolt's blobstore `Close()` triggers

## Test plan

- [x] `TestCleanGitRemoteCacheGarbage` -- stale tmp_pack/tmp_idx files deleted, recent files and finalized packs preserved
- [x] `TestCleanGitRemoteCacheGarbage_Throttled` -- cleanup skipped when rate-limited
- [x] `TestCleanGitRemoteCacheGarbage_NoCacheDir` -- no panic when cache directory doesn't exist
- [x] All tests pass with CGO_ENABLED=1

## Related

- Fixes #3354
- Possibly related to Dolt issues: dolthub/dolt#9983 (temptf bloat), dolthub/dolt#10732 (temp file leaks)
- The upstream root cause (why `GitBlobstore.Close()` never triggers `maybeRunGC` in embedded mode) may warrant a separate investigation/fix in dolthub/dolt