### PR TITLE
test(setup): use filepath.Join in TestGeminiSettingsPaths assertions

### DIFF
--- a/cmd/bd/setup/gemini_test.go
+++ b/cmd/bd/setup/gemini_test.go
@@ -468,12 +468,12 @@ func TestHasGeminiBeadsHooks(t *testing.T) {
 
 func TestGeminiSettingsPaths(t *testing.T) {
 	projectPath := geminiProjectSettingsPath("/my/project")
-	if projectPath != "/my/project/.gemini/settings.json" {
-		t.Errorf("unexpected project path: %s", projectPath)
+	if want := filepath.Join("/my/project", ".gemini", "settings.json"); projectPath != want {
+		t.Errorf("project path = %q, want %q", projectPath, want)
 	}
 
 	globalPath := geminiGlobalSettingsPath("/home/user")
-	if globalPath != "/home/user/.gemini/settings.json" {
-		t.Errorf("unexpected global path: %s", globalPath)
+	if want := filepath.Join("/home/user", ".gemini", "settings.json"); globalPath != want {
+		t.Errorf("global path = %q, want %q", globalPath, want)
 	}
 }


### PR DESCRIPTION
## Problem

`TestGeminiSettingsPaths` at `cmd/bd/setup/gemini_test.go:469-479` fails on Windows:

```
gemini_test.go:472: unexpected project path: \my\project\.gemini\settings.json
gemini_test.go:477: unexpected global path: \home\user\.gemini\settings.json
```

The test hardcodes forward-slash path literals (`/my/project/.gemini/settings.json`) and compares them against output from `filepath.Join`, which returns OS-native separators.

## Root cause

Production code at `cmd/bd/setup/gemini.go:59-64` is correct — both `geminiProjectSettingsPath` and `geminiGlobalSettingsPath` use `filepath.Join`. The bug is purely test-side: the assertions need to use `filepath.Join` on the expected side too.

## Fix

Match the established pattern from sibling tests in the same package (`TestMuxProjectAgentsPath` at `mux_test.go:43-51`, `TestMuxGlobalAgentsPath` at `mux_test.go:115-131`), which compare `filepath.Join(...)` on both sides.

## Test Plan

- [x] `go test -tags gms_pure_go -short -run TestGeminiSettingsPaths ./cmd/bd/setup/` — passes after fix (was failing on Windows)
- [x] `golangci-lint run --build-tags gms_pure_go ./cmd/bd/setup/` — 0 issues

## Context

Caught while running the full test suite on Windows. Spotted alongside #3552 (CRLF doubled-markers production bug, fix in #3553) but kept separate per CONTRIBUTING one-issue-per-PR — different root cause, different mechanism.

Related: #3404 (closed) covered the same forward-slash test pattern for the `TestMux*` and `TestCanonicalizeIfRelative` family. Those got fixed; this Gemini test was either added later or missed in the sweep.

Fixes #3554
