### PR TITLE
feat(init): default to unix socket transport when /tmp/mysql.sock is present

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -28,6 +28,39 @@ import (
 	"golang.org/x/term"
 )
 
+// defaultDoltSocketPath is the standard path Dolt's sql-server uses for its
+// unix domain socket. Declared as a var (not const) so init tests can swap
+// it for a temp-dir socket without depending on a real Dolt instance.
+var defaultDoltSocketPath = "/tmp/mysql.sock"
+
+// detectDefaultDoltSocket returns the standard Dolt unix socket path if a
+// unix socket is currently listening there, otherwise returns "". Used by
+// `bd init` to opt new beads dirs into unix-socket transport when the
+// machine clearly has Dolt running locally.
+//
+// Rationale: short-lived `bd` invocations over TCP loopback create a
+// TIME_WAIT entry per close that lingers ~30s on macOS (2*MSL with
+// MSL=15s). Across crew sessions, mayor, refinery, polecats, and daemons
+// the count climbs past port-monitor alert thresholds and risks port
+// exhaustion. Unix-socket transport bypasses TIME_WAIT entirely. Setting
+// the key at init time means new rigs/clones inherit the correct config
+// from the start instead of needing a post-init fixer script.
+//
+// Conservative semantics: only sets when the socket is *currently
+// present* at init time. Machines without a running Dolt server (or with
+// a non-default socket path) fall through to the existing TCP behavior.
+// Users with a custom path can still pass `--socket` explicitly.
+func detectDefaultDoltSocket() string {
+	info, err := os.Stat(defaultDoltSocketPath)
+	if err != nil {
+		return ""
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return ""
+	}
+	return defaultDoltSocketPath
+}
+
 var initCmd = &cobra.Command{
 	Use:     "init",
 	GroupID: "setup",
@@ -857,6 +890,8 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				fmt.Fprintf(os.Stderr, "Warning: failed to load existing metadata.json: %v\n", err)
 			}
 
+			freshInit := existingCfg == nil
+
 			var cfg *configfile.Config
 			if existingCfg != nil {
 				// Preserve existing config
@@ -936,6 +971,15 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				}
 				if serverSocket != "" {
 					cfg.DoltServerSocket = serverSocket
+				} else if freshInit && cfg.DoltServerSocket == "" {
+					// Fresh init + no explicit --socket flag: probe the standard
+					// Dolt unix socket and adopt it if present. Eliminates TCP
+					// TIME_WAIT churn from short-lived bd invocations on busy
+					// rigs (rationale on detectDefaultDoltSocket). Falls back
+					// silently to TCP when the socket is absent.
+					if sock := detectDefaultDoltSocket(); sock != "" {
+						cfg.DoltServerSocket = sock
+					}
 				}
 				if serverUser != "" {
 					cfg.DoltServerUser = serverUser

--- a/cmd/bd/init_default_socket_test.go
+++ b/cmd/bd/init_default_socket_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestDetectDefaultDoltSocket_Present verifies that detectDefaultDoltSocket
+// returns the configured path when a real unix socket is listening there.
+//
+// Uses MkdirTemp under /tmp with a short prefix instead of t.TempDir() —
+// macOS limits unix socket paths to 104 chars (sun_path), and the default
+// per-test temp dir blows past that with the test name embedded.
+func TestDetectDefaultDoltSocket_Present(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix domain sockets are not supported on Windows")
+	}
+
+	tmpDir, err := os.MkdirTemp("/tmp", "bds")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "s.sock")
+
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", sockPath, err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	orig := defaultDoltSocketPath
+	defaultDoltSocketPath = sockPath
+	t.Cleanup(func() { defaultDoltSocketPath = orig })
+
+	got := detectDefaultDoltSocket()
+	if got != sockPath {
+		t.Errorf("detectDefaultDoltSocket() = %q; want %q", got, sockPath)
+	}
+}
+
+// TestDetectDefaultDoltSocket_Absent verifies that detectDefaultDoltSocket
+// returns empty when nothing is at the configured path.
+func TestDetectDefaultDoltSocket_Absent(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonExistent := filepath.Join(tmpDir, "does-not-exist.sock")
+
+	orig := defaultDoltSocketPath
+	defaultDoltSocketPath = nonExistent
+	t.Cleanup(func() { defaultDoltSocketPath = orig })
+
+	got := detectDefaultDoltSocket()
+	if got != "" {
+		t.Errorf("detectDefaultDoltSocket() = %q; want empty (path does not exist)", got)
+	}
+}
+
+// TestDetectDefaultDoltSocket_RegularFile verifies that a non-socket file
+// at the configured path is rejected. This guards against false positives
+// from leftover regular files (e.g., a `mysql.sock` text file from a
+// previous experiment).
+func TestDetectDefaultDoltSocket_RegularFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	notSocket := filepath.Join(tmpDir, "regular-file.sock")
+	if err := os.WriteFile(notSocket, []byte("not actually a socket"), 0o644); err != nil {
+		t.Fatalf("write regular file: %v", err)
+	}
+
+	orig := defaultDoltSocketPath
+	defaultDoltSocketPath = notSocket
+	t.Cleanup(func() { defaultDoltSocketPath = orig })
+
+	got := detectDefaultDoltSocket()
+	if got != "" {
+		t.Errorf("detectDefaultDoltSocket() = %q; want empty (path is a regular file, not a socket)", got)
+	}
+}
+
+// TestDetectDefaultDoltSocket_Directory verifies that a directory at the
+// configured path is rejected (defense in depth — same category of
+// false-positive guard as TestDetectDefaultDoltSocket_RegularFile).
+func TestDetectDefaultDoltSocket_Directory(t *testing.T) {
+	tmpDir := t.TempDir()
+	dir := filepath.Join(tmpDir, "a-dir-not-a-socket")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	orig := defaultDoltSocketPath
+	defaultDoltSocketPath = dir
+	t.Cleanup(func() { defaultDoltSocketPath = orig })
+
+	got := detectDefaultDoltSocket()
+	if got != "" {
+		t.Errorf("detectDefaultDoltSocket() = %q; want empty (path is a directory, not a socket)", got)
+	}
+}


### PR DESCRIPTION
## Summary

`bd init` now probes the standard Dolt unix socket path (`/tmp/mysql.sock`) and adopts it as the default `dolt_server_socket` in the new `metadata.json` when:

1. the user did not pass `--socket` explicitly,
2. this is a fresh init (not an existing-config preserve), and
3. the path is currently a listening unix socket.

New rigs/clones inherit the correct transport from the start instead of needing a post-init fixer or `BEADS_DOLT_SERVER_SOCKET` environment variable.

**Conservative semantics:** if the socket is not present at init time, falls back to the existing TCP behavior — no breakage for setups that don't have a local Dolt server on the default path. Users with custom paths can still pass `--socket /path` explicitly; the explicit flag wins. Existing-config inits do not have the default applied (preserve mode is honored).

## Why

Short-lived `bd` invocations over TCP loopback create a `TIME_WAIT` entry per close that lingers ~30s on macOS (`2 * MSL` with `MSL=15s`). On busy rigs with many crew sessions + mayor + refinery + polecats + daemons all running `bd` cycles, the `TIME_WAIT` count climbs past port-monitor alert thresholds (downstream incident: peak 280 sockets on port 3307, `ntfy` alert spam, port-exhaustion risk). Unix-socket transport bypasses `TIME_WAIT` entirely.

Setting the key at `bd init` means new metadata files get the correct transport without each clone owner needing to remember a post-init fixer.

## Implementation

- New helper `detectDefaultDoltSocket()` in `cmd/bd/init.go`. Returns `/tmp/mysql.sock` if it exists and is a unix domain socket; `""` otherwise. Uses `os.Stat().Mode()&os.ModeSocket` to check.
- New unexported `defaultDoltSocketPath` var (not const) so tests can swap it for a temp socket without depending on a real Dolt.
- `init.go` tracks `freshInit := existingCfg == nil` and applies the default only on fresh inits when no explicit flag is set and the field is empty.

Diff is small and isolated to `cmd/bd/init.go` plus a new test file.

## Tests

`cmd/bd/init_default_socket_test.go` covers:

- `TestDetectDefaultDoltSocket_Present` — listener on a temp socket → returns the path.
- `TestDetectDefaultDoltSocket_Absent` — path does not exist → returns `""`.
- `TestDetectDefaultDoltSocket_RegularFile` — path is a regular file → returns `""` (guards against false positives from leftover non-socket files).
- `TestDetectDefaultDoltSocket_Directory` — path is a directory → returns `""` (defense in depth).

The Present test uses `MkdirTemp(\"/tmp\", \"bds\") + filepath.Join(..., \"s.sock\")` to keep the path under macOS's 104-char `sun_path` limit. Skipped on Windows. All four tests run with `CGO_ENABLED=0` and do not require a Dolt instance.

```
$ CGO_ENABLED=0 go test ./cmd/bd/ -run TestDetectDefaultDoltSocket -count=1
=== RUN   TestDetectDefaultDoltSocket_Present
--- PASS
=== RUN   TestDetectDefaultDoltSocket_Absent
--- PASS
=== RUN   TestDetectDefaultDoltSocket_RegularFile
--- PASS
=== RUN   TestDetectDefaultDoltSocket_Directory
--- PASS
PASS
```

Note: full-package build / existing test suite was not verified locally due to an unrelated CGO/ICU header issue on my Mac (`unicode/regex.h not found`); CI will validate on a fresh runner.

## Refs

Downstream tracking bead: `dc-fsue` — applied a live fixer (`scripts/setup-bd-socket.sh`) to existing `~/gt/*/.beads/metadata.json` files; this PR closes the loop on the upstream side so future rigs do not need that fixer.

🤖 Generated with Gas Town crew workflow

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->