### PR TITLE
fix(sort): natural numeric sort for issue IDs with dotted suffixes (GH#3477)

### DIFF
--- a/cmd/bd/graph.go
+++ b/cmd/bd/graph.go
@@ -768,7 +768,7 @@ func renderGraphCompact(layout *GraphLayout, subgraph *TemplateSubgraph) {
 			if nodeI.Issue.Priority != nodeJ.Issue.Priority {
 				return nodeI.Issue.Priority < nodeJ.Issue.Priority
 			}
-			return nodeI.Issue.ID < nodeJ.Issue.ID
+			return utils.NaturalCompareIDs(nodeI.Issue.ID, nodeJ.Issue.ID) < 0
 		})
 	}
 

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -250,7 +250,7 @@ func sortIssues(issues []*types.Issue, sortBy string, reverse bool) {
 		case "status":
 			result = cmp.Compare(a.Status, b.Status)
 		case "id":
-			result = cmp.Compare(a.ID, b.ID)
+			result = utils.NaturalCompareIDs(a.ID, b.ID)
 		case "title":
 			result = cmp.Compare(strings.ToLower(a.Title), strings.ToLower(b.Title))
 		case "type":

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // buildIssueTree builds parent-child tree structure from issues
@@ -105,7 +106,7 @@ func compareIssuesByPriority(a, b *types.Issue) int {
 		return result
 	}
 	// Secondary: ID for deterministic order when priorities match
-	return cmp.Compare(a.ID, b.ID)
+	return utils.NaturalCompareIDs(a.ID, b.ID)
 }
 
 // printPrettyTree recursively prints the issue tree

--- a/cmd/bd/swarm.go
+++ b/cmd/bd/swarm.go
@@ -768,16 +768,16 @@ func getSwarmStatus(ctx context.Context, s SwarmStorage, epic *types.Issue) (*Sw
 
 	// Sort each category by ID for consistent output
 	sort.Slice(status.Completed, func(i, j int) bool {
-		return status.Completed[i].ID < status.Completed[j].ID
+		return utils.NaturalCompareIDs(status.Completed[i].ID, status.Completed[j].ID) < 0
 	})
 	sort.Slice(status.Active, func(i, j int) bool {
-		return status.Active[i].ID < status.Active[j].ID
+		return utils.NaturalCompareIDs(status.Active[i].ID, status.Active[j].ID) < 0
 	})
 	sort.Slice(status.Ready, func(i, j int) bool {
-		return status.Ready[i].ID < status.Ready[j].ID
+		return utils.NaturalCompareIDs(status.Ready[i].ID, status.Ready[j].ID) < 0
 	})
 	sort.Slice(status.Blocked, func(i, j int) bool {
-		return status.Blocked[i].ID < status.Blocked[j].ID
+		return utils.NaturalCompareIDs(status.Blocked[i].ID, status.Blocked[j].ID) < 0
 	})
 
 	// Compute counts and progress

--- a/cmd/bd/todo.go
+++ b/cmd/bd/todo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 var todoCmd = &cobra.Command{
@@ -229,6 +230,6 @@ func todoSortIssues(issues []*types.Issue) {
 		if a.Priority != b.Priority {
 			return a.Priority - b.Priority
 		}
-		return strings.Compare(a.ID, b.ID)
+		return utils.NaturalCompareIDs(a.ID, b.ID)
 	})
 }

--- a/internal/utils/issue_id.go
+++ b/internal/utils/issue_id.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -131,6 +132,51 @@ func ExtractIssuePrefixKnown(issueID string, knownPrefixes []string) string {
 
 	// No known prefix matched; fall back to heuristic
 	return ExtractIssuePrefix(issueID)
+}
+
+// NaturalCompareIDs compares two issue IDs with numeric-aware sorting.
+// Segments separated by "." or "-" are compared numerically when both
+// are pure digits, otherwise lexicographically. This ensures bd-E.4
+// sorts before bd-E.10 (GH#3477).
+func NaturalCompareIDs(a, b string) int {
+	sa := splitIDSegments(a)
+	sb := splitIDSegments(b)
+	for i := 0; i < len(sa) && i < len(sb); i++ {
+		if sa[i] == sb[i] {
+			continue
+		}
+		na, aErr := strconv.Atoi(sa[i])
+		nb, bErr := strconv.Atoi(sb[i])
+		if aErr == nil && bErr == nil {
+			if na != nb {
+				return na - nb
+			}
+			continue
+		}
+		if sa[i] < sb[i] {
+			return -1
+		}
+		return 1
+	}
+	return len(sa) - len(sb)
+}
+
+// splitIDSegments splits an ID into segments by "." and "-" separators.
+func splitIDSegments(id string) []string {
+	var segments []string
+	start := 0
+	for i, r := range id {
+		if r == '.' || r == '-' {
+			if i > start {
+				segments = append(segments, id[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(id) {
+		segments = append(segments, id[start:])
+	}
+	return segments
 }
 
 // ExtractIssueNumber extracts the number from an issue ID like "bd-123" -> 123

--- a/internal/utils/issue_id_test.go
+++ b/internal/utils/issue_id_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import "testing"
+
+func TestNaturalCompareIDs(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int // <0, 0, >0
+	}{
+		{"bd-1", "bd-2", -1},
+		{"bd-2", "bd-10", -1},     // numeric: 2 < 10
+		{"bd-E.4", "bd-E.10", -1}, // suffix: 4 < 10
+		{"bd-E.10", "bd-E.4", 1},
+		{"bd-E.4", "bd-E.4", 0},
+		{"bd-A.1", "bd-B.1", -1}, // alpha prefix
+		{"bd-1.1", "bd-1.2", -1},
+		{"bd-1.9", "bd-1.10", -1}, // 9 < 10
+	}
+	for _, tt := range tests {
+		got := NaturalCompareIDs(tt.a, tt.b)
+		if (tt.want < 0 && got >= 0) || (tt.want > 0 && got <= 0) || (tt.want == 0 && got != 0) {
+			t.Errorf("NaturalCompareIDs(%q, %q) = %d, want sign %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestSplitIDSegments(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"bd-1", []string{"bd", "1"}},
+		{"bd-E.10", []string{"bd", "E", "10"}},
+		{"bd-1.2.3", []string{"bd", "1", "2", "3"}},
+	}
+	for _, tt := range tests {
+		got := splitIDSegments(tt.input)
+		if len(got) != len(tt.want) {
+			t.Errorf("splitIDSegments(%q) = %v, want %v", tt.input, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("splitIDSegments(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `NaturalCompareIDs` to `internal/utils/issue_id.go` — splits IDs by `.`/`-` separators, compares numeric segments numerically
- Replaces string-based ID comparison across 5 files (6 call sites) so `bd-E.10` sorts after `bd-E.9`

Closes #3477

## Details

Issue IDs like `bd-E.4`, `bd-E.10` were compared as strings, so `.10` sorted before `.4` lexicographically. The new `NaturalCompareIDs` function splits on `.` and `-` separators and compares segments numerically when both are digits.

**Files changed:**
- `internal/utils/issue_id.go` — new `NaturalCompareIDs` + `splitIDSegments`
- `internal/utils/issue_id_test.go` — tests for both functions
- `cmd/bd/list_tree.go` — `compareIssuesByPriority` secondary sort
- `cmd/bd/graph.go` — graph child node sorting
- `cmd/bd/list.go` — `--sort=id` column sort
- `cmd/bd/swarm.go` — all four category sorts
- `cmd/bd/todo.go` — `todoSortIssues` secondary sort

## Test plan

- [ ] `go test ./internal/utils/...` — new unit tests pass
- [ ] `go build ./cmd/bd` compiles
- [ ] Create epic with children `.4` through `.16`, verify `bd list` shows them in numeric order

🤖 Generated with [Claude Code](https://claude.ai/code)