### PR TITLE
fix(config): reject bd config set issue-prefix with actionable error

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -85,7 +85,7 @@ var configSetCmd = &cobra.Command{
 
 		// Reject keys that look like init-only state so the user does not
 		// silently land a write in a store that 'bd create' never reads.
-		// bd-f4m: 'bd config set issue-prefix' used to write DB key "issue-prefix"
+		// 'bd config set issue-prefix' used to write DB key "issue-prefix"
 		// (dash) while 'bd create' only reads YAML "issue-prefix" or DB
 		// "issue_prefix" (underscore) — three divergent stores, write never
 		// visible.
@@ -769,7 +769,7 @@ func isRecognizedConfigKey(key string) bool {
 
 // rejectProtectedConfigKey rejects keys that are owned by a dedicated
 // lifecycle command (init/rename) rather than 'bd config set'. The canonical
-// example (bd-f4m) is issue_prefix: 'bd create' reads YAML "issue-prefix"
+// example is issue_prefix: 'bd create' reads YAML "issue-prefix"
 // then DB "issue_prefix", while 'bd config set' would land in DB
 // "issue-prefix" — a third key no reader consults. Accepting either the
 // dash or underscore form silently produces a write that looks like it

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -83,6 +83,17 @@ var configSetCmd = &cobra.Command{
 		key := args[0]
 		value := args[1]
 
+		// Reject keys that look like init-only state so the user does not
+		// silently land a write in a store that 'bd create' never reads.
+		// bd-f4m: 'bd config set issue-prefix' used to write DB key "issue-prefix"
+		// (dash) while 'bd create' only reads YAML "issue-prefix" or DB
+		// "issue_prefix" (underscore) — three divergent stores, write never
+		// visible.
+		if msg, rejected := rejectProtectedConfigKey(key); rejected {
+			fmt.Fprintln(os.Stderr, msg)
+			os.Exit(1)
+		}
+
 		// Warn on unrecognized config keys so typos don't silently become
 		// no-ops. The custom.* namespace is exempt (user-extensible). GH#3293.
 		if !isRecognizedConfigKey(key) {
@@ -754,6 +765,25 @@ func isRecognizedConfigKey(key string) bool {
 		}
 	}
 	return false
+}
+
+// rejectProtectedConfigKey rejects keys that are owned by a dedicated
+// lifecycle command (init/rename) rather than 'bd config set'. The canonical
+// example (bd-f4m) is issue_prefix: 'bd create' reads YAML "issue-prefix"
+// then DB "issue_prefix", while 'bd config set' would land in DB
+// "issue-prefix" — a third key no reader consults. Accepting either the
+// dash or underscore form silently produces a write that looks like it
+// succeeded but is never visible to 'bd create'. Reject both and point the
+// user at the right command.
+func rejectProtectedConfigKey(key string) (string, bool) {
+	switch key {
+	case "issue_prefix", "issue-prefix":
+		return "Error: issue_prefix cannot be set via 'bd config set'.\n" +
+			"  - New project:       bd init --prefix <prefix>\n" +
+			"  - Fresh clone:       bd bootstrap\n" +
+			"  - Rename existing:   bd rename-prefix <new-prefix>", true
+	}
+	return "", false
 }
 
 // suggestConfigKey tries to find a close match for a mistyped key by checking

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -52,7 +52,7 @@ func TestRejectProtectedConfigKey(t *testing.T) {
 			t.Errorf("rejectProtectedConfigKey(%q) = (_, false), want rejected", key)
 			continue
 		}
-		// Error message must surface the alternatives bd-f4m asks for.
+		// Error message must surface the three lifecycle alternatives.
 		wantSubstrings := []string{"bd init --prefix", "bd bootstrap", "bd rename-prefix"}
 		for _, want := range wantSubstrings {
 			if !strings.Contains(msg, want) {

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsRecognizedConfigKey(t *testing.T) {
 	recognized := []string{
@@ -37,6 +40,31 @@ func TestSuggestConfigKey(t *testing.T) {
 		got := suggestConfigKey(tt.input)
 		if got != tt.want {
 			t.Errorf("suggestConfigKey(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestRejectProtectedConfigKey(t *testing.T) {
+	rejectedKeys := []string{"issue_prefix", "issue-prefix"}
+	for _, key := range rejectedKeys {
+		msg, rejected := rejectProtectedConfigKey(key)
+		if !rejected {
+			t.Errorf("rejectProtectedConfigKey(%q) = (_, false), want rejected", key)
+			continue
+		}
+		// Error message must surface the alternatives bd-f4m asks for.
+		wantSubstrings := []string{"bd init --prefix", "bd bootstrap", "bd rename-prefix"}
+		for _, want := range wantSubstrings {
+			if !strings.Contains(msg, want) {
+				t.Errorf("rejectProtectedConfigKey(%q) message missing %q; got:\n%s", key, want, msg)
+			}
+		}
+	}
+
+	allowedKeys := []string{"allowed_prefixes", "export.auto", "status.custom", "custom.anything"}
+	for _, key := range allowedKeys {
+		if _, rejected := rejectProtectedConfigKey(key); rejected {
+			t.Errorf("rejectProtectedConfigKey(%q) = (_, true), want not rejected", key)
 		}
 	}
 }

--- a/internal/storage/issueops/helpers.go
+++ b/internal/storage/issueops/helpers.go
@@ -501,7 +501,7 @@ func ReadConfigPrefix(ctx context.Context, tx *sql.Tx) (string, error) {
 	var configPrefix string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "issue_prefix").Scan(&configPrefix)
 	if err == sql.ErrNoRows || configPrefix == "" {
-		return "", fmt.Errorf("%w: issue_prefix config is missing (run 'bd init --prefix <prefix>' first)", storage.ErrNotInitialized)
+		return "", fmt.Errorf("%w: issue_prefix config is missing (run 'bd init --prefix <prefix>' for a new project, or 'bd bootstrap' to clone an existing remote)", storage.ErrNotInitialized)
 	} else if err != nil {
 		return "", fmt.Errorf("failed to get config: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fix `bd config set issue-prefix <val>` silently writing to a dead DB key, leaving the user unable to create issues after what looked like a successful config change.

The divergence (three stores for one logical value):

- **Reader** at `cmd/bd/create.go:447–450`: YAML `issue-prefix` → DB `issue_prefix` (underscore fallback)
- **Writer** at `cmd/bd/config.go:161`: `bd config set issue-prefix X` → DB `issue-prefix` (dash)
- `issue-prefix` is not a yaml-only key, so `bd config set` never lands in YAML either

Net effect: write reports success, read never sees it.

### Changes Made

- **Reject `bd config set issue-prefix` and `bd config set issue_prefix`** at the top of the config-set handler, with an actionable error listing the three commands that own the prefix lifecycle:
  - `bd init --prefix <prefix>` — new project
  - `bd bootstrap` — fresh clone
  - `bd rename-prefix <new-prefix>` — existing project rename
- **Added `rejectProtectedConfigKey` helper** co-located with `isRecognizedConfigKey` so the list of lifecycle-owned keys lives in one place.
- **Improved the "issue_prefix config is missing" hint** at `internal/storage/issueops/helpers.go` to mention `bd bootstrap` alongside `bd init --prefix`, so the fresh-clone path is directed at the right command.
- **Unit test** locks in the rejected keys, the required error substrings, and a control set of adjacent keys that must continue to work (`allowed_prefixes`, `export.auto`, `status.custom`, `custom.*`).

### Backward Compatibility

- **Same behavior** for every other config key — `allowed_prefixes`, `export.*`, `status.custom`, `custom.*`, `jira.*`, `linear.*`, etc. continue to work unchanged.
- **Breaking change for one path**: `bd config set issue-prefix X` and `bd config set issue_prefix X` now exit non-zero instead of reporting success. **Users who were relying on the prior behavior were already broken** — the "success" was followed by `bd create` errors — so this replaces a silent misconfiguration with a loud one. The error text tells them exactly which command to run instead.

### Technical Details

Guard fires at the very top of the `Run` handler, before `IsYamlOnlyKey`, before the `beads.role` git-config branch, and before any DB access. Both dash and underscore forms are rejected so users can't stumble onto the "underscore happens to land in the right place" path by accident — that would still bypass `bd init` / `bd rename-prefix` semantics.

### Benefits

- **Removes the silent-success bug class** for one key; the same helper can cover future lifecycle-owned keys.
- **Fresh-clone UX improvement**: "missing issue_prefix" no longer exclusively points at `bd init` (which would re-initialize and potentially conflict with a clone).
- **Test coverage** will catch regression if someone ever changes the rejected-key list silently.

### Related

- **GH#1145** (closed, PR #1146): the original "config uses dash, internals use underscore" fix. The fresh bug was a missed surface on the write side; this PR closes that remaining gap.

### Size: Small

~60 lines of code + test + one-line error message improvement; tight, well-scoped, with complete regression test coverage.

🤖 Generated with [Claude Code](https://claude.ai/code)