### PR TITLE
docs: prevent malformed PR comments

### DIFF
--- a/PR_MAINTAINER_GUIDELINES.md
+++ b/PR_MAINTAINER_GUIDELINES.md
@@ -58,3 +58,4 @@ Other outcomes are possible, including rerouting a PR to the right project or ba
 - Treat request-changes as exceptional because it can strand contributor work.
 - File follow-up work as beads issues instead of hidden notes.
 - When code changes result from PR maintenance, follow repo quality gates and session completion rules in `AGENTS.md`.
+- Post multi-line PR comments from a real Markdown body file or a shell heredoc, not from strings with escaped `\n` sequences. After posting or editing, verify the rendered body with `gh pr view --comments --json comments --jq ...` before moving on.


### PR DESCRIPTION
## Summary
- add a maintainer guideline for posting multi-line PR comments from Markdown files or heredocs
- require a quick `gh pr view --comments` verification after posting or editing comments

## Why
This prevents GitHub comments from rendering literal `\n` sequences when a multi-line body is passed through an escaped shell string.

## Testing
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->