### PR TITLE
feat(close): add --reason-file flag mirroring --body-file pattern

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -52,6 +52,14 @@ create, update, show, or close operation).`,
 			reason, _ = cmd.Flags().GetString("comment")
 		}
 
+		// --reason-file <path> (with - for stdin) mirrors `bd create --body-file`,
+		// so agents can pass structured close templates without shell-escaping hell (#3512).
+		if fileReason, ok, err := resolveReasonFile(cmd, reason); err != nil {
+			FatalErrorRespectJSON("%v", err)
+		} else if ok {
+			reason = fileReason
+		}
+
 		// Desire-path: "bd done <id> <message>" treats last positional arg as reason
 		// when no reason flag was explicitly provided (hq-pe8ce)
 		if reason == "" && cmd.CalledAs() == "done" && len(args) >= 2 {
@@ -284,6 +292,7 @@ func init() {
 	_ = closeCmd.Flags().MarkHidden("message") // Hidden alias for agent/CLI ergonomics
 	closeCmd.Flags().String("comment", "", "Alias for --reason")
 	_ = closeCmd.Flags().MarkHidden("comment") // Hidden alias for agent/CLI ergonomics
+	closeCmd.Flags().String("reason-file", "", "Read close reason from file (use - for stdin)")
 	closeCmd.Flags().BoolP("force", "f", false, "Force close pinned issues or unsatisfied gates")
 	closeCmd.Flags().Bool("continue", false, "Auto-advance to next step in molecule")
 	closeCmd.Flags().Bool("no-auto", false, "With --continue, show next step but don't claim it")
@@ -418,6 +427,30 @@ func shouldAutoCloseCompletedRoot(root *types.Issue) bool {
 	}
 
 	return false
+}
+
+// resolveReasonFile resolves the --reason-file flag for `bd close`.
+// Returns (content, true, nil) when --reason-file was set and read successfully.
+// Returns (_, false, nil) when --reason-file was not set.
+// Returns an error on conflict with an existing reason, file read failure, or empty content.
+// Mirrors the --body-file pattern from `bd create` so agents can pass structured close
+// templates without shell-escaping hell.
+func resolveReasonFile(cmd *cobra.Command, existingReason string) (string, bool, error) {
+	if !cmd.Flags().Changed("reason-file") {
+		return "", false, nil
+	}
+	if existingReason != "" {
+		return "", false, fmt.Errorf("cannot specify both --reason-file and --reason/--resolution/--message/--comment")
+	}
+	path, _ := cmd.Flags().GetString("reason-file")
+	content, err := readBodyFile(path)
+	if err != nil {
+		return "", false, fmt.Errorf("reading reason file %q: %w", path, err)
+	}
+	if strings.TrimSpace(content) == "" {
+		return "", false, fmt.Errorf("--reason-file %q is empty; close reason is required", path)
+	}
+	return content, true, nil
 }
 
 // countEpicOpenChildren returns the number of open (non-closed) children for an epic.

--- a/cmd/bd/close_reason_file_test.go
+++ b/cmd/bd/close_reason_file_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newCloseLikeCmd builds a minimal cobra command with the close reason flags
+// registered, so resolveReasonFile can be exercised without spinning up the
+// full CLI / database layer.
+func newCloseLikeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "close",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	cmd.Flags().StringP("reason", "r", "", "Reason for closing")
+	cmd.Flags().String("resolution", "", "")
+	cmd.Flags().StringP("message", "m", "", "")
+	cmd.Flags().String("comment", "", "")
+	cmd.Flags().String("reason-file", "", "Read close reason from file (use - for stdin)")
+	return cmd
+}
+
+func TestCloseResolveReasonFile_FileWithContent(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "reason.md")
+	content := "## Shipped\n\nWired up the thing. See PR #123.\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := newCloseLikeCmd()
+	if err := cmd.ParseFlags([]string{"--reason-file", path}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	got, ok, err := resolveReasonFile(cmd, "")
+	if err != nil {
+		t.Fatalf("resolveReasonFile: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != content {
+		t.Errorf("content mismatch:\nwant: %q\ngot:  %q", content, got)
+	}
+}
+
+func TestCloseResolveReasonFile_StdinDash(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = oldStdin })
+
+	content := "Closed via stdin\nMulti-line reason\n"
+	go func() {
+		_, _ = w.WriteString(content)
+		_ = w.Close()
+	}()
+
+	cmd := newCloseLikeCmd()
+	if err := cmd.ParseFlags([]string{"--reason-file", "-"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	got, ok, err := resolveReasonFile(cmd, "")
+	if err != nil {
+		t.Fatalf("resolveReasonFile: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != content {
+		t.Errorf("content mismatch:\nwant: %q\ngot:  %q", content, got)
+	}
+}
+
+func TestCloseResolveReasonFile_FileNotFound(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.md")
+	cmd := newCloseLikeCmd()
+	if err := cmd.ParseFlags([]string{"--reason-file", missing}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	_, ok, err := resolveReasonFile(cmd, "")
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if ok {
+		t.Error("expected ok=false on error")
+	}
+	// Path should be quoted in the error so users can see what was attempted.
+	if !strings.Contains(err.Error(), missing) {
+		t.Errorf("expected error to reference path %q, got: %v", missing, err)
+	}
+}
+
+func TestCloseResolveReasonFile_ConflictWithReason(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "reason.md")
+	if err := os.WriteFile(path, []byte("from file"), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := newCloseLikeCmd()
+	if err := cmd.ParseFlags([]string{"--reason-file", path, "--reason", "from flag"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	// Caller has already collected the inline reason from the various aliases,
+	// so we pass it in directly to mirror how close.go invokes the helper.
+	_, ok, err := resolveReasonFile(cmd, "from flag")
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if ok {
+		t.Error("expected ok=false on conflict")
+	}
+	if !strings.Contains(err.Error(), "--reason-file") {
+		t.Errorf("expected conflict error to mention --reason-file, got: %v", err)
+	}
+}
+
+func TestCloseResolveReasonFile_EmptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "empty.md")
+	if err := os.WriteFile(path, []byte("   \n\t\n"), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := newCloseLikeCmd()
+	if err := cmd.ParseFlags([]string{"--reason-file", path}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	_, ok, err := resolveReasonFile(cmd, "")
+	if err == nil {
+		t.Fatal("expected error for whitespace-only file, got nil")
+	}
+	if ok {
+		t.Error("expected ok=false on empty content")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected error to mention 'empty', got: %v", err)
+	}
+}
+
+func TestCloseResolveReasonFile_FlagNotSet(t *testing.T) {
+	cmd := newCloseLikeCmd()
+	if err := cmd.ParseFlags([]string{"--reason", "inline"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	got, ok, err := resolveReasonFile(cmd, "inline")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false when --reason-file not set")
+	}
+	if got != "" {
+		t.Errorf("expected empty content, got %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

`bd close` only takes `--reason "<inline string>"`. For agent workflows, close reasons are structured markdown — Summary / Files / Verify / Risk / Notes templates, often 30-80 lines. Inlining that as a shell string hits escape-character hell (backticks, `$`, quotes) and is especially painful on Windows where pwsh / bash / cmd quoting all differ. The workarounds (build content into a shell var first, or skip the template entirely) either add a step or lose the discipline the template exists to enforce.

## Approach

Mirror the existing `bd create --body-file <path>` pattern, with `-` for stdin. `bd create` solved this exact escape-hell problem; `bd close` should match for symmetry.

## What changed

- New `--reason-file <path>` flag on `bd close`. `-` reads from stdin.
- Conflict detection: setting `--reason-file` along with any of `--reason` / `--resolution` / `--message` / `--comment` errors out before any persistence.
- File-not-found errors quote the offending path so the user sees what was attempted.
- Whitespace-only file content errors out (no silent empty close that would just save a blank reason).
- Existing flag behavior is unchanged.
- Extracted `resolveReasonFile` as a small testable helper so the `Run` func stays clean while tests can assert the conflict and empty-file branches without poking `os.Exit`.

`git diff --stat origin/main`: 2 files, +204 lines (mostly the new test file).

## Test Plan

New test file `cmd/bd/close_reason_file_test.go` with cases:

- `TestCloseResolveReasonFile_FileWithContent` — reads file, returns content
- `TestCloseResolveReasonFile_StdinDash` — `-` reads from stdin
- `TestCloseResolveReasonFile_FileNotFound` — clear error with quoted path
- `TestCloseResolveReasonFile_ConflictWithReason` — both flags non-empty errors out
- `TestCloseResolveReasonFile_EmptyFile` — whitespace-only content errors out
- `TestCloseResolveReasonFile_FlagNotSet` — no `--reason-file` is a no-op

Verification:
- `make build` clean
- `go test -tags gms_pure_go -run "TestClose" ./cmd/bd/...` — all pass
- `golangci-lint run --build-tags gms_pure_go ./cmd/bd/...` — 0 issues
- `./bd close --help` shows the new flag

## Context

This is the second half of a symmetry pair with `bd create --body-file`. With both flags in place, agent workflows can keep close-reason templates as files in their conventions docs and pipe them in cleanly:

```
cat .beads/conventions/close-template.md | bd close <id> --reason-file -
```

The conflict-detection on multiple reason-source flags is conservative — i didn't want to invent a precedence rule for `--reason` vs `--resolution` vs `--message` vs `--comment` vs `--reason-file` since the existing fall-through-on-empty pattern is fine for inline use but would be footgun-prone if `--reason-file` could silently override.

Fixes #3512
