### PR TITLE
fix(formula): bd formula show --full emits step descriptions

### DIFF
--- a/cmd/bd/formula.go
+++ b/cmd/bd/formula.go
@@ -75,9 +75,12 @@ Displays:
   - Composition rules (extends, aspects, expansions)
   - Bond points for external composition
 
+Use --full to emit each step's description below its title — the form
+formula-driven agents need to execute the recipe.
+
 Examples:
   bd formula show shiny
-  bd formula show rule-of-five
+  bd formula show rule-of-five --full
   bd formula show security-audit --json`,
 	Args: cobra.ExactArgs(1),
 	Run:  runFormulaShow,
@@ -183,6 +186,7 @@ func runFormulaList(cmd *cobra.Command, args []string) {
 
 func runFormulaShow(cmd *cobra.Command, args []string) {
 	name := args[0]
+	full, _ := cmd.Flags().GetBool("full")
 
 	// Create parser with default search paths
 	parser := formula.NewParser()
@@ -260,13 +264,13 @@ func runFormulaShow(cmd *cobra.Command, args []string) {
 	// Print steps
 	if len(f.Steps) > 0 {
 		fmt.Printf("\n%s Steps (%d):\n", ui.RenderPass("🌲"), countSteps(f.Steps))
-		printFormulaStepsTree(f.Steps, "   ")
+		printFormulaStepsTree(f.Steps, "   ", full)
 	}
 
 	// Print template (for expansion formulas)
 	if len(f.Template) > 0 {
 		fmt.Printf("\n%s Template (%d steps):\n", ui.RenderAccent("📐"), len(f.Template))
-		printFormulaStepsTree(f.Template, "   ")
+		printFormulaStepsTree(f.Template, "   ", full)
 	}
 
 	// Print advice rules
@@ -422,8 +426,10 @@ func getTypeIcon(t string) string {
 	}
 }
 
-// printFormulaStepsTree prints steps in a tree format.
-func printFormulaStepsTree(steps []*formula.Step, indent string) {
+// printFormulaStepsTree prints steps in a tree format. When full is true,
+// each step's description is emitted below its title, indented under the
+// step's children-continuation column.
+func printFormulaStepsTree(steps []*formula.Step, indent string, full bool) {
 	for i, step := range steps {
 		connector := "├──"
 		if i == len(steps)-1 {
@@ -454,14 +460,23 @@ func printFormulaStepsTree(steps []*formula.Step, indent string) {
 
 		fmt.Printf("%s%s %s: %s%s%s\n", indent, connector, step.ID, step.Title, typeStr, depStr)
 
-		if len(step.Children) > 0 {
-			childIndent := indent
-			if i == len(steps)-1 {
-				childIndent += "    "
-			} else {
-				childIndent += "│   "
+		// childIndent is shared by --full description rendering and child
+		// step rendering: both should sit under the step's content column.
+		childIndent := indent
+		if i == len(steps)-1 {
+			childIndent += "    "
+		} else {
+			childIndent += "│   "
+		}
+
+		if full && step.Description != "" {
+			for _, line := range strings.Split(strings.TrimRight(step.Description, "\n"), "\n") {
+				fmt.Printf("%s%s\n", childIndent, line)
 			}
-			printFormulaStepsTree(step.Children, childIndent)
+		}
+
+		if len(step.Children) > 0 {
+			printFormulaStepsTree(step.Children, childIndent, full)
 		}
 	}
 }
@@ -745,6 +760,7 @@ func fixIntegerFields(m map[string]interface{}) {
 
 func init() {
 	formulaListCmd.Flags().String("type", "", "Filter by type (workflow, expansion, aspect, convoy)")
+	formulaShowCmd.Flags().Bool("full", false, "Emit each step's description below its title (formula-driven agents need this to execute the recipe)")
 	formulaConvertCmd.Flags().BoolVar(&convertAll, "all", false, "Convert all JSON formulas")
 	formulaConvertCmd.Flags().BoolVar(&convertDelete, "delete", false, "Delete JSON file after conversion")
 	formulaConvertCmd.Flags().BoolVar(&convertStdout, "stdout", false, "Print TOML to stdout instead of file")

--- a/cmd/bd/formula_show_test.go
+++ b/cmd/bd/formula_show_test.go
@@ -1,0 +1,157 @@
+//go:build cgo
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/formula"
+	"github.com/steveyegge/beads/internal/git"
+)
+
+func captureStdoutForFormulaShow(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("pipe close: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("pipe drain: %v", err)
+	}
+	return buf.String()
+}
+
+// printFormulaStepsTree is the function the --full flag plumbs through to.
+// Test it directly so the formatting contract is locked in without
+// depending on filesystem-resident formulas.
+
+func TestPrintFormulaStepsTreeDefaultOmitsDescriptions(t *testing.T) {
+	steps := []*formula.Step{
+		{ID: "first", Title: "First step title", Description: "First-step body."},
+		{ID: "second", Title: "Second step title", Description: "Second-step body."},
+	}
+	out := captureStdoutForFormulaShow(t, func() {
+		printFormulaStepsTree(steps, "   ", false)
+	})
+	if !strings.Contains(out, "First step title") {
+		t.Fatalf("default should still emit titles, got:\n%s", out)
+	}
+	if strings.Contains(out, "step body") {
+		t.Fatalf("default should NOT emit descriptions (use --full), got:\n%s", out)
+	}
+}
+
+func TestPrintFormulaStepsTreeFullEmitsDescriptions(t *testing.T) {
+	steps := []*formula.Step{
+		{ID: "first", Title: "First step title", Description: "First-line body.\nSecond-line body."},
+		{ID: "second", Title: "Second step title", Description: "Final-step body."},
+	}
+	out := captureStdoutForFormulaShow(t, func() {
+		printFormulaStepsTree(steps, "   ", true)
+	})
+	for _, want := range []string{
+		"First step title",
+		"First-line body.",
+		"Second-line body.",
+		"Second step title",
+		"Final-step body.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("--full output should contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintFormulaStepsTreeFullSkipsEmptyDescriptions(t *testing.T) {
+	steps := []*formula.Step{
+		{ID: "first", Title: "First step", Description: ""},
+		{ID: "second", Title: "Second step", Description: "Has body."},
+	}
+	out := captureStdoutForFormulaShow(t, func() {
+		printFormulaStepsTree(steps, "   ", true)
+	})
+	if !strings.Contains(out, "Has body.") {
+		t.Fatalf("--full should emit non-empty descriptions, got:\n%s", out)
+	}
+	// First step's empty description should not produce a blank-line block;
+	// guard against accidental "\n\n" gap between first-step title and
+	// second-step entry.
+	if strings.Contains(out, "First step\n   │   \n") {
+		t.Fatalf("--full should not emit a placeholder block for empty descriptions, got:\n%s", out)
+	}
+}
+
+// End-to-end test: drive `bd formula show <name> --full` against a real
+// formula on disk and verify the flag plumbs through the cobra command
+// to the print routine.
+func TestFormulaShowCmdFullFlagEmitsDescriptions(t *testing.T) {
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("GT_ROOT", "")
+	beads.ResetCaches()
+	git.ResetCaches()
+	t.Cleanup(func() {
+		beads.ResetCaches()
+		git.ResetCaches()
+	})
+
+	root := t.TempDir()
+	formulaDir := filepath.Join(root, ".beads", "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	formulaBody := `formula = "test-recipe"
+type = "workflow"
+description = "Smoke test for --full"
+
+[[steps]]
+id = "do"
+title = "Do the thing"
+description = "Carefully do exactly the thing the bead says."
+`
+	if err := os.WriteFile(filepath.Join(formulaDir, "test-recipe.formula.toml"), []byte(formulaBody), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+	t.Chdir(root)
+	beads.ResetCaches()
+	git.ResetCaches()
+
+	// Default: no description.
+	defaultOut := captureStdoutForFormulaShow(t, func() {
+		formulaShowCmd.Run(formulaShowCmd, []string{"test-recipe"})
+	})
+	if !strings.Contains(defaultOut, "Do the thing") {
+		t.Fatalf("default should emit step title, got:\n%s", defaultOut)
+	}
+	if strings.Contains(defaultOut, "Carefully do exactly") {
+		t.Fatalf("default should NOT emit step descriptions, got:\n%s", defaultOut)
+	}
+
+	// --full: description appears.
+	if err := formulaShowCmd.Flags().Set("full", "true"); err != nil {
+		t.Fatalf("set --full: %v", err)
+	}
+	t.Cleanup(func() { _ = formulaShowCmd.Flags().Set("full", "false") })
+
+	fullOut := captureStdoutForFormulaShow(t, func() {
+		formulaShowCmd.Run(formulaShowCmd, []string{"test-recipe"})
+	})
+	if !strings.Contains(fullOut, "Carefully do exactly the thing the bead says.") {
+		t.Fatalf("--full should emit step descriptions, got:\n%s", fullOut)
+	}
+}

--- a/cmd/bd/mol_distill.go
+++ b/cmd/bd/mol_distill.go
@@ -176,7 +176,7 @@ func runMolDistill(cmd *cobra.Command, args []string) {
 			}
 		}
 		fmt.Printf("\nStructure:\n")
-		printFormulaStepsTree(f.Steps, "")
+		printFormulaStepsTree(f.Steps, "", false)
 		return
 	}
 


### PR DESCRIPTION
## What

Adds a `--full` flag to `bd formula show <name>` that emits each step's
description below its title, indented under the tree's continuation
column. Default output (no flag) is unchanged.

## Why

`bd formula show` is the canonical surface for reading a formula's
recipe — but today it emits step IDs and titles only, not the step
descriptions agents need to execute the formula. That gap forced
formula-driven agents (deacon, witness, refinery, dog, pool-worker)
to fall back to reading the on-disk `.beads/formulas/<name>.formula.toml`
directly. Forensic transcripts from a 2026-05-08 gastownhall/gascity
run captured agents spending redundant turns paginating
`bd formula show` output then `Read`-ing the .toml source.

The naive fix was to point each agent prompt at the .toml path
(gastownhall/gascity#1845, closed): that couples every prompt to the
on-disk layout and fights the formulas-as-shared-code abstraction.
Eric's closing comment on that PR pinned the right surface here —
"extend `bd formula show` to emit step descriptions (likely via a
`--full` flag, or by changing the default)." This PR is option A:
backwards-compatible flag, default unchanged.

## Verification

- `make build` passes.
- Smoke test: `bd formula show test-recipe` (default) prints the
  existing summary tree; `bd formula show test-recipe --full` prints
  descriptions under each step's title with proper tree indentation
  (`│   ` for non-last steps, `    ` for last).
- Tests in `cmd/bd/formula_show_test.go`:
  - `TestPrintFormulaStepsTreeDefaultOmitsDescriptions` — regression
    coverage that default output still omits descriptions.
  - `TestPrintFormulaStepsTreeFullEmitsDescriptions` — new behavior.
  - `TestPrintFormulaStepsTreeFullSkipsEmptyDescriptions` — edge case.
  - `TestFormulaShowCmdFullFlagEmitsDescriptions` — end-to-end through
    cobra against a real formula on disk.

`make test` did not introduce regressions. Pre-existing failures in
`cmd/bd/doctor` (`TestCheckBeadsRole_NotConfigured`, `TestRole_NoConfig`)
and `internal/storage/dolt` (`TestCloudAuthCLIRouting`, Docker-gated)
also fail on origin/main with my git config (`beads.role=maintainer`)
and are unrelated to this diff.

Surface: read a formula's step descriptions via `bd formula show
<name> --full` (the canonical surface this PR closes the gap on);
not the wrong-way variant of reading
`.beads/formulas/<name>.formula.toml` directly from the agent prompt.

## Checklist

- [x] Linked an issue, or explained why one is not needed: this is the
  follow-up to gastownhall/gascity#1845's closing comment, no separate
  issue filed.
- [x] Added or updated tests for behavior changes.
- [x] Updated docs for user-facing changes: `bd formula show --help`
  now describes `--full`.
- [x] Called out breaking changes or migration notes: none — default
  behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->