### PR TITLE
fix(formula): carry step metadata through cook and pour (GH#3341)

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -560,6 +560,13 @@ func processStepToIssue(step *formula.Step, parentID string) *types.Issue {
 		issue.Labels = append(issue.Labels, gateLabel)
 	}
 
+	// Carry step metadata through to the issue (GH#3341).
+	if len(step.Metadata) > 0 {
+		if metaJSON, err := json.Marshal(step.Metadata); err == nil {
+			issue.Metadata = metaJSON
+		}
+	}
+
 	return issue
 }
 

--- a/cmd/bd/cook_test.go
+++ b/cmd/bd/cook_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/formula"
@@ -643,5 +644,57 @@ func TestCookFormulaToSubgraph_StandaloneExpansionWithWorkflowVars(t *testing.T)
 	}
 	if workIssue.Description != "Build {{feature}} per brief: {{brief}}" {
 		t.Errorf("Description = %q, want {{vars}} preserved", workIssue.Description)
+	}
+}
+
+// TestCookFormulaToSubgraph_StepMetadata verifies that a step's Metadata flows
+// through cook onto the resulting Issue.Metadata as a JSON object. Regression
+// for gastownhall/beads#3341.
+func TestCookFormulaToSubgraph_StepMetadata(t *testing.T) {
+	f := &formula.Formula{
+		Formula: "repro",
+		Version: 1,
+		Type:    formula.TypeWorkflow,
+		Steps: []*formula.Step{
+			{
+				ID:     "work",
+				Title:  "Do the work",
+				Labels: []string{"worker"},
+				Metadata: map[string]interface{}{
+					"priority_level": "high",
+					"origin":         "repro",
+				},
+			},
+		},
+	}
+
+	subgraph, err := cookFormulaToSubgraph(f, "repro")
+	if err != nil {
+		t.Fatalf("cookFormulaToSubgraph failed: %v", err)
+	}
+
+	var workIssue *types.Issue
+	for _, issue := range subgraph.Issues {
+		if issue.ID == "repro.work" {
+			workIssue = issue
+			break
+		}
+	}
+	if workIssue == nil {
+		t.Fatal("repro.work issue not found in subgraph")
+	}
+	if len(workIssue.Metadata) == 0 {
+		t.Fatalf("workIssue.Metadata is empty; want JSON object carrying step metadata")
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(workIssue.Metadata, &decoded); err != nil {
+		t.Fatalf("workIssue.Metadata is not valid JSON: %v (raw: %s)", err, string(workIssue.Metadata))
+	}
+	if got := decoded["priority_level"]; got != "high" {
+		t.Errorf("Metadata[priority_level] = %v, want \"high\"", got)
+	}
+	if got := decoded["origin"]; got != "repro" {
+		t.Errorf("Metadata[origin] = %v, want \"repro\"", got)
 	}
 }

--- a/cmd/bd/mol_test.go
+++ b/cmd/bd/mol_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -2985,6 +2986,70 @@ func TestSpawnMoleculeFromFormulaEphemeral(t *testing.T) {
 				t.Errorf("Ephemeral issue %s should not appear in ready work", spawnedID)
 			}
 		}
+	}
+}
+
+// TestSpawnMolecule_PreservesStepMetadata verifies that a cooked formula with
+// per-step metadata results in spawned issues whose Metadata field carries the
+// declared keys through to the database. Regression for gastownhall/beads#3341.
+func TestSpawnMolecule_PreservesStepMetadata(t *testing.T) {
+	ctx := context.Background()
+	dbPath := t.TempDir() + "/test.db"
+	s, err := dolt.New(ctx, &dolt.Config{Path: dbPath})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	defer s.Close()
+	if err := s.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	f := &formula.Formula{
+		Formula: "meta-test",
+		Version: 1,
+		Type:    formula.TypeWorkflow,
+		Steps: []*formula.Step{
+			{
+				ID:    "work",
+				Title: "Do the work",
+				Metadata: map[string]interface{}{
+					"reminder_list": "brewery",
+					"origin":        "repro",
+				},
+			},
+		},
+	}
+
+	subgraph, err := cookFormulaToSubgraph(f, "meta-test")
+	if err != nil {
+		t.Fatalf("cookFormulaToSubgraph failed: %v", err)
+	}
+
+	result, err := spawnMolecule(ctx, s, subgraph, nil, "", "test", false, types.IDPrefixMol)
+	if err != nil {
+		t.Fatalf("spawnMolecule failed: %v", err)
+	}
+
+	newWorkID, ok := result.IDMapping["meta-test.work"]
+	if !ok {
+		t.Fatalf("result.IDMapping missing entry for meta-test.work; got %v", result.IDMapping)
+	}
+	spawned, err := s.GetIssue(ctx, newWorkID)
+	if err != nil {
+		t.Fatalf("GetIssue(%s) failed: %v", newWorkID, err)
+	}
+	if len(spawned.Metadata) == 0 {
+		t.Fatalf("spawned issue %s has empty Metadata; want step metadata carried through", newWorkID)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(spawned.Metadata, &decoded); err != nil {
+		t.Fatalf("spawned.Metadata is not valid JSON: %v (raw: %s)", err, string(spawned.Metadata))
+	}
+	if got := decoded["reminder_list"]; got != "brewery" {
+		t.Errorf("spawned.Metadata[reminder_list] = %v, want \"brewery\"", got)
+	}
+	if got := decoded["origin"]; got != "repro" {
+		t.Errorf("spawned.Metadata[origin] = %v, want \"repro\"", got)
 	}
 }
 

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -520,6 +520,7 @@ func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *Templat
 				AwaitType: oldIssue.AwaitType,
 				AwaitID:   substituteVariables(oldIssue.AwaitID, opts.Vars),
 				Timeout:   oldIssue.Timeout,
+				Metadata:  oldIssue.Metadata, // carry formula step metadata (GH#3341)
 				CreatedAt: time.Now(),
 				UpdatedAt: time.Now(),
 			}

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -1933,3 +1933,72 @@ title = "Test"
 		}
 	}
 }
+
+// TestParseTOML_StepMetadata verifies that a `metadata = { ... }` table on a
+// step is preserved through TOML parsing. Regression for gastownhall/beads#3341.
+func TestParseTOML_StepMetadata(t *testing.T) {
+	tomlData := `
+formula = "repro"
+description = "Reproduction case"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "work"
+title = "Do the work"
+labels = ["worker"]
+metadata = { priority_level = "high", origin = "repro" }
+`
+	p := NewParser()
+	formula, err := p.ParseTOML([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseTOML failed: %v", err)
+	}
+
+	if len(formula.Steps) != 1 {
+		t.Fatalf("len(Steps) = %d, want 1", len(formula.Steps))
+	}
+	step := formula.Steps[0]
+	if len(step.Metadata) != 2 {
+		t.Fatalf("Steps[0].Metadata has %d entries, want 2 (%v)", len(step.Metadata), step.Metadata)
+	}
+	if got := step.Metadata["priority_level"]; got != "high" {
+		t.Errorf("Steps[0].Metadata[priority_level] = %v, want \"high\"", got)
+	}
+	if got := step.Metadata["origin"]; got != "repro" {
+		t.Errorf("Steps[0].Metadata[origin] = %v, want \"repro\"", got)
+	}
+}
+
+// TestParseJSON_StepMetadata verifies that `"metadata": { ... }` on a step is
+// preserved through JSON parsing. Regression for gastownhall/beads#3341.
+func TestParseJSON_StepMetadata(t *testing.T) {
+	jsonData := `{
+  "formula": "repro",
+  "version": 1,
+  "type": "workflow",
+  "steps": [
+    {
+      "id": "work",
+      "title": "Do the work",
+      "metadata": {"priority_level": "high", "origin": "repro"}
+    }
+  ]
+}`
+	p := NewParser()
+	formula, err := p.Parse([]byte(jsonData))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(formula.Steps) != 1 {
+		t.Fatalf("len(Steps) = %d, want 1", len(formula.Steps))
+	}
+	step := formula.Steps[0]
+	if len(step.Metadata) != 2 {
+		t.Fatalf("Steps[0].Metadata has %d entries, want 2 (%v)", len(step.Metadata), step.Metadata)
+	}
+	if got := step.Metadata["priority_level"]; got != "high" {
+		t.Errorf("Steps[0].Metadata[priority_level] = %v, want \"high\"", got)
+	}
+}

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -211,6 +211,11 @@ type Step struct {
 	// Labels are applied to the created issue.
 	Labels []string `json:"labels,omitempty"`
 
+	// Metadata is carried through to the created issue's Metadata field as
+	// JSON. Lets formulas pre-declare keys that downstream tooling can project
+	// without a post-pour compose step.
+	Metadata map[string]interface{} `json:"metadata,omitempty" toml:"metadata,omitempty"`
+
 	// DependsOn lists step IDs this step blocks on (within the formula).
 	DependsOn []string `json:"depends_on,omitempty" toml:"depends_on,omitempty"`
 


### PR DESCRIPTION
Fixes #3341.

## Summary

TOML and JSON formulas accepted `metadata = { ... }` on a step without error, but the table was silently dropped:

- `formula.Step` had no `Metadata` field, so the TOML/JSON parsers discarded the table during decode.
- `processStepToIssue` built the template issue with no metadata.
- `cloneSubgraph` omitted `Metadata` when spawning the mol/wisp, so even if the template carried it, the poured bead did not.

This PR:

1. Adds `Step.Metadata map[string]interface{}` with `json`/`toml` tags so the parser preserves the table.
2. Marshals `step.Metadata` into `Issue.Metadata` (JSON bytes) inside `processStepToIssue`, so the cooked proto shows the declared keys.
3. Copies `Metadata` through `cloneSubgraph`, so `bd mol pour` / `bd mol wisp` land the bead with the metadata set.

After the fix, running the repro formula in the issue yields:

```json
{
  "id": "work",
  "title": "Do the work",
  "labels": ["worker"],
  "metadata": {
    "origin": "repro",
    "priority_level": "high"
  }
}
```

and `bd mol pour repro; bd show <poured-id> --json` now reports the same `metadata` on the poured bead.

## What is intentionally out of scope

Step 4 from the issue (variable substitution inside metadata values, like `{{recipe_name}}`) is **not** included — the issue marks it as an optional "while you're in there". Happy to add it in a follow-up if wanted, but kept this PR to the critical path so the diff stays small and reviewable.

## Tests

- `internal/formula`: `TestParseTOML_StepMetadata`, `TestParseJSON_StepMetadata` — parser preserves the table round-trip in both formats.
- `cmd/bd`: `TestCookFormulaToSubgraph_StepMetadata` — cook populates `Issue.Metadata` with the declared keys.
- `cmd/bd` (cgo, Dolt): `TestSpawnMolecule_PreservesStepMetadata` — end-to-end spawn into a real Dolt backend preserves the metadata through to the stored issue.