### PR TITLE
docs: update user-facing URLs from steveyegge/beads to gastownhall/beads (GH#3059)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -74,5 +74,5 @@ git config --global user.email "your.email@example.com"
 
 ## Related Issues
 
-- GitHub Issue [#229](https://github.com/steveyegge/beads/issues/229): Git hooks not available in devcontainers
+- GitHub Issue [#229](https://github.com/gastownhall/beads/issues/229): Git hooks not available in devcontainers
 - bd-ry1u: Publish official devcontainer configuration

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -170,7 +170,7 @@ brews:
     # so goreleaser can't generate a complete formula. The update-homebrew-formula
     # job in release.yml generates the formula after all archives are uploaded.
     skip_upload: true
-    homepage: "https://github.com/steveyegge/beads"
+    homepage: "https://github.com/gastownhall/beads"
     description: "AI-supervised issue tracker for coding workflows"
     license: "MIT"
     install: |
@@ -223,12 +223,12 @@ release:
 
     **Quick Install (macOS/Linux/FreeBSD):**
     ```bash
-    curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+    curl -sSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
     ```
 
     **Windows (PowerShell):**
     ```powershell
-    irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+    irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
     ```
 
     **Manual Install:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,53 +93,53 @@ Beads 1.0 marks the transition from rapid iteration to production stability. The
 
 ### Added
 
-- **Embedded Dolt default on macOS** — Native CGO builds on macOS enable embedded Dolt by default, eliminating the external Dolt server entirely. ([PR #2971](https://github.com/steveyegge/beads/pull/2971))
-- **Custom status/type normalized tables** — `custom_statuses(name, category)` and `custom_types(name)` tables replace comma-separated config strings. Views use table-backed subqueries instead of dynamic IN clauses. Migration is automatic and idempotent. ([PR #2961](https://github.com/steveyegge/beads/pull/2961))
-- **`bd rules audit` and `bd rules compact`** — Scan `.claude/rules/*.md` for contradictions and near-duplicates; merge rule groups with deduplication. ([PR #2810](https://github.com/steveyegge/beads/pull/2810))
-- **`bd config set-many`** — Batch config operations across yaml, git, and database keys in a single command. ([PR #2943](https://github.com/steveyegge/beads/pull/2943))
-- **Credentials file support** — `~/.config/beads/credentials` for Dolt server passwords with Unix permission checks, env var override, and proper DSN escaping. ([PR #2854](https://github.com/steveyegge/beads/pull/2854))
-- **Spike, story, and milestone issue types** — First-class support with constants, validation, and normalization aliases. ([PR #2923](https://github.com/steveyegge/beads/pull/2923))
-- **GitLab sync: epic→milestone, task hierarchy, type filtering** — Epics sync as GitLab milestones, tasks create work items via GraphQL with parent hierarchy, internal types excluded from push by default. ([PR #2889](https://github.com/steveyegge/beads/pull/2889))
-- **ADO shorthand refs** — `ado:NNNNN` recognized in IsExternalRef and ExtractIdentifier, preventing duplicates on sync. ([PR #2966](https://github.com/steveyegge/beads/pull/2966))
-- **ADO push filters** — `--types`, `--states`, and `--no-create` flags now apply to push operations. ([PR #2944](https://github.com/steveyegge/beads/pull/2944))
-- **Public format package** — `format.PrettyIssue`, `CompactIssue`, `LongIssue` for external tooling. ([PR #2871](https://github.com/steveyegge/beads/pull/2871))
-- **SlotSet/SlotGet/SlotClear** — Per-issue metadata slots in the Storage interface for delegation tracking and hook state. ([PR #2870](https://github.com/steveyegge/beads/pull/2870))
-- **WispFilter export** — `beads.WispFilter` type alias exported from root package. ([PR #2868](https://github.com/steveyegge/beads/pull/2868))
-- **`--non-interactive` / `--yes` for bootstrap** — Skip confirmation prompts in CI/automation. ([PR #2942](https://github.com/steveyegge/beads/pull/2942))
-- **Batch dependency list** — `GetDependenciesWithMetadata` supports multiple issue IDs. ([PR #2875](https://github.com/steveyegge/beads/pull/2875))
-- **`bd ready --explain`** — Dependency-aware reasoning for why issues are or aren't ready. ([PR #2814](https://github.com/steveyegge/beads/pull/2814))
-- **Graph integrity enforcement** — Extended cycle detection and `bd graph check` command. ([PR #2814](https://github.com/steveyegge/beads/pull/2814))
-- **Tracker hardening** — Retry logic with jitter for all tracker HTTP clients, pagination guards for Linear/Jira, response size limits, terminal-safe content sanitization. ([PRs #2814](https://github.com/steveyegge/beads/pull/2814))
-- **Release stability gate** — Upgrade safety checks and breaking-change communication. ([GH#2951](https://github.com/steveyegge/beads/issues/2951))
-- **Hook firing in storage layer** — `HookFiringStore` decorator moves hook logic out of CLI layer. ([PR #2891](https://github.com/steveyegge/beads/pull/2891))
+- **Embedded Dolt default on macOS** — Native CGO builds on macOS enable embedded Dolt by default, eliminating the external Dolt server entirely. ([PR #2971](https://github.com/gastownhall/beads/pull/2971))
+- **Custom status/type normalized tables** — `custom_statuses(name, category)` and `custom_types(name)` tables replace comma-separated config strings. Views use table-backed subqueries instead of dynamic IN clauses. Migration is automatic and idempotent. ([PR #2961](https://github.com/gastownhall/beads/pull/2961))
+- **`bd rules audit` and `bd rules compact`** — Scan `.claude/rules/*.md` for contradictions and near-duplicates; merge rule groups with deduplication. ([PR #2810](https://github.com/gastownhall/beads/pull/2810))
+- **`bd config set-many`** — Batch config operations across yaml, git, and database keys in a single command. ([PR #2943](https://github.com/gastownhall/beads/pull/2943))
+- **Credentials file support** — `~/.config/beads/credentials` for Dolt server passwords with Unix permission checks, env var override, and proper DSN escaping. ([PR #2854](https://github.com/gastownhall/beads/pull/2854))
+- **Spike, story, and milestone issue types** — First-class support with constants, validation, and normalization aliases. ([PR #2923](https://github.com/gastownhall/beads/pull/2923))
+- **GitLab sync: epic→milestone, task hierarchy, type filtering** — Epics sync as GitLab milestones, tasks create work items via GraphQL with parent hierarchy, internal types excluded from push by default. ([PR #2889](https://github.com/gastownhall/beads/pull/2889))
+- **ADO shorthand refs** — `ado:NNNNN` recognized in IsExternalRef and ExtractIdentifier, preventing duplicates on sync. ([PR #2966](https://github.com/gastownhall/beads/pull/2966))
+- **ADO push filters** — `--types`, `--states`, and `--no-create` flags now apply to push operations. ([PR #2944](https://github.com/gastownhall/beads/pull/2944))
+- **Public format package** — `format.PrettyIssue`, `CompactIssue`, `LongIssue` for external tooling. ([PR #2871](https://github.com/gastownhall/beads/pull/2871))
+- **SlotSet/SlotGet/SlotClear** — Per-issue metadata slots in the Storage interface for delegation tracking and hook state. ([PR #2870](https://github.com/gastownhall/beads/pull/2870))
+- **WispFilter export** — `beads.WispFilter` type alias exported from root package. ([PR #2868](https://github.com/gastownhall/beads/pull/2868))
+- **`--non-interactive` / `--yes` for bootstrap** — Skip confirmation prompts in CI/automation. ([PR #2942](https://github.com/gastownhall/beads/pull/2942))
+- **Batch dependency list** — `GetDependenciesWithMetadata` supports multiple issue IDs. ([PR #2875](https://github.com/gastownhall/beads/pull/2875))
+- **`bd ready --explain`** — Dependency-aware reasoning for why issues are or aren't ready. ([PR #2814](https://github.com/gastownhall/beads/pull/2814))
+- **Graph integrity enforcement** — Extended cycle detection and `bd graph check` command. ([PR #2814](https://github.com/gastownhall/beads/pull/2814))
+- **Tracker hardening** — Retry logic with jitter for all tracker HTTP clients, pagination guards for Linear/Jira, response size limits, terminal-safe content sanitization. ([PRs #2814](https://github.com/gastownhall/beads/pull/2814))
+- **Release stability gate** — Upgrade safety checks and breaking-change communication. ([GH#2951](https://github.com/gastownhall/beads/issues/2951))
+- **Hook firing in storage layer** — `HookFiringStore` decorator moves hook logic out of CLI layer. ([PR #2891](https://github.com/gastownhall/beads/pull/2891))
 
 ### Changed
 
-- **`bd setup claude` defaults to project-local** — Settings written to `.claude/settings.json` (shared/team) by default; `--global` for user-level. Auto-runs during `bd init`. ([PR #2972](https://github.com/steveyegge/beads/pull/2972))
-- **`strconv.ParseBool` for env vars** — `IsAutoStartDisabled` uses standard boolean parsing with whitespace trimming. ([PRs #2955, #2956](https://github.com/steveyegge/beads/pull/2956))
-- **Comma-separated `--status` filter** — `bd list --status open,in_progress` now works. ([GH#2846](https://github.com/steveyegge/beads/issues/2846))
-- **Custom types from YAML** — `ResolveCustomTypesInTx` honors config.yaml custom types in create path. ([GH#2793](https://github.com/steveyegge/beads/issues/2793))
+- **`bd setup claude` defaults to project-local** — Settings written to `.claude/settings.json` (shared/team) by default; `--global` for user-level. Auto-runs during `bd init`. ([PR #2972](https://github.com/gastownhall/beads/pull/2972))
+- **`strconv.ParseBool` for env vars** — `IsAutoStartDisabled` uses standard boolean parsing with whitespace trimming. ([PRs #2955, #2956](https://github.com/gastownhall/beads/pull/2956))
+- **Comma-separated `--status` filter** — `bd list --status open,in_progress` now works. ([GH#2846](https://github.com/gastownhall/beads/issues/2846))
+- **Custom types from YAML** — `ResolveCustomTypesInTx` honors config.yaml custom types in create path. ([GH#2793](https://github.com/gastownhall/beads/issues/2793))
 - **lipgloss v2, backoff v5, goldmark 1.8.2** — Dependency updates.
 
 ### Fixed
 
-- **Concurrent embedded Dolt panic** — Exclusive flock acquired on embedded store open, held for store lifetime. Second concurrent opener gets a clear error instead of a nil-pointer panic. ([GH#2571](https://github.com/steveyegge/beads/issues/2571))
-- **Spaces in repo path** — Embedded Dolt no longer URL-encodes local filesystem paths, fixing `%20` lookup failures on macOS. ([GH#2920](https://github.com/steveyegge/beads/issues/2920))
-- **Schema version bump** — `currentSchemaVersion` bumped to 11 for custom_statuses/custom_types migration. Prevents "table not found" errors on upgrade. ([GH#2974](https://github.com/steveyegge/beads/issues/2974))
-- **Dolt init failure** — Embedded-by-default eliminates server port 0 / connection refused issues for new users. ([GH#2656](https://github.com/steveyegge/beads/issues/2656))
-- **Bootstrap for missing database** — `bd bootstrap` probes server for actual database existence before declaring no-op. Recovery guidance updated across all error surfaces. ([PR #2940](https://github.com/steveyegge/beads/pull/2940))
-- **Diverged history recovery** — Dolt push/pull detect diverged history and print actionable recovery guidance. ([PR #2941](https://github.com/steveyegge/beads/pull/2941))
-- **No-db command routing** — `bd context`, `bd dolt show`, etc. honor `--db` flag, `BEADS_DB` env, and external `dolt_data_dir` layouts. ([PR #2844](https://github.com/steveyegge/beads/pull/2844))
-- **Auto-backup address conflict** — Detects when another backup remote owns the URL and syncs through it. ([PR #2927](https://github.com/steveyegge/beads/pull/2927))
-- **Shared server project_id** — `bd init --database` on a shared server adopts existing `_project_id` instead of generating a new one. ([PR #2925](https://github.com/steveyegge/beads/pull/2925))
-- **Init leaves beads.role unset** — Fixed edge cases where role was not persisted during init. ([GH#2950](https://github.com/steveyegge/beads/issues/2950))
-- **`--shared-server` mode detection** — Correctly treated as server mode for DoltMode resolution. ([PR #2947](https://github.com/steveyegge/beads/pull/2947))
-- **GitLab work_items URL dedup** — Pull dedup checks both issues and wisps tables; URL pattern matches `/work_items/` paths. ([PR #2889](https://github.com/steveyegge/beads/pull/2889))
-- **GitLab work item type ID** — Dynamic GraphQL query with per-session cache instead of hardcoded `gid://...`. ([Follow-up to PR #2889](https://github.com/steveyegge/beads/pull/2889))
-- **Stale noms LOCK files** — Cleaned after bootstrap clone. ([PR #2913](https://github.com/steveyegge/beads/pull/2913))
-- **ADO WIQL date precision** — RFC3339 timezone formatting in WIQL queries. ([PR #2911](https://github.com/steveyegge/beads/pull/2911))
-- **Blocked icon in `bd list`** — Dependency-blocked issues now show blocked indicator. ([GH#2858](https://github.com/steveyegge/beads/issues/2858))
-- **Installer ICU/CGO fallback** — Correct handling on systems without ICU libraries. ([PR #2965](https://github.com/steveyegge/beads/pull/2965))
+- **Concurrent embedded Dolt panic** — Exclusive flock acquired on embedded store open, held for store lifetime. Second concurrent opener gets a clear error instead of a nil-pointer panic. ([GH#2571](https://github.com/gastownhall/beads/issues/2571))
+- **Spaces in repo path** — Embedded Dolt no longer URL-encodes local filesystem paths, fixing `%20` lookup failures on macOS. ([GH#2920](https://github.com/gastownhall/beads/issues/2920))
+- **Schema version bump** — `currentSchemaVersion` bumped to 11 for custom_statuses/custom_types migration. Prevents "table not found" errors on upgrade. ([GH#2974](https://github.com/gastownhall/beads/issues/2974))
+- **Dolt init failure** — Embedded-by-default eliminates server port 0 / connection refused issues for new users. ([GH#2656](https://github.com/gastownhall/beads/issues/2656))
+- **Bootstrap for missing database** — `bd bootstrap` probes server for actual database existence before declaring no-op. Recovery guidance updated across all error surfaces. ([PR #2940](https://github.com/gastownhall/beads/pull/2940))
+- **Diverged history recovery** — Dolt push/pull detect diverged history and print actionable recovery guidance. ([PR #2941](https://github.com/gastownhall/beads/pull/2941))
+- **No-db command routing** — `bd context`, `bd dolt show`, etc. honor `--db` flag, `BEADS_DB` env, and external `dolt_data_dir` layouts. ([PR #2844](https://github.com/gastownhall/beads/pull/2844))
+- **Auto-backup address conflict** — Detects when another backup remote owns the URL and syncs through it. ([PR #2927](https://github.com/gastownhall/beads/pull/2927))
+- **Shared server project_id** — `bd init --database` on a shared server adopts existing `_project_id` instead of generating a new one. ([PR #2925](https://github.com/gastownhall/beads/pull/2925))
+- **Init leaves beads.role unset** — Fixed edge cases where role was not persisted during init. ([GH#2950](https://github.com/gastownhall/beads/issues/2950))
+- **`--shared-server` mode detection** — Correctly treated as server mode for DoltMode resolution. ([PR #2947](https://github.com/gastownhall/beads/pull/2947))
+- **GitLab work_items URL dedup** — Pull dedup checks both issues and wisps tables; URL pattern matches `/work_items/` paths. ([PR #2889](https://github.com/gastownhall/beads/pull/2889))
+- **GitLab work item type ID** — Dynamic GraphQL query with per-session cache instead of hardcoded `gid://...`. ([Follow-up to PR #2889](https://github.com/gastownhall/beads/pull/2889))
+- **Stale noms LOCK files** — Cleaned after bootstrap clone. ([PR #2913](https://github.com/gastownhall/beads/pull/2913))
+- **ADO WIQL date precision** — RFC3339 timezone formatting in WIQL queries. ([PR #2911](https://github.com/gastownhall/beads/pull/2911))
+- **Blocked icon in `bd list`** — Dependency-blocked issues now show blocked indicator. ([GH#2858](https://github.com/gastownhall/beads/issues/2858))
+- **Installer ICU/CGO fallback** — Correct handling on systems without ICU libraries. ([PR #2965](https://github.com/gastownhall/beads/pull/2965))
 
 ### Community
 
@@ -149,48 +149,48 @@ Contributors: harry-miller-trimble, coffeegoddd, quad341, Bella-Giraffety, maphe
 
 ### Added
 
-- **Embedded mode by default** — New installations now use embedded Dolt as the default storage backend, eliminating the need to run a separate Dolt server process. Existing server-mode installations are unaffected. ([PR #2842](https://github.com/steveyegge/beads/pull/2842))
-- **`bd create --graph`** — Batch issue creation from a YAML/JSON dependency graph, replacing the standalone `bd graph-apply` command. ([PR #2894](https://github.com/steveyegge/beads/pull/2894))
-- **Multi-project/team sync** — Linear, Jira, and ADO integrations now support syncing multiple projects and teams in a single repo. ([PR #2868](https://github.com/steveyegge/beads/pull/2868))
-- **Notion sync** — Reimplemented Notion integration on REST data sources with full page property mapping. ([PR #2843](https://github.com/steveyegge/beads/pull/2843))
-- **GitLab sync** — Optional group-level GitLab issue sync. ([PR #2801](https://github.com/steveyegge/beads/pull/2801))
-- **Linear `--parent` flag** — `bd linear sync --parent` limits sync push to a specific ticket tree. ([PR #2853](https://github.com/steveyegge/beads/pull/2853))
-- **Remote URL support** — Multi-repo hydration now supports remote URLs. ([PR #2827](https://github.com/steveyegge/beads/pull/2827))
-- **Top-level command aliases** — `bd comment`, `bd assign`, `bd tag`, `bd link`, `bd priority` as convenient shortcuts. ([GH#2611](https://github.com/steveyegge/beads/issues/2611))
-- **Storage interface expansion** — `ListWisps`, `MergeSlot`, `ReopenIssue`, `UpdateIssueType`, replication, and VC interfaces now exposed in the public API. ([PRs #2782-#2788](https://github.com/steveyegge/beads/pull/2782))
-- **SearchIssues dependency hydration** — Bulk dependency population for search results. ([PR #2773](https://github.com/steveyegge/beads/pull/2773))
-- **`--agents-file` flag** — `bd init --agents-file` customizes the agent instructions filename. ([PR #2761](https://github.com/steveyegge/beads/pull/2761))
-- **Multi-process concurrency tests** — Server lifecycle and concurrent access integration tests. ([PR #2767](https://github.com/steveyegge/beads/pull/2767))
+- **Embedded mode by default** — New installations now use embedded Dolt as the default storage backend, eliminating the need to run a separate Dolt server process. Existing server-mode installations are unaffected. ([PR #2842](https://github.com/gastownhall/beads/pull/2842))
+- **`bd create --graph`** — Batch issue creation from a YAML/JSON dependency graph, replacing the standalone `bd graph-apply` command. ([PR #2894](https://github.com/gastownhall/beads/pull/2894))
+- **Multi-project/team sync** — Linear, Jira, and ADO integrations now support syncing multiple projects and teams in a single repo. ([PR #2868](https://github.com/gastownhall/beads/pull/2868))
+- **Notion sync** — Reimplemented Notion integration on REST data sources with full page property mapping. ([PR #2843](https://github.com/gastownhall/beads/pull/2843))
+- **GitLab sync** — Optional group-level GitLab issue sync. ([PR #2801](https://github.com/gastownhall/beads/pull/2801))
+- **Linear `--parent` flag** — `bd linear sync --parent` limits sync push to a specific ticket tree. ([PR #2853](https://github.com/gastownhall/beads/pull/2853))
+- **Remote URL support** — Multi-repo hydration now supports remote URLs. ([PR #2827](https://github.com/gastownhall/beads/pull/2827))
+- **Top-level command aliases** — `bd comment`, `bd assign`, `bd tag`, `bd link`, `bd priority` as convenient shortcuts. ([GH#2611](https://github.com/gastownhall/beads/issues/2611))
+- **Storage interface expansion** — `ListWisps`, `MergeSlot`, `ReopenIssue`, `UpdateIssueType`, replication, and VC interfaces now exposed in the public API. ([PRs #2782-#2788](https://github.com/gastownhall/beads/pull/2782))
+- **SearchIssues dependency hydration** — Bulk dependency population for search results. ([PR #2773](https://github.com/gastownhall/beads/pull/2773))
+- **`--agents-file` flag** — `bd init --agents-file` customizes the agent instructions filename. ([PR #2761](https://github.com/gastownhall/beads/pull/2761))
+- **Multi-process concurrency tests** — Server lifecycle and concurrent access integration tests. ([PR #2767](https://github.com/gastownhall/beads/pull/2767))
 
 ### Changed
 
-- **Backup system simplified** — Removed git-based backup/restore (`backup export-git`, `backup fetch-git`). Backup and restore now operate exclusively through Dolt's native replication. ([PR #2842](https://github.com/steveyegge/beads/pull/2842))
+- **Backup system simplified** — Removed git-based backup/restore (`backup export-git`, `backup fetch-git`). Backup and restore now operate exclusively through Dolt's native replication. ([PR #2842](https://github.com/gastownhall/beads/pull/2842))
 - **dolthub/driver v1.84.0** — Updated from v1.83.8, picking up serialization retry support.
-- **Dolt write retry** — `writeRetryTx` automatically retries on Dolt serialization errors. ([PR #2855](https://github.com/steveyegge/beads/pull/2855))
+- **Dolt write retry** — `writeRetryTx` automatically retries on Dolt serialization errors. ([PR #2855](https://github.com/gastownhall/beads/pull/2855))
 - **CI overhaul** — Test sharding, precompiled binaries, shared Go module cache for faster CI runs.
-- **Gas Town terminology removed** — Remaining Gas Town naming removed from beads orchestrator detection. ([PR #2762](https://github.com/steveyegge/beads/pull/2762))
+- **Gas Town terminology removed** — Remaining Gas Town naming removed from beads orchestrator detection. ([PR #2762](https://github.com/gastownhall/beads/pull/2762))
 - **TypeScript v6, backoff v5, goldmark 1.7.17** — Dependency updates.
 
 ### Fixed
 
-- **Init git cache reset** — `bd init` now resets git caches after auto-init, preventing stale `.beads/dolt/` references in embedded mode. ([PR #2907](https://github.com/steveyegge/beads/pull/2907))
-- **Doctor embedded mode** — Improved embedded mode detection and push error guidance. ([PR #2910](https://github.com/steveyegge/beads/pull/2910))
-- **Create description warning** — Removed spurious description warning; test-issue warning now gated on DB size. ([PR #2908](https://github.com/steveyegge/beads/pull/2908))
-- **External contributor PRs** — `block-gh-watch` hook now allows external contributors to create PRs. ([PR #2907](https://github.com/steveyegge/beads/pull/2907))
+- **Init git cache reset** — `bd init` now resets git caches after auto-init, preventing stale `.beads/dolt/` references in embedded mode. ([PR #2907](https://github.com/gastownhall/beads/pull/2907))
+- **Doctor embedded mode** — Improved embedded mode detection and push error guidance. ([PR #2910](https://github.com/gastownhall/beads/pull/2910))
+- **Create description warning** — Removed spurious description warning; test-issue warning now gated on DB size. ([PR #2908](https://github.com/gastownhall/beads/pull/2908))
+- **External contributor PRs** — `block-gh-watch` hook now allows external contributors to create PRs. ([PR #2907](https://github.com/gastownhall/beads/pull/2907))
 - **CWD `.beads/` priority** — `bd` now checks CWD for `.beads/` before git-worktree resolution, fixing worktree-based discovery in nested projects.
-- **Epic closure eligibility** — Wisp children now correctly included in epic closure checks. ([PR #2843](https://github.com/steveyegge/beads/pull/2843))
-- **Prefix routing** — `bd edit`, `bd reopen`, and `bd delete` now correctly route with prefixes from town root. ([PRs #2780, #2847](https://github.com/steveyegge/beads/pull/2847))
-- **ADO/Jira custom type_map** — Custom type maps no longer silently ignored. ADO dependency links now imported correctly. ([PR #2771](https://github.com/steveyegge/beads/pull/2771))
-- **Init safety guard** — `bd init --force` no longer bypasses close --quiet check. ([PR #2799](https://github.com/steveyegge/beads/pull/2799))
-- **Circuit breaker TTL** — Stale circuit breaker files cleaned during init; files moved to subdirectory. ([PR #2799](https://github.com/steveyegge/beads/pull/2799))
-- **`bd show --watch`** — Replaced fsnotify with polling to fix cross-platform compatibility. ([PR #2755](https://github.com/steveyegge/beads/pull/2755))
-- **Config unset routing** — `config unset` now routes to correct store; backup keys shown in list. ([GH#2727](https://github.com/steveyegge/beads/issues/2727))
-- **Doctor false errors** — Server health checks skipped when no Dolt server expected; bare worktree fallback fixed. ([GH#2722](https://github.com/steveyegge/beads/issues/2722))
-- **UTC timestamps** — ADO/Jira defer_until comparisons use UTC_TIMESTAMP(). ([PR #2819](https://github.com/steveyegge/beads/pull/2819))
-- **Cloud storage routing** — Push/pull routed through CLI when cloud storage env vars are set. ([GH#2820](https://github.com/steveyegge/beads/issues/2820))
-- **Embedded schema** — Removed HOP columns (crystallizes, quality_score) from embedded schema. ([PR #2837](https://github.com/steveyegge/beads/pull/2837))
-- **JSON path quoting** — Dotted metadata keys now properly quoted in JSON path expressions. ([PR #2865](https://github.com/steveyegge/beads/pull/2865))
-- **Hook fire on update** — `bd update --status closed` now fires on_close hook; `bd close` fires on_update. ([PR #2754](https://github.com/steveyegge/beads/pull/2754))
+- **Epic closure eligibility** — Wisp children now correctly included in epic closure checks. ([PR #2843](https://github.com/gastownhall/beads/pull/2843))
+- **Prefix routing** — `bd edit`, `bd reopen`, and `bd delete` now correctly route with prefixes from town root. ([PRs #2780, #2847](https://github.com/gastownhall/beads/pull/2847))
+- **ADO/Jira custom type_map** — Custom type maps no longer silently ignored. ADO dependency links now imported correctly. ([PR #2771](https://github.com/gastownhall/beads/pull/2771))
+- **Init safety guard** — `bd init --force` no longer bypasses close --quiet check. ([PR #2799](https://github.com/gastownhall/beads/pull/2799))
+- **Circuit breaker TTL** — Stale circuit breaker files cleaned during init; files moved to subdirectory. ([PR #2799](https://github.com/gastownhall/beads/pull/2799))
+- **`bd show --watch`** — Replaced fsnotify with polling to fix cross-platform compatibility. ([PR #2755](https://github.com/gastownhall/beads/pull/2755))
+- **Config unset routing** — `config unset` now routes to correct store; backup keys shown in list. ([GH#2727](https://github.com/gastownhall/beads/issues/2727))
+- **Doctor false errors** — Server health checks skipped when no Dolt server expected; bare worktree fallback fixed. ([GH#2722](https://github.com/gastownhall/beads/issues/2722))
+- **UTC timestamps** — ADO/Jira defer_until comparisons use UTC_TIMESTAMP(). ([PR #2819](https://github.com/gastownhall/beads/pull/2819))
+- **Cloud storage routing** — Push/pull routed through CLI when cloud storage env vars are set. ([GH#2820](https://github.com/gastownhall/beads/issues/2820))
+- **Embedded schema** — Removed HOP columns (crystallizes, quality_score) from embedded schema. ([PR #2837](https://github.com/gastownhall/beads/pull/2837))
+- **JSON path quoting** — Dotted metadata keys now properly quoted in JSON path expressions. ([PR #2865](https://github.com/gastownhall/beads/pull/2865))
+- **Hook fire on update** — `bd update --status closed` now fires on_close hook; `bd close` fires on_update. ([PR #2754](https://github.com/gastownhall/beads/pull/2754))
 
 ### Embedded Dolt
 
@@ -204,7 +204,7 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 
 ### Added
 
-- **Custom status categories** — `bd config set status.custom "in_review:active,qa_testing:wip,archived:done,on_hold:frozen"` assigns categories to custom statuses that control behavior in `bd ready` (active statuses included) and `bd list` (done/frozen statuses excluded by default). Backward compatible — old flat format `"foo,bar"` still works with no behavior change. ([PR #2665](https://github.com/steveyegge/beads/pull/2665))
+- **Custom status categories** — `bd config set status.custom "in_review:active,qa_testing:wip,archived:done,on_hold:frozen"` assigns categories to custom statuses that control behavior in `bd ready` (active statuses included) and `bd list` (done/frozen statuses excluded by default). Backward compatible — old flat format `"foo,bar"` still works with no behavior change. ([PR #2665](https://github.com/gastownhall/beads/pull/2665))
 - **`bd statuses` command** — Lists all built-in and custom statuses with their icons, categories, and descriptions. Supports `--json` for programmatic use.
 - **`bd note` command** — Shorthand for appending notes to issues without the `bd update --note` ceremony.
 - **Audit logging** — Status, assignee, and priority changes are logged to `.beads/interactions.jsonl` with close reasons. Survives Dolt GC flatten, so you can recover context after aggressive cleanup.
@@ -225,21 +225,21 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 
 ### Fixed
 
-- **Windows Dolt server lifecycle** — `ErrServerNotRunning` sentinel error prevents false "failed to stop" warnings; stale PID/port files cleaned up even when server is already dead. ([GH#2670](https://github.com/steveyegge/beads/issues/2670))
-- **Hook preservation** — `bd init` now preserves ALL pre-existing hooks (not just beads-managed ones) when overriding `core.hooksPath`. ([PR #2738](https://github.com/steveyegge/beads/pull/2738))
-- **Shim timeout** — Hook shim timeout increased from 30s to 300s, preventing premature termination of chained pre-commit pipelines (linters, formatters, type-checkers). Configurable via `BEADS_HOOK_TIMEOUT`. ([GH#2732](https://github.com/steveyegge/beads/issues/2732))
-- **GetNextChildIDTx query** — Replaced broken `CAST(SUBSTRING_INDEX(...) AS UNSIGNED)` with Go-side `ParseHierarchicalID`, fixing child ID reconciliation for non-numeric IDs after JSONL imports. ([GH#2721](https://github.com/steveyegge/beads/issues/2721))
-- **Credential key in .gitignore** — `.beads-credential-key` added to project-root `.gitignore` template as defense-in-depth for the AES-256 encryption key. ([GH#2695](https://github.com/steveyegge/beads/issues/2695))
+- **Windows Dolt server lifecycle** — `ErrServerNotRunning` sentinel error prevents false "failed to stop" warnings; stale PID/port files cleaned up even when server is already dead. ([GH#2670](https://github.com/gastownhall/beads/issues/2670))
+- **Hook preservation** — `bd init` now preserves ALL pre-existing hooks (not just beads-managed ones) when overriding `core.hooksPath`. ([PR #2738](https://github.com/gastownhall/beads/pull/2738))
+- **Shim timeout** — Hook shim timeout increased from 30s to 300s, preventing premature termination of chained pre-commit pipelines (linters, formatters, type-checkers). Configurable via `BEADS_HOOK_TIMEOUT`. ([GH#2732](https://github.com/gastownhall/beads/issues/2732))
+- **GetNextChildIDTx query** — Replaced broken `CAST(SUBSTRING_INDEX(...) AS UNSIGNED)` with Go-side `ParseHierarchicalID`, fixing child ID reconciliation for non-numeric IDs after JSONL imports. ([GH#2721](https://github.com/gastownhall/beads/issues/2721))
+- **Credential key in .gitignore** — `.beads-credential-key` added to project-root `.gitignore` template as defense-in-depth for the AES-256 encryption key. ([GH#2695](https://github.com/gastownhall/beads/issues/2695))
 - **SQL stored procedures for flatten/compact** — `bd flatten` and `bd compact` now use SQL stored procedures in server mode, fixing failures on shared Dolt servers.
 - **`--format json` collision** — Resolved flag collision between `rootCmd` persistent `--format` flag and `list`/`dep-tree` local `--json` flags.
-- **Concurrent schema init** — `initSchemaOnDB` serialized with `GET_LOCK` to prevent Dolt journal corruption in multi-agent environments. ([GH#2672](https://github.com/steveyegge/beads/issues/2672))
-- **External Dolt server safety** — `KillStaleServers` respects `IsAutoStartDisabled` and server ownership, preventing accidental kills of externally-managed servers. ([GH#2641](https://github.com/steveyegge/beads/issues/2641))
-- **Doctor infinite restart loop** — Doctor no longer triggers infinite Dolt server restart cycles. ([GH#2636](https://github.com/steveyegge/beads/issues/2636))
-- **Schema version 8** — Dolt schema bumped to version 8 with proper commit of version update. ([PR #2635](https://github.com/steveyegge/beads/pull/2635))
+- **Concurrent schema init** — `initSchemaOnDB` serialized with `GET_LOCK` to prevent Dolt journal corruption in multi-agent environments. ([GH#2672](https://github.com/gastownhall/beads/issues/2672))
+- **External Dolt server safety** — `KillStaleServers` respects `IsAutoStartDisabled` and server ownership, preventing accidental kills of externally-managed servers. ([GH#2641](https://github.com/gastownhall/beads/issues/2641))
+- **Doctor infinite restart loop** — Doctor no longer triggers infinite Dolt server restart cycles. ([GH#2636](https://github.com/gastownhall/beads/issues/2636))
+- **Schema version 8** — Dolt schema bumped to version 8 with proper commit of version update. ([PR #2635](https://github.com/gastownhall/beads/pull/2635))
 - **Repo-local servers** — Auto-started Dolt servers kept alive across sequential `bd` commands within the same repo.
-- **Store config preservation** — Reopening stores by path no longer drops repo-specific config. ([PR #2628](https://github.com/steveyegge/beads/pull/2628))
-- **Validation on close** — `--validate` now checks `--acceptance` field; `validation.on-close` config controls enforcement. ([PR #2654](https://github.com/steveyegge/beads/pull/2654))
-- **`.beads/.env` load order** — Environment file loaded before `noDbCommands` early return, fixing env-dependent non-DB commands. ([GH#2677](https://github.com/steveyegge/beads/issues/2677))
+- **Store config preservation** — Reopening stores by path no longer drops repo-specific config. ([PR #2628](https://github.com/gastownhall/beads/pull/2628))
+- **Validation on close** — `--validate` now checks `--acceptance` field; `validation.on-close` config controls enforcement. ([PR #2654](https://github.com/gastownhall/beads/pull/2654))
+- **`.beads/.env` load order** — Environment file loaded before `noDbCommands` early return, fixing env-dependent non-DB commands. ([GH#2677](https://github.com/gastownhall/beads/issues/2677))
 - **Update description safety** — Empty stdin/file no longer silently erases descriptions; requires explicit opt-in.
 - **Bootstrap JSONL imports** — Correctly imports from git-tracked `.beads/issues.jsonl`.
 - **Doctor fail-closed** — Server-mode integrity recovery now fails closed instead of silently passing.
@@ -256,19 +256,19 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 
 ### Added
 
-- **`--no-history` flag** — `bd create --no-history` stores beads in the wisps table (skipping Dolt commits) without making them GC-eligible, fixing agent identity beads being incorrectly garbage collected. `bd update --no-history`/`--history` toggles the flag. ([GH#2619](https://github.com/steveyegge/beads/issues/2619))
+- **`--no-history` flag** — `bd create --no-history` stores beads in the wisps table (skipping Dolt commits) without making them GC-eligible, fixing agent identity beads being incorrectly garbage collected. `bd update --no-history`/`--history` toggles the flag. ([GH#2619](https://github.com/gastownhall/beads/issues/2619))
 - **`--claim-next` flag** — `bd close --claim-next` auto-claims the next highest priority available issue after closing
 - **`--skills` and `--context` flags** — `bd create --skills`/`--context` add structured sections to issue descriptions
 - **`--exclude-type` for wisp GC** — `bd mol wisp gc --exclude-type agent,rig` protects specific types from garbage collection
 - **`--type` filter for wisp list** — `bd mol wisp list --type bug` filters by issue type
-- **Auto-detect beads database on git origin** — `bd bootstrap` probes origin for `refs/dolt/data` and auto-clones the database; `bd init` warns when existing data is detected ([GH#2580](https://github.com/steveyegge/beads/issues/2580))
-- **Install checksum verification** — install scripts verify SHA256 checksums before extraction ([GH#1857](https://github.com/steveyegge/beads/issues/1857))
+- **Auto-detect beads database on git origin** — `bd bootstrap` probes origin for `refs/dolt/data` and auto-clones the database; `bd init` warns when existing data is detected ([GH#2580](https://github.com/gastownhall/beads/issues/2580))
+- **Install checksum verification** — install scripts verify SHA256 checksums before extraction ([GH#1857](https://github.com/gastownhall/beads/issues/1857))
 - **Jira `pull_jql` config** — `jira.pull_jql` config key or `JIRA_PULL_JQL` env var for custom JQL filters during issue fetch
 - **UUID primary keys** — events, comments, and snapshot tables migrated from AUTO_INCREMENT to UUID() primary keys for federation-safe multi-clone operation
 
 ### Changed
 
-- **Prime SSOT** — `bd prime` is now the single source of truth for agent instructions. Agent files use versioned hash-based markers with profile support (full/minimal) for staleness detection and automatic upgrades. Symlink safety and profile precedence (full preserved over minimal) ([GH#2139](https://github.com/steveyegge/beads/issues/2139))
+- **Prime SSOT** — `bd prime` is now the single source of truth for agent instructions. Agent files use versioned hash-based markers with profile support (full/minimal) for staleness detection and automatic upgrades. Symlink safety and profile precedence (full preserved over minimal) ([GH#2139](https://github.com/gastownhall/beads/issues/2139))
 - **Formula extends merges by ID** — child steps with matching IDs override parent steps in-place instead of appending duplicates
 - **Circuit breaker keyed on host:port** — prevents cross-host blocking when servers share a port
 - **Backup scoped by prefix** — backup export and restore filter by current project prefix, preventing cross-project data leakage on shared servers
@@ -292,80 +292,80 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 
 ### Added
 
-- **`bd bootstrap` with recovery actions** — `bd bootstrap` now executes recovery actions directly instead of just printing advice, making first-run and repair workflows hands-free ([GH#2438](https://github.com/steveyegge/beads/issues/2438), [GH#2372](https://github.com/steveyegge/beads/issues/2372))
-- **`bd context` command** — new command for safe-first error guidance, surfacing relevant context when things go wrong (fix-merge [PR #2496](https://github.com/steveyegge/beads/pull/2496))
-- **`bd help --list` and `bd help --doc`** — CLI doc generation flags for producing machine-readable command listings and full documentation ([GH#2527](https://github.com/steveyegge/beads/issues/2527))
+- **`bd bootstrap` with recovery actions** — `bd bootstrap` now executes recovery actions directly instead of just printing advice, making first-run and repair workflows hands-free ([GH#2438](https://github.com/gastownhall/beads/issues/2438), [GH#2372](https://github.com/gastownhall/beads/issues/2372))
+- **`bd context` command** — new command for safe-first error guidance, surfacing relevant context when things go wrong (fix-merge [PR #2496](https://github.com/gastownhall/beads/pull/2496))
+- **`bd help --list` and `bd help --doc`** — CLI doc generation flags for producing machine-readable command listings and full documentation ([GH#2527](https://github.com/gastownhall/beads/issues/2527))
 - **`bd done` alias** — `bd done` is now an alias for `bd close`, aligning with Gas Town's session lifecycle vocabulary
 - **`bd done <id> <message>`** — last argument is treated as the close reason, removing the need for `--comment`
-- **`--design-file` flag** — read design documents from files instead of stdin for `bd create` workflows ([PR #2524](https://github.com/steveyegge/beads/pull/2524))
-- **`--destroy-token` for safe re-init** — enables non-interactive `bd init` re-initialization with explicit confirmation token ([GH#2497](https://github.com/steveyegge/beads/issues/2497))
-- **GitHub Issues integration** — tracker plugin for syncing GitHub Issues with beads ([GH#2373](https://github.com/steveyegge/beads/issues/2373))
-- **Global PRIME.md fallback** — `~/.config/beads/PRIME.md` is used when no project-level PRIME.md exists ([GH#2330](https://github.com/steveyegge/beads/issues/2330))
-- **Shared Dolt server mode** — multi-repo and multi-agent setups can share a single Dolt server instance ([GH#2416](https://github.com/steveyegge/beads/issues/2416))
-- **Ephemeral port allocation for Dolt** — replaces hash-derived ports with OS-assigned ephemeral ports, eliminating port collisions entirely ([GH#2415](https://github.com/steveyegge/beads/issues/2415))
-- **Workspace identity preflight** — `bd bootstrap` validates workspace identity before any operations ([GH#2438](https://github.com/steveyegge/beads/issues/2438))
+- **`--design-file` flag** — read design documents from files instead of stdin for `bd create` workflows ([PR #2524](https://github.com/gastownhall/beads/pull/2524))
+- **`--destroy-token` for safe re-init** — enables non-interactive `bd init` re-initialization with explicit confirmation token ([GH#2497](https://github.com/gastownhall/beads/issues/2497))
+- **GitHub Issues integration** — tracker plugin for syncing GitHub Issues with beads ([GH#2373](https://github.com/gastownhall/beads/issues/2373))
+- **Global PRIME.md fallback** — `~/.config/beads/PRIME.md` is used when no project-level PRIME.md exists ([GH#2330](https://github.com/gastownhall/beads/issues/2330))
+- **Shared Dolt server mode** — multi-repo and multi-agent setups can share a single Dolt server instance ([GH#2416](https://github.com/gastownhall/beads/issues/2416))
+- **Ephemeral port allocation for Dolt** — replaces hash-derived ports with OS-assigned ephemeral ports, eliminating port collisions entirely ([GH#2415](https://github.com/gastownhall/beads/issues/2415))
+- **Workspace identity preflight** — `bd bootstrap` validates workspace identity before any operations ([GH#2438](https://github.com/gastownhall/beads/issues/2438))
 - **Epic close guards** — prevents accidental closure of epics with open children; includes merge re-parenting and progress display
-- **`bd search` searches `external_ref`** — external references (GitHub issue URLs, Linear IDs, etc.) are now searchable ([GH#2494](https://github.com/steveyegge/beads/issues/2494))
-- **JSON-aware error output** — errors include structured JSON when `--json` is active, with JSONL schema validation and contract tests ([GH#2499](https://github.com/steveyegge/beads/issues/2499))
+- **`bd search` searches `external_ref`** — external references (GitHub issue URLs, Linear IDs, etc.) are now searchable ([GH#2494](https://github.com/gastownhall/beads/issues/2494))
+- **JSON-aware error output** — errors include structured JSON when `--json` is active, with JSONL schema validation and contract tests ([GH#2499](https://github.com/gastownhall/beads/issues/2499))
 - **`ai.api_key` config** — fallback for `ANTHROPIC_API_KEY` environment variable, stored in `config.yaml`
-- **Embedded Dolt storage interfaces** — new storage abstraction layer contributed by DoltHub (coffeegoddd) for future embedded Dolt work ([PR #2427](https://github.com/steveyegge/beads/pull/2427), [PR #2428](https://github.com/steveyegge/beads/pull/2428))
-- **Community tools** — added beads-web and claude-protocol to COMMUNITY_TOOLS.md; added community forks listing ([PR #2457](https://github.com/steveyegge/beads/pull/2457))
+- **Embedded Dolt storage interfaces** — new storage abstraction layer contributed by DoltHub (coffeegoddd) for future embedded Dolt work ([PR #2427](https://github.com/gastownhall/beads/pull/2427), [PR #2428](https://github.com/gastownhall/beads/pull/2428))
+- **Community tools** — added beads-web and claude-protocol to COMMUNITY_TOOLS.md; added community forks listing ([PR #2457](https://github.com/gastownhall/beads/pull/2457))
 
 ### Changed
 
-- **Dolt port allocation** — switched from deterministic hash-derived ports to OS-assigned ephemeral ports; stored in repo-local state file rather than derived at runtime ([GH#2415](https://github.com/steveyegge/beads/issues/2415))
-- **Auto-push state moved to local file** — prevents metadata merge conflicts during `bd dolt pull` by keeping auto-push state out of the shared metadata ([GH#2466](https://github.com/steveyegge/beads/issues/2466))
-- **YAML config prefix precedence** — YAML config prefix now takes precedence over DB-stored prefix in shared-server mode ([GH#2469](https://github.com/steveyegge/beads/issues/2469))
-- **Charm library upgrades** — migrated glamour to v2 (`charm.land/glamour/v2`) and huh to v2 (`charm.land/huh/v2`) ([GH#2471](https://github.com/steveyegge/beads/issues/2471))
-- **Daemon infrastructure fully removed** — final cleanup of all remaining daemon references and idle monitor infrastructure ([GH#2431](https://github.com/steveyegge/beads/issues/2431), [GH#2452](https://github.com/steveyegge/beads/issues/2452))
-- **Dead sync mode scaffolding removed** — removed remaining sync mode code that was left behind after the Dolt migration ([GH#2485](https://github.com/steveyegge/beads/issues/2485))
-- **3-way merge engine remnants removed** — cleaned up leftover code from the removed 3-way merge system ([GH#2391](https://github.com/steveyegge/beads/issues/2391))
+- **Dolt port allocation** — switched from deterministic hash-derived ports to OS-assigned ephemeral ports; stored in repo-local state file rather than derived at runtime ([GH#2415](https://github.com/gastownhall/beads/issues/2415))
+- **Auto-push state moved to local file** — prevents metadata merge conflicts during `bd dolt pull` by keeping auto-push state out of the shared metadata ([GH#2466](https://github.com/gastownhall/beads/issues/2466))
+- **YAML config prefix precedence** — YAML config prefix now takes precedence over DB-stored prefix in shared-server mode ([GH#2469](https://github.com/gastownhall/beads/issues/2469))
+- **Charm library upgrades** — migrated glamour to v2 (`charm.land/glamour/v2`) and huh to v2 (`charm.land/huh/v2`) ([GH#2471](https://github.com/gastownhall/beads/issues/2471))
+- **Daemon infrastructure fully removed** — final cleanup of all remaining daemon references and idle monitor infrastructure ([GH#2431](https://github.com/gastownhall/beads/issues/2431), [GH#2452](https://github.com/gastownhall/beads/issues/2452))
+- **Dead sync mode scaffolding removed** — removed remaining sync mode code that was left behind after the Dolt migration ([GH#2485](https://github.com/gastownhall/beads/issues/2485))
+- **3-way merge engine remnants removed** — cleaned up leftover code from the removed 3-way merge system ([GH#2391](https://github.com/gastownhall/beads/issues/2391))
 - **Nix flake** — uses `go mod edit` instead of `sed` for version patching (more reliable)
 
 ### Fixed
 
-- **Dolt journal corruption** — `KillStaleServers` now runs inside `flock` to prevent concurrent server kills from corrupting the Dolt journal ([GH#2430](https://github.com/steveyegge/beads/issues/2430))
-- **Dolt config corruption** — uses explicit `DOLT_ADD` to prevent config corruption from stale working set state ([GH#2455](https://github.com/steveyegge/beads/issues/2455))
-- **Dolt pull merge errors** — auto-commits pending changes before pull to prevent merge errors ([GH#2474](https://github.com/steveyegge/beads/issues/2474))
-- **Dolt pull transaction safety** — wraps `DOLT_PULL` in explicit transaction for autocommit compatibility ([GH#2501](https://github.com/steveyegge/beads/issues/2501))
-- **Dolt remote directory** — `bd dolt remote add/list/remove` now operate on the correct directory ([GH#2306](https://github.com/steveyegge/beads/issues/2306), [GH#2311](https://github.com/steveyegge/beads/issues/2311))
-- **Dolt endpoint drift** — warns when auto-started server endpoint doesn't match config ([GH#2399](https://github.com/steveyegge/beads/issues/2399))
-- **CLI remotes synced into SQL server** — CLI-managed remotes are now synced into the SQL server on store open ([GH#2315](https://github.com/steveyegge/beads/issues/2315))
-- **Server mode `.beads/` creation** — correctly creates `.beads/` directory when using external `BEADS_DOLT_*` env vars ([GH#2519](https://github.com/steveyegge/beads/issues/2519))
-- **Metadata merge conflicts** — auto-resolves metadata merge conflicts during `bd dolt pull` ([GH#2466](https://github.com/steveyegge/beads/issues/2466))
-- **Metadata replacement bug** — `--metadata` now merges with existing metadata instead of replacing it ([GH#2423](https://github.com/steveyegge/beads/issues/2423))
-- **Backup file detection** — detects backup files on database-not-found and after `bd init` ([GH#2327](https://github.com/steveyegge/beads/issues/2327))
-- **`bd export` crash** — fixed crash on zero-time timestamps and stale `bd sync` refs ([GH#2488](https://github.com/steveyegge/beads/issues/2488), [GH#2493](https://github.com/steveyegge/beads/issues/2493))
-- **`bd children`** — now includes closed children by default ([GH#2481](https://github.com/steveyegge/beads/issues/2481))
-- **`bd doctor --fix`** — regenerates missing `metadata.json` ([GH#2482](https://github.com/steveyegge/beads/issues/2482)); backfills `project_id` for pre-GH#2372 Dolt stores ([GH#2490](https://github.com/steveyegge/beads/issues/2490)); blocked at Gas Town town root to prevent accidental damage ([GH#2450](https://github.com/steveyegge/beads/issues/2450))
-- **`bd doctor`** — detects stale `.legacy` hook sidecars ([GH#2398](https://github.com/steveyegge/beads/issues/2398)); `--clean --json` now works correctly ([GH#2438](https://github.com/steveyegge/beads/issues/2438))
-- **`bd lint`** — accepts non-empty `acceptance_criteria` field without heading ([GH#2468](https://github.com/steveyegge/beads/issues/2468))
+- **Dolt journal corruption** — `KillStaleServers` now runs inside `flock` to prevent concurrent server kills from corrupting the Dolt journal ([GH#2430](https://github.com/gastownhall/beads/issues/2430))
+- **Dolt config corruption** — uses explicit `DOLT_ADD` to prevent config corruption from stale working set state ([GH#2455](https://github.com/gastownhall/beads/issues/2455))
+- **Dolt pull merge errors** — auto-commits pending changes before pull to prevent merge errors ([GH#2474](https://github.com/gastownhall/beads/issues/2474))
+- **Dolt pull transaction safety** — wraps `DOLT_PULL` in explicit transaction for autocommit compatibility ([GH#2501](https://github.com/gastownhall/beads/issues/2501))
+- **Dolt remote directory** — `bd dolt remote add/list/remove` now operate on the correct directory ([GH#2306](https://github.com/gastownhall/beads/issues/2306), [GH#2311](https://github.com/gastownhall/beads/issues/2311))
+- **Dolt endpoint drift** — warns when auto-started server endpoint doesn't match config ([GH#2399](https://github.com/gastownhall/beads/issues/2399))
+- **CLI remotes synced into SQL server** — CLI-managed remotes are now synced into the SQL server on store open ([GH#2315](https://github.com/gastownhall/beads/issues/2315))
+- **Server mode `.beads/` creation** — correctly creates `.beads/` directory when using external `BEADS_DOLT_*` env vars ([GH#2519](https://github.com/gastownhall/beads/issues/2519))
+- **Metadata merge conflicts** — auto-resolves metadata merge conflicts during `bd dolt pull` ([GH#2466](https://github.com/gastownhall/beads/issues/2466))
+- **Metadata replacement bug** — `--metadata` now merges with existing metadata instead of replacing it ([GH#2423](https://github.com/gastownhall/beads/issues/2423))
+- **Backup file detection** — detects backup files on database-not-found and after `bd init` ([GH#2327](https://github.com/gastownhall/beads/issues/2327))
+- **`bd export` crash** — fixed crash on zero-time timestamps and stale `bd sync` refs ([GH#2488](https://github.com/gastownhall/beads/issues/2488), [GH#2493](https://github.com/gastownhall/beads/issues/2493))
+- **`bd children`** — now includes closed children by default ([GH#2481](https://github.com/gastownhall/beads/issues/2481))
+- **`bd doctor --fix`** — regenerates missing `metadata.json` ([GH#2482](https://github.com/gastownhall/beads/issues/2482)); backfills `project_id` for pre-GH#2372 Dolt stores ([GH#2490](https://github.com/gastownhall/beads/issues/2490)); blocked at Gas Town town root to prevent accidental damage ([GH#2450](https://github.com/gastownhall/beads/issues/2450))
+- **`bd doctor`** — detects stale `.legacy` hook sidecars ([GH#2398](https://github.com/gastownhall/beads/issues/2398)); `--clean --json` now works correctly ([GH#2438](https://github.com/gastownhall/beads/issues/2438))
+- **`bd lint`** — accepts non-empty `acceptance_criteria` field without heading ([GH#2468](https://github.com/gastownhall/beads/issues/2468))
 - **`bd list --json`** — no longer ignored when `--tree` defaults to true (three separate fixes consolidated)
 - **`bd mol wisp`** — reports correct count when `RootOnly=true`
-- **`bd init`** — prevented from creating DB on another project's Dolt server ([GH#2336](https://github.com/steveyegge/beads/issues/2336)); init guard allows fresh clones with committed `metadata.json` ([GH#2433](https://github.com/steveyegge/beads/issues/2433)); `data-dir` blocked in server mode ([GH#2438](https://github.com/steveyegge/beads/issues/2438))
+- **`bd init`** — prevented from creating DB on another project's Dolt server ([GH#2336](https://github.com/gastownhall/beads/issues/2336)); init guard allows fresh clones with committed `metadata.json` ([GH#2433](https://github.com/gastownhall/beads/issues/2433)); `data-dir` blocked in server mode ([GH#2438](https://github.com/gastownhall/beads/issues/2438))
 - **Init guard error message** — removed dangerous `--force` suggestion
-- **JSONL backups** — preserve dependency metadata ([GH#2487](https://github.com/steveyegge/beads/issues/2487)); restore denormalized JSONL without data loss ([GH#2479](https://github.com/steveyegge/beads/issues/2479))
-- **Reparented children** — excluded from molecule auto-close ([GH#2480](https://github.com/steveyegge/beads/issues/2480))
-- **Worktree hooks** — use absolute path for `core.hooksPath` so hooks work in worktrees ([GH#2414](https://github.com/steveyegge/beads/issues/2414))
+- **JSONL backups** — preserve dependency metadata ([GH#2487](https://github.com/gastownhall/beads/issues/2487)); restore denormalized JSONL without data loss ([GH#2479](https://github.com/gastownhall/beads/issues/2479))
+- **Reparented children** — excluded from molecule auto-close ([GH#2480](https://github.com/gastownhall/beads/issues/2480))
+- **Worktree hooks** — use absolute path for `core.hooksPath` so hooks work in worktrees ([GH#2414](https://github.com/gastownhall/beads/issues/2414))
 - **Worktree `.gitignore`** — skip append when parent directory pattern already covers the entry
 - **Git hook shims** — added timeout and graceful DB-missing handling
 - **Stale lock files** — follow redirect target when cleaning stale lock files
 - **BEADS_DIR** — stabilized paths from detached commit worktrees; prefer stable branch worktrees
-- **`BEADS_DOLT_PORT` fallback** — added fallback in `GetDoltServerPort()` ([GH#2486](https://github.com/steveyegge/beads/issues/2486))
-- **PersistentPreRun flag checks** — use `Root().PersistentFlags()` for all persistent flag checks ([GH#2514](https://github.com/steveyegge/beads/issues/2514))
+- **`BEADS_DOLT_PORT` fallback** — added fallback in `GetDoltServerPort()` ([GH#2486](https://github.com/gastownhall/beads/issues/2486))
+- **PersistentPreRun flag checks** — use `Root().PersistentFlags()` for all persistent flag checks ([GH#2514](https://github.com/gastownhall/beads/issues/2514))
 - **Stale pinned flag** — auto-cleared on status transition
-- **Install script** — detects WSL and MINGW/MSYS/CYGWIN environments ([PR #2409](https://github.com/steveyegge/beads/pull/2409))
+- **Install script** — detects WSL and MINGW/MSYS/CYGWIN environments ([PR #2409](https://github.com/gastownhall/beads/pull/2409))
 - **Test stability** — Dolt test suite eliminates container crashes and cascading failures; timezone-aware date assertions; same-type issues for blocks dependency tests
 
 ### Performance
 
-- **Close-time template subgraph loading** — significantly faster epic close operations ([GH#2458](https://github.com/steveyegge/beads/issues/2458))
+- **Close-time template subgraph loading** — significantly faster epic close operations ([GH#2458](https://github.com/gastownhall/beads/issues/2458))
 
 ### Documentation
 
-- **Stale sync references purged** — comprehensive cleanup of `bd sync`, `bd import`, `--branch` refs across CLI help, setup generators, and docs ([GH#2522](https://github.com/steveyegge/beads/issues/2522), [GH#2435](https://github.com/steveyegge/beads/issues/2435), [GH#2442](https://github.com/steveyegge/beads/issues/2442))
-- **Stale migration ref fixed** — `bd migrate --to-dolt` references replaced with `bd init --from-jsonl` ([GH#2333](https://github.com/steveyegge/beads/issues/2333))
-- **QUICKSTART.md** — removed stale `--branch` flag and SQLite references ([GH#2522](https://github.com/steveyegge/beads/issues/2522))
+- **Stale sync references purged** — comprehensive cleanup of `bd sync`, `bd import`, `--branch` refs across CLI help, setup generators, and docs ([GH#2522](https://github.com/gastownhall/beads/issues/2522), [GH#2435](https://github.com/gastownhall/beads/issues/2435), [GH#2442](https://github.com/gastownhall/beads/issues/2442))
+- **Stale migration ref fixed** — `bd migrate --to-dolt` references replaced with `bd init --from-jsonl` ([GH#2333](https://github.com/gastownhall/beads/issues/2333))
+- **QUICKSTART.md** — removed stale `--branch` flag and SQLite references ([GH#2522](https://github.com/gastownhall/beads/issues/2522))
 - **CI doc validation** — added CI check to catch stale documentation references
 - **Community tools** — added beads-web and claude-protocol
 
@@ -384,36 +384,36 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 
 ### Added
 
-- **`bd list --tree` default** — tree view is now the default display mode for `bd list` ([GH#2345](https://github.com/steveyegge/beads/issues/2345))
+- **`bd list --tree` default** — tree view is now the default display mode for `bd list` ([GH#2345](https://github.com/gastownhall/beads/issues/2345))
 - **OpenCode recipe** — `bd setup` now includes an OpenCode integration recipe
-- **Fresh clone detection** — `bd doctor` detects fresh clones on Dolt server and guides through init ([GH#2372](https://github.com/steveyegge/beads/issues/2372))
-- **Config-aware init guard** — `bd init` distinguishes server-reachable from DB-exists, with better error messages ([GH#2372](https://github.com/steveyegge/beads/issues/2372))
+- **Fresh clone detection** — `bd doctor` detects fresh clones on Dolt server and guides through init ([GH#2372](https://github.com/gastownhall/beads/issues/2372))
+- **Config-aware init guard** — `bd init` distinguishes server-reachable from DB-exists, with better error messages ([GH#2372](https://github.com/gastownhall/beads/issues/2372))
 - **Sync remote hint in errors** — database-not-found errors now surface `sync.git-remote` config for easier troubleshooting
 - **Nix flake modernization** — updated flake for nixpkgs-25.11, fix-merge of PR #2314
-- **Doctor warning suppression** — suppress specific `bd doctor` warnings via config ([GH#1095](https://github.com/steveyegge/beads/issues/1095))
+- **Doctor warning suppression** — suppress specific `bd doctor` warnings via config ([GH#1095](https://github.com/gastownhall/beads/issues/1095))
 - **Community Tools** — added fancypantalons/nvim-beads to COMMUNITY_TOOLS.md
 
 ### Changed
 
-- **3-way merge config removed** — `ConflictStrategy`, `FieldStrategy`, and all associated config/validation removed; Dolt handles merge natively ([GH#2353](https://github.com/steveyegge/beads/pull/2353))
-- **Daemon infrastructure removed** — the bd daemon has been fully removed; bd is now purely CLI-driven ([w-bd-001](https://github.com/steveyegge/beads/issues/w-bd-001))
+- **3-way merge config removed** — `ConflictStrategy`, `FieldStrategy`, and all associated config/validation removed; Dolt handles merge natively ([GH#2353](https://github.com/gastownhall/beads/pull/2353))
+- **Daemon infrastructure removed** — the bd daemon has been fully removed; bd is now purely CLI-driven ([w-bd-001](https://github.com/gastownhall/beads/issues/w-bd-001))
 - **Legacy daemon lock infrastructure removed** — cleaned up stale lock files and related code
-- **Backup git-push defaults to OFF** — `bd backup` git push now requires explicit opt-in ([GH#2363](https://github.com/steveyegge/beads/issues/2363))
-- **Test infrastructure modernized** — migrated all tests from `StartTestDoltServer` to container-native API; readiness expanded to 5-state enum; crash detection via standalone functions ([GH#2304](https://github.com/steveyegge/beads/pull/2304))
+- **Backup git-push defaults to OFF** — `bd backup` git push now requires explicit opt-in ([GH#2363](https://github.com/gastownhall/beads/issues/2363))
+- **Test infrastructure modernized** — migrated all tests from `StartTestDoltServer` to container-native API; readiness expanded to 5-state enum; crash detection via standalone functions ([GH#2304](https://github.com/gastownhall/beads/pull/2304))
 - **`ExtractPrefix` consolidated** — moved to `types` package for reuse across codebase
 
 ### Fixed
 
-- **Hook marker handling** — `bd doctor --fix` repairs broken/orphaned hook markers; version added to END marker for future matching ([GH#2344](https://github.com/steveyegge/beads/issues/2344))
+- **Hook marker handling** — `bd doctor --fix` repairs broken/orphaned hook markers; version added to END marker for future matching ([GH#2344](https://github.com/gastownhall/beads/issues/2344))
 - **Legacy hook migration** — warn on user-modified legacy hooks; handle backup sidecar files during migration
 - **Dolt push/pull directory** — use correct database subdirectory for CLI push/pull/fetch operations
-- **Contributor auto-routing** — add fallback routing for show/update/close commands ([GH#2345](https://github.com/steveyegge/beads/issues/2345))
+- **Contributor auto-routing** — add fallback routing for show/update/close commands ([GH#2345](https://github.com/gastownhall/beads/issues/2345))
 - **Config-aware prefix detection** — `ResolvePartialID` now respects config for prefix routing
 - **Doctor command order** — correct `enrichFreshClone` command sequencing
-- **Batch IN-clause queries** — prevent full table scans in all IN-clause queries ([GH#2294](https://github.com/steveyegge/beads/issues/2294))
-- **Init port resolution** — use `DefaultConfig` for port resolution during init ([GH#2372](https://github.com/steveyegge/beads/issues/2372))
-- **Idle monitor** — single-instance lock, port config isolation, project UUID verification ([GH#2367](https://github.com/steveyegge/beads/issues/2367), [GH#2372](https://github.com/steveyegge/beads/issues/2372))
-- **Init data safety** — prevent data destruction from misleading error messages ([GH#2363](https://github.com/steveyegge/beads/issues/2363), [GH#2372](https://github.com/steveyegge/beads/issues/2372))
+- **Batch IN-clause queries** — prevent full table scans in all IN-clause queries ([GH#2294](https://github.com/gastownhall/beads/issues/2294))
+- **Init port resolution** — use `DefaultConfig` for port resolution during init ([GH#2372](https://github.com/gastownhall/beads/issues/2372))
+- **Idle monitor** — single-instance lock, port config isolation, project UUID verification ([GH#2367](https://github.com/gastownhall/beads/issues/2367), [GH#2372](https://github.com/gastownhall/beads/issues/2372))
+- **Init data safety** — prevent data destruction from misleading error messages ([GH#2363](https://github.com/gastownhall/beads/issues/2363), [GH#2372](https://github.com/gastownhall/beads/issues/2372))
 - **Circuit breaker tuning** — reduce cooldown to 5s and add active TCP health probe
 - **Deterministic ordering** — add ID tiebreaker to all ORDER BY clauses
 - **Backup on feature branches** — skip git commits during hook runs and on feature branches
@@ -422,16 +422,16 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 - **Tombstone entries** — skip tombstone entries in `bd init --from-jsonl`
 - **DerivePort** — restore as standalone default in `DefaultConfig`; log fallback on collision
 - **Cross-type blocking** — align validation with cross-type blocking rules
-- **Cross-prefix dep routing** — extend to dep commands ([GH#2296](https://github.com/steveyegge/beads/pull/2296))
+- **Cross-prefix dep routing** — extend to dep commands ([GH#2296](https://github.com/gastownhall/beads/pull/2296))
 - **Dolt serialization retry** — retry on serialization error in concurrent tests
-- **CLI routing** — gate on local remote availability; extend SQL push timeout ([GH#2295](https://github.com/steveyegge/beads/pull/2295))
-- **Docker Hub network calls** — skip when Dolt image not cached ([GH#2277](https://github.com/steveyegge/beads/issues/2277))
+- **CLI routing** — gate on local remote availability; extend SQL push timeout ([GH#2295](https://github.com/gastownhall/beads/pull/2295))
+- **Docker Hub network calls** — skip when Dolt image not cached ([GH#2277](https://github.com/gastownhall/beads/issues/2277))
 - **Wisp batch deletes** — commit per batch in `deleteWispBatch` to avoid write timeout
 - **Idle monitor watchdog** — kills itself via `Stop()` to prevent zombie processes
 
 ### Documentation
 
-- Audit and clean up stale sync mode documentation ([w-bd-004](https://github.com/steveyegge/beads/issues/w-bd-004))
+- Audit and clean up stale sync mode documentation ([w-bd-004](https://github.com/gastownhall/beads/issues/w-bd-004))
 - Network/privacy section added to SECURITY.md
 - DerivePort birthday-problem collision recovery documented
 - Misleading examples corrected in QUICKSTART.md
@@ -444,61 +444,61 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 ### Added
 
 - **Persistent agent memory** — `bd remember`, `bd memories`, `bd recall`, `bd forget` for knowledge that survives sessions and account rotations. Backed by the k/v store, auto-injected at `bd prime` time.
-- **`bd purge`** — delete closed ephemeral beads (wisps) to reclaim storage ([GH#1692](https://github.com/steveyegge/beads/issues/1692))
-- **`bd mol last-activity`** — show the most recent activity timestamp for any molecule ([GH#1456](https://github.com/steveyegge/beads/issues/1456))
-- **`bd show --current`** — show the active issue without specifying an ID ([GH#2184](https://github.com/steveyegge/beads/issues/2184))
-- **`bd doctor validate`** — Dolt-native conflict detection for data integrity checks ([GH#2249](https://github.com/steveyegge/beads/issues/2249))
+- **`bd purge`** — delete closed ephemeral beads (wisps) to reclaim storage ([GH#1692](https://github.com/gastownhall/beads/issues/1692))
+- **`bd mol last-activity`** — show the most recent activity timestamp for any molecule ([GH#1456](https://github.com/gastownhall/beads/issues/1456))
+- **`bd show --current`** — show the active issue without specifying an ID ([GH#2184](https://github.com/gastownhall/beads/issues/2184))
+- **`bd doctor validate`** — Dolt-native conflict detection for data integrity checks ([GH#2249](https://github.com/gastownhall/beads/issues/2249))
 - **`bd init --backend`** — explicit backend selection with SQLite deprecation notice
 - **`--stdin` flag** — alias for `--body-file -` on `bd create` and `bd update`
-- **`bd preflight --check`** — aligned with CI checks for pre-push validation ([GH#2230](https://github.com/steveyegge/beads/issues/2230))
-- **gofmt + golangci-lint pre-commit hook** — automatic code quality enforcement ([GH#2179](https://github.com/steveyegge/beads/issues/2179))
-- **JSONL-to-Dolt migration script** — standalone bash script for pre-0.50 users ([GH#2276](https://github.com/steveyegge/beads/issues/2276))
+- **`bd preflight --check`** — aligned with CI checks for pre-push validation ([GH#2230](https://github.com/gastownhall/beads/issues/2230))
+- **gofmt + golangci-lint pre-commit hook** — automatic code quality enforcement ([GH#2179](https://github.com/gastownhall/beads/issues/2179))
+- **JSONL-to-Dolt migration script** — standalone bash script for pre-0.50 users ([GH#2276](https://github.com/gastownhall/beads/issues/2276))
 - **`bd doctor --fix`** — bridge pending hook migrations into automated repair
 - **`bd create-form --parent`** — create sub-issues with label inheritance
 
 ### Fixed
 
-- **Dolt CPU spikes** — batch IN-clause queries in `dependencies.go` and `computeBlockedIDs` to prevent runaway CPU usage on large databases ([GH#2294](https://github.com/steveyegge/beads/issues/2294))
+- **Dolt CPU spikes** — batch IN-clause queries in `dependencies.go` and `computeBlockedIDs` to prevent runaway CPU usage on large databases ([GH#2294](https://github.com/gastownhall/beads/issues/2294))
 - **Dolt joinIter hangs** — avoid hanging queries in `GetReadyWork` blocker computation
-- **Stealth mode backup push** — `no-git-ops` config now correctly prevents backup git push ([GH#2290](https://github.com/steveyegge/beads/issues/2290))
-- **Stale DB connection crash** — retry stale connection and preserve temp file in `bd edit` ([GH#2267](https://github.com/steveyegge/beads/issues/2267))
-- **OSC escape leaks** — prevent escape sequence pollution when third-party hook runners (lefthook, husky) call `bd hooks run` directly ([GH#1303](https://github.com/steveyegge/beads/issues/1303))
-- **`validateIssueIDPrefix`** — now checks `allowed_prefixes` config, unblocking convoy creation with multi-prefix databases ([GH#1179](https://github.com/steveyegge/beads/issues/1179))
-- **Molecule steps in `bd ready`** — remove stale SQLite-era filtering that hid mol steps ([GH#1359](https://github.com/steveyegge/beads/issues/1359))
-- **`bd blocked` children** — include children of blocked parents in output ([GH#1495](https://github.com/steveyegge/beads/issues/1495))
+- **Stealth mode backup push** — `no-git-ops` config now correctly prevents backup git push ([GH#2290](https://github.com/gastownhall/beads/issues/2290))
+- **Stale DB connection crash** — retry stale connection and preserve temp file in `bd edit` ([GH#2267](https://github.com/gastownhall/beads/issues/2267))
+- **OSC escape leaks** — prevent escape sequence pollution when third-party hook runners (lefthook, husky) call `bd hooks run` directly ([GH#1303](https://github.com/gastownhall/beads/issues/1303))
+- **`validateIssueIDPrefix`** — now checks `allowed_prefixes` config, unblocking convoy creation with multi-prefix databases ([GH#1179](https://github.com/gastownhall/beads/issues/1179))
+- **Molecule steps in `bd ready`** — remove stale SQLite-era filtering that hid mol steps ([GH#1359](https://github.com/gastownhall/beads/issues/1359))
+- **`bd blocked` children** — include children of blocked parents in output ([GH#1495](https://github.com/gastownhall/beads/issues/1495))
 - **Same-type blocking validation** — enforce that dependencies match allowed type pairs
-- **Cross-prefix dependency routing** — `bd dep add/rm/blocks/tree` now routes by prefix ([GH#2285](https://github.com/steveyegge/beads/pull/2285))
+- **Cross-prefix dependency routing** — `bd dep add/rm/blocks/tree` now routes by prefix ([GH#2285](https://github.com/gastownhall/beads/pull/2285))
 - **Cross-prefix dep existence check** — skip target existence check for cross-prefix dependencies
-- **Wisps table recreation** — recreate `dolt_ignore`'d wisps tables on schema fast-path ([GH#2271](https://github.com/steveyegge/beads/issues/2271))
-- **Missing wisps table** — gracefully handle in epic/blocked queries ([GH#2271](https://github.com/steveyegge/beads/issues/2271))
+- **Wisps table recreation** — recreate `dolt_ignore`'d wisps tables on schema fast-path ([GH#2271](https://github.com/gastownhall/beads/issues/2271))
+- **Missing wisps table** — gracefully handle in epic/blocked queries ([GH#2271](https://github.com/gastownhall/beads/issues/2271))
 - **Wisp dependency scanning** — scan `wisp_dependencies` in `getChildrenOfIssues` and `getChildrenWithParents`
 - **Cascade-delete wisp children** — delete blocked step children during wisp GC
 - **Batch wisp deletes** — reduce Dolt commit pressure in `DeleteIssues`
-- **Dolt push/pull hint** — show helpful message when remote not found ([GH#2118](https://github.com/steveyegge/beads/issues/2118))
-- **Git-protocol remote fallback** — use CLI fallback for all git-protocol remotes, not just SSH ([GH#2268](https://github.com/steveyegge/beads/issues/2268))
-- **`dolt_data_dir` persistence** — strip absolute paths from `metadata.json` on save ([GH#2251](https://github.com/steveyegge/beads/issues/2251))
-- **Dolt config port** — consult `config.yaml` for `dolt.port` in `DefaultConfig` ([GH#2073](https://github.com/steveyegge/beads/issues/2073))
-- **Missing `dolt_database`** — detect and repair in `metadata.json` ([GH#2160](https://github.com/steveyegge/beads/issues/2160))
-- **Dolt remote guards** — guard remote subcommands against store init bypass ([GH#2224](https://github.com/steveyegge/beads/issues/2224))
+- **Dolt push/pull hint** — show helpful message when remote not found ([GH#2118](https://github.com/gastownhall/beads/issues/2118))
+- **Git-protocol remote fallback** — use CLI fallback for all git-protocol remotes, not just SSH ([GH#2268](https://github.com/gastownhall/beads/issues/2268))
+- **`dolt_data_dir` persistence** — strip absolute paths from `metadata.json` on save ([GH#2251](https://github.com/gastownhall/beads/issues/2251))
+- **Dolt config port** — consult `config.yaml` for `dolt.port` in `DefaultConfig` ([GH#2073](https://github.com/gastownhall/beads/issues/2073))
+- **Missing `dolt_database`** — detect and repair in `metadata.json` ([GH#2160](https://github.com/gastownhall/beads/issues/2160))
+- **Dolt remote guards** — guard remote subcommands against store init bypass ([GH#2224](https://github.com/gastownhall/beads/issues/2224))
 - **`bd search` performance** — avoid `LIKE %%` full-table scans
-- **Worktree DB discovery** — skip own `.beads/` in separate-DB discovery ([GH#2190](https://github.com/steveyegge/beads/issues/2190))
+- **Worktree DB discovery** — skip own `.beads/` in separate-DB discovery ([GH#2190](https://github.com/gastownhall/beads/issues/2190))
 - **Contributor routing** — detect fork workflow, apply routing to list and ready
 - **Pre-commit Go version mismatch** — detect before golangci-lint panics
 - **Viper defaults** — skip in `getRoutingConfigValue` to unblock DB fallback
 - **`bd mol wisp create`** — default to root-only unless formula sets `pour=true`
 - **Bare repo init** — skip `AGENTS.md` generation in bare repositories
-- **`last_import_time` refresh** — prevent false staleness after write commands ([GH#2255](https://github.com/steveyegge/beads/issues/2255))
-- **Hook marker detection** — validate marker count and order; recognize marker-managed hooks ([GH#2244](https://github.com/steveyegge/beads/issues/2244), [GH#2242](https://github.com/steveyegge/beads/issues/2242))
-- **Gitignore template** — add missing dolt runtime files ([GH#2256](https://github.com/steveyegge/beads/issues/2256))
-- **Pre-0.56 Dolt database upgrade** — graceful recovery path ([GH#2137](https://github.com/steveyegge/beads/issues/2137))
-- **Remotesapi port check** — skip when no federation peers configured ([GH#2273](https://github.com/steveyegge/beads/issues/2273))
+- **`last_import_time` refresh** — prevent false staleness after write commands ([GH#2255](https://github.com/gastownhall/beads/issues/2255))
+- **Hook marker detection** — validate marker count and order; recognize marker-managed hooks ([GH#2244](https://github.com/gastownhall/beads/issues/2244), [GH#2242](https://github.com/gastownhall/beads/issues/2242))
+- **Gitignore template** — add missing dolt runtime files ([GH#2256](https://github.com/gastownhall/beads/issues/2256))
+- **Pre-0.56 Dolt database upgrade** — graceful recovery path ([GH#2137](https://github.com/gastownhall/beads/issues/2137))
+- **Remotesapi port check** — skip when no federation peers configured ([GH#2273](https://github.com/gastownhall/beads/issues/2273))
 - **Doctor subsystem** — fix panics, masked errors, missing `rows.Err()`, federation port, hardcoded paths; add 3 new tests
 - **N+1 query patterns** — replace with batch queries in `deep.go` and `migration_validation.go`
-- **`IsBlocked` reporting** — align blocker reporting with blocked-cache semantics ([GH#1524](https://github.com/steveyegge/beads/issues/1524))
+- **`IsBlocked` reporting** — align blocker reporting with blocked-cache semantics ([GH#1524](https://github.com/gastownhall/beads/issues/1524))
 
 ### Removed
 
-- **Beads Classic SQLite backend** — the SQLite storage layer and all migration infrastructure have been removed. Dolt is the only backend. ([GH#87493ce](https://github.com/steveyegge/beads/commit/87493ce9))
+- **Beads Classic SQLite backend** — the SQLite storage layer and all migration infrastructure have been removed. Dolt is the only backend. ([GH#87493ce](https://github.com/gastownhall/beads/commit/87493ce9))
 - **`go-sqlite3` dependency** — no more CGO requirement; tests use Dolt testcontainers
 - **Deprecated commands** — removed dead SQLite-era code and legacy scripts
 
@@ -511,110 +511,110 @@ Contributors: coffeegoddd (Dustin Brown), matt wilkie (maphew), harry-miller-tri
 
 ### Added
 
-- **`bd doctor --agent` mode** — AI agent diagnostics for automated health checks ([bd-6ud](https://github.com/steveyegge/beads/commit/8d5e3ef7))
-- **SSH push/pull fallback** — dual-surface remote management (SQL + CLI) with automatic SSH detection ([#2178](https://github.com/steveyegge/beads/pull/2178))
-- **Hook migration system** — census and migration planning for git hooks with doctor signal ([#2217](https://github.com/steveyegge/beads/pull/2221))
-- **Section markers for git hooks** — hooks now use section markers for safer updates ([GH#1380](https://github.com/steveyegge/beads/pull/2222))
-- **Auto-close molecule root** — molecule root automatically closes when all steps complete ([#2200](https://github.com/steveyegge/beads/issues/2200))
+- **`bd doctor --agent` mode** — AI agent diagnostics for automated health checks ([bd-6ud](https://github.com/gastownhall/beads/commit/8d5e3ef7))
+- **SSH push/pull fallback** — dual-surface remote management (SQL + CLI) with automatic SSH detection ([#2178](https://github.com/gastownhall/beads/pull/2178))
+- **Hook migration system** — census and migration planning for git hooks with doctor signal ([#2217](https://github.com/gastownhall/beads/pull/2221))
+- **Section markers for git hooks** — hooks now use section markers for safer updates ([GH#1380](https://github.com/gastownhall/beads/pull/2222))
+- **Auto-close molecule root** — molecule root automatically closes when all steps complete ([#2200](https://github.com/gastownhall/beads/issues/2200))
 - **CLI aliases** — `--comment` alias for `bd close`, `--yes/-y` alias for `bd mol burn`
 - **`bd backup` commands** — `init`, `sync`, and `restore` for Dolt-native backups
 - **JSONL backup & auto-backup** — `bd export` command for JSONL backup, auto-enable when git remote exists
 - **`bd gc`, `bd compact`, `bd flatten`** — standalone beads lifecycle management
 - **Circuit breaker** — Dolt server connection circuit breaker to prevent agent hangs
-- **Config-driven metadata schema** — enforcement via `metadata_schema` config ([GH#1416](https://github.com/steveyegge/beads/issues/1416))
-- **Metadata flags** — `--metadata` for `bd create`, `--set-metadata`/`--unset-metadata` for `bd update`, metadata filtering in `bd ready` ([GH#1406](https://github.com/steveyegge/beads/issues/1406))
+- **Config-driven metadata schema** — enforcement via `metadata_schema` config ([GH#1416](https://github.com/gastownhall/beads/issues/1416))
+- **Metadata flags** — `--metadata` for `bd create`, `--set-metadata`/`--unset-metadata` for `bd update`, metadata filtering in `bd ready` ([GH#1406](https://github.com/gastownhall/beads/issues/1406))
 - **PreToolUse hook** — blocks interactive cp/mv/rm prompts in agent workflows
-- **Auto-update stale hooks** — `bd init` detects and updates outdated hooks ([GH#1466](https://github.com/steveyegge/beads/issues/1466))
+- **Auto-update stale hooks** — `bd init` detects and updates outdated hooks ([GH#1466](https://github.com/gastownhall/beads/issues/1466))
 - **`--root-only` flag** — for `bd mol wisp create`
-- **`hk` support** — hk.jdx.dev as supported git hook manager ([#2182](https://github.com/steveyegge/beads/pull/2182))
+- **`hk` support** — hk.jdx.dev as supported git hook manager ([#2182](https://github.com/gastownhall/beads/pull/2182))
 - **`bd dolt remote`** — add, list, remove subcommands for Dolt remote management
 - **Auto-push to Dolt remote** — automatic push with 5-minute debounce after Dolt commits
-- **`dolt-data-dir` config** — custom dolt data directory ([#2143](https://github.com/steveyegge/beads/pull/2143))
-- **`--database` flag for `bd init`** — configure existing server database ([#2102](https://github.com/steveyegge/beads/issues/2102))
-- **Per-worktree redirect** — `.beads/redirect` overrides main repo `.beads` ([#1995](https://github.com/steveyegge/beads/pull/1995))
-- **`has_metadata_key`** — new predicate in `bd query` DSL ([#1996](https://github.com/steveyegge/beads/pull/1996))
-- **MCP claim tool** — atomic start-work for MCP integrations ([#2071](https://github.com/steveyegge/beads/pull/2071))
-- **Auto-clean noms LOCK** — stale Dolt noms LOCK file cleanup on startup ([#2059](https://github.com/steveyegge/beads/issues/2059))
+- **`dolt-data-dir` config** — custom dolt data directory ([#2143](https://github.com/gastownhall/beads/pull/2143))
+- **`--database` flag for `bd init`** — configure existing server database ([#2102](https://github.com/gastownhall/beads/issues/2102))
+- **Per-worktree redirect** — `.beads/redirect` overrides main repo `.beads` ([#1995](https://github.com/gastownhall/beads/pull/1995))
+- **`has_metadata_key`** — new predicate in `bd query` DSL ([#1996](https://github.com/gastownhall/beads/pull/1996))
+- **MCP claim tool** — atomic start-work for MCP integrations ([#2071](https://github.com/gastownhall/beads/pull/2071))
+- **Auto-clean noms LOCK** — stale Dolt noms LOCK file cleanup on startup ([#2059](https://github.com/gastownhall/beads/issues/2059))
 - **Stale database detection** — in `bd doctor` and `bd dolt clean-databases`
-- **Self-managing Dolt server** — port collision fallback, idle monitor, crash watchdog for standalone users ([GH#2049](https://github.com/steveyegge/beads/issues/2049), [GH#2050](https://github.com/steveyegge/beads/issues/2050))
+- **Self-managing Dolt server** — port collision fallback, idle monitor, crash watchdog for standalone users ([GH#2049](https://github.com/gastownhall/beads/issues/2049), [GH#2050](https://github.com/gastownhall/beads/issues/2050))
 - **`bd dolt start/stop`** — server lifecycle management commands
-- **Counter mode** — `issue_id_mode=counter` for sequential issue IDs ([#2013](https://github.com/steveyegge/beads/issues/2013))
+- **Counter mode** — `issue_id_mode=counter` for sequential issue IDs ([#2013](https://github.com/gastownhall/beads/issues/2013))
 - **Auto-migration shim** — SQLite to Dolt migration via sqlite3 CLI
 - **Auto-migrate on first command** — SQLite to Dolt auto-migration on first `bd` command
-- **Linear Project sync** — sync Linear projects to beads ([#2022](https://github.com/steveyegge/beads/pull/2022))
+- **Linear Project sync** — sync Linear projects to beads ([#2022](https://github.com/gastownhall/beads/pull/2022))
 - **Label inheritance** — child issues inherit parent labels on creation
 - **Infra type routing** — route agent/rig/role/message beads to wisps table
 - **`IsInfraType` config-driven** — via `types.infra` config key
-- **`bd init --stealth`** — sets `no-git-ops: true` in config ([GH#2159](https://github.com/steveyegge/beads/issues/2159))
+- **`bd init --stealth`** — sets `no-git-ops: true` in config ([GH#2159](https://github.com/gastownhall/beads/issues/2159))
 - **Staleness check** — read-only commands validate against JSONL freshness
-- **CLI feedback titles** — command feedback now shows issue titles ([GH#1384](https://github.com/steveyegge/beads/issues/1384))
-- **OTel design docs** — OpenTelemetry architecture and data model documentation ([#2195](https://github.com/steveyegge/beads/pull/2195))
-- **Jira V2 API** — support for Jira V2 API ([#2088](https://github.com/steveyegge/beads/pull/2088))
+- **CLI feedback titles** — command feedback now shows issue titles ([GH#1384](https://github.com/gastownhall/beads/issues/1384))
+- **OTel design docs** — OpenTelemetry architecture and data model documentation ([#2195](https://github.com/gastownhall/beads/pull/2195))
+- **Jira V2 API** — support for Jira V2 API ([#2088](https://github.com/gastownhall/beads/pull/2088))
 
 ### Fixed
 
 - **Shadow database prevention** — `bd` no longer runs `CREATE DATABASE IF NOT EXISTS` unconditionally; errors with clear diagnostic instead of creating shadow databases
 - **Auto-start suppressed with explicit server port** — prevents shadow database creation when configured server is temporarily down
-- **Phantom catalog entries** — respect existing `dolt_database` config in init and migrate paths ([#2051](https://github.com/steveyegge/beads/issues/2051))
+- **Phantom catalog entries** — respect existing `dolt_database` config in init and migrate paths ([#2051](https://github.com/gastownhall/beads/issues/2051))
 - **`information_schema` resilience** — replace with `SHOW COLUMNS`/`SHOW TABLES` to avoid stale catalog crashes
 - **`bd doctor --server`** — fix crash on phantom entries
-- **Reparented child display** — reparented child no longer appears under old parent ([#2001](https://github.com/steveyegge/beads/pull/2001))
+- **Reparented child display** — reparented child no longer appears under old parent ([#2001](https://github.com/gastownhall/beads/pull/2001))
 - **Homebrew publishing** — use `brews` instead of `homebrew_casks` for formula publishing; auto-publish tap on release
-- **NULL `created_by` crash** — handle NULL in issue scan to prevent `bd duplicates` crash ([#2198](https://github.com/steveyegge/beads/pull/2198))
+- **NULL `created_by` crash** — handle NULL in issue scan to prevent `bd duplicates` crash ([#2198](https://github.com/gastownhall/beads/pull/2198))
 - **Dolt UNION crash** — avoid `SELECT * UNION` that crashes Dolt on column count mismatch
 - **`SHOW DATABASES LIKE`** — replace with exact-match iteration for Dolt compatibility
-- **Dolt port resolution** — doctor checks and all commands use hash-derived port instead of hardcoded 3307 ([#2148](https://github.com/steveyegge/beads/pull/2148))
-- **`dolt_data_dir` respect** — doctor checks use configured data directory ([#2181](https://github.com/steveyegge/beads/pull/2181))
-- **Wisps table defaults** — add default values to NOT NULL TEXT columns ([bd-5nn](https://github.com/steveyegge/beads/commit/f489463b))
-- **AUTO_INCREMENT reset** — reset counters after `DOLT_PULL` ([#2135](https://github.com/steveyegge/beads/pull/2135))
-- **`bd init --stealth`** — correctly sets `no-git-ops: true` in config ([GH#2159](https://github.com/steveyegge/beads/issues/2159))
-- **Skip autopush on read-only** — prevent writes on read-only commands ([GH#2191](https://github.com/steveyegge/beads/pull/2215))
-- **Sandbox guard** — restore sandbox guard in `maybeAutoPush` ([#2192](https://github.com/steveyegge/beads/pull/2210))
-- **Mol notes field** — propagate notes field from formula steps to issues ([#2155](https://github.com/steveyegge/beads/pull/2211))
-- **Graph children layer** — lift children to parent's layer in graph layout ([GH#1748](https://github.com/steveyegge/beads/pull/2208))
-- **DefaultInfraTypes mutation** — unexport to prevent inconsistency ([#2193](https://github.com/steveyegge/beads/pull/2209))
-- **Conditional-blocks readiness** — evaluate conditional-blocks deps in `computeBlockedIDs()` ([#2128](https://github.com/steveyegge/beads/pull/2128))
+- **Dolt port resolution** — doctor checks and all commands use hash-derived port instead of hardcoded 3307 ([#2148](https://github.com/gastownhall/beads/pull/2148))
+- **`dolt_data_dir` respect** — doctor checks use configured data directory ([#2181](https://github.com/gastownhall/beads/pull/2181))
+- **Wisps table defaults** — add default values to NOT NULL TEXT columns ([bd-5nn](https://github.com/gastownhall/beads/commit/f489463b))
+- **AUTO_INCREMENT reset** — reset counters after `DOLT_PULL` ([#2135](https://github.com/gastownhall/beads/pull/2135))
+- **`bd init --stealth`** — correctly sets `no-git-ops: true` in config ([GH#2159](https://github.com/gastownhall/beads/issues/2159))
+- **Skip autopush on read-only** — prevent writes on read-only commands ([GH#2191](https://github.com/gastownhall/beads/pull/2215))
+- **Sandbox guard** — restore sandbox guard in `maybeAutoPush` ([#2192](https://github.com/gastownhall/beads/pull/2210))
+- **Mol notes field** — propagate notes field from formula steps to issues ([#2155](https://github.com/gastownhall/beads/pull/2211))
+- **Graph children layer** — lift children to parent's layer in graph layout ([GH#1748](https://github.com/gastownhall/beads/pull/2208))
+- **DefaultInfraTypes mutation** — unexport to prevent inconsistency ([#2193](https://github.com/gastownhall/beads/pull/2209))
+- **Conditional-blocks readiness** — evaluate conditional-blocks deps in `computeBlockedIDs()` ([#2128](https://github.com/gastownhall/beads/pull/2128))
 - **Dolt connection timeouts** — prevent agent hangs with connection timeouts
-- **Migration safety** — verify DB target, deduplicate, spot-check data during migration ([#2156](https://github.com/steveyegge/beads/issues/2156))
-- **Ephemeral read-path fallback** — fall through to issues table when wisps table missing ([#2161](https://github.com/steveyegge/beads/pull/2161))
-- **Ephemeral explicit-ID lookup** — complete routing across all storage layers ([GH#2053](https://github.com/steveyegge/beads/issues/2053))
-- **`waits-for` deps in `bd blocked`** — include in output ([GH#2043](https://github.com/steveyegge/beads/issues/2043))
-- **Reopen/undefer no-op status** — report correct status ([GH#2037](https://github.com/steveyegge/beads/issues/2037))
-- **Post-create metadata** — commit deps and labels to Dolt after create ([GH#2009](https://github.com/steveyegge/beads/issues/2009))
-- **Status validation** — validate against built-in + custom statuses on update ([#2021](https://github.com/steveyegge/beads/issues/2021))
-- **Empty title/label rejection** — reject on update/label add ([GH#1994](https://github.com/steveyegge/beads/issues/1994))
-- **Non-zero exit on failure** — exit non-zero when all close/update attempts fail ([GH#2014](https://github.com/steveyegge/beads/issues/2014))
-- **JSON metadata validation** — validate on creation path ([#2032](https://github.com/steveyegge/beads/issues/2032))
-- **Wisp field validation** — parity with issues in `createWisp` ([#2032](https://github.com/steveyegge/beads/issues/2032))
+- **Migration safety** — verify DB target, deduplicate, spot-check data during migration ([#2156](https://github.com/gastownhall/beads/issues/2156))
+- **Ephemeral read-path fallback** — fall through to issues table when wisps table missing ([#2161](https://github.com/gastownhall/beads/pull/2161))
+- **Ephemeral explicit-ID lookup** — complete routing across all storage layers ([GH#2053](https://github.com/gastownhall/beads/issues/2053))
+- **`waits-for` deps in `bd blocked`** — include in output ([GH#2043](https://github.com/gastownhall/beads/issues/2043))
+- **Reopen/undefer no-op status** — report correct status ([GH#2037](https://github.com/gastownhall/beads/issues/2037))
+- **Post-create metadata** — commit deps and labels to Dolt after create ([GH#2009](https://github.com/gastownhall/beads/issues/2009))
+- **Status validation** — validate against built-in + custom statuses on update ([#2021](https://github.com/gastownhall/beads/issues/2021))
+- **Empty title/label rejection** — reject on update/label add ([GH#1994](https://github.com/gastownhall/beads/issues/1994))
+- **Non-zero exit on failure** — exit non-zero when all close/update attempts fail ([GH#2014](https://github.com/gastownhall/beads/issues/2014))
+- **JSON metadata validation** — validate on creation path ([#2032](https://github.com/gastownhall/beads/issues/2032))
+- **Wisp field validation** — parity with issues in `createWisp` ([#2032](https://github.com/gastownhall/beads/issues/2032))
 - **Empty comment rejection** — reject whitespace-only comment text
 - **`bd stale` validation** — reject non-positive `--days` flag
 - **`bd defer` past date warning** — warn when `--until` date is in the past
 - **Doctor non-git-repo** — gracefully handle in fingerprint and role checks
-- **Doctor cruft cleaning** — clean cruft in redirect-expected dirs without redirect file ([#2194](https://github.com/steveyegge/beads/pull/2194))
-- **Doctor gitignore** — follow redirect when fixing outdated `.beads/.gitignore` ([#2078](https://github.com/steveyegge/beads/pull/2078))
-- **Doctor maintenance** — migrate maintenance checks to Dolt ([#2146](https://github.com/steveyegge/beads/pull/2146))
-- **Dolt server management** — Gas Town guardrails, one server per town, kill-before-start ([#2089](https://github.com/steveyegge/beads/issues/2089))
-- **Migration 007 resilience** — handle schema evolution differences ([#2168](https://github.com/steveyegge/beads/pull/2168))
-- **Windows compatibility** — Makefile ldflags fix, connectex syscall handling, doltserver filesystem heuristic ([#2165](https://github.com/steveyegge/beads/pull/2165), [#2171](https://github.com/steveyegge/beads/pull/2171), [#2092](https://github.com/steveyegge/beads/pull/2092))
-- **Batch SQL queries** — prevent query explosion with IN-clause batching ([#2108](https://github.com/steveyegge/beads/pull/2108))
-- **Routing write divergence** — check local store before prefix routing ([#2106](https://github.com/steveyegge/beads/pull/2106))
-- **Hook outdated detection** — unify between `CheckGitHooks` and `hooksNeedUpdate` ([#2105](https://github.com/steveyegge/beads/pull/2105))
-- **Linear status sync** — include `stateId` in push updates ([#2144](https://github.com/steveyegge/beads/pull/2144))
+- **Doctor cruft cleaning** — clean cruft in redirect-expected dirs without redirect file ([#2194](https://github.com/gastownhall/beads/pull/2194))
+- **Doctor gitignore** — follow redirect when fixing outdated `.beads/.gitignore` ([#2078](https://github.com/gastownhall/beads/pull/2078))
+- **Doctor maintenance** — migrate maintenance checks to Dolt ([#2146](https://github.com/gastownhall/beads/pull/2146))
+- **Dolt server management** — Gas Town guardrails, one server per town, kill-before-start ([#2089](https://github.com/gastownhall/beads/issues/2089))
+- **Migration 007 resilience** — handle schema evolution differences ([#2168](https://github.com/gastownhall/beads/pull/2168))
+- **Windows compatibility** — Makefile ldflags fix, connectex syscall handling, doltserver filesystem heuristic ([#2165](https://github.com/gastownhall/beads/pull/2165), [#2171](https://github.com/gastownhall/beads/pull/2171), [#2092](https://github.com/gastownhall/beads/pull/2092))
+- **Batch SQL queries** — prevent query explosion with IN-clause batching ([#2108](https://github.com/gastownhall/beads/pull/2108))
+- **Routing write divergence** — check local store before prefix routing ([#2106](https://github.com/gastownhall/beads/pull/2106))
+- **Hook outdated detection** — unify between `CheckGitHooks` and `hooksNeedUpdate` ([#2105](https://github.com/gastownhall/beads/pull/2105))
+- **Linear status sync** — include `stateId` in push updates ([#2144](https://github.com/gastownhall/beads/pull/2144))
 - **Dep type overwrites** — prevent silent dependency type overwrites on dep add
-- **Prefix sanitization** — sanitize hyphens to underscores for SQL database names ([GH#2142](https://github.com/steveyegge/beads/issues/2142))
+- **Prefix sanitization** — sanitize hyphens to underscores for SQL database names ([GH#2142](https://github.com/gastownhall/beads/issues/2142))
 - **Issue prefix normalization** — prevent double-hyphen bead IDs
-- **SQLite `#` in URI paths** — escape to prevent truncation ([#2150](https://github.com/steveyegge/beads/pull/2150))
-- **`bd dep` traversal** — traverse blocks-type edges in dep tree and graph commands ([#2151](https://github.com/steveyegge/beads/pull/2151))
-- **`bd dolt push/pull/commit`** — allow to initialize store ([GH#2042](https://github.com/steveyegge/beads/issues/2042))
+- **SQLite `#` in URI paths** — escape to prevent truncation ([#2150](https://github.com/gastownhall/beads/pull/2150))
+- **`bd dep` traversal** — traverse blocks-type edges in dep tree and graph commands ([#2151](https://github.com/gastownhall/beads/pull/2151))
+- **`bd dolt push/pull/commit`** — allow to initialize store ([GH#2042](https://github.com/gastownhall/beads/issues/2042))
 - **`bd init --from-jsonl`** — restore for server mode
-- **Doctor stale verification** — improved verification after --fix ([#2077](https://github.com/steveyegge/beads/pull/2077))
-- **Upsert on insert** — prevent duplicate primary key errors ([GH#2061](https://github.com/steveyegge/beads/issues/2061))
+- **Doctor stale verification** — improved verification after --fix ([#2077](https://github.com/gastownhall/beads/pull/2077))
+- **Upsert on insert** — prevent duplicate primary key errors ([GH#2061](https://github.com/gastownhall/beads/issues/2061))
 - **Database version auto-migrate** — auto-migrate on CLI upgrade for all commands
 - **Wisp double-prefixing** — stop wisp ID double-prefixing and add wisp fallback to `ResolvePartialID`
 - **Dolt `DOLT_COMMIT` transaction** — commit SQL tx before `DOLT_COMMIT` to persist wisp data
-- **OSC escape leaks** — prevent in git hooks ([GH#1303](https://github.com/steveyegge/beads/issues/1303))
+- **OSC escape leaks** — prevent in git hooks ([GH#1303](https://github.com/gastownhall/beads/issues/1303))
 - **`bd ready --json`** — include labels, deps, and parent in output
-- **Git upstream warning** — suppress for repos with no remotes ([#2116](https://github.com/steveyegge/beads/pull/2116))
+- **Git upstream warning** — suppress for repos with no remotes ([#2116](https://github.com/gastownhall/beads/pull/2116))
 - **`bd` init prefix sanitization** — sanitize auto-detected prefix for MySQL database names
 - **Rejected flag-like args** — reject flag-like positional args in `bd create`
 - **Backup streaming** — stream backup exports to disk, reduce allocations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for your interest in contributing to bd! This document provides guidel
 
 ```bash
 # Clone the repository
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 
 # Build the project (uses gms_pure_go tag via Makefile)
@@ -370,7 +370,7 @@ dlv debug ./cmd/bd -- create "Test issue"
 
 ## Questions?
 
-- Check existing [issues](https://github.com/steveyegge/beads/issues)
+- Check existing [issues](https://github.com/gastownhall/beads/issues)
 - Open a new issue for questions
 - Review [README.md](README.md) and other documentation
 

--- a/NEWSLETTER.md
+++ b/NEWSLETTER.md
@@ -83,9 +83,9 @@ Contributors: coffeegoddd (Dustin Brown / DoltHub), matt wilkie (maphew), harry-
 ```bash
 brew upgrade bd
 # or
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 **Breaking change**: `BD_ACTOR` is deprecated in favor of `BEADS_ACTOR`. The old variable still works as a fallback but will be removed in a future release.
 
-Full changelog: [CHANGELOG.md](CHANGELOG.md) | GitHub release: [v0.62.0](https://github.com/steveyegge/beads/releases/tag/v0.62.0)
+Full changelog: [CHANGELOG.md](CHANGELOG.md) | GitHub release: [v0.62.0](https://github.com/gastownhall/beads/releases/tag/v0.62.0)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **Platforms:** macOS, Linux, Windows, FreeBSD
 
-[![License](https://img.shields.io/github/license/steveyegge/beads)](LICENSE)
+[![License](https://img.shields.io/github/license/gastownhall/beads)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/steveyegge/beads)](https://goreportcard.com/report/github.com/steveyegge/beads)
-[![Release](https://img.shields.io/github/v/release/steveyegge/beads)](https://github.com/steveyegge/beads/releases)
+[![Release](https://img.shields.io/github/v/release/gastownhall/beads)](https://github.com/gastownhall/beads/releases)
 [![npm version](https://img.shields.io/npm/v/@beads/bd)](https://www.npmjs.com/package/@beads/bd)
 [![PyPI](https://img.shields.io/pypi/v/beads-mcp)](https://pypi.org/project/beads-mcp/)
 
@@ -18,7 +18,7 @@ Beads provides a persistent, structured memory for coding agents. It replaces me
 
 ```bash
 # Install beads CLI (system-wide - don't clone this repo into your project)
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
 # Initialize in YOUR project
 cd your-project
@@ -175,7 +175,7 @@ This is useful for:
 - **Evaluation/testing** — ephemeral databases in `/tmp`
 
 For daemon mode without git, use `bd daemon start --local`
-(see [PR #433](https://github.com/steveyegge/beads/pull/433)).
+(see [PR #433](https://github.com/gastownhall/beads/pull/433)).
 
 ## 📝 Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,7 @@ A beads release involves multiple distribution channels:
 
 ### Required Tools
 
-- `git` with push access to steveyegge/beads
+- `git` with push access to gastownhall/beads
 - `goreleaser` for building binaries
 - `npm` with authentication (for npm releases)
 - `python3` and `twine` (for PyPI releases)
@@ -45,7 +45,7 @@ A beads release involves multiple distribution channels:
 
 ```bash
 # Check git
-git remote -v  # Should show steveyegge/beads
+git remote -v  # Should show gastownhall/beads
 
 # Check goreleaser
 goreleaser --version
@@ -221,7 +221,7 @@ gh release create v0.22.0 \
 
 ### Verify GitHub Release
 
-1. Visit https://github.com/steveyegge/beads/releases
+1. Visit https://github.com/gastownhall/beads/releases
 2. Verify v0.22.0 is marked as "Latest"
 3. Check all platform binaries are present:
    - `beads_0.22.0_darwin_amd64.tar.gz`
@@ -416,7 +416,7 @@ After all distribution channels are updated, verify each one:
 
 ```bash
 # Download and test binary
-wget https://github.com/steveyegge/beads/releases/download/v0.22.0/beads_0.22.0_darwin_arm64.tar.gz
+wget https://github.com/gastownhall/beads/releases/download/v0.22.0/beads_0.22.0_darwin_arm64.tar.gz
 tar -xzf beads_0.22.0_darwin_arm64.tar.gz
 ./bd version
 ```
@@ -447,7 +447,7 @@ bd version
 
 ```bash
 # Test quick install script
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 bd version
 ```
 
@@ -662,5 +662,5 @@ Examples:
 
 ## Questions?
 
-- Open an issue: https://github.com/steveyegge/beads/issues
-- Check existing releases: https://github.com/steveyegge/beads/releases
+- Open an issue: https://github.com/gastownhall/beads/issues
+- Check existing releases: https://github.com/gastownhall/beads/releases

--- a/docs/AIDER_INTEGRATION.md
+++ b/docs/AIDER_INTEGRATION.md
@@ -372,6 +372,6 @@ Then sync:
 ## References
 
 - [Aider Documentation](https://aider.chat/docs/)
-- [Beads Documentation](https://github.com/steveyegge/beads)
+- [Beads Documentation](https://github.com/gastownhall/beads)
 - [AGENTS.md](../AGENTS.md) - Complete bd workflow guide
 - [QUICKSTART.md](QUICKSTART.md) - Quick start guide

--- a/docs/ANTIVIRUS.md
+++ b/docs/ANTIVIRUS.md
@@ -32,7 +32,7 @@ Kaspersky's PDM (Proactive Defense Module) uses behavioral analysis that commonl
 
 Before running a downloaded binary or adding antivirus exclusions, verify the file is legitimate:
 
-1. Download beads from the [official GitHub releases](https://github.com/steveyegge/beads/releases)
+1. Download beads from the [official GitHub releases](https://github.com/gastownhall/beads/releases)
 2. Verify the SHA256 checksum matches the `checksums.txt` file in the release
 3. If a release includes code signing, verify that signature too
 
@@ -77,7 +77,7 @@ Help improve detection accuracy by reporting the false positive:
 1. Visit [Kaspersky Threat Intelligence Portal](https://opentip.kaspersky.com/)
 2. Upload the `bd.exe` file for analysis
 3. Mark it as a false positive
-4. Reference: beads is open-source CLI tool (https://github.com/steveyegge/beads)
+4. Reference: beads is open-source CLI tool (https://github.com/gastownhall/beads)
 
 **Windows Defender:**
 1. Go to [Microsoft Security Intelligence](https://www.microsoft.com/en-us/wdsi/filesubmission)
@@ -151,7 +151,7 @@ However, results vary by antivirus vendor and version.
 ### Is beads safe to use?
 
 Yes. Beads is:
-- Open source (all code is auditable on [GitHub](https://github.com/steveyegge/beads))
+- Open source (all code is auditable on [GitHub](https://github.com/gastownhall/beads))
 - Releases include checksums for verification
 - Used by developers worldwide
 - A simple CLI tool for issue tracking
@@ -188,7 +188,7 @@ False positives may still occur with new releases until the certificate builds r
 
 If you encounter a new antivirus false positive:
 
-1. Open an issue on [GitHub](https://github.com/steveyegge/beads/issues)
+1. Open an issue on [GitHub](https://github.com/gastownhall/beads/issues)
 2. Include:
    - Antivirus software name and version
    - Detection/threat name

--- a/docs/COMMUNITY_TOOLS.md
+++ b/docs/COMMUNITY_TOOLS.md
@@ -111,7 +111,7 @@ Install with `uv tool install git+https://github.com/jklenk/thread`. Built by [@
 
 ## Discussion
 
-See [GitHub Discussions #276](https://github.com/steveyegge/beads/discussions/276) for ongoing UI development conversations, design decisions, and community contributions.
+See [GitHub Discussions #276](https://github.com/gastownhall/beads/discussions/276) for ongoing UI development conversations, design decisions, and community contributions.
 
 ## Contributing
 

--- a/docs/EXCLUSIVE_LOCK.md
+++ b/docs/EXCLUSIVE_LOCK.md
@@ -226,4 +226,4 @@ For integration help, see:
 - **README.md** - Server configuration
 - **examples/** - Sample integrations
 
-File issues at: https://github.com/steveyegge/beads/issues
+File issues at: https://github.com/gastownhall/beads/issues

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -40,7 +40,7 @@ GitHub Issues + gh CLI can approximate some features, but fundamentally cannot r
 
 **When to use each:** GitHub Issues excels for human teams in web UI with cross-repo dashboards and integrations. bd excels for AI agents needing offline, git-synchronized task memory with graph semantics and deterministic queries.
 
-See [GitHub issue #125](https://github.com/steveyegge/beads/issues/125) for detailed comparison.
+See [GitHub issue #125](https://github.com/gastownhall/beads/issues/125) for detailed comparison.
 
 ### How is this different from Taskwarrior?
 
@@ -489,8 +489,8 @@ bd dolt pull    # Pull from Dolt remote if configured
 - **Documentation**: [README.md](../README.md), [QUICKSTART.md](QUICKSTART.md), [ADVANCED.md](ADVANCED.md)
 - **Troubleshooting**: [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 - **Examples**: [examples/](../examples/)
-- **GitHub Issues**: [Report bugs or request features](https://github.com/steveyegge/beads/issues)
-- **GitHub Discussions**: [Ask questions](https://github.com/steveyegge/beads/discussions)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/gastownhall/beads/issues)
+- **GitHub Discussions**: [Ask questions](https://github.com/gastownhall/beads/discussions)
 
 ### How can I contribute?
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -52,8 +52,8 @@ You can install beads using mise in 2 different ways:
 1. Install the latest github release
 
 ```bash
-mise install github:steveyegge/beads
-mise use -g github:steveyegge/beads
+mise install github:gastownhall/beads
+mise use -g github:gastownhall/beads
 ```
 
 2.  Build the latest code from git using go:
@@ -74,7 +74,7 @@ mise use -g go:github.com/steveyegge/beads/cmd/bd
 ### Quick Install Script (All Platforms)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 The installer will:
@@ -87,7 +87,7 @@ The installer will:
 On macOS, the script preserves the downloaded binary signature by default. If you explicitly want ad-hoc local re-signing, opt in:
 
 ```bash
-BEADS_INSTALL_RESIGN_MACOS=1 curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+BEADS_INSTALL_RESIGN_MACOS=1 curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 ### Comparison of Installation Methods
@@ -136,7 +136,7 @@ CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/c
 
 **From source**:
 ```bash
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 make build   # uses gms_pure_go tag and CGO
 sudo mv bd /usr/local/bin/
@@ -172,7 +172,7 @@ CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/c
 
 **From source**:
 ```bash
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 make build   # uses gms_pure_go tag and CGO
 sudo mv bd /usr/local/bin/
@@ -182,7 +182,7 @@ sudo mv bd /usr/local/bin/
 
 **Via Quick Install Script**:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 **Via go install** (server-mode only, simplest):
@@ -200,7 +200,7 @@ Beads now ships with native Windows support—no MSYS or MinGW required.
 
 **Via PowerShell script**:
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 The script installs a prebuilt Windows release if available and verifies the downloaded ZIP checksum against release `checksums.txt`. Go is only required for `go install` or building from source.
@@ -225,7 +225,7 @@ Requires MinGW-w64 gcc on your PATH. ICU is **not** required — `gms_pure_go` s
 
 **From source**:
 ```pwsh
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 make build   # uses gms_pure_go tag and CGO
 Move-Item bd.exe $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\
@@ -321,7 +321,7 @@ For enhanced UX with slash commands:
 
 ```bash
 # In Claude Code
-/plugin marketplace add steveyegge/beads
+/plugin marketplace add gastownhall/beads
 /plugin install beads
 # Restart Claude Code
 ```
@@ -464,13 +464,13 @@ Some users report crashes when running `bd init` or other commands on macOS. Thi
 CGO_ENABLED=1 go install github.com/steveyegge/beads/cmd/bd@latest
 
 # Or if building from source
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 CGO_ENABLED=1 go build -o bd ./cmd/bd
 sudo mv bd /usr/local/bin/
 ```
 
-If you installed via Homebrew, this shouldn't be necessary as the formula already enables CGO. If you're still seeing crashes with the Homebrew version, please [file an issue](https://github.com/steveyegge/beads/issues).
+If you installed via Homebrew, this shouldn't be necessary as the formula already enables CGO. If you're still seeing crashes with the Homebrew version, please [file an issue](https://github.com/gastownhall/beads/issues).
 
 ### Claude Code Plugin: MCP server fails to start
 
@@ -513,13 +513,13 @@ Use the update command that matches how you installed `bd`.
 ### Quick Install Script (macOS/Linux/FreeBSD)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 ### PowerShell Installer (Windows)
 
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 ### Homebrew

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -13,4 +13,4 @@ Avoid these prefixes in user-defined keys to prevent conflicts with future Beads
 
 ## Related
 
-- [#1416](https://github.com/steveyegge/beads/issues/1416) — Optional schema enforcement (future)
+- [#1416](https://github.com/gastownhall/beads/issues/1416) — Optional schema enforcement (future)

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -16,7 +16,7 @@ Beads (`bd`) is an issue tracker designed specifically for AI-supervised coding 
 
 1. Install beads CLI:
 ```bash
-curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 2. Install Python and uv (for MCP server):
@@ -33,7 +33,7 @@ There are two ways to install the beads plugin:
 
 ```bash
 # In Claude Code
-/plugin marketplace add steveyegge/beads
+/plugin marketplace add gastownhall/beads
 /plugin install beads
 ```
 
@@ -41,7 +41,7 @@ There are two ways to install the beads plugin:
 
 ```bash
 # Clone the repository (shell command)
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 ```
 
@@ -306,7 +306,7 @@ The plugin requires the `bd` CLI to be installed. Update it separately:
 
 ```bash
 # Quick update
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
 # Or with go
 go install github.com/steveyegge/beads/cmd/bd@latest
@@ -373,7 +373,7 @@ Beads follows semantic versioning. The plugin version tracks the bd CLI version:
 
 ## Learn More
 
-- **GitHub**: https://github.com/steveyegge/beads
+- **GitHub**: https://github.com/gastownhall/beads
 - **Documentation**: See README.md in the repository
 - **Examples**: Check `examples/` directory for integration patterns
 - **MCP Server**: See `integrations/beads-mcp/` for server details

--- a/docs/PROTECTED_BRANCHES.md
+++ b/docs/PROTECTED_BRANCHES.md
@@ -512,7 +512,7 @@ jobs:
 
       - name: Install bd
         run: |
-          curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
       - name: Pull changes
         run: |
@@ -650,4 +650,4 @@ Future commits will go to your current branch (e.g., `main`).
 
 ---
 
-**Need help?** Open an issue at https://github.com/steveyegge/beads/issues
+**Need help?** Open an issue at https://github.com/gastownhall/beads/issues

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,23 +1,23 @@
 # Beads Quickstart
 
-**Canonical documentation:** [Quick Start (published)](https://steveyegge.github.io/beads/getting-started/quickstart) — browse the full tutorial with navigation and search.
+**Canonical documentation:** [Quick Start (published)](https://gastownhall.github.io/beads/getting-started/quickstart) — browse the full tutorial with navigation and search.
 
 **Source in this repo:** [website/docs/getting-started/quickstart.md](../website/docs/getting-started/quickstart.md) (what GitHub Pages builds from; the `docs/` copy here is a pointer for deep links and agents).
 
 ## Ultra-short path
 
-1. Install `bd` — see [Installation](INSTALLING.md) or the [site installation page](https://steveyegge.github.io/beads/getting-started/installation).
+1. Install `bd` — see [Installation](INSTALLING.md) or the [site installation page](https://gastownhall.github.io/beads/getting-started/installation).
 2. In your project: `bd init`
 3. Create work: `bd create "My task" -p 1` then `bd ready`
 
-For dependencies, sync, Notion, migrations, and maintenance, use the [full Quick Start](https://steveyegge.github.io/beads/getting-started/quickstart) linked above.
+For dependencies, sync, Notion, migrations, and maintenance, use the [full Quick Start](https://gastownhall.github.io/beads/getting-started/quickstart) linked above.
 
 ---
 
 ## Why Beads?
 
-See **[Why Beads?](https://steveyegge.github.io/beads/getting-started/quickstart#why-beads)** on the documentation site.
+See **[Why Beads?](https://gastownhall.github.io/beads/getting-started/quickstart#why-beads)** on the documentation site.
 
 ## Dependencies
 
-See **[Add dependencies](https://steveyegge.github.io/beads/getting-started/quickstart#add-dependencies)** on the documentation site (blocking dependencies and `bd dep`).
+See **[Add dependencies](https://gastownhall.github.io/beads/getting-started/quickstart#add-dependencies)** on the documentation site (blocking dependencies and `bd dep`).

--- a/docs/RELEASE-STABILITY-GATE.md
+++ b/docs/RELEASE-STABILITY-GATE.md
@@ -61,7 +61,7 @@ document the breaking change with explicit migration steps before shipping.
 
 ## Related Issues
 
-- [#2764](https://github.com/steveyegge/beads/issues/2764) — Test gap: upgrade paths
-- [#2765](https://github.com/steveyegge/beads/issues/2765) — Test gap: mode preservation
-- [#2949](https://github.com/steveyegge/beads/issues/2949) — v0.63.3 silent mode switch
-- [#2950](https://github.com/steveyegge/beads/issues/2950) — beads.role left unset
+- [#2764](https://github.com/gastownhall/beads/issues/2764) — Test gap: upgrade paths
+- [#2765](https://github.com/gastownhall/beads/issues/2765) — Test gap: mode preservation
+- [#2949](https://github.com/gastownhall/beads/issues/2949) — v0.63.3 silent mode switch
+- [#2950](https://github.com/gastownhall/beads/issues/2950) — beads.role left unset

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -106,7 +106,7 @@ The automation requires this secret to be configured:
 
 **PYPI_API_TOKEN**: Your PyPI API token
 1. Generate token at https://pypi.org/manage/account/token/
-2. Add to GitHub at https://github.com/steveyegge/beads/settings/secrets/actions
+2. Add to GitHub at https://github.com/gastownhall/beads/settings/secrets/actions
 3. Name: `PYPI_API_TOKEN`
 4. Value: `pypi-...` (your full token)
 
@@ -170,9 +170,9 @@ Just push your tag and wait ~5 minutes:
 git push origin v0.9.X
 ```
 
-Monitor at: https://github.com/steveyegge/beads/actions
+Monitor at: https://github.com/gastownhall/beads/actions
 
-The release will appear at: https://github.com/steveyegge/beads/releases
+The release will appear at: https://github.com/gastownhall/beads/releases
 
 ### Documentation site (Docusaurus)
 

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -236,7 +236,7 @@ go test -v -run TestRouting
 
 ## Future Enhancements
 
-See [bd-k58](https://github.com/steveyegge/beads/issues/k58) for proposal workflow:
+See [bd-k58](https://github.com/gastownhall/beads/issues/k58) for proposal workflow:
 - `bd propose <id>` - Move issue from planning to upstream
 - `bd withdraw <id>` - Un-propose
 - `bd accept <id>` - Maintainer accepts proposal

--- a/docs/RULES_AUDIT_DESIGN.md
+++ b/docs/RULES_AUDIT_DESIGN.md
@@ -1,6 +1,6 @@
 # `bd rules audit` / `bd rules compact` Design Doc
 
-> **Status:** Ready | **Target:** Upstream PR to `steveyegge/beads`
+> **Status:** Ready | **Target:** Upstream PR to `gastownhall/beads`
 > **Companion spec:** SESSION-OUTPUT-SPEC Items 2 & 6
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -180,13 +180,13 @@ Some users report crashes when running `bd init` or other commands on macOS. Thi
 CGO_ENABLED=1 go install github.com/steveyegge/beads/cmd/bd@latest
 
 # Or if building from source
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 CGO_ENABLED=1 go build -o bd ./cmd/bd
 sudo mv bd /usr/local/bin/
 ```
 
-If you installed via Homebrew, this shouldn't be necessary as the formula already enables CGO. If you're still seeing crashes with the Homebrew version, please [file an issue](https://github.com/steveyegge/beads/issues).
+If you installed via Homebrew, this shouldn't be necessary as the formula already enables CGO. If you're still seeing crashes with the Homebrew version, please [file an issue](https://github.com/gastownhall/beads/issues).
 
 ## Antivirus False Positives
 
@@ -210,7 +210,7 @@ If you installed via Homebrew, this shouldn't be necessary as the formula alread
    # macOS/Linux
    shasum -a 256 bd
    ```
-   Compare with checksums from the [GitHub release page](https://github.com/steveyegge/beads/releases)
+   Compare with checksums from the [GitHub release page](https://github.com/gastownhall/beads/releases)
 
 2. **Add bd to antivirus exclusions only after verification**:
    - Add the bd installation directory to your antivirus exclusion list
@@ -433,9 +433,9 @@ bd init
 bd config set sync.branch ""  # Disable sync branch feature
 ```
 
-**Note:** The `--hard` and `--skip-init` flags mentioned in [GH#479](https://github.com/steveyegge/beads/issues/479) were never implemented. Use the workarounds above for a complete reset.
+**Note:** The `--hard` and `--skip-init` flags mentioned in [GH#479](https://github.com/gastownhall/beads/issues/479) were never implemented. Use the workarounds above for a complete reset.
 
-**Related:** [GH#922](https://github.com/steveyegge/beads/issues/922)
+**Related:** [GH#922](https://github.com/gastownhall/beads/issues/922)
 
 ### Database corruption
 
@@ -927,7 +927,7 @@ bd dolt push
 
 **Related:**
 - See [Claude Code sandboxing documentation](https://www.anthropic.com/engineering/claude-code-sandboxing) for more about sandbox restrictions
-- GitHub issue [#353](https://github.com/steveyegge/beads/issues/353) for background
+- GitHub issue [#353](https://github.com/gastownhall/beads/issues/353) for background
 
 ## Platform-Specific Issues
 
@@ -1014,14 +1014,14 @@ export PATH="$HOME/.local/bin:$PATH"
 
 If none of these solutions work:
 
-1. **Check existing issues**: [GitHub Issues](https://github.com/steveyegge/beads/issues)
+1. **Check existing issues**: [GitHub Issues](https://github.com/gastownhall/beads/issues)
 2. **Enable debug logging**: `bd --verbose <command>`
 3. **File a bug report**: Include:
    - bd version: `bd version`
    - OS and architecture: `uname -a`
    - Error message and full command
    - Steps to reproduce
-4. **Join discussions**: [GitHub Discussions](https://github.com/steveyegge/beads/discussions)
+4. **Join discussions**: [GitHub Discussions](https://github.com/gastownhall/beads/discussions)
 
 ## Related Documentation
 

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -489,7 +489,7 @@ When `BEADS_DIR` points to a different git repository than your current director
 2. Git operations (add, commit, push, pull) target the beads repo
 3. Your code repository is never touched
 
-This was contributed by @dand-oss in [PR #533](https://github.com/steveyegge/beads/pull/533).
+This was contributed by @dand-oss in [PR #533](https://github.com/gastownhall/beads/pull/533).
 
 ### Combining with Worktrees
 

--- a/docs/pr-752-chaos-testing-review.md
+++ b/docs/pr-752-chaos-testing-review.md
@@ -1,6 +1,6 @@
 # PR #752 Chaos Testing Review
 
-**PR**: https://github.com/steveyegge/beads/pull/752
+**PR**: https://github.com/gastownhall/beads/pull/752
 **Author**: jordanhubbard
 **Bead**: bd-kx1j
 **Status**: Under Review

--- a/examples/compaction/workflow.sh
+++ b/examples/compaction/workflow.sh
@@ -23,7 +23,7 @@ if ! command -v bd &> /dev/null; then
   echo "❌ Error: bd command not found"
   echo
   echo "Install bd:"
-  echo "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash"
+  echo "  curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash"
   echo
   exit 1
 fi

--- a/examples/protected-branch/README.md
+++ b/examples/protected-branch/README.md
@@ -249,7 +249,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install bd
-        run: curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+        run: curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
       - name: Check for changes
         id: check

--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,6 @@
 # Beads (bd) Windows installer
 # Usage:
-#   irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
@@ -182,7 +182,7 @@ function Install-FromRelease {
         return $false
     }
 
-    $apiUrl = "https://api.github.com/repos/steveyegge/beads/releases/latest"
+    $apiUrl = "https://api.github.com/repos/gastownhall/beads/releases/latest"
     try {
         $release = Invoke-RestMethod -Uri $apiUrl -Headers @{ "User-Agent" = "beads-install" }
     } catch {
@@ -286,7 +286,7 @@ function Install-FromSource {
             }
         } else {
             Write-Info "Cloning repository..."
-            & git clone --depth 1 https://github.com/steveyegge/beads.git $repoPath
+            & git clone --depth 1 https://github.com/gastownhall/beads.git $repoPath
             if ($LASTEXITCODE -ne 0) {
                 throw "git clone failed with exit code $LASTEXITCODE"
             }

--- a/integrations/beads-mcp/CONTEXT_MANAGEMENT.md
+++ b/integrations/beads-mcp/CONTEXT_MANAGEMENT.md
@@ -109,6 +109,6 @@ uv run pytest tests/test_mcp_server_integration.py -v
 
 ## Future Work
 
-See [bd-105](https://github.com/steveyegge/beads/issues/105) for full architectural analysis and roadmap.
+See [bd-105](https://github.com/gastownhall/beads/issues/105) for full architectural analysis and roadmap.
 
 Priority: P0/P1 - Active data corruption risk in multi-repo setups.

--- a/integrations/beads-mcp/README.md
+++ b/integrations/beads-mcp/README.md
@@ -1,6 +1,6 @@
 # beads-mcp
 
-MCP server for [beads](https://github.com/steveyegge/beads) issue tracker and agentic memory system.
+MCP server for [beads](https://github.com/gastownhall/beads) issue tracker and agentic memory system.
 Enables AI agents to manage tasks using bd CLI through Model Context Protocol.
 
 > **Note:** For environments with shell access (Claude Code, Cursor, Windsurf), the **CLI + hooks approach is recommended** over MCP. It uses ~1-2k tokens vs 10-50k for MCP schemas, resulting in lower compute cost and latency. See the [main README](../../README.md) for CLI setup.
@@ -36,7 +36,7 @@ Add to your Claude Desktop config:
 For development, clone the repository:
 
 ```bash
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads/integrations/beads-mcp
 uv sync
 ```
@@ -225,7 +225,7 @@ await beads_ready_work(workspace_root="/Users/you/project-a")
 
 ## Known Issues
 
-### ~~MCP Tools Not Loading in Claude Code~~ (Issue [#346](https://github.com/steveyegge/beads/issues/346)) - RESOLVED
+### ~~MCP Tools Not Loading in Claude Code~~ (Issue [#346](https://github.com/gastownhall/beads/issues/346)) - RESOLVED
 
 **Status:** ✅ Fixed in v0.24.0+
 

--- a/integrations/beads-mcp/pyproject.toml
+++ b/integrations/beads-mcp/pyproject.toml
@@ -31,10 +31,10 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/steveyegge/beads"
-Repository = "https://github.com/steveyegge/beads"
-Documentation = "https://github.com/steveyegge/beads/blob/main/integrations/beads-mcp/README.md"
-Issues = "https://github.com/steveyegge/beads/issues"
+Homepage = "https://github.com/gastownhall/beads"
+Repository = "https://github.com/gastownhall/beads"
+Documentation = "https://github.com/gastownhall/beads/blob/main/integrations/beads-mcp/README.md"
+Issues = "https://github.com/gastownhall/beads/issues"
 
 [project.scripts]
 beads-mcp = "beads_mcp.server:main"

--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -71,8 +71,8 @@ class BdNotFoundError(BdError):
             f"bd CLI not found at: {attempted_path}\n\n"
             "The beads Claude Code plugin requires the bd CLI to be installed separately.\n\n"
             "Install bd CLI:\n"
-            "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n\n"
-            "Or visit: https://github.com/steveyegge/beads#installation\n\n"
+            "  curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash\n\n"
+            "Or visit: https://github.com/gastownhall/beads#installation\n\n"
             "After installation, restart Claude Code to reload the MCP server."
         )
 
@@ -390,7 +390,7 @@ class BdCliClient(BdClientBase):
         if version < min_version:
             min_ver_str = ".".join(str(x) for x in min_version)
             cur_ver_str = ".".join(str(x) for x in version)
-            install_cmd = "curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash"
+            install_cmd = "curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash"
             raise BdVersionError(
                 f"bd version {cur_ver_str} is too old. "
                 f"This MCP server requires bd >= {min_ver_str}. "

--- a/integrations/beads-mcp/src/beads_mcp/config.py
+++ b/integrations/beads-mcp/src/beads_mcp/config.py
@@ -66,8 +66,8 @@ class Config(BaseSettings):
                     f"bd executable not found at: {v}\n\n"
                     + "The beads Claude Code plugin requires the bd CLI to be installed.\n\n"
                     + "Install bd CLI:\n"
-                    + "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n\n"
-                    + "Or visit: https://github.com/steveyegge/beads#installation\n\n"
+                    + "  curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash\n\n"
+                    + "Or visit: https://github.com/gastownhall/beads#installation\n\n"
                     + "After installation, restart Claude Code to reload the MCP server."
                 )
 
@@ -154,8 +154,8 @@ def load_config() -> Config:
             "Beads MCP Server Configuration Error\n\n"
             + f"{e}\n\n"
             + "Common fix: Install the bd CLI first:\n"
-            + "  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n\n"
-            + "Or visit: https://github.com/steveyegge/beads#installation\n\n"
+            + "  curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash\n\n"
+            + "Or visit: https://github.com/gastownhall/beads#installation\n\n"
             + "After installation, restart Claude Code.\n\n"
             + "Advanced configuration (optional):\n"
             + f"  BEADS_PATH            - Path to bd executable (default: {default_path})\n"

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -6,7 +6,7 @@ Slash command for converting [Claude Code](https://docs.anthropic.com/en/docs/cl
 
 ```bash
 # Install beads
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
 # Install hooks (auto-injects workflow context on session start)
 bd setup claude

--- a/integrations/junie/README.md
+++ b/integrations/junie/README.md
@@ -6,7 +6,7 @@ Integration for [Junie](https://www.jetbrains.com/junie/) (JetBrains AI Agent) w
 
 ```bash
 # Install beads
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
 # Initialize beads in your project
 bd init

--- a/npm-package/CLAUDE_CODE_WEB.md
+++ b/npm-package/CLAUDE_CODE_WEB.md
@@ -334,7 +334,7 @@ npx bd create "New issue"
 
 ## Resources
 
-- [beads GitHub repository](https://github.com/steveyegge/beads)
+- [beads GitHub repository](https://github.com/gastownhall/beads)
 - [npm package page](https://www.npmjs.com/package/@beads/bd)
-- [Complete documentation](https://github.com/steveyegge/beads#readme)
+- [Complete documentation](https://github.com/gastownhall/beads#readme)
 - [Claude Code hooks documentation](https://docs.claude.com/claude-code)

--- a/npm-package/INTEGRATION_GUIDE.md
+++ b/npm-package/INTEGRATION_GUIDE.md
@@ -292,14 +292,14 @@ npm install --save-dev @beads/bd
 
 ## 📚 Next Steps
 
-1. **Read the full docs**: https://github.com/steveyegge/beads
+1. **Read the full docs**: https://github.com/gastownhall/beads
 2. **Try the quickstart**: `bd quickstart` (interactive tutorial)
 3. **Set up MCP**: For local Claude Desktop integration
-4. **Explore examples**: https://github.com/steveyegge/beads/tree/main/examples
+4. **Explore examples**: https://github.com/gastownhall/beads/tree/main/examples
 
 ## 🔗 Resources
 
-- [beads GitHub](https://github.com/steveyegge/beads)
+- [beads GitHub](https://github.com/gastownhall/beads)
 - [npm package](https://www.npmjs.com/package/@beads/bd)
 - [Claude Code docs](https://docs.claude.com/claude-code)
 - [SessionStart hooks](https://docs.claude.com/claude-code/hooks)
@@ -347,6 +347,6 @@ After setup, you should see:
 
 ## 🆘 Support
 
-- [File an issue](https://github.com/steveyegge/beads/issues)
-- [Read the FAQ](https://github.com/steveyegge/beads/blob/main/FAQ.md)
-- [Check troubleshooting](https://github.com/steveyegge/beads/blob/main/TROUBLESHOOTING.md)
+- [File an issue](https://github.com/gastownhall/beads/issues)
+- [Read the FAQ](https://github.com/gastownhall/beads/blob/main/FAQ.md)
+- [Check troubleshooting](https://github.com/gastownhall/beads/blob/main/TROUBLESHOOTING.md)

--- a/npm-package/LAUNCH.md
+++ b/npm-package/LAUNCH.md
@@ -95,7 +95,7 @@ All success criteria from bd-febc met:
 1. Visit: https://www.npmjs.com/package/@beads/bd
 2. Install: `npm install -g @beads/bd`
 3. Use: `bd init` in your project
-4. Read: https://github.com/steveyegge/beads for full docs
+4. Read: https://github.com/gastownhall/beads for full docs
 
 ### For Maintainers
 
@@ -113,9 +113,9 @@ Create `.github/workflows/publish-npm.yml` to auto-publish on GitHub releases.
 ## 🔗 Links
 
 - **npm package**: https://www.npmjs.com/package/@beads/bd
-- **GitHub repo**: https://github.com/steveyegge/beads
+- **GitHub repo**: https://github.com/gastownhall/beads
 - **npm organization**: https://www.npmjs.com/org/beads
-- **Documentation**: https://github.com/steveyegge/beads#readme
+- **Documentation**: https://github.com/gastownhall/beads#readme
 
 ## 💡 Key Features
 

--- a/npm-package/PUBLISHING.md
+++ b/npm-package/PUBLISHING.md
@@ -156,7 +156,7 @@ You don't have permission to publish to @beads. Either:
 
 The version in package.json doesn't match a GitHub release, or the release doesn't have the required binary assets.
 
-Check: https://github.com/steveyegge/beads/releases/v{VERSION}
+Check: https://github.com/gastownhall/beads/releases/v{VERSION}
 
 ## Version Sync
 
@@ -167,5 +167,5 @@ Keep these in sync:
 
 The postinstall script downloads binaries from:
 ```
-https://github.com/steveyegge/beads/releases/download/v{VERSION}/beads_{VERSION}_{platform}_{arch}.{ext}
+https://github.com/gastownhall/beads/releases/download/v{VERSION}/beads_{VERSION}_{platform}_{arch}.{ext}
 ```

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -97,13 +97,13 @@ This package downloads the appropriate native binary for your platform:
 
 ## Full Documentation
 
-For complete documentation, see the [beads GitHub repository](https://github.com/steveyegge/beads):
+For complete documentation, see the [beads GitHub repository](https://github.com/gastownhall/beads):
 
-- [Complete README](https://github.com/steveyegge/beads#readme)
-- [Quick Start (documentation site)](https://steveyegge.github.io/beads/getting-started/quickstart) · [repo pointer](https://github.com/steveyegge/beads/blob/main/docs/QUICKSTART.md)
-- [Installation Guide](https://github.com/steveyegge/beads/blob/main/docs/INSTALLING.md)
-- [FAQ](https://github.com/steveyegge/beads/blob/main/docs/FAQ.md)
-- [Troubleshooting](https://github.com/steveyegge/beads/blob/main/docs/TROUBLESHOOTING.md)
+- [Complete README](https://github.com/gastownhall/beads#readme)
+- [Quick Start (documentation site)](https://gastownhall.github.io/beads/getting-started/quickstart) · [repo pointer](https://github.com/gastownhall/beads/blob/main/docs/QUICKSTART.md)
+- [Installation Guide](https://github.com/gastownhall/beads/blob/main/docs/INSTALLING.md)
+- [FAQ](https://github.com/gastownhall/beads/blob/main/docs/FAQ.md)
+- [Troubleshooting](https://github.com/gastownhall/beads/blob/main/docs/TROUBLESHOOTING.md)
 
 ## Why npm Package vs WASM?
 
@@ -120,5 +120,5 @@ MIT - See [LICENSE](LICENSE) for details.
 
 ## Support
 
-- [GitHub Issues](https://github.com/steveyegge/beads/issues)
-- [Documentation](https://github.com/steveyegge/beads)
+- [GitHub Issues](https://github.com/gastownhall/beads/issues)
+- [Documentation](https://github.com/gastownhall/beads)

--- a/npm-package/SUMMARY.md
+++ b/npm-package/SUMMARY.md
@@ -47,7 +47,7 @@ npm-package/
 - Runs automatically after `npm install`
 - Detects OS (darwin/linux/windows) and architecture (amd64/arm64)
 - Downloads the correct binary from GitHub releases
-- Constructs URL: `https://github.com/steveyegge/beads/releases/download/v{VERSION}/beads_{VERSION}_{platform}_{arch}.{ext}`
+- Constructs URL: `https://github.com/gastownhall/beads/releases/download/v{VERSION}/beads_{VERSION}_{platform}_{arch}.{ext}`
 - Supports both tar.gz (Unix) and zip (Windows) archives
 - Extracts the binary to `bin/` directory
 - Makes binary executable on Unix systems
@@ -250,7 +250,7 @@ Note: Requires creating @beads organization on npm.
 
 ## References
 
-- [beads repository](https://github.com/steveyegge/beads)
+- [beads repository](https://github.com/gastownhall/beads)
 - [npm scoped packages](https://docs.npmjs.com/cli/v8/using-npm/scope)
 - [npm postinstall scripts](https://docs.npmjs.com/cli/v8/using-npm/scripts#pre--post-scripts)
 - [Node.js child_process](https://nodejs.org/api/child_process.html)

--- a/npm-package/scripts/postinstall.js
+++ b/npm-package/scripts/postinstall.js
@@ -260,11 +260,11 @@ async function install() {
     }
 
     // Construct download URL
-    // Format: https://github.com/steveyegge/beads/releases/download/v0.21.5/beads_0.21.5_darwin_amd64.tar.gz
+    // Format: https://github.com/gastownhall/beads/releases/download/v0.21.5/beads_0.21.5_darwin_amd64.tar.gz
     const releaseVersion = VERSION;
     const archiveExt = platformName === 'windows' ? 'zip' : 'tar.gz';
     const archiveName = `beads_${releaseVersion}_${platformName}_${archName}.${archiveExt}`;
-    const downloadUrl = `https://github.com/steveyegge/beads/releases/download/v${releaseVersion}/${archiveName}`;
+    const downloadUrl = `https://github.com/gastownhall/beads/releases/download/v${releaseVersion}/${archiveName}`;
     const archivePath = path.join(binDir, archiveName);
 
     // Download the archive
@@ -299,9 +299,9 @@ async function install() {
     console.error(`Error installing bd: ${err.message}`);
     console.error('');
     console.error('Installation failed. You can try:');
-    console.error('1. Installing manually from: https://github.com/steveyegge/beads/releases');
-    console.error('2. Using the install script: curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash');
-    console.error('3. Opening an issue: https://github.com/steveyegge/beads/issues');
+    console.error('1. Installing manually from: https://github.com/gastownhall/beads/releases');
+    console.error('2. Using the install script: curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash');
+    console.error('3. Opening an issue: https://github.com/gastownhall/beads/issues');
     process.exit(1);
   }
 }

--- a/npm-package/test/integration.test.js
+++ b/npm-package/test/integration.test.js
@@ -391,7 +391,7 @@ async function testPlatformDetection() {
     // Check if GitHub release has this binary
     const version = require(path.join(PACKAGE_DIR, 'package.json')).version;
     const ext = platform === 'win32' ? 'zip' : 'tar.gz';
-    const binaryUrl = `https://github.com/steveyegge/beads/releases/download/v${version}/beads_${version}_${platform}_${mappedArch}.${ext}`;
+    const binaryUrl = `https://github.com/gastownhall/beads/releases/download/v${version}/beads_${version}_${platform}_${mappedArch}.${ext}`;
 
     logInfo(`Expected binary URL: ${binaryUrl}`);
     logSuccess('Platform detection logic validated');

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,7 +47,7 @@ This master script automates the **entire release process**:
 - All changes committed
 - golangci-lint installed
 - Homebrew installed (for local upgrade)
-- Push access to steveyegge/beads
+- Push access to gastownhall/beads
 
 ### Output
 

--- a/scripts/cross-version-smoke-test.sh
+++ b/scripts/cross-version-smoke-test.sh
@@ -71,7 +71,7 @@ download_binary() {
     fi
 
     local asset="beads_${ver_bare}_${OS}_${ARCH}.tar.gz"
-    local url="https://github.com/steveyegge/beads/releases/download/${version}/${asset}"
+    local url="https://github.com/gastownhall/beads/releases/download/${version}/${asset}"
 
     echo -e "  ${YELLOW}downloading ${version}...${NC}" >&2
     local tmpdir

--- a/scripts/migration-test/lib/binary.sh
+++ b/scripts/migration-test/lib/binary.sh
@@ -31,7 +31,7 @@ download_binary() {
 
     # Try downloading the release binary first
     local asset="beads_${ver_bare}_${OS}_${ARCH}.tar.gz"
-    local url="https://github.com/steveyegge/beads/releases/download/${version}/${asset}"
+    local url="https://github.com/gastownhall/beads/releases/download/${version}/${asset}"
 
     echo -e "  ${YELLOW:-}downloading ${version}...${NC:-}" >&2
     local tmpdir
@@ -73,7 +73,7 @@ build_from_source() {
     if ! git clone --depth 1 --branch "$version" "$PROJECT_ROOT" "$srcdir" 2>/dev/null; then
         # Tag might not exist locally; try the remote
         if ! git clone --depth 1 --branch "$version" \
-            "https://github.com/steveyegge/beads.git" "$srcdir" 2>/dev/null; then
+            "https://github.com/gastownhall/beads.git" "$srcdir" 2>/dev/null; then
             rm -rf "$srcdir"
             echo -e "  ${RED:-}ERROR: cannot clone tag ${version}${NC:-}" >&2
             return 1

--- a/scripts/sign-windows.sh
+++ b/scripts/sign-windows.sh
@@ -103,7 +103,7 @@ osslsigncode sign \
     -pkcs12 "$CERT_FILE" \
     -pass "$WINDOWS_SIGNING_CERT_PASSWORD" \
     -n "beads - AI-supervised issue tracker" \
-    -i "https://github.com/steveyegge/beads" \
+    -i "https://github.com/gastownhall/beads" \
     -t "$TIMESTAMP_SERVER" \
     -in "$EXE_PATH" \
     -out "${EXE_PATH}.signed"

--- a/scripts/update-winget.sh
+++ b/scripts/update-winget.sh
@@ -23,11 +23,11 @@ WINGET_DIR="$SCRIPT_DIR/../winget"
 
 # Get SHA256 from release checksums
 echo "Fetching SHA256 for v$VERSION..."
-SHA256=$(curl -sL "https://github.com/steveyegge/beads/releases/download/v$VERSION/checksums.txt" | grep windows | awk '{print $1}')
+SHA256=$(curl -sL "https://github.com/gastownhall/beads/releases/download/v$VERSION/checksums.txt" | grep windows | awk '{print $1}')
 
 if [ -z "$SHA256" ]; then
     echo "Error: Could not find Windows checksum for v$VERSION"
-    echo "Make sure the release exists: https://github.com/steveyegge/beads/releases/tag/v$VERSION"
+    echo "Make sure the release exists: https://github.com/gastownhall/beads/releases/tag/v$VERSION"
     exit 1
 fi
 
@@ -60,7 +60,7 @@ NestedInstallerFiles:
     PortableCommandAlias: bd
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/steveyegge/beads/releases/download/v$VERSION/beads_${VERSION}_windows_amd64.zip
+    InstallerUrl: https://github.com/gastownhall/beads/releases/download/v$VERSION/beads_${VERSION}_windows_amd64.zip
     InstallerSha256: $SHA256
 ManifestType: installer
 ManifestVersion: 1.6.0
@@ -74,12 +74,12 @@ PackageVersion: $VERSION
 PackageLocale: en-US
 Publisher: Steve Yegge
 PublisherUrl: https://github.com/steveyegge
-PublisherSupportUrl: https://github.com/steveyegge/beads/issues
+PublisherSupportUrl: https://github.com/gastownhall/beads/issues
 Author: Steve Yegge
 PackageName: beads
-PackageUrl: https://github.com/steveyegge/beads
+PackageUrl: https://github.com/gastownhall/beads
 License: MIT
-LicenseUrl: https://github.com/steveyegge/beads/blob/main/LICENSE
+LicenseUrl: https://github.com/gastownhall/beads/blob/main/LICENSE
 Copyright: Copyright (c) 2024 Steve Yegge
 ShortDescription: Distributed, Dolt-powered graph issue tracker for AI agents
 Description: |
@@ -94,7 +94,7 @@ Tags:
   - git
   - cli
   - developer-tools
-ReleaseNotesUrl: https://github.com/steveyegge/beads/releases/tag/v$VERSION
+ReleaseNotesUrl: https://github.com/gastownhall/beads/releases/tag/v$VERSION
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0
 EOF

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ brew install beads
 ### Quick Install Script (All Platforms)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 The installer will:
@@ -75,7 +75,7 @@ go install github.com/steveyegge/beads/cmd/bd@latest
 
 **From source**:
 ```bash
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 go build -o bd ./cmd/bd
 sudo mv bd /usr/local/bin/
@@ -105,7 +105,7 @@ go install github.com/steveyegge/beads/cmd/bd@latest
 
 **Via quick install script**:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 **Via go install**:
@@ -123,7 +123,7 @@ Beads ships with native Windows support—no MSYS or MinGW required.
 
 **Via PowerShell script**:
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 The script installs a prebuilt Windows release if available. Go is only required for `go install` or building from source.
@@ -229,13 +229,13 @@ CGO_ENABLED=1 go install github.com/steveyegge/beads/cmd/bd@latest
 ### Quick install script (macOS/Linux/FreeBSD)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 ### PowerShell installer (Windows)
 
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 ### Homebrew

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -266,7 +266,7 @@ bd dolt pull
 
 When a teammate clones the repo, `bd bootstrap` auto-detects the existing database on `refs/dolt/data` and clones it — no manual remote setup needed.
 
-See [Sync](/cli-reference/sync) for CLI details. For remote configuration and federation, see the repository docs [DOLT-BACKEND.md](https://github.com/steveyegge/beads/blob/main/docs/DOLT-BACKEND.md) and [FEDERATION-SETUP.md](https://github.com/steveyegge/beads/blob/main/FEDERATION-SETUP.md).
+See [Sync](/cli-reference/sync) for CLI details. For remote configuration and federation, see the repository docs [DOLT-BACKEND.md](https://github.com/gastownhall/beads/blob/main/docs/DOLT-BACKEND.md) and [FEDERATION-SETUP.md](https://github.com/gastownhall/beads/blob/main/FEDERATION-SETUP.md).
 
 ## Optional: Notion sync
 
@@ -367,4 +367,4 @@ bd admin cleanup --force
 - More sync scenarios: [Sync](/cli-reference/sync)
 - Full command list: [CLI Reference](/cli-reference)
 
-See the [repository README](https://github.com/steveyegge/beads/blob/main/README.md) for an overview and links to deeper docs.
+See the [repository README](https://github.com/gastownhall/beads/blob/main/README.md) for an overview and links to deeper docs.

--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -25,8 +25,8 @@ Use the command that matches your install method.
 
 | Install method | Platforms | Command |
 |---|---|---|
-| Quick install script | macOS, Linux, FreeBSD | `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh \| bash` |
-| PowerShell installer | Windows | `irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 \| iex` |
+| Quick install script | macOS, Linux, FreeBSD | `curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh \| bash` |
+| PowerShell installer | Windows | `irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 \| iex` |
 | Homebrew | macOS, Linux | `brew upgrade beads` |
 | go install | macOS, Linux, FreeBSD, Windows | `go install github.com/steveyegge/beads/cmd/bd@latest` |
 | npm | macOS, Linux, Windows | `npm update -g @beads/bd` |
@@ -36,13 +36,13 @@ Use the command that matches your install method.
 ### Quick install script (macOS/Linux/FreeBSD)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 ### PowerShell installer (Windows)
 
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 ### Homebrew
@@ -162,7 +162,7 @@ The old binary stored data in SQLite. The new binary uses Dolt.
 
 ```bash
 # Download the script from the beads repo
-curl -fsSLO https://raw.githubusercontent.com/steveyegge/beads/main/scripts/migrate-sqlite-to-current.sh
+curl -fsSLO https://raw.githubusercontent.com/gastownhall/beads/main/scripts/migrate-sqlite-to-current.sh
 chmod +x migrate-sqlite-to-current.sh
 
 # Run it in your project directory
@@ -171,7 +171,7 @@ chmod +x migrate-sqlite-to-current.sh
 
 The script exports issues, dependencies, and labels from SQLite, handles type normalization, and imports everything into the new Dolt backend.
 
-**Alternative: manual export with the old binary.** Old binaries are always available on [GitHub Releases](https://github.com/steveyegge/beads/releases). Download the version that matches your project, then:
+**Alternative: manual export with the old binary.** Old binaries are always available on [GitHub Releases](https://github.com/gastownhall/beads/releases). Download the version that matches your project, then:
 
 ```bash
 # 1. Export with the old binary

--- a/website/docs/integrations/claude-code.md
+++ b/website/docs/integrations/claude-code.md
@@ -138,7 +138,7 @@ For enhanced UX with slash commands:
 
 ```bash
 # In Claude Code
-/plugin marketplace add steveyegge/beads
+/plugin marketplace add gastownhall/beads
 /plugin install beads
 # Restart Claude Code
 ```

--- a/website/docs/integrations/github-copilot.md
+++ b/website/docs/integrations/github-copilot.md
@@ -142,4 +142,4 @@ Git hooks are optional. They auto-sync issues but you can skip them during `bd i
 
 - [MCP Server](/integrations/mcp-server) - Detailed MCP configuration
 - [Installation](/getting-started/installation) - Full install guide
-- [Detailed Copilot Guide](https://github.com/steveyegge/beads/blob/main/docs/COPILOT_INTEGRATION.md) - Comprehensive documentation
+- [Detailed Copilot Guide](https://github.com/gastownhall/beads/blob/main/docs/COPILOT_INTEGRATION.md) - Comprehensive documentation

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -26,7 +26,7 @@ Traditional issue trackers (Jira, GitHub Issues) weren't designed for AI agents.
 brew install beads
 
 # Or quick install (macOS/Linux/FreeBSD)
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
 # Initialize in your project
 cd your-project

--- a/website/docs/recovery/index.md
+++ b/website/docs/recovery/index.md
@@ -41,5 +41,5 @@ Most issues can be diagnosed with `bd status`. Start there before following spec
 If these runbooks don't resolve your issue:
 
 1. Check the [FAQ](/reference/faq)
-2. Search [existing issues](https://github.com/steveyegge/beads/issues)
+2. Search [existing issues](https://github.com/gastownhall/beads/issues)
 3. Open a new issue with diagnostic output

--- a/website/docs/reference/advanced.md
+++ b/website/docs/reference/advanced.md
@@ -89,7 +89,7 @@ storage.UnderlyingDB().Exec(`
 `)
 ```
 
-See [EXTENDING.md](https://github.com/steveyegge/beads/blob/main/docs/EXTENDING.md).
+See [EXTENDING.md](https://github.com/gastownhall/beads/blob/main/docs/EXTENDING.md).
 
 ## Event System
 

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -123,7 +123,7 @@ bd setup aider    # Aider
 
 ### Can beads import from GitHub Issues?
 
-Yes — see the [GitHub integration documentation](https://github.com/steveyegge/beads/blob/main/docs/GITHUB_IMPORT.md) for details.
+Yes — see the [GitHub integration documentation](https://github.com/gastownhall/beads/blob/main/docs/GITHUB_IMPORT.md) for details.
 
 ## Troubleshooting
 
@@ -153,6 +153,6 @@ bd hooks status
 
 ### How do I report a bug?
 
-1. Check existing issues: https://github.com/steveyegge/beads/issues
+1. Check existing issues: https://github.com/gastownhall/beads/issues
 2. Include: `bd version`, `bd info --json`, reproduction steps
-3. File at: https://github.com/steveyegge/beads/issues/new
+3. File at: https://github.com/gastownhall/beads/issues/new

--- a/website/docs/reference/troubleshooting.md
+++ b/website/docs/reference/troubleshooting.md
@@ -222,4 +222,4 @@ bd info --json
 uname -a
 ```
 
-Report at: https://github.com/steveyegge/beads/issues
+Report at: https://github.com/gastownhall/beads/issues

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -4,7 +4,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 
 // Environment-based URL configuration for fork flexibility
 // SITE_URL: Full URL (e.g., "https://myuser.github.io/beads" or "https://myuser.github.io")
-// ORG_NAME: GitHub organization/user name (defaults to "steveyegge")
+// ORG_NAME: GitHub organization/user name (defaults to "gastownhall")
 // PROJECT_NAME: Repository/project name (defaults to "beads")
 const orgName = process.env.ORG_NAME || 'gastownhall';
 const projectName = process.env.PROJECT_NAME || 'beads';

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -30,7 +30,7 @@ Traditional issue trackers (Jira, GitHub Issues) weren't designed for AI agents.
 brew install beads
 
 # Or quick install (macOS/Linux/FreeBSD)
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
 # Initialize in your project
 cd your-project
@@ -322,7 +322,7 @@ brew install beads
 ### Quick Install Script (All Platforms)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 The installer will:
@@ -372,7 +372,7 @@ go install github.com/steveyegge/beads/cmd/bd@latest
 
 **From source**:
 ```bash
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 go build -o bd ./cmd/bd
 sudo mv bd /usr/local/bin/
@@ -402,7 +402,7 @@ go install github.com/steveyegge/beads/cmd/bd@latest
 
 **Via quick install script**:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 **Via go install**:
@@ -420,7 +420,7 @@ Beads ships with native Windows support—no MSYS or MinGW required.
 
 **Via PowerShell script**:
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 The script installs a prebuilt Windows release if available. Go is only required for `go install` or building from source.
@@ -526,13 +526,13 @@ CGO_ENABLED=1 go install github.com/steveyegge/beads/cmd/bd@latest
 ### Quick install script (macOS/Linux/FreeBSD)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 ### PowerShell installer (Windows)
 
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 ### Homebrew
@@ -824,7 +824,7 @@ bd dolt pull
 
 When a teammate clones the repo, `bd bootstrap` auto-detects the existing database on `refs/dolt/data` and clones it — no manual remote setup needed.
 
-See [Sync](/cli-reference/sync) for CLI details. For remote configuration and federation, see the repository docs [DOLT-BACKEND.md](https://github.com/steveyegge/beads/blob/main/docs/DOLT-BACKEND.md) and [FEDERATION-SETUP.md](https://github.com/steveyegge/beads/blob/main/FEDERATION-SETUP.md).
+See [Sync](/cli-reference/sync) for CLI details. For remote configuration and federation, see the repository docs [DOLT-BACKEND.md](https://github.com/gastownhall/beads/blob/main/docs/DOLT-BACKEND.md) and [FEDERATION-SETUP.md](https://github.com/gastownhall/beads/blob/main/FEDERATION-SETUP.md).
 
 ## Optional: Notion sync
 
@@ -925,7 +925,7 @@ bd admin cleanup --force
 - More sync scenarios: [Sync](/cli-reference/sync)
 - Full command list: [CLI Reference](/cli-reference)
 
-See the [repository README](https://github.com/steveyegge/beads/blob/main/README.md) for an overview and links to deeper docs.
+See the [repository README](https://github.com/gastownhall/beads/blob/main/README.md) for an overview and links to deeper docs.
 
 </document>
 
@@ -953,8 +953,8 @@ Use the command that matches your install method.
 
 | Install method | Platforms | Command |
 |---|---|---|
-| Quick install script | macOS, Linux, FreeBSD | `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh \| bash` |
-| PowerShell installer | Windows | `irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 \| iex` |
+| Quick install script | macOS, Linux, FreeBSD | `curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh \| bash` |
+| PowerShell installer | Windows | `irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 \| iex` |
 | Homebrew | macOS, Linux | `brew upgrade beads` |
 | go install | macOS, Linux, FreeBSD, Windows | `go install github.com/steveyegge/beads/cmd/bd@latest` |
 | npm | macOS, Linux, Windows | `npm update -g @beads/bd` |
@@ -964,13 +964,13 @@ Use the command that matches your install method.
 ### Quick install script (macOS/Linux/FreeBSD)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 ### PowerShell installer (Windows)
 
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 ### Homebrew
@@ -4519,7 +4519,7 @@ For enhanced UX with slash commands:
 
 ```bash
 # In Claude Code
-/plugin marketplace add steveyegge/beads
+/plugin marketplace add gastownhall/beads
 /plugin install beads
 # Restart Claude Code
 ```
@@ -4708,7 +4708,7 @@ Git hooks are optional. They auto-sync issues but you can skip them during `bd i
 
 - [MCP Server](/integrations/mcp-server) - Detailed MCP configuration
 - [Installation](/getting-started/installation) - Full install guide
-- [Detailed Copilot Guide](https://github.com/steveyegge/beads/blob/main/docs/COPILOT_INTEGRATION.md) - Comprehensive documentation
+- [Detailed Copilot Guide](https://github.com/gastownhall/beads/blob/main/docs/COPILOT_INTEGRATION.md) - Comprehensive documentation
 
 </document>
 
@@ -5157,7 +5157,7 @@ Most issues can be diagnosed with `bd status`. Start there before following spec
 If these runbooks don't resolve your issue:
 
 1. Check the [FAQ](/reference/faq)
-2. Search [existing issues](https://github.com/steveyegge/beads/issues)
+2. Search [existing issues](https://github.com/gastownhall/beads/issues)
 3. Open a new issue with diagnostic output
 
 </document>
@@ -5512,7 +5512,7 @@ storage.UnderlyingDB().Exec(`
 `)
 ```
 
-See [EXTENDING.md](https://github.com/steveyegge/beads/blob/main/docs/EXTENDING.md).
+See [EXTENDING.md](https://github.com/gastownhall/beads/blob/main/docs/EXTENDING.md).
 
 ## Event System
 
@@ -5886,7 +5886,7 @@ bd setup aider    # Aider
 
 ### Can beads import from GitHub Issues?
 
-Yes — see the [GitHub integration documentation](https://github.com/steveyegge/beads/blob/main/docs/GITHUB_IMPORT.md) for details.
+Yes — see the [GitHub integration documentation](https://github.com/gastownhall/beads/blob/main/docs/GITHUB_IMPORT.md) for details.
 
 ## Troubleshooting
 
@@ -5916,9 +5916,9 @@ bd hooks status
 
 ### How do I report a bug?
 
-1. Check existing issues: https://github.com/steveyegge/beads/issues
+1. Check existing issues: https://github.com/gastownhall/beads/issues
 2. Include: `bd version`, `bd info --json`, reproduction steps
-3. File at: https://github.com/steveyegge/beads/issues/new
+3. File at: https://github.com/gastownhall/beads/issues/new
 
 </document>
 
@@ -6264,7 +6264,7 @@ bd info --json
 uname -a
 ```
 
-Report at: https://github.com/steveyegge/beads/issues
+Report at: https://github.com/gastownhall/beads/issues
 
 </document>
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -54,7 +54,7 @@ Quick fixes for common issues:
 - Circular Dependencies: `bd doctor` (diagnose only, NEVER --fix)
 - Sync Failures: `bd dolt pull`
 
-Full runbooks: https://steveyegge.github.io/beads/recovery/
+Full runbooks: https://gastownhall.github.io/beads/recovery/
 
 ## Session Close Protocol
 
@@ -67,13 +67,13 @@ WARNING: Skipping sync or backup publication causes stale state in multi-agent w
 
 ## Documentation
 
-- Full docs: https://steveyegge.github.io/beads/
-- CLI reference: https://steveyegge.github.io/beads/cli-reference
-- Agent guide: https://steveyegge.github.io/beads/integrations/claude-code
-- Complete LLM context: https://steveyegge.github.io/beads/llms-full.txt
+- Full docs: https://gastownhall.github.io/beads/
+- CLI reference: https://gastownhall.github.io/beads/cli-reference
+- Agent guide: https://gastownhall.github.io/beads/integrations/claude-code
+- Complete LLM context: https://gastownhall.github.io/beads/llms-full.txt
 
 ## Links
 
-- GitHub: https://github.com/steveyegge/beads
+- GitHub: https://github.com/gastownhall/beads
 - npm: https://www.npmjs.com/package/@beads/bd
 - PyPI (MCP): https://pypi.org/project/beads-mcp/

--- a/website/versioned_docs/version-1.0.0/getting-started/installation.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/installation.md
@@ -17,13 +17,13 @@ brew install beads
 ### Install Script (macOS/Linux/FreeBSD)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 ```
 
 ### PowerShell (Windows)
 
 ```pwsh
-irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 | iex
 ```
 
 ### npm
@@ -66,12 +66,12 @@ Building from source or using `go install` requires CGO dependencies:
 | Fedora/RHEL | `sudo dnf install -y libicu-devel libzstd-devel` |
 
 ```bash
-git clone https://github.com/steveyegge/beads
+git clone https://github.com/gastownhall/beads
 cd beads
 go build -o bd ./cmd/bd
 ```
 
-See [CONTRIBUTING.md](https://github.com/steveyegge/beads/blob/main/CONTRIBUTING.md) for full developer setup.
+See [CONTRIBUTING.md](https://github.com/gastownhall/beads/blob/main/CONTRIBUTING.md) for full developer setup.
 
 ## Next Steps
 

--- a/website/versioned_docs/version-1.0.0/getting-started/upgrading.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/upgrading.md
@@ -13,8 +13,8 @@ Use the command that matches your install method:
 | Install method | Command |
 |---|---|
 | Homebrew | `brew upgrade beads` |
-| Install script (macOS/Linux) | `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh \| bash` |
-| PowerShell (Windows) | `irm https://raw.githubusercontent.com/steveyegge/beads/main/install.ps1 \| iex` |
+| Install script (macOS/Linux) | `curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh \| bash` |
+| PowerShell (Windows) | `irm https://raw.githubusercontent.com/gastownhall/beads/main/install.ps1 \| iex` |
 | npm | `npm update -g @beads/bd` |
 | go install | `go install github.com/steveyegge/beads/cmd/bd@latest` |
 

--- a/website/versioned_docs/version-1.0.0/integrations/claude-code.md
+++ b/website/versioned_docs/version-1.0.0/integrations/claude-code.md
@@ -138,7 +138,7 @@ For enhanced UX with slash commands:
 
 ```bash
 # In Claude Code
-/plugin marketplace add steveyegge/beads
+/plugin marketplace add gastownhall/beads
 /plugin install beads
 # Restart Claude Code
 ```

--- a/website/versioned_docs/version-1.0.0/integrations/github-copilot.md
+++ b/website/versioned_docs/version-1.0.0/integrations/github-copilot.md
@@ -142,4 +142,4 @@ Git hooks are optional. They auto-sync issues but you can skip them during `bd i
 
 - [MCP Server](/integrations/mcp-server) - Detailed MCP configuration
 - [Installation](/getting-started/installation) - Full install guide
-- [Detailed Copilot Guide](https://github.com/steveyegge/beads/blob/main/docs/COPILOT_INTEGRATION.md) - Comprehensive documentation
+- [Detailed Copilot Guide](https://github.com/gastownhall/beads/blob/main/docs/COPILOT_INTEGRATION.md) - Comprehensive documentation

--- a/website/versioned_docs/version-1.0.0/intro.md
+++ b/website/versioned_docs/version-1.0.0/intro.md
@@ -26,7 +26,7 @@ Traditional issue trackers (Jira, GitHub Issues) weren't designed for AI agents.
 brew install beads
 
 # Or quick install (macOS/Linux/FreeBSD)
-curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
 
 # Initialize in your project
 cd your-project

--- a/website/versioned_docs/version-1.0.0/recovery/index.md
+++ b/website/versioned_docs/version-1.0.0/recovery/index.md
@@ -41,5 +41,5 @@ Most issues can be diagnosed with `bd status`. Start there before following spec
 If these runbooks don't resolve your issue:
 
 1. Check the [FAQ](/reference/faq)
-2. Search [existing issues](https://github.com/steveyegge/beads/issues)
+2. Search [existing issues](https://github.com/gastownhall/beads/issues)
 3. Open a new issue with diagnostic output

--- a/website/versioned_docs/version-1.0.0/reference/advanced.md
+++ b/website/versioned_docs/version-1.0.0/reference/advanced.md
@@ -89,7 +89,7 @@ storage.UnderlyingDB().Exec(`
 `)
 ```
 
-See [EXTENDING.md](https://github.com/steveyegge/beads/blob/main/docs/EXTENDING.md).
+See [EXTENDING.md](https://github.com/gastownhall/beads/blob/main/docs/EXTENDING.md).
 
 ## Event System
 

--- a/website/versioned_docs/version-1.0.0/reference/faq.md
+++ b/website/versioned_docs/version-1.0.0/reference/faq.md
@@ -123,7 +123,7 @@ bd setup aider    # Aider
 
 ### Can beads import from GitHub Issues?
 
-Yes — see the [GitHub integration documentation](https://github.com/steveyegge/beads/blob/main/docs/GITHUB_IMPORT.md) for details.
+Yes — see the [GitHub integration documentation](https://github.com/gastownhall/beads/blob/main/docs/GITHUB_IMPORT.md) for details.
 
 ## Troubleshooting
 
@@ -153,6 +153,6 @@ bd hooks status
 
 ### How do I report a bug?
 
-1. Check existing issues: https://github.com/steveyegge/beads/issues
+1. Check existing issues: https://github.com/gastownhall/beads/issues
 2. Include: `bd version`, `bd info --json`, reproduction steps
-3. File at: https://github.com/steveyegge/beads/issues/new
+3. File at: https://github.com/gastownhall/beads/issues/new

--- a/website/versioned_docs/version-1.0.0/reference/troubleshooting.md
+++ b/website/versioned_docs/version-1.0.0/reference/troubleshooting.md
@@ -222,4 +222,4 @@ bd info --json
 uname -a
 ```
 
-Report at: https://github.com/steveyegge/beads/issues
+Report at: https://github.com/gastownhall/beads/issues

--- a/winget/README.md
+++ b/winget/README.md
@@ -39,5 +39,5 @@ When releasing a new version:
 ### Getting the SHA256
 
 ```bash
-curl -sL https://github.com/steveyegge/beads/releases/download/v<VERSION>/checksums.txt | grep windows
+curl -sL https://github.com/gastownhall/beads/releases/download/v<VERSION>/checksums.txt | grep windows
 ```

--- a/winget/SteveYegge.beads.installer.yaml
+++ b/winget/SteveYegge.beads.installer.yaml
@@ -8,10 +8,10 @@ NestedInstallerFiles:
     PortableCommandAlias: bd
 Installers:
   - Architecture: x64
-    InstallerUrl: https://github.com/steveyegge/beads/releases/download/v0.30.7/beads_0.30.7_windows_amd64.zip
+    InstallerUrl: https://github.com/gastownhall/beads/releases/download/v0.30.7/beads_0.30.7_windows_amd64.zip
     InstallerSha256: 91A3D0799533DE8FA9AAB6415B8A57BDD542C59A21805FBF80A559A53F3CD02E
   - Architecture: arm64
-    InstallerUrl: https://github.com/steveyegge/beads/releases/download/v0.30.7/beads_0.30.7_windows_arm64.zip
+    InstallerUrl: https://github.com/gastownhall/beads/releases/download/v0.30.7/beads_0.30.7_windows_arm64.zip
     InstallerSha256: "0000000000000000000000000000000000000000000000000000000000000000"
 ManifestType: installer
 ManifestVersion: 1.6.0

--- a/winget/SteveYegge.beads.locale.en-US.yaml
+++ b/winget/SteveYegge.beads.locale.en-US.yaml
@@ -4,12 +4,12 @@ PackageVersion: 0.30.7
 PackageLocale: en-US
 Publisher: Steve Yegge
 PublisherUrl: https://github.com/steveyegge
-PublisherSupportUrl: https://github.com/steveyegge/beads/issues
+PublisherSupportUrl: https://github.com/gastownhall/beads/issues
 Author: Steve Yegge
 PackageName: beads
-PackageUrl: https://github.com/steveyegge/beads
+PackageUrl: https://github.com/gastownhall/beads
 License: MIT
-LicenseUrl: https://github.com/steveyegge/beads/blob/main/LICENSE
+LicenseUrl: https://github.com/gastownhall/beads/blob/main/LICENSE
 Copyright: Copyright (c) 2024 Steve Yegge
 ShortDescription: Distributed, Dolt-powered graph issue tracker for AI agents
 Description: |
@@ -24,6 +24,6 @@ Tags:
   - git
   - cli
   - developer-tools
-ReleaseNotesUrl: https://github.com/steveyegge/beads/releases/tag/v0.30.7
+ReleaseNotesUrl: https://github.com/gastownhall/beads/releases/tag/v0.30.7
 ManifestType: defaultLocale
 ManifestVersion: 1.6.0


### PR DESCRIPTION
Partially addresses GH#3059 — the **documentation** category of the migration gap.

## Scope

Rewrites documentation, installation instructions, and package metadata to point at the new repo location at `github.com/gastownhall/beads`. Every rewritten URL was verified to resolve (200) at gastownhall today, including historical PR and commit links (GitHub preserves these across the repo transfer).

Notably, `https://steveyegge.github.io/beads/` currently returns **404**, so the doc-site links updated to `gastownhall.github.io/beads/` (which returns 200) were actively broken before this PR.

## Intentionally NOT changed

These are code / package-registry coordinates that would break downstream consumers if changed unilaterally:

- **Go module path** in `go.mod` and all Go imports / `go install` / `go get` / `go list` references — module remains `github.com/steveyegge/beads`
- **Winget** `PackageIdentifier: SteveYegge.beads` and publisher URLs (`Publisher: Steve Yegge` remains the publisher identity; changing the identifier would create a new winget registry entry and break upgrades for existing installers)
- `claude-plugin/plugin.json` `"url"` publisher field (kept aligned with winget publisher)
- **goreportcard.com** badge (tied to the Go module path)
- `security@steveyegge.com` in `SECURITY.md` (personal contact)
- `CHANGELOG.md` narrative text describing the move itself (lines 14, 4591)

## What's covered

- `https://github.com/steveyegge/beads/*` URLs (repo, releases, issues, pull, blob, tree, .git)
- `raw.githubusercontent.com/steveyegge/beads`
- `api.github.com/repos/steveyegge/beads`
- `steveyegge.github.io/beads` → `gastownhall.github.io/beads` (fixes 404)
- shields.io license/release badges in `README.md`
- `mise install github:steveyegge/beads` → `gastownhall/beads`
- `/plugin marketplace add steveyegge/beads` → `gastownhall/beads`
- Display text in `.beads/README.md` markdown link labels
- Docusaurus config stale default-value comment
- Bare references in `RELEASING.md`, `scripts/README.md`, `docs/RULES_AUDIT_DESIGN.md`

## Still open from GH#3059

- **Go module path migration** (largest category — needs backcompat strategy decision)
- **Claude Code marketplace collision** (`beads-marketplace` built-in points at old source serving v0.60.0) — likely needs Anthropic-side coordination

## Test plan

- [ ] Spot-check rendered docs on `website/` build
- [ ] Confirm `gastownhall.github.io/beads/` Pages site renders the updated links correctly
- [ ] Confirm shields.io badges render against `gastownhall/beads`
- [ ] Verify `/plugin marketplace add gastownhall/beads` works end-to-end in Claude Code
- [ ] Verify `mise install github:gastownhall/beads` fetches a release successfully