### PR TITLE
fix(hooks): preserve user content when migrating v0.62.x → v1.0.x (GH#3536)

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -286,7 +286,7 @@ func isOnlyShebangOrEmpty(content string) bool {
 // shouldPreserveHookContent decides what preservePreexistingHooks should do
 // with one hook file's content. Returns (transformedContent, true) when the
 // file should be preserved into the target directory (possibly with the bd
-// section stripped or the husky helper-layout sanitised); returns
+// section stripped or the husky helper-layout sanitized); returns
 // ("", false) when preservation should skip this file because it's wholly
 // bd-managed and contains nothing user-owned worth keeping.
 //
@@ -297,7 +297,7 @@ func isOnlyShebangOrEmpty(content string) bool {
 //     block injected into them (the v0.49+ section-marker model). Strip
 //     the bd block and preserve the remaining user content. If only a
 //     shebang/blank/comments remain, treat as wholly bd-owned and skip.
-//   - When fromHusky is true, sanitise the (possibly stripped) content so
+//   - When fromHusky is true, sanitize the (possibly stripped) content so
 //     it doesn't depend on husky's helper-layout being mirrored into the
 //     target directory (GH#3132).
 //

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -269,7 +269,7 @@ func removeHookSection(content string) (string, bool) {
 
 // isOnlyShebangOrEmpty reports whether the given hook content consists of
 // nothing meaningful — only an optional shebang line plus blank lines and
-// comments. Used by preservePreexistingHooks to decide, after stripping a
+// comments. Used by shouldPreserveHookContent to decide, after stripping a
 // BEADS INTEGRATION block, whether anything user-owned remains worth
 // preserving. (GH#3536)
 func isOnlyShebangOrEmpty(content string) bool {
@@ -281,6 +281,42 @@ func isOnlyShebangOrEmpty(content string) bool {
 		return false
 	}
 	return true
+}
+
+// shouldPreserveHookContent decides what preservePreexistingHooks should do
+// with one hook file's content. Returns (transformedContent, true) when the
+// file should be preserved into the target directory (possibly with the bd
+// section stripped or the husky helper-layout sanitised); returns
+// ("", false) when preservation should skip this file because it's wholly
+// bd-managed and contains nothing user-owned worth keeping.
+//
+// Decision rules (GH#3536):
+//   - inlineHookMarker (the "# bd (beads)" tag from GH#1120) marks files
+//     that were always wholly bd-owned one-liners — skip.
+//   - hookSectionBeginPrefix marks files that were *user-owned* with bd's
+//     block injected into them (the v0.49+ section-marker model). Strip
+//     the bd block and preserve the remaining user content. If only a
+//     shebang/blank/comments remain, treat as wholly bd-owned and skip.
+//   - When fromHusky is true, sanitise the (possibly stripped) content so
+//     it doesn't depend on husky's helper-layout being mirrored into the
+//     target directory (GH#3132).
+//
+// The function is pure: no I/O, no global state.
+func shouldPreserveHookContent(content string, fromHusky bool) (string, bool) {
+	if strings.Contains(content, inlineHookMarker) {
+		return "", false
+	}
+	if strings.Contains(content, hookSectionBeginPrefix) {
+		stripped, _ := removeHookSection(content)
+		if isOnlyShebangOrEmpty(stripped) {
+			return "", false
+		}
+		content = stripped
+	}
+	if fromHusky {
+		content = sanitizeHuskyHook(content)
+	}
+	return content, true
 }
 
 // HookStatus represents the status of a single git hook
@@ -736,34 +772,11 @@ func preservePreexistingHooks(targetDir string) {
 			continue
 		}
 
-		contentStr := string(content)
-		// inlineHookMarker (the "# bd (beads)" tag from GH#1120) was always
-		// applied to wholly bd-owned files. If we see it, skip — there's no
-		// user content to preserve.
-		if strings.Contains(contentStr, inlineHookMarker) {
+		newContent, keep := shouldPreserveHookContent(string(content), fromHusky)
+		if !keep {
 			continue
 		}
-		// hookSectionBeginPrefix is different: starting with the GH#1380
-		// section-marker model (v0.49+), bd injected its block INTO existing
-		// user-owned hooks (e.g. dispatchers, framework integrations). Marker
-		// presence does NOT mean the file is wholly bd-owned. Strip the bd
-		// section and preserve any remaining user content. Only skip if
-		// stripping leaves nothing meaningful (i.e. the file was just a
-		// shebang plus the bd block). (GH#3536)
-		if strings.Contains(contentStr, hookSectionBeginPrefix) {
-			stripped, _ := removeHookSection(contentStr)
-			if isOnlyShebangOrEmpty(stripped) {
-				continue
-			}
-			contentStr = stripped
-		}
-
-		// If this came from a husky directory, rewrite the hook so it no
-		// longer depends on husky's helper layout being mirrored into the
-		// target directory. See sanitizeHuskyHook below for details.
-		if fromHusky {
-			contentStr = sanitizeHuskyHook(contentStr)
-		}
+		contentStr := newContent
 
 		// Don't overwrite existing files in target
 		dstPath := filepath.Join(targetDir, entry.Name())

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -271,7 +271,12 @@ func removeHookSection(content string) (string, bool) {
 // nothing meaningful — only an optional shebang line plus blank lines and
 // comments. Used by shouldPreserveHookContent to decide, after stripping a
 // BEADS INTEGRATION block, whether anything user-owned remains worth
-// preserving. (GH#3536)
+// preserving.
+//
+// Note: non-shebang comment lines (e.g. `# preamble`) are intentionally
+// treated as non-content. A file that's only a shebang plus a comment is
+// classified empty and skipped — comments alone aren't user logic worth
+// carrying forward to .beads/hooks/<name>. (GH#3536)
 func isOnlyShebangOrEmpty(content string) bool {
 	for _, line := range strings.Split(content, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -311,7 +316,11 @@ func shouldPreserveHookContent(content string, fromHusky bool) (string, bool) {
 		if isOnlyShebangOrEmpty(stripped) {
 			return "", false
 		}
-		content = stripped
+		// Normalize CRLF → LF on the preserved-and-stripped content so
+		// Windows / autocrlf=true repos don't end up with `\r\n` line
+		// endings in .beads/hooks/<name>. Mirrors the normalization that
+		// injectHookSection does on its output (`hooks.go` ~line 622).
+		content = strings.ReplaceAll(stripped, "\r\n", "\n")
 	}
 	if fromHusky {
 		content = sanitizeHuskyHook(content)

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -267,6 +267,22 @@ func removeHookSection(content string) (string, bool) {
 	return result, true
 }
 
+// isOnlyShebangOrEmpty reports whether the given hook content consists of
+// nothing meaningful — only an optional shebang line plus blank lines and
+// comments. Used by preservePreexistingHooks to decide, after stripping a
+// BEADS INTEGRATION block, whether anything user-owned remains worth
+// preserving. (GH#3536)
+func isOnlyShebangOrEmpty(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#!") || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // HookStatus represents the status of a single git hook
 type HookStatus struct {
 	Name      string
@@ -721,10 +737,25 @@ func preservePreexistingHooks(targetDir string) {
 		}
 
 		contentStr := string(content)
-		// Skip if it's already a beads hook
-		if strings.Contains(contentStr, hookSectionBeginPrefix) ||
-			strings.Contains(contentStr, inlineHookMarker) {
+		// inlineHookMarker (the "# bd (beads)" tag from GH#1120) was always
+		// applied to wholly bd-owned files. If we see it, skip — there's no
+		// user content to preserve.
+		if strings.Contains(contentStr, inlineHookMarker) {
 			continue
+		}
+		// hookSectionBeginPrefix is different: starting with the GH#1380
+		// section-marker model (v0.49+), bd injected its block INTO existing
+		// user-owned hooks (e.g. dispatchers, framework integrations). Marker
+		// presence does NOT mean the file is wholly bd-owned. Strip the bd
+		// section and preserve any remaining user content. Only skip if
+		// stripping leaves nothing meaningful (i.e. the file was just a
+		// shebang plus the bd block). (GH#3536)
+		if strings.Contains(contentStr, hookSectionBeginPrefix) {
+			stripped, _ := removeHookSection(contentStr)
+			if isOnlyShebangOrEmpty(stripped) {
+				continue
+			}
+			contentStr = stripped
 		}
 
 		// If this came from a husky directory, rewrite the hook so it no

--- a/cmd/bd/hooks_marker_skip_test.go
+++ b/cmd/bd/hooks_marker_skip_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsOnlyShebangOrEmpty_TableDriven exercises the helper used by
+// preservePreexistingHooks to decide, after stripping a BEADS INTEGRATION
+// block, whether anything user-owned remains worth preserving. (GH#3536)
+func TestIsOnlyShebangOrEmpty_TableDriven(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "empty", content: "", want: true},
+		{name: "only blanks", content: "\n\n\n", want: true},
+		{name: "only shebang", content: "#!/usr/bin/env sh\n", want: true},
+		{name: "shebang + blank lines", content: "#!/bin/sh\n\n\n", want: true},
+		{name: "shebang + comments", content: "#!/bin/sh\n# a comment\n# another\n", want: true},
+		{name: "shebang + one command", content: "#!/bin/sh\necho hi\n", want: false},
+		{name: "no shebang, has command", content: "echo hi\n", want: false},
+		{name: "user dispatcher", content: "#!/bin/sh\nset -e\nrun_precommit pre-commit\n", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOnlyShebangOrEmpty(tt.content); got != tt.want {
+				t.Errorf("isOnlyShebangOrEmpty(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPreservePreexistingHooks_StripsLegacyMarkerBlock reproduces GH#3536.
+// In the v0.62.x inline-injection model, bd appended its BEADS INTEGRATION
+// block to the BOTTOM of an otherwise-user-owned hook. When v1.0.x tries to
+// preserve that hook into .beads/hooks/<name>, the marker-presence check
+// previously caused the entire file to be skipped — silently discarding the
+// user's content.
+//
+// Expected behaviour after the fix: the bd marker block is stripped, the
+// user content above it is preserved, and the new v1.0.x BEADS INTEGRATION
+// block (added later by injectHookSection) re-installs the bd integration.
+//
+// This test exercises only the strip-decision logic — the same composition
+// used inside preservePreexistingHooks.
+func TestPreservePreexistingHooks_StripsLegacyMarkerBlock(t *testing.T) {
+	// A v0.62.x-style file: user dispatcher above, bd marker block below.
+	existing := `#!/bin/sh
+set -e
+# User's custom dispatcher (e.g. invokes the pre-commit framework)
+if [ -f .pre-commit-config.yaml ] && command -v pre-commit >/dev/null 2>&1; then
+    pre-commit run --hook-stage pre-commit "$@"
+fi
+
+# --- BEGIN BEADS INTEGRATION v0.62.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  bd hook pre-commit "$@"
+fi
+# --- END BEADS INTEGRATION v0.62.0 ---
+`
+
+	// 1. Old behaviour would skip on marker presence: confirm the marker IS present.
+	if !strings.Contains(existing, hookSectionBeginPrefix) {
+		t.Fatal("test fixture missing marker — fix the fixture")
+	}
+
+	// 2. Strip the bd section. User content must be preserved.
+	stripped, found := removeHookSection(existing)
+	if !found {
+		t.Fatal("removeHookSection did not find a section in fixture")
+	}
+	if !strings.Contains(stripped, "pre-commit run --hook-stage") {
+		t.Errorf("user dispatcher line lost in strip:\n%s", stripped)
+	}
+	if strings.Contains(stripped, "BEGIN BEADS INTEGRATION") ||
+		strings.Contains(stripped, "END BEADS INTEGRATION") {
+		t.Errorf("strip left bd markers in place:\n%s", stripped)
+	}
+
+	// 3. The stripped file must NOT be classified as "only shebang or empty",
+	//    so preservation will keep it instead of skipping.
+	if isOnlyShebangOrEmpty(stripped) {
+		t.Errorf("stripped file mis-classified as empty (would be skipped):\n%s", stripped)
+	}
+}
+
+// TestPreservePreexistingHooks_SkipsWhollyManagedFile guards the inverse
+// case: a file that contains ONLY the bd marker block (no user content)
+// genuinely is wholly bd-owned and should still be skipped — both the v1.0.x
+// shim format and the bare-marker-block-with-shebang form.
+func TestPreservePreexistingHooks_SkipsWhollyManagedFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "v1.0.x bare shim",
+			content: `#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+if command -v bd >/dev/null 2>&1; then
+  bd hooks run pre-commit "$@"
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---
+`,
+		},
+		{
+			name: "v0.62.0 marker block + nothing else",
+			content: `#!/bin/sh
+
+# --- BEGIN BEADS INTEGRATION v0.62.0 ---
+# managed
+if command -v bd >/dev/null 2>&1; then
+  bd hook pre-commit "$@"
+fi
+# --- END BEADS INTEGRATION v0.62.0 ---
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stripped, found := removeHookSection(tt.content)
+			if !found {
+				t.Fatal("removeHookSection did not find a section")
+			}
+			if !isOnlyShebangOrEmpty(stripped) {
+				t.Errorf("expected stripped content to be classified as empty (preservation should skip), got:\n%q", stripped)
+			}
+		})
+	}
+}
+
+// TestPreservePreexistingHooks_LeavesNonMarkerHookAlone is the regression
+// guard: a file with no bd markers must not be touched by the new
+// strip-then-preserve logic.
+func TestPreservePreexistingHooks_LeavesNonMarkerHookAlone(t *testing.T) {
+	content := `#!/bin/sh
+set -e
+echo "user pre-commit"
+make lint
+`
+	if strings.Contains(content, hookSectionBeginPrefix) {
+		t.Fatal("test fixture contains bd marker — adjust fixture")
+	}
+	// removeHookSection on a no-marker file should report nothing found and
+	// return content unchanged.
+	stripped, found := removeHookSection(content)
+	if found {
+		t.Errorf("unexpected: removeHookSection reported found on a no-marker file")
+	}
+	if stripped != content {
+		t.Errorf("removeHookSection mutated a no-marker file:\nbefore=%q\nafter =%q", content, stripped)
+	}
+}

--- a/cmd/bd/hooks_marker_skip_test.go
+++ b/cmd/bd/hooks_marker_skip_test.go
@@ -86,7 +86,7 @@ func TestShouldPreserveHookContent_TableDriven(t *testing.T) {
 			wantNot:   "/_/husky.sh",
 		},
 		{
-			name:      "husky after marker-strip: still gets sanitised",
+			name:      "husky after marker-strip: still gets sanitized",
 			content:   "#!/usr/bin/env sh\n. \"$(dirname -- \"$0\")/_/husky.sh\"\n\nnpx lint-staged\n\n" + v062Marker,
 			fromHusky: true,
 			wantKeep:  true,

--- a/cmd/bd/hooks_marker_skip_test.go
+++ b/cmd/bd/hooks_marker_skip_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // TestIsOnlyShebangOrEmpty_TableDriven exercises the helper used by
-// preservePreexistingHooks to decide, after stripping a BEADS INTEGRATION
+// shouldPreserveHookContent to decide, after stripping a BEADS INTEGRATION
 // block, whether anything user-owned remains worth preserving. (GH#3536)
 func TestIsOnlyShebangOrEmpty_TableDriven(t *testing.T) {
 	tests := []struct {
@@ -32,24 +32,94 @@ func TestIsOnlyShebangOrEmpty_TableDriven(t *testing.T) {
 	}
 }
 
-// TestPreservePreexistingHooks_StripsLegacyMarkerBlock reproduces GH#3536.
-// In the v0.62.x inline-injection model, bd appended its BEADS INTEGRATION
-// block to the BOTTOM of an otherwise-user-owned hook. When v1.0.x tries to
-// preserve that hook into .beads/hooks/<name>, the marker-presence check
-// previously caused the entire file to be skipped — silently discarding the
-// user's content.
-//
-// Expected behaviour after the fix: the bd marker block is stripped, the
-// user content above it is preserved, and the new v1.0.x BEADS INTEGRATION
-// block (added later by injectHookSection) re-installs the bd integration.
-//
-// This test exercises only the strip-decision logic — the same composition
-// used inside preservePreexistingHooks.
-func TestPreservePreexistingHooks_StripsLegacyMarkerBlock(t *testing.T) {
-	// A v0.62.x-style file: user dispatcher above, bd marker block below.
-	existing := `#!/bin/sh
+// TestShouldPreserveHookContent_TableDriven covers every branch of the new
+// pure-function decision used by preservePreexistingHooks. Each case mirrors
+// a real situation the migration path encounters. (GH#3536)
+func TestShouldPreserveHookContent_TableDriven(t *testing.T) {
+	const v062Marker = "# --- BEGIN BEADS INTEGRATION v0.62.0 ---\n" +
+		"# This section is managed by beads. Do not remove these markers.\n" +
+		"if command -v bd >/dev/null 2>&1; then\n" +
+		"  bd hook pre-commit \"$@\"\n" +
+		"fi\n" +
+		"# --- END BEADS INTEGRATION v0.62.0 ---\n"
+
+	tests := []struct {
+		name      string
+		content   string
+		fromHusky bool
+		wantKeep  bool
+		wantBody  string // exact wantBody when wantKeep is true; ignored otherwise
+		wantNot   string // substring that must NOT be present in the kept body
+	}{
+		{
+			name:     "inline marker — wholly bd-managed, skip",
+			content:  "#!/bin/sh\n# bd (beads)\nbd hook pre-commit \"$@\"\n",
+			wantKeep: false,
+		},
+		{
+			name: "v0.62.x style: dispatcher above + bd marker block — strip and preserve",
+			content: "#!/bin/sh\nset -e\n" +
+				"# user dispatcher\n" +
+				"if [ -f .pre-commit-config.yaml ] && command -v pre-commit >/dev/null 2>&1; then\n" +
+				"    pre-commit run --hook-stage pre-commit \"$@\"\n" +
+				"fi\n\n" +
+				v062Marker,
+			wantKeep: true,
+			wantNot:  "BEADS INTEGRATION",
+		},
+		{
+			name:     "marker block + only shebang — strip leaves nothing, skip",
+			content:  "#!/bin/sh\n\n" + v062Marker,
+			wantKeep: false,
+		},
+		{
+			name:     "no markers — preserve verbatim",
+			content:  "#!/bin/sh\nset -e\necho 'plain user hook'\nmake lint\n",
+			wantKeep: true,
+			wantBody: "#!/bin/sh\nset -e\necho 'plain user hook'\nmake lint\n",
+		},
+		{
+			name:      "husky v8: source line stripped, PATH injected",
+			content:   "#!/usr/bin/env sh\n. \"$(dirname -- \"$0\")/_/husky.sh\"\n\nnpx lint-staged\n",
+			fromHusky: true,
+			wantKeep:  true,
+			wantNot:   "/_/husky.sh",
+		},
+		{
+			name:      "husky after marker-strip: still gets sanitised",
+			content:   "#!/usr/bin/env sh\n. \"$(dirname -- \"$0\")/_/husky.sh\"\n\nnpx lint-staged\n\n" + v062Marker,
+			fromHusky: true,
+			wantKeep:  true,
+			wantNot:   "BEADS INTEGRATION",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, keep := shouldPreserveHookContent(tt.content, tt.fromHusky)
+			if keep != tt.wantKeep {
+				t.Fatalf("keep = %v, want %v (body=%q)", keep, tt.wantKeep, body)
+			}
+			if !tt.wantKeep {
+				return
+			}
+			if tt.wantBody != "" && body != tt.wantBody {
+				t.Errorf("body mismatch:\nwant=%q\ngot =%q", tt.wantBody, body)
+			}
+			if tt.wantNot != "" && strings.Contains(body, tt.wantNot) {
+				t.Errorf("kept body unexpectedly contains %q:\n%s", tt.wantNot, body)
+			}
+		})
+	}
+}
+
+// TestShouldPreserveHookContent_StrippedDispatcherSurvives is the explicit
+// GH#3536 regression: the user dispatcher above the bd marker block must
+// remain in the returned body so preservePreexistingHooks writes it into
+// .beads/hooks/<name>.
+func TestShouldPreserveHookContent_StrippedDispatcherSurvives(t *testing.T) {
+	in := `#!/bin/sh
 set -e
-# User's custom dispatcher (e.g. invokes the pre-commit framework)
 if [ -f .pre-commit-config.yaml ] && command -v pre-commit >/dev/null 2>&1; then
     pre-commit run --hook-stage pre-commit "$@"
 fi
@@ -61,96 +131,18 @@ if command -v bd >/dev/null 2>&1; then
 fi
 # --- END BEADS INTEGRATION v0.62.0 ---
 `
-
-	// 1. Old behaviour would skip on marker presence: confirm the marker IS present.
-	if !strings.Contains(existing, hookSectionBeginPrefix) {
-		t.Fatal("test fixture missing marker — fix the fixture")
+	body, keep := shouldPreserveHookContent(in, false)
+	if !keep {
+		t.Fatalf("dispatcher with marker block: keep=false, body=%q", body)
 	}
-
-	// 2. Strip the bd section. User content must be preserved.
-	stripped, found := removeHookSection(existing)
-	if !found {
-		t.Fatal("removeHookSection did not find a section in fixture")
+	if !strings.Contains(body, "pre-commit run --hook-stage") {
+		t.Errorf("dispatcher line lost:\n%s", body)
 	}
-	if !strings.Contains(stripped, "pre-commit run --hook-stage") {
-		t.Errorf("user dispatcher line lost in strip:\n%s", stripped)
+	if strings.Contains(body, "BEGIN BEADS INTEGRATION") ||
+		strings.Contains(body, "END BEADS INTEGRATION") {
+		t.Errorf("bd markers leaked through:\n%s", body)
 	}
-	if strings.Contains(stripped, "BEGIN BEADS INTEGRATION") ||
-		strings.Contains(stripped, "END BEADS INTEGRATION") {
-		t.Errorf("strip left bd markers in place:\n%s", stripped)
-	}
-
-	// 3. The stripped file must NOT be classified as "only shebang or empty",
-	//    so preservation will keep it instead of skipping.
-	if isOnlyShebangOrEmpty(stripped) {
-		t.Errorf("stripped file mis-classified as empty (would be skipped):\n%s", stripped)
-	}
-}
-
-// TestPreservePreexistingHooks_SkipsWhollyManagedFile guards the inverse
-// case: a file that contains ONLY the bd marker block (no user content)
-// genuinely is wholly bd-owned and should still be skipped — both the v1.0.x
-// shim format and the bare-marker-block-with-shebang form.
-func TestPreservePreexistingHooks_SkipsWhollyManagedFile(t *testing.T) {
-	tests := []struct {
-		name    string
-		content string
-	}{
-		{
-			name: "v1.0.x bare shim",
-			content: `#!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
-if command -v bd >/dev/null 2>&1; then
-  bd hooks run pre-commit "$@"
-fi
-# --- END BEADS INTEGRATION v1.0.3 ---
-`,
-		},
-		{
-			name: "v0.62.0 marker block + nothing else",
-			content: `#!/bin/sh
-
-# --- BEGIN BEADS INTEGRATION v0.62.0 ---
-# managed
-if command -v bd >/dev/null 2>&1; then
-  bd hook pre-commit "$@"
-fi
-# --- END BEADS INTEGRATION v0.62.0 ---
-`,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			stripped, found := removeHookSection(tt.content)
-			if !found {
-				t.Fatal("removeHookSection did not find a section")
-			}
-			if !isOnlyShebangOrEmpty(stripped) {
-				t.Errorf("expected stripped content to be classified as empty (preservation should skip), got:\n%q", stripped)
-			}
-		})
-	}
-}
-
-// TestPreservePreexistingHooks_LeavesNonMarkerHookAlone is the regression
-// guard: a file with no bd markers must not be touched by the new
-// strip-then-preserve logic.
-func TestPreservePreexistingHooks_LeavesNonMarkerHookAlone(t *testing.T) {
-	content := `#!/bin/sh
-set -e
-echo "user pre-commit"
-make lint
-`
-	if strings.Contains(content, hookSectionBeginPrefix) {
-		t.Fatal("test fixture contains bd marker — adjust fixture")
-	}
-	// removeHookSection on a no-marker file should report nothing found and
-	// return content unchanged.
-	stripped, found := removeHookSection(content)
-	if found {
-		t.Errorf("unexpected: removeHookSection reported found on a no-marker file")
-	}
-	if stripped != content {
-		t.Errorf("removeHookSection mutated a no-marker file:\nbefore=%q\nafter =%q", content, stripped)
+	if strings.Contains(body, "bd hook pre-commit") {
+		t.Errorf("legacy 'bd hook' invocation should have been stripped with the marker block:\n%s", body)
 	}
 }

--- a/cmd/bd/hooks_marker_skip_test.go
+++ b/cmd/bd/hooks_marker_skip_test.go
@@ -113,6 +113,58 @@ func TestShouldPreserveHookContent_TableDriven(t *testing.T) {
 	}
 }
 
+// TestShouldPreserveHookContent_TwoBlankLinesBeforeMarker exercises the
+// boundary where user content ends in two blank lines before the bd marker
+// block. removeHookSection collapses runs of `\n\n\n` to `\n\n`, so this
+// fixture confirms the strip doesn't over-trim user content.
+func TestShouldPreserveHookContent_TwoBlankLinesBeforeMarker(t *testing.T) {
+	in := "#!/bin/sh\n" +
+		"set -e\n" +
+		"echo 'user line 1'\n" +
+		"echo 'user line 2'\n" +
+		"\n" +
+		"\n" +
+		"# --- BEGIN BEADS INTEGRATION v0.62.0 ---\n" +
+		"if command -v bd >/dev/null 2>&1; then bd hook pre-commit \"$@\"; fi\n" +
+		"# --- END BEADS INTEGRATION v0.62.0 ---\n"
+
+	body, keep := shouldPreserveHookContent(in, false)
+	if !keep {
+		t.Fatalf("two-blank-line boundary: keep=false, body=%q", body)
+	}
+	if !strings.Contains(body, "echo 'user line 1'") || !strings.Contains(body, "echo 'user line 2'") {
+		t.Errorf("user content lost across two-blank-line boundary:\n%q", body)
+	}
+	if strings.Contains(body, "BEADS INTEGRATION") {
+		t.Errorf("bd markers leaked through:\n%q", body)
+	}
+}
+
+// TestShouldPreserveHookContent_CRLFNormalised verifies that a v0.62.x hook
+// stored with Windows-style `\r\n` line endings is normalised to LF on the
+// preserved-and-stripped output. Mirrors the normalisation that
+// injectHookSection applies on its inject path. (GH#3536 nit)
+func TestShouldPreserveHookContent_CRLFNormalised(t *testing.T) {
+	in := "#!/bin/sh\r\n" +
+		"set -e\r\n" +
+		"echo 'user'\r\n" +
+		"\r\n" +
+		"# --- BEGIN BEADS INTEGRATION v0.62.0 ---\r\n" +
+		"if command -v bd >/dev/null 2>&1; then bd hook pre-commit \"$@\"; fi\r\n" +
+		"# --- END BEADS INTEGRATION v0.62.0 ---\r\n"
+
+	body, keep := shouldPreserveHookContent(in, false)
+	if !keep {
+		t.Fatalf("CRLF input: keep=false, body=%q", body)
+	}
+	if strings.Contains(body, "\r\n") {
+		t.Errorf("CRLF survived into preserved output (should be normalised to LF):\n%q", body)
+	}
+	if !strings.Contains(body, "echo 'user'") {
+		t.Errorf("user content lost:\n%q", body)
+	}
+}
+
 // TestShouldPreserveHookContent_StrippedDispatcherSurvives is the explicit
 // GH#3536 regression: the user dispatcher above the bd marker block must
 // remain in the returned body so preservePreexistingHooks writes it into


### PR DESCRIPTION
Fixes #3536.

## Summary

`preservePreexistingHooks` (`cmd/bd/hooks.go`) treated any file containing the `# --- BEGIN BEADS INTEGRATION` marker as wholly bd-managed and skipped it during preservation:

```go
// before
if strings.Contains(contentStr, hookSectionBeginPrefix) ||
    strings.Contains(contentStr, inlineHookMarker) {
    continue
}
```

But the v0.62.x inline-injection model only injected a *block* into otherwise-user-owned files (custom dispatchers, framework integrations, husky setups). On migration to v1.0.x's relocate-to-`.beads/hooks/` model, that user content was silently discarded — only the bare bd shim ended up in `.beads/hooks/<name>`.

Reproduced on a personal dotfiles repo and 7 of 10 surveyed local repos that were initialized under v0.62.x and later upgraded.

## What this PR does

- When the begin marker is present, strip the bd section using the existing `removeHookSection` helper (no new logic invented), then preserve any remaining user content. The new content path goes through the same husky-sanitization + write logic as fresh hooks.
- Only skip if stripping leaves nothing meaningful — guarded by a new pure helper `isOnlyShebangOrEmpty`. This handles two cases that genuinely should still be skipped: a `v1.0.x bare shim` file (no user content above the bd block) and a `v0.62.0 marker-block-only` file (e.g. a hook bd installed onto an empty starting point).
- The `inlineHookMarker` (the `# bd (beads)` tag from GH#1120) skip is unchanged — those files genuinely were wholly bd-owned one-liners with no user content above.

## Diff

The functional change is small — one branch in `preservePreexistingHooks` plus the new helper. No new logic in `removeHookSection` (which already does the right thing).

```go
// after
if strings.Contains(contentStr, inlineHookMarker) {
    continue   // unchanged: v1120 one-liners are wholly bd-owned
}
if strings.Contains(contentStr, hookSectionBeginPrefix) {
    stripped, _ := removeHookSection(contentStr)
    if isOnlyShebangOrEmpty(stripped) {
        continue   // wholly bd-owned: shebang+block only
    }
    contentStr = stripped   // preserve user content above/below the bd block
}
```

## Tests

`cmd/bd/hooks_marker_skip_test.go` adds:

- `TestIsOnlyShebangOrEmpty_TableDriven` — 8 cases covering empty, blanks-only, shebang-only, shebang+blanks, shebang+comments, shebang+command, no-shebang+command, and a representative user dispatcher.
- `TestPreservePreexistingHooks_StripsLegacyMarkerBlock` — the GH#3536 repro: a v0.62.x-style file (user dispatcher above + bd marker block below) must produce stripped content with the dispatcher intact and the bd markers gone, and must NOT be classified as empty (i.e. preservation will keep it).
- `TestPreservePreexistingHooks_SkipsWhollyManagedFile` — both the v1.0.x bare shim and the v0.62.0-marker-only-with-shebang case must still be skipped after stripping.
- `TestPreservePreexistingHooks_LeavesNonMarkerHookAlone` — regression guard: hooks with no bd markers are untouched by the new logic.

All hooks-related tests pass:

```
$ go test -tags gms_pure_go -short -run 'Hook|hook|Inject|Marker|Sanitize|IsOnly|Preserve' ./cmd/bd/
ok  	github.com/steveyegge/beads/cmd/bd	90.474s
```

Linter clean (with the build tag CONTRIBUTING.md documents):

```
$ golangci-lint run --new-from-rev=main --build-tags=gms_pure_go ./cmd/bd/
0 issues.
```

## Out of scope

This PR fixes only the marker-skip preservation path. The closely-related exec-composition bug (#3537) — where `injectHookSection` appends the bd block below pre-commit's templated hook's `exec` line, making it unreachable — is a separate code path with its own root cause; per CONTRIBUTING.md's "one issue per PR" rule, that fix is being submitted separately as a sibling PR.

## Test plan

- [ ] CI passes (linter, tests, build matrix).
- [ ] On a repo where `.git/hooks/pre-commit` contains a v0.62.x `# --- BEGIN BEADS INTEGRATION v0.62.0 ---` marker block above otherwise-user-owned content, run `bd hooks install --beads` and verify `.beads/hooks/pre-commit` ends with: user content (preserved) → new v1.0.x BEADS INTEGRATION block. Confirm `Preserving existing pre-commit hook from .git/hooks` is printed.
