### PR TITLE
ci(docs): fix lychee link check by adding --fallback-extensions html

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,6 +60,7 @@ jobs:
             --include-fragments
             --timeout 30
             --root-dir website/link-check-root
+            --fallback-extensions html
             --exclude-path 'website/build/search/**'
             website/build
           fail: true


### PR DESCRIPTION
## Summary

The Deploy Documentation workflow has been failing on `main` since
2026-04-07 (every run red for ~1 month). The `Check internal links`
step reports tens of thousands of broken file:// links inside the
built site.

Root cause: Docusaurus is configured with `trailingSlash: false`, so
it emits `installation.html`, `architecture.html`, etc. rather than
`installation/index.html`. Rendered pages, however, use extensionless
links such as `/beads/getting-started/installation` (footer, sidebar,
auto-cross-links). In `--offline` mode lychee resolves those paths
literally against `website/link-check-root/beads/...` and reports
them missing because no extensionless file or `index.html` matches.

Fix: pass `--fallback-extensions html` to the internal link check so
lychee retries `installation.html` after the bare-path miss. This
matches how the deployed GitHub Pages site actually serves the URLs.

## Validation

Reproduced locally with the same lychee invocation the workflow uses:

- Before: `🔍 39379 Total  ✅ 9910 OK  🚫 26877 Errors`
- After (with `--fallback-extensions html`): `🔍 39379 Total  ✅ 36787 OK  🚫 0 Errors`

## Test plan

- [ ] Deploy Documentation workflow run on this PR turns green
- [ ] After merge, Deploy Documentation runs green on `main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->