### PR TITLE
Fix: ~/.config/bd/config.yaml not loaded on macOS

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,25 @@ func Initialize() error {
 		}
 	}
 
+	// Also check ~/.config/bd/config.yaml explicitly. On macOS,
+	// os.UserConfigDir() returns ~/Library/Application Support, not ~/.config.
+	// This ensures the documented path works on all platforms.
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		xdgPath := filepath.Join(homeDir, ".config", "bd", "config.yaml")
+		alreadyAdded := false
+		for _, existing := range configPaths {
+			if filepath.Clean(existing) == filepath.Clean(xdgPath) {
+				alreadyAdded = true
+				break
+			}
+		}
+		if !alreadyAdded {
+			if _, err := os.Stat(xdgPath); err == nil {
+				configPaths = append(configPaths, xdgPath)
+			}
+		}
+	}
+
 	// 1. Project: walk up from CWD to find .beads/config.yaml
 	beadsDirEnv := strings.TrimSpace(os.Getenv("BEADS_DIR"))
 	beadsEnvConfigPath := ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1415,6 +1415,125 @@ func TestGetStringFromDir(t *testing.T) {
 	})
 }
 
+// TestXDGConfigPath_Loaded verifies that ~/.config/bd/config.yaml is loaded
+// when it exists, even if os.UserConfigDir() returns a different path (macOS).
+func TestXDGConfigPath_Loaded(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	// Clear env vars that could interfere with config defaults
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome) // Windows
+
+	// Create ~/.config/bd/config.yaml with a distinctive value
+	xdgConfigDir := filepath.Join(tmpHome, ".config", "bd")
+	if err := os.MkdirAll(xdgConfigDir, 0o755); err != nil {
+		t.Fatalf("failed to create xdg config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(xdgConfigDir, "config.yaml"),
+		[]byte("actor: xdg-test-user\n"), 0o600); err != nil {
+		t.Fatalf("failed to write xdg config: %v", err)
+	}
+
+	// Set XDG_CONFIG_HOME to a DIFFERENT directory so os.UserConfigDir()
+	// won't return ~/.config (simulates macOS behavior).
+	altConfigDir := filepath.Join(tmpHome, "Library", "Application Support")
+	if err := os.MkdirAll(altConfigDir, 0o755); err != nil {
+		t.Fatalf("failed to create alt config dir: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", altConfigDir)
+
+	// CWD should be somewhere with no .beads/
+	t.Chdir(tmpHome)
+
+	ResetForTesting()
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	if got := GetString("actor"); got != "xdg-test-user" {
+		t.Errorf("GetString(actor) = %q, want %q (from ~/.config/bd/config.yaml)", got, "xdg-test-user")
+	}
+}
+
+// TestXDGConfigPath_Dedup verifies that when os.UserConfigDir() already returns
+// ~/.config, the path is not added twice.
+func TestXDGConfigPath_Dedup(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+
+	// Make XDG_CONFIG_HOME point to ~/.config so os.UserConfigDir() returns it
+	dotConfig := filepath.Join(tmpHome, ".config")
+	t.Setenv("XDG_CONFIG_HOME", dotConfig)
+
+	// Create the config file
+	xdgConfigDir := filepath.Join(dotConfig, "bd")
+	if err := os.MkdirAll(xdgConfigDir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(xdgConfigDir, "config.yaml"),
+		[]byte("actor: dedup-user\n"), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	t.Chdir(tmpHome)
+
+	ResetForTesting()
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	// The config should load exactly once (no error from duplicate merge)
+	if got := GetString("actor"); got != "dedup-user" {
+		t.Errorf("GetString(actor) = %q, want %q", got, "dedup-user")
+	}
+}
+
+// TestXDGConfigPath_Missing verifies that when ~/.config/bd/config.yaml does
+// not exist, no error occurs.
+func TestXDGConfigPath_Missing(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, "xdg-config"))
+
+	t.Chdir(tmpHome)
+
+	ResetForTesting()
+	err := Initialize()
+	if err != nil {
+		t.Fatalf("Initialize() returned error when ~/.config/bd/config.yaml missing: %v", err)
+	}
+
+	// Should still have defaults
+	if got := GetString("actor"); got != "" {
+		t.Errorf("GetString(actor) = %q, want empty (default)", got)
+	}
+}
+
 func TestInitialize_ExternalBEADSDirDoesNotMergeCallerProjectConfig(t *testing.T) {
 	restore := envSnapshot(t)
 	defer restore()


### PR DESCRIPTION
## Summary

- The docs say to put config at `~/.config/bd/config.yaml`, but on macOS beads only checks `~/Library/Application Support/bd/config.yaml`. If you follow the docs on a Mac, your config is silently ignored.
- This adds `~/.config/bd/config.yaml` as a config source on all platforms. On Linux it's already checked via `os.UserConfigDir()`, so a dedup guard prevents loading it twice. On Windows it adds `C:\Users\<name>\.config\bd\` alongside `AppData\Roaming\bd\`.
- If the file doesn't exist, nothing changes. No new behavior for users without it.

## Test plan

- [x] Config at `~/.config/bd/` loads when the platform default points elsewhere (macOS case)
- [x] No double-load on Linux where the platform default is already `~/.config`
- [x] No error when `~/.config/bd/config.yaml` doesn't exist
- [x] All config tests pass
- [x] Clean build with `CGO_ENABLED=0 go build -tags nocgo ./...`
- [ ] Manual: create `~/.config/bd/config.yaml` on a Mac, confirm `bd` picks it up

## Config priority order (unchanged)

1. `BEADS_DIR/config.yaml` (highest)
2. Project `.beads/config.yaml`
3. `~/.config/bd/config.yaml` -- now works on macOS and Windows
4. `os.UserConfigDir()/bd/config.yaml` (platform default)
5. `~/.beads/config.yaml` (legacy, lowest)

## Files changed

- `internal/config/config.go` -- 19 lines added in `Initialize()`
- `internal/config/config_test.go` -- 3 new test functions