### PR TITLE
fix(ci): unblock main — gosec G122 + credentials_test signatures

### DIFF
--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -442,7 +442,7 @@ func TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 		remote:         "origin",
 	}
 
-	if !store.shouldUseCLIForCredentials(context.Background()) {
+	if !store.shouldUseCLIForCredentials(context.Background(), store.remote, store.mainRemoteCredentials()) {
 		t.Fatalf("expected shared-server credential routing to resolve CLI remote via %q, got CLIDir %q", cliDir, store.CLIDir())
 	}
 }
@@ -469,7 +469,7 @@ func TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 		t.Fatalf("dolt init failed: %s: %v", out, err)
 	}
 
-	cmd = exec.Command("dolt", "remote", "add", "origin", "https://example.com/repo")
+	cmd = exec.Command("dolt", "remote", "add", "origin", "az://account.blob.core.windows.net/container")
 	cmd.Dir = cliDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("dolt remote add failed: %s: %v", out, err)
@@ -483,7 +483,7 @@ func TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 		remote:     "origin",
 	}
 
-	if !store.shouldUseCLIForCloudAuth() {
+	if !store.shouldUseCLIForCloudAuth(store.remote) {
 		t.Fatalf("expected shared-server cloud-auth routing to resolve CLI remote via %q, got CLIDir %q", cliDir, store.CLIDir())
 	}
 }

--- a/internal/storage/embeddeddolt/cache_cleanup.go
+++ b/internal/storage/embeddeddolt/cache_cleanup.go
@@ -51,6 +51,11 @@ func (s *EmbeddedDoltStore) cleanGitRemoteCacheGarbage() {
 			return nil
 		}
 		if info.ModTime().Before(cutoff) {
+			// #nosec G122 -- path is under .dolt/git-remote-cache/ which is
+			// owned by the user running bd. A TOCTOU symlink swap would
+			// require write access to that directory; in that case the
+			// attacker already controls the Dolt data. The tmp_pack_/tmp_idx_
+			// prefix check further narrows the scope to files Dolt itself writes.
 			_ = os.Remove(path)
 		}
 		return nil


### PR DESCRIPTION
`upstream/main` is currently red on two unrelated issues blocking every open PR's CI:

1. **Lint: gosec G122** — `internal/storage/embeddeddolt/cache_cleanup.go:54` — `os.Remove(path)` inside a `filepath.WalkDir` callback trips the new race-prone-path check. Fixed by adding `// #nosec G122` with a one-line rationale (this is an intentional best-effort cleanup of a directory we own).

2. **Build: `internal/storage/dolt`** — `credentials_test.go` two call sites still use the old `shouldUseCLIForCredentials(ctx)` / `shouldUseCLIForCloudAuth()` signatures after the per-remote refactor. Updated to match the current `(ctx, remote, mainRemoteCredentials)` and `(remote)` signatures. Also updated the cloud-auth test to use an `az://` URL so the routing path under test is actually exercised.

Together these two small surgical fixes turn main back green and unblock (at minimum) PRs #3368, #3380, #3381, #3387 which are all tripping one or both of these.

Folds in the fix from #3387 (now closeable).

## Test plan

- [x] Local `golangci-lint run --build-tags=gms_pure_go ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/storage/dolt/...` compiles and passes (integration tests skip without a Dolt server, as expected)