### PR TITLE
fix(formula): carry step labels through cook and pour

### DIFF
--- a/cmd/bd/mol_embedded_test.go
+++ b/cmd/bd/mol_embedded_test.go
@@ -1,0 +1,73 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/formula"
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestSpawnMolecule_PreservesStepLabels verifies that a cooked formula with
+// per-step labels results in spawned issues whose labels are persisted to the
+// database. Regression for labels being silently dropped by cloneSubgraph in
+// the same shape as the metadata bug fixed by gastownhall/beads#3341.
+func TestSpawnMolecule_PreservesStepLabels(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+
+	ctx := t.Context()
+	s, err := embeddeddolt.New(ctx, t.TempDir(), "beads", "main")
+	if err != nil {
+		t.Fatalf("embeddeddolt.New failed: %v", err)
+	}
+	defer s.Close()
+	if err := s.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("SetConfig failed: %v", err)
+	}
+
+	f := &formula.Formula{
+		Formula: "label-test",
+		Version: 1,
+		Type:    formula.TypeWorkflow,
+		Steps: []*formula.Step{
+			{
+				ID:     "work",
+				Title:  "Do the work",
+				Labels: []string{"worker", "phase:build"},
+			},
+		},
+	}
+
+	subgraph, err := cookFormulaToSubgraph(f, "label-test")
+	if err != nil {
+		t.Fatalf("cookFormulaToSubgraph failed: %v", err)
+	}
+
+	result, err := spawnMolecule(ctx, s, subgraph, nil, "", "test", false, types.IDPrefixMol)
+	if err != nil {
+		t.Fatalf("spawnMolecule failed: %v", err)
+	}
+
+	newWorkID, ok := result.IDMapping["label-test.work"]
+	if !ok {
+		t.Fatalf("result.IDMapping missing entry for label-test.work; got %v", result.IDMapping)
+	}
+	labels, err := s.GetLabels(ctx, newWorkID)
+	if err != nil {
+		t.Fatalf("GetLabels(%s) failed: %v", newWorkID, err)
+	}
+	got := make(map[string]bool, len(labels))
+	for _, l := range labels {
+		got[l] = true
+	}
+	for _, want := range []string{"worker", "phase:build"} {
+		if !got[want] {
+			t.Errorf("spawned issue %s missing label %q; got %v", newWorkID, want, labels)
+		}
+	}
+}

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -599,8 +599,8 @@ func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *Templat
 				AwaitType: oldIssue.AwaitType,
 				AwaitID:   substituteVariables(oldIssue.AwaitID, opts.Vars),
 				Timeout:   oldIssue.Timeout,
-				Labels:    oldIssue.Labels,   // carry formula step labels
-				Metadata:  oldIssue.Metadata, // carry formula step metadata (GH#3341)
+				Labels:    oldIssue.Labels,
+				Metadata:  oldIssue.Metadata,
 				CreatedAt: time.Now(),
 				UpdatedAt: time.Now(),
 			}

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -599,6 +599,7 @@ func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *Templat
 				AwaitType: oldIssue.AwaitType,
 				AwaitID:   substituteVariables(oldIssue.AwaitID, opts.Vars),
 				Timeout:   oldIssue.Timeout,
+				Labels:    oldIssue.Labels,   // carry formula step labels
 				Metadata:  oldIssue.Metadata, // carry formula step metadata (GH#3341)
 				CreatedAt: time.Now(),
 				UpdatedAt: time.Now(),


### PR DESCRIPTION
Follow-up to #3359.

## Summary

The metadata fix in #3359 paired `processStepToIssue` with `cloneSubgraph` so per-step `metadata = { ... }` survives `bd mol pour`. Labels had the same hole on the pour side: `processStepToIssue` populates `issue.Labels` from `step.Labels`, but `cloneSubgraph` builds the new issue without copying `Labels`, so `PersistLabels` writes nothing and the spawned bead lands with no labels.

This is a one-field add to `cloneSubgraph` mirroring the metadata copy. The cook side already works; only the pour side was dropping labels. Same shape, same fix.

## Tests

- `cmd/bd` (embedded dolt): `TestSpawnMolecule_PreservesStepLabels` — declares two labels on a formula step (`worker`, `phase:build`), spawns the molecule via `spawnMolecule`, and asserts `GetLabels` on the spawned issue returns both. The test lives in a new `mol_embedded_test.go` (gated on `BEADS_TEST_EMBEDDED_DOLT=1` per project convention) so it runs in-process against an embedded Dolt store, no testcontainer required.

Verified red→green locally: pre-fix the assertion reports `missing label "worker"; got []`; post-fix it passes.