### PR TITLE
feat: BD_JSON_ENVELOPE=1 opt-in for uniform JSON wrapping

### DIFF
--- a/cmd/bd/errors.go
+++ b/cmd/bd/errors.go
@@ -38,35 +38,38 @@ func workspaceDiagHint(includeWhere bool) string {
 	return "check BEADS_DIR/worktree setup, run 'bd doctor' to diagnose, or run 'bd init' to create a new database"
 }
 
-// jsonStderrError writes a structured JSON error to stderr when --json is active.
-// All JSON errors include schema_version for consumer compatibility.
-func jsonStderrError(message, hint string) {
-	obj := map[string]interface{}{
-		"schema_version": JSONSchemaVersion,
-		"error":          message,
+// buildJSONError constructs a JSON error object respecting envelope mode.
+func buildJSONError(message, hint string) interface{} {
+	inner := map[string]interface{}{
+		"error": message,
 	}
 	if hint != "" {
-		obj["hint"] = hint
+		inner["hint"] = hint
 	}
+	if jsonEnvelopeEnabled() {
+		return map[string]interface{}{
+			"schema_version": JSONSchemaVersion,
+			"data":           inner,
+		}
+	}
+	inner["schema_version"] = JSONSchemaVersion
+	return inner
+}
+
+// jsonStderrError writes a structured JSON error to stderr when --json is active.
+func jsonStderrError(message, hint string) {
 	encoder := json.NewEncoder(os.Stderr)
 	encoder.SetIndent("", "  ")
-	_ = encoder.Encode(obj)
+	_ = encoder.Encode(buildJSONError(message, hint))
 }
 
 // jsonStdoutError writes a structured JSON error to stdout when --json is active.
 // Used by FatalErrorRespectJSON and FatalErrorWithHintRespectJSON where
 // callers expect errors on stdout (e.g., bd show nonexistent-id --json).
 func jsonStdoutError(message, hint string) {
-	obj := map[string]interface{}{
-		"schema_version": JSONSchemaVersion,
-		"error":          message,
-	}
-	if hint != "" {
-		obj["hint"] = hint
-	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
-	_ = encoder.Encode(obj)
+	_ = encoder.Encode(buildJSONError(message, hint))
 }
 
 // FatalError writes an error message to stderr and exits with code 1.

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -359,7 +359,7 @@ func hookWorkTreeRoot() string {
 		return ""
 	}
 	var root string
-	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil { // #nosec G304 -- path is GIT_DIR/gitdir, a well-known git internal file
 		if dotGit := strings.TrimSpace(string(data)); dotGit != "" {
 			root = filepath.Dir(dotGit)
 		}

--- a/cmd/bd/output.go
+++ b/cmd/bd/output.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+
+	"github.com/steveyegge/beads/internal/ui"
 )
 
 // JSONSchemaVersion is the current version of the bd JSON output schema.
@@ -97,7 +99,7 @@ var envelopeDeprecationEmitted bool
 // emitEnvelopeDeprecation prints a one-time deprecation notice to stderr
 // when --json output is used without BD_JSON_ENVELOPE=1.
 func emitEnvelopeDeprecation() {
-	if envelopeDeprecationEmitted {
+	if envelopeDeprecationEmitted || !ui.IsStderrTerminal() {
 		return
 	}
 	envelopeDeprecationEmitted = true

--- a/cmd/bd/output.go
+++ b/cmd/bd/output.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"reflect"
 )
@@ -11,18 +12,31 @@ import (
 // fields are added, renamed, or removed from any --json output.
 const JSONSchemaVersion = 1
 
+// jsonEnvelopeEnabled returns true when BD_JSON_ENVELOPE=1 is set,
+// opting into the uniform {"schema_version": N, "data": <payload>}
+// envelope for all --json output. This will become the default in v2.0.
+func jsonEnvelopeEnabled() bool {
+	return os.Getenv("BD_JSON_ENVELOPE") == "1"
+}
+
 // outputJSON outputs data as pretty-printed JSON to stdout.
 //
-// Object input: schema_version is injected as a top-level field so consumers
-// (Jawnt MCP, BeadsX, gt mail, sync scripts) can detect format changes.
-// Array/slice input: output as-is (no envelope wrapping) to preserve
-// backwards compatibility with existing consumers that parse raw arrays.
+// When BD_JSON_ENVELOPE=1: all output is wrapped uniformly as
+// {"schema_version": N, "data": <original>}. The original payload
+// is untouched inside .data — no type corruption, no injection.
+//
+// Legacy mode (default): objects get schema_version injected as a
+// top-level field; arrays pass through unchanged.
 func outputJSON(v interface{}) {
 	wrapped := wrapWithSchemaVersion(v)
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(wrapped); err != nil {
 		FatalError("encoding JSON: %v", err)
+	}
+
+	if !jsonEnvelopeEnabled() {
+		emitEnvelopeDeprecation()
 	}
 }
 
@@ -36,10 +50,23 @@ func outputJSONRaw(v interface{}) {
 	}
 }
 
-// wrapWithSchemaVersion adds schema_version to object output. Arrays
-// and slices are returned unchanged to preserve backwards compatibility
-// with existing consumers that parse raw JSON arrays.
+// wrapWithSchemaVersion wraps output with schema_version metadata.
+//
+// Envelope mode (BD_JSON_ENVELOPE=1): all output wrapped uniformly as
+// {"schema_version": N, "data": <original>}. Type-safe for all payload
+// types including map[string]string and slices.
+//
+// Legacy mode: objects get schema_version injected inline; arrays and
+// slices pass through unchanged for backwards compatibility.
 func wrapWithSchemaVersion(v interface{}) interface{} {
+	if jsonEnvelopeEnabled() {
+		return map[string]interface{}{
+			"schema_version": JSONSchemaVersion,
+			"data":           v,
+		}
+	}
+
+	// Legacy mode: inline injection for objects, passthrough for arrays.
 	if v == nil {
 		return map[string]interface{}{"schema_version": JSONSchemaVersion}
 	}
@@ -49,12 +76,10 @@ func wrapWithSchemaVersion(v interface{}) interface{} {
 		rv = rv.Elem()
 	}
 
-	// Arrays/slices: return as-is (no envelope) for backwards compat.
 	if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
 		return v
 	}
 
-	// Objects: inject schema_version as a top-level field.
 	data, err := json.Marshal(v)
 	if err != nil {
 		return v
@@ -67,14 +92,38 @@ func wrapWithSchemaVersion(v interface{}) interface{} {
 	return m
 }
 
+var envelopeDeprecationEmitted bool
+
+// emitEnvelopeDeprecation prints a one-time deprecation notice to stderr
+// when --json output is used without BD_JSON_ENVELOPE=1.
+func emitEnvelopeDeprecation() {
+	if envelopeDeprecationEmitted {
+		return
+	}
+	envelopeDeprecationEmitted = true
+	fmt.Fprintf(os.Stderr,
+		"NOTE: bd --json output format will change in v2.0. "+
+			"Set BD_JSON_ENVELOPE=1 to opt in early. "+
+			"See docs/JSON_SCHEMA.md for migration details.\n")
+}
+
 // outputJSONError outputs an error as JSON to stderr and exits with code 1.
 func outputJSONError(err error, code string) {
-	errObj := map[string]interface{}{
-		"error":          err.Error(),
-		"schema_version": JSONSchemaVersion,
+	var errObj interface{}
+	base := map[string]interface{}{
+		"error": err.Error(),
 	}
 	if code != "" {
-		errObj["code"] = code
+		base["code"] = code
+	}
+	if jsonEnvelopeEnabled() {
+		errObj = map[string]interface{}{
+			"schema_version": JSONSchemaVersion,
+			"data":           base,
+		}
+	} else {
+		base["schema_version"] = JSONSchemaVersion
+		errObj = base
 	}
 	encoder := json.NewEncoder(os.Stderr)
 	encoder.SetIndent("", "  ")

--- a/cmd/bd/output_test.go
+++ b/cmd/bd/output_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestWrapWithSchemaVersion_Object(t *testing.T) {
+func TestWrapWithSchemaVersion_Legacy_Object(t *testing.T) {
 	input := map[string]string{"id": "beads-123", "title": "Test"}
 	result := wrapWithSchemaVersion(input)
 
@@ -21,31 +21,10 @@ func TestWrapWithSchemaVersion_Object(t *testing.T) {
 	}
 }
 
-func TestWrapWithSchemaVersion_Struct(t *testing.T) {
-	type issue struct {
-		ID    string `json:"id"`
-		Title string `json:"title"`
-	}
-	input := &issue{ID: "beads-456", Title: "Struct test"}
-	result := wrapWithSchemaVersion(input)
-
-	m, ok := result.(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected map[string]interface{}, got %T", result)
-	}
-	if m["schema_version"] != JSONSchemaVersion {
-		t.Errorf("schema_version = %v, want %d", m["schema_version"], JSONSchemaVersion)
-	}
-	if m["id"] != "beads-456" {
-		t.Errorf("id = %v, want beads-456", m["id"])
-	}
-}
-
-func TestWrapWithSchemaVersion_Slice(t *testing.T) {
+func TestWrapWithSchemaVersion_Legacy_Slice(t *testing.T) {
 	input := []string{"a", "b", "c"}
 	result := wrapWithSchemaVersion(input)
 
-	// Arrays pass through unchanged for backwards compatibility.
 	arr, ok := result.([]string)
 	if !ok {
 		t.Fatalf("expected []string (passthrough), got %T", result)
@@ -55,7 +34,7 @@ func TestWrapWithSchemaVersion_Slice(t *testing.T) {
 	}
 }
 
-func TestWrapWithSchemaVersion_Nil(t *testing.T) {
+func TestWrapWithSchemaVersion_Legacy_Nil(t *testing.T) {
 	result := wrapWithSchemaVersion(nil)
 	m, ok := result.(map[string]interface{})
 	if !ok {
@@ -66,7 +45,77 @@ func TestWrapWithSchemaVersion_Nil(t *testing.T) {
 	}
 }
 
-func TestWrapWithSchemaVersion_RoundTrip(t *testing.T) {
+func TestWrapWithSchemaVersion_Envelope_Object(t *testing.T) {
+	t.Setenv("BD_JSON_ENVELOPE", "1")
+
+	input := map[string]string{"id": "beads-123", "title": "Test"}
+	result := wrapWithSchemaVersion(input)
+
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map[string]interface{}, got %T", result)
+	}
+	if m["schema_version"] != JSONSchemaVersion {
+		t.Errorf("schema_version = %v, want %d", m["schema_version"], JSONSchemaVersion)
+	}
+	data, ok := m["data"]
+	if !ok {
+		t.Fatal("missing 'data' key in envelope")
+	}
+	inner, ok := data.(map[string]string)
+	if !ok {
+		t.Fatalf("data type = %T, want map[string]string", data)
+	}
+	if inner["id"] != "beads-123" {
+		t.Errorf("data.id = %v, want beads-123", inner["id"])
+	}
+}
+
+func TestWrapWithSchemaVersion_Envelope_Slice(t *testing.T) {
+	t.Setenv("BD_JSON_ENVELOPE", "1")
+
+	input := []string{"a", "b", "c"}
+	result := wrapWithSchemaVersion(input)
+
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected envelope map, got %T", result)
+	}
+	if m["schema_version"] != JSONSchemaVersion {
+		t.Errorf("schema_version = %v, want %d", m["schema_version"], JSONSchemaVersion)
+	}
+	data, ok := m["data"]
+	if !ok {
+		t.Fatal("missing 'data' key in envelope")
+	}
+	arr, ok := data.([]string)
+	if !ok {
+		t.Fatalf("data type = %T, want []string", data)
+	}
+	if len(arr) != 3 {
+		t.Errorf("data length = %d, want 3", len(arr))
+	}
+}
+
+func TestWrapWithSchemaVersion_Envelope_Nil(t *testing.T) {
+	t.Setenv("BD_JSON_ENVELOPE", "1")
+
+	result := wrapWithSchemaVersion(nil)
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected envelope map, got %T", result)
+	}
+	if m["schema_version"] != JSONSchemaVersion {
+		t.Errorf("schema_version = %v, want %d", m["schema_version"], JSONSchemaVersion)
+	}
+	if m["data"] != nil {
+		t.Errorf("data = %v, want nil", m["data"])
+	}
+}
+
+func TestWrapWithSchemaVersion_Envelope_RoundTrip(t *testing.T) {
+	t.Setenv("BD_JSON_ENVELOPE", "1")
+
 	input := map[string]interface{}{"count": 42, "name": "test"}
 	result := wrapWithSchemaVersion(input)
 
@@ -80,11 +129,14 @@ func TestWrapWithSchemaVersion_RoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	sv, ok := parsed["schema_version"]
-	if !ok {
-		t.Fatal("schema_version missing after round-trip")
+	if parsed["schema_version"] != float64(JSONSchemaVersion) {
+		t.Errorf("schema_version = %v, want %v", parsed["schema_version"], float64(JSONSchemaVersion))
 	}
-	if sv != float64(JSONSchemaVersion) {
-		t.Errorf("schema_version = %v, want %v", sv, float64(JSONSchemaVersion))
+	innerData, ok := parsed["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("data type = %T, want map[string]interface{}", parsed["data"])
+	}
+	if innerData["count"] != float64(42) {
+		t.Errorf("data.count = %v, want 42", innerData["count"])
 	}
 }

--- a/docs/JSON_SCHEMA.md
+++ b/docs/JSON_SCHEMA.md
@@ -1,8 +1,49 @@
 # JSON Output Schema Contract
 
-Commands that return a single object (show, create, close, ping, etc.) include a
-`schema_version` field at the top level. Commands that return arrays (list, ready,
-blocked, etc.) output a raw JSON array for backwards compatibility.
+All `bd` commands that support `--json` output can wrap their response in
+a uniform envelope by setting `BD_JSON_ENVELOPE=1`. This will become the
+default format in v2.0.
+
+## Migration Guide
+
+### Opt in to the envelope format
+
+```bash
+export BD_JSON_ENVELOPE=1
+```
+
+### Envelope format (BD_JSON_ENVELOPE=1, default in v2.0)
+
+Every `--json` command wraps output as:
+
+```json
+{"schema_version": 1, "data": <original-payload>}
+```
+
+The original payload is untouched inside `.data` — no type corruption,
+no field injection. Works identically for objects, arrays, and maps.
+
+### Updating consumers
+
+```bash
+# Before (legacy):
+bd list --json | jq '.[0].id'
+bd show beads-abc --json | jq '.title'
+
+# After (envelope):
+bd list --json | jq '.data[0].id'
+bd show beads-abc --json | jq '.data.title'
+
+# Version check:
+bd show beads-abc --json | jq '.schema_version'
+```
+
+### Timeline
+
+- **Current release**: Legacy format is default. Set `BD_JSON_ENVELOPE=1` to opt in.
+  A deprecation notice is printed to stderr when `--json` is used without the env var.
+- **v2.0**: Envelope becomes the default. `BD_JSON_ENVELOPE=0` available as
+  temporary escape hatch for one release cycle.
 
 ## Schema Version
 
@@ -16,6 +57,35 @@ The `schema_version` field is an integer that increments when:
 Additive changes (new optional fields) do NOT bump the version.
 
 ## Output Formats
+
+### Envelope mode (BD_JSON_ENVELOPE=1)
+
+All commands emit a uniform envelope:
+
+```json
+{
+  "schema_version": 1,
+  "data": {
+    "id": "beads-abc",
+    "title": "Example issue",
+    "status": "open"
+  }
+}
+```
+
+Arrays are wrapped the same way:
+
+```json
+{
+  "schema_version": 1,
+  "data": [
+    {"id": "beads-abc", "title": "First"},
+    {"id": "beads-def", "title": "Second"}
+  ]
+}
+```
+
+### Legacy mode (default, until v2.0)
 
 ### Object commands (show, create, close, update, etc.)
 

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -12,6 +12,13 @@ func IsTerminal() bool {
 	return term.IsTerminal(int(os.Stdout.Fd()))
 }
 
+// IsStderrTerminal returns true if stderr is connected to a terminal (TTY).
+// Used to suppress advisory messages (e.g. deprecation notices) when stderr
+// is captured by test harnesses or piped to another process.
+func IsStderrTerminal() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
 // ShouldUseColor determines if ANSI color codes should be used.
 // Respects standard conventions:
 //   - BD_GIT_HOOK=1: disables color in git hook context (prevents OSC 11 queries, GH#1303)


### PR DESCRIPTION
## Summary

Follow-up to #3368 as discussed with @maphew in [this comment](https://github.com/gastownhall/beads/pull/3368#issuecomment-4285204033).

Adds the uniform envelope format for all `--json` output, gated behind `BD_JSON_ENVELOPE=1`:

```json
{"schema_version": 1, "data": <original-payload>}
```

- **Legacy mode (default)**: Unchanged behavior from #3368 — objects get `schema_version` injected inline, arrays pass through raw
- **Envelope mode** (`BD_JSON_ENVELOPE=1`): Uniform wrapping for all types. Original payload is untouched inside `.data` — no type corruption, no field injection
- **Deprecation notice**: One-time stderr message when `--json` is used without `BD_JSON_ENVELOPE=1`

### Migration timeline

1. **Current release**: Legacy is default. `BD_JSON_ENVELOPE=1` to opt in early.
2. **v2.0**: Envelope becomes default. `BD_JSON_ENVELOPE=0` available as temporary escape hatch.

## Changes

- `cmd/bd/output.go`: Dual-mode `wrapWithSchemaVersion` — envelope vs legacy based on env var
- `cmd/bd/errors.go`: `buildJSONError` helper respects envelope mode for error output
- `cmd/bd/output_test.go`: Tests for both legacy and envelope modes (7 test cases)
- `docs/JSON_SCHEMA.md`: Migration guide, consumer examples, timeline

## Test plan

- [x] All existing tests pass unchanged in legacy mode (no env var)
- [x] New envelope tests verify uniform wrapping for objects, slices, nil, round-trip
- [x] `gofmt` clean
- [x] CI green