### PR TITLE
fix(gate): drop removed 'merged' field from gh pr view call (GH#3411)

### DIFF
--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -453,7 +453,7 @@ Gate types:
 
 GitHub gates use the 'gh' CLI to query status:
   - gh:run checks 'gh run view <id> --json status,conclusion'
-  - gh:pr checks 'gh pr view <id> --json state,merged'
+  - gh:pr checks 'gh pr view <id> --json state,title'
 
 A gate is resolved when:
   - gh:run: status=completed AND conclusion=success
@@ -635,9 +635,8 @@ type ghRunStatus struct {
 
 // ghPRStatus holds the JSON response from 'gh pr view'
 type ghPRStatus struct {
-	State  string `json:"state"`
-	Merged bool   `json:"merged"`
-	Title  string `json:"title"`
+	State string `json:"state"`
+	Title string `json:"title"`
 }
 
 var (
@@ -790,8 +789,8 @@ func checkGHPR(gate *types.Issue) (resolved, escalated bool, reason string, err 
 		return false, false, "no PR number specified", nil
 	}
 
-	// Run: gh pr view <id> --json state,merged,title
-	cmd := exec.Command("gh", "pr", "view", gate.AwaitID, "--json", "state,merged,title") // #nosec G204 -- gate.AwaitID is a validated GitHub PR number
+	// Run: gh pr view <id> --json state,title
+	cmd := exec.Command("gh", "pr", "view", gate.AwaitID, "--json", "state,title") // #nosec G204 -- gate.AwaitID is a validated GitHub PR number
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -819,9 +818,6 @@ func checkGHPR(gate *types.Issue) (resolved, escalated bool, reason string, err 
 	case "MERGED":
 		return true, false, fmt.Sprintf("PR '%s' was merged", status.Title), nil
 	case "CLOSED":
-		if status.Merged {
-			return true, false, fmt.Sprintf("PR '%s' was merged", status.Title), nil
-		}
 		return false, true, fmt.Sprintf("PR '%s' was closed without merging", status.Title), nil
 	case "OPEN":
 		return false, false, fmt.Sprintf("PR '%s' is still open", status.Title), nil

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -648,6 +648,96 @@ func TestWorkflowNameMatches(t *testing.T) {
 	}
 }
 
+func TestCheckGHPR_StateHandling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-sh fake binary; skipping on Windows")
+	}
+
+	tests := []struct {
+		name           string
+		ghJSON         string
+		wantResolved   bool
+		wantEscalated  bool
+		reasonContains string
+	}{
+		{
+			name:           "MERGED resolves gate",
+			ghJSON:         `{"state":"MERGED","title":"Add feature X"}`,
+			wantResolved:   true,
+			wantEscalated:  false,
+			reasonContains: "was merged",
+		},
+		{
+			name:           "CLOSED escalates without merge",
+			ghJSON:         `{"state":"CLOSED","title":"Stale PR"}`,
+			wantResolved:   false,
+			wantEscalated:  true,
+			reasonContains: "closed without merging",
+		},
+		{
+			name:           "OPEN leaves gate pending",
+			ghJSON:         `{"state":"OPEN","title":"WIP"}`,
+			wantResolved:   false,
+			wantEscalated:  false,
+			reasonContains: "still open",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installFakeGHScript(t, tt.ghJSON)
+			gate := &types.Issue{AwaitID: "https://github.com/org/repo/pull/1"}
+			resolved, escalated, reason, err := checkGHPR(gate)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resolved != tt.wantResolved {
+				t.Errorf("resolved = %v, want %v", resolved, tt.wantResolved)
+			}
+			if escalated != tt.wantEscalated {
+				t.Errorf("escalated = %v, want %v", escalated, tt.wantEscalated)
+			}
+			if !gateTestContainsIgnoreCase(reason, tt.reasonContains) {
+				t.Errorf("reason %q does not contain %q", reason, tt.reasonContains)
+			}
+		})
+	}
+}
+
+func TestCheckGHPR_NoMergedFieldRequested(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-sh fake binary; skipping on Windows")
+	}
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "gh")
+	// Fake gh that fails if "merged" appears anywhere in args
+	script := `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    *merged*) echo "ERROR: 'merged' field must not be requested" >&2; exit 1;;
+  esac
+done
+echo '{"state":"MERGED","title":"Test PR"}'
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	gate := &types.Issue{AwaitID: "https://github.com/org/repo/pull/99"}
+	resolved, _, reason, err := checkGHPR(gate)
+	if err != nil {
+		t.Fatalf("checkGHPR failed (likely requested 'merged' field): %v", err)
+	}
+	if !resolved {
+		t.Errorf("expected resolved=true for MERGED state")
+	}
+	if !gateTestContainsIgnoreCase(reason, "was merged") {
+		t.Errorf("reason %q should contain 'was merged'", reason)
+	}
+}
+
 func installFakeGHScript(t *testing.T, stdout string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Removes `merged` from `gh pr view --json` call — field was removed in gh CLI v2.89+
- Removes `Merged bool` from `ghPRStatus` struct
- Simplifies CLOSED case — `MERGED` is already a distinct state value

Closes #3411

## Details

gh CLI >=2.89 removed the `merged` boolean JSON field in favor of `state == "MERGED"`. The code already had a `case "MERGED"` handler, so the `merged` field was redundant. With this change, `gh:pr` gates work on all current gh CLI versions.

## Test plan

- [ ] `go build ./cmd/bd` compiles
- [ ] `bd gate check --type=gh:pr --await-id <merged-pr-url>` returns "was merged"
- [ ] `bd gate check --type=gh:pr --await-id <open-pr-url>` returns "still open"
- [ ] `bd gate check --type=gh:pr --await-id <closed-pr-url>` returns "closed without merging"

🤖 Generated with [Claude Code](https://claude.ai/code)