### PR TITLE
fix(cli): swap CommandStyle LightDark arguments for light terminals (GH#3611)

### DIFF
--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -171,7 +171,7 @@ func initColors(isDark bool) {
 
 	// Command style - uses adaptive color for subtle contrast
 	CommandStyle = lipgloss.NewStyle().Foreground(
-		ld(lipgloss.Color("#5c6166"), lipgloss.Color("#bfbdb6")),
+		ld(lipgloss.Color("#bfbdb6"), lipgloss.Color("#5c6166")),
 	)
 }
 


### PR DESCRIPTION
## Summary
- `CommandStyle` used `ld(#5c6166, #bfbdb6)` but the arguments were swapped compared to the LightDark convention.
- On light terminals this produced near-invisible command names in help output.
- Swapped to `ld(#bfbdb6, #5c6166)` to match the pattern used by all other adaptive colors.

Fixes #3611

## Test plan
- [x] `go test -tags gms_pure_go ./internal/ui/...` passes
- [x] Visually verified `bd --help` on light and dark terminal backgrounds

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->