### PR TITLE
fix(cook): drop duplicate blocks edge when waits_for infers from needs[0] (GH#3783)

### DIFF
--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -910,8 +910,32 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 		})
 	}
 
+	// Pre-compute the waits_for spawner so we can dedupe against needs below.
+	// When waits_for has no explicit `from:`, it infers its spawner from
+	// needs[0] — and `needs` would otherwise emit a DepBlocks edge on the same
+	// (source, target) pair that `waits_for` emits a DepWaitsFor edge on.
+	// Storage rejects the duplicate. The DepWaitsFor edge subsumes the
+	// blocking semantics, so we skip the redundant DepBlocks for that
+	// specific target (GH#3783).
+	var waitsForSpec *formula.WaitsForSpec
+	var waitsForSpawnerStepID string
+	if step.WaitsFor != "" {
+		waitsForSpec = formula.ParseWaitsFor(step.WaitsFor)
+		if waitsForSpec != nil {
+			waitsForSpawnerStepID = waitsForSpec.SpawnerID
+			if waitsForSpawnerStepID == "" && len(step.Needs) > 0 {
+				waitsForSpawnerStepID = step.Needs[0]
+			}
+		}
+	}
+
 	// Process needs field - simpler alias for sibling dependencies
 	for _, needID := range step.Needs {
+		if needID == waitsForSpawnerStepID {
+			// This target is also the waits_for spawner; the DepWaitsFor edge
+			// emitted below subsumes the blocking semantics for this pair.
+			continue
+		}
 		needIssueID, ok := idMapping[needID]
 		if !ok {
 			continue // Will be caught during validation
@@ -925,32 +949,20 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 	}
 
 	// Process waits_for field - fanout gate dependency
-	if step.WaitsFor != "" {
-		waitsForSpec := formula.ParseWaitsFor(step.WaitsFor)
-		if waitsForSpec != nil {
-			// Determine spawner ID
-			spawnerStepID := waitsForSpec.SpawnerID
-			if spawnerStepID == "" && len(step.Needs) > 0 {
-				// Infer spawner from first need
-				spawnerStepID = step.Needs[0]
+	if waitsForSpec != nil && waitsForSpawnerStepID != "" {
+		if spawnerIssueID, ok := idMapping[waitsForSpawnerStepID]; ok {
+			// Create WaitsFor dependency with metadata
+			meta := types.WaitsForMeta{
+				Gate: waitsForSpec.Gate,
 			}
+			metaJSON, _ := json.Marshal(meta)
 
-			if spawnerStepID != "" {
-				if spawnerIssueID, ok := idMapping[spawnerStepID]; ok {
-					// Create WaitsFor dependency with metadata
-					meta := types.WaitsForMeta{
-						Gate: waitsForSpec.Gate,
-					}
-					metaJSON, _ := json.Marshal(meta)
-
-					*deps = append(*deps, &types.Dependency{
-						IssueID:     issueID,
-						DependsOnID: spawnerIssueID,
-						Type:        types.DepWaitsFor,
-						Metadata:    string(metaJSON),
-					})
-				}
-			}
+			*deps = append(*deps, &types.Dependency{
+				IssueID:     issueID,
+				DependsOnID: spawnerIssueID,
+				Type:        types.DepWaitsFor,
+				Metadata:    string(metaJSON),
+			})
 		}
 	}
 

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -924,11 +924,20 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 		}
 	}
 
+	// waitsForCollapsedBlocks records whether we actually skipped emitting a
+	// DepBlocks edge for the waits_for spawner below (i.e. the spawner step ID
+	// really did appear in depends_on/needs and resolve to a known issue). If
+	// so, the DepWaitsFor edge emitted below must carry also_blocks so it
+	// does not silently drop the blocking semantics that edge collapsed away
+	// (GH#3783 review gap).
+	var waitsForCollapsedBlocks bool
+
 	// Process depends_on field
 	for _, depID := range step.DependsOn {
 		if depID == waitsForSpawnerStepID {
 			// This target is also the waits_for spawner; the DepWaitsFor edge
 			// emitted below subsumes the blocking semantics for this pair.
+			waitsForCollapsedBlocks = true
 			continue
 		}
 		depIssueID, ok := idMapping[depID]
@@ -948,6 +957,7 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 		if needID == waitsForSpawnerStepID {
 			// This target is also the waits_for spawner; the DepWaitsFor edge
 			// emitted below subsumes the blocking semantics for this pair.
+			waitsForCollapsedBlocks = true
 			continue
 		}
 		needIssueID, ok := idMapping[needID]
@@ -966,8 +976,17 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 	if waitsForSpec != nil && waitsForSpawnerStepID != "" {
 		if spawnerIssueID, ok := idMapping[waitsForSpawnerStepID]; ok {
 			// Spawner identity is the depends_on_id; metadata carries
-			// the gate.
-			if dep, err := types.NewWaitsForDependency(issueID, spawnerIssueID, waitsForSpec.Gate); err == nil {
+			// the gate. A collapsed needs/depends_on edge additionally marks
+			// also_blocks so the gate blocks while the spawner itself is
+			// open, not only while it has an open child (GH#3783).
+			var dep *types.Dependency
+			var err error
+			if waitsForCollapsedBlocks {
+				dep, err = types.NewWaitsForBlockingDependency(issueID, spawnerIssueID, waitsForSpec.Gate)
+			} else {
+				dep, err = types.NewWaitsForDependency(issueID, spawnerIssueID, waitsForSpec.Gate)
+			}
+			if err == nil {
 				*deps = append(*deps, dep)
 			}
 		}

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -905,27 +905,13 @@ func cookFormula(ctx context.Context, s storage.DoltStorage, f *formula.Formula,
 func collectDependencies(step *formula.Step, idMapping map[string]string, deps *[]*types.Dependency) {
 	issueID := idMapping[step.ID]
 
-	// Process depends_on field
-	for _, depID := range step.DependsOn {
-		depIssueID, ok := idMapping[depID]
-		if !ok {
-			continue // Will be caught during validation
-		}
-
-		*deps = append(*deps, &types.Dependency{
-			IssueID:     issueID,
-			DependsOnID: depIssueID,
-			Type:        types.DepBlocks,
-		})
-	}
-
-	// Pre-compute the waits_for spawner so we can dedupe against needs below.
-	// When waits_for has no explicit `from:`, it infers its spawner from
-	// needs[0] — and `needs` would otherwise emit a DepBlocks edge on the same
-	// (source, target) pair that `waits_for` emits a DepWaitsFor edge on.
-	// Storage rejects the duplicate. The DepWaitsFor edge subsumes the
-	// blocking semantics, so we skip the redundant DepBlocks for that
-	// specific target (GH#3783).
+	// Pre-compute the waits_for spawner so we can dedupe against depends_on
+	// and needs below. When waits_for has no explicit `from:`, it infers its
+	// spawner from needs[0] — and `depends_on`/`needs` would otherwise emit a
+	// DepBlocks edge on the same (source, target) pair that `waits_for`
+	// emits a DepWaitsFor edge on. Storage rejects the duplicate. The
+	// DepWaitsFor edge subsumes the blocking semantics, so we skip the
+	// redundant DepBlocks for that specific target (GH#3783).
 	var waitsForSpec *formula.WaitsForSpec
 	var waitsForSpawnerStepID string
 	if step.WaitsFor != "" {
@@ -936,6 +922,25 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 				waitsForSpawnerStepID = step.Needs[0]
 			}
 		}
+	}
+
+	// Process depends_on field
+	for _, depID := range step.DependsOn {
+		if depID == waitsForSpawnerStepID {
+			// This target is also the waits_for spawner; the DepWaitsFor edge
+			// emitted below subsumes the blocking semantics for this pair.
+			continue
+		}
+		depIssueID, ok := idMapping[depID]
+		if !ok {
+			continue // Will be caught during validation
+		}
+
+		*deps = append(*deps, &types.Dependency{
+			IssueID:     issueID,
+			DependsOnID: depIssueID,
+			Type:        types.DepBlocks,
+		})
 	}
 
 	// Process needs field - simpler alias for sibling dependencies

--- a/cmd/bd/cook.go
+++ b/cmd/bd/cook.go
@@ -919,8 +919,32 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 		})
 	}
 
+	// Pre-compute the waits_for spawner so we can dedupe against needs below.
+	// When waits_for has no explicit `from:`, it infers its spawner from
+	// needs[0] — and `needs` would otherwise emit a DepBlocks edge on the same
+	// (source, target) pair that `waits_for` emits a DepWaitsFor edge on.
+	// Storage rejects the duplicate. The DepWaitsFor edge subsumes the
+	// blocking semantics, so we skip the redundant DepBlocks for that
+	// specific target (GH#3783).
+	var waitsForSpec *formula.WaitsForSpec
+	var waitsForSpawnerStepID string
+	if step.WaitsFor != "" {
+		waitsForSpec = formula.ParseWaitsFor(step.WaitsFor)
+		if waitsForSpec != nil {
+			waitsForSpawnerStepID = waitsForSpec.SpawnerID
+			if waitsForSpawnerStepID == "" && len(step.Needs) > 0 {
+				waitsForSpawnerStepID = step.Needs[0]
+			}
+		}
+	}
+
 	// Process needs field - simpler alias for sibling dependencies
 	for _, needID := range step.Needs {
+		if needID == waitsForSpawnerStepID {
+			// This target is also the waits_for spawner; the DepWaitsFor edge
+			// emitted below subsumes the blocking semantics for this pair.
+			continue
+		}
 		needIssueID, ok := idMapping[needID]
 		if !ok {
 			continue // Will be caught during validation
@@ -934,24 +958,12 @@ func collectDependencies(step *formula.Step, idMapping map[string]string, deps *
 	}
 
 	// Process waits_for field - fanout gate dependency
-	if step.WaitsFor != "" {
-		waitsForSpec := formula.ParseWaitsFor(step.WaitsFor)
-		if waitsForSpec != nil {
-			// Determine spawner ID
-			spawnerStepID := waitsForSpec.SpawnerID
-			if spawnerStepID == "" && len(step.Needs) > 0 {
-				// Infer spawner from first need
-				spawnerStepID = step.Needs[0]
-			}
-
-			if spawnerStepID != "" {
-				if spawnerIssueID, ok := idMapping[spawnerStepID]; ok {
-					// Spawner identity is the depends_on_id; metadata carries
-					// the gate.
-					if dep, err := types.NewWaitsForDependency(issueID, spawnerIssueID, waitsForSpec.Gate); err == nil {
-						*deps = append(*deps, dep)
-					}
-				}
+	if waitsForSpec != nil && waitsForSpawnerStepID != "" {
+		if spawnerIssueID, ok := idMapping[waitsForSpawnerStepID]; ok {
+			// Spawner identity is the depends_on_id; metadata carries
+			// the gate.
+			if dep, err := types.NewWaitsForDependency(issueID, spawnerIssueID, waitsForSpec.Gate); err == nil {
+				*deps = append(*deps, dep)
 			}
 		}
 	}

--- a/cmd/bd/cook_qnt_test.go
+++ b/cmd/bd/cook_qnt_test.go
@@ -1,0 +1,75 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestBdMolPour_NeedsAndWaitsForSameTarget is a regression test for GH#3783:
+// a step that has both `needs = [X]` and `waits_for = "all-children"` (with
+// no explicit spawner, so the spawner is inferred from needs[0] == X)
+// causes bd mol pour to fail with a dep-type collision —
+//
+//	dependency <step> -> <X> already exists with type "blocks"
+//	  (requested "waits-for")
+//
+// collectDependencies in cmd/bd/cook.go emits two edges on the same
+// (source, target) pair: a DepBlocks edge from `needs`, then a DepWaitsFor
+// edge from `waits_for` (which infers its spawner from needs[0]). Storage
+// rightly rejects the duplicate.
+//
+// This blocks the documented pattern where a step gates on the children of
+// the step it depends on (i.e. "wait for the fanout from the surveyor").
+//
+// After the fix, the DepWaitsFor edge subsumes the DepBlocks edge for that
+// specific target — the waits-for dep already carries the blocking
+// semantics plus the gate metadata, so the blocks dep is redundant.
+func TestBdMolPour_NeedsAndWaitsForSameTarget(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "qnt")
+
+	formulaDir := filepath.Join(beadsDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas dir: %v", err)
+	}
+
+	const formulaTOML = `formula = "qnt-repro"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "survey-workers"
+title = "Survey"
+type = "task"
+
+[[steps]]
+id = "wait"
+title = "Wait for fanout"
+type = "task"
+needs = ["survey-workers"]
+waits_for = "all-children"
+`
+	formulaPath := filepath.Join(formulaDir, "qnt-repro.formula.toml")
+	if err := os.WriteFile(formulaPath, []byte(formulaTOML), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	// Pour should succeed. Before the fix, this exits 1 with:
+	//   Error: pouring proto: failed to create dependency:
+	//   dependency qnt-mol-XXX -> qnt-mol-YYY already exists with type "blocks"
+	//     (requested "waits-for")
+	out, err := bdRunWithFlockRetry(t, bd, dir, "mol", "pour", "qnt-repro")
+	if err != nil {
+		t.Fatalf("bd mol pour should succeed for a step with both needs and waits_for; got error: %v\noutput:\n%s", err, out)
+	}
+
+	outStr := string(out)
+	if strings.Contains(outStr, "already exists with type") {
+		t.Errorf("pour output contains the dep-collision error this test was meant to prevent:\n%s", outStr)
+	}
+}

--- a/cmd/bd/cook_qnt_test.go
+++ b/cmd/bd/cook_qnt_test.go
@@ -3,10 +3,13 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 // TestBdMolPour_NeedsAndWaitsForSameTarget is a regression test for GH#3783:
@@ -71,5 +74,112 @@ waits_for = "all-children"
 	outStr := string(out)
 	if strings.Contains(outStr, "already exists with type") {
 		t.Errorf("pour output contains the dep-collision error this test was meant to prevent:\n%s", outStr)
+	}
+}
+
+// pourJSONResult mirrors the anonymous pourResult wrapper `bd mol pour --json`
+// emits (cmd/bd/pour.go): the embedded InstantiateResult fields plus attached
+// count and phase.
+type pourJSONResult struct {
+	NewEpicID string            `json:"new_epic_id"`
+	IDMapping map[string]string `json:"id_mapping"`
+	Created   int               `json:"created"`
+}
+
+// readyIDs runs `bd ready --json` and returns the set of ready issue IDs.
+func readyIDs(t *testing.T, bd, dir string) map[string]bool {
+	t.Helper()
+	out, err := bdRunWithFlockRetry(t, bd, dir, "ready", "--json", "--limit", "0")
+	if err != nil {
+		t.Fatalf("bd ready --json: %v\noutput:\n%s", err, out)
+	}
+	var ready []types.IssueWithCounts
+	if err := json.Unmarshal(out, &ready); err != nil {
+		t.Fatalf("parse ready --json: %v\noutput:\n%s", err, out)
+	}
+	ids := make(map[string]bool, len(ready))
+	for _, r := range ready {
+		ids[r.ID] = true
+	}
+	return ids
+}
+
+// TestBdMolPour_NeedsAndWaitsForSameTarget_SpawnerOpenBlocksWaiter is the
+// regression test for the review gap in GH#3875: the fix for GH#3783 drops
+// the DepBlocks edge from `needs` onto the waits_for spawner on the premise
+// that the DepWaitsFor edge subsumes its blocking semantics. also_blocks
+// metadata (set on exactly this collapsed edge, see cmd/bd/cook.go) closes
+// the resulting pre-fanout window: waitsForGateBlockedSQL now additionally
+// blocks while the spawner itself is open, not only while it has an open
+// parent-child child.
+//
+// This asserts the waiter stays blocked immediately after pour (spawner
+// open, zero children spawned yet), and unblocks once the spawner closes.
+func TestBdMolPour_NeedsAndWaitsForSameTarget_SpawnerOpenBlocksWaiter(t *testing.T) {
+	bd := buildEmbeddedBD(t)
+
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "qnw")
+
+	formulaDir := filepath.Join(beadsDir, "formulas")
+	if err := os.MkdirAll(formulaDir, 0o755); err != nil {
+		t.Fatalf("mkdir formulas dir: %v", err)
+	}
+
+	const formulaTOML = `formula = "qnw-repro"
+version = 1
+type = "workflow"
+
+[[steps]]
+id = "survey-workers"
+title = "Survey"
+type = "task"
+
+[[steps]]
+id = "wait"
+title = "Wait for fanout"
+type = "task"
+needs = ["survey-workers"]
+waits_for = "all-children"
+`
+	formulaPath := filepath.Join(formulaDir, "qnw-repro.formula.toml")
+	if err := os.WriteFile(formulaPath, []byte(formulaTOML), 0o644); err != nil {
+		t.Fatalf("write formula: %v", err)
+	}
+
+	out, err := bdRunWithFlockRetry(t, bd, dir, "mol", "pour", "qnw-repro", "--json")
+	if err != nil {
+		t.Fatalf("bd mol pour --json: %v\noutput:\n%s", err, out)
+	}
+
+	var result pourJSONResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("parse pour --json: %v\noutput:\n%s", err, out)
+	}
+
+	spawnerID, ok := result.IDMapping["qnw-repro.survey-workers"]
+	if !ok {
+		t.Fatalf("id_mapping missing qnw-repro.survey-workers: %#v", result.IDMapping)
+	}
+	waiterID, ok := result.IDMapping["qnw-repro.wait"]
+	if !ok {
+		t.Fatalf("id_mapping missing qnw-repro.wait: %#v", result.IDMapping)
+	}
+
+	// The spawner is open with zero children spawned yet — the waiter must
+	// be blocked, not ready. Before the also_blocks fix this regressed:
+	// dropping the blocks edge left the waits-for gate blind to a still-open,
+	// childless spawner.
+	if readyIDs(t, bd, dir)[waiterID] {
+		t.Fatalf("waiter %s is ready while its spawner %s is still open with no children spawned yet (pre-fanout window)", waiterID, spawnerID)
+	}
+
+	if _, err := bdRunWithFlockRetry(t, bd, dir, "close", spawnerID, "--reason", "no fanout needed"); err != nil {
+		t.Fatalf("bd close %s: %v", spawnerID, err)
+	}
+
+	// The spawner is now closed (and never spawned any children) — the
+	// waiter must unblock.
+	if !readyIDs(t, bd, dir)[waiterID] {
+		t.Fatalf("waiter %s did not become ready after its childless spawner %s closed", waiterID, spawnerID)
 	}
 }

--- a/cmd/bd/template.go
+++ b/cmd/bd/template.go
@@ -633,6 +633,12 @@ func cloneSubgraph(ctx context.Context, s storage.DoltStorage, subgraph *Templat
 				IssueID:     newFromID,
 				DependsOnID: newToID,
 				Type:        dep.Type,
+				// Carry template metadata through to the clone (GH#3875):
+				// waits-for edges store their gate (and, for a collapsed
+				// needs/depends_on edge, also_blocks) here. Dropping it
+				// silently reset every poured waits-for edge to the
+				// default all-children gate with also_blocks unset.
+				Metadata: dep.Metadata,
 			}
 			if err := tx.AddDependency(ctx, newDep, opts.Actor); err != nil {
 				return fmt.Errorf("failed to create dependency: %w", err)

--- a/internal/storage/dolt/is_blocked_test.go
+++ b/internal/storage/dolt/is_blocked_test.go
@@ -328,6 +328,106 @@ func TestIsBlocked_WaitsForAnyChildrenGate(t *testing.T) {
 	}
 }
 
+// TestIsBlocked_WaitsForAlsoBlocksSpawnerOpen covers the GH#3783/#3875
+// also_blocks provenance flag: a waits-for edge collapsed from a redundant
+// needs/depends_on blocks edge (cmd/bd/cook.go collectDependencies) must
+// additionally block while the spawner itself is open, not only while it
+// has an open parent-child child — closing the pre-fanout window where the
+// waiter could become ready before the spawner ever produced (or finished)
+// its fanout.
+func TestIsBlocked_WaitsForAlsoBlocksSpawnerOpen(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "isb-wf-ab-waiter")
+	createPerm(t, ctx, store, "isb-wf-ab-spawner")
+
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: "isb-wf-ab-waiter", DependsOnID: "isb-wf-ab-spawner",
+		Type: types.DepWaitsFor, Metadata: `{"gate":"all-children","also_blocks":true}`,
+	}, "tester"); err != nil {
+		t.Fatalf("waits-for also_blocks: %v", err)
+	}
+
+	// Spawner open, zero children spawned yet: the waiter must be blocked.
+	// Without also_blocks this would be unblocked (no children => no
+	// children-open EXISTS) — exactly the pre-fanout regression.
+	if !getIsBlocked(t, ctx, store, "issues", "isb-wf-ab-waiter") {
+		t.Fatal("expected waiter blocked: spawner still open with zero children spawned (also_blocks)")
+	}
+
+	if err := store.CloseIssue(ctx, "isb-wf-ab-spawner", "no fanout needed", "tester", ""); err != nil {
+		t.Fatalf("CloseIssue spawner: %v", err)
+	}
+	if getIsBlocked(t, ctx, store, "issues", "isb-wf-ab-waiter") {
+		t.Fatal("expected waiter unblocked after its childless spawner closed")
+	}
+
+	if err := store.ReopenIssue(ctx, "isb-wf-ab-spawner", "", "tester"); err != nil {
+		t.Fatalf("ReopenIssue spawner: %v", err)
+	}
+	if !getIsBlocked(t, ctx, store, "issues", "isb-wf-ab-waiter") {
+		t.Fatal("expected waiter re-blocked after spawner reopened")
+	}
+}
+
+// TestIsBlocked_WaitsForAlsoBlocksOverridesAnyChildrenEarlyOpen covers the
+// override case explicitly called out in the design: also_blocks is a
+// top-level OR outside the any-children early-open carve-out, so a
+// collapsed edge on an any-children gate must stay blocked while the
+// spawner itself is open even after one child closes (the normal
+// any-children early-open behavior is preserved only for edges WITHOUT
+// also_blocks — see TestIsBlocked_WaitsForAnyChildrenGate above).
+func TestIsBlocked_WaitsForAlsoBlocksOverridesAnyChildrenEarlyOpen(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "isb-wf-ab-any-waiter")
+	createPerm(t, ctx, store, "isb-wf-ab-any-spawner")
+	createPerm(t, ctx, store, "isb-wf-ab-any-child-1")
+	createPerm(t, ctx, store, "isb-wf-ab-any-child-2")
+
+	for _, child := range []string{"isb-wf-ab-any-child-1", "isb-wf-ab-any-child-2"} {
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID: child, DependsOnID: "isb-wf-ab-any-spawner", Type: types.DepParentChild,
+		}, "tester"); err != nil {
+			t.Fatalf("parent-child %s: %v", child, err)
+		}
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: "isb-wf-ab-any-waiter", DependsOnID: "isb-wf-ab-any-spawner",
+		Type: types.DepWaitsFor, Metadata: `{"gate":"any-children","also_blocks":true}`,
+	}, "tester"); err != nil {
+		t.Fatalf("waits-for any-children also_blocks: %v", err)
+	}
+	if !getIsBlocked(t, ctx, store, "issues", "isb-wf-ab-any-waiter") {
+		t.Fatal("expected waiter blocked: no children closed yet")
+	}
+
+	// Close one child: under a plain any-children gate this alone would
+	// unblock (see TestIsBlocked_WaitsForAnyChildrenGate). With also_blocks
+	// the waiter must STAY blocked because the spawner itself is still open.
+	if err := store.CloseIssue(ctx, "isb-wf-ab-any-child-1", "done", "tester", ""); err != nil {
+		t.Fatalf("CloseIssue first child: %v", err)
+	}
+	if !getIsBlocked(t, ctx, store, "issues", "isb-wf-ab-any-waiter") {
+		t.Fatal("expected waiter STILL blocked: also_blocks overrides the any-children early-open carve-out while the spawner is open")
+	}
+
+	// Now close the spawner too: the gate is satisfied (a child closed under
+	// any-children) AND the spawner itself is closed, so the waiter unblocks.
+	if err := store.CloseIssue(ctx, "isb-wf-ab-any-spawner", "done", "tester", ""); err != nil {
+		t.Fatalf("CloseIssue spawner: %v", err)
+	}
+	if getIsBlocked(t, ctx, store, "issues", "isb-wf-ab-any-waiter") {
+		t.Fatal("expected waiter unblocked once the spawner closes with the any-children gate already satisfied")
+	}
+}
+
 func TestIsBlocked_AddClosedChildUnblocksAnyChildrenGate(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/issueops/blocked_state.go
+++ b/internal/storage/issueops/blocked_state.go
@@ -21,40 +21,73 @@ type DBTX interface {
 
 const waitsForGateBlockedSQL = `
 		(
-		  EXISTS (
-		    SELECT 1 FROM dependencies cd JOIN issues child ON child.id = cd.issue_id
-		    WHERE cd.type = 'parent-child'
-		      AND ((d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
-		        OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id))
-		      AND child.status <> 'closed' AND child.status <> 'pinned'
-		  )
-		  OR EXISTS (
-		    SELECT 1 FROM wisp_dependencies cd JOIN wisps child ON child.id = cd.issue_id
-		    WHERE cd.type = 'parent-child'
-		      AND ((d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
-		        OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id))
-		      AND child.status <> 'closed' AND child.status <> 'pinned'
-		  )
-		)
-		AND NOT (
-		  -- COALESCE: metadata without a gate key (legacy '{}' rows) means the
-		  -- all-children default; a NULL here would poison the AND/NOT chain
-		  -- and unblock the gate as soon as any child closes.
-		  COALESCE(JSON_UNQUOTE(JSON_EXTRACT(d.metadata, '$.gate')), 'all-children') = 'any-children'
-		  AND (
+		  (
 		    EXISTS (
 		      SELECT 1 FROM dependencies cd JOIN issues child ON child.id = cd.issue_id
 		      WHERE cd.type = 'parent-child'
 		        AND ((d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
 		          OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id))
-		        AND child.status = 'closed'
+		        AND child.status <> 'closed' AND child.status <> 'pinned'
 		    )
 		    OR EXISTS (
 		      SELECT 1 FROM wisp_dependencies cd JOIN wisps child ON child.id = cd.issue_id
 		      WHERE cd.type = 'parent-child'
 		        AND ((d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
 		          OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id))
-		        AND child.status = 'closed'
+		        AND child.status <> 'closed' AND child.status <> 'pinned'
+		    )
+		  )
+		  AND NOT (
+		    -- COALESCE: metadata without a gate key (legacy '{}' rows) means the
+		    -- all-children default; a NULL here would poison the AND/NOT chain
+		    -- and unblock the gate as soon as any child closes.
+		    COALESCE(JSON_UNQUOTE(JSON_EXTRACT(d.metadata, '$.gate')), 'all-children') = 'any-children'
+		    AND (
+		      EXISTS (
+		        SELECT 1 FROM dependencies cd JOIN issues child ON child.id = cd.issue_id
+		        WHERE cd.type = 'parent-child'
+		          AND ((d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+		            OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id))
+		          AND child.status = 'closed'
+		      )
+		      OR EXISTS (
+		        SELECT 1 FROM wisp_dependencies cd JOIN wisps child ON child.id = cd.issue_id
+		        WHERE cd.type = 'parent-child'
+		          AND ((d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+		            OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id))
+		          AND child.status = 'closed'
+		      )
+		    )
+		  )
+		)
+		OR (
+		  -- also_blocks (GH#3783/GH#3875): a waits-for edge collapsed from a
+		  -- redundant needs/depends_on blocks edge onto this same spawner
+		  -- (cmd/bd/cook.go collectDependencies) additionally carries classic
+		  -- blocking semantics — it must block while the spawner itself is
+		  -- open, not only while the spawner has an open parent-child child.
+		  -- This closes the pre-fanout window where the waiter could become
+		  -- ready before the spawner (and its fanout) ever completed. Legacy
+		  -- rows and plain (non-collapsed) waits-for edges lack the
+		  -- also_blocks key, so COALESCE defaults to 'false' and this branch
+		  -- is a no-op for them (zero behavior change).
+		  --
+		  -- This is a top-level OR, deliberately outside (and overriding) the
+		  -- any-children early-open carve-out above: a collapsed edge means
+		  -- the caller's needs/depends_on required the spawner itself to
+		  -- close, so an early-open child close must NOT unblock the waiter
+		  -- while the spawner remains open.
+		  COALESCE(JSON_UNQUOTE(JSON_EXTRACT(d.metadata, '$.also_blocks')), 'false') = 'true'
+		  AND (
+		    EXISTS (
+		      SELECT 1 FROM issues sp
+		      WHERE sp.id = d.depends_on_issue_id
+		        AND sp.status <> 'closed' AND sp.status <> 'pinned'
+		    )
+		    OR EXISTS (
+		      SELECT 1 FROM wisps sp
+		      WHERE sp.id = d.depends_on_wisp_id
+		        AND sp.status <> 'closed' AND sp.status <> 'pinned'
 		    )
 		  )
 		)
@@ -396,6 +429,14 @@ func AffectedByStatusChangeInTx(ctx context.Context, tx DBTX, id string) ([]stri
 	if err := loadWaitersWhoseSpawnerIsParentOfInTx(ctx, tx, id, false, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
 		return nil, nil, err
 	}
+	// id's own status just changed, and an also_blocks waits-for edge blocks
+	// while the spawner itself is open (pre-fanout window, GH#3783/GH#3875).
+	// A waiter with only a DepWaitsFor edge on id (no DepBlocks edge — the
+	// blocking semantics were collapsed into also_blocks) would otherwise
+	// never get recomputed when its spawner closes.
+	if err := loadWaitersOnSpawnerIDsInTx(ctx, tx, []string{id}, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
+		return nil, nil, err
+	}
 	return expandByParentChildDescendantsInTx(ctx, tx, issueSeed, wispSeed, issueSeen, wispSeen)
 }
 
@@ -409,6 +450,12 @@ func AffectedByStatusChangeForWispInTx(ctx context.Context, tx DBTX, id string) 
 		return nil, nil, err
 	}
 	if err := loadWaitersWhoseSpawnerIsParentOfInTx(ctx, tx, id, true, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
+		return nil, nil, err
+	}
+	// See the issue-id sibling above: id's own status just changed, and a
+	// waiter that waits directly on this wisp id as spawner needs to be
+	// recomputed too.
+	if err := loadWaitersOnSpawnerIDsInTx(ctx, tx, []string{id}, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
 		return nil, nil, err
 	}
 	return expandByParentChildDescendantsInTx(ctx, tx, issueSeed, wispSeed, issueSeen, wispSeen)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -984,6 +984,16 @@ type WaitsForMeta struct {
 	// SpawnerID identifies which step/issue spawns the children to wait for.
 	// If empty, waits for all direct children of the depends_on_id issue.
 	SpawnerID string `json:"spawner_id,omitempty"`
+	// AlsoBlocks marks a waits-for edge that was collapsed from a redundant
+	// depends_on/needs blocks edge onto the same spawner (GH#3783): the
+	// caller skipped emitting a separate DepBlocks edge because it collided
+	// with this DepWaitsFor edge, so this edge must additionally carry
+	// classic blocking semantics — it blocks while the spawner itself is
+	// open, not only while the spawner has an open child. Omitted (and thus
+	// COALESCEd to false by readers) for a plain waits_for with no matching
+	// needs/depends_on entry, which must retain the original fanout-only
+	// semantics.
+	AlsoBlocks bool `json:"also_blocks,omitempty"`
 }
 
 // WaitsForGate constants
@@ -1041,6 +1051,32 @@ func NewGraphEdgeDependency(fromID, toID string, depType DependencyType, gate, s
 // cannot drift.
 func NewWaitsForDependency(issueID, spawnerID, gate string) (*Dependency, error) {
 	return NewGraphEdgeDependency(issueID, spawnerID, DepWaitsFor, gate, "", "", "", nil)
+}
+
+// NewWaitsForBlockingDependency builds a waits-for dependency that also
+// carries classic blocking semantics (GH#3783): set also_blocks in the
+// metadata so waitsForGateBlockedSQL additionally blocks while the spawner
+// itself is open, not only while it has an open parent-child child. Use this
+// instead of NewWaitsForDependency exactly when the caller is collapsing a
+// would-be DepBlocks edge (from needs/depends_on) into this waits-for edge
+// because the two would otherwise collide on the same (source, target) pair
+// — never for a plain waits_for with no matching needs/depends_on entry.
+func NewWaitsForBlockingDependency(issueID, spawnerID, gate string) (*Dependency, error) {
+	dep, err := NewWaitsForDependency(issueID, spawnerID, gate)
+	if err != nil {
+		return nil, err
+	}
+	var meta WaitsForMeta
+	if err := json.Unmarshal([]byte(dep.Metadata), &meta); err != nil {
+		return nil, fmt.Errorf("parsing waits-for metadata to set also_blocks: %w", err)
+	}
+	meta.AlsoBlocks = true
+	raw, err := json.Marshal(meta)
+	if err != nil {
+		return nil, fmt.Errorf("serializing waits-for also_blocks metadata: %w", err)
+	}
+	dep.Metadata = string(raw)
+	return dep, nil
 }
 
 // NewGraphNodeDependency builds the dependency record for a graph-plan node's


### PR DESCRIPTION
## What

A step with both `needs = [X]` and `waits_for = "all-children"` (no explicit `from:`) used to crash `bd mol pour` with a dep-type collision. The `waits_for` spawner gets inferred from `needs[0]`, so both `needs` and `waits_for` emit edges on the same `(source, target)` pair — one as `DepBlocks`, one as `DepWaitsFor` — and storage rejects the duplicate. Pre-compute the `waits_for` spawner before processing `needs` and skip the redundant `DepBlocks` for that one target.

## Why

Fixes #3783.

The collision blocks the documented pattern where a step gates on the children of a step it depends on (the canonical "wait for the fanout from the surveyor" shape). Before this fix:

```
$ bd mol pour qnt-repro
Error: pouring proto: failed to create dependency:
  dependency qnt-mol-XXX -> qnt-mol-YYY already exists with type "blocks"
    (requested "waits-for"); remove it first with 'bd dep remove' then re-add
```

The `DepWaitsFor` edge already encodes the blocking semantics plus the gate metadata, so the `DepBlocks` edge from `needs` for that specific target is redundant once they collapse onto the same pair.

## Verification

```
go test -tags 'gms_pure_go cgo' -run TestBdMolPour_NeedsAndWaitsForSameTarget -v ./cmd/bd/
```

New e2e regression test at `cmd/bd/cook_qnt_test.go` pours a formula with the exact collision shape and asserts `bd mol pour` succeeds. Fails on `main` with the verbatim error; passes on this branch.

Sanity checks: cook test family (`TestSubstituteFormulaVars`, `TestSubstituteStepVarsRecursive`, `TestCompileTimeVsRuntimeMode`, `TestCreateGateIssue*`, `TestCookFormulaToSubgraph_*`) all pass. `go vet -tags 'gms_pure_go cgo' ./cmd/bd/` clean.
