### PR TITLE
fix(history): respect --json flag when issue has no history

### DIFF
--- a/cmd/bd/history.go
+++ b/cmd/bd/history.go
@@ -32,18 +32,20 @@ Examples:
 			FatalErrorRespectJSON("failed to get history: %v", err)
 		}
 
-		if len(history) == 0 {
-			fmt.Printf("No history found for issue %s\n", issueID)
-			return
-		}
-
 		// Apply limit if specified
 		if historyLimit > 0 && historyLimit < len(history) {
 			history = history[:historyLimit]
 		}
 
+		// Honor --json before the empty-history early-return so consumers
+		// always get valid JSON ([]) regardless of whether history exists.
 		if jsonOutput {
 			outputJSON(history)
+			return
+		}
+
+		if len(history) == 0 {
+			fmt.Printf("No history found for issue %s\n", issueID)
 			return
 		}
 

--- a/cmd/bd/history.go
+++ b/cmd/bd/history.go
@@ -32,20 +32,24 @@ Examples:
 			FatalErrorRespectJSON("failed to get history: %v", err)
 		}
 
-		// Apply limit if specified
+		// Empty-history short-circuit handles both formats: --json gets []
+		// (so consumers piping to jq don't break), human format gets prose.
+		if len(history) == 0 {
+			if jsonOutput {
+				outputJSON(history)
+				return
+			}
+			fmt.Printf("No history found for issue %s\n", issueID)
+			return
+		}
+
+		// Apply limit only to non-empty history; slicing an empty slice is a no-op.
 		if historyLimit > 0 && historyLimit < len(history) {
 			history = history[:historyLimit]
 		}
 
-		// Honor --json before the empty-history early-return so consumers
-		// always get valid JSON ([]) regardless of whether history exists.
 		if jsonOutput {
 			outputJSON(history)
-			return
-		}
-
-		if len(history) == 0 {
-			fmt.Printf("No history found for issue %s\n", issueID)
 			return
 		}
 

--- a/cmd/bd/history_embedded_test.go
+++ b/cmd/bd/history_embedded_test.go
@@ -168,6 +168,27 @@ func TestEmbeddedHistory(t *testing.T) {
 		}
 	})
 
+	// --json must always produce parseable JSON, even when history is empty.
+	// Without this, consumers piping `bd history --json | jq` break on the
+	// empty case while every other --json subcommand returns valid JSON.
+	t.Run("nonexistent_issue_json_returns_empty_array", func(t *testing.T) {
+		cmd := exec.Command(bd, "history", "--json", "hi-nonexistent999")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd history --json failed: %v\n%s", err, out)
+		}
+		s := strings.TrimSpace(string(out))
+		var entries []map[string]interface{}
+		if err := json.Unmarshal([]byte(s), &entries); err != nil {
+			t.Fatalf("expected valid JSON for empty history, got prose:\n%s\n(parse error: %v)", s, err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("expected empty array for nonexistent issue, got %d entries", len(entries))
+		}
+	})
+
 	// ===== Wrong number of args =====
 
 	t.Run("no_args_fails", func(t *testing.T) {

--- a/cmd/bd/history_embedded_test.go
+++ b/cmd/bd/history_embedded_test.go
@@ -189,6 +189,27 @@ func TestEmbeddedHistory(t *testing.T) {
 		}
 	})
 
+	// --limit combined with --json on empty history must still produce [].
+	// Guards against future reordering that might apply limit semantics
+	// before the empty-check and skip the JSON branch.
+	t.Run("nonexistent_issue_json_with_limit_returns_empty_array", func(t *testing.T) {
+		cmd := exec.Command(bd, "history", "--json", "--limit", "2", "hi-nonexistent999")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd history --json --limit 2 failed: %v\n%s", err, out)
+		}
+		s := strings.TrimSpace(string(out))
+		var entries []map[string]interface{}
+		if err := json.Unmarshal([]byte(s), &entries); err != nil {
+			t.Fatalf("expected valid JSON for empty history with --limit, got prose:\n%s\n(parse error: %v)", s, err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("expected empty array for nonexistent issue with --limit, got %d entries", len(entries))
+		}
+	})
+
 	// ===== Wrong number of args =====
 
 	t.Run("no_args_fails", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`bd history <id> --json` returns prose, not JSON, when the bead has no history. Breaks any consumer that pipes the output to `jq` or otherwise expects structured output. Every other input shape (non-empty history) honors `--json` correctly — only the empty case slips through.

## Root Cause

`cmd/bd/history.go` lines 35-48 (pre-fix): the empty-history early-return fires *before* the `if jsonOutput` check. When `--json` is set AND history is empty, the consumer hits the prose branch instead of the JSON branch.

## Fix

Reorder so the JSON branch runs above the empty-check. Net change ~5 lines moved, no behavior change for any non-empty case, no behavior change for the human-readable path.

Result: `bd history <id> --json` returns `[]` for empty, full array otherwise — consistent with `bd list --json` / `bd show --json` / etc.

## Test Plan

- New subtest `nonexistent_issue_json_returns_empty_array` in `cmd/bd/history_embedded_test.go` runs `bd history --json <nonexistent-id>` and strictly parses stdout as JSON, asserting empty array
- Note: I used a fresh `exec.Command` call rather than the existing `bdHistoryJSON` helper. The helper does `strings.Index(s, "[")` lenient parsing which would return `nil` (and treat that as "no entries") for prose output — masking the bug rather than catching it. The new test does strict `json.Unmarshal` on full stdout.
- All 11 history subtests pass locally:
  ```
  --- PASS: TestEmbeddedHistory (12.11s)
      --- PASS: TestEmbeddedHistory/basic_history
      --- PASS: TestEmbeddedHistory/history_shows_multiple_entries
      --- PASS: TestEmbeddedHistory/limit_restricts_entries
      --- PASS: TestEmbeddedHistory/limit_1
      --- PASS: TestEmbeddedHistory/json_output_structure
      --- PASS: TestEmbeddedHistory/json_issue_snapshot_has_fields
      --- PASS: TestEmbeddedHistory/nonexistent_issue_empty_history
      --- PASS: TestEmbeddedHistory/nonexistent_issue_json_returns_empty_array
      --- PASS: TestEmbeddedHistory/no_args_fails
      --- PASS: TestEmbeddedHistory/too_many_args_fails
      --- PASS: TestEmbeddedHistory/single_entry_for_new_issue
  ```
- `golangci-lint run --build-tags gms_pure_go ./cmd/bd/...` clean

## Context

Came up while planning a cross-project tool that wants to compose `bd history --json` for a bead-event timeline. Without this, every consumer has to defensively detect-and-discard the prose case for empty results, which is ugly and avoidable for what should be a clean JSON contract.

If you'd prefer a structured envelope (`{"id":"<id>","history":[]}`) instead of bare `[]`, happy to revise — kept the bare array shape since that's what the non-empty path returns and the consistency seemed cleanest. Open to either.

Fixes #3502
