### PR TITLE
fix(export): sort memory keys for deterministic JSONL output (GH#3474)

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -187,10 +188,16 @@ func runExport(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to read config for memories: %w", err)
 		}
 		fullPrefix := kvPrefix + memoryPrefix
-		for k, v := range allConfig {
-			if !strings.HasPrefix(k, fullPrefix) {
-				continue
+		// Sort keys for deterministic output order (GH#3474).
+		var memKeys []string
+		for k := range allConfig {
+			if strings.HasPrefix(k, fullPrefix) {
+				memKeys = append(memKeys, k)
 			}
+		}
+		sort.Strings(memKeys)
+		for _, k := range memKeys {
+			v := allConfig[k]
 			userKey := strings.TrimPrefix(k, fullPrefix)
 			record := map[string]string{
 				"_type": "memory",

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -207,10 +208,16 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 		allConfig, err := store.GetAllConfig(ctx)
 		if err == nil {
 			fullPrefix := kvPrefix + memoryPrefix
-			for k, v := range allConfig {
-				if !strings.HasPrefix(k, fullPrefix) {
-					continue
+			// Sort keys for deterministic output order (GH#3474).
+			var memKeys []string
+			for k := range allConfig {
+				if strings.HasPrefix(k, fullPrefix) {
+					memKeys = append(memKeys, k)
 				}
+			}
+			sort.Strings(memKeys)
+			for _, k := range memKeys {
+				v := allConfig[k]
 				userKey := strings.TrimPrefix(k, fullPrefix)
 				record := map[string]string{
 					"_type": "memory",
@@ -219,7 +226,7 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 				}
 				data, err := json.Marshal(record)
 				if err != nil {
-					continue
+					return issueCount, memoryCount, fmt.Errorf("failed to marshal memory %s: %w", userKey, err)
 				}
 				if _, err := f.Write(data); err != nil {
 					return issueCount, memoryCount, fmt.Errorf("failed to write memory: %w", err)

--- a/cmd/bd/export_test.go
+++ b/cmd/bd/export_test.go
@@ -537,6 +537,108 @@ func TestExportNoHistoryBeadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestExportMemoryDeterminism(t *testing.T) {
+	// GH#3474: memory lines must appear in deterministic order across exports.
+	// Seeds multiple memories, exports twice to separate files, and asserts
+	// byte-for-byte identical output.
+	if testDoltServerPort == 0 {
+		t.Skip("Dolt test server not available")
+	}
+	if testutil.DoltContainerCrashed() {
+		t.Skipf("Dolt test server crashed: %v", testutil.DoltContainerCrashError())
+	}
+
+	ensureTestMode(t)
+	saved := saveAndRestoreGlobals(t)
+	_ = saved
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	dbName := uniqueTestDBName(t)
+	testDBPath := filepath.Join(beadsDir, "dolt")
+	writeTestMetadata(t, testDBPath, dbName)
+	s := newTestStore(t, testDBPath)
+	store = s
+	storeMutex.Lock()
+	storeActive = true
+	storeMutex.Unlock()
+	t.Cleanup(func() {
+		store = nil
+		storeMutex.Lock()
+		storeActive = false
+		storeMutex.Unlock()
+	})
+
+	ctx := context.Background()
+	rootCtx = ctx
+
+	// Seed 5 memories with keys that would sort differently than insertion order.
+	memKeys := []string{"zeta-config", "alpha-note", "mu-decision", "beta-lesson", "omega-context"}
+	for _, mk := range memKeys {
+		storageKey := "kv.memory." + mk
+		if err := s.SetConfig(ctx, storageKey, "value-for-"+mk); err != nil {
+			t.Fatalf("SetConfig(%s): %v", storageKey, err)
+		}
+	}
+
+	doExport := func(path string) []byte {
+		t.Helper()
+		exportOutput = path
+		exportAll = false
+		exportIncludeInfra = false
+		exportScrub = false
+		exportNoMemories = false
+		if err := runExport(nil, nil); err != nil {
+			t.Fatalf("runExport(%s): %v", path, err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		return data
+	}
+
+	export1 := doExport(filepath.Join(tmpDir, "export1.jsonl"))
+	export2 := doExport(filepath.Join(tmpDir, "export2.jsonl"))
+
+	if string(export1) != string(export2) {
+		t.Error("exports are not byte-identical — memory ordering is non-deterministic")
+		t.Logf("export1:\n%s", export1)
+		t.Logf("export2:\n%s", export2)
+	}
+
+	// Verify memories are present and sorted alphabetically by key.
+	lines := splitJSONL(export1)
+	var memoryKeys []string
+	for _, line := range lines {
+		var rec map[string]interface{}
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("parse line: %v", err)
+		}
+		if rec["_type"] == "memory" {
+			memoryKeys = append(memoryKeys, rec["key"].(string))
+		}
+	}
+	if len(memoryKeys) != len(memKeys) {
+		t.Fatalf("expected %d memory lines, got %d", len(memKeys), len(memoryKeys))
+	}
+	for i := 1; i < len(memoryKeys); i++ {
+		if memoryKeys[i] < memoryKeys[i-1] {
+			t.Errorf("memory keys not sorted: %q appears after %q", memoryKeys[i], memoryKeys[i-1])
+		}
+	}
+}
+
 func TestExportNoDuplicateWisps(t *testing.T) {
 	// GH#3352: A previous bug caused every wisp to appear twice in the export
 	// because export.go ran a separate Ephemeral=true query and appended the


### PR DESCRIPTION
## Summary

- Sorts `_type:"memory"` keys alphabetically before writing to JSONL, eliminating non-deterministic order from Go map iteration
- Fixes noisy diffs in committed `issues.jsonl` where memory lines were reshuffled on every export

Closes #3474

## Details

`cmd/bd/export.go` iterated `allConfig` (a `map[string]string`) directly, so `_type:"memory"` lines appeared in random order on every export. This produced churn in committed `issues.jsonl` even when no memories changed.

Fix: collect matching keys into a slice, sort, then iterate.

## Test plan

- [ ] `go build ./cmd/bd` compiles cleanly
- [ ] Run `bd export` twice on a project with memories — output is identical both times
- [ ] Existing export tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)