### PR TITLE
fix(auto-import): restore empty-DB guard regressed by #3630, plus a test repair

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -17,15 +17,27 @@ type jsonlImporter interface {
 	ImportJSONLData(ctx context.Context, issues []*types.Issue, configEntries map[string]string, actor string) (int, error)
 }
 
+// fallbackImporter is the function maybeAutoImportJSONL invokes for stores
+// that do not implement jsonlImporter (server-mode dolt). It exists as a
+// package-level variable so tests can substitute a counter and verify the
+// top-level emptiness guard prevents the fallback path from running on a
+// non-empty database. Production builds always use importFromLocalJSONLFull.
+var fallbackImporter = importFromLocalJSONLFull
+
 // maybeAutoImportJSONL checks whether the database is empty and a
 // issues.jsonl file exists in beadsDir. When both conditions are true it
 // auto-imports the JSONL data so users upgrading from pre-0.56 (which used
 // .beads/dolt/) to 1.0+ (which uses .beads/embeddeddolt/) don't appear to
 // lose their issues.  See GH#2994.
 //
-// When the store implements jsonlImporter (embedded mode), the emptiness
-// check and import happen in a single transaction with no DOLT_COMMIT —
-// the caller's PersistentPostRun auto-commit handles the Dolt commit.
+// The top-level emptiness guard (GetStatistics) protects BOTH the
+// embedded fast-path and the server-mode fallback. The embedded
+// jsonlImporter has its own in-transaction emptiness check as a
+// concurrency-safe second line of defense; the fallback path's
+// importFromLocalJSONLFull uses INSERT … ON DUPLICATE KEY UPDATE
+// semantics under the hood, so without this guard a stale
+// issues.jsonl would be re-imposed on top of live Dolt rows on
+// every command, clobbering recent partial-update writes.
 //
 // The function is best-effort: failures are logged as warnings but do not
 // prevent the store from being used.
@@ -35,6 +47,18 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	info, err := os.Stat(jsonlPath)
 	if err != nil || info.Size() == 0 {
 		return // no JSONL file or empty — nothing to import
+	}
+
+	// Top-level emptiness guard (covers both embedded and fallback paths).
+	// Without this, the fallback path silently re-imposes stale JSONL on
+	// top of live Dolt rows via UPSERT semantics on every invocation.
+	stats, err := s.GetStatistics(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: auto-import: failed to check issue count: %v\n", err)
+		return
+	}
+	if stats.TotalIssues > 0 {
+		return // database is not empty — nothing to do
 	}
 
 	// Parse the JSONL file without touching the store.
@@ -73,7 +97,7 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	// Fallback for non-embedded stores: multi-call path (original behavior).
 	fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
 
-	result, err := importFromLocalJSONLFull(ctx, s, jsonlPath)
+	result, err := fallbackImporter(ctx, s, jsonlPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: auto-import from %s failed: %v\n", jsonlPath, err)
 		fmt.Fprintf(os.Stderr, "\nYour issues are still safe in %s.\n", jsonlPath)

--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -57,6 +57,10 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 		fmt.Fprintf(os.Stderr, "warning: auto-import: failed to check issue count: %v\n", err)
 		return
 	}
+	if stats == nil {
+		fmt.Fprintf(os.Stderr, "warning: auto-import: issue count unavailable\n")
+		return
+	}
 	if stats.TotalIssues > 0 {
 		return // database is not empty — nothing to do
 	}

--- a/cmd/bd/auto_import_upgrade_test.go
+++ b/cmd/bd/auto_import_upgrade_test.go
@@ -52,20 +52,36 @@ func TestEmbeddedAutoImportJSONLNoExplicitCommit(t *testing.T) {
 		t.Fatalf("writing issues.jsonl: %v", err)
 	}
 
-	// Run "bd list --json" — triggers maybeAutoImportJSONL in pre-run,
-	// auto-commit in post-run.
+	// Trigger auto-import via a write command. bd list is registered as
+	// read-only in cmd/bd/main.go's dispatcher and skips
+	// maybeAutoImportJSONL entirely — using it here would leave the
+	// destination empty and the test would assert against zero issues.
+	// bd create runs maybeAutoImportJSONL in PersistentPreRun (which
+	// stages the imported issues in the Dolt working set without an
+	// explicit DOLT_COMMIT), performs its own create write into the same
+	// working set, and then explicitly calls store.Commit at the end of
+	// cmd/bd/create.go — that single commit picks up both the auto-import
+	// and the new issue. PersistentPostRun's maybeAutoCommit is then a
+	// no-op (nothing left to commit).
+	bdCreate(t, bd, dstDir, "post-import marker", "--type", "task")
 	issues := bdListJSON(t, bd, dstDir)
-	if len(issues) != 3 {
-		t.Fatalf("expected 3 imported issues, got %d", len(issues))
+	if len(issues) != 4 {
+		t.Fatalf("expected 4 issues (3 imported + 1 created post-import), got %d", len(issues))
 	}
 
-	// Verify commit count: should be exactly 2 (init + post-run auto-commit).
-	// If the old code path were used, there would be 3 (init + auto-import
-	// DOLT_COMMIT + post-run auto-commit).
+	// Verify auto-import did NOT issue its own DOLT_COMMIT. The
+	// single-transaction import sets commandDidWrite and defers the commit
+	// to PersistentPostRun, so the auto-import and the post-run write
+	// (the bd create above) coalesce into one Dolt commit. The exact total
+	// depends on init detail (2-3 init commits + 1 coalesced post-run);
+	// what we want to forbid is a separate auto-import commit appearing
+	// alongside the post-run commit. The "auto-import: ... (upgrade
+	// recovery, GH#2994)" message is only used when the function calls
+	// s.Commit explicitly (the fallback path) — its absence proves the
+	// embedded path used the deferred-commit flow.
 	logOut := bdDolt(t, bd, dstDir, "log")
-	commitCount := strings.Count(logOut, "commit ")
-	if commitCount > 2 {
-		t.Errorf("expected at most 2 Dolt commits (init + auto-commit), got %d;\nlog:\n%s", commitCount, logOut)
+	if strings.Contains(logOut, "auto-import:") && strings.Contains(logOut, "upgrade recovery, GH#2994") {
+		t.Errorf("embedded auto-import path issued an explicit DOLT_COMMIT; expected the commit to be deferred to PersistentPostRun;\nlog:\n%s", logOut)
 	}
 }
 

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// fakeFallbackStore satisfies storage.DoltStorage via an embedded nil
+// interface (any unimplemented method panics) and returns a configurable
+// Statistics. It does NOT implement jsonlImporter, so the type assertion
+// in maybeAutoImportJSONL fails and the server-mode fallback path is taken
+// — exactly the path that lacked an emptiness guard prior to the fix.
+type fakeFallbackStore struct {
+	storage.DoltStorage // nil — panics on any non-overridden method
+	statsTotalIssues    int
+}
+
+func (f *fakeFallbackStore) GetStatistics(_ context.Context) (*types.Statistics, error) {
+	return &types.Statistics{TotalIssues: f.statsTotalIssues}, nil
+}
+
+func writeAutoImportFixtureJSONL(t *testing.T, dir string) {
+	t.Helper()
+	// Minimal valid issue line. Contents are irrelevant for the
+	// skip-when-non-empty test (returns before parseJSONLFile) and are
+	// only required to be parseable for the negative-control test.
+	line := `{"_type":"issue","id":"unit-1","title":"unit-test-fixture","status":"open","priority":2,"issue_type":"task"}`
+	if err := os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func swapFallbackImporter(t *testing.T, returnErr error) *atomic.Int32 {
+	t.Helper()
+	orig := fallbackImporter
+	var count atomic.Int32
+	fallbackImporter = func(_ context.Context, _ storage.DoltStorage, _ string) (*importLocalResult, error) {
+		count.Add(1)
+		if returnErr != nil {
+			return nil, returnErr
+		}
+		return &importLocalResult{}, nil
+	}
+	t.Cleanup(func() { fallbackImporter = orig })
+	return &count
+}
+
+// TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty is the
+// regression test for the auto-import-on-non-empty data-clobber bug
+// introduced upstream by PR #3630.
+//
+// Pre-fix, maybeAutoImportJSONL had no top-level emptiness guard for
+// stores that did not implement jsonlImporter (i.e. server-mode dolt).
+// Every command unconditionally invoked importFromLocalJSONLFull, which
+// UPSERTs JSONL contents on top of live Dolt rows — silently clobbering
+// recent partial-update writes whose values had not yet been re-exported
+// to JSONL.
+//
+// This test fails on the buggy code (counter == 1) and passes after the
+// guard is restored (counter == 0).
+func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	count := swapFallbackImporter(t, errors.New("test importer should not run"))
+
+	store := &fakeFallbackStore{statsTotalIssues: 5}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+
+	if got := count.Load(); got != 0 {
+		t.Fatalf("regression: server-mode fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
+	}
+}
+
+// TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty is the negative
+// control. Without it, a future change that always short-circuits would
+// leave the regression test above passing vacuously.
+//
+// The substituted importer returns an error to short-circuit before
+// s.Commit is called, so the bare fakeFallbackStore (which panics on
+// every other method) does not need the full DoltStorage surface.
+func TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	count := swapFallbackImporter(t, errors.New("test importer: short-circuit before s.Commit"))
+
+	store := &fakeFallbackStore{statsTotalIssues: 0}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+
+	if got := count.Load(); got != 1 {
+		t.Fatalf("server-mode fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
+	}
+}

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -20,9 +20,13 @@ import (
 type fakeFallbackStore struct {
 	storage.DoltStorage // nil — panics on any non-overridden method
 	statsTotalIssues    int
+	statsNil            bool
 }
 
 func (f *fakeFallbackStore) GetStatistics(_ context.Context) (*types.Statistics, error) {
+	if f.statsNil {
+		return nil, nil
+	}
 	return &types.Statistics{TotalIssues: f.statsTotalIssues}, nil
 }
 
@@ -75,6 +79,22 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty(t *testing.T)
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("regression: server-mode fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
+	}
+}
+
+// TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenStatisticsNil covers
+// the defensive nil-statistics guard: if the store reports no error but also
+// no counts, auto-import should skip rather than panic or assume emptiness.
+func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenStatisticsNil(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	count := swapFallbackImporter(t, errors.New("test importer should not run"))
+
+	store := &fakeFallbackStore{statsNil: true}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+
+	if got := count.Load(); got != 0 {
+		t.Fatalf("server-mode fallback importer was invoked %d time(s) when statistics were nil; expected 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR #3630 (\`Fix maybeAutoImportJSONL concurrency race in embedded mode\`, merged 2026-05-01) introduced two related issues. This PR fixes both.

### Issue 1 — Server-mode data clobber regression

The refactor in #3630 moved \`maybeAutoImportJSONL\`'s \`TotalIssues > 0\` emptiness guard *inside* the new embedded-mode \`jsonlImporter\` fast path (correct, atomic, race-safe for that path). But the **top-level** emptiness check that previously guarded the function as a whole was removed, leaving the server-mode (non-\`jsonlImporter\`) fallback path unguarded.

Net effect: every \`bd <command>\` invocation in server mode unconditionally runs \`importFromLocalJSONLFull\` on a non-empty Dolt. That eventually reaches \`InsertIssueIntoTable\` (\`internal/storage/issueops/helpers.go:45-102\`), which uses \`INSERT … ON DUPLICATE KEY UPDATE\` and **overwrites every business field** (\`title\`, \`description\`, \`design\`, \`acceptance_criteria\`, \`notes\`, \`status\`, \`priority\`, \`issue_type\`, \`assignee\`, \`estimated_minutes\`, …) with the JSONL values.

Combined with the auto-export's debounce/commit-watermark gating in \`export_auto.go\` (especially with \`--dolt-auto-commit=off\`), JSONL is frequently stale relative to Dolt. So partial-field \`bd update\` invocations (e.g. \`--append-notes\` alone, \`--priority=N\` alone) silently lose the unspecified fields on the next \`bd\` command — the auto-import re-imposes the stale JSONL row on top of Dolt truth.

#### Reproducer (server mode, default config)

```bash
bd update X --priority=2 --notes=\"X\"      # combined: lands cleanly
bd update X --append-notes \"; appended\"   # single field
bd update X --priority=3                   # single field
bd show X --json | jq '.[0] | {priority, notes}'
```

**Pre-fix:** the third \`bd show\` returns \`priority=3, notes=\"X\"\` — the \`; appended\` from step 2 is silently lost.
**Post-fix:** returns \`priority=3, notes=\"X\\n; appended\"\` — both single-field updates preserve unspecified fields from Dolt.

#### Fix

Restore the v1.0.3 top-level \`GetStatistics\` / \`TotalIssues > 0\` guard, placed *before* the embedded-vs-fallback path fork. The embedded \`jsonlImporter\`'s atomic in-tx check is retained as defense-in-depth against the concurrent-writer race that #3630 was designed to fix; nothing about that intent is reverted. The fallback path is once again a true upgrade-recovery path that only fires on a genuinely empty database.

#### Regression test

Added \`cmd/bd/auto_import_upgrade_unit_test.go\` (no \`//go:build cgo\` tag) covering the server-mode fallback path. Uses a tiny testability seam (\`importFromLocalJSONLFull\` exposed as a package-level \`fallbackImporter\` var) plus a stub storage that does not implement \`jsonlImporter\`, so the test exercises exactly the path that lacked an emptiness guard. Two cases:

- \`TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty\` — the regression test. Fails on the buggy code (substituted importer is invoked when it shouldn't be) and passes after the guard is restored.
- \`TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty\` — negative control. Guards against a future change that always short-circuits and would let the regression test pass vacuously.

### Issue 2 — \`TestEmbeddedAutoImportJSONLNoExplicitCommit\` was broken when shipped

The new test in #3630 uses \`bd list --json\` to trigger \`maybeAutoImportJSONL\`. But \`bd list\` is registered as a read-only command in \`cmd/bd/main.go\`'s \`readOnlyCommands\` map, and the dispatcher at \`cmd/bd/main.go:1023\` explicitly skips \`maybeAutoImportJSONL\` for read-only commands:

```go
if store != nil && !useReadOnly && !globalFlag && cmd.Name() != \"import\" {
    maybeAutoImportJSONL(...)
}
```

The \`!useReadOnly\` guard was added 2026-04-14 in \`fa87dd2bd\` (intentional, addresses GH#804). The broken test was added 18 days later with a comment claiming the opposite. The test consequently asserts on an empty destination store and fails:

```
auto_import_upgrade_test.go:59: expected 3 imported issues, got 0
```

CI did not catch this because the test is gated behind \`BEADS_TEST_EMBEDDED_DOLT=1\` and \`t.Skip\`s otherwise; the embedded suite must not have been enabled in #3630's pipeline.

#### Fix

Use \`bd create\` (a write command) to trigger auto-import in pre-run. \`bd create\` itself calls \`store.Commit\` at \`cmd/bd/create.go:676\` (gated on \`isEmbeddedMode\` || \`postCreateWrites\`); the auto-import stages writes into the same Dolt working set and \`bd create\`'s commit picks them up. The post-import marker brings the asserted total to 4 (3 imported + 1 created).

The original \`commitCount > 2\` assertion was a brittle proxy for \"auto-import didn't issue its own \`DOLT_COMMIT\`.\" Replaced with a direct check: forbid the \`\"auto-import: ... (upgrade recovery, GH#2994)\"\` commit message, which the function only emits when it calls \`s.Commit\` explicitly (the fallback path). Its absence is the actual property under test.

## Out of scope

The two sibling tests in the same file (\`SkipsNonEmpty\`, \`ConcurrentWriter\`) are also questionable. \`SkipsNonEmpty\` is tautologically true given the same read-only \`bd list\` trigger, and \`ConcurrentWriter\` works for incidental reasons (the parallel \`bd create\` calls are write commands and DO trigger auto-import). They pass, but their coverage is weaker than their names suggest. Worth a follow-up cleanup but not strictly required to fix CI signal here.

## Test plan

- [x] \`make build\` clean
- [x] \`TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty\` — passes; verified to FAIL when the top-level guard is removed (proves the test catches the regression)
- [x] \`TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty\` — passes (negative control)
- [x] \`TestEmbeddedAutoImportJSONLNoExplicitCommit\` — passes after the trigger swap; was failing on every prior run with this PR's first commit applied alone
- [x] \`TestEmbeddedAutoImportJSONLConcurrentWriter\` — passes (the #3630 concurrent-writer scenario, untouched)
- [x] \`TestEmbeddedAutoImportJSONLSkipsNonEmpty\` — passes
- [x] Empirical reproducer in a real bd workspace: priority preserved through \`--append-notes\`, notes preserved through \`--priority=N\`
- [x] Cross-binary sanity: Homebrew \`1.0.3\` (which predates #3630) and a freshly-built local binary on this branch produce identical, correct behavior

## Splitting

If maintainers prefer single-purpose PRs, I'm happy to split this into two: one for the empty-guard fix + regression test, one for the test-trigger repair. Both already exist as separate commits on this branch (\`42dbb70fc\` and \`8c636d4ad\`); a per-commit revert is clean.

🤖 Investigated, fixed, and tested with assistance from Claude Code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->