### PR TITLE
fix: ApplyCLIAutoStart respects ServerModeExternal (mirror NewFromConfigWithOptions)

### DIFF
--- a/cmd/bd/doctor/federation_test.go
+++ b/cmd/bd/doctor/federation_test.go
@@ -98,9 +98,11 @@ func TestCheckFederationRemotesAPI_ServerNotRunning(t *testing.T) {
 	}
 }
 
-func TestDoltServerConfig_EnablesCLIAutoStartWithConfiguredPort(t *testing.T) {
+func TestDoltServerConfig_SuppressesCLIAutoStartWithConfiguredPort(t *testing.T) {
 	t.Setenv("BEADS_TEST_MODE", "")
 	t.Setenv("BEADS_DOLT_AUTO_START", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
 
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
@@ -119,8 +121,35 @@ func TestDoltServerConfig_EnablesCLIAutoStartWithConfiguredPort(t *testing.T) {
 	}
 
 	result := doltServerConfig(beadsDir, filepath.Join(beadsDir, "dolt"))
+	if result.AutoStart {
+		t.Fatal("doltServerConfig should suppress CLI auto-start with an external configured server port")
+	}
+}
+
+func TestDoltServerConfig_EnablesCLIAutoStartWithoutConfiguredPort(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "")
+	t.Setenv("BEADS_DOLT_AUTO_START", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configfile.Config{
+		Backend:      configfile.BackendDolt,
+		DoltDatabase: "beads_test",
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := doltServerConfig(beadsDir, filepath.Join(beadsDir, "dolt"))
 	if !result.AutoStart {
-		t.Fatal("doltServerConfig should enable CLI auto-start even with a configured server port")
+		t.Fatal("doltServerConfig should enable CLI auto-start for owned standalone configs")
 	}
 }
 

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -22,18 +22,26 @@ const (
 	ServerModeEmbedded = doltserver.ServerModeEmbedded
 )
 
-// ApplyCLIAutoStart sets the same standalone auto-start policy used by the
-// normal CLI path. This intentionally ignores metadata.json explicit-port
-// suppression so doctor and other CLI helper paths behave the same way as
-// cmd/bd/main.go on cold repo-local standalone setups.
+// ApplyCLIAutoStart sets the standalone auto-start policy used by the
+// normal CLI path. Honors the actual server mode resolved from
+// metadata.json + env: when External (e.g. metadata.json has explicit
+// dolt_server_port), suppresses fallback auto-spawn — the user has
+// configured an external server; if it's transiently unreachable, bd
+// errors out rather than silently spawning a different server from
+// .beads/dolt/ (the shadow database bug).
+//
+// Cold standalone setups remain unaffected: bd init writes the port and
+// starts the server in one shot, so subsequent commands find a running
+// server and don't need fallback auto-start. If the user explicitly
+// stops the server, External mode's "you manage the lifecycle" semantics
+// asks the user to run `bd dolt start`.
 func ApplyCLIAutoStart(beadsDir string, cfg *Config) {
 	autoStartCfg := config.GetString("dolt.auto-start")
 	if autoStartCfg == "" {
 		autoStartCfg = config.GetStringFromDir(beadsDir, "dolt.auto-start")
 	}
-	// Pass ServerModeOwned to avoid external-mode suppression — this path
-	// intentionally behaves like a standalone owned-server setup.
-	cfg.AutoStart = resolveAutoStart(true, autoStartCfg, ServerModeOwned)
+	mode := doltserver.ResolveServerMode(beadsDir)
+	cfg.AutoStart = resolveAutoStart(true, autoStartCfg, mode)
 }
 
 // NewFromConfig creates a DoltStore based on the metadata.json configuration.

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -51,10 +51,9 @@ func NewFromConfig(ctx context.Context, beadsDir string) (*DoltStore, error) {
 }
 
 // NewFromConfigWithCLIOptions creates a DoltStore using the standalone CLI
-// auto-start policy from cmd/bd/main.go instead of the explicit-port
-// suppression used by library-style config opens. This is for CLI helper paths
-// like `bd doctor` that should behave the same way as normal top-level CLI
-// commands on cold repo-local standalone setups.
+// auto-start policy from cmd/bd/main.go. This is for CLI helper paths like
+// `bd doctor` that should behave the same way as normal top-level CLI commands
+// while still honoring externally managed server mode.
 func NewFromConfigWithCLIOptions(ctx context.Context, beadsDir string, cfg *Config) (*DoltStore, error) {
 	fileCfg, err := configfile.Load(beadsDir)
 	if err != nil {

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -106,6 +106,43 @@ func TestResolveAutoStart(t *testing.T) {
 	}
 }
 
+// TestApplyCLIAutoStart_RespectsExternalMode verifies that an external-mode
+// repo (metadata.json with explicit dolt_server_port) suppresses the CLI
+// auto-start path, preventing the shadow-database fallback when the
+// configured external server is transiently unreachable.
+//
+// Regression for the case where ApplyCLIAutoStart hardcoded ServerModeOwned
+// and bypassed resolveAutoStart's external-mode check, so any bd command in
+// an external-mode repo could spawn a fallback embedded server when the
+// configured server didn't respond (e.g. during a service cutover).
+func TestApplyCLIAutoStart_RespectsExternalMode(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_AUTO_START", "")
+	t.Setenv("BEADS_TEST_MODE", "")
+
+	beadsDir := t.TempDir()
+	// metadata.json with explicit dolt_server_port → ServerModeExternal.
+	cfg := configfile.DefaultConfig()
+	cfg.DoltMode = configfile.DoltModeServer
+	cfg.DoltServerPort = 3399
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata.json: %v", err)
+	}
+
+	if got := doltserver.ResolveServerMode(beadsDir); got != doltserver.ServerModeExternal {
+		t.Fatalf("ResolveServerMode = %v, want External (preflight)", got)
+	}
+
+	// No config.yaml dolt.auto-start set — relies entirely on External-
+	// mode suppression. Pre-fix this would return AutoStart=true (default).
+	storeCfg := &Config{}
+	ApplyCLIAutoStart(beadsDir, storeCfg)
+	if storeCfg.AutoStart {
+		t.Errorf("ApplyCLIAutoStart set AutoStart=true in external-mode repo; want false (shadow database protection)")
+	}
+}
+
 func TestCLIDirUsesSharedDoltRootInSharedServerMode(t *testing.T) {
 	sharedRoot := t.TempDir()
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")


### PR DESCRIPTION
## Summary

\`ApplyCLIAutoStart\` (in \`internal/storage/dolt/open.go\`) hardcoded
\`ServerModeOwned\` when calling \`resolveAutoStart\`, bypassing the
external-mode check that \`resolveAutoStart\`'s docstring lists as
priority 3 — the protection against the **shadow database bug**:
when a repo has \`metadata.json dolt_server_port\` set (External
mode) and the configured server is transiently unreachable, bd
was free to spawn a fallback embedded server from \`.beads/dolt/\`.

The companion path \`NewFromConfigWithOptions\` correctly resolves
the actual server mode (open.go:104) and passes it to
\`resolveAutoStart\`, so external-mode suppression worked there.
The \`cmd/bd/main.go:889\` path that routes through
\`ApplyCLIAutoStart\` silently lost the protection.

## Real-world failure mode

Hit at factfiber.ai 2026-04-24 during a service cutover that
briefly took the team's central Dolt server offline. A bd
write hook fired in an external-mode repo, hit a transient
connect-failure to the configured server, and spawned a shadow
\`dolt sql-server\` on the same loopback port. The orphan
ran for 18 hours, intercepting bd commands from other shells
and surfacing \"database not found\" errors against an empty
fallback chunkstore. Investigation in
[this team's notes](https://github.com/factfiber/factfiber-meta/blob/main/tmp/issues/factfiber-meta/dolt-2/v3/phase-0-results.md)
traced it to \`ApplyCLIAutoStart\`'s hardcoded \`ServerModeOwned\`.

## Patch

\`\`\`diff
 func ApplyCLIAutoStart(beadsDir string, cfg *Config) {
     autoStartCfg := config.GetString(\"dolt.auto-start\")
     if autoStartCfg == \"\" {
         autoStartCfg = config.GetStringFromDir(beadsDir, \"dolt.auto-start\")
     }
-    // Pass ServerModeOwned to avoid external-mode suppression — this path
-    // intentionally behaves like a standalone owned-server setup.
-    cfg.AutoStart = resolveAutoStart(true, autoStartCfg, ServerModeOwned)
+    mode := doltserver.ResolveServerMode(beadsDir)
+    cfg.AutoStart = resolveAutoStart(true, autoStartCfg, mode)
 }
\`\`\`

Plus an updated doc comment explaining why the prior rationale
(\"so doctor and other CLI helper paths behave the same way as
cmd/bd/main.go on cold repo-local standalone setups\") is no
longer load-bearing once respected: a cold standalone post-bd-init
already has its server running, so no fallback auto-start is
needed; if the user explicitly stops the server, External mode's
\"you manage the lifecycle\" semantics asks the user to run
\`bd dolt start\`.

## Test plan

- [x] New \`TestApplyCLIAutoStart_RespectsExternalMode\` regression
      in \`internal/storage/dolt/open_test.go\` — metadata.json with
      \`dolt_server_port\` set + no config.yaml \`dolt.auto-start\` →
      \`cfg.AutoStart\` must be false. Pre-fix this returned true.
- [x] \`go test ./internal/storage/dolt/ ./internal/configfile/ ./internal/config/\`
      passes (with \`BEADS_DOLT_SERVER_HOST\` cleared from env —
      pre-existing test isolation requirement).
- [x] Existing \`TestResolveAutoStart\` cases unchanged.

## Notes

- Same shape as the upstream \`dolt.host\` config.yaml symmetry fix
  in #3471 (mirroring of GH#2073's port fix to host).
- \`internal/storage/dolt\` already imports
  \`internal/doltserver\` for the \`ServerMode\` re-exports, so no
  new dependency.