### PR TITLE
ci(regression): pull Dolt sql-server image so tests use shared container

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -34,6 +34,14 @@ jobs:
           dolt config --global --add user.email "ci@beads.test"
           dolt version
 
+      - name: Pull Dolt sql-server image
+        # Without this, isDoltImageCached() returns false in TestMain and the
+        # regression suite falls back to embedded Dolt with HOME=<tmpdir>, which
+        # has a known cleanup race (see beads issue: TestCreateWithParentFlag
+        # TempDir RemoveAll "directory not empty" flake). Keep the tag in sync
+        # with internal/testutil/testdoltcommon.go:DoltDockerImage.
+        run: docker pull dolthub/dolt-sql-server:1.86.0
+
       - name: Cache baseline binary
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:


### PR DESCRIPTION
## Summary

- Pull `dolthub/dolt-sql-server:1.86.0` in the Regression Tests workflow before running tests.
- Eliminates a `t.TempDir()` cleanup race in the embedded-Dolt fallback path that produced a spurious `TestCreateWithParentFlag` failure on `main`.

## Background

Run [25413410192](https://github.com/gastownhall/beads/actions/runs/25413410192) (push of #3735 to main) failed with:

```
--- FAIL: TestCreateWithParentFlag (2.65s)
    testing.go:1464: TempDir RemoveAll cleanup:
      unlinkat /tmp/TestCreateWithParentFlag2554405098: directory not empty
```

The test logic passed — the failure was in Go's framework cleanup, after the test function returned.

The same job logged earlier:

```
WARN: Docker image dolthub/dolt-sql-server:1.86.0 not cached locally
(run 'docker pull dolthub/dolt-sql-server:1.86.0'), skipping Dolt tests
```

When the image isn't cached, `isDoltImageCached()` in `internal/testutil/testdoltserver.go` returns false, `EnsureDoltContainerForTestMain` skips, and `testDoltServerPort` stays 0. `bd` subprocesses spawned per workspace then run with embedded Dolt and `HOME=<t.TempDir()>`. Lockfile/journal writes from embedded Dolt's shutdown path can race `os.RemoveAll`, producing `directory not empty` on cleanup.

The very next push to main (#3704, run 25413647135) ran the same workflow ~8 minutes later with no related code changes and passed cleanly — confirming this is environment-dependent flake from the embedded-Dolt fallback, not a regression.

## Fix

Add a `docker pull` step. With the image cached, `TestMain` uses the shared sql-server container and bypasses the per-workspace embedded-Dolt path entirely.

The image tag must stay in sync with `DoltDockerImage` in `internal/testutil/testdoltcommon.go` — comment in the workflow flags this.

## Test plan

- [ ] Workflow run on this PR completes Regression Tests green
- [ ] Job log no longer contains `not cached locally ... skipping Dolt tests`
- [ ] `TestCreateWithParentFlag` passes (and no `TempDir RemoveAll` warnings)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->