### PR TITLE
feat(dolt): add --verbose flag to bd dolt pull

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -303,7 +303,7 @@ silently ignored.`,
 					} else {
 						fmt.Println("Pulling from Dolt remote...")
 					}
-					if err := doltPullStreaming(ctx, cliDir, remote); err != nil {
+					if err := doltPullStreamingFn(ctx, cliDir, remote); err != nil {
 						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 						if isRemoteNotFoundErr(err) {
 							if remote != "" {
@@ -358,6 +358,10 @@ silently ignored.`,
 		fmt.Println("Pull complete.")
 	},
 }
+
+// doltPullStreamingFn is the function used by --verbose to stream dolt pull
+// output. Overridable in tests to avoid shelling out to the dolt binary.
+var doltPullStreamingFn = doltPullStreaming
 
 // doltPullStreaming runs dolt pull as a subprocess with stdout and stderr
 // piped directly to the terminal, so transfer progress is visible in real time.

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -277,7 +278,13 @@ For Hosted Dolt, set DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD environment
 variables for authentication.
 
 Use --remote to pull from a specific named remote instead of the default.
-The remote must already exist (see 'bd dolt remote add').`,
+The remote must already exist (see 'bd dolt remote add').
+
+Use --verbose to stream transfer output from the dolt binary in real time,
+showing actual progress as objects are received. This requires a local dolt
+CLI directory (the default for SSH/git-protocol remotes). For SQL-based
+remotes (Hosted Dolt, DoltHub), --verbose is not supported and the flag is
+silently ignored.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		st := getStore()
@@ -285,7 +292,41 @@ The remote must already exist (see 'bd dolt remote add').`,
 			fmt.Fprintf(os.Stderr, "Error: no store available\n")
 			os.Exit(1)
 		}
+		verbose, _ := cmd.Flags().GetBool("verbose")
 		remote, _ := cmd.Flags().GetString("remote")
+
+		if verbose {
+			if locator, ok := storage.UnwrapStore(st).(storage.StoreLocator); ok {
+				if cliDir := locator.CLIDir(); cliDir != "" {
+					if remote != "" {
+						fmt.Printf("Pulling from Dolt remote %q...\n", remote)
+					} else {
+						fmt.Println("Pulling from Dolt remote...")
+					}
+					if err := doltPullStreaming(ctx, cliDir, remote); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						if isRemoteNotFoundErr(err) {
+							if remote != "" {
+								fmt.Fprintf(os.Stderr, "\nRemote %q is not configured.\n", remote)
+								fmt.Fprintln(os.Stderr, "Use 'bd dolt remote add <name> <url>' to add it.")
+								fmt.Fprintln(os.Stderr, "Use 'bd dolt remote list' to see configured remotes.")
+							} else {
+								printNoRemoteGuidance()
+							}
+						} else if isDivergedHistoryErr(err) {
+							printDivergedHistoryGuidance("pull")
+						}
+						os.Exit(1)
+					}
+					fmt.Println("Pull complete.")
+					return
+				}
+			}
+			// CLIDir unavailable: --verbose is not supported for this remote type.
+			// Fall through to the standard (silent) pull path.
+			fmt.Fprintln(os.Stderr, "Note: --verbose is not supported for SQL-based remotes; proceeding without transfer output.")
+		}
+
 		if remote != "" {
 			fmt.Printf("Pulling from Dolt remote %q...\n", remote)
 			if err := st.PullRemote(ctx, remote); err != nil {
@@ -316,6 +357,66 @@ The remote must already exist (see 'bd dolt remote add').`,
 		}
 		fmt.Println("Pull complete.")
 	},
+}
+
+// doltPullStreaming runs dolt pull as a subprocess with stdout and stderr
+// piped directly to the terminal, so transfer progress is visible in real time.
+// Used by --verbose to surface genuine feedback from the dolt binary rather
+// than a synthetic progress indicator.
+//
+// Remote and branch are always passed explicitly to avoid "no tracking
+// information" errors (dolt pull with no args fails when branch tracking is
+// not configured in repo_state.json, which is the default for beads databases).
+// When remote is empty, it is resolved from repo_state.json.
+func doltPullStreaming(ctx context.Context, cliDir, remote string) error {
+	if remote == "" {
+		remote = doltDefaultRemote(cliDir)
+	}
+	branch := doltActiveBranch(ctx, cliDir)
+	args := []string{"pull", remote}
+	if branch != "" {
+		args = append(args, branch)
+	}
+	c := exec.CommandContext(ctx, "dolt", args...) // #nosec G204 -- fixed command, remote is a validated flag value
+	c.Dir = cliDir
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c.Run()
+}
+
+// doltActiveBranch returns the currently checked-out branch in the dolt
+// database at dir. Returns empty string if the branch cannot be determined.
+func doltActiveBranch(ctx context.Context, dir string) string {
+	tctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	c := exec.CommandContext(tctx, "dolt", "branch", "--show-current")
+	c.Dir = dir
+	out, err := c.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// doltDefaultRemote reads the first configured remote name from repo_state.json
+// in the dolt database at dir. Returns "origin" if the file cannot be read or
+// no remotes are configured.
+func doltDefaultRemote(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, ".dolt", "repo_state.json"))
+	if err != nil {
+		return "origin"
+	}
+	const marker = `"remotes": {"`
+	idx := strings.Index(string(data), marker)
+	if idx == -1 {
+		return "origin"
+	}
+	rest := string(data)[idx+len(marker):]
+	end := strings.IndexByte(rest, '"')
+	if end <= 0 {
+		return "origin"
+	}
+	return rest[:end]
 }
 
 var doltCommitCmd = &cobra.Command{
@@ -1235,6 +1336,7 @@ func init() {
 	doltPushCmd.Flags().Bool("force", false, "Force push (overwrite remote changes)")
 	doltPushCmd.Flags().String("remote", "", "Push to a specific named remote instead of the default")
 	doltPullCmd.Flags().String("remote", "", "Pull from a specific named remote instead of the default")
+	doltPullCmd.Flags().Bool("verbose", false, "Stream transfer output from dolt in real time (SSH/git-protocol remotes only)")
 	doltCommitCmd.Flags().StringP("message", "m", "", "Commit message (default: auto-generated)")
 	doltCleanDatabasesCmd.Flags().Bool("dry-run", false, "Show what would be dropped without dropping")
 	doltRemoteRemoveCmd.Flags().Bool("force", false, "Force remove even when SQL and CLI URLs conflict")

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1396,6 +1396,79 @@ func TestShouldUseExternalDoltStatus(t *testing.T) {
 	}
 }
 
+// TestDoltPullVerboseFlagRegistered verifies --verbose is declared on bd dolt pull.
+func TestDoltPullVerboseFlagRegistered(t *testing.T) {
+	f := doltPullCmd.Flag("verbose")
+	if f == nil {
+		t.Fatal("expected --verbose flag to be registered on bd dolt pull")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--verbose default = %q, want %q", f.DefValue, "false")
+	}
+}
+
+// TestDoltPullStreamingFnOverridable verifies doltPullStreamingFn can be
+// swapped in tests (injectable var pattern, same as listDoltCLIRemotes).
+func TestDoltPullStreamingFnOverridable(t *testing.T) {
+	original := doltPullStreamingFn
+	defer func() { doltPullStreamingFn = original }()
+
+	called := false
+	doltPullStreamingFn = func(_ context.Context, _, _ string) error {
+		called = true
+		return nil
+	}
+	_ = doltPullStreamingFn(context.Background(), "/fake", "origin")
+	if !called {
+		t.Fatal("expected overridden doltPullStreamingFn to be called")
+	}
+}
+
+// TestDoltDefaultRemoteFromRepoState verifies doltDefaultRemote reads the
+// first remote name from .dolt/repo_state.json when the file exists.
+func TestDoltDefaultRemoteFromRepoState(t *testing.T) {
+	dir := t.TempDir()
+	doltDir := filepath.Join(dir, ".dolt")
+	if err := os.MkdirAll(doltDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	repoState := `{"remotes": {"nas": {"name": "nas", "url": "file:///vol/nas"}}}`
+	if err := os.WriteFile(filepath.Join(doltDir, "repo_state.json"), []byte(repoState), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got := doltDefaultRemote(dir)
+	if got != "nas" {
+		t.Errorf("doltDefaultRemote = %q, want %q", got, "nas")
+	}
+}
+
+// TestDoltDefaultRemoteFallback verifies doltDefaultRemote returns "origin"
+// when repo_state.json is absent or malformed.
+func TestDoltDefaultRemoteFallback(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"missing file", ""},
+		{"no remotes key", `{"head": "main"}`},
+		{"empty remotes", `{"remotes": {}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.content != "" {
+				doltDir := filepath.Join(dir, ".dolt")
+				_ = os.MkdirAll(doltDir, 0o755)
+				_ = os.WriteFile(filepath.Join(doltDir, "repo_state.json"), []byte(tc.content), 0o644)
+			}
+			got := doltDefaultRemote(dir)
+			if got != "origin" {
+				t.Errorf("doltDefaultRemote = %q, want %q", got, "origin")
+			}
+		})
+	}
+}
+
 // TestRenderLocalDoltStatus exercises the bd-managed (PID-file) output
 // path that doltStatusCmd takes when bd owns the server lifecycle. The
 // externally-managed path is covered by TestRunExternalDoltStatus_Unreachable;


### PR DESCRIPTION
## Summary

- Adds `--verbose` flag to `bd dolt pull` that streams transfer output from the dolt binary in real time
- Resolves the default remote from `repo_state.json` and the active branch via `dolt branch --show-current`, then runs `dolt pull <remote> <branch>` as a subprocess with stdout/stderr piped to the terminal
- For SQL-based remotes (Hosted Dolt, DoltHub) where no local CLI directory is available, the flag is not supported; a note is printed and the command falls back to the standard silent pull

## Motivation

`bd dolt pull` currently blocks silently until the transfer completes with no indication of progress. For slow or unreliable remotes (e.g. NAS over SSH), this makes it impossible to distinguish a slow pull from a hung one. The `--verbose` flag surfaces dolt's own transfer output — the same feedback you'd see running `dolt pull` directly — so progress is visible in real time.

Note: streaming output is only available for SSH/git-protocol remotes where a local dolt CLI directory exists. SQL-based remotes have no progress channel at the protocol level; the flag is silently ignored for those and documented as such.

## Test plan

- [ ] `bd dolt pull --verbose` on an SSH remote with new commits — dolt's spinner and transfer output appear live
- [ ] `bd dolt pull --verbose` when already up to date — completes silently with "Pull complete."
- [ ] `bd dolt pull` (no flag) — unchanged behaviour
- [ ] `bd dolt pull --help` — `--verbose` appears in flags with correct description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->