### PR TITLE
fix: pass CLI filters through tree mode recursive walk

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -359,7 +359,7 @@ func hookWorkTreeRoot() string {
 		return ""
 	}
 	var root string
-	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil { // #nosec G304 -- path is GIT_DIR/gitdir, a well-known git internal file
 		if dotGit := strings.TrimSpace(string(data)); dotGit != "" {
 			root = filepath.Dir(dotGit)
 		}

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -40,8 +40,9 @@ func withStorage(ctx context.Context, store storage.DoltStorage, dbPath string, 
 	return fmt.Errorf("no storage available")
 }
 
-// getHierarchicalChildren handles the --tree --parent combination logic
-func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string) ([]*types.Issue, error) {
+// getHierarchicalChildren handles the --tree --parent combination logic.
+// baseFilter carries CLI filters (--type, --status, etc.) through the recursive walk.
+func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string, baseFilter types.IssueFilter) ([]*types.Issue, error) {
 	// First verify that the parent issue exists
 	var parentIssue *types.Issue
 	err := withStorage(ctx, store, dbPath, func(s storage.DoltStorage) error {
@@ -61,7 +62,7 @@ func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbP
 	// their descendants. This matches the behavior of --json and --flat (GH#3349).
 	allDescendants := make(map[string]*types.Issue)
 
-	err = findAllDescendants(ctx, store, dbPath, parentID, allDescendants, 0, 10) // max depth 10
+	err = findAllDescendants(ctx, store, dbPath, parentID, baseFilter, allDescendants, 0, 10) // max depth 10
 	if err != nil {
 		return nil, fmt.Errorf("error finding descendants: %v", err)
 	}
@@ -82,18 +83,18 @@ func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbP
 	return treeIssues, nil
 }
 
-// findAllDescendants recursively finds all descendants using parent filtering
-func findAllDescendants(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string, result map[string]*types.Issue, currentDepth, maxDepth int) error {
+// findAllDescendants recursively finds all descendants using parent filtering.
+// baseFilter carries CLI filters (--type, --status, etc.) so the tree respects them.
+func findAllDescendants(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string, baseFilter types.IssueFilter, result map[string]*types.Issue, currentDepth, maxDepth int) error {
 	if currentDepth >= maxDepth {
 		return nil // Prevent infinite recursion
 	}
 
-	// Get direct children using the same filter logic as regular --parent
 	var children []*types.Issue
 	err := withStorage(ctx, store, dbPath, func(s storage.DoltStorage) error {
-		filter := types.IssueFilter{
-			ParentID: &parentID,
-		}
+		filter := baseFilter
+		filter.ParentID = &parentID
+		filter.Limit = 0 // unlimited per level to avoid truncating the tree walk
 		var err error
 		children, err = s.SearchIssues(ctx, "", filter)
 		return err
@@ -102,12 +103,10 @@ func findAllDescendants(ctx context.Context, store storage.DoltStorage, dbPath s
 		return err
 	}
 
-	// Add children and recursively find their descendants
 	for _, child := range children {
 		if _, exists := result[child.ID]; !exists {
 			result[child.ID] = child
-			// Recursively find this child's descendants
-			err = findAllDescendants(ctx, store, dbPath, child.ID, result, currentDepth+1, maxDepth)
+			err = findAllDescendants(ctx, store, dbPath, child.ID, baseFilter, result, currentDepth+1, maxDepth)
 			if err != nil {
 				return err
 			}
@@ -126,7 +125,7 @@ type watchListDependencyStore interface {
 
 func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, parentID string, sortBy string, reverse bool) ([]*types.Issue, error) {
 	if parentID != "" {
-		issues, err := getHierarchicalChildren(ctx, store, "", parentID)
+		issues, err := getHierarchicalChildren(ctx, store, "", parentID, filter)
 		if err != nil {
 			return nil, err
 		}
@@ -872,7 +871,7 @@ var listCmd = &cobra.Command{
 		if prettyFormat && !jsonOutput {
 			// Special handling for --tree --parent combination (hierarchical descendants)
 			if parentID != "" {
-				treeIssues, err := getHierarchicalChildren(ctx, activeStore, "", parentID)
+				treeIssues, err := getHierarchicalChildren(ctx, activeStore, "", parentID, filter)
 				if err != nil {
 					FatalError("%v", err)
 				}

--- a/cmd/bd/list_test.go
+++ b/cmd/bd/list_test.go
@@ -1291,7 +1291,7 @@ func TestHierarchicalChildren(t *testing.T) {
 
 	// Test full hierarchy (should return all 6 issues)
 	t.Run("full_hierarchy", func(t *testing.T) {
-		issues, err := getHierarchicalChildren(ctx, store, "", parent.ID)
+		issues, err := getHierarchicalChildren(ctx, store, "", parent.ID, types.IssueFilter{})
 		if err != nil {
 			t.Fatalf("getHierarchicalChildren failed: %v", err)
 		}
@@ -1302,7 +1302,7 @@ func TestHierarchicalChildren(t *testing.T) {
 
 	// Test child subset (should return child1 + its 2 grandchildren = 3 total)
 	t.Run("child_subset", func(t *testing.T) {
-		issues, err := getHierarchicalChildren(ctx, store, "", child1.ID)
+		issues, err := getHierarchicalChildren(ctx, store, "", child1.ID, types.IssueFilter{})
 		if err != nil {
 			t.Fatalf("getHierarchicalChildren for child1 failed: %v", err)
 		}
@@ -1313,7 +1313,7 @@ func TestHierarchicalChildren(t *testing.T) {
 
 	// Test leaf node (should return only itself)
 	t.Run("leaf_node", func(t *testing.T) {
-		issues, err := getHierarchicalChildren(ctx, store, "", grandchild11.ID)
+		issues, err := getHierarchicalChildren(ctx, store, "", grandchild11.ID, types.IssueFilter{})
 		if err != nil {
 			t.Fatalf("getHierarchicalChildren for leaf failed: %v", err)
 		}
@@ -1324,7 +1324,7 @@ func TestHierarchicalChildren(t *testing.T) {
 
 	// Test error case - non-existent parent
 	t.Run("nonexistent_parent", func(t *testing.T) {
-		_, err := getHierarchicalChildren(ctx, store, "", "nonexistent-id")
+		_, err := getHierarchicalChildren(ctx, store, "", "nonexistent-id", types.IssueFilter{})
 		if err == nil || !strings.Contains(err.Error(), "not found") {
 			t.Error("Expected 'not found' error for nonexistent parent")
 		}


### PR DESCRIPTION
## Summary

- Threads the caller's `IssueFilter` (carrying `--type`, `--status`, `--labels`,
  etc.) through `getHierarchicalChildren` and `findAllDescendants`
- Each recursive level merges `ParentID` into the base filter instead of
  constructing a fresh empty filter
- Sets `Limit=0` per level to avoid truncating intermediate tree results
- Updates `list_test.go` call sites to pass `types.IssueFilter{}`

## Root Cause

`findAllDescendants` constructs `IssueFilter{ParentID: &parentID}` at each level,
discarding all CLI filters. The `--flat` and `--json` code paths already use the
full filter correctly — this was only broken in the pretty-print tree path.

## Test plan

- [x] `TestHierarchicalChildren` updated and compiles (skipped without Dolt server)
- [x] `go build` succeeds
- [x] `gofmt` clean
- [ ] Manual: `bd list --tree --parent <id> --type task` should filter results

Fixes #3350