### PR TITLE
test: let bash canonicalize formula path in release script tests

### DIFF
--- a/scripts/release_script_test.go
+++ b/scripts/release_script_test.go
@@ -167,9 +167,15 @@ func runReleaseDryRunWithEnv(t *testing.T, repo, bin string, extraEnv ...string)
 
 func writeFakeBD(t *testing.T, bin, repo string) {
 	t.Helper()
-	source := filepath.Join(repo, ".beads", "formulas", "beads-release.formula.toml")
+	// Let bash itself canonicalize the formula path. release.sh derives
+	// FORMULA_PATH from `pwd`, which on Windows under Git Bash/MSYS produces
+	// mount-aware forms like /c/Users/... or /tmp/... . Embedding the Go
+	// path with %q would yield C:\\Users\\... and never match. Using
+	// filepath.ToSlash gives bash a path it can `cd` into, then `pwd`
+	// resolves it to whatever form release.sh will compare against.
+	formulaDir := filepath.ToSlash(filepath.Join(repo, ".beads", "formulas"))
 	body := fmt.Sprintf(`#!/bin/sh
-SOURCE=%q
+SOURCE="$(cd %q && pwd)/beads-release.formula.toml"
 if [ "$1 $2 $3 $4" = "formula show beads-release --json" ]; then
   printf '%%s\n' "{\"source\":\"$SOURCE\"}"
   exit 0
@@ -181,7 +187,7 @@ if [ "$1 $2 $3" = "formula show beads-release" ]; then
 fi
 echo "unexpected fake bd invocation: $*" >&2
 exit 64
-`, source)
+`, formulaDir)
 	writeExecutable(t, filepath.Join(bin, "bd"), body)
 }
 


### PR DESCRIPTION
## What

Fix `writeFakeBD` in `scripts/release_script_test.go` to let bash canonicalize the formula path at script-execution time. Two Windows-only test failures (`TestReleaseScriptInstalledBDSelectionDoesNotRequireJQ` and `TestReleaseScriptUsesVerifiedInstalledBDBeforeStaleRepoBD`) start passing.

Test-only change. One helper. Production code (`release.sh`, `bd`) untouched.

## Why

Fixes #3796.

On Windows, both tests above fail because release.sh's installed-bd selection never matches the fake bd, falls back to `go run`, and then errors out because `go run` can't find `go.mod` from the test's working directory:

```
Using bd: go run -tags gms_pure_go ./cmd/bd (falling back to go run; run make install for faster releases)
...
go: go.mod file not found in current directory or any parent directory
--- FAIL: TestReleaseScriptInstalledBDSelectionDoesNotRequireJQ (0.29s)
```

Root cause: `writeFakeBD` embeds the formula path into a bash heredoc with `fmt.Sprintf` `%q`. On Windows, `filepath.Join` returns backslashes and `%q` quotes them as `"C:\\Users\\..."`. release.sh derives `FORMULA_PATH` from bash's `pwd`, which on Git Bash/MSYS is mount-aware and produces forms like `/c/Users/...` or `/tmp/...` (the `AppData\Local\Temp` mount aliases as `/tmp`). The embedded windows path never matches whatever `pwd` produces, `bd_resolves_repo_formula` returns false for every candidate, and we fall through to the `go run` branch.

The fix lets bash canonicalize the path itself. Instead of embedding the path with `%q`, the fake bd computes `SOURCE` at execution time via `cd <formula-dir> && pwd`, so bash produces whatever canonical form release.sh will compare against. `filepath.ToSlash` is enough on the Go side because bash accepts forward-slash native windows paths for `cd`.

## Verification

Repro on Windows (Git Bash / MSYS) against upstream HEAD `8b7cbfc3b`:

```
go test -tags gms_pure_go ./scripts/... -run TestReleaseScriptInstalledBDSelectionDoesNotRequireJQ -v
```

Before this PR: fails as shown above. After this PR:

```
$ go test -tags gms_pure_go ./scripts/... -v -count=1
=== RUN   TestReleaseScriptUsesVerifiedInstalledBDBeforeStaleRepoBD
--- PASS: TestReleaseScriptUsesVerifiedInstalledBDBeforeStaleRepoBD (0.33s)
=== RUN   TestReleaseScriptInstalledBDSelectionDoesNotRequireJQ
--- PASS: TestReleaseScriptInstalledBDSelectionDoesNotRequireJQ (0.33s)
=== RUN   TestReleaseScriptRejectsExplicitBDThatDoesNotResolveRepoFormula
--- PASS: TestReleaseScriptRejectsExplicitBDThatDoesNotResolveRepoFormula (0.14s)
=== RUN   TestReleaseFormulaCleanupStaleDoltOrphansHandlesLocalModeWithoutJQ
--- PASS: TestReleaseFormulaCleanupStaleDoltOrphansHandlesLocalModeWithoutJQ (0.02s)
PASS
ok  	github.com/steveyegge/beads/scripts	1.231s
```

`make build` clean. `go vet -tags gms_pure_go ./scripts/...` clean. No related guards or fixes in flight upstream.
