### PR TITLE
feat(setup): Gemini/Claude hook JSON compliance, --hook-json flag, legacy migration

### DIFF
--- a/cmd/bd/doctor/agent.go
+++ b/cmd/bd/doctor/agent.go
@@ -525,7 +525,7 @@ func enrichStaleMolecules(dc DoctorCheck) agentEnrichment {
 func enrichClaude(dc DoctorCheck) agentEnrichment {
 	return agentEnrichment{
 		severity:    "advisory",
-		explanation: fmt.Sprintf("Claude integration: %s. Beads integrates with Claude Code via hooks (SessionStart, PreCompact) defined in .claude/settings.json.", dc.Message),
+		explanation: fmt.Sprintf("Claude integration: %s. Beads integrates with Claude Code via SessionStart hooks defined in .claude/settings.json.", dc.Message),
 		observed:    dc.Message + "\n" + dc.Detail,
 		expected:    "Claude Code hooks configured for beads (bd prime on SessionStart)",
 		commands:    []string{"bd hooks install"},
@@ -547,9 +547,9 @@ func enrichClaudeSettings(dc DoctorCheck) agentEnrichment {
 func enrichClaudeHooks(dc DoctorCheck) agentEnrichment {
 	return agentEnrichment{
 		severity:    "advisory",
-		explanation: fmt.Sprintf("Claude hook completeness: %s. Beads needs both SessionStart and PreCompact hooks to function properly in Claude Code sessions.", dc.Message),
+		explanation: fmt.Sprintf("Claude hook completeness: %s. Beads needs a SessionStart hook to inject context in Claude Code sessions, including after compaction.", dc.Message),
 		observed:    dc.Message + "\n" + dc.Detail,
-		expected:    "Both SessionStart and PreCompact hooks configured for beads",
+		expected:    "SessionStart hook configured for beads",
 		commands:    []string{"bd hooks install"},
 		sourceFiles: []string{"cmd/bd/doctor/claude.go:CheckClaudeHookCompleteness"},
 	}

--- a/cmd/bd/doctor/claude.go
+++ b/cmd/bd/doctor/claude.go
@@ -54,7 +54,7 @@ func CheckClaude(repoPath string) DoctorCheck {
 			Detail: "MCP-only mode: relies on tools for every query (~10.5k tokens)\n" +
 				"  bd prime hooks provide much better token efficiency",
 			Fix: "Add bd prime hooks for better token efficiency:\n" +
-				"  1. Run 'bd setup claude' to add SessionStart/PreCompact hooks\n" +
+				"  1. Run 'bd setup claude' to add SessionStart hooks\n" +
 				"\n" +
 				"Benefits:\n" +
 				"  • MCP mode: ~50 tokens vs ~10.5k for full tool scan (99% reduction)\n" +
@@ -85,7 +85,7 @@ func CheckClaude(repoPath string) DoctorCheck {
 				"    • See: https://github.com/steveyegge/beads/blob/main/docs/PLUGIN.md\n" +
 				"\n" +
 				"  Option 2: CLI-only mode\n" +
-				"    • Run 'bd setup claude' to add SessionStart/PreCompact hooks\n" +
+				"    • Run 'bd setup claude' to add SessionStart hooks\n" +
 				"    • No slash commands, but hooks provide workflow context\n" +
 				"\n" +
 				"Benefits:\n" +
@@ -270,7 +270,9 @@ func hasBeadsHooks(settingsPath string) bool {
 					continue
 				}
 				cmdStr, _ := cmdMap["command"].(string)
-				if cmdStr == "bd prime" || cmdStr == "bd prime --stealth" {
+				switch cmdStr {
+				case "bd prime", "bd prime --stealth",
+					"bd prime --hook-json", "bd prime --stealth --hook-json":
 					return true
 				}
 			}
@@ -698,9 +700,10 @@ func CheckClaudeSettingsHealth(repoPath string) DoctorCheck {
 	}
 }
 
-// CheckClaudeHookCompleteness verifies that when hooks are installed, both
-// SessionStart and PreCompact events are covered. Having only one means
-// context injection works on session start but not after compaction (or vice versa).
+// CheckClaudeHookCompleteness verifies that when hooks are installed,
+// SessionStart is covered. Claude Code fires SessionStart on startup, resume,
+// clear, and after compaction, so current bd prime context injection only needs
+// SessionStart.
 // repoPath is the project root directory.
 func CheckClaudeHookCompleteness(repoPath string) DoctorCheck {
 	home, err := os.UserHomeDir()
@@ -718,9 +721,8 @@ func CheckClaudeHookCompleteness(repoPath string) DoctorCheck {
 		filepath.Join(repoPath, ".claude", "settings.local.json"),
 	}
 
-	// Check if any settings file has hooks at all
 	var hasAnyHook bool
-	var hasSessionStart, hasPreCompact bool
+	var hasSessionStart bool
 
 	for _, sf := range settingsFiles {
 		ss, pc := checkHookEvents(sf)
@@ -729,9 +731,6 @@ func CheckClaudeHookCompleteness(repoPath string) DoctorCheck {
 		}
 		if ss {
 			hasSessionStart = true
-		}
-		if pc {
-			hasPreCompact = true
 		}
 	}
 
@@ -744,30 +743,20 @@ func CheckClaudeHookCompleteness(repoPath string) DoctorCheck {
 		}
 	}
 
-	if hasSessionStart && hasPreCompact {
+	if hasSessionStart {
 		return DoctorCheck{
 			Name:    "Claude Hook Completeness",
 			Status:  StatusOK,
-			Message: "Both SessionStart and PreCompact hooks present",
+			Message: "SessionStart hook present",
 		}
-	}
-
-	var missing []string
-	if !hasSessionStart {
-		missing = append(missing, "SessionStart")
-	}
-	if !hasPreCompact {
-		missing = append(missing, "PreCompact")
 	}
 
 	return DoctorCheck{
 		Name:    "Claude Hook Completeness",
 		Status:  StatusWarning,
-		Message: fmt.Sprintf("Missing hook event(s): %s", strings.Join(missing, ", ")),
-		Detail: "SessionStart injects context on new sessions.\n" +
-			"PreCompact preserves context before compaction.\n" +
-			"Both are needed for reliable workflow context.",
-		Fix: "Run 'bd setup claude' to install both hooks, or\n" +
+		Message: "Missing hook event(s): SessionStart",
+		Detail:  "SessionStart injects context on new sessions and after compaction.",
+		Fix: "Run 'bd setup claude' to install hooks, or\n" +
 			"install the beads plugin which includes hooks automatically.",
 	}
 }
@@ -809,7 +798,9 @@ func checkHookEvents(settingsPath string) (hasSessionStart, hasPreCompact bool) 
 					continue
 				}
 				cmdStr, _ := cmdMap["command"].(string)
-				if cmdStr == "bd prime" || cmdStr == "bd prime --stealth" {
+				switch cmdStr {
+				case "bd prime", "bd prime --stealth",
+					"bd prime --hook-json", "bd prime --stealth --hook-json":
 					return true
 				}
 			}

--- a/cmd/bd/doctor/claude_test.go
+++ b/cmd/bd/doctor/claude_test.go
@@ -671,8 +671,8 @@ func TestCheckClaudeHookCompleteness(t *testing.T) {
 		}
 
 		check := CheckClaudeHookCompleteness(tmpDir)
-		if check.Status != StatusWarning {
-			t.Errorf("Expected warning for missing PreCompact, got %s", check.Status)
+		if check.Status != StatusOK {
+			t.Errorf("Expected OK for SessionStart hook, got %s", check.Status)
 		}
 	})
 

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -73,7 +73,7 @@ func CheckLegacyBeadsSlashCommands(repoPath string) DoctorCheck {
 		Fix: "Migrate to bd prime hooks for better token efficiency:\n" +
 			"\n" +
 			"Migration Steps:\n" +
-			"  1. Run 'bd setup claude' to add SessionStart/PreCompact hooks\n" +
+			"  1. Run 'bd setup claude' to add SessionStart hooks\n" +
 			"  2. Update " + config.AgentsFile() + "/CLAUDE.md:\n" +
 			"     - Remove /beads:* slash command references\n" +
 			"     - Add: \"Run 'bd prime' for workflow context\" (for users without hooks)\n" +
@@ -135,7 +135,7 @@ func CheckLegacyMCPToolReferences(repoPath string) DoctorCheck {
 		Fix: "Migrate to bd prime hooks for better token efficiency:\n" +
 			"\n" +
 			"Migration Steps:\n" +
-			"  1. Run 'bd setup claude' to add SessionStart/PreCompact hooks\n" +
+			"  1. Run 'bd setup claude' to add SessionStart hooks\n" +
 			"  2. Replace MCP tool references with CLI commands:\n" +
 			"     - mcp__beads_beads__list  → bd list\n" +
 			"     - mcp__beads_beads__show  → bd show <id>\n" +

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -58,7 +58,7 @@ Automatically detects if MCP server is active and adapts output:
 - MCP mode: Brief workflow reminders (~50 tokens)
 - CLI mode: Full command reference (~1-2k tokens)
 
-Designed for Claude Code and Codex hooks to prevent
+Designed for Claude Code, Gemini CLI, and Codex SessionStart hooks to prevent
 agents from forgetting bd workflow after context compaction.
 
 Config options:

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -24,6 +25,7 @@ var (
 	primeStealthMode  bool
 	primeExportMode   bool
 	primeMemoriesOnly bool
+	primeHookJSONMode bool
 )
 
 // resolveGlobalPrimePath returns the path to ~/.config/beads/PRIME.md if it
@@ -69,12 +71,28 @@ Config options:
 	- Use --export to dump the default content for customization.
 	- Use --memories-only for hook contexts that should inject only persistent memories.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// emit writes content either as raw text (default behavior) or wrapped
+		// in the SessionStart hook JSON envelope when --hook-json is set.
+		emit := func(content string) {
+			if primeHookJSONMode {
+				_ = outputHookJSON(os.Stdout, content)
+			} else {
+				fmt.Print(content)
+			}
+		}
+
 		// Resolve the active beads workspace.
 		beadsDir := beads.FindBeadsDir()
 		if beadsDir == "" {
 			// Not in a beads project - silent exit with success
 			// CRITICAL: No stderr output, exit 0
-			// This enables cross-platform hook integration
+			// This enables cross-platform hook integration.
+			//
+			// Under --hook-json we still must emit a valid JSON envelope
+			// (with empty additionalContext) so the hook host receives valid JSON.
+			if primeHookJSONMode {
+				_ = outputHookJSON(os.Stdout, "")
+			}
 			os.Exit(0)
 		}
 
@@ -106,31 +124,39 @@ Config options:
 			// Try local first (user's clone-specific customization)
 			// #nosec G304 -- path is relative to cwd
 			if content, err := os.ReadFile(localPrimePath); err == nil {
-				fmt.Print(string(content))
+				emit(string(content))
 				return
 			}
 			// Fall back to redirected location (shared customization)
 			// #nosec G304 -- path is constructed from beadsDir which we control
 			if content, err := os.ReadFile(redirectedPrimePath); err == nil {
-				fmt.Print(string(content))
+				emit(string(content))
 				return
 			}
 			// Fall back to global config (~/.config/beads/PRIME.md)
 			// #nosec G304 -- path constructed from UserConfigDir which we control
 			if globalPath := resolveGlobalPrimePath(""); globalPath != "" {
 				if content, err := os.ReadFile(globalPath); err == nil {
-					fmt.Print(string(content))
+					emit(string(content))
 					return
 				}
 			}
 		}
 
-		// Output workflow context (adaptive based on MCP and stealth mode)
-		if err := outputPrimeContextWithOptions(os.Stdout, mcpMode, stealthMode, primeMemoriesOnly); err != nil {
-			// Suppress all errors - silent exit with success
-			// Never write to stderr (breaks Windows compatibility)
+		// Output workflow context (adaptive based on MCP and stealth mode).
+		// Buffer first so we can wrap in the hook JSON envelope as a single field.
+		var buf bytes.Buffer
+		if err := outputPrimeContextWithOptions(&buf, mcpMode, stealthMode, primeMemoriesOnly); err != nil {
+			// Suppress all errors - silent exit with success.
+			// Never write to stderr (breaks Windows compatibility).
+			// Under --hook-json still emit the empty envelope so stdout
+			// is valid JSON for the hook host.
+			if primeHookJSONMode {
+				_ = outputHookJSON(os.Stdout, "")
+			}
 			os.Exit(0)
 		}
+		emit(buf.String())
 	},
 }
 
@@ -140,7 +166,28 @@ func init() {
 	primeCmd.Flags().BoolVar(&primeStealthMode, "stealth", false, "Stealth mode (no git operations, flush only)")
 	primeCmd.Flags().BoolVar(&primeExportMode, "export", false, "Output default content (ignores PRIME.md override)")
 	primeCmd.Flags().BoolVar(&primeMemoriesOnly, "memories-only", false, "Output only persistent memories for compact hook contexts")
+	primeCmd.Flags().BoolVar(&primeHookJSONMode, "hook-json", false, "Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)")
 	rootCmd.AddCommand(primeCmd)
+}
+
+// outputHookJSON wraps content in the SessionStart hook JSON envelope shared
+// by Claude Code, Gemini CLI, and Codex. All three require stdout to be valid
+// JSON — no plain text may be emitted alongside it. See:
+// https://geminicli.com/docs/hooks/reference/
+func outputHookJSON(w io.Writer, content string) error {
+	type hookSpecificOutput struct {
+		HookEventName     string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext"`
+	}
+	envelope := struct {
+		HookSpecificOutput hookSpecificOutput `json:"hookSpecificOutput"`
+	}{
+		HookSpecificOutput: hookSpecificOutput{
+			HookEventName:     "SessionStart",
+			AdditionalContext: content,
+		},
+	}
+	return json.NewEncoder(w).Encode(envelope)
 }
 
 // isMCPActive detects if MCP server is currently active

--- a/cmd/bd/prime_gemini_hook_test.go
+++ b/cmd/bd/prime_gemini_hook_test.go
@@ -1,0 +1,330 @@
+//go:build cgo
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runPrimeBinary runs the bd binary built by buildBDUnderTest in the given
+// working directory with a clean env (HOME isolated), capturing stdout.
+// stderr is captured separately so JSON-validity checks aren't polluted by
+// auto-pull or warning lines.
+func runPrimeBinary(t *testing.T, binPath, workDir string, args ...string) (stdout []byte, stderr []byte) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	full := append([]string{"prime"}, args...)
+	cmd := exec.CommandContext(ctx, binPath, full...)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"XDG_CONFIG_HOME="+t.TempDir(),
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+		"BEADS_DIR=",
+		"BEADS_DB=",
+		"LINEAR_API_KEY=", // Suppress Linear auto-pull noise
+	)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		// bd prime exits 0 on every path we care about (silent-success
+		// contract). A non-zero exit is itself a failure.
+		t.Fatalf("bd %v in %s: %v\nstdout: %s\nstderr: %s", full, workDir, err, outBuf.String(), errBuf.String())
+	}
+	return outBuf.Bytes(), errBuf.Bytes()
+}
+
+// initBeadsWorkspace creates a minimal beads workspace at workDir using `bd
+// init --prefix`. We don't need a Dolt server or any issues — just the
+// .beads/ directory so FindBeadsDir succeeds.
+func initBeadsWorkspace(t *testing.T, binPath, workDir string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binPath, "init", "--prefix", "test")
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"XDG_CONFIG_HOME="+t.TempDir(),
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+		"BEADS_DIR=",
+		"BEADS_DB=",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd init in %s: %v\n%s", workDir, err, out)
+	}
+}
+
+type primeEnvelope struct {
+	HookSpecificOutput struct {
+		HookEventName     string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext"`
+	} `json:"hookSpecificOutput"`
+}
+
+func parseEnvelope(t *testing.T, raw []byte) primeEnvelope {
+	t.Helper()
+	trimmed := bytes.TrimSpace(raw)
+	var env primeEnvelope
+	if err := json.Unmarshal(trimmed, &env); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, raw)
+	}
+	if env.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Errorf("hookEventName = %q, want SessionStart", env.HookSpecificOutput.HookEventName)
+	}
+	return env
+}
+
+// TestPrime_HookJSON_DefaultPath: with --hook-json and no PRIME.md
+// override, output is the JSON envelope wrapping the generated workflow
+// context.
+func TestPrime_HookJSON_DefaultPath(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	workDir := t.TempDir()
+	initBeadsWorkspace(t, binPath, workDir)
+
+	stdout, _ := runPrimeBinary(t, binPath, workDir, "--hook-json")
+	env := parseEnvelope(t, stdout)
+
+	if env.HookSpecificOutput.AdditionalContext == "" {
+		t.Fatal("expected non-empty additionalContext for default path")
+	}
+	// Sanity-check that the generated content actually flowed through.
+	// The CLI/MCP variants both lead with one of these phrases.
+	ctx := env.HookSpecificOutput.AdditionalContext
+	if !strings.Contains(ctx, "Beads") {
+		t.Errorf("additionalContext should contain generated bd prime markdown, got: %q", firstN(ctx, 200))
+	}
+}
+
+// TestPrime_HookJSON_LocalPrimeOverride: with --hook-json and a
+// .beads/PRIME.md file present, output is the JSON envelope with that file's
+// contents in additionalContext (verbatim).
+func TestPrime_HookJSON_LocalPrimeOverride(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	workDir := t.TempDir()
+	initBeadsWorkspace(t, binPath, workDir)
+
+	const custom = "# Custom local PRIME.md override\nBe excellent.\n"
+	primePath := filepath.Join(workDir, ".beads", "PRIME.md")
+	if err := os.WriteFile(primePath, []byte(custom), 0o644); err != nil {
+		t.Fatalf("write PRIME.md: %v", err)
+	}
+
+	stdout, _ := runPrimeBinary(t, binPath, workDir, "--hook-json")
+	env := parseEnvelope(t, stdout)
+
+	if env.HookSpecificOutput.AdditionalContext != custom {
+		t.Errorf("additionalContext = %q, want %q", env.HookSpecificOutput.AdditionalContext, custom)
+	}
+}
+
+// TestPrime_HookJSON_NotJSON_WithoutFlag is a regression guard: without
+// --hook-json, prime output is raw markdown — NOT a JSON envelope.
+// This is the binary-level companion to the in-process unit test in
+// prime_test.go and protects the existing Claude/CLI contract.
+func TestPrime_HookJSON_NotJSON_WithoutFlag(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	workDir := t.TempDir()
+	initBeadsWorkspace(t, binPath, workDir)
+
+	stdout, _ := runPrimeBinary(t, binPath, workDir)
+	out := strings.TrimSpace(string(stdout))
+	if strings.HasPrefix(out, "{") {
+		t.Fatalf("bd prime (no flag) emitted JSON-looking content; raw markdown expected: %q", firstN(out, 200))
+	}
+	var any map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &any); err == nil {
+		t.Fatal("bd prime (no flag) output should not be valid JSON")
+	}
+}
+
+// TestPrime_HookJSON_StealthCompose: --hook-json composed with --stealth
+// emits the JSON envelope, and additionalContext is in stealth mode (no raw
+// `git push` instructions in the close protocol).
+func TestPrime_HookJSON_StealthCompose(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	workDir := t.TempDir()
+	initBeadsWorkspace(t, binPath, workDir)
+
+	stdout, _ := runPrimeBinary(t, binPath, workDir, "--hook-json", "--stealth")
+	env := parseEnvelope(t, stdout)
+
+	ctx := env.HookSpecificOutput.AdditionalContext
+	if ctx == "" {
+		t.Fatal("expected non-empty additionalContext under --stealth --hook-json")
+	}
+	// Stealth mode: close protocol must not steer agents to git push.
+	// (Local-only also suppresses git ops, but stealth is the explicit user
+	// signal we care about here.)
+	if strings.Contains(ctx, "git push") {
+		t.Errorf("stealth mode should not include 'git push' in additionalContext, got snippet: %q", firstN(ctx, 400))
+	}
+	// And the close-protocol section must still exist.
+	if !strings.Contains(ctx, "bd close") {
+		t.Errorf("stealth mode should still teach 'bd close', got snippet: %q", firstN(ctx, 400))
+	}
+}
+
+// TestPrime_HookJSON_GlobalPrimeOverride: with --hook-json and a
+// ~/.config/beads/PRIME.md file present (XDG path), output is the JSON
+// envelope wrapping that file's contents. This exercises the third
+// custom-PRIME.md path through the wrapper.
+func TestPrime_HookJSON_GlobalPrimeOverride(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	workDir := t.TempDir()
+	initBeadsWorkspace(t, binPath, workDir)
+
+	const custom = "# Global PRIME override\nGreetings from XDG.\n"
+
+	// resolveGlobalPrimePath uses os.UserConfigDir, which on Linux honors
+	// XDG_CONFIG_HOME. On macOS it returns ~/Library/Application Support
+	// regardless of XDG, so we set HOME and also stage the macOS path to
+	// be cross-platform-safe.
+	xdg := t.TempDir()
+	home := t.TempDir()
+
+	xdgBeadsDir := filepath.Join(xdg, "beads")
+	if err := os.MkdirAll(xdgBeadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir xdg beads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(xdgBeadsDir, "PRIME.md"), []byte(custom), 0o644); err != nil {
+		t.Fatalf("write xdg PRIME.md: %v", err)
+	}
+	// Cross-platform staging for macOS UserConfigDir.
+	macConfigDir := filepath.Join(home, "Library", "Application Support", "beads")
+	if err := os.MkdirAll(macConfigDir, 0o755); err != nil {
+		t.Fatalf("mkdir mac config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(macConfigDir, "PRIME.md"), []byte(custom), 0o644); err != nil {
+		t.Fatalf("write mac PRIME.md: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binPath, "prime", "--hook-json")
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+xdg,
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+		"BEADS_DIR=",
+		"BEADS_DB=",
+		"LINEAR_API_KEY=",
+	)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd prime --hook-json: %v\nstdout: %s\nstderr: %s", err, outBuf.String(), errBuf.String())
+	}
+
+	env := parseEnvelope(t, outBuf.Bytes())
+	if env.HookSpecificOutput.AdditionalContext != custom {
+		t.Errorf("additionalContext = %q, want %q", env.HookSpecificOutput.AdditionalContext, custom)
+	}
+}
+
+// TestPrime_HookJSON_RedirectedPrimeOverride: with --hook-json and a
+// PRIME.md staged at <beadsDir>/PRIME.md where <beadsDir> is NOT the local
+// .beads directory (i.e. relocated via BEADS_DIR), the output is the JSON
+// envelope wrapping that file's contents. This exercises the redirected
+// path independently from the local path so DoD #2 ("ALL FOUR output paths
+// wrap correctly") is fully covered end-to-end.
+func TestPrime_HookJSON_RedirectedPrimeOverride(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+
+	// CWD has no .beads/ at all — the local override can't fire.
+	workDir := t.TempDir()
+
+	// Stage the relocated beads dir at a sibling path. We can't `bd init`
+	// straight into it (init resolves to ./.beads), so we init in a separate
+	// dir and copy the .beads/ into our target. That gives FindBeadsDir
+	// what it needs to validate the dir.
+	relocatedRoot := t.TempDir()
+	initBeadsWorkspace(t, binPath, relocatedRoot)
+	relocatedBeads := filepath.Join(relocatedRoot, ".beads")
+
+	const custom = "# Redirected PRIME override\nFrom a relocated beadsDir.\n"
+	if err := os.WriteFile(filepath.Join(relocatedBeads, "PRIME.md"), []byte(custom), 0o644); err != nil {
+		t.Fatalf("write redirected PRIME.md: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binPath, "prime", "--hook-json")
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"XDG_CONFIG_HOME="+t.TempDir(),
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+		"BEADS_DIR="+relocatedBeads, // forces FindBeadsDir to return this absolute path
+		"BEADS_DB=",
+		"LINEAR_API_KEY=",
+	)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd prime --hook-json: %v\nstdout: %s\nstderr: %s", err, outBuf.String(), errBuf.String())
+	}
+
+	env := parseEnvelope(t, outBuf.Bytes())
+	if env.HookSpecificOutput.AdditionalContext != custom {
+		t.Errorf("additionalContext = %q, want %q", env.HookSpecificOutput.AdditionalContext, custom)
+	}
+}
+
+// TestPrime_HookJSON_NoBeadsWorkspace: when bd prime would otherwise emit
+// nothing (no beads workspace resolved), --hook-json still emits the empty
+// JSON envelope so Gemini's strict stdout-must-be-JSON contract is honored.
+func TestPrime_HookJSON_NoBeadsWorkspace(t *testing.T) {
+	binPath := buildBDUnderTest(t)
+	// Use a freshly created tmpdir with NO beads workspace and HOME isolated
+	// so FindBeadsDir cannot walk up into the test repo.
+	workDir := t.TempDir()
+	home := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binPath, "prime", "--hook-json")
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+t.TempDir(),
+		"BEADS_TEST_IGNORE_REPO_CONFIG=1",
+		"BEADS_DIR=",
+		"BEADS_DB=",
+		"LINEAR_API_KEY=",
+	)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd prime --hook-json: %v\nstdout: %s\nstderr: %s", err, outBuf.String(), errBuf.String())
+	}
+
+	env := parseEnvelope(t, outBuf.Bytes())
+	if env.HookSpecificOutput.AdditionalContext != "" {
+		t.Errorf("additionalContext should be empty when no beads workspace, got: %q",
+			firstN(env.HookSpecificOutput.AdditionalContext, 200))
+	}
+}
+
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -290,5 +291,86 @@ func TestPrimeGlobalFallback_Missing(t *testing.T) {
 	got := resolveGlobalPrimePath(tmpDir)
 	if got != "" {
 		t.Errorf("resolveGlobalPrimePath = %q, want empty for missing file", got)
+	}
+}
+
+// hookJSONEnvelope mirrors the JSON shape produced by outputHookJSON —
+// kept in test code so the assertion fails loudly if the production shape
+// drifts.
+type hookJSONEnvelope struct {
+	HookSpecificOutput struct {
+		HookEventName     string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext"`
+	} `json:"hookSpecificOutput"`
+}
+
+func TestOutputHookJSON_ShapeWithContent(t *testing.T) {
+	var buf bytes.Buffer
+	const payload = "# Hello\n\nbd ready\n"
+	if err := outputHookJSON(&buf, payload); err != nil {
+		t.Fatalf("outputHookJSON: %v", err)
+	}
+
+	// json.Encoder.Encode appends a trailing newline; the JSON itself must
+	// still be valid.
+	out := strings.TrimRight(buf.String(), "\n")
+
+	var env hookJSONEnvelope
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if env.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Errorf("hookEventName = %q, want SessionStart", env.HookSpecificOutput.HookEventName)
+	}
+	if env.HookSpecificOutput.AdditionalContext != payload {
+		t.Errorf("additionalContext = %q, want %q", env.HookSpecificOutput.AdditionalContext, payload)
+	}
+}
+
+func TestOutputHookJSON_EmptyContent(t *testing.T) {
+	// Empty envelope is the contract for "nothing to inject" — the hook host
+	// still requires valid JSON on stdout, so we cannot just emit nothing.
+	var buf bytes.Buffer
+	if err := outputHookJSON(&buf, ""); err != nil {
+		t.Fatalf("outputHookJSON: %v", err)
+	}
+
+	var env hookJSONEnvelope
+	if err := json.Unmarshal(bytes.TrimRight(buf.Bytes(), "\n"), &env); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if env.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Errorf("hookEventName = %q, want SessionStart", env.HookSpecificOutput.HookEventName)
+	}
+	if env.HookSpecificOutput.AdditionalContext != "" {
+		t.Errorf("additionalContext = %q, want empty", env.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+// TestPrime_RawMarkdown_NotJSON_WithoutFlag is a regression guard: without
+// --hook-json, prime output must remain raw markdown (used by CLI users and
+// any hook-free integrations). It would be a regression if the JSON envelope
+// leaked into the default path.
+func TestPrime_RawMarkdown_NotJSON_WithoutFlag(t *testing.T) {
+	defer stubIsEphemeralBranch(false)()
+	defer stubPrimeHasGitRemote(true)()
+
+	var buf bytes.Buffer
+	if err := outputPrimeContext(&buf, false, false); err != nil {
+		t.Fatalf("outputPrimeContext: %v", err)
+	}
+
+	output := buf.String()
+	if strings.HasPrefix(strings.TrimSpace(output), "{") {
+		preview := output
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		t.Fatalf("prime output without --gemini-hook should be raw markdown, got JSON-looking content: %q", preview)
+	}
+	// Best-effort: confirm the raw markdown contract holds.
+	var envelope map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &envelope); err == nil {
+		t.Fatal("prime output without --gemini-hook should not be valid JSON (regression guard)")
 	}
 }

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -366,11 +366,11 @@ func TestPrime_RawMarkdown_NotJSON_WithoutFlag(t *testing.T) {
 		if len(preview) > 200 {
 			preview = preview[:200]
 		}
-		t.Fatalf("prime output without --gemini-hook should be raw markdown, got JSON-looking content: %q", preview)
+		t.Fatalf("prime output without --hook-json should be raw markdown, got JSON-looking content: %q", preview)
 	}
 	// Best-effort: confirm the raw markdown contract holds.
 	var envelope map[string]interface{}
 	if err := json.Unmarshal([]byte(output), &envelope); err == nil {
-		t.Fatal("prime output without --gemini-hook should not be valid JSON (regression guard)")
+		t.Fatal("prime output without --hook-json should not be valid JSON (regression guard)")
 	}
 }

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -137,9 +137,22 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 		}
 	}
 
-	command := "bd prime"
+	command := "bd prime --hook-json"
 	if stealth {
-		command = "bd prime --stealth"
+		command = "bd prime --stealth --hook-json"
+	}
+
+	// Migration sweep: remove bare "bd prime" variants registered by older
+	// installations. The documented SessionStart/PreCompact hook contract
+	// (Claude Code, Gemini CLI, Codex) uses the JSON envelope; re-running
+	// setup upgrades to the canonical --hook-json command.
+	legacyBareVariants := []string{"bd prime", "bd prime --stealth"}
+	for _, legacy := range legacyBareVariants {
+		if legacy == command {
+			continue
+		}
+		removeHookCommand(hooks, "SessionStart", legacy)
+		removeHookCommand(hooks, "PreCompact", legacy)
 	}
 
 	// GH#3192: Skip writing hooks if the beads plugin is already providing them.
@@ -176,10 +189,10 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 				var legacySettings map[string]interface{}
 				if json.Unmarshal(legacyData, &legacySettings) == nil {
 					if legacyHooks, ok := legacySettings["hooks"].(map[string]interface{}); ok {
-						removeHookCommand(legacyHooks, "SessionStart", "bd prime")
-						removeHookCommand(legacyHooks, "PreCompact", "bd prime")
-						removeHookCommand(legacyHooks, "SessionStart", "bd prime --stealth")
-						removeHookCommand(legacyHooks, "PreCompact", "bd prime --stealth")
+						for _, v := range []string{"bd prime", "bd prime --stealth", "bd prime --hook-json", "bd prime --stealth --hook-json"} {
+							removeHookCommand(legacyHooks, "SessionStart", v)
+							removeHookCommand(legacyHooks, "PreCompact", v)
+						}
 						if migrated, marshalErr := json.MarshalIndent(legacySettings, "", "  "); marshalErr == nil {
 							if writeErr := env.writeFile(legacyPath, migrated); writeErr == nil {
 								_, _ = fmt.Fprintf(env.stdout, "✓ Migrated hooks from %s\n", legacyPath)
@@ -339,10 +352,10 @@ func removeClaude(env claudeEnv, global bool) error {
 		if !ok {
 			_, _ = fmt.Fprintln(env.stdout, "No hooks found")
 		} else {
-			removeHookCommand(hooks, "SessionStart", "bd prime")
-			removeHookCommand(hooks, "PreCompact", "bd prime")
-			removeHookCommand(hooks, "SessionStart", "bd prime --stealth")
-			removeHookCommand(hooks, "PreCompact", "bd prime --stealth")
+			for _, v := range []string{"bd prime", "bd prime --stealth", "bd prime --hook-json", "bd prime --stealth --hook-json"} {
+				removeHookCommand(hooks, "SessionStart", v)
+				removeHookCommand(hooks, "PreCompact", v)
+			}
 
 			data, err = json.MarshalIndent(settings, "", "  ")
 			if err != nil {
@@ -364,10 +377,10 @@ func removeClaude(env claudeEnv, global bool) error {
 			var legacySettings map[string]interface{}
 			if json.Unmarshal(legacyData, &legacySettings) == nil {
 				if legacyHooks, ok := legacySettings["hooks"].(map[string]interface{}); ok {
-					removeHookCommand(legacyHooks, "SessionStart", "bd prime")
-					removeHookCommand(legacyHooks, "PreCompact", "bd prime")
-					removeHookCommand(legacyHooks, "SessionStart", "bd prime --stealth")
-					removeHookCommand(legacyHooks, "PreCompact", "bd prime --stealth")
+					for _, v := range []string{"bd prime", "bd prime --stealth", "bd prime --hook-json", "bd prime --stealth --hook-json"} {
+						removeHookCommand(legacyHooks, "SessionStart", v)
+						removeHookCommand(legacyHooks, "PreCompact", v)
+					}
 					if migrated, marshalErr := json.MarshalIndent(legacySettings, "", "  "); marshalErr == nil {
 						_ = env.writeFile(legacyPath, migrated)
 					}
@@ -573,9 +586,10 @@ func hasBeadsHooks(settingsPath string) bool {
 				if !ok {
 					continue
 				}
-				// Check for either variant
-				cmd := cmdMap["command"]
-				if cmd == "bd prime" || cmd == "bd prime --stealth" {
+				// Recognize both current (--hook-json) and legacy bare variants.
+				switch cmdMap["command"] {
+				case "bd prime", "bd prime --stealth",
+					"bd prime --hook-json", "bd prime --stealth --hook-json":
 					return true
 				}
 			}

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -143,9 +143,9 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 	}
 
 	// Migration sweep: remove bare "bd prime" variants registered by older
-	// installations. The documented SessionStart/PreCompact hook contract
-	// (Claude Code, Gemini CLI, Codex) uses the JSON envelope; re-running
-	// setup upgrades to the canonical --hook-json command.
+	// installations. Claude Code's current context-injection contract uses
+	// the SessionStart JSON envelope; SessionStart also fires after compaction
+	// with source=compact, so PreCompact no longer needs a bd prime hook.
 	legacyBareVariants := []string{"bd prime", "bd prime --stealth"}
 	for _, legacy := range legacyBareVariants {
 		if legacy == command {
@@ -154,19 +154,17 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 		removeHookCommand(hooks, "SessionStart", legacy)
 		removeHookCommand(hooks, "PreCompact", legacy)
 	}
+	removeHookCommand(hooks, "PreCompact", "bd prime --hook-json")
+	removeHookCommand(hooks, "PreCompact", "bd prime --stealth --hook-json")
 
-	// GH#3192: Skip writing hooks if the beads plugin is already providing them.
-	// The plugin declares identical SessionStart/PreCompact hooks in plugin.json,
-	// so project-level hooks would fire bd prime twice per session.
+	// GH#3192: Skip writing hooks if the beads plugin is already providing them,
+	// so project-level hooks don't fire bd prime twice per session.
 	pluginManaged := hasBeadsPlugin(env)
 	if pluginManaged {
 		_, _ = fmt.Fprintln(env.stdout, "✓ Beads plugin detected — hooks are plugin-managed, skipping")
 	} else {
 		if addHookCommand(hooks, "SessionStart", command) {
 			_, _ = fmt.Fprintln(env.stdout, "✓ Registered SessionStart hook")
-		}
-		if addHookCommand(hooks, "PreCompact", command) {
-			_, _ = fmt.Fprintln(env.stdout, "✓ Registered PreCompact hook")
 		}
 	}
 
@@ -508,8 +506,8 @@ func removeHookCommand(hooks map[string]interface{}, event, command string) {
 }
 
 // hasBeadsPlugin checks if the beads Claude Code plugin is enabled in any
-// settings file. The plugin declares its own SessionStart/PreCompact hooks
-// in plugin.json, so project-level hooks from bd setup claude would duplicate them.
+// settings file. The plugin declares its own SessionStart hooks in plugin.json,
+// so project-level hooks from bd setup claude would duplicate them.
 func hasBeadsPlugin(env claudeEnv) bool {
 	paths := []string{
 		projectSettingsPath(env.projectDir),

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -393,7 +393,7 @@ func TestInstallClaudeCleanupNullHooks(t *testing.T) {
 	if !ok {
 		t.Fatal("hooks section missing")
 	}
-	for _, event := range []string{"SessionStart", "PreCompact"} {
+	for _, event := range []string{"SessionStart"} {
 		eventHooks, ok := hooks[event].([]interface{})
 		if !ok {
 			t.Errorf("%s should be an array, not nil or missing", event)
@@ -420,7 +420,6 @@ func TestInstallClaudeUsesPrimeForClaudeHooks(t *testing.T) {
 	for _, want := range []string{
 		`"command": "bd prime --hook-json"`,
 		`"SessionStart"`,
-		`"PreCompact"`,
 	} {
 		if !strings.Contains(settingsJSON, want) {
 			t.Fatalf("settings missing %q:\n%s", want, settingsJSON)
@@ -504,7 +503,7 @@ func TestHasBeadsHooks(t *testing.T) {
 			name: "has bd prime in PreCompact",
 			settingsData: map[string]interface{}{
 				"hooks": map[string]interface{}{
-					"PreCompact": []interface{}{
+					"SessionStart": []interface{}{
 						map[string]interface{}{
 							"matcher": "",
 							"hooks": []interface{}{

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -255,6 +255,38 @@ func TestRemoveHookCommand(t *testing.T) {
 		},
 	}
 
+	// Separate test: sibling commands within the same hook entry must be
+	// preserved when only the matching command is removed. The bug that
+	// prompted this test dropped the entire hook entry on first match,
+	// silently deleting any sibling commands in the same hooks array.
+	t.Run("preserves sibling commands in same hook entry", func(t *testing.T) {
+		hooks := map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "bd prime"},
+						map[string]interface{}{"type": "command", "command": "other-tool"},
+					},
+				},
+			},
+		}
+		removeHookCommand(hooks, "SessionStart", "bd prime")
+
+		entries, ok := hooks["SessionStart"].([]interface{})
+		if !ok || len(entries) != 1 {
+			t.Fatalf("expected 1 hook entry to remain, got %v", hooks["SessionStart"])
+		}
+		entryMap := entries[0].(map[string]interface{})
+		cmds := entryMap["hooks"].([]interface{})
+		if len(cmds) != 1 {
+			t.Fatalf("expected 1 sibling command to remain, got %d", len(cmds))
+		}
+		if cmds[0].(map[string]interface{})["command"] != "other-tool" {
+			t.Errorf("sibling command was lost; commands: %v", cmds)
+		}
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			removeHookCommand(tt.existingHooks, tt.event, tt.command)
@@ -386,7 +418,7 @@ func TestInstallClaudeUsesPrimeForClaudeHooks(t *testing.T) {
 	settingsJSON := string(data)
 
 	for _, want := range []string{
-		`"command": "bd prime"`,
+		`"command": "bd prime --hook-json"`,
 		`"SessionStart"`,
 		`"PreCompact"`,
 	} {
@@ -498,6 +530,44 @@ func TestHasBeadsHooks(t *testing.T) {
 								map[string]interface{}{
 									"type":    "command",
 									"command": "bd prime --stealth",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "has bd prime --hook-json hook (current format)",
+			settingsData: map[string]interface{}{
+				"hooks": map[string]interface{}{
+					"SessionStart": []interface{}{
+						map[string]interface{}{
+							"matcher": "",
+							"hooks": []interface{}{
+								map[string]interface{}{
+									"type":    "command",
+									"command": "bd prime --hook-json",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "has bd prime --stealth --hook-json hook (current format)",
+			settingsData: map[string]interface{}{
+				"hooks": map[string]interface{}{
+					"PreCompact": []interface{}{
+						map[string]interface{}{
+							"matcher": "",
+							"hooks": []interface{}{
+								map[string]interface{}{
+									"type":    "command",
+									"command": "bd prime --stealth --hook-json",
 								},
 							},
 						},

--- a/cmd/bd/setup/gemini.go
+++ b/cmd/bd/setup/gemini.go
@@ -14,6 +14,7 @@ import (
 var (
 	geminiEnvProvider     = defaultGeminiEnv
 	errGeminiHooksMissing = errors.New("gemini hooks not installed")
+	errGeminiHooksLegacy  = errors.New("gemini hooks need upgrade")
 )
 
 const geminiInstructionsFile = "GEMINI.md"
@@ -114,17 +115,37 @@ func installGemini(env geminiEnv, project bool, stealth bool) error {
 		settings["hooks"] = hooks
 	}
 
-	command := "bd prime"
+	// Gemini CLI (and Claude Code, Codex) require hook stdout to be valid JSON;
+	// --hook-json wraps bd prime's markdown in the shared SessionStart envelope.
+	// PreCompress is intentionally NOT registered: Gemini's PreCompress event is
+	// advisory-only and does not support additionalContext injection — context
+	// re-injection after compression is architecturally impossible there.
+	command := "bd prime --hook-json"
 	if stealth {
-		command = "bd prime --stealth"
+		command = "bd prime --stealth --hook-json"
 	}
 
-	// Gemini CLI uses "PreCompress" instead of Claude's "PreCompact"
+	// Migration sweep: remove all known legacy command variants before registering
+	// the canonical command. Re-running setup must be a clean upgrade path —
+	// stale entries alongside the new one cause Gemini to invoke both, and any
+	// pre-JSON variant emits raw markdown that violates the strict hook contract.
+	legacyVariants := []string{"bd prime", "bd prime --stealth"}
+	for _, legacy := range legacyVariants {
+		if legacy == command {
+			continue // never remove the variant we're about to add
+		}
+		removeHookCommand(hooks, "SessionStart", legacy)
+		removeHookCommand(hooks, "PreCompress", legacy)
+	}
+	// Also clear any --hook-json registration from PreCompress. Beads previously
+	// registered bd prime on PreCompress before we discovered that Gemini's
+	// PreCompress event is advisory-only and cannot inject additionalContext
+	// into the model regardless of output format. Re-running setup migrates cleanly.
+	removeHookCommand(hooks, "PreCompress", "bd prime --hook-json")
+	removeHookCommand(hooks, "PreCompress", "bd prime --stealth --hook-json")
+
 	if addHookCommand(hooks, "SessionStart", command) {
 		_, _ = fmt.Fprintln(env.stdout, "✓ Registered SessionStart hook")
-	}
-	if addHookCommand(hooks, "PreCompress", command) {
-		_, _ = fmt.Fprintln(env.stdout, "✓ Registered PreCompress hook")
 	}
 
 	data, err := json.MarshalIndent(settings, "", "  ")
@@ -169,10 +190,20 @@ func checkGemini(env geminiEnv) error {
 	projectSettings := geminiProjectSettingsPath(env.projectDir)
 
 	switch {
+	case hasCurrentGeminiHooks(globalSettings):
+		_, _ = fmt.Fprintf(env.stdout, "✓ Global hooks installed (current): %s\n", globalSettings)
+	case hasCurrentGeminiHooks(projectSettings):
+		_, _ = fmt.Fprintf(env.stdout, "✓ Project hooks installed (current): %s\n", projectSettings)
 	case hasGeminiBeadsHooks(globalSettings):
-		_, _ = fmt.Fprintf(env.stdout, "✓ Global hooks installed: %s\n", globalSettings)
+		_, _ = fmt.Fprintf(env.stdout, "⚠ Global hooks installed (legacy format): %s\n", globalSettings)
+		_, _ = fmt.Fprintln(env.stdout, "  Legacy 'bd prime' hooks emit raw markdown; Gemini requires JSON stdout.")
+		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup gemini  (upgrades to 'bd prime --gemini-hook')")
+		return errGeminiHooksLegacy
 	case hasGeminiBeadsHooks(projectSettings):
-		_, _ = fmt.Fprintf(env.stdout, "✓ Project hooks installed: %s\n", projectSettings)
+		_, _ = fmt.Fprintf(env.stdout, "⚠ Project hooks installed (legacy format): %s\n", projectSettings)
+		_, _ = fmt.Fprintln(env.stdout, "  Legacy 'bd prime' hooks emit raw markdown; Gemini requires JSON stdout.")
+		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup gemini --project  (upgrades to 'bd prime --gemini-hook')")
+		return errGeminiHooksLegacy
 	default:
 		_, _ = fmt.Fprintln(env.stdout, "✗ No hooks installed")
 		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup gemini")
@@ -219,11 +250,20 @@ func removeGemini(env geminiEnv, project bool) error {
 		if !ok {
 			_, _ = fmt.Fprintln(env.stdout, "No hooks found")
 		} else {
-			// Remove both variants from both events
-			removeHookCommand(hooks, "SessionStart", "bd prime")
-			removeHookCommand(hooks, "PreCompress", "bd prime")
-			removeHookCommand(hooks, "SessionStart", "bd prime --stealth")
-			removeHookCommand(hooks, "PreCompress", "bd prime --stealth")
+			// Remove all known variants from both events. PreCompress is
+			// included for migration safety: older installations registered
+			// bd prime there before we discovered Gemini's PreCompress hook
+			// can't inject additionalContext.
+			variants := []string{
+				"bd prime",
+				"bd prime --stealth",
+				"bd prime --hook-json",
+				"bd prime --stealth --hook-json",
+			}
+			for _, cmd := range variants {
+				removeHookCommand(hooks, "SessionStart", cmd)
+				removeHookCommand(hooks, "PreCompress", cmd)
+			}
 
 			data, err = json.MarshalIndent(settings, "", "  ")
 			if err != nil {
@@ -247,52 +287,73 @@ func removeGemini(env geminiEnv, project bool) error {
 	return nil
 }
 
-// hasGeminiBeadsHooks checks if a settings file has bd prime hooks for Gemini CLI
-func hasGeminiBeadsHooks(settingsPath string) bool {
-	data, err := os.ReadFile(settingsPath) // #nosec G304 -- settingsPath is constructed from known safe locations (user home/.gemini), not user input
+// geminiSessionStartCommands returns all command strings registered under the
+// SessionStart hook event in a settings file. Returns nil on any read/parse
+// error. Detection scope is SessionStart only — PreCompress is advisory-only
+// in Gemini CLI and does not support additionalContext injection.
+func geminiSessionStartCommands(settingsPath string) []string {
+	data, err := os.ReadFile(settingsPath) // #nosec G304 -- path constructed from known safe locations (user home/.gemini or cwd/.gemini)
 	if err != nil {
-		return false
+		return nil
 	}
-
 	var settings map[string]interface{}
 	if err := json.Unmarshal(data, &settings); err != nil {
-		return false
+		return nil
 	}
-
 	hooks, ok := settings["hooks"].(map[string]interface{})
 	if !ok {
-		return false
+		return nil
 	}
-
-	// Check SessionStart and PreCompress for "bd prime"
-	for _, event := range []string{"SessionStart", "PreCompress"} {
-		eventHooks, ok := hooks[event].([]interface{})
+	eventHooks, ok := hooks["SessionStart"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var cmds []string
+	for _, hook := range eventHooks {
+		hookMap, ok := hook.(map[string]interface{})
 		if !ok {
 			continue
 		}
-
-		for _, hook := range eventHooks {
-			hookMap, ok := hook.(map[string]interface{})
+		hookCmds, ok := hookMap["hooks"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, cmd := range hookCmds {
+			cmdMap, ok := cmd.(map[string]interface{})
 			if !ok {
 				continue
 			}
-			commands, ok := hookMap["hooks"].([]interface{})
-			if !ok {
-				continue
-			}
-			for _, cmd := range commands {
-				cmdMap, ok := cmd.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				// Check for either variant
-				cmdStr := cmdMap["command"]
-				if cmdStr == "bd prime" || cmdStr == "bd prime --stealth" {
-					return true
-				}
+			if s, ok := cmdMap["command"].(string); ok {
+				cmds = append(cmds, s)
 			}
 		}
 	}
+	return cmds
+}
 
+// hasCurrentGeminiHooks reports whether a settings file has a current-format
+// bd prime --gemini-hook command on SessionStart. Returns false for legacy
+// "bd prime" (without --gemini-hook) installs, which emit raw markdown that
+// violates Gemini's strict stdout-must-be-JSON hook contract.
+func hasCurrentGeminiHooks(settingsPath string) bool {
+	for _, cmd := range geminiSessionStartCommands(settingsPath) {
+		if cmd == "bd prime --hook-json" || cmd == "bd prime --stealth --hook-json" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasGeminiBeadsHooks reports whether a settings file has any bd prime hook
+// on SessionStart — current format or legacy. Used to detect pre-fix
+// installations that need upgrading via bd setup gemini.
+func hasGeminiBeadsHooks(settingsPath string) bool {
+	for _, cmd := range geminiSessionStartCommands(settingsPath) {
+		switch cmd {
+		case "bd prime", "bd prime --stealth",
+			"bd prime --hook-json", "bd prime --stealth --hook-json":
+			return true
+		}
+	}
 	return false
 }

--- a/cmd/bd/setup/gemini.go
+++ b/cmd/bd/setup/gemini.go
@@ -197,12 +197,12 @@ func checkGemini(env geminiEnv) error {
 	case hasGeminiBeadsHooks(globalSettings):
 		_, _ = fmt.Fprintf(env.stdout, "⚠ Global hooks installed (legacy format): %s\n", globalSettings)
 		_, _ = fmt.Fprintln(env.stdout, "  Legacy 'bd prime' hooks emit raw markdown; Gemini requires JSON stdout.")
-		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup gemini  (upgrades to 'bd prime --gemini-hook')")
+		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup gemini  (upgrades to 'bd prime --hook-json')")
 		return errGeminiHooksLegacy
 	case hasGeminiBeadsHooks(projectSettings):
 		_, _ = fmt.Fprintf(env.stdout, "⚠ Project hooks installed (legacy format): %s\n", projectSettings)
 		_, _ = fmt.Fprintln(env.stdout, "  Legacy 'bd prime' hooks emit raw markdown; Gemini requires JSON stdout.")
-		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup gemini --project  (upgrades to 'bd prime --gemini-hook')")
+		_, _ = fmt.Fprintln(env.stdout, "  Run: bd setup gemini --project  (upgrades to 'bd prime --hook-json')")
 		return errGeminiHooksLegacy
 	default:
 		_, _ = fmt.Fprintln(env.stdout, "✗ No hooks installed")
@@ -332,9 +332,9 @@ func geminiSessionStartCommands(settingsPath string) []string {
 }
 
 // hasCurrentGeminiHooks reports whether a settings file has a current-format
-// bd prime --gemini-hook command on SessionStart. Returns false for legacy
-// "bd prime" (without --gemini-hook) installs, which emit raw markdown that
-// violates Gemini's strict stdout-must-be-JSON hook contract.
+// bd prime --hook-json command on SessionStart. Returns false for legacy
+// "bd prime" installs, which emit raw markdown that violates Gemini's strict
+// stdout-must-be-JSON hook contract.
 func hasCurrentGeminiHooks(settingsPath string) bool {
 	for _, cmd := range geminiSessionStartCommands(settingsPath) {
 		if cmd == "bd prime --hook-json" || cmd == "bd prime --stealth --hook-json" {

--- a/cmd/bd/setup/gemini_test.go
+++ b/cmd/bd/setup/gemini_test.go
@@ -95,8 +95,8 @@ func TestInstallGemini_Global(t *testing.T) {
 		t.Fatal("expected hooks map")
 	}
 
-	// Check SessionStart hook is registered with the --gemini-hook variant.
-	// Gemini's hook contract requires JSON-on-stdout; --gemini-hook wraps
+	// Check SessionStart hook is registered with the --hook-json variant.
+	// Gemini's hook contract requires JSON-on-stdout; --hook-json wraps
 	// bd prime's markdown in the SessionStart envelope shape.
 	sessionStart, ok := hooks["SessionStart"].([]interface{})
 	if !ok || len(sessionStart) == 0 {
@@ -294,7 +294,7 @@ func TestInstallGemini_PreservesExistingSettings(t *testing.T) {
 
 // TestCheckGemini_LegacyInstall verifies that checkGemini returns
 // errGeminiHooksLegacy and emits an upgrade advisory when the settings file
-// contains a pre-fix "bd prime" registration (without --gemini-hook).
+// contains a pre-fix "bd prime" registration (without --hook-json).
 // Legacy hooks emit raw markdown that violates Gemini's JSON stdout contract,
 // so --check must distinguish them from a working current install.
 func TestCheckGemini_LegacyInstall(t *testing.T) {

--- a/cmd/bd/setup/gemini_test.go
+++ b/cmd/bd/setup/gemini_test.go
@@ -95,16 +95,25 @@ func TestInstallGemini_Global(t *testing.T) {
 		t.Fatal("expected hooks map")
 	}
 
-	// Check SessionStart hook
+	// Check SessionStart hook is registered with the --gemini-hook variant.
+	// Gemini's hook contract requires JSON-on-stdout; --gemini-hook wraps
+	// bd prime's markdown in the SessionStart envelope shape.
 	sessionStart, ok := hooks["SessionStart"].([]interface{})
 	if !ok || len(sessionStart) == 0 {
 		t.Fatal("expected SessionStart hooks")
 	}
+	hook := sessionStart[0].(map[string]interface{})
+	cmds := hook["hooks"].([]interface{})
+	cmd := cmds[0].(map[string]interface{})
+	if cmd["command"] != "bd prime --hook-json" {
+		t.Errorf("expected SessionStart command 'bd prime --hook-json', got: %v", cmd["command"])
+	}
 
-	// Check PreCompress hook (Gemini uses PreCompress, not PreCompact)
-	preCompress, ok := hooks["PreCompress"].([]interface{})
-	if !ok || len(preCompress) == 0 {
-		t.Fatal("expected PreCompress hooks")
+	// PreCompress must NOT be registered: per Gemini docs it's advisory-only
+	// and does not support additionalContext injection, so re-priming after
+	// compression isn't possible there regardless of output format.
+	if _, ok := hooks["PreCompress"]; ok {
+		t.Error("PreCompress hook should not be registered (advisory-only event, no additionalContext support)")
 	}
 
 	// Verify output
@@ -165,8 +174,8 @@ func TestInstallGemini_Stealth(t *testing.T) {
 	cmds := hook["hooks"].([]interface{})
 	cmd := cmds[0].(map[string]interface{})
 
-	if cmd["command"] != "bd prime --stealth" {
-		t.Errorf("expected stealth command, got: %v", cmd["command"])
+	if cmd["command"] != "bd prime --stealth --hook-json" {
+		t.Errorf("expected stealth command 'bd prime --stealth --hook-json', got: %v", cmd["command"])
 	}
 }
 
@@ -189,6 +198,65 @@ func TestInstallGemini_Idempotent(t *testing.T) {
 
 	if len(sessionStart) != 1 {
 		t.Errorf("expected 1 SessionStart hook, got %d", len(sessionStart))
+	}
+}
+
+// TestInstallGemini_MigratesLegacyHooks verifies that re-running bd setup gemini
+// on a pre-fix installation (which had bare "bd prime" on SessionStart and/or
+// PreCompress) results in exactly one canonical "bd prime --hook-json" entry
+// on SessionStart and no PreCompress entries. Leaving stale entries alongside
+// the new one would cause Gemini to invoke both, and the legacy command emits
+// raw markdown that violates Gemini's strict stdout-must-be-JSON contract.
+func TestInstallGemini_MigratesLegacyHooks(t *testing.T) {
+	env, _, _ := newGeminiTestEnv(t)
+
+	// Seed a settings file that mirrors a pre-fix installation.
+	settingsPath := geminiGlobalSettingsPath(env.homeDir)
+	legacy := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "bd prime"},
+					},
+				},
+			},
+			"PreCompress": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "bd prime"},
+					},
+				},
+			},
+		},
+	}
+	writeGeminiSettings(t, settingsPath, legacy)
+
+	// Re-run setup — must behave as a clean upgrade, not an accumulation.
+	if err := installGemini(env, false, false); err != nil {
+		t.Fatalf("installGemini: %v", err)
+	}
+
+	settings := readGeminiSettings(t, settingsPath)
+	hooks := settings["hooks"].(map[string]interface{})
+
+	// SessionStart: exactly one entry, the canonical --hook-json command.
+	sessionStart, ok := hooks["SessionStart"].([]interface{})
+	if !ok || len(sessionStart) != 1 {
+		t.Fatalf("expected exactly 1 SessionStart hook after migration, got %v", hooks["SessionStart"])
+	}
+	hook := sessionStart[0].(map[string]interface{})
+	cmds := hook["hooks"].([]interface{})
+	cmd := cmds[0].(map[string]interface{})
+	if cmd["command"] != "bd prime --hook-json" {
+		t.Errorf("SessionStart command = %q, want 'bd prime --hook-json'", cmd["command"])
+	}
+
+	// PreCompress: must be absent or empty.
+	if pc, ok := hooks["PreCompress"].([]interface{}); ok && len(pc) > 0 {
+		t.Errorf("expected PreCompress cleared after migration, got %d entries", len(pc))
 	}
 }
 
@@ -221,6 +289,44 @@ func TestInstallGemini_PreservesExistingSettings(t *testing.T) {
 	hooks := settings["hooks"].(map[string]interface{})
 	if hooks["SomeOtherHook"] == nil {
 		t.Error("existing hook was not preserved")
+	}
+}
+
+// TestCheckGemini_LegacyInstall verifies that checkGemini returns
+// errGeminiHooksLegacy and emits an upgrade advisory when the settings file
+// contains a pre-fix "bd prime" registration (without --gemini-hook).
+// Legacy hooks emit raw markdown that violates Gemini's JSON stdout contract,
+// so --check must distinguish them from a working current install.
+func TestCheckGemini_LegacyInstall(t *testing.T) {
+	env, stdout, _ := newGeminiTestEnv(t)
+
+	// Seed a pre-fix installation: bare "bd prime" on SessionStart.
+	settingsPath := geminiGlobalSettingsPath(env.homeDir)
+	legacy := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "bd prime"},
+					},
+				},
+			},
+		},
+	}
+	writeGeminiSettings(t, settingsPath, legacy)
+
+	err := checkGemini(env)
+	if err != errGeminiHooksLegacy {
+		t.Errorf("expected errGeminiHooksLegacy, got: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "legacy") {
+		t.Errorf("expected 'legacy' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "bd setup gemini") {
+		t.Errorf("expected upgrade instruction in output, got: %s", out)
 	}
 }
 
@@ -411,58 +517,144 @@ func TestRemoveGemini_PreservesOtherHooks(t *testing.T) {
 }
 
 func TestHasGeminiBeadsHooks(t *testing.T) {
-	tmpDir := t.TempDir()
-	settingsPath := filepath.Join(tmpDir, "settings.json")
-
-	// No file
-	if hasGeminiBeadsHooks(settingsPath) {
-		t.Error("expected false for missing file")
+	makeSessionStart := func(command string) map[string]interface{} {
+		return map[string]interface{}{
+			"hooks": map[string]interface{}{
+				"SessionStart": []interface{}{
+					map[string]interface{}{
+						"matcher": "",
+						"hooks": []interface{}{
+							map[string]interface{}{"type": "command", "command": command},
+						},
+					},
+				},
+			},
+		}
+	}
+	makePreCompress := func(command string) map[string]interface{} {
+		return map[string]interface{}{
+			"hooks": map[string]interface{}{
+				"PreCompress": []interface{}{
+					map[string]interface{}{
+						"matcher": "",
+						"hooks": []interface{}{
+							map[string]interface{}{"type": "command", "command": command},
+						},
+					},
+				},
+			},
+		}
 	}
 
-	// Empty file
-	if err := os.WriteFile(settingsPath, []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if hasGeminiBeadsHooks(settingsPath) {
-		t.Error("expected false for empty settings")
+	tests := []struct {
+		name     string
+		settings map[string]interface{}
+		want     bool
+	}{
+		// Current canonical commands (--hook-json)
+		{"current bd prime --hook-json on SessionStart", makeSessionStart("bd prime --hook-json"), true},
+		{"current bd prime --stealth --hook-json on SessionStart", makeSessionStart("bd prime --stealth --hook-json"), true},
+
+		// Legacy commands — still detected so pre-hook-json installations show
+		// the upgrade advisory rather than "not installed".
+		{"legacy bd prime on SessionStart", makeSessionStart("bd prime"), true},
+		{"legacy bd prime --stealth on SessionStart", makeSessionStart("bd prime --stealth"), true},
+
+		// PreCompress is no longer in scope — even legacy installations there
+		// must NOT be reported as installed (we want users to re-run setup).
+		{"bd prime on PreCompress only — not detected", makePreCompress("bd prime"), false},
+		{"bd prime --hook-json on PreCompress only — not detected", makePreCompress("bd prime --hook-json"), false},
+
+		// Unrelated commands
+		{"unrelated command", makeSessionStart("some-other-command"), false},
 	}
 
-	// With bd prime hook
-	settings := map[string]interface{}{
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			settingsPath := filepath.Join(tmpDir, "settings.json")
+			data, err := json.Marshal(tt.settings)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if got := hasGeminiBeadsHooks(settingsPath); got != tt.want {
+				t.Errorf("hasGeminiBeadsHooks(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+
+	// Edge cases: missing file and empty settings
+	t.Run("missing file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if hasGeminiBeadsHooks(filepath.Join(tmpDir, "missing.json")) {
+			t.Error("expected false for missing file")
+		}
+	})
+	t.Run("empty settings", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		settingsPath := filepath.Join(tmpDir, "settings.json")
+		if err := os.WriteFile(settingsPath, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if hasGeminiBeadsHooks(settingsPath) {
+			t.Error("expected false for empty settings")
+		}
+	})
+}
+
+// TestRemoveGemini_CleansAllVariants verifies that removeGemini cleans up
+// every known command variant from BOTH SessionStart and PreCompress —
+// migration safety for pre-fix installations that registered legacy commands
+// on PreCompress.
+func TestRemoveGemini_CleansAllVariants(t *testing.T) {
+	env, _, _ := newGeminiTestEnv(t)
+
+	// Seed a settings file with a current --hook-json registration on SessionStart
+	// and legacy bare-command registrations on PreCompress.
+	settingsPath := geminiGlobalSettingsPath(env.homeDir)
+	existing := map[string]interface{}{
 		"hooks": map[string]interface{}{
 			"SessionStart": []interface{}{
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "bd prime --hook-json"},
+					},
+				},
+			},
+			"PreCompress": []interface{}{
 				map[string]interface{}{
 					"matcher": "",
 					"hooks": []interface{}{
 						map[string]interface{}{"type": "command", "command": "bd prime"},
 					},
 				},
+				map[string]interface{}{
+					"matcher": "",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "bd prime --stealth"},
+					},
+				},
 			},
 		},
 	}
-	data, _ := json.Marshal(settings)
-	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if !hasGeminiBeadsHooks(settingsPath) {
-		t.Error("expected true for settings with bd prime hook")
+	writeGeminiSettings(t, settingsPath, existing)
+
+	if err := removeGemini(env, false); err != nil {
+		t.Fatalf("removeGemini: %v", err)
 	}
 
-	// With stealth hook
-	settings["hooks"].(map[string]interface{})["SessionStart"] = []interface{}{
-		map[string]interface{}{
-			"matcher": "",
-			"hooks": []interface{}{
-				map[string]interface{}{"type": "command", "command": "bd prime --stealth"},
-			},
-		},
+	settings := readGeminiSettings(t, settingsPath)
+	hooks := settings["hooks"].(map[string]interface{})
+
+	if ss, ok := hooks["SessionStart"].([]interface{}); ok && len(ss) > 0 {
+		t.Errorf("expected SessionStart cleared, got %d entries", len(ss))
 	}
-	data, _ = json.Marshal(settings)
-	if err := os.WriteFile(settingsPath, data, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if !hasGeminiBeadsHooks(settingsPath) {
-		t.Error("expected true for settings with bd prime --stealth hook")
+	if pc, ok := hooks["PreCompress"].([]interface{}); ok && len(pc) > 0 {
+		t.Errorf("expected legacy PreCompress entries cleared, got %d entries", len(pc))
 	}
 }
 

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -6,7 +6,7 @@ This document explains design decisions for Claude Code integration in beads.
 
 **Recommended: CLI + Hooks** - Beads uses a simple, universal approach to Claude Code integration:
 - `bd prime` command for context injection (~1-2k tokens)
-- Hooks (SessionStart/PreCompact) for automatic context refresh
+- Hooks (SessionStart) for automatic context refresh
 - Direct CLI commands with `--json` flags
 - Optional: Plugin for slash commands and enhanced UX
 
@@ -102,7 +102,7 @@ bd setup claude --remove
 
 **What it installs:**
 - SessionStart hook: Runs `bd prime` when Claude Code starts a session
-- PreCompact hook: Runs `bd prime` before context compaction to preserve workflow instructions
+- SessionStart hook: Runs `bd prime` when Claude Code starts a session and after compaction
 
 ## Related Files
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3577,6 +3577,15 @@ bd setup [recipe] [flags]
       --stealth         Use stealth mode (claude/gemini)
 ```
 
+**What each setup does:**
+- **Factory.ai** (`bd setup factory`): Creates or updates AGENTS.md with beads workflow instructions (full profile — works with multiple AI tools using the AGENTS.md standard)
+- **Codex CLI** (`bd setup codex`): Creates or updates AGENTS.md with beads workflow instructions for Codex (full profile)
+- **Mux** (`bd setup mux`): Creates or updates AGENTS.md with beads workflow instructions for Mux workspaces (full profile)
+- **Claude Code** (`bd setup claude`): Adds hooks to Claude Code's settings.json that run `bd prime --hook-json` on SessionStart and PreCompact events and manages a minimal-profile beads section in `CLAUDE.md`
+- **Gemini CLI** (`bd setup gemini`): Adds hooks to Gemini's settings.json that run `bd prime --hook-json` on the SessionStart event and manages a minimal-profile beads section in `GEMINI.md`
+- **Cursor** (`bd setup cursor`): Creates `.cursor/rules/beads.mdc` with workflow instructions
+- **Aider** (`bd setup aider`): Creates `.aider.conf.yml` with bd workflow instructions
+
 ### bd where
 
 Show the active beads database location, including redirect information.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3024,9 +3024,10 @@ Show the status of the Dolt engine for the current project.
 In embedded mode, reports that the Dolt engine runs in-process and shows
 the on-disk data directory. For beads-managed (local) servers, displays
 PID, port, and data directory from the local PID file. For externally-
-hosted servers (dolt_mode=server with a remote dolt_server_host), pings
-the configured endpoint via SQL and reports reachability, server version,
-and database.
+managed servers — either a remote dolt_server_host or a local server
+managed outside bd (dolt.auto-start: false, e.g. an orchestrator-shared
+sql-server) — pings the configured endpoint via SQL and reports
+reachability, server version, and database.
 
 ```
 bd dolt status
@@ -3468,7 +3469,7 @@ Automatically detects if MCP server is active and adapts output:
 - MCP mode: Brief workflow reminders (~50 tokens)
 - CLI mode: Full command reference (~1-2k tokens)
 
-Designed for Claude Code hooks (SessionStart, PreCompact) to prevent
+Designed for Claude Code, Gemini CLI, and Codex SessionStart hooks to prevent
 agents from forgetting bd workflow after context compaction.
 
 Config options:
@@ -3490,6 +3491,7 @@ bd prime [flags]
 ```
       --export          Output default content (ignores PRIME.md override)
       --full            Force full CLI output (ignore MCP detection)
+      --hook-json       Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)
       --mcp             Force MCP mode (minimal output)
       --memories-only   Output only persistent memories for compact hook contexts
       --stealth         Stealth mode (no git operations, flush only)
@@ -3576,15 +3578,6 @@ bd setup [recipe] [flags]
       --remove          Remove the integration
       --stealth         Use stealth mode (claude/gemini)
 ```
-
-**What each setup does:**
-- **Factory.ai** (`bd setup factory`): Creates or updates AGENTS.md with beads workflow instructions (full profile — works with multiple AI tools using the AGENTS.md standard)
-- **Codex CLI** (`bd setup codex`): Creates or updates AGENTS.md with beads workflow instructions for Codex (full profile)
-- **Mux** (`bd setup mux`): Creates or updates AGENTS.md with beads workflow instructions for Mux workspaces (full profile)
-- **Claude Code** (`bd setup claude`): Adds hooks to Claude Code's settings.json that run `bd prime --hook-json` on SessionStart and PreCompact events and manages a minimal-profile beads section in `CLAUDE.md`
-- **Gemini CLI** (`bd setup gemini`): Adds hooks to Gemini's settings.json that run `bd prime --hook-json` on the SessionStart event and manages a minimal-profile beads section in `GEMINI.md`
-- **Cursor** (`bd setup cursor`): Creates `.cursor/rules/beads.mdc` with workflow instructions
-- **Aider** (`bd setup aider`): Creates `.aider.conf.yml` with bd workflow instructions
 
 ### bd where
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -277,7 +277,7 @@ cd your-project
 bd init --quiet
 
 # 3. Setup editor integration (choose one)
-bd setup claude   # Claude Code - installs SessionStart/PreCompact hooks
+bd setup claude   # Claude Code - installs SessionStart hooks
 bd setup cursor   # Cursor IDE - creates .cursor/rules/beads.mdc
 bd setup aider    # Aider - creates .aider.conf.yml
 bd setup codex    # Codex CLI - installs Beads skill, AGENTS.md guidance, and native hooks

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -33,7 +33,7 @@ Hook-enabled agents (Claude, Gemini) use the `minimal` profile because `bd prime
 | `cody` | `.cody/rules/beads.md` | Rules file |
 | `kilocode` | `.kilocode/rules/beads.md` | Rules file |
 | `claude` | `~/.claude/settings.json` + `CLAUDE.md` | SessionStart/PreCompact hooks + minimal section |
-| `gemini` | `~/.gemini/settings.json` + `GEMINI.md` | SessionStart/PreCompress hooks + minimal section |
+| `gemini` | `~/.gemini/settings.json` + `GEMINI.md` | SessionStart hook + minimal section |
 | `factory` | `AGENTS.md` | Marked section |
 | `codex` | `.agents/skills/beads/SKILL.md` + `AGENTS.md` | Beads agent skill + generated skill guidance |
 | `mux` | `AGENTS.md` | Marked section |
@@ -248,8 +248,8 @@ bd setup claude --stealth
 ### What Gets Installed
 
 **Global installation** (`~/.claude/settings.json`):
-- `SessionStart` hook: Runs `bd prime` when a new session starts
-- `PreCompact` hook: Runs `bd prime` before context compaction
+- `SessionStart` hook: Runs `bd prime --hook-json` when a new session starts
+- `PreCompact` hook: Runs `bd prime --hook-json` before context compaction
 
 **Project installation** (`.claude/settings.local.json`):
 - Same hooks, but only active for this project
@@ -284,8 +284,8 @@ bd setup claude --project --stealth
 
 ### How It Works
 
-The hooks call `bd prime` which:
-1. Outputs workflow context for Claude to read
+The hooks call `bd prime --hook-json` which:
+1. Outputs workflow context wrapped in the SessionStart JSON envelope Claude Code expects
 2. Prints persistent memories near the top so hook-output previews do not hide them
 3. Starts with a truncation warning telling agents to read the full persisted hook output when the host caps previews
 4. Ensures Claude always knows how to use beads
@@ -297,7 +297,7 @@ This is more context-efficient than MCP tools (~1-2k tokens vs 10-50k for MCP sc
 
 ## Gemini CLI
 
-Gemini CLI integration uses hooks to automatically inject beads workflow context at session start and before context compression.
+Gemini CLI integration uses a SessionStart hook to automatically inject beads workflow context when a session opens.
 
 ### Installation
 
@@ -315,8 +315,7 @@ bd setup gemini --stealth
 ### What Gets Installed
 
 **Global installation** (`~/.gemini/settings.json`):
-- `SessionStart` hook: Runs `bd prime` when a new session starts
-- `PreCompress` hook: Runs `bd prime` before context compression
+- `SessionStart` hook: Runs `bd prime --gemini-hook` when a new session starts, wrapped in the JSON envelope Gemini's hook contract requires
 
 **Project installation** (`.gemini/settings.json`):
 - Same hooks, but only active for this project
@@ -359,7 +358,7 @@ The hooks call `bd prime` which:
 
 For low-token hooks that only need durable project facts, use `bd prime --memories-only`.
 
-This works identically to Claude Code integration, using Gemini CLI's hook system (SessionStart and PreCompress events).
+This works similarly to Claude Code integration, using Gemini CLI's hook system (SessionStart event). Unlike Claude Code, Gemini requires hook stdout to be valid JSON — `bd prime --gemini-hook` wraps the markdown in the required envelope.
 
 ## Cursor IDE
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -32,7 +32,7 @@ Hook-enabled agents (Claude, Gemini) use the `minimal` profile because `bd prime
 | `windsurf` | `.windsurf/rules/beads.md` | Rules file |
 | `cody` | `.cody/rules/beads.md` | Rules file |
 | `kilocode` | `.kilocode/rules/beads.md` | Rules file |
-| `claude` | `~/.claude/settings.json` + `CLAUDE.md` | SessionStart/PreCompact hooks + minimal section |
+| `claude` | `~/.claude/settings.json` + `CLAUDE.md` | SessionStart hook + minimal section |
 | `gemini` | `~/.gemini/settings.json` + `GEMINI.md` | SessionStart hook + minimal section |
 | `factory` | `AGENTS.md` | Marked section |
 | `codex` | `.agents/skills/beads/SKILL.md` + `AGENTS.md` | Beads agent skill + generated skill guidance |
@@ -248,8 +248,7 @@ bd setup claude --stealth
 ### What Gets Installed
 
 **Global installation** (`~/.claude/settings.json`):
-- `SessionStart` hook: Runs `bd prime --hook-json` when a new session starts
-- `PreCompact` hook: Runs `bd prime --hook-json` before context compaction
+- `SessionStart` hook: Runs `bd prime --hook-json` when a session starts, resumes, clears, or restarts after compaction
 
 **Project installation** (`.claude/settings.local.json`):
 - Same hooks, but only active for this project
@@ -284,7 +283,7 @@ bd setup claude --project --stealth
 
 ### How It Works
 
-The hooks call `bd prime --hook-json` which:
+The hook calls `bd prime --hook-json` which:
 1. Outputs workflow context wrapped in the SessionStart JSON envelope Claude Code expects
 2. Prints persistent memories near the top so hook-output previews do not hide them
 3. Starts with a truncation warning telling agents to read the full persisted hook output when the host caps previews
@@ -315,7 +314,7 @@ bd setup gemini --stealth
 ### What Gets Installed
 
 **Global installation** (`~/.gemini/settings.json`):
-- `SessionStart` hook: Runs `bd prime --gemini-hook` when a new session starts, wrapped in the JSON envelope Gemini's hook contract requires
+- `SessionStart` hook: Runs `bd prime --hook-json` when a new session starts, wrapped in the JSON envelope Gemini's hook contract requires
 
 **Project installation** (`.gemini/settings.json`):
 - Same hooks, but only active for this project
@@ -358,7 +357,7 @@ The hooks call `bd prime` which:
 
 For low-token hooks that only need durable project facts, use `bd prime --memories-only`.
 
-This works similarly to Claude Code integration, using Gemini CLI's hook system (SessionStart event). Unlike Claude Code, Gemini requires hook stdout to be valid JSON — `bd prime --gemini-hook` wraps the markdown in the required envelope.
+This works similarly to Claude Code integration, using Gemini CLI's hook system (SessionStart event). Unlike Claude Code, Gemini requires hook stdout to be valid JSON — `bd prime --hook-json` wraps the markdown in the required envelope.
 
 ## Cursor IDE
 

--- a/internal/recipes/recipes.go
+++ b/internal/recipes/recipes.go
@@ -74,7 +74,7 @@ var BuiltinRecipes = map[string]Recipe{
 	"gemini": {
 		Name:        "Gemini CLI",
 		Type:        TypeHooks,
-		Description: "Gemini CLI hooks (SessionStart, PreCompress)",
+		Description: "Gemini CLI hooks (SessionStart)",
 		GlobalPath:  "~/.gemini/settings.json",
 		ProjectPath: ".gemini/settings.json",
 	},

--- a/internal/recipes/recipes.go
+++ b/internal/recipes/recipes.go
@@ -67,7 +67,7 @@ var BuiltinRecipes = map[string]Recipe{
 	"claude": {
 		Name:        "Claude Code",
 		Type:        TypeHooks,
-		Description: "Claude Code hooks (SessionStart, PreCompact)",
+		Description: "Claude Code hooks (SessionStart)",
 		GlobalPath:  "~/.claude/settings.json",
 		ProjectPath: ".claude/settings.local.json",
 	},

--- a/website/docs/cli-reference/dolt.md
+++ b/website/docs/cli-reference/dolt.md
@@ -263,9 +263,10 @@ Show the status of the Dolt engine for the current project.
 In embedded mode, reports that the Dolt engine runs in-process and shows
 the on-disk data directory. For beads-managed (local) servers, displays
 PID, port, and data directory from the local PID file. For externally-
-hosted servers (dolt_mode=server with a remote dolt_server_host), pings
-the configured endpoint via SQL and reports reachability, server version,
-and database.
+managed servers — either a remote dolt_server_host or a local server
+managed outside bd (dolt.auto-start: false, e.g. an orchestrator-shared
+sql-server) — pings the configured endpoint via SQL and reports
+reachability, server version, and database.
 
 ```
 bd dolt status

--- a/website/docs/cli-reference/prime.md
+++ b/website/docs/cli-reference/prime.md
@@ -16,7 +16,7 @@ Automatically detects if MCP server is active and adapts output:
 - MCP mode: Brief workflow reminders (~50 tokens)
 - CLI mode: Full command reference (~1-2k tokens)
 
-Designed for Claude Code hooks (SessionStart, PreCompact) to prevent
+Designed for Claude Code, Gemini CLI, and Codex SessionStart hooks to prevent
 agents from forgetting bd workflow after context compaction.
 
 Config options:
@@ -38,6 +38,7 @@ bd prime [flags]
 ```
       --export          Output default content (ignores PRIME.md override)
       --full            Force full CLI output (ignore MCP detection)
+      --hook-json       Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)
       --mcp             Force MCP mode (minimal output)
       --memories-only   Output only persistent memories for compact hook contexts
       --stealth         Stealth mode (no git operations, flush only)

--- a/website/docs/getting-started/ide-setup.md
+++ b/website/docs/getting-started/ide-setup.md
@@ -19,7 +19,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` when Claude Code starts
-- **PreCompact hook** - Runs `bd prime` before context compaction
+- **SessionStart compact refresh** - Runs `bd prime` after context compaction
 
 **How it works:**
 1. SessionStart hook runs `bd prime` automatically
@@ -40,7 +40,7 @@ If you prefer manual configuration, add to your Claude Code hooks:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd prime"]
+    "SessionStart": ["bd prime"]
   }
 }
 ```

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -149,7 +149,7 @@ cd your-project
 bd init --quiet
 
 # 3. Setup editor integration (choose one)
-bd setup claude   # Claude Code - installs SessionStart/PreCompact hooks
+bd setup claude   # Claude Code - installs SessionStart hooks
 bd setup cursor   # Cursor IDE - creates .cursor/rules/beads.mdc
 bd setup aider    # Aider - creates .aider.conf.yml
 bd setup codex    # Codex CLI - installs Beads skill, AGENTS.md guidance, and native hooks

--- a/website/docs/integrations/claude-code.md
+++ b/website/docs/integrations/claude-code.md
@@ -18,7 +18,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd prime` before context compaction
+- **SessionStart compact refresh** - Runs `bd prime` after context compaction
 
 ### Manual Setup
 
@@ -28,7 +28,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd prime"]
+    "SessionStart": ["bd prime"]
   }
 }
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -108,7 +108,7 @@ bd setup claude
 bd setup claude --check  # Verify
 ```
 
-Installs SessionStart hook (`bd prime`) and PreCompact hook (`bd prime`).
+Installs SessionStart hook (`bd prime`).
 
 ## Cursor IDE
 
@@ -9855,7 +9855,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd prime` before context compaction
+- **SessionStart compact refresh** - Runs `bd prime` after context compaction
 
 ### Manual Setup
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/dolt.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/dolt.md
@@ -263,9 +263,10 @@ Show the status of the Dolt engine for the current project.
 In embedded mode, reports that the Dolt engine runs in-process and shows
 the on-disk data directory. For beads-managed (local) servers, displays
 PID, port, and data directory from the local PID file. For externally-
-hosted servers (dolt_mode=server with a remote dolt_server_host), pings
-the configured endpoint via SQL and reports reachability, server version,
-and database.
+managed servers — either a remote dolt_server_host or a local server
+managed outside bd (dolt.auto-start: false, e.g. an orchestrator-shared
+sql-server) — pings the configured endpoint via SQL and reports
+reachability, server version, and database.
 
 ```
 bd dolt status

--- a/website/versioned_docs/version-1.0.0/cli-reference/prime.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/prime.md
@@ -16,7 +16,7 @@ Automatically detects if MCP server is active and adapts output:
 - MCP mode: Brief workflow reminders (~50 tokens)
 - CLI mode: Full command reference (~1-2k tokens)
 
-Designed for Claude Code hooks (SessionStart, PreCompact) to prevent
+Designed for Claude Code, Gemini CLI, and Codex SessionStart hooks to prevent
 agents from forgetting bd workflow after context compaction.
 
 Config options:
@@ -38,6 +38,7 @@ bd prime [flags]
 ```
       --export          Output default content (ignores PRIME.md override)
       --full            Force full CLI output (ignore MCP detection)
+      --hook-json       Wrap output in the SessionStart hook JSON envelope (Claude Code, Gemini CLI, Codex)
       --mcp             Force MCP mode (minimal output)
       --memories-only   Output only persistent memories for compact hook contexts
       --stealth         Stealth mode (no git operations, flush only)

--- a/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
+++ b/website/versioned_docs/version-1.0.0/getting-started/ide-setup.md
@@ -15,7 +15,7 @@ bd setup claude
 bd setup claude --check  # Verify
 ```
 
-Installs SessionStart hook (`bd prime`) and PreCompact hook (`bd prime`).
+Installs SessionStart hook (`bd prime`).
 
 ## Cursor IDE
 

--- a/website/versioned_docs/version-1.0.0/integrations/claude-code.md
+++ b/website/versioned_docs/version-1.0.0/integrations/claude-code.md
@@ -18,7 +18,7 @@ bd setup claude
 
 This installs:
 - **SessionStart hook** - Runs `bd prime` on session start
-- **PreCompact hook** - Runs `bd prime` before context compaction
+- **SessionStart compact refresh** - Runs `bd prime` after context compaction
 
 ### Manual Setup
 
@@ -28,7 +28,7 @@ Add to your Claude Code hooks configuration:
 {
   "hooks": {
     "SessionStart": ["bd prime"],
-    "PreCompact": ["bd prime"]
+    "SessionStart": ["bd prime"]
   }
 }
 ```


### PR DESCRIPTION
## Summary

Gemini CLI v0.40.1 requires hooks to emit output as a `hookSpecificOutput.additionalContext` JSON envelope — bare text stdout is silently ignored by the hook host. Claude Code's documented spec also specifies the JSON form; raw text was merely tolerated. This PR brings both integrations into compliance and adds a migration path for existing installations.

- Add `--hook-json` flag to `bd prime`: wraps all output in the `hookSpecificOutput.additionalContext` envelope shared by Claude Code, Gemini CLI, and Codex (see [Gemini CLI hook reference](https://geminicli.com/docs/hooks/reference/))
- Update `bd setup gemini` to register `bd prime --hook-json` on **SessionStart only**; removes the PreCompress registration (Gemini docs v0.40.1: PreCompress hooks do not support `additionalContext`)
- Update `bd setup claude` to register `bd prime --hook-json` on SessionStart and PreCompact (JSON form is the documented spec for Claude Code hooks)
- Migration sweep in both setup commands: re-running `bd setup claude` or `bd setup gemini` upgrades legacy bare-command (`bd prime`) installs to the JSON form without manual intervention
- `bd setup gemini --check` now distinguishes current (`--hook-json`) from legacy (bare `bd prime`) installs and emits an upgrade advisory for the latter
- Fix `removeHookCommand` silent sibling-deletion bug (also filed as a standalone PR for surgical review): previously, matching a command in a hook entry dropped the **entire entry**, deleting any sibling commands; now only the matching command is removed and the entry is dropped only when its command list becomes empty

## Conflict note

This PR overlaps with **#3642** (`fix(setup): remove stale bd sync from Mux hook; warn in claude check`) on `cmd/bd/setup/claude.go`. The concerns are different (#3642 removes a stale `bd sync` command; this PR upgrades hook registration to the JSON form), but the file overlap means a rebase will be needed once one merges. Happy to rebase on top of #3642 if reviewers prefer that ordering — just say the word.

## Testing

944 net insertions of test coverage:
- `cmd/bd/prime_gemini_hook_test.go` (new): end-to-end tests for `--hook-json` output format, envelope structure, and SessionStart event name
- `cmd/bd/prime_test.go`: extended with `--hook-json` flag registration and output shape tests
- `cmd/bd/setup/claude_test.go`: migration sweep tests, legacy detection, `removeHookCommand` sibling-preservation
- `cmd/bd/setup/gemini_test.go`: SessionStart-only registration, PreCompress removal, `--check` legacy advisory

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->