### PR TITLE
fix(dolt): bd dolt status probes SQL when local server is externally-managed (be-0eyj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bd dolt status` reports externally-managed local servers truthfully** - when a rig is configured as `dolt_mode: server` pointing at a local host but `dolt.auto-start: false` (so an orchestrator or systemd owns the sql-server lifecycle), `bd dolt status` previously said `not running` because no PID file existed. It now SQL-probes the configured endpoint, matching the path already used for non-local hosts, and reports `running (external)` with host/port/database/version when the server answers. **JSON output shape change**: on affected rigs, `bd dolt status --json` now emits `{"running": true, "mode": "external", ...}` instead of `{"running": false, "pid": 0, ...}`. Automation that parsed the old `running:false` as a "needs restart" sentinel should switch to checking `running` directly. (be-0eyj, [#3550](https://github.com/gastownhall/beads/pull/3550))
+
 ## [1.0.4] - 2026-05-07
 
 ### Added

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -430,9 +430,10 @@ var doltStatusCmd = &cobra.Command{
 In embedded mode, reports that the Dolt engine runs in-process and shows
 the on-disk data directory. For beads-managed (local) servers, displays
 PID, port, and data directory from the local PID file. For externally-
-hosted servers (dolt_mode=server with a remote dolt_server_host), pings
-the configured endpoint via SQL and reports reachability, server version,
-and database.`,
+managed servers — either a remote dolt_server_host or a local server
+managed outside bd (dolt.auto-start: false, e.g. an orchestrator-shared
+sql-server) — pings the configured endpoint via SQL and reports
+reachability, server version, and database.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		beadsDir := selectedDoltBeadsDir()
 		if beadsDir == "" {
@@ -443,11 +444,28 @@ and database.`,
 			return
 		}
 
-		// For externally-hosted Dolt servers (non-local host with
-		// dolt_mode=server), the local PID file is meaningless — ping the
-		// configured endpoint via SQL instead (bd-q35w).
-		if cfg, cfgErr := configfile.Load(beadsDir); cfgErr == nil && cfg != nil &&
-			cfg.IsDoltServerMode() && !isLocalHost(cfg.GetDoltServerHost()) {
+		// For externally-managed Dolt servers, the local PID file is
+		// meaningless or absent — ping the configured endpoint via SQL
+		// instead. Two flavors qualify:
+		//   - non-local host (Hosted Dolt, remote shared sql-server, bd-q35w)
+		//   - local host with auto-start disabled (an orchestrator or
+		//     systemd manages the server lifecycle, be-0eyj)
+		//
+		// IsAutoStartDisabled reads the active (globally-bound) config and
+		// BEADS_DOLT_AUTO_START env, not the per-beadsDir cfg loaded just
+		// below. That coupling is intentional and consistent with every
+		// other call site of IsAutoStartDisabled in this package — both
+		// resolve against the same active workspace at command time.
+		cfg, cfgErr := configfile.Load(beadsDir)
+		if cfgErr != nil {
+			// Don't silently swallow. A corrupted or missing metadata.json
+			// would otherwise mask the externally-managed routing for both
+			// the remote-host and auto-start-disabled-local cases, falling
+			// through to the PID-file path with a misleading "not running"
+			// — which is the exact failure mode this PR addresses.
+			fmt.Fprintf(os.Stderr, "Warning: cannot load .beads config (%v); falling back to PID-file status path\n", cfgErr)
+		}
+		if cfg != nil && shouldUseExternalDoltStatus(cfg, doltserver.IsAutoStartDisabled()) {
 			runExternalDoltStatus(beadsDir, cfg)
 			return
 		}
@@ -459,28 +477,60 @@ and database.`,
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-
-		if jsonOutput {
-			outputJSON(state)
-			return
-		}
-
-		if state == nil || !state.Running {
-			cfg := doltserver.DefaultConfig(serverDir)
-			fmt.Println("Dolt server: not running")
-			fmt.Printf("  Expected port: %d\n", cfg.Port)
-			return
-		}
-
-		fmt.Println("Dolt server: running")
-		fmt.Printf("  PID:  %d\n", state.PID)
-		fmt.Printf("  Port: %d\n", state.Port)
-		fmt.Printf("  Data: %s\n", state.DataDir)
-		fmt.Printf("  Logs: %s\n", doltserver.LogPath(serverDir))
-		if doltserver.IsSharedServerMode() {
-			fmt.Println("  Mode: shared server")
-		}
+		renderLocalDoltStatus(state, serverDir)
 	},
+}
+
+// renderLocalDoltStatus writes the bd-managed (local PID-file) status of
+// the Dolt server to stdout, honoring jsonOutput. Extracted from the
+// doltStatusCmd Run closure so the bd-managed output path is unit-testable
+// without requiring a live dolt sql-server (the externally-managed path
+// is exercised by TestRunExternalDoltStatus_Unreachable).
+func renderLocalDoltStatus(state *doltserver.State, serverDir string) {
+	if jsonOutput {
+		outputJSON(state)
+		return
+	}
+	if state == nil || !state.Running {
+		cfg := doltserver.DefaultConfig(serverDir)
+		fmt.Println("Dolt server: not running")
+		fmt.Printf("  Expected port: %d\n", cfg.Port)
+		return
+	}
+	fmt.Println("Dolt server: running")
+	fmt.Printf("  PID:  %d\n", state.PID)
+	fmt.Printf("  Port: %d\n", state.Port)
+	fmt.Printf("  Data: %s\n", state.DataDir)
+	fmt.Printf("  Logs: %s\n", doltserver.LogPath(serverDir))
+	if doltserver.IsSharedServerMode() {
+		fmt.Println("  Mode: shared server")
+	}
+}
+
+// shouldUseExternalDoltStatus reports whether bd dolt status should treat
+// the server as externally-managed and probe via SQL instead of consulting
+// the local PID file. Returns true when:
+//   - dolt_mode=server with a non-local host (Hosted Dolt, remote shared
+//     sql-server) — the PID file is on a different machine.
+//   - dolt_mode=server with a local host but bd auto-start is disabled —
+//     the server lifecycle is owned by something outside bd (e.g. an
+//     orchestrator or systemd unit), so no bd PID file exists. Without
+//     this branch, status reports "not running" even when bd CRUD
+//     commands successfully connect to the server (be-0eyj).
+//
+// When false, the caller falls back to the PID-file path that reports
+// PID, port, log path, and data directory for bd-managed servers.
+//
+// autoStartDisabled is passed in (rather than read here) so the predicate
+// is pure and unit-testable without manipulating package-level config.
+func shouldUseExternalDoltStatus(cfg *configfile.Config, autoStartDisabled bool) bool {
+	if cfg == nil || !cfg.IsDoltServerMode() {
+		return false
+	}
+	if !isLocalHost(cfg.GetDoltServerHost()) {
+		return true
+	}
+	return autoStartDisabled
 }
 
 // isLocalHost reports whether host refers to this machine. Used to

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1289,3 +1289,265 @@ func TestRunExternalDoltStatus_Unreachable(t *testing.T) {
 		}
 	})
 }
+
+// TestShouldUseExternalDoltStatus covers the routing predicate for
+// `bd dolt status`. The predicate decides whether to ping the configured
+// SQL endpoint (externally-managed server) or read the local PID file
+// (bd-managed server). Three scenarios qualify as externally-managed:
+// non-local hosts, and local hosts where bd does not own the lifecycle
+// (auto-start disabled — be-0eyj). Other configurations should keep the
+// PID-file path so bd-managed servers continue to report PID/log/data.
+func TestShouldUseExternalDoltStatus(t *testing.T) {
+	tests := []struct {
+		name              string
+		cfg               *configfile.Config
+		autoStartDisabled bool
+		want              bool
+	}{
+		{
+			name:              "nil config falls back to PID-file path",
+			cfg:               nil,
+			autoStartDisabled: false,
+			want:              false,
+		},
+		{
+			name: "embedded mode never uses external status",
+			cfg: &configfile.Config{
+				Backend:  "dolt",
+				DoltMode: "embedded",
+			},
+			autoStartDisabled: true, // even with auto-start off
+			want:              false,
+		},
+		{
+			name: "server mode + remote host always uses external status",
+			cfg: &configfile.Config{
+				Backend:        "dolt",
+				DoltMode:       "server",
+				DoltServerHost: "dolt.example.com",
+			},
+			autoStartDisabled: false,
+			want:              true,
+		},
+		{
+			name: "server mode + remote host + auto-start disabled",
+			cfg: &configfile.Config{
+				Backend:        "dolt",
+				DoltMode:       "server",
+				DoltServerHost: "192.168.1.50",
+			},
+			autoStartDisabled: true,
+			want:              true,
+		},
+		{
+			name: "server mode + local host + auto-start enabled keeps PID-file path",
+			cfg: &configfile.Config{
+				Backend:        "dolt",
+				DoltMode:       "server",
+				DoltServerHost: "127.0.0.1",
+			},
+			autoStartDisabled: false,
+			want:              false,
+		},
+		{
+			name: "server mode + local host + auto-start disabled routes to external (be-0eyj)",
+			cfg: &configfile.Config{
+				Backend:        "dolt",
+				DoltMode:       "server",
+				DoltServerHost: "127.0.0.1",
+			},
+			autoStartDisabled: true,
+			want:              true,
+		},
+		{
+			name: "server mode + empty host (defaults to local) + auto-start disabled",
+			cfg: &configfile.Config{
+				Backend:  "dolt",
+				DoltMode: "server",
+				// DoltServerHost empty → defaults to 127.0.0.1
+			},
+			autoStartDisabled: true,
+			want:              true,
+		},
+		{
+			name: "server mode + localhost literal + auto-start disabled",
+			cfg: &configfile.Config{
+				Backend:        "dolt",
+				DoltMode:       "server",
+				DoltServerHost: "localhost",
+			},
+			autoStartDisabled: true,
+			want:              true,
+		},
+	}
+
+	// Make sure ambient env doesn't perturb cfg.IsDoltServerMode() lookups.
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldUseExternalDoltStatus(tc.cfg, tc.autoStartDisabled)
+			if got != tc.want {
+				t.Errorf("shouldUseExternalDoltStatus = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderLocalDoltStatus exercises the bd-managed (PID-file) output
+// path that doltStatusCmd takes when bd owns the server lifecycle. The
+// externally-managed path is covered by TestRunExternalDoltStatus_Unreachable;
+// this test closes the test-plan gap noted in the PR #3550 review by
+// asserting that the preserved local path still reports PID/Port/Data/Logs
+// (text mode) and a State-shaped JSON payload distinct from the external
+// {"mode":"external", ...} shape.
+func TestRenderLocalDoltStatus(t *testing.T) {
+	// Clear ambient mode/host so DefaultConfig and IsSharedServerMode are
+	// deterministic regardless of how the test runner is invoked.
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+	// Pin the expected port so the not-running text branch is host-agnostic.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "13306")
+
+	t.Run("nil state prints not running with expected port", func(t *testing.T) {
+		orig := jsonOutput
+		defer func() { jsonOutput = orig }()
+		jsonOutput = false
+
+		serverDir := t.TempDir()
+		out := captureStdout(t, func() error {
+			renderLocalDoltStatus(nil, serverDir)
+			return nil
+		})
+
+		for _, want := range []string{
+			"Dolt server: not running",
+			"Expected port: 13306",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected output to contain %q, got:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("Running:false prints not running", func(t *testing.T) {
+		orig := jsonOutput
+		defer func() { jsonOutput = orig }()
+		jsonOutput = false
+
+		serverDir := t.TempDir()
+		state := &doltserver.State{Running: false}
+		out := captureStdout(t, func() error {
+			renderLocalDoltStatus(state, serverDir)
+			return nil
+		})
+
+		if !strings.Contains(out, "Dolt server: not running") {
+			t.Errorf("expected 'not running', got:\n%s", out)
+		}
+	})
+
+	t.Run("Running:true prints PID/Port/Data/Logs", func(t *testing.T) {
+		orig := jsonOutput
+		defer func() { jsonOutput = orig }()
+		jsonOutput = false
+
+		serverDir := t.TempDir()
+		state := &doltserver.State{
+			Running: true,
+			PID:     12345,
+			Port:    28231,
+			DataDir: "/tmp/data",
+		}
+		out := captureStdout(t, func() error {
+			renderLocalDoltStatus(state, serverDir)
+			return nil
+		})
+
+		for _, want := range []string{
+			"Dolt server: running",
+			"PID:  12345",
+			"Port: 28231",
+			"Data: /tmp/data",
+			"Logs:",
+			"dolt-server.log",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected output to contain %q, got:\n%s", want, out)
+			}
+		}
+		// Without BEADS_DOLT_SHARED_SERVER set, the shared-server line
+		// must NOT appear — guards against accidental coupling.
+		if strings.Contains(out, "Mode: shared server") {
+			t.Errorf("did not expect shared-server line in non-shared mode, got:\n%s", out)
+		}
+	})
+
+	t.Run("Running:true under shared-server mode adds Mode line", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+		orig := jsonOutput
+		defer func() { jsonOutput = orig }()
+		jsonOutput = false
+
+		serverDir := t.TempDir()
+		state := &doltserver.State{
+			Running: true,
+			PID:     1,
+			Port:    2,
+			DataDir: serverDir,
+		}
+		out := captureStdout(t, func() error {
+			renderLocalDoltStatus(state, serverDir)
+			return nil
+		})
+
+		if !strings.Contains(out, "Mode: shared server") {
+			t.Errorf("expected shared-server line under BEADS_DOLT_SHARED_SERVER=1, got:\n%s", out)
+		}
+	})
+
+	t.Run("json output produces State-shaped payload (no mode=external)", func(t *testing.T) {
+		orig := jsonOutput
+		defer func() { jsonOutput = orig }()
+		jsonOutput = true
+
+		serverDir := t.TempDir()
+		state := &doltserver.State{
+			Running: true,
+			PID:     7777,
+			Port:    28231,
+			DataDir: "/var/data",
+		}
+		out := captureStdout(t, func() error {
+			renderLocalDoltStatus(state, serverDir)
+			return nil
+		})
+
+		var result map[string]any
+		if err := json.Unmarshal([]byte(out), &result); err != nil {
+			t.Fatalf("expected valid JSON, got error %v, raw: %s", err, out)
+		}
+
+		if result["running"] != true {
+			t.Errorf("running = %v, want true", result["running"])
+		}
+		if v, _ := result["pid"].(float64); int(v) != 7777 {
+			t.Errorf("pid = %v, want 7777", result["pid"])
+		}
+		if v, _ := result["port"].(float64); int(v) != 28231 {
+			t.Errorf("port = %v, want 28231", result["port"])
+		}
+		if result["data_dir"] != "/var/data" {
+			t.Errorf("data_dir = %v, want /var/data", result["data_dir"])
+		}
+		// Crucial: the bd-managed path must NOT report mode=external —
+		// that is the externally-managed shape introduced in this PR for
+		// the SQL-probe routing only.
+		if result["mode"] == "external" {
+			t.Errorf("did not expect mode=external on bd-managed path, got:\n%s", out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`bd dolt status` previously printed **\"Dolt server: not running\"** when the rig pointed at a **local** Dolt sql-server whose lifecycle was owned by something other than bd (an orchestrator like gc, a systemd unit, etc.). Every other CRUD command (`bd list`, `bd ready`, …) connected to the same server fine — only `dolt status` lied. This caused agents in the field to halt thinking Dolt was down.

This PR widens the routing in `doltStatusCmd` so the SQL-probe path covers both flavors of externally-managed server:

- non-local host (already covered, GH#3362)
- **local host with bd auto-start disabled** — new (be-0eyj)

## Root cause

The current condition routes to `runExternalDoltStatus` only when the host is non-local:

\`\`\`go
if cfg.IsDoltServerMode() && !isLocalHost(cfg.GetDoltServerHost()) {
    runExternalDoltStatus(beadsDir, cfg)
    return
}
// ↓ falls through to PID-file path even when nothing wrote a PID file
serverDir := doltserver.ResolveServerDir(beadsDir)
state, err := doltserver.IsRunning(serverDir)
\`\`\`

A rig configured as \`dolt_mode: server\` + \`dolt.auto-start: false\` (with the orchestrator running the dolt sql-server itself) lands on \`localhost\`. \`isLocalHost\` returns true, so the dispatcher falls through to \`IsRunning\`, which reads a PID file that no one ever wrote and returns \`Running: false\`.

## Fix

Extract the routing into a small pure predicate:

\`\`\`go
func shouldUseExternalDoltStatus(cfg *configfile.Config, autoStartDisabled bool) bool {
    if cfg == nil || !cfg.IsDoltServerMode() {
        return false
    }
    if !isLocalHost(cfg.GetDoltServerHost()) {
        return true
    }
    return autoStartDisabled
}
\`\`\`

When auto-start is disabled, bd is by definition not the lifecycle owner — there is no PID file to consult, so SQL probe is the right answer regardless of host. The PID-file path is preserved unchanged for genuinely bd-managed servers (auto-start enabled, local host) so PID/log/data details continue to appear there.

## Verification

Against a live rig that hit the bug (gc-managed shared dolt on \`127.0.0.1:28231\`, \`BEADS_DOLT_AUTO_START=0\`):

**Before:**
\`\`\`
$ bd dolt status
Dolt server: not running
  Expected port: 28231
\`\`\`

**After:**
\`\`\`
$ bd dolt status
Dolt server: running (external)
  Host:     127.0.0.1
  Port:     28231
  Database: be
  User:     root
  TLS:      false
  Version:  8.0.31
\`\`\`

JSON output is now \`{\"running\": true, \"mode\": \"external\", …}\` instead of \`{\"running\": false, \"port\": 0, \"pid\": 0, …}\`, so any automation parsing it gets the truth.

## Test plan

- [x] \`go vet ./cmd/bd/...\` clean
- [x] \`TestShouldUseExternalDoltStatus\` (new) — table-driven coverage of the routing predicate: nil cfg, embedded mode, server+remote, server+local with auto-start enabled vs disabled, default-host and \`localhost\` literals
- [x] \`TestIsLocalHost\` — unchanged, still passes
- [x] \`TestRunExternalDoltStatus_Unreachable\` — unchanged, still covers the SQL-probe output path (text + JSON)
- [x] Manual: \`bd dolt status\` against the live affected rig prints \`running (external)\` with full server details
- [ ] Manual: \`bd dolt status\` against a bd-managed local server still prints PID/log/data (preserved path, not exercised by CI here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)