### PR TITLE
fix: promote gate to built-in type so formula pour works

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -359,7 +359,7 @@ func hookWorkTreeRoot() string {
 		return ""
 	}
 	var root string
-	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil { // #nosec G304 -- path is GIT_DIR/gitdir, a well-known git internal file
 		if dotGit := strings.TrimSpace(string(data)); dotGit != "" {
 			root = filepath.Dir(dotGit)
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -529,6 +529,7 @@ const (
 	TypeDecision  IssueType = "decision"
 	TypeMessage   IssueType = "message"
 	TypeMolecule  IssueType = "molecule"  // Molecule type for swarm coordination (internal use)
+	TypeGate      IssueType = "gate"      // Gate type for async coordination (bd gate, formula gates)
 	TypeSpike     IssueType = "spike"     // Timeboxed investigation to reduce uncertainty
 	TypeStory     IssueType = "story"     // User story describing a feature from the user's perspective
 	TypeMilestone IssueType = "milestone" // Marks completion of a set of related issues (no work itself)
@@ -540,19 +541,22 @@ const (
 // ValidateWithCustom and treated as built-in for hydration trust (GH#1356).
 const TypeEvent IssueType = "event"
 
-// Note: Orchestrator types (molecule, gate, convoy, merge-request, slot, agent, role, rig)
+// Note: Most orchestrator types (convoy, merge-request, slot, agent, role, rig)
 // were removed from beads core. They are now purely custom types with no built-in constants.
-// Use string literals like types.IssueType("molecule") if needed, and configure types.custom.
-// (event was also an orchestrator type but was promoted to a built-in internal type above.)
+// Use string literals like types.IssueType("convoy") if needed, and configure types.custom.
+// molecule, gate, and event were re-promoted to built-in because bd commands rely on them:
+//   - molecule: bd mol pour/wisp/bond (swarm coordination)
+//   - gate: bd gate create/check/resolve, formula gate steps (GH#3213)
+//   - event: set-state audit trail beads (GH#1356)
 // (message was re-promoted to built-in for inter-agent communication — GH#1347.)
 
 // IsValid checks if the issue type is a core work type.
 // Core work types (bug, feature, task, epic, chore, decision, message, spike, story, milestone)
-// and molecule type are built-in. Other types require types.custom configuration.
+// and internal types (molecule, gate) are built-in. Other types require types.custom configuration.
 func (t IssueType) IsValid() bool {
 	switch t {
 	case TypeBug, TypeFeature, TypeTask, TypeEpic, TypeChore, TypeDecision, TypeMessage, TypeMolecule,
-		TypeSpike, TypeStory, TypeMilestone:
+		TypeGate, TypeSpike, TypeStory, TypeMilestone:
 		return true
 	}
 	return false

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -583,9 +583,9 @@ func TestEventTypeValidation(t *testing.T) {
 	if !IssueType("molecule").IsBuiltIn() {
 		t.Error("IssueType(molecule).IsBuiltIn() = false, want true")
 	}
-	// custom types must NOT be treated as built-in
-	if IssueType("gate").IsBuiltIn() {
-		t.Error("IssueType(gate).IsBuiltIn() = true, want false")
+	// gate is now a built-in type (used by bd gate, formula gates — GH#3213)
+	if !IssueType("gate").IsBuiltIn() {
+		t.Error("IssueType(gate).IsBuiltIn() = false, want true")
 	}
 
 	// Normalize must not map event to a core type

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -514,11 +514,12 @@ func TestIssueTypeIsValid(t *testing.T) {
 		{TypeChore, true},
 		{TypeDecision, true},
 		{TypeMessage, true},
-		// Molecule is now a core type (used by swarm create)
+		// Molecule is a core type (used by swarm create)
 		{IssueType("molecule"), true},
-		// Orchestrator types are now custom types (not built-in)
+		// Gate is a core type (used by bd gate, formula gates — GH#3213)
+		{IssueType("gate"), true},
+		// Remaining orchestrator types are custom types (not built-in)
 		{IssueType("merge-request"), false},
-		{IssueType("gate"), false},
 		{IssueType("agent"), false},
 		{IssueType("role"), false},
 		{IssueType("convoy"), false},

--- a/internal/validation/bead_test.go
+++ b/internal/validation/bead_test.go
@@ -219,9 +219,10 @@ func TestParseIssueType(t *testing.T) {
 		{"chore type", "chore", types.TypeChore, false, ""},
 		// Molecule is now a core type (used by swarm create)
 		{"molecule type", "molecule", types.TypeMolecule, false, ""},
-		// Orchestrator types require types.custom configuration (invalid without config)
+		// Gate is a core type (used by bd gate, formula gates — GH#3213)
+		{"gate type", "gate", types.TypeGate, false, ""},
+		// Remaining orchestrator types require types.custom configuration
 		{"merge-request type", "merge-request", types.TypeTask, true, "invalid issue type"},
-		{"gate type", "gate", types.TypeTask, true, "invalid issue type"},
 		{"event type", "event", types.TypeTask, true, "invalid issue type"},
 		{"message type", "message", types.TypeMessage, false, ""},
 


### PR DESCRIPTION
## Summary

- Promotes `gate` from removed orchestrator type to built-in type, matching
  the treatment of `molecule` (re-promoted for swarm coordination) and `event`
  (re-promoted for audit trails)
- Adds `TypeGate` constant to `internal/types/types.go` and includes it in
  `IsValid()` so it passes validation without `types.custom` configuration
- Updates tests in `types_test.go` and `validation/bead_test.go` to expect
  `gate` as valid

## Root Cause

`bd mol pour` creates companion beads of type `gate` when a formula step has a
`gate` field. The validation path calls `IsValid()` which rejects `gate` because
it was removed from built-in types. Meanwhile, `bd gate create/check/resolve`
commands all hardcode `IssueType("gate")`, confirming gate is a first-class
concept in bd.

This is the same class of bug as GH#3030 (fourth missed call site, as noted in
the issue).

## Test plan

- [x] `TestIssueTypeIsValid/gate` passes (was `false`, now `true`)
- [x] `TestParseIssueType/gate_type` passes (was error, now `TypeGate`)
- [x] All existing type validation tests still pass
- [x] `go build` succeeds
- [x] `gofmt` clean

Fixes #3213