### PR TITLE
fix(dolt): update shared-server credential tests for new per-remote signatures

### DIFF
--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -442,7 +442,7 @@ func TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 		remote:         "origin",
 	}
 
-	if !store.shouldUseCLIForCredentials(context.Background()) {
+	if !store.shouldUseCLIForCredentials(context.Background(), store.remote, store.mainRemoteCredentials()) {
 		t.Fatalf("expected shared-server credential routing to resolve CLI remote via %q, got CLIDir %q", cliDir, store.CLIDir())
 	}
 }
@@ -469,7 +469,7 @@ func TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 		t.Fatalf("dolt init failed: %s: %v", out, err)
 	}
 
-	cmd = exec.Command("dolt", "remote", "add", "origin", "https://example.com/repo")
+	cmd = exec.Command("dolt", "remote", "add", "origin", "az://account.blob.core.windows.net/container")
 	cmd.Dir = cliDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("dolt remote add failed: %s: %v", out, err)
@@ -483,7 +483,7 @@ func TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 		remote:     "origin",
 	}
 
-	if !store.shouldUseCLIForCloudAuth() {
+	if !store.shouldUseCLIForCloudAuth(store.remote) {
 		t.Fatalf("expected shared-server cloud-auth routing to resolve CLI remote via %q, got CLIDir %q", cliDir, store.CLIDir())
 	}
 }


### PR DESCRIPTION
## Summary

Restores \`go build ./...\` on \`upstream/main\`. Two tests added by #3223 were not updated when #3211 widened the credential-routing guards to take per-remote parameters. The signature drift landed on main and broke the Test (ubuntu-latest) and Test (macos-latest) CI jobs on every PR that rebases past the merge.

Failure on current main:

\`\`\`
internal/storage/dolt/credentials_test.go:445:39: not enough arguments in call to store.shouldUseCLIForCredentials
internal/storage/dolt/credentials_test.go:486:6: not enough arguments in call to store.shouldUseCLIForCloudAuth
\`\`\`

## Root cause

- **#3223** (\`f9ec9859\`, 2026-04-13) added \`TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot\` and \`TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot\` with the then-current signatures (1-arg and 0-arg).
- **#3211** (\`73d72ec0\`, 2026-04-20) widened the guards to \`shouldUseCLIForCredentials(ctx, remote, creds)\` and \`shouldUseCLIForCloudAuth(remote)\` and updated every *other* call site in \`credentials_test.go\`, but missed the two tests added by #3223 (parallel branches, no rebase before merge).

\`f9ec9859..73d72ec0\` has no ancestry path → the two commits were developed independently; the signature update in #3211 never saw the new shared-server tests.

## Fix

Three-line change in \`internal/storage/dolt/credentials_test.go\`:

1. \`TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot\`: pass \`store.remote\` and \`store.mainRemoteCredentials()\` to match the new signature. Same pattern as the sibling \`TestCredentialCLIRoutingExternalServer\` / \`TestCredentialCLIRoutingNoRemote\` tests that #3211 already updated (lines 386, 403).
2. \`TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot\`: pass \`store.remote\` to match the new signature.
3. Same test: change the dolt remote URL from \`https://example.com/repo\` to \`az://account.blob.core.windows.net/container\`. #3211 also replaced the old global \"any cloud env var + shared-server → CLI routing\" heuristic with **per-scheme matching** — \`AZURE_STORAGE_*\` env vars only trigger CLI routing for \`az://\` remotes. The test sets \`AZURE_STORAGE_ACCOUNT\`, so the remote must be \`az://\` for the positive assertion to hold. This mirrors the positive-case entries in \`TestCloudAuthCLIRouting\` (line 543, etc.).

Diffstat: \`+3 / -3\` in a single file.

## Test plan

- [x] \`go vet ./internal/storage/dolt/...\` — clean
- [x] \`go test -tags gms_pure_go -run 'TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot|TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot' ./internal/storage/dolt/\` — pass
- [x] \`go test -tags gms_pure_go -run 'TestCredential|TestCloudAuth|TestFederationCredential|TestEnv' ./internal/storage/dolt/\` — pass (full credentials suite)

## Related

Blocks: any PR that rebases past 73d72ec0 and runs the non-embedded test matrix. I hit this on #3381 but it affects everyone.

Unrelated but adjacent: `Lint` is also red on main due to a \`gosec G122\` toolchain bump flagging pre-existing code in \`internal/storage/embeddeddolt/cache_cleanup.go\`. Separate fix.