### PR TITLE
fix(release): harden shipped release formula adoption

### DIFF
--- a/.beads/formulas/beads-release.formula.toml
+++ b/.beads/formulas/beads-release.formula.toml
@@ -8,7 +8,7 @@
 #   1. Prep & Push: preflight -> push-tag (polecat work)
 #   2. Gate: await-ci (async wait for release.yml)
 #   3. Verify: verify-github, verify-npm, verify-pypi (parallel)
-#   4. Install: local-install -> release-complete (fan-in)
+#   4. Install: local-install -> cleanup-stale-dolt-orphans -> release-complete
 
 formula = "beads-release"
 description = """
@@ -30,7 +30,7 @@ Phase 2 (Parallel Verification):
 
 Phase 3 (Installation):
   7. Local installation update
-  8. Daemon restart
+  8. Stale Dolt orphan cleanup
 
 ## Usage
 
@@ -48,6 +48,7 @@ until release.yml finishes. A new polecat (or the same one) resumes for Phases 2
 """
 type = "workflow"
 phase = "vapor"  # Ensures this runs as a wisp - bd pour will warn, gt sling --formula creates wisp
+pour = true      # Materialize release steps for checkpoint/resume visibility
 version = 1
 
 [vars.version]
@@ -760,21 +761,49 @@ All should show {{version}}.
 """
 
 [[steps]]
-id = "restart-daemons"
-title = "Restart daemons"
+id = "cleanup-stale-dolt-orphans"
+title = "Clean up stale Dolt orphans"
 needs = ["local-install"]
 description = """
-Restart bd daemons to pick up new version.
+Clean up orphaned local Dolt server processes left behind by older bd runs.
+The active canonical server, embedded mode, and external Dolt hosts are left alone.
 
 ```bash
-bd daemons killall
+STATUS_JSON=$(bd dolt status --json 2>/dev/null) || {
+  echo "Could not query Dolt status."
+  bd dolt status
+  exit 1
+}
+MODE=$(printf "%s\n" "$STATUS_JSON" | sed -n 's/.*"mode"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -1)
+case "$MODE" in
+  embedded)
+    echo "Embedded Dolt mode; no server restart needed."
+    ;;
+  external)
+    echo "External Dolt mode; no local orphan cleanup needed."
+    ;;
+  "")
+    if ! printf "%s\n" "$STATUS_JSON" | grep -Eq '"(running|data_dir)"[[:space:]]*:'; then
+      echo "Dolt status JSON did not identify a mode or local server state."
+      bd dolt status
+      exit 1
+    fi
+    bd dolt killall
+    ;;
+  *)
+    echo "Unrecognized Dolt mode: $MODE"
+    bd dolt status
+    exit 1
+    ;;
+esac
 ```
 
-Daemons will auto-restart with new version on next bd command.
+This step only reaps orphaned local Dolt processes. It does not stop the
+canonical active server.
 
 Verify:
 ```bash
-bd daemons list
+bd dolt status
 ```
 """
 
@@ -806,7 +835,7 @@ needs the tag to exist, not the CI artifacts.
 [[steps]]
 id = "release-complete"
 title = "Release complete"
-needs = ["restart-daemons", "generate-newsletter"]
+needs = ["cleanup-stale-dolt-orphans", "generate-newsletter"]
 description = """
 Release v{{version}} is complete!
 
@@ -816,7 +845,7 @@ Summary:
 - CI artifacts built (via gate)
 - npm and PyPI packages verified
 - Local installation updated
-- Daemons restarted
+- Dolt servers refreshed if applicable
 - Newsletter generated
 
 Optional next steps:

--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,9 @@ bd_test
 
 # Orchestrator (added by gt)
 .logs/
-.beads/
+.beads/*
+!.beads/formulas/
+!.beads/formulas/**
 .opencode/
 
 # Beads / Dolt files (added by bd init)

--- a/cmd/bd/formula.go
+++ b/cmd/bd/formula.go
@@ -31,8 +31,9 @@ The Rig → Cook → Run lifecycle:
 
 Search paths (in order):
   1. <resolved-beads-dir>/formulas/ (active project)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. <checkout-root>/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -47,8 +48,9 @@ var formulaListCmd = &cobra.Command{
 
 Search paths (in order of priority):
   1. <resolved-beads-dir>/formulas/ (active project - highest priority)
-  2. ~/.beads/formulas/ (user)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  2. <checkout-root>/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -714,6 +714,7 @@ var rootCmd = &cobra.Command{
 			"doctor",
 			"dolt", // bare "bd dolt" shows help only; subcommands handled below
 			"fish",
+			"formula", // parser-only subcommands; add a store-needed guard before adding DB-backed formula subcommands
 			"help",
 			"hook", // manages its own store lifecycle (#1719)
 			"hooks",

--- a/cmd/bd/mol_distill.go
+++ b/cmd/bd/mol_distill.go
@@ -37,7 +37,8 @@ Variable syntax (both work - we detect which side is the concrete value):
 
 Output locations (first writable wins):
   1. <resolved-beads-dir>/formulas/ (project-level, default)
-  2. ~/.beads/formulas/     (user-level, if project not writable)
+  2. <checkout-root>/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/     (user-level, if project not writable)
 
 Examples:
   bd mol distill bd-o5xe my-workflow

--- a/cmd/bd/mol_seed.go
+++ b/cmd/bd/mol_seed.go
@@ -18,8 +18,9 @@ attempting to spawn work from a formula.
 
 Formula search paths (checked in order):
   1. <resolved-beads-dir>/formulas/ (active project)
-  2. ~/.beads/formulas/ (user level)
-  3. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  2. <checkout-root>/.beads/formulas/ (repo-local formulas)
+  3. ~/.beads/formulas/ (user level)
+  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 #   Phase 1: Preflight → version bumps → git push (agent work)
 #   Gate:    Await CI completion (async, no polling)
 #   Phase 2: Verify GitHub/npm/PyPI releases (parallel)
-#   Phase 3: Local install → daemon restart
+#   Phase 3: Local install → stale Dolt orphan cleanup
 #
 # View the full formula:
 #   bd formula show beads-release
@@ -116,20 +116,68 @@ fi
 # Strip 'v' prefix if present
 VERSION="${VERSION#v}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+FORMULA_PATH="$REPO_ROOT/.beads/formulas/beads-release.formula.toml"
+
+bd_resolves_repo_formula() {
+    local -a candidate=("$@")
+    local formula_json
+    local formula_source
+
+    if ! formula_json=$("${candidate[@]}" formula show beads-release --json 2>/dev/null); then
+        return 1
+    fi
+    formula_source=$(printf "%s\n" "$formula_json" | sed -n 's/.*"source"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+    [ "$formula_source" = "$FORMULA_PATH" ]
+}
+
+BD_FALLBACK_HINT=""
+if [ -n "${BD:-}" ]; then
+    if ! bd_resolves_repo_formula "$BD"; then
+        echo -e "${RED}BD is set but does not resolve the checked-in beads-release formula:${NC}"
+        echo "  BD=$BD"
+        echo "  Expected formula source: $FORMULA_PATH"
+        exit 1
+    fi
+    BD_CMD=("$BD")
+elif command -v bd >/dev/null 2>&1 && bd_resolves_repo_formula bd; then
+    BD_CMD=(bd)
+elif [ -x "$REPO_ROOT/bd" ] && bd_resolves_repo_formula "$REPO_ROOT/bd"; then
+    BD_CMD=("$REPO_ROOT/bd")
+else
+    BD_CMD=(go run -tags gms_pure_go ./cmd/bd)
+    BD_FALLBACK_HINT=" (falling back to go run; run make install for faster releases)"
+fi
+
 echo -e "${BLUE}╔═══════════════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║${NC}   ${GREEN}Beads Release v${VERSION}${NC}                                       ${BLUE}║${NC}"
 echo -e "${BLUE}║${NC}   Creating release molecule (not running a batch script)      ${BLUE}║${NC}"
 echo -e "${BLUE}╚═══════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo "Using bd: ${BD_CMD[*]}${BD_FALLBACK_HINT}"
 echo ""
 
 if [ "$DRY_RUN" = true ]; then
     echo -e "${YELLOW}DRY RUN - showing what would happen${NC}"
     echo ""
     echo "Would create release molecule with:"
-    echo "  bd mol wisp beads-release --var version=${VERSION}"
+    echo "  ${BD_CMD[*]} mol wisp beads-release --var version=${VERSION}"
     echo ""
-    FORMULA_STEPS=$(bd formula show beads-release 2>/dev/null | grep -E "^   [├└]" || true)
+    if ! FORMULA_OUTPUT=$("${BD_CMD[@]}" formula show beads-release 2>&1); then
+        echo -e "${RED}Could not load beads-release formula:${NC}"
+        echo "$FORMULA_OUTPUT"
+        exit 1
+    fi
+    FORMULA_STEPS=$(printf "%s\n" "$FORMULA_OUTPUT" | grep -E "[├└]──" || true)
     STEP_COUNT=$(printf "%s\n" "$FORMULA_STEPS" | sed '/^$/d' | wc -l | tr -d ' ')
+    if [ "$STEP_COUNT" -eq 0 ]; then
+        echo -e "${RED}Could not enumerate beads-release formula steps.${NC}"
+        echo "Run: ${BD_CMD[*]} formula show beads-release"
+        exit 1
+    fi
     echo "The molecule has ${STEP_COUNT} steps:"
     printf "%s\n" "$FORMULA_STEPS" | head -15
     if [ "$STEP_COUNT" -gt 15 ]; then
@@ -151,7 +199,7 @@ echo -e "${YELLOW}Creating release molecule...${NC}"
 echo ""
 
 # Create the wisp and capture the output
-OUTPUT=$(bd mol wisp beads-release --var version="${VERSION}" 2>&1)
+OUTPUT=$("${BD_CMD[@]}" mol wisp beads-release --var version="${VERSION}" 2>&1)
 MOL_ID=$(echo "$OUTPUT" | grep -oE 'bd-wisp-[a-z0-9]+' | head -1)
 
 if [ -z "$MOL_ID" ]; then
@@ -164,7 +212,7 @@ echo -e "${GREEN}✓ Created release molecule: ${MOL_ID}${NC}"
 echo ""
 
 # Show the molecule
-bd show "$MOL_ID" 2>/dev/null | head -20
+"${BD_CMD[@]}" show "$MOL_ID" 2>/dev/null | head -20
 echo ""
 
 echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"
@@ -173,16 +221,16 @@ echo ""
 echo "Next steps:"
 echo ""
 echo "  ${YELLOW}Option 1: Work on it yourself${NC}"
-echo "    bd hook ${MOL_ID}"
-echo "    # Then follow the steps in bd show ${MOL_ID}"
+echo "    ${BD_CMD[*]} hook ${MOL_ID}"
+echo "    # Then follow the steps in ${BD_CMD[*]} show ${MOL_ID}"
 echo ""
 echo "  ${YELLOW}Option 2: Assign to an agent${NC}"
-echo "    bd sling beads/agents/p1 --mol ${MOL_ID}"
+echo "    ${BD_CMD[*]} sling beads/agents/p1 --mol ${MOL_ID}"
 echo ""
 echo "  ${YELLOW}Watch progress:${NC}"
-echo "    bd activity --follow"
+echo "    ${BD_CMD[*]} activity --follow"
 echo ""
 echo "  ${YELLOW}See all steps:${NC}"
-echo "    bd mol steps ${MOL_ID}"
+echo "    ${BD_CMD[*]} mol steps ${MOL_ID}"
 echo ""
 echo -e "${BLUE}═══════════════════════════════════════════════════════════════${NC}"

--- a/scripts/release_script_test.go
+++ b/scripts/release_script_test.go
@@ -1,0 +1,193 @@
+package scripts_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/formula"
+)
+
+func TestReleaseScriptUsesVerifiedInstalledBDBeforeStaleRepoBD(t *testing.T) {
+	repo := copyReleaseScriptFixture(t)
+	writeExecutable(t, filepath.Join(repo, "bd"), `#!/bin/sh
+echo "stale repo bd should not run" >&2
+exit 42
+`)
+
+	bin := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeBD(t, bin, repo)
+	writeExecutable(t, filepath.Join(bin, "jq"), `#!/bin/sh
+echo "jq should not be called" >&2
+exit 99
+`)
+
+	output, err := runReleaseDryRun(t, repo, bin)
+	if err != nil {
+		t.Fatalf("release.sh failed: %v\n%s", err, output)
+	}
+	if strings.Contains(output, "stale repo bd should not run") {
+		t.Fatalf("release.sh used stale repo-root bd:\n%s", output)
+	}
+	if !strings.Contains(output, "bd mol wisp beads-release --var version=1.2.3") {
+		t.Fatalf("release.sh did not use installed bd command:\n%s", output)
+	}
+}
+
+func TestReleaseScriptInstalledBDSelectionDoesNotRequireJQ(t *testing.T) {
+	repo := copyReleaseScriptFixture(t)
+
+	bin := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeBD(t, bin, repo)
+	writeExecutable(t, filepath.Join(bin, "jq"), `#!/bin/sh
+echo "jq should not be called" >&2
+exit 99
+`)
+
+	output, err := runReleaseDryRun(t, repo, bin)
+	if err != nil {
+		t.Fatalf("release.sh failed without jq: %v\n%s", err, output)
+	}
+	if strings.Contains(output, "jq should not be called") {
+		t.Fatalf("release.sh invoked jq during bd selection:\n%s", output)
+	}
+}
+
+func TestReleaseScriptRejectsExplicitBDThatDoesNotResolveRepoFormula(t *testing.T) {
+	repo := copyReleaseScriptFixture(t)
+	bin := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	staleBD := filepath.Join(bin, "bd-stale")
+	writeExecutable(t, staleBD, `#!/bin/sh
+echo '{"source":"/tmp/stale.formula.toml"}'
+`)
+
+	output, err := runReleaseDryRunWithEnv(t, repo, bin, "BD="+staleBD)
+	if err == nil {
+		t.Fatalf("release.sh succeeded with stale explicit BD:\n%s", output)
+	}
+	if !strings.Contains(output, "BD is set but does not resolve the checked-in beads-release formula") {
+		t.Fatalf("release.sh did not explain stale explicit BD:\n%s", output)
+	}
+}
+
+func TestReleaseFormulaCleanupStaleDoltOrphansHandlesLocalModeWithoutJQ(t *testing.T) {
+	repoRoot := sourceRepoRoot(t)
+	formulaPath := filepath.Join(repoRoot, ".beads", "formulas", "beads-release.formula.toml")
+	if _, err := formula.NewParser().ParseFile(formulaPath); err != nil {
+		t.Fatalf("beads-release formula does not parse: %v", err)
+	}
+
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	start := strings.Index(text, `id = "cleanup-stale-dolt-orphans"`)
+	if start < 0 {
+		t.Fatal("cleanup-stale-dolt-orphans step not found")
+	}
+	step := text[start:]
+	if next := strings.Index(step[len(`id = "cleanup-stale-dolt-orphans"`):], "\n[[steps]]"); next >= 0 {
+		step = step[:len(`id = "cleanup-stale-dolt-orphans"`)+next]
+	}
+
+	for _, unwanted := range []string{"jq", "Could not determine Dolt mode"} {
+		if strings.Contains(step, unwanted) {
+			t.Fatalf("cleanup-stale-dolt-orphans still contains %q:\n%s", unwanted, step)
+		}
+	}
+	for _, want := range []string{`case "$MODE" in`, "embedded)", "external)", "running|data_dir", `bd dolt killall`} {
+		if !strings.Contains(step, want) {
+			t.Fatalf("cleanup-stale-dolt-orphans missing %q:\n%s", want, step)
+		}
+	}
+}
+
+func copyReleaseScriptFixture(t *testing.T) string {
+	t.Helper()
+
+	src := filepath.Join(sourceRepoRoot(t), "scripts", "release.sh")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, ".beads", "formulas"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "scripts", "release.sh"), data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".beads", "formulas", "beads-release.formula.toml"), []byte("formula = \"beads-release\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func sourceRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(filepath.Dir(file))
+}
+
+func runReleaseDryRun(t *testing.T, repo, bin string) (string, error) {
+	t.Helper()
+	return runReleaseDryRunWithEnv(t, repo, bin, "BD=")
+}
+
+func runReleaseDryRunWithEnv(t *testing.T, repo, bin string, extraEnv ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("bash", filepath.Join(repo, "scripts", "release.sh"), "1.2.3", "--dry-run")
+	cmd.Dir = repo
+	cmd.Env = append(os.Environ(), "PATH="+bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	cmd.Env = append(cmd.Env, extraEnv...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func writeFakeBD(t *testing.T, bin, repo string) {
+	t.Helper()
+	source := filepath.Join(repo, ".beads", "formulas", "beads-release.formula.toml")
+	body := fmt.Sprintf(`#!/bin/sh
+SOURCE=%q
+if [ "$1 $2 $3 $4" = "formula show beads-release --json" ]; then
+  printf '%%s\n' "{\"source\":\"$SOURCE\"}"
+  exit 0
+fi
+if [ "$1 $2 $3" = "formula show beads-release" ]; then
+  printf '   ├── preflight\n'
+  printf '   └── release-complete\n'
+  exit 0
+fi
+echo "unexpected fake bd invocation: $*" >&2
+exit 64
+`, source)
+	writeExecutable(t, filepath.Join(bin, "bd"), body)
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Follow-up to #3631 after maintainer adoption review. PR #3631 was merged before the adoption fixups could be pushed back to the contributor branch, so this carries the review fixups as a separate maintainer PR.

Summary:
- Keep shipped formulas trackable under .beads/formulas and keep formula CLI/search-path docs aligned.
- Let bd formula run without store initialization so release scripts can probe shipped formulas before a local DB is available.
- Harden scripts/release.sh so it uses a bd binary only when it resolves the checked-in beads-release formula, rejects stale explicit BD= overrides, and falls back to go run with a visible diagnostic.
- Replace the obsolete daemon restart step with accurate stale Dolt orphan cleanup and keep release steps materialized with pour=true.
- Add release gateway regression tests for stale local bd, jq-free installed bd probing, stale explicit BD=, and formula parsing/cleanup-step shape.

Validation:
- GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 make test
- go test -tags gms_pure_go ./cmd/bd ./internal/formula ./scripts
- ./scripts/release.sh 1.0.4 --dry-run
- no-local-bd fallback dry-run using go run
- ./bd formula show beads-release --json
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->