### PR TITLE
test(hooks): skip 5 POSIX-shebang tests on Windows (GH#3800)

### DIFF
--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -148,6 +148,16 @@ func TestRunSync_NotExecutable(t *testing.T) {
 }
 
 func TestRunSync_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the marker file is never created
+		// and the assertion fails. Skipping until the runner gains Windows script
+		// support (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnCreate)
 	outputFile := filepath.Join(tmpDir, "output.txt")
@@ -180,6 +190,16 @@ echo "$1 $2" > ` + outputFile
 }
 
 func TestRunSync_ReceivesJSON(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so stdin is never read and the JSON
+		// assertion fails. Skipping until the runner gains Windows script support
+		// (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnCreate)
 	outputFile := filepath.Join(tmpDir, "stdin.txt")
@@ -219,6 +239,16 @@ cat > ` + outputFile
 }
 
 func TestRunSync_Timeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. The 'sleep 60' shell hook silently no-ops
+		// instead of running, so RunSync returns immediately rather than hitting the
+		// timeout path and the expected timeout error never surfaces. Skipping until
+		// the runner gains Windows script support (PATHEXT-aware extension lookup +
+		// interpreter dispatch). See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	if testing.Short() {
 		t.Skip("Skipping timeout test in short mode")
 	}
@@ -311,6 +341,16 @@ func TestRunSync_KillsDescendants(t *testing.T) {
 }
 
 func TestRunSync_HookFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the hook silently no-ops instead
+		// of exiting 1, and the expected error is never returned. Skipping until the
+		// runner gains Windows script support (PATHEXT-aware extension lookup +
+		// interpreter dispatch). See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnUpdate)
 
@@ -331,6 +371,16 @@ exit 1`
 }
 
 func TestRun_Async(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The hook runner on Windows executes hook files directly via CreateProcess,
+		// which has no shebang dispatch. An extensionless file containing #!/bin/sh
+		// cannot be executed as a shell script, so the marker file is never created
+		// and the assertion fails. Skipping until the runner gains Windows script
+		// support (PATHEXT-aware extension lookup + interpreter dispatch).
+		// See: https://github.com/gastownhall/beads/issues/3800
+		t.Skip("hook script execution not supported on Windows - see GH#3800")
+	}
+
 	tmpDir := t.TempDir()
 	hookPath := filepath.Join(tmpDir, HookOnClose)
 	outputFile := filepath.Join(tmpDir, "async_output.txt")


### PR DESCRIPTION
Fixes #3805

## What

Skip 5 POSIX-shebang hook tests on Windows with explanatory comments and GH#3800 references. Five tests, five skip guards, no other changes. Companion to PR #3802 (`TestUpdateCloseHookFiring`), same root cause, same fix pattern.

Tests skipped:
- `TestRunSync_Success`
- `TestRunSync_HookFailure`
- `TestRun_Async`
- `TestRunSync_ReceivesJSON`
- `TestRunSync_Timeout`

## Why

Each test writes an extensionless `#!/bin/sh` script as a hook file, then asserts execution side effects (file created, stdin captured, non-zero exit code, timeout error). On Windows the hook runner (`internal/hooks/hooks_windows.go`) delegates to `exec.Command` → `CreateProcess`, which has no shebang dispatch. The hook silently no-ops: no file is written, stdin is never read, the expected error from `exit 1` is never returned, and `RunSync` returns immediately rather than hitting the timeout path.

Root cause in one line: tests assume POSIX shell execution; the Windows runner provides none.

The right long-term fix is PATHEXT-aware extension lookup and interpreter dispatch in the Windows runner. That is tracked in GH#3800 and is deliberately out of scope here, same call as PR #3802.

## Verification

Before (Windows, HEAD `8b7cbfc3b`):

```
=== RUN   TestRunSync_Success
    hooks_test.go:171: Failed to read output file: open ...\output.txt: The system cannot find the file specified.
--- FAIL: TestRunSync_Success (0.00s)
=== RUN   TestRunSync_HookFailure
    hooks_test.go:329: RunSync should have returned error for failed hook
--- FAIL: TestRunSync_HookFailure (0.00s)
=== RUN   TestRun_Async
    hooks_test.go:365: Failed to read output file after retries: open ...\async_output.txt: The system cannot find the file specified.
--- FAIL: TestRun_Async (0.00s)
=== RUN   TestRunSync_ReceivesJSON
    hooks_test.go:210: Hook did not receive JSON input
--- FAIL: TestRunSync_ReceivesJSON (0.00s)
=== RUN   TestRunSync_Timeout
    hooks_test.go:267: RunSync should have returned error for timeout
--- FAIL: TestRunSync_Timeout (0.00s)
```

After:

```
=== RUN   TestRunSync_Success
    hooks_test.go:158: hook script execution not supported on Windows - see GH#3800
--- SKIP: TestRunSync_Success (0.00s)
=== RUN   TestRunSync_ReceivesJSON
    hooks_test.go:200: hook script execution not supported on Windows - see GH#3800
--- SKIP: TestRunSync_ReceivesJSON (0.00s)
=== RUN   TestRunSync_Timeout
    hooks_test.go:249: hook script execution not supported on Windows - see GH#3800
--- SKIP: TestRunSync_Timeout (0.00s)
=== RUN   TestRunSync_HookFailure
    hooks_test.go:351: hook script execution not supported on Windows - see GH#3800
--- SKIP: TestRunSync_HookFailure (0.00s)
=== RUN   TestRun_Async
    hooks_test.go:381: hook script execution not supported on Windows - see GH#3800
--- SKIP: TestRun_Async (0.00s)
PASS
ok      github.com/steveyegge/beads/internal/hooks      0.385s
```

Pure-logic tests (`TestNewRunner`, `TestEventToHook`, `TestHookExists_*`, `TestRunSync_NoHook`, `TestRunSync_NotExecutable`, `TestAllHookEvents`) continue to pass on Windows unchanged. `make build` clean.

Note: `TestHookExists_Executable` fails on Windows on `upstream/main` for an unrelated reason (NTFS does not honor `0755` exec bits the way POSIX file modes assume) — pre-existing, different root cause, will be filed separately.
