### PR TITLE
fix(setup): remove stale bd sync from Mux hook; warn in claude check (GH#3546)

### DIFF
--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -204,6 +204,64 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 	return nil
 }
 
+// claudeSettingsUsesRemovedSyncCommand reports whether any hook command references
+// bd sync (removed as a real command; GH#3546).
+func claudeSettingsUsesRemovedSyncCommand(data []byte) bool {
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return false
+	}
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	for _, raw := range hooks {
+		eventHooks, ok := raw.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, hook := range eventHooks {
+			hookMap, ok := hook.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cmds, ok := hookMap["hooks"].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, c := range cmds {
+				cmdMap, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				command, _ := cmdMap["command"].(string)
+				if strings.Contains(command, "bd sync") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func warnIfClaudeHooksUseRemovedSync(env claudeEnv) {
+	paths := []string{
+		projectSettingsPath(env.projectDir),
+		globalSettingsPath(env.homeDir),
+		legacyProjectSettingsPath(env.projectDir),
+	}
+	for _, p := range paths {
+		data, err := env.readFile(p)
+		if err != nil {
+			continue
+		}
+		if !claudeSettingsUsesRemovedSyncCommand(data) {
+			continue
+		}
+		_, _ = fmt.Fprintf(env.stderr, "Warning: %s contains a hook using removed \"bd sync\". Run bd setup claude to refresh hooks (bd prime / bd dolt push), or edit settings manually.\n", p)
+	}
+}
+
 // CheckClaude checks if Claude integration is installed
 func CheckClaude() {
 	env, err := claudeEnvProvider()
@@ -218,6 +276,8 @@ func CheckClaude() {
 }
 
 func checkClaude(env claudeEnv) error {
+	warnIfClaudeHooksUseRemovedSync(env)
+
 	projectSettings := projectSettingsPath(env.projectDir)
 	globalSettings := globalSettingsPath(env.homeDir)
 	legacySettings := legacyProjectSettingsPath(env.projectDir)

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -402,6 +402,26 @@ func TestInstallClaudeUsesPrimeForClaudeHooks(t *testing.T) {
 	}
 }
 
+func TestClaudeSettingsUsesRemovedSyncCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"empty", "{}", false},
+		{"bd prime only", `{"hooks":{"PreCompact":[{"matcher":"","hooks":[{"type":"command","command":"bd prime"}]}]}}`, false},
+		{"bd sync hook", `{"hooks":{"PreCompact":[{"matcher":"","hooks":[{"type":"command","command":"bd sync"}]}]}}`, true},
+		{"bd sync with suffix", `{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"bd sync --flush-only"}]}]}}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := claudeSettingsUsesRemovedSyncCommand([]byte(tt.raw)); got != tt.want {
+				t.Fatalf("claudeSettingsUsesRemovedSyncCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasBeadsHooks(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/cmd/bd/setup/mux.go
+++ b/cmd/bd/setup/mux.go
@@ -37,7 +37,7 @@ if [ "${MUX_TOOL:-}" = "file_edit_replace_string" ] || [ "${MUX_TOOL:-}" = "file
   if command -v bd >/dev/null 2>&1; then
     bd dolt push >/dev/null 2>&1 || true
   elif [ -x "$HOME/bin/bd" ]; then
-    "$HOME/bin/bd" sync >/dev/null 2>&1 || true
+    "$HOME/bin/bd" dolt push >/dev/null 2>&1 || true
   fi
 fi
 ` + muxHookMarkerEnd + `


### PR DESCRIPTION
## Summary

- **Mux:** The post-edit hook fallback when only `\`$HOME/bin/bd\`` is available now runs `\`bd dolt push\`` instead of removed `\`bd sync\`` (matches the `command -v bd` branch above it).
- **`bd setup claude --check`:** Before validating hooks, scan project/global/legacy Claude settings for hook commands containing `\`bd sync\`` and emit a **stderr warning** with remediation (`bd setup claude` / manual edit).

`bd setup claude` itself already installs `\`bd prime\`` for PreCompact on current main; this closes the remaining stale surfaces called out in the issue.

## Tests

- `TestClaudeSettingsUsesRemovedSyncCommand`

Closes #3546

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->