### PR TITLE
fix(doctor): run full pipeline in embedded mode

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -184,8 +184,8 @@ Examples:
   bd doctor --migration=post   # Validate Dolt migration completed
   bd doctor --migration=pre --json  # Machine-parseable migration validation`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// bd-ffe: embedded mode runs the full check pipeline. Server-only
-		// checks (RunDoltHealthChecks) already gate on server reachability.
+		// Embedded mode runs the full check pipeline. Server-only checks
+		// (RunDoltHealthChecks) already gate on server reachability.
 		// Use global jsonOutput set by PersistentPreRun
 
 		// Determine path to check

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -184,16 +184,8 @@ Examples:
   bd doctor --migration=post   # Validate Dolt migration completed
   bd doctor --migration=pre --json  # Machine-parseable migration validation`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if isEmbeddedMode() {
-			fmt.Fprintln(os.Stderr, "Note: 'bd doctor' is not yet supported in embedded mode.")
-			fmt.Fprintln(os.Stderr, "")
-			fmt.Fprintln(os.Stderr, "For embedded mode troubleshooting:")
-			fmt.Fprintln(os.Stderr, "  • Verify database exists:  ls -la .beads/embeddeddolt/")
-			fmt.Fprintln(os.Stderr, "  • Check bd version:        bd version")
-			fmt.Fprintln(os.Stderr, "  • Reinitialize if needed:  bd init --force")
-			fmt.Fprintln(os.Stderr, "  • Switch to server mode:   bd init --server")
-			os.Exit(0)
-		}
+		// bd-ffe: embedded mode runs the full check pipeline. Server-only
+		// checks (RunDoltHealthChecks) already gate on server reachability.
 		// Use global jsonOutput set by PersistentPreRun
 
 		// Determine path to check

--- a/cmd/bd/doctor/claude.go
+++ b/cmd/bd/doctor/claude.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -282,9 +283,27 @@ func hasBeadsHooks(settingsPath string) bool {
 
 // VerifyPrimeOutput checks if bd prime command works and adapts correctly.
 // repoPath is the project root directory.
+//
+// Uses a short timeout because bd prime acquires the embedded-mode flock on
+// .beads/embeddeddolt/.lock. If another bd process (sync, export) holds the
+// lock, bd prime would block indefinitely and deadlock the doctor run
+// (bd-ffe).
 func VerifyPrimeOutput(repoPath string) DoctorCheck {
-	cmd := exec.Command("bd", "prime")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", "prime")
 	output, err := cmd.CombinedOutput()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return DoctorCheck{
+			Name:    "bd prime Command",
+			Status:  "warning",
+			Message: "Command timed out",
+			Detail:  "bd prime did not finish in 10s; another bd process may hold the embedded-mode lock",
+			Fix:     "Check for stuck bd processes (ps | grep bd), then re-run 'bd doctor'",
+		}
+	}
 
 	if err != nil {
 		return DoctorCheck{

--- a/cmd/bd/doctor/claude.go
+++ b/cmd/bd/doctor/claude.go
@@ -286,8 +286,7 @@ func hasBeadsHooks(settingsPath string) bool {
 //
 // Uses a short timeout because bd prime acquires the embedded-mode flock on
 // .beads/embeddeddolt/.lock. If another bd process (sync, export) holds the
-// lock, bd prime would block indefinitely and deadlock the doctor run
-// (bd-ffe).
+// lock, bd prime would block indefinitely and deadlock the doctor run.
 func VerifyPrimeOutput(repoPath string) DoctorCheck {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/cmd/bd/doctor/config_values.go
+++ b/cmd/bd/doctor/config_values.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -416,7 +417,7 @@ func checkDatabaseConfigValues(repoPath string) []string {
 	return checkDatabaseConfigValuesWithStore(store)
 }
 
-func checkDatabaseConfigValuesWithStore(store *dolt.DoltStore) []string {
+func checkDatabaseConfigValuesWithStore(store storage.DoltStorage) []string {
 	var issues []string
 	ctx := context.Background()
 

--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -10,6 +10,7 @@ import (
 	"github.com/steveyegge/beads/cmd/bd/doctor/fix"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"gopkg.in/yaml.v3"
 )
@@ -94,6 +95,9 @@ func CheckDatabaseVersionWithStore(ss *SharedStore, cliVersion string) DoctorChe
 	beadsDir := sharedStoreBeadsDir(ss)
 	store := ss.Store()
 	if store == nil {
+		if ss.IsEmbedded() {
+			return embeddedSkippedCheck("Database", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+		}
 		if !sharedStoreNeedsLocalDoltDir(beadsDir) {
 			return DoctorCheck{
 				Name:    "Database",
@@ -104,7 +108,7 @@ func CheckDatabaseVersionWithStore(ss *SharedStore, cliVersion string) DoctorChe
 			}
 		}
 
-		doltPath := getDatabasePath(beadsDir)
+		doltPath := resolveDatabasePath(beadsDir)
 		if _, err := os.Stat(doltPath); os.IsNotExist(err) {
 			return DoctorCheck{
 				Name:    "Database",
@@ -125,7 +129,7 @@ func CheckDatabaseVersionWithStore(ss *SharedStore, cliVersion string) DoctorChe
 	return checkDatabaseVersionWithStore(store, cliVersion)
 }
 
-func checkDatabaseVersionWithStore(store *dolt.DoltStore, cliVersion string) DoctorCheck {
+func checkDatabaseVersionWithStore(store storage.DoltStorage, cliVersion string) DoctorCheck {
 	ctx := context.Background()
 	dbVersion, err := store.GetLocalMetadata(ctx, "bd_version")
 	if err != nil {
@@ -198,6 +202,9 @@ func CheckSchemaCompatibility(path string) DoctorCheck {
 func CheckSchemaCompatibilityWithStore(ss *SharedStore) DoctorCheck {
 	store := ss.Store()
 	if store == nil {
+		if ss.IsEmbedded() {
+			return embeddedSkippedCheck("Schema Compatibility", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+		}
 		return DoctorCheck{
 			Name:    "Schema Compatibility",
 			Status:  StatusOK,
@@ -207,7 +214,7 @@ func CheckSchemaCompatibilityWithStore(ss *SharedStore) DoctorCheck {
 	return checkSchemaCompatibilityWithStore(store)
 }
 
-func checkSchemaCompatibilityWithStore(store *dolt.DoltStore) DoctorCheck {
+func checkSchemaCompatibilityWithStore(store storage.DoltStorage) DoctorCheck {
 	ctx := context.Background()
 	// Exercise core tables/views.
 	if _, err := store.GetStatistics(ctx); err != nil {
@@ -269,6 +276,9 @@ func CheckDatabaseIntegrity(path string) DoctorCheck {
 func CheckDatabaseIntegrityWithStore(ss *SharedStore) DoctorCheck {
 	store := ss.Store()
 	if store == nil {
+		if ss.IsEmbedded() {
+			return embeddedSkippedCheck("Database Integrity", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+		}
 		return DoctorCheck{
 			Name:    "Database Integrity",
 			Status:  StatusOK,
@@ -278,7 +288,7 @@ func CheckDatabaseIntegrityWithStore(ss *SharedStore) DoctorCheck {
 	return checkDatabaseIntegrityWithStore(store)
 }
 
-func checkDatabaseIntegrityWithStore(store *dolt.DoltStore) DoctorCheck {
+func checkDatabaseIntegrityWithStore(store storage.DoltStorage) DoctorCheck {
 	ctx := context.Background()
 	// Minimal checks: metadata + statistics. If these work, the store is at least readable.
 	if _, err := store.GetLocalMetadata(ctx, "bd_version"); err != nil {
@@ -383,7 +393,19 @@ func CheckProjectIdentityWithStore(ss *SharedStore, path string) DoctorCheck {
 
 	store := ss.Store()
 	if store == nil {
-		doltPath := getDatabasePath(beadsDir)
+		if ss.IsEmbedded() {
+			if hasLocalID {
+				return DoctorCheck{
+					Name:     "Project Identity",
+					Status:   StatusOK,
+					Message:  "Skipped in embedded mode (metadata.json has project_id)",
+					Detail:   "Run 'bd doctor --check=validate' to verify the database-side _project_id",
+					Category: CategoryData,
+				}
+			}
+			return embeddedSkippedCheck("Project Identity", "metadata.json lacks project_id and embedded engine not opened by doctor (bd-ffe)")
+		}
+		doltPath := resolveDatabasePath(beadsDir)
 		if _, err := os.Stat(doltPath); os.IsNotExist(err) {
 			return DoctorCheck{
 				Name:     "Project Identity",
@@ -416,7 +438,7 @@ func checkProjectIdentityNoStore(_ *configfile.Config, hasLocalID bool) DoctorCh
 	}
 }
 
-func checkProjectIdentityWithStore(store *dolt.DoltStore, cfg *configfile.Config) DoctorCheck {
+func checkProjectIdentityWithStore(store storage.DoltStorage, cfg *configfile.Config) DoctorCheck {
 	hasLocalID := cfg.ProjectID != ""
 	ctx := context.Background()
 
@@ -468,15 +490,46 @@ func FixDatabaseConfig(path string) error {
 	return fix.DatabaseConfig(path)
 }
 
-// getDatabasePath returns the actual database directory path, respecting dolt_data_dir.
-// When dolt_data_dir is configured (e.g. ext4 redirect for WSL), the database lives
-// outside .beads/dolt/ — this function resolves the correct location.
+// getDatabasePath returns the server-mode database directory path, respecting
+// dolt_data_dir (which redirects the location on e.g. ext4 for WSL).
+//
+// This is the legacy server-mode location (.beads/dolt/<db>). In embedded
+// mode the database actually lives at .beads/embeddeddolt/<db> — callers
+// that need the real on-disk path for both modes should use
+// resolveDatabasePath instead (bd-ffe).
 func getDatabasePath(beadsDir string) string {
 	cfg, err := configfile.Load(beadsDir)
 	if err != nil || cfg == nil {
 		return filepath.Join(beadsDir, "dolt") // fallback to default
 	}
 	return cfg.DatabasePath(beadsDir)
+}
+
+// resolveDatabasePath returns the actual on-disk database directory for the
+// configured mode: server-mode uses .beads/dolt/ (or dolt_data_dir), embedded
+// mode uses .beads/embeddeddolt/<database>. Use this when an os.Stat presence
+// check must work in both modes (bd-ffe).
+//
+// When metadata.json is missing, falls back to whichever legacy directory
+// already exists on disk (.beads/dolt/ wins for compatibility with pre-
+// embedded-default repos).
+func resolveDatabasePath(beadsDir string) string {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		doltPath := filepath.Join(beadsDir, "dolt")
+		if info, err := os.Stat(doltPath); err == nil && info.IsDir() {
+			return doltPath
+		}
+		return filepath.Join(beadsDir, "embeddeddolt")
+	}
+	if cfg.IsDoltServerMode() {
+		return cfg.DatabasePath(beadsDir)
+	}
+	database := cfg.GetDoltDatabase()
+	if database == "" {
+		database = configfile.DefaultDoltDatabase
+	}
+	return filepath.Join(beadsDir, "embeddeddolt", database)
 }
 
 // isNoDbModeConfigured checks if no-db: true is set in config.yaml
@@ -538,6 +591,14 @@ func CheckDatabaseSize(path string) DoctorCheck {
 func CheckDatabaseSizeWithStore(ss *SharedStore) DoctorCheck {
 	store := ss.Store()
 	if store == nil {
+		if ss.IsEmbedded() {
+			return DoctorCheck{
+				Name:    "Large Database",
+				Status:  StatusOK,
+				Message: "Skipped in embedded mode",
+				Detail:  "Pruning suggestions are advisory; re-check under server mode or via 'bd stats'",
+			}
+		}
 		return DoctorCheck{
 			Name:    "Large Database",
 			Status:  StatusOK,
@@ -547,7 +608,7 @@ func CheckDatabaseSizeWithStore(ss *SharedStore) DoctorCheck {
 	return checkDatabaseSizeWithStore(store)
 }
 
-func checkDatabaseSizeWithStore(store *dolt.DoltStore) DoctorCheck {
+func checkDatabaseSizeWithStore(store storage.DoltStorage) DoctorCheck {
 	ctx := context.Background()
 
 	// Read threshold from config (default 5000, 0 = disabled)

--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -96,7 +96,7 @@ func CheckDatabaseVersionWithStore(ss *SharedStore, cliVersion string) DoctorChe
 	store := ss.Store()
 	if store == nil {
 		if ss.IsEmbedded() {
-			return embeddedSkippedCheck("Database", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+			return embeddedSkippedCheck("Database", "embedded engine not opened by doctor to avoid subprocess deadlock")
 		}
 		if !sharedStoreNeedsLocalDoltDir(beadsDir) {
 			return DoctorCheck{
@@ -203,7 +203,7 @@ func CheckSchemaCompatibilityWithStore(ss *SharedStore) DoctorCheck {
 	store := ss.Store()
 	if store == nil {
 		if ss.IsEmbedded() {
-			return embeddedSkippedCheck("Schema Compatibility", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+			return embeddedSkippedCheck("Schema Compatibility", "embedded engine not opened by doctor to avoid subprocess deadlock")
 		}
 		return DoctorCheck{
 			Name:    "Schema Compatibility",
@@ -277,7 +277,7 @@ func CheckDatabaseIntegrityWithStore(ss *SharedStore) DoctorCheck {
 	store := ss.Store()
 	if store == nil {
 		if ss.IsEmbedded() {
-			return embeddedSkippedCheck("Database Integrity", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+			return embeddedSkippedCheck("Database Integrity", "embedded engine not opened by doctor to avoid subprocess deadlock")
 		}
 		return DoctorCheck{
 			Name:    "Database Integrity",
@@ -403,7 +403,7 @@ func CheckProjectIdentityWithStore(ss *SharedStore, path string) DoctorCheck {
 					Category: CategoryData,
 				}
 			}
-			return embeddedSkippedCheck("Project Identity", "metadata.json lacks project_id and embedded engine not opened by doctor (bd-ffe)")
+			return embeddedSkippedCheck("Project Identity", "metadata.json lacks project_id and embedded engine not opened by doctor")
 		}
 		doltPath := resolveDatabasePath(beadsDir)
 		if _, err := os.Stat(doltPath); os.IsNotExist(err) {
@@ -496,7 +496,7 @@ func FixDatabaseConfig(path string) error {
 // This is the legacy server-mode location (.beads/dolt/<db>). In embedded
 // mode the database actually lives at .beads/embeddeddolt/<db> — callers
 // that need the real on-disk path for both modes should use
-// resolveDatabasePath instead (bd-ffe).
+// resolveDatabasePath instead.
 func getDatabasePath(beadsDir string) string {
 	cfg, err := configfile.Load(beadsDir)
 	if err != nil || cfg == nil {
@@ -508,7 +508,7 @@ func getDatabasePath(beadsDir string) string {
 // resolveDatabasePath returns the actual on-disk database directory for the
 // configured mode: server-mode uses .beads/dolt/ (or dolt_data_dir), embedded
 // mode uses .beads/embeddeddolt/<database>. Use this when an os.Stat presence
-// check must work in both modes (bd-ffe).
+// check must work in both modes.
 //
 // When metadata.json is missing, falls back to whichever legacy directory
 // already exists on disk (.beads/dolt/ wins for compatibility with pre-

--- a/cmd/bd/doctor/installation.go
+++ b/cmd/bd/doctor/installation.go
@@ -127,7 +127,7 @@ func CheckPermissionsWithStore(path string, ss *SharedStore) DoctorCheck {
 			}
 		}
 
-		doltPath := getDatabasePath(beadsDir)
+		doltPath := resolveDatabasePath(beadsDir)
 		if info, err := os.Stat(doltPath); err == nil {
 			if !info.IsDir() {
 				return DoctorCheck{
@@ -137,8 +137,10 @@ func CheckPermissionsWithStore(path string, ss *SharedStore) DoctorCheck {
 					Fix:     "Run 'bd doctor --fix' to fix permissions",
 				}
 			}
-			// If shared store is nil, the database could not be opened
-			if store == nil {
+			if store == nil && ss.IsEmbedded() {
+				// Embedded mode: doctor does not open the engine (bd-ffe).
+				// Fall through to the filesystem-permissions OK path below.
+			} else if store == nil {
 				return DoctorCheck{
 					Name:    "Permissions",
 					Status:  StatusError,

--- a/cmd/bd/doctor/installation.go
+++ b/cmd/bd/doctor/installation.go
@@ -138,7 +138,7 @@ func CheckPermissionsWithStore(path string, ss *SharedStore) DoctorCheck {
 				}
 			}
 			if store == nil && ss.IsEmbedded() {
-				// Embedded mode: doctor does not open the engine (bd-ffe).
+				// Embedded mode: doctor does not open the engine.
 				// Fall through to the filesystem-permissions OK path below.
 			} else if store == nil {
 				return DoctorCheck{

--- a/cmd/bd/doctor/integrity.go
+++ b/cmd/bd/doctor/integrity.go
@@ -50,7 +50,7 @@ func CheckIDFormatWithStore(ss *SharedStore) DoctorCheck {
 	db := ss.RawDB()
 	if db == nil {
 		if ss.IsEmbedded() {
-			return embeddedSkippedCheck("Issue IDs", "raw SQL access requires a server-mode store; embedded skipped in full doctor run (bd-ffe)")
+			return embeddedSkippedCheck("Issue IDs", "raw SQL access requires a server-mode store; embedded skipped in full doctor run")
 		}
 		return DoctorCheck{
 			Name:    "Issue IDs",
@@ -154,7 +154,7 @@ func CheckDependencyCyclesWithStore(ss *SharedStore) DoctorCheck {
 	db := ss.RawDB()
 	if db == nil {
 		if ss.IsEmbedded() {
-			return embeddedSkippedCheck("Dependency Cycles", "raw SQL access requires a server-mode store; embedded skipped in full doctor run (bd-ffe)")
+			return embeddedSkippedCheck("Dependency Cycles", "raw SQL access requires a server-mode store; embedded skipped in full doctor run")
 		}
 		return DoctorCheck{
 			Name:    "Dependency Cycles",
@@ -365,7 +365,7 @@ func CheckRepoFingerprintWithStore(ss *SharedStore, path string) DoctorCheck {
 	store := ss.Store()
 	if store == nil {
 		if ss.IsEmbedded() {
-			return embeddedSkippedCheck("Repo Fingerprint", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+			return embeddedSkippedCheck("Repo Fingerprint", "embedded engine not opened by doctor to avoid subprocess deadlock")
 		}
 		return DoctorCheck{
 			Name:    "Repo Fingerprint",

--- a/cmd/bd/doctor/integrity.go
+++ b/cmd/bd/doctor/integrity.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -46,20 +47,26 @@ func CheckIDFormat(path string) DoctorCheck {
 
 // CheckIDFormatWithStore checks ID format using a shared store (GH#2636).
 func CheckIDFormatWithStore(ss *SharedStore) DoctorCheck {
-	store := ss.Store()
-	if store == nil {
+	db := ss.RawDB()
+	if db == nil {
+		if ss.IsEmbedded() {
+			return embeddedSkippedCheck("Issue IDs", "raw SQL access requires a server-mode store; embedded skipped in full doctor run (bd-ffe)")
+		}
 		return DoctorCheck{
 			Name:    "Issue IDs",
 			Status:  StatusOK,
 			Message: "No issues yet (will use hash-based IDs)",
 		}
 	}
-	return checkIDFormatWithStore(store)
+	return checkIDFormatDB(db)
 }
 
 func checkIDFormatWithStore(store *dolt.DoltStore) DoctorCheck {
+	return checkIDFormatDB(store.UnderlyingDB())
+}
+
+func checkIDFormatDB(db *sql.DB) DoctorCheck {
 	ctx := context.Background()
-	db := store.UnderlyingDB()
 
 	// Get sample of issues to check ID format (up to 10 for pattern analysis)
 	rows, err := db.QueryContext(ctx, "SELECT id FROM issues ORDER BY created_at LIMIT 10")
@@ -144,19 +151,25 @@ func CheckDependencyCycles(path string) DoctorCheck {
 
 // CheckDependencyCyclesWithStore checks for cycles using a shared store (GH#2636).
 func CheckDependencyCyclesWithStore(ss *SharedStore) DoctorCheck {
-	store := ss.Store()
-	if store == nil {
+	db := ss.RawDB()
+	if db == nil {
+		if ss.IsEmbedded() {
+			return embeddedSkippedCheck("Dependency Cycles", "raw SQL access requires a server-mode store; embedded skipped in full doctor run (bd-ffe)")
+		}
 		return DoctorCheck{
 			Name:    "Dependency Cycles",
 			Status:  StatusOK,
 			Message: "N/A (no database)",
 		}
 	}
-	return checkDependencyCyclesWithStore(store)
+	return checkDependencyCyclesDB(db)
 }
 
 func checkDependencyCyclesWithStore(store *dolt.DoltStore) DoctorCheck {
-	db := store.UnderlyingDB()
+	return checkDependencyCyclesDB(store.UnderlyingDB())
+}
+
+func checkDependencyCyclesDB(db *sql.DB) DoctorCheck {
 
 	// Query for cycles using simplified SQL (CONCAT for Dolt/MySQL compatibility)
 	query := `
@@ -351,6 +364,9 @@ func CheckRepoFingerprint(path string) DoctorCheck {
 func CheckRepoFingerprintWithStore(ss *SharedStore, path string) DoctorCheck {
 	store := ss.Store()
 	if store == nil {
+		if ss.IsEmbedded() {
+			return embeddedSkippedCheck("Repo Fingerprint", "embedded engine not opened by doctor to avoid subprocess deadlock (bd-ffe)")
+		}
 		return DoctorCheck{
 			Name:    "Repo Fingerprint",
 			Status:  StatusOK,
@@ -360,7 +376,7 @@ func CheckRepoFingerprintWithStore(ss *SharedStore, path string) DoctorCheck {
 	return checkRepoFingerprintWithStore(store, path)
 }
 
-func checkRepoFingerprintWithStore(store *dolt.DoltStore, path string) DoctorCheck {
+func checkRepoFingerprintWithStore(store storage.DoltStorage, path string) DoctorCheck {
 	ctx := context.Background()
 
 	storedRepoID, err := store.GetMetadata(ctx, "repo_id")

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -295,8 +295,9 @@ func CheckFreshClone(repoPath string) DoctorCheck {
 	// Check if database exists (backend-aware)
 	switch backend {
 	case configfile.BackendDolt:
-		// Dolt is directory-backed: treat .beads/dolt as the DB existence signal.
-		if info, err := os.Stat(getDatabasePath(beadsDir)); err == nil && info.IsDir() {
+		// Dolt is directory-backed. resolveDatabasePath handles both
+		// server mode (.beads/dolt/) and embedded mode (.beads/embeddeddolt/<db>).
+		if info, err := os.Stat(resolveDatabasePath(beadsDir)); err == nil && info.IsDir() {
 			return DoctorCheck{
 				Name:    "Fresh Clone",
 				Status:  StatusOK,

--- a/cmd/bd/doctor/role.go
+++ b/cmd/bd/doctor/role.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -133,7 +134,7 @@ func getRoleFromDatabase(path string) string {
 }
 
 // getRoleFromStore checks for role in the database config using a provided store.
-func getRoleFromStore(store *dolt.DoltStore) string {
+func getRoleFromStore(store storage.DoltStorage) string {
 	if store == nil {
 		return ""
 	}

--- a/cmd/bd/doctor/shared_store.go
+++ b/cmd/bd/doctor/shared_store.go
@@ -12,8 +12,8 @@ import (
 // that occurs when each check opens and closes its own store (GH#2636).
 //
 // In server mode, the underlying store is a *dolt.DoltStore. In embedded mode
-// (the default), it is a *embeddeddolt.EmbeddedDoltStore (bd-ffe). Both
-// satisfy storage.DoltStorage.
+// (the default), it is a *embeddeddolt.EmbeddedDoltStore. Both satisfy
+// storage.DoltStorage.
 //
 // Usage:
 //
@@ -32,9 +32,9 @@ type SharedStore struct {
 	// mode this is the dolt.DoltStore's UnderlyingDB. In embedded mode it is
 	// a dedicated sql.DB opened via embeddeddolt.OpenSQL (may be nil when the
 	// store failed to open).
-	rawDB        *sql.DB
-	rawCleanup   func() error
-	isEmbedded   bool
+	rawDB      *sql.DB
+	rawCleanup func() error
+	isEmbedded bool
 }
 
 // Store returns the shared DoltStorage, or nil if the database couldn't be opened.
@@ -67,7 +67,7 @@ func (ss *SharedStore) RawDB() *sql.DB {
 }
 
 // IsEmbedded reports whether the shared store is backed by an embedded Dolt engine.
-// Checks that require server-mode connectivity can gate on this (AC bullet 2 of bd-ffe).
+// Checks that require server-mode connectivity can gate on this.
 func (ss *SharedStore) IsEmbedded() bool {
 	return ss != nil && ss.isEmbedded
 }
@@ -120,7 +120,7 @@ func sharedStoreIsEmbeddedConfig(beadsDir string) bool {
 
 // embeddedSkippedCheck builds a standard "skipped in embedded mode" DoctorCheck.
 // Used by DB-backed checks that cannot run without an open store and whose
-// open path would deadlock subprocess-spawning checks (bd-ffe).
+// open path would deadlock subprocess-spawning checks.
 func embeddedSkippedCheck(name, detail string) DoctorCheck {
 	return DoctorCheck{
 		Name:    name,

--- a/cmd/bd/doctor/shared_store.go
+++ b/cmd/bd/doctor/shared_store.go
@@ -1,16 +1,19 @@
 package doctor
 
 import (
-	"context"
-	"os"
+	"database/sql"
 
 	"github.com/steveyegge/beads/internal/configfile"
-	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage"
 )
 
-// SharedStore holds a single DoltStore open for the duration of a doctor run,
-// preventing the infinite Dolt server restart loop that occurs when each check
-// opens and closes its own store (GH#2636).
+// SharedStore holds a single read-only storage.DoltStorage open for the
+// duration of a doctor run, preventing the infinite Dolt server restart loop
+// that occurs when each check opens and closes its own store (GH#2636).
+//
+// In server mode, the underlying store is a *dolt.DoltStore. In embedded mode
+// (the default), it is a *embeddeddolt.EmbeddedDoltStore (bd-ffe). Both
+// satisfy storage.DoltStorage.
 //
 // Usage:
 //
@@ -18,12 +21,71 @@ import (
 //	defer ss.Close()
 //	store := ss.Store() // may be nil if DB doesn't exist or can't open
 //
-// Check functions that accept a *dolt.DoltStore parameter should use the
+// Check functions that accept a storage.DoltStorage parameter should use the
 // shared store when available, falling back to opening their own store when
 // called standalone (e.g., from tests or one-off checks).
 type SharedStore struct {
-	store    *dolt.DoltStore
+	store    storage.DoltStorage
 	beadsDir string
+	// rawDB is a long-lived raw *sql.DB handle for checks that need direct
+	// SQL access (e.g., validation.go, integrity.go, multirepo.go). In server
+	// mode this is the dolt.DoltStore's UnderlyingDB. In embedded mode it is
+	// a dedicated sql.DB opened via embeddeddolt.OpenSQL (may be nil when the
+	// store failed to open).
+	rawDB        *sql.DB
+	rawCleanup   func() error
+	isEmbedded   bool
+}
+
+// Store returns the shared DoltStorage, or nil if the database couldn't be opened.
+func (ss *SharedStore) Store() storage.DoltStorage {
+	if ss == nil {
+		return nil
+	}
+	return ss.store
+}
+
+// BeadsDir returns the resolved .beads directory path.
+func (ss *SharedStore) BeadsDir() string {
+	if ss == nil {
+		return ""
+	}
+	return ss.beadsDir
+}
+
+// RawDB returns a raw *sql.DB handle for direct SQL queries, or nil if no
+// database is available. Callers must NOT close the returned DB — SharedStore
+// manages its lifetime.
+//
+// Prefer the typed methods on Store() when possible. Use RawDB only for
+// diagnostic queries that cannot be expressed through the DoltStorage interface.
+func (ss *SharedStore) RawDB() *sql.DB {
+	if ss == nil {
+		return nil
+	}
+	return ss.rawDB
+}
+
+// IsEmbedded reports whether the shared store is backed by an embedded Dolt engine.
+// Checks that require server-mode connectivity can gate on this (AC bullet 2 of bd-ffe).
+func (ss *SharedStore) IsEmbedded() bool {
+	return ss != nil && ss.isEmbedded
+}
+
+// Close closes the underlying store and raw DB. Safe to call multiple times.
+func (ss *SharedStore) Close() {
+	if ss == nil {
+		return
+	}
+	if ss.rawCleanup != nil {
+		_ = ss.rawCleanup()
+		ss.rawCleanup = nil
+	}
+	ss.rawDB = nil
+	if ss.store != nil {
+		_ = ss.store.Close()
+		ss.store = nil
+	}
 }
 
 func beadsDirFromSharedStore(path string, ss *SharedStore) string {
@@ -45,51 +107,26 @@ func sharedStoreNeedsLocalDoltDir(beadsDir string) bool {
 	return err != nil || cfg == nil || !cfg.IsDoltServerMode()
 }
 
-// NewSharedStore opens a single read-only DoltStore for the given repo path.
-// If the database doesn't exist or can't be opened, Store() will return nil.
-// The caller MUST call Close() when done (typically via defer).
-func NewSharedStore(path string) *SharedStore {
-	beadsDir := ResolveBeadsDirForRepo(path)
-	ss := &SharedStore{beadsDir: beadsDir}
-
-	if sharedStoreNeedsLocalDoltDir(beadsDir) {
-		doltPath := getDatabasePath(beadsDir)
-		if _, err := os.Stat(doltPath); os.IsNotExist(err) {
-			return ss // No database, store stays nil
-		}
+// sharedStoreIsEmbeddedConfig reports whether the persisted config selects
+// embedded mode (either explicitly via dolt_mode=embedded, or implicitly by
+// the absence of server-mode settings).
+func sharedStoreIsEmbeddedConfig(beadsDir string) bool {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		return true // default: embedded
 	}
-
-	ctx := context.Background()
-	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
-	if err != nil {
-		return ss // Can't open, store stays nil
-	}
-
-	ss.store = store
-	return ss
+	return !cfg.IsDoltServerMode()
 }
 
-// Store returns the shared DoltStore, or nil if the database couldn't be opened.
-func (ss *SharedStore) Store() *dolt.DoltStore {
-	if ss == nil {
-		return nil
+// embeddedSkippedCheck builds a standard "skipped in embedded mode" DoctorCheck.
+// Used by DB-backed checks that cannot run without an open store and whose
+// open path would deadlock subprocess-spawning checks (bd-ffe).
+func embeddedSkippedCheck(name, detail string) DoctorCheck {
+	return DoctorCheck{
+		Name:    name,
+		Status:  StatusOK,
+		Message: "Skipped in embedded mode",
+		Detail:  detail,
+		Fix:     "Run targeted checks with 'bd doctor --check=validate' (or pollution/artifacts/conventions) for DB-backed diagnostics",
 	}
-	return ss.store
-}
-
-// BeadsDir returns the resolved .beads directory path.
-func (ss *SharedStore) BeadsDir() string {
-	if ss == nil {
-		return ""
-	}
-	return ss.beadsDir
-}
-
-// Close closes the underlying DoltStore. Safe to call multiple times.
-func (ss *SharedStore) Close() {
-	if ss == nil || ss.store == nil {
-		return
-	}
-	_ = ss.store.Close()
-	ss.store = nil
 }

--- a/cmd/bd/doctor/shared_store_cgo.go
+++ b/cmd/bd/doctor/shared_store_cgo.go
@@ -1,0 +1,54 @@
+//go:build cgo
+
+package doctor
+
+import (
+	"context"
+	"os"
+
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+// NewSharedStore opens a single read-only DoltStorage for the given repo path,
+// routing to the embedded engine or an external Dolt server based on
+// metadata.json (bd-ffe).
+//
+// In server mode, the returned SharedStore holds an open *dolt.DoltStore and
+// a raw *sql.DB for diagnostic queries. In embedded mode, the SharedStore
+// records the mode but does NOT open the embedded Dolt engine — doing so
+// would hold the exclusive flock for the entire doctor run, deadlocking
+// subprocesses that the doctor itself spawns (e.g. `bd prime` via
+// VerifyPrimeOutput). DB-backed checks consult SharedStore.IsEmbedded() and
+// emit a clear "skipped in embedded mode" diagnostic instead.
+//
+// Callers MUST call Close() when done (typically via defer).
+func NewSharedStore(path string) *SharedStore {
+	beadsDir := ResolveBeadsDirForRepo(path)
+	ss := &SharedStore{beadsDir: beadsDir}
+
+	if !sharedStoreIsEmbeddedConfig(beadsDir) {
+		openSharedStoreServer(context.Background(), ss, beadsDir)
+		return ss
+	}
+
+	ss.isEmbedded = true
+	return ss
+}
+
+// openSharedStoreServer populates ss for server-mode configs. Failures leave
+// ss.store as nil so downstream checks surface their own "Unable to open
+// database" diagnostics.
+func openSharedStoreServer(ctx context.Context, ss *SharedStore, beadsDir string) {
+	if sharedStoreNeedsLocalDoltDir(beadsDir) {
+		doltPath := getDatabasePath(beadsDir)
+		if _, err := os.Stat(doltPath); os.IsNotExist(err) {
+			return
+		}
+	}
+	store, err := dolt.NewFromConfigWithOptions(ctx, beadsDir, &dolt.Config{ReadOnly: true})
+	if err != nil {
+		return
+	}
+	ss.store = store
+	ss.rawDB = store.UnderlyingDB()
+}

--- a/cmd/bd/doctor/shared_store_cgo.go
+++ b/cmd/bd/doctor/shared_store_cgo.go
@@ -11,7 +11,7 @@ import (
 
 // NewSharedStore opens a single read-only DoltStorage for the given repo path,
 // routing to the embedded engine or an external Dolt server based on
-// metadata.json (bd-ffe).
+// metadata.json.
 //
 // In server mode, the returned SharedStore holds an open *dolt.DoltStore and
 // a raw *sql.DB for diagnostic queries. In embedded mode, the SharedStore

--- a/cmd/bd/doctor/shared_store_nocgo.go
+++ b/cmd/bd/doctor/shared_store_nocgo.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewSharedStore opens a single read-only DoltStorage for the given repo path.
-// Embedded-mode routing (bd-ffe) requires CGO; non-CGO builds only support
+// Embedded-mode routing requires CGO; non-CGO builds only support
 // server-mode Dolt.
 func NewSharedStore(path string) *SharedStore {
 	beadsDir := ResolveBeadsDirForRepo(path)

--- a/cmd/bd/doctor/shared_store_nocgo.go
+++ b/cmd/bd/doctor/shared_store_nocgo.go
@@ -1,0 +1,33 @@
+//go:build !cgo
+
+package doctor
+
+import (
+	"context"
+	"os"
+
+	"github.com/steveyegge/beads/internal/storage/dolt"
+)
+
+// NewSharedStore opens a single read-only DoltStorage for the given repo path.
+// Embedded-mode routing (bd-ffe) requires CGO; non-CGO builds only support
+// server-mode Dolt.
+func NewSharedStore(path string) *SharedStore {
+	beadsDir := ResolveBeadsDirForRepo(path)
+	ss := &SharedStore{beadsDir: beadsDir}
+
+	if sharedStoreNeedsLocalDoltDir(beadsDir) {
+		doltPath := getDatabasePath(beadsDir)
+		if _, err := os.Stat(doltPath); os.IsNotExist(err) {
+			return ss
+		}
+	}
+
+	store, err := dolt.NewFromConfigWithOptions(context.Background(), beadsDir, &dolt.Config{ReadOnly: true})
+	if err != nil {
+		return ss
+	}
+	ss.store = store
+	ss.rawDB = store.UnderlyingDB()
+	return ss
+}

--- a/cmd/bd/doctor/shared_store_test.go
+++ b/cmd/bd/doctor/shared_store_test.go
@@ -17,8 +17,85 @@ func TestSharedStore_NilSafe(t *testing.T) {
 	if ss.BeadsDir() != "" {
 		t.Error("expected empty beadsDir from nil SharedStore")
 	}
+	if ss.IsEmbedded() {
+		t.Error("nil SharedStore should not report embedded")
+	}
+	if ss.RawDB() != nil {
+		t.Error("nil SharedStore should return nil RawDB")
+	}
 	// Close should not panic on nil
 	ss.Close()
+}
+
+// TestSharedStore_EmbeddedModeDoesNotOpen verifies that NewSharedStore in
+// embedded mode records the mode but does NOT open the Dolt engine.
+// Opening the engine would hold the exclusive flock for the lifetime of the
+// doctor run, deadlocking subprocesses that the doctor itself spawns
+// (e.g. `bd prime` via VerifyPrimeOutput) — bd-ffe.
+func TestSharedStore_EmbeddedModeDoesNotOpen(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate an initialized embedded-mode repo: metadata.json + the
+	// embedded data directory.
+	metadata := []byte(`{"backend":"dolt","dolt_mode":"embedded","dolt_database":"test"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(beadsDir, "embeddeddolt", "test"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := NewSharedStore(tmpDir)
+	defer ss.Close()
+
+	if !ss.IsEmbedded() {
+		t.Fatal("expected IsEmbedded=true for embedded-mode config")
+	}
+	if ss.Store() != nil {
+		t.Error("embedded-mode SharedStore must not open the engine (bd-ffe)")
+	}
+	if ss.RawDB() != nil {
+		t.Error("embedded-mode SharedStore must not hold a raw DB (bd-ffe)")
+	}
+
+	// The lock file must remain free — no flock should have been acquired.
+	lockPath := filepath.Join(beadsDir, "embeddeddolt", ".lock")
+	if _, err := os.Stat(lockPath); err == nil {
+		t.Log("lock file exists (OK — only checking nobody holds it)")
+	}
+}
+
+// TestCheckDatabaseVersionWithStore_EmbeddedMode verifies that DB-backed
+// checks emit a clear "skipped in embedded mode" diagnostic instead of
+// a misleading "Unable to open database" error (bd-ffe AC3).
+func TestCheckDatabaseVersionWithStore_EmbeddedMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"backend":"dolt","dolt_mode":"embedded","dolt_database":"test"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(beadsDir, "embeddeddolt", "test"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	ss := NewSharedStore(tmpDir)
+	defer ss.Close()
+
+	check := CheckDatabaseVersionWithStore(ss, "0.61.0")
+	if check.Status != "ok" {
+		t.Errorf("embedded-mode DB check must be OK (skipped), got status=%q message=%q", check.Status, check.Message)
+	}
+	if check.Message == "" || check.Message == "Unable to open database" {
+		t.Errorf("embedded-mode DB check must not report 'Unable to open database' — got %q", check.Message)
+	}
 }
 
 func TestSharedStore_NoDatabase(t *testing.T) {

--- a/cmd/bd/doctor/shared_store_test.go
+++ b/cmd/bd/doctor/shared_store_test.go
@@ -31,7 +31,7 @@ func TestSharedStore_NilSafe(t *testing.T) {
 // embedded mode records the mode but does NOT open the Dolt engine.
 // Opening the engine would hold the exclusive flock for the lifetime of the
 // doctor run, deadlocking subprocesses that the doctor itself spawns
-// (e.g. `bd prime` via VerifyPrimeOutput) — bd-ffe.
+// (e.g. `bd prime` via VerifyPrimeOutput).
 func TestSharedStore_EmbeddedModeDoesNotOpen(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
@@ -56,10 +56,10 @@ func TestSharedStore_EmbeddedModeDoesNotOpen(t *testing.T) {
 		t.Fatal("expected IsEmbedded=true for embedded-mode config")
 	}
 	if ss.Store() != nil {
-		t.Error("embedded-mode SharedStore must not open the engine (bd-ffe)")
+		t.Error("embedded-mode SharedStore must not open the engine")
 	}
 	if ss.RawDB() != nil {
-		t.Error("embedded-mode SharedStore must not hold a raw DB (bd-ffe)")
+		t.Error("embedded-mode SharedStore must not hold a raw DB")
 	}
 
 	// The lock file must remain free — no flock should have been acquired.
@@ -71,7 +71,7 @@ func TestSharedStore_EmbeddedModeDoesNotOpen(t *testing.T) {
 
 // TestCheckDatabaseVersionWithStore_EmbeddedMode verifies that DB-backed
 // checks emit a clear "skipped in embedded mode" diagnostic instead of
-// a misleading "Unable to open database" error (bd-ffe AC3).
+// a misleading "Unable to open database" error.
 func TestCheckDatabaseVersionWithStore_EmbeddedMode(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")

--- a/cmd/bd/doctor/suppress.go
+++ b/cmd/bd/doctor/suppress.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 )
 
@@ -44,7 +45,7 @@ func GetSuppressedChecksWithStore(ss *SharedStore) map[string]bool {
 	return getSuppressedChecksFromStore(store)
 }
 
-func getSuppressedChecksFromStore(store *dolt.DoltStore) map[string]bool {
+func getSuppressedChecksFromStore(store storage.DoltStorage) map[string]bool {
 	suppressed := make(map[string]bool)
 
 	ctx := context.Background()

--- a/cmd/bd/doctor_embedded_test.go
+++ b/cmd/bd/doctor_embedded_test.go
@@ -1,0 +1,97 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEmbeddedDoctorRunsFullPipeline(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt doctor tests")
+	}
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "dr")
+	env := embeddedDoctorEnv(t, bd, dir)
+
+	textOut, _ := runEmbeddedDoctor(t, bd, dir, env, "doctor")
+	assertNoEmbeddedDoctorStub(t, textOut)
+	if !strings.Contains(textOut, "bd doctor v") {
+		t.Fatalf("doctor text output did not run full diagnostics:\n%s", textOut)
+	}
+	if !strings.Contains(textOut, "passed") {
+		t.Fatalf("doctor text output missing diagnostic summary:\n%s", textOut)
+	}
+
+	jsonOut, _ := runEmbeddedDoctor(t, bd, dir, env, "doctor", "--json")
+	assertNoEmbeddedDoctorStub(t, jsonOut)
+	var result doctorResult
+	if err := json.Unmarshal([]byte(jsonOut), &result); err != nil {
+		t.Fatalf("doctor --json did not emit parseable doctorResult JSON: %v\n%s", err, jsonOut)
+	}
+	if len(result.Checks) == 0 {
+		t.Fatalf("doctor --json emitted no checks:\n%s", jsonOut)
+	}
+	if result.CLIVersion == "" {
+		t.Fatalf("doctor --json missing cli_version:\n%s", jsonOut)
+	}
+
+	agentOut, _ := runEmbeddedDoctor(t, bd, dir, env, "doctor", "--agent", "--json")
+	assertNoEmbeddedDoctorStub(t, agentOut)
+	var agentResult agentDoctorResult
+	if err := json.Unmarshal([]byte(agentOut), &agentResult); err != nil {
+		t.Fatalf("doctor --agent --json did not emit parseable agent JSON: %v\n%s", err, agentOut)
+	}
+	if agentResult.CLIVersion == "" {
+		t.Fatalf("doctor --agent --json missing cli_version:\n%s", agentOut)
+	}
+	if agentResult.Summary == "" {
+		t.Fatalf("doctor --agent --json missing summary:\n%s", agentOut)
+	}
+	if agentResult.PassedCount == 0 && len(agentResult.Diagnostics) == 0 {
+		t.Fatalf("doctor --agent --json emitted neither passed checks nor diagnostics:\n%s", agentOut)
+	}
+}
+
+func embeddedDoctorEnv(t *testing.T, bd, dir string) []string {
+	t.Helper()
+	env := bdEnv(dir)
+	bdDir := filepath.Dir(bd)
+	replacedPath := false
+	for i, entry := range env {
+		if strings.HasPrefix(entry, "PATH=") {
+			env[i] = "PATH=" + bdDir + string(os.PathListSeparator) + strings.TrimPrefix(entry, "PATH=")
+			replacedPath = true
+			break
+		}
+	}
+	if !replacedPath {
+		env = append(env, "PATH="+bdDir)
+	}
+	return env
+}
+
+func runEmbeddedDoctor(t *testing.T, bd, dir string, env []string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(bd, args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func assertNoEmbeddedDoctorStub(t *testing.T, out string) {
+	t.Helper()
+	if strings.Contains(out, "not yet supported in embedded mode") {
+		t.Fatalf("doctor emitted old embedded-mode stub:\n%s", out)
+	}
+	if strings.Contains(out, "Reinitialize if needed") || strings.Contains(out, "Switch to server mode") {
+		t.Fatalf("doctor emitted old destructive embedded-mode hints:\n%s", out)
+	}
+}

--- a/scripts/cross-version-smoke-test.sh
+++ b/scripts/cross-version-smoke-test.sh
@@ -315,10 +315,14 @@ verify_candidate() {
         [ -z "$VERIFY_DETAIL" ] && VERIFY_DETAIL="dependency lost"
     fi
 
-    if bd_in "$ws" "$cand_bin" doctor quick >/dev/null 2>&1; then
-        echo -e "  ${GREEN}✓${NC} doctor quick"
+    # `--check-health` is the lightweight health check; bare `doctor quick`
+    # was never a real subcommand (cobra treated "quick" as the positional
+    # [path] arg and only "passed" because embedded mode short-circuited
+    # with exit 0).
+    if bd_in "$ws" "$cand_bin" doctor --check-health >/dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} doctor --check-health"
     else
-        echo -e "  ${RED}✗${NC} doctor quick failed"
+        echo -e "  ${RED}✗${NC} doctor --check-health failed"
         VERIFY_ERRORS=$((VERIFY_ERRORS + 1))
         [ -z "$VERIFY_DETAIL" ] && VERIFY_DETAIL="doctor failed"
     fi

--- a/scripts/upgrade-smoke-test.sh
+++ b/scripts/upgrade-smoke-test.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 #   1. Issue data (issues created before upgrade are visible after)
 #   2. Storage mode (embedded stays embedded, shared stays shared)
 #   3. Role config (beads.role git config is not cleared or changed)
-#   4. Doctor health (bd doctor quick passes after upgrade)
+#   4. Doctor health (bd doctor --check-health passes after upgrade)
 #   5. Mutations (bd update after upgrade persists correctly)
 #
 # Usage:
@@ -270,11 +270,14 @@ else
     pass "Data migration check skipped (old binary could not write issues)"
 fi
 
-# Doctor check
-if cand doctor quick 2>/dev/null; then
-    pass "bd doctor quick passes"
+# Doctor check — `--check-health` is the lightweight health check;
+# bare `doctor quick` was never a real subcommand (it was silently treated
+# as a path argument and only "passed" because embedded mode short-circuited
+# with exit 0).
+if cand doctor --check-health 2>/dev/null; then
+    pass "bd doctor --check-health passes"
 else
-    fail "bd doctor quick fails after upgrade"
+    fail "bd doctor --check-health fails after upgrade"
 fi
 
 rm -rf "$WS"


### PR DESCRIPTION
## Summary

Fixes the silent no-op where `bd doctor` short-circuited in embedded mode — the default backend — hiding ~70 diagnostic checks behind a three-bullet stub and `os.Exit(0)`. On a freshly initialized embedded repo the doctor now runs the full pipeline (68 passing checks) with correct exit codes for both human and `--json` output.

Cross-ref: #3369 proposes a broader doctor refactor but does not cover the embedded short-circuit — this fix is narrower and targeted.

### Changes Made

- **Removed the unconditional short-circuit** in `cmd/bd/doctor.go:187-196`. The stub also recommended `bd init --force` (re-fetches ~2GB of Dolt content and bakes `origin` into `repo_state.json`) and `bd init --server` (switches backends) as "recovery" — both have known destructive side effects. Those hints are gone.
- **Made `NewSharedStore` mode-aware.** Split across `shared_store_cgo.go` / `shared_store_nocgo.go`. Server-mode behavior is unchanged. Embedded-mode records the mode but does NOT open the Dolt engine, because doing so would hold the exclusive flock for the entire run and deadlock subprocesses the doctor itself spawns (e.g. `bd prime` via `VerifyPrimeOutput`).
- **Widened check function signatures** from `*dolt.DoltStore` to `storage.DoltStorage` so they accept either backend through the common interface. Raw-SQL checks (`checkIDFormatDB`, `checkDependencyCyclesDB`) now take the raw DB via `SharedStore.RawDB()`.
- **Added `resolveDatabasePath()`** returning the real on-disk database directory for both modes; used by `CheckFreshClone` and the nil-store fallbacks so embedded-mode presence checks succeed instead of reporting a spurious "fresh clone".
- **Bounded `VerifyPrimeOutput` with a 10s timeout** (`exec.CommandContext`) so a stuck bd subprocess — which holds the embedded flock — can no longer wedge the entire doctor run.
- **DB-backed `WithStore` checks** (`Database`, `Schema Compatibility`, `Database Integrity`, `Project Identity`, `Issue IDs`, `Dependency Cycles`, `Repo Fingerprint`, `Large Database`) now emit a structured `"Skipped in embedded mode"` `DoctorCheck` with a `Fix` hint pointing to `bd doctor --check=validate` (et al.), so agents consuming `--json` can distinguish "skipped" from "failed".

### Backward Compatibility

- **Server mode**: untouched. `NewSharedStore` in server mode still opens `*dolt.DoltStore` and exposes `UnderlyingDB()` via `RawDB()`.
- **Existing tests**: all pass (`go test ./...`). Added two new tests — `TestSharedStore_EmbeddedModeDoesNotOpen` and `TestCheckDatabaseVersionWithStore_EmbeddedMode` — to lock in the "don't open the engine during a full run" contract.
- **CLI contract**: `--json`, `--agent`, `--verbose`, `--check=*` flags all reachable in both modes. Exit code is `1` when a real error surfaces, `0` when all ran and passed.
- **Breaking**: none. `SharedStore.Store()`'s return type changed from `*dolt.DoltStore` to `storage.DoltStorage` inside the `doctor` package, but all call sites are in-tree and updated in this PR.

### Technical Details

**Why not open the embedded engine at all?** Running `embeddeddolt.New(...)` holds the exclusive flock on `.beads/embeddeddolt/.lock` for the store's lifetime. The doctor run then calls `VerifyPrimeOutput`, which spawns `bd prime` — a subprocess that also wants the flock. Deadlock. Server mode doesn't hit this because concurrent clients share a single `dolt sql-server`. The earliest prototype of this patch tried `TryLock` + `WithLock` and observed the deadlock in practice (`lsof` on the lock file showed both the parent `bd doctor` and the child `bd prime` blocked on the same file descriptor).

**Follow-up**: the targeted `bd doctor --check=validate` / `--check=pollution` / `--deep` flags still open server-mode stores via `dolt.New()`/`openStoreDB`. Since those targeted paths do NOT spawn subprocesses, they can safely open a short-lived embedded store for the duration of the check. That is tracked separately and not part of this PR.

### Verification

On a fresh embedded repo:

```
$ bd doctor
bd doctor v1.0.2  ────────  ✓ 68 passed  ⚠ 5 warnings  ✖ 1 errors
```

Before this PR the exact same command produced:

```
Note: 'bd doctor' is not yet supported in embedded mode.

For embedded mode troubleshooting:
  • Verify database exists:  ls -la .beads/embeddeddolt/
  • Check bd version:        bd version
  • Reinitialize if needed:  bd init --force       ← destructive
  • Switch to server mode:   bd init --server      ← destructive
```

(exit 0)

### Benefits

- **Correctness**: agents piping `bd doctor --agent --json` now get structured diagnostics instead of empty stdout + exit 0 — the worst silent-failure variant for the intended consumer.
- **Safety**: the destructive `bd init --force` / `bd init --server` "recovery" hints are gone.
- **CI**: `bd doctor` in embedded mode can now gate pipelines on real failures instead of always passing.
- **Observability**: "Skipped in embedded mode" is structured, so agents can decide to re-run with `--check=validate` for the DB-backed subset.

### Size: Medium

Code footprint is moderate: one new test file split (two build tags), signature widenings across six files, and ~300 lines of net change. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)