### PR TITLE
fix(cli): swap CommandStyle colors for correct light/dark contrast (GH#3611)

### DIFF
--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -170,8 +170,9 @@ func initColors(isDark bool) {
 	ColorID = lipgloss.NoColor{} // standard text
 
 	// Command style - uses adaptive color for subtle contrast
+	// Light bg gets dark gray text; dark bg gets light gray text (Ayu theme)
 	CommandStyle = lipgloss.NewStyle().Foreground(
-		ld(lipgloss.Color("#bfbdb6"), lipgloss.Color("#5c6166")),
+		ld(lipgloss.Color("#5c6166"), lipgloss.Color("#bfbdb6")),
 	)
 }
 


### PR DESCRIPTION
## Summary
- The `CommandStyle` in `internal/ui/styles.go` had its `LightDark()` color arguments reversed: light gray (`#bfbdb6`) was used on light backgrounds (nearly invisible) and dark gray (`#5c6166`) on dark backgrounds (poor contrast)
- Swaps the two arguments so each variant is legible on its intended background — dark gray text on light terminals, light gray text on dark terminals
- This fixes the unreadable command names in `bd --help` output on light terminals

Closes #3611

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (pre-existing timeout in embedded Dolt tests is unrelated)
- [x] Verified color values: `#5c6166` (dark gray) is correct for light backgrounds, `#bfbdb6` (light gray) for dark backgrounds, matching the Ayu theme palette used throughout the project

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->