### PR TITLE
fix(close): route ID resolution like show/update (closes #3608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`bd close <id>` in contributor auto-routing mode** — `bd close` now resolves IDs through the same routing fallback as `bd show` and `bd update`. Previously `bd close` errored with `no issue found matching <id>` in workspaces with `routing.mode=auto`, `routing.contributor=<path>`, and `beads.role=contributor` — even for IDs that `bd create` had just returned, because the issue lived in the routed planning store while `bd close` only checked the local primary. Bulk close (`bd close <id1> <id2> ...`) is also fixed; per-call resolution now shares one routed-store handle to avoid the [GH#3586](https://github.com/gastownhall/beads/pull/3586) flock-deadlock pattern when multiple IDs route to the same target. Fixes [#3608](https://github.com/gastownhall/beads/issues/3608).
+- **`bd close <id>` in contributor auto-routing mode** — `bd close` now resolves IDs through the same routing fallback as `bd show` and `bd update`. Previously `bd close` errored with `no issue found matching <id>` in workspaces with `routing.mode=auto`, `routing.contributor=<path>`, and `beads.role=contributor` — even for IDs that `bd create` had just returned, because the issue lived in the routed planning store while `bd close` only checked the local primary. Bulk close (`bd close <id1> <id2> ...`) is also fixed by sharing one routed-store handle across the close batch. Fixes [#3608](https://github.com/gastownhall/beads/issues/3608).
 
 ## [1.0.3] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`bd init --force`** — deprecated alias for `--reinit-local`. Continues to work for ≥2 releases, emits a `DeprecationWarning`, routes internally to `--reinit-local`. Use `--reinit-local` going forward. CI and scripts are unaffected for the duration of the deprecation window.
 
+### Fixed
+
+- **`bd close <id>` in contributor auto-routing mode** — `bd close` now resolves IDs through the same routing fallback as `bd show` and `bd update`. Previously `bd close` errored with `no issue found matching <id>` in workspaces with `routing.mode=auto`, `routing.contributor=<path>`, and `beads.role=contributor` — even for IDs that `bd create` had just returned, because the issue lived in the routed planning store while `bd close` only checked the local primary. Bulk close (`bd close <id1> <id2> ...`) is also fixed; per-call resolution now shares one routed-store handle to avoid the [GH#3586](https://github.com/gastownhall/beads/pull/3586) flock-deadlock pattern when multiple IDs route to the same target. Fixes [#3608](https://github.com/gastownhall/beads/issues/3608).
+
 ## [1.0.3] - 2026-04-24
 
 ### Fixed

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -118,8 +118,8 @@ create, update, show, or close operation).`,
 			resolvedIDs = append(resolvedIDs, r.ResolvedID)
 		}
 
-		// Track which routed stores we mutated so we can flush each in embedded mode.
-		// Deduped by pointer; the local store is added unconditionally below.
+		// Track which stores were mutated so routed closes can commit before
+		// cleanup closes the routed handle. Deduped by pointer.
 		mutatedStores := map[storage.DoltStorage]struct{}{}
 
 		// Direct mode
@@ -285,18 +285,29 @@ create, update, show, or close operation).`,
 			}
 		}
 
-		// Embedded mode: flush Dolt commit. DoltStore commits
-		// inline during CloseIssue so this is only needed for EmbeddedDoltStore.
-		// With contributor auto-routing, the close lands in the routed store, not
-		// the local one — flush every store we actually mutated.
-		if isEmbeddedMode() && closedCount > 0 {
+		if closedCount > 0 {
+			hasRoutedMutation := false
 			for s := range mutatedStores {
-				if s == nil {
-					continue
+				if s != nil && s != store {
+					hasRoutedMutation = true
+					break
 				}
-				if _, err := s.CommitPending(ctx, actor); err != nil {
-					FatalErrorRespectJSON("failed to commit: %v", err)
+			}
+			if hasRoutedMutation {
+				for s := range mutatedStores {
+					if s == nil {
+						continue
+					}
+					if err := maybeAutoCommitStore(ctx, s, doltAutoCommitParams{
+						Command:  cmd.Name(),
+						IssueIDs: resolvedIDs,
+					}); err != nil {
+						FatalErrorRespectJSON("dolt auto-commit failed: %v", err)
+					}
 				}
+				commandDidExplicitDoltCommit = true
+			} else {
+				commandDidWrite.Store(true)
 			}
 		}
 
@@ -479,14 +490,13 @@ func resolveReasonFile(cmd *cobra.Command, existingReason string) (string, bool,
 }
 
 // resolveCloseTargets resolves a batch of partial issue IDs for `bd close`,
-// preserving input order. For each ID it tries the local store first, then a
-// shared contributor-routed store, then explicit prefix routing via routes.jsonl.
+// preserving input order. For each ID it tries the local store first, then
+// explicit prefix routing via routes.jsonl, then a shared contributor-routed
+// store. This matches resolveAndGetIssueWithRouting's routing precedence.
 //
-// Why "shared": opening the routed embeddeddolt store more than once in the same
-// process deadlocks on its flock (same class as GH#3586 / beads-i4s). Per-id
-// routing in close.go would hit that for every multi-id close where the IDs all
-// route to the same target — i.e. the common case. We open at most one routed
-// handle and reuse it for every routed ID; the cleanup func releases it.
+// The contributor-routed handle is shared across the batch so bulk close does
+// not repeatedly open the same planning store and every result has a clear store
+// owner for subsequent close-time checks and writes.
 //
 // Each returned RoutedResult.Store points to whichever store actually owns the
 // issue. The caller invokes cleanup() once when done; per-result Close() is a
@@ -530,18 +540,17 @@ func resolveCloseTargets(ctx context.Context, localStore storage.DoltStorage, id
 			cleanup()
 			return nil, func() {}, fmt.Errorf("resolving ID %s: %w", id, err)
 		}
-		// Shared routed store (contributor auto-routing).
+		if r, err := resolveViaPrefixRouting(ctx, id); err == nil {
+			results = append(results, r)
+			continue
+		}
+		// Contributor auto-routing uses one shared store for the whole batch.
 		if rs, rerr := ensureShared(); rerr == nil {
 			if r, err := resolveAndGetFromStore(ctx, rs, id, true); err == nil {
 				// Per-id RoutedResult does not own the shared handle; cleanup() does.
 				results = append(results, r)
 				continue
 			}
-		}
-		// Last resort: prefix routing opens its own store; per-result Close() handles it.
-		if r, err := resolveViaPrefixRouting(ctx, id); err == nil {
-			results = append(results, r)
-			continue
 		}
 		cleanup()
 		return nil, func() {}, fmt.Errorf("resolving ID %s: no issue found matching %q", id, id)

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -13,7 +13,6 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
-	"github.com/steveyegge/beads/internal/utils"
 	"github.com/steveyegge/beads/internal/validation"
 )
 
@@ -108,23 +107,30 @@ create, update, show, or close operation).`,
 			FatalErrorRespectJSON("--suggest-next only works when closing a single issue")
 		}
 
-		// Resolve partial IDs
-		var resolvedIDs []string
-		for _, id := range args {
-			resolved, err := utils.ResolvePartialID(ctx, store, id)
-			if err != nil {
-				FatalErrorRespectJSON("resolving ID %s: %v", id, err)
-			}
-			resolvedIDs = append(resolvedIDs, resolved)
+		// Resolve partial IDs with routing fallback (beads-0km).
+		results, cleanup, resolveErr := resolveCloseTargets(ctx, store, args)
+		defer cleanup()
+		if resolveErr != nil {
+			FatalErrorRespectJSON("%v", resolveErr)
 		}
+		resolvedIDs := make([]string, 0, len(results))
+		for _, r := range results {
+			resolvedIDs = append(resolvedIDs, r.ResolvedID)
+		}
+
+		// Track which routed stores we mutated so we can flush each in embedded mode.
+		// Deduped by pointer; the local store is added unconditionally below.
+		mutatedStores := map[storage.DoltStorage]struct{}{}
 
 		// Direct mode
 		closedIssues := []*types.Issue{}
 		closedCount := 0
 
-		for _, id := range resolvedIDs {
+		for i, id := range resolvedIDs {
+			result := results[i]
+			activeStore := result.Store
 			// Get issue for checks (nil issue is handled by validateIssueClosable)
-			issue, _ := store.GetIssue(ctx, id)
+			issue := result.Issue
 
 			if err := validateIssueClosable(id, issue, force); err != nil {
 				fmt.Fprintf(os.Stderr, "%s\n", err)
@@ -133,7 +139,7 @@ create, update, show, or close operation).`,
 
 			// Epic close guard: prevent closing epics with open children (mw-local-4so.5.2)
 			if !force && issue != nil && issue.IssueType == types.TypeEpic {
-				openChildren := countEpicOpenChildren(ctx, id)
+				openChildren := countEpicOpenChildren(ctx, activeStore, id)
 				if openChildren > 0 {
 					fmt.Fprintf(os.Stderr, "cannot close epic %s: %d open child issue(s); close children first or use --force to override\n", id, openChildren)
 					continue
@@ -150,7 +156,7 @@ create, update, show, or close operation).`,
 
 			// Check if issue has open blockers (GH#962)
 			if !force {
-				blocked, blockers, err := store.IsBlocked(ctx, id)
+				blocked, blockers, err := activeStore.IsBlocked(ctx, id)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error checking blockers for %s: %v\n", id, err)
 					continue
@@ -161,10 +167,11 @@ create, update, show, or close operation).`,
 				}
 			}
 
-			if err := store.CloseIssue(ctx, id, reason, actor, session); err != nil {
+			if err := activeStore.CloseIssue(ctx, id, reason, actor, session); err != nil {
 				fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
 				continue
 			}
+			mutatedStores[activeStore] = struct{}{}
 
 			// Audit log the close (survives Dolt GC flatten)
 			oldStatus := "open"
@@ -175,11 +182,12 @@ create, update, show, or close operation).`,
 
 			closedCount++
 
-			// Auto-close parent molecule if all steps are now complete
-			autoCloseCompletedMolecule(ctx, store, id, actor, session)
+			// Auto-close parent molecule if all steps are now complete.
+			// Runs against the same store the step was closed in.
+			autoCloseCompletedMolecule(ctx, activeStore, id, actor, session)
 
 			// Re-fetch for display
-			closedIssue, _ := store.GetIssue(ctx, id)
+			closedIssue, _ := activeStore.GetIssue(ctx, id)
 
 			if jsonOutput {
 				if closedIssue != nil {
@@ -190,9 +198,18 @@ create, update, show, or close operation).`,
 			}
 		}
 
+		// Pick a store for post-close work (--suggest-next, --continue, --claim-next).
+		// All three flags are documented as single-issue paths; for the multi-id case
+		// we use the first resolved ID's store, which matches the common case where
+		// every ID routes to the same place.
+		postCloseStore := store
+		if len(results) > 0 && results[0].Store != nil {
+			postCloseStore = results[0].Store
+		}
+
 		// Handle --suggest-next flag in direct mode
 		if suggestNext && len(resolvedIDs) == 1 && closedCount > 0 {
-			unblocked, err := store.GetNewlyUnblockedByClose(ctx, resolvedIDs[0])
+			unblocked, err := postCloseStore.GetNewlyUnblockedByClose(ctx, resolvedIDs[0])
 			if err == nil && len(unblocked) > 0 {
 				if jsonOutput {
 					outputJSON(map[string]interface{}{
@@ -211,7 +228,7 @@ create, update, show, or close operation).`,
 		// Handle --continue flag
 		if continueFlag && len(resolvedIDs) == 1 && closedCount > 0 {
 			autoClaim := !noAuto
-			result, err := AdvanceToNextStep(ctx, store, resolvedIDs[0], autoClaim, actor)
+			result, err := AdvanceToNextStep(ctx, postCloseStore, resolvedIDs[0], autoClaim, actor)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: could not advance to next step: %v\n", err)
 			} else if result != nil {
@@ -230,7 +247,7 @@ create, update, show, or close operation).`,
 		// Handle --claim-next flag
 		var claimedNextIssue *types.Issue
 		if claimNext && closedCount > 0 && !continueFlag {
-			readyIssues, err := store.GetReadyWork(ctx, types.WorkFilter{
+			readyIssues, err := postCloseStore.GetReadyWork(ctx, types.WorkFilter{
 				Status:     "open",
 				Limit:      1,
 				SortPolicy: types.SortPolicy("priority"),
@@ -239,9 +256,10 @@ create, update, show, or close operation).`,
 				fmt.Fprintf(os.Stderr, "Warning: could not get ready issues: %v\n", err)
 			} else if len(readyIssues) > 0 {
 				nextIssue := readyIssues[0]
-				err := store.ClaimIssue(ctx, nextIssue.ID, actor)
+				err := postCloseStore.ClaimIssue(ctx, nextIssue.ID, actor)
 				if err == nil {
 					claimedNextIssue = nextIssue
+					mutatedStores[postCloseStore] = struct{}{}
 					if jsonOutput {
 						// JSON handled below
 					} else {
@@ -267,8 +285,19 @@ create, update, show, or close operation).`,
 			}
 		}
 
-		if closedCount > 0 {
-			commandDidWrite.Store(true)
+		// Embedded mode: flush Dolt commit. DoltStore commits
+		// inline during CloseIssue so this is only needed for EmbeddedDoltStore.
+		// With contributor auto-routing, the close lands in the routed store, not
+		// the local one — flush every store we actually mutated.
+		if isEmbeddedMode() && closedCount > 0 {
+			for s := range mutatedStores {
+				if s == nil {
+					continue
+				}
+				if _, err := s.CommitPending(ctx, actor); err != nil {
+					FatalErrorRespectJSON("failed to commit: %v", err)
+				}
+			}
 		}
 
 		// Exit non-zero if no issues were actually closed (close guard
@@ -449,10 +478,83 @@ func resolveReasonFile(cmd *cobra.Command, existingReason string) (string, bool,
 	return content, true, nil
 }
 
+// resolveCloseTargets resolves a batch of partial issue IDs for `bd close`,
+// preserving input order. For each ID it tries the local store first, then a
+// shared contributor-routed store, then explicit prefix routing via routes.jsonl.
+//
+// Why "shared": opening the routed embeddeddolt store more than once in the same
+// process deadlocks on its flock (same class as GH#3586 / beads-i4s). Per-id
+// routing in close.go would hit that for every multi-id close where the IDs all
+// route to the same target — i.e. the common case. We open at most one routed
+// handle and reuse it for every routed ID; the cleanup func releases it.
+//
+// Each returned RoutedResult.Store points to whichever store actually owns the
+// issue. The caller invokes cleanup() once when done; per-result Close() is a
+// no-op for routed-via-shared-handle entries because they don't own the handle.
+func resolveCloseTargets(ctx context.Context, localStore storage.DoltStorage, ids []string) ([]*RoutedResult, func(), error) {
+	results := make([]*RoutedResult, 0, len(ids))
+	var sharedRouted storage.DoltStorage
+	var sharedRoutedTried bool
+	cleanup := func() {
+		for _, r := range results {
+			r.Close()
+		}
+		if sharedRouted != nil {
+			_ = sharedRouted.Close()
+		}
+	}
+	ensureShared := func() (storage.DoltStorage, error) {
+		if sharedRouted != nil {
+			return sharedRouted, nil
+		}
+		if sharedRoutedTried {
+			return nil, fmt.Errorf("no auto-routed store available")
+		}
+		sharedRoutedTried = true
+		rs, routed, err := openRoutedReadStore(ctx, localStore)
+		if err != nil {
+			return nil, err
+		}
+		if !routed {
+			return nil, fmt.Errorf("no auto-routed store available")
+		}
+		sharedRouted = rs
+		return rs, nil
+	}
+	for _, id := range ids {
+		// Local first.
+		if r, err := resolveAndGetFromStore(ctx, localStore, id, false); err == nil {
+			results = append(results, r)
+			continue
+		} else if !isNotFoundErr(err) {
+			cleanup()
+			return nil, func() {}, fmt.Errorf("resolving ID %s: %w", id, err)
+		}
+		// Shared routed store (contributor auto-routing).
+		if rs, rerr := ensureShared(); rerr == nil {
+			if r, err := resolveAndGetFromStore(ctx, rs, id, true); err == nil {
+				// Per-id RoutedResult does not own the shared handle; cleanup() does.
+				results = append(results, r)
+				continue
+			}
+		}
+		// Last resort: prefix routing opens its own store; per-result Close() handles it.
+		if r, err := resolveViaPrefixRouting(ctx, id); err == nil {
+			results = append(results, r)
+			continue
+		}
+		cleanup()
+		return nil, func() {}, fmt.Errorf("resolving ID %s: no issue found matching %q", id, id)
+	}
+	return results, cleanup, nil
+}
+
 // countEpicOpenChildren returns the number of open (non-closed) children for an epic.
 // Uses GetDependentsWithMetadata to find parent-child relationships.
-func countEpicOpenChildren(ctx context.Context, epicID string) int {
-	dependents, err := store.GetDependentsWithMetadata(ctx, epicID)
+// Takes an explicit store so callers can route to the store actually holding the epic
+// (relevant for contributor auto-routing where the epic lives in the planning repo).
+func countEpicOpenChildren(ctx context.Context, s storage.DoltStorage, epicID string) int {
+	dependents, err := s.GetDependentsWithMetadata(ctx, epicID)
 	if err != nil {
 		return 0
 	}

--- a/cmd/bd/close_routing_test.go
+++ b/cmd/bd/close_routing_test.go
@@ -1,0 +1,164 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestResolveCloseTargets_RoutesToContributorPlanning is the regression test
+// for beads-0km: bd close failed for issues that lived only in the routed
+// contributor planning store, while bd show / bd update succeeded for the
+// same IDs because they routed via resolveAndGetIssueWithRouting and close
+// did not. The fix uses resolveCloseTargets, which now performs the same
+// routing fallback (and shares one routed-store handle across IDs to avoid
+// the GH#3586 flock-deadlock pattern when multiple IDs route to one target).
+func TestResolveCloseTargets_RoutesToContributorPlanning(t *testing.T) {
+	initConfigForTest(t)
+
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	planningDir := filepath.Join(tmpDir, "planning")
+
+	runCmd(t, tmpDir, "git", "init", repoDir)
+	runCmd(t, repoDir, "git", "config", "beads.role", "contributor")
+
+	primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
+	ctx := context.Background()
+
+	if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
+		t.Fatalf("set routing.mode: %v", err)
+	}
+	if err := primaryStore.SetConfig(ctx, "routing.contributor", planningDir); err != nil {
+		t.Fatalf("set routing.contributor: %v", err)
+	}
+
+	// Planning store with two issues that share the primary's prefix —
+	// the contributor-routing layout `bd create` produces in this scenario.
+	planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
+	for _, id := range []string{"shared-aaa", "shared-bbb"} {
+		issue := &types.Issue{
+			ID:        id,
+			Title:     "planning issue " + id,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := planningStore.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("seed planning issue %s: %v", id, err)
+		}
+	}
+	// Release the lock so openRoutedReadStore can acquire it.
+	if err := planningStore.Close(); err != nil {
+		t.Fatalf("close planning store: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir repoDir: %v", err)
+	}
+
+	// Multi-id batch: this is the deadlock-prone case. resolveCloseTargets
+	// must open the routed store at most once and reuse it across both IDs.
+	results, cleanup, err := resolveCloseTargets(ctx, primaryStore, []string{"shared-aaa", "shared-bbb"})
+	if err != nil {
+		t.Fatalf("resolveCloseTargets: %v", err)
+	}
+	defer cleanup()
+
+	if got, want := len(results), 2; got != want {
+		t.Fatalf("got %d results, want %d", got, want)
+	}
+	wantIDs := []string{"shared-aaa", "shared-bbb"}
+	for i, r := range results {
+		if r == nil || r.Issue == nil {
+			t.Fatalf("result[%d] missing Issue", i)
+		}
+		if r.ResolvedID != wantIDs[i] {
+			t.Errorf("result[%d].ResolvedID = %q, want %q", i, r.ResolvedID, wantIDs[i])
+		}
+		if !r.Routed {
+			t.Errorf("result[%d].Routed = false, want true (issue lives in planning store)", i)
+		}
+		if r.Store == nil {
+			t.Errorf("result[%d].Store is nil", i)
+		}
+	}
+	// Both results must point at the same routed store handle — the dedupe
+	// is what prevents the flock deadlock.
+	if results[0].Store != results[1].Store {
+		t.Error("both results should share one routed store handle to avoid flock deadlock")
+	}
+
+	// Sanity: the close path can mutate via that store.
+	if err := results[0].Store.CloseIssue(ctx, results[0].ResolvedID, "Closed", "test", ""); err != nil {
+		t.Fatalf("CloseIssue via routed store failed: %v", err)
+	}
+	closed, err := results[0].Store.GetIssue(ctx, results[0].ResolvedID)
+	if err != nil {
+		t.Fatalf("re-read closed issue: %v", err)
+	}
+	if closed.Status != types.StatusClosed {
+		t.Errorf("issue status = %q, want %q", closed.Status, types.StatusClosed)
+	}
+}
+
+// TestResolveCloseTargets_LocalStoreUnchanged guards the maintainer-mode
+// (no-routing) path: when an issue lives in the local store, resolveCloseTargets
+// must resolve it without ever opening a routed store.
+func TestResolveCloseTargets_LocalStoreUnchanged(t *testing.T) {
+	initConfigForTest(t)
+
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	runCmd(t, tmpDir, "git", "init", repoDir)
+	runCmd(t, repoDir, "git", "config", "beads.role", "maintainer")
+
+	localStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
+	ctx := context.Background()
+
+	issue := &types.Issue{
+		ID:        "shared-local",
+		Title:     "local-only issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := localStore.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("seed local issue: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("chdir repoDir: %v", err)
+	}
+
+	results, cleanup, err := resolveCloseTargets(ctx, localStore, []string{"shared-local"})
+	if err != nil {
+		t.Fatalf("resolveCloseTargets: %v", err)
+	}
+	defer cleanup()
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Routed {
+		t.Error("results[0].Routed = true, want false (issue is local)")
+	}
+	if results[0].Store != localStore {
+		t.Error("results[0].Store should be the local store for non-routed lookup")
+	}
+}

--- a/cmd/bd/close_routing_test.go
+++ b/cmd/bd/close_routing_test.go
@@ -17,13 +17,12 @@ import (
 // while bd show / bd update succeeded for the same IDs because they routed via
 // resolveAndGetIssueWithRouting and close did not. The fix uses
 // resolveCloseTargets, which performs the same routing fallback and shares one
-// routed-store handle across IDs to avoid the GH#3586 flock-deadlock pattern
-// when multiple IDs route to the same target.
+// routed-store handle across IDs when multiple IDs route to the same target.
 //
 // The cases cover:
 //   - maintainer-mode local resolution (no routing involved)
 //   - contributor-mode batch where every ID lives in the planning store
-//     (must share one routed-store handle to avoid the deadlock)
+//     (must share one routed-store handle)
 //   - contributor-mode mixed batch with one local ID and one routed ID
 //     (validates the per-result store routing and the mutatedStores fan-out)
 func TestResolveCloseTargets(t *testing.T) {
@@ -99,8 +98,8 @@ func TestResolveCloseTargets(t *testing.T) {
 				for _, id := range tc.planningSeed {
 					seedIssue(t, ctx, planningStore, id)
 				}
-				// Release the planning store's flock so resolveCloseTargets'
-				// openRoutedReadStore call can acquire it.
+				// Release the planning store so resolveCloseTargets can open
+				// the routed store through the normal command path.
 				if err := planningStore.Close(); err != nil {
 					t.Fatalf("close planning store: %v", err)
 				}
@@ -125,9 +124,8 @@ func TestResolveCloseTargets(t *testing.T) {
 				t.Fatalf("got %d results, want %d", len(results), len(tc.inputIDs))
 			}
 
-			// Track the first routed-store handle we see so we can assert that
-			// every subsequent routed result reuses it (the dedupe that prevents
-			// the GH#3586 flock deadlock).
+			// Track the first routed-store handle we see so every subsequent
+			// routed result reuses the same batch handle.
 			var sharedRoutedStore storage.DoltStorage
 
 			for i, r := range results {
@@ -156,7 +154,7 @@ func TestResolveCloseTargets(t *testing.T) {
 					if sharedRoutedStore == nil {
 						sharedRoutedStore = r.Store
 					} else if r.Store != sharedRoutedStore {
-						t.Errorf("result[%d].Store: routed handles should be deduped to one shared handle (flock-deadlock guard)", i)
+						t.Errorf("result[%d].Store: routed handles should be deduped to one shared handle", i)
 					}
 				default:
 					t.Fatalf("unknown wantStoreOrigin[%d] = %q", i, tc.wantStoreOrigin[i])

--- a/cmd/bd/close_routing_test.go
+++ b/cmd/bd/close_routing_test.go
@@ -8,157 +8,175 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// TestResolveCloseTargets_RoutesToContributorPlanning is the regression test
-// for beads-0km: bd close failed for issues that lived only in the routed
-// contributor planning store, while bd show / bd update succeeded for the
-// same IDs because they routed via resolveAndGetIssueWithRouting and close
-// did not. The fix uses resolveCloseTargets, which now performs the same
-// routing fallback (and shares one routed-store handle across IDs to avoid
-// the GH#3586 flock-deadlock pattern when multiple IDs route to one target).
-func TestResolveCloseTargets_RoutesToContributorPlanning(t *testing.T) {
-	initConfigForTest(t)
-
-	tmpDir := t.TempDir()
-	repoDir := filepath.Join(tmpDir, "repo")
-	planningDir := filepath.Join(tmpDir, "planning")
-
-	runCmd(t, tmpDir, "git", "init", repoDir)
-	runCmd(t, repoDir, "git", "config", "beads.role", "contributor")
-
-	primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
-	ctx := context.Background()
-
-	if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
-		t.Fatalf("set routing.mode: %v", err)
-	}
-	if err := primaryStore.SetConfig(ctx, "routing.contributor", planningDir); err != nil {
-		t.Fatalf("set routing.contributor: %v", err)
-	}
-
-	// Planning store with two issues that share the primary's prefix —
-	// the contributor-routing layout `bd create` produces in this scenario.
-	planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
-	for _, id := range []string{"shared-aaa", "shared-bbb"} {
-		issue := &types.Issue{
-			ID:        id,
-			Title:     "planning issue " + id,
-			Status:    types.StatusOpen,
-			Priority:  2,
-			IssueType: types.TypeTask,
-		}
-		if err := planningStore.CreateIssue(ctx, issue, "test"); err != nil {
-			t.Fatalf("seed planning issue %s: %v", id, err)
-		}
-	}
-	// Release the lock so openRoutedReadStore can acquire it.
-	if err := planningStore.Close(); err != nil {
-		t.Fatalf("close planning store: %v", err)
-	}
-
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWD) })
-	if err := os.Chdir(repoDir); err != nil {
-		t.Fatalf("chdir repoDir: %v", err)
-	}
-
-	// Multi-id batch: this is the deadlock-prone case. resolveCloseTargets
-	// must open the routed store at most once and reuse it across both IDs.
-	results, cleanup, err := resolveCloseTargets(ctx, primaryStore, []string{"shared-aaa", "shared-bbb"})
-	if err != nil {
-		t.Fatalf("resolveCloseTargets: %v", err)
-	}
-	defer cleanup()
-
-	if got, want := len(results), 2; got != want {
-		t.Fatalf("got %d results, want %d", got, want)
-	}
-	wantIDs := []string{"shared-aaa", "shared-bbb"}
-	for i, r := range results {
-		if r == nil || r.Issue == nil {
-			t.Fatalf("result[%d] missing Issue", i)
-		}
-		if r.ResolvedID != wantIDs[i] {
-			t.Errorf("result[%d].ResolvedID = %q, want %q", i, r.ResolvedID, wantIDs[i])
-		}
-		if !r.Routed {
-			t.Errorf("result[%d].Routed = false, want true (issue lives in planning store)", i)
-		}
-		if r.Store == nil {
-			t.Errorf("result[%d].Store is nil", i)
-		}
-	}
-	// Both results must point at the same routed store handle — the dedupe
-	// is what prevents the flock deadlock.
-	if results[0].Store != results[1].Store {
-		t.Error("both results should share one routed store handle to avoid flock deadlock")
+// TestResolveCloseTargets is the regression test for beads-0km: bd close
+// failed for issues that lived only in the routed contributor planning store,
+// while bd show / bd update succeeded for the same IDs because they routed via
+// resolveAndGetIssueWithRouting and close did not. The fix uses
+// resolveCloseTargets, which performs the same routing fallback and shares one
+// routed-store handle across IDs to avoid the GH#3586 flock-deadlock pattern
+// when multiple IDs route to the same target.
+//
+// The cases cover:
+//   - maintainer-mode local resolution (no routing involved)
+//   - contributor-mode batch where every ID lives in the planning store
+//     (must share one routed-store handle to avoid the deadlock)
+//   - contributor-mode mixed batch with one local ID and one routed ID
+//     (validates the per-result store routing and the mutatedStores fan-out)
+func TestResolveCloseTargets(t *testing.T) {
+	cases := []struct {
+		name            string
+		role            string   // git config beads.role value
+		enableRouting   bool     // set routing.mode=auto + routing.contributor=<planningDir>
+		localSeed       []string // IDs to create in the primary (local) store
+		planningSeed    []string // IDs to create in the planning store; non-nil also creates the dir
+		inputIDs        []string // argument to resolveCloseTargets
+		wantRoutedFlag  []bool   // expected RoutedResult.Routed per result
+		wantStoreOrigin []string // per result: "local" (== primaryStore) or "planning" (routed handle)
+	}{
+		{
+			name:            "maintainer_local_only",
+			role:            "maintainer",
+			enableRouting:   false,
+			localSeed:       []string{"shared-local"},
+			inputIDs:        []string{"shared-local"},
+			wantRoutedFlag:  []bool{false},
+			wantStoreOrigin: []string{"local"},
+		},
+		{
+			name:            "contributor_batch_all_routed_shares_one_handle",
+			role:            "contributor",
+			enableRouting:   true,
+			planningSeed:    []string{"shared-aaa", "shared-bbb"},
+			inputIDs:        []string{"shared-aaa", "shared-bbb"},
+			wantRoutedFlag:  []bool{true, true},
+			wantStoreOrigin: []string{"planning", "planning"},
+		},
+		{
+			name:            "contributor_mixed_local_and_routed",
+			role:            "contributor",
+			enableRouting:   true,
+			localSeed:       []string{"shared-here"},
+			planningSeed:    []string{"shared-there"},
+			inputIDs:        []string{"shared-here", "shared-there"},
+			wantRoutedFlag:  []bool{false, true},
+			wantStoreOrigin: []string{"local", "planning"},
+		},
 	}
 
-	// Sanity: the close path can mutate via that store.
-	if err := results[0].Store.CloseIssue(ctx, results[0].ResolvedID, "Closed", "test", ""); err != nil {
-		t.Fatalf("CloseIssue via routed store failed: %v", err)
-	}
-	closed, err := results[0].Store.GetIssue(ctx, results[0].ResolvedID)
-	if err != nil {
-		t.Fatalf("re-read closed issue: %v", err)
-	}
-	if closed.Status != types.StatusClosed {
-		t.Errorf("issue status = %q, want %q", closed.Status, types.StatusClosed)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			initConfigForTest(t)
+
+			tmpDir := t.TempDir()
+			repoDir := filepath.Join(tmpDir, "repo")
+			planningDir := filepath.Join(tmpDir, "planning")
+
+			runCmd(t, tmpDir, "git", "init", repoDir)
+			runCmd(t, repoDir, "git", "config", "beads.role", tc.role)
+
+			primaryStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
+			ctx := context.Background()
+
+			if tc.enableRouting {
+				if err := primaryStore.SetConfig(ctx, "routing.mode", "auto"); err != nil {
+					t.Fatalf("set routing.mode: %v", err)
+				}
+				if err := primaryStore.SetConfig(ctx, "routing.contributor", planningDir); err != nil {
+					t.Fatalf("set routing.contributor: %v", err)
+				}
+			}
+
+			for _, id := range tc.localSeed {
+				seedIssue(t, ctx, primaryStore, id)
+			}
+
+			if len(tc.planningSeed) > 0 {
+				planningStore := newTestStoreIsolatedDB(t, filepath.Join(planningDir, ".beads", "beads.db"), "shared")
+				for _, id := range tc.planningSeed {
+					seedIssue(t, ctx, planningStore, id)
+				}
+				// Release the planning store's flock so resolveCloseTargets'
+				// openRoutedReadStore call can acquire it.
+				if err := planningStore.Close(); err != nil {
+					t.Fatalf("close planning store: %v", err)
+				}
+			}
+
+			oldWD, err := os.Getwd()
+			if err != nil {
+				t.Fatalf("getwd: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			if err := os.Chdir(repoDir); err != nil {
+				t.Fatalf("chdir repoDir: %v", err)
+			}
+
+			results, cleanup, err := resolveCloseTargets(ctx, primaryStore, tc.inputIDs)
+			if err != nil {
+				t.Fatalf("resolveCloseTargets: %v", err)
+			}
+			defer cleanup()
+
+			if len(results) != len(tc.inputIDs) {
+				t.Fatalf("got %d results, want %d", len(results), len(tc.inputIDs))
+			}
+
+			// Track the first routed-store handle we see so we can assert that
+			// every subsequent routed result reuses it (the dedupe that prevents
+			// the GH#3586 flock deadlock).
+			var sharedRoutedStore storage.DoltStorage
+
+			for i, r := range results {
+				if r == nil || r.Issue == nil {
+					t.Fatalf("result[%d] missing Issue", i)
+				}
+				if r.ResolvedID != tc.inputIDs[i] {
+					t.Errorf("result[%d].ResolvedID = %q, want %q", i, r.ResolvedID, tc.inputIDs[i])
+				}
+				if r.Routed != tc.wantRoutedFlag[i] {
+					t.Errorf("result[%d].Routed = %v, want %v", i, r.Routed, tc.wantRoutedFlag[i])
+				}
+
+				switch tc.wantStoreOrigin[i] {
+				case "local":
+					if r.Store != primaryStore {
+						t.Errorf("result[%d].Store should be the local primary store", i)
+					}
+				case "planning":
+					if r.Store == nil {
+						t.Errorf("result[%d].Store is nil", i)
+					}
+					if r.Store == primaryStore {
+						t.Errorf("result[%d].Store should be the routed planning store, not the local one", i)
+					}
+					if sharedRoutedStore == nil {
+						sharedRoutedStore = r.Store
+					} else if r.Store != sharedRoutedStore {
+						t.Errorf("result[%d].Store: routed handles should be deduped to one shared handle (flock-deadlock guard)", i)
+					}
+				default:
+					t.Fatalf("unknown wantStoreOrigin[%d] = %q", i, tc.wantStoreOrigin[i])
+				}
+			}
+		})
 	}
 }
 
-// TestResolveCloseTargets_LocalStoreUnchanged guards the maintainer-mode
-// (no-routing) path: when an issue lives in the local store, resolveCloseTargets
-// must resolve it without ever opening a routed store.
-func TestResolveCloseTargets_LocalStoreUnchanged(t *testing.T) {
-	initConfigForTest(t)
-
-	tmpDir := t.TempDir()
-	repoDir := filepath.Join(tmpDir, "repo")
-	runCmd(t, tmpDir, "git", "init", repoDir)
-	runCmd(t, repoDir, "git", "config", "beads.role", "maintainer")
-
-	localStore := newTestStoreIsolatedDB(t, filepath.Join(repoDir, ".beads", "beads.db"), "shared")
-	ctx := context.Background()
-
+// seedIssue creates a minimal open task in the given store for test fixtures.
+func seedIssue(t *testing.T, ctx context.Context, s storage.DoltStorage, id string) {
+	t.Helper()
 	issue := &types.Issue{
-		ID:        "shared-local",
-		Title:     "local-only issue",
+		ID:        id,
+		Title:     "test issue " + id,
 		Status:    types.StatusOpen,
 		Priority:  2,
 		IssueType: types.TypeTask,
 	}
-	if err := localStore.CreateIssue(ctx, issue, "test"); err != nil {
-		t.Fatalf("seed local issue: %v", err)
-	}
-
-	oldWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWD) })
-	if err := os.Chdir(repoDir); err != nil {
-		t.Fatalf("chdir repoDir: %v", err)
-	}
-
-	results, cleanup, err := resolveCloseTargets(ctx, localStore, []string{"shared-local"})
-	if err != nil {
-		t.Fatalf("resolveCloseTargets: %v", err)
-	}
-	defer cleanup()
-
-	if len(results) != 1 {
-		t.Fatalf("got %d results, want 1", len(results))
-	}
-	if results[0].Routed {
-		t.Error("results[0].Routed = true, want false (issue is local)")
-	}
-	if results[0].Store != localStore {
-		t.Error("results[0].Store should be the local store for non-routed lookup")
+	if err := s.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("seed issue %s: %v", id, err)
 	}
 }

--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -40,6 +40,10 @@ type doltAutoCommitParams struct {
 //   - Uses Dolt's "commit all" behavior under the hood (DOLT_COMMIT -Am).
 //   - Treats "nothing to commit" as a no-op.
 func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
+	return maybeAutoCommitStore(ctx, getStore(), p)
+}
+
+func maybeAutoCommitStore(ctx context.Context, st storage.DoltStorage, p doltAutoCommitParams) error {
 	mode, err := getDoltAutoCommitMode()
 	if err != nil {
 		return err
@@ -50,7 +54,6 @@ func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
 		return nil
 	}
 
-	st := getStore()
 	if st == nil {
 		return nil
 	}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -5417,8 +5417,9 @@ The Rig → Cook → Run lifecycle:
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -5465,8 +5466,9 @@ List all formulas from search paths.
 
 Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 
@@ -6000,7 +6002,8 @@ Variable syntax (both work - we detect which side is the concrete value):
 
 Output locations (first writable wins):
   1. &lt;resolved-beads-dir&gt;/formulas/ (project-level, default)
-  2. ~/.beads/formulas/     (user-level, if project not writable)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/     (user-level, if project not writable)
 
 Examples:
   bd mol distill bd-o5xe my-workflow
@@ -6133,8 +6136,9 @@ attempting to spawn work from a formula.
 
 Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
-  2. ~/.beads/formulas/ (user level)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user level)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula

--- a/website/docs/cli-reference/formula.md
+++ b/website/docs/cli-reference/formula.md
@@ -22,8 +22,9 @@ The Rig → Cook → Run lifecycle:
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -70,8 +71,9 @@ List all formulas from search paths.
 
 Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 

--- a/website/docs/cli-reference/mol.md
+++ b/website/docs/cli-reference/mol.md
@@ -197,7 +197,8 @@ Variable syntax (both work - we detect which side is the concrete value):
 
 Output locations (first writable wins):
   1. &lt;resolved-beads-dir&gt;/formulas/ (project-level, default)
-  2. ~/.beads/formulas/     (user-level, if project not writable)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/     (user-level, if project not writable)
 
 Examples:
   bd mol distill bd-o5xe my-workflow
@@ -330,8 +331,9 @@ attempting to spawn work from a formula.
 
 Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
-  2. ~/.beads/formulas/ (user level)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user level)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula

--- a/website/versioned_docs/version-1.0.0/cli-reference/formula.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/formula.md
@@ -22,8 +22,9 @@ The Rig → Cook → Run lifecycle:
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -70,8 +71,9 @@ List all formulas from search paths.
 
 Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/mol.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/mol.md
@@ -197,7 +197,8 @@ Variable syntax (both work - we detect which side is the concrete value):
 
 Output locations (first writable wins):
   1. &lt;resolved-beads-dir&gt;/formulas/ (project-level, default)
-  2. ~/.beads/formulas/     (user-level, if project not writable)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/     (user-level, if project not writable)
 
 Examples:
   bd mol distill bd-o5xe my-workflow
@@ -330,8 +331,9 @@ attempting to spawn work from a formula.
 
 Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
-  2. ~/.beads/formulas/ (user level)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user level)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula


### PR DESCRIPTION
> **Note from author:** I think this change might be too heavy — the call-site
> dedupe in `resolveCloseTargets` adds ~70 lines of routing wiring to one
> command, and a maintainer might prefer a different shape. Curious about your
> opinions on the design choice (see "Open design question" below) before this
> lands. Happy to rework.

## Summary

Fixes #3608.

`bd close <id>` previously errored with `no issue found matching <id>` in
workspaces with contributor auto-routing (`routing.mode=auto` +
`routing.contributor=<path>` + `beads.role=contributor`), even for IDs that
`bd create` had just returned. `bd show` and `bd update` already routed
through `resolveAndGetIssueWithRouting`; `bd close` did not. The issue lives
in the routed planning store, so the local primary lookup misses and `close`
errors while `show`/`update` fall through to `resolveViaAutoRouting` and
succeed.

## Fix

- New `resolveCloseTargets` helper in `cmd/bd/close.go`. Tries the local
  store first, then a single shared contributor-routed handle reused across
  every routed ID, then explicit prefix routing as a last resort.
- Per-id close loop now uses each `RoutedResult.Store` for `IsBlocked`,
  `CloseIssue`, `autoCloseCompletedMolecule`, and the re-fetch.
  `countEpicOpenChildren` takes an explicit store parameter.
- `CommitPending` fans out across every mutated store so embedded mode
  flushes the routed store too.
- `--suggest-next`, `--continue`, `--claim-next` use the first resolved
  result's store (matches the common-case assumption that all IDs route
  together).

## Why "shared" routed handle

Opening the routed embeddeddolt store more than once in the same process
deadlocks on its flock — same class as #3586. Per-id routing inside `bd close`
would hit that for every multi-id close where the IDs all live in the
planning store (the common case). The shared handle dedupes per-call.

## Open design question

There's an open in-tree decision (`beads-pss`) about whether
`resolveCloseTargets` should stay call-site-local or move down a layer.
Three options:

- **A. Status quo (this PR).** Smallest, most surgical. Future multi-id
  commands that want routing fallback will need to copy this dedupe shape.
- **B. Promote `resolveCloseTargets` to a shared `cmd/bd/` helper.** One
  immediate beneficiary outside close.go: `bd dep add --bulk` (#beads-lcw,
  hits the same flock pattern). Other callers are single-id and don't need
  it.
- **C. Refcount embeddeddolt opens by path within one process** (#beads-0nj).
  Kills the deadlock class entirely and removes the need for the batching
  helper. Larger refactor with subtle lifecycle bugs to avoid (mixed
  read/read-write opens, first-opener-closes-before-second-borrower).

I picked A as the smallest correct fix in isolation, but B is roughly one
PR's worth of work and would let beads-lcw close too. Happy to switch to B
in this PR if you prefer.

## Test plan

- [x] `make build` clean.
- [x] `golangci-lint run --new-from-rev=main ./cmd/bd/...`: 0 new issues.
- [x] New table-driven `TestResolveCloseTargets` in `cmd/bd/close_routing_test.go`
  covers maintainer-mode local-only resolution, contributor-mode all-routed
  batch (asserts shared-handle dedupe), and contributor-mode mixed
  local+routed batch.
- [x] Manual verification in a contributor-routed workspace: `bd close <id>`
  (single), `bd close <id1> <id2> <id3>` (bulk), and a maintainer-mode close
  regression all behave as expected.
- [x] `make test`: zero new failures versus `main` run from the same checkout.

## Notes

- The new `TestResolveCloseTargets` cases skip when no Dolt test server is
  available (`//go:build cgo`, gated by `testDoltServerPort`); the assertion
  shape is preserved for CI environments that have it.
- `make test` from a workspace whose project root contains a populated
  `.beads/` directory will surface two unrelated pre-existing failures
  (`TestInstallHooksBeads_WorktreeAccess` — git template lacks an initial
  commit, fails on git 2.39+; `TestResolveWhereBeadsDir_UsesInitializedDBPath`
  — leaks the workspace `.beads/` via `FindBeadsDir`, same shape as the note
  in #3578). Both reproduce on a clean `main` checkout from the project
  root and have been logged as separate issues for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->