### PR TITLE
fix(init): resolve symlinks before writing agent docs (GH#3722)

### DIFF
--- a/cmd/bd/init_agent.go
+++ b/cmd/bd/init_agent.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/templates/agents"
 	"github.com/steveyegge/beads/internal/ui"
+	"github.com/steveyegge/beads/internal/utils"
 )
 
 // addAgentsInstructions creates or updates the agents file with embedded template content.
@@ -35,6 +36,13 @@ func addAgentsInstructions(agentFile string, verbose bool, templatePath string, 
 // If the file already has a full profile and a minimal profile is requested, the full
 // profile is preserved to avoid information loss.
 func updateAgentFile(filename string, verbose bool, templatePath string, profile agents.Profile, opts agents.RenderOpts) error {
+	// Resolve symlinks so we read/write the target file, not the symlink itself (GH#3722)
+	resolved, resolveErr := utils.ResolveForWrite(filename)
+	if resolveErr != nil {
+		return fmt.Errorf("failed to resolve path %s: %w", filename, resolveErr)
+	}
+	filename = resolved
+
 	// Check if file exists
 	//nolint:gosec // G304: filename validated by config.ValidateAgentsFile or defaulted to AGENTS.md
 	content, err := os.ReadFile(filename)


### PR DESCRIPTION
## Summary
- Fixes `bd init` corrupting symlinked CLAUDE.md/AGENTS.md by resolving symlinks via `utils.ResolveForWrite` before reading or writing
- The setup path (`installAgents`) already handles this correctly; this aligns `updateAgentFile` with the same pattern
- Prevents the macOS APFS breakage where symlink targets exceeding ~1023 bytes make the repo unrecoverable

Closes #3722

## Test plan
- [x] `make build` succeeds
- [x] Tests pass
- [x] Symlinked agent docs are written to the target file, not the symlink

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->