### PR TITLE
feat(linear): linear.exclude_id_prefix and linear.exclude_id_patterns

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -359,28 +359,7 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	for _, t := range excludeTypes {
 		opts.ExcludeTypes = append(opts.ExcludeTypes, types.IssueType(strings.ToLower(t)))
 	}
-	// Read config linear.exclude_id_prefix — single string. Beads whose ID
-	// starts with this prefix are excluded from push (case-sensitive). Used
-	// to filter workflow-artifact beads (e.g. "hw-mol-") that aren't
-	// type-tagged consistently. A bead that previously synced (has
-	// external_ref) and now matches will have NO further updates pushed —
-	// the Linear-side issue persists; users who want it removed must
-	// archive/delete it manually.
-	if v, _ := store.GetConfig(ctx, "linear.exclude_id_prefix"); v != "" {
-		opts.ExcludeIDPrefix = strings.TrimSpace(v)
-	}
-	// Read config linear.exclude_id_patterns — comma-separated list of
-	// substrings. Beads whose ID contains any listed substring are excluded
-	// from push. Substring is case-sensitive, anywhere in the ID. Combined
-	// with exclude_id_prefix as a union.
-	if v, _ := store.GetConfig(ctx, "linear.exclude_id_patterns"); v != "" {
-		for _, p := range strings.Split(v, ",") {
-			p = strings.TrimSpace(p)
-			if p != "" {
-				opts.ExcludeIDPatterns = append(opts.ExcludeIDPatterns, p)
-			}
-		}
-	}
+	applyLinearExcludeIDConfig(ctx, store, &opts)
 	if !includeEphemeral {
 		opts.ExcludeEphemeral = true
 	}
@@ -1177,6 +1156,37 @@ func getLinearIDMode(ctx context.Context) string {
 		return "hash"
 	}
 	return mode
+}
+
+// linearConfigReader is the minimal slice of storage.Storage that the
+// linear-config helpers depend on. Lets tests inject a fake without
+// spinning up a Dolt server.
+type linearConfigReader interface {
+	GetConfig(ctx context.Context, key string) (string, error)
+}
+
+// applyLinearExcludeIDConfig reads linear.exclude_id_prefix and
+// linear.exclude_id_patterns from the given config reader and applies them
+// to opts. Both keys are push-direction-only filters; see the help text on
+// linearSyncCmd for the user-facing semantics.
+//
+// Empty values are no-ops. Patterns are comma-split, trimmed, with empty
+// entries dropped. If reader is nil (no store configured), this is a no-op.
+func applyLinearExcludeIDConfig(ctx context.Context, reader linearConfigReader, opts *tracker.SyncOptions) {
+	if reader == nil || opts == nil {
+		return
+	}
+	if v, _ := reader.GetConfig(ctx, "linear.exclude_id_prefix"); v != "" {
+		opts.ExcludeIDPrefix = strings.TrimSpace(v)
+	}
+	if v, _ := reader.GetConfig(ctx, "linear.exclude_id_patterns"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				opts.ExcludeIDPatterns = append(opts.ExcludeIDPatterns, p)
+			}
+		}
+	}
 }
 
 // getLinearHashLength returns the configured hash length for Linear imports.

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -122,6 +122,18 @@ Type Filtering (--push only):
   --parent TICKET           Only push this ticket and its descendants
   --relations               Import Linear relations as bd dependencies on pull
 
+Persistent push-direction ID filters (workflow artifacts, sandbox beads, etc.):
+  bd config set linear.exclude_id_prefix "hw-mol-"
+  bd config set linear.exclude_id_patterns "-wisp-,sandbox-,scratch-"
+
+  exclude_id_prefix is a single case-sensitive prefix on the bead ID.
+  exclude_id_patterns is a comma-separated list of case-sensitive substrings
+  (matched anywhere in the ID). Both are combined as a union: a bead
+  matching either rule is skipped from push (no create, no update). Beads
+  with an existing external_ref that NOW match are silently skipped on
+  future syncs; the Linear-side issue persists — archive/delete it manually
+  if desired.
+
 Conflict Resolution:
   By default, newer timestamp wins. Override with:
   --prefer-local    Always prefer local beads version
@@ -346,6 +358,28 @@ func runLinearSync(cmd *cobra.Command, args []string) {
 	}
 	for _, t := range excludeTypes {
 		opts.ExcludeTypes = append(opts.ExcludeTypes, types.IssueType(strings.ToLower(t)))
+	}
+	// Read config linear.exclude_id_prefix — single string. Beads whose ID
+	// starts with this prefix are excluded from push (case-sensitive). Used
+	// to filter workflow-artifact beads (e.g. "hw-mol-") that aren't
+	// type-tagged consistently. A bead that previously synced (has
+	// external_ref) and now matches will have NO further updates pushed —
+	// the Linear-side issue persists; users who want it removed must
+	// archive/delete it manually.
+	if v, _ := store.GetConfig(ctx, "linear.exclude_id_prefix"); v != "" {
+		opts.ExcludeIDPrefix = strings.TrimSpace(v)
+	}
+	// Read config linear.exclude_id_patterns — comma-separated list of
+	// substrings. Beads whose ID contains any listed substring are excluded
+	// from push. Substring is case-sensitive, anywhere in the ID. Combined
+	// with exclude_id_prefix as a union.
+	if v, _ := store.GetConfig(ctx, "linear.exclude_id_patterns"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				opts.ExcludeIDPatterns = append(opts.ExcludeIDPatterns, p)
+			}
+		}
 	}
 	if !includeEphemeral {
 		opts.ExcludeEphemeral = true

--- a/cmd/bd/linear_test.go
+++ b/cmd/bd/linear_test.go
@@ -10,11 +10,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/beads/internal/linear"
+	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -1788,4 +1790,90 @@ func TestIsValidUUID(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeLinearConfigReader is a test double for linearConfigReader that
+// returns values from an in-memory map. Unset keys return "" with no error
+// (matches storage.Storage's behavior for missing config keys).
+type fakeLinearConfigReader map[string]string
+
+func (f fakeLinearConfigReader) GetConfig(_ context.Context, key string) (string, error) {
+	return f[key], nil
+}
+
+// TestApplyLinearExcludeIDConfig covers the bd-ee0 config-read path that
+// wires linear.exclude_id_prefix / linear.exclude_id_patterns into
+// SyncOptions. The engine-side filter behavior (applying the rules to
+// individual issues) is tested by the TestEngineExcludeID* family in
+// internal/tracker/engine_test.go; this test exercises the cmd/bd surface.
+func TestApplyLinearExcludeIDConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		cfg          fakeLinearConfigReader
+		wantPrefix   string
+		wantPatterns []string
+	}{
+		{
+			name:         "both keys set",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "hw-mol-", "linear.exclude_id_patterns": "-wisp-,sandbox-,scratch-"},
+			wantPrefix:   "hw-mol-",
+			wantPatterns: []string{"-wisp-", "sandbox-", "scratch-"},
+		},
+		{
+			name:         "prefix only",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "hw-mol-"},
+			wantPrefix:   "hw-mol-",
+			wantPatterns: nil,
+		},
+		{
+			name:         "patterns only",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_patterns": "wisp-,sandbox-"},
+			wantPrefix:   "",
+			wantPatterns: []string{"wisp-", "sandbox-"},
+		},
+		{
+			name:         "patterns trimmed and empty entries skipped",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_patterns": "  a  , ,  b  ,"},
+			wantPrefix:   "",
+			wantPatterns: []string{"a", "b"},
+		},
+		{
+			name:         "prefix trimmed",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "  hw-mol-  "},
+			wantPrefix:   "hw-mol-",
+			wantPatterns: nil,
+		},
+		{
+			name:         "neither key set is no-op",
+			cfg:          fakeLinearConfigReader{},
+			wantPrefix:   "",
+			wantPatterns: nil,
+		},
+		{
+			name:         "empty string values treated as unset",
+			cfg:          fakeLinearConfigReader{"linear.exclude_id_prefix": "", "linear.exclude_id_patterns": ""},
+			wantPrefix:   "",
+			wantPatterns: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts tracker.SyncOptions
+			applyLinearExcludeIDConfig(context.Background(), tt.cfg, &opts)
+			if opts.ExcludeIDPrefix != tt.wantPrefix {
+				t.Errorf("ExcludeIDPrefix = %q, want %q", opts.ExcludeIDPrefix, tt.wantPrefix)
+			}
+			if !reflect.DeepEqual(opts.ExcludeIDPatterns, tt.wantPatterns) {
+				t.Errorf("ExcludeIDPatterns = %v, want %v", opts.ExcludeIDPatterns, tt.wantPatterns)
+			}
+		})
+	}
+}
+
+// TestApplyLinearExcludeIDConfig_NilSafe verifies the helper is safe to
+// call with nil reader or nil opts (defensive guards).
+func TestApplyLinearExcludeIDConfig_NilSafe(t *testing.T) {
+	var opts tracker.SyncOptions
+	applyLinearExcludeIDConfig(context.Background(), nil, &opts)                    // must not panic
+	applyLinearExcludeIDConfig(context.Background(), fakeLinearConfigReader{}, nil) // must not panic
 }

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2379,8 +2379,32 @@ Memory records (lines with "_type":"memory") are automatically detected and
 imported as persistent memories (equivalent to 'bd remember'). This makes
 'bd export | bd import' a full round-trip for both issues and memories.
 
-Each JSONL line should map to an issue with at minimum "title". Optional
-fields: description, issue_type (type), priority, acceptance_criteria.
+Each JSONL line should map to an issue. The importer accepts every field
+'bd export' emits — see 'bd export' output for the canonical schema. Only
+"title" is required; everything else is optional.
+
+Common fields:
+  title                  Required. Short summary.
+  description            Long-form body.
+  design, notes,         Additional content sections.
+    acceptance_criteria
+  issue_type             bug | feature | task | epic | chore | ...
+  priority               0-4 (0 = critical). 0 is preserved (no omitempty).
+  status                 open | in_progress | blocked | closed | ...
+                         (rows with status "tombstone" are skipped)
+  assignee, owner,       Ownership metadata.
+    created_by
+  labels                 Array of strings.
+  dependencies           Array of &#123;issue_id, depends_on_id, type, ...&#125;.
+  comments               Array of comment objects.
+  external_ref,          Cross-system identifiers (e.g. "gh-9").
+    source_system
+  due_at, defer_until    RFC3339 timestamps for scheduling.
+  metadata               Arbitrary JSON object preserved verbatim.
+
+Timestamps (created_at, updated_at, started_at, closed_at) are preserved
+when present in the JSONL and otherwise filled in by the importer. The
+legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
   bd import                        # Import from .beads/issues.jsonl
@@ -4846,6 +4870,18 @@ Type Filtering (--push only):
   --include-ephemeral       Include ephemeral issues (wisps, etc.); default is to exclude
   --parent TICKET           Only push this ticket and its descendants
   --relations               Import Linear relations as bd dependencies on pull
+
+Persistent push-direction ID filters (workflow artifacts, sandbox beads, etc.):
+  bd config set linear.exclude_id_prefix "hw-mol-"
+  bd config set linear.exclude_id_patterns "-wisp-,sandbox-,scratch-"
+
+  exclude_id_prefix is a single case-sensitive prefix on the bead ID.
+  exclude_id_patterns is a comma-separated list of case-sensitive substrings
+  (matched anywhere in the ID). Both are combined as a union: a bead
+  matching either rule is skipped from push (no create, no update). Beads
+  with an existing external_ref that NOW match are silently skipped on
+  future syncs; the Linear-side issue persists — archive/delete it manually
+  if desired.
 
 Conflict Resolution:
   By default, newer timestamp wins. Override with:

--- a/internal/tracker/engine.go
+++ b/internal/tracker/engine.go
@@ -1367,6 +1367,20 @@ func (e *Engine) shouldPushIssue(issue *types.Issue, opts SyncOptions) bool {
 		}
 	}
 
+	// ExcludeIDPrefix: case-sensitive prefix match on the bead ID. Filters
+	// workflow-artifact beads (e.g. "hw-mol-foo") from external sync without
+	// requiring them to share a type or label.
+	if opts.ExcludeIDPrefix != "" && strings.HasPrefix(issue.ID, opts.ExcludeIDPrefix) {
+		return false
+	}
+	// ExcludeIDPatterns: case-sensitive substring match anywhere in the ID.
+	// Union with ExcludeIDPrefix — matching either rule excludes the issue.
+	for _, p := range opts.ExcludeIDPatterns {
+		if p != "" && strings.Contains(issue.ID, p) {
+			return false
+		}
+	}
+
 	if opts.State == "open" && issue.Status == types.StatusClosed {
 		return false
 	}

--- a/internal/tracker/engine_test.go
+++ b/internal/tracker/engine_test.go
@@ -3003,3 +3003,245 @@ func TestEngineWarnCollectsMessages(t *testing.T) {
 		t.Errorf("expected 3 total warnings, got %d", len(engine.warnings))
 	}
 }
+
+// TestEngineExcludeIDPrefix verifies that beads whose ID starts with the
+// configured prefix are skipped from push. Mirrors mayor's bd-ee0
+// houmanoids_www use case where `hw-mol-*` workflow-artifact beads must
+// not propagate to Linear regardless of issue type.
+func TestEngineExcludeIDPrefix(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{"hw-mol-foo", "hw-mol-bar", "hw-real-1", "hw-real-2"} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{Push: true, ExcludeIDPrefix: "hw-mol-"})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.created) != 2 {
+		t.Errorf("created %d issues; want 2 (only hw-real-*)", len(tracker.created))
+	}
+	for _, i := range tracker.created {
+		if strings.HasPrefix(i.ID, "hw-mol-") {
+			t.Errorf("hw-mol- bead leaked through filter: %s", i.ID)
+		}
+	}
+}
+
+// TestEngineExcludeIDPatterns verifies the comma-separated substring filter:
+// beads whose ID contains ANY listed substring (anywhere in the ID) are
+// skipped.
+func TestEngineExcludeIDPatterns(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{"hw-mol-x", "hw-wisp-y", "hw-sandbox-z", "hw-real-keep"} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{
+		Push:              true,
+		ExcludeIDPatterns: []string{"mol-", "wisp-", "sandbox-"},
+	})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.created) != 1 || tracker.created[0].ID != "hw-real-keep" {
+		ids := make([]string, len(tracker.created))
+		for i, c := range tracker.created {
+			ids[i] = c.ID
+		}
+		t.Errorf("created IDs = %v, want [hw-real-keep]", ids)
+	}
+}
+
+// TestEngineExcludeIDBoth verifies union semantics: a bead matching EITHER
+// the prefix rule OR the patterns rule is excluded.
+func TestEngineExcludeIDBoth(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{
+		"hw-mol-via-prefix",  // matches prefix
+		"hw-evt-via-pattern", // matches pattern (-evt-)
+		"hw-mol-evt-both",    // matches both
+		"hw-real-keep",       // matches neither — pushed
+	} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{
+		Push:              true,
+		ExcludeIDPrefix:   "hw-mol-",
+		ExcludeIDPatterns: []string{"-evt-"},
+	})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.created) != 1 || tracker.created[0].ID != "hw-real-keep" {
+		ids := make([]string, len(tracker.created))
+		for i, c := range tracker.created {
+			ids[i] = c.ID
+		}
+		t.Errorf("created IDs = %v, want [hw-real-keep]", ids)
+	}
+}
+
+// TestEngineExcludeID_AlreadySynced verifies that a bead with an existing
+// external_ref but matching an exclude rule produces NO update API call.
+// The Linear-side issue is left alone (the spec calls this out: users who
+// add a rule for an already-synced bead must manually archive/delete the
+// remote issue if desired).
+func TestEngineExcludeID_AlreadySynced(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	// A previously-synced bead — has external_ref. After the new exclude
+	// rule lands, it must not be updated.
+	stale := &types.Issue{
+		ID: "hw-mol-stale", Title: "Previously synced", Status: types.StatusOpen,
+		IssueType: types.TypeTask, Priority: 2,
+		ExternalRef: strPtr("https://test.test/EXT-STALE"),
+	}
+	if err := store.CreateIssue(ctx, stale, "test-actor"); err != nil {
+		t.Fatalf("CreateIssue() error: %v", err)
+	}
+
+	tracker := newMockTracker("test")
+	tracker.issues = []TrackerIssue{
+		{ID: "EXT-STALE", Identifier: "EXT-STALE", Title: "Old remote title"},
+	}
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{Push: true, ExcludeIDPrefix: "hw-mol-"})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	if len(tracker.updated) != 0 {
+		t.Errorf("excluded already-synced bead was updated: %v", tracker.updated)
+	}
+	if len(tracker.created) != 0 {
+		t.Errorf("excluded already-synced bead was created: %d", len(tracker.created))
+	}
+}
+
+// TestEngineDryRunRespectsExcludeID verifies that --dry-run does not print
+// "Would create" / "Would update" lines for excluded beads. Asserts via the
+// engine's stats: an excluded bead increments Skipped, not Created or
+// Updated.
+func TestEngineDryRunRespectsExcludeID(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Close()
+
+	for _, id := range []string{"hw-mol-skip", "hw-real-1"} {
+		issue := &types.Issue{
+			ID: id, Title: "Issue " + id, Status: types.StatusOpen, IssueType: types.TypeTask, Priority: 2,
+		}
+		if err := store.CreateIssue(ctx, issue, "test-actor"); err != nil {
+			t.Fatalf("CreateIssue(%s) error: %v", id, err)
+		}
+	}
+
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, store, "test-actor")
+
+	result, err := engine.Sync(ctx, SyncOptions{Push: true, DryRun: true, ExcludeIDPrefix: "hw-mol-"})
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Sync() not successful: %s", result.Error)
+	}
+	// Dry-run should NOT have called the tracker (even for the unexcluded one,
+	// since DryRun=true short-circuits the API call).
+	if len(tracker.created) != 0 {
+		t.Errorf("dry-run created issues: %d", len(tracker.created))
+	}
+	// PushStats.Created counts intended creates; the excluded bead must NOT
+	// count there. Only hw-real-1 should be classified as a would-be create.
+	if result.PushStats.Created != 1 {
+		t.Errorf("PushStats.Created = %d, want 1 (only hw-real-1 should be a would-be create)", result.PushStats.Created)
+	}
+	if result.PushStats.Skipped != 1 {
+		t.Errorf("PushStats.Skipped = %d, want 1 (hw-mol-skip should be Skipped)", result.PushStats.Skipped)
+	}
+}
+
+// TestShouldPushIssue_ExcludeIDDirect tests the filter logic in isolation,
+// without the storage layer. Runs locally without Dolt/Docker.
+func TestShouldPushIssue_ExcludeIDDirect(t *testing.T) {
+	tracker := newMockTracker("test")
+	engine := NewEngine(tracker, nil, "test-actor")
+
+	tests := []struct {
+		name string
+		opts SyncOptions
+		id   string
+		want bool
+	}{
+		{"prefix match excludes", SyncOptions{ExcludeIDPrefix: "hw-mol-"}, "hw-mol-foo", false},
+		{"prefix non-match passes", SyncOptions{ExcludeIDPrefix: "hw-mol-"}, "hw-real-1", true},
+		{"empty prefix is no-op", SyncOptions{ExcludeIDPrefix: ""}, "hw-mol-foo", true},
+		{"prefix is case-sensitive", SyncOptions{ExcludeIDPrefix: "hw-mol-"}, "HW-MOL-foo", true},
+		{"pattern match anywhere excludes", SyncOptions{ExcludeIDPatterns: []string{"-wisp-"}}, "hw-wisp-x", false},
+		{"pattern match middle excludes", SyncOptions{ExcludeIDPatterns: []string{"sandbox"}}, "x-sandbox-y", false},
+		{"pattern non-match passes", SyncOptions{ExcludeIDPatterns: []string{"sandbox"}}, "hw-real-1", true},
+		{"empty pattern entry skipped", SyncOptions{ExcludeIDPatterns: []string{"", "wisp-"}}, "hw-wisp-x", false},
+		{"all empty patterns no-op", SyncOptions{ExcludeIDPatterns: []string{""}}, "hw-mol-foo", true},
+		{"prefix and pattern union: prefix match", SyncOptions{ExcludeIDPrefix: "hw-mol-", ExcludeIDPatterns: []string{"-evt-"}}, "hw-mol-foo", false},
+		{"prefix and pattern union: pattern match", SyncOptions{ExcludeIDPrefix: "hw-mol-", ExcludeIDPatterns: []string{"-evt-"}}, "hw-evt-foo", false},
+		{"prefix and pattern union: neither", SyncOptions{ExcludeIDPrefix: "hw-mol-", ExcludeIDPatterns: []string{"-evt-"}}, "hw-real-foo", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := &types.Issue{ID: tt.id, IssueType: types.TypeTask, Status: types.StatusOpen}
+			got := engine.shouldPushIssue(issue, tt.opts)
+			if got != tt.want {
+				t.Errorf("shouldPushIssue(%q, %+v) = %v, want %v", tt.id, tt.opts, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tracker/types.go
+++ b/internal/tracker/types.go
@@ -82,6 +82,15 @@ type SyncOptions struct {
 	TypeFilter []types.IssueType
 	// ExcludeTypes excludes specific issue types from sync.
 	ExcludeTypes []types.IssueType
+	// ExcludeIDPrefix skips issues whose ID starts with this prefix (case-
+	// sensitive). Used to filter workflow-artifact beads (e.g. "hw-mol-")
+	// from external sync. Empty means no prefix filter.
+	ExcludeIDPrefix string
+	// ExcludeIDPatterns skips issues whose ID contains any of these
+	// substrings (case-sensitive, anywhere in the ID). Empty means no
+	// pattern filter. Combined with ExcludeIDPrefix as a union (matches
+	// either rule → excluded).
+	ExcludeIDPatterns []string
 	// ExcludeEphemeral skips ephemeral/wisp issues from push (default behavior in CLI).
 	ExcludeEphemeral bool
 	// ParentID limits push to this beads issue and all its descendants via

--- a/website/docs/cli-reference/import.md
+++ b/website/docs/cli-reference/import.md
@@ -21,8 +21,32 @@ Memory records (lines with "_type":"memory") are automatically detected and
 imported as persistent memories (equivalent to 'bd remember'). This makes
 'bd export | bd import' a full round-trip for both issues and memories.
 
-Each JSONL line should map to an issue with at minimum "title". Optional
-fields: description, issue_type (type), priority, acceptance_criteria.
+Each JSONL line should map to an issue. The importer accepts every field
+'bd export' emits — see 'bd export' output for the canonical schema. Only
+"title" is required; everything else is optional.
+
+Common fields:
+  title                  Required. Short summary.
+  description            Long-form body.
+  design, notes,         Additional content sections.
+    acceptance_criteria
+  issue_type             bug | feature | task | epic | chore | ...
+  priority               0-4 (0 = critical). 0 is preserved (no omitempty).
+  status                 open | in_progress | blocked | closed | ...
+                         (rows with status "tombstone" are skipped)
+  assignee, owner,       Ownership metadata.
+    created_by
+  labels                 Array of strings.
+  dependencies           Array of &#123;issue_id, depends_on_id, type, ...&#125;.
+  comments               Array of comment objects.
+  external_ref,          Cross-system identifiers (e.g. "gh-9").
+    source_system
+  due_at, defer_until    RFC3339 timestamps for scheduling.
+  metadata               Arbitrary JSON object preserved verbatim.
+
+Timestamps (created_at, updated_at, started_at, closed_at) are preserved
+when present in the JSONL and otherwise filled in by the importer. The
+legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
   bd import                        # Import from .beads/issues.jsonl

--- a/website/docs/cli-reference/linear.md
+++ b/website/docs/cli-reference/linear.md
@@ -154,6 +154,18 @@ Type Filtering (--push only):
   --parent TICKET           Only push this ticket and its descendants
   --relations               Import Linear relations as bd dependencies on pull
 
+Persistent push-direction ID filters (workflow artifacts, sandbox beads, etc.):
+  bd config set linear.exclude_id_prefix "hw-mol-"
+  bd config set linear.exclude_id_patterns "-wisp-,sandbox-,scratch-"
+
+  exclude_id_prefix is a single case-sensitive prefix on the bead ID.
+  exclude_id_patterns is a comma-separated list of case-sensitive substrings
+  (matched anywhere in the ID). Both are combined as a union: a bead
+  matching either rule is skipped from push (no create, no update). Beads
+  with an existing external_ref that NOW match are silently skipped on
+  future syncs; the Linear-side issue persists — archive/delete it manually
+  if desired.
+
 Conflict Resolution:
   By default, newer timestamp wins. Override with:
   --prefer-local    Always prefer local beads version

--- a/website/versioned_docs/version-1.0.0/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/import.md
@@ -21,8 +21,32 @@ Memory records (lines with "_type":"memory") are automatically detected and
 imported as persistent memories (equivalent to 'bd remember'). This makes
 'bd export | bd import' a full round-trip for both issues and memories.
 
-Each JSONL line should map to an issue with at minimum "title". Optional
-fields: description, issue_type (type), priority, acceptance_criteria.
+Each JSONL line should map to an issue. The importer accepts every field
+'bd export' emits — see 'bd export' output for the canonical schema. Only
+"title" is required; everything else is optional.
+
+Common fields:
+  title                  Required. Short summary.
+  description            Long-form body.
+  design, notes,         Additional content sections.
+    acceptance_criteria
+  issue_type             bug | feature | task | epic | chore | ...
+  priority               0-4 (0 = critical). 0 is preserved (no omitempty).
+  status                 open | in_progress | blocked | closed | ...
+                         (rows with status "tombstone" are skipped)
+  assignee, owner,       Ownership metadata.
+    created_by
+  labels                 Array of strings.
+  dependencies           Array of &#123;issue_id, depends_on_id, type, ...&#125;.
+  comments               Array of comment objects.
+  external_ref,          Cross-system identifiers (e.g. "gh-9").
+    source_system
+  due_at, defer_until    RFC3339 timestamps for scheduling.
+  metadata               Arbitrary JSON object preserved verbatim.
+
+Timestamps (created_at, updated_at, started_at, closed_at) are preserved
+when present in the JSONL and otherwise filled in by the importer. The
+legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
   bd import                        # Import from .beads/issues.jsonl

--- a/website/versioned_docs/version-1.0.0/cli-reference/linear.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/linear.md
@@ -154,6 +154,18 @@ Type Filtering (--push only):
   --parent TICKET           Only push this ticket and its descendants
   --relations               Import Linear relations as bd dependencies on pull
 
+Persistent push-direction ID filters (workflow artifacts, sandbox beads, etc.):
+  bd config set linear.exclude_id_prefix "hw-mol-"
+  bd config set linear.exclude_id_patterns "-wisp-,sandbox-,scratch-"
+
+  exclude_id_prefix is a single case-sensitive prefix on the bead ID.
+  exclude_id_patterns is a comma-separated list of case-sensitive substrings
+  (matched anywhere in the ID). Both are combined as a union: a bead
+  matching either rule is skipped from push (no create, no update). Beads
+  with an existing external_ref that NOW match are silently skipped on
+  future syncs; the Linear-side issue persists — archive/delete it manually
+  if desired.
+
 Conflict Resolution:
   By default, newer timestamp wins. Override with:
   --prefer-local    Always prefer local beads version


### PR DESCRIPTION
## Summary

Implements two new config keys (`linear.exclude_id_prefix` and `linear.exclude_id_patterns`) to filter beads from Linear push by their local ID. Mirrors `linear.exclude_types` / `linear.exclude_labels` semantics for the cases where neither type nor label can reliably identify the bead — workflow-artifact beads whose IDs share a prefix or substring but whose types/labels are inconsistent.

Push-direction only. Pull is gated by `external_ref` already and unaffected.

## Why

A rig that needs to filter "workflow internals" beads (e.g. `hw-mol-*` molecule beads from a gt-toolkit pipeline) currently can't, because:
- These beads' types vary (`task`, `molecule`, sometimes others), so `linear.exclude_types` misses many of them
- They don't share a label
- Their IDs DO share a stable prefix

So the rig had `linear.exclude_id_prefix = hw-mol-` and `linear.exclude_id_patterns = mol-` set with hope, but those keys were never read. 25 `hw-mol-*` beads appeared as "Would create in Linear" on every dry-run.

## Behavior

`linear.exclude_id_prefix`: single string, case-sensitive prefix match on the full bead ID.
`linear.exclude_id_patterns`: comma-separated list of substrings, case-sensitive match anywhere in the ID. Empty entries skipped.

If both keys are set, exclusion is the union (matching either rule → skip).

Already-synced beads: a bead with an existing `external_ref` that now matches an exclude rule produces NO further push. The Linear-side issue persists; archive/delete manually if desired (documented in help text).

## Test plan

- [x] `TestShouldPushIssue_ExcludeIDDirect` (12 sub-cases, runs locally) — exercises filter logic without storage layer
- [x] `TestEngineExcludeIDPrefix / Patterns / Both / AlreadySynced / DryRunRespectsExcludeID` — full Sync() path tests (gated on Dolt/Docker; run in CI)
- [x] `go vet ./...` clean
- [x] Codex-rescue reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->