### PR TITLE
fix(list): sort children with numeric suffixes naturally (GH#3477)

### DIFF
--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -99,13 +100,28 @@ func buildIssueTreeWithDeps(issues []*types.Issue, allDeps map[string][]*types.D
 // compareIssuesByPriority provides stable sorting for tree display
 // Primary sort: priority (P0 before P1 before P2...)
 // Secondary sort: ID for deterministic ordering when priorities match
+func compareIDsNumerically(a, b string) int {
+	aDot := strings.LastIndex(a, ".")
+	bDot := strings.LastIndex(b, ".")
+	if aDot >= 0 && bDot >= 0 {
+		aPrefix, aSuffix := a[:aDot], a[aDot+1:]
+		bPrefix, bSuffix := b[:bDot], b[bDot+1:]
+		if aPrefix == bPrefix {
+			aNum, aErr := strconv.Atoi(aSuffix)
+			bNum, bErr := strconv.Atoi(bSuffix)
+			if aErr == nil && bErr == nil {
+				return cmp.Compare(aNum, bNum)
+			}
+		}
+	}
+	return cmp.Compare(a, b)
+}
+
 func compareIssuesByPriority(a, b *types.Issue) int {
-	// Primary: priority (ascending: P0 before P1 before P2...)
 	if result := cmp.Compare(a.Priority, b.Priority); result != 0 {
 		return result
 	}
-	// Secondary: ID for deterministic order when priorities match
-	return cmp.Compare(a.ID, b.ID)
+	return compareIDsNumerically(a.ID, b.ID)
 }
 
 // printPrettyTree recursively prints the issue tree


### PR DESCRIPTION
## Summary

Children with numeric dotted suffixes (e.g. `hq-abc.4`, `hq-abc.5` ... `hq-abc.10`, `hq-abc.11`) were sorted alphabetically by `compareIssuesByPriority`, causing `.10` to appear before `.9` in `bd list --pretty` / tree output.

## Root cause

`compareIssuesByPriority` fell back to `cmp.Compare(a.ID, b.ID)` — a plain lexicographic string comparison — for the secondary sort key. Because `"10" < "2"` lexicographically, children with double-digit numeric suffixes landed ahead of single-digit ones.

## Fix

Add `compareIDsNumerically(a, b string) int`:
- Splits each ID on the **last** `.`
- If both share the same prefix **and** both suffixes parse cleanly as integers, compare numerically
- Otherwise falls back to plain `cmp.Compare` (no behaviour change for non-numeric IDs)

`compareIssuesByPriority` now delegates its secondary sort to `compareIDsNumerically`.

## Before / After

**Before:**
```
hq-abc.10  hq-abc.11  hq-abc.12  hq-abc.4  hq-abc.5 ...
```

**After:**
```
hq-abc.4  hq-abc.5  hq-abc.6  ... hq-abc.10  hq-abc.11  hq-abc.12
```

Closes #3477

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>