### PR TITLE
Tier embedded Dolt CI for PRs

### DIFF
--- a/.github/scripts/ci-embedded-tier.sh
+++ b/.github/scripts/ci-embedded-tier.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Decide whether CI should run the full embedded Dolt build/storage/cmd matrix.
+
+set -euo pipefail
+
+event_name="${GITHUB_EVENT_NAME:-}"
+base_sha="${PR_BASE_SHA:-}"
+head_sha="${PR_HEAD_SHA:-}"
+
+full_embedded=false
+reason=""
+changed_files=""
+
+write_outputs() {
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "full_embedded=$full_embedded"
+      echo "reason=$reason"
+    } >> "$GITHUB_OUTPUT"
+  fi
+}
+
+case "$event_name" in
+  push)
+    full_embedded=true
+    reason="push to main runs full embedded Dolt coverage"
+    write_outputs
+    echo "$reason"
+    exit 0
+    ;;
+  merge_group)
+    full_embedded=true
+    reason="merge queue runs full embedded Dolt coverage"
+    write_outputs
+    echo "$reason"
+    exit 0
+    ;;
+esac
+
+if [ "$event_name" != "pull_request" ]; then
+  full_embedded=true
+  reason="non-PR event runs full embedded Dolt coverage"
+  write_outputs
+  echo "$reason"
+  exit 0
+fi
+
+if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+  full_embedded=true
+  reason="PR diff bounds unavailable; defaulting to full embedded Dolt coverage"
+  write_outputs
+  echo "$reason"
+  exit 0
+fi
+
+if ! changed_files="$(git diff --name-only "$base_sha" "$head_sha")"; then
+  full_embedded=true
+  reason="PR diff failed; defaulting to full embedded Dolt coverage"
+  write_outputs
+  echo "$reason"
+  exit 0
+fi
+
+if [ -z "$changed_files" ]; then
+  reason="no changed files detected; skipping embedded Dolt matrix"
+  write_outputs
+  echo "$reason"
+  exit 0
+fi
+
+while IFS= read -r path; do
+  case "$path" in
+    cmd/*|internal/*|tests/*|scripts/*|.github/scripts/*|.github/workflows/*)
+      full_embedded=true
+      reason="changed $path"
+      break
+      ;;
+    *.go|go.mod|go.sum|Makefile|default.nix|flake.nix|flake.lock|packages.nix)
+      full_embedded=true
+      reason="changed $path"
+      break
+      ;;
+    AGENTS.md|AGENT_INSTRUCTIONS.md|CONTRIBUTING.md|RELEASING.md)
+      full_embedded=true
+      reason="changed $path"
+      break
+      ;;
+  esac
+done <<< "$changed_files"
+
+if [ "$full_embedded" = true ]; then
+  reason="risk path detected: $reason; running full embedded Dolt coverage"
+else
+  reason="docs/metadata-only PR; skipping embedded Dolt storage/cmd matrix"
+fi
+
+write_outputs
+
+echo "$reason"
+echo "Changed files:"
+while IFS= read -r path; do
+  printf '  %s\n' "$path"
+done <<< "$changed_files"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-ci-tier:
+    name: Detect CI tier
+    runs-on: ubuntu-latest
+    outputs:
+      full_embedded: ${{ steps.tier.outputs.full_embedded }}
+      reason: ${{ steps.tier.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide embedded Dolt coverage
+        id: tier
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/scripts/ci-embedded-tier.sh
+
   # Fast check: every `go build|test|run|generate|install` invocation in
   # tracked scripts/hooks/CI carries -tags=gms_pure_go. Prevents ICU-linkage
   # regressions from re-entering the build (see docs/ICU-POLICY.md).
@@ -161,6 +179,8 @@ jobs:
 
   build-embedded:
     name: Build (Embedded Dolt)
+    needs: detect-ci-tier
+    if: needs.detect-ci-tier.outputs.full_embedded == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -191,7 +211,8 @@ jobs:
 
   test-embedded-storage:
     name: Test (Embedded Dolt Storage)
-    needs: build-embedded
+    needs: [detect-ci-tier, build-embedded]
+    if: needs.detect-ci-tier.outputs.full_embedded == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -218,7 +239,8 @@ jobs:
 
   test-embedded-cmd:
     name: Test (Embedded Dolt Cmd ${{ matrix.shard }}/${{ strategy.job-total }})
-    needs: build-embedded
+    needs: [detect-ci-tier, build-embedded]
+    if: needs.detect-ci-tier.outputs.full_embedded == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/cross-version-smoke.yml
+++ b/.github/workflows/cross-version-smoke.yml
@@ -18,6 +18,10 @@ on:
         required: false
         default: '5'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     name: Upgrade smoke (${{ matrix.prev_version }} → candidate)


### PR DESCRIPTION
## Summary

- add a `detect-ci-tier` job that classifies PRs before embedded Dolt jobs run
- run full embedded Dolt coverage for `push`, `merge_group`, and PRs touching code/build/script/CI risk paths
- skip the embedded Dolt storage/cmd matrix for docs- and metadata-only PRs while leaving normal build/test/lint checks unchanged
- add concurrency cancellation to cross-version smoke runs

## Validation

- `bash -n .github/scripts/ci-embedded-tier.sh`
- `yq eval '.' .github/workflows/ci.yml >/dev/null && yq eval '.' .github/workflows/cross-version-smoke.yml >/dev/null`
- `GITHUB_EVENT_NAME=push bash .github/scripts/ci-embedded-tier.sh`
- `GITHUB_EVENT_NAME=merge_group bash .github/scripts/ci-embedded-tier.sh`
- `PR_BASE_SHA=$(git rev-parse HEAD) PR_HEAD_SHA=$(git rev-parse HEAD) GITHUB_EVENT_NAME=pull_request bash .github/scripts/ci-embedded-tier.sh`
- `PR_BASE_SHA=$(git rev-parse upstream/main^) PR_HEAD_SHA=$(git rev-parse upstream/main) GITHUB_EVENT_NAME=pull_request bash .github/scripts/ci-embedded-tier.sh`
- `git diff --check upstream/main...HEAD`

`make test` was also attempted. Package tests ran until `cmd/bd` tried to link an embedded test binary and failed with `/usr/sbin/ld: final link failed: No space left on device`; the shown test failures were from that linker error, not assertions in this patch.

## Follow-up

Shard rebalancing was split out to `bd-8zg` so this PR stays focused on CI tiering.
