### PR TITLE
fix(create): warn on unknown fields and honor --dry-run with --graph

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -58,7 +58,8 @@ var createCmd = &cobra.Command{
 			if len(args) > 0 {
 				FatalError("cannot specify both title and --graph flag")
 			}
-			createIssuesFromGraph(graphFile)
+			graphDryRun, _ := cmd.Flags().GetBool("dry-run")
+			createIssuesFromGraph(graphFile, graphDryRun)
 			return
 		}
 

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 
@@ -49,11 +50,200 @@ type GraphApplyResult struct {
 	IDs map[string]string `json:"ids"`
 }
 
+// GraphApplyDryRun describes the actions that would be taken by a graph plan,
+// without performing any writes. Emitted by `bd create --graph --dry-run`.
+type GraphApplyDryRun struct {
+	DryRun     bool                  `json:"dry_run"`
+	NodeCount  int                   `json:"node_count"`
+	EdgeCount  int                   `json:"edge_count"`
+	ParentDeps int                   `json:"parent_deps"`
+	Nodes      []GraphApplyDryRunRow `json:"nodes"`
+}
+
+// GraphApplyDryRunRow describes a single planned node in the dry-run preview.
+type GraphApplyDryRunRow struct {
+	Key       string `json:"key"`
+	Title     string `json:"title"`
+	Type      string `json:"type"`
+	Priority  int    `json:"priority"`
+	ParentKey string `json:"parent_key,omitempty"`
+	ParentID  string `json:"parent_id,omitempty"`
+}
+
+// knownGraphPlanFields lists the JSON keys recognized at the top level of a
+// GraphApplyPlan. Any other top-level keys produce a warning so users can spot
+// schema typos (e.g. when a plan uses a sibling tool's format) instead of
+// having fields silently dropped by encoding/json. (GH#3367)
+var knownGraphPlanFields = map[string]struct{}{
+	"commit_message": {},
+	"nodes":          {},
+	"edges":          {},
+}
+
+// knownGraphNodeFields lists the JSON keys recognized on a GraphApplyNode.
+// Kept in sync with the json tags on GraphApplyNode. (GH#3367)
+var knownGraphNodeFields = map[string]struct{}{
+	"key":                 {},
+	"title":               {},
+	"type":                {},
+	"description":         {},
+	"assignee":            {},
+	"assign_after_create": {},
+	"priority":            {},
+	"labels":              {},
+	"metadata":            {},
+	"metadata_refs":       {},
+	"parent_key":          {},
+	"parent_id":           {},
+}
+
+// knownGraphEdgeFields lists the JSON keys recognized on a GraphApplyEdge.
+// Kept in sync with the json tags on GraphApplyEdge. (GH#3367)
+var knownGraphEdgeFields = map[string]struct{}{
+	"from_key": {},
+	"from_id":  {},
+	"to_key":   {},
+	"to_id":    {},
+	"type":     {},
+}
+
+// graphFieldHints maps unknown-field names to a corrective hint pointing at
+// the recognized schema field. Used by warnUnknownGraphFields to suggest the
+// intended schema when a plan uses a common-but-wrong name (e.g. nodes carry
+// a "parent" string instead of "parent_key", or "blocks" arrays instead of
+// the top-level edges array). (GH#3367)
+var graphFieldHints = map[string]string{
+	"parent":   "use 'parent_key' (referencing another node's 'key') or 'parent_id' (an existing issue ID)",
+	"blocks":   "use the top-level 'edges' array, e.g. {\"from_key\": \"a\", \"to_key\": \"b\", \"type\": \"blocks\"}",
+	"depends":  "use the top-level 'edges' array with type 'blocks'",
+	"children": "set 'parent_key' on each child instead of listing children on the parent",
+}
+
+// detectUnknownGraphFields scans the raw plan JSON and returns unknown field
+// names grouped by their location in the plan. The returned map keys describe
+// the location ("plan", "node[<key-or-index>]", "edge[<index>]") and values
+// are sorted lists of unknown field names at that location. Returns an empty
+// map when the plan is structurally invalid (callers should still attempt the
+// strict parse so the operator gets a normal parse error rather than only the
+// schema warning). (GH#3367)
+func detectUnknownGraphFields(rawData []byte) map[string][]string {
+	out := make(map[string][]string)
+
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(rawData, &top); err != nil {
+		return out
+	}
+
+	if planUnknown := unknownKeys(top, knownGraphPlanFields); len(planUnknown) > 0 {
+		out["plan"] = planUnknown
+	}
+
+	if nodesRaw, ok := top["nodes"]; ok {
+		var rawNodes []json.RawMessage
+		if err := json.Unmarshal(nodesRaw, &rawNodes); err == nil {
+			for i, nodeRaw := range rawNodes {
+				var nodeMap map[string]json.RawMessage
+				if err := json.Unmarshal(nodeRaw, &nodeMap); err != nil {
+					continue
+				}
+				if unknown := unknownKeys(nodeMap, knownGraphNodeFields); len(unknown) > 0 {
+					label := fmt.Sprintf("node[%d]", i)
+					if keyRaw, ok := nodeMap["key"]; ok {
+						var keyStr string
+						if err := json.Unmarshal(keyRaw, &keyStr); err == nil && keyStr != "" {
+							label = fmt.Sprintf("node[%q]", keyStr)
+						}
+					}
+					out[label] = unknown
+				}
+			}
+		}
+	}
+
+	if edgesRaw, ok := top["edges"]; ok {
+		var rawEdges []json.RawMessage
+		if err := json.Unmarshal(edgesRaw, &rawEdges); err == nil {
+			for i, edgeRaw := range rawEdges {
+				var edgeMap map[string]json.RawMessage
+				if err := json.Unmarshal(edgeRaw, &edgeMap); err != nil {
+					continue
+				}
+				if unknown := unknownKeys(edgeMap, knownGraphEdgeFields); len(unknown) > 0 {
+					out[fmt.Sprintf("edge[%d]", i)] = unknown
+				}
+			}
+		}
+	}
+
+	return out
+}
+
+// unknownKeys returns the keys present in have that are not in known, sorted
+// alphabetically for deterministic output.
+func unknownKeys(have map[string]json.RawMessage, known map[string]struct{}) []string {
+	var unknown []string
+	for k := range have {
+		if _, ok := known[k]; !ok {
+			unknown = append(unknown, k)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// warnUnknownGraphFields prints a single warning line per location in the
+// plan with one or more unknown fields, plus a per-field hint when one is
+// available. Output goes to w (typically os.Stderr). Returns the set of
+// distinct unknown field names that were warned about, primarily for tests.
+// (GH#3367)
+func warnUnknownGraphFields(w io.Writer, unknown map[string][]string) []string {
+	if len(unknown) == 0 {
+		return nil
+	}
+
+	locations := make([]string, 0, len(unknown))
+	for loc := range unknown {
+		locations = append(locations, loc)
+	}
+	sort.Strings(locations)
+
+	distinct := make(map[string]struct{})
+	for _, loc := range locations {
+		fields := append([]string(nil), unknown[loc]...)
+		sort.Strings(fields)
+		fmt.Fprintf(w, "warning: graph plan %s has unknown field(s): %v (silently dropped — see 'bd create --graph' schema)\n", loc, fields)
+		for _, f := range fields {
+			distinct[f] = struct{}{}
+		}
+	}
+
+	hintFields := make([]string, 0, len(distinct))
+	for f := range distinct {
+		hintFields = append(hintFields, f)
+	}
+	sort.Strings(hintFields)
+	for _, f := range hintFields {
+		if hint, ok := graphFieldHints[f]; ok {
+			fmt.Fprintf(w, "  hint: %q is not part of the schema; %s\n", f, hint)
+		}
+	}
+
+	return hintFields
+}
+
 // createIssuesFromGraph handles `bd create --graph <plan-file>`.
-func createIssuesFromGraph(planFile string) {
+// When dryRun is true, the plan is parsed and validated but no writes occur;
+// a preview is emitted to stdout (JSON when jsonOutput is set, otherwise
+// human-readable). Unknown plan/node/edge fields are reported to stderr in
+// both modes so schema gaps are visible before any writes happen. (GH#3367)
+func createIssuesFromGraph(planFile string, dryRun bool) {
 	data, err := os.ReadFile(planFile) // #nosec G304 -- user-provided path is intentional
 	if err != nil {
 		FatalError("reading graph plan: %v", err)
+	}
+
+	if unknown := detectUnknownGraphFields(data); len(unknown) > 0 {
+		warnUnknownGraphFields(os.Stderr, unknown)
 	}
 
 	var plan GraphApplyPlan
@@ -63,6 +253,11 @@ func createIssuesFromGraph(planFile string) {
 
 	if err := validateGraphApplyPlan(&plan); err != nil {
 		FatalError("invalid graph plan: %v", err)
+	}
+
+	if dryRun {
+		emitGraphApplyDryRun(&plan)
+		return
 	}
 
 	result, err := executeGraphApply(rootCtx, &plan)
@@ -82,6 +277,61 @@ func createIssuesFromGraph(planFile string) {
 		for _, key := range keys {
 			fmt.Printf("  %s -> %s\n", key, result.IDs[key])
 		}
+	}
+}
+
+// emitGraphApplyDryRun prints what `bd create --graph` would do without
+// performing any writes. Mirrors the JSON-vs-human split of the live path.
+// (GH#3367)
+func emitGraphApplyDryRun(plan *GraphApplyPlan) {
+	parentDeps := 0
+	rows := make([]GraphApplyDryRunRow, 0, len(plan.Nodes))
+	for _, node := range plan.Nodes {
+		issueType := node.Type
+		if issueType == "" {
+			issueType = string(types.TypeTask)
+		}
+		priority := 2
+		if node.Priority != nil {
+			priority = *node.Priority
+		}
+		if node.ParentKey != "" || node.ParentID != "" {
+			parentDeps++
+		}
+		rows = append(rows, GraphApplyDryRunRow{
+			Key:       node.Key,
+			Title:     node.Title,
+			Type:      issueType,
+			Priority:  priority,
+			ParentKey: node.ParentKey,
+			ParentID:  node.ParentID,
+		})
+	}
+
+	preview := GraphApplyDryRun{
+		DryRun:     true,
+		NodeCount:  len(plan.Nodes),
+		EdgeCount:  len(plan.Edges),
+		ParentDeps: parentDeps,
+		Nodes:      rows,
+	}
+
+	if jsonOutput {
+		outputJSON(preview)
+		return
+	}
+
+	fmt.Printf("Dry run: would create %d issue(s) and %d edge(s) (%d parent-child link(s))\n",
+		preview.NodeCount, preview.EdgeCount, preview.ParentDeps)
+	for _, row := range rows {
+		parent := ""
+		switch {
+		case row.ParentKey != "":
+			parent = fmt.Sprintf(" parent_key=%s", row.ParentKey)
+		case row.ParentID != "":
+			parent = fmt.Sprintf(" parent_id=%s", row.ParentID)
+		}
+		fmt.Printf("  %s [%s] P%d %q%s\n", row.Key, row.Type, row.Priority, row.Title, parent)
 	}
 }
 

--- a/cmd/bd/graph_apply_test.go
+++ b/cmd/bd/graph_apply_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"reflect"
+	"sort"
+	"strings"
 	"testing"
 )
 
@@ -66,5 +70,188 @@ func TestValidateGraphApplyPlanAcceptsEmptyType(t *testing.T) {
 	}
 	if err := validateGraphApplyPlan(plan); err != nil {
 		t.Fatalf("empty type rejected: %v", err)
+	}
+}
+
+// TestDetectUnknownGraphFields_ReporterRepro reproduces the schema-mismatch
+// pattern from GH#3367: the user passes 'parent' (a string) and 'blocks' (an
+// array) directly on nodes, expecting them to wire hierarchy/dependencies.
+// json.Unmarshal silently drops them. detectUnknownGraphFields must surface
+// both fields, scoped to the offending nodes.
+func TestDetectUnknownGraphFields_ReporterRepro(t *testing.T) {
+	planJSON := []byte(`{
+        "nodes": [
+            {"key": "root",   "type": "epic", "title": "Root epic",    "priority": 2},
+            {"key": "child1", "type": "task", "title": "Child task 1", "parent": "root", "priority": 2, "blocks": ["child2"]},
+            {"key": "child2", "type": "task", "title": "Child task 2", "parent": "root", "priority": 2}
+        ]
+    }`)
+
+	got := detectUnknownGraphFields(planJSON)
+	want := map[string][]string{
+		`node["child1"]`: {"blocks", "parent"},
+		`node["child2"]`: {"parent"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("detectUnknownGraphFields:\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+// TestDetectUnknownGraphFields_KnownSchemaIsClean verifies that a plan using
+// only the documented schema (parent_key, edges array) reports no unknowns.
+// Guards against the schema lists drifting from the GraphApplyPlan/Node/Edge
+// json tags.
+func TestDetectUnknownGraphFields_KnownSchemaIsClean(t *testing.T) {
+	planJSON := []byte(`{
+        "commit_message": "test",
+        "nodes": [
+            {"key": "root", "title": "Root", "type": "epic", "priority": 2,
+             "description": "d", "assignee": "alice", "assign_after_create": false,
+             "labels": ["a"], "metadata": {"k": "v"}, "metadata_refs": {"r": "root"}},
+            {"key": "child", "title": "Child", "parent_key": "root",
+             "parent_id": "ext-1"}
+        ],
+        "edges": [
+            {"from_key": "child", "to_key": "root", "type": "blocks"},
+            {"from_id": "ext-1", "to_id": "ext-2", "type": "related"}
+        ]
+    }`)
+
+	if got := detectUnknownGraphFields(planJSON); len(got) != 0 {
+		t.Fatalf("expected no unknown fields for canonical schema, got %#v", got)
+	}
+}
+
+// TestDetectUnknownGraphFields_PlanAndEdgeLevel verifies coverage at the plan
+// top level and edge level, not just node level.
+func TestDetectUnknownGraphFields_PlanAndEdgeLevel(t *testing.T) {
+	planJSON := []byte(`{
+        "version": "1.0",
+        "nodes": [{"key": "n", "title": "n"}],
+        "edges": [{"from_key": "n", "to_key": "n", "weight": 5}]
+    }`)
+
+	got := detectUnknownGraphFields(planJSON)
+	if !reflect.DeepEqual(got["plan"], []string{"version"}) {
+		t.Errorf("plan-level unknowns: got=%v want=[version]", got["plan"])
+	}
+	if !reflect.DeepEqual(got["edge[0]"], []string{"weight"}) {
+		t.Errorf("edge-level unknowns: got=%v want=[weight]", got["edge[0]"])
+	}
+}
+
+// TestDetectUnknownGraphFields_BadJSON returns empty rather than panicking
+// when the plan can't be parsed at the top level. Callers run the strict
+// json.Unmarshal afterwards and surface the parse error there.
+func TestDetectUnknownGraphFields_BadJSON(t *testing.T) {
+	if got := detectUnknownGraphFields([]byte(`{not json`)); len(got) != 0 {
+		t.Fatalf("expected empty map for bad JSON, got %#v", got)
+	}
+}
+
+// TestWarnUnknownGraphFields_HintsForReporterFields asserts that the hint
+// text for the two highest-friction fields ('parent', 'blocks' from GH#3367)
+// is emitted and points the user at the canonical schema field.
+func TestWarnUnknownGraphFields_HintsForReporterFields(t *testing.T) {
+	var buf bytes.Buffer
+	hinted := warnUnknownGraphFields(&buf, map[string][]string{
+		`node["c1"]`: {"parent", "blocks"},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, `unknown field(s): [blocks parent]`) {
+		t.Errorf("warning missing field list: %q", out)
+	}
+	if !strings.Contains(out, "parent_key") {
+		t.Errorf("expected 'parent' hint to mention parent_key: %q", out)
+	}
+	if !strings.Contains(out, "edges") {
+		t.Errorf("expected 'blocks' hint to mention edges array: %q", out)
+	}
+
+	got := append([]string(nil), hinted...)
+	sort.Strings(got)
+	want := []string{"blocks", "parent"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("hinted fields: got=%v want=%v", got, want)
+	}
+}
+
+// TestWarnUnknownGraphFields_NoUnknownsIsSilent verifies the warning function
+// emits nothing when the input map is empty (the common path for well-formed
+// plans).
+func TestWarnUnknownGraphFields_NoUnknownsIsSilent(t *testing.T) {
+	var buf bytes.Buffer
+	warnUnknownGraphFields(&buf, nil)
+	if buf.Len() != 0 {
+		t.Fatalf("expected silent on empty input, wrote: %q", buf.String())
+	}
+}
+
+// TestKnownGraphFieldSetsMatchStructTags is a guardrail: the
+// knownGraphPlanFields / knownGraphNodeFields / knownGraphEdgeFields sets
+// must match the json tags on the corresponding structs so that adding a
+// new field on the schema doesn't silently re-introduce the false-positive
+// warning that GH#3367 was trying to remove. Reflection lets us spot drift
+// at test time without forcing manual upkeep on the schema author.
+func TestKnownGraphFieldSetsMatchStructTags(t *testing.T) {
+	check := func(name string, sample interface{}, known map[string]struct{}) {
+		t.Helper()
+		typ := reflect.TypeOf(sample)
+		tagged := make(map[string]struct{})
+		for i := 0; i < typ.NumField(); i++ {
+			tag := typ.Field(i).Tag.Get("json")
+			if tag == "" || tag == "-" {
+				continue
+			}
+			if comma := strings.IndexByte(tag, ','); comma >= 0 {
+				tag = tag[:comma]
+			}
+			tagged[tag] = struct{}{}
+		}
+		for k := range tagged {
+			if _, ok := known[k]; !ok {
+				t.Errorf("%s: json tag %q present on struct but missing from known set (would be flagged as unknown)", name, k)
+			}
+		}
+		for k := range known {
+			if _, ok := tagged[k]; !ok {
+				t.Errorf("%s: %q in known set but not on struct (stale entry)", name, k)
+			}
+		}
+	}
+	check("GraphApplyPlan", GraphApplyPlan{}, knownGraphPlanFields)
+	check("GraphApplyNode", GraphApplyNode{}, knownGraphNodeFields)
+	check("GraphApplyEdge", GraphApplyEdge{}, knownGraphEdgeFields)
+}
+
+// TestEmitGraphApplyDryRun_Counts verifies the dry-run preview reports the
+// node count, edge count, and parent-link count without performing any
+// writes. Captures stdout (the dry-run path writes to stdout, with warnings
+// going to stderr from the upstream caller).
+func TestEmitGraphApplyDryRun_Counts(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "c1", Title: "Child 1", ParentKey: "root"},
+			{Key: "c2", Title: "Child 2", ParentKey: "root"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "c1", ToKey: "c2", Type: "blocks"},
+		},
+	}
+
+	out := captureStdout(t, func() error {
+		emitGraphApplyDryRun(plan)
+		return nil
+	})
+
+	if !strings.Contains(out, "would create 3 issue(s) and 1 edge(s) (2 parent-child link(s))") {
+		t.Errorf("dry-run summary missing or wrong:\n%s", out)
+	}
+	for _, want := range []string{"root", "c1", "c2", "parent_key=root"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run missing %q in output:\n%s", want, out)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #3367. Two related bugs on the `bd create --graph <plan>` path:

1. **Unknown fields silently dropped.** Plans whose nodes carry `parent` (a string) or `blocks` (an array) — a reasonable guess at the schema, but not the one bd accepts — parse cleanly with no signal that hierarchy/dependencies were lost. Per the reporter, this orphaned ~25 nodes across two production plans before being noticed.
2. **`--dry-run` ignored.** The flag is defined on `bd create` and honored on the `--file` path, but `createIssuesFromGraph` skipped it and went straight to `executeGraphApply`.

This PR addresses both. Per the reporter's "in priority order" suggestions, this PR ships **option 2 (warn loudly) + option 3 (honor --dry-run)** rather than option 1 (extend the schema to accept `parent`/`blocks` natively), since option 1 is a schema decision better made by the maintainer. The warnings make the gap visible and point each unknown field at the correct schema field, so users who want `parent`/`blocks` semantics get an immediate, actionable hint.

## Changes

- **`cmd/bd/graph_apply.go`**
  - New `detectUnknownGraphFields(rawData)` scans the raw plan JSON before unmarshal and returns unknown keys grouped by location (`plan`, `node["<key>"]`, `edge[<i>]`).
  - New `warnUnknownGraphFields(w, ...)` emits a stderr warning per location plus per-field hints. Hints cover `parent`, `blocks`, `depends`, `children` — the four most likely typos.
  - `knownGraphPlanFields` / `knownGraphNodeFields` / `knownGraphEdgeFields` constant sets, with a reflection-based test that fails on drift from the json tags on `GraphApplyPlan` / `GraphApplyNode` / `GraphApplyEdge`.
  - `createIssuesFromGraph` now takes `dryRun bool`. On dry-run it parses + validates as normal but skips `executeGraphApply` and emits a `GraphApplyDryRun` preview (JSON under `--json`, otherwise human-readable).
- **`cmd/bd/create.go`** — pass `--dry-run` through to `createIssuesFromGraph`, matching the existing `--file` wiring.
- **`cmd/bd/graph_apply_test.go`** — 8 new tests:
  - `TestDetectUnknownGraphFields_ReporterRepro` uses the reporter's exact JSON.
  - `TestDetectUnknownGraphFields_KnownSchemaIsClean` guards against false positives on the canonical schema (every known field listed).
  - `TestDetectUnknownGraphFields_PlanAndEdgeLevel` covers non-node locations.
  - `TestDetectUnknownGraphFields_BadJSON` ensures malformed input doesn't panic and falls through to the normal parse error.
  - `TestWarnUnknownGraphFields_HintsForReporterFields` asserts hint text mentions `parent_key` and the `edges` array.
  - `TestWarnUnknownGraphFields_NoUnknownsIsSilent` keeps the common path quiet.
  - `TestKnownGraphFieldSetsMatchStructTags` is a reflection-based drift guardrail.
  - `TestEmitGraphApplyDryRun_Counts` covers the dry-run preview.

## Test plan

- [x] `make test` passes (no regressions in `cmd/bd`, `cmd/bd/doctor`, `cmd/bd/setup`, or any other package).
- [x] Focused tests on the new helpers and `validateGraphApplyPlan` callers all pass.
- [x] `go vet -tags gms_pure_go ./cmd/bd/...` clean.
- [x] End-to-end smoke test against the reporter's exact JSON on a fresh `bd init` workspace:
  - `--dry-run` writes the warnings + preview, leaves the database empty (`bd list --json` returns `[]`).
  - Live run writes the same warnings + creates the 3 issues, exactly matching legacy behavior for plans that don't use unknown fields.

## Out of scope (for the maintainer to decide)

- Whether to honor `parent` / `blocks` natively (reporter's option 1). That's a schema-surface decision; this PR keeps the door open by warning rather than hard-failing.
- Strict mode (`DisallowUnknownFields`-style fail-on-unknown). Not adopted because it would break any pre-existing plan that carries extra metadata fields outside this schema.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->