### PR TITLE
fix(list): emphasize tree truncation warning with WarnStyle (GH#3580)

### DIFF
--- a/cmd/bd/doctor/gitignore.go
+++ b/cmd/bd/doctor/gitignore.go
@@ -23,9 +23,6 @@ last-touched
 # Daemon runtime (lock, log, pid)
 daemon.*
 
-# Interactions log (runtime, not versioned)
-interactions.jsonl
-
 # Push state (runtime, per-machine)
 push-state.json
 
@@ -114,7 +111,6 @@ var requiredPatterns = []string{
 	"dolt-server.port",
 	"dolt-server.activity",
 	"daemon.*",
-	"interactions.jsonl",
 	"*.lock",
 	"*.corrupt.backup/",
 	".beads-credential-key",

--- a/cmd/bd/doctor/tracked_runtime.go
+++ b/cmd/bd/doctor/tracked_runtime.go
@@ -14,6 +14,9 @@ import (
 //
 // Each entry is matched against the relative path within .beads/ using
 // filepath.Match or prefix matching for directory patterns (trailing /).
+//
+// Note: interactions.jsonl is intentionally omitted — it may be versioned
+// per bd audit policy (see `bd audit` help text).
 var trackedRuntimePatterns = []string{
 	// Lock files
 	"*.lock",
@@ -34,7 +37,6 @@ var trackedRuntimePatterns = []string{
 	".exclusive-lock",
 
 	// Runtime state
-	"interactions.jsonl",
 	"push-state.json",
 	"export-state.json",
 	"sync-state.json",


### PR DESCRIPTION
## Summary
- The default `--limit` truncation hint was easy to miss in `bd list --tree` output, especially for agent consumers.
- Use `WarnStyle` for visual emphasis and show a tree-specific message that calls out the default limit behavior.
- Non-tree output (JSON, format, flat) keeps the existing message wording.

Fixes #3580

## Test plan
- [x] Updated `limit_truncation_hint` embedded test expectations
- [x] `go test -tags gms_pure_go ./cmd/bd/...` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->