### PR TITLE
fix(dolt): disable auto-push by default; require explicit opt-in

### DIFF
--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -61,38 +61,22 @@ func savePushState(ps *pushState) error {
 	return atomicWriteFile(path, data)
 }
 
-// Default timeouts for auto-push operations. The push timeout bounds
-// the st.Push() call that shells out to git fetch, which blocks
-// indefinitely when the remote is unreachable (GH#3370).
-const (
-	autoPushTimeout       = 30 * time.Second
-	autoPushRemoteTimeout = 5 * time.Second
-)
+// autoPushTimeout bounds the st.Push() call that shells out to git fetch,
+// which blocks indefinitely when the remote is unreachable (GH#3370).
+const autoPushTimeout = 30 * time.Second
 
 // isDoltAutoPushEnabled returns whether auto-push to Dolt remote should run.
-// If user explicitly configured dolt.auto-push, use that.
-// Otherwise, auto-enable when a Dolt remote named "origin" exists.
-func isDoltAutoPushEnabled(ctx context.Context) bool {
-	if config.GetValueSource("dolt.auto-push") != config.SourceDefault {
-		return config.GetBool("dolt.auto-push")
-	}
-	// Auto-enable when a Dolt remote exists
-	st := getStore()
-	if st == nil {
-		return false
-	}
-	if lm, ok := storage.UnwrapStore(st).(storage.LifecycleManager); ok && lm.IsClosed() {
-		return false
-	}
-	// Bound the remote check so a hung network doesn't block the CLI (GH#3370).
-	remoteCtx, cancel := context.WithTimeout(ctx, autoPushRemoteTimeout)
-	defer cancel()
-	has, err := st.HasRemote(remoteCtx, "origin")
-	if err != nil {
-		debug.Logf("dolt auto-push: failed to check remote: %v\n", err)
-		return false
-	}
-	return has
+// Returns true only when explicitly opted in via dolt.auto-push=true in
+// .beads/config.yaml (or BD_DOLT_AUTO_PUSH=true env var).
+//
+// Previously the default was to auto-enable when an "origin" remote exists.
+// That is unsafe at any concurrency above one writer: git+ssh remotes have no
+// chunk-level upload atomicity, so concurrent dolt pushes race on the remote
+// manifest and can leave it referencing chunks that were never uploaded. Any
+// subsequent fetch/clone/push propagates the dangling reference. Set
+// dolt.auto-push=true to restore the old behavior on single-writer setups.
+func isDoltAutoPushEnabled(_ context.Context) bool {
+	return config.GetBool("dolt.auto-push")
 }
 
 // maybeAutoPush pushes to the Dolt remote if enabled and the debounce interval has passed.

--- a/cmd/bd/dolt_autopush_test.go
+++ b/cmd/bd/dolt_autopush_test.go
@@ -50,8 +50,8 @@ func TestIsDoltAutoPushEnabled_ExplicitConfig(t *testing.T) {
 	}
 }
 
-func TestIsDoltAutoPushEnabled_DefaultNoStore(t *testing.T) {
-	// When no explicit config and no store, should return false.
+func TestIsDoltAutoPushEnabled_DefaultOff(t *testing.T) {
+	// Default (no explicit config) must return false — auto-push is opt-in only.
 	os.Unsetenv("BD_DOLT_AUTO_PUSH")
 	t.Cleanup(func() { os.Unsetenv("BD_DOLT_AUTO_PUSH") })
 
@@ -61,10 +61,9 @@ func TestIsDoltAutoPushEnabled_DefaultNoStore(t *testing.T) {
 		t.Fatalf("config.Initialize: %v", err)
 	}
 
-	// store is nil → auto-detection returns false
 	got := isDoltAutoPushEnabled(context.Background())
 	if got != false {
-		t.Errorf("isDoltAutoPushEnabled() with nil store = %v, want false", got)
+		t.Errorf("isDoltAutoPushEnabled() default = %v, want false", got)
 	}
 }
 
@@ -104,9 +103,6 @@ func TestAutoPushTimeoutConstants(t *testing.T) {
 	// Verify timeout defaults are reasonable (GH#3370).
 	if autoPushTimeout < 10*time.Second || autoPushTimeout > 120*time.Second {
 		t.Errorf("autoPushTimeout = %s, want 10s-120s range", autoPushTimeout)
-	}
-	if autoPushRemoteTimeout < 2*time.Second || autoPushRemoteTimeout > 30*time.Second {
-		t.Errorf("autoPushRemoteTimeout = %s, want 2s-30s range", autoPushRemoteTimeout)
 	}
 }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -44,7 +44,7 @@ Tool-level settings you can configure:
 | `external_projects` | - | - | (none) | Map project names to paths for cross-project deps |
 | `backup.enabled` | - | `BD_BACKUP_ENABLED` | `false` | Enable periodic Dolt-native backup to `.beads/backup/` |
 | `backup.interval` | - | `BD_BACKUP_INTERVAL` | `15m` | Minimum time between auto-backups |
-| `dolt.auto-push` | - | `BD_DOLT_AUTO_PUSH` | (auto) | Auto-push to Dolt remote after writes (auto-enabled when origin exists) |
+| `dolt.auto-push` | - | `BD_DOLT_AUTO_PUSH` | `false` | Auto-push to Dolt remote after writes (explicit opt-in) |
 | `dolt.auto-push-interval` | - | `BD_DOLT_AUTO_PUSH_INTERVAL` | `5m` | Minimum time between auto-pushes |
 | `dolt.shared-server` | `--shared-server` | `BEADS_DOLT_SHARED_SERVER` | `false` | Share a single Dolt server across all projects at `~/.beads/shared-server/` |
 | `dolt.idle-timeout` | - | - | `30m` | Idle auto-stop timeout (`"0"` disables) |
@@ -103,11 +103,11 @@ backup:
 
 ### Dolt Auto-Push
 
-When a Dolt remote named `origin` is configured, `bd` automatically pushes after write commands with a 5-minute debounce. This completes the Dolt replication story: add a remote once, and data flows automatically.
+By default, `bd` does not push automatically after write commands. Auto-push is explicit opt-in because concurrent pushes to git-protocol Dolt remotes can corrupt or strand remote history when multiple writers race.
 
 ```yaml
 dolt:
-  auto-push: true       # Auto-enable when origin remote exists (default)
+  auto-push: false      # Explicit opt-in only; set true for single-writer setups
   auto-push-interval: 5m  # Minimum time between auto-pushes
 ```
 
@@ -118,10 +118,10 @@ dolt:
 - Push failures are warnings only (non-fatal)
 - Last push time and commit are tracked in the metadata table
 
-**Opt out:**
+**Opt in:**
 ```yaml
 dolt:
-  auto-push: false
+  auto-push: true
 ```
 
 ### Actor Identity Resolution


### PR DESCRIPTION
## Problem

`bd` currently auto-enables Dolt push whenever an `origin` remote exists. This
is unsafe at any concurrency above one writer.

**Root cause:** git+ssh remotes (GitHub, Hosted Dolt via SSH) have no
chunk-level upload atomicity. When two agents push concurrently, one push's
manifest update can land before the other's chunks finish uploading. The remote
ends up with a manifest that references `.darc` blobs that were never stored.
Any subsequent `dolt fetch`, `dolt pull`, or `dolt push` from a client that
ingested that manifest then propagates the dangling reference to new remotes.

We hit this three times in ~24 hours with ~10 concurrent agents writing to the
same database. Each "fix" (new remote + fresh push) was re-corrupted within an
hour because agents fetched the corrupt state, then auto-pushed it elsewhere.

## Change

Remove the auto-enable-when-remote-exists logic. `isDoltAutoPushEnabled` now
returns `config.GetBool("dolt.auto-push")`, which defaults to `false`.

**To restore auto-push on single-writer setups**, add to `.beads/config.yaml`:
```yaml
dolt.auto-push: true
```
or set `BD_DOLT_AUTO_PUSH=true`.

The explicit-config path (`dolt.auto-push: true/false`) is unchanged — this
only affects the case where the key is not set at all.

## Tests

- `TestIsDoltAutoPushEnabled_DefaultOff` (renamed from `_DefaultNoStore`) now
  documents that the default is `false` regardless of store state.
- All existing autopush tests pass.

## Notes

I'm happy to discuss whether a warning (rather than silent change) would be
better for existing users who relied on auto-push. The behavior is easy to
restore with one config line, but I wanted to raise the option.