### PR TITLE
feat(setup): omit bd dolt push from template when no remote configured

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1247,14 +1247,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			if resolvedAgentsFile == "" {
 				resolvedAgentsFile = config.SafeAgentsFile()
 			}
-		if isBareGitRepo() {
-			if !quiet {
-				fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
+			if isBareGitRepo() {
+				if !quiet {
+					fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
+				}
+			} else {
+				renderOpts := agents.RenderOpts{HasRemote: shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig)}
+				addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile, renderOpts)
 			}
-		} else {
-			renderOpts := agents.RenderOpts{HasRemote: shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig)}
-			addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile, renderOpts)
-		}
 		}
 
 		// Auto-setup Claude hooks for project (writes to .claude/settings.json)

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1247,13 +1247,14 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			if resolvedAgentsFile == "" {
 				resolvedAgentsFile = config.SafeAgentsFile()
 			}
-			if isBareGitRepo() {
-				if !quiet {
-					fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
-				}
-			} else {
-				addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile)
+		if isBareGitRepo() {
+			if !quiet {
+				fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
 			}
+		} else {
+			renderOpts := agents.RenderOpts{HasRemote: shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig)}
+			addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile, renderOpts)
+		}
 		}
 
 		// Auto-setup Claude hooks for project (writes to .claude/settings.json)

--- a/cmd/bd/init_agent.go
+++ b/cmd/bd/init_agent.go
@@ -15,12 +15,13 @@ import (
 // agentFile is the target filename (e.g. "AGENTS.md" or "BEADS.md").
 // If templatePath is non-empty, the custom template file is used instead of the embedded default.
 // profile controls which template variant to render (full or minimal); defaults to minimal.
-func addAgentsInstructions(agentFile string, verbose bool, templatePath string, profile agents.Profile) {
+// opts controls conditional content (e.g. omitting bd dolt push when no remote is configured).
+func addAgentsInstructions(agentFile string, verbose bool, templatePath string, profile agents.Profile, opts agents.RenderOpts) {
 	if profile == "" {
 		profile = agents.ProfileMinimal
 	}
 
-	if err := updateAgentFile(agentFile, verbose, templatePath, profile); err != nil {
+	if err := updateAgentFile(agentFile, verbose, templatePath, profile, opts); err != nil {
 		// Non-fatal - continue with other files
 		if verbose {
 			fmt.Fprintf(os.Stderr, "Warning: failed to update %s: %v\n", agentFile, err)
@@ -33,7 +34,7 @@ func addAgentsInstructions(agentFile string, verbose bool, templatePath string, 
 // versioned format so that `bd init` never silently locks in stale sections.
 // If the file already has a full profile and a minimal profile is requested, the full
 // profile is preserved to avoid information loss.
-func updateAgentFile(filename string, verbose bool, templatePath string, profile agents.Profile) error {
+func updateAgentFile(filename string, verbose bool, templatePath string, profile agents.Profile, opts agents.RenderOpts) error {
 	// Check if file exists
 	//nolint:gosec // G304: filename validated by config.ValidateAgentsFile or defaulted to AGENTS.md
 	content, err := os.ReadFile(filename)
@@ -55,7 +56,7 @@ func updateAgentFile(filename string, verbose bool, templatePath string, profile
 		// EmbeddedDefault() ships with profile:full; swap to the requested profile
 		// (which defaults to minimal). Also handles legacy markers without profile metadata.
 		if strings.Contains(newContent, "BEGIN BEADS INTEGRATION") {
-			if replaced, changed, err := agents.ReplaceSection(newContent, profile); err == nil && changed {
+			if replaced, changed, err := agents.ReplaceSectionWithOpts(newContent, profile, opts); err == nil && changed {
 				newContent = replaced
 			}
 		}
@@ -88,7 +89,7 @@ func updateAgentFile(filename string, verbose bool, templatePath string, profile
 		}
 
 		// Update existing section to latest versioned format (upgrades legacy markers)
-		updated, changed, replaceErr := agents.ReplaceSection(contentStr, effectiveProfile)
+		updated, changed, replaceErr := agents.ReplaceSectionWithOpts(contentStr, effectiveProfile, opts)
 		if replaceErr != nil {
 			return fmt.Errorf("failed to update beads section in %s: %w", filename, replaceErr)
 		}
@@ -112,7 +113,7 @@ func updateAgentFile(filename string, verbose bool, templatePath string, profile
 		newContent += "\n"
 	}
 
-	newContent += "\n" + agents.RenderSection(profile)
+	newContent += "\n" + agents.RenderSectionWithOpts(profile, opts)
 
 	// #nosec G306 - markdown needs to be readable
 	if err := os.WriteFile(filename, []byte(newContent), 0644); err != nil {

--- a/cmd/bd/setup/agents.go
+++ b/cmd/bd/setup/agents.go
@@ -52,6 +52,20 @@ func defaultAgentsEnv() agentsEnv {
 	}
 }
 
+// detectRenderOptsImpl checks whether a Dolt sync remote is configured and returns
+// appropriate RenderOpts. When no remote is configured, the rendered template
+// omits "bd dolt push" from session-completion instructions.
+// Exposed as a variable so tests can override.
+var detectRenderOptsImpl = func() agents.RenderOpts {
+	return agents.RenderOpts{
+		HasRemote: config.GetString("sync.remote") != "" || config.GetString("sync.git-remote") != "",
+	}
+}
+
+func detectRenderOpts() agents.RenderOpts {
+	return detectRenderOptsImpl()
+}
+
 // containsBeadsMarker returns true if content contains a BEGIN BEADS INTEGRATION marker
 // (either legacy or new format with metadata).
 func containsBeadsMarker(content string) bool {
@@ -79,6 +93,7 @@ func installAgents(env agentsEnv, integration agentsIntegration) error {
 	agentsFile := agentsFileName(env.agentsPath)
 
 	profile := resolveProfile(integration)
+	opts := detectRenderOpts()
 
 	// Resolve symlinks so that e.g. CLAUDE.md -> AGENTS.md writes to the real target.
 	// This uses the existing atomicWriteFile path which also calls ResolveForWrite,
@@ -109,11 +124,11 @@ func installAgents(env agentsEnv, integration agentsIntegration) error {
 		}
 	}
 
-	beadsSection := agents.RenderSection(profile)
+	beadsSection := agents.RenderSectionWithOpts(profile, opts)
 
 	if currentContent != "" {
 		if containsBeadsMarker(currentContent) {
-			newContent := updateBeadsSectionWithProfile(currentContent, profile)
+			newContent := updateBeadsSectionWithOpts(currentContent, profile, opts)
 			if err := atomicWriteFile(env.agentsPath, []byte(newContent)); err != nil {
 				_, _ = fmt.Fprintf(env.stderr, "Error: write %s: %v\n", env.agentsPath, err)
 				return err
@@ -128,7 +143,7 @@ func installAgents(env agentsEnv, integration agentsIntegration) error {
 			_, _ = fmt.Fprintf(env.stdout, "✓ Added beads section to existing %s\n", agentsFile)
 		}
 	} else {
-		newContent := createNewAgentsFileWithProfile(profile)
+		newContent := createNewAgentsFileWithOpts(profile, opts)
 		if err := atomicWriteFile(env.agentsPath, []byte(newContent)); err != nil {
 			_, _ = fmt.Fprintf(env.stderr, "Error: write %s: %v\n", env.agentsPath, err)
 			return err
@@ -187,7 +202,7 @@ func checkAgents(env agentsEnv, integration agentsIntegration) error {
 		checkProfile = agents.ProfileFull
 	}
 
-	currentHash := agents.CurrentHash(checkProfile)
+	currentHash := agents.CurrentHashWithOpts(checkProfile, detectRenderOpts())
 	if meta != nil && meta.Hash == currentHash && existingProf == checkProfile {
 		_, _ = fmt.Fprintf(env.stdout, "✓ %s integration installed: %s (current)\n", integration.name, env.agentsPath)
 		return nil
@@ -237,12 +252,13 @@ func updateBeadsSection(content string) string {
 // Delegates to the canonical agents.ReplaceSection. Returns an error string on
 // malformed markers (logged by callers) instead of silently appending.
 func updateBeadsSectionWithProfile(content string, profile agents.Profile) string {
-	replaced, _, err := agents.ReplaceSection(content, profile)
+	return updateBeadsSectionWithOpts(content, profile, agents.DefaultRenderOpts())
+}
+
+// updateBeadsSectionWithOpts replaces the beads section with the given profile and render opts.
+func updateBeadsSectionWithOpts(content string, profile agents.Profile, opts agents.RenderOpts) string {
+	replaced, _, err := agents.ReplaceSectionWithOpts(content, profile, opts)
 	if err != nil {
-		// ErrNoSection or ErrMalformedMarkers — return content unchanged.
-		// Callers check containsBeadsMarker() before calling, so ErrNoSection
-		// should not occur in practice. Malformed markers are preserved rather
-		// than silently appending a duplicate section.
 		return content
 	}
 	return replaced
@@ -311,7 +327,12 @@ func createNewAgentsFile() string {
 
 // createNewAgentsFileWithProfile creates a new AGENTS.md with the given profile.
 func createNewAgentsFileWithProfile(profile agents.Profile) string {
-	beadsSection := agents.RenderSection(profile)
+	return createNewAgentsFileWithOpts(profile, agents.DefaultRenderOpts())
+}
+
+// createNewAgentsFileWithOpts creates a new AGENTS.md with the given profile and render opts.
+func createNewAgentsFileWithOpts(profile agents.Profile, opts agents.RenderOpts) string {
+	beadsSection := agents.RenderSectionWithOpts(profile, opts)
 
 	return `# Project Instructions for AI Agents
 

--- a/cmd/bd/setup/agents_marker_test.go
+++ b/cmd/bd/setup/agents_marker_test.go
@@ -229,6 +229,8 @@ func TestCheckAgentsDetectsStale(t *testing.T) {
 }
 
 func TestCheckAgentsCurrent(t *testing.T) {
+	stubDetectRenderOpts(t)
+
 	env, stdout, _ := newFactoryTestEnv(t)
 	section := agents.RenderSection(agents.ProfileFull)
 	if err := os.WriteFile(env.agentsPath, []byte(section), 0644); err != nil {
@@ -248,6 +250,8 @@ func TestCheckAgentsCurrent(t *testing.T) {
 }
 
 func TestCheckAgentsMinimalAcceptsFullProfile(t *testing.T) {
+	stubDetectRenderOpts(t)
+
 	env, _, _ := newFactoryTestEnv(t)
 	section := agents.RenderSection(agents.ProfileFull)
 	if err := os.WriteFile(env.agentsPath, []byte(section), 0644); err != nil {

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -639,6 +639,8 @@ func TestInstallClaudeErrors(t *testing.T) {
 }
 
 func TestCheckClaudeScenarios(t *testing.T) {
+	stubDetectRenderOpts(t)
+
 	t.Run("global hooks", func(t *testing.T) {
 		env, stdout, _ := newClaudeTestEnv(t)
 		writeSettings(t, globalSettingsPath(env.homeDir), map[string]interface{}{
@@ -955,6 +957,7 @@ func TestInstallClaudeWritesHooksWithoutPlugin(t *testing.T) {
 }
 
 func TestCheckClaudePluginManaged(t *testing.T) {
+	stubDetectRenderOpts(t)
 	env, stdout, _ := newClaudeTestEnv(t)
 
 	// Plugin enabled but no hooks in settings files

--- a/cmd/bd/setup/factory_test.go
+++ b/cmd/bd/setup/factory_test.go
@@ -237,6 +237,8 @@ func TestInstallFactoryReportsWriteError(t *testing.T) {
 }
 
 func TestCheckFactoryScenarios(t *testing.T) {
+	stubDetectRenderOpts(t)
+
 	t.Run("missing file", func(t *testing.T) {
 		env, stdout, _ := newFactoryTestEnv(t)
 		err := checkFactory(env)

--- a/cmd/bd/setup/setup_test_helpers.go
+++ b/cmd/bd/setup/setup_test_helpers.go
@@ -1,6 +1,10 @@
 package setup
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/templates/agents"
+)
 
 type exitCapture struct {
 	called bool
@@ -19,4 +23,14 @@ func stubSetupExit(t *testing.T) *exitCapture {
 		setupExit = orig
 	})
 	return cap
+}
+
+// stubDetectRenderOpts overrides detectRenderOptsImpl to return
+// DefaultRenderOpts (HasRemote=true), matching what agents.RenderSection()
+// produces. This prevents hash mismatches in tests where no beads config exists.
+func stubDetectRenderOpts(t *testing.T) {
+	t.Helper()
+	orig := detectRenderOptsImpl
+	detectRenderOptsImpl = func() agents.RenderOpts { return agents.DefaultRenderOpts() }
+	t.Cleanup(func() { detectRenderOptsImpl = orig })
 }

--- a/internal/templates/agents/render.go
+++ b/internal/templates/agents/render.go
@@ -41,10 +41,32 @@ type SectionMeta struct {
 	Hash    string
 }
 
+// RenderOpts controls conditional content in rendered templates.
+type RenderOpts struct {
+	// HasRemote indicates whether a Dolt remote is configured.
+	// When false, "bd dolt push" is omitted from session-completion instructions.
+	HasRemote bool
+}
+
+// DefaultRenderOpts returns opts that assume a remote is configured,
+// preserving backward-compatible behavior for callers that don't pass opts.
+func DefaultRenderOpts() RenderOpts {
+	return RenderOpts{HasRemote: true}
+}
+
 // RenderSection returns the beads integration section for the given profile,
 // wrapped in markers that include version, profile, and hash metadata for freshness detection.
+// Assumes a Dolt remote is configured (backward-compatible). Use RenderSectionWithOpts
+// to control conditional content.
 func RenderSection(profile Profile) string {
-	body := templateBody(profile)
+	return RenderSectionWithOpts(profile, DefaultRenderOpts())
+}
+
+// RenderSectionWithOpts renders the beads integration section with conditional content
+// controlled by opts. When opts.HasRemote is false, "bd dolt push" is omitted from
+// session-completion instructions.
+func RenderSectionWithOpts(profile Profile, opts RenderOpts) string {
+	body := templateBodyWithOpts(profile, opts)
 	hash := computeHash(body)
 	beginMarker := fmt.Sprintf("<!-- BEGIN BEADS INTEGRATION v:%d profile:%s hash:%s -->", MarkerVersion, profile, hash)
 	return beginMarker + "\n" + body + "\n<!-- END BEADS INTEGRATION -->\n"
@@ -53,11 +75,19 @@ func RenderSection(profile Profile) string {
 // ReplaceSection replaces an existing beads integration section in content with a
 // freshly rendered section for the given profile. Returns the (possibly unchanged)
 // content, whether it was modified, and any error.
+// Assumes a Dolt remote is configured (backward-compatible). Use ReplaceSectionWithOpts
+// to control conditional content.
 //
 // Errors:
 //   - ErrNoSection: no BEGIN marker found (caller should append instead)
 //   - ErrMalformedMarkers: BEGIN exists but END is missing or appears before BEGIN
 func ReplaceSection(content string, profile Profile) (string, bool, error) {
+	return ReplaceSectionWithOpts(content, profile, DefaultRenderOpts())
+}
+
+// ReplaceSectionWithOpts replaces an existing beads integration section in content with a
+// freshly rendered section for the given profile and opts.
+func ReplaceSectionWithOpts(content string, profile Profile, opts RenderOpts) (string, bool, error) {
 	beginIdx := strings.Index(content, "<!-- BEGIN BEADS INTEGRATION")
 	if beginIdx == -1 {
 		return content, false, ErrNoSection
@@ -78,7 +108,7 @@ func ReplaceSection(content string, profile Profile) (string, bool, error) {
 		firstLine = firstLine[:nl]
 	}
 	meta := ParseMarker(firstLine)
-	if meta != nil && meta.Hash == CurrentHash(profile) && meta.Profile == profile {
+	if meta != nil && meta.Hash == CurrentHashWithOpts(profile, opts) && meta.Profile == profile {
 		return content, false, nil // already up to date
 	}
 
@@ -88,14 +118,20 @@ func ReplaceSection(content string, profile Profile) (string, bool, error) {
 		endOfEndMarker++
 	}
 
-	replaced := content[:beginIdx] + RenderSection(profile) + content[endOfEndMarker:]
+	replaced := content[:beginIdx] + RenderSectionWithOpts(profile, opts) + content[endOfEndMarker:]
 	return replaced, true, nil
 }
 
 // CurrentHash returns the hash of the current template body for a profile.
 // Callers can compare this against a parsed marker's hash to detect staleness.
+// Assumes a Dolt remote is configured (backward-compatible).
 func CurrentHash(profile Profile) string {
-	return computeHash(templateBody(profile))
+	return CurrentHashWithOpts(profile, DefaultRenderOpts())
+}
+
+// CurrentHashWithOpts returns the hash for a profile with the given render opts.
+func CurrentHashWithOpts(profile Profile, opts RenderOpts) string {
+	return computeHash(templateBodyWithOpts(profile, opts))
 }
 
 // ParseMarker parses a BEGIN BEADS INTEGRATION marker line and returns its metadata.
@@ -141,10 +177,18 @@ func ParseMarker(line string) *SectionMeta {
 }
 
 // templateBody returns the raw body content (without markers) for a profile.
+// Backward-compatible wrapper that assumes a Dolt remote is configured.
 func templateBody(profile Profile) string {
+	return templateBodyWithOpts(profile, DefaultRenderOpts())
+}
+
+// templateBodyWithOpts returns the raw body content (without markers) for a
+// profile, with conditional content controlled by opts.
+func templateBodyWithOpts(profile Profile, opts RenderOpts) string {
+	var body string
 	switch profile {
 	case ProfileMinimal:
-		return strings.TrimRight(beadsSectionMinimal, "\n")
+		body = strings.TrimRight(beadsSectionMinimal, "\n")
 	default:
 		// Full profile uses the same body as the legacy beads-section.md
 		// Strip the existing markers from the embedded content. Normalize CRLF→LF
@@ -152,12 +196,28 @@ func templateBody(profile Profile) string {
 		// from the working tree) still matches the LF-only prefix/suffix below.
 		// Without this, the legacy markers stay in the body and RenderSection
 		// wraps them again, producing doubled markers in the installed file (#3552).
-		body := strings.ReplaceAll(beadsSection, "\r\n", "\n")
+		body = strings.ReplaceAll(beadsSection, "\r\n", "\n")
 		body = strings.TrimRight(body, "\n")
 		body = strings.TrimPrefix(body, "<!-- BEGIN BEADS INTEGRATION -->\n")
 		body = strings.TrimSuffix(body, "\n<!-- END BEADS INTEGRATION -->")
-		return body
 	}
+
+	if !opts.HasRemote {
+		body = stripDoltPushReferences(body)
+	}
+
+	return body
+}
+
+// stripDoltPushReferences removes "bd dolt push" directives from the template body.
+// Strips the indented code-block line from session completion, and the
+// informational Auto-Sync bullet that references dolt push/pull.
+func stripDoltPushReferences(body string) string {
+	// Session completion code block: "   bd dolt push\n"
+	body = strings.ReplaceAll(body, "   bd dolt push\n", "")
+	// Auto-Sync informational bullet (full profile only)
+	body = strings.ReplaceAll(body, "- Use `bd dolt push`/`bd dolt pull` for remote sync\n", "")
+	return body
 }
 
 // computeHash returns the first 8 hex chars of the SHA-256 of the body.

--- a/internal/templates/agents/render_test.go
+++ b/internal/templates/agents/render_test.go
@@ -366,3 +366,105 @@ func TestRenderSectionIncludesVersion(t *testing.T) {
 		t.Errorf("Version = %d, want %d", meta.Version, MarkerVersion)
 	}
 }
+
+func TestRenderSectionWithOptsNoRemoteFull(t *testing.T) {
+	opts := RenderOpts{HasRemote: false}
+	section := RenderSectionWithOpts(ProfileFull, opts)
+
+	if strings.Contains(section, "bd dolt push") {
+		t.Error("full profile with HasRemote=false should not contain 'bd dolt push'")
+	}
+
+	// Should still contain other session completion content
+	if !strings.Contains(section, "git push") {
+		t.Error("should still contain 'git push'")
+	}
+	if !strings.Contains(section, "Session Completion") {
+		t.Error("should still contain Session Completion section")
+	}
+}
+
+func TestRenderSectionWithOptsNoRemoteMinimal(t *testing.T) {
+	opts := RenderOpts{HasRemote: false}
+	section := RenderSectionWithOpts(ProfileMinimal, opts)
+
+	if strings.Contains(section, "bd dolt push") {
+		t.Error("minimal profile with HasRemote=false should not contain 'bd dolt push'")
+	}
+
+	if !strings.Contains(section, "git push") {
+		t.Error("should still contain 'git push'")
+	}
+}
+
+func TestRenderSectionWithOptsHasRemoteIncludesDoltPush(t *testing.T) {
+	opts := RenderOpts{HasRemote: true}
+	for _, profile := range []Profile{ProfileFull, ProfileMinimal} {
+		section := RenderSectionWithOpts(profile, opts)
+		if !strings.Contains(section, "bd dolt push") {
+			t.Errorf("%s profile with HasRemote=true should contain 'bd dolt push'", profile)
+		}
+	}
+}
+
+func TestRenderSectionBackwardCompatIncludesDoltPush(t *testing.T) {
+	// RenderSection (no opts) should default to HasRemote=true for backward compat
+	for _, profile := range []Profile{ProfileFull, ProfileMinimal} {
+		section := RenderSection(profile)
+		if !strings.Contains(section, "bd dolt push") {
+			t.Errorf("RenderSection(%s) should include 'bd dolt push' (backward compat)", profile)
+		}
+	}
+}
+
+func TestRenderSectionWithOptsDifferentHashes(t *testing.T) {
+	// HasRemote=true and HasRemote=false should produce different hashes
+	// since the content differs
+	withRemote := RenderSectionWithOpts(ProfileFull, RenderOpts{HasRemote: true})
+	withoutRemote := RenderSectionWithOpts(ProfileFull, RenderOpts{HasRemote: false})
+
+	meta1 := ParseMarker(strings.SplitN(withRemote, "\n", 2)[0])
+	meta2 := ParseMarker(strings.SplitN(withoutRemote, "\n", 2)[0])
+
+	if meta1 == nil || meta2 == nil {
+		t.Fatal("ParseMarker returned nil")
+	}
+	if meta1.Hash == meta2.Hash {
+		t.Error("HasRemote=true and HasRemote=false should produce different hashes")
+	}
+}
+
+func TestReplaceSectionWithOptsIdempotent(t *testing.T) {
+	opts := RenderOpts{HasRemote: false}
+	section := RenderSectionWithOpts(ProfileFull, opts)
+	content := "# Header\n\n" + section + "\n# Footer\n"
+
+	result, changed, err := ReplaceSectionWithOpts(content, ProfileFull, opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("should not change when section is already current with same opts")
+	}
+	if result != content {
+		t.Error("content should be unchanged")
+	}
+}
+
+func TestReplaceSectionWithOptsDetectsRemoteChange(t *testing.T) {
+	// Render with remote, then replace with no-remote opts → should detect as stale
+	withRemote := RenderSectionWithOpts(ProfileFull, RenderOpts{HasRemote: true})
+	content := "# Header\n\n" + withRemote + "\n# Footer\n"
+
+	noRemoteOpts := RenderOpts{HasRemote: false}
+	result, changed, err := ReplaceSectionWithOpts(content, ProfileFull, noRemoteOpts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("should detect stale hash when remote state changes")
+	}
+	if strings.Contains(result, "bd dolt push") {
+		t.Error("replaced content should not contain 'bd dolt push' with HasRemote=false")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `RenderOpts` with `HasRemote` flag to the template rendering system (`internal/templates/agents/render.go`). When `HasRemote` is false, `bd dolt push` is stripped from the session-completion code block and the Auto-Sync bullet in the full profile.
- `bd init` detects the remote via the existing `shouldWireInitRemote()` logic and passes opts through `addAgentsInstructions` → `updateAgentFile`.
- `bd setup <recipe>` detects the remote by reading `sync.remote` / `sync.git-remote` from config.yaml at install/check time.
- Backward-compatible: `RenderSection()` and `ReplaceSection()` (no opts) default to `HasRemote: true`, so all existing callers and tests are unaffected.

## Motivation

When `bd init` renders the BEADS INTEGRATION template into CLAUDE.md / AGENTS.md, it unconditionally includes `bd dolt push` in the session-completion checklist. For solo/local-only projects with no Dolt remote configured, this is a no-op that agents dutifully execute every session. The agent sees `bd dolt push` as MANDATORY, runs it, gets "No remote is configured — skipping", and moves on — wasting a tool call and cluttering the session close.

## Test plan

- [x] New tests: `TestRenderSectionWithOptsNoRemoteFull`, `TestRenderSectionWithOptsNoRemoteMinimal` — verify `bd dolt push` absent when `HasRemote=false`
- [x] New tests: `TestRenderSectionWithOptsHasRemoteIncludesDoltPush`, `TestRenderSectionBackwardCompatIncludesDoltPush` — verify backward compat
- [x] New tests: `TestRenderSectionWithOptsDifferentHashes` — verify hash diverges between remote/no-remote
- [x] New tests: `TestReplaceSectionWithOptsIdempotent`, `TestReplaceSectionWithOptsDetectsRemoteChange` — verify freshness detection works with opts
- [x] All existing template tests pass unchanged
- [x] All existing setup tests pass (with test seam for config-less test environments)
- [x] `go vet` clean on all changed packages
- [x] Full `go build -tags gms_pure_go ./cmd/bd/` succeeds