### PR TITLE
fix(template): persist labels in cloneSubgraph (GH#3784)

### DIFF
--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -618,6 +618,16 @@ func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *Templat
 				return fmt.Errorf("failed to create issue from %s: %w", oldIssue.ID, err)
 			}
 
+			// Persist labels separately - tx.CreateIssue does not handle the
+			// Labels field (storage keeps labels in a separate table). Without
+			// this, labels on the in-memory subgraph (e.g. the gate:<await>
+			// label cook generates from waits_for) silently vanish on pour.
+			for _, label := range oldIssue.Labels {
+				if err := tx.AddLabel(ctx, newIssue.ID, label, opts.Actor); err != nil {
+					return fmt.Errorf("failed to add label %q to %s: %w", label, newIssue.ID, err)
+				}
+			}
+
 			idMapping[oldIssue.ID] = newIssue.ID
 		}
 

--- a/cmd/bd/template_test.go
+++ b/cmd/bd/template_test.go
@@ -435,6 +435,50 @@ func TestTemplateSuite(t *testing.T) {
 		}
 	})
 
+	t.Run("Clone_PersistsInMemoryLabels", func(t *testing.T) {
+		// The fresh-cook pour path (cmd/bd/cook.go:463) calls collectSteps
+		// with labelHandler=nil, which leaves labels on issue.Labels rather
+		// than persisting them via a separate channel. cloneSubgraph must
+		// pick those labels up and call AddLabel for each, otherwise labels
+		// generated at cook time (e.g. the gate:<await> label from waits_for)
+		// silently vanish on pour. Regression test for #3784.
+		epic := &types.Issue{
+			ID:        "proto-clone-labels",
+			Title:     "Proto with labels",
+			IssueType: types.TypeEpic,
+			Status:    types.StatusOpen,
+			Priority:  2,
+			Labels:    []string{"gate:all-children", "custom-label"},
+		}
+		subgraph := &TemplateSubgraph{
+			Root:     epic,
+			Issues:   []*types.Issue{epic},
+			IssueMap: map[string]*types.Issue{epic.ID: epic},
+		}
+
+		opts := CloneOptions{Actor: "test-user"}
+		result, err := cloneSubgraph(ctx, s, subgraph, opts)
+		if err != nil {
+			t.Fatalf("cloneSubgraph failed: %v", err)
+		}
+
+		gotLabels, err := s.GetLabels(ctx, result.NewEpicID)
+		if err != nil {
+			t.Fatalf("GetLabels failed: %v", err)
+		}
+
+		want := map[string]bool{"gate:all-children": true, "custom-label": true}
+		got := make(map[string]bool, len(gotLabels))
+		for _, l := range gotLabels {
+			got[l] = true
+		}
+		for label := range want {
+			if !got[label] {
+				t.Errorf("cloned issue %s missing label %q (got: %v)", result.NewEpicID, label, gotLabels)
+			}
+		}
+	})
+
 	t.Run("Clone_AssigneeOverrideRootOnly", func(t *testing.T) {
 		epic := h.createIssue("Root Epic", "", types.TypeEpic, 1)
 		child := h.createIssue("Child Task", "", types.TypeTask, 2)


### PR DESCRIPTION
## What

In `cloneSubgraph`, persist `oldIssue.Labels` via `tx.AddLabel` after `tx.CreateIssue`, so step labels actually reach storage on pour.

## Why

Fixes #3784. `tx.CreateIssue` does not persist the `Labels` field — storage keeps labels in a separate table. `cloneSubgraph` was copying `oldIssue.Labels` onto the new issue but never calling `AddLabel`, so any labels on the in-memory subgraph silently vanished. The most user-visible casualty was the `gate:<await>` label that cook generates from `waits_for` (`cmd/bd/cook.go:569-572`): present on the cooked step, absent on the poured step. Affects every label on the pour-from-fresh-cook path, not just `gate:`.

## Verification

```
go test -tags 'gms_pure_go cgo' -run 'TestTemplateSuite/Clone_PersistsInMemoryLabels' ./cmd/bd/
```

End-to-end repro from #3784:

```toml
formula = "test-waits-for"
version = 1
type = "workflow"

[[steps]]
id = "wait-step"
title = "Wait for children"
type = "task"
waits_for = "all-children"
```

```
$ bd mol pour test-waits-for
$ bd label list <step-id>
gate:all-children     # was empty before this change
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->