### PR TITLE
fix(test): thread -tags gms_pure_go to subprocess build in embeddeddolt concurrency test

### DIFF
--- a/internal/storage/embeddeddolt/concurrency_test.go
+++ b/internal/storage/embeddeddolt/concurrency_test.go
@@ -69,9 +69,14 @@ func TestConcurrencyMultiProcess(t *testing.T) {
 		t.Logf("using pre-built test binary: %s", testBin)
 	} else {
 		testBin = filepath.Join(t.TempDir(), "embeddeddolt.test")
-		t.Logf("building test binary: go test -c -o %s ./internal/storage/embeddeddolt/", testBin)
+		t.Logf("building test binary: go test -c -tags gms_pure_go -o %s ./internal/storage/embeddeddolt/", testBin)
+		// -tags gms_pure_go is mandatory project-wide (see CLAUDE.md). Without it
+		// the subprocess build pulls in the cgo-backed ICU regex package, which
+		// requires unicode/uregex.h headers that aren't present on Windows
+		// toolchains and breaks the subprocess compile before any assertions run.
 		build := exec.CommandContext(ctx, "go", "test",
 			"-c",
+			"-tags", "gms_pure_go",
 			"-o", testBin,
 			"./internal/storage/embeddeddolt/",
 		)


### PR DESCRIPTION
## Problem

`TestConcurrencyMultiProcess` in `internal/storage/embeddeddolt/concurrency_test.go` fails on Windows. The test shells out to `go test -c` to build a child test binary that subprocesses then exec — but the build invocation didn't pass `-tags gms_pure_go`. So on Windows the subprocess build pulled in the cgo-backed ICU regex package and failed at compile time:

```
unicode/uregex.h: No such file or directory
```

The parent `go test` process compiled fine because it received the tag from the user's invocation; the subprocess `go test -c` invocation lost it.

## Root Cause

Linux/macOS toolchains ship ICU dev headers by default, so the cgo build path quietly compiled even without the tag — that's why this only fired on Windows. The bug is structural: any subprocess `go build`/`go test -c` invocation in this codebase needs to propagate `gms_pure_go` (it's a project-wide CLAUDE.md mandate, not a Go convention).

## Fix

Pass `"-tags", "gms_pure_go"` in the args of the subprocess `go test -c` invocation in `concurrency_test.go`, plus a brief comment explaining why the tag is required (the constraint is non-obvious from Go alone — it's project policy).

```go
buildCmd := exec.CommandContext(buildCtx, "go", "test",
    "-tags", "gms_pure_go",
    "-c",
    ...
)
```

Single file, +6/-1. No other multi-process subprocess builders found in `internal/storage/dolt/` or `embeddeddolt/` that need the same treatment.

## Test Plan

- **Pre-fix on Windows**: `TestConcurrencyMultiProcess` reproduces the exact ICU header error from the briefing.
- **Post-fix on Windows**: full `go test -tags gms_pure_go ./internal/storage/embeddeddolt/...` passes including `TestConcurrencyMultiProcess`.
- `golangci-lint run --build-tags gms_pure_go ./internal/storage/embeddeddolt/...` — 0 issues.
- Linux/macOS unaffected (those envs were silently green pre-fix; post-fix they continue to be green via the explicit tag).

## Context

Discovered while running the embedded-dolt suites locally on Windows after touching unrelated dolt code. Linux/macOS CI never surfaced this because their toolchains compile the cgo ICU path without the tag. Worth knowing in case other subprocess invocations elsewhere in the repo have the same pattern — i didn't find any in dolt/embeddeddolt, but a `grep` for `exec.Command.*go.*test` across the repo would catch any future regressions.

Fixes #3508
