### PR TITLE
perf(storage): amortize per-ID wisp routing via WispIDSetInTx

### DIFF
--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -499,7 +499,7 @@ func (s *DoltStore) GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.
 	var result []*types.Issue
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.GetIssuesByIDsInTx(ctx, tx, ids)
+		result, err = issueops.GetIssuesByIDsInTx(ctx, tx, ids, nil)
 		return err
 	})
 	return result, err

--- a/internal/storage/dolt/dolt_benchmark_test.go
+++ b/internal/storage/dolt/dolt_benchmark_test.go
@@ -973,3 +973,84 @@ func BenchmarkGetLabels(b *testing.B) {
 		}
 	}
 }
+
+// =============================================================================
+// WispIDSet mixed-ID routing benchmarks (be-nu4.2.1 / D2)
+// =============================================================================
+
+// seedMixedForWispSetBench populates the store with N issues at the requested
+// wisp share. IDs are returned in the order created (perms first, then wisps)
+// so benchmarks can shuffle if needed. Callers are responsible for cleanup.
+func seedMixedForWispSetBench(b *testing.B, store *DoltStore, totalN int, wispShare float64) []string {
+	b.Helper()
+	ctx := context.Background()
+	numWisps := int(float64(totalN) * wispShare)
+	numPerms := totalN - numWisps
+
+	ids := make([]string, 0, totalN)
+	for i := 0; i < numPerms; i++ {
+		iss := &types.Issue{
+			ID:        fmt.Sprintf("ws-perm-%d", i),
+			Title:     "perm",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, iss, "bench"); err != nil {
+			b.Fatalf("create perm %d: %v", i, err)
+		}
+		ids = append(ids, iss.ID)
+	}
+	for i := 0; i < numWisps; i++ {
+		iss := &types.Issue{
+			Title:     "wisp",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "bench"); err != nil {
+			b.Fatalf("create wisp %d: %v", i, err)
+		}
+		ids = append(ids, iss.ID)
+	}
+	return ids
+}
+
+func benchmarkGetLabelsForIssuesMixed(b *testing.B, totalN int) {
+	store, cleanup := setupBenchStore(b)
+	defer cleanup()
+
+	ids := seedMixedForWispSetBench(b, store, totalN, 0.25)
+
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.GetLabelsForIssues(ctx, ids); err != nil {
+			b.Fatalf("GetLabelsForIssues: %v", err)
+		}
+	}
+}
+
+func BenchmarkGetLabelsForIssues_Mixed1K(b *testing.B)  { benchmarkGetLabelsForIssuesMixed(b, 1000) }
+func BenchmarkGetLabelsForIssues_Mixed10K(b *testing.B) { benchmarkGetLabelsForIssuesMixed(b, 10000) }
+func BenchmarkGetLabelsForIssues_Mixed50K(b *testing.B) { benchmarkGetLabelsForIssuesMixed(b, 50000) }
+
+func benchmarkGetIssuesByIDsMixed(b *testing.B, totalN int) {
+	store, cleanup := setupBenchStore(b)
+	defer cleanup()
+
+	ids := seedMixedForWispSetBench(b, store, totalN, 0.25)
+
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.GetIssuesByIDs(ctx, ids); err != nil {
+			b.Fatalf("GetIssuesByIDs: %v", err)
+		}
+	}
+}
+
+func BenchmarkGetIssuesByIDs_Mixed1K(b *testing.B)  { benchmarkGetIssuesByIDsMixed(b, 1000) }
+func BenchmarkGetIssuesByIDs_Mixed10K(b *testing.B) { benchmarkGetIssuesByIDsMixed(b, 10000) }
+func BenchmarkGetIssuesByIDs_Mixed50K(b *testing.B) { benchmarkGetIssuesByIDsMixed(b, 50000) }

--- a/internal/storage/dolt/dolt_benchmark_test.go
+++ b/internal/storage/dolt/dolt_benchmark_test.go
@@ -1054,3 +1054,138 @@ func benchmarkGetIssuesByIDsMixed(b *testing.B, totalN int) {
 func BenchmarkGetIssuesByIDs_Mixed1K(b *testing.B)  { benchmarkGetIssuesByIDsMixed(b, 1000) }
 func BenchmarkGetIssuesByIDs_Mixed10K(b *testing.B) { benchmarkGetIssuesByIDsMixed(b, 10000) }
 func BenchmarkGetIssuesByIDs_Mixed50K(b *testing.B) { benchmarkGetIssuesByIDsMixed(b, 50000) }
+
+// =============================================================================
+// WispIDSet scoped-query benchmarks (be-rgm / small-N against large-W)
+// =============================================================================
+//
+// These benchmarks target the case maphew flagged on PR #3453:
+// a small hydration batch (N input IDs) against a wisps table of W rows.
+// The pre-be-rgm unscoped `SELECT id FROM wisps` scaled O(W); the
+// scoped `SELECT id FROM wisps WHERE id IN (?…)` should scale O(N·log W)
+// instead, so a small N against a large W should be materially cheaper
+// than the full-scan implementation.
+//
+// Seed shape: a large wisps table (W rows) plus a handful of permanent
+// issues (≈ inputN/2, just enough to build a mixed-input batch). The
+// input batch is inputN/2 perms + inputN/2 sampled wisps, so only a
+// tiny fraction of the wisp table is actually hydrated each call.
+
+// seedSmallNLargeW seeds permCount permanent issues and wispCount active
+// wisps and returns (permIDs, wispIDs) in creation order.
+func seedSmallNLargeW(b *testing.B, store *DoltStore, permCount, wispCount int) (permIDs, wispIDs []string) {
+	b.Helper()
+	ctx := context.Background()
+
+	permIDs = make([]string, 0, permCount)
+	for i := 0; i < permCount; i++ {
+		iss := &types.Issue{
+			ID:        fmt.Sprintf("smN-perm-%d", i),
+			Title:     "perm",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, iss, "bench"); err != nil {
+			b.Fatalf("create perm %d: %v", i, err)
+		}
+		permIDs = append(permIDs, iss.ID)
+	}
+	wispIDs = make([]string, 0, wispCount)
+	for i := 0; i < wispCount; i++ {
+		iss := &types.Issue{
+			Title:     "wisp",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "bench"); err != nil {
+			b.Fatalf("create wisp %d: %v", i, err)
+		}
+		wispIDs = append(wispIDs, iss.ID)
+	}
+	return permIDs, wispIDs
+}
+
+// mixedInputSmallN returns a mixed input slice of size inputN: half
+// permanents (from permIDs) + half wisps (from wispIDs). The callers
+// want half/half so both the perm and wisp branches of the partition
+// exercise the IN-clause.
+func mixedInputSmallN(permIDs, wispIDs []string, inputN int) []string {
+	input := make([]string, 0, inputN)
+	half := inputN / 2
+	for i := 0; i < half && i < len(permIDs); i++ {
+		input = append(input, permIDs[i])
+	}
+	for i := 0; i < inputN-len(input) && i < len(wispIDs); i++ {
+		input = append(input, wispIDs[i])
+	}
+	return input
+}
+
+// benchmarkGetLabelsForIssuesSmallN runs GetLabelsForIssues against a
+// seeded store where wispW wisps exist but only inputN input IDs are
+// hydrated. Half the input is permanent and half is wisps.
+func benchmarkGetLabelsForIssuesSmallN(b *testing.B, wispW, inputN int) {
+	store, cleanup := setupBenchStore(b)
+	defer cleanup()
+
+	permIDs, wispIDs := seedSmallNLargeW(b, store, inputN/2+1, wispW)
+	input := mixedInputSmallN(permIDs, wispIDs, inputN)
+
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.GetLabelsForIssues(ctx, input); err != nil {
+			b.Fatalf("GetLabelsForIssues: %v", err)
+		}
+	}
+}
+
+// BenchmarkGetLabelsForIssues_SmallNLargeW_10_5K measures the canonical
+// regression case: 10 input IDs against 5 000 wisps in the table.
+func BenchmarkGetLabelsForIssues_SmallNLargeW_10_5K(b *testing.B) {
+	benchmarkGetLabelsForIssuesSmallN(b, 5000, 10)
+}
+
+// BenchmarkGetLabelsForIssues_SmallNLargeW_10_10K stresses the same
+// shape against a bigger wisp table so the O(W) full-scan regression
+// would be obvious in wall time.
+func BenchmarkGetLabelsForIssues_SmallNLargeW_10_10K(b *testing.B) {
+	benchmarkGetLabelsForIssuesSmallN(b, 10000, 10)
+}
+
+// BenchmarkGetLabelsForIssues_SmallNLargeW_100_5K checks a slightly
+// larger N to confirm the scaled-N·log(W) path still beats full scan.
+func BenchmarkGetLabelsForIssues_SmallNLargeW_100_5K(b *testing.B) {
+	benchmarkGetLabelsForIssuesSmallN(b, 5000, 100)
+}
+
+// benchmarkGetIssuesByIDsSmallN mirrors benchmarkGetLabelsForIssuesSmallN
+// for the issue-hydration caller.
+func benchmarkGetIssuesByIDsSmallN(b *testing.B, wispW, inputN int) {
+	store, cleanup := setupBenchStore(b)
+	defer cleanup()
+
+	permIDs, wispIDs := seedSmallNLargeW(b, store, inputN/2+1, wispW)
+	input := mixedInputSmallN(permIDs, wispIDs, inputN)
+
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := store.GetIssuesByIDs(ctx, input); err != nil {
+			b.Fatalf("GetIssuesByIDs: %v", err)
+		}
+	}
+}
+
+func BenchmarkGetIssuesByIDs_SmallNLargeW_10_5K(b *testing.B) {
+	benchmarkGetIssuesByIDsSmallN(b, 5000, 10)
+}
+func BenchmarkGetIssuesByIDs_SmallNLargeW_10_10K(b *testing.B) {
+	benchmarkGetIssuesByIDsSmallN(b, 10000, 10)
+}
+func BenchmarkGetIssuesByIDs_SmallNLargeW_100_5K(b *testing.B) {
+	benchmarkGetIssuesByIDsSmallN(b, 5000, 100)
+}

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -40,7 +40,7 @@ func (s *DoltStore) GetLabelsForIssues(ctx context.Context, issueIDs []string) (
 	var result map[string][]string
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs)
+		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs, nil)
 		return err
 	})
 	return result, err

--- a/internal/storage/dolt/wisp_set_routing_test.go
+++ b/internal/storage/dolt/wisp_set_routing_test.go
@@ -66,7 +66,7 @@ func TestWispIDSetInTx_HardGate(t *testing.T) {
 	ids := []string{perm.ID, wisp.ID}
 	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
 		// WispIDSetInTx should contain only the wisp ID, not the perm.
-		set, err := issueops.WispIDSetInTx(ctx, tx)
+		set, err := issueops.WispIDSetInTx(ctx, tx, ids)
 		if err != nil {
 			t.Fatalf("WispIDSetInTx: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestWispIDSetInTx_Empty(t *testing.T) {
 
 		// And the wisp set query itself should return cleanly on an empty
 		// wisps table.
-		set, err := issueops.WispIDSetInTx(ctx, tx)
+		set, err := issueops.WispIDSetInTx(ctx, tx, nil)
 		if err != nil {
 			t.Fatalf("WispIDSetInTx empty: %v", err)
 		}

--- a/internal/storage/dolt/wisp_set_routing_test.go
+++ b/internal/storage/dolt/wisp_set_routing_test.go
@@ -1,0 +1,183 @@
+package dolt
+
+import (
+	"database/sql"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestWispIDSetInTx_HardGate covers the D2 "mixed-ID routing" hard gate
+// from be-nu4.2.1. It seeds one permanent issue and one active wisp, each
+// tagged with a distinct label, and verifies that the refactored helpers
+// GetLabelsForIssuesInTx and GetIssuesByIDsInTx route each ID to the correct
+// underlying table when given a mixed input slice.
+//
+// Regression direction: a bug in the wisp-set construction or partitioning
+// would cause a wisp ID to be queried against `labels`/`issues` (returning
+// empty) or a permanent ID to be queried against `wisp_labels`/`wisps`
+// (also returning empty). The test asserts full round-trip label + issue
+// hydration across both tables.
+func TestWispIDSetInTx_HardGate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Seed: one permanent issue tagged "foo".
+	perm := &types.Issue{
+		ID:        "wispset-perm-1",
+		Title:     "perm issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, perm, "tester"); err != nil {
+		t.Fatalf("create perm: %v", err)
+	}
+	if err := store.AddLabel(ctx, perm.ID, "foo", "tester"); err != nil {
+		t.Fatalf("add label to perm: %v", err)
+	}
+
+	// Seed: one active wisp tagged "bar".
+	wisp := &types.Issue{
+		Title:     "wisp issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("create wisp: %v", err)
+	}
+	if err := store.AddLabel(ctx, wisp.ID, "bar", "tester"); err != nil {
+		t.Fatalf("add label to wisp: %v", err)
+	}
+	if !store.isActiveWisp(ctx, wisp.ID) {
+		t.Fatalf("expected %q to be active wisp", wisp.ID)
+	}
+
+	// Run assertions inside one read tx so the WispIDSetInTx result is
+	// visible alongside the partitioned reads.
+	ids := []string{perm.ID, wisp.ID}
+	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		// WispIDSetInTx should contain only the wisp ID, not the perm.
+		set, err := issueops.WispIDSetInTx(ctx, tx)
+		if err != nil {
+			t.Fatalf("WispIDSetInTx: %v", err)
+		}
+		if _, ok := set[wisp.ID]; !ok {
+			t.Errorf("WispIDSetInTx missing wisp %q, set=%v", wisp.ID, setKeys(set))
+		}
+		if _, ok := set[perm.ID]; ok {
+			t.Errorf("WispIDSetInTx contains permanent %q (should not), set=%v", perm.ID, setKeys(set))
+		}
+
+		// GetLabelsForIssuesInTx: each ID gets its own label, not the
+		// other's; nil wispSet exercises the internal build path.
+		labelMap, err := issueops.GetLabelsForIssuesInTx(ctx, tx, ids, nil)
+		if err != nil {
+			t.Fatalf("GetLabelsForIssuesInTx (nil set): %v", err)
+		}
+		if got, want := labelMap[perm.ID], []string{"foo"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("perm labels: got %v, want %v", got, want)
+		}
+		if got, want := labelMap[wisp.ID], []string{"bar"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("wisp labels: got %v, want %v", got, want)
+		}
+
+		// Same call with caller-provided set must produce identical results.
+		labelMap2, err := issueops.GetLabelsForIssuesInTx(ctx, tx, ids, set)
+		if err != nil {
+			t.Fatalf("GetLabelsForIssuesInTx (caller set): %v", err)
+		}
+		if !reflect.DeepEqual(labelMap2, labelMap) {
+			t.Errorf("label map differs when caller provides set: %v vs %v", labelMap2, labelMap)
+		}
+
+		// GetIssuesByIDsInTx: both rows come back fully hydrated, labels
+		// attached to the matching IDs.
+		issues, err := issueops.GetIssuesByIDsInTx(ctx, tx, ids, nil)
+		if err != nil {
+			t.Fatalf("GetIssuesByIDsInTx (nil set): %v", err)
+		}
+		if len(issues) != 2 {
+			t.Fatalf("GetIssuesByIDsInTx returned %d issues, want 2", len(issues))
+		}
+		issueByID := map[string]*types.Issue{}
+		for _, iss := range issues {
+			issueByID[iss.ID] = iss
+		}
+		gotPerm := issueByID[perm.ID]
+		gotWisp := issueByID[wisp.ID]
+		if gotPerm == nil || gotWisp == nil {
+			t.Fatalf("GetIssuesByIDsInTx missing ids: got %v", issueByID)
+		}
+		if !reflect.DeepEqual(gotPerm.Labels, []string{"foo"}) {
+			t.Errorf("perm issue labels: got %v, want [foo]", gotPerm.Labels)
+		}
+		if !reflect.DeepEqual(gotWisp.Labels, []string{"bar"}) {
+			t.Errorf("wisp issue labels: got %v, want [bar]", gotWisp.Labels)
+		}
+		if gotWisp.Ephemeral != true {
+			t.Errorf("wisp issue Ephemeral=%v, want true", gotWisp.Ephemeral)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+}
+
+// TestWispIDSetInTx_Empty verifies the helpers handle empty inputs without
+// issuing a wisp-set query (GetLabelsForIssuesInTx / GetIssuesByIDsInTx both
+// short-circuit on empty input).
+func TestWispIDSetInTx_Empty(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		labelMap, err := issueops.GetLabelsForIssuesInTx(ctx, tx, nil, nil)
+		if err != nil {
+			t.Fatalf("GetLabelsForIssuesInTx empty: %v", err)
+		}
+		if len(labelMap) != 0 {
+			t.Errorf("expected empty map, got %v", labelMap)
+		}
+		issues, err := issueops.GetIssuesByIDsInTx(ctx, tx, nil, nil)
+		if err != nil {
+			t.Fatalf("GetIssuesByIDsInTx empty: %v", err)
+		}
+		if len(issues) != 0 {
+			t.Errorf("expected no issues, got %v", issues)
+		}
+
+		// And the wisp set query itself should return cleanly on an empty
+		// wisps table.
+		set, err := issueops.WispIDSetInTx(ctx, tx)
+		if err != nil {
+			t.Fatalf("WispIDSetInTx empty: %v", err)
+		}
+		if len(set) != 0 {
+			t.Errorf("expected empty wisp set, got %v", set)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+}
+
+func setKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/storage/dolt/wisp_set_scoped_test.go
+++ b/internal/storage/dolt/wisp_set_scoped_test.go
@@ -1,0 +1,318 @@
+package dolt
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// setKeys is defined in wisp_set_routing_test.go (same package).
+
+// TestWispIDSetInTx_Scoped_ReturnsOnlyInputIDs is the "lock the fix in"
+// regression test for be-rgm (maphew on PR #3453). It seeds N wisps but
+// passes only a single ID through WispIDSetInTx; the returned set must
+// contain exactly that one ID. A revert to the unscoped
+// `SELECT id FROM wisps` fallback would cause the returned set to
+// include all N seeded wisps, failing this test.
+func TestWispIDSetInTx_Scoped_ReturnsOnlyInputIDs(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Seed five active wisps. Only one will be passed to WispIDSetInTx.
+	wispIDs := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		iss := &types.Issue{
+			Title:     fmt.Sprintf("wisp %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create wisp %d: %v", i, err)
+		}
+		wispIDs = append(wispIDs, iss.ID)
+	}
+
+	target := wispIDs[2]
+
+	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		set, err := issueops.WispIDSetInTx(ctx, tx, []string{target})
+		if err != nil {
+			return fmt.Errorf("WispIDSetInTx: %w", err)
+		}
+		if len(set) != 1 {
+			t.Errorf("scoped set size: got %d (%v), want 1", len(set), setKeys(set))
+		}
+		if _, ok := set[target]; !ok {
+			t.Errorf("scoped set missing target %q, got %v", target, setKeys(set))
+		}
+		for _, other := range wispIDs {
+			if other == target {
+				continue
+			}
+			if _, leaked := set[other]; leaked {
+				t.Errorf("scoped set leaked unrequested wisp %q (regression: reverted to unscoped SELECT?), got %v",
+					other, setKeys(set))
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+}
+
+// TestWispIDSetInTx_Scoped_AcrossBatchBoundary verifies the scoped helper
+// handles input larger than queryBatchSize (200) by iterating batched
+// IN-clauses. Seeds 250 wisps, passes all 250, expects every ID back.
+func TestWispIDSetInTx_Scoped_AcrossBatchBoundary(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const n = 250
+	wispIDs := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		iss := &types.Issue{
+			Title:     fmt.Sprintf("batch-wisp %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create wisp %d: %v", i, err)
+		}
+		wispIDs = append(wispIDs, iss.ID)
+	}
+
+	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		set, err := issueops.WispIDSetInTx(ctx, tx, wispIDs)
+		if err != nil {
+			return fmt.Errorf("WispIDSetInTx: %w", err)
+		}
+		if len(set) != n {
+			t.Errorf("batched set size: got %d, want %d (keys=%v)", len(set), n, setKeys(set))
+		}
+		for _, id := range wispIDs {
+			if _, ok := set[id]; !ok {
+				t.Errorf("batched set missing %q", id)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+}
+
+// TestWispIDSetInTx_Scoped_UnknownIDsReturnEmpty verifies the helper
+// returns a clean empty set when every input ID is absent from the
+// wisps table (not a wisp and not an error condition).
+func TestWispIDSetInTx_Scoped_UnknownIDsReturnEmpty(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Seed one wisp to prove the query would find something if it was unscoped.
+	bait := &types.Issue{
+		Title:     "bait wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, bait, "tester"); err != nil {
+		t.Fatalf("create bait: %v", err)
+	}
+
+	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		set, err := issueops.WispIDSetInTx(ctx, tx, []string{"nonexistent-a", "nonexistent-b"})
+		if err != nil {
+			return fmt.Errorf("WispIDSetInTx: %w", err)
+		}
+		if len(set) != 0 {
+			t.Errorf("unknown-ids set: got %v, want empty", setKeys(set))
+		}
+		if _, leaked := set[bait.ID]; leaked {
+			t.Errorf("scoped set leaked bait wisp %q (regression: reverted to unscoped SELECT?)", bait.ID)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+}
+
+// TestGetLabelsForIssuesInTx_SmallInputLargeWispTable exercises the
+// end-to-end hydration path maphew flagged: a small input ID batch
+// against a large wisps table. The scoped WispIDSetInTx internal build
+// (nil wispSet) must still return the correct labels for the one
+// requested wisp, without being disturbed by the N-1 other wisps that
+// happen to share the table.
+func TestGetLabelsForIssuesInTx_SmallInputLargeWispTable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// Seed one permanent issue with a label.
+	perm := &types.Issue{
+		ID:        "smallN-perm-1",
+		Title:     "perm",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, perm, "tester"); err != nil {
+		t.Fatalf("create perm: %v", err)
+	}
+	if err := store.AddLabel(ctx, perm.ID, "perm-label", "tester"); err != nil {
+		t.Fatalf("add perm label: %v", err)
+	}
+
+	// Seed one target wisp with its own label.
+	target := &types.Issue{
+		Title:     "target wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, target, "tester"); err != nil {
+		t.Fatalf("create target wisp: %v", err)
+	}
+	if err := store.AddLabel(ctx, target.ID, "target-label", "tester"); err != nil {
+		t.Fatalf("add target label: %v", err)
+	}
+
+	// Seed a batch of noise wisps with labels that must NOT leak into
+	// the result — "large wisp table" relative to the small input.
+	const noiseCount = 20
+	noiseIDs := make([]string, 0, noiseCount)
+	for i := 0; i < noiseCount; i++ {
+		iss := &types.Issue{
+			Title:     fmt.Sprintf("noise wisp %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create noise %d: %v", i, err)
+		}
+		if err := store.AddLabel(ctx, iss.ID, fmt.Sprintf("noise-%d", i), "tester"); err != nil {
+			t.Fatalf("add noise label %d: %v", i, err)
+		}
+		noiseIDs = append(noiseIDs, iss.ID)
+	}
+
+	input := []string{perm.ID, target.ID}
+
+	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		// Nil wispSet exercises the internal scoped build on input IDs.
+		labelMap, err := issueops.GetLabelsForIssuesInTx(ctx, tx, input, nil)
+		if err != nil {
+			return fmt.Errorf("GetLabelsForIssuesInTx: %w", err)
+		}
+		if got, want := labelMap[perm.ID], []string{"perm-label"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("perm labels: got %v, want %v", got, want)
+		}
+		if got, want := labelMap[target.ID], []string{"target-label"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("target labels: got %v, want %v", got, want)
+		}
+		// Noise IDs were never requested — the map should not contain them.
+		for _, n := range noiseIDs {
+			if _, leaked := labelMap[n]; leaked {
+				t.Errorf("result leaked noise wisp %q (regression: nil-set build was unscoped?)", n)
+			}
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+}
+
+// TestGetIssuesByIDsInTx_SmallInputLargeWispTable is the issue-hydration
+// mirror of TestGetLabelsForIssuesInTx_SmallInputLargeWispTable. It
+// verifies the fast-path caller still produces correct hydrated issues
+// when the wisp set was built with a scoped internal query.
+func TestGetIssuesByIDsInTx_SmallInputLargeWispTable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	perm := &types.Issue{
+		ID:        "smallN-issue-perm",
+		Title:     "perm",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, perm, "tester"); err != nil {
+		t.Fatalf("create perm: %v", err)
+	}
+
+	target := &types.Issue{
+		Title:     "target wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, target, "tester"); err != nil {
+		t.Fatalf("create target wisp: %v", err)
+	}
+
+	const noiseCount = 20
+	for i := 0; i < noiseCount; i++ {
+		iss := &types.Issue{
+			Title:     fmt.Sprintf("noise wisp %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create noise %d: %v", i, err)
+		}
+	}
+
+	input := []string{perm.ID, target.ID}
+
+	if err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		issues, err := issueops.GetIssuesByIDsInTx(ctx, tx, input, nil)
+		if err != nil {
+			return fmt.Errorf("GetIssuesByIDsInTx: %w", err)
+		}
+		if len(issues) != 2 {
+			t.Fatalf("got %d issues, want 2: %v", len(issues), issues)
+		}
+		gotIDs := make([]string, 0, len(issues))
+		for _, iss := range issues {
+			gotIDs = append(gotIDs, iss.ID)
+		}
+		sort.Strings(gotIDs)
+		want := []string{perm.ID, target.ID}
+		sort.Strings(want)
+		if !reflect.DeepEqual(gotIDs, want) {
+			t.Errorf("issue IDs: got %v, want %v", gotIDs, want)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+}

--- a/internal/storage/embeddeddolt/dependencies.go
+++ b/internal/storage/embeddeddolt/dependencies.go
@@ -30,7 +30,7 @@ func (s *EmbeddedDoltStore) GetIssuesByIDs(ctx context.Context, ids []string) ([
 	var result []*types.Issue
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.GetIssuesByIDsInTx(ctx, tx, ids)
+		result, err = issueops.GetIssuesByIDsInTx(ctx, tx, ids, nil)
 		return err
 	})
 	return result, err

--- a/internal/storage/embeddeddolt/list_queries.go
+++ b/internal/storage/embeddeddolt/list_queries.go
@@ -35,7 +35,7 @@ func (s *EmbeddedDoltStore) GetLabelsForIssues(ctx context.Context, issueIDs []s
 	var result map[string][]string
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs)
+		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs, nil)
 		return err
 	})
 	return result, err

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -402,7 +402,7 @@ func GetBlockedIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilt
 	for id := range blockerMap {
 		blockedIDs = append(blockedIDs, id)
 	}
-	issues, err := GetIssuesByIDsInTx(ctx, tx, blockedIDs)
+	issues, err := GetIssuesByIDsInTx(ctx, tx, blockedIDs, nil)
 	if err != nil {
 		return nil, fmt.Errorf("batch-fetch blocked issues: %w", err)
 	}

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -201,21 +201,26 @@ func RemoveDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID 
 // transaction, including labels. Automatically routes each ID to the correct
 // table (issues/wisps). Uses batched IN clauses.
 //
+// wispSet is an optional pre-built set of active wisp IDs (see WispIDSetInTx).
+// Pass nil to have the helper build the set once internally; callers hydrating
+// multiple batches inside one tx can build it up-front and reuse.
+//
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
-func GetIssuesByIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) ([]*types.Issue, error) {
+func GetIssuesByIDsInTx(ctx context.Context, tx *sql.Tx, ids []string, wispSet map[string]struct{}) ([]*types.Issue, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
 
-	// Partition IDs by wisp status.
-	var wispIDs, permIDs []string
-	for _, id := range ids {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
+	if wispSet == nil {
+		var err error
+		wispSet, err = WispIDSetInTx(ctx, tx)
+		if err != nil {
+			return nil, fmt.Errorf("get issues by IDs: build wisp set: %w", err)
 		}
 	}
+
+	// Partition IDs by wisp status.
+	wispIDs, permIDs := partitionByWispSet(ids, wispSet)
 
 	var allIssues []*types.Issue
 	for _, pair := range []struct {
@@ -335,7 +340,7 @@ func GetDependenciesWithMetadataInTx(ctx context.Context, tx *sql.Tx, issueID st
 	for i, d := range deps {
 		ids[i] = d.depID
 	}
-	issues, err := GetIssuesByIDsInTx(ctx, tx, ids)
+	issues, err := GetIssuesByIDsInTx(ctx, tx, ids, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get dependencies: fetch issues: %w", err)
 	}
@@ -398,7 +403,7 @@ func GetDependentsWithMetadataInTx(ctx context.Context, tx *sql.Tx, issueID stri
 	for i, d := range deps {
 		ids[i] = d.depID
 	}
-	issues, err := GetIssuesByIDsInTx(ctx, tx, ids)
+	issues, err := GetIssuesByIDsInTx(ctx, tx, ids, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get dependents: fetch issues: %w", err)
 	}
@@ -451,7 +456,7 @@ func GetDependenciesInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*ty
 		return nil, nil
 	}
 
-	return GetIssuesByIDsInTx(ctx, tx, ids)
+	return GetIssuesByIDsInTx(ctx, tx, ids, nil)
 }
 
 // GetDependentsInTx returns issues that depend on the given issueID.
@@ -484,5 +489,5 @@ func GetDependentsInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*type
 		return nil, nil
 	}
 
-	return GetIssuesByIDsInTx(ctx, tx, ids)
+	return GetIssuesByIDsInTx(ctx, tx, ids, nil)
 }

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -201,9 +201,11 @@ func RemoveDependencyInTx(ctx context.Context, tx *sql.Tx, issueID, dependsOnID 
 // transaction, including labels. Automatically routes each ID to the correct
 // table (issues/wisps). Uses batched IN clauses.
 //
-// wispSet is an optional pre-built set of active wisp IDs (see WispIDSetInTx).
-// Pass nil to have the helper build the set once internally; callers hydrating
-// multiple batches inside one tx can build it up-front and reuse.
+// wispSet is an optional pre-built set of active wisp IDs scoped to
+// cover ids (see WispIDSetInTx). Pass nil to have the helper build
+// a scoped set internally; callers hydrating multiple batches inside
+// one tx can build the set once over the union of their IDs and
+// reuse it across calls.
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func GetIssuesByIDsInTx(ctx context.Context, tx *sql.Tx, ids []string, wispSet map[string]struct{}) ([]*types.Issue, error) {
@@ -213,7 +215,7 @@ func GetIssuesByIDsInTx(ctx context.Context, tx *sql.Tx, ids []string, wispSet m
 
 	if wispSet == nil {
 		var err error
-		wispSet, err = WispIDSetInTx(ctx, tx)
+		wispSet, err = WispIDSetInTx(ctx, tx, ids)
 		if err != nil {
 			return nil, fmt.Errorf("get issues by IDs: build wisp set: %w", err)
 		}

--- a/internal/storage/issueops/epic_closure.go
+++ b/internal/storage/issueops/epic_closure.go
@@ -115,7 +115,7 @@ func GetEpicsEligibleForClosureInTx(ctx context.Context, tx *sql.Tx) ([]*types.E
 			epicsWithChildren = append(epicsWithChildren, epicID)
 		}
 	}
-	epicIssues, err := GetIssuesByIDsInTx(ctx, tx, epicsWithChildren)
+	epicIssues, err := GetIssuesByIDsInTx(ctx, tx, epicsWithChildren, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to batch-fetch epic issues: %w", err)
 	}

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -39,11 +39,11 @@ func GetLabelsInTx(ctx context.Context, tx *sql.Tx, table, issueID string) ([]st
 // Routes each ID to labels or wisp_labels based on wisp status.
 // Uses batched IN clauses (queryBatchSize) to avoid query-planner spikes.
 //
-// wispSet is an optional pre-built set of active wisp IDs (see WispIDSetInTx).
-// Pass nil to have the helper build the set once internally; callers hydrating
-// multiple batches inside one tx can build it up-front and reuse. Either way,
-// routing is consistent for the tx's lifetime (Dolt MVCC) and a wisp created
-// in another connection after the set is built will NOT be visible to this tx.
+// wispSet is an optional pre-built set of active wisp IDs scoped to
+// cover issueIDs (see WispIDSetInTx). Pass nil to have the helper build
+// a scoped set internally; callers hydrating multiple batches inside
+// one tx can build the set once over the union of their IDs and
+// reuse it across calls.
 func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string, wispSet map[string]struct{}) (map[string][]string, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string][]string), nil
@@ -51,7 +51,7 @@ func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string, 
 
 	if wispSet == nil {
 		var err error
-		wispSet, err = WispIDSetInTx(ctx, tx)
+		wispSet, err = WispIDSetInTx(ctx, tx, issueIDs)
 		if err != nil {
 			return nil, fmt.Errorf("get labels for issues: build wisp set: %w", err)
 		}

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -38,21 +38,28 @@ func GetLabelsInTx(ctx context.Context, tx *sql.Tx, table, issueID string) ([]st
 // GetLabelsForIssuesInTx fetches labels for multiple issues in a single transaction.
 // Routes each ID to labels or wisp_labels based on wisp status.
 // Uses batched IN clauses (queryBatchSize) to avoid query-planner spikes.
-func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (map[string][]string, error) {
+//
+// wispSet is an optional pre-built set of active wisp IDs (see WispIDSetInTx).
+// Pass nil to have the helper build the set once internally; callers hydrating
+// multiple batches inside one tx can build it up-front and reuse. Either way,
+// routing is consistent for the tx's lifetime (Dolt MVCC) and a wisp created
+// in another connection after the set is built will NOT be visible to this tx.
+func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string, wispSet map[string]struct{}) (map[string][]string, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string][]string), nil
 	}
 
-	result := make(map[string][]string)
-
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
+	if wispSet == nil {
+		var err error
+		wispSet, err = WispIDSetInTx(ctx, tx)
+		if err != nil {
+			return nil, fmt.Errorf("get labels for issues: build wisp set: %w", err)
 		}
 	}
+
+	result := make(map[string][]string)
+
+	wispIDs, permIDs := partitionByWispSet(issueIDs, wispSet)
 
 	for _, pair := range []struct {
 		table string

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -200,7 +200,7 @@ func GetReadyWorkInTx(
 	}
 
 	// Batch-fetch full issues preserving order.
-	issues, err := GetIssuesByIDsInTx(ctx, tx, issueIDs)
+	issues, err := GetIssuesByIDsInTx(ctx, tx, issueIDs, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get ready work: fetch issues: %w", err)
 	}

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -100,7 +100,7 @@ func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 		for i, issue := range issues {
 			ids[i] = issue.ID
 		}
-		labelMap, labelErr := GetLabelsForIssuesInTx(ctx, tx, ids)
+		labelMap, labelErr := GetLabelsForIssuesInTx(ctx, tx, ids, nil)
 		if labelErr != nil {
 			return nil, fmt.Errorf("search %s: hydrate labels: %w", tables.Main, labelErr)
 		}

--- a/internal/storage/issueops/stale.go
+++ b/internal/storage/issueops/stale.go
@@ -68,7 +68,7 @@ func GetStaleIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.StaleFilte
 
 	// GetIssuesByIDsInTx returns issues in arbitrary order (WHERE IN),
 	// so re-order to preserve the updated_at ASC ordering from the query.
-	issues, err := GetIssuesByIDsInTx(ctx, tx, ids)
+	issues, err := GetIssuesByIDsInTx(ctx, tx, ids, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 // IsActiveWispInTx checks whether the given ID exists in the wisps table
@@ -11,36 +12,60 @@ import (
 // This handles both auto-generated wisp IDs (containing "-wisp-") and
 // ephemeral issues created with explicit IDs that were routed to wisps.
 //
-// For hot-path callers that partition a batch of IDs by wisp status, prefer
-// WispIDSetInTx + map lookup to amortize the per-ID query cost.
+// For hot-path callers that partition a batch of IDs by wisp status,
+// prefer WispIDSetInTx + partitionByWispSet to amortize the per-ID
+// query cost into a single scoped query over the batch.
 func IsActiveWispInTx(ctx context.Context, tx *sql.Tx, id string) bool {
 	var exists int
 	err := tx.QueryRowContext(ctx, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1", id).Scan(&exists)
 	return err == nil
 }
 
-// WispIDSetInTx returns the set of all currently-active wisp IDs for the tx.
-// The set is consistent for the tx's lifetime (Dolt MVCC). Intended for
-// hot-path partitioning where a batch of IDs must be split into
-// wisps vs permanents; one query amortized over the batch replaces N
-// per-ID IsActiveWispInTx calls.
-func WispIDSetInTx(ctx context.Context, tx *sql.Tx) (map[string]struct{}, error) {
-	rows, err := tx.QueryContext(ctx, "SELECT id FROM wisps")
-	if err != nil {
-		return nil, fmt.Errorf("wisp id set: %w", err)
-	}
-	defer rows.Close()
-
+// WispIDSetInTx returns the subset of ids that are currently-active wisps
+// within the tx. The set is consistent for the tx's lifetime (Dolt MVCC).
+// Intended for hot-path partitioning where a batch of IDs must be split
+// into wisps vs permanents; one scoped query amortized over the batch
+// replaces N per-ID IsActiveWispInTx calls without paying for a full
+// wisps-table scan when callers have a small batch against a large
+// wisps table.
+//
+// Returns an empty set when ids is empty; never issues a query.
+//
+//nolint:gosec // G201: query uses placeholder-only interpolation
+func WispIDSetInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]struct{}, error) {
 	set := make(map[string]struct{})
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("wisp id set: scan: %w", err)
-		}
-		set[id] = struct{}{}
+	if len(ids) == 0 {
+		return set, nil
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("wisp id set: rows: %w", err)
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		q := fmt.Sprintf("SELECT id FROM wisps WHERE id IN (%s)", strings.Join(placeholders, ","))
+		rows, err := tx.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("wisp id set: %w", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("wisp id set: scan: %w", err)
+			}
+			set[id] = struct{}{}
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("wisp id set: rows: %w", err)
+		}
 	}
 	return set, nil
 }

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -3,16 +3,60 @@ package issueops
 import (
 	"context"
 	"database/sql"
+	"fmt"
 )
 
 // IsActiveWispInTx checks whether the given ID exists in the wisps table
 // within an existing transaction. Returns true if the ID is found.
 // This handles both auto-generated wisp IDs (containing "-wisp-") and
 // ephemeral issues created with explicit IDs that were routed to wisps.
+//
+// For hot-path callers that partition a batch of IDs by wisp status, prefer
+// WispIDSetInTx + map lookup to amortize the per-ID query cost.
 func IsActiveWispInTx(ctx context.Context, tx *sql.Tx, id string) bool {
 	var exists int
 	err := tx.QueryRowContext(ctx, "SELECT 1 FROM wisps WHERE id = ? LIMIT 1", id).Scan(&exists)
 	return err == nil
+}
+
+// WispIDSetInTx returns the set of all currently-active wisp IDs for the tx.
+// The set is consistent for the tx's lifetime (Dolt MVCC). Intended for
+// hot-path partitioning where a batch of IDs must be split into
+// wisps vs permanents; one query amortized over the batch replaces N
+// per-ID IsActiveWispInTx calls.
+func WispIDSetInTx(ctx context.Context, tx *sql.Tx) (map[string]struct{}, error) {
+	rows, err := tx.QueryContext(ctx, "SELECT id FROM wisps")
+	if err != nil {
+		return nil, fmt.Errorf("wisp id set: %w", err)
+	}
+	defer rows.Close()
+
+	set := make(map[string]struct{})
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("wisp id set: scan: %w", err)
+		}
+		set[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("wisp id set: rows: %w", err)
+	}
+	return set, nil
+}
+
+// partitionByWispSet splits ids into (wispIDs, permIDs) using the provided
+// wisp-id set. If wispSet is nil the caller must populate it first via
+// WispIDSetInTx; this helper does no I/O.
+func partitionByWispSet(ids []string, wispSet map[string]struct{}) (wispIDs, permIDs []string) {
+	for _, id := range ids {
+		if _, isWisp := wispSet[id]; isWisp {
+			wispIDs = append(wispIDs, id)
+		} else {
+			permIDs = append(permIDs, id)
+		}
+	}
+	return wispIDs, permIDs
 }
 
 // WispTableRouting returns the appropriate issue, label, event, and dependency

--- a/internal/storage/issueops/wisp_routing_test.go
+++ b/internal/storage/issueops/wisp_routing_test.go
@@ -1,6 +1,7 @@
 package issueops
 
 import (
+	"context"
 	"reflect"
 	"testing"
 )
@@ -67,5 +68,19 @@ func TestPartitionByWispSet(t *testing.T) {
 				t.Errorf("permIDs: got %v, want %v", gotPerms, tc.wantPerms)
 			}
 		})
+	}
+}
+
+func TestWispIDSetInTx_EmptyIDsNoQuery(t *testing.T) {
+	t.Parallel()
+	set, err := WispIDSetInTx(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("WispIDSetInTx(nil, nil): %v", err)
+	}
+	if set == nil {
+		t.Fatalf("expected non-nil empty map, got nil")
+	}
+	if len(set) != 0 {
+		t.Fatalf("expected empty map, got %v", set)
 	}
 }

--- a/internal/storage/issueops/wisp_routing_test.go
+++ b/internal/storage/issueops/wisp_routing_test.go
@@ -1,0 +1,71 @@
+package issueops
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPartitionByWispSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wispSet   map[string]struct{}
+		wantWisps []string
+		wantPerms []string
+	}{
+		{
+			name:    "all permanent",
+			ids:     []string{"be-1", "be-2", "be-3"},
+			wispSet: map[string]struct{}{},
+			// wantWisps nil — no entries appended
+			wantPerms: []string{"be-1", "be-2", "be-3"},
+		},
+		{
+			name:      "all wisps",
+			ids:       []string{"be-wisp-a", "be-wisp-b"},
+			wispSet:   map[string]struct{}{"be-wisp-a": {}, "be-wisp-b": {}},
+			wantWisps: []string{"be-wisp-a", "be-wisp-b"},
+			// wantPerms nil
+		},
+		{
+			name:      "mixed",
+			ids:       []string{"be-1", "be-wisp-a", "be-2", "be-wisp-b", "be-3"},
+			wispSet:   map[string]struct{}{"be-wisp-a": {}, "be-wisp-b": {}},
+			wantWisps: []string{"be-wisp-a", "be-wisp-b"},
+			wantPerms: []string{"be-1", "be-2", "be-3"},
+		},
+		{
+			name: "empty input",
+			ids:  nil,
+			// wantWisps nil, wantPerms nil
+			wispSet: map[string]struct{}{"be-wisp-a": {}},
+		},
+		{
+			name:      "nil wisp set treats all as permanent",
+			ids:       []string{"be-1", "be-wisp-a"},
+			wispSet:   nil,
+			wantPerms: []string{"be-1", "be-wisp-a"},
+		},
+		{
+			name:      "explicit-id wisp routes as wisp",
+			ids:       []string{"custom-id-42"},
+			wispSet:   map[string]struct{}{"custom-id-42": {}},
+			wantWisps: []string{"custom-id-42"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotWisps, gotPerms := partitionByWispSet(tc.ids, tc.wispSet)
+			if !reflect.DeepEqual(gotWisps, tc.wantWisps) {
+				t.Errorf("wispIDs: got %v, want %v", gotWisps, tc.wantWisps)
+			}
+			if !reflect.DeepEqual(gotPerms, tc.wantPerms) {
+				t.Errorf("permIDs: got %v, want %v", gotPerms, tc.wantPerms)
+			}
+		})
+	}
+}

--- a/release-gates/be-eqw-gate.md
+++ b/release-gates/be-eqw-gate.md
@@ -1,0 +1,62 @@
+# Release gate — be-eqw (WispIDSetInTx amortized wisp routing)
+
+- **Bead:** be-eqw (review bead for build be-nu4.2.1 / ADR be-nu4 §4.D2)
+- **Commit shipped:** 12ab3647 (cherry-pick of 61cfc45c from gc-builder-e35c0415a93c)
+- **Branch:** `release/be-eqw` off `origin/main`
+- **Evaluated:** 2026-04-23 by beads/deployer
+
+## Scope note
+
+The builder worktree `gc-builder-e35c0415a93c` carries two commits on top of
+`origin/main`:
+
+- `61cfc45c` — D2 build (be-nu4.2.1, reviewed PASS as be-eqw) — **shipped**
+- `5023e0e1` — D3 build (be-nu4.3.2, review be-3ht still open) — **excluded**
+
+This PR cuts a clean branch off `origin/main` with only the D2 commit, so the
+un-reviewed D3 change does not ride along.
+
+## Gate criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | **PASS** | reviewer-1 recorded `Verdict: PASS` in be-eqw notes (single-pass; gemini second-pass currently disabled). Findings F1 (medium scope-completeness), F2 (low benchmark-numbers) are advisory/follow-up, not blockers. |
+| 2 | Acceptance criteria met | **PASS** | Reviewer trace table: hot-path callers make one wisp-id query per invocation ✓; mixed-ID routing hard gate ✓; `IsActiveWispInTx` retained for single-ID paths ✓; benchmark code at 1K/10K/50K with ≥25% wisp share ✓; no correlated EXISTS / recursive CTEs / UNION ALL ✓. Full-audit gap tracked as explicit follow-up (see §F1 below). |
+| 3 | Tests pass | **PASS** | See "Tests run on release branch" below. |
+| 4 | No high-severity review findings open | **PASS** | 0 HIGH findings. F1=medium, F2=low. |
+| 5 | Final branch is clean | **PASS** | `git status` on `release/be-eqw` shows nothing except worktree-scaffolding untracked paths (`.gc/`, `.gitkeep`) that are never staged. |
+| 6 | Branch diverges cleanly from main | **PASS** | Branch cut fresh from `origin/main` via `git checkout -B release/be-eqw origin/main`; `git cherry-pick 61cfc45c` applied with zero conflicts. |
+
+## Tests run on release branch
+
+| Test | Result | Notes |
+|------|--------|-------|
+| `go build ./...` | PASS | Go 1.26.2 via `GOTOOLCHAIN=auto`. |
+| `go vet ./...` | clean | No output. |
+| `gofmt -l` on 6 changed files | clean | No output. |
+| `TestPartitionByWispSet` (pure-fn, authoritative gate per design bead) | PASS 0.006s | 6 subcases: all_permanent, all_wisps, mixed, empty_input, nil_wisp_set_treats_all_as_permanent, explicit-id_wisp_routes_as_wisp. |
+| `TestWispIDSetInTx_HardGate` + `TestWispIDSetInTx_Empty` (Dolt testcontainer, `TESTCONTAINERS_RYUK_DISABLED=true`) | PASS 2.94s | Container flakiness builder reported did not reproduce on deployer pass; matches reviewer's observation. |
+| `go test ./internal/storage/issueops/... ./internal/types/... ./internal/ui/...` | PASS | All container-free packages clean. |
+
+## Findings tracked from review
+
+**F1 (medium, scope-completeness — advisory):** Reviewer identified three
+additional N-per-ID `IsActiveWispInTx` hot loops the builder did not flag
+(`DeleteIssuesInTx`, `GetCommentCountsInTx`, `GetCommentsForIssuesInTx`) on
+top of the two already flagged (`GetDependencyRecordsForIssuesInTx`,
+`GetBlockingInfoForIssuesInTx`). Design bead be-nu4.2.1 scoped work to the
+two named sites, so the build is correct as-delivered; a consolidated
+follow-up bead covering all five remaining sites must exist before the
+be-nu4 epic closes. Not a release blocker.
+
+**F2 (low, benchmark numbers not captured — advisory):** Benchmark code
+ships and compiles; runtime 1K/10K/50K numbers were not captured because
+the Dolt server / testcontainer environment is flaky in both the builder
+and reviewer sandboxes (Docker 29.4 + ryuk 0.13.0). Release-gate decision:
+defer numeric capture to a clean CI environment; code-level deliverable
+(the benchmarks exist) is satisfied per ADR §11.2.
+
+## Verdict
+
+**PASS** — push to `fork` (origin is locked for quad341; `fork =
+quad341/beads`), open PR against `gastownhall/beads:main`.


### PR DESCRIPTION
## What this changes

The batch label/issue hydration paths (`GetLabelsForIssuesInTx`,
`GetIssuesByIDsInTx`) previously ran `IsActiveWispInTx` once per input ID
to decide whether each ID routed to the `wisps` table or the permanent
tables. That's N round-trips to answer "is this a wisp?" before any
actual hydration could run.

This PR collapses that to a single `SELECT id FROM wisps` per transaction
via a new `WispIDSetInTx` helper. Callers that already know the wisp set
can pass it in and reuse it across calls; callers that don't (every
current site) pass `nil` and the helpers build the set internally. The
set is MVCC-consistent for the transaction's lifetime, which is the
correctness invariant Dolt already gives us — documented on
`GetLabelsForIssuesInTx`.

`IsActiveWispInTx` is retained unchanged for the ~21 single-ID call
sites (claim, close, single-ID comments, events, etc.); those still do
one round-trip per call, which is what they'd do anyway.

## Review notes

- **New helper surface:** `internal/storage/issueops/wisp_routing.go` —
  `WispIDSetInTx` (new) + `partitionByWispSet` (pure fn). The helper is
  internal to `issueops`; no storage-interface or CLI shape change.
- **Signature change:** `GetLabelsForIssuesInTx` and
  `GetIssuesByIDsInTx` gain a trailing `wispSet map[string]struct{}`
  parameter. All 13 call sites in `dolt`, `embeddeddolt`, and `issueops`
  migrated to pass `nil`; the nil path preserves today's behavior
  semantically (one wisp-id query up-front instead of N per-ID queries).
- **Behavior when a wisp is created concurrently in another
  connection** mid-transaction: that wisp routes as permanent in the
  current tx and yields an empty lookup. This is documented and matches
  Dolt's MVCC snapshot semantics — flagged explicitly so future
  maintainers don't re-discover it as a bug.
- **What is *not* changed:** `IsActiveWispInTx` itself (still used by
  single-ID paths), and the three other N-per-ID `IsActiveWispInTx`
  loops in `delete.go`, `comments.go`, `bulk_ops.go`, and two in
  `dependency_queries.go`. Those are tracked as a consolidated
  follow-up bead; the scope of this PR is narrower by design.

## Test plan

- [x] `TestPartitionByWispSet` — pure-fn gate, 6 subcases (all permanent /
      all wisps / mixed / empty / nil-set / explicit-id). PASS on release
      branch.
- [x] `TestWispIDSetInTx_HardGate` + `TestWispIDSetInTx_Empty` — Dolt
      testcontainer gates covering mixed-ID routing through both
      refactored helpers (`TESTCONTAINERS_RYUK_DISABLED=true`). PASS on
      release branch.
- [x] `go test ./internal/storage/issueops/... ./internal/types/...
      ./internal/ui/...` on the assembled branch. PASS.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` on 6 changed files.
      All clean.
- [x] Benchmark code compiles at 1K / 10K / 50K with 25% wisp share
      (`BenchmarkGetLabelsForIssues_Mixed`, `BenchmarkGetIssuesByIDs_Mixed`).
      Runtime numbers not captured on this worktree — Dolt testcontainer
      is flaky under Docker 29.4 + ryuk 0.13.0; capture on clean CI.
- [x] Release gate: [`release-gates/be-eqw-gate.md`](release-gates/be-eqw-gate.md).

🤖 Deployed by actual-factory