### PR TITLE
docs(website): config.toml → config.yaml in git-integration.md

### DIFF
--- a/website/docs/reference/git-integration.md
+++ b/website/docs/reference/git-integration.md
@@ -20,7 +20,7 @@ Data storage and sync are handled by Dolt (a version-controlled SQL database).
 
 ```
 .beads/
-├── config.toml        # Project config (git-tracked)
+├── config.yaml        # Project config (git-tracked)
 ├── metadata.json      # Backend metadata (git-tracked)
 └── dolt/              # Dolt database and server data (gitignored)
 ```

--- a/website/versioned_docs/version-1.0.0/reference/git-integration.md
+++ b/website/versioned_docs/version-1.0.0/reference/git-integration.md
@@ -20,7 +20,7 @@ Data storage and sync are handled by Dolt (a version-controlled SQL database).
 
 ```
 .beads/
-├── config.toml        # Project config (git-tracked)
+├── config.yaml        # Project config (git-tracked)
 ├── metadata.json      # Backend metadata (git-tracked)
 └── dolt/              # Dolt database and server data (gitignored)
 ```


### PR DESCRIPTION
## Summary

`website/docs/reference/git-integration.md:23` and the v1.0.0 versioned snapshot at `website/versioned_docs/version-1.0.0/reference/git-integration.md:23` both show `config.toml` in the `.beads/` tree diagram. Live config has been YAML since v1.0.0 (`git show v1.0.0:internal/config/config.go` → `SetConfigType("yaml")`).

Same wholly-stale pattern as PR #3714 (mybd-hxq), smaller blast radius.

## Checked while in the file

- All other `.toml` references in `website/docs/` and `website/versioned_docs/` refer to `.formula.toml` — formulas legitimately use TOML, so those are correct and untouched.
- `website/static/llms-full.txt` has stale `config.toml` references at lines 11074-11075 and 11196. **Out of scope** here — that's a generated file being brought under the freshness gate by a separate issue (mybd-ssn upstream). Did not edit.

## Diff

2 files changed, 2 insertions(+), 2 deletions(-)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->