### PR TITLE
docs(agents): document storage-driver boundary in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,28 @@ and credit their design/tests.
 
 See [AGENT_INSTRUCTIONS.md](AGENT_INSTRUCTIONS.md) for full development guidelines.
 
+## Storage Boundary
+
+Beads talks to storage through a driver interface (`dolthub/driver` for Dolt).
+Beads code should not reach across that boundary — no flocks, no engine
+introspection, no storage-engine-specific retry or crash-recovery logic in
+beads packages. Concurrency, locking, and crash-safety are the driver's job.
+
+If you find yourself adding storage-implementation details to beads code —
+especially anywhere on the public SDK surface (`OpenBestAvailable`, the
+`Storage` interface, return types crossing `pkg/`) — stop and reconsider.
+That is a signal the driver interface needs widening, not that beads needs
+more storage logic.
+
+**Roadmap target:** all storage interaction lives behind the driver. Beads
+stays storage-agnostic.
+
+**Filing storage issues is still encouraged** — but flag them clearly so
+they can be routed to the driver (`dolthub/driver`) rather than patched
+beads-side. Reflexive workarounds in beads (extra locks, retries, schema
+poking) are exactly the kind of cross-boundary leak this direction is
+removing. When in doubt, file the issue and ask which side owns the fix.
+
 ## Agent Warning: Interactive Commands
 
 **DO NOT use `bd edit`** - it opens an interactive editor ($EDITOR) which AI agents cannot use.


### PR DESCRIPTION
## Summary

Adds a **Storage Boundary** section to `AGENTS.md` capturing the architectural direction that beads talks to storage through a driver interface (`dolthub/driver` for Dolt) and should not reach across that boundary. Concurrency, locking, and crash-safety are the driver's job; storage-implementation details should not appear on the public SDK surface.

The section also notes that storage issues are still welcome to be filed from the beads side — but should be flagged for routing to the driver rather than reflexively worked around in beads code (extra flocks, retries, schema poking).

## Why now

#3614 (removing the embedded-mode flock) is a concrete example of this direction in motion. The lifetime flock was beads reaching across the storage boundary to enforce an invariant the driver should own. Capturing the principle in `AGENTS.md` means future contributors and agents have the architectural context to avoid reintroducing the same kind of cross-boundary workaround by reflex when something goes sideways.

## Scope

- One file: `AGENTS.md` (+22 lines).
- No code changes, no behavior changes.
- Placed after the Visual Design Anti-Patterns section, before the tactical bd / shell guidance.

cc @coffeegoddd — would value your review since this codifies the storage-layer direction you've been driving. Happy to reword if any of the framing doesn't match how you'd describe the boundary.

## Test plan

- [x] `AGENTS.md` renders cleanly on GitHub
- [x] Reviewer confirms framing matches the intended driver-relationship roadmap

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->