### PR TITLE
fix(schema): repair v0.63→v1.0 upgrades missing issues.started_at (GH#3363)

### DIFF
--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -32,6 +32,7 @@ var compatMigrationsList = []CompatMigration{
 	{"cleanup_autopush_metadata", migrations.MigrateCleanupAutopushMetadata},
 	{"uuid_primary_keys", migrations.MigrateUUIDPrimaryKeys},
 	{"add_no_history_column", migrations.MigrateAddNoHistoryColumn},
+	{"add_started_at_column", migrations.MigrateAddStartedAtColumn},
 	{"drop_hop_columns", migrations.MigrateDropHOPColumns},
 	{"drop_child_counters_fk", migrations.MigrateDropChildCountersFK},
 	{"wisp_events_created_at_index", migrations.MigrateWispEventsCreatedAtIndex},

--- a/internal/storage/dolt/migrations/017_add_started_at_column.go
+++ b/internal/storage/dolt/migrations/017_add_started_at_column.go
@@ -1,0 +1,50 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// MigrateAddStartedAtColumn ensures the started_at column exists on the
+// issues and wisps tables. This is a defensive, idempotent compat migration
+// that repairs databases where the embedded SQL migration 0027 was recorded
+// as applied but its ALTER TABLE issues statement did not actually run.
+//
+// Observed on upgrades from v0.63.x (Go-based migrations, no schema_migrations
+// tracking) to v1.0.x: the backfillMigrations path runs every embedded
+// migration with tolerateExisting=true, swallowing all errors. For the
+// two-statement migration 0027, the ALTER on wisps races with
+// EnsureIgnoredTables (which has already added started_at to the dolt-ignored
+// wisps table) and errors with "duplicate column"; depending on driver
+// multi-statement semantics this could mask the preceding ALTER on issues.
+// The version was recorded regardless, so subsequent `bd list` queries failed
+// with "column started_at could not be found". (GH#3363)
+//
+// Safe to run unconditionally: each ALTER is gated by a SHOW COLUMNS check.
+func MigrateAddStartedAtColumn(db *sql.DB) error {
+	for _, table := range []string{"issues", "wisps"} {
+		tableOK, err := TableExists(db, table)
+		if err != nil {
+			return fmt.Errorf("failed to check %s table existence: %w", table, err)
+		}
+		if !tableOK {
+			// wisps is a dolt-ignored table recreated by EnsureIgnoredTables;
+			// if it's missing here we skip — the ignored-table path owns it.
+			continue
+		}
+
+		exists, err := columnExists(db, table, "started_at")
+		if err != nil {
+			return fmt.Errorf("failed to check started_at column on %s: %w", table, err)
+		}
+		if exists {
+			continue
+		}
+
+		//nolint:gosec // G201: table is from hardcoded list
+		if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN started_at DATETIME", table)); err != nil {
+			return fmt.Errorf("failed to add started_at column to %s: %w", table, err)
+		}
+	}
+	return nil
+}

--- a/internal/storage/dolt/migrations/017_add_started_at_column_test.go
+++ b/internal/storage/dolt/migrations/017_add_started_at_column_test.go
@@ -1,0 +1,48 @@
+package migrations
+
+import (
+	"testing"
+)
+
+// TestMigrateAddStartedAtColumn verifies the compat migration adds
+// started_at to the issues table when missing, and is idempotent on re-run.
+// Regression test for GH#3363.
+func TestMigrateAddStartedAtColumn(t *testing.T) {
+	db := openTestDoltBranch(t)
+
+	// Drop the column if it exists from the test's base schema so we can
+	// observe the migration adding it back.
+	if exists, err := columnExists(db, "issues", "started_at"); err != nil {
+		t.Fatalf("failed to check column: %v", err)
+	} else if exists {
+		if _, err := db.Exec("ALTER TABLE `issues` DROP COLUMN started_at"); err != nil {
+			t.Fatalf("failed to drop started_at for test setup: %v", err)
+		}
+	}
+
+	// Verify precondition
+	exists, err := columnExists(db, "issues", "started_at")
+	if err != nil {
+		t.Fatalf("failed to check column: %v", err)
+	}
+	if exists {
+		t.Fatal("started_at should not exist yet")
+	}
+
+	if err := MigrateAddStartedAtColumn(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	exists, err = columnExists(db, "issues", "started_at")
+	if err != nil {
+		t.Fatalf("failed to check column: %v", err)
+	}
+	if !exists {
+		t.Fatal("started_at should exist on issues after migration")
+	}
+
+	// Idempotent: re-running must succeed even when column already exists.
+	if err := MigrateAddStartedAtColumn(db); err != nil {
+		t.Fatalf("re-running migration should be idempotent: %v", err)
+	}
+}

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -192,13 +192,13 @@ func runMigrations(ctx context.Context, db DBConn, minVersion int, tolerateExist
 			return 0, fmt.Errorf("reading migration %s: %w", mf.name, err)
 		}
 
-		// Both the embedded Dolt driver and the MySQL server driver are
-		// configured with multiStatements=true, so multi-statement .up.sql
-		// files can be executed in a single Exec call.
-		if sqlStr := strings.TrimSpace(string(data)); sqlStr != "" {
-			if _, err := db.ExecContext(ctx, sqlStr); err != nil {
+		// Execute statements individually. Multi-statement Exec can abort the
+		// batch on the first error, which under tolerateExisting silently skips
+		// subsequent DDL while still recording the version as applied (GH#3363).
+		for _, stmt := range splitStatements(string(data)) {
+			if _, err := db.ExecContext(ctx, stmt); err != nil {
 				if !tolerateExisting && !isConcurrentInitError(err) {
-					return 0, fmt.Errorf("migration %s failed: %w", mf.name, err)
+					return 0, fmt.Errorf("migration %s: statement failed: %w", mf.name, err)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes GH #3363 — after upgrading from v0.63.x to v1.0.x, `bd list` fails with:
```
Error 1105: column "started_at" could not be found in any table in scope
```

## Root cause

v0.63.x used Go-based migrations that did not populate `schema_migrations`. v1.0.x `MigrateUp` therefore sees empty `schema_migrations` + existing `issues` table and falls into `backfillMigrations`, which runs every `.up.sql` as a single multi-statement Exec with `tolerateExisting=true`.

Migration `0027_add_started_at.up.sql` bundles two ALTERs:
```sql
ALTER TABLE issues ADD COLUMN started_at DATETIME;
ALTER TABLE wisps  ADD COLUMN started_at DATETIME;
```

`EnsureIgnoredTables` (store.go:1082) runs **before** migrations and has already added `started_at` to the dolt-ignored `wisps` table. The wisps ALTER then errors with "duplicate column". Depending on driver multi-statement semantics, that error can abort the batch before the issues ALTER takes effect. Backfill swallows the error and records version 27 anyway — `schema_migrations` lies about what was applied, and `issues.started_at` is missing.

## Fix — two layers

1. **`internal/storage/schema/schema.go`** — `runMigrations` now splits each `.up.sql` into individual statements and executes them one-by-one. Every statement is attempted regardless of driver batch-abort behavior. Error tolerance is unchanged (fatal on real failures in strict mode; tolerated in backfill).

2. **`internal/storage/dolt/migrations/017_add_started_at_column.go`** — new idempotent Go compat migration (`MigrateAddStartedAtColumn`) registered in `compatMigrationsList`. Runs after the SQL pipeline in `RunCompatMigrations` and repairs databases already broken by the batch-abort race. Uses the existing `columnExists` / `TableExists` helpers.

Fix (1) prevents the bug on future upgrades; fix (2) recovers already-broken installations.

## Test plan

- [x] `go build -tags gms_pure_go ./...`
- [x] `go test -tags gms_pure_go -short ./...` — all green
- [x] New regression test `TestMigrateAddStartedAtColumn` (drop → migrate → idempotent re-run). Passes locally; skips when the Dolt test server isn't available — CI will exercise it.
- [ ] Manual verification on a v0.63.x database upgraded to this build: `bd list` succeeds on first connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)