### PR TITLE
fix(config): remove dead dolt.idle-timeout key

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -47,7 +47,6 @@ Tool-level settings you can configure:
 | `dolt.auto-push` | - | `BD_DOLT_AUTO_PUSH` | `false` | Auto-push to Dolt remote after writes (explicit opt-in) |
 | `dolt.auto-push-interval` | - | `BD_DOLT_AUTO_PUSH_INTERVAL` | `5m` | Minimum time between auto-pushes |
 | `dolt.shared-server` | `--shared-server` | `BEADS_DOLT_SHARED_SERVER` | `false` | Share a single Dolt server across all projects at `~/.beads/shared-server/` |
-| `dolt.idle-timeout` | - | - | `30m` | Idle auto-stop timeout (`"0"` disables) |
 | `db` | `--db` | `BD_DB` | (auto-discover) | Database path |
 | `actor` | `--actor` | `BEADS_ACTOR` | `git config user.name` | Actor name for audit trail (see below) |
 

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -354,9 +354,6 @@ dolt:
   # at ~/.beads/shared-server/. Each project uses its own database (prefix-based).
   # Eliminates port conflicts and reduces resource usage on multi-project machines.
   shared-server: false   # true | false
-
-  # Idle auto-stop timeout for the Dolt server (default: "30m", "0" disables)
-  idle-timeout: 30m
 ```
 
 ### Environment Variables

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1402,7 +1402,7 @@ func TestGetStringFromDir(t *testing.T) {
 
 	t.Run("non-existent key returns empty string", func(t *testing.T) {
 		dir := t.TempDir()
-		writeConfig(t, dir, "dolt:\n  idle-timeout: 30m\n")
+		writeConfig(t, dir, "dolt:\n  shared-server: true\n")
 		if got := GetStringFromDir(dir, "dolt.auto-start"); got != "" {
 			t.Errorf("got %q, want %q", got, "")
 		}

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // YamlOnlyKeys are configuration keys that must be stored in config.yaml
@@ -65,7 +64,6 @@ var YamlOnlyKeys = map[string]bool{
 	"backup.git-repo": true,
 
 	// Dolt server settings
-	"dolt.idle-timeout":  true, // Idle auto-stop timeout (default "30m", "0" disables)
 	"dolt.shared-server": true, // Shared Dolt server at ~/.beads/shared-server/ (GH#2377)
 	"dolt.max-conns":     true, // Connection pool size override (default 10, GH#3140)
 
@@ -517,13 +515,6 @@ func validateYamlConfigValue(key, value string) error {
 		}
 		if depth < 1 {
 			return fmt.Errorf("hierarchy.max-depth must be at least 1, got %d", depth)
-		}
-	case "dolt.idle-timeout":
-		// "0" disables, otherwise must be a valid Go duration
-		if value != "0" {
-			if _, err := time.ParseDuration(value); err != nil {
-				return fmt.Errorf("dolt.idle-timeout must be a duration (e.g. \"30m\", \"1h\") or \"0\" to disable, got %q", value)
-			}
 		}
 	case "dolt.shared-server":
 		lower := strings.ToLower(value)

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -94,7 +94,6 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `no-git-ops` | — | — | `false` | Disable git ops in `bd prime` close protocol |
 | `dolt.auto-commit` | `--dolt-auto-commit` | `BD_DOLT_AUTO_COMMIT` | `on` | Create a Dolt history commit after each successful write |
 | `dolt.auto-push` | — | `BD_DOLT_AUTO_PUSH` | `false` | Auto-push to Dolt remote after writes (opt-in) |
-| `dolt.idle-timeout` | — | — | `30m` | Idle auto-stop timeout (`"0"` disables) |
 | `dolt.shared-server` | `--shared-server` | `BEADS_DOLT_SHARED_SERVER` | `false` | Share one Dolt server at `~/.beads/shared-server/` |
 | `dolt.max-conns` | — | `BEADS_DOLT_MAX_CONNS` | `10` | Connection pool size |
 | `git.author` | — | — | (none) | Override commit author for beads commits |

--- a/website/versioned_docs/version-1.0.0/reference/configuration.md
+++ b/website/versioned_docs/version-1.0.0/reference/configuration.md
@@ -94,7 +94,6 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `no-git-ops` | — | — | `false` | Disable git ops in `bd prime` close protocol |
 | `dolt.auto-commit` | `--dolt-auto-commit` | `BD_DOLT_AUTO_COMMIT` | `on` | Create a Dolt history commit after each successful write |
 | `dolt.auto-push` | — | `BD_DOLT_AUTO_PUSH` | `false` | Auto-push to Dolt remote after writes (opt-in) |
-| `dolt.idle-timeout` | — | — | `30m` | Idle auto-stop timeout (`"0"` disables) |
 | `dolt.shared-server` | `--shared-server` | `BEADS_DOLT_SHARED_SERVER` | `false` | Share one Dolt server at `~/.beads/shared-server/` |
 | `dolt.max-conns` | — | `BEADS_DOLT_MAX_CONNS` | `10` | Connection pool size |
 | `git.author` | — | — | (none) | Override commit author for beads commits |


### PR DESCRIPTION
## Summary

The `dolt.idle-timeout` config key has been dead since GH#2452 (commit 4df17ca34, in v0.60.0) removed the idle-monitor and activity-signal daemon infrastructure. There is:

- No `SetDefault` for it in `internal/config/config.go`
- No `GetString` / `GetDuration` / viper consumer anywhere in `cmd/` or `internal/`
- The only references were docs, the `YamlOnlyKeys` entry, and a validator `case`

The validator served no purpose (the value was never read anywhere). User-visible: someone setting `dolt.idle-timeout: 10m` today would get a clean `bd config` validation but the value is silently ignored.

## Changes

- `internal/config/yaml_config.go` — drop `YamlOnlyKeys` entry, drop validator `case`, drop now-unused `time` import
- `internal/config/config_test.go` — change a fixture YAML that incidentally used `idle-timeout` to use `shared-server` (the test asserts on a different key so the change is incidental)
- `docs/CONFIG.md`, `docs/DOLT.md`, `website/docs/reference/configuration.md`, `website/versioned_docs/version-1.0.0/reference/configuration.md` — drop the table row and YAML example

6 files changed, 1 insertion(+), 16 deletions(-)

## Out of scope

`docs/DOLT-BACKEND.md:467` has `idle_timeout: "30s"` under Dolt server lock-retry settings — that's the upstream Dolt server's own config key, not the removed beads key. Untouched.

## Verification

```
$ go build -tags gms_pure_go ./...        # ok
$ CGO_ENABLED=1 go test -tags gms_pure_go ./internal/config/
ok  	github.com/steveyegge/beads/internal/config	0.190s
```

Discovered during review of PR #3714 (mybd-b5q).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->