### PR TITLE
fix(init): preserve server mode on --reinit-local (GH#3585)

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -376,6 +376,20 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// to ensure consistent path representation.
 		beadsDir := beadsDirForInit
 
+		// GH#3585: on --reinit-local, inherit server mode from persisted
+		// metadata.json so reinit doesn't create a parasitic embeddeddolt/
+		// directory or print "Mode: embedded" for server-mode stores.
+		// Only apply when the user did not explicitly pass --server.
+		if reinitLocal && !cmd.Flags().Changed("server") {
+			if existingCfg, err := configfile.Load(beadsDir); err == nil && existingCfg != nil && existingCfg.IsDoltServerMode() {
+				initServerMode = true
+				serverMode = true
+				if cmdCtx != nil {
+					cmdCtx.ServerMode = true
+				}
+			}
+		}
+
 		// Prevent nested .beads directories
 		// Check if current working directory is inside a .beads directory
 		if strings.Contains(filepath.Clean(cwd), string(filepath.Separator)+".beads"+string(filepath.Separator)) ||


### PR DESCRIPTION
## Summary
- Fixes `bd init --reinit-local` printing "Mode: embedded" and creating a parasitic `.beads/embeddeddolt/` directory on server-mode stores
- Root cause: init determined mode entirely from CLI flags/env vars, ignoring persisted `dolt_mode` in metadata.json during reinit
- Fix: on reinit, load existing config from metadata.json and inherit server mode when the user didn't explicitly pass `--server`

Closes #3585

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (pre-existing `TestCloudAuthCLIRouting` failure unrelated)
- [x] No lint errors introduced
- [ ] Manual: reinit on server-mode store preserves mode and does not create `embeddeddolt/`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->