### PR TITLE
fix(config): refuse to write secret keys to git-tracked config.yaml

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -75,6 +75,8 @@ Examples:
   bd config unset jira.url`,
 }
 
+var forceGitTracked bool
+
 var configSetCmd = &cobra.Command{
 	Use:   "set <key> <value>",
 	Short: "Set a configuration value",
@@ -104,6 +106,16 @@ var configSetCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "Warning: %q is not a recognized config key. Use 'custom.*' for user-defined keys.\n", key)
 			}
 			fmt.Fprintf(os.Stderr, "Run 'bd config --help' for valid namespaces.\n")
+		}
+
+		// Refuse to write secret keys to git-tracked config files unless
+		// --force-git-tracked is set. This prevents accidental exposure of
+		// API keys and tokens in git history.
+		if !forceGitTracked {
+			if err := config.CheckSecretKeyGitSafety(key); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
 		}
 
 		// Check if this is a yaml-only key (startup settings like no-db, etc.)
@@ -667,6 +679,16 @@ Examples:
 			}
 		}
 
+		// Phase 3b: Check git-tracked secret safety for yaml keys
+		if !forceGitTracked {
+			for _, p := range yamlPairs {
+				if err := config.CheckSecretKeyGitSafety(p.key); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					os.Exit(1)
+				}
+			}
+		}
+
 		// Phase 4: Write yaml-only keys
 		for _, p := range yamlPairs {
 			if err := config.SetYamlConfig(p.key, p.value); err != nil {
@@ -835,6 +857,9 @@ func levenshteinDistance(a, b string) int {
 }
 
 func init() {
+	configSetCmd.Flags().BoolVar(&forceGitTracked, "force-git-tracked", false, "Allow writing secret keys to git-tracked config files (use with caution)")
+	configSetManyCmd.Flags().BoolVar(&forceGitTracked, "force-git-tracked", false, "Allow writing secret keys to git-tracked config files (use with caution)")
+
 	configCmd.AddCommand(configSetCmd)
 	configCmd.AddCommand(configSetManyCmd)
 	configCmd.AddCommand(configGetCmd)

--- a/cmd/bd/init_templates.go
+++ b/cmd/bd/init_templates.go
@@ -74,13 +74,14 @@ func createConfigYaml(beadsDir string, noDbMode bool, prefix string) error {
 #   git-repo: ""       # Separate git repo for backups (default: project repo)
 
 # Integration settings (access with 'bd config get/set')
-# These are stored in the database, not in this file:
-# - jira.url
-# - jira.project
-# - linear.url
-# - linear.api-key
-# - github.org
-# - github.repo
+# Non-secret keys (stored in the database):
+# - jira.url, jira.project
+# - linear.team_id
+# - github.org, github.repo
+#
+# Secret keys (stored in this file but prefer env vars to avoid git exposure):
+# - linear.api_key  → use LINEAR_API_KEY env var instead
+# - github.token    → use GITHUB_TOKEN env var instead
 `, prefixLine, noDbLine)
 
 	if err := os.WriteFile(configYamlPath, []byte(configYamlTemplate), 0600); err != nil {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -641,8 +641,8 @@ Linear integration provides bidirectional sync between bd and Linear via GraphQL
 **Required configuration:**
 
 ```bash
-# API Key (can also use LINEAR_API_KEY environment variable)
-bd config set linear.api_key "lin_api_YOUR_API_KEY"
+# API Key (recommended: use environment variable to avoid git exposure)
+export LINEAR_API_KEY="lin_api_YOUR_API_KEY"  # add to ~/.secrets or ~/.zshrc
 
 # Team ID (find in Linear team settings or URL)
 bd config set linear.team_id "team-uuid-here"

--- a/examples/linear-workflow/README.md
+++ b/examples/linear-workflow/README.md
@@ -22,8 +22,8 @@ The Linear integration provides:
 ### 2. Configure bd
 
 ```bash
-# Set API key (or use LINEAR_API_KEY environment variable)
-bd config set linear.api_key "lin_api_YOUR_API_KEY_HERE"
+# Set API key via environment variable (recommended — avoids git exposure)
+export LINEAR_API_KEY="lin_api_YOUR_API_KEY_HERE"  # add to ~/.secrets or ~/.zshrc
 
 # Set team ID
 bd config set linear.team_id "YOUR_TEAM_UUID"
@@ -58,11 +58,11 @@ Linear uses Personal API Keys for authentication. Create one at:
 Store securely:
 
 ```bash
-# Option 1: bd config (stored in database)
-bd config set linear.api_key "lin_api_..."
+# Recommended: Environment variable (avoids git exposure)
+export LINEAR_API_KEY="lin_api_..."  # add to ~/.secrets or ~/.zshrc
 
-# Option 2: Environment variable
-export LINEAR_API_KEY="lin_api_..."
+# Alternative: bd config (only if config.yaml is NOT git-tracked)
+bd config set linear.api_key "lin_api_..."
 ```
 
 ### Team ID
@@ -271,7 +271,7 @@ First-time import of existing Linear issues:
 
 ```bash
 # Configure credentials
-bd config set linear.api_key "lin_api_..."
+export LINEAR_API_KEY="lin_api_..."  # add to ~/.secrets or ~/.zshrc
 bd config set linear.team_id "team-uuid"
 
 # Check status
@@ -431,9 +431,8 @@ linear.relation_map.related   # (default: related)
 Set the API key:
 
 ```bash
-bd config set linear.api_key "lin_api_YOUR_KEY"
-# Or
-export LINEAR_API_KEY="lin_api_YOUR_KEY"
+# Recommended: environment variable
+export LINEAR_API_KEY="lin_api_YOUR_KEY"  # add to ~/.secrets or ~/.zshrc
 ```
 
 ### "Linear team ID not configured"
@@ -488,7 +487,7 @@ For large projects, initial sync fetches all issues. Subsequent syncs are increm
 ```bash
 # Initial setup
 $ bd init --quiet
-$ bd config set linear.api_key "lin_api_abc123..."
+$ export LINEAR_API_KEY="lin_api_abc123..."  # add to ~/.secrets or ~/.zshrc
 $ bd config set linear.team_id "team-uuid-456"
 
 # Check status

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -92,6 +93,75 @@ func IsYamlOnlyKey(key string) bool {
 	}
 
 	return false
+}
+
+// secretKeyPatterns are substrings that identify a yaml-only key as containing
+// sensitive material that should not be written to git-tracked files.
+var secretKeyPatterns = []string{"api_key", "api-key", "secret", "token", "password"}
+
+// IsSecretKey returns true if the given config key holds sensitive material
+// (API keys, tokens, passwords) that should not be committed to git.
+func IsSecretKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, pattern := range secretKeyPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// isGitTracked returns true if the file at path is tracked by git
+// (i.e., has been git-added). Uses `git ls-files --error-unmatch`.
+func isGitTracked(path string) bool {
+	cmd := exec.Command("git", "ls-files", "--error-unmatch", path)
+	cmd.Dir = filepath.Dir(path)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
+// secretKeyEnvVarHint returns a suggested environment variable name for a
+// secret config key, e.g. "linear.api_key" → "LINEAR_API_KEY".
+func secretKeyEnvVarHint(key string) string {
+	return strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
+}
+
+// CheckSecretKeyGitSafety checks whether writing key to the project's
+// config.yaml would expose a secret in git history. Returns a descriptive
+// error with remediation steps if so; nil otherwise. Non-secret keys always
+// return nil.
+func CheckSecretKeyGitSafety(key string) error {
+	configPath, err := findProjectConfigYaml()
+	if err != nil {
+		return nil // can't resolve path; let the write fail with its own error
+	}
+	return checkSecretGitTracked(configPath, key)
+}
+
+func checkSecretGitTracked(configPath, key string) error {
+	if !IsSecretKey(key) {
+		return nil
+	}
+	if !isGitTracked(configPath) {
+		return nil
+	}
+	envVar := secretKeyEnvVarHint(key)
+	return fmt.Errorf(
+		"refusing to write secret key %q to git-tracked config file %s\n\n"+
+			"This would expose your secret in git history. Instead:\n"+
+			"  export %s=\"your-key-here\"    # add to ~/.secrets or ~/.zshrc\n\n"+
+			"Or move config.yaml out of git tracking:\n"+
+			"  git rm --cached %s\n"+
+			"  echo \"config.yaml\" >> %s/.gitignore\n\n"+
+			"To override this check (e.g., for testing):\n"+
+			"  bd config set --force-git-tracked %s \"value\"",
+		key, configPath,
+		envVar,
+		configPath,
+		filepath.Dir(configPath),
+		key,
+	)
 }
 
 // keyAliases maps alternative key names to their canonical yaml form.

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -121,7 +121,7 @@ func isGitTracked(path string) bool {
 	return cmd.Run() == nil
 }
 
-var secretKeyEnvVarHints = map[string]string{
+var secretKeyEnvVarHints = map[string]string{ //nolint:gosec // Values are environment variable names, not credentials.
 	"ai.api_key":     "ANTHROPIC_API_KEY",
 	"github.token":   "GITHUB_TOKEN",
 	"linear.api_key": "LINEAR_API_KEY",

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -121,10 +121,19 @@ func isGitTracked(path string) bool {
 	return cmd.Run() == nil
 }
 
+var secretKeyEnvVarHints = map[string]string{
+	"ai.api_key":     "ANTHROPIC_API_KEY",
+	"github.token":   "GITHUB_TOKEN",
+	"linear.api_key": "LINEAR_API_KEY",
+}
+
 // secretKeyEnvVarHint returns a suggested environment variable name for a
-// secret config key, e.g. "linear.api_key" → "LINEAR_API_KEY".
+// secret config key, e.g. "linear.api_key" -> "LINEAR_API_KEY".
 func secretKeyEnvVarHint(key string) string {
-	return strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
+	if envVar, ok := secretKeyEnvVarHints[key]; ok {
+		return envVar
+	}
+	return "BD_" + strings.ToUpper(strings.ReplaceAll(strings.ReplaceAll(key, "-", "_"), ".", "_"))
 }
 
 // CheckSecretKeyGitSafety checks whether writing key to the project's
@@ -140,6 +149,9 @@ func CheckSecretKeyGitSafety(key string) error {
 }
 
 func checkSecretGitTracked(configPath, key string) error {
+	if !IsYamlOnlyKey(key) {
+		return nil
+	}
 	if !IsSecretKey(key) {
 		return nil
 	}

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -572,6 +572,27 @@ func TestIsSecretKey(t *testing.T) {
 	}
 }
 
+func TestSecretKeyEnvVarHint(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"linear.api_key", "LINEAR_API_KEY"},
+		{"github.token", "GITHUB_TOKEN"},
+		{"ai.api_key", "ANTHROPIC_API_KEY"},
+		{"custom.secret-token", "BD_CUSTOM_SECRET_TOKEN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := secretKeyEnvVarHint(tt.key)
+			if got != tt.expected {
+				t.Errorf("secretKeyEnvVarHint(%q) = %q, want %q", tt.key, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestCheckSecretKeyGitSafety_RefusesGitTrackedSecret(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -610,6 +631,36 @@ func TestCheckSecretKeyGitSafety_RefusesGitTrackedSecret(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--force-git-tracked") {
 		t.Fatalf("expected --force-git-tracked hint in error, got: %v", err)
+	}
+}
+
+func TestCheckSecretKeyGitSafety_AllowsDatabaseBackedSecretKey(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = tmpDir
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("json: false\n"), 0644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+	gitAdd := exec.Command("git", "add", configPath)
+	gitAdd.Dir = tmpDir
+	if out, err := gitAdd.CombinedOutput(); err != nil {
+		t.Fatalf("git add failed: %v\n%s", err, out)
+	}
+
+	// Secret-looking keys that are not YAML-backed do not write to config.yaml.
+	err := checkSecretGitTracked(configPath, "notion.token")
+	if err != nil {
+		t.Fatalf("expected no error for database-backed secret key, got: %v", err)
 	}
 }
 

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -540,6 +541,131 @@ func TestValidateYamlConfigValue_SharedServer(t *testing.T) {
 	}
 	if err := validateYamlConfigValue("dolt.shared-server", "1"); err == nil {
 		t.Error("expected '1' to be invalid (not a boolean string)")
+	}
+}
+
+func TestIsSecretKey(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected bool
+	}{
+		{"linear.api_key", true},
+		{"github.token", true},
+		{"some.password", true},
+		{"some.secret", true},
+		{"some.api-key", true},
+
+		{"no-db", false},
+		{"json", false},
+		{"routing.mode", false},
+		{"sync.remote", false},
+		{"linear.team_id", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := IsSecretKey(tt.key)
+			if got != tt.expected {
+				t.Errorf("IsSecretKey(%q) = %v, want %v", tt.key, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckSecretKeyGitSafety_RefusesGitTrackedSecret(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Initialize a git repo
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = tmpDir
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+
+	// Create .beads/config.yaml and git-add it
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("json: false\n"), 0644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+	gitAdd := exec.Command("git", "add", configPath)
+	gitAdd.Dir = tmpDir
+	if out, err := gitAdd.CombinedOutput(); err != nil {
+		t.Fatalf("git add failed: %v\n%s", err, out)
+	}
+
+	// checkSecretGitTracked should refuse a secret key
+	err := checkSecretGitTracked(configPath, "linear.api_key")
+	if err == nil {
+		t.Fatal("expected error for secret key on git-tracked config, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing to write secret key") {
+		t.Fatalf("expected 'refusing to write' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "LINEAR_API_KEY") {
+		t.Fatalf("expected env var hint in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--force-git-tracked") {
+		t.Fatalf("expected --force-git-tracked hint in error, got: %v", err)
+	}
+}
+
+func TestCheckSecretKeyGitSafety_AllowsUntrackedConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Initialize a git repo but do NOT add config.yaml
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = tmpDir
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("json: false\n"), 0644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+
+	// checkSecretGitTracked should allow untracked config
+	err := checkSecretGitTracked(configPath, "linear.api_key")
+	if err != nil {
+		t.Fatalf("expected no error for untracked config, got: %v", err)
+	}
+}
+
+func TestCheckSecretKeyGitSafety_AllowsNonSecretKeyOnTrackedConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = tmpDir
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("json: false\n"), 0644); err != nil {
+		t.Fatalf("failed to write config.yaml: %v", err)
+	}
+	gitAdd := exec.Command("git", "add", configPath)
+	gitAdd.Dir = tmpDir
+	if out, err := gitAdd.CombinedOutput(); err != nil {
+		t.Fatalf("git add failed: %v\n%s", err, out)
+	}
+
+	// Non-secret keys should always be allowed, even on tracked files
+	err := checkSecretGitTracked(configPath, "no-db")
+	if err != nil {
+		t.Fatalf("expected no error for non-secret key, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

P0 security fix. `bd config set` for secret keys (`api_key`, `secret`, `token`, `password`) now detects whether the target `config.yaml` is tracked by git and refuses the write with an actionable error message.

This addresses the verified credential-leak-on-default-path: the documented setup (`bd config set linear.api_key ...`) writes to `.beads/config.yaml` which is git-tracked by default, leaking Linear API keys into git history.

## Changes

- **`internal/config/yaml_config.go`** — Added `IsSecretKey`, `isGitTracked`, `CheckSecretKeyGitSafety` functions. Secret key detection uses substring matching against `api_key`, `secret`, `token`, `password`. Git tracking detection uses `git ls-files --error-unmatch`.
- **`cmd/bd/config.go`** — Wired the safety check into `config set` and `config set-many`. Added `--force-git-tracked` escape hatch flag.
- **`cmd/bd/init_templates.go`** — Fixed stale comment that incorrectly claimed secrets are "stored in the database" — now documents they're in config.yaml and recommends env vars.
- **`examples/linear-workflow/README.md`** — Replaced `bd config set linear.api_key` with `export LINEAR_API_KEY=...`
- **`docs/CONFIG.md`** — Linear setup section now leads with env var approach.

## Test plan

- [x] 3 new tests: refuses git-tracked secret write, allows untracked config, allows non-secret keys on tracked config
- [x] Full `internal/config` test suite passes (0 regressions)
- [x] `go vet` clean
- [x] `--force-git-tracked` escape hatch works for test environments

## Backward compatibility

- Existing configurations are read unchanged; only writes are gated
- Non-secret config keys (`linear.team_ids`, `linear.priority_map.*`, etc.) are unaffected
- `--force-git-tracked` provides an opt-out for CI/test environments

## Charter compliance

Security hygiene of an existing flow. No new features, no new config surface beyond the `--force-git-tracked` flag.

## Related

- See also #3649 (wisp leak) and #3650 (memory leak) for additional privacy boundary fixes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->