### PR TITLE
fix: don't normalize user-provided sync.remote URLs (GH#3339)

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -249,7 +249,10 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 	// Check sync.remote (primary) or sync.git-remote (deprecated fallback)
 	syncRemote := resolveSyncRemote()
 	if syncRemote != "" {
-		plan.SyncRemote = normalizeRemoteURL(syncRemote)
+		// User-provided sync.remote — trust the URL format as-is.
+		// normalizeRemoteURL would convert http:// to git+http://,
+		// breaking Dolt remotesapi endpoints (GH#3339).
+		plan.SyncRemote = syncRemote
 		plan.Action = "sync"
 		plan.Reason = "sync.remote configured — will clone from " + syncRemote
 		return plan

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -327,6 +327,47 @@ func TestDetectBootstrapAction_SyncWhenOriginHasDoltRef(t *testing.T) {
 	}
 }
 
+func TestDetectBootstrapAction_ExplicitSyncRemotePreservesRemotesAPIURL(t *testing.T) {
+	restore := snapshotBootstrapEnv(t)
+	defer restore()
+	config.ResetForTesting()
+	defer config.ResetForTesting()
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	const syncRemote = "http://myserver:7007/mydb"
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("sync.remote: "+syncRemote+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", beadsDir)
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize failed: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := configfile.DefaultConfig()
+	plan := detectBootstrapAction(beadsDir, cfg)
+
+	if plan.Action != "sync" {
+		t.Errorf("action = %q, want %q", plan.Action, "sync")
+	}
+	if plan.SyncRemote != syncRemote {
+		t.Errorf("SyncRemote = %q, want unnormalized explicit sync.remote %q", plan.SyncRemote, syncRemote)
+	}
+}
+
 func TestDetectBootstrapAction_InitWhenOriginHasNoDoltRef(t *testing.T) {
 	t.Setenv("BEADS_DOLT_DATA_DIR", "")
 	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -304,7 +304,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			var earlySyncURL string
 			earlyRemoteHasDoltData := false
 			if s := resolveSyncRemote(); s != "" {
-				earlySyncURL = normalizeRemoteURL(s)
+				earlySyncURL = s
 				earlyRemoteHasDoltData = true // sync.remote configured = user intends bootstrap
 			} else if isGitRepo() && !isBareGitRepo() {
 				if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
@@ -568,7 +568,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// sync.remote was explicitly configured. Treat as bootstrap-
 			// from-remote intent; CheckRemoteSafety still enforces that
 			// --force/--reinit-local can't silently fight that intent.
-			syncURL = normalizeRemoteURL(syncURL)
+			// Trust the URL format as-is: normalizeRemoteURL would convert
+			// http:// to git+http:// and break Dolt remotesapi endpoints
+			// configured explicitly by the user (GH#3339).
 			syncFromRemote = true
 		} else if isGitRepo() && !isBareGitRepo() {
 			if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {

--- a/cmd/bd/sync_remote_test.go
+++ b/cmd/bd/sync_remote_test.go
@@ -21,6 +21,11 @@ func TestNormalizeRemoteURL(t *testing.T) {
 		{"http://github.com/org/repo.git", "git+http://github.com/org/repo.git"},
 		{"ssh://git@github.com/org/repo.git", "git+ssh://git@github.com/org/repo.git"},
 		{"git@github.com:org/repo.git", "git+ssh://git@github.com/org/repo.git"},
+
+		// Dolt remotesapi URLs — also converted (callers that need
+		// pass-through for user-provided URLs should skip normalization)
+		{"http://myserver:7007/mydb", "git+http://myserver:7007/mydb"},
+		{"https://doltremoteapi.example.com/mydb", "git+https://doltremoteapi.example.com/mydb"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/internal/remotecache/url.go
+++ b/internal/remotecache/url.go
@@ -21,6 +21,7 @@ var remoteSchemes = []string{
 	"ssh://",
 	"git+ssh://",
 	"git+https://",
+	"git+http://",
 }
 
 // allowedSchemes is the set of recognized URL schemes for validation.
@@ -35,6 +36,7 @@ var allowedSchemes = map[string]bool{
 	"ssh":       true,
 	"git+ssh":   true,
 	"git+https": true,
+	"git+http":  true,
 }
 
 // gitSSHPattern matches SCP-style git remote URLs (user@host:path).
@@ -133,7 +135,7 @@ func validateSchemeURL(rawURL string) error {
 		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 			return fmt.Errorf("dolthub:// URL must have org/repo format (e.g., dolthub://myorg/myrepo)")
 		}
-	case "https", "http", "git+https":
+	case "https", "http", "git+https", "git+http":
 		if parsed.Host == "" {
 			return fmt.Errorf("%s:// URL must include a hostname", scheme)
 		}
@@ -219,7 +221,7 @@ func ValidateRemoteURLWithPatterns(rawURL string, patterns []string) error {
 
 func sortedSchemes() []string {
 	// Return in a consistent display order
-	return []string{"dolthub", "https", "http", "ssh", "git+ssh", "git+https", "s3", "gs", "az", "file"}
+	return []string{"dolthub", "https", "http", "ssh", "git+ssh", "git+https", "git+http", "s3", "gs", "az", "file"}
 }
 
 // CacheKey returns a filesystem-safe identifier for a remote URL.

--- a/internal/remotecache/url_test.go
+++ b/internal/remotecache/url_test.go
@@ -22,6 +22,7 @@ func TestIsRemoteURL(t *testing.T) {
 		{"ssh://git@github.com/org/repo", true},
 		{"git+ssh://git@github.com/org/repo", true},
 		{"git+https://github.com/org/repo", true},
+		{"git+http://example.com/repo.git", true},
 		{"git@github.com:org/repo.git", true},
 		{"deploy@myserver.com:beads/data", true},
 
@@ -65,6 +66,7 @@ func TestValidateRemoteURL(t *testing.T) {
 		{"ssh URL", "ssh://git@github.com/org/repo", false, ""},
 		{"git+ssh URL", "git+ssh://git@github.com/org/repo", false, ""},
 		{"git+https URL", "git+https://github.com/org/repo", false, ""},
+		{"git+http URL", "git+http://example.com/repo.git", false, ""},
 		{"SCP-style git", "git@github.com:org/repo.git", false, ""},
 		{"SCP-style deploy", "deploy@myserver.com:beads/data", false, ""},
 		{"https with port", "https://example.com:8443/repo", false, ""},
@@ -102,6 +104,7 @@ func TestValidateRemoteURL(t *testing.T) {
 		{"ssh no host", "ssh:///path", true, "hostname"},
 		{"git+ssh no host", "git+ssh:///path", true, "hostname"},
 		{"git+https no host", "git+https:///path", true, "hostname"},
+		{"git+http no host", "git+http:///path", true, "hostname"},
 		{"s3 no bucket", "s3:///path", true, "bucket"},
 		{"gs no bucket", "gs:///path", true, "bucket"},
 		{"az no host", "az:///path", true, "hostname"},


### PR DESCRIPTION
## Summary

- Stop calling `normalizeRemoteURL()` on user-provided `sync.remote` values in `init.go` and `bootstrap.go` — the user chose the URL format, so we trust it as-is
- Keep normalization for auto-detected git origin URLs (those always need `git+` conversion)
- Add `git+http` to `allowedSchemes`, `remoteSchemes`, and `validateSchemeURL` in `internal/remotecache/url.go` (secondary bug: `ValidateRemoteURL()` rejected `git+http://` URLs)

Fixes #3339

## Test plan

- [ ] `TestNormalizeRemoteURL` passes with new remotesapi test cases (verified locally)
- [ ] `TestIsRemoteURL` passes with `git+http://` (verified locally)
- [ ] `TestValidateRemoteURL` passes for `git+http://` valid and structural validation (verified locally)
- [ ] Existing `git+ssh://`, `git+https://`, `https://` sync workflows unaffected (normalization still applies to git origin auto-detection path)
- [ ] Manual test: `sync.remote: http://<host>:7007/<db>` passed through to `dolt clone` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)