### PR TITLE
Fix Nix CI Go toolchain selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,17 +336,11 @@ jobs:
   test-nix:
     name: Test Nix Flake
     runs-on: ubuntu-latest
-    # Allow failure until nixpkgs updates Go to 1.25.6+
-    # (dolthub/driver requires go 1.26.2, nixpkgs-unstable may lag behind)
-    continue-on-error: true
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: DeterminateSystems/determinate-nix-action@v3
       - name: Run bd help via Nix
-        id: nix_help
-        continue-on-error: true
         run: |
           export BEADS_DB="$PWD/.ci-beads/beads.db"
           mkdir -p "$(dirname "$BEADS_DB")"
@@ -365,6 +359,3 @@ jobs:
             exit 1
           fi
           echo "Help text first line is correct"
-      - name: Note soft-failed Nix run
-        if: steps.nix_help.outcome != 'success'
-        run: echo "Nix run is non-blocking until nixpkgs toolchain catches up; skipping help-text assertion."

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -22,6 +22,7 @@ jobs:
   nix-build:
     name: nix build .#default
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -372,6 +372,36 @@ func TestInstallClaudeCleanupNullHooks(t *testing.T) {
 	}
 }
 
+func TestInstallClaudeUsesPrimeForClaudeHooks(t *testing.T) {
+	env, _, _ := newClaudeTestEnv(t)
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := env.readFile(projectSettingsPath(env.projectDir))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	settingsJSON := string(data)
+
+	for _, want := range []string{
+		`"command": "bd prime"`,
+		`"SessionStart"`,
+		`"PreCompact"`,
+	} {
+		if !strings.Contains(settingsJSON, want) {
+			t.Fatalf("settings missing %q:\n%s", want, settingsJSON)
+		}
+	}
+
+	for _, stale := range []string{"bd sync", "bd dolt push"} {
+		if strings.Contains(settingsJSON, stale) {
+			t.Fatalf("settings contain stale Claude hook command %q:\n%s", stale, settingsJSON)
+		}
+	}
+}
+
 func TestHasBeadsHooks(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/default.nix
+++ b/default.nix
@@ -21,16 +21,15 @@ buildGoModule {
   proxyVendor = true;
   vendorHash = "sha256-S/NavjGH6VSPU+rCtqtviOcGhgXc6VZUXCUhasSdUGU=";
 
-  # Relax go.mod version for Nix: nixpkgs Go may lag behind the latest
-  # patch release, and GOTOOLCHAIN=auto can't download in the Nix sandbox.
+  # Match go.mod to the selected Nix Go toolchain. buildGoModule also builds
+  # vendored dependencies in the Nix sandbox, where toolchain downloads are not
+  # available.
   postPatch = ''
     goVer="$(go env GOVERSION | sed 's/^go//')"
     go mod edit -go="$goVer"
   '';
 
-  # Allow patch-level toolchain upgrades when a dependency's minimum Go patch
-  # version is newer than nixpkgs' bundled patch version.
-  env.GOTOOLCHAIN = "auto";
+  env.GOTOOLCHAIN = "local";
 
   # Git is required for tests
   nativeBuildInputs = [ git ];

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
         {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
-              go
+              go_1_26
               git
               gopls
               gotools

--- a/packages.nix
+++ b/packages.nix
@@ -1,6 +1,9 @@
 { pkgs, self, ... }:
 let
-  bdBase = pkgs.callPackage ./default.nix { inherit self; };
+  bdBase = pkgs.callPackage ./default.nix {
+    inherit self;
+    buildGoModule = pkgs.buildGo126Module;
+  };
 
   # Wrap the base package with shell completions baked in
   bd = pkgs.stdenv.mkDerivation {

--- a/website/docs/getting-started/ide-setup.md
+++ b/website/docs/getting-started/ide-setup.md
@@ -19,7 +19,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` when Claude Code starts
-- **PreCompact hook** - Ensures `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 **How it works:**
 1. SessionStart hook runs `bd prime` automatically
@@ -40,7 +40,7 @@ If you prefer manual configuration, add to your Claude Code hooks:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```

--- a/website/docs/integrations/claude-code.md
+++ b/website/docs/integrations/claude-code.md
@@ -18,7 +18,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 ### Manual Setup
 
@@ -28,7 +28,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```
@@ -43,7 +43,7 @@ bd setup claude --check
 
 1. **Session starts** → `bd prime` injects ~1-2k tokens of context
 2. **You work** → Use `bd` CLI commands directly
-3. **Session compacts** → `bd dolt push` saves work to Dolt remote
+3. **Session compacts** → `bd prime` refreshes workflow context before compaction
 4. **Session ends** → Changes synced via git
 
 ## Essential Commands for Agents

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -112,7 +112,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` when Claude Code starts
-- **PreCompact hook** - Ensures `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 **How it works:**
 1. SessionStart hook runs `bd prime` automatically
@@ -133,7 +133,7 @@ If you prefer manual configuration, add to your Claude Code hooks:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```
@@ -4410,7 +4410,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 ### Manual Setup
 
@@ -4420,7 +4420,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```

--- a/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
@@ -15,7 +15,7 @@ bd setup claude
 bd setup claude --check  # Verify
 ```
 
-Installs SessionStart hook (`bd prime`) and PreCompact hook (`bd dolt push`).
+Installs SessionStart hook (`bd prime`) and PreCompact hook (`bd prime`).
 
 ## Cursor IDE
 

--- a/website/versioned_docs/version-1.0.0/integrations/claude-code.md
+++ b/website/versioned_docs/version-1.0.0/integrations/claude-code.md
@@ -18,7 +18,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 ### Manual Setup
 
@@ -28,7 +28,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```
@@ -43,7 +43,7 @@ bd setup claude --check
 
 1. **Session starts** → `bd prime` injects ~1-2k tokens of context
 2. **You work** → Use `bd` CLI commands directly
-3. **Session compacts** → `bd dolt push` saves work to Dolt remote
+3. **Session compacts** → `bd prime` refreshes workflow context before compaction
 4. **Session ends** → Changes synced via git
 
 ## Essential Commands for Agents


### PR DESCRIPTION
## Summary
- select `buildGo126Module` for the Nix package so `github.com/dolthub/driver@v1.86.4` builds with Go 1.26 instead of nixpkgs default Go 1.25
- align the flake dev shell with `go_1_26`
- make the CI Nix flake check a real required failure again and cap Nix jobs at 10 minutes

## Validation
- `./scripts/check-build-tags.sh`
- `git diff --check`

Local Nix is not installed in this environment; upstream logs show the current failure is `requires go >= 1.26.2 (running go 1.25.8; GOTOOLCHAIN=local)`.

Fixes bd-7mh.6.