### PR TITLE
fix: no-git-ops=true now implies export.git-add=false (#3314)

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -106,9 +106,9 @@ func maybeAutoExport(ctx context.Context) {
 		return
 	}
 
-	// Optional git add — skip silently when not in a git repo (standalone
-	// BEADS_DIR flow) to avoid noisy "exit status 128" warnings on every write.
-	if config.GetBool("export.git-add") && isGitRepo() {
+	// Optional git add — skip when no-git-ops is set (GH#3314), when not in a
+	// git repo (standalone BEADS_DIR flow), or when export.git-add is false.
+	if config.GetBool("export.git-add") && !config.GetBool("no-git-ops") && isGitRepo() {
 		if err := gitAddFile(fullPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export: git add failed: %v\n", err)
 		}

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1091,8 +1091,8 @@ func exportJSONLForCommit() {
 		return
 	}
 
-	// Stage the exported file if configured.
-	if config.GetBool("export.git-add") {
+	// Stage the exported file if configured. Skip when no-git-ops is set (GH#3314).
+	if config.GetBool("export.git-add") && !config.GetBool("no-git-ops") {
 		addCmd := exec.Command("git", "add", fullPath)
 		addCmd.Dir = filepath.Dir(fullPath)
 		if err := addCmd.Run(); err != nil {


### PR DESCRIPTION
## Summary

Fixes #3314 — `no-git-ops=true` now suppresses the auto-export `git add` without requiring a separate `export.git-add=false` config entry.

**Problem**: When `no-git-ops=true` was set, bd still attempted `git add` on the auto-export file after every write, producing `Warning: auto-export: git add failed: exit status 1` on every invocation.

**Fix**: Check `config.GetBool("no-git-ops")` in both git-add paths:
- `export_auto.go`: auto-export after write commands
- `hooks.go`: pre-commit hook export staging

When `no-git-ops` is true, the git add is skipped silently.

## Test plan

- [x] Compiles cleanly
- [ ] With `no-git-ops=true`, no "git add failed" warning on write commands
- [ ] With `no-git-ops=false` and `export.git-add=true`, git add still works
- [ ] `export.git-add=false` still works independently of `no-git-ops`