### PR TITLE
fix(npm): create flat macOS archives to fix postinstall path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
             mkdir -p "$staging"
             cp "bd-darwin-${arch}" "$staging/bd"
             cp LICENSE README.md CHANGELOG.md "$staging/"
-            tar -czf "${staging}.tar.gz" "$staging"
+            tar -czf "${staging}.tar.gz" -C "$staging" .
             shasum -a 256 "${staging}.tar.gz" >> darwin-checksums.txt
           done
 


### PR DESCRIPTION
## Summary

PR #2971 (`d326a27b`) moved macOS builds to a dedicated CI job that manually packages tar archives. Unlike goreleaser (which produces flat archives for Linux), the manual packaging ran `tar -czf archive.tar.gz dir/`, wrapping contents in a subdirectory (e.g. `beads_1.0.2_darwin_arm64/bd`). The npm postinstall script expects the `bd` binary at the archive root, so macOS installs via pnpm/npm fail with "Binary not found after extraction".

Fix by using `tar -czf ... -C "$staging" .` to produce flat archives matching goreleaser's format.

## Verification

- Confirmed v1.0.2 macOS archive contains a wrapping directory (`beads_1.0.2_darwin_arm64/bd`) while v0.63.3 and Linux v1.0.2 are flat (`bd` at root)
- Verified locally that `tar -czf out.tar.gz -C staging .` produces a flat archive

Fixes https://github.com/gastownhall/beads/issues/3388

🤖 Generated with [Claude Code](https://claude.com/claude-code)