### PR TITLE
fix(config): default Dolt database name when metadata.json is missing

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -856,8 +856,20 @@ var rootCmd = &cobra.Command{
 			doltCfg.ServerTLS = cfg.GetDoltServerTLS()
 		} else if cfgErr == nil {
 			// Load returned (nil, nil) — no config file found.
-			// Log so silent fallback to default DB is visible.
-			fmt.Fprintf(os.Stderr, "warning: no beads configuration found in %s; database name may default incorrectly\n", beadsDir)
+			// Fall back to the canonical default database name; matches the
+			// behavior of newDoltStoreFromConfig / newReadOnlyStoreFromConfig
+			// (see store_factory.go). Without this, embeddeddolt.New rejects
+			// the empty database name with "database name must not be empty
+			// (caller should default to \"beads\")".
+			fmt.Fprintf(os.Stderr, "warning: no beads configuration found in %s; using default database name %q\n", beadsDir, configfile.DefaultDoltDatabase)
+			doltCfg.Database = configfile.DefaultDoltDatabase
+		}
+		// If config parse failed (cfgErr != nil), still default the database
+		// name so the store-open error is about the real problem (the parse
+		// failure warning already printed) rather than a confusing "database
+		// name must not be empty" downstream.
+		if doltCfg.Database == "" {
+			doltCfg.Database = configfile.DefaultDoltDatabase
 		}
 		doltCfg.SyncRemote = resolveSyncRemote()
 


### PR DESCRIPTION
## Summary

`bd <any-command>` run against a `.beads/` directory that has an `embeddeddolt/` (or `dolt/`) subdir but **no `metadata.json`** fails with:

```
warning: no beads configuration found in .beads; database name may default incorrectly
Error: failed to open database: embeddeddolt: database name must not be empty (caller should default to "beads")
```

The error message literally prescribes the fix — but the caller (`cmd/bd/main.go` PersistentPreRun) never applied it. This PR makes it apply.

## Root cause

`cmd/bd/main.go` line ~857 (the `else if cfgErr == nil` branch of the `configfile.Load` result check) printed a warning but never populated `doltCfg.Database`. `newDoltStore` then passed the empty name to `embeddeddolt.New`, which rejected it.

The sibling factories `newDoltStoreFromConfig` (`cmd/bd/store_factory.go:74`) and `newReadOnlyStoreFromConfig` (`store_factory.go:146`) already apply `configfile.DefaultDoltDatabase` when cfg is nil. That pattern was established by the GH#2988 fix; the PreRun path here was simply missed.

## Fix

One-line semantic change: in the nil-cfg branch, set `doltCfg.Database = configfile.DefaultDoltDatabase`. Also updated the warning text to name the default so it's an informative message rather than an ominous one.

A belt-and-suspenders default is also applied when config loading returned an error (`cfgErr != nil`) — in that case the parse-failure warning has already printed, but `doltCfg.Database` was still empty, leading to the same confusing downstream error. Defaulting there makes the subsequent failure (if any) surface the real problem.

Net diff: `+14 / -2` in `cmd/bd/main.go`, no other files touched.

## Test plan

Reproducer before the fix:

\`\`\`bash
mkdir -p /tmp/bd-repro/.beads/embeddeddolt
cd /tmp/bd-repro
bd info
# warning: no beads configuration found in .beads; database name may default incorrectly
# Error: failed to open database: embeddeddolt: database name must not be empty
#   (caller should default to "beads")
\`\`\`

After the fix:

\`\`\`
warning: no beads configuration found in .beads; using default database name "beads"

Beads Database Information
===========================
Database: /tmp/bd-repro/.beads/embeddeddolt
Mode: direct

Issue Count: 0
\`\`\`

- [x] Repro above succeeds against built binary (branch HEAD)
- [x] Happy path (cwd with real `.beads/metadata.json`) still resolves correctly and reports the existing Dolt DB
- [x] \`go test -tags gms_pure_go -short ./cmd/bd/... ./internal/configfile/... ./internal/storage/embeddeddolt/...\` passes (all green)

## Notes

- Precedent: PR #3379 (`fix: bd config set --db <path> resolves BEADS_DIR for yaml-only keys (#3348)`) shipped a similar small PreRun change (7 lines in main.go, no dedicated test) — treating this fix the same way.
- No regression test added: the PreRun closure isn't directly unit-testable without refactoring the ~40-line block into a helper, and the existing `TestNewDoltStoreFromConfig_NoMetadata` + `TestEmbeddedNew_EmptyDatabaseRejected` already pin the downstream contract that this fix lines up with.