### PR TITLE
fix: use routed ID resolution in bd comments

### DIFF
--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
-	"github.com/steveyegge/beads/internal/utils"
 )
 
 var commentsCmd = &cobra.Command{
@@ -38,13 +37,24 @@ Examples:
 			FatalErrorRespectJSON("getting comments: %v", err)
 		}
 		ctx := rootCtx
-		fullID, err := utils.ResolvePartialID(ctx, store, issueID)
+
+		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
 		if err != nil {
+			if result != nil {
+				result.Close()
+			}
 			FatalErrorRespectJSON("resolving %s: %v", issueID, err)
 		}
-		issueID = fullID
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue %s not found", issueID)
+		}
+		defer result.Close()
+		issueID = result.ResolvedID
 
-		comments, err := store.GetIssueComments(ctx, issueID)
+		comments, err := result.Store.GetIssueComments(ctx, issueID)
 		if err != nil {
 			FatalErrorRespectJSON("getting comments: %v", err)
 		}
@@ -128,13 +138,23 @@ Examples:
 		}
 		ctx := rootCtx
 
-		fullID, err := utils.ResolvePartialID(ctx, store, issueID)
+		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
 		if err != nil {
+			if result != nil {
+				result.Close()
+			}
 			FatalErrorRespectJSON("resolving %s: %v", issueID, err)
 		}
-		issueID = fullID
+		if result == nil || result.Issue == nil {
+			if result != nil {
+				result.Close()
+			}
+			FatalErrorRespectJSON("issue %s not found", issueID)
+		}
+		defer result.Close()
+		issueID = result.ResolvedID
 
-		comment, err := store.AddIssueComment(ctx, issueID, author, commentText)
+		comment, err := result.Store.AddIssueComment(ctx, issueID, author, commentText)
 		if err != nil {
 			FatalErrorRespectJSON("adding comment: %v", err)
 		}

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -359,7 +359,7 @@ func hookWorkTreeRoot() string {
 		return ""
 	}
 	var root string
-	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil { // #nosec G304 -- path is GIT_DIR/gitdir, a well-known git internal file
 		if dotGit := strings.TrimSpace(string(data)); dotGit != "" {
 			root = filepath.Dir(dotGit)
 		}


### PR DESCRIPTION
## Summary

- Replaces `utils.ResolvePartialID` (local-only) with
  `resolveAndGetIssueWithRouting` in both `bd comments` (list) and
  `bd comments add` code paths
- Uses `result.Store` for `GetIssueComments` and `AddIssueComment`
  so operations target the correct (possibly routed) database
- Matches the pattern already used by `bd comment`, `bd show`, and `bd update`

## Root Cause

`bd comments` and `bd comments add` resolve the issue ID with
`utils.ResolvePartialID(ctx, store, issueID)` on the local store only.
When an issue lives in a routed database (via `routes.jsonl` or contributor
auto-routing), the local resolution fails with "no issue found" even though
`bd show` and `bd update` resolve the same ID successfully.

The newer `bd comment` command (added later) already uses the correct
`resolveAndGetIssueWithRouting` path.

## Test plan

- [x] `go build` succeeds
- [x] `gofmt` clean
- [x] No lint errors
- [ ] Manual: `bd comments add <routed-id> "text"` should succeed

Fixes #3334