### PR TITLE
fix(linear): push bead labels to Linear on sync --push (GH#3753)

### DIFF
--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -706,6 +707,18 @@ func isLinearMilestoneIssue(issue *types.Issue) bool {
 // buildLinearPushHooks creates PushHooks for Linear-specific push behavior.
 func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectCreates bool) *tracker.PushHooks {
 	config := lt.MappingConfig()
+	var labelOnce sync.Once
+	var labelCache *linear.LabelCache
+	var labelCacheErr error
+	loadPushLabelCache := func() *linear.LabelCache {
+		labelOnce.Do(func() {
+			labelCache, labelCacheErr = linear.BuildLabelCacheFromTracker(ctx, lt)
+		})
+		if labelCacheErr != nil {
+			return nil
+		}
+		return labelCache
+	}
 	return &tracker.PushHooks{
 		FormatDescription: func(issue *types.Issue) string {
 			return linear.BuildLinearDescription(issue)
@@ -713,7 +726,7 @@ func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectC
 		ContentEqual: func(local *types.Issue, remote *tracker.TrackerIssue) bool {
 			remoteIssue, ok := remote.Raw.(*linear.Issue)
 			if ok && remoteIssue != nil {
-				return linear.PushFieldsEqual(local, remoteIssue, config)
+				return linear.PushFieldsEqual(local, remoteIssue, config, loadPushLabelCache())
 			}
 			remoteConv := lt.FieldMapper().IssueToBeads(remote)
 			if remoteConv == nil || remoteConv.Issue == nil {

--- a/cmd/bd/linear.go
+++ b/cmd/bd/linear.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -744,6 +745,18 @@ func isLinearMilestoneIssue(issue *types.Issue) bool {
 // buildLinearPushHooks creates PushHooks for Linear-specific push behavior.
 func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectCreates bool) *tracker.PushHooks {
 	config := lt.MappingConfig()
+	var labelOnce sync.Once
+	var labelCache *linear.LabelCache
+	var labelCacheErr error
+	loadPushLabelCache := func() *linear.LabelCache {
+		labelOnce.Do(func() {
+			labelCache, labelCacheErr = linear.BuildLabelCacheFromTracker(ctx, lt)
+		})
+		if labelCacheErr != nil {
+			return nil
+		}
+		return labelCache
+	}
 	return &tracker.PushHooks{
 		FormatDescription: func(issue *types.Issue) string {
 			return linear.BuildLinearDescription(issue)
@@ -751,7 +764,7 @@ func buildLinearPushHooks(ctx context.Context, lt *linear.Tracker, allowProjectC
 		ContentEqual: func(local *types.Issue, remote *tracker.TrackerIssue) bool {
 			remoteIssue, ok := remote.Raw.(*linear.Issue)
 			if ok && remoteIssue != nil {
-				return linear.PushFieldsEqual(local, remoteIssue, config)
+				return linear.PushFieldsEqual(local, remoteIssue, config, loadPushLabelCache())
 			}
 			remoteConv := lt.FieldMapper().IssueToBeads(remote)
 			if remoteConv == nil || remoteConv.Issue == nil {

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -602,6 +602,80 @@ func (c *Client) GetTeamStates(ctx context.Context) ([]State, error) {
 	return teamResp.Team.States.Nodes, nil
 }
 
+// GetTeamLabels returns all issue labels defined for the team (paginated).
+func (c *Client) GetTeamLabels(ctx context.Context) ([]Label, error) {
+	const pageSize = 250
+	query := `
+		query TeamLabels($teamId: String!, $first: Int!, $after: String) {
+			team(id: $teamId) {
+				labels(first: $first, after: $after) {
+					nodes {
+						id
+						name
+					}
+					pageInfo {
+						hasNextPage
+						endCursor
+					}
+				}
+			}
+		}
+	`
+
+	var all []Label
+	var after *string
+	for {
+		vars := map[string]interface{}{
+			"teamId": c.TeamID,
+			"first":  pageSize,
+			"after":  nil,
+		}
+		if after != nil {
+			vars["after"] = *after
+		}
+
+		req := &GraphQLRequest{
+			Query:     query,
+			Variables: vars,
+		}
+
+		data, err := c.Execute(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch team labels: %w", err)
+		}
+
+		var page struct {
+			Team struct {
+				Labels *struct {
+					Nodes    []Label `json:"nodes"`
+					PageInfo struct {
+						HasNextPage bool   `json:"hasNextPage"`
+						EndCursor   string `json:"endCursor"`
+					} `json:"pageInfo"`
+				} `json:"labels"`
+			} `json:"team"`
+		}
+		if err := json.Unmarshal(data, &page); err != nil {
+			return nil, fmt.Errorf("failed to parse team labels response: %w", err)
+		}
+		if page.Team.Labels == nil {
+			return nil, fmt.Errorf("no labels connection found for team")
+		}
+
+		all = append(all, page.Team.Labels.Nodes...)
+		if !page.Team.Labels.PageInfo.HasNextPage {
+			break
+		}
+		if page.Team.Labels.PageInfo.EndCursor == "" {
+			break
+		}
+		cursor := page.Team.Labels.PageInfo.EndCursor
+		after = &cursor
+	}
+
+	return all, nil
+}
+
 // FindIssueByDescriptionContains searches for an issue whose description
 // contains the given text. This powers idempotency dedup: we embed a
 // deterministic marker in the description and search for it before creating.

--- a/internal/linear/fieldmapper.go
+++ b/internal/linear/fieldmapper.go
@@ -7,7 +7,8 @@ import (
 
 // linearFieldMapper implements tracker.FieldMapper for Linear.
 type linearFieldMapper struct {
-	config *MappingConfig
+	config     *MappingConfig
+	labelCache *LabelCache // optional; when set, IssueToTracker includes labelIds
 }
 
 func (m *linearFieldMapper) PriorityToBeads(trackerPriority interface{}) int {
@@ -80,6 +81,11 @@ func (m *linearFieldMapper) IssueToTracker(issue *types.Issue) map[string]interf
 		"title":       issue.Title,
 		"description": issue.Description,
 		"priority":    PriorityToLinear(issue.Priority, m.config),
+	}
+	if m.labelCache != nil {
+		if ids, _ := ResolveLabelIDs(issue, m.labelCache, m.config); len(ids) > 0 {
+			updates["labelIds"] = ids
+		}
 	}
 	return updates
 }

--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -1,7 +1,10 @@
 package linear
 
 import (
+	"context"
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -416,10 +419,111 @@ func StatusToLinearStateType(status types.Status) string {
 	}
 }
 
+// LabelCache maps normalized Linear label names (lowercase) to Linear label IDs
+// for a single team.
+type LabelCache struct {
+	IDByLowerName map[string]string
+}
+
+// BuildLabelCache fetches team labels and indexes them by lowercase trimmed name.
+func BuildLabelCache(ctx context.Context, client *Client) (*LabelCache, error) {
+	if client == nil {
+		return nil, fmt.Errorf("no linear client")
+	}
+	labels, err := client.GetTeamLabels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c := &LabelCache{
+		IDByLowerName: make(map[string]string, len(labels)),
+	}
+	for _, lb := range labels {
+		k := strings.ToLower(strings.TrimSpace(lb.Name))
+		if k != "" && lb.ID != "" {
+			c.IDByLowerName[k] = lb.ID
+		}
+	}
+	return c, nil
+}
+
+// IssueTypeToLinearLabelLookupKey returns the label_type_map key (lowercase) for
+// the given beads issue type, inverting linear.label_type_map.<label>=<type>.
+// When multiple labels map to the same type, the smallest key lexicographically wins.
+func IssueTypeToLinearLabelLookupKey(issueType types.IssueType, config *MappingConfig) string {
+	if config == nil || len(config.LabelTypeMap) == 0 {
+		return ""
+	}
+	want := strings.ToLower(strings.TrimSpace(string(issueType)))
+	if want == "" {
+		return ""
+	}
+	var keys []string
+	for labelKey, typeStr := range config.LabelTypeMap {
+		if strings.ToLower(strings.TrimSpace(typeStr)) == want {
+			keys = append(keys, labelKey)
+		}
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+	return keys[0]
+}
+
+// ResolveLabelIDs maps beads issue_type (via inverted label_type_map) and
+// issue.Labels to Linear label UUIDs. Names not present on the team are returned
+// in missing (deduplicated by display string order of discovery).
+func ResolveLabelIDs(issue *types.Issue, cache *LabelCache, config *MappingConfig) (ids []string, missing []string) {
+	if issue == nil || cache == nil || len(cache.IDByLowerName) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{})
+
+	tryAdd := func(lowerName, display string) {
+		if lowerName == "" {
+			return
+		}
+		id, ok := cache.IDByLowerName[lowerName]
+		if !ok {
+			missing = append(missing, display)
+			return
+		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	if lk := IssueTypeToLinearLabelLookupKey(issue.IssueType, config); lk != "" {
+		tryAdd(lk, lk)
+	}
+	for _, raw := range issue.Labels {
+		ln := strings.ToLower(strings.TrimSpace(raw))
+		tryAdd(ln, raw)
+	}
+	return ids, missing
+}
+
+func linearIssueLabelIDs(remote *Issue) []string {
+	if remote == nil || remote.Labels == nil {
+		return nil
+	}
+	out := make([]string, 0, len(remote.Labels.Nodes))
+	for _, n := range remote.Labels.Nodes {
+		if n.ID != "" {
+			out = append(out, n.ID)
+		}
+	}
+	return out
+}
+
 // PushFieldsEqual compares only the fields that a Linear push can actually
 // mutate. This avoids repeated updates caused by local-only fields such as
-// issue type, metadata, or labels that are preserved elsewhere.
-func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) bool {
+// issue type and metadata. When labelCache is non-nil, resolved Linear label ID
+// sets are compared so label drift is detected; when nil, labels are ignored
+// (callers that can build a LabelCache should pass it for accurate skip logic).
+func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig, labelCache *LabelCache) bool {
 	if local == nil || remote == nil {
 		return false
 	}
@@ -432,7 +536,19 @@ func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) b
 	if PriorityToLinear(local.Priority, config) != remote.Priority {
 		return false
 	}
-	return StateToBeadsStatus(remote.State, config) == local.Status
+	if StateToBeadsStatus(remote.State, config) != local.Status {
+		return false
+	}
+	if labelCache != nil {
+		wantIDs, _ := ResolveLabelIDs(local, labelCache, config)
+		remoteIDs := linearIssueLabelIDs(remote)
+		slices.Sort(wantIDs)
+		slices.Sort(remoteIDs)
+		if !slices.Equal(wantIDs, remoteIDs) {
+			return false
+		}
+	}
+	return true
 }
 
 // PushFieldsEqualToBeads is a fallback comparator for cases where Linear's raw

--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -1,7 +1,10 @@
 package linear
 
 import (
+	"context"
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -470,10 +473,111 @@ func StatusToLinearStateType(status types.Status) string {
 	}
 }
 
+// LabelCache maps normalized Linear label names (lowercase) to Linear label IDs
+// for a single team.
+type LabelCache struct {
+	IDByLowerName map[string]string
+}
+
+// BuildLabelCache fetches team labels and indexes them by lowercase trimmed name.
+func BuildLabelCache(ctx context.Context, client *Client) (*LabelCache, error) {
+	if client == nil {
+		return nil, fmt.Errorf("no linear client")
+	}
+	labels, err := client.GetTeamLabels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c := &LabelCache{
+		IDByLowerName: make(map[string]string, len(labels)),
+	}
+	for _, lb := range labels {
+		k := strings.ToLower(strings.TrimSpace(lb.Name))
+		if k != "" && lb.ID != "" {
+			c.IDByLowerName[k] = lb.ID
+		}
+	}
+	return c, nil
+}
+
+// IssueTypeToLinearLabelLookupKey returns the label_type_map key (lowercase) for
+// the given beads issue type, inverting linear.label_type_map.<label>=<type>.
+// When multiple labels map to the same type, the smallest key lexicographically wins.
+func IssueTypeToLinearLabelLookupKey(issueType types.IssueType, config *MappingConfig) string {
+	if config == nil || len(config.LabelTypeMap) == 0 {
+		return ""
+	}
+	want := strings.ToLower(strings.TrimSpace(string(issueType)))
+	if want == "" {
+		return ""
+	}
+	var keys []string
+	for labelKey, typeStr := range config.LabelTypeMap {
+		if strings.ToLower(strings.TrimSpace(typeStr)) == want {
+			keys = append(keys, labelKey)
+		}
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+	return keys[0]
+}
+
+// ResolveLabelIDs maps beads issue_type (via inverted label_type_map) and
+// issue.Labels to Linear label UUIDs. Names not present on the team are returned
+// in missing (deduplicated by display string order of discovery).
+func ResolveLabelIDs(issue *types.Issue, cache *LabelCache, config *MappingConfig) (ids []string, missing []string) {
+	if issue == nil || cache == nil || len(cache.IDByLowerName) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{})
+
+	tryAdd := func(lowerName, display string) {
+		if lowerName == "" {
+			return
+		}
+		id, ok := cache.IDByLowerName[lowerName]
+		if !ok {
+			missing = append(missing, display)
+			return
+		}
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	if lk := IssueTypeToLinearLabelLookupKey(issue.IssueType, config); lk != "" {
+		tryAdd(lk, lk)
+	}
+	for _, raw := range issue.Labels {
+		ln := strings.ToLower(strings.TrimSpace(raw))
+		tryAdd(ln, raw)
+	}
+	return ids, missing
+}
+
+func linearIssueLabelIDs(remote *Issue) []string {
+	if remote == nil || remote.Labels == nil {
+		return nil
+	}
+	out := make([]string, 0, len(remote.Labels.Nodes))
+	for _, n := range remote.Labels.Nodes {
+		if n.ID != "" {
+			out = append(out, n.ID)
+		}
+	}
+	return out
+}
+
 // PushFieldsEqual compares only the fields that a Linear push can actually
 // mutate. This avoids repeated updates caused by local-only fields such as
-// issue type, metadata, or labels that are preserved elsewhere.
-func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) bool {
+// issue type and metadata. When labelCache is non-nil, resolved Linear label ID
+// sets are compared so label drift is detected; when nil, labels are ignored
+// (callers that can build a LabelCache should pass it for accurate skip logic).
+func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig, labelCache *LabelCache) bool {
 	if local == nil || remote == nil {
 		return false
 	}
@@ -486,7 +590,19 @@ func PushFieldsEqual(local *types.Issue, remote *Issue, config *MappingConfig) b
 	if PriorityToLinear(local.Priority, config) != remote.Priority {
 		return false
 	}
-	return StateToBeadsStatus(remote.State, config) == local.Status
+	if StateToBeadsStatus(remote.State, config) != local.Status {
+		return false
+	}
+	if labelCache != nil {
+		wantIDs, _ := ResolveLabelIDs(local, labelCache, config)
+		remoteIDs := linearIssueLabelIDs(remote)
+		slices.Sort(wantIDs)
+		slices.Sort(remoteIDs)
+		if !slices.Equal(wantIDs, remoteIDs) {
+			return false
+		}
+	}
+	return true
 }
 
 // PushFieldsEqualToBeads is a fallback comparator for cases where Linear's raw

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -1,6 +1,8 @@
 package linear
 
 import (
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -610,7 +612,7 @@ func TestLoadMappingConfig(t *testing.T) {
 	loader := &mockConfigLoader{
 		config: map[string]string{
 			"linear.priority_map.0":       "3",
-			"linear.state_map.custom":     "in_progress",
+			"linear.state_map.custom":   "in_progress",
 			"linear.label_type_map.story": "feature",
 			"linear.relation_map.parent":  "parent-child",
 		},
@@ -774,6 +776,76 @@ func TestResolveStateIDForBeadsStatusPrefersExplicitStateName(t *testing.T) {
 	}
 }
 
+func TestIssueTypeToLinearLabelLookupKeyDeterministic(t *testing.T) {
+	cfg := DefaultMappingConfig()
+	cfg.LabelTypeMap["enhancement"] = "feature"
+	cfg.LabelTypeMap["feature"] = "feature"
+	// Lexicographically smallest label key wins when multiple map to the same type.
+	if got := IssueTypeToLinearLabelLookupKey(types.TypeFeature, cfg); got != "enhancement" {
+		t.Fatalf("IssueTypeToLinearLabelLookupKey(feature) = %q, want enhancement", got)
+	}
+}
+
+func TestResolveLabelIDsDedupesAndReportsMissing(t *testing.T) {
+	cfg := DefaultMappingConfig()
+	cache := &LabelCache{
+		IDByLowerName: map[string]string{
+			"bug":         "id-bug",
+			"customer-x":  "id-cx",
+			"task":        "id-task",
+		},
+	}
+	issue := &types.Issue{
+		IssueType: types.TypeBug,
+		Labels:    []string{"Customer-X", "ghost"},
+	}
+	ids, missing := ResolveLabelIDs(issue, cache, cfg)
+	sort.Strings(ids)
+	want := []string{"id-bug", "id-cx"}
+	sort.Strings(want)
+	if !slices.Equal(ids, want) {
+		t.Fatalf("ResolveLabelIDs ids = %v, want %v", ids, want)
+	}
+	if len(missing) != 1 || missing[0] != "ghost" {
+		t.Fatalf("ResolveLabelIDs missing = %v, want [ghost]", missing)
+	}
+}
+
+func TestPushFieldsEqualComparesResolvedLabelIDs(t *testing.T) {
+	config := DefaultMappingConfig()
+	cache := &LabelCache{
+		IDByLowerName: map[string]string{
+			"task": "id-task",
+			"a":    "id-a",
+		},
+	}
+	local := &types.Issue{
+		Title:       "x",
+		Description: "d",
+		Status:      types.StatusOpen,
+		Priority:    0, // critical in beads → urgent in Linear (priority 1)
+		IssueType:   types.TypeTask,
+		Labels:      []string{"A"},
+	}
+	remote := &Issue{
+		Title:       "x",
+		Description: "d",
+		Priority:    4, // low in Linear — differs from beads P0 mapping
+		State:       &State{ID: "s", Name: "Backlog", Type: "backlog"},
+		Labels: &Labels{Nodes: []Label{
+			{ID: "id-task", Name: "task"},
+			{ID: "id-a", Name: "a"},
+		}},
+	}
+	if PushFieldsEqual(local, remote, config, cache) {
+		t.Fatal("expected false when Linear priority differs")
+	}
+	remote.Priority = PriorityToLinear(0, config)
+	if !PushFieldsEqual(local, remote, config, cache) {
+		t.Fatal("expected true when fields and resolved label ID sets match")
+	}
+}
+
 func TestPushFieldsEqualIgnoresLocalOnlyDifferences(t *testing.T) {
 	config := DefaultMappingConfig()
 	local := &types.Issue{
@@ -792,7 +864,7 @@ func TestPushFieldsEqualIgnoresLocalOnlyDifferences(t *testing.T) {
 		State:       &State{ID: "state-3", Name: "In Progress", Type: "started"},
 	}
 
-	if !PushFieldsEqual(local, remote, config) {
+	if !PushFieldsEqual(local, remote, config, nil) {
 		t.Fatal("expected push fields to compare equal despite local-only issue type and labels")
 	}
 }

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -1,6 +1,8 @@
 package linear
 
 import (
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -953,6 +955,76 @@ func TestResolveStateIDForBeadsStatusDeferredExplicitMapping(t *testing.T) {
 	}
 }
 
+func TestIssueTypeToLinearLabelLookupKeyDeterministic(t *testing.T) {
+	cfg := DefaultMappingConfig()
+	cfg.LabelTypeMap["enhancement"] = "feature"
+	cfg.LabelTypeMap["feature"] = "feature"
+	// Lexicographically smallest label key wins when multiple map to the same type.
+	if got := IssueTypeToLinearLabelLookupKey(types.TypeFeature, cfg); got != "enhancement" {
+		t.Fatalf("IssueTypeToLinearLabelLookupKey(feature) = %q, want enhancement", got)
+	}
+}
+
+func TestResolveLabelIDsDedupesAndReportsMissing(t *testing.T) {
+	cfg := DefaultMappingConfig()
+	cache := &LabelCache{
+		IDByLowerName: map[string]string{
+			"bug":        "id-bug",
+			"customer-x": "id-cx",
+			"task":       "id-task",
+		},
+	}
+	issue := &types.Issue{
+		IssueType: types.TypeBug,
+		Labels:    []string{"Customer-X", "ghost"},
+	}
+	ids, missing := ResolveLabelIDs(issue, cache, cfg)
+	sort.Strings(ids)
+	want := []string{"id-bug", "id-cx"}
+	sort.Strings(want)
+	if !slices.Equal(ids, want) {
+		t.Fatalf("ResolveLabelIDs ids = %v, want %v", ids, want)
+	}
+	if len(missing) != 1 || missing[0] != "ghost" {
+		t.Fatalf("ResolveLabelIDs missing = %v, want [ghost]", missing)
+	}
+}
+
+func TestPushFieldsEqualComparesResolvedLabelIDs(t *testing.T) {
+	config := DefaultMappingConfig()
+	cache := &LabelCache{
+		IDByLowerName: map[string]string{
+			"task": "id-task",
+			"a":    "id-a",
+		},
+	}
+	local := &types.Issue{
+		Title:       "x",
+		Description: "d",
+		Status:      types.StatusOpen,
+		Priority:    0, // critical in beads → urgent in Linear (priority 1)
+		IssueType:   types.TypeTask,
+		Labels:      []string{"A"},
+	}
+	remote := &Issue{
+		Title:       "x",
+		Description: "d",
+		Priority:    4, // low in Linear — differs from beads P0 mapping
+		State:       &State{ID: "s", Name: "Backlog", Type: "backlog"},
+		Labels: &Labels{Nodes: []Label{
+			{ID: "id-task", Name: "task"},
+			{ID: "id-a", Name: "a"},
+		}},
+	}
+	if PushFieldsEqual(local, remote, config, cache) {
+		t.Fatal("expected false when Linear priority differs")
+	}
+	remote.Priority = PriorityToLinear(0, config)
+	if !PushFieldsEqual(local, remote, config, cache) {
+		t.Fatal("expected true when fields and resolved label ID sets match")
+	}
+}
+
 func TestPushFieldsEqualIgnoresLocalOnlyDifferences(t *testing.T) {
 	config := DefaultMappingConfig()
 	local := &types.Issue{
@@ -971,7 +1043,7 @@ func TestPushFieldsEqualIgnoresLocalOnlyDifferences(t *testing.T) {
 		State:       &State{ID: "state-3", Name: "In Progress", Type: "started"},
 	}
 
-	if !PushFieldsEqual(local, remote, config) {
+	if !PushFieldsEqual(local, remote, config, nil) {
 		t.Fatal("expected push fields to compare equal despite local-only issue type and labels")
 	}
 }

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -195,6 +195,15 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 		return nil, fmt.Errorf("finding state for status %s: %w", issue.Status, err)
 	}
 
+	labelCache, err := BuildLabelCache(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("loading team labels: %w", err)
+	}
+	labelIDs, unknown := ResolveLabelIDs(issue, labelCache, t.config)
+	for _, name := range unknown {
+		fmt.Fprintf(os.Stderr, "linear: bead %s: label %q not found on Linear team (skipped)\n", issue.ID, name)
+	}
+
 	// Use issue.Description as-is: the sync engine's FormatDescription hook
 	// (BuildLinearDescription) has already merged AcceptanceCriteria/Design/Notes
 	// into the description before calling CreateIssue. Calling BuildLinearDescription
@@ -207,7 +216,7 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 	// write-back.
 	if issue.ID != "" && issue.CreatedBy != "" {
 		marker := GenerateIdempotencyMarker(issue.ID, issue.CreatedBy, issue.CreatedAt.UnixNano())
-		created, deduped, err := client.CreateIssueIdempotent(ctx, issue.Title, description, priority, stateID, nil, marker)
+		created, deduped, err := client.CreateIssueIdempotent(ctx, issue.Title, description, priority, stateID, labelIDs, marker)
 		if err != nil {
 			return nil, err
 		}
@@ -218,7 +227,7 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 		return &ti, nil
 	}
 
-	created, err := client.CreateIssue(ctx, issue.Title, description, priority, stateID, nil)
+	created, err := client.CreateIssue(ctx, issue.Title, description, priority, stateID, labelIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +243,15 @@ func (t *Tracker) UpdateIssue(ctx context.Context, externalID string, issue *typ
 		return nil, fmt.Errorf("cannot determine Linear team for issue %s", externalID)
 	}
 
-	mapper := t.FieldMapper()
+	labelCache, err := BuildLabelCache(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("loading team labels: %w", err)
+	}
+	_, unknown := ResolveLabelIDs(issue, labelCache, t.config)
+	for _, name := range unknown {
+		fmt.Fprintf(os.Stderr, "linear: bead %s: label %q not found on Linear team (skipped)\n", issue.ID, name)
+	}
+	mapper := &linearFieldMapper{config: t.config, labelCache: labelCache}
 	updates := mapper.IssueToTracker(issue)
 
 	// Resolve and include state so status changes are pushed to Linear.
@@ -295,6 +312,23 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 		return nil, fmt.Errorf("building state cache: no cache for primary team %s", t.teamIDs[0])
 	}
 
+	teamLabelCaches := make(map[string]*LabelCache, len(t.teamIDs))
+	for _, teamID := range t.teamIDs {
+		teamClient := t.clients[teamID]
+		if teamClient == nil {
+			continue
+		}
+		lc, err := BuildLabelCache(ctx, teamClient)
+		if err != nil {
+			return nil, fmt.Errorf("building label cache for team %s: %w", teamID, err)
+		}
+		teamLabelCaches[teamID] = lc
+	}
+	primaryLabelCache := teamLabelCaches[t.teamIDs[0]]
+	if primaryLabelCache == nil {
+		return nil, fmt.Errorf("building label cache: no cache for primary team %s", t.teamIDs[0])
+	}
+
 	result := &tracker.BatchPushResult{}
 
 	var toCreate []*types.Issue
@@ -344,7 +378,12 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			}
 
 			marker := GenerateIdempotencyMarker(issue.ID, issue.CreatedBy, issue.CreatedAt.UnixNano())
-			var labelIDs []string
+			labelIDs, unknown := ResolveLabelIDs(issue, primaryLabelCache, t.config)
+			for _, name := range unknown {
+				msg := fmt.Sprintf("linear: bead %s: label %q not found on Linear team (skipped)", issue.ID, name)
+				fmt.Fprintf(os.Stderr, "%s\n", msg)
+				result.Warnings = append(result.Warnings, msg)
+			}
 			created, _, createErr := client.CreateIssueIdempotent(ctx, issue.Title, issue.Description, priority, stateID, labelIDs, marker)
 			if createErr != nil {
 				result.Errors = append(result.Errors, tracker.BatchPushError{
@@ -376,12 +415,20 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			marker := GenerateIdempotencyMarker(issue.ID, issue.CreatedBy, issue.CreatedAt.UnixNano())
 			desc := AppendIdempotencyMarker(issue.Description, marker)
 
+			labelIDs, unknown := ResolveLabelIDs(issue, primaryLabelCache, t.config)
+			for _, name := range unknown {
+				msg := fmt.Sprintf("linear: bead %s: label %q not found on Linear team (skipped)", issue.ID, name)
+				fmt.Fprintf(os.Stderr, "%s\n", msg)
+				result.Warnings = append(result.Warnings, msg)
+			}
+
 			input := IssueCreateInput{
 				TeamID:      client.TeamID,
 				Title:       issue.Title,
 				Description: desc,
 				Priority:    priority,
 				StateID:     stateID,
+				LabelIDs:    labelIDs,
 			}
 			if client.ProjectID != "" {
 				input.ProjectID = client.ProjectID
@@ -443,6 +490,11 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			teamCache = primaryCache // defensive fallback
 		}
 
+		teamLabelCache := primaryLabelCache
+		if lc, ok := teamLabelCaches[routeClient.TeamID]; ok && lc != nil {
+			teamLabelCache = lc
+		}
+
 		// Skip issues that haven't changed since the last push, unless forced.
 		// This mirrors the ContentEqual / UpdatedAt skip logic in the single-issue
 		// push path (engine.go doPush) to avoid redundant API writes.
@@ -451,14 +503,14 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			fetched, lookupErr := routeClient.FetchIssueByIdentifier(ctx, externalID)
 			if lookupErr == nil && fetched != nil {
 				remoteIssue = fetched
-				if PushFieldsEqual(issue, remoteIssue, t.config) {
+				if PushFieldsEqual(issue, remoteIssue, t.config, teamLabelCache) {
 					result.Skipped = append(result.Skipped, issue.ID)
 					continue
 				}
 			}
 		}
 
-		mapper := t.FieldMapper()
+		mapper := &linearFieldMapper{config: t.config, labelCache: teamLabelCache}
 		updates := mapper.IssueToTracker(issue)
 
 		stateID, stateErr := ResolveStateIDForBeadsStatus(teamCache, issue.Status, t.config)
@@ -703,6 +755,16 @@ func BuildStateCacheFromTracker(ctx context.Context, t *Tracker) (*StateCache, e
 		return nil, fmt.Errorf("Linear tracker not initialized")
 	}
 	return BuildStateCache(ctx, client)
+}
+
+// BuildLabelCacheFromTracker builds a LabelCache using the tracker's primary client.
+// This allows CLI push hooks to compare label sets without reaching into the client.
+func BuildLabelCacheFromTracker(ctx context.Context, t *Tracker) (*LabelCache, error) {
+	client := t.primaryClient()
+	if client == nil {
+		return nil, fmt.Errorf("Linear tracker not initialized")
+	}
+	return BuildLabelCache(ctx, client)
 }
 
 // configLoaderAdapter wraps storage.Storage to implement linear.ConfigLoader.

--- a/internal/linear/tracker.go
+++ b/internal/linear/tracker.go
@@ -195,6 +195,15 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 		return nil, fmt.Errorf("finding state for status %s: %w", issue.Status, err)
 	}
 
+	labelCache, err := BuildLabelCache(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("loading team labels: %w", err)
+	}
+	labelIDs, unknown := ResolveLabelIDs(issue, labelCache, t.config)
+	for _, name := range unknown {
+		fmt.Fprintf(os.Stderr, "linear: bead %s: label %q not found on Linear team (skipped)\n", issue.ID, name)
+	}
+
 	// Use issue.Description as-is: the sync engine's FormatDescription hook
 	// (BuildLinearDescription) has already merged AcceptanceCriteria/Design/Notes
 	// into the description before calling CreateIssue. Calling BuildLinearDescription
@@ -207,7 +216,7 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 	// write-back.
 	if issue.ID != "" && issue.CreatedBy != "" {
 		marker := GenerateIdempotencyMarker(issue.ID, issue.CreatedBy, issue.CreatedAt.UnixNano())
-		created, deduped, err := client.CreateIssueIdempotent(ctx, issue.Title, description, priority, stateID, nil, marker)
+		created, deduped, err := client.CreateIssueIdempotent(ctx, issue.Title, description, priority, stateID, labelIDs, marker)
 		if err != nil {
 			return nil, err
 		}
@@ -218,7 +227,7 @@ func (t *Tracker) CreateIssue(ctx context.Context, issue *types.Issue) (*tracker
 		return &ti, nil
 	}
 
-	created, err := client.CreateIssue(ctx, issue.Title, description, priority, stateID, nil)
+	created, err := client.CreateIssue(ctx, issue.Title, description, priority, stateID, labelIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +243,15 @@ func (t *Tracker) UpdateIssue(ctx context.Context, externalID string, issue *typ
 		return nil, fmt.Errorf("cannot determine Linear team for issue %s", externalID)
 	}
 
-	mapper := t.FieldMapper()
+	labelCache, err := BuildLabelCache(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("loading team labels: %w", err)
+	}
+	_, unknown := ResolveLabelIDs(issue, labelCache, t.config)
+	for _, name := range unknown {
+		fmt.Fprintf(os.Stderr, "linear: bead %s: label %q not found on Linear team (skipped)\n", issue.ID, name)
+	}
+	mapper := &linearFieldMapper{config: t.config, labelCache: labelCache}
 	updates := mapper.IssueToTracker(issue)
 
 	// Resolve and include state so status changes are pushed to Linear.
@@ -295,6 +312,23 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 		return nil, fmt.Errorf("building state cache: no cache for primary team %s", t.teamIDs[0])
 	}
 
+	teamLabelCaches := make(map[string]*LabelCache, len(t.teamIDs))
+	for _, teamID := range t.teamIDs {
+		teamClient := t.clients[teamID]
+		if teamClient == nil {
+			continue
+		}
+		lc, err := BuildLabelCache(ctx, teamClient)
+		if err != nil {
+			return nil, fmt.Errorf("building label cache for team %s: %w", teamID, err)
+		}
+		teamLabelCaches[teamID] = lc
+	}
+	primaryLabelCache := teamLabelCaches[t.teamIDs[0]]
+	if primaryLabelCache == nil {
+		return nil, fmt.Errorf("building label cache: no cache for primary team %s", t.teamIDs[0])
+	}
+
 	result := &tracker.BatchPushResult{}
 
 	var toCreate []*types.Issue
@@ -344,7 +378,12 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			}
 
 			marker := GenerateIdempotencyMarker(issue.ID, issue.CreatedBy, issue.CreatedAt.UnixNano())
-			var labelIDs []string
+			labelIDs, unknown := ResolveLabelIDs(issue, primaryLabelCache, t.config)
+			for _, name := range unknown {
+				msg := fmt.Sprintf("linear: bead %s: label %q not found on Linear team (skipped)", issue.ID, name)
+				fmt.Fprintf(os.Stderr, "%s\n", msg)
+				result.Warnings = append(result.Warnings, msg)
+			}
 			created, _, createErr := client.CreateIssueIdempotent(ctx, issue.Title, issue.Description, priority, stateID, labelIDs, marker)
 			if createErr != nil {
 				result.Errors = append(result.Errors, tracker.BatchPushError{
@@ -376,12 +415,20 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			marker := GenerateIdempotencyMarker(issue.ID, issue.CreatedBy, issue.CreatedAt.UnixNano())
 			desc := AppendIdempotencyMarker(issue.Description, marker)
 
+			labelIDs, unknown := ResolveLabelIDs(issue, primaryLabelCache, t.config)
+			for _, name := range unknown {
+				msg := fmt.Sprintf("linear: bead %s: label %q not found on Linear team (skipped)", issue.ID, name)
+				fmt.Fprintf(os.Stderr, "%s\n", msg)
+				result.Warnings = append(result.Warnings, msg)
+			}
+
 			input := IssueCreateInput{
 				TeamID:      client.TeamID,
 				Title:       issue.Title,
 				Description: desc,
 				Priority:    priority,
 				StateID:     stateID,
+				LabelIDs:    labelIDs,
 			}
 			if client.ProjectID != "" {
 				input.ProjectID = client.ProjectID
@@ -443,6 +490,11 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			teamCache = primaryCache // defensive fallback
 		}
 
+		teamLabelCache := primaryLabelCache
+		if lc, ok := teamLabelCaches[routeClient.TeamID]; ok && lc != nil {
+			teamLabelCache = lc
+		}
+
 		// Skip issues that haven't changed since the last push, unless forced.
 		// This mirrors the ContentEqual / UpdatedAt skip logic in the single-issue
 		// push path (engine.go doPush) to avoid redundant API writes.
@@ -451,14 +503,14 @@ func (t *Tracker) BatchPush(ctx context.Context, issues []*types.Issue, forceIDs
 			fetched, lookupErr := routeClient.FetchIssueByIdentifier(ctx, externalID)
 			if lookupErr == nil && fetched != nil {
 				remoteIssue = fetched
-				if PushFieldsEqual(issue, remoteIssue, t.config) {
+				if PushFieldsEqual(issue, remoteIssue, t.config, teamLabelCache) {
 					result.Skipped = append(result.Skipped, issue.ID)
 					continue
 				}
 			}
 		}
 
-		mapper := t.FieldMapper()
+		mapper := &linearFieldMapper{config: t.config, labelCache: teamLabelCache}
 		updates := mapper.IssueToTracker(issue)
 
 		stateID, stateErr := ResolveStateIDForBeadsStatus(teamCache, issue.Status, t.config)
@@ -734,6 +786,16 @@ func BuildStateCacheFromTracker(ctx context.Context, t *Tracker) (*StateCache, e
 		return nil, fmt.Errorf("Linear tracker not initialized")
 	}
 	return BuildStateCache(ctx, client)
+}
+
+// BuildLabelCacheFromTracker builds a LabelCache using the tracker's primary client.
+// This allows CLI push hooks to compare label sets without reaching into the client.
+func BuildLabelCacheFromTracker(ctx context.Context, t *Tracker) (*LabelCache, error) {
+	client := t.primaryClient()
+	if client == nil {
+		return nil, fmt.Errorf("Linear tracker not initialized")
+	}
+	return BuildLabelCache(ctx, client)
 }
 
 // configLoaderAdapter wraps storage.Storage to implement linear.ConfigLoader.

--- a/internal/linear/tracker_test.go
+++ b/internal/linear/tracker_test.go
@@ -35,6 +35,24 @@ func teamStatesResp(teamID, stateID, stateName, stateType string) map[string]int
 	}
 }
 
+// teamLabelsEmptyResp builds a paginated TeamLabels GraphQL response with no labels.
+func teamLabelsEmptyResp(teamID string) map[string]interface{} {
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"team": map[string]interface{}{
+				"id": teamID,
+				"labels": map[string]interface{}{
+					"nodes": []interface{}{},
+					"pageInfo": map[string]interface{}{
+						"hasNextPage": false,
+						"endCursor":   "",
+					},
+				},
+			},
+		},
+	}
+}
+
 // issueByIdentifierResp builds the JSON body for an IssueByIdentifier GraphQL response.
 func issueByIdentifierResp(id, identifier, title, description string, priority int, stateID, stateName, stateType string) map[string]interface{} {
 	return map[string]interface{}{
@@ -78,6 +96,8 @@ func TestBatchPush_SkipsUnchangedIssue(t *testing.T) {
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "IssueByIdentifier"):
 			// Remote issue has the same title, empty description, priority 0 (no
 			// priority), and "backlog" state — matching the local issue exactly.
@@ -150,6 +170,8 @@ func TestBatchPush_ForceBypassesSkip(t *testing.T) {
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "IssueByIdentifier"):
 			// Return the same content as local (would be skipped without force).
 			json.NewEncoder(w).Encode(issueByIdentifierResp(
@@ -217,6 +239,8 @@ func TestBatchPush_BatchCreateMappingByTitle(t *testing.T) {
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "issueBatchCreate"):
 			// Return the two issues in REVERSE order to expose index-based mapping bugs.
 			json.NewEncoder(w).Encode(map[string]interface{}{
@@ -306,6 +330,8 @@ func TestBatchPush_PerTeamStateCache(t *testing.T) {
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-2", "t2-state-open", "Ready", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-2"))
 		case strings.Contains(req.Query, "IssueByIdentifier"):
 			// Return the issue with DIFFERENT title so PushFieldsEqual = false and we proceed.
 			json.NewEncoder(w).Encode(issueByIdentifierResp(
@@ -340,6 +366,8 @@ func TestBatchPush_PerTeamStateCache(t *testing.T) {
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "t1-state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "IssueByIdentifier"):
 			// Team-1 does not own this issue; return an empty result.
 			json.NewEncoder(w).Encode(map[string]interface{}{
@@ -403,6 +431,8 @@ func TestBatchPush_DuplicateTitlesFallbackToSingleCreate(t *testing.T) {
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "FindByDescription"):
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"data": map[string]interface{}{
@@ -509,6 +539,8 @@ func TestBatchPush_AmbiguousBatchFailureSearchesMarkers(t *testing.T) {
 		switch {
 		case strings.Contains(req.Query, "TeamStates"):
 			json.NewEncoder(w).Encode(teamStatesResp("team-1", "state-open", "Backlog", "backlog"))
+		case strings.Contains(req.Query, "TeamLabels"):
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 		case strings.Contains(req.Query, "issueBatchCreate"):
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"data": map[string]interface{}{
@@ -901,7 +933,7 @@ func TestCreateIssueNoDoubleFormatDescription(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 
-		if strings.Contains(req.Query, "TeamStates") || strings.Contains(req.Query, "team(") {
+		if strings.Contains(req.Query, "TeamStates") {
 			json.NewEncoder(w).Encode(map[string]interface{}{
 				"data": map[string]interface{}{
 					"team": map[string]interface{}{
@@ -914,6 +946,11 @@ func TestCreateIssueNoDoubleFormatDescription(t *testing.T) {
 					},
 				},
 			})
+			return
+		}
+
+		if strings.Contains(req.Query, "TeamLabels") {
+			json.NewEncoder(w).Encode(teamLabelsEmptyResp("team-1"))
 			return
 		}
 


### PR DESCRIPTION
## Summary
- Fetch team labels via new `Client.GetTeamLabels` (paginated) and build a per-team `LabelCache` during `BatchPush` / single-issue push paths.
- Invert `linear.label_type_map` on push with `IssueTypeToLinearLabelLookupKey` so `issue_type` maps to a Linear label name, then resolve to UUIDs.
- Merge `issue.Labels` into the same resolved `labelIds` set (deduped); unknown names log to stderr and append to batch `Warnings` without blocking.
- `IssueToTracker` / creates / updates send `labelIds`; `PushFieldsEqual` accepts an optional `LabelCache` so skip logic notices label drift. `buildLinearPushHooks` loads the primary team label cache once per process for `ContentEqual`.

## Tests
- `go test ./internal/linear/...`
- New: `TestIssueTypeToLinearLabelLookupKeyDeterministic`, `TestResolveLabelIDsDedupesAndReportsMissing`, `TestPushFieldsEqualComparesResolvedLabelIDs`.

Closes #3753

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->