### PR TITLE
fix(lint): move sanitizeDBName to untagged file so non-cgo typecheck succeeds

### DIFF
--- a/cmd/bd/db_name.go
+++ b/cmd/bd/db_name.go
@@ -1,0 +1,17 @@
+package main
+
+import "strings"
+
+// sanitizeDBName replaces hyphens and dots with underscores for
+// SQL-idiomatic embedded Dolt database names (GH#2142, GH#3231).
+//
+// Defined here without a build tag so the pure-string helper is visible
+// to non-cgo callers (e.g. cmd/bd/init.go) and to lint typechecking passes
+// that run with CGO_ENABLED=0. The consumers that actually use embedded
+// Dolt (in store_factory.go, //go:build cgo) still link to this same
+// implementation.
+func sanitizeDBName(name string) string {
+	name = strings.ReplaceAll(name, "-", "_")
+	name = strings.ReplaceAll(name, ".", "_")
+	return name
+}


### PR DESCRIPTION
Fixes #3402

## Problem

`.githooks/pre-commit` runs `golangci-lint` with `CGO_ENABLED=0` (intentional, documented in the hook — avoids requiring system headers from CGO-only deps like `go-icu-regex` and `gozstd`). with `CGO_ENABLED=0`, Go does not auto-apply the `cgo` build tag, so any first-party file with `//go:build cgo` is invisible to the typechecker.

`cmd/bd/store_factory.go` (`//go:build cgo`) defined `sanitizeDBName`, a pure-string 3-line helper. `cmd/bd/init.go:172` (no build tag) called it directly. under `CGO_ENABLED=0`, `init.go` is visible but the function is not, so the hook tripped on every contributor's commit with:

```
level=error msg="[linters_context] typechecking error: : # github.com/steveyegge/beads/cmd/bd
cmd/bd/init.go:172:15: undefined: sanitizeDBName"
0 issues.
exit status 7
```

note the `0 issues.` — zero actual lint findings, the typechecker just can't resolve the symbol.

## Root Cause

a function with zero cgo dependency (just `strings.ReplaceAll`) sitting in a cgo-tagged file — by historical accident, not by design. wrong build-tag granularity.

## Fix

move `sanitizeDBName` to a new untagged file `cmd/bd/db_name.go`:
- same package (`main`)
- same implementation (no behavior change)
- same three call sites (two in cgo-tagged `store_factory.go`, one in non-tagged `init.go`, plus the test in `store_factory_test.go`) — all continue to resolve because package-level functions don't care about build tags at the call site, only at the definition site.

also drop the now-unused `strings` import from `store_factory.go`.

## Alternatives considered (and rejected)

- **add `--build-tags=cgo` to the hook's `golangci-lint` invocation.** does not work — forces the cgo tag into the typechecker view, but without `CGO_ENABLED=1` the third-party CGO-only deps then fail to typecheck on their own `import "C"` symbols (`undefined: DefaultCompressionLevel`, etc. from `gozstd`; similar from `go-icu-regex`). cure worse than the disease.
- **set `CGO_ENABLED=1` in the hook.** reintroduces the system-header requirement the hook explicitly avoids.
- **non-cgo stub for `sanitizeDBName`.** adds duplicate implementation, fragile.

the move is structurally correct regardless of the hook — a pure string helper shouldn't carry an unnecessary build tag.

## Test Plan

- [x] `CGO_ENABLED=0 go build ./cmd/bd/` — clean (reproduces bug pre-fix, passes post-fix)
- [x] `go build -tags gms_pure_go ./...` — clean (production build, unchanged)
- [x] `go vet -tags gms_pure_go ./...` — clean
- [x] `go test ./cmd/bd/ -run '^TestSanitize'` — existing sanitize test in `store_factory_test.go` still passes without modification
- [x] `.githooks/pre-commit` ran against its own commit and passed (`0 issues.`, no typecheck error) — recursive validation
