### PR TITLE
fix(cli): initialize store in human respond/dismiss commands

### DIFF
--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -191,6 +191,11 @@ Examples:
 		ctx := rootCtx
 		issueID := args[0]
 
+		// Direct mode
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("responding to human bead: %v", err)
+		}
+
 		// Resolve partial ID and get issue
 		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)
 		if err != nil {
@@ -262,6 +267,11 @@ Examples:
 
 		ctx := rootCtx
 		issueID := args[0]
+
+		// Direct mode
+		if err := ensureStoreActive(); err != nil {
+			FatalErrorRespectJSON("dismissing human bead: %v", err)
+		}
 
 		// Resolve partial ID and get issue
 		result, err := resolveAndGetIssueWithRouting(ctx, store, issueID)

--- a/cmd/bd/human_embedded_test.go
+++ b/cmd/bd/human_embedded_test.go
@@ -65,28 +65,14 @@ func TestEmbeddedHuman(t *testing.T) {
 
 	t.Run("human_respond_and_dismiss", func(t *testing.T) {
 		// Create a bead
-		cmd := exec.Command(bd, "create", "Human test issue", "--type", "task")
+		cmd := exec.Command(bd, "create", "Human test issue", "--type", "task", "--silent")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("create failed: %v\n%s", err, out)
 		}
-
-		// Extract ID (e.g., "th-a3f2")
-		lines := strings.Split(string(out), "\n")
-		var id string
-		for _, line := range lines {
-			if strings.Contains(line, "Created issue:") {
-				parts := strings.Fields(line)
-				for i, p := range parts {
-					if p == "issue:" && i+1 < len(parts) {
-						id = parts[i+1]
-						break
-					}
-				}
-			}
-		}
+		id := strings.TrimSpace(string(out))
 		if id == "" {
 			t.Fatalf("could not find issue ID in output: %s", out)
 		}
@@ -112,33 +98,33 @@ func TestEmbeddedHuman(t *testing.T) {
 		cmd = exec.Command(bd, "show", id)
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		showOut, _ := cmd.CombinedOutput()
+		showOut, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("show failed: %v\n%s", err, showOut)
+		}
 		if !strings.Contains(string(showOut), "CLOSED") {
 			t.Errorf("expected issue %s to be closed after respond:\n%s", id, showOut)
 		}
 
 		// Create another for Dismiss
-		cmd = exec.Command(bd, "create", "Dismiss test issue")
+		cmd = exec.Command(bd, "create", "Dismiss test issue", "--silent")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		out, _ = cmd.CombinedOutput()
-		id2 := ""
-		for _, line := range strings.Split(string(out), "\n") {
-			if strings.Contains(line, "Created issue:") {
-				parts := strings.Fields(line)
-				for i, p := range parts {
-					if p == "issue:" && i+1 < len(parts) {
-						id2 = parts[i+1]
-						break
-					}
-				}
-			}
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("create failed: %v\n%s", err, out)
+		}
+		id2 := strings.TrimSpace(string(out))
+		if id2 == "" {
+			t.Fatalf("could not find issue ID in output: %s", out)
 		}
 
 		cmd = exec.Command(bd, "label", "add", id2, "human")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		_, _ = cmd.CombinedOutput()
+		if out, err = cmd.CombinedOutput(); err != nil {
+			t.Fatalf("label add failed: %v\n%s", err, out)
+		}
 
 		// Test Dismiss
 		bdHuman(t, bd, dir, "dismiss", id2, "--reason", "Not needed")
@@ -147,7 +133,10 @@ func TestEmbeddedHuman(t *testing.T) {
 		cmd = exec.Command(bd, "show", id2)
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		showOut2, _ := cmd.CombinedOutput()
+		showOut2, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("show failed: %v\n%s", err, showOut2)
+		}
 		if !strings.Contains(string(showOut2), "CLOSED") {
 			t.Errorf("expected issue %s to be closed after dismiss:\n%s", id2, showOut2)
 		}

--- a/cmd/bd/human_embedded_test.go
+++ b/cmd/bd/human_embedded_test.go
@@ -60,6 +60,101 @@ func TestEmbeddedHuman(t *testing.T) {
 			t.Error("expected non-empty stats output")
 		}
 	})
+
+	// ===== Respond and Dismiss =====
+
+	t.Run("human_respond_and_dismiss", func(t *testing.T) {
+		// Create a bead
+		cmd := exec.Command(bd, "create", "Human test issue", "--type", "task")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("create failed: %v\n%s", err, out)
+		}
+
+		// Extract ID (e.g., "th-a3f2")
+		lines := strings.Split(string(out), "\n")
+		var id string
+		for _, line := range lines {
+			if strings.Contains(line, "Created issue:") {
+				parts := strings.Fields(line)
+				for i, p := range parts {
+					if p == "issue:" && i+1 < len(parts) {
+						id = parts[i+1]
+						break
+					}
+				}
+			}
+		}
+		if id == "" {
+			t.Fatalf("could not find issue ID in output: %s", out)
+		}
+
+		// Humanize it
+		cmd = exec.Command(bd, "label", "add", id, "human")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("label add failed: %v\n%s", err, out)
+		}
+
+		// Verify it shows up in human list
+		listOut := bdHuman(t, bd, dir, "list")
+		if !strings.Contains(listOut, id) {
+			t.Errorf("expected issue %s in human list output:\n%s", id, listOut)
+		}
+
+		// Test Respond
+		bdHuman(t, bd, dir, "respond", id, "--response", "Approved")
+
+		// Verify closed
+		cmd = exec.Command(bd, "show", id)
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		showOut, _ := cmd.CombinedOutput()
+		if !strings.Contains(string(showOut), "CLOSED") {
+			t.Errorf("expected issue %s to be closed after respond:\n%s", id, showOut)
+		}
+
+		// Create another for Dismiss
+		cmd = exec.Command(bd, "create", "Dismiss test issue")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		out, _ = cmd.CombinedOutput()
+		id2 := ""
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.Contains(line, "Created issue:") {
+				parts := strings.Fields(line)
+				for i, p := range parts {
+					if p == "issue:" && i+1 < len(parts) {
+						id2 = parts[i+1]
+						break
+					}
+				}
+			}
+		}
+
+		cmd = exec.Command(bd, "label", "add", id2, "human")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		_, _ = cmd.CombinedOutput()
+
+		// Test Dismiss
+		bdHuman(t, bd, dir, "dismiss", id2, "--reason", "Not needed")
+
+		// Verify closed
+		cmd = exec.Command(bd, "show", id2)
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		showOut2, _ := cmd.CombinedOutput()
+		if !strings.Contains(string(showOut2), "CLOSED") {
+			t.Errorf("expected issue %s to be closed after dismiss:\n%s", id2, showOut2)
+		}
+		if !strings.Contains(string(showOut2), "Dismissed: Not needed") {
+			t.Errorf("expected dismiss reason in output:\n%s", showOut2)
+		}
+	})
 }
 
 // TestEmbeddedHumanConcurrent exercises human operations concurrently.


### PR DESCRIPTION
## Problem

`bd human respond` and `bd human dismiss` were listed in `noDbCommands`, which bypasses the automatic store initialization in `PersistentPreRunE`. Neither subcommand called `ensureStoreActive()` manually, so any invocation hit a `storage is nil` panic before doing any real work.

## Fix

Added a `// Direct mode` `ensureStoreActive()` call at the top of each subcommand's `RunE` — the same pattern used by `list`, `close`, `dep`, and other commands that opt out of auto-init.

## Tests

Added `human_respond_and_dismiss` to `human_embedded_test.go`:
- Creates a human-labeled issue using `bd create --silent` for reliable ID extraction
- Exercises `bd human respond` and verifies the issue closes
- Creates a second issue, exercises `bd human dismiss --reason`, and verifies both the closed status and the reason string in output
- All setup steps (`label add`, `bd show`) check errors and fatalf with context so failures point to the right place

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->