### PR TITLE
Fix: uuid primary key migration deadlock

### DIFF
--- a/internal/storage/dolt/migrations/010_uuid_primary_keys.go
+++ b/internal/storage/dolt/migrations/010_uuid_primary_keys.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -49,20 +50,18 @@ func migrateTableToUUID(db *sql.DB, table string) error {
 	// Uses SHOW COLUMNS instead of information_schema to avoid
 	// "no root value found in session" errors in Dolt server mode
 	// when the session working set is not fully initialized (GH#2051).
-	//nolint:gosec // G201: table is from hardcoded list
-	rows, err := db.Query(fmt.Sprintf("SHOW COLUMNS FROM `%s` WHERE Field = 'id'", table))
-	if err != nil {
-		return fmt.Errorf("check column type: %w", err)
-	}
-	defer rows.Close()
-
-	if !rows.Next() {
-		return nil // No id column — nothing to migrate
-	}
-
 	var field, colType, nullable, key string
 	var defaultVal, extra sql.NullString
-	if err := rows.Scan(&field, &colType, &nullable, &key, &defaultVal, &extra); err != nil {
+	// QueryRow releases the single pooled connection after Scan. Leaving a
+	// SHOW COLUMNS result set open here self-deadlocks embedded mode, which
+	// runs with MaxOpenConns(1), when the migration immediately performs DDL.
+	//nolint:gosec // G201: table is from hardcoded list
+	err = db.QueryRow(fmt.Sprintf("SHOW COLUMNS FROM `%s` WHERE Field = 'id'", table)).
+		Scan(&field, &colType, &nullable, &key, &defaultVal, &extra)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil // No id column — nothing to migrate
+	}
+	if err != nil {
 		return fmt.Errorf("scan column info: %w", err)
 	}
 

--- a/internal/storage/dolt/migrations/migrations_test.go
+++ b/internal/storage/dolt/migrations/migrations_test.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -438,5 +439,55 @@ func TestMigrateInfraToWisps_SchemaEvolution(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("Expected 0 issues, got %d", count)
+	}
+}
+
+func TestMigrateUUIDPrimaryKeys_DoesNotDeadlockWithSingleConnection(t *testing.T) {
+	db := openTestDoltBranch(t)
+
+	_, err := db.Exec("DROP TABLE IF EXISTS events")
+	if err != nil {
+		t.Fatalf("drop events: %v", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE events (
+			id BIGINT NOT NULL AUTO_INCREMENT,
+			issue_id VARCHAR(255) NOT NULL,
+			event_type VARCHAR(32) NOT NULL,
+			actor VARCHAR(255) NOT NULL,
+			old_value TEXT,
+			new_value TEXT,
+			comment TEXT,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			KEY idx_events_created_at (created_at),
+			KEY idx_events_issue (issue_id)
+		)
+	`)
+	if err != nil {
+		t.Fatalf("create old-shape events table: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- MigrateUUIDPrimaryKeys(db)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("MigrateUUIDPrimaryKeys failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("MigrateUUIDPrimaryKeys timed out with MaxOpenConns=1; SHOW COLUMNS rows likely remained open across DDL")
+	}
+
+	var tableName, createStmt string
+	if err := db.QueryRow("SHOW CREATE TABLE `events`").Scan(&tableName, &createStmt); err != nil {
+		t.Fatalf("SHOW CREATE TABLE events: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(createStmt), "`id` char(36) not null") {
+		t.Fatalf("events.id was not migrated to CHAR(36): %s", createStmt)
 	}
 }


### PR DESCRIPTION
Issue:
Old beads repo with early adoption deadlocks on migration
This happens on nearly every `bd` function all.

Cause:

 1. given a repo that still has old table shapes from an earlier era of beads, so it legitimately needs compat migration 010
 1. embedded mode opens Dolt through database/sql with a single pooled connection
 1. that migration probed SHOW COLUMNS with db.Query(...), left the rowset open, then immediately tried ALTER TABLE
 1. with only one connection available, it deadlocked itself

Fix: internal/storage/dolt/migrations/010_uuid_primary_keys.go
Regression test: internal/storage/dolt/migrations/migrations_test.go

*What Changed*

 - `internal/storage/dolt/migrations/010_uuid_primary_keys.go:39`: switched the SHOW COLUMNS probe from db.Query(...) to db.QueryRow(...).Scan(...).
 - `internal/storage/dolt/migrations/010_uuid_primary_keys.go:55`: added the comment documenting the embedded MaxOpenConns(1) deadlock mechanism.
 - `internal/storage/dolt/migrations/migrations_test.go:445`: added a regression test that recreates an old-shape events table and asserts MigrateUUIDPrimaryKeys completes under a single-connection pool.
