### PR TITLE
fix(graph): emit [] not null for empty links in HTML output (GH#3592)

### DIFF
--- a/cmd/bd/graph_export.go
+++ b/cmd/bd/graph_export.go
@@ -171,7 +171,7 @@ type HTMLEdge struct {
 }
 
 func buildHTMLGraphData(layout *GraphLayout, _ *TemplateSubgraph) []HTMLNode {
-	var nodes []HTMLNode
+	nodes := make([]HTMLNode, 0, len(layout.Nodes))
 	for _, node := range layout.Nodes {
 		nodes = append(nodes, HTMLNode{
 			ID:       node.Issue.ID,
@@ -187,7 +187,7 @@ func buildHTMLGraphData(layout *GraphLayout, _ *TemplateSubgraph) []HTMLNode {
 }
 
 func buildHTMLEdgeData(layout *GraphLayout, subgraph *TemplateSubgraph) []HTMLEdge {
-	var edges []HTMLEdge
+	edges := make([]HTMLEdge, 0, len(subgraph.Dependencies))
 	for _, dep := range subgraph.Dependencies {
 		if dep.Type != types.DepBlocks && dep.Type != types.DepParentChild {
 			continue

--- a/cmd/bd/graph_export_test.go
+++ b/cmd/bd/graph_export_test.go
@@ -329,4 +329,41 @@ func TestMergeSubgraphsForHTML_SingleDOCTYPE(t *testing.T) {
 	if !strings.Contains(output, "comp-b") {
 		t.Error("merged HTML should contain comp-b")
 	}
+
+	// links must be [] not null — null breaks d3.forceLink (GH#3592)
+	if strings.Contains(output, "const links = null") {
+		t.Error("links must be [] not null for d3 compatibility")
+	}
+	if !strings.Contains(output, "const links = []") {
+		t.Error("empty links should serialize as [] not null")
+	}
+}
+
+func TestRenderGraphHTML_EmptyEdgesNotNull(t *testing.T) {
+	// Verify that a single-node graph emits [] not null for links (GH#3592)
+	issue := &types.Issue{
+		ID: "solo-1", Title: "Solo node", Status: types.StatusOpen,
+		Priority: 2, IssueType: types.TypeTask,
+	}
+
+	subgraph := &TemplateSubgraph{
+		Root:     issue,
+		Issues:   []*types.Issue{issue},
+		IssueMap: map[string]*types.Issue{"solo-1": issue},
+	}
+	layout := computeLayout(subgraph)
+
+	output := captureGraphOutput(func() {
+		renderGraphHTML(layout, subgraph)
+	})
+
+	if strings.Contains(output, "const links = null") {
+		t.Error("single-node graph must emit const links = [] not null")
+	}
+	if !strings.Contains(output, "const links = []") {
+		t.Error("single-node graph should have const links = []")
+	}
+	if strings.Contains(output, "const nodes = null") {
+		t.Error("nodes must never be null")
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes `const links = null` in `bd graph --html` output for single-node components (and any graph with no qualifying edges)
- Go nil slices marshal to JSON `null`, which breaks `d3.forceLink(links)` — changed `buildHTMLGraphData` and `buildHTMLEdgeData` to use `make()` so empty collections serialize as `[]`
- Adds test `TestRenderGraphHTML_EmptyEdgesNotNull` and extends `TestMergeSubgraphsForHTML_SingleDOCTYPE` to assert no `null` links

Closes #3592

## Test plan
- [x] `make build` succeeds
- [x] `go test -tags gms_pure_go ./cmd/bd/... -run 'Graph|HTML'` — all pass
- [x] New test verifies single-node graph emits `const links = []` not `null`
- [x] Existing merge test extended to verify `[]` links after component merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->