### PR TITLE
fix(mol): clear root Ephemeral on bd mol squash

### DIFF
--- a/cmd/bd/mol_squash.go
+++ b/cmd/bd/mol_squash.go
@@ -282,6 +282,10 @@ func squashMolecule(ctx context.Context, s storage.DoltStorage, root *types.Issu
 			if err := tx.CloseIssue(ctx, root.ID, reason, actorName, ""); err != nil {
 				return fmt.Errorf("failed to close wisp root %s: %w", root.ID, err)
 			}
+			// Clear ephemeral so the closed root stops being re-emitted by every wisp-table export cycle.
+			if err := tx.UpdateIssue(ctx, root.ID, map[string]interface{}{"wisp": false}, actorName); err != nil {
+				return fmt.Errorf("failed to clear ephemeral flag on root %s: %w", root.ID, err)
+			}
 			result.WispSquash = true
 		}
 

--- a/cmd/bd/mol_squash_embedded_test.go
+++ b/cmd/bd/mol_squash_embedded_test.go
@@ -1,0 +1,83 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedSquashWispMoleculeClearsRootEphemeral mirrors
+// TestSquashWispMoleculeClearsRootEphemeral but runs against the embedded
+// Dolt backend used by CI. Without this, the standalone-Dolt regression test
+// skips in the Embedded Dolt CI tier and the fix's lines stay uncovered.
+func TestEmbeddedSquashWispMoleculeClearsRootEphemeral(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt integration tests")
+	}
+
+	ctx := context.Background()
+	beadsDir := t.TempDir()
+
+	s, err := embeddeddolt.Open(ctx, beadsDir, "moltest", "main")
+	if err != nil {
+		t.Fatalf("embeddeddolt.Open: %v", err)
+	}
+	defer s.Close()
+
+	if err := s.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	root := &types.Issue{
+		Title:     "Wisp Molecule Root",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+		Ephemeral: true,
+	}
+	if err := s.CreateIssue(ctx, root, "test"); err != nil {
+		t.Fatalf("CreateIssue root: %v", err)
+	}
+
+	child := &types.Issue{
+		Title:     "Wisp Step",
+		Status:    types.StatusClosed,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := s.CreateIssue(ctx, child, "test"); err != nil {
+		t.Fatalf("CreateIssue child: %v", err)
+	}
+	if err := s.AddDependency(ctx, &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: root.ID,
+		Type:        types.DepParentChild,
+	}, "test"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	result, err := squashMolecule(ctx, s, root, []*types.Issue{child}, false, "", "test")
+	if err != nil {
+		t.Fatalf("squashMolecule: %v", err)
+	}
+	if !result.WispSquash {
+		t.Error("expected WispSquash=true for ephemeral root")
+	}
+
+	closed, err := s.GetIssue(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("GetIssue root after squash: %v", err)
+	}
+	if closed.Status != types.StatusClosed {
+		t.Errorf("root status = %v, want closed", closed.Status)
+	}
+	if closed.Ephemeral {
+		t.Error("root Ephemeral should be false after squash; closed wisp roots otherwise leak as duplicate JSONL rows on every export cycle")
+	}
+}

--- a/cmd/bd/mol_test.go
+++ b/cmd/bd/mol_test.go
@@ -746,6 +746,73 @@ func TestSquashMoleculeWithAgentSummary(t *testing.T) {
 	}
 }
 
+// TestSquashWispMoleculeClearsRootEphemeral verifies that squashing a wisp
+// molecule (root with Ephemeral=true) clears the root's Ephemeral flag in
+// addition to auto-closing it. Without this, auto-export keeps re-emitting
+// the closed root as ephemeral=true on every export cycle, accumulating
+// duplicate JSONL rows.
+func TestSquashWispMoleculeClearsRootEphemeral(t *testing.T) {
+	ctx := context.Background()
+	dbPath := t.TempDir() + "/test.db"
+	s, err := dolt.New(ctx, &dolt.Config{Path: dbPath})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	defer s.Close()
+	if err := s.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	// Wisp molecule: root is ephemeral too (created via `bd mol wisp`).
+	root := &types.Issue{
+		Title:     "Wisp Molecule Root",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+		Ephemeral: true,
+	}
+	if err := s.CreateIssue(ctx, root, "test"); err != nil {
+		t.Fatalf("Failed to create ephemeral root: %v", err)
+	}
+
+	child := &types.Issue{
+		Title:     "Wisp Step",
+		Status:    types.StatusClosed,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := s.CreateIssue(ctx, child, "test"); err != nil {
+		t.Fatalf("Failed to create child: %v", err)
+	}
+	if err := s.AddDependency(ctx, &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: root.ID,
+		Type:        types.DepParentChild,
+	}, "test"); err != nil {
+		t.Fatalf("Failed to add dependency: %v", err)
+	}
+
+	result, err := squashMolecule(ctx, s, root, []*types.Issue{child}, false, "", "test")
+	if err != nil {
+		t.Fatalf("squashMolecule failed: %v", err)
+	}
+	if !result.WispSquash {
+		t.Error("expected WispSquash=true for ephemeral root")
+	}
+
+	closed, err := s.GetIssue(ctx, root.ID)
+	if err != nil {
+		t.Fatalf("Failed to get root after squash: %v", err)
+	}
+	if closed.Status != types.StatusClosed {
+		t.Errorf("root status = %v, want closed", closed.Status)
+	}
+	if closed.Ephemeral {
+		t.Errorf("root Ephemeral should be false after squash, got true (issue: closed wisp roots leak as duplicate JSONL rows on every export)")
+	}
+}
+
 // =============================================================================
 // Spawn --attach Tests (bd-f7p1)
 // =============================================================================


### PR DESCRIPTION
## Summary

- `bd mol squash` auto-closes a wisp molecule's root but never clears its `Ephemeral` flag, contradicting the wisp lifecycle help (`bd mol wisp --help` step 3: *"Squash: bd mol squash <id> (clears Ephemeral flag, promotes to persistent)"*).
- The closed-but-still-ephemeral root stays in the `wisps` table, so auto-export queries (`Ephemeral=true`) re-emit it as a duplicate JSONL row on every export cycle, accumulating noise indefinitely.
- Fix: inside the existing squash transaction, after closing the wisp root, also call `tx.UpdateIssue(root.ID, {"wisp": false})`. Same code path as the `bd update <id> --persistent` workaround orchestrators use today.

## Why this shape

The reporter ([context](https://github.com/gastownhall/beads/issues/new) — discovered downstream in a SimFlow E2E run) framed two options:

1. **Match the wisp-help contract** by changing `mol squash` to clear the root's `Ephemeral` flag. ← this PR.
2. Match the squash-help contract by updating `bd mol wisp --help` step 3 and documenting the orchestrator workaround.

Shape 1 is preferred because it matches the natural "squash absorbs the molecule into a digest" mental model, makes the wisp-lifecycle help truthful end-to-end, and removes the need for orchestrators to issue a follow-up `bd update --persistent` inside the export-throttle window.

## Test plan

- [x] New regression test `TestSquashWispMoleculeClearsRootEphemeral` in `cmd/bd/mol_test.go`: creates a wisp molecule (root + child both `Ephemeral=true`), runs `squashMolecule`, asserts root is closed AND `Ephemeral=false` after. Skips when Dolt server is unavailable (matches existing `TestSquashMolecule*` pattern).
- [x] `go vet -tags cgo ./cmd/bd/` clean.
- [x] Existing squash tests (`TestSquashMolecule`, `TestSquashMoleculeWithDelete`, `TestSquashMoleculeWithAgentSummary`) compile and discover correctly under the same build tag.
- [ ] CI to exercise the new test against the Docker-backed Dolt fixture.

## Out of scope

- The companion concern about `bd mol wisp gc` also emitting `ephemeral:true` rows for reclaimed wisps — that's a separate export-filter issue (orthogonal but in the same family).
- Updating the `bd mol squash --help` long description to mention root behavior (the existing `WispSquash` printout already surfaces it; help text changes can land separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->