### PR TITLE
fix(worktree): don't prefer inherited .beads/ over shared fallback

### DIFF
--- a/cmd/bd/where.go
+++ b/cmd/bd/where.go
@@ -109,14 +109,18 @@ func findOriginalBeadsDir() string {
 		cwd = resolved
 	}
 
-	// Check BEADS_DIR first
+	// Check BEADS_DIR first: if the env points at a .beads directory with a
+	// redirect file, that's the original. Fall through to the fs walk if
+	// BEADS_DIR is set but does not contain a redirect — bd's startup now
+	// rebinds BEADS_DIR to the resolved target (#3230) after following
+	// redirects, so an unconditional early-return here would hide every
+	// redirect from `bd where` output.
 	if envDir := os.Getenv("BEADS_DIR"); envDir != "" {
 		envDir = utils.CanonicalizePath(envDir)
 		redirectFile := filepath.Join(envDir, beads.RedirectFileName)
 		if _, err := os.Stat(redirectFile); err == nil {
 			return envDir
 		}
-		return ""
 	}
 
 	// Walk up directory tree looking for .beads with redirect

--- a/cmd/bd/where_test.go
+++ b/cmd/bd/where_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+)
+
+// TestFindOriginalBeadsDir_BeadsDirEnvWithoutRedirectFallsThrough guards
+// against a regression where `bd where` silently dropped its "(via redirect
+// from ...)" footnote after #3230 started rebinding BEADS_DIR to the
+// post-redirect target. Before the fix, an early `return ""` when BEADS_DIR
+// was set but had no redirect file short-circuited the filesystem walk,
+// so `bd where` from inside a redirecting worktree never reported the
+// redirect source.
+//
+// Scenario: worktree's .beads/ holds a redirect file pointing to the
+// shared .beads/, and BEADS_DIR has been set to the shared target (as
+// bd's own startup does for rebound commands). findOriginalBeadsDir must
+// still walk up from cwd and discover the worktree's redirecting .beads/.
+func TestFindOriginalBeadsDir_BeadsDirEnvWithoutRedirectFallsThrough(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Redirect source: worktree/.beads/ with a redirect file.
+	worktreeRoot := filepath.Join(tmp, "worktree")
+	worktreeBeads := filepath.Join(worktreeRoot, ".beads")
+	if err := os.MkdirAll(worktreeBeads, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(tmp, "main", ".beads")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	redirectFile := filepath.Join(worktreeBeads, beads.RedirectFileName)
+	if err := os.WriteFile(redirectFile, []byte(target), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate bd's post-rebind state: BEADS_DIR points at the resolved
+	// target, which does NOT carry a redirect file.
+	t.Setenv("BEADS_DIR", target)
+	t.Chdir(worktreeRoot)
+
+	got := findOriginalBeadsDir()
+	if got == "" {
+		t.Fatal("findOriginalBeadsDir returned empty; expected the redirecting worktree .beads/")
+	}
+	// Compare by base+parent since /var vs /private/var may be resolved either way.
+	if !strings.HasSuffix(got, filepath.Join("worktree", ".beads")) {
+		t.Errorf("findOriginalBeadsDir = %q, want a path ending in worktree/.beads", got)
+	}
+}
+
+// TestFindOriginalBeadsDir_BeadsDirEnvWithRedirectReturnsEnv keeps the
+// BEADS_DIR fast path working when the env var itself points at a
+// redirecting directory (a user-set BEADS_DIR override). The env value
+// should win without a filesystem walk.
+func TestFindOriginalBeadsDir_BeadsDirEnvWithRedirectReturnsEnv(t *testing.T) {
+	tmp := t.TempDir()
+	envBeads := filepath.Join(tmp, "alt", ".beads")
+	if err := os.MkdirAll(envBeads, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(tmp, "shared", ".beads")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(envBeads, beads.RedirectFileName), []byte(target), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run cwd from an unrelated directory so the fs walk alone cannot find
+	// the redirect — only the BEADS_DIR env check can.
+	unrelated := filepath.Join(tmp, "unrelated")
+	if err := os.MkdirAll(unrelated, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", envBeads)
+	t.Chdir(unrelated)
+
+	got := findOriginalBeadsDir()
+	// Compare by suffix for macOS /var vs /private/var differences.
+	if !strings.HasSuffix(got, filepath.Join("alt", ".beads")) {
+		t.Errorf("findOriginalBeadsDir = %q, want a path ending in alt/.beads", got)
+	}
+}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -862,11 +862,13 @@ func findDatabaseInTree() string {
 		return ""
 	}
 
-	// Resolve symlinks in working directory to ensure consistent path handling
-	// This prevents issues when repos are accessed via symlinks (e.g. /Users/user/Code -> /Users/user/Documents/Code)
-	if resolvedDir, err := filepath.EvalSymlinks(dir); err == nil {
-		dir = resolvedDir
-	}
+	// Canonicalize the starting directory so the gitRoot boundary comparison
+	// below matches. utils.CanonicalizePath resolves symlinks AND normalizes
+	// case on macOS/Windows — the same form git helpers return — so the
+	// eventual `dir == gitRoot` check doesn't silently overshoot on
+	// /var → /private/var or case-insensitive filesystems. Matches the
+	// canonicalization strategy in FindBeadsDir.
+	dir = utils.CanonicalizePath(dir)
 
 	// Check cwd first — a rig subdirectory with its own .beads/ takes
 	// priority over the git root's .beads/ (same fix as FindBeadsDir step 1b).
@@ -923,6 +925,12 @@ func findDatabaseInTree() string {
 		// For worktrees, extend search boundary to include main repo
 		gitRoot = mainRepoRoot
 	}
+	// Canonicalize the boundary so the `dir == gitRoot` comparison is robust
+	// against symlink or case-form mismatches between git helpers and os.Getwd.
+	gitRootCanonical := ""
+	if gitRoot != "" {
+		gitRootCanonical = utils.CanonicalizePath(gitRoot)
+	}
 
 	// Walk up directory tree (regular repository or worktree fallback)
 	for {
@@ -945,7 +953,7 @@ func findDatabaseInTree() string {
 		}
 
 		// Stop at git root to avoid finding unrelated databases
-		if gitRoot != "" && dir == gitRoot {
+		if gitRootCanonical != "" && dir == gitRootCanonical {
 			break
 		}
 

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -553,6 +553,34 @@ func hasBeadsProjectFiles(beadsDir string) bool {
 	return false
 }
 
+// hasBeadsDatabase is the strict counterpart to hasBeadsProjectFiles: it
+// returns true only when beadsDir contains an actual database — a dolt/
+// directory, an embeddeddolt/ directory, or a non-backup *.db file. Mere
+// presence of metadata.json / config.yaml / issues.jsonl does not count.
+//
+// Used by FindBeadsDir's worktree-separate-DB branch to distinguish a
+// genuine separate-database worktree (which owns its own Dolt data) from
+// a worktree that has inherited tracked .beads/ artifacts through a git
+// checkout of the parent repo's working-tree snapshot. Without this strict
+// check, the separate-DB branch would match on inherited metadata.json and
+// return a broken directory, short-circuiting the shared-DB fallback.
+func hasBeadsDatabase(beadsDir string) bool {
+	if info, err := os.Stat(filepath.Join(beadsDir, "dolt")); err == nil && info.IsDir() {
+		return true
+	}
+	if info, err := os.Stat(filepath.Join(beadsDir, "embeddeddolt")); err == nil && info.IsDir() {
+		return true
+	}
+	dbMatches, _ := filepath.Glob(filepath.Join(beadsDir, "*.db"))
+	for _, match := range dbMatches {
+		baseName := filepath.Base(match)
+		if !strings.Contains(baseName, ".backup") && baseName != "vc.db" {
+			return true
+		}
+	}
+	return false
+}
+
 // FindBeadsDir finds the .beads/ directory in the current directory tree.
 // Returns empty string if not found.
 //
@@ -610,12 +638,24 @@ func FindBeadsDir() string {
 		walkBoundary = git.GetRepoRoot()
 	}
 
-	for dir := cwd; dir != "/" && dir != "."; {
+	// Canonicalize both walk start and walk boundary so the `dir == walkBoundary`
+	// comparison below works even when the two come from different sources
+	// (os.Getwd() often returns unresolved symlinks like /var/... on macOS
+	// while git rev-parse returns the canonical /private/var/... form). Without
+	// this, the boundary check silently never matches and the walk overshoots
+	// the worktree root — finding an inherited .beads/ directory there and
+	// short-circuiting the worktree-fallback logic in step 3.
+	cwdCanonical := utils.CanonicalizePath(cwd)
+	walkBoundaryCanonical := ""
+	if walkBoundary != "" {
+		walkBoundaryCanonical = utils.CanonicalizePath(walkBoundary)
+	}
+	for dir := cwdCanonical; dir != "/" && dir != "."; {
 		// Stop at the walk boundary (exclusive — don't check this directory).
 		// For worktrees: stops before worktree root so step 3 handles it.
 		// For non-worktrees: stops before git root (which is checked below in the
 		// post-worktree walk, step 4).
-		if walkBoundary != "" && dir == walkBoundary {
+		if walkBoundaryCanonical != "" && dir == walkBoundaryCanonical {
 			break
 		}
 
@@ -648,11 +688,38 @@ func FindBeadsDir() string {
 			}
 		}
 
-		// 3b. Worktree's own .beads (separate-DB mode, no redirect)
+		// 3b. Worktree's own .beads (separate-DB mode, no redirect).
+		//
+		// Only accept the worktree-local .beads/ as separate-DB if it owns an
+		// actual database (dolt/, embeddeddolt/, or a *.db file). A worktree
+		// that only has metadata.json / config.yaml / issues.jsonl is almost
+		// certainly carrying tracked artifacts from the parent repo's
+		// working-tree snapshot — `git worktree add` checks them out, but the
+		// dolt/ data directory is gitignored and therefore absent. Returning
+		// such a directory short-circuits the shared-DB fallback (3c) and
+		// causes bd to spawn a sidecar Dolt server against an empty data
+		// directory, which cannot serve the project's database.
+		//
+		// If no fallback is available (non-worktree edge case, or the main
+		// repo itself has no .beads/), fall back to hasBeadsProjectFiles so a
+		// fresh `bd init` can still locate the nascent project directory.
 		if worktreeRoot := git.GetRepoRoot(); worktreeRoot != "" {
 			worktreeBeadsDir := filepath.Join(worktreeRoot, ".beads")
 			if info, err := os.Stat(worktreeBeadsDir); err == nil && info.IsDir() {
-				if hasBeadsProjectFiles(worktreeBeadsDir) {
+				if hasBeadsDatabase(worktreeBeadsDir) {
+					return worktreeBeadsDir
+				}
+				// Lenient acceptance only when there is no shared .beads with
+				// a real database to fall back to.
+				fallback := GetWorktreeFallbackBeadsDir()
+				fallbackHasDB := false
+				if fallback != "" {
+					if fbInfo, err := os.Stat(fallback); err == nil && fbInfo.IsDir() {
+						resolved := FollowRedirect(fallback)
+						fallbackHasDB = hasBeadsDatabase(resolved)
+					}
+				}
+				if !fallbackHasDB && hasBeadsProjectFiles(worktreeBeadsDir) {
 					return worktreeBeadsDir
 				}
 			}
@@ -685,8 +752,16 @@ func FindBeadsDir() string {
 		if isWt && mainRepoRoot != "" {
 			extendedRoot = mainRepoRoot
 		}
+		// Canonicalize the extended-root so the `dir == extendedRoot` check
+		// matches when extendedRoot came from a git helper (canonical) and
+		// the starting `dir` came from walkBoundary (also canonicalized
+		// above). Keeps the walk bounded on macOS-style /var → /private/var.
+		extendedRootCanonical := ""
+		if extendedRoot != "" {
+			extendedRootCanonical = utils.CanonicalizePath(extendedRoot)
+		}
 
-		for dir := walkBoundary; dir != "/" && dir != "."; {
+		for dir := walkBoundaryCanonical; dir != "/" && dir != "."; {
 			beadsDir := filepath.Join(dir, ".beads")
 			if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
 				beadsDir = FollowRedirect(beadsDir)
@@ -696,7 +771,7 @@ func FindBeadsDir() string {
 			}
 
 			// Stop at the extended root
-			if extendedRoot != "" && dir == extendedRoot {
+			if extendedRootCanonical != "" && dir == extendedRootCanonical {
 				break
 			}
 

--- a/internal/beads/beads_inherited_artifacts_test.go
+++ b/internal/beads/beads_inherited_artifacts_test.go
@@ -213,3 +213,207 @@ func TestFindBeadsDir_WorktreeSeparateDBPreservesLocal(t *testing.T) {
 			result, worktreeBeadsDir)
 	}
 }
+
+// TestFindBeadsDir_WorktreeSeparateDBPreservesLocalWithDoltDir is the same
+// separate-DB regression guard but exercises the `dolt/` directory branch of
+// hasBeadsDatabase (server mode) rather than the *.db branch.
+func TestFindBeadsDir_WorktreeSeparateDBPreservesLocalWithDoltDir(t *testing.T) {
+	runWorktreeSeparateDBPreservedTest(t, "dolt")
+}
+
+// TestFindBeadsDir_WorktreeSeparateDBPreservesLocalWithEmbeddedDolt exercises
+// the `embeddeddolt/` directory branch of hasBeadsDatabase (embedded-engine
+// mode) for the separate-DB regression guard.
+func TestFindBeadsDir_WorktreeSeparateDBPreservesLocalWithEmbeddedDolt(t *testing.T) {
+	runWorktreeSeparateDBPreservedTest(t, "embeddeddolt")
+}
+
+// runWorktreeSeparateDBPreservedTest is shared by the three separate-DB
+// regression tests. databaseMarker names what to create inside the worktree's
+// .beads/ so hasBeadsDatabase returns true: "dolt" / "embeddeddolt" (directory)
+// or "beads.db" (file).
+func runWorktreeSeparateDBPreservedTest(t *testing.T, databaseMarker string) {
+	t.Helper()
+
+	originalEnv := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("BEADS_DIR", originalEnv)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir, err := os.MkdirTemp("", "beads-separate-db-variant-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit(mainRepoDir, "config", "user.email", "test@example.com")
+	runGit(mainRepoDir, "config", "user.name", "Test User")
+
+	// Main repo has a real DB so the shared fallback would win if the
+	// worktree's own database weren't recognized.
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainBeadsDir, "beads.db"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(mainRepoDir, "add", "README.md")
+	runGit(mainRepoDir, "commit", "-m", "initial")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	runGit(mainRepoDir, "worktree", "add", worktreeDir, "HEAD")
+	defer func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	}()
+
+	worktreeBeadsDir := filepath.Join(worktreeDir, ".beads")
+	if err := os.MkdirAll(worktreeBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	switch databaseMarker {
+	case "dolt", "embeddeddolt":
+		if err := os.MkdirAll(filepath.Join(worktreeBeadsDir, databaseMarker), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		if err := os.WriteFile(filepath.Join(worktreeBeadsDir, databaseMarker), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	result := FindBeadsDir()
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	worktreeResolved, _ := filepath.EvalSymlinks(worktreeBeadsDir)
+
+	if resultResolved != worktreeResolved {
+		t.Errorf("FindBeadsDir() = %q, want worktree .beads %q (separate-DB mode via %q)",
+			result, worktreeBeadsDir, databaseMarker)
+	}
+}
+
+// TestFindBeadsDir_WorktreeNoDatabaseAnywhereFallsBackToLocal exercises the
+// lenient-fallback escape hatch in step 3b: when the worktree has inherited
+// metadata but no database AND the shared fallback also has no database,
+// FindBeadsDir should return the worktree-local .beads/ so a fresh
+// `bd init` in the worktree can still bootstrap. If the strict check ran
+// unconditionally, a brand-new worktree with no main-repo database would
+// return empty and block init.
+func TestFindBeadsDir_WorktreeNoDatabaseAnywhereFallsBackToLocal(t *testing.T) {
+	originalEnv := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("BEADS_DIR", originalEnv)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir, err := os.MkdirTemp("", "beads-no-db-anywhere-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit(mainRepoDir, "config", "user.email", "test@example.com")
+	runGit(mainRepoDir, "config", "user.name", "Test User")
+
+	// Main repo has a .beads/ with metadata only — NO database. This is the
+	// "pre-bd-init" state on both sides.
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainBeadsDir, "metadata.json"), []byte(`{"database":"dolt"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainBeadsDir, ".gitignore"), []byte("*.db\ndolt/\nembeddeddolt/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(mainRepoDir, "add", "README.md", ".beads/metadata.json", ".beads/.gitignore")
+	runGit(mainRepoDir, "commit", "-m", "seed .beads without db")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	runGit(mainRepoDir, "worktree", "add", worktreeDir, "HEAD")
+	defer func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	}()
+
+	worktreeBeadsDir := filepath.Join(worktreeDir, ".beads")
+	if _, err := os.Stat(filepath.Join(worktreeBeadsDir, "metadata.json")); err != nil {
+		t.Fatalf("precondition: worktree should have inherited metadata.json, got: %v", err)
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	result := FindBeadsDir()
+	if result == "" {
+		t.Fatal("FindBeadsDir returned empty; lenient escape hatch should return the worktree .beads/ when no DB exists anywhere")
+	}
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	worktreeResolved, _ := filepath.EvalSymlinks(worktreeBeadsDir)
+	if resultResolved != worktreeResolved {
+		t.Errorf("FindBeadsDir() = %q, want worktree .beads %q (lenient fallback — no DB anywhere)",
+			result, worktreeBeadsDir)
+	}
+}

--- a/internal/beads/beads_inherited_artifacts_test.go
+++ b/internal/beads/beads_inherited_artifacts_test.go
@@ -1,0 +1,215 @@
+package beads
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/git"
+)
+
+// TestFindBeadsDir_WorktreeWithInheritedArtifacts covers the case where a
+// git worktree inherits the parent repo's tracked .beads/ artifacts —
+// metadata.json, config.yaml, issues.jsonl, etc. — but NOT an actual Dolt
+// database directory (which is gitignored under .beads/.gitignore). Without
+// a real database, the worktree must resolve to the shared .beads/ via the
+// git common-dir fallback; otherwise bd would spawn a sidecar Dolt server
+// against an empty data directory and fail every query.
+//
+// Regression test for "bd worktree create --help" promise: "The worktree
+// automatically shares the same beads database as the main repository via
+// git common directory discovery — no manual redirect configuration needed."
+func TestFindBeadsDir_WorktreeWithInheritedArtifacts(t *testing.T) {
+	originalEnv := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("BEADS_DIR", originalEnv)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir, err := os.MkdirTemp("", "beads-inherited-artifacts-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit(mainRepoDir, "config", "user.email", "test@example.com")
+	runGit(mainRepoDir, "config", "user.name", "Test User")
+
+	// Simulate a real parent-repo beads install: metadata.json, config.yaml,
+	// issues.jsonl, AND a database. The database is what makes this a real
+	// beads project.
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(filepath.Join(mainBeadsDir, "metadata.json"), `{"database":"dolt","dolt_database":"beads"}`)
+	mustWrite(filepath.Join(mainBeadsDir, "config.yaml"), "issue-prefix: \"proj\"\n")
+	mustWrite(filepath.Join(mainBeadsDir, "issues.jsonl"), "")
+	mustWrite(filepath.Join(mainBeadsDir, "beads.db"), "")
+
+	// Commit the artifact files (NOT the db — gitignore it as real projects do).
+	mustWrite(filepath.Join(mainBeadsDir, ".gitignore"), "*.db\ndolt/\nembeddeddolt/\n")
+	mustWrite(filepath.Join(mainRepoDir, "README.md"), "# Test\n")
+	runGit(mainRepoDir, "add", "README.md", ".beads/metadata.json", ".beads/config.yaml", ".beads/issues.jsonl", ".beads/.gitignore")
+	runGit(mainRepoDir, "commit", "-m", "initial")
+
+	// Create a worktree by git — `git worktree add` checks out the tracked
+	// files, so the worktree's .beads/ ends up with metadata.json + config.yaml
+	// + issues.jsonl but no database (since *.db is gitignored).
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	runGit(mainRepoDir, "worktree", "add", worktreeDir, "HEAD")
+	defer func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	}()
+
+	// Sanity-check the shape of the worktree's .beads/.
+	worktreeBeadsDir := filepath.Join(worktreeDir, ".beads")
+	if _, err := os.Stat(filepath.Join(worktreeBeadsDir, "metadata.json")); err != nil {
+		t.Fatalf("precondition: worktree should have inherited metadata.json, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktreeBeadsDir, "beads.db")); err == nil {
+		t.Fatalf("precondition: worktree's *.db should be gitignored, but beads.db exists")
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	result := FindBeadsDir()
+
+	// Expect the shared (main repo's) .beads/ — not the worktree's
+	// metadata-only one. Resolve symlinks for macOS /var → /private/var.
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	mainResolved, _ := filepath.EvalSymlinks(mainBeadsDir)
+	worktreeResolved, _ := filepath.EvalSymlinks(worktreeBeadsDir)
+
+	if resultResolved == worktreeResolved {
+		t.Fatalf("FindBeadsDir() returned the worktree's inherited-artifacts .beads/ (%q); "+
+			"expected the shared .beads/ (%q). This is the sidecar-Dolt-server bug: "+
+			"bd should not try to run a database out of a directory that only contains "+
+			"tracked metadata files.", result, mainBeadsDir)
+	}
+	if resultResolved != mainResolved {
+		t.Errorf("FindBeadsDir() = %q, want shared .beads %q", result, mainBeadsDir)
+	}
+}
+
+// TestFindBeadsDir_WorktreeSeparateDBPreservesLocal verifies the companion
+// case: if a worktree really does own its own database (true separate-DB
+// mode), FindBeadsDir must continue to return the worktree's .beads/ — the
+// inherited-artifacts fix must not regress separate-DB mode.
+func TestFindBeadsDir_WorktreeSeparateDBPreservesLocal(t *testing.T) {
+	originalEnv := os.Getenv("BEADS_DIR")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("BEADS_DIR", originalEnv)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+
+	tmpDir, err := os.MkdirTemp("", "beads-separate-db-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit(mainRepoDir, "config", "user.email", "test@example.com")
+	runGit(mainRepoDir, "config", "user.name", "Test User")
+
+	// Main repo has its own beads install WITH a database.
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainBeadsDir, "beads.db"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mainRepoDir, "README.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(mainRepoDir, "add", "README.md")
+	runGit(mainRepoDir, "commit", "-m", "initial")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	runGit(mainRepoDir, "worktree", "add", worktreeDir, "HEAD")
+	defer func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	}()
+
+	// Worktree has its OWN real database — separate-DB mode.
+	worktreeBeadsDir := filepath.Join(worktreeDir, ".beads")
+	if err := os.MkdirAll(worktreeBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeBeadsDir, "beads.db"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	result := FindBeadsDir()
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	worktreeResolved, _ := filepath.EvalSymlinks(worktreeBeadsDir)
+
+	if resultResolved != worktreeResolved {
+		t.Errorf("FindBeadsDir() = %q, want worktree .beads %q (separate-DB mode)",
+			result, worktreeBeadsDir)
+	}
+}


### PR DESCRIPTION
## Summary

Fix a bug where `bd` fails from inside a git worktree when the parent repo commits its `.beads/` artifacts.

`bd worktree create --help` advertises: *"The worktree automatically shares the same beads database as the main repository via git common directory discovery — no manual redirect configuration needed."*

That promise breaks when the parent repo tracks `.beads/metadata.json`, `.beads/config.yaml`, `.beads/issues.jsonl`, etc. (a common setup — these are the portable/durable record of the project). `git worktree add` checks out those tracked files into the worktree's `.beads/`, but the gitignored `.beads/dolt/` data directory is not checked out. `FindBeadsDir` then prefers the worktree's metadata-only `.beads/` over the shared `.beads/` with the real database, and bd tries to auto-start a Dolt server against an empty data directory:

```
failed to open database: database "<proj>" not found on Dolt server at 127.0.0.1:<port>
```

Every subsequent `bd` invocation from inside the worktree errors.

## Root causes (both fixed here)

**1. Path-canonicalization mismatch in the walk-up boundary check.**
`FindBeadsDir` step 2 walks up from `cwd` with a boundary check at `git.GetRepoRoot()`. On macOS, `os.Getwd()` returns the unresolved `/var/folders/...` path while `git rev-parse --show-toplevel` returns the canonical `/private/var/folders/...`. `dir == walkBoundary` silently never matches, so the walk overshoots the worktree root, finds the inherited `.beads/` at the worktree root, and returns it — never reaching the worktree-fallback logic in step 3.

Fix: canonicalize both `cwd` and `walkBoundary` (and the step 4 `extendedRoot`) before comparison via `utils.CanonicalizePath`.

**2. `hasBeadsProjectFiles` is too lenient for worktree separate-DB detection.**
Step 3b accepted the worktree-local `.beads/` as separate-DB if `hasBeadsProjectFiles` returned true. That check matches on `metadata.json` alone, so tracked-artifact dirs pass and the shared-DB fallback (3c) is never reached.

Fix: add `hasBeadsDatabase` — a strict counterpart that requires an actual database (`dolt/`, `embeddeddolt/`, or a non-backup `*.db`). Step 3b now requires a real database for the separate-DB verdict. If the worktree-local `.beads/` lacks a database but the shared fallback has one, fall through to 3c. The lenient check is preserved as an escape hatch when *no* shared fallback with a real database exists — so `bd init` in a fresh worktree can still bootstrap.

## Test plan

- [x] New regression test `TestFindBeadsDir_WorktreeWithInheritedArtifacts` — sets up a main repo with tracked `.beads/` artifacts + an ignored `.db`, runs `git worktree add`, then asserts `FindBeadsDir()` returns the shared `.beads/`. Fails on unpatched `main`; passes with the fix.
- [x] New guard test `TestFindBeadsDir_WorktreeSeparateDBPreservesLocal` — ensures true separate-DB mode (worktree has its own real database) still returns the worktree-local path.
- [x] `go test ./internal/beads/...` passes (including all pre-existing worktree tests: `TestFindBeadsDir_Worktree`, `TestFindBeadsDir_WorktreeRedirectOverride`, `TestFindBeadsDir_SiblingWorktree`, `TestFindBeadsDir_BareParentWorktreeFallback`, etc.).
- [x] `go test ./internal/git/...` passes (canonicalization uses the existing helper; no behaviour change in the git package itself).

## Notes

- `findLocalBeadsDir` (used for redirect *detection*, not database routing) is intentionally left unchanged. Its current behaviour of matching on `metadata.json` in a worktree is semantically different — callers are checking whether a redirect exists at that path, not trying to locate a usable database.
- The fix is additive: all existing `FindBeadsDir` call sites keep their current semantics except for the narrow "worktree with only inherited artifacts and a usable shared fallback" case, which now correctly resolves to the shared fallback.