### PR TITLE
fix(dolt): distinguish fsck open-failures from integrity failures

### DIFF
--- a/internal/storage/dolt/fsck_test.go
+++ b/internal/storage/dolt/fsck_test.go
@@ -2,7 +2,6 @@ package dolt
 
 import (
 	"context"
-	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,11 +56,18 @@ func TestPrePushFSCK_CleanDB(t *testing.T) {
 	}
 }
 
-// TestPrePushFSCK_CorruptNoms verifies that prePushFSCK returns
-// ErrDanglingReference when dolt fsck detects an invalid local store.
-// We simulate corruption by creating a .dolt/noms directory without running
-// dolt init — fsck fails because the repository state is invalid.
-func TestPrePushFSCK_CorruptNoms(t *testing.T) {
+// TestPrePushFSCK_UnopenableDB verifies that prePushFSCK logs a warning and
+// proceeds (returns nil) when dolt fsck cannot open the database. This avoids
+// misleading users with a corruption warning for environmental / tooling
+// failures. Example: dolthub/dolt#10915 (Windows url.Parse bug pre-v1.86.4)
+// caused fsck to fail-to-open healthy databases, which the previous wrapper
+// reported as "dangling chunk reference: aborting push to prevent propagating
+// corrupt chunks".
+//
+// We simulate the unopenable state by creating a .dolt/noms directory without
+// running dolt init — fsck prints "Could not open dolt database" and exits
+// non-zero.
+func TestPrePushFSCK_UnopenableDB(t *testing.T) {
 	t.Parallel()
 	if _, err := exec.LookPath("dolt"); err != nil {
 		t.Skip("dolt not in PATH")
@@ -75,11 +81,49 @@ func TestPrePushFSCK_CorruptNoms(t *testing.T) {
 	}
 
 	s := &DoltStore{dbPath: tmp, database: "mydb"}
-	err := s.prePushFSCK(context.Background())
-	if err == nil {
-		t.Fatal("expected ErrDanglingReference for invalid repo, got nil")
+	if err := s.prePushFSCK(context.Background()); err != nil {
+		t.Fatalf("expected nil when fsck cannot open db (should warn and proceed), got %v", err)
 	}
-	if !errors.Is(err, ErrDanglingReference) {
-		t.Fatalf("expected ErrDanglingReference, got %v", err)
+}
+
+// TestFsckCouldNotOpen verifies the helper identifies both known dolt
+// "couldn't open" phrasings and does not classify actual integrity failures
+// (or unrelated output) as open-failures.
+func TestFsckCouldNotOpen(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "windows url.Parse bug pre-1.86.4 (dolthub/dolt#10915)",
+			output: `Could not open dolt database: CreateFile \C:\Users\x\.beads\...\.dolt\noms: The filename, directory name, or volume label syntax is incorrect.`,
+			want:   true,
+		},
+		{
+			name:   "uninitialized .dolt directory",
+			output: "The current directories repository state is invalid\nopen .dolt/repo_state.json: no such file or directory",
+			want:   true,
+		},
+		{
+			name:   "actual dangling chunk reference (must still abort)",
+			output: "dangling chunk reference: hash abc123 referenced but not present",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fsckCouldNotOpen(tc.output); got != tc.want {
+				t.Errorf("fsckCouldNotOpen(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -1918,10 +1919,42 @@ func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		output := strings.TrimSpace(string(out))
+		// Distinguish "fsck couldn't run the integrity check" (environmental /
+		// tooling issue) from "fsck ran and found integrity problems" (the actual
+		// concern of PR #3447). Wrapping an open-failure as ErrDanglingReference
+		// misleads users into thinking their db is corrupt.
+		//
+		// Concrete example: dolthub/dolt#10915 (Windows url.Parse bug, pre-v1.86.4)
+		// caused fsck to construct a malformed file path and fail to open; users
+		// running `bd dolt push` saw "dangling chunk reference" errors on perfectly
+		// healthy databases.
+		//
+		// The two known "couldn't open" signatures from dolt are covered below.
+		// Any other fsck failure still aborts the push so real dangling references
+		// continue to block propagation.
+		if fsckCouldNotOpen(output) {
+			log.Printf("pre-push fsck could not run, skipping integrity check: %s", output)
+			return nil
+		}
 		return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks: %s",
-			ErrDanglingReference, strings.TrimSpace(string(out)))
+			ErrDanglingReference, output)
 	}
 	return nil
+}
+
+// fsckCouldNotOpen reports whether dolt fsck output indicates the check
+// could not run at all (as opposed to finding integrity problems). Matches
+// the known error phrasings dolt emits before any integrity work begins.
+func fsckCouldNotOpen(output string) bool {
+	switch {
+	case strings.Contains(output, "Could not open dolt database"):
+		return true
+	case strings.Contains(output, "repository state is invalid"):
+		return true
+	default:
+		return false
+	}
 }
 
 // doltCLIPush shells out to `dolt push` from the database directory.


### PR DESCRIPTION
## Problem

`prePushFSCK` (added in #3447) wraps any `dolt fsck` error as `ErrDanglingReference` with the message `aborting push to prevent propagating corrupt chunks`. That phrasing implies the local database is corrupt — but fsck can fail for environmental reasons that have nothing to do with integrity, and wrapping those as corruption misleads users.

## Root Cause

`prePushFSCK` at `internal/storage/dolt/store.go:1907-1925` treats all non-zero fsck exits identically. No distinction between:

- **fsck ran and found integrity problems** (the intended abort case)
- **fsck couldn't even open the database** (tooling / version mismatch / environmental)

## Concrete Trigger (resolved upstream, still worth hardening)

dolthub/dolt#10915 (shipped in dolt v1.86.4, 2026-04-22) — `fsck.go` used `url.Parse` to parse the database file URL; on Windows this placed the drive letter into the URL Host field rather than Path, causing `dbfactory/file.go` to construct an invalid `\C:\...` path. Every Windows bd user on dolt <1.86.4 running post-#3447 bd hit this: `bd dolt push` returned a "dangling chunk reference" error on perfectly healthy databases.

The dolt bug is fixed. This PR hardens beads against the **class** of failure mode so future dolt/bd version mismatches don't produce misleading corruption warnings.

## Fix

Distinguish "fsck couldn't run" from "fsck found problems" by matching the two known dolt phrasings that mean the check never executed:

- `"Could not open dolt database"` — the url.Parse bug symptom (and any other open failure)
- `"repository state is invalid"` — uninitialized or partial `.dolt` directory

For those cases, log a warning and proceed. For any other fsck failure, abort as before. Real dangling-reference errors still block propagation; only misleading wrappings of environmental failures are changed.

## Test Plan

```
go test -tags gms_pure_go -run TestPrePushFSCK ./internal/storage/dolt/
go test -tags gms_pure_go -run TestFsckCouldNotOpen ./internal/storage/dolt/
go test -tags gms_pure_go ./internal/storage/dolt/
```

**Updated tests:**

- `TestPrePushFSCK_UnopenableDB` (renamed from `TestPrePushFSCK_CorruptNoms`) — simulates the unopenable state (`.dolt/noms` present, no `dolt init`) and verifies `prePushFSCK` returns nil + logs a warning rather than wrapping as `ErrDanglingReference`.
- `TestFsckCouldNotOpen` (new) — table test covering both known "couldn't open" phrasings, a real dangling-reference string (must not match), and an empty string.

All previously-passing fsck tests continue to pass.

## Context

Fixes #3464.

Root cause in dolt: dolthub/dolt#10915 (fixed in v1.86.4).

Full discovery thread: `#beads` channel on Dolt Discord, 2026-04-24 — @macneale and @elianddb identified the dolt fix within minutes of the symptom being surfaced.

## Scope Guards

- Not changing `prePushFSCK`'s core intent or `#3447`'s safety-check goal
- Not adding platform-specific skips (OS-agnostic class of failure)
- Not modifying push code paths outside `prePushFSCK`
- No user-facing behavior change for healthy databases on current dolt
