### PR TITLE
docs(list): warn that repeated -s/--status silently overwrites (#3916)

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -1067,7 +1067,7 @@ var listCmd = &cobra.Command{
 }
 
 func init() {
-	listCmd.Flags().StringP("status", "s", "", "Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress")
+	listCmd.Flags().StringP("status", "s", "", "Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.")
 	listCmd.Flags().String("state", "", "Alias for --status")
 	_ = listCmd.Flags().MarkHidden("state")
 	registerPriorityFlag(listCmd, "")

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -923,7 +923,7 @@ bd list [flags]
   -r, --reverse                      Reverse sort order
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)

--- a/website/docs/cli-reference/list.md
+++ b/website/docs/cli-reference/list.md
@@ -66,7 +66,7 @@ bd list [flags]
   -r, --reverse                      Reverse sort order
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)

--- a/website/versioned_docs/version-1.0.0/cli-reference/list.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/list.md
@@ -66,7 +66,7 @@ bd list [flags]
   -r, --reverse                      Reverse sort order
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)

--- a/website/versioned_docs/version-1.0.4/cli-reference/list.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/list.md
@@ -66,7 +66,7 @@ bd list [flags]
   -r, --reverse                      Reverse sort order
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)


### PR DESCRIPTION
## Summary

`bd list -s/--status` is non-repeatable: `bd list --status open --status in_progress` silently keeps only the last value and returns only `in_progress` matches, with no warning. The flag is registered as a single-value string, so cobra silently overwrites on each occurrence.

This PR adds a one-sentence help-text warning documenting the behavior and pointing users at the comma-separated form, which is the supported way to filter multiple statuses. Smaller of two viable fix shapes — see #3916 for the semantic-fix alternative (`StringSliceP`) which is left for maintainer call.

Closes #3916.

## Changes

- `cmd/bd/list.go`: 1-line addition to the `-s/--status` help text noting repeated flags silently overwrite; canonical form is `--status open,in_progress`.
- 4 regenerated CLI doc files reflecting the new help text.

## Test plan

- [x] `bash -n cmd/bd/list.go` clean
- [x] `make check-docs` PASS (regenerated docs match)
- [x] `go build ./...` clean (CGO_ENABLED=0 -tags gms_pure_go)
- [x] `./bd list --help` shows the new warning text under `-s/--status`
- Baseline noise: `TestCheckHooksDriftNotGitRepo` (full-suite flake) and `go vet ./...` warnings in `internal/storage/embeddeddolt` + `internal/tracker` reproduce identically on `origin/main` with this branch stashed — pre-existing, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
