### PR TITLE
test(init): make embedded init hook path windows-safe

### DIFF
--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -67,7 +67,8 @@ func initGitRepoAt(t *testing.T, dir string) {
 		{"init"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "Test"},
-		{"config", "core.hooksPath", "/dev/null"},
+		// Force repo-local hooks so tests ignore any global hooksPath override.
+		{"config", "core.hooksPath", ".git/hooks"},
 	} {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir


### PR DESCRIPTION
## Summary

`initGitRepoAt` (in `cmd/bd/init_embedded_test.go`) sets `core.hooksPath` to `/dev/null` to prevent any inherited global git hooks (e.g., a contributor's pre-commit framework) from running during embedded-init tests. `/dev/null` does not exist on Windows, so the test misbehaves there.

This change points `core.hooksPath` at the repo's own freshly-init'd `.git/hooks` directory, which is empty for these tests and achieves the same "no extraneous hooks" effect portably across Linux, macOS, and Windows.

## Change

```diff
-{"config", "core.hooksPath", "/dev/null"},
+// Force repo-local hooks so tests ignore any global hooksPath override.
+{"config", "core.hooksPath", ".git/hooks"},
```

One-line test-only change in `cmd/bd/init_embedded_test.go`. No production code touched.

## Related

Complements the Windows test portability work tracked in #3404 (closed); that umbrella enumerated several Windows test failures but did not include this `/dev/null` hooksPath case.