### PR TITLE
fix(storage/dolt): DOLT_COMMIT after label/comment writes

### DIFF
--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -10,7 +10,10 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// AddComment adds a comment event to an issue
+// AddComment adds a comment event to an issue.
+// Permanent issue comments create a Dolt commit so the change reaches push
+// targets and does not leave the working set dirty in server mode. Wisp
+// comments live in dolt_ignore'd tables and skip DOLT_COMMIT.
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -21,7 +24,13 @@ func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment stri
 	if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if s.isActiveWisp(ctx, issueID) {
+		return nil
+	}
+	return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: comment %s", issueID))
 }
 
 // GetEvents retrieves events for an issue
@@ -54,6 +63,9 @@ func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text s
 
 // ImportIssueComment adds a comment during import, preserving the original timestamp.
 // This prevents comment timestamp drift across import/export cycles.
+// Permanent issue comments create a Dolt commit so the change reaches push
+// targets and does not leave the working set dirty in server mode. Wisp
+// comments live in dolt_ignore'd tables and skip DOLT_COMMIT.
 func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
 	var result *types.Comment
 	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
@@ -61,7 +73,16 @@ func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, tex
 		result, err = issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
 		return err
 	})
-	return result, err
+	if err != nil {
+		return result, err
+	}
+	if s.isActiveWisp(ctx, issueID) {
+		return result, nil
+	}
+	if err := s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment add %s", issueID)); err != nil {
+		return result, err
+	}
+	return result, nil
 }
 
 // GetIssueComments retrieves all comments for an issue

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -3,24 +3,41 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// AddLabel adds a label to an issue
+// AddLabel adds a label to an issue.
+// Wisp labels live in dolt_ignore'd tables and skip DOLT_COMMIT; permanent
+// issue labels create a Dolt commit so the change reaches push targets and
+// does not leave the working set dirty in server mode (GH server-mode flush).
 func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
-	})
+	}); err != nil {
+		return err
+	}
+	if s.isActiveWisp(ctx, issueID) {
+		return nil
+	}
+	return s.doltAddAndCommit(ctx, []string{"labels", "events"}, fmt.Sprintf("bd: label add %s %s", issueID, label))
 }
 
 // RemoveLabel removes a label from an issue.
 // Delegates SQL work to issueops.RemoveLabelInTx which handles wisp routing.
+// See AddLabel for the DOLT_COMMIT contract.
 func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
-	})
+	}); err != nil {
+		return err
+	}
+	if s.isActiveWisp(ctx, issueID) {
+		return nil
+	}
+	return s.doltAddAndCommit(ctx, []string{"labels", "events"}, fmt.Sprintf("bd: label remove %s %s", issueID, label))
 }
 
 // GetLabels retrieves all labels for an issue

--- a/internal/storage/dolt/server_mode_flush_test.go
+++ b/internal/storage/dolt/server_mode_flush_test.go
@@ -1,0 +1,88 @@
+package dolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestLabelAndCommentWritesLeaveCleanWorkingSet verifies that AddLabel,
+// RemoveLabel, AddComment, and AddIssueComment each create a Dolt commit
+// so the working set is clean afterwards. Before the fix, server-mode bd
+// writes accumulated as uncommitted rows on the live sql-server's working
+// set, blocking subsequent remotesapi pushes from other clients with
+// "target has uncommitted changes" until a manual DOLT_COMMIT was issued.
+func TestLabelAndCommentWritesLeaveCleanWorkingSet(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "flush-1",
+		Title:     "label/comment commit hygiene",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	// CreateIssue itself commits — confirm the baseline is clean.
+	assertWorkingSetClean(t, store, "after CreateIssue")
+
+	if err := store.AddLabel(ctx, issue.ID, "bug", "tester"); err != nil {
+		t.Fatalf("AddLabel: %v", err)
+	}
+	assertWorkingSetClean(t, store, "after AddLabel")
+
+	if err := store.RemoveLabel(ctx, issue.ID, "bug", "tester"); err != nil {
+		t.Fatalf("RemoveLabel: %v", err)
+	}
+	assertWorkingSetClean(t, store, "after RemoveLabel")
+
+	if err := store.AddComment(ctx, issue.ID, "tester", "drive-by note"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	assertWorkingSetClean(t, store, "after AddComment")
+
+	if _, err := store.AddIssueComment(ctx, issue.ID, "tester", "structured comment"); err != nil {
+		t.Fatalf("AddIssueComment: %v", err)
+	}
+	assertWorkingSetClean(t, store, "after AddIssueComment")
+}
+
+// assertWorkingSetClean fails the test if any non-ignored table is dirty
+// in the Dolt working set. dolt_ignore'd tables (wisps, local_metadata,
+// repo_mtimes) are intentionally excluded — they never commit by design.
+func assertWorkingSetClean(t *testing.T, store *DoltStore, label string) {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), `
+		SELECT s.table_name FROM dolt_status s
+		WHERE NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			AND s.table_name LIKE di.pattern
+		)`)
+	if err != nil {
+		t.Fatalf("%s: query dolt_status: %v", label, err)
+	}
+	defer rows.Close()
+	var dirty []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("%s: scan dolt_status: %v", label, err)
+		}
+		dirty = append(dirty, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("%s: iterate dolt_status: %v", label, err)
+	}
+	if len(dirty) > 0 {
+		t.Errorf("%s: working set has uncommitted tables %v (expected clean)", label, dirty)
+	}
+}


### PR DESCRIPTION
## Summary

`DoltStore.{AddLabel,RemoveLabel,AddComment,AddIssueComment,ImportIssueComment}` only committed the SQL transaction; they did not fire `CALL DOLT_COMMIT`. The other issue mutations (`CreateIssue`/`UpdateIssue`/`Claim`/`Close`/`Delete` and `AddDependency`/`RemoveDependency`) already commit per-write via `doltAddAndCommit`; the label/comment paths were the gap.

The maintainers already know about this gap: `cmd/bd/create_form.go:261-271` carries an explicit post-create commit workaround for the create flow (referencing GH#2009), but standalone `bd label add`, `bd label rm`, `bd comment add`, and `bd compact`'s `AddComment` had no equivalent.

## Symptoms

**In server mode** (bd connecting to an external `dolt-sql-server` — e.g. Termux clients reaching a shared Dolt instance), label/comment writes accumulate as uncommitted rows in the server's working set. Subsequent remotesapi pushes from other clients (e.g. a desktop in embedded mode) fail with `target has uncommitted changes — --force required to overwrite` because the remote `main` has dirty rows the server-mode writers never committed.

**In embedded mode** it's a latent correctness issue — label and comment changes silently don't make it into pushes until the user manually `bd dolt commit`s. The current default of `dolt.auto-commit=off` makes this trivial to hit.

## Changes

- `internal/storage/dolt/labels.go` — `AddLabel`, `RemoveLabel` call `s.doltAddAndCommit(...)` after the SQL tx commits.
- `internal/storage/dolt/events.go` — `AddComment`, `ImportIssueComment` (which `AddIssueComment` delegates to) do the same.
- All four are gated by `s.isActiveWisp(ctx, issueID)` so wisp tables (which live in `dolt_ignore`'d tables and intentionally skip versioning) keep their existing behavior — matching the pattern in `CreateIssue`/`UpdateIssue`.
- Transaction-scoped writes via `RunInTransaction` are unaffected — `runDoltTransaction` already commits at the end with `versioncontrolops.StageAndCommit`, so these per-method commits don't fire when the call originates from inside a transaction.

## Test plan

- [x] New test `TestLabelAndCommentWritesLeaveCleanWorkingSet` in `internal/storage/dolt/server_mode_flush_test.go` asserts `dolt_status` is empty (excluding `dolt_ignore`'d tables) after each of the patched mutations.
- [x] `make build` — clean
- [x] `make test` for `internal/storage/dolt/...`, `internal/storage/embeddeddolt/...`, `cmd/bd/...` — all green
- [x] Manually verified in a real server-mode setup that the cleanup cron previously needed to flush these working-set entries can be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)