### PR TITLE
fix(doctor): don't emit fresh-clone false positive in Dolt server mode

### DIFF
--- a/cmd/bd/doctor/fresh_clone_server.go
+++ b/cmd/bd/doctor/fresh_clone_server.go
@@ -105,3 +105,40 @@ func freshCloneServerResult(dbExists bool, dbName, host string, port int, syncRe
 		Fix:     fix,
 	}
 }
+
+// freshCloneServerUnreachableResult builds the DoctorCheck for the case where
+// dolt_mode=server is configured but the server cannot be reached (TCP refused,
+// TLS mismatch, auth failure, etc.). Falling through to the legacy "Fresh clone
+// detected (no database)" warning is misleading in server mode because the
+// absence of a local database is expected — see GH#35.
+//
+// The message identifies that we're in server mode, points at the configured
+// host:port, surfaces the underlying connection error for diagnostics, and
+// suggests connectivity/credential checks rather than bd bootstrap (which
+// won't help when the server itself is unreachable).
+func freshCloneServerUnreachableResult(dbName, host string, port int, connErr error) DoctorCheck {
+	var msg strings.Builder
+	fmt.Fprintf(&msg, "Dolt server unreachable at %s:%d (database %q, server mode configured).", host, port, dbName)
+	msg.WriteString(" The local database directory is not expected in server mode, so this is not a fresh clone — it's a connectivity or auth problem.")
+
+	var detail strings.Builder
+	detail.WriteString("dolt_mode=server is configured but the doctor check could not reach the server.\n")
+	detail.WriteString("  In server mode, beads stores data on the Dolt server, so no local .beads/dolt directory is expected.\n")
+	if connErr != nil {
+		fmt.Fprintf(&detail, "  Underlying error: %v\n", connErr)
+	}
+	detail.WriteString("  Common causes: server not running, wrong host/port, TLS misconfiguration, or invalid credentials.")
+
+	return DoctorCheck{
+		Name:    "Fresh Clone",
+		Status:  StatusWarning,
+		Message: msg.String(),
+		Detail:  detail.String(),
+		Fix: "Verify Dolt server connectivity:\n" +
+			"  1. Confirm the server is running and reachable from this host\n" +
+			"  2. Check .beads/metadata.json: dolt_server_host, dolt_server_port, dolt_server_tls\n" +
+			"  3. Verify credentials in ~/.config/beads/credentials (or BEADS_DOLT_PASSWORD)\n" +
+			"  4. Try a CRUD command (e.g. 'bd ready') to confirm the server is usable\n" +
+			"  5. Re-run 'bd doctor' once connectivity is restored",
+	}
+}

--- a/cmd/bd/doctor/fresh_clone_server_test.go
+++ b/cmd/bd/doctor/fresh_clone_server_test.go
@@ -113,12 +113,15 @@ func TestCheckFreshCloneDB_ServerUnreachable(t *testing.T) {
 }
 
 func TestCheckFreshClone_ServerModeUnreachable(t *testing.T) {
-	// bd-tzo9: When metadata.json declares dolt_mode=server but the server
-	// is unreachable, CheckFreshClone must resolve credentials by the
-	// *resolved runtime port* (not the deprecated metadata port default),
-	// invoke checkFreshCloneDB, observe Reachable=false, and fall through
-	// to the existing JSONL-based warning. This exercises the
-	// GetDoltServerPasswordForPort(port) code path.
+	// GH#35 + bd-tzo9: When metadata.json declares dolt_mode=server but the
+	// server is unreachable, CheckFreshClone must:
+	//   1. Resolve credentials by the resolved runtime port (bd-tzo9), not
+	//      the deprecated metadata port default — exercised by going through
+	//      the GetDoltServerPasswordForPort(port) call before the failed ping.
+	//   2. Surface a server-mode-aware warning instead of the misleading
+	//      legacy "Fresh clone detected (no database)" message (GH#35). In
+	//      server mode the local DB absence is expected; suggesting bd
+	//      bootstrap is wrong when the actual problem is connectivity/auth.
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
@@ -132,9 +135,7 @@ func TestCheckFreshClone_ServerModeUnreachable(t *testing.T) {
 	}
 
 	// metadata.json declaring server mode pointed at an unreachable host:port.
-	// Port 1 is guaranteed-unreachable on loopback; Reachable=false exercises
-	// the FR-030 fall-through branch that contains the fixed password-resolution
-	// line.
+	// Port 1 is guaranteed-unreachable on loopback.
 	meta := `{
   "database": "beads.db",
   "dolt_mode": "server",
@@ -149,15 +150,92 @@ func TestCheckFreshClone_ServerModeUnreachable(t *testing.T) {
 
 	check := CheckFreshClone(tmpDir)
 
-	// Server unreachable → falls through to legacy JSONL-based warning.
 	if check.Status != StatusWarning {
-		t.Fatalf("expected %q on unreachable server fall-through, got %q (message: %s)",
+		t.Fatalf("expected %q on unreachable server, got %q (message: %s)",
 			StatusWarning, check.Status, check.Message)
 	}
-	if !strings.Contains(check.Fix, "bd bootstrap") {
-		t.Errorf("expected fall-through fix to mention 'bd bootstrap', got: %s", check.Fix)
+
+	// GH#35: must NOT emit the misleading legacy "Fresh clone detected
+	// (N issues in issues.jsonl, no database)" message in server mode.
+	if strings.Contains(check.Message, "issues in issues.jsonl, no database") {
+		t.Errorf("server-mode unreachable should not emit legacy fresh-clone message; got: %s", check.Message)
+	}
+
+	// Must call out server-mode connectivity, not "fresh clone".
+	wantSubstrings := []string{"server", "127.0.0.1:1"}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(strings.ToLower(check.Message), strings.ToLower(want)) {
+			t.Errorf("expected message to mention %q, got: %s", want, check.Message)
+		}
+	}
+
+	// Fix should suggest connectivity/credential checks, not bd bootstrap
+	// (which won't help when the server itself is unreachable).
+	if strings.Contains(check.Fix, "bd bootstrap") {
+		t.Errorf("server-mode unreachable fix should not suggest 'bd bootstrap'; got: %s", check.Fix)
+	}
+	for _, want := range []string{"server", "credentials"} {
+		if !strings.Contains(strings.ToLower(check.Fix), want) {
+			t.Errorf("expected fix to mention %q, got: %s", want, check.Fix)
+		}
 	}
 }
+
+func TestFreshCloneServerUnreachableResult(t *testing.T) {
+	// Pure-function coverage for the server-unreachable branch (GH#35).
+	// Verifies the message identifies server mode, includes host:port and
+	// the underlying error, and avoids the misleading bd bootstrap fix.
+	check := freshCloneServerUnreachableResult(
+		"acf_beads",
+		"dolt.example.com",
+		3306,
+		errSentinelForTest{msg: "dial tcp: i/o timeout"},
+	)
+
+	if check.Name != "Fresh Clone" {
+		t.Errorf("expected Name %q, got %q", "Fresh Clone", check.Name)
+	}
+	if check.Status != StatusWarning {
+		t.Errorf("expected Status %q, got %q", StatusWarning, check.Status)
+	}
+
+	wantInMsg := []string{
+		"unreachable",
+		"dolt.example.com:3306",
+		`"acf_beads"`,
+		"server mode",
+	}
+	for _, want := range wantInMsg {
+		if !strings.Contains(check.Message, want) {
+			t.Errorf("expected message to contain %q, got: %s", want, check.Message)
+		}
+	}
+
+	if !strings.Contains(check.Detail, "dial tcp: i/o timeout") {
+		t.Errorf("expected detail to surface underlying error, got: %s", check.Detail)
+	}
+
+	// Must NOT recommend bd bootstrap — the problem is connectivity, not
+	// missing local state.
+	if strings.Contains(check.Fix, "bd bootstrap") {
+		t.Errorf("server-unreachable fix should not suggest 'bd bootstrap'; got: %s", check.Fix)
+	}
+
+	// Nil error path should still produce a usable message and not panic.
+	checkNil := freshCloneServerUnreachableResult("beads", "127.0.0.1", 3307, nil)
+	if checkNil.Status != StatusWarning {
+		t.Errorf("nil-err path: expected Status %q, got %q", StatusWarning, checkNil.Status)
+	}
+	if !strings.Contains(checkNil.Message, "unreachable") {
+		t.Errorf("nil-err path: expected message to mention 'unreachable', got: %s", checkNil.Message)
+	}
+}
+
+// errSentinelForTest is a minimal error type used to drive the server-unreachable
+// helper without depending on the network/MySQL driver. Local to this test file.
+type errSentinelForTest struct{ msg string }
+
+func (e errSentinelForTest) Error() string { return e.msg }
 
 func TestCheckFreshClone_EmbeddedMode(t *testing.T) {
 	// AC-005: Embedded mode (not server mode) uses only filesystem checks.

--- a/cmd/bd/doctor/legacy.go
+++ b/cmd/bd/doctor/legacy.go
@@ -498,7 +498,13 @@ func CheckFreshClone(repoPath string) DoctorCheck {
 				}
 				return freshCloneServerResult(result.Exists, dbName, host, port, syncRemote)
 			}
-			// Server unreachable — fall through to existing behavior (FR-030).
+			// Server unreachable in server mode — emit a server-aware warning
+			// instead of falling through to the legacy "Fresh clone detected
+			// (no database)" message, which is a false positive when
+			// dolt_mode=server (the local DB absence is expected). See GH#35.
+			// FR-030 only requires that we don't panic on unreachable; it does
+			// not mandate the misleading fall-through.
+			return freshCloneServerUnreachableResult(dbName, host, port, result.Err)
 		}
 	default:
 		// SQLite (default): check configured .db file path.


### PR DESCRIPTION
## Summary

Fixes a false positive in `bd doctor`'s "Fresh Clone" check when `dolt_mode=server` is configured and the Dolt server is unreachable.

When the doctor's connectivity probe fails (TCP refused, TLS mismatch, auth failure), `CheckFreshClone` previously fell through to the legacy `Fresh clone detected (N issues in issues.jsonl, no database)` warning and recommended `bd bootstrap`. In server mode the local Dolt directory is *expected* to be absent (data lives on the server), so:

- the warning is misleading — there is no fresh clone,
- the suggested fix is wrong — `bd bootstrap` won't help when the server itself is unreachable.

The `// Server unreachable — fall through to existing behavior (FR-030).` comment misread FR-030, which only requires that an unreachable server not panic the caller; it does not mandate the misleading fall-through.

## Changes

- `cmd/bd/doctor/fresh_clone_server.go`: new pure helper `freshCloneServerUnreachableResult` that
  - identifies that we're in server mode and points at the configured `host:port`,
  - surfaces the underlying connection error in `Detail` for diagnostics (also useful for diagnosing TLS/auth misconfigurations),
  - and recommends verifying server health, host/port, TLS, and credentials — not `bd bootstrap`.
- `cmd/bd/doctor/legacy.go`: `CheckFreshClone` now returns the new helper's result on the unreachable branch instead of falling through.
- `cmd/bd/doctor/fresh_clone_server_test.go`:
  - `TestCheckFreshClone_ServerModeUnreachable` updated to assert the new behavior (no legacy "fresh clone" message, no `bd bootstrap` recommendation, message names server + `host:port`). The bd-tzo9 password-resolution path is still exercised through the same fixture.
  - New `TestFreshCloneServerUnreachableResult` for direct pure-function coverage, including a nil-error path.

The check still:
- returns `StatusOK` when the local `.beads/dolt` directory exists,
- returns `StatusOK` when the server is reachable and the database exists (FR-021),
- returns the existing server-mode `StatusWarning` when the server is reachable but the database is missing (FR-020),
- returns the legacy fresh-clone warning when **not** in server mode and no database is present.

## Testing

- `make test` — full suite passes locally against current upstream/main.
- `go vet -tags gms_pure_go ./cmd/bd/doctor/...` — clean.
- `make build` — succeeds.
- Focused: `go test -tags gms_pure_go -run 'TestCheckFreshClone|TestFreshCloneServer' -v ./cmd/bd/doctor/...` — all pass, including the new and updated tests.

`golangci-lint` isn't available locally; CI will run it on this PR.

Fixes #3756
