### PR TITLE
Document Linear external_ref pre-linking

### DIFF
--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -665,6 +665,15 @@ func finalizeSyncedBootstrap(beadsDir, syncRemote string, cfg *configfile.Config
 	return nil
 }
 
+type remoteCloneMode int
+
+const (
+	remoteCloneAuto remoteCloneMode = iota
+	remoteCloneEmbedded
+	remoteCloneExternalServer
+	remoteCloneCLI
+)
+
 // cloneFromRemote clones a Dolt database from a remote URL.
 // In embedded mode, uses the embedded engine's DOLT_CLONE procedure.
 // In external server mode, connects to the running server via MySQL and
@@ -673,13 +682,17 @@ func finalizeSyncedBootstrap(beadsDir, syncRemote string, cfg *configfile.Config
 // BootstrapFromRemoteWithDB.
 // Shared by bd init and bd bootstrap to keep clone logic in one place.
 func cloneFromRemote(ctx context.Context, beadsDir, remoteURL, dbName string, cfg *configfile.Config) error {
-	mode := doltserver.ResolveServerMode(beadsDir)
+	return cloneFromRemoteWithMode(ctx, beadsDir, remoteURL, dbName, cfg, remoteCloneAuto)
+}
+
+func cloneFromRemoteWithMode(ctx context.Context, beadsDir, remoteURL, dbName string, cfg *configfile.Config, cloneMode remoteCloneMode) error {
+	mode := resolveRemoteCloneMode(beadsDir, cfg, cloneMode)
 
 	switch mode {
-	case doltserver.ServerModeEmbedded:
+	case remoteCloneEmbedded:
 		return cloneViaEmbedded(ctx, beadsDir, remoteURL, dbName)
 
-	case doltserver.ServerModeExternal:
+	case remoteCloneExternalServer:
 		if cfg == nil {
 			// Caller didn't provide config; fall back to loading from disk.
 			if loaded, err := configfile.Load(beadsDir); err == nil && loaded != nil {
@@ -693,8 +706,30 @@ func cloneFromRemote(ctx context.Context, beadsDir, remoteURL, dbName string, cf
 		fmt.Fprintf(os.Stderr, "Warning: server mode detected but no config available, falling back to CLI clone\n")
 		return cloneViaCLI(ctx, beadsDir, remoteURL, dbName)
 
-	default: // ServerModeOwned
+	default:
 		return cloneViaCLI(ctx, beadsDir, remoteURL, dbName)
+	}
+}
+
+func resolveRemoteCloneMode(beadsDir string, cfg *configfile.Config, cloneMode remoteCloneMode) remoteCloneMode {
+	if cloneMode != remoteCloneAuto {
+		return cloneMode
+	}
+
+	if cfg != nil {
+		if cfg.IsDoltServerMode() || doltserver.IsSharedServerMode() || os.Getenv("BEADS_DOLT_SERVER_MODE") == "1" {
+			return remoteCloneExternalServer
+		}
+		return remoteCloneEmbedded
+	}
+
+	switch doltserver.ResolveServerMode(beadsDir) {
+	case doltserver.ServerModeEmbedded:
+		return remoteCloneEmbedded
+	case doltserver.ServerModeExternal:
+		return remoteCloneExternalServer
+	default:
+		return remoteCloneCLI
 	}
 }
 
@@ -722,12 +757,13 @@ func cloneViaEmbedded(ctx context.Context, beadsDir, remoteURL, dbName string) e
 // data directory, which is the correct behavior for externally managed
 // servers where bd does not know the filesystem layout.
 func cloneViaServer(ctx context.Context, beadsDir, remoteURL, dbName string, cfg *configfile.Config) error {
-	resolved := doltserver.DefaultConfig(beadsDir)
+	port := serverClonePort(beadsDir, cfg)
 	dsn := doltutil.ServerDSN{
+		Socket:   cfg.GetDoltServerSocket(),
 		Host:     cfg.GetDoltServerHost(),
-		Port:     resolved.Port,
+		Port:     port,
 		User:     cfg.GetDoltServerUser(),
-		Password: cfg.GetDoltServerPasswordForPort(resolved.Port),
+		Password: cfg.GetDoltServerPasswordForPort(port),
 		TLS:      cfg.GetDoltServerTLS(),
 		// No Database — DOLT_CLONE creates the database.
 	}.String()
@@ -743,15 +779,38 @@ func cloneViaServer(ctx context.Context, beadsDir, remoteURL, dbName string, cfg
 
 	if err := db.PingContext(cloneCtx); err != nil {
 		return fmt.Errorf("dolt server unreachable at %s:%d (is dolt sql-server running?): %w",
-			cfg.GetDoltServerHost(), resolved.Port, err)
+			cfg.GetDoltServerHost(), port, err)
 	}
 
 	if err := versioncontrolops.DoltClone(cloneCtx, db, remoteURL, dbName); err != nil {
 		return fmt.Errorf("clone from remote via server: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "Synced database from %s (via server at %s:%d)\n",
-		remoteURL, cfg.GetDoltServerHost(), resolved.Port)
+		remoteURL, cfg.GetDoltServerHost(), port)
 	return nil
+}
+
+func serverClonePort(beadsDir string, cfg *configfile.Config) int {
+	if cfg != nil && cfg.DoltServerPort > 0 {
+		return cfg.DoltServerPort
+	}
+	if p := os.Getenv("BEADS_DOLT_SERVER_PORT"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port
+		}
+	}
+	if p := os.Getenv("BEADS_DOLT_PORT"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port
+		}
+	}
+	if resolved := doltserver.DefaultConfig(beadsDir); resolved.Port > 0 {
+		return resolved.Port
+	}
+	if cfg != nil {
+		return cfg.GetDoltServerPort()
+	}
+	return configfile.DefaultDoltServerPort
 }
 
 // cloneViaCLI clones by shelling out to the dolt CLI.

--- a/cmd/bd/bootstrap_test.go
+++ b/cmd/bd/bootstrap_test.go
@@ -1557,6 +1557,45 @@ func TestCloneFromRemoteOwnedModeUsesCLI(t *testing.T) {
 	}
 }
 
+func TestResolveRemoteCloneModeDefaultConfigUsesEmbedded(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	cfg := configfile.DefaultConfig()
+
+	got := resolveRemoteCloneMode(beadsDir, cfg, remoteCloneAuto)
+	if got != remoteCloneEmbedded {
+		t.Fatalf("resolveRemoteCloneMode(default cfg) = %v, want embedded", got)
+	}
+}
+
+func TestResolveRemoteCloneModeExplicitExternalOverridesMissingMetadata(t *testing.T) {
+	t.Setenv("BEADS_DOLT_DATA_DIR", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	cfg := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: 3312,
+		DoltDatabase:   "beads_external",
+	}
+
+	got := resolveRemoteCloneMode(beadsDir, cfg, remoteCloneExternalServer)
+	if got != remoteCloneExternalServer {
+		t.Fatalf("resolveRemoteCloneMode(explicit external) = %v, want external server", got)
+	}
+}
+
 // TestCloneFromRemoteSharedServerModeUsesServer verifies that
 // BEADS_DOLT_SHARED_SERVER=1 triggers the server clone path.
 func TestCloneFromRemoteSharedServerModeUsesServer(t *testing.T) {

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -424,6 +424,15 @@ func TestEmbeddedCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("linear_external_ref", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "ler")
+		ref := "https://linear.app/team/issue/TEAM-123/fix-login"
+		issue := bdCreate(t, bd, dir, "Pre-linked Linear issue", "--external-ref", ref)
+		if issue.ExternalRef == nil || *issue.ExternalRef != ref {
+			t.Errorf("external_ref: got %v, want %q", issue.ExternalRef, ref)
+		}
+	})
+
 	t.Run("metadata", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "mt")
 		issue := bdCreate(t, bd, dir, "Metadata issue", "--metadata", `{"key":"value"}`)

--- a/cmd/bd/flags.go
+++ b/cmd/bd/flags.go
@@ -31,7 +31,7 @@ func registerCommonIssueFlags(cmd *cobra.Command) {
 	cmd.Flags().String("acceptance", "", "Acceptance criteria")
 	cmd.Flags().String("notes", "", "Additional notes")
 	cmd.Flags().String("append-notes", "", "Append to existing notes (with newline separator)")
-	cmd.Flags().String("external-ref", "", "External reference (e.g., 'gh-9', 'jira-ABC')")
+	cmd.Flags().String("external-ref", "", "External reference (e.g., 'gh-9', 'jira-ABC', Linear URL)")
 }
 
 // getDescriptionFlag retrieves the description value, checking --body-file, --description-file,

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -463,7 +463,7 @@ A gate is resolved when:
 
 A gate is escalated when:
   - gh:run: status=completed AND conclusion in (failure, canceled)
-  - gh:pr: state=CLOSED AND merged=false
+  - gh:pr: state=CLOSED
 
 Examples:
   bd gate check              # Check all gates

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -79,6 +79,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		nonInteractiveFlag, _ := cmd.Flags().GetBool("non-interactive")
 		roleFlag, _ := cmd.Flags().GetString("role")
 		fromJSONL, _ := cmd.Flags().GetBool("from-jsonl")
+		initRemote, _ := cmd.Flags().GetString("remote")
 		// Dolt server connection flags
 		backendFlag, _ := cmd.Flags().GetString("backend")
 		initServerMode, _ := cmd.Flags().GetBool("server")

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -303,7 +303,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		{
 			var earlySyncURL string
 			earlyRemoteHasDoltData := false
-			if s := resolveSyncRemote(); s != "" {
+			if initRemote != "" {
+				earlySyncURL = initRemote
+				// An explicit --remote is intent to bootstrap or wire that URL,
+				// but it is not proof that the remote already contains Dolt
+				// history. Let the clone attempt below distinguish populated
+				// remotes from empty remotes so --reinit-local can still fall
+				// back to a fresh local init against a new remote.
+			} else if s := resolveSyncRemote(); s != "" {
 				earlySyncURL = s
 				earlyRemoteHasDoltData = true // sync.remote configured = user intends bootstrap
 			} else if isGitRepo() && !isBareGitRepo() {
@@ -626,13 +633,32 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 		if syncFromRemote {
-			if err := cloneFromRemote(ctx, beadsDir, syncURL, dbName, nil); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				os.Exit(1)
+			var err error
+			cloneCfg := initTimeCloneConfig(initServerMode, serverHost, serverPort, serverSocket, serverUser, dbName)
+			if initServerMode {
+				cloneMode := remoteCloneCLI
+				if externalServer {
+					cloneMode = remoteCloneExternalServer
+				}
+				err = cloneFromRemoteWithMode(ctx, beadsDir, syncURL, dbName, cloneCfg, cloneMode)
+			} else {
+				err = cloneFromRemoteWithMode(ctx, beadsDir, syncURL, dbName, cloneCfg, remoteCloneEmbedded)
 			}
-			bootstrappedFromRemote = true
-			if !quiet {
-				fmt.Printf("  %s Bootstrapped from remote: %s\n", ui.RenderPass("✓"), syncURL)
+			if err != nil {
+				if isEmptyRemoteCloneError(err) {
+					if !quiet {
+						fmt.Printf("  %s Remote has no Dolt data yet; initialized a fresh local database\n", ui.RenderWarn("!"))
+					}
+					syncFromRemote = false
+				} else {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					os.Exit(1)
+				}
+			} else {
+				bootstrappedFromRemote = true
+				if !quiet {
+					fmt.Printf("  %s Bootstrapped from remote: %s\n", ui.RenderPass("✓"), syncURL)
+				}
 			}
 		}
 
@@ -930,12 +956,8 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Only persist when the URL is from explicit config or a
 			// confirmed Dolt remote — not an auto-detected git origin
 			// for a plain source repo (GH#3356).
-			if shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig) {
-				if existing := config.GetYamlConfig("sync.remote"); existing == "" {
-					if err := config.SetYamlConfig("sync.remote", syncURL); err != nil {
-						FatalError("failed to persist sync.remote to config.yaml: %v", err)
-					}
-				}
+			if err := persistInitSyncRemote(beadsDir, initRemote, syncURL, syncFromRemote, syncURLFromConfig); err != nil {
+				FatalError("failed to persist sync.remote to config.yaml: %v", err)
 			}
 
 			// Enable shared server mode if requested via flag OR env var (GH#2377).
@@ -1837,6 +1859,53 @@ func shouldWireInitRemote(syncURL string, syncFromRemote, syncURLFromConfig bool
 	// Auto-detected plain git origins are not Dolt remotes. Only wire origin
 	// when it was explicitly configured or proven to carry refs/dolt/data.
 	return syncURL != "" && (syncFromRemote || syncURLFromConfig)
+}
+
+func initTimeCloneConfig(serverMode bool, serverHost string, serverPort int, serverSocket, serverUser, dbName string) *configfile.Config {
+	cfg := configfile.DefaultConfig()
+	cfg.Backend = configfile.BackendDolt
+	cfg.DoltDatabase = dbName
+	if serverMode {
+		cfg.DoltMode = configfile.DoltModeServer
+		cfg.DoltServerHost = configfile.DefaultDoltServerHost
+		cfg.DoltServerUser = configfile.DefaultDoltServerUser
+	} else {
+		cfg.DoltMode = configfile.DoltModeEmbedded
+	}
+	if serverHost != "" {
+		cfg.DoltServerHost = serverHost
+	}
+	if serverPort != 0 {
+		cfg.DoltServerPort = serverPort
+	}
+	if serverSocket != "" {
+		cfg.DoltServerSocket = serverSocket
+	}
+	if serverUser != "" {
+		cfg.DoltServerUser = serverUser
+	}
+	return cfg
+}
+
+func persistInitSyncRemote(beadsDir, initRemote, syncURL string, syncFromRemote, syncURLFromConfig bool) error {
+	if initRemote != "" {
+		return config.SetYamlConfigInDir(beadsDir, "sync.remote", initRemote)
+	}
+	if !shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig) {
+		return nil
+	}
+	if existing := config.GetStringFromDir(beadsDir, "sync.remote"); existing != "" {
+		return nil
+	}
+	return config.SetYamlConfigInDir(beadsDir, "sync.remote", syncURL)
+}
+
+func isEmptyRemoteCloneError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "contains no dolt data")
 }
 
 // verifyMetadata writes a metadata field and verifies the write succeeded.

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -80,6 +80,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		roleFlag, _ := cmd.Flags().GetString("role")
 		fromJSONL, _ := cmd.Flags().GetBool("from-jsonl")
 		initRemote, _ := cmd.Flags().GetString("remote")
+		initRemoteChanged := cmd.Flags().Changed("remote")
 		// Dolt server connection flags
 		backendFlag, _ := cmd.Flags().GetString("backend")
 		initServerMode, _ := cmd.Flags().GetBool("server")
@@ -303,18 +304,18 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// beadsDir is computed. See CheckRemoteSafety in init_safety.go.
 		{
 			var earlySyncURL string
+			earlyRemoteSource := initSyncRemoteNone
 			earlyRemoteHasDoltData := false
-			if initRemote != "" {
-				earlySyncURL = initRemote
+			earlySyncURL, earlyRemoteSource = resolveInitConfiguredSyncRemote(initRemote, initRemoteChanged, resolveSyncRemote)
+			if earlyRemoteSource == initSyncRemoteExplicit {
 				// An explicit --remote is intent to bootstrap or wire that URL,
 				// but it is not proof that the remote already contains Dolt
 				// history. Let the clone attempt below distinguish populated
 				// remotes from empty remotes so --reinit-local can still fall
 				// back to a fresh local init against a new remote.
-			} else if s := resolveSyncRemote(); s != "" {
-				earlySyncURL = s
+			} else if earlyRemoteSource == initSyncRemoteConfigured {
 				earlyRemoteHasDoltData = true // sync.remote configured = user intends bootstrap
-			} else if isGitRepo() && !isBareGitRepo() {
+			} else if earlyRemoteSource == initSyncRemoteNone && isGitRepo() && !isBareGitRepo() {
 				if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 					earlySyncURL = normalizeRemoteURL(originURL)
 					earlyRemoteHasDoltData = gitOriginHasDoltDataRef()
@@ -567,8 +568,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// CheckRemoteSafety chokepoint encodes this invariant; any future
 		// flag that can interact with remote history must route through
 		// it rather than adding another `&& !someFlag` here.
-		syncURL := resolveSyncRemote()
-		syncURLFromConfig := syncURL != "" // true when URL came from explicit user config
+		syncResolutionURL, syncRemoteSource := resolveInitConfiguredSyncRemote(initRemote, initRemoteChanged, resolveSyncRemote)
+		syncURL := syncResolutionURL
+		syncURLFromConfig := syncURL != "" && syncRemoteSource != initSyncRemoteNone // true when URL came from explicit user config
 		bootstrappedFromRemote := false
 		syncFromRemote := false
 		remoteHasDoltData := false
@@ -581,7 +583,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// http:// to git+http:// and break Dolt remotesapi endpoints
 			// configured explicitly by the user (GH#3339).
 			syncFromRemote = true
-		} else if isGitRepo() && !isBareGitRepo() {
+		} else if syncRemoteSource == initSyncRemoteNone && isGitRepo() && !isBareGitRepo() {
 			if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 				syncURL = normalizeRemoteURL(originURL)
 				remoteHasDoltData = gitOriginHasDoltDataRef()
@@ -636,15 +638,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		if syncFromRemote {
 			var err error
 			cloneCfg := initTimeCloneConfig(initServerMode, serverHost, serverPort, serverSocket, serverUser, dbName)
-			if initServerMode {
-				cloneMode := remoteCloneCLI
-				if externalServer {
-					cloneMode = remoteCloneExternalServer
-				}
-				err = cloneFromRemoteWithMode(ctx, beadsDir, syncURL, dbName, cloneCfg, cloneMode)
-			} else {
-				err = cloneFromRemoteWithMode(ctx, beadsDir, syncURL, dbName, cloneCfg, remoteCloneEmbedded)
-			}
+			err = cloneFromRemoteWithMode(ctx, beadsDir, syncURL, dbName, cloneCfg, initRemoteCloneMode(initServerMode, externalServer))
 			if err != nil {
 				if isEmptyRemoteCloneError(err) {
 					if !quiet {
@@ -1419,6 +1413,7 @@ func init() {
 	initCmd.Flags().String("agents-template", "", "Path to custom AGENTS.md template (overrides embedded default)")
 	initCmd.Flags().String("agents-profile", "", "AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)")
 	initCmd.Flags().String("agents-file", "", "Custom filename for agent instructions (default: AGENTS.md)")
+	initCmd.Flags().String("remote", "", "Dolt remote URL to clone from and persist as sync.remote")
 
 	// Non-interactive mode for CI/cloud agents
 	initCmd.Flags().Bool("non-interactive", false, "Skip all interactive prompts (auto-detected in CI or non-TTY environments)")
@@ -1860,6 +1855,34 @@ func shouldWireInitRemote(syncURL string, syncFromRemote, syncURLFromConfig bool
 	// Auto-detected plain git origins are not Dolt remotes. Only wire origin
 	// when it was explicitly configured or proven to carry refs/dolt/data.
 	return syncURL != "" && (syncFromRemote || syncURLFromConfig)
+}
+
+type initSyncRemoteSource int
+
+const (
+	initSyncRemoteNone initSyncRemoteSource = iota
+	initSyncRemoteExplicit
+	initSyncRemoteConfigured
+)
+
+func resolveInitConfiguredSyncRemote(initRemote string, initRemoteChanged bool, resolveConfiguredRemote func() string) (string, initSyncRemoteSource) {
+	if initRemoteChanged {
+		return initRemote, initSyncRemoteExplicit
+	}
+	if syncURL := resolveConfiguredRemote(); syncURL != "" {
+		return syncURL, initSyncRemoteConfigured
+	}
+	return "", initSyncRemoteNone
+}
+
+func initRemoteCloneMode(initServerMode, externalServer bool) remoteCloneMode {
+	if !initServerMode {
+		return remoteCloneEmbedded
+	}
+	if externalServer {
+		return remoteCloneExternalServer
+	}
+	return remoteCloneCLI
 }
 
 func initTimeCloneConfig(serverMode bool, serverHost string, serverPort int, serverSocket, serverUser, dbName string) *configfile.Config {

--- a/cmd/bd/init_remote_test.go
+++ b/cmd/bd/init_remote_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func TestPersistInitSyncRemoteExplicitRemoteWritesTargetDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	callerDir := filepath.Join(tmpDir, "caller")
+	targetBeadsDir := filepath.Join(tmpDir, "target", ".beads")
+	callerBeadsDir := filepath.Join(callerDir, ".beads")
+	if err := os.MkdirAll(callerBeadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(targetBeadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	callerConfig := filepath.Join(callerBeadsDir, "config.yaml")
+	if err := os.WriteFile(callerConfig, []byte("sync.remote: git+ssh://git@example.com/wrong/repo.git\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	targetConfig := filepath.Join(targetBeadsDir, "config.yaml")
+	if err := os.WriteFile(targetConfig, []byte("# Beads Config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(callerDir); err != nil {
+		t.Fatal(err)
+	}
+
+	const remote = "git+ssh://git@example.com/right/repo.git"
+	if err := persistInitSyncRemote(targetBeadsDir, remote, remote, false, true); err != nil {
+		t.Fatalf("persistInitSyncRemote failed: %v", err)
+	}
+
+	targetBytes, err := os.ReadFile(targetConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(targetBytes), remote) {
+		t.Fatalf("target config.yaml does not contain explicit remote %q:\n%s", remote, targetBytes)
+	}
+
+	callerBytes, err := os.ReadFile(callerConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(callerBytes), remote) {
+		t.Fatalf("caller config.yaml was modified instead of target:\n%s", callerBytes)
+	}
+}
+
+func TestInitTimeCloneConfigExternalDefaultsAreSelfContained(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+	t.Setenv("BEADS_DOLT_SERVER_USER", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+
+	cfg := initTimeCloneConfig(true, "", 3312, "", "", "beads_proj")
+
+	if cfg.GetDoltMode() != configfile.DoltModeServer {
+		t.Fatalf("dolt mode = %q, want server", cfg.GetDoltMode())
+	}
+	if cfg.GetDoltServerHost() != configfile.DefaultDoltServerHost {
+		t.Fatalf("host = %q, want default %q", cfg.GetDoltServerHost(), configfile.DefaultDoltServerHost)
+	}
+	if cfg.GetDoltServerUser() != configfile.DefaultDoltServerUser {
+		t.Fatalf("user = %q, want default %q", cfg.GetDoltServerUser(), configfile.DefaultDoltServerUser)
+	}
+	if cfg.GetDoltServerPort() != 3312 {
+		t.Fatalf("port = %d, want 3312", cfg.GetDoltServerPort())
+	}
+	if cfg.GetDoltDatabase() != "beads_proj" {
+		t.Fatalf("database = %q, want beads_proj", cfg.GetDoltDatabase())
+	}
+}

--- a/cmd/bd/init_remote_test.go
+++ b/cmd/bd/init_remote_test.go
@@ -9,6 +9,81 @@ import (
 	"github.com/steveyegge/beads/internal/configfile"
 )
 
+func TestInitCommandRegistersRemoteFlag(t *testing.T) {
+	if initCmd.Flags().Lookup("remote") == nil {
+		t.Fatal("init command does not register --remote")
+	}
+}
+
+func TestInitExplicitRemoteDrivesCloneAndPersistence(t *testing.T) {
+	const remote = "git+ssh://git@example.com/right/repo.git"
+	resolveConfiguredRemote := func() string {
+		return "git+ssh://git@example.com/wrong/repo.git"
+	}
+
+	syncURL, source := resolveInitConfiguredSyncRemote(remote, true, resolveConfiguredRemote)
+	if syncURL != remote {
+		t.Fatalf("syncURL = %q, want explicit remote %q", syncURL, remote)
+	}
+	if source != initSyncRemoteExplicit {
+		t.Fatalf("source = %v, want explicit", source)
+	}
+	syncFromRemote := syncURL != ""
+	syncURLFromConfig := syncURL != "" && source != initSyncRemoteNone
+	if !syncFromRemote {
+		t.Fatal("explicit remote did not select clone-from-remote path")
+	}
+	if !syncURLFromConfig {
+		t.Fatal("explicit remote was not treated as user-configured sync URL")
+	}
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("# Beads Config\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := persistInitSyncRemote(beadsDir, remote, syncURL, syncFromRemote, syncURLFromConfig); err != nil {
+		t.Fatalf("persistInitSyncRemote failed: %v", err)
+	}
+	configBytes, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(configBytes), remote) {
+		t.Fatalf("config.yaml does not contain explicit remote %q:\n%s", remote, configBytes)
+	}
+}
+
+func TestInitServerExternalRemoteUsesServerCloneMode(t *testing.T) {
+	if got := initRemoteCloneMode(true, true); got != remoteCloneExternalServer {
+		t.Fatalf("initRemoteCloneMode(server=true, external=true) = %v, want external server clone mode", got)
+	}
+}
+
+func TestInitExplicitEmptyRemoteSkipsAmbientConfig(t *testing.T) {
+	called := false
+	resolveConfiguredRemote := func() string {
+		called = true
+		return "git+ssh://git@example.com/ambient/repo.git"
+	}
+
+	syncURL, source := resolveInitConfiguredSyncRemote("", true, resolveConfiguredRemote)
+	if called {
+		t.Fatal("explicit empty --remote consulted ambient sync config")
+	}
+	if syncURL != "" {
+		t.Fatalf("syncURL = %q, want empty explicit remote", syncURL)
+	}
+	if source != initSyncRemoteExplicit {
+		t.Fatalf("source = %v, want explicit", source)
+	}
+	if syncURL != "" {
+		t.Fatal("explicit empty --remote would trigger early remote safety")
+	}
+}
+
 func TestPersistInitSyncRemoteExplicitRemoteWritesTargetDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	callerDir := filepath.Join(tmpDir, "caller")

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -70,6 +70,8 @@ Examples:
   bd linear sync --push         # Export issues to Linear
   bd linear sync                # Bidirectional sync (pull then push)
   bd linear sync --dry-run      # Preview sync without changes
+  bd create "Fix login" --external-ref https://linear.app/team/issue/TEAM-123
+                              # Link a local issue to an existing Linear issue
   bd linear status              # Show sync status`,
 }
 

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -233,7 +233,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 		CreateOnly: createOnly,
 		State:      state,
 	}
-	opts.DependencyTypes = linearPullDependencyTypes(relations)
+	opts.DependencySources = linearPullDependencySources(relations)
 
 	// Convert type filters
 	for _, t := range typeFilters {
@@ -300,11 +300,11 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	}
 }
 
-func linearPullDependencyTypes(includeRelations bool) []types.DependencyType {
+func linearPullDependencySources(includeRelations bool) []tracker.DependencySource {
 	if includeRelations {
 		return nil
 	}
-	return []types.DependencyType{types.DepParentChild}
+	return []tracker.DependencySource{tracker.DependencySourceParent}
 }
 
 // buildLinearPullHooks creates PullHooks for Linear-specific pull behavior.

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -96,7 +96,7 @@ func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbP
 	// their descendants. This matches the behavior of --json and --flat (GH#3349).
 	allDescendants := make(map[string]*types.Issue)
 
-	err = findAllDescendants(ctx, store, dbPath, parentID, baseFilter, allDescendants, 0, 10) // max depth 10
+	err = findAllDescendants(ctx, store, dbPath, parentID, baseFilter, allDescendants)
 	if err != nil {
 		return nil, fmt.Errorf("error finding descendants: %v", err)
 	}
@@ -119,11 +119,7 @@ func getHierarchicalChildren(ctx context.Context, store storage.DoltStorage, dbP
 
 // findAllDescendants recursively finds all descendants using parent filtering.
 // baseFilter carries CLI filters (--type, --status, etc.) so the tree respects them.
-func findAllDescendants(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string, baseFilter types.IssueFilter, result map[string]*types.Issue, currentDepth, maxDepth int) error {
-	if currentDepth >= maxDepth {
-		return nil // Prevent infinite recursion
-	}
-
+func findAllDescendants(ctx context.Context, store storage.DoltStorage, dbPath string, parentID string, baseFilter types.IssueFilter, result map[string]*types.Issue) error {
 	var children []*types.Issue
 	err := withStorage(ctx, store, dbPath, func(s storage.DoltStorage) error {
 		filter := baseFilter
@@ -140,7 +136,7 @@ func findAllDescendants(ctx context.Context, store storage.DoltStorage, dbPath s
 	for _, child := range children {
 		if _, exists := result[child.ID]; !exists {
 			result[child.ID] = child
-			err = findAllDescendants(ctx, store, dbPath, child.ID, baseFilter, result, currentDepth+1, maxDepth)
+			err = findAllDescendants(ctx, store, dbPath, child.ID, baseFilter, result)
 			if err != nil {
 				return err
 			}

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -377,6 +377,20 @@ func TestEmbeddedList(t *testing.T) {
 		}
 	})
 
+	t.Run("ready_parent_filter_includes_grandchildren", func(t *testing.T) {
+		parent := bdCreate(t, bd, dir, "Ready parent recursive", "--type", "epic")
+		child := bdCreate(t, bd, dir, "Ready child recursive", "--type", "task", "--parent", parent.ID)
+		grandchild := bdCreate(t, bd, dir, "Ready grandchild recursive", "--type", "task", "--parent", child.ID)
+
+		issues := bdListJSON(t, bd, dir, "--ready", "--parent", parent.ID, "--limit", "0")
+		if !containsID(issues, child.ID) {
+			t.Errorf("ready parent filter should include direct child %s, got %v", child.ID, listIssueIDs(issues))
+		}
+		if !containsID(issues, grandchild.ID) {
+			t.Errorf("ready parent filter should include recursive grandchild %s, got %v", grandchild.ID, listIssueIDs(issues))
+		}
+	})
+
 	t.Run("flat", func(t *testing.T) {
 		// --flat disables tree format, uses legacy flat list
 		out := bdList(t, bd, dir, "--flat")

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -321,3 +321,116 @@ func TestLoadWatchedIssues_WithParentIncludesHierarchyAndStableOrder(t *testing.
 		t.Fatalf("expected watched issues to be normalized by id for snapshot stability, got %v want %v", firstIDs, wantIDs)
 	}
 }
+
+func TestLoadWatchedIssues_ReadyWithParentPreservesReadySemantics(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	store := newTestStore(t, testDB)
+
+	createIssue := func(title string, issueType types.IssueType) *types.Issue {
+		issue := &types.Issue{
+			Title:     title,
+			Priority:  2,
+			IssueType: issueType,
+			Status:    types.StatusOpen,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-user"); err != nil {
+			t.Fatalf("Failed to create issue %s: %v", title, err)
+		}
+		return issue
+	}
+	addDep := func(child, parent *types.Issue, depType types.DependencyType) {
+		dep := &types.Dependency{
+			IssueID:     child.ID,
+			DependsOnID: parent.ID,
+			Type:        depType,
+			CreatedAt:   time.Now(),
+			CreatedBy:   "test-user",
+		}
+		if err := store.AddDependency(ctx, dep, "test-user"); err != nil {
+			t.Fatalf("Failed to add dependency %s -> %s: %v", child.ID, parent.ID, err)
+		}
+	}
+
+	parent := createIssue("Watch ready parent", types.TypeEpic)
+	readyChild := createIssue("Watch ready child", types.TypeTask)
+	blockedChild := createIssue("Watch blocked child", types.TypeTask)
+	blocker := createIssue("Watch blocker", types.TypeTask)
+	addDep(readyChild, parent, types.DepParentChild)
+	addDep(blockedChild, parent, types.DepParentChild)
+	addDep(blockedChild, blocker, types.DepBlocks)
+
+	filter := types.IssueFilter{ParentID: &parent.ID}
+	issues, err := loadWatchedIssues(ctx, store, filter, true, parent.ID, "", false)
+	if err != nil {
+		t.Fatalf("loadWatchedIssues ready parent failed: %v", err)
+	}
+
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		ids = append(ids, issue.ID)
+	}
+	if !slices.Contains(ids, readyChild.ID) {
+		t.Fatalf("expected ready child %s in watch ready parent result, got %v", readyChild.ID, ids)
+	}
+	if slices.Contains(ids, blockedChild.ID) {
+		t.Fatalf("blocked child %s should not appear in watch ready parent result, got %v", blockedChild.ID, ids)
+	}
+}
+
+func TestGetHierarchicalChildrenIncludesDescendantsBeyondDepthTen(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	testDB := filepath.Join(tmpDir, ".beads", "beads.db")
+	store := newTestStore(t, testDB)
+
+	root := &types.Issue{
+		Title:     "Deep tree root",
+		Priority:  2,
+		IssueType: types.TypeEpic,
+		Status:    types.StatusOpen,
+	}
+	if err := store.CreateIssue(ctx, root, "test-user"); err != nil {
+		t.Fatalf("Failed to create root: %v", err)
+	}
+
+	parent := root
+	var leaf *types.Issue
+	const depth = 12
+	for i := 1; i <= depth; i++ {
+		child := &types.Issue{
+			Title:     "Deep tree child",
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Status:    types.StatusOpen,
+		}
+		if err := store.CreateIssue(ctx, child, "test-user"); err != nil {
+			t.Fatalf("Failed to create child at depth %d: %v", i, err)
+		}
+		dep := &types.Dependency{
+			IssueID:     child.ID,
+			DependsOnID: parent.ID,
+			Type:        types.DepParentChild,
+			CreatedAt:   time.Now(),
+			CreatedBy:   "test-user",
+		}
+		if err := store.AddDependency(ctx, dep, "test-user"); err != nil {
+			t.Fatalf("Failed to add parent-child dependency at depth %d: %v", i, err)
+		}
+		parent = child
+		leaf = child
+	}
+
+	issues, err := getHierarchicalChildren(ctx, store, "", root.ID, types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("getHierarchicalChildren failed: %v", err)
+	}
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		ids = append(ids, issue.ID)
+	}
+	if !slices.Contains(ids, leaf.ID) {
+		t.Fatalf("expected descendant at depth %d (%s), got %v", depth, leaf.ID, ids)
+	}
+}

--- a/cmd/bd/sync_push_pull.go
+++ b/cmd/bd/sync_push_pull.go
@@ -459,11 +459,11 @@ func runLinearPull(cmd *cobra.Command, args []string) {
 	engine.PullHooks = buildLinearPullHooks(ctx)
 
 	result, err := engine.Sync(ctx, tracker.SyncOptions{
-		Pull:            true,
-		Push:            false,
-		DryRun:          dryRun,
-		IssueIDs:        args,
-		DependencyTypes: linearPullDependencyTypes(relations),
+		Pull:              true,
+		Push:              false,
+		DryRun:            dryRun,
+		IssueIDs:          args,
+		DependencySources: linearPullDependencySources(relations),
 	})
 	if err != nil {
 		FatalError("sync failed: %v", err)

--- a/internal/linear/fieldmapper.go
+++ b/internal/linear/fieldmapper.go
@@ -65,6 +65,7 @@ func (m *linearFieldMapper) IssueToBeads(ti *tracker.TrackerIssue) *tracker.Issu
 			FromExternalID: d.FromLinearID,
 			ToExternalID:   d.ToLinearID,
 			Type:           d.Type,
+			Source:         tracker.DependencySource(d.Source),
 		})
 	}
 

--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -557,6 +557,7 @@ func IssueToBeads(li *Issue, config *MappingConfig) *IssueConversion {
 			FromLinearID: li.Identifier,
 			ToLinearID:   li.Parent.Identifier,
 			Type:         "parent-child",
+			Source:       DependencySourceParent,
 		})
 	}
 
@@ -571,6 +572,7 @@ func IssueToBeads(li *Issue, config *MappingConfig) *IssueConversion {
 					FromLinearID: li.Identifier,
 					ToLinearID:   rel.RelatedIssue.Identifier,
 					Type:         depType,
+					Source:       DependencySourceRelation,
 				})
 				continue
 			}
@@ -581,6 +583,7 @@ func IssueToBeads(li *Issue, config *MappingConfig) *IssueConversion {
 					FromLinearID: rel.RelatedIssue.Identifier,
 					ToLinearID:   li.Identifier,
 					Type:         depType,
+					Source:       DependencySourceRelation,
 				})
 				continue
 			}
@@ -590,6 +593,7 @@ func IssueToBeads(li *Issue, config *MappingConfig) *IssueConversion {
 				FromLinearID: li.Identifier,
 				ToLinearID:   rel.RelatedIssue.Identifier,
 				Type:         depType,
+				Source:       DependencySourceRelation,
 			})
 		}
 	}

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -441,6 +441,48 @@ func TestIssueToBeadsWithParent(t *testing.T) {
 	if result.Dependencies[0].ToLinearID != "PROJ-123" {
 		t.Errorf("ToLinearID = %q, want %q", result.Dependencies[0].ToLinearID, "PROJ-123")
 	}
+	if result.Dependencies[0].Source != DependencySourceParent {
+		t.Errorf("Source = %q, want %q", result.Dependencies[0].Source, DependencySourceParent)
+	}
+}
+
+func TestIssueToBeadsRelationMappedToParentChildKeepsRelationSource(t *testing.T) {
+	config := DefaultMappingConfig()
+	config.RelationMap["related"] = "parent-child"
+
+	linearIssue := &Issue{
+		ID:         "uuid-456",
+		Identifier: "PROJ-456",
+		Title:      "Related Issue",
+		URL:        "https://linear.app/team/issue/PROJ-456",
+		Priority:   3,
+		State:      &State{Type: "unstarted", Name: "Todo"},
+		Relations: &Relations{Nodes: []Relation{
+			{
+				ID:   "rel-1",
+				Type: "related",
+				RelatedIssue: struct {
+					ID         string `json:"id"`
+					Identifier string `json:"identifier"`
+				}{ID: "uuid-789", Identifier: "PROJ-789"},
+			},
+		}},
+		CreatedAt: "2024-01-15T10:00:00Z",
+		UpdatedAt: "2024-01-16T12:00:00Z",
+	}
+
+	result := IssueToBeads(linearIssue, config)
+
+	if len(result.Dependencies) != 1 {
+		t.Fatalf("Expected 1 dependency, got %d", len(result.Dependencies))
+	}
+	dep := result.Dependencies[0]
+	if dep.Type != "parent-child" {
+		t.Errorf("Dependency type = %q, want %q", dep.Type, "parent-child")
+	}
+	if dep.Source != DependencySourceRelation {
+		t.Errorf("Source = %q, want %q", dep.Source, DependencySourceRelation)
+	}
 }
 
 func TestBuildLinearToLocalUpdates(t *testing.T) {

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -277,7 +277,13 @@ type DependencyInfo struct {
 	FromLinearID string // Linear identifier of the dependent issue (e.g., "TEAM-123")
 	ToLinearID   string // Linear identifier of the dependency target
 	Type         string // Beads dependency type (blocks, related, duplicates, parent-child)
+	Source       string // Linear relationship origin: parent or relation
 }
+
+const (
+	DependencySourceParent   = "parent"
+	DependencySourceRelation = "relation"
+)
 
 // StateCache caches workflow states for the team to avoid repeated API calls.
 type StateCache struct {

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -132,8 +132,22 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 	// Explicit parent-child dependency takes precedence over dotted-ID prefix.
 	if filter.ParentID != nil {
 		parentID := *filter.ParentID
-		whereClauses = append(whereClauses, "(id IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child' AND depends_on_id = ?) OR (id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child')))")
-		args = append(args, parentID, parentID)
+		descendantIDs, descErr := s.getDescendantIDs(ctx, parentID)
+		if descErr != nil {
+			return nil, fmt.Errorf("get parent descendants: %w", descErr)
+		}
+		parentClauses := []string{"(id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child'))"}
+		args = append(args, parentID)
+		for start := 0; start < len(descendantIDs); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(descendantIDs) {
+				end = len(descendantIDs)
+			}
+			placeholders, batchArgs := doltBuildSQLInClause(descendantIDs[start:end])
+			parentClauses = append(parentClauses, fmt.Sprintf("id IN (%s)", placeholders))
+			args = append(args, batchArgs...)
+		}
+		whereClauses = append(whereClauses, "("+strings.Join(parentClauses, " OR ")+")")
 	}
 
 	// Molecule filtering: filter to direct children of the specified molecule.
@@ -441,6 +455,16 @@ func (s *DoltStore) getChildrenWithParents(ctx context.Context, parentIDs []stri
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
 		result, err = issueops.GetChildrenWithParentsInTx(ctx, tx, parentIDs)
+		return err
+	})
+	return result, err
+}
+
+func (s *DoltStore) getDescendantIDs(ctx context.Context, rootID string) ([]string, error) {
+	var result []string
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetDescendantIDsInTx(ctx, tx, rootID, 0)
 		return err
 	})
 	return result, err

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -116,23 +116,22 @@ func GetReadyWorkInTx(
 	// WorkFilter.ParentID godoc both promising "descendants (recursive)".
 	if filter.ParentID != nil {
 		parentID := *filter.ParentID
-		descendants, dErr := GetDescendantIDsInTx(ctx, tx, parentID, 0)
-		if dErr != nil {
-			return nil, fmt.Errorf("get descendants for parent filter: %w", dErr)
+		descendantIDs, descErr := GetDescendantIDsInTx(ctx, tx, parentID, 0)
+		if descErr != nil {
+			return nil, fmt.Errorf("get parent descendants: %w", descErr)
 		}
-		// Compose two branches, matching the prior semantics:
-		//   1. Any ID reachable via parent-child deps from parentID.
-		//   2. Dotted-ID descendants (id LIKE "parent.%") that have no
-		//      explicit parent-child dep - the implicit-parent convention.
-		var orParts []string
-		if len(descendants) > 0 {
-			placeholders, batchArgs := buildSQLInClause(descendants)
-			orParts = append(orParts, fmt.Sprintf("id IN (%s)", placeholders))
+		parentClauses := []string{"(id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child'))"}
+		args = append(args, parentID)
+		for start := 0; start < len(descendantIDs); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(descendantIDs) {
+				end = len(descendantIDs)
+			}
+			placeholders, batchArgs := buildSQLInClause(descendantIDs[start:end])
+			parentClauses = append(parentClauses, fmt.Sprintf("id IN (%s)", placeholders))
 			args = append(args, batchArgs...)
 		}
-		orParts = append(orParts, "(id LIKE CONCAT(?, '.%') AND id NOT IN (SELECT issue_id FROM dependencies WHERE type = 'parent-child'))")
-		args = append(args, parentID)
-		whereClauses = append(whereClauses, "("+strings.Join(orParts, " OR ")+")")
+		whereClauses = append(whereClauses, "("+strings.Join(parentClauses, " OR ")+")")
 	}
 
 	// Molecule filtering: filter to direct children of the specified molecule.

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -316,6 +316,8 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 		localByExternalIdentifier[identifier] = localIssue
 	}
 
+	prelinkedHydrateIDs := make(map[string]bool)
+
 	// Fetch issues from external tracker
 	var extIssues []TrackerIssue
 	if len(opts.IssueIDs) > 0 {
@@ -360,10 +362,20 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 		if provider, ok := e.Tracker.(PullStatsProvider); ok {
 			stats.Queried, stats.Candidates = provider.LastPullStats()
 		}
+		hydrated, hydratedLocalIDs, err := e.fetchPrelinkedIssues(ctx, extIssues, localIssues, lastSync)
+		if err != nil {
+			e.warn("Failed to hydrate pre-linked %s issues: %v", e.Tracker.DisplayName(), err)
+		}
+		extIssues = append(extIssues, hydrated...)
+		stats.Candidates += len(hydrated)
+		for id := range hydratedLocalIDs {
+			prelinkedHydrateIDs[id] = true
+		}
 	}
 
 	mapper := e.Tracker.FieldMapper()
 	var pendingDeps []DependencyInfo
+	var dryRunIssues []*types.Issue
 
 	for _, extIssue := range extIssues {
 		// ShouldImport hook: filter before conversion
@@ -409,8 +421,25 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 			}
 		}
 
-		if !opts.DryRun {
-			pendingDeps = appendFilteredDependencies(pendingDeps, conv.Dependencies, opts.DependencyTypes)
+		if existing != nil {
+			// Conflict-aware pull: skip updating issues that were locally
+			// modified since last sync. Conflict detection (Phase 2) will
+			// handle these per the configured resolution strategy.
+			// Without this guard, pull silently overwrites local changes
+			// before conflict detection can compare timestamps.
+			if lastSync != nil && existing.UpdatedAt.After(*lastSync) && !allowOverwriteIDs[existing.ID] && !prelinkedHydrateIDs[existing.ID] {
+				stats.Skipped++
+				continue
+			}
+		}
+
+		pendingDeps = appendFilteredDependencies(pendingDeps, conv.Dependencies, opts.DependencyTypes)
+		if opts.DryRun {
+			dryRunIssue := *conv.Issue
+			if strings.TrimSpace(ref) != "" {
+				dryRunIssue.ExternalRef = strPtr(ref)
+			}
+			dryRunIssues = append(dryRunIssues, &dryRunIssue)
 		}
 
 		if existing != nil && pullIssueEqual(existing, conv.Issue, ref) {
@@ -430,16 +459,6 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 		}
 
 		if existing != nil {
-			// Conflict-aware pull: skip updating issues that were locally
-			// modified since last sync. Conflict detection (Phase 2) will
-			// handle these per the configured resolution strategy.
-			// Without this guard, pull silently overwrites local changes
-			// before conflict detection can compare timestamps.
-			if lastSync != nil && existing.UpdatedAt.After(*lastSync) && !allowOverwriteIDs[existing.ID] {
-				stats.Skipped++
-				continue
-			}
-
 			updates := buildPullIssueUpdates(existing, conv.Issue, ref)
 			if raw, ok := marshalTrackerMetadata(extIssue.Metadata); ok {
 				updates["metadata"] = raw
@@ -467,11 +486,15 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 			}
 			stats.Created++
 		}
-
 	}
 
 	// Create dependencies after all issues are imported
-	depErrors := e.createDependencies(ctx, pendingDeps)
+	depErrors := 0
+	if opts.DryRun {
+		depErrors = e.previewDependencies(ctx, pendingDeps, dryRunIssues)
+	} else {
+		depErrors = e.createDependencies(ctx, pendingDeps)
+	}
 	stats.Skipped += depErrors
 
 	span.SetAttributes(
@@ -549,6 +572,60 @@ func appendFilteredDependencies(dst []DependencyInfo, deps []DependencyInfo, all
 		}
 	}
 	return dst
+}
+
+func (e *Engine) fetchPrelinkedIssues(ctx context.Context, fetched []TrackerIssue, localIssues []*types.Issue, lastSync *time.Time) ([]TrackerIssue, map[string]bool, error) {
+	hydratedLocalIDs := make(map[string]bool)
+	if lastSync == nil {
+		return nil, hydratedLocalIDs, nil
+	}
+
+	seen := make(map[string]struct{}, len(fetched))
+	for _, issue := range fetched {
+		for _, id := range []string{
+			strings.TrimSpace(issue.Identifier),
+			strings.TrimSpace(e.Tracker.ExtractIdentifier(e.Tracker.BuildExternalRef(&issue))),
+		} {
+			if id != "" {
+				seen[id] = struct{}{}
+				seen[strings.ToLower(id)] = struct{}{}
+			}
+		}
+	}
+
+	var hydrated []TrackerIssue
+	for _, local := range localIssues {
+		if local == nil || local.ExternalRef == nil || !local.CreatedAt.After(*lastSync) {
+			continue
+		}
+		ref := strings.TrimSpace(*local.ExternalRef)
+		if ref == "" || !e.Tracker.IsExternalRef(ref) {
+			continue
+		}
+		identifier := strings.TrimSpace(e.Tracker.ExtractIdentifier(ref))
+		if identifier == "" {
+			continue
+		}
+		if _, ok := seen[identifier]; ok {
+			continue
+		}
+		if _, ok := seen[strings.ToLower(identifier)]; ok {
+			continue
+		}
+
+		extIssue, err := e.Tracker.FetchIssue(ctx, identifier)
+		if err != nil {
+			return hydrated, hydratedLocalIDs, err
+		}
+		if extIssue == nil {
+			continue
+		}
+		hydrated = append(hydrated, *extIssue)
+		hydratedLocalIDs[local.ID] = true
+		seen[identifier] = struct{}{}
+		seen[strings.ToLower(identifier)] = struct{}{}
+	}
+	return hydrated, hydratedLocalIDs, nil
 }
 
 func syncIssueLabels(ctx context.Context, tx storage.Transaction, issueID string, desired []string, actor string) error {
@@ -974,7 +1051,7 @@ func (e *Engine) createDependencies(ctx context.Context, deps []DependencyInfo) 
 		return 0
 	}
 
-	resolveIssue, err := e.dependencyIssueResolver(ctx)
+	resolveIssue, err := e.dependencyIssueResolver(ctx, nil)
 	if err != nil {
 		e.warn("Failed to build dependency resolver: %v", err)
 		return len(deps)
@@ -1012,11 +1089,53 @@ func (e *Engine) createDependencies(ctx context.Context, deps []DependencyInfo) 
 	return errCount
 }
 
-func (e *Engine) dependencyIssueResolver(ctx context.Context) (func(context.Context, string) (*types.Issue, error), error) {
+func (e *Engine) previewDependencies(ctx context.Context, deps []DependencyInfo, dryRunIssues []*types.Issue) int {
+	if len(deps) == 0 {
+		return 0
+	}
+
+	resolveIssue, err := e.dependencyIssueResolver(ctx, dryRunIssues)
+	if err != nil {
+		e.warn("Failed to build dependency resolver: %v", err)
+		return len(deps)
+	}
+
+	wouldCreate := 0
+	for _, dep := range deps {
+		fromIssue, err := resolveIssue(ctx, dep.FromExternalID)
+		if err != nil {
+			e.warn("Failed to resolve dependency source %s: %v", dep.FromExternalID, err)
+			continue
+		}
+		toIssue, err := resolveIssue(ctx, dep.ToExternalID)
+		if err != nil {
+			e.warn("Failed to resolve dependency target %s: %v", dep.ToExternalID, err)
+			continue
+		}
+		if fromIssue == nil || toIssue == nil {
+			continue
+		}
+		if dependencyExists(ctx, e.Store, fromIssue.ID, toIssue.ID, types.DependencyType(dep.Type)) {
+			continue
+		}
+		fromDisplay := firstNonEmpty(fromIssue.ID, dep.FromExternalID)
+		toDisplay := firstNonEmpty(toIssue.ID, dep.ToExternalID)
+		e.msg("[dry-run] Would create dependency: %s -> %s (%s)", fromDisplay, toDisplay, dep.Type)
+		wouldCreate++
+	}
+	if wouldCreate > 0 {
+		e.msg("[dry-run] Would create %d dependencies", wouldCreate)
+	}
+	return 0
+}
+
+func (e *Engine) dependencyIssueResolver(ctx context.Context, extraIssues []*types.Issue) (func(context.Context, string) (*types.Issue, error), error) {
 	issues, searchErr := e.Store.SearchIssues(ctx, "", types.IssueFilter{})
 	if searchErr != nil {
 		return nil, searchErr
 	}
+	issues = append(issues, extraIssues...)
+
 	byExternal := make(map[string]*types.Issue, len(issues)*2)
 	for _, candidate := range issues {
 		if candidate == nil || candidate.ExternalRef == nil {
@@ -1026,11 +1145,18 @@ func (e *Engine) dependencyIssueResolver(ctx context.Context) (func(context.Cont
 		if ref == "" || !e.Tracker.IsExternalRef(ref) {
 			continue
 		}
-		byExternal[ref] = candidate
+		if _, exists := byExternal[ref]; !exists {
+			byExternal[ref] = candidate
+		}
 		identifier := strings.TrimSpace(e.Tracker.ExtractIdentifier(ref))
 		if identifier != "" {
-			byExternal[identifier] = candidate
-			byExternal[strings.ToLower(identifier)] = candidate
+			if _, exists := byExternal[identifier]; !exists {
+				byExternal[identifier] = candidate
+			}
+			lowerIdentifier := strings.ToLower(identifier)
+			if _, exists := byExternal[lowerIdentifier]; !exists {
+				byExternal[lowerIdentifier] = candidate
+			}
 		}
 	}
 
@@ -1050,6 +1176,31 @@ func (e *Engine) dependencyIssueResolver(ctx context.Context) (func(context.Cont
 		}
 		return nil, nil
 	}, nil
+}
+
+func dependencyExists(ctx context.Context, store storage.Storage, issueID, dependsOnID string, depType types.DependencyType) bool {
+	if strings.TrimSpace(issueID) == "" || strings.TrimSpace(dependsOnID) == "" {
+		return false
+	}
+	records, err := store.GetDependenciesWithMetadata(ctx, issueID)
+	if err != nil {
+		return false
+	}
+	for _, record := range records {
+		if record.ID == dependsOnID && record.DependencyType == depType {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // buildDescendantSet returns the set of issue IDs consisting of the given parent

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -2,6 +2,7 @@ package tracker
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -364,7 +365,7 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 		}
 		hydrated, hydratedLocalIDs, err := e.fetchPrelinkedIssues(ctx, extIssues, localIssues, lastSync)
 		if err != nil {
-			e.warn("Failed to hydrate pre-linked %s issues: %v", e.Tracker.DisplayName(), err)
+			return nil, fmt.Errorf("hydrating pre-linked %s issues: %w", e.Tracker.DisplayName(), err)
 		}
 		extIssues = append(extIssues, hydrated...)
 		stats.Candidates += len(hydrated)
@@ -595,11 +596,18 @@ func (e *Engine) fetchPrelinkedIssues(ctx context.Context, fetched []TrackerIssu
 
 	var hydrated []TrackerIssue
 	for _, local := range localIssues {
-		if local == nil || local.ExternalRef == nil || !local.CreatedAt.After(*lastSync) {
+		if local == nil || local.ExternalRef == nil {
 			continue
 		}
 		ref := strings.TrimSpace(*local.ExternalRef)
 		if ref == "" || !e.Tracker.IsExternalRef(ref) {
+			continue
+		}
+		changedAfterLastSync, err := e.externalRefChangedAfter(ctx, local, ref, *lastSync)
+		if err != nil {
+			return hydrated, hydratedLocalIDs, fmt.Errorf("checking pre-linked local issue %s: %w", local.ID, err)
+		}
+		if !changedAfterLastSync {
 			continue
 		}
 		identifier := strings.TrimSpace(e.Tracker.ExtractIdentifier(ref))
@@ -626,6 +634,38 @@ func (e *Engine) fetchPrelinkedIssues(ctx context.Context, fetched []TrackerIssu
 		seen[strings.ToLower(identifier)] = struct{}{}
 	}
 	return hydrated, hydratedLocalIDs, nil
+}
+
+type dbProvider interface {
+	DB() *sql.DB
+}
+
+func (e *Engine) externalRefChangedAfter(ctx context.Context, local *types.Issue, currentRef string, lastSync time.Time) (bool, error) {
+	if local == nil {
+		return false, nil
+	}
+	provider, ok := e.Store.(dbProvider)
+	if !ok || provider.DB() == nil {
+		return local.CreatedAt.After(lastSync) || local.UpdatedAt.After(lastSync), nil
+	}
+
+	var previousRef sql.NullString
+	err := provider.DB().QueryRowContext(ctx, `
+		SELECT external_ref
+		FROM (
+			SELECT id, external_ref, commit_date FROM dolt_history_issues
+		) h
+		WHERE h.id = ? AND h.commit_date <= ?
+		ORDER BY h.commit_date DESC
+		LIMIT 1
+	`, local.ID, lastSync.UTC()).Scan(&previousRef)
+	if err == sql.ErrNoRows {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return !previousRef.Valid || strings.TrimSpace(previousRef.String) != strings.TrimSpace(currentRef), nil
 }
 
 func syncIssueLabels(ctx context.Context, tx storage.Transaction, issueID string, desired []string, actor string) error {

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -1171,7 +1171,7 @@ func (e *Engine) previewDependencies(ctx context.Context, deps []DependencyInfo,
 		if dependencyExists(ctx, e.Store, fromIssue.ID, toIssue.ID, types.DependencyType(dep.Type)) {
 			continue
 		}
-		key := pendingDependencyPreviewKey(fromIssue.ID, toIssue.ID, dep.Type, dep.Source)
+		key := pendingDependencyPreviewKey(fromIssue.ID, toIssue.ID, dep.Type)
 		if _, ok := pending[key]; ok {
 			continue
 		}
@@ -1187,12 +1187,11 @@ func (e *Engine) previewDependencies(ctx context.Context, deps []DependencyInfo,
 	return 0
 }
 
-func pendingDependencyPreviewKey(fromID, toID, depType string, source DependencySource) string {
+func pendingDependencyPreviewKey(fromID, toID, depType string) string {
 	return strings.Join([]string{
 		strings.TrimSpace(fromID),
 		strings.TrimSpace(toID),
 		strings.TrimSpace(depType),
-		string(source),
 	}, "\x00")
 }
 

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -434,7 +434,7 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 			}
 		}
 
-		pendingDeps = appendFilteredDependencies(pendingDeps, conv.Dependencies, opts.DependencyTypes)
+		pendingDeps = appendFilteredDependencies(pendingDeps, conv.Dependencies, opts.DependencyTypes, opts.DependencySources)
 		if opts.DryRun {
 			dryRunIssue := *conv.Issue
 			if strings.TrimSpace(ref) != "" {
@@ -556,21 +556,33 @@ func marshalTrackerMetadata(metadata interface{}) (json.RawMessage, bool) {
 	return json.RawMessage(raw), true
 }
 
-func appendFilteredDependencies(dst []DependencyInfo, deps []DependencyInfo, allowedTypes []types.DependencyType) []DependencyInfo {
+func appendFilteredDependencies(dst []DependencyInfo, deps []DependencyInfo, allowedTypes []types.DependencyType, allowedSources []DependencySource) []DependencyInfo {
 	if len(deps) == 0 {
 		return dst
 	}
-	if len(allowedTypes) == 0 {
+	if len(allowedTypes) == 0 && len(allowedSources) == 0 {
 		return append(dst, deps...)
 	}
 	allowed := make(map[string]struct{}, len(allowedTypes))
 	for _, depType := range allowedTypes {
 		allowed[string(depType)] = struct{}{}
 	}
+	allowedSourceSet := make(map[DependencySource]struct{}, len(allowedSources))
+	for _, source := range allowedSources {
+		allowedSourceSet[source] = struct{}{}
+	}
 	for _, dep := range deps {
-		if _, ok := allowed[dep.Type]; ok {
-			dst = append(dst, dep)
+		if len(allowed) > 0 {
+			if _, ok := allowed[dep.Type]; !ok {
+				continue
+			}
 		}
+		if len(allowedSourceSet) > 0 {
+			if _, ok := allowedSourceSet[dep.Source]; !ok {
+				continue
+			}
+		}
+		dst = append(dst, dep)
 	}
 	return dst
 }
@@ -1141,6 +1153,7 @@ func (e *Engine) previewDependencies(ctx context.Context, deps []DependencyInfo,
 	}
 
 	wouldCreate := 0
+	pending := make(map[string]struct{}, len(deps))
 	for _, dep := range deps {
 		fromIssue, err := resolveIssue(ctx, dep.FromExternalID)
 		if err != nil {
@@ -1158,6 +1171,11 @@ func (e *Engine) previewDependencies(ctx context.Context, deps []DependencyInfo,
 		if dependencyExists(ctx, e.Store, fromIssue.ID, toIssue.ID, types.DependencyType(dep.Type)) {
 			continue
 		}
+		key := pendingDependencyPreviewKey(fromIssue.ID, toIssue.ID, dep.Type, dep.Source)
+		if _, ok := pending[key]; ok {
+			continue
+		}
+		pending[key] = struct{}{}
 		fromDisplay := firstNonEmpty(fromIssue.ID, dep.FromExternalID)
 		toDisplay := firstNonEmpty(toIssue.ID, dep.ToExternalID)
 		e.msg("[dry-run] Would create dependency: %s -> %s (%s)", fromDisplay, toDisplay, dep.Type)
@@ -1167,6 +1185,15 @@ func (e *Engine) previewDependencies(ctx context.Context, deps []DependencyInfo,
 		e.msg("[dry-run] Would create %d dependencies", wouldCreate)
 	}
 	return 0
+}
+
+func pendingDependencyPreviewKey(fromID, toID, depType string, source DependencySource) string {
+	return strings.Join([]string{
+		strings.TrimSpace(fromID),
+		strings.TrimSpace(toID),
+		strings.TrimSpace(depType),
+		string(source),
+	}, "\x00")
 }
 
 func (e *Engine) dependencyIssueResolver(ctx context.Context, extraIssues []*types.Issue) (func(context.Context, string) (*types.Issue, error), error) {

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -62,6 +62,7 @@ type mockTracker struct {
 	createFailAfter int // fail after this many successful creates (0 = fail immediately)
 	updateErr       error
 	fieldMapper     FieldMapper
+	fetchIssues     func(context.Context, FetchOptions) ([]TrackerIssue, error)
 }
 
 type mockExternalRefTracker struct {
@@ -156,9 +157,12 @@ func (m *mockBatchTracker) BatchPushDryRun(_ context.Context, issues []*types.Is
 	return &BatchPushResult{}, nil
 }
 
-func (m *mockTracker) FetchIssues(_ context.Context, _ FetchOptions) ([]TrackerIssue, error) {
+func (m *mockTracker) FetchIssues(ctx context.Context, opts FetchOptions) ([]TrackerIssue, error) {
 	if m.fetchErr != nil {
 		return nil, m.fetchErr
+	}
+	if m.fetchIssues != nil {
+		return m.fetchIssues(ctx, opts)
 	}
 	return m.issues, nil
 }
@@ -2184,27 +2188,70 @@ func TestEngineCreateDependenciesResolvesExternalIdentifiers(t *testing.T) {
 	}
 }
 
+func TestEngineCreateDependenciesResolvesBareIdentifierFromExternalRef(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issues := []*types.Issue{
+		{ID: "bd-linear-child", Title: "Child", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+		{ID: "bd-linear-parent", Title: "Parent", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+	}
+	for _, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+	}
+	if err := store.UpdateIssue(ctx, "bd-linear-child", map[string]interface{}{"external_ref": "https://linear.app/team/issue/TEAM-101/child-title"}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue child external_ref: %v", err)
+	}
+	if err := store.UpdateIssue(ctx, "bd-linear-parent", map[string]interface{}{"external_ref": "https://linear.app/team/issue/TEAM-100/parent-title"}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue parent external_ref: %v", err)
+	}
+
+	base := newMockTracker("linear")
+	lt := &mockExternalRefTracker{
+		mockTracker: base,
+		extract: func(ref string) string {
+			parts := strings.Split(ref, "/issue/")
+			if len(parts) != 2 {
+				return ref
+			}
+			return strings.Split(parts[1], "/")[0]
+		},
+		isRef: func(ref string) bool {
+			return strings.Contains(ref, "linear.app/") && strings.Contains(ref, "/issue/")
+		},
+	}
+	engine := NewEngine(lt, store, "test-actor")
+
+	errCount := engine.createDependencies(ctx, []DependencyInfo{
+		{FromExternalID: "TEAM-101", ToExternalID: "TEAM-100", Type: string(types.DepParentChild)},
+	})
+	if errCount != 0 {
+		t.Fatalf("createDependencies returned errCount=%d, warnings=%v", errCount, engine.warnings)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, "bd-linear-child")
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 1 {
+		t.Fatalf("expected 1 dependency record, got %d", len(depRecords))
+	}
+	if depRecords[0].DependsOnID != "bd-linear-parent" || depRecords[0].Type != types.DepParentChild {
+		t.Fatalf("dependency = %s -> %s (%s), want bd-linear-child -> bd-linear-parent (%s)",
+			depRecords[0].IssueID, depRecords[0].DependsOnID, depRecords[0].Type, types.DepParentChild)
+	}
+}
+
 func TestEnginePullCreatesDependenciesForUnchangedIssues(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)
 	defer store.Close()
 
-	issue1 := &types.Issue{
-		ID:          "bd-unchanged-1",
-		Title:       "Blocked issue",
-		Description: "already pulled",
-		Status:      types.StatusOpen,
-		IssueType:   types.TypeTask,
-		Priority:    2,
-	}
-	issue2 := &types.Issue{
-		ID:          "bd-unchanged-2",
-		Title:       "Blocker issue",
-		Description: "already pulled",
-		Status:      types.StatusOpen,
-		IssueType:   types.TypeTask,
-		Priority:    2,
-	}
+	issue1 := &types.Issue{ID: "bd-unchanged-1", Title: "Blocked issue", Description: "already pulled", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2}
+	issue2 := &types.Issue{ID: "bd-unchanged-2", Title: "Blocker issue", Description: "already pulled", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2}
 	for _, issue := range []*types.Issue{issue1, issue2} {
 		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
 			t.Fatalf("CreateIssue error: %v", err)
@@ -2245,6 +2292,131 @@ func TestEnginePullCreatesDependenciesForUnchangedIssues(t *testing.T) {
 	}
 	if len(depRecords) != 1 || depRecords[0].DependsOnID != issue2.ID {
 		t.Fatalf("dependency records = %+v, want %s -> %s", depRecords, issue1.ID, issue2.ID)
+	}
+}
+
+func TestEnginePullDoesNotCreateDependenciesForLocallyModifiedSkippedIssue(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	lastSync := time.Now().UTC().Add(-1 * time.Hour)
+	if err := store.SetLocalMetadata(ctx, "test.last_sync", lastSync.Format(time.RFC3339)); err != nil {
+		t.Fatalf("SetLocalMetadata error: %v", err)
+	}
+	child := &types.Issue{
+		ID:          "bd-local-child",
+		Title:       "Local child",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		ExternalRef: strPtr("https://test.test/EXT-1"),
+		CreatedAt:   lastSync.Add(-2 * time.Hour),
+		UpdatedAt:   lastSync.Add(30 * time.Minute),
+	}
+	parent := &types.Issue{
+		ID:          "bd-local-parent",
+		Title:       "Parent",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		ExternalRef: strPtr("https://test.test/EXT-2"),
+		CreatedAt:   lastSync.Add(-2 * time.Hour),
+		UpdatedAt:   lastSync.Add(-30 * time.Minute),
+	}
+	for _, issue := range []*types.Issue{child, parent} {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{Identifier: "EXT-1", Title: "Remote child", UpdatedAt: lastSync.Add(10 * time.Minute)},
+		{Identifier: "EXT-2", Title: "Parent", UpdatedAt: lastSync.Add(10 * time.Minute)},
+	}
+	tracker.fieldMapper = &mockMapper{issueToBeads: func(ti *TrackerIssue) *IssueConversion {
+		conv := (&mockMapper{}).IssueToBeads(ti)
+		if ti.Identifier == "EXT-1" {
+			conv.Dependencies = []DependencyInfo{
+				{FromExternalID: "EXT-1", ToExternalID: "EXT-2", Type: string(types.DepBlocks)},
+			}
+		}
+		return conv
+	}}
+
+	engine := NewEngine(tracker, store, "test-actor")
+	if _, err := engine.Sync(ctx, SyncOptions{Pull: true}); err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, child.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 0 {
+		t.Fatalf("dependency records = %+v, want none for locally modified skipped issue", depRecords)
+	}
+}
+
+func TestEnginePullDryRunPreviewsDependencies(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issue1 := &types.Issue{ID: "bd-dry-child", Title: "Child", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2}
+	issue2 := &types.Issue{ID: "bd-dry-blocker", Title: "Blocker", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2}
+	for _, issue := range []*types.Issue{issue1, issue2} {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+		ref := "https://test.test/EXT-2"
+		if issue.ID == "bd-dry-child" {
+			ref = "https://test.test/EXT-1"
+		}
+		if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"external_ref": ref}, "test-actor"); err != nil {
+			t.Fatalf("UpdateIssue external_ref: %v", err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{Identifier: "EXT-1", Title: issue1.Title},
+		{Identifier: "EXT-2", Title: issue2.Title},
+	}
+	tracker.fieldMapper = &mockMapper{issueToBeads: func(ti *TrackerIssue) *IssueConversion {
+		conv := (&mockMapper{}).IssueToBeads(ti)
+		if ti.Identifier == "EXT-1" {
+			conv.Dependencies = []DependencyInfo{
+				{FromExternalID: "EXT-1", ToExternalID: "EXT-2", Type: string(types.DepBlocks)},
+			}
+		}
+		return conv
+	}}
+
+	var messages []string
+	engine := NewEngine(tracker, store, "test-actor")
+	engine.OnMessage = func(msg string) { messages = append(messages, msg) }
+	if _, err := engine.Sync(ctx, SyncOptions{Pull: true, DryRun: true}); err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, issue1.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 0 {
+		t.Fatalf("dependency records = %+v, want none in dry-run", depRecords)
+	}
+	found := false
+	for _, msg := range messages {
+		if strings.Contains(msg, "Would create 1 dependencies") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("dry-run messages = %v, want dependency summary", messages)
 	}
 }
 
@@ -2303,6 +2475,90 @@ func TestEnginePullFiltersDependencyTypes(t *testing.T) {
 	if depRecords[0].DependsOnID != "bd-filter-parent" || depRecords[0].Type != types.DepParentChild {
 		t.Fatalf("dependency = %s -> %s (%s), want bd-filter-child -> bd-filter-parent (%s)",
 			depRecords[0].IssueID, depRecords[0].DependsOnID, depRecords[0].Type, types.DepParentChild)
+	}
+}
+
+func TestEnginePullHydratesNewPrelinkedExternalRefAfterLastSync(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	lastSync := time.Now().UTC().Add(-2 * time.Hour)
+	if err := store.SetLocalMetadata(ctx, "linear.last_sync", lastSync.Format(time.RFC3339)); err != nil {
+		t.Fatalf("SetLocalMetadata error: %v", err)
+	}
+	localRef := "https://linear.app/team/issue/TEAM-123/stub"
+	local := &types.Issue{
+		ID:          "bd-prelinked-after-sync",
+		Title:       "Local stub",
+		Description: "stub",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		ExternalRef: strPtr(localRef),
+		CreatedAt:   lastSync.Add(30 * time.Minute),
+		UpdatedAt:   lastSync.Add(30 * time.Minute),
+	}
+	if err := store.CreateIssue(ctx, local, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue error: %v", err)
+	}
+
+	base := newMockTracker("linear")
+	base.issues = []TrackerIssue{{
+		ID:          "linear-internal-123",
+		Identifier:  "TEAM-123",
+		URL:         "https://linear.app/team/issue/TEAM-123/remote-title",
+		Title:       "Remote title",
+		Description: "Remote description",
+		Priority:    1,
+		UpdatedAt:   lastSync.Add(-30 * time.Minute),
+	}}
+	base.fetchIssues = func(_ context.Context, opts FetchOptions) ([]TrackerIssue, error) {
+		if opts.Since == nil {
+			return base.issues, nil
+		}
+		return nil, nil
+	}
+	lt := &mockExternalRefTracker{
+		mockTracker: base,
+		buildRef: func(issue *TrackerIssue) string {
+			return "https://linear.app/team/issue/" + issue.Identifier
+		},
+		extract: func(ref string) string {
+			parts := strings.Split(ref, "/issue/")
+			if len(parts) != 2 {
+				return ""
+			}
+			return strings.Split(parts[1], "/")[0]
+		},
+		isRef: func(ref string) bool {
+			return strings.Contains(ref, "linear.app/") && strings.Contains(ref, "/issue/")
+		},
+	}
+
+	engine := NewEngine(lt, store, "test-actor")
+	engine.PushHooks = &PushHooks{ContentEqual: func(local *types.Issue, remote *TrackerIssue) bool {
+		return local.Title == remote.Title && local.Description == remote.Description
+	}}
+	result, err := engine.Sync(ctx, SyncOptions{Pull: true, Push: true})
+	if err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+	if result.PullStats.Updated != 1 {
+		t.Fatalf("PullStats = %+v, want one hydrated update", result.PullStats)
+	}
+	if len(base.updated) != 0 {
+		t.Fatalf("pushed updates = %+v, want none after hydration", base.updated)
+	}
+	got, err := store.GetIssue(ctx, local.ID)
+	if err != nil {
+		t.Fatalf("GetIssue error: %v", err)
+	}
+	if got.Title != "Remote title" || got.Description != "Remote description" {
+		t.Fatalf("hydrated issue = %q/%q, want remote content", got.Title, got.Description)
+	}
+	if got.ExternalRef == nil || *got.ExternalRef != "https://linear.app/team/issue/TEAM-123" {
+		t.Fatalf("external_ref = %#v, want canonical prelinked ref", got.ExternalRef)
 	}
 }
 

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -2585,7 +2585,7 @@ func TestEnginePreviewDependenciesDedupesPendingRelations(t *testing.T) {
 			FromExternalID: "EXT-PREVIEW-1",
 			ToExternalID:   "EXT-PREVIEW-2",
 			Type:           string(types.DepRelated),
-			Source:         DependencySourceRelation,
+			Source:         DependencySourceParent,
 		},
 	}, nil)
 	if errCount != 0 {

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -58,6 +58,7 @@ type mockTracker struct {
 	created         []*types.Issue
 	updated         map[string]*types.Issue
 	fetchErr        error
+	fetchIssueErr   error
 	createErr       error
 	createFailAfter int // fail after this many successful creates (0 = fail immediately)
 	updateErr       error
@@ -168,6 +169,9 @@ func (m *mockTracker) FetchIssues(ctx context.Context, opts FetchOptions) ([]Tra
 }
 
 func (m *mockTracker) FetchIssue(_ context.Context, identifier string) (*TrackerIssue, error) {
+	if m.fetchIssueErr != nil {
+		return nil, m.fetchIssueErr
+	}
 	if m.fetchErr != nil {
 		return nil, m.fetchErr
 	}
@@ -2559,6 +2563,168 @@ func TestEnginePullHydratesNewPrelinkedExternalRefAfterLastSync(t *testing.T) {
 	}
 	if got.ExternalRef == nil || *got.ExternalRef != "https://linear.app/team/issue/TEAM-123" {
 		t.Fatalf("external_ref = %#v, want canonical prelinked ref", got.ExternalRef)
+	}
+}
+
+func TestEnginePullHydratesOlderIssueWhenExternalRefAddedAfterLastSync(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	local := &types.Issue{
+		ID:          "bd-prelinked-existing",
+		Title:       "Local stub",
+		Description: "stub",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		CreatedAt:   time.Now().UTC().Add(-4 * time.Hour),
+		UpdatedAt:   time.Now().UTC().Add(-4 * time.Hour),
+	}
+	if err := store.CreateIssue(ctx, local, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue error: %v", err)
+	}
+
+	lastSync := time.Now().UTC()
+	if err := store.SetLocalMetadata(ctx, "linear.last_sync", lastSync.Format(time.RFC3339Nano)); err != nil {
+		t.Fatalf("SetLocalMetadata error: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	localRef := "https://linear.app/team/issue/TEAM-456/stub"
+	if err := store.UpdateIssue(ctx, local.ID, map[string]interface{}{"external_ref": localRef}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue external_ref error: %v", err)
+	}
+
+	base := newMockTracker("linear")
+	base.issues = []TrackerIssue{{
+		ID:          "linear-internal-456",
+		Identifier:  "TEAM-456",
+		URL:         "https://linear.app/team/issue/TEAM-456/remote-title",
+		Title:       "Remote title",
+		Description: "Remote description",
+		Priority:    1,
+		UpdatedAt:   lastSync.Add(-30 * time.Minute),
+	}}
+	base.fetchIssues = func(_ context.Context, opts FetchOptions) ([]TrackerIssue, error) {
+		if opts.Since == nil {
+			return base.issues, nil
+		}
+		return nil, nil
+	}
+	lt := &mockExternalRefTracker{
+		mockTracker: base,
+		buildRef: func(issue *TrackerIssue) string {
+			return "https://linear.app/team/issue/" + issue.Identifier
+		},
+		extract: func(ref string) string {
+			parts := strings.Split(ref, "/issue/")
+			if len(parts) != 2 {
+				return ""
+			}
+			return strings.Split(parts[1], "/")[0]
+		},
+		isRef: func(ref string) bool {
+			return strings.Contains(ref, "linear.app/") && strings.Contains(ref, "/issue/")
+		},
+	}
+
+	engine := NewEngine(lt, store, "test-actor")
+	result, err := engine.Sync(ctx, SyncOptions{Pull: true})
+	if err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+	if result.PullStats.Updated != 1 {
+		t.Fatalf("PullStats = %+v, want one hydrated update", result.PullStats)
+	}
+	got, err := store.GetIssue(ctx, local.ID)
+	if err != nil {
+		t.Fatalf("GetIssue error: %v", err)
+	}
+	if got.Title != "Remote title" || got.Description != "Remote description" {
+		t.Fatalf("hydrated issue = %q/%q, want remote content", got.Title, got.Description)
+	}
+	if got.ExternalRef == nil || *got.ExternalRef != "https://linear.app/team/issue/TEAM-456" {
+		t.Fatalf("external_ref = %#v, want canonical prelinked ref", got.ExternalRef)
+	}
+}
+
+func TestEngineSyncPrelinkedHydrationFailureStopsPushAndLastSync(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	local := &types.Issue{
+		ID:          "bd-prelinked-failure",
+		Title:       "Local stub",
+		Description: "stub",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		CreatedAt:   time.Now().UTC().Add(-4 * time.Hour),
+		UpdatedAt:   time.Now().UTC().Add(-4 * time.Hour),
+	}
+	if err := store.CreateIssue(ctx, local, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue error: %v", err)
+	}
+
+	lastSync := time.Now().UTC()
+	lastSyncStr := lastSync.Format(time.RFC3339Nano)
+	if err := store.SetLocalMetadata(ctx, "linear.last_sync", lastSyncStr); err != nil {
+		t.Fatalf("SetLocalMetadata error: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	localRef := "https://linear.app/team/issue/TEAM-789/stub"
+	if err := store.UpdateIssue(ctx, local.ID, map[string]interface{}{"external_ref": localRef}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue external_ref error: %v", err)
+	}
+
+	base := newMockTracker("linear")
+	base.fetchIssueErr = fmt.Errorf("linear fetch failed")
+	base.fetchIssues = func(_ context.Context, opts FetchOptions) ([]TrackerIssue, error) {
+		if opts.Since == nil {
+			return base.issues, nil
+		}
+		return nil, nil
+	}
+	lt := &mockExternalRefTracker{
+		mockTracker: base,
+		buildRef: func(issue *TrackerIssue) string {
+			return "https://linear.app/team/issue/" + issue.Identifier
+		},
+		extract: func(ref string) string {
+			parts := strings.Split(ref, "/issue/")
+			if len(parts) != 2 {
+				return ""
+			}
+			return strings.Split(parts[1], "/")[0]
+		},
+		isRef: func(ref string) bool {
+			return strings.Contains(ref, "linear.app/") && strings.Contains(ref, "/issue/")
+		},
+	}
+
+	engine := NewEngine(lt, store, "test-actor")
+	result, err := engine.Sync(ctx, SyncOptions{Pull: true, Push: true})
+	if err == nil {
+		t.Fatalf("Sync error = nil, want hydration failure")
+	}
+	if result == nil || result.Success {
+		t.Fatalf("result = %+v, want unsuccessful result", result)
+	}
+	if !strings.Contains(err.Error(), "hydrating pre-linked linear issues") {
+		t.Fatalf("Sync error = %v, want hydration context", err)
+	}
+	if len(base.created) != 0 || len(base.updated) != 0 {
+		t.Fatalf("push ran after hydration failure: created=%d updated=%d", len(base.created), len(base.updated))
+	}
+	gotLastSync, err := store.GetLocalMetadata(ctx, "linear.last_sync")
+	if err != nil {
+		t.Fatalf("GetLocalMetadata error: %v", err)
+	}
+	if gotLastSync != lastSyncStr {
+		t.Fatalf("last_sync = %q, want unchanged %q", gotLastSync, lastSyncStr)
 	}
 }
 

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -603,6 +603,84 @@ func TestEnginePullOnly(t *testing.T) {
 	}
 }
 
+func TestEnginePullUsesPrelinkedExternalRefIdentifier(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	localRef := "https://linear.app/team/issue/TEAM-123/fix-login"
+	local := &types.Issue{
+		ID:          "bd-linear-prelink",
+		Title:       "Fix login",
+		Description: "Local draft",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+		ExternalRef: strPtr(localRef),
+	}
+	if err := store.CreateIssue(ctx, local, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue() error: %v", err)
+	}
+
+	base := newMockTracker("linear")
+	base.issues = []TrackerIssue{{
+		ID:          "linear-internal-123",
+		Identifier:  "TEAM-123",
+		URL:         "https://linear.app/team/issue/TEAM-123/renamed-login-fix",
+		Title:       "Fix login",
+		Description: "Linear copy",
+		Priority:    2,
+		UpdatedAt:   time.Now(),
+	}}
+	lt := &mockExternalRefTracker{
+		mockTracker: base,
+		buildRef: func(issue *TrackerIssue) string {
+			return "https://linear.app/team/issue/" + issue.Identifier
+		},
+		extract: func(ref string) string {
+			parts := strings.Split(ref, "/issue/")
+			if len(parts) != 2 {
+				return ""
+			}
+			return strings.Split(parts[1], "/")[0]
+		},
+		isRef: func(ref string) bool {
+			return strings.Contains(ref, "linear.app/") && strings.Contains(ref, "/issue/")
+		},
+	}
+
+	engine := NewEngine(lt, store, "test-actor")
+	result, err := engine.Sync(ctx, SyncOptions{Pull: true})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if result.PullStats.Created != 0 || result.PullStats.Updated != 1 {
+		t.Fatalf("PullStats = %+v, want Created=0 Updated=1", result.PullStats)
+	}
+
+	issues, err := store.SearchIssues(ctx, "", types.IssueFilter{ExternalRefContains: "TEAM-123"})
+	if err != nil {
+		t.Fatalf("SearchIssues() error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues linked to TEAM-123 = %d, want 1", len(issues))
+	}
+	got, err := store.GetIssue(ctx, local.ID)
+	if err != nil {
+		t.Fatalf("GetIssue() error: %v", err)
+	}
+	wantRef := "https://linear.app/team/issue/TEAM-123"
+	if got.ExternalRef == nil || *got.ExternalRef != wantRef {
+		t.Fatalf("external_ref = %#v, want %q", got.ExternalRef, wantRef)
+	}
+	if got.Description != "Linear copy" {
+		t.Fatalf("description = %q, want Linear copy", got.Description)
+	}
+}
+
 func TestEnginePushOnly(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -2482,6 +2482,131 @@ func TestEnginePullFiltersDependencyTypes(t *testing.T) {
 	}
 }
 
+func TestEnginePullFiltersLinearRelationsBySource(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issues := []*types.Issue{
+		{ID: "bd-source-child", Title: "Child", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+		{ID: "bd-source-parent", Title: "Parent", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+		{ID: "bd-source-related-parent", Title: "Related parent", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+	}
+	for i, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+		ref := fmt.Sprintf("https://test.test/EXT-SRC-%d", i+1)
+		if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"external_ref": ref}, "test-actor"); err != nil {
+			t.Fatalf("UpdateIssue external_ref: %v", err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{Identifier: "EXT-SRC-1", Title: "Child"},
+		{Identifier: "EXT-SRC-2", Title: "Parent"},
+		{Identifier: "EXT-SRC-3", Title: "Related parent"},
+	}
+	tracker.fieldMapper = &mockMapper{issueToBeads: func(ti *TrackerIssue) *IssueConversion {
+		conv := (&mockMapper{}).IssueToBeads(ti)
+		if ti.Identifier == "EXT-SRC-1" {
+			conv.Dependencies = []DependencyInfo{
+				{
+					FromExternalID: "EXT-SRC-1",
+					ToExternalID:   "EXT-SRC-2",
+					Type:           string(types.DepParentChild),
+					Source:         DependencySourceParent,
+				},
+				{
+					FromExternalID: "EXT-SRC-1",
+					ToExternalID:   "EXT-SRC-3",
+					Type:           string(types.DepParentChild),
+					Source:         DependencySourceRelation,
+				},
+			}
+		}
+		return conv
+	}}
+
+	engine := NewEngine(tracker, store, "test-actor")
+	if _, err := engine.Sync(ctx, SyncOptions{
+		Pull:              true,
+		DependencySources: []DependencySource{DependencySourceParent},
+	}); err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, "bd-source-child")
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 1 {
+		t.Fatalf("expected 1 dependency record, got %d: %+v", len(depRecords), depRecords)
+	}
+	if depRecords[0].DependsOnID != "bd-source-parent" || depRecords[0].Type != types.DepParentChild {
+		t.Fatalf("dependency = %s -> %s (%s), want bd-source-child -> bd-source-parent (%s)",
+			depRecords[0].IssueID, depRecords[0].DependsOnID, depRecords[0].Type, types.DepParentChild)
+	}
+}
+
+func TestEnginePreviewDependenciesDedupesPendingRelations(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issues := []*types.Issue{
+		{ID: "bd-preview-source", Title: "Source", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+		{ID: "bd-preview-target", Title: "Target", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+	}
+	for i, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+		ref := fmt.Sprintf("https://test.test/EXT-PREVIEW-%d", i+1)
+		if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"external_ref": ref}, "test-actor"); err != nil {
+			t.Fatalf("UpdateIssue external_ref: %v", err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	var messages []string
+	engine := NewEngine(tracker, store, "test-actor")
+	engine.OnMessage = func(msg string) { messages = append(messages, msg) }
+
+	errCount := engine.previewDependencies(ctx, []DependencyInfo{
+		{
+			FromExternalID: "EXT-PREVIEW-1",
+			ToExternalID:   "EXT-PREVIEW-2",
+			Type:           string(types.DepRelated),
+			Source:         DependencySourceRelation,
+		},
+		{
+			FromExternalID: "EXT-PREVIEW-1",
+			ToExternalID:   "EXT-PREVIEW-2",
+			Type:           string(types.DepRelated),
+			Source:         DependencySourceRelation,
+		},
+	}, nil)
+	if errCount != 0 {
+		t.Fatalf("previewDependencies errCount = %d, want 0", errCount)
+	}
+
+	dependencyLines := 0
+	summaryFound := false
+	for _, msg := range messages {
+		if strings.Contains(msg, "Would create dependency:") {
+			dependencyLines++
+		}
+		if strings.Contains(msg, "Would create 1 dependencies") {
+			summaryFound = true
+		}
+	}
+	if dependencyLines != 1 || !summaryFound {
+		t.Fatalf("dry-run messages = %v, want one dependency preview and a one-dependency summary", messages)
+	}
+}
+
 func TestEnginePullHydratesNewPrelinkedExternalRefAfterLastSync(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/internal/tracker/types.go
+++ b/internal/tracker/types.go
@@ -94,6 +94,9 @@ type SyncOptions struct {
 	// DependencyTypes limits which dependency types pull creates from tracker
 	// mapper output. Empty means all dependency types are created.
 	DependencyTypes []types.DependencyType
+	// DependencySources limits which dependency sources pull creates from tracker
+	// mapper output. Empty means all dependency sources are created.
+	DependencySources []DependencySource
 }
 
 // SyncResult is the complete result of a sync operation.
@@ -193,4 +196,13 @@ type DependencyInfo struct {
 	FromExternalID string // External identifier of the dependent issue
 	ToExternalID   string // External identifier of the dependency target
 	Type           string // Beads dependency type (blocks, related, duplicates, parent-child)
+	Source         DependencySource
 }
+
+// DependencySource identifies which tracker relationship produced a dependency.
+type DependencySource string
+
+const (
+	DependencySourceParent   DependencySource = "parent"
+	DependencySourceRelation DependencySource = "relation"
+)


### PR DESCRIPTION
## Summary
- document `bd create --external-ref <linear-url>` as the supported Linear pre-link workflow
- clarify common `--external-ref` help text to include Linear URLs
- add regressions for creating a Linear external ref and for pull matching a pre-linked slugged Linear URL by identifier instead of creating a duplicate

## Tests
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedCreate$/linear_external_ref' -count=1`\n- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/tracker -run '^TestEnginePullUsesPrelinkedExternalRefIdentifier$' -count=1`\n- `make test`\n\nRefs #3254\nPart of bd-ly3