### PR TITLE
Revert "revert: remove external server CLI dir override"

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ or environment variables:
 | `--server-socket` | `BEADS_DOLT_SERVER_SOCKET` | (none; uses TCP) |
 | `--server-user` | `BEADS_DOLT_SERVER_USER` | `root` |
 | | `BEADS_DOLT_PASSWORD` | (none) |
+| | `BEADS_DOLT_CLI_DIR` | local Dolt database path for CLI push/pull |
 
 **Unix domain sockets:** Use `--server-socket` to connect via a Unix socket
 instead of TCP. This avoids port conflicts between concurrent projects and
@@ -143,6 +144,12 @@ is useful in sandboxed environments (e.g., Claude Code) where file-level
 access control is simpler than network allowlists. The Dolt server must be
 started with `dolt sql-server --socket <path>`. Auto-start is not supported
 in socket mode.
+
+When `BEADS_DOLT_SERVER_MODE=1` points at a Dolt server managed outside
+Beads, set `BEADS_DOLT_CLI_DIR` if `bd dolt push` / `bd dolt pull` must use
+the local `dolt` CLI (for example git-protocol remotes or credentials that
+only exist in the current shell). Use the actual Dolt database directory, not
+the server root.
 
 ### Backup & Migration
 

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -868,6 +868,9 @@ func listRemoteSurfaces(ctx context.Context, st storage.RemoteStore, dbPath stri
 		// that flock, so treat the SQL-visible remotes as the shared surface.
 		return sqlRemotes, sqlErr, sqlRemotes, nil
 	}
+	if strings.TrimSpace(dbPath) == "" {
+		return sqlRemotes, sqlErr, nil, fmt.Errorf("local Dolt CLI directory is not configured; set BEADS_DOLT_CLI_DIR to list filesystem remotes")
+	}
 	cliRemotes, cliErr = listDoltCLIRemotes(dbPath)
 	return sqlRemotes, sqlErr, cliRemotes, cliErr
 }
@@ -951,7 +954,10 @@ var doltRemoteAddCmd = &cobra.Command{
 		// In embedded mode, SQL and CLI operate on the same directory,
 		// so the SQL add already wrote the remote config — skip CLI.
 		cliFailed := false
-		if !embedded && cliURL != url {
+		if !embedded && dbPath == "" {
+			cliFailed = true
+			fmt.Fprintf(os.Stderr, "Warning: SQL remote added but CLI remote was not configured: set BEADS_DOLT_CLI_DIR to the local Dolt database path\n")
+		} else if !embedded && cliURL != url {
 			if err := doltutil.AddCLIRemote(dbPath, name, url); err != nil {
 				cliFailed = true
 				// Non-fatal: SQL remote was added successfully
@@ -1094,13 +1100,13 @@ var doltRemoteListCmd = &cobra.Command{
 		}
 
 		if cliErr != nil {
-			fmt.Printf("\n%s Could not read CLI remotes: %v\n", ui.RenderWarn("⚠"), cliErr)
+			fmt.Printf("\n%s Could not read CLI remotes: %v\n", ui.RenderWarn("!"), cliErr)
 		}
 		if hasDiscrepancy {
 			if embedded {
-				fmt.Printf("\n%s Remote discrepancies detected.\n", ui.RenderWarn("⚠"))
+				fmt.Printf("\n%s Remote discrepancies detected.\n", ui.RenderWarn("!"))
 			} else {
-				fmt.Printf("\n%s Remote discrepancies detected. Run 'bd doctor --fix' to resolve.\n", ui.RenderWarn("⚠"))
+				fmt.Printf("\n%s Remote discrepancies detected. Run 'bd doctor --fix' to resolve.\n", ui.RenderWarn("!"))
 			}
 		}
 	},
@@ -1157,7 +1163,12 @@ var doltRemoteRemoveCmd = &cobra.Command{
 		// In embedded mode, SQL and CLI operate on the same directory,
 		// so the SQL remove already cleared the remote config — skip CLI.
 		cliRemoveFailed := false
-		if !embedded && cliURL != "" {
+		if !embedded && dbPath == "" {
+			cliRemoveFailed = cliURL != ""
+			if cliURL != "" {
+				fmt.Fprintf(os.Stderr, "Warning: SQL remote removed but CLI remote was not configured: set BEADS_DOLT_CLI_DIR to the local Dolt database path\n")
+			}
+		} else if !embedded && cliURL != "" {
 			if err := doltutil.RemoveCLIRemote(dbPath, name); err != nil {
 				cliRemoveFailed = true
 				fmt.Fprintf(os.Stderr, "Warning: SQL remote removed but CLI remote failed: %v\n", err)

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -70,6 +70,18 @@ bd init --server
 export BEADS_DOLT_SERVER_MODE=1
 ```
 
+For externally managed servers, set `BEADS_DOLT_CLI_DIR` when a sync operation
+must fall back to the local Dolt CLI, such as git-protocol remotes or
+credentials/cloud auth that only exist in the current shell:
+
+```bash
+export BEADS_DOLT_CLI_DIR=/path/to/dolt-data/beads
+```
+
+The value must be the actual Dolt database directory where `dolt push` or
+`dolt pull` can run, not the parent server root. Remote types supported by
+SQL `DOLT_PUSH` / `DOLT_PULL` do not need this setting.
+
 ```yaml
 # .beads/config.yaml (server mode settings)
 dolt:

--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -759,12 +759,31 @@ func (s *DoltStore) shouldUseCLIForCloudAuth(remote string) bool {
 	if len(prefixes) == 0 {
 		return false // unknown scheme — not a cloud remote
 	}
+	return envHasAnyPrefix(prefixes)
+}
+
+func envHasAnyPrefix(prefixes []string) bool {
 	for _, e := range os.Environ() {
 		for _, prefix := range prefixes {
 			if strings.HasPrefix(e, prefix) {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+func (s *DoltStore) hasCloudAuthForSQLRemote(ctx context.Context, remote string) bool {
+	remotes, err := s.ListRemotes(ctx)
+	if err != nil {
+		return false
+	}
+	for _, r := range remotes {
+		if r.Name != remote {
+			continue
+		}
+		prefixes := envPrefixesForRemoteURL(r.URL)
+		return len(prefixes) > 0 && envHasAnyPrefix(prefixes)
 	}
 	return false
 }

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -145,6 +145,7 @@ func TestApplyCLIAutoStart_RespectsExternalMode(t *testing.T) {
 
 func TestCLIDirUsesSharedDoltRootInSharedServerMode(t *testing.T) {
 	sharedRoot := t.TempDir()
+	t.Setenv(EnvDoltCLIDir, "")
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
 	t.Setenv("BEADS_SHARED_SERVER_DIR", sharedRoot)
 
@@ -162,6 +163,7 @@ func TestCLIDirUsesSharedDoltRootInSharedServerMode(t *testing.T) {
 }
 
 func TestCLIDirUsesDbPathOutsideSharedServerMode(t *testing.T) {
+	t.Setenv(EnvDoltCLIDir, "")
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
 
 	dbPath := filepath.Join(t.TempDir(), ".beads", "dolt")
@@ -175,6 +177,58 @@ func TestCLIDirUsesDbPathOutsideSharedServerMode(t *testing.T) {
 	want := filepath.Join(dbPath, "local_db")
 	if got := store.CLIDir(); got != want {
 		t.Fatalf("CLIDir() = %q, want %q", got, want)
+	}
+}
+
+func TestCLIDirUsesExplicitEnvOverride(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	cliDir := filepath.Join(t.TempDir(), "server-db")
+	t.Setenv(EnvDoltCLIDir, cliDir)
+
+	store := &DoltStore{
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+		dbPath:      filepath.Join(t.TempDir(), ".beads", "dolt"),
+		database:    "local_db",
+	}
+
+	if got := store.CLIDir(); got != cliDir {
+		t.Fatalf("CLIDir() = %q, want %q", got, cliDir)
+	}
+}
+
+func TestCLIDirEmptyForGenericExternalServerModeWithoutEnv(t *testing.T) {
+	t.Setenv(EnvDoltCLIDir, "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+
+	store := &DoltStore{
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+		dbPath:      filepath.Join(t.TempDir(), ".beads", "dolt"),
+		database:    "local_db",
+	}
+
+	if got := store.CLIDir(); got != "" {
+		t.Fatalf("CLIDir() = %q, want empty string", got)
+	}
+}
+
+func TestDoltCLIRequiresExplicitDirInGenericExternalServerMode(t *testing.T) {
+	t.Setenv(EnvDoltCLIDir, "")
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+
+	store := &DoltStore{
+		serverMode:  true,
+		serverOwner: doltserver.ServerModeExternal,
+		branch:      "main",
+	}
+
+	err := store.doltCLIPull(t.Context(), "origin", nil)
+	if err == nil {
+		t.Fatal("doltCLIPull() error = nil, want explicit CLI dir error")
+	}
+	if !strings.Contains(err.Error(), EnvDoltCLIDir) {
+		t.Fatalf("doltCLIPull() error = %q, want mention of %s", err.Error(), EnvDoltCLIDir)
 	}
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -49,6 +49,10 @@ import (
 // DefaultSQLPort is the default port for dolt sql-server.
 const DefaultSQLPort = 3307
 
+// EnvDoltCLIDir points bd at the local Dolt database directory used for
+// subprocess CLI operations when the SQL server is externally managed.
+const EnvDoltCLIDir = "BEADS_DOLT_CLI_DIR"
+
 // testDatabasePrefixes are name prefixes that indicate a test database.
 // Used by isTestDatabaseName to prevent test databases from being created
 // on the production Dolt server (Clown Shows #12-#18).
@@ -191,6 +195,7 @@ type DoltStore struct {
 	remoteUser     string // Remote auth user for Hosted Dolt push/pull (optional)
 	remotePassword string // Remote auth password for Hosted Dolt push/pull (optional)
 	serverMode     bool   // true when connected to external dolt sql-server (not embedded)
+	serverOwner    doltserver.ServerMode
 
 	// autoStartedServerDir is set when this store triggered a dolt sql-server
 	// auto-start. Close() uses it to stop the server when the last store
@@ -1105,6 +1110,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		remoteUser:           cfg.RemoteUser,
 		remotePassword:       cfg.RemotePassword,
 		serverMode:           true,
+		serverOwner:          doltserver.ResolveServerMode(beadsDir),
 		readOnly:             cfg.ReadOnly,
 		autoStartedServerDir: autoStartedDir,
 	}
@@ -1536,13 +1542,36 @@ func (s *DoltStore) Path() string {
 // Use this instead of Path() when running dolt CLI commands that target the
 // actual database (e.g., remote add/remove, push, pull).
 func (s *DoltStore) CLIDir() string {
+	if dir := strings.TrimSpace(os.Getenv(EnvDoltCLIDir)); dir != "" {
+		return filepath.Clean(dir)
+	}
 	if s.serverMode && doltserver.IsSharedServerMode() && s.beadsDir != "" {
 		return filepath.Join(doltserver.ResolveDoltDir(s.beadsDir), s.database)
+	}
+	if s.requiresExplicitCLIDir() {
+		return ""
 	}
 	if s.dbPath == "" {
 		return ""
 	}
 	return filepath.Join(s.dbPath, s.database)
+}
+
+func (s *DoltStore) requiresExplicitCLIDir() bool {
+	return s.serverMode &&
+		s.serverOwner == doltserver.ServerModeExternal &&
+		!doltserver.IsSharedServerMode()
+}
+
+func (s *DoltStore) requireCLIDir(operation string) (string, error) {
+	dir := s.CLIDir()
+	if dir != "" {
+		return dir, nil
+	}
+	if s.requiresExplicitCLIDir() {
+		return "", fmt.Errorf("%s requires a local Dolt CLI database directory in external-server mode; set %s to the local Dolt database path or use a remote type supported by SQL DOLT_PUSH/DOLT_PULL", operation, EnvDoltCLIDir)
+	}
+	return "", fmt.Errorf("%s requires a local Dolt CLI database directory, but none is configured", operation)
 }
 
 // DoltGC runs Dolt garbage collection to reclaim disk space.
@@ -1849,6 +1878,9 @@ func (s *DoltStore) isGitProtocolRemote(ctx context.Context, remote string) bool
 				if !doltutil.IsGitProtocolURL(r.URL) {
 					return false
 				}
+				if s.requiresExplicitCLIDir() && s.CLIDir() == "" {
+					return true
+				}
 				// Verify remote exists in CLI directory before routing to CLI push/pull.
 				// When the dolt sql-server is externally managed, remotes may exist only
 				// on the server's filesystem, not in the local dbPath.
@@ -1954,6 +1986,10 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 	if err := s.prePushFSCK(ctx); err != nil {
 		return err
 	}
+	cliDir, err := s.requireCLIDir("dolt push")
+	if err != nil {
+		return err
+	}
 	ctx, cancel := context.WithTimeout(ctx, cliExecTimeout)
 	defer cancel()
 	args := []string{"push"}
@@ -1962,7 +1998,7 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 	}
 	args = append(args, remote, s.branch)
 	cmd := exec.CommandContext(ctx, "dolt", args...) // #nosec G204 -- fixed command with validated remote/branch
-	cmd.Dir = s.CLIDir()
+	cmd.Dir = cliDir
 	creds.applyToCmd(cmd)
 	if s.isS3Remote(ctx, remote) {
 		applyS3ChecksumEnvToCmd(cmd)
@@ -1979,10 +2015,14 @@ func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, 
 // Used for git-protocol remotes where CALL DOLT_PULL times out through the SQL connection.
 // If creds is non-nil, credentials are set on the subprocess environment only.
 func (s *DoltStore) doltCLIPull(ctx context.Context, remote string, creds *remoteCredentials) error {
+	cliDir, err := s.requireCLIDir("dolt pull")
+	if err != nil {
+		return err
+	}
 	ctx, cancel := context.WithTimeout(ctx, cliExecTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "dolt", "pull", remote, s.branch) // #nosec G204 -- fixed command
-	cmd.Dir = s.CLIDir()
+	cmd.Dir = cliDir
 	creds.applyToCmd(cmd)
 	if s.isS3Remote(ctx, remote) {
 		applyS3ChecksumEnvToCmd(cmd)
@@ -2048,12 +2088,20 @@ func (s *DoltStore) pushToRemote(ctx context.Context, remote string, force bool)
 	if s.shouldUseCLIForCredentials(ctx, remote, creds) {
 		return s.doltCLIPush(ctx, remote, force, creds)
 	}
+	if !creds.empty() && s.requiresExplicitCLIDir() && s.CLIDir() == "" {
+		_, err := s.requireCLIDir("dolt push")
+		return err
+	}
 	// Cloud auth CLI routing: when cloud storage env vars (AZURE_*, AWS_*,
 	// etc.) are set and we're in server mode, route through CLI so the dolt
 	// subprocess inherits the current env. The SQL server may not have these
 	// vars if it was started in a different context (GH#6).
 	if s.shouldUseCLIForCloudAuth(remote) {
 		return s.doltCLIPush(ctx, remote, force, creds)
+	}
+	if s.requiresExplicitCLIDir() && s.CLIDir() == "" && s.hasCloudAuthForSQLRemote(ctx, remote) {
+		_, err := s.requireCLIDir("dolt push")
+		return err
 	}
 	// If the same remote exists in the local Dolt directory, prefer CLI push.
 	// This matches direct `dolt push` behavior and avoids sql-server mediated
@@ -2154,9 +2202,17 @@ func (s *DoltStore) pullFromRemote(ctx context.Context, remote string) (retErr e
 		}
 		return nil
 	}
+	if !creds.empty() && s.requiresExplicitCLIDir() && s.CLIDir() == "" {
+		_, err := s.requireCLIDir("dolt pull")
+		return err
+	}
 	// Cloud auth CLI routing (GH#6).
 	if s.shouldUseCLIForCloudAuth(remote) {
 		return s.doltCLIPull(ctx, remote, creds)
+	}
+	if s.requiresExplicitCLIDir() && s.CLIDir() == "" && s.hasCloudAuthForSQLRemote(ctx, remote) {
+		_, err := s.requireCLIDir("dolt pull")
+		return err
 	}
 	if s.remoteUser != "" && remote == s.remote {
 		return withRemoteOperationEnv(creds, s.isS3Remote(ctx, remote), func() error {


### PR DESCRIPTION
Reverts gastownhall/beads#3862 . Clean up after rogue agent merged before Dolt-related PR was cleared by @coffeegoddd 