### PR TITLE
Add atomic ready queue claiming

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -31,11 +31,19 @@ Use --mol to filter to a specific molecule's steps:
 Use --gated to find molecules ready for gate-resume dispatch:
   bd ready --gated           # Find molecules where a gate closed
 
+Use --claim to atomically claim the first ready issue matching the filters:
+  bd ready --claim --json
+
 This is useful for agents executing molecules to see which steps can run next.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		claimReady, _ := cmd.Flags().GetBool("claim")
+
 		// Handle --gated flag (gate-resume discovery)
 		gated, _ := cmd.Flags().GetBool("gated")
 		if gated {
+			if claimReady {
+				FatalErrorRespectJSON("--claim cannot be combined with --gated")
+			}
 			runMolReadyGated(cmd, args)
 			return
 		}
@@ -43,6 +51,9 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		// Handle molecule-specific ready query
 		molID, _ := cmd.Flags().GetString("mol")
 		if molID != "" {
+			if claimReady {
+				FatalErrorRespectJSON("--claim cannot be combined with --mol")
+			}
 			runMoleculeReady(cmd, molID)
 			return
 		}
@@ -50,6 +61,9 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		// Handle --explain flag (dependency-aware reasoning)
 		explain, _ := cmd.Flags().GetBool("explain")
 		if explain {
+			if claimReady {
+				FatalErrorRespectJSON("--claim cannot be combined with --explain")
+			}
 			runReadyExplain(cmd)
 			return
 		}
@@ -79,6 +93,9 @@ This is useful for agents executing molecules to see which steps can run next.`,
 			molType = &mt
 		}
 		// Use global jsonOutput set by PersistentPreRun (respects config.yaml + env vars)
+		if claimReady && assignee != "" {
+			FatalErrorRespectJSON("--claim cannot be combined with --assignee")
+		}
 
 		// Normalize labels: trim, dedupe, remove empty
 		labels = utils.NormalizeLabels(labels)
@@ -164,14 +181,45 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		ctx := rootCtx
 
 		activeStore := store
-		// Contributor auto-routing: read from the same target repo as bd create.
-		routedStore, routed, err := openRoutedReadStore(ctx, activeStore)
-		if err != nil {
-			FatalError("%v", err)
+		if claimReady {
+			CheckReadonly("ready --claim")
+		} else {
+			// Contributor auto-routing: read from the same target repo as bd create.
+			routedStore, routed, err := openRoutedReadStore(ctx, activeStore)
+			if err != nil {
+				FatalError("%v", err)
+			}
+			if routed {
+				defer func() { _ = routedStore.Close() }()
+				activeStore = routedStore
+			}
 		}
-		if routed {
-			defer func() { _ = routedStore.Close() }()
-			activeStore = routedStore
+
+		if claimReady {
+			claimed, err := activeStore.ClaimReadyIssue(ctx, filter, actor)
+			if err != nil {
+				FatalErrorRespectJSON("%v", err)
+			}
+			if claimed == nil {
+				if jsonOutput {
+					outputJSON([]*types.IssueWithCounts{})
+				} else {
+					fmt.Printf("\n%s No ready work to claim\n\n", ui.RenderWarn("○"))
+				}
+				return
+			}
+			if isEmbeddedMode() {
+				if _, err := store.CommitPending(ctx, actor); err != nil {
+					FatalErrorRespectJSON("failed to commit: %v", err)
+				}
+			}
+			SetLastTouchedID(claimed.ID)
+			if jsonOutput {
+				outputJSON(buildReadyIssueOutput(ctx, activeStore, []*types.Issue{claimed}))
+			} else {
+				fmt.Printf("%s Claimed issue: %s\n", ui.RenderPass("✓"), formatFeedbackID(claimed.ID, claimed.Title))
+			}
+			return
 		}
 
 		issues, err := activeStore.GetReadyWork(ctx, filter)
@@ -192,50 +240,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 		}
 
 		if jsonOutput {
-			// Always output array, even if empty
-			if issues == nil {
-				issues = []*types.Issue{}
-			}
-			issueIDs := make([]string, len(issues))
-			for i, issue := range issues {
-				issueIDs[i] = issue.ID
-			}
-			// Best effort: display gracefully degrades with empty data
-			labelsMap, _ := activeStore.GetLabelsForIssues(ctx, issueIDs)
-			depCounts, _ := activeStore.GetDependencyCounts(ctx, issueIDs)
-			allDeps, _ := activeStore.GetDependencyRecordsForIssues(ctx, issueIDs)
-			commentCounts, _ := activeStore.GetCommentCounts(ctx, issueIDs)
-
-			// Populate labels and dependencies for JSON output
-			for _, issue := range issues {
-				issue.Labels = labelsMap[issue.ID]
-				issue.Dependencies = allDeps[issue.ID]
-			}
-
-			// Build response with counts + computed parent (consistent with bd list --json)
-			issuesWithCounts := make([]*types.IssueWithCounts, len(issues))
-			for i, issue := range issues {
-				counts := depCounts[issue.ID]
-				if counts == nil {
-					counts = &types.DependencyCounts{DependencyCount: 0, DependentCount: 0}
-				}
-				// Compute parent from dependency records
-				var parent *string
-				for _, dep := range allDeps[issue.ID] {
-					if dep.Type == types.DepParentChild {
-						parent = &dep.DependsOnID
-						break
-					}
-				}
-				issuesWithCounts[i] = &types.IssueWithCounts{
-					Issue:           issue,
-					DependencyCount: counts.DependencyCount,
-					DependentCount:  counts.DependentCount,
-					CommentCount:    commentCounts[issue.ID],
-					Parent:          parent,
-				}
-			}
-			outputJSON(issuesWithCounts)
+			outputJSON(buildReadyIssueOutput(ctx, activeStore, issues))
 			if truncated {
 				fmt.Fprintf(os.Stderr, "Showing %d of %d ready issues. Use --limit 0 for all, or --limit N to raise the cap.\n", len(issues), totalReady)
 			}
@@ -406,6 +411,50 @@ func displayReadyList(issues []*types.Issue, parentEpicMap map[string]string) {
 	fmt.Printf("Ready: %d issues with no active blockers\n", len(issues))
 	fmt.Println()
 	fmt.Println("Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred")
+}
+
+func buildReadyIssueOutput(ctx context.Context, s storage.DoltStorage, issues []*types.Issue) []*types.IssueWithCounts {
+	if issues == nil {
+		issues = []*types.Issue{}
+	}
+	issueIDs := make([]string, len(issues))
+	for i, issue := range issues {
+		issueIDs[i] = issue.ID
+	}
+
+	// Best effort: display gracefully degrades with empty data.
+	labelsMap, _ := s.GetLabelsForIssues(ctx, issueIDs)
+	depCounts, _ := s.GetDependencyCounts(ctx, issueIDs)
+	allDeps, _ := s.GetDependencyRecordsForIssues(ctx, issueIDs)
+	commentCounts, _ := s.GetCommentCounts(ctx, issueIDs)
+
+	for _, issue := range issues {
+		issue.Labels = labelsMap[issue.ID]
+		issue.Dependencies = allDeps[issue.ID]
+	}
+
+	issuesWithCounts := make([]*types.IssueWithCounts, len(issues))
+	for i, issue := range issues {
+		counts := depCounts[issue.ID]
+		if counts == nil {
+			counts = &types.DependencyCounts{DependencyCount: 0, DependentCount: 0}
+		}
+		var parent *string
+		for _, dep := range allDeps[issue.ID] {
+			if dep.Type == types.DepParentChild {
+				parent = &dep.DependsOnID
+				break
+			}
+		}
+		issuesWithCounts[i] = &types.IssueWithCounts{
+			Issue:           issue,
+			DependencyCount: counts.DependencyCount,
+			DependentCount:  counts.DependentCount,
+			CommentCount:    commentCounts[issue.ID],
+			Parent:          parent,
+		}
+	}
+	return issuesWithCounts
 }
 
 // runReadyExplain shows dependency-aware reasoning for why issues are ready or blocked.
@@ -684,6 +733,7 @@ func init() {
 	readyCmd.Flags().Bool("gated", false, "Find molecules ready for gate-resume dispatch")
 	readyCmd.Flags().StringSlice("exclude-type", nil, "Exclude issue types from results (comma-separated or repeatable, e.g., --exclude-type=convoy,epic)")
 	readyCmd.Flags().Bool("explain", false, "Show dependency-aware reasoning for why issues are ready or blocked")
+	readyCmd.Flags().Bool("claim", false, "Atomically claim the first ready issue matching the filters")
 	// Metadata filtering (GH#1406)
 	readyCmd.Flags().StringArray("metadata-field", nil, "Filter by metadata field (key=value, repeatable)")
 	readyCmd.Flags().String("has-metadata-key", "", "Filter issues that have this metadata key set")

--- a/cmd/bd/ready_embedded_test.go
+++ b/cmd/bd/ready_embedded_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func TestEmbeddedReady(t *testing.T) {
@@ -78,6 +80,49 @@ func TestEmbeddedReady(t *testing.T) {
 		}
 		if !strings.Contains(stderr.String(), "Use --limit 0 for all") {
 			t.Fatalf("expected truncation hint on stderr, got: %q", stderr.String())
+		}
+	})
+
+	t.Run("ready_claim_json", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Ready claim json", "--type", "task", "--label", "ready-claim-json")
+
+		cmd := exec.Command(bd, "ready", "--claim", "--json", "--label", "missing-label")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd ready --claim --json with no matches failed: %v\n%s", err, out)
+		}
+		var empty []types.IssueWithCounts
+		if err := json.Unmarshal(bytes.TrimSpace(out), &empty); err != nil {
+			t.Fatalf("parse empty claim JSON: %v\n%s", err, out)
+		}
+		if len(empty) != 0 {
+			t.Fatalf("expected no claimed issues for unmatched label, got %d", len(empty))
+		}
+
+		cmd = exec.Command(bd, "ready", "--claim", "--json", "--label", "ready-claim-json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd ready --claim --json failed: %v\n%s", err, out)
+		}
+		var claimed []types.IssueWithCounts
+		if err := json.Unmarshal(bytes.TrimSpace(out), &claimed); err != nil {
+			t.Fatalf("parse claim JSON: %v\n%s", err, out)
+		}
+		if len(claimed) != 1 {
+			t.Fatalf("expected one claimed issue, got %d: %s", len(claimed), out)
+		}
+		if claimed[0].ID != issue.ID {
+			t.Fatalf("claimed ID = %s, want %s", claimed[0].ID, issue.ID)
+		}
+		if claimed[0].Status != types.StatusInProgress {
+			t.Fatalf("claimed status = %s, want %s", claimed[0].Status, types.StatusInProgress)
+		}
+		if claimed[0].Assignee == "" {
+			t.Fatal("expected claimed issue to have assignee")
 		}
 	})
 
@@ -224,5 +269,75 @@ func TestEmbeddedReadyConcurrent(t *testing.T) {
 		if r.err != nil && !strings.Contains(r.err.Error(), "one writer at a time") {
 			t.Errorf("worker %d failed: %v", r.worker, r.err)
 		}
+	}
+}
+
+func TestEmbeddedReadyClaimConcurrent(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "rc")
+
+	issue := bdCreate(t, bd, dir, "Ready claim concurrent issue", "--type", "task")
+
+	const numWorkers = 8
+	type workerResult struct {
+		worker  int
+		claimed []types.IssueWithCounts
+		err     error
+		out     string
+	}
+	results := make([]workerResult, numWorkers)
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+
+	for w := 0; w < numWorkers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+			r := workerResult{worker: worker}
+			out, err := bdRunWithFlockRetry(t, bd, dir, "ready", "--claim", "--json")
+			r.out = string(out)
+			if err != nil {
+				r.err = fmt.Errorf("ready --claim (worker %d): %v\n%s", worker, err, out)
+				results[worker] = r
+				return
+			}
+			if err := json.Unmarshal(bytes.TrimSpace(out), &r.claimed); err != nil {
+				r.err = fmt.Errorf("parse ready --claim JSON (worker %d): %v\n%s", worker, err, out)
+			}
+			results[worker] = r
+		}(w)
+	}
+	wg.Wait()
+
+	claimCount := 0
+	for _, r := range results {
+		if r.err != nil {
+			t.Errorf("worker %d failed: %v", r.worker, r.err)
+			continue
+		}
+		if len(r.claimed) > 1 {
+			t.Errorf("worker %d claimed %d issues: %s", r.worker, len(r.claimed), r.out)
+			continue
+		}
+		if len(r.claimed) == 1 {
+			claimCount++
+			if r.claimed[0].ID != issue.ID {
+				t.Errorf("worker %d claimed %s, want %s", r.worker, r.claimed[0].ID, issue.ID)
+			}
+		}
+	}
+	if claimCount != 1 {
+		t.Fatalf("expected exactly one successful claim, got %d", claimCount)
+	}
+	got := bdShow(t, bd, dir, issue.ID)
+	if got.Status != types.StatusInProgress {
+		t.Fatalf("final status = %s, want %s", got.Status, types.StatusInProgress)
+	}
+	if got.Assignee == "" {
+		t.Fatal("expected final assignee to be set")
 	}
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -37,6 +37,7 @@ bd info --json
 bd ready --json
 
 # Atomically claim an issue from the ready queue
+bd ready --claim --json                     # Finds and claims one ready issue
 bd update <id> --claim --json               # Fails if already claimed
 
 # Find stale issues (not updated recently)

--- a/internal/storage/bulk_issues.go
+++ b/internal/storage/bulk_issues.go
@@ -13,6 +13,7 @@ type BulkIssueStore interface {
 	DeleteIssuesBySourceRepo(ctx context.Context, sourceRepo string) (int, error)
 	UpdateIssueID(ctx context.Context, oldID, newID string, issue *types.Issue, actor string) error
 	ClaimIssue(ctx context.Context, id string, actor string) error
+	ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error)
 	PromoteFromEphemeral(ctx context.Context, id string, actor string) error
 	GetNextChildID(ctx context.Context, parentID string) (string, error)
 	RenameCounterPrefix(ctx context.Context, oldPrefix, newPrefix string) error

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -229,6 +229,41 @@ func (s *DoltStore) ClaimIssue(ctx context.Context, id string, actor string) err
 	return nil
 }
 
+// ClaimReadyIssue atomically claims the first ready issue matching filter.
+func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	claimed, err := issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor, func(ctx context.Context, tx *sql.Tx, includeWisps bool) ([]string, error) {
+		ids, _, err := issueops.ComputeBlockedIDsInTx(ctx, tx, includeWisps)
+		return ids, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if claimed == nil {
+		return nil, nil
+	}
+
+	for _, table := range []string{"issues", "events"} {
+		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+	}
+	commitMsg := fmt.Sprintf("bd: claim ready %s", claimed.ID)
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+		return nil, fmt.Errorf("dolt commit: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, wrapTransactionError("commit claim ready issue", err)
+	}
+	s.invalidateBlockedIDsCache()
+	return claimed, nil
+}
+
 // ReopenIssue reopens a closed issue, setting status to open and clearing
 // closed_at and defer_until. If reason is non-empty, it is recorded as a comment.
 // Wraps UpdateIssue for Dolt-specific concerns (wisp routing, DOLT_COMMIT, etc.).

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -22,6 +22,17 @@ func (s *EmbeddedDoltStore) ClaimIssue(ctx context.Context, id string, actor str
 	})
 }
 
+// ClaimReadyIssue atomically claims the first ready issue matching filter.
+func (s *EmbeddedDoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error) {
+	var claimed *types.Issue
+	err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+		var err error
+		claimed, err = issueops.ClaimReadyIssueInTx(ctx, tx, filter, actor, computeBlockedIDsWrapper)
+		return err
+	})
+	return claimed, err
+}
+
 // UpdateIssue updates fields on an issue.
 // Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
 func (s *EmbeddedDoltStore) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -19,9 +20,10 @@ type ClaimResult struct {
 
 // ClaimIssueInTx atomically claims an issue using compare-and-swap semantics.
 // It sets the assignee to actor and status to "in_progress" only if the issue
-// currently has no assignee. Returns storage.ErrAlreadyClaimed if already
-// claimed by a different user. Idempotent: re-claiming by the same actor is
-// a no-op success (supports agent retry workflows).
+// is currently open and unassigned or already assigned to the same actor.
+// Returns storage.ErrAlreadyClaimed if already claimed by a different user.
+// Idempotent: re-claiming an in_progress issue by the same actor is a no-op
+// success (supports agent retry workflows).
 // Routes to the correct table (issues/wisps) automatically.
 // The caller is responsible for Dolt versioning (DOLT_ADD/COMMIT) if needed.
 //
@@ -38,7 +40,7 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 
 	now := time.Now().UTC()
 
-	// Conditional UPDATE: only succeeds if assignee is currently empty.
+	// Conditional UPDATE: only succeeds while the issue is still claimable.
 	// Also set started_at on first transition to in_progress (GH#2796); preserve
 	// any existing value so re-claims don't overwrite the original start time.
 	var (
@@ -48,14 +50,14 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?, started_at = ?
-			WHERE id = ? AND (assignee = '' OR assignee IS NULL)
-		`, issueTable), actor, now, now, id)
+			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
+		`, issueTable), actor, now, now, id, actor)
 	} else {
 		result, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET assignee = ?, status = 'in_progress', updated_at = ?
-			WHERE id = ? AND (assignee = '' OR assignee IS NULL)
-		`, issueTable), actor, now, id)
+			WHERE id = ? AND status = 'open' AND (assignee = '' OR assignee IS NULL OR assignee = ?)
+		`, issueTable), actor, now, id, actor)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to claim issue: %w", err)
@@ -67,20 +69,28 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 	}
 
 	if rowsAffected == 0 {
-		// Query current assignee inside the same transaction for consistency.
-		var currentAssignee string
+		// Query current state inside the same transaction for consistency.
+		var currentAssignee sql.NullString
+		var currentStatus types.Status
 		err := tx.QueryRowContext(ctx, fmt.Sprintf(
-			`SELECT assignee FROM %s WHERE id = ?`, issueTable), id).Scan(&currentAssignee)
+			`SELECT assignee, status FROM %s WHERE id = ?`, issueTable), id).Scan(&currentAssignee, &currentStatus)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get current assignee: %w", err)
+			return nil, fmt.Errorf("failed to get current claim state: %w", err)
 		}
-		// Idempotent: if already claimed by the same actor, treat as success.
+		assignee := ""
+		if currentAssignee.Valid {
+			assignee = currentAssignee.String
+		}
+		// Idempotent: if already claimed in_progress by the same actor, treat as success.
 		// This supports agent retry workflows where claim may be called multiple
 		// times after transient failures (GH#8).
-		if currentAssignee == actor {
+		if assignee == actor && currentStatus == types.StatusInProgress {
 			return &ClaimResult{OldIssue: oldIssue, IsWisp: isWisp}, nil
 		}
-		return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, currentAssignee)
+		if assignee != "" && assignee != actor {
+			return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
+		}
+		return nil, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, currentStatus)
 	}
 
 	// Record the claim event.
@@ -96,4 +106,40 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 	}
 
 	return &ClaimResult{OldIssue: oldIssue, IsWisp: isWisp}, nil
+}
+
+// ClaimReadyIssueInTx claims the first currently ready issue matching filter in
+// the same transaction that computes readiness. It returns nil when no matching
+// ready issue can be claimed.
+func ClaimReadyIssueInTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	filter types.WorkFilter,
+	actor string,
+	computeBlockedFn func(ctx context.Context, tx *sql.Tx, includeWisps bool) ([]string, error),
+) (*types.Issue, error) {
+	claimFilter := filter
+	claimFilter.Status = types.StatusOpen
+	claimFilter.Unassigned = true
+	claimFilter.Assignee = nil
+	claimFilter.Limit = 0
+
+	readyIssues, err := GetReadyWorkInTx(ctx, tx, claimFilter, computeBlockedFn)
+	if err != nil {
+		return nil, err
+	}
+	for _, issue := range readyIssues {
+		if _, err := ClaimIssueInTx(ctx, tx, issue.ID, actor); err != nil {
+			if errors.Is(err, storage.ErrAlreadyClaimed) || errors.Is(err, storage.ErrNotClaimable) {
+				continue
+			}
+			return nil, err
+		}
+		claimed, err := GetIssueInTx(ctx, tx, issue.ID)
+		if err != nil {
+			return nil, fmt.Errorf("get claimed issue: %w", err)
+		}
+		return claimed, nil
+	}
+	return nil, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -18,6 +18,11 @@ import (
 // claimed by another user. The error message contains the current assignee.
 var ErrAlreadyClaimed = errors.New("issue already claimed")
 
+// ErrNotClaimable is returned when attempting to claim an issue that is not in a
+// claimable state, such as closed, deferred, or already in progress without the
+// same actor owning the claim.
+var ErrNotClaimable = errors.New("issue not claimable")
+
 // ErrNotFound is returned when a requested entity does not exist in the database.
 var ErrNotFound = errors.New("not found")
 


### PR DESCRIPTION
Fixes #3570.

## Summary
- Adds `bd ready --claim` to claim one ready issue from the queue with readiness filtering and claim in the same transaction.
- Tightens claim CAS semantics so claims only transition open issues, while preserving same-actor idempotent retries.
- Adds embedded coverage for JSON ready-claim behavior and concurrent one-winner claiming.

## Tests
- `go test -tags gms_pure_go ./internal/storage/issueops ./internal/storage/dolt ./internal/storage/embeddeddolt`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedReady$|TestEmbeddedReadyClaimConcurrent|TestEmbeddedUpdate/update_claim'`\n- `golangci-lint run --build-tags gms_pure_go ./...`\n\n## Notes\n- Full `make test` was also run; it failed in existing `TestResolveWhereBeadsDir_UsesInitializedDBPath` because this workspace is nested under `/var/home/matt/dev/mybd/.beads`, causing the test to resolve the parent workspace config instead of its temp `.beads` directory.