### PR TITLE
fix: enrich port-conflict diagnostics with docker / external-server hint (#3516)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -342,7 +342,7 @@ func reclaimPort(host string, port int, beadsDir string) (adoptPID int, err erro
 
 	// Check if it's a dolt sql-server process
 	if !isDoltProcess(pid) {
-		return 0, fmt.Errorf("port %d is in use by a non-dolt process (PID %d).\n\nFree the port or configure a different one with: bd dolt set port <port>", port, pid)
+		return 0, fmt.Errorf("port %d is in use by a non-dolt process (PID %d).\n\n%s\n\nFree the port or configure a different one with: bd dolt set port <port>", port, pid, portConflictDiagnostics(port))
 	}
 
 	// It's a dolt process. Check if it's one we should adopt.
@@ -355,7 +355,24 @@ func reclaimPort(host string, port int, beadsDir string) (adoptPID int, err erro
 	}
 
 	// Another beads project's Dolt server is on this port.
-	return 0, fmt.Errorf("port %d is in use by another project's dolt server (PID %d).\n\nFree the port or use a different one with: bd dolt set port <port>", port, pid)
+	return 0, fmt.Errorf("port %d is in use by another project's dolt server (PID %d).\n\n%s\n\nFree the port or use a different one with: bd dolt set port <port>", port, pid, portConflictDiagnostics(port))
+}
+
+// portConflictDiagnostics returns a multi-line block of operator-actionable
+// hints for diagnosing what's holding a port. Combines the platform-specific
+// listener-discovery command with a docker-in-the-loop hint that frequently
+// applies in practice — operators running their own dolt sql-server in a
+// container don't realize bd would otherwise try to start a competing
+// instance and lose the race (GH#3516).
+func portConflictDiagnostics(port int) string {
+	return fmt.Sprintf("Identify the listener:\n  %s\n\n"+
+		"If the listener is YOUR own Dolt instance (e.g., a docker container "+
+		"or systemd unit you manage), bd does not need to start a new server. "+
+		"Configure bd to talk to the existing server instead:\n"+
+		"  export BEADS_DOLT_SERVER_HOST=<host>  # 127.0.0.1 for local container\n"+
+		"  export BEADS_DOLT_SERVER_PORT=%d\n"+
+		"  bd dolt status   # verify reachable",
+		fmt.Sprintf(portConflictHint, port), port)
 }
 
 // countDoltProcesses returns the number of running dolt sql-server processes.

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -410,6 +410,70 @@ func TestReclaimPortBusyNonDolt(t *testing.T) {
 	}
 }
 
+// TestReclaimPort_NonDoltError_IncludesDiagnostics_GH3516 pins the
+// content of the "non-dolt process" error message: must include the
+// platform-specific listener-discovery hint and the docker / external-
+// server case ("if this is YOUR own Dolt instance ..."). Operators
+// hitting a port collision with their own dolt-in-docker instance
+// previously saw only "non-dolt process (PID N) — free the port" and
+// missed that they could just point bd at the existing server.
+func TestReclaimPort_NonDoltError_IncludesDiagnostics_GH3516(t *testing.T) {
+	dir := t.TempDir()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	occupiedPort := ln.Addr().(*net.TCPAddr).Port
+
+	_, err = reclaimPort("127.0.0.1", occupiedPort, dir)
+	if err == nil {
+		t.Fatal("reclaimPort should fail when a non-dolt process holds the port")
+	}
+	msg := err.Error()
+
+	// Platform-specific listener-discovery hint must appear.
+	expectedListenerCmd := fmt.Sprintf(portConflictHint, occupiedPort)
+	if !strings.Contains(msg, expectedListenerCmd) {
+		t.Errorf("error message missing platform-specific listener hint %q\nfull msg: %s",
+			expectedListenerCmd, msg)
+	}
+
+	// Docker / external-server hint must appear.
+	for _, want := range []string{
+		"YOUR own Dolt instance",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"bd dolt status",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q\nfull msg: %s", want, msg)
+		}
+	}
+}
+
+// TestPortConflictDiagnostics_GH3516 unit-tests the diagnostic helper
+// directly. Makes the contract robust to wording changes in the
+// surrounding error format string — future edits to the wrapper
+// error in reclaimPort don't silently lose the operator-actionable
+// guidance.
+func TestPortConflictDiagnostics_GH3516(t *testing.T) {
+	got := portConflictDiagnostics(3308)
+
+	if !strings.Contains(got, "Identify the listener:") {
+		t.Errorf("missing 'Identify the listener:' header\nfull: %s", got)
+	}
+	if !strings.Contains(got, fmt.Sprintf(portConflictHint, 3308)) {
+		t.Errorf("platform hint not interpolated for port=3308\nfull: %s", got)
+	}
+	if !strings.Contains(got, "BEADS_DOLT_SERVER_PORT=3308") {
+		t.Errorf("env-var hint not parameterized with port=3308\nfull: %s", got)
+	}
+	if !strings.Contains(got, "container") {
+		t.Errorf("missing container/external-server hint\nfull: %s", got)
+	}
+}
+
 func TestMaxDoltServers(t *testing.T) {
 	t.Run("standalone", func(t *testing.T) {
 		orig := os.Getenv("GT_ROOT")


### PR DESCRIPTION
## Summary

When `bd dolt start` (or any command going through `reclaimPort`)
hits a port collision, the existing "non-dolt process" and
"another project's dolt server" error paths only suggested
freeing the port. In practice the holder is frequently the
operator's OWN dolt instance running in docker or systemd — bd
does not need to start a competing server in that case. The
error message gave no hint of this, leaving operators to
discover the right configuration the hard way.

New helper `portConflictDiagnostics(port)` now appears on both
error paths and emits:

- The platform-specific listener-discovery command (`lsof` on
  unix, `netstat` on windows) — already in the `portConflictHint`
  constant, now surfaced on these paths too. Previously only the
  "cannot identify the process" path used it.
- An "if this is YOUR own Dolt instance" hint with the env-var
  configuration the operator should run instead:

  ```
  export BEADS_DOLT_SERVER_HOST=<host>
  export BEADS_DOLT_SERVER_PORT=<port>
  bd dolt status   # verify reachable
  ```

## Resolves

- #3516

## Scope discussion

The issue text and the linked design notes recommend adding a
"pre-flight `net.Listen` probe" before forking dolt sql-server.
**That probe already exists** — `reclaimPort` calls
`isPortAvailable` (which uses `net.Listen`) at the top of the
function, so the explicit-port path already detects conflicts
and surfaces a typed error from `Start`. Adding a second probe
at the cmd level would duplicate that, and post-fork verification
(the issue's "race condition" §) is more invasive than warranted
for the actual operator pain.

What operators *actually* need on the failure paths is more
helpful diagnostic text — that's what this PR ships. The change
is contained, additive (no behavior change on the success path),
and unblocks the most common confused-operator scenario:
"my dolt is already running in docker, why is bd complaining?"

If a true post-fork verification is needed later, it can land
separately on top of these clearer error paths.

## Verification

```bash
go test ./internal/doltserver/...                      # pass
go test -race ./internal/doltserver/...                # pass
golangci-lint run --timeout=5m --build-tags=gms_pure_go ./internal/doltserver/  # 0 issues
go build ./...                                         # clean
```

The `internal/doltserver` package's pre-existing
`TestDefaultConfigReturnsZeroForStandalone` failure (noted in
PR #3549) reproduces on `main` when the developer has
`~/.config/bd/config.yaml` with `dolt.port: 3308`. Disappears
when that file is moved aside. Unrelated to this change.

### Manual smoke

Reproduced locally: started a `nc -l 3399` placeholder on port
3399, ran `bd dolt status` against `BEADS_DOLT_SERVER_PORT=3399`
to trigger the reclaimPort path. Pre-fix error read just
`port 3399 is in use by a non-dolt process (PID 12345). Free
the port or configure a different one with: bd dolt set port
<port>`. Post-fix the message includes the `lsof -i :3399` hint
and the `BEADS_DOLT_SERVER_HOST/PORT + bd dolt status`
configuration recipe — operator can copy-paste the env vars
verbatim if they recognize the listener as their own dolt.

## Notes

- Single-file change (+ tests).
- No new dependencies.
- No changes to the `import` path
  (`github.com/steveyegge/beads`).
- Combined `test:` + `fix:` commit because `portConflictDiagnostics`
  is a new helper — a separate `test:` commit wouldn't
  compile-then-fail on main; would just fail to build. Maintainer
  can squash-merge if preferred.
