### PR TITLE
fix: doltTransaction.DeleteIssue cascades to related tables (follow-up to #3803)

### DIFF
--- a/internal/storage/dolt/events_test.go
+++ b/internal/storage/dolt/events_test.go
@@ -1,9 +1,11 @@
 package dolt
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -73,6 +75,59 @@ func TestGetAllEventsSince_UnionBothTables(t *testing.T) {
 			t.Errorf("events not in chronological order: [%d] %v > [%d] %v",
 				i-1, events[i-1].CreatedAt, i, events[i].CreatedAt)
 		}
+	}
+}
+
+// TestDeleteIssue_CascadesRelatedTables verifies that DeleteIssue via
+// RunInTransaction delegates to issueops.DeleteIssueInTx, which cascades to
+// related tables (labels, events, comments, dependencies). Regression guard
+// for the parity gap where the dolt path did a raw DELETE with no cascade,
+// mirroring the embedded path at internal/storage/embeddeddolt/transaction.go:78-84.
+func TestDeleteIssue_CascadesRelatedTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "ev-delete-1",
+		Title:     "Issue to delete",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	// Add a label so we can verify cascade cleanup happened
+	if err := store.AddLabel(ctx, issue.ID, "to-delete", "tester"); err != nil {
+		t.Fatalf("AddLabel: %v", err)
+	}
+
+	// Delete via transaction — exercises doltTransaction.DeleteIssue
+	err := store.RunInTransaction(ctx, "test: delete issue", func(tx storage.Transaction) error {
+		return tx.DeleteIssue(ctx, issue.ID)
+	})
+	if err != nil {
+		t.Fatalf("RunInTransaction/DeleteIssue: %v", err)
+	}
+
+	// Issue must be gone
+	_, getErr := store.GetIssue(ctx, issue.ID)
+	if !errors.Is(getErr, storage.ErrNotFound) {
+		t.Errorf("expected ErrNotFound after DeleteIssue, got %v", getErr)
+	}
+
+	// Labels must be cascade-cleaned — the raw-SQL path only deleted from issues,
+	// leaving label rows orphaned. Delegation to DeleteIssueInTx removes them.
+	labels, err := store.GetLabels(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetLabels after delete: %v", err)
+	}
+	if len(labels) != 0 {
+		t.Errorf("expected no labels after DeleteIssue, got %v (cascade did not run)", labels)
 	}
 }
 

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -616,17 +616,21 @@ func (t *doltTransaction) CloseIssue(ctx context.Context, id string, reason stri
 
 // DeleteIssue deletes an issue within the transaction
 func (t *doltTransaction) DeleteIssue(ctx context.Context, id string) error {
-	table := "issues"
-	if t.isActiveWisp(ctx, id) {
-		table = "wisps"
+	isWisp := t.isActiveWisp(ctx, id)
+	issueTable, labelTable, eventTable, depTable := issueops.WispTableRouting(isWisp)
+	commentTable := "comments"
+	if isWisp {
+		commentTable = "wisp_comments"
 	}
-
-	//nolint:gosec // G201: table is hardcoded
-	_, err := t.tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE id = ?", table), id)
-	if err == nil {
-		t.dirty.MarkDirty(table)
+	if err := issueops.DeleteIssueInTx(ctx, t.tx, id); err != nil {
+		return wrapExecError("delete issue in tx", err)
 	}
-	return wrapExecError("delete issue in tx", err)
+	t.dirty.MarkDirty(issueTable)
+	t.dirty.MarkDirty(depTable)
+	t.dirty.MarkDirty(labelTable)
+	t.dirty.MarkDirty(commentTable)
+	t.dirty.MarkDirty(eventTable)
+	return nil
 }
 
 // AddDependency adds a dependency within the transaction.


### PR DESCRIPTION
Fixes #3807

## What

`doltTransaction.DeleteIssue` now delegates to `issueops.DeleteIssueInTx` and marks all five affected tables dirty, matching the embedded path at `internal/storage/embeddeddolt/transaction.go:78-84`.

## Why

The dolt transaction path used raw SQL that only deleted the issue row:

```go
_, err := t.tx.ExecContext(ctx, fmt.Sprintf("DELETE FROM %s WHERE id = ?", table), id)
```

No cascade to labels, events, comments, or dependencies. Label rows, event history, comments, and dependency edges were left orphaned whenever an issue was deleted inside a transaction. The non-transactional `DoltStore.DeleteIssue` (line 344 of `issues.go`) already correctly calls `issueops.DeleteIssueInTx` — the transaction path was the outlier.

This is the structural twin of PR #3803, which fixed `CloseIssue`, `AddLabel`, and `RemoveLabel`. That PR flagged `DeleteIssue` explicitly in its "out-of-scope finding" section; this PR closes the gap.

**Fix**: delegate to `issueops.DeleteIssueInTx`, use `issueops.WispTableRouting` to get routed table names, and mark all relevant tables dirty. Comment table is routed directly (`"comments"` / `"wisp_comments"`) since `WispTableRouting` has no comment-table entry — same as the embedded reference.

## Verification

New regression test in `internal/storage/dolt/events_test.go`:

- `TestDeleteIssue_CascadesRelatedTables` — creates an issue with a label, deletes via `RunInTransaction`, asserts the issue is gone and labels are cascade-cleaned. The raw-SQL path left labels orphaned; delegation to `DeleteIssueInTx` removes them.

```bash
go test -tags gms_pure_go -run "TestDeleteIssue_CascadesRelatedTables" ./internal/storage/dolt/...
```

Test skips cleanly without a Dolt server. `make build` and `go test -tags gms_pure_go ./internal/storage/dolt/...` both pass.

## Out-of-scope

No other methods in `transaction.go` were touched. Any further parity gaps found during review should be filed as separate beads.

Note: builds on top of #3803's fix shape; can land in either order without rebase since they touch different methods.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->