### PR TITLE
fix(dolt): batch wisp-ID partition in bulk hydrators (GH#3414)

### DIFF
--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -40,7 +40,7 @@ func (s *DoltStore) GetLabelsForIssues(ctx context.Context, issueIDs []string) (
 	var result map[string][]string
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs, nil)
+		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs)
 		return err
 	})
 	return result, err

--- a/internal/storage/dolt/labels_test.go
+++ b/internal/storage/dolt/labels_test.go
@@ -74,6 +74,65 @@ func TestGetLabelsForIssues(t *testing.T) {
 	}
 }
 
+// TestGetLabelsForIssues_MixedWispAndPermanent verifies that GetLabelsForIssues
+// correctly partitions a mixed batch of wisp and permanent issue IDs using the
+// batched partitioner introduced for GH#3414 (rather than one round-trip per
+// ID), and still routes each ID to the right label table.
+func TestGetLabelsForIssues_MixedWispAndPermanent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	perm := &types.Issue{
+		ID:        "mixed-perm",
+		Title:     "Permanent",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	wisp := &types.Issue{
+		ID:        "mixed-wisp",
+		Title:     "Wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+
+	if err := store.CreateIssue(ctx, perm, "tester"); err != nil {
+		t.Fatalf("create perm: %v", err)
+	}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("create wisp: %v", err)
+	}
+
+	if err := store.AddLabel(ctx, perm.ID, "alpha", "tester"); err != nil {
+		t.Fatalf("add label perm: %v", err)
+	}
+	if err := store.AddLabel(ctx, wisp.ID, "beta", "tester"); err != nil {
+		t.Fatalf("add label wisp: %v", err)
+	}
+
+	// Include an unknown ID to confirm PartitionWispIDsInTx treats it as
+	// a perm ID (no round-trip per ID) and we still get sane results.
+	labelsMap, err := store.GetLabelsForIssues(ctx, []string{perm.ID, wisp.ID, "does-not-exist"})
+	if err != nil {
+		t.Fatalf("GetLabelsForIssues: %v", err)
+	}
+
+	if got := labelsMap[perm.ID]; len(got) != 1 || got[0] != "alpha" {
+		t.Errorf("perm labels: want [alpha], got %v", got)
+	}
+	if got := labelsMap[wisp.ID]; len(got) != 1 || got[0] != "beta" {
+		t.Errorf("wisp labels: want [beta], got %v", got)
+	}
+	if got, ok := labelsMap["does-not-exist"]; ok && len(got) != 0 {
+		t.Errorf("unknown id: want none, got %v", got)
+	}
+}
+
 func TestGetLabelsForIssues_EmptyList(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/wisp_partition_test.go
+++ b/internal/storage/dolt/wisp_partition_test.go
@@ -1,0 +1,389 @@
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// =============================================================================
+// PartitionWispIDsInTx tests
+//
+// These lock in the GH#3414 fix: one batched wisp-partition query instead of
+// N per-ID round-trips. They also cover boundary cases (empty, unknown IDs,
+// >queryBatchSize batches) and ensure mixed-wisp bulk hydrators still route
+// correctly through the refactored code paths.
+// =============================================================================
+
+// createPerm creates a permanent issue with the given ID.
+func createPerm(t *testing.T, ctx context.Context, store *DoltStore, id string) {
+	t.Helper()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     "perm " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create perm %s: %v", id, err)
+	}
+}
+
+// createWisp creates an ephemeral (wisp) issue with the given ID.
+func createWisp(t *testing.T, ctx context.Context, store *DoltStore, id string) {
+	t.Helper()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     "wisp " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create wisp %s: %v", id, err)
+	}
+}
+
+// partitionInTx runs PartitionWispIDsInTx inside a store read transaction.
+func partitionInTx(t *testing.T, ctx context.Context, store *DoltStore, ids []string) (wispIDs, permIDs []string) {
+	t.Helper()
+	err := store.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		wispIDs, permIDs, err = issueops.PartitionWispIDsInTx(ctx, tx, ids)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("PartitionWispIDsInTx: %v", err)
+	}
+	return wispIDs, permIDs
+}
+
+func TestPartitionWispIDsInTx_Empty(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	wispIDs, permIDs := partitionInTx(t, ctx, store, nil)
+	if len(wispIDs) != 0 || len(permIDs) != 0 {
+		t.Errorf("empty input: want ([], []), got (%v, %v)", wispIDs, permIDs)
+	}
+
+	wispIDs, permIDs = partitionInTx(t, ctx, store, []string{})
+	if len(wispIDs) != 0 || len(permIDs) != 0 {
+		t.Errorf("empty slice: want ([], []), got (%v, %v)", wispIDs, permIDs)
+	}
+}
+
+func TestPartitionWispIDsInTx_AllPerm(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ids := []string{"part-all-perm-1", "part-all-perm-2", "part-all-perm-3"}
+	for _, id := range ids {
+		createPerm(t, ctx, store, id)
+	}
+
+	wispIDs, permIDs := partitionInTx(t, ctx, store, ids)
+	if len(wispIDs) != 0 {
+		t.Errorf("expected no wisp IDs, got %v", wispIDs)
+	}
+	if len(permIDs) != len(ids) {
+		t.Errorf("expected %d perm IDs, got %d (%v)", len(ids), len(permIDs), permIDs)
+	}
+	// Input ordering should be preserved.
+	for i, want := range ids {
+		if permIDs[i] != want {
+			t.Errorf("perm ordering broken at %d: want %s, got %s", i, want, permIDs[i])
+		}
+	}
+}
+
+func TestPartitionWispIDsInTx_AllWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	ids := []string{"part-all-wisp-1", "part-all-wisp-2", "part-all-wisp-3"}
+	for _, id := range ids {
+		createWisp(t, ctx, store, id)
+	}
+
+	wispIDs, permIDs := partitionInTx(t, ctx, store, ids)
+	if len(permIDs) != 0 {
+		t.Errorf("expected no perm IDs, got %v", permIDs)
+	}
+	if len(wispIDs) != len(ids) {
+		t.Errorf("expected %d wisp IDs, got %d (%v)", len(ids), len(wispIDs), wispIDs)
+	}
+	for i, want := range ids {
+		if wispIDs[i] != want {
+			t.Errorf("wisp ordering broken at %d: want %s, got %s", i, want, wispIDs[i])
+		}
+	}
+}
+
+func TestPartitionWispIDsInTx_MixedWithUnknown(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	createPerm(t, ctx, store, "part-mix-perm-1")
+	createPerm(t, ctx, store, "part-mix-perm-2")
+	createWisp(t, ctx, store, "part-mix-wisp-1")
+	createWisp(t, ctx, store, "part-mix-wisp-2")
+
+	// Interleave IDs and include an unknown one. Unknowns must fall into
+	// the permanent bucket (callers treat them as "not a wisp"), mirroring
+	// the old per-ID IsActiveWispInTx behavior.
+	input := []string{
+		"part-mix-perm-1",
+		"part-mix-wisp-1",
+		"part-mix-unknown",
+		"part-mix-perm-2",
+		"part-mix-wisp-2",
+	}
+
+	wispIDs, permIDs := partitionInTx(t, ctx, store, input)
+
+	sortedWisp := append([]string(nil), wispIDs...)
+	sortedPerm := append([]string(nil), permIDs...)
+	sort.Strings(sortedWisp)
+	sort.Strings(sortedPerm)
+
+	wantWisp := []string{"part-mix-wisp-1", "part-mix-wisp-2"}
+	wantPerm := []string{"part-mix-perm-1", "part-mix-perm-2", "part-mix-unknown"}
+
+	if fmt.Sprint(sortedWisp) != fmt.Sprint(wantWisp) {
+		t.Errorf("wisp bucket: want %v, got %v", wantWisp, sortedWisp)
+	}
+	if fmt.Sprint(sortedPerm) != fmt.Sprint(wantPerm) {
+		t.Errorf("perm bucket: want %v, got %v", wantPerm, sortedPerm)
+	}
+}
+
+func TestPartitionWispIDsInTx_PreservesInputOrderWithinBucket(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create IDs in non-alphabetical order to verify we don't re-sort.
+	createPerm(t, ctx, store, "order-perm-c")
+	createPerm(t, ctx, store, "order-perm-a")
+	createWisp(t, ctx, store, "order-wisp-z")
+	createWisp(t, ctx, store, "order-wisp-m")
+
+	input := []string{
+		"order-perm-c",
+		"order-wisp-z",
+		"order-perm-a",
+		"order-wisp-m",
+	}
+
+	wispIDs, permIDs := partitionInTx(t, ctx, store, input)
+
+	wantWisp := []string{"order-wisp-z", "order-wisp-m"}
+	wantPerm := []string{"order-perm-c", "order-perm-a"}
+
+	if fmt.Sprint(wispIDs) != fmt.Sprint(wantWisp) {
+		t.Errorf("wisp order: want %v, got %v", wantWisp, wispIDs)
+	}
+	if fmt.Sprint(permIDs) != fmt.Sprint(wantPerm) {
+		t.Errorf("perm order: want %v, got %v", wantPerm, permIDs)
+	}
+}
+
+// TestPartitionWispIDsInTx_LargeBatch exercises the queryBatchSize chunking
+// path (internal batch size is 200). Regression guard: confirms we handle
+// multi-batch partitions without losing or duplicating IDs.
+func TestPartitionWispIDsInTx_LargeBatch(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	const total = 450 // > 2 * queryBatchSize (200)
+	ids := make([]string, 0, total)
+	wantWisp := make(map[string]bool)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("large-batch-%04d", i)
+		ids = append(ids, id)
+		if i%3 == 0 {
+			createWisp(t, ctx, store, id)
+			wantWisp[id] = true
+		} else {
+			createPerm(t, ctx, store, id)
+		}
+	}
+
+	wispIDs, permIDs := partitionInTx(t, ctx, store, ids)
+
+	if len(wispIDs)+len(permIDs) != total {
+		t.Fatalf("bucket total mismatch: wisp=%d perm=%d want total=%d",
+			len(wispIDs), len(permIDs), total)
+	}
+	gotWisp := make(map[string]bool, len(wispIDs))
+	for _, id := range wispIDs {
+		if gotWisp[id] {
+			t.Errorf("duplicate id in wisp bucket: %s", id)
+		}
+		gotWisp[id] = true
+		if !wantWisp[id] {
+			t.Errorf("id %s misrouted to wisp bucket", id)
+		}
+	}
+	gotPerm := make(map[string]bool, len(permIDs))
+	for _, id := range permIDs {
+		if gotPerm[id] {
+			t.Errorf("duplicate id in perm bucket: %s", id)
+		}
+		gotPerm[id] = true
+		if wantWisp[id] {
+			t.Errorf("wisp id %s misrouted to perm bucket", id)
+		}
+	}
+}
+
+// =============================================================================
+// Mixed-bucket bulk hydration regression tests
+//
+// These go through the public store API (which uses the refactored
+// issueops.GetXxxForIssuesInTx functions internally) and assert that routing
+// remains correct across wisp and permanent tables after the partitioner
+// rewrite.
+// =============================================================================
+
+func TestGetCommentsForIssues_MixedWispAndPermanent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mix-cmt-perm")
+	createWisp(t, ctx, store, "mix-cmt-wisp")
+
+	if err := store.AddComment(ctx, "mix-cmt-perm", "alice", "on perm"); err != nil {
+		t.Fatalf("add comment on perm: %v", err)
+	}
+	if err := store.AddComment(ctx, "mix-cmt-wisp", "bob", "on wisp"); err != nil {
+		t.Fatalf("add comment on wisp: %v", err)
+	}
+
+	got, err := store.GetCommentsForIssues(ctx, []string{"mix-cmt-perm", "mix-cmt-wisp", "mix-cmt-unknown"})
+	if err != nil {
+		t.Fatalf("GetCommentsForIssues: %v", err)
+	}
+
+	if cs := got["mix-cmt-perm"]; len(cs) != 1 || cs[0].Text != "on perm" {
+		t.Errorf("perm comments: want [on perm], got %+v", cs)
+	}
+	if cs := got["mix-cmt-wisp"]; len(cs) != 1 || cs[0].Text != "on wisp" {
+		t.Errorf("wisp comments: want [on wisp], got %+v", cs)
+	}
+	if cs, ok := got["mix-cmt-unknown"]; ok && len(cs) != 0 {
+		t.Errorf("unknown id: expected no comments, got %+v", cs)
+	}
+}
+
+func TestGetDependencyRecordsForIssues_MixedWispAndPermanent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Perm-on-perm dependency.
+	createPerm(t, ctx, store, "mix-dep-perm-src")
+	createPerm(t, ctx, store, "mix-dep-perm-tgt")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mix-dep-perm-src",
+		DependsOnID: "mix-dep-perm-tgt",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("add perm dep: %v", err)
+	}
+
+	// Wisp-on-perm dependency (dep lives in wisp_dependencies).
+	createWisp(t, ctx, store, "mix-dep-wisp-src")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mix-dep-wisp-src",
+		DependsOnID: "mix-dep-perm-tgt",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("add wisp dep: %v", err)
+	}
+
+	got, err := store.GetDependencyRecordsForIssues(ctx,
+		[]string{"mix-dep-perm-src", "mix-dep-wisp-src"})
+	if err != nil {
+		t.Fatalf("GetDependencyRecordsForIssues: %v", err)
+	}
+
+	if ds := got["mix-dep-perm-src"]; len(ds) != 1 || ds[0].DependsOnID != "mix-dep-perm-tgt" {
+		t.Errorf("perm deps: want 1 record targeting mix-dep-perm-tgt, got %+v", ds)
+	}
+	if ds := got["mix-dep-wisp-src"]; len(ds) != 1 || ds[0].DependsOnID != "mix-dep-perm-tgt" {
+		t.Errorf("wisp deps: want 1 record targeting mix-dep-perm-tgt, got %+v", ds)
+	}
+}
+
+// TestGetLabelsForIssues_ManyIDs exercises the queryBatchSize chunking path
+// inside GetLabelsForIssuesInTx — regression guard for partition + label
+// fetch crossing the 200-ID boundary.
+func TestGetLabelsForIssues_ManyIDs(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	const total = 250 // > queryBatchSize (200)
+	ids := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		id := fmt.Sprintf("many-label-%04d", i)
+		ids = append(ids, id)
+		if i%5 == 0 {
+			createWisp(t, ctx, store, id)
+		} else {
+			createPerm(t, ctx, store, id)
+		}
+		if err := store.AddLabel(ctx, id, fmt.Sprintf("lbl-%d", i), "tester"); err != nil {
+			t.Fatalf("add label on %s: %v", id, err)
+		}
+	}
+
+	got, err := store.GetLabelsForIssues(ctx, ids)
+	if err != nil {
+		t.Fatalf("GetLabelsForIssues: %v", err)
+	}
+
+	if len(got) != total {
+		t.Errorf("want labels for %d issues, got %d", total, len(got))
+	}
+	for i, id := range ids {
+		want := fmt.Sprintf("lbl-%d", i)
+		if labels := got[id]; len(labels) != 1 || labels[0] != want {
+			t.Errorf("%s labels: want [%s], got %v", id, want, labels)
+		}
+	}
+}

--- a/internal/storage/embeddeddolt/list_queries.go
+++ b/internal/storage/embeddeddolt/list_queries.go
@@ -35,7 +35,7 @@ func (s *EmbeddedDoltStore) GetLabelsForIssues(ctx context.Context, issueIDs []s
 	var result map[string][]string
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs, nil)
+		result, err = issueops.GetLabelsForIssuesInTx(ctx, tx, issueIDs)
 		return err
 	})
 	return result, err

--- a/internal/storage/issueops/bulk_ops.go
+++ b/internal/storage/issueops/bulk_ops.go
@@ -109,14 +109,11 @@ func GetCommentsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string
 
 	result := make(map[string][]*types.Comment)
 
-	// Partition IDs by wisp status.
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	// Partition IDs by wisp status in a single batched query, to avoid N
+	// round-trips on remote backends (GH#3414).
+	wispIDs, permIDs, err := PartitionWispIDsInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(permIDs) > 0 {

--- a/internal/storage/issueops/delete.go
+++ b/internal/storage/issueops/delete.go
@@ -73,14 +73,11 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 		return &types.DeleteIssuesResult{}, nil
 	}
 
-	// Partition into wisps and regular issues.
-	var wispIDs, regularIDs []string
-	for _, id := range ids {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			regularIDs = append(regularIDs, id)
-		}
+	// Partition into wisps and regular issues in a single batched query
+	// instead of one round-trip per ID (GH#3414).
+	wispIDs, regularIDs, err := PartitionWispIDsInTx(ctx, tx, ids)
+	if err != nil {
+		return nil, err
 	}
 
 	// Delete wisps first.

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -34,69 +34,82 @@ func GetAllDependencyRecordsInTx(ctx context.Context, tx *sql.Tx) (map[string][]
 
 // GetDependencyRecordsForIssuesInTx returns dependency records for specific issues,
 // routing each ID to dependencies or wisp_dependencies based on wisp status.
-// Uses batched IN clauses (queryBatchSize) to avoid query-planner spikes.
+// Uses a single batched wisp-partition query + batched IN clauses, so cost is
+// O(1 + N/queryBatchSize) round-trips rather than O(N) — important on remote
+// backends (see GH#3414).
 func GetDependencyRecordsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (map[string][]*types.Dependency, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string][]*types.Dependency), nil
 	}
 
+	wispIDs, permIDs, err := PartitionWispIDsInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	result := make(map[string][]*types.Dependency)
-
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
+	if len(wispIDs) > 0 {
+		if err := getDependencyRecordsIntoFromTable(ctx, tx, "wisp_dependencies", wispIDs, result); err != nil {
+			return nil, err
 		}
 	}
-
-	for _, pair := range []struct {
-		table string
-		ids   []string
-	}{
-		{"wisp_dependencies", wispIDs},
-		{"dependencies", permIDs},
-	} {
-		if len(pair.ids) == 0 {
-			continue
-		}
-		for start := 0; start < len(pair.ids); start += queryBatchSize {
-			end := start + queryBatchSize
-			if end > len(pair.ids) {
-				end = len(pair.ids)
-			}
-			batch := pair.ids[start:end]
-			placeholders := make([]string, len(batch))
-			args := make([]any, len(batch))
-			for i, id := range batch {
-				placeholders[i] = "?"
-				args[i] = id
-			}
-			//nolint:gosec // G201: pair.table is hardcoded
-			rows, err := tx.QueryContext(ctx, fmt.Sprintf(
-				`SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id
-				 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id`,
-				pair.table, strings.Join(placeholders, ",")), args...)
-			if err != nil {
-				return nil, fmt.Errorf("get dependency records from %s: %w", pair.table, err)
-			}
-			for rows.Next() {
-				dep, scanErr := scanDependencyRow(rows)
-				if scanErr != nil {
-					_ = rows.Close()
-					return nil, fmt.Errorf("get dependency records: scan: %w", scanErr)
-				}
-				result[dep.IssueID] = append(result[dep.IssueID], dep)
-			}
-			_ = rows.Close()
-			if err := rows.Err(); err != nil {
-				return nil, fmt.Errorf("get dependency records: rows: %w", err)
-			}
+	if len(permIDs) > 0 {
+		if err := getDependencyRecordsIntoFromTable(ctx, tx, "dependencies", permIDs, result); err != nil {
+			return nil, err
 		}
 	}
-
 	return result, nil
+}
+
+// GetDependencyRecordsForIssuesFromTableInTx is a fast-path variant used by
+// callers that already know every ID belongs to a single dep table (e.g.
+// searchTableInTx). Skips the wisp-partition round-trip.
+func GetDependencyRecordsForIssuesFromTableInTx(ctx context.Context, tx *sql.Tx, depTable string, issueIDs []string) (map[string][]*types.Dependency, error) {
+	if len(issueIDs) == 0 {
+		return make(map[string][]*types.Dependency), nil
+	}
+	result := make(map[string][]*types.Dependency)
+	if err := getDependencyRecordsIntoFromTable(ctx, tx, depTable, issueIDs, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+//nolint:gosec // G201: depTable is "dependencies" or "wisp_dependencies" (hardcoded by callers).
+func getDependencyRecordsIntoFromTable(ctx context.Context, tx *sql.Tx, depTable string, ids []string, result map[string][]*types.Dependency) error {
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+			`SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id
+			 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id`,
+			depTable, strings.Join(placeholders, ",")), args...)
+		if err != nil {
+			return fmt.Errorf("get dependency records from %s: %w", depTable, err)
+		}
+		for rows.Next() {
+			dep, scanErr := scanDependencyRow(rows)
+			if scanErr != nil {
+				_ = rows.Close()
+				return fmt.Errorf("get dependency records: scan: %w", scanErr)
+			}
+			result[dep.IssueID] = append(result[dep.IssueID], dep)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("get dependency records: rows: %w", err)
+		}
+	}
+	return nil
 }
 
 // GetDependencyCountsInTx returns dependency counts for multiple issues within a transaction.
@@ -203,14 +216,12 @@ func GetBlockingInfoForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []st
 		return
 	}
 
-	// Partition into wisp and perm IDs for routing.
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	// Partition into wisp and perm IDs for routing. Use the batched
+	// partitioner so we don't take a round-trip per ID on remote backends
+	// (GH#3414).
+	wispIDs, permIDs, partErr := PartitionWispIDsInTx(ctx, tx, issueIDs)
+	if partErr != nil {
+		return nil, nil, nil, partErr
 	}
 
 	// Process wisp IDs against wisp_dependencies.

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -41,14 +41,23 @@ func GetLabelsInTx(ctx context.Context, tx *sql.Tx, table, issueID string) ([]st
 // table, so the number of round-trips is O(1 + N/queryBatchSize) rather than
 // O(N). This matters on remote backends (Dolt) where per-ID round-trips would
 // otherwise blow past the context deadline — see GH#3414.
-func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (map[string][]string, error) {
+//
+// Callers hydrating multiple batches inside one tx may pass a precomputed
+// active-wisp set scoped to issueIDs to avoid rebuilding it.
+func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string, wispSetOpt ...map[string]struct{}) (map[string][]string, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string][]string), nil
 	}
 
-	wispIDs, permIDs, err := PartitionWispIDsInTx(ctx, tx, issueIDs)
-	if err != nil {
-		return nil, err
+	var wispIDs, permIDs []string
+	if len(wispSetOpt) > 0 && wispSetOpt[0] != nil {
+		wispIDs, permIDs = partitionByWispSet(issueIDs, wispSetOpt[0])
+	} else {
+		var err error
+		wispIDs, permIDs, err = PartitionWispIDsInTx(ctx, tx, issueIDs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	result := make(map[string][]string)

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -37,75 +37,87 @@ func GetLabelsInTx(ctx context.Context, tx *sql.Tx, table, issueID string) ([]st
 
 // GetLabelsForIssuesInTx fetches labels for multiple issues in a single transaction.
 // Routes each ID to labels or wisp_labels based on wisp status.
-// Uses batched IN clauses (queryBatchSize) to avoid query-planner spikes.
-//
-// wispSet is an optional pre-built set of active wisp IDs scoped to
-// cover issueIDs (see WispIDSetInTx). Pass nil to have the helper build
-// a scoped set internally; callers hydrating multiple batches inside
-// one tx can build the set once over the union of their IDs and
-// reuse it across calls.
-func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string, wispSet map[string]struct{}) (map[string][]string, error) {
+// Uses a single batched wisp-partition query plus batched IN clauses per label
+// table, so the number of round-trips is O(1 + N/queryBatchSize) rather than
+// O(N). This matters on remote backends (Dolt) where per-ID round-trips would
+// otherwise blow past the context deadline — see GH#3414.
+func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (map[string][]string, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string][]string), nil
 	}
 
-	if wispSet == nil {
-		var err error
-		wispSet, err = WispIDSetInTx(ctx, tx, issueIDs)
-		if err != nil {
-			return nil, fmt.Errorf("get labels for issues: build wisp set: %w", err)
-		}
+	wispIDs, permIDs, err := PartitionWispIDsInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	result := make(map[string][]string)
-
-	wispIDs, permIDs := partitionByWispSet(issueIDs, wispSet)
-
-	for _, pair := range []struct {
-		table string
-		ids   []string
-	}{
-		{"wisp_labels", wispIDs},
-		{"labels", permIDs},
-	} {
-		if len(pair.ids) == 0 {
-			continue
-		}
-		for start := 0; start < len(pair.ids); start += queryBatchSize {
-			end := start + queryBatchSize
-			if end > len(pair.ids) {
-				end = len(pair.ids)
-			}
-			batch := pair.ids[start:end]
-			placeholders := make([]string, len(batch))
-			args := make([]any, len(batch))
-			for i, id := range batch {
-				placeholders[i] = "?"
-				args[i] = id
-			}
-			//nolint:gosec // G201: pair.table is hardcoded
-			rows, err := tx.QueryContext(ctx, fmt.Sprintf(
-				`SELECT issue_id, label FROM %s WHERE issue_id IN (%s) ORDER BY issue_id, label`,
-				pair.table, strings.Join(placeholders, ",")), args...)
-			if err != nil {
-				return nil, fmt.Errorf("get labels for issues from %s: %w", pair.table, err)
-			}
-			for rows.Next() {
-				var issueID, label string
-				if err := rows.Scan(&issueID, &label); err != nil {
-					_ = rows.Close()
-					return nil, fmt.Errorf("get labels for issues: scan: %w", err)
-				}
-				result[issueID] = append(result[issueID], label)
-			}
-			_ = rows.Close()
-			if err := rows.Err(); err != nil {
-				return nil, fmt.Errorf("get labels for issues: rows: %w", err)
-			}
+	if len(wispIDs) > 0 {
+		if err := getLabelsIntoFromTable(ctx, tx, "wisp_labels", wispIDs, result); err != nil {
+			return nil, err
 		}
 	}
-
+	if len(permIDs) > 0 {
+		if err := getLabelsIntoFromTable(ctx, tx, "labels", permIDs, result); err != nil {
+			return nil, err
+		}
+	}
 	return result, nil
+}
+
+// GetLabelsForIssuesFromTableInTx is a fast path for callers that already know
+// which label table applies to every ID in the batch (e.g. searchTableInTx,
+// which queries either the issues or wisps table exclusively). It skips the
+// wisp-partition round-trip entirely. labelTable must be "labels" or
+// "wisp_labels"; callers route via FilterTables.
+func GetLabelsForIssuesFromTableInTx(ctx context.Context, tx *sql.Tx, labelTable string, issueIDs []string) (map[string][]string, error) {
+	if len(issueIDs) == 0 {
+		return make(map[string][]string), nil
+	}
+	result := make(map[string][]string)
+	if err := getLabelsIntoFromTable(ctx, tx, labelTable, issueIDs, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// getLabelsIntoFromTable executes the batched SELECT for a single label table
+// and accumulates results into the provided map.
+//
+//nolint:gosec // G201: labelTable is "labels" or "wisp_labels" (hardcoded by callers).
+func getLabelsIntoFromTable(ctx context.Context, tx *sql.Tx, labelTable string, ids []string, result map[string][]string) error {
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+			`SELECT issue_id, label FROM %s WHERE issue_id IN (%s) ORDER BY issue_id, label`,
+			labelTable, strings.Join(placeholders, ",")), args...)
+		if err != nil {
+			return fmt.Errorf("get labels for issues from %s: %w", labelTable, err)
+		}
+		for rows.Next() {
+			var issueID, label string
+			if err := rows.Scan(&issueID, &label); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("get labels for issues: scan: %w", err)
+			}
+			result[issueID] = append(result[issueID], label)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("get labels for issues: rows: %w", err)
+		}
+	}
+	return nil
 }
 
 // AddLabelInTx adds a label to an issue and records an event within an existing

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -100,7 +100,11 @@ func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 		for i, issue := range issues {
 			ids[i] = issue.ID
 		}
-		labelMap, labelErr := GetLabelsForIssuesInTx(ctx, tx, ids, nil)
+		// Fast path: searchTableInTx queries exclusively either the issues
+		// or wisps table, so every ID in `ids` belongs to tables.Labels.
+		// Skip the per-batch wisp-partition round-trip that the generic
+		// GetLabelsForIssuesInTx performs (GH#3414).
+		labelMap, labelErr := GetLabelsForIssuesFromTableInTx(ctx, tx, tables.Labels, ids)
 		if labelErr != nil {
 			return nil, fmt.Errorf("search %s: hydrate labels: %w", tables.Main, labelErr)
 		}
@@ -112,7 +116,7 @@ func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 
 		// Optionally hydrate dependencies in bulk (same batched pattern as labels).
 		if filter.IncludeDependencies {
-			depMap, depErr := GetDependencyRecordsForIssuesInTx(ctx, tx, ids)
+			depMap, depErr := GetDependencyRecordsForIssuesFromTableInTx(ctx, tx, tables.Dependencies, ids)
 			if depErr != nil {
 				return nil, fmt.Errorf("search %s: hydrate dependencies: %w", tables.Main, depErr)
 			}

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -84,6 +84,66 @@ func partitionByWispSet(ids []string, wispSet map[string]struct{}) (wispIDs, per
 	return wispIDs, permIDs
 }
 
+// PartitionWispIDsInTx partitions a set of IDs into wisp vs non-wisp buckets
+// using a single batched `SELECT id FROM wisps WHERE id IN (...)` query per
+// queryBatchSize chunk, rather than one round-trip per ID. This is critical
+// for remote backends (Dolt) where per-ID round-trips multiply WAN latency
+// and can push bulk hydration past the context deadline (see GH#3414).
+// IDs not present in the wisps table are treated as permanent issue IDs.
+// Returned slices preserve the input ordering within each bucket.
+func PartitionWispIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) (wispIDs, permIDs []string, err error) {
+	if len(ids) == 0 {
+		return nil, nil, nil
+	}
+
+	wispSet := make(map[string]struct{}, len(ids))
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		//nolint:gosec // G201: only ? placeholders in the IN clause.
+		rows, qErr := tx.QueryContext(ctx,
+			fmt.Sprintf("SELECT id FROM wisps WHERE id IN (%s)", strings.Join(placeholders, ",")),
+			args...)
+		if qErr != nil {
+			// Wisps table may not exist yet on older schemas — treat as "no wisps".
+			if isTableNotExistError(qErr) {
+				return nil, append([]string(nil), ids...), nil
+			}
+			return nil, nil, fmt.Errorf("partition wisp ids: %w", qErr)
+		}
+		for rows.Next() {
+			var id string
+			if scanErr := rows.Scan(&id); scanErr != nil {
+				_ = rows.Close()
+				return nil, nil, fmt.Errorf("partition wisp ids: scan: %w", scanErr)
+			}
+			wispSet[id] = struct{}{}
+		}
+		_ = rows.Close()
+		if rowsErr := rows.Err(); rowsErr != nil {
+			return nil, nil, fmt.Errorf("partition wisp ids: rows: %w", rowsErr)
+		}
+	}
+
+	for _, id := range ids {
+		if _, ok := wispSet[id]; ok {
+			wispIDs = append(wispIDs, id)
+		} else {
+			permIDs = append(permIDs, id)
+		}
+	}
+	return wispIDs, permIDs, nil
+}
+
 // WispTableRouting returns the appropriate issue, label, event, and dependency
 // table names based on whether the ID is an active wisp. Call IsActiveWispInTx
 // first to determine isWisp.


### PR DESCRIPTION
## Summary

Rebased split of #3417 — addresses @maphew's review by removing the unrelated ADO WIQL date fix (already merged in #3345). This PR contains only the wisp-partition performance fix for GH#3414.

Resolves merge conflicts with upstream's `WispIDSetInTx`/`partitionByWispSet` additions by keeping both the upstream helpers (still used by `dependencies.go`) and adding the new `PartitionWispIDsInTx` function with `isTableNotExistError` fallback for pre-migration databases.

## What changed vs #3417

- Removed the ADO WIQL date fix (already merged as #3345)
- Resolved merge conflicts with upstream's wisp routing evolution
- Updated `GetLabelsForIssuesInTx` callers to match the new signature (no `wispSet` param)

## Original fix (unchanged)

1. **`PartitionWispIDsInTx`** — one batched `SELECT id FROM wisps WHERE id IN (...)` per `queryBatchSize` chunk. Reduces partitioning cost from **O(N)** to **O(1 + N/200)** round-trips.
2. Rewrote five bulk fetchers to use it.
3. Added **fast-path helpers** for callers that already know every ID belongs to a single table.

## Tests

All existing + new tests pass (`go build ./...`, `go test -short ./internal/storage/issueops/...`).

Supersedes #3417.
Fixes #3414

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->