### PR TITLE
fix(mol bond): resolve plain formula names like every other subcommand (GH#3873)

### DIFF
--- a/cmd/bd/mol_bond.go
+++ b/cmd/bd/mol_bond.go
@@ -575,12 +575,10 @@ func resolveOrDescribe(ctx context.Context, s storage.DoltStorage, operand strin
 		}
 	}
 
-	// Not found as issue - check if it looks like a formula name
-	if !looksLikeFormulaName(operand) {
-		return nil, "", fmt.Errorf("'%s' not found (not an issue ID or formula name)", operand)
-	}
-
-	// Try to load the formula (but don't cook it)
+	// Not found as issue — fall through to the formula registry. parser.LoadByName
+	// returns "formula %q not found in search paths" for genuinely unknown names,
+	// which is the right error. This matches the resolution behavior of
+	// bd formula show / bd mol seed / bd mol pour / bd cook.
 	parser := formula.NewParser()
 	f, err := parser.LoadByName(operand)
 	if err != nil {
@@ -619,37 +617,15 @@ func resolveOrCookToSubgraph(ctx context.Context, s storage.DoltStorage, operand
 		}
 	}
 
-	// Not found as issue - check if it looks like a formula name
-	if !looksLikeFormulaName(operand) {
-		return nil, false, fmt.Errorf("'%s' not found (not an issue ID or formula name)", operand)
-	}
-
-	// Try to cook formula inline to in-memory subgraph
-	// Pass vars for step condition filtering (bd-7zka.1)
+	// Not found as issue — fall through to the formula registry. Same rationale
+	// as resolveOrDescribe above: let the parser decide. Pass vars for step
+	// condition filtering (bd-7zka.1).
 	subgraph, err := resolveAndCookFormulaWithVars(operand, nil, vars)
 	if err != nil {
 		return nil, false, fmt.Errorf("'%s' not found as issue or formula: %w", operand, err)
 	}
 
 	return subgraph, true, nil
-}
-
-// looksLikeFormulaName checks if an operand looks like a formula name.
-// Formula names typically start with "mol-" or contain ".formula" patterns.
-func looksLikeFormulaName(operand string) bool {
-	// Common formula prefixes
-	if strings.HasPrefix(operand, "mol-") {
-		return true
-	}
-	// Formula file references
-	if strings.Contains(operand, ".formula") {
-		return true
-	}
-	// If it contains a path separator, might be a formula path
-	if strings.Contains(operand, "/") || strings.Contains(operand, "\\") {
-		return true
-	}
-	return false
 }
 
 func init() {

--- a/cmd/bd/mol_bond_gwn_test.go
+++ b/cmd/bd/mol_bond_gwn_test.go
@@ -1,0 +1,107 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBdMolBond_ResolvesPlainFormulaName is a regression test for GH#3873:
+// bd mol bond fails to resolve formula names that don't match the
+// looksLikeFormulaName gatekeeper at cmd/bd/mol_bond.go.
+//
+// The gatekeeper only accepts names starting with "mol-", containing
+// ".formula", or containing a path separator. Plain formula names — names
+// that are valid formula filenames but match none of those three patterns —
+// are rejected even though parser.LoadByName would load them, and every
+// other subcommand (bd formula show, bd mol seed, bd mol pour, bd cook)
+// resolves them without trouble.
+//
+// Before the fix, this test reproduces the user-reported error verbatim:
+//
+//	Error: 'plain-name-formula' not found (not an issue ID or formula name)
+func TestBdMolBond_ResolvesPlainFormulaName(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+
+	// Set up a workspace with a plain-named formula and an issue to bond
+	// against. HOME is pointed at the temp dir, so $HOME/.beads/formulas is the
+	// same as the workspace's formulas dir — formulas written here are
+	// discoverable through both the workspace and the user-level search paths.
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gwn")
+
+	formulaDir := filepath.Join(beadsDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas dir: %v", err)
+	}
+
+	const formulaTOML = `formula = "plain-name-formula"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "do-thing"
+title = "Do the thing"
+type = "task"
+`
+	formulaPath := filepath.Join(formulaDir, "plain-name-formula.formula.toml")
+	if err := os.WriteFile(formulaPath, []byte(formulaTOML), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	// Create an issue to use as the second operand of bd mol bond.
+	out, err := bdRunWithFlockRetry(t, bd, dir, "create", "target", "-t", "task", "-p", "4", "--json")
+	if err != nil {
+		t.Fatalf("bd create failed: %v\n%s", err, out)
+	}
+	targetID := extractFirstJSONStringField(string(out), "id")
+	if targetID == "" {
+		t.Fatalf("could not parse issue id from bd create output: %s", out)
+	}
+
+	// Confirm the formula registry is wired up: bd formula show works for the
+	// plain name. If this fails, the test setup is wrong, not the bug.
+	out, err = bdRunWithFlockRetry(t, bd, dir, "formula", "show", "plain-name-formula")
+	if err != nil {
+		t.Fatalf("bd formula show could not resolve the plain formula name (test setup issue, not the gwn bug): %v\n%s", err, out)
+	}
+
+	// The critical step. bd mol bond should accept the same plain formula
+	// name that bd formula show / bd mol seed / bd mol pour / bd cook all
+	// resolve fine.
+	out, err = bdRunWithFlockRetry(t, bd, dir, "mol", "bond", "plain-name-formula", targetID, "--dry-run")
+	if err != nil {
+		t.Fatalf("bd mol bond should resolve a plain formula name; got error: %v\noutput:\n%s", err, out)
+	}
+
+	outStr := string(out)
+	if !strings.Contains(outStr, "plain-name-formula") {
+		t.Errorf("dry-run output did not mention the formula:\n%s", outStr)
+	}
+	if !strings.Contains(outStr, "formula") {
+		t.Errorf("dry-run output did not indicate a formula was resolved:\n%s", outStr)
+	}
+}
+
+// extractFirstJSONStringField pulls the first occurrence of "<field>": "value"
+// from a JSON-ish blob. Good enough for the JSON shape `bd create --json`
+// returns; avoids pulling in encoding/json for one field.
+func extractFirstJSONStringField(blob, field string) string {
+	key := `"` + field + `":`
+	idx := strings.Index(blob, key)
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimLeft(blob[idx+len(key):], " \t")
+	if !strings.HasPrefix(rest, `"`) {
+		return ""
+	}
+	rest = rest[1:]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}


### PR DESCRIPTION
## What

`bd mol bond <formula-name> <mol-id>` couldn't resolve plain formula names like `download-arxiv` or `comprehensive-literature-search` — names that `bd formula show`, `bd mol seed`, `bd mol pour`, and `bd cook` all resolve without trouble. Drop the gatekeeper that rejected them so bond uses the same resolution path as every other subcommand.

## Why

Fixes #3873.

`resolveOrDescribe` and `resolveOrCookToSubgraph` in `cmd/bd/mol_bond.go` gated the formula-registry fallback on `looksLikeFormulaName`, which only accepted names starting with `mol-`, containing `.formula`, or containing a path separator. Anything else — including normal formula filenames — short-circuited to `Error: '<name>' not found (not an issue ID or formula name)` before `parser.LoadByName` was ever tried. Every other subcommand calls the parser directly, which is why only bond was broken. This silently breaks the documented declarative-fanout pattern (a formula bonding a child formula by name).

## Verification

```
go test -tags 'gms_pure_go cgo' -run TestBdMolBond_ResolvesPlainFormulaName -v ./cmd/bd/
```

New e2e regression test at `cmd/bd/mol_bond_gwn_test.go` writes a plain-named formula, confirms `bd formula show` resolves it (rules out test-setup issues), and asserts `bd mol bond <name> <id> --dry-run` succeeds. Fails on `main` with the verbatim user error, passes on this branch.

Sanity checks: `go vet -tags 'gms_pure_go cgo' ./cmd/bd/` clean, `go build -tags gms_pure_go ./cmd/bd/` clean.
