### PR TITLE
fix(auto-import): skip JSONL import when external store already has data

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -71,6 +71,22 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	}
 
 	// Fallback for non-embedded stores: multi-call path (original behavior).
+	//
+	// Defensive empty check (gastownhall/beads dc-4dix). Without this, every
+	// `bd <write-command>` against an external Dolt SQL server (TCP or unix
+	// socket) re-imports the full JSONL into a database that already has all
+	// the data — costing ~3 minutes per call on rigs with thousands of issues.
+	// The single-transaction fast-path above (jsonlImporter) does this check
+	// atomically inside the import; the fallback path historically did not,
+	// because the original GH#2994 use case was a fresh `embeddeddolt/`
+	// database, which is reliably empty on first run. External-server setups
+	// did not exist at that time but are now common (one shared Dolt server
+	// per workspace, multiple bd processes connecting via SQL).
+	if stats, err := s.GetStatistics(ctx); err == nil && stats != nil && stats.TotalIssues > 0 {
+		// Database already has data — no upgrade-recovery import needed.
+		return
+	}
+
 	fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
 
 	result, err := importFromLocalJSONLFull(ctx, s, jsonlPath)


### PR DESCRIPTION
## Summary

`bd <write-command>` triggers a full JSONL re-import on every invocation when connected to an **external Dolt SQL server** (TCP or unix socket). On a workspace with ~2500 issues this costs ~3 minutes per write. Add a missing empty-check on the non-embedded fallback path so the upgrade-recovery import only fires when the database is actually empty.

## Repro

External Dolt server (the typical multi-rig setup), `~/gt/.dolt-data/` populated, `~/gt/<rig>/.beads/issues.jsonl` exported:

```
$ echo "test" | bd comment <bead-id> --stdin
auto-importing 2921487 bytes from .beads/issues.jsonl into empty database...
auto-imported 2497 issues from .beads/issues.jsonl
✓ Comment added
real    3m12s
```

After the fix:

```
$ echo "test" | bd comment <bead-id> --stdin
✓ Comment added
real    0m1.2s
```

## Root cause

`cmd/bd/auto_import_upgrade.go::maybeAutoImportJSONL` has two paths:

1. **Fast-path (embedded mode):** `s.(jsonlImporter)` succeeds for `EmbeddedDoltStore`. Inside `ImportJSONLData`, the very first thing it does is `ScanIssueCountsInTx` → `if stats.TotalIssues > 0 { return nil }`. Atomic, correct. ✅
2. **Fallback (non-embedded):** when `s.(jsonlImporter)` fails (the case for the SQL-backed `DoltSqlStore`), the code calls `importFromLocalJSONLFull` *unconditionally*. That function walks the JSONL and upserts every record into the SQL server, even if every record is already there. ❌

Original GH#2994 motivated the fallback for upgrades from pre-0.56 (`.beads/dolt/` → `.beads/embeddeddolt/`) where the new database was reliably empty on first run, so the missing empty check had no observable effect. Today, multi-rig setups with one shared Dolt server reach the fallback for every `bd <write>` and pay the full re-import cost each time.

The user-visible symptom is the misleading `auto-importing N bytes from <path> into empty database...` line — the database is *not* empty; the code just hasn't asked.

## Fix

Add `s.GetStatistics(ctx)` before the fallback's `importFromLocalJSONLFull`. `GetStatistics` is on the base `storage.Storage` interface (which both `EmbeddedDoltStore` and `DoltSqlStore` already satisfy), so the fix is interface-pure with no type assertions or backend-specific code:

```go
if stats, err := s.GetStatistics(ctx); err == nil && stats != nil && stats.TotalIssues > 0 {
    return  // database already has data — no upgrade-recovery import needed
}
fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
result, err := importFromLocalJSONLFull(ctx, s, jsonlPath)
```

Conservative semantics: when `GetStatistics` errors, we still attempt the import (preserves the original recovery path under partial-failure conditions). The check is purely additive.

## Test plan

- [x] `go build ./...` — clean (the unrelated `unicode/regex.h` CGO error referenced in c3edbca5c is environment-specific, not a code issue; CI handles it)
- [x] Manual smoke against an external Dolt server with ~2500 issues:
  - `bd comment <id> --stdin` before fix → `auto-importing 2921487 bytes...` + ~3min wall time
  - `bd comment <id> --stdin` after fix → no auto-import line, ~1s wall time
- [x] Embedded fast-path unchanged (its empty check inside `ImportJSONLData` is independent of this guard).

A new unit test for the fallback-with-data case would require either spinning up a real Dolt SQL server in test or building a comprehensive `storage.DoltStorage` mock. Both are heavier than the one-line guard warrants. The existing `cmd/bd/auto_import_upgrade_test.go::TestEmbeddedAutoImportJSONLNoExplicitCommit` continues to cover the fast-path; CI verifies the call site builds.

## Workaround (for users on older bd until this lands)

`BEADS_NO_AUTO_IMPORT=1` env var skips the import entirely. Effective but fragile — every script and every agent has to remember it, and it also disables the legitimate upgrade-recovery for first-run setups. The fix removes the need for the workaround.

## Companion bugs in the same regression family

- `gt escalate` rejects newline-containing `--description` (different bd 1.0.3 parser path) — addressed in gastownhall/gastown#3890 (thies)
- bd init defaults to unix socket when `/tmp/mysql.sock` present (TIME_WAIT prevention) — gastownhall/beads c3edbca5c (digo, just merged)

This PR closes the perf side of the same downstream incident chain (`dc-4dix` in the WhatsApp automation rig — bd auto-import loop reproducible on every write command in agent sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->