### PR TITLE
fix: remove orphan detection from compat migration hot path (#3344)

### DIFF
--- a/internal/storage/dolt/migrations/003_orphan_detection.go
+++ b/internal/storage/dolt/migrations/003_orphan_detection.go
@@ -1,63 +1,17 @@
 package migrations
 
-import (
-	"database/sql"
-	"fmt"
-	"log"
-	"strings"
-)
+import "database/sql"
 
-// DetectOrphanedChildren finds child issues whose parent no longer exists.
-// A child issue has a dotted ID (e.g., "bd-abc.1") where the parent is the
-// part before the last dot ("bd-abc"). An orphan is a child whose parent ID
-// is not present in the issues table.
+// DetectOrphanedChildren was a diagnostic migration that ran a full table scan
+// with a LEFT JOIN on every store open to find child issues whose parent no
+// longer exists. This caused significant CPU load and log noise in workspaces
+// with frequent bd invocations (GH#3344: 107 orphan warnings on every command,
+// full scan at ~90 connections/sec).
 //
-// This migration is non-destructive: it only logs orphans for the user to
-// review. Users can then decide to delete orphans or convert them to
-// top-level issues using 'bd doctor --fix'.
-func DetectOrphanedChildren(db *sql.DB) error {
-	// Find child issues (IDs containing a dot) whose parent doesn't exist.
-	// SUBSTRING_INDEX(id, '.', -1) gives the last segment after the final dot.
-	// Removing that (plus the dot) gives us the parent ID.
-	// We use a LEFT JOIN to find children with no matching parent.
-	query := `
-		SELECT child.id, child.title, child.status
-		FROM issues child
-		LEFT JOIN issues parent
-			ON parent.id = SUBSTRING(child.id, 1, LENGTH(child.id) - LENGTH(SUBSTRING_INDEX(child.id, '.', -1)) - 1)
-		WHERE child.id LIKE '%.%'
-			AND parent.id IS NULL
-		ORDER BY child.id`
-
-	rows, err := db.Query(query)
-	if err != nil {
-		// If the query fails (e.g., older Dolt version), log and continue.
-		// This is a diagnostic migration, not a schema change.
-		log.Printf("orphan detection: query failed (non-fatal): %v", err)
-		return nil
-	}
-	defer rows.Close()
-
-	var orphans []string
-	for rows.Next() {
-		var id, title, status string
-		if err := rows.Scan(&id, &title, &status); err != nil {
-			continue
-		}
-		orphans = append(orphans, fmt.Sprintf("  %s [%s] %s", id, status, title))
-	}
-	if err := rows.Err(); err != nil {
-		log.Printf("orphan detection: row iteration error (non-fatal): %v", err)
-		return nil
-	}
-
-	if len(orphans) == 0 {
-		return nil
-	}
-
-	log.Printf("orphan detection: found %d orphaned child issue(s) whose parent no longer exists:\n%s",
-		len(orphans), strings.Join(orphans, "\n"))
-	log.Printf("orphan detection: run 'bd doctor --deep' to review, or 'bd doctor --fix' to repair")
-
+// Orphan detection now lives exclusively in `bd doctor --deep` and
+// `bd doctor --check=conventions`, where it belongs as an on-demand diagnostic.
+// This migration is retained as a no-op to preserve the compat migration
+// registry ordering.
+func DetectOrphanedChildren(_ *sql.DB) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #3344 — orphan detector no longer runs on every `bd` command.

**Problem**: `DetectOrphanedChildren` (compat migration 003) ran a full `issues LEFT JOIN issues` table scan on every store open — meaning every `bd list`, `bd show`, `bd ready`, etc. In workspaces with ~90 bd connections/sec, this caused:
- 107 orphan warnings logged to stderr per invocation
- Sustained backend CPU from repeated full table scans
- Users trained to ignore stderr, masking real diagnostics

**Fix**: Replace `DetectOrphanedChildren` with a no-op. The migration slot is preserved for registry ordering. Orphan detection already exists in `bd doctor --deep` and `bd doctor --check=conventions` as an on-demand diagnostic.

## Test plan

- [x] Compiles cleanly
- [ ] `bd list` no longer prints orphan detection warnings
- [ ] `bd doctor --deep` still detects orphans
- [ ] `bd doctor --check=conventions` still detects orphans