### PR TITLE
fix(hooks): use BeadsDirPerm (0700) for .beads/hooks directory

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -753,8 +753,14 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 		}
 	}
 
-	// Create hooks directory if it doesn't exist
-	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+	// Create hooks directory if it doesn't exist.
+	// Directories inside .beads/ use BeadsDirPerm (0700); git-managed hook
+	// dirs (.git/hooks, .beads-hooks) use 0755 so git can execute them.
+	hooksDirPerm := os.FileMode(0755)
+	if beadsHooks {
+		hooksDirPerm = config.BeadsDirPerm
+	}
+	if err := os.MkdirAll(hooksDir, hooksDirPerm); err != nil {
 		return fmt.Errorf("failed to create hooks directory: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

When `bd hooks install` runs in beads mode (`--beads` flag), `hooksDir` resolves to `<beadsDir>/hooks` — a path inside the `.beads/` hierarchy. The directory was being created with `0755`, inconsistent with `config.BeadsDirPerm` (0700) and causing world-readable permission warnings.

## Fix

Track whether the directory is beads-owned and use `config.BeadsDirPerm` for that case. Git-managed hook directories (`.git/hooks`, `.beads-hooks`) keep `0755` since git itself needs to traverse and execute scripts in them.

```go
hooksDirPerm := os.FileMode(0755)
if beadsHooks {
    hooksDirPerm = config.BeadsDirPerm
}
if err := os.MkdirAll(hooksDir, hooksDirPerm); err != nil {
```

The `config` package is already imported in this file; no new dependencies.