### PR TITLE
fix(ready): honor filter.ExcludeTypes in GetReadyWorkInTx (GH#3397)

### DIFF
--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -354,6 +354,82 @@ func TestGetReadyWork_TypeFilter(t *testing.T) {
 	}
 }
 
+// TestGetReadyWork_ExcludeTypeFilter verifies that filter.ExcludeTypes is
+// honored in addition to the hardcoded default exclusion list. Regression test
+// for GH#3397: the CLI flag --exclude-type was silently ignored because
+// GetReadyWorkInTx built the NOT IN clause from the hardcoded defaults only.
+func TestGetReadyWork_ExcludeTypeFilter(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic := &types.Issue{
+		ID:        "rw-ex-epic",
+		Title:     "An Epic",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	task := &types.Issue{
+		ID:        "rw-ex-task",
+		Title:     "A Task",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	bug := &types.Issue{
+		ID:        "rw-ex-bug",
+		Title:     "A Bug",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeBug,
+	}
+
+	for _, iss := range []*types.Issue{epic, task, bug} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("failed to create issue: %v", err)
+		}
+	}
+
+	// Single-type exclusion.
+	work, err := store.GetReadyWork(ctx, types.WorkFilter{
+		ExcludeTypes: []types.IssueType{types.TypeEpic},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, w := range work {
+		if w.ID == epic.ID {
+			t.Error("epic should not appear when ExcludeTypes includes epic")
+		}
+	}
+
+	// Multi-type exclusion.
+	work, err = store.GetReadyWork(ctx, types.WorkFilter{
+		ExcludeTypes: []types.IssueType{types.TypeEpic, types.TypeTask},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundBug := false
+	for _, w := range work {
+		if w.ID == epic.ID {
+			t.Error("epic should not appear when ExcludeTypes includes epic")
+		}
+		if w.ID == task.ID {
+			t.Error("task should not appear when ExcludeTypes includes task")
+		}
+		if w.ID == bug.ID {
+			foundBug = true
+		}
+	}
+	if !foundBug {
+		t.Error("bug should still appear when ExcludeTypes excludes only epic and task")
+	}
+}
+
 // TestGetReadyWork_CustomStatusBlockerStillBlocks verifies that a blocker with
 // a custom status still prevents blocked issues from appearing in ready work.
 // Regression test for bd-1x0.

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -51,6 +51,18 @@ func GetReadyWorkInTx(
 		args = append(args, filter.Type)
 	} else {
 		excludeTypes := []string{"merge-request", "gate", "molecule", "message", "agent", "role", "rig"}
+		seen := make(map[string]bool, len(excludeTypes)+len(filter.ExcludeTypes))
+		for _, t := range excludeTypes {
+			seen[t] = true
+		}
+		for _, t := range filter.ExcludeTypes {
+			s := string(t)
+			if s == "" || seen[s] {
+				continue
+			}
+			seen[s] = true
+			excludeTypes = append(excludeTypes, s)
+		}
 		placeholders := make([]string, len(excludeTypes))
 		for i, t := range excludeTypes {
 			placeholders[i] = "?"


### PR DESCRIPTION
## Summary

`bd ready --exclude-type=<T>` was silently ignored for every issue type (reported in #3397). The CLI flag correctly populated `filter.ExcludeTypes`, and the `WorkFilter.ExcludeTypes` godoc (`internal/types/types.go:1315-1318`) explicitly promises the values are *"Appended to the default exclusion list"*. But the no-`Type` branch of `GetReadyWorkInTx` (`internal/storage/issueops/ready_work.go:49-60`) built the `NOT IN` clause from the hardcoded defaults only — user-supplied exclusions were never read.

This PR closes that gap. When `filter.Type == ""`, merge `filter.ExcludeTypes` into the default exclusion list (deduping against defaults and empties) before building the placeholders. This matches the pattern already used by `issueops/filters.go` and `dolt/queries.go` (which power `bd list`, the command that *was* working against the same database).

## Changes

- `internal/storage/issueops/ready_work.go` — append `filter.ExcludeTypes` into `excludeTypes` before building the `NOT IN` placeholders.
- `internal/storage/dolt/queries_test.go` — regression test `TestGetReadyWork_ExcludeTypeFilter` covering single-type and multi-type exclusion.

## Test plan

- [x] `go vet ./internal/storage/issueops/...` passes
- [x] `go vet ./internal/storage/dolt/...` (CGO) passes
- [x] Full build passes with `CGO_ENABLED=1 go build ./...`
- [ ] CI runs `TestGetReadyWork_ExcludeTypeFilter` against embedded Dolt

Fixes #3397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)