### PR TITLE
fix(utils): be-szr ResolvePartialID falls through to GetIssue for wisps (PG)

### DIFF
--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -50,6 +50,15 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 		return issues[0].ID, nil
 	}
 
+	// Wisp fallback (be-szr): SearchIssues only consults the issues table,
+	// but on the Postgres backend wisps live in a separate table. GetIssue's
+	// PG implementation falls through to wisps on NotFound, so try it next
+	// for full IDs. This makes `bd show <wisp-id>` and `gc mail peek/read`
+	// work against PG-backed rigs.
+	if issue, err := store.GetIssue(ctx, input); err == nil && issue != nil {
+		return issue.ID, nil
+	}
+
 	// Get the configured prefix
 	prefix, err := store.GetConfig(ctx, "issue_prefix")
 	if err != nil || prefix == "" {


### PR DESCRIPTION
## Problem

`bd show <wisp-id>` and `gc mail peek <wisp-id>` return "no issue
found matching" / "bead not found" against Postgres-backed rigs after
migration.

`internal/utils/id_parser.go::ResolvePartialID`'s fast path uses
`store.SearchIssues` with an exact-ID filter. PG's `SearchIssues`
only consults the `issues` table, so full wisp IDs miss. PG's
`GetIssue` already falls through from issues→wisps on NotFound, but
the resolver wasn't reaching it for full IDs.

## Fix

After the `SearchIssues` fast path returns no rows, try
`store.GetIssue(input)`. PG's `GetIssue` handles the wisp fallback
transparently. Dolt is unaffected because its `GetIssue` resolves
wisps via the same store.

Cost: one extra indexed lookup only on the cold path (`SearchIssues`
miss), and only for callers passing full IDs.

## Verification

The PG regression test for this fix lives at
`internal/storage/postgres/wisp_resolve_test.go::TestResolvePartialIDForWispOnPG`
(build tag `integration_pg`) on PR #3768. It depends on
`startPG`/`openStore`/`storage.ConnectionConfig` from the be-6fk PG
testfixture, which is not yet on main, so the test was deliberately
not cherry-picked into this focused PR — it would not compile here.
The test will land with PR #3768 (or whichever PR brings the PG
testfixture to main).

Manual verification:
- Reverting this change in `id_parser.go` makes
  `TestResolvePartialIDForWispOnPG` fail on PR #3768 with the
  user-reported "no issue found matching" error.
- The existing Dolt-backed test
  `TestResolvePartialID_Wisp/full_wisp_ID` in
  `internal/utils/id_parser_test.go` still passes, confirming Dolt is
  unaffected.

## Out of scope

Partial wisp-ID resolution on PG (e.g., `bd show eu1` for
`bd-wisp-eu1`). The substring path in `ResolvePartialID` also goes
through `SearchIssues`, so partial wisp IDs still miss on PG.
Reported bug uses full IDs; partial wisp IDs is a separate
follow-up.

These two commits (fix + test) are also bundled in PR #3768 (a much
larger local-integ rebase). This focused PR exists so the fix can
land independently; PR #3768 will pick it up as already-merged on
rebase. The test stays in #3768 because it depends on the PG
testfixture also bundled there.

Refs: be-szr (root cause), be-h6xv (build bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->