### PR TITLE
fix: preserve Windows drive remotes for dolt sync

### DIFF
--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -110,12 +110,24 @@ func gitURLToDoltRemote(url string) string {
 	if strings.HasPrefix(url, "ssh://") {
 		return "git+" + url
 	}
+	if isWindowsDrivePath(url) {
+		return "git+" + url
+	}
 	// SCP-style: git@github.com:org/repo.git → git+ssh://git@github.com/org/repo.git
 	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") {
 		return "git+ssh://" + url[:idx] + "/" + url[idx+1:]
 	}
 	// Fallback: just prepend git+
 	return "git+" + url
+}
+
+func isWindowsDrivePath(path string) bool {
+	if len(path) < 3 || path[1] != ':' {
+		return false
+	}
+	drive := path[0]
+	return ((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) &&
+		(path[2] == '/' || path[2] == '\\')
 }
 
 // gitBranchHasUpstream checks if a specific branch has an upstream configured.

--- a/cmd/bd/sync_git_test.go
+++ b/cmd/bd/sync_git_test.go
@@ -170,6 +170,8 @@ func TestGitURLToDoltRemote(t *testing.T) {
 		{"git@github.com:org/repo.git", "git+ssh://git@github.com/org/repo.git"},
 		{"git+https://github.com/org/repo.git", "git+https://github.com/org/repo.git"},
 		{"git+ssh://git@github.com/org/repo.git", "git+ssh://git@github.com/org/repo.git"},
+		{"C:/Users/alice/repos/beads.git", "git+C:/Users/alice/repos/beads.git"},
+		{`D:\repos\beads.git`, `git+D:\repos\beads.git`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep Windows drive-letter local remotes as local paths when converting git origin URLs for Dolt
- add coverage for both `C:/...` and `D:\...` drive path forms

## Why
`gitURLToDoltRemote` treats any string with a colon before a slash as SCP-style SSH (`git@host:org/repo`). On Windows, local bare remotes commonly look like `C:/Users/alice/repos/beads.git` or `D:\repos\beads.git`; those currently become malformed `git+ssh://C//Users/...` or `git+ssh://D/\repos...` remotes instead of staying local paths.

## Tests
- `gofmt -w cmd/bd/sync_git.go cmd/bd/sync_git_test.go`
- `git diff --check`
- `go test ./cmd/bd -run TestGitURLToDoltRemote -count=1` could not run locally because this machine has Go 1.19.5 and the repo now requires `go 1.26.2` in `go.mod`.
