### PR TITLE
Document project scope boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,17 @@ expected and should not be flagged.
 
 - **Issue Tracking** - How to use bd for work management
 - **Development Guidelines** - Code standards and testing
+- **Project Scope** - Read [docs/PROJECT_CHARTER.md](docs/PROJECT_CHARTER.md) before adding new feature surface area
 - **Visual Design System** - Status icons, colors, and semantic styling for CLI output
 - **Contributor Protection** - Read [CONTRIBUTING.md](CONTRIBUTING.md) before handling external PRs
 - **Maintainer PR Guidelines** - Read [PR_MAINTAINER_GUIDELINES.md](PR_MAINTAINER_GUIDELINES.md) before triaging, landing, or closing PRs
+
+## Project Scope
+
+Before adding new feature surface area, read
+[docs/PROJECT_CHARTER.md](docs/PROJECT_CHARTER.md). Beads owns issue tracking
+primitives and should not encode orchestration-layer policy, become a storage
+engine, or casually expand the database schema when metadata would work.
 
 ## PR Safety for Agents
 
@@ -50,25 +58,13 @@ See [AGENT_INSTRUCTIONS.md](AGENT_INSTRUCTIONS.md) for full development guidelin
 
 ## Storage Boundary
 
+The canonical storage boundary is in
+[docs/PROJECT_CHARTER.md](docs/PROJECT_CHARTER.md#storage-boundary). In short:
 Beads talks to storage through a driver interface (`dolthub/driver` for Dolt).
-Beads code should not reach across that boundary — no flocks, no engine
-introspection, no storage-engine-specific retry or crash-recovery logic in
-beads packages. Concurrency, locking, and crash-safety are the driver's job.
-
-If you find yourself adding storage-implementation details to beads code —
-especially anywhere on the public SDK surface (`OpenBestAvailable`, the
-`Storage` interface, return types crossing `pkg/`) — stop and reconsider.
-That is a signal the driver interface needs widening, not that beads needs
-more storage logic.
-
-**Roadmap target:** all storage interaction lives behind the driver. Beads
-stays storage-agnostic.
-
-**Filing storage issues is still encouraged** — but flag them clearly so
-they can be routed to the driver (`dolthub/driver`) rather than patched
-beads-side. Reflexive workarounds in beads (extra locks, retries, schema
-poking) are exactly the kind of cross-boundary leak this direction is
-removing. When in doubt, file the issue and ask which side owns the fix.
+Do not add beads-side flocks, engine introspection, storage-specific retry or
+crash-recovery logic, or public SDK return types that leak driver internals.
+If the boundary is too narrow, widen the interface or route the issue to the
+driver instead of patching around it in beads.
 
 ## Agent Warning: Interactive Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,13 @@ CI will automatically run linting on all pull requests.
 
 ## Making Changes
 
+### Project Scope
+
+Before adding new feature surface area, read
+[docs/PROJECT_CHARTER.md](docs/PROJECT_CHARTER.md). Beads owns issue tracking
+primitives. It should not encode orchestration-layer policy, become a storage
+engine, or expand the database schema when issue metadata is sufficient.
+
 ### Workflow
 
 1. Fork the repository

--- a/PR_MAINTAINER_GUIDELINES.md
+++ b/PR_MAINTAINER_GUIDELINES.md
@@ -10,6 +10,10 @@ For every PR, look for the value in it and choose the action that moves useful w
 
 The goal is not to block contributors unnecessarily. The goal is to identify useful work, preserve it, and keep the project moving.
 
+Read [docs/PROJECT_CHARTER.md](docs/PROJECT_CHARTER.md) when a PR changes
+Beads' product surface area. Scope boundaries should guide where value lands:
+core, metadata, integration, plugin, orchestration layer, or external tool.
+
 ## Contributor Protection
 
 External contributor PRs have priority. Before implementing related work, opening a competing PR, or closing a PR, check whether an existing contributor PR already addresses the same area.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes bd's overall architecture - the data model, sync mechanism, and how components fit together. For internal implementation details (FlushManager, Blocked Cache), see [INTERNALS.md](INTERNALS.md).
+This document describes bd's overall architecture - the data model, sync mechanism, and how components fit together. For product scope boundaries, see [PROJECT_CHARTER.md](PROJECT_CHARTER.md). For internal implementation details (FlushManager, Blocked Cache), see [INTERNALS.md](INTERNALS.md).
 
 ## The Two-Layer Data Model
 
@@ -213,6 +213,10 @@ open ──▶ in_progress ──▶ closed
 
 Each issue in the Dolt database (and in JSONL exports via `bd export`) has the following fields. Fields marked with `(optional)` use `omitempty` and are excluded when empty/zero.
 
+The schema is stable by default. Prefer issue metadata for integration,
+orchestration, or team-specific data before adding new first-class fields; see
+[Project Charter: Schema Boundary](PROJECT_CHARTER.md#schema-boundary).
+
 **Core Identification:**
 
 | Field | Type | Description |
@@ -354,6 +358,7 @@ The `bd mol squash` command uses hard delete intentionally - tombstones would be
 
 ## Related Documentation
 
+- [PROJECT_CHARTER.md](PROJECT_CHARTER.md) - Product scope and boundaries
 - [MOLECULES.md](MOLECULES.md) - Molecular chemistry metaphor (protos, pour, bond, squash, burn)
 - [INTERNALS.md](INTERNALS.md) - FlushManager, Blocked Cache implementation details
 - [ADVANCED.md](ADVANCED.md) - Advanced features and configuration

--- a/docs/DOC_INVENTORY.md
+++ b/docs/DOC_INVENTORY.md
@@ -87,6 +87,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `OBSERVABILITY.md` | Keep | User-facing OTel guide; data-model reference owns schema tables. |
 | `PERFORMANCE_TESTING.md` | Keep | Maintainer testing guide. |
 | `PLUGIN.md` | Keep | User-facing plugin guide. |
+| `PROJECT_CHARTER.md` | Keep | Canonical product scope and boundary policy. |
 | `PROTECTED_BRANCHES.md` | Keep | User-facing protected-branch workflow. |
 | `QUICKSTART.md` | Keep pointer | Short pointer to website quickstart; low drift. |
 | `README_TESTING.md` | Consolidated pointer | Old duplicate staged; active path points to `TESTING.md` and `TESTING_PHILOSOPHY.md`. |

--- a/docs/INTEGRATION_CHARTER.md
+++ b/docs/INTEGRATION_CHARTER.md
@@ -1,6 +1,9 @@
 # Integration Charter
 
-This document defines the scope boundary for beads tracker integrations. It exists to keep the project focused on its core value — dependency-aware issue tracking for AI agents — and to prevent scope creep into platform territory.
+This document specializes the project scope boundary from
+[Project Charter](PROJECT_CHARTER.md) for tracker integrations. It exists to
+keep the project focused on its core value - dependency-aware issue tracking
+for AI agents - and to prevent scope creep into platform territory.
 
 ## Core Principle
 
@@ -83,6 +86,7 @@ When adding support for a new tracker or extending an existing one:
 
 ## Related Documents
 
+- [Project Charter](PROJECT_CHARTER.md) - Overall product scope and boundaries
 - [CLI Reference](CLI_REFERENCE.md) — Full command documentation
 - [SECURITY.md](../SECURITY.md) — Security considerations for tracker tokens
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — How to contribute new integrations

--- a/docs/METADATA.md
+++ b/docs/METADATA.md
@@ -2,6 +2,11 @@
 
 The `metadata` field on issues accepts arbitrary JSON. Any valid JSON value is stored as-is.
 
+Metadata is the preferred extension point for data that is specific to an
+integration, orchestrator, team workflow, or experimental automation. Before
+adding first-class fields, commands, or schema changes, check the
+[Project Charter](PROJECT_CHARTER.md#schema-boundary).
+
 ## Agent Execution Metadata
 
 Automation may store execution hints in issue metadata so agents can make
@@ -46,4 +51,5 @@ Avoid these prefixes in user-defined keys to prevent conflicts with future Beads
 
 ## Related
 
-- [#1416](https://github.com/gastownhall/beads/issues/1416) — Optional schema enforcement (future)
+- [Project Charter](PROJECT_CHARTER.md) - Product scope and schema boundary
+- [#1416](https://github.com/gastownhall/beads/issues/1416) - Optional schema enforcement (future)

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,0 +1,109 @@
+# Project Charter
+
+This document defines the product boundary for beads. It is the source of
+truth for deciding whether proposed work belongs in core, belongs in an
+integration or plugin, belongs in an orchestration layer, or should stay
+outside the project.
+
+Beads is a focused issue tracker for AI-supervised development. It should stay
+small enough to remain reliable, understandable, and composable.
+
+## Core Scope
+
+Beads owns issue tracking primitives:
+
+- issues and issue lifecycle
+- dependency relationships and readiness
+- labels, comments, status, priority, and assignment
+- metadata attached to issues
+- local CLI workflows around those concepts
+- import, export, sync, backup, and recovery for beads data
+- integrations that translate external tracker data into beads concepts
+
+Within those boundaries, the project should absorb useful contributor work
+when practical. If a contribution has value but does not fit as submitted,
+prefer preserving the value by simplifying it, moving it to metadata, routing
+it to an integration or plugin, cherry-picking the reusable part, or
+reimplementing the use case in a smaller design.
+
+## Orchestration Boundary
+
+Beads should not know about orchestration layers built on top of it. Systems
+such as Gastown, Gas City, schedulers, swarms, release coordinators, and future
+workflow engines may use beads, but beads should not encode their concepts in
+core.
+
+Core beads can expose stable issue data, metadata, CLI output, and documented
+extension points. The orchestration layer owns orchestration policy: agent
+routing, task assignment strategy, model choice, retry plans, scheduling,
+workflow semantics, and cross-system coordination.
+
+When orchestration needs extra per-issue data, prefer issue metadata before
+adding first-class fields or commands.
+
+## Storage Boundary
+
+Beads should not become a storage engine. Dolt provides storage, versioning,
+sync, merge behavior, concurrency, and crash safety. Beads should put data in
+and pull data out through the storage boundary.
+
+Storage-engine details should not leak into beads packages unless they are part
+of a deliberate storage interface. Avoid beads-side flocks, engine
+introspection, storage-specific retry loops, crash-recovery workarounds, or
+schema poking that belongs in Dolt or the Dolt driver.
+
+If the current storage interface cannot express a needed operation, widen the
+interface or route the issue to the driver instead of embedding storage-engine
+logic in core.
+
+## Schema Boundary
+
+The database schema is considered stable. Schema changes are allowed when there
+is a pressing product or correctness need, but they should not be the first
+answer to extension requests.
+
+Use issue metadata first when:
+
+- the data is specific to one integration, orchestrator, or team workflow
+- the data is advisory rather than part of beads' core issue model
+- the data can be represented as JSON without harming queryability
+- the shape may evolve before it deserves a stable CLI or schema contract
+
+Promote metadata to first-class schema only when the field has broad, durable
+meaning for beads itself and the migration cost is justified.
+
+## Integration Boundary
+
+Tracker integrations are adoption bridges, not a second product surface. They
+should map external tracker data into beads concepts and keep the dependency
+graph useful. They should not replicate tracker UIs, notification systems,
+credential vaults, webhook gateways, or cross-tracker automation.
+
+See [Integration Charter](INTEGRATION_CHARTER.md) for the detailed policy for
+GitHub, GitLab, Jira, Linear, Azure DevOps, and similar tracker integrations.
+
+## Review Posture
+
+These boundaries are fences, not bounce messages. Maintainers should not reject
+useful work reflexively just because the first version crosses a boundary.
+
+For pull requests and proposals:
+
+- identify the contributor value first
+- keep the part that belongs in core when possible
+- move boundary-crossing behavior to metadata, integrations, plugins, or
+  external tools when that preserves the use case
+- preserve attribution when transforming, cherry-picking, or reimplementing
+  contributor work
+- explain clearly when a feature belongs outside beads
+
+Use request-changes or rejection only after considering whether the project can
+absorb, transform, or reroute the useful part.
+
+## Related Documents
+
+- [Integration Charter](INTEGRATION_CHARTER.md) - tracker integration scope
+- [Issue Metadata](METADATA.md) - metadata extension point
+- [Architecture](ARCHITECTURE.md) - data model and storage architecture
+- [Maintainer PR Guidelines](../PR_MAINTAINER_GUIDELINES.md) - PR triage and
+  contributor handling


### PR DESCRIPTION
## Summary
- adds `docs/PROJECT_CHARTER.md` as the canonical project scope boundary for core, orchestration, storage, schema, and integrations
- links the charter from agent, contributor, maintainer, architecture, integration, metadata, and docs inventory surfaces
- reconciles the branch on top of upstream PR #3820 / merge `ec116c46f5d12426793e16dae8784adbcb9977e1` without reintroducing stale docs inventory or staged-for-removal content

## Tracking
- Follow-up bead: `mybd-rph`
- Original implementation bead: `mybd-1fn`

## Checks
- `git diff --check upstream/main...HEAD`
- `CGO_ENABLED=0 go build -tags gms_pure_go -ldflags="-X main.Build=ce7c91cbb" -o ./bd ./cmd/bd`
- `./scripts/check-doc-flags.sh ./bd`
- targeted local Markdown link check over changed `.md` files

Note: `make check-docs` was attempted on Windows, but this local `make.exe` installation fails before running the check because `sh` is not available. The equivalent build and checker commands above pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->