### PR TITLE
fix(dep): tolerate unresolved IDs in batch dep list

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -632,18 +632,32 @@ Examples:
 		}
 
 		// Resolve all IDs and group by store.
+		// In batch mode (>1 arg), unresolved IDs are skipped with a stderr
+		// warning so a single bad ID does not abort the whole batch — this
+		// is the ZFC-compliant transport behavior callers like the gascity
+		// supervisor's dep-cache refresh expect. Single-arg mode keeps the
+		// fatal behavior for backward compatibility.
 		type resolvedID struct {
 			fullID string
 			store  storage.DoltStorage
 			result *RoutedResult
 		}
 		var resolved []resolvedID
+		batchMode := len(args) > 1
 		for _, arg := range args {
 			routedResult, err := resolveAndGetIssueWithRouting(ctx, store, arg)
 			if err != nil {
+				if batchMode {
+					fmt.Fprintf(os.Stderr, "warning: resolving %s: %v (skipped)\n", arg, err)
+					continue
+				}
 				FatalErrorRespectJSON("resolving %s: %v", arg, err)
 			}
 			if routedResult == nil || routedResult.Issue == nil {
+				if batchMode {
+					fmt.Fprintf(os.Stderr, "warning: no issue found: %s (skipped)\n", arg)
+					continue
+				}
 				FatalErrorRespectJSON("no issue found: %s", arg)
 			}
 			depStore := store
@@ -655,6 +669,16 @@ Examples:
 				store:  depStore,
 				result: routedResult,
 			})
+		}
+		if batchMode && len(resolved) == 0 {
+			// No IDs resolved at all; emit empty result so callers can parse
+			// JSON cleanly without a special error path.
+			if jsonOutput {
+				outputJSON([]*types.Dependency{})
+				return
+			}
+			fmt.Fprintln(os.Stderr, "no resolvable issues in batch")
+			return
 		}
 		defer func() {
 			for _, r := range resolved {


### PR DESCRIPTION
## Summary

When `bd dep list` is invoked with multiple IDs (batch mode), a single unresolvable ID currently aborts the entire call with exit 1. This makes `bd dep list` unusable as a transport primitive for callers that fetch deps for a snapshot of IDs from another store, since their snapshot may transiently include IDs the resolver cannot find.

## Concrete consumer

[gastownhall/gascity#1560](https://github.com/gastownhall/gascity/issues/1560) — gascity's `CachingStore` reconcile loop calls `bd dep list <all-bead-ids> --json` every 30–60 s. Ephemeral `*-wisp-*` patrol-molecule beads are visible to `bd list` but not resolvable by `bd show` / `bd dep list`, so the supervisor's batch fails wholesale on every cycle, cascading into stale-cache session-lifecycle bugs.

## Behavior change

| Mode | Before | After |
|---|---|---|
| Single arg (`bd dep list X`) | Fatal exit on resolution failure | **UNCHANGED** — fatal exit (matches `bd show` semantics) |
| Batch (`bd dep list X Y Z`) | One bad ID kills the whole batch | Unresolvable IDs skipped with stderr warning (`warning: resolving X: ... (skipped)`); resolvable IDs continue |
| Batch + `--json` | Exit 1, JSON error envelope on stdout | Valid JSON array on stdout (only resolvable IDs); empty `[]` if none resolve |

## Why batch tolerance

`bd dep list` in batch mode is a transport primitive — callers want "deps for the IDs I have right now". They cannot pre-validate every ID without a round-trip per ID, defeating the purpose of batch. ZFC: the transport mechanically degrades on bad input instead of forcing the caller to reason about which IDs might fail.

Single-arg behavior is intentionally preserved as a backward-compat decision: existing scripts that rely on `bd dep list X` failing loudly when X is missing keep working.

## Test plan

- [x] `go build ./cmd/bd` — builds clean
- [x] `go test ./cmd/bd -run Dep` — passes (1.811 s)
- [x] Smoke test:
  ```
  bd dep list <good-id> ga-FAKE --json
  → exit 0, stderr "warning: resolving ga-FAKE: ... (skipped)", stdout "[]"
  bd dep list ga-FAKE --json
  → exit 1, JSON error (unchanged single-arg behavior)
  ```

## Adjacent issue (not addressed here)

Beads also has a separate consistency bug: `*-wisp-*` molecule beads appear in `bd list` but are unresolvable by `bd show`, `bd dep list`, AND `bd list --all` excludes them entirely. That root cause is worth fixing too (consistency of list/show/--all/dep), but this PR is the smaller, surgical change that unblocks the gascity reconcile loop today regardless of how the wisp inconsistency is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->