### PR TITLE
fix(hooks): skip export when export file is staged for deletion

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1077,6 +1077,18 @@ func exportJSONLForCommit() {
 	}
 	fullPath := filepath.Join(beadsDir, exportPath)
 
+	// If the export file is staged for deletion (user ran `git rm`), do not
+	// re-export or re-stage it. GIT_INDEX_FILE is set during an actual commit,
+	// so git-diff-index reads the pending index — where the deletion lives.
+	// Without this guard, git add fullPath would convert the staged deletion
+	// back to a modification and the file would never be removed from the repo.
+	checkCmd := exec.Command("git", "diff", "--cached", "--diff-filter=D", "--name-only", "--", filepath.Base(fullPath))
+	checkCmd.Dir = filepath.Dir(fullPath)
+	if out, _ := checkCmd.Output(); len(out) > 0 {
+		debug.Logf("pre-commit: %s staged for deletion — skipping export\n", exportPath)
+		return
+	}
+
 	debug.Logf("pre-commit: exporting JSONL to %s\n", fullPath)
 
 	// Shell out to `bd export` which initializes its own store.


### PR DESCRIPTION
## Problem

`exportJSONLForCommit` in the pre-commit hook unconditionally exports
the JSONL file and then runs \`git add\` on it. If the user has staged
a deletion of the file with \`git rm\` (e.g. they decided to stop
tracking it), the hook re-creates the file and re-stages it, which
converts the staged deletion back to a modification — so the file
never actually gets removed from the repo.

Reproducer:

\`\`\`
git rm .beads/issues.jsonl
git commit -m \"drop tracked export\"
git status
# .beads/issues.jsonl reappears, modified instead of deleted
\`\`\`

I hit this trying to retire a tracked JSONL on one of our repos and
ended up having to disable the hook to delete the file.

## Change

In \`cmd/bd/hooks.go\`, before exporting, check whether the export
file is staged for deletion:

\`\`\`
git diff --cached --diff-filter=D --name-only -- <basename>
\`\`\`

If the basename appears in the staged-deletion list, skip the export
and the \`git add\` entirely. \`GIT_INDEX_FILE\` is already in the
environment during a real commit, so \`git diff --cached\` reads the
pending index.

12-line addition, no new dependencies, no behavior change for users
who aren't \`git rm\`'ing the export file.

## Not in scope

- Doesn't touch the export-on-write or export-on-merge paths.
- Doesn't change behavior when the file is staged for *modification*.
- Doesn't add a config key — staged deletion is an unambiguous user
  intent signal.

## Testing

- \`go build -tags gms_pure_go ./...\` passes.
- Manually verified the reproducer above: with the fix, \`git rm\`
  + commit cleanly removes the file; without it, the file resurrects.

Happy to add a unit test if there's a preferred shape for hook tests
in the repo (couldn't find an obvious existing pattern for the
pre-commit path).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->