### PR TITLE
fix(init): chmod existing .beads/ to 0700 instead of only warning (GH#3391)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -429,6 +429,16 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				FatalError("failed to create .beads directory: %v", err)
 			}
 
+			// Fix permissions on pre-existing .beads/ directories that may
+			// have been created with a permissive umask (GH#3391).
+			if fixed, err := config.FixBeadsDirPermissions(beadsDir); err != nil {
+				if !quiet {
+					fmt.Fprintf(os.Stderr, "Warning: could not fix .beads permissions: %v\n", err)
+				}
+			} else if fixed && !quiet {
+				fmt.Fprintf(os.Stderr, "→ Fixed .beads permissions to %04o\n", config.BeadsDirPerm)
+			}
+
 			// On Linux btrfs, disable transparent compression on .beads/ so that
 			// dolt's hot append-only write path (under .beads/dolt/ or
 			// .beads/embeddeddolt/) does not trigger kworker thrashing from

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -436,7 +436,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					fmt.Fprintf(os.Stderr, "Warning: could not fix .beads permissions: %v\n", err)
 				}
 			} else if fixed && !quiet {
-				fmt.Fprintf(os.Stderr, "→ Fixed .beads permissions to %04o\n", config.BeadsDirPerm)
+				fmt.Fprintf(os.Stderr, "→ Stripped world-accessible bits from .beads permissions\n")
 			}
 
 			// On Linux btrfs, disable transparent compression on .beads/ so that

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -436,7 +436,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					fmt.Fprintf(os.Stderr, "Warning: could not fix .beads permissions: %v\n", err)
 				}
 			} else if fixed && !quiet {
-				fmt.Fprintf(os.Stderr, "→ Stripped world-accessible bits from .beads permissions\n")
+				fmt.Fprintf(os.Stderr, "Fixed .beads permissions to %04o\n", config.BeadsDirPerm)
 			}
 
 			// On Linux btrfs, disable transparent compression on .beads/ so that

--- a/cmd/bd/init_permissions_test.go
+++ b/cmd/bd/init_permissions_test.go
@@ -1,0 +1,105 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInitRepairsPermissiveBeadsDir is the init-path regression test for
+// GH#3391: a pre-existing .beads/ directory with world-accessible bits
+// (e.g. 0755 from a permissive umask) must be repaired to strip those
+// bits during bd init.
+//
+// The test creates a real git repo with a pre-existing .beads/ at 0755,
+// runs bd init, and asserts that world bits are stripped. The init may
+// fail later (e.g. no Dolt server), but the permission fix happens early
+// enough that the assertion is valid regardless of exit code.
+func TestInitRepairsPermissiveBeadsDir(t *testing.T) {
+	bdBin := buildBDForInitTests(t)
+
+	repoDir := newGitRepo(t)
+
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads: %v", err)
+	}
+	if err := os.Chmod(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to chmod .beads: %v", err)
+	}
+
+	// Verify starting permissions.
+	info, err := os.Stat(beadsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got&0007 == 0 {
+		t.Fatalf("precondition failed: .beads should have world bits, got %04o", got)
+	}
+
+	cmd := exec.Command(bdBin, "init", "--prefix", "bd",
+		"--non-interactive", "--skip-hooks", "--skip-agents")
+	cmd.Dir = repoDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	// We don't check the exit code — init may fail later for reasons
+	// unrelated to permissions (no Dolt, etc.). The permission fix runs
+	// before database creation.
+	_ = cmd.Run()
+
+	// Assert: world-accessible bits must be stripped.
+	info, err = os.Stat(beadsDir)
+	if err != nil {
+		t.Fatalf("Stat(.beads) after init: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm&0007 != 0 {
+		t.Errorf(".beads permissions after init = %04o; world bits should have been stripped", perm)
+	}
+
+	// Assert: the fix was announced on stderr.
+	if !strings.Contains(stderr.String(), "Stripped world-accessible bits") {
+		t.Errorf("expected permission-fix message on stderr, got:\n%s", stderr.String())
+	}
+}
+
+// TestInitPreservesSecureBeadsDir verifies that bd init does NOT touch a
+// .beads/ directory that already has secure permissions (0700).
+func TestInitPreservesSecureBeadsDir(t *testing.T) {
+	bdBin := buildBDForInitTests(t)
+
+	repoDir := newGitRepo(t)
+
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0700); err != nil {
+		t.Fatalf("failed to create .beads: %v", err)
+	}
+
+	cmd := exec.Command(bdBin, "init", "--prefix", "bd",
+		"--non-interactive", "--skip-hooks", "--skip-agents")
+	cmd.Dir = repoDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	_ = cmd.Run()
+
+	// Permissions should remain 0700.
+	info, err := os.Stat(beadsDir)
+	if err != nil {
+		t.Fatalf("Stat(.beads) after init: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm != 0700 {
+		t.Errorf(".beads permissions after init = %04o, want 0700", perm)
+	}
+
+	// No fix message expected.
+	if strings.Contains(stderr.String(), "Stripped world-accessible bits") {
+		t.Errorf("unexpected permission-fix message for already-secure .beads/:\n%s", stderr.String())
+	}
+}

--- a/cmd/bd/init_permissions_test.go
+++ b/cmd/bd/init_permissions_test.go
@@ -4,24 +4,52 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
+var (
+	initPermissionTestBD     string
+	initPermissionTestBDOnce sync.Once
+	initPermissionTestBDErr  error
+)
+
+func buildBDForInitPermissionTests(t *testing.T) string {
+	t.Helper()
+	initPermissionTestBDOnce.Do(func() {
+		tmpDir, err := os.MkdirTemp("", "bd-init-permissions-test-*")
+		if err != nil {
+			initPermissionTestBDErr = fmt.Errorf("failed to create temp dir: %w", err)
+			return
+		}
+		initPermissionTestBD = filepath.Join(tmpDir, "bd")
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", initPermissionTestBD, ".")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			initPermissionTestBDErr = fmt.Errorf("go build failed: %v\n%s", err, out)
+		}
+	})
+	if initPermissionTestBDErr != nil {
+		t.Fatalf("failed to build bd binary: %v", initPermissionTestBDErr)
+	}
+	return initPermissionTestBD
+}
+
 // TestInitRepairsPermissiveBeadsDir is the init-path regression test for
-// GH#3391: a pre-existing .beads/ directory with world-accessible bits
-// (e.g. 0755 from a permissive umask) must be repaired to strip those
-// bits during bd init.
+// GH#3391: a pre-existing .beads/ directory with permissive bits
+// (e.g. 0755 from a permissive umask) must be repaired to 0700 during
+// bd init.
 //
 // The test creates a real git repo with a pre-existing .beads/ at 0755,
-// runs bd init, and asserts that world bits are stripped. The init may
+// runs bd init, and asserts that permissions are repaired. The init may
 // fail later (e.g. no Dolt server), but the permission fix happens early
 // enough that the assertion is valid regardless of exit code.
 func TestInitRepairsPermissiveBeadsDir(t *testing.T) {
-	bdBin := buildBDForInitTests(t)
+	bdBin := buildBDForInitPermissionTests(t)
 
 	repoDir := newGitRepo(t)
 
@@ -53,18 +81,19 @@ func TestInitRepairsPermissiveBeadsDir(t *testing.T) {
 	// before database creation.
 	_ = cmd.Run()
 
-	// Assert: world-accessible bits must be stripped.
+	// Assert: permissions must be repaired to the same mode bd uses when
+	// creating .beads/ itself.
 	info, err = os.Stat(beadsDir)
 	if err != nil {
 		t.Fatalf("Stat(.beads) after init: %v", err)
 	}
 	perm := info.Mode().Perm()
-	if perm&0007 != 0 {
-		t.Errorf(".beads permissions after init = %04o; world bits should have been stripped", perm)
+	if perm != 0700 {
+		t.Errorf(".beads permissions after init = %04o, want 0700", perm)
 	}
 
 	// Assert: the fix was announced on stderr.
-	if !strings.Contains(stderr.String(), "Stripped world-accessible bits") {
+	if !strings.Contains(stderr.String(), "Fixed .beads permissions to 0700") {
 		t.Errorf("expected permission-fix message on stderr, got:\n%s", stderr.String())
 	}
 }
@@ -72,7 +101,7 @@ func TestInitRepairsPermissiveBeadsDir(t *testing.T) {
 // TestInitPreservesSecureBeadsDir verifies that bd init does NOT touch a
 // .beads/ directory that already has secure permissions (0700).
 func TestInitPreservesSecureBeadsDir(t *testing.T) {
-	bdBin := buildBDForInitTests(t)
+	bdBin := buildBDForInitPermissionTests(t)
 
 	repoDir := newGitRepo(t)
 
@@ -99,7 +128,7 @@ func TestInitPreservesSecureBeadsDir(t *testing.T) {
 	}
 
 	// No fix message expected.
-	if strings.Contains(stderr.String(), "Stripped world-accessible bits") {
+	if strings.Contains(stderr.String(), "Fixed .beads permissions") {
 		t.Errorf("unexpected permission-fix message for already-secure .beads/:\n%s", stderr.String())
 	}
 }

--- a/internal/config/permissions.go
+++ b/internal/config/permissions.go
@@ -33,19 +33,22 @@ func CheckBeadsDirPermissions(path string) {
 	}
 }
 
-// FixBeadsDirPermissions sets the .beads directory to BeadsDirPerm if it
-// has overly permissive modes. Returns true if permissions were changed.
+// FixBeadsDirPermissions strips world-accessible bits from the .beads
+// directory. Group bits (0070) are left untouched — users may
+// intentionally set 0750 for shared access. Returns true if permissions
+// were changed.
 func FixBeadsDirPermissions(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false, nil // directory doesn't exist yet
 	}
 	perm := info.Mode().Perm()
-	if perm&0077 == 0 {
-		return false, nil // already secure
+	if perm&0007 == 0 {
+		return false, nil // no world-accessible bits
 	}
-	if err := os.Chmod(path, BeadsDirPerm); err != nil {
-		return false, fmt.Errorf("failed to chmod %s to %04o: %w", path, BeadsDirPerm, err)
+	fixed := perm &^ 0007 // strip other bits, preserve owner+group
+	if err := os.Chmod(path, fixed); err != nil {
+		return false, fmt.Errorf("failed to chmod %s to %04o: %w", path, fixed, err)
 	}
 	return true, nil
 }

--- a/internal/config/permissions.go
+++ b/internal/config/permissions.go
@@ -32,3 +32,20 @@ func CheckBeadsDirPermissions(path string) {
 		fmt.Fprintf(os.Stderr, "Warning: %s has permissions %04o (recommended: 0700). Run: chmod 700 %s\n", path, perm, path)
 	}
 }
+
+// FixBeadsDirPermissions sets the .beads directory to BeadsDirPerm if it
+// has overly permissive modes. Returns true if permissions were changed.
+func FixBeadsDirPermissions(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, nil // directory doesn't exist yet
+	}
+	perm := info.Mode().Perm()
+	if perm&0077 == 0 {
+		return false, nil // already secure
+	}
+	if err := os.Chmod(path, BeadsDirPerm); err != nil {
+		return false, fmt.Errorf("failed to chmod %s to %04o: %w", path, BeadsDirPerm, err)
+	}
+	return true, nil
+}

--- a/internal/config/permissions.go
+++ b/internal/config/permissions.go
@@ -33,22 +33,19 @@ func CheckBeadsDirPermissions(path string) {
 	}
 }
 
-// FixBeadsDirPermissions strips world-accessible bits from the .beads
-// directory. Group bits (0070) are left untouched — users may
-// intentionally set 0750 for shared access. Returns true if permissions
-// were changed.
+// FixBeadsDirPermissions sets the .beads directory to BeadsDirPerm when it
+// has group or world-accessible bits. Returns true if permissions changed.
 func FixBeadsDirPermissions(path string) (bool, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return false, nil // directory doesn't exist yet
 	}
 	perm := info.Mode().Perm()
-	if perm&0007 == 0 {
-		return false, nil // no world-accessible bits
+	if perm&0077 == 0 {
+		return false, nil // no group or world-accessible bits
 	}
-	fixed := perm &^ 0007 // strip other bits, preserve owner+group
-	if err := os.Chmod(path, fixed); err != nil {
-		return false, fmt.Errorf("failed to chmod %s to %04o: %w", path, fixed, err)
+	if err := os.Chmod(path, BeadsDirPerm); err != nil {
+		return false, fmt.Errorf("failed to chmod %s to %04o: %w", path, BeadsDirPerm, err)
 	}
 	return true, nil
 }

--- a/internal/config/permissions_test.go
+++ b/internal/config/permissions_test.go
@@ -115,15 +115,15 @@ func TestCheckBeadsDirPermissions_Nonexistent(t *testing.T) {
 
 func TestFixBeadsDirPermissions(t *testing.T) {
 	tests := []struct {
-		name        string
-		startPerm   os.FileMode
-		wantFixed   bool
-		wantPerm    os.FileMode
+		name      string
+		startPerm os.FileMode
+		wantFixed bool
+		wantPerm  os.FileMode
 	}{
-		{"world_readable_0755", 0755, true, 0750},
-		{"world_writable_0777", 0777, true, 0770},
+		{"world_readable_0755", 0755, true, 0700},
+		{"world_writable_0777", 0777, true, 0700},
 		{"world_only_0707", 0707, true, 0700},
-		{"group_only_0770", 0770, false, 0770},
+		{"group_only_0770", 0770, true, 0700},
 		{"already_secure_0700", 0700, false, 0700},
 		{"owner_only_0600", 0600, false, 0600},
 	}

--- a/internal/config/permissions_test.go
+++ b/internal/config/permissions_test.go
@@ -112,3 +112,58 @@ func TestCheckBeadsDirPermissions_Nonexistent(t *testing.T) {
 		t.Errorf("expected no output for nonexistent dir, got: %s", buf.String())
 	}
 }
+
+func TestFixBeadsDirPermissions(t *testing.T) {
+	tests := []struct {
+		name        string
+		startPerm   os.FileMode
+		wantFixed   bool
+		wantPerm    os.FileMode
+	}{
+		{"world_readable_0755", 0755, true, 0750},
+		{"world_writable_0777", 0777, true, 0770},
+		{"world_only_0707", 0707, true, 0700},
+		{"group_only_0770", 0770, false, 0770},
+		{"already_secure_0700", 0700, false, 0700},
+		{"owner_only_0600", 0600, false, 0600},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), ".beads")
+			if err := os.Mkdir(dir, tt.startPerm); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Chmod(dir, tt.startPerm); err != nil {
+				t.Fatal(err)
+			}
+
+			fixed, err := FixBeadsDirPermissions(dir)
+			if err != nil {
+				t.Fatalf("FixBeadsDirPermissions() error = %v", err)
+			}
+			if fixed != tt.wantFixed {
+				t.Errorf("fixed = %v, want %v", fixed, tt.wantFixed)
+			}
+
+			info, err := os.Stat(dir)
+			if err != nil {
+				t.Fatalf("Stat() error = %v", err)
+			}
+			got := info.Mode().Perm()
+			if got != tt.wantPerm {
+				t.Errorf("permissions after fix = %04o, want %04o", got, tt.wantPerm)
+			}
+		})
+	}
+}
+
+func TestFixBeadsDirPermissions_Nonexistent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "no-such-dir")
+	fixed, err := FixBeadsDirPermissions(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fixed {
+		t.Error("expected fixed=false for nonexistent directory")
+	}
+}

--- a/internal/config/permissions_windows.go
+++ b/internal/config/permissions_windows.go
@@ -22,3 +22,7 @@ func EnsureBeadsDir(path string) error {
 // CheckBeadsDirPermissions is a no-op on Windows where filesystem
 // permissions use ACLs rather than Unix permission bits.
 func CheckBeadsDirPermissions(path string) {}
+
+// FixBeadsDirPermissions is a no-op on Windows where filesystem
+// permissions use ACLs rather than Unix permission bits.
+func FixBeadsDirPermissions(path string) (bool, error) { return false, nil }


### PR DESCRIPTION
## Summary

- `bd init` now fixes permissions on pre-existing `.beads/` directories to 0700
- Adds `config.FixBeadsDirPermissions()` that checks and repairs overly permissive modes
- Eliminates the recurring warning on every `bd` invocation when `.beads/` was created with default umask

Closes #3391

## Details

When `.beads/` already exists (e.g. from `git clone` with `umask 022`), `os.MkdirAll` does not change its permissions. Previously this left the directory at 0755, causing a warning on every subsequent `bd` command. Now `bd init` detects and fixes the permissions, printing a one-time status message.

**Files changed:**
- `internal/config/permissions.go` — new `FixBeadsDirPermissions()` function
- `cmd/bd/init.go` — call it after `MkdirAll`

## Test plan

- [ ] `go build ./cmd/bd` compiles cleanly
- [ ] `go test ./internal/config/...` passes
- [ ] Manual: `mkdir .beads && chmod 755 .beads && bd init` → permissions fixed to 0700

🤖 Generated with [Claude Code](https://claude.ai/code)