### PR TITLE
fix(jira): use UTC suffix in JQL updated timestamp filter

### DIFF
--- a/internal/jira/tracker.go
+++ b/internal/jira/tracker.go
@@ -165,7 +165,7 @@ func (t *Tracker) FetchIssues(ctx context.Context, opts tracker.FetchOptions) ([
 
 	// Incremental sync
 	if opts.Since != nil {
-		jql += fmt.Sprintf(" AND updated >= %q", opts.Since.Format("2006-01-02 15:04"))
+		jql += fmt.Sprintf(` AND updated >= "%s"`, opts.Since.UTC().Format("2006-01-02 15:04 UTC"))
 	}
 
 	jql += " ORDER BY updated DESC"


### PR DESCRIPTION
Fixes #3788

## Problem

When `bd jira sync --pull` runs an incremental sync, it appends a JQL clause like:

```
AND updated >= "2026-05-07 12:00"
```

The timestamp is taken from the stored `last_sync` value (which is UTC), but formatted **without a timezone specifier**. Per Atlassian's JQL docs, a bare datetime string is interpreted in the **user's Jira profile timezone**. For users behind UTC (e.g. US Eastern = UTC-4), this shifts the cutoff ~4 hours into the future, causing every recent issue to be excluded and the pull to silently return nothing.

## Fix

One-line change in `internal/jira/tracker.go`:

```go
// Before
jql += fmt.Sprintf(" AND updated >= %q", opts.Since.Format("2006-01-02 15:04"))

// After
jql += fmt.Sprintf(` AND updated >= "%s"`, opts.Since.UTC().Format("2006-01-02 15:04 UTC"))
```

Calling `.UTC()` ensures the value is always in UTC, and appending `' UTC'` is the explicit timezone form that Jira JQL accepts, so the cutoff is evaluated correctly for all users regardless of their profile timezone.

## Testing

Verified manually against Jira Cloud with a US Eastern profile timezone:
- Before fix: incremental pull returned 0 results despite recently-updated issues
- After fix: incremental pull correctly returned all issues updated since `last_sync`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->