### PR TITLE
fix(setup): removeHookCommand silently drops sibling commands

### DIFF
--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -372,15 +372,17 @@ func addHookCommand(hooks map[string]interface{}, event, command string) bool {
 	return true
 }
 
-// removeHookCommand removes a hook command from an event
+// removeHookCommand removes a specific command from an event's hook entries.
+// Only the matching command object is removed; sibling commands in the same
+// hook entry are preserved. A hook entry is dropped only when its command list
+// becomes empty after filtering.
 func removeHookCommand(hooks map[string]interface{}, event, command string) {
 	eventHooks, ok := hooks[event].([]interface{})
 	if !ok {
 		return
 	}
 
-	// Filter out bd prime hooks
-	// Initialize as empty slice (not nil) to avoid JSON null serialization
+	// Initialize as empty slice (not nil) to avoid JSON null serialization.
 	filtered := make([]interface{}, 0, len(eventHooks))
 	for _, hook := range eventHooks {
 		hookMap, ok := hook.(map[string]interface{})
@@ -395,21 +397,30 @@ func removeHookCommand(hooks map[string]interface{}, event, command string) {
 			continue
 		}
 
-		keepHook := true
+		// Filter only the matching command; preserve any siblings.
+		remaining := make([]interface{}, 0, len(commands))
+		removed := false
 		for _, cmd := range commands {
 			cmdMap, ok := cmd.(map[string]interface{})
 			if !ok {
+				remaining = append(remaining, cmd)
 				continue
 			}
 			if cmdMap["command"] == command {
-				keepHook = false
-				fmt.Printf("✓ Removed %s hook\n", event)
-				break
+				removed = true
+				continue
 			}
+			remaining = append(remaining, cmd)
 		}
 
-		if keepHook {
-			filtered = append(filtered, hook)
+		if removed {
+			fmt.Printf("✓ Removed %s hook\n", event)
+		}
+
+		// Drop the hook entry only when it has no commands left.
+		if len(remaining) > 0 {
+			hookMap["hooks"] = remaining
+			filtered = append(filtered, hookMap)
 		}
 	}
 


### PR DESCRIPTION
## Bug

`removeHookCommand` in `cmd/bd/setup/claude.go` was intended to remove a single named command from a hook event entry. Instead, when it found a matching command it set `keepHook = false` and broke out of the loop — which discarded the **entire hook entry** (all commands in it), not just the matching one.

Any sibling commands sharing the same hook entry were silently deleted.

## Fix

Build a `remaining` slice by iterating all commands and skipping only the matching one. The hook entry is dropped only when `remaining` becomes empty after filtering.

Before:
```go
keepHook := true
for _, cmd := range commands {
    // ...
    if cmdMap["command"] == command {
        keepHook = false
        break  // drops entire entry
    }
}
if keepHook {
    filtered = append(filtered, hook)
}
```

After:
```go
remaining := make([]interface{}, 0, len(commands))
removed := false
for _, cmd := range commands {
    // ...
    if cmdMap["command"] == command {
        removed = true
        continue  // skip only this command
    }
    remaining = append(remaining, cmd)
}
// Drop the entry only when empty
if len(remaining) > 0 {
    hookMap["hooks"] = remaining
    filtered = append(filtered, hookMap)
}
```

## Impact

Any caller that registered multiple commands under one hook event was subject to silent data loss. The `installClaude`, `removeClaude`, and `installGemini` paths all call this function.

No behavior change for single-command entries (the common case).

## Scope

One function body, one file. No test changes — the existing `claude_test.go` suite covers the remove path and continues to pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->