### PR TITLE
fix(ready): --parent filter now returns all descendants via recursive CTE (GH#3396)

### DIFF
--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -98,10 +98,19 @@ func GetReadyWorkInTx(
 		}
 		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT issue_id FROM labels WHERE label IN (%s))", strings.Join(placeholders, ", ")))
 	}
-	// Parent filtering.
+	// Parent filtering: recursive CTE walks full parent-child tree (GH#3396).
 	if filter.ParentID != nil {
 		parentID := *filter.ParentID
-		whereClauses = append(whereClauses, "(id IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child' AND depends_on_id = ?) OR (id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child')))")
+		whereClauses = append(whereClauses, `(id IN (
+			WITH RECURSIVE descendants AS (
+				SELECT issue_id FROM dependencies WHERE type = 'parent-child' AND depends_on_id = ?
+				UNION ALL
+				SELECT d.issue_id FROM dependencies d
+				INNER JOIN descendants dt ON d.depends_on_id = dt.issue_id
+				WHERE d.type = 'parent-child'
+			)
+			SELECT issue_id FROM descendants
+		) OR (id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child')))`)
 		args = append(args, parentID, parentID)
 	}
 


### PR DESCRIPTION
## Summary

- `bd ready --parent=<id>` now returns all descendants (grandchildren, etc.), not just direct children
- Replaces single-hop join with `WITH RECURSIVE` CTE in `GetReadyWorkInTx`
- Help text already said "descendants" — behavior now matches

Closes #3396

## Details

The parent filter in `GetReadyWorkInTx` used a one-hop join against the `dependencies` table, so only direct children of the given parent were returned. Grandchildren and deeper descendants were silently dropped.

Now uses a recursive CTE to walk the full `parent-child` dependency tree. The ID-prefix fallback (`id LIKE CONCAT(?, '.%')`) is preserved for issues not in the dependency table.

## Test plan

- [ ] `go build ./cmd/bd` compiles
- [ ] Create epic -> phase -> leaf task hierarchy
- [ ] `bd ready --parent=<epic>` returns the leaf task (not just the phase)
- [ ] `bd ready --parent=<phase>` still returns the leaf task (direct child)

🤖 Generated with [Claude Code](https://claude.ai/code)