### PR TITLE
fix(setup): align Claude PreCompact hook docs

### DIFF
--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -372,6 +372,36 @@ func TestInstallClaudeCleanupNullHooks(t *testing.T) {
 	}
 }
 
+func TestInstallClaudeUsesPrimeForClaudeHooks(t *testing.T) {
+	env, _, _ := newClaudeTestEnv(t)
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := env.readFile(projectSettingsPath(env.projectDir))
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	settingsJSON := string(data)
+
+	for _, want := range []string{
+		`"command": "bd prime"`,
+		`"SessionStart"`,
+		`"PreCompact"`,
+	} {
+		if !strings.Contains(settingsJSON, want) {
+			t.Fatalf("settings missing %q:\n%s", want, settingsJSON)
+		}
+	}
+
+	for _, stale := range []string{"bd sync", "bd dolt push"} {
+		if strings.Contains(settingsJSON, stale) {
+			t.Fatalf("settings contain stale Claude hook command %q:\n%s", stale, settingsJSON)
+		}
+	}
+}
+
 func TestHasBeadsHooks(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/website/docs/getting-started/ide-setup.md
+++ b/website/docs/getting-started/ide-setup.md
@@ -19,7 +19,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` when Claude Code starts
-- **PreCompact hook** - Ensures `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 **How it works:**
 1. SessionStart hook runs `bd prime` automatically
@@ -40,7 +40,7 @@ If you prefer manual configuration, add to your Claude Code hooks:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```

--- a/website/docs/integrations/claude-code.md
+++ b/website/docs/integrations/claude-code.md
@@ -18,7 +18,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 ### Manual Setup
 
@@ -28,7 +28,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```
@@ -43,7 +43,7 @@ bd setup claude --check
 
 1. **Session starts** → `bd prime` injects ~1-2k tokens of context
 2. **You work** → Use `bd` CLI commands directly
-3. **Session compacts** → `bd dolt push` saves work to Dolt remote
+3. **Session compacts** → `bd prime` refreshes workflow context before compaction
 4. **Session ends** → Changes synced via git
 
 ## Essential Commands for Agents

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -112,7 +112,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` when Claude Code starts
-- **PreCompact hook** - Ensures `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 **How it works:**
 1. SessionStart hook runs `bd prime` automatically
@@ -133,7 +133,7 @@ If you prefer manual configuration, add to your Claude Code hooks:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```
@@ -4410,7 +4410,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 ### Manual Setup
 
@@ -4420,7 +4420,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```

--- a/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
@@ -15,7 +15,7 @@ bd setup claude
 bd setup claude --check  # Verify
 ```
 
-Installs SessionStart hook (`bd prime`) and PreCompact hook (`bd dolt push`).
+Installs SessionStart hook (`bd prime`) and PreCompact hook (`bd prime`).
 
 ## Cursor IDE
 

--- a/website/versioned_docs/version-1.0.0/integrations/claude-code.md
+++ b/website/versioned_docs/version-1.0.0/integrations/claude-code.md
@@ -18,7 +18,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd dolt push` before context compaction
+- **PreCompact hook** - Runs `bd prime` before context compaction
 
 ### Manual Setup
 
@@ -28,7 +28,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd dolt push"]
+    "PreCompact": ["bd prime"]
   }
 }
 ```
@@ -43,7 +43,7 @@ bd setup claude --check
 
 1. **Session starts** → `bd prime` injects ~1-2k tokens of context
 2. **You work** → Use `bd` CLI commands directly
-3. **Session compacts** → `bd dolt push` saves work to Dolt remote
+3. **Session compacts** → `bd prime` refreshes workflow context before compaction
 4. **Session ends** → Changes synced via git
 
 ## Essential Commands for Agents


### PR DESCRIPTION
## Summary
- add regression coverage that Claude setup writes bd prime hooks, not stale bd sync or bd dolt push commands
- update Claude Code docs, versioned docs, and llms-full output to match the generated PreCompact hook behavior

Fixes GH#3546.

## Tests
- go test ./cmd/bd/setup ./cmd/bd/doctor

## Notes
- Broader go test ./cmd/bd/... could not complete in this environment because cgo ICU headers were unavailable, and no-cgo mode hits pre-existing cmd/bd test helper build errors.