### PR TITLE
doctor: detect AGENTS.md / CLAUDE.md user-authored divergence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,14 @@
 # Agent Instructions
 
+<!-- bd-doctor-divergence: ok -->
+
 See [AGENT_INSTRUCTIONS.md](AGENT_INSTRUCTIONS.md) for full instructions.
 
 This file exists for compatibility with tools that look for AGENTS.md.
+
+The marker above tells `bd doctor` that the intentional divergence between
+this file and `CLAUDE.md` (different audiences, different reading orders) is
+expected and should not be flagged.
 
 ## Key Sections
 

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -632,6 +632,11 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, agentDocsCheck)
 	// Don't fail overall check for missing docs, just warn
 
+	// Check 12a: AGENTS.md / CLAUDE.md user-authored divergence
+	agentDocDivergenceCheck := convertWithCategory(doctor.CheckAgentDocDivergence(path), doctor.CategoryIntegration)
+	result.Checks = append(result.Checks, agentDocDivergenceCheck)
+	// Don't fail overall check for divergence, just warn
+
 	// Check 13: Legacy beads slash commands in documentation
 	legacyDocsCheck := convertWithCategory(doctor.CheckLegacyBeadsSlashCommands(path), doctor.CategoryMetadata)
 	result.Checks = append(result.Checks, legacyDocsCheck)

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -190,6 +190,178 @@ func CheckAgentDocumentation(repoPath string) DoctorCheck {
 	}
 }
 
+// stripBeadsIntegrationSection removes the <!-- BEGIN BEADS INTEGRATION ... -->
+// ... <!-- END BEADS INTEGRATION --> block (plus an optional trailing newline)
+// so the remaining content represents user-authored material. Returns the input
+// unchanged if no well-formed marker pair is found.
+func stripBeadsIntegrationSection(content string) string {
+	const beginPrefix = "<!-- BEGIN BEADS INTEGRATION"
+	const endMarker = "<!-- END BEADS INTEGRATION -->"
+
+	beginIdx := strings.Index(content, beginPrefix)
+	if beginIdx == -1 {
+		return content
+	}
+	endIdx := strings.Index(content, endMarker)
+	if endIdx == -1 || endIdx < beginIdx {
+		return content
+	}
+	end := endIdx + len(endMarker)
+	if end < len(content) && content[end] == '\n' {
+		end++
+	}
+	return content[:beginIdx] + content[end:]
+}
+
+// normalizeUserAuthored canonicalizes content for divergence comparison:
+// strips the managed beads section, normalizes line endings, and collapses
+// trailing whitespace. Leading/trailing blank lines are removed so cosmetic
+// reformatting (e.g. an extra newline at EOF) does not flag as divergence.
+func normalizeUserAuthored(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = stripBeadsIntegrationSection(content)
+	lines := strings.Split(content, "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight(ln, " \t")
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// sameInode reports whether two files refer to the same underlying inode
+// (hardlinked or one is a symlink resolving to the other). Falls back to
+// comparing resolved paths on platforms where syscall stat is unavailable.
+func sameInode(a, b string) (bool, error) {
+	resolvedA, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		return false, err
+	}
+	resolvedB, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		return false, err
+	}
+	if resolvedA == resolvedB {
+		return true, nil
+	}
+	infoA, err := os.Stat(resolvedA)
+	if err != nil {
+		return false, err
+	}
+	infoB, err := os.Stat(resolvedB)
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(infoA, infoB), nil
+}
+
+// CheckAgentDocDivergence detects when AGENTS.md and CLAUDE.md exist as
+// independent regular files whose user-authored regions (everything outside
+// the BEGIN/END BEADS INTEGRATION markers) have drifted apart. Hand-edits to
+// only one of the pair are a common source of inconsistency; the warning
+// recommends symlinking, regenerating via bd setup, or reconciling manually.
+//
+// Skipped when:
+//   - Either file is missing
+//   - The files share an inode (hardlink) or one is a symlink to the other
+//   - The user-authored content matches after normalization
+func CheckAgentDocDivergence(repoPath string) DoctorCheck {
+	agentsFile := config.SafeAgentsFile()
+	agentsPath := filepath.Join(repoPath, agentsFile)
+	claudePath := filepath.Join(repoPath, "CLAUDE.md")
+
+	agentsInfo, errA := os.Lstat(agentsPath)
+	claudeInfo, errB := os.Lstat(claudePath)
+	if errA != nil || errB != nil {
+		return DoctorCheck{
+			Name:    "Agent Doc Divergence",
+			Status:  StatusOK,
+			Message: "N/A (one or both files missing)",
+		}
+	}
+
+	// If either side is a symlink, treat the pair as intentionally linked
+	// and skip the divergence check.
+	if agentsInfo.Mode()&os.ModeSymlink != 0 || claudeInfo.Mode()&os.ModeSymlink != 0 {
+		return DoctorCheck{
+			Name:    "Agent Doc Divergence",
+			Status:  StatusOK,
+			Message: fmt.Sprintf("%s and CLAUDE.md are linked", agentsFile),
+		}
+	}
+
+	// Hardlinked to the same inode — same file, no divergence possible.
+	if same, err := sameInode(agentsPath, claudePath); err == nil && same {
+		return DoctorCheck{
+			Name:    "Agent Doc Divergence",
+			Status:  StatusOK,
+			Message: fmt.Sprintf("%s and CLAUDE.md share an inode", agentsFile),
+		}
+	}
+
+	agentsContent, err := os.ReadFile(agentsPath) // #nosec G304 - path under repoPath
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Agent Doc Divergence",
+			Status:  StatusOK,
+			Message: fmt.Sprintf("Cannot read %s: %v", agentsFile, err),
+		}
+	}
+	claudeContent, err := os.ReadFile(claudePath) // #nosec G304 - path under repoPath
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Agent Doc Divergence",
+			Status:  StatusOK,
+			Message: fmt.Sprintf("Cannot read CLAUDE.md: %v", err),
+		}
+	}
+
+	// Honor an explicit opt-out marker in either file. Some projects
+	// intentionally maintain distinct AGENTS.md and CLAUDE.md (different
+	// audiences, different reading orders). The marker lets them silence
+	// this check without losing the protection elsewhere.
+	const optOutMarker = "<!-- bd-doctor-divergence: ok -->"
+	if strings.Contains(string(agentsContent), optOutMarker) || strings.Contains(string(claudeContent), optOutMarker) {
+		return DoctorCheck{
+			Name:    "Agent Doc Divergence",
+			Status:  StatusOK,
+			Message: "Divergence check opted out via marker",
+		}
+	}
+
+	if normalizeUserAuthored(string(agentsContent)) == normalizeUserAuthored(string(claudeContent)) {
+		return DoctorCheck{
+			Name:    "Agent Doc Divergence",
+			Status:  StatusOK,
+			Message: fmt.Sprintf("%s and CLAUDE.md user-authored content matches", agentsFile),
+		}
+	}
+
+	return DoctorCheck{
+		Name:    "Agent Doc Divergence",
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%s and CLAUDE.md user-authored content has diverged", agentsFile),
+		Detail: "Both files exist as independent regular files (not symlinked, different inodes),\n" +
+			"  but their content outside the <!-- BEGIN/END BEADS INTEGRATION --> markers differs.\n" +
+			"  Hand-edits to only one of the pair are a common cause.",
+		Fix: "Reconcile the two files using one of:\n" +
+			"\n" +
+			"  (a) Symlink one to the other so future edits stay in sync:\n" +
+			"      ln -sf " + agentsFile + " CLAUDE.md\n" +
+			"\n" +
+			"  (b) Regenerate the managed sections (preserves user-authored content\n" +
+			"      from AGENTS.md as the source of truth):\n" +
+			"      bd setup claude && bd setup codex\n" +
+			"\n" +
+			"  (c) Reconcile manually — diff the files and copy the intended\n" +
+			"      user-authored content into both:\n" +
+			"      diff " + agentsFile + " CLAUDE.md\n" +
+			"\n" +
+			"  (d) If the divergence is intentional (e.g. distinct audiences for\n" +
+			"      each file), opt out by adding this HTML comment anywhere in\n" +
+			"      either file:\n" +
+			"      <!-- bd-doctor-divergence: ok -->",
+	}
+}
+
 // CheckDatabaseConfig verifies that the configured database path matches what
 // actually exists on disk. For Dolt backends, data is on the server. For legacy
 // backends, this checks that .db files match the configuration.

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -228,7 +228,7 @@ func normalizeUserAuthored(content string) string {
 }
 
 // sameInode reports whether two files refer to the same underlying inode
-// (hardlinked or one is a symlink resolving to the other). Falls back to
+// (hard-linked or one is a symlink resolving to the other). Falls back to
 // comparing resolved paths on platforms where syscall stat is unavailable.
 func sameInode(a, b string) (bool, error) {
 	resolvedA, err := filepath.EvalSymlinks(a)
@@ -288,7 +288,7 @@ func CheckAgentDocDivergence(repoPath string) DoctorCheck {
 		}
 	}
 
-	// Hardlinked to the same inode — same file, no divergence possible.
+	// Hard-linked to the same inode — same file, no divergence possible.
 	if same, err := sameInode(agentsPath, claudePath); err == nil && same {
 		return DoctorCheck{
 			Name:    "Agent Doc Divergence",

--- a/cmd/bd/doctor/legacy_test.go
+++ b/cmd/bd/doctor/legacy_test.go
@@ -461,3 +461,157 @@ func TestCheckFreshClone(t *testing.T) {
 		})
 	}
 }
+
+func TestStripBeadsIntegrationSection(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no markers — content unchanged",
+			in:   "# Header\n\nUser content.\n",
+			want: "# Header\n\nUser content.\n",
+		},
+		{
+			name: "legacy markers stripped with trailing newline",
+			in:   "# Header\n<!-- BEGIN BEADS INTEGRATION -->\nManaged body\n<!-- END BEADS INTEGRATION -->\nFooter\n",
+			want: "# Header\nFooter\n",
+		},
+		{
+			name: "v1 markers stripped",
+			in:   "Pre\n<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:abcd1234 -->\nbody\n<!-- END BEADS INTEGRATION -->\nPost\n",
+			want: "Pre\nPost\n",
+		},
+		{
+			name: "missing END marker — left untouched",
+			in:   "<!-- BEGIN BEADS INTEGRATION -->\nbody without end\n",
+			want: "<!-- BEGIN BEADS INTEGRATION -->\nbody without end\n",
+		},
+		{
+			name: "END before BEGIN — left untouched",
+			in:   "<!-- END BEADS INTEGRATION -->\nstuff\n<!-- BEGIN BEADS INTEGRATION -->\n",
+			want: "<!-- END BEADS INTEGRATION -->\nstuff\n<!-- BEGIN BEADS INTEGRATION -->\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripBeadsIntegrationSection(tt.in); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeUserAuthored(t *testing.T) {
+	a := "# Header\n\nUser content.\n\n<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:aaaa1111 -->\nbody A\n<!-- END BEADS INTEGRATION -->\n"
+	b := "# Header\r\n\r\nUser content.   \r\n<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:bbbb2222 -->\nbody B is different\n<!-- END BEADS INTEGRATION -->\n\n"
+	if normalizeUserAuthored(a) != normalizeUserAuthored(b) {
+		t.Errorf("expected normalized equality despite CRLF, trailing space, and managed-section differences\nA: %q\nB: %q", normalizeUserAuthored(a), normalizeUserAuthored(b))
+	}
+
+	c := "# Header\n\nUser content.\n"
+	d := "# Header\n\nDIFFERENT user content.\n"
+	if normalizeUserAuthored(c) == normalizeUserAuthored(d) {
+		t.Error("expected divergent user-authored content to differ after normalization")
+	}
+}
+
+func TestCheckAgentDocDivergence(t *testing.T) {
+	const managed = "<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:abcd1234 -->\nManaged body\n<!-- END BEADS INTEGRATION -->\n"
+
+	t.Run("missing files — N/A ok", func(t *testing.T) {
+		tmp := t.TempDir()
+		check := CheckAgentDocDivergence(tmp)
+		if check.Status != StatusOK {
+			t.Errorf("expected ok when files missing, got %s", check.Status)
+		}
+	})
+
+	t.Run("matching user-authored content — ok", func(t *testing.T) {
+		tmp := t.TempDir()
+		body := "# Project\n\nShared instructions.\n\n" + managed
+		writeFile(t, tmp, "AGENTS.md", body)
+		writeFile(t, tmp, "CLAUDE.md", body)
+		check := CheckAgentDocDivergence(tmp)
+		if check.Status != StatusOK {
+			t.Errorf("expected ok for matching content, got %s (msg=%s)", check.Status, check.Message)
+		}
+	})
+
+	t.Run("matching content with different managed sections — ok", func(t *testing.T) {
+		tmp := t.TempDir()
+		writeFile(t, tmp, "AGENTS.md", "# Project\n\nShared instructions.\n\n"+managed)
+		writeFile(t, tmp, "CLAUDE.md", "# Project\n\nShared instructions.\n\n<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:99999999 -->\nDifferent managed body\n<!-- END BEADS INTEGRATION -->\n")
+		check := CheckAgentDocDivergence(tmp)
+		if check.Status != StatusOK {
+			t.Errorf("expected ok when only managed sections differ, got %s", check.Status)
+		}
+	})
+
+	t.Run("diverged user-authored content — warning with fix", func(t *testing.T) {
+		tmp := t.TempDir()
+		writeFile(t, tmp, "AGENTS.md", "# Project\n\nOriginal instructions.\n\n"+managed)
+		writeFile(t, tmp, "CLAUDE.md", "# Project\n\nHand-edited divergent instructions.\n\n"+managed)
+		check := CheckAgentDocDivergence(tmp)
+		if check.Status != StatusWarning {
+			t.Fatalf("expected warning, got %s (msg=%s)", check.Status, check.Message)
+		}
+		if check.Fix == "" {
+			t.Error("expected fix message")
+		}
+		if !strings.Contains(check.Fix, "ln -sf") {
+			t.Error("expected fix to suggest symlink option")
+		}
+		if !strings.Contains(check.Fix, "bd setup claude") {
+			t.Error("expected fix to suggest bd setup claude")
+		}
+	})
+
+	t.Run("opt-out marker silences divergence — ok", func(t *testing.T) {
+		tmp := t.TempDir()
+		writeFile(t, tmp, "AGENTS.md", "# Agents\n\n<!-- bd-doctor-divergence: ok -->\n\nFor agents.\n\n"+managed)
+		writeFile(t, tmp, "CLAUDE.md", "# Claude\n\nFor Claude with totally different content.\n\n"+managed)
+		check := CheckAgentDocDivergence(tmp)
+		if check.Status != StatusOK {
+			t.Errorf("expected ok with opt-out marker, got %s (msg=%s)", check.Status, check.Message)
+		}
+	})
+
+	t.Run("symlinked pair — skipped as ok", func(t *testing.T) {
+		tmp := t.TempDir()
+		writeFile(t, tmp, "AGENTS.md", "# Project\n\nInstructions.\n\n"+managed)
+		if err := os.Symlink("AGENTS.md", filepath.Join(tmp, "CLAUDE.md")); err != nil {
+			t.Skipf("symlink not supported in this environment: %v", err)
+		}
+		check := CheckAgentDocDivergence(tmp)
+		if check.Status != StatusOK {
+			t.Errorf("expected ok for symlinked pair, got %s (msg=%s)", check.Status, check.Message)
+		}
+	})
+
+	t.Run("hardlinked pair — skipped as ok", func(t *testing.T) {
+		tmp := t.TempDir()
+		writeFile(t, tmp, "AGENTS.md", "# Project\n\nInstructions.\n\n"+managed)
+		if err := os.Link(filepath.Join(tmp, "AGENTS.md"), filepath.Join(tmp, "CLAUDE.md")); err != nil {
+			t.Skipf("hardlink not supported in this environment: %v", err)
+		}
+		check := CheckAgentDocDivergence(tmp)
+		if check.Status != StatusOK {
+			t.Errorf("expected ok for hardlinked pair, got %s (msg=%s)", check.Status, check.Message)
+		}
+	})
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if d := filepath.Dir(path); d != dir {
+		if err := os.MkdirAll(d, 0750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/bd/preflight.go
+++ b/cmd/bd/preflight.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/cmd/bd/doctor"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/git"
 )
@@ -120,6 +121,10 @@ func runChecks(jsonOutput, skipLint bool) {
 	// Run version sync check
 	versionResult := runVersionSyncCheck()
 	results = append(results, versionResult)
+
+	// Run AGENTS.md / CLAUDE.md divergence check
+	divergenceResult := runAgentDocDivergenceCheck()
+	results = append(results, divergenceResult)
 
 	// Calculate overall result
 	allPassed := true
@@ -507,6 +512,40 @@ func runVersionSyncCheck() CheckResult {
 		Name:    "Version sync",
 		Passed:  true,
 		Output:  fmt.Sprintf("Versions match: %s", goVersion),
+		Command: command,
+	}
+}
+
+// runAgentDocDivergenceCheck flags drift between AGENTS.md and CLAUDE.md
+// user-authored regions so the inconsistency is caught pre-PR rather than in
+// review.
+func runAgentDocDivergenceCheck() CheckResult {
+	command := "bd doctor (Agent Doc Divergence)"
+
+	repoRoot := git.GetRepoRoot()
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+	check := doctor.CheckAgentDocDivergence(repoRoot)
+	if check.Status == doctor.StatusOK {
+		return CheckResult{
+			Name:    "AGENTS.md/CLAUDE.md in sync",
+			Passed:  true,
+			Command: command,
+		}
+	}
+	output := check.Message
+	if check.Detail != "" {
+		output += "\n" + check.Detail
+	}
+	if check.Fix != "" {
+		output += "\n" + check.Fix
+	}
+	return CheckResult{
+		Name:    "AGENTS.md/CLAUDE.md in sync",
+		Passed:  false,
+		Warning: true,
+		Output:  output,
 		Command: command,
 	}
 }


### PR DESCRIPTION
## Summary

Adds `CheckAgentDocDivergence` to `bd doctor` and `bd preflight` to flag drift between `AGENTS.md` and `CLAUDE.md` when they exist as independent regular files. The check compares content outside the `<!-- BEGIN/END BEADS INTEGRATION -->` markers — i.e. the user-authored regions — so updates to the managed sections don't trigger false positives.

A common drift pattern: an agent hand-edits one file without mirroring the change to the other. This catches it before it ships.

### Skipped when

- Either file is missing
- The pair is symlinked or shares an inode (hardlink)
- Normalized user-authored content matches (CRLF, trailing whitespace, leading/trailing blank lines normalized away)
- Either file contains the opt-out marker `<!-- bd-doctor-divergence: ok -->`

### Why the opt-out marker

This repo's own `AGENTS.md` and `CLAUDE.md` intentionally diverge — they serve different audiences with different reading orders. The marker lets projects in that situation silence the check without losing the protection elsewhere. This PR adds the marker to `AGENTS.md` so the new check doesn't regress preflight on the upstream repo itself.

### Wired into

- `bd doctor` — Check 12a, category `Integration`, warning-only (does not fail)
- `bd preflight --check` — new `AGENTS.md/CLAUDE.md in sync` check, warning-only

## Test plan

- [x] `go test -tags gms_pure_go ./cmd/bd/doctor/...` — all new tests pass
- [x] `gofmt -l` clean on touched files
- [x] `go vet` clean
- [ ] Manual: create a divergent pair, run `bd doctor` — see warning
- [ ] Manual: add opt-out marker, rerun — warning silenced
- [ ] Manual: symlink the pair, rerun — skipped as ok

Closes a downstream tracker item (mybd-31m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->