### PR TITLE
fix: bd config set --db <path> resolves BEADS_DIR for yaml-only keys (#3348)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -748,6 +748,13 @@ var rootCmd = &cobra.Command{
 				// - config subcommands that operate on config.yaml, git config,
 				//   or best-effort diagnostics only (GH#536, bd-934, bd-omc, bd-3rw)
 				if configCommandCanRunWithoutStore(cmd, args) {
+					// When --db is provided, resolve BEADS_DIR so yaml-only
+					// config writes target the correct directory (GH#3348).
+					if dbPath != "" {
+						if beadsDir := resolveCommandBeadsDir(dbPath); beadsDir != "" {
+							prepareSelectedCommandContext(beadsDir, false)
+						}
+					}
 					return
 				}
 


### PR DESCRIPTION
## Summary

Fixes #3348 — `bd config set --db <path>` now works for yaml-only keys (like `dolt.auto-commit`).

**Root cause**: When `config set` is called with a yaml-only key, `configCommandCanRunWithoutStore()` returns early in `PersistentPreRun`, skipping `prepareSelectedCommandContext()`. This means `BEADS_DIR` is never set from the `--db` flag, so `findProjectConfigYaml()` looks for `config.yaml` relative to CWD instead of the `--db` target.

**Fix**: When `--db` is provided and the command can run without a store, resolve the beads dir and call `prepareSelectedCommandContext()` before returning early. This sets `BEADS_DIR` so the yaml config write targets the correct directory.

## Test plan

- [x] Compiles cleanly
- [ ] `bd --db /tmp/project/.beads config set dolt.auto-commit on` writes to `/tmp/project/.beads/config.yaml`
- [ ] `bd config set dolt.auto-commit on` (no --db) continues to work from CWD
- [ ] `bd --db /tmp/project/.beads config get dolt.auto-commit` still works