### PR TITLE
fix(linear): state_map validation for deferred, pinned, hooked, custom (GH#3754)

### DIFF
--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -144,6 +144,10 @@ type MappingConfig struct {
 	// RelationMap maps Linear relation types to Beads dependency types.
 	// Key is Linear relation type, value is Beads dependency type.
 	RelationMap map[string]string
+
+	// CustomStatuses holds typed entries from status.custom (beads config).
+	// Used for push-time state_map validation and matching non-built-in statuses.
+	CustomStatuses []types.CustomStatus
 }
 
 // DefaultMappingConfig returns sensible default mappings.
@@ -220,6 +224,16 @@ func LoadMappingConfig(loader ConfigLoader) *MappingConfig {
 	}
 
 	for key, value := range allConfig {
+		if key == "status.custom" {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				if custom, err := types.ParseCustomStatusConfig(value); err == nil {
+					config.CustomStatuses = custom
+				}
+			}
+			continue
+		}
+
 		// Parse priority mappings: linear.priority_map.<linear_priority>
 		if strings.HasPrefix(key, "linear.priority_map.") {
 			linearPriority := strings.TrimPrefix(key, "linear.priority_map.")
@@ -320,7 +334,14 @@ func stateMapMatchesStatus(mapped string, status types.Status) bool {
 	if normalizedMapped == normalizedStatus {
 		return true
 	}
-	if status.IsValid() && ParseBeadsStatus(mapped) == status {
+	parsed := ParseBeadsStatus(mapped)
+	if parsed == status {
+		// ParseBeadsStatus returns StatusOpen for unrecognized strings; do not
+		// treat those as matching built-in open (avoids false "ambiguous mapping"
+		// when state_map values are custom status names like "review").
+		if parsed == types.StatusOpen && normalizedMapped != "open" {
+			return false
+		}
 		return true
 	}
 	return false

--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -153,6 +153,10 @@ type MappingConfig struct {
 	// RelationMap maps Linear relation types to Beads dependency types.
 	// Key is Linear relation type, value is Beads dependency type.
 	RelationMap map[string]string
+
+	// CustomStatuses holds typed entries from status.custom (beads config).
+	// Used for push-time state_map validation and matching non-built-in statuses.
+	CustomStatuses []types.CustomStatus
 }
 
 // DefaultMappingConfig returns sensible default mappings.
@@ -231,6 +235,16 @@ func LoadMappingConfig(loader ConfigLoader) *MappingConfig {
 	}
 
 	for key, value := range allConfig {
+		if key == "status.custom" {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				if custom, err := types.ParseCustomStatusConfig(value); err == nil {
+					config.CustomStatuses = custom
+				}
+			}
+			continue
+		}
+
 		// Parse priority mappings: linear.priority_map.<linear_priority>
 		if strings.HasPrefix(key, "linear.priority_map.") {
 			linearPriority := strings.TrimPrefix(key, "linear.priority_map.")
@@ -338,7 +352,14 @@ func stateMapMatchesStatus(mapped string, status types.Status) bool {
 	if normalizedMapped == normalizedStatus {
 		return true
 	}
-	if status.IsValid() && ParseBeadsStatus(mapped) == status {
+	parsed := ParseBeadsStatus(mapped)
+	if parsed == status {
+		// ParseBeadsStatus returns StatusOpen for unrecognized strings; do not
+		// treat those as matching built-in open (avoids false "ambiguous mapping"
+		// when state_map values are custom status names like "review").
+		if parsed == types.StatusOpen && normalizedMapped != "open" {
+			return false
+		}
 		return true
 	}
 	return false

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -609,10 +609,11 @@ func (m *mockConfigLoader) GetAllConfig() (map[string]string, error) {
 func TestLoadMappingConfig(t *testing.T) {
 	loader := &mockConfigLoader{
 		config: map[string]string{
-			"linear.priority_map.0":       "3",
+			"linear.priority_map.0":         "3",
 			"linear.state_map.custom":     "in_progress",
 			"linear.label_type_map.story": "feature",
 			"linear.relation_map.parent":  "parent-child",
+			"status.custom":               "review:active",
 		},
 	}
 
@@ -644,6 +645,10 @@ func TestLoadMappingConfig(t *testing.T) {
 	// Check that defaults are preserved
 	if config.StateMap["started"] != "in_progress" {
 		t.Errorf("StateMap[started] = %s, want in_progress (default preserved)", config.StateMap["started"])
+	}
+
+	if len(config.CustomStatuses) != 1 || config.CustomStatuses[0].Name != "review" {
+		t.Fatalf("CustomStatuses = %#v, want one entry named review", config.CustomStatuses)
 	}
 }
 
@@ -771,6 +776,54 @@ func TestResolveStateIDForBeadsStatusPrefersExplicitStateName(t *testing.T) {
 	}
 	if got != "state-1" {
 		t.Fatalf("ResolveStateIDForBeadsStatus() = %q, want state-1", got)
+	}
+}
+
+// Regression GH#3754: explicit state_map values that are custom status names
+// must not parse as StatusOpen and create phantom matches for beads "open".
+func TestResolveStateIDForBeadsStatusCustomValueDoesNotFalseMatchOpen(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-todo", Name: "Todo", Type: "unstarted"},
+			{ID: "state-review", Name: "In Review", Type: "unstarted"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["todo"] = "open"
+	config.ExplicitStateMap["in review"] = "review"
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusOpen, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus(open) error = %v", err)
+	}
+	if got != "state-todo" {
+		t.Fatalf("ResolveStateIDForBeadsStatus(open) = %q, want state-todo", got)
+	}
+
+	got2, err := ResolveStateIDForBeadsStatus(cache, types.Status("review"), config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus(review) error = %v", err)
+	}
+	if got2 != "state-review" {
+		t.Fatalf("ResolveStateIDForBeadsStatus(review) = %q, want state-review", got2)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusDeferredExplicitMapping(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-icebox", Name: "Icebox", Type: "unstarted"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["icebox"] = "deferred"
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusDeferred, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus() error = %v", err)
+	}
+	if got != "state-icebox" {
+		t.Fatalf("ResolveStateIDForBeadsStatus() = %q, want state-icebox", got)
 	}
 }
 

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -613,6 +613,7 @@ func TestLoadMappingConfig(t *testing.T) {
 			"linear.state_map.custom":     "in_progress",
 			"linear.label_type_map.story": "feature",
 			"linear.relation_map.parent":  "parent-child",
+			"status.custom":               "review:active",
 		},
 	}
 
@@ -644,6 +645,10 @@ func TestLoadMappingConfig(t *testing.T) {
 	// Check that defaults are preserved
 	if config.StateMap["started"] != "in_progress" {
 		t.Errorf("StateMap[started] = %s, want in_progress (default preserved)", config.StateMap["started"])
+	}
+
+	if len(config.CustomStatuses) != 1 || config.CustomStatuses[0].Name != "review" {
+		t.Fatalf("CustomStatuses = %#v, want one entry named review", config.CustomStatuses)
 	}
 }
 
@@ -897,6 +902,54 @@ func TestLoadMappingConfigParsesOutboundStateMap(t *testing.T) {
 	// Defaults still empty for unset keys.
 	if got, ok := config.OutboundStateMap["closed"]; ok {
 		t.Errorf("OutboundStateMap[closed] = %q, want unset", got)
+	}
+}
+
+// Regression GH#3754: explicit state_map values that are custom status names
+// must not parse as StatusOpen and create phantom matches for beads "open".
+func TestResolveStateIDForBeadsStatusCustomValueDoesNotFalseMatchOpen(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-todo", Name: "Todo", Type: "unstarted"},
+			{ID: "state-review", Name: "In Review", Type: "unstarted"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["todo"] = "open"
+	config.ExplicitStateMap["in review"] = "review"
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusOpen, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus(open) error = %v", err)
+	}
+	if got != "state-todo" {
+		t.Fatalf("ResolveStateIDForBeadsStatus(open) = %q, want state-todo", got)
+	}
+
+	got2, err := ResolveStateIDForBeadsStatus(cache, types.Status("review"), config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus(review) error = %v", err)
+	}
+	if got2 != "state-review" {
+		t.Fatalf("ResolveStateIDForBeadsStatus(review) = %q, want state-review", got2)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusDeferredExplicitMapping(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-icebox", Name: "Icebox", Type: "unstarted"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["icebox"] = "deferred"
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusDeferred, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus() error = %v", err)
+	}
+	if got != "state-icebox" {
+		t.Fatalf("ResolveStateIDForBeadsStatus() = %q, want state-icebox", got)
 	}
 }
 

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -527,11 +527,36 @@ func (t *Tracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
 	return fmt.Sprintf("https://linear.app/issue/%s", issue.Identifier)
 }
 
+func skipOptionalPushStateMapping(status types.Status, err error, custom []types.CustomStatus) bool {
+	if !strings.Contains(err.Error(), "has no configured Linear state") {
+		return false
+	}
+	switch status {
+	case types.StatusBlocked, types.StatusDeferred, types.StatusPinned, types.StatusHooked:
+		return true
+	}
+	for _, cs := range custom {
+		if types.Status(cs.Name) == status {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidatePushStateMappings ensures push has explicit, non-ambiguous status
 // mappings for every configured team before any mutation occurs.
 func (t *Tracker) ValidatePushStateMappings(ctx context.Context) error {
 	if t.config == nil || len(t.config.ExplicitStateMap) == 0 {
 		return fmt.Errorf("%s", missingExplicitStateMapMessage)
+	}
+	statuses := []types.Status{
+		types.StatusOpen,
+		types.StatusInProgress,
+		types.StatusBlocked,
+		types.StatusClosed,
+		types.StatusDeferred,
+		types.StatusPinned,
+		types.StatusHooked,
 	}
 	for _, teamID := range t.teamIDs {
 		client := t.clients[teamID]
@@ -542,12 +567,18 @@ func (t *Tracker) ValidatePushStateMappings(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("fetching workflow states for team %s: %w", teamID, err)
 		}
-		for _, status := range []types.Status{types.StatusOpen, types.StatusInProgress, types.StatusBlocked, types.StatusClosed} {
+		for _, status := range statuses {
 			if _, err := ResolveStateIDForBeadsStatus(cache, status, t.config); err != nil {
-				// Only fail for statuses the config explicitly tries to map or when
-				// mappings are entirely absent. Missing blocked mappings are allowed
-				// until a blocked issue is actually pushed.
-				if status == types.StatusBlocked && strings.Contains(err.Error(), "has no configured Linear state") {
+				if skipOptionalPushStateMapping(status, err, t.config.CustomStatuses) {
+					continue
+				}
+				return err
+			}
+		}
+		for _, cs := range t.config.CustomStatuses {
+			st := types.Status(cs.Name)
+			if _, err := ResolveStateIDForBeadsStatus(cache, st, t.config); err != nil {
+				if skipOptionalPushStateMapping(st, err, t.config.CustomStatuses) {
 					continue
 				}
 				return err


### PR DESCRIPTION
## Summary
- Guard `stateMapMatchesStatus` so `ParseBeadsStatus` defaulting unknown strings to `open` does not make custom `linear.state_map` values (e.g. `review`) falsely match beads `open`, which caused bogus ambiguous-mapping errors (GH#3754).
- Parse `status.custom` into `MappingConfig.CustomStatuses` from config loader.
- Extend `ValidatePushStateMappings` to pre-check deferred, pinned, hooked, and each configured custom status, with the same skip-if-unmapped leniency as blocked.

## Tests
- `go test ./internal/linear/...`
- New: `TestResolveStateIDForBeadsStatusCustomValueDoesNotFalseMatchOpen`, `TestResolveStateIDForBeadsStatusDeferredExplicitMapping`, extended `TestLoadMappingConfig` for `status.custom`.

Closes #3754

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->