### PR TITLE
fix: suppress gosec G304 false positive in hookWorkTreeRoot

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -359,7 +359,7 @@ func hookWorkTreeRoot() string {
 		return ""
 	}
 	var root string
-	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil {
+	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil { // #nosec G304 -- path is GIT_DIR/gitdir, a well-known git internal file
 		if dotGit := strings.TrimSpace(string(data)); dotGit != "" {
 			root = filepath.Dir(dotGit)
 		}


### PR DESCRIPTION
## Summary

Suppress a gosec G304 false positive that causes the Lint CI check to fail on **every PR** in the repo.

## Problem

`golangci-lint` (gosec rule G304) flags `os.ReadFile(filepath.Join(gitDir, "gitdir"))` in `hookWorkTreeRoot()` as a potential file inclusion via variable. The path is actually `GIT_DIR/gitdir` — a well-known git internal file read from a trusted environment variable that git itself sets during hook execution. This is not a user-controlled file inclusion.

Because the CI lint job runs with `only-new-issues: false`, this single false positive fails the Lint check on every open PR, making it impossible to tell whether a PR introduces its own lint issues.

## Fix

Add `// #nosec G304` with an explanatory comment on the flagged line.

## Test plan

- [ ] CI Lint check passes