### PR TITLE
chore(dolt): converge bd dolt clean-databases prefix list with firewall

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -662,16 +662,35 @@ servers are preserved.`,
 	},
 }
 
-// staleDatabasePrefixes identifies test/agent databases that should not persist
-// on the production Dolt server. These accumulate from interrupted test runs and
-// terminated agents, wasting server memory.
-// - testdb_*: BEADS_TEST_MODE=1 FNV hash of temp paths
-// - doctest_*: doctor test helpers
-// - doctortest_*: doctor test helpers
-// - beads_pt*: orchestrator patrol_helpers_test.go random prefixes
-// - beads_vr*: orchestrator mail/router_test.go random prefixes
-// - beads_t[0-9a-f]*: protocol test random prefixes (t + 8 hex chars)
-var staleDatabasePrefixes = []string{"testdb_", "doctest_", "doctortest_", "beads_pt", "beads_vr", "beads_t"}
+// staleDatabasePrefixes lists database name prefixes that
+// `bd dolt clean-databases` will drop. This is the cleanup side of the
+// test/prod split. Two sibling lists must converge with it (be-avn):
+//   - internal/storage/dolt/store.go:testDatabasePrefixes (firewall side)
+//   - .gc/system/packs/dolt/formulas/mol-dog-stale-db.toml (city formula)
+//
+// The firewall list, this cleanup list, and the formula list MUST
+// converge — operators rely on consistent semantics across `bd dolt
+// clean-databases`, the SQL-side firewall, and `gc dolt cleanup`.
+//
+// Origin of each prefix:
+//   - testdb_     : applyConfigDefaults derives this for BEADS_TEST_MODE=1
+//     without an explicit Database (FNV hash of cfg.Path).
+//   - beads_test  : convention for hand-written integration tests.
+//   - beads_pt    : property-test fixtures.
+//   - beads_vr    : version-roundtrip / migration fixtures.
+//   - doctest_    : `bd doctor` self-check fixtures.
+//   - doctortest_ : older `bd doctor` fixture name (kept for back-compat).
+//   - benchdb_    : per-bench scratch DBs (uniqueBenchDBName below,
+//     format `benchdb_<pid>_<8 hex>`).
+var staleDatabasePrefixes = []string{
+	"testdb_",
+	"beads_test",
+	"beads_pt",
+	"beads_vr",
+	"doctest_",
+	"doctortest_",
+	"benchdb_",
+}
 
 var doltCleanDatabasesCmd = &cobra.Command{
 	Use:   "clean-databases",
@@ -679,7 +698,7 @@ var doltCleanDatabasesCmd = &cobra.Command{
 	Long: `Identify and drop leftover test and agent databases that accumulate
 on the shared Dolt server from interrupted test runs and terminated agents.
 
-Stale database prefixes: testdb_*, doctest_*, doctortest_*, beads_pt*, beads_vr*, beads_t*
+Stale database prefixes: testdb_*, beads_test*, beads_pt*, beads_vr*, doctest_*, doctortest_*, benchdb_*
 
 These waste server memory and can degrade performance under concurrent load.
 Use --dry-run to see what would be dropped without actually dropping.`,

--- a/release-gates/be-ripy-gate.md
+++ b/release-gates/be-ripy-gate.md
@@ -1,0 +1,88 @@
+# Release gate — be-ripy (be-avn `staleDatabasePrefixes` canonical sync)
+
+**Date:** 2026-04-30
+**Deployer:** beads/deployer (deployer-1, fresh evaluation post-builder-rebase)
+**Bead (review):** be-ripy — Review: be-avn staleDatabasePrefixes canonical sync (AD-04 follow-up)
+**Feature bead:** be-avn (closed; source bead)
+**Reviewed commit:** `0f76453f` (rebased equivalent: `ee67d5f9` on `be-vzu-rebase-fix`)
+**Final branch:** `release/be-ripy` @ `1014c759` (cherry-pick of `ee67d5f9` onto `origin/main`)
+**Base:** `origin/main` @ `8694c535` ("doctor: detect AGENTS.md / CLAUDE.md user-authored divergence (#3600)")
+
+## Verdict: PASS
+
+## What this ships
+
+`bd dolt clean-databases` cleanup-side prefix list converged with the
+firewall-side `testDatabasePrefixes`. After this change:
+
+- `staleDatabasePrefixes` becomes `[testdb_, beads_test, beads_pt, beads_vr,
+  doctest_, doctortest_, benchdb_]` — the architect-canonical 7-prefix list.
+- Net behavioral change vs. prior list:
+  - **+** `benchdb_` now cleaned (closes the AD-04-documented bench-DB leaker)
+  - **+** `beads_test` now cleaned (matches firewall scope when be-c5p lands)
+  - **−** `beads_t<hex>` protocol-test prefix no longer matched by cleanup;
+    those workspaces clean themselves up in tearDown per AD-04 problem statement
+- The doc-block on `staleDatabasePrefixes` is restructured to mirror
+  `testDatabasePrefixes` (per-prefix origin notes plus a cross-reference
+  to the two sibling lists). The `Long:` help string is updated.
+
+## Criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | reviewer-gm-po6pox3 PASS verdict in be-ripy notes — 0 blockers, 0 high, 0 medium, 1 advisory low (out-of-scope doctor copy follow-up). |
+| 2 | Acceptance criteria met | PASS | All 4 ACs walked by reviewer (canonical list match, sibling list already matches, cross-reference doc-block, build/lint clean) — re-verified below. |
+| 3 | Tests pass | PASS | Build + vet clean on full repo; targeted tests PASS (see below). |
+| 4 | No HIGH-severity review findings open | PASS | 0 HIGH findings. The 1 LOW advisory (doctor's separate `staleDatabasePrefixes` is not converged) is explicitly out-of-scope per the bead's "Files in scope". |
+| 5 | Final branch is clean | PASS | `git status` clean on `release/be-ripy` (only untracked items are `.gc/` and `.gitkeep` from worktree harness, unrelated to this change). |
+| 6 | Branch diverges cleanly from main | PASS | `git cherry-pick ee67d5f9` onto `origin/main@8694c535` applied without conflict. Only one file changed (`cmd/bd/dolt.go`); no path overlap with the 32 commits on `origin/main` since the prior rebase base `f4c46d91`. |
+
+## Test evidence (criterion 3)
+
+Run from `release/be-ripy` @ `1014c759`:
+
+- `go build -tags gms_pure_go ./...` — clean (exit 0).
+- `go vet -tags gms_pure_go ./...` — clean (exit 0).
+- `go test -tags gms_pure_go -count=1 -run 'TestStaleCommand|TestDoltClean' ./cmd/bd/` — PASS (0.089s). Includes `TestStaleCommandInit` (Docker-gated `TestStaleSuite` skipped — Docker not available in deployer harness; runs on CI).
+- `go test -tags gms_pure_go -count=1 -run 'TestStaleDatabasePrefixes' ./cmd/bd/doctor/` — PASS (0.073s, 12 sub-tests). The doctor package has its own `staleDatabasePrefixes` list (out-of-scope per AD-04 bead), confirmed unaffected.
+
+The reviewer's targeted suite (`go build`, `golangci-lint run`) was independently re-verified at the source SHA before rebase. No new code paths in this commit — the change is a constant-list edit plus a doc-block rewrite, so existing coverage applies.
+
+## Cherry-pick mechanics (criterion 6)
+
+This deploy follows the precedent of PR #3562 / `release/be-l9q`: the bead
+covers a single commit, so the deployer cherry-picks just that commit onto
+fresh `origin/main` rather than shipping the full source branch. The
+reviewed SHA `0f76453f` was rebased by the builder to `ee67d5f9` after the
+gate-FAIL on the prior `be-l9q` deploy attempt; the builder confirmed
+content equivalence (`git diff ee67d5f9 0f76453f` shows only an unrelated
+`.gitattributes` upstream-noise hunk).
+
+Cherry-pick on top of current `origin/main` (8694c535) was conflict-free.
+Touched file (`cmd/bd/dolt.go`) was not modified by any of the 32 commits
+on `origin/main` since the prior rebase base, so the rebased commit's tree
+applies textually.
+
+## Cross-list convergence note (informational)
+
+The new doc-block declares the cleanup list, the firewall list
+(`internal/storage/dolt/store.go:testDatabasePrefixes`), and the city
+formula list "must converge". On current `origin/main`, the firewall
+list does not yet contain `benchdb_` (that addition lands with be-c5p,
+not yet shipped). After this deploy:
+
+- Cleanup list (this PR): `[testdb_, beads_test, beads_pt, beads_vr,
+  doctest_, doctortest_, benchdb_]` — 7 prefixes
+- Firewall list (`origin/main`): `[testdb_, beads_test, beads_pt,
+  beads_vr, doctest_, doctortest_]` — 6 prefixes (missing `benchdb_`)
+
+The two lists drift on `benchdb_` until be-c5p ships. This is a
+defense-in-depth gap (firewall doesn't reject `benchdb_*` at creation
+time on the production server), not a runtime regression — the cleanup
+job still drops them. Not a gate blocker.
+
+## Hand-off
+
+- Final branch `release/be-ripy` @ `1014c759` ready to push.
+- PR target: `gastownhall/beads:main` (origin), pushed via `quad341/beads`
+  (fork) per the rig's push-target protocol.


### PR DESCRIPTION
## What this changes

`bd dolt clean-databases` cleans up leftover test/agent databases from a
shared Dolt server. Its `staleDatabasePrefixes` list has been quietly
drifting out of sync with the firewall-side `testDatabasePrefixes` list
in `internal/storage/dolt/store.go`. This PR brings the two lists into
the same shape, so operators and reviewers can read either list and get
the same answer to "what counts as a test database?".

After this change, the cleanup list is:

```
testdb_, beads_test, beads_pt, beads_vr, doctest_, doctortest_, benchdb_
```

Net behavioral change for `bd dolt clean-databases`:

- **+ `benchdb_`** is now cleaned. These are the per-bench scratch DBs
  emitted by `cmd/bd/dolt.go:uniqueBenchDBName` (format
  `benchdb_<pid>_<8 hex>`). They were the most prominent leaker in the
  AD-04 problem statement.
- **+ `beads_test`** is now cleaned. Matches the firewall scope
  (production servers refuse this prefix).
- **− `beads_t`** is no longer matched. Protocol-test workspaces with
  this prefix self-clean in `tearDown`; they were never the leakers, and
  matching them risks false positives against any future legitimate
  database that happens to start with `beads_t`.

## Review notes

- **`cmd/bd/dolt.go`** is the only file touched. The doc-block on
  `staleDatabasePrefixes` has been restructured to mirror the firewall
  list's per-prefix origin notes plus an explicit cross-reference to
  the two sibling lists (`internal/storage/dolt/store.go:testDatabasePrefixes`
  and the city-formula list at
  `.gc/system/packs/dolt/formulas/mol-dog-stale-db.toml`).
- The comment block declares the three lists "must converge". The
  firewall list (`testDatabasePrefixes`) on `main` does not yet contain
  `benchdb_` — that lands with a separate change. Until then, the
  cleanup list is one prefix ahead of the firewall list. This is a
  defense-in-depth gap (firewall doesn't reject `benchdb_*` at
  creation time on a production server), not a runtime regression —
  the cleanup job still drops them.
- `cmd/bd/doctor/server.go` carries its own
  `staleDatabasePrefixes` for an unrelated read-only check; that copy
  is intentionally out of scope for this change. A future consolidation
  bead can converge it with a cross-reference comment.

## Test plan

- [x] `go build -tags gms_pure_go ./...` clean
- [x] `go vet -tags gms_pure_go ./...` clean
- [x] `cmd/bd/` `TestStaleCommandInit` and the doctor package's
      `TestStaleDatabasePrefixes` (12 sub-tests) all pass.
      Docker-gated `TestStaleSuite` skips locally; runs on CI.
- [x] No new code paths — change is a constant-list edit plus
      doc-block rewrite, so existing coverage applies.
- [x] Release gate: [`release-gates/be-ripy-gate.md`](release-gates/be-ripy-gate.md)

🤖 Deployed by actual-factory

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->