### PR TITLE
fix(list): --deferred returns complete deferred set (GH#3571)

### DIFF
--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -465,7 +465,8 @@ func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter
 
 	// Time-based scheduling filters
 	if filter.Deferred {
-		whereClauses = append(whereClauses, "defer_until IS NOT NULL")
+		whereClauses = append(whereClauses, "(defer_until IS NOT NULL OR status = ?)")
+		args = append(args, types.StatusDeferred)
 	}
 	if filter.Overdue {
 		whereClauses = append(whereClauses, "due_at IS NOT NULL AND due_at < ? AND status != ?")

--- a/internal/storage/issueops/filters.go
+++ b/internal/storage/issueops/filters.go
@@ -259,7 +259,8 @@ func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables Filt
 	}
 
 	if filter.Deferred {
-		whereClauses = append(whereClauses, "defer_until IS NOT NULL")
+		whereClauses = append(whereClauses, "(defer_until IS NOT NULL OR status = ?)")
+		args = append(args, types.StatusDeferred)
 	}
 	if filter.Overdue {
 		whereClauses = append(whereClauses, "due_at IS NOT NULL AND due_at < ? AND status != ?")

--- a/internal/storage/issueops/filters_test.go
+++ b/internal/storage/issueops/filters_test.go
@@ -240,6 +240,29 @@ func TestBuildIssueFilterClauses_DateFilters(t *testing.T) {
 	}
 }
 
+
+func TestBuildIssueFilterClauses_DeferredIncludesStatus(t *testing.T) {
+	t.Parallel()
+	clauses, args, err := BuildIssueFilterClauses("", types.IssueFilter{Deferred: true}, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "(defer_until IS NOT NULL OR status = ?)"
+	var found bool
+	for _, c := range clauses {
+		if c == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected deferred clause %q in %v", want, clauses)
+	}
+	if len(args) != 1 || args[0] != types.StatusDeferred {
+		t.Fatalf("args = %v, want [%q]", args, types.StatusDeferred)
+	}
+}
+
 func TestBuildIssueFilterClauses_BooleanFilters(t *testing.T) {
 	t.Parallel()
 

--- a/internal/storage/issueops/filters_test.go
+++ b/internal/storage/issueops/filters_test.go
@@ -240,7 +240,6 @@ func TestBuildIssueFilterClauses_DateFilters(t *testing.T) {
 	}
 }
 
-
 func TestBuildIssueFilterClauses_DeferredIncludesStatus(t *testing.T) {
 	t.Parallel()
 	clauses, args, err := BuildIssueFilterClauses("", types.IssueFilter{Deferred: true}, IssuesFilterTables)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1239,7 +1239,7 @@ type IssueFilter struct {
 	ExcludeTypes []IssueType // Exclude issues with these types
 
 	// Time-based scheduling filters (GH#820)
-	Deferred    bool       // Filter issues with defer_until set (any value)
+	Deferred    bool       // Filter issues that are scheduled later: defer_until set OR status is deferred
 	DeferAfter  *time.Time // Filter issues with defer_until > this time
 	DeferBefore *time.Time // Filter issues with defer_until < this time
 	DueAfter    *time.Time // Filter issues with due_at > this time


### PR DESCRIPTION
## Summary
- `bd list --deferred` only matched issues with `defer_until` set, missing issues with `status=deferred` but no `defer_until` timestamp.
- Updated filter to `(defer_until IS NOT NULL OR status = 'deferred')` in both `issueops/filters.go` and `dolt/transaction.go`.

Fixes #3571

## Test plan
- [x] `TestBuildIssueFilterClauses_DeferredIncludesStatus` verifies clause and args
- [x] `go test -tags gms_pure_go ./internal/storage/issueops/...` passes
- [x] `go test -tags gms_pure_go ./internal/storage/dolt/...` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->