### PR TITLE
fix: resolve symlinks in DirToFileURL for cross-filesystem-view backup remotes

### DIFF
--- a/internal/storage/versioncontrolops/backup.go
+++ b/internal/storage/versioncontrolops/backup.go
@@ -47,11 +47,24 @@ func BackupRestore(ctx context.Context, db DBConn, url, dbName string, force boo
 	return nil
 }
 
-// DirToFileURL resolves dir to an absolute path and returns a file:// URL.
+// DirToFileURL resolves dir to an absolute realpath and returns a
+// file:// URL.
+//
+// Symlinks are resolved via filepath.EvalSymlinks so the URL works
+// on filesystem views that only expose the realpath (e.g. a Dolt
+// SQL server inside a container with a bind-mount of the resolved
+// path, where the operator's pwd traverses a host-side symlink).
+// EvalSymlinks errors (e.g. dangling symlink, non-existent target)
+// are tolerated: the function falls back to the un-resolved
+// absolute path, preserving the pre-patch behavior on paths that
+// can't be resolved.
 func DirToFileURL(dir string) (string, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return "", fmt.Errorf("resolve absolute path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
 	}
 	return "file://" + abs, nil
 }

--- a/internal/storage/versioncontrolops/backup_test.go
+++ b/internal/storage/versioncontrolops/backup_test.go
@@ -2,6 +2,9 @@ package versioncontrolops
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -43,5 +46,95 @@ func TestExtractAddressConflictName(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDirToFileURL_ResolvesSymlinks_GH3524 is a regression test for
+// gastownhall/beads#3524: when the supplied directory traverses a
+// symlink, DirToFileURL must emit the realpath form so that the
+// resulting file:// URL is reachable from filesystem views (e.g.
+// container bind-mounts) that only expose the target path.
+func TestDirToFileURL_ResolvesSymlinks_GH3524(t *testing.T) {
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "real")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	link := filepath.Join(tmp, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// On macOS / some Linux setups t.TempDir itself can sit behind
+	// a symlink (/tmp -> /private/tmp). Capture the resolved real
+	// directory to compare against; the assertion is that the URL
+	// matches the resolved path of the link, not the link path.
+	wantRealAbs, err := filepath.EvalSymlinks(real)
+	if err != nil {
+		t.Fatalf("evalsymlinks real: %v", err)
+	}
+
+	got, err := DirToFileURL(link)
+	if err != nil {
+		t.Fatalf("DirToFileURL(link): %v", err)
+	}
+	want := "file://" + wantRealAbs
+	if got != want {
+		t.Errorf("symlink not resolved: got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "/link") {
+		t.Errorf("URL still contains symlink component: %q", got)
+	}
+}
+
+// TestDirToFileURL_BrokenSymlinkFallsBack covers the resilience case
+// — EvalSymlinks fails on a dangling symlink; DirToFileURL must
+// fall through to the un-resolved abs form rather than erroring out.
+// This preserves the behavior callers had before the symlink-resolve
+// patch when a path simply can't be resolved.
+func TestDirToFileURL_BrokenSymlinkFallsBack(t *testing.T) {
+	tmp := t.TempDir()
+	link := filepath.Join(tmp, "broken-link")
+	if err := os.Symlink(filepath.Join(tmp, "does-not-exist"), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	got, err := DirToFileURL(link)
+	if err != nil {
+		t.Fatalf("DirToFileURL(broken-link) returned error: %v", err)
+	}
+	// The exact form is the un-resolved abs path of the symlink
+	// itself. Whether t.TempDir is itself behind a symlink
+	// (e.g. on macOS) is irrelevant — we only require that the
+	// function did not error, and that the URL is the file:// abs
+	// of the symlink path.
+	abs, err := filepath.Abs(link)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	want := "file://" + abs
+	if got != want {
+		t.Errorf("broken-symlink fallback: got %q, want %q", got, want)
+	}
+}
+
+// TestDirToFileURL_AlreadyRealpath confirms the no-op case: a
+// directory that contains no symlink components round-trips
+// unchanged. Guards against an over-eager EvalSymlinks
+// implementation that might mangle simple paths.
+func TestDirToFileURL_AlreadyRealpath(t *testing.T) {
+	tmp := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(tmp)
+	if err != nil {
+		t.Fatalf("evalsymlinks tmp: %v", err)
+	}
+
+	got, err := DirToFileURL(resolved)
+	if err != nil {
+		t.Fatalf("DirToFileURL(resolved): %v", err)
+	}
+	want := "file://" + resolved
+	if got != want {
+		t.Errorf("already-realpath altered: got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

When the operator's pwd traverses a symlink (e.g. `~/src` →
`/data/disk-b/src/`) but the Dolt SQL server runs in a container
with a bind-mount of the *realpath* only, `bd backup`
registration fails because `DirToFileURL` emits the symlink form
verbatim and the server-side resolution can't find that path on
its filesystem view.

This patch resolves symlinks via `filepath.EvalSymlinks` after
`filepath.Abs`. `EvalSymlinks` errors (dangling symlink,
non-existent target) are tolerated — the function falls through
to the un-resolved abs path, preserving pre-patch behavior on
those inputs.

## Resolves

- #3524

## Test strategy (separate `test:` commit before the `fix:` commit)

Three regression tests pin all branches:

- `TestDirToFileURL_ResolvesSymlinks_GH3524` — fails on `main`,
  passes with the fix. Captures the bug.
- `TestDirToFileURL_BrokenSymlinkFallsBack` — guards the
  resilience contract: a dangling symlink must not cause
  `DirToFileURL` to error.
- `TestDirToFileURL_AlreadyRealpath` — no-op round-trip on a path
  with no symlink components; guards against an over-eager
  `EvalSymlinks` mangling simple inputs.

Reviewer can checkout the `test:` commit alone, run
`go test -run TestDirToFileURL ./internal/storage/versioncontrolops/`,
and observe `TestDirToFileURL_ResolvesSymlinks_GH3524` failing.
The `fix:` commit makes it pass.

## Verification

```bash
go test ./internal/storage/versioncontrolops/...        # pass
go test -race ./internal/storage/versioncontrolops/...  # pass
golangci-lint run --timeout=5m --build-tags=gms_pure_go ./internal/storage/versioncontrolops/  # 0 issues
go build ./...                                          # clean
```

Full `go test ./...` is clean except for two pre-existing
failures in `internal/configfile` and `internal/doltserver` that
read `~/.config/bd/config.yaml` (test-isolation bugs unrelated to
this change — they reproduce on `main` with the same user-global
config and disappear when that file is moved aside). Happy to
file a separate issue for the test-isolation bugs.

### Manual smoke

Reproduced the original bug locally with operator pwd at
`/home/shauncutts/src/factfiber.ai/infra/factfiber-meta` (a
symlink to `/data/sda/shaunc-src/factfiber.ai/infra/factfiber-meta`)
and a Dolt server in docker with `-v
/data/sda/shaunc-src:/data/sda/shaunc-src`. Pre-fix:
`bd backup add` emits `file:///home/shauncutts/...` and the
server returns `failed to create directory ... permission denied`
because the symlink path doesn't exist inside the container.
Post-fix: emits `file:///data/sda/shaunc-src/...`, server
accepts.

## Notes

- Single-file change; no new dependencies.
- `filepath` already imported in `backup.go`.
- Doc comment expanded to cover the symlink-resolution rationale
  and fallback semantics.
