### PR TITLE
fix(dolt): skip git hooks in commitBeadsConfig to avoid embedded Dolt re-entry deadlock (GH#3340)

### DIFF
--- a/cmd/bd/dolt_remote_hook_test.go
+++ b/cmd/bd/dolt_remote_hook_test.go
@@ -1,0 +1,112 @@
+//go:build cgo && !windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestDoltRemoteAddRemoveDoesNotDeadlockWithBeadsHooks is a regression test
+// for GH#3340.
+//
+// `bd dolt remote add origin <url>` (and `remove`) auto-commit
+// .beads/config.yaml via commitBeadsConfig. If that git commit runs the
+// beads pre-commit hook, the hook shells out to `bd export`, which tries to
+// acquire the embedded Dolt flock that the parent `bd dolt remote …`
+// process already holds — and the whole process tree deadlocks.
+//
+// All the existing embedded init/remote tests use initGitRepoAt, which sets
+// core.hooksPath=/dev/null — so the hook never runs and the bug stays
+// hidden. This test deliberately leaves git hooks enabled and runs `bd init`
+// without --skip-hooks so the pre-commit hook is installed.
+func TestDoltRemoteAddRemoveDoesNotDeadlockWithBeadsHooks(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+
+	bd := buildEmbeddedBD(t)
+	bdDir := filepath.Dir(bd)
+
+	dir := t.TempDir()
+	// Plain git repo with hooks ENABLED (do not use initGitRepoAt — it
+	// disables hooks, which would mask the bug).
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	// Pre-commit hook shells out to `bd hooks run pre-commit`, which calls
+	// `bd export`. Both need bd on PATH.
+	env := bdEnv(dir)
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + bdDir + string(os.PathListSeparator) + strings.TrimPrefix(e, "PATH=")
+		}
+	}
+
+	initCmd := exec.Command(bd, "init", "--quiet", "--prefix", "hookdeadlock", "--skip-agents")
+	initCmd.Dir = dir
+	initCmd.Env = env
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd init failed: %v\n%s", err, out)
+	}
+
+	hookPath := filepath.Join(dir, ".beads", "hooks", "pre-commit")
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Fatalf("expected beads pre-commit hook at %s: %v", hookPath, err)
+	}
+
+	// git+ssh:// is a Dolt-native scheme: normalizeRemoteURL passes it
+	// through unchanged and `dolt remote add` accepts it without trying to
+	// connect. We get to the commitBeadsConfig path without depending on
+	// network.
+	remoteURL := "git+ssh://git@example.com/acme/beads.git"
+
+	runWithTimeout := func(label string, args ...string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, bd, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		// Put the subprocess in its own process group so we can kill the
+		// whole tree (git → hook → `bd hooks run` → `bd export`) on hang.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Cancel = func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		cmd.WaitDelay = 5 * time.Second
+
+		out, err := cmd.CombinedOutput()
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatalf("%s hung — GH#3340 deadlock regression: commitBeadsConfig must run `git commit --no-verify` to avoid re-entering bd while embedded Dolt flock is held.\noutput so far:\n%s", label, out)
+		}
+		if err != nil {
+			t.Fatalf("%s failed: %v\n%s", label, err, out)
+		}
+	}
+
+	runWithTimeout(fmt.Sprintf("bd dolt remote add origin %s", remoteURL),
+		"dolt", "remote", "add", "origin", remoteURL)
+	runWithTimeout("bd dolt remote remove origin",
+		"dolt", "remote", "remove", "origin")
+}

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -35,12 +35,18 @@ func resolveSyncRemoteFromDir(beadsDir string) string {
 // Silently no-ops if the file is clean or the commit fails (e.g. hooks,
 // nothing to commit). Used by bd dolt remote add/remove to keep the
 // working tree clean after persisting sync.remote.
+//
+// The commit runs with --no-verify so the beads pre-commit hook (which
+// shells out to `bd export`) does not re-enter bd while the parent
+// `bd dolt remote add/remove` process still holds the embedded Dolt flock
+// — that re-entry deadlocks the whole process tree (GH#3340). Same
+// rationale as init.go's bootstrap commit.
 func commitBeadsConfig(msg string) {
 	addCmd := exec.Command("git", "add", ".beads/config.yaml")
 	if err := addCmd.Run(); err != nil {
 		return
 	}
-	commitCmd := exec.Command("git", "commit", "-m", msg) //nolint:gosec // G702: msg is from internal callers only, not user input
+	commitCmd := exec.Command("git", "commit", "--no-verify", "-m", msg) //nolint:gosec // G702: msg is from internal callers only, not user input
 	if out, err := commitCmd.CombinedOutput(); err != nil {
 		// "nothing to commit" is normal if the file was already staged
 		if !strings.Contains(string(out), "nothing to commit") {


### PR DESCRIPTION
## Summary

- Fixes #3340: `bd dolt remote add origin <url>` (and `remove`) deadlocks under embedded Dolt because `commitBeadsConfig` runs `git commit` **without** `--no-verify`. The beads pre-commit hook shells out to `bd export`, which blocks on the embedded Dolt flock that the parent `bd dolt remote …` process already holds.
- Adds `--no-verify` to the internal config commit, mirroring the same rationale already applied to the bootstrap commit at `cmd/bd/init.go:1309-1312`.
- Adds a regression test (`TestDoltRemoteAddRemoveDoesNotDeadlockWithBeadsHooks`) that exercises the real failure path with the beads pre-commit hook installed and active. The existing embedded tests all use `initGitRepoAt`, which sets `core.hooksPath=/dev/null` and is precisely why this bug went undetected.

## Test plan

- [x] Pre-fix: new test reliably reproduces the deadlock (test fails with `GH#3340 deadlock regression: …`).
- [x] Post-fix: new test passes — both `bd dolt remote add origin` and `bd dolt remote remove origin` complete cleanly with hooks enabled.
- [x] `golangci-lint run --build-tags=gms_pure_go ./cmd/bd/` → 0 issues.
- [x] `./scripts/test.sh ./cmd/bd/` passes (with `TEST_TIMEOUT=5m`; baseline also exceeds the default 3m on this machine — pre-existing).

## Manual repro

```bash
cd "$(mktemp -d)" && git init -q
bd init --prefix=repro
timeout 10 bd dolt remote add origin http://example.com:7007/mydb && echo OK || echo HUNG
```

Pre-fix prints `HUNG`. Post-fix prints `OK` (or a clean dolt error — but no hang).

## Notes

- The new test is gated on `BEADS_TEST_EMBEDDED_DOLT=1` and uses `//go:build cgo && !windows`, matching the existing embedded integration test pattern.
- No behavior change for any other code path: only the internal `git commit` invocation in `commitBeadsConfig` (used solely by `bd dolt remote add/remove`) is affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->