### PR TITLE
fix(embeddeddolt): pass DOLT_REMOTE_USER to push/pull/fetch

### DIFF
--- a/internal/storage/embeddeddolt/version_control.go
+++ b/internal/storage/embeddeddolt/version_control.go
@@ -197,6 +197,16 @@ func (s *EmbeddedDoltStore) ResolveConflicts(ctx context.Context, table string, 
 
 const defaultRemote = "origin"
 
+// remoteAuthUser returns the username to authenticate with the remote, read
+// from DOLT_REMOTE_USER. When set, push/pull/fetch invocations pass --user so
+// the in-process Dolt server authenticates against the remotesapi (which
+// otherwise rejects with CLONE_ADMIN). DOLT_REMOTE_PASSWORD is read by Dolt
+// itself from the same process environment. Returns "" when no auth is
+// configured (typical for git+ssh, file://, or unauthenticated remotes).
+func remoteAuthUser() string {
+	return os.Getenv("DOLT_REMOTE_USER")
+}
+
 func (s *EmbeddedDoltStore) RemoveRemote(ctx context.Context, name string) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
 		return versioncontrolops.RemoveRemote(ctx, db, name)
@@ -215,46 +225,46 @@ func (s *EmbeddedDoltStore) ListRemotes(ctx context.Context) ([]storage.RemoteIn
 
 func (s *EmbeddedDoltStore) Push(ctx context.Context) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		return versioncontrolops.Push(ctx, db, defaultRemote, s.branch)
+		return versioncontrolops.Push(ctx, db, defaultRemote, s.branch, remoteAuthUser())
 	})
 }
 
 func (s *EmbeddedDoltStore) Pull(ctx context.Context) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		return versioncontrolops.Pull(ctx, db, defaultRemote, s.branch)
+		return versioncontrolops.Pull(ctx, db, defaultRemote, s.branch, remoteAuthUser())
 	})
 }
 
 func (s *EmbeddedDoltStore) ForcePush(ctx context.Context) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		return versioncontrolops.ForcePush(ctx, db, defaultRemote, s.branch)
+		return versioncontrolops.ForcePush(ctx, db, defaultRemote, s.branch, remoteAuthUser())
 	})
 }
 
 func (s *EmbeddedDoltStore) PushRemote(ctx context.Context, remote string, force bool) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
 		if force {
-			return versioncontrolops.ForcePush(ctx, db, remote, s.branch)
+			return versioncontrolops.ForcePush(ctx, db, remote, s.branch, remoteAuthUser())
 		}
-		return versioncontrolops.Push(ctx, db, remote, s.branch)
+		return versioncontrolops.Push(ctx, db, remote, s.branch, remoteAuthUser())
 	})
 }
 
 func (s *EmbeddedDoltStore) PullRemote(ctx context.Context, remote string) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		return versioncontrolops.Pull(ctx, db, remote, s.branch)
+		return versioncontrolops.Pull(ctx, db, remote, s.branch, remoteAuthUser())
 	})
 }
 
 func (s *EmbeddedDoltStore) Fetch(ctx context.Context, peer string) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		return versioncontrolops.Fetch(ctx, db, peer)
+		return versioncontrolops.Fetch(ctx, db, peer, remoteAuthUser())
 	})
 }
 
 func (s *EmbeddedDoltStore) PushTo(ctx context.Context, peer string) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		return versioncontrolops.Push(ctx, db, peer, s.branch)
+		return versioncontrolops.Push(ctx, db, peer, s.branch, remoteAuthUser())
 	})
 }
 
@@ -267,7 +277,7 @@ func (s *EmbeddedDoltStore) PullFrom(ctx context.Context, peer string) ([]storag
 
 	var conflicts []storage.Conflict
 	err := s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
-		if pullErr := versioncontrolops.Pull(ctx, db, peer, s.branch); pullErr != nil {
+		if pullErr := versioncontrolops.Pull(ctx, db, peer, s.branch, remoteAuthUser()); pullErr != nil {
 			// Check if the error is due to merge conflicts.
 			c, conflictErr := versioncontrolops.GetConflicts(ctx, db)
 			if conflictErr == nil && len(c) > 0 {

--- a/internal/storage/versioncontrolops/remotes.go
+++ b/internal/storage/versioncontrolops/remotes.go
@@ -37,12 +37,21 @@ func RemoveRemote(ctx context.Context, db DBConn, name string) error {
 
 // Fetch fetches refs from a remote without merging.
 //
+// If user is non-empty, authenticates with that user — DOLT_REMOTE_PASSWORD
+// must be set in the in-process Dolt server's environment.
+//
 // On failure, a best-effort GC is run to clean up any orphaned tmp_pack_*
 // files that DOLT_FETCH may have left in the git-remote-cache. These files
 // accumulate unboundedly across repeated failures and can consume hundreds of
 // gigabytes over time.
-func Fetch(ctx context.Context, db DBConn, peer string) error {
-	if _, err := db.ExecContext(ctx, "CALL DOLT_FETCH(?)", peer); err != nil {
+func Fetch(ctx context.Context, db DBConn, peer, user string) error {
+	var err error
+	if user != "" {
+		_, err = db.ExecContext(ctx, "CALL DOLT_FETCH('--user', ?, ?)", user, peer)
+	} else {
+		_, err = db.ExecContext(ctx, "CALL DOLT_FETCH(?)", peer)
+	}
+	if err != nil {
 		// Best-effort: ignore GC errors — the original fetch error is what matters.
 		// DoltGC requires a non-transactional connection; if db is a tx it will
 		// fail silently here, which is acceptable.
@@ -53,7 +62,16 @@ func Fetch(ctx context.Context, db DBConn, peer string) error {
 }
 
 // Push pushes the given branch to the named remote.
-func Push(ctx context.Context, db DBConn, remote, branch string) error {
+// If user is non-empty, authenticates with that user — DOLT_REMOTE_PASSWORD
+// must be set in the in-process Dolt server's environment. Required when
+// pushing to a remotesapi server that enforces CLONE_ADMIN authentication.
+func Push(ctx context.Context, db DBConn, remote, branch, user string) error {
+	if user != "" {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_PUSH('--user', ?, ?, ?)", user, remote, branch); err != nil {
+			return fmt.Errorf("push to %s/%s: %w", remote, branch, err)
+		}
+		return nil
+	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_PUSH(?, ?)", remote, branch); err != nil {
 		return fmt.Errorf("push to %s/%s: %w", remote, branch, err)
 	}
@@ -61,7 +79,14 @@ func Push(ctx context.Context, db DBConn, remote, branch string) error {
 }
 
 // ForcePush force-pushes the given branch to the named remote.
-func ForcePush(ctx context.Context, db DBConn, remote, branch string) error {
+// See Push for the user/auth contract.
+func ForcePush(ctx context.Context, db DBConn, remote, branch, user string) error {
+	if user != "" {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_PUSH('--force', '--user', ?, ?, ?)", user, remote, branch); err != nil {
+			return fmt.Errorf("force push to %s/%s: %w", remote, branch, err)
+		}
+		return nil
+	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_PUSH('--force', ?, ?)", remote, branch); err != nil {
 		return fmt.Errorf("force push to %s/%s: %w", remote, branch, err)
 	}
@@ -72,9 +97,18 @@ func ForcePush(ctx context.Context, db DBConn, remote, branch string) error {
 // the remote tracking ref. This is equivalent to DOLT_PULL(remote, branch) but
 // avoids a nil-pointer panic in embedded Dolt when upstream branch tracking is
 // not configured in repo_state.json (GH#3144).
-func Pull(ctx context.Context, db DBConn, remote, branch string) error {
-	if _, err := db.ExecContext(ctx, "CALL DOLT_FETCH(?, ?)", remote, branch); err != nil {
-		return fmt.Errorf("fetch from %s/%s: %w", remote, branch, err)
+//
+// See Push for the user/auth contract; only the fetch step authenticates,
+// since the merge step is local.
+func Pull(ctx context.Context, db DBConn, remote, branch, user string) error {
+	if user != "" {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_FETCH('--user', ?, ?, ?)", user, remote, branch); err != nil {
+			return fmt.Errorf("fetch from %s/%s: %w", remote, branch, err)
+		}
+	} else {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_FETCH(?, ?)", remote, branch); err != nil {
+			return fmt.Errorf("fetch from %s/%s: %w", remote, branch, err)
+		}
 	}
 	trackingRef := remote + "/" + branch
 	if _, err := db.ExecContext(ctx, "CALL DOLT_MERGE(?)", trackingRef); err != nil {


### PR DESCRIPTION
## Summary

Embedded-mode `bd dolt push`/`pull`/`fetch` failed against any Dolt remotesapi server that requires `CLONE_ADMIN` authentication (DoltHub, self-hosted `dolt sql-server` with auth, any team-shared Dolt remote behind credentials), even when `DOLT_REMOTE_USER` and `DOLT_REMOTE_PASSWORD` were set in the environment.

The non-embedded `DoltStore` path already handled this correctly via the `s.remoteUser != ""` branch in `internal/storage/dolt/store.go` that fires `CALL DOLT_PUSH('--user', ?, ?, ?)`. The embedded path bypassed that entirely — `EmbeddedDoltStore.Push/Pull/ForcePush/Fetch/PushRemote/PullRemote/PushTo/PullFrom` route through `versioncontrolops` helpers that always called `CALL DOLT_PUSH/PULL/FETCH` with no `--user`. Result: the in-process Dolt connected to the remotesapi as anonymous and got rejected with `unauthenticated user does not have privilege CLONE_ADMIN`.

The `bd dolt push --help` and `bd dolt pull --help` text already documents `DOLT_REMOTE_USER`/`DOLT_REMOTE_PASSWORD`, implying it should work — this fix matches the documented contract.

## Changes

- `internal/storage/versioncontrolops/remotes.go`: `Push`, `Pull`, `ForcePush`, `Fetch` now take a trailing `user string`; empty preserves prior behavior. When non-empty, the SQL stored procedures get `--user` appended.
- `internal/storage/embeddeddolt/version_control.go`: reads `DOLT_REMOTE_USER` from process env at call time and threads it through the eight call sites (`Push`, `Pull`, `ForcePush`, `Fetch`, `PushRemote`, `PullRemote`, `PushTo`, `PullFrom`). `DOLT_REMOTE_PASSWORD` is read by the in-process Dolt server from the same env, matching how the non-embedded path already works.

The merge with `Fetch`'s recent best-effort `DoltGC()` cleanup-on-failure (added on `main` ~2 weeks ago) is preserved — both auth and unauth paths benefit from the GC cleanup.

## Test plan

- [x] `make build` — clean
- [x] `make test` for touched packages (`storage/versioncontrolops`, `storage/embeddeddolt`, `cmd/bd`) — all green
- [x] **Confirmed against a real auth-protected Dolt remotesapi server** (self-hosted Hetzner `dolt sql-server`): `bd dolt pull` returned "Pull complete." Before the fix, the same call returned `unauthenticated user does not have privilege CLONE_ADMIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)