### PR TITLE
fix(linear): correct issueBatchCreate GraphQL variable type

### DIFF
--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -895,7 +895,7 @@ func (c *Client) BatchCreateIssues(ctx context.Context, inputs []IssueCreateInpu
 	}
 
 	query := `
-		mutation BatchCreateIssues($input: [IssueCreateInput!]!) {
+		mutation BatchCreateIssues($input: IssueBatchCreateInput!) {
 			issueBatchCreate(input: $input) {
 				success
 				issues {
@@ -927,7 +927,9 @@ func (c *Client) BatchCreateIssues(ctx context.Context, inputs []IssueCreateInpu
 		req := &GraphQLRequest{
 			Query: query,
 			Variables: map[string]interface{}{
-				"input": chunk,
+				"input": map[string]interface{}{
+					"issues": chunk,
+				},
 			},
 		}
 

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -187,10 +187,22 @@ func TestBatchCreateIssues_SingleBatch(t *testing.T) {
 		if !strings.Contains(req.Query, "issueBatchCreate") {
 			t.Fatalf("expected issueBatchCreate mutation, got: %s", req.Query)
 		}
+		// Validate the correct GraphQL variable shape: IssueBatchCreateInput
+		// wraps the array in an "issues" field.
+		if !strings.Contains(req.Query, "IssueBatchCreateInput!") {
+			t.Fatalf("mutation must declare $input as IssueBatchCreateInput!, got: %s", req.Query)
+		}
+		inputWrapper, ok := req.Variables["input"].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected input variable to be an object with 'issues' field")
+		}
+		inputArr, ok := inputWrapper["issues"].([]interface{})
+		if !ok {
+			t.Fatal("expected input.issues to be an array")
+		}
 
 		issues := make([]Issue, 0)
-		inputs := req.Variables["input"].([]interface{})
-		for i := range inputs {
+		for i := range inputArr {
 			issues = append(issues, Issue{
 				ID:         fmt.Sprintf("id-%d", i),
 				Identifier: fmt.Sprintf("TEAM-%d", i+1),
@@ -240,7 +252,8 @@ func TestBatchCreateIssues_Chunking(t *testing.T) {
 		var req GraphQLRequest
 		json.Unmarshal(body, &req)
 
-		inputs := req.Variables["input"].([]interface{})
+		inputWrapper := req.Variables["input"].(map[string]interface{})
+		inputs := inputWrapper["issues"].([]interface{})
 		issues := make([]Issue, len(inputs))
 		for i := range inputs {
 			issues[i] = Issue{

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -414,7 +414,8 @@ func TestBatchPush_DuplicateTitlesFallbackToSingleCreate(t *testing.T) {
 			})
 		case strings.Contains(req.Query, "issueBatchCreate"):
 			batchCreateCount++
-			inputs := req.Variables["input"].([]interface{})
+			inputWrapper := req.Variables["input"].(map[string]interface{})
+			inputs := inputWrapper["issues"].([]interface{})
 			var issues []interface{}
 			for i, inp := range inputs {
 				m := inp.(map[string]interface{})


### PR DESCRIPTION
## Summary

`BatchCreateIssues` declared the GraphQL mutation variable `$input` as `[IssueCreateInput!]!` and passed the issue array directly. Linear's API actually expects `IssueBatchCreateInput!` — a wrapper object containing an `issues` field.

This mismatch caused **all batch issue creation to silently fail**: the API returned no errors but also created no issues. The `issueBatchCreate` response always came back with an empty `issues` array, leading to the "not returned in batch create response" fallback path.

## Changes

1. **`internal/linear/client.go`**: Changed the mutation's variable type from `[IssueCreateInput!]!` to `IssueBatchCreateInput!`, and wrapped the input array in `map[string]interface{}{"issues": chunk}` instead of passing it directly.

2. **`internal/linear/client_test.go`**: Updated `TestBatchCreateIssues_SingleBatch` to validate the correct variable shape (`IssueBatchCreateInput!` type declaration and `input.issues` wrapper). Updated `TestBatchCreateIssues_Chunking` similarly.

3. **`internal/linear/tracker_test.go`**: Updated `TestBatchPush_DuplicateTitlesFallbackToSingleCreate` mock server to parse the new variable shape.

## How it was discovered

Dogfooding a live Linear sync: pushing 9 new beads, all silently dropped. Confirmed via `--verbose` logging and direct `curl` against Linear's GraphQL schema (`__type(name: "Mutation")` introspection).

## Test plan

- [x] All existing `TestBatchCreateIssues_*` tests pass
- [x] `TestBatchPush_DuplicateTitlesFallbackToSingleCreate` passes
- [x] Full `internal/linear/` test suite passes
- [x] Verified live: 9 issues successfully batch-created after fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->