### PR TITLE
test: skip TestUpdateCloseHookFiring on Windows (GH#3800)

### DIFF
--- a/cmd/bd/update_close_hook_test.go
+++ b/cmd/bd/update_close_hook_test.go
@@ -13,6 +13,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/hooks"
@@ -22,6 +23,16 @@ import (
 // TestUpdateCloseHookFiring verifies hook firing logic for status transitions.
 // Uses RunSync to test hooks without needing the full CLI or Dolt infrastructure.
 func TestUpdateCloseHookFiring(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the marker file is never created
+		// and the assertion fails. Skipping until the runner gains Windows script
+		// support (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	t.Run("on_close_fires_for_status_transition_to_closed", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		markerFile := filepath.Join(tmpDir, "on_close_fired.txt")


### PR DESCRIPTION
Fixes #3800

## What

Skip `TestUpdateCloseHookFiring` on Windows with an explanatory comment and issue reference. One test, one skip guard, no other changes.

## Why

The test writes a POSIX shell script (`#!/bin/sh`) as the hook file, then calls `runner.RunSync(...)` and asserts the hook created a marker file. On Windows the hook runner (`internal/hooks/hooks_windows.go`) executes hooks via `exec.Command(ctx, hookPath, ...)`, which delegates to `CreateProcess`. Windows has no shebang dispatch: an extensionless file starting with `#!/bin/sh` is not runnable as a shell script, the exec silently no-ops (no error, no output), and the marker file is never created.

Root cause in one line: test setup assumes POSIX shell execution; the Windows runner provides none.

The right long-term fix is to add PATHEXT-aware extension lookup and interpreter dispatch to the Windows runner (look for `on_close.ps1`, `on_close.cmd`, etc. and invoke the appropriate interpreter). That is tracked in GH#3800 and is a non-trivial runner change, deliberately out of scope here.

## Verification

Before (Windows, HEAD `8b7cbfc3b`):

```
=== RUN   TestUpdateCloseHookFiring/on_close_fires_for_status_transition_to_closed
    update_close_hook_test.go:49: on_close hook did not create marker file: ...The system cannot find the file specified.
--- FAIL: TestUpdateCloseHookFiring (0.00s)
```

After:

```
=== RUN   TestUpdateCloseHookFiring
    update_close_hook_test.go:33: hook script execution not supported on Windows - see GH#3800
--- SKIP: TestUpdateCloseHookFiring (0.00s)
PASS
ok  	github.com/steveyegge/beads/cmd/bd	0.218s
```

`TestUpdateCloseHookCondition` (pure logic, no exec) continues to pass on Windows unchanged. `make build` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->