### PR TITLE
fix(bd): write labels in CreateIssue tx instead of N AddLabel calls

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -528,31 +528,10 @@ var createCmd = &cobra.Command{
 			// If error getting parent or parent has no source_repo, continue with default
 		}
 
-		if err := store.CreateIssue(ctx, issue, actor); err != nil {
-			FatalError("%v", err)
-		}
-
-		// Track whether any post-create writes occurred. CreateIssue commits
-		// the issue to Dolt internally, but subsequent AddDependency/AddLabel
-		// calls only write to the working set. A follow-up Dolt commit is
-		// needed to persist them (GH#2009).
-		postCreateWrites := false
-
-		// If parent was specified, add parent-child dependency
-		if parentID != "" {
-			dep := &types.Dependency{
-				IssueID:     issue.ID,
-				DependsOnID: parentID,
-				Type:        types.DepParentChild,
-			}
-			if err := store.AddDependency(ctx, dep, actor); err != nil {
-				WarnError("failed to add parent-child dependency %s -> %s: %v", issue.ID, parentID, err)
-			} else {
-				postCreateWrites = true
-			}
-		}
-
 		// Merge inherited parent labels with user-specified labels (GH#2100)
+		// and attach them to the issue so they're persisted in the same
+		// transaction as the insert. Previously a post-create AddLabel loop
+		// emitted N extra update events per create (stg-u81).
 		if len(inheritedLabels) > 0 {
 			seen := make(map[string]bool)
 			for _, l := range labels {
@@ -564,11 +543,27 @@ var createCmd = &cobra.Command{
 				}
 			}
 		}
+		issue.Labels = labels
 
-		// Add labels if specified
-		for _, label := range labels {
-			if err := store.AddLabel(ctx, issue.ID, label, actor); err != nil {
-				WarnError("failed to add label %s: %v", label, err)
+		if err := store.CreateIssue(ctx, issue, actor); err != nil {
+			FatalError("%v", err)
+		}
+
+		// Track whether any post-create writes occurred. CreateIssue commits
+		// the issue (and labels) to Dolt internally, but subsequent
+		// AddDependency calls only write to the working set. A follow-up
+		// Dolt commit is needed to persist them (GH#2009).
+		postCreateWrites := false
+
+		// If parent was specified, add parent-child dependency
+		if parentID != "" {
+			dep := &types.Dependency{
+				IssueID:     issue.ID,
+				DependsOnID: parentID,
+				Type:        types.DepParentChild,
+			}
+			if err := store.AddDependency(ctx, dep, actor); err != nil {
+				WarnError("failed to add parent-child dependency %s -> %s: %v", issue.ID, parentID, err)
 			} else {
 				postCreateWrites = true
 			}

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -276,6 +276,44 @@ func TestEmbeddedCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("labels_atomic", func(t *testing.T) {
+		// Regression for stg-u81 / gastownhall/beads#3868: `bd create
+		// --labels A,B,C` must persist labels in the create transaction,
+		// not via N post-create AddLabel calls. The bug was in CLI
+		// plumbing (buildCreateIssue did not propagate labels onto the
+		// *Issue), so a storage-layer test would not catch a regression.
+		// This test runs the CLI as a subprocess and inspects the events
+		// table directly.
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "la")
+		issue := bdCreate(t, bd, dir, "Atomic labels via CLI",
+			"-l", "alpha,beta,gamma")
+
+		dataDir := filepath.Join(beadsDir, "embeddeddolt")
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "la", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+
+		var created, labelAdded int
+		if err := db.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = 'created'",
+			issue.ID).Scan(&created); err != nil {
+			t.Fatalf("query created events: %v", err)
+		}
+		if err := db.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM events WHERE issue_id = ? AND event_type = 'label_added'",
+			issue.ID).Scan(&labelAdded); err != nil {
+			t.Fatalf("query label_added events: %v", err)
+		}
+		if created != 1 {
+			t.Errorf("expected 1 created event, got %d", created)
+		}
+		if labelAdded != 0 {
+			t.Errorf("expected 0 label_added events (labels should land in the create tx), got %d", labelAdded)
+		}
+	})
+
 	t.Run("explicit_id", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "ei")
 		issue := bdCreate(t, bd, dir, "Explicit ID", "--id", "ei-custom42")

--- a/cmd/bd/create_form.go
+++ b/cmd/bd/create_form.go
@@ -171,31 +171,10 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 		}
 	}
 
-	if err := s.CreateIssue(ctx, issue, actor); err != nil {
-		return nil, fmt.Errorf("failed to create issue: %w", err)
-	}
-
-	// Track whether any post-create writes occurred. CreateIssue commits
-	// the issue to Dolt internally, but subsequent AddDependency/AddLabel
-	// calls only write to the working set. A follow-up Dolt commit is
-	// needed to persist them (GH#2009).
-	postCreateWrites := false
-
-	// If parent was specified, add parent-child dependency (GH#1983)
-	if fv.ParentID != "" {
-		dep := &types.Dependency{
-			IssueID:     issue.ID,
-			DependsOnID: fv.ParentID,
-			Type:        types.DepParentChild,
-		}
-		if err := s.AddDependency(ctx, dep, actor); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to add parent-child dependency %s -> %s: %v\n", issue.ID, fv.ParentID, err)
-		} else {
-			postCreateWrites = true
-		}
-	}
-
 	// Merge inherited parent labels with user-specified labels (GH#2100)
+	// and attach them to the issue so they're persisted in the same
+	// transaction as the insert. Previously a post-create AddLabel loop
+	// emitted N extra update events per create (stg-u81).
 	if len(inheritedLabels) > 0 {
 		seen := make(map[string]bool)
 		for _, l := range fv.Labels {
@@ -207,12 +186,27 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 			}
 		}
 	}
+	issue.Labels = fv.Labels
 
-	// Add labels if specified
-	for _, label := range fv.Labels {
-		if err := s.AddLabel(ctx, issue.ID, label, actor); err != nil {
-			// Log warning but don't fail the entire operation
-			fmt.Fprintf(os.Stderr, "Warning: failed to add label %s: %v\n", label, err)
+	if err := s.CreateIssue(ctx, issue, actor); err != nil {
+		return nil, fmt.Errorf("failed to create issue: %w", err)
+	}
+
+	// Track whether any post-create writes occurred. CreateIssue commits
+	// the issue (and labels) to Dolt internally, but subsequent
+	// AddDependency calls only write to the working set. A follow-up
+	// Dolt commit is needed to persist them (GH#2009).
+	postCreateWrites := false
+
+	// If parent was specified, add parent-child dependency (GH#1983)
+	if fv.ParentID != "" {
+		dep := &types.Dependency{
+			IssueID:     issue.ID,
+			DependsOnID: fv.ParentID,
+			Type:        types.DepParentChild,
+		}
+		if err := s.AddDependency(ctx, dep, actor); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to add parent-child dependency %s -> %s: %v\n", issue.ID, fv.ParentID, err)
 		} else {
 			postCreateWrites = true
 		}

--- a/cmd/bd/create_form_test.go
+++ b/cmd/bd/create_form_test.go
@@ -301,6 +301,52 @@ func TestCreateIssueFromFormValues(t *testing.T) {
 		}
 	})
 
+	t.Run("WithLabelsAtomic", func(t *testing.T) {
+		// Regression for stg-u81 / gastownhall/beads#3868: the form path
+		// must persist labels in the create transaction, not via N
+		// post-create AddLabel calls. Parallel to the CLI fix in
+		// cmd/bd/create.go; same shape, same call site for the bug.
+		fv := &createFormValues{
+			Title:     "Atomic labels via form",
+			Priority:  1,
+			IssueType: "task",
+			Labels:    []string{"alpha", "beta", "gamma"},
+		}
+
+		issue, err := CreateIssueFromFormValues(ctx, s, fv, "test")
+		if err != nil {
+			t.Fatalf("failed to create issue: %v", err)
+		}
+
+		got, err := s.GetLabels(ctx, issue.ID)
+		if err != nil {
+			t.Fatalf("get labels: %v", err)
+		}
+		if len(got) != 3 {
+			t.Errorf("expected 3 labels persisted, got %d: %v", len(got), got)
+		}
+
+		events, err := s.GetEvents(ctx, issue.ID, 100)
+		if err != nil {
+			t.Fatalf("get events: %v", err)
+		}
+		var created, labelAdded int
+		for _, e := range events {
+			switch e.EventType {
+			case types.EventCreated:
+				created++
+			case types.EventLabelAdded:
+				labelAdded++
+			}
+		}
+		if created != 1 {
+			t.Errorf("expected 1 created event, got %d", created)
+		}
+		if labelAdded != 0 {
+			t.Errorf("expected 0 label_added events (labels should land in the create tx), got %d", labelAdded)
+		}
+	})
+
 	t.Run("WithDependencies", func(t *testing.T) {
 		// Create a parent issue first
 		parentFv := &createFormValues{

--- a/cmd/bd/create_test.go
+++ b/cmd/bd/create_test.go
@@ -179,6 +179,53 @@ func TestCreateSuite(t *testing.T) {
 		}
 	})
 
+	t.Run("CreateWithLabelsAtomic", func(t *testing.T) {
+		// Regression for stg-u81 / GH#3865: create-with-labels must persist
+		// labels in the same transaction as the issue insert. The previous
+		// shape (CreateIssue with empty Labels, then N AddLabel calls) emitted
+		// a label_added event per label.
+		issue := &types.Issue{
+			Title:     "Atomic labels at create",
+			Labels:    []string{"alpha", "beta", "gamma"},
+			Priority:  1,
+			Status:    types.StatusOpen,
+			IssueType: types.TypeTask,
+			CreatedAt: time.Now(),
+		}
+
+		if err := s.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatalf("failed to create issue: %v", err)
+		}
+
+		got, err := s.GetLabels(ctx, issue.ID)
+		if err != nil {
+			t.Fatalf("failed to get labels: %v", err)
+		}
+		if len(got) != 3 {
+			t.Errorf("expected 3 labels persisted, got %d: %v", len(got), got)
+		}
+
+		events, err := s.GetEvents(ctx, issue.ID, 100)
+		if err != nil {
+			t.Fatalf("failed to get events: %v", err)
+		}
+		var created, labelAdded int
+		for _, e := range events {
+			switch e.EventType {
+			case types.EventCreated:
+				created++
+			case types.EventLabelAdded:
+				labelAdded++
+			}
+		}
+		if created != 1 {
+			t.Errorf("expected 1 created event, got %d (events: %v)", created, events)
+		}
+		if labelAdded != 0 {
+			t.Errorf("expected 0 label_added events (labels should land in the create tx), got %d (events: %v)", labelAdded, events)
+		}
+	})
+
 	t.Run("WithDependencies", func(t *testing.T) {
 		parent := &types.Issue{
 			Title:     "Parent issue",

--- a/cmd/bd/create_test.go
+++ b/cmd/bd/create_test.go
@@ -180,10 +180,13 @@ func TestCreateSuite(t *testing.T) {
 	})
 
 	t.Run("CreateWithLabelsAtomic", func(t *testing.T) {
-		// Regression for stg-u81 / GH#3865: create-with-labels must persist
-		// labels in the same transaction as the issue insert. The previous
-		// shape (CreateIssue with empty Labels, then N AddLabel calls) emitted
-		// a label_added event per label.
+		// Contract test for the storage-layer invariant the cmd/bd fix
+		// for stg-u81 (gastownhall/beads#3868) relies on: when *Issue
+		// has Labels populated, CreateIssue persists them in the same
+		// transaction (one created event, zero label_added events).
+		// The CLI-level regression test that catches a recurrence of
+		// the actual bug lives in cmd/bd/create_embedded_test.go
+		// (TestEmbeddedCreate / labels_atomic).
 		issue := &types.Issue{
 			Title:     "Atomic labels at create",
 			Labels:    []string{"alpha", "beta", "gamma"},


### PR DESCRIPTION
## What

`bd create --labels A,B,C` (CLI and interactive-form paths) now emits a
single `EventCreated` row with all labels persisted in the create
transaction, instead of `EventCreated` (no labels) followed by N
`EventLabelAdded` events.

## Why

`buildCreateIssue` (`cmd/bd/create.go:746`) constructs `*types.Issue`
without a `Labels` field, so `PersistLabels` (called inside
`CreateIssueInTx`, `internal/storage/issueops/create.go:98`) is a no-op
on an empty slice — labels weren't landing in the create transaction.
The post-create code at `cmd/bd/create.go:568-575` then looped
`store.AddLabel` per label, emitting an `EventLabelAdded` row each time
and writing a follow-up Dolt commit per #2055. The interactive form
path (`cmd/bd/create_form.go`, used by `CreateIssueFromFormValues`) had
the same shape.

Per `bd create --labels=...` invocation:
- N `EventLabelAdded` events suppressed.
- One Dolt commit instead of one + N working-set writes.
- The create event correctly carries the initial label set instead of
  showing `labels=null`.

`PersistLabels` already iterates `issue.Labels` and writes each label
inside the same SQL transaction (`internal/storage/issueops/create.go:255-271`)
— the storage layer was already prepared for this; the CLI/form just
weren't using the field.

## Surface check

`cmd/bd/create.go` and `cmd/bd/create_form.go` are the canonical
surfaces for the CLI's and the form's labeled-create flows; the
underlying tx-level helper (`PersistLabels`) already supports atomic
writes. No new API; the fix is to feed labels into the struct that's
already being persisted.

## Behavior change

Per-label INSERT failures previously emitted `WarnError` and continued
(partial-success); they now roll back the whole `CreateIssue`.

This is intentional and arguably more correct. `PersistLabels` uses
`INSERT INTO labels ... ON DUPLICATE KEY UPDATE label = label`, so the
common "label already exists" case is a no-op, not an error. The only
INSERT failures left are infrastructure errors (connection lost, schema
violation, label string exceeding the column length) — exactly the
class of error that should roll back a create rather than silently
warn-and-continue with a half-formed issue. The prior loose behavior
was masking write errors that should surface.

## Verification

`make test` runs the regression tests:

```bash
cd <beads>
make test
# CLI-level (subprocess; requires BEADS_TEST_EMBEDDED_DOLT=1):
BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go \
    -run 'TestEmbeddedCreate/labels_atomic' ./cmd/bd/...
# Storage and form-path tests:
go test -tags gms_pure_go \
    -run 'TestCreateSuite/CreateWithLabelsAtomic|TestCreateIssueFromFormValues/WithLabelsAtomic' \
    ./cmd/bd/...
```

Three tests cover the change:

- **`TestEmbeddedCreate/labels_atomic`** (CLI regression). Runs
  `bd create --labels alpha,beta,gamma` as a subprocess and queries
  the events table directly. Asserts exactly 1 `created` event and
  0 `label_added` events. Under the previous shape would see 3
  `label_added` rows. This is the layer-matched regression test for
  the actual bug.
- **`TestCreateIssueFromFormValues/WithLabelsAtomic`** (form-path
  regression). Calls `CreateIssueFromFormValues` with pre-populated
  `fv.Labels` and asserts the same event-count invariant.
- **`TestCreateSuite/CreateWithLabelsAtomic`** (storage contract).
  Calls `s.CreateIssue` with `Labels` pre-populated. Documents the
  storage-layer invariant the CLI/form fixes rely on; doesn't
  regression-cover the CLI plumbing.

Existing tests (`TestCreateSuite/WithLabels`, `TestEmbeddedCreate/labels`,
`TestCreateIssueFromFormValues/WithLabels`) still pass — `AddLabel`
itself is unchanged.

## Out of scope

`make test-integration` per the repo's PR template — current local
policy is to defer (past attempts hit the 30-minute timeout with no
saved partial output). Reviewers can request a run if they want one.

## Discovery sweep

- **#2055** (merged) — established the post-create commit pattern this
  PR optimizes.
- **#3493** (open) — `DOLT_COMMIT after label/comment writes` in server
  mode. Complementary; this PR reduces the surface #3493 patches but
  doesn't conflict.
- **#3803** (open) — `doltTransaction CloseIssue/AddLabel/RemoveLabel
  now emit events`. Opposite problem (missing events in a different
  code path); unrelated.

No overlapping in-flight PR for the atomic-labels-at-create
optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)