### PR TITLE
fix(dolt): suppress DOLT_COMMIT no-op warnings on read-only commands (GH#3529)

### DIFF
--- a/cmd/bd/dolt_autopush_test.go
+++ b/cmd/bd/dolt_autopush_test.go
@@ -98,11 +98,19 @@ func TestMaybeAutoPush_NilStore(t *testing.T) {
 
 func TestAutoPush_SkippedForReadOnlyCommands(t *testing.T) {
 	// Read-only commands should not trigger auto-push (GH#2191).
-	readOnly := []string{"list", "ready", "show", "stats", "blocked", "search", "graph"}
+	// GH#3529: use cmd.Name() values (first word of Use field), not aliases.
+	// "status" is the cmd.Name() for the statusCmd (alias "stats").
+	readOnly := []string{"list", "ready", "show", "status", "blocked", "search", "graph", "memories", "recall"}
 	for _, cmd := range readOnly {
 		if !isReadOnlyCommand(cmd) {
 			t.Errorf("isReadOnlyCommand(%q) = false, want true", cmd)
 		}
+	}
+
+	// Verify aliases are NOT what gets checked (cmd.Name() returns
+	// the Use field name, not the alias).
+	if isReadOnlyCommand("stats") {
+		t.Error("isReadOnlyCommand(\"stats\") = true; map should use \"status\" (cmd.Name()), not the alias")
 	}
 
 	writeCmds := []string{"create", "update", "close", "import"}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -111,7 +111,7 @@ var readOnlyCommands = map[string]bool{
 	"list":       true,
 	"ready":      true,
 	"show":       true,
-	"stats":      true,
+	"status":     true, // GH#3529: was "stats" (alias), but cmd.Name() returns "status"
 	"blocked":    true,
 	"count":      true,
 	"search":     true,
@@ -122,6 +122,8 @@ var readOnlyCommands = map[string]bool{
 	"ping":       true,
 	"backup":     true, // reads from Dolt, writes only to .beads/backup/
 	"export":     true, // reads from Dolt, writes JSONL to file/stdout
+	"memories":   true, // GH#3529: read-only listing of stored memories
+	"recall":     true, // GH#3529: read-only retrieval of a single memory
 }
 
 // isReadOnlyCommand returns true if the command only reads from the database.

--- a/internal/storage/dolt/migrations/runner.go
+++ b/internal/storage/dolt/migrations/runner.go
@@ -49,14 +49,21 @@ func RunCompatMigrations(db *sql.DB) error {
 		}
 	}
 
-	// Only stage and commit when compat migrations actually produced changes.
-	// Previously, DOLT_COMMIT was called unconditionally, causing a
-	// "nothing to commit" WARNING on the server for every bd invocation
-	// (94% of server log lines in one reported case). GH#3366.
+	// Only stage and commit when compat migrations actually produced committable
+	// changes. Exclude dolt-ignored tables (wisps, local_metadata, etc.) that
+	// appear in dolt_status but can never be staged — attempting to commit when
+	// only ignored tables are dirty produces a "nothing to commit" WARNING on
+	// the Dolt server. GH#3366, GH#3529.
 	var dirtyCount int
-	if err := db.QueryRow("SELECT COUNT(*) FROM dolt_status").Scan(&dirtyCount); err != nil {
-		// dolt_status might not be available (e.g. older servers); fall through
-		// to the original behavior as a safe fallback.
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM dolt_status s
+		WHERE NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			AND s.table_name LIKE di.pattern
+		)`).Scan(&dirtyCount); err != nil {
+		// dolt_status/dolt_ignore might not be available (e.g. older servers);
+		// fall through to the original behavior as a safe fallback.
 		dirtyCount = 1
 	}
 	if dirtyCount == 0 {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1656,12 +1656,19 @@ func (s *DoltStore) Commit(ctx context.Context, message string) (retErr error) {
 	}
 	defer conn.Close()
 
-	// GH#2455: Stage all dirty tables EXCEPT config. Query dolt_status for
-	// dirty tables and stage each one individually, skipping config to avoid
-	// sweeping up stale issue_prefix changes from concurrent operations.
-	rows, err := conn.QueryContext(ctx, "SELECT table_name FROM dolt_status")
+	// GH#2455, GH#3529: Stage all dirty tables EXCEPT config and dolt-ignored
+	// tables. Query dolt_status with a dolt_ignore exclusion filter to avoid
+	// staging ignored tables (wisps, local_metadata, etc.) that would cause a
+	// "nothing to commit" warning on the Dolt server.
+	rows, err := conn.QueryContext(ctx, `
+		SELECT table_name FROM dolt_status s
+		WHERE s.table_name != 'config'
+		AND NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			AND s.table_name LIKE di.pattern
+		)`)
 	if err != nil {
-		// If dolt_status fails, fall back to nothing (rare edge case).
 		return fmt.Errorf("failed to query dolt_status: %w", err)
 	}
 	var tables []string
@@ -1671,9 +1678,7 @@ func (s *DoltStore) Commit(ctx context.Context, message string) (retErr error) {
 			_ = rows.Close()
 			return fmt.Errorf("failed to scan dolt_status: %w", err)
 		}
-		if table != "config" {
-			tables = append(tables, table)
-		}
+		tables = append(tables, table)
 	}
 	_ = rows.Close()
 	if err := rows.Err(); err != nil {
@@ -1686,9 +1691,7 @@ func (s *DoltStore) Commit(ctx context.Context, message string) (retErr error) {
 
 	for _, table := range tables {
 		if _, err := conn.ExecContext(ctx, "CALL DOLT_ADD(?)", table); err != nil {
-			// Best effort: some tables may be dolt_ignore'd (e.g., wisps).
-			// DOLT_ADD fails for ignored tables; skip silently.
-			continue
+			return fmt.Errorf("dolt add %s: %w", table, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- **Fixes the `readOnlyCommands` map** so `bd status`/`bd stats` and `bd memories`/`bd recall` open the store read-only and skip `initSchema()` entirely. The map had `"stats"` (the alias) instead of `"status"` (what `cmd.Name()` returns), and was missing `"memories"` and `"recall"`.
- **Guards `RunCompatMigrations` DOLT_COMMIT** with a `dolt_ignore`-filtered `dolt_status` check so dolt-ignored tables (wisps, local_metadata, etc.) don't trigger a no-op commit that floods the server log.
- **Guards `DoltStore.Commit()`** with the same `dolt_ignore`-filtered query, replacing the best-effort `DOLT_ADD` skip that still allowed the `DOLT_COMMIT` call to reach the server and produce the warning.

Extends the guard pattern from PR #3373 (which fixed `bd list`/`bd show`) to the remaining call paths.

Closes #3529

## Test plan
- [x] `make build` succeeds
- [x] `go test -tags gms_pure_go ./internal/storage/dolt/... -count=1 -race` passes
- [x] `TestAutoPush_SkippedForReadOnlyCommands` updated and passes — verifies `"status"`, `"memories"`, `"recall"` are read-only and alias `"stats"` is NOT matched
- [x] Verified guard pattern matches the existing fix from #3373 (dolt_ignore exclusion)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->