### PR TITLE
Skip Dolt remote registration for plain git source repos during init

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -560,6 +560,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// flag that can interact with remote history must route through
 		// it rather than adding another `&& !someFlag` here.
 		syncURL := resolveSyncRemote()
+		syncURLFromConfig := syncURL != "" // true when URL came from explicit user config
 		bootstrappedFromRemote := false
 		syncFromRemote := false
 		remoteHasDoltData := false
@@ -747,10 +748,13 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		}
 
 		// Configure the remote in the Dolt store so bd dolt push/pull
-		// work immediately after bootstrap. Also add the remote when
-		// sync.remote is configured but bootstrap was skipped (DB already
-		// existed) — ensures the remote is always wired up.
-		if syncURL != "" {
+		// work immediately after bootstrap. Only register the remote when
+		// the URL came from explicit config (sync.remote) or the remote
+		// was confirmed to have Dolt data (refs/dolt/data). Auto-detected
+		// git origin URLs for plain source repos must NOT be registered —
+		// they cause every Dolt fetch to fail and leak tmp_pack_* files
+		// that can consume 100+ GB of disk space (GH#3354, GH#3356).
+		if shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig) {
 			hasRemote, _ := store.HasRemote(ctx, "origin")
 			if !hasRemote {
 				if err := store.AddRemote(ctx, "origin", syncURL); err != nil {
@@ -923,7 +927,10 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Persist sync.remote to config.yaml so fresh clones can
 			// bootstrap from it (the Dolt database is gitignored).
 			// Must run AFTER createConfigYaml which creates the file.
-			if syncURL != "" {
+			// Only persist when the URL is from explicit config or a
+			// confirmed Dolt remote — not an auto-detected git origin
+			// for a plain source repo (GH#3356).
+			if shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig) {
 				if existing := config.GetYamlConfig("sync.remote"); existing == "" {
 					if err := config.SetYamlConfig("sync.remote", syncURL); err != nil {
 						FatalError("failed to persist sync.remote to config.yaml: %v", err)
@@ -1824,6 +1831,12 @@ func promptAutoExport() (bool, error) {
 
 	// Default to yes (empty or "y" or "yes")
 	return response == "" || response == "y" || response == "yes", nil
+}
+
+func shouldWireInitRemote(syncURL string, syncFromRemote, syncURLFromConfig bool) bool {
+	// Auto-detected plain git origins are not Dolt remotes. Only wire origin
+	// when it was explicitly configured or proven to carry refs/dolt/data.
+	return syncURL != "" && (syncFromRemote || syncURLFromConfig)
 }
 
 // verifyMetadata writes a metadata field and verifies the write succeeded.

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -321,6 +321,30 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("plain_git_origin_not_registered_as_dolt_remote", func(t *testing.T) {
+		bareDir := filepath.Join(t.TempDir(), "plain.git")
+		runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+		runGitForBootstrapTest(t, dir, "remote", "add", "origin", bareDir)
+
+		runBDInit(t, bd, dir, "--prefix", "pg", "--skip-hooks", "--skip-agents")
+
+		out := bdDolt(t, bd, dir, "remote", "list")
+		if strings.Contains(out, "origin") {
+			t.Fatalf("plain git origin should not be registered as a Dolt remote; remote list:\n%s", out)
+		}
+
+		configYAML, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if strings.Contains(string(configYAML), "sync.remote:") || strings.Contains(string(configYAML), "sync-remote:") {
+			t.Fatalf("plain git origin should not be persisted as sync.remote; config.yaml:\n%s", configYAML)
+		}
+	})
+
 	t.Run("database", func(t *testing.T) {
 		_, beadsDir, _ := bdInit(t, bd, "--database", "custom_db")
 		cfg, err := configfile.Load(beadsDir)

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -159,6 +159,53 @@ func TestCheckRemoteSafety_RefusalTextNoEcho(t *testing.T) {
 	}
 }
 
+func TestShouldWireInitRemote(t *testing.T) {
+	tests := []struct {
+		name              string
+		syncURL           string
+		syncFromRemote    bool
+		syncURLFromConfig bool
+		want              bool
+	}{
+		{
+			name:    "no url",
+			syncURL: "",
+			want:    false,
+		},
+		{
+			name:              "plain git origin without dolt data",
+			syncURL:           "git+https://github.com/org/plain-source.git",
+			syncFromRemote:    false,
+			syncURLFromConfig: false,
+			want:              false,
+		},
+		{
+			name:              "git origin with refs/dolt/data",
+			syncURL:           "git+https://github.com/org/beads-data.git",
+			syncFromRemote:    true,
+			syncURLFromConfig: false,
+			want:              true,
+		},
+		{
+			name:              "explicit sync.remote",
+			syncURL:           "http://myserver:7007/mydb",
+			syncFromRemote:    false,
+			syncURLFromConfig: true,
+			want:              true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldWireInitRemote(tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig)
+			if got != tt.want {
+				t.Errorf("shouldWireInitRemote(%q, %v, %v) = %v, want %v",
+					tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestFormatDestroyToken asserts the token format contract that
 // bd help init-safety documents. If this format changes, help text
 // and the ADR must update together.


### PR DESCRIPTION
## Summary

- Gate `AddRemote("origin", syncURL)` in `bd init` on either `syncFromRemote` (remote confirmed to have `refs/dolt/data`) or `syncURLFromConfig` (URL from explicit `sync.remote` config)
- Apply the same guard to `sync.remote` persistence in `config.yaml`
- Auto-detected git origin URLs that lack Dolt data are no longer registered as Dolt remotes

## Problem

`bd init` unconditionally registered the parent git repo's `origin` URL as a Dolt remote whenever `origin` existed, even when the remote had no `refs/dolt/data`. For plain Git source repos (e.g. `gastownhall/beads` itself), this caused:

1. Every Dolt fetch operation to fail (the remote is a Go source repo, not a Dolt database)
2. Each failed fetch left a 100-900 MB `tmp_pack_*` file in `.dolt/git-remote-cache/`
3. Files accumulated at ~15 GB/day, consuming 102 GB in 7 days (#3354)

The clone path correctly gated on `syncFromRemote` (which requires `refs/dolt/data`), but `AddRemote` and `sync.remote` persistence only checked `syncURL != ""`.

## Fix

Introduce `syncURLFromConfig` to distinguish between explicit user config and auto-detected git origin. Only register the Dolt remote when:
- `syncFromRemote` is true (remote has `refs/dolt/data`), OR
- `syncURLFromConfig` is true (URL came from `sync.remote` config, meaning the user explicitly configured it)

This matches the stricter behavior already used by `bd bootstrap`'s `detectBootstrapAction`, which only sets `SyncRemote` when `refs/dolt/data` exists.

## Test plan

- [x] `go vet ./cmd/bd/` passes
- [ ] `bd init` in a plain git repo (no `refs/dolt/data`) should NOT register a Dolt remote
- [ ] `bd init` in a repo with `refs/dolt/data` should still register the remote (unchanged behavior)
- [ ] `bd init` with explicit `sync.remote` config should still register the remote (unchanged behavior)
- [ ] `bd init --stealth` in a git repo should not write `sync.remote` to config.yaml for plain git origins

## Related

- Fixes #3356
- Root cause of #3354 (tmp_pack file leak)
- Companion to #3355 (cleanup of leaked tmp_pack files)