### PR TITLE
fix(makefile): use /dev/null instead of nul to silence stderr on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # On Windows, GNU Make defaults to cmd.exe which doesn't support POSIX
 # shell syntax used throughout this Makefile. Use Git for Windows' bash.
 ifeq ($(OS),Windows_NT)
-GIT_BASH := $(shell where git 2>nul)
+GIT_BASH := $(shell where git 2>/dev/null)
 ifneq ($(GIT_BASH),)
 SHELL := $(subst cmd,bin,$(subst git.exe,bash.exe,$(GIT_BASH)))
 endif


### PR DESCRIPTION
## Problem

Every `make <target>` on Windows + Git Bash creates (or touches) a zero-byte file named `nul` in the project root. Untracked, harmless, but pollutes `git status` output and confuses tooling that scans for stray files. Recurs forever — manual `rm -f nul` doesn't help because the next `make` invocation recreates it.

## Root Cause

`Makefile:6`:

```makefile
GIT_BASH := $(shell where git 2>nul)
```

The `2>nul` is cmd.exe's bit-bucket convention. But GNU Make's `$(shell ...)` on Windows + Git Bash uses `/bin/sh` (MSYS bash) as its subshell, where `nul` is NOT a special device — it's treated as a literal file path. So `where git 2>nul` redirects stderr to a file literally named `nul` in the cwd. Every make invocation parses this assignment, runs the subshell, creates the file.

The block guards on `OS=Windows_NT` and exists specifically to detect Git Bash so SHELL can be switched to bash for subsequent recipes. Anyone hitting this line is by definition someone who has Git Bash installed and is invoking make from MSYS — exactly the env where `2>nul` creates a stray file.

## Fix

```diff
-GIT_BASH := $(shell where git 2>nul)
+GIT_BASH := $(shell where git 2>/dev/null)
```

- **MSYS bash / git bash** (the affected env): `/dev/null` works as bit-bucket. No file created. ✓
- **Pure cmd.exe make** (rare; mostly hypothetical for this codebase since git bash is required for the SHELL switch on line 8): `/dev/null` isn't recognized as a special path; the redirect attempts to write to `<cwd>/dev/null`. `<cwd>/dev/` doesn't exist, redirect fails harmlessly, stderr leaks to terminal. No file created either way — strictly better than the current behavior.

There's no portable single-redirect that's clean in both cmd and bash without shell detection (and detection itself needs a subshell, so it's circular). `/dev/null` is the right pick because the affected env is the dominant Windows dev env for this project, and the alternative env's worst case is a one-time stderr leak rather than file creation.

## Test Plan

Empirical verification on Windows + Git Bash:

```
==pre-fix nul mtime== 2026-04-25 22:35:58
==current time==     2026-04-25 22:38:00
==run `make help`==  ok
==post-fix nul mtime== 2026-04-25 22:35:58   ← unchanged, make didn't touch it
==confirm git still resolves==
GIT_BASH := C:\Program Files\Git\mingw64\bin\git.exe ...
```

Pre-fix, the mtime updated on every `make` run (proving make was creating/touching the file). Post-fix, mtime stays static across multiple `make` invocations. `GIT_BASH` and `SHELL` still resolve correctly to Git Bash.

## Context

Came up while running an upstream-PR-review session — every `make build` and `make test` was leaving a stray `nul` in the working tree, polluting `git status` between commits and forcing manual cleanup. Tracing the recurrence pointed at `Makefile:6` as the sole source repo-wide (verified via `grep -rn '2>nul' .` — single hit).

`grep -rn '2>nul' ./Makefile`:
```
Makefile:6:GIT_BASH := $(shell where git 2>nul)
```

Linux/macOS users were never affected (the block guards on `Windows_NT`).

Fixes #3513
