### PR TITLE
fix: remove duplicate wisp query in bd export (#3352)

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -103,20 +103,13 @@ func runExport(cmd *cobra.Command, args []string) error {
 		filter.IsTemplate = &isTemplate
 	}
 
-	// Fetch all matching issues from the issues table
+	// Fetch all issues (persistent + wisps). SearchIssues with Ephemeral=nil
+	// already queries both the issues and wisps tables with ID-based dedup
+	// (see issueops/search.go). A separate Ephemeral=true query would cause
+	// every wisp to appear twice in the output (GH#3352).
 	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
 		return fmt.Errorf("failed to search issues: %w", err)
-	}
-
-	// Also fetch wisps (ephemeral beads) using the store's ephemeral routing.
-	// SearchIssues with Ephemeral=true queries the wisps table directly.
-	ephemeral := true
-	wispFilter := filter
-	wispFilter.Ephemeral = &ephemeral
-	wispIssues, err := store.SearchIssues(ctx, "", wispFilter)
-	if err == nil && len(wispIssues) > 0 {
-		issues = append(issues, wispIssues...)
 	}
 
 	// Scrub test/pollution records if requested

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -153,19 +153,11 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 	isTemplate := false
 	filter.IsTemplate = &isTemplate
 
-	// Fetch issues
+	// Fetch all issues (persistent + wisps). SearchIssues with Ephemeral=nil
+	// already includes wisps via ID-based dedup (GH#3352).
 	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to search issues: %w", err)
-	}
-
-	// Also fetch wisps
-	ephemeral := true
-	wispFilter := filter
-	wispFilter.Ephemeral = &ephemeral
-	wispIssues, err := store.SearchIssues(ctx, "", wispFilter)
-	if err == nil && len(wispIssues) > 0 {
-		issues = append(issues, wispIssues...)
 	}
 
 	// Bulk-load relational data

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -351,7 +351,7 @@ func hookWorkTreeRoot() string {
 		return ""
 	}
 	var root string
-	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil { // #nosec G304 -- path is GIT_DIR/gitdir, a well-known git internal file
 		if dotGit := strings.TrimSpace(string(data)); dotGit != "" {
 			root = filepath.Dir(dotGit)
 		}

--- a/cmd/bd/export_test.go
+++ b/cmd/bd/export_test.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -533,5 +534,139 @@ func TestExportNoHistoryBeadRoundTrip(t *testing.T) {
 	}
 	if imported.Ephemeral {
 		t.Error("NoHistory bead must not become ephemeral=true after roundtrip")
+	}
+}
+
+func TestExportNoDuplicateWisps(t *testing.T) {
+	// GH#3352: A previous bug caused every wisp to appear twice in the export
+	// because export.go ran a separate Ephemeral=true query and appended the
+	// results, even though SearchIssues(Ephemeral=nil) already includes wisps.
+	// This regression test ensures no duplicate IDs appear in the export and
+	// the wisp count matches what was created.
+	if testDoltServerPort == 0 {
+		t.Skip("Dolt test server not available")
+	}
+	if testutil.DoltContainerCrashed() {
+		t.Skipf("Dolt test server crashed: %v", testutil.DoltContainerCrashError())
+	}
+
+	ensureTestMode(t)
+	saved := saveAndRestoreGlobals(t)
+	_ = saved
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	dbName := uniqueTestDBName(t)
+	testDBPath := filepath.Join(beadsDir, "dolt")
+	writeTestMetadata(t, testDBPath, dbName)
+	s := newTestStore(t, testDBPath)
+	store = s
+	storeMutex.Lock()
+	storeActive = true
+	storeMutex.Unlock()
+	t.Cleanup(func() {
+		store = nil
+		storeMutex.Lock()
+		storeActive = false
+		storeMutex.Unlock()
+	})
+
+	ctx := context.Background()
+	rootCtx = ctx
+
+	// Create regular (persistent) issues.
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("duptest-regular-%d", i)
+		if _, err := s.DB().ExecContext(ctx,
+			`INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			id, fmt.Sprintf("Regular issue %d", i), "", "", "", "", "open", 2, "task"); err != nil {
+			t.Fatalf("insert regular issue %d: %v", i, err)
+		}
+	}
+
+	// Create ephemeral wisps via the store API (routes to wisps table).
+	wispIDs := make(map[string]bool)
+	for i := 1; i <= 3; i++ {
+		wisp := &types.Issue{
+			Title:     fmt.Sprintf("Wisp %d for export dedup", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := s.CreateIssue(ctx, wisp, "test"); err != nil {
+			t.Fatalf("CreateIssue (wisp %d): %v", i, err)
+		}
+		wispIDs[wisp.ID] = true
+	}
+
+	// Export with --all to include everything.
+	exportFile := filepath.Join(tmpDir, "dedup_export.jsonl")
+	exportOutput = exportFile
+	exportAll = true
+	exportIncludeInfra = false
+	exportScrub = false
+	exportNoMemories = true
+	t.Cleanup(func() {
+		exportOutput = ""
+		exportAll = false
+		exportNoMemories = false
+	})
+
+	if err := runExport(nil, nil); err != nil {
+		t.Fatalf("runExport: %v", err)
+	}
+
+	data, err := os.ReadFile(exportFile)
+	if err != nil {
+		t.Fatalf("read export file: %v", err)
+	}
+
+	lines := splitJSONL(data)
+
+	// Parse every line and collect IDs.
+	seenIDs := make(map[string]int)
+	exportedWispCount := 0
+	for _, line := range lines {
+		var rec map[string]interface{}
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("parse exported JSONL: %v", err)
+		}
+		id, ok := rec["id"].(string)
+		if !ok {
+			continue // skip non-issue records (e.g. memories)
+		}
+		seenIDs[id]++
+		if wispIDs[id] {
+			exportedWispCount++
+		}
+	}
+
+	// Assert no duplicate IDs.
+	for id, count := range seenIDs {
+		if count > 1 {
+			t.Errorf("duplicate export entry for ID %q: appeared %d times", id, count)
+		}
+	}
+
+	// Assert all wisps are present exactly once.
+	if exportedWispCount != len(wispIDs) {
+		t.Errorf("expected %d wisps in export, got %d", len(wispIDs), exportedWispCount)
+	}
+
+	// Assert total count = 3 regular + 3 wisps = 6.
+	expectedTotal := 6
+	if len(seenIDs) != expectedTotal {
+		t.Errorf("expected %d unique issues in export, got %d", expectedTotal, len(seenIDs))
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3352 — `bd export` emits each wisp twice in the JSONL output.

**Root cause**: `SearchIssues` with `Ephemeral=nil` already queries both the `issues` and `wisps` tables with ID-based dedup (see `issueops/search.go`). A second query with `Ephemeral=true` followed by `append` duplicated every wisp.

**Fix**: Remove the redundant wisp-specific query from both `export.go` (manual export) and `export_auto.go` (`exportToFile`). The existing `SearchIssues` call with `Ephemeral=nil` continues to include all wisps correctly.

## Test plan

- [ ] `bd export` produces no duplicate JSONL lines for wisps
- [ ] `TestExportImportRoundTrip` passes (existing test)
- [ ] `TestEmbeddedExport` passes (existing test)
- [ ] Wisp count in export matches `bd list --all | grep wisp | wc -l`