### PR TITLE
docs(codex): add skill path hint and marker-coexistence note

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -196,6 +196,7 @@ bd setup codex --global # Global Beads skill + global AGENTS.md guidance
 - Restart Codex if it's already running to pick up the new instructions.
 - The plugin package under `plugins/beads/` is separate from `bd setup codex`. The setup command writes a small setup-only skill and managed guidance into the target repository or user-level `.agents` directory.
 - In worktree/shared/`BEADS_DIR` setups, use `bd where` to confirm the resolved workspace; the integration does not require a local `./.beads`.
+- `bd setup codex` uses its own marker pair (`BEGIN/END BEADS CODEX SETUP`), distinct from the `BEGIN/END BEADS INTEGRATION` markers used by `bd setup factory` and `bd setup mux`. Running both `bd setup codex` and `bd setup factory`/`mux` against the same `AGENTS.md` will leave two managed sections side by side; each `bd setup … --check` only inspects its own section, and `bd setup … --remove` only removes its own section.
 
 ## Mux
 

--- a/internal/templates/agents/defaults/beads-section-codex.md
+++ b/internal/templates/agents/defaults/beads-section-codex.md
@@ -1,6 +1,6 @@
 ## Beads Issue Tracker
 
-Use Beads (`bd`) for durable task tracking in repositories that include it. Use the `beads` skill for Beads workflow guidance, then use the `bd` CLI for issue operations.
+Use Beads (`bd`) for durable task tracking in repositories that include it. Use the `beads` skill at `.agents/skills/beads/SKILL.md` (project install) or `~/.agents/skills/beads/SKILL.md` (global install) for Beads workflow guidance, then use the `bd` CLI for issue operations.
 
 ### Quick Reference
 


### PR DESCRIPTION
Maintainer follow-up to #3670 (slice 2 of #3317). Two small documentation tweaks raised in the #3670 review and tracked privately. Both nits were noted as non-blocking on the original review; landing them now to keep the trail tight.

## Summary

- **`internal/templates/agents/defaults/beads-section-codex.md`** — the managed Codex `AGENTS.md` section pointed agents at "the `beads` skill" without saying where `SKILL.md` lives. Codex doesn't auto-discover `.agents/skills/`, so the section now names the project and global paths inline. Existing tests that look for the `\`beads\` skill` substring still match.
- **`docs/SETUP.md`** — note that `bd setup codex` uses its own `BEADS CODEX SETUP` markers (distinct from the `BEADS INTEGRATION` markers used by `factory`/`mux`), that both can coexist in the same `AGENTS.md`, and that each setup's `--check`/`--remove` only touches its own section.

No code or behavior changes.

## Validation

- `go test ./cmd/bd/setup/... ./internal/templates/...` — pass

## Test plan

- [x] Unit tests touching the affected templates still pass
- [x] No production code changes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->