### PR TITLE
fix: support Jira Cloud token pagination

### DIFF
--- a/internal/jira/client.go
+++ b/internal/jira/client.go
@@ -91,10 +91,12 @@ type TransitionsResult struct {
 
 // SearchResult represents a Jira JQL search response.
 type SearchResult struct {
-	StartAt    int     `json:"startAt"`
-	MaxResults int     `json:"maxResults"`
-	Total      int     `json:"total"`
-	Issues     []Issue `json:"issues"`
+	StartAt       int     `json:"startAt"`
+	MaxResults    int     `json:"maxResults"`
+	Total         int     `json:"total"`
+	NextPageToken string  `json:"nextPageToken"`
+	IsLast        bool    `json:"isLast"`
+	Issues        []Issue `json:"issues"`
 }
 
 // Client provides HTTP access to a Jira instance.
@@ -164,8 +166,10 @@ const searchFields = "summary,description,status,priority,issuetype,project,assi
 func (c *Client) SearchIssues(ctx context.Context, jql string) ([]Issue, error) {
 	var allIssues []Issue
 	startAt := 0
+	nextPageToken := ""
 	maxResults := 100
 	page := 0
+	useV2Pagination := c.APIVersion == "2"
 
 	for {
 		select {
@@ -182,13 +186,17 @@ func (c *Client) SearchIssues(ctx context.Context, jql string) ([]Issue, error) 
 		params := url.Values{
 			"jql":        {jql},
 			"fields":     {searchFields},
-			"startAt":    {fmt.Sprintf("%d", startAt)},
 			"maxResults": {fmt.Sprintf("%d", maxResults)},
+		}
+		if useV2Pagination {
+			params.Set("startAt", fmt.Sprintf("%d", startAt))
+		} else if nextPageToken != "" {
+			params.Set("nextPageToken", nextPageToken)
 		}
 
 		// v3 uses /search/jql; v2 uses /search (both accept jql as a query param)
 		searchPath := "search/jql"
-		if c.APIVersion == "2" {
+		if useV2Pagination {
 			searchPath = "search"
 		}
 		apiURL := fmt.Sprintf("%s/%s?%s", c.apiBase(), searchPath, params.Encode())
@@ -205,10 +213,20 @@ func (c *Client) SearchIssues(ctx context.Context, jql string) ([]Issue, error) 
 
 		allIssues = append(allIssues, result.Issues...)
 
-		if len(result.Issues) == 0 || startAt+len(result.Issues) >= result.Total {
+		if len(result.Issues) == 0 {
 			break
 		}
-		startAt += len(result.Issues)
+		if useV2Pagination {
+			if startAt+len(result.Issues) >= result.Total {
+				break
+			}
+			startAt += len(result.Issues)
+			continue
+		}
+		if result.IsLast || result.NextPageToken == "" {
+			break
+		}
+		nextPageToken = result.NextPageToken
 	}
 
 	return allIssues, nil

--- a/internal/jira/client_test.go
+++ b/internal/jira/client_test.go
@@ -331,3 +331,83 @@ func TestSearchIssuesQueryParam(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchIssuesV3UsesNextPageTokenPagination(t *testing.T) {
+	var gotTokens []string
+	var gotStartAts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTokens = append(gotTokens, r.URL.Query().Get("nextPageToken"))
+		gotStartAts = append(gotStartAts, r.URL.Query().Get("startAt"))
+		w.Header().Set("Content-Type", "application/json")
+
+		switch len(gotTokens) {
+		case 1:
+			_ = json.NewEncoder(w).Encode(SearchResult{
+				NextPageToken: "page-2",
+				IsLast:        false,
+				Issues:        []Issue{{Key: "PROJ-1"}, {Key: "PROJ-2"}},
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(SearchResult{
+				IsLast: true,
+				Issues: []Issue{{Key: "PROJ-3"}},
+			})
+		default:
+			t.Fatalf("unexpected extra pagination request %d", len(gotTokens))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "3")
+	issues, err := c.SearchIssues(context.Background(), "project = PROJ")
+	if err != nil {
+		t.Fatalf("SearchIssues error: %v", err)
+	}
+	if len(issues) != 3 {
+		t.Fatalf("issues count = %d, want 3", len(issues))
+	}
+	if want := []string{"", "page-2"}; len(gotTokens) != len(want) || gotTokens[0] != want[0] || gotTokens[1] != want[1] {
+		t.Fatalf("nextPageToken values = %#v, want %#v", gotTokens, want)
+	}
+	for i, startAt := range gotStartAts {
+		if startAt != "" {
+			t.Fatalf("request %d unexpectedly sent startAt=%q for v3 token pagination", i+1, startAt)
+		}
+	}
+}
+
+func TestSearchIssuesV2UsesStartAtPagination(t *testing.T) {
+	var gotStartAts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotStartAts = append(gotStartAts, r.URL.Query().Get("startAt"))
+		w.Header().Set("Content-Type", "application/json")
+
+		switch len(gotStartAts) {
+		case 1:
+			_ = json.NewEncoder(w).Encode(SearchResult{
+				Total:  3,
+				Issues: []Issue{{Key: "PROJ-1"}, {Key: "PROJ-2"}},
+			})
+		case 2:
+			_ = json.NewEncoder(w).Encode(SearchResult{
+				Total:  3,
+				Issues: []Issue{{Key: "PROJ-3"}},
+			})
+		default:
+			t.Fatalf("unexpected extra pagination request %d", len(gotStartAts))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "2")
+	issues, err := c.SearchIssues(context.Background(), "project = PROJ")
+	if err != nil {
+		t.Fatalf("SearchIssues error: %v", err)
+	}
+	if len(issues) != 3 {
+		t.Fatalf("issues count = %d, want 3", len(issues))
+	}
+	if want := []string{"0", "2"}; len(gotStartAts) != len(want) || gotStartAts[0] != want[0] || gotStartAts[1] != want[1] {
+		t.Fatalf("startAt values = %#v, want %#v", gotStartAts, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add Jira Cloud `nextPageToken` and `isLast` handling to `SearchIssues`
- keep Jira v2 `startAt` pagination unchanged
- add regression coverage for both pagination modes

## Validation
- `go test ./internal/jira/...`
- `make test` *(hits existing unrelated failures in `cmd/bd/doctor` and `cmd/bd/doctor/fix` on this checkout)*

Closes #3444
