### PR TITLE
Add suppress-history update primitive

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -240,6 +240,9 @@ create, update, show, or close operation).`,
 		if historyChanged {
 			updates["no_history"] = false
 		}
+		if suppressHistory, _ := cmd.Flags().GetBool("suppress-history"); suppressHistory {
+			updates[storage.UpdateKeySuppressHistory] = true
+		}
 		// Metadata flag (GH#1413)
 		if cmd.Flags().Changed("metadata") {
 			metadataValue, _ := cmd.Flags().GetString("metadata")
@@ -623,6 +626,7 @@ func init() {
 	updateCmd.Flags().Bool("persistent", false, "Mark issue as persistent (promote wisp to regular issue)")
 	updateCmd.Flags().Bool("no-history", false, "Mark issue as no-history (skip Dolt commits, not GC-eligible)")
 	updateCmd.Flags().Bool("history", false, "Clear no-history flag (re-enable Dolt commit history)")
+	updateCmd.Flags().Bool("suppress-history", false, "Apply this update without recording a durable event row")
 	// Metadata flag (GH#1413)
 	updateCmd.Flags().String("metadata", "", "Set custom metadata (JSON string or @file.json to read from file)")
 	// Incremental metadata edits (GH#1406)

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -770,6 +770,43 @@ func TestEmbeddedUpdate(t *testing.T) {
 		}
 	})
 
+	t.Run("update_suppress_history_skips_event_row", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Compact history test", "--type", "task")
+		dataDir := filepath.Join(beadsDir, "embeddeddolt")
+		cfg, _ := configfile.Load(beadsDir)
+		database := ""
+		if cfg != nil {
+			database = cfg.GetDoltDatabase()
+		}
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, database, "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		var eventsBefore int
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM events WHERE issue_id = ?", issue.ID).Scan(&eventsBefore); err != nil {
+			cleanup()
+			t.Fatalf("count events before: %v", err)
+		}
+		cleanup()
+		bdUpdate(t, bd, dir, issue.ID, "--description", "after", "--suppress-history")
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Description != "after" {
+			t.Fatalf("expected description 'after', got %q", got.Description)
+		}
+		db, cleanup, err = embeddeddolt.OpenSQL(t.Context(), dataDir, database, "main")
+		if err != nil {
+			t.Fatalf("OpenSQL reopen: %v", err)
+		}
+		defer cleanup()
+		var eventsAfter int
+		if err := db.QueryRowContext(t.Context(), "SELECT COUNT(*) FROM events WHERE issue_id = ?", issue.ID).Scan(&eventsAfter); err != nil {
+			t.Fatalf("count events after: %v", err)
+		}
+		if eventsAfter != eventsBefore {
+			t.Fatalf("events after = %d, want %d", eventsAfter, eventsBefore)
+		}
+	})
+
 	t.Run("update_description_body_alias", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Body alias test", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--body", "via body flag")

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -1043,6 +1043,51 @@ func TestDoltStoreEvents(t *testing.T) {
 	}
 }
 
+func TestDoltStoreSuppressHistorySkipsUpdateEvent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:          "test-suppress-history",
+		Title:       "Issue with compact history",
+		Description: "before",
+		Status:      types.StatusOpen,
+		Priority:    2,
+		IssueType:   types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	eventsBefore, err := store.GetEvents(ctx, issue.ID, 20)
+	if err != nil {
+		t.Fatalf("GetEvents before: %v", err)
+	}
+	if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{
+		"description":                    "after",
+		storage.UpdateKeySuppressHistory: true,
+	}, "tester"); err != nil {
+		t.Fatalf("UpdateIssue suppress history: %v", err)
+	}
+	got, err := store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssue after: %v", err)
+	}
+	if got.Description != "after" {
+		t.Fatalf("Description = %q, want after", got.Description)
+	}
+	eventsAfter, err := store.GetEvents(ctx, issue.ID, 20)
+	if err != nil {
+		t.Fatalf("GetEvents after: %v", err)
+	}
+	if len(eventsAfter) != len(eventsBefore) {
+		t.Fatalf("event count = %d, want %d", len(eventsAfter), len(eventsBefore))
+	}
+}
+
 func TestDoltStoreDeleteIssue(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -168,7 +168,11 @@ func (s *DoltStore) UpdateIssue(ctx context.Context, id string, updates map[stri
 
 	// Dolt versioning for permanent issues.
 	// GH#2455: Stage only the tables we modified, then commit without -A.
-	for _, table := range []string{"issues", "events"} {
+	tables := []string{"issues"}
+	if result.EventRecorded {
+		tables = append(tables, "events")
+	}
+	for _, table := range tables {
 		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
 	}
 	commitMsg := fmt.Sprintf("bd: update %s", id)

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -63,9 +63,14 @@ func (t *embeddedTransaction) CreateIssues(ctx context.Context, issues []*types.
 
 func (t *embeddedTransaction) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
 	t.dirty.MarkDirty("issues")
-	t.dirty.MarkDirty("events")
-	_, err := issueops.UpdateIssueInTx(ctx, t.tx, id, updates, actor)
-	return err
+	result, err := issueops.UpdateIssueInTx(ctx, t.tx, id, updates, actor)
+	if err != nil {
+		return err
+	}
+	if result.EventRecorded {
+		t.dirty.MarkDirty("events")
+	}
+	return nil
 }
 
 func (t *embeddedTransaction) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -116,8 +116,30 @@ func DetermineEventType(oldIssue *types.Issue, updates map[string]interface{}) t
 
 // UpdateResult holds the result of an UpdateIssueInTx call.
 type UpdateResult struct {
-	OldIssue *types.Issue
-	IsWisp   bool
+	OldIssue          *types.Issue
+	IsWisp            bool
+	HistorySuppressed bool
+	EventRecorded     bool
+}
+
+func suppressHistoryRequested(updates map[string]interface{}) bool {
+	raw, ok := updates[storage.UpdateKeySuppressHistory]
+	if !ok {
+		return false
+	}
+	flag, ok := raw.(bool)
+	return ok && flag
+}
+
+func materialUpdates(updates map[string]interface{}) map[string]interface{} {
+	filtered := make(map[string]interface{}, len(updates))
+	for key, value := range updates {
+		if key == storage.UpdateKeySuppressHistory {
+			continue
+		}
+		filtered[key] = value
+	}
+	return filtered
 }
 
 // UpdateIssueInTx performs the full update SQL logic within a transaction.
@@ -126,6 +148,9 @@ type UpdateResult struct {
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func UpdateIssueInTx(ctx context.Context, tx *sql.Tx, id string, updates map[string]interface{}, actor string) (*UpdateResult, error) {
+	historySuppressed := suppressHistoryRequested(updates)
+	updates = materialUpdates(updates)
+
 	// Route to correct table.
 	isWisp := IsActiveWispInTx(ctx, tx, id)
 	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
@@ -213,16 +238,19 @@ func UpdateIssueInTx(ctx context.Context, tx *sql.Tx, id string, updates map[str
 		return nil, fmt.Errorf("failed to update issue: %w", err)
 	}
 
-	// Record event.
-	oldData, _ := json.Marshal(oldIssue)
-	newData, _ := json.Marshal(updates)
-	eventType := DetermineEventType(oldIssue, updates)
+	eventRecorded := false
+	if !historySuppressed {
+		oldData, _ := json.Marshal(oldIssue)
+		newData, _ := json.Marshal(updates)
+		eventType := DetermineEventType(oldIssue, updates)
 
-	if err := RecordFullEventInTable(ctx, tx, eventTable, id, eventType, actor, string(oldData), string(newData)); err != nil {
-		return nil, fmt.Errorf("failed to record event: %w", err)
+		if err := RecordFullEventInTable(ctx, tx, eventTable, id, eventType, actor, string(oldData), string(newData)); err != nil {
+			return nil, fmt.Errorf("failed to record event: %w", err)
+		}
+		eventRecorded = true
 	}
 
-	return &UpdateResult{OldIssue: oldIssue, IsWisp: isWisp}, nil
+	return &UpdateResult{OldIssue: oldIssue, IsWisp: isWisp, HistorySuppressed: historySuppressed, EventRecorded: eventRecorded}, nil
 }
 
 // RecordFullEventInTable records an event with both old and new values.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -28,6 +28,11 @@ var ErrNotInitialized = errors.New("database not initialized")
 // ErrPrefixMismatch is returned when an issue ID does not match the configured prefix.
 var ErrPrefixMismatch = errors.New("prefix mismatch")
 
+// UpdateKeySuppressHistory is a reserved update-map key that applies the
+// requested field changes while suppressing durable update-history event rows.
+// Current-state persistence semantics remain unchanged.
+const UpdateKeySuppressHistory = "suppress_history"
+
 // Storage is the interface satisfied by *dolt.DoltStore.
 // Consumers depend on this interface rather than on the concrete type so that
 // alternative implementations (mocks, proxies, etc.) can be substituted.


### PR DESCRIPTION
## Problem
Some downstream callers need to persist issue changes without appending a durable update-history event row for every volatile metadata update.

## Why this fix is needed
Current-state persistence must remain intact, but durable update-history churn is expensive for high-frequency lifecycle writes such as managed session metadata updates downstream.

## What fix we implemented
- add a reserved `suppress_history` update key for storage-layer updates
- thread suppress-history handling through update planning, Dolt storage, embedded Dolt transactions, and `bd update`
- preserve current-state persistence semantics while skipping the durable update-history event row
- add focused regressions for the Dolt store and embedded `bd update --suppress-history`

## Test plan
- [x] `GOTMPDIR=/home/joenathan/.claude/tmp-go/beads go test ./internal/storage/dolt -run TestDoltStoreSuppressHistorySkipsUpdateEvent -count=1`
- [x] `TMPDIR=/home/joenathan/.claude/tmp-go/beads TMP=/home/joenathan/.claude/tmp-go/beads TEMP=/home/joenathan/.claude/tmp-go/beads GOTMPDIR=/home/joenathan/.claude/tmp-go/beads BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run 'TestEmbeddedUpdate/update_suppress_history_skips_event_row' -count=1`