### PR TITLE
fix(prime): surface memories before hook truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ bd setup factory  # Factory.ai Droid - creates/updates AGENTS.md
 
 Manual copy-paste is only for unsupported agents, existing projects where you cannot rerun `bd init`/`bd setup`, or custom instruction files. In those cases, run `bd onboard` and paste the printed snippet into the file your agent reads.
 
+If your agent is not covered by `bd setup`, add this minimal `AGENTS.md` section:
+
+```markdown
+This project uses bd (beads) for issue tracking.
+
+- Run `bd prime` for workflow context and command guidance.
+- Use `bd ready`, `bd show <id>`, `bd update <id> --claim`, and `bd close <id>`.
+- Use `bd remember "insight"` for persistent project memory; do not create MEMORY.md files.
+- Do not use markdown TODO lists for task tracking.
+```
+
 ## 🛠 Features
 
 * **[Dolt](https://github.com/dolthub/dolt)-Powered:** Version-controlled SQL database with cell-level merge, native branching, and built-in sync via Dolt remotes.
@@ -54,6 +65,8 @@ Manual copy-paste is only for unsupported agents, existing projects where you ca
 | `bd update <id> --claim` | Atomically claim a task (sets assignee + in_progress). |
 | `bd dep add <child> <parent>` | Link tasks (blocks, related, parent-child). |
 | `bd show <id>` | View task details and audit trail. |
+| `bd prime` | Print agent workflow context and persistent memories. |
+| `bd remember "insight"` | Store project memory that `bd prime` injects later. |
 
 ## 🔗 Hierarchy & Workflow
 

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -19,10 +19,11 @@ import (
 )
 
 var (
-	primeFullMode    bool
-	primeMCPMode     bool
-	primeStealthMode bool
-	primeExportMode  bool
+	primeFullMode     bool
+	primeMCPMode      bool
+	primeStealthMode  bool
+	primeExportMode   bool
+	primeMemoriesOnly bool
 )
 
 // resolveGlobalPrimePath returns the path to ~/.config/beads/PRIME.md if it
@@ -65,7 +66,8 @@ Config options:
 
 	Workflow customization:
 	- Place a .beads/PRIME.md file in the local clone or resolved workspace to override the default output entirely.
-	- Use --export to dump the default content for customization.`,
+	- Use --export to dump the default content for customization.
+	- Use --memories-only for hook contexts that should inject only persistent memories.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Resolve the active beads workspace.
 		beadsDir := beads.FindBeadsDir()
@@ -124,7 +126,7 @@ Config options:
 		}
 
 		// Output workflow context (adaptive based on MCP and stealth mode)
-		if err := outputPrimeContext(os.Stdout, mcpMode, stealthMode); err != nil {
+		if err := outputPrimeContextWithOptions(os.Stdout, mcpMode, stealthMode, primeMemoriesOnly); err != nil {
 			// Suppress all errors - silent exit with success
 			// Never write to stderr (breaks Windows compatibility)
 			os.Exit(0)
@@ -137,6 +139,7 @@ func init() {
 	primeCmd.Flags().BoolVar(&primeMCPMode, "mcp", false, "Force MCP mode (minimal output)")
 	primeCmd.Flags().BoolVar(&primeStealthMode, "stealth", false, "Stealth mode (no git operations, flush only)")
 	primeCmd.Flags().BoolVar(&primeExportMode, "export", false, "Output default content (ignores PRIME.md override)")
+	primeCmd.Flags().BoolVar(&primeMemoriesOnly, "memories-only", false, "Output only persistent memories for compact hook contexts")
 	rootCmd.AddCommand(primeCmd)
 }
 
@@ -225,10 +228,29 @@ func getRedirectNotice(verbose bool) string {
 
 // outputPrimeContext outputs workflow context in markdown format
 func outputPrimeContext(w io.Writer, mcpMode bool, stealthMode bool) error {
+	return outputPrimeContextWithOptions(w, mcpMode, stealthMode, false)
+}
+
+func outputPrimeContextWithOptions(w io.Writer, mcpMode bool, stealthMode bool, memoriesOnly bool) error {
+	if memoriesOnly {
+		return outputMemoriesOnlyContext(w)
+	}
 	if mcpMode {
 		return outputMCPContext(w, stealthMode)
 	}
 	return outputCLIContext(w, stealthMode)
+}
+
+const primeTruncationDirective = "[bd prime] If this output is truncated by your host, read the full persisted hook output before continuing; it may contain project memories and session rules not visible in the preview.\n\n"
+
+func outputMemoriesOnlyContext(w io.Writer) error {
+	_, _ = fmt.Fprint(w, primeTruncationDirective)
+	if mem := formatMemoriesForPrime(false); mem != "" {
+		_, _ = fmt.Fprint(w, mem)
+		return nil
+	}
+	_, _ = fmt.Fprint(w, "# Beads Persistent Memories\n\nNo memories stored. Use `bd remember \"insight\"` to add one.\n")
+	return nil
 }
 
 // formatMemoriesForPrime queries memories from the k/v store and formats them for injection.
@@ -351,10 +373,16 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 	}
 
 	redirectNotice := getRedirectNotice(false)
+	memories := formatMemoriesForPrime(true)
 
-	context := `# Beads Issue Tracker Active
+	context := primeTruncationDirective + `# Beads Issue Tracker Active
 
-` + redirectNotice + `# 🚨 SESSION CLOSE PROTOCOL 🚨
+` + redirectNotice
+	if memories != "" {
+		context += memories + "\n"
+	}
+
+	context += `# 🚨 SESSION CLOSE PROTOCOL 🚨
 
 ` + closeProtocol + `
 
@@ -368,11 +396,6 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 Start: Check ` + "`ready`" + ` tool for available work.
 `
 	_, _ = fmt.Fprint(w, context)
-
-	// Inject memories (compact for MCP)
-	if mem := formatMemoriesForPrime(true); mem != "" {
-		_, _ = fmt.Fprint(w, mem)
-	}
 
 	return nil
 }
@@ -460,13 +483,19 @@ git push                    # Push to remote
 	}
 
 	redirectNotice := getRedirectNotice(true)
+	memories := formatMemoriesForPrime(false)
 
-	context := `# Beads Workflow Context
+	context := primeTruncationDirective + `# Beads Workflow Context
 
 > **Context Recovery**: Run ` + "`bd prime`" + ` after compaction, clear, or new session
 > Hooks auto-call this in Claude Code when a beads workspace is resolved
 
-` + redirectNotice + `# 🚨 SESSION CLOSE PROTOCOL 🚨
+` + redirectNotice
+	if memories != "" {
+		context += memories + "\n"
+	}
+
+	context += `# 🚨 SESSION CLOSE PROTOCOL 🚨
 
 **CRITICAL**: Before saying "done" or "complete", you MUST run this checklist:
 
@@ -558,11 +587,6 @@ bd dep add beads-yyy beads-xxx  # Tests depend on Feature (Feature blocks tests)
 ` + "```" + `
 `
 	_, _ = fmt.Fprint(w, context)
-
-	// Inject memories (full format for CLI)
-	if mem := formatMemoriesForPrime(false); mem != "" {
-		_, _ = fmt.Fprint(w, mem)
-	}
 
 	return nil
 }

--- a/cmd/bd/prime_embedded_test.go
+++ b/cmd/bd/prime_embedded_test.go
@@ -82,6 +82,23 @@ func TestEmbeddedPrime(t *testing.T) {
 		if !strings.Contains(primeOut, "race") {
 			t.Errorf("expected memory content in prime output: %s", primeOut[:min(500, len(primeOut))])
 		}
+		memoryIdx := strings.Index(primeOut, "prime-test-mem")
+		sessionIdx := strings.Index(primeOut, "SESSION CLOSE PROTOCOL")
+		if memoryIdx == -1 || sessionIdx == -1 || memoryIdx > sessionIdx {
+			t.Errorf("expected memories before session protocol in prime output")
+		}
+	})
+
+	// ===== Memories Only =====
+
+	t.Run("prime_memories_only", func(t *testing.T) {
+		out := bdPrime(t, bd, dir, "--memories-only")
+		if !strings.Contains(out, "prime-test-mem") {
+			t.Errorf("expected memory content in --memories-only output: %s", out)
+		}
+		if strings.Contains(out, "Essential Commands") {
+			t.Errorf("expected --memories-only to omit full command guide: %s", out)
+		}
 	})
 }
 

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -174,6 +174,36 @@ func TestPrimeClaimGuidanceUsesAtomicClaim(t *testing.T) {
 	}
 }
 
+func TestPrimeStartsWithTruncationDirective(t *testing.T) {
+	defer stubIsEphemeralBranch(false)()
+	defer stubPrimeHasGitRemote(true)()
+
+	for _, mcpMode := range []bool{false, true} {
+		var buf bytes.Buffer
+		if err := outputPrimeContext(&buf, mcpMode, false); err != nil {
+			t.Fatalf("outputPrimeContext failed: %v", err)
+		}
+		if !strings.HasPrefix(buf.String(), primeTruncationDirective) {
+			t.Fatalf("prime output should start with truncation directive; got %q", buf.String()[:min(120, buf.Len())])
+		}
+	}
+}
+
+func TestPrimeMemoriesOnlyNoMemories(t *testing.T) {
+	var buf bytes.Buffer
+	if err := outputPrimeContextWithOptions(&buf, false, false, true); err != nil {
+		t.Fatalf("outputPrimeContextWithOptions failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.HasPrefix(output, primeTruncationDirective) {
+		t.Fatal("memories-only output should start with truncation directive")
+	}
+	if strings.Contains(output, "Essential Commands") {
+		t.Fatalf("memories-only output should not include the full workflow guide: %s", output)
+	}
+}
+
 func TestPrimeContextUsesWorkspaceLanguage(t *testing.T) {
 	defer stubIsEphemeralBranch(false)()
 	defer stubPrimeHasGitRemote(true)()

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3479,6 +3479,7 @@ Config options:
 	Workflow customization:
 	- Place a .beads/PRIME.md file in the local clone or resolved workspace to override the default output entirely.
 	- Use --export to dump the default content for customization.
+	- Use --memories-only for hook contexts that should inject only persistent memories.
 
 ```
 bd prime [flags]
@@ -3487,10 +3488,11 @@ bd prime [flags]
 **Flags:**
 
 ```
-      --export    Output default content (ignores PRIME.md override)
-      --full      Force full CLI output (ignore MCP detection)
-      --mcp       Force MCP mode (minimal output)
-      --stealth   Stealth mode (no git operations, flush only)
+      --export          Output default content (ignores PRIME.md override)
+      --full            Force full CLI output (ignore MCP detection)
+      --mcp             Force MCP mode (minimal output)
+      --memories-only   Output only persistent memories for compact hook contexts
+      --stealth         Stealth mode (no git operations, flush only)
 ```
 
 ### bd quickstart

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -286,9 +286,12 @@ bd setup claude --project --stealth
 
 The hooks call `bd prime` which:
 1. Outputs workflow context for Claude to read
-2. Syncs any pending changes
-3. Ensures Claude always knows how to use beads
-4. Follows resolved workspace semantics, so `bd where` is the right diagnostic check when local `./.beads` is absent
+2. Prints persistent memories near the top so hook-output previews do not hide them
+3. Starts with a truncation warning telling agents to read the full persisted hook output when the host caps previews
+4. Ensures Claude always knows how to use beads
+5. Follows resolved workspace semantics, so `bd where` is the right diagnostic check when local `./.beads` is absent
+
+For low-token hooks that only need durable project facts, use `bd prime --memories-only`.
 
 This is more context-efficient than MCP tools (~1-2k tokens vs 10-50k for MCP schemas).
 
@@ -350,8 +353,11 @@ bd setup gemini --project --stealth
 
 The hooks call `bd prime` which:
 1. Outputs workflow context for Gemini to read
-2. Syncs any pending changes
-3. Ensures Gemini always knows how to use beads
+2. Prints persistent memories near the top so hook-output previews do not hide them
+3. Starts with a truncation warning telling agents to read the full persisted hook output when the host caps previews
+4. Ensures Gemini always knows how to use beads
+
+For low-token hooks that only need durable project facts, use `bd prime --memories-only`.
 
 This works identically to Claude Code integration, using Gemini CLI's hook system (SessionStart and PreCompress events).
 

--- a/plugins/beads/skills/beads/commands/prime.md
+++ b/plugins/beads/skills/beads/commands/prime.md
@@ -4,4 +4,7 @@ Outputs essential beads workflow rules and command reference to help agents reme
 
 ```bash
 bd prime
+bd prime --memories-only
 ```
+
+Use `--memories-only` when a hook should inject durable project memories without the full workflow guide.

--- a/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
+++ b/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
@@ -6,6 +6,7 @@
 ## Quick Navigation
 
 - [Health & Status](#health--status)
+- [Agent Context & Memory](#agent-context--memory)
 - [Basic Operations](#basic-operations)
 - [Issue Management](#issue-management)
 - [Dependencies & Labels](#dependencies--labels)
@@ -63,10 +64,45 @@ bd prime                       # Auto-detects MCP vs CLI mode
 bd prime --full                # Force full CLI output
 bd prime --mcp                 # Force minimal MCP output
 bd prime --stealth             # No git operations mode
+bd prime --memories-only       # Print persistent memories only
 bd prime --export              # Dump default content for customization
 ```
 
+`bd prime` starts with a truncation warning for hosts that cap hook output. If your agent sees a persisted-output path, read that full file before continuing; memories and session rules may be below the preview cutoff.
+
 **Customization:** Place `.beads/PRIME.md` to override default output.
+
+## Agent Context & Memory
+
+### Prime
+
+`bd prime` prints AI-optimized workflow context. Claude Code and Gemini hooks can run it automatically at session start and before compaction; hookless agents can run it manually when they need the current workflow rules.
+
+```bash
+bd prime                       # Auto-detect MCP vs CLI mode
+bd prime --full                # Force full CLI command guide
+bd prime --mcp                 # Force minimal MCP-oriented context
+bd prime --stealth             # Omit git operations from close protocol
+bd prime --memories-only       # Print persistent memories only
+bd prime --export              # Dump default PRIME.md content for customization
+```
+
+Customize the default context by placing a `.beads/PRIME.md` file in the project or `~/.config/beads/PRIME.md` globally.
+
+### Persistent Memories
+
+Use memories for durable project facts that should survive account rotations and context compaction. Do not use `MEMORY.md` files for this purpose.
+
+```bash
+bd remember "always run auth tests with TEST_DB=postgres"
+bd remember "auth module uses JWT, not server sessions" --key auth-jwt
+bd memories                    # List all memories
+bd memories auth               # Search memory keys and values
+bd recall auth-jwt             # Print one full memory
+bd forget auth-jwt             # Delete one memory
+```
+
+Memories are injected by `bd prime`. For low-token hooks, use `bd prime --memories-only`.
 
 ## Basic Operations
 

--- a/website/docs/cli-reference/prime.md
+++ b/website/docs/cli-reference/prime.md
@@ -27,6 +27,7 @@ Config options:
 	Workflow customization:
 	- Place a .beads/PRIME.md file in the local clone or resolved workspace to override the default output entirely.
 	- Use --export to dump the default content for customization.
+	- Use --memories-only for hook contexts that should inject only persistent memories.
 
 ```
 bd prime [flags]
@@ -35,8 +36,9 @@ bd prime [flags]
 **Flags:**
 
 ```
-      --export    Output default content (ignores PRIME.md override)
-      --full      Force full CLI output (ignore MCP detection)
-      --mcp       Force MCP mode (minimal output)
-      --stealth   Stealth mode (no git operations, flush only)
+      --export          Output default content (ignores PRIME.md override)
+      --full            Force full CLI output (ignore MCP detection)
+      --mcp             Force MCP mode (minimal output)
+      --memories-only   Output only persistent memories for compact hook contexts
+      --stealth         Stealth mode (no git operations, flush only)
 ```

--- a/website/docs/getting-started/ide-setup.md
+++ b/website/docs/getting-started/ide-setup.md
@@ -134,6 +134,15 @@ This outputs a compact (~1-2k tokens) workflow reference including:
 - Current project status
 - Workflow patterns
 - Best practices
+- Persistent memories from `bd remember`
+
+`bd prime` prints memories near the top and starts with a truncation warning. If your host stores the full hook output in a file and only shows a preview, have the agent read the full file before continuing.
+
+For memory-only hooks:
+
+```bash
+bd prime --memories-only
+```
 
 **Why context efficiency matters:**
 - Compute cost scales with tokens

--- a/website/versioned_docs/version-1.0.0/cli-reference/prime.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/prime.md
@@ -27,6 +27,7 @@ Config options:
 	Workflow customization:
 	- Place a .beads/PRIME.md file in the local clone or resolved workspace to override the default output entirely.
 	- Use --export to dump the default content for customization.
+	- Use --memories-only for hook contexts that should inject only persistent memories.
 
 ```
 bd prime [flags]
@@ -35,8 +36,9 @@ bd prime [flags]
 **Flags:**
 
 ```
-      --export    Output default content (ignores PRIME.md override)
-      --full      Force full CLI output (ignore MCP detection)
-      --mcp       Force MCP mode (minimal output)
-      --stealth   Stealth mode (no git operations, flush only)
+      --export          Output default content (ignores PRIME.md override)
+      --full            Force full CLI output (ignore MCP detection)
+      --mcp             Force MCP mode (minimal output)
+      --memories-only   Output only persistent memories for compact hook contexts
+      --stealth         Stealth mode (no git operations, flush only)
 ```


### PR DESCRIPTION
## Summary

Addresses user-facing friction from #3677 and #3683 around `bd prime`, memory visibility, and command documentation.

- Make `bd prime` fail safer under hook-output truncation by putting an explicit truncation directive on the first line.
- Move persistent memories before the long workflow guide in both CLI and MCP prime output so preview caps do not silently hide the highest-value context.
- Add `bd prime --memories-only` for low-token hook contexts that only need durable project memory.
- Document `bd prime`, `bd remember`, `bd memories`, `bd recall`, and `bd forget` in human and plugin-facing CLI references.
- Improve README onboarding by pointing users to `bd setup ...` and providing a copy-paste `AGENTS.md` fallback.

Note: I found no `bd dream` command in the current CLI (`bd --help`), so this does not document it as a real command.

## Validation

- `go test ./internal/templates/agents`
- `CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd`
- `git diff --check`

Full `cmd/bd` tests were not runnable in this environment: cgo builds fail on missing ICU headers (`unicode/uregex.h`), and non-cgo package test compilation hits existing build-tag helper mismatches unrelated to this patch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->