### PR TITLE
fix(setup): prevent doubled BEGIN/END markers from CRLF embedded template

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,9 @@
 # Shell scripts must always use LF line endings (especially git hook templates)
 *.sh text eol=lf
 cmd/bd/templates/hooks/* text eol=lf
+
+# Embedded markdown templates are shipped data, not user-edited text. Pin LF so
+# Windows checkouts (default core.autocrlf=true) don't bake CRLF into //go:embed
+# bytes, which breaks LF-only marker stripping in templateBody() and produces
+# doubled BEGIN/END BEADS INTEGRATION markers in installed AGENTS.md (#3552).
+internal/templates/agents/defaults/*.md text eol=lf

--- a/internal/templates/agents/render.go
+++ b/internal/templates/agents/render.go
@@ -147,8 +147,13 @@ func templateBody(profile Profile) string {
 		return strings.TrimRight(beadsSectionMinimal, "\n")
 	default:
 		// Full profile uses the same body as the legacy beads-section.md
-		// Strip the existing markers from the embedded content
-		body := strings.TrimRight(beadsSection, "\n")
+		// Strip the existing markers from the embedded content. Normalize CRLF→LF
+		// first so a Windows-checkout build (where //go:embed picks up CRLF bytes
+		// from the working tree) still matches the LF-only prefix/suffix below.
+		// Without this, the legacy markers stay in the body and RenderSection
+		// wraps them again, producing doubled markers in the installed file (#3552).
+		body := strings.ReplaceAll(beadsSection, "\r\n", "\n")
+		body = strings.TrimRight(body, "\n")
 		body = strings.TrimPrefix(body, "<!-- BEGIN BEADS INTEGRATION -->\n")
 		body = strings.TrimSuffix(body, "\n<!-- END BEADS INTEGRATION -->")
 		return body

--- a/internal/templates/agents/render_test.go
+++ b/internal/templates/agents/render_test.go
@@ -50,6 +50,22 @@ func TestRenderSectionFull(t *testing.T) {
 	}
 }
 
+// TestRenderSectionFullSingleMarkers guards against #3552: when bd is built
+// from a Windows checkout, //go:embed picks up CRLF bytes from the working
+// tree, and templateBody()'s LF-only marker stripping previously left the
+// legacy markers inside the body. RenderSection then wrapped them in fresh
+// markers, producing doubled BEGIN/END pairs. Output must always contain
+// exactly one of each — regardless of the embedded file's line endings.
+func TestRenderSectionFullSingleMarkers(t *testing.T) {
+	section := RenderSection(ProfileFull)
+	if got := strings.Count(section, "<!-- BEGIN BEADS INTEGRATION"); got != 1 {
+		t.Errorf("expected exactly 1 BEGIN marker, got %d", got)
+	}
+	if got := strings.Count(section, "<!-- END BEADS INTEGRATION -->"); got != 1 {
+		t.Errorf("expected exactly 1 END marker, got %d", got)
+	}
+}
+
 func TestRenderSectionMinimal(t *testing.T) {
 	section := RenderSection(ProfileMinimal)
 	if section == "" {


### PR DESCRIPTION
## Problem

When bd is built from a Windows checkout (default `core.autocrlf=true`), `bd setup mux`/`claude`/etc. write **doubled BEGIN/END BEADS INTEGRATION markers** into AGENTS.md:

```
<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:5f744a27 -->
<!-- BEGIN BEADS INTEGRATION -->
## Issue Tracking with bd (beads)
...
<!-- END BEADS INTEGRATION -->
<!-- END BEADS INTEGRATION -->
```

`bd setup mux --remove` then only strips the outer pair (find-first semantics), leaving a stray `<!-- END BEADS INTEGRATION -->` in the user's file. `TestRemoveMuxProjectRemovesBothLayers` catches this on Windows.

## Root cause

`internal/templates/agents/defaults/beads-section.md` is **LF in the git index, CRLF in the working tree** on default Windows checkouts:

```
$ git ls-files --eol internal/templates/agents/defaults/beads-section.md
i/lf    w/crlf  attr/                 internal/templates/agents/defaults/beads-section.md
```

`.gitattributes` previously only pinned `*.sh` and `cmd/bd/templates/hooks/*` to LF. `//go:embed` reads working-tree bytes at build time, so the embedded `beadsSection` carries `\r\n` on a Windows-built binary.

`templateBody()` at `internal/templates/agents/render.go:151-153` strips legacy markers using LF-only literals:

```go
body := strings.TrimRight(beadsSection, "\n")
body = strings.TrimPrefix(body, "<!-- BEGIN BEADS INTEGRATION -->\n")
body = strings.TrimSuffix(body, "\n<!-- END BEADS INTEGRATION -->")
```

CRLF input → no prefix/suffix match → legacy markers remain inside `body` → `RenderSection` wraps them with fresh markers → doubled output.

## Fix

Two complementary changes:

1. **`.gitattributes`**: pin `internal/templates/agents/defaults/*.md` to `eol=lf`. Embedded templates are shipped data, not user-edited text — they should never carry CRLF.
2. **`templateBody()`**: normalize CRLF→LF before stripping markers. Defense in depth — guards against any future template added without a gitattributes pin.

Verified the pin took effect: `git check-attr eol` reports `eol: lf` for both `beads-section.md` and `beads-section-minimal.md` after the change.

## Test Plan

- [x] `go test -tags gms_pure_go -short -run TestRemoveMuxProjectRemovesBothLayers ./cmd/bd/setup/` — passes after fix (was failing on Windows)
- [x] New `TestRenderSectionFullSingleMarkers` in `internal/templates/agents/render_test.go` — direct regression guard, asserts exactly one BEGIN and one END marker in `RenderSection` output. Platform-independent.
- [x] `go test -tags gms_pure_go -short ./internal/templates/agents/... ./cmd/bd/setup/` — all pass except `TestGeminiSettingsPaths` (unrelated test-side path-hardcoding bug, separate PR planned)
- [x] `make build` clean
- [x] `golangci-lint run --build-tags gms_pure_go ./internal/templates/agents/... ./cmd/bd/setup/` — 0 issues

## Context

Caught on a Windows workstation while running the full test suite. Previous related issue #3404 (windows test suite red — paths hardcoded, POSIX perms) was closed as completed but didn't cover this — that one was test-side path hardcoding; this is a production correctness bug where the binary itself silently corrupts user files.

Anyone who built bd from source on Windows with default git settings has been writing doubled markers. The stray `<!-- END BEADS INTEGRATION -->` left behind by `--remove` is benign (markdown comment), but it's an unexpected residue and the doubled pairs make the section harder to reason about.

Fixes #3552
