### PR TITLE
fix(create): respect --repo when cwd has no .beads/ workspace (GH#3686)

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/hooks"
 	"github.com/steveyegge/beads/internal/molecules"
+	"github.com/steveyegge/beads/internal/remotecache"
+	"github.com/steveyegge/beads/internal/routing"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/telemetry"
@@ -846,7 +848,18 @@ var rootCmd = &cobra.Command{
 					return
 				}
 
-				if cmd.Name() != "import" && cmd.Name() != "setup" {
+				// GH#3686: `create --repo` targets a different repo; resolve
+				// that repo's .beads/ so PreRun doesn't exit early.
+				if cmd.Name() == "create" && cmd.Flags().Changed("repo") {
+					repoVal, _ := cmd.Flags().GetString("repo")
+					if repoVal != "" && !remotecache.IsRemoteURL(repoVal) {
+						targetDir := routing.ExpandPath(repoVal)
+						targetBeadsDB := filepath.Join(targetDir, ".beads", beads.CanonicalDatabaseName)
+						dbPath = utils.CanonicalizePath(targetBeadsDB)
+					}
+				}
+
+				if cmd.Name() != "import" && cmd.Name() != "setup" && dbPath == "" {
 					// No database found - provide context-aware error message
 					fmt.Fprintf(os.Stderr, "Error: no beads database found\n")
 					fmt.Fprintf(os.Stderr, "Hint: %s\n", diagHint())


### PR DESCRIPTION
## Summary
- Fixes `bd create --repo=/path/to/repo` failing with "no beads database found" when the current directory has no `.beads/` workspace
- Root cause: `PersistentPreRun` in `main.go` exits before `create.go`'s `--repo` handling runs
- Fix: when `create --repo` is set with a local path, resolve the target `.beads/` in PreRun so bootstrap uses the correct workspace

Closes #3686

## Test plan
- [x] `make build` succeeds
- [x] Tests pass (`make test` — only pre-existing `TestCloudAuthCLIRouting` failure unrelated to this change)
- [x] `bd create --repo` from non-beads directory resolves correctly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->