### PR TITLE
ci: don't fail workflows when codecov upload has no token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: matrix.coverage && !cancelled()
         uses: codecov/codecov-action@v6
+        continue-on-error: true
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -136,6 +137,7 @@ jobs:
       - name: Upload test results to Codecov
         if: matrix.coverage && !cancelled()
         uses: codecov/codecov-action@v6
+        continue-on-error: true
         with:
           files: junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v6
         if: success()
+        continue-on-error: true
         with:
           file: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
## Problem

Every external-contributor (forked-PR) run shows `Test (ubuntu-latest)` red even though the actual `go test` step succeeds. The failure comes from the `codecov/codecov-action@v6` upload steps: forked-PR runs don't have access to `CODECOV_TOKEN`, so the action prints `Token length: 0` and its internal CLI exits non-zero. Despite `fail_ci_if_error: false`, the action surfaces that exit code to the job.

Confirmed red on every recent external-contributor PR:

- #3300 (taheris)
- #3214 (pstradowski) — merged anyway
- #3255 (harry-miller) — merged anyway  
- #3197 (sjsyrek)

Each logged `Token length: 0` in the Upload coverage / Upload test results steps; the go test step before them passed.

## Fix

Add `continue-on-error: true` at the step level on all three codecov upload steps:

- `ci.yml` → Upload coverage to Codecov
- `ci.yml` → Upload test results to Codecov  
- `nightly.yml` → Upload coverage

This forces the step to be treated as successful at the GitHub Actions level regardless of what the action's internal wrapper does — belt-and-suspenders over `fail_ci_if_error: false`.

Nothing about coverage collection changes for non-forked runs (where the token is available); those still upload normally. The only behavior change: a missing token no longer fails the job.

## Scope

Workflow-only. No Go code, no test changes. 3 lines added across 2 files.

## Test plan

- [ ] After merge, verify the next external-contributor PR run shows `Test (ubuntu-latest)` green even with codecov upload failing.
- [ ] Internal PRs (where `CODECOV_TOKEN` is available) continue to upload normally.