### PR TITLE
Fix worktree server mode spawning duplicate dolt servers

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -989,12 +989,24 @@ func findDatabaseInTree() string {
 
 	// Check cwd first — a rig subdirectory with its own .beads/ takes
 	// priority over the git root's .beads/ (same fix as FindBeadsDir step 1b).
+	//
+	// In a worktree, skip the CWD check at the worktree root. The worktree
+	// root's .beads/ may contain git-tracked metadata (metadata.json with
+	// dolt_mode=server) inherited from the parent repo checkout, but NOT the
+	// gitignored dolt/ data directory. In server mode, findDatabaseInBeadsDir
+	// returns a path regardless of whether the data dir exists, which would
+	// short-circuit the worktree-aware fallback below — causing each worktree
+	// to spawn its own dolt server against an empty data directory.
+	// The worktree-specific code (below) handles this correctly.
 	{
-		cwdBeadsDir := filepath.Join(dir, ".beads")
-		if info, err := os.Stat(cwdBeadsDir); err == nil && info.IsDir() {
-			cwdBeadsDir = FollowRedirect(cwdBeadsDir)
-			if dbPath := findDatabaseInBeadsDir(cwdBeadsDir, true); dbPath != "" {
-				return dbPath
+		skipCwdCheck := git.IsWorktree() && dir == utils.CanonicalizePath(git.GetRepoRoot())
+		if !skipCwdCheck {
+			cwdBeadsDir := filepath.Join(dir, ".beads")
+			if info, err := os.Stat(cwdBeadsDir); err == nil && info.IsDir() {
+				cwdBeadsDir = FollowRedirect(cwdBeadsDir)
+				if dbPath := findDatabaseInBeadsDir(cwdBeadsDir, true); dbPath != "" {
+					return dbPath
+				}
 			}
 		}
 	}
@@ -1009,12 +1021,19 @@ func findDatabaseInTree() string {
 			}
 		}
 
-		// Worktree's own .beads (separate-DB mode, no redirect)
+		// Worktree's own .beads (separate-DB mode, no redirect).
+		// Only use it if the worktree has an actual database (dolt/, embeddeddolt/,
+		// or *.db). A worktree that only has git-tracked metadata (metadata.json
+		// with dolt_mode=server, config.yaml, etc.) should fall through to the
+		// shared fallback below. This mirrors FindBeadsDir step 3b's
+		// hasBeadsDatabase guard and prevents duplicate server spawns.
 		if worktreeRoot := git.GetRepoRoot(); worktreeRoot != "" {
 			worktreeBeadsDir := filepath.Join(worktreeRoot, ".beads")
 			if info, err := os.Stat(worktreeBeadsDir); err == nil && info.IsDir() {
-				if dbPath := findDatabaseInBeadsDir(worktreeBeadsDir, true); dbPath != "" {
-					return dbPath
+				if hasBeadsDatabase(worktreeBeadsDir) {
+					if dbPath := findDatabaseInBeadsDir(worktreeBeadsDir, true); dbPath != "" {
+						return dbPath
+					}
 				}
 			}
 		}

--- a/internal/beads/beads_inherited_artifacts_test.go
+++ b/internal/beads/beads_inherited_artifacts_test.go
@@ -417,3 +417,237 @@ func TestFindBeadsDir_WorktreeNoDatabaseAnywhereFallsBackToLocal(t *testing.T) {
 			result, worktreeBeadsDir)
 	}
 }
+
+// TestFindDatabasePath_WorktreeServerModeSharesMainRepo verifies that
+// FindDatabasePath in a worktree with inherited server-mode metadata.json
+// resolves to the main repo's .beads/dolt — NOT the worktree's metadata-only
+// .beads/dolt. Without this, each worktree spawns its own dolt sql-server
+// against an empty data directory, fails to find the project database, and
+// leaves orphaned server processes.
+//
+// Regression test for the "worktree server mode duplicate server" bug.
+func TestFindDatabasePath_WorktreeServerModeSharesMainRepo(t *testing.T) {
+	originalEnvDir := os.Getenv("BEADS_DIR")
+	originalEnvDB := os.Getenv("BEADS_DB")
+	defer func() {
+		if originalEnvDir != "" {
+			os.Setenv("BEADS_DIR", originalEnvDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+		if originalEnvDB != "" {
+			os.Setenv("BEADS_DB", originalEnvDB)
+		} else {
+			os.Unsetenv("BEADS_DB")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+	os.Unsetenv("BEADS_DB")
+
+	tmpDir, err := os.MkdirTemp("", "beads-worktree-server-mode-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit(mainRepoDir, "config", "user.email", "test@example.com")
+	runGit(mainRepoDir, "config", "user.name", "Test User")
+
+	// Simulate a server-mode beads install: metadata.json has dolt_mode=server,
+	// and the main repo has a dolt/ data directory (created by bd init --server).
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mainDoltDir := filepath.Join(mainBeadsDir, "dolt")
+	if err := os.MkdirAll(mainDoltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mustWrite := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Server-mode metadata — the key trigger for the bug.
+	mustWrite(filepath.Join(mainBeadsDir, "metadata.json"),
+		`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"test_project","project_id":"aaaa-bbbb"}`)
+	mustWrite(filepath.Join(mainBeadsDir, "config.yaml"), "issue-prefix: \"tp\"\n")
+	// .gitignore excludes the dolt data dir (as real projects do)
+	mustWrite(filepath.Join(mainBeadsDir, ".gitignore"), "dolt/\nembeddeddolt/\n*.db\ndolt-server.*\n")
+
+	mustWrite(filepath.Join(mainRepoDir, "README.md"), "# Test\n")
+	runGit(mainRepoDir, "add", "README.md", ".beads/metadata.json", ".beads/config.yaml", ".beads/.gitignore")
+	runGit(mainRepoDir, "commit", "-m", "initial with server-mode beads")
+
+	// Create a worktree — git checks out the tracked .beads/ files
+	// (metadata.json, config.yaml, .gitignore) but NOT the gitignored dolt/ dir.
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	runGit(mainRepoDir, "worktree", "add", worktreeDir, "HEAD")
+	defer func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	}()
+
+	// Sanity checks: worktree has metadata but no dolt/ dir.
+	worktreeBeadsDir := filepath.Join(worktreeDir, ".beads")
+	if _, err := os.Stat(filepath.Join(worktreeBeadsDir, "metadata.json")); err != nil {
+		t.Fatalf("precondition: worktree should have inherited metadata.json, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktreeBeadsDir, "dolt")); err == nil {
+		t.Fatalf("precondition: worktree's dolt/ should be gitignored, but it exists")
+	}
+
+	t.Chdir(worktreeDir)
+	git.ResetCaches()
+
+	// FindDatabasePath must resolve to the main repo's dolt dir, not the worktree's.
+	result := FindDatabasePath()
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	mainDoltResolved, _ := filepath.EvalSymlinks(mainDoltDir)
+	worktreeDoltDir := filepath.Join(worktreeBeadsDir, "dolt")
+
+	if resultResolved == worktreeDoltDir {
+		t.Fatalf("FindDatabasePath() returned worktree's .beads/dolt (%q); "+
+			"expected main repo's .beads/dolt (%q). "+
+			"This is the duplicate-server bug: the worktree's inherited "+
+			"server-mode metadata causes a separate dolt server to spawn "+
+			"against an empty data directory.",
+			result, mainDoltDir)
+	}
+	if resultResolved != mainDoltResolved {
+		t.Errorf("FindDatabasePath() = %q, want main repo dolt dir %q", result, mainDoltDir)
+	}
+
+	// Also verify FindBeadsDir resolves to the main repo's .beads.
+	beadsDirResult := FindBeadsDir()
+	beadsDirResolved, _ := filepath.EvalSymlinks(beadsDirResult)
+	mainBeadsDirResolved, _ := filepath.EvalSymlinks(mainBeadsDir)
+	if beadsDirResolved != mainBeadsDirResolved {
+		t.Errorf("FindBeadsDir() = %q, want main repo .beads %q", beadsDirResult, mainBeadsDir)
+	}
+}
+
+// TestFindDatabasePath_WorktreeServerModeFromSubdir is the same scenario as
+// TestFindDatabasePath_WorktreeServerModeSharesMainRepo but with the CWD set
+// to a subdirectory of the worktree rather than the worktree root. This
+// exercises the walk-up and worktree-specific code paths (as opposed to the
+// CWD check which only fires at the worktree root).
+func TestFindDatabasePath_WorktreeServerModeFromSubdir(t *testing.T) {
+	originalEnvDir := os.Getenv("BEADS_DIR")
+	originalEnvDB := os.Getenv("BEADS_DB")
+	defer func() {
+		if originalEnvDir != "" {
+			os.Setenv("BEADS_DIR", originalEnvDir)
+		} else {
+			os.Unsetenv("BEADS_DIR")
+		}
+		if originalEnvDB != "" {
+			os.Setenv("BEADS_DB", originalEnvDB)
+		} else {
+			os.Unsetenv("BEADS_DB")
+		}
+	}()
+	os.Unsetenv("BEADS_DIR")
+	os.Unsetenv("BEADS_DB")
+
+	tmpDir, err := os.MkdirTemp("", "beads-worktree-server-subdir-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	mainRepoDir := filepath.Join(tmpDir, "main-repo")
+	if err := os.MkdirAll(mainRepoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = mainRepoDir
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	runGit(mainRepoDir, "config", "user.email", "test@example.com")
+	runGit(mainRepoDir, "config", "user.name", "Test User")
+
+	mainBeadsDir := filepath.Join(mainRepoDir, ".beads")
+	if err := os.MkdirAll(mainBeadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mainDoltDir := filepath.Join(mainBeadsDir, "dolt")
+	if err := os.MkdirAll(mainDoltDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mustWrite := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(filepath.Join(mainBeadsDir, "metadata.json"),
+		`{"database":"dolt","backend":"dolt","dolt_mode":"server","dolt_database":"test_project"}`)
+	mustWrite(filepath.Join(mainBeadsDir, "config.yaml"), "issue-prefix: \"tp\"\n")
+	mustWrite(filepath.Join(mainBeadsDir, ".gitignore"), "dolt/\nembeddeddolt/\n*.db\ndolt-server.*\n")
+
+	mustWrite(filepath.Join(mainRepoDir, "README.md"), "# Test\n")
+	runGit(mainRepoDir, "add", "README.md", ".beads/metadata.json", ".beads/config.yaml", ".beads/.gitignore")
+	runGit(mainRepoDir, "commit", "-m", "initial")
+
+	worktreeDir := filepath.Join(tmpDir, "worktree")
+	runGit(mainRepoDir, "worktree", "add", worktreeDir, "HEAD")
+	defer func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+		cmd.Dir = mainRepoDir
+		_ = cmd.Run()
+	}()
+
+	// CWD is a subdirectory of the worktree — tests the worktree-specific
+	// code path rather than the CWD check.
+	subDir := filepath.Join(worktreeDir, "src", "pkg")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subDir)
+	git.ResetCaches()
+
+	result := FindDatabasePath()
+	resultResolved, _ := filepath.EvalSymlinks(result)
+	mainDoltResolved, _ := filepath.EvalSymlinks(mainDoltDir)
+
+	if resultResolved != mainDoltResolved {
+		t.Errorf("FindDatabasePath() from subdir = %q, want main repo dolt dir %q", result, mainDoltDir)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3421

- **Bug**: In server mode, each git worktree spawns its own dolt sql-server against an empty data directory instead of sharing the main repo's server. The worktree's `.beads/metadata.json` (inherited via `git worktree add`) has `dolt_mode=server`, causing `findDatabaseInTree()` to return the worktree's `.beads/dolt` path without verifying it exists — short-circuiting the worktree fallback logic that would find the main repo's server.
- **Fix**: Add worktree awareness to `findDatabaseInTree()` — skip the CWD check at the worktree root (let worktree-specific code handle it), and add a `hasBeadsDatabase()` guard to the worktree's own `.beads` check (mirroring `FindBeadsDir` step 3b).
- **Tests**: Two regression tests covering CWD at worktree root and CWD in a subdirectory.

## Before (broken)

Each worktree spawns a separate dolt server against an empty data dir, can't find the database:

```
➜  wt_1 git:(wt_1) bd list
Error: failed to open database: database "test_worktree" not found on Dolt server at 127.0.0.1:41257

➜  ps aux | grep "sql-server"
dustin  783129  dolt sql-server -H 127.0.0.1 -P 39969   # main repo
dustin  783904  dolt sql-server -H 127.0.0.1 -P 41257   # wt_1 (duplicate!)
dustin  784355  dolt sql-server -H 127.0.0.1 -P 38973   # wt_2 (duplicate!)
```

## After (fixed)

All worktrees share the main repo's dolt server:

```
➜  alt git:(main) bd init --server
✓ bd initialized successfully!
  Server: root@127.0.0.1:44513

➜  alt git:(main) bd worktree create ./wt_1
✓ Created worktree: /home/dustin/cursor_src/beads/alt/wt_1

➜  wt_1 git:(wt_1) bd list
No issues found.

➜  wt_1 git:(wt_1) ps aux | grep "sql-server"
dustin  1024351  dolt sql-server -H 127.0.0.1 -P 44513   # only one server!

➜  alt git:(main) bd create "this is an issue from the top-level repo"
✓ Created issue: alt-dy6

➜  alt git:(main) bd worktree create ./wt_2
✓ Created worktree: /home/dustin/cursor_src/beads/alt/wt_2

➜  wt_2 git:(wt_2) bd list
○ alt-dy6 ● P2 this is an issue from the top-level repo

➜  wt_1 git:(wt_1) bd list
○ alt-dy6 ● P2 this is an issue from the top-level repo
```

## Related

See #3601 for the broader design issue of standardizing workspace resolution into a coherent interface.

## Test plan

- [x] New regression tests pass: `TestFindDatabasePath_WorktreeServerModeSharesMainRepo`, `TestFindDatabasePath_WorktreeServerModeFromSubdir`
- [x] All 18 existing worktree tests pass
- [x] Full `internal/beads` package tests pass
- [x] Manual verification with `bd init --server` + `bd worktree create` confirms single server shared across worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->