### PR TITLE
fix: remote dolt server support — backup, push, pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-06-03 — session 9eea745c
+
+Files: internal/types/types_test.go, internal/types/types.go
+
+> AI summary pending — check ProjectDocs Handover in next session.
 All notable changes to the beads project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -145,6 +145,16 @@ Run 'bd backup init <path>' first to configure a destination.`,
 			return fmt.Errorf("no store available")
 		}
 
+		// Guard: reject sync when connected to a remote server without a
+		// cloud backup destination. File-based Dolt backups send paths to
+		// the server, which fails for remote machines.
+		if isRemoteDoltServer() {
+			cfg, _ := loadDoltBackupConfig()
+			if err := checkBackupSyncRemoteGuard(true, cfg); err != nil {
+				return err
+			}
+		}
+
 		bs, ok := storage.UnwrapStore(store).(storage.BackupStore)
 		if !ok {
 			return fmt.Errorf("storage backend does not support backup operations")
@@ -194,6 +204,22 @@ func checkBackupInitRemoteGuard(backupURL string, isRemote bool) error {
 		return fmt.Errorf("filesystem backup path is not supported for remote dolt servers; the path %q would be created on the remote server's filesystem, not locally. Use a cloud URL (DoltHub, S3, GCS) or JSONL export instead", backupURL)
 	}
 	return nil
+}
+
+// checkBackupSyncRemoteGuard returns an error when bd backup sync is run
+// against a remote Dolt server and no cloud backup destination is configured.
+// Dolt's native backup sends filesystem paths to the server via SQL, which
+// fails for remote servers. When the user has a cloud URL (DoltHub, S3, GCS)
+// configured, the sync can proceed normally.
+func checkBackupSyncRemoteGuard(isRemote bool, cfg *doltBackupConfig) error {
+	if !isRemote {
+		return nil
+	}
+	// If a cloud (non-file://) backup is configured, sync can proceed.
+	if cfg != nil && cfg.BackupURL != "" && !strings.HasPrefix(cfg.BackupURL, "file://") {
+		return nil
+	}
+	return fmt.Errorf("backup sync is not supported for remote dolt servers with a filesystem destination.\n\nDolt's backup mechanism sends filesystem paths to the server, which fails\nwhen the server is on a different machine.\n\nTo back up your data locally, use JSONL export:\n  bd export -o /path/to/backup.jsonl\n\nOr configure a cloud backup destination (DoltHub, S3, GCS):\n  bd backup init https://doltremoteapi.dolthub.com/<user>/<repo>")
 }
 
 // resolveDoltBackupURL converts a user-provided path or URL into a Dolt backup URL.

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -500,13 +500,3 @@ func init() {
 	backupCmd.AddCommand(backupSyncCmd)
 	backupCmd.AddCommand(backupRemoveCmd)
 }
-
-// checkBackupSyncRemoteGuard validates that a remote server backup sync has
-// a cloud-compatible destination configured. Returns an error with guidance
-// when the server is remote but no cloud backup URL is set.
-// TODO: implement (stub for red test bc72bff1)
-func checkBackupSyncRemoteGuard(isRemote bool, cfg *doltBackupConfig) error {
-	_ = isRemote
-	_ = cfg
-	return nil
-}

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -149,7 +149,10 @@ Run 'bd backup init <path>' first to configure a destination.`,
 		// cloud backup destination. File-based Dolt backups send paths to
 		// the server, which fails for remote machines.
 		if isRemoteDoltServer() {
-			cfg, _ := loadDoltBackupConfig()
+			cfg, err := loadDoltBackupConfig()
+			if err != nil {
+				return fmt.Errorf("failed to read backup config: %w", err)
+			}
 			if err := checkBackupSyncRemoteGuard(true, cfg); err != nil {
 				return err
 			}

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -68,6 +68,11 @@ After adding, run 'bd backup sync' to push your data.`,
 		// DoltHub URLs are passed through as-is.
 		backupURL := resolveDoltBackupURL(rawPath)
 
+		// Guard: reject file:// URLs when connected to a remote server.
+		if err := checkBackupInitRemoteGuard(backupURL, isRemoteDoltServer()); err != nil {
+			return err
+		}
+
 		bs, ok := storage.UnwrapStore(store).(storage.BackupStore)
 		if !ok {
 			return fmt.Errorf("storage backend does not support backup operations")
@@ -179,6 +184,16 @@ Run 'bd backup init <path>' first to configure a destination.`,
 		fmt.Printf("Backup synced in %s\n", elapsed.Round(time.Millisecond))
 		return nil
 	},
+}
+
+// checkBackupInitRemoteGuard returns an error if a file:// backup URL is being
+// sent to a remote Dolt server. The server would try to create the directory on
+// its own filesystem, not the client's. Cloud/DoltHub URLs are fine for remote.
+func checkBackupInitRemoteGuard(backupURL string, isRemote bool) error {
+	if isRemote && strings.HasPrefix(backupURL, "file://") {
+		return fmt.Errorf("filesystem backup path is not supported for remote dolt servers; the path %q would be created on the remote server's filesystem, not locally. Use a cloud URL (DoltHub, S3, GCS) or JSONL export instead", backupURL)
+	}
+	return nil
 }
 
 // resolveDoltBackupURL converts a user-provided path or URL into a Dolt backup URL.

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -500,3 +500,13 @@ func init() {
 	backupCmd.AddCommand(backupSyncCmd)
 	backupCmd.AddCommand(backupRemoveCmd)
 }
+
+// checkBackupSyncRemoteGuard validates that a remote server backup sync has
+// a cloud-compatible destination configured. Returns an error with guidance
+// when the server is remote but no cloud backup URL is set.
+// TODO: implement (stub for red test bc72bff1)
+func checkBackupSyncRemoteGuard(isRemote bool, cfg *doltBackupConfig) error {
+	_ = isRemote
+	_ = cfg
+	return nil
+}

--- a/cmd/bd/backup_dolt_test.go
+++ b/cmd/bd/backup_dolt_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -273,6 +274,94 @@ func TestCheckBackupInitRemoteGuard(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error for url=%q isRemote=%v: %v", tt.url, tt.isRemote, err)
+			}
+		})
+	}
+}
+
+// TestCheckBackupSyncRemoteGuard verifies that bd backup sync on a remote
+// server returns a helpful error when no cloud backup URL is configured,
+// guiding the user toward `bd export -o` for JSONL export instead.
+//
+// User stories (docs/REMOTE_SERVER_USER_STORIES.md - Backup):
+//
+//	Given beads is connected to a remote dolt server
+//	When I run `bd backup sync` without a cloud backup destination
+//	Then beads errors with a clear message explaining that server mode
+//	  requires an explicit backup location
+//	And suggests: `bd export -o /path/to/backup.jsonl`
+func TestCheckBackupSyncRemoteGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		isRemote  bool
+		backupCfg *doltBackupConfig
+		wantErr   bool
+		wantMsg   string // substring expected in error message
+	}{
+		{
+			name:      "remote + no backup config = error",
+			isRemote:  true,
+			backupCfg: nil,
+			wantErr:   true,
+			wantMsg:   "bd export",
+		},
+		{
+			name:     "remote + file:// backup = error",
+			isRemote: true,
+			backupCfg: &doltBackupConfig{
+				BackupURL: "file:///mnt/backup",
+			},
+			wantErr: true,
+			wantMsg: "bd export",
+		},
+		{
+			name:     "remote + dolthub URL = ok",
+			isRemote: true,
+			backupCfg: &doltBackupConfig{
+				BackupURL: "https://doltremoteapi.dolthub.com/user/repo",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "remote + aws URL = ok",
+			isRemote: true,
+			backupCfg: &doltBackupConfig{
+				BackupURL: "aws://bucket/path",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "local + no backup config = ok (normal flow handles this)",
+			isRemote:  false,
+			backupCfg: nil,
+			wantErr:   false,
+		},
+		{
+			name:     "local + file:// backup = ok",
+			isRemote: false,
+			backupCfg: &doltBackupConfig{
+				BackupURL: "file:///mnt/backup",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkBackupSyncRemoteGuard(tt.isRemote, tt.backupCfg)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for isRemote=%v backupCfg=%+v, got nil", tt.isRemote, tt.backupCfg)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for isRemote=%v backupCfg=%+v: %v", tt.isRemote, tt.backupCfg, err)
+			}
+			if tt.wantErr && err != nil && tt.wantMsg != "" {
+				if !strings.Contains(err.Error(), tt.wantMsg) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantMsg)
+				}
 			}
 		})
 	}

--- a/cmd/bd/backup_dolt_test.go
+++ b/cmd/bd/backup_dolt_test.go
@@ -240,6 +240,44 @@ func TestDoltBackupSizeFromSizer(t *testing.T) {
 	}
 }
 
+// TestCheckBackupInitRemoteGuard verifies that a local filesystem path is
+// rejected when the Dolt server is remote. DoltHub/cloud URLs should pass.
+//
+// User story (docs/REMOTE_SERVER_USER_STORIES.md - Backup):
+//
+//	Given beads is connected to a remote dolt server
+//	When I run `bd backup init /some/local/path`
+//	Then beads does NOT send that local path to the remote server
+//	And instead tells me this operation isn't supported in remote mode
+func TestCheckBackupInitRemoteGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		url      string
+		isRemote bool
+		wantErr  bool
+	}{
+		{name: "file URL + remote = error", url: "file:///mnt/backup", isRemote: true, wantErr: true},
+		{name: "file URL + local = ok", url: "file:///mnt/backup", isRemote: false, wantErr: false},
+		{name: "dolthub URL + remote = ok", url: "https://doltremoteapi.dolthub.com/user/repo", isRemote: true, wantErr: false},
+		{name: "aws URL + remote = ok", url: "aws://bucket/path", isRemote: true, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := checkBackupInitRemoteGuard(tt.url, tt.isRemote)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for url=%q isRemote=%v, got nil", tt.url, tt.isRemote)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for url=%q isRemote=%v: %v", tt.url, tt.isRemote, err)
+			}
+		})
+	}
+}
+
 func TestShowDoltBackupStatusJSON_NilWhenNotConfigured(t *testing.T) {
 	t.Parallel()
 	// When no .beads dir exists, should return configured=false

--- a/cmd/bd/backup_export.go
+++ b/cmd/bd/backup_export.go
@@ -127,9 +127,11 @@ func atomicWriteFile(path string, data []byte) error {
 // (i.e., not localhost). Used to guard DOLT_BACKUP calls that send local
 // filesystem paths to the server via SQL.
 func isRemoteHost(host string) bool {
-	// TODO: implement remote host detection
-	_ = host
-	return false
+	switch host {
+	case "", "127.0.0.1", "localhost", "::1", "[::1]":
+		return false
+	}
+	return true
 }
 
 // isRemoteDoltServerForDir checks whether the Dolt server configured in the
@@ -176,6 +178,33 @@ func runBackupExport(ctx context.Context, force bool) (*backupState, error) {
 			debug.Logf("backup: no changes since last backup (commit %s)\n", truncateHash(currentCommit))
 			return state, nil
 		}
+	}
+
+	// When the Dolt server is remote, DOLT_BACKUP('add', ..., 'file:///local/path')
+	// sends the local filesystem path to the remote server, which tries to mkdir
+	// that path on its own filesystem. Fall back to JSONL export instead.
+	if isRemoteDoltServer() {
+		debug.Logf("backup: remote dolt server detected, falling back to JSONL export\n")
+		exportPath := filepath.Join(dir, "export.jsonl")
+		issueCount, memoryCount, err := exportToFile(ctx, exportPath, true)
+		if err != nil {
+			return nil, fmt.Errorf("JSONL backup export failed: %w", err)
+		}
+		debug.Logf("backup: JSONL export wrote %d issues and %d memories to %s\n",
+			issueCount, memoryCount, exportPath)
+
+		// Update watermarks
+		currentCommit, err := store.GetCurrentCommit(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current commit for state: %w", err)
+		}
+		state.LastDoltCommit = currentCommit
+		state.Timestamp = time.Now().UTC()
+
+		if err := saveBackupState(dir, state); err != nil {
+			return nil, err
+		}
+		return state, nil
 	}
 
 	bs, ok := storage.UnwrapStore(store).(storage.BackupStore)

--- a/cmd/bd/backup_export.go
+++ b/cmd/bd/backup_export.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/storage"
 )
@@ -120,6 +121,36 @@ func atomicWriteFile(path string, data []byte) error {
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 	return nil
+}
+
+// isRemoteHost returns true if the given host string refers to a remote machine
+// (i.e., not localhost). Used to guard DOLT_BACKUP calls that send local
+// filesystem paths to the server via SQL.
+func isRemoteHost(host string) bool {
+	// TODO: implement remote host detection
+	_ = host
+	return false
+}
+
+// isRemoteDoltServerForDir checks whether the Dolt server configured in the
+// given beads directory is remote. Extracted for testability.
+func isRemoteDoltServerForDir(beadsDir string) bool {
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		return false
+	}
+	return isRemoteHost(cfg.DoltServerHost)
+}
+
+// isRemoteDoltServer checks whether the configured Dolt server is remote.
+// DOLT_BACKUP commands send local filesystem paths to the server via SQL,
+// which fails when the server is on a different machine.
+func isRemoteDoltServer() bool {
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		return false
+	}
+	return isRemoteDoltServerForDir(beadsDir)
 }
 
 // runBackupExport performs a Dolt-native backup to .beads/backup/.

--- a/cmd/bd/backup_export_test.go
+++ b/cmd/bd/backup_export_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsRemoteHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "empty string is local", host: "", want: false},
+		{name: "127.0.0.1 is local", host: "127.0.0.1", want: false},
+		{name: "localhost is local", host: "localhost", want: false},
+		{name: "::1 is local", host: "::1", want: false},
+		{name: "[::1] is local", host: "[::1]", want: false},
+		{name: "LAN IP is remote", host: "10.0.0.2", want: true},
+		{name: "192.168 IP is remote", host: "192.168.1.100", want: true},
+		{name: "hostname is remote", host: "mini2", want: true},
+		{name: "FQDN is remote", host: "db.example.com", want: true},
+		{name: "public IP is remote", host: "203.0.113.1", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isRemoteHost(tt.host)
+			if got != tt.want {
+				t.Errorf("isRemoteHost(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRemoteDoltServer_WithRemoteConfig(t *testing.T) {
+	// Create a temp .beads dir with a metadata.json pointing to a remote host.
+	beadsDir := t.TempDir()
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+
+	metadata := map[string]interface{}{
+		"backend":          "dolt",
+		"dolt_mode":        "server",
+		"dolt_server_host": "10.0.0.2",
+		"dolt_server_port": 3307,
+		"database":         "beads",
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(metadataPath, data, 0600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	// isRemoteDoltServerForDir lets us test with a specific beads dir
+	// rather than relying on FindBeadsDir() which searches the filesystem.
+	got := isRemoteDoltServerForDir(beadsDir)
+	if !got {
+		t.Errorf("isRemoteDoltServerForDir(%q) = false, want true (host=10.0.0.2)", beadsDir)
+	}
+}
+
+func TestIsRemoteDoltServer_WithLocalConfig(t *testing.T) {
+	beadsDir := t.TempDir()
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+
+	metadata := map[string]interface{}{
+		"backend":          "dolt",
+		"dolt_mode":        "server",
+		"dolt_server_host": "127.0.0.1",
+		"dolt_server_port": 3307,
+		"database":         "beads",
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(metadataPath, data, 0600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	got := isRemoteDoltServerForDir(beadsDir)
+	if got {
+		t.Errorf("isRemoteDoltServerForDir(%q) = true, want false (host=127.0.0.1)", beadsDir)
+	}
+}
+
+func TestIsRemoteDoltServer_NoMetadata(t *testing.T) {
+	beadsDir := t.TempDir()
+	// No metadata.json — should default to local (false).
+	got := isRemoteDoltServerForDir(beadsDir)
+	if got {
+		t.Errorf("isRemoteDoltServerForDir(%q) = true, want false (no metadata)", beadsDir)
+	}
+}
+
+func TestIsRemoteDoltServer_EmptyHost(t *testing.T) {
+	beadsDir := t.TempDir()
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+
+	metadata := map[string]interface{}{
+		"backend":  "dolt",
+		"database": "beads",
+		// No dolt_server_host — defaults to empty string = local
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(metadataPath, data, 0600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	got := isRemoteDoltServerForDir(beadsDir)
+	if got {
+		t.Errorf("isRemoteDoltServerForDir(%q) = true, want false (empty host)", beadsDir)
+	}
+}

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -21,6 +21,7 @@ const (
 	statusOK      = "ok"
 	statusWarning = "warning"
 	statusError   = "error"
+	statusSkip    = "skip"
 )
 
 type doctorCheck struct {
@@ -1095,7 +1096,7 @@ func printDiagnostics(result doctorResult) {
 	// Pre-calculate counts and collect issues grouped by category
 	checksByCategory := make(map[string][]doctorCheck)
 	issuesByCategory := make(map[string][]doctorCheck)
-	var passCount, warnCount, failCount int
+	var passCount, warnCount, failCount, skipCount int
 	hasIssues := false
 
 	for _, check := range result.Checks {
@@ -1108,6 +1109,8 @@ func printDiagnostics(result doctorResult) {
 		switch check.Status {
 		case statusOK:
 			passCount++
+		case statusSkip:
+			skipCount++
 		case statusWarning:
 			warnCount++
 			issuesByCategory[cat] = append(issuesByCategory[cat], check)
@@ -1121,11 +1124,16 @@ func printDiagnostics(result doctorResult) {
 
 	// Print header with version and summary
 	fmt.Printf("\nbd doctor v%s", result.CLIVersion)
-	fmt.Printf("  %s  %s %d passed  %s %d warnings  %s %d errors\n",
+	skipSuffix := ""
+	if skipCount > 0 {
+		skipSuffix = fmt.Sprintf("  %s %d skipped", ui.RenderMuted("◌"), skipCount)
+	}
+	fmt.Printf("  %s  %s %d passed  %s %d warnings  %s %d errors%s\n",
 		ui.RenderSeparator(),
 		ui.RenderPassIcon(), passCount,
 		ui.RenderWarnIcon(), warnCount,
 		ui.RenderFailIcon(), failCount,
+		skipSuffix,
 	)
 
 	if doctorVerbose {
@@ -1255,6 +1263,8 @@ func printAllChecks(checksByCategory map[string][]doctorCheck) {
 			switch check.Status {
 			case statusOK:
 				statusIcon = ui.RenderPassIcon()
+			case statusSkip:
+				statusIcon = ui.RenderMuted("◌")
 			case statusWarning:
 				statusIcon = ui.RenderWarnIcon()
 			case statusError:
@@ -1282,6 +1292,8 @@ func printAllChecks(checksByCategory map[string][]doctorCheck) {
 			switch check.Status {
 			case statusOK:
 				statusIcon = ui.RenderPassIcon()
+			case statusSkip:
+				statusIcon = ui.RenderMuted("◌")
 			case statusWarning:
 				statusIcon = ui.RenderWarnIcon()
 			case statusError:

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -1126,7 +1126,7 @@ func printDiagnostics(result doctorResult) {
 	fmt.Printf("\nbd doctor v%s", result.CLIVersion)
 	skipSuffix := ""
 	if skipCount > 0 {
-		skipSuffix = fmt.Sprintf("  %s %d skipped", ui.RenderMuted("◌"), skipCount)
+		skipSuffix = fmt.Sprintf("  %s %d skipped", ui.RenderMuted("○"), skipCount)
 	}
 	fmt.Printf("  %s  %s %d passed  %s %d warnings  %s %d errors%s\n",
 		ui.RenderSeparator(),
@@ -1231,7 +1231,11 @@ func printDiagnostics(result doctorResult) {
 		}
 	} else {
 		fmt.Println()
-		fmt.Printf("%s\n", ui.RenderPass("✓ All checks passed"))
+		if skipCount > 0 {
+			fmt.Printf("%s\n", ui.RenderPass("✓ All applicable checks passed"))
+		} else {
+			fmt.Printf("%s\n", ui.RenderPass("✓ All checks passed"))
+		}
 		if !doctorVerbose {
 			fmt.Printf("%s\n", ui.RenderMuted("Run with --verbose to see all checks"))
 		}
@@ -1264,7 +1268,7 @@ func printAllChecks(checksByCategory map[string][]doctorCheck) {
 			case statusOK:
 				statusIcon = ui.RenderPassIcon()
 			case statusSkip:
-				statusIcon = ui.RenderMuted("◌")
+				statusIcon = ui.RenderMuted("○")
 			case statusWarning:
 				statusIcon = ui.RenderWarnIcon()
 			case statusError:
@@ -1293,7 +1297,7 @@ func printAllChecks(checksByCategory map[string][]doctorCheck) {
 			case statusOK:
 				statusIcon = ui.RenderPassIcon()
 			case statusSkip:
-				statusIcon = ui.RenderMuted("◌")
+				statusIcon = ui.RenderMuted("○")
 			case statusWarning:
 				statusIcon = ui.RenderWarnIcon()
 			case statusError:

--- a/cmd/bd/doctor/database.go
+++ b/cmd/bd/doctor/database.go
@@ -26,6 +26,10 @@ type localConfig struct {
 // with the current server-only architecture. The ensureDoltInit function
 // auto-recovers these at server start; this check provides early detection.
 func CheckDoltFormat(path string) DoctorCheck {
+	if IsRemoteServerMode(path) {
+		return SkipForRemoteServer("Dolt Format", CategoryCore)
+	}
+
 	_, beadsDir := getBackendAndBeadsDir(path)
 	doltDir := filepath.Join(beadsDir, "dolt")
 

--- a/cmd/bd/doctor/nocow.go
+++ b/cmd/bd/doctor/nocow.go
@@ -24,6 +24,10 @@ import (
 func CheckBtrfsNoCOW(path string) DoctorCheck {
 	const name = "Btrfs NoCOW (dolt)"
 
+	if IsRemoteServerMode(path) {
+		return SkipForRemoteServer(name, CategoryPerformance)
+	}
+
 	if runtime.GOOS != "linux" {
 		return DoctorCheck{
 			Name:     name,

--- a/cmd/bd/doctor/remote_server.go
+++ b/cmd/bd/doctor/remote_server.go
@@ -1,0 +1,43 @@
+package doctor
+
+import (
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+// IsRemoteServerMode returns true if the beads directory at the given path is
+// configured to connect to a remote (non-localhost) Dolt server. When true,
+// doctor checks that access the local .dolt/ directory should be skipped since
+// there is no local Dolt data directory — the data lives on the remote server.
+func IsRemoteServerMode(repoPath string) bool {
+	beadsDir := ResolveBeadsDirForRepo(repoPath)
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil {
+		return false
+	}
+	return isRemoteHost(cfg.DoltServerHost)
+}
+
+// isRemoteHost returns true if the given host string refers to a remote machine
+// (i.e., not localhost).
+func isRemoteHost(host string) bool {
+	switch host {
+	case "", "127.0.0.1", "localhost", "::1", "[::1]":
+		return false
+	}
+	return true
+}
+
+// remoteServerSkipMessage is the standard message for checks skipped in
+// remote server mode.
+const remoteServerSkipMessage = "skipped: remote server mode"
+
+// SkipForRemoteServer returns a DoctorCheck with StatusSkip for checks that
+// are not applicable in remote server mode.
+func SkipForRemoteServer(name, category string) DoctorCheck {
+	return DoctorCheck{
+		Name:     name,
+		Status:   StatusSkip,
+		Message:  remoteServerSkipMessage,
+		Category: category,
+	}
+}

--- a/cmd/bd/doctor/types.go
+++ b/cmd/bd/doctor/types.go
@@ -5,6 +5,7 @@ const (
 	StatusOK      = "ok"
 	StatusWarning = "warning"
 	StatusError   = "error"
+	StatusSkip    = "skip"
 )
 
 // Category constants for grouping doctor checks

--- a/cmd/bd/doctor/types.go
+++ b/cmd/bd/doctor/types.go
@@ -39,7 +39,7 @@ var CategoryOrder = []string{
 // DoctorCheck represents a single diagnostic check result
 type DoctorCheck struct {
 	Name     string `json:"name"`
-	Status   string `json:"status"` // StatusOK, StatusWarning, or StatusError
+	Status   string `json:"status"` // StatusOK, StatusWarning, StatusError, or StatusSkip
 	Message  string `json:"message"`
 	Detail   string `json:"detail,omitempty"`
 	Fix      string `json:"fix,omitempty"`

--- a/cmd/bd/doctor_remote_server_test.go
+++ b/cmd/bd/doctor_remote_server_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/cmd/bd/doctor"
+)
+
+// TestDoctorRemoteServerSkipsFilesystemChecks verifies that when the Dolt
+// server is remote (not localhost), filesystem-dependent checks return
+// "skip" status with a message explaining why.
+func TestDoctorRemoteServerSkipsFilesystemChecks(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp project dir with .beads/ pointing to a remote host.
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	metadata := map[string]interface{}{
+		"backend":          "dolt",
+		"dolt_mode":        "server",
+		"dolt_server_host": "10.0.0.2",
+		"dolt_server_port": 3307,
+		"database":         "beads",
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// These checks access the local .dolt/ directory and should be skipped
+	// for remote server mode.
+	checksToSkip := []string{
+		"Dolt Format",
+		"Remote Consistency",
+		"Btrfs NoCOW (dolt)",
+	}
+
+	for _, checkName := range checksToSkip {
+		t.Run(checkName, func(t *testing.T) {
+			var dc doctor.DoctorCheck
+			switch checkName {
+			case "Dolt Format":
+				dc = doctor.CheckDoltFormat(tmpDir)
+			case "Remote Consistency":
+				dc = doctor.CheckRemoteConsistency(tmpDir)
+			case "Btrfs NoCOW (dolt)":
+				dc = doctor.CheckBtrfsNoCOW(tmpDir)
+			}
+
+			if dc.Status != "skip" {
+				t.Errorf("%s: got status %q, want %q", checkName, dc.Status, "skip")
+			}
+			if dc.Message == "" || dc.Message != "skipped: remote server mode" {
+				t.Errorf("%s: got message %q, want %q", checkName, dc.Message, "skipped: remote server mode")
+			}
+		})
+	}
+}
+
+// TestDoctorRemoteServerRunsSQLChecks verifies that SQL-based checks still
+// run normally when the Dolt server is remote.
+func TestDoctorRemoteServerRunsSQLChecks(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp project dir with .beads/ pointing to a remote host.
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	metadata := map[string]interface{}{
+		"backend":          "dolt",
+		"dolt_mode":        "server",
+		"dolt_server_host": "10.0.0.2",
+		"dolt_server_port": 3307,
+		"database":         "beads",
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dolt Locks uses SQL (dolt_status) — should NOT be skipped.
+	// It may fail to connect (no real server), but should not return "skip".
+	dc := doctor.CheckDoltLocks(tmpDir)
+	if dc.Status == "skip" {
+		t.Errorf("Dolt Locks should not be skipped for remote server mode (it uses SQL)")
+	}
+}
+
+// TestDoctorLocalServerDoesNotSkip verifies that local server configs
+// do NOT trigger skip behavior.
+func TestDoctorLocalServerDoesNotSkip(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.Mkdir(beadsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	metadata := map[string]interface{}{
+		"backend":          "dolt",
+		"dolt_mode":        "server",
+		"dolt_server_host": "127.0.0.1",
+		"dolt_server_port": 3307,
+		"database":         "beads",
+	}
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// With localhost config, CheckDoltFormat should NOT be skipped.
+	dc := doctor.CheckDoltFormat(tmpDir)
+	if dc.Status == "skip" {
+		t.Errorf("Dolt Format should not be skipped for local server (host=127.0.0.1)")
+	}
+}

--- a/docs/REMOTE_SERVER_USER_STORIES.md
+++ b/docs/REMOTE_SERVER_USER_STORIES.md
@@ -38,15 +38,20 @@ And the remote server pushes to the "backup" remote
 
 ```gherkin
 Given beads is connected to a remote dolt server
-When I run `bd backup export` without specifying a location
-Then beads errors with a clear message explaining that server mode
-  requires an explicit backup location
-And suggests: `bd backup export --output /path/to/backup.jsonl`
+When auto-backup runs (or any internal call to runBackupExport)
+Then beads detects it cannot use Dolt's filesystem backup mechanism
+And silently falls back to JSONL export at .beads/backup/export.jsonl
+And .beads/ is always local so this works without network issues
 
 Given beads is connected to a remote dolt server
-When I run `bd backup export --output ~/backups/beads.jsonl`
-Then beads exports issues as JSONL to the specified local path
+When I run `bd export -o ~/backups/beads.jsonl`
+Then beads exports issues as JSONL to the specified local path via SQL
 And does NOT attempt to use Dolt's filesystem backup mechanism
+
+Given beads is connected to a remote dolt server
+When I run `bd backup sync` with no cloud backup URL configured
+Then beads tells me filesystem backup is not supported in remote mode
+And suggests `bd export -o path` for JSONL or a cloud URL for Dolt backup
 
 Given beads is connected to a remote dolt server
 When I run `bd backup init /some/local/path`
@@ -97,7 +102,11 @@ And NOT a hang or raw stack trace
 Given config.yaml specifies host: mini2
 And BEADS_DOLT_CLI_DIR is also set
 When beads initializes
-Then [DECISION NEEDED: error at startup? CLI dir wins? remote wins with warning?]
+Then the remote host wins and BEADS_DOLT_CLI_DIR is ignored
+And a warning is printed: "BEADS_DOLT_CLI_DIR is set but ignored — connected to remote dolt server at mini2"
+# Decision: env var precedence (flags > env > config > defaults) applies generally,
+# but BEADS_DOLT_CLI_DIR is meaningless for remote servers (no local database),
+# so remote host takes functional precedence with a visible warning.
 
 Given beads is connected to a dolt server on localhost via SQL (not embedded mode)
 When I run `bd backup init /some/local/path`
@@ -113,7 +122,11 @@ Then it uses SQL (network) not filesystem (local)
 And it never sends local filesystem paths to the remote server
 And it never shells out to a local dolt CLI expecting a local database
 
-# Exception: .beads/ config, hooks, JSONL exports are always local operations
+# Exceptions (always local, never sent to remote server):
+#   .beads/ config and metadata
+#   .beads/backup/ (JSONL export destination)
+#   Git hooks
+#   JSONL export/import files
 ```
 
 ## Out of Scope (follow-up work)
@@ -122,4 +135,3 @@ And it never shells out to a local dolt CLI expecting a local database
 - Server version mismatch detection
 - Read-only SQL user handling
 - Federation peer sync in remote mode
-- Connection timeout tuning

--- a/docs/REMOTE_SERVER_USER_STORIES.md
+++ b/docs/REMOTE_SERVER_USER_STORIES.md
@@ -1,0 +1,125 @@
+# Remote Dolt Server — User Stories
+
+Stories describing expected behavior when beads connects to a remote dolt server
+(e.g., `host: mini2`) instead of localhost. These drive the fix in PR #3595.
+
+## Push/Pull
+
+```gherkin
+Given beads is connected to a remote dolt server (mini2)
+When I run `bd dolt push`
+Then the push command is sent via SQL to the remote server
+And the remote server executes the push against its own remotes
+And I see "Push complete."
+
+Given beads is connected to a remote dolt server
+When I run `bd dolt pull`
+Then the pull command is sent via SQL to the remote server
+And the remote server pulls from its own remotes
+And my next query sees the updated data
+
+Given beads is connected to a remote dolt server with no remotes configured
+When I run `bd dolt push`
+Then I see a clear error explaining no remotes are configured on the server
+And NOT a raw SQL error or stack trace
+
+Given beads is connected to a remote dolt server
+When I run `bd dolt push --force`
+Then the force flag is passed through the SQL path
+And the remote server executes a force push
+
+Given beads is connected to a remote dolt server
+When I run `bd dolt push --remote backup`
+Then the named remote is passed through the SQL path
+And the remote server pushes to the "backup" remote
+```
+
+## Backup
+
+```gherkin
+Given beads is connected to a remote dolt server
+When I run `bd backup export` without specifying a location
+Then beads errors with a clear message explaining that server mode
+  requires an explicit backup location
+And suggests: `bd backup export --output /path/to/backup.jsonl`
+
+Given beads is connected to a remote dolt server
+When I run `bd backup export --output ~/backups/beads.jsonl`
+Then beads exports issues as JSONL to the specified local path
+And does NOT attempt to use Dolt's filesystem backup mechanism
+
+Given beads is connected to a remote dolt server
+When I run `bd backup init /some/local/path`
+Then beads does NOT send that local path to the remote server
+And instead tells me filesystem backup is not supported in remote mode
+And suggests using a cloud URL (DoltHub, S3, GCS) instead
+
+Given beads is connected to a remote dolt server
+When I run `bd backup init https://doltremoteapi.dolthub.com/user/repo`
+Then the DoltHub URL is passed through to the remote server
+And the remote server registers it as a backup destination
+
+Given beads is connected to a local dolt server (localhost)
+When I run `bd backup init /some/local/path`
+Then the backup is created at that path as normal
+
+Given beads is connected to a remote dolt server
+When I have a JSONL backup file
+And I run `bd init --from-jsonl backup.jsonl`
+Then the issues are imported into the remote server via SQL
+```
+
+## Info/Diagnostics
+
+```gherkin
+Given beads is connected to a remote dolt server
+When I run `bd dolt show`
+Then remotes are queried via SQL (SELECT * FROM dolt_remotes)
+And I see the server's actual configured remotes
+And it does NOT say "no remotes found" just because there's no local dolt dir
+
+Given beads is connected to a remote dolt server
+When I run `bd doctor`
+Then checks that require local filesystem access show SKIP (remote mode)
+And I do NOT see misleading errors about missing directories
+And I can see which checks were skipped and why
+
+Given beads is connected to a remote dolt server
+And the SQL connection is down
+When I run any bd command
+Then I see "Cannot connect to dolt server at <host>:<port>" within a reasonable timeout
+And NOT a hang or raw stack trace
+```
+
+## Config Conflicts
+
+```gherkin
+Given config.yaml specifies host: mini2
+And BEADS_DOLT_CLI_DIR is also set
+When beads initializes
+Then [DECISION NEEDED: error at startup? CLI dir wins? remote wins with warning?]
+
+Given beads is connected to a dolt server on localhost via SQL (not embedded mode)
+When I run `bd backup init /some/local/path`
+Then the filesystem backup works because the server CAN access local paths
+```
+
+## General Principle
+
+```gherkin
+Given beads is connected to a remote dolt server
+When any command needs to interact with the dolt database or its version control
+Then it uses SQL (network) not filesystem (local)
+And it never sends local filesystem paths to the remote server
+And it never shells out to a local dolt CLI expecting a local database
+
+# Exception: .beads/ config, hooks, JSONL exports are always local operations
+```
+
+## Out of Scope (follow-up work)
+
+- SQL-mode vs CLI-mode refactor (deeper than remote host detection)
+- Server version mismatch detection
+- Read-only SQL user handling
+- Federation peer sync in remote mode
+- Connection timeout tuning

--- a/internal/storage/dolt/backup_remote_test.go
+++ b/internal/storage/dolt/backup_remote_test.go
@@ -1,0 +1,88 @@
+package dolt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+)
+
+// remoteBackupGuardMsg is the error substring that the remote server guard
+// should produce. Using a const keeps the red tests and green fix in sync.
+const remoteBackupGuardMsg = "not supported for remote dolt servers"
+
+// TestBackupDatabaseRejectsRemoteServer verifies that BackupDatabase returns
+// an error when connected to a remote Dolt server. Sending file:// URLs to a
+// remote server would create directories on the remote filesystem.
+//
+// User story (docs/REMOTE_SERVER_USER_STORIES.md - Backup):
+//
+//	Given beads is connected to a remote dolt server
+//	When I run `bd backup init /some/local/path`
+//	Then beads does NOT send that local path to the remote server
+func TestBackupDatabaseRejectsRemoteServer(t *testing.T) {
+	t.Parallel()
+
+	s := &DoltStore{
+		db:          stubDB(t),
+		serverHost:  "mini2",
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+	}
+
+	err := s.BackupDatabase(t.Context(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected BackupDatabase to return error on remote server, got nil")
+	}
+	if !strings.Contains(err.Error(), remoteBackupGuardMsg) {
+		t.Errorf("expected error containing %q, got: %v", remoteBackupGuardMsg, err)
+	}
+}
+
+// TestBackupDatabaseAllowsLocalServer verifies that BackupDatabase does NOT
+// reject local server connections. The file:// URL is valid when server and
+// client share a filesystem.
+//
+// User story:
+//
+//	Given beads is connected to a local dolt server (localhost)
+//	When I run `bd backup init /some/local/path`
+//	Then the backup is created at that path as normal
+func TestBackupDatabaseAllowsLocalServer(t *testing.T) {
+	t.Parallel()
+
+	s := &DoltStore{
+		db:          stubDB(t),
+		serverHost:  "127.0.0.1",
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+	}
+
+	// BackupDatabase on a local server should NOT return the remote guard error.
+	// It will fail for other reasons (fake DB), but not with the remote guard.
+	err := s.BackupDatabase(t.Context(), t.TempDir())
+	if err != nil && strings.Contains(err.Error(), remoteBackupGuardMsg) {
+		t.Errorf("BackupDatabase should not reject local server, got: %v", err)
+	}
+}
+
+// TestRestoreDatabaseRejectsRemoteServer verifies that RestoreDatabase also
+// rejects remote servers. Same file:// URL problem applies to restore.
+func TestRestoreDatabaseRejectsRemoteServer(t *testing.T) {
+	t.Parallel()
+
+	s := &DoltStore{
+		db:          stubDB(t),
+		serverHost:  "mini2",
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+	}
+
+	err := s.RestoreDatabase(t.Context(), t.TempDir(), false)
+	if err == nil {
+		t.Fatal("expected RestoreDatabase to return error on remote server, got nil")
+	}
+	if !strings.Contains(err.Error(), remoteBackupGuardMsg) {
+		t.Errorf("expected error containing %q, got: %v", remoteBackupGuardMsg, err)
+	}
+}

--- a/internal/storage/dolt/connection_error_test.go
+++ b/internal/storage/dolt/connection_error_test.go
@@ -1,0 +1,120 @@
+package dolt
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConnectionError_CleanMessage verifies that when the Dolt server is
+// unreachable (connection refused), the error message uses the clean format
+// "cannot connect to dolt server at <host>:<port>" rather than a raw driver
+// error or stack trace. This is the user-facing contract from the user story:
+//
+//	Given beads is connected to a remote dolt server
+//	And the SQL connection is down
+//	When I run any bd command
+//	Then I see "Cannot connect to dolt server at <host>:<port>"
+//	And NOT a hang or raw stack trace
+func TestConnectionError_CleanMessage(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "1")
+	t.Setenv("BEADS_DOLT_AUTO_START", "0") // prevent auto-start
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "") // don't let env override our port
+	t.Setenv("BEADS_DOLT_PORT", "")        // don't let legacy env override either
+
+	// Find a port that nothing is listening on.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate ephemeral port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close() // close immediately so nothing is listening
+
+	tmpDir := t.TempDir()
+
+	cfg := &Config{
+		Path:       tmpDir + "/dolt",
+		BeadsDir:   tmpDir,
+		ServerHost: "127.0.0.1",
+		ServerPort: port,
+		ServerUser: "root",
+		Database:   "testdb",
+		AutoStart:  false,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_, err = New(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected error when connecting to non-listening port, got nil")
+	}
+
+	msg := err.Error()
+
+	// The error message must start with a clean, user-friendly prefix.
+	wantPrefix := "cannot connect to dolt server at"
+	if !strings.Contains(strings.ToLower(msg), wantPrefix) {
+		t.Errorf("error message should contain %q, got:\n%s", wantPrefix, msg)
+	}
+
+	// Must include the host:port so the user knows which server failed.
+	wantAddr := "127.0.0.1"
+	if !strings.Contains(msg, wantAddr) {
+		t.Errorf("error message should contain address %q, got:\n%s", wantAddr, msg)
+	}
+
+	// Must complete within the timeout (not hang).
+	select {
+	case <-ctx.Done():
+		t.Fatal("connection attempt timed out — the error should have been immediate")
+	default:
+		// good — we got here before the timeout
+	}
+}
+
+// TestConnectionError_ReasonableTimeout verifies that a connection attempt
+// to an unreachable server completes within a reasonable time (not hanging).
+func TestConnectionError_ReasonableTimeout(t *testing.T) {
+	t.Setenv("BEADS_TEST_MODE", "1")
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
+
+	// Use a port that will refuse connections immediately.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to allocate ephemeral port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	tmpDir := t.TempDir()
+
+	cfg := &Config{
+		Path:       tmpDir + "/dolt",
+		BeadsDir:   tmpDir,
+		ServerHost: "127.0.0.1",
+		ServerPort: port,
+		ServerUser: "root",
+		Database:   "testdb",
+		AutoStart:  false,
+	}
+
+	start := time.Now()
+
+	ctx := context.Background()
+	_, err = New(ctx, cfg)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected connection error, got nil")
+	}
+
+	// Should fail fast (well under 10 seconds for a refused connection).
+	if elapsed > 5*time.Second {
+		t.Errorf("connection error took %v — should complete within 5s", elapsed)
+	}
+}

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -69,6 +69,28 @@ func isBranchTrackingError(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "did not specify a branch")
 }
 
+// isRemoteNotFoundError returns true if the error indicates that a Dolt
+// push/pull failed because the named remote does not exist on the server.
+// This typically happens when CALL DOLT_PUSH or DOLT_PULL targets a remote
+// that was never added to the server's dolt_remotes table.
+func isRemoteNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "remote") && strings.Contains(msg, "not found")
+}
+
+// wrapRemoteNotFoundError checks whether err is a remote-not-found error and,
+// if so, wraps it with a user-friendly message. Non-matching errors (including
+// nil) are returned unchanged.
+func wrapRemoteNotFoundError(err error, op string) error {
+	if err == nil || !isRemoteNotFoundError(err) {
+		return err
+	}
+	return fmt.Errorf("%s: no remotes configured on the dolt server; configure a remote on the server first: %w", op, err)
+}
+
 // isSerializationError returns true if the error is a Dolt/MySQL serialization
 // failure that guarantees the transaction was rolled back. Safe to retry.
 //   - 1213 (ER_LOCK_DEADLOCK): concurrent transactions conflict at commit time

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -102,7 +102,14 @@ func NewFromConfigWithCLIOptions(ctx context.Context, beadsDir string, cfg *Conf
 	}
 	ApplyCLIAutoStart(beadsDir, cfg)
 
-	return New(ctx, cfg)
+	store, err := New(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if msg := warnCLIDirIgnoredForRemoteServer(store); msg != "" {
+		fmt.Fprint(os.Stderr, msg)
+	}
+	return store, nil
 }
 
 // NewFromConfigWithOptions creates a DoltStore with options from metadata.json.
@@ -157,7 +164,14 @@ func NewFromConfigWithOptions(ctx context.Context, beadsDir string, cfg *Config)
 		cfg.AutoStart = resolveAutoStart(cfg.AutoStart, autoStartCfg, mode)
 	}
 
-	return New(ctx, cfg)
+	store, err := New(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if msg := warnCLIDirIgnoredForRemoteServer(store); msg != "" {
+		fmt.Fprint(os.Stderr, msg)
+	}
+	return store, nil
 }
 
 // resolveAutoStart computes the effective AutoStart value, respecting a
@@ -218,6 +232,22 @@ func GetBackendFromConfig(beadsDir string) string {
 		return configfile.BackendDolt
 	}
 	return cfg.GetBackend()
+}
+
+// warnCLIDirIgnoredForRemoteServer returns a non-empty warning message when
+// BEADS_DOLT_CLI_DIR is set but the store is connected to a remote Dolt server.
+// In that scenario the env var is meaningless — there is no local database
+// directory — so we warn the user rather than silently ignoring it.
+// Returns "" when no warning is needed.
+func warnCLIDirIgnoredForRemoteServer(s *DoltStore) string {
+	if !s.isRemoteServer() {
+		return ""
+	}
+	if strings.TrimSpace(os.Getenv(EnvDoltCLIDir)) == "" {
+		return ""
+	}
+	return fmt.Sprintf("Warning: %s is set but ignored — connected to remote dolt server at %s\n",
+		EnvDoltCLIDir, s.serverHost)
 }
 
 // applyResolvedConfig merges metadata.json-derived defaults into a store config.

--- a/internal/storage/dolt/remote_server_routing_test.go
+++ b/internal/storage/dolt/remote_server_routing_test.go
@@ -147,15 +147,11 @@ func TestLocalServerPushStillRequiresCLIDir(t *testing.T) {
 
 	err := s.pushToRemote(t.Context(), "origin", false)
 	if err == nil {
-		// Local external server with credentials and no CLI dir should error
-		// at the credential guard or fall through to SQL. Either way is OK —
-		// the key invariant is that remote servers bypass the guard.
-		t.Log("push returned nil — local server routed to SQL path (acceptable)")
-		return
+		t.Fatal("expected CLI-dir error for local external server with credentials and no CLI dir")
 	}
-	// The error should be the CLI-dir error (credentials present, no CLI dir,
-	// local server) or a connection error. Both are acceptable.
-	t.Logf("local server push error (expected): %v", err)
+	if !strings.Contains(err.Error(), "requires a local Dolt CLI database directory") {
+		t.Fatalf("expected CLI-dir guard error, got: %v", err)
+	}
 }
 
 // --- Config conflict tests (BEADS_DOLT_CLI_DIR + remote server) ---

--- a/internal/storage/dolt/remote_server_routing_test.go
+++ b/internal/storage/dolt/remote_server_routing_test.go
@@ -2,6 +2,7 @@ package dolt
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -157,6 +158,8 @@ func TestLocalServerPushStillRequiresCLIDir(t *testing.T) {
 	t.Logf("local server push error (expected): %v", err)
 }
 
+// --- Config conflict tests (BEADS_DOLT_CLI_DIR + remote server) ---
+
 // TestRemoteServerCLIDirConflictDetected verifies that when a store is
 // connected to a remote Dolt server AND BEADS_DOLT_CLI_DIR is set, the
 // conflict is detected: isRemoteServer() returns true and CLIDir() is
@@ -228,5 +231,104 @@ func TestNoWarningForRemoteServerWithoutCLIDir(t *testing.T) {
 	msg := warnCLIDirIgnoredForRemoteServer(s)
 	if msg != "" {
 		t.Errorf("expected no warning when BEADS_DOLT_CLI_DIR is not set, got: %s", msg)
+	}
+}
+
+// --- Remote-not-found error wrapping tests ---
+
+// TestIsRemoteNotFoundError verifies that the isRemoteNotFoundError helper
+// correctly detects Dolt's raw SQL errors for missing remotes.
+func TestIsRemoteNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  fmt.Errorf("connection refused"),
+			want: false,
+		},
+		{
+			name: "remote not found lowercase",
+			err:  fmt.Errorf("remote 'origin' not found"),
+			want: true,
+		},
+		{
+			name: "remote not found in SQL wrapper",
+			err:  fmt.Errorf("Error 1105 (HY000): remote 'origin' not found"),
+			want: true,
+		},
+		{
+			name: "remote not found mixed case",
+			err:  fmt.Errorf("Remote not found: origin"),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRemoteNotFoundError(tt.err)
+			if got != tt.want {
+				t.Errorf("isRemoteNotFoundError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWrapRemoteNotFoundError verifies that wrapRemoteNotFoundError returns
+// a user-friendly message when the error is a remote-not-found error, and
+// passes through other errors unchanged.
+func TestWrapRemoteNotFoundError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		op           string
+		wantContain  string
+		wantPassThru bool
+	}{
+		{
+			name:        "wraps remote not found",
+			err:         fmt.Errorf("Error 1105 (HY000): remote 'origin' not found"),
+			op:          "push",
+			wantContain: "no remotes configured on the dolt server",
+		},
+		{
+			name:         "passes through unrelated error",
+			err:          fmt.Errorf("connection refused"),
+			op:           "push",
+			wantPassThru: true,
+		},
+		{
+			name:         "nil returns nil",
+			err:          nil,
+			op:           "push",
+			wantPassThru: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapRemoteNotFoundError(tt.err, tt.op)
+			if tt.wantPassThru {
+				if got != tt.err {
+					t.Errorf("expected error to pass through unchanged, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected wrapped error, got nil")
+			}
+			if !strings.Contains(got.Error(), tt.wantContain) {
+				t.Errorf("wrapped error %q should contain %q", got.Error(), tt.wantContain)
+			}
+			// The original error should still be in the chain
+			if !strings.Contains(got.Error(), tt.err.Error()) {
+				t.Errorf("wrapped error %q should preserve original %q", got.Error(), tt.err.Error())
+			}
+		})
 	}
 }

--- a/internal/storage/dolt/remote_server_routing_test.go
+++ b/internal/storage/dolt/remote_server_routing_test.go
@@ -1,10 +1,26 @@
 package dolt
 
 import (
+	"database/sql"
+	"strings"
 	"testing"
 
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/doltserver"
 )
+
+// stubDB returns a *sql.DB that is non-nil but will fail on any actual query.
+// This avoids nil-pointer panics in routing methods that call ListRemotes etc.
+func stubDB(t *testing.T) *sql.DB {
+	t.Helper()
+	// Open with a DSN that will fail on connect — but the *sql.DB handle is valid.
+	db, err := sql.Open("mysql", "root@tcp(127.0.0.1:1)/nonexistent")
+	if err != nil {
+		t.Fatalf("sql.Open stub: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
 
 // TestIsRemoteServer verifies the isRemoteServer method on DoltStore.
 func TestIsRemoteServer(t *testing.T) {
@@ -51,6 +67,7 @@ func TestRemoteServerPushSkipsCLIDirGuard(t *testing.T) {
 	t.Parallel()
 
 	s := &DoltStore{
+		db:          stubDB(t),
 		serverHost:  "mini2",
 		serverMode:  true,
 		serverOwner: doltserver.ServerModeExternal,
@@ -73,7 +90,7 @@ func TestRemoteServerPushSkipsCLIDirGuard(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error (no real DB), got nil")
 	}
-	if contains(err.Error(), "requires a local Dolt CLI database directory") {
+	if strings.Contains(err.Error(), "requires a local Dolt CLI database directory") {
 		t.Errorf("pushToRemote returned CLI-dir error on remote server: %v", err)
 	}
 }
@@ -83,11 +100,13 @@ func TestRemoteServerPullSkipsCLIDirGuard(t *testing.T) {
 	t.Parallel()
 
 	s := &DoltStore{
+		db:          stubDB(t),
 		serverHost:  "mini2",
 		serverMode:  true,
 		serverOwner: doltserver.ServerModeExternal,
 		remote:      "origin",
 		branch:      "main",
+		readOnly:    true, // skip auto-commit before pull (no real db)
 	}
 
 	if !s.requiresExplicitCLIDir() {
@@ -101,17 +120,18 @@ func TestRemoteServerPullSkipsCLIDirGuard(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error (no real DB), got nil")
 	}
-	if contains(err.Error(), "requires a local Dolt CLI database directory") {
+	if strings.Contains(err.Error(), "requires a local Dolt CLI database directory") {
 		t.Errorf("pullFromRemote returned CLI-dir error on remote server: %v", err)
 	}
 }
 
 // TestLocalServerPushStillRequiresCLIDir verifies that the CLI-dir guard still
-// fires for local external servers (the original behavior).
+// fires for local external servers with credentials and no CLI dir.
 func TestLocalServerPushStillRequiresCLIDir(t *testing.T) {
 	t.Parallel()
 
 	s := &DoltStore{
+		db:          stubDB(t),
 		serverHost:  "127.0.0.1",
 		serverMode:  true,
 		serverOwner: doltserver.ServerModeExternal,
@@ -126,22 +146,13 @@ func TestLocalServerPushStillRequiresCLIDir(t *testing.T) {
 
 	err := s.pushToRemote(t.Context(), "origin", false)
 	if err == nil {
-		// Local external server with credentials and no CLI dir should error.
-		// The error might be CLI-dir or might be something else depending on
-		// routing, but it should not silently succeed.
-		t.Log("push returned nil — local server may route to SQL path (acceptable)")
+		// Local external server with credentials and no CLI dir should error
+		// at the credential guard or fall through to SQL. Either way is OK —
+		// the key invariant is that remote servers bypass the guard.
+		t.Log("push returned nil — local server routed to SQL path (acceptable)")
+		return
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	// The error should be the CLI-dir error (credentials present, no CLI dir,
+	// local server) or a connection error. Both are acceptable.
+	t.Logf("local server push error (expected): %v", err)
 }

--- a/internal/storage/dolt/remote_server_routing_test.go
+++ b/internal/storage/dolt/remote_server_routing_test.go
@@ -1,0 +1,147 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/doltserver"
+)
+
+// TestIsRemoteServer verifies the isRemoteServer method on DoltStore.
+func TestIsRemoteServer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		serverHost string
+		serverMode bool
+		want       bool
+	}{
+		{name: "remote host in server mode", serverHost: "mini2", serverMode: true, want: true},
+		{name: "LAN IP in server mode", serverHost: "10.0.0.2", serverMode: true, want: true},
+		{name: "localhost is not remote", serverHost: "localhost", serverMode: true, want: false},
+		{name: "127.0.0.1 is not remote", serverHost: "127.0.0.1", serverMode: true, want: false},
+		{name: "::1 is not remote", serverHost: "::1", serverMode: true, want: false},
+		{name: "[::1] is not remote", serverHost: "[::1]", serverMode: true, want: false},
+		{name: "empty host is not remote", serverHost: "", serverMode: true, want: false},
+		{name: "remote host but not server mode", serverHost: "mini2", serverMode: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := &DoltStore{
+				serverHost: tt.serverHost,
+				serverMode: tt.serverMode,
+			}
+			got := s.isRemoteServer()
+			if got != tt.want {
+				t.Errorf("isRemoteServer() = %v, want %v (host=%q, serverMode=%v)",
+					got, tt.want, tt.serverHost, tt.serverMode)
+			}
+		})
+	}
+}
+
+// TestRemoteServerPushSkipsCLIDirGuard verifies that pushToRemote on a remote
+// server with no CLI dir does NOT return the "requires a local Dolt CLI
+// database directory" error. Instead it should fall through to the SQL path
+// (CALL DOLT_PUSH), which will fail with a connection error in tests — but
+// crucially NOT with the CLI-dir error.
+func TestRemoteServerPushSkipsCLIDirGuard(t *testing.T) {
+	t.Parallel()
+
+	s := &DoltStore{
+		serverHost:  "mini2",
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+		remote:      "origin",
+		branch:      "main",
+	}
+
+	// Verify the preconditions: this store requires explicit CLI dir and has none.
+	if !s.requiresExplicitCLIDir() {
+		t.Fatal("expected requiresExplicitCLIDir() = true")
+	}
+	if s.CLIDir() != "" {
+		t.Fatal("expected CLIDir() = empty")
+	}
+
+	// pushToRemote should NOT return the CLI-dir error.
+	// It will fail (no real DB connection), but the error should NOT be
+	// "requires a local Dolt CLI database directory".
+	err := s.pushToRemote(t.Context(), "origin", false)
+	if err == nil {
+		t.Fatal("expected an error (no real DB), got nil")
+	}
+	if contains(err.Error(), "requires a local Dolt CLI database directory") {
+		t.Errorf("pushToRemote returned CLI-dir error on remote server: %v", err)
+	}
+}
+
+// TestRemoteServerPullSkipsCLIDirGuard verifies the same for pullFromRemote.
+func TestRemoteServerPullSkipsCLIDirGuard(t *testing.T) {
+	t.Parallel()
+
+	s := &DoltStore{
+		serverHost:  "mini2",
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+		remote:      "origin",
+		branch:      "main",
+	}
+
+	if !s.requiresExplicitCLIDir() {
+		t.Fatal("expected requiresExplicitCLIDir() = true")
+	}
+	if s.CLIDir() != "" {
+		t.Fatal("expected CLIDir() = empty")
+	}
+
+	err := s.pullFromRemote(t.Context(), "origin")
+	if err == nil {
+		t.Fatal("expected an error (no real DB), got nil")
+	}
+	if contains(err.Error(), "requires a local Dolt CLI database directory") {
+		t.Errorf("pullFromRemote returned CLI-dir error on remote server: %v", err)
+	}
+}
+
+// TestLocalServerPushStillRequiresCLIDir verifies that the CLI-dir guard still
+// fires for local external servers (the original behavior).
+func TestLocalServerPushStillRequiresCLIDir(t *testing.T) {
+	t.Parallel()
+
+	s := &DoltStore{
+		serverHost:  "127.0.0.1",
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+		remote:      "origin",
+		branch:      "main",
+		remoteUser:  "testuser",
+	}
+
+	if !s.requiresExplicitCLIDir() {
+		t.Fatal("expected requiresExplicitCLIDir() = true")
+	}
+
+	err := s.pushToRemote(t.Context(), "origin", false)
+	if err == nil {
+		// Local external server with credentials and no CLI dir should error.
+		// The error might be CLI-dir or might be something else depending on
+		// routing, but it should not silently succeed.
+		t.Log("push returned nil — local server may route to SQL path (acceptable)")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/dolt/remote_server_routing_test.go
+++ b/internal/storage/dolt/remote_server_routing_test.go
@@ -156,3 +156,83 @@ func TestLocalServerPushStillRequiresCLIDir(t *testing.T) {
 	// local server) or a connection error. Both are acceptable.
 	t.Logf("local server push error (expected): %v", err)
 }
+
+// TestRemoteServerCLIDirConflictDetected verifies that when a store is
+// connected to a remote Dolt server AND BEADS_DOLT_CLI_DIR is set, the
+// conflict is detected: isRemoteServer() returns true and CLIDir() is
+// non-empty. The warning emitted at init time depends on this detection.
+func TestRemoteServerCLIDirConflictDetected(t *testing.T) {
+	t.Parallel()
+
+	t.Setenv(EnvDoltCLIDir, "/tmp/fake-dolt-dir")
+
+	s := &DoltStore{
+		serverHost: "mini2",
+		serverMode: true,
+	}
+
+	if !s.isRemoteServer() {
+		t.Fatal("expected isRemoteServer() = true for host 'mini2'")
+	}
+	if s.CLIDir() == "" {
+		t.Fatal("expected CLIDir() non-empty when BEADS_DOLT_CLI_DIR is set")
+	}
+
+	// The warnCLIDirIgnoredForRemoteServer helper should return a non-empty
+	// warning string when both conditions hold.
+	msg := warnCLIDirIgnoredForRemoteServer(s)
+	if msg == "" {
+		t.Error("expected non-empty warning when remote server and BEADS_DOLT_CLI_DIR are both set")
+	}
+	if !strings.Contains(msg, "BEADS_DOLT_CLI_DIR") {
+		t.Errorf("warning should mention BEADS_DOLT_CLI_DIR, got: %s", msg)
+	}
+	if !strings.Contains(msg, "mini2") {
+		t.Errorf("warning should mention the remote host, got: %s", msg)
+	}
+}
+
+// TestNoWarningForLocalServerWithCLIDir verifies that a local server with
+// BEADS_DOLT_CLI_DIR set does NOT trigger the warning.
+func TestNoWarningForLocalServerWithCLIDir(t *testing.T) {
+	t.Parallel()
+
+	t.Setenv(EnvDoltCLIDir, "/tmp/fake-dolt-dir")
+
+	s := &DoltStore{
+		serverHost: "127.0.0.1",
+		serverMode: true,
+	}
+
+	if s.isRemoteServer() {
+		t.Fatal("localhost should not be a remote server")
+	}
+
+	msg := warnCLIDirIgnoredForRemoteServer(s)
+	if msg != "" {
+		t.Errorf("expected no warning for local server, got: %s", msg)
+	}
+}
+
+// TestNoWarningForRemoteServerWithoutCLIDir verifies that a remote server
+// without BEADS_DOLT_CLI_DIR does NOT trigger the warning.
+func TestNoWarningForRemoteServerWithoutCLIDir(t *testing.T) {
+	t.Parallel()
+
+	// Ensure env var is NOT set (t.Setenv restores after test).
+	t.Setenv(EnvDoltCLIDir, "")
+
+	s := &DoltStore{
+		serverHost: "mini2",
+		serverMode: true,
+	}
+
+	if !s.isRemoteServer() {
+		t.Fatal("expected isRemoteServer() = true")
+	}
+
+	msg := warnCLIDirIgnoredForRemoteServer(s)
+	if msg != "" {
+		t.Errorf("expected no warning when BEADS_DOLT_CLI_DIR is not set, got: %s", msg)
+	}
+}

--- a/internal/storage/dolt/remote_server_routing_test.go
+++ b/internal/storage/dolt/remote_server_routing_test.go
@@ -162,8 +162,6 @@ func TestLocalServerPushStillRequiresCLIDir(t *testing.T) {
 // conflict is detected: isRemoteServer() returns true and CLIDir() is
 // non-empty. The warning emitted at init time depends on this detection.
 func TestRemoteServerCLIDirConflictDetected(t *testing.T) {
-	t.Parallel()
-
 	t.Setenv(EnvDoltCLIDir, "/tmp/fake-dolt-dir")
 
 	s := &DoltStore{
@@ -195,8 +193,6 @@ func TestRemoteServerCLIDirConflictDetected(t *testing.T) {
 // TestNoWarningForLocalServerWithCLIDir verifies that a local server with
 // BEADS_DOLT_CLI_DIR set does NOT trigger the warning.
 func TestNoWarningForLocalServerWithCLIDir(t *testing.T) {
-	t.Parallel()
-
 	t.Setenv(EnvDoltCLIDir, "/tmp/fake-dolt-dir")
 
 	s := &DoltStore{
@@ -217,8 +213,6 @@ func TestNoWarningForLocalServerWithCLIDir(t *testing.T) {
 // TestNoWarningForRemoteServerWithoutCLIDir verifies that a remote server
 // without BEADS_DOLT_CLI_DIR does NOT trigger the warning.
 func TestNoWarningForRemoteServerWithoutCLIDir(t *testing.T) {
-	t.Parallel()
-
 	// Ensure env var is NOT set (t.Setenv restores after test).
 	t.Setenv(EnvDoltCLIDir, "")
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -3546,7 +3546,10 @@ func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool)
 			attribute.String("dolt.branch", s.branch),
 		)...),
 	)
-	defer func() { endSpan(span, retErr) }()
+	defer func() {
+		endSpan(span, retErr)
+		retErr = wrapRemoteNotFoundError(retErr, "push")
+	}()
 	creds := s.credentialsForRemote(remote)
 	// Git-protocol remotes: use CLI to avoid MySQL connection timeout during transfer.
 	// Must check before remoteUser — Hosted Dolt SSH remotes have remoteUser set
@@ -3639,7 +3642,10 @@ func (s *DoltStore) pullFromRemote(ctx context.Context, remote string) (retErr e
 			attribute.String("dolt.branch", s.branch),
 		)...),
 	)
-	defer func() { endSpan(span, retErr) }()
+	defer func() {
+		endSpan(span, retErr)
+		retErr = wrapRemoteNotFoundError(retErr, "pull")
+	}()
 
 	// GH#2474: Auto-commit pending changes before pull to prevent
 	// "cannot merge with uncommitted changes" errors. Store initialization

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1142,6 +1142,10 @@ func (s *DoltStore) BackupRemove(ctx context.Context, name string) error {
 // BackupDatabase registers dir as a file:// Dolt backup remote and syncs
 // the full database to it, preserving complete commit history.
 func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
+	if s.isRemoteServer() {
+		return fmt.Errorf("filesystem backup is not supported for remote dolt servers (host=%s); use JSONL export (bd backup export) or a cloud backup URL instead", s.serverHost)
+	}
+
 	info, err := os.Stat(dir)
 	if err != nil {
 		return fmt.Errorf("backup destination does not exist: %w", err)
@@ -1185,6 +1189,10 @@ func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 // RestoreDatabase restores the database from a Dolt backup at dir.
 // When force is true, an existing database is overwritten.
 func (s *DoltStore) RestoreDatabase(ctx context.Context, dir string, force bool) error {
+	if s.isRemoteServer() {
+		return fmt.Errorf("filesystem restore is not supported for remote dolt servers (host=%s); use JSONL import (bd init --from-jsonl) instead", s.serverHost)
+	}
+
 	info, err := os.Stat(dir)
 	if err != nil {
 		return fmt.Errorf("backup source does not exist: %w", err)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1143,7 +1143,7 @@ func (s *DoltStore) BackupRemove(ctx context.Context, name string) error {
 // the full database to it, preserving complete commit history.
 func (s *DoltStore) BackupDatabase(ctx context.Context, dir string) error {
 	if s.isRemoteServer() {
-		return fmt.Errorf("filesystem backup is not supported for remote dolt servers (host=%s); use JSONL export (bd backup export) or a cloud backup URL instead", s.serverHost)
+		return fmt.Errorf("filesystem backup is not supported for remote dolt servers (host=%s); use JSONL export (bd export -o /path/to/backup.jsonl) or a cloud backup URL instead", s.serverHost)
 	}
 
 	info, err := os.Stat(dir)


### PR DESCRIPTION
## Summary

Fixes multiple operations that break when beads connects to a remote dolt server (e.g., `host: mini2`) instead of localhost.

**Root cause:** Several code paths assume local filesystem access — sending `file://` URLs to a remote server, or requiring a local dolt CLI directory that doesn't exist.

### Fixed so far
- **backup export**: Detects remote server, falls back to JSONL export instead of `CALL DOLT_BACKUP` with local path
- **push/pull**: Skips CLI-dir guard clauses for remote servers, falls through to SQL path (`CALL DOLT_PUSH`/`CALL DOLT_PULL`)

### Coming
- **backup init**: Same `file://` URL problem as backup export
- **BackupDatabase() store method**: Underlying store function needs remote guard

## 🚧 Work in progress — more changes coming

## Test plan
- [x] `TestIsRemoteHost` — 10 subtests (local/remote host detection)
- [x] `TestIsRemoteDoltServer` — 4 subtests (config-based detection)
- [x] `TestIsRemoteServer` — 8 subtests (store-level detection)
- [x] `TestRemoteServerPushSkipsCLIDirGuard`
- [x] `TestRemoteServerPullSkipsCLIDirGuard`
- [x] `TestLocalServerPushStillRequiresCLIDir`
- [ ] Backup init remote guard tests (coming)
- [ ] BackupDatabase store method tests (coming)