### PR TITLE
feat: add first-class prompt capture command

### DIFF
--- a/.github/scripts/embedded-cmd-test-shards.txt
+++ b/.github/scripts/embedded-cmd-test-shards.txt
@@ -100,6 +100,7 @@
 20 12 TestEmbeddedOrphansConcurrent
 20 13 TestEmbeddedPrime
 20 14 TestEmbeddedPrimeConcurrent
+20 17 TestEmbeddedPromptCapture
 20 15 TestEmbeddedPromote
 20 16 TestEmbeddedPromoteCLI
 20 17 TestEmbeddedPromoteCLIConcurrent

--- a/cmd/bd/prompt_capture.go
+++ b/cmd/bd/prompt_capture.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
+)
+
+var promptCmd = &cobra.Command{
+	Use:     "prompt",
+	GroupID: "issues",
+	Short:   "Capture user prompts as traceable beads",
+}
+
+var promptCaptureCmd = &cobra.Command{
+	Use:   "capture",
+	Short: "Capture a raw user prompt as a bead",
+	Run: func(cmd *cobra.Command, args []string) {
+		CheckReadonly("prompt capture")
+
+		title, _ := cmd.Flags().GetString("title")
+		if strings.TrimSpace(title) == "" {
+			FatalError("--title is required")
+		}
+
+		promptText := getPromptTextFlag(cmd)
+		if strings.TrimSpace(promptText) == "" {
+			FatalError("prompt text is required; pass --stdin or --body-file")
+		}
+
+		parentID, _ := cmd.Flags().GetString("parent")
+		sessionID, _ := cmd.Flags().GetString("session")
+		sourceTool, _ := cmd.Flags().GetString("source-tool")
+		summary, _ := cmd.Flags().GetString("summary")
+		silent, _ := cmd.Flags().GetBool("silent")
+		labels, _ := cmd.Flags().GetStringSlice("labels")
+		labelAlias, _ := cmd.Flags().GetStringSlice("label")
+		labels = append(labels, labelAlias...)
+		labels = mergePromptLabels(labels)
+
+		if sessionID == "" {
+			sessionID = os.Getenv("BEADS_SESSION_ID")
+		}
+
+		metadata, err := promptCaptureMetadata(sessionID, sourceTool, summary)
+		if err != nil {
+			FatalError("failed to build prompt metadata: %v", err)
+		}
+
+		auditActor := getActorWithGit()
+		if parentID != "" {
+			if _, err := store.GetIssue(rootCtx, parentID); err != nil {
+				if errors.Is(err, storage.ErrNotFound) {
+					FatalError("parent issue %s not found", parentID)
+				}
+				FatalError("failed to check parent issue: %v", err)
+			}
+		}
+
+		issue := &types.Issue{
+			Title:              title,
+			Description:        promptText,
+			AcceptanceCriteria: "Prompt captured; related work should be linked, parented, or noted from this bead.",
+			Status:             types.StatusOpen,
+			Priority:           2,
+			IssueType:          types.TypeTask,
+			CreatedBy:          auditActor,
+			Owner:              getOwner(),
+			SourceSystem:       "bd prompt capture",
+			Metadata:           metadata,
+		}
+
+		if err := store.CreateIssue(rootCtx, issue, auditActor); err != nil {
+			FatalError("%v", err)
+		}
+
+		postCreateWrites := false
+		if parentID != "" {
+			dep := &types.Dependency{
+				IssueID:     issue.ID,
+				DependsOnID: parentID,
+				Type:        types.DepParentChild,
+			}
+			if err := store.AddDependency(rootCtx, dep, auditActor); err != nil {
+				WarnError("failed to add parent-child dependency %s -> %s: %v", issue.ID, parentID, err)
+			} else {
+				postCreateWrites = true
+			}
+		}
+
+		for _, label := range labels {
+			if err := store.AddLabel(rootCtx, issue.ID, label, auditActor); err != nil {
+				WarnError("failed to add label %s: %v", label, err)
+			} else {
+				postCreateWrites = true
+			}
+		}
+
+		if isEmbeddedMode() || postCreateWrites {
+			if err := store.Commit(rootCtx, fmt.Sprintf("bd: prompt capture %s", issue.ID)); err != nil && !isDoltNothingToCommit(err) {
+				WarnError("failed to commit: %v", err)
+			}
+		}
+
+		issue.Labels = labels
+		if jsonOutput {
+			outputJSON(issue)
+		} else if silent {
+			fmt.Println(issue.ID)
+		} else {
+			fmt.Printf("%s Captured prompt: %s\n", ui.RenderPass("✓"), formatFeedbackID(issue.ID, issue.Title))
+		}
+		SetLastTouchedID(issue.ID)
+	},
+}
+
+func promptCaptureMetadata(sessionID, sourceTool, summary string) (json.RawMessage, error) {
+	cwd, _ := os.Getwd()
+	metadata := map[string]string{
+		"kind":        "prompt",
+		"source":      "user_prompt",
+		"captured_at": time.Now().UTC().Format(time.RFC3339Nano),
+		"actor":       getActorWithGit(),
+		"cwd":         cwd,
+	}
+	if summary != "" {
+		metadata["summary"] = summary
+	}
+	if sessionID != "" {
+		metadata["session_id"] = sessionID
+	}
+	if sourceTool != "" {
+		metadata["source_tool"] = sourceTool
+	}
+	if repo := gitOutput("rev-parse", "--show-toplevel"); repo != "" {
+		metadata["repo"] = repo
+	}
+	if branch := gitOutput("rev-parse", "--abbrev-ref", "HEAD"); branch != "" {
+		metadata["git_branch"] = branch
+	}
+	if head := gitOutput("rev-parse", "--short", "HEAD"); head != "" {
+		metadata["git_head"] = head
+	}
+
+	raw, err := json.Marshal(metadata)
+	return json.RawMessage(raw), err
+}
+
+func gitOutput(args ...string) string {
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func mergePromptLabels(labels []string) []string {
+	seen := make(map[string]bool, len(labels)+2)
+	result := make([]string, 0, len(labels)+2)
+	for _, label := range append([]string{"prompt", "user-request"}, labels...) {
+		label = strings.TrimSpace(label)
+		if label == "" || seen[label] {
+			continue
+		}
+		seen[label] = true
+		result = append(result, label)
+	}
+	return result
+}
+
+func getPromptTextFlag(cmd *cobra.Command) string {
+	stdinFlag, _ := cmd.Flags().GetBool("stdin")
+	bodyFile, _ := cmd.Flags().GetString("body-file")
+	description, _ := cmd.Flags().GetString("description")
+
+	changed := 0
+	if stdinFlag {
+		changed++
+	}
+	if bodyFile != "" {
+		changed++
+	}
+	if description != "" {
+		changed++
+	}
+	if changed > 1 {
+		FatalError("use only one of --stdin, --body-file, or --description")
+	}
+	if stdinFlag {
+		content, err := readBodyFile("-")
+		if err != nil {
+			FatalError("reading from stdin: %v", err)
+		}
+		return content
+	}
+	if bodyFile != "" {
+		content, err := readBodyFile(bodyFile)
+		if err != nil {
+			FatalError("reading body file: %v", err)
+		}
+		return content
+	}
+	return description
+}
+
+func init() {
+	promptCaptureCmd.Flags().String("title", "", "Prompt bead title")
+	promptCaptureCmd.Flags().String("summary", "", "Short normalized summary of the prompt")
+	promptCaptureCmd.Flags().String("parent", "", "Parent issue ID for hierarchical child")
+	promptCaptureCmd.Flags().String("session", "", "Agent/session identifier")
+	promptCaptureCmd.Flags().String("source-tool", "", "Tool or agent that captured the prompt")
+	promptCaptureCmd.Flags().StringP("description", "d", "", "Raw prompt text")
+	promptCaptureCmd.Flags().String("body-file", "", "Read raw prompt text from file (use - for stdin)")
+	promptCaptureCmd.Flags().Bool("stdin", false, "Read raw prompt text from stdin")
+	promptCaptureCmd.Flags().StringSliceP("labels", "l", []string{}, "Additional labels")
+	promptCaptureCmd.Flags().StringSlice("label", []string{}, "Alias for --labels")
+	_ = promptCaptureCmd.Flags().MarkHidden("label")
+	promptCaptureCmd.Flags().Bool("silent", false, "Output only the issue ID")
+	promptCmd.AddCommand(promptCaptureCmd)
+	rootCmd.AddCommand(promptCmd)
+}

--- a/cmd/bd/prompt_capture_test.go
+++ b/cmd/bd/prompt_capture_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/utils"
+)
+
+func TestMergePromptLabels(t *testing.T) {
+	got := mergePromptLabels([]string{"product", "prompt", " user-request ", "", "product", "audit"})
+	want := []string{"prompt", "user-request", "product", "audit"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mergePromptLabels() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPromptCaptureMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldDir); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+
+	raw, err := promptCaptureMetadata("sess-42", "codex", "Summarize prompt")
+	if err != nil {
+		t.Fatalf("promptCaptureMetadata: %v", err)
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		t.Fatalf("metadata json: %v", err)
+	}
+
+	for key, want := range map[string]string{
+		"kind":        "prompt",
+		"source":      "user_prompt",
+		"session_id":  "sess-42",
+		"source_tool": "codex",
+		"summary":     "Summarize prompt",
+	} {
+		if metadata[key] != want {
+			t.Errorf("metadata[%q] = %q, want %q", key, metadata[key], want)
+		}
+	}
+	if !utils.PathsEqual(metadata["cwd"], tmpDir) {
+		t.Errorf("metadata cwd = %q, want %q", metadata["cwd"], tmpDir)
+	}
+	if metadata["captured_at"] == "" {
+		t.Error("metadata captured_at is empty")
+	}
+	if metadata["actor"] == "" {
+		t.Error("metadata actor is empty")
+	}
+}
+
+func TestGetPromptTextFlag(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "capture"}
+		cmd.Flags().StringP("description", "d", "", "Raw prompt text")
+		cmd.Flags().String("body-file", "", "Read raw prompt text from file")
+		cmd.Flags().Bool("stdin", false, "Read raw prompt text from stdin")
+		return cmd
+	}
+
+	t.Run("Description", func(t *testing.T) {
+		cmd := newCmd()
+		if err := cmd.ParseFlags([]string{"--description", "raw user prompt"}); err != nil {
+			t.Fatalf("parse flags: %v", err)
+		}
+		if got := getPromptTextFlag(cmd); got != "raw user prompt" {
+			t.Fatalf("getPromptTextFlag() = %q", got)
+		}
+	})
+
+	t.Run("BodyFile", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "prompt.txt")
+		if err := os.WriteFile(path, []byte("prompt from file"), 0644); err != nil {
+			t.Fatalf("write prompt file: %v", err)
+		}
+		cmd := newCmd()
+		if err := cmd.ParseFlags([]string{"--body-file", path}); err != nil {
+			t.Fatalf("parse flags: %v", err)
+		}
+		if got := getPromptTextFlag(cmd); got != "prompt from file" {
+			t.Fatalf("getPromptTextFlag() = %q", got)
+		}
+	})
+
+	t.Run("Stdin", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("pipe: %v", err)
+		}
+		oldStdin := os.Stdin
+		os.Stdin = r
+		t.Cleanup(func() { os.Stdin = oldStdin })
+		go func() {
+			_, _ = w.WriteString("prompt from stdin")
+			_ = w.Close()
+		}()
+
+		cmd := newCmd()
+		if err := cmd.ParseFlags([]string{"--stdin"}); err != nil {
+			t.Fatalf("parse flags: %v", err)
+		}
+		if got := getPromptTextFlag(cmd); got != "prompt from stdin" {
+			t.Fatalf("getPromptTextFlag() = %q", got)
+		}
+	})
+}
+
+func TestPromptCommandRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"prompt", "capture"})
+	if err != nil {
+		t.Fatalf("find prompt capture: %v", err)
+	}
+	if cmd != promptCaptureCmd {
+		t.Fatalf("root prompt capture command mismatch")
+	}
+
+	for _, name := range []string{"title", "summary", "parent", "session", "source-tool", "description", "body-file", "stdin", "labels", "label", "silent"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing prompt capture flag %q", name)
+		}
+	}
+	if !strings.Contains(cmd.Short, "Capture") {
+		t.Errorf("unexpected short help: %q", cmd.Short)
+	}
+}

--- a/cmd/bd/prompt_capture_test.go
+++ b/cmd/bd/prompt_capture_test.go
@@ -1,16 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/utils"
 )
+
+var promptCaptureCLIMutex sync.Mutex
 
 func TestMergePromptLabels(t *testing.T) {
 	got := mergePromptLabels([]string{"product", "prompt", " user-request ", "", "product", "audit"})
@@ -64,6 +70,116 @@ func TestPromptCaptureMetadata(t *testing.T) {
 	}
 	if metadata["actor"] == "" {
 		t.Error("metadata actor is empty")
+	}
+}
+
+func TestPromptCaptureCommandCreatesPromptBead(t *testing.T) {
+	dir := t.TempDir()
+	runPromptCaptureCommand(t, dir, "init", "--prefix", "pc", "--quiet")
+
+	parentOut := runPromptCaptureCommand(t, dir, "create", "Parent prompt work", "--json")
+	parentID := parsePromptCaptureIssueID(t, parentOut)
+
+	bodyPath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(bodyPath, []byte("please capture this exact prompt"), 0600); err != nil {
+		t.Fatalf("write prompt body: %v", err)
+	}
+
+	out := runPromptCaptureCommand(
+		t,
+		dir,
+		"prompt",
+		"capture",
+		"--json",
+		"--title", "Capture CLI prompt",
+		"--summary", "Capture prompt from CLI",
+		"--session", "sess-cli",
+		"--source-tool", "codex",
+		"--parent", parentID,
+		"--label", "product",
+		"--labels", "handoff",
+		"--body-file", bodyPath,
+	)
+
+	var issue struct {
+		ID                 string          `json:"id"`
+		Title              string          `json:"title"`
+		Description        string          `json:"description"`
+		AcceptanceCriteria string          `json:"acceptance_criteria"`
+		SourceSystem       string          `json:"source_system"`
+		Labels             []string        `json:"labels"`
+		Metadata           json.RawMessage `json:"metadata"`
+	}
+	if err := json.Unmarshal([]byte(extractPromptCaptureJSON(out)), &issue); err != nil {
+		t.Fatalf("parse prompt capture JSON: %v\n%s", err, out)
+	}
+
+	if issue.ID == "" {
+		t.Fatal("expected prompt issue ID")
+	}
+	if issue.Title != "Capture CLI prompt" {
+		t.Fatalf("title = %q", issue.Title)
+	}
+	if issue.Description != "please capture this exact prompt" {
+		t.Fatalf("description = %q", issue.Description)
+	}
+	if !strings.Contains(issue.AcceptanceCriteria, "Prompt captured") {
+		t.Fatalf("acceptance criteria = %q", issue.AcceptanceCriteria)
+	}
+	if issue.SourceSystem != "bd prompt capture" {
+		t.Fatalf("source system = %q", issue.SourceSystem)
+	}
+
+	for _, want := range []string{"prompt", "user-request", "product", "handoff"} {
+		if !hasPromptCaptureLabel(issue.Labels, want) {
+			t.Fatalf("missing label %q in %#v", want, issue.Labels)
+		}
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal(issue.Metadata, &metadata); err != nil {
+		t.Fatalf("metadata JSON: %v\n%s", err, issue.Metadata)
+	}
+	for key, want := range map[string]string{
+		"kind":        "prompt",
+		"source":      "user_prompt",
+		"session_id":  "sess-cli",
+		"source_tool": "codex",
+		"summary":     "Capture prompt from CLI",
+	} {
+		if metadata[key] != want {
+			t.Fatalf("metadata[%q] = %q, want %q", key, metadata[key], want)
+		}
+	}
+	if metadata["actor"] != "prompt-test-user" {
+		t.Fatalf("metadata actor = %q", metadata["actor"])
+	}
+	if !utils.PathsEqual(metadata["cwd"], dir) {
+		t.Fatalf("metadata cwd = %q, want %q", metadata["cwd"], dir)
+	}
+
+	showOut := runPromptCaptureCommand(t, dir, "show", issue.ID, "--json")
+	var shown []struct {
+		Dependencies []struct {
+			ID             string `json:"id"`
+			DependencyType string `json:"dependency_type"`
+		} `json:"dependencies"`
+	}
+	if err := json.Unmarshal([]byte(extractPromptCaptureJSON(showOut)), &shown); err != nil {
+		t.Fatalf("parse show JSON: %v\n%s", err, showOut)
+	}
+	if len(shown) != 1 {
+		t.Fatalf("expected one shown issue, got %d", len(shown))
+	}
+	foundParent := false
+	for _, dep := range shown[0].Dependencies {
+		if dep.ID == parentID && dep.DependencyType == "parent-child" {
+			foundParent = true
+			break
+		}
+	}
+	if !foundParent {
+		t.Fatalf("expected parent dependency %s in %#v", parentID, shown[0].Dependencies)
 	}
 }
 
@@ -140,4 +256,121 @@ func TestPromptCommandRegistered(t *testing.T) {
 	if !strings.Contains(cmd.Short, "Capture") {
 		t.Errorf("unexpected short help: %q", cmd.Short)
 	}
+}
+
+func runPromptCaptureCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	promptCaptureCLIMutex.Lock()
+	defer promptCaptureCLIMutex.Unlock()
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	oldDir, _ := os.Getwd()
+	oldArgs := os.Args
+
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	restoreEnv := setPromptCaptureEnv(t, "BEADS_TEST_MODE", "1")
+	defer restoreEnv()
+	restoreActor := setPromptCaptureEnv(t, "BEADS_ACTOR", "prompt-test-user")
+	defer restoreActor()
+	restoreLegacyActor := setPromptCaptureEnv(t, "BD_ACTOR", "prompt-test-user")
+	defer restoreLegacyActor()
+	restoreBeadsDir := setPromptCaptureEnv(t, "BEADS_DIR", filepath.Join(dir, ".beads"))
+	defer restoreBeadsDir()
+
+	rootCmd.SetArgs(args)
+	os.Args = append([]string{"bd"}, args...)
+	err := rootCmd.Execute()
+
+	if store != nil {
+		_ = store.Close()
+		store = nil
+	}
+	dbPath = ""
+	actor = ""
+	jsonOutput = false
+	sandboxMode = false
+	readonlyMode = false
+	serverMode = false
+	rootCtx = nil
+	rootCancel = nil
+	resetCommandContext()
+
+	time.Sleep(10 * time.Millisecond)
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	_ = os.Chdir(oldDir)
+	os.Args = oldArgs
+	rootCmd.SetArgs(nil)
+
+	var outBuf, errBuf bytes.Buffer
+	_, _ = io.Copy(&outBuf, rOut)
+	_, _ = io.Copy(&errBuf, rErr)
+	_ = rOut.Close()
+	_ = rErr.Close()
+
+	stdout := outBuf.String()
+	stderr := errBuf.String()
+	if err != nil {
+		t.Fatalf("bd %v failed: %v\nStdout: %s\nStderr: %s", args, err, stdout, stderr)
+	}
+
+	return stdout
+}
+
+func setPromptCaptureEnv(t *testing.T, key, value string) func() {
+	t.Helper()
+	old, ok := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("set %s: %v", key, err)
+	}
+	return func() {
+		if ok {
+			_ = os.Setenv(key, old)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	}
+}
+
+func parsePromptCaptureIssueID(t *testing.T, out string) string {
+	t.Helper()
+	var issue struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(extractPromptCaptureJSON(out)), &issue); err != nil {
+		t.Fatalf("parse issue JSON: %v\n%s", err, out)
+	}
+	if issue.ID == "" {
+		t.Fatalf("missing issue ID in output: %s", out)
+	}
+	return issue.ID
+}
+
+func extractPromptCaptureJSON(s string) string {
+	if i := strings.IndexAny(s, "[{"); i >= 0 {
+		return s[i:]
+	}
+	return s
+}
+
+func hasPromptCaptureLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/bd/prompt_embedded_test.go
+++ b/cmd/bd/prompt_embedded_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 func TestEmbeddedPromptCapture(t *testing.T) {
@@ -90,7 +91,7 @@ func TestEmbeddedPromptCapture(t *testing.T) {
 	if metadata["summary"] != "Build prompt capture" {
 		t.Errorf("metadata summary: got %q", metadata["summary"])
 	}
-	if metadata["cwd"] != dir {
+	if !utils.PathsEqual(metadata["cwd"], dir) {
 		t.Errorf("metadata cwd: got %q, want %q", metadata["cwd"], dir)
 	}
 

--- a/cmd/bd/prompt_embedded_test.go
+++ b/cmd/bd/prompt_embedded_test.go
@@ -1,0 +1,106 @@
+//go:build cgo
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestEmbeddedPromptCapture(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt prompt tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "pc")
+
+	parent := bdCreate(t, bd, dir, "Parent work")
+
+	cmd := exec.Command(
+		bd,
+		"prompt",
+		"capture",
+		"--json",
+		"--title", "Capture raw user request",
+		"--summary", "Build prompt capture",
+		"--session", "sess-123",
+		"--source-tool", "codex",
+		"--parent", parent.ID,
+		"--label", "product",
+		"--stdin",
+	)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	cmd.Stdin = strings.NewReader("please remember this exact user prompt")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("bd prompt capture failed: %v\n%s", err, out)
+	}
+
+	issue := parseIssueJSON(t, out)
+	if issue.ID == "" {
+		t.Fatal("expected issue ID")
+	}
+	if issue.Title != "Capture raw user request" {
+		t.Errorf("title: got %q", issue.Title)
+	}
+	if issue.Description != "please remember this exact user prompt" {
+		t.Errorf("description: got %q", issue.Description)
+	}
+	if issue.IssueType != types.TypeTask {
+		t.Errorf("type: got %q, want %q", issue.IssueType, types.TypeTask)
+	}
+
+	labels := map[string]bool{}
+	for _, label := range issue.Labels {
+		labels[label] = true
+	}
+	for _, want := range []string{"prompt", "user-request", "product"} {
+		if !labels[want] {
+			t.Errorf("missing label %q in %#v", want, issue.Labels)
+		}
+	}
+
+	shown := bdShow(t, bd, dir, issue.ID)
+	var metadata map[string]string
+	if err := json.Unmarshal(shown.Metadata, &metadata); err != nil {
+		t.Fatalf("metadata json: %v\n%s", err, shown.Metadata)
+	}
+	if metadata["kind"] != "prompt" {
+		t.Errorf("metadata kind: got %q", metadata["kind"])
+	}
+	if metadata["source"] != "user_prompt" {
+		t.Errorf("metadata source: got %q", metadata["source"])
+	}
+	if metadata["session_id"] != "sess-123" {
+		t.Errorf("metadata session_id: got %q", metadata["session_id"])
+	}
+	if metadata["source_tool"] != "codex" {
+		t.Errorf("metadata source_tool: got %q", metadata["source_tool"])
+	}
+	if metadata["summary"] != "Build prompt capture" {
+		t.Errorf("metadata summary: got %q", metadata["summary"])
+	}
+	if metadata["cwd"] != dir {
+		t.Errorf("metadata cwd: got %q, want %q", metadata["cwd"], dir)
+	}
+
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("load metadata: %v", err)
+	}
+	database := "beads"
+	if cfg != nil && cfg.DoltDatabase != "" {
+		database = cfg.DoltDatabase
+	}
+	assertDepExistsWithType(t, filepath.Join(beadsDir), database, issue.ID, parent.ID, string(types.DepParentChild))
+}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -41,6 +41,8 @@ Reference for bd Latest. Generated from `bd help --all`.
 - [bd note](#bd-note) — Append a note to an issue
 - [bd priority](#bd-priority) — Set the priority of an issue
 - [bd promote](#bd-promote) — Promote a wisp to a permanent bead
+- [bd prompt](#bd-prompt) — Capture user prompts as traceable beads
+  - [bd prompt capture](#bd-prompt-capture) — Capture a raw user prompt as a bead
 - [bd q](#bd-q) — Quick capture: create issue and output only ID
 - [bd query](#bd-query) — Query issues using a simple query language
 - [bd reopen](#bd-reopen) — Reopen one or more closed issues
@@ -1090,6 +1092,37 @@ bd promote <wisp-id> [flags]
 
 ```
   -r, --reason string   Reason for promotion
+```
+
+### bd prompt
+
+Capture user prompts as traceable beads
+
+```
+bd prompt
+```
+
+#### bd prompt capture
+
+Capture a raw user prompt as a bead
+
+```
+bd prompt capture [flags]
+```
+
+**Flags:**
+
+```
+      --body-file string     Read raw prompt text from file (use - for stdin)
+  -d, --description string   Raw prompt text
+  -l, --labels strings       Additional labels
+      --parent string        Parent issue ID for hierarchical child
+      --session string       Agent/session identifier
+      --silent               Output only the issue ID
+      --source-tool string   Tool or agent that captured the prompt
+      --stdin                Read raw prompt text from stdin
+      --summary string       Short normalized summary of the prompt
+      --title string         Prompt bead title
 ```
 
 ### bd q

--- a/plugins/beads/skills/beads/commands/prompt.md
+++ b/plugins/beads/skills/beads/commands/prompt.md
@@ -1,0 +1,27 @@
+---
+description: Capture user prompts as traceable beads
+---
+
+# Prompt Capture
+
+Use `bd prompt capture` to preserve the raw user request that caused work to happen.
+
+```bash
+echo 'Raw user prompt text' | bd prompt capture \
+  --title "Short prompt summary" \
+  --summary "Normalized summary" \
+  --session "$BEADS_SESSION_ID" \
+  --source-tool codex \
+  --parent <parent-id> \
+  --stdin \
+  --json
+```
+
+Prompt capture creates a normal task bead with:
+
+- Description set to the raw prompt text.
+- Labels `prompt` and `user-request`, plus any labels passed with `--labels`.
+- Metadata fields for `kind=prompt`, `source=user_prompt`, `captured_at`, actor, cwd, repo, git branch/head, session id, source tool, and summary when provided.
+- Optional parent-child dependency when `--parent` is provided.
+
+Use prompt beads as provenance. Promote or split them into ordinary feature, task, bug, decision, or question beads when the work becomes clear.

--- a/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
+++ b/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
@@ -163,6 +163,16 @@ bd create "Issue title" --id worker1-100 -p 1 --json
 bd create "Issue title" -t bug -p 1 -l bug,critical --json
 bd create "Issue title" -t bug -p 1 --label bug,critical --json
 
+# Capture a raw user prompt as a traceability bead
+echo 'Please build prompt capture' | bd prompt capture \
+  --title "Capture prompt request" \
+  --summary "Build prompt capture" \
+  --session "$BEADS_SESSION_ID" \
+  --source-tool codex \
+  --parent <parent-id> \
+  --stdin \
+  --json
+
 # Examples with special characters (all require quoting):
 bd create "Fix: auth doesn't validate tokens" -t bug -p 1 --json
 bd create "Add support for OAuth 2.0" -d "Implement RFC 6749 (OAuth 2.0 spec)" --json

--- a/website/docs/cli-reference/index.md
+++ b/website/docs/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd Latest. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -87,6 +87,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd prime`](./prime.md)
 - [`bd priority`](./priority.md)
 - [`bd promote`](./promote.md)
+- [`bd prompt`](./prompt.md)
 - [`bd prune`](./prune.md)
 - [`bd purge`](./purge.md)
 - [`bd q`](./q.md)

--- a/website/docs/cli-reference/prompt.md
+++ b/website/docs/cli-reference/prompt.md
@@ -1,0 +1,40 @@
+---
+id: prompt
+title: bd prompt
+slug: /cli-reference/prompt
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc prompt`
+
+## bd prompt
+
+Capture user prompts as traceable beads
+
+```
+bd prompt
+```
+
+### bd prompt capture
+
+Capture a raw user prompt as a bead
+
+```
+bd prompt capture [flags]
+```
+
+**Flags:**
+
+```
+      --body-file string     Read raw prompt text from file (use - for stdin)
+  -d, --description string   Raw prompt text
+  -l, --labels strings       Additional labels
+      --parent string        Parent issue ID for hierarchical child
+      --session string       Agent/session identifier
+      --silent               Output only the issue ID
+      --source-tool string   Tool or agent that captured the prompt
+      --stdin                Read raw prompt text from stdin
+      --summary string       Short normalized summary of the prompt
+      --title string         Prompt bead title
+```

--- a/website/versioned_docs/version-1.0.0/cli-reference/index.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 <!-- AUTO-GENERATED: do not edit manually -->
 Reference for bd v1.0.0. Generated from `bd help --list` and `bd help --doc <command>`.
 
-This reference covers all 106 live top-level `bd` commands. Regenerate it with:
+This reference covers all 107 live top-level `bd` commands. Regenerate it with:
 
 ```bash
 ./scripts/generate-cli-docs.sh
@@ -87,6 +87,7 @@ This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 - [`bd prime`](./prime.md)
 - [`bd priority`](./priority.md)
 - [`bd promote`](./promote.md)
+- [`bd prompt`](./prompt.md)
 - [`bd prune`](./prune.md)
 - [`bd purge`](./purge.md)
 - [`bd q`](./q.md)

--- a/website/versioned_docs/version-1.0.0/cli-reference/prompt.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/prompt.md
@@ -1,0 +1,40 @@
+---
+id: prompt
+title: bd prompt
+slug: /cli-reference/prompt
+sidebar_position: 999
+---
+
+<!-- AUTO-GENERATED: do not edit manually -->
+Generated from `bd help --doc prompt`
+
+## bd prompt
+
+Capture user prompts as traceable beads
+
+```
+bd prompt
+```
+
+### bd prompt capture
+
+Capture a raw user prompt as a bead
+
+```
+bd prompt capture [flags]
+```
+
+**Flags:**
+
+```
+      --body-file string     Read raw prompt text from file (use - for stdin)
+  -d, --description string   Raw prompt text
+  -l, --labels strings       Additional labels
+      --parent string        Parent issue ID for hierarchical child
+      --session string       Agent/session identifier
+      --silent               Output only the issue ID
+      --source-tool string   Tool or agent that captured the prompt
+      --stdin                Read raw prompt text from stdin
+      --summary string       Short normalized summary of the prompt
+      --title string         Prompt bead title
+```


### PR DESCRIPTION
## Summary

Implements #3731 with a first-class `bd prompt capture` command for preserving raw user prompts as traceable beads.

The new command:
- accepts raw prompt text via `--stdin`, `--body-file`, or `--description`
- requires a short `--title`
- records optional `--summary`, `--session`, `--source-tool`, and `--parent`
- creates a normal task bead with `prompt,user-request` labels
- stores structured prompt metadata: kind/source, captured_at, actor, cwd, repo, git branch/head, session id, source tool, and summary
- creates a parent-child dependency when `--parent` is provided
- supports `--json` and `--silent` for hook/agent automation

Docs were added to the Beads skill CLI reference and command docs.

Closes #3731.

## Validation

- PASS: `go test -tags gms_pure_go ./cmd/bd -run 'Test(MergePromptLabels|PromptCaptureMetadata|GetPromptTextFlag|PromptCommandRegistered|EmbeddedPromptCapture)' -count=1`
- PASS: `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedPromptCapture' -count=1`
- PASS: `go test -tags gms_pure_go ./cmd/bd -run 'TestResolveWhereBeadsDir_UsesInitializedDBPath|TestResolveWhereDatabasePath_PrefersInitializedDBPath' -count=1 -v`
- PASS: `git diff --check`
- PASS: GitHub CI for the previous revision was fully green; rerun is pending for the latest coverage-only test commit.

## Preflight

- Ran `scripts/pr-preflight.sh --search "prompt capture session ledger" --repo gastownhall/beads`; no open PRs matched.