### PR TITLE
fix(dep): distinguish blocks vs parent-child in dep tree output (GH#3565)

### DIFF
--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -1120,16 +1120,19 @@ func renderTree(tree []*types.TreeNode, maxDepth int, direction string) {
 		root = tree[0]
 	}
 
-	// Check if root has open children (meaning it's blocked, not ready)
+	// Check if root has open blocking dependencies (GH#3565).
+	// Only genuine blockers (blocks, conditional-blocks, waits-for) count;
+	// parent-child, related, discovered-from, etc. do not block.
 	if root != nil {
-		hasOpenChildren := false
+		hasOpenBlockers := false
 		for _, child := range children[root.ID] {
-			if child.Status == types.StatusOpen || child.Status == types.StatusInProgress {
-				hasOpenChildren = true
+			if (child.Status == types.StatusOpen || child.Status == types.StatusInProgress) &&
+				child.EdgeFromParent.IsBlockingEdge() {
+				hasOpenBlockers = true
 				break
 			}
 		}
-		r.rootBlocked = hasOpenChildren
+		r.rootBlocked = hasOpenBlockers
 	}
 
 	// Render recursively from root

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -839,6 +839,13 @@ func (d DependencyType) AffectsReadyWork() bool {
 	return d == DepBlocks || d == DepParentChild || d == DepConditionalBlocks || d == DepWaitsFor
 }
 
+// IsBlockingEdge returns true if this dependency type represents a hard blocker.
+// Unlike AffectsReadyWork, this excludes parent-child (structural, not blocking).
+// Used by dep tree rendering to decide whether the [BLOCKED] badge applies.
+func (d DependencyType) IsBlockingEdge() bool {
+	return d == DepBlocks || d == DepConditionalBlocks || d == DepWaitsFor
+}
+
 // WaitsForMeta holds metadata for waits-for dependencies (fanout gates).
 // Stored as JSON in the Dependency.Metadata field.
 type WaitsForMeta struct {


### PR DESCRIPTION
## Summary
- The `[BLOCKED]` badge on the root node of `bd dep tree` now only appears when genuine blocking dependencies (`blocks`, `conditional-blocks`, `waits-for`) are open — not for `parent-child`, `related`, `discovered-from`, or other non-blocking types
- Adds `DependencyType.IsBlockingEdge()` method to cleanly distinguish hard blockers from structural/associative dependency types
- Edge type labels (`[blocks]`, `[parent-child]`, etc.) on child nodes were already present; this fix corrects the root badge logic to match

Closes #3565

## Test plan
- [x] `make build` succeeds
- [x] All dep-related tests pass (`FormatTreeNode`, `RenderTreeOutput`, `TreeNodeJSON`, `FormatTreeNodeShowsDependencyType`, `RenderTreeOutputShowsDependencyTypeLabelsInMixedGraph`)
- [x] Types tests pass (`AffectsReadyWork`, etc.)
- [x] Verified `IsBlockingEdge()` returns true only for `blocks`, `conditional-blocks`, `waits-for`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->