### PR TITLE
docs: add lightweight PR description template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!--
+This is a starting scaffold to help reviewers (human and agent) parse intent before diff.
+Replace, expand, or delete sections freely. CONTRIBUTING.md has the full hygiene rules.
+-->
+
+## What
+
+<!-- One or two plain-language sentences: what does this change do? -->
+
+## Why
+
+<!-- The problem this solves, the motivation, or a link to the issue: e.g. "Fixes #123" -->
+
+## Verification
+
+<!-- How you tested. Commands a reviewer can run to confirm. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,7 @@ Add cycle detection for dependency graphs
 - Update documentation as needed
 - Ensure CI passes before requesting review
 - Respond to review feedback promptly
+- Lead the PR with a brief plain-language `What` and `Why` so reviewers can grasp the goal without reading the diff. `.github/PULL_REQUEST_TEMPLATE.md` is a starting scaffold — replace, expand, or delete sections to fit your change.
 
 ### ZFC (Zero Framework Cognition)
 


### PR DESCRIPTION
## What

Adds `.github/PULL_REQUEST_TEMPLATE.md` with three short sections (`What` / `Why` / `Verification`) and references it from CONTRIBUTING.md's Pull Request Hygiene list.

## Why

Right now PR description shape is fully contributor-defined, so reviewers (human or agent) often have to reverse-engineer intent from the diff. A small predictable header makes the goal of each PR scannable without that work.

A few signals point at this being low-friction-positive:

- 99% of incoming PRs are AI-generated per [Vibe Maintainer](https://steve-yegge.medium.com/vibe-maintainer-a2273a841040). Agents write better PR descriptions when given structure to fill — predictable headers reduce drift and make automated triage more reliable.
- Median resolution noted at 15 hrs across 50 daily PRs — anything that shaves seconds off per-PR triage compounds.
- A template is **scaffolding, not a gate**. Contributors can replace, expand, or delete sections freely. Existing hygiene rules and the maintainer decision tree are unchanged.

Fixes #3748.

## Verification

- New file: `.github/PULL_REQUEST_TEMPLATE.md` (GitHub will auto-populate this into new PR descriptions; this PR was opened before the template was on `main`, so it isn't using its own template — that's expected.)
- One-line addition under "Pull Request Hygiene" in `CONTRIBUTING.md`.

## Explicitly Out of Scope

- No enforcement (no CI checks, no lint).
- No checkbox-style impact matrices.
- No consumer-cohort lists or cross-project sections (respects the existing "beads stays independent from gas town" hygiene rule).
- No edits to `PR_MAINTAINER_GUIDELINES.md` or `AGENT_INSTRUCTIONS.md`.

If maintainers prefer to leave PR shape contributor-defined, no problem — close this and #3748 

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->