### PR TITLE
ci: install dolt binary on Linux and macOS test runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,20 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Configure Git
+      - name: Install Dolt (Linux)
+        if: runner.os == 'Linux'
+        run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+
+      - name: Install Dolt (macOS)
+        if: runner.os == 'macOS'
+        run: brew install dolt
+
+      - name: Configure Git and Dolt identity
         run: |
           git config --global user.name "CI Bot"
           git config --global user.email "ci@beads.test"
+          dolt config --global --add user.name "CI Bot"
+          dolt config --global --add user.email "ci@beads.test"
 
       - name: Install gotestsum
         if: matrix.coverage

--- a/beads_test.go
+++ b/beads_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -36,9 +35,7 @@ func TestMain(m *testing.M) {
 
 func skipIfNoDolt(t *testing.T) {
 	t.Helper()
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 }
 
 func skipIfNoDoltServer(t *testing.T) {

--- a/cmd/bd/doctor/fix/metadata_dolt_test.go
+++ b/cmd/bd/doctor/fix/metadata_dolt_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 // setupDoltWorkspace creates a temp beads workspace with a Dolt database.
@@ -18,9 +19,7 @@ import (
 // Returns the workspace root path.
 func setupDoltWorkspace(t *testing.T) string {
 	t.Helper()
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 
 	dir := t.TempDir()
 	beadsDir := filepath.Join(dir, ".beads")

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -18,15 +18,14 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 // skipIfNoDolt skips the test when no Dolt server is available.
 // Checks both binary availability and test server status.
 func skipIfNoDolt(t *testing.T) {
 	t.Helper()
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("skipping: dolt not installed")
-	}
+	testutil.RequireDoltBinary(t)
 	if testDoltServerPort == 0 {
 		t.Skip("skipping: Dolt test server not running")
 	}
@@ -1443,10 +1442,7 @@ func TestInit_WithBEADS_DIR_DoltBackend(t *testing.T) {
 		t.Skip("Skipping BEADS_DIR Dolt test on Windows")
 	}
 
-	// Check if dolt is available
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping Dolt backend test")
-	}
+	testutil.RequireDoltBinary(t)
 
 	// Reset global state
 	origDBPath := dbPath
@@ -1515,9 +1511,6 @@ func TestInitDoltMetadata(t *testing.T) {
 	skipIfNoDolt(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping Dolt metadata test on Windows")
-	}
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping Dolt metadata test")
 	}
 
 	saveAndRestoreGlobals(t)
@@ -1629,9 +1622,6 @@ func TestInitDoltMetadataNoGit(t *testing.T) {
 	skipIfNoDolt(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping Dolt metadata test on Windows")
-	}
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping Dolt metadata test")
 	}
 
 	saveAndRestoreGlobals(t)

--- a/cmd/bd/protocol/helpers_test.go
+++ b/cmd/bd/protocol/helpers_test.go
@@ -160,9 +160,7 @@ func testPrefix(t *testing.T) string {
 
 func newWorkspace(t *testing.T) *workspace {
 	t.Helper()
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("skipping: dolt not installed")
-	}
+	testutil.RequireDoltBinary(t)
 	if testDoltPort == 0 {
 		t.Skip("skipping: test Dolt server not available")
 	}

--- a/internal/remotecache/cache_test.go
+++ b/internal/remotecache/cache_test.go
@@ -10,11 +10,18 @@ import (
 	"time"
 )
 
-// skipIfNoDolt skips the test if the dolt CLI is not installed.
+// skipIfNoDolt skips the test if the dolt CLI is not installed. Under
+// GitHub Actions the test fails instead — CI must install dolt.
+//
+// (Duplicated inline rather than importing testutil.RequireDoltBinary to avoid
+// an import cycle: testutil → doltutil → remotecache.)
 func skipIfNoDolt(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt CLI not found, skipping integration test")
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			t.Fatalf("dolt binary missing under GITHUB_ACTIONS: %v — the CI workflow must install dolt", err)
+		}
+		t.Skipf("dolt CLI not found, skipping integration test: %v", err)
 	}
 }
 

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 func TestEncryptDecryptWithKey(t *testing.T) {
@@ -340,9 +342,7 @@ func setupCredentialTestStoreWithURL(t *testing.T, remoteUser, remotePassword st
 // CLI subprocess routing for Push, ForcePush, and Pull when credentials are set.
 // The guard is shared across all three operations (same insertion pattern in store.go).
 func TestCredentialCLIRouting(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping credential routing test")
-	}
+	testutil.RequireDoltBinary(t)
 
 	tests := []struct {
 		name           string
@@ -406,9 +406,7 @@ func TestCredentialCLIRoutingNoRemote(t *testing.T) {
 }
 
 func TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping shared-server credential routing test")
-	}
+	testutil.RequireDoltBinary(t)
 
 	sharedRoot := t.TempDir()
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
@@ -448,9 +446,7 @@ func TestCredentialCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 }
 
 func TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping shared-server cloud-auth routing test")
-	}
+	testutil.RequireDoltBinary(t)
 
 	sharedRoot := t.TempDir()
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
@@ -492,9 +488,7 @@ func TestCloudAuthCLIRoutingSharedServerUsesSharedDoltRoot(t *testing.T) {
 // that controls CLI subprocess routing for federation PushTo, PullFrom, and Fetch
 // when peer credentials are resolved from the federation_peers table.
 func TestFederationCredentialCLIRouting(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping credential routing test")
-	}
+	testutil.RequireDoltBinary(t)
 
 	tests := []struct {
 		name        string
@@ -528,9 +522,7 @@ func TestFederationCredentialCLIRouting(t *testing.T) {
 }
 
 func TestCloudAuthCLIRouting(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed")
-	}
+	testutil.RequireDoltBinary(t)
 
 	tests := []struct {
 		name      string
@@ -576,9 +568,7 @@ func TestCloudAuthCLIRouting(t *testing.T) {
 }
 
 func TestCloudAuthCLIRoutingStructural(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed")
-	}
+	testutil.RequireDoltBinary(t)
 
 	t.Run("embedded mode", func(t *testing.T) {
 		store := setupCredentialTestStoreWithURL(t, "", "", false, true, "origin", "az://account.blob.core.windows.net/container")
@@ -600,9 +590,7 @@ func TestCloudAuthCLIRoutingStructural(t *testing.T) {
 // DoltHub (primary) + Azure (backup) remotes. AZURE_STORAGE_ACCOUNT should
 // trigger CLI routing ONLY for the Azure remote, not the DoltHub remote.
 func TestPerRemoteCloudAuthHybrid(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed")
-	}
+	testutil.RequireDoltBinary(t)
 
 	tmpDir := t.TempDir()
 	dbName := "testdb"

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -52,9 +51,7 @@ func testContext(t *testing.T) (context.Context, context.CancelFunc) {
 // TestMain in testmain_test.go.
 func skipIfNoDolt(t *testing.T) {
 	t.Helper()
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 	if testServerPort == 0 {
 		t.Skip("Test Dolt server not running, skipping test")
 	}

--- a/internal/storage/dolt/git_remote_shared_server_test.go
+++ b/internal/storage/dolt/git_remote_shared_server_test.go
@@ -22,9 +22,7 @@ import (
 // route credential-bearing pushes through the shared Dolt root even when the
 // per-project dbPath is stale and lacks the remote.
 func TestCredentialCLIRoutingE2ESharedServer(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 
 	baseDir, err := os.MkdirTemp("", "credential-cli-routing-shared-server-e2e-*")

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -1004,9 +1004,7 @@ func findClonedDBName(t *testing.T, doltDir string) string {
 // false when the SQL server reports a git-protocol remote but the CLI directory
 // (dbPath) lacks that remote.
 func TestGitRemoteExternalServerRouting(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 
 	baseDir, err := os.MkdirTemp("", "external-server-routing-*")
@@ -1108,9 +1106,7 @@ func TestGitRemoteExternalServerRouting(t *testing.T) {
 // If the guard fails and falls through to SQL withEnvCredentials, the external
 // server process cannot see the env vars and push fails (SC-001).
 func TestCredentialCLIRoutingE2E(t *testing.T) {
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 	skipIfNoGit(t)
 
 	baseDir, err := os.MkdirTemp("", "credential-cli-routing-e2e-*")

--- a/internal/storage/dolt/migrations/migrations_test.go
+++ b/internal/storage/dolt/migrations/migrations_test.go
@@ -2,7 +2,6 @@ package migrations
 
 import (
 	"database/sql"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -17,9 +16,7 @@ import (
 func openTestDoltBranch(t *testing.T) *sql.DB {
 	t.Helper()
 
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt binary not found, skipping migration test")
-	}
+	testutil.RequireDoltBinary(t)
 	if testServerPort == 0 {
 		t.Skip("test Dolt server not running, skipping migration test")
 	}

--- a/internal/testutil/testdoltcommon.go
+++ b/internal/testutil/testdoltcommon.go
@@ -3,11 +3,28 @@ package testutil
 import (
 	"fmt"
 	"net"
+	"os"
+	"os/exec"
+	"testing"
 	"time"
 )
 
 // DoltDockerImage is the Docker image used for Dolt test containers.
 const DoltDockerImage = "dolthub/dolt-sql-server:1.86.0"
+
+// RequireDoltBinary ensures the `dolt` CLI binary is available. The test is
+// skipped locally when dolt is missing but fatally fails under GitHub Actions
+// (GITHUB_ACTIONS=true). CI is expected to install dolt; a missing binary
+// there means the workflow is broken, not that the test should be skipped.
+func RequireDoltBinary(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("dolt"); err != nil {
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			t.Fatalf("dolt binary missing under GITHUB_ACTIONS: %v — the CI workflow must install dolt (see .github/workflows/ci.yml)", err)
+		}
+		t.Skipf("dolt binary not found: %v", err)
+	}
+}
 
 // FindFreePort finds an available TCP port by binding to :0.
 func FindFreePort() (int, error) {

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -5,7 +5,6 @@ package tracker
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -19,9 +18,7 @@ import (
 // newTestStore creates a dolt store on the shared database with branch isolation.
 func newTestStore(t *testing.T) *dolt.DoltStore {
 	t.Helper()
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 	if testServerPort == 0 || testSharedDB == "" {
 		t.Skip("shared test Dolt database not initialized, skipping test")
 	}

--- a/internal/utils/id_parser_test.go
+++ b/internal/utils/id_parser_test.go
@@ -7,18 +7,16 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"os/exec"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/testutil"
 	"github.com/steveyegge/beads/internal/types"
 )
 
 func newTestStore(t *testing.T) *dolt.DoltStore {
 	t.Helper()
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("Dolt not installed, skipping test")
-	}
+	testutil.RequireDoltBinary(t)
 	if testServerPort == 0 {
 		t.Skip("Test Dolt server not running, skipping test")
 	}

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -49,6 +49,10 @@ func TestMain(m *testing.M) {
 	// Start an isolated Dolt server so regression tests don't pollute
 	// the production database on port 3307.
 	if _, err := exec.LookPath("dolt"); err != nil {
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			fmt.Fprintln(os.Stderr, "FAIL: dolt missing under GITHUB_ACTIONS — CI workflow must install dolt")
+			os.Exit(1)
+		}
 		fmt.Fprintln(os.Stderr, "SKIP: dolt not found in PATH; regression tests require dolt")
 		os.Exit(0)
 	}


### PR DESCRIPTION
## Summary

CI's main `test` job silently skips all Dolt-gated tests on every PR because the `dolt` binary is not installed on the Ubuntu/macOS runners. Roughly 24 test gates of the form `if _, err := exec.LookPath(\"dolt\"); err != nil { t.Skip(...) }` fall through quietly, so the storage backbone has no per-PR coverage.

This change installs the `dolt` binary on both Linux and macOS runners and refactors the skip-gates to hard-fail under `GITHUB_ACTIONS=true` so a missing binary in CI becomes a loud error instead of a silent skip.

### Changes Made

- **Added Install Dolt (Linux / macOS) steps** to `.github/workflows/ci.yml` — Linux uses the official `install.sh` (matching `nightly.yml`); macOS uses Homebrew.
- **Added `testutil.RequireDoltBinary(t)`** in `internal/testutil/testdoltcommon.go` — skips locally when dolt is missing, `t.Fatalf` under `GITHUB_ACTIONS=true`.
- **Replaced 22 bare `exec.LookPath(\"dolt\")` skip-gates** across 11 test files with `testutil.RequireDoltBinary(t)`.
- **Inlined the gate** in `tests/regression/regression_test.go` (TestMain context) and `internal/remotecache/cache_test.go` (avoids `testutil -> doltutil -> remotecache` import cycle).

### Out of Scope (followup)

Docker-testcontainer gates (~28 `testDoltServerPort == 0` skips) are intentionally left alone. `nightly.yml:37-41` documents a known hang where Dolt testcontainers become unresponsive in GitHub Actions (see `scripts/repro-dolt-hang/INCIDENT-REPORT.md`). Unblocking those requires either fixing the hang upstream or switching tests from testcontainers to a local `dolt sql-server` subprocess, which is a larger refactor.

### Backward Compatibility

✅ **Maintained**: Local dev still skips when `dolt` is not on PATH (ergonomic for contributors without dolt installed).
✅ **Same behavior**: Tests that pass today continue to pass.
❌ **Breaking changes**: None.

### Technical Details

Local verification of the three behavior paths (with an isolated `PATH` excluding dolt):

```
# dolt present, any env → runs
PASS: TestCloudAuthCLIRoutingStructural (0.19s)

# dolt absent, GITHUB_ACTIONS=true → hard fail
FAIL: TestCloudAuthCLIRoutingStructural — dolt binary missing under GITHUB_ACTIONS...

# dolt absent, local dev → skip
SKIP: TestCloudAuthCLIRoutingStructural — dolt binary not found
```

### Benefits

- **Coverage**: ~24 previously-silent test gates now execute on every PR.
- **Detection**: Future regressions that remove the dolt install step trip an immediate hard fail instead of silently reducing coverage.
- **Consistency**: `test` job now mirrors the installation pattern in `nightly.yml`.

### Size: Medium ✓

Two commits (CI change + test refactor), ~70 line-equivalent churn concentrated in skip-gate replacement.

🤖 Generated with [Claude Code](https://claude.ai/code)