### PR TITLE
feat(schema): widen TEXT columns to MEDIUMTEXT for large per-row content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Schema migration: widen TEXT columns to MEDIUMTEXT for large per-row content** — Migration `0033_widen_text_columns` raises the column-size cap on `issues.notes`, `events.{old_value, new_value, comment}`, `comments.text`, `wisps.notes`, `wisp_events.{old_value, new_value, comment}`, `wisp_comments.text`, and `issue_snapshots.{original_content, archived_events}` from MySQL TEXT (65,535-byte cap) to MEDIUMTEXT (16 MiB cap). Resolves silent truncation on cumulative `bd note` appends and large state-snapshot rows on high-volume issues. 12 ALTER statements covering 11 unique columns; metadata-only on Dolt's prolly-tree storage (no content rewrite). The `0033_widen_text_columns.down.sql` companion is provided for symmetry but is operationally one-way for any database that has accumulated rows >65,535 bytes under a widened column (silent truncation on column-narrowing).
+
 ### Fixed
 
 - **`bd dolt status` reports externally-managed local servers truthfully** - when a rig is configured as `dolt_mode: server` pointing at a local host but `dolt.auto-start: false` (so an orchestrator or systemd owns the sql-server lifecycle), `bd dolt status` previously said `not running` because no PID file existed. It now SQL-probes the configured endpoint, matching the path already used for non-local hosts, and reports `running (external)` with host/port/database/version when the server answers. **JSON output shape change**: on affected rigs, `bd dolt status --json` now emits `{"running": true, "mode": "external", ...}` instead of `{"running": false, "pid": 0, ...}`. Automation that parsed the old `running:false` as a "needs restart" sentinel should switch to checking `running` directly. (be-0eyj, [#3550](https://github.com/gastownhall/beads/pull/3550))

--- a/internal/storage/dolt/widen_text_columns_test.go
+++ b/internal/storage/dolt/widen_text_columns_test.go
@@ -1,0 +1,82 @@
+package dolt
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWidenTextColumns0033 verifies that migration 0033 raises the MySQL/Dolt
+// TEXT cap (65,535 bytes) on notes/events/comments/wisp/snapshots tables to
+// MEDIUMTEXT (16 MiB) by:
+//  1. Asserting the column types are MEDIUMTEXT after schema init.
+//  2. Round-tripping a >65,535-byte value through issues.notes and verifying
+//     byte-equality on read (ensures no truncation).
+//  3. Preserving NOT NULL on columns that carry it.
+func TestWidenTextColumns0033(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// ---------- (1) Column-type assertions ----------
+	// Each table -> column -> expected lowercase type prefix. We use HasPrefix
+	// because information_schema.columns can return "mediumtext" or
+	// "mediumtext collate ..." depending on the column's collation. Any
+	// "text" prefix without "medium" would indicate the migration didn't run.
+	wantCols := map[string]map[string]string{
+		"issues":          {"notes": "mediumtext"},
+		"events":          {"old_value": "mediumtext", "new_value": "mediumtext", "comment": "mediumtext"},
+		"comments":        {"text": "mediumtext"},
+		"wisps":           {"notes": "mediumtext"},
+		"wisp_events":     {"old_value": "mediumtext", "new_value": "mediumtext", "comment": "mediumtext"},
+		"wisp_comments":   {"text": "mediumtext"},
+		"issue_snapshots": {"original_content": "mediumtext", "archived_events": "mediumtext"},
+	}
+	for table, cols := range wantCols {
+		got := queryColumns(t, store, table)
+		gotMap := make(map[string]string, len(got))
+		for _, c := range got {
+			gotMap[c.Name] = strings.ToLower(c.ColumnType)
+		}
+		for col, wantType := range cols {
+			if !strings.HasPrefix(gotMap[col], wantType) {
+				t.Errorf("%s.%s: got column type %q, want prefix %q (migration 0033 may not have run)",
+					table, col, gotMap[col], wantType)
+			}
+		}
+	}
+
+	// ---------- (2) Byte-equality round-trip on issues.notes (>64KB) ----------
+	const issueID = "test-widen-1"
+	largeContent := strings.Repeat("A", 100_000) // 100 KB; well above the 65,535-byte TEXT cap.
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO issues (id, title, description, design, acceptance_criteria, notes)
+		 VALUES (?, ?, '', '', '', ?)`,
+		issueID, "Widen test", largeContent); err != nil {
+		t.Fatalf("INSERT large notes failed (likely truncation cap of 65,535 bytes still in effect): %v", err)
+	}
+	var got string
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT notes FROM issues WHERE id = ?`, issueID).Scan(&got); err != nil {
+		t.Fatalf("SELECT notes failed: %v", err)
+	}
+	if len(got) != len(largeContent) {
+		t.Errorf("notes round-trip length mismatch: len(got)=%d, len(want)=%d", len(got), len(largeContent))
+	}
+	if got != largeContent {
+		t.Errorf("notes round-trip byte-mismatch (truncation or corruption)")
+	}
+
+	// ---------- (3) NOT NULL preservation ----------
+	// issues.notes is declared MEDIUMTEXT NOT NULL post-0033. An INSERT that
+	// omits notes (forcing NULL) MUST fail. We use a separate ID to avoid PK
+	// collision with the round-trip row above.
+	const nullCheckID = "test-widen-notnull"
+	_, err := store.db.ExecContext(ctx,
+		`INSERT INTO issues (id, title, description, design, acceptance_criteria, notes)
+		 VALUES (?, ?, '', '', '', NULL)`,
+		nullCheckID, "Null-check")
+	if err == nil {
+		t.Error("expected NOT NULL constraint violation on issues.notes = NULL, got nil error (NOT NULL preservation broken?)")
+	}
+}

--- a/internal/storage/schema/ignored_tables.go
+++ b/internal/storage/schema/ignored_tables.go
@@ -29,6 +29,7 @@ var ignoredMigrations = []ignoredMigration{
 	{version: 23, filter: "wisps"}, // ALTER TABLE wisps ADD COLUMN no_history (skip issues ALTER)
 	{version: 27, filter: "wisps"}, // ALTER TABLE wisps ADD COLUMN started_at (skip issues ALTER)
 	{version: 31},                  // CREATE INDEX idx_wisp_events_created_at
+	{version: 33, filter: "wisp"},  // ALTER wisps/wisp_events/wisp_comments MODIFY COLUMN ... MEDIUMTEXT (skip issues/events/comments/issue_snapshots ALTERs)
 }
 
 var (

--- a/internal/storage/schema/ignored_tables_test.go
+++ b/internal/storage/schema/ignored_tables_test.go
@@ -32,6 +32,12 @@ func TestIgnoredTableDDL(t *testing.T) {
 	if !strings.Contains(combined, "idx_wisp_events_created_at") {
 		t.Error("IgnoredTableDDL missing idx_wisp_events_created_at index")
 	}
+
+	// Verify the 0033 widening (TEXT -> MEDIUMTEXT) on wisp tables is present.
+	// Case-insensitive match accommodates either case in the splitter output.
+	if !strings.Contains(strings.ToUpper(combined), "MEDIUMTEXT") {
+		t.Error("IgnoredTableDDL missing MEDIUMTEXT — migration 0033 not included?")
+	}
 }
 
 func TestReadMigrationSQL(t *testing.T) {

--- a/internal/storage/schema/migrations/0033_widen_text_columns.down.sql
+++ b/internal/storage/schema/migrations/0033_widen_text_columns.down.sql
@@ -1,0 +1,19 @@
+-- 0033_widen_text_columns.down.sql
+-- Reverse migration: narrow MEDIUMTEXT back to TEXT.
+-- IMPORTANT: this is operationally one-way for any database that has
+-- accumulated rows >65,535 bytes -- MySQL silently truncates on
+-- column-narrow. Provided for completeness; do not run against a database
+-- that has carried >64KB content under any of the widened columns.
+
+ALTER TABLE issues          MODIFY COLUMN notes            TEXT NOT NULL;
+ALTER TABLE events          MODIFY COLUMN old_value        TEXT;
+ALTER TABLE events          MODIFY COLUMN new_value        TEXT;
+ALTER TABLE events          MODIFY COLUMN comment          TEXT;
+ALTER TABLE comments        MODIFY COLUMN text             TEXT NOT NULL;
+ALTER TABLE wisps           MODIFY COLUMN notes            TEXT NOT NULL DEFAULT '';
+ALTER TABLE wisp_events     MODIFY COLUMN old_value        TEXT DEFAULT '';
+ALTER TABLE wisp_events     MODIFY COLUMN new_value        TEXT DEFAULT '';
+ALTER TABLE wisp_events     MODIFY COLUMN comment          TEXT DEFAULT '';
+ALTER TABLE wisp_comments   MODIFY COLUMN text             TEXT NOT NULL;
+ALTER TABLE issue_snapshots MODIFY COLUMN original_content TEXT NOT NULL;
+ALTER TABLE issue_snapshots MODIFY COLUMN archived_events  TEXT;

--- a/internal/storage/schema/migrations/0033_widen_text_columns.up.sql
+++ b/internal/storage/schema/migrations/0033_widen_text_columns.up.sql
@@ -1,0 +1,25 @@
+-- 0033_widen_text_columns.up.sql
+-- Widen TEXT columns to MEDIUMTEXT on tables that hold large per-row content
+-- (notes, events, comments, snapshots, and their wisp counterparts). MySQL/Dolt
+-- TEXT caps at 65,535 bytes per row, and high-volume issues exceed that on
+-- cumulative bd note appends. MEDIUMTEXT raises the cap to 16 MiB
+-- (256x capacity) and is metadata-only on Dolt's prolly-tree storage --
+-- existing rows are preserved without rewrite.
+--
+-- 12 ALTER statements covering 11 unique columns (issues.notes + events x3 +
+-- comments.text + wisps.notes + wisp_events x3 + wisp_comments.text +
+-- issue_snapshots x2). The wisps.notes widening preserves schema parity
+-- with issues.notes per TestSchemaParityIssuesVsWisps.
+
+ALTER TABLE issues          MODIFY COLUMN notes            MEDIUMTEXT NOT NULL;
+ALTER TABLE events          MODIFY COLUMN old_value        MEDIUMTEXT;
+ALTER TABLE events          MODIFY COLUMN new_value        MEDIUMTEXT;
+ALTER TABLE events          MODIFY COLUMN comment          MEDIUMTEXT;
+ALTER TABLE comments        MODIFY COLUMN text             MEDIUMTEXT NOT NULL;
+ALTER TABLE wisps           MODIFY COLUMN notes            MEDIUMTEXT NOT NULL DEFAULT '';
+ALTER TABLE wisp_events     MODIFY COLUMN old_value        MEDIUMTEXT DEFAULT '';
+ALTER TABLE wisp_events     MODIFY COLUMN new_value        MEDIUMTEXT DEFAULT '';
+ALTER TABLE wisp_events     MODIFY COLUMN comment          MEDIUMTEXT DEFAULT '';
+ALTER TABLE wisp_comments   MODIFY COLUMN text             MEDIUMTEXT NOT NULL;
+ALTER TABLE issue_snapshots MODIFY COLUMN original_content MEDIUMTEXT NOT NULL;
+ALTER TABLE issue_snapshots MODIFY COLUMN archived_events  MEDIUMTEXT;

--- a/internal/storage/schema/migrations/0033_widen_text_columns.up.sql
+++ b/internal/storage/schema/migrations/0033_widen_text_columns.up.sql
@@ -6,7 +6,7 @@
 -- (256x capacity) and is metadata-only on Dolt's prolly-tree storage --
 -- existing rows are preserved without rewrite.
 --
--- 12 ALTER statements covering 11 unique columns (issues.notes + events x3 +
+-- 12 ALTER statements covering 12 unique columns (issues.notes + events x3 +
 -- comments.text + wisps.notes + wisp_events x3 + wisp_comments.text +
 -- issue_snapshots x2). The wisps.notes widening preserves schema parity
 -- with issues.notes per TestSchemaParityIssuesVsWisps.

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -41,12 +41,18 @@ func TestMigration0032ToleratesMissingAppliedAtColumn(t *testing.T) {
 		},
 	}
 
+	// Start from version 31 to exercise migration 0032's applied_at-drop
+	// tolerance. As subsequent migrations are added, the applied count grows;
+	// the assertion below tracks LatestVersion()-31 to stay accurate, while
+	// the recorded check verifies 0032 specifically was recorded after the
+	// missing-column error (the regression this test was authored to catch).
 	applied, err := runMigrations(context.Background(), db, 31, false)
 	if err != nil {
 		t.Fatalf("runMigrations returned error for already-missing applied_at: %v", err)
 	}
-	if applied != 1 {
-		t.Fatalf("applied migrations = %d, want 1", applied)
+	wantApplied := LatestVersion() - 31
+	if applied != wantApplied {
+		t.Fatalf("applied migrations = %d, want %d (LatestVersion=%d)", applied, wantApplied, LatestVersion())
 	}
 	if !recorded {
 		t.Fatal("migration 0032 was not recorded after already-missing applied_at")


### PR DESCRIPTION
## What

Migration `0033_widen_text_columns` widens **12 columns / 12 ALTER statements** from MySQL TEXT (65,535-byte cap) to MEDIUMTEXT (16 MiB cap):

- `issues.notes` (NOT NULL preserved)
- `events.{old_value, new_value, comment}`
- `comments.text` (NOT NULL preserved)
- `wisps.notes` (NOT NULL DEFAULT '' preserved; required for `TestSchemaParityIssuesVsWisps` parity invariant)
- `wisp_events.{old_value, new_value, comment}` (DEFAULT '' preserved)
- `wisp_comments.text` (NOT NULL preserved)
- `issue_snapshots.{original_content, archived_events}` (NOT NULL preserved on `original_content`)

Registers in `internal/storage/schema/ignored_tables.go::ignoredMigrations` with filter `"wisp"` so the embedded-issues path applies the issues/events/comments/issue_snapshots ALTERs and the wisp counterparts apply via the same migration. Adds a companion test `internal/storage/dolt/widen_text_columns_test.go` covering (1) post-migration column types, (2) 100KB byte-equality round-trip through `issues.notes`, (3) NOT NULL preservation. Includes a defensive update to `TestMigration0032ToleratesMissingAppliedAtColumn` (uses `LatestVersion()-31` instead of hard-coded `1`) so it stays accurate as new migrations land. CHANGELOG entry under `## [Unreleased]` `### Changed`.

## Why

On installs with high-volume issues that accumulate many `bd note` appends, the TEXT cap silently truncates writes once cumulative content approaches 65,535 bytes. The cap also fires earlier on a state-snapshot path: `bd note` / `bd update` write the full post-mutation issue-state JSON into `events.new_value`, so on issues whose `description + notes` already approach 64KB, even small new writes blow past the cap before any new content is added.

Widening to MEDIUMTEXT raises the per-row cap by 256x and resolves both at the source. Metadata-only on Dolt's prolly-tree storage; no content rewrite of existing rows.

Down-migration to TEXT is provided for symmetry but is **operationally one-way** for any database that has accumulated >65,535 bytes in a widened column (silent truncation on column-narrow). The migration documents this clearly in the `.down.sql` header comment.

## Verification

- **Dedicated test**: `TestWidenTextColumns0033` (`internal/storage/dolt/widen_text_columns_test.go`) — column-type assertions, 100KB byte-equality round-trip, NOT NULL preservation. Skips locally without Docker / testcontainers; runs in CI.
- **Schema parity**: `TestSchemaParityIssuesVsWisps` continues to pass (the `wisps.notes` widening preserves the issues/wisps parity invariant).
- **Full migration chain**: `TestNewDoltServerStore_HappyPath` (uses local `dolt sql-server`; no Docker required) exercises the migration end-to-end.
- **Defensive cross-test**: `TestMigration0032ToleratesMissingAppliedAtColumn` continues to pass after the `LatestVersion()-31` update.
- **DDL coverage**: `TestIgnoredTableDDL` continues to pass with an added MEDIUMTEXT-presence check.
- **End-to-end on a real install**: a fork-built binary applied the migration on a real bd database; a 230KB synthetic note round-tripped byte-equally on a fresh sandbox issue, and a high-baseline-payload write on an issue whose cumulative `description + notes` exceeded 64KB completed cleanly post-migration (the same write would have hit the events-row state-snapshot cap pre-migration).

Reviewer commands (no Docker required for the doltserver-path coverage):

```bash
go test ./internal/storage/dolt/ -run TestNewDoltServerStore_HappyPath -v
go test ./internal/storage/dolt/ -run TestSchemaParityIssuesVsWisps -v
go test ./internal/storage/schema/ -v
make test
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/beads/pr/3846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->