### PR TITLE
wire DoltServer into db-proxy-child for the local-server backend

### DIFF
--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -80,17 +80,11 @@ not intended to be invoked directly by users.`,
 func newDatabaseServer(backend proxy.Backend, rootDir, configPath, logPath, doltBin string) (server.DatabaseServer, error) {
 	switch backend {
 	case proxy.BackendLocalServer:
-		return newLocalDoltServer(rootDir, configPath, logPath, doltBin)
+		return server.NewDoltServer(doltBin, rootDir, configPath, logPath, "root", "", 0)
 	case proxy.BackendExternal, proxy.BackendLocalSharedServer:
 		return nil, fmt.Errorf("backend %q: not yet implemented", backend)
 	}
 	return nil, fmt.Errorf("unknown backend %q", backend)
-}
-
-const localDoltDefaultUser = "root"
-
-func newLocalDoltServer(rootDir, configPath, logPath, doltBin string) (server.DatabaseServer, error) {
-	return server.NewDoltServer(doltBin, rootDir, configPath, logPath, localDoltDefaultUser, "", 0)
 }
 
 func init() {

--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -25,6 +25,9 @@ var (
 	dbProxyChildPort        int
 	dbProxyChildIdleTimeout time.Duration
 	dbProxyChildBackend     string
+	dbProxyChildConfig      string
+	dbProxyChildLogPath     string
+	dbProxyChildDoltBin     string
 )
 
 var dbProxyChildCmd = &cobra.Command{
@@ -59,7 +62,7 @@ not intended to be invoked directly by users.`,
 		}
 		defer lock.Unlock()
 
-		srv, err := newDatabaseServer(backend, dbProxyChildRoot)
+		srv, err := newDatabaseServer(backend, dbProxyChildRoot, dbProxyChildConfig, dbProxyChildLogPath, dbProxyChildDoltBin)
 		if err != nil {
 			return err
 		}
@@ -74,19 +77,20 @@ not intended to be invoked directly by users.`,
 	},
 }
 
-// rootDir is currently unused — every backend dispatch returns
-// "not yet implemented". Once a real implementation lands it will need
-// rootDir to locate per-workspace state, and the first return value will
-// no longer always be nil.
-//
-//nolint:unparam // first return is always nil while every backend is a stub
-func newDatabaseServer(backend proxy.Backend, _ string) (server.DatabaseServer, error) {
+func newDatabaseServer(backend proxy.Backend, rootDir, configPath, logPath, doltBin string) (server.DatabaseServer, error) {
 	switch backend {
-	case proxy.BackendExternal, proxy.BackendLocalServer, proxy.BackendLocalSharedServer:
+	case proxy.BackendLocalServer:
+		return newLocalDoltServer(rootDir, configPath, logPath, doltBin)
+	case proxy.BackendExternal, proxy.BackendLocalSharedServer:
 		return nil, fmt.Errorf("backend %q: not yet implemented", backend)
 	}
-	// Unreachable in normal flow: RunE validates before reaching here.
 	return nil, fmt.Errorf("unknown backend %q", backend)
+}
+
+const localDoltDefaultUser = "root"
+
+func newLocalDoltServer(rootDir, configPath, logPath, doltBin string) (server.DatabaseServer, error) {
+	return server.NewDoltServer(doltBin, rootDir, configPath, logPath, localDoltDefaultUser, "", 0)
 }
 
 func init() {
@@ -95,6 +99,9 @@ func init() {
 	dbProxyChildCmd.Flags().DurationVar(&dbProxyChildIdleTimeout, "idle-timeout", 5*time.Minute, "idle timeout before shutdown (0 disables)")
 	dbProxyChildCmd.Flags().StringVar(&dbProxyChildBackend, "backend", "",
 		"backend kind: "+strings.Join(proxy.KnownBackendNames(), " | "))
+	dbProxyChildCmd.Flags().StringVar(&dbProxyChildConfig, "config", "", "path to backend server config (e.g. dolt sql-server YAML)")
+	dbProxyChildCmd.Flags().StringVar(&dbProxyChildLogPath, "logpath", "", "path the backend server should write its stdout/stderr to")
+	dbProxyChildCmd.Flags().StringVar(&dbProxyChildDoltBin, "dolt-bin", "", "path to the dolt executable")
 	_ = dbProxyChildCmd.MarkFlagRequired("root")
 	_ = dbProxyChildCmd.MarkFlagRequired("port")
 	_ = dbProxyChildCmd.MarkFlagRequired("backend")

--- a/internal/storage/db/proxy/endpoint.go
+++ b/internal/storage/db/proxy/endpoint.go
@@ -25,8 +25,11 @@ func (e Endpoint) Address() string {
 }
 
 type OpenOpts struct {
-	IdleTimeout time.Duration
-	Backend     Backend
+	IdleTimeout    time.Duration
+	Backend        Backend
+	ConfigFilePath string
+	LogFilePath    string
+	DoltBinPath    string
 }
 
 const (
@@ -35,9 +38,30 @@ const (
 	openPollInterval      = 100 * time.Millisecond
 )
 
+func PickFreePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port, nil
+}
+
 func GetCreateDatabaseProxyServerEndpoint(rootDir string, opts OpenOpts) (Endpoint, error) {
 	if err := opts.Backend.Validate(); err != nil {
 		return Endpoint{}, fmt.Errorf("OpenOpts.Backend: %w", err)
+	}
+	if opts.Backend == BackendLocalServer {
+		if opts.ConfigFilePath == "" {
+			return Endpoint{}, fmt.Errorf("OpenOpts.ConfigFilePath is required for backend %q", opts.Backend)
+		}
+		if opts.LogFilePath == "" {
+			return Endpoint{}, fmt.Errorf("OpenOpts.LogFilePath is required for backend %q", opts.Backend)
+		}
+		if opts.DoltBinPath == "" {
+			return Endpoint{}, fmt.Errorf("OpenOpts.DoltBinPath is required for backend %q", opts.Backend)
+		}
 	}
 	deadline := time.Now().Add(openDeadline)
 
@@ -87,13 +111,13 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 	// readers into dialing a port that nobody is listening on.
 	_ = RemoveDatabaseProxyPidFile(rootDir)
 
-	port, err := pickFreePort()
+	port, err := PickFreePort()
 	if err != nil {
 		return Endpoint{}, fmt.Errorf("pick port: %w", err)
 	}
 
 	handedOff = true
-	cmd, done, err := forkExecChild(rootDir, port, opts.IdleTimeout, opts.Backend, lock)
+	cmd, done, err := forkExecChild(rootDir, opts.ConfigFilePath, opts.LogFilePath, opts.DoltBinPath, port, opts.IdleTimeout, opts.Backend, lock)
 	if err != nil {
 		return Endpoint{}, fmt.Errorf("fork child: %w", err)
 	}
@@ -122,17 +146,7 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 	}
 }
 
-func pickFreePort() (int, error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
-	return port, nil
-}
-
-func forkExecChild(rootDir string, port int, idleTimeout time.Duration, backend Backend, lock *util.Lock) (*exec.Cmd, <-chan struct{}, error) {
+func forkExecChild(rootDir, configFilePath, logFilePath, doltBinPath string, port int, idleTimeout time.Duration, backend Backend, lock *util.Lock) (*exec.Cmd, <-chan struct{}, error) {
 	released := false
 	defer func() {
 		if !released {
@@ -156,11 +170,19 @@ func forkExecChild(rootDir string, port int, idleTimeout time.Duration, backend 
 		"--idle-timeout", idleTimeout.String(),
 		"--backend", string(backend),
 	}
+	if configFilePath != "" {
+		args = append(args, "--config", configFilePath)
+	}
+	if logFilePath != "" {
+		args = append(args, "--logpath", logFilePath)
+	}
+	if doltBinPath != "" {
+		args = append(args, "--dolt-bin", doltBinPath)
+	}
 
-	logFile, err := os.OpenFile(filepath.Join(rootDir, "proxy.log"), //nolint:gosec // rootDir is caller-derived (workspace path), not user request input
-		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600) //nolint:gosec // G304: logFilePath is caller-derived (workspace path), not user-request input
 	if err != nil {
-		return nil, nil, fmt.Errorf("open proxy.log: %w", err)
+		return nil, nil, fmt.Errorf("open log file %q: %w", logFilePath, err)
 	}
 
 	cmd := exec.Command(self, args...)


### PR DESCRIPTION
## Summary

- Wires the `local-server` backend in `db-proxy-child` to a real `server.DoltServer`; `external` and `local-shared-server` still return "not yet implemented".
- Adds `--config`, `--logpath`, and `--dolt-bin` flags (and matching `proxy.OpenOpts` fields) so the parent supplies the sql-server YAML, log path, and dolt binary; required when `Backend == BackendLocalServer`.
- `forkExecChild` now writes proxy-child stdout/stderr to `OpenOpts.LogFilePath` instead of `<rootDir>/proxy.log`, and `pickFreePort` is exported as `PickFreePort`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->