### PR TITLE
fix(export): exclude ephemeral wisps from bd export by default

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -112,10 +112,14 @@ func runExport(cmd *cobra.Command, args []string) error {
 		filter.IsTemplate = &isTemplate
 	}
 
-	// Fetch all issues (persistent + wisps). SearchIssues with Ephemeral=nil
-	// already queries both the issues and wisps tables with ID-based dedup
-	// (see issueops/search.go). A separate Ephemeral=true query would cause
-	// every wisp to appear twice in the output (GH#3352).
+	// Exclude ephemeral wisps by default — they are private/transient and
+	// must not reach git history or external integrations (GH#3649).
+	// --all overrides to include everything.
+	if !exportAll {
+		persistentOnly := false
+		filter.Ephemeral = &persistentOnly
+	}
+
 	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
 		return fmt.Errorf("failed to search issues: %w", err)

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -160,8 +160,11 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 	isTemplate := false
 	filter.IsTemplate = &isTemplate
 
-	// Fetch all issues (persistent + wisps). SearchIssues with Ephemeral=nil
-	// already includes wisps via ID-based dedup (GH#3352).
+	// Exclude ephemeral wisps — they are private/transient and must not
+	// reach git history or external integrations (GH#3649).
+	persistentOnly := false
+	filter.Ephemeral = &persistentOnly
+
 	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to search issues: %w", err)

--- a/cmd/bd/export_test.go
+++ b/cmd/bd/export_test.go
@@ -772,3 +772,124 @@ func TestExportNoDuplicateWisps(t *testing.T) {
 		t.Errorf("expected %d unique issues in export, got %d", expectedTotal, len(seenIDs))
 	}
 }
+
+func TestExportExcludesWispsByDefault(t *testing.T) {
+	// GH#3649: bd export must exclude ephemeral wisps by default.
+	// Wisps are private/transient and must not reach git history.
+	// Only --all should include them.
+	if testDoltServerPort == 0 {
+		t.Skip("Dolt test server not available")
+	}
+	if testutil.DoltContainerCrashed() {
+		t.Skipf("Dolt test server crashed: %v", testutil.DoltContainerCrashError())
+	}
+
+	ensureTestMode(t)
+	saved := saveAndRestoreGlobals(t)
+	_ = saved
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	origWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+
+	dbName := uniqueTestDBName(t)
+	testDBPath := filepath.Join(beadsDir, "dolt")
+	writeTestMetadata(t, testDBPath, dbName)
+	s := newTestStore(t, testDBPath)
+	store = s
+	storeMutex.Lock()
+	storeActive = true
+	storeMutex.Unlock()
+	t.Cleanup(func() {
+		store = nil
+		storeMutex.Lock()
+		storeActive = false
+		storeMutex.Unlock()
+	})
+
+	ctx := context.Background()
+	rootCtx = ctx
+
+	// Create persistent issues.
+	for i := 1; i <= 2; i++ {
+		id := fmt.Sprintf("wispexcl-regular-%d", i)
+		if _, err := s.DB().ExecContext(ctx,
+			`INSERT INTO issues (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			id, fmt.Sprintf("Persistent issue %d", i), "", "", "", "", "open", 2, "task"); err != nil {
+			t.Fatalf("insert persistent issue %d: %v", i, err)
+		}
+	}
+
+	// Create ephemeral wisps via the store API (routes to wisps table).
+	for i := 1; i <= 3; i++ {
+		wisp := &types.Issue{
+			Title:     fmt.Sprintf("Private wisp %d", i),
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := s.CreateIssue(ctx, wisp, "test"); err != nil {
+			t.Fatalf("CreateIssue (wisp %d): %v", i, err)
+		}
+	}
+
+	// Default export (no --all): wisps must be excluded.
+	exportFile := filepath.Join(tmpDir, "default_export.jsonl")
+	exportOutput = exportFile
+	exportAll = false
+	exportIncludeInfra = false
+	exportScrub = false
+	exportNoMemories = true
+	t.Cleanup(func() {
+		exportOutput = ""
+		exportAll = false
+		exportNoMemories = false
+	})
+
+	if err := runExport(nil, nil); err != nil {
+		t.Fatalf("runExport (default): %v", err)
+	}
+
+	data, err := os.ReadFile(exportFile)
+	if err != nil {
+		t.Fatalf("read default export: %v", err)
+	}
+	defaultLines := splitJSONL(data)
+	for _, line := range defaultLines {
+		var rec map[string]interface{}
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if ephemeral, ok := rec["ephemeral"].(bool); ok && ephemeral {
+			t.Errorf("default export contains ephemeral wisp: %s", rec["id"])
+		}
+	}
+	if len(defaultLines) != 2 {
+		t.Errorf("default export: expected 2 persistent issues, got %d lines", len(defaultLines))
+	}
+
+	// --all export: wisps must be included.
+	allFile := filepath.Join(tmpDir, "all_export.jsonl")
+	exportOutput = allFile
+	exportAll = true
+	if err := runExport(nil, nil); err != nil {
+		t.Fatalf("runExport (--all): %v", err)
+	}
+	allData, err := os.ReadFile(allFile)
+	if err != nil {
+		t.Fatalf("read --all export: %v", err)
+	}
+	allLines := splitJSONL(allData)
+	if len(allLines) != 5 {
+		t.Errorf("--all export: expected 5 issues (2 persistent + 3 wisps), got %d", len(allLines))
+	}
+}

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -30,9 +30,14 @@ func SearchIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter type
 		return nil, fmt.Errorf("search issues: %w", err)
 	}
 
-	// When filter.Ephemeral is nil (search everything), also search the wisps
-	// table and merge results.
-	if filter.Ephemeral == nil {
+	// When filter.Ephemeral is nil (search everything) or false (non-ephemeral
+	// only), also search the wisps table and merge results. NoHistory beads are
+	// stored in the wisps table with ephemeral=0, so they must survive an
+	// Ephemeral=&false filter (GH#3649). The WHERE clause added by
+	// BuildIssueFilterClauses handles the per-row ephemeral column check, so
+	// querying wisps here with Ephemeral=&false returns only NoHistory beads
+	// while correctly excluding true ephemeral wisps. (GH#3659)
+	if filter.Ephemeral == nil || !*filter.Ephemeral {
 		wispResults, wispErr := searchTableInTx(ctx, tx, query, filter, WispsFilterTables)
 		if wispErr != nil && !isTableNotExistError(wispErr) {
 			return nil, fmt.Errorf("search wisps (merge): %w", wispErr)


### PR DESCRIPTION
## Summary

Fixes #3649.

- `bd export` and auto-export (pre-commit hook) included ephemeral wisps in JSONL output because the `SearchIssues` filter had `Ephemeral=nil` (match all)
- Wisps are private/transient and must not reach git history or external integrations
- Sets `filter.Ephemeral = &false` (persistent-only) in both `export.go` and `export_auto.go`
- `--all` flag overrides to include everything, preserving backward compatibility for full backups

## Test plan

- [x] `TestExportExcludesWispsByDefault` — verifies default export excludes wisps and `--all` includes them
- [x] `TestExportNoDuplicateWisps` — existing dedup test still passes (uses `--all`)
- [x] `go build -tags gms_pure_go ./cmd/bd/` — compiles cleanly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->