### PR TITLE
docs: resolve legacy extension guide reference

### DIFF
--- a/docs/DOC_INVENTORY.md
+++ b/docs/DOC_INVENTORY.md
@@ -164,7 +164,7 @@ All `examples/*/README.md` files are narrative tutorials. Classification: unifor
 |------|-------|---------|------------|
 | `examples/README.md` | a | Examples index. | low. |
 | `examples/bash-agent/README.md` | a | Bash agent walkthrough. | med. |
-| `examples/bd-example-extension-go/README.md` | a / **broken link** | References `docs/EXTENDING.md` **which does not exist in this tree** — already drifted. | high (because of the dead link). |
+| `examples/bd-example-extension-go/README.md` | a / legacy SQLite example | Legacy custom-table extension example. It now points at `docs/ADVANCED.md#extensible-database` for current Dolt-era guidance instead of relying on the old missing extension guide. | med — legacy SQLite pattern can drift from current Dolt guidance. |
 | `examples/claude-desktop-mcp/README.md` | a | Claude Desktop MCP example. | med. |
 | `examples/compaction/README.md` | a | Compaction examples. | low. |
 | `examples/contributor-workflow/README.md` | a | OSS contributor workflow. | med. |
@@ -434,7 +434,7 @@ After maintainer reviews this inventory, Phase 2 candidates:
 - **`docs/CLI_REFERENCE.md` `Version: 0.21.0+` header** — this is exactly the GH#3683 issue PR #3704 fixes; included here for completeness.
 - **`docs/DOLT.md` and `docs/DOLT-BACKEND.md`** — two Dolt-backend overview docs at different lengths. Possible duplication or scope-bleed.
 - **`docs/RELEASING.md` and root `RELEASING.md`** — same content, different files. Possible duplication.
-- **`examples/bd-example-extension-go/README.md` references `docs/EXTENDING.md`** — that file does not exist in upstream/main. Dead cross-reference.
+- **`examples/bd-example-extension-go/README.md` used to reference the old extension guide** — that file does not exist in upstream/main. The example now carries a legacy SQLite note and links to `docs/ADVANCED.md#extensible-database`.
 - **A second hand-written CLI reference lives at `plugins/beads/skills/beads/resources/CLI_REFERENCE.md`** — separate from `docs/CLI_REFERENCE.md`. PR #3704 only fixes one of them.
 - **`docs/dev-notes/`** contains five resolved/historical audit reports. They're (c) historical, but it's worth deciding whether to archive them or leave them where they are.
 - **`docs/LINTING.md`'s "22 issues as of Nov 6 2025"** — date-stamped snapshot inside narrative prose; likely already wrong.
@@ -443,5 +443,5 @@ After maintainer reviews this inventory, Phase 2 candidates:
 
 - **Versioned docs:** treated as "snapshots that should not have a freshness mechanism" — a stale snapshot for v1.0.0 is correct behaviour, not drift. Confirm this matches Docusaurus norm.
 - **Plugin command files** (`plugins/beads/skills/beads/commands/*.md`) classified as (b). They're part of a published Claude Code skill bundle; regenerating them upstream may collide with downstream skill packaging. The recommendation is to coordinate with the skill maintainers before adding a generator.
-- **`docs/EXTENDING.md` is missing.** Either it should be written (and the example link unbroken) or the example reference should be removed. Out of scope for Phase 1.
+- **The old extension guide is missing.** The live example reference has been removed; do not reintroduce links to it unless a focused extension guide is added.
 - **Boundary between (a) and (b) for docs with mixed content** (e.g., `docs/LABELS.md`, `docs/ADVANCED.md`, `docs/TROUBLESHOOTING.md`) — classified as primarily (a) when narrative dominates but flagged as having (b)-style sections. Phase 2 may want to split these or use partial-generation block markers.

--- a/examples/bd-example-extension-go/README.md
+++ b/examples/bd-example-extension-go/README.md
@@ -1,6 +1,8 @@
 # BD Extension Example (Go)
 
-This example demonstrates how to extend bd with custom tables for application-specific orchestration.
+This legacy example demonstrates how to extend SQLite-backed bd databases with custom tables for application-specific orchestration.
+
+> **Note:** Custom SQLite table extensions are a legacy pattern. Current Dolt-backed beads workflows should prefer standalone integration tools that call `bd --json` commands or use `bd query` for SQL access. See [Extensible Database](../../docs/ADVANCED.md#extensible-database) for the current guidance.
 
 ## What This Example Shows
 

--- a/examples/library-usage/README.md
+++ b/examples/library-usage/README.md
@@ -194,6 +194,6 @@ func (s *VCStorage) ClaimWork(ctx context.Context, executorID string) (*beads.Is
 
 ## See Also
 
-- [bd-example-extension-go](../bd-example-extension-go/README.md) - Working extension example
+- [bd-example-extension-go](../bd-example-extension-go/README.md) - Legacy SQLite extension example
 - [beads.go](../../beads.go) - Public API source
 - [internal/storage/storage.go](../../internal/storage/storage.go) - Storage interface


### PR DESCRIPTION
## Context
This is part of the documentation scope/boundaries cleanup tracked locally from `mybd-1fn` (`Document Beads project scope boundaries`). That work created the project charter and turned up a small cluster of follow-up doc hygiene items where older wording still described pre-Dolt or pre-charter behavior.

One of those follow-ups is local issue `mybd-e62`: `docs/DOC_INVENTORY.md` reported that `examples/bd-example-extension-go/README.md` linked to `docs/EXTENDING.md`, but that document no longer exists. The backstory is that the Go extension example describes a legacy SQLite custom-table pattern. After the Dolt backend migration, the current extension guidance lives under `docs/ADVANCED.md#extensible-database`, while `cmd/bd/info.go` already treats the old `EXTENDING.md` / custom SQLite table extension docs as deprecated.

## Why This Change
Leaving the missing `docs/EXTENDING.md` reference in examples makes the docs inventory look stale and sends readers toward a removed guide. This PR keeps the legacy example available for historical/contextual use, but points current readers at the maintained extensible database documentation instead of recreating a guide for an obsolete path.

## Summary
- mark the Go extension example as a legacy SQLite custom-table pattern
- point current guidance to `docs/ADVANCED.md#extensible-database`
- update the docs inventory and library example wording so docs/examples no longer reference `EXTENDING.md`

## Verification
- `rg -n "docs/EXTENDING\\.md|\\]\\([^)]*EXTENDING\\.md\\)|EXTENDING\\.md" docs examples -S` returned no matches

Tracked locally as `mybd-e62`, discovered from `mybd-1fn`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
