### PR TITLE
Fix ready/list UX regressions

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -850,9 +850,56 @@ var listCmd = &cobra.Command{
 		}
 
 		// Direct mode
-		issues, err := activeStore.SearchIssues(ctx, "", filter)
-		if err != nil {
-			FatalError("%v", err)
+		var issues []*types.Issue
+		if readyFlag {
+			// Use blocker-aware GetReadyWork semantics (GH#3478).
+			// This ensures bd list --ready matches bd ready behavior,
+			// excluding issues with open blocks dependencies.
+			wf := types.WorkFilter{
+				Status: types.StatusOpen,
+				Limit:  filter.Limit,
+			}
+			if filter.IssueType != nil {
+				wf.Type = string(*filter.IssueType)
+			}
+			if filter.Priority != nil {
+				wf.Priority = filter.Priority
+			}
+			if filter.Assignee != nil {
+				wf.Assignee = filter.Assignee
+			}
+			if filter.NoAssignee {
+				wf.Unassigned = true
+			}
+			if len(filter.Labels) > 0 {
+				wf.Labels = filter.Labels
+			}
+			if len(filter.LabelsAny) > 0 {
+				wf.LabelsAny = filter.LabelsAny
+			}
+			if len(filter.ExcludeLabels) > 0 {
+				wf.ExcludeLabels = filter.ExcludeLabels
+			}
+			if filter.LabelPattern != "" {
+				wf.LabelPattern = filter.LabelPattern
+			}
+			if filter.LabelRegex != "" {
+				wf.LabelRegex = filter.LabelRegex
+			}
+			if filter.ParentID != nil {
+				wf.ParentID = filter.ParentID
+			}
+			var err error
+			issues, err = activeStore.GetReadyWork(ctx, wf)
+			if err != nil {
+				FatalError("%v", err)
+			}
+		} else {
+			var err error
+			issues, err = activeStore.SearchIssues(ctx, "", filter)
+			if err != nil {
+				FatalError("%v", err)
+			}
 		}
 
 		// Apply sorting
@@ -1107,7 +1154,7 @@ func init() {
 	listCmd.Flags().Bool("no-pager", false, "Disable pager output")
 
 	// Ready filter: show only issues ready to be worked on (bd-ihu31)
-	listCmd.Flags().Bool("ready", false, "Show only ready issues (status=open, excludes hooked/in_progress/blocked/deferred)")
+	listCmd.Flags().Bool("ready", false, "Show only ready issues (no active blockers, same semantics as bd ready)")
 
 	// Note: --json flag is defined as a persistent flag in main.go, not here
 	rootCmd.AddCommand(listCmd)

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -40,6 +40,40 @@ func withStorage(ctx context.Context, store storage.DoltStorage, dbPath string, 
 	return fmt.Errorf("no storage available")
 }
 
+func readyWorkFilterFromIssueFilter(filter types.IssueFilter) types.WorkFilter {
+	wf := types.WorkFilter{
+		Status:         types.StatusOpen,
+		Limit:          filter.Limit,
+		Labels:         filter.Labels,
+		LabelsAny:      filter.LabelsAny,
+		ExcludeLabels:  filter.ExcludeLabels,
+		LabelPattern:   filter.LabelPattern,
+		LabelRegex:     filter.LabelRegex,
+		ParentID:       filter.ParentID,
+		MolType:        filter.MolType,
+		WispType:       filter.WispType,
+		ExcludeTypes:   filter.ExcludeTypes,
+		MetadataFields: filter.MetadataFields,
+		HasMetadataKey: filter.HasMetadataKey,
+	}
+	if filter.IssueType != nil {
+		wf.Type = string(*filter.IssueType)
+	}
+	if filter.Priority != nil {
+		wf.Priority = filter.Priority
+	}
+	if filter.Assignee != nil {
+		wf.Assignee = filter.Assignee
+	}
+	if filter.NoAssignee {
+		wf.Unassigned = true
+	}
+	if filter.Ephemeral != nil && *filter.Ephemeral {
+		wf.IncludeEphemeral = true
+	}
+	return wf
+}
+
 // getHierarchicalChildren handles the --tree --parent combination logic.
 // baseFilter carries CLI filters (--type, --status, etc.) through the recursive walk.
 func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string, baseFilter types.IssueFilter) ([]*types.Issue, error) {
@@ -123,7 +157,16 @@ type watchListDependencyStore interface {
 	GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error)
 }
 
-func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, parentID string, sortBy string, reverse bool) ([]*types.Issue, error) {
+func loadWatchedIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, ready bool, parentID string, sortBy string, reverse bool) ([]*types.Issue, error) {
+	if ready {
+		issues, err := store.GetReadyWork(ctx, readyWorkFilterFromIssueFilter(filter))
+		if err != nil {
+			return nil, err
+		}
+		sortIssues(issues, sortBy, reverse)
+		return issues, nil
+	}
+
 	if parentID != "" {
 		issues, err := getHierarchicalChildren(ctx, store, "", parentID, filter)
 		if err != nil {
@@ -154,9 +197,9 @@ func displayWatchedIssueList(ctx context.Context, store watchListDependencyStore
 	displayPrettyListWithDeps(issues, true, allDeps)
 }
 
-func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, parentID string, sortBy string, reverse bool, effectiveLimit int) {
+func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.IssueFilter, ready bool, parentID string, sortBy string, reverse bool, effectiveLimit int) {
 	// Initial display
-	issues, err := loadWatchedIssues(ctx, store, filter, parentID, sortBy, reverse)
+	issues, err := loadWatchedIssues(ctx, store, filter, ready, parentID, sortBy, reverse)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error querying issues: %v\n", err)
 		return
@@ -186,7 +229,7 @@ func watchIssues(ctx context.Context, store storage.DoltStorage, filter types.Is
 			fmt.Fprintf(os.Stderr, "\nStopped watching.\n")
 			return
 		case <-ticker.C:
-			issues, err := loadWatchedIssues(ctx, store, filter, parentID, sortBy, reverse)
+			issues, err := loadWatchedIssues(ctx, store, filter, ready, parentID, sortBy, reverse)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error refreshing issues: %v\n", err)
 				continue
@@ -855,40 +898,7 @@ var listCmd = &cobra.Command{
 			// Use blocker-aware GetReadyWork semantics (GH#3478).
 			// This ensures bd list --ready matches bd ready behavior,
 			// excluding issues with open blocks dependencies.
-			wf := types.WorkFilter{
-				Status: types.StatusOpen,
-				Limit:  filter.Limit,
-			}
-			if filter.IssueType != nil {
-				wf.Type = string(*filter.IssueType)
-			}
-			if filter.Priority != nil {
-				wf.Priority = filter.Priority
-			}
-			if filter.Assignee != nil {
-				wf.Assignee = filter.Assignee
-			}
-			if filter.NoAssignee {
-				wf.Unassigned = true
-			}
-			if len(filter.Labels) > 0 {
-				wf.Labels = filter.Labels
-			}
-			if len(filter.LabelsAny) > 0 {
-				wf.LabelsAny = filter.LabelsAny
-			}
-			if len(filter.ExcludeLabels) > 0 {
-				wf.ExcludeLabels = filter.ExcludeLabels
-			}
-			if filter.LabelPattern != "" {
-				wf.LabelPattern = filter.LabelPattern
-			}
-			if filter.LabelRegex != "" {
-				wf.LabelRegex = filter.LabelRegex
-			}
-			if filter.ParentID != nil {
-				wf.ParentID = filter.ParentID
-			}
+			wf := readyWorkFilterFromIssueFilter(filter)
 			var err error
 			issues, err = activeStore.GetReadyWork(ctx, wf)
 			if err != nil {
@@ -914,7 +924,7 @@ var listCmd = &cobra.Command{
 
 		// Handle watch mode (GH#654) - must be before other output modes
 		if watchMode {
-			watchIssues(ctx, activeStore, filter, parentID, sortBy, reverse, effectiveLimit)
+			watchIssues(ctx, activeStore, filter, readyFlag, parentID, sortBy, reverse, effectiveLimit)
 			return
 		}
 
@@ -922,7 +932,7 @@ var listCmd = &cobra.Command{
 		// JSON output takes priority over pretty/tree format (bd-list-json-fix, bd-03r)
 		if prettyFormat && !jsonOutput {
 			// Special handling for --tree --parent combination (hierarchical descendants)
-			if parentID != "" {
+			if parentID != "" && !readyFlag {
 				treeIssues, err := getHierarchicalChildren(ctx, activeStore, "", parentID, filter)
 				if err != nil {
 					FatalError("%v", err)

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -308,6 +308,16 @@ func TestEmbeddedList(t *testing.T) {
 		}
 	})
 
+	t.Run("ready_exclude_type", func(t *testing.T) {
+		issues := bdListJSON(t, bd, dir, "--ready", "--exclude-type", "epic", "--limit", "0")
+		if containsID(issues, seed.epic) {
+			t.Errorf("--ready --exclude-type epic should exclude epic %s, got %v", seed.epic, listIssueIDs(issues))
+		}
+		if !containsID(issues, seed.readyTask) {
+			t.Errorf("--ready --exclude-type epic should still include ready task %s, got %v", seed.readyTask, listIssueIDs(issues))
+		}
+	})
+
 	t.Run("overdue", func(t *testing.T) {
 		issues := bdListJSON(t, bd, dir, "--overdue")
 		if !containsID(issues, seed.overdueTask) {
@@ -348,6 +358,22 @@ func TestEmbeddedList(t *testing.T) {
 		out := bdList(t, bd, dir, "--tree", "--parent", seed.epic)
 		if !strings.Contains(out, seed.epic) {
 			t.Errorf("tree output should contain parent ID %s", seed.epic)
+		}
+	})
+
+	t.Run("ready_parent_tree_excludes_blocked_descendants", func(t *testing.T) {
+		parent := bdCreate(t, bd, dir, "Ready parent tree", "--type", "epic")
+		readyChild := bdCreate(t, bd, dir, "Ready child in tree", "--type", "task", "--parent", parent.ID)
+		blockedChild := bdCreate(t, bd, dir, "Blocked child in tree", "--type", "task", "--parent", parent.ID)
+		blocker := bdCreate(t, bd, dir, "Tree child blocker", "--type", "task")
+		bdDepAdd(t, bd, dir, blockedChild.ID, blocker.ID)
+
+		out := bdList(t, bd, dir, "--ready", "--parent", parent.ID, "--no-pager")
+		if !strings.Contains(out, readyChild.ID) {
+			t.Errorf("ready child %s should appear in ready parent tree:\n%s", readyChild.ID, out)
+		}
+		if strings.Contains(out, blockedChild.ID) {
+			t.Errorf("blocked child %s should not appear in ready parent tree:\n%s", blockedChild.ID, out)
 		}
 	})
 

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -492,6 +492,9 @@ func TestEmbeddedList(t *testing.T) {
 		if !strings.Contains(out, "Found") {
 			t.Error("--long format should contain 'Found N issues'")
 		}
+		if !strings.Contains(out, "Description:") || !strings.Contains(out, "This is a bug") {
+			t.Errorf("--long format should include issue descriptions, got: %s", out)
+		}
 	})
 
 	t.Run("pretty_format", func(t *testing.T) {

--- a/cmd/bd/list_format.go
+++ b/cmd/bd/list_format.go
@@ -101,6 +101,12 @@ func formatIssueLong(buf *strings.Builder, issue *types.Issue, labels []string) 
 	if issue.Assignee != "" {
 		buf.WriteString(fmt.Sprintf("  Assignee: %s\n", issue.Assignee))
 	}
+	if desc := strings.TrimSpace(issue.Description); desc != "" {
+		buf.WriteString("  Description:\n")
+		for _, line := range strings.Split(desc, "\n") {
+			buf.WriteString(fmt.Sprintf("    %s\n", line))
+		}
+	}
 	if len(labels) > 0 {
 		buf.WriteString(fmt.Sprintf("  Labels: %v\n", labels))
 	}

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -296,11 +296,11 @@ func TestLoadWatchedIssues_WithParentIncludesHierarchyAndStableOrder(t *testing.
 	addParentChild(grandchild, child)
 
 	filter := types.IssueFilter{ParentID: &parent.ID}
-	first, err := loadWatchedIssues(ctx, store, filter, parent.ID, "", false)
+	first, err := loadWatchedIssues(ctx, store, filter, false, parent.ID, "", false)
 	if err != nil {
 		t.Fatalf("loadWatchedIssues first call failed: %v", err)
 	}
-	second, err := loadWatchedIssues(ctx, store, filter, parent.ID, "", false)
+	second, err := loadWatchedIssues(ctx, store, filter, false, parent.ID, "", false)
 	if err != nil {
 		t.Fatalf("loadWatchedIssues second call failed: %v", err)
 	}

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -23,7 +23,7 @@ var readyCmd = &cobra.Command{
 Excludes in_progress, blocked, deferred, and hooked issues. This uses the
 GetReadyWork API which applies blocker-aware semantics to find truly claimable work.
 
-Note: 'bd list --ready' is NOT equivalent - it only filters by status=open.
+Note: 'bd list --ready' uses the same blocker-aware ready-work semantics.
 
 Use --mol to filter to a specific molecule's steps:
   bd ready --mol bd-patrol   # Show ready steps within molecule

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -178,6 +178,19 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		if err != nil {
 			FatalError("%v", err)
 		}
+
+		totalReady := len(issues)
+		truncated := false
+		if filter.Limit > 0 && len(issues) == filter.Limit {
+			countFilter := filter
+			countFilter.Limit = 0
+			allIssues, countErr := activeStore.GetReadyWork(ctx, countFilter)
+			if countErr == nil && len(allIssues) > len(issues) {
+				totalReady = len(allIssues)
+				truncated = true
+			}
+		}
+
 		if jsonOutput {
 			// Always output array, even if empty
 			if issues == nil {
@@ -223,6 +236,9 @@ This is useful for agents executing molecules to see which steps can run next.`,
 				}
 			}
 			outputJSON(issuesWithCounts)
+			if truncated {
+				fmt.Fprintf(os.Stderr, "Showing %d of %d ready issues. Use --limit 0 for all, or --limit N to raise the cap.\n", len(issues), totalReady)
+			}
 			return
 		}
 		// Show upgrade notification if needed
@@ -244,20 +260,6 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			maybeShowTip(store)
 			return
 		}
-		// Check if results were truncated by the limit
-		totalReady := len(issues)
-		truncated := false
-		if filter.Limit > 0 && len(issues) == filter.Limit {
-			// Re-query without limit to get total count
-			countFilter := filter
-			countFilter.Limit = 0
-			allIssues, countErr := activeStore.GetReadyWork(ctx, countFilter)
-			if countErr == nil && len(allIssues) > len(issues) {
-				totalReady = len(allIssues)
-				truncated = true
-			}
-		}
-
 		// Build parent epic map for pretty display
 		parentEpicMap := buildParentEpicMap(ctx, activeStore, issues)
 
@@ -663,7 +665,7 @@ type MoleculeReadyOutput struct {
 }
 
 func init() {
-	readyCmd.Flags().IntP("limit", "n", 10, "Maximum issues to show")
+	readyCmd.Flags().IntP("limit", "n", 100, "Maximum issues to show (use 0 for unlimited)")
 	readyCmd.Flags().IntP("priority", "p", 0, "Filter by priority")
 	readyCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
 	readyCmd.Flags().BoolP("unassigned", "u", false, "Show only unassigned issues")

--- a/cmd/bd/ready_embedded_test.go
+++ b/cmd/bd/ready_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -54,6 +55,28 @@ func TestEmbeddedReady(t *testing.T) {
 		}
 		if !json.Valid([]byte(s[start:])) {
 			t.Errorf("invalid JSON in ready output: %s", s[:min(200, len(s))])
+		}
+	})
+
+	t.Run("ready_json_truncation_hint", func(t *testing.T) {
+		for i := 0; i < 3; i++ {
+			bdCreate(t, bd, dir, fmt.Sprintf("Ready capped issue %d", i), "--type", "task")
+		}
+
+		cmd := exec.Command(bd, "ready", "--json", "--limit", "2")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("bd ready --json --limit 2 failed: %v\nstderr: %s\nstdout: %s", err, stderr.String(), out)
+		}
+		if !json.Valid(bytes.TrimSpace(out)) {
+			t.Fatalf("ready JSON stdout should remain parseable, got: %s", out)
+		}
+		if !strings.Contains(stderr.String(), "Use --limit 0 for all") {
+			t.Fatalf("expected truncation hint on stderr, got: %q", stderr.String())
 		}
 	})
 

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -354,6 +354,82 @@ func TestGetReadyWork_TypeFilter(t *testing.T) {
 	}
 }
 
+// TestGetReadyWork_ExcludeTypeFilter verifies that filter.ExcludeTypes is
+// honored in addition to the hardcoded default exclusion list. Regression test
+// for GH#3397: the CLI flag --exclude-type was silently ignored because
+// GetReadyWorkInTx built the NOT IN clause from the hardcoded defaults only.
+func TestGetReadyWork_ExcludeTypeFilter(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic := &types.Issue{
+		ID:        "rw-ex-epic",
+		Title:     "An Epic",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	task := &types.Issue{
+		ID:        "rw-ex-task",
+		Title:     "A Task",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	bug := &types.Issue{
+		ID:        "rw-ex-bug",
+		Title:     "A Bug",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeBug,
+	}
+
+	for _, iss := range []*types.Issue{epic, task, bug} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("failed to create issue: %v", err)
+		}
+	}
+
+	// Single-type exclusion.
+	work, err := store.GetReadyWork(ctx, types.WorkFilter{
+		ExcludeTypes: []types.IssueType{types.TypeEpic},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, w := range work {
+		if w.ID == epic.ID {
+			t.Error("epic should not appear when ExcludeTypes includes epic")
+		}
+	}
+
+	// Multi-type exclusion.
+	work, err = store.GetReadyWork(ctx, types.WorkFilter{
+		ExcludeTypes: []types.IssueType{types.TypeEpic, types.TypeTask},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundBug := false
+	for _, w := range work {
+		if w.ID == epic.ID {
+			t.Error("epic should not appear when ExcludeTypes includes epic")
+		}
+		if w.ID == task.ID {
+			t.Error("task should not appear when ExcludeTypes includes task")
+		}
+		if w.ID == bug.ID {
+			foundBug = true
+		}
+	}
+	if !foundBug {
+		t.Error("bug should still appear when ExcludeTypes excludes only epic and task")
+	}
+}
+
 // TestGetReadyWork_CustomStatusBlockerStillBlocks verifies that a blocker with
 // a custom status still prevents blocked issues from appearing in ready work.
 // Regression test for bd-1x0.

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -430,6 +430,96 @@ func TestGetReadyWork_ExcludeTypeFilter(t *testing.T) {
 	}
 }
 
+// TestGetReadyWork_ParentFilterReturnsDescendants verifies that --parent
+// returns all transitive descendants, not just direct children. Regression
+// test for GH#3396: the SQL clause was a one-hop subquery, so grandchildren
+// of the given parent were silently dropped despite the help text and the
+// WorkFilter.ParentID godoc both promising "descendants (recursive)".
+func TestGetReadyWork_ParentFilterReturnsDescendants(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic := &types.Issue{
+		ID:        "rw-pd-epic",
+		Title:     "Epic",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	phase := &types.Issue{
+		ID:        "rw-pd-phase",
+		Title:     "Phase",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	leaf := &types.Issue{
+		ID:        "rw-pd-leaf",
+		Title:     "Leaf Task",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+
+	for _, iss := range []*types.Issue{epic, phase, leaf} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("failed to create issue %s: %v", iss.ID, err)
+		}
+	}
+
+	// epic <- phase <- leaf via parent-child deps.
+	for _, dep := range []*types.Dependency{
+		{IssueID: phase.ID, DependsOnID: epic.ID, Type: types.DepParentChild},
+		{IssueID: leaf.ID, DependsOnID: phase.ID, Type: types.DepParentChild},
+	} {
+		if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("failed to add dep %s->%s: %v", dep.IssueID, dep.DependsOnID, err)
+		}
+	}
+
+	// Direct parent filter still works (control).
+	parentPhase := phase.ID
+	workPhase, err := store.GetReadyWork(ctx, types.WorkFilter{ParentID: &parentPhase})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundLeaf := false
+	for _, w := range workPhase {
+		if w.ID == leaf.ID {
+			foundLeaf = true
+		}
+	}
+	if !foundLeaf {
+		t.Error("direct-parent filter should return the leaf task")
+	}
+
+	// Grandparent filter: leaf must appear (the bug under test).
+	parentEpic := epic.ID
+	workEpic, err := store.GetReadyWork(ctx, types.WorkFilter{ParentID: &parentEpic})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundLeaf = false
+	foundPhase := false
+	for _, w := range workEpic {
+		if w.ID == leaf.ID {
+			foundLeaf = true
+		}
+		if w.ID == phase.ID {
+			foundPhase = true
+		}
+	}
+	if !foundPhase {
+		t.Error("grandparent filter should include the direct child (phase)")
+	}
+	if !foundLeaf {
+		t.Error("grandparent filter should include transitive grandchildren (leaf) - regression for GH#3396")
+	}
+}
+
 // TestGetReadyWork_CustomStatusBlockerStillBlocks verifies that a blocker with
 // a custom status still prevents blocked issues from appearing in ready work.
 // Regression test for bd-1x0.

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -520,6 +520,64 @@ func TestGetReadyWork_ParentFilterReturnsDescendants(t *testing.T) {
 	}
 }
 
+func TestGetReadyWork_ParentFilterReturnsDeepDescendants(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	root := &types.Issue{
+		ID:        "rw-deep-root",
+		Title:     "Deep Root",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, root, "tester"); err != nil {
+		t.Fatalf("failed to create root: %v", err)
+	}
+
+	parentID := root.ID
+	const depth = 105
+	for i := 1; i <= depth; i++ {
+		issue := &types.Issue{
+			ID:        fmt.Sprintf("rw-deep-%03d", i),
+			Title:     fmt.Sprintf("Deep child %03d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("failed to create issue %s: %v", issue.ID, err)
+		}
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID:     issue.ID,
+			DependsOnID: parentID,
+			Type:        types.DepParentChild,
+		}, "tester"); err != nil {
+			t.Fatalf("failed to add parent-child dep for %s: %v", issue.ID, err)
+		}
+		parentID = issue.ID
+	}
+
+	rootID := root.ID
+	work, err := store.GetReadyWork(ctx, types.WorkFilter{ParentID: &rootID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	foundLeaf := false
+	for _, w := range work {
+		if w.ID == fmt.Sprintf("rw-deep-%03d", depth) {
+			foundLeaf = true
+			break
+		}
+	}
+	if !foundLeaf {
+		t.Fatalf("parent filter should include descendant beyond depth 100, got %d descendants", len(work))
+	}
+}
+
 // TestGetReadyWork_CustomStatusBlockerStillBlocks verifies that a blocker with
 // a custom status still prevents blocked issues from appearing in ready work.
 // Regression test for bd-1x0.

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -332,6 +332,40 @@ func GetChildrenOfIssuesInTx(ctx context.Context, tx *sql.Tx, parentIDs []string
 	return children, nil
 }
 
+// GetDescendantIDsInTx returns IDs of all transitive parent-child descendants
+// of rootID, traversing parent-child edges in both the dependencies and
+// wisp_dependencies tables via BFS. rootID itself is NOT included. Cycles are
+// broken via a visited set. maxDepth caps traversal depth; pass 0 for the
+// default safety cap.
+func GetDescendantIDsInTx(ctx context.Context, tx *sql.Tx, rootID string, maxDepth int) ([]string, error) {
+	if rootID == "" {
+		return nil, nil
+	}
+	if maxDepth <= 0 {
+		maxDepth = 100
+	}
+	seen := map[string]bool{rootID: true}
+	var result []string
+	frontier := []string{rootID}
+	for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
+		children, err := GetChildrenOfIssuesInTx(ctx, tx, frontier)
+		if err != nil {
+			return nil, err
+		}
+		var next []string
+		for _, c := range children {
+			if seen[c] {
+				continue
+			}
+			seen[c] = true
+			result = append(result, c)
+			next = append(next, c)
+		}
+		frontier = next
+	}
+	return result, nil
+}
+
 // GetBlockedIssuesInTx returns issues that are blocked by other issues.
 // This is the full implementation including transitive child blocking and parent filtering.
 //

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -334,34 +334,81 @@ func GetChildrenOfIssuesInTx(ctx context.Context, tx *sql.Tx, parentIDs []string
 
 // GetDescendantIDsInTx returns IDs of all transitive parent-child descendants
 // of rootID, traversing parent-child edges in both the dependencies and
-// wisp_dependencies tables via BFS. rootID itself is NOT included. Cycles are
-// broken via a visited set. maxDepth caps traversal depth; pass 0 for the
-// default safety cap.
+// wisp_dependencies tables. rootID itself is NOT included. Cycles are broken
+// inside the recursive CTE. maxDepth caps traversal depth only when positive;
+// reaching that cap returns an explicit error rather than silently truncating.
 func GetDescendantIDsInTx(ctx context.Context, tx *sql.Tx, rootID string, maxDepth int) ([]string, error) {
 	if rootID == "" {
 		return nil, nil
 	}
-	if maxDepth <= 0 {
-		maxDepth = 100
+
+	queryDescendants := func(includeWisps bool) ([]string, bool, error) {
+		edgeQuery := `
+			SELECT issue_id, depends_on_id FROM dependencies WHERE type = 'parent-child'
+		`
+		if includeWisps {
+			edgeQuery += `
+			UNION ALL
+			SELECT issue_id, depends_on_id FROM wisp_dependencies WHERE type = 'parent-child'
+		`
+		}
+
+		query := fmt.Sprintf(`
+			WITH RECURSIVE
+			parent_edges(issue_id, depends_on_id) AS (
+				%s
+			),
+			descendants(id, depth, path) AS (
+				SELECT issue_id, 1, CONCAT(',', ?, ',', issue_id, ',')
+				FROM parent_edges
+				WHERE depends_on_id = ?
+				UNION ALL
+				SELECT e.issue_id, d.depth + 1, CONCAT(d.path, e.issue_id, ',')
+				FROM parent_edges e
+				JOIN descendants d ON e.depends_on_id = d.id
+				WHERE (? <= 0 OR d.depth < ?)
+				  AND LOCATE(CONCAT(',', e.issue_id, ','), d.path) = 0
+			)
+			SELECT id, depth FROM descendants WHERE id <> ?
+		`, edgeQuery)
+
+		rows, err := tx.QueryContext(ctx, query, rootID, rootID, maxDepth, maxDepth, rootID)
+		if err != nil {
+			return nil, false, err
+		}
+		defer func() { _ = rows.Close() }()
+
+		var result []string
+		reachedMaxDepth := false
+		for rows.Next() {
+			var id string
+			var depth int
+			if err := rows.Scan(&id, &depth); err != nil {
+				return nil, false, fmt.Errorf("scan descendant: %w", err)
+			}
+			result = append(result, id)
+			if maxDepth > 0 && depth >= maxDepth {
+				reachedMaxDepth = true
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, false, fmt.Errorf("descendant rows: %w", err)
+		}
+		return result, reachedMaxDepth, nil
 	}
-	seen := map[string]bool{rootID: true}
-	var result []string
-	frontier := []string{rootID}
-	for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
-		children, err := GetChildrenOfIssuesInTx(ctx, tx, frontier)
+
+	result, reachedMaxDepth, err := queryDescendants(true)
+	if err != nil {
+		if !isTableNotExistError(err) {
+			return nil, err
+		}
+		result, reachedMaxDepth, err = queryDescendants(false)
 		if err != nil {
 			return nil, err
 		}
-		var next []string
-		for _, c := range children {
-			if seen[c] {
-				continue
-			}
-			seen[c] = true
-			result = append(result, c)
-			next = append(next, c)
-		}
-		frontier = next
+	}
+	if reachedMaxDepth {
+		return nil, fmt.Errorf("parent descendant traversal for %s reached max depth %d", rootID, maxDepth)
 	}
 	return result, nil
 }

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -51,6 +51,18 @@ func GetReadyWorkInTx(
 		args = append(args, filter.Type)
 	} else {
 		excludeTypes := []string{"merge-request", "gate", "molecule", "message", "agent", "role", "rig"}
+		seen := make(map[string]bool, len(excludeTypes)+len(filter.ExcludeTypes))
+		for _, t := range excludeTypes {
+			seen[t] = true
+		}
+		for _, t := range filter.ExcludeTypes {
+			s := string(t)
+			if s == "" || seen[s] {
+				continue
+			}
+			seen[s] = true
+			excludeTypes = append(excludeTypes, s)
+		}
 		placeholders := make([]string, len(excludeTypes))
 		for i, t := range excludeTypes {
 			placeholders[i] = "?"

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -110,11 +110,29 @@ func GetReadyWorkInTx(
 		}
 		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT issue_id FROM labels WHERE label IN (%s))", strings.Join(placeholders, ", ")))
 	}
-	// Parent filtering.
+	// Parent filtering: return all transitive descendants of parentID.
+	// GH#3396: previously was a one-hop subquery against dependencies, so
+	// grandchildren were silently dropped despite the help text and
+	// WorkFilter.ParentID godoc both promising "descendants (recursive)".
 	if filter.ParentID != nil {
 		parentID := *filter.ParentID
-		whereClauses = append(whereClauses, "(id IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child' AND depends_on_id = ?) OR (id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child')))")
-		args = append(args, parentID, parentID)
+		descendants, dErr := GetDescendantIDsInTx(ctx, tx, parentID, 0)
+		if dErr != nil {
+			return nil, fmt.Errorf("get descendants for parent filter: %w", dErr)
+		}
+		// Compose two branches, matching the prior semantics:
+		//   1. Any ID reachable via parent-child deps from parentID.
+		//   2. Dotted-ID descendants (id LIKE "parent.%") that have no
+		//      explicit parent-child dep - the implicit-parent convention.
+		var orParts []string
+		if len(descendants) > 0 {
+			placeholders, batchArgs := buildSQLInClause(descendants)
+			orParts = append(orParts, fmt.Sprintf("id IN (%s)", placeholders))
+			args = append(args, batchArgs...)
+		}
+		orParts = append(orParts, "(id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child'))")
+		args = append(args, parentID)
+		whereClauses = append(whereClauses, "("+strings.Join(orParts, " OR ")+")")
 	}
 
 	// Molecule filtering: filter to direct children of the specified molecule.

--- a/tests/regression/discovery_test.go
+++ b/tests/regression/discovery_test.go
@@ -79,6 +79,33 @@ func containsID(ids []string, target string) bool {
 	return false
 }
 
+func diffIDSets(got, want []string) string {
+	gotSet := make(map[string]bool, len(got))
+	wantSet := make(map[string]bool, len(want))
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	for _, id := range want {
+		wantSet[id] = true
+	}
+
+	var missing, extra []string
+	for id := range wantSet {
+		if !gotSet[id] {
+			missing = append(missing, id)
+		}
+	}
+	for id := range gotSet {
+		if !wantSet[id] {
+			extra = append(extra, id)
+		}
+	}
+	if len(missing) == 0 && len(extra) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("missing from list --ready: %v\nextra in list --ready: %v", missing, extra)
+}
+
 // =============================================================================
 // BUG REPRODUCTION TESTS
 // =============================================================================
@@ -221,9 +248,18 @@ func TestBug9_ListReadyIncludesBlocked(t *testing.T) {
 		t.Errorf("bd ready should include free %s", c)
 	}
 
-	// Ideally list --ready should match bd ready
-	if containsID(listReady, a) && !containsID(bdReady, a) {
-		t.Logf("KNOWN: list --ready includes blocked %s but bd ready does not", a)
+	if containsID(listReady, a) {
+		t.Errorf("list --ready should not include blocked %s", a)
+	}
+	if !containsID(listReady, b) {
+		t.Errorf("list --ready should include unblocked %s", b)
+	}
+	if !containsID(listReady, c) {
+		t.Errorf("list --ready should include free %s", c)
+	}
+
+	if diff := diffIDSets(listReady, bdReady); diff != "" {
+		t.Errorf("list --ready and bd ready should agree:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Builds on contributor PRs #3428 and #3429 by cherry-picking Daniel Jasinski's commits with original authorship preserved.
- Fixes `bd ready --exclude-type` by honoring `WorkFilter.ExcludeTypes` in ready-work filtering.
- Fixes `bd ready --parent` to return transitive descendants while preserving dotted-ID descendants.
- Raises the default `bd ready` limit from 10 to 100 and emits a JSON-mode stderr truncation hint while keeping stdout as a JSON array.
- Makes `bd list --long` include issue descriptions.

## Upstream context
- PR #3441 (`--exclude-label`) is already merged and present on this branch base.
- PR #3428 was open and unstable; this PR includes its patch and tests with attribution.
- PR #3429 was open and conflicted; this PR includes its patch and tests with conflict resolution against current `main`.
- #3280 remains intentionally unresolved here because wrapping `bd list --json` only when truncated would create a variable JSON schema; that needs a separate schema decision.

Fixes #3397.
Fixes #3396.
Fixes #3409.
Fixes #3285.

## Tests
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/storage/dolt -run 'TestGetReadyWork_(ExcludeTypeFilter|ParentFilterReturnsDescendants)$'`
- `CGO_ENABLED=1 BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run '^(TestEmbeddedReady|TestEmbeddedList)$/^(ready_json_truncation_hint|ready_exclude_label|long_format)$'`
- `make test`
