### PR TITLE
docs(claude): fix stale CLAUDE.md content for Dolt default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,8 @@ bd list --overdue               # Due date in past (not closed)
    - `bd create "Found bug in auth" -t bug -p 1 --json`
    - Link it: `bd dep add <new-id> <current-id> --type discovered-from`
 5. **Complete**: `bd close <id> --reason "Implemented"`
-6. **Export**: Run `bd export -o .beads/issues.jsonl` before committing
+
+(Writes auto-commit to Dolt history; `.beads/issues.jsonl` is maintained by auto-export — no manual `bd export` needed.)
 
 ### Issue Types
 
@@ -93,8 +94,8 @@ Only `blocks` dependencies affect the ready work queue.
 
 ### Code Standards
 
-- **Go version**: 1.21+
-- **Linting**: `golangci-lint run ./...` (baseline warnings documented in LINTING.md)
+- **Go version**: 1.25+ (see `go.mod`)
+- **Linting**: `golangci-lint run ./...` (baseline warnings documented in `docs/LINTING.md`)
 - **Testing**: All new features need tests (`go test ./...`)
 - **Documentation**: Update relevant .md files
 
@@ -102,42 +103,42 @@ Only `blocks` dependencies affect the ready work queue.
 
 ```
 beads/
-├── cmd/bd/              # CLI commands
+├── cmd/bd/              # CLI commands (Cobra)
 ├── internal/
 │   ├── types/           # Core data types
-│   └── storage/         # Storage layer
-│       └── sqlite/      # SQLite implementation
+│   ├── storage/         # Storage layer
+│   │   ├── dolt/            # Dolt backend (versioned SQL)
+│   │   ├── embeddeddolt/    # Embedded-mode Dolt
+│   │   ├── schema/          # Schema + migrations
+│   │   ├── issueops/        # Issue-level helpers
+│   │   └── versioncontrolops/ # VC helpers
+│   └── ui/              # Shared styles / rendering
+├── docs/                # User and contributor docs
 ├── examples/            # Integration examples
-└── *.md                 # Documentation
+└── *.md                 # Top-level guides (README.md, AGENTS.md, etc.)
 ```
 
 ### Before Committing
 
 1. **Run tests**: `go test ./...`
 2. **Run linter**: `golangci-lint run ./...` (ignore baseline warnings)
-3. **Export issues**: `bd export -o .beads/issues.jsonl`
-4. **Update docs**: If you changed behavior, update README.md or other docs
-5. **Git add both**: `git add .beads/issues.jsonl <your-changes>`
+3. **Update docs**: If you changed behavior, update README.md or other docs
 
 ### Git Workflow
 
+bd uses **Dolt** as its database. Issue writes auto-commit to Dolt history (one commit per write). Standard Git is for *code* changes; `bd dolt push` / `bd dolt pull` (or auto-export) handle Dolt sync.
+
 ```bash
-# Make changes
+# Make code changes
 git add <files>
-
-# Export beads issues
-bd export -o .beads/issues.jsonl
-git add .beads/issues.jsonl
-
-# Commit
 git commit -m "Your message"
 
-# After pull
-git pull
-bd import .beads/issues.jsonl  # Sync Dolt database
+# Push / pull
+git push            # code
+bd dolt push        # beads issues (auto-export also writes .beads/issues.jsonl for portability)
 ```
 
-Or use the git hooks in `examples/git-hooks/` for automation.
+Run `bd hooks install` once per clone to wire up pre-commit / post-merge hooks so bd state stays in sync with git operations.
 
 ## Current Project Status
 
@@ -171,10 +172,10 @@ bd dep tree bd-8  # Show 1.0 epic dependencies
 
 ### Adding Storage Features
 
-1. Update schema in `internal/storage/sqlite/schema.go`
-2. Add migration if needed
+1. Update schema in `internal/storage/schema/`
+2. Add migration SQL under `internal/storage/schema/migrations/`
 3. Update `internal/types/types.go` if new types
-4. Implement in `internal/storage/sqlite/sqlite.go`
+4. Implement in `internal/storage/dolt/` (and `embeddeddolt/` if embedded-mode specific)
 5. Add tests
 6. Update export/import in `cmd/bd/export.go` and `cmd/bd/import.go`
 
@@ -190,14 +191,15 @@ bd dep tree bd-8  # Show 1.0 epic dependencies
 
 - Check existing issues: `bd list`
 - Look at recent commits: `git log --oneline -20`
-- Read the docs: README.md, TEXT_FORMATS.md, EXTENDING.md
+- Read the docs: README.md, AGENT_INSTRUCTIONS.md, `docs/`
 - Create an issue if unsure: `bd create "Question: ..." -t task -p 2`
 
 ## Important Files
 
 - **README.md** - Main documentation (keep this updated!)
-- **EXTENDING.md** - Database extension guide
-- **TEXT_FORMATS.md** - JSONL format analysis
+- **AGENT_INSTRUCTIONS.md** - Detailed agent operational guide
+- **AGENTS.md** - Agent-entry pointer (kept in sync with AGENT_INSTRUCTIONS.md)
+- **docs/CLAUDE.md** - Architecture notes for Claude Code
 - **CONTRIBUTING.md** - Contribution guidelines
 - **SECURITY.md** - Security policy
 
@@ -206,7 +208,7 @@ bd dep tree bd-8  # Show 1.0 epic dependencies
 - Always use `--json` flags for programmatic use
 - Link discoveries with `discovered-from` to maintain context
 - Check `bd ready` before asking "what next?"
-- Export to JSONL before committing (or use git hooks)
+- Dolt auto-commits every bd write — manual export is not required
 - Use `bd dep tree` to understand complex dependencies
 - Priority 0-1 issues are usually more important than 2-4
 


### PR DESCRIPTION
## Summary

Root `CLAUDE.md` had drifted and was actively misleading agents. Worst offense: it prescribed a routine `bd export → git add → bd import` sync loop that's obsolete under the Dolt default and can silently drop data committed to Dolt but not yet exported. Fix surgically — keep everything accurate, replace only what's wrong.

### Stale content replaced

| Claim | Reality |
|---|---|
| Go 1.21+ (line 96) | `go.mod` requires `go 1.25` |
| `internal/storage/sqlite/` (lines 109, 174, 177) | No `sqlite/` subdir — actual packages: `dolt/`, `embeddeddolt/`, `schema/`, `issueops/`, `versioncontrolops/` |
| `bd export → git add → bd import` workflow (lines 118, 124–138) | `bd dolt push` / `bd dolt pull` + auto-export handles sync |
| `TEXT_FORMATS.md`, `EXTENDING.md` doc links (lines 193, 199–200) | Neither file exists |
| "Git add both" JSONL + code bullet (line 120) | Auto-export handles `.beads/issues.jsonl` |
| "Export to JSONL before committing" pro tip (line 209) | Same stale assumption |

### Preserved verbatim

- bd workflow quick reference (lines 11–65 ex. one stale bullet)
- Issue type / priority / dependency-type tables
- **Visual Design System** (status icons `○ ◐ ● ✓ ❄`, priority colors, semantic lipgloss styles, design principles) — unique content not duplicated in AGENT_INSTRUCTIONS.md
- Building and Testing, Release Process, Adding a New Command, Common Tasks

### Changes Made

- Replaced the `Git Workflow` block with a Dolt-native one that separates `git` (code) from `bd dolt push`/auto-export (issues) and mentions `bd hooks install` for automation.
- Fixed the file-organization diagram to show actual storage subpackages (`dolt/`, `embeddeddolt/`, `schema/`, `issueops/`, `versioncontrolops/`) plus `docs/` and `internal/ui/`.
- Corrected `Adding Storage Features` steps to point at `internal/storage/schema/` and `internal/storage/dolt/` instead of nonexistent `sqlite/` paths.
- Removed the obsolete export-step from 'Before Committing'; the "git add both" bullet went with it.
- Updated `Important Files` to list files that exist (`AGENT_INSTRUCTIONS.md`, `AGENTS.md`, `docs/CLAUDE.md`) and drop the ones that don't.
- Replaced the "export to JSONL before committing" pro tip with the accurate "Dolt auto-commits every bd write".

### Acceptance Criteria

- CLAUDE.md rewritten for the Dolt default workflow (surgical path)
- Broken internal doc links removed or replaced
- Go version stamp accurate (defers to `go.mod`)
- No JSONL export-import sync loop recommended as a routine git workflow

### Backward Compatibility

**Docs-only change.** No code impact.
**No duplicate-surface drift** introduced — AGENT_INSTRUCTIONS.md remains the canonical agent guide; this CLAUDE.md keeps project-specific content (Visual Design System) that isn't duplicated there.

### Size: Small

Single-file doc change; +30 / -28 lines (net +2). Load-bearing fixes only.

### Note on commit history

An earlier pass of this commit took the second AC option from the tracking issue (reduce to ≤20-line pointer) and accidentally discarded the Visual Design System, which is not duplicated in AGENT_INSTRUCTIONS.md. Reverted and redone as the surgical rewrite above.

🤖 Generated with [Claude Code](https://claude.ai/code)