### PR TITLE
fix: skip DOLT_COMMIT when compat migrations produce no changes (#3366)

### DIFF
--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -50,6 +50,20 @@ func RunCompatMigrations(db *sql.DB) error {
 		}
 	}
 
+	// Only stage and commit when compat migrations actually produced changes.
+	// Previously, DOLT_COMMIT was called unconditionally, causing a
+	// "nothing to commit" WARNING on the server for every bd invocation
+	// (94% of server log lines in one reported case). GH#3366.
+	var dirtyCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM dolt_status").Scan(&dirtyCount); err != nil {
+		// dolt_status might not be available (e.g. older servers); fall through
+		// to the original behavior as a safe fallback.
+		dirtyCount = 1
+	}
+	if dirtyCount == 0 {
+		return nil
+	}
+
 	// GH#2455: Stage only schema tables (not config) to avoid sweeping up
 	// stale issue_prefix changes from concurrent operations.
 	migrationTables := []string{
@@ -65,7 +79,6 @@ func RunCompatMigrations(db *sql.DB) error {
 	}
 	_, err := db.Exec("CALL DOLT_COMMIT('-m', 'schema: auto-migrate')")
 	if err != nil {
-		// "nothing to commit" is expected when migrations were already applied
 		if !strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
 			log.Printf("dolt compat migration commit warning: %v", err)
 		}


### PR DESCRIPTION
## Summary

Fixes #3366 — `DOLT_COMMIT` called unconditionally on every `bd` command, flooding the dolt server log with "nothing to commit" warnings.

**Root cause**: `RunCompatMigrations()` in `internal/storage/dolt/migrations.go` unconditionally calls `DOLT_ADD` + `DOLT_COMMIT('-m', 'schema: auto-migrate')` on every store open. Since compat migrations are idempotent and typically no-ops, this produces a "nothing to commit" WARNING on the server side for every `bd` invocation — including read-only commands like `bd list` and `bd ready`.

In the reporter's workspace: 103,438 "nothing to commit" warnings out of 110,053 total log lines (94%), at a steady-state rate of ~280/minute.

**Fix**: Check `SELECT COUNT(*) FROM dolt_status` for dirty tables before staging and committing. When no schema tables are dirty (the common case after all migrations have run), skip the `DOLT_ADD`/`DOLT_COMMIT` entirely. Falls back to the original behavior if `dolt_status` is unavailable on older servers.

## Test plan

- [x] Compiles cleanly
- [ ] `bd list` no longer produces "nothing to commit" warning in dolt server log
- [ ] `bd create "test"` still commits schema changes when migrations actually run
- [ ] Existing migration tests pass (`./scripts/test-cgo.sh ./internal/storage/dolt/...`)