### PR TITLE
ci: mint Homebrew tap token from GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual dispatch is only for rerunning a release from a v* tag. Publishing
+  # jobs below are tag-gated and skip branch refs.
   workflow_dispatch:
 
 concurrency:
@@ -16,7 +18,7 @@ permissions:
 jobs:
   goreleaser:
     # Guard: only run goreleaser in the canonical repository (not in forks)
-    if: ${{ github.repository == 'gastownhall/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -66,7 +68,7 @@ jobs:
   goreleaser-macos:
     # Build macOS binaries with CGO_ENABLED=1 for embedded Dolt support.
     # Runs on native macOS to avoid zig/osxcross cross-compilation issues.
-    if: ${{ github.repository == 'gastownhall/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     needs: goreleaser
     runs-on: macos-latest
     steps:
@@ -178,7 +180,7 @@ jobs:
 
   update-homebrew-formula:
     # Generate Homebrew formula after all archives (Linux + macOS) are uploaded.
-    if: ${{ github.repository == 'gastownhall/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     needs: [goreleaser, goreleaser-macos]
     runs-on: ubuntu-latest
     steps:
@@ -279,7 +281,7 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     needs: goreleaser
-    if: ${{ always() && github.repository == 'gastownhall/beads' }}
+    if: ${{ always() && github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -308,7 +310,7 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     needs: goreleaser
-    if: ${{ github.repository == 'gastownhall/beads' }}
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: read
       id-token: write  # Required for npm provenance/trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,6 @@ jobs:
             ${{ github.repository != 'gastownhall/beads' && '--skip=publish --skip=announce' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Homebrew tap is updated by the update-homebrew-formula job (not goreleaser)
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           # Windows code signing (optional - signing is skipped if not set)
           WINDOWS_SIGNING_CERT_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_PFX_BASE64 }}
           WINDOWS_SIGNING_CERT_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERT_PASSWORD }}
@@ -191,10 +189,20 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Mint Homebrew tap token
+        id: homebrew-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: gastownhall
+          repositories: homebrew-beads
+          permission-contents: write
+
       - name: Generate and push Homebrew formula
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-token.outputs.token }}
         run: |
           version="${{ steps.version.outputs.version }}"
           tag="v${version}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -164,7 +164,6 @@ brews:
     repository:
       owner: gastownhall
       name: homebrew-beads
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     # Disabled: macOS archives are built by a separate CI job (goreleaser-macos),
     # so goreleaser can't generate a complete formula. The update-homebrew-formula

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -38,6 +38,9 @@ A beads release involves multiple distribution channels:
 ### Required Access
 
 - GitHub: Write access to repository and ability to create releases
+- GitHub: Ability to create protected `v*` release tags. The repository should
+  restrict `refs/tags/v*` creation, updates, and deletion to trusted release
+  maintainers.
 - PyPI: Maintainer access to `beads-mcp` package
 - npm: Member of `@beads` organization
 
@@ -164,6 +167,10 @@ git tag -a v0.22.0 -m "Release v0.22.0"
 git push origin main
 git push origin v0.22.0
 ```
+
+The release workflow is intentionally gated to `refs/tags/v*`. A manual
+workflow dispatch from a branch will skip publishing jobs; manual reruns must
+select the release tag.
 
 **Alternative (step-by-step):**
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -100,6 +100,11 @@ git push origin v0.9.X
 - GoReleaser builds and publishes binaries to GitHub Releases
 - PyPI publish job uploads the MCP server package to PyPI
 
+Release automation only runs for `v*` tags. Keep `refs/tags/v*` protected so
+only trusted release maintainers can create, update, or delete release tags.
+Manual workflow dispatch is for rerunning a release from the tag, not from a
+branch.
+
 ### 2. GitHub Secrets Setup (One-Time)
 
 The automation requires this secret to be configured:


### PR DESCRIPTION
## Summary

- Mint `HOMEBREW_TAP_TOKEN` in the release workflow using `actions/create-github-app-token@v3` and the new `HOMEBREW_TAP_APP_*` secrets.
- Scope the installation token to `gastownhall/homebrew-beads` with `contents: write`.
- Remove the stale `HOMEBREW_TAP_TOKEN` dependency from the GoReleaser job and GoReleaser config, since the tap is updated by the dedicated workflow job.
- Gate every release publishing job to the canonical repo and `refs/tags/v*`, so manual branch dispatches skip publishing credentials.
- Document that `refs/tags/v*` should be protected for trusted release maintainers.

## Verification

- Confirmed OpenBao contains `HOMEBREW_TAP_APP_ID` and `HOMEBREW_TAP_APP_PRIVATE_KEY` for `gastownhall/beads`.
- Synced both secrets into `gastownhall/beads` Actions secrets.
- Verified the GitHub App can mint an installation token with `contents: write` for `gastownhall/homebrew-beads`.
- Verified the minted token can authenticate Git HTTPS access to `gastownhall/homebrew-beads.git`.
- Ran `yq` checks for the workflow and exact release-job tag guard expression.
- Ran `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`.
- Ran `git diff --check`.

## Notes

This avoids relying on Steve's temporary personal tap token for future releases and keeps release publishing credentials tied to protected `v*` release refs.