### PR TITLE
Add maintainer PR guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,15 @@ expected and should not be flagged.
 - **Development Guidelines** - Code standards and testing
 - **Visual Design System** - Status icons, colors, and semantic styling for CLI output
 - **Contributor Protection** - Read [CONTRIBUTING.md](CONTRIBUTING.md) before handling external PRs
+- **Maintainer PR Guidelines** - Read [PR_MAINTAINER_GUIDELINES.md](PR_MAINTAINER_GUIDELINES.md) before triaging, landing, or closing PRs
 
 ## PR Safety for Agents
+
+Before triaging, reviewing, landing, closing, or otherwise maintaining PRs, read
+[PR_MAINTAINER_GUIDELINES.md](PR_MAINTAINER_GUIDELINES.md). The maintainer
+policy is to maximize community throughput: find useful contributor value,
+absorb or transform it locally when practical, preserve attribution, and use
+request-changes only as a last resort.
 
 Before implementing work, opening a PR, or merging/closing a PR, run the PR
 preflight:

--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -113,6 +113,14 @@ defer to the standard PR flow to keep changes reviewable.
 - When handling external contributor PRs, use fix-merge: checkout the PR
   branch locally, fix/rebase onto main, merge via PR, then close the PR
 
+### Maintainer PR Guidelines
+
+Before triaging, reviewing, landing, closing, or otherwise maintaining PRs,
+read [PR_MAINTAINER_GUIDELINES.md](PR_MAINTAINER_GUIDELINES.md). The
+maintainer policy is to maximize community throughput: find useful contributor
+value, absorb or transform it locally when practical, preserve attribution, and
+use request-changes only as a last resort.
+
 ### External Contributor PRs: Check Before You Build
 
 **Read [CONTRIBUTING.md](CONTRIBUTING.md)** — it contains promises we've made to contributors. Violating them damages trust and community.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Instructions for AI Agents Working on Beads
 
-> **Reading order**: Architecture → `docs/CLAUDE.md` | Workflow → `AGENT_INSTRUCTIONS.md` | Quick ref → `AGENTS.md`
+> **Reading order**: Architecture → `docs/CLAUDE.md` | Workflow → `AGENT_INSTRUCTIONS.md` | PR maintenance → `PR_MAINTAINER_GUIDELINES.md` | Quick ref → `AGENTS.md`
 >
 > Run `bd prime` for AI-optimized context. Run `bd memories` to see persistent learnings.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,8 @@ This project uses AI agents for maintenance. We've established strict rules to p
 
 If any of this goes wrong, please open an issue — we take contributor experience seriously.
 
+Maintainers and agents follow [PR_MAINTAINER_GUIDELINES.md](PR_MAINTAINER_GUIDELINES.md) when triaging, landing, transforming, or closing PRs.
+
 ### Refactoring Campaign PR Intake Checklist
 
 Before starting a rewrite, cleanup, or large refactoring pass, maintainers and agents must review open contributor PRs that touch the same area. Use this checklist to decide whether to merge, rebase, incorporate, or close each PR.

--- a/PR_MAINTAINER_GUIDELINES.md
+++ b/PR_MAINTAINER_GUIDELINES.md
@@ -1,0 +1,60 @@
+# Maintainer PR Guidelines
+
+This is the source of truth for agents triaging, reviewing, landing, closing, or otherwise maintaining pull requests for beads.
+
+## Philosophy
+
+Help contributors get to the finish line. Optimize for community throughput.
+
+For every PR, look for the value in it and choose the action that moves useful work into the codebase with the least contributor starvation. If a PR contains something worth keeping, absorb that value directly when practical: accept it as-is, fix bugs, improve the architecture, rename things, turn it into a plugin, cherry-pick parts, or reject the parts that do not fit.
+
+The goal is not to block contributors unnecessarily. The goal is to identify useful work, preserve it, and keep the project moving.
+
+## Contributor Protection
+
+External contributor PRs have priority. Before implementing related work, opening a competing PR, or closing a PR, check whether an existing contributor PR already addresses the same area.
+
+- Review contributor work first. Read the PR description, changed files, linked issues, tests, CI status, and latest discussion.
+- Build on the contributor branch when practical instead of rewriting the same work in parallel.
+- Preserve contributor tests unless they are actually wrong.
+- Preserve attribution with original commits when possible, or with `Co-authored-by:` and PR references when transforming the work locally.
+- Never close, supersede, or replace a contributor PR silently. Explain what was preserved, what changed, and why.
+- If a rewrite is unavoidable, credit the contributor's design, tests, bug report, or use case in the replacement commit or PR.
+
+## Triage Groups
+
+Classify each PR into one of these groups:
+
+- **Easy win**: Targeted bug fixes, documentation updates, dependency bot upgrades, drafts to close, PRs from banned contributors, and other low-risk cases.
+- **Fix-merge candidate**: A PR that otherwise fits easy-win criteria but has a simple blocker, such as failed CI, a needed rebase, or a small implementation error.
+- **Needs review**: A PR that looks suspicious, complex, broad, risky, or otherwise requires deeper investigation.
+
+Easy wins can be handled automatically during a PR review run and by recurring patrols. Fix-merge candidates can also be handled automatically when the maintainer determines the repair is simple enough to make locally.
+
+Needs-review PRs require a deeper agent review and a concrete report. The maintainer can summarize those reports or inspect the agent sessions directly.
+
+## Outcomes
+
+Use these recommendations after review:
+
+- **Easy win**: The PR turns out to fit easy-win criteria after all.
+- **Merge**: Recommend merge. The PR is well-tested, broadly useful, well-documented, and ready as-is.
+- **Merge-fix**: Merge the PR as-is, then push a follow-up fix to `main`. Use when the remaining issues are safe to repair afterward.
+- **Fix-merge**: Pull the PR locally, make substantial fixes, then push with contributor attribution. Use when the PR is busted but valuable.
+- **Cherry-pick**: Keep only selected items from a PR with multiple features or fixes. Commit the useful parts locally with attribution, then close the PR with an explanation.
+- **Split-merge**: Split a multi-concern PR into separate commits, then push all accepted parts with attribution to the original contributor.
+- **Redesign/reimplement**: Reject the submitted design but solve the underlying problem another way. Close the PR with thanks and an explanation.
+- **Retire**: Close an obsolete PR with thanks because it was superseded or already fixed elsewhere.
+- **Reject**: Close politely when the feature does not pay its weight in tech debt, is too niche for core, or the design does not meet project standards.
+- **Request changes**: Last resort. Avoid this when the maintainer or agents can reasonably absorb, transform, or land the useful parts directly.
+
+Other outcomes are possible, including rerouting a PR to the right project or banning a contributor, but the list above covers the normal cases.
+
+## Operating Rules
+
+- Prefer landing or transforming useful work over asking the contributor to do more rounds.
+- Preserve contributor attribution when absorbing, fixing, cherry-picking, splitting, or reimplementing PR value.
+- Be explicit when closing a PR: thank the contributor, state the outcome, and explain what was accepted, rejected, superseded, or implemented differently.
+- Treat request-changes as exceptional because it can strand contributor work.
+- File follow-up work as beads issues instead of hidden notes.
+- When code changes result from PR maintenance, follow repo quality gates and session completion rules in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- Turn the PR assessment workflow from @steveyegge 's [Vibe Maintainer](https://steve-yegge.medium.com/vibe-maintainer-a2273a841040) into an agent-neutral maintainer PR guidelines document
- combine existing contributor-protection rules with maintainer outcome categories such as merge-fix, fix-merge, cherry-pick, split-merge, reimplement, retire, reject, and request-changes-as-last-resort
- link the guide from AGENTS.md, AGENT_INSTRUCTIONS.md, CLAUDE.md, and CONTRIBUTING.md

## Validation
- scripts/pr-preflight.sh --search "maintainer PR guidelines contributor protection agent profile" --repo gastownhall/beads
- git diff --check

Tracked in bd-k0j.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->