### PR TITLE
perf(storage): gate compat migrations with tracking table

### DIFF
--- a/internal/storage/dolt/compat_migrations_test.go
+++ b/internal/storage/dolt/compat_migrations_test.go
@@ -1,0 +1,80 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
+)
+
+// TestRunCompatMigrationsSkipsWhenUpToDate verifies that RunCompatMigrations
+// returns early once all migrations have been recorded as applied.
+// Regression test for be-9s8: previously, every store open ran all 17
+// compat migrations, adding ~30 SQL queries per bd invocation.
+func TestRunCompatMigrationsSkipsWhenUpToDate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// setupTestStore already ran RunCompatMigrations during init.
+	// Drop a table that compat migration 015 (custom_status_type_tables)
+	// would recreate, as a marker for "did the migration run again?".
+	if _, err := store.db.ExecContext(ctx, "DROP TABLE IF EXISTS custom_statuses"); err != nil {
+		t.Fatalf("failed to drop custom_statuses: %v", err)
+	}
+
+	if err := migrations.RunCompatMigrations(store.db); err != nil {
+		t.Fatalf("RunCompatMigrations failed: %v", err)
+	}
+
+	var count int
+	err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'custom_statuses' AND table_schema = DATABASE()").Scan(&count)
+	if err != nil {
+		t.Fatalf("checking custom_statuses: %v", err)
+	}
+	if count != 0 {
+		t.Error("custom_statuses was recreated — RunCompatMigrations should skip when migrations are tracked as applied")
+	}
+}
+
+// TestRunCompatMigrationsRunsPendingMigrations verifies the slow path:
+// when compat_migrations is empty (e.g. pre-fix DB upgrading), pending
+// migrations actually run.
+func TestRunCompatMigrationsRunsPendingMigrations(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM compat_migrations"); err != nil {
+		t.Fatalf("clearing compat_migrations: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "DROP TABLE IF EXISTS custom_statuses"); err != nil {
+		t.Fatalf("dropping custom_statuses: %v", err)
+	}
+
+	if err := migrations.RunCompatMigrations(store.db); err != nil {
+		t.Fatalf("RunCompatMigrations failed: %v", err)
+	}
+
+	var count int
+	err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'custom_statuses' AND table_schema = DATABASE()").Scan(&count)
+	if err != nil {
+		t.Fatalf("checking custom_statuses: %v", err)
+	}
+	if count == 0 {
+		t.Error("custom_statuses was not recreated — slow path should re-run migration 015 when compat_migrations is empty")
+	}
+
+	var rows int
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM compat_migrations").Scan(&rows); err != nil {
+		t.Fatalf("checking compat_migrations: %v", err)
+	}
+	if rows != len(migrations.ListCompatMigrations()) {
+		t.Errorf("compat_migrations has %d rows, want %d", rows, len(migrations.ListCompatMigrations()))
+	}
+}

--- a/internal/storage/dolt/compat_migrations_test.go
+++ b/internal/storage/dolt/compat_migrations_test.go
@@ -6,10 +6,14 @@ import (
 	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
 )
 
-// TestRunCompatMigrationsSkipsWhenUpToDate verifies that RunCompatMigrations
-// returns early once all migrations have been recorded as applied.
-// Regression test for be-9s8: previously, every store open ran all 17
-// compat migrations, adding ~30 SQL queries per bd invocation.
+// TestRunCompatMigrationsSkipsWhenUpToDate verifies that backfill-tier
+// migrations are gated by compat_migrations once recorded as applied.
+// Drift-tier migrations (the schema-shape repairs) intentionally run
+// every time — their idempotency check IS the drift detector, per
+// GH#3412 / be-bjxf — so this test exercises only the backfill path.
+//
+// Regression test for be-9s8 (the fast-path savings) and be-zjv6 (the
+// fix that re-enables drift-tier self-heal by gating only backfill-tier).
 func TestRunCompatMigrationsSkipsWhenUpToDate(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
@@ -17,11 +21,14 @@ func TestRunCompatMigrationsSkipsWhenUpToDate(t *testing.T) {
 	ctx, cancel := testContext(t)
 	defer cancel()
 
-	// setupTestStore already ran RunCompatMigrations during init.
-	// Drop a table that compat migration 015 (custom_status_type_tables)
-	// would recreate, as a marker for "did the migration run again?".
-	if _, err := store.db.ExecContext(ctx, "DROP TABLE IF EXISTS custom_statuses"); err != nil {
-		t.Fatalf("failed to drop custom_statuses: %v", err)
+	// setupTestStore already ran RunCompatMigrations, so compat_migrations
+	// has a row for backfill_custom_tables and custom_types is populated
+	// (migration 016 backfilled the legacy default rows).
+	// Clear custom_types to set up the gating assertion: if the backfill
+	// re-runs, it will repopulate the table; if it's gated, the table
+	// stays empty.
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM custom_types"); err != nil {
+		t.Fatalf("failed to clear custom_types: %v", err)
 	}
 
 	if err := migrations.RunCompatMigrations(store.db); err != nil {
@@ -29,19 +36,18 @@ func TestRunCompatMigrationsSkipsWhenUpToDate(t *testing.T) {
 	}
 
 	var count int
-	err := store.db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'custom_statuses' AND table_schema = DATABASE()").Scan(&count)
-	if err != nil {
-		t.Fatalf("checking custom_statuses: %v", err)
+	if err := store.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM custom_types").Scan(&count); err != nil {
+		t.Fatalf("checking custom_types: %v", err)
 	}
 	if count != 0 {
-		t.Error("custom_statuses was recreated — RunCompatMigrations should skip when migrations are tracked as applied")
+		t.Errorf("custom_types has %d rows, want 0 — backfill_custom_tables should be gated by compat_migrations once applied", count)
 	}
 }
 
 // TestRunCompatMigrationsRunsPendingMigrations verifies the slow path:
-// when compat_migrations is empty (e.g. pre-fix DB upgrading), pending
-// migrations actually run.
+// when compat_migrations is empty (e.g. pre-fix DB upgrading), every
+// migration runs — both drift-tier (which always runs anyway) and
+// backfill-tier (whose tracking-table row was cleared).
 func TestRunCompatMigrationsRunsPendingMigrations(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/migrations/runner.go
+++ b/internal/storage/dolt/migrations/runner.go
@@ -7,44 +7,61 @@ import (
 	"strings"
 )
 
+// CompatTier classifies a compat migration's eligibility for tracking-table
+// gating. Drift-tier migrations always re-run because their idempotency check
+// IS the drift detector — gating them silences the self-heal that GH#3412 /
+// be-bjxf depends on. Backfill-tier migrations are one-shot data fills; safe
+// to skip after first apply.
+type CompatTier int
+
+const (
+	CompatTierDrift    CompatTier = iota // always run; check is the drift detector
+	CompatTierBackfill                   // gate via compat_migrations after first apply
+)
+
 // CompatMigration represents a backward-compat migration for databases that
 // predate the embedded migration system.
 type CompatMigration struct {
 	Name string
 	Func func(*sql.DB) error
+	Tier CompatTier
 }
 
 // compatMigrationsList is the ordered list of backward-compat migrations
 // for databases that predate the embedded migration system. Each migration
 // must be idempotent — safe to run multiple times.
 var compatMigrationsList = []CompatMigration{
-	{"wisp_type_column", MigrateWispTypeColumn},
-	{"spec_id_column", MigrateSpecIDColumn},
-	{"orphan_detection", DetectOrphanedChildren},
-	{"wisps_table", MigrateWispsTable},
-	{"wisp_auxiliary_tables", MigrateWispAuxiliaryTables},
-	{"issue_counter_table", MigrateIssueCounterTable},
-	{"infra_to_wisps", MigrateInfraToWisps},
-	{"wisp_dep_type_index", MigrateWispDepTypeIndex},
-	{"cleanup_autopush_metadata", MigrateCleanupAutopushMetadata},
-	{"uuid_primary_keys", MigrateUUIDPrimaryKeys},
-	{"add_no_history_column", MigrateAddNoHistoryColumn},
-	{"add_started_at_column", MigrateAddStartedAtColumn},
-	{"drop_hop_columns", MigrateDropHOPColumns},
-	{"drop_child_counters_fk", MigrateDropChildCountersFK},
-	{"wisp_events_created_at_index", MigrateWispEventsCreatedAtIndex},
-	{"custom_status_type_tables", MigrateCustomStatusTypeTables},
-	{"backfill_custom_tables", BackfillCustomTables},
+	{"wisp_type_column", MigrateWispTypeColumn, CompatTierDrift},
+	{"spec_id_column", MigrateSpecIDColumn, CompatTierDrift},
+	{"orphan_detection", DetectOrphanedChildren, CompatTierDrift},
+	{"wisps_table", MigrateWispsTable, CompatTierDrift},
+	{"wisp_auxiliary_tables", MigrateWispAuxiliaryTables, CompatTierDrift},
+	{"issue_counter_table", MigrateIssueCounterTable, CompatTierDrift},
+	{"infra_to_wisps", MigrateInfraToWisps, CompatTierDrift},
+	{"wisp_dep_type_index", MigrateWispDepTypeIndex, CompatTierDrift},
+	{"cleanup_autopush_metadata", MigrateCleanupAutopushMetadata, CompatTierDrift},
+	{"uuid_primary_keys", MigrateUUIDPrimaryKeys, CompatTierDrift},
+	{"add_no_history_column", MigrateAddNoHistoryColumn, CompatTierDrift},
+	{"add_started_at_column", MigrateAddStartedAtColumn, CompatTierDrift},
+	{"drop_hop_columns", MigrateDropHOPColumns, CompatTierDrift},
+	{"drop_child_counters_fk", MigrateDropChildCountersFK, CompatTierDrift},
+	{"wisp_events_created_at_index", MigrateWispEventsCreatedAtIndex, CompatTierDrift},
+	{"custom_status_type_tables", MigrateCustomStatusTypeTables, CompatTierDrift},
+	{"backfill_custom_tables", BackfillCustomTables, CompatTierBackfill},
 }
 
 // RunCompatMigrations executes pending backward-compat migrations. These handle
 // historical data transforms for databases that predate the embedded
 // migration system (ALTER TABLE ADD COLUMN, data moves, FK drops, etc.).
 //
-// A compat_migrations tracking table records which migrations have already
-// been applied. Once a migration is recorded, it is skipped on subsequent
-// store opens. Without this gate every bd invocation paid for ~30 SQL
-// roundtrips of idempotent no-op checks (be-9s8).
+// A compat_migrations tracking table records which migrations have run, but
+// gating is tier-aware:
+//   - CompatTierDrift migrations always run because their idempotency check
+//     is the drift detector — gating them silences the schema-shape self-heal
+//     that GH#3412 / be-bjxf depends on.
+//   - CompatTierBackfill migrations are one-shot data fills and are skipped
+//     once recorded as applied. This is the be-9s8 fast path that drops
+//     the bd-invocation cost of repeated idempotent inserts.
 func RunCompatMigrations(db *sql.DB) error {
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS compat_migrations (
 		name VARCHAR(64) PRIMARY KEY,
@@ -72,7 +89,7 @@ func RunCompatMigrations(db *sql.DB) error {
 	}
 
 	for _, m := range compatMigrationsList {
-		if applied[m.Name] {
+		if m.Tier == CompatTierBackfill && applied[m.Name] {
 			continue
 		}
 		if err := m.Func(db); err != nil {

--- a/internal/storage/dolt/migrations/runner.go
+++ b/internal/storage/dolt/migrations/runner.go
@@ -37,15 +37,51 @@ var compatMigrationsList = []CompatMigration{
 	{"backfill_custom_tables", BackfillCustomTables},
 }
 
-// RunCompatMigrations executes all backward-compat migrations. These handle
+// RunCompatMigrations executes pending backward-compat migrations. These handle
 // historical data transforms for databases that predate the embedded
 // migration system (ALTER TABLE ADD COLUMN, data moves, FK drops, etc.).
-// Each migration is idempotent and checks whether its changes have already
-// been applied.
+//
+// A compat_migrations tracking table records which migrations have already
+// been applied. Once a migration is recorded, it is skipped on subsequent
+// store opens. Without this gate every bd invocation paid for ~30 SQL
+// roundtrips of idempotent no-op checks (be-9s8).
 func RunCompatMigrations(db *sql.DB) error {
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS compat_migrations (
+		name VARCHAR(64) PRIMARY KEY,
+		applied_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+	)`); err != nil {
+		return fmt.Errorf("creating compat_migrations table: %w", err)
+	}
+
+	applied := make(map[string]bool, len(compatMigrationsList))
+	rows, err := db.Query("SELECT name FROM compat_migrations")
+	if err != nil {
+		return fmt.Errorf("reading compat_migrations: %w", err)
+	}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning compat_migrations: %w", err)
+		}
+		applied[name] = true
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating compat_migrations: %w", err)
+	}
+
 	for _, m := range compatMigrationsList {
+		if applied[m.Name] {
+			continue
+		}
 		if err := m.Func(db); err != nil {
 			return fmt.Errorf("compat migration %q failed: %w", m.Name, err)
+		}
+		// INSERT IGNORE so concurrent processes racing on a fresh DB don't
+		// fail on duplicate-key — same pattern as schema_migrations.
+		if _, err := db.Exec("INSERT IGNORE INTO compat_migrations (name) VALUES (?)", m.Name); err != nil {
+			return fmt.Errorf("recording compat migration %s: %w", m.Name, err)
 		}
 	}
 
@@ -72,11 +108,12 @@ func RunCompatMigrations(db *sql.DB) error {
 		"issue_snapshots", "compaction_snapshots", "federation_peers",
 		"custom_statuses", "custom_types",
 		"dolt_ignore",
+		"compat_migrations",
 	}
 	for _, table := range migrationTables {
 		_, _ = db.Exec("CALL DOLT_ADD(?)", table)
 	}
-	_, err := db.Exec("CALL DOLT_COMMIT('-m', 'schema: auto-migrate')")
+	_, err = db.Exec("CALL DOLT_COMMIT('-m', 'schema: auto-migrate')")
 	if err != nil {
 		if !strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
 			log.Printf("dolt compat migration commit warning: %v", err)

--- a/release-gates/be-86hb-gate.md
+++ b/release-gates/be-86hb-gate.md
@@ -1,0 +1,64 @@
+# Release gate — be-86hb (PR #3540 hotfix: tier-aware compat migrations)
+
+**Date:** 2026-04-30
+**Deployer:** beads/deployer-1
+**Bead (review):** be-86hb — Review: be-zjv6 tier-aware compat migrations (PR #3540 fix)
+**Feature bead:** be-zjv6 (closed) — discovered from be-4m8o
+**Source commit:** `145a67a4` on `be-xtf-readme`
+**Cherry-picked as:** `75514126` on `release/be-n6n`
+**Base:** `release/be-n6n` @ `720afaf3` (original be-n6n gate PASS commit)
+
+## Verdict: PASS
+
+This is a follow-up gate on top of the original `release-gates/be-n6n-gate.md`.
+PR #3540 had landed `92cb2022` (be-n6n perf gate) which CI subsequently
+caught as a regression in `TestEmbeddedOpenRunsCompatMigrations`: the
+tracking-table gate silenced the GH#3412 schema-shape self-heal that
+017_add_started_at_column relies on. be-zjv6 introduced the tier split
+fix; this deploy lands it on top of the existing PR.
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | reviewer-gm-po6pox3 verdict in be-86hb notes: "0 blockers, 0 high, 0 medium, 0 low." Commit 145a67a4 reviewed against be-zjv6 spec; tier semantics + test rewrite confirmed correct. |
+| 2 | Acceptance criteria met | PASS | `CompatTier` enum + `Tier` field on `CompatMigration` (runner.go); 16 entries `CompatTierDrift`, only `backfill_custom_tables` is `CompatTierBackfill`; gate is `if m.Tier == CompatTierBackfill && applied[m.Name]`. `compat_migrations_test.go::TestRunCompatMigrationsSkipsWhenUpToDate` rewritten to assert backfill gate via `DELETE FROM custom_types` + post-call recount. Out-of-scope files (`embeddeddolt/compat_migrations_test.go`, `release-gates/be-n6n-gate.md`) untouched. |
+| 3 | Tests pass | PASS | Targeted regression: `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go -count=1 -run TestEmbeddedOpenRunsCompatMigrations ./internal/storage/embeddeddolt/` → `ok 0.519s` (the CI failure that motivated this fix). `go test -tags gms_pure_go -count=1 -run TestRunCompatMigrations ./internal/storage/dolt/` → PASS. `go test -tags gms_pure_go ./internal/storage/dolt/migrations/...` → PASS. Build clean (`go build -tags gms_pure_go ./...`). Full `./internal/storage/dolt/` run shows the same pre-existing failure set documented on the original be-n6n gate (`TestApplyConfigDefaults_*` from `BEADS_DOLT_SERVER_PORT=28231` in the rig env, `TestPrePushFSCK_UnopenableDB` fixture issue) — no new regressions. |
+| 4 | No high-severity review findings open | PASS | Reviewer reported 0 blockers, 0 high, 0 medium, 0 low. |
+| 5 | Final branch is clean | PASS | `git status` shows only pre-existing untracked scaffolding (`.gc/`, `.gitkeep`, `release-gates/be-pq5-gate.md` from a prior FAIL deploy). Same set as original be-n6n gate. |
+| 6 | Branch diverges cleanly from main | PASS | Cherry-pick of `145a67a4` onto `release/be-n6n` @ `720afaf3` applied with no conflicts (`git cherry-pick 145a67a4` → `[release/be-n6n 75514126] fix(dolt): be-zjv6 tier-aware compat migrations preserve drift self-heal`, 2 files changed, 61+/38−). |
+
+## Cherry-pick decision
+
+Source branch `be-xtf-readme` carries downstream commits beyond 145a67a4
+(fd11920c be-xtf docs, ee67d5f9 be-avn staleDatabasePrefixes,
+5e6d84b4 be-a5z list --skip-labels, 77f6bd34 be-z5w isProductionPort
+docs). Only `145a67a4` is in scope here per be-86hb hand-off — the others
+are tracked under their own review beads (be-jdoy, be-ripy, etc.) and
+will deploy through their own ship paths.
+
+## Trade-off acknowledged
+
+Fast-path SQL savings change from "30 → 3 roundtrips" to "30 → ~17"
+because drift-tier idempotency checks still run. This is the deliberate
+trade-off documented in be-zjv6 and the runner doc comment. If gas-city
+contention re-surfaces, the follow-up is an introspection cache or
+fingerprint sentinel — out of scope for this fix.
+
+## Pre-existing failures (acknowledged, not introduced)
+
+`./internal/storage/dolt/...` full run shows the same set the original
+be-n6n gate catalogued and the be-bpb validator independently flagged:
+
+- `TestApplyConfigDefaults_*` (5 cases) — port-isolation tests that
+  observe `BEADS_DOLT_SERVER_PORT=28231` set in the deployer rig env;
+  failures reproduce on `origin/main` baseline, orthogonal to this fix.
+- `TestPrePushFSCK_UnopenableDB` — pre-existing fixture issue.
+
+None touch compat-migration code paths.
+
+## Hand-off notes
+
+- PR #3540 commit history after this deploy: `92cb2022` (be-n6n perf) →
+  `720afaf3` (original gate) → `75514126` (this fix). No history rewrite;
+  forward push only.
+- Post-deploy: comment on PR #3540 enumerating the regression and the
+  tier-split fix per be-zjv6 done-when.

--- a/release-gates/be-n6n-gate.md
+++ b/release-gates/be-n6n-gate.md
@@ -1,0 +1,55 @@
+# Release gate — be-n6n (gate compat migrations with tracking table)
+
+**Date:** 2026-04-27
+**Deployer:** beads/deployer-1
+**Bead (review):** be-bwp — Review: be-n6n gate RunCompatMigrations with compat_migrations tracking table
+**Feature bead:** be-n6n (closed)
+**Source commit:** `76d4215b` on `be-vzu-rebase-fix`
+**Cherry-picked as:** `92cb2022` on `release/be-n6n`
+**Base:** `origin/main` @ `0bc4c725` (feat: add JSONL bulk dep add (#3530))
+
+## Verdict: PASS
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | beads/reviewer-1 verdict in be-bwp notes: triangulated review (eng-mgr / principal-eng / security-eng), all findings INFO non-blocking, "Verdict: **PASS** — ready to deploy." |
+| 2 | Acceptance criteria met | PASS | Per reviewer's done-when checklist walk: tracking table created, `compat_migrations` added to `migrationTables` (line 111), both regression tests added in dolt package and pass, FAIL on stash-revert verified, concurrent-init tests pass, lint clean. The two non-checkbox items (repo-wide flakes and before/after timing) carve out under reviewer-policy (c). |
+| 3 | Tests pass | PASS | Targeted: `go test -tags gms_pure_go -run 'TestRunCompatMigrations\|TestInitSchemaConcurrent' ./internal/storage/dolt/...` → `ok 2.106s`. Full `make test`: failures present, all verified pre-existing by reverting `runner.go` + `compat_migrations_test.go` to `origin/main` and re-running the same tests — same set fails on baseline, no new regressions from be-n6n. Driver: `BEADS_DOLT_SERVER_PORT=28231` is set in the deployer worktree env (gc rig), which breaks `TestApplyConfigDefaults_*` and other port-isolation-sensitive tests on origin/main too. Orthogonal to this fix. |
+| 4 | No high-severity review findings open | PASS | Three INFO-only findings, all marked non-blocking. Zero MAJOR/HIGH/BLOCKING findings. |
+| 5 | Final branch is clean | PASS | `git status` clean against tracked files; only untracked are pre-existing scaffolding (`.gc/`, `.gitkeep`, `release-gates/be-pq5-gate.md` from a prior FAIL deploy). |
+| 6 | Branch diverges cleanly from main | PASS | Single cherry-pick of `76d4215b` onto `origin/main` applied with no conflicts. `git log origin/main..HEAD` = exactly one commit (`92cb2022`). 2 files changed, 121 insertions, 4 deletions — matches the source commit's stat exactly. |
+
+## Cherry-pick decision
+
+The source branch `be-vzu-rebase-fix` carried three unrelated commits:
+
+- `d67652be` — be-vzu (already deployed via `release/be-vzu`)
+- `76d4215b` — be-n6n (this deploy)
+- `c835e2eb` — be-c5p (review be-z5w returned **REQUEST-CHANGES** — must NOT ship)
+
+Only `76d4215b` was picked, by hash. The bead description names this commit
+explicitly: *"Review of commit 76d4215b on be-vzu-rebase-fix."*
+
+## Review findings (all INFO, non-blocking)
+
+1. **Done-when "before/after timing" gap** — carve-out (c) applies. The
+   bug's pathological cost is server-mode + cross-process contention; the
+   embedded backend's in-process SQL is sub-millisecond, so local timings
+   are within noise. Structural fix (~30 SQL queries → 3 on the fast
+   path) is visible in the diff.
+2. **Two documented spec divergences:** file path
+   (`migrations/runner.go` vs spec's `migrations.go` — relocation in
+   `f368f988`) and caller scope (embedded backend DOES call
+   `RunCompatMigrations` post-relocation, fix benefits both callers).
+   Builder flagged both transparently.
+3. **Pre-existing test failures explicitly catalogued** by the builder
+   (`TestPullWithAutoResolve_BranchTrackingFallback`,
+   `TestSchemaParityAuxiliaryTables/*`, `TestSchemaParityIssuesVsWisps`,
+   `TestSchemaRunsInitWhenStale`). Each verified to fail on
+   stash-reverted code; not introduced by this fix.
+
+## Push target
+
+`origin` (gastownhall/beads) is upstream — `git push --dry-run origin HEAD`
+returns 403 for quad341. `PUSH_REMOTE=fork` (quad341/beads). PR is cross-repo
+with `--head quad341:release/be-n6n`.


### PR DESCRIPTION
## What this changes

Every time a `bd` command opens the Dolt store, the backward-compat migration
runner unconditionally executed all 17 entries in `compatMigrationsList`.
Each migration is idempotent, but its idempotency check is itself a SQL
roundtrip (`SHOW COLUMNS`, `SHOW TABLES`, `SHOW INDEX`, `SELECT COUNT(*)`,
etc.), so every `bd` invocation paid for ~30 SQL roundtrips against Dolt
for a no-op result. Against the embedded backend that's sub-millisecond,
but in shared-server deployments under contention each query is a TCP
roundtrip plus lock acquisition — this contributed to the gas-city 120s
timeouts tracked in `ga-sed` / `ga-fjjw`.

This PR introduces a `compat_migrations` tracking table that records which
named migrations have already run. On subsequent opens, recorded migrations
are skipped. Fast-path cost drops from ~30 queries to 3:

1. `CREATE TABLE IF NOT EXISTS compat_migrations` (no-op once bootstrapped)
2. `SELECT name FROM compat_migrations`
3. `SELECT COUNT FROM dolt_status` (existing dirty-check, unchanged)

## Review notes

- **Same gating pattern** as the existing `schema_migrations` table that
  already gates the embedded `.up.sql` migrations
  (`internal/storage/schema/schema.go:139`). The new code is the compat-side
  equivalent.
- **Concurrent first-open is safe** via `INSERT IGNORE INTO compat_migrations`.
  Compat migrations are documented as idempotent and have survived years of
  unconditional re-execution; concurrent identical execution is tolerated.
  `INSERT IGNORE` only silences the duplicate-key race.
- **Bootstrap** — `compat_migrations` is added to `migrationTables` in the
  same file so Dolt stages and commits the new tracking table on the first
  upgrade run. Once committed, subsequent opens see the populated table and
  skip every migration.
- **No caller change required.** Both `DoltStore` and `EmbeddedDoltStore`
  call `migrations.RunCompatMigrations` already; both benefit automatically.
- **No structural change to migration files.** The 17 individual migrations
  retain their internal idempotency checks as a second line of defense.

## Test plan

- [x] New unit tests in `internal/storage/dolt/compat_migrations_test.go`:
  - `TestRunCompatMigrationsSkipsWhenUpToDate` — drops a table that
    migration 015 would recreate, runs `RunCompatMigrations`, asserts the
    table is **not** recreated (proves the gate skipped).
  - `TestRunCompatMigrationsRunsPendingMigrations` — clears the tracking
    table to simulate a pre-fix DB upgrading, asserts migration 015 runs
    and that `compat_migrations` ends up fully populated.
- [x] FAIL-on-stash-revert verified: stashing the `runner.go` change while
  keeping the test causes `TestRunCompatMigrationsSkipsWhenUpToDate` to
  fail with "custom_statuses was recreated" (the unconditional re-run
  signature). Restoring the fix returns it to PASS.
- [x] `golangci-lint run --build-tags gms_pure_go ./internal/storage/dolt/...`
  is clean.
- [x] Release gate: [`release-gates/be-n6n-gate.md`](release-gates/be-n6n-gate.md)