### PR TITLE
internal/storage/db/server: add DoltServer + lifecycle tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,13 +158,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install Dolt (Linux)
-        if: runner.os == 'Linux'
+      - name: Install Dolt (Linux/macOS)
         run: curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
 
-      - name: Install Dolt (macOS)
-        if: runner.os == 'macOS'
-        run: brew install dolt
+      - name: Verify dolt on PATH
+        run: dolt version
 
       - name: Configure Git and Dolt identity
         run: |

--- a/internal/storage/db/proxy/server.go
+++ b/internal/storage/db/proxy/server.go
@@ -89,6 +89,9 @@ func (p *proxyServer) Start(parentCtx context.Context) error {
 
 	addr := fmt.Sprintf("127.0.0.1:%d", p.port)
 
+	// TODO: support listening on a unix socket as an alternative to
+	// 127.0.0.1:port (requires plumbing through the backend's transport
+	// choice from servercfg).
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", addr, err)

--- a/internal/storage/db/proxy/server.go
+++ b/internal/storage/db/proxy/server.go
@@ -89,9 +89,6 @@ func (p *proxyServer) Start(parentCtx context.Context) error {
 
 	addr := fmt.Sprintf("127.0.0.1:%d", p.port)
 
-	// TODO: support listening on a unix socket as an alternative to
-	// 127.0.0.1:port (requires plumbing through the backend's transport
-	// choice from servercfg).
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", addr, err)

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -2,13 +2,20 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"net"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
+	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+
+	"github.com/steveyegge/beads/internal/storage/doltutil"
 )
 
 type DoltServer struct {
+	id         string
 	rootDir    string
 	configPath string
 	config     servercfg.ServerConfig
@@ -17,15 +24,40 @@ type DoltServer struct {
 var _ DatabaseServer = (*DoltServer)(nil)
 
 func NewDoltServer(rootDir, configPath string) (*DoltServer, error) {
-	return nil, errors.New("server: NewDoltServer not implemented")
+	if rootDir == "" {
+		return nil, errors.New("server: NewDoltServer: rootDir is required")
+	}
+	if configPath == "" {
+		return nil, errors.New("server: NewDoltServer: configPath is required")
+	}
+	cfg, err := servercfg.YamlConfigFromFile(filesys.LocalFS, configPath)
+	if err != nil {
+		return nil, fmt.Errorf("server: NewDoltServer: parse config %q: %w", configPath, err)
+	}
+	sum := sha256.Sum256([]byte(rootDir))
+	return &DoltServer{
+		id:         hex.EncodeToString(sum[:]),
+		rootDir:    rootDir,
+		configPath: configPath,
+		config:     cfg,
+	}, nil
 }
 
 func (s *DoltServer) ID(_ context.Context) string {
-	return ""
+	return s.id
 }
 
-func (s *DoltServer) DSN(_ context.Context) string {
-	return ""
+// TODO: support unix-socket connections (servercfg.Socket()) instead of
+// always building a TCP DSN.
+func (s *DoltServer) DSN(_ context.Context, database string) string {
+	return doltutil.ServerDSN{
+		Host:     s.config.Host(),
+		Port:     s.config.Port(),
+		User:     s.config.User(),
+		Password: s.config.Password(),
+		Database: database,
+		TLS:      false,
+	}.String()
 }
 
 func (s *DoltServer) Start(_ context.Context) error {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -7,39 +7,77 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/steveyegge/beads/internal/storage/db/util"
 )
 
 type DoltServer struct {
-	id         string
-	rootDir    string
-	configPath string
-	config     servercfg.ServerConfig
+	id          string
+	doltBinExec string
+	rootDir     string
+	configPath  string
+	config      servercfg.ServerConfig
+
+	cmd     *exec.Cmd       // the dolt sql-server process; nil when not started
+	logFile *os.File        // stdout/stderr destination; closed by Stop
+	errChan chan error      // single-buffered; receives cmd.Wait() result on non-nil error
+	egCtx   context.Context // canceled when the wait goroutine returns an error or parent ctx cancels
 }
 
 var _ DatabaseServer = (*DoltServer)(nil)
 
-func NewDoltServer(rootDir, configPath string) (*DoltServer, error) {
+func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string) (*DoltServer, error) {
+	if doltBinExec == "" {
+		return nil, errors.New("server: NewDoltServer: doltBinExec is required")
+	}
 	if rootDir == "" {
 		return nil, errors.New("server: NewDoltServer: rootDir is required")
 	}
 	if configPath == "" {
 		return nil, errors.New("server: NewDoltServer: configPath is required")
 	}
+	absDoltBinExec, err := filepath.Abs(doltBinExec)
+	if err != nil {
+		return nil, errors.New("server: NewDoltServer: failed to determine absolute path of doltBinExec")
+	}
+	absRootDir, err := filepath.Abs(rootDir)
+	if err != nil {
+		return nil, errors.New("server: NewDoltServer: failed to determine absolute path of rootDir")
+	}
+	absConfigPath, err := filepath.Abs(configPath)
+	if err != nil {
+		return nil, errors.New("server: NewDoltServer: failed to determine absolute path of configPath")
+	}
 	cfg, err := servercfg.YamlConfigFromFile(filesys.LocalFS, configPath)
 	if err != nil {
 		return nil, fmt.Errorf("server: NewDoltServer: parse config %q: %w", configPath, err)
 	}
+	var logFile *os.File
+	if logFilePath != "" {
+		absLogFilePath, err := filepath.Abs(logFilePath)
+		if err != nil {
+			return nil, errors.New("server: NewDoltServer: failed to determine absolute path of logFilePath")
+		}
+		logFile, err = os.OpenFile(absLogFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // logFilePath is caller-derived, not user-request input
+		if err != nil {
+			return nil, fmt.Errorf("server: NewDoltServer: open log %q: %w", logFilePath, err)
+		}
+	}
 	sum := sha256.Sum256([]byte(rootDir))
 	return &DoltServer{
-		id:         hex.EncodeToString(sum[:]),
-		rootDir:    rootDir,
-		configPath: configPath,
-		config:     cfg,
+		id:          hex.EncodeToString(sum[:]),
+		doltBinExec: absDoltBinExec,
+		rootDir:     absRootDir,
+		configPath:  absConfigPath,
+		config:      cfg,
+		logFile:     logFile,
 	}, nil
 }
 
@@ -65,8 +103,38 @@ func (s *DoltServer) DSN(_ context.Context, database string) string {
 	return dsn.String()
 }
 
-func (s *DoltServer) Start(_ context.Context) error {
-	return errors.New("server: DoltServer.Start not implemented")
+func (s *DoltServer) Start(ctx context.Context) error {
+	args := []string{
+		"sql-server",
+		"-c", s.configPath,
+	}
+
+	cmd := exec.Command(s.doltBinExec, args...)
+	cmd.Dir = s.rootDir
+	cmd.Stdin = nil
+	if s.logFile != nil {
+		cmd.Stdout = s.logFile
+		cmd.Stderr = s.logFile
+	}
+	cmd.Env = os.Environ()
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("server: DoltServer.Start: launch dolt sql-server: %w", err)
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	s.cmd = cmd
+	s.errChan = make(chan error, 1)
+	s.egCtx = egCtx
+
+	eg.Go(func() error {
+		defer close(s.errChan)
+		waitErr := cmd.Wait()
+		s.errChan <- waitErr
+		return waitErr
+	})
+
+	return nil
 }
 
 func (s *DoltServer) Stop(_ context.Context) error {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -25,10 +25,11 @@ type DoltServer struct {
 	configPath  string
 	config      servercfg.ServerConfig
 
-	cmd     *exec.Cmd       // the dolt sql-server process; nil when not started
-	logFile *os.File        // stdout/stderr destination; closed by Stop
-	errChan chan error      // single-buffered; receives cmd.Wait() result on non-nil error
-	egCtx   context.Context // canceled when the wait goroutine returns an error or parent ctx cancels
+	cmd     *exec.Cmd
+	logFile *os.File
+	eg      *errgroup.Group
+	egCtx   context.Context
+	cancel  context.CancelFunc // cancels the parent of egCtx; called by Stop
 }
 
 var _ DatabaseServer = (*DoltServer)(nil)
@@ -103,42 +104,63 @@ func (s *DoltServer) DSN(_ context.Context, database string) string {
 	return dsn.String()
 }
 
-func (s *DoltServer) Start(ctx context.Context) error {
+func (s *DoltServer) Start(_ context.Context) error {
 	args := []string{
 		"sql-server",
 		"-c", s.configPath,
 	}
 
-	cmd := exec.Command(s.doltBinExec, args...)
+	if s.eg != nil || s.egCtx != nil {
+		return fmt.Errorf("server: DoltServer.Start: server already started")
+	}
+
+	managedCtx, cancel := context.WithCancel(context.Background())
+	eg, egCtx := errgroup.WithContext(managedCtx)
+	s.eg = eg
+	s.egCtx = egCtx
+	s.cancel = cancel
+
+	cmd := exec.CommandContext(managedCtx, s.doltBinExec, args...)
 	cmd.Dir = s.rootDir
 	cmd.Stdin = nil
 	if s.logFile != nil {
 		cmd.Stdout = s.logFile
 		cmd.Stderr = s.logFile
 	}
+
 	cmd.Env = os.Environ()
 
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("server: DoltServer.Start: launch dolt sql-server: %w", err)
-	}
-
-	eg, egCtx := errgroup.WithContext(ctx)
-	s.cmd = cmd
-	s.errChan = make(chan error, 1)
-	s.egCtx = egCtx
-
 	eg.Go(func() error {
-		defer close(s.errChan)
-		waitErr := cmd.Wait()
-		s.errChan <- waitErr
-		return waitErr
+		return cmd.Run()
 	})
 
 	return nil
 }
 
 func (s *DoltServer) Stop(_ context.Context) error {
-	return errors.New("server: DoltServer.Stop not implemented")
+	if s.cancel != nil {
+		s.cancel()
+	}
+	var waitErr error
+	if s.eg != nil {
+		waitErr = s.eg.Wait()
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) || errors.Is(waitErr, context.Canceled) {
+			waitErr = nil
+		}
+	}
+	var closeErr error
+	if s.logFile != nil {
+		closeErr = s.logFile.Close()
+		s.logFile = nil
+	}
+	if waitErr != nil {
+		return fmt.Errorf("server: DoltServer.Stop: %w", waitErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("server: DoltServer.Stop: close log: %w", closeErr)
+	}
+	return nil
 }
 
 func (s *DoltServer) Restart(_ context.Context) error {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -86,7 +86,7 @@ func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath, user, password
 	if keepAlivePeriod == 0 {
 		keepAlivePeriod = defaultKeepAlivePeriod
 	}
-	sum := sha256.Sum256([]byte(rootDir))
+	sum := sha256.Sum256([]byte(absRootDir))
 	return &DoltServer{
 		id:              hex.EncodeToString(sum[:]),
 		doltBinExec:     absDoltBinExec,

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"golang.org/x/sync/errgroup"
@@ -174,6 +175,44 @@ func (s *DoltServer) doltInit(ctx context.Context) error {
 	return nil
 }
 
+var retryableDoltInitErrSubstrings = []string{
+	"repository state is invalid",
+}
+
+func isRetryableDoltInitErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, s := range retryableDoltInitErrSubstrings {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *DoltServer) doltInitWithRetries(ctx context.Context) error {
+	const maxRetries = 4
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 100 * time.Millisecond
+	bo.MaxInterval = 1 * time.Second
+	bo.MaxElapsedTime = 0
+
+	op := func() error {
+		err := s.doltInit(ctx)
+		if err == nil {
+			return nil
+		}
+		if !isRetryableDoltInitErr(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+
+	return backoff.Retry(op, backoff.WithMaxRetries(backoff.WithContext(bo, ctx), maxRetries))
+}
+
 func (s *DoltServer) Start(ctx context.Context) error {
 	if s.eg != nil || s.egCtx != nil {
 		return fmt.Errorf("server: DoltServer.Start: server already started")
@@ -183,7 +222,7 @@ func (s *DoltServer) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.doltInit(ctx); err != nil {
+	if err := s.doltInitWithRetries(ctx); err != nil {
 		return err
 	}
 

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -165,6 +165,13 @@ func (s *DoltServer) doltInit(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, s.doltBinExec, "init")
 	cmd.Dir = s.rootDir
 	if out, err := cmd.CombinedOutput(); err != nil {
+		// Concurrent Starts on the same rootDir race here: only one `dolt
+		// init` wins; the rest see "This directory has already been
+		// initialized." and exit non-zero. The repo is initialized either
+		// way, so treat that case as success.
+		if strings.Contains(string(out), "already been initialized") {
+			return nil
+		}
 		return fmt.Errorf("server: DoltServer.doltInit: %w\n%s", err, out)
 	}
 

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
@@ -31,7 +32,6 @@ type DoltServer struct {
 	config          servercfg.ServerConfig
 	keepAlivePeriod time.Duration
 
-	cmd     *exec.Cmd
 	logFile *os.File
 	eg      *errgroup.Group
 	egCtx   context.Context
@@ -114,14 +114,72 @@ func (s *DoltServer) DSN(_ context.Context, database string) string {
 	return dsn.String()
 }
 
-func (s *DoltServer) Start(_ context.Context) error {
+func (s *DoltServer) doltConfigure(ctx context.Context) error {
+	probe := exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--get", "user.name")
+	if out, err := probe.Output(); err == nil && strings.TrimSpace(string(out)) != "" {
+		return nil
+	}
+	name, email := "beads", "beads@localhost"
+	if out, err := exec.CommandContext(ctx, "git", "config", "user.name").Output(); err == nil {
+		if v := strings.TrimSpace(string(out)); v != "" {
+			name = v
+		}
+	}
+	if out, err := exec.CommandContext(ctx, "git", "config", "user.email").Output(); err == nil {
+		if v := strings.TrimSpace(string(out)); v != "" {
+			email = v
+		}
+	}
+	if out, err := exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--add", "user.name", name).CombinedOutput(); err != nil {
+		return fmt.Errorf("server: DoltServer.doltConfigure: set user.name: %w\n%s", err, out)
+	}
+	if out, err := exec.CommandContext(ctx, s.doltBinExec, "config", "--global", "--add", "user.email", email).CombinedOutput(); err != nil {
+		return fmt.Errorf("server: DoltServer.doltConfigure: set user.email: %w\n%s", err, out)
+	}
+	return nil
+}
+
+func (s *DoltServer) doltInit(ctx context.Context) error {
+	if err := os.MkdirAll(s.rootDir, 0o755); err != nil {
+		return fmt.Errorf("server: DoltServer.doltInit: mkdir %q: %w", s.rootDir, err)
+	}
+
+	probe := exec.CommandContext(ctx, s.doltBinExec, "status")
+	probe.Dir = s.rootDir
+	probeOut, probeErr := probe.CombinedOutput()
+	if probeErr == nil {
+		return nil
+	}
+
+	if !strings.Contains(string(probeOut), "not a valid dolt repository") {
+		return fmt.Errorf("server: DoltServer.doltInit: probe status: %w\n%s", probeErr, probeOut)
+	}
+
+	cmd := exec.CommandContext(ctx, s.doltBinExec, "init")
+	cmd.Dir = s.rootDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("server: DoltServer.doltInit: %w\n%s", err, out)
+	}
+
+	return nil
+}
+
+func (s *DoltServer) Start(ctx context.Context) error {
+	if s.eg != nil || s.egCtx != nil {
+		return fmt.Errorf("server: DoltServer.Start: server already started")
+	}
+
+	if err := s.doltConfigure(ctx); err != nil {
+		return err
+	}
+
+	if err := s.doltInit(ctx); err != nil {
+		return err
+	}
+
 	args := []string{
 		"sql-server",
 		"-c", s.configPath,
-	}
-
-	if s.eg != nil || s.egCtx != nil {
-		return fmt.Errorf("server: DoltServer.Start: server already started")
 	}
 
 	managedCtx, cancel := context.WithCancel(context.Background())

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -152,17 +152,6 @@ func (s *DoltServer) doltInit(ctx context.Context) error {
 		return fmt.Errorf("server: DoltServer.doltInit: mkdir %q: %w", s.rootDir, err)
 	}
 
-	probe := exec.CommandContext(ctx, s.doltBinExec, "status")
-	probe.Dir = s.rootDir
-	probeOut, probeErr := probe.CombinedOutput()
-	if probeErr == nil {
-		return nil
-	}
-
-	if !strings.Contains(string(probeOut), "not a valid dolt repository") {
-		return fmt.Errorf("server: DoltServer.doltInit: probe status: %w\n%s", probeErr, probeOut)
-	}
-
 	cmd := exec.CommandContext(ctx, s.doltBinExec, "init")
 	cmd.Dir = s.rootDir
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
@@ -134,6 +136,8 @@ func (s *DoltServer) Start(_ context.Context) error {
 		return cmd.Run()
 	})
 
+	// give server time to come up
+	time.Sleep(200 * time.Millisecond)
 	return nil
 }
 
@@ -171,8 +175,16 @@ func (s *DoltServer) Running(_ context.Context) bool {
 	return false
 }
 
-func (s *DoltServer) Ping(_ context.Context) error {
-	return errors.New("server: DoltServer.Ping not implemented")
+func (s *DoltServer) Ping(ctx context.Context) error {
+	db, err := sql.Open("mysql", s.DSN(ctx, ""))
+	if err != nil {
+		return fmt.Errorf("server: DoltServer.Ping: open: %w", err)
+	}
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		return fmt.Errorf("server: DoltServer.Ping: %w", err)
+	}
+	return nil
 }
 
 func (s *DoltServer) Dial(_ context.Context) (net.Conn, error) {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -30,6 +30,8 @@ type DoltServer struct {
 	rootDir         string
 	configPath      string
 	config          servercfg.ServerConfig
+	user            string
+	password        string
 	keepAlivePeriod time.Duration
 
 	logFile *os.File
@@ -40,7 +42,7 @@ type DoltServer struct {
 
 var _ DatabaseServer = (*DoltServer)(nil)
 
-func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAlivePeriod time.Duration) (*DoltServer, error) {
+func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath, user, password string, keepAlivePeriod time.Duration) (*DoltServer, error) {
 	if doltBinExec == "" {
 		return nil, errors.New("server: NewDoltServer: doltBinExec is required")
 	}
@@ -49,6 +51,9 @@ func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAli
 	}
 	if configPath == "" {
 		return nil, errors.New("server: NewDoltServer: configPath is required")
+	}
+	if user == "" {
+		return nil, errors.New("server: NewDoltServer: user is required")
 	}
 	absDoltBinExec, err := filepath.Abs(doltBinExec)
 	if err != nil {
@@ -87,6 +92,8 @@ func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAli
 		rootDir:         absRootDir,
 		configPath:      absConfigPath,
 		config:          cfg,
+		user:            user,
+		password:        password,
 		keepAlivePeriod: keepAlivePeriod,
 		logFile:         logFile,
 	}, nil
@@ -96,10 +103,10 @@ func (s *DoltServer) ID(_ context.Context) string {
 	return s.id
 }
 
-func (s *DoltServer) DSN(_ context.Context, database string) string {
+func (s *DoltServer) DSN(_ context.Context, database, user, password string) string {
 	dsn := util.DoltServerDSN{
-		User:        s.config.User(),
-		Password:    s.config.Password(),
+		User:        user,
+		Password:    password,
 		Database:    database,
 		TLSRequired: s.config.RequireSecureTransport(),
 		TLSCert:     s.config.TLSCert(),
@@ -179,7 +186,7 @@ func (s *DoltServer) Start(ctx context.Context) error {
 
 	args := []string{
 		"sql-server",
-		"-c", s.configPath,
+		"--config", s.configPath,
 	}
 
 	managedCtx, cancel := context.WithCancel(context.Background())
@@ -241,7 +248,7 @@ func (s *DoltServer) Running(_ context.Context) bool {
 }
 
 func (s *DoltServer) Ping(ctx context.Context) error {
-	db, err := sql.Open("mysql", s.DSN(ctx, ""))
+	db, err := sql.Open("mysql", s.DSN(ctx, "", s.user, s.password))
 	if err != nil {
 		return fmt.Errorf("server: DoltServer.Ping: open: %w", err)
 	}

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 
-	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/db/util"
 )
 
 type DoltServer struct {
@@ -47,17 +47,22 @@ func (s *DoltServer) ID(_ context.Context) string {
 	return s.id
 }
 
-// TODO: support unix-socket connections (servercfg.Socket()) instead of
-// always building a TCP DSN.
 func (s *DoltServer) DSN(_ context.Context, database string) string {
-	return doltutil.ServerDSN{
-		Host:     s.config.Host(),
-		Port:     s.config.Port(),
-		User:     s.config.User(),
-		Password: s.config.Password(),
-		Database: database,
-		TLS:      false,
-	}.String()
+	dsn := util.DoltServerDSN{
+		User:        s.config.User(),
+		Password:    s.config.Password(),
+		Database:    database,
+		TLSRequired: s.config.RequireSecureTransport(),
+		TLSCert:     s.config.TLSCert(),
+		TLSKey:      s.config.TLSKey(),
+	}
+	if sock := s.config.Socket(); sock != "" {
+		dsn.Socket = sock
+	} else {
+		dsn.Host = s.config.Host()
+		dsn.Port = s.config.Port()
+	}
+	return dsn.String()
 }
 
 func (s *DoltServer) Start(_ context.Context) error {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -165,10 +165,6 @@ func (s *DoltServer) doltInit(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, s.doltBinExec, "init")
 	cmd.Dir = s.rootDir
 	if out, err := cmd.CombinedOutput(); err != nil {
-		// Concurrent Starts on the same rootDir race here: only one `dolt
-		// init` wins; the rest see "This directory has already been
-		// initialized." and exit non-zero. The repo is initialized either
-		// way, so treat that case as success.
 		if strings.Contains(string(out), "already been initialized") {
 			return nil
 		}

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
@@ -20,23 +21,26 @@ import (
 	"github.com/steveyegge/beads/internal/storage/db/util"
 )
 
+const defaultKeepAlivePeriod = 30 * time.Second
+
 type DoltServer struct {
-	id          string
-	doltBinExec string
-	rootDir     string
-	configPath  string
-	config      servercfg.ServerConfig
+	id              string
+	doltBinExec     string
+	rootDir         string
+	configPath      string
+	config          servercfg.ServerConfig
+	keepAlivePeriod time.Duration
 
 	cmd     *exec.Cmd
 	logFile *os.File
 	eg      *errgroup.Group
 	egCtx   context.Context
-	cancel  context.CancelFunc // cancels the parent of egCtx; called by Stop
+	cancel  context.CancelFunc
 }
 
 var _ DatabaseServer = (*DoltServer)(nil)
 
-func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string) (*DoltServer, error) {
+func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAlivePeriod time.Duration) (*DoltServer, error) {
 	if doltBinExec == "" {
 		return nil, errors.New("server: NewDoltServer: doltBinExec is required")
 	}
@@ -73,14 +77,18 @@ func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string) (*DoltS
 			return nil, fmt.Errorf("server: NewDoltServer: open log %q: %w", logFilePath, err)
 		}
 	}
+	if keepAlivePeriod == 0 {
+		keepAlivePeriod = defaultKeepAlivePeriod
+	}
 	sum := sha256.Sum256([]byte(rootDir))
 	return &DoltServer{
-		id:          hex.EncodeToString(sum[:]),
-		doltBinExec: absDoltBinExec,
-		rootDir:     absRootDir,
-		configPath:  absConfigPath,
-		config:      cfg,
-		logFile:     logFile,
+		id:              hex.EncodeToString(sum[:]),
+		doltBinExec:     absDoltBinExec,
+		rootDir:         absRootDir,
+		configPath:      absConfigPath,
+		config:          cfg,
+		keepAlivePeriod: keepAlivePeriod,
+		logFile:         logFile,
 	}, nil
 }
 
@@ -187,6 +195,19 @@ func (s *DoltServer) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (s *DoltServer) Dial(_ context.Context) (net.Conn, error) {
-	return nil, errors.New("server: DoltServer.Dial not implemented")
+func (s *DoltServer) Dial(ctx context.Context) (net.Conn, error) {
+	network, addr := "tcp", net.JoinHostPort(s.config.Host(), strconv.Itoa(s.config.Port()))
+	if sock := s.config.Socket(); sock != "" {
+		network, addr = "unix", sock
+	}
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, network, addr)
+	if err != nil {
+		return nil, fmt.Errorf("server: DoltServer.Dial: %w", err)
+	}
+	if tc, ok := conn.(*net.TCPConn); ok {
+		_ = tc.SetKeepAlive(true)
+		_ = tc.SetKeepAlivePeriod(s.keepAlivePeriod)
+	}
+	return conn, nil
 }

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -233,10 +233,6 @@ func (s *DoltServer) Stop(_ context.Context) error {
 	return nil
 }
 
-func (s *DoltServer) Restart(_ context.Context) error {
-	return errors.New("server: DoltServer.Restart not implemented")
-}
-
 func (s *DoltServer) Running(_ context.Context) bool {
 	if s.egCtx == nil {
 		return false

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -180,7 +180,10 @@ func (s *DoltServer) Restart(_ context.Context) error {
 }
 
 func (s *DoltServer) Running(_ context.Context) bool {
-	return false
+	if s.egCtx == nil {
+		return false
+	}
+	return s.egCtx.Err() == nil
 }
 
 func (s *DoltServer) Ping(ctx context.Context) error {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"github.com/dolthub/dolt/go/libraries/doltcore/servercfg"
+)
+
+type DoltServer struct {
+	rootDir    string
+	configPath string
+	config     servercfg.ServerConfig
+}
+
+var _ DatabaseServer = (*DoltServer)(nil)
+
+func NewDoltServer(rootDir, configPath string) (*DoltServer, error) {
+	return nil, errors.New("server: NewDoltServer not implemented")
+}
+
+func (s *DoltServer) ID(_ context.Context) string {
+	return ""
+}
+
+func (s *DoltServer) DSN(_ context.Context) string {
+	return ""
+}
+
+func (s *DoltServer) Start(_ context.Context) error {
+	return errors.New("server: DoltServer.Start not implemented")
+}
+
+func (s *DoltServer) Stop(_ context.Context) error {
+	return errors.New("server: DoltServer.Stop not implemented")
+}
+
+func (s *DoltServer) Restart(_ context.Context) error {
+	return errors.New("server: DoltServer.Restart not implemented")
+}
+
+func (s *DoltServer) Running(_ context.Context) bool {
+	return false
+}
+
+func (s *DoltServer) Ping(_ context.Context) error {
+	return errors.New("server: DoltServer.Ping not implemented")
+}
+
+func (s *DoltServer) Dial(_ context.Context) (net.Conn, error) {
+	return nil, errors.New("server: DoltServer.Dial not implemented")
+}

--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -186,16 +187,81 @@ func TestDoltServer_StartStop_HappyPath(t *testing.T) {
 
 	db, err := sql.Open("mysql", s.DSN(ctx, "", "root", ""))
 	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
 	var got int
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT 1").Scan(&got))
 	assert.Equal(t, 1, got)
+	// Close the pool before stopping the server so COM_QUIT is sent while
+	// the listener is still alive. Otherwise the driver logs broken-pipe
+	// errors when it tries to drain the pool against a dead socket.
+	require.NoError(t, db.Close())
 
 	require.NoError(t, s.Stop(ctx))
 	assert.False(t, s.Running(ctx))
 
 	// Second Stop is a no-op.
 	require.NoError(t, s.Stop(ctx))
+}
+
+func TestDoltServer_StartStop_UnixSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix domain sockets not supported on windows")
+	}
+	bin := requireDolt(t)
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+
+	sock := filepath.Join(t.TempDir(), "s.sock")
+	// Linux sun_path is 108 bytes including the NUL terminator; macOS is 104.
+	// Skip on systems where t.TempDir() pushes us past the limit rather than
+	// surface a confusing bind() error.
+	if len(sock) >= 104 {
+		t.Skipf("socket path too long (%d bytes): %s", len(sock), sock)
+	}
+
+	port := freePort(t)
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "config.yaml")
+	body := fmt.Sprintf(`log_level: debug
+listener:
+  host: 127.0.0.1
+  port: %d
+  socket: %s
+`, port, sock)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
+
+	logPath := filepath.Join(t.TempDir(), "server.log")
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, "root", "", 0)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx))
+	t.Cleanup(func() { stopWithTimeout(t, s) })
+	waitReady(t, s)
+	assert.True(t, s.Running(ctx))
+
+	// DSN must select the unix transport when a socket is configured.
+	dsn := s.DSN(ctx, "", "root", "")
+	parsed, err := mysqldrv.ParseDSN(dsn)
+	require.NoError(t, err)
+	assert.Equal(t, "unix", parsed.Net, "DSN must use unix transport when socket is configured")
+	assert.Equal(t, sock, parsed.Addr)
+
+	db, err := sql.Open("mysql", dsn)
+	require.NoError(t, err)
+	var got int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT 1").Scan(&got))
+	assert.Equal(t, 1, got)
+	// Close the pool before stopping the server (see HappyPath comment).
+	require.NoError(t, db.Close())
+
+	// Dial uses the socket too.
+	conn, err := s.Dial(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "unix", conn.RemoteAddr().Network())
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, s.Stop(ctx))
+	assert.False(t, s.Running(ctx))
 }
 
 func TestDoltServer_DoubleStart_Errors(t *testing.T) {

--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -398,6 +399,96 @@ func TestDoltServer_StopCancelsBeforeReady(t *testing.T) {
 		t.Fatal("Stop did not return in time")
 	}
 	assert.False(t, s.Running(ctx))
+}
+
+func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
+	bin := requireDolt(t)
+	t.Setenv("HOME", t.TempDir())
+
+	// Pre-configure dolt's global user.name/email so doltConfigure is a
+	// no-op for every concurrent Start (no JSON-write race on
+	// ~/.dolt/config_global.json).
+	require.NoError(t, exec.Command(bin, "config", "--global", "--add", "user.name", "beads-test").Run())
+	require.NoError(t, exec.Command(bin, "config", "--global", "--add", "user.email", "beads@test").Run())
+
+	rootDir := t.TempDir()
+	// Pre-init disabled — let the 10 concurrent Starts race through
+	// doltInit themselves.
+	// initCmd := exec.Command(bin, "init")
+	// initCmd.Dir = rootDir
+	// initOut, err := initCmd.CombinedOutput()
+	// require.NoError(t, err, "manual dolt init failed: %s", initOut)
+
+	const n = 10
+	servers := make([]*server.DoltServer, n)
+	logDir := t.TempDir()
+	for i := 0; i < n; i++ {
+		port := freePort(t)
+		cfg := writeConfig(t, port)
+		log := filepath.Join(logDir, fmt.Sprintf("server-%d.log", i))
+		s, err := server.NewDoltServer(bin, rootDir, cfg, log, "root", "", 0)
+		require.NoError(t, err)
+		servers[i] = s
+	}
+	t.Cleanup(func() {
+		for _, s := range servers {
+			ctx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+			_ = s.Stop(ctx)
+			cancel()
+		}
+	})
+
+	// Fire all Starts concurrently. Start currently returns nil even if
+	// the spawned sql-server later dies (the 200ms sleep returns before
+	// cmd.Run reports failure), so the test checks Running()/Ping() to
+	// determine the actual winner.
+	var wg sync.WaitGroup
+	startErrs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			startErrs[i] = servers[i].Start(context.Background())
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range startErrs {
+		require.NoError(t, err, "server %d Start returned err", i)
+	}
+
+	// Wait for the losers' subprocesses to exit. A loser is a DoltServer
+	// whose dolt sql-server child failed to acquire the rootDir lock and
+	// exited non-zero — that cancels its egCtx and flips Running() to
+	// false. The fight can take a moment to settle, so poll.
+	tally := func() (winners, losers int) {
+		for _, s := range servers {
+			if s.Running(context.Background()) {
+				winners++
+			} else {
+				losers++
+			}
+		}
+		return winners, losers
+	}
+	require.Eventually(t, func() bool {
+		w, l := tally()
+		return w == 1 && l == n-1
+	}, 10*time.Second, 100*time.Millisecond, "expected 1 winner + %d losers after rootDir lock fight", n-1)
+
+	winners, losers := tally()
+	assert.Equal(t, 1, winners, "exactly 1 Start must win the rootDir lock")
+	assert.Equal(t, n-1, losers, "the other %d Starts must lose", n-1)
+
+	// The single survivor must be ping-able (i.e., actually serving SQL).
+	winner := -1
+	for i, s := range servers {
+		if s.Running(context.Background()) {
+			winner = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, winner, 0)
+	require.NoError(t, servers[winner].Ping(context.Background()))
 }
 
 func TestDoltServer_DoltInit_Idempotent(t *testing.T) {

--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -1,0 +1,343 @@
+package server_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	mysqldrv "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/storage/db/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testUser     = "testuser"
+	testPassword = "testpass"
+
+	pingPollInterval = 100 * time.Millisecond
+	pingPollTimeout  = 10 * time.Second
+	stopTimeout      = 15 * time.Second
+)
+
+func requireDolt(t *testing.T) string {
+	t.Helper()
+	p, err := exec.LookPath("dolt")
+	if err != nil {
+		t.Skipf("dolt not on PATH: %v", err)
+	}
+	return p
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+	return port
+}
+
+func writeConfig(t *testing.T, port int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	body := fmt.Sprintf(`log_level: debug
+listener:
+  host: 127.0.0.1
+  port: %d
+user:
+  name: %s
+  password: %s
+`, port, testUser, testPassword)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+func newDoltServer(t *testing.T) (*server.DoltServer, string) {
+	t.Helper()
+	bin := requireDolt(t)
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	port := freePort(t)
+	cfg := writeConfig(t, port)
+	log := filepath.Join(t.TempDir(), "server.log")
+	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
+	require.NoError(t, err)
+	return s, rootDir
+}
+
+func stopWithTimeout(t *testing.T, s *server.DoltServer) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+	defer cancel()
+	require.NoError(t, s.Stop(ctx))
+}
+
+func waitReady(t *testing.T, s *server.DoltServer) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return s.Ping(context.Background()) == nil
+	}, pingPollTimeout, pingPollInterval, "server never became ready")
+}
+
+func TestNewDoltServer_Validation(t *testing.T) {
+	cfgDir := t.TempDir()
+	goodCfg := filepath.Join(cfgDir, "config.yaml")
+	require.NoError(t, os.WriteFile(goodCfg, []byte("log_level: debug\n"), 0o600))
+	badYAML := filepath.Join(cfgDir, "bad.yaml")
+	// Unclosed flow sequence — guaranteed YAML parse error.
+	require.NoError(t, os.WriteFile(badYAML, []byte("foo: [bar\n"), 0o600))
+	missingCfg := filepath.Join(cfgDir, "does-not-exist.yaml")
+
+	cases := []struct {
+		name string
+		bin  string
+		root string
+		cfg  string
+		want string
+	}{
+		{"empty bin", "", t.TempDir(), goodCfg, "doltBinExec is required"},
+		{"empty root", "dolt", "", goodCfg, "rootDir is required"},
+		{"empty cfg", "dolt", t.TempDir(), "", "configPath is required"},
+		{"missing cfg", "dolt", t.TempDir(), missingCfg, "parse config"},
+		{"bad yaml", "dolt", t.TempDir(), badYAML, "parse config"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := server.NewDoltServer(tc.bin, tc.root, tc.cfg, "", 0)
+			assert.Nil(t, s)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestDoltServer_ID_Stable(t *testing.T) {
+	cfgPath := writeConfig(t, 3306)
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+
+	a1, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
+	require.NoError(t, err)
+	a2, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
+	require.NoError(t, err)
+	b, err := server.NewDoltServer("dolt", rootB, cfgPath, "", 0)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	assert.Equal(t, a1.ID(ctx), a2.ID(ctx), "same rootDir -> same ID")
+	assert.NotEqual(t, a1.ID(ctx), b.ID(ctx), "different rootDir -> different ID")
+}
+
+func TestDoltServer_DSN(t *testing.T) {
+	cfgPath := writeConfig(t, 13306)
+	s, err := server.NewDoltServer("dolt", t.TempDir(), cfgPath, "", 0)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	parsed, err := mysqldrv.ParseDSN(s.DSN(ctx, ""))
+	require.NoError(t, err)
+	assert.Equal(t, testUser, parsed.User)
+	assert.Equal(t, testPassword, parsed.Passwd)
+	assert.Equal(t, "tcp", parsed.Net)
+	assert.Equal(t, "127.0.0.1:13306", parsed.Addr)
+	assert.Empty(t, parsed.DBName)
+	assert.True(t, parsed.ParseTime)
+	assert.True(t, parsed.MultiStatements)
+
+	parsedDB, err := mysqldrv.ParseDSN(s.DSN(ctx, "mydb"))
+	require.NoError(t, err)
+	assert.Equal(t, "mydb", parsedDB.DBName)
+}
+
+func TestDoltServer_StartStop_HappyPath(t *testing.T) {
+	s, _ := newDoltServer(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.Start(ctx))
+	t.Cleanup(func() { stopWithTimeout(t, s) })
+	waitReady(t, s)
+	assert.True(t, s.Running(ctx))
+
+	db, err := sql.Open("mysql", s.DSN(ctx, ""))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	var got int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT 1").Scan(&got))
+	assert.Equal(t, 1, got)
+
+	require.NoError(t, s.Stop(ctx))
+	assert.False(t, s.Running(ctx))
+
+	// Second Stop is a no-op.
+	require.NoError(t, s.Stop(ctx))
+}
+
+func TestDoltServer_DoubleStart_Errors(t *testing.T) {
+	s, _ := newDoltServer(t)
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx))
+	t.Cleanup(func() { stopWithTimeout(t, s) })
+
+	err := s.Start(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+}
+
+func TestDoltServer_StartStopStart_SameInstanceErrors(t *testing.T) {
+	s, _ := newDoltServer(t)
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx))
+	require.NoError(t, s.Stop(ctx))
+
+	// Same instance refuses to restart by design — Start is single-shot.
+	err := s.Start(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+}
+
+func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) {
+	bin := requireDolt(t)
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "server.log")
+	ctx := context.Background()
+
+	port1 := freePort(t)
+	cfg1 := writeConfig(t, port1)
+	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, 0)
+	require.NoError(t, err)
+	require.NoError(t, s1.Start(ctx))
+	waitReady(t, s1)
+	require.NoError(t, s1.Stop(ctx))
+
+	// Fresh port to dodge any TIME_WAIT lingering on the old one.
+	port2 := freePort(t)
+	cfg2 := writeConfig(t, port2)
+	s2, err := server.NewDoltServer(bin, rootDir, cfg2, logPath, 0)
+	require.NoError(t, err)
+	require.NoError(t, s2.Start(ctx), "new instance at same rootDir must start")
+	t.Cleanup(func() { stopWithTimeout(t, s2) })
+	waitReady(t, s2)
+	assert.True(t, s2.Running(ctx))
+
+	// ID is rootDir-derived and therefore stable across instances.
+	assert.Equal(t, s1.ID(ctx), s2.ID(ctx))
+}
+
+func TestDoltServer_Ping_BeforeStart(t *testing.T) {
+	s, _ := newDoltServer(t)
+	err := s.Ping(context.Background())
+	require.Error(t, err, "Ping must fail before Start")
+}
+
+func TestDoltServer_Dial_AfterStart(t *testing.T) {
+	s, _ := newDoltServer(t)
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx))
+	t.Cleanup(func() { stopWithTimeout(t, s) })
+	waitReady(t, s)
+
+	conn, err := s.Dial(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	// The MySQL handshake packet starts with a 3-byte little-endian length
+	// header + 1-byte sequence id, then a 1-byte protocol version. Modern
+	// servers (incl. Dolt) emit protocol version 10. Reading these bytes
+	// proves the listener is actually speaking MySQL, not just accepting TCP.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(3*time.Second)))
+	var hdr [4]byte
+	_, err = io.ReadFull(conn, hdr[:])
+	require.NoError(t, err)
+	payloadLen := int(hdr[0]) | int(hdr[1])<<8 | int(hdr[2])<<16
+	require.Greater(t, payloadLen, 0)
+
+	var proto [1]byte
+	_, err = io.ReadFull(conn, proto[:])
+	require.NoError(t, err)
+	assert.Equal(t, byte(10), proto[0], "expected MySQL protocol version 10")
+}
+
+func TestDoltServer_Dial_BeforeStart(t *testing.T) {
+	s, _ := newDoltServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := s.Dial(ctx)
+	require.Error(t, err, "Dial must fail before Start")
+}
+
+func TestDoltServer_LogFile_CapturesOutput(t *testing.T) {
+	bin := requireDolt(t)
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+	port := freePort(t)
+	cfgPath := writeConfig(t, port)
+	logPath := filepath.Join(t.TempDir(), "server.log")
+
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx))
+	t.Cleanup(func() { stopWithTimeout(t, s) })
+	waitReady(t, s)
+	require.NoError(t, s.Stop(ctx))
+
+	info, err := os.Stat(logPath)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0), "log file should have captured server output")
+}
+
+func TestDoltServer_StopCancelsBeforeReady(t *testing.T) {
+	s, _ := newDoltServer(t)
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx))
+
+	// Stop immediately, without waiting for ping. Must return within the
+	// bounded window and leave Running == false.
+	stopCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.Stop(stopCtx) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(stopTimeout):
+		t.Fatal("Stop did not return in time")
+	}
+	assert.False(t, s.Running(ctx))
+}
+
+func TestDoltServer_DoltInit_Idempotent(t *testing.T) {
+	bin := requireDolt(t)
+	t.Setenv("HOME", t.TempDir())
+	rootDir := t.TempDir()
+
+	// Pre-init the dolt repo manually. dolt init refuses to run without
+	// user.name/email in global config, so set those first.
+	require.NoError(t, exec.Command(bin, "config", "--global", "--add", "user.name", "beads-test").Run())
+	require.NoError(t, exec.Command(bin, "config", "--global", "--add", "user.email", "beads@test").Run())
+	cmd := exec.Command(bin, "init")
+	cmd.Dir = rootDir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "manual dolt init failed: %s", out)
+
+	port := freePort(t)
+	cfgPath := writeConfig(t, port)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, "", 0)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, s.Start(ctx), "Start against pre-initialized rootDir should succeed")
+	t.Cleanup(func() { stopWithTimeout(t, s) })
+	waitReady(t, s)
+}

--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -1,5 +1,10 @@
 package server_test
 
+// doltserver_test.go covers the DoltServer lifecycle. Most tests start a real
+// `dolt sql-server` subprocess; those skip when `dolt` is not on PATH.
+// Validation tests (constructor argument checks, ID stability, DSN building)
+// run unconditionally.
+
 import (
 	"context"
 	"database/sql"
@@ -19,9 +24,6 @@ import (
 )
 
 const (
-	testUser     = "testuser"
-	testPassword = "testpass"
-
 	pingPollInterval = 100 * time.Millisecond
 	pingPollTimeout  = 10 * time.Second
 	stopTimeout      = 15 * time.Second
@@ -49,14 +51,14 @@ func writeConfig(t *testing.T, port int) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
+	// dolt deprecated user/password in sql-server YAML (it now creates
+	// root@localhost as the superuser regardless). DoltServer takes
+	// credentials via NewDoltServer instead.
 	body := fmt.Sprintf(`log_level: debug
 listener:
   host: 127.0.0.1
   port: %d
-user:
-  name: %s
-  password: %s
-`, port, testUser, testPassword)
+`, port)
 	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
 	return path
 }
@@ -69,7 +71,9 @@ func newDoltServer(t *testing.T) (*server.DoltServer, string) {
 	port := freePort(t)
 	cfg := writeConfig(t, port)
 	log := filepath.Join(t.TempDir(), "server.log")
-	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
+	// dolt auto-creates root@localhost with empty password; match those
+	// credentials so Ping/Dial/SELECT actually authenticate.
+	s, err := server.NewDoltServer(bin, rootDir, cfg, log, "root", "", 0)
 	require.NoError(t, err)
 	return s, rootDir
 }
@@ -102,17 +106,19 @@ func TestNewDoltServer_Validation(t *testing.T) {
 		bin  string
 		root string
 		cfg  string
+		user string
 		want string
 	}{
-		{"empty bin", "", t.TempDir(), goodCfg, "doltBinExec is required"},
-		{"empty root", "dolt", "", goodCfg, "rootDir is required"},
-		{"empty cfg", "dolt", t.TempDir(), "", "configPath is required"},
-		{"missing cfg", "dolt", t.TempDir(), missingCfg, "parse config"},
-		{"bad yaml", "dolt", t.TempDir(), badYAML, "parse config"},
+		{"empty bin", "", t.TempDir(), goodCfg, "root", "doltBinExec is required"},
+		{"empty root", "dolt", "", goodCfg, "root", "rootDir is required"},
+		{"empty cfg", "dolt", t.TempDir(), "", "root", "configPath is required"},
+		{"empty user", "dolt", t.TempDir(), goodCfg, "", "user is required"},
+		{"missing cfg", "dolt", t.TempDir(), missingCfg, "root", "parse config"},
+		{"bad yaml", "dolt", t.TempDir(), badYAML, "root", "parse config"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s, err := server.NewDoltServer(tc.bin, tc.root, tc.cfg, "", 0)
+			s, err := server.NewDoltServer(tc.bin, tc.root, tc.cfg, "", tc.user, "", 0)
 			assert.Nil(t, s)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.want)
@@ -125,11 +131,11 @@ func TestDoltServer_ID_Stable(t *testing.T) {
 	rootA := t.TempDir()
 	rootB := t.TempDir()
 
-	a1, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
+	a1, err := server.NewDoltServer("dolt", rootA, cfgPath, "", "root", "", 0)
 	require.NoError(t, err)
-	a2, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
+	a2, err := server.NewDoltServer("dolt", rootA, cfgPath, "", "root", "", 0)
 	require.NoError(t, err)
-	b, err := server.NewDoltServer("dolt", rootB, cfgPath, "", 0)
+	b, err := server.NewDoltServer("dolt", rootB, cfgPath, "", "root", "", 0)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -139,23 +145,34 @@ func TestDoltServer_ID_Stable(t *testing.T) {
 
 func TestDoltServer_DSN(t *testing.T) {
 	cfgPath := writeConfig(t, 13306)
-	s, err := server.NewDoltServer("dolt", t.TempDir(), cfgPath, "", 0)
+
+	// Construct with one set of credentials, then call DSN with a different
+	// set — the args must win. This proves DSN does not silently fall back
+	// to the DoltServer's stored creds.
+	s, err := server.NewDoltServer("dolt", t.TempDir(), cfgPath, "", "stored-user", "stored-pass", 0)
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	parsed, err := mysqldrv.ParseDSN(s.DSN(ctx, ""))
+	parsed, err := mysqldrv.ParseDSN(s.DSN(ctx, "", "alice", "s3cret"))
 	require.NoError(t, err)
-	assert.Equal(t, testUser, parsed.User)
-	assert.Equal(t, testPassword, parsed.Passwd)
+	assert.Equal(t, "alice", parsed.User, "DSN must use the user arg, not s.user")
+	assert.Equal(t, "s3cret", parsed.Passwd, "DSN must use the password arg, not s.password")
 	assert.Equal(t, "tcp", parsed.Net)
 	assert.Equal(t, "127.0.0.1:13306", parsed.Addr)
 	assert.Empty(t, parsed.DBName)
 	assert.True(t, parsed.ParseTime)
 	assert.True(t, parsed.MultiStatements)
 
-	parsedDB, err := mysqldrv.ParseDSN(s.DSN(ctx, "mydb"))
+	// database arg is independent of credentials.
+	parsedDB, err := mysqldrv.ParseDSN(s.DSN(ctx, "mydb", "alice", "s3cret"))
 	require.NoError(t, err)
 	assert.Equal(t, "mydb", parsedDB.DBName)
+
+	// Empty password is allowed.
+	parsedEmpty, err := mysqldrv.ParseDSN(s.DSN(ctx, "", "root", ""))
+	require.NoError(t, err)
+	assert.Equal(t, "root", parsedEmpty.User)
+	assert.Empty(t, parsedEmpty.Passwd)
 }
 
 func TestDoltServer_StartStop_HappyPath(t *testing.T) {
@@ -167,7 +184,7 @@ func TestDoltServer_StartStop_HappyPath(t *testing.T) {
 	waitReady(t, s)
 	assert.True(t, s.Running(ctx))
 
-	db, err := sql.Open("mysql", s.DSN(ctx, ""))
+	db, err := sql.Open("mysql", s.DSN(ctx, "", "root", ""))
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 	var got int
@@ -213,7 +230,7 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 
 	port1 := freePort(t)
 	cfg1 := writeConfig(t, port1)
-	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, 0)
+	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, "root", "", 0)
 	require.NoError(t, err)
 	require.NoError(t, s1.Start(ctx))
 	waitReady(t, s1)
@@ -222,7 +239,7 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 	// Fresh port to dodge any TIME_WAIT lingering on the old one.
 	port2 := freePort(t)
 	cfg2 := writeConfig(t, port2)
-	s2, err := server.NewDoltServer(bin, rootDir, cfg2, logPath, 0)
+	s2, err := server.NewDoltServer(bin, rootDir, cfg2, logPath, "root", "", 0)
 	require.NoError(t, err)
 	require.NoError(t, s2.Start(ctx), "new instance at same rootDir must start")
 	t.Cleanup(func() { stopWithTimeout(t, s2) })
@@ -283,7 +300,7 @@ func TestDoltServer_LogFile_CapturesOutput(t *testing.T) {
 	cfgPath := writeConfig(t, port)
 	logPath := filepath.Join(t.TempDir(), "server.log")
 
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, "root", "", 0)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, s.Start(ctx))
@@ -333,7 +350,7 @@ func TestDoltServer_DoltInit_Idempotent(t *testing.T) {
 
 	port := freePort(t)
 	cfgPath := writeConfig(t, port)
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, "", 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, "", "root", "", 0)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/internal/storage/db/server/server.go
+++ b/internal/storage/db/server/server.go
@@ -12,7 +12,10 @@ import (
 // backend during shutdown.
 type DatabaseServer interface {
 	ID(ctx context.Context) string
-	DSN(ctx context.Context) string
+	// DSN returns a connection string to the backend. If database is
+	// non-empty, the resulting DSN selects that database; otherwise the
+	// caller must select one explicitly (e.g. via USE).
+	DSN(ctx context.Context, database string) string
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 	Restart(ctx context.Context) error

--- a/internal/storage/db/server/server.go
+++ b/internal/storage/db/server/server.go
@@ -18,7 +18,6 @@ type DatabaseServer interface {
 	DSN(ctx context.Context, database string) string
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
-	Restart(ctx context.Context) error
 	Running(ctx context.Context) bool
 	Ping(ctx context.Context) error
 	Dial(ctx context.Context) (net.Conn, error)

--- a/internal/storage/db/server/server.go
+++ b/internal/storage/db/server/server.go
@@ -5,19 +5,8 @@ import (
 	"net"
 )
 
-// DatabaseServer is the contract a backend must satisfy to sit behind the
-// proxy. Every method takes a context so callers can bound or cancel any
-// operation — implementations MUST honor cancellation, especially in Start /
-// Stop / Dial. The proxy relies on this to avoid wedging on a misbehaving
-// backend during shutdown.
 type DatabaseServer interface {
 	ID(ctx context.Context) string
-	// DSN returns a connection string to the backend. If database is
-	// non-empty, the resulting DSN selects that database; otherwise the
-	// caller must select one explicitly (e.g. via USE). user and password
-	// are the credentials embedded in the returned DSN — implementations
-	// must use exactly what the caller passed, not any internally stored
-	// credentials.
 	DSN(ctx context.Context, database, user, password string) string
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error

--- a/internal/storage/db/server/server.go
+++ b/internal/storage/db/server/server.go
@@ -14,8 +14,11 @@ type DatabaseServer interface {
 	ID(ctx context.Context) string
 	// DSN returns a connection string to the backend. If database is
 	// non-empty, the resulting DSN selects that database; otherwise the
-	// caller must select one explicitly (e.g. via USE).
-	DSN(ctx context.Context, database string) string
+	// caller must select one explicitly (e.g. via USE). user and password
+	// are the credentials embedded in the returned DSN — implementations
+	// must use exactly what the caller passed, not any internally stored
+	// credentials.
+	DSN(ctx context.Context, database, user, password string) string
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 	Running(ctx context.Context) bool

--- a/internal/storage/db/server/testserver.go
+++ b/internal/storage/db/server/testserver.go
@@ -85,7 +85,7 @@ func (s *TestDatabaseServerImpl) ID(_ context.Context) string {
 	return s.ID_
 }
 
-func (s *TestDatabaseServerImpl) DSN(_ context.Context) string {
+func (s *TestDatabaseServerImpl) DSN(_ context.Context, _ string) string {
 	s.mu.Lock()
 	s.counters.DSNCalls++
 	s.mu.Unlock()

--- a/internal/storage/db/server/testserver.go
+++ b/internal/storage/db/server/testserver.go
@@ -84,7 +84,7 @@ func (s *TestDatabaseServerImpl) ID(_ context.Context) string {
 	return s.ID_
 }
 
-func (s *TestDatabaseServerImpl) DSN(_ context.Context, _ string) string {
+func (s *TestDatabaseServerImpl) DSN(_ context.Context, _, _, _ string) string {
 	s.mu.Lock()
 	s.counters.DSNCalls++
 	s.mu.Unlock()

--- a/internal/storage/db/server/testserver.go
+++ b/internal/storage/db/server/testserver.go
@@ -17,7 +17,6 @@ type Counters struct {
 	DSNCalls      int64
 	StartCalls    int64
 	StopCalls     int64
-	RestartCalls  int64
 	RunningCalls  int64
 	PingCalls     int64
 	PingErrors    int64
@@ -115,16 +114,6 @@ func (s *TestDatabaseServerImpl) Stop(_ context.Context) error {
 		_ = c.Close()
 	}
 	return err
-}
-
-func (s *TestDatabaseServerImpl) Restart(ctx context.Context) error {
-	s.mu.Lock()
-	s.counters.RestartCalls++
-	s.mu.Unlock()
-	if err := s.Stop(ctx); err != nil {
-		return err
-	}
-	return s.Start(ctx)
 }
 
 func (s *TestDatabaseServerImpl) Running(_ context.Context) bool {

--- a/internal/storage/db/server/testserver_test.go
+++ b/internal/storage/db/server/testserver_test.go
@@ -64,7 +64,7 @@ func TestID_DSN_CountAndReturn(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		assert.Equal(t, "custom-id", srv.ID(ctx))
-		assert.Equal(t, "custom://dsn", srv.DSN(ctx))
+		assert.Equal(t, "custom://dsn", srv.DSN(ctx, ""))
 	}
 
 	c := srv.Snapshot()

--- a/internal/storage/db/server/testserver_test.go
+++ b/internal/storage/db/server/testserver_test.go
@@ -64,7 +64,7 @@ func TestID_DSN_CountAndReturn(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		assert.Equal(t, "custom-id", srv.ID(ctx))
-		assert.Equal(t, "custom://dsn", srv.DSN(ctx, ""))
+		assert.Equal(t, "custom://dsn", srv.DSN(ctx, "", "", ""))
 	}
 
 	c := srv.Snapshot()

--- a/internal/storage/db/server/testserver_test.go
+++ b/internal/storage/db/server/testserver_test.go
@@ -110,44 +110,6 @@ func TestStop_Error(t *testing.T) {
 	assert.Equal(t, int64(1), srv.Snapshot().StopCalls)
 }
 
-func TestRestart_Success(t *testing.T) {
-	ctx := context.Background()
-	srv := server.New()
-	require.NoError(t, srv.Start(ctx))
-
-	require.NoError(t, srv.Restart(ctx))
-
-	c := srv.Snapshot()
-	assert.Equal(t, int64(1), c.RestartCalls)
-	assert.Equal(t, int64(2), c.StartCalls) // initial Start + Restart's Start
-	assert.Equal(t, int64(1), c.StopCalls)
-	assert.True(t, srv.Running(ctx))
-}
-
-func TestRestart_StopError(t *testing.T) {
-	ctx := context.Background()
-	srv := server.New()
-	require.NoError(t, srv.Start(ctx))
-	srv.StopErr = errors.New("stop failed")
-
-	assert.EqualError(t, srv.Restart(ctx), "stop failed")
-
-	c := srv.Snapshot()
-	assert.Equal(t, int64(1), c.RestartCalls)
-	assert.Equal(t, int64(1), c.StopCalls)
-	assert.Equal(t, int64(1), c.StartCalls) // Restart's Start was never reached
-}
-
-func TestRestart_StartError(t *testing.T) {
-	ctx := context.Background()
-	srv := server.New()
-	require.NoError(t, srv.Start(ctx))
-	srv.StartErr = errors.New("start failed")
-
-	assert.EqualError(t, srv.Restart(ctx), "start failed")
-	assert.False(t, srv.Running(ctx))
-}
-
 func TestRunning_Counter(t *testing.T) {
 	ctx := context.Background()
 	srv := server.New()

--- a/internal/storage/db/util/dsn.go
+++ b/internal/storage/db/util/dsn.go
@@ -15,7 +15,7 @@ type DoltServerDSN struct {
 	Host     string
 	Port     int
 	User     string
-	Password string //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
+	Password string        //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
 	Database string        // optional; empty connects without selecting a database
 	Timeout  time.Duration // connect timeout; 0 defaults to 5s
 	// TLSRequired is true when the server rejects non-TLS connections

--- a/internal/storage/db/util/dsn.go
+++ b/internal/storage/db/util/dsn.go
@@ -15,7 +15,7 @@ type DoltServerDSN struct {
 	Host     string
 	Port     int
 	User     string
-	Password string
+	Password string //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
 	Database string        // optional; empty connects without selecting a database
 	Timeout  time.Duration // connect timeout; 0 defaults to 5s
 	// TLSRequired is true when the server rejects non-TLS connections

--- a/internal/storage/db/util/dsn.go
+++ b/internal/storage/db/util/dsn.go
@@ -7,31 +7,19 @@ import (
 	mysql "github.com/go-sql-driver/mysql"
 )
 
-// DoltServerDSN holds connection parameters for building a MySQL DSN to a
-// Dolt server fronted by the proxy. All DSNs built with this struct set
-// parseTime=true and multiStatements=true.
 type DoltServerDSN struct {
-	Socket   string // Unix domain socket path; when set, Net="unix" and Host/Port are ignored
-	Host     string
-	Port     int
-	User     string
-	Password string        //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
-	Database string        // optional; empty connects without selecting a database
-	Timeout  time.Duration // connect timeout; 0 defaults to 5s
-	// TLSRequired is true when the server rejects non-TLS connections
-	// (servercfg.RequireSecureTransport). When true, String() emits tls=true.
+	Socket      string
+	Host        string
+	Port        int
+	User        string
+	Password    string //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
+	Database    string
+	Timeout     time.Duration
 	TLSRequired bool
-	// TLSCert and TLSKey are paths to PEM-encoded TLS material associated with
-	// the server. They are carried on the DSN so consumers can wire them up;
-	// String() does not yet register a custom mysql TLS config from them.
-	// TODO: when set together with TLSRequired, register a custom config via
-	// mysql.RegisterTLSConfig and emit tls=<name>.
-	TLSCert string
-	TLSKey  string
+	TLSCert     string
+	TLSKey      string
 }
 
-// String builds the MySQL DSN string. Always sets parseTime=true,
-// multiStatements=true, allowNativePasswords=true, and a connect timeout.
 func (d DoltServerDSN) String() string {
 	timeout := d.Timeout
 	if timeout == 0 {
@@ -59,10 +47,6 @@ func (d DoltServerDSN) String() string {
 	if d.TLSRequired {
 		cfg.TLSConfig = "true"
 	} else {
-		// go-sql-driver/mysql v1.8+ defaults to tls=preferred when TLSConfig
-		// is empty. Dolt servers without TLS reject preferred-mode negotiation
-		// with "TLS requested but server does not support TLS". Explicitly
-		// disable TLS so connections work against non-TLS Dolt instances.
 		cfg.TLSConfig = "false"
 	}
 

--- a/internal/storage/db/util/dsn.go
+++ b/internal/storage/db/util/dsn.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"fmt"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+// DoltServerDSN holds connection parameters for building a MySQL DSN to a
+// Dolt server fronted by the proxy. All DSNs built with this struct set
+// parseTime=true and multiStatements=true.
+type DoltServerDSN struct {
+	Socket   string // Unix domain socket path; when set, Net="unix" and Host/Port are ignored
+	Host     string
+	Port     int
+	User     string
+	Password string
+	Database string        // optional; empty connects without selecting a database
+	Timeout  time.Duration // connect timeout; 0 defaults to 5s
+	// TLSRequired is true when the server rejects non-TLS connections
+	// (servercfg.RequireSecureTransport). When true, String() emits tls=true.
+	TLSRequired bool
+	// TLSCert and TLSKey are paths to PEM-encoded TLS material associated with
+	// the server. They are carried on the DSN so consumers can wire them up;
+	// String() does not yet register a custom mysql TLS config from them.
+	// TODO: when set together with TLSRequired, register a custom config via
+	// mysql.RegisterTLSConfig and emit tls=<name>.
+	TLSCert string
+	TLSKey  string
+}
+
+// String builds the MySQL DSN string. Always sets parseTime=true,
+// multiStatements=true, allowNativePasswords=true, and a connect timeout.
+func (d DoltServerDSN) String() string {
+	timeout := d.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+
+	net := "tcp"
+	addr := fmt.Sprintf("%s:%d", d.Host, d.Port)
+	if d.Socket != "" {
+		net = "unix"
+		addr = d.Socket
+	}
+
+	cfg := mysql.Config{
+		User:                 d.User,
+		Passwd:               d.Password,
+		Net:                  net,
+		Addr:                 addr,
+		DBName:               d.Database,
+		ParseTime:            true,
+		MultiStatements:      true,
+		Timeout:              timeout,
+		AllowNativePasswords: true,
+	}
+	if d.TLSRequired {
+		cfg.TLSConfig = "true"
+	} else {
+		// go-sql-driver/mysql v1.8+ defaults to tls=preferred when TLSConfig
+		// is empty. Dolt servers without TLS reject preferred-mode negotiation
+		// with "TLS requested but server does not support TLS". Explicitly
+		// disable TLS so connections work against non-TLS Dolt instances.
+		cfg.TLSConfig = "false"
+	}
+
+	return cfg.FormatDSN()
+}

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -14,7 +14,7 @@ type ServerDSN struct {
 	Host     string
 	Port     int
 	User     string
-	Password string
+	Password string //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
 	Database string        // optional; empty connects without selecting a database
 	Timeout  time.Duration // connect timeout; 0 defaults to 5s
 	TLS      bool

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -14,7 +14,7 @@ type ServerDSN struct {
 	Host     string
 	Port     int
 	User     string
-	Password string //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
+	Password string        //nolint:gosec // G117: MySQL DSN password field; required by the connection-string builder, not serialized as JSON
 	Database string        // optional; empty connects without selecting a database
 	Timeout  time.Duration // connect timeout; 0 defaults to 5s
 	TLS      bool


### PR DESCRIPTION
## Summary

- Adds `server.DoltServer`, a `DatabaseServer` implementation that runs `dolt sql-server` as a managed subprocess.
- Adds a lifecycle test suite covering Start/Stop, Ping, Dial, DSN building, unix-socket transport, and concurrent-Start contention on a shared rootDir.

## Test plan

- [ ] `make test` passes locally (with `dolt` on PATH)
- [ ] `go test -tags gms_pure_go -v ./internal/storage/db/server/...` shows all `TestDoltServer_*` passing
- [ ] Re-run with `dolt` removed from `PATH`: lifecycle tests skip, validation/ID/DSN still pass
- [ ] `golangci-lint run ./...` clean for the touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->