### PR TITLE
Fix maybeAutoImportJSONL concurrency race in embedded mode

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -92,8 +92,6 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 		return
 	}
 
-	commandDidWrite.Store(true)
-
 	if result.Memories > 0 {
 		fmt.Fprintf(os.Stderr, "auto-imported %d issues and %d memories from %s\n", result.Issues, result.Memories, jsonlPath)
 	} else {

--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -7,13 +7,25 @@ import (
 	"path/filepath"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
 )
+
+// jsonlImporter is implemented by stores that support single-transaction
+// JSONL import (currently EmbeddedDoltStore). Stores that don't implement
+// this fall back to the multi-call path.
+type jsonlImporter interface {
+	ImportJSONLData(ctx context.Context, issues []*types.Issue, configEntries map[string]string, actor string) (int, error)
+}
 
 // maybeAutoImportJSONL checks whether the database is empty and a
 // issues.jsonl file exists in beadsDir. When both conditions are true it
 // auto-imports the JSONL data so users upgrading from pre-0.56 (which used
 // .beads/dolt/) to 1.0+ (which uses .beads/embeddeddolt/) don't appear to
 // lose their issues.  See GH#2994.
+//
+// When the store implements jsonlImporter (embedded mode), the emptiness
+// check and import happen in a single transaction with no DOLT_COMMIT —
+// the caller's PersistentPostRun auto-commit handles the Dolt commit.
 //
 // The function is best-effort: failures are logged as warnings but do not
 // prevent the store from being used.
@@ -25,17 +37,42 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 		return // no JSONL file or empty — nothing to import
 	}
 
-	// Check whether the database already has issues.
-	stats, err := s.GetStatistics(ctx)
+	// Parse the JSONL file without touching the store.
+	issues, configEntries, err := parseJSONLFile(jsonlPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: auto-import: failed to check issue count: %v\n", err)
+		fmt.Fprintf(os.Stderr, "warning: auto-import: failed to parse %s: %v\n", jsonlPath, err)
 		return
 	}
-	if stats.TotalIssues > 0 {
-		return // database is not empty — nothing to do
+	if len(issues) == 0 {
+		return // nothing to import
 	}
 
-	// Database is empty but JSONL has data — auto-import.
+	// Prefer single-transaction import (embedded mode) to avoid
+	// DOLT_COMMIT races with concurrent writers.
+	if importer, ok := s.(jsonlImporter); ok {
+		fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
+
+		imported, err := importer.ImportJSONLData(ctx, issues, configEntries, "auto-import")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: auto-import from %s failed: %v\n", jsonlPath, err)
+			fmt.Fprintf(os.Stderr, "\nYour issues are still safe in %s.\n", jsonlPath)
+			fmt.Fprintf(os.Stderr, "Try: bd init --from-jsonl   (re-initialize and import from the JSONL file)\n")
+			fmt.Fprintf(os.Stderr, "If this persists, please report at https://github.com/gastownhall/beads/issues\n\n")
+			return
+		}
+		if imported > 0 {
+			// Signal PersistentPostRun to auto-commit (no explicit DOLT_COMMIT here).
+			commandDidWrite.Store(true)
+			fmt.Fprintf(os.Stderr, "auto-imported %d issues", imported)
+			if len(configEntries) > 0 {
+				fmt.Fprintf(os.Stderr, " and %d config entries", len(configEntries))
+			}
+			fmt.Fprintf(os.Stderr, " from %s\n", jsonlPath)
+		}
+		return
+	}
+
+	// Fallback for non-embedded stores: multi-call path (original behavior).
 	fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
 
 	result, err := importFromLocalJSONLFull(ctx, s, jsonlPath)
@@ -47,7 +84,7 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 		return
 	}
 
-	// Commit the imported data to Dolt history.
+	// Commit the imported data to Dolt history (fallback path only).
 	commitMsg := fmt.Sprintf("auto-import: %d issues from %s (upgrade recovery, GH#2994)", result.Issues, filepath.Base(jsonlPath))
 	if result.Memories > 0 {
 		commitMsg = fmt.Sprintf("auto-import: %d issues, %d memories from %s (upgrade recovery, GH#2994)", result.Issues, result.Memories, filepath.Base(jsonlPath))
@@ -56,6 +93,8 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 		fmt.Fprintf(os.Stderr, "warning: auto-import: dolt commit failed: %v\n", err)
 		return
 	}
+
+	commandDidWrite.Store(true)
 
 	if result.Memories > 0 {
 		fmt.Fprintf(os.Stderr, "auto-imported %d issues and %d memories from %s\n", result.Issues, result.Memories, jsonlPath)

--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -50,8 +50,6 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	// Prefer single-transaction import (embedded mode) to avoid
 	// DOLT_COMMIT races with concurrent writers.
 	if importer, ok := s.(jsonlImporter); ok {
-		fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
-
 		imported, err := importer.ImportJSONLData(ctx, issues, configEntries, "auto-import")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: auto-import from %s failed: %v\n", jsonlPath, err)

--- a/cmd/bd/auto_import_upgrade_test.go
+++ b/cmd/bd/auto_import_upgrade_test.go
@@ -1,0 +1,250 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedAutoImportJSONLNoExplicitCommit verifies that auto-import
+// uses a single transaction and defers the Dolt commit to PersistentPostRun
+// (no separate DOLT_COMMIT during pre-run).
+func TestEmbeddedAutoImportJSONLNoExplicitCommit(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// Create a source store with 3 issues, then export to JSONL.
+	srcDir, _, _ := bdInit(t, bd, "--prefix", "src")
+	for i := 0; i < 3; i++ {
+		bdCreate(t, bd, srcDir, fmt.Sprintf("auto-import-test-%d", i), "--type", "task")
+	}
+	srcJSONL := filepath.Join(srcDir, "export.jsonl")
+	cmd := exec.Command(bd, "export", "-o", srcJSONL)
+	cmd.Dir = srcDir
+	cmd.Env = bdEnv(srcDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd export failed: %v\n%s", err, out)
+	}
+
+	// Create a fresh empty store in a new directory.
+	dstDir, dstBeadsDir, _ := bdInit(t, bd, "--prefix", "dst")
+
+	// Place the JSONL file where auto-import looks for it.
+	srcData, err := os.ReadFile(srcJSONL)
+	if err != nil {
+		t.Fatalf("reading exported JSONL: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dstBeadsDir, "issues.jsonl"), srcData, 0644); err != nil {
+		t.Fatalf("writing issues.jsonl: %v", err)
+	}
+
+	// Run "bd list --json" — triggers maybeAutoImportJSONL in pre-run,
+	// auto-commit in post-run.
+	issues := bdListJSON(t, bd, dstDir)
+	if len(issues) != 3 {
+		t.Fatalf("expected 3 imported issues, got %d", len(issues))
+	}
+
+	// Verify commit count: should be exactly 2 (init + post-run auto-commit).
+	// If the old code path were used, there would be 3 (init + auto-import
+	// DOLT_COMMIT + post-run auto-commit).
+	logOut := bdDolt(t, bd, dstDir, "log")
+	commitCount := strings.Count(logOut, "commit ")
+	if commitCount > 2 {
+		t.Errorf("expected at most 2 Dolt commits (init + auto-commit), got %d;\nlog:\n%s", commitCount, logOut)
+	}
+}
+
+// TestEmbeddedAutoImportJSONLConcurrentWriter verifies no data loss when
+// auto-import runs concurrently with other writers (the race that prompted
+// the single-transaction fix).
+func TestEmbeddedAutoImportJSONLConcurrentWriter(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// Create a fresh store and place a hand-crafted issues.jsonl.
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "cr")
+
+	jsonlIssues := []types.Issue{
+		{ID: "cr-import-1", Title: "Imported One", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: "cr-import-2", Title: "Imported Two", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeBug, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: "cr-import-3", Title: "Imported Three", Status: types.StatusOpen, Priority: 3, IssueType: types.TypeTask, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	}
+	var lines []string
+	for _, issue := range jsonlIssues {
+		b, _ := json.Marshal(issue)
+		lines = append(lines, string(b))
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Launch concurrent writers + one "bd list" that triggers auto-import.
+	const numWriters = 4
+
+	type result struct {
+		id  string
+		err error
+	}
+
+	var wg sync.WaitGroup
+	writerResults := make([]result, numWriters)
+
+	// Concurrent create workers
+	for i := 0; i < numWriters; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			issue := bdCreateAllowError(t, bd, dir, fmt.Sprintf("concurrent-%d", idx), "--type", "task")
+			if issue != nil {
+				writerResults[idx] = result{id: issue.ID}
+			} else {
+				writerResults[idx] = result{err: fmt.Errorf("create failed for worker %d", idx)}
+			}
+		}(i)
+	}
+
+	// Trigger auto-import via bd list (runs concurrently with creates)
+	wg.Add(1)
+	var listIssues []*types.IssueWithCounts
+	go func() {
+		defer wg.Done()
+		listIssues = bdListJSONAllowError(t, bd, dir)
+	}()
+
+	wg.Wait()
+
+	// Count successful creates
+	var successfulCreates []string
+	for _, r := range writerResults {
+		if r.err == nil && r.id != "" {
+			successfulCreates = append(successfulCreates, r.id)
+		}
+	}
+
+	// Final authoritative list — after all concurrency is done
+	finalIssues := bdListJSON(t, bd, dir)
+	finalIDs := make(map[string]bool)
+	for _, issue := range finalIssues {
+		finalIDs[issue.ID] = true
+	}
+
+	// Every successfully created issue must be present (no lost writes)
+	for _, id := range successfulCreates {
+		if !finalIDs[id] {
+			t.Errorf("concurrent create %s succeeded but is missing from final list", id)
+		}
+	}
+
+	// If the list ran before any creates, the imported issues should be present
+	// (they may or may not be, depending on whether auto-import won the flock race)
+	t.Logf("final issue count: %d (imports: up to 3, concurrent creates: %d, list saw: %d)",
+		len(finalIssues), len(successfulCreates), len(listIssues))
+}
+
+// TestEmbeddedAutoImportJSONLSkipsNonEmpty verifies that auto-import is
+// a no-op when the database already has issues (atomicity of the
+// emptiness check + import within a single transaction).
+func TestEmbeddedAutoImportJSONLSkipsNonEmpty(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	// Create a store with one existing issue.
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ne")
+	existing := bdCreate(t, bd, dir, "pre-existing issue", "--type", "task")
+
+	// Place a JSONL file with different issues.
+	jsonlIssues := []types.Issue{
+		{ID: "ne-should-not-import-1", Title: "Should Not Import", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: "ne-should-not-import-2", Title: "Also Should Not Import", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeBug, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+	}
+	var lines []string
+	for _, issue := range jsonlIssues {
+		b, _ := json.Marshal(issue)
+		lines = append(lines, string(b))
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run bd list — auto-import should skip because DB is non-empty.
+	issues := bdListJSON(t, bd, dir)
+
+	// Only the pre-existing issue should be present.
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue (pre-existing only), got %d", len(issues))
+	}
+	if issues[0].ID != existing.ID {
+		t.Errorf("expected issue %s, got %s", existing.ID, issues[0].ID)
+	}
+}
+
+// bdCreateAllowError runs "bd create --json" and returns the issue on success,
+// or nil on failure (without failing the test).
+func bdCreateAllowError(t *testing.T, bd, dir string, args ...string) *types.Issue {
+	t.Helper()
+	fullArgs := append([]string{"create", "--json"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil
+	}
+	s := string(out)
+	start := strings.Index(s, "{")
+	if start < 0 {
+		return nil
+	}
+	var issue types.Issue
+	if err := json.Unmarshal([]byte(s[start:]), &issue); err != nil {
+		return nil
+	}
+	return &issue
+}
+
+// bdListJSONAllowError runs "bd list --json" and returns issues on success,
+// or nil on failure (without failing the test).
+func bdListJSONAllowError(t *testing.T, bd, dir string, args ...string) []*types.IssueWithCounts {
+	t.Helper()
+	fullArgs := append([]string{"list", "--json"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil
+	}
+	s := string(out)
+	start := strings.Index(s, "[")
+	if start < 0 {
+		return nil
+	}
+	var issues []*types.IssueWithCounts
+	if err := json.Unmarshal([]byte(s[start:]), &issues); err != nil {
+		return nil
+	}
+	return issues
+}

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -85,21 +85,20 @@ func importFromLocalJSONL(ctx context.Context, store storage.DoltStorage, localP
 	return result.Issues, nil
 }
 
-// importFromLocalJSONLFull imports issues and memories from a local JSONL file.
-// It detects memory records (lines with "_type":"memory") and imports them
-// via SetConfig, while routing regular issue records through the normal path.
-func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, localPath string) (*importLocalResult, error) {
+// parseJSONLFile reads a JSONL file and returns parsed issues and config
+// entries (memories). Pure function — no store I/O.
+func parseJSONLFile(path string) ([]*types.Issue, map[string]string, error) {
 	//nolint:gosec // G304: path from user-provided CLI argument
-	data, err := os.ReadFile(localPath)
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read JSONL file %s: %w", localPath, err)
+		return nil, nil, fmt.Errorf("failed to read JSONL file %s: %w", path, err)
 	}
 
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	// Allow up to 64MB per line for large descriptions
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 	var issues []*types.Issue
-	var memories []memoryRecord
+	configEntries := make(map[string]string)
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -110,7 +109,7 @@ func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, lo
 		// Peek at the record to check for _type field
 		var peek map[string]json.RawMessage
 		if err := json.Unmarshal([]byte(line), &peek); err != nil {
-			return nil, fmt.Errorf("failed to parse JSONL line: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse JSONL line: %w", err)
 		}
 
 		// Check if this is a memory record
@@ -119,10 +118,10 @@ func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, lo
 			if err := json.Unmarshal(rawType, &typeStr); err == nil && typeStr == "memory" {
 				var mem memoryRecord
 				if err := json.Unmarshal([]byte(line), &mem); err != nil {
-					return nil, fmt.Errorf("failed to parse memory record: %w", err)
+					return nil, nil, fmt.Errorf("failed to parse memory record: %w", err)
 				}
 				if mem.Key != "" && mem.Value != "" {
-					memories = append(memories, mem)
+					configEntries[kvPrefix+memoryPrefix+mem.Key] = mem.Value
 				}
 				continue
 			}
@@ -131,7 +130,7 @@ func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, lo
 		// Regular issue record
 		var issue types.Issue
 		if err := json.Unmarshal([]byte(line), &issue); err != nil {
-			return nil, fmt.Errorf("failed to parse issue from JSONL: %w", err)
+			return nil, nil, fmt.Errorf("failed to parse issue from JSONL: %w", err)
 		}
 		// Skip tombstone entries: these are deleted issues exported by older
 		// versions (pre-v0.50) with status "tombstone" and deleted_at set.
@@ -153,16 +152,27 @@ func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, lo
 		issues = append(issues, &issue)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan JSONL: %w", err)
+		return nil, nil, fmt.Errorf("failed to scan JSONL: %w", err)
+	}
+
+	return issues, configEntries, nil
+}
+
+// importFromLocalJSONLFull imports issues and memories from a local JSONL file.
+// It detects memory records (lines with "_type":"memory") and imports them
+// via SetConfig, while routing regular issue records through the normal path.
+func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, localPath string) (*importLocalResult, error) {
+	issues, configEntries, err := parseJSONLFile(localPath)
+	if err != nil {
+		return nil, err
 	}
 
 	result := &importLocalResult{}
 
 	// Import memories
-	for _, mem := range memories {
-		storageKey := kvPrefix + memoryPrefix + mem.Key
-		if err := store.SetConfig(ctx, storageKey, mem.Value); err != nil {
-			return nil, fmt.Errorf("failed to import memory %q: %w", mem.Key, err)
+	for key, value := range configEntries {
+		if err := store.SetConfig(ctx, key, value); err != nil {
+			return nil, fmt.Errorf("failed to import config %q: %w", key, err)
 		}
 		result.Memories++
 	}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // Compile-time interface checks.
@@ -509,6 +510,63 @@ func (s *EmbeddedDoltStore) DoltGC(ctx context.Context) error {
 	return s.withDBConn(ctx, func(db versioncontrolops.DBConn) error {
 		return versioncontrolops.DoltGC(ctx, db)
 	})
+}
+
+// ImportJSONLData atomically checks if the database is empty and, if so,
+// imports parsed issues and config key/value pairs in a single transaction.
+// Returns the count of issues imported, or 0 if the database was not empty.
+// Does NOT issue DOLT_COMMIT — the caller is responsible for committing
+// (e.g. via the PersistentPostRun auto-commit hook).
+func (s *EmbeddedDoltStore) ImportJSONLData(
+	ctx context.Context,
+	issues []*types.Issue,
+	configEntries map[string]string,
+	actor string,
+) (int, error) {
+	var imported int
+	err := s.withConn(ctx, true, func(tx *sql.Tx) error {
+		// Atomically check: is the database empty?
+		stats := &types.Statistics{}
+		if err := issueops.ScanIssueCountsInTx(ctx, tx, stats); err != nil {
+			return fmt.Errorf("checking issue count: %w", err)
+		}
+		if stats.TotalIssues > 0 {
+			return nil // database is not empty — skip import
+		}
+
+		// Import config entries (memories, etc.)
+		for key, value := range configEntries {
+			if err := issueops.SetConfigInTx(ctx, tx, key, value); err != nil {
+				return fmt.Errorf("importing config %q: %w", key, err)
+			}
+		}
+
+		if len(issues) == 0 {
+			return nil
+		}
+
+		// Auto-detect prefix from first issue if not already provided
+		if _, hasPrefix := configEntries["issue_prefix"]; !hasPrefix {
+			firstPrefix := utils.ExtractIssuePrefix(issues[0].ID)
+			if firstPrefix != "" {
+				if err := issueops.SetConfigInTx(ctx, tx, "issue_prefix", firstPrefix); err != nil {
+					return fmt.Errorf("setting issue_prefix: %w", err)
+				}
+			}
+		}
+
+		// Create all issues in the same transaction
+		if err := issueops.CreateIssuesInTx(ctx, tx, issues, actor, storage.BatchCreateOptions{
+			OrphanHandling:       storage.OrphanAllow,
+			SkipPrefixValidation: true,
+		}); err != nil {
+			return err
+		}
+
+		imported = len(issues)
+		return nil
+	})
+	return imported, err
 }
 
 // Flatten squashes all Dolt commit history into a single commit.


### PR DESCRIPTION
## Summary

`maybeAutoImportJSONL` — which runs in `PersistentPreRun` for every write command — had a concurrency bug in embedded Dolt mode. It performed 3 independent `withConn` calls (check emptiness, import issues, `DOLT_COMMIT`) with no transactional continuity. The final `DOLT_ADD('-A') + DOLT_COMMIT` could steal or clobber concurrent writers' uncommitted working set changes.

This bug was uncovered by #3614, which removed an erroneous filesystem locking layer that had been masking the race.

### The race

Each `withConn` opens a fresh `*sql.DB`, begins a new transaction, and closes it. Between the import and the `DOLT_COMMIT`, any concurrent writer (e.g. `bd create`, `bd promote`) could:

1. **Have its changes stolen** — `DOLT_ADD('-A')` stages everything in the working set, so the auto-import's commit absorbs another writer's data under the wrong commit message
2. **Lose data** — if `DOLT_COMMIT` resets the working set to HEAD after committing only the auto-import's staged data, the concurrent writer's unstaged changes are lost
3. **Skip its own commit** — `CommitPending` finds nothing pending (already committed by auto-import) and silently returns

### The fix

- **Single-transaction import**: New `ImportJSONLData` method on `EmbeddedDoltStore` performs the emptiness check + config writes + issue creation in one `withConn`/transaction. No TOCTOU gap.
- **No explicit `DOLT_COMMIT`**: The import leaves changes in the working set and sets `commandDidWrite`, deferring the Dolt commit to `PersistentPostRun`'s standard `maybeAutoCommit` — the same path every other write command uses.
- **Extracted `parseJSONLFile`**: Pure parsing function (no store I/O) shared by both the auto-import and `importFromLocalJSONLFull`, keeping `bd import` behavior identical.
- **Non-embedded fallback**: Stores that don't implement the new `jsonlImporter` interface (dolt server mode) fall back to the original multi-call path.

## Test plan

- [x] New `TestEmbeddedAutoImportJSONLNoExplicitCommit` — verifies import works and produces at most 2 Dolt commits (init + post-run), not 3
- [x] New `TestEmbeddedAutoImportJSONLConcurrentWriter` — concurrent creates + auto-import with no lost writes
- [x] New `TestEmbeddedAutoImportJSONLSkipsNonEmpty` — atomic skip when DB already has issues
- [x] Existing `TestEmbeddedPromoteCLIConcurrent` still passes
- [x] `make test` passes (pre-existing failures in `internal/tracker` and `internal/utils` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->