### PR TITLE
fix(mol): recognize TypeMolecule roots in findParentMolecules (#3719)

### DIFF
--- a/cmd/bd/mol_current.go
+++ b/cmd/bd/mol_current.go
@@ -461,7 +461,11 @@ func findParentMolecules(ctx context.Context, s storage.DoltStorage, issueIDs []
 
 	isMolecule := make(map[string]bool, len(rootIssues))
 	for _, issue := range rootIssues {
-		if issue.IssueType == types.TypeEpic {
+		// `bd mol pour` creates roots with TypeMolecule (no template label),
+		// while distilled-from-epic templates use TypeEpic + BeadsTemplateLabel.
+		// Both shapes must be recognized so --continue can advance through
+		// poured molecules. See gastownhall/beads#3719.
+		if issue.IssueType == types.TypeEpic || issue.IssueType == types.TypeMolecule {
 			isMolecule[issue.ID] = true
 			continue
 		}

--- a/cmd/bd/mol_test.go
+++ b/cmd/bd/mol_test.go
@@ -1647,6 +1647,172 @@ func TestFindParentMoleculesBatch(t *testing.T) {
 	}
 }
 
+// TestFindParentMolecule_RootShapes covers every shape of molecule root that
+// findParentMolecule(s) needs to recognize:
+//   - TypeEpic + BeadsTemplateLabel  (distilled / older formula path)
+//   - TypeMolecule with no label     (`bd mol pour` path — gastownhall/beads#3719)
+//   - TypeTask + BeadsTemplateLabel  (template-label-only fallback)
+//   - TypeTask, no label             (not a molecule)
+//
+// Before the fix for #3719 the TypeMolecule case returned "", which caused
+// `bd close --continue` to silently no-op for any poured molecule.
+func TestFindParentMolecule_RootShapes(t *testing.T) {
+	ctx := context.Background()
+	dbPath := t.TempDir() + "/test.db"
+	s, err := dolt.New(ctx, &dolt.Config{Path: dbPath})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	defer s.Close()
+	if err := s.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		rootType   types.IssueType
+		rootLabels []string
+		isMolecule bool
+	}{
+		{"epic with template label", types.TypeEpic, []string{BeadsTemplateLabel}, true},
+		{"poured molecule (no label)", types.TypeMolecule, nil, true},
+		{"task with template label", types.TypeTask, []string{BeadsTemplateLabel}, true},
+		{"plain task is not a molecule", types.TypeTask, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &types.Issue{
+				Title:     tt.name + " root",
+				Status:    types.StatusOpen,
+				Priority:  1,
+				IssueType: tt.rootType,
+				Labels:    tt.rootLabels,
+			}
+			if err := s.CreateIssue(ctx, root, "test"); err != nil {
+				t.Fatalf("Failed to create root: %v", err)
+			}
+
+			child := &types.Issue{
+				Title:     tt.name + " child",
+				Status:    types.StatusOpen,
+				Priority:  2,
+				IssueType: types.TypeTask,
+			}
+			if err := s.CreateIssue(ctx, child, "test"); err != nil {
+				t.Fatalf("Failed to create child: %v", err)
+			}
+			if err := s.AddDependency(ctx, &types.Dependency{
+				IssueID:     child.ID,
+				DependsOnID: root.ID,
+				Type:        types.DepParentChild,
+			}, "test"); err != nil {
+				t.Fatalf("Failed to add parent-child: %v", err)
+			}
+
+			wantSingle := ""
+			if tt.isMolecule {
+				wantSingle = root.ID
+			}
+			if got := findParentMolecule(ctx, s, child.ID); got != wantSingle {
+				t.Errorf("findParentMolecule(child) = %q, want %q", got, wantSingle)
+			}
+
+			wantBatch := map[string]string{child.ID: wantSingle}
+			gotBatch := findParentMolecules(ctx, s, []string{child.ID})
+			if got := gotBatch[child.ID]; got != wantBatch[child.ID] {
+				t.Errorf("findParentMolecules(child) = %q, want %q", got, wantBatch[child.ID])
+			}
+		})
+	}
+}
+
+// TestAdvanceToNextStep_PouredMolecule reproduces gastownhall/beads#3719: when a
+// step lives under a TypeMolecule root (as `bd mol pour` creates), AdvanceToNextStep
+// must find the parent molecule and (with autoClaim=true) claim the next ready step.
+// Before the fix it silently returned (nil, nil).
+func TestAdvanceToNextStep_PouredMolecule(t *testing.T) {
+	ctx := context.Background()
+	dbPath := t.TempDir() + "/test.db"
+	s, err := dolt.New(ctx, &dolt.Config{Path: dbPath})
+	if err != nil {
+		t.Skipf("skipping: Dolt server not available: %v", err)
+	}
+	defer s.Close()
+	if err := s.SetConfig(ctx, "issue_prefix", "test"); err != nil {
+		t.Fatalf("Failed to set config: %v", err)
+	}
+
+	// Root shaped like `bd mol pour` output: TypeMolecule, no template label.
+	root := &types.Issue{
+		Title:     "Poured Molecule",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeMolecule,
+	}
+	if err := s.CreateIssue(ctx, root, "test"); err != nil {
+		t.Fatalf("Failed to create root: %v", err)
+	}
+
+	step1 := &types.Issue{
+		Title:     "Step 1",
+		Status:    types.StatusClosed,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	step2 := &types.Issue{
+		Title:     "Step 2",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	for _, step := range []*types.Issue{step1, step2} {
+		if err := s.CreateIssue(ctx, step, "test"); err != nil {
+			t.Fatalf("Failed to create step: %v", err)
+		}
+		if err := s.AddDependency(ctx, &types.Dependency{
+			IssueID:     step.ID,
+			DependsOnID: root.ID,
+			Type:        types.DepParentChild,
+		}, "test"); err != nil {
+			t.Fatalf("Failed to add parent-child: %v", err)
+		}
+	}
+	if err := s.AddDependency(ctx, &types.Dependency{
+		IssueID:     step2.ID,
+		DependsOnID: step1.ID,
+		Type:        types.DepBlocks,
+	}, "test"); err != nil {
+		t.Fatalf("Failed to add blocking dep: %v", err)
+	}
+
+	result, err := AdvanceToNextStep(ctx, s, step1.ID, true, "test")
+	if err != nil {
+		t.Fatalf("AdvanceToNextStep failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("AdvanceToNextStep returned nil result; expected molecule advance for TypeMolecule root")
+	}
+	if result.MoleculeID != root.ID {
+		t.Errorf("MoleculeID = %q, want %q", result.MoleculeID, root.ID)
+	}
+	if result.NextStep == nil || result.NextStep.ID != step2.ID {
+		t.Errorf("NextStep = %v, want step2 (%s)", result.NextStep, step2.ID)
+	}
+	if !result.AutoAdvanced {
+		t.Errorf("AutoAdvanced = false; want true (autoClaim was on)")
+	}
+
+	// Confirm step2 is in_progress now.
+	got, err := s.GetIssue(ctx, step2.ID)
+	if err != nil {
+		t.Fatalf("GetIssue(step2) failed: %v", err)
+	}
+	if got.Status != types.StatusInProgress {
+		t.Errorf("step2 status = %q, want %q", got.Status, types.StatusInProgress)
+	}
+}
+
 // TestFindHookedMolecules tests finding molecules bonded to hooked issues
 func TestFindHookedMolecules(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Adds `IssueType == types.TypeMolecule` to the `isMolecule` decision in `findParentMolecules` (`cmd/bd/mol_current.go:464`), so molecules created by `bd mol pour` are recognized when walking parent-child chains.
- Adds two regression tests in `cmd/bd/mol_test.go` covering the previously-untested third arm.

## Related Issue

Fixes #3719

## Why this slipped through

`bd mol pour` creates the molecule root with `IssueType: types.TypeMolecule` (`cmd/bd/cook.go:452`, `:840`). `findParentMolecules` only matched `TypeEpic` or `BeadsTemplateLabel`, so walking up from any poured-molecule step returned `""`. Knock-on effects:

- `bd close <step> --continue` silently no-oped — `AdvanceToNextStep` returned `nil, nil` and the close-flow's print-path at `cmd/bd/close.go:212-228` is gated on `result != nil`.
- `bd close <step> --continue --claim-next` claimed nothing — `--claim-next`'s branch in close.go:232 is gated on `!continueFlag`.

`cmd/bd/close.go:411` already special-cases `TypeMolecule`, so the close-flow knows about the type. `mol_current.go` was simply not updated when the type was introduced.

The existing tests (`TestFindParentMolecule`, `TestFindParentMoleculesBatch`, `TestAdvanceToNextStep` plus its concurrency variants) all build the root with `TypeEpic + BeadsTemplateLabel`, so both clauses of `isMolecule` matched and the gap stayed hidden. The new tests construct roots the way `bd mol pour` actually does.

## Changes Made

- `cmd/bd/mol_current.go` — one-line fix + comment pointing to #3719.
- `cmd/bd/mol_test.go`:
  - `TestFindParentMolecule_RootShapes` — table-driven, covers every root shape (TypeEpic+label, TypeMolecule no-label, TypeTask+label, plain TypeTask) for both `findParentMolecule` and `findParentMolecules`.
  - `TestAdvanceToNextStep_PouredMolecule` — reproduces #3719 end-to-end: poured-style root, `autoClaim=true`, asserts the next step is moved to in_progress.

## How to Test

```bash
make test  # full suite (CI runs this with Docker for Dolt)

# Or focused, once Docker is available locally:
go test -tags gms_pure_go -v -run 'TestFindParentMolecule_RootShapes|TestAdvanceToNextStep_PouredMolecule' ./cmd/bd
```

End-to-end repro from #3719 (against a freshly-built bd from this branch):

```bash
bd init --non-interactive
mkdir -p .beads/formulas
cat > .beads/formulas/demo.formula.json <<'JSON'
{
  "formula": "demo", "version": 1, "type": "workflow",
  "vars": { "x": { "description": "x", "required": true } },
  "steps": [
    {"id": "a", "title": "A {{x}}"},
    {"id": "b", "title": "B {{x}}", "needs": ["a"]}
  ]
}
JSON
bd mol pour demo --var x=foo
A=$(bd ready --json | jq -r '.[] | select(.title | startswith("A ")) | .id')
bd update $A --claim
bd close $A --reason test --continue
# After: B is IN_PROGRESS (was OPEN before this fix); next-step message prints.
```

## Checklist

- [x] One issue per PR (#3719)
- [x] No unrelated changes / no `.beads/` data
- [x] `go vet` clean, `gofmt` clean, `go build ./...` clean
- [x] New tests added; existing tests untouched
- [ ] Full `make test` will run in CI (Docker required for Dolt — not available in my local env)
- [x] No documentation changes required (behavior matches existing `--no-auto` help text once the bug is fixed)

Out of scope: the `--continue` / `--claim-next` interaction at `close.go:232` (where `--continue` suppresses `--claim-next` without documenting the suppression). Mentioned in #3719's "Acceptance Criteria"; happy to follow up in a separate PR per the one-issue-per-PR rule.

— Keeping my human friend @idvorkin in the loop!

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->