### PR TITLE
fix(nix): use proxy vendor for pure-go package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,16 +16,16 @@ buildGoModule {
   tags = [ "gms_pure_go" ];
   doCheck = false;
 
-  # Go module dependencies hash - if build fails with hash mismatch, update with the "got:" value
-  vendorHash = "sha256-Rn1MnasYUOBbIgjFx0E6R2Zak6la1VajDkHqoiFpHtw=";
+  # proxyVendor avoids vendor/modules.txt consistency checks when the vendored
+  # tree lags go.mod/go.sum.
+  proxyVendor = true;
+  vendorHash = "sha256-S/NavjGH6VSPU+rCtqtviOcGhgXc6VZUXCUhasSdUGU=";
 
   # Relax go.mod version for Nix: nixpkgs Go may lag behind the latest
   # patch release, and GOTOOLCHAIN=auto can't download in the Nix sandbox.
   postPatch = ''
     goVer="$(go env GOVERSION | sed 's/^go//')"
     go mod edit -go="$goVer"
-
-    env
   '';
 
   # Allow patch-level toolchain upgrades when a dependency's minimum Go patch

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,7 @@
           }
         );
     in rec {
-      icu = nixpkgs.icu77;
-      packages = forAllSystems (args: import ./packages.nix (args // { inherit icu; }));
+      packages = forAllSystems (args: import ./packages.nix args);
 
       apps = forAllSystems (
         { self, system, ... }:


### PR DESCRIPTION
## Summary
- enable `proxyVendor` for the Nix Go module build and update the current-main module hash
- keep the existing `gms_pure_go` Nix build tag while removing stale ICU flake wiring
- remove the leftover `env` dump from `postPatch`

Based on the focused Nix packaging work from #3278, with contributor attribution preserved in the commit.

## Validation
- `scripts/pr-preflight.sh 3278 --repo gastownhall/beads` (blocked autonomous replacement/merge because #3278 is an external contributor PR with a broad diff; used it only as source context)
- `scripts/pr-preflight.sh --search "Nix gms_pure_go vendorHash ICU packaging" --repo gastownhall/beads`
- `git diff --check`
- `docker run --rm -v /tmp/tmp.LfkGIl1tTK:/work -w /work nixos/nix:latest nix --extra-experimental-features "nix-command flakes" build path:/work#default --print-build-logs`

## Notes
- `make test` was attempted and timed out in unrelated `cmd/bd` test `TestContextUsesExplicitDBFlagForNoDBCommand`; most packages completed.
- A compile-only retry with `go test -tags gms_pure_go -run "^$" ./cmd/bd` then failed with local `disk quota exceeded` after the containerized Nix validation.