### PR TITLE
fix: wire embedded backend compat migrations by relocating runner

### DIFF
--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
@@ -640,7 +640,7 @@ func handleToSeparateBranch(branch string, dryRun bool) {
 
 // listMigrations returns registered Dolt schema migrations.
 func listMigrations() []string {
-	return dolt.ListCompatMigrations()
+	return migrations.ListCompatMigrations()
 }
 
 // migrateSyncCmd is the "bd migrate sync <branch>" subcommand that

--- a/internal/storage/dolt/migrations.go
+++ b/internal/storage/dolt/migrations.go
@@ -3,90 +3,9 @@ package dolt
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"log"
-	"strings"
 
-	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
 	"github.com/steveyegge/beads/internal/storage/schema"
 )
-
-// CompatMigration represents a DoltStore-specific backward-compat migration.
-type CompatMigration struct {
-	Name string
-	Func func(*sql.DB) error
-}
-
-// compatMigrationsList is the ordered list of DoltStore-specific migrations
-// for databases that predate the embedded migration system. Each migration
-// must be idempotent — safe to run multiple times.
-var compatMigrationsList = []CompatMigration{
-	{"wisp_type_column", migrations.MigrateWispTypeColumn},
-	{"spec_id_column", migrations.MigrateSpecIDColumn},
-	{"orphan_detection", migrations.DetectOrphanedChildren},
-	{"wisps_table", migrations.MigrateWispsTable},
-	{"wisp_auxiliary_tables", migrations.MigrateWispAuxiliaryTables},
-	{"issue_counter_table", migrations.MigrateIssueCounterTable},
-	{"infra_to_wisps", migrations.MigrateInfraToWisps},
-	{"wisp_dep_type_index", migrations.MigrateWispDepTypeIndex},
-	{"cleanup_autopush_metadata", migrations.MigrateCleanupAutopushMetadata},
-	{"uuid_primary_keys", migrations.MigrateUUIDPrimaryKeys},
-	{"add_no_history_column", migrations.MigrateAddNoHistoryColumn},
-	{"add_started_at_column", migrations.MigrateAddStartedAtColumn},
-	{"drop_hop_columns", migrations.MigrateDropHOPColumns},
-	{"drop_child_counters_fk", migrations.MigrateDropChildCountersFK},
-	{"wisp_events_created_at_index", migrations.MigrateWispEventsCreatedAtIndex},
-	{"custom_status_type_tables", migrations.MigrateCustomStatusTypeTables},
-	{"backfill_custom_tables", migrations.BackfillCustomTables},
-}
-
-// RunCompatMigrations executes all DoltStore-specific backward-compat migrations.
-// These handle historical data transforms for databases that predate the embedded
-// migration system (ALTER TABLE ADD COLUMN, data moves, FK drops, etc.).
-// Each migration is idempotent and checks whether its changes have already been applied.
-func RunCompatMigrations(db *sql.DB) error {
-	for _, m := range compatMigrationsList {
-		if err := m.Func(db); err != nil {
-			return fmt.Errorf("compat migration %q failed: %w", m.Name, err)
-		}
-	}
-
-	// Only stage and commit when compat migrations actually produced changes.
-	// Previously, DOLT_COMMIT was called unconditionally, causing a
-	// "nothing to commit" WARNING on the server for every bd invocation
-	// (94% of server log lines in one reported case). GH#3366.
-	var dirtyCount int
-	if err := db.QueryRow("SELECT COUNT(*) FROM dolt_status").Scan(&dirtyCount); err != nil {
-		// dolt_status might not be available (e.g. older servers); fall through
-		// to the original behavior as a safe fallback.
-		dirtyCount = 1
-	}
-	if dirtyCount == 0 {
-		return nil
-	}
-
-	// GH#2455: Stage only schema tables (not config) to avoid sweeping up
-	// stale issue_prefix changes from concurrent operations.
-	migrationTables := []string{
-		"issues", "wisps", "events", "wisp_events", "dependencies",
-		"wisp_dependencies", "labels", "wisp_labels", "comments",
-		"wisp_comments", "metadata", "child_counters", "issue_counter",
-		"issue_snapshots", "compaction_snapshots", "federation_peers",
-		"custom_statuses", "custom_types",
-		"dolt_ignore",
-	}
-	for _, table := range migrationTables {
-		_, _ = db.Exec("CALL DOLT_ADD(?)", table)
-	}
-	_, err := db.Exec("CALL DOLT_COMMIT('-m', 'schema: auto-migrate')")
-	if err != nil {
-		if !strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
-			log.Printf("dolt compat migration commit warning: %v", err)
-		}
-	}
-
-	return nil
-}
 
 // CreateIgnoredTables re-creates dolt_ignore'd tables (wisps, wisp_*)
 // on the current branch. These tables only exist in the working set and
@@ -94,13 +13,4 @@ func RunCompatMigrations(db *sql.DB) error {
 // Exported for use by test helpers in other packages.
 func CreateIgnoredTables(db *sql.DB) error {
 	return schema.CreateIgnoredTables(context.Background(), db)
-}
-
-// ListCompatMigrations returns the names of all registered compat migrations.
-func ListCompatMigrations() []string {
-	names := make([]string, len(compatMigrationsList))
-	for i, m := range compatMigrationsList {
-		names[i] = m.Name
-	}
-	return names
 }

--- a/internal/storage/dolt/migrations/runner.go
+++ b/internal/storage/dolt/migrations/runner.go
@@ -1,0 +1,96 @@
+package migrations
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+)
+
+// CompatMigration represents a backward-compat migration for databases that
+// predate the embedded migration system.
+type CompatMigration struct {
+	Name string
+	Func func(*sql.DB) error
+}
+
+// compatMigrationsList is the ordered list of backward-compat migrations
+// for databases that predate the embedded migration system. Each migration
+// must be idempotent — safe to run multiple times.
+var compatMigrationsList = []CompatMigration{
+	{"wisp_type_column", MigrateWispTypeColumn},
+	{"spec_id_column", MigrateSpecIDColumn},
+	{"orphan_detection", DetectOrphanedChildren},
+	{"wisps_table", MigrateWispsTable},
+	{"wisp_auxiliary_tables", MigrateWispAuxiliaryTables},
+	{"issue_counter_table", MigrateIssueCounterTable},
+	{"infra_to_wisps", MigrateInfraToWisps},
+	{"wisp_dep_type_index", MigrateWispDepTypeIndex},
+	{"cleanup_autopush_metadata", MigrateCleanupAutopushMetadata},
+	{"uuid_primary_keys", MigrateUUIDPrimaryKeys},
+	{"add_no_history_column", MigrateAddNoHistoryColumn},
+	{"add_started_at_column", MigrateAddStartedAtColumn},
+	{"drop_hop_columns", MigrateDropHOPColumns},
+	{"drop_child_counters_fk", MigrateDropChildCountersFK},
+	{"wisp_events_created_at_index", MigrateWispEventsCreatedAtIndex},
+	{"custom_status_type_tables", MigrateCustomStatusTypeTables},
+	{"backfill_custom_tables", BackfillCustomTables},
+}
+
+// RunCompatMigrations executes all backward-compat migrations. These handle
+// historical data transforms for databases that predate the embedded
+// migration system (ALTER TABLE ADD COLUMN, data moves, FK drops, etc.).
+// Each migration is idempotent and checks whether its changes have already
+// been applied.
+func RunCompatMigrations(db *sql.DB) error {
+	for _, m := range compatMigrationsList {
+		if err := m.Func(db); err != nil {
+			return fmt.Errorf("compat migration %q failed: %w", m.Name, err)
+		}
+	}
+
+	// Only stage and commit when compat migrations actually produced changes.
+	// Previously, DOLT_COMMIT was called unconditionally, causing a
+	// "nothing to commit" WARNING on the server for every bd invocation
+	// (94% of server log lines in one reported case). GH#3366.
+	var dirtyCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM dolt_status").Scan(&dirtyCount); err != nil {
+		// dolt_status might not be available (e.g. older servers); fall through
+		// to the original behavior as a safe fallback.
+		dirtyCount = 1
+	}
+	if dirtyCount == 0 {
+		return nil
+	}
+
+	// GH#2455: Stage only schema tables (not config) to avoid sweeping up
+	// stale issue_prefix changes from concurrent operations.
+	migrationTables := []string{
+		"issues", "wisps", "events", "wisp_events", "dependencies",
+		"wisp_dependencies", "labels", "wisp_labels", "comments",
+		"wisp_comments", "metadata", "child_counters", "issue_counter",
+		"issue_snapshots", "compaction_snapshots", "federation_peers",
+		"custom_statuses", "custom_types",
+		"dolt_ignore",
+	}
+	for _, table := range migrationTables {
+		_, _ = db.Exec("CALL DOLT_ADD(?)", table)
+	}
+	_, err := db.Exec("CALL DOLT_COMMIT('-m', 'schema: auto-migrate')")
+	if err != nil {
+		if !strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
+			log.Printf("dolt compat migration commit warning: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// ListCompatMigrations returns the names of all registered compat migrations.
+func ListCompatMigrations() []string {
+	names := make([]string, len(compatMigrationsList))
+	for i, m := range compatMigrationsList {
+		names[i] = m.Name
+	}
+	return names
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -39,6 +39,7 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
@@ -1482,10 +1483,10 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		}
 	}
 
-	// Run DoltStore-specific backward-compat migrations for databases that
-	// predate the embedded migration system (e.g. ALTER TABLE ADD COLUMN,
-	// historical data transforms). These are idempotent.
-	if err := RunCompatMigrations(db); err != nil {
+	// Run backward-compat migrations for databases that predate the embedded
+	// migration system (e.g. ALTER TABLE ADD COLUMN, historical data
+	// transforms). These are idempotent.
+	if err := migrations.RunCompatMigrations(db); err != nil {
 		return fmt.Errorf("failed to run compat migrations: %w", err)
 	}
 

--- a/internal/storage/embeddeddolt/compat_migrations_test.go
+++ b/internal/storage/embeddeddolt/compat_migrations_test.go
@@ -1,0 +1,99 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+)
+
+// TestEmbeddedOpenRunsCompatMigrations verifies that opening an existing
+// embedded Dolt database with a newer bd binary runs the idempotent compat
+// migrations that repair column-shape drift. Regression test for GH#3412.
+//
+// Setup:
+//  1. Initialize a fresh embedded store (creates all tables + runs SQL
+//     migrations, including the one that adds issues.started_at).
+//  2. Simulate a pre-existing DB whose SQL migration for started_at was
+//     recorded as applied but never actually produced the column — drop the
+//     column while leaving schema_migrations intact.
+//  3. Close and reopen the store.
+//
+// If compat migrations are NOT wired into the embedded open path, the column
+// stays missing and any subsequent query referencing started_at fails with
+// "column started_at could not be found". With the wiring in place, compat
+// migration 017 (MigrateAddStartedAtColumn) adds it back.
+func TestEmbeddedOpenRunsCompatMigrations(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+
+	ctx := t.Context()
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+
+	// Step 1: fresh init — schema.MigrateUp adds all columns including started_at.
+	store, err := embeddeddolt.New(ctx, beadsDir, "testdb", "main")
+	if err != nil {
+		t.Fatalf("initial New: %v", err)
+	}
+
+	// Step 2: drop issues.started_at to simulate a DB that predates (or was
+	// stranded missing) the started_at SQL migration, WITHOUT rolling back
+	// schema_migrations. This is the exact shape of the bug: schema_migrations
+	// says the migration ran, but the column is absent, and the compat runner
+	// is the only path that repairs it.
+	db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, "testdb", "main")
+	if err != nil {
+		store.Close()
+		t.Fatalf("OpenSQL for setup: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "ALTER TABLE `issues` DROP COLUMN started_at"); err != nil {
+		cleanup()
+		store.Close()
+		t.Fatalf("dropping started_at for test setup: %v", err)
+	}
+	cleanup()
+	store.Close()
+
+	// Step 3: reopen. If compat migrations are wired in, this repairs the
+	// column via MigrateAddStartedAtColumn.
+	store2, err := embeddeddolt.New(ctx, beadsDir, "testdb", "main")
+	if err != nil {
+		t.Fatalf("reopen New: %v", err)
+	}
+	defer store2.Close()
+
+	db2, cleanup2, err := embeddeddolt.OpenSQL(ctx, dataDir, "testdb", "main")
+	if err != nil {
+		t.Fatalf("OpenSQL for verification: %v", err)
+	}
+	defer cleanup2()
+
+	// The column must now exist. SHOW COLUMNS LIKE returns a row on hit,
+	// no rows on miss — mirrors the shape of migrations.columnExists.
+	rows, err := db2.QueryContext(ctx, "SHOW COLUMNS FROM `issues` LIKE 'started_at'")
+	if err != nil {
+		t.Fatalf("SHOW COLUMNS: %v", err)
+	}
+	found := rows.Next()
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		t.Fatalf("iterating SHOW COLUMNS: %v", err)
+	}
+	rows.Close()
+	if !found {
+		t.Fatal("issues.started_at missing after reopen — compat migration runner did not execute on embedded open path")
+	}
+
+	// Sanity check: a SELECT that references the column must succeed, proving
+	// the exact original failure mode ("column … could not be found in any
+	// table in scope") is repaired.
+	if _, err := db2.ExecContext(ctx, "SELECT started_at FROM `issues` LIMIT 0"); err != nil {
+		t.Fatalf("SELECT started_at after compat migration: %v", err)
+	}
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
@@ -232,8 +233,14 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 // committing them to Dolt history. Uses withRootConn so the database can be
 // created before USE; this avoids running CREATE DATABASE inside withConn,
 // which is not safe for concurrent use in the embedded Dolt engine.
+//
+// After the schema-migration transaction commits, a fresh *sql.DB is opened
+// and used to drive the idempotent compat-migration runner. Mirrors the
+// server-mode open path in dolt/store.go:initSchemaOnDB and repairs
+// pre-existing embedded databases that predate the embedded migration
+// system's full coverage (GH#3412).
 func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
-	return s.withRootConn(ctx, true, func(tx *sql.Tx) error {
+	if err := s.withRootConn(ctx, true, func(tx *sql.Tx) error {
 		if s.database != "" {
 			if !validIdentifier.MatchString(s.database) {
 				msg := fmt.Sprintf("embeddeddolt: invalid database name: %q", s.database)
@@ -279,7 +286,25 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+
+	// Run idempotent compat migrations on a fresh connection scoped to the
+	// newly-created database and branch. The embedded migration system only
+	// covers databases created from fresh init; pre-existing databases that
+	// predate specific SQL migrations need the defensive compat runner to
+	// repair missing columns and tables (GH#3412).
+	db, cleanup, err := OpenSQL(ctx, s.dataDir, s.database, s.branch)
+	if err != nil {
+		return fmt.Errorf("embeddeddolt: open for compat migrations: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	if err := migrations.RunCompatMigrations(db); err != nil {
+		return fmt.Errorf("embeddeddolt: compat migrations: %w", err)
+	}
+	return nil
 }
 
 // ensureIgnoredTables creates dolt_ignore'd wisp tables if they don't exist.


### PR DESCRIPTION
Fixes #3412. Refs #3400.

## Problem

`RunCompatMigrations` was called only from the server-mode open path at `dolt.initSchemaOnDB` (`internal/storage/dolt/store.go:1445`). The embedded backend's open path (`EmbeddedDoltStore.initSchema`) ran `schema.MigrateUp` and stopped. Pre-existing embedded databases opened by a newer `bd` binary therefore skipped every compat migration 001–017, leaving missing columns and tables unrepaired.

The symptom is `Error 1105 (HY000): column "<name>" could not be found in any table in scope` for any query referencing a column added by a compat migration. Fresh `bd init` was unaffected because the embedded SQL migration system runs cleanly on new databases.

## Fix (Option B: relocate the runner)

The runner has no coupling to `package dolt` — it drives idempotent migration functions that already live in `internal/storage/dolt/migrations/`. Relocating `CompatMigration`, `compatMigrationsList`, `RunCompatMigrations`, and `ListCompatMigrations` into `package migrations` puts them alongside the functions they drive, and lets both the server and embedded backends share them without a cross-backend import.

This is a mechanical relocation: the registry list, iteration logic, and dolt staging/commit behaviour are preserved exactly. Only the import paths and function receiver package change.

### Option A considered and rejected

Making `package embeddeddolt` import `package dolt` directly would give `embeddeddolt` a dependency on the server backend's package just to call a backend-agnostic utility. The utility has nothing to do with server semantics — `package migrations` is its correct architectural home.

## Changes

- **New** `internal/storage/dolt/migrations/runner.go` — receives the moved runner, registry, and List function.
- **Modified** `internal/storage/dolt/migrations.go` — trimmed to `CreateIgnoredTables`.
- **Modified** `internal/storage/dolt/store.go` — `RunCompatMigrations(db)` → `migrations.RunCompatMigrations(db)`.
- **Modified** `cmd/bd/migrate.go` — `dolt.ListCompatMigrations()` → `migrations.ListCompatMigrations()`. (This call site wasn't surfaced in the initial scope estimate but is required for compile after relocating the symbol.)
- **Modified** `internal/storage/embeddeddolt/store.go` — after the schema-migration `withRootConn` tx commits, open a fresh `*sql.DB` via `OpenSQL` and call `migrations.RunCompatMigrations`.
- **New** `internal/storage/embeddeddolt/compat_migrations_test.go` — regression test: init fresh embedded DB, drop `issues.started_at` to simulate the stranded-migration state (column missing but `schema_migrations` intact), reopen, assert the compat runner re-adds the column and a `SELECT started_at` succeeds.

Diff: 4 modified, 2 new, +229 / −98 lines.

## Verification

- `go build -tags gms_pure_go ./...` — clean.
- `go vet -tags gms_pure_go ./...` — clean.
- `go test -tags gms_pure_go ./internal/storage/dolt/ ./internal/storage/dolt/migrations/ ./cmd/bd/` — passes. (The `migrations/` subpackage tests skip locally when no test Dolt server is running, as designed.)
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go -run TestEmbeddedOpenRunsCompatMigrations -v ./internal/storage/embeddeddolt/` — passes.
- Smoke test against a real bd binary built from this branch (`bd-phase0.exe`), in a fresh embedded-mode workspace:
  - `bd init --prefix smoke` — succeeds.
  - `bd create "smoke phase0 create" -t task -p 2 --json` — succeeds; issue `smoke-o15` created.
  - `bd show smoke-o15` — succeeds; renders issue header, owner, type, dates, description.
  - `bd list` and `bd list --status=open` — succeed; the `--status` variant exercises the `IssueSelectColumns` filter codepath that was the original symptom surface.
  - `bd dep list smoke-o15` — succeeds; reports `no dependencies`.

The handoff that spawned this PR cited a pre-existing embedded DB as a canonical broken example; that DB is actually on server mode locally, so the stranded-column scenario isn't reproducible end-to-end against a real binary here. The unit regression test covers the stranded-column repair path directly; the smoke test above covers "compat runner on embedded open doesn't regress normal operation."

## Scope guards

- Relocation only. No changes to individual compat migration bodies, no changes to the registry ordering, no changes to the embedded SQL migration system.
- No shared-server drift detection (separate concern).
- No `bd dolt upgrade` subcommand (separate concern).
- No migration-upgrade CI harness (separate concern).

## Blast radius beyond the immediate symptom

Every compat migration 001–017 is currently stranded on pre-existing embedded DBs. Migration 017 (`add_started_at_column`, GH#3363) surfaces the same class of bug — the compat runner is the defensive repair path for exactly this shape of drift, but was never wired into the embedded open path. This PR closes that gap for all existing migrations and any future ones.
