### PR TITLE
fix(storage/dolt): apply ExcludeLabels filter in server-mode GetReadyWork

### DIFF
--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -118,6 +118,16 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 			args = append(args, label)
 		}
 	}
+	if len(filter.ExcludeLabels) > 0 {
+		placeholders := make([]string, len(filter.ExcludeLabels))
+		for i, label := range filter.ExcludeLabels {
+			placeholders[i] = "?"
+			args = append(args, label)
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf(
+			"id NOT IN (SELECT issue_id FROM labels WHERE label IN (%s))",
+			strings.Join(placeholders, ", ")))
+	}
 	// Parent filtering: filter to children of specified parent (GH#2009)
 	// Explicit parent-child dependency takes precedence over dotted-ID prefix.
 	if filter.ParentID != nil {


### PR DESCRIPTION
## Summary

`DoltStore.GetReadyWork` in **server mode** handled `WorkFilter.Labels` but never applied `WorkFilter.ExcludeLabels`, so `bd ready --exclude-label=<label>` silently no-opped against dolt server-mode stores. The embedded backend already implements the clause correctly via `issueops.GetReadyWorkInTx` (lines 93–100), so the two code paths had drifted.

## Reproduction (1.0.3, server-mode store)

```
$ bd list --label=tracker --exclude-label=tracker --status=open
No issues found.    # exclude-label works on bd list

$ bd ready --exclude-label=tracker | grep ass-b0b0
○ ass-b0b0 ● P1 …    # still appears — exclude ignored
```

## Fix

Port the same SQL clause from `internal/storage/issueops/ready_work.go` into `DoltStore.GetReadyWork` in `internal/storage/dolt/queries.go`, slotted between the existing `Labels` block and the `ParentID` block.

## Test coverage

`cmd/bd/ready_test.go::TestGetReadyWork_ExcludeLabels` already existed and exercises `*dolt.DoltStore` via `newTestStore`. It was previously hidden behind the `t.Skip` in `newTestStoreWithPrefix` when the dolt test container was unavailable. With the dolt test container running locally, the test fails on `main` and passes on this branch:

```
--- FAIL: TestGetReadyWork_ExcludeLabels (before)
    --- FAIL: TestGetReadyWork_ExcludeLabels/ExcludeSingleLabel
    --- FAIL: TestGetReadyWork_ExcludeLabels/ExcludeMultipleLabels

--- PASS: TestGetReadyWork_ExcludeLabels (after)
    --- PASS: TestGetReadyWork_ExcludeLabels/ExcludeSingleLabel
    --- PASS: TestGetReadyWork_ExcludeLabels/ExcludeMultipleLabels
```

## Notes

`DoltStore.GetBlockedIssues` delegates to `issueops.GetBlockedIssuesInTx`, which does not filter by label at all — but `blockedCmd` in `cmd/bd/ready.go` only surfaces `--parent`, not `--exclude-label`, so there is no parallel user-visible bug to fix on that path.

The silent-skip behavior in `cmd/bd/test_helpers_test.go` that allowed this regression to slip through is left for a follow-up so this PR stays focused on the bug.