### PR TITLE
docs: remove date-stamped fossils from LINTING.md

### DIFF
--- a/docs/LINTING.md
+++ b/docs/LINTING.md
@@ -4,13 +4,11 @@ This document explains our approach to `golangci-lint` warnings in this codebase
 
 ## Current Status
 
-Running `golangci-lint run ./...` currently reports **22 issues** as of Nov 6, 2025. These are not actual code quality problems - they are false positives or intentional patterns that reflect idiomatic Go practice.
-
-**Historical note**: The count was ~200 before extensive cleanup in October 2025, reduced to 34 by Oct 27, and now 22 after removing legacy code. The remaining issues represent the acceptable baseline that doesn't warrant fixing.
+Running `golangci-lint run ./...` reports a small number of remaining issues. These are not actual code quality problems - they are false positives or intentional patterns that reflect idiomatic Go practice. Run the command locally to see the current count and breakdown.
 
 ## Issue Breakdown
 
-### errcheck (4 issues)
+### errcheck
 
 **Pattern**: Unchecked errors from `defer` cleanup operations
 **Status**: Intentional and idiomatic
@@ -29,9 +27,9 @@ defer os.RemoveAll(tmpDir)  // in tests
 
 Fixing these would add noise without improving code quality. The critical cleanup operations (where errors matter) are already checked explicitly.
 
-### gosec (12 issues)
+### gosec
 
-**Pattern 1**: G204 - Subprocess launched with variable (3 issues)
+**Pattern 1**: G204 - Subprocess launched with variable
 **Status**: Intentional - launching editor and git commands with user-specified paths
 
 Examples:
@@ -39,7 +37,7 @@ Examples:
 - Executing git commands
 - Running external commands (e.g., git, dolt)
 
-**Pattern 2**: G304 - File inclusion via variable (3 issues)
+**Pattern 2**: G304 - File inclusion via variable
 **Status**: Intended feature - user-specified file paths for import/export
 
 All file paths are either:
@@ -47,26 +45,26 @@ All file paths are either:
 - Test fixtures in controlled test environments
 - Validated paths with security checks
 
-**Pattern 3**: G301/G302/G306 - File permissions (3 issues)
+**Pattern 3**: G301/G302/G306 - File permissions
 **Status**: Acceptable for user-facing database files
 
 - G301: 0755 for database directories (allows other users to read)
 - G302: 0644 for data files (needs to be readable)
 - G306: 0644 for new data files (consistency with existing files)
 
-**Pattern 4**: G201/G202 - SQL string formatting/concatenation (3 issues)
+**Pattern 4**: G201/G202 - SQL string formatting/concatenation
 **Status**: Safe - using placeholders and bounded queries
 
 All SQL concatenation uses proper placeholders and is bounded by controlled input (issue ID lists).
 
-### misspell (3 issues)
+### misspell
 
 **Pattern**: British vs American spelling - `cancelled` vs `canceled`
 **Status**: Acceptable spelling variation
 
 The codebase uses "cancelled" (British spelling) in user-facing messages. Both spellings are correct.
 
-### unparam (4 issues)
+### unparam
 
 **Pattern**: Function parameters or return values that are always the same
 **Status**: Interface compliance and future-proofing
@@ -87,10 +85,10 @@ This appears to be a known limitation of golangci-lint's configuration system.
 
 ## Recommendation
 
-**For contributors**: Don't be alarmed by the 22 lint warnings. The code quality is high.
+**For contributors**: Don't be alarmed by the lint warnings reported. The code quality is high.
 
 **For code review**: Focus on:
-- New issues introduced by changes (not the baseline 22)
+- New issues introduced by changes (not the existing baseline)
 - Actual logic errors
 - Missing error checks on critical operations (file writes, database commits)
 - Security concerns beyond gosec's false positives


### PR DESCRIPTION
## Summary

`docs/LINTING.md` opened with **"22 issues as of Nov 6, 2025"** — a date-stamped count fossilized inside otherwise-current narrative. Reads as outdated immediately after the date passes; readers cannot tell if the rest of the doc is current.

This PR removes the date-stamped count and other count fossils from the same file:

- Drop the "**22 issues** as of Nov 6, 2025" sentence and the "Historical note" paragraph that tracked the October 2025 cleanup arc (200 → 34 → 22). Replace with a sentence pointing readers at running `golangci-lint run ./...` locally for a current count.
- Drop the "(N issues)" sub-counts on each linter section heading: `errcheck`, `gosec`, `misspell`, `unparam`.
- Drop the "(3 issues)" sub-counts on the four gosec pattern bullets (G204, G304, G301/G302/G306, G201/G202).
- Reword two later references in the Recommendation section: "the 22 lint warnings" → "the lint warnings reported"; "(not the baseline 22)" → "(not the existing baseline)".

The narrative point — that the remaining warnings are intentional / idiomatic and not a quality problem — is preserved. Section structure and rationale text are unchanged.

## Why

Date-stamped counts inside flowing prose are an antipattern: they fossilize on the day the doc is written, mislead readers the moment they go stale, and provide no mechanism to know whether the surrounding narrative is also out of date. Counts that genuinely need to be authoritative should come from a live source (CI script output, generated table); counts that are merely illustrative are usually clearer dropped entirely. Here the counts were illustrative — the doc's argument is "these warnings are acceptable", not "there are exactly 22 of them".

## Refs

- mybd-6yw (private tracker)
- Discovered during the mybd-p71 hand-written-doc audit
- Related upstream issue: #3683
- Companion PR: #3706

## Test plan

- [x] `docs/LINTING.md` no longer mentions specific dates or specific issue counts
- [x] Section headings and pattern bullets remain readable without the parenthetical counts
- [x] Narrative claim ("intentional, idiomatic, not technical debt") is preserved
- [ ] Reviewer sanity-check: re-read the doc top-to-bottom and confirm it still makes sense without the numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->