### PR TITLE
fix(storage): emit placeholders for cross-rig dependency targets

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -780,6 +780,13 @@ Examples:
 			default:
 				idStr = iss.ID
 			}
+			// Cross-rig placeholder: storage layer emits zero-value Issue
+			// (empty Title and Status) when the dep target lives in another
+			// rig DB. Render with a marker so users see the edge.
+			if iss.Title == "" && iss.Status == "" {
+				fmt.Printf("  %s: (cross-rig) via %s\n", idStr, iss.DependencyType)
+				continue
+			}
 			fmt.Printf("  %s: %s [P%d] (%s) via %s\n",
 				idStr, iss.Title, iss.Priority, iss.Status, iss.DependencyType)
 		}

--- a/cmd/bd/dep_test.go
+++ b/cmd/bd/dep_test.go
@@ -1469,3 +1469,121 @@ func TestDepListCrossRigRouting(t *testing.T) {
 
 	t.Log("Successfully resolved cross-rig dependencies via routing")
 }
+
+// TestDepListCrossRigDepTarget is a regression test for bd-mtc / hq-mtc.
+//
+// Scenario: gt-child1 lives in rig DB "gt" and has a `blocks` dep on hq-foo
+// which lives in town DB "hq". The dependency row exists in the "gt" DB
+// (`dependencies` table), but the target issue (hq-foo) is NOT in "gt" — it's
+// in "hq".
+//
+// Bug (before fix): GetDependenciesWithMetadata silently dropped the dep row
+// because the target was missing from the local DB → bd dep list said
+// "no dependencies" and gt convoy stage saw zero edges.
+//
+// Fix: storage layer now emits a placeholder IssueWithDependencyMetadata
+// (Issue with only ID set) so callers see the dep edge.
+func TestDepListCrossRigDepTarget(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	rigBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("Failed to create rig beads dir: %v", err)
+	}
+	rigDBPath := filepath.Join(rigBeadsDir, "dolt")
+	rigStore := newTestStoreIsolatedDB(t, rigDBPath, "gt")
+	defer rigStore.Close()
+
+	// Create gt-child1 in this rig DB. NOTE: hq-foo is NOT created here —
+	// it represents an issue that lives in a different rig's DB entirely.
+	child := &types.Issue{
+		ID:        "gt-child1",
+		Title:     "Child Issue",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := rigStore.CreateIssue(ctx, child, "test"); err != nil {
+		t.Fatalf("Failed to create child issue: %v", err)
+	}
+
+	// gt-child1 depends on hq-foo (which doesn't exist in this DB).
+	// This mirrors how cross-rig deps are stored in production.
+	dep := &types.Dependency{
+		IssueID:     "gt-child1",
+		DependsOnID: "hq-foo",
+		Type:        types.DepBlocks,
+	}
+	if err := rigStore.AddDependency(ctx, dep, "test"); err != nil {
+		t.Fatalf("Failed to add cross-rig dependency: %v", err)
+	}
+
+	// Down direction: gt-child1 should report depending on hq-foo (placeholder).
+	deps, err := rigStore.GetDependenciesWithMetadata(ctx, "gt-child1")
+	if err != nil {
+		t.Fatalf("GetDependenciesWithMetadata failed: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("Expected 1 dependency (placeholder for hq-foo), got %d", len(deps))
+	}
+	if deps[0].ID != "hq-foo" {
+		t.Errorf("Expected dependency on hq-foo, got %s", deps[0].ID)
+	}
+	if string(deps[0].DependencyType) != string(types.DepBlocks) {
+		t.Errorf("Expected dep type %q, got %q", types.DepBlocks, deps[0].DependencyType)
+	}
+	// Placeholder identification: title and status should be zero-value.
+	if deps[0].Title != "" {
+		t.Errorf("Expected empty Title for cross-rig placeholder, got %q", deps[0].Title)
+	}
+	if deps[0].Status != "" {
+		t.Errorf("Expected empty Status for cross-rig placeholder, got %q", deps[0].Status)
+	}
+
+	// Up direction: hq-foo should report being depended on by gt-child1.
+	// The local issue (gt-child1) is fully populated, no placeholder needed.
+	dependents, err := rigStore.GetDependentsWithMetadata(ctx, "hq-foo")
+	if err != nil {
+		t.Fatalf("GetDependentsWithMetadata failed: %v", err)
+	}
+	if len(dependents) != 1 {
+		t.Fatalf("Expected 1 dependent of hq-foo, got %d", len(dependents))
+	}
+	if dependents[0].ID != "gt-child1" {
+		t.Errorf("Expected dependent gt-child1, got %s", dependents[0].ID)
+	}
+
+	// Up direction with cross-rig dependent: simulate hq-foo being depended on
+	// by an issue (gt-child2) that is local to this rig — we already covered
+	// that above. Now test the inverse: a dep row points FROM a missing local
+	// issue TO a local issue. This shouldn't happen in practice (you can't
+	// create a dep from a non-existent issue) but exercise the placeholder
+	// path on the dependents query just to be safe.
+	otherDep := &types.Dependency{
+		IssueID:     "hq-bar",    // doesn't exist locally
+		DependsOnID: "gt-child1", // exists locally
+		Type:        types.DepBlocks,
+	}
+	if err := rigStore.AddDependency(ctx, otherDep, "test"); err != nil {
+		// Some stores may reject this if they validate issue existence;
+		// that's fine. Skip the rest if so.
+		t.Logf("Could not insert cross-rig dependent row (storage validates): %v", err)
+		return
+	}
+	dependents2, err := rigStore.GetDependentsWithMetadata(ctx, "gt-child1")
+	if err != nil {
+		t.Fatalf("GetDependentsWithMetadata after cross-rig dependent failed: %v", err)
+	}
+	// Expect both: gt-child1 (no, that's self) — actually gt-child2 from above
+	// doesn't exist; we expect at least one entry containing hq-bar placeholder.
+	foundPlaceholder := false
+	for _, d := range dependents2 {
+		if d.ID == "hq-bar" && d.Title == "" && d.Status == "" {
+			foundPlaceholder = true
+		}
+	}
+	if !foundPlaceholder {
+		t.Errorf("Expected hq-bar placeholder dependent of gt-child1, got %+v", dependents2)
+	}
+}

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -174,6 +174,15 @@ func (s *DoltStore) GetDependenciesWithMetadata(ctx context.Context, issueID str
 	for _, d := range deps {
 		issue, ok := issueMap[d.depID]
 		if !ok {
+			// Cross-rig dependency: target issue lives in a different Dolt
+			// database. Emit a placeholder with just the ID so callers see the
+			// dep edge instead of silently dropping it. The Title/Status fields
+			// are zero-value; CLI consumers should render these as "(cross-rig)".
+			// See bd-mtc / hq-mtc for context.
+			results = append(results, &types.IssueWithDependencyMetadata{
+				Issue:          types.Issue{ID: d.depID},
+				DependencyType: types.DependencyType(d.depType),
+			})
 			continue
 		}
 		results = append(results, &types.IssueWithDependencyMetadata{

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -358,6 +358,15 @@ func GetDependenciesWithMetadataInTx(ctx context.Context, tx *sql.Tx, issueID st
 	for _, d := range deps {
 		issue, ok := issueMap[d.depID]
 		if !ok {
+			// Cross-rig dependency: target issue lives in a different Dolt
+			// database. Emit a placeholder with just the ID so callers see the
+			// dep edge instead of silently dropping it. CLI consumers should
+			// render zero-value Issues as "(cross-rig)".
+			// See bd-mtc / hq-mtc for context.
+			results = append(results, &types.IssueWithDependencyMetadata{
+				Issue:          types.Issue{ID: d.depID},
+				DependencyType: types.DependencyType(d.depType),
+			})
 			continue
 		}
 		results = append(results, &types.IssueWithDependencyMetadata{
@@ -421,6 +430,11 @@ func GetDependentsWithMetadataInTx(ctx context.Context, tx *sql.Tx, issueID stri
 	for _, d := range deps {
 		issue, ok := issueMap[d.depID]
 		if !ok {
+			// Cross-rig dependent: see GetDependenciesWithMetadataInTx for rationale.
+			results = append(results, &types.IssueWithDependencyMetadata{
+				Issue:          types.Issue{ID: d.depID},
+				DependencyType: types.DependencyType(d.depType),
+			})
 			continue
 		}
 		results = append(results, &types.IssueWithDependencyMetadata{


### PR DESCRIPTION
## Summary

`GetDependenciesWithMetadata` and `GetDependentsWithMetadata` previously silently dropped dependency rows whose target/source issue did not exist in the local Dolt database. In multi-rig (gastown) deployments this hid all cross-rig dep edges from `bd dep list` and any caller that uses these methods (incl. `gt convoy stage` wave computation), producing wrong wave layering and silently-broken epic/parent-child status propagation.

## Repro (before fix)

```sh
cd ~/gt/<rig>
bd create -t task --title "Local issue"        # → gt-foo
bd dep add gt-foo hq-bar                        # add cross-rig dep (target lives in town)
bd dep list gt-foo                              # → "gt-foo has no dependencies" ❌
```

Direct SQL confirms the row exists:
```sql
USE <rig>; SELECT * FROM dependencies WHERE issue_id='gt-foo';
-- gt-foo | hq-bar | blocks   (row IS there)
```

## Fix

In both `DoltStore.GetDependenciesWithMetadata` and the shared `issueops.GetDependenciesWithMetadataInTx` / `GetDependentsWithMetadataInTx`, emit a placeholder `IssueWithDependencyMetadata` (Issue with only `ID` populated) when the target/source is not local, instead of `continue`-ing past the row.

`bd dep list` now renders cross-rig placeholders as:
```
  hq-bar: (cross-rig) via blocks
```

JSON output also includes the placeholder entry (Title="", Status="" — easy to detect downstream).

## Downstream impact

Callers that semantically check dep targets will now see cross-rig deps:
- `gt convoy stage` wave computation gets correct DAG layering across rigs
- Epic auto-close in `cmd/bd/close.go` will (correctly) refuse to close when cross-rig children are open
- `internal/tracker/engine.go` propagation now sees full graph

The previous behavior was a silent correctness bug; downstream callers were already best-effort tolerant of partial data.

## Tests

Adds `TestDepListCrossRigDepTarget` in `cmd/bd/dep_test.go` covering both down (deps) and up (dependents) directions with a target that lives in a different DB than the source. Verifies:
- Placeholder appears with `ID` set, `Title=""`, `Status=""`
- `DependencyType` is preserved
- Both `GetDependenciesWithMetadata` and `GetDependentsWithMetadata` paths emit placeholders

All existing `TestDep*`, `TestShow*`, `TestRelate*`, `TestClose*`, `TestMol*`, `TestCritical*`, `TestTracker*`, `TestDuplicates*`, `TestAdo*`, `TestTemplate*`, full `internal/storage/...`, and `internal/tracker/...` `internal/gitlab/...` `internal/jira/...` test suites pass.

## Refs

Filed as `hq-mtc` in our internal beads tracker; companion fix to `gastown` is unnecessary — gastown's `bdDepList` already routes correctly per-bead via `resolveBeadDir` and was just receiving empty results. With this fix, `gt convoy stage` cross-rig waves work correctly with no gastown change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->