### PR TITLE
fix(list): emphasize truncation warning with WarnStyle (GH#3580)

### DIFF
--- a/cmd/bd/list_output.go
+++ b/cmd/bd/list_output.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
+	"github.com/steveyegge/beads/internal/ui"
 )
 
 // printTruncationHint emits a one-line notice to stderr when the list output
@@ -18,7 +19,8 @@ func printTruncationHint(truncated bool, effectiveLimit int) {
 	if !truncated || effectiveLimit <= 0 {
 		return
 	}
-	fmt.Fprintf(os.Stderr, "\nShowing %d issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.\n", effectiveLimit)
+	msg := fmt.Sprintf("\nShowing %d issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.\n", effectiveLimit)
+	fmt.Fprint(os.Stderr, ui.RenderWarn(msg))
 }
 
 // outputDotFormat outputs issues in Graphviz DOT format


### PR DESCRIPTION
## Summary
- Renders the truncation hint from `printTruncationHint` with `ui.RenderWarn` (yellow) so it stands out visually
- Especially important in `--tree` mode where truncation can make the tree structure misleading — a plain-text warning was easy to miss

Replaces the corrupted #3644 (closed).

Closes #3580

## Test plan
- [x] `make build` succeeds
- [x] Verified `ui.RenderWarn` applies `WarnStyle` (yellow foreground) to the truncation message

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->