### PR TITLE
fix(linear): add done/deferred/pinned/hooked aliases to ParseBeadsStatus

### DIFF
--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -386,8 +386,14 @@ func ParseBeadsStatus(s string) types.Status {
 		return types.StatusInProgress
 	case "blocked":
 		return types.StatusBlocked
-	case "closed":
+	case "closed", "done":
 		return types.StatusClosed
+	case "deferred":
+		return types.StatusDeferred
+	case "pinned":
+		return types.StatusPinned
+	case "hooked":
+		return types.StatusHooked
 	default:
 		return types.StatusOpen
 	}

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -279,6 +279,11 @@ func TestParseBeadsStatus(t *testing.T) {
 		{"blocked", types.StatusBlocked},
 		{"closed", types.StatusClosed},
 		{"CLOSED", types.StatusClosed},
+		{"done", types.StatusClosed},
+		{"Done", types.StatusClosed},
+		{"deferred", types.StatusDeferred},
+		{"pinned", types.StatusPinned},
+		{"hooked", types.StatusHooked},
 		{"unknown", types.StatusOpen}, // Default
 	}
 


### PR DESCRIPTION
## Summary

`ParseBeadsStatus` only recognized 4 of 7 valid beads statuses (`open`, `in_progress`, `blocked`, `closed`). The remaining 3 (`done`, `deferred`, `pinned`, `hooked`) fell through to the `default` case which silently returned `StatusOpen`.

This caused two real bugs during Linear sync:
- **"done" beads pushed as Todo** — `done` parsed to `StatusOpen`, resolving to Linear's "Todo" state instead of "Done"
- **"deferred" state_map entries collided with "open"** — mapping `backlog=deferred` was intended to avoid a push conflict, but `ParseBeadsStatus("deferred")` returned `StatusOpen`, creating the same collision

## Fix

Add all valid beads statuses as explicit cases:
- `"done"` → `StatusClosed` (same terminal state, different name)
- `"deferred"` → `StatusDeferred`
- `"pinned"` → `StatusPinned`
- `"hooked"` → `StatusHooked`

The `default` case still returns `StatusOpen` for genuinely unknown strings.

## Test plan

- [x] Extended `TestParseBeadsStatus` with cases for `done`, `Done`, `deferred`, `pinned`, `hooked`
- [x] `go build ./...` clean
- [x] `go vet ./...` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->