### PR TITLE
test(regression): prevent baseline daemon timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ endif
 # ICU flags are only needed for scripts/test-icu-path.sh (which exercises the
 # opt-in ICU regex path).
 BUILD_TAGS := gms_pure_go
+REGRESSION_TIMEOUT ?= 20m
 
 # Build the bd binary
 build:
@@ -83,7 +84,7 @@ test-full-cgo:
 # Override baseline: BD_REGRESSION_BASELINE_BIN=/path/to/bd make test-regression
 test-regression:
 	@echo "Running regression tests (baseline vs candidate)..."
-	go test -tags=regression,$(BUILD_TAGS) -timeout=10m -v ./tests/regression/...
+	go test -tags=regression,$(BUILD_TAGS) -timeout=$(REGRESSION_TIMEOUT) -v ./tests/regression/...
 
 # Run upgrade smoke tests (release stability gate).
 # Tests that upgrading from previous release preserves data, role, and mode.

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -13,6 +13,7 @@ package regression
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -21,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -249,6 +251,7 @@ func newWorkspace(t *testing.T, bdPath string) *workspace {
 	t.Helper()
 	dir := t.TempDir()
 	w := &workspace{dir: dir, bdPath: bdPath, t: t}
+	w.cleanupBaselineDaemon()
 
 	w.git("init")
 	w.git("config", "user.name", "regression-test")
@@ -269,6 +272,31 @@ func newWorkspace(t *testing.T, bdPath string) *workspace {
 	w.run("init", "--prefix", prefix, "--quiet")
 
 	return w
+}
+
+func (w *workspace) cleanupBaselineDaemon() {
+	w.t.Helper()
+	if baselineBin == "" || w.bdPath != baselineBin {
+		return
+	}
+
+	w.t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, w.bdPath, "daemon", "stop")
+		cmd.Dir = w.dir
+		cmd.Env = w.runEnv()
+		_ = cmd.Run()
+
+		if pkill, err := exec.LookPath("pkill"); err == nil {
+			pkillCtx, pkillCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer pkillCancel()
+
+			pattern := "^" + regexp.QuoteMeta(w.bdPath) + " daemon start$"
+			_ = exec.CommandContext(pkillCtx, pkill, "-f", pattern).Run()
+		}
+	})
 }
 
 func (w *workspace) runEnv() []string {


### PR DESCRIPTION
## Summary
- make the regression gate timeout overrideable and raise the default to 20m
- clean up legacy v0.49.6 baseline daemon processes from regression workspaces

## Verification
- make test-regression passed in WSL in 1069.712s
- Docker daemon was unavailable in WSL, so the harness skipped Dolt container tests

Tracked locally as mybd-0sg.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->