### PR TITLE
fix(graph): merge components for bd graph --all --html (GH#3592)

### DIFF
--- a/cmd/bd/graph.go
+++ b/cmd/bd/graph.go
@@ -103,13 +103,19 @@ Examples:
 				return
 			}
 
+			// HTML: merge all components into one graph for a single document
+			if graphHTML {
+				merged := mergeSubgraphsForHTML(subgraphs)
+				layout := computeLayout(merged)
+				renderGraphHTML(layout, merged)
+				return
+			}
+
 			// Render all subgraphs
 			for i, subgraph := range subgraphs {
 				layout := computeLayout(subgraph)
 				if graphDOT {
 					renderGraphDOT(layout, subgraph)
-				} else if graphHTML {
-					renderGraphHTML(layout, subgraph)
 				} else if graphCompact {
 					renderGraphCompact(layout, subgraph)
 				} else if graphBox {
@@ -117,7 +123,7 @@ Examples:
 				} else {
 					renderGraphVisual(layout, subgraph)
 				}
-				if !graphDOT && !graphHTML && i < len(subgraphs)-1 {
+				if !graphDOT && i < len(subgraphs)-1 {
 					fmt.Println(strings.Repeat("─", 60))
 				}
 			}
@@ -521,10 +527,40 @@ func loadAllGraphSubgraphs(ctx context.Context, s storage.DoltStorage) ([]*Templ
 }
 
 // computeLayout assigns layers to nodes using topological sort
+// mergeSubgraphsForHTML joins disconnected components into one subgraph so
+// `bd graph --all --html` emits a single valid HTML document.
+func mergeSubgraphsForHTML(subgraphs []*TemplateSubgraph) *TemplateSubgraph {
+	switch len(subgraphs) {
+	case 0:
+		return &TemplateSubgraph{IssueMap: make(map[string]*types.Issue)}
+	case 1:
+		return subgraphs[0]
+	}
+	merged := &TemplateSubgraph{
+		IssueMap: make(map[string]*types.Issue),
+	}
+	for _, sg := range subgraphs {
+		for _, issue := range sg.Issues {
+			merged.IssueMap[issue.ID] = issue
+		}
+		merged.Dependencies = append(merged.Dependencies, sg.Dependencies...)
+	}
+	merged.Issues = make([]*types.Issue, 0, len(merged.IssueMap))
+	for _, issue := range merged.IssueMap {
+		merged.Issues = append(merged.Issues, issue)
+	}
+	sort.Slice(merged.Issues, func(i, j int) bool {
+		return merged.Issues[i].ID < merged.Issues[j].ID
+	})
+	return merged
+}
+
 func computeLayout(subgraph *TemplateSubgraph) *GraphLayout {
 	layout := &GraphLayout{
-		Nodes:  make(map[string]*GraphNode),
-		RootID: subgraph.Root.ID,
+		Nodes: make(map[string]*GraphNode),
+	}
+	if subgraph.Root != nil {
+		layout.RootID = subgraph.Root.ID
 	}
 
 	// Build dependency map (only "blocks" dependencies, not parent-child)

--- a/cmd/bd/graph_export_test.go
+++ b/cmd/bd/graph_export_test.go
@@ -284,3 +284,49 @@ func TestDotEdgeStyle(t *testing.T) {
 		t.Errorf("related edge should have no style, got %q", related)
 	}
 }
+
+func TestMergeSubgraphsForHTML_SingleDOCTYPE(t *testing.T) {
+	// Not parallel: captureGraphOutput redirects global os.Stdout
+
+	// Create two disconnected subgraphs (separate components)
+	issueA := &types.Issue{
+		ID: "comp-a", Title: "Component A", Status: types.StatusOpen,
+		Priority: 1, IssueType: types.TypeTask,
+	}
+	issueB := &types.Issue{
+		ID: "comp-b", Title: "Component B", Status: types.StatusInProgress,
+		Priority: 2, IssueType: types.TypeTask,
+	}
+
+	sg1 := &TemplateSubgraph{
+		Root:     issueA,
+		Issues:   []*types.Issue{issueA},
+		IssueMap: map[string]*types.Issue{"comp-a": issueA},
+	}
+	sg2 := &TemplateSubgraph{
+		Root:     issueB,
+		Issues:   []*types.Issue{issueB},
+		IssueMap: map[string]*types.Issue{"comp-b": issueB},
+	}
+
+	merged := mergeSubgraphsForHTML([]*TemplateSubgraph{sg1, sg2})
+	layout := computeLayout(merged)
+
+	output := captureGraphOutput(func() {
+		renderGraphHTML(layout, merged)
+	})
+
+	// Must contain exactly one DOCTYPE declaration
+	count := strings.Count(output, "<!DOCTYPE html>")
+	if count != 1 {
+		t.Errorf("expected exactly 1 <!DOCTYPE html>, got %d", count)
+	}
+
+	// Both issues must appear in the single document
+	if !strings.Contains(output, "comp-a") {
+		t.Error("merged HTML should contain comp-a")
+	}
+	if !strings.Contains(output, "comp-b") {
+		t.Error("merged HTML should contain comp-b")
+	}
+}

--- a/cmd/bd/graph_test.go
+++ b/cmd/bd/graph_test.go
@@ -474,4 +474,23 @@ func TestComputeLayout(t *testing.T) {
 				layout.Nodes["child-1"].Layer, layout.Nodes["epic-1"].Layer)
 		}
 	})
+
+	t.Run("nil root does not panic", func(t *testing.T) {
+		subgraph := &TemplateSubgraph{
+			Root:         nil,
+			Issues:       []*types.Issue{{ID: "orphan-1", Title: "Orphan"}},
+			Dependencies: []*types.Dependency{},
+			IssueMap:     map[string]*types.Issue{"orphan-1": {ID: "orphan-1", Title: "Orphan"}},
+		}
+		layout := computeLayout(subgraph)
+		if layout == nil {
+			t.Fatal("computeLayout returned nil")
+		}
+		if layout.RootID != "" {
+			t.Errorf("RootID = %q, want empty string for nil root", layout.RootID)
+		}
+		if len(layout.Nodes) != 1 {
+			t.Errorf("len(Nodes) = %d, want 1", len(layout.Nodes))
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- `bd graph --all --html` concatenated N full `<!DOCTYPE html>` documents (one per connected component), producing invalid HTML that browsers could not render correctly.
- Merge all components into a single subgraph before rendering so stdout is always one valid HTML page.
- `computeLayout` now tolerates `nil Root` for the merged graph.

Fixes #3592

## Test plan
- [x] `TestMergeSubgraphsForHTML_SingleDOCTYPE` — two disconnected components produce exactly one HTML document
- [x] `TestComputeLayout/nil_root_does_not_panic`
- [x] `go test -tags gms_pure_go ./cmd/bd/...` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->