### PR TITLE
fix(init): use git origin as default Dolt remote

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -86,7 +86,7 @@ This enables `bd doctor` to detect **orphaned issues** - work that was committed
 
 bd uses **Dolt** as its primary database. Changes are committed to Dolt history automatically (one Dolt commit per write command).
 
-**Install git hooks** for automatic sync:
+**Install git hooks** for commit integration and legacy fallback behavior:
 ```bash
 bd hooks install
 ```
@@ -296,7 +296,7 @@ bd dolt push
 This installs:
 
 - **pre-commit** — Commits pending Dolt changes
-- **post-merge** — Pulls remote Dolt changes after git merge
+- **post-merge** — Runs chained hooks and a legacy JSONL import fallback only when no Dolt remote is configured
 
 **Note:** Hooks are embedded in the bd binary and work for all bd users (not just source repo users).
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ Dolt runs in-process — no external server needed. Data lives in
 `.beads/embeddeddolt/`. Single-writer only (file locking enforced).
 This is the recommended mode for most users.
 
+When the git repo has an `origin` remote, `bd init` configures a Dolt remote
+named `origin` automatically. Cross-machine sync uses `bd dolt push` and
+`bd dolt pull` against `refs/dolt/data`; `.beads/issues.jsonl` is an export
+for viewers, interchange, and backup, not the source of truth.
+
 ### Server Mode
 
 ```bash
@@ -198,5 +203,5 @@ For daemon mode without git, use `bd daemon start --local`
 
 ## 📝 Documentation
 
-* [Documentation site](https://gastownhall.github.io/beads/) (versioned) | [Installing](docs/INSTALLING.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot Setup](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
+* [Documentation site](https://gastownhall.github.io/beads/) (versioned) | [Installing](docs/INSTALLING.md) | [Sync Concepts](docs/SYNC_CONCEPTS.md) | [Agent Workflow](AGENT_INSTRUCTIONS.md) | [Copilot Setup](docs/COPILOT_INTEGRATION.md) | [Articles](ARTICLES.md) | [Sync Branch Mode](docs/PROTECTED_BRANCHES.md) | [Troubleshooting](docs/TROUBLESHOOTING.md) | [FAQ](docs/FAQ.md)
 * [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/gastownhall/beads)

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -98,7 +98,7 @@ Unlike 'bd init --force', bootstrap will never delete existing issues.
 
 Bootstrap auto-detects the right action:
   • If sync.remote is configured: clones from the remote
-  • If git origin has Dolt data (refs/dolt/data): clones from git
+  • If git origin has Dolt data (refs/dolt/data): clones from git and wires origin for future push/pull
   • If .beads/backup/*.jsonl exists: restores from backup
   • If .beads/issues.jsonl exists: imports from git-tracked JSONL
   • If no database exists: creates a fresh one
@@ -649,6 +649,7 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		fmt.Fprintf(os.Stderr, "Warning: post-clone store init failed (wisp tables may be missing): %v\n", err)
 		return nil
 	}
+	configureInitDoltRemote(ctx, warmupStore, plan.SyncRemote, false)
 	_ = warmupStore.Close()
 
 	return nil

--- a/cmd/bd/bootstrap_embedded_test.go
+++ b/cmd/bd/bootstrap_embedded_test.go
@@ -201,6 +201,43 @@ func TestEmbeddedBootstrap(t *testing.T) {
 			t.Errorf("expected 'Imported' in output: %s", out)
 		}
 	})
+
+	t.Run("bootstrap_from_git_origin_wires_remote", func(t *testing.T) {
+		bareDir := filepath.Join(t.TempDir(), "origin.git")
+		runGitForBootstrapTest(t, "", "init", "--bare", "--initial-branch=main", bareDir)
+		remoteURL := "file://" + bareDir
+
+		sourceDir := t.TempDir()
+		initGitRepoAt(t, sourceDir)
+		runGitForBootstrapTest(t, sourceDir, "branch", "-M", "main")
+		runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", remoteURL)
+		runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
+		runGitForBootstrapTest(t, sourceDir, "push", "-u", "origin", "main")
+		runBDInit(t, bd, sourceDir, "--prefix", "beads", "--skip-hooks", "--skip-agents")
+		bdCreate(t, bd, sourceDir, "Seed remote data", "--type", "task")
+		bdDolt(t, bd, sourceDir, "push")
+
+		cloneDir := t.TempDir()
+		runGitForBootstrapTest(t, cloneDir, "init", "-b", "main")
+		runGitForBootstrapTest(t, cloneDir, "remote", "add", "origin", remoteURL)
+
+		out := bdBootstrap(t, bd, cloneDir, "--yes")
+		if !strings.Contains(out, "clone from remote") {
+			t.Fatalf("expected bootstrap sync plan, got:\n%s", out)
+		}
+
+		remotes := bdDolt(t, bd, cloneDir, "remote", "list")
+		if !strings.Contains(remotes, "origin") || !strings.Contains(remotes, remoteURL) {
+			t.Fatalf("bootstrap should leave origin configured as a Dolt remote %q; remote list:\n%s", remoteURL, remotes)
+		}
+		configYAML, err := os.ReadFile(filepath.Join(cloneDir, ".beads", "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if !strings.Contains(string(configYAML), remoteURL) {
+			t.Fatalf("bootstrap should persist sync.remote; config.yaml:\n%s", configYAML)
+		}
+	})
 }
 
 // TestEmbeddedBootstrapConcurrent exercises bootstrap --dry-run concurrently.

--- a/cmd/bd/close_embedded_test.go
+++ b/cmd/bd/close_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -534,10 +535,7 @@ func TestEmbeddedCloseConcurrent(t *testing.T) {
 			for i := 0; i < issuesPerWorker; i++ {
 				// Create an issue.
 				title := fmt.Sprintf("w%d-close-%d", worker, i)
-				cmd := exec.Command(bd, "create", "--silent", title)
-				cmd.Dir = dir
-				cmd.Env = bdEnv(dir)
-				out, err := cmd.CombinedOutput()
+				out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--silent", title)
 				if err != nil {
 					r.err = fmt.Errorf("create %d: %v\n%s", i, err, out)
 					results[worker] = r
@@ -567,13 +565,15 @@ func TestEmbeddedCloseConcurrent(t *testing.T) {
 				listCmd := exec.Command(bd, "list", "--json", "--limit", "0", "--all")
 				listCmd.Dir = dir
 				listCmd.Env = bdEnv(dir)
-				listOut, err := listCmd.CombinedOutput()
-				if err != nil {
-					r.err = fmt.Errorf("list after close %d: %v\n%s", i, err, listOut)
+				var listStdout, listStderr bytes.Buffer
+				listCmd.Stdout = &listStdout
+				listCmd.Stderr = &listStderr
+				if err := listCmd.Run(); err != nil {
+					r.err = fmt.Errorf("list after close %d: %v\nstdout:\n%s\nstderr:\n%s", i, err, listStdout.String(), listStderr.String())
 					results[worker] = r
 					return
 				}
-				s := string(listOut)
+				s := listStdout.String()
 				start := strings.Index(s, "[")
 				if start < 0 {
 					r.listCounts = append(r.listCounts, 0)
@@ -581,7 +581,7 @@ func TestEmbeddedCloseConcurrent(t *testing.T) {
 				}
 				var issues []json.RawMessage
 				if jsonErr := json.Unmarshal([]byte(s[start:]), &issues); jsonErr != nil {
-					r.err = fmt.Errorf("list parse %d: %v\nraw: %s", i, jsonErr, s)
+					r.err = fmt.Errorf("list parse %d: %v\nstdout:\n%s\nstderr:\n%s", i, jsonErr, s, listStderr.String())
 					results[worker] = r
 					return
 				}

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -37,7 +37,8 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv) and git-based sync.
+  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
     export.auto       Enable/disable auto-export (default: true)

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -942,10 +942,7 @@ func TestEmbeddedCreateConcurrent(t *testing.T) {
 			var ids []string
 			for i := 0; i < issuesPerWorker; i++ {
 				title := fmt.Sprintf("worker-%d-issue-%d", worker, i)
-				cmd := exec.Command(bd, "create", "--silent", title)
-				cmd.Dir = dir
-				cmd.Env = bdEnv(dir)
-				out, err := cmd.CombinedOutput()
+				out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--silent", title)
 				if err != nil {
 					results[worker] = result{worker: worker, err: fmt.Errorf("issue %d: %v\n%s", i, err, out)}
 					return

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -167,7 +167,7 @@ Examples:
   bd doctor --fix -i     # Confirm each fix individually
   bd doctor --fix --fix-child-parent  # Also fix child→parent deps (opt-in)
   bd doctor --fix --force # Force repair even when database can't be opened
-  bd doctor --fix --source=jsonl # Rebuild database from JSONL (source of truth)
+  bd doctor --fix --source=jsonl # Rebuild database from a JSONL export
   bd doctor --dry-run    # Preview what --fix would do without making changes
   bd doctor --perf       # Performance diagnostics
   bd doctor --output diagnostics.json  # Export diagnostics to file

--- a/cmd/bd/doctor/agent.go
+++ b/cmd/bd/doctor/agent.go
@@ -242,7 +242,7 @@ func enrichCLIVersion(dc DoctorCheck) agentEnrichment {
 func enrichGitHooks(dc DoctorCheck) agentEnrichment {
 	return agentEnrichment{
 		severity:    "degraded",
-		explanation: fmt.Sprintf("Git hooks issue: %s. Beads git hooks auto-sync the database on commit/merge/push. Without them, changes won't propagate to other clones.", dc.Message),
+		explanation: fmt.Sprintf("Git hooks issue: %s. Beads git hooks refresh JSONL exports and run legacy fallback checks, while cross-clone sync uses Dolt remotes via bd dolt push/pull.", dc.Message),
 		observed:    dc.Message + "\n" + dc.Detail,
 		expected:    "Git hooks installed and version matches CLI version",
 		commands:    []string{"bd hooks install"},
@@ -255,7 +255,7 @@ func enrichGitHooksDolt(dc DoctorCheck) agentEnrichment {
 		severity:    "blocking",
 		explanation: fmt.Sprintf("Git hooks are incompatible with Dolt backend: %s. Hooks that predate the Dolt migration may run SQLite operations on a Dolt database, causing errors on every git operation.", dc.Message),
 		observed:    dc.Message + "\n" + dc.Detail,
-		expected:    "Git hooks contain Dolt-compatible sync commands",
+		expected:    "Git hooks contain Dolt-compatible commands",
 		commands:    []string{"bd hooks install"},
 		sourceFiles: []string{"cmd/bd/doctor/git.go:CheckGitHooksDoltCompatibility"},
 	}

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -108,6 +108,7 @@ func maybeAutoExport(ctx context.Context) {
 		_ = os.Remove(fullPath)
 		return
 	}
+	warnJSONLWithoutDoltRemote("auto-export")
 
 	// Optional git add — skip when no-git-ops is set (GH#3314), when not in a
 	// git repo (standalone BEADS_DIR flow), or when export.git-add is false.

--- a/cmd/bd/gate_embedded_test.go
+++ b/cmd/bd/gate_embedded_test.go
@@ -619,10 +619,7 @@ func TestEmbeddedGateConcurrent(t *testing.T) {
 
 			// Each worker: create a gate, add a waiter, resolve it
 			title := fmt.Sprintf("w%d-gate", worker)
-			cmd := exec.Command(bd, "create", "--silent", title, "--type", "gate")
-			cmd.Dir = dir
-			cmd.Env = bdEnv(dir)
-			out, err := cmd.CombinedOutput()
+			out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--silent", title, "--type", "gate")
 			if err != nil {
 				r.err = fmt.Errorf("create gate: %v\n%s", err, out)
 				results[worker] = r
@@ -631,7 +628,7 @@ func TestEmbeddedGateConcurrent(t *testing.T) {
 			gateID := strings.TrimSpace(string(out))
 
 			// Add waiter
-			cmd = exec.Command(bd, "gate", "add-waiter", gateID, fmt.Sprintf("agent-%d", worker))
+			cmd := exec.Command(bd, "gate", "add-waiter", gateID, fmt.Sprintf("agent-%d", worker))
 			cmd.Dir = dir
 			cmd.Env = bdEnv(dir)
 			out, err = cmd.CombinedOutput()

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1349,6 +1349,7 @@ func exportJSONLForCommit() {
 	fullPath := filepath.Join(beadsDir, exportPath)
 
 	debug.Logf("pre-commit: exporting JSONL to %s\n", fullPath)
+	warnJSONLWithoutDoltRemote("pre-commit auto-export")
 
 	// Shell out to `bd export` which initializes its own store.
 	// Clear BD_GIT_HOOK from the subprocess env so that its
@@ -1388,9 +1389,9 @@ func exportSubprocessDir(beadsDir string) string {
 }
 
 // importJSONLForSync imports .beads/issues.jsonl into Dolt after a git
-// pull/merge/branch-checkout, so issues created on other machines enter
-// the local database before the next auto-export overwrites the JSONL
-// with our (possibly stale) view. Symmetric to exportJSONLForCommit.
+// pull/merge/branch-checkout only for legacy projects with no Dolt remote.
+// When sync.remote is configured, Dolt remains the source of truth and JSONL
+// import is skipped because upsert-only import cannot reconcile stale exports.
 //
 // Errors are logged as warnings but never block the merge/checkout. The
 // import is upsert; running it on an unchanged JSONL is a no-op (bd
@@ -1399,6 +1400,10 @@ func exportSubprocessDir(beadsDir string) string {
 // See GH#3729.
 func importJSONLForSync(reason string) {
 	if !config.GetBool("import.auto") {
+		return
+	}
+	if resolveSyncRemote() != "" {
+		debug.Logf("%s: skipping JSONL import because sync.remote is configured\n", reason)
 		return
 	}
 
@@ -1418,6 +1423,7 @@ func importJSONLForSync(reason string) {
 	}
 
 	debug.Logf("%s: importing JSONL from %s\n", reason, fullPath)
+	warnJSONLWithoutDoltRemote(reason + " JSONL import")
 
 	// Shell out to `bd import` — same pattern as exportJSONLForCommit.
 	// Clear BD_GIT_HOOK so the subprocess's own hook-detection logic
@@ -1439,6 +1445,19 @@ func importJSONLForSync(reason string) {
 	fmt.Fprintf(os.Stderr, "beads: %s import warning: %v\n%s", reason, err, out)
 }
 
+func warnJSONLWithoutDoltRemote(reason string) {
+	if config.GetBool("no-git-ops") || resolveSyncRemote() != "" || !isGitRepo() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "beads: %s warning: no Dolt remote configured.\n", reason)
+	fmt.Fprintln(os.Stderr, "beads: .beads/issues.jsonl is an export, not cross-machine sync or source of truth.")
+	if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
+		fmt.Fprintf(os.Stderr, "beads: repair: bd dolt remote add origin %s && bd dolt push\n", normalizeRemoteURL(originURL))
+		return
+	}
+	fmt.Fprintln(os.Stderr, "beads: repair: add a git origin, then run 'bd dolt remote add origin <git-remote-url>' and 'bd dolt push'.")
+}
+
 // filterEnv returns a copy of env with entries matching the given key removed.
 func filterEnv(env []string, key string) []string {
 	prefix := key + "="
@@ -1451,10 +1470,8 @@ func filterEnv(env []string, key string) []string {
 	return out
 }
 
-// runPostMergeHook runs chained hooks after merge, then auto-imports
-// .beads/issues.jsonl into Dolt so issues created on other machines (and
-// just landed via git pull) enter the local database before the next
-// auto-export overwrites the JSONL with our stale view. See GH#3729.
+// runPostMergeHook runs chained hooks after merge, then runs the legacy
+// JSONL import fallback only when no Dolt remote is configured. See GH#3729.
 //
 // Returns 0 on success (or if not applicable).
 //
@@ -1478,10 +1495,10 @@ func runPrePushHook(args []string) int {
 	return 0
 }
 
-// runPostCheckoutHook runs chained hooks after branch checkout, then
-// auto-imports .beads/issues.jsonl into Dolt when the checkout was a
-// branch switch (flag=1). File-mode checkouts (flag=0) are skipped to
-// avoid spurious imports on `git checkout -- <file>`. See GH#3729.
+// runPostCheckoutHook runs chained hooks after branch checkout, then runs
+// the legacy JSONL import fallback when the checkout was a branch switch
+// (flag=1) and no Dolt remote is configured. File-mode checkouts (flag=0)
+// are skipped to avoid spurious imports on `git checkout -- <file>`. See GH#3729.
 //
 // args: [previous-HEAD, new-HEAD, flag] where flag=1 for branch checkout
 // Returns 0 on success (or if not applicable).

--- a/cmd/bd/hooks_post_merge_import_test.go
+++ b/cmd/bd/hooks_post_merge_import_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/config"
@@ -62,6 +64,45 @@ func TestImportJSONLForSync_GuardClauses(t *testing.T) {
 		// Empty file: os.Stat.Size==0 fast path returns before subprocess.
 		importJSONLForSync("test")
 	})
+
+	t.Run("sync.remote suppresses jsonl import", func(t *testing.T) {
+		beadsDir := filepath.Join(tmp, ".beads")
+		if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		config.Set("import.auto", true)
+		config.Set("sync.remote", "git+ssh://git@example.com/acme/repo.git")
+		t.Cleanup(func() { config.Set("sync.remote", "") })
+
+		stderr := captureHookStderr(t, func() {
+			importJSONLForSync("test")
+		})
+		if strings.Contains(stderr, "import warning") || strings.Contains(stderr, "no Dolt remote") {
+			t.Fatalf("sync.remote should skip JSONL import without warning, got stderr:\n%s", stderr)
+		}
+	})
+}
+
+func captureHookStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	fn()
+	_ = w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
 }
 
 // TestRunPostCheckoutHook_FileModeSkipsImport asserts that file-mode

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -22,6 +22,7 @@ import (
 	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/templates/agents"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
@@ -54,7 +55,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv) and git-based workflows up to date without extra steps.
+viewers (bv), interchange, and backups up to date without extra steps.
+Cross-machine sync uses Dolt remotes, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
@@ -359,7 +361,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				// back to a fresh local init against a new remote.
 			} else if earlyRemoteSource == initSyncRemoteConfigured {
 				earlyRemoteHasDoltData = true // sync.remote configured = user intends bootstrap
-			} else if earlyRemoteSource == initSyncRemoteNone && isGitRepo() && !isBareGitRepo() {
+			} else if earlyRemoteSource == initSyncRemoteNone && !stealth && isGitRepo() && !isBareGitRepo() {
 				if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 					earlySyncURL = normalizeRemoteURL(originURL)
 					earlyRemoteHasDoltData = gitOriginHasDoltDataRef()
@@ -627,6 +629,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		syncURLFromConfig := syncURL != "" && syncRemoteSource != initSyncRemoteNone // true when URL came from explicit user config
 		bootstrappedFromRemote := false
 		syncFromRemote := false
+		syncURLFromGitOrigin := false
 		remoteHasDoltData := false
 
 		if syncURL != "" {
@@ -637,9 +640,10 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// http:// to git+http:// and break Dolt remotesapi endpoints
 			// configured explicitly by the user (GH#3339).
 			syncFromRemote = true
-		} else if syncRemoteSource == initSyncRemoteNone && isGitRepo() && !isBareGitRepo() {
+		} else if syncRemoteSource == initSyncRemoteNone && !stealth && isGitRepo() && !isBareGitRepo() {
 			if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 				syncURL = normalizeRemoteURL(originURL)
+				syncURLFromGitOrigin = true
 				remoteHasDoltData = gitOriginHasDoltDataRef()
 
 				decision := CheckRemoteSafety(RemoteSafetyInput{
@@ -824,23 +828,13 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			initGlobalDatabaseConfig(ctx, doltCfg, quiet)
 		}
 
-		// Configure the remote in the Dolt store so bd dolt push/pull
-		// work immediately after bootstrap. Only register the remote when
-		// the URL came from explicit config (sync.remote) or the remote
-		// was confirmed to have Dolt data (refs/dolt/data). Auto-detected
-		// git origin URLs for plain source repos must NOT be registered —
-		// they cause every Dolt fetch to fail and leak tmp_pack_* files
-		// that can consume 100+ GB of disk space (GH#3354, GH#3356).
-		if shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig) {
-			hasRemote, _ := store.HasRemote(ctx, "origin")
-			if !hasRemote {
-				if err := store.AddRemote(ctx, "origin", syncURL); err != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to add remote 'origin': %v\n", err)
-					// Non-fatal — user can add manually with: bd dolt remote add origin <url>
-				} else if !quiet {
-					fmt.Printf("  %s Configured Dolt remote: origin → %s\n", ui.RenderPass("✓"), syncURL)
-				}
-			}
+		// Configure the remote in the Dolt store so bd dolt push/pull work
+		// immediately after init/bootstrap. A git origin is a valid Dolt
+		// remote even before refs/dolt/data exists; the first bd dolt push
+		// creates that ref. This keeps the default path durable without
+		// falling back to JSONL-as-sync.
+		if shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin) {
+			configureInitDoltRemote(ctx, store, syncURL, quiet)
 		}
 
 		// === CONFIGURATION METADATA (Pattern A: Fatal) ===
@@ -1027,10 +1021,10 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			// Persist sync.remote to config.yaml so fresh clones can
 			// bootstrap from it (the Dolt database is gitignored).
 			// Must run AFTER createConfigYaml which creates the file.
-			// Only persist when the URL is from explicit config or a
-			// confirmed Dolt remote — not an auto-detected git origin
-			// for a plain source repo (GH#3356).
-			if err := persistInitSyncRemote(beadsDir, initRemote, syncURL, syncFromRemote, syncURLFromConfig); err != nil {
+			// Persist the effective remote so future bootstrap and hooks know
+			// Dolt, not JSONL, is the cross-machine sync path. Plain git
+			// origins are valid here: the first push creates refs/dolt/data.
+			if err := persistInitSyncRemote(beadsDir, initRemote, syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin); err != nil {
 				FatalError("failed to persist sync.remote to config.yaml: %v", err)
 			}
 
@@ -1326,7 +1320,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
 				}
 			} else {
-				renderOpts := agents.RenderOpts{HasRemote: shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig)}
+				renderOpts := agents.RenderOpts{HasRemote: shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin)}
 				addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile, renderOpts)
 			}
 		}
@@ -1397,6 +1391,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				fmt.Fprintf(os.Stderr, "\n%s Git upstream not configured\n", ui.RenderWarn("⚠"))
 				fmt.Fprintf(os.Stderr, "  For sync workflows, set your upstream with:\n")
 				fmt.Fprintf(os.Stderr, "  %s\n\n", ui.RenderAccent("git remote add upstream <repo-url>"))
+			}
+			if !stealth && !initRemoteChanged && !shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin) {
+				printInitNoDoltRemoteWarning()
 			}
 		}
 
@@ -1933,7 +1930,7 @@ func promptContributorMode() (isContributor bool, err error) {
 // Returns true to keep it enabled, false to disable.
 func promptAutoExport() (bool, error) {
 	fmt.Printf("\n%s Auto-export keeps .beads/issues.jsonl up to date after every write command.\n", ui.RenderAccent("▶"))
-	fmt.Println("  This is useful for viewers (bv) and git-based sync workflows.")
+	fmt.Println("  This is useful for viewers (bv), interchange, and backups. Dolt remotes handle sync.")
 	fmt.Print("\nEnable auto-export? [Y/n]: ")
 
 	reader := bufio.NewReader(os.Stdin)
@@ -1950,10 +1947,57 @@ func promptAutoExport() (bool, error) {
 	return response == "" || response == "y" || response == "yes", nil
 }
 
-func shouldWireInitRemote(syncURL string, syncFromRemote, syncURLFromConfig bool) bool {
-	// Auto-detected plain git origins are not Dolt remotes. Only wire origin
-	// when it was explicitly configured or proven to carry refs/dolt/data.
-	return syncURL != "" && (syncFromRemote || syncURLFromConfig)
+func shouldWireInitRemote(syncURL string, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin bool) bool {
+	// A git origin is a valid Dolt remote even before refs/dolt/data exists:
+	// the first `bd dolt push` creates the Dolt ref on that git remote. We
+	// still keep explicit empty --remote as an opt-out because that leaves
+	// syncURL empty and syncURLFromGitOrigin false.
+	return syncURL != "" && (syncFromRemote || syncURLFromConfig || syncURLFromGitOrigin)
+}
+
+func configureInitDoltRemote(ctx context.Context, store storage.DoltStorage, syncURL string, quiet bool) {
+	hasRemote, _ := store.HasRemote(ctx, "origin")
+	if !hasRemote {
+		if err := store.AddRemote(ctx, "origin", syncURL); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to add remote 'origin': %v\n", err)
+			// Non-fatal — user can add manually with: bd dolt remote add origin <url>
+		} else if !quiet {
+			fmt.Printf("  %s Configured Dolt remote: origin → %s\n", ui.RenderPass("✓"), syncURL)
+		}
+	}
+
+	// Server-mode git remotes often need a matching CLI remote so push/pull can
+	// use the user's local SSH keys or credential helpers instead of the SQL
+	// server process environment.
+	if !usesSQLServer() {
+		return
+	}
+	locator, ok := storage.UnwrapStore(store).(storage.StoreLocator)
+	if !ok {
+		return
+	}
+	dbPath := locator.CLIDir()
+	if dbPath == "" || doltutil.FindCLIRemote(dbPath, "origin") != "" {
+		return
+	}
+	if err := doltutil.AddCLIRemote(dbPath, "origin", syncURL); err != nil && !quiet {
+		fmt.Fprintf(os.Stderr, "Warning: failed to add CLI remote 'origin': %v\n", err)
+	}
+}
+
+func printInitNoDoltRemoteWarning() {
+	fmt.Fprintf(os.Stderr, "\n%s No Dolt remote configured\n", ui.RenderWarn("⚠"))
+	fmt.Fprintln(os.Stderr, "  Issues are stored in local Dolt. .beads/issues.jsonl is an export,")
+	fmt.Fprintln(os.Stderr, "  not cross-machine sync or the source of truth.")
+	if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
+		fmt.Fprintln(os.Stderr, "  To use your git origin for durable sync, run:")
+		fmt.Fprintf(os.Stderr, "    %s\n", ui.RenderAccent("bd dolt remote add origin "+normalizeRemoteURL(originURL)))
+		fmt.Fprintf(os.Stderr, "    %s\n\n", ui.RenderAccent("bd dolt push"))
+		return
+	}
+	fmt.Fprintln(os.Stderr, "  To enable durable sync, add a git origin and then run:")
+	fmt.Fprintf(os.Stderr, "    %s\n", ui.RenderAccent("bd dolt remote add origin <git-remote-url>"))
+	fmt.Fprintf(os.Stderr, "    %s\n\n", ui.RenderAccent("bd dolt push"))
 }
 
 type initSyncRemoteSource int
@@ -2010,11 +2054,11 @@ func initTimeCloneConfig(serverMode bool, serverHost string, serverPort int, ser
 	return cfg
 }
 
-func persistInitSyncRemote(beadsDir, initRemote, syncURL string, syncFromRemote, syncURLFromConfig bool) error {
+func persistInitSyncRemote(beadsDir, initRemote, syncURL string, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin bool) error {
 	if initRemote != "" {
 		return config.SetYamlConfigInDir(beadsDir, "sync.remote", initRemote)
 	}
-	if !shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig) {
+	if !shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin) {
 		return nil
 	}
 	if existing := config.GetStringFromDir(beadsDir, "sync.remote"); existing != "" {

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -329,19 +329,61 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
-	t.Run("plain_git_origin_not_registered_as_dolt_remote", func(t *testing.T) {
+	t.Run("git_origin_registered_as_dolt_remote", func(t *testing.T) {
 		bareDir := filepath.Join(t.TempDir(), "plain.git")
-		runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", bareDir)
+
+		seedDir := t.TempDir()
+		initGitRepoAt(t, seedDir)
+		runGitForBootstrapTest(t, seedDir, "branch", "-M", "main")
+		runGitForBootstrapTest(t, seedDir, "commit", "--allow-empty", "-m", "init")
+		runGitForBootstrapTest(t, seedDir, "remote", "add", "origin", "file://"+bareDir)
+		runGitForBootstrapTest(t, seedDir, "push", "-u", "origin", "main")
 
 		dir := t.TempDir()
 		initGitRepoAt(t, dir)
-		runGitForBootstrapTest(t, dir, "remote", "add", "origin", bareDir)
+		remoteURL := "file://" + bareDir
+		runGitForBootstrapTest(t, dir, "remote", "add", "origin", remoteURL)
 
 		runBDInit(t, bd, dir, "--prefix", "pg", "--skip-hooks", "--skip-agents")
 
 		out := bdDolt(t, bd, dir, "remote", "list")
+		if !strings.Contains(out, "origin") || !strings.Contains(out, remoteURL) {
+			t.Fatalf("git origin should be registered as a Dolt remote %q; remote list:\n%s", remoteURL, out)
+		}
+
+		configYAML, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if !strings.Contains(string(configYAML), remoteURL) {
+			t.Fatalf("git origin should be persisted as sync.remote; config.yaml:\n%s", configYAML)
+		}
+
+		bdDolt(t, bd, dir, "push")
+		ls := exec.Command("git", "ls-remote", remoteURL, "refs/dolt/data")
+		lsOut, err := ls.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git ls-remote refs/dolt/data failed: %v\n%s", err, lsOut)
+		}
+		if !strings.Contains(string(lsOut), "refs/dolt/data") {
+			t.Fatalf("bd dolt push did not publish refs/dolt/data:\n%s", lsOut)
+		}
+	})
+
+	t.Run("stealth_skips_git_origin_remote_synthesis", func(t *testing.T) {
+		bareDir := filepath.Join(t.TempDir(), "stealth.git")
+		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", bareDir)
+
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+		runGitForBootstrapTest(t, dir, "remote", "add", "origin", "file://"+bareDir)
+
+		runBDInit(t, bd, dir, "--prefix", "st", "--stealth", "--skip-agents")
+
+		out := bdDolt(t, bd, dir, "remote", "list")
 		if strings.Contains(out, "origin") {
-			t.Fatalf("plain git origin should not be registered as a Dolt remote; remote list:\n%s", out)
+			t.Fatalf("stealth init should not synthesize a Dolt remote; remote list:\n%s", out)
 		}
 
 		configYAML, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
@@ -349,7 +391,7 @@ func TestEmbeddedInit(t *testing.T) {
 			t.Fatalf("read config.yaml: %v", err)
 		}
 		if strings.Contains(string(configYAML), "sync.remote:") || strings.Contains(string(configYAML), "sync-remote:") {
-			t.Fatalf("plain git origin should not be persisted as sync.remote; config.yaml:\n%s", configYAML)
+			t.Fatalf("stealth init should not persist sync.remote; config.yaml:\n%s", configYAML)
 		}
 	})
 

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -97,8 +98,8 @@ func isEmbeddedLockOutput(out string) bool {
 }
 
 // bdRunWithFlockRetry runs a bd command with retry on flock contention.
-// Returns the combined output and nil on success, or the last output and error
-// after all retries are exhausted or a non-flock error occurs.
+// Returns stdout and nil on success, or combined stdout/stderr and the last
+// error after retries are exhausted or a non-flock error occurs.
 func bdRunWithFlockRetry(t *testing.T, bd, dir string, args ...string) ([]byte, error) {
 	t.Helper()
 	var out []byte
@@ -107,10 +108,14 @@ func bdRunWithFlockRetry(t *testing.T, bd, dir string, args ...string) ([]byte, 
 		cmd := exec.Command(bd, args...)
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		out, err = cmd.CombinedOutput()
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err = cmd.Run()
 		if err == nil {
-			return out, nil
+			return stdout.Bytes(), nil
 		}
+		out = append(stdout.Bytes(), stderr.Bytes()...)
 		if !isEmbeddedLockOutput(string(out)) {
 			return out, err
 		}

--- a/cmd/bd/init_remote_test.go
+++ b/cmd/bd/init_remote_test.go
@@ -44,7 +44,7 @@ func TestInitExplicitRemoteDrivesCloneAndPersistence(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("# Beads Config\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := persistInitSyncRemote(beadsDir, remote, syncURL, syncFromRemote, syncURLFromConfig); err != nil {
+	if err := persistInitSyncRemote(beadsDir, remote, syncURL, syncFromRemote, syncURLFromConfig, false); err != nil {
 		t.Fatalf("persistInitSyncRemote failed: %v", err)
 	}
 	configBytes, err := os.ReadFile(filepath.Join(beadsDir, "config.yaml"))
@@ -115,7 +115,7 @@ func TestPersistInitSyncRemoteExplicitRemoteWritesTargetDir(t *testing.T) {
 	}
 
 	const remote = "git+ssh://git@example.com/right/repo.git"
-	if err := persistInitSyncRemote(targetBeadsDir, remote, remote, false, true); err != nil {
+	if err := persistInitSyncRemote(targetBeadsDir, remote, remote, false, true, false); err != nil {
 		t.Fatalf("persistInitSyncRemote failed: %v", err)
 	}
 

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -165,6 +165,7 @@ func TestShouldWireInitRemote(t *testing.T) {
 		syncURL           string
 		syncFromRemote    bool
 		syncURLFromConfig bool
+		syncURLFromGit    bool
 		want              bool
 	}{
 		{
@@ -173,11 +174,17 @@ func TestShouldWireInitRemote(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:              "plain git origin without dolt data",
+			name:              "unattributed url is not wired",
 			syncURL:           "git+https://github.com/org/plain-source.git",
 			syncFromRemote:    false,
 			syncURLFromConfig: false,
 			want:              false,
+		},
+		{
+			name:           "plain git origin without dolt data",
+			syncURL:        "git+https://github.com/org/plain-source.git",
+			syncURLFromGit: true,
+			want:           true,
 		},
 		{
 			name:              "git origin with refs/dolt/data",
@@ -197,10 +204,10 @@ func TestShouldWireInitRemote(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldWireInitRemote(tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig)
+			got := shouldWireInitRemote(tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig, tt.syncURLFromGit)
 			if got != tt.want {
-				t.Errorf("shouldWireInitRemote(%q, %v, %v) = %v, want %v",
-					tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig, got, tt.want)
+				t.Errorf("shouldWireInitRemote(%q, %v, %v, %v) = %v, want %v",
+					tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig, tt.syncURLFromGit, got, tt.want)
 			}
 		})
 	}

--- a/cmd/bd/init_templates.go
+++ b/cmd/bd/init_templates.go
@@ -38,7 +38,7 @@ func createConfigYaml(beadsDir string, noDbMode bool, prefix string) error {
 %s
 
 # Use no-db mode: JSONL-only, no Dolt database
-# When true, bd will use .beads/issues.jsonl as the source of truth
+# When true, .beads/issues.jsonl is the only local store
 %s
 
 # Enable JSON output by default
@@ -66,7 +66,7 @@ func createConfigYaml(beadsDir string, noDbMode bool, prefix string) error {
 #     - ~/work-planning   # Work planning repo
 
 # JSONL backup (periodic export for off-machine recovery)
-# Auto-enabled when a git remote exists. Override explicitly:
+# This is backup/export only. Cross-machine sync uses Dolt remotes.
 # backup:
 #   enabled: false     # Disable auto-backup entirely
 #   interval: 15m      # Minimum time between auto-exports
@@ -138,7 +138,7 @@ Issues in Beads are:
 - **Git-native**: Stored in Dolt database with version control and branching
 - **AI-friendly**: CLI-first design works perfectly with AI coding agents
 - **Branch-aware**: Issues can follow your branch workflow
-- **Always in sync**: Auto-syncs with your commits
+- **Sync-ready**: Uses Dolt remotes for backup and team sharing
 
 ## Why Beads?
 
@@ -153,7 +153,7 @@ Issues in Beads are:
 - Fast, lightweight, and stays out of your way
 
 🔧 **Git Integration**
-- Automatic sync with git commits
+- Dolt-native sync via bd dolt push / bd dolt pull
 - Branch-aware issue tracking
 - Dolt-native three-way merge resolution
 

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -745,10 +745,7 @@ func TestEmbeddedListConcurrent(t *testing.T) {
 			for i := 0; i < issuesPerWorker; i++ {
 				// Create
 				title := fmt.Sprintf("w%d-issue-%d", worker, i)
-				cmd := exec.Command(bd, "create", "--silent", title)
-				cmd.Dir = dir
-				cmd.Env = bdEnv(dir)
-				out, err := cmd.CombinedOutput()
+				out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--silent", title)
 				if err != nil {
 					r.err = fmt.Errorf("create %d: %v\n%s", i, err, out)
 					results[worker] = r
@@ -766,14 +763,16 @@ func TestEmbeddedListConcurrent(t *testing.T) {
 				listCmd := exec.Command(bd, "list", "--json", "--limit", "0")
 				listCmd.Dir = dir
 				listCmd.Env = bdEnv(dir)
-				listOut, err := listCmd.CombinedOutput()
-				if err != nil {
-					r.err = fmt.Errorf("list after create %d: %v\n%s", i, err, listOut)
+				var listStdout, listStderr bytes.Buffer
+				listCmd.Stdout = &listStdout
+				listCmd.Stderr = &listStderr
+				if err := listCmd.Run(); err != nil {
+					r.err = fmt.Errorf("list after create %d: %v\nstdout:\n%s\nstderr:\n%s", i, err, listStdout.String(), listStderr.String())
 					results[worker] = r
 					return
 				}
 				// Parse JSON array to count issues
-				s := string(listOut)
+				s := listStdout.String()
 				start := strings.Index(s, "[")
 				if start < 0 {
 					r.listCounts = append(r.listCounts, 0)
@@ -781,7 +780,7 @@ func TestEmbeddedListConcurrent(t *testing.T) {
 				}
 				var issues []json.RawMessage
 				if jsonErr := json.Unmarshal([]byte(s[start:]), &issues); jsonErr != nil {
-					r.err = fmt.Errorf("list parse after create %d: %v\nraw: %s", i, jsonErr, s)
+					r.err = fmt.Errorf("list parse after create %d: %v\nstdout:\n%s\nstderr:\n%s", i, jsonErr, s, listStderr.String())
 					results[worker] = r
 					return
 				}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -501,7 +501,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	rootCmd.PersistentFlags().String("format", "", "Output format (json). Alias for --json")
 	_ = rootCmd.PersistentFlags().MarkHidden("format") // Hidden alias for CLI ergonomics
-	rootCmd.PersistentFlags().BoolVar(&sandboxMode, "sandbox", false, "Sandbox mode: disables auto-sync")
+	rootCmd.PersistentFlags().BoolVar(&sandboxMode, "sandbox", false, "Sandbox mode: disables Dolt auto-push")
 	rootCmd.PersistentFlags().BoolVar(&readonlyMode, "readonly", false, "Read-only mode: block write operations (for worker sandboxes)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlag, "global", false, "Use the global shared-server database (beads_global)")
 	rootCmd.PersistentFlags().StringVar(&doltAutoCommit, "dolt-auto-commit", "", "Dolt auto-commit policy (off|on|batch). 'on': commit after each write. 'batch': defer commits to bd dolt commit; uncommitted changes persist in the working set until then. SIGTERM/SIGHUP flush pending batch commits. Default: off. Override via config key dolt.auto-commit")

--- a/cmd/bd/quick_embedded_test.go
+++ b/cmd/bd/quick_embedded_test.go
@@ -15,10 +15,7 @@ import (
 func bdQuick(t *testing.T, bd, dir string, args ...string) string {
 	t.Helper()
 	fullArgs := append([]string{"q"}, args...)
-	cmd := exec.Command(bd, fullArgs...)
-	cmd.Dir = dir
-	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
+	out, err := bdRunWithFlockRetry(t, bd, dir, fullArgs...)
 	if err != nil {
 		t.Fatalf("bd q %s failed: %v\n%s", strings.Join(args, " "), err, out)
 	}
@@ -166,10 +163,7 @@ func TestEmbeddedQuickConcurrent(t *testing.T) {
 
 			for i := 0; i < issuesPerWorker; i++ {
 				title := fmt.Sprintf("w%d-quick-%d", worker, i)
-				cmd := exec.Command(bd, "q", title)
-				cmd.Dir = dir
-				cmd.Env = bdEnv(dir)
-				out, err := cmd.CombinedOutput()
+				out, err := bdRunWithFlockRetry(t, bd, dir, "q", title)
 				if err != nil {
 					r.err = fmt.Errorf("q %s: %v\n%s", title, err, out)
 					results[worker] = r

--- a/cmd/bd/quickstart.go
+++ b/cmd/bd/quickstart.go
@@ -72,10 +72,11 @@ var quickstartCmd = &cobra.Command{
 
 		fmt.Printf("%s\n", ui.RenderBold("SYNC"))
 		fmt.Printf("  Share issues with your team using Dolt remotes:\n")
-		fmt.Printf("    %s  Add remote\n", ui.RenderAccent("bd dolt remote add origin git+ssh://git@github.com/org/repo.git"))
+		fmt.Printf("    %s  Verify remote (bd init auto-wires git origin when present)\n", ui.RenderAccent("bd dolt remote list"))
+		fmt.Printf("    %s  Add remote if needed\n", ui.RenderAccent("bd dolt remote add origin git+ssh://git@github.com/org/repo.git"))
 		fmt.Printf("    %s              Push issues\n", ui.RenderAccent("bd dolt push"))
 		fmt.Printf("    %s              Pull from teammates\n", ui.RenderAccent("bd dolt pull"))
-		fmt.Printf("  Dolt handles sync natively with cell-level merge — no manual export needed\n\n")
+		fmt.Printf("  Dolt handles sync natively with cell-level merge; JSONL is export, not sync\n\n")
 
 		fmt.Printf("%s\n", ui.RenderBold("AGENT INTEGRATION"))
 		fmt.Printf("  bd is designed for AI-supervised workflows:\n")

--- a/cmd/bd/setup/cursor.go
+++ b/cmd/bd/setup/cursor.go
@@ -20,8 +20,8 @@ This project uses [Beads (bd)](https://github.com/steveyegge/beads) for issue tr
 - Track ALL work in bd (never use markdown TODOs or comment-based task lists)
 - Use ` + "`bd ready`" + ` to find available work
 - Use ` + "`bd create`" + ` to track new issues/tasks/bugs
-- Use ` + "`bd dolt push`" + ` at end of session to sync with git remote
-- Git hooks auto-sync on commit/merge
+- Use ` + "`bd dolt push`" + ` at end of session to sync with the Dolt remote
+- Git hooks refresh exports and legacy fallbacks; Dolt remotes handle sync
 
 ## Quick Reference
 ` + "```bash" + `
@@ -32,7 +32,7 @@ bd create --title="..." --type=task  # Create new issue
 bd update <id> --claim               # Claim work atomically
 bd close <id>                         # Mark complete
 bd dep add <issue> <depends-on>       # Add dependency (issue depends on depends-on)
-bd dolt push                               # Sync with git remote
+bd dolt push                               # Sync with Dolt remote
 ` + "```" + `
 
 ## Workflow
@@ -40,7 +40,7 @@ bd dolt push                               # Sync with git remote
 2. Claim an issue atomically: ` + "`bd update <id> --claim`" + `
 3. Do the work
 4. Mark complete: ` + "`bd close <id>`" + `
-5. Sync: ` + "`bd dolt push`" + ` (or let git hooks handle it)
+5. Sync: ` + "`bd dolt push`" + `
 
 ## Context Loading
 Run ` + "`bd prime`" + ` to get complete workflow documentation in AI-optimized format (~1-2k tokens).

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -829,10 +830,7 @@ func TestEmbeddedUpdateConcurrent(t *testing.T) {
 			for i := 0; i < issuesPerWorker; i++ {
 				// Create an issue.
 				title := fmt.Sprintf("w%d-issue-%d", worker, i)
-				cmd := exec.Command(bd, "create", "--silent", title)
-				cmd.Dir = dir
-				cmd.Env = bdEnv(dir)
-				out, err := cmd.CombinedOutput()
+				out, err := bdRunWithFlockRetry(t, bd, dir, "create", "--silent", title)
 				if err != nil {
 					r.err = fmt.Errorf("create %d: %v\n%s", i, err, out)
 					results[worker] = r
@@ -883,13 +881,15 @@ func TestEmbeddedUpdateConcurrent(t *testing.T) {
 				listCmd := exec.Command(bd, "list", "--json", "--limit", "0")
 				listCmd.Dir = dir
 				listCmd.Env = bdEnv(dir)
-				listOut, err := listCmd.CombinedOutput()
-				if err != nil {
-					r.err = fmt.Errorf("list after update %d: %v\n%s", i, err, listOut)
+				var listStdout, listStderr bytes.Buffer
+				listCmd.Stdout = &listStdout
+				listCmd.Stderr = &listStderr
+				if err := listCmd.Run(); err != nil {
+					r.err = fmt.Errorf("list after update %d: %v\nstdout:\n%s\nstderr:\n%s", i, err, listStdout.String(), listStderr.String())
 					results[worker] = r
 					return
 				}
-				s := string(listOut)
+				s := listStdout.String()
 				start := strings.Index(s, "[")
 				if start < 0 {
 					r.listCounts = append(r.listCounts, 0)
@@ -897,7 +897,7 @@ func TestEmbeddedUpdateConcurrent(t *testing.T) {
 				}
 				var issues []json.RawMessage
 				if jsonErr := json.Unmarshal([]byte(s[start:]), &issues); jsonErr != nil {
-					r.err = fmt.Errorf("list parse %d: %v\nraw: %s", i, jsonErr, s)
+					r.err = fmt.Errorf("list parse %d: %v\nstdout:\n%s\nstderr:\n%s", i, jsonErr, s, listStderr.String())
 					results[worker] = r
 					return
 				}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -299,7 +299,7 @@ These flags apply to all commands:
       --profile                   Generate CPU profile for performance analysis
   -q, --quiet                     Suppress non-essential output (errors only)
       --readonly                  Read-only mode: block write operations (for worker sandboxes)
-      --sandbox                   Sandbox mode: disables auto-sync
+      --sandbox                   Sandbox mode: disables Dolt auto-push
   -v, --verbose                   Enable verbose/debug output
 ```
 
@@ -2524,7 +2524,7 @@ Unlike 'bd init --force', bootstrap will never delete existing issues.
 
 Bootstrap auto-detects the right action:
   • If sync.remote is configured: clones from the remote
-  • If git origin has Dolt data (refs/dolt/data): clones from git
+  • If git origin has Dolt data (refs/dolt/data): clones from git and wires origin for future push/pull
   • If .beads/backup/*.jsonl exists: restores from backup
   • If .beads/issues.jsonl exists: imports from git-tracked JSONL
   • If no database exists: creates a fresh one
@@ -2575,7 +2575,8 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv) and git-based sync.
+  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
     export.auto       Enable/disable auto-export (default: true)
@@ -3333,7 +3334,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv) and git-based workflows up to date without extra steps.
+viewers (bv), interchange, and backups up to date without extra steps.
+Cross-machine sync uses Dolt remotes, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
@@ -3818,7 +3820,7 @@ Examples:
   bd doctor --fix -i     # Confirm each fix individually
   bd doctor --fix --fix-child-parent  # Also fix child→parent deps (opt-in)
   bd doctor --fix --force # Force repair even when database can't be opened
-  bd doctor --fix --source=jsonl # Rebuild database from JSONL (source of truth)
+  bd doctor --fix --source=jsonl # Rebuild database from a JSONL export
   bd doctor --dry-run    # Preview what --fix would do without making changes
   bd doctor --perf       # Performance diagnostics
   bd doctor --output diagnostics.json  # Export diagnostics to file

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -342,7 +342,7 @@ Configuration keys use dot-notation namespaces to organize settings:
 - `min_hash_length` - Minimum hash ID length (default: 4)
 - `max_hash_length` - Maximum hash ID length (default: 8)
 - `import.orphan_handling` - How to handle hierarchical issues with missing parents during import (default: `allow`)
-- `export.auto` - Refresh the git-tracked JSONL file after every write command (default: `true`)
+- `export.auto` - Refresh the JSONL export after every write command (default: `true`). This is for viewers, interchange, and backup, not cross-machine sync.
 - `export.path` - Output filename relative to `.beads/` (default: `issues.jsonl`)
 - `export.interval` - Minimum time between auto-exports (default: `60s`)
 - `export.git-add` - Run `git add` on the export file after writing (default: `true`)
@@ -352,6 +352,7 @@ Configuration keys use dot-notation namespaces to organize settings:
 - `export.skip_encoding_errors` - Skip issues that fail JSON encoding (default: false)
 - `export.write_manifest` - Write .manifest.json with export metadata (default: false)
 - `auto_export.error_policy` - Override error policy for auto-exports (default: `best-effort`)
+- `import.auto` - Legacy hook fallback that imports JSONL after git merge/checkout only when no Dolt remote is configured (default: `true`)
 - `sync.branch` - Name of the dedicated sync branch for beads data (see docs/PROTECTED_BRANCHES.md)
 - `sync.require_confirmation_on_mass_delete` - Require interactive confirmation before pushing when >50% of issues vanish during a merge AND more than 5 issues existed before (default: `false`)
 

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -246,8 +246,9 @@ When someone clones a repository that uses Dolt backend:
 
 If `sync.remote` is set in `.beads/config.yaml`, that takes precedence
 over auto-detection. Any Dolt-compatible remote URL is supported (DoltHub,
-S3, GCS, file, or git). `bd init` will warn if it detects `refs/dolt/data`
-on origin and suggest using `bd bootstrap` instead.
+S3, GCS, file, or git). On brand-new projects, `bd init` auto-detects
+`git origin` and persists it as `sync.remote`, so the first `bd dolt push`
+publishes Dolt history to `refs/dolt/data` on the same git remote.
 
 ### Verifying Bootstrap Worked
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -193,7 +193,8 @@ bd ready --json  # Start using bd normally
 All writes go directly to the Dolt database and are automatically committed to Dolt history. To sync with Dolt remotes:
 
 ```bash
-bd init --remote http://myserver:7007/mydb  # Configure remote during first init
+bd init       # Auto-configures git origin as the Dolt remote when present
+# or: bd init --remote http://myserver:7007/mydb  # Explicit non-origin remote
 bd dolt push    # Push changes to Dolt remote
 bd dolt pull    # Pull changes from Dolt remote
 ```

--- a/docs/GIT_INTEGRATION.md
+++ b/docs/GIT_INTEGRATION.md
@@ -37,7 +37,7 @@ Git worktrees share the same `.git` directory and `.beads` database:
 Sync with remotes using Dolt's native push/pull:
 
 ```bash
-bd init --remote http://myserver:7007/mydb  # First setup or clone from a Dolt remote
+bd init         # Auto-wires git origin as a Dolt remote when origin exists
 bd dolt push    # Push changes to Dolt remote
 bd dolt pull    # Pull changes from Dolt remote
 ```
@@ -191,7 +191,9 @@ bd hooks install --beads
 - Runs pre-commit checks for beads data consistency
 
 **post-merge hook:**
-- Ensures Dolt database is current after pull/merge operations
+- Runs chained user hooks, then uses JSONL import only as a legacy fallback
+  when no Dolt remote is configured. With `sync.remote` configured, use
+  `bd dolt pull` for canonical issue sync.
 
 ### Hook Timeout
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -291,7 +291,7 @@ bd setup mux      # Mux - creates/updates AGENTS.md
 - Codex 0.129.0+ uses native `/hooks`: SessionStart injects `bd prime`, compact hooks mark context stale, and the next prompt after compaction refreshes Beads context once
 - `bd prime` provides ~1-2k tokens of workflow context
 - You use `bd` CLI commands directly
-- Git hooks (installed by `bd init`) auto-sync the database
+- Git hooks (installed by `bd init`) refresh exports and legacy fallbacks; `bd dolt push/pull` syncs the database
 - `bd onboard` prints the small manual snippet for unsupported agents or custom instruction files
 
 **Why this is recommended:**

--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -8,7 +8,7 @@ Beads (`bd`) is an issue tracker designed specifically for AI-supervised coding 
 - Track work with a simple CLI
 - Discover and link related tasks during development
 - Maintain context across coding sessions
-- Auto-sync issues via Dolt for distributed workflows
+- Sync issues via Dolt remotes for distributed workflows
 
 ## Installation
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -93,7 +93,7 @@ Creates or updates `AGENTS.md` in your project root with:
 - Issue tracking workflow instructions
 - Quick command reference
 - Issue types and priorities
-- Auto-sync explanation
+- Dolt remote sync explanation
 - Important rules for AI agents
 
 The beads section is wrapped in HTML comments (`<!-- BEGIN/END BEADS INTEGRATION -->`) with metadata for safe updates. The begin marker includes profile and hash metadata (e.g., `<!-- BEGIN BEADS INTEGRATION profile:full hash:d4f96305 -->`) for freshness detection. Legacy markers without metadata are auto-upgraded on the next install or update.

--- a/docs/SYNC_CONCEPTS.md
+++ b/docs/SYNC_CONCEPTS.md
@@ -1,0 +1,67 @@
+# Sync Concepts
+
+Beads issue data lives in Dolt. The local Dolt database is the source of truth
+for `bd list`, `bd show`, `bd ready`, and every write command.
+
+## The Wire Format
+
+Cross-machine sync uses Dolt remotes:
+
+```bash
+bd dolt push
+bd dolt pull
+```
+
+For normal git-hosted projects, the Dolt remote can be the same `origin` URL
+used for source code. Dolt stores issue history under `refs/dolt/data`, separate
+from source branches such as `refs/heads/main`.
+
+On new projects, `bd init` auto-detects `git remote get-url origin` and
+configures a Dolt remote named `origin`. The first `bd dolt push` publishes
+`refs/dolt/data`. Fresh clones should run `bd bootstrap` to clone that Dolt
+history. When bootstrap finds `refs/dolt/data` on git origin, it also wires
+that origin as the Dolt remote for future `bd dolt push` and `bd dolt pull`.
+
+## What JSONL Is For
+
+`.beads/issues.jsonl` is an export. It exists for viewers, interchange,
+migration, and backup. It is not the canonical cross-machine sync channel.
+
+Do not use routine `bd import .beads/issues.jsonl` as a replacement for
+`bd dolt pull`. JSONL import is upsert-only; it cannot infer that records absent
+from an export were deleted, pruned, or simply never exported.
+
+## Hooks
+
+The pre-commit hook refreshes `.beads/issues.jsonl` when `export.auto=true`.
+That keeps the export current for tools, but it does not push Dolt history.
+
+The post-merge and post-checkout hooks skip JSONL import when `sync.remote` is
+configured. For old projects with no Dolt remote, they may import JSONL as a
+compatibility fallback and print a warning that this is not durable sync.
+
+## Repair
+
+For projects initialized before automatic git-origin remote wiring, pick the
+machine with the authoritative local Dolt database first. Then run:
+
+```bash
+bd dolt remote list
+bd export -o .beads/issues.pre-remote.jsonl   # optional audit backup
+bd dolt remote add origin <git-origin-url>
+bd dolt push
+```
+
+Use the Dolt-compatible git URL form when needed. For example,
+`git+ssh://git@github.com/org/repo.git` or
+`git+https://github.com/org/repo.git`. `bd dolt remote add origin ...`
+persists `sync.remote` into `.beads/config.yaml`; commit and push that config
+change so fresh clones can run `bd bootstrap`.
+
+Other machines should then run:
+
+```bash
+bd dolt pull
+# or, if the local database is stale or missing:
+bd bootstrap
+```

--- a/docs/SYNC_SETUP.md
+++ b/docs/SYNC_SETUP.md
@@ -27,7 +27,10 @@ cd your-project
 bd init
 ```
 
-This creates the `.beads/` directory with a Dolt database and starts a background `dolt sql-server`.
+This creates the `.beads/` directory with a Dolt database. If the git repo has
+an `origin` remote, `bd init` also configures a Dolt remote named `origin`
+pointing at that same git URL. Dolt stores issue data under `refs/dolt/data`,
+separate from normal source branches.
 
 ### 2. Create some issues
 
@@ -37,16 +40,24 @@ bd create "Add authentication" -p 2 -t feature
 bd list
 ```
 
-### 3. Add a Dolt remote
+### 3. Verify or add a Dolt remote
 
-Point beads at your Git remote for sync. Dolt stores data under `refs/dolt/data`, separate from your normal Git refs — so you can use the same remote as your source code.
+In a normal git repo with `origin`, this should already be configured:
+
+```bash
+bd dolt remote list
+# Expected: origin  <your git origin URL>
+```
+
+If the repo had no `origin` during init, point beads at your Git remote for
+sync:
 
 ```bash
 # GitHub (SSH — recommended)
 bd dolt remote add origin git+ssh://git@github.com/org/repo.git
 
 # GitHub (HTTPS)
-bd dolt remote add origin https://github.com/org/repo.git
+bd dolt remote add origin git+https://github.com/org/repo.git
 
 # Other options: DoltHub, S3, GCS, local path
 # See DOLT.md for all remote types
@@ -64,6 +75,24 @@ Verify the push worked:
 git ls-remote origin | grep dolt
 # Expected: <hash>  refs/dolt/data
 ```
+
+## Existing Projects Without a Dolt Remote
+
+Projects initialized by older versions of `bd init` may have a local embedded
+Dolt database and a committed `.beads/issues.jsonl`, but no Dolt remote. Fix
+that from the machine whose local database is authoritative:
+
+```bash
+bd dolt remote list
+bd export -o .beads/issues.pre-remote.jsonl   # optional audit backup
+bd dolt remote add origin git+ssh://git@github.com/org/repo.git
+bd dolt push
+```
+
+`bd dolt remote add origin ...` writes `sync.remote` to `.beads/config.yaml`.
+Commit and push that config file with your normal git workflow. Other clones can
+then run `bd bootstrap` if their database is missing/stale, or `bd dolt pull`
+when they already have the right database.
 
 ## Cloning to a New Computer
 
@@ -191,6 +220,7 @@ bd list                            # sees the closed task
 - **Always use `bd dolt ...` commands** — never run raw `dolt` CLI commands while the Dolt server is running. It causes journal corruption.
 - **Commit before pulling** — if you have uncommitted working set changes, `bd dolt pull` will fail with "cannot merge with uncommitted changes". Run `bd dolt commit` first.
 - **Push before switching machines** — unpushed changes only exist locally.
+- **Do not use JSONL as sync** — `.beads/issues.jsonl` is an export for viewers, interchange, and backup. It is not the source of truth and cannot safely reconcile deletes or pruning.
 
 ## Troubleshooting
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -686,7 +686,7 @@ git worktree prune
 
 See [WORKTREES.md](WORKTREES.md) for details on how beads uses worktrees.
 
-### Auto-sync not working
+### Dolt remote sync not working
 
 Check if Dolt server is running and configured:
 
@@ -948,7 +948,7 @@ bd dolt push
 
 | Flag | Purpose | When to use | Risk |
 |------|---------|-------------|------|
-| `--sandbox` | Use embedded mode, disable auto-sync | Sandboxed environments (Codex, containers) | Low - safe for sandboxes |
+| `--sandbox` | Use embedded mode, disable Dolt auto-push | Sandboxed environments (Codex, containers) | Low - safe for sandboxes |
 | `bd doctor --fix` | Force metadata update | Stuck staleness loop | Low - updates metadata only |
 
 **Related:**

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -237,20 +237,17 @@ func Initialize() error {
 	v.SetDefault("backup.git-push", false)
 	v.SetDefault("backup.git-repo", "")
 
-	// Auto-export: write git-tracked JSONL after mutations for portability
-	// When no Dolt remote is configured, this is the primary way to share
-	// beads state (issues + memories) across machines via git.  Enabled by
-	// default so that viewers (bv) and git-based workflows see fresh data
-	// without extra configuration (GH#2973).
+	// Auto-export: write JSONL after mutations for viewers, interchange, and
+	// backup. It is not cross-machine sync; Dolt remotes are the source of
+	// truth for sync. Enabled by default so tools like bv see fresh data.
 	v.SetDefault("export.auto", true)
 	v.SetDefault("export.interval", "60s")
 	v.SetDefault("export.path", "issues.jsonl") // relative to .beads/; canonical name
 	v.SetDefault("export.git-add", true)
 
-	// Auto-import: pull JSONL into Dolt after git merge/checkout so issues
-	// created on other machines enter the local database before the next
-	// auto-export overwrites the JSONL with our (possibly stale) view.
-	// Symmetric to export.auto. Closes the JSONL-in-git sync gap (GH#3729).
+	// Auto-import: legacy compatibility fallback for projects that have not
+	// configured a Dolt remote yet. Hook code skips this path when sync.remote
+	// is configured because JSONL import is upsert-only, not reconciliation.
 	v.SetDefault("import.auto", true)
 
 	// AI configuration defaults

--- a/internal/templates/agents/defaults/beads-section-codex.md
+++ b/internal/templates/agents/defaults/beads-section-codex.md
@@ -17,3 +17,5 @@ bd prime                # Refresh Beads context
 - Use `bd` for all task tracking; do not create markdown TODO lists.
 - Run `bd prime` when Beads context is missing or stale. Codex 0.129.0+ can load Beads context automatically through native hooks; use `/hooks` to inspect or toggle them.
 - Keep persistent project memory in Beads via `bd remember`; do not create ad hoc memory files.
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.

--- a/internal/templates/agents/render_test.go
+++ b/internal/templates/agents/render_test.go
@@ -136,6 +136,8 @@ func TestCodexSectionBody(t *testing.T) {
 		"bd ready",
 		"bd prime",
 		"bd remember",
+		"refs/dolt/data",
+		"SYNC_CONCEPTS.md",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("CodexSectionBody missing %q", want)

--- a/website/docs/cli-reference/bootstrap.md
+++ b/website/docs/cli-reference/bootstrap.md
@@ -15,7 +15,7 @@ Unlike 'bd init --force', bootstrap will never delete existing issues.
 
 Bootstrap auto-detects the right action:
   • If sync.remote is configured: clones from the remote
-  • If git origin has Dolt data (refs/dolt/data): clones from git
+  • If git origin has Dolt data (refs/dolt/data): clones from git and wires origin for future push/pull
   • If .beads/backup/*.jsonl exists: restores from backup
   • If .beads/issues.jsonl exists: imports from git-tracked JSONL
   • If no database exists: creates a fresh one

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -25,7 +25,8 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv) and git-based sync.
+  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
     export.auto       Enable/disable auto-export (default: true)

--- a/website/docs/cli-reference/doctor.md
+++ b/website/docs/cli-reference/doctor.md
@@ -109,7 +109,7 @@ Examples:
   bd doctor --fix -i     # Confirm each fix individually
   bd doctor --fix --fix-child-parent  # Also fix child→parent deps (opt-in)
   bd doctor --fix --force # Force repair even when database can't be opened
-  bd doctor --fix --source=jsonl # Rebuild database from JSONL (source of truth)
+  bd doctor --fix --source=jsonl # Rebuild database from a JSONL export
   bd doctor --dry-run    # Preview what --fix would do without making changes
   bd doctor --perf       # Performance diagnostics
   bd doctor --output diagnostics.json  # Export diagnostics to file

--- a/website/docs/cli-reference/init.md
+++ b/website/docs/cli-reference/init.md
@@ -32,7 +32,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv) and git-based workflows up to date without extra steps.
+viewers (bv), interchange, and backups up to date without extra steps.
+Cross-machine sync uses Dolt remotes, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):

--- a/website/docs/getting-started/ide-setup.md
+++ b/website/docs/getting-started/ide-setup.md
@@ -25,7 +25,7 @@ This installs:
 1. SessionStart hook runs `bd prime` automatically
 2. `bd prime` injects ~1-2k tokens of workflow context
 3. You use `bd` CLI commands directly
-4. Git hooks auto-sync the database
+4. Git hooks refresh exports and legacy fallbacks; Dolt remotes handle sync
 
 **Verify installation:**
 ```bash
@@ -178,7 +178,7 @@ See [MCP Server](/integrations/mcp-server) for detailed configuration.
 
 ## Git Hooks
 
-Ensure git hooks are installed for auto-sync:
+Ensure git hooks are installed for export refresh and legacy fallback behavior:
 
 ```bash
 bd hooks install

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -163,7 +163,7 @@ bd setup mux      # Mux - creates/updates AGENTS.md
 - Codex 0.129.0+ uses native `/hooks` for startup and compaction-aware context refresh
 - `bd prime` provides ~1-2k tokens of workflow context
 - You use `bd` CLI commands directly
-- Git hooks (installed by `bd init`) auto-sync the database
+- Git hooks (installed by `bd init`) refresh exports and legacy fallbacks; `bd dolt push/pull` syncs the database
 - `bd onboard` prints the small manual snippet for unsupported agents or custom instruction files
 
 **Why this is recommended:**

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -251,11 +251,12 @@ bd stats
 
 ## Team sync
 
-Share issues with your team using Dolt remotes. Dolt stores data under `refs/dolt/data` on the same Git remote, separate from standard Git refs.
+Share issues with your team using Dolt remotes. Dolt stores data under `refs/dolt/data` on the same Git remote, separate from standard Git refs. In repos with `origin`, `bd init` configures that Dolt remote automatically.
 
 ```bash
-# Add a remote (GitHub example — also supports DoltHub, S3, GCS, local paths)
-bd dolt remote add origin git+ssh://git@github.com/org/repo.git
+# Verify the remote, or add one if the repo had no origin during init
+bd dolt remote list
+bd dolt remote add origin git+ssh://git@github.com/org/repo.git  # if needed
 
 # Push your issues
 bd dolt push
@@ -264,7 +265,7 @@ bd dolt push
 bd dolt pull
 ```
 
-When a teammate clones the repo, `bd bootstrap` auto-detects the existing database on `refs/dolt/data` and clones it — no manual remote setup needed.
+When a teammate clones the repo, `bd bootstrap` auto-detects the existing database on `refs/dolt/data`, clones it, and wires `origin` for future `bd dolt push` / `bd dolt pull`.
 
 See [`bd dolt`](/cli-reference/dolt) for CLI details. For remote configuration and federation, see the repository docs [DOLT.md](https://github.com/gastownhall/beads/blob/main/docs/DOLT.md) and [FEDERATION-SETUP.md](https://github.com/gastownhall/beads/blob/main/FEDERATION-SETUP.md).
 

--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -89,7 +89,7 @@ bd info  # Shows warnings if hooks are outdated
 bd dolt stop && bd dolt start
 ```
 
-**Why update hooks?** Git hooks are versioned with bd. Outdated hooks may miss new auto-sync features or bug fixes.
+**Why update hooks?** Git hooks are versioned with bd. Outdated hooks may miss export refresh, legacy fallback, or safety fixes.
 
 ## Database Migrations
 
@@ -122,11 +122,30 @@ If you're upgrading from a much older version of bd, your project may use a diff
 
 ### From v0.63.3+ (current era)
 
-No special steps needed. Just upgrade the binary and run:
+Upgrade the binary and run:
 
 ```bash
 bd migrate
 ```
+
+If the project was initialized before `bd init` automatically wired git origin
+as the Dolt remote, verify the remote after upgrading:
+
+```bash
+bd dolt remote list
+```
+
+When the list is empty, fix it on the machine whose local database is
+authoritative:
+
+```bash
+bd export -o .beads/issues.pre-remote.jsonl   # optional audit backup
+bd dolt remote add origin git+ssh://git@github.com/org/repo.git
+bd dolt push
+```
+
+Commit the resulting `.beads/config.yaml` change so other clones can run
+`bd bootstrap` or `bd dolt pull`.
 
 ### From v0.59–v0.63.2 (old embedded)
 

--- a/website/docs/integrations/github-copilot.md
+++ b/website/docs/integrations/github-copilot.md
@@ -136,7 +136,7 @@ bd init --quiet
 
 ### What about git hooks?
 
-Git hooks are optional. They auto-sync issues but you can skip them during `bd init` and manually run `bd dolt push` / `bd dolt pull` instead.
+Git hooks are optional. They refresh exports and legacy fallback checks, while issue sync uses `bd dolt push` / `bd dolt pull`.
 
 ## See Also
 

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -108,7 +108,7 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `backup.interval` | — | `BD_BACKUP_INTERVAL` | `15m` | Minimum time between auto-backups |
 | `backup.git-push` | — | — | `false` | Auto-push backup repo |
 | `backup.git-repo` | — | `BD_BACKUP_GIT_REPO` | (none) | Backup git repo URL |
-| `export.auto` | — | — | `true` | Refresh `.beads/issues.jsonl` after every write |
+| `export.auto` | — | — | `true` | Refresh `.beads/issues.jsonl` export after every write; not cross-machine sync |
 | `export.path` | — | — | `issues.jsonl` | Output filename relative to `.beads/` |
 | `export.interval` | — | — | `60s` | Minimum time between auto-exports |
 | `export.git-add` | — | — | `true` | Run `git add` on the export file |
@@ -210,7 +210,7 @@ backup:
   enabled: true
   interval: 15m
 
-# Auto-export issues.jsonl after writes (default settings shown for clarity)
+# Auto-export issues.jsonl after writes for viewers/interchange/backup
 export:
   auto: true
   path: issues.jsonl

--- a/website/docs/reference/git-integration.md
+++ b/website/docs/reference/git-integration.md
@@ -63,7 +63,7 @@ bd doctor --fix
 
 ## Protected Branches
 
-Dolt stores data under `refs/dolt/data`, separate from Git refs. This means beads data doesn't conflict with protected Git branches — no special branch flag is needed.
+Dolt stores data under `refs/dolt/data`, separate from Git refs. This means beads data doesn't conflict with protected Git branches — no special branch flag is needed. On new projects with a git `origin`, `bd init` configures that origin as the Dolt remote automatically.
 
 ## Git Worktrees
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/bootstrap.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/bootstrap.md
@@ -15,7 +15,7 @@ Unlike 'bd init --force', bootstrap will never delete existing issues.
 
 Bootstrap auto-detects the right action:
   • If sync.remote is configured: clones from the remote
-  • If git origin has Dolt data (refs/dolt/data): clones from git
+  • If git origin has Dolt data (refs/dolt/data): clones from git and wires origin for future push/pull
   • If .beads/backup/*.jsonl exists: restores from backup
   • If .beads/issues.jsonl exists: imports from git-tracked JSONL
   • If no database exists: creates a fresh one

--- a/website/versioned_docs/version-1.0.0/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/config.md
@@ -25,7 +25,8 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv) and git-based sync.
+  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
     export.auto       Enable/disable auto-export (default: true)

--- a/website/versioned_docs/version-1.0.0/cli-reference/doctor.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/doctor.md
@@ -109,7 +109,7 @@ Examples:
   bd doctor --fix -i     # Confirm each fix individually
   bd doctor --fix --fix-child-parent  # Also fix child→parent deps (opt-in)
   bd doctor --fix --force # Force repair even when database can't be opened
-  bd doctor --fix --source=jsonl # Rebuild database from JSONL (source of truth)
+  bd doctor --fix --source=jsonl # Rebuild database from a JSONL export
   bd doctor --dry-run    # Preview what --fix would do without making changes
   bd doctor --perf       # Performance diagnostics
   bd doctor --output diagnostics.json  # Export diagnostics to file

--- a/website/versioned_docs/version-1.0.0/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/init.md
@@ -32,7 +32,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv) and git-based workflows up to date without extra steps.
+viewers (bv), interchange, and backups up to date without extra steps.
+Cross-machine sync uses Dolt remotes, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):

--- a/website/versioned_docs/version-1.0.4/cli-reference/bootstrap.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/bootstrap.md
@@ -15,7 +15,7 @@ Unlike 'bd init --force', bootstrap will never delete existing issues.
 
 Bootstrap auto-detects the right action:
   • If sync.remote is configured: clones from the remote
-  • If git origin has Dolt data (refs/dolt/data): clones from git
+  • If git origin has Dolt data (refs/dolt/data): clones from git and wires origin for future push/pull
   • If .beads/backup/*.jsonl exists: restores from backup
   • If .beads/issues.jsonl exists: imports from git-tracked JSONL
   • If no database exists: creates a fresh one

--- a/website/versioned_docs/version-1.0.4/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/config.md
@@ -25,7 +25,8 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv) and git-based sync.
+  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
     export.auto       Enable/disable auto-export (default: true)

--- a/website/versioned_docs/version-1.0.4/cli-reference/doctor.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/doctor.md
@@ -109,7 +109,7 @@ Examples:
   bd doctor --fix -i     # Confirm each fix individually
   bd doctor --fix --fix-child-parent  # Also fix child→parent deps (opt-in)
   bd doctor --fix --force # Force repair even when database can't be opened
-  bd doctor --fix --source=jsonl # Rebuild database from JSONL (source of truth)
+  bd doctor --fix --source=jsonl # Rebuild database from a JSONL export
   bd doctor --dry-run    # Preview what --fix would do without making changes
   bd doctor --perf       # Performance diagnostics
   bd doctor --output diagnostics.json  # Export diagnostics to file

--- a/website/versioned_docs/version-1.0.4/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/init.md
@@ -32,7 +32,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv) and git-based workflows up to date without extra steps.
+viewers (bv), interchange, and backups up to date without extra steps.
+Cross-machine sync uses Dolt remotes, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):


### PR DESCRIPTION
## Summary

- Configure `bd init` to synthesize a Dolt `origin` remote from the repo's git `origin` when no explicit `sync.remote` is set, and persist it as `sync.remote` so fresh clones/bootstrap use Dolt instead of JSONL.
- Preserve opt-outs and explicit behavior: `--stealth` skips git-origin synthesis, explicit/configured remotes keep precedence, and explicit empty `--remote` still opts out.
- Fix the bootstrap-side gap from #3419: when `bd bootstrap` auto-detects `refs/dolt/data` on git origin, the cloned workspace now also has `origin` wired for future `bd dolt push/pull`.
- Treat `.beads/issues.jsonl` as export/interchange/backup only: JSONL auto-import is skipped when `sync.remote` exists, and auto-export/hooks warn loudly when no Dolt remote is configured.
- Update docs, generated CLI docs, website docs, and agent templates to name Dolt/`refs/dolt/data` as the sync channel, including an explicit repair path for existing pre-fix projects.

## Context

This implements the durable default proposed in #3688: use the existing git remote as the Dolt remote via `refs/dolt/data` rather than leaving new embedded-Dolt projects with only local state.

It also clarifies the architecture confusion captured in #3135: Dolt is the source of truth for `bd list/show/ready` and writes; `.beads/issues.jsonl` is not canonical sync.

#3729's post-merge JSONL import path remains only as a legacy fallback. It is not treated as sufficient sync because JSONL import is upsert-only and cannot reconcile deletes, pruning, or stale local-only records.

#3419 is covered as the fresh-clone counterpart: `bd bootstrap` now rehydrates the remote after cloning from git origin, matching the workaround described by @thewoolleyman but without requiring a manual `bd dolt remote add` on the second machine.

## Existing Project Repair Path

For projects initialized before this change, use the machine whose local Dolt database is authoritative:

```bash
bd dolt remote list
bd export -o .beads/issues.pre-remote.jsonl   # optional audit backup
bd dolt remote add origin git+ssh://git@github.com/org/repo.git
bd dolt push
```

Then commit/push the resulting `.beads/config.yaml` with `sync.remote`. Other clones can run `bd bootstrap` if stale/missing, or `bd dolt pull` when they already have the right database.

## Tests

- `go test -tags gms_pure_go ./cmd/bd`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -v -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedInit/(git_origin_registered_as_dolt_remote|stealth_skips_git_origin_remote_synthesis)'`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -v -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedBootstrap/bootstrap_from_git_origin_wires_remote'`
- `go test -tags gms_pure_go ./internal/templates/agents`
- `go test -tags gms_pure_go ./cmd/bd -run 'TestShouldWireInitRemote|TestImportJSONLForSync_GuardClauses'`
- `make check-docs`
- `make fmt-check`
- `git diff --check`

_codex-gpt-5-xhigh on behalf of maphew_
