### PR TITLE
feat(nix): turn packages into an overlay to allow for overriding

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  self,
   buildGoModule,
   git,
   icu,
@@ -10,7 +9,7 @@ buildGoModule {
   pname = "beads";
   version = "1.0.2";
 
-  src = self;
+  src = ./.;
 
   # Point to the main Go package
   subPackages = [ "cmd/bd" ];
@@ -33,8 +32,8 @@ buildGoModule {
   env.GOTOOLCHAIN = "auto";
   # Due to https://github.com/dolthub/go-icu-regex, which requires
   # separate install of icu headers and library.
-  env.CGO_CPPFLAGS="-I${icu.dev}/include";
-  env.CGO_LDFLAGS="-L${icu}/lib";
+  env.CGO_CPPFLAGS = "-I${icu.dev}/include";
+  env.CGO_LDFLAGS = "-L${icu}/lib";
 
   # Git is required for tests
   nativeBuildInputs = [ git ];

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
 
   outputs =
     {
-      self,
       nixpkgs,
+      ...
     }:
     let
       systems = [
@@ -19,19 +19,14 @@
       ];
 
       forAllSystems =
-        f:
-        nixpkgs.lib.genAttrs systems (
-          system:
-          f {
-            pkgs = import nixpkgs {
-              inherit system;
-            };
-            inherit system self;
-          }
-        );
-    in rec {
+        f: overlays: nixpkgs.lib.genAttrs systems (system: f (import nixpkgs { inherit system overlays; }));
+
+      overlay = import ./overlay.nix;
+    in
+    {
       icu = nixpkgs.icu77;
-      packages = forAllSystems (args: import ./packages.nix (args // { inherit icu; }));
+      packages = forAllSystems (import ./packages.nix) [ overlay ];
+      overlay.default = overlay;
 
       apps = forAllSystems (
         { self, system, ... }:

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,46 @@
+final: prev: {
+  beads-unwrapped = final.callPackage ./default.nix { };
+
+  beads = final.stdenv.mkDerivation {
+    pname = "beads";
+    version = final.beads-unwrapped.version;
+
+    phases = [ "installPhase" ];
+
+    installPhase = ''
+      mkdir -p $out/bin
+      cp ${final.beads-unwrapped}/bin/bd $out/bin/bd
+
+      # Create 'beads' alias symlink
+      ln -s bd $out/bin/beads
+
+      # Generate shell completions
+      mkdir -p $out/share/fish/vendor_completions.d
+      mkdir -p $out/share/bash-completion/completions
+      mkdir -p $out/share/zsh/site-functions
+
+      $out/bin/bd completion fish > $out/share/fish/vendor_completions.d/bd.fish
+      $out/bin/bd completion bash > $out/share/bash-completion/completions/bd
+      $out/bin/bd completion zsh > $out/share/zsh/site-functions/_bd
+    '';
+
+    meta = final.beads-unwrapped.meta;
+
+    passthru = {
+      fish-completions = final.runCommand "bd-fish-completions" { } ''
+        mkdir -p $out/share/fish/vendor_completions.d
+        ln -s ${final.beads}/share/fish/vendor_completions.d/bd.fish $out/share/fish/vendor_completions.d/bd.fish
+      '';
+
+      bash-completions = final.runCommand "bd-bash-completions" { } ''
+        mkdir -p $out/share/bash-completion/completions
+        ln -s ${final.beads}/share/bash-completion/completions/bd $out/share/bash-completion/completions/bd
+      '';
+
+      zsh-completions = final.runCommand "bd-zsh-completions" { } ''
+        mkdir -p $out/share/zsh/site-functions
+        ln -s ${final.beads}/share/zsh/site-functions/_bd $out/share/zsh/site-functions/_bd
+      '';
+    };
+  };
+}

--- a/packages.nix
+++ b/packages.nix
@@ -1,51 +1,7 @@
-{ pkgs, self, ... }:
-let
-  bdBase = pkgs.callPackage ./default.nix { inherit self; };
-
-  # Wrap the base package with shell completions baked in
-  bd = pkgs.stdenv.mkDerivation {
-    pname = "beads";
-    version = bdBase.version;
-
-    phases = [ "installPhase" ];
-
-    installPhase = ''
-      mkdir -p $out/bin
-      cp ${bdBase}/bin/bd $out/bin/bd
-
-      # Create 'beads' alias symlink
-      ln -s bd $out/bin/beads
-
-      # Generate shell completions
-      mkdir -p $out/share/fish/vendor_completions.d
-      mkdir -p $out/share/bash-completion/completions
-      mkdir -p $out/share/zsh/site-functions
-
-      $out/bin/bd completion fish > $out/share/fish/vendor_completions.d/bd.fish
-      $out/bin/bd completion bash > $out/share/bash-completion/completions/bd
-      $out/bin/bd completion zsh > $out/share/zsh/site-functions/_bd
-    '';
-
-    meta = bdBase.meta;
-  };
-  default = bd;
-in
-{
-  inherit default bd;
-
-  # Separate completion packages for users who only want specific shells
-  fish-completions = pkgs.runCommand "bd-fish-completions" { } ''
-    mkdir -p $out/share/fish/vendor_completions.d
-    ln -s ${bd}/share/fish/vendor_completions.d/bd.fish $out/share/fish/vendor_completions.d/bd.fish
-  '';
-
-  bash-completions = pkgs.runCommand "bd-bash-completions" { } ''
-    mkdir -p $out/share/bash-completion/completions
-    ln -s ${bd}/share/bash-completion/completions/bd $out/share/bash-completion/completions/bd
-  '';
-
-  zsh-completions = pkgs.runCommand "bd-zsh-completions" { } ''
-    mkdir -p $out/share/zsh/site-functions
-    ln -s ${bd}/share/zsh/site-functions/_bd $out/share/zsh/site-functions/_bd
-  '';
+pkgs: {
+  default = pkgs.beads;
+  bd = pkgs.beads;
+  fish-completions = pkgs.beads.passthru.fish-completions;
+  bash-completions = pkgs.beads.passthru.bash-completions;
+  zsh-completions = pkgs.beads.passthru.zsh-completions;
 }


### PR DESCRIPTION
## Summary
Turn the nix packages into an overlay so they can be more easily overridden.

## Details
Currently the exported bd / default package is a stdenv.mkDerivation wrapper around the `callPackage` beads package which makes it impossible to use the regular `bd.override` pattern provided by callPackage. By restructuring it into an overlay first, and providing that overlays as an output downstream consumers can more easily consume the package with their own nixpkgs version as well as override its inputs. 

e.g.

```nix
final: prev: {
  beads-unwrapped = prev.beads-unwrapped.override (prevArgs: {
    goBuildModule = args: prevArgs.goBuildModule (args // { vendorHash = "someNewhash"; });
  });
}