### PR TITLE
feat(session): capture created_by_session on bd create (phase 1a of #3400)

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -219,6 +219,14 @@ var createCmd = &cobra.Command{
 			deferUntil = &t
 		}
 
+		// Get Claude Code session ID from flag or environment variable.
+		// Captured at create as created_by_session (immutable after creation).
+		// Mirrors the existing --session pattern on bd close / bd update --status=closed.
+		createSession, _ := cmd.Flags().GetString("session")
+		if createSession == "" {
+			createSession = os.Getenv("CLAUDE_SESSION_ID")
+		}
+
 		// Parse --metadata flag (GH#1406)
 		var metadata json.RawMessage
 		if cmd.Flags().Changed("metadata") {
@@ -278,6 +286,7 @@ var createCmd = &cobra.Command{
 				Ephemeral:          wisp,
 				NoHistory:          noHistory,
 				CreatedBy:          getActorWithGit(),
+				CreatedBySession:   createSession,
 				Owner:              getOwner(),
 				MolType:            molType,
 				WispType:           wispType,
@@ -475,6 +484,7 @@ var createCmd = &cobra.Command{
 			Ephemeral:          wisp,
 			NoHistory:          noHistory,
 			CreatedBy:          getActorWithGit(),
+			CreatedBySession:   createSession,
 			Owner:              getOwner(),
 			MolType:            molType,
 			WispType:           wispType,
@@ -723,6 +733,7 @@ type createIssueParams struct {
 	Ephemeral          bool
 	NoHistory          bool
 	CreatedBy          string
+	CreatedBySession   string
 	Owner              string
 	MolType            types.MolType
 	WispType           types.WispType
@@ -758,6 +769,7 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		Ephemeral:          params.Ephemeral,
 		NoHistory:          params.NoHistory,
 		CreatedBy:          params.CreatedBy,
+		CreatedBySession:   params.CreatedBySession,
 		Owner:              params.Owner,
 		MolType:            params.MolType,
 		WispType:           params.WispType,
@@ -844,6 +856,7 @@ func init() {
 	createCmd.Flags().String("due", "", "Due date/time. Formats: +6h, +1d, +2w, tomorrow, next monday, 2025-01-15")
 	createCmd.Flags().String("defer", "", "Defer until date (issue hidden from bd ready until then). Same formats as --due")
 	createCmd.Flags().String("metadata", "", "Set custom metadata (JSON string or @file.json to read from file)")
+	createCmd.Flags().String("session", "", "Claude Code session ID to record as created_by_session (or set CLAUDE_SESSION_ID env var)")
 	// Note: --json flag is defined as a persistent flag in main.go, not here
 	rootCmd.AddCommand(createCmd)
 }

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -635,6 +635,101 @@ A new feature
 			t.Errorf("expected title-related error, got: %s", out)
 		}
 	})
+
+	// ===== Session Flag (created_by_session) =====
+
+	t.Run("create_with_session", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "cs")
+		issue := bdCreate(t, bd, dir, "Created with explicit session", "--session", "sess-create-1")
+		if issue.CreatedBySession != "sess-create-1" {
+			t.Errorf("CreatedBySession: got %q, want %q", issue.CreatedBySession, "sess-create-1")
+		}
+
+		// Verify round-trip through bd show --json.
+		shown := bdShow(t, bd, dir, issue.ID)
+		if shown.CreatedBySession != "sess-create-1" {
+			t.Errorf("show CreatedBySession: got %q, want %q", shown.CreatedBySession, "sess-create-1")
+		}
+	})
+
+	t.Run("create_session_from_env", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "ce")
+		cmd := exec.Command(bd, "create", "--json", "Env session test")
+		cmd.Dir = dir
+		env := bdEnv(dir)
+		env = append(env, "CLAUDE_SESSION_ID=env-create-sess")
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd create with env session failed: %v\n%s", err, out)
+		}
+		issue := parseIssueJSON(t, out)
+		if issue.CreatedBySession != "env-create-sess" {
+			t.Errorf("CreatedBySession: got %q, want %q", issue.CreatedBySession, "env-create-sess")
+		}
+	})
+
+	t.Run("create_without_session_empty", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "cn")
+		issue := bdCreate(t, bd, dir, "No session provided")
+		if issue.CreatedBySession != "" {
+			t.Errorf("CreatedBySession without flag or env: got %q, want empty", issue.CreatedBySession)
+		}
+	})
+
+	t.Run("created_by_session_immutable", func(t *testing.T) {
+		// Create with session A, then run an update that would touch other
+		// fields, and verify created_by_session is unchanged afterward.
+		// created_by_session is not in IsAllowedUpdateField, so it cannot be
+		// modified through the update path — this test locks that invariant.
+		dir, _, _ := bdInit(t, bd, "--prefix", "ci")
+		issue := bdCreate(t, bd, dir, "Immutable session test", "--session", "sess-original")
+		if issue.CreatedBySession != "sess-original" {
+			t.Fatalf("precondition: CreatedBySession got %q, want %q", issue.CreatedBySession, "sess-original")
+		}
+
+		// Update something else on the issue. Attempt with a different --session
+		// env — that only affects closed_by_session on status=closed, never
+		// created_by_session.
+		cmd := exec.Command(bd, "update", issue.ID, "--priority", "1")
+		cmd.Dir = dir
+		env := bdEnv(dir)
+		env = append(env, "CLAUDE_SESSION_ID=sess-attempted-override")
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd update failed: %v\n%s", err, out)
+		}
+
+		shown := bdShow(t, bd, dir, issue.ID)
+		if shown.CreatedBySession != "sess-original" {
+			t.Errorf("after update, CreatedBySession: got %q, want %q (immutable)", shown.CreatedBySession, "sess-original")
+		}
+	})
+
+	t.Run("create_session_json_and_long", func(t *testing.T) {
+		// Regression: created_by_session must hydrate in JSON output AND appear
+		// in the `bd show --long` human surface.
+		dir, _, _ := bdInit(t, bd, "--prefix", "cl")
+		issue := bdCreate(t, bd, dir, "JSON and long render", "--session", "sess-render")
+
+		// JSON round-trip.
+		shown := bdShow(t, bd, dir, issue.ID)
+		if shown.CreatedBySession != "sess-render" {
+			t.Errorf("JSON CreatedBySession: got %q, want %q", shown.CreatedBySession, "sess-render")
+		}
+
+		// Long render.
+		cmd := exec.Command(bd, "show", issue.ID, "--long")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd show --long failed: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "Created by session: sess-render") {
+			t.Errorf("bd show --long should contain 'Created by session: sess-render', got:\n%s", out)
+		}
+	})
 }
 
 // TestEmbeddedCreateCommitPending verifies that CommitPending works on EmbeddedDoltStore:
@@ -943,4 +1038,64 @@ func TestEmbeddedCreateConcurrent(t *testing.T) {
 	}
 
 	t.Logf("created %d issues across %d concurrent workers (%d succeeded), %d in DB", len(allIDs), numWorkers, successes, stats.TotalIssues)
+}
+
+// TestEmbeddedCreateSessionConcurrent verifies that concurrent bd create
+// invocations with distinct --session values each persist their own
+// created_by_session without cross-contamination. Uses real OS processes
+// (bd invocations) to exercise the full multi-process code path, not just
+// goroutine-level concurrency.
+func TestEmbeddedCreateSessionConcurrent(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "csc")
+
+	const numWorkers = 5
+	type result struct {
+		worker  int
+		issueID string
+		session string
+		err     error
+	}
+	results := make([]result, numWorkers)
+	var wg sync.WaitGroup
+
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			session := fmt.Sprintf("sess-concurrent-%d", worker)
+			title := fmt.Sprintf("Concurrent session %d", worker)
+
+			// Use bdRunWithFlockRetry so flock contention between processes
+			// is handled the same way the rest of the suite handles it.
+			out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--json", "--session", session, title)
+			if err != nil {
+				results[worker] = result{worker: worker, err: fmt.Errorf("bd create failed: %w\n%s", err, out)}
+				return
+			}
+			issue := parseIssueJSON(t, out)
+			results[worker] = result{worker: worker, issueID: issue.ID, session: issue.CreatedBySession}
+		}(w)
+	}
+	wg.Wait()
+
+	// Verify each successful worker got its own session persisted with no mix-up.
+	for _, r := range results {
+		if r.err != nil {
+			if strings.Contains(r.err.Error(), "one writer at a time") {
+				continue // acceptable flock loss under contention
+			}
+			t.Errorf("worker %d failed: %v", r.worker, r.err)
+			continue
+		}
+		want := fmt.Sprintf("sess-concurrent-%d", r.worker)
+		if r.session != want {
+			t.Errorf("worker %d: CreatedBySession got %q, want %q (issue %s)", r.worker, r.session, want, r.issueID)
+		}
+	}
 }

--- a/cmd/bd/show_format.go
+++ b/cmd/bd/show_format.go
@@ -243,6 +243,9 @@ func formatIssueLongExtras(issue *types.Issue, formatTime func(time.Time) string
 
 	// Extended timestamps and closure details
 	var closeParts []string
+	if issue.CreatedBySession != "" {
+		closeParts = append(closeParts, fmt.Sprintf("  Created by session: %s", issue.CreatedBySession))
+	}
 	if issue.ClosedAt != nil {
 		closeParts = append(closeParts, fmt.Sprintf("  Closed at: %s", formatTime(*issue.ClosedAt)))
 	}

--- a/internal/storage/dolt/migrations/018_add_session_columns.go
+++ b/internal/storage/dolt/migrations/018_add_session_columns.go
@@ -1,0 +1,44 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// MigrateAddSessionColumns ensures the created_by_session and claimed_by_session
+// columns exist on the issues and wisps tables. These columns mirror the
+// per-event session attribution pattern established by closed_by_session:
+// each lifecycle event (create / claim / close) has its own dedicated column
+// naming the Claude Code session responsible, with the audit log remaining
+// the source of truth for full multi-session history.
+//
+// This compat migration repairs databases that predate schema migration 0033.
+// Safe to run unconditionally: each ALTER is gated by a SHOW COLUMNS check.
+func MigrateAddSessionColumns(db *sql.DB) error {
+	cols := []string{"created_by_session", "claimed_by_session"}
+	for _, table := range []string{"issues", "wisps"} {
+		tableOK, err := TableExists(db, table)
+		if err != nil {
+			return fmt.Errorf("failed to check %s table existence: %w", table, err)
+		}
+		if !tableOK {
+			// wisps is a dolt-ignored table recreated by EnsureIgnoredTables;
+			// if it's missing here we skip — the ignored-table path owns it.
+			continue
+		}
+		for _, col := range cols {
+			exists, err := columnExists(db, table, col)
+			if err != nil {
+				return fmt.Errorf("failed to check %s column on %s: %w", col, table, err)
+			}
+			if exists {
+				continue
+			}
+			//nolint:gosec // G201: table and col are from hardcoded lists
+			if _, err := db.Exec(fmt.Sprintf("ALTER TABLE `%s` ADD COLUMN %s VARCHAR(255) DEFAULT ''", table, col)); err != nil {
+				return fmt.Errorf("failed to add %s column to %s: %w", col, table, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/storage/dolt/migrations/018_add_session_columns_test.go
+++ b/internal/storage/dolt/migrations/018_add_session_columns_test.go
@@ -1,0 +1,57 @@
+package migrations
+
+import (
+	"testing"
+)
+
+// TestMigrateAddSessionColumns verifies the compat migration adds
+// created_by_session and claimed_by_session to the issues table when
+// missing, and is idempotent on re-run.
+func TestMigrateAddSessionColumns(t *testing.T) {
+	db := openTestDoltBranch(t)
+
+	cols := []string{"created_by_session", "claimed_by_session"}
+
+	// Drop columns if they exist from the test's base schema so we can
+	// observe the migration adding them back.
+	for _, col := range cols {
+		if exists, err := columnExists(db, "issues", col); err != nil {
+			t.Fatalf("failed to check %s column: %v", col, err)
+		} else if exists {
+			if _, err := db.Exec("ALTER TABLE `issues` DROP COLUMN " + col); err != nil {
+				t.Fatalf("failed to drop %s for test setup: %v", col, err)
+			}
+		}
+	}
+
+	// Verify preconditions
+	for _, col := range cols {
+		exists, err := columnExists(db, "issues", col)
+		if err != nil {
+			t.Fatalf("failed to check %s column: %v", col, err)
+		}
+		if exists {
+			t.Fatalf("%s should not exist yet", col)
+		}
+	}
+
+	if err := MigrateAddSessionColumns(db); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	// Verify post-conditions
+	for _, col := range cols {
+		exists, err := columnExists(db, "issues", col)
+		if err != nil {
+			t.Fatalf("failed to check %s column: %v", col, err)
+		}
+		if !exists {
+			t.Fatalf("%s should exist on issues after migration", col)
+		}
+	}
+
+	// Idempotent: re-running must succeed even when columns already exist.
+	if err := MigrateAddSessionColumns(db); err != nil {
+		t.Fatalf("re-running migration should be idempotent: %v", err)
+	}
+}

--- a/internal/storage/dolt/migrations/runner.go
+++ b/internal/storage/dolt/migrations/runner.go
@@ -35,6 +35,7 @@ var compatMigrationsList = []CompatMigration{
 	{"wisp_events_created_at_index", MigrateWispEventsCreatedAtIndex},
 	{"custom_status_type_tables", MigrateCustomStatusTypeTables},
 	{"backfill_custom_tables", BackfillCustomTables},
+	{"add_session_columns", MigrateAddSessionColumns},
 }
 
 // RunCompatMigrations executes all backward-compat migrations. These handle

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -47,7 +47,7 @@ func InsertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 		INSERT INTO %s (
 			id, content_hash, title, description, design, acceptance_criteria, notes,
 			status, priority, issue_type, assignee, estimated_minutes,
-			created_at, created_by, owner, updated_at, started_at, closed_at, external_ref, spec_id,
+			created_at, created_by, created_by_session, owner, updated_at, started_at, closed_at, external_ref, spec_id,
 			compaction_level, compacted_at, compacted_at_commit, original_size,
 			sender, ephemeral, no_history, wisp_type, pinned, is_template,
 			mol_type, work_type, source_system, source_repo, close_reason,
@@ -57,7 +57,7 @@ func InsertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?,
@@ -87,7 +87,7 @@ func InsertIssueIntoTable(ctx context.Context, tx *sql.Tx, table string, issue *
 	`, table),
 		issue.ID, issue.ContentHash, issue.Title, issue.Description, issue.Design, issue.AcceptanceCriteria, issue.Notes,
 		issue.Status, issue.Priority, issue.IssueType, NullString(issue.Assignee), NullInt(issue.EstimatedMinutes),
-		issue.CreatedAt, issue.CreatedBy, issue.Owner, issue.UpdatedAt, issue.StartedAt, issue.ClosedAt, NullStringPtr(issue.ExternalRef), issue.SpecID,
+		issue.CreatedAt, issue.CreatedBy, issue.CreatedBySession, issue.Owner, issue.UpdatedAt, issue.StartedAt, issue.ClosedAt, NullStringPtr(issue.ExternalRef), issue.SpecID,
 		issue.CompactionLevel, issue.CompactedAt, NullStringPtr(issue.CompactedAtCommit), NullIntVal(issue.OriginalSize),
 		issue.Sender, issue.Ephemeral, issue.NoHistory, issue.WispType, issue.Pinned, issue.IsTemplate,
 		issue.MolType, issue.WorkType, issue.SourceSystem, issue.SourceRepo, issue.CloseReason,

--- a/internal/storage/issueops/scan.go
+++ b/internal/storage/issueops/scan.go
@@ -13,8 +13,8 @@ import (
 // use this constant to avoid column-list drift between scan sites.
 const IssueSelectColumns = `id, content_hash, title, description, design, acceptance_criteria, notes,
 	       status, priority, issue_type, assignee, estimated_minutes,
-	       created_at, created_by, owner, updated_at, started_at, closed_at, external_ref, spec_id,
-	       compaction_level, compacted_at, compacted_at_commit, original_size, source_repo, close_reason,
+	       created_at, created_by, created_by_session, owner, updated_at, started_at, closed_at, external_ref, spec_id,
+	       compaction_level, compacted_at, compacted_at_commit, original_size, source_repo, close_reason, closed_by_session,
 	       sender, ephemeral, no_history, wisp_type, pinned, is_template,
 	       await_type, await_id, timeout_ns, waiters,
 	       mol_type,
@@ -36,9 +36,9 @@ func ScanIssueFrom(s IssueScanner) (*types.Issue, error) {
 	var createdAtStr, updatedAtStr sql.NullString // TEXT columns - must parse manually
 	var startedAt, closedAt, compactedAt, dueAt, deferUntil sql.NullTime
 	var estimatedMinutes, originalSize, timeoutNs sql.NullInt64
-	var createdBy sql.NullString
+	var createdBy, createdBySession sql.NullString
 	var assignee, externalRef, specID, compactedAtCommit, owner sql.NullString
-	var contentHash, sourceRepo, closeReason sql.NullString
+	var contentHash, sourceRepo, closeReason, closedBySession sql.NullString
 	var workType, sourceSystem sql.NullString
 	var sender, wispType, molType, eventKind, actor, target, payload sql.NullString
 	var awaitType, awaitID, waiters sql.NullString
@@ -49,8 +49,8 @@ func ScanIssueFrom(s IssueScanner) (*types.Issue, error) {
 		&issue.ID, &contentHash, &issue.Title, &issue.Description, &issue.Design,
 		&issue.AcceptanceCriteria, &issue.Notes, &issue.Status,
 		&issue.Priority, &issue.IssueType, &assignee, &estimatedMinutes,
-		&createdAtStr, &createdBy, &owner, &updatedAtStr, &startedAt, &closedAt, &externalRef, &specID,
-		&issue.CompactionLevel, &compactedAt, &compactedAtCommit, &originalSize, &sourceRepo, &closeReason,
+		&createdAtStr, &createdBy, &createdBySession, &owner, &updatedAtStr, &startedAt, &closedAt, &externalRef, &specID,
+		&issue.CompactionLevel, &compactedAt, &compactedAtCommit, &originalSize, &sourceRepo, &closeReason, &closedBySession,
 		&sender, &ephemeral, &noHistory, &wispType, &pinned, &isTemplate,
 		&awaitType, &awaitID, &timeoutNs, &waiters,
 		&molType,
@@ -88,6 +88,12 @@ func ScanIssueFrom(s IssueScanner) (*types.Issue, error) {
 	}
 	if createdBy.Valid {
 		issue.CreatedBy = createdBy.String
+	}
+	if createdBySession.Valid {
+		issue.CreatedBySession = createdBySession.String
+	}
+	if closedBySession.Valid {
+		issue.ClosedBySession = closedBySession.String
 	}
 	if owner.Valid {
 		issue.Owner = owner.String

--- a/internal/storage/schema/ignored_tables.go
+++ b/internal/storage/schema/ignored_tables.go
@@ -29,6 +29,7 @@ var ignoredMigrations = []ignoredMigration{
 	{version: 23, filter: "wisps"}, // ALTER TABLE wisps ADD COLUMN no_history (skip issues ALTER)
 	{version: 27, filter: "wisps"}, // ALTER TABLE wisps ADD COLUMN started_at (skip issues ALTER)
 	{version: 31},                  // CREATE INDEX idx_wisp_events_created_at
+	{version: 33, filter: "wisps"}, // ALTER TABLE wisps ADD session attribution columns (skip issues ALTER)
 }
 
 var (

--- a/internal/storage/schema/ignored_tables_test.go
+++ b/internal/storage/schema/ignored_tables_test.go
@@ -25,7 +25,7 @@ func TestIgnoredTableDDL(t *testing.T) {
 
 	// Verify columns added by later migrations are present (the bug that
 	// motivated this refactor: started_at was missing from the Go constant).
-	for _, col := range []string{"started_at", "no_history"} {
+	for _, col := range []string{"started_at", "no_history", "created_by_session", "claimed_by_session"} {
 		if !strings.Contains(combined, col) {
 			t.Errorf("IgnoredTableDDL missing column %q — migration not included?", col)
 		}

--- a/internal/storage/schema/migrations/0033_add_session_columns.down.sql
+++ b/internal/storage/schema/migrations/0033_add_session_columns.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE issues DROP COLUMN created_by_session;
+ALTER TABLE wisps DROP COLUMN created_by_session;
+ALTER TABLE issues DROP COLUMN claimed_by_session;
+ALTER TABLE wisps DROP COLUMN claimed_by_session;

--- a/internal/storage/schema/migrations/0033_add_session_columns.up.sql
+++ b/internal/storage/schema/migrations/0033_add_session_columns.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE issues ADD COLUMN created_by_session VARCHAR(255) DEFAULT '';
+ALTER TABLE wisps ADD COLUMN created_by_session VARCHAR(255) DEFAULT '';
+ALTER TABLE issues ADD COLUMN claimed_by_session VARCHAR(255) DEFAULT '';
+ALTER TABLE wisps ADD COLUMN claimed_by_session VARCHAR(255) DEFAULT '';

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -37,13 +37,14 @@ type Issue struct {
 	EstimatedMinutes *int   `json:"estimated_minutes,omitempty"`
 
 	// ===== Timestamps =====
-	CreatedAt       time.Time  `json:"created_at"`
-	CreatedBy       string     `json:"created_by,omitempty"` // Who created this issue (GH#748)
-	UpdatedAt       time.Time  `json:"updated_at"`
-	StartedAt       *time.Time `json:"started_at,omitempty"` // When this issue transitioned to in_progress (GH#2796)
-	ClosedAt        *time.Time `json:"closed_at,omitempty"`
-	CloseReason     string     `json:"close_reason,omitempty"`      // Reason provided when closing
-	ClosedBySession string     `json:"closed_by_session,omitempty"` // Claude Code session that closed this issue
+	CreatedAt        time.Time  `json:"created_at"`
+	CreatedBy        string     `json:"created_by,omitempty"`         // Who created this issue (GH#748)
+	CreatedBySession string     `json:"created_by_session,omitempty"` // Claude Code session that created this issue
+	UpdatedAt        time.Time  `json:"updated_at"`
+	StartedAt        *time.Time `json:"started_at,omitempty"` // When this issue transitioned to in_progress (GH#2796)
+	ClosedAt         *time.Time `json:"closed_at,omitempty"`
+	CloseReason      string     `json:"close_reason,omitempty"`      // Reason provided when closing
+	ClosedBySession  string     `json:"closed_by_session,omitempty"` // Claude Code session that closed this issue
 
 	// ===== Time-Based Scheduling (GH#820) =====
 	DueAt      *time.Time `json:"due_at,omitempty"`      // When this issue should be completed


### PR DESCRIPTION
Refs #3400

## Problem

bd has a first-class `closed_by_session` column that captures which Claude Code session closed a bead (added in commit `b362b3682` per decision doc `009-session-events-architecture.md`). but session provenance is only captured at close — create and claim events have no first-class capture.

in multi-session / multi-agent workflows, the gap is felt immediately: `bd show` can tell you who finished a bead but not who opened it or who's holding it now.

## Root Cause

the close-only scoping was the MVP per the 009 decision — deliberate incremental delivery, not a rejection of full-lifecycle tracking. the existing column is intentionally named `closed_by_session` (per-event), not a generic `session_id` — so the natural extension mirrors that pattern.

this PR covers **phase 1a** of two from issue #3400:

- **phase 1a (this PR):** schema migration for both columns + `created_by_session` write path + readability fix for both session columns
- **phase 1b (follow-up PR):** `claimed_by_session` write path (requires extending `ClaimIssueInTx` signature + 3 caller updates, wiring `--session` on the claim / in-progress transition in `bd update`, multi-session re-claim concurrency test)

both columns are provisioned in the same schema migration so phase 1b is a pure write-path change with no schema churn. see #3400 for the combined design.

## Fix

- **types.go** — new `CreatedBySession string` field on `Issue` with `json:"created_by_session,omitempty"` tag, grouped next to `CreatedBy`
- **schema/migrations/0033_add_session_columns.up.sql** — new SQL migration: `ALTER TABLE issues ADD COLUMN created_by_session VARCHAR(255) DEFAULT ''` on both `issues` and `wisps`; same for `claimed_by_session` (provisioned for phase 1b)
- **dolt/migrations/018_add_session_columns.go** — new compat migration mirroring `017_add_started_at_column.go`: idempotent, dual-table, column-gated via the existing `columnExists` helper. registered in `compatMigrationsList`.
- **issueops/helpers.go** — `created_by_session` threaded into the `InsertIssueIntoTable` column list, placeholder list, and argument tuple. intentionally kept **out** of `ON DUPLICATE KEY UPDATE` so re-imports (e.g. `bd export` → `bd import` round-trip) don't overwrite the original creation session.
- **issueops/scan.go** — `IssueSelectColumns` and `ScanIssueFrom` hydrate `created_by_session` into `issue.CreatedBySession`. while extending the read path i also hydrated `closed_by_session` into `issue.ClosedBySession` — this was a pre-existing dead-code bug (written by `CloseIssueInTx` but never scanned, so `bd show --long`'s `Closed by session:` line never rendered). coherent same-surface fix; called out here for transparency.
- **cmd/bd/create.go** — new `--session` flag, reads from flag first then falls back to `$CLAUDE_SESSION_ID`, mirrors the existing pattern in `cmd/bd/close.go:85-89`. threaded through `createIssueParams` and `buildCreateIssue` (both dry-run and real-create call sites).
- **cmd/bd/show_format.go** — `Created by session: <id>` line added to the `--long` extended-details block when populated.

## Test Plan

- [x] `go build -tags gms_pure_go ./...` — clean
- [x] `go vet -tags gms_pure_go ./...` — clean
- [x] `go test ./internal/types/... ./internal/storage/issueops/...` — pass
- [x] `TestMigrateAddSessionColumns` runs via `go test ./internal/storage/dolt/migrations/...` (skipped locally without Docker+Dolt; CI will exercise it)

new tests added to `cmd/bd/create_embedded_test.go`:
- `create_with_session` — `--session sess-create-1` persists and round-trips through `bd show --json`
- `create_session_from_env` — `CLAUDE_SESSION_ID` fallback works, matching the `bd close` pattern
- `create_without_session_empty` — default is empty string when neither flag nor env set
- `created_by_session_immutable` — after create with session A, a subsequent `bd update --priority 1` with `CLAUDE_SESSION_ID=sess-attempted-override` does **not** overwrite `created_by_session`. locks the invariant (the field is intentionally absent from `IsAllowedUpdateField`).
- `create_session_json_and_long` — regression test for full read path: creates with a session, verifies both JSON round-trip and `bd show --long` render contain the session id
- `TestEmbeddedCreateSessionConcurrent` — 5 workers create issues concurrently with distinct session ids; verifies each persists with no cross-contamination (multi-process via real `bd` invocations, not just goroutines)

## Context

- upstream issue #3400 — combined design; this PR covers phase 1a, phase 1b to follow against the same issue
- governing principle from `/design/operational-state/`: *events are the source of truth, labels are the cache* — these columns are the denormalized cache of an attribution fact the audit log also records
- BD_ACTOR attribution (`<rig>/<role>/<name>` in `created_by` / `updated_by`) stays orthogonal to session attribution — this PR adds a new dimension, not a replacement
- polecat identity model from `/concepts/identity/` matches the split exactly: persistent identity → `created_by_session` (immutable); ephemeral session → future `claimed_by_session` (overwrite on re-claim)

## Additional finding (unrelated, not fixed here)

while working on this PR i noticed the `.githooks/pre-commit` hook invokes `golangci-lint` with `CGO_ENABLED=0` but without `--build-tags cgo`, so any `//go:build cgo`-tagged file (e.g. `cmd/bd/store_factory.go`) is invisible to the typechecker — the hook exits 7 on `undefined: sanitizeDBName` even when the actual `go build` is clean and there are zero new lint issues in the diff. reproducible on a fresh checkout of `origin/main` with `CGO_ENABLED=0 go build ./cmd/bd/`.

filing a separate issue + small one-line PR for this before my phase 1b PR, since the hook fix is unrelated to session tracking and belongs on its own branch per CONTRIBUTING.md "one PR per issue".
