### PR TITLE
docs: fix broken xref to docs/EXTENDING.md in extension example

### DIFF
--- a/beads.go
+++ b/beads.go
@@ -4,7 +4,7 @@
 // This package exports only the essential types and functions needed for
 // Go-based extensions that want to use bd's storage layer programmatically.
 //
-// For detailed guidance on extending bd, see docs/EXTENDING.md.
+// For a working extension example, see examples/bd-example-extension-go.
 package beads
 
 import (

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -288,7 +288,7 @@ See [DOLT.md](DOLT.md) for details on how the Dolt backend handles sync natively
 
 > **Note:** Custom table extensions via `UnderlyingDB()` are a **SQLite-only** pattern.
 > With the Dolt backend, build standalone integration tools using bd's CLI with `--json`
-> flags, or use `bd query` for direct SQL access. See [EXTENDING.md](EXTENDING.md) for details.
+> flags, or use `bd query` for direct SQL access.
 
 For SQLite-backend users, you can extend bd with your own tables and queries:
 
@@ -297,7 +297,7 @@ For SQLite-backend users, you can extend bd with your own tables and queries:
 - Implement custom workflows
 - Create reports and analytics
 
-**See [EXTENDING.md](EXTENDING.md) for complete documentation.**
+See [examples/bd-example-extension-go](../examples/bd-example-extension-go/README.md) for a working extension example.
 
 ## Architecture: Storage, RPC, and MCP
 
@@ -329,4 +329,4 @@ Understanding the role of each component:
 - **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Common issues and solutions
 - **[FAQ.md](FAQ.md)** - Frequently asked questions
 - **[CONFIG.md](CONFIG.md)** - Configuration system guide
-- **[EXTENDING.md](EXTENDING.md)** - Database extension patterns
+- **[examples/bd-example-extension-go](../examples/bd-example-extension-go/README.md)** - Working SQLite extension example

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -324,7 +324,7 @@ Configuration keys use dot-notation namespaces to organize settings:
 
 ### Core Namespaces
 
-- `compact_*` - Compaction settings (see EXTENDING.md)
+- `compact_*` - Compaction settings (used by `bd admin compact`)
 - `issue_prefix` - Issue ID prefix (managed by `bd init`)
 - `issue_id_mode` - ID generation mode: `hash` (default) or `counter` (sequential integers)
 - `max_collision_prob` - Maximum collision probability for adaptive hash IDs (default: 0.25)
@@ -981,4 +981,4 @@ External integration scripts can read configuration to sync with Jira, Linear, G
 ## See Also
 
 - [README.md](../README.md) - Main documentation
-- [EXTENDING.md](EXTENDING.md) - Database schema and compaction config
+- [ADVANCED.md](ADVANCED.md) - Extensible Database section and other advanced topics

--- a/examples/bd-example-extension-go/README.md
+++ b/examples/bd-example-extension-go/README.md
@@ -1,6 +1,6 @@
 # BD Extension Example (Go)
 
-This example demonstrates how to extend bd with custom tables for application-specific orchestration, following the patterns described in [EXTENDING.md](../../docs/EXTENDING.md).
+This example demonstrates how to extend bd with custom tables for application-specific orchestration.
 
 ## What This Example Shows
 
@@ -224,8 +224,6 @@ This pattern is used in production by:
 - **CI/CD Systems**: Build tracking and artifact management
 - **Task Runners**: Parallel execution with dependency resolution
 
-See [EXTENDING.md](../../EXTENDING.md) for more patterns and the VC implementation example.
-
 ## Next Steps
 
 1. **Add Your Own Tables**: Extend the schema with application-specific tables
@@ -236,6 +234,5 @@ See [EXTENDING.md](../../EXTENDING.md) for more patterns and the VC implementati
 
 ## See Also
 
-- [EXTENDING.md](../../EXTENDING.md) - Complete extension guide
 - [../../README.md](../../README.md) - bd documentation
 - [QUICKSTART.md](../../docs/QUICKSTART.md) - Quick start tutorial

--- a/examples/library-usage/README.md
+++ b/examples/library-usage/README.md
@@ -194,6 +194,6 @@ func (s *VCStorage) ClaimWork(ctx context.Context, executorID string) (*beads.Is
 
 ## See Also
 
-- [EXTENDING.md](../../EXTENDING.md) - Detailed extension guide
+- [bd-example-extension-go](../bd-example-extension-go/README.md) - Working extension example
 - [beads.go](../../beads.go) - Public API source
 - [internal/storage/storage.go](../../internal/storage/storage.go) - Storage interface

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -4,7 +4,7 @@
 // This package exports only the essential types and functions needed for
 // Go-based extensions that want to use bd's storage layer programmatically.
 //
-// For detailed guidance on extending bd, see EXTENDING.md.
+// For a working extension example, see examples/bd-example-extension-go.
 package beads
 
 import (

--- a/website/docs/reference/advanced.md
+++ b/website/docs/reference/advanced.md
@@ -89,7 +89,7 @@ storage.UnderlyingDB().Exec(`
 `)
 ```
 
-See [EXTENDING.md](https://github.com/gastownhall/beads/blob/main/docs/EXTENDING.md).
+See the [bd-example-extension-go example](https://github.com/gastownhall/beads/blob/main/examples/bd-example-extension-go/README.md) for a working extension.
 
 ## Event System
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5523,7 +5523,7 @@ storage.UnderlyingDB().Exec(`
 `)
 ```
 
-See [EXTENDING.md](https://github.com/gastownhall/beads/blob/main/docs/EXTENDING.md).
+See the [bd-example-extension-go example](https://github.com/gastownhall/beads/blob/main/examples/bd-example-extension-go/README.md) for a working extension.
 
 ## Event System
 

--- a/website/versioned_docs/version-1.0.0/reference/advanced.md
+++ b/website/versioned_docs/version-1.0.0/reference/advanced.md
@@ -89,7 +89,7 @@ storage.UnderlyingDB().Exec(`
 `)
 ```
 
-See [EXTENDING.md](https://github.com/gastownhall/beads/blob/main/docs/EXTENDING.md).
+See the [bd-example-extension-go example](https://github.com/gastownhall/beads/blob/main/examples/bd-example-extension-go/README.md) for a working extension.
 
 ## Event System
 


### PR DESCRIPTION
## Summary

The deletion of `docs/EXTENDING.md` in the SQLite to Dolt migration (CHANGELOG: "Deleted deprecated docs - removed EXTENDING.md and MULTI_REPO_HYDRATION.md (SQLite-era, no longer applicable)") left broken xrefs scattered across the repo. The bead acceptance for this work (mybd-q71 / #3683) is repo-wide: no broken xrefs to the deleted file anywhere.

This PR cleans up all of them in one shot per the "one issue per PR" rule.

## In scope, fixed (round 1)

`examples/bd-example-extension-go/README.md` — three references removed. The example itself is now the canonical extension reference, so no redirect target is needed in that file. (Commit ddeff314c.)

## In scope, fixed (round 2)

EXTENDING.md was deleted in commit 508387377, which is an ancestor of tag v1.0.0 — so the v1.0.0 versioned snapshot has been broken since v1.0.0 release. Treatments per file:

| File | Action | Treatment |
|------|--------|-----------|
| `docs/ADVANCED.md` (line 291) | removed clause | Drop "See EXTENDING.md for details" from Extensible Database Note; surrounding Dolt guidance stands alone. |
| `docs/ADVANCED.md` (line 300) | replaced | Redirect "See ... for complete documentation" to `examples/bd-example-extension-go`. |
| `docs/ADVANCED.md` (line 332) | replaced | Next Steps bullet now points to `examples/bd-example-extension-go`. |
| `docs/CONFIG.md` (line 327) | replaced inline | `compact_*` namespace doc: "(see EXTENDING.md)" -> "(used by `bd admin compact`)"; the doc already describes the keys. |
| `docs/CONFIG.md` (line 984) | replaced | See Also bullet -> `docs/ADVANCED.md` (Extensible Database section). |
| `examples/library-usage/README.md` (line 197) | replaced | See Also bullet -> sibling `../bd-example-extension-go/README.md`. |
| `website/docs/reference/advanced.md` (line 92) | replaced | Custom Tables link -> `bd-example-extension-go` README on GitHub. |
| `website/versioned_docs/version-1.0.0/reference/advanced.md` (line 92) | replaced | Same fix as live docs. Deletion predated v1.0.0 release, so the link was never valid in the v1.0.0 snapshot — fixing it does not violate frozen-in-time correctness. |
| `website/static/llms-full.txt` (line 5526) | replaced | Auto-generated artifact updated to match corrected source so it isn't broken until next regen. |
| `beads.go` (line 7) | replaced | Public package doc comment: "see docs/EXTENDING.md" -> "see examples/bd-example-extension-go". |
| `internal/beads/beads.go` (line 7) | replaced | Internal package doc comment: same fix. |

## Explicitly out of scope

- `CHANGELOG.md` historical entries (lines 898, 1611, 5056, 5060, 5391, 5473) — intentional historical references, must not be edited.
- `cmd/bd/info.go:747` — programmatic CHANGELOG entry rendered by `bd info`, equivalent to a CHANGELOG line.

## Test plan

- [x] `grep -rn 'EXTENDING\.md' --include='*.md' .` returns only CHANGELOG.md hits.
- [x] `grep -rn 'EXTENDING\.md' --exclude='*.md' --exclude-dir=.git --exclude='*.jsonl' .` returns only `cmd/bd/info.go` (intentionally preserved).
- [x] Branch is based on `upstream/main`; `git log --oneline HEAD --not upstream/main` shows the two commits in this PR and no fork-only baggage.
- [x] All replacement links target files that exist on `upstream/main`.

Refs: GH #3683, follow-up from PR #3706.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->