### PR TITLE
fix(update): clear external_ref to SQL NULL when --external-ref ""

### DIFF
--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -126,7 +126,14 @@ create, update, show, or close operation).`,
 		}
 		if cmd.Flags().Changed("external-ref") {
 			externalRef, _ := cmd.Flags().GetString("external-ref")
-			updates["external_ref"] = externalRef
+			// Empty string clears the ref to SQL NULL, mirroring buildCreateIssue's
+			// nil-when-empty pointer semantics so cleared refs round-trip as a
+			// missing field (omitempty) instead of an empty string. GH#3902.
+			if externalRef == "" {
+				updates["external_ref"] = nil
+			} else {
+				updates["external_ref"] = externalRef
+			}
 		}
 		if cmd.Flags().Changed("spec-id") {
 			specID, _ := cmd.Flags().GetString("spec-id")

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -268,6 +268,36 @@ func TestEmbeddedUpdate(t *testing.T) {
 		}
 	})
 
+	// GH#3902: --external-ref "" must clear to SQL NULL (matching buildCreateIssue's
+	// pointer semantics), not write an empty string. Otherwise sync/tracker code
+	// that checks ExternalRef == nil silently misclassifies cleared refs as still
+	// tracked, and two cleared issues round-trip with different JSON shapes
+	// (cleared via CLI emits "external_ref":"" while never-set issues omit the field).
+	t.Run("update_external_ref_clear", func(t *testing.T) {
+		a := bdCreate(t, bd, dir, "ExtRef clear A", "--type", "task", "--external-ref", "ref-a")
+		b := bdCreate(t, bd, dir, "ExtRef clear B", "--type", "task", "--external-ref", "ref-b")
+
+		bdUpdate(t, bd, dir, a.ID, "--external-ref", "")
+		// Repeat clear must succeed for a second issue — historical UNIQUE
+		// constraint repro from the issue report.
+		bdUpdate(t, bd, dir, b.ID, "--external-ref", "")
+
+		gotA := bdShow(t, bd, dir, a.ID)
+		gotB := bdShow(t, bd, dir, b.ID)
+		if gotA.ExternalRef != nil {
+			t.Errorf("expected A.external_ref to be nil after clear, got %q", *gotA.ExternalRef)
+		}
+		if gotB.ExternalRef != nil {
+			t.Errorf("expected B.external_ref to be nil after clear, got %q", *gotB.ExternalRef)
+		}
+
+		// JSON output: cleared ref should be omitted via omitempty, not emitted as "".
+		rawA := bdShowJSON(t, bd, dir, a.ID)
+		if strings.Contains(rawA, `"external_ref"`) {
+			t.Errorf("expected external_ref field to be omitted from JSON after clear, got: %s", rawA)
+		}
+	})
+
 	t.Run("update_spec_id", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "SpecID test", "--type", "task")
 		bdUpdate(t, bd, dir, issue.ID, "--spec-id", "RFC-007")

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -396,7 +396,11 @@ func applyUpdatesToIssueStruct(issue *types.Issue, updates map[string]interface{
 				issue.AcceptanceCriteria = v
 			}
 		case "external_ref":
-			if v, ok := value.(string); ok {
+			// nil clears the ref (CLI passes nil for --external-ref ""); non-nil
+			// string sets it. GH#3902.
+			if value == nil {
+				issue.ExternalRef = nil
+			} else if v, ok := value.(string); ok {
 				issue.ExternalRef = &v
 			}
 		case "spec_id":


### PR DESCRIPTION
Closes #3902.

## Summary

`bd update <id> --external-ref ""` was writing an empty string into the `external_ref` column instead of SQL NULL, leaving the database with two semantically different "no external ref" states.

`bd create` already does the right thing — `buildCreateIssue` converts an empty `ExternalRef` to a nil `*string` so newly created issues round-trip as NULL. The update path never mirrored that conversion. This PR makes the two paths consistent.

## Why this matters

- `internal/tracker/engine.go` treats `localIssue.ExternalRef == nil` as "not linked" and compares the empty string as a real value, so a cleared ref looked like a link to a non-existent record.
- `types.Issue.ExternalRef` is `*string` with `json:",omitempty"`, so cleared issues emitted `"external_ref":""` while never-set issues omitted the field entirely.
- The historical `UNIQUE` constraint repro in the issue only stopped firing because the SQLite backend that had the constraint was removed; the empty-string semantic mismatch was the durable bug.

## Changes

- **`cmd/bd/update.go`**: when `--external-ref` is set to `""`, store nil in the updates map. The SQL driver translates nil to NULL.
- **`internal/storage/dolt/ephemeral_routing.go`**: `applyUpdatesToIssueStruct` (used on wisp/no_history flips) previously ignored a nil value because the `value.(string)` type assertion failed silently, leaving in-memory `ExternalRef` at its prior value. Handle nil explicitly so the wisp-flip path agrees with the regular update path.
- **`cmd/bd/update_embedded_test.go`**: new `update_external_ref_clear` subtest verifies that
  - clearing two refs in a row succeeds (the historical UNIQUE repro),
  - `ExternalRef` reads back as nil, and
  - the JSON output omits the field rather than emitting `"external_ref":""`.

## Test plan

- [x] `go vet -tags gms_pure_go ./cmd/bd/ ./internal/storage/dolt/` — clean
- [x] `go build -tags gms_pure_go ./cmd/bd` — clean
- [x] `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go -run 'TestEmbeddedUpdate/update_external_ref' ./cmd/bd/` — passes (existing + new subtest)
- [ ] CI (full test matrix on Linux/macOS, lint)

Made with [Cursor](https://cursor.com)