### PR TITLE
feat: add JSONL bulk dep add

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -2,9 +2,13 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -197,6 +201,10 @@ The depends-on-id can be:
   - A local issue ID (e.g., bd-xyz)
   - An external reference: external:<project>:<capability>
 
+For bulk wiring, pass newline-delimited JSON with --file. Each line must be an
+object with "from" and "to" fields, and may include "type". The aliases
+"issue_id" and "depends_on_id" are also accepted. Use --file - to read stdin.
+
 External references are stored as-is and resolved at query time using
 the external_projects config. They block the issue until the capability
 is "shipped" in the target project.
@@ -206,11 +214,23 @@ Examples:
   bd dep add bd-42 --blocked-by bd-41                 # Flag syntax (same effect)
   bd dep add bd-42 --depends-on bd-41                 # Alias (same effect)
   bd dep add gt-xyz external:beads:mol-run-assignee   # Cross-project dependency
-  bd dep add bd-42 bd-41 --no-cycle-check             # Skip cycle check (bulk wiring)`,
+  bd dep add bd-42 bd-41 --no-cycle-check             # Skip cycle check (bulk wiring)
+  bd dep add --file deps.jsonl                        # Bulk JSONL: {"from":"bd-42","to":"bd-41"}`,
 	Args: func(cmd *cobra.Command, args []string) error {
+		file, _ := cmd.Flags().GetString("file")
 		blockedBy, _ := cmd.Flags().GetString("blocked-by")
 		dependsOn, _ := cmd.Flags().GetString("depends-on")
 		hasFlag := blockedBy != "" || dependsOn != ""
+
+		if file != "" {
+			if len(args) != 0 {
+				return fmt.Errorf("--file cannot be used with positional issue IDs")
+			}
+			if hasFlag {
+				return fmt.Errorf("--file cannot be used with --blocked-by or --depends-on")
+			}
+			return nil
+		}
 
 		if hasFlag {
 			// If a flag is provided, we only need 1 positional arg (the dependent issue)
@@ -231,6 +251,12 @@ Examples:
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("dep add")
 		depType, _ := cmd.Flags().GetString("type")
+		file, _ := cmd.Flags().GetString("file")
+
+		if file != "" {
+			addBulkDependencies(cmd, file, depType)
+			return
+		}
 
 		// Get the dependency target from flag or positional arg
 		blockedBy, _ := cmd.Flags().GetString("blocked-by")
@@ -333,6 +359,248 @@ Examples:
 		fmt.Printf("%s Added dependency: %s depends on %s (%s)\n",
 			ui.RenderPass("✓"), formatFeedbackIDParen(fromID, lookupTitle(fromID)), formatFeedbackIDParen(toID, lookupTitle(toID)), depType)
 	},
+}
+
+type bulkDepInput struct {
+	From        string `json:"from"`
+	To          string `json:"to"`
+	Type        string `json:"type"`
+	IssueID     string `json:"issue_id"`
+	DependsOnID string `json:"depends_on_id"`
+}
+
+type bulkDepEdge struct {
+	Line        int
+	IssueID     string
+	DependsOnID string
+	Type        types.DependencyType
+	Store       storage.DoltStorage
+	StoreKey    string
+	Cleanups    []func()
+}
+
+func addBulkDependencies(cmd *cobra.Command, file string, defaultType string) {
+	edges, err := readBulkDepEdges(file, defaultType)
+	if err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	resolved, err := validateBulkDepEdges(rootCtx, edges)
+	if err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+	defer func() {
+		for _, edge := range resolved {
+			for _, cleanup := range edge.Cleanups {
+				cleanup()
+			}
+		}
+	}()
+
+	if len(resolved) == 0 {
+		FatalErrorRespectJSON("no dependency edges found")
+	}
+	targetStore := resolved[0].Store
+	targetStoreKey := resolved[0].StoreKey
+	for _, edge := range resolved[1:] {
+		if edge.StoreKey != targetStoreKey {
+			FatalErrorRespectJSON("bulk dep add requires all source issues to resolve to the same store")
+		}
+	}
+
+	noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
+	commitMsg := fmt.Sprintf("dependency: add %d edges", len(resolved))
+	if err := transact(rootCtx, targetStore, commitMsg, func(tx storage.Transaction) error {
+		for _, edge := range resolved {
+			dep := &types.Dependency{
+				IssueID:     edge.IssueID,
+				DependsOnID: edge.DependsOnID,
+				Type:        edge.Type,
+			}
+			if err := tx.AddDependencyWithOptions(rootCtx, dep, actor, storage.DependencyAddOptions{SkipCycleCheck: noCycleCheck}); err != nil {
+				return fmt.Errorf("line %d: %w", edge.Line, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		FatalErrorRespectJSON("%v", err)
+	}
+
+	if !noCycleCheck {
+		warnIfCyclesExist(targetStore)
+	}
+
+	if jsonOutput {
+		out := make([]map[string]interface{}, 0, len(resolved))
+		for _, edge := range resolved {
+			out = append(out, map[string]interface{}{
+				"issue_id":      edge.IssueID,
+				"depends_on_id": edge.DependsOnID,
+				"type":          string(edge.Type),
+			})
+		}
+		outputJSON(map[string]interface{}{
+			"status":       "added",
+			"count":        len(resolved),
+			"dependencies": out,
+		})
+		return
+	}
+
+	fmt.Printf("%s Added %d dependencies\n", ui.RenderPass("✓"), len(resolved))
+}
+
+func readBulkDepEdges(file string, defaultType string) ([]bulkDepEdge, error) {
+	var r io.Reader
+	var f *os.File
+	if file == "-" {
+		r = os.Stdin
+	} else {
+		var err error
+		f, err = os.Open(file)
+		if err != nil {
+			return nil, fmt.Errorf("open dependency file: %w", err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var edges []bulkDepEdge
+	var errs []string
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var in bulkDepInput
+		if err := json.Unmarshal([]byte(line), &in); err != nil {
+			errs = append(errs, fmt.Sprintf("line %d: invalid JSON: %v", lineNo, err))
+			continue
+		}
+
+		from := strings.TrimSpace(in.From)
+		if from == "" {
+			from = strings.TrimSpace(in.IssueID)
+		}
+		to := strings.TrimSpace(in.To)
+		if to == "" {
+			to = strings.TrimSpace(in.DependsOnID)
+		}
+		depType := strings.TrimSpace(in.Type)
+		if depType == "" {
+			depType = defaultType
+		}
+
+		if from == "" {
+			errs = append(errs, fmt.Sprintf("line %d: missing from", lineNo))
+		}
+		if to == "" {
+			errs = append(errs, fmt.Sprintf("line %d: missing to", lineNo))
+		}
+		dt := types.DependencyType(depType)
+		if !dt.IsValid() {
+			errs = append(errs, fmt.Sprintf("line %d: invalid dependency type %q: must be non-empty and at most 50 characters", lineNo, depType))
+		}
+		if from == "" || to == "" || !dt.IsValid() {
+			continue
+		}
+
+		edges = append(edges, bulkDepEdge{
+			Line:        lineNo,
+			IssueID:     from,
+			DependsOnID: to,
+			Type:        dt,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read dependency file: %w", err)
+	}
+	if len(errs) > 0 {
+		return nil, bulkDepValidationError(errs)
+	}
+	return edges, nil
+}
+
+func validateBulkDepEdges(ctx context.Context, edges []bulkDepEdge) ([]bulkDepEdge, error) {
+	resolved := make([]bulkDepEdge, 0, len(edges))
+	var errs []string
+
+	for _, edge := range edges {
+		current := edge
+		fromID, fromStore, fromCleanup, err := resolveIDWithRouting(ctx, store, edge.IssueID)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("line %d: resolving issue ID %s: %v", edge.Line, edge.IssueID, err))
+			continue
+		}
+		current.Cleanups = append(current.Cleanups, fromCleanup)
+		current.IssueID = fromID
+		current.Store = fromStore
+		current.StoreKey = dependencyStoreKey(fromStore)
+
+		if strings.HasPrefix(edge.DependsOnID, "external:") {
+			if err := validateExternalRef(edge.DependsOnID); err != nil {
+				errs = append(errs, fmt.Sprintf("line %d: %v", edge.Line, err))
+				resolved = append(resolved, current)
+				continue
+			}
+			current.DependsOnID = edge.DependsOnID
+		} else {
+			toID, _, toCleanup, err := resolveIDWithRouting(ctx, store, edge.DependsOnID)
+			if err != nil {
+				srcPrefix := types.ExtractPrefix(current.IssueID)
+				tgtPrefix := types.ExtractPrefix(edge.DependsOnID)
+				if srcPrefix != "" && tgtPrefix != "" && srcPrefix != tgtPrefix {
+					toID = edge.DependsOnID
+				} else {
+					errs = append(errs, fmt.Sprintf("line %d: resolving dependency ID %s: %v", edge.Line, edge.DependsOnID, err))
+					resolved = append(resolved, current)
+					continue
+				}
+			} else {
+				current.Cleanups = append(current.Cleanups, toCleanup)
+			}
+			current.DependsOnID = toID
+		}
+
+		if isChildOf(current.IssueID, current.DependsOnID) {
+			errs = append(errs, fmt.Sprintf("line %d: cannot add dependency: %s is already a child of %s", edge.Line, current.IssueID, current.DependsOnID))
+			resolved = append(resolved, current)
+			continue
+		}
+
+		resolved = append(resolved, current)
+	}
+
+	if len(errs) > 0 {
+		for _, edge := range resolved {
+			for _, cleanup := range edge.Cleanups {
+				cleanup()
+			}
+		}
+		return nil, bulkDepValidationError(errs)
+	}
+	return resolved, nil
+}
+
+func bulkDepValidationError(errs []string) error {
+	return fmt.Errorf("bulk dependency validation failed:\n  %s", strings.Join(errs, "\n  "))
+}
+
+func dependencyStoreKey(s storage.DoltStorage) string {
+	if locator, ok := storage.UnwrapStore(s).(storage.StoreLocator); ok {
+		if cliDir := strings.TrimSpace(locator.CLIDir()); cliDir != "" {
+			return "cli:" + filepath.Clean(cliDir)
+		}
+		if path := strings.TrimSpace(locator.Path()); path != "" {
+			return "path:" + filepath.Clean(path)
+		}
+	}
+	return fmt.Sprintf("instance:%p", s)
 }
 
 var depListCmd = &cobra.Command{
@@ -1121,6 +1389,7 @@ func init() {
 	depAddCmd.Flags().StringP("type", "t", "blocks", "Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes)")
 	depAddCmd.Flags().String("blocked-by", "", "Issue ID that blocks the first issue (alternative to positional arg)")
 	depAddCmd.Flags().String("depends-on", "", "Issue ID that the first issue depends on (alias for --blocked-by)")
+	depAddCmd.Flags().String("file", "", "Read dependency edges from JSONL file, or '-' for stdin")
 	depAddCmd.Flags().Bool("no-cycle-check", false, "Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)")
 
 	depTreeCmd.Flags().Bool("show-all-paths", false, "Show all paths to nodes (no deduplication for diamond dependencies)")

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -457,7 +457,7 @@ func readBulkDepEdges(file string, defaultType string) ([]bulkDepEdge, error) {
 		r = os.Stdin
 	} else {
 		var err error
-		f, err = os.Open(file)
+		f, err = os.Open(file) // #nosec G304 -- user-supplied bulk dependency file
 		if err != nil {
 			return nil, fmt.Errorf("open dependency file: %w", err)
 		}

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -148,8 +148,11 @@ Examples:
 				FatalErrorRespectJSON("%v", err)
 			}
 
-			// Check for cycles after adding dependency
-			warnIfCyclesExist(fromStore)
+			// Check for cycles after adding dependency (skipped with --no-cycle-check)
+			noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
+			if !noCycleCheck {
+				warnIfCyclesExist(fromStore)
+			}
 
 			if isEmbeddedMode() && fromStore != nil {
 				if _, err := fromStore.CommitPending(ctx, actor); err != nil {
@@ -202,7 +205,8 @@ Examples:
   bd dep add bd-42 bd-41                              # Positional args
   bd dep add bd-42 --blocked-by bd-41                 # Flag syntax (same effect)
   bd dep add bd-42 --depends-on bd-41                 # Alias (same effect)
-  bd dep add gt-xyz external:beads:mol-run-assignee   # Cross-project dependency`,
+  bd dep add gt-xyz external:beads:mol-run-assignee   # Cross-project dependency
+  bd dep add bd-42 bd-41 --no-cycle-check             # Skip cycle check (bulk wiring)`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		blockedBy, _ := cmd.Flags().GetString("blocked-by")
 		dependsOn, _ := cmd.Flags().GetString("depends-on")
@@ -304,8 +308,11 @@ Examples:
 			FatalErrorRespectJSON("%v", err)
 		}
 
-		// Check for cycles after adding dependency
-		warnIfCyclesExist(fromStore)
+		// Check for cycles after adding dependency (skipped with --no-cycle-check)
+		noCycleCheck, _ := cmd.Flags().GetBool("no-cycle-check")
+		if !noCycleCheck {
+			warnIfCyclesExist(fromStore)
+		}
 
 		if isEmbeddedMode() && fromStore != nil {
 			if _, err := fromStore.CommitPending(ctx, actor); err != nil {
@@ -1109,10 +1116,12 @@ func ParseExternalRef(ref string) (project, capability string) {
 func init() {
 	// dep command shorthand flag
 	depCmd.Flags().StringP("blocks", "b", "", "Issue ID that this issue blocks (shorthand for: bd dep add <blocked> <blocker>)")
+	depCmd.Flags().Bool("no-cycle-check", false, "Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)")
 
 	depAddCmd.Flags().StringP("type", "t", "blocks", "Dependency type (blocks|tracks|related|parent-child|discovered-from|until|caused-by|validates|relates-to|supersedes)")
 	depAddCmd.Flags().String("blocked-by", "", "Issue ID that blocks the first issue (alternative to positional arg)")
 	depAddCmd.Flags().String("depends-on", "", "Issue ID that the first issue depends on (alias for --blocked-by)")
+	depAddCmd.Flags().Bool("no-cycle-check", false, "Skip cycle detection after adding (use for bulk wiring — run 'bd dep cycles' to verify afterwards)")
 
 	depTreeCmd.Flags().Bool("show-all-paths", false, "Show all paths to nodes (no deduplication for diamond dependencies)")
 	depTreeCmd.Flags().IntP("max-depth", "d", 50, "Maximum tree depth to display (safety limit)")

--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -436,3 +436,41 @@ func TestEmbeddedDepConcurrent(t *testing.T) {
 		}
 	}
 }
+
+func TestEmbeddedDepNoCycleCheck(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "ncc")
+
+	// Create a linear chain of issues to simulate bulk dependency wiring.
+	const n = 10
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		issue := bdCreate(t, bd, dir, fmt.Sprintf("bulk-dep-%d", i), "--type", "task")
+		ids[i] = issue.ID
+	}
+
+	// Wire the chain with --no-cycle-check — each call must succeed without
+	// hanging on a full-graph cycle traversal.
+	for i := 1; i < n; i++ {
+		out := bdDep(t, bd, dir, "add", ids[i], ids[i-1], "--no-cycle-check")
+		// Must not print a cycle warning (there are no cycles in a linear chain).
+		if strings.Contains(out, "cycle") {
+			t.Errorf("unexpected cycle warning with --no-cycle-check: %s", out)
+		}
+	}
+
+	// Verify the graph is acyclic after bulk wiring.
+	cyclesOut := bdDep(t, bd, dir, "cycles")
+	if strings.Contains(cyclesOut, "Found") {
+		t.Errorf("unexpected cycles after bulk wiring: %s", cyclesOut)
+	}
+
+	// Verify --no-cycle-check also works with the dep --blocks shorthand.
+	extra := bdCreate(t, bd, dir, "bulk-dep-extra", "--type", "task")
+	bdDep(t, bd, dir, extra.ID, "--blocks", ids[n-1], "--no-cycle-check")
+}

--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -67,6 +67,20 @@ func bdDepJSON(t *testing.T, bd, dir string, args ...string) map[string]interfac
 	return m
 }
 
+func bdDepWithInput(t *testing.T, bd, dir, input string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"dep"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bd dep %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
 func dropEmbeddedWispDependencies(t *testing.T, beadsDir, database string) {
 	t.Helper()
 	db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), filepath.Join(beadsDir, "embeddeddolt"), database, "main")
@@ -211,6 +225,49 @@ func TestEmbeddedDep(t *testing.T) {
 		m := bdDepJSON(t, bd, dir, "add", j1.ID, j2.ID)
 		if m["status"] != "added" {
 			t.Errorf("expected status=added, got %v", m["status"])
+		}
+	})
+
+	t.Run("add_bulk_file_jsonl", func(t *testing.T) {
+		b1 := bdCreate(t, bd, dir, "Bulk dep A", "--type", "task")
+		b2 := bdCreate(t, bd, dir, "Bulk dep B", "--type", "task")
+		b3 := bdCreate(t, bd, dir, "Bulk dep C", "--type", "task")
+		path := filepath.Join(t.TempDir(), "deps.jsonl")
+		body := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"issue_id\":%q,\"depends_on_id\":%q,\"type\":\"tracks\"}\n", b1.ID, b2.ID, b3.ID, b2.ID)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write deps file: %v", err)
+		}
+
+		out := bdDep(t, bd, dir, "add", "--file", path)
+		if !strings.Contains(out, "Added 2 dependencies") {
+			t.Fatalf("expected bulk add summary, got: %s", out)
+		}
+		list1 := bdDep(t, bd, dir, "list", b1.ID)
+		if !strings.Contains(list1, b2.ID) {
+			t.Fatalf("expected first bulk dependency in list: %s", list1)
+		}
+		list3 := bdDep(t, bd, dir, "list", b3.ID)
+		if !strings.Contains(list3, b2.ID) || !strings.Contains(list3, "tracks") {
+			t.Fatalf("expected typed bulk dependency in list: %s", list3)
+		}
+	})
+
+	t.Run("add_bulk_file_validation_no_partial_mutation", func(t *testing.T) {
+		v1 := bdCreate(t, bd, dir, "Bulk validation A", "--type", "task")
+		v2 := bdCreate(t, bd, dir, "Bulk validation B", "--type", "task")
+		path := filepath.Join(t.TempDir(), "bad-deps.jsonl")
+		body := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"from\":\"\",\"to\":%q}\n{\"from\":%q,\"to\":\"\"}\n", v1.ID, v2.ID, v2.ID, v1.ID)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write bad deps file: %v", err)
+		}
+
+		out := bdDepFail(t, bd, dir, "add", "--file", path)
+		if !strings.Contains(out, "line 2: missing from") || !strings.Contains(out, "line 3: missing to") {
+			t.Fatalf("expected all validation errors, got: %s", out)
+		}
+		list := bdDep(t, bd, dir, "list", v1.ID)
+		if strings.Contains(list, v2.ID) {
+			t.Fatalf("bulk validation failure should not add valid rows: %s", list)
 		}
 	})
 
@@ -473,4 +530,28 @@ func TestEmbeddedDepNoCycleCheck(t *testing.T) {
 	// Verify --no-cycle-check also works with the dep --blocks shorthand.
 	extra := bdCreate(t, bd, dir, "bulk-dep-extra", "--type", "task")
 	bdDep(t, bd, dir, extra.ID, "--blocks", ids[n-1], "--no-cycle-check")
+}
+
+func TestEmbeddedDepBulkNoCycleCheckSkipsPerEdgeCycleValidation(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "bcy")
+
+	a := bdCreate(t, bd, dir, "Bulk cycle A", "--type", "task")
+	b := bdCreate(t, bd, dir, "Bulk cycle B", "--type", "task")
+	input := fmt.Sprintf("{\"from\":%q,\"to\":%q}\n{\"from\":%q,\"to\":%q}\n", a.ID, b.ID, b.ID, a.ID)
+
+	out := bdDepWithInput(t, bd, dir, input, "add", "--file", "-", "--no-cycle-check")
+	if !strings.Contains(out, "Added 2 dependencies") {
+		t.Fatalf("expected bulk add summary, got: %s", out)
+	}
+
+	cycles := bdDep(t, bd, dir, "cycles")
+	if !strings.Contains(cycles, "Found") {
+		t.Fatalf("expected skipped cycle validation to leave detectable cycle, got: %s", cycles)
+	}
 }

--- a/cmd/bd/dep_test.go
+++ b/cmd/bd/dep_test.go
@@ -463,6 +463,14 @@ func TestDepAddFlagAliases(t *testing.T) {
 	if !strings.Contains(longDesc, "--depends-on") {
 		t.Error("Expected Long description to mention --depends-on flag")
 	}
+	if fileFlag := depAddCmd.Flags().Lookup("file"); fileFlag == nil {
+		t.Fatal("depAddCmd should have --file flag")
+	} else if fileFlag.DefValue != "" {
+		t.Errorf("Expected default file='', got %q", fileFlag.DefValue)
+	}
+	if !strings.Contains(longDesc, "--file") {
+		t.Error("Expected Long description to mention --file flag")
+	}
 }
 
 func TestDepBlocksFlag(t *testing.T) {

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -631,37 +631,36 @@ func (t *doltTransaction) DeleteIssue(ctx context.Context, id string) error {
 // AddDependency adds a dependency within the transaction.
 // Checks for existing pairs to prevent silent type overwrites.
 func (t *doltTransaction) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	return t.AddDependencyWithOptions(ctx, dep, actor, storage.DependencyAddOptions{})
+}
+
+func (t *doltTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
 	table := "dependencies"
+	sourceTable := "issues"
 	if t.isActiveWisp(ctx, dep.IssueID) {
 		table = "wisp_dependencies"
+		sourceTable = "wisps"
 	}
 
-	// Check for existing dependency to prevent silent type overwrites.
-	var existingType string
-	//nolint:gosec // G201: table is hardcoded
-	err := t.tx.QueryRowContext(ctx, fmt.Sprintf(`
-		SELECT type FROM %s WHERE issue_id = ? AND depends_on_id = ?
-	`, table), dep.IssueID, dep.DependsOnID).Scan(&existingType)
-	if err == nil {
-		if existingType == string(dep.Type) {
-			return nil // idempotent
-		}
-		return fmt.Errorf("dependency %s -> %s already exists with type %q (requested %q); remove it first with 'bd dep remove' then re-add",
-			dep.IssueID, dep.DependsOnID, existingType, dep.Type)
-	}
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("failed to check existing dependency: %w", err)
+	isCrossPrefix := isCrossPrefixDep(dep.IssueID, dep.DependsOnID)
+	targetTable := "issues"
+	if !strings.HasPrefix(dep.DependsOnID, "external:") && !isCrossPrefix && t.isActiveWisp(ctx, dep.DependsOnID) {
+		targetTable = "wisps"
 	}
 
-	//nolint:gosec // G201: table is hardcoded
-	_, err = t.tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO %s (issue_id, depends_on_id, type, created_at, created_by, thread_id)
-		VALUES (?, ?, ?, NOW(), ?, ?)
-	`, table), dep.IssueID, dep.DependsOnID, dep.Type, actor, dep.ThreadID)
-	if err == nil {
-		t.dirty.MarkDirty(table)
+	opts := issueops.AddDependencyOpts{
+		SourceTable:    sourceTable,
+		TargetTable:    targetTable,
+		WriteTable:     table,
+		IsCrossPrefix:  isCrossPrefix,
+		SkipCycleCheck: addOpts.SkipCycleCheck,
 	}
-	return wrapExecError("add dependency in tx", err)
+	if err := issueops.AddDependencyInTx(ctx, t.tx, dep, actor, opts); err != nil {
+		return err
+	}
+	t.dirty.MarkDirty(table)
+	t.store.invalidateBlockedIDsCache()
+	return nil
 }
 
 func (t *doltTransaction) GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error) {

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -93,8 +93,15 @@ func (t *embeddedTransaction) SearchIssues(ctx context.Context, query string, fi
 }
 
 func (t *embeddedTransaction) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	return t.AddDependencyWithOptions(ctx, dep, actor, storage.DependencyAddOptions{})
+}
+
+func (t *embeddedTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
 	t.dirty.MarkDirty("dependencies")
-	return issueops.AddDependencyInTx(ctx, t.tx, dep, actor, issueops.AddDependencyOpts{})
+	return issueops.AddDependencyInTx(ctx, t.tx, dep, actor, issueops.AddDependencyOpts{
+		IsCrossPrefix:  types.ExtractPrefix(dep.IssueID) != types.ExtractPrefix(dep.DependsOnID),
+		SkipCycleCheck: addOpts.SkipCycleCheck,
+	})
 }
 
 func (t *embeddedTransaction) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -263,7 +263,11 @@ func (t *hookTrackingTransaction) CloseIssue(ctx context.Context, id string, rea
 }
 
 func (t *hookTrackingTransaction) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
-	if err := t.Transaction.AddDependency(ctx, dep, actor); err != nil {
+	return t.AddDependencyWithOptions(ctx, dep, actor, DependencyAddOptions{})
+}
+
+func (t *hookTrackingTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, opts DependencyAddOptions) error {
+	if err := t.Transaction.AddDependencyWithOptions(ctx, dep, actor, opts); err != nil {
 		return err
 	}
 	if issue, err := t.Transaction.GetIssue(ctx, dep.IssueID); err == nil {

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -31,6 +31,9 @@ type AddDependencyOpts struct {
 	// IsCrossPrefix is true when source and target have different prefixes,
 	// meaning the target lives in another rig's database.
 	IsCrossPrefix bool
+	// SkipCycleCheck skips the recursive pre-insert cycle check for callers
+	// that intentionally trade validation cost for bulk graph wiring speed.
+	SkipCycleCheck bool
 }
 
 // AddDependencyInTx validates and inserts a dependency within an existing
@@ -120,7 +123,7 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	}
 
 	// Cycle detection for blocking deps via recursive CTE.
-	if dep.Type == types.DepBlocks || dep.Type == types.DepConditionalBlocks {
+	if !opts.SkipCycleCheck && (dep.Type == types.DepBlocks || dep.Type == types.DepConditionalBlocks) {
 		// Build UNION ALL across all dep tables for the CTE.
 		var unions []string
 		for _, t := range depTables {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -255,6 +255,7 @@ type Transaction interface {
 
 	// Dependency operations
 	AddDependency(ctx context.Context, dep *types.Dependency, actor string) error
+	AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, opts DependencyAddOptions) error
 	RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error
 	GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error)
 
@@ -281,4 +282,11 @@ type Transaction interface {
 	AddComment(ctx context.Context, issueID, actor, comment string) error
 	ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error)
 	GetIssueComments(ctx context.Context, issueID string) ([]*types.Comment, error)
+}
+
+// DependencyAddOptions controls transaction-scoped dependency insertion.
+type DependencyAddOptions struct {
+	// SkipCycleCheck bypasses the recursive pre-insert cycle check. This is
+	// intended for bulk wiring paths that perform a final graph check separately.
+	SkipCycleCheck bool
 }


### PR DESCRIPTION
## Summary

Fixes #3408.

Adds a machine-friendly bulk form for `bd dep add`:

- `bd dep add --file <path>` reads newline-delimited JSON dependency edges from a file
- `bd dep add --file -` reads the same JSONL format from stdin
- each edge is `{ "from": "bd-2", "to": "bd-1", "type": "blocks" }`, with `type` defaulting to `--type`
- `issue_id` / `depends_on_id` aliases are accepted for machine-generated records
- file parse errors and resolution/validation errors are reported together before mutation
- mutation runs through one transaction for one coherent Dolt commit

The transaction dependency path now exposes `DependencyAddOptions` so bulk `--no-cycle-check` skips the per-edge recursive cycle check as well as the post-add warning. Normal transaction adds still use the shared `issueops.AddDependencyInTx` validation path.

## Coordination

Preflight found and reviewed overlapping PRs before updating this PR:

- #3521 (`rjc123`): directly related `--no-cycle-check` work. This PR is logically stacked on the approved #3521 head `bb0493d20` and should not merge before #3521 lands, unless maintainers intentionally want to merge the stack together while preserving Robin’s commit attribution.
- #3417: adjacent issueops/wisp bulk hydrator work; no direct CLI bulk dep-add overlap.
- #3526 and #3337: bulk/wisp-routing performance work in nearby storage areas; no direct CLI JSONL dep-add overlap found.

I updated this existing PR instead of opening a duplicate PR.

## Tests

- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run '^TestEmbeddedDepBulkNoCycleCheckSkipsPerEdgeCycleValidation$|^TestEmbeddedDep$|^TestEmbeddedDepNoCycleCheck$' -count=1`
- `go test -tags gms_pure_go ./cmd/bd -run '^TestDepAddFlagAliases$|^TestDepBlocksFlag$|^TestDepCommandFlags$' -count=1`
- `go test -tags gms_pure_go ./internal/storage/issueops ./internal/storage/dolt ./internal/storage/embeddeddolt`
- `make test` with `TMPDIR=/var/tmp/beads-test-bd-wjl-review GOTMPDIR=/var/tmp/beads-test-bd-wjl-review`
