### PR TITLE
fix(comments): reject bd comments list with helpful hint (GH#3542)

### DIFF
--- a/cmd/bd/cli_fast_test.go
+++ b/cmd/bd/cli_fast_test.go
@@ -1211,6 +1211,21 @@ func TestCLI_CreateDryRun(t *testing.T) {
 	})
 }
 
+// TestCLI_CommentsListMisplacedSyntax ensures "bd comments list" gets a helpful error (GH#3542).
+func TestCLI_CommentsListMisplacedSyntax(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := setupCLITestDB(t)
+	stdout, stderr, err := runBDInProcessAllowError(t, tmpDir, "comments", "list")
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got stdout=%q stderr=%q", stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "bd comments") || !strings.Contains(combined, "<issue-id>") {
+		t.Fatalf("expected hint with bd comments and issue-id placeholder, got stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
 // TestCLI_CommentsAddShortID tests that 'comments add' accepts short IDs (issue #1070)
 // Most bd commands accept short IDs (e.g., "5wbm") but comments add previously required
 // full IDs (e.g., "mike.vibe-coding-5wbm"). This test ensures short IDs work.

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -17,7 +17,7 @@ var commentsCmd = &cobra.Command{
 	Long: `View or manage comments on an issue.
 
 Examples:
-  # List all comments on an issue
+  # List all comments on an issue (issue id is required — there is no "comments list")
   bd comments bd-123
 
   # List comments in JSON format
@@ -89,6 +89,24 @@ Examples:
 			}
 			fmt.Println()
 		}
+	},
+}
+
+// commentsMisplacedListCmd catches the reflexive "bd comments list" invocation (GH#3542).
+// Listing comments always requires an issue id: bd comments <issue-id>.
+var commentsMisplacedListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Invalid — use bd comments <issue-id> to list comments",
+	Run: func(cmd *cobra.Command, args []string) {
+		FatalErrorRespectJSON(`"bd comments list" is not valid.
+
+To list comments on an issue, run:
+  bd comments <issue-id>
+
+Example:
+  bd comments bd-123
+
+See: bd comments --help`)
 	},
 }
 
@@ -171,6 +189,7 @@ Examples:
 }
 
 func init() {
+	commentsCmd.AddCommand(commentsMisplacedListCmd)
 	commentsCmd.AddCommand(commentsAddCmd)
 	commentsCmd.Flags().Bool("local-time", false, "Show timestamps in local time instead of UTC")
 	commentsAddCmd.Flags().StringP("file", "f", "", "Read comment text from file")


### PR DESCRIPTION
## Summary

- Registers `comments list` as a dedicated subcommand so `bd comments list` no longer tries to resolve `"list"` as an issue id (GH#3542).
- Prints a short message directing users to `bd comments <issue-id>`.

## Tests

- `TestCLI_CommentsListMisplacedSyntax` (`cli_fast_test.go`, integration build tag).

Closes #3542

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->