### PR TITLE
Import Linear relations as dependencies

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -488,8 +488,9 @@ func createGateIssue(step *formula.Step, parentID string) *types.Issue {
 
 	// Build title from gate type and ID
 	title := fmt.Sprintf("Gate: %s", step.Gate.Type)
-	if step.Gate.ID != "" {
-		title = fmt.Sprintf("Gate: %s %s", step.Gate.Type, step.Gate.ID)
+	awaitID := gateAwaitID(step.Gate)
+	if awaitID != "" {
+		title = fmt.Sprintf("Gate: %s %s", step.Gate.Type, awaitID)
 	}
 
 	// Parse timeout if specified
@@ -508,12 +509,22 @@ func createGateIssue(step *formula.Step, parentID string) *types.Issue {
 		Priority:    2,
 		IssueType:   "gate",
 		AwaitType:   step.Gate.Type,
-		AwaitID:     step.Gate.ID,
+		AwaitID:     awaitID,
 		Timeout:     timeout,
 		IsTemplate:  true,
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 	}
+}
+
+func gateAwaitID(gate *formula.Gate) string {
+	if gate == nil {
+		return ""
+	}
+	if gate.AwaitID != "" {
+		return gate.AwaitID
+	}
+	return gate.ID
 }
 
 // processStepToIssue converts a formula.Step to a types.Issue.
@@ -1029,12 +1040,18 @@ func substituteFormulaVars(f *formula.Formula, vars map[string]string) {
 	substituteStepVars(f.Steps, vars)
 }
 
-// substituteStepVars recursively substitutes variables in step titles and descriptions.
+// substituteStepVars recursively substitutes variables in step fields.
 func substituteStepVars(steps []*formula.Step, vars map[string]string) {
 	for _, step := range steps {
 		step.Title = substituteVariables(step.Title, vars)
 		step.Description = substituteVariables(step.Description, vars)
 		step.Notes = substituteVariables(step.Notes, vars)
+		if step.Gate != nil {
+			step.Gate.Type = substituteVariables(step.Gate.Type, vars)
+			step.Gate.ID = substituteVariables(step.Gate.ID, vars)
+			step.Gate.AwaitID = substituteVariables(step.Gate.AwaitID, vars)
+			step.Gate.Timeout = substituteVariables(step.Gate.Timeout, vars)
+		}
 		if len(step.Children) > 0 {
 			substituteStepVars(step.Children, vars)
 		}

--- a/cmd/bd/cook_test.go
+++ b/cmd/bd/cook_test.go
@@ -116,6 +116,43 @@ func TestSubstituteFormulaVars(t *testing.T) {
 	}
 }
 
+func TestSubstituteFormulaVars_GateFields(t *testing.T) {
+	f := &formula.Formula{
+		Steps: []*formula.Step{
+			{
+				ID: "wait-for-pr",
+				Gate: &formula.Gate{
+					Type:    "gh:{{kind}}",
+					ID:      "{{legacy_id}}",
+					AwaitID: "{{pr}}",
+					Timeout: "{{timeout}}",
+				},
+			},
+		},
+	}
+
+	substituteFormulaVars(f, map[string]string{
+		"kind":      "pr",
+		"legacy_id": "legacy-42",
+		"pr":        "https://github.com/org/repo/pull/123",
+		"timeout":   "1h",
+	})
+
+	gate := f.Steps[0].Gate
+	if gate.Type != "gh:pr" {
+		t.Errorf("Gate.Type = %q, want gh:pr", gate.Type)
+	}
+	if gate.ID != "legacy-42" {
+		t.Errorf("Gate.ID = %q, want legacy-42", gate.ID)
+	}
+	if gate.AwaitID != "https://github.com/org/repo/pull/123" {
+		t.Errorf("Gate.AwaitID = %q, want expanded PR URL", gate.AwaitID)
+	}
+	if gate.Timeout != "1h" {
+		t.Errorf("Gate.Timeout = %q, want 1h", gate.Timeout)
+	}
+}
+
 // TestSubstituteStepVarsRecursive tests deep nesting works correctly
 func TestSubstituteStepVarsRecursive(t *testing.T) {
 	steps := []*formula.Step{
@@ -206,7 +243,7 @@ func TestCreateGateIssue(t *testing.T) {
 		wantAwaitID   string
 	}{
 		{
-			name: "gh:run gate with ID",
+			name: "gh:run gate with legacy ID",
 			step: &formula.Step{
 				ID:    "await-ci",
 				Title: "Wait for CI",
@@ -220,6 +257,22 @@ func TestCreateGateIssue(t *testing.T) {
 			wantTitle:     "Gate: gh:run release-build",
 			wantAwaitType: "gh:run",
 			wantAwaitID:   "release-build",
+		},
+		{
+			name: "gh:pr gate with await_id",
+			step: &formula.Step{
+				ID:    "await-pr",
+				Title: "Wait for PR",
+				Gate: &formula.Gate{
+					Type:    "gh:pr",
+					AwaitID: "https://github.com/org/repo/pull/123",
+				},
+			},
+			parentID:      "mol-feature",
+			wantID:        "mol-feature.gate-await-pr",
+			wantTitle:     "Gate: gh:pr https://github.com/org/repo/pull/123",
+			wantAwaitType: "gh:pr",
+			wantAwaitID:   "https://github.com/org/repo/pull/123",
 		},
 		{
 			name: "gh:pr gate without ID",

--- a/cmd/bd/gate.go
+++ b/cmd/bd/gate.go
@@ -453,7 +453,7 @@ Gate types:
 
 GitHub gates use the 'gh' CLI to query status:
   - gh:run checks 'gh run view <id> --json status,conclusion'
-  - gh:pr checks 'gh pr view <id> --json state,merged'
+  - gh:pr checks 'gh pr view <id> --json state,title'
 
 A gate is resolved when:
   - gh:run: status=completed AND conclusion=success
@@ -635,9 +635,8 @@ type ghRunStatus struct {
 
 // ghPRStatus holds the JSON response from 'gh pr view'
 type ghPRStatus struct {
-	State  string `json:"state"`
-	Merged bool   `json:"merged"`
-	Title  string `json:"title"`
+	State string `json:"state"`
+	Title string `json:"title"`
 }
 
 var (
@@ -790,8 +789,8 @@ func checkGHPR(gate *types.Issue) (resolved, escalated bool, reason string, err 
 		return false, false, "no PR number specified", nil
 	}
 
-	// Run: gh pr view <id> --json state,merged,title
-	cmd := exec.Command("gh", "pr", "view", gate.AwaitID, "--json", "state,merged,title") // #nosec G204 -- gate.AwaitID is a validated GitHub PR number
+	// Run: gh pr view <id> --json state,title
+	cmd := exec.Command("gh", "pr", "view", gate.AwaitID, "--json", "state,title") // #nosec G204 -- gate.AwaitID is a validated GitHub PR number
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -819,9 +818,6 @@ func checkGHPR(gate *types.Issue) (resolved, escalated bool, reason string, err 
 	case "MERGED":
 		return true, false, fmt.Sprintf("PR '%s' was merged", status.Title), nil
 	case "CLOSED":
-		if status.Merged {
-			return true, false, fmt.Sprintf("PR '%s' was merged", status.Title), nil
-		}
 		return false, true, fmt.Sprintf("PR '%s' was closed without merging", status.Title), nil
 	case "OPEN":
 		return false, false, fmt.Sprintf("PR '%s' is still open", status.Title), nil

--- a/cmd/bd/gate_test.go
+++ b/cmd/bd/gate_test.go
@@ -199,6 +199,46 @@ func TestCheckBeadGate_TargetClosed(t *testing.T) {
 	t.Skip("SQLite-specific: created SQLite DB directly; full integration testing requires routes.jsonl + Dolt rig infrastructure")
 }
 
+func TestCheckGHPRUsesStateWithoutMergedField(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake gh shell script uses POSIX sh")
+	}
+
+	binDir := t.TempDir()
+	fakeGH := filepath.Join(binDir, "gh")
+	script := `#!/bin/sh
+case "$*" in
+  *merged*)
+    echo "unexpected merged field" >&2
+    exit 9
+    ;;
+esac
+printf '{"state":"MERGED","title":"Fix gate"}'
+`
+	if err := os.WriteFile(fakeGH, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	resolved, escalated, reason, err := checkGHPR(&types.Issue{
+		IssueType: "gate",
+		AwaitType: "gh:pr",
+		AwaitID:   "3488",
+	})
+	if err != nil {
+		t.Fatalf("checkGHPR returned error: %v", err)
+	}
+	if !resolved {
+		t.Fatal("expected merged PR to resolve")
+	}
+	if escalated {
+		t.Fatal("did not expect merged PR to escalate")
+	}
+	if !gateTestContains(reason, "was merged") {
+		t.Fatalf("reason = %q, want merged message", reason)
+	}
+}
+
 func TestIsNumericID(t *testing.T) {
 	tests := []struct {
 		input string

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -95,6 +95,7 @@ Type Filtering (--push only):
   --exclude-type wisp       Exclude issues of these types
   --include-ephemeral       Include ephemeral issues (wisps, etc.); default is to exclude
   --parent TICKET           Only push this ticket and its descendants
+  --relations               Import Linear relations as bd dependencies on pull
 
 Conflict Resolution:
   By default, newer timestamp wins. Override with:
@@ -103,6 +104,7 @@ Conflict Resolution:
 
 Examples:
   bd linear sync --pull                         # Import from Linear
+  bd linear sync --pull --relations             # Import Linear blocking relations as bd deps
   bd linear sync --push --create-only           # Push new issues only
   bd linear sync --push --type=task,feature     # Push only tasks and features
   bd linear sync --push --exclude-type=wisp     # Push all except wisps
@@ -152,6 +154,7 @@ func init() {
 	linearSyncCmd.Flags().Bool("include-ephemeral", false, "Include ephemeral issues (wisps, etc.) when pushing to Linear")
 	linearSyncCmd.Flags().String("parent", "", "Limit push to this beads ticket and its descendants")
 	linearSyncCmd.Flags().StringSlice("team", nil, "Team ID(s) to sync (overrides configured team_id/team_ids)")
+	linearSyncCmd.Flags().Bool("relations", false, "Import Linear relations as bd dependencies when pulling")
 	registerSelectiveSyncFlags(linearSyncCmd)
 
 	linearCmd.AddCommand(linearSyncCmd)
@@ -172,6 +175,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	excludeTypes, _ := cmd.Flags().GetStringSlice("exclude-type")
 	includeEphemeral, _ := cmd.Flags().GetBool("include-ephemeral")
 	cliTeams, _ := cmd.Flags().GetStringSlice("team")
+	relations, _ := cmd.Flags().GetBool("relations")
 
 	if !dryRun {
 		CheckReadonly("linear sync")
@@ -227,6 +231,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 		CreateOnly: createOnly,
 		State:      state,
 	}
+	opts.DependencyTypes = linearPullDependencyTypes(relations)
 
 	// Convert type filters
 	for _, t := range typeFilters {
@@ -291,6 +296,13 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 			}
 		}
 	}
+}
+
+func linearPullDependencyTypes(includeRelations bool) []types.DependencyType {
+	if includeRelations {
+		return nil
+	}
+	return []types.DependencyType{types.DepParentChild}
 }
 
 // buildLinearPullHooks creates PullHooks for Linear-specific pull behavior.

--- a/cmd/bd/sync_push_pull.go
+++ b/cmd/bd/sync_push_pull.go
@@ -168,6 +168,7 @@ func init() {
 	// Linear push/pull
 	linearPushCmd.Flags().Bool("dry-run", false, "Preview push without making changes")
 	linearPullCmd.Flags().Bool("dry-run", false, "Preview pull without making changes")
+	linearPullCmd.Flags().Bool("relations", false, "Import Linear relations as bd dependencies when pulling")
 	linearCmd.AddCommand(linearPushCmd)
 	linearCmd.AddCommand(linearPullCmd)
 
@@ -431,6 +432,7 @@ func runLinearPull(cmd *cobra.Command, args []string) {
 		FatalError("at least one bead ID or external reference is required")
 	}
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	relations, _ := cmd.Flags().GetBool("relations")
 	if !dryRun {
 		CheckReadonly("linear pull")
 	}
@@ -457,10 +459,11 @@ func runLinearPull(cmd *cobra.Command, args []string) {
 	engine.PullHooks = buildLinearPullHooks(ctx)
 
 	result, err := engine.Sync(ctx, tracker.SyncOptions{
-		Pull:     true,
-		Push:     false,
-		DryRun:   dryRun,
-		IssueIDs: args,
+		Pull:            true,
+		Push:            false,
+		DryRun:          dryRun,
+		IssueIDs:        args,
+		DependencyTypes: linearPullDependencyTypes(relations),
 	})
 	if err != nil {
 		FatalError("sync failed: %v", err)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -718,6 +718,12 @@ bd config set linear.relation_map.duplicate duplicates
 bd config set linear.relation_map.related related
 ```
 
+Relation import is opt-in when pulling:
+
+```bash
+bd linear sync --pull --relations
+```
+
 **Sync commands:**
 
 ```bash
@@ -726,6 +732,9 @@ bd linear sync
 
 # Pull only (import from Linear)
 bd linear sync --pull
+
+# Pull issues and Linear relations as bd dependencies
+bd linear sync --pull --relations
 
 # Push only (export to Linear)
 bd linear sync --push

--- a/examples/linear-workflow/README.md
+++ b/examples/linear-workflow/README.md
@@ -38,6 +38,9 @@ bd linear status
 # Pull issues from Linear
 bd linear sync --pull
 
+# Pull issues and Linear blocking relations as bd dependencies
+bd linear sync --pull --relations
+
 # Push local issues to Linear
 bd linear sync --push
 
@@ -76,6 +79,9 @@ Import issues from Linear without pushing local changes:
 
 ```bash
 bd linear sync --pull
+
+# Import Linear relations as bd dependencies
+bd linear sync --pull --relations
 
 # Filter by state
 bd linear sync --pull --state open    # Only open issues
@@ -199,6 +205,12 @@ bd config set linear.label_type_map.story feature
 ### Relation Mapping
 
 Map Linear relations to bd dependencies:
+
+Relation import is opt-in during pull:
+
+```bash
+bd linear sync --pull --relations
+```
 
 | Linear Relation | Beads Dependency |
 |-----------------|------------------|

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -388,6 +388,12 @@ func ExtractVariables(formula *Formula) []string {
 		extract(step.Description)
 		extract(step.Assignee)
 		extract(step.Condition)
+		if step.Gate != nil {
+			extract(step.Gate.Type)
+			extract(step.Gate.ID)
+			extract(step.Gate.AwaitID)
+			extract(step.Gate.Timeout)
+		}
 		for _, child := range step.Children {
 			extractFromStep(child)
 		}

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -432,11 +432,19 @@ func TestExtractVariables(t *testing.T) {
 		Steps: []*Step{
 			{ID: "s1", Title: "Deploy {{project}} to {{env}}"},
 			{ID: "s2", Title: "Notify {{owner}}"},
+			{ID: "s3", Gate: &Gate{Type: "gh:{{gate_kind}}", AwaitID: "{{pr_url}}", Timeout: "{{gate_timeout}}"}},
 		},
 	}
 
 	vars := ExtractVariables(formula)
-	want := map[string]bool{"project": true, "env": true, "owner": true}
+	want := map[string]bool{
+		"project":      true,
+		"env":          true,
+		"owner":        true,
+		"gate_kind":    true,
+		"pr_url":       true,
+		"gate_timeout": true,
+	}
 
 	if len(vars) != len(want) {
 		t.Errorf("ExtractVariables found %d vars, want %d", len(vars), len(want))
@@ -1262,6 +1270,7 @@ func TestParse_GateField(t *testing.T) {
       "gate": {
         "type": "gh:run",
         "id": "ci-tests",
+        "await_id": "12345",
         "timeout": "1h"
       }
     },
@@ -1290,6 +1299,9 @@ func TestParse_GateField(t *testing.T) {
 	if gate.ID != "ci-tests" {
 		t.Errorf("Gate.ID = %q, want 'ci-tests'", gate.ID)
 	}
+	if gate.AwaitID != "12345" {
+		t.Errorf("Gate.AwaitID = %q, want '12345'", gate.AwaitID)
+	}
 	if gate.Timeout != "1h" {
 		t.Errorf("Gate.Timeout = %q, want '1h'", gate.Timeout)
 	}
@@ -1306,6 +1318,7 @@ id = "wait-for-approval"
 title = "Wait for human approval"
 [steps.gate]
 type = "human"
+await_id = "approval-ticket"
 timeout = "24h"
 
 [[steps]]
@@ -1331,6 +1344,9 @@ depends_on = ["wait-for-approval"]
 	}
 	if gate.Type != "human" {
 		t.Errorf("Gate.Type = %q, want 'human'", gate.Type)
+	}
+	if gate.AwaitID != "approval-ticket" {
+		t.Errorf("Gate.AwaitID = %q, want 'approval-ticket'", gate.AwaitID)
 	}
 	if gate.Timeout != "24h" {
 		t.Errorf("Gate.Timeout = %q, want '24h'", gate.Timeout)

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -283,6 +283,10 @@ type Gate struct {
 	// ID is the condition identifier (e.g., workflow name for gh:run).
 	ID string `json:"id,omitempty"`
 
+	// AwaitID is the runtime condition identifier. This is preferred by
+	// formula authors because it maps directly to Issue.AwaitID.
+	AwaitID string `json:"await_id,omitempty" toml:"await_id,omitempty"`
+
 	// Timeout is how long to wait before escalation (e.g., "1h", "24h").
 	Timeout string `json:"timeout,omitempty"`
 }

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -409,6 +409,10 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 			}
 		}
 
+		if !opts.DryRun {
+			pendingDeps = appendFilteredDependencies(pendingDeps, conv.Dependencies, opts.DependencyTypes)
+		}
+
 		if existing != nil && pullIssueEqual(existing, conv.Issue, ref) {
 			stats.Skipped++
 			continue
@@ -464,7 +468,6 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 			stats.Created++
 		}
 
-		pendingDeps = append(pendingDeps, conv.Dependencies...)
 	}
 
 	// Create dependencies after all issues are imported
@@ -527,6 +530,25 @@ func marshalTrackerMetadata(metadata interface{}) (json.RawMessage, bool) {
 		return nil, false
 	}
 	return json.RawMessage(raw), true
+}
+
+func appendFilteredDependencies(dst []DependencyInfo, deps []DependencyInfo, allowedTypes []types.DependencyType) []DependencyInfo {
+	if len(deps) == 0 {
+		return dst
+	}
+	if len(allowedTypes) == 0 {
+		return append(dst, deps...)
+	}
+	allowed := make(map[string]struct{}, len(allowedTypes))
+	for _, depType := range allowedTypes {
+		allowed[string(depType)] = struct{}{}
+	}
+	for _, dep := range deps {
+		if _, ok := allowed[dep.Type]; ok {
+			dst = append(dst, dep)
+		}
+	}
+	return dst
 }
 
 func syncIssueLabels(ctx context.Context, tx storage.Transaction, issueID string, desired []string, actor string) error {
@@ -952,15 +974,21 @@ func (e *Engine) createDependencies(ctx context.Context, deps []DependencyInfo) 
 		return 0
 	}
 
+	resolveIssue, err := e.dependencyIssueResolver(ctx)
+	if err != nil {
+		e.warn("Failed to build dependency resolver: %v", err)
+		return len(deps)
+	}
+
 	errCount := 0
 	for _, dep := range deps {
-		fromIssue, err := e.Store.GetIssueByExternalRef(ctx, dep.FromExternalID)
+		fromIssue, err := resolveIssue(ctx, dep.FromExternalID)
 		if err != nil {
 			e.warn("Failed to resolve dependency source %s: %v", dep.FromExternalID, err)
 			errCount++
 			continue
 		}
-		toIssue, err := e.Store.GetIssueByExternalRef(ctx, dep.ToExternalID)
+		toIssue, err := resolveIssue(ctx, dep.ToExternalID)
 		if err != nil {
 			e.warn("Failed to resolve dependency target %s: %v", dep.ToExternalID, err)
 			errCount++
@@ -982,6 +1010,46 @@ func (e *Engine) createDependencies(ctx context.Context, deps []DependencyInfo) 
 		}
 	}
 	return errCount
+}
+
+func (e *Engine) dependencyIssueResolver(ctx context.Context) (func(context.Context, string) (*types.Issue, error), error) {
+	issues, searchErr := e.Store.SearchIssues(ctx, "", types.IssueFilter{})
+	if searchErr != nil {
+		return nil, searchErr
+	}
+	byExternal := make(map[string]*types.Issue, len(issues)*2)
+	for _, candidate := range issues {
+		if candidate == nil || candidate.ExternalRef == nil {
+			continue
+		}
+		ref := strings.TrimSpace(*candidate.ExternalRef)
+		if ref == "" || !e.Tracker.IsExternalRef(ref) {
+			continue
+		}
+		byExternal[ref] = candidate
+		identifier := strings.TrimSpace(e.Tracker.ExtractIdentifier(ref))
+		if identifier != "" {
+			byExternal[identifier] = candidate
+			byExternal[strings.ToLower(identifier)] = candidate
+		}
+	}
+
+	return func(ctx context.Context, externalID string) (*types.Issue, error) {
+		externalID = strings.TrimSpace(externalID)
+		if externalID == "" {
+			return nil, nil
+		}
+		if issue := byExternal[externalID]; issue != nil {
+			return issue, nil
+		}
+		if issue := byExternal[strings.ToLower(externalID)]; issue != nil {
+			return issue, nil
+		}
+		if strings.Contains(externalID, "://") {
+			return e.Store.GetIssueByExternalRef(ctx, externalID)
+		}
+		return nil, nil
+	}, nil
 }
 
 // buildDescendantSet returns the set of issue IDs consisting of the given parent

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -2037,6 +2037,197 @@ func TestEngineCreateDependencies(t *testing.T) {
 	}
 }
 
+func TestEngineCreateDependenciesResolvesExternalIdentifiers(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issue1 := &types.Issue{
+		ID:        "bd-linear-blocked",
+		Title:     "Blocked issue",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		Priority:  2,
+	}
+	issue2 := &types.Issue{
+		ID:        "bd-linear-blocker",
+		Title:     "Blocker issue",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		Priority:  2,
+	}
+	for _, issue := range []*types.Issue{issue1, issue2} {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+	}
+	if err := store.UpdateIssue(ctx, issue1.ID, map[string]interface{}{"external_ref": "https://linear.app/team/issue/TEAM-101/blocked-issue"}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue issue1 external_ref: %v", err)
+	}
+	if err := store.UpdateIssue(ctx, issue2.ID, map[string]interface{}{"external_ref": "https://linear.app/team/issue/TEAM-100/blocker-issue"}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue issue2 external_ref: %v", err)
+	}
+
+	engine := NewEngine(&mockExternalRefTracker{
+		mockTracker: newMockTracker("linear"),
+		isRef: func(ref string) bool {
+			return strings.Contains(ref, "linear.app")
+		},
+		extract: func(ref string) string {
+			parts := strings.Split(ref, "/")
+			for _, part := range parts {
+				if strings.HasPrefix(part, "TEAM-") {
+					return part
+				}
+			}
+			return ref
+		},
+	}, store, "test-actor")
+
+	deps := []DependencyInfo{
+		{FromExternalID: "TEAM-101", ToExternalID: "TEAM-100", Type: string(types.DepBlocks)},
+	}
+	errCount := engine.createDependencies(ctx, deps)
+	if errCount != 0 {
+		t.Errorf("createDependencies returned errCount=%d, want 0; warnings=%v", errCount, engine.warnings)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, issue1.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 1 {
+		t.Fatalf("expected 1 dependency record, got %d", len(depRecords))
+	}
+	if depRecords[0].DependsOnID != issue2.ID || depRecords[0].Type != types.DepBlocks {
+		t.Errorf("dependency = %s -> %s (%s), want %s -> %s (%s)",
+			depRecords[0].IssueID, depRecords[0].DependsOnID, depRecords[0].Type,
+			issue1.ID, issue2.ID, types.DepBlocks)
+	}
+}
+
+func TestEnginePullCreatesDependenciesForUnchangedIssues(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issue1 := &types.Issue{
+		ID:          "bd-unchanged-1",
+		Title:       "Blocked issue",
+		Description: "already pulled",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+	}
+	issue2 := &types.Issue{
+		ID:          "bd-unchanged-2",
+		Title:       "Blocker issue",
+		Description: "already pulled",
+		Status:      types.StatusOpen,
+		IssueType:   types.TypeTask,
+		Priority:    2,
+	}
+	for _, issue := range []*types.Issue{issue1, issue2} {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+		ref := fmt.Sprintf("https://test.test/EXT-%s", strings.TrimPrefix(issue.ID, "bd-unchanged-"))
+		if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"external_ref": ref}, "test-actor"); err != nil {
+			t.Fatalf("UpdateIssue external_ref: %v", err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{Identifier: "EXT-1", Title: issue1.Title, Description: issue1.Description},
+		{Identifier: "EXT-2", Title: issue2.Title, Description: issue2.Description},
+	}
+	tracker.fieldMapper = &mockMapper{issueToBeads: func(ti *TrackerIssue) *IssueConversion {
+		conv := (&mockMapper{}).IssueToBeads(ti)
+		if ti.Identifier == "EXT-1" {
+			conv.Dependencies = []DependencyInfo{
+				{FromExternalID: "EXT-1", ToExternalID: "EXT-2", Type: string(types.DepBlocks)},
+			}
+		}
+		return conv
+	}}
+
+	engine := NewEngine(tracker, store, "test-actor")
+	result, err := engine.Sync(ctx, SyncOptions{Pull: true})
+	if err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+	if result.PullStats.Updated != 0 || result.PullStats.Created != 0 {
+		t.Fatalf("PullStats = %+v, want only skipped unchanged issues", result.PullStats)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, issue1.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 1 || depRecords[0].DependsOnID != issue2.ID {
+		t.Fatalf("dependency records = %+v, want %s -> %s", depRecords, issue1.ID, issue2.ID)
+	}
+}
+
+func TestEnginePullFiltersDependencyTypes(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issues := []*types.Issue{
+		{ID: "bd-filter-child", Title: "Child", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+		{ID: "bd-filter-parent", Title: "Parent", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+		{ID: "bd-filter-blocker", Title: "Blocker", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+	}
+	for i, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+		ref := fmt.Sprintf("https://test.test/EXT-%d", i+1)
+		if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{"external_ref": ref}, "test-actor"); err != nil {
+			t.Fatalf("UpdateIssue external_ref: %v", err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{Identifier: "EXT-1", Title: "Child"},
+		{Identifier: "EXT-2", Title: "Parent"},
+		{Identifier: "EXT-3", Title: "Blocker"},
+	}
+	tracker.fieldMapper = &mockMapper{issueToBeads: func(ti *TrackerIssue) *IssueConversion {
+		conv := (&mockMapper{}).IssueToBeads(ti)
+		if ti.Identifier == "EXT-1" {
+			conv.Dependencies = []DependencyInfo{
+				{FromExternalID: "EXT-1", ToExternalID: "EXT-2", Type: string(types.DepParentChild)},
+				{FromExternalID: "EXT-1", ToExternalID: "EXT-3", Type: string(types.DepBlocks)},
+			}
+		}
+		return conv
+	}}
+
+	engine := NewEngine(tracker, store, "test-actor")
+	if _, err := engine.Sync(ctx, SyncOptions{
+		Pull:            true,
+		DependencyTypes: []types.DependencyType{types.DepParentChild},
+	}); err != nil {
+		t.Fatalf("Sync error: %v", err)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, "bd-filter-child")
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 1 {
+		t.Fatalf("expected 1 dependency record, got %d: %+v", len(depRecords), depRecords)
+	}
+	if depRecords[0].DependsOnID != "bd-filter-parent" || depRecords[0].Type != types.DepParentChild {
+		t.Fatalf("dependency = %s -> %s (%s), want bd-filter-child -> bd-filter-parent (%s)",
+			depRecords[0].IssueID, depRecords[0].DependsOnID, depRecords[0].Type, types.DepParentChild)
+	}
+}
+
 func TestEngineCreateDependencies_UnresolvableRef(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/internal/tracker/types.go
+++ b/internal/tracker/types.go
@@ -91,6 +91,9 @@ type SyncOptions struct {
 	// or external refs (e.g. "EXT-456"). When non-empty, push filters local issues
 	// by ID and pull uses FetchIssue() for targeted retrieval instead of bulk fetch.
 	IssueIDs []string
+	// DependencyTypes limits which dependency types pull creates from tracker
+	// mapper output. Empty means all dependency types are created.
+	DependencyTypes []types.DependencyType
 }
 
 // SyncResult is the complete result of a sync operation.


### PR DESCRIPTION
## Summary
- add Linear `--relations` opt-in for importing relation edges during pull
- resolve pulled dependency endpoints by tracker identifier (for example `TEAM-123`) as well as exact external_ref URL
- queue dependency creation even when pulled issues are otherwise unchanged, so existing mirrors can repair their graph
- document Linear relation import in config and workflow docs

## Tests
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/tracker -run 'TestEngine(CreateDependencies|PullCreatesDependencies)'`
- `go test -tags gms_pure_go ./internal/linear ./cmd/bd -run 'TestLinear(RelationToBeadsDep|IssueToBeads|RoundTripCoreFields)|TestRelationToBeadsDep'`
- `make test`
- `GOFLAGS='-tags=gms_pure_go' golangci-lint run ./...`

Fixes #3185