### PR TITLE
Add PR preflight and contributor intake guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,11 @@
 ### Git Workflow
 - Install git hooks: `bd hooks install`
 - Use `bd dolt push` / `bd dolt pull` for remote sync
+- Before implementing related work, opening a PR, or merging/closing a PR, run:
+  `scripts/pr-preflight.sh --search "<topic>" --repo gastownhall/beads` or
+  `scripts/pr-preflight.sh <pr-number> --repo gastownhall/beads`
+- External contributor PRs have priority: build on them when possible, preserve
+  tests and attribution, and never close or replace them silently.
 
 ## Issue Tracking with bd
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,20 @@ This file exists for compatibility with tools that look for AGENTS.md.
 - **Visual Design System** - Status icons, colors, and semantic styling for CLI output
 - **Contributor Protection** - Read [CONTRIBUTING.md](CONTRIBUTING.md) before handling external PRs
 
+## PR Safety for Agents
+
+Before implementing work, opening a PR, or merging/closing a PR, run the PR
+preflight:
+```bash
+scripts/pr-preflight.sh --search "<topic keywords>" --repo gastownhall/beads
+scripts/pr-preflight.sh <pr-number> --repo gastownhall/beads
+```
+
+External contributor PRs have priority. Review and build on their branch when
+possible, preserve their tests and attribution, and never close or supersede
+their PR silently. If a rewrite is unavoidable, explain why on the original PR
+and credit their design/tests.
+
 ## Visual Design Anti-Patterns
 
 **NEVER use emoji-style icons** (🔴🟠🟡🔵⚪) in CLI output. They cause cognitive overload.

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -117,6 +117,14 @@ defer to the standard PR flow to keep changes reviewable.
 
 **Read [CONTRIBUTING.md](CONTRIBUTING.md)** — it contains promises we've made to contributors. Violating them damages trust and community.
 
+Run the read-only preflight before implementing related work, opening a PR, or
+merging/closing a PR:
+
+```bash
+scripts/pr-preflight.sh --search "<topic keywords>" --repo gastownhall/beads
+scripts/pr-preflight.sh <pr-number> --repo gastownhall/beads
+```
+
 **Before implementing any feature or fix, check for existing open PRs on the same topic:**
 
 ```bash
@@ -132,7 +140,8 @@ gh pr list --repo gastownhall/beads --state open --search "<topic keywords>" --j
 
 If you must rewrite (e.g., fundamentally different approach needed), explain why on the original PR and credit the contributor's design/tests in your commits.
 
-This is enforced by pre-use hooks. If you try `gh pr create`, it will be blocked.
+Do not rely on auto-discovery of CONTRIBUTING.md; the preflight is the agent
+gate for PR handling.
 
 ## Landing the Plane
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,6 +296,40 @@ This project uses AI agents for maintenance. We've established strict rules to p
 
 If any of this goes wrong, please open an issue — we take contributor experience seriously.
 
+### Refactoring Campaign PR Intake Checklist
+
+Before starting a rewrite, cleanup, or large refactoring pass, maintainers and agents must review open contributor PRs that touch the same area. Use this checklist to decide whether to merge, rebase, incorporate, or close each PR.
+
+1. Identify overlap:
+   - Read the PR description, changed files, linked issues, and latest review comments.
+   - Compare the PR scope with the planned refactor and note any shared files, commands, migrations, tests, docs, or release paths.
+   - If the PR is unrelated, leave it alone unless the refactor would still create a merge conflict.
+
+2. Prefer clean merges:
+   - If the PR is focused, passing CI, and aligned with current design, review it as the first option.
+   - Merge it before the refactor when that reduces conflict risk.
+   - Preserve the contributor's commits and attribution unless the contributor agrees to a squash or rework.
+
+3. Request a rebase when needed:
+   - Ask for a rebase if the PR is still valid but conflicts with main or depends on code that has moved.
+   - Give concrete instructions about the new target files or APIs.
+   - Do not rewrite the same work in parallel while waiting unless there is a release blocker or security issue.
+
+4. Preserve tests and intent:
+   - Treat contributor tests as part of the contribution, not optional scaffolding.
+   - If a refactor supersedes implementation code, port the tests or explain why they are invalid.
+   - Keep user-facing behavior, docs examples, and regression coverage intact unless the PR is explicitly changing the contract.
+
+5. Close superseded PRs with explicit rationale:
+   - Close only after commenting with the replacement commit, PR, or issue.
+   - Explain what was preserved, what changed, and why the original branch will not be merged.
+   - Thank the contributor and invite follow-up if their use case was not fully covered.
+
+6. Leave an audit trail:
+   - Link the intake decision from the refactor PR or Beads issue.
+   - Record any follow-up work as Beads issues instead of hidden notes.
+   - Call out contributor-owned tests or behavior in the refactor PR summary.
+
 ## Code Review Process
 
 All contributions go through code review:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,23 @@
 
 Utility scripts for maintaining the beads project.
 
+## pr-preflight.sh
+
+Read-only PR safety check for agents and maintainers.
+
+```bash
+# Before implementing or opening a related PR
+./scripts/pr-preflight.sh --search "topic keywords" --repo gastownhall/beads
+
+# Before changing, closing, or merging an existing PR
+./scripts/pr-preflight.sh 123 --repo gastownhall/beads
+```
+
+It reports contributor/fork status, draft/review/merge/check state, risky diff
+signals such as `.beads/` changes or missing tests, and the required
+contributor-protection next steps. It does not replace code review or local
+validation.
+
 ## release.sh (⭐ The Easy Button)
 
 **One-command release** from version bump to local installation.

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Agent PR preflight for beads.
+#
+# This script is read-only. It turns the contributor-protection policy into a
+# concrete checklist before an agent reviews, closes, merges, or supersedes a PR.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pr-preflight.sh <pr-number-or-url> [--repo owner/name]
+  scripts/pr-preflight.sh --search "<topic keywords>" [--repo owner/name]
+
+Before changing or merging an existing PR:
+  scripts/pr-preflight.sh 123 --repo gastownhall/beads
+
+Before implementing a feature/fix or opening a replacement PR:
+  scripts/pr-preflight.sh --search "dependency cycle detection" --repo gastownhall/beads
+
+What this checks:
+  - whether an existing PR is external/cross-repository contributor work
+  - draft, review, mergeability, and check status
+  - risky diff signals: .beads data, missing tests for code changes, large diffs
+  - contributor-protection next steps and attribution reminders
+
+The script does not replace code review or local validation.
+EOF
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 2
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+repo_from_url() {
+  sed -E \
+    -e 's#^git@github.com:##' \
+    -e 's#^https://github.com/##' \
+    -e 's#^ssh://git@github.com/##' \
+    -e 's#\.git$##' \
+    <<<"$1"
+}
+
+default_repo() {
+  local url
+  if url=$(git remote get-url upstream 2>/dev/null); then
+    repo_from_url "$url"
+    return
+  fi
+  if url=$(git remote get-url origin 2>/dev/null); then
+    repo_from_url "$url"
+    return
+  fi
+  gh repo view --json nameWithOwner --jq .nameWithOwner
+}
+
+repo=""
+pr=""
+search=""
+
+while (($#)); do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || die "--repo requires owner/name"
+      repo="$2"
+      shift 2
+      ;;
+    --search)
+      [[ $# -ge 2 ]] || die "--search requires keywords"
+      search="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      die "unknown option: $1"
+      ;;
+    *)
+      [[ -z "$pr" ]] || die "only one PR may be provided"
+      pr="$1"
+      shift
+      ;;
+  esac
+done
+
+need gh
+need git
+need jq
+
+repo="${repo:-$(default_repo)}"
+[[ -n "$repo" ]] || die "could not determine GitHub repo; pass --repo owner/name"
+
+if [[ -n "$search" ]]; then
+  printf 'PR topic preflight for %s\n' "$repo"
+  printf 'Search: %s\n\n' "$search"
+
+  results=$(gh pr list \
+    --repo "$repo" \
+    --state open \
+    --search "$search" \
+    --json number,title,author,headRefName,isCrossRepository,url,updatedAt)
+
+  count=$(jq 'length' <<<"$results")
+  if [[ "$count" -eq 0 ]]; then
+    printf '[pass] No open PRs matched this search.\n'
+    printf '[next] Use broader keywords if the topic is ambiguous before opening a new PR.\n'
+    exit 0
+  fi
+
+  printf '[block] Found %s open PR(s). Review relevant contributor work before building separately.\n\n' "$count"
+  jq -r '.[] |
+    "- PR #\(.number): \(.title)\n  author: \(.author.login)  external: \(.isCrossRepository)  branch: \(.headRefName)\n  url: \(.url)"' \
+    <<<"$results"
+  printf '\n[next] Run scripts/pr-preflight.sh <number> --repo %s for each relevant PR.\n' "$repo"
+  exit 1
+fi
+
+[[ -n "$pr" ]] || { usage; exit 2; }
+
+json=$(gh pr view "$pr" \
+  --repo "$repo" \
+  --json number,title,author,url,baseRefName,headRefName,headRepositoryOwner,isCrossRepository,isDraft,maintainerCanModify,mergeStateStatus,mergeable,reviewDecision,changedFiles,additions,deletions,files,statusCheckRollup,closingIssuesReferences,latestReviews)
+
+number=$(jq -r .number <<<"$json")
+title=$(jq -r .title <<<"$json")
+author=$(jq -r .author.login <<<"$json")
+url=$(jq -r .url <<<"$json")
+external=$(jq -r .isCrossRepository <<<"$json")
+draft=$(jq -r .isDraft <<<"$json")
+review=$(jq -r 'if (.reviewDecision // "") == "" then "REVIEW_REQUIRED" else .reviewDecision end' <<<"$json")
+merge_state=$(jq -r '.mergeStateStatus // "UNKNOWN"' <<<"$json")
+mergeable=$(jq -r '.mergeable // "UNKNOWN"' <<<"$json")
+files=$(jq -r .changedFiles <<<"$json")
+additions=$(jq -r .additions <<<"$json")
+deletions=$(jq -r .deletions <<<"$json")
+maintainer_can_modify=$(jq -r '.maintainerCanModify // false' <<<"$json")
+
+status=0
+
+block() {
+  printf '[block] %s\n' "$*"
+  status=1
+}
+
+warn() {
+  printf '[warn] %s\n' "$*"
+}
+
+pass() {
+  printf '[pass] %s\n' "$*"
+}
+
+printf 'PR preflight for %s#%s\n' "$repo" "$number"
+printf 'Title: %s\n' "$title"
+printf 'Author: %s\n' "$author"
+printf 'URL: %s\n' "$url"
+printf 'Base/head: %s <- %s\n' "$(jq -r .baseRefName <<<"$json")" "$(jq -r .headRefName <<<"$json")"
+printf 'Diff: %s files, +%s/-%s\n\n' "$files" "$additions" "$deletions"
+
+if [[ "$external" == "true" ]]; then
+  warn "External contributor PR. Do not rewrite, close, or supersede silently."
+  if [[ "$maintainer_can_modify" == "true" ]]; then
+    pass "Maintainers can push fixes to this PR branch."
+  else
+    warn "Maintainers cannot push to this PR branch; coordinate in comments or use a credited follow-up branch."
+  fi
+else
+  pass "PR is not cross-repository contributor work."
+fi
+
+if [[ "$draft" == "true" ]]; then
+  block "PR is draft."
+fi
+
+case "$review" in
+  APPROVED)
+    pass "Review decision is APPROVED."
+    ;;
+  CHANGES_REQUESTED)
+    block "Review decision is CHANGES_REQUESTED."
+    ;;
+  *)
+    warn "Review decision is ${review}."
+    ;;
+esac
+
+case "$merge_state" in
+  CLEAN|HAS_HOOKS)
+    pass "Merge state is ${merge_state}."
+    ;;
+  BLOCKED|DIRTY|UNKNOWN|UNSTABLE)
+    block "Merge state is ${merge_state}."
+    ;;
+  *)
+    warn "Merge state is ${merge_state}; verify in GitHub before merging."
+    ;;
+esac
+
+if [[ "$mergeable" == "CONFLICTING" ]]; then
+  block "GitHub reports merge conflicts."
+fi
+
+failed_checks=$(jq '[.statusCheckRollup[]? | select(
+  ((.conclusion // "") | test("FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED")) or
+  ((.state // "") | test("ERROR|FAILURE"))
+)] | length' <<<"$json")
+pending_checks=$(jq '[.statusCheckRollup[]? | select(
+  if (.status? // null) != null then
+    .status != "COMPLETED"
+  elif (.state? // null) != null then
+    (.state | test("^(EXPECTED|PENDING)$"))
+  else
+    true
+  end
+)] | length' <<<"$json")
+if [[ "$failed_checks" -gt 0 ]]; then
+  block "$failed_checks status check(s) failed or require action."
+elif [[ "$pending_checks" -gt 0 ]]; then
+  block "$pending_checks status check(s) are still pending."
+else
+  pass "No failed or pending status checks reported."
+fi
+
+beads_files=$(jq '[.files[]?.path | select(startswith(".beads/"))] | length' <<<"$json")
+if [[ "$beads_files" -gt 0 ]]; then
+  block "PR changes .beads/ data; contributor PRs must not include planning database changes."
+fi
+
+code_files=$(jq '[.files[]?.path | select(test("\\.(go|py|sh)$"))] | length' <<<"$json")
+test_files=$(jq '[.files[]?.path | select(test("(^|/)(test|tests)/|_test\\.go$|\\.bats$"))] | length' <<<"$json")
+if [[ "$code_files" -gt 0 && "$test_files" -eq 0 ]]; then
+  warn "Code changed but no obvious test files changed."
+fi
+
+if [[ "$files" -gt 30 || "$additions" -gt 1000 ]]; then
+  warn "Large PR; verify scope is one issue and one PR."
+fi
+
+issue_count=$(jq '[.closingIssuesReferences[]?] | length' <<<"$json")
+if [[ "$issue_count" -eq 0 ]]; then
+  warn "No closing issue reference found."
+else
+  pass "PR references $issue_count closing issue(s)."
+fi
+
+printf '\nChanged files:\n'
+jq -r '.files[]?.path | "  - \(.)"' <<<"$json"
+
+printf '\nRequired agent behavior:\n'
+printf '  - Review contributor work first; build on it when relevant.\n'
+printf '  - Preserve contributor tests unless they are wrong.\n'
+printf '  - Preserve attribution with existing commits or Co-authored-by trailers.\n'
+printf '  - If a rewrite is unavoidable, explain why on PR #%s and credit design/tests.\n' "$number"
+printf '  - Run local validation before merge, normally: make test\n'
+
+if [[ "$status" -ne 0 ]]; then
+  printf '\nResult: BLOCKED for autonomous merge/close/replacement until addressed.\n'
+else
+  printf '\nResult: preflight passed. Continue with code review and local validation.\n'
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- add `scripts/pr-preflight.sh` for read-only agent PR safety checks
- wire the preflight into `AGENTS.md`, `AGENT_INSTRUCTIONS.md`, Copilot instructions, and `scripts/README.md`
- add the `CONTRIBUTING.md` refactoring-campaign PR intake checklist from the original agent-protection work
- classify legacy `StatusContext.state` values separately from Actions check-run fields, so successful legacy commit statuses are not treated as pending

## Validation
- `scripts/pr-preflight.sh --search "agent contributor protection preflight" --repo gastownhall/beads`
- `bash -n scripts/pr-preflight.sh`
- `shellcheck scripts/pr-preflight.sh`
- synthetic jq rollup check for legacy status contexts plus check runs

## Notes
- Full `make test` was attempted earlier but blocked by environment-specific test issues unrelated to this shell/doc change: tmpfs Go build quota, home-directory `.beads` discovery, and missing Dolt identity under isolated `HOME`.
