### PR TITLE
fix(docs): repair Pages link checking

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,10 +45,15 @@ jobs:
         working-directory: website
         run: npm run build
 
-      - name: Prepare link check (map baseUrl /beads/ to build output)
+      - name: Prepare link check route aliases
         run: |
-          mkdir -p website/link-check-root
-          ln -s "$PWD/website/build" website/link-check-root/beads
+          rm -rf website/link-check-root
+          mkdir -p website/link-check-root/beads
+          cp -a website/build/. website/link-check-root/beads/
+          find website/link-check-root/beads -type f -name '*.html' ! -name 'index.html' -print0 |
+            while IFS= read -r -d '' file; do
+              ln -sf "$(basename "$file")" "${file%.html}"
+            done
 
       - name: Check internal links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2


### PR DESCRIPTION
## Summary

Fix the GitHub Pages deployment path that has kept the public docs stuck on an old artifact. The docs source already renders the Core Concepts Dolt links as hash anchors, but the Deploy Documentation workflow has been failing in the offline lychee step because extensionless Docusaurus routes such as /beads/reference/configuration were checked as literal files instead of the generated .html pages.

This updates the temporary link-check tree only: it copies the built site under /beads and adds extensionless aliases for generated HTML files before lychee runs. The uploaded Pages artifact remains website/build.

## Validation

- scripts/pr-preflight.sh --search "docs core concepts dolt sync broken link" --repo gastownhall/beads
- npm ci
- npm run build
- lychee 0.23.0 --verbose --no-progress --offline --include-fragments --timeout 30 --root-dir website/link-check-root --exclude-path 'website/build/search/**' website/build
- Verified generated core-concepts.html uses href="#dolt-sync" for Dolt Sync in both stable and Next docs

## Notes

The local bd workspace is not initialized in this checkout, so bd ready/where could not load a project database for issue bookkeeping.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->