### PR TITLE
fix(init): refuse --force when remote has Dolt history

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# CODEOWNERS — review ownership
+#
+# Changes under cmd/bd/init*.go interact with init-safety invariants
+# documented in docs/adr/0002-init-safety-invariants.md. Reviewers MUST
+# confirm new flags / data sources extend CheckRemoteSafety's guard
+# matrix (cmd/bd/init_safety_test.go) before approving. Silent guard
+# accretion is how we ended up with 8+ paper-over commits before ADR 0002
+# — the matrix + review gate is the structural hedge.
+
+# Init-safety critical path
+cmd/bd/init.go              @gastownhall/beads-maintainers
+cmd/bd/init_*.go            @gastownhall/beads-maintainers
+cmd/bd/init_safety*.go      @gastownhall/beads-maintainers
+docs/adr/0002-init-safety-invariants.md  @gastownhall/beads-maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`bd init --reinit-local` / `--discard-remote`** — named-intent flags for local re-initialization and explicit remote-history override. Replaces the overloaded `--force`. See [`bd help init-safety`](docs/adr/0002-init-safety-invariants.md) and [`docs/RECOVERY.md`](docs/RECOVERY.md).
+- **`bd init-safety`** — documents the init flag surface + destroy-token format. Referenced by every init refusal message.
+- **Stable exit codes for init refusals** — `10` remote divergence, `11` local exists, `12` destroy-token missing. Grep-safe for CI.
+- **[ADR 0002 — `bd init` safety invariants](docs/adr/0002-init-safety-invariants.md)** — encodes the single-source identity rule, scope-bound `--force`/`--reinit-local`, the `CheckRemoteSafety` chokepoint, the error-text-no-echo rule, and the race-safety invariant.
+- **[`docs/RECOVERY.md`](docs/RECOVERY.md)** — playbooks for each named init refusal.
+- **CODEOWNERS** — `cmd/bd/init*.go` routes review to maintainers with an ADR-linked acknowledgment requirement.
+
+### Changed
+
+- **`bd init --force` semantics narrowed to local-only** — `--force` (or `--reinit-local`) bypasses only the LOCAL data-safety guard. It does NOT authorize silent divergence of remote history. When origin has `refs/dolt/data`, `bd init --force` now refuses with exit code 10 unless `--discard-remote` is also passed. Fixes the long-standing footgun where `bd init --force` in a repo with remote Dolt history silently set up an orphan branch that failed to push.
+- **Init refusal messages follow What/Why/Next structure** — runtime error text no longer echoes copy-pasteable destructive invocations. Token values and exact override commands live in `bd help init-safety` and `docs/RECOVERY.md` only. Closes the failure class where an AI agent destroyed 247 issues by pattern-matching on the tool's own error output (`58f5989bf`).
+
+### Deprecated
+
+- **`bd init --force`** — deprecated alias for `--reinit-local`. Continues to work for ≥2 releases, emits a `DeprecationWarning`, routes internally to `--reinit-local`. Use `--reinit-local` going forward. CI and scripts are unaffected for the duration of the deprecation window.
+
 ## [1.0.2] - 2026-04-15
 
 ### Fixed

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -139,8 +139,8 @@ Examples:
 			// flow. Actual directory creation is deferred to executeSyncAction
 			// to preserve --dry-run semantics.
 			if isGitRepo() && !isBareGitRepo() {
-				if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
-					if gitLsRemoteHasRef("origin", "refs/dolt/data") {
+				if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
+					if gitOriginHasDoltDataRef() {
 						if fallbackDir := beads.GetWorktreeFallbackBeadsDir(); fallbackDir != "" {
 							beadsDir = fallbackDir
 						} else {
@@ -259,8 +259,8 @@ func detectBootstrapAction(beadsDir string, cfg *configfile.Config) BootstrapPla
 	// (refs/dolt/data). This only applies to git remotes — Dolt-native
 	// remotes (DoltHub, S3, etc.) must be configured via sync.remote.
 	if isGitRepo() && !isBareGitRepo() {
-		if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
-			if gitLsRemoteHasRef("origin", "refs/dolt/data") {
+		if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
+			if gitOriginHasDoltDataRef() {
 				plan.SyncRemote = normalizeRemoteURL(originURL)
 				plan.Action = "sync"
 				plan.Reason = "Found Dolt data on git origin (refs/dolt/data) — will clone from " + originURL

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -293,7 +293,7 @@ func TestDetectBootstrapAction_SyncWhenOriginHasDoltRef(t *testing.T) {
 	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
 	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
 	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
-	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
 	// Create refs/dolt/data by pushing HEAD to that ref
 	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
 
@@ -390,7 +390,7 @@ func TestBootstrapFreshCloneDetectsRemote(t *testing.T) {
 	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
 	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
 	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
-	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
 	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
 
 	// Clone into a fresh directory — no .beads exists.
@@ -420,11 +420,11 @@ func TestBootstrapFreshCloneDetectsRemote(t *testing.T) {
 	if !isGitRepo() {
 		t.Fatal("expected to be in a git repo")
 	}
-	originURL, err := gitRemoteGetURL("origin")
+	originURL, err := gitOriginGetURL()
 	if err != nil || originURL == "" {
 		t.Fatalf("expected origin URL, got err=%v url=%q", err, originURL)
 	}
-	if !gitLsRemoteHasRef("origin", "refs/dolt/data") {
+	if !gitOriginHasDoltDataRef() {
 		t.Fatal("expected origin to have refs/dolt/data")
 	}
 
@@ -474,7 +474,7 @@ func TestBootstrapFreshCloneNoRemoteData(t *testing.T) {
 	if !isGitRepo() {
 		t.Fatal("expected to be in a git repo")
 	}
-	if gitLsRemoteHasRef("origin", "refs/dolt/data") {
+	if gitOriginHasDoltDataRef() {
 		t.Fatal("origin should NOT have refs/dolt/data")
 	}
 
@@ -783,7 +783,7 @@ func TestBootstrapFreshCloneSynthesizedDirUsesDefaultDB(t *testing.T) {
 	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
 	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
 	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
-	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
 	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
 
 	// Clone — no .beads dir
@@ -865,7 +865,7 @@ func TestBootstrapRigSubdirUsesParentDBName(t *testing.T) {
 	runGitForBootstrapTest(t, rigDir, "config", "user.name", "Test User")
 	runGitForBootstrapTest(t, rigDir, "commit", "--allow-empty", "-m", "init")
 	runGitForBootstrapTest(t, rigDir, "remote", "add", "origin", bareDir)
-	runGitForBootstrapTest(t, rigDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, rigDir, "push", "origin", "HEAD:refs/dolt/data")
 	runGitForBootstrapTest(t, rigDir, "push", "origin", "HEAD:refs/dolt/data")
 
 	oldWd, err := os.Getwd()

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -307,9 +307,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				earlySyncURL = normalizeRemoteURL(s)
 				earlyRemoteHasDoltData = true // sync.remote configured = user intends bootstrap
 			} else if isGitRepo() && !isBareGitRepo() {
-				if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
+				if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 					earlySyncURL = normalizeRemoteURL(originURL)
-					earlyRemoteHasDoltData = gitLsRemoteHasRef("origin", "refs/dolt/data")
+					earlyRemoteHasDoltData = gitOriginHasDoltDataRef()
 				}
 			}
 			if earlySyncURL != "" {
@@ -571,9 +571,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			syncURL = normalizeRemoteURL(syncURL)
 			syncFromRemote = true
 		} else if isGitRepo() && !isBareGitRepo() {
-			if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
+			if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 				syncURL = normalizeRemoteURL(originURL)
-				remoteHasDoltData = gitLsRemoteHasRef("origin", "refs/dolt/data")
+				remoteHasDoltData = gitOriginHasDoltDataRef()
 
 				decision := CheckRemoteSafety(RemoteSafetyInput{
 					Force:             force,
@@ -607,11 +607,11 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 						}
 					}
 					// Race-safety: re-verify the remote state hasn't
-					// changed between our earlier gitLsRemoteHasRef and
+					// changed between our earlier gitOriginHasDoltDataRef and
 					// the user's confirmation. If another agent pushed
 					// during the prompt window, fail rather than silently
 					// overwriting their fresh work.
-					if gitLsRemoteHasRef("origin", "refs/dolt/data") != remoteHasDoltData {
+					if gitOriginHasDoltDataRef() != remoteHasDoltData {
 						fmt.Fprintf(os.Stderr, "\nAborted: remote state changed during confirmation. Re-run to re-verify intent.\n")
 						os.Exit(ExitRemoteDivergenceRefused)
 					}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -74,6 +74,8 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		skipHooks, _ := cmd.Flags().GetBool("skip-hooks")
 		skipAgents, _ := cmd.Flags().GetBool("skip-agents")
 		force, _ := cmd.Flags().GetBool("force")
+		reinitLocal, _ := cmd.Flags().GetBool("reinit-local")
+		discardRemote, _ := cmd.Flags().GetBool("discard-remote")
 		nonInteractiveFlag, _ := cmd.Flags().GetBool("non-interactive")
 		roleFlag, _ := cmd.Flags().GetString("role")
 		fromJSONL, _ := cmd.Flags().GetBool("from-jsonl")
@@ -86,6 +88,16 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		serverUser, _ := cmd.Flags().GetString("server-user")
 		database, _ := cmd.Flags().GetString("database")
 		destroyToken, _ := cmd.Flags().GetString("destroy-token")
+
+		// --force is a deprecated alias for --reinit-local. They share
+		// semantics for the local data-safety guard; both refuse remote
+		// divergence unless --discard-remote is also passed. See
+		// docs/adr/0002-init-safety-invariants.md.
+		if force && !reinitLocal {
+			fmt.Fprintf(os.Stderr, "%s --force is deprecated; use --reinit-local instead.\n", ui.RenderWarn("DeprecationWarning:"))
+			fmt.Fprintf(os.Stderr, "  See 'bd help init-safety' for the init flag surface.\n\n")
+			reinitLocal = true
+		}
 		sharedServer, _ := cmd.Flags().GetBool("shared-server")
 		externalServer, _ := cmd.Flags().GetBool("external")
 
@@ -179,19 +191,22 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Non-fatal - continue with defaults
 		}
 
-		// Safety guard: check for existing beads data
-		// This prevents accidental re-initialization
-		if !force {
+		// Safety guard: check for existing beads data.
+		// This prevents accidental re-initialization. --force and
+		// --reinit-local both bypass this local-only guard; they do NOT
+		// authorize cross-boundary operations on remote history (see
+		// CheckRemoteSafety at cmd/bd/init_safety.go and
+		// docs/adr/0002-init-safety-invariants.md).
+		if !reinitLocal {
 			if err := checkExistingBeadsData(prefix); err != nil {
 				FatalError("%v", err)
 			}
 		}
 
-		// Even with --force, warn about existing data and require confirmation.
-		// In non-interactive mode, accepts --destroy-token for explicit opt-in,
-		// or --quiet for legacy (deprecated) bypass.
-		// This prevents AI agents and users from accidentally destroying data.
-		if force {
+		// Even with --reinit-local, warn about existing data and require
+		// confirmation. Non-interactive mode accepts --destroy-token for
+		// explicit opt-in; interactive mode prompts for typed confirmation.
+		if reinitLocal {
 			if count, err := countExistingIssues(prefix); err == nil && count > 0 {
 				fmt.Fprintf(os.Stderr, "\n%s Re-initializing will destroy the existing database.\n\n", ui.RenderWarn("WARNING:"))
 				fmt.Fprintf(os.Stderr, "  Existing issues: %d\n\n", count)
@@ -207,18 +222,24 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					expected := fmt.Sprintf("destroy %d issues", count)
 					if strings.TrimSpace(scanner.Text()) != expected {
 						fmt.Fprintf(os.Stderr, "\nAborted. Database was NOT modified.\n")
-						os.Exit(1)
+						os.Exit(ExitLocalExistsRefused)
 					}
 				} else {
 					// Non-interactive (piped input, AI agent, etc.)
-					expectedToken := fmt.Sprintf("DESTROY-%s", prefix)
+					//
+					// ADR invariant (docs/adr/0002-init-safety-invariants.md):
+					// runtime error text must not echo a complete destructive
+					// invocation. See 'bd help init-safety' for the token
+					// format. This closes the 58f5989bf failure class where
+					// an agent copy-pasted the suggested command.
+					expectedToken := FormatDestroyToken(prefix)
 					if destroyToken == expectedToken {
 						fmt.Fprintf(os.Stderr, "Destroy token accepted. Proceeding with re-initialization.\n")
 					} else {
 						fmt.Fprintf(os.Stderr, "Refusing to destroy %d issues in non-interactive mode.\n", count)
-						fmt.Fprintf(os.Stderr, "To proceed, use: bd init --force --destroy-token=%s\n", expectedToken)
-						fmt.Fprintf(os.Stderr, "Or export first: bd export > backup.jsonl\n")
-						os.Exit(1)
+						fmt.Fprintf(os.Stderr, "  See 'bd help init-safety' for the required --destroy-token format.\n")
+						fmt.Fprintf(os.Stderr, "  Or export first: bd export > backup.jsonl\n")
+						os.Exit(ExitDestroyTokenMissing)
 					}
 				}
 			}
@@ -273,6 +294,39 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// MySQL identifiers must start with a letter or underscore.
 		if len(prefix) > 0 && !((prefix[0] >= 'a' && prefix[0] <= 'z') || (prefix[0] >= 'A' && prefix[0] <= 'Z') || prefix[0] == '_') {
 			prefix = "bd_" + prefix
+		}
+
+		// Cross-boundary safety (bd-q83 / ADR 0002): check remote state
+		// BEFORE any filesystem side-effects so a refusal exits cleanly.
+		// We only refuse here; bootstrap decisions happen later once
+		// beadsDir is computed. See CheckRemoteSafety in init_safety.go.
+		{
+			var earlySyncURL string
+			earlyRemoteHasDoltData := false
+			if s := resolveSyncRemote(); s != "" {
+				earlySyncURL = normalizeRemoteURL(s)
+				earlyRemoteHasDoltData = true // sync.remote configured = user intends bootstrap
+			} else if isGitRepo() && !isBareGitRepo() {
+				if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
+					earlySyncURL = normalizeRemoteURL(originURL)
+					earlyRemoteHasDoltData = gitLsRemoteHasRef("origin", "refs/dolt/data")
+				}
+			}
+			if earlySyncURL != "" {
+				earlyDecision := CheckRemoteSafety(RemoteSafetyInput{
+					Force:             force,
+					ReinitLocal:       reinitLocal,
+					DiscardRemote:     discardRemote,
+					DestroyToken:      destroyToken,
+					ExpectedToken:     FormatDestroyToken(prefix),
+					RemoteHasDoltData: earlyRemoteHasDoltData,
+					IsInteractive:     term.IsTerminal(int(os.Stdin.Fd())),
+				})
+				if earlyDecision.Action == ActionRefuseDivergence || earlyDecision.Action == ActionRequireDestroyToken {
+					fmt.Fprintf(os.Stderr, "\n%s\n\n", earlyDecision.UserMessage)
+					os.Exit(earlyDecision.ExitCode)
+				}
+			}
 		}
 
 		// Determine beadsDir first (used for all storage path calculations).
@@ -493,23 +547,78 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
-		// Auto-bootstrap from git remote if sync.git-remote is configured
-		// or origin has refs/dolt/data. This makes bd init and bd bootstrap
 		// Auto-bootstrap from remote if sync.remote (or deprecated
 		// sync.git-remote) is configured, or git origin has Dolt data
 		// (refs/dolt/data). This makes bd init and bd bootstrap
 		// interchangeable — both clone from the remote when one exists.
+		//
+		// Cross-boundary safety (bd-q83 / ADR 0002): when the caller
+		// passes --force or --reinit-local and the remote already has
+		// refs/dolt/data, we must refuse — the new local identity would
+		// orphan-push over the team's history on first write. The
+		// CheckRemoteSafety chokepoint encodes this invariant; any future
+		// flag that can interact with remote history must route through
+		// it rather than adding another `&& !someFlag` here.
 		syncURL := resolveSyncRemote()
 		bootstrappedFromRemote := false
 		syncFromRemote := false
+		remoteHasDoltData := false
+
 		if syncURL != "" {
+			// sync.remote was explicitly configured. Treat as bootstrap-
+			// from-remote intent; CheckRemoteSafety still enforces that
+			// --force/--reinit-local can't silently fight that intent.
 			syncURL = normalizeRemoteURL(syncURL)
 			syncFromRemote = true
 		} else if isGitRepo() && !isBareGitRepo() {
 			if originURL, err := gitRemoteGetURL("origin"); err == nil && originURL != "" {
 				syncURL = normalizeRemoteURL(originURL)
-				if !force && gitLsRemoteHasRef("origin", "refs/dolt/data") {
+				remoteHasDoltData = gitLsRemoteHasRef("origin", "refs/dolt/data")
+
+				decision := CheckRemoteSafety(RemoteSafetyInput{
+					Force:             force,
+					ReinitLocal:       reinitLocal,
+					DiscardRemote:     discardRemote,
+					DestroyToken:      destroyToken,
+					ExpectedToken:     FormatDestroyToken(prefix),
+					RemoteHasDoltData: remoteHasDoltData,
+					IsInteractive:     term.IsTerminal(int(os.Stdin.Fd())),
+				})
+
+				switch decision.Action {
+				case ActionRefuseDivergence, ActionRequireDestroyToken:
+					fmt.Fprintf(os.Stderr, "\n%s\n\n", decision.UserMessage)
+					os.Exit(decision.ExitCode)
+				case ActionBootstrap:
 					syncFromRemote = true
+				case ActionProceedWithDivergence:
+					// Interactive destroy-token prompt (non-interactive
+					// path already validated by CheckRemoteSafety).
+					if decision.Reason == "authorized-divergence" && term.IsTerminal(int(os.Stdin.Fd())) && destroyToken == "" {
+						expected := FormatDestroyToken(prefix)
+						fmt.Fprintf(os.Stderr, "\n%s You are about to discard the remote's Dolt history.\n\n", ui.RenderWarn("WARNING:"))
+						fmt.Fprintf(os.Stderr, "  Remote: %s\n", syncURL)
+						fmt.Fprintf(os.Stderr, "  Type %q to confirm: ", expected)
+						scanner := bufio.NewScanner(os.Stdin)
+						scanner.Scan()
+						if strings.TrimSpace(scanner.Text()) != expected {
+							fmt.Fprintf(os.Stderr, "\nAborted. See 'bd help init-safety' for details.\n")
+							os.Exit(ExitDestroyTokenMissing)
+						}
+					}
+					// Race-safety: re-verify the remote state hasn't
+					// changed between our earlier gitLsRemoteHasRef and
+					// the user's confirmation. If another agent pushed
+					// during the prompt window, fail rather than silently
+					// overwriting their fresh work.
+					if gitLsRemoteHasRef("origin", "refs/dolt/data") != remoteHasDoltData {
+						fmt.Fprintf(os.Stderr, "\nAborted: remote state changed during confirmation. Re-run to re-verify intent.\n")
+						os.Exit(ExitRemoteDivergenceRefused)
+					}
+					// Proceed without bootstrap; remote will be overwritten on next push.
+					// syncFromRemote stays false.
+				case ActionNoRemoteData:
+					// Fresh remote, no-op for bootstrap decision.
 				}
 			}
 		}
@@ -1270,7 +1379,9 @@ func init() {
 	initCmd.Flags().Bool("setup-exclude", false, "Configure .git/info/exclude to keep beads files local (for forks)")
 	initCmd.Flags().Bool("skip-hooks", false, "Skip git hooks installation")
 	initCmd.Flags().Bool("skip-agents", false, "Skip AGENTS.md and Claude settings generation")
-	initCmd.Flags().Bool("force", false, "Force re-initialization even if database already has issues (may cause data loss)")
+	initCmd.Flags().Bool("force", false, "Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').")
+	initCmd.Flags().Bool("reinit-local", false, "Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.")
+	initCmd.Flags().Bool("discard-remote", false, "Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.")
 	initCmd.Flags().Bool("from-jsonl", false, "Import issues from .beads/issues.jsonl instead of git history")
 	initCmd.Flags().String("destroy-token", "", "Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')")
 	initCmd.Flags().String("agents-template", "", "Path to custom AGENTS.md template (overrides embedded default)")

--- a/cmd/bd/init_safety.go
+++ b/cmd/bd/init_safety.go
@@ -1,0 +1,204 @@
+package main
+
+// Init-safety decision logic.
+//
+// See docs/adr/0002-init-safety-invariants.md for the ADR this encodes.
+// The invariant: every `bd init` resolves `project_id` from exactly one
+// explicitly-named source; ambiguous sources refuse. `--force` (or its
+// replacement `--reinit-local`) bypasses the local data-safety guard only;
+// it never authorizes silent divergence of remote history. When origin
+// advertises `refs/dolt/data`, `bd init` refuses unless the caller
+// authorizes the cross-boundary operation via `--discard-remote` + a
+// destroy-token.
+//
+// Error-message contract: no runtime error may emit a complete destructive
+// invocation. Flag identifiers and safe-tool names are permitted; token
+// values and other friction-bearing arguments live in `bd help init-safety`
+// and `docs/RECOVERY.md` only.
+
+import "fmt"
+
+// Exit codes for init-safety refusals. Stable values so CI scripts can
+// branch on them without grep'ing stderr.
+const (
+	// ExitRemoteDivergenceRefused signals `bd init --force` was called
+	// against a remote that already has `refs/dolt/data`, without
+	// `--discard-remote`. Ambiguous identity source.
+	ExitRemoteDivergenceRefused = 10
+
+	// ExitLocalExistsRefused signals `bd init` was called against a
+	// directory that already has beads data, without `--force` or
+	// `--reinit-local`. The existing local-safety refusal.
+	ExitLocalExistsRefused = 11
+
+	// ExitDestroyTokenMissing signals `--discard-remote` was passed in
+	// non-interactive mode without a valid `--destroy-token`. The caller
+	// must look up the token format via `bd help init-safety`.
+	ExitDestroyTokenMissing = 12
+)
+
+// RemoteSafetyAction names what the init command should do once it has
+// observed the remote state and read the user's flag intent.
+type RemoteSafetyAction int
+
+const (
+	// ActionNoRemoteData — remote has no Dolt data; proceed with a normal
+	// init. Caller does not need to bootstrap.
+	ActionNoRemoteData RemoteSafetyAction = iota
+
+	// ActionBootstrap — remote has Dolt data; caller should clone from it
+	// instead of minting a fresh identity. This is the "adopt" path.
+	ActionBootstrap
+
+	// ActionRefuseDivergence — remote has Dolt data AND caller passed
+	// `--force` or `--reinit-local` without `--discard-remote`. The new
+	// identity would orphan-push over the remote on first write. Refuse
+	// with `ExitRemoteDivergenceRefused`.
+	ActionRefuseDivergence
+
+	// ActionRequireDestroyToken — caller passed `--discard-remote` but
+	// destroy-token validation failed (non-interactive path with no token,
+	// or wrong token). Refuse with `ExitDestroyTokenMissing`. The
+	// interactive path should prompt for confirmation instead.
+	ActionRequireDestroyToken
+
+	// ActionProceedWithDivergence — caller passed `--discard-remote` and
+	// destroy-token is valid (or will be supplied via TTY prompt by the
+	// caller). Skip bootstrap; wire the remote so the caller can
+	// force-push local history on next operation.
+	ActionProceedWithDivergence
+)
+
+// RemoteSafetyInput is the minimal input to CheckRemoteSafety. Pure
+// function; no filesystem, no network, no git. Caller populates flag
+// state and remote-detection state, gets back a decision.
+type RemoteSafetyInput struct {
+	// Flag state. Force is kept as a separate field so callers can route
+	// deprecation warnings at the call site; CheckRemoteSafety treats it
+	// as equivalent to ReinitLocal.
+	Force         bool
+	ReinitLocal   bool
+	DiscardRemote bool
+
+	// Destroy-token supplied on the command line, plus the token the
+	// caller expects (computed from issue prefix). Both are empty when
+	// the caller hasn't computed them yet — ReinitLocal without
+	// DiscardRemote doesn't need a token check.
+	DestroyToken  string
+	ExpectedToken string
+
+	// Observed state.
+	RemoteHasDoltData bool
+
+	// IsInteractive is true when the caller is attached to a TTY.
+	// Interactive callers can prompt for destroy-token confirmation; the
+	// decision returned for interactive callers assumes they will prompt
+	// (so ActionProceedWithDivergence can be returned without a token
+	// match — the caller must do the prompt itself).
+	IsInteractive bool
+}
+
+// RemoteSafetyDecision is the action + human-readable reason. UserMessage
+// is populated for Refuse* actions so the caller can print exactly what
+// the ADR-compliant refusal text says.
+type RemoteSafetyDecision struct {
+	Action      RemoteSafetyAction
+	Reason      string
+	ExitCode    int
+	UserMessage string
+}
+
+// CheckRemoteSafety is the chokepoint the ADR names. Every future flag on
+// `bd init` that can interact with remote history must go through this
+// function — never add a new `&& !someFlag` at the call site. See the
+// guard matrix test in init_safety_test.go.
+func CheckRemoteSafety(in RemoteSafetyInput) RemoteSafetyDecision {
+	// No remote data → no cross-boundary concern. Proceed.
+	if !in.RemoteHasDoltData {
+		return RemoteSafetyDecision{Action: ActionNoRemoteData, Reason: "no-remote-data"}
+	}
+
+	// Any explicit override intent (force / reinit-local / discard-remote)
+	// means the user is not accepting the default bootstrap. DiscardRemote
+	// is treated as override-intent too — naming discard explicitly
+	// implies the user knows the remote has data and wants to replace it.
+	userOverride := in.Force || in.ReinitLocal || in.DiscardRemote
+
+	// Remote has data, user did not override anything. Bootstrap is the
+	// safe adoption path — this is the existing correct behavior.
+	if !userOverride {
+		return RemoteSafetyDecision{Action: ActionBootstrap, Reason: "bootstrap-from-remote"}
+	}
+
+	// User wanted to override but did NOT authorize the cross-boundary
+	// operation. This is the bd-q83 bug in pre-fix code: `--force` without
+	// `--discard-remote`. Refuse with structured message.
+	if !in.DiscardRemote {
+		return RemoteSafetyDecision{
+			Action:      ActionRefuseDivergence,
+			Reason:      "force-without-discard-remote",
+			ExitCode:    ExitRemoteDivergenceRefused,
+			UserMessage: refusalMessageDivergence(),
+		}
+	}
+
+	// User authorized. Interactive callers prompt; non-interactive must
+	// supply a matching destroy-token.
+	if !in.IsInteractive {
+		if in.ExpectedToken == "" || in.DestroyToken != in.ExpectedToken {
+			return RemoteSafetyDecision{
+				Action:      ActionRequireDestroyToken,
+				Reason:      "destroy-token-missing-or-wrong",
+				ExitCode:    ExitDestroyTokenMissing,
+				UserMessage: refusalMessageTokenMissing(),
+			}
+		}
+	}
+
+	return RemoteSafetyDecision{Action: ActionProceedWithDivergence, Reason: "authorized-divergence"}
+}
+
+// refusalMessageDivergence returns the What/Why/Next refusal text for the
+// `--force` / `--reinit-local` without `--discard-remote` case. Deliberately
+// does not echo a complete destructive invocation — the ADR invariant bars
+// runtime error output from constructing a copy-pasteable override.
+func refusalMessageDivergence() string {
+	return `bd init refuses: remote 'origin' already has Dolt history (refs/dolt/data).
+
+  Why: --force / --reinit-local bypasses only the LOCAL data-safety
+       guard. It does not authorize silent divergence of remote history.
+       Proceeding would orphan-push over the team's data on first write.
+
+  Next:
+    Adopt the remote (recommended):
+      bd bootstrap
+
+    Diagnose first:
+      bd doctor
+
+    Overwrite the remote intentionally (destructive):
+      See 'bd help init-safety' for the --discard-remote workflow.`
+}
+
+// refusalMessageTokenMissing returns the What/Why/Next refusal text for
+// the `--discard-remote` + missing/wrong destroy-token case. Deliberately
+// does not echo the token value.
+func refusalMessageTokenMissing() string {
+	return `bd init refuses: --discard-remote requires an explicit destroy-token in non-interactive mode.
+
+  Why: Destructive cross-boundary operations cannot be authorized
+       silently. The token exists so automation has to make a
+       deliberate, project-specific choice.
+
+  Next:
+    See 'bd help init-safety' for the destroy-token format.
+    Or re-run interactively (attached to a TTY) and confirm at the prompt.`
+}
+
+// FormatDestroyToken returns the destroy-token the caller should supply
+// for a given issue prefix. Callers that need to surface this to users
+// should do so via `bd help init-safety` or `docs/RECOVERY.md` — NOT via
+// runtime error text (see the ADR invariant).
+func FormatDestroyToken(prefix string) string {
+	return fmt.Sprintf("DESTROY-%s", prefix)
+}

--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// initSafetyHelpCmd documents the init flag surface and the destroy-token
+// format. Its contents are the authoritative runtime reference for the
+// error-message-no-echo invariant: refusal texts point here rather than
+// constructing copy-pasteable destructive invocations. See
+// docs/adr/0002-init-safety-invariants.md.
+var initSafetyHelpCmd = &cobra.Command{
+	Use:   "init-safety",
+	Short: "Explain bd init flag semantics and the destroy-token format",
+	Long: `bd init flag safety contract.
+
+Every bd init invocation resolves project_id from exactly one explicitly
+named source (local reinit, remote adoption, or a fresh mint). When the
+source is ambiguous, bd init refuses.
+
+FLAG SURFACE
+
+  bd init                       Mint a new identity. Bootstraps from
+                                origin if it has refs/dolt/data.
+
+  bd init --reinit-local        Re-initialize local .beads/ over existing
+                                local data. Does NOT authorize discarding
+                                remote history. If origin has Dolt data
+                                this will refuse — pair with
+                                --discard-remote to override.
+
+  bd init --reinit-local \      Discard the remote's Dolt history and
+      --discard-remote          replace it with the local reinit. First
+                                bd dolt push after this will be a
+                                history-replacing force-push.
+
+  bd init --force               Deprecated alias for --reinit-local.
+                                Kept working for ≥2 releases.
+
+ADOPTING A REMOTE
+
+  If you want to use the remote's existing history, use:
+
+      bd bootstrap
+
+  bd init will automatically suggest this when a remote is detected.
+
+DESTROY-TOKEN (non-interactive only)
+
+  When running with no TTY (CI, agents, piped input), --discard-remote
+  requires an explicit --destroy-token value. The token format is:
+
+      DESTROY-<issue-prefix>
+
+  For example, if your issue prefix is "bd", the token is "DESTROY-bd":
+
+      bd init --reinit-local --discard-remote --destroy-token=DESTROY-bd
+
+  In interactive (TTY) mode you confirm via a typed prompt instead. The
+  token is not echoed by bd's runtime error messages — this is a
+  deliberate guard against pattern-matched one-liners (see
+  docs/adr/0002-init-safety-invariants.md).
+
+EXIT CODES
+
+  10    refused: remote has Dolt history and you passed --force/--reinit-local
+        without --discard-remote
+  11    refused: existing local data and you declined the destroy confirm
+  12    refused: --discard-remote passed without a valid --destroy-token
+        (non-interactive mode)
+
+RECOVERY
+
+  If you hit a refusal, see docs/RECOVERY.md for step-by-step recovery
+  playbooks for each exit code.
+`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		fmt.Print(cmd.Long)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initSafetyHelpCmd)
+}

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -1,0 +1,260 @@
+package main
+
+// Init-safety guard matrix + end-to-end subprocess tests.
+//
+// The table-driven tests here enforce the invariant from
+// docs/adr/0002-init-safety-invariants.md. Adding a new flag that can
+// interact with remote history is a signal to extend this matrix — if the
+// table doesn't exhaustively cover (dataSource × flagSet) → outcome, the
+// ADR's structural lock has a gap.
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckRemoteSafety_GuardMatrix(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      RemoteSafetyInput
+		want    RemoteSafetyAction
+		wantExit int // 0 when not a refusal
+	}{
+		// No-remote-data column: nothing to refuse, regardless of flags.
+		{"fresh/no-flags", RemoteSafetyInput{}, ActionNoRemoteData, 0},
+		{"fresh/force", RemoteSafetyInput{Force: true}, ActionNoRemoteData, 0},
+		{"fresh/reinit-local", RemoteSafetyInput{ReinitLocal: true}, ActionNoRemoteData, 0},
+		{"fresh/discard-remote", RemoteSafetyInput{DiscardRemote: true}, ActionNoRemoteData, 0},
+		{"fresh/force+discard", RemoteSafetyInput{Force: true, DiscardRemote: true}, ActionNoRemoteData, 0},
+
+		// Remote-has-data column, user did NOT force: bootstrap is the
+		// adoption path. This is the existing correct behavior.
+		{"remote/no-flags", RemoteSafetyInput{RemoteHasDoltData: true}, ActionBootstrap, 0},
+
+		// Remote-has-data column, user forced WITHOUT discard-remote: the
+		// bd-q83 bug. Must refuse with ExitRemoteDivergenceRefused.
+		{
+			"remote/force",
+			RemoteSafetyInput{RemoteHasDoltData: true, Force: true},
+			ActionRefuseDivergence, ExitRemoteDivergenceRefused,
+		},
+		{
+			"remote/reinit-local",
+			RemoteSafetyInput{RemoteHasDoltData: true, ReinitLocal: true},
+			ActionRefuseDivergence, ExitRemoteDivergenceRefused,
+		},
+		{
+			"remote/force+reinit-local",
+			RemoteSafetyInput{RemoteHasDoltData: true, Force: true, ReinitLocal: true},
+			ActionRefuseDivergence, ExitRemoteDivergenceRefused,
+		},
+
+		// Remote-has-data, user forced WITH discard-remote, non-interactive,
+		// no token: requires destroy-token.
+		{
+			"remote/force+discard/non-interactive/no-token",
+			RemoteSafetyInput{RemoteHasDoltData: true, Force: true, DiscardRemote: true, ExpectedToken: "DESTROY-bd"},
+			ActionRequireDestroyToken, ExitDestroyTokenMissing,
+		},
+
+		// Remote-has-data, user forced WITH discard-remote, non-interactive,
+		// WRONG token: requires destroy-token.
+		{
+			"remote/force+discard/non-interactive/wrong-token",
+			RemoteSafetyInput{
+				RemoteHasDoltData: true, Force: true, DiscardRemote: true,
+				DestroyToken: "DESTROY-wrong", ExpectedToken: "DESTROY-bd",
+			},
+			ActionRequireDestroyToken, ExitDestroyTokenMissing,
+		},
+
+		// Remote-has-data, user forced WITH discard-remote, non-interactive,
+		// MATCHING token: authorized divergence.
+		{
+			"remote/force+discard/non-interactive/matching-token",
+			RemoteSafetyInput{
+				RemoteHasDoltData: true, Force: true, DiscardRemote: true,
+				DestroyToken: "DESTROY-bd", ExpectedToken: "DESTROY-bd",
+			},
+			ActionProceedWithDivergence, 0,
+		},
+
+		// Remote-has-data, user forced WITH discard-remote, INTERACTIVE:
+		// no token needed at decision time (caller will prompt).
+		{
+			"remote/force+discard/interactive",
+			RemoteSafetyInput{
+				RemoteHasDoltData: true, Force: true, DiscardRemote: true,
+				IsInteractive: true,
+			},
+			ActionProceedWithDivergence, 0,
+		},
+
+		// Remote-has-data, DISCARD without FORCE: also authorized since
+		// the user named the intent explicitly. This is a small
+		// ergonomics win — a user who knows about --discard-remote
+		// doesn't also have to type --reinit-local. The local-safety
+		// guard still fires separately (checkExistingBeadsData) if there's
+		// local data; that's a separate column not in this matrix.
+		{
+			"remote/discard-remote-only/interactive",
+			RemoteSafetyInput{RemoteHasDoltData: true, DiscardRemote: true, IsInteractive: true},
+			ActionProceedWithDivergence, 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CheckRemoteSafety(tc.in)
+			if got.Action != tc.want {
+				t.Errorf("Action = %v (reason=%q), want %v", got.Action, got.Reason, tc.want)
+			}
+			if tc.wantExit != 0 && got.ExitCode != tc.wantExit {
+				t.Errorf("ExitCode = %d, want %d", got.ExitCode, tc.wantExit)
+			}
+			// Refusal actions must populate UserMessage (per ADR text contract).
+			if (tc.want == ActionRefuseDivergence || tc.want == ActionRequireDestroyToken) && got.UserMessage == "" {
+				t.Errorf("refusal action %v returned empty UserMessage", tc.want)
+			}
+		})
+	}
+}
+
+// TestCheckRemoteSafety_RefusalTextNoEcho enforces the error-message
+// contract: runtime refusal text must not echo a complete destructive
+// invocation. A copy-pasteable command in the error is the failure class
+// that produced the 58f5989bf 247-issue incident.
+func TestCheckRemoteSafety_RefusalTextNoEcho(t *testing.T) {
+	// The refusal text must point to `bd help init-safety` or
+	// `bd bootstrap` (safe tools), not construct a full destructive
+	// command. Grep for flag combinations that would form a destructive
+	// one-liner.
+	in := RemoteSafetyInput{
+		RemoteHasDoltData: true, Force: true,
+	}
+	msg := CheckRemoteSafety(in).UserMessage
+
+	bannedEchoes := []string{
+		"bd init --force --discard-remote --destroy-token",
+		"bd init --reinit-local --discard-remote --destroy-token",
+		"DESTROY-",
+	}
+	for _, banned := range bannedEchoes {
+		if strings.Contains(msg, banned) {
+			t.Errorf("refusal text contains destructive one-liner %q:\n%s", banned, msg)
+		}
+	}
+
+	// It MUST name the safe path.
+	if !strings.Contains(msg, "bd bootstrap") {
+		t.Errorf("refusal text does not name the safe tool 'bd bootstrap':\n%s", msg)
+	}
+	// And it must point to the help topic for the destructive path.
+	if !strings.Contains(msg, "bd help init-safety") {
+		t.Errorf("refusal text does not point to 'bd help init-safety':\n%s", msg)
+	}
+}
+
+// TestFormatDestroyToken asserts the token format contract that
+// bd help init-safety documents. If this format changes, help text
+// and the ADR must update together.
+func TestFormatDestroyToken(t *testing.T) {
+	got := FormatDestroyToken("bd")
+	want := "DESTROY-bd"
+	if got != want {
+		t.Errorf("FormatDestroyToken(\"bd\") = %q, want %q", got, want)
+	}
+}
+
+// TestInitForceRefusesWhenRemoteHasDoltData is the end-to-end subprocess
+// regression test for bd-q83. It creates a bare repo with a synthetic
+// `refs/dolt/data` ref, then runs `bd init --force` in a clone of that
+// repo. Expected: non-zero exit, refusal message points to `bd bootstrap`,
+// no `.beads/` directory created.
+//
+// Per the test-engineer position: the fixture uses a synthetic git ref
+// (no real Dolt push needed). `gitLsRemoteHasRef` only checks that the
+// ref exists, not its content.
+func TestInitForceRefusesWhenRemoteHasDoltData(t *testing.T) {
+	bdBin := buildBDForInitTests(t)
+
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+
+	sourceDir := t.TempDir()
+	runGitForBootstrapTest(t, sourceDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.email", "test@test.com")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
+	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
+	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
+
+	cloneDir := t.TempDir()
+	runGitForBootstrapTest(t, cloneDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, cloneDir, "remote", "add", "origin", bareDir)
+	runGitForBootstrapTest(t, cloneDir, "config", "core.hooksPath", ".git/hooks")
+
+	cmd := exec.Command(bdBin, "init", "--force", "--prefix", "bd", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	cmd.Dir = cloneDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	// Expected: non-zero exit.
+	if err == nil {
+		t.Fatalf("bd init --force succeeded; expected refusal. stderr:\n%s", stderr.String())
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("non-exec-exit error: %v\nstderr:\n%s", err, stderr.String())
+	}
+	if code := exitErr.ExitCode(); code != ExitRemoteDivergenceRefused {
+		t.Errorf("exit code = %d, want %d (ExitRemoteDivergenceRefused)", code, ExitRemoteDivergenceRefused)
+	}
+
+	// Refusal text must name the safe path.
+	stderrStr := stderr.String()
+	for _, must := range []string{"bd bootstrap", "bd help init-safety", "remote 'origin'"} {
+		if !strings.Contains(stderrStr, must) {
+			t.Errorf("refusal missing %q:\n%s", must, stderrStr)
+		}
+	}
+	// Refusal text must NOT echo a destructive one-liner.
+	for _, banned := range []string{"--destroy-token=DESTROY-", "--force --discard-remote --destroy-token"} {
+		if strings.Contains(stderrStr, banned) {
+			t.Errorf("refusal echoes banned one-liner %q:\n%s", banned, stderrStr)
+		}
+	}
+
+	// No .beads/ should have been created.
+	beadsDir := filepath.Join(cloneDir, ".beads")
+	if _, err := os.Stat(beadsDir); err == nil {
+		t.Errorf("refusal should not have created %s", beadsDir)
+	}
+}
+
+// TestInitForceDiscardRemoteProceedsWithToken is the positive counterpart:
+// when the caller explicitly passes --discard-remote with a valid
+// destroy-token, init proceeds. This is slower (real Dolt init) so we
+// bound its scope to verify "refusal clears" — not full bootstrap
+// correctness, which is covered elsewhere.
+//
+// Skipped if dolt binary isn't available; remote-divergence refusal is
+// the primary regression concern.
+func TestInitForceDiscardRemoteProceedsWithToken(t *testing.T) {
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt binary not available; skipping end-to-end discard-remote path")
+	}
+	// The pure-function matrix above covers the decision; this test just
+	// confirms the CLI wires the happy path through. Keep minimal to
+	// avoid flaky dolt interactions in CI.
+	t.Skip("covered by matrix; full end-to-end deferred to a follow-up when the full init path is simplified")
+}
+
+// Helpers used above: buildBDForInitTests, runGitForBootstrapTest — both
+// defined elsewhere in the test package (init_test.go and bootstrap_test.go).

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -19,9 +19,9 @@ import (
 
 func TestCheckRemoteSafety_GuardMatrix(t *testing.T) {
 	cases := []struct {
-		name    string
-		in      RemoteSafetyInput
-		want    RemoteSafetyAction
+		name     string
+		in       RemoteSafetyInput
+		want     RemoteSafetyAction
 		wantExit int // 0 when not a refusal
 	}{
 		// No-remote-data column: nothing to refuse, regardless of flags.
@@ -177,7 +177,7 @@ func TestFormatDestroyToken(t *testing.T) {
 // no `.beads/` directory created.
 //
 // Per the test-engineer position: the fixture uses a synthetic git ref
-// (no real Dolt push needed). `gitLsRemoteHasRef` only checks that the
+// (no real Dolt push needed). `gitOriginHasDoltDataRef` only checks that the
 // ref exists, not its content.
 func TestInitForceRefusesWhenRemoteHasDoltData(t *testing.T) {
 	bdBin := buildBDForInitTests(t)

--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -69,9 +69,9 @@ func gitHasAnyRemotes() bool {
 	return strings.TrimSpace(string(output)) != ""
 }
 
-// gitRemoteGetURL returns the URL for a named git remote.
-func gitRemoteGetURL(remote string) (string, error) {
-	cmd := exec.Command("git", "remote", "get-url", remote)
+// gitOriginGetURL returns the URL for the origin git remote.
+func gitOriginGetURL() (string, error) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -79,14 +79,14 @@ func gitRemoteGetURL(remote string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// gitLsRemoteHasRef checks if a remote has a specific ref.
+// gitOriginHasDoltDataRef checks if origin has refs/dolt/data.
 // Returns false on any error (network, no remote, timeout, etc).
 // Uses a 10s timeout since this is a network call used for auto-detection,
 // and suppresses credential prompts to avoid blocking on SSH remotes.
-func gitLsRemoteHasRef(remote, ref string) bool {
+func gitOriginHasDoltDataRef() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", remote, ref)
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "origin", "refs/dolt/data")
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.Output()
 	if err != nil {

--- a/cmd/bd/sync_git_test.go
+++ b/cmd/bd/sync_git_test.go
@@ -62,7 +62,7 @@ func TestIsBareGitRepo(t *testing.T) {
 	})
 }
 
-func TestGitRemoteGetURL(t *testing.T) {
+func TestGitOriginGetURL(t *testing.T) {
 	t.Run("returns origin URL", func(t *testing.T) {
 		repoDir := t.TempDir()
 		bareDir := filepath.Join(t.TempDir(), "bare.git")
@@ -79,12 +79,12 @@ func TestGitRemoteGetURL(t *testing.T) {
 			t.Fatalf("failed to chdir: %v", err)
 		}
 
-		url, err := gitRemoteGetURL("origin")
+		url, err := gitOriginGetURL()
 		if err != nil {
-			t.Fatalf("gitRemoteGetURL failed: %v", err)
+			t.Fatalf("gitOriginGetURL failed: %v", err)
 		}
 		if url != bareDir {
-			t.Errorf("gitRemoteGetURL = %q, want %q", url, bareDir)
+			t.Errorf("gitOriginGetURL = %q, want %q", url, bareDir)
 		}
 	})
 
@@ -101,14 +101,14 @@ func TestGitRemoteGetURL(t *testing.T) {
 			t.Fatalf("failed to chdir: %v", err)
 		}
 
-		_, err = gitRemoteGetURL("origin")
+		_, err = gitOriginGetURL()
 		if err == nil {
 			t.Fatal("expected error for nonexistent remote")
 		}
 	})
 }
 
-func TestGitLsRemoteHasRef(t *testing.T) {
+func TestGitOriginHasDoltDataRef(t *testing.T) {
 	t.Run("returns false for nonexistent ref", func(t *testing.T) {
 		bareDir := filepath.Join(t.TempDir(), "bare.git")
 		runGitForSyncTest(t, "", "init", "--bare", bareDir)
@@ -126,7 +126,7 @@ func TestGitLsRemoteHasRef(t *testing.T) {
 			t.Fatalf("failed to chdir: %v", err)
 		}
 
-		if gitLsRemoteHasRef("origin", "refs/dolt/data") {
+		if gitOriginHasDoltDataRef() {
 			t.Fatal("expected false for nonexistent ref")
 		}
 	})
@@ -135,14 +135,14 @@ func TestGitLsRemoteHasRef(t *testing.T) {
 		bareDir := filepath.Join(t.TempDir(), "bare.git")
 		runGitForSyncTest(t, "", "init", "--bare", bareDir)
 
-		// Create a repo, commit, push to create refs/heads/main
+		// Create a repo, commit, push to create refs/dolt/data
 		repoDir := t.TempDir()
 		runGitForSyncTest(t, repoDir, "init", "-b", "main")
 		runGitForSyncTest(t, repoDir, "config", "user.email", "test@test.com")
 		runGitForSyncTest(t, repoDir, "config", "user.name", "Test User")
 		runGitForSyncTest(t, repoDir, "commit", "--allow-empty", "-m", "init")
 		runGitForSyncTest(t, repoDir, "remote", "add", "origin", bareDir)
-		runGitForSyncTest(t, repoDir, "push", "origin", "main")
+		runGitForSyncTest(t, repoDir, "push", "origin", "HEAD:refs/dolt/data")
 
 		oldWd, err := os.Getwd()
 		if err != nil {
@@ -153,7 +153,7 @@ func TestGitLsRemoteHasRef(t *testing.T) {
 			t.Fatalf("failed to chdir: %v", err)
 		}
 
-		if !gitLsRemoteHasRef("origin", "refs/heads/main") {
+		if !gitOriginHasDoltDataRef() {
 			t.Fatal("expected true for existing ref")
 		}
 	})

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -1,0 +1,147 @@
+# Recovery Playbooks
+
+This document lives next to the ADRs and matches the structure of `bd`'s
+error messages: each named refusal in `bd init` points here to a labeled
+anchor with step-by-step recovery instructions.
+
+See also: `bd help init-safety`, and
+[ADR 0002 — `bd init` safety invariants](adr/0002-init-safety-invariants.md).
+
+## Table of contents
+
+- [init-force-refused — `bd init --force`/`--reinit-local` refused because origin has Dolt history](#init-force-refused)
+- [init-token-missing — `--discard-remote` refused because `--destroy-token` is missing or wrong](#init-token-missing)
+- [init-local-exists — `bd init` refused because local data already exists](#init-local-exists)
+
+---
+
+## init-force-refused
+
+**Exit code:** `10` (`ExitRemoteDivergenceRefused`)
+
+**Symptom**
+
+```
+bd init refuses: remote 'origin' already has Dolt history (refs/dolt/data).
+  Why: --force / --reinit-local bypasses only the LOCAL data-safety
+       guard. ...
+```
+
+**Why this happens**
+
+`bd init --force` (or `--reinit-local`) tells `bd` to bypass the local
+data-safety guard. But the remote already has project history. Proceeding
+would create an orphan local Dolt branch with no common ancestor on
+origin. The next `bd dolt push` would either fail (no common ancestor)
+or — worse, if force-pushed — destroy the team's data.
+
+**Recovery paths**
+
+Pick the one that matches your intent.
+
+### 1. You want to adopt the remote's history (most common)
+
+```
+bd bootstrap
+```
+
+This clones the remote's Dolt database into a fresh local `.beads/`.
+Your local state is ignored; the team's history becomes yours.
+
+### 2. You want to diagnose what went wrong before deciding
+
+```
+bd doctor
+bd dolt status
+```
+
+`bd doctor` walks the local + remote state and names concrete problems.
+`bd dolt status` shows the Dolt-level view. Neither modifies anything.
+
+### 3. You intentionally want to overwrite the remote's history (destructive)
+
+This is a cross-boundary operation that affects every collaborator. You
+need to pair `--reinit-local` with `--discard-remote`. In interactive
+mode `bd` will prompt for confirmation; in non-interactive mode you must
+supply a `--destroy-token`. See `bd help init-safety` for the token
+format.
+
+After `bd init --reinit-local --discard-remote`, your next
+`bd dolt push` must be a history-replacing push. Coordinate with your
+team before doing this.
+
+---
+
+## init-token-missing
+
+**Exit code:** `12` (`ExitDestroyTokenMissing`)
+
+**Symptom**
+
+```
+bd init refuses: --discard-remote requires an explicit destroy-token in non-interactive mode.
+```
+
+**Why this happens**
+
+You're running non-interactively (CI, agent, piped input) and passed
+`--discard-remote`. Destructive cross-boundary operations cannot be
+authorized silently.
+
+**Recovery paths**
+
+### 1. Run interactively
+
+Re-run in a TTY. `bd init --reinit-local --discard-remote` will prompt
+you to type the destroy-token at confirmation time.
+
+### 2. Supply the token explicitly (CI/automation)
+
+The token format is `DESTROY-<issue-prefix>`. For a project whose issue
+prefix is `bd`:
+
+```
+bd init --reinit-local --discard-remote --destroy-token=DESTROY-bd
+```
+
+Automation should template the token from project state, not from error
+output. See [ADR 0002 — Invariant 4](adr/0002-init-safety-invariants.md)
+for why the token is never echoed in `bd`'s error messages.
+
+---
+
+## init-local-exists
+
+**Exit code:** `11` (`ExitLocalExistsRefused`)
+
+**Symptom**
+
+```
+Refusing to destroy N issues in non-interactive mode.
+  See 'bd help init-safety' for the required --destroy-token format.
+```
+
+Or, in interactive mode, you declined the typed `destroy N issues`
+confirmation.
+
+**Why this happens**
+
+Local `.beads/` has existing issues. `bd init --reinit-local` would
+permanently destroy them.
+
+**Recovery paths**
+
+### 1. Export first, then proceed
+
+```
+bd export > backup.jsonl
+bd init --reinit-local
+```
+
+`backup.jsonl` lets you re-import individual issues if needed.
+
+### 2. Investigate why you hit this
+
+If you did NOT expect `bd init` to be the right command here, run
+`bd doctor` first — you may be looking at a server config issue that a
+re-init won't fix.

--- a/docs/adr/0002-init-safety-invariants.md
+++ b/docs/adr/0002-init-safety-invariants.md
@@ -1,0 +1,164 @@
+# ADR 0002 — `bd init` safety invariants
+
+## Status
+
+Accepted — 2026-04-24.
+
+## Context
+
+`bd init --force` in a repo whose origin already has `refs/dolt/data`
+silently skipped the bootstrap-from-remote path at `cmd/bd/init.go:511`
+and then still wired origin as a Dolt remote (`init.go:643-650`). The
+next write auto-pushed an orphan Dolt history, failing with
+"no common ancestor." Recovery options were all destructive (force-push
+over the team's remote, or `rm -rf .beads/dolt`). The tool's own warning
+text acknowledged the failure class as a well-known footgun.
+
+Historical pattern analysis (git log for `cmd/bd/init.go`): at least
+eight prior commits each patched one surface of this class without
+encoding the underlying invariant:
+
+- `58f5989bf` — misleading error messages cost a user 247 issues.
+- `af12d6f72` — server→embedded migration export ordering.
+- `9db6b56f2` — v0.63→v1.0 schema backfill multi-statement ALTER.
+- `63c7a2601` — `project_id` adoption in shared-server mode.
+- `401da9df7` — `project_id` backfill via `bd doctor --fix`.
+- `3a4840169` — introduced `--force` as a safety-bypass override.
+- `12dc4e075` — `--destroy-token` because `--force+--quiet` bypassed confirmation.
+- `83b0f099b` — remove `--quiet` bypass of the safety guard.
+
+Each commit added a guard for one data source (local JSONL, local DB
+file, shared-server `_project_id`, remote `refs/dolt/data`) but the
+`--force` flag lived in global scope. Every future guard silently
+inherited `--force` as an implicit bypass unless its author remembered
+to special-case it. `3a4840169` introduced this shape: the flag said
+"bypass the safety guard" (singular) but the code wrote it in a form
+that applied to every future guard.
+
+## Decision
+
+### Invariant 1 — single-source identity resolution
+
+Every `bd init` invocation resolves `project_id` from exactly **one**
+explicitly-named source: (a) mint fresh, (b) adopt from remote (via
+`bd bootstrap` or automatic bootstrap when origin has `refs/dolt/data`),
+or (c) reuse remote identity with local reinit. When two disjoint
+candidate sources exist (local data + remote Dolt history) and no flag
+names the winner, `bd init` refuses.
+
+### Invariant 2 — scope-bound `--force` / `--reinit-local`
+
+`--force` (and its replacement `--reinit-local`) bypasses the **local**
+data-safety guard only. It never authorizes silent divergence of remote
+history. When origin advertises `refs/dolt/data`, `bd init --force`
+refuses unless `--discard-remote` is also passed.
+
+### Invariant 3 — central chokepoint (executable, not advisory)
+
+Every flag on `bd init` that can interact with remote history routes
+through `CheckRemoteSafety` in `cmd/bd/init_safety.go`. Adding a new
+flag is a signal to extend the guard matrix test in
+`cmd/bd/init_safety_test.go`; if the table doesn't exhaustively cover
+`(dataSource × flagSet) → outcome`, this ADR has a gap.
+
+### Invariant 4 — error-text-no-echo
+
+No `bd` runtime error output may contain a complete invocation of a
+destructive command. Flag identifiers (`--discard-remote`,
+`--destroy-token`) and safe-tool names (`bd bootstrap`, `bd doctor`,
+`bd help init-safety`) are permitted; token values
+(`DESTROY-<prefix>`), hashes, and other friction-bearing arguments
+live in `bd help init-safety`, this ADR, and `docs/RECOVERY.md` only.
+
+This invariant closes the `58f5989bf` failure class where an AI agent
+copy-pasted the suggested `bd init --force --destroy-token=<hash>`
+one-liner from the tool's own error text and destroyed 247 issues. The
+agent's behavior was rational for the error it read; the text was the
+bug.
+
+### Invariant 5 — race-safety
+
+When `--discard-remote` is authorized (interactive confirm or
+destroy-token match), `bd init` re-verifies `refs/dolt/data` on origin
+between prompt/confirm and execute. If the remote state changed during
+the confirmation window (another agent pushed), `bd init` aborts with
+`ExitRemoteDivergenceRefused`. Race-safety is an internal invariant,
+not a user-facing ceremony.
+
+## Consequences
+
+### Flag surface after this ADR
+
+```
+bd init                         mint, or auto-bootstrap if origin has refs/dolt/data
+bd init --reinit-local          local reinit; refuses remote divergence
+bd init --reinit-local \        local reinit, overwrite remote on next push
+    --discard-remote            (interactive confirm or --destroy-token required)
+bd init --force                 deprecated alias for --reinit-local (≥2 releases)
+bd bootstrap                    adopt remote — signposted by init refusal
+```
+
+### Exit codes (stable, grep-safe)
+
+```
+10   ExitRemoteDivergenceRefused   --force/--reinit-local without --discard-remote
+11   ExitLocalExistsRefused        existing local data, declined destroy confirm
+12   ExitDestroyTokenMissing       --discard-remote without valid --destroy-token
+```
+
+### Deprecation cycle
+
+`--force` continues to work for ≥2 releases post-0.x, emitting a
+`DeprecationWarning` and routing internally to `--reinit-local`. Scripts
+and CI muscle memory keep working; the CHANGELOG under "Deprecations"
+names the substitute.
+
+### Test contract
+
+1. `TestCheckRemoteSafety_GuardMatrix` — table-driven, covers every
+   (flag combination × remote state) permutation. New flags must extend
+   this table.
+2. `TestCheckRemoteSafety_RefusalTextNoEcho` — asserts Invariant 4:
+   refusal text must name `bd bootstrap` and `bd help init-safety`; must
+   NOT contain a complete destructive invocation.
+3. `TestInitForceRefusesWhenRemoteHasDoltData` — subprocess regression
+   for the bd-q83 bug, using a synthetic `refs/dolt/data` git ref
+   fixture (no real Dolt push needed).
+
+Mutation-testing ritual (optional but recommended): flip `!force &&` to
+`!force ||` in the legacy gate, or flip any decision tree branch in
+`CheckRemoteSafety`, and confirm both the matrix test and the
+subprocess test fail. If either stays green, coverage is theater.
+
+### Review discipline
+
+`.github/CODEOWNERS` points `cmd/bd/init*.go` at maintainers and
+references this ADR in the review-requirement comment. Future reviewers
+are reminded to walk the matrix when a new flag or data source lands.
+
+## Alternatives considered
+
+- **Symmetric `--take-local` / `--take-remote` flag pair.** Rejected:
+  names symmetric-sounding flags for structurally asymmetric operations
+  (one-rig scope vs team-wide blast radius). The asymmetric
+  `--reinit-local` + `--discard-remote` split exposes that asymmetry
+  explicitly.
+- **Typed remote-URL confirmation** instead of `--destroy-token`.
+  Rejected: `--destroy-token` already existed at `init.go:214-222` for
+  the local-data-destruction path. Introducing a second confirmation
+  convention for the same op class is surface bloat. With Invariant 4,
+  the token pattern is not friction-theater.
+- **Fold `bd bootstrap` into `bd init --adopt-remote`.** Rejected:
+  `bd bootstrap` is a first-class command users rely on; the verb split
+  between "init" (mint) and "bootstrap" (adopt) is the UX that works.
+  Flattening it would break existing muscle memory for zero structural
+  benefit.
+
+## References
+
+- Issue source: bd-q83 (local beads tracker, merged from qa-engineer F1
+  and historian F3 findings in `council-2026-04-22-beads-resilience-audit`).
+- Decision log: `~/.claude/councils/2026-04-24-bd-q83-init-force-safety/log.md`.
+- Implementation chokepoint: `cmd/bd/init_safety.go`.
+- Guard matrix: `cmd/bd/init_safety_test.go`.
+- Recovery playbooks: `docs/RECOVERY.md`.


### PR DESCRIPTION
## Summary

`bd init --force` in a repo whose `origin` has `refs/dolt/data` silently skipped the bootstrap-from-remote path and then wired `origin` as a Dolt remote anyway. The next write auto-pushed an orphan Dolt history, failing with "no common ancestor." Recovery options were all destructive (force-push over the team's remote, or `rm -rf .beads/dolt`). The tool's own warning text already acknowledged this as a well-known footgun.

This PR narrows `--force` semantics to the local data-safety guard only, introduces named-intent flags for the remote dimension, and encodes the invariant in an ADR + executable guard matrix so future flags can't silently reintroduce the class.

## Changes

### New flags on `bd init`
- **`--reinit-local`** — local reinit; replaces the overloaded `--force`.
- **`--discard-remote`** — explicit cross-boundary authorization; composable with `--reinit-local`. Requires `--destroy-token` in non-interactive mode, TTY confirmation interactively.
- **`--force`** — deprecated alias for `--reinit-local`; emits `DeprecationWarning`, continues to work for ≥2 releases.

### Refusal behavior
- `bd init --force` (or `--reinit-local`) when `origin` has `refs/dolt/data` and no `--discard-remote` → refuse with exit code **10** (`ExitRemoteDivergenceRefused`).
- `bd init --discard-remote` non-interactively without a valid `--destroy-token` → refuse with exit code **12** (`ExitDestroyTokenMissing`).
- Existing local-exists refusal gets exit code **11** (`ExitLocalExistsRefused`).
- Refusal text follows a What/Why/Next structure; does NOT echo copy-pasteable destructive invocations (see ADR Invariant 4).

### Structural changes
- **`cmd/bd/init_safety.go`** — new file with the `CheckRemoteSafety` chokepoint (pure function) that every init flag affecting remote history must route through. Adding a new flag is a signal to extend the guard matrix in `cmd/bd/init_safety_test.go` — 13 cases exhaustively covering `(dataSourcePresent × flagSet) → outcome`.
- **`bd init-safety`** — documents the flag surface and destroy-token format. Referenced by every init refusal (per the no-echo invariant, runtime errors never include the destructive command — only pointers to this topic and `docs/RECOVERY.md`).
- **Internal race-safety** — when `--discard-remote` is authorized interactively, `bd init` re-verifies `refs/dolt/data` between confirm and execute. If the remote changed during the confirmation window, abort.
- **Retrofit of the existing destroy-token echo** at `cmd/bd/init.go:231`. That site emitted `"To proceed, use: bd init --force --destroy-token=<hash>"` — the exact failure class that produced the 247-issue incident ([`58f5989bf`](https://github.com/gastownhall/beads/commit/58f5989bf)). Replaced with a pointer to `bd help init-safety`.

### Docs
- **[ADR 0002 — `bd init` safety invariants](docs/adr/0002-init-safety-invariants.md)** — encodes the five invariants (single-source identity, scope-bound `--force`/`--reinit-local`, central chokepoint, error-text-no-echo, race-safety). Includes a retrospective on the pattern: 8+ prior commits patched individual surfaces of this class without encoding the invariant. `--force` was introduced in [`3a4840169`](https://github.com/gastownhall/beads/commit/3a4840169) as a singular bypass but lived in global scope, so every future guard implicitly inherited it unless the author remembered to special-case.
- **[`docs/RECOVERY.md`](docs/RECOVERY.md)** — named recovery playbooks per refusal exit code.
- **`CHANGELOG.md`** — entries under Added / Changed / Deprecated.
- **`.github/CODEOWNERS`** — review ownership for `cmd/bd/init*.go` pointing reviewers at ADR 0002.

## Tests

- `TestCheckRemoteSafety_GuardMatrix` — 13 cases, exhaustive table. Adding a new flag must extend this.
- `TestCheckRemoteSafety_RefusalTextNoEcho` — asserts the ADR text contract: refusal must name safe tools (`bd bootstrap`, `bd help init-safety`) and must NOT contain a complete destructive invocation.
- `TestInitForceRefusesWhenRemoteHasDoltData` — end-to-end subprocess regression test using a synthetic `refs/dolt/data` git ref fixture (no real Dolt push needed — per the test-engineer's insight that `gitLsRemoteHasRef` only checks ref existence).

All new tests pass; `go test -tags gms_pure_go ./cmd/bd/...` clean.

**Mutation verification ritual:** flip `!force &&` at the old call site or any branch of `CheckRemoteSafety` — both the matrix test and the subprocess test must fail. If either stays green, coverage is theater.

## Backward compatibility

- **`bd init --force` continues to work** for ≥2 releases. It emits a `DeprecationWarning` pointing to `--reinit-local`, then routes internally with the same local-only semantics. Scripts / CI / muscle memory are unaffected for the deprecation window.
- **New refusal is a behavior change** for `bd init --force` callers whose origin has `refs/dolt/data`. This is the bug being fixed — in pre-fix code, that invocation produced an orphan history and a broken next-push. The refusal surfaces the problem at init time instead of shipping it to the next writer.
- Existing fresh-repo / no-remote-data / bootstrap paths are unchanged.

## Size: Medium

~1000 lines added / 17 removed. Most of the volume is the ADR (~170 lines), guard-matrix test (~170 lines), RECOVERY playbook (~130 lines), and the init-safety help text (~80 lines). Core logic change in `cmd/bd/init.go` is surgical (refusal chokepoint + flag wiring).

🤖 Generated with [Claude Code](https://claude.ai/code)