### PR TITLE
Sync Linear milestones as local epics

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -14,6 +16,7 @@ import (
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/linear"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -109,6 +112,9 @@ Team Selection:
   Falls back to linear.team_id for backward compatibility.
   Push requires explicit --team when multiple teams are configured.
 
+Pull Options:
+  --milestones       Reconstruct Linear project milestones as local epic parents
+
 Type Filtering (--push only):
   --type task,feature       Only sync issues of these types
   --exclude-type wisp       Exclude issues of these types
@@ -169,6 +175,7 @@ func init() {
 	linearSyncCmd.Flags().Bool("prefer-linear", false, "Prefer Linear version on conflicts")
 	linearSyncCmd.Flags().Bool("create-only", false, "Only create new issues, don't update existing")
 	linearSyncCmd.Flags().Bool("update-refs", true, "Update external_ref after creating Linear issues")
+	linearSyncCmd.Flags().Bool("milestones", false, "Reconstruct Linear project milestones as local epic parents when pulling")
 	linearSyncCmd.Flags().String("state", "all", "Issue state to sync: open, closed, all")
 	linearSyncCmd.Flags().StringSlice("type", nil, "Only sync issues of these types (can be repeated)")
 	linearSyncCmd.Flags().StringSlice("exclude-type", nil, "Exclude issues of these types (can be repeated)")
@@ -194,6 +201,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	preferLocal, _ := cmd.Flags().GetBool("prefer-local")
 	preferLinear, _ := cmd.Flags().GetBool("prefer-linear")
 	createOnly, _ := cmd.Flags().GetBool("create-only")
+	milestones, _ := cmd.Flags().GetBool("milestones")
 	state, _ := cmd.Flags().GetString("state")
 	typeFilters, _ := cmd.Flags().GetStringSlice("type")
 	excludeTypes, _ := cmd.Flags().GetStringSlice("exclude-type")
@@ -276,6 +284,9 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	if preferLocal && preferLinear {
 		FatalError("cannot use both --prefer-local and --prefer-linear")
 	}
+	if milestones && push && !pull {
+		FatalError("--milestones only applies when pulling from Linear")
+	}
 
 	if err := ensureStoreActive(); err != nil {
 		FatalError("database not available: %v", err)
@@ -313,7 +324,11 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	engine.OnWarning = func(msg string) { fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
 
 	// Set up Linear-specific pull hooks
-	engine.PullHooks = buildLinearPullHooks(ctx)
+	engine.PullHooks = buildLinearPullHooks(ctx, linearPullHookOptions{
+		Milestones: milestones,
+		DryRun:     dryRun,
+		Actor:      actor,
+	})
 
 	// Build sync options from CLI flags
 	opts := tracker.SyncOptions{
@@ -415,16 +430,31 @@ func linearPullDependencySources(includeRelations bool) []tracker.DependencySour
 	return []tracker.DependencySource{tracker.DependencySourceParent}
 }
 
+type linearPullHookOptions struct {
+	Milestones bool
+	DryRun     bool
+	Actor      string
+}
+
 // buildLinearPullHooks creates PullHooks for Linear-specific pull behavior.
-func buildLinearPullHooks(ctx context.Context) *tracker.PullHooks {
+func buildLinearPullHooks(ctx context.Context, opts linearPullHookOptions) *tracker.PullHooks {
+	return buildLinearPullHooksForStore(ctx, store, opts)
+}
+
+func buildLinearPullHooksForStore(ctx context.Context, st storage.Storage, opts linearPullHookOptions) *tracker.PullHooks {
 	idMode := getLinearIDMode(ctx)
 	hashLength := getLinearHashLength(ctx)
 
 	hooks := &tracker.PullHooks{}
+	hookActor := opts.Actor
+	if hookActor == "" {
+		hookActor = actor
+	}
 
-	if idMode == "hash" {
+	var generateID func(context.Context, *types.Issue) error
+	if idMode == "hash" && st != nil {
 		// Pre-load existing IDs for collision avoidance
-		existingIssues, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+		existingIssues, err := st.SearchIssues(ctx, "", types.IssueFilter{})
 		usedIDs := make(map[string]bool)
 		if err == nil {
 			for _, issue := range existingIssues {
@@ -439,13 +469,13 @@ func buildLinearPullHooks(ctx context.Context) *tracker.PullHooks {
 		prefix := config.GetString("issue-prefix")
 		if prefix == "" {
 			var err error
-			prefix, err = store.GetConfig(ctx, "issue_prefix")
+			prefix, err = st.GetConfig(ctx, "issue_prefix")
 			if err != nil || prefix == "" {
 				prefix = "bd"
 			}
 		}
 
-		hooks.GenerateID = func(_ context.Context, issue *types.Issue) error {
+		generateID = func(_ context.Context, issue *types.Issue) error {
 			ids := []*types.Issue{issue}
 			idOpts := linear.IDGenerationOptions{
 				BaseLength: hashLength,
@@ -459,9 +489,218 @@ func buildLinearPullHooks(ctx context.Context) *tracker.PullHooks {
 			usedIDs[issue.ID] = true
 			return nil
 		}
+		hooks.GenerateID = generateID
+	}
+
+	if opts.Milestones && st != nil {
+		hooks.AfterConvert = func(ctx context.Context, extIssue *tracker.TrackerIssue, conv *tracker.IssueConversion, ref string, _ *types.Issue, syncOpts tracker.SyncOptions) error {
+			li, ok := extIssue.Raw.(*linear.Issue)
+			if !ok || li == nil || li.ProjectMilestone == nil {
+				return nil
+			}
+			if syncOpts.DryRun || opts.DryRun {
+				return nil
+			}
+			milestoneRef, err := ensureLinearMilestoneEpic(ctx, st, li.ProjectMilestone, hookActor, generateID)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(ref) == "" {
+				return fmt.Errorf("missing external ref for Linear issue %s", extIssue.Identifier)
+			}
+			conv.Dependencies = append(conv.Dependencies, tracker.DependencyInfo{
+				FromExternalID: ref,
+				ToExternalID:   milestoneRef,
+				Type:           string(types.DepParentChild),
+				Source:         tracker.DependencySourceParent,
+			})
+			return nil
+		}
 	}
 
 	return hooks
+}
+
+const linearMilestoneExternalRefPrefix = "linear:project-milestone:"
+
+func linearMilestoneExternalRef(id string) string {
+	return linearMilestoneExternalRefPrefix + strings.TrimSpace(id)
+}
+
+func isLinearMilestoneExternalRef(ref string) bool {
+	return strings.HasPrefix(strings.TrimSpace(ref), linearMilestoneExternalRefPrefix)
+}
+
+func ensureLinearMilestoneEpic(ctx context.Context, st storage.Storage, ms *linear.ProjectMilestone, actor string, generateID func(context.Context, *types.Issue) error) (string, error) {
+	milestoneID := strings.TrimSpace(ms.ID)
+	if milestoneID == "" {
+		return "", fmt.Errorf("Linear project milestone is missing id")
+	}
+	title := strings.TrimSpace(ms.Name)
+	if title == "" {
+		title = milestoneID
+	}
+	description := ms.Description
+	ref := linearMilestoneExternalRef(milestoneID)
+
+	metadata, err := mergedLinearMilestoneMetadata(nil, ms)
+	if err != nil {
+		return "", err
+	}
+
+	existing, err := findLinearMilestoneEpic(ctx, st, ref, milestoneID, title)
+	if err != nil {
+		return "", err
+	}
+	if existing != nil {
+		updates := map[string]interface{}{}
+		if existing.Title != title {
+			updates["title"] = title
+		}
+		if existing.Description != description {
+			updates["description"] = description
+		}
+		if existing.IssueType != types.TypeEpic {
+			updates["issue_type"] = string(types.TypeEpic)
+		}
+		if existing.ExternalRef == nil || strings.TrimSpace(*existing.ExternalRef) != ref {
+			updates["external_ref"] = ref
+		}
+		mergedMetadata, err := mergedLinearMilestoneMetadata(existing.Metadata, ms)
+		if err != nil {
+			return "", err
+		}
+		if string(existing.Metadata) != string(mergedMetadata) {
+			updates["metadata"] = mergedMetadata
+		}
+		if len(updates) > 0 {
+			if err := st.UpdateIssue(ctx, existing.ID, updates, actor); err != nil {
+				return "", fmt.Errorf("updating Linear milestone epic %s: %w", existing.ID, err)
+			}
+		}
+		return ref, nil
+	}
+
+	externalRef := ref
+	epic := &types.Issue{
+		Title:       title,
+		Description: description,
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeEpic,
+		ExternalRef: &externalRef,
+		Metadata:    metadata,
+	}
+	if generateID != nil {
+		if err := generateID(ctx, epic); err != nil {
+			return "", fmt.Errorf("generating Linear milestone epic ID: %w", err)
+		}
+	}
+	if err := st.CreateIssue(ctx, epic, actor); err != nil {
+		return "", fmt.Errorf("creating Linear milestone epic %q: %w", title, err)
+	}
+	return ref, nil
+}
+
+func findLinearMilestoneEpic(ctx context.Context, st storage.Storage, ref, milestoneID, title string) (*types.Issue, error) {
+	if existing, err := st.GetIssueByExternalRef(ctx, ref); err == nil {
+		return existing, nil
+	} else if !errors.Is(err, storage.ErrNotFound) {
+		return nil, err
+	}
+
+	issues, err := st.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		return nil, fmt.Errorf("searching local issues for Linear milestone %s: %w", milestoneID, err)
+	}
+	for _, issue := range issues {
+		if issueHasLinearMilestoneID(issue, milestoneID) {
+			return issue, nil
+		}
+	}
+
+	for _, issue := range issues {
+		if issue.IssueType != types.TypeEpic || !strings.EqualFold(strings.TrimSpace(issue.Title), title) {
+			continue
+		}
+		ref := ""
+		if issue.ExternalRef != nil {
+			ref = strings.TrimSpace(*issue.ExternalRef)
+		}
+		if ref == "" {
+			return issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func mergedLinearMilestoneMetadata(existing json.RawMessage, ms *linear.ProjectMilestone) (json.RawMessage, error) {
+	data := make(map[string]interface{})
+	if len(existing) > 0 {
+		trimmed := strings.TrimSpace(string(existing))
+		if trimmed != "" && trimmed != "null" {
+			if err := json.Unmarshal(existing, &data); err != nil {
+				return nil, fmt.Errorf("existing milestone metadata is not a JSON object: %w", err)
+			}
+		}
+	}
+
+	linearMeta, _ := data["linear"].(map[string]interface{})
+	if linearMeta == nil {
+		linearMeta = make(map[string]interface{})
+	}
+	linearMeta["kind"] = "project_milestone"
+	linearMeta["project_milestone"] = map[string]interface{}{
+		"id":          strings.TrimSpace(ms.ID),
+		"name":        ms.Name,
+		"description": ms.Description,
+		"progress":    ms.Progress,
+		"targetDate":  ms.TargetDate,
+	}
+	data["linear"] = linearMeta
+
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling Linear milestone metadata: %w", err)
+	}
+	return json.RawMessage(raw), nil
+}
+
+func issueHasLinearMilestoneID(issue *types.Issue, milestoneID string) bool {
+	if issue == nil || len(issue.Metadata) == 0 {
+		return false
+	}
+	var data struct {
+		Linear struct {
+			Kind             string `json:"kind"`
+			ProjectMilestone struct {
+				ID string `json:"id"`
+			} `json:"project_milestone"`
+		} `json:"linear"`
+	}
+	if err := json.Unmarshal(issue.Metadata, &data); err != nil {
+		return false
+	}
+	return data.Linear.Kind == "project_milestone" &&
+		strings.TrimSpace(data.Linear.ProjectMilestone.ID) == strings.TrimSpace(milestoneID)
+}
+
+func isLinearMilestoneIssue(issue *types.Issue) bool {
+	if issue == nil {
+		return false
+	}
+	if issue.ExternalRef != nil && isLinearMilestoneExternalRef(*issue.ExternalRef) {
+		return true
+	}
+	var data struct {
+		Linear struct {
+			Kind string `json:"kind"`
+		} `json:"linear"`
+	}
+	if len(issue.Metadata) == 0 || json.Unmarshal(issue.Metadata, &data) != nil {
+		return false
+	}
+	return data.Linear.Kind == "project_milestone"
 }
 
 // buildLinearPushHooks creates PushHooks for Linear-specific push behavior.
@@ -494,6 +733,9 @@ func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectC
 			return id, id != ""
 		},
 		ShouldPush: func(issue *types.Issue) bool {
+			if isLinearMilestoneIssue(issue) {
+				return false
+			}
 			if projectID, _ := store.GetConfig(ctx, "linear.project_id"); projectID != "" {
 				if issue.ExternalRef == nil || strings.TrimSpace(*issue.ExternalRef) == "" {
 					if !allowProjectCreates {

--- a/cmd/bd/linear_roundtrip_test.go
+++ b/cmd/bd/linear_roundtrip_test.go
@@ -464,6 +464,150 @@ func TestLinearRoundTripCoreFields(t *testing.T) {
 	}
 }
 
+func TestLinearPullMilestonesCreatesEpicHierarchy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	teamID := "test-team-uuid"
+
+	targetStore, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	mock := newMockLinearServer(teamID, "MOCK")
+	server := httptest.NewServer(mock)
+	defer server.Close()
+
+	for k, v := range map[string]string{
+		"linear.api_key":      "test-api-key",
+		"linear.team_id":      teamID,
+		"linear.api_endpoint": server.URL,
+		"issue_prefix":        "bd",
+	} {
+		if err := targetStore.SetConfig(ctx, k, v); err != nil {
+			t.Fatalf("SetConfig(%s): %v", k, err)
+		}
+	}
+
+	milestone := &linear.ProjectMilestone{
+		ID:          "milestone-1",
+		Name:        "M7: Team-Ready",
+		Description: "Everything the team needs before handoff.",
+		Progress:    60.61,
+		TargetDate:  "2026-05-12",
+	}
+	now := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+
+	mock.mu.Lock()
+	mock.issues["uuid-1"] = &linear.Issue{
+		ID:               "uuid-1",
+		Identifier:       "MOCK-1",
+		Title:            "Build checklist",
+		Description:      "Create the readiness checklist.",
+		URL:              "https://linear.app/mock/issue/MOCK-1",
+		Priority:         2,
+		State:            &linear.State{ID: "state-started", Name: "In Progress", Type: "started"},
+		ProjectMilestone: milestone,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	mock.issues["uuid-2"] = &linear.Issue{
+		ID:               "uuid-2",
+		Identifier:       "MOCK-2",
+		Title:            "Write docs",
+		Description:      "Document the handoff process.",
+		URL:              "https://linear.app/mock/issue/MOCK-2",
+		Priority:         3,
+		State:            &linear.State{ID: "state-unstarted", Name: "Todo", Type: "unstarted"},
+		ProjectMilestone: milestone,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	mock.mu.Unlock()
+
+	lt := &linear.Tracker{}
+	lt.SetTeamIDs([]string{teamID})
+	if err := lt.Init(ctx, targetStore); err != nil {
+		t.Fatalf("Tracker.Init: %v", err)
+	}
+
+	pullEngine := tracker.NewEngine(lt, targetStore, "test-actor")
+	pullEngine.PullHooks = buildLinearPullHooksForStore(ctx, targetStore, linearPullHookOptions{
+		Milestones: true,
+		Actor:      "test-actor",
+	})
+
+	pullResult, err := pullEngine.Sync(ctx, tracker.SyncOptions{Pull: true})
+	if err != nil {
+		t.Fatalf("Pull sync failed: %v", err)
+	}
+	if pullResult.Stats.Created != 2 {
+		t.Fatalf("expected 2 Linear issues pulled, got created=%d", pullResult.Stats.Created)
+	}
+
+	epicRef := linearMilestoneExternalRef("milestone-1")
+	epic, err := targetStore.GetIssueByExternalRef(ctx, epicRef)
+	if err != nil {
+		t.Fatalf("GetIssueByExternalRef(%s): %v", epicRef, err)
+	}
+	if epic.Title != milestone.Name {
+		t.Errorf("epic title = %q, want %q", epic.Title, milestone.Name)
+	}
+	if epic.Description != milestone.Description {
+		t.Errorf("epic description = %q, want %q", epic.Description, milestone.Description)
+	}
+	if epic.IssueType != types.TypeEpic {
+		t.Errorf("epic type = %q, want %q", epic.IssueType, types.TypeEpic)
+	}
+
+	all, err := targetStore.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("SearchIssues: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 local issues (1 epic + 2 tasks), got %d", len(all))
+	}
+
+	for _, ref := range []string{
+		"https://linear.app/mock/issue/MOCK-1",
+		"https://linear.app/mock/issue/MOCK-2",
+	} {
+		issue, err := targetStore.GetIssueByExternalRef(ctx, ref)
+		if err != nil {
+			t.Fatalf("GetIssueByExternalRef(%s): %v", ref, err)
+		}
+		deps, err := targetStore.GetDependenciesWithMetadata(ctx, issue.ID)
+		if err != nil {
+			t.Fatalf("GetDependenciesWithMetadata(%s): %v", issue.ID, err)
+		}
+		foundParent := false
+		for _, dep := range deps {
+			if dep.ID == epic.ID && dep.DependencyType == types.DepParentChild {
+				foundParent = true
+				break
+			}
+		}
+		if !foundParent {
+			t.Errorf("issue %s is not parented to milestone epic %s", issue.ID, epic.ID)
+		}
+	}
+
+	pushHooks := buildLinearPushHooksForTest(ctx, lt)
+	if !pushHooks.ShouldPush(&types.Issue{
+		Title:       "normal",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+		ExternalRef: strPtr(""),
+	}) {
+		t.Fatal("expected normal issue to be pushable")
+	}
+	if pushHooks.ShouldPush(epic) {
+		t.Fatal("milestone epic should be excluded from Linear push")
+	}
+}
+
 // TestLinearRoundTripRelationships is a spec test documenting that parent-child
 // hierarchy, blocking dependencies, and issue type do not survive a push→pull
 // round-trip because the Linear push path does not yet send these fields.
@@ -509,6 +653,9 @@ func buildLinearPushHooksForTest(ctx context.Context, lt *linear.Tracker) *track
 			}
 			id := sc.FindStateForBeadsStatus(status)
 			return id, id != ""
+		},
+		ShouldPush: func(issue *types.Issue) bool {
+			return !isLinearMilestoneIssue(issue)
 		},
 	}
 }

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -1137,6 +1137,13 @@ func TestLinearClientFetchIssues(t *testing.T) {
 									{"id": "label-1", "name": "bug"}
 								]
 							},
+							"projectMilestone": {
+								"id": "milestone-1",
+								"name": "M7: Team-Ready",
+								"description": "Team-ready milestone",
+								"progress": 60.61,
+								"targetDate": "2026-05-12"
+							},
 							"createdAt": "2025-01-15T10:00:00Z",
 							"updatedAt": "2025-01-16T10:00:00Z"
 						},
@@ -1195,6 +1202,9 @@ func TestLinearClientFetchIssues(t *testing.T) {
 	}
 	if issue1.State.Type != "started" {
 		t.Errorf("expected state type 'started', got %s", issue1.State.Type)
+	}
+	if issue1.ProjectMilestone == nil || issue1.ProjectMilestone.ID != "milestone-1" {
+		t.Fatalf("expected projectMilestone milestone-1, got %#v", issue1.ProjectMilestone)
 	}
 }
 

--- a/cmd/bd/sync_push_pull.go
+++ b/cmd/bd/sync_push_pull.go
@@ -481,7 +481,10 @@ func runLinearPull(cmd *cobra.Command, args []string) {
 	engine := tracker.NewEngine(lt, store, actor)
 	engine.OnMessage = func(msg string) { fmt.Println("  " + msg) }
 	engine.OnWarning = func(msg string) { fmt.Fprintf(os.Stderr, "Warning: %s\n", msg) }
-	engine.PullHooks = buildLinearPullHooks(ctx)
+	engine.PullHooks = buildLinearPullHooks(ctx, linearPullHookOptions{
+		DryRun: dryRun,
+		Actor:  actor,
+	})
 
 	result, err := engine.Sync(ctx, tracker.SyncOptions{
 		Pull:              true,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -742,6 +742,9 @@ bd linear sync --pull-if-stale --threshold 5m
 # Pull issues and Linear relations as bd dependencies
 bd linear sync --pull --relations
 
+# Pull and rebuild Linear project milestones as local epic parents
+bd linear sync --pull --milestones
+
 # Push only (export to Linear)
 bd linear sync --push
 

--- a/examples/linear-workflow/README.md
+++ b/examples/linear-workflow/README.md
@@ -87,7 +87,15 @@ bd linear sync --pull --relations
 bd linear sync --pull --state open    # Only open issues
 bd linear sync --pull --state closed  # Only closed issues
 bd linear sync --pull --state all     # All issues (default)
+
+# Reconstruct Linear project milestones as local epic parents
+bd linear sync --pull --milestones
 ```
+
+With `--milestones`, bd creates or reuses one local epic per Linear
+`projectMilestone`, then adds parent-child links from each pulled issue to its
+milestone epic. Milestone epics are marked as Linear milestone records and are
+skipped by later Linear pushes.
 
 ### Push Only (bd → Linear)
 

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -83,6 +83,13 @@ const issuesQuery = `
 					id
 					identifier
 				}
+				projectMilestone {
+					id
+					name
+					description
+					progress
+					targetDate
+				}
 				relations {
 					nodes {
 						id
@@ -911,6 +918,17 @@ func (c *Client) FetchIssueByIdentifier(ctx context.Context, identifier string) 
 							id
 							name
 						}
+					}
+					parent {
+						id
+						identifier
+					}
+					projectMilestone {
+						id
+						name
+						description
+						progress
+						targetDate
 					}
 					createdAt
 					updatedAt

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -425,6 +425,14 @@ func linearToTrackerIssue(li *Issue) tracker.TrackerIssue {
 		ti.ParentInternalID = li.Parent.ID
 	}
 
+	if li.ProjectMilestone != nil {
+		ti.Metadata = map[string]interface{}{
+			"linear": map[string]interface{}{
+				"project_milestone": li.ProjectMilestone,
+			},
+		}
+	}
+
 	if t, err := time.Parse(time.RFC3339, li.CreatedAt); err == nil {
 		ti.CreatedAt = t
 	}

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -181,6 +181,13 @@ func TestLinearToTrackerIssue(t *testing.T) {
 		UpdatedAt:   "2026-01-16T14:30:00Z",
 		Assignee:    &User{ID: "user-1", Name: "Alice", Email: "alice@example.com"},
 		State:       &State{Type: "started", Name: "In Progress"},
+		ProjectMilestone: &ProjectMilestone{
+			ID:          "milestone-1",
+			Name:        "M7: Team-Ready",
+			Description: "Team-ready milestone",
+			Progress:    60.61,
+			TargetDate:  "2026-05-12",
+		},
 	}
 
 	ti := linearToTrackerIssue(li)
@@ -199,6 +206,21 @@ func TestLinearToTrackerIssue(t *testing.T) {
 	}
 	if ti.Raw != li {
 		t.Error("Raw should reference original linear.Issue")
+	}
+	var meta struct {
+		Linear struct {
+			ProjectMilestone ProjectMilestone `json:"project_milestone"`
+		} `json:"linear"`
+	}
+	raw, err := json.Marshal(ti.Metadata)
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Linear.ProjectMilestone.ID != "milestone-1" {
+		t.Errorf("ProjectMilestone.ID = %q, want milestone-1", meta.Linear.ProjectMilestone.ID)
 	}
 }
 

--- a/internal/linear/types.go
+++ b/internal/linear/types.go
@@ -119,21 +119,22 @@ type GraphQLError struct {
 
 // Issue represents an issue from the Linear API.
 type Issue struct {
-	ID          string     `json:"id"`
-	Identifier  string     `json:"identifier"` // e.g., "TEAM-123"
-	Title       string     `json:"title"`
-	Description string     `json:"description"`
-	URL         string     `json:"url"`
-	Priority    int        `json:"priority"` // 0=no priority, 1=urgent, 2=high, 3=medium, 4=low
-	State       *State     `json:"state"`
-	Assignee    *User      `json:"assignee"`
-	Labels      *Labels    `json:"labels"`
-	Project     *Project   `json:"project,omitempty"`
-	Parent      *Parent    `json:"parent,omitempty"`
-	Relations   *Relations `json:"relations,omitempty"`
-	CreatedAt   string     `json:"createdAt"`
-	UpdatedAt   string     `json:"updatedAt"`
-	CompletedAt string     `json:"completedAt,omitempty"`
+	ID               string            `json:"id"`
+	Identifier       string            `json:"identifier"` // e.g., "TEAM-123"
+	Title            string            `json:"title"`
+	Description      string            `json:"description"`
+	URL              string            `json:"url"`
+	Priority         int               `json:"priority"` // 0=no priority, 1=urgent, 2=high, 3=medium, 4=low
+	State            *State            `json:"state"`
+	Assignee         *User             `json:"assignee"`
+	Labels           *Labels           `json:"labels"`
+	Project          *Project          `json:"project,omitempty"`
+	ProjectMilestone *ProjectMilestone `json:"projectMilestone,omitempty"`
+	Parent           *Parent           `json:"parent,omitempty"`
+	Relations        *Relations        `json:"relations,omitempty"`
+	CreatedAt        string            `json:"createdAt"`
+	UpdatedAt        string            `json:"updatedAt"`
+	CompletedAt      string            `json:"completedAt,omitempty"`
 }
 
 // State represents a workflow state in Linear.
@@ -238,6 +239,15 @@ type Project struct {
 	CreatedAt   string  `json:"createdAt"`
 	UpdatedAt   string  `json:"updatedAt"`
 	CompletedAt string  `json:"completedAt,omitempty"`
+}
+
+// ProjectMilestone represents a milestone within a Linear project.
+type ProjectMilestone struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Progress    float64 `json:"progress"`
+	TargetDate  string  `json:"targetDate,omitempty"`
 }
 
 // ProjectsResponse represents the response from projects query.

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -55,6 +55,12 @@ type PullHooks struct {
 	// Called on the raw TrackerIssue before conversion to beads format.
 	// If nil, all issues are imported.
 	ShouldImport func(issue *TrackerIssue) bool
+
+	// AfterConvert is called after the external issue has been converted to
+	// a beads issue, transformed, and assigned an ID, but before it is stored.
+	// Hooks may mutate the conversion, for example by adding dependencies that
+	// should be created after all pulled issues have been saved.
+	AfterConvert func(ctx context.Context, extIssue *TrackerIssue, conv *IssueConversion, ref string, existing *types.Issue, opts SyncOptions) error
 }
 
 // PushHooks contains optional callbacks that customize push (export) behavior.
@@ -445,6 +451,14 @@ func (e *Engine) doPull(ctx context.Context, opts SyncOptions, allowOverwriteIDs
 			// Without this guard, pull silently overwrites local changes
 			// before conflict detection can compare timestamps.
 			if lastSync != nil && existing.UpdatedAt.After(*lastSync) && !allowOverwriteIDs[existing.ID] && !prelinkedHydrateIDs[existing.ID] {
+				stats.Skipped++
+				continue
+			}
+		}
+
+		if e.PullHooks != nil && e.PullHooks.AfterConvert != nil {
+			if err := e.PullHooks.AfterConvert(ctx, &extIssue, conv, ref, existing, opts); err != nil {
+				e.warn("Failed to prepare %s: %v", extIssue.Identifier, err)
 				stats.Skipped++
 				continue
 			}
@@ -1241,11 +1255,14 @@ func (e *Engine) dependencyIssueResolver(ctx context.Context, extraIssues []*typ
 			continue
 		}
 		ref := strings.TrimSpace(*candidate.ExternalRef)
-		if ref == "" || !e.Tracker.IsExternalRef(ref) {
+		if ref == "" {
 			continue
 		}
 		if _, exists := byExternal[ref]; !exists {
 			byExternal[ref] = candidate
+		}
+		if !e.Tracker.IsExternalRef(ref) {
+			continue
 		}
 		identifier := strings.TrimSpace(e.Tracker.ExtractIdentifier(ref))
 		if identifier != "" {

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -2249,6 +2249,66 @@ func TestEngineCreateDependenciesResolvesBareIdentifierFromExternalRef(t *testin
 	}
 }
 
+func TestEngineCreateDependenciesResolvesSyntheticExternalRef(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	issues := []*types.Issue{
+		{ID: "bd-linear-child", Title: "Child", Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2},
+		{ID: "bd-linear-milestone", Title: "Milestone", Status: types.StatusOpen, IssueType: types.TypeEpic, Priority: 2},
+	}
+	for _, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue error: %v", err)
+		}
+	}
+	if err := store.UpdateIssue(ctx, "bd-linear-child", map[string]interface{}{"external_ref": "https://linear.app/team/issue/TEAM-101/child-title"}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue child external_ref: %v", err)
+	}
+	if err := store.UpdateIssue(ctx, "bd-linear-milestone", map[string]interface{}{"external_ref": "linear:project-milestone:milestone-1"}, "test-actor"); err != nil {
+		t.Fatalf("UpdateIssue milestone external_ref: %v", err)
+	}
+
+	lt := &mockExternalRefTracker{
+		mockTracker: newMockTracker("linear"),
+		isRef: func(ref string) bool {
+			return strings.Contains(ref, "linear.app/") && strings.Contains(ref, "/issue/")
+		},
+		extract: func(ref string) string {
+			parts := strings.Split(ref, "/issue/")
+			if len(parts) != 2 {
+				return ref
+			}
+			return strings.Split(parts[1], "/")[0]
+		},
+	}
+	engine := NewEngine(lt, store, "test-actor")
+
+	errCount := engine.createDependencies(ctx, []DependencyInfo{
+		{
+			FromExternalID: "https://linear.app/team/issue/TEAM-101",
+			ToExternalID:   "linear:project-milestone:milestone-1",
+			Type:           string(types.DepParentChild),
+		},
+	})
+	if errCount != 0 {
+		t.Fatalf("createDependencies returned errCount=%d, warnings=%v", errCount, engine.warnings)
+	}
+
+	depRecords, err := store.GetDependencyRecords(ctx, "bd-linear-child")
+	if err != nil {
+		t.Fatalf("GetDependencyRecords error: %v", err)
+	}
+	if len(depRecords) != 1 {
+		t.Fatalf("expected 1 dependency record, got %d", len(depRecords))
+	}
+	if depRecords[0].DependsOnID != "bd-linear-milestone" || depRecords[0].Type != types.DepParentChild {
+		t.Fatalf("dependency = %s -> %s (%s), want bd-linear-child -> bd-linear-milestone (%s)",
+			depRecords[0].IssueID, depRecords[0].DependsOnID, depRecords[0].Type, types.DepParentChild)
+	}
+}
+
 func TestEnginePullCreatesDependenciesForUnchangedIssues(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)


### PR DESCRIPTION
## Summary
- add opt-in `bd linear sync --pull --milestones` support for reconstructing Linear project milestone hierarchy
- persist Linear `projectMilestone` metadata and create/reuse local epic issues with synthetic milestone external refs
- parent pulled Linear issues under their milestone epics while keeping those synthetic epics out of Linear push sync

## Validation
- `go test ./internal/linear`
- `go test ./internal/tracker -run 'TestEnginePull|TestEngineCreateDependencies'`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestLinearClientFetchIssues|TestLinearPullMilestonesCreatesEpicHierarchy|TestLinearRoundTripCoreFields'`
- `CGO_ENABLED=1 go test -tags gms_pure_go -timeout 5m ./cmd/bd`

Refs #3184