### PR TITLE
fix(ready): --parent returns transitive descendants, not direct children (GH#3396)

### DIFF
--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -354,6 +354,96 @@ func TestGetReadyWork_TypeFilter(t *testing.T) {
 	}
 }
 
+// TestGetReadyWork_ParentFilterReturnsDescendants verifies that --parent
+// returns all transitive descendants, not just direct children. Regression
+// test for GH#3396: the SQL clause was a one-hop subquery, so grandchildren
+// of the given parent were silently dropped despite the help text and the
+// WorkFilter.ParentID godoc both promising "descendants (recursive)".
+func TestGetReadyWork_ParentFilterReturnsDescendants(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic := &types.Issue{
+		ID:        "rw-pd-epic",
+		Title:     "Epic",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	phase := &types.Issue{
+		ID:        "rw-pd-phase",
+		Title:     "Phase",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	leaf := &types.Issue{
+		ID:        "rw-pd-leaf",
+		Title:     "Leaf Task",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+
+	for _, iss := range []*types.Issue{epic, phase, leaf} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("failed to create issue %s: %v", iss.ID, err)
+		}
+	}
+
+	// epic <- phase <- leaf via parent-child deps.
+	for _, dep := range []*types.Dependency{
+		{IssueID: phase.ID, DependsOnID: epic.ID, Type: types.DepParentChild},
+		{IssueID: leaf.ID, DependsOnID: phase.ID, Type: types.DepParentChild},
+	} {
+		if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("failed to add dep %s->%s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+
+	// Direct parent filter still works (control).
+	parentPhase := phase.ID
+	workPhase, err := store.GetReadyWork(ctx, types.WorkFilter{ParentID: &parentPhase})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundLeaf := false
+	for _, w := range workPhase {
+		if w.ID == leaf.ID {
+			foundLeaf = true
+		}
+	}
+	if !foundLeaf {
+		t.Error("direct-parent filter should return the leaf task")
+	}
+
+	// Grandparent filter: leaf must appear (the bug under test).
+	parentEpic := epic.ID
+	workEpic, err := store.GetReadyWork(ctx, types.WorkFilter{ParentID: &parentEpic})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundLeaf = false
+	foundPhase := false
+	for _, w := range workEpic {
+		if w.ID == leaf.ID {
+			foundLeaf = true
+		}
+		if w.ID == phase.ID {
+			foundPhase = true
+		}
+	}
+	if !foundPhase {
+		t.Error("grandparent filter should include the direct child (phase)")
+	}
+	if !foundLeaf {
+		t.Error("grandparent filter should include transitive grandchildren (leaf) — regression for GH#3396")
+	}
+}
+
 // TestGetReadyWork_CustomStatusBlockerStillBlocks verifies that a blocker with
 // a custom status still prevents blocked issues from appearing in ready work.
 // Regression test for bd-1x0.

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -332,6 +332,40 @@ func GetChildrenOfIssuesInTx(ctx context.Context, tx *sql.Tx, parentIDs []string
 	return children, nil
 }
 
+// GetDescendantIDsInTx returns IDs of all transitive parent-child descendants
+// of rootID, traversing parent-child edges in both the dependencies and
+// wisp_dependencies tables via BFS. rootID itself is NOT included. Cycles are
+// broken via a visited set. maxDepth caps traversal depth; pass 0 for the
+// default safety cap.
+func GetDescendantIDsInTx(ctx context.Context, tx *sql.Tx, rootID string, maxDepth int) ([]string, error) {
+	if rootID == "" {
+		return nil, nil
+	}
+	if maxDepth <= 0 {
+		maxDepth = 100
+	}
+	seen := map[string]bool{rootID: true}
+	var result []string
+	frontier := []string{rootID}
+	for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
+		children, err := GetChildrenOfIssuesInTx(ctx, tx, frontier)
+		if err != nil {
+			return nil, err
+		}
+		var next []string
+		for _, c := range children {
+			if seen[c] {
+				continue
+			}
+			seen[c] = true
+			result = append(result, c)
+			next = append(next, c)
+		}
+		frontier = next
+	}
+	return result, nil
+}
+
 // GetBlockedIssuesInTx returns issues that are blocked by other issues.
 // This is the full implementation including transitive child blocking and parent filtering.
 //

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -90,11 +90,29 @@ func GetReadyWorkInTx(
 			args = append(args, label)
 		}
 	}
-	// Parent filtering.
+	// Parent filtering: return all transitive descendants of parentID.
+	// GH#3396: previously was a one-hop subquery against dependencies, so
+	// grandchildren were silently dropped despite the help text and
+	// WorkFilter.ParentID godoc both promising "descendants (recursive)".
 	if filter.ParentID != nil {
 		parentID := *filter.ParentID
-		whereClauses = append(whereClauses, "(id IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child' AND depends_on_id = ?) OR (id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child')))")
-		args = append(args, parentID, parentID)
+		descendants, dErr := GetDescendantIDsInTx(ctx, tx, parentID, 0)
+		if dErr != nil {
+			return nil, fmt.Errorf("get descendants for parent filter: %w", dErr)
+		}
+		// Compose two branches, matching the prior semantics:
+		//   1. Any ID reachable via parent-child deps from parentID.
+		//   2. Dotted-ID descendants (id LIKE "parent.%") that have no
+		//      explicit parent-child dep — the implicit-parent convention.
+		var orParts []string
+		if len(descendants) > 0 {
+			placeholders, batchArgs := buildSQLInClause(descendants)
+			orParts = append(orParts, fmt.Sprintf("id IN (%s)", placeholders))
+			args = append(args, batchArgs...)
+		}
+		orParts = append(orParts, "(id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child'))")
+		args = append(args, parentID)
+		whereClauses = append(whereClauses, "("+strings.Join(orParts, " OR ")+")")
 	}
 
 	// Molecule filtering: filter to direct children of the specified molecule.


### PR DESCRIPTION
## Summary

`bd ready --parent=<id>` was documented as *"Filter to descendants of this bead/epic"* (`cmd/bd/ready.go:672`) and the `WorkFilter.ParentID` godoc (`internal/types/types.go:1295-1296`) promises *"descendants of a bead/epic (recursive)"* — but the SQL in `GetReadyWorkInTx` (`internal/storage/issueops/ready_work.go:94-98`) was a one-hop subquery against `dependencies`. Grandchildren were silently dropped.

Reproducer from #3396:
```bash
bd create --title=Epic  --type=epic                  # bd-E
bd create --title=Phase --type=epic --parent=bd-E    # bd-P
bd create --title=Leaf  --type=task --parent=bd-P    # bd-L
bd ready --parent=bd-E --json | jq -r '.[].id'
# Before: bd-P only (bd-L missing)
# After:  bd-P, bd-L
```

## Approach

- New helper `GetDescendantIDsInTx(ctx, tx, rootID, maxDepth)` in `internal/storage/issueops/blocked.go`, next to the existing `GetChildrenOfIssuesInTx`. BFS rather than a recursive CTE because the existing children helper already iterates across both `dependencies` and `wisp_dependencies` tables, and composing that inside a single CTE gets ugly. The visited set breaks cycles; the depth cap (default 100) matches the cycle-detection CTE in `dependencies.go:141`.

- `GetReadyWorkInTx` `ParentID` branch now calls the helper to collect descendants, then OR-composes with the prior dotted-ID prefix match (for implicit-parent IDs with no explicit `parent-child` dep), preserving the original semantics for dotted IDs.

- `MoleculeID` is deliberately **left as one-hop** — its inline comment (`ready_work.go:100`) explicitly scopes it to *"direct children of the specified molecule"* unlike `ParentID`.

## Out of scope (follow-up)

`GetBlockedIssuesInTx` (`blocked.go:414-431`) has the same one-hop pattern, so `bd blocked --parent=<id>` has the equivalent bug — the `blocked` help text (`cmd/bd/ready.go:685`) also says "descendants". That warrants its own PR; this one is scoped to `bd ready` per the issue title/reproducer.

## Changes

- `internal/storage/issueops/blocked.go` — add `GetDescendantIDsInTx` helper.
- `internal/storage/issueops/ready_work.go` — rewrite `ParentID` branch to use the recursive helper + preserve the dotted-ID OR branch.
- `internal/storage/dolt/queries_test.go` — regression test `TestGetReadyWork_ParentFilterReturnsDescendants` with a 3-level hierarchy (epic ← phase ← leaf), asserting the leaf surfaces under the grandparent filter.

## Test plan

- [x] `go vet ./internal/storage/issueops/...` passes
- [x] `go vet ./internal/storage/dolt/...` (CGO) passes
- [x] Full build passes with `CGO_ENABLED=1 go build ./...`
- [ ] CI runs `TestGetReadyWork_ParentFilterReturnsDescendants` against embedded Dolt

Fixes #3396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)