### PR TITLE
Add Jira custom field support for push

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -663,7 +663,17 @@ bd config set jira.status_map.closed "Done"
 bd config set jira.type_map.bug "Bug"
 bd config set jira.type_map.feature "Story"
 bd config set jira.type_map.task "Task"
+
+# Set Jira custom fields on pushed issues
+bd config set jira.custom_fields.customfield_10042 '{"value":"AI Platform"}'
+bd config set jira.custom_fields.Story.customfield_10042 '{"value":"AI Platform"}'
 ```
+
+`jira.custom_fields.<field>` applies to every issue pushed to Jira.
+`jira.custom_fields.<JiraType>.<field>` applies only when the mapped Jira issue
+type matches `<JiraType>`; per-type fields override global fields with the same
+field key. Values beginning with `{` or `[` are sent as JSON, which is useful
+for select-like fields. Other values are sent as strings.
 
 ### Example: Linear Integration
 

--- a/internal/jira/fieldmapper.go
+++ b/internal/jira/fieldmapper.go
@@ -10,10 +10,12 @@ import (
 
 // jiraFieldMapper implements tracker.FieldMapper for Jira.
 type jiraFieldMapper struct {
-	apiVersion  string            // "2" or "3" (default: "3")
-	statusMap   map[string]string // beads status → Jira status name (from jira.status_map.* config)
-	typeMap     map[string]string // beads type → Jira type (from jira.type_map.* config)
-	priorityMap map[string]string // beads priority (as string "0"-"4") → Jira priority name (from jira.priority_map.* config)
+	apiVersion       string                            // "2" or "3" (default: "3")
+	statusMap        map[string]string                 // beads status → Jira status name (from jira.status_map.* config)
+	typeMap          map[string]string                 // beads type → Jira type (from jira.type_map.* config)
+	priorityMap      map[string]string                 // beads priority (as string "0"-"4") → Jira priority name (from jira.priority_map.* config)
+	customFields     map[string]interface{}            // Jira field name/id → value (from jira.custom_fields.* config)
+	typeCustomFields map[string]map[string]interface{} // Jira issue type → field name/id → value
 }
 
 func (m *jiraFieldMapper) PriorityToBeads(trackerPriority interface{}) int {
@@ -214,6 +216,21 @@ func (m *jiraFieldMapper) IssueToTracker(issue *types.Issue) map[string]interfac
 	// Set labels
 	if len(issue.Labels) > 0 {
 		fields["labels"] = issue.Labels
+	}
+
+	for fieldName, value := range m.customFields {
+		fields[fieldName] = value
+	}
+
+	if name, ok := typeName.(string); ok {
+		for jiraType, customFields := range m.typeCustomFields {
+			if !strings.EqualFold(jiraType, name) {
+				continue
+			}
+			for fieldName, value := range customFields {
+				fields[fieldName] = value
+			}
+		}
 	}
 
 	return fields

--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -22,14 +23,16 @@ func init() {
 
 // Tracker implements tracker.IssueTracker for Jira.
 type Tracker struct {
-	client      *Client
-	store       storage.Storage
-	jiraURL     string
-	projectKeys []string          // one or more project keys (first is primary)
-	apiVersion  string            // "2" or "3" (default: "3")
-	statusMap   map[string]string // beads status → Jira status name (from jira.status_map.* config)
-	typeMap     map[string]string // beads type → Jira type (from jira.type_map.* config)
-	priorityMap map[string]string // beads priority → Jira priority name (from jira.priority_map.* config)
+	client           *Client
+	store            storage.Storage
+	jiraURL          string
+	projectKeys      []string                          // one or more project keys (first is primary)
+	apiVersion       string                            // "2" or "3" (default: "3")
+	statusMap        map[string]string                 // beads status → Jira status name (from jira.status_map.* config)
+	typeMap          map[string]string                 // beads type → Jira type (from jira.type_map.* config)
+	priorityMap      map[string]string                 // beads priority → Jira priority name (from jira.priority_map.* config)
+	customFields     map[string]interface{}            // Jira field name/id → value (from jira.custom_fields.* config)
+	typeCustomFields map[string]map[string]interface{} // Jira issue type → Jira field name/id → value
 }
 
 // SetProjectKeys sets project keys before Init(). When set, Init() uses these
@@ -123,6 +126,44 @@ func (t *Tracker) Init(ctx context.Context, store storage.Storage) error {
 		}
 		if len(priorityMap) > 0 {
 			t.priorityMap = priorityMap
+		}
+
+		const customFieldPrefix = "jira.custom_fields."
+		customFields := make(map[string]interface{})
+		typeCustomFields := make(map[string]map[string]interface{})
+		for key, val := range allConfig {
+			if !strings.HasPrefix(key, customFieldPrefix) || strings.TrimSpace(val) == "" {
+				continue
+			}
+
+			suffix := strings.TrimPrefix(key, customFieldPrefix)
+			if suffix == "" {
+				continue
+			}
+
+			parsed, err := parseJiraCustomFieldValue(val)
+			if err != nil {
+				return fmt.Errorf("parse %s: %w", key, err)
+			}
+
+			parts := strings.SplitN(suffix, ".", 2)
+			if len(parts) == 2 {
+				if parts[0] == "" || parts[1] == "" {
+					continue
+				}
+				if typeCustomFields[parts[0]] == nil {
+					typeCustomFields[parts[0]] = make(map[string]interface{})
+				}
+				typeCustomFields[parts[0]][parts[1]] = parsed
+				continue
+			}
+			customFields[suffix] = parsed
+		}
+		if len(customFields) > 0 {
+			t.customFields = customFields
+		}
+		if len(typeCustomFields) > 0 {
+			t.typeCustomFields = typeCustomFields
 		}
 	}
 
@@ -273,7 +314,14 @@ func (t *Tracker) applyTransition(ctx context.Context, key string, status types.
 }
 
 func (t *Tracker) FieldMapper() tracker.FieldMapper {
-	return &jiraFieldMapper{apiVersion: t.apiVersion, statusMap: t.statusMap, typeMap: t.typeMap, priorityMap: t.priorityMap}
+	return &jiraFieldMapper{
+		apiVersion:       t.apiVersion,
+		statusMap:        t.statusMap,
+		typeMap:          t.typeMap,
+		priorityMap:      t.priorityMap,
+		customFields:     t.customFields,
+		typeCustomFields: t.typeCustomFields,
+	}
 }
 
 func (t *Tracker) IsExternalRef(ref string) bool {
@@ -316,6 +364,21 @@ func (t *Tracker) getConfig(ctx context.Context, key, envVar string) (string, er
 		}
 	}
 	return "", nil
+}
+
+func parseJiraCustomFieldValue(value string) (interface{}, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	}
+	return trimmed, nil
 }
 
 // jiraToTrackerIssue converts a Jira API Issue to the generic TrackerIssue format.

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -267,6 +267,109 @@ func TestFieldMapperIssueToTracker(t *testing.T) {
 	}
 }
 
+func TestFieldMapperIssueToTrackerIncludesGlobalCustomFields(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		customFields: map[string]interface{}{
+			"customfield_10042": "AI Platform",
+		},
+	}
+
+	fields := mapper.IssueToTracker(&types.Issue{
+		Title:     "New feature",
+		Priority:  2,
+		IssueType: types.TypeFeature,
+	})
+
+	if fields["customfield_10042"] != "AI Platform" {
+		t.Errorf("customfield_10042 = %v, want %q", fields["customfield_10042"], "AI Platform")
+	}
+}
+
+func TestFieldMapperIssueToTrackerIncludesJSONObjectCustomField(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		customFields: map[string]interface{}{
+			"customfield_10042": map[string]interface{}{"value": "AI Platform"},
+		},
+	}
+
+	fields := mapper.IssueToTracker(&types.Issue{
+		Title:     "New feature",
+		Priority:  2,
+		IssueType: types.TypeFeature,
+	})
+
+	field, ok := fields["customfield_10042"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("customfield_10042 type = %T, want map[string]interface{}", fields["customfield_10042"])
+	}
+	if field["value"] != "AI Platform" {
+		t.Errorf("customfield_10042.value = %v, want %q", field["value"], "AI Platform")
+	}
+}
+
+func TestFieldMapperIssueToTrackerAppliesPerTypeCustomFields(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		typeCustomFields: map[string]map[string]interface{}{
+			"Story": {
+				"Team": "AI Platform",
+			},
+		},
+	}
+
+	fields := mapper.IssueToTracker(&types.Issue{
+		Title:     "New feature",
+		Priority:  2,
+		IssueType: types.TypeFeature,
+	})
+
+	if fields["Team"] != "AI Platform" {
+		t.Errorf("Team = %v, want %q", fields["Team"], "AI Platform")
+	}
+}
+
+func TestFieldMapperIssueToTrackerPerTypeCustomFieldsOverrideGlobal(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		customFields: map[string]interface{}{
+			"Team": "Global Team",
+		},
+		typeCustomFields: map[string]map[string]interface{}{
+			"story": {
+				"Team": "Story Team",
+			},
+		},
+	}
+
+	fields := mapper.IssueToTracker(&types.Issue{
+		Title:     "New feature",
+		Priority:  2,
+		IssueType: types.TypeFeature,
+	})
+
+	if fields["Team"] != "Story Team" {
+		t.Errorf("Team = %v, want %q", fields["Team"], "Story Team")
+	}
+}
+
+func TestFieldMapperIssueToTrackerIgnoresNonMatchingPerTypeCustomFields(t *testing.T) {
+	mapper := &jiraFieldMapper{
+		typeCustomFields: map[string]map[string]interface{}{
+			"Epic": {
+				"Team": "AI Platform",
+			},
+		},
+	}
+
+	fields := mapper.IssueToTracker(&types.Issue{
+		Title:     "New feature",
+		Priority:  2,
+		IssueType: types.TypeFeature,
+	})
+
+	if _, ok := fields["Team"]; ok {
+		t.Errorf("Team = %v, want unset for non-matching type", fields["Team"])
+	}
+}
+
 func TestFieldMapperDescriptionV3UsesADF(t *testing.T) {
 	mapper := &jiraFieldMapper{apiVersion: "3"}
 	issue := &types.Issue{Title: "T", Description: "Hello world"}
@@ -871,6 +974,184 @@ func TestInitLoadsCustomPriorityMapFromAllConfig(t *testing.T) {
 	}
 	if tr.priorityMap["2"] != "Normal" {
 		t.Errorf("priorityMap[\"2\"] = %q, want %q", tr.priorityMap["2"], "Normal")
+	}
+}
+
+func TestInitLoadsCustomFieldsFromAllConfig(t *testing.T) {
+	// jira.api_token is yaml-only (secret), so set it via env var.
+	t.Setenv("JIRA_API_TOKEN", "token123")
+	store := &configStore{
+		data: map[string]string{
+			"jira.url":                                  "https://example.atlassian.net",
+			"jira.project":                              "PROJ",
+			"jira.custom_fields.":                       "ignored",
+			"jira.custom_fields.Empty":                  "",
+			"jira.custom_fields.Whitespace":             "   ",
+			"jira.custom_fields.Team":                   "Global Team",
+			"jira.custom_fields.customfield_10042":      `{"value":"AI Platform"}`,
+			"jira.custom_fields.Story.":                 "ignored",
+			"jira.custom_fields..Team":                  "ignored",
+			"jira.custom_fields.Story.Team":             "Story Team",
+			"jira.custom_fields.Initiative.customfield": "Initiative Value",
+		},
+	}
+
+	tr := &Tracker{}
+	if err := tr.Init(context.Background(), store); err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+
+	if tr.customFields == nil {
+		t.Fatal("customFields should not be nil after Init with jira.custom_fields.* config")
+	}
+	if tr.customFields["Team"] != "Global Team" {
+		t.Errorf("customFields[\"Team\"] = %v, want %q", tr.customFields["Team"], "Global Team")
+	}
+	if _, ok := tr.customFields[""]; ok {
+		t.Error("customFields should ignore empty field names")
+	}
+	if _, ok := tr.customFields["Empty"]; ok {
+		t.Error("customFields should ignore empty values")
+	}
+	if _, ok := tr.customFields["Whitespace"]; ok {
+		t.Error("customFields should ignore whitespace-only values")
+	}
+	field, ok := tr.customFields["customfield_10042"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("customFields[\"customfield_10042\"] type = %T, want map[string]interface{}", tr.customFields["customfield_10042"])
+	}
+	if field["value"] != "AI Platform" {
+		t.Errorf("customFields[\"customfield_10042\"].value = %v, want %q", field["value"], "AI Platform")
+	}
+
+	if tr.typeCustomFields == nil {
+		t.Fatal("typeCustomFields should not be nil after Init with per-type jira.custom_fields.* config")
+	}
+	if tr.typeCustomFields["Story"]["Team"] != "Story Team" {
+		t.Errorf("typeCustomFields[\"Story\"][\"Team\"] = %v, want %q", tr.typeCustomFields["Story"]["Team"], "Story Team")
+	}
+	if _, ok := tr.typeCustomFields["Story"][""]; ok {
+		t.Error("typeCustomFields should ignore empty per-type field names")
+	}
+	if _, ok := tr.typeCustomFields[""]["Team"]; ok {
+		t.Error("typeCustomFields should ignore empty Jira type names")
+	}
+	if tr.typeCustomFields["Initiative"]["customfield"] != "Initiative Value" {
+		t.Errorf("typeCustomFields[\"Initiative\"][\"customfield\"] = %v, want %q", tr.typeCustomFields["Initiative"]["customfield"], "Initiative Value")
+	}
+
+	mapper := tr.FieldMapper()
+	fields := mapper.IssueToTracker(&types.Issue{
+		Title:     "New feature",
+		Priority:  2,
+		IssueType: types.TypeFeature,
+	})
+	if fields["Team"] != "Story Team" {
+		t.Errorf("FieldMapper Team = %v, want per-type override %q", fields["Team"], "Story Team")
+	}
+	field, ok = fields["customfield_10042"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("FieldMapper customfield_10042 type = %T, want map[string]interface{}", fields["customfield_10042"])
+	}
+	if field["value"] != "AI Platform" {
+		t.Errorf("FieldMapper customfield_10042.value = %v, want %q", field["value"], "AI Platform")
+	}
+}
+
+func TestInitRejectsInvalidCustomFieldJSON(t *testing.T) {
+	// jira.api_token is yaml-only (secret), so set it via env var.
+	t.Setenv("JIRA_API_TOKEN", "token123")
+	store := &configStore{
+		data: map[string]string{
+			"jira.url":                             "https://example.atlassian.net",
+			"jira.project":                         "PROJ",
+			"jira.custom_fields.customfield_10042": `{"value":`,
+		},
+	}
+
+	tr := &Tracker{}
+	err := tr.Init(context.Background(), store)
+	if err == nil {
+		t.Fatal("Init should reject invalid jira.custom_fields JSON")
+	}
+	if !strings.Contains(err.Error(), "parse jira.custom_fields.customfield_10042") {
+		t.Fatalf("Init error = %v, want custom field parse context", err)
+	}
+}
+
+func TestParseJiraCustomFieldValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		check func(t *testing.T, got interface{})
+	}{
+		{
+			name:  "string",
+			value: " AI Platform ",
+			check: func(t *testing.T, got interface{}) {
+				if got != "AI Platform" {
+					t.Errorf("got = %v, want %q", got, "AI Platform")
+				}
+			},
+		},
+		{
+			name:  "empty after trim",
+			value: "   ",
+			check: func(t *testing.T, got interface{}) {
+				if got != "" {
+					t.Errorf("got = %v, want empty string", got)
+				}
+			},
+		},
+		{
+			name:  "object",
+			value: `{"value":"AI Platform"}`,
+			check: func(t *testing.T, got interface{}) {
+				field, ok := got.(map[string]interface{})
+				if !ok {
+					t.Fatalf("got type = %T, want map[string]interface{}", got)
+				}
+				if field["value"] != "AI Platform" {
+					t.Errorf("got.value = %v, want %q", field["value"], "AI Platform")
+				}
+			},
+		},
+		{
+			name:  "array",
+			value: `[{"id":"10042"}]`,
+			check: func(t *testing.T, got interface{}) {
+				values, ok := got.([]interface{})
+				if !ok {
+					t.Fatalf("got type = %T, want []interface{}", got)
+				}
+				if len(values) != 1 {
+					t.Fatalf("len(got) = %d, want 1", len(values))
+				}
+				field, ok := values[0].(map[string]interface{})
+				if !ok {
+					t.Fatalf("got[0] type = %T, want map[string]interface{}", values[0])
+				}
+				if field["id"] != "10042" {
+					t.Errorf("got[0].id = %v, want %q", field["id"], "10042")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseJiraCustomFieldValue(tt.value)
+			if err != nil {
+				t.Fatalf("parseJiraCustomFieldValue error: %v", err)
+			}
+			tt.check(t, got)
+		})
+	}
+}
+
+func TestParseJiraCustomFieldValueInvalidJSON(t *testing.T) {
+	if _, err := parseJiraCustomFieldValue(`{"value":`); err == nil {
+		t.Fatal("parseJiraCustomFieldValue should reject invalid JSON object values")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `jira.custom_fields.*` config loading for Jira push
- merge global custom fields and per-Jira-type overrides into Jira create/update field payloads
- support JSON object/array custom field values for Jira fields that require structured payloads
- document the config and add focused mapper/init/parser tests

## Validation
- `scripts/pr-preflight.sh 3678 --repo gastownhall/beads`
- `go test ./internal/jira -coverprofile=/tmp/jira.cover.out`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run '^TestNonExistent$'`
- `git diff --check`

## Notes
- Rebased onto current `upstream/main`.
- PR-specific preflight reports the PR is no longer blocked by draft status after marking ready; it still warns that no closing issue reference exists because local `bd create` could not run without `issue_prefix`.
- GitHub CI is rerunning on the rebased commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
