### PR TITLE
fix: warn on unrecognized config keys in bd config set (#3293)

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -83,6 +83,18 @@ var configSetCmd = &cobra.Command{
 		key := args[0]
 		value := args[1]
 
+		// Warn on unrecognized config keys so typos don't silently become
+		// no-ops. The custom.* namespace is exempt (user-extensible). GH#3293.
+		if !isRecognizedConfigKey(key) {
+			suggestion := suggestConfigKey(key)
+			if suggestion != "" {
+				fmt.Fprintf(os.Stderr, "Warning: %q is not a recognized config key. Did you mean %q?\n", key, suggestion)
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: %q is not a recognized config key. Use 'custom.*' for user-defined keys.\n", key)
+			}
+			fmt.Fprintf(os.Stderr, "Run 'bd config --help' for valid namespaces.\n")
+		}
+
 		// Check if this is a yaml-only key (startup settings like no-db, etc.)
 		// These must be written to config.yaml, not SQLite, because they're read
 		// before the database is opened. (GH#536)
@@ -712,6 +724,89 @@ Examples:
 			}
 		}
 	},
+}
+
+// recognizedConfigPrefixes lists valid top-level config namespaces.
+// Keys under custom.* are always accepted (user-extensible).
+var recognizedConfigPrefixes = []string{
+	"export.", "dolt.", "jira.", "linear.", "github.", "custom.",
+	"status.", "doctor.suppress.", "routing.", "sync.", "git.",
+	"directory.", "repos.", "external_projects.", "validation.",
+	"hierarchy.", "ai.", "backup.", "federation.",
+}
+
+// recognizedConfigKeys lists valid non-namespaced config keys.
+var recognizedConfigKeys = map[string]bool{
+	"no-db": true, "json": true, "db": true, "actor": true,
+	"identity": true, "no-push": true, "no-git-ops": true,
+	"create.require-description": true, "beads.role": true,
+	"auto_compact_enabled":       true, "schema_version": true,
+	"output.title-length":        true,
+}
+
+func isRecognizedConfigKey(key string) bool {
+	if recognizedConfigKeys[key] {
+		return true
+	}
+	for _, prefix := range recognizedConfigPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// suggestConfigKey tries to find a close match for a mistyped key by checking
+// if the key's prefix is a known prefix with a typo. Returns empty string if
+// no suggestion can be made.
+func suggestConfigKey(key string) string {
+	parts := strings.SplitN(key, ".", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	prefix := parts[0] + "."
+
+	bestMatch := ""
+	bestDist := 3 // max edit distance to suggest
+	for _, known := range recognizedConfigPrefixes {
+		knownPrefix := strings.TrimSuffix(known, ".")
+		d := levenshteinDistance(parts[0], knownPrefix)
+		if d > 0 && d < bestDist {
+			bestDist = d
+			bestMatch = known + parts[1]
+		}
+	}
+	_ = prefix
+	return bestMatch
+}
+
+func levenshteinDistance(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, min(prev[j]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
 }
 
 func init() {

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -740,8 +740,8 @@ var recognizedConfigKeys = map[string]bool{
 	"no-db": true, "json": true, "db": true, "actor": true,
 	"identity": true, "no-push": true, "no-git-ops": true,
 	"create.require-description": true, "beads.role": true,
-	"auto_compact_enabled":       true, "schema_version": true,
-	"output.title-length":        true,
+	"auto_compact_enabled": true, "schema_version": true,
+	"output.title-length": true,
 }
 
 func isRecognizedConfigKey(key string) bool {

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func TestIsRecognizedConfigKey(t *testing.T) {
+	recognized := []string{
+		"export.auto", "dolt.auto-push", "jira.url", "custom.anything",
+		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
+		"status.custom", "ai.model", "backup.enabled",
+	}
+	for _, key := range recognized {
+		if !isRecognizedConfigKey(key) {
+			t.Errorf("isRecognizedConfigKey(%q) = false, want true", key)
+		}
+	}
+
+	unrecognized := []string{
+		"totally.bogus", "exprot.auto", "xport.path", "nodb",
+	}
+	for _, key := range unrecognized {
+		if isRecognizedConfigKey(key) {
+			t.Errorf("isRecognizedConfigKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestSuggestConfigKey(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"exprot.auto", "export.auto"},
+		{"exoprt.path", "export.path"},
+		{"totally.bogus", ""},
+	}
+	for _, tt := range tests {
+		got := suggestConfigKey(tt.input)
+		if got != tt.want {
+			t.Errorf("suggestConfigKey(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"abc", "abd", 1},
+		{"export", "exprot", 2},
+		{"dolt", "bolt", 1},
+		{"abc", "", 3},
+	}
+	for _, tt := range tests {
+		got := levenshteinDistance(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("levenshteinDistance(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3293 — `bd config set` now warns when a key doesn't match any known namespace.

**Problem**: Any string was silently accepted as a config key. Typos like `export.auto-export` (correct: `export.auto`) persisted in config.yaml as dead entries with no signal to the user.

**Fix**: Validate keys against known namespaces and standalone keys. On mismatch:
- Warn on stderr (still writes — backwards compatible)
- Suggest closest match via Levenshtein distance
- Point user to `bd config --help`

The `custom.*` namespace remains exempt as documented (user-extensible).

```
$ bd config set exprot.auto false
Warning: "exprot.auto" is not a recognized config key. Did you mean "export.auto"?
Run 'bd config --help' for valid namespaces.
Set exprot.auto = false
```

Chose **option 2** from the issue (warn + write) to preserve backwards compat for scripts that may depend on arbitrary-key acceptance.

## Test plan

- [x] `TestIsRecognizedConfigKey` — validates known/unknown keys
- [x] `TestSuggestConfigKey` — Levenshtein-based suggestions
- [x] `TestLevenshteinDistance` — edit distance correctness
- [ ] Manual: `bd config set totally.bogus foo` shows warning
- [ ] Manual: `bd config set custom.mykey foo` has no warning