### PR TITLE
docs: add canonical cross-machine sync entry-point + anti-patterns (GH#3683)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,5 +186,5 @@ For daemon mode without git, use `bd daemon start --local`
 
 ## 📝 Documentation
 
-* [Documentation site](https://gastownhall.github.io/beads/) (versioned) | [Installing](docs/INSTALLING.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot Setup](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
+* [Documentation site](https://gastownhall.github.io/beads/) (versioned) | [Installing](docs/INSTALLING.md) | [How sync works](docs/SYNC_CONCEPTS.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot Setup](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
 * [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/gastownhall/beads)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 This document describes bd's overall architecture - the data model, sync mechanism, and how components fit together. For internal implementation details (FlushManager, Blocked Cache), see [INTERNALS.md](INTERNALS.md).
 
+> **Looking for the short version first?** [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) is a one-screen overview of how cross-machine sync works (Dolt + `refs/dolt/data` + JSONL-as-export) plus a list of common anti-patterns.
+
 ## The Two-Layer Data Model
 
 bd's core design enables a distributed, Dolt-powered issue tracker that feels like a centralized database. The architecture has two synchronized layers:
@@ -354,6 +356,7 @@ The `bd mol squash` command uses hard delete intentionally - tombstones would be
 
 ## Related Documentation
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) - One-screen overview of cross-machine sync + anti-patterns (read first)
 - [MOLECULES.md](MOLECULES.md) - Molecular chemistry metaphor (protos, pour, bond, squash, burn)
 - [INTERNALS.md](INTERNALS.md) - FlushManager, Blocked Cache implementation details
 - [ADVANCED.md](ADVANCED.md) - Advanced features and configuration

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -542,6 +542,7 @@ rm .beads/*.backup-*.db
 
 ## See Also
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) - One-screen overview of cross-machine sync + anti-patterns
 - [SYNC_SETUP.md](SYNC_SETUP.md) - Setting up sync across multiple computers
 - [CONFIG.md](CONFIG.md) - Full configuration reference
 - [DEPENDENCIES.md](DEPENDENCIES.md) - Dependencies and gates

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,6 +2,8 @@
 
 Common questions about bd (beads) and how to use it effectively.
 
+For a one-screen overview of how cross-machine sync works (plus anti-patterns), see [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md).
+
 ## General Questions
 
 ### What is bd?

--- a/docs/GIT_INTEGRATION.md
+++ b/docs/GIT_INTEGRATION.md
@@ -346,6 +346,7 @@ This configures Jujutsu to invoke `bd merge` as its merge tool, restricted to `.
 
 ## See Also
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) - One-screen overview of cross-machine sync + anti-patterns
 - [AGENTS.md](../AGENTS.md) - Main agent workflow guide
 - [PROTECTED_BRANCHES.md](PROTECTED_BRANCHES.md) - Protected branch workflows
 - [MULTI_REPO_MIGRATION.md](MULTI_REPO_MIGRATION.md) - Multi-repo patterns

--- a/docs/SYNC_CONCEPTS.md
+++ b/docs/SYNC_CONCEPTS.md
@@ -1,0 +1,101 @@
+# Cross-Machine Sync: How It Works
+
+> **One-sentence model:** Issues live in a local Dolt database under
+> `.beads/dolt/`; cross-machine sync uses Dolt's native push/pull, which
+> stores the issue history under `refs/dolt/data` on your git remote —
+> separate from `refs/heads/*` where your code lives. `.beads/issues.jsonl`
+> is a passive export for portability, not the wire protocol.
+
+This page is the entry point. Read it first, then follow the deeper-doc
+links below for the layer you need.
+
+## Mental Model
+
+```
+┌──────────────────────┐                    ┌──────────────────────┐
+│   Machine A          │                    │   Machine B          │
+│                      │                    │                      │
+│   bd create / list   │                    │   bd create / list   │
+│         ↕            │                    │         ↕            │
+│   Local Dolt DB      │                    │   Local Dolt DB      │
+│   .beads/dolt/       │                    │   .beads/dolt/       │
+│   (source of truth)  │                    │   (source of truth)  │
+└──────────┬───────────┘                    └──────────┬───────────┘
+           │                                           │
+           │  bd dolt push                bd dolt pull │
+           │  (Dolt commit graph)                      │
+           v                                           v
+        ┌────────────────────────────────────────────────┐
+        │   git remote                                   │
+        │   refs/heads/*    ← your code                  │
+        │   refs/dolt/data  ← issues (Dolt history)      │
+        └────────────────────────────────────────────────┘
+```
+
+When you run a `bd` command, it reads or writes the **local Dolt
+database**. Every write auto-commits to Dolt history. To share with
+another machine you run `bd dolt push`, which pushes the Dolt commit
+graph to your git remote under `refs/dolt/data` — a separate ref
+namespace from `refs/heads/*`, so it does not collide with your code's
+branches. The other machine runs `bd dolt pull` to fetch and merge
+those refs into its own local Dolt DB.
+
+`.beads/issues.jsonl` (when present) is an export view: a human-readable
+snapshot produced by `bd export` or by hooks. It exists for portability,
+git-diff review, and bootstrap — it is not the channel that `bd dolt
+push` / `bd dolt pull` use.
+
+## Where to read deeper
+
+After this overview, follow the doc that matches what you need to do:
+
+| Doc | When to read it |
+|-----|-----------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | The full data-model picture: two-layer design, write path, read path, federation. |
+| [SYNC_SETUP.md](SYNC_SETUP.md) | Step-by-step: set up Dolt sync on a new machine and add a remote. |
+| [GIT_INTEGRATION.md](GIT_INTEGRATION.md) | Working with git worktrees, protected branches, or the `bd merge` driver for `.beads/issues.jsonl`. |
+| [DOLT.md](DOLT.md) | Configuring Dolt remotes, embedded vs server mode, backup, and advanced Dolt CLI use. |
+
+## Anti-patterns
+
+These are footguns that look reasonable but break the sync model.
+Newcomers — humans and agents alike — keep rediscovering them.
+
+### Don't treat `.beads/issues.jsonl` as the source of truth
+
+The local Dolt database is the source of truth. `.beads/issues.jsonl`
+is an export — useful for human diff review, for portability, and as a
+bootstrap input for `bd init --from-jsonl`. Editing JSONL directly will
+be overwritten by the next export, and `bd dolt push` / `bd dolt pull`
+don't move data through it. Drive all changes through `bd` commands so
+they land in Dolt; let JSONL be a downstream view.
+
+(Note: some users do use JSONL-via-git as their cross-machine sync
+*channel* in place of `bd dolt push` — that's a valid fallback pattern.
+Even then, the Dolt DB on each machine remains the source of truth;
+JSONL is the wire format between them.)
+
+### Don't use `bd import` as part of normal operation
+
+`bd import` is a bootstrap path: load a JSONL snapshot into a fresh or
+re-initialised database. If you find yourself running it routinely to
+get a peer's latest issues, you've drifted off the Dolt-native sync
+channel — fix the underlying remote / credential / network issue
+instead of rebuilding the local database from a JSONL snapshot each
+time. Reaching for `bd import` regularly is a smell, not a workflow.
+
+### Don't propose a third-party Dolt hosting workaround
+
+Dolt sync uses *your existing git remote*. The Dolt commit graph lives
+under `refs/dolt/data` on the same GitHub / GitLab / SSH remote that
+hosts your code — no separate Dolt server, no DoltHub account, no
+side-channel sync service required. Reach for a hosted Dolt service
+(or a self-run `dolt sql-server`) only when you have a concrete
+requirement that the default doesn't cover (e.g. a multi-writer
+orchestrator with concurrent agents). Start with the default; only
+add infrastructure when something measurable forces you to.
+
+---
+
+**See also:** [FAQ.md](FAQ.md) for general questions,
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md) when sync misbehaves.

--- a/docs/SYNC_CONCEPTS.md
+++ b/docs/SYNC_CONCEPTS.md
@@ -1,10 +1,11 @@
 # Cross-Machine Sync: How It Works
 
 > **One-sentence model:** Issues live in a local Dolt database under
-> `.beads/dolt/`; cross-machine sync uses Dolt's native push/pull, which
-> stores the issue history under `refs/dolt/data` on your git remote —
-> separate from `refs/heads/*` where your code lives. `.beads/issues.jsonl`
-> is a passive export for portability, not the wire protocol.
+> `.beads/dolt/` (server mode) or `.beads/embeddeddolt/` (embedded mode);
+> cross-machine sync uses Dolt's native push/pull, which stores the issue
+> history under `refs/dolt/data` on your git remote — separate from
+> `refs/heads/*` where your code lives. `.beads/issues.jsonl` is a passive
+> export for portability, not the wire protocol.
 
 This page is the entry point. Read it first, then follow the deeper-doc
 links below for the layer you need.
@@ -33,12 +34,14 @@ links below for the layer you need.
 ```
 
 When you run a `bd` command, it reads or writes the **local Dolt
-database**. Every write auto-commits to Dolt history. To share with
-another machine you run `bd dolt push`, which pushes the Dolt commit
-graph to your git remote under `refs/dolt/data` — a separate ref
-namespace from `refs/heads/*`, so it does not collide with your code's
-branches. The other machine runs `bd dolt pull` to fetch and merge
-those refs into its own local Dolt DB.
+database** — `.beads/dolt/` in server mode or `.beads/embeddeddolt/` in
+embedded mode (see [DOLT.md](DOLT.md) for the difference). Every write
+auto-commits to Dolt history. To share with another machine you run
+`bd dolt push`, which pushes the Dolt commit graph to your git remote
+under `refs/dolt/data` — a separate ref namespace from `refs/heads/*`,
+so it does not collide with your code's branches. The other machine
+runs `bd dolt pull` to fetch and merge those refs into its own local
+Dolt DB.
 
 `.beads/issues.jsonl` (when present) is an export view: a human-readable
 snapshot produced by `bd export` or by hooks. It exists for portability,
@@ -55,6 +58,7 @@ After this overview, follow the doc that matches what you need to do:
 | [SYNC_SETUP.md](SYNC_SETUP.md) | Step-by-step: set up Dolt sync on a new machine and add a remote. |
 | [GIT_INTEGRATION.md](GIT_INTEGRATION.md) | Working with git worktrees, protected branches, or the `bd merge` driver for `.beads/issues.jsonl`. |
 | [DOLT.md](DOLT.md) | Configuring Dolt remotes, embedded vs server mode, backup, and advanced Dolt CLI use. |
+| [DOLT-BACKEND.md](DOLT-BACKEND.md) | Remote types (Dolt remotes, S3, GCS, filesystem) and configuration details. |
 
 ## Anti-patterns
 
@@ -70,10 +74,13 @@ be overwritten by the next export, and `bd dolt push` / `bd dolt pull`
 don't move data through it. Drive all changes through `bd` commands so
 they land in Dolt; let JSONL be a downstream view.
 
-(Note: some users do use JSONL-via-git as their cross-machine sync
-*channel* in place of `bd dolt push` — that's a valid fallback pattern.
-Even then, the Dolt DB on each machine remains the source of truth;
-JSONL is the wire format between them.)
+### When JSONL-via-git IS acceptable as a sync channel
+
+If you can't use `bd dolt push` (e.g. policy forbids extra refs on the
+remote), it's fine to commit `.beads/issues.jsonl` to git and have peers
+`bd init --from-jsonl` or re-import on pull. The Dolt DB on each machine
+still remains the source of truth — JSONL is just the wire format
+between them.
 
 ### Don't use `bd import` as part of normal operation
 
@@ -91,9 +98,21 @@ under `refs/dolt/data` on the same GitHub / GitLab / SSH remote that
 hosts your code — no separate Dolt server, no DoltHub account, no
 side-channel sync service required. Reach for a hosted Dolt service
 (or a self-run `dolt sql-server`) only when you have a concrete
-requirement that the default doesn't cover (e.g. a multi-writer
-orchestrator with concurrent agents). Start with the default; only
-add infrastructure when something measurable forces you to.
+requirement that the default doesn't cover (e.g. multiple agents
+writing simultaneously from different processes or machines that can't
+all reach the same git remote). Start with the default; only add
+infrastructure when something measurable forces you to.
+
+### Don't commit `.beads/dolt/` to git
+
+The Dolt database directory lives next to your code, but it does not
+travel through git's commit flow. `bd init` adds `.beads/dolt/` and
+`.beads/embeddeddolt/` to `.gitignore` automatically. Committing those
+directories would bloat the repo with binary chunk files and break
+Dolt's expectations about exclusive on-disk ownership — sync moves
+through `bd dolt push` / `bd dolt pull` (refs under `refs/dolt/data`)
+instead. See [GIT_INTEGRATION.md](GIT_INTEGRATION.md) for the full
+boundary between git-tracked and Dolt-tracked state.
 
 ---
 

--- a/docs/SYNC_SETUP.md
+++ b/docs/SYNC_SETUP.md
@@ -2,6 +2,8 @@
 
 Set up beads with Dolt sync so your issues follow you across computers.
 
+> **New here?** Read [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) first for a one-screen overview of *what* cross-machine sync is doing under the hood. This page is the *how*.
+
 ## Prerequisites
 
 You need two tools installed on every machine:
@@ -246,6 +248,7 @@ bd dolt start
 
 ## See Also
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) — One-screen overview of how cross-machine sync works + anti-patterns
 - [QUICKSTART.md](QUICKSTART.md) — Getting started with beads
 - [DOLT.md](DOLT.md) — Dolt backend details, server modes, federation
 - [DOLT-BACKEND.md](DOLT-BACKEND.md) — Remote types, sync modes, advanced usage


### PR DESCRIPTION
## Summary

Adds `docs/SYNC_CONCEPTS.md` — a one-screen entry-point for *how cross-machine sync works* — and links it from the four natural reading-path homes so newcomers (humans **and** agents) land on it first before being routed to the deeper docs.

This responds directly to @thewoolleyman's feedback on #3683 ([comment](https://github.com/gastownhall/beads/issues/3683#issuecomment-)) which laid out 4 concrete onboarding gaps. This PR addresses items **#1 (single entry-point doc)** and **#4 (anti-patterns section)**, with item #2 (architecture summary in the bd-init AGENTS.md template) tracked as a follow-up.

## What's in the doc

1. **One-sentence architecture model** at the top — issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export, not the wire protocol.
2. **ASCII mental-model diagram** showing two machines, their local Dolt DBs, and the shared git remote with `refs/heads/*` and `refs/dolt/data` side by side.
3. **"Where to read deeper" routing table** linking to the 4 docs thewoolleyman cited (ARCHITECTURE, SYNC_SETUP, GIT_INTEGRATION, DOLT) with explicit "read this when…" framing.
4. **Anti-patterns section** explicitly naming the three failure modes from the comment:
   - Don't treat `.beads/issues.jsonl` as the source of truth (with a nuance acknowledging JSONL-via-git as a valid alternative *channel*, since the dolt remote isn't always reachable — but the local Dolt DB remains the source of truth either way).
   - Don't use `bd import` as part of normal operation.
   - Don't propose a third-party Dolt hosting workaround.

## Cross-links

To make the new doc discoverable without disturbing existing reading paths:

- `README.md` — added to the documentation links line.
- `docs/ARCHITECTURE.md` — front-matter "looking for the short version first?" pointer + `Related Documentation` entry.
- `docs/SYNC_SETUP.md` — front-matter "new here?" pointer + `See Also` entry.
- `docs/DOLT.md` — `See Also` entry.
- `docs/GIT_INTEGRATION.md` — `See Also` entry.

## Coordination with sibling #3683 PRs

| PR | Overlap with this PR? |
|---|---|
| #3704 (auto-gen CLI reference) | No — orthogonal. This is conceptual overview, not command reference. |
| #3692 (`bd prime` memory truncation + per-command docs) | No — orthogonal; per-command docs are not what's missing here. |
| #3712 (FAQ "git-based" wording fix) | Same architectural truth; this PR provides the canonical destination to point at. No file overlap. |
| #3715 (DOLT.md / DOLT-BACKEND.md dedupe) | Independent. My link to DOLT.md remains correct after that lands. |
| #3706 (DOC_INVENTORY) | Independent audit; not in conflict. |
| #3711, #3713, #3714 (LINTING fossil, broken xref, configuration.md staleness) | Independent. |

## Follow-up

@thewoolleyman's item #2 ("auto-include the architecture statement at the top of bd-init-generated AGENTS.md / CLAUDE.md") is tracked as a separate PR depending on this one — once SYNC_CONCEPTS.md exists, the template can prepend a 1-2 line architecture summary plus link.

Item #3 ("Document `bd prime`, `bd remember`, `bd dream`, `bd edit`") is largely covered by #3704 (auto-gen reference) and #3692 (prime + memory commands); `bd dream` is not a real command per the issue thread.

## Test plan

- [x] `git log --oneline HEAD --not upstream/main` shows only this commit.
- [x] `bash scripts/check-doc-flags.sh` introduces no new failures (the existing CLI_REFERENCE coverage failure is pre-existing and is what #3704 fixes).
- [ ] Maintainer skim: does the one-sentence model line up with how you'd describe it to someone for the first time?
- [ ] Maintainer skim: anti-patterns wording — agree with the framing? Anything to add or soften?
- [ ] Renders cleanly on the docs site once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->