### PR TITLE
docs: neutralize formula workflow terminology

### DIFF
--- a/cmd/bd/formula.go
+++ b/cmd/bd/formula.go
@@ -21,19 +21,14 @@ var formulaCmd = &cobra.Command{
 	Short: "Manage workflow formulas",
 	Long: `Manage workflow formulas - the source layer for molecule templates.
 
-Formulas are YAML/JSON files that define workflows with composition rules.
-They are "cooked" into proto beads which can then be poured or wisped.
-
-The Rig → Cook → Run lifecycle:
-  - Rig: Compose formulas (extends, compose)
-  - Cook: Transform to proto (bd cook expands macros, applies aspects)
-  - Run: Agents execute poured mols or wisps
+Formulas are TOML/JSON files that define workflows with composition rules.
+Define formulas, cook them into protos, then pour or wisp them into work.
 
 Search paths (in order):
   1. <resolved-beads-dir>/formulas/ (active project)
   2. <checkout-root>/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -50,7 +45,7 @@ Search paths (in order of priority):
   1. <resolved-beads-dir>/formulas/ (active project - highest priority)
   2. <checkout-root>/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 

--- a/cmd/bd/formula_help_test.go
+++ b/cmd/bd/formula_help_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormulaHelpUsesGenericWorkflowLanguage(t *testing.T) {
+	help := formulaCmd.Long + "\n" + formulaListCmd.Long + "\n" + molSeedCmd.Long
+
+	for _, want := range []string{
+		"Formulas are TOML/JSON files",
+		"Define formulas, cook them into protos, then pour or wisp them into work.",
+		"shared workspace root",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("formula help missing %q:\n%s", want, help)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"YAML/" + "JSON files",
+		"Rig:",
+		"Formula " + "workflow:",
+		"Author" + ":",
+		"Compile: " + "Resolve",
+		"Instantiate: " + "Agents",
+		"orchestrator, if " + "GT_ROOT set",
+		"orchestrator level, if " + "GT_ROOT set",
+	} {
+		if strings.Contains(help, forbidden) {
+			t.Fatalf("formula help still contains %q:\n%s", forbidden, help)
+		}
+	}
+}

--- a/cmd/bd/mol_seed.go
+++ b/cmd/bd/mol_seed.go
@@ -20,7 +20,7 @@ Formula search paths (checked in order):
   1. <resolved-beads-dir>/formulas/ (active project)
   2. <checkout-root>/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user level)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -5437,19 +5437,14 @@ bd defer [id...] [flags]
 
 Manage workflow formulas - the source layer for molecule templates.
 
-Formulas are YAML/JSON files that define workflows with composition rules.
-They are "cooked" into proto beads which can then be poured or wisped.
-
-The Rig → Cook → Run lifecycle:
-  - Rig: Compose formulas (extends, compose)
-  - Cook: Transform to proto (bd cook expands macros, applies aspects)
-  - Run: Agents execute poured mols or wisps
+Formulas are TOML/JSON files that define workflows with composition rules.
+Define formulas, cook them into protos, then pour or wisp them into work.
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -5498,7 +5493,7 @@ Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 
@@ -6168,7 +6163,7 @@ Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user level)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula

--- a/website/docs/cli-reference/formula.md
+++ b/website/docs/cli-reference/formula.md
@@ -12,19 +12,14 @@ Generated from `bd help --doc formula`
 
 Manage workflow formulas - the source layer for molecule templates.
 
-Formulas are YAML/JSON files that define workflows with composition rules.
-They are "cooked" into proto beads which can then be poured or wisped.
-
-The Rig → Cook → Run lifecycle:
-  - Rig: Compose formulas (extends, compose)
-  - Cook: Transform to proto (bd cook expands macros, applies aspects)
-  - Run: Agents execute poured mols or wisps
+Formulas are TOML/JSON files that define workflows with composition rules.
+Define formulas, cook them into protos, then pour or wisp them into work.
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -73,7 +68,7 @@ Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 

--- a/website/docs/cli-reference/mol.md
+++ b/website/docs/cli-reference/mol.md
@@ -333,7 +333,7 @@ Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user level)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula

--- a/website/versioned_docs/version-1.0.0/cli-reference/formula.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/formula.md
@@ -12,19 +12,14 @@ Generated from `bd help --doc formula`
 
 Manage workflow formulas - the source layer for molecule templates.
 
-Formulas are YAML/JSON files that define workflows with composition rules.
-They are "cooked" into proto beads which can then be poured or wisped.
-
-The Rig → Cook → Run lifecycle:
-  - Rig: Compose formulas (extends, compose)
-  - Cook: Transform to proto (bd cook expands macros, applies aspects)
-  - Run: Agents execute poured mols or wisps
+Formulas are TOML/JSON files that define workflows with composition rules.
+Define formulas, cook them into protos, then pour or wisp them into work.
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -73,7 +68,7 @@ Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/mol.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/mol.md
@@ -333,7 +333,7 @@ Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user level)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula

--- a/website/versioned_docs/version-1.0.4/cli-reference/formula.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/formula.md
@@ -12,19 +12,14 @@ Generated from `bd help --doc formula`
 
 Manage workflow formulas - the source layer for molecule templates.
 
-Formulas are YAML/JSON files that define workflows with composition rules.
-They are "cooked" into proto beads which can then be poured or wisped.
-
-The Rig → Cook → Run lifecycle:
-  - Rig: Compose formulas (extends, compose)
-  - Cook: Transform to proto (bd cook expands macros, applies aspects)
-  - Run: Agents execute poured mols or wisps
+Formulas are TOML/JSON files that define workflows with composition rules.
+Define formulas, cook them into protos, then pour or wisp them into work.
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -73,7 +68,7 @@ Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 

--- a/website/versioned_docs/version-1.0.4/cli-reference/mol.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/mol.md
@@ -333,7 +333,7 @@ Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user level)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula


### PR DESCRIPTION
## Summary
- replace formula help's Rig/Cook/Run lifecycle with existing beads verbs: define formulas, cook them into protos, then pour or wisp them into work
- describe GT_ROOT formula search path as a shared workspace root instead of an orchestrator path
- update generated CLI docs and add a regression test for the help text

## Validation
- go test -tags gms_pure_go ./cmd/bd -run TestFormulaHelpUsesGenericWorkflowLanguage
- CGO_ENABLED=0 go build -tags gms_pure_go -o .tmp-doccheck/bd.exe ./cmd/bd
- bash ./scripts/generate-cli-docs.sh --check .tmp-doccheck/bd.exe

_codex-gpt-5-medium on behalf of matt wilkie_