### PR TITLE
fix(autopush): bound auto-push, throttle failed attempts (#3370)

### DIFF
--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -61,6 +61,14 @@ func savePushState(ps *pushState) error {
 	return atomicWriteFile(path, data)
 }
 
+// Default timeouts for auto-push operations. The push timeout bounds
+// the st.Push() call that shells out to git fetch, which blocks
+// indefinitely when the remote is unreachable (GH#3370).
+const (
+	autoPushTimeout       = 30 * time.Second
+	autoPushRemoteTimeout = 5 * time.Second
+)
+
 // isDoltAutoPushEnabled returns whether auto-push to Dolt remote should run.
 // If user explicitly configured dolt.auto-push, use that.
 // Otherwise, auto-enable when a Dolt remote named "origin" exists.
@@ -76,7 +84,10 @@ func isDoltAutoPushEnabled(ctx context.Context) bool {
 	if lm, ok := storage.UnwrapStore(st).(storage.LifecycleManager); ok && lm.IsClosed() {
 		return false
 	}
-	has, err := st.HasRemote(ctx, "origin")
+	// Bound the remote check so a hung network doesn't block the CLI (GH#3370).
+	remoteCtx, cancel := context.WithTimeout(ctx, autoPushRemoteTimeout)
+	defer cancel()
+	has, err := st.HasRemote(remoteCtx, "origin")
 	if err != nil {
 		debug.Logf("dolt auto-push: failed to check remote: %v\n", err)
 		return false
@@ -137,16 +148,40 @@ func maybeAutoPush(ctx context.Context) {
 		return
 	}
 
-	// Push
-	debug.Logf("dolt auto-push: pushing to origin...\n")
-	if err := st.Push(ctx); err != nil {
+	// Push with a bounded timeout so an unreachable remote doesn't block
+	// the CLI indefinitely (GH#3370). The timeout is configurable via
+	// dolt.auto-push-timeout (default 30s).
+	pushTimeout := config.GetDuration("dolt.auto-push-timeout")
+	if pushTimeout == 0 {
+		pushTimeout = autoPushTimeout
+	}
+	pushCtx, pushCancel := context.WithTimeout(ctx, pushTimeout)
+	defer pushCancel()
+
+	debug.Logf("dolt auto-push: pushing to origin (timeout %s)...\n", pushTimeout)
+	if err := st.Push(pushCtx); err != nil {
 		if !isQuiet() && !jsonOutput {
-			fmt.Fprintf(os.Stderr, "Warning: dolt auto-push failed: %v\n", err)
+			if pushCtx.Err() == context.DeadlineExceeded {
+				fmt.Fprintf(os.Stderr, "Warning: dolt auto-push timed out after %s (remote may be unreachable)\n", pushTimeout)
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: dolt auto-push failed: %v\n", err)
+			}
 			if isDivergedHistoryErr(err) {
 				printDivergedHistoryGuidance("push")
 			}
 		}
 		debug.Logf("dolt auto-push: push error: %v\n", err)
+		// Throttle retries after failure so a hanging remote doesn't make every
+		// subsequent bd command pay the push timeout. We record the attempt
+		// timestamp but NOT a new LastCommit, so when the remote recovers the
+		// change-detection check (currentCommit != LastCommit) still triggers.
+		if ps == nil {
+			ps = &pushState{}
+		}
+		ps.LastPush = time.Now().UTC().Format(time.RFC3339)
+		if saveErr := savePushState(ps); saveErr != nil {
+			debug.Logf("dolt auto-push: failed to save push state after error: %v\n", saveErr)
+		}
 		return
 	}
 

--- a/cmd/bd/dolt_autopush_test.go
+++ b/cmd/bd/dolt_autopush_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/config"
 )
@@ -97,6 +98,31 @@ func TestAutoPush_SkippedForReadOnlyCommands(t *testing.T) {
 			t.Errorf("isReadOnlyCommand(%q) = true, want false", cmd)
 		}
 	}
+}
+
+func TestAutoPushTimeoutConstants(t *testing.T) {
+	// Verify timeout defaults are reasonable (GH#3370).
+	if autoPushTimeout < 10*time.Second || autoPushTimeout > 120*time.Second {
+		t.Errorf("autoPushTimeout = %s, want 10s-120s range", autoPushTimeout)
+	}
+	if autoPushRemoteTimeout < 2*time.Second || autoPushRemoteTimeout > 30*time.Second {
+		t.Errorf("autoPushRemoteTimeout = %s, want 2s-30s range", autoPushRemoteTimeout)
+	}
+}
+
+func TestMaybeAutoPush_CancelledContext(t *testing.T) {
+	// maybeAutoPush should handle cancelled context gracefully (GH#3370).
+	t.Setenv("BD_DOLT_AUTO_PUSH", "true")
+
+	config.ResetForTesting()
+	t.Cleanup(func() { config.ResetForTesting() })
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	maybeAutoPush(ctx)
 }
 
 func TestMaybeAutoPush_DisabledByConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Consolidates two independently-developed fixes for GH#3370 (`dolt auto-push` hangs against an unreachable remote) into a single commit, with dual attribution.

- **#3331** (@ckumar1) — adds 30s push timeout + **throttle-on-failure** (persists `LastPush` on push error so subsequent bd commands in the debounce window skip the attempt)
- **#3371** (@kevglynn) — adds 30s push timeout + separate 5s `HasRemote()` bound + named constants + `DeadlineExceeded`-aware error message + 2 tests

Per maintainer triage, kept #3331 as the base (throttle-on-failure is non-trivial to bolt on and is independently valuable), folded #3371's additions on top, and credited both authors via `Co-authored-by:` trailers.

Both authors were notified:
- https://github.com/gastownhall/beads/pull/3331#issuecomment-4285116117
- https://github.com/gastownhall/beads/pull/3371#issuecomment-4285116529

Closes #3331. Supersedes #3371 (already closed).

## Behavior

- `st.Push()` is bounded with `dolt.auto-push-timeout` (configurable, default `autoPushTimeout = 30s`) so an unreachable remote cannot hang bd indefinitely.
- `HasRemote()` (the auto-detection probe in `isDoltAutoPushEnabled`) is bounded separately with `autoPushRemoteTimeout = 5s`.
- On push failure, `LastPush` is persisted but `LastCommit` is **not** updated. Subsequent bd commands inside the 5-minute debounce window skip the push attempt; when the remote recovers, change-detection (`currentCommit != LastCommit`) still fires because `LastCommit` was never bumped.
- On `DeadlineExceeded`, the user-facing warning reads `dolt auto-push timed out after Ns (remote may be unreachable)` instead of the generic `push failed:` message. Divergence guidance still prints when applicable.
- If `ps == nil` at the failure branch (no prior push state), a fresh `pushState` is allocated before writing.

Diffstat: `+66 / -5` across `cmd/bd/dolt_autopush.go` (+40/-5) and `cmd/bd/dolt_autopush_test.go` (+26/0).

## Test plan

- [x] \`go vet -tags gms_pure_go ./cmd/bd/...\` — clean
- [x] \`go build -tags gms_pure_go ./cmd/bd/...\` — clean
- [x] \`go test -tags gms_pure_go -run 'AutoPush|MaybeAutoPush|IsDoltAutoPush|LoadSavePushState|LoadPushState_CorruptJSON' -race ./cmd/bd/\` — pass
- [x] \`go test -tags gms_pure_go -short ./cmd/bd/\` — pass (103s)
- Two new tests from #3371: `TestAutoPushTimeoutConstants` and `TestMaybeAutoPush_CancelledContext`.

## Notes

The named-constant refactor means `config.GetDuration("dolt.auto-push-timeout")` returning 0 falls back to the `autoPushTimeout` const (not a re-inlined literal), matching #3371's design intent.