### PR TITLE
feat: add bd unclaim command to release stuck issues

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -497,6 +497,7 @@ git push                    # Push to remote
 - ` + "`bd create --title=\"Summary of this issue\" --description=\"Why this issue exists and what needs to be done\" --type=task|bug|feature --priority=2`" + ` - New issue
   - Priority: 0-4 or P0-P4 (0=critical, 2=medium, 4=backlog). NOT "high"/"medium"/"low"
 - ` + "`bd update <id> --claim`" + ` - Claim work
+- ` + "`bd unclaim <id>`" + ` - Release stuck issue (agent crashed)
 - ` + "`bd update <id> --assignee=username`" + ` - Assign to someone
 - ` + "`bd update <id> --title/--description/--notes/--design`" + ` - Update fields inline
 - ` + "`bd close <id>`" + ` - Mark complete

--- a/cmd/bd/setup/aider.go
+++ b/cmd/bd/setup/aider.go
@@ -32,6 +32,7 @@ This project uses **Beads (bd)** for issue tracking. Aider requires explicit com
 - ` + "`bd list --status=open`" + ` - List all open issues
 - ` + "`bd create --title=\"...\" --type=task`" + ` - Create new issue
 - ` + "`bd update <id> --claim`" + ` - Claim work atomically
+- ` + "`bd unclaim <id>`" + ` - Release stuck issue
 - ` + "`bd close <id>`" + ` - Mark complete
 - ` + "`bd dep add <issue> <depends-on>`" + ` - Add dependency (issue depends on depends-on)
 - ` + "`bd dolt push`" + ` - Push changes to Dolt remote

--- a/cmd/bd/setup/cursor.go
+++ b/cmd/bd/setup/cursor.go
@@ -30,6 +30,7 @@ bd ready                              # Show issues ready to work (no blockers)
 bd list --status=open                 # List all open issues
 bd create --title="..." --type=task  # Create new issue
 bd update <id> --claim               # Claim work atomically
+bd unclaim <id>                    # Release stuck issue (agent crashed)
 bd close <id>                         # Mark complete
 bd dep add <issue> <depends-on>       # Add dependency (issue depends on depends-on)
 bd dolt push                               # Sync with git remote

--- a/cmd/bd/setup/junie.go
+++ b/cmd/bd/setup/junie.go
@@ -39,6 +39,7 @@ bd create "Found bug" --description="Details" --deps discovered-from:bd-42 --jso
 bd update <id> --claim               # Claim work atomically
 bd update <id> --priority 1          # Change priority
 bd close <id> --reason "Completed"   # Mark complete
+bd unclaim <id>                    # Release stuck issue (agent crashed)
 ` + "```" + `
 
 ### Dependencies

--- a/cmd/bd/unclaim.go
+++ b/cmd/bd/unclaim.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var unclaimCmd = &cobra.Command{
+	Use:     "unclaim [id...]",
+	GroupID: "issues",
+	Short:   "Release a claimed issue",
+	Long: `Release a claimed issue by clearing the assignee and resetting status to 'open'.
+
+Use this when an agent crashes mid-work or you need to abandon a claimed task.
+The issue becomes available for re-claiming by other agents.
+
+Examples:
+  bd unclaim bd-123
+  bd unclaim bd-123 --reason "Agent crashed"
+  bd unclaim bd-123 bd-456`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("unclaim")
+		reason, _ := cmd.Flags().GetString("reason")
+		ctx := rootCtx
+
+		unclaimedIssues := []*types.Issue{}
+		hasError := false
+		if store == nil {
+			FatalErrorWithHint("database not initialized",
+				diagHint())
+		}
+		for _, id := range args {
+			// Resolve with prefix routing
+			result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+				hasError = true
+				continue
+			}
+			fullID := result.ResolvedID
+			issueStore := result.Store
+
+			if err := issueStore.UnclaimIssue(ctx, fullID, actor); err != nil {
+				fmt.Fprintf(os.Stderr, "Error unclaiming %s: %v\n", fullID, err)
+				hasError = true
+				result.Close()
+				continue
+			}
+
+			if reason != "" {
+				if _, err := issueStore.AddIssueComment(ctx, fullID, actor, reason); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to add reason comment: %v\n", err)
+				}
+			}
+
+			if jsonOutput {
+				updated, _ := issueStore.GetIssue(ctx, fullID)
+				if updated != nil {
+					unclaimedIssues = append(unclaimedIssues, updated)
+				}
+			} else {
+				reasonMsg := ""
+				if reason != "" {
+					reasonMsg = ": " + reason
+				}
+				fmt.Printf("%s Unclaimed %s%s\n", ui.RenderPass("✓"), fullID, reasonMsg)
+			}
+			result.Close()
+		}
+
+		commandDidWrite.Store(true)
+
+		if jsonOutput && len(unclaimedIssues) > 0 {
+			outputJSON(unclaimedIssues)
+		}
+
+		if hasError {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	unclaimCmd.Flags().StringP("reason", "r", "", "Reason for unclaiming")
+	unclaimCmd.ValidArgsFunction = issueIDCompletion
+	rootCmd.AddCommand(unclaimCmd)
+}

--- a/cmd/bd/unclaim_embedded_test.go
+++ b/cmd/bd/unclaim_embedded_test.go
@@ -1,0 +1,161 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// bdUnclaim runs "bd unclaim" with the given args and returns stdout.
+// Retries on flock contention.
+func bdUnclaim(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"unclaim"}, args...)
+	out, err := bdRunWithFlockRetry(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd unclaim %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+// bdUnclaimFail runs "bd unclaim" expecting failure.
+func bdUnclaimFail(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	fullArgs := append([]string{"unclaim"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected bd unclaim %s to fail, but it succeeded:\n%s", strings.Join(args, " "), out)
+	}
+	return string(out)
+}
+
+func TestEmbeddedUnclaim(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "tu")
+
+	// ===== Basic Success =====
+
+	t.Run("unclaim_from_in_progress", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Unclaim test", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--claim")
+		bdUnclaim(t, bd, dir, issue.ID)
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "" {
+			t.Errorf("expected assignee to be empty after unclaim, got %q", got.Assignee)
+		}
+		if got.Status != types.StatusOpen {
+			t.Errorf("expected status open after unclaim, got %s", got.Status)
+		}
+	})
+
+	t.Run("unclaim_from_open_stuck_claim", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Stuck claim test", "--type", "task")
+		// Manually set assignee without changing status (simulates stuck claim)
+		bdUpdate(t, bd, dir, issue.ID, "--assignee", "alice")
+		bdUnclaim(t, bd, dir, issue.ID)
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "" {
+			t.Errorf("expected assignee to be empty after unclaim, got %q", got.Assignee)
+		}
+		if got.Status != types.StatusOpen {
+			t.Errorf("expected status open after unclaim, got %s", got.Status)
+		}
+	})
+
+	// ===== With Reason =====
+
+	t.Run("unclaim_with_reason", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Reason test", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--claim")
+		out := bdUnclaim(t, bd, dir, issue.ID, "--reason", "Agent crashed")
+		if !strings.Contains(out, "Agent crashed") {
+			t.Errorf("expected reason in output, got: %s", out)
+		}
+		got := bdShow(t, bd, dir, issue.ID)
+		if got.Assignee != "" {
+			t.Errorf("expected assignee to be empty after unclaim, got %q", got.Assignee)
+		}
+		if got.Status != types.StatusOpen {
+			t.Errorf("expected status open after unclaim, got %s", got.Status)
+		}
+	})
+
+	// ===== JSON Output =====
+
+	t.Run("unclaim_json_output", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "JSON test", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--claim")
+		out := bdUnclaim(t, bd, dir, issue.ID, "--json")
+		if !strings.Contains(out, `"assignee":""`) && !strings.Contains(out, `"assignee": null`) {
+			t.Errorf("expected empty assignee in JSON output, got: %s", out)
+		}
+		if !strings.Contains(out, `"status":"open"`) {
+			t.Errorf("expected status open in JSON output, got: %s", out)
+		}
+	})
+
+	// ===== Multiple IDs =====
+
+	t.Run("unclaim_multiple_ids", func(t *testing.T) {
+		issue1 := bdCreate(t, bd, dir, "Multi test 1", "--type", "task")
+		issue2 := bdCreate(t, bd, dir, "Multi test 2", "--type", "task")
+		bdUpdate(t, bd, dir, issue1.ID, "--claim")
+		bdUpdate(t, bd, dir, issue2.ID, "--claim")
+		bdUnclaim(t, bd, dir, issue1.ID, issue2.ID)
+		got1 := bdShow(t, bd, dir, issue1.ID)
+		got2 := bdShow(t, bd, dir, issue2.ID)
+		if got1.Assignee != "" {
+			t.Errorf("expected assignee to be empty for issue1, got %q", got1.Assignee)
+		}
+		if got2.Assignee != "" {
+			t.Errorf("expected assignee to be empty for issue2, got %q", got2.Assignee)
+		}
+		if got1.Status != types.StatusOpen {
+			t.Errorf("expected status open for issue1, got %s", got1.Status)
+		}
+		if got2.Status != types.StatusOpen {
+			t.Errorf("expected status open for issue2, got %s", got2.Status)
+		}
+	})
+
+	// ===== Error Cases =====
+
+	t.Run("unclaim_non_existent_issue", func(t *testing.T) {
+		out := bdUnclaimFail(t, bd, dir, "nonexistent")
+		if !strings.Contains(out, "not found") && !strings.Contains(out, "Error") {
+			t.Errorf("expected error about non-existent issue, got: %s", out)
+		}
+	})
+
+	t.Run("unclaim_closed_issue", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Closed test", "--type", "task")
+		bdUpdate(t, bd, dir, issue.ID, "--claim")
+		// Close the issue first
+		bdClose(t, bd, dir, issue.ID)
+		out := bdUnclaimFail(t, bd, dir, issue.ID)
+		if !strings.Contains(out, "cannot unclaim closed issue") {
+			t.Errorf("expected error about closed issue, got: %s", out)
+		}
+	})
+
+	t.Run("unclaim_unassigned_issue", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "Unassigned test", "--type", "task")
+		out := bdUnclaimFail(t, bd, dir, issue.ID)
+		if !strings.Contains(out, "is not assigned") {
+			t.Errorf("expected error about unassigned issue, got: %s", out)
+		}
+	})
+}

--- a/cmd/bd/unclaim_test.go
+++ b/cmd/bd/unclaim_test.go
@@ -1,0 +1,48 @@
+//go:build cgo
+
+package main
+
+import (
+	"testing"
+)
+
+func TestUnclaimCommand_Structure(t *testing.T) {
+	// Test that the unclaim command is properly registered
+	if unclaimCmd == nil {
+		t.Fatal("unclaimCmd should not be nil")
+	}
+
+	// Test command properties
+	if unclaimCmd.Use != "unclaim [id...]" {
+		t.Errorf("expected Use to be 'unclaim [id...]', got %q", unclaimCmd.Use)
+	}
+
+	if unclaimCmd.GroupID != "issues" {
+		t.Errorf("expected GroupID to be 'issues', got %q", unclaimCmd.GroupID)
+	}
+
+	if unclaimCmd.Short != "Release a claimed issue" {
+		t.Errorf("expected Short to be 'Release a claimed issue', got %q", unclaimCmd.Short)
+	}
+
+	// Test that command requires at least one argument
+	if unclaimCmd.Args == nil {
+		t.Fatal("Args should not be nil")
+	}
+}
+
+func TestUnclaimCommand_Flags(t *testing.T) {
+	// Test that the reason flag is properly defined
+	reasonFlag := unclaimCmd.Flags().Lookup("reason")
+	if reasonFlag == nil {
+		t.Fatal("reason flag should be defined")
+	}
+
+	if reasonFlag.Shorthand != "r" {
+		t.Errorf("expected shorthand 'r', got %q", reasonFlag.Shorthand)
+	}
+
+	if reasonFlag.DefValue != "" {
+		t.Errorf("expected default value '', got %q", reasonFlag.DefValue)
+	}
+}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -122,7 +122,7 @@ bd edit <id> --notes            # Edit notes
 bd edit <id> --acceptance       # Edit acceptance criteria
 ```
 
-### Close/Reopen Issues
+### Close/Reopen/Unclaim Issues
 
 ```bash
 # Complete work (supports multiple IDs)
@@ -130,6 +130,9 @@ bd close <id> [<id>...] --reason "Done" --json
 
 # Reopen closed issues (supports multiple IDs)
 bd reopen <id> [<id>...] --reason "Reopening" --json
+
+# Release a claimed issue (clears assignee, resets status to open)
+bd unclaim <id> [<id>...] --reason "Agent crashed" --json
 ```
 
 ### View Issues

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,6 +9,8 @@
 1. Install `bd` — see [Installation](INSTALLING.md) or the [site installation page](https://gastownhall.github.io/beads/getting-started/installation).
 2. In your project: `bd init`
 3. Create work: `bd create "My task" -p 1` then `bd ready`
+4. Claim work: `bd update <id> --claim`
+5. **Stuck?** If an agent crashes mid-work: `bd unclaim <id>` to release the stuck issue
 
 For dependencies, sync, Notion, migrations, and maintenance, use the [full Quick Start](https://gastownhall.github.io/beads/getting-started/quickstart) linked above.
 

--- a/docs/superpowers/plans/2026-05-03-unclaim-command.md
+++ b/docs/superpowers/plans/2026-05-03-unclaim-command.md
@@ -1,0 +1,729 @@
+# `bd unclaim` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `bd unclaim` command to release stuck claimed issues and improve `bd claim` error messages.
+
+**Architecture:** Storage-layer `UnclaimIssue` method (mirrors `ClaimIssue`) with CLI command following `reopen.go` pattern. Atomic operation clears assignee and resets status to `open`.
+
+**Tech Stack:** Go, Cobra CLI, Dolt SQL database, issueops transaction pattern
+
+---
+
+## File Structure
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `internal/storage/issueops/unclaim.go` | Create | Core unclaim logic in transaction |
+| `internal/storage/issueops/unclaim_test.go` | Create | Unit tests for UnclaimIssueInTx |
+| `internal/storage/storage.go` | Modify | Add UnclaimIssue to Storage interface |
+| `internal/storage/dolt/issues.go` | Modify | DoltStore.UnclaimIssue implementation |
+| `internal/storage/embeddeddolt/issues.go` | Modify | EmbeddedDoltStore.UnclaimIssue implementation |
+| `internal/storage/issueops/claim.go` | Modify | Improve error message for assigned-but-open |
+| `cmd/bd/unclaim.go` | Create | CLI command |
+| `cmd/bd/unclaim_test.go` | Create | CLI integration tests |
+| `cmd/bd/unclaim_embedded_test.go` | Create | Embedded Dolt CLI tests |
+| `cmd/bd/update_embedded_test.go` | Modify | Add claim error guidance test |
+| `docs/CLI_REFERENCE.md` | Modify | Add unclaim documentation |
+| `docs/QUICKSTART.md` | Modify | Add unclaim to workflow |
+| `website/docs/cli-reference/issues.md` | Modify | Add unclaim to website docs |
+| `cmd/bd/prime.go` | Modify | Add unclaim to agent guidance |
+| `cmd/bd/setup/junie.go` | Modify | Add unclaim to setup template |
+| `cmd/bd/setup/aider.go` | Modify | Add unclaim to setup template |
+| `cmd/bd/setup/cursor.go` | Modify | Add unclaim to setup template |
+
+---
+
+## Task 1: Storage Layer — `UnclaimIssueInTx`
+
+**Files:**
+- Create: `internal/storage/issueops/unclaim.go`
+- Create: `internal/storage/issueops/unclaim_test.go`
+
+### Step 1: Write failing tests for UnclaimIssueInTx
+
+Create `internal/storage/issueops/unclaim_test.go`:
+
+```go
+package issueops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestUnclaimIssueInTx_ClearsAssigneeAndStatus(t *testing.T) {
+	// Setup: Create issue with assignee and status=in_progress
+	// Act: Call UnclaimIssueInTx
+	// Assert: assignee="" and status="open"
+}
+
+func TestUnclaimIssueInTx_FromOpenStuckClaim(t *testing.T) {
+	// Setup: Create issue with assignee and status=open (stuck claim)
+	// Act: Call UnclaimIssueInTx
+	// Assert: assignee="" and status="open"
+}
+
+func TestUnclaimIssueInTx_ClosedIssueReturnsError(t *testing.T) {
+	// Setup: Create issue with status=closed
+	// Act: Call UnclaimIssueInTx
+	// Assert: Error contains "cannot unclaim closed issue"
+}
+
+func TestUnclaimIssueInTx_UnassignedIssueReturnsError(t *testing.T) {
+	// Setup: Create issue with no assignee and status=open
+	// Act: Call UnclaimIssueInTx
+	// Assert: Error contains "is not assigned"
+}
+
+func TestUnclaimIssueInTx_RecordsEvent(t *testing.T) {
+	// Setup: Create issue with assignee and status=in_progress
+	// Act: Call UnclaimIssueInTx
+	// Assert: Event recorded with type "unclaimed"
+}
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+go test -tags gms_pure_go -run 'TestUnclaimIssueInTx' ./internal/storage/issueops/...
+```
+
+Expected: FAIL — `UnclaimIssueInTx` not defined
+
+### Step 3: Implement UnclaimIssueInTx
+
+Create `internal/storage/issueops/unclaim.go`:
+
+```go
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// UnclaimIssueInTx atomically unclaims an issue.
+// Sets assignee to "" and status to "open".
+// Records an "unclaimed" event.
+// Only works on issues that have an assignee and status is "open" or "in_progress".
+// Returns error if:
+//   - Issue is closed (cannot unclaim closed issues)
+//   - Issue has no assignee (nothing to unclaim)
+//
+//nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
+func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) error {
+	// Read current issue
+	issueTable := "issues"
+	eventTable := "events"
+
+	oldIssue, err := GetIssueInTx(ctx, tx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get issue for unclaim: %w", err)
+	}
+
+	// Validate: cannot unclaim closed issues
+	if oldIssue.Status == types.StatusClosed {
+		return fmt.Errorf("cannot unclaim closed issue %s", id)
+	}
+
+	// Validate: must have an assignee to unclaim
+	if oldIssue.Assignee == "" {
+		return fmt.Errorf("issue %s is not assigned", id)
+	}
+
+	now := time.Now().UTC()
+
+	// Atomic UPDATE: clear assignee and reset status to open
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET assignee = '', status = 'open', updated_at = ?
+		WHERE id = ? AND assignee != '' AND status IN ('open', 'in_progress')
+	`, issueTable), now, id)
+	if err != nil {
+		return fmt.Errorf("failed to unclaim issue: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("failed to unclaim issue %s: no matching row", id)
+	}
+
+	// Record the unclaim event
+	oldData, _ := json.Marshal(oldIssue)
+	newUpdates := map[string]interface{}{
+		"assignee": "",
+		"status":   "open",
+	}
+	newData, _ := json.Marshal(newUpdates)
+
+	if err := RecordFullEventInTable(ctx, tx, eventTable, id, "unclaimed", actor, string(oldData), string(newData)); err != nil {
+		return fmt.Errorf("failed to record unclaim event: %w", err)
+	}
+
+	return nil
+}
+```
+
+### Step 4: Run tests to verify they pass
+
+```bash
+go test -tags gms_pure_go -run 'TestUnclaimIssueInTx' ./internal/storage/issueops/...
+```
+
+Expected: PASS
+
+### Step 5: Commit
+
+```bash
+git add internal/storage/issueops/unclaim.go internal/storage/issueops/unclaim_test.go
+git commit -m "feat: add UnclaimIssueInTx storage operation"
+```
+
+---
+
+## Task 2: Storage Interface + Dolt Implementation
+
+**Files:**
+- Modify: `internal/storage/storage.go`
+- Modify: `internal/storage/dolt/issues.go`
+
+### Step 1: Add UnclaimIssue to Storage interface
+
+In `internal/storage/storage.go`, add to the `Storage` interface:
+
+```go
+type Storage interface {
+	// ... existing methods ...
+	UnclaimIssue(ctx context.Context, id string, actor string) error
+}
+```
+
+### Step 2: Implement DoltStore.UnclaimIssue
+
+In `internal/storage/dolt/issues.go`, add after `ClaimIssue`:
+
+```go
+// UnclaimIssue atomically unclaims an issue by clearing the assignee
+// and resetting status to "open". Records an "unclaimed" event.
+// Delegates SQL work to issueops.UnclaimIssueInTx; handles Dolt-specific concerns
+// (DOLT_ADD/COMMIT, cache invalidation).
+func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := issueops.UnclaimIssueInTx(ctx, tx, id, actor); err != nil {
+		return err
+	}
+
+	// Dolt versioning for permanent issues.
+	for _, table := range []string{"issues", "events"} {
+		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+	}
+	commitMsg := fmt.Sprintf("bd: unclaim %s", id)
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+		return fmt.Errorf("dolt commit: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return wrapTransactionError("commit unclaim issue", err)
+	}
+	// Unclaiming changes status to open, affecting blocked ID computation
+	s.invalidateBlockedIDsCache()
+	return nil
+}
+```
+
+### Step 3: Build to verify compilation
+
+```bash
+go build ./internal/storage/...
+```
+
+Expected: SUCCESS
+
+### Step 4: Commit
+
+```bash
+git add internal/storage/storage.go internal/storage/dolt/issues.go
+git commit -m "feat: add UnclaimIssue to Storage interface and DoltStore"
+```
+
+---
+
+## Task 3: Embedded Dolt Implementation
+
+**Files:**
+- Modify: `internal/storage/embeddeddolt/issues.go`
+
+### Step 1: Implement EmbeddedDoltStore.UnclaimIssue
+
+In `internal/storage/embeddeddolt/issues.go`, add after `ClaimIssue`:
+
+```go
+// UnclaimIssue atomically unclaims an issue by clearing the assignee
+// and resetting status to "open". Records an "unclaimed" event.
+// Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
+func (s *EmbeddedDoltStore) UnclaimIssue(ctx context.Context, id string, actor string) error {
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		return issueops.UnclaimIssueInTx(ctx, tx, id, actor)
+	})
+}
+```
+
+### Step 2: Build to verify compilation
+
+```bash
+go build ./internal/storage/...
+```
+
+Expected: SUCCESS
+
+### Step 3: Commit
+
+```bash
+git add internal/storage/embeddeddolt/issues.go
+git commit -m "feat: add UnclaimIssue to EmbeddedDoltStore"
+```
+
+---
+
+## Task 4: Improve Claim Error Message
+
+**Files:**
+- Modify: `internal/storage/issueops/claim.go`
+
+### Step 1: Update error message in ClaimIssueInTx
+
+In `internal/storage/issueops/claim.go`, find the error handling block (around line 90-93):
+
+```go
+// Current code:
+if assignee != "" && assignee != actor {
+    return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
+}
+```
+
+Change to:
+
+```go
+if assignee != "" && assignee != actor {
+    if currentStatus == types.StatusOpen {
+        return nil, fmt.Errorf("issue already assigned to %q. Use `bd unclaim %s` to release it before re-claiming", assignee, id)
+    }
+    return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
+}
+```
+
+### Step 2: Run existing claim tests
+
+```bash
+go test -tags gms_pure_go -run 'TestClaim' ./internal/storage/issueops/...
+```
+
+Expected: PASS (existing tests still pass)
+
+### Step 3: Commit
+
+```bash
+git add internal/storage/issueops/claim.go
+git commit -m "feat: improve claim error message for assigned-but-open issues"
+```
+
+---
+
+## Task 5: CLI Command — `bd unclaim`
+
+**Files:**
+- Create: `cmd/bd/unclaim.go`
+
+### Step 1: Create unclaim.go command
+
+Create `cmd/bd/unclaim.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var unclaimCmd = &cobra.Command{
+	Use:     "unclaim [id...]",
+	GroupID: "issues",
+	Short:   "Release a claimed issue",
+	Long: `Release a claimed issue by clearing the assignee and resetting status to 'open'.
+
+Use this when an agent crashes mid-work or you need to abandon a claimed task.
+The issue becomes available for re-claiming by other agents.
+
+Examples:
+  bd unclaim bd-123
+  bd unclaim bd-123 --reason "Agent crashed"
+  bd unclaim bd-123 bd-456`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("unclaim")
+		reason, _ := cmd.Flags().GetString("reason")
+		ctx := rootCtx
+
+		unclaimedIssues := []*types.Issue{}
+		hasError := false
+		if store == nil {
+			FatalErrorWithHint("database not initialized",
+				diagHint())
+		}
+		for _, id := range args {
+			// Resolve with prefix routing
+			result, err := resolveAndGetIssueWithRouting(ctx, store, id)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error resolving %s: %v\n", id, err)
+				hasError = true
+				continue
+			}
+			fullID := result.ResolvedID
+			issueStore := result.Store
+
+			if err := issueStore.UnclaimIssue(ctx, fullID, actor); err != nil {
+				fmt.Fprintf(os.Stderr, "Error unclaiming %s: %v\n", fullID, err)
+				hasError = true
+				result.Close()
+				continue
+			}
+
+			if reason != "" {
+				if err := issueStore.AddIssueComment(ctx, fullID, actor, reason); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to add reason comment: %v\n", err)
+				}
+			}
+
+			if jsonOutput {
+				updated, _ := issueStore.GetIssue(ctx, fullID)
+				if updated != nil {
+					unclaimedIssues = append(unclaimedIssues, updated)
+				}
+			} else {
+				reasonMsg := ""
+				if reason != "" {
+					reasonMsg = ": " + reason
+				}
+				fmt.Printf("%s Unclaimed %s%s\n", ui.RenderPass("✓"), fullID, reasonMsg)
+			}
+			result.Close()
+		}
+
+		commandDidWrite.Store(true)
+
+		if jsonOutput && len(unclaimedIssues) > 0 {
+			outputJSON(unclaimedIssues)
+		}
+
+		if hasError {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	unclaimCmd.Flags().StringP("reason", "r", "", "Reason for unclaiming")
+	unclaimCmd.ValidArgsFunction = issueIDCompletion
+	rootCmd.AddCommand(unclaimCmd)
+}
+```
+
+### Step 2: Build to verify compilation
+
+```bash
+go build ./cmd/bd/...
+```
+
+Expected: SUCCESS
+
+### Step 3: Commit
+
+```bash
+git add cmd/bd/unclaim.go
+git commit -m "feat: add bd unclaim CLI command"
+```
+
+---
+
+## Task 6: CLI Tests
+
+**Files:**
+- Create: `cmd/bd/unclaim_test.go`
+- Create: `cmd/bd/unclaim_embedded_test.go`
+
+### Step 1: Create unclaim_test.go
+
+Create `cmd/bd/unclaim_test.go`:
+
+```go
+package main
+
+import (
+	"testing"
+)
+
+func TestUnclaim_BasicSuccess(t *testing.T) {
+	// Setup: Create issue, claim it
+	// Act: bd unclaim <id>
+	// Assert: Success output, assignee cleared, status=open
+}
+
+func TestUnclaim_FromOpenStuckClaim(t *testing.T) {
+	// Setup: Create issue, set assignee manually, status=open
+	// Act: bd unclaim <id>
+	// Assert: Success output, assignee cleared, status=open
+}
+
+func TestUnclaim_WithReason(t *testing.T) {
+	// Setup: Create issue, claim it
+	// Act: bd unclaim <id> --reason "Agent crashed"
+	// Assert: Success output includes reason, comment recorded
+}
+
+func TestUnclaim_JSONOutput(t *testing.T) {
+	// Setup: Create issue, claim it
+	// Act: bd unclaim <id> --json
+	// Assert: Valid JSON output with updated issue
+}
+
+func TestUnclaim_MultipleIDs(t *testing.T) {
+	// Setup: Create two issues, claim both
+	// Act: bd unclaim <id1> <id2>
+	// Assert: Both unclaimed successfully
+}
+
+func TestUnclaim_NonExistentIssue(t *testing.T) {
+	// Act: bd unclaim nonexistent
+	// Assert: Error output
+}
+
+func TestUnclaim_ClosedIssue(t *testing.T) {
+	// Setup: Create issue, close it
+	// Act: bd unclaim <id>
+	// Assert: Error about closed issue
+}
+
+func TestUnclaim_UnassignedIssue(t *testing.T) {
+	// Setup: Create issue (no assignee)
+	// Act: bd unclaim <id>
+	// Assert: Error about not assigned
+}
+```
+
+### Step 2: Create unclaim_embedded_test.go
+
+Create `cmd/bd/unclaim_embedded_test.go` with same test scenarios using embedded Dolt backend.
+
+### Step 3: Run tests
+
+```bash
+go test -tags gms_pure_go -run 'TestUnclaim' ./cmd/bd/...
+```
+
+Expected: PASS
+
+### Step 4: Commit
+
+```bash
+git add cmd/bd/unclaim_test.go cmd/bd/unclaim_embedded_test.go
+git commit -m "test: add tests for bd unclaim command"
+```
+
+---
+
+## Task 7: Claim Error Guidance Test
+
+**Files:**
+- Modify: `cmd/bd/update_embedded_test.go`
+
+### Step 1: Add test for claim error guidance
+
+In `cmd/bd/update_embedded_test.go`, add:
+
+```go
+func TestClaim_AssignedButOpen_ReturnsGuidance(t *testing.T) {
+	// Setup: Create issue, manually set assignee, status=open
+	// Act: bd update <id> --claim (with different actor)
+	// Assert: Error contains "Use `bd unclaim"
+}
+```
+
+### Step 2: Run test
+
+```bash
+go test -tags gms_pure_go -run 'TestClaim_AssignedButOpen' ./cmd/bd/...
+```
+
+Expected: PASS
+
+### Step 3: Commit
+
+```bash
+git add cmd/bd/update_embedded_test.go
+git commit -m "test: add test for claim error guidance on assigned-but-open issues"
+```
+
+---
+
+## Task 8: Documentation Updates
+
+**Files:**
+- Modify: `docs/CLI_REFERENCE.md`
+- Modify: `docs/QUICKSTART.md`
+- Modify: `website/docs/cli-reference/issues.md`
+- Modify: `cmd/bd/prime.go`
+- Modify: `cmd/bd/setup/junie.go`
+- Modify: `cmd/bd/setup/aider.go`
+- Modify: `cmd/bd/setup/cursor.go`
+
+### Step 1: Update CLI_REFERENCE.md
+
+Add `bd unclaim` section after `bd reopen`:
+
+```markdown
+### bd unclaim
+
+Release a claimed issue by clearing the assignee and resetting status to 'open'.
+
+**Usage:** `bd unclaim <id> [id...] [--reason "reason"]`
+
+**Flags:**
+- `--reason, -r` — Reason for unclaiming
+
+**Examples:**
+```bash
+bd unclaim bd-123
+bd unclaim bd-123 --reason "Agent crashed"
+bd unclaim bd-123 bd-456
+```
+
+**When to use:**
+- Agent crashed mid-work
+- Need to abandon a claimed task
+- Issue is stuck with assignee but status is open
+```
+
+### Step 2: Update QUICKSTART.md
+
+Add unclaim to workflow section:
+
+```markdown
+**Stuck issue?** If an agent crashes mid-work:
+```bash
+bd unclaim <id>  # Release the stuck issue
+bd ready          # Find available work
+```
+```
+
+### Step 3: Update website docs
+
+In `website/docs/cli-reference/issues.md`, add unclaim command documentation.
+
+### Step 4: Update prime.go
+
+In `cmd/bd/prime.go`, add to agent guidance:
+
+```markdown
+- `bd unclaim <id>` — Release a stuck claimed issue
+```
+
+### Step 5: Update setup templates
+
+In `cmd/bd/setup/junie.go`, `aider.go`, `cursor.go`, add:
+
+```markdown
+bd unclaim <id>               # Release stuck issue
+```
+
+### Step 6: Commit
+
+```bash
+git add docs/CLI_REFERENCE.md docs/QUICKSTART.md website/docs/cli-reference/issues.md cmd/bd/prime.go cmd/bd/setup/junie.go cmd/bd/setup/aider.go cmd/bd/setup/cursor.go
+git commit -m "docs: add bd unclaim command documentation"
+```
+
+---
+
+## Task 9: Final Verification
+
+### Step 1: Run full test suite
+
+```bash
+make test
+```
+
+Expected: ALL PASS
+
+### Step 2: Run linter
+
+```bash
+golangci-lint run ./...
+```
+
+Expected: No new warnings
+
+### Step 3: Build binary
+
+```bash
+make install
+```
+
+Expected: SUCCESS
+
+### Step 4: Manual smoke test
+
+```bash
+bd init --prefix test-unclaim
+bd create "Test unclaim issue" -p 1
+bd update <id> --claim
+bd unclaim <id>
+bd show <id>  # Verify assignee="" and status=open
+```
+
+### Step 5: Final commit (if any fixes needed)
+
+```bash
+git add -A
+git commit -m "fix: address final verification issues"
+```
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] `bd unclaim <id>` clears assignee and sets status to open (from in_progress)
+- [ ] `bd unclaim <id>` clears assignee and sets status to open (from open — stuck claim)
+- [ ] `bd unclaim <id>` returns error if issue is closed
+- [ ] `bd unclaim <id>` returns error if issue has no assignee
+- [ ] `bd unclaim <id> --reason "reason"` records the reason
+- [ ] `bd unclaim <id> --json` outputs JSON
+- [ ] `bd unclaim` with multiple IDs works
+- [ ] `bd claim` on assigned-but-open issue returns guidance message
+- [ ] Documentation updated for unclaim command
+- [ ] Documentation updated for claim command with alert about unclaim
+- [ ] All tests pass
+- [ ] Linter passes
+- [ ] Binary builds successfully

--- a/docs/superpowers/specs/2026-05-03-unclaim-command-design.md
+++ b/docs/superpowers/specs/2026-05-03-unclaim-command-design.md
@@ -1,0 +1,194 @@
+# Design: `bd unclaim` Command
+
+**Issue:** gastownhall/beads#3693
+**Date:** 2026-05-03
+**Status:** Draft
+
+## Problem
+
+When an agent crashes mid-work, the issue gets stuck with:
+- `assignee` set to the crashed agent
+- `status` = `in_progress`
+
+To re-claim the issue, users must manually:
+1. Remove the assignee (`bd assign <id> ""`)
+2. Change status to open (`bd update <id> --status open`)
+
+This is error-prone and undocumented. Additionally, `bd claim` silently fails when an issue has an assignee but status is `open` (a different stuck state), with no guidance on how to fix it.
+
+## Solution
+
+Add a `bd unclaim` command that atomically:
+1. Clears the assignee (sets to empty string)
+2. Resets status to `open`
+3. Records an `"unclaimed"` event
+
+Also improve `bd claim` error messages to guide users toward `bd unclaim` when they encounter stuck issues.
+
+## Design Decisions
+
+### Command Placement
+**Decision:** Standalone top-level command (`bd unclaim <id>`)
+
+**Rationale:** Cleaner UX than a flag on `bd update`. Mirrors `bd reopen` pattern. Easier to discover.
+
+### Scope
+**Decision:** Regular issues only (no wisp support)
+
+**Rationale:** Wisps are ephemeral and less likely to get stuck. Wisp support can be added later if needed.
+
+### Atomicity
+**Decision:** Storage-layer `UnclaimIssue` method with transaction semantics
+
+**Rationale:** Consistent with `ClaimIssue` pattern. Ensures both fields are updated atomically with event recording.
+
+## Implementation
+
+### 1. Storage Layer
+
+#### New file: `internal/storage/issueops/unclaim.go`
+
+```go
+package issueops
+
+// UnclaimIssueInTx atomically unclaims an issue.
+// Sets assignee to "" and status to "open".
+// Records an "unclaimed" event.
+// Only works on issues that have an assignee and status is "open" or "in_progress".
+// Returns error if:
+//   - Issue is closed (cannot unclaim closed issues)
+//   - Issue has no assignee (nothing to unclaim)
+func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) error {
+    // 1. Read current issue for event recording
+    // 2. If status is "closed", return error: "cannot unclaim closed issue %s"
+    // 3. If assignee is empty/null, return error: "issue %s is not assigned"
+    // 4. UPDATE issues SET assignee = '', status = 'open', updated_at = ? WHERE id = ?
+    // 5. Record "unclaimed" event
+}
+```
+
+#### Storage interface addition: `internal/storage/storage.go`
+
+```go
+type Storage interface {
+    // ... existing methods ...
+    UnclaimIssue(ctx context.Context, id string, actor string) error
+}
+```
+
+#### Dolt implementation: `internal/storage/dolt/issues.go`
+
+```go
+func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string) error {
+    // 1. Begin transaction
+    // 2. Call issueops.UnclaimIssueInTx
+    // 3. DOLT_ADD/COMMIT
+    // 4. Invalidate blocked IDs cache
+}
+```
+
+#### Embedded Dolt implementation: `internal/storage/embeddeddolt/issues.go`
+
+```go
+func (s *EmbeddedDoltStore) UnclaimIssue(ctx context.Context, id string, actor string) error {
+    // Same pattern as DoltStore
+}
+```
+
+### 2. CLI Command
+
+#### New file: `cmd/bd/unclaim.go`
+
+```go
+var unclaimCmd = &cobra.Command{
+    Use:     "unclaim [id...]",
+    GroupID: "issues",
+    Short:   "Release a claimed issue",
+    Long: `Release a claimed issue by clearing the assignee and resetting status to 'open'.
+
+Use this when an agent crashes mid-work or you need to abandon a claimed task.
+The issue becomes available for re-claiming by other agents.
+
+Examples:
+  bd unclaim bd-123
+  bd unclaim bd-123 --reason "Agent crashed"
+  bd unclaim bd-123 bd-456`,
+    Args: cobra.MinimumNArgs(1),
+    Run: func(cmd *cobra.Command, args []string) {
+        // For each ID:
+        //   1. Resolve issue
+        //   2. Call issueStore.UnclaimIssue
+        //   3. Output: "✓ Unclaimed bd-123" (or with reason)
+        //   4. Support --json flag
+    },
+}
+```
+
+### 3. Claim Error Enhancement
+
+#### Modified: `internal/storage/issueops/claim.go`
+
+In `ClaimIssueInTx`, when `rowsAffected == 0`:
+
+```go
+if assignee != "" && currentStatus == types.StatusOpen {
+    return nil, fmt.Errorf(
+        "issue already assigned to %q. Use `bd unclaim %s` to release it before re-claiming",
+        assignee, id,
+    )
+}
+```
+
+### 4. Documentation Updates
+
+| File | Change |
+|------|--------|
+| `docs/CLI_REFERENCE.md` | Add `bd unclaim` command reference |
+| `docs/QUICKSTART.md` | Add unclaim to workflow examples |
+| `website/docs/cli-reference/issues.md` | Add unclaim to website docs |
+| `cmd/bd/prime.go` | Add unclaim to agent guidance output |
+| `cmd/bd/setup/junie.go` | Add unclaim to setup template |
+| `cmd/bd/setup/aider.go` | Add unclaim to setup template |
+| `cmd/bd/setup/cursor.go` | Add unclaim to setup template |
+
+### 5. Testing
+
+#### New file: `internal/storage/issueops/unclaim_test.go`
+
+- Test unclaim clears assignee and sets status to open (from in_progress)
+- Test unclaim clears assignee and sets status to open (from open — stuck claim)
+- Test unclaim on closed issue returns error
+- Test unclaim on unassigned issue returns error
+- Test event recording
+
+#### New file: `cmd/bd/unclaim_test.go`
+
+- Test `bd unclaim bd-123` succeeds (from in_progress)
+- Test `bd unclaim bd-123` succeeds (from open — stuck claim)
+- Test `bd unclaim bd-123 --reason "crashed"` records reason
+- Test `bd unclaim bd-123 --json` outputs JSON
+- Test `bd unclaim` with multiple IDs
+- Test error on non-existent issue
+- Test error on closed issue
+- Test error on unassigned issue
+
+#### New file: `cmd/bd/unclaim_embedded_test.go`
+
+- Same scenarios with embedded Dolt backend
+
+#### Update: `cmd/bd/update_embedded_test.go`
+
+- Test that claiming an assigned-but-open issue returns guidance message
+
+## Acceptance Criteria
+
+- [ ] `bd unclaim <id>` clears assignee and sets status to open (from in_progress or open)
+- [ ] `bd unclaim <id>` returns error if issue is closed
+- [ ] `bd unclaim <id>` returns error if issue has no assignee
+- [ ] `bd unclaim <id> --reason "reason"` records the reason
+- [ ] `bd unclaim <id> --json` outputs JSON
+- [ ] `bd unclaim` with multiple IDs works
+- [ ] `bd claim` on assigned-but-open issue returns guidance message
+- [ ] Documentation updated for unclaim command
+- [ ] Documentation updated for claim command with alert about unclaim
+- [ ] All tests pass

--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -620,8 +620,9 @@ func (s *configStore) SlotSet(_ context.Context, _, _, _, _ string) error    { r
 func (s *configStore) SlotGet(_ context.Context, _, _ string) (string, error) {
 	return "", nil
 }
-func (s *configStore) SlotClear(_ context.Context, _, _, _ string) error { return nil }
-func (s *configStore) Close() error                                      { return nil }
+func (s *configStore) SlotClear(_ context.Context, _, _, _ string) error        { return nil }
+func (s *configStore) Close() error                                             { return nil }
+func (s *configStore) UnclaimIssue(_ context.Context, _ string, _ string) error { return nil }
 
 func TestFetchIssuesIncludesPullJQLInQuery(t *testing.T) {
 	var capturedJQL string

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -264,6 +264,39 @@ func (s *DoltStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter
 	return claimed, nil
 }
 
+// UnclaimIssue atomically unclaims an issue by clearing the assignee
+// and resetting status to "open". Records an "unclaimed" event.
+// Delegates SQL work to issueops.UnclaimIssueInTx; handles Dolt-specific concerns
+// (DOLT_ADD/COMMIT, cache invalidation).
+func (s *DoltStore) UnclaimIssue(ctx context.Context, id string, actor string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := issueops.UnclaimIssueInTx(ctx, tx, id, actor); err != nil {
+		return err
+	}
+
+	// Dolt versioning for permanent issues.
+	for _, table := range []string{"issues", "events"} {
+		_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
+	}
+	commitMsg := fmt.Sprintf("bd: unclaim %s", id)
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+		return fmt.Errorf("dolt commit: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return wrapTransactionError("commit unclaim issue", err)
+	}
+	// Unclaiming changes status to open, affecting blocked ID computation
+	s.invalidateBlockedIDsCache()
+	return nil
+}
+
 // ReopenIssue reopens a closed issue, setting status to open and clearing
 // closed_at and defer_until. If reason is non-empty, it is recorded as a comment.
 // Wraps UpdateIssue for Dolt-specific concerns (wisp routing, DOLT_COMMIT, etc.).

--- a/internal/storage/embeddeddolt/issues.go
+++ b/internal/storage/embeddeddolt/issues.go
@@ -33,6 +33,15 @@ func (s *EmbeddedDoltStore) ClaimReadyIssue(ctx context.Context, filter types.Wo
 	return claimed, err
 }
 
+// UnclaimIssue atomically unclaims an issue by clearing the assignee
+// and resetting status to "open". Records an "unclaimed" event.
+// Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
+func (s *EmbeddedDoltStore) UnclaimIssue(ctx context.Context, id string, actor string) error {
+	return s.withConn(ctx, true, func(tx *sql.Tx) error {
+		return issueops.UnclaimIssueInTx(ctx, tx, id, actor)
+	})
+}
+
 // UpdateIssue updates fields on an issue.
 // Delegates SQL work to issueops; EmbeddedDolt auto-commits the transaction.
 func (s *EmbeddedDoltStore) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {

--- a/internal/storage/issueops/claim.go
+++ b/internal/storage/issueops/claim.go
@@ -88,6 +88,9 @@ func ClaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) (*
 			return &ClaimResult{OldIssue: oldIssue, IsWisp: isWisp}, nil
 		}
 		if assignee != "" && assignee != actor {
+			if currentStatus == types.StatusOpen {
+				return nil, fmt.Errorf("issue already assigned to %q. Use `bd unclaim %s` to release it before re-claiming", assignee, id)
+			}
 			return nil, fmt.Errorf("%w by %s", storage.ErrAlreadyClaimed, assignee)
 		}
 		return nil, fmt.Errorf("%w: status %s", storage.ErrNotClaimable, currentStatus)

--- a/internal/storage/issueops/unclaim.go
+++ b/internal/storage/issueops/unclaim.go
@@ -1,0 +1,76 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// UnclaimIssueInTx atomically unclaims an issue.
+// Sets assignee to "" and status to "open".
+// Records an "unclaimed" event.
+// Only works on issues that have an assignee and status is "open" or "in_progress".
+// Returns error if:
+//   - Issue is closed (cannot unclaim closed issues)
+//   - Issue has no assignee (nothing to unclaim)
+//
+//nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
+func UnclaimIssueInTx(ctx context.Context, tx *sql.Tx, id string, actor string) error {
+	// Read current issue
+	issueTable := "issues"
+	eventTable := "events"
+
+	oldIssue, err := GetIssueInTx(ctx, tx, id)
+	if err != nil {
+		return fmt.Errorf("failed to get issue for unclaim: %w", err)
+	}
+
+	// Validate: cannot unclaim closed issues
+	if oldIssue.Status == types.StatusClosed {
+		return fmt.Errorf("cannot unclaim closed issue %s", id)
+	}
+
+	// Validate: must have an assignee to unclaim
+	if oldIssue.Assignee == "" {
+		return fmt.Errorf("issue %s is not assigned", id)
+	}
+
+	now := time.Now().UTC()
+
+	// Atomic UPDATE: clear assignee and reset status to open
+	result, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s
+		SET assignee = '', status = 'open', updated_at = ?
+		WHERE id = ? AND assignee != '' AND status IN ('open', 'in_progress')
+	`, issueTable), now, id)
+	if err != nil {
+		return fmt.Errorf("failed to unclaim issue: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("failed to unclaim issue %s: no matching row", id)
+	}
+
+	// Record the unclaim event
+	oldData, _ := json.Marshal(oldIssue)
+	newUpdates := map[string]interface{}{
+		"assignee": "",
+		"status":   "open",
+	}
+	newData, _ := json.Marshal(newUpdates)
+
+	if err := RecordFullEventInTable(ctx, tx, eventTable, id, "unclaimed", actor, string(oldData), string(newData)); err != nil {
+		return fmt.Errorf("failed to record unclaim event: %w", err)
+	}
+
+	return nil
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -45,6 +45,7 @@ type Storage interface {
 	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
 	UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error
 	ReopenIssue(ctx context.Context, id string, reason string, actor string) error
+	UnclaimIssue(ctx context.Context, id string, actor string) error
 	UpdateIssueType(ctx context.Context, id string, issueType string, actor string) error
 	CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error
 	DeleteIssue(ctx context.Context, id string) error

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -151,6 +151,17 @@ func (s *InstrumentedStorage) ReopenIssue(ctx context.Context, id string, reason
 	return err
 }
 
+func (s *InstrumentedStorage) UnclaimIssue(ctx context.Context, id string, actor string) error {
+	attrs := []attribute.KeyValue{
+		attribute.String("bd.issue.id", id),
+		attribute.String("bd.actor", actor),
+	}
+	ctx, span, t := s.op(ctx, "UnclaimIssue", attrs...)
+	err := s.inner.UnclaimIssue(ctx, id, actor)
+	s.done(ctx, span, t, err, attrs...)
+	return err
+}
+
 func (s *InstrumentedStorage) UpdateIssueType(ctx context.Context, id string, issueType string, actor string) error {
 	attrs := []attribute.KeyValue{
 		attribute.String("bd.issue.id", id),


### PR DESCRIPTION
## Summary

- Add `bd unclaim <id>` command that atomically clears assignee and resets status to 'open'
- Useful when an agent crashes mid-work and the issue gets stuck with an assignee
- Improve `bd claim` error message when issue has assignee but status is 'open' (now suggests using `bd unclaim`)

Closes gastownhall/beads#3693

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->