### PR TITLE
Repair ignored wisp dependency table bootstrap

### DIFF
--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 )
 
 // bdDep runs "bd dep" with the given args and returns raw stdout.
@@ -62,6 +65,41 @@ func bdDepJSON(t *testing.T, bd, dir string, args ...string) map[string]interfac
 		t.Fatalf("parse dep JSON: %v\n%s", err, s)
 	}
 	return m
+}
+
+func dropEmbeddedWispDependencies(t *testing.T, beadsDir, database string) {
+	t.Helper()
+	db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), database, "main")
+	if err != nil {
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	defer cleanup()
+	if _, err := db.ExecContext(t.Context(), "DROP TABLE IF EXISTS wisp_dependencies"); err != nil {
+		t.Fatalf("drop table wisp_dependencies: %v", err)
+	}
+}
+
+func TestEmbeddedDepMissingWispDependencies(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "mw")
+	blocker := bdCreate(t, bd, dir, "Missing wisp dep blocker", "--type", "task")
+	blocked := bdCreate(t, bd, dir, "Missing wisp dep blocked", "--type", "task")
+
+	dropEmbeddedWispDependencies(t, beadsDir, "mw")
+
+	out := bdDep(t, bd, dir, "add", blocked.ID, blocker.ID)
+	if !strings.Contains(out, "Added dependency") {
+		t.Fatalf("expected dep add to succeed after recreating wisp_dependencies: %s", out)
+	}
+
+	tree := bdDep(t, bd, dir, "tree", blocked.ID)
+	if !strings.Contains(tree, blocker.ID) {
+		t.Fatalf("expected dep tree to include blocker %s after wisp_dependencies repair:\n%s", blocker.ID, tree)
+	}
 }
 
 func TestEmbeddedDep(t *testing.T) {

--- a/internal/storage/schema/helpers.go
+++ b/internal/storage/schema/helpers.go
@@ -13,18 +13,26 @@ import (
 // dolt_ignore entries are committed and persist across branches; only the
 // tables themselves (which live in the working set) need recreation.
 func EnsureIgnoredTables(ctx context.Context, db DBConn) error {
-	wispsOK, err := TableExists(ctx, db, "wisps")
-	if err != nil {
-		return fmt.Errorf("check wisps table: %w", err)
+	for _, table := range ignoredTableNames {
+		ok, err := TableExists(ctx, db, table)
+		if err != nil {
+			return fmt.Errorf("check %s table: %w", table, err)
+		}
+		if !ok {
+			return CreateIgnoredTables(ctx, db)
+		}
 	}
-	localOK, err := TableExists(ctx, db, "local_metadata")
-	if err != nil {
-		return fmt.Errorf("check local_metadata table: %w", err)
-	}
-	if wispsOK && localOK {
-		return nil
-	}
-	return CreateIgnoredTables(ctx, db)
+	return nil
+}
+
+var ignoredTableNames = []string{
+	"local_metadata",
+	"repo_mtimes",
+	"wisps",
+	"wisp_labels",
+	"wisp_dependencies",
+	"wisp_events",
+	"wisp_comments",
 }
 
 // CreateIgnoredTables unconditionally creates all dolt_ignore'd tables

--- a/internal/storage/schema/ignored_tables_test.go
+++ b/internal/storage/schema/ignored_tables_test.go
@@ -14,10 +14,7 @@ func TestIgnoredTableDDL(t *testing.T) {
 	combined := strings.Join(ddl, "\n")
 
 	// Verify all expected tables are referenced.
-	for _, table := range []string{
-		"local_metadata", "repo_mtimes", "wisps",
-		"wisp_labels", "wisp_dependencies", "wisp_events", "wisp_comments",
-	} {
+	for _, table := range ignoredTableNames {
 		if !strings.Contains(combined, table) {
 			t.Errorf("IgnoredTableDDL missing reference to table %q", table)
 		}


### PR DESCRIPTION
## Summary
- ensure ignored-table bootstrap verifies the full expected set, including `wisp_dependencies`
- add an embedded CLI regression covering `bd dep add` and `bd dep tree` when `wisp_dependencies` is missing

## Tests
- `go test ./internal/storage/schema`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run TestEmbeddedDepMissingWispDependencies -count=1 -vet=off`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/storage/schema ./internal/storage/embeddeddolt`

Full `make test` was attempted but could not complete in the local environment due disk/quota failures while subprocess tests built/downloaded dependencies.

Closes bd-8e8