### PR TITLE
add doltserver store (storage.DoltStorage)

### DIFF
--- a/cmd/bd/db_proxy_child.go
+++ b/cmd/bd/db_proxy_child.go
@@ -80,7 +80,7 @@ not intended to be invoked directly by users.`,
 func newDatabaseServer(backend proxy.Backend, rootDir, configPath, logPath, doltBin string) (server.DatabaseServer, error) {
 	switch backend {
 	case proxy.BackendLocalServer:
-		return server.NewDoltServer(doltBin, rootDir, configPath, logPath, "root", "", 0)
+		return server.NewDoltServer(doltBin, rootDir, configPath, logPath, 0)
 	case proxy.BackendExternal, proxy.BackendLocalSharedServer:
 		return nil, fmt.Errorf("backend %q: not yet implemented", backend)
 	}

--- a/internal/storage/db/pidfile/pidfile.go
+++ b/internal/storage/db/pidfile/pidfile.go
@@ -1,4 +1,4 @@
-package proxy
+package pidfile
 
 import (
 	"encoding/json"
@@ -10,19 +10,17 @@ import (
 	"github.com/steveyegge/beads/internal/atomicfile"
 )
 
-const pidFileName = "proxy.pid"
-
 type PidFile struct {
 	Pid  int `json:"pid"`
 	Port int `json:"port"`
 }
 
-func pidFilePath(rootDir string) string {
-	return filepath.Join(rootDir, pidFileName)
+func Path(rootDir, name string) string {
+	return filepath.Join(rootDir, name)
 }
 
-func ReadDatabaseProxyPidFile(rootDir string) (*PidFile, error) {
-	data, err := os.ReadFile(pidFilePath(rootDir))
+func Read(rootDir, name string) (*PidFile, error) {
+	data, err := os.ReadFile(Path(rootDir, name))
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
@@ -36,16 +34,16 @@ func ReadDatabaseProxyPidFile(rootDir string) (*PidFile, error) {
 	return &pf, nil
 }
 
-func WriteDatabaseProxyPidFile(rootDir string, pf PidFile) error {
+func Write(rootDir, name string, pf PidFile) error {
 	data, err := json.Marshal(pf)
 	if err != nil {
 		return err
 	}
-	return atomicfile.WriteFile(pidFilePath(rootDir), data, 0o644)
+	return atomicfile.WriteFile(Path(rootDir, name), data, 0o644)
 }
 
-func RemoveDatabaseProxyPidFile(rootDir string) error {
-	err := os.Remove(pidFilePath(rootDir))
+func Remove(rootDir, name string) error {
+	err := os.Remove(Path(rootDir, name))
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}

--- a/internal/storage/db/proxy/endpoint.go
+++ b/internal/storage/db/proxy/endpoint.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage/db/pidfile"
+	"github.com/steveyegge/beads/internal/storage/db/server"
 	"github.com/steveyegge/beads/internal/storage/db/util"
 )
 
@@ -113,6 +114,13 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 	// Stale pidfile from a previous (now-dead) proxy must not mislead racing
 	// readers into dialing a port that nobody is listening on.
 	_ = pidfile.Remove(rootDir, PIDFileName)
+
+	if pf, err := pidfile.Read(rootDir, server.PIDFileName); err == nil && pf != nil {
+		if proc, perr := os.FindProcess(pf.Pid); perr == nil {
+			_ = proc.Kill()
+		}
+		_ = pidfile.Remove(rootDir, server.PIDFileName)
+	}
 
 	port, err := PickFreePort()
 	if err != nil {

--- a/internal/storage/db/proxy/endpoint.go
+++ b/internal/storage/db/proxy/endpoint.go
@@ -115,11 +115,19 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 	// readers into dialing a port that nobody is listening on.
 	_ = pidfile.Remove(rootDir, PIDFileName)
 
-	if pf, err := pidfile.Read(rootDir, server.PIDFileName); err == nil && pf != nil {
-		if proc, perr := os.FindProcess(pf.Pid); perr == nil {
-			_ = proc.Kill()
+	// Probe the proxy-child flock: if held, a previous proxy-child is still
+	// alive and has an orphaned dolt sql-server we must kill before
+	// respawning. If we can acquire it, no proxy-child is running — release
+	// immediately so the child we are about to spawn can take it.
+	if l, err := util.TryLock(filepath.Join(rootDir, server.LockFileName)); err == nil {
+		l.Unlock()
+	} else if lockfile.IsLocked(err) {
+		if pf, perr := pidfile.Read(rootDir, server.PIDFileName); perr == nil && pf != nil {
+			if proc, ferr := os.FindProcess(pf.Pid); ferr == nil {
+				_ = proc.Kill()
+			}
+			_ = pidfile.Remove(rootDir, server.PIDFileName)
 		}
-		_ = pidfile.Remove(rootDir, server.PIDFileName)
 	}
 
 	port, err := PickFreePort()

--- a/internal/storage/db/proxy/endpoint.go
+++ b/internal/storage/db/proxy/endpoint.go
@@ -38,6 +38,12 @@ const (
 	openPollInterval      = 100 * time.Millisecond
 )
 
+// ResolveExecutable returns the path of the binary the proxy should fork as
+// the child. Defaults to os.Executable. Tests may swap it (e.g. to point at
+// a freshly-built `bd`) so the proxy forks a real `bd` rather than the go
+// test binary, which would not understand the `db-proxy-child` subcommand.
+var ResolveExecutable = os.Executable
+
 func PickFreePort() (int, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -154,7 +160,7 @@ func forkExecChild(rootDir, configFilePath, logFilePath, doltBinPath string, por
 		}
 	}()
 
-	self, err := os.Executable()
+	self, err := ResolveExecutable()
 	if err != nil {
 		return nil, nil, fmt.Errorf("locate bd executable: %w", err)
 	}

--- a/internal/storage/db/proxy/endpoint.go
+++ b/internal/storage/db/proxy/endpoint.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage/db/pidfile"
 	"github.com/steveyegge/beads/internal/storage/db/util"
 )
 
@@ -38,10 +39,6 @@ const (
 	openPollInterval      = 100 * time.Millisecond
 )
 
-// ResolveExecutable returns the path of the binary the proxy should fork as
-// the child. Defaults to os.Executable. Tests may swap it (e.g. to point at
-// a freshly-built `bd`) so the proxy forks a real `bd` rather than the go
-// test binary, which would not understand the `db-proxy-child` subcommand.
 var ResolveExecutable = os.Executable
 
 func PickFreePort() (int, error) {
@@ -115,7 +112,7 @@ func spawnAndHandoff(rootDir string, opts OpenOpts, deadline time.Time, lock *ut
 
 	// Stale pidfile from a previous (now-dead) proxy must not mislead racing
 	// readers into dialing a port that nobody is listening on.
-	_ = RemoveDatabaseProxyPidFile(rootDir)
+	_ = pidfile.Remove(rootDir, PIDFileName)
 
 	port, err := PickFreePort()
 	if err != nil {
@@ -216,7 +213,7 @@ func forkExecChild(rootDir, configFilePath, logFilePath, doltBinPath string, por
 }
 
 func readAndDial(rootDir string) (Endpoint, bool) {
-	pf, err := ReadDatabaseProxyPidFile(rootDir)
+	pf, err := pidfile.Read(rootDir, PIDFileName)
 	if err != nil || pf == nil {
 		return Endpoint{}, false
 	}

--- a/internal/storage/db/proxy/server.go
+++ b/internal/storage/db/proxy/server.go
@@ -44,7 +44,7 @@ type proxyServer struct {
 
 const (
 	serverReadyTimeout     = 30 * time.Second
-	readyPingTimeout       = 2 * time.Second
+	readyDialTimeout       = 2 * time.Second
 	readyInitialBackoff    = 50 * time.Millisecond
 	readyMaxBackoff        = 1 * time.Second
 	idleWatcherMinInterval = 1 * time.Second
@@ -263,8 +263,13 @@ func waitForServerReady(ctx context.Context, s server.DatabaseServer, timeout ti
 		if !s.Running(ctx) {
 			return errors.New("database server not running")
 		}
-		pingCtx, cancel := context.WithTimeout(ctx, readyPingTimeout)
+		dialCtx, cancel := context.WithTimeout(ctx, readyDialTimeout)
 		defer cancel()
-		return s.Ping(pingCtx)
+		conn, err := s.Dial(dialCtx)
+		if err != nil {
+			return err
+		}
+		_ = conn.Close()
+		return nil
 	}, backoff.WithContext(bo, ctx))
 }

--- a/internal/storage/db/proxy/server.go
+++ b/internal/storage/db/proxy/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/steveyegge/beads/internal/storage/db/pidfile"
 	"github.com/steveyegge/beads/internal/storage/db/server"
 )
 
@@ -41,6 +42,8 @@ type proxyServer struct {
 	activeConns atomic.Int64
 	conns       errgroup.Group
 }
+
+const PIDFileName = "proxy.pid"
 
 const (
 	serverReadyTimeout     = 30 * time.Second
@@ -109,12 +112,12 @@ func (p *proxyServer) Start(parentCtx context.Context) error {
 		return fmt.Errorf("database server not ready: %w", err)
 	}
 
-	if err := WriteDatabaseProxyPidFile(p.rootDir, PidFile{Pid: os.Getpid(), Port: p.port}); err != nil {
+	if err := pidfile.Write(p.rootDir, PIDFileName, pidfile.PidFile{Pid: os.Getpid(), Port: p.port}); err != nil {
 		p.stats.IncBackendStop()
 		_ = stopBackendBounded(p.server)
 		return fmt.Errorf("write pid file: %w", err)
 	}
-	defer func() { _ = RemoveDatabaseProxyPidFile(p.rootDir) }()
+	defer func() { _ = pidfile.Remove(p.rootDir, PIDFileName) }()
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
@@ -137,11 +140,6 @@ func (p *proxyServer) Start(parentCtx context.Context) error {
 	return runErr
 }
 
-// stopBackendBounded calls server.Stop with a fresh, time-bounded context.
-// We use Background here (not the parent ctx) because by the time Stop
-// runs, the parent ctx is typically already canceled — a backend that
-// honors ctx would bail immediately and skip its cleanup. The bound
-// protects against backends that ignore ctx entirely.
 func stopBackendBounded(s server.DatabaseServer) error {
 	ctx, cancel := context.WithTimeout(context.Background(), backendStopTimeout)
 	defer cancel()

--- a/internal/storage/db/proxy/server_test.go
+++ b/internal/storage/db/proxy/server_test.go
@@ -170,9 +170,9 @@ func TestProxy_HappyPath_Echo(t *testing.T) {
 
 	bs := ts.Snapshot()
 	assert.Equal(t, int64(1), bs.StartCalls)
-	assert.GreaterOrEqual(t, bs.PingCalls, int64(1))
-	assert.Equal(t, int64(1), bs.DialCalls)
-	assert.Equal(t, int64(1), bs.AcceptedConns)
+	// readiness Dial + client Dial both go through the backend
+	assert.Equal(t, int64(2), bs.DialCalls)
+	assert.Equal(t, int64(2), bs.AcceptedConns)
 	assert.Equal(t, int64(5), bs.BytesIn)
 	assert.Equal(t, int64(5), bs.BytesOut)
 	assert.Equal(t, int64(1), bs.StopCalls)
@@ -260,7 +260,7 @@ func TestProxy_BackendNotReady_CtxCancel(t *testing.T) {
 	t.Parallel()
 
 	ts := server.New()
-	ts.PingErr = errors.New("not ready")
+	ts.DialErr = errors.New("not ready")
 	stats := &proxy.Stats{}
 	port := freeTCPPort(t)
 	root := t.TempDir()
@@ -268,11 +268,11 @@ func TestProxy_BackendNotReady_CtxCancel(t *testing.T) {
 	h := runProxy(t, proxy.ProxyOpts{
 		RootDir: root, Port: port, Server: ts, Stats: stats,
 	})
-	// The pidfile is written only after readiness succeeds, but PingErr
+	// The pidfile is written only after readiness succeeds, but DialErr
 	// keeps readiness failing — so waitListening would hang. Wait until
-	// the proxy is in the readiness loop (>=1 Ping attempt observed).
+	// the proxy is in the readiness loop (>=1 Dial attempt observed).
 	require.Eventually(t, func() bool {
-		return ts.Snapshot().PingCalls >= 1
+		return ts.Snapshot().DialCalls >= 1
 	}, listenWait, 10*time.Millisecond)
 	h.Cancel()
 	err := h.waitErr(t, shutdownWait)
@@ -286,7 +286,7 @@ func TestProxy_BackendNotReady_CtxCancel(t *testing.T) {
 
 	bs := ts.Snapshot()
 	assert.Equal(t, int64(1), bs.StartCalls)
-	assert.GreaterOrEqual(t, bs.PingCalls, int64(1))
+	assert.GreaterOrEqual(t, bs.DialCalls, int64(1))
 	assert.Equal(t, int64(1), bs.StopCalls)
 
 	assertNoPidFile(t, root)
@@ -296,7 +296,6 @@ func TestProxy_BackendDialError(t *testing.T) {
 	t.Parallel()
 
 	ts := server.New()
-	ts.DialErr = errors.New("refused")
 	stats := &proxy.Stats{}
 	port := freeTCPPort(t)
 	root := t.TempDir()
@@ -304,7 +303,10 @@ func TestProxy_BackendDialError(t *testing.T) {
 	h := runProxy(t, proxy.ProxyOpts{
 		RootDir: root, Port: port, Server: ts, Stats: stats,
 	})
+	// Wait for readiness Dial to succeed, then flip DialErr so subsequent
+	// proxied connections fail.
 	waitListening(t, root, listenWait)
+	ts.SetDialErr(errors.New("refused"))
 
 	for i := 0; i < 2; i++ {
 		c := dialProxy(t, port)
@@ -456,7 +458,8 @@ func TestProxy_ConcurrentConnections(t *testing.T) {
 	assert.Equal(t, int64(N*payloadLen), s.BytesClientToBackend)
 	assert.Equal(t, int64(N*payloadLen), s.BytesBackendToClient)
 
-	assert.Equal(t, int64(N), ts.Snapshot().AcceptedConns)
+	// readiness Dial counts as one extra AcceptedConn against the backend
+	assert.Equal(t, int64(N+1), ts.Snapshot().AcceptedConns)
 
 	h.Cancel()
 	require.NoError(t, h.waitErr(t, shutdownWait))

--- a/internal/storage/db/proxy/server_test.go
+++ b/internal/storage/db/proxy/server_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage/db/pidfile"
 	"github.com/steveyegge/beads/internal/storage/db/proxy"
 	"github.com/steveyegge/beads/internal/storage/db/server"
 	"github.com/stretchr/testify/assert"
@@ -85,16 +86,11 @@ func runProxy(t *testing.T, opts proxy.ProxyOpts) *proxyHandle {
 	return h
 }
 
-// waitListening polls for the pidfile, which proxyServer.Start writes
-// immediately after binding the listener (and before starting the backend or
-// the accept loop). We can't use a TCP probe here: the kernel queues the
-// connection until accept loop runs, and the proxy then accounts for it,
-// inflating the test's expected counters by one.
 func waitListening(t *testing.T, root string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		pf, err := proxy.ReadDatabaseProxyPidFile(root)
+		pf, err := pidfile.Read(root, proxy.PIDFileName)
 		if err == nil && pf != nil {
 			return
 		}
@@ -105,7 +101,7 @@ func waitListening(t *testing.T, root string, timeout time.Duration) {
 
 func assertNoPidFile(t *testing.T, root string) {
 	t.Helper()
-	pf, err := proxy.ReadDatabaseProxyPidFile(root)
+	pf, err := pidfile.Read(root, proxy.PIDFileName)
 	require.NoError(t, err)
 	assert.Nil(t, pf)
 }
@@ -117,8 +113,6 @@ func dialProxy(t *testing.T, port int) net.Conn {
 	require.NoError(t, c.SetDeadline(time.Now().Add(ioTimeout)))
 	return c
 }
-
-// ---------------------------------------------------------------------------
 
 func TestProxy_HappyPath_Echo(t *testing.T) {
 	t.Parallel()
@@ -144,8 +138,7 @@ func TestProxy_HappyPath_Echo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "hello", string(buf))
 
-	// Pidfile is in place while proxy is running.
-	pf, err := proxy.ReadDatabaseProxyPidFile(root)
+	pf, err := pidfile.Read(root, proxy.PIDFileName)
 	require.NoError(t, err)
 	require.NotNil(t, pf)
 	assert.Equal(t, os.Getpid(), pf.Pid)
@@ -192,7 +185,7 @@ func TestProxy_PidFile_WrittenAndRemoved(t *testing.T) {
 	})
 	waitListening(t, root, listenWait)
 
-	pf, err := proxy.ReadDatabaseProxyPidFile(root)
+	pf, err := pidfile.Read(root, proxy.PIDFileName)
 	require.NoError(t, err)
 	require.NotNil(t, pf)
 	assert.Equal(t, os.Getpid(), pf.Pid)

--- a/internal/storage/db/proxy/shutdown.go
+++ b/internal/storage/db/proxy/shutdown.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage/db/pidfile"
+	"github.com/steveyegge/beads/internal/storage/db/server"
+	"github.com/steveyegge/beads/internal/storage/db/util"
+)
+
+const (
+	shutdownConfirmDeadline = 5 * time.Second
+	shutdownConfirmPoll     = 50 * time.Millisecond
+)
+
+// Shutdown forcibly terminates the proxy and its child dolt sql-server for the
+// given rootDir. Intended for test cleanup: guarantees no proxy or dolt
+// sql-server process is left running against rootDir when this returns nil.
+//
+// For each (lock, pid) pair — proxy-child first, then proxy — it tries to
+// acquire the flock. If the flock is held, it reads the pidfile, sends SIGKILL
+// to the recorded PID, then polls the flock until it can be acquired (the OS
+// releases flocks on process exit). The pidfile is removed on success.
+func Shutdown(rootDir string) error {
+	if err := shutdownPair(rootDir, server.LockFileName, server.PIDFileName); err != nil {
+		return fmt.Errorf("proxy.Shutdown: dolt sql-server: %w", err)
+	}
+	if err := shutdownPair(rootDir, lockFileName, PIDFileName); err != nil {
+		return fmt.Errorf("proxy.Shutdown: proxy: %w", err)
+	}
+	return nil
+}
+
+func shutdownPair(rootDir, lockName, pidName string) error {
+	lockPath := filepath.Join(rootDir, lockName)
+
+	if l, err := util.TryLock(lockPath); err == nil {
+		l.Unlock()
+		_ = pidfile.Remove(rootDir, pidName)
+		return nil
+	} else if !lockfile.IsLocked(err) {
+		return fmt.Errorf("probe %s: %w", lockName, err)
+	}
+
+	if pf, err := pidfile.Read(rootDir, pidName); err == nil && pf != nil {
+		if proc, ferr := os.FindProcess(pf.Pid); ferr == nil {
+			_ = proc.Kill()
+		}
+	}
+
+	deadline := time.Now().Add(shutdownConfirmDeadline)
+	for {
+		l, err := util.TryLock(lockPath)
+		if err == nil {
+			l.Unlock()
+			_ = pidfile.Remove(rootDir, pidName)
+			return nil
+		}
+		if !lockfile.IsLocked(err) {
+			return fmt.Errorf("reacquire %s: %w", lockName, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout (%s) confirming death of process holding %s", shutdownConfirmDeadline, lockName)
+		}
+		time.Sleep(shutdownConfirmPoll)
+	}
+}

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -30,6 +30,12 @@ const (
 	LockFileName = "proxy-child.lock"
 )
 
+const (
+	startReadyTimeout      = 30 * time.Second
+	startReadyPollInterval = 50 * time.Millisecond
+	startReadyDialTimeout  = 250 * time.Millisecond
+)
+
 type DoltServer struct {
 	id              string
 	doltBinExec     string
@@ -268,9 +274,43 @@ func (s *DoltServer) Start(ctx context.Context) error {
 		return cmd.Wait()
 	})
 
-	// give server time to come up
-	time.Sleep(200 * time.Millisecond)
+	if err := s.waitReady(ctx); err != nil {
+		cancel()
+		_ = s.eg.Wait()
+		s.eg, s.egCtx, s.cancel, s.pid = nil, nil, nil, 0
+		_ = pidfile.Remove(s.rootDir, PIDFileName)
+		return fmt.Errorf("server: DoltServer.Start: %w", err)
+	}
 	return nil
+}
+
+func (s *DoltServer) waitReady(ctx context.Context) error {
+	deadline := time.Now().Add(startReadyTimeout)
+	for {
+		if s.egCtx.Err() != nil {
+			return errors.New("dolt sql-server exited before listener became ready")
+		}
+
+		dctx, dcancel := context.WithTimeout(ctx, startReadyDialTimeout)
+		conn, err := s.Dial(dctx)
+		dcancel()
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("listener not ready after %s: %w", startReadyTimeout, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.egCtx.Done():
+			return errors.New("dolt sql-server exited before listener became ready")
+		case <-time.After(startReadyPollInterval):
+		}
+	}
 }
 
 func (s *DoltServer) Stop(_ context.Context) error {

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -25,7 +25,10 @@ import (
 
 const defaultKeepAlivePeriod = 30 * time.Second
 
-const PIDFileName = "proxy-child.pid"
+const (
+	PIDFileName  = "proxy-child.pid"
+	LockFileName = "proxy-child.lock"
+)
 
 type DoltServer struct {
 	id              string
@@ -203,11 +206,18 @@ func (s *DoltServer) Start(ctx context.Context) error {
 		return fmt.Errorf("server: DoltServer.Start: server already started")
 	}
 
+	lock, err := util.TryLock(filepath.Join(s.rootDir, LockFileName))
+	if err != nil {
+		return fmt.Errorf("server: DoltServer.Start: acquire %s: %w", LockFileName, err)
+	}
+
 	if err := s.doltConfigure(ctx); err != nil {
+		lock.Unlock()
 		return err
 	}
 
 	if err := s.doltInitWithRetries(ctx); err != nil {
+		lock.Unlock()
 		return err
 	}
 
@@ -235,6 +245,7 @@ func (s *DoltServer) Start(ctx context.Context) error {
 	if err := cmd.Start(); err != nil {
 		s.eg, s.egCtx, s.cancel = nil, nil, nil
 		cancel()
+		lock.Unlock()
 		return fmt.Errorf("server: DoltServer.Start: spawn dolt: %w", err)
 	}
 
@@ -248,10 +259,12 @@ func (s *DoltServer) Start(ctx context.Context) error {
 		_, _ = cmd.Process.Wait()
 		s.eg, s.egCtx, s.cancel, s.pid = nil, nil, nil, 0
 		cancel()
+		lock.Unlock()
 		return fmt.Errorf("server: DoltServer.Start: write pidfile: %w", err)
 	}
 
 	eg.Go(func() error {
+		defer lock.Unlock()
 		return cmd.Wait()
 	})
 

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -19,10 +19,13 @@ import (
 	"github.com/dolthub/dolt/go/libraries/utils/filesys"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/steveyegge/beads/internal/storage/db/pidfile"
 	"github.com/steveyegge/beads/internal/storage/db/util"
 )
 
 const defaultKeepAlivePeriod = 30 * time.Second
+
+const PIDFileName = "proxy-child.pid"
 
 type DoltServer struct {
 	id              string
@@ -36,6 +39,7 @@ type DoltServer struct {
 	eg      *errgroup.Group
 	egCtx   context.Context
 	cancel  context.CancelFunc
+	pid     int
 }
 
 var _ DatabaseServer = (*DoltServer)(nil)
@@ -228,8 +232,27 @@ func (s *DoltServer) Start(ctx context.Context) error {
 
 	cmd.Env = os.Environ()
 
+	if err := cmd.Start(); err != nil {
+		s.eg, s.egCtx, s.cancel = nil, nil, nil
+		cancel()
+		return fmt.Errorf("server: DoltServer.Start: spawn dolt: %w", err)
+	}
+
+	s.pid = cmd.Process.Pid
+
+	if err := pidfile.Write(s.rootDir, PIDFileName, pidfile.PidFile{
+		Pid:  s.pid,
+		Port: s.config.Port(),
+	}); err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		s.eg, s.egCtx, s.cancel, s.pid = nil, nil, nil, 0
+		cancel()
+		return fmt.Errorf("server: DoltServer.Start: write pidfile: %w", err)
+	}
+
 	eg.Go(func() error {
-		return cmd.Run()
+		return cmd.Wait()
 	})
 
 	// give server time to come up
@@ -254,11 +277,19 @@ func (s *DoltServer) Stop(_ context.Context) error {
 		closeErr = s.logFile.Close()
 		s.logFile = nil
 	}
+	var rmErr error
+	if s.pid != 0 {
+		rmErr = pidfile.Remove(s.rootDir, PIDFileName)
+		s.pid = 0
+	}
 	if waitErr != nil {
 		return fmt.Errorf("server: DoltServer.Stop: %w", waitErr)
 	}
 	if closeErr != nil {
 		return fmt.Errorf("server: DoltServer.Stop: close log: %w", closeErr)
+	}
+	if rmErr != nil {
+		return fmt.Errorf("server: DoltServer.Stop: remove pidfile: %w", rmErr)
 	}
 	return nil
 }

--- a/internal/storage/db/server/doltserver.go
+++ b/internal/storage/db/server/doltserver.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -31,8 +30,6 @@ type DoltServer struct {
 	rootDir         string
 	configPath      string
 	config          servercfg.ServerConfig
-	user            string
-	password        string
 	keepAlivePeriod time.Duration
 
 	logFile *os.File
@@ -43,7 +40,7 @@ type DoltServer struct {
 
 var _ DatabaseServer = (*DoltServer)(nil)
 
-func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath, user, password string, keepAlivePeriod time.Duration) (*DoltServer, error) {
+func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath string, keepAlivePeriod time.Duration) (*DoltServer, error) {
 	if doltBinExec == "" {
 		return nil, errors.New("server: NewDoltServer: doltBinExec is required")
 	}
@@ -52,9 +49,6 @@ func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath, user, password
 	}
 	if configPath == "" {
 		return nil, errors.New("server: NewDoltServer: configPath is required")
-	}
-	if user == "" {
-		return nil, errors.New("server: NewDoltServer: user is required")
 	}
 	absDoltBinExec, err := filepath.Abs(doltBinExec)
 	if err != nil {
@@ -93,8 +87,6 @@ func NewDoltServer(doltBinExec, rootDir, configPath, logFilePath, user, password
 		rootDir:         absRootDir,
 		configPath:      absConfigPath,
 		config:          cfg,
-		user:            user,
-		password:        password,
 		keepAlivePeriod: keepAlivePeriod,
 		logFile:         logFile,
 	}, nil
@@ -276,18 +268,6 @@ func (s *DoltServer) Running(_ context.Context) bool {
 		return false
 	}
 	return s.egCtx.Err() == nil
-}
-
-func (s *DoltServer) Ping(ctx context.Context) error {
-	db, err := sql.Open("mysql", s.DSN(ctx, "", s.user, s.password))
-	if err != nil {
-		return fmt.Errorf("server: DoltServer.Ping: open: %w", err)
-	}
-	defer db.Close()
-	if err := db.PingContext(ctx); err != nil {
-		return fmt.Errorf("server: DoltServer.Ping: %w", err)
-	}
-	return nil
 }
 
 func (s *DoltServer) Dial(ctx context.Context) (net.Conn, error) {

--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -22,11 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	pingPollInterval = 100 * time.Millisecond
-	pingPollTimeout  = 10 * time.Second
-	stopTimeout      = 15 * time.Second
-)
+const stopTimeout = 15 * time.Second
 
 func requireDolt(t *testing.T) string {
 	t.Helper()
@@ -77,20 +73,6 @@ func stopWithTimeout(t *testing.T, s *server.DoltServer) {
 	ctx, cancel := context.WithTimeout(context.Background(), stopTimeout)
 	defer cancel()
 	require.NoError(t, s.Stop(ctx))
-}
-
-// waitReady polls Dial until the listener accepts. Proves the server's
-// socket is up but does not authenticate a SQL session.
-func waitReady(t *testing.T, s *server.DoltServer) {
-	t.Helper()
-	require.Eventually(t, func() bool {
-		conn, err := s.Dial(context.Background())
-		if err != nil {
-			return false
-		}
-		_ = conn.Close()
-		return true
-	}, pingPollTimeout, pingPollInterval, "server never became ready")
 }
 
 func TestNewDoltServer_Validation(t *testing.T) {
@@ -176,7 +158,6 @@ func TestDoltServer_StartStop_HappyPath(t *testing.T) {
 
 	require.NoError(t, s.Start(ctx))
 	t.Cleanup(func() { stopWithTimeout(t, s) })
-	waitReady(t, s)
 	assert.True(t, s.Running(ctx))
 
 	db, err := sql.Open("mysql", s.DSN(ctx, "", "root", ""))
@@ -230,7 +211,6 @@ listener:
 	ctx := context.Background()
 	require.NoError(t, s.Start(ctx))
 	t.Cleanup(func() { stopWithTimeout(t, s) })
-	waitReady(t, s)
 	assert.True(t, s.Running(ctx))
 
 	// DSN must select the unix transport when a socket is configured.
@@ -293,7 +273,6 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, 0)
 	require.NoError(t, err)
 	require.NoError(t, s1.Start(ctx))
-	waitReady(t, s1)
 	require.NoError(t, s1.Stop(ctx))
 
 	// Fresh port to dodge any TIME_WAIT lingering on the old one.
@@ -303,7 +282,6 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 	require.NoError(t, err)
 	require.NoError(t, s2.Start(ctx), "new instance at same rootDir must start")
 	t.Cleanup(func() { stopWithTimeout(t, s2) })
-	waitReady(t, s2)
 	assert.True(t, s2.Running(ctx))
 
 	// ID is rootDir-derived and therefore stable across instances.
@@ -315,7 +293,6 @@ func TestDoltServer_Dial_AfterStart(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, s.Start(ctx))
 	t.Cleanup(func() { stopWithTimeout(t, s) })
-	waitReady(t, s)
 
 	conn, err := s.Dial(ctx)
 	require.NoError(t, err)
@@ -359,7 +336,6 @@ func TestDoltServer_LogFile_CapturesOutput(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, s.Start(ctx))
 	t.Cleanup(func() { stopWithTimeout(t, s) })
-	waitReady(t, s)
 	require.NoError(t, s.Stop(ctx))
 
 	info, err := os.Stat(logPath)
@@ -474,5 +450,4 @@ func TestDoltServer_DoltInit_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, s.Start(ctx), "Start against pre-initialized rootDir should succeed")
 	t.Cleanup(func() { stopWithTimeout(t, s) })
-	waitReady(t, s)
 }

--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -1,13 +1,9 @@
 package server_test
 
-// doltserver_test.go covers the DoltServer lifecycle. Most tests start a real
-// `dolt sql-server` subprocess; those skip when `dolt` is not on PATH.
-// Validation tests (constructor argument checks, ID stability, DSN building)
-// run unconditionally.
-
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -20,6 +16,7 @@ import (
 	"time"
 
 	mysqldrv "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage/db/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,9 +50,6 @@ func writeConfig(t *testing.T, port int) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	// dolt deprecated user/password in sql-server YAML (it now creates
-	// root@localhost as the superuser regardless). DoltServer takes
-	// credentials via NewDoltServer instead.
 	body := fmt.Sprintf(`log_level: debug
 listener:
   host: 127.0.0.1
@@ -405,12 +399,6 @@ func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
 	require.NoError(t, exec.Command(bin, "config", "--global", "--add", "user.email", "beads@test").Run())
 
 	rootDir := t.TempDir()
-	// Pre-init disabled — let the 10 concurrent Starts race through
-	// doltInit themselves.
-	// initCmd := exec.Command(bin, "init")
-	// initCmd.Dir = rootDir
-	// initOut, err := initCmd.CombinedOutput()
-	// require.NoError(t, err, "manual dolt init failed: %s", initOut)
 
 	const n = 10
 	servers := make([]*server.DoltServer, n)
@@ -431,10 +419,6 @@ func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
 		}
 	})
 
-	// Fire all Starts concurrently. Start currently returns nil even if
-	// the spawned sql-server later dies (the 200ms sleep returns before
-	// cmd.Run reports failure), so the test checks Running()/Ping() to
-	// determine the actual winner.
 	var wg sync.WaitGroup
 	startErrs := make([]error, n)
 	for i := 0; i < n; i++ {
@@ -445,42 +429,23 @@ func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+
+	winner := -1
+	losers := 0
 	for i, err := range startErrs {
-		require.NoError(t, err, "server %d Start returned err", i)
-	}
-
-	// Wait for the losers' subprocesses to exit. A loser is a DoltServer
-	// whose dolt sql-server child failed to acquire the rootDir lock and
-	// exited non-zero — that cancels its egCtx and flips Running() to
-	// false. The fight can take a moment to settle, so poll.
-	tally := func() (winners, losers int) {
-		for _, s := range servers {
-			if s.Running(context.Background()) {
-				winners++
-			} else {
-				losers++
-			}
+		if err == nil {
+			require.Equal(t, -1, winner, "more than one Start succeeded (server %d and %d)", winner, i)
+			winner = i
+			continue
 		}
-		return winners, losers
+		require.True(t, errors.Is(err, lockfile.ErrLocked),
+			"server %d: expected proxy-child.lock contention, got %v", i, err)
+		losers++
 	}
-	require.Eventually(t, func() bool {
-		w, l := tally()
-		return w == 1 && l == n-1
-	}, 10*time.Second, 100*time.Millisecond, "expected 1 winner + %d losers after rootDir lock fight", n-1)
-
-	winners, losers := tally()
-	assert.Equal(t, 1, winners, "exactly 1 Start must win the rootDir lock")
+	require.GreaterOrEqual(t, winner, 0, "no Start succeeded")
 	assert.Equal(t, n-1, losers, "the other %d Starts must lose", n-1)
 
-	// The single survivor must be dial-able (i.e., its listener is up).
-	winner := -1
-	for i, s := range servers {
-		if s.Running(context.Background()) {
-			winner = i
-			break
-		}
-	}
-	require.GreaterOrEqual(t, winner, 0)
+	assert.True(t, servers[winner].Running(context.Background()), "winner must be running")
 	conn, err := servers[winner].Dial(context.Background())
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
@@ -495,6 +460,7 @@ func TestDoltServer_DoltInit_Idempotent(t *testing.T) {
 	// user.name/email in global config, so set those first.
 	require.NoError(t, exec.Command(bin, "config", "--global", "--add", "user.name", "beads-test").Run())
 	require.NoError(t, exec.Command(bin, "config", "--global", "--add", "user.email", "beads@test").Run())
+
 	cmd := exec.Command(bin, "init")
 	cmd.Dir = rootDir
 	out, err := cmd.CombinedOutput()

--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -73,9 +73,7 @@ func newDoltServer(t *testing.T) (*server.DoltServer, string) {
 	port := freePort(t)
 	cfg := writeConfig(t, port)
 	log := filepath.Join(t.TempDir(), "server.log")
-	// dolt auto-creates root@localhost with empty password; match those
-	// credentials so Ping/Dial/SELECT actually authenticate.
-	s, err := server.NewDoltServer(bin, rootDir, cfg, log, "root", "", 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
 	require.NoError(t, err)
 	return s, rootDir
 }
@@ -87,10 +85,17 @@ func stopWithTimeout(t *testing.T, s *server.DoltServer) {
 	require.NoError(t, s.Stop(ctx))
 }
 
+// waitReady polls Dial until the listener accepts. Proves the server's
+// socket is up but does not authenticate a SQL session.
 func waitReady(t *testing.T, s *server.DoltServer) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		return s.Ping(context.Background()) == nil
+		conn, err := s.Dial(context.Background())
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
 	}, pingPollTimeout, pingPollInterval, "server never became ready")
 }
 
@@ -108,19 +113,17 @@ func TestNewDoltServer_Validation(t *testing.T) {
 		bin  string
 		root string
 		cfg  string
-		user string
 		want string
 	}{
-		{"empty bin", "", t.TempDir(), goodCfg, "root", "doltBinExec is required"},
-		{"empty root", "dolt", "", goodCfg, "root", "rootDir is required"},
-		{"empty cfg", "dolt", t.TempDir(), "", "root", "configPath is required"},
-		{"empty user", "dolt", t.TempDir(), goodCfg, "", "user is required"},
-		{"missing cfg", "dolt", t.TempDir(), missingCfg, "root", "parse config"},
-		{"bad yaml", "dolt", t.TempDir(), badYAML, "root", "parse config"},
+		{"empty bin", "", t.TempDir(), goodCfg, "doltBinExec is required"},
+		{"empty root", "dolt", "", goodCfg, "rootDir is required"},
+		{"empty cfg", "dolt", t.TempDir(), "", "configPath is required"},
+		{"missing cfg", "dolt", t.TempDir(), missingCfg, "parse config"},
+		{"bad yaml", "dolt", t.TempDir(), badYAML, "parse config"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s, err := server.NewDoltServer(tc.bin, tc.root, tc.cfg, "", tc.user, "", 0)
+			s, err := server.NewDoltServer(tc.bin, tc.root, tc.cfg, "", 0)
 			assert.Nil(t, s)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.want)
@@ -133,11 +136,11 @@ func TestDoltServer_ID_Stable(t *testing.T) {
 	rootA := t.TempDir()
 	rootB := t.TempDir()
 
-	a1, err := server.NewDoltServer("dolt", rootA, cfgPath, "", "root", "", 0)
+	a1, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
 	require.NoError(t, err)
-	a2, err := server.NewDoltServer("dolt", rootA, cfgPath, "", "root", "", 0)
+	a2, err := server.NewDoltServer("dolt", rootA, cfgPath, "", 0)
 	require.NoError(t, err)
-	b, err := server.NewDoltServer("dolt", rootB, cfgPath, "", "root", "", 0)
+	b, err := server.NewDoltServer("dolt", rootB, cfgPath, "", 0)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -147,18 +150,14 @@ func TestDoltServer_ID_Stable(t *testing.T) {
 
 func TestDoltServer_DSN(t *testing.T) {
 	cfgPath := writeConfig(t, 13306)
-
-	// Construct with one set of credentials, then call DSN with a different
-	// set — the args must win. This proves DSN does not silently fall back
-	// to the DoltServer's stored creds.
-	s, err := server.NewDoltServer("dolt", t.TempDir(), cfgPath, "", "stored-user", "stored-pass", 0)
+	s, err := server.NewDoltServer("dolt", t.TempDir(), cfgPath, "", 0)
 	require.NoError(t, err)
 
 	ctx := context.Background()
 	parsed, err := mysqldrv.ParseDSN(s.DSN(ctx, "", "alice", "s3cret"))
 	require.NoError(t, err)
-	assert.Equal(t, "alice", parsed.User, "DSN must use the user arg, not s.user")
-	assert.Equal(t, "s3cret", parsed.Passwd, "DSN must use the password arg, not s.password")
+	assert.Equal(t, "alice", parsed.User)
+	assert.Equal(t, "s3cret", parsed.Passwd)
 	assert.Equal(t, "tcp", parsed.Net)
 	assert.Equal(t, "127.0.0.1:13306", parsed.Addr)
 	assert.Empty(t, parsed.DBName)
@@ -231,7 +230,7 @@ listener:
 	require.NoError(t, os.WriteFile(cfgPath, []byte(body), 0o600))
 
 	logPath := filepath.Join(t.TempDir(), "server.log")
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, "root", "", 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -297,7 +296,7 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 
 	port1 := freePort(t)
 	cfg1 := writeConfig(t, port1)
-	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, "root", "", 0)
+	s1, err := server.NewDoltServer(bin, rootDir, cfg1, logPath, 0)
 	require.NoError(t, err)
 	require.NoError(t, s1.Start(ctx))
 	waitReady(t, s1)
@@ -306,7 +305,7 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 	// Fresh port to dodge any TIME_WAIT lingering on the old one.
 	port2 := freePort(t)
 	cfg2 := writeConfig(t, port2)
-	s2, err := server.NewDoltServer(bin, rootDir, cfg2, logPath, "root", "", 0)
+	s2, err := server.NewDoltServer(bin, rootDir, cfg2, logPath, 0)
 	require.NoError(t, err)
 	require.NoError(t, s2.Start(ctx), "new instance at same rootDir must start")
 	t.Cleanup(func() { stopWithTimeout(t, s2) })
@@ -315,12 +314,6 @@ func TestDoltServer_StartStopStart_NewInstanceSameRootDirSucceeds(t *testing.T) 
 
 	// ID is rootDir-derived and therefore stable across instances.
 	assert.Equal(t, s1.ID(ctx), s2.ID(ctx))
-}
-
-func TestDoltServer_Ping_BeforeStart(t *testing.T) {
-	s, _ := newDoltServer(t)
-	err := s.Ping(context.Background())
-	require.Error(t, err, "Ping must fail before Start")
 }
 
 func TestDoltServer_Dial_AfterStart(t *testing.T) {
@@ -367,7 +360,7 @@ func TestDoltServer_LogFile_CapturesOutput(t *testing.T) {
 	cfgPath := writeConfig(t, port)
 	logPath := filepath.Join(t.TempDir(), "server.log")
 
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, "root", "", 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, logPath, 0)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, s.Start(ctx))
@@ -426,7 +419,7 @@ func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
 		port := freePort(t)
 		cfg := writeConfig(t, port)
 		log := filepath.Join(logDir, fmt.Sprintf("server-%d.log", i))
-		s, err := server.NewDoltServer(bin, rootDir, cfg, log, "root", "", 0)
+		s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
 		require.NoError(t, err)
 		servers[i] = s
 	}
@@ -479,7 +472,7 @@ func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
 	assert.Equal(t, 1, winners, "exactly 1 Start must win the rootDir lock")
 	assert.Equal(t, n-1, losers, "the other %d Starts must lose", n-1)
 
-	// The single survivor must be ping-able (i.e., actually serving SQL).
+	// The single survivor must be dial-able (i.e., its listener is up).
 	winner := -1
 	for i, s := range servers {
 		if s.Running(context.Background()) {
@@ -488,7 +481,9 @@ func TestDoltServer_ConcurrentStart_SameRootDir_OneWins(t *testing.T) {
 		}
 	}
 	require.GreaterOrEqual(t, winner, 0)
-	require.NoError(t, servers[winner].Ping(context.Background()))
+	conn, err := servers[winner].Dial(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
 }
 
 func TestDoltServer_DoltInit_Idempotent(t *testing.T) {
@@ -507,7 +502,7 @@ func TestDoltServer_DoltInit_Idempotent(t *testing.T) {
 
 	port := freePort(t)
 	cfgPath := writeConfig(t, port)
-	s, err := server.NewDoltServer(bin, rootDir, cfgPath, "", "root", "", 0)
+	s, err := server.NewDoltServer(bin, rootDir, cfgPath, "", 0)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/internal/storage/db/server/server.go
+++ b/internal/storage/db/server/server.go
@@ -11,6 +11,5 @@ type DatabaseServer interface {
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
 	Running(ctx context.Context) bool
-	Ping(ctx context.Context) error
 	Dial(ctx context.Context) (net.Conn, error)
 }

--- a/internal/storage/db/server/testserver.go
+++ b/internal/storage/db/server/testserver.go
@@ -18,8 +18,6 @@ type Counters struct {
 	StartCalls    int64
 	StopCalls     int64
 	RunningCalls  int64
-	PingCalls     int64
-	PingErrors    int64
 	DialCalls     int64
 	DialErrors    int64
 	AcceptedConns int64 // cumulative
@@ -38,7 +36,6 @@ type TestDatabaseServerImpl struct {
 	DSN_     string                 // returned by DSN(); default "test://in-memory"
 	StartErr error                  // if non-nil, Start returns it (and does not mark started)
 	StopErr  error                  // if non-nil, Stop returns it after closing conns
-	PingErr  error                  // if non-nil, Ping returns it
 	DialErr  error                  // if non-nil, Dial returns it
 	Handler  func(backend net.Conn) // runs once per Dial; default EchoHandler
 
@@ -69,6 +66,14 @@ func EchoHandler(c net.Conn) {
 func DiscardHandler(c net.Conn) {
 	defer func() { _ = c.Close() }()
 	_, _ = io.Copy(io.Discard, c)
+}
+
+// SetDialErr atomically replaces DialErr. Use to flip Dial behavior after
+// the proxy has already reached readiness.
+func (s *TestDatabaseServerImpl) SetDialErr(err error) {
+	s.mu.Lock()
+	s.DialErr = err
+	s.mu.Unlock()
 }
 
 func (s *TestDatabaseServerImpl) Snapshot() Counters {
@@ -121,17 +126,6 @@ func (s *TestDatabaseServerImpl) Running(_ context.Context) bool {
 	defer s.mu.Unlock()
 	s.counters.RunningCalls++
 	return s.started
-}
-
-func (s *TestDatabaseServerImpl) Ping(_ context.Context) error {
-	s.mu.Lock()
-	s.counters.PingCalls++
-	if s.PingErr != nil {
-		s.counters.PingErrors++
-	}
-	err := s.PingErr
-	s.mu.Unlock()
-	return err
 }
 
 func (s *TestDatabaseServerImpl) Dial(_ context.Context) (net.Conn, error) {

--- a/internal/storage/db/server/testserver_test.go
+++ b/internal/storage/db/server/testserver_test.go
@@ -120,27 +120,6 @@ func TestRunning_Counter(t *testing.T) {
 	assert.Equal(t, int64(5), srv.Snapshot().RunningCalls)
 }
 
-func TestPing_Success(t *testing.T) {
-	srv := server.New()
-
-	require.NoError(t, srv.Ping(context.Background()))
-
-	c := srv.Snapshot()
-	assert.Equal(t, int64(1), c.PingCalls)
-	assert.Equal(t, int64(0), c.PingErrors)
-}
-
-func TestPing_Error(t *testing.T) {
-	srv := server.New()
-	srv.PingErr = errors.New("offline")
-
-	assert.EqualError(t, srv.Ping(context.Background()), "offline")
-
-	c := srv.Snapshot()
-	assert.Equal(t, int64(1), c.PingCalls)
-	assert.Equal(t, int64(1), c.PingErrors)
-}
-
 func TestDial_Echo(t *testing.T) {
 	ctx := context.Background()
 	srv := server.New()

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -1,27 +1,31 @@
-// Package doltserver provides a storage.DoltStorage implementation backed by
-// a managed dolt sql-server subprocess. All methods are currently
-// unimplemented stubs.
 package doltserver
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/db/proxy"
 	"github.com/steveyegge/beads/internal/types"
 )
 
 type DoltServerStore struct {
-	serverRootDir        string
-	beadsDir             string
-	database             string
-	committerName        string
-	committerEmail       string
+	serverRootDir          string
+	beadsDir               string
+	database               string
+	committerName          string
+	committerEmail         string
 	serverLogFilePath      string
 	serverConfigFilePath   string
 	backend                proxy.Backend
 	autoSyncToOriginRemote bool
+	user                   string
+	password               string
+	doltBinExec            string
 }
 
 var (
@@ -31,6 +35,86 @@ var (
 	_ storage.Flattener        = (*DoltServerStore)(nil)
 	_ storage.Compactor        = (*DoltServerStore)(nil)
 )
+
+func newDoltServerStore(
+	ctx context.Context,
+	serverRootDir string,
+	beadsDir string,
+	database string,
+	committerName string,
+	committerEmail string,
+	serverLogFilePath string,
+	serverConfigFilePath string,
+	backend proxy.Backend,
+	autoSyncToOriginRemote bool,
+	user string,
+	password string,
+	doltBinExec string,
+) (*DoltServerStore, error) {
+	if database == "" {
+		return nil, fmt.Errorf("doltserver: database name must not be empty (caller should default to %q)", "beads")
+	}
+	if err := backend.Validate(); err != nil {
+		return nil, fmt.Errorf("doltserver: backend: %w", err)
+	}
+	if user == "" {
+		return nil, fmt.Errorf("doltserver: user must not be empty")
+	}
+	if doltBinExec == "" {
+		return nil, fmt.Errorf("doltserver: doltBinExec must not be empty")
+	}
+
+	absServerRootDir, err := filepath.Abs(serverRootDir)
+	if err != nil {
+		return nil, fmt.Errorf("doltserver: resolving server root dir: %w", err)
+	}
+	absBeadsDir, err := filepath.Abs(beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("doltserver: resolving beads dir: %w", err)
+	}
+	absDoltBinExec, err := filepath.Abs(doltBinExec)
+	if err != nil {
+		return nil, fmt.Errorf("doltserver: resolving dolt bin exec: %w", err)
+	}
+	if err := os.MkdirAll(absServerRootDir, config.BeadsDirPerm); err != nil {
+		return nil, fmt.Errorf("doltserver: creating server root directory: %w", err)
+	}
+
+	s := &DoltServerStore{
+		serverRootDir:          absServerRootDir,
+		beadsDir:               absBeadsDir,
+		database:               database,
+		committerName:          committerName,
+		committerEmail:         committerEmail,
+		serverLogFilePath:      serverLogFilePath,
+		serverConfigFilePath:   serverConfigFilePath,
+		backend:                backend,
+		autoSyncToOriginRemote: autoSyncToOriginRemote,
+		user:                   user,
+		password:               password,
+		doltBinExec:            absDoltBinExec,
+	}
+
+	if err := s.initSchema(ctx); err != nil {
+		return nil, fmt.Errorf("doltserver: init schema: %w", err)
+	}
+
+	if err := s.ensureIgnoredTables(ctx); err != nil {
+		return nil, fmt.Errorf("doltserver: ensure ignored tables: %w", err)
+	}
+
+	return s, nil
+}
+
+// initSchema creates the database (if needed) and runs all pending migrations.
+func (s *DoltServerStore) initSchema(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+// ensureIgnoredTables creates dolt_ignore'd wisp tables if they don't exist.
+func (s *DoltServerStore) ensureIgnoredTables(ctx context.Context) error {
+	panic("unimplemented")
+}
 
 // Storage — issue CRUD
 

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -15,8 +17,13 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/db/proxy"
 	"github.com/steveyegge/beads/internal/storage/db/util"
+	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
+	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+// validIdentifier matches safe SQL identifiers (letters, digits, underscores).
+var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 type DoltServerStore struct {
 	serverRootDir          string
@@ -117,11 +124,6 @@ func newDoltServerStore(
 		return nil, fmt.Errorf("doltserver: init schema: %w", err)
 	}
 
-	if err := s.ensureIgnoredTables(ctx); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("doltserver: ensure ignored tables: %w", err)
-	}
-
 	return s, nil
 }
 
@@ -176,11 +178,42 @@ func (s *DoltServerStore) withWriteTx(ctx context.Context, fn func(ctx context.C
 }
 
 func (s *DoltServerStore) initSchema(ctx context.Context) error {
-	panic("unimplemented")
-}
+	if !validIdentifier.MatchString(s.database) {
+		return fmt.Errorf("doltserver: invalid database name: %q", s.database)
+	}
+	dbIdent := "`" + s.database + "`"
 
-func (s *DoltServerStore) ensureIgnoredTables(ctx context.Context) error {
-	panic("unimplemented")
+	return s.withWriteTx(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS "+dbIdent); err != nil {
+			return fmt.Errorf("doltserver: creating database: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, "USE "+dbIdent); err != nil {
+			return fmt.Errorf("doltserver: switching to database: %w", err)
+		}
+
+		if err := schema.EnsureIgnoredTables(ctx, tx); err != nil {
+			return fmt.Errorf("ensure ignored tables before migration: %w", err)
+		}
+
+		applied, err := schema.MigrateUp(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		if applied > 0 {
+			if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+				return fmt.Errorf("dolt add after migrations: %w", err)
+			}
+
+			if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'schema: apply migrations')"); err != nil {
+				if !strings.Contains(err.Error(), "nothing to commit") {
+					return fmt.Errorf("dolt commit after migrations: %w", err)
+				}
+			}
+		}
+
+		return nil
+	})
 }
 
 // Storage — issue CRUD

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -88,6 +88,7 @@ func newDoltServerStore(
 	if err != nil {
 		return nil, fmt.Errorf("doltserver: resolving dolt bin exec: %w", err)
 	}
+
 	if err := os.MkdirAll(absServerRootDir, config.BeadsDirPerm); err != nil {
 		return nil, fmt.Errorf("doltserver: creating server root directory: %w", err)
 	}
@@ -112,16 +113,30 @@ func newDoltServerStore(
 		return nil, fmt.Errorf("doltserver: get proxy endpoint: %w", err)
 	}
 
+	// Open the initial connection with no default database — the target
+	// database does not yet exist, so a DSN-level USE would 1049. initSchema
+	// is responsible for CREATE DATABASE + migrations on this connection.
+	initDB, err := openDB(ctx, buildDSN(ep, "", rootUser, rootPassword))
+	if err != nil {
+		return nil, err
+	}
+	s.db = initDB
+
+	if err := s.initSchema(ctx); err != nil {
+		_ = initDB.Close()
+		return nil, fmt.Errorf("doltserver: init schema: %w", err)
+	}
+	if err := initDB.Close(); err != nil {
+		return nil, fmt.Errorf("doltserver: close init db: %w", err)
+	}
+	s.db = nil
+
+	// Reopen with the target database now that initSchema has created it.
 	db, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword))
 	if err != nil {
 		return nil, err
 	}
 	s.db = db
-
-	if err := s.initSchema(ctx); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("doltserver: init schema: %w", err)
-	}
 
 	return s, nil
 }

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -2,14 +2,18 @@ package doltserver
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
+	_ "github.com/go-sql-driver/mysql"
+
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/db/proxy"
+	"github.com/steveyegge/beads/internal/storage/db/util"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -26,6 +30,7 @@ type DoltServerStore struct {
 	user                   string
 	password               string
 	doltBinExec            string
+	db                     *sql.DB
 }
 
 var (
@@ -80,6 +85,15 @@ func newDoltServerStore(
 		return nil, fmt.Errorf("doltserver: creating server root directory: %w", err)
 	}
 
+	ep, err := getDatabaseProxyEndpoint(absServerRootDir, backend)
+	if err != nil {
+		return nil, fmt.Errorf("doltserver: get proxy endpoint: %w", err)
+	}
+	db, err := openDB(buildDSN(ep, database, user, password))
+	if err != nil {
+		return nil, err
+	}
+
 	s := &DoltServerStore{
 		serverRootDir:          absServerRootDir,
 		beadsDir:               absBeadsDir,
@@ -93,25 +107,59 @@ func newDoltServerStore(
 		user:                   user,
 		password:               password,
 		doltBinExec:            absDoltBinExec,
+		db:                     db,
+	}
+
+	if err := s.ensureSQLUserAndPermissions(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("doltserver: ensureSQLUserAndPermissions: %w", err)
 	}
 
 	if err := s.initSchema(ctx); err != nil {
+		_ = db.Close()
 		return nil, fmt.Errorf("doltserver: init schema: %w", err)
 	}
 
 	if err := s.ensureIgnoredTables(ctx); err != nil {
+		_ = db.Close()
 		return nil, fmt.Errorf("doltserver: ensure ignored tables: %w", err)
 	}
 
 	return s, nil
 }
 
-// initSchema creates the database (if needed) and runs all pending migrations.
+func getDatabaseProxyEndpoint(serverRootDir string, backend proxy.Backend) (proxy.Endpoint, error) {
+	return proxy.GetCreateDatabaseProxyServerEndpoint(serverRootDir, proxy.OpenOpts{
+		Backend: backend,
+	})
+}
+
+func buildDSN(ep proxy.Endpoint, database, user, password string) string {
+	return util.DoltServerDSN{
+		Host:     ep.Host,
+		Port:     ep.Port,
+		User:     user,
+		Password: password,
+		Database: database,
+	}.String()
+}
+
+func openDB(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("doltserver: open db: %w", err)
+	}
+	return db, nil
+}
+
+func (s *DoltServerStore) ensureSQLUserAndPermissions(ctx context.Context) error {
+	panic("unimplemented")
+}
+
 func (s *DoltServerStore) initSchema(ctx context.Context) error {
 	panic("unimplemented")
 }
 
-// ensureIgnoredTables creates dolt_ignore'd wisp tables if they don't exist.
 func (s *DoltServerStore) ensureIgnoredTables(ctx context.Context) error {
 	panic("unimplemented")
 }

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -28,8 +28,8 @@ type DoltServerStore struct {
 	serverConfigFilePath   string
 	backend                proxy.Backend
 	autoSyncToOriginRemote bool
-	user                   string
-	password               string
+	rootUser               string
+	rootPassword           string
 	doltBinExec            string
 	db                     *sql.DB
 }
@@ -53,8 +53,8 @@ func newDoltServerStore(
 	serverConfigFilePath string,
 	backend proxy.Backend,
 	autoSyncToOriginRemote bool,
-	user string,
-	password string,
+	rootUser string,
+	rootPassword string,
 	doltBinExec string,
 ) (*DoltServerStore, error) {
 	if database == "" {
@@ -63,8 +63,8 @@ func newDoltServerStore(
 	if err := backend.Validate(); err != nil {
 		return nil, fmt.Errorf("doltserver: backend: %w", err)
 	}
-	if user == "" {
-		return nil, fmt.Errorf("doltserver: user must not be empty")
+	if rootUser == "" {
+		return nil, fmt.Errorf("doltserver: rootUser must not be empty")
 	}
 	if doltBinExec == "" {
 		return nil, fmt.Errorf("doltserver: doltBinExec must not be empty")
@@ -90,7 +90,8 @@ func newDoltServerStore(
 	if err != nil {
 		return nil, fmt.Errorf("doltserver: get proxy endpoint: %w", err)
 	}
-	db, err := openDB(buildDSN(ep, database, user, password))
+
+	db, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword))
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +106,8 @@ func newDoltServerStore(
 		serverConfigFilePath:   serverConfigFilePath,
 		backend:                backend,
 		autoSyncToOriginRemote: autoSyncToOriginRemote,
-		user:                   user,
-		password:               password,
+		rootUser:               rootUser,
+		rootPassword:           rootPassword,
 		doltBinExec:            absDoltBinExec,
 		db:                     db,
 	}
@@ -140,10 +141,13 @@ func buildDSN(ep proxy.Endpoint, database, user, password string) string {
 	}.String()
 }
 
-func openDB(dsn string) (*sql.DB, error) {
+func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("doltserver: open db: %w", err)
+	}
+	if err := db.PingContext(ctx); err != nil {
+		return nil, errors.Join(fmt.Errorf("doltserver: ping db: %w", err), db.Close())
 	}
 	return db, nil
 }

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -3,6 +3,7 @@ package doltserver
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -110,11 +111,6 @@ func newDoltServerStore(
 		db:                     db,
 	}
 
-	if err := s.ensureSQLUserAndPermissions(ctx); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("doltserver: ensureSQLUserAndPermissions: %w", err)
-	}
-
 	if err := s.initSchema(ctx); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("doltserver: init schema: %w", err)
@@ -152,8 +148,27 @@ func openDB(dsn string) (*sql.DB, error) {
 	return db, nil
 }
 
-func (s *DoltServerStore) ensureSQLUserAndPermissions(ctx context.Context) error {
-	panic("unimplemented")
+func (s *DoltServerStore) withReadTx(ctx context.Context, fn func(ctx context.Context, tx *sql.Tx) error) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("doltserver: begin read tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	return fn(ctx, tx)
+}
+
+func (s *DoltServerStore) withWriteTx(ctx context.Context, fn func(ctx context.Context, tx *sql.Tx) error) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("doltserver: begin write tx: %w", err)
+	}
+	if err := fn(ctx, tx); err != nil {
+		return errors.Join(err, tx.Rollback())
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("doltserver: commit: %w", err)
+	}
+	return nil
 }
 
 func (s *DoltServerStore) initSchema(ctx context.Context) error {

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -1,0 +1,601 @@
+// Package doltserver provides a storage.DoltStorage implementation backed by
+// a managed dolt sql-server subprocess. All methods are currently
+// unimplemented stubs.
+package doltserver
+
+import (
+	"context"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/db/proxy"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type DoltServerStore struct {
+	serverRootDir        string
+	beadsDir             string
+	database             string
+	committerName        string
+	committerEmail       string
+	serverLogFilePath      string
+	serverConfigFilePath   string
+	backend                proxy.Backend
+	autoSyncToOriginRemote bool
+}
+
+var (
+	_ storage.DoltStorage      = (*DoltServerStore)(nil)
+	_ storage.StoreLocator     = (*DoltServerStore)(nil)
+	_ storage.GarbageCollector = (*DoltServerStore)(nil)
+	_ storage.Flattener        = (*DoltServerStore)(nil)
+	_ storage.Compactor        = (*DoltServerStore)(nil)
+)
+
+// Storage — issue CRUD
+
+func (s *DoltServerStore) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetIssue(ctx context.Context, id string) (*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetIssueByExternalRef(ctx context.Context, externalRef string) (*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) UpdateIssue(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ReopenIssue(ctx context.Context, id string, reason string, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) UpdateIssueType(ctx context.Context, id string, issueType string, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) CloseIssue(ctx context.Context, id string, reason string, actor string, session string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) DeleteIssue(ctx context.Context, id string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+// Storage — dependencies
+
+func (s *DoltServerStore) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetDependencies(ctx context.Context, issueID string) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetDependents(ctx context.Context, issueID string) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetDependenciesWithMetadata(ctx context.Context, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetDependentsWithMetadata(ctx context.Context, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetDependencyTree(ctx context.Context, issueID string, maxDepth int, showAllPaths bool, reverse bool) ([]*types.TreeNode, error) {
+	panic("unimplemented")
+}
+
+// Storage — labels
+
+func (s *DoltServerStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetLabels(ctx context.Context, issueID string) ([]string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetIssuesByLabel(ctx context.Context, label string) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+// Storage — work queries
+
+func (s *DoltServerStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetBlockedIssues(ctx context.Context, filter types.WorkFilter) ([]*types.BlockedIssue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetEpicsEligibleForClosure(ctx context.Context) ([]*types.EpicStatus, error) {
+	panic("unimplemented")
+}
+
+// Storage — wisp queries
+
+func (s *DoltServerStore) ListWisps(ctx context.Context, filter types.WispFilter) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+// Storage — comments and events
+
+func (s *DoltServerStore) AddIssueComment(ctx context.Context, issueID, author, text string) (*types.Comment, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetIssueComments(ctx context.Context, issueID string) ([]*types.Comment, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetEvents(ctx context.Context, issueID string, limit int) ([]*types.Event, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetAllEventsSince(ctx context.Context, since time.Time) ([]*types.Event, error) {
+	panic("unimplemented")
+}
+
+// Storage — statistics
+
+func (s *DoltServerStore) GetStatistics(ctx context.Context) (*types.Statistics, error) {
+	panic("unimplemented")
+}
+
+// Storage — configuration
+
+func (s *DoltServerStore) SetConfig(ctx context.Context, key, value string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetConfig(ctx context.Context, key string) (string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetAllConfig(ctx context.Context) (map[string]string, error) {
+	panic("unimplemented")
+}
+
+// Storage — local metadata
+
+func (s *DoltServerStore) SetLocalMetadata(ctx context.Context, key, value string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetLocalMetadata(ctx context.Context, key string) (string, error) {
+	panic("unimplemented")
+}
+
+// Storage — transactions
+
+func (s *DoltServerStore) RunInTransaction(ctx context.Context, commitMsg string, fn func(tx storage.Transaction) error) error {
+	panic("unimplemented")
+}
+
+// Storage — merge slot
+
+func (s *DoltServerStore) MergeSlotCreate(ctx context.Context, actor string) (*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) MergeSlotCheck(ctx context.Context) (*storage.MergeSlotStatus, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) MergeSlotAcquire(ctx context.Context, holder, actor string, wait bool) (*storage.MergeSlotResult, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) MergeSlotRelease(ctx context.Context, holder, actor string) error {
+	panic("unimplemented")
+}
+
+// Storage — metadata slots
+
+func (s *DoltServerStore) SlotSet(ctx context.Context, issueID, key, value, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) SlotGet(ctx context.Context, issueID, key string) (string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) SlotClear(ctx context.Context, issueID, key, actor string) error {
+	panic("unimplemented")
+}
+
+// Storage — lifecycle
+
+func (s *DoltServerStore) Close() error {
+	panic("unimplemented")
+}
+
+// VersionControl
+
+func (s *DoltServerStore) Branch(ctx context.Context, name string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Checkout(ctx context.Context, branch string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) CurrentBranch(ctx context.Context) (string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) DeleteBranch(ctx context.Context, branch string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ListBranches(ctx context.Context) ([]string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Commit(ctx context.Context, message string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) CommitWithConfig(ctx context.Context, message string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) CommitPending(ctx context.Context, actor string) (bool, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) CommitExists(ctx context.Context, commitHash string) (bool, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetCurrentCommit(ctx context.Context) (string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Status(ctx context.Context) (*storage.Status, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Log(ctx context.Context, limit int) ([]storage.CommitInfo, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Merge(ctx context.Context, branch string) ([]storage.Conflict, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetConflicts(ctx context.Context) ([]storage.Conflict, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ResolveConflicts(ctx context.Context, table string, strategy string) error {
+	panic("unimplemented")
+}
+
+// HistoryViewer
+
+func (s *DoltServerStore) History(ctx context.Context, issueID string) ([]*storage.HistoryEntry, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) AsOf(ctx context.Context, issueID string, ref string) (*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Diff(ctx context.Context, fromRef, toRef string) ([]*storage.DiffEntry, error) {
+	panic("unimplemented")
+}
+
+// RemoteStore
+
+func (s *DoltServerStore) AddRemote(ctx context.Context, name, url string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) RemoveRemote(ctx context.Context, name string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) HasRemote(ctx context.Context, name string) (bool, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ListRemotes(ctx context.Context) ([]storage.RemoteInfo, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Push(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Pull(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ForcePush(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) PushRemote(ctx context.Context, remote string, force bool) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) PullRemote(ctx context.Context, remote string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) Fetch(ctx context.Context, peer string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) PushTo(ctx context.Context, peer string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) PullFrom(ctx context.Context, peer string) ([]storage.Conflict, error) {
+	panic("unimplemented")
+}
+
+// SyncStore
+
+func (s *DoltServerStore) Sync(ctx context.Context, peer string, strategy string) (*storage.SyncResult, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) SyncStatus(ctx context.Context, peer string) (*storage.SyncStatus, error) {
+	panic("unimplemented")
+}
+
+// FederationStore
+
+func (s *DoltServerStore) AddFederationPeer(ctx context.Context, peer *storage.FederationPeer) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetFederationPeer(ctx context.Context, name string) (*storage.FederationPeer, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ListFederationPeers(ctx context.Context) ([]*storage.FederationPeer, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) RemoveFederationPeer(ctx context.Context, name string) error {
+	panic("unimplemented")
+}
+
+// BulkIssueStore
+
+func (s *DoltServerStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) DeleteIssues(ctx context.Context, ids []string, cascade bool, force bool, dryRun bool) (*types.DeleteIssuesResult, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) DeleteIssuesBySourceRepo(ctx context.Context, sourceRepo string) (int, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) UpdateIssueID(ctx context.Context, oldID, newID string, issue *types.Issue, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ClaimIssue(ctx context.Context, id string, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ClaimReadyIssue(ctx context.Context, filter types.WorkFilter, actor string) (*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) PromoteFromEphemeral(ctx context.Context, id string, actor string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetNextChildID(ctx context.Context, parentID string) (string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) RenameCounterPrefix(ctx context.Context, oldPrefix, newPrefix string) error {
+	panic("unimplemented")
+}
+
+// DependencyQueryStore
+
+func (s *DoltServerStore) GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetDependencyRecordsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Dependency, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetAllDependencyRecords(ctx context.Context) (map[string][]*types.Dependency, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetDependencyCounts(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetBlockingInfoForIssues(ctx context.Context, issueIDs []string) (map[string][]string, map[string][]string, map[string]string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) IsBlocked(ctx context.Context, issueID string) (bool, []string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) DetectCycles(ctx context.Context) ([][]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) FindWispDependentsRecursive(ctx context.Context, ids []string) (map[string]bool, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) RenameDependencyPrefix(ctx context.Context, oldPrefix, newPrefix string) error {
+	panic("unimplemented")
+}
+
+// AnnotationStore
+
+func (s *DoltServerStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetCommentCounts(ctx context.Context, issueIDs []string) (map[string]int, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetCommentsForIssues(ctx context.Context, issueIDs []string) (map[string][]*types.Comment, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetLabelsForIssues(ctx context.Context, issueIDs []string) (map[string][]string, error) {
+	panic("unimplemented")
+}
+
+// ConfigMetadataStore
+
+func (s *DoltServerStore) GetMetadata(ctx context.Context, key string) (string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) SetMetadata(ctx context.Context, key, value string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) DeleteConfig(ctx context.Context, key string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetCustomStatuses(ctx context.Context) ([]string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetCustomStatusesDetailed(ctx context.Context) ([]types.CustomStatus, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetCustomTypes(ctx context.Context) ([]string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetInfraTypes(ctx context.Context) map[string]bool {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) IsInfraTypeCtx(ctx context.Context, t types.IssueType) bool {
+	panic("unimplemented")
+}
+
+// CompactionStore
+
+func (s *DoltServerStore) CheckEligibility(ctx context.Context, issueID string, tier int) (bool, string, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ApplyCompaction(ctx context.Context, issueID string, tier int, originalSize int, compactedSize int, commitHash string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetTier1Candidates(ctx context.Context) ([]*types.CompactionCandidate, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetTier2Candidates(ctx context.Context) ([]*types.CompactionCandidate, error) {
+	panic("unimplemented")
+}
+
+// AdvancedQueryStore
+
+func (s *DoltServerStore) GetRepoMtime(ctx context.Context, repoPath string) (int64, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) SetRepoMtime(ctx context.Context, repoPath, jsonlPath string, mtimeNs int64) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) ClearRepoMtime(ctx context.Context, repoPath string) error {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetMoleculeProgress(ctx context.Context, moleculeID string) (*types.MoleculeProgressStats, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetMoleculeLastActivity(ctx context.Context, moleculeID string) (*types.MoleculeLastActivity, error) {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) GetStaleIssues(ctx context.Context, filter types.StaleFilter) ([]*types.Issue, error) {
+	panic("unimplemented")
+}
+
+// StoreLocator
+
+func (s *DoltServerStore) Path() string {
+	panic("unimplemented")
+}
+
+func (s *DoltServerStore) CLIDir() string {
+	panic("unimplemented")
+}
+
+// GarbageCollector
+
+func (s *DoltServerStore) DoltGC(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+// Flattener
+
+func (s *DoltServerStore) Flatten(ctx context.Context) error {
+	panic("unimplemented")
+}
+
+// Compactor
+
+func (s *DoltServerStore) Compact(ctx context.Context, initialHash, boundaryHash string, oldCommits int, recentHashes []string) error {
+	panic("unimplemented")
+}

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -92,16 +92,6 @@ func newDoltServerStore(
 		return nil, fmt.Errorf("doltserver: creating server root directory: %w", err)
 	}
 
-	ep, err := getDatabaseProxyEndpoint(absServerRootDir, backend)
-	if err != nil {
-		return nil, fmt.Errorf("doltserver: get proxy endpoint: %w", err)
-	}
-
-	db, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword))
-	if err != nil {
-		return nil, err
-	}
-
 	s := &DoltServerStore{
 		serverRootDir:          absServerRootDir,
 		beadsDir:               absBeadsDir,
@@ -115,8 +105,18 @@ func newDoltServerStore(
 		rootUser:               rootUser,
 		rootPassword:           rootPassword,
 		doltBinExec:            absDoltBinExec,
-		db:                     db,
 	}
+
+	ep, err := s.getDatabaseProxyEndpoint()
+	if err != nil {
+		return nil, fmt.Errorf("doltserver: get proxy endpoint: %w", err)
+	}
+
+	db, err := openDB(ctx, buildDSN(ep, database, rootUser, rootPassword))
+	if err != nil {
+		return nil, err
+	}
+	s.db = db
 
 	if err := s.initSchema(ctx); err != nil {
 		_ = db.Close()
@@ -126,9 +126,12 @@ func newDoltServerStore(
 	return s, nil
 }
 
-func getDatabaseProxyEndpoint(serverRootDir string, backend proxy.Backend) (proxy.Endpoint, error) {
-	return proxy.GetCreateDatabaseProxyServerEndpoint(serverRootDir, proxy.OpenOpts{
-		Backend: backend,
+func (s *DoltServerStore) getDatabaseProxyEndpoint() (proxy.Endpoint, error) {
+	return proxy.GetCreateDatabaseProxyServerEndpoint(s.serverRootDir, proxy.OpenOpts{
+		Backend:        s.backend,
+		ConfigFilePath: s.serverConfigFilePath,
+		LogFilePath:    s.serverLogFilePath,
+		DoltBinPath:    s.doltBinExec,
 	})
 }
 

--- a/internal/storage/doltserver/store.go
+++ b/internal/storage/doltserver/store.go
@@ -17,7 +17,6 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/db/proxy"
 	"github.com/steveyegge/beads/internal/storage/db/util"
-	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/types"
 )

--- a/internal/storage/doltserver/store_test.go
+++ b/internal/storage/doltserver/store_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"sync"
+	"syscall"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -17,6 +19,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// shutdownOnInterrupt installs a SIGINT/SIGTERM handler that runs
+// proxy.Shutdown(rootDir) and exits, so the proxy and child dolt sql-server
+// don't survive an early test abort (e.g. Ctrl+C). The handler is removed via
+// t.Cleanup on normal test completion.
+func shutdownOnInterrupt(t *testing.T, rootDir string) {
+	t.Helper()
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ch:
+			_ = proxy.Shutdown(rootDir)
+			os.Exit(1)
+		case <-done:
+		}
+	}()
+	t.Cleanup(func() {
+		signal.Stop(ch)
+		close(done)
+	})
+}
 
 func TestNewDoltServerStore_ValidationErrors(t *testing.T) {
 	cases := []struct {
@@ -63,6 +88,12 @@ func TestNewDoltServerStore_HappyPath(t *testing.T) {
 	port, err := proxy.PickFreePort()
 	require.NoError(t, err)
 	storeRootDir := t.TempDir()
+	shutdownOnInterrupt(t, storeRootDir)
+	t.Cleanup(func() {
+		if err := proxy.Shutdown(storeRootDir); err != nil {
+			t.Logf("proxy.Shutdown(%s): %v", storeRootDir, err)
+		}
+	})
 	cfgPath := writeServerConfig(t, port)
 	logPath := filepath.Join(t.TempDir(), "server.log")
 

--- a/internal/storage/doltserver/store_test.go
+++ b/internal/storage/doltserver/store_test.go
@@ -2,10 +2,7 @@ package doltserver
 
 import (
 	"context"
-	"encoding/json"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"

--- a/internal/storage/doltserver/store_test.go
+++ b/internal/storage/doltserver/store_test.go
@@ -2,7 +2,12 @@ package doltserver
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -48,9 +53,18 @@ func TestNewDoltServerStore_HappyPath(t *testing.T) {
 	bin, err := exec.LookPath("dolt")
 	require.NoError(t, err)
 
+	bdBin := buildBDBinary(t)
+	prev := proxy.ResolveExecutable
+	proxy.ResolveExecutable = func() (string, error) { return bdBin, nil }
+	t.Cleanup(func() { proxy.ResolveExecutable = prev })
+
 	t.Setenv("HOME", t.TempDir())
 
+	port, err := proxy.PickFreePort()
+	require.NoError(t, err)
 	storeRootDir := t.TempDir()
+	cfgPath := writeServerConfig(t, port)
+	logPath := filepath.Join(t.TempDir(), "server.log")
 
 	store, err := newDoltServerStore(
 		context.Background(),
@@ -59,8 +73,8 @@ func TestNewDoltServerStore_HappyPath(t *testing.T) {
 		"beads",
 		"test_user",
 		"test@example.com",
-		"",
-		"",
+		logPath,
+		cfgPath,
 		proxy.BackendLocalServer,
 		false,
 		"root",
@@ -71,4 +85,50 @@ func TestNewDoltServerStore_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, store)
 	t.Cleanup(func() { _ = store.db.Close() })
+}
+
+var (
+	bdBinaryOnce sync.Once
+	bdBinary     string
+	bdBinaryErr  error
+)
+
+func buildBDBinary(t *testing.T) string {
+	t.Helper()
+	bdBinaryOnce.Do(func() {
+		if prebuilt := os.Getenv("BEADS_TEST_BD_BINARY"); prebuilt != "" {
+			if _, err := os.Stat(prebuilt); err != nil {
+				bdBinaryErr = fmt.Errorf("BEADS_TEST_BD_BINARY=%q not found: %w", prebuilt, err)
+				return
+			}
+			bdBinary = prebuilt
+			return
+		}
+		tmpDir, err := os.MkdirTemp("", "bd-doltserver-test-*")
+		if err != nil {
+			bdBinaryErr = fmt.Errorf("temp dir: %w", err)
+			return
+		}
+		name := "bd"
+		if runtime.GOOS == "windows" {
+			name = "bd.exe"
+		}
+		bdBinary = filepath.Join(tmpDir, name)
+		cmd := exec.Command("go", "build", "-tags", "gms_pure_go", "-o", bdBinary, "github.com/steveyegge/beads/cmd/bd")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			bdBinaryErr = fmt.Errorf("go build bd: %v\n%s", err, out)
+		}
+	})
+	if bdBinaryErr != nil {
+		t.Fatalf("build bd: %v", bdBinaryErr)
+	}
+	return bdBinary
+}
+
+func writeServerConfig(t *testing.T, port int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	body := fmt.Sprintf("log_level: debug\nlistener:\n  host: 127.0.0.1\n  port: %d\n", port)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
 }

--- a/internal/storage/doltserver/store_test.go
+++ b/internal/storage/doltserver/store_test.go
@@ -1,0 +1,77 @@
+package doltserver
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/beads/internal/storage/db/proxy"
+	"github.com/steveyegge/beads/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDoltServerStore_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		database string
+		rootUser string
+		doltBin  string
+		backend  proxy.Backend
+		want     string
+	}{
+		{"empty database", "", "root", "/usr/bin/true", proxy.BackendLocalServer, "database name must not be empty"},
+		{"invalid backend", "beads", "root", "/usr/bin/true", proxy.Backend("nope"), "unknown backend"},
+		{"empty rootUser", "beads", "", "/usr/bin/true", proxy.BackendLocalServer, "rootUser must not be empty"},
+		{"empty doltBin", "beads", "root", "", proxy.BackendLocalServer, "doltBinExec must not be empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := newDoltServerStore(
+				context.Background(),
+				t.TempDir(), t.TempDir(),
+				tc.database, "Test", "test@example.com",
+				"", "", tc.backend, false,
+				tc.rootUser, "", tc.doltBin,
+			)
+			assert.Nil(t, s)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestNewDoltServerStore_HappyPath(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+	bin, err := exec.LookPath("dolt")
+	require.NoError(t, err)
+
+	t.Setenv("HOME", t.TempDir())
+
+	storeRootDir := t.TempDir()
+
+	store, err := newDoltServerStore(
+		context.Background(),
+		storeRootDir,
+		t.TempDir(),
+		"beads",
+		"test_user",
+		"test@example.com",
+		"",
+		"",
+		proxy.BackendLocalServer,
+		false,
+		"root",
+		"",
+		bin,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, store)
+	t.Cleanup(func() { _ = store.db.Close() })
+}


### PR DESCRIPTION
## Summary
- Scaffold `internal/storage/doltserver.DoltServerStore`, a `storage.DoltStorage` implementation that talks to a dolt sql-server via the proxy. Constructor + schema bootstrap are wired; CRUD methods are stubbed.
- Harden proxy-child lifecycle with a `proxy-child.lock` flock and reap orphans on respawn. Add `proxy.Shutdown(rootDir)` for test cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->