### PR TITLE
fix(doctor): resolve Dolt password/TLS for externally-hosted servers

### DIFF
--- a/cmd/bd/doctor/dolt.go
+++ b/cmd/bd/doctor/dolt.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -32,7 +31,6 @@ func openDoltDB(beadsDir string) (*sql.DB, *configfile.Config, error) {
 	host := cfg.GetDoltServerHost()
 	user := cfg.GetDoltServerUser()
 	database := cfg.GetDoltDatabase()
-	password := os.Getenv("BEADS_DOLT_PASSWORD")
 
 	// Use doltserver.DefaultConfig for port resolution (env > port file > config.yaml).
 	// Port 0 means no server running yet.
@@ -41,6 +39,14 @@ func openDoltDB(beadsDir string) (*sql.DB, *configfile.Config, error) {
 	if port == 0 {
 		return nil, nil, fmt.Errorf("no Dolt server port configured and no server running; run any bd command to auto-start")
 	}
+
+	// Resolve the password using the credentials file fallback keyed by the
+	// resolved runtime port — matching the CRUD path. Env var BEADS_DOLT_PASSWORD
+	// still takes precedence inside GetDoltServerPasswordForPort. Without this,
+	// externally-hosted Dolt servers that keep credentials in
+	// ~/.config/beads/credentials fail doctor checks with "Access denied" while
+	// regular CRUD commands succeed (bd-h5k7).
+	password := cfg.GetDoltServerPasswordForPort(port)
 
 	connStr := doltutil.ServerDSN{
 		Host:     host,

--- a/cmd/bd/doctor/fresh_clone_server_test.go
+++ b/cmd/bd/doctor/fresh_clone_server_test.go
@@ -112,6 +112,53 @@ func TestCheckFreshCloneDB_ServerUnreachable(t *testing.T) {
 	}
 }
 
+func TestCheckFreshClone_ServerModeUnreachable(t *testing.T) {
+	// bd-tzo9: When metadata.json declares dolt_mode=server but the server
+	// is unreachable, CheckFreshClone must resolve credentials by the
+	// *resolved runtime port* (not the deprecated metadata port default),
+	// invoke checkFreshCloneDB, observe Reachable=false, and fall through
+	// to the existing JSONL-based warning. This exercises the
+	// GetDoltServerPasswordForPort(port) code path.
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// JSONL with issues so the check proceeds past the fresh-clone gate.
+	jsonl := `{"id":"bd-abc","title":"t"}` + "\n" + `{"id":"bd-def","title":"t"}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// metadata.json declaring server mode pointed at an unreachable host:port.
+	// Port 1 is guaranteed-unreachable on loopback; Reachable=false exercises
+	// the FR-030 fall-through branch that contains the fixed password-resolution
+	// line.
+	meta := `{
+  "database": "beads.db",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_port": 1,
+  "dolt_server_user": "root",
+  "dolt_database": "beads"
+}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := CheckFreshClone(tmpDir)
+
+	// Server unreachable → falls through to legacy JSONL-based warning.
+	if check.Status != StatusWarning {
+		t.Fatalf("expected %q on unreachable server fall-through, got %q (message: %s)",
+			StatusWarning, check.Status, check.Message)
+	}
+	if !strings.Contains(check.Fix, "bd bootstrap") {
+		t.Errorf("expected fall-through fix to mention 'bd bootstrap', got: %s", check.Fix)
+	}
+}
+
 func TestCheckFreshClone_EmbeddedMode(t *testing.T) {
 	// AC-005: Embedded mode (not server mode) uses only filesystem checks.
 	// No server connection should be attempted.

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -310,7 +310,13 @@ func CheckFreshClone(repoPath string) DoctorCheck {
 			// the correct port for standalone server mode (ephemeral).
 			port := doltserver.DefaultConfig(beadsDir).Port
 			user := cfg.GetDoltServerUser()
-			password := cfg.GetDoltServerPassword()
+			// Look up the password by the resolved runtime port — cfg.GetDoltServerPassword
+			// uses cfg.GetDoltServerPort() which falls back to the 3307 default when
+			// metadata.json omits the port, causing credentials lookup to miss when
+			// the actual server runs on a different port (e.g. 3306 for
+			// externally-hosted Dolt). That mismatch produced spurious
+			// "Fresh clone detected" warnings (bd-tzo9).
+			password := cfg.GetDoltServerPasswordForPort(port)
 			dbName := cfg.GetDoltDatabase()
 			result := checkFreshCloneDB(host, port, user, password, dbName, cfg.GetDoltServerTLS())
 			if result.Reachable {

--- a/cmd/bd/doctor/perf_dolt.go
+++ b/cmd/bd/doctor/perf_dolt.go
@@ -107,12 +107,16 @@ func runDoltServerDiagnostics(metrics *DoltPerfMetrics, host string, port int, d
 	metrics.ServerMode = true
 
 	// Resolve credentials from config and environment, matching openDoltDB behavior.
+	// GetDoltServerPasswordForPort checks BEADS_DOLT_PASSWORD env first, then
+	// falls back to ~/.config/beads/credentials keyed by [host:port] — required
+	// for externally-hosted Dolt servers (bd-h5k7).
 	user := configfile.DefaultDoltServerUser
-	password := os.Getenv("BEADS_DOLT_PASSWORD")
+	var password string
 	var tls bool
 	if cfg, err := configfile.Load(beadsDir); err == nil && cfg != nil {
 		user = cfg.GetDoltServerUser()
 		tls = cfg.GetDoltServerTLS()
+		password = cfg.GetDoltServerPasswordForPort(port)
 	}
 
 	dsn := doltutil.ServerDSN{

--- a/cmd/bd/doctor/server.go
+++ b/cmd/bd/doctor/server.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 	"time"
 
@@ -292,8 +291,12 @@ func checkDoltVersion(cfg *configfile.Config, beadsDir string) (DoctorCheck, *sq
 	port := doltserver.DefaultConfig(beadsDir).Port
 	user := cfg.GetDoltServerUser()
 
-	// Get password from environment (more secure than config file)
-	password := os.Getenv("BEADS_DOLT_PASSWORD")
+	// Resolve password the same way the CRUD path does: BEADS_DOLT_PASSWORD env
+	// takes precedence (checked inside GetDoltServerPasswordForPort), with a
+	// fallback to ~/.config/beads/credentials keyed by [host:port]. Using the
+	// resolved runtime port is required because the port file may differ from
+	// the metadata port (bd-h5k7).
+	password := cfg.GetDoltServerPasswordForPort(port)
 
 	// Build DSN without database (just to test server connectivity)
 	connStr := doltutil.ServerDSN{

--- a/cmd/bd/doctor/server_test.go
+++ b/cmd/bd/doctor/server_test.go
@@ -2,8 +2,12 @@ package doctor
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
 )
 
 func TestIsValidIdentifier(t *testing.T) {
@@ -159,5 +163,70 @@ func TestCheckDatabaseExists_InvalidIdentifier(t *testing.T) {
 				t.Errorf("isValidIdentifier(%q) = %v, want %v", tt.name, got, tt.valid)
 			}
 		})
+	}
+}
+
+// TestCheckDoltVersion_Unreachable exercises the credential-resolution and
+// DSN-building path in checkDoltVersion with an unreachable server (bd-h5k7).
+// The ping is expected to fail; the important thing is that we take the
+// GetDoltServerPasswordForPort(port) branch without panicking and return a
+// clean StatusError DoctorCheck.
+func TestCheckDoltVersion_Unreachable(t *testing.T) {
+	// Force the resolved port to 1 (guaranteed unreachable on loopback)
+	// so we don't depend on any running server.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "1")
+
+	beadsDir := t.TempDir()
+	cfg := &configfile.Config{
+		DoltMode:       "server",
+		DoltServerHost: "127.0.0.1",
+		DoltServerUser: "root",
+		DoltDatabase:   "beads",
+	}
+
+	check, db := checkDoltVersion(cfg, beadsDir)
+	if db != nil {
+		_ = db.Close()
+		t.Fatal("expected nil db handle on unreachable server")
+	}
+	if check.Status != StatusError {
+		t.Errorf("expected Status %q, got %q (message: %s, detail: %s)",
+			StatusError, check.Status, check.Message, check.Detail)
+	}
+	if check.Name != "Dolt Version" {
+		t.Errorf("expected Name %q, got %q", "Dolt Version", check.Name)
+	}
+}
+
+// TestRunDoltServerDiagnostics_Unreachable exercises the credential-resolution
+// branch in runDoltServerDiagnostics (bd-h5k7). metadata.json is loaded so
+// that user / tls / password are pulled from configfile.Load before the DSN
+// is built and the ping fails against the unreachable port.
+func TestRunDoltServerDiagnostics_Unreachable(t *testing.T) {
+	beadsDir := t.TempDir()
+
+	// Write a minimal metadata.json so configfile.Load returns a non-nil
+	// cfg — that's what gates the user/tls/password assignments.
+	meta := `{
+  "database": "beads.db",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_user": "root",
+  "dolt_database": "beads"
+}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics := &DoltPerfMetrics{}
+	err := runDoltServerDiagnostics(metrics, "127.0.0.1", 1, "beads", beadsDir)
+	if err == nil {
+		t.Fatal("expected error connecting to unreachable server")
+	}
+	if metrics.Backend != "dolt-server" {
+		t.Errorf("expected Backend %q, got %q", "dolt-server", metrics.Backend)
+	}
+	if !metrics.ServerMode {
+		t.Error("expected ServerMode=true")
 	}
 }

--- a/cmd/bd/doctor_health.go
+++ b/cmd/bd/doctor_health.go
@@ -57,6 +57,7 @@ func runCheckHealth(path string) {
 		Host:     host,
 		Port:     port,
 		User:     cfg.GetDoltServerUser(),
+		Password: cfg.GetDoltServerPasswordForPort(port),
 		Database: database,
 		Timeout:  2 * time.Second,
 		TLS:      cfg.GetDoltServerTLS(),

--- a/cmd/bd/doctor_health_smoke_test.go
+++ b/cmd/bd/doctor_health_smoke_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRunCheckHealth_UnreachableServer exercises the DSN-building branch in
+// runCheckHealth (bd-h5k7). With metadata.json pointing at an unreachable
+// port, the code should resolve Password via GetDoltServerPasswordForPort
+// without panicking, fail the ping silently, and return.
+func TestRunCheckHealth_UnreachableServer(t *testing.T) {
+	// Force the resolved port to 1 (guaranteed unreachable) so we don't
+	// depend on any real server.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "1")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{
+  "database": "beads.db",
+  "dolt_mode": "server",
+  "dolt_server_host": "127.0.0.1",
+  "dolt_server_user": "root",
+  "dolt_database": "beads"
+}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not panic. Silent exit on ping failure is the expected path.
+	runCheckHealth(tmpDir)
+}

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -202,6 +202,18 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 	if cfg.ServerUser == "" {
 		cfg.ServerUser = fileCfg.GetDoltServerUser()
 	}
+	// Populate password and TLS the same way the CLI CRUD path does. Without
+	// this, callers that rely on NewFromConfigWithOptions (e.g. doctor's
+	// SharedStore) fail to reach externally-hosted Dolt servers that keep
+	// credentials in ~/.config/beads/credentials, while bd create/list/close
+	// succeed (bd-h5k7). GetDoltServerPasswordForPort checks BEADS_DOLT_PASSWORD
+	// env first, then credentials file keyed by [host:resolved-port].
+	if cfg.ServerPassword == "" {
+		cfg.ServerPassword = fileCfg.GetDoltServerPasswordForPort(cfg.ServerPort)
+	}
+	if !cfg.ServerTLS {
+		cfg.ServerTLS = fileCfg.GetDoltServerTLS()
+	}
 
 	// Pool size: env var > config.yaml > caller override > default (10).
 	// Useful for shared-server setups with many worktrees (GH#3140).


### PR DESCRIPTION
## Summary

`bd doctor` fails against externally-hosted Dolt servers (`dolt_mode=server` with a remote `dolt_server_host`) while `bd create`/`list`/`close` all succeed. The CRUD path in `cmd/bd/main.go` sets `ServerPassword` (via `GetDoltServerPasswordForPort`) and `ServerTLS` explicitly, but the doctor code paths either read `BEADS_DOLT_PASSWORD` env-only or omit the password/TLS entirely. Users whose credentials live in `~/.config/beads/credentials` (the credentials file that `configfile.LookupCredentialsPassword` already supports) see:

- `Database: Unable to open database`
- `Permissions: Unable to verify Dolt server-backed database permissions`
- `Dolt Locks: cannot connect to Dolt: server not reachable: Error 1045 (28000): Access denied for user 'root'`
- `Fresh Clone: Fresh clone detected (N issues in issues.jsonl, no database)` (false positive)

even though normal CRUD commands authenticate against the same server just fine.

## Root cause

`applyResolvedConfig` in `internal/storage/dolt/open.go` populated `Host`/`Port`/`User` from `metadata.json` but never `Password` or `TLS`, so any caller that went through `NewFromConfigWithOptions` (notably doctor's `SharedStore`) got an unauthenticated DSN. Additionally, four doctor connection sites hardcoded `os.Getenv(\"BEADS_DOLT_PASSWORD\")` only, or omitted the password field entirely.

## Changes

- **`internal/storage/dolt/open.go`** — `applyResolvedConfig` now resolves `ServerPassword` via `GetDoltServerPasswordForPort(cfg.ServerPort)` and `ServerTLS` from `fileCfg`, matching the CRUD path in `main.go`. This alone fixes Database / Permissions / Repo Fingerprint / Project Identity checks (they all go through `SharedStore`).
- **`cmd/bd/doctor/dolt.go`, `doctor/server.go`, `doctor/perf_dolt.go`** — use `cfg.GetDoltServerPasswordForPort(port)` instead of reading only `BEADS_DOLT_PASSWORD`. That helper already checks the env var first so behavior is a strict superset. Unused `os` import removed from `dolt.go` and `server.go`.
- **`cmd/bd/doctor_health.go`** — include `Password` in the DSN (it was omitted entirely, so the periodic health check silently couldn't auth).
- **`cmd/bd/doctor/legacy.go`** (`CheckFreshClone`) — look up the password using the resolved runtime port instead of `cfg.GetDoltServerPassword()`, which internally uses `cfg.GetDoltServerPort()` and defaults to 3307 when `metadata.json` omits `dolt_server_port`. Credentials are keyed by `[host:port]`, so the mismatched-port lookup returned empty and produced the spurious \"Fresh clone detected\" warning.

Using `GetDoltServerPasswordForPort(port)` (not `GetDoltServerPassword()`) is important because the resolved runtime port from the port file may differ from the metadata port — same reasoning as the existing comment in `main.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/bd/...`
- [x] `go test ./cmd/bd/doctor/ -count=1`
- [x] `go test ./internal/storage/dolt/ -count=1`
- [x] `go test ./cmd/bd/ -count=1`
- [x] End-to-end repro on a repo connected to an external Dolt server (TLS, password in `~/.config/beads/credentials`): `bd doctor` went from `65 passed / 7 warn / 2 error` to `69 passed / 5 warn / 0 error`, with all remaining warnings reflecting genuine project state (missing fingerprint, uncommitted working tree, etc.), not bugs.


Made with [Cursor](https://cursor.com)