### PR TITLE
fix(auto-backup): serialize concurrent forks via flock

### DIFF
--- a/cmd/bd/backup_auto.go
+++ b/cmd/bd/backup_auto.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/debug"
+	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 )
 
 // isBackupAutoEnabled returns whether backup should run.
@@ -64,6 +67,23 @@ func maybeAutoBackup(ctx context.Context) {
 			time.Since(state.Timestamp).Round(time.Second), interval)
 		return
 	}
+
+	// Serialize concurrent auto-backups across bd CLI forks. In server mode
+	// multiple bd processes share one Dolt sql-server; without this lock,
+	// PersistentPostRun fires per fork and all forks race past the throttle
+	// window into BackupDatabase's rm-then-add, producing duplicate
+	// CALL DOLT_BACKUP traffic. Non-blocking: if another fork holds the lock,
+	// this one skips — the holder's run already covers our changes.
+	lock, err := util.TryLock(filepath.Join(dir, ".backup.lock"))
+	if err != nil {
+		if lockfile.IsLocked(err) {
+			debug.Logf("backup: another process is backing up, skipping\n")
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Warning: auto-backup skipped: %v\n", err)
+		return
+	}
+	defer lock.Unlock()
 
 	// Change detection: skip if nothing changed
 	currentCommit, err := store.GetCurrentCommit(ctx)

--- a/cmd/bd/backup_auto_test.go
+++ b/cmd/bd/backup_auto_test.go
@@ -4,9 +4,12 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 )
 
 func TestIsBackupAutoEnabled(t *testing.T) {
@@ -82,5 +85,34 @@ func TestIsBackupAutoEnabled(t *testing.T) {
 				t.Errorf("isBackupAutoEnabled() = %v, want %v", got, tt.wantResult)
 			}
 		})
+	}
+}
+
+// TestAutoBackupLockSerializesForks pins the contract that maybeAutoBackup
+// relies on: when one bd CLI fork holds the auto-backup flock at
+// <backup-dir>/.backup.lock, a second TryLock on the same path returns an
+// error that lockfile.IsLocked recognizes. The skip-on-contention branch in
+// maybeAutoBackup depends on that recognition; if a refactor of util.TryLock
+// or lockfile.IsLocked breaks the recognition, concurrent forks would race
+// past the lock and back into the noisy DOLT_BACKUP rm/add path this test
+// guards against.
+func TestAutoBackupLockSerializesForks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, ".backup.lock")
+
+	held, err := util.TryLock(lockPath)
+	if err != nil {
+		t.Fatalf("first TryLock on uncontended path: %v", err)
+	}
+	defer held.Unlock()
+
+	_, err = util.TryLock(lockPath)
+	if err == nil {
+		t.Fatalf("second TryLock should fail while the lock is held")
+	}
+	if !lockfile.IsLocked(err) {
+		t.Fatalf("second TryLock error should be IsLocked-recognized; got: %v", err)
 	}
 }

--- a/cmd/bd/backup_auto_test.go
+++ b/cmd/bd/backup_auto_test.go
@@ -3,12 +3,17 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/lockfile"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dbproxy/util"
 )
 
@@ -115,4 +120,118 @@ func TestAutoBackupLockSerializesForks(t *testing.T) {
 	if !lockfile.IsLocked(err) {
 		t.Fatalf("second TryLock error should be IsLocked-recognized; got: %v", err)
 	}
+}
+
+// recordingStore satisfies storage.DoltStorage just enough for
+// maybeAutoBackup to traverse the pre-lock guards. It records whether
+// GetCurrentCommit — the first store call past the .backup.lock guard —
+// was invoked. The embedded DoltStorage is intentionally nil; any
+// method call on it would nil-panic, which is exactly the assertion we
+// want for any post-lock store reference.
+type recordingStore struct {
+	storage.DoltStorage
+	getCurrentCommitCalled atomic.Bool
+}
+
+func (r *recordingStore) GetCurrentCommit(ctx context.Context) (string, error) {
+	r.getCurrentCommitCalled.Store(true)
+	return "", nil
+}
+
+// TestMaybeAutoBackupSkipsOnLockContention drives maybeAutoBackup directly and
+// asserts it short-circuits at the .backup.lock guard when another holder is
+// alive — pinning the production caller's behavior, not just the TryLock
+// primitive it depends on. TestAutoBackupLockSerializesForks above would still
+// pass if a refactor dropped the TryLock call from maybeAutoBackup entirely;
+// this test would not.
+//
+// The function has two subtests so the contended-lock assertion is anchored to
+// a control: in the uncontended case maybeAutoBackup must reach the store
+// (proving the test setup gets past every pre-lock guard), and in the
+// contended case it must not.
+func TestMaybeAutoBackupSkipsOnLockContention(t *testing.T) {
+	// Cannot be parallel: subtests assign to global store and global config.
+
+	setup := func(t *testing.T) (ctx context.Context, repoDir string, rec *recordingStore) {
+		t.Helper()
+		ctx = context.Background()
+
+		// Use the backup.git-repo path so backupDir() resolves without any
+		// FindBeadsDir / cwd walk-up dance — point it at a minimal
+		// git-init'd temp dir.
+		repoDir = t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+			t.Fatalf("mkdir .git: %v", err)
+		}
+		t.Setenv("BD_BACKUP_GIT_REPO", repoDir)
+
+		beads.ResetCaches()
+		git.ResetCaches()
+		t.Cleanup(func() {
+			beads.ResetCaches()
+			git.ResetCaches()
+		})
+
+		// Force-enable auto-backup independent of the git-remote heuristic.
+		t.Setenv("BD_BACKUP_ENABLED", "true")
+		config.ResetForTesting()
+		t.Cleanup(func() { config.ResetForTesting() })
+		if err := config.Initialize(); err != nil {
+			t.Fatalf("config.Initialize: %v", err)
+		}
+
+		originalStore := store
+		t.Cleanup(func() { store = originalStore })
+		rec = &recordingStore{}
+		store = rec
+
+		if err := os.MkdirAll(filepath.Join(repoDir, "backup"), 0o700); err != nil {
+			t.Fatalf("mkdir backup dir: %v", err)
+		}
+		return ctx, repoDir, rec
+	}
+
+	t.Run("lock held → skip", func(t *testing.T) {
+		ctx, repoDir, rec := setup(t)
+
+		// Pre-acquire the auto-backup lock from this goroutine to simulate
+		// another bd CLI fork already holding it.
+		lockPath := filepath.Join(repoDir, "backup", ".backup.lock")
+		held, err := util.TryLock(lockPath)
+		if err != nil {
+			t.Fatalf("pre-acquire TryLock: %v", err)
+		}
+		defer held.Unlock()
+
+		maybeAutoBackup(ctx)
+
+		if rec.getCurrentCommitCalled.Load() {
+			t.Fatalf("maybeAutoBackup reached store.GetCurrentCommit despite contended lock — lock-skip path did not run")
+		}
+
+		statePath := filepath.Join(repoDir, "backup", "backup_state.json")
+		if _, err := os.Stat(statePath); err == nil {
+			t.Fatalf("maybeAutoBackup wrote %s despite contended lock", statePath)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("unexpected error stat'ing %s: %v", statePath, err)
+		}
+	})
+
+	t.Run("lock free → control: store is consulted", func(t *testing.T) {
+		ctx, _, rec := setup(t)
+
+		// No pre-acquired lock. maybeAutoBackup should pass the lock guard
+		// and reach store.GetCurrentCommit. The recordingStore returns
+		// ("", nil), so the downstream runBackupExport will fail at the
+		// BackupStore type assertion — that's expected and produces a
+		// "Warning: auto-backup failed: storage backend does not support
+		// backup operations" line on stderr. We only care that the store
+		// was consulted; if it wasn't, the "skip" subtest above would
+		// pass for the wrong reason.
+		maybeAutoBackup(ctx)
+
+		if !rec.getCurrentCommitCalled.Load() {
+			t.Fatalf("maybeAutoBackup did not consult store.GetCurrentCommit even with an uncontended lock — the 'skip' subtest is passing for the wrong reason")
+		}
+	})
 }


### PR DESCRIPTION
## What

Acquire a non-blocking exclusive flock at `<backup-dir>/.backup.lock`
in `maybeAutoBackup` between the throttle check and change detection.
Only one fork per throttle window does the registration + sync;
contended forks see `lockfile.IsLocked` and skip silently.

## Why

In server mode (multiple bd CLI processes against one Dolt sql-server)
`PersistentPostRun` fires per fork. When the throttle window opens, all
forks read the same stale `backup_state.json`, pass the cheap throttle
check at roughly the same instant, and race into `BackupDatabase`'s
unconditional `BackupRemove` followed by `BackupAdd` for `backup_export`.

Dolt logs each duplicate `CALL DOLT_BACKUP('rm', ...)` and
`CALL DOLT_BACKUP('add', ...)` as a warning (`backup_export not found`,
`backup_export already exists`) even though the rm error is absorbed at
the call site (`internal/storage/{embeddeddolt,dolt}/...:BackupDatabase`,
the `_ = versioncontrolops.BackupRemove(...)` line) and the add
eventually succeeds for one fork. The result is noisy `dolt.log`
output (5+ duplicate warnings within a single ms during a 5-fork
race observed locally) that downstream tooling flags as non-benign,
requiring manual inspection each run to confirm it was absorbed.

Functional impact pre-fix: none — the registration always succeeds for
one fork. Operational impact: log noise + cognitive overhead.

## Verification

- `go test -tags=gms_pure_go -count=1 -run '^TestAutoBackupLockSerializesForks$|^TestIsBackupAutoEnabled$' ./cmd/bd/` — pass.
- New test `TestAutoBackupLockSerializesForks` pins the contract that
  `util.TryLock` returns a `lockfile.IsLocked`-recognized error when a
  second TryLock targets the same path. The skip-on-contention branch
  in `maybeAutoBackup` depends on that recognition.
- `make test`: pre-existing failures unrelated to this change reproduce
  identically on `origin/main` (cb9d7aad5):
  - `cmd/bd`: `TestContextUsesExplicitDBFlagForNoDBCommand` deterministically
    hangs at the `os/exec` pipe-wait stack (Go #23019 shape) — same
    121s timeout, same goroutine stack on the unmodified worktree.
    Filed as EXPECT-FAIL.
  - `internal/beads`: `TestRole_NoConfig` / `TestRequireRole_NotConfigured`
    fail when the test environment has `git config --global beads.role`
    set (the tests `git init` a temp repo but don't isolate from
    inherited global config). Environmental, not introduced here.
  - `internal/storage/dolt`: `TestCloudAuthCLIRouting/azure_env_+_s3://_remote`
    is the documented EXPECT-FAIL for that area.

`make test-integration` not run (per project policy: known to exceed
the 30-min tool timeout with no saved partial output).

## Design notes

**Lock scope: single fork per throttle window.** Under contention the
lock-loser returns silently; it doesn't queue, doesn't retry, doesn't
re-check the throttle. This is sufficient because the lock-holder's run
already covers the loser's changes (auto-backup is rolling, not
per-commit). After the holder updates `backup_state.json`, the next
incoming fork sees a fresh timestamp and the cheap throttle check fires
before the lock is touched.

**Throttle before lock.** Most commands hit the throttle skip and never
need the flock — the lock acquisition stays out of the steady-state
PersistentPostRun fast path.

**Lock placement: `<backup-dir>/.backup.lock`.** The backup-dir is
already used to coordinate the same set of processes (`backup_state.json`
lives next to it) and `backupDir()` creates it `0700`. `util.TryLock`
also handles `MkdirAll` defensively. This matches the existing
embeddeddolt pattern (`acquireEmbeddedLock`) which holds an exclusive
flock on the data-dir's `.lock` file.

**Out of scope.** The unconditional `_ = bs.BackupRemove(ctx,
"backup_export")` in `cmd/bd/backup_dolt.go:411` (the explicit
`bd backup remove` command path) is left untouched: that path is
user-explicit and not the high-fork-rate caller observed in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)