### PR TITLE
fix: bd list --parent no longer echoes parent as a result when children are empty (#3349)

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -56,20 +56,24 @@ func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbP
 		return nil, fmt.Errorf("parent issue '%s' not found", parentID)
 	}
 
-	// Use recursive search to find all descendants using the same logic as --parent filter
-	// This works around issues with GetDependencyTree not finding all dependents properly
+	// Use recursive search to find all descendants using the same logic as --parent filter.
+	// The parent itself is NOT included in the result set — only actual children and
+	// their descendants. This matches the behavior of --json and --flat (GH#3349).
 	allDescendants := make(map[string]*types.Issue)
 
-	// Always include the parent
-	allDescendants[parentID] = parentIssue
-
-	// Recursively find all descendants
 	err = findAllDescendants(ctx, store, dbPath, parentID, allDescendants, 0, 10) // max depth 10
 	if err != nil {
 		return nil, fmt.Errorf("error finding descendants: %v", err)
 	}
 
-	// Convert map to slice for display
+	if len(allDescendants) == 0 {
+		return nil, nil
+	}
+
+	// Include the parent as the tree root only when descendants exist,
+	// so the tree renderer can draw the hierarchy with the parent at the top.
+	allDescendants[parentID] = parentIssue
+
 	treeIssues := make([]*types.Issue, 0, len(allDescendants))
 	for _, issue := range allDescendants {
 		treeIssues = append(treeIssues, issue)


### PR DESCRIPTION
## Summary

Fixes #3349 — `bd list --parent <id>` text output echoes the parent itself even when it has no children, disagreeing with `--json` and `--flat`.

**Root cause**: `getHierarchicalChildren()` unconditionally seeded the parent into the result map (`allDescendants[parentID] = parentIssue`) before finding descendants. This made `len(treeIssues) == 0` impossible, preventing the "has no children" message from triggering.

**Fix**: Only include the parent in the tree when actual descendants exist. When no descendants are found, return nil so the caller prints the existing "Issue 'X' has no children" message. This aligns text, JSON, and flat output semantics.

## Before/After

```
# Before: parent echoed even with zero children
$ bd list --parent foo
◐ foo ● P1 Some parent issue
Total: 1 issues

# After: matches --json behavior
$ bd list --parent foo
Issue 'foo' has no children
```

## Test plan

- [x] Compiles cleanly
- [ ] `bd list --parent <id>` with no children shows "has no children" message
- [ ] `bd list --parent <id>` with children still renders tree correctly (parent at root)
- [ ] `--json` and `--flat` behavior unchanged

## Related

Sibling issue #3350 (filters dropped in tree mode) is a separate concern — that requires propagating or post-filtering user flags through the tree traversal, which has design implications for tree rendering when intermediate nodes are filtered out.