### PR TITLE
fix: add timeout to dolt auto-push to prevent indefinite hang (#3370)

### DIFF
--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -61,6 +61,14 @@ func savePushState(ps *pushState) error {
 	return atomicWriteFile(path, data)
 }
 
+// Default timeouts for auto-push operations. The push timeout bounds
+// the st.Push() call that shells out to git fetch, which blocks
+// indefinitely when the remote is unreachable (GH#3370).
+const (
+	autoPushTimeout       = 30 * time.Second
+	autoPushRemoteTimeout = 5 * time.Second
+)
+
 // isDoltAutoPushEnabled returns whether auto-push to Dolt remote should run.
 // If user explicitly configured dolt.auto-push, use that.
 // Otherwise, auto-enable when a Dolt remote named "origin" exists.
@@ -68,7 +76,6 @@ func isDoltAutoPushEnabled(ctx context.Context) bool {
 	if config.GetValueSource("dolt.auto-push") != config.SourceDefault {
 		return config.GetBool("dolt.auto-push")
 	}
-	// Auto-enable when a Dolt remote exists
 	st := getStore()
 	if st == nil {
 		return false
@@ -76,7 +83,10 @@ func isDoltAutoPushEnabled(ctx context.Context) bool {
 	if lm, ok := storage.UnwrapStore(st).(storage.LifecycleManager); ok && lm.IsClosed() {
 		return false
 	}
-	has, err := st.HasRemote(ctx, "origin")
+	// Bound the remote check so a hung network doesn't block the CLI (GH#3370).
+	remoteCtx, cancel := context.WithTimeout(ctx, autoPushRemoteTimeout)
+	defer cancel()
+	has, err := st.HasRemote(remoteCtx, "origin")
 	if err != nil {
 		debug.Logf("dolt auto-push: failed to check remote: %v\n", err)
 		return false
@@ -137,11 +147,24 @@ func maybeAutoPush(ctx context.Context) {
 		return
 	}
 
-	// Push
-	debug.Logf("dolt auto-push: pushing to origin...\n")
-	if err := st.Push(ctx); err != nil {
+	// Push with a bounded timeout so an unreachable remote doesn't block
+	// the CLI indefinitely (GH#3370). The timeout is configurable via
+	// dolt.auto-push-timeout (default 30s).
+	pushTimeout := config.GetDuration("dolt.auto-push-timeout")
+	if pushTimeout == 0 {
+		pushTimeout = autoPushTimeout
+	}
+	pushCtx, pushCancel := context.WithTimeout(ctx, pushTimeout)
+	defer pushCancel()
+
+	debug.Logf("dolt auto-push: pushing to origin (timeout %s)...\n", pushTimeout)
+	if err := st.Push(pushCtx); err != nil {
 		if !isQuiet() && !jsonOutput {
-			fmt.Fprintf(os.Stderr, "Warning: dolt auto-push failed: %v\n", err)
+			if pushCtx.Err() == context.DeadlineExceeded {
+				fmt.Fprintf(os.Stderr, "Warning: dolt auto-push timed out after %s (remote may be unreachable)\n", pushTimeout)
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: dolt auto-push failed: %v\n", err)
+			}
 			if isDivergedHistoryErr(err) {
 				printDivergedHistoryGuidance("push")
 			}

--- a/cmd/bd/dolt_autopush_test.go
+++ b/cmd/bd/dolt_autopush_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/config"
 )
@@ -97,6 +98,31 @@ func TestAutoPush_SkippedForReadOnlyCommands(t *testing.T) {
 			t.Errorf("isReadOnlyCommand(%q) = true, want false", cmd)
 		}
 	}
+}
+
+func TestAutoPushTimeoutConstants(t *testing.T) {
+	// Verify timeout defaults are reasonable (GH#3370).
+	if autoPushTimeout < 10*time.Second || autoPushTimeout > 120*time.Second {
+		t.Errorf("autoPushTimeout = %s, want 10s-120s range", autoPushTimeout)
+	}
+	if autoPushRemoteTimeout < 2*time.Second || autoPushRemoteTimeout > 30*time.Second {
+		t.Errorf("autoPushRemoteTimeout = %s, want 2s-30s range", autoPushRemoteTimeout)
+	}
+}
+
+func TestMaybeAutoPush_CancelledContext(t *testing.T) {
+	// maybeAutoPush should handle cancelled context gracefully (GH#3370).
+	t.Setenv("BD_DOLT_AUTO_PUSH", "true")
+
+	config.ResetForTesting()
+	t.Cleanup(func() { config.ResetForTesting() })
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	maybeAutoPush(ctx)
 }
 
 func TestMaybeAutoPush_DisabledByConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #3370 — `dolt auto-push` hangs indefinitely when the remote is unreachable.

- **Root cause**: `st.Push(ctx)` called with unbounded context; underlying `git fetch` blocks forever on network errors
- **Fix**: Wrap push with `context.WithTimeout` (30s default, configurable via `dolt.auto-push-timeout`)
- **Also**: Added 5s timeout to `HasRemote()` check in auto-detection path
- **User-facing**: On timeout, shows `"dolt auto-push timed out after 30s (remote may be unreachable)"` instead of hanging

No data loss risk — local writes have already succeeded before auto-push runs. A timeout simply defers the remote sync.

## Test plan

- [x] `TestAutoPushTimeoutConstants` — verify defaults are in 10s-120s / 2s-30s range
- [x] `TestMaybeAutoPush_CancelledContext` — graceful handling of pre-cancelled context
- [x] All existing auto-push tests pass (explicit config, nil store, disabled, read-only commands)
- [ ] Manual: `bd create` in workspace with unreachable remote exits within ~30s instead of hanging