### PR TITLE
fix(sync): add --no-verify to commitBeadsConfig auto-commit (GH#3598)

### DIFF
--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -35,12 +35,17 @@ func resolveSyncRemoteFromDir(beadsDir string) string {
 // Silently no-ops if the file is clean or the commit fails (e.g. hooks,
 // nothing to commit). Used by bd dolt remote add/remove to keep the
 // working tree clean after persisting sync.remote.
+//
+// Uses --no-verify so the bd-installed pre-commit hook can't re-enter
+// `bd export` and deadlock on the embedded Dolt lock the caller is
+// still holding. Same shape as the bootstrap-commit fix in PR #3457
+// (GH#3437); see GH#3598 for the bd dolt remote add reproduction.
 func commitBeadsConfig(msg string) {
 	addCmd := exec.Command("git", "add", ".beads/config.yaml")
 	if err := addCmd.Run(); err != nil {
 		return
 	}
-	commitCmd := exec.Command("git", "commit", "-m", msg) //nolint:gosec // G702: msg is from internal callers only, not user input
+	commitCmd := exec.Command("git", "commit", "--no-verify", "-m", msg) //nolint:gosec // G702: msg is from internal callers only, not user input
 	if out, err := commitCmd.CombinedOutput(); err != nil {
 		// "nothing to commit" is normal if the file was already staged
 		if !strings.Contains(string(out), "nothing to commit") {

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -36,10 +36,21 @@ func resolveSyncRemoteFromDir(beadsDir string) string {
 // nothing to commit). Used by bd dolt remote add/remove to keep the
 // working tree clean after persisting sync.remote.
 //
-// Uses --no-verify so the bd-installed pre-commit hook can't re-enter
-// `bd export` and deadlock on the embedded Dolt lock the caller is
-// still holding. Same shape as the bootstrap-commit fix in PR #3457
-// (GH#3437); see GH#3598 for the bd dolt remote add reproduction.
+// Uses --no-verify so neither the bd-installed pre-commit hook nor any
+// commit-msg hook can re-enter `bd export` and deadlock on the embedded
+// Dolt lock the caller is still holding. Same shape as the
+// bootstrap-commit fix in PR #3457 (GH#3437); see GH#3598 for the
+// bd dolt remote add reproduction.
+//
+// Caveats:
+//   - --no-verify bypasses pre-commit and commit-msg hooks only; GPG
+//     signing (commit.gpgSign=true) is unaffected. A repo with required
+//     signing and no usable key will still surface as a "Warning:
+//     failed to commit config change" rather than a deadlock.
+//   - The "nothing to commit" string match below is git's
+//     English-locale phrasing. Translated git binaries would surface
+//     the message as a warning instead of being suppressed; harmless
+//     and pre-existing.
 func commitBeadsConfig(msg string) {
 	addCmd := exec.Command("git", "add", ".beads/config.yaml")
 	if err := addCmd.Run(); err != nil {

--- a/cmd/bd/sync_remote_test.go
+++ b/cmd/bd/sync_remote_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
 
 func TestNormalizeRemoteURL(t *testing.T) {
 	tests := []struct {
@@ -34,5 +41,62 @@ func TestNormalizeRemoteURL(t *testing.T) {
 				t.Errorf("normalizeRemoteURL(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestCommitBeadsConfigBypassesHooks verifies that the auto-commit
+// fired by bd dolt remote add (and any other caller of commitBeadsConfig)
+// runs `git commit --no-verify`, so a bd-installed pre-commit hook can't
+// re-enter `bd export` and deadlock on the embedded Dolt lock the parent
+// is still holding. Mirrors the PR #3457 fix at the bd init bootstrap
+// commit site. See GH#3598.
+func TestCommitBeadsConfigBypassesHooks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell hook not portable to Windows")
+	}
+
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("sync.remote: \"file:///tmp/x\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	preCommitPath := filepath.Join(dir, ".git", "hooks", "pre-commit")
+	preCommit := "#!/bin/sh\necho hook-fired >> .hook-ran\nexit 1\n"
+	if err := os.WriteFile(preCommitPath, []byte(preCommit), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(dir)
+
+	commitBeadsConfig("bd: update sync.remote")
+
+	if _, err := os.Stat(filepath.Join(dir, ".hook-ran")); err == nil {
+		t.Fatal("expected commitBeadsConfig to bypass git pre-commit hook (GH#3598)")
+	}
+
+	logCmd := exec.Command("git", "log", "--oneline", "-n", "1")
+	logCmd.Dir = dir
+	logOut, err := logCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log failed: %v\n%s", err, logOut)
+	}
+	if !strings.Contains(string(logOut), "bd: update sync.remote") {
+		t.Fatalf("expected commit to succeed despite hostile hook, got log: %s", logOut)
 	}
 }

--- a/cmd/bd/sync_remote_test.go
+++ b/cmd/bd/sync_remote_test.go
@@ -44,22 +44,23 @@ func TestNormalizeRemoteURL(t *testing.T) {
 	}
 }
 
-// TestCommitBeadsConfigBypassesHooks verifies that the auto-commit
-// fired by bd dolt remote add (and any other caller of commitBeadsConfig)
-// runs `git commit --no-verify`, so a bd-installed pre-commit hook can't
-// re-enter `bd export` and deadlock on the embedded Dolt lock the parent
-// is still holding. Mirrors the PR #3457 fix at the bd init bootstrap
-// commit site. See GH#3598.
-func TestCommitBeadsConfigBypassesHooks(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX shell hook not portable to Windows")
-	}
-
+// setupHostileHookRepo creates a git repo at a fresh temp dir with
+// .beads/config.yaml staged and the named hook scripts installed under
+// .git/hooks. Each hook writes its name to a marker file (".<name>-ran")
+// and exits 1, so a successful commit proves the hook was bypassed.
+// Returns the repo dir.
+func setupHostileHookRepo(t *testing.T, hooks ...string) string {
+	t.Helper()
 	dir := t.TempDir()
 	for _, args := range [][]string{
 		{"init"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "Test"},
+		// Disable any signing the user may have inherited from their
+		// global config — --no-verify does NOT bypass commit.gpgSign,
+		// and a missing key would surface as a generic commit failure.
+		{"config", "commit.gpgSign", "false"},
+		{"config", "tag.gpgSign", "false"},
 	} {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
@@ -76,18 +77,41 @@ func TestCommitBeadsConfigBypassesHooks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	preCommitPath := filepath.Join(dir, ".git", "hooks", "pre-commit")
-	preCommit := "#!/bin/sh\necho hook-fired >> .hook-ran\nexit 1\n"
-	if err := os.WriteFile(preCommitPath, []byte(preCommit), 0o755); err != nil {
-		t.Fatal(err)
+	for _, hook := range hooks {
+		path := filepath.Join(dir, ".git", "hooks", hook)
+		body := "#!/bin/sh\necho fired >> ." + hook + "-ran\nexit 1\n"
+		if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// TestCommitBeadsConfigBypassesHooks verifies that the auto-commit
+// fired by bd dolt remote add (and any other caller of commitBeadsConfig)
+// runs `git commit --no-verify`, so neither a bd-installed pre-commit hook
+// nor a commit-msg hook can re-enter `bd export` and deadlock on the
+// embedded Dolt lock the parent is still holding. Mirrors the PR #3457
+// fix at the bd init bootstrap commit site. See GH#3598.
+//
+// Covers both hook types because `--no-verify` is documented to bypass
+// pre-commit AND commit-msg; pinning both prevents a future change from
+// silently regressing one while leaving the other guarded.
+func TestCommitBeadsConfigBypassesHooks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell hook not portable to Windows")
 	}
 
+	dir := setupHostileHookRepo(t, "pre-commit", "commit-msg")
 	t.Chdir(dir)
 
 	commitBeadsConfig("bd: update sync.remote")
 
-	if _, err := os.Stat(filepath.Join(dir, ".hook-ran")); err == nil {
-		t.Fatal("expected commitBeadsConfig to bypass git pre-commit hook (GH#3598)")
+	for _, hook := range []string{"pre-commit", "commit-msg"} {
+		marker := filepath.Join(dir, "."+hook+"-ran")
+		if _, err := os.Stat(marker); err == nil {
+			t.Errorf("expected commitBeadsConfig to bypass %s hook (GH#3598)", hook)
+		}
 	}
 
 	logCmd := exec.Command("git", "log", "--oneline", "-n", "1")
@@ -97,6 +121,34 @@ func TestCommitBeadsConfigBypassesHooks(t *testing.T) {
 		t.Fatalf("git log failed: %v\n%s", err, logOut)
 	}
 	if !strings.Contains(string(logOut), "bd: update sync.remote") {
-		t.Fatalf("expected commit to succeed despite hostile hook, got log: %s", logOut)
+		t.Fatalf("expected commit to succeed despite hostile hooks, got log: %s", logOut)
+	}
+}
+
+// TestCommitBeadsConfigIsIdempotent verifies that calling
+// commitBeadsConfig a second time with no further changes is a silent
+// no-op (the "nothing to commit" branch). bd dolt remote add can be
+// re-invoked with the same URL; a noisy warning each time would be a
+// UX regression and a flaky-CI hazard.
+func TestCommitBeadsConfigIsIdempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell hook not portable to Windows")
+	}
+
+	dir := setupHostileHookRepo(t)
+	t.Chdir(dir)
+
+	commitBeadsConfig("bd: update sync.remote")
+	commitBeadsConfig("bd: update sync.remote") // second call: nothing to commit
+
+	logCmd := exec.Command("git", "log", "--oneline")
+	logCmd.Dir = dir
+	logOut, err := logCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log failed: %v\n%s", err, logOut)
+	}
+	commits := strings.Count(strings.TrimSpace(string(logOut)), "\n") + 1
+	if commits != 1 {
+		t.Fatalf("expected exactly 1 commit after two calls, got %d:\n%s", commits, logOut)
 	}
 }


### PR DESCRIPTION
Fixes #3598.

## Summary

Mirrors PR #3457's pattern at the other bd-internal `git commit` site. PR #3457 added `--no-verify` to `bd init`'s bootstrap commit so the just-installed pre-commit hook couldn't re-enter `bd export` while the parent process still held the embedded-Dolt lock. The same root cause — bd-internal commit while holding the lock — re-fires from `commitBeadsConfig` (`cmd/bd/sync_remote.go`), which is the auto-commit path used by `bd dolt remote add` (and `bd dolt remote remove`) after persisting `sync.remote` to `.beads/config.yaml`.

On stock macOS without GNU `coreutils` on `PATH` (the default), the hook wrapper's `BEADS_HOOK_TIMEOUT=2` escape hatch falls through to the un-timed branch and the parent `bd dolt remote add` hangs forever:

```
bd dolt remote add origin git+ssh://...   [holds .beads/embeddeddolt/.lock]
  └─ git commit -m "bd: update sync.remote"
      └─ .beads/hooks/pre-commit  →  bd hooks run pre-commit
          └─ bd export …            [waits forever on the same lock]
```

## What this PR does

One-liner in the same shape as PR #3457: insert `--no-verify` into the `git commit` invocation inside `commitBeadsConfig`, plus a doc-comment edit explaining the why and a backref to the prior PR / issue.

```go
// before
commitCmd := exec.Command("git", "commit", "-m", msg)

// after
commitCmd := exec.Command("git", "commit", "--no-verify", "-m", msg)
```

This covers both call sites of `commitBeadsConfig` (in `cmd/bd/dolt.go`):

- `bd dolt remote add origin <url>` — the issue's primary repro.
- `bd dolt remote remove origin` — same auto-commit path; also fixed.

The issue body also mentions `bd config set`. I traced its yaml-only branch (`cmd/bd/config.go` → `config.SetYamlConfig`) and it does **not** currently fire a git commit on its own — it just rewrites `config.yaml` and returns. So no second commit site needs changing today; if a future patch adds an auto-commit there, the safe pattern is to route it through `commitBeadsConfig` (now bypass-by-default) rather than re-rolling a raw `git commit`.

## Tests

`cmd/bd/sync_remote_test.go` adds **`TestCommitBeadsConfigBypassesHooks`** — same shape as the `auto_commit_bypasses_hooks` subtest PR #3457 added to `TestEmbeddedInit`:

- Sets up a temp git repo, writes `.beads/config.yaml`.
- Installs a hostile `.git/hooks/pre-commit` that writes a marker file and `exit 1`.
- Calls `commitBeadsConfig("bd: update sync.remote")` directly.
- Verifies (a) the marker file does **not** exist (hook bypassed) **and** (b) `git log` shows the commit succeeded.

Without the `--no-verify` change, the test fails on both assertions: the hook fires (creating the marker) and the commit aborts because the hook returned non-zero.

```
$ go test -tags gms_pure_go -run 'TestCommitBeadsConfigBypassesHooks|TestNormalizeRemoteURL' ./cmd/bd/ -v
=== RUN   TestNormalizeRemoteURL
--- PASS: TestNormalizeRemoteURL (0.00s)
... (13 sub-cases all pass)
=== RUN   TestCommitBeadsConfigBypassesHooks
--- PASS: TestCommitBeadsConfigBypassesHooks (0.04s)
PASS
ok  	github.com/steveyegge/beads/cmd/bd	1.116s
```

Broader hook+commit related tests (Inject, Marker, Sanitize, Preserve, NormalizeRemoteURL) all pass:

```
$ go test -tags gms_pure_go -short -run 'CommitBeadsConfig|NormalizeRemoteURL|Inject|Marker|Sanitize|Preserve' ./cmd/bd/
ok  	github.com/steveyegge/beads/cmd/bd	71.908s
```

Linter clean on the diff with the build tag CONTRIBUTING.md documents:

```
$ golangci-lint run --new-from-rev=main --build-tags=gms_pure_go ./cmd/bd/
0 issues.
```

(Note: `TestCheckHooksDriftNotGitRepo` fails when run with the broader `Sync|Remote|Hook|hook` selection on `main` as well — pre-existing test-ordering bug unrelated to this PR. Verified by stash-and-rerun on the unmodified main.)

## Out of scope

- Auditing every other `exec.Command("git", "commit", ...)` callsite in the tree for the same hook-while-locked exposure. The known sites are `bd init` (already fixed in PR #3457) and `commitBeadsConfig` (this PR). `init_contributor.go` runs only inside `bd init --contributor` against a freshly-`git init`-ed planning repo where no bd hooks exist yet.
- Wrapping config-yaml writes from `bd config set` in a `commitBeadsConfig` auto-commit. That's a behavior change (introducing a new commit), not a bug fix — out of scope per CONTRIBUTING.md's "one issue per PR" rule.

## Test plan

- [ ] CI passes (linter, tests, build matrix).
- [ ] On stock macOS without `gtimeout`/`timeout` on `PATH`: in a fresh repo, run `bd init --non-interactive --role=maintainer` then `bd dolt remote add origin "git+ssh://git@github.com/me/test.git"` — should return immediately rather than hanging. `git log -1` should show `bd: update sync.remote`.
- [ ] On the same repo, `bd dolt remote remove origin` should also return immediately and produce `bd: clear sync.remote` in `git log`.

## Related

- #3335 — `bd init --from-jsonl` deadlock (closed by #3342)
- #3437 — embedded-lock re-entry on plain `bd init`
- #3457 — added `--no-verify` to `bd init`'s bootstrap commit (this PR is the same fix at a sibling commit site)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->