### PR TITLE
fix(auto-export): surface git add stderr in failure warning

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -279,7 +279,17 @@ func gitAddFile(path string) error {
 	cmd := exec.Command("git", "add", path)
 	cmd.Dir = filepath.Dir(path)
 	cmd.Env = scrubGitHookEnv(os.Environ())
-	return cmd.Run()
+	// Capture combined output so the caller's warning surfaces git's stderr
+	// (e.g. "paths are ignored", "Unable to create index.lock") instead of
+	// just the exit-status text.
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			return fmt.Errorf("%w: %s", err, trimmed)
+		}
+		return err
+	}
+	return nil
 }
 
 // scrubGitHookEnv returns env with the GIT_* variables that can poison

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -356,6 +356,73 @@ func TestGitAddFile_NonHookContext_GuardDoesNotFire(t *testing.T) {
 	}
 }
 
+// TestGitAddFile_CapturesStderrOnFailure verifies that when `git add` fails,
+// the returned error wraps git's stderr text instead of just the bare exit
+// status. Regression guard for the silent "Warning: auto-export: git add
+// failed: exit status 1" noise where the user has no signal as to why.
+func TestGitAddFile_CapturesStderrOnFailure(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "bd-stderr-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = repo
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+
+	// Force git add to fail by gitignoring the target. Common real-world
+	// trigger: a parent .gitignore excluding .beads/ that the user is
+	// unaware of.
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte(".beads/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(repo, ".beads", "issues.jsonl")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`{"id":"x"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Unsetenv("GIT_DIR"); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+
+	err = gitAddFile(target)
+	if err == nil {
+		t.Fatal("expected gitAddFile to fail on gitignored target, got nil")
+	}
+	msg := err.Error()
+	// Bare-exit-status regression guard: pre-fix message was just "exit
+	// status 1" with nothing else. Post-fix must include git's stderr.
+	if !strings.Contains(strings.ToLower(msg), "ignored") {
+		t.Errorf("expected error to surface git's stderr (containing 'ignored'), got: %q", msg)
+	}
+}
+
 // TestGitAddFile_RedirectCase_DoesNotStageInMainRepo regresses the
 // silent-stage-in-main follow-up from the GH#3311 review: when a worktree
 // has .beads/redirect -> main/.beads, the worktree's pre-commit hook must


### PR DESCRIPTION
## Problem

`auto-export: git add failed` warning fires once per `bd` mutation when `export.git-add` is enabled, but discards `git add`'s stderr — users see the symptom (`exit status 1`) without the cause. Across multi-command sessions this trains people to ignore the warning entirely, at which point real signal also gets missed.

## Root Cause

`cmd/bd/export_auto.go:282` (pre-fix) called `cmd.Run()`, which throws away stdout + stderr. The caller at `:113` then formatted the warning with `%v` on just the bare exec error.

## Fix

`gitAddFile` switches to `cmd.CombinedOutput()` and, on error, wraps the trimmed output via `fmt.Errorf("%w: %s", err, trimmed)`. Function signature stays `error`. The caller's existing `%v` formatter then naturally prints `exit status 1: <git's stderr>`.

```go
out, err := cmd.CombinedOutput()
if err != nil {
    if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
        return fmt.Errorf("%w: %s", err, trimmed)
    }
    return err
}
return nil
```

No change to the success path, no change to callers, no signature change. `errors.Is`/`errors.As` consumers still get the underlying exec error via `%w`.

## Test Plan

- New `TestGitAddFile_CapturesStderrOnFailure`: temp git repo with `.gitignore` excluding `.beads/`, attempts `gitAddFile` on a target inside `.beads/`, asserts the returned error message contains `"ignored"` (proxy for git's stderr surfacing).
- All 4 `TestGitAddFile_*` tests pass locally:
  ```
  --- PASS: TestGitAddFile_InWorktreeHook_StagesCorrectPath (0.25s)
  --- PASS: TestGitAddFile_NonHookContext_GuardDoesNotFire (0.09s)
  --- PASS: TestGitAddFile_CapturesStderrOnFailure (0.08s)   ← new
  --- PASS: TestGitAddFile_RedirectCase_DoesNotStageInMainRepo (0.23s)
  ```
- `golangci-lint run --build-tags gms_pure_go ./cmd/bd/...` clean.

## Observed triggers in real sessions

Captured stderr would have made all of these obvious instead of "exit status 1":

- A concurrent `git commit` holding the index lock — `Unable to create index.lock: File exists`
- A parent `.gitignore` excluding `.beads/issues.jsonl` — `The following paths are ignored by one of your .gitignore files`
- Detached HEAD or rebase-in-progress states

## Out of scope (deferred follow-ups)

- Config-gated suppression of "paths are ignored" as the common false positive — opinionated default; would want maintainer input.
- Retry/backoff on `index.lock` contention — opinionated race-window choices.

Both are mentioned in the originating local notes; happy to file as separate issues if you want them addressed.

Fixes #3504
