### PR TITLE
fix(ready): exclude transitive descendants of blocked parents from bd ready

### DIFF
--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -191,10 +191,10 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 		// Also exclude ALL transitive descendants of blocked parents (GH#1495):
 		// If a parent/epic is blocked, grandchildren and deeper must also be
 		// excluded — not just direct children.
-		descendantsOfBlocked, descErr := s.getTransitiveDescendantsOfIssues(ctx, blockedIDs)
+		descendantsOfBlocked, descErr := s.getTransitiveDescendantsOfIssues(ctx, blockedIDs, filter.IncludeEphemeral)
 		if descErr == nil {
-			for childID := range descendantsOfBlocked {
-				blockedIDs = append(blockedIDs, childID)
+			for descendantID := range descendantsOfBlocked {
+				blockedIDs = append(blockedIDs, descendantID)
 			}
 		}
 
@@ -451,11 +451,12 @@ func (s *DoltStore) getChildrenOfIssues(ctx context.Context, parentIDs []string)
 
 // getTransitiveDescendantsOfIssues returns all transitive parent-child descendants
 // (grandchildren, great-grandchildren, etc.) of the given issue IDs, with cycle detection.
-func (s *DoltStore) getTransitiveDescendantsOfIssues(ctx context.Context, parentIDs []string) (map[string]string, error) {
+// Pass includeWisps=true only when ephemeral issues are in scope.
+func (s *DoltStore) getTransitiveDescendantsOfIssues(ctx context.Context, parentIDs []string, includeWisps bool) (map[string]string, error) {
 	result := make(map[string]string)
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var txErr error
-		result, txErr = issueops.GetTransitiveDescendantsWithParentsInTx(ctx, tx, parentIDs)
+		result, txErr = issueops.GetTransitiveDescendantsWithParentsInTx(ctx, tx, parentIDs, includeWisps)
 		return txErr
 	})
 	return result, err

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -448,18 +448,6 @@ func (s *DoltStore) getChildrenOfIssues(ctx context.Context, parentIDs []string)
 	return result, err
 }
 
-// getChildrenWithParents returns a map of childID -> parentID for direct children
-// (parent-child deps) of the given parent IDs.
-func (s *DoltStore) getChildrenWithParents(ctx context.Context, parentIDs []string) (map[string]string, error) {
-	var result map[string]string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
-		var err error
-		result, err = issueops.GetChildrenWithParentsInTx(ctx, tx, parentIDs)
-		return err
-	})
-	return result, err
-}
-
 func (s *DoltStore) getDescendantIDs(ctx context.Context, rootID string) ([]string, error) {
 	var result []string
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -188,11 +188,12 @@ func (s *DoltStore) GetReadyWork(ctx context.Context, filter types.WorkFilter) (
 	// blocking deps exist, and skipping 16K+ wisps avoids query timeouts.
 	blockedIDs, err := s.computeBlockedIDs(ctx, filter.IncludeEphemeral)
 	if err == nil && len(blockedIDs) > 0 {
-		// Also exclude children of blocked parents (GH#1495):
-		// If a parent/epic is blocked, its children should not appear as ready work.
-		childrenOfBlocked, childErr := s.getChildrenOfIssues(ctx, blockedIDs)
-		if childErr == nil {
-			for _, childID := range childrenOfBlocked {
+		// Also exclude ALL transitive descendants of blocked parents (GH#1495):
+		// If a parent/epic is blocked, grandchildren and deeper must also be
+		// excluded — not just direct children.
+		descendantsOfBlocked, descErr := s.getTransitiveDescendantsOfIssues(ctx, blockedIDs)
+		if descErr == nil {
+			for childID := range descendantsOfBlocked {
 				blockedIDs = append(blockedIDs, childID)
 			}
 		}
@@ -444,6 +445,18 @@ func (s *DoltStore) getChildrenOfIssues(ctx context.Context, parentIDs []string)
 		var err error
 		result, err = issueops.GetChildrenOfIssuesInTx(ctx, tx, parentIDs)
 		return err
+	})
+	return result, err
+}
+
+// getTransitiveDescendantsOfIssues returns all transitive parent-child descendants
+// (grandchildren, great-grandchildren, etc.) of the given issue IDs, with cycle detection.
+func (s *DoltStore) getTransitiveDescendantsOfIssues(ctx context.Context, parentIDs []string) (map[string]string, error) {
+	result := make(map[string]string)
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var txErr error
+		result, txErr = issueops.GetTransitiveDescendantsWithParentsInTx(ctx, tx, parentIDs)
+		return txErr
 	})
 	return result, err
 }

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -1023,6 +1023,161 @@ func TestGetBlockedIssues_IncludesChildrenOfBlockedParents(t *testing.T) {
 	}
 }
 
+// TestGetReadyWork_ExcludesTransitiveDescendantsOfBlockedParents verifies that
+// grandchildren (and deeper) of a blocked parent are also excluded from ready
+// work — not just direct children.
+func TestGetReadyWork_ExcludesTransitiveDescendantsOfBlockedParents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// A (blocker) → blocks → B (epic) → child B1 → grandchild B1a
+	blocker := &types.Issue{ID: "rd-blocker", Title: "Blocker", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	epic := &types.Issue{ID: "rd-epic", Title: "Blocked Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "rd-epic.1", Title: "Child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	grandchild := &types.Issue{ID: "rd-epic.1.1", Title: "Grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+	for _, iss := range []*types.Issue{blocker, epic, child, grandchild} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", iss.ID, err)
+		}
+	}
+
+	// blocker blocks epic
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: epic.ID, DependsOnID: blocker.ID, Type: types.DepBlocks}, "tester"); err != nil {
+		t.Fatalf("add blocks dep: %v", err)
+	}
+	// epic → child (parent-child)
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: child.ID, DependsOnID: epic.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add child dep: %v", err)
+	}
+	// child → grandchild (parent-child)
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: grandchild.ID, DependsOnID: child.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add grandchild dep: %v", err)
+	}
+
+	ready, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	for _, iss := range ready {
+		if iss.ID == child.ID {
+			t.Error("direct child of blocked parent should NOT be in ready work")
+		}
+		if iss.ID == grandchild.ID {
+			t.Error("grandchild of blocked parent should NOT be in ready work")
+		}
+	}
+}
+
+// TestGetReadyWork_ExcludesDeeplyNestedDescendantsOfBlockedParents verifies that
+// the recursive descent handles chains deeper than two levels (4-level chain).
+func TestGetReadyWork_ExcludesDeeplyNestedDescendantsOfBlockedParents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	// blocker → blocks → epic → child → grandchild → great-grandchild
+	blocker := &types.Issue{ID: "dn-blocker", Title: "Blocker", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	epic := &types.Issue{ID: "dn-epic", Title: "Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "dn-epic.1", Title: "Child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	grandchild := &types.Issue{ID: "dn-epic.1.1", Title: "Grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	greatGrandchild := &types.Issue{ID: "dn-epic.1.1.1", Title: "Great-grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+	for _, iss := range []*types.Issue{blocker, epic, child, grandchild, greatGrandchild} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", iss.ID, err)
+		}
+	}
+	deps := []types.Dependency{
+		{IssueID: epic.ID, DependsOnID: blocker.ID, Type: types.DepBlocks},
+		{IssueID: child.ID, DependsOnID: epic.ID, Type: types.DepParentChild},
+		{IssueID: grandchild.ID, DependsOnID: child.ID, Type: types.DepParentChild},
+		{IssueID: greatGrandchild.ID, DependsOnID: grandchild.ID, Type: types.DepParentChild},
+	}
+	for _, d := range deps {
+		d := d
+		if err := store.AddDependency(ctx, &d, "tester"); err != nil {
+			t.Fatalf("add dep %s->%s: %v", d.IssueID, d.DependsOnID, err)
+		}
+	}
+
+	ready, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	excluded := map[string]bool{child.ID: true, grandchild.ID: true, greatGrandchild.ID: true}
+	for _, iss := range ready {
+		if excluded[iss.ID] {
+			t.Errorf("%s (descendant of blocked epic) should NOT appear in ready work", iss.ID)
+		}
+	}
+}
+
+// TestGetBlockedIssues_IncludesTransitiveDescendantsOfBlockedParents verifies
+// that bd blocked shows grandchildren (and deeper) as blocked, not just direct
+// children.
+func TestGetBlockedIssues_IncludesTransitiveDescendantsOfBlockedParents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	blocker := &types.Issue{ID: "bt-blocker", Title: "Blocker", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	epic := &types.Issue{ID: "bt-epic", Title: "Blocked Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "bt-epic.1", Title: "Child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	grandchild := &types.Issue{ID: "bt-epic.1.1", Title: "Grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+	for _, iss := range []*types.Issue{blocker, epic, child, grandchild} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", iss.ID, err)
+		}
+	}
+
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: epic.ID, DependsOnID: blocker.ID, Type: types.DepBlocks}, "tester"); err != nil {
+		t.Fatalf("add blocks dep: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: child.ID, DependsOnID: epic.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add child dep: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: grandchild.ID, DependsOnID: child.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add grandchild dep: %v", err)
+	}
+
+	blocked, err := store.GetBlockedIssues(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetBlockedIssues: %v", err)
+	}
+
+	found := make(map[string]bool)
+	for _, bi := range blocked {
+		found[bi.Issue.ID] = true
+	}
+	if !found[epic.ID] {
+		t.Error("epic should be in blocked list")
+	}
+	if !found[child.ID] {
+		t.Error("direct child of blocked epic should be in blocked list")
+	}
+	if !found[grandchild.ID] {
+		t.Error("grandchild of blocked epic should be in blocked list")
+	}
+
+	// Verify grandchild is attributed to its immediate parent, not the root blocker.
+	for _, bi := range blocked {
+		if bi.Issue.ID == grandchild.ID {
+			if len(bi.BlockedBy) == 0 || bi.BlockedBy[0] != child.ID {
+				t.Errorf("grandchild BlockedBy should be [%s] (immediate parent), got %v", child.ID, bi.BlockedBy)
+			}
+		}
+	}
+}
+
 // =============================================================================
 // SearchIssues tests
 // =============================================================================

--- a/internal/storage/embeddeddolt/dependencies_test.go
+++ b/internal/storage/embeddeddolt/dependencies_test.go
@@ -282,3 +282,148 @@ func TestAddDependency(t *testing.T) {
 		}
 	})
 }
+
+// TestGetReadyWork_ExcludesTransitiveDescendantsOfBlockedParents verifies that
+// grandchildren (and deeper) of a blocked parent are excluded from ready work,
+// not just direct children.
+func TestGetReadyWork_ExcludesTransitiveDescendantsOfBlockedParents(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "rt")
+	ctx := t.Context()
+
+	// blocker (A) → blocks → epic (B) → child (B1) → grandchild (B1a)
+	blocker := &types.Issue{ID: "rt-blocker", Title: "Blocker", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	epic := &types.Issue{ID: "rt-epic", Title: "Blocked Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "rt-epic.1", Title: "Child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	grandchild := &types.Issue{ID: "rt-epic.1.1", Title: "Grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+	for _, iss := range []*types.Issue{blocker, epic, child, grandchild} {
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", iss.ID, err)
+		}
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: epic.ID, DependsOnID: blocker.ID, Type: types.DepBlocks}, "tester"); err != nil {
+		t.Fatalf("add blocks dep: %v", err)
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: child.ID, DependsOnID: epic.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add child dep: %v", err)
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: grandchild.ID, DependsOnID: child.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add grandchild dep: %v", err)
+	}
+
+	ready, err := te.store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	for _, iss := range ready {
+		if iss.ID == child.ID {
+			t.Errorf("direct child %s of blocked parent should NOT appear in ready work", child.ID)
+		}
+		if iss.ID == grandchild.ID {
+			t.Errorf("grandchild %s of blocked parent should NOT appear in ready work", grandchild.ID)
+		}
+	}
+}
+
+// TestGetReadyWork_ExcludesDeeplyNestedDescendantsOfBlockedParents verifies that
+// the recursive descent handles chains deeper than two levels (4-level chain).
+func TestGetReadyWork_ExcludesDeeplyNestedDescendantsOfBlockedParents(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "dn")
+	ctx := t.Context()
+
+	// blocker → blocks → epic → child → grandchild → great-grandchild
+	blocker := &types.Issue{ID: "dn-blocker", Title: "Blocker", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	epic := &types.Issue{ID: "dn-epic", Title: "Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "dn-epic.1", Title: "Child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	grandchild := &types.Issue{ID: "dn-epic.1.1", Title: "Grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	greatGrandchild := &types.Issue{ID: "dn-epic.1.1.1", Title: "Great-grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+	for _, iss := range []*types.Issue{blocker, epic, child, grandchild, greatGrandchild} {
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", iss.ID, err)
+		}
+	}
+	deps := []types.Dependency{
+		{IssueID: epic.ID, DependsOnID: blocker.ID, Type: types.DepBlocks},
+		{IssueID: child.ID, DependsOnID: epic.ID, Type: types.DepParentChild},
+		{IssueID: grandchild.ID, DependsOnID: child.ID, Type: types.DepParentChild},
+		{IssueID: greatGrandchild.ID, DependsOnID: grandchild.ID, Type: types.DepParentChild},
+	}
+	for _, d := range deps {
+		d := d
+		if err := te.store.AddDependency(ctx, &d, "tester"); err != nil {
+			t.Fatalf("AddDependency %s->%s: %v", d.IssueID, d.DependsOnID, err)
+		}
+	}
+
+	ready, err := te.store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	excluded := map[string]bool{child.ID: true, grandchild.ID: true, greatGrandchild.ID: true}
+	for _, iss := range ready {
+		if excluded[iss.ID] {
+			t.Errorf("%s (descendant of blocked epic) should NOT appear in ready work", iss.ID)
+		}
+	}
+}
+
+// TestGetBlockedIssues_IncludesTransitiveDescendantsOfBlockedParents verifies
+// that bd blocked surfaces grandchildren (and deeper) of a blocked issue, not
+// just direct children.
+func TestGetBlockedIssues_IncludesTransitiveDescendantsOfBlockedParents(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "bt")
+	ctx := t.Context()
+
+	blocker := &types.Issue{ID: "bt-blocker", Title: "Blocker", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	epic := &types.Issue{ID: "bt-epic", Title: "Blocked Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "bt-epic.1", Title: "Child", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	grandchild := &types.Issue{ID: "bt-epic.1.1", Title: "Grandchild", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+	for _, iss := range []*types.Issue{blocker, epic, child, grandchild} {
+		if err := te.store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", iss.ID, err)
+		}
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: epic.ID, DependsOnID: blocker.ID, Type: types.DepBlocks}, "tester"); err != nil {
+		t.Fatalf("add blocks dep: %v", err)
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: child.ID, DependsOnID: epic.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add child dep: %v", err)
+	}
+	if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: grandchild.ID, DependsOnID: child.ID, Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("add grandchild dep: %v", err)
+	}
+
+	blocked, err := te.store.GetBlockedIssues(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetBlockedIssues: %v", err)
+	}
+	found := make(map[string]bool)
+	for _, bi := range blocked {
+		found[bi.Issue.ID] = true
+	}
+	if !found[epic.ID] {
+		t.Errorf("epic %s should appear in blocked list", epic.ID)
+	}
+	if !found[child.ID] {
+		t.Errorf("direct child %s should appear in blocked list", child.ID)
+	}
+	if !found[grandchild.ID] {
+		t.Errorf("grandchild %s should appear in blocked list", grandchild.ID)
+	}
+	// Verify grandchild is attributed to its immediate parent, not the root blocker.
+	for _, bi := range blocked {
+		if bi.Issue.ID == grandchild.ID {
+			if len(bi.BlockedBy) == 0 || bi.BlockedBy[0] != child.ID {
+				t.Errorf("grandchild BlockedBy should be [%s] (immediate parent), got %v", child.ID, bi.BlockedBy)
+			}
+		}
+	}
+}

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -249,16 +249,18 @@ func ComputeBlockedIDsInTx(ctx context.Context, tx *sql.Tx, includeWisps bool) (
 // paths, an arbitrary immediate parent is recorded (the CTE has no ORDER BY, so which
 // parent is chosen is non-deterministic). Seeds are batched to stay under SQL
 // parameter limits; each batch's CTE recurses fully, so no descendants are missed.
+// Pass includeWisps=true only when ephemeral issues are in scope; false skips the
+// wisp_dependencies table scan (which can be large) to avoid query timeouts.
 //
 //nolint:gosec // G201: edgeSQL built from hardcoded table names; placeholders use ? params
-func GetTransitiveDescendantsWithParentsInTx(ctx context.Context, tx *sql.Tx, parentIDs []string) (map[string]string, error) {
+func GetTransitiveDescendantsWithParentsInTx(ctx context.Context, tx *sql.Tx, parentIDs []string, includeWisps bool) (map[string]string, error) {
 	if len(parentIDs) == 0 {
 		return nil, nil
 	}
 
-	doQuery := func(includeWisps bool) (map[string]string, error) {
+	doQuery := func(withWisps bool) (map[string]string, error) {
 		edgeSQL := `SELECT issue_id, depends_on_id FROM dependencies WHERE type = 'parent-child'`
-		if includeWisps {
+		if withWisps {
 			edgeSQL += ` UNION ALL SELECT issue_id, depends_on_id FROM wisp_dependencies WHERE type = 'parent-child'`
 		}
 
@@ -290,13 +292,13 @@ func GetTransitiveDescendantsWithParentsInTx(ctx context.Context, tx *sql.Tx, pa
 				return nil, err
 			}
 			for rows.Next() {
-				var childID, parentID string
-				if err := rows.Scan(&childID, &parentID); err != nil {
+				var descendantID, parentID string
+				if err := rows.Scan(&descendantID, &parentID); err != nil {
 					_ = rows.Close()
 					return nil, fmt.Errorf("transitive descendants: scan: %w", err)
 				}
-				if _, exists := result[childID]; !exists {
-					result[childID] = parentID
+				if _, exists := result[descendantID]; !exists {
+					result[descendantID] = parentID
 				}
 			}
 			_ = rows.Close()
@@ -307,6 +309,9 @@ func GetTransitiveDescendantsWithParentsInTx(ctx context.Context, tx *sql.Tx, pa
 		return result, nil
 	}
 
+	if !includeWisps {
+		return doQuery(false)
+	}
 	result, err := doQuery(true)
 	if err != nil {
 		if isTableNotExistError(err) {
@@ -459,12 +464,12 @@ func GetBlockedIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilt
 	}
 
 	// Step 2: Include ALL transitive descendants of blocked parents (GH#1495 + recursive extension).
-	childToParent, childErr := GetTransitiveDescendantsWithParentsInTx(ctx, tx, blockedIDList)
+	childToParent, childErr := GetTransitiveDescendantsWithParentsInTx(ctx, tx, blockedIDList, filter.IncludeEphemeral)
 	if childErr == nil {
-		for childID := range childToParent {
-			if activeIDs[childID] && !blockedSet[childID] {
-				blockedSet[childID] = true
-				blockedIDList = append(blockedIDList, childID)
+		for descendantID := range childToParent {
+			if activeIDs[descendantID] && !blockedSet[descendantID] {
+				blockedSet[descendantID] = true
+				blockedIDList = append(blockedIDList, descendantID)
 			}
 		}
 	}

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -243,16 +243,26 @@ func ComputeBlockedIDsInTx(ctx context.Context, tx *sql.Tx, includeWisps bool) (
 	return result, activeIDs, nil
 }
 
-// GetChildrenWithParentsInTx returns a map of childID -> parentID for direct children
-// (parent-child deps) of the given parent IDs.
+// GetTransitiveDescendantsWithParentsInTx returns a map of descendantID → immediateParentID
+// for ALL transitive parent-child descendants of the given issue IDs. Cycle detection via
+// path tracking prevents infinite traversal. When a descendant is reachable via multiple
+// paths, an arbitrary immediate parent is recorded (the CTE has no ORDER BY, so which
+// parent is chosen is non-deterministic). Seeds are batched to stay under SQL
+// parameter limits; each batch's CTE recurses fully, so no descendants are missed.
 //
-//nolint:gosec // G201: tables are hardcoded
-func GetChildrenWithParentsInTx(ctx context.Context, tx *sql.Tx, parentIDs []string) (map[string]string, error) {
+//nolint:gosec // G201: edgeSQL built from hardcoded table names; placeholders use ? params
+func GetTransitiveDescendantsWithParentsInTx(ctx context.Context, tx *sql.Tx, parentIDs []string) (map[string]string, error) {
 	if len(parentIDs) == 0 {
 		return nil, nil
 	}
-	result := make(map[string]string)
-	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+
+	doQuery := func(includeWisps bool) (map[string]string, error) {
+		edgeSQL := `SELECT issue_id, depends_on_id FROM dependencies WHERE type = 'parent-child'`
+		if includeWisps {
+			edgeSQL += ` UNION ALL SELECT issue_id, depends_on_id FROM wisp_dependencies WHERE type = 'parent-child'`
+		}
+
+		result := make(map[string]string)
 		for start := 0; start < len(parentIDs); start += queryBatchSize {
 			end := start + queryBatchSize
 			if end > len(parentIDs) {
@@ -261,29 +271,48 @@ func GetChildrenWithParentsInTx(ctx context.Context, tx *sql.Tx, parentIDs []str
 			placeholders, args := buildSQLInClause(parentIDs[start:end])
 
 			query := fmt.Sprintf(`
-				SELECT issue_id, depends_on_id FROM %s
-				WHERE type = 'parent-child' AND depends_on_id IN (%s)
-			`, depTable, placeholders)
+				WITH RECURSIVE
+				edges(issue_id, depends_on_id) AS (%s),
+				desc_tree(id, immediate_parent, path) AS (
+					SELECT issue_id, depends_on_id, CONCAT(',', depends_on_id, ',', issue_id, ',')
+					FROM edges WHERE depends_on_id IN (%s)
+					UNION ALL
+					SELECT e.issue_id, d.id, CONCAT(d.path, e.issue_id, ',')
+					FROM edges e
+					JOIN desc_tree d ON e.depends_on_id = d.id
+					WHERE LOCATE(CONCAT(',', e.issue_id, ','), d.path) = 0
+				)
+				SELECT id, immediate_parent FROM desc_tree
+			`, edgeSQL, placeholders)
+
 			rows, err := tx.QueryContext(ctx, query, args...)
 			if err != nil {
-				if isTableNotExistError(err) {
-					break
-				}
-				return nil, fmt.Errorf("get children with parents from %s: %w", depTable, err)
+				return nil, err
 			}
 			for rows.Next() {
 				var childID, parentID string
 				if err := rows.Scan(&childID, &parentID); err != nil {
 					_ = rows.Close()
-					return nil, fmt.Errorf("scan children with parents: %w", err)
+					return nil, fmt.Errorf("transitive descendants: scan: %w", err)
 				}
-				result[childID] = parentID
+				if _, exists := result[childID]; !exists {
+					result[childID] = parentID
+				}
 			}
 			_ = rows.Close()
 			if err := rows.Err(); err != nil {
-				return nil, fmt.Errorf("children with parents rows from %s: %w", depTable, err)
+				return nil, fmt.Errorf("transitive descendants: rows: %w", err)
 			}
 		}
+		return result, nil
+	}
+
+	result, err := doQuery(true)
+	if err != nil {
+		if isTableNotExistError(err) {
+			return doQuery(false)
+		}
+		return nil, fmt.Errorf("transitive descendants: %w", err)
 	}
 	return result, nil
 }
@@ -429,8 +458,8 @@ func GetBlockedIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilt
 		blockedSet[id] = true
 	}
 
-	// Step 2: Include children of blocked parents (GH#1495).
-	childToParent, childErr := GetChildrenWithParentsInTx(ctx, tx, blockedIDList)
+	// Step 2: Include ALL transitive descendants of blocked parents (GH#1495 + recursive extension).
+	childToParent, childErr := GetTransitiveDescendantsWithParentsInTx(ctx, tx, blockedIDList)
 	if childErr == nil {
 		for childID := range childToParent {
 			if activeIDs[childID] && !blockedSet[childID] {

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -169,10 +169,10 @@ func GetReadyWorkInTx(
 	blockedIDs, err := computeBlockedFn(ctx, tx, filter.IncludeEphemeral)
 	if err == nil && len(blockedIDs) > 0 {
 		// Also exclude ALL transitive descendants of blocked parents.
-		descendants, childErr := GetTransitiveDescendantsWithParentsInTx(ctx, tx, blockedIDs)
+		descendants, childErr := GetTransitiveDescendantsWithParentsInTx(ctx, tx, blockedIDs, filter.IncludeEphemeral)
 		if childErr == nil {
-			for childID := range descendants {
-				blockedIDs = append(blockedIDs, childID)
+			for descendantID := range descendants {
+				blockedIDs = append(blockedIDs, descendantID)
 			}
 		}
 

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -168,10 +168,12 @@ func GetReadyWorkInTx(
 	// Exclude blocked issues.
 	blockedIDs, err := computeBlockedFn(ctx, tx, filter.IncludeEphemeral)
 	if err == nil && len(blockedIDs) > 0 {
-		// Also exclude children of blocked parents.
-		childrenOfBlocked, childErr := getChildrenOfIssuesInTx(ctx, tx, blockedIDs)
+		// Also exclude ALL transitive descendants of blocked parents.
+		descendants, childErr := GetTransitiveDescendantsWithParentsInTx(ctx, tx, blockedIDs)
 		if childErr == nil {
-			blockedIDs = append(blockedIDs, childrenOfBlocked...)
+			for childID := range descendants {
+				blockedIDs = append(blockedIDs, childID)
+			}
 		}
 
 		for start := 0; start < len(blockedIDs); start += queryBatchSize {


### PR DESCRIPTION
## Problem

`bd ready` and `bd blocked` only excluded **direct children** of a blocked parent from the ready work queue. Grandchildren and deeper descendants of a blocked epic/feature leaked into `bd ready` even though they couldn't meaningfully be worked on.

### Example

```
A (open blocker)
  └── blocks → B (epic, blocked)
                 └── B1 (child)
                       └── B1a (grandchild)  ← incorrectly appeared in bd ready
```

`B1` was excluded (one-hop worked), but `B1a` was not.

## Root cause

Two separate `GetReadyWork` implementations each had a one-hop child query:

1. **`internal/storage/issueops/ready_work.go`** (`GetReadyWorkInTx`) — used by the embedded Dolt path
2. **`internal/storage/dolt/queries.go`** (`DoltStore.GetReadyWork`) — used by the external Dolt server path

Both called `getChildrenOfIssues`/`GetChildrenOfIssuesInTx` (direct children only) instead of walking the full parent-child tree.

## Fix

Adds `GetTransitiveDescendantsWithParentsInTx` in `internal/storage/issueops/blocked.go` — a recursive CTE that walks the full parent-child subtree with path-based cycle detection:

```sql
WITH RECURSIVE
edges(issue_id, depends_on_id) AS (SELECT ... WHERE type = 'parent-child'),
desc_tree(id, immediate_parent, path) AS (
    -- seed: direct children of blocked parents
    SELECT issue_id, depends_on_id, CONCAT(',', depends_on_id, ',', issue_id, ',')
    FROM edges WHERE depends_on_id IN (?, ...)
    UNION ALL
    -- recurse: children of already-found descendants
    SELECT e.issue_id, d.id, CONCAT(d.path, e.issue_id, ',')
    FROM edges e JOIN desc_tree d ON e.depends_on_id = d.id
    WHERE LOCATE(CONCAT(',', e.issue_id, ','), d.path) = 0  -- cycle guard
)
SELECT id, immediate_parent FROM desc_tree
```

Both `GetReadyWorkInTx` (issueops path) and `DoltStore.GetReadyWork` (dolt path) are updated to use this function. The `immediate_parent` column records the **direct** parent of each descendant, not the root blocker, so `GetBlockedIssues` attribution is correct at every level.

The one-hop child exclusion for **deferred** parents (not blocked parents) is intentionally left unchanged — one-hop is correct semantics there.

## Tests

New tests in both backends (requires live Dolt server for the dolt package tests):

- `TestGetReadyWork_ExcludesTransitiveDescendantsOfBlockedParents` — 3-level chain
- `TestGetReadyWork_ExcludesDeeplyNestedDescendantsOfBlockedParents` — 4-level chain
- `TestGetBlockedIssues_IncludesTransitiveDescendantsOfBlockedParents` — with `BlockedBy` attribution assertion (grandchild is attributed to its immediate parent, not the root blocker)

## Verified on real data

Tested against a project with a real dependency DAG (`vaac` → children → grandchildren). Before the fix: 70 issues in `bd ready`. After: 48. The 22 removed items were all transitive descendants of blocked milestones.

## Note on the existing `ready_issues` view (deliberate non-use)

While auditing this code path we re-discovered the `ready_issues` SQL view defined in `0017_create_ready_issues_view.up.sql` and updated in `0025_update_ready_issues_view.up.sql`. It is **structurally similar** to the Go-side logic this PR fixes — a recursive CTE that walks blocked → transitive descendants — and it is created at schema apply time by `RebuildStatusViews` (`internal/storage/dolt/store.go:2498`). But it is not used by `DoltStore.GetReadyWork`:

```go
// internal/storage/dolt/queries.go:332-334
// Ready count: compute without using the ready_issues view to avoid
// recursive CTE join that triggers the same Dolt panic.
```

And the broader avoidance pattern at `queries.go:184-186`:

```go
// Pre-compute blocked set using separate single-table queries to avoid
// Dolt's joinIter panic (join_iters.go:192). Correlated EXISTS/NOT EXISTS
// subqueries across tables trigger the same panic.
```

**This PR explicitly chooses not to re-architect onto the view.** The fix here patches the existing Go-side recursive-descendants logic so it correctly walks the full parent-child tree (matching the view's intent semantically). We trust the existing batching (`queryBatchSize = 200`) and process-lifetime `blockedIDsCache` to compensate for the Go-side cost.

The current implementation is **structurally different** from the panic-triggering view — no `issues × dependencies` joins, no correlated `EXISTS`, the recursive CTE stays inside edge tables — so the deferral is informed, not reckless. But it does pay a non-trivial cost per cold call (two unbounded full-scans before the user's limit applies).

A follow-up issue has been filed to revisit whether the view can now be leveraged on modern Dolt, along with suggested indexing improvements: gastownhall/beads#3877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
