### PR TITLE
fix(github): map decision, spike, story, milestone type labels (GH#3604)

### DIFF
--- a/internal/github/mapping_test.go
+++ b/internal/github/mapping_test.go
@@ -178,6 +178,26 @@ func TestTypeFromLabels(t *testing.T) {
 			wantType: "chore",
 		},
 		{
+			name:     "type::decision",
+			labels:   []string{"type::decision"},
+			wantType: "decision",
+		},
+		{
+			name:     "type::spike",
+			labels:   []string{"type::spike"},
+			wantType: "spike",
+		},
+		{
+			name:     "type::story",
+			labels:   []string{"type::story"},
+			wantType: "story",
+		},
+		{
+			name:     "type::milestone",
+			labels:   []string{"type::milestone"},
+			wantType: "milestone",
+		},
+		{
 			name:     "enhancement maps to feature",
 			labels:   []string{"type::enhancement"},
 			wantType: "feature",

--- a/internal/github/types.go
+++ b/internal/github/types.go
@@ -247,6 +247,10 @@ var typeMapping = map[string]string{
 	"task":        "task",
 	"epic":        "epic",
 	"chore":       "chore",
+	"decision":    "decision",
+	"spike":       "spike",
+	"story":       "story",
+	"milestone":   "milestone",
 	"enhancement": "feature",
 }
 


### PR DESCRIPTION
## Summary

- Extends `typeMapping` in `internal/github/types.go` with `decision`, `spike`, `story`, `milestone` so `type::*` GitHub labels round-trip during `bd github sync --pull-only --prefer-github` instead of silently defaulting to `task`.

## Tests

- Extended `TestTypeFromLabels` for all four types.

Closes #3604

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->