### PR TITLE
Add bd init --remote bootstrap path

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -859,12 +859,17 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// This UUID is stored in both metadata.json and the database,
 			// and verified on every connection to detect cross-project leakage.
 			//
-			// When --database is specified and the database already exists on the
-			// server, adopt the existing project_id instead of generating a new
-			// one. This prevents identity mismatch when a second user joins a
-			// shared remote Dolt server. (GH#2922)
+			// Adopt the existing _project_id from the database when:
+			//   - --database is set and the database already exists on a
+			//     shared remote Dolt server (GH#2922), or
+			//   - we just bootstrapped from a remote whose Dolt history
+			//     already carried a _project_id.
+			// In both cases another rig has already chosen an identity;
+			// minting a new one and writing it back would overwrite the
+			// source identity and cause cross-project verification to
+			// fail on subsequent pulls.
 			if cfg.ProjectID == "" {
-				if database != "" && store != nil {
+				if store != nil && (database != "" || bootstrappedFromRemote) {
 					if existingID, err := store.GetMetadata(ctx, "_project_id"); err == nil && existingID != "" {
 						cfg.ProjectID = existingID
 						if !quiet {

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -345,6 +345,128 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("remote_bootstraps_existing_dolt_data", func(t *testing.T) {
+		remoteDir := filepath.Join(t.TempDir(), "remote")
+		remoteURL := "file://" + remoteDir
+
+		sourceDir, _, _ := bdInit(t, bd, "--prefix", "src", "--skip-hooks", "--skip-agents")
+		sourceCfg, err := configfile.Load(filepath.Join(sourceDir, ".beads"))
+		if err != nil {
+			t.Fatalf("load source metadata.json: %v", err)
+		}
+		if sourceCfg.ProjectID == "" {
+			t.Fatal("source project ID is empty")
+		}
+
+		cmd := exec.Command(bd, "create", "Remote issue", "--type", "task")
+		cmd.Dir = sourceDir
+		cmd.Env = bdEnv(sourceDir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd create failed: %v\n%s", err, out)
+		}
+		bdDolt(t, bd, sourceDir, "commit")
+		bdDolt(t, bd, sourceDir, "remote", "add", "origin", remoteURL)
+		bdDolt(t, bd, sourceDir, "push", "--force")
+
+		cloneDir := t.TempDir()
+		initGitRepoAt(t, cloneDir)
+		gitBin, err := exec.LookPath("git")
+		if err != nil {
+			t.Fatalf("git not found: %v", err)
+		}
+		pathDir := filepath.Join(t.TempDir(), "path")
+		if err := os.MkdirAll(pathDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(gitBin, filepath.Join(pathDir, "git")); err != nil {
+			t.Fatalf("symlink git into PATH: %v", err)
+		}
+		noDoltEnv := bdEnv(cloneDir)
+		replacedPath := false
+		for i, entry := range noDoltEnv {
+			if strings.HasPrefix(entry, "PATH=") {
+				noDoltEnv[i] = "PATH=" + pathDir
+				replacedPath = true
+				break
+			}
+		}
+		if !replacedPath {
+			noDoltEnv = append(noDoltEnv, "PATH="+pathDir)
+		}
+		cmd = exec.Command(bd, "init", "--quiet", "--prefix", "clone", "--remote", remoteURL, "--skip-hooks", "--skip-agents")
+		cmd.Dir = cloneDir
+		cmd.Env = noDoltEnv
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd init --remote without dolt CLI failed: %v\n%s", err, out)
+		}
+
+		cloneCfg, err := configfile.Load(filepath.Join(cloneDir, ".beads"))
+		if err != nil {
+			t.Fatalf("load clone metadata.json: %v", err)
+		}
+		if cloneCfg.ProjectID != sourceCfg.ProjectID {
+			t.Fatalf("clone ProjectID = %q, want source ProjectID %q", cloneCfg.ProjectID, sourceCfg.ProjectID)
+		}
+		if val := readBack(t, filepath.Join(cloneDir, ".beads"), "clone", "_project_id", true); val != sourceCfg.ProjectID {
+			t.Fatalf("clone database _project_id = %q, want source ProjectID %q", val, sourceCfg.ProjectID)
+		}
+
+		cmd = exec.Command(bd, "list")
+		cmd.Dir = cloneDir
+		cmd.Env = bdEnv(cloneDir)
+		listOut, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd list failed: %v\n%s", err, listOut)
+		}
+		if !strings.Contains(string(listOut), "Remote issue") {
+			t.Fatalf("cloned database missing remote issue:\n%s", listOut)
+		}
+
+		cloneBeadsDir := filepath.Join(cloneDir, ".beads")
+		out := bdDolt(t, bd, cloneDir, "remote", "list")
+		if !strings.Contains(out, "origin") || !strings.Contains(out, remoteURL) {
+			t.Fatalf("expected origin remote %q in remote list:\n%s", remoteURL, out)
+		}
+
+		configYAML, err := os.ReadFile(filepath.Join(cloneBeadsDir, "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if !strings.Contains(string(configYAML), remoteURL) {
+			t.Fatalf("config.yaml should persist --remote URL %q:\n%s", remoteURL, configYAML)
+		}
+	})
+
+	t.Run("remote_empty_initializes_fresh_and_wires_origin", func(t *testing.T) {
+		remoteDir := filepath.Join(t.TempDir(), "empty-remote")
+		if err := os.MkdirAll(remoteDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		remoteURL := "file://" + remoteDir
+
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+		runBDInit(t, bd, dir, "--prefix", "fresh", "--remote", remoteURL, "--skip-hooks", "--skip-agents")
+
+		beadsDir := filepath.Join(dir, ".beads")
+		if val := readBack(t, beadsDir, "fresh", "issue_prefix", false); val != "fresh" {
+			t.Fatalf("fresh issue_prefix = %q, want %q", val, "fresh")
+		}
+
+		out := bdDolt(t, bd, dir, "remote", "list")
+		if !strings.Contains(out, "origin") || !strings.Contains(out, remoteURL) {
+			t.Fatalf("expected origin remote %q in remote list:\n%s", remoteURL, out)
+		}
+
+		configYAML, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if !strings.Contains(string(configYAML), remoteURL) {
+			t.Fatalf("config.yaml should persist --remote URL %q:\n%s", remoteURL, configYAML)
+		}
+	})
+
 	t.Run("database", func(t *testing.T) {
 		_, beadsDir, _ := bdInit(t, bd, "--database", "custom_db")
 		cfg, err := configfile.Load(beadsDir)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -194,6 +194,7 @@ bd ready --json  # Start using bd normally
 All writes go directly to the Dolt database and are automatically committed to Dolt history. To sync with Dolt remotes:
 
 ```bash
+bd init --remote http://myserver:7007/mydb  # Configure remote during first init
 bd dolt push    # Push changes to Dolt remote
 bd dolt pull    # Pull changes from Dolt remote
 ```

--- a/docs/GIT_INTEGRATION.md
+++ b/docs/GIT_INTEGRATION.md
@@ -37,6 +37,7 @@ Git worktrees share the same `.git` directory and `.beads` database:
 Sync with remotes using Dolt's native push/pull:
 
 ```bash
+bd init --remote http://myserver:7007/mydb  # First setup or clone from a Dolt remote
 bd dolt push    # Push changes to Dolt remote
 bd dolt pull    # Pull changes from Dolt remote
 ```


### PR DESCRIPTION
## Summary
- add `bd init --remote <url>` for explicit Dolt remotes
- preserve explicit remotesapi/http URLs instead of normalizing them through git schemes
- bootstrap embedded databases from existing remote data, or initialize fresh and wire origin when the remote has no Dolt data yet
- persist `sync.remote` during init and document the setup path

## Upstream context
- Implements #3430
- Reviewed related #3339, #3407, PR #3317, and PR #3438 before implementation
- Keeps #3407 shared-server database creation separate

## Review fixes
- preserve cloned `_project_id` in both `metadata.json` and the database instead of minting a new project identity
- keep embedded `bd init --remote` on the embedded `DOLT_CLONE` path so it does not require an external `dolt` CLI
- add regression coverage for remote bootstrap with no `dolt` on `PATH` and cloned project identity preservation

## Tests
- `go test -tags gms_pure_go ./cmd/bd -run 'TestShouldWireInitRemote|TestNormalizeRemoteURL|TestCloneFromRemote' -count=1`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedInit$/remote_bootstraps_existing_dolt_data$' -count=1 -v`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedInit$/remote_' -count=1 -v`
- `git diff --check`
- `make test`
