### PR TITLE
fix(ready): raise default limit from 10 to 50 (GH#3409)

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -663,7 +663,7 @@ type MoleculeReadyOutput struct {
 }
 
 func init() {
-	readyCmd.Flags().IntP("limit", "n", 10, "Maximum issues to show")
+	readyCmd.Flags().IntP("limit", "n", 50, "Maximum issues to show")
 	readyCmd.Flags().IntP("priority", "p", 0, "Filter by priority")
 	readyCmd.Flags().StringP("assignee", "a", "", "Filter by assignee")
 	readyCmd.Flags().BoolP("unassigned", "u", false, "Show only unassigned issues")


### PR DESCRIPTION
## Summary

- Raises `bd ready` default `--limit` from 10 to 50
- Existing truncation hint ("Showing X of Y ready issues. Use -n to show more.") now fires less frequently but still works when needed

Closes #3409

## Details

The previous default of 10 silently truncated results in projects with many ready beads. This bit a planning session where validation reported "all Tier 0 ready" based on a list that had been cut to 10 of 12. The truncation detection and hint infrastructure already existed — just the default was too low.

One-line change in `cmd/bd/ready.go`.

## Test plan

- [ ] `go build ./cmd/bd` compiles cleanly
- [ ] `go test ./cmd/bd/... -run Ready` passes
- [ ] `bd ready --help` shows default of 50

🤖 Generated with [Claude Code](https://claude.ai/code)