### PR TITLE
feat: skip Claude Code agent worktrees during project-root walk

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -564,6 +564,20 @@ func hasBeadsProjectFiles(beadsDir string) bool {
 // checkout of the parent repo's working-tree snapshot. Without this strict
 // check, the separate-DB branch would match on inherited metadata.json and
 // return a broken directory, short-circuiting the shared-DB fallback.
+// isClaudeCodeAgentWorktree returns true if dir is inside a Claude Code
+// per-agent worktree (path matches .claude/worktrees/agent-<id>/...).
+// The Claude Code harness (https://docs.claude.com/en/docs/claude-code)
+// creates these via `git worktree add` for parallel-agent isolation;
+// the resulting worktrees ship a stub .beads/ (tracked metadata files
+// but no dolt/ database) that would otherwise shadow the parent repo's
+// real .beads/ during bd's upward walk. The check is a generous
+// substring match — false positives are bounded to projects that
+// genuinely place repos under .claude/worktrees/agent-*/, which is
+// strongly discouraged in any case.
+func isClaudeCodeAgentWorktree(dir string) bool {
+	return strings.Contains(filepath.ToSlash(dir), "/.claude/worktrees/agent-")
+}
+
 func hasBeadsDatabase(beadsDir string) bool {
 	if info, err := os.Stat(filepath.Join(beadsDir, "dolt")); err == nil && info.IsDir() {
 		return true
@@ -659,11 +673,21 @@ func FindBeadsDir() string {
 			break
 		}
 
-		beadsDir := filepath.Join(dir, ".beads")
-		if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
-			beadsDir = FollowRedirect(beadsDir)
-			if hasBeadsProjectFiles(beadsDir) {
-				return beadsDir
+		// Skip Claude Code agent worktrees during the walk. The harness
+		// creates per-agent worktrees at .claude/worktrees/agent-<id>/,
+		// each populated by `git worktree add` which checks out tracked
+		// .beads/{metadata.json,config.yaml,issues.jsonl} but NOT the
+		// gitignored dolt/ data directory. Stopping at such a stub leaves
+		// bd connected to an empty database ("table not found: issues").
+		// Step 3c's fallback to the shared .beads handles the resolution
+		// once we walk past the stub. (Tracked under flagship-2mi8.1.)
+		if !isClaudeCodeAgentWorktree(dir) {
+			beadsDir := filepath.Join(dir, ".beads")
+			if info, err := os.Stat(beadsDir); err == nil && info.IsDir() {
+				beadsDir = FollowRedirect(beadsDir)
+				if hasBeadsProjectFiles(beadsDir) {
+					return beadsDir
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

Claude Code's harness creates per-agent isolated worktrees at `.claude/worktrees/agent-<id>/` via `git worktree add` for parallel-agent execution. The new worktrees inherit a checkout of all tracked `.beads/` files (metadata.json, config.yaml, issues.jsonl) but NOT the gitignored `dolt/` data directory.

Result: bd's upward walk finds the stub `.beads/`, which passes `hasBeadsProjectFiles()` (the metadata is present), and stops there. Every subsequent bd query hits an empty Dolt server and returns `Error 1146 (HY000): table not found: issues`.

This makes bd unusable inside any Claude Code agent's worktree without a manual `cd` to the parent repo first.

## Fix

Skip directories matching `.claude/worktrees/agent-*` during step 2's upward walk in `FindBeadsDir()`. The existing step 3c shared-`.beads` fallback (`GetWorktreeFallbackBeadsDir()`) then resolves correctly to the parent repo's real `.beads/`.

The check is a substring match on `/.claude/worktrees/agent-` — generous on purpose. False positives are bounded to projects that genuinely place repos under that path, which is strongly discouraged in any case.

## Test plan

- Manual repro: from a Claude Code agent worktree at `.claude/worktrees/agent-<id>/`, before this fix `bd ready` returns "table not found: issues"; with the fix it returns the parent repo's open issues.
- Unit test: TBD — happy to add one if a maintainer points at the right test pattern in this repo (the existing TestFindBeadsDir at internal/beads/beads_test.go:82 is the obvious extension point).

## What's intentionally NOT changed

- Step 3a (per-worktree redirect override) still works as before.
- Step 3b (worktree's own `.beads` with database) still honored when the worktree has a real `dolt/` (legitimate separate-DB mode).
- Non-Claude-Code worktrees (`git worktree add` without the `.claude/...` path) are unaffected.

## Downstream context

Tracked in github.com/armadasystems/flagship-system as `flagship-2mi8` / `flagship-2mi8.1`. The same project ships an in-repo `bin/bd` wrapper (flagship-2mi8.2) as defense-in-depth — that wrapper can remain after this PR lands; both fixes are independent and the wrapper is operator-installed, not a bd dependency.