### PR TITLE
fix: auto-import: skip non-embedded fallback when store is populated

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -71,6 +71,24 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	}
 
 	// Fallback for non-embedded stores: multi-call path (original behavior).
+	//
+	// Confirm the database is genuinely empty before printing the
+	// progress message and running the import. The embedded path's
+	// jsonlImporter handles this internally inside its single
+	// transaction, but the non-embedded fallback historically printed
+	// the "auto-importing N bytes... into empty database" message
+	// unconditionally — so every command that reached this branch on
+	// a populated store kept emitting the message and re-running the
+	// import (idempotent for issues but still spammy and wasteful).
+	// Mirrors the embedded path's gating.
+	if stats, statsErr := s.GetStatistics(ctx); statsErr != nil || stats == nil || stats.TotalIssues > 0 {
+		// Either the store has data (no upgrade-recovery import needed)
+		// or we couldn't determine emptiness; in both cases skip the
+		// import to avoid duplicate writes and spurious messages. Users
+		// can still run `bd init --from-jsonl` to force a re-import.
+		return
+	}
+
 	fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
 
 	result, err := importFromLocalJSONLFull(ctx, s, jsonlPath)


### PR DESCRIPTION
## Summary

The embedded-mode path of `maybeAutoImportJSONL` gates the import on emptiness inside `ImportJSONLData` (single transaction, prints only when `imported > 0`). The non-embedded fallback path printed the `"auto-importing N bytes... into empty database..."` message and ran `importFromLocalJSONLFull` unconditionally, regardless of whether the store was actually empty.

Any consumer running bd against a populated database in shared-server mode (where bd's per-context state is just a `dolt-server.port` pointer rather than a local `.beads/dolt/<db>/` directory) hits this on every write command. The import is idempotent on already-populated rows, but the message contaminates stderr — and breaks `--json` consumers when a write command returns its result on stdout while stderr has the spurious noise.

## Fix

Mirror the embedded path's gating: query `GetStatistics` and skip the print + import when `TotalIssues > 0`. When statistics are unavailable (transient store error, schema mismatch, etc.) be conservative and skip the import — users can still force a re-import via `bd init --from-jsonl`.

```go
// Confirm the database is genuinely empty before printing the
// progress message and running the import. Mirrors the embedded
// path's gating.
if stats, statsErr := s.GetStatistics(ctx); statsErr != nil || stats == nil || stats.TotalIssues > 0 {
    return
}
```

This complements `a2db80a2` ("auto-import: don't print progress message before confirming import needed") which addressed the same kind of issue for the embedded path; the same gating is now in the fallback branch.

## Verified end-to-end

- Setup: shared-server bd connecting to a multi-database dolt sql-server with 28 pre-existing committed issues in the target database + a populated `issues.jsonl` in `.beads/`.
- Pre-fix: every `bd create` / `bd update` / `bd close` printed `"auto-importing 97274 bytes..."` to stderr; `--json` writes had stderr leakage that broke `jq` pipelines.
- Post-fix: writes are silent on populated stores; the upgrade-recovery path still triggers when the database is genuinely empty.

## Tests

`cmd/bd/...` tests pass. Pre-existing `internal/storage/dolt` failures (`TestApplyConfigDefaults_*`) are environmental — they assume an isolated test-mode setup and are present on plain `main` without this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->