### PR TITLE
fix: show (none) placeholder when description is empty in bd show (#3336)

### DIFF
--- a/cmd/bd/show.go
+++ b/cmd/bd/show.go
@@ -204,9 +204,12 @@ var showCmd = &cobra.Command{
 				}
 			}
 
-			// Content sections
+			// Content sections — always show DESCRIPTION header so the user
+			// can distinguish "empty" from "hidden" (GH#3336).
 			if issue.Description != "" {
 				fmt.Printf("\n%s\n%s\n", ui.RenderBold("DESCRIPTION"), ui.RenderMarkdown(issue.Description))
+			} else {
+				fmt.Printf("\n%s\n  %s\n", ui.RenderBold("DESCRIPTION"), ui.RenderMuted("(none)"))
 			}
 			if issue.Design != "" {
 				fmt.Printf("\n%s\n%s\n", ui.RenderBold("DESIGN"), ui.RenderMarkdown(issue.Design))


### PR DESCRIPTION
## Summary

Fixes #3336 (proposal 1) — `bd show` now shows a `DESCRIPTION` section even when the description is empty.

**Problem**: When a bead's description was null/empty, `bd show` printed no DESCRIPTION section at all. Users couldn't distinguish "description is empty" from "tool is hiding the description," leading to confusion and wasted debugging.

**Fix**: Always render the `DESCRIPTION` header. When the body is empty, display `(none)` in muted text.

## Before/After

```
# Before: no DESCRIPTION section at all
$ bd show <id>
TITLE: Some bead
LABELS: ...

# After: clear signal that description is empty
$ bd show <id>
TITLE: Some bead

DESCRIPTION
  (none)

LABELS: ...
```

## Test plan

- [x] Compiles cleanly
- [ ] `bd show <id>` with no description shows `DESCRIPTION\n  (none)`
- [ ] `bd show <id>` with description continues to render normally
- [ ] `bd show <id> --json` unaffected (description already shows null)