### PR TITLE
fix: bd dolt pull fails when remote added without branch tracking

### DIFF
--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -45,6 +45,15 @@ func isTableNotExistError(err error) bool {
 	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1146
 }
 
+// isBranchTrackingError returns true if the error indicates that DOLT_PULL
+// failed because upstream branch tracking is not configured. This happens
+// when a remote was added via DOLT_REMOTE('add') or bd dolt remote add
+// rather than via dolt clone / bd bootstrap, leaving repo_state.json with
+// an empty "branches" map (GH#3144).
+func isBranchTrackingError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "did not specify a branch")
+}
+
 // isSerializationError returns true if the error is a Dolt/MySQL serialization
 // failure that guarantees the transaction was rolled back. Safe to retry.
 //   - 1213 (ER_LOCK_DEADLOCK): concurrent transactions conflict at commit time

--- a/internal/storage/dolt/errors_test.go
+++ b/internal/storage/dolt/errors_test.go
@@ -249,3 +249,26 @@ func TestHasBackupFiles(t *testing.T) {
 		}
 	})
 }
+
+func TestIsBranchTrackingError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches dolt branch tracking error", func(t *testing.T) {
+		err := fmt.Errorf("Error 1105: You asked to pull from the remote 'origin', but did not specify a branch. Because this is not the default configured remote for your current branch, you must specify a branch.")
+		if !isBranchTrackingError(err) {
+			t.Error("expected true for branch tracking error")
+		}
+	})
+
+	t.Run("does not match unrelated errors", func(t *testing.T) {
+		if isBranchTrackingError(fmt.Errorf("connection refused")) {
+			t.Error("expected false for connection error")
+		}
+	})
+
+	t.Run("nil error returns false", func(t *testing.T) {
+		if isBranchTrackingError(nil) {
+			t.Error("expected false for nil error")
+		}
+	})
+}

--- a/internal/storage/dolt/pull_branch_tracking_integration_test.go
+++ b/internal/storage/dolt/pull_branch_tracking_integration_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestPullWithAutoResolve_BranchTrackingSuccess is the end-to-end regression
+// test for GH#3144. It reproduces the exact failure scenario:
+//
+//  1. A remote is added via DOLT_REMOTE('add', ...) rather than `dolt clone`,
+//     so repo_state.json's 'branches' map is empty (no tracking config).
+//  2. DOLT_PULL('origin', 'main') fails with the branch-tracking error.
+//  3. pullWithAutoResolve detects the error and falls back to
+//     DOLT_FETCH('origin', 'main') + DOLT_MERGE('origin/main').
+//  4. The pull succeeds and the local store reflects the remote content.
+//
+// Prerequisites (all satisfied by the integration CI environment):
+//   - `dolt` CLI ≥ 1.81 available in PATH
+//   - Loopback TCP available for two dolt sql-server instances
+func TestPullWithAutoResolve_BranchTrackingSuccess(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	baseDir := t.TempDir()
+
+	// ── Remote server ──────────────────────────────────────────────────────────
+	// Set up a "remote" Dolt repo with a committed beads schema. This represents
+	// the centralised NAS repo that `bd dolt remote add` points at.
+	remoteDir := filepath.Join(baseDir, "remote")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	runCmd(t, remoteDir, "dolt", "init")
+
+	initSQL := `
+		CREATE TABLE branch_tracking_marker (id INT PRIMARY KEY, value TEXT);
+		INSERT INTO branch_tracking_marker VALUES (1, 'from remote');
+		CALL DOLT_ADD('.');
+		CALL DOLT_COMMIT('-Am', 'init: branch tracking marker');
+	`
+	runDoltSQL(t, remoteDir, initSQL)
+
+	remoteSQLPort, err := findFreePort()
+	if err != nil {
+		t.Fatalf("find free port (SQL): %v", err)
+	}
+	remotesAPIPort, err := findFreePort()
+	if err != nil {
+		t.Fatalf("find free port (remotesapi): %v", err)
+	}
+	stopRemote := startDoltServer(t, remoteDir, remoteSQLPort, remotesAPIPort)
+	defer stopRemote()
+
+	// ── Local DoltStore ────────────────────────────────────────────────────────
+	// Create a fresh local DoltStore (embedded auto-start). This mirrors what a
+	// user gets after `bd init` on a new machine: a local repo with no remote.
+	localDir := filepath.Join(baseDir, "local")
+	localStore, localCleanup := setupFederationStore(t, ctx, localDir, "local")
+	defer localCleanup()
+
+	// Add the remote via DOLT_REMOTE SQL — NOT via dolt clone. This leaves
+	// repo_state.json with an empty 'branches' map: the prerequisite for GH#3144.
+	remoteURL := fmt.Sprintf("doltremoteapi://127.0.0.1:%d/beads", remotesAPIPort)
+	if _, err := localStore.db.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'origin', ?)", remoteURL); err != nil {
+		t.Fatalf("failed to add remote: %v", err)
+	}
+	localStore.remote = "origin"
+	localStore.branch = "main"
+
+	// ── Confirm the bug scenario is present ────────────────────────────────────
+	// DOLT_PULL('origin', 'main') must fail with the tracking error, otherwise
+	// we are not actually testing the fallback — we are testing a working pull.
+	// If Dolt has fixed GH#3144 upstream, skip gracefully.
+	tx, txErr := localStore.db.BeginTx(ctx, nil)
+	if txErr != nil {
+		t.Fatalf("begin tx for bug-check: %v", txErr)
+	}
+	_, rawPullErr := tx.ExecContext(ctx, "CALL DOLT_PULL(?, ?)", "origin", "main")
+	_ = tx.Rollback()
+
+	if rawPullErr == nil {
+		t.Skip("DOLT_PULL succeeded without tracking config — GH#3144 may be fixed upstream; skipping fallback test")
+	}
+	if !isBranchTrackingError(rawPullErr) {
+		t.Skipf("DOLT_PULL failed with unexpected error (not a tracking error) — skipping: %v", rawPullErr)
+	}
+	t.Logf("confirmed GH#3144 scenario: DOLT_PULL produced tracking error: %v", rawPullErr)
+
+	// ── Verify the fix: pullWithAutoResolve succeeds via fallback ──────────────
+	err = localStore.pullWithAutoResolve(ctx, "CALL DOLT_PULL(?, ?)", "origin", "main")
+	if err != nil {
+		t.Errorf("pullWithAutoResolve should succeed via DOLT_FETCH+DOLT_MERGE fallback, got: %v", err)
+	}
+	var got string
+	if err := localStore.db.QueryRowContext(ctx, "SELECT value FROM branch_tracking_marker WHERE id = 1").Scan(&got); err != nil {
+		t.Fatalf("query pulled marker: %v", err)
+	}
+	if got != "from remote" {
+		t.Fatalf("pulled marker value = %q, want %q", got, "from remote")
+	}
+}
+
+// findFreePort returns an available TCP port on 127.0.0.1.
+func findFreePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}
+
+// startDoltServer starts a dolt sql-server subprocess on sqlPort with remotesapi
+// on remotesAPIPort and waits until both ports are accepting connections.
+// Returns a stop function that kills the server and waits for it to exit.
+func startDoltServer(t *testing.T, dir string, sqlPort, remotesAPIPort int) func() {
+	t.Helper()
+
+	cmd := exec.Command("dolt", "sql-server",
+		"--host", "127.0.0.1",
+		"--port", strconv.Itoa(sqlPort),
+		"--remotesapi-port", strconv.Itoa(remotesAPIPort),
+		"--loglevel", "error",
+	)
+	cmd.Dir = dir
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start dolt sql-server: %v", err)
+	}
+
+	// Wait for both the SQL port and the remotesapi port to accept connections.
+	for _, port := range []int{sqlPort, remotesAPIPort} {
+		addr := fmt.Sprintf("127.0.0.1:%d", port)
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			if time.Now().After(deadline) {
+				cmd.Process.Kill() //nolint:errcheck
+				t.Fatalf("dolt sql-server did not start on %s within 30s", addr)
+			}
+			conn, err := net.DialTimeout("tcp", addr, time.Second)
+			if err == nil {
+				conn.Close()
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	return func() {
+		if cmd.Process != nil {
+			cmd.Process.Kill() //nolint:errcheck
+			cmd.Wait()         //nolint:errcheck
+		}
+	}
+}

--- a/internal/storage/dolt/pull_branch_tracking_test.go
+++ b/internal/storage/dolt/pull_branch_tracking_test.go
@@ -1,0 +1,132 @@
+package dolt
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPullWithAutoResolve_BranchTrackingFallback verifies that when DOLT_PULL
+// returns the GH#3144 branch-tracking error (repo_state.json 'branches' map
+// is empty because the remote was added via `bd dolt remote add` rather than
+// `dolt clone`), pullWithAutoResolve enters the DOLT_FETCH + DOLT_MERGE
+// fallback path.
+//
+// This test covers the fallback error leg (DOLT_FETCH fails because the test
+// store has no configured remote). The full success path — where DOLT_FETCH
+// and DOLT_MERGE both succeed — is exercised by
+// TestPullWithAutoResolve_BranchTrackingSuccess in the integration test file
+// (//go:build integration), which requires a remotesapi-accessible Dolt server.
+func TestPullWithAutoResolve_BranchTrackingFallback(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Create a stored procedure that injects the exact Dolt GH#3144 error text.
+	// This reproduces the message DOLT_PULL emits when repo_state.json lacks
+	// branch-tracking info for the remote, without requiring a real remote.
+	const createSP = `
+		CREATE PROCEDURE inject_tracking_error()
+		BEGIN
+			SIGNAL SQLSTATE 'HY000'
+			SET MESSAGE_TEXT = 'Error 1105: You asked to pull from the remote origin, but did not specify a branch. Because this is not the default configured remote for your current branch, you must specify a branch.';
+		END`
+	if _, err := store.db.ExecContext(ctx, createSP); err != nil {
+		t.Skipf("stored procedures with SIGNAL not supported by this Dolt version: %v", err)
+	}
+	t.Cleanup(func() {
+		store.db.ExecContext(context.Background(), "DROP PROCEDURE IF EXISTS inject_tracking_error") //nolint:errcheck
+	})
+
+	// pullWithAutoResolve executes the query inside a transaction, checks the
+	// error with isBranchTrackingError, and — on match — falls back to
+	// DOLT_FETCH(s.remote, s.branch). The test store's s.remote is "" (no
+	// remote configured), so DOLT_FETCH immediately fails, producing the
+	// "fetch from /" error that confirms the fallback was entered.
+	err := store.pullWithAutoResolve(ctx, "CALL inject_tracking_error()")
+
+	// The error must come from the DOLT_FETCH attempt, not from the original
+	// DOLT_PULL proxy. If the fallback was not triggered, the error would
+	// surface a different message (e.g. the raw SIGNAL text).
+	if err == nil {
+		t.Fatal("expected an error from DOLT_FETCH (no remote configured), got nil")
+	}
+	if !strings.Contains(err.Error(), "fetch from") {
+		t.Errorf("expected 'fetch from' error confirming fallback was triggered; got: %v", err)
+	}
+}
+
+func TestPullWithAutoResolve_BranchTrackingFallbackSuccess(t *testing.T) {
+	remoteDir := filepath.Join(t.TempDir(), "remote")
+	if err := os.MkdirAll(remoteDir, 0o755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	runDoltCmdForBranchTracking(t, remoteDir, "init")
+	runDoltSQLForBranchTracking(t, remoteDir, `
+		CREATE TABLE branch_tracking_marker (id INT PRIMARY KEY, value TEXT);
+		INSERT INTO branch_tracking_marker VALUES (1, 'from remote');
+		CALL DOLT_ADD('.');
+		CALL DOLT_COMMIT('-Am', 'init: branch tracking marker');
+	`)
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	remoteURL := "file://" + remoteDir
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_REMOTE('add', 'origin', ?)", remoteURL); err != nil {
+		t.Fatalf("add remote via DOLT_REMOTE: %v", err)
+	}
+	store.remote = "origin"
+	store.branch = "main"
+
+	tx, txErr := store.db.BeginTx(ctx, nil)
+	if txErr != nil {
+		t.Fatalf("begin tx for raw pull check: %v", txErr)
+	}
+	_, rawPullErr := tx.ExecContext(ctx, "CALL DOLT_PULL(?, ?)", "origin", "main")
+	_ = tx.Rollback()
+	if rawPullErr == nil {
+		t.Skip("DOLT_PULL succeeded without tracking config; fallback path is not needed for this Dolt version")
+	}
+	if !isBranchTrackingError(rawPullErr) {
+		t.Skipf("DOLT_PULL failed with an unexpected non-tracking error: %v", rawPullErr)
+	}
+
+	if err := store.pullWithAutoResolve(ctx, "CALL DOLT_PULL(?, ?)", "origin", "main"); err != nil {
+		t.Fatalf("pullWithAutoResolve fallback failed: %v", err)
+	}
+
+	var got string
+	if err := store.db.QueryRowContext(ctx, "SELECT value FROM branch_tracking_marker WHERE id = 1").Scan(&got); err != nil {
+		t.Fatalf("query pulled marker: %v", err)
+	}
+	if got != "from remote" {
+		t.Fatalf("pulled marker value = %q, want %q", got, "from remote")
+	}
+}
+
+func runDoltCmdForBranchTracking(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("dolt", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt %v failed in %s: %v\n%s", args, dir, err, output)
+	}
+}
+
+func runDoltSQLForBranchTracking(t *testing.T, dir, query string) {
+	t.Helper()
+	cmd := exec.Command("dolt", "sql", "-q", query)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt sql failed in %s: %v\nQuery: %.200s...\n%s", dir, err, query, output)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2150,6 +2150,23 @@ func (s *DoltStore) pullWithAutoResolve(ctx context.Context, query string, args 
 
 	_, pullErr := tx.ExecContext(ctx, query, args...)
 
+	// GH#3144: When DOLT_PULL fails because upstream branch tracking is not
+	// configured in repo_state.json (common when remote was added via
+	// bd dolt remote add rather than bd bootstrap/dolt clone), fall back to
+	// DOLT_FETCH + DOLT_MERGE which does not require tracking config.
+	if pullErr != nil && isBranchTrackingError(pullErr) {
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_FETCH(?, ?)", s.remote, s.branch); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("fetch from %s/%s: %w", s.remote, s.branch, err)
+		}
+		trackingRef := s.remote + "/" + s.branch
+		_, mergeErr := tx.ExecContext(ctx, "CALL DOLT_MERGE(?)", trackingRef)
+		if mergeErr != nil && strings.Contains(mergeErr.Error(), "up to date") {
+			mergeErr = nil
+		}
+		pullErr = mergeErr
+	}
+
 	// Check for merge conflicts regardless of whether DOLT_PULL errored.
 	// Some Dolt versions error on conflicts, others leave them in the working set.
 	resolved, resolveErr := s.tryAutoResolveMetadataConflicts(ctx, tx)


### PR DESCRIPTION
## Summary
- When `DOLT_PULL` fails with "did not specify a branch" (missing upstream tracking in `repo_state.json`), falls back to `DOLT_FETCH` + `DOLT_MERGE` which does not require tracking config
- Adds `isBranchTrackingError()` helper to detect the specific Dolt error
- Preserves the existing `pullWithAutoResolve` metadata conflict resolution logic

## Root cause
When a remote is added via `bd dolt remote add` (or `CALL DOLT_REMOTE('add', ?, ?)`), the remote is registered in `repo_state.json` under `"remotes"`, but `"branches"` remains `{}`. `DOLT_PULL` validates upstream tracking config before executing, even when the branch is passed explicitly. `dolt clone` / `bd bootstrap` set up branch tracking automatically, so this only affects databases where remotes were added after init.

The `DOLT_FETCH` + `DOLT_MERGE` approach is already used in `versioncontrolops.Pull()` (lines 66-80) specifically for this case (GH#3144), but was not applied to the `pullWithAutoResolve` path used by `DoltStore.Pull()`.

## Reproduction
```bash
bd init
bd dolt remote add origin <url>
bd dolt push   # works
bd dolt pull   # fails: "did not specify a branch"
```

## Test plan
- [x] Unit tests: `TestIsBranchTrackingError` — matches Dolt error, rejects unrelated errors, handles nil
- [x] Verified `repo_state.json` has empty `"branches": {}` on affected database
- [x] `versioncontrolops.Pull` already proven in production for the fetch+merge approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)