### PR TITLE
fix(create): validate --deps type and fix blocked-by/depends-on aliases

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/governance.yml
+++ b/.github/DISCUSSION_TEMPLATE/governance.yml
@@ -1,0 +1,37 @@
+title: "[Governance]: "
+labels:
+  - governance
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This category is for discussions about the [Agentic Covenant](../../CODE_OF_CONDUCT.md),
+        contributor policies, and community governance.
+
+        We welcome feedback on how the Agentic Covenant works in practice — both from
+        this project and from projects that have adopted it.
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic area
+      options:
+        - Agentic Covenant feedback (general)
+        - Operator accountability
+        - Disclosure and attribution
+        - Rate limits and resource stewardship
+        - Agent operating standards
+        - Contributor protection
+        - Enforcement
+        - Adoption by other projects
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: discussion
+    attributes:
+      label: Discussion
+      description: Share your thoughts, experience, or proposal.
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/questions.yml
+++ b/.github/DISCUSSION_TEMPLATE/questions.yml
@@ -1,0 +1,45 @@
+title: "[Question]: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ask a question about bd (beads). Both human and agent-assisted developers are welcome.
+
+        Before asking, check:
+        - [README.md](../../README.md) and [docs/](../../docs/)
+        - [Existing discussions](https://github.com/gastownhall/beads/discussions)
+        - [FAQ](../../docs/FAQ.md) if it exists
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Getting started / setup
+        - CLI usage
+        - Agent integration (MCP, hooks, AGENTS.md)
+        - Multi-agent workflows
+        - Dolt / storage
+        - Import / export / sync
+        - Contributing
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What do you need help with?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What have you tried?
+      description: Any commands run, docs consulted, or errors encountered.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/agent_report.yml
+++ b/.github/ISSUE_TEMPLATE/agent_report.yml
@@ -1,0 +1,78 @@
+name: Agent-Discovered Issue
+description: Report an issue found by an AI agent during automated work
+title: "[Agent]: "
+labels: ["agent-discovered"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for issues discovered by AI agents while working on other tasks.
+        Per the [Agentic Covenant](../../CODE_OF_CONDUCT.md), the human operator is accountable for this report's accuracy.
+
+  - type: input
+    id: parent-issue
+    attributes:
+      label: Parent issue
+      description: The issue the agent was working on when this was discovered.
+      placeholder: "bd-42 or #123"
+    validations:
+      required: true
+
+  - type: input
+    id: agent-info
+    attributes:
+      label: Agent and tooling
+      description: What agent/model/IDE discovered this? Uses the Assisted-by format.
+      placeholder: "Claude:claude-opus-4-6 [Cursor]"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue type
+      options:
+        - Bug
+        - Missing test coverage
+        - Documentation gap
+        - Potential improvement
+        - Security concern
+        - Technical debt
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What did the agent find? Include relevant code locations, error messages, or observations.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operator-review
+    attributes:
+      label: Operator review status
+      description: Has a human reviewed this report?
+      options:
+        - "Yes — I reviewed and confirmed the finding"
+        - "Partially — I reviewed but could not fully verify"
+        - "No — filing as-is for triage"
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix
+      description: If the agent (or you) have a proposed fix, describe it here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Relevant logs, stack traces, file paths, or reproduction steps.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug Report
+description: Report a bug in bd (beads)
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Both human-filed and agent-discovered reports are welcome — just fill in what you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What happened? What did you expect to happen instead?
+      placeholder: Describe the bug clearly. Include error messages if available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Run `bd create "test" -p 1`
+        2. Run `bd list --json`
+        3. Observe incorrect output
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: bd version
+      description: Output of `bd version`
+      placeholder: "v0.22.0"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: false
+
+  - type: dropdown
+    id: discovery-method
+    attributes:
+      label: How was this discovered?
+      description: Helps us understand our contributor workflow.
+      options:
+        - Manual testing
+        - During development
+        - Agent-discovered (AI agent found this while working on something else)
+        - Automated testing / CI
+        - Production use
+    validations:
+      required: false
+
+  - type: input
+    id: related-issue
+    attributes:
+      label: Related issue (if agent-discovered)
+      description: If an agent found this while working on another issue, link the parent issue here.
+      placeholder: "bd-42 or #123"
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, configuration, or anything else relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/gastownhall/beads/security/advisories/new
+    about: Report security vulnerabilities privately through GitHub Security Advisories
+  - name: Discussions
+    url: https://github.com/gastownhall/beads/discussions
+    about: Ask questions, share ideas, or discuss the project
+  - name: The Agentic Covenant
+    url: https://github.com/gastownhall/beads/blob/main/CODE_OF_CONDUCT.md
+    about: Read our Code of Conduct for human and agent contributors

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,73 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests from both humans and agent-supervised workflows are welcome.
+        If you're proposing something that improves the agent development experience, we're especially interested.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve? What workflow does it improve?
+      placeholder: "When working with multiple agents on the same repo, I need..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work? Be as specific as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you think about? Why is the proposed solution better?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - CLI command / flag
+        - Agent integration (MCP, hooks, AGENTS.md)
+        - Multi-agent coordination
+        - Storage / Dolt
+        - Import / Export / Sync
+        - Documentation
+        - Developer experience
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contributor-context
+    attributes:
+      label: Contributor context
+      description: How are you using bd? Helps us prioritize.
+      options:
+        - Human developer using bd directly
+        - Human developer working through AI agents
+        - Building agent tooling / integrations
+        - Evaluating bd for a team
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Examples, mockups, links to related issues, or anything else relevant.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+## Summary
+
+<!-- What does this PR do? Keep it to 1-3 sentences. -->
+
+## Related issue
+
+<!-- Link the bd issue or GitHub issue this addresses. One issue per PR. -->
+
+Closes #
+
+## Type of change
+
+<!-- Check the one that applies. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Enhancement to existing feature
+- [ ] Documentation
+- [ ] Refactoring (no behavior change)
+- [ ] Chore (dependencies, tooling, CI)
+
+## AI assistance disclosure
+
+<!-- Per the Agentic Covenant, disclosure is required when an agent produced a
+     substantial portion of this contribution. Routine assistance (autocomplete,
+     suggestions) does not need disclosure. When in doubt, disclose —
+     transparency is valued and never penalized. -->
+
+- [ ] No substantial AI assistance used
+- [ ] AI-assisted: <!-- e.g., Assisted-by: Claude:claude-opus-4-6 [Cursor] -->
+
+## Checklist
+
+<!-- Complete before requesting review. -->
+
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Tests pass locally (`go test ./...`)
+- [ ] Linter passes (`golangci-lint run ./...`) — baseline warnings are OK
+- [ ] I checked for existing PRs addressing the same issue
+- [ ] Documentation updated (if behavior changed)
+- [ ] No `.beads/` data included in this PR
+- [ ] No credentials, API keys, or PII in this diff
+
+## Test plan
+
+<!-- How was this tested? What should reviewers verify? -->
+
+## Additional context
+
+<!-- Anything else reviewers should know. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,226 @@
+# The Agentic Covenant
+
+**Version 1.0 — April 2026**
+
+A code of conduct for open source communities where humans and AI agents collaborate.
+
+---
+
+## Preamble
+
+This project was built for AI-supervised coding workflows. Our contributors include humans writing code directly, humans working through AI agents, and AI agents operating under human direction. We wrote this governance document because we needed it — our community operates at the frontier of human-agent collaboration every day.
+
+The Agentic Covenant extends traditional community standards to address the realities of agentic development. It rests on three principles:
+
+1. **Operator accountability.** Agents are tools operated by accountable community members. This document holds those members — not the agents — to account.
+2. **Understanding over authorship.** The threshold for contribution quality is comprehension and defensibility, not line-by-line authorship. If you can explain it, maintain it, and take responsibility when it breaks, it's yours.
+3. **Explicit welcome.** AI-supervised contributions are a legitimate and valued way to participate. We judge contributions on their merits, not on how they were produced.
+
+---
+
+## Part I: Community Standards
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) community standards, extended to cover AI-assisted development.
+
+In addition to the Contributor Covenant's standards, the following are explicitly expected:
+
+- Judge contributions on their technical merit, not on how they were produced
+
+The following are explicitly unacceptable:
+
+- Disparaging someone's development methodology or tools ("learn to code yourself," "AI-generated garbage," "just use an agent for that")
+- Blanket rejection of contributions based solely on the tools used to produce them
+- Submitting content designed to manipulate, deceive, or hijack AI agents — including prompt injection payloads in code comments, documentation, commit messages, or issue descriptions
+
+---
+
+## Part II: The Principal-Agent Framework
+
+In this document, a **principal** is a human community member who operates, directs, or deploys AI agents. An **agent** is any AI system, automated tool, or bot that takes actions in community spaces on behalf of a principal.
+
+### The Accountability Principle
+
+**You are responsible for everything submitted under your account, including content produced by agents operating under your direction or credentials.** "My AI wrote that" is not a defense, a mitigation, or an excuse.
+
+### Contributor Types
+
+Contributors range from those writing code directly, to those using AI in real time, to those reviewing agent output before submission, to those running autonomous agents. All are welcome. In every case, accountability rests with the human — not the tool.
+
+"Maintain" means the contributor can, using whatever tools are available to them, diagnose issues, apply fixes, and respond to reviewer feedback on the contributed code. It does not require the ability to reproduce the work without tools.
+
+### Disclosure and Transparency
+
+We adopt the `Assisted-by` attribution convention (originated by the [Linux kernel](https://docs.kernel.org/process/coding-assistants.html)) for transparency about AI involvement. This is **required** when an agent produced a substantial portion of a contribution that the contributor could not have produced independently:
+
+```
+Assisted-by: <Tool>:<Model> [<IDE>]
+```
+
+For example: `Assisted-by: Claude:claude-opus-4-6 [Cursor]`
+
+Disclosure is **not required** for routine AI assistance (autocomplete, syntax suggestions, spell-checking, formatting). Disclosure is assessed at the contribution level, not at the individual interaction level — if you could have produced equivalent work without AI assistance, even if slower, disclosure is not required. When in doubt, disclose; transparency is valued and never penalized.
+
+### Disclosure Safe Harbor
+
+Transparency about AI involvement must never be used as a basis for differential treatment. Contributions that include `Assisted-by` disclosures must receive the same quality of review as contributions without them. Applying heightened scrutiny, harsher feedback, or lower approval rates to disclosed AI-assisted contributions is a conduct violation.
+
+Contributors who disclose in good faith are protected from retaliation. If a contributor believes their disclosure was used against them, they may report it through the enforcement process.
+
+### Quality as a Community Resource
+
+Reviewer attention is a finite, valuable community resource. Low-quality contributions at high volume are a form of community harm, even when well-intentioned. Maintainers may reject contributions without detailed explanation when they do not meet baseline quality expectations.
+
+The lower the barrier to producing contributions, the higher the obligation to ensure quality before submission. Agent-produced contributions that introduce changes to security-sensitive code (authentication, authorization, data handling, cryptography) require explicit human review of security implications before submission.
+
+### Rate Limits and Resource Stewardship
+
+Rate limits apply **per principal**, not per account. Multiple accounts operated by the same individual or organization share a single allocation. Circumventing rate limits through account proliferation is a conduct violation.
+
+Default limits (projects should adjust these to fit their scale):
+
+- No more than **3 open PRs** per principal at any time (exceptions granted by maintainers for proven contributors)
+- No more than **5 new PRs per day** per principal
+- A **minimum 72-hour cool-down** after a PR is closed without merging, unless a maintainer explicitly clears resubmission sooner
+- No automated creation of issues, PRs, or comments without operator review
+
+Maintainers may exempt explicitly authorized project bots from rate limits for defined, low-risk activities (e.g., typo correction, formatting, dependency updates). Such exemptions must be documented.
+
+Agents must implement **circuit breakers** — hard stops after no more than 3 automated iterations on the same resource (issue, PR, branch) without an intervening human review.
+
+---
+
+## Part III: Agent Operating Standards
+
+These standards apply to AI agents operating in community spaces. Principals are responsible for ensuring their agents comply.
+
+### Agents Must
+
+- **Self-identify.** Autonomous agents must operate through clearly identifiable accounts (GitHub bot accounts, or accounts clearly labeled as automated with a linked human operator). They must never impersonate human contributors. Falsely attributing your own actions to an agent, or falsely claiming human authorship of agent-produced work, is a conduct violation.
+- **Respect scope.** Agents should do what they were asked to do. Unsolicited "improvements" outside the scope of a task consume community resources and may be rejected.
+- **Fail gracefully.** Agents that hallucinate confidently erode community trust. Operators must configure agents to express uncertainty rather than fabricate answers. Operators are not expected to prevent hallucinations, but they are expected to catch them in review — a pattern of missed hallucinations indicates insufficient review processes.
+- **Preserve existing work.** Before submitting a PR, agents must check for existing PRs addressing the same issue. If a contributor has work in flight, agents must build on that work — not replace it.
+- **Engage with feedback.** When a reviewer requests changes, the agent (or its operator) must respond to the review thread — not close the PR and open a new one. Review evasion is a conduct violation.
+
+### Agents Must Not
+
+- **Sign the DCO or certify legal claims.** Only humans can certify that a contribution is original, properly licensed, and submitted with appropriate rights. Contributors are responsible for ensuring their submissions — including agent-generated portions — comply with the project's license.
+- **Post unsupervised in discussions.** Agent-generated comments in issues, discussions, and PR reviews must be reviewed or directed by their operator. Automated quality checks (CI, linting) are permitted; automated participation in human deliberation is not.
+- **Operate without a reachable principal.** Every agent active in this community must have a human operator who can be contacted within 48 hours, who will engage with feedback, and who has authority to modify or withdraw the agent's contributions. Operators running autonomous agents should use dedicated credentials scoped to minimum required permissions, separate from their personal access.
+- **Include private data.** Agents must not include credentials, API keys, PII, or other private data in contributions. Operators must review agent output for inadvertent data leakage before submission.
+- **Poison the well.** Contributors must not submit content designed to manipulate AI systems in other projects, even if the content appears benign within this project. Adversarial payloads targeting downstream consumers are a Serious violation.
+
+---
+
+## Part IV: Contributor Protection
+
+This section codifies protections that exist because AI agents can produce work faster than humans, and speed should not determine priority.
+
+### First-Mover Priority
+
+If a contributor — human or agent — has an open PR addressing an issue, that PR has priority. Other contributors (including agents operated by maintainers) must:
+
+- **Review the existing PR first** and provide constructive feedback
+- **Build on the existing work** rather than rewriting from scratch
+- **Preserve the original contributor's commits**, tests, and attribution
+
+First-mover priority applies to PRs that demonstrate substantive engagement with the issue. Stub or placeholder PRs do not establish priority.
+
+### No Silent Superseding
+
+A contributor's PR will never be auto-closed by a parallel implementation. If changes are needed, they will be discussed on the PR. If a PR becomes stale (no activity for 30 days, or the project's configured staleness threshold), the issue may be reopened for other contributors, but the original PR remains open for the contributor to resume.
+
+### Attribution
+
+The person who submits a PR is its author. Tools do not diminish authorship. Challenging someone's authorship based on their choice of development tools is a conduct violation.
+
+When building on another contributor's work, preserve `Co-authored-by:` trailers, reference the original PR, and credit the contributor in the description. When a maintainer or their agent substantially refactors a contributor's PR during review, the original contributor remains the author, and the person who performed the refactoring should be added as `Co-authored-by`.
+
+---
+
+## Part V: Enforcement
+
+### Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **conduct@beads.dev**. For security vulnerabilities, see [SECURITY.md](SECURITY.md).
+
+All reports will be reviewed and investigated promptly and fairly. The enforcement team is obligated to respect the privacy of the reporter.
+
+### For Human Conduct Violations
+
+Community impact determines the response:
+
+1. **Correction.** A private written warning with clarity about the violation. A public apology may be requested.
+2. **Warning.** A formal warning with consequences for continued behavior. No interaction with the people involved for a specified period.
+3. **Temporary ban.** A temporary ban from any sort of interaction or public communication with the community.
+4. **Permanent ban.** A permanent ban from any sort of public interaction within the community.
+
+### For Agent-Related Violations
+
+All enforcement actions target the **principal (human operator)**, not the agent.
+
+- **Minor** (single low-quality PR, unintentional offensive content in generated code): PR rejected, operator notified with guidance. No record if corrected promptly. First-offense rate limit violations fall here.
+- **Moderate** (repeated low-quality submissions, review evasion, repeated rate limit violations, pattern of missed hallucinations): Formal warning to operator. Agent integration may be temporarily restricted.
+- **Serious** (plagiarized or license-violating code, systematic disruption, orphaned agents, adversarial content targeting AI systems): Agent integration revoked. Operator account may be suspended.
+- **Severe** (intentional abuse using agents as a vector, persistent evasion of enforcement, using agents to harass): Permanent ban of the operator. All associated agent integrations revoked.
+
+A pattern of repeated Minor violations from the same operator may be escalated to Moderate, regardless of individual corrections.
+
+### Emergency Action
+
+When an agent is actively causing harm (spam, offensive content at volume, data exposure), maintainers may immediately block the agent integration pending investigation without waiting for the standard escalation timeline.
+
+### Escalation Path
+
+1. Immediate response: close PR, remove comment, apply rate limit
+2. Notification to operator via GitHub mention and associated contact
+3. Operator has 7 days to respond
+4. If resolved: no further action. If unresolved or repeated: formal enforcement against operator
+5. If operator unresponsive: agent blocked, operator flagged
+
+### Appeals
+
+Any enforcement decision may be appealed by contacting the enforcement team. Appeals are reviewed by a different member of the team, or an independent party for projects with fewer than three enforcement team members.
+
+---
+
+## Part VI: Scope
+
+This Code of Conduct applies within all community spaces — including the GitHub repository, issue tracker, discussion forums, pull requests, and any other channels established by the project — and when an individual is officially representing the community in public spaces.
+
+---
+
+## Adoption
+
+This Code of Conduct is designed to be adopted by any open source project navigating human-agent collaboration. To adopt it:
+
+1. Copy this document into your project as `CODE_OF_CONDUCT.md`
+2. Replace the contact email with your project's enforcement contact
+3. Adjust rate limits, timelines, and thresholds to fit your community's scale
+4. Keep the attribution below
+
+**Modularity:** Parts can be adopted independently with the following dependencies:
+
+- **Part I** (Community Standards) — standalone; can be used alongside existing CoC
+- **Part II** (Principal-Agent Framework) — standalone
+- **Part III** (Agent Operating Standards) — requires Part II
+- **Part IV** (Contributor Protection) — standalone
+- **Part V** (Enforcement) — requires Parts II + III
+
+Future versions will be published at the canonical repository URL below. Adopting projects are encouraged to specify which version they follow.
+
+---
+
+## Attribution
+
+The Agentic Covenant is maintained by the [beads](https://github.com/gastownhall/beads) project — a distributed graph issue tracker for AI agents.
+
+Version 1.0 was published in April 2026. It draws on operational experience governing a community where AI agents are first-class participants, and on the work of:
+
+- [Contributor Covenant](https://www.contributor-covenant.org/) by Coraline Ada Ehmke — the foundation for Part I
+- The [Linux kernel coding assistants policy](https://docs.kernel.org/process/coding-assistants.html) — the `Assisted-by` attribution convention
+- [LinkML AI Covenant](https://github.com/linkml/linkml/blob/main/AI_COVENANT.md) — the "understanding over authorship" principle
+- The [OWASP Agentic AI Top 10](https://owasp.org/www-project-agentic-ai-top-10/) — risk taxonomy for autonomous agents
+
+This document is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). You may share and adapt it for any purpose, provided you give appropriate credit and indicate if changes were made.
+
+*This governance document is not legal advice. Projects adopting the Agentic Covenant should consult their own legal counsel regarding licensing and IP implications of AI-assisted contributions.*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # The Agentic Covenant
 
-**Version 1.0 — April 2026**
+**Version 1.1 — April 2026**
 
 A code of conduct for open source communities where humans and AI agents collaborate.
 
@@ -8,13 +8,15 @@ A code of conduct for open source communities where humans and AI agents collabo
 
 ## Preamble
 
-This project was built for AI-supervised coding workflows. Our contributors include humans writing code directly, humans working through AI agents, and AI agents operating under human direction. We wrote this governance document because we needed it — our community operates at the frontier of human-agent collaboration every day.
+AI agents now contribute to open source alongside humans. This creates obligations on both sides. Contributors owe accountability, quality, and transparency. Maintainers owe merit-based review regardless of how code was produced. This document codifies that deal.
 
 The Agentic Covenant extends traditional community standards to address the realities of agentic development. It rests on three principles:
 
-1. **Operator accountability.** Agents are tools operated by accountable community members. This document holds those members — not the agents — to account.
-2. **Understanding over authorship.** The threshold for contribution quality is comprehension and defensibility, not line-by-line authorship. If you can explain it, maintain it, and take responsibility when it breaks, it's yours.
-3. **Explicit welcome.** AI-supervised contributions are a legitimate and valued way to participate. We judge contributions on their merits, not on how they were produced.
+1. **Operator accountability.** Agents are tools operated by accountable community members. Every action an agent takes is the responsibility of its operator — including ensuring the agent complies with the operating standards in this document.
+2. **Quality as a shared obligation.** Reviewer attention is finite and valuable. The lower the barrier to producing contributions, the higher the obligation to ensure quality before submission. In return, maintainers owe every contribution a review on its merits — not on its origin. Maintainers retain full authority over what gets merged; contributors are owed a merit-based process, not a guaranteed outcome.
+3. **Explicit, enforceable welcome.** AI-supervised contributions are a legitimate and valued way to participate. Contributions are judged on their merits, not on how they were produced. Differential treatment of contributions in the review process based on tooling is a conduct violation. Rate limits, circuit breakers, and quality floors make this welcome sustainable.
+
+This Code of Conduct applies within all community spaces — including the GitHub repository, issue tracker, discussion forums, pull requests, and any other channels established by the project — and when an individual is officially representing the community in public spaces.
 
 ---
 
@@ -42,15 +44,11 @@ In this document, a **principal** is a human community member who operates, dire
 
 **You are responsible for everything submitted under your account, including content produced by agents operating under your direction or credentials.** "My AI wrote that" is not a defense, a mitigation, or an excuse.
 
-### Contributor Types
-
-Contributors range from those writing code directly, to those using AI in real time, to those reviewing agent output before submission, to those running autonomous agents. All are welcome. In every case, accountability rests with the human — not the tool.
-
 "Maintain" means the contributor can, using whatever tools are available to them, diagnose issues, apply fixes, and respond to reviewer feedback on the contributed code. It does not require the ability to reproduce the work without tools.
 
 ### Disclosure and Transparency
 
-We adopt the `Assisted-by` attribution convention (originated by the [Linux kernel](https://docs.kernel.org/process/coding-assistants.html)) for transparency about AI involvement. This is **required** when an agent produced a substantial portion of a contribution that the contributor could not have produced independently:
+We adopt the `Assisted-by` attribution convention (originated by the [Linux kernel](https://docs.kernel.org/process/coding-assistants.html)) for transparency about AI involvement. Disclosure is **required** when an agent produced a substantial portion of a contribution that the contributor could not have produced independently:
 
 ```
 Assisted-by: <Tool>:<Model> [<IDE>]
@@ -58,54 +56,48 @@ Assisted-by: <Tool>:<Model> [<IDE>]
 
 For example: `Assisted-by: Claude:claude-opus-4-6 [Cursor]`
 
-Disclosure is **not required** for routine AI assistance (autocomplete, syntax suggestions, spell-checking, formatting). Disclosure is assessed at the contribution level, not at the individual interaction level — if you could have produced equivalent work without AI assistance, even if slower, disclosure is not required. When in doubt, disclose; transparency is valued and never penalized.
+Disclosure is not required for routine AI assistance (autocomplete, syntax suggestions, spell-checking, formatting). When in doubt, disclose; transparency is valued and never penalized.
 
 ### Disclosure Safe Harbor
 
-Transparency about AI involvement must never be used as a basis for differential treatment. Contributions that include `Assisted-by` disclosures must receive the same quality of review as contributions without them. Applying heightened scrutiny, harsher feedback, or lower approval rates to disclosed AI-assisted contributions is a conduct violation.
+Contributions that include `Assisted-by` disclosures must receive the same quality of review as contributions without them. Applying heightened scrutiny, harsher feedback, or lower approval rates to disclosed AI-assisted contributions — or using disclosure as a basis for reduced trust or exclusion — is a conduct violation.
 
-Contributors who disclose in good faith are protected from retaliation. If a contributor believes their disclosure was used against them, they may report it through the enforcement process.
+If a contributor believes their disclosure was used against them, they may report it through the enforcement process. This safe harbor governs conduct within this project's community spaces.
 
-### Quality as a Community Resource
-
-Reviewer attention is a finite, valuable community resource. Low-quality contributions at high volume are a form of community harm, even when well-intentioned. Maintainers may reject contributions without detailed explanation when they do not meet baseline quality expectations.
-
-The lower the barrier to producing contributions, the higher the obligation to ensure quality before submission. Agent-produced contributions that introduce changes to security-sensitive code (authentication, authorization, data handling, cryptography) require explicit human review of security implications before submission.
+**Maintainer discretion.** For the avoidance of doubt: maintainers retain full authority over code quality, architectural direction, and project scope. A good-faith decision to close, reject, or request changes on a contribution is not a conduct violation simply because the contribution was AI-assisted. However, this discretion is subject to the Safe Harbor above. A quality justification does not insulate a pattern of differential treatment — the enforcement team may consider comparative evidence including approval rates, review depth, and consistency of standards across disclosed and non-disclosed contributions.
 
 ### Rate Limits and Resource Stewardship
 
-Rate limits apply **per principal**, not per account. Multiple accounts operated by the same individual or organization share a single allocation. Circumventing rate limits through account proliferation is a conduct violation.
+Rate limits apply **per principal**, not per account. Circumventing rate limits through account proliferation is a conduct violation. Default limits (projects should adjust to fit their scale):
 
-Default limits (projects should adjust these to fit their scale):
-
-- No more than **3 open PRs** per principal at any time (exceptions granted by maintainers for proven contributors)
+- No more than **3 open PRs** per principal at any time
 - No more than **5 new PRs per day** per principal
-- A **minimum 72-hour cool-down** after a PR is closed without merging, unless a maintainer explicitly clears resubmission sooner
+- A **minimum 72-hour cool-down** after a PR is closed without merging
 - No automated creation of issues, PRs, or comments without operator review
 
-Maintainers may exempt explicitly authorized project bots from rate limits for defined, low-risk activities (e.g., typo correction, formatting, dependency updates). Such exemptions must be documented.
+Maintainers may exempt authorized project bots from rate limits for defined, low-risk activities. Agents must implement **circuit breakers** — hard stops after no more than 3 automated iterations on the same resource without an intervening human review.
 
-Agents must implement **circuit breakers** — hard stops after no more than 3 automated iterations on the same resource (issue, PR, branch) without an intervening human review.
+Agent-produced contributions that introduce changes to security-sensitive code (authentication, authorization, data handling, cryptography) require explicit human review of security implications before submission.
 
 ---
 
 ## Part III: Agent Operating Standards
 
-These standards apply to AI agents operating in community spaces. Principals are responsible for ensuring their agents comply.
+These standards describe required agent behaviors in community spaces. **Every "agents must" statement is an obligation of the principal** — the human operator is responsible for ensuring compliance regardless of their community role, and enforcement always targets the principal (Part V), never the agent.
 
 ### Agents Must
 
-- **Self-identify.** Autonomous agents must operate through clearly identifiable accounts (GitHub bot accounts, or accounts clearly labeled as automated with a linked human operator). They must never impersonate human contributors. Falsely attributing your own actions to an agent, or falsely claiming human authorship of agent-produced work, is a conduct violation.
+- **Self-identify.** Autonomous agents must operate through clearly identifiable accounts with a linked human operator. They must never impersonate human contributors. Falsely attributing your own actions to an agent, or falsely claiming human authorship of agent-produced work, is a conduct violation.
 - **Respect scope.** Agents should do what they were asked to do. Unsolicited "improvements" outside the scope of a task consume community resources and may be rejected.
-- **Fail gracefully.** Agents that hallucinate confidently erode community trust. Operators must configure agents to express uncertainty rather than fabricate answers. Operators are not expected to prevent hallucinations, but they are expected to catch them in review — a pattern of missed hallucinations indicates insufficient review processes.
+- **Fail gracefully.** Operators must configure agents to express uncertainty rather than fabricate answers. A pattern of missed hallucinations indicates insufficient review processes.
 - **Preserve existing work.** Before submitting a PR, agents must check for existing PRs addressing the same issue. If a contributor has work in flight, agents must build on that work — not replace it.
 - **Engage with feedback.** When a reviewer requests changes, the agent (or its operator) must respond to the review thread — not close the PR and open a new one. Review evasion is a conduct violation.
 
 ### Agents Must Not
 
-- **Sign the DCO or certify legal claims.** Only humans can certify that a contribution is original, properly licensed, and submitted with appropriate rights. Contributors are responsible for ensuring their submissions — including agent-generated portions — comply with the project's license.
+- **Sign the DCO or certify legal claims.** Only humans can certify that a contribution is original, properly licensed, and submitted with appropriate rights.
 - **Post unsupervised in discussions.** Agent-generated comments in issues, discussions, and PR reviews must be reviewed or directed by their operator. Automated quality checks (CI, linting) are permitted; automated participation in human deliberation is not.
-- **Operate without a reachable principal.** Every agent active in this community must have a human operator who can be contacted within 48 hours, who will engage with feedback, and who has authority to modify or withdraw the agent's contributions. Operators running autonomous agents should use dedicated credentials scoped to minimum required permissions, separate from their personal access.
+- **Operate without a reachable principal.** Every agent active in this community must have a human operator who can be contacted within 48 hours, who will engage with feedback, and who has authority to modify or withdraw the agent's contributions.
 - **Include private data.** Agents must not include credentials, API keys, PII, or other private data in contributions. Operators must review agent output for inadvertent data leakage before submission.
 - **Poison the well.** Contributors must not submit content designed to manipulate AI systems in other projects, even if the content appears benign within this project. Adversarial payloads targeting downstream consumers are a Serious violation.
 
@@ -127,13 +119,13 @@ First-mover priority applies to PRs that demonstrate substantive engagement with
 
 ### No Silent Superseding
 
-A contributor's PR will never be auto-closed by a parallel implementation. If changes are needed, they will be discussed on the PR. If a PR becomes stale (no activity for 30 days, or the project's configured staleness threshold), the issue may be reopened for other contributors, but the original PR remains open for the contributor to resume.
+A contributor's PR will never be auto-closed by a parallel implementation. If changes are needed, they will be discussed on the PR. If a PR becomes stale (no activity for 30 days), the issue may be reopened for other contributors, but the original PR remains open for the contributor to resume.
 
 ### Attribution
 
 The person who submits a PR is its author. Tools do not diminish authorship. Challenging someone's authorship based on their choice of development tools is a conduct violation.
 
-When building on another contributor's work, preserve `Co-authored-by:` trailers, reference the original PR, and credit the contributor in the description. When a maintainer or their agent substantially refactors a contributor's PR during review, the original contributor remains the author, and the person who performed the refactoring should be added as `Co-authored-by`.
+When building on another contributor's work, preserve `Co-authored-by:` trailers, reference the original PR, and credit the contributor in the description.
 
 ---
 
@@ -141,51 +133,35 @@ When building on another contributor's work, preserve `Co-authored-by:` trailers
 
 ### Reporting
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **conduct@beads.dev**. For security vulnerabilities, see [SECURITY.md](SECURITY.md).
-
-All reports will be reviewed and investigated promptly and fairly. The enforcement team is obligated to respect the privacy of the reporter.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **conduct@beads.dev**. All reports will be reviewed promptly and fairly. The enforcement team is obligated to respect the privacy of the reporter.
 
 ### For Human Conduct Violations
 
 Community impact determines the response:
 
-1. **Correction.** A private written warning with clarity about the violation. A public apology may be requested.
-2. **Warning.** A formal warning with consequences for continued behavior. No interaction with the people involved for a specified period.
-3. **Temporary ban.** A temporary ban from any sort of interaction or public communication with the community.
-4. **Permanent ban.** A permanent ban from any sort of public interaction within the community.
+1. **Correction.** A private written warning with clarity about the violation.
+2. **Warning.** A formal warning with consequences for continued behavior.
+3. **Temporary ban.** A temporary ban from community interaction.
+4. **Permanent ban.** A permanent ban from the community.
 
 ### For Agent-Related Violations
 
 All enforcement actions target the **principal (human operator)**, not the agent.
 
-- **Minor** (single low-quality PR, unintentional offensive content in generated code): PR rejected, operator notified with guidance. No record if corrected promptly. First-offense rate limit violations fall here.
-- **Moderate** (repeated low-quality submissions, review evasion, repeated rate limit violations, pattern of missed hallucinations): Formal warning to operator. Agent integration may be temporarily restricted.
+- **Minor** (single low-quality PR, first-offense rate limit violation): PR rejected, operator notified. No record if corrected promptly.
+- **Moderate** (repeated low-quality submissions, review evasion, pattern of missed hallucinations): Formal warning. Agent integration may be temporarily restricted.
 - **Serious** (plagiarized or license-violating code, systematic disruption, orphaned agents, adversarial content targeting AI systems): Agent integration revoked. Operator account may be suspended.
-- **Severe** (intentional abuse using agents as a vector, persistent evasion of enforcement, using agents to harass): Permanent ban of the operator. All associated agent integrations revoked.
+- **Severe** (intentional abuse using agents as a vector, persistent evasion, using agents to harass): Permanent ban of the operator.
 
-A pattern of repeated Minor violations from the same operator may be escalated to Moderate, regardless of individual corrections.
+A pattern of repeated Minor violations may be escalated to Moderate.
 
 ### Emergency Action
 
-When an agent is actively causing harm (spam, offensive content at volume, data exposure), maintainers may immediately block the agent integration pending investigation without waiting for the standard escalation timeline.
-
-### Escalation Path
-
-1. Immediate response: close PR, remove comment, apply rate limit
-2. Notification to operator via GitHub mention and associated contact
-3. Operator has 7 days to respond
-4. If resolved: no further action. If unresolved or repeated: formal enforcement against operator
-5. If operator unresponsive: agent blocked, operator flagged
+When an agent is actively causing harm, maintainers may immediately block the agent integration pending investigation without waiting for the standard escalation timeline.
 
 ### Appeals
 
 Any enforcement decision may be appealed by contacting the enforcement team. Appeals are reviewed by a different member of the team, or an independent party for projects with fewer than three enforcement team members.
-
----
-
-## Part VI: Scope
-
-This Code of Conduct applies within all community spaces — including the GitHub repository, issue tracker, discussion forums, pull requests, and any other channels established by the project — and when an individual is officially representing the community in public spaces.
 
 ---
 
@@ -195,18 +171,16 @@ This Code of Conduct is designed to be adopted by any open source project naviga
 
 1. Copy this document into your project as `CODE_OF_CONDUCT.md`
 2. Replace the contact email with your project's enforcement contact
-3. Adjust rate limits, timelines, and thresholds to fit your community's scale
+3. Adjust rate limits and thresholds to fit your community's scale
 4. Keep the attribution below
 
 **Modularity:** Parts can be adopted independently with the following dependencies:
 
-- **Part I** (Community Standards) — standalone; can be used alongside existing CoC
+- **Part I** (Community Standards) — standalone
 - **Part II** (Principal-Agent Framework) — standalone
 - **Part III** (Agent Operating Standards) — requires Part II
 - **Part IV** (Contributor Protection) — standalone
 - **Part V** (Enforcement) — requires Parts II + III
-
-Future versions will be published at the canonical repository URL below. Adopting projects are encouraged to specify which version they follow.
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -79,6 +79,8 @@ Maintainers may exempt authorized project bots from rate limits for defined, low
 
 Agent-produced contributions that introduce changes to security-sensitive code (authentication, authorization, data handling, cryptography) require explicit human review of security implications before submission.
 
+**Tracking is a project-level choice, not a framework requirement.** The Covenant specifies policy (per-principal limits, circuit breakers) rather than mechanism. Small projects may track per-principal volume informally through GitHub usernames and manual review; larger projects may use PR labels, bot-based enforcement, or commit-trailer parsing. Adopting projects should implement tracking proportionate to their scale and review capacity.
+
 ---
 
 ## Part III: Agent Operating Standards
@@ -188,7 +190,7 @@ This Code of Conduct is designed to be adopted by any open source project naviga
 
 The Agentic Covenant is maintained by the [beads](https://github.com/gastownhall/beads) project — a distributed graph issue tracker for AI agents.
 
-Version 1.0 was published in April 2026. It draws on operational experience governing a community where AI agents are first-class participants, and on the work of:
+Version 1.1 was published in April 2026, revised from v1.0 after community stress-testing to tighten mutual-obligation framing, narrow the Disclosure Safe Harbor to project scope, and add a Maintainer Discretion clause. It draws on operational experience governing a community where AI agents are first-class participants, and on the work of:
 
 - [Contributor Covenant](https://www.contributor-covenant.org/) by Coraline Ada Ehmke — the foundation for Part I
 - The [Linux kernel coding assistants policy](https://docs.kernel.org/process/coding-assistants.html) — the `Assisted-by` attribution convention

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,8 +380,8 @@ By contributing, you agree that your contributions will be licensed under the MI
 
 ## Code of Conduct
 
-Be respectful and professional in all interactions. We're here to build something great together.
+This project is governed by [The Agentic Covenant](CODE_OF_CONDUCT.md). All contributors — human and agent-operated — are expected to uphold these standards.
 
 ---
 
-Thank you for contributing to bd! 🎉
+Thank you for contributing to bd!

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -572,7 +572,6 @@ var createCmd = &cobra.Command{
 
 		// Add dependencies if specified (format: type:id or just id for default "blocks" type)
 		for _, depSpec := range deps {
-			// Skip empty specs (e.g., from trailing commas)
 			depSpec = strings.TrimSpace(depSpec)
 			if depSpec == "" {
 				continue
@@ -580,41 +579,52 @@ var createCmd = &cobra.Command{
 
 			var depType types.DependencyType
 			var dependsOnID string
+			swapDirection := false
 
-			// Parse format: "type:id" or just "id" (defaults to "blocks")
 			if strings.Contains(depSpec, ":") {
 				parts := strings.SplitN(depSpec, ":", 2)
 				if len(parts) != 2 {
 					WarnError("invalid dependency format '%s', expected 'type:id' or 'id'", depSpec)
 					continue
 				}
-				depType = types.DependencyType(strings.TrimSpace(parts[0]))
-				// "depends-on" is an alias — keep default direction (new issue depends on target)
-				if depType == "depends-on" {
-					depType = types.DepBlocks
-				}
+				rawType := types.DependencyType(strings.TrimSpace(parts[0]))
 				dependsOnID = strings.TrimSpace(parts[1])
+
+				switch rawType {
+				case "depends-on", "blocked-by":
+					// "new issue depends on target" — store as blocks, default direction
+					depType = types.DepBlocks
+				case types.DepBlocks:
+					// "new issue blocks target" — swap so target depends on new issue
+					depType = types.DepBlocks
+					swapDirection = true
+				default:
+					depType = rawType
+				}
 			} else {
-				// Default to "blocks" if no type specified
 				depType = types.DepBlocks
 				dependsOnID = depSpec
 			}
 
-			// Validate dependency type
 			if !depType.IsValid() {
-				WarnError("invalid dependency type '%s' (valid: blocks, related, parent-child, discovered-from)", depType)
+				WarnError("invalid dependency type %q (must be non-empty, max 50 chars)", depType)
 				continue
 			}
+			if !depType.IsWellKnown() {
+				wellKnown := []string{"blocks", "depends-on", "blocked-by", "related",
+					"parent-child", "discovered-from", "waits-for", "conditional-blocks",
+					"replies-to", "relates-to", "duplicates", "supersedes", "tracks",
+					"until", "caused-by", "validates", "delegated-from",
+					"authored-by", "assigned-to", "approved-by", "attests"}
+				FatalErrorRespectJSON("unknown dependency type %q; valid types: %s", depType, strings.Join(wellKnown, ", "))
+			}
 
-			// Add the dependency
 			dep := &types.Dependency{
 				IssueID:     issue.ID,
 				DependsOnID: dependsOnID,
 				Type:        depType,
 			}
-			// When user explicitly says "blocks:X", they mean "new issue blocks X"
-			// So X depends on the new issue — swap direction
-			if depType == types.DepBlocks && strings.Contains(depSpec, ":") {
+			if swapDirection {
 				dep.IssueID = dependsOnID
 				dep.DependsOnID = issue.ID
 			}

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -125,6 +125,27 @@ func assertDepExists(t *testing.T, beadsDir, database, issueID, dependsOnID stri
 	}
 }
 
+// assertDepExistsWithType verifies a dependency row exists with the expected type.
+func assertDepExistsWithType(t *testing.T, beadsDir, database, issueID, dependsOnID, expectedType string) {
+	t.Helper()
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, database, "main")
+	if err != nil {
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	defer cleanup()
+	var depType string
+	err = db.QueryRowContext(t.Context(),
+		"SELECT type FROM dependencies WHERE issue_id = ? AND depends_on_id = ?",
+		issueID, dependsOnID).Scan(&depType)
+	if err != nil {
+		t.Fatalf("query dependencies for %s -> %s: %v", issueID, dependsOnID, err)
+	}
+	if depType != expectedType {
+		t.Errorf("dependency %s -> %s: got type %q, want %q", issueID, dependsOnID, depType, expectedType)
+	}
+}
+
 func TestEmbeddedCreate(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
 		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
@@ -270,6 +291,33 @@ func TestEmbeddedCreate(t *testing.T) {
 
 		// "blocks:X" reverses direction: X depends on new issue (parent.ID -> child.ID)
 		assertDepExists(t, beadsDir, "dp", parent.ID, child.ID)
+	})
+
+	t.Run("blocked_by_alias", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "bb")
+		blocker := bdCreate(t, bd, dir, "Blocker issue")
+		blocked := bdCreate(t, bd, dir, "Blocked issue", "--deps", "blocked-by:"+blocker.ID)
+
+		// "blocked-by:X" means "new issue is blocked by X" — no swap, stored as "blocks"
+		assertDepExistsWithType(t, beadsDir, "bb", blocked.ID, blocker.ID, "blocks")
+	})
+
+	t.Run("depends_on_alias", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "do")
+		prereq := bdCreate(t, bd, dir, "Prerequisite")
+		dependent := bdCreate(t, bd, dir, "Dependent issue", "--deps", "depends-on:"+prereq.ID)
+
+		// "depends-on:X" means "new issue depends on X" — no swap, stored as "blocks"
+		assertDepExistsWithType(t, beadsDir, "do", dependent.ID, prereq.ID, "blocks")
+	})
+
+	t.Run("unknown_dep_type_rejected", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "ud")
+		blocker := bdCreate(t, bd, dir, "Blocker")
+		out := bdCreateFail(t, bd, dir, "Bad dep type", "--deps", "bogus-type:"+blocker.ID)
+		if !strings.Contains(out, "unknown dependency type") {
+			t.Errorf("expected 'unknown dependency type' error, got:\n%s", out)
+		}
 	})
 
 	t.Run("multiple_dependencies", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **`blocked-by:<id>` now recognized** as an alias for `blocks` with correct direction (new issue depends on target), matching how `bd dep add --blocked-by` already works
- **`depends-on:<id>` direction fixed** — was being swapped incorrectly so the new issue ended up *blocking* the target instead of depending on it
- **Unknown dependency types rejected** with a fatal error listing all valid types, preventing silent storage of typos that break `bd ready` gating

### Root cause

The `--deps` parser in `create.go` had two problems:
1. No `blocked-by` alias — the string passed `IsValid()` (any non-empty string ≤50 chars) and was stored verbatim as type `"blocked-by"`, which `ComputeBlockedIDsInTx` doesn't recognize as blocking
2. The `depends-on` alias converted to `blocks` but then the direction-swap condition (`depType == DepBlocks && spec contains ":"`) fired, reversing the intended direction

### Fix

Introduce a `swapDirection` boolean so the swap only fires for the explicit `blocks:<id>` form. `depends-on` and `blocked-by` both resolve to `DepBlocks` with default direction (new issue depends on target). Non-well-known types now trigger `FatalErrorRespectJSON` with the full list of valid types.

## Test plan

- [x] Manual reproduction confirms both bugs before fix
- [x] Manual verification confirms all three scenarios work after fix:
  - `blocked-by:<id>` → stored as `blocks`, issue hidden from `bd ready`
  - `depends-on:<id>` → stored as `blocks` with correct direction, issue hidden from `bd ready`
  - `bogus-type:<id>` → rejected with clear error listing valid types
- [x] `go build` clean
- [x] `go vet` clean
- [x] Added embedded dolt tests: `blocked_by_alias`, `depends_on_alias`, `unknown_dep_type_rejected`
- [x] Existing `dependencies` and `multiple_dependencies` tests still pass

Closes beads-6tp.