### PR TITLE
test(doltserver): release log handle in newDoltServer cleanup on Windows

### DIFF
--- a/internal/storage/db/server/doltserver_test.go
+++ b/internal/storage/db/server/doltserver_test.go
@@ -65,6 +65,10 @@ func newDoltServer(t *testing.T) (*server.DoltServer, string) {
 	log := filepath.Join(t.TempDir(), "server.log")
 	s, err := server.NewDoltServer(bin, rootDir, cfg, log, 0)
 	require.NoError(t, err)
+	// Close the log file handle before t.TempDir's RemoveAll runs.
+	// On Windows, an open handle prevents directory removal; Stop is
+	// idempotent so this is safe even when the test calls Stop itself.
+	t.Cleanup(func() { _ = s.Stop(context.Background()) })
 	return s, rootDir
 }
 


### PR DESCRIPTION
Fixes #3798

## Symptom

`TestDoltServer_Dial_BeforeStart` fails on Windows during test cleanup with:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...\server.log:
    The process cannot access the file because it is being used by another process.
--- FAIL: TestDoltServer_Dial_BeforeStart (1.71s)
```

The test's assertions pass. The failure is in Go's `testing` framework trying to remove the temp directory afterward. macOS/Linux are unaffected because POSIX allows unlinking open files.

## Root cause

`NewDoltServer` opens `server.log` at construction time and stores the handle in `s.logFile`. The handle is only closed inside `Stop()`. `TestDoltServer_Dial_BeforeStart` constructs a server (via `newDoltServer`), calls `Dial` which fails as expected before the server starts, then returns — never calling `Stop`. The `*os.File` remains open, and Windows blocks `RemoveAll` on its directory.

File: `internal/storage/db/server/doltserver.go:88` (the `os.OpenFile` call).

## Fix

Register a `t.Cleanup` in the `newDoltServer` test helper that calls `s.Stop(context.Background())` before `t.TempDir`'s `RemoveAll` runs. Cleanup callbacks execute LIFO, so this fires first. `Stop` is already idempotent — it guards every field (`s.cancel != nil`, `s.eg != nil`, `s.logFile != nil`, `s.pid != 0`) and zeroes them on first call — so tests that already call `Stop` themselves are not affected.

Test-only change. No production code touched.

## Verification

Before (Windows, upstream HEAD `8b7cbfc3b`):

```
$ go test -tags gms_pure_go ./internal/storage/db/server/... -run Dial_BeforeStart -v
=== RUN   TestDoltServer_Dial_BeforeStart
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...\server.log: The process cannot access the file because it is being used by another process.
--- FAIL: TestDoltServer_Dial_BeforeStart (1.71s)
```

After (this branch):

```
$ go test -tags gms_pure_go ./internal/storage/db/server/... -run Dial_BeforeStart -v
=== RUN   TestDoltServer_Dial_BeforeStart
--- PASS: TestDoltServer_Dial_BeforeStart (0.01s)
PASS
```

Full package (`./internal/storage/db/server/...`): 26 tests pass, 1 skipped (unix sockets, expected on Windows). `make build` clean.

To reproduce the original failure: check out `8b7cbfc3b` on Windows and run:

```
go test -tags gms_pure_go ./internal/storage/db/server/... -run Dial_BeforeStart -v
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->