### PR TITLE
fix: consult config.yaml for dolt.host in GetDoltServerHost (mirror GH#2073)

### DIFF
--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/steveyegge/beads/internal/config"
 )
 
 const ConfigFileName = "metadata.json"
@@ -263,13 +265,20 @@ func (c *Config) GetDoltMode() string {
 }
 
 // GetDoltServerHost returns the Dolt server host.
-// Checks BEADS_DOLT_SERVER_HOST env var first, then config, then default.
+// Priority: BEADS_DOLT_SERVER_HOST env var > metadata.json dolt_server_host
+// > config.yaml / global config dolt.host > DefaultDoltServerHost.
+// The config.yaml layer mirrors the dolt.port fix (GH#2073) so a shared
+// team / user-level Dolt server can be configured once without per-clone
+// metadata.json edits.
 func (c *Config) GetDoltServerHost() string {
 	if h := os.Getenv("BEADS_DOLT_SERVER_HOST"); h != "" {
 		return h
 	}
 	if c.DoltServerHost != "" {
 		return c.DoltServerHost
+	}
+	if h := config.GetYamlConfig("dolt.host"); h != "" {
+		return h
 	}
 	return DefaultDoltServerHost
 }

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -266,6 +268,44 @@ func TestDoltServerMode(t *testing.T) {
 					t.Errorf("GetDoltServerHost() = %q, want %q", got, tt.want)
 				}
 			})
+		}
+	})
+
+	t.Run("GetDoltServerHost_config_yaml", func(t *testing.T) {
+		// Mirror of the dolt.port config.yaml fix (GH#2073) for host.
+		// Precedence: env > metadata.json > config.yaml > default.
+
+		// Ensure no host env var leaks into the test.
+		t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+
+		configDir := t.TempDir()
+		configYaml := filepath.Join(configDir, "config.yaml")
+		if err := os.WriteFile(configYaml,
+			[]byte("dolt.host: 100.64.0.1\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("BEADS_DIR", configDir)
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+		t.Cleanup(config.ResetForTesting)
+
+		// config.yaml wins when metadata.json leaves host unset.
+		emptyCfg := &Config{}
+		if got := emptyCfg.GetDoltServerHost(); got != "100.64.0.1" {
+			t.Errorf("empty cfg + config.yaml: GetDoltServerHost() = %q, want 100.64.0.1", got)
+		}
+
+		// metadata.json wins over config.yaml when both set.
+		metaCfg := &Config{DoltServerHost: "192.168.1.100"}
+		if got := metaCfg.GetDoltServerHost(); got != "192.168.1.100" {
+			t.Errorf("metadata over config.yaml: GetDoltServerHost() = %q, want 192.168.1.100", got)
+		}
+
+		// env var wins over config.yaml.
+		t.Setenv("BEADS_DOLT_SERVER_HOST", "10.0.0.1")
+		if got := emptyCfg.GetDoltServerHost(); got != "10.0.0.1" {
+			t.Errorf("env over config.yaml: GetDoltServerHost() = %q, want 10.0.0.1", got)
 		}
 	})
 


### PR DESCRIPTION
## Summary

`GetDoltServerHost()` resolves the Dolt server host as
`BEADS_DOLT_SERVER_HOST env > metadata.json dolt_server_host > 127.0.0.1`
— skipping the `~/.config/bd/config.yaml` / global config layer. This
makes the host story asymmetric with port: GH#2073 added config.yaml
consultation for `dolt.port` in `DefaultConfig` (commit `e6734290`),
but no analogous fix for host has landed.

## Why this matters

Multi-developer teams sharing a single tailnet-reachable Dolt
sql-server want to pin the host once per user in
`~/.config/bd/config.yaml`. Without this, teams must either:

1. Set `BEADS_DOLT_SERVER_HOST` in every operator's shell profile
   (works but per-shell), or
2. Sweep per-clone `.beads/metadata.json` edits (works but per-repo).

Neither matches the documented "user config is consulted" precedence
that `bd dolt show` advertises.

We hit this on a factfiber.ai migration moving Dolt from per-dev
loopback to a shared tailnet IP. The port fix from GH#2073 helped;
host needed the symmetric treatment.

## Patch

`internal/configfile/configfile.go`:

```diff
 // GetDoltServerHost returns the Dolt server host.
-// Checks BEADS_DOLT_SERVER_HOST env var first, then config, then default.
+// Priority: BEADS_DOLT_SERVER_HOST env var > metadata.json dolt_server_host
+// > config.yaml / global config dolt.host > DefaultDoltServerHost.
 func (c *Config) GetDoltServerHost() string {
     if h := os.Getenv("BEADS_DOLT_SERVER_HOST"); h != "" {
         return h
     }
     if c.DoltServerHost != "" {
         return c.DoltServerHost
     }
+    if h := config.GetYamlConfig("dolt.host"); h != "" {
+        return h
+    }
     return DefaultDoltServerHost
 }
```

Resulting precedence: `env > metadata.json > config.yaml > default`,
matching the order shown by `bd dolt show` and consistent with the
GH#2073 port fix.

## Test plan

- [x] New `GetDoltServerHost_config_yaml` subtest in
      `internal/configfile/configfile_test.go` covering four
      precedence branches: yaml-wins-when-metadata-empty,
      metadata-over-yaml, env-over-yaml, default-when-no-signal
      (existing default test continues to cover the last case).
- [x] `go test ./internal/configfile/` passes (with
      `BEADS_DOLT_SERVER_HOST` cleared from env — existing tests in
      `TestDoltServerMode/GetDoltServerHost` already assume this).
- [x] `gofmt` clean, `go vet` clean.

## Notes

- `internal/configfile` previously had no dependency on
  `internal/config`; the new import is one-directional, no cycle.
- Stale `~/.config/bd/config.yaml` from prior `bd dolt set host`
  invocations could surprise users who expect the previous metadata-
  only behavior. Mitigation: `bd doctor --fix` or manual cleanup.
  This is the same surprise window the port fix introduced.