### PR TITLE
fix(dolt): pre-push integrity check via dolt fsck

### DIFF
--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -28,6 +28,12 @@ var (
 
 	// ErrExec indicates a database exec (INSERT/UPDATE/DELETE) failure.
 	ErrExec = errors.New("exec error")
+
+	// ErrDanglingReference indicates that the pre-push integrity check detected
+	// missing chunks in the local Dolt noms store. The push was aborted to
+	// prevent propagating the corruption to the remote. Run bd dolt verify
+	// to diagnose and recover.
+	ErrDanglingReference = errors.New("dangling chunk reference")
 )
 
 // isTableNotExistError returns true if the error indicates a MySQL/Dolt

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -377,6 +377,9 @@ func (s *DoltStore) isPeerGitProtocolRemote(ctx context.Context, peer string) bo
 // Used for git-protocol remotes where CALL DOLT_PUSH times out through the SQL connection.
 // Credentials are set on the subprocess environment only via cmd.Env.
 func (s *DoltStore) doltCLIPushToPeer(ctx context.Context, peer string, creds *remoteCredentials) error {
+	if err := s.prePushFSCK(ctx); err != nil {
+		return err
+	}
 	cmd := exec.CommandContext(ctx, "dolt", "push", peer, s.branch) // #nosec G204 -- fixed command with validated peer/branch
 	cmd.Dir = s.CLIDir()
 	creds.applyToCmd(cmd)

--- a/internal/storage/dolt/fsck_test.go
+++ b/internal/storage/dolt/fsck_test.go
@@ -1,0 +1,85 @@
+package dolt
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestPrePushFSCK_EmptyCLIDir verifies that prePushFSCK is a no-op when
+// CLIDir is empty (no local noms store configured).
+func TestPrePushFSCK_EmptyCLIDir(t *testing.T) {
+	t.Parallel()
+	s := &DoltStore{dbPath: "", database: "test"}
+	if err := s.prePushFSCK(context.Background()); err != nil {
+		t.Fatalf("expected nil for empty CLIDir, got %v", err)
+	}
+}
+
+// TestPrePushFSCK_NoNomsDir verifies that prePushFSCK is a no-op when
+// CLIDir exists but .dolt/noms does not (uninitialized or non-dolt directory).
+func TestPrePushFSCK_NoNomsDir(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	s := &DoltStore{dbPath: tmp, database: "mydb"}
+	// CLIDir() = tmp/mydb, which doesn't exist and has no .dolt/noms
+	if err := s.prePushFSCK(context.Background()); err != nil {
+		t.Fatalf("expected nil when .dolt/noms absent, got %v", err)
+	}
+}
+
+// TestPrePushFSCK_CleanDB verifies that prePushFSCK passes on a fresh
+// dolt-initialized database with no corruption.
+func TestPrePushFSCK_CleanDB(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not in PATH")
+	}
+
+	tmp := t.TempDir()
+	dbDir := filepath.Join(tmp, "mydb")
+	if err := os.MkdirAll(dbDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	initCmd := exec.Command("dolt", "init", "--name", "test", "--email", "test@example.com")
+	initCmd.Dir = dbDir
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt init: %v\n%s", err, out)
+	}
+
+	s := &DoltStore{dbPath: tmp, database: "mydb"}
+	if err := s.prePushFSCK(context.Background()); err != nil {
+		t.Fatalf("expected nil on clean DB, got %v", err)
+	}
+}
+
+// TestPrePushFSCK_CorruptNoms verifies that prePushFSCK returns
+// ErrDanglingReference when dolt fsck detects an invalid local store.
+// We simulate corruption by creating a .dolt/noms directory without running
+// dolt init — fsck fails because the repository state is invalid.
+func TestPrePushFSCK_CorruptNoms(t *testing.T) {
+	t.Parallel()
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not in PATH")
+	}
+
+	tmp := t.TempDir()
+	dbDir := filepath.Join(tmp, "mydb")
+	// Create .dolt/noms so the skip check passes, but don't init the repo.
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt", "noms"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	s := &DoltStore{dbPath: tmp, database: "mydb"}
+	err := s.prePushFSCK(context.Background())
+	if err == nil {
+		t.Fatal("expected ErrDanglingReference for invalid repo, got nil")
+	}
+	if !errors.Is(err, ErrDanglingReference) {
+		t.Fatalf("expected ErrDanglingReference, got %v", err)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -272,6 +272,11 @@ const (
 // this prevents the process from blocking forever.
 const cliExecTimeout = 5 * time.Minute
 
+// fsckTimeout is the maximum time to wait for dolt fsck to verify the local
+// chunk store before a push. fsck reads local files only; 30 seconds is ample
+// for any DB size we currently operate.
+const fsckTimeout = 30 * time.Second
+
 // Retry configuration for transient connection errors (stale pool connections,
 // brief network issues, server restarts).
 const serverRetryMaxElapsed = 30 * time.Second
@@ -1875,11 +1880,45 @@ func (s *DoltStore) credentialsForRemote(remote string) *remoteCredentials {
 	return nil
 }
 
+// prePushFSCK runs dolt fsck --quiet to verify local chunk integrity before
+// pushing. This prevents propagating Dolt remote corruption (dangling blob
+// references) that arise when concurrent pushes race on the remote manifest.
+//
+// When multiple agents push simultaneously, one push's manifest update can
+// land before another's chunks finish uploading, leaving a manifest that
+// references chunks that were never stored. Any agent that then fetches and
+// re-pushes that remote faithfully propagates the dangling reference.
+//
+// If CLIDir is empty or .dolt/noms does not exist, the check is skipped.
+// Any fsck failure returns ErrDanglingReference — the push is NOT attempted.
+func (s *DoltStore) prePushFSCK(ctx context.Context) error {
+	dir := s.CLIDir()
+	if dir == "" {
+		return nil
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".dolt", "noms")); os.IsNotExist(err) {
+		return nil
+	}
+	fsckCtx, cancel := context.WithTimeout(ctx, fsckTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(fsckCtx, "dolt", "fsck", "--quiet") // #nosec G204 -- fixed command
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks: %s",
+			ErrDanglingReference, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // doltCLIPush shells out to `dolt push` from the database directory.
 // Used for git-protocol remotes where CALL DOLT_PUSH times out through the SQL connection.
 // If creds is non-nil, credentials are set on the subprocess environment only,
 // avoiding process-wide env var races with concurrent goroutines.
 func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, creds *remoteCredentials) error {
+	if err := s.prePushFSCK(ctx); err != nil {
+		return err
+	}
 	ctx, cancel := context.WithTimeout(ctx, cliExecTimeout)
 	defer cancel()
 	args := []string{"push"}


### PR DESCRIPTION
## Problem

After fixing auto-push throttling (#3381), we hit a deeper issue: even a
controlled `bd dolt push` can propagate chunk-store corruption to GitHub remotes.

**Root cause:** git+ssh remotes have no chunk-level upload atomicity. If two
agents push concurrently (or if a client fetches a corrupt remote and then
pushes), the remote manifest can reference `.darc` blobs that were never
uploaded. Any `dolt pull` or `dolt fetch` that ingests that manifest then
has dangling references in its local noms store — and the next push faithfully
carries them to whatever new remote is created. We experienced this as three
successive remote corruption incidents in ~24 hours, each time a "fresh"
remote was re-corrupted within an hour.

## Fix

Run `dolt fsck --quiet` before every CLI push (`doltCLIPush` and
`doltCLIPushToPeer`). `dolt fsck` walks the local chunk graph from HEAD and
verifies every referenced blob exists in the local noms store. If any chunk is
missing, a new `ErrDanglingReference` error is returned and the push is
**aborted before any network activity**. This catches the propagation pattern:
a client that fetched a corrupt remote will refuse to push, preventing the
damage from spreading to new remotes.

The check is skipped when:
- `CLIDir()` is empty (no local noms store configured)
- `.dolt/noms` doesn't exist (database not yet initialized)

SQL push paths (CALL DOLT_PUSH) are not affected — those paths are used for
Hosted Dolt where the server handles integrity.

## Tests

Four unit tests in `fsck_test.go`:
- `TestPrePushFSCK_EmptyCLIDir` — skip when no CLIDir
- `TestPrePushFSCK_NoNomsDir` — skip when `.dolt/noms` absent
- `TestPrePushFSCK_CleanDB` — pass on a fresh `dolt init`'d database
- `TestPrePushFSCK_CorruptNoms` — return `ErrDanglingReference` for invalid store

## Note

I'm using `dolt fsck` as a black-box check rather than walking the noms chunk
graph directly via the Go API. This keeps the implementation simple and stable
against internal noms API changes. If fsck performance becomes a concern for
large databases, a timeout flag (`fsckTimeout = 30s`) will abort the check
rather than block the push indefinitely.