### PR TITLE
chore(install): remove extensionless 'bd' leftover on Windows install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ endif
 install install-force: build
 	@mkdir -p $(INSTALL_DIR)
 ifeq ($(OS),Windows_NT)
-	@rm -f $(INSTALL_DIR)/bd.exe
+	@rm -f $(INSTALL_DIR)/bd $(INSTALL_DIR)/bd.exe
 	@cp $(BUILD_DIR)/bd.exe $(INSTALL_DIR)/bd.exe
 	@echo "Installed bd.exe to $(INSTALL_DIR)/bd.exe"
 else


### PR DESCRIPTION
Fixes #3399

## Problem

on windows, `make install` / `make install-force` only cleans `$(INSTALL_DIR)/bd.exe` before copying the new binary. if a previous install left an extensionless `bd` file at the same location, the stale file keeps shadowing `bd.exe` in MSYS/git-bash PATH resolution.

symptom i hit personally: after a fresh `make install-force`, `bd version` still reported the old commit. `~/.local/bin/bd` (no extension, weeks old) was resolving before `~/.local/bin/bd.exe`. manual `rm -f ~/.local/bin/bd` fixed it.

## Root Cause

`Makefile:150-153` only rms the `.exe` on windows:

```makefile
ifeq ($(OS),Windows_NT)
	@rm -f $(INSTALL_DIR)/bd.exe
	@cp $(BUILD_DIR)/bd.exe $(INSTALL_DIR)/bd.exe
	@echo "Installed bd.exe to $(INSTALL_DIR)/bd.exe"
```

the linux/macOS branch rms extensionless `bd`, but the windows branch never does — so any historical extensionless leftover just sits there.

## Fix

one-line change: also `rm -f $(INSTALL_DIR)/bd` on windows so each install starts from a clean slate.

```diff
 ifeq ($(OS),Windows_NT)
-	@rm -f $(INSTALL_DIR)/bd.exe
+	@rm -f $(INSTALL_DIR)/bd $(INSTALL_DIR)/bd.exe
 	@cp $(BUILD_DIR)/bd.exe $(INSTALL_DIR)/bd.exe
 	@echo "Installed bd.exe to $(INSTALL_DIR)/bd.exe"
```

linux/macOS branch unchanged.

## Test Plan

- [x] `make -n install-force` dry-run on windows shows the updated rm line: `rm -f .../bd .../bd.exe`
- [x] reproduced the bug locally (`touch ~/.local/bin/bd`, `make install-force`, stale file still present on pre-patch HEAD)
- [x] after patch: same repro, stale file is removed, only `bd.exe` remains
- [x] linux branch untouched, still produces `$(INSTALL_DIR)/bd` + `beads` symlink

## Context

- low severity — workaround is a one-time manual `rm` — but a fresh windows contributor hitting this would waste time wondering why their install didn't take
- affects anyone who at some point built beads cross-platform without distinguishing `.exe` (e.g. older local builds, or if they ever manually dropped the binary as extensionless)
- surfaced in my own session 2026-04-20 while updating after an upstream rebase
