### PR TITLE
fix(dolt): bd dolt status recognizes externally-hosted Dolt servers

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -414,7 +414,10 @@ var doltStatusCmd = &cobra.Command{
 	Short: "Show Dolt server status",
 	Long: `Show the status of the dolt sql-server for the current project.
 
-Displays whether the server is running, its PID, port, and data directory.`,
+For beads-managed (local) servers, displays PID, port, and data directory
+from the local PID file. For externally-hosted servers (dolt_mode=server
+with a remote dolt_server_host), pings the configured endpoint via SQL and
+reports reachability, server version, and database.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if isEmbeddedMode() {
 			fmt.Fprintln(os.Stderr, "Error: 'bd dolt status' is not supported in embedded mode (no Dolt server)")
@@ -424,6 +427,16 @@ Displays whether the server is running, its PID, port, and data directory.`,
 		if beadsDir == "" {
 			FatalErrorWithHint(activeWorkspaceNotFoundError(), diagHint())
 		}
+
+		// For externally-hosted Dolt servers (non-local host with
+		// dolt_mode=server), the local PID file is meaningless — ping the
+		// configured endpoint via SQL instead (bd-q35w).
+		if cfg, cfgErr := configfile.Load(beadsDir); cfgErr == nil && cfg != nil &&
+			cfg.IsDoltServerMode() && !isLocalHost(cfg.GetDoltServerHost()) {
+			runExternalDoltStatus(beadsDir, cfg)
+			return
+		}
+
 		serverDir := doltserver.ResolveServerDir(beadsDir)
 
 		state, err := doltserver.IsRunning(serverDir)
@@ -453,6 +466,101 @@ Displays whether the server is running, its PID, port, and data directory.`,
 			fmt.Println("  Mode: shared server")
 		}
 	},
+}
+
+// isLocalHost reports whether host refers to this machine. Used to
+// distinguish beads-managed local servers from externally-hosted ones.
+func isLocalHost(host string) bool {
+	h := strings.ToLower(strings.TrimSpace(host))
+	if h == "" {
+		return true // empty defaults to local
+	}
+	switch h {
+	case "localhost", "127.0.0.1", "::1", "0.0.0.0":
+		return true
+	}
+	return false
+}
+
+// runExternalDoltStatus queries an externally-hosted Dolt server and prints
+// (or returns, for --json) status. Unlike the local path, there is no PID or
+// log file — reachability, version, host/port/database, and TLS mode are the
+// user-relevant signals.
+func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
+	host := cfg.GetDoltServerHost()
+	port := doltserver.DefaultConfig(beadsDir).Port
+	user := cfg.GetDoltServerUser()
+	database := cfg.GetDoltDatabase()
+	tls := cfg.GetDoltServerTLS()
+	password := cfg.GetDoltServerPasswordForPort(port)
+
+	dsn := doltutil.ServerDSN{
+		Host:     host,
+		Port:     port,
+		User:     user,
+		Password: password,
+		TLS:      tls,
+		Timeout:  5 * time.Second,
+	}.String()
+
+	result := map[string]interface{}{
+		"mode":     "external",
+		"host":     host,
+		"port":     port,
+		"user":     user,
+		"database": database,
+		"tls":      tls,
+	}
+
+	db, openErr := sql.Open("mysql", dsn)
+	var running bool
+	var version string
+	var connErr error
+
+	if openErr == nil {
+		defer db.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if pingErr := db.PingContext(ctx); pingErr != nil {
+			connErr = pingErr
+		} else {
+			running = true
+			// Best-effort version lookup; don't treat errors as fatal.
+			_ = db.QueryRowContext(ctx, "SELECT @@version").Scan(&version)
+		}
+	} else {
+		connErr = openErr
+	}
+
+	result["running"] = running
+	if version != "" {
+		result["version"] = version
+	}
+	if connErr != nil {
+		result["error"] = connErr.Error()
+	}
+
+	if jsonOutput {
+		outputJSON(result)
+		return
+	}
+
+	if running {
+		fmt.Println("Dolt server: running (external)")
+	} else {
+		fmt.Println("Dolt server: not reachable (external)")
+	}
+	fmt.Printf("  Host:     %s\n", host)
+	fmt.Printf("  Port:     %d\n", port)
+	fmt.Printf("  Database: %s\n", database)
+	fmt.Printf("  User:     %s\n", user)
+	fmt.Printf("  TLS:      %t\n", tls)
+	if version != "" {
+		fmt.Printf("  Version:  %s\n", version)
+	}
+	if connErr != nil {
+		fmt.Printf("  Error:    %v\n", connErr)
+	}
 }
 
 var doltKillallCmd = &cobra.Command{

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1094,3 +1094,84 @@ func TestIsLocalHost(t *testing.T) {
 		})
 	}
 }
+
+// TestRunExternalDoltStatus_Unreachable exercises the external-server
+// status path (bd-q35w) against an unreachable port. This covers the DSN
+// build, ping failure branch, and both output modes (text + JSON) without
+// needing a running Dolt server.
+func TestRunExternalDoltStatus_Unreachable(t *testing.T) {
+	// Force the resolved port to 1 (guaranteed unreachable on loopback).
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "1")
+
+	beadsDir := t.TempDir()
+	// Use 127.0.0.1 so the OS RSTs the connect() fast (connection refused)
+	// rather than taking the 5s DSN timeout against a routable-but-silent
+	// host. runExternalDoltStatus does not consult isLocalHost itself.
+	cfg := &configfile.Config{
+		DoltMode:       "server",
+		DoltServerHost: "127.0.0.1",
+		DoltServerUser: "root",
+		DoltDatabase:   "beads_ext",
+		DoltServerTLS:  true,
+	}
+
+	t.Run("text output", func(t *testing.T) {
+		orig := jsonOutput
+		defer func() { jsonOutput = orig }()
+		jsonOutput = false
+
+		out := captureStdout(t, func() error { runExternalDoltStatus(beadsDir, cfg); return nil })
+
+		for _, want := range []string{
+			"not reachable (external)",
+			"Host:",
+			"127.0.0.1",
+			"Database:",
+			"beads_ext",
+			"User:",
+			"root",
+			"TLS:",
+			"true",
+			"Error:",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected output to contain %q, got:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		orig := jsonOutput
+		defer func() { jsonOutput = orig }()
+		jsonOutput = true
+
+		out := captureStdout(t, func() error { runExternalDoltStatus(beadsDir, cfg); return nil })
+
+		var result map[string]any
+		if err := json.Unmarshal([]byte(out), &result); err != nil {
+			t.Fatalf("expected valid JSON output, got error %v, raw: %s", err, out)
+		}
+
+		if result["mode"] != "external" {
+			t.Errorf("mode = %v, want %q", result["mode"], "external")
+		}
+		if result["running"] != false {
+			t.Errorf("running = %v, want false", result["running"])
+		}
+		if result["host"] != "127.0.0.1" {
+			t.Errorf("host = %v, want %q", result["host"], "127.0.0.1")
+		}
+		if result["database"] != "beads_ext" {
+			t.Errorf("database = %v, want %q", result["database"], "beads_ext")
+		}
+		if result["user"] != "root" {
+			t.Errorf("user = %v, want %q", result["user"], "root")
+		}
+		if result["tls"] != true {
+			t.Errorf("tls = %v, want true", result["tls"])
+		}
+		if _, ok := result["error"]; !ok {
+			t.Error("expected 'error' field in JSON output for unreachable server")
+		}
+	})
+}

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1067,3 +1067,30 @@ func TestPrintDivergedHistoryGuidance(t *testing.T) {
 		t.Error("expected guidance to mention manual recovery")
 	}
 }
+
+func TestIsLocalHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{"empty defaults to local", "", true},
+		{"localhost literal", "localhost", true},
+		{"uppercase Localhost", "Localhost", true},
+		{"IPv4 loopback", "127.0.0.1", true},
+		{"IPv6 loopback", "::1", true},
+		{"all-zeros bind", "0.0.0.0", true},
+		{"surrounding whitespace", "  127.0.0.1  ", true},
+		{"public IPv4", "20.150.139.92", false},
+		{"named remote", "dolt.example.com", false},
+		{"private LAN IPv4", "192.168.1.10", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLocalHost(tc.host); got != tc.want {
+				t.Errorf("isLocalHost(%q) = %v, want %v", tc.host, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`bd dolt status` always inspects the local PID/port files written by a beads-managed dolt process. With `dolt_mode=server` pointing at a remote `dolt_server_host` (e.g. Hosted Dolt, a shared team server, an Azure-hosted Dolt instance), it unconditionally reports \"not running\" — even though `bd create`, `bd list`, `bd close`, etc. authenticate and connect to that server just fine.

Before (against an externally-hosted server):
```
$ bd dolt status
Dolt server: not running
  Expected port: 3306
```

After:
```
$ bd dolt status
Dolt server: running (external)
  Host:     20.150.139.92
  Port:     3306
  Database: agentic_workflows
  User:     root
  TLS:      true
  Version:  8.0.31
```

## Changes

When `cfg.IsDoltServerMode()` is true **and** the configured host is not local (`localhost` / `127.0.0.1` / `::1` / `0.0.0.0` / empty), dispatch to a new `runExternalDoltStatus` helper that:

- Pings the configured endpoint via SQL using the same DSN resolution as the CRUD path (host, resolved runtime port, user, password via `GetDoltServerPasswordForPort`, TLS).
- Reports host / port / database / user / TLS and the remote server version from `SELECT @@version`.
- For `--json`, emits a structured object including `mode: \"external\"`, `running` (bool), `version`, and `error` (on failure) so automation can act on it.

The local PID-file path is preserved unchanged for beads-managed and local shared-server setups.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/bd/...`
- [x] Unit test for `isLocalHost` covering empty, localhost (case-insensitive), `127.0.0.1`, `::1`, `0.0.0.0`, whitespace, and several remote hosts.
- [x] `go test ./cmd/bd/ -run Dolt -count=1`
- [x] End-to-end repro against an externally-hosted Dolt server (TLS, credentials in `~/.config/beads/credentials`):
  - `bd dolt status` → \"Dolt server: running (external)\" with host/port/db/user/TLS/version
  - `bd dolt status --json` → `{\"mode\":\"external\",\"running\":true,\"version\":\"8.0.31\",\"host\":\"…\",\"port\":3306,\"database\":\"…\",\"user\":\"root\",\"tls\":true}`


Made with [Cursor](https://cursor.com)