### PR TITLE
fix(dolt): skip git hooks on internal push of refs/dolt/data (GH#3724)

### DIFF
--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -476,6 +476,27 @@ func applyS3ChecksumEnvToCmd(cmd *exec.Cmd) {
 	setCmdEnv(cmd, awsResponseChecksumValidationEnv, "when_required")
 }
 
+// applyNoGitHooksToCmd disables git client-side hooks (notably pre-push) for
+// any git invocation made by the subprocess. bd-internal git ops — in
+// particular the `git push --porcelain --force-with-lease=… refs/dolt/data`
+// that Dolt runs against its embedded `git-remote-cache/<hash>/repo.git/`
+// mirror during `dolt push` — must not run user-installed hooks.
+//
+// The cache-mirror is a bare-style repo with no work tree, but `git init`
+// still honors the user's `init.templateDir` and copies template hooks
+// into its `hooks/` dir. When the user's templated `pre-push` hook calls
+// `git diff` / `git status` (e.g. via the pre-commit framework's
+// staged_files_only setup) it fails with `fatal: this operation must be
+// run in a work tree` and bd's push fails with it.
+//
+// `GIT_CONFIG_PARAMETERS='core.hooksPath=/dev/null'` tells every git
+// invocation in the subprocess to look for hooks in `/dev/null` — i.e. to
+// skip them. Same intent as the `--no-verify` fix on the commit side
+// (GH#3340 / GH#3598 / PR #3626), applied at the push site (GH#3724).
+func applyNoGitHooksToCmd(cmd *exec.Cmd) {
+	setCmdEnv(cmd, "GIT_CONFIG_PARAMETERS", "'core.hooksPath=/dev/null'")
+}
+
 // setFederationCredentials sets DOLT_REMOTE_USER and DOLT_REMOTE_PASSWORD env vars.
 // Returns a cleanup function that must be called (typically via defer) to unset them.
 // The caller must hold federationEnvMutex.

--- a/internal/storage/dolt/credentials_test.go
+++ b/internal/storage/dolt/credentials_test.go
@@ -67,6 +67,49 @@ func TestApplyS3ChecksumEnvToCmd(t *testing.T) {
 	}
 }
 
+func TestApplyNoGitHooksToCmd(t *testing.T) {
+	cmd := exec.Command("dolt", "push") // #nosec G204 -- test command is not executed
+	applyNoGitHooksToCmd(cmd)
+
+	var got string
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "GIT_CONFIG_PARAMETERS=") {
+			got = strings.TrimPrefix(e, "GIT_CONFIG_PARAMETERS=")
+			break
+		}
+	}
+	if want := "'core.hooksPath=/dev/null'"; got != want {
+		t.Fatalf("GIT_CONFIG_PARAMETERS = %q, want %q", got, want)
+	}
+}
+
+// TestApplyNoGitHooksToCmdComposesWithCredentials verifies the helper layers
+// cleanly on top of credential env vars, so callers that already populated
+// cmd.Env via remoteCredentials.applyToCmd keep their values.
+func TestApplyNoGitHooksToCmdComposesWithCredentials(t *testing.T) {
+	cmd := exec.Command("dolt", "push") // #nosec G204 -- test command is not executed
+	(&remoteCredentials{username: "user", password: "pass"}).applyToCmd(cmd)
+	applyNoGitHooksToCmd(cmd)
+
+	var gotHooks, gotUser, gotPassword string
+	for _, e := range cmd.Env {
+		switch {
+		case strings.HasPrefix(e, "GIT_CONFIG_PARAMETERS="):
+			gotHooks = strings.TrimPrefix(e, "GIT_CONFIG_PARAMETERS=")
+		case strings.HasPrefix(e, "DOLT_REMOTE_USER="):
+			gotUser = strings.TrimPrefix(e, "DOLT_REMOTE_USER=")
+		case strings.HasPrefix(e, "DOLT_REMOTE_PASSWORD="):
+			gotPassword = strings.TrimPrefix(e, "DOLT_REMOTE_PASSWORD=")
+		}
+	}
+	if gotHooks != "'core.hooksPath=/dev/null'" {
+		t.Fatalf("GIT_CONFIG_PARAMETERS = %q, want hook-disabling override", gotHooks)
+	}
+	if gotUser != "user" || gotPassword != "pass" {
+		t.Fatalf("credential env = user:%q password:%q (creds clobbered by applyNoGitHooksToCmd)", gotUser, gotPassword)
+	}
+}
+
 func TestWithRemoteOperationEnvRestoresS3ChecksumEnv(t *testing.T) {
 	t.Setenv(awsResponseChecksumValidationEnv, "when_supported")
 

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -478,6 +478,7 @@ func (s *DoltStore) doltCLIPushRefToPeer(ctx context.Context, peer string, refsp
 	cmd := exec.CommandContext(ctx, "dolt", "push", peer, refspec) // #nosec G204 -- fixed command with validated peer/refspec
 	cmd.Dir = s.CLIDir()
 	creds.applyToCmd(cmd)
+	applyNoGitHooksToCmd(cmd) // GH#3724
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to push to peer %s: %s: %w", peer, strings.TrimSpace(string(out)), err)

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -763,6 +763,131 @@ func TestGitRemoteEmbeddedHasRemote(t *testing.T) {
 	}
 }
 
+// TestGitRemotePushSkipsUserPrePushHook is a regression test for GH#3724.
+//
+// `bd dolt push` shells out to `dolt push`, which in turn runs
+// `git push refs/dolt/data` against the embedded Dolt cache-mirror at
+// `<doltDir>/<db>/.dolt/git-remote-cache/<hash>/repo.git/`. If the user has
+// `init.templateDir` set globally with pre-commit-framework hooks, those
+// templates land in the cache-mirror's `hooks/` dir (because Dolt's
+// internal `git init` honours `init.templateDir`). The user's templated
+// `pre-push` hook then runs `git diff` inside the bare-style cache mirror
+// and fails with `fatal: this operation must be run in a work tree`.
+//
+// This test installs a deliberately failing `pre-push` hook directly into
+// the cache-mirror after the first push materialises it, then performs a
+// second push. With the fix in place, `doltCLIPush` sets
+// `GIT_CONFIG_PARAMETERS='core.hooksPath=/dev/null'` on the dolt
+// subprocess, so the hook is bypassed and the push succeeds. Without the
+// fix, the hook runs and the second push fails.
+//
+// Mirrors PR #3626 / GH#3340 (the commit-side sibling) at the push site.
+func TestGitRemotePushSkipsUserPrePushHook(t *testing.T) {
+	store, setup, cleanup := setupEmbeddedGitRemote(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// First push: materialises the cache-mirror at
+	// <doltDir>/<db>/.dolt/git-remote-cache/<hash>/repo.git/.
+	first := &types.Issue{
+		ID:        "hookpush-001",
+		Title:     "Materialise cache mirror",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+	}
+	if err := store.CreateIssue(ctx, first, "tester"); err != nil {
+		t.Fatalf("first CreateIssue failed: %v", err)
+	}
+	if err := store.Commit(ctx, "Add hookpush-001"); err != nil {
+		t.Fatalf("first Commit failed: %v", err)
+	}
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("first Push failed (cache-mirror not materialised): %v", err)
+	}
+
+	// Locate the cache-mirror's hooks directory by walking
+	// .dolt/git-remote-cache/<hash>/repo.git/hooks. There is exactly one
+	// such directory per configured git remote.
+	cacheBase := findGitRemoteCacheRepoGit(t, setup.sourceDir)
+	hooksDir := filepath.Join(cacheBase, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("mkdir hooks dir: %v", err)
+	}
+
+	// Install a pre-push hook that touches a sentinel and fails. Pre-fix,
+	// the second push fires this hook (because `git push` honours
+	// repo-local `core.hooksPath` defaults) and fails. Post-fix,
+	// `core.hooksPath=/dev/null` from GIT_CONFIG_PARAMETERS suppresses it.
+	sentinel := filepath.Join(setup.baseDir, "pre-push-hook-fired")
+	hookPath := filepath.Join(hooksDir, "pre-push")
+	hookScript := fmt.Sprintf("#!/bin/sh\ntouch %q\necho 'GH#3724: bd-internal git push must not run user pre-push hook' >&2\nexit 1\n",
+		sentinel)
+	if err := os.WriteFile(hookPath, []byte(hookScript), 0o755); err != nil { // #nosec G306 -- hook scripts must be executable
+		t.Fatalf("write pre-push hook: %v", err)
+	}
+
+	// Second push: should succeed despite the failing pre-push hook.
+	second := &types.Issue{
+		ID:        "hookpush-002",
+		Title:     "Push past failing pre-push hook",
+		IssueType: types.TypeTask,
+		Status:    types.StatusOpen,
+		Priority:  2,
+	}
+	if err := store.CreateIssue(ctx, second, "tester"); err != nil {
+		t.Fatalf("second CreateIssue failed: %v", err)
+	}
+	if err := store.Commit(ctx, "Add hookpush-002"); err != nil {
+		t.Fatalf("second Commit failed: %v", err)
+	}
+
+	// Confirm the hook is still in place — guards against the test passing
+	// for the wrong reason if Dolt re-templates the hooks dir between
+	// pushes.
+	if _, err := os.Stat(hookPath); err != nil {
+		t.Fatalf("pre-push hook disappeared between pushes: %v", err)
+	}
+
+	if err := store.Push(ctx); err != nil {
+		t.Fatalf("GH#3724 regression: second Push failed — bd's internal `dolt push` is running the user's pre-push hook against the cache-mirror. doltCLIPush must pass GIT_CONFIG_PARAMETERS='core.hooksPath=/dev/null' to suppress client-side hooks: %v", err)
+	}
+
+	if _, err := os.Stat(sentinel); err == nil {
+		t.Fatalf("GH#3724 regression: pre-push hook executed (sentinel %s exists). bd's internal git push must skip user hooks", sentinel)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("unexpected stat error for sentinel: %v", err)
+	}
+}
+
+// findGitRemoteCacheRepoGit walks doltDir for the single
+// .dolt/git-remote-cache/<hash>/repo.git directory created when a
+// git-protocol remote is pushed. Fails the test if zero or more than one
+// is found.
+func findGitRemoteCacheRepoGit(t *testing.T, doltDir string) string {
+	t.Helper()
+	var matches []string
+	err := filepath.WalkDir(doltDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() && d.Name() == "repo.git" &&
+			strings.Contains(filepath.ToSlash(path), "/.dolt/git-remote-cache/") {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", doltDir, err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one git-remote-cache/.../repo.git under %s, got %d: %v", doltDir, len(matches), matches)
+	}
+	return matches[0]
+}
+
 func TestGitRemoteSyncRoundTrip(t *testing.T) {
 	// Full bidirectional sync test:
 	// 1. Source creates issues, commits, pushes to git remote

--- a/internal/storage/dolt/git_remote_test.go
+++ b/internal/storage/dolt/git_remote_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -783,6 +784,10 @@ func TestGitRemoteEmbeddedHasRemote(t *testing.T) {
 //
 // Mirrors PR #3626 / GH#3340 (the commit-side sibling) at the push site.
 func TestGitRemotePushSkipsUserPrePushHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hook script uses POSIX shell; the bug + fix are platform-agnostic but this assertion isn't")
+	}
+
 	store, setup, cleanup := setupEmbeddedGitRemote(t)
 	defer cleanup()
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2014,13 +2014,7 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 	if s.isS3Remote(ctx, remote) {
 		applyS3ChecksumEnvToCmd(cmd)
 	}
-	// Disable git client-side hooks (notably pre-push) for the internal
-	// `git push refs/dolt/data` against Dolt's git-remote-cache mirror.
-	// Without this, a user's `init.templateDir`-installed pre-push hook
-	// runs against the bare-style cache mirror and fails with "must be run
-	// in a work tree" (GH#3724). Same family as the commit-side fix in
-	// PR #3626 (GH#3340) — different commit site.
-	applyNoGitHooksToCmd(cmd)
+	applyNoGitHooksToCmd(cmd) // GH#3724
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("dolt push failed: %s: %w", strings.TrimSpace(string(out)), err)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -2014,6 +2014,13 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 	if s.isS3Remote(ctx, remote) {
 		applyS3ChecksumEnvToCmd(cmd)
 	}
+	// Disable git client-side hooks (notably pre-push) for the internal
+	// `git push refs/dolt/data` against Dolt's git-remote-cache mirror.
+	// Without this, a user's `init.templateDir`-installed pre-push hook
+	// runs against the bare-style cache mirror and fails with "must be run
+	// in a work tree" (GH#3724). Same family as the commit-side fix in
+	// PR #3626 (GH#3340) — different commit site.
+	applyNoGitHooksToCmd(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("dolt push failed: %s: %w", strings.TrimSpace(string(out)), err)


### PR DESCRIPTION
## Summary

Closes #3724.

`bd dolt push` fails with `fatal: this operation must be run in a work tree` when the user's `init.templateDir` has populated the embedded Dolt cache-mirror's `hooks/` dir with a pre-push hook (typically via the [pre-commit framework](https://pre-commit.com/)). Dolt's internal `git push --porcelain --force-with-lease=… refs/dolt/data` against the bare-style cache repo at `.beads/embeddeddolt/<db>/.dolt/git-remote-cache/<hash>/repo.git/` fires that hook, which then calls `git diff` and bombs out — the cache-mirror has no work tree.

This is the **push-side sibling** of the commit-side bugs already fixed by PR #3626 (GH#3340) and PR #3599 (GH#3598) — same root pattern, different commit site.

## Fix (Option A from the issue)

Set `GIT_CONFIG_PARAMETERS='core.hooksPath=/dev/null'` on the subprocess env in `doltCLIPush` (`internal/storage/dolt/store.go`). Every `git` invocation made by the `dolt push` subprocess inherits the override and skips client-side hooks.

The shape mirrors PR #3626 (`commitBeadsConfig` → `git commit --no-verify`), but at the push site we can't pass `--no-verify` directly because bd shells out to `dolt`, not `git` — Dolt invokes git internally. The env-var path is the supported way to override config for nested git invocations. I verified the quoting works against vanilla git (`GIT_CONFIG_PARAMETERS="'core.hooksPath=/dev/null'" git push` reliably suppresses the pre-push hook).

The same one-liner is also applied to `doltCLIPushRefToPeer` in `federation.go` — same file, same root cause: federation pushes against git-protocol peers go through the same git-remote-cache mirror and have identical exposure.

Option B (sentinel env var) and Option C (scrub cache-mirror hooks at init) from the issue are intentionally **not** included — single-concern PR. C in particular would be a reasonable stacked follow-up.

## What changed

- `internal/storage/dolt/credentials.go` — new `applyNoGitHooksToCmd(cmd)` helper next to `applyS3ChecksumEnvToCmd`, with a comment explaining the cache-mirror / `init.templateDir` interaction.
- `internal/storage/dolt/store.go` — call the helper in `doltCLIPush` after credentials and S3 env are applied.
- `internal/storage/dolt/federation.go` — call the helper in `doltCLIPushRefToPeer` for the federation peer-push path.
- `internal/storage/dolt/credentials_test.go` — unit tests verifying the env var is set correctly and composes cleanly with credentials. Run on regular PR CI.
- `internal/storage/dolt/git_remote_test.go` — integration test (`TestGitRemotePushSkipsUserPrePushHook`) that materialises the cache-mirror with a first push, drops a deliberately failing `pre-push` hook into it, and verifies a second push succeeds without firing the hook. Skipped on Windows (POSIX-shell hook script). Gated `//go:build integration` to match the existing embedded git-remote tests; runs in the nightly suite.

## Test plan

- [x] `make test` — all packages pass.
- [x] `golangci-lint run --build-tags=gms_pure_go ./...` → 0 new issues. (4 baseline gosec warnings in `internal/testutil/integration/` predate this PR — verified via stash + relint on main.)
- [x] `go test -tags='gms_pure_go integration' -run TestGitRemotePushSkipsUserPrePushHook ./internal/storage/dolt/` — compiles cleanly; skips locally without the Docker test container (same as the existing embedded git-remote tests); CI nightly will exercise it.
- [x] Unit tests `TestApplyNoGitHooksToCmd` and `TestApplyNoGitHooksToCmdComposesWithCredentials` pass on regular PR CI (no integration tag).
- [x] Manual: `GIT_CONFIG_PARAMETERS="'core.hooksPath=/dev/null'" git push` confirmed to suppress a deliberately failing `pre-push` hook on a real local repo.

## Notes

- Scope is **push only**, matching the issue. `dolt pull` doesn't fire client-side hooks against the cache-mirror in standard git (`git fetch` has no client-side hook), so it's not exposed by the same bug.
- Behavior change is limited to bd-internal `dolt push` subprocesses for git-protocol remotes (`git+ssh://`, `git://`, `git+https://`, `file://`). Hosted Dolt SQL pushes and S3/GCS pushes don't reach `doltCLIPush` and are unaffected.
- `internal/remotecache/cache.go` shells out to `dolt push origin main` for the routing-cache feature and would have the same exposure for git-protocol routes. That's a different package / different feature surface; left as a possible follow-up rather than expanding scope here.
- The override only suppresses hooks for the bd-internal subprocess. Users' own `git push` commands in their working tree are untouched.

## Self-review nits already addressed

After the initial commit I went back and tightened a few things to save a review round-trip:

- Added the same fix to the federation peer-push site (same file, same root cause).
- Trimmed the verbose call-site comment in `doltCLIPush` down to a `// GH#3724` reference, matching the style of the adjacent `applyS3ChecksumEnvToCmd` call. Full context lives in the helper docstring.
- Added a Windows runtime skip on the integration test (the bug + fix are platform-agnostic; the assertion's POSIX shell hook script isn't).
