### PR TITLE
schema: migration progress output + large-rig warning (be-ldr)

### DIFF
--- a/internal/storage/schema/progress_test.go
+++ b/internal/storage/schema/progress_test.go
@@ -1,0 +1,107 @@
+package schema
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestEmitLargeRigNotice covers the be-8ja large-rig warning branch. The
+// fresh-install case (count reported via error, typically "table doesn't
+// exist") must stay silent — that's the UX contract: on a first-ever bd run,
+// there is no rig to warn about.
+func TestEmitLargeRigNotice(t *testing.T) {
+	cases := []struct {
+		name      string
+		count     int64
+		countErr  error
+		wantEmpty bool
+		wantSub   string
+	}{
+		{
+			name:      "fresh_install_table_missing",
+			count:     0,
+			countErr:  errors.New("Table 'issues' doesn't exist"),
+			wantEmpty: true,
+		},
+		{
+			name:      "small_rig_below_threshold",
+			count:     9_999,
+			countErr:  nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "at_threshold_no_warning",
+			count:     10_000,
+			countErr:  nil,
+			wantEmpty: true,
+		},
+		{
+			name:    "one_past_threshold_warns",
+			count:   10_001,
+			wantSub: "Large rig detected (10001 issues)",
+		},
+		{
+			name:    "typical_large_rig",
+			count:   49_187,
+			wantSub: "Large rig detected (49187 issues)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			emitLargeRigNotice(&buf, tc.count, tc.countErr)
+
+			got := buf.String()
+			if tc.wantEmpty {
+				if got != "" {
+					t.Errorf("want no output, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantSub) {
+				t.Errorf("want substring %q; got %q", tc.wantSub, got)
+			}
+			if !strings.Contains(got, "do not interrupt") {
+				t.Errorf("warning missing operator guidance; got %q", got)
+			}
+			if !strings.HasSuffix(got, "\n") {
+				t.Errorf("warning must end with newline; got %q", got)
+			}
+		})
+	}
+}
+
+// TestHumanMigrationName pins the filename → display-name mapping for the
+// per-migration progress line. The be-8ja progress output MUST be stable and
+// human-readable; regression here would change operator-visible text.
+func TestHumanMigrationName(t *testing.T) {
+	cases := map[string]string{
+		"0033_add_date_indexes.up.sql":          "add_date_indexes",
+		"0001_initial.up.sql":                   "initial",
+		"0027_add_started_at.up.sql":            "add_started_at",
+		"noversion.up.sql":                      "noversion",
+		"0099_multi_word_migration_name.up.sql": "multi_word_migration_name",
+	}
+	for in, want := range cases {
+		if got := humanMigrationName(in); got != want {
+			t.Errorf("humanMigrationName(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+// TestProgressOutDefaultsToStderr guards the be-8ja invariant that the
+// package-level writer starts pointed at os.Stderr. A regression here would
+// silently leak migration progress into stdout and break bd <anything> --json
+// pipelines — exactly the failure mode the bead called out.
+func TestProgressOutDefaultsToStderr(t *testing.T) {
+	if progressOut == nil {
+		t.Fatal("progressOut must not be nil")
+	}
+	// Package-level default must be os.Stderr so stdout-sensitive consumers
+	// (bd list --json | jq, etc.) stay unpolluted. We don't pin the pointer
+	// identity here — tests swap progressOut via a helper — but a nil or
+	// stdout-bound default would be a regression worth catching.
+}

--- a/internal/storage/schema/progress_test.go
+++ b/internal/storage/schema/progress_test.go
@@ -92,16 +92,8 @@ func TestHumanMigrationName(t *testing.T) {
 	}
 }
 
-// TestProgressOutDefaultsToStderr guards the be-8ja invariant that the
-// package-level writer starts pointed at os.Stderr. A regression here would
-// silently leak migration progress into stdout and break bd <anything> --json
-// pipelines — exactly the failure mode the bead called out.
-func TestProgressOutDefaultsToStderr(t *testing.T) {
-	if progressOut == nil {
-		t.Fatal("progressOut must not be nil")
-	}
-	// Package-level default must be os.Stderr so stdout-sensitive consumers
-	// (bd list --json | jq, etc.) stay unpolluted. We don't pin the pointer
-	// identity here — tests swap progressOut via a helper — but a nil or
-	// stdout-bound default would be a regression worth catching.
-}
+// Note: be-8ja's original TestProgressOutDefaultsToStderr (pinning a
+// package-level progressOut default) doesn't apply after the #3919 slim —
+// this branch reuses main's existing `stderr` writer (see defaultStderr,
+// TTY-gated), landed independently by #3914. That invariant is exercised by
+// #3914's own tests, not duplicated here.

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -35,6 +35,47 @@ func defaultStderr() io.Writer {
 	return io.Discard
 }
 
+// progressOut is where migration progress lines are written. Defaults to
+// os.Stderr so that JSON pipelines on stdout (e.g. bd list --json | jq) are
+// not polluted. Unexported so tests in this package can swap it without
+// leaking a setter into production API.
+var progressOut io.Writer = os.Stderr
+
+const largeRigThreshold = 10000
+
+// issueRowCounter returns the current issues-table row count, or an error if
+// the table is unreachable (fresh install → table doesn't exist yet). The
+// caller uses the error as the "no warning" signal. Variable so tests in this
+// package that exercise runMigrations against a non-DB mock can stub out the
+// query without panicking on QueryRowContext.
+var issueRowCounter = func(ctx context.Context, db DBConn) (int64, error) {
+	var n int64
+	err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues").Scan(&n)
+	return n, err
+}
+
+// emitLargeRigNotice writes the one-line large-rig warning to out when the
+// issues count exceeds largeRigThreshold. An error from the counter is
+// treated as "fresh install / table missing" and suppresses the warning —
+// see be-8ja for the UX rationale.
+func emitLargeRigNotice(out io.Writer, count int64, err error) {
+	if err != nil || count <= largeRigThreshold {
+		return
+	}
+	fmt.Fprintf(out, "Large rig detected (%d issues). This migration may take up to 90 seconds; do not interrupt.\n", count)
+}
+
+// humanMigrationName turns "0033_add_date_indexes.up.sql" into
+// "add_date_indexes" for the progress line.
+func humanMigrationName(filename string) string {
+	s := strings.TrimSuffix(filename, ".up.sql")
+	parts := strings.SplitN(s, "_", 2)
+	if len(parts) < 2 {
+		return s
+	}
+	return parts[1]
+}
+
 // DBConn is the minimal interface satisfied by *sql.DB, *sql.Tx, and *sql.Conn.
 // It provides query and exec methods needed by the migration runner.
 type DBConn interface {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -1172,14 +1172,21 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 		upTo = src.latest()
 	}
 
-	// One-shot large-rig notice, ahead of the migration loop below. Treats a
-	// missing issues table as "fresh install" and emits nothing — on a
-	// first-ever run there is no rig to warn about, and the COUNT(*) query
-	// would error on the missing table. issueRowCounter/emitLargeRigNotice
-	// predate this call site (be-8ja); this just threads them onto main's
-	// existing TTY-gated `stderr` writer instead of a second progressOut.
-	rowCount, rowCountErr := issueRowCounter(ctx, db)
-	emitLargeRigNotice(stderr, rowCount, rowCountErr)
+	// One-shot large-rig notice, ahead of the migration loop below — gated to
+	// the main-source pass only. MigrateUp calls runMigrations once for
+	// mainSource and once for ignoredSource in the same pass; without this
+	// gate a large rig with pending migrations in both sources would print
+	// the warning twice (and issue the COUNT(*) query twice) despite the
+	// "one-shot" framing. Treats a missing issues table as "fresh install"
+	// and emits nothing — on a first-ever run there is no rig to warn about,
+	// and the COUNT(*) query would error on the missing table.
+	// issueRowCounter/emitLargeRigNotice predate this call site (be-8ja);
+	// this just threads them onto main's existing TTY-gated `stderr` writer
+	// instead of a second progressOut.
+	if src.cursorTable == mainSource.cursorTable {
+		rowCount, rowCountErr := issueRowCounter(ctx, db)
+		emitLargeRigNotice(stderr, rowCount, rowCountErr)
+	}
 
 	count := 0
 	for _, mf := range src.list() {
@@ -1227,14 +1234,21 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 		if _, err := db.ExecContext(ctx, "INSERT IGNORE INTO "+src.cursorTable+" (version, content_hash) VALUES (?, ?)", mf.version, contentHash); err != nil {
 			return count, fmt.Errorf("recording %s in %s: %w", mf.name, src.cursorTable, err)
 		}
-		fmt.Fprintf(stderr, "  done (%.1fs)\n", time.Since(start).Seconds())
 		count++
 
+		// commitEachStep's DOLT_ADD/DOLT_COMMIT is the expensive, fallible
+		// part of this step on the production embedded path. The "done" line
+		// (and its timing) must land after that commit succeeds, not before
+		// it: printing "done" and then hitting a commit error would show an
+		// operator a false completion, and timing that stopped before the
+		// commit would understate the step's real cost. A failed commit
+		// returns before either print statement below runs.
 		if commitEachStep {
 			if err := commitMigrationStep(ctx, db, src.cursorTable, mf.name, dirtyBeforeStep); err != nil {
 				return count, fmt.Errorf("committing migration %s: %w", mf.name, err)
 			}
 		}
+		fmt.Fprintf(stderr, "  done (%.1fs)\n", time.Since(start).Seconds())
 
 		if migrateStepFaultHook != nil {
 			if err := migrateStepFaultHook(ctx, db, mf.version); err != nil {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage/dberrors"
 	"golang.org/x/term"
@@ -34,12 +35,6 @@ func defaultStderr() io.Writer {
 	}
 	return io.Discard
 }
-
-// progressOut is where migration progress lines are written. Defaults to
-// os.Stderr so that JSON pipelines on stdout (e.g. bd list --json | jq) are
-// not polluted. Unexported so tests in this package can swap it without
-// leaking a setter into production API.
-var progressOut io.Writer = os.Stderr
 
 const largeRigThreshold = 10000
 
@@ -1176,6 +1171,16 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 	if upTo == 0 {
 		upTo = src.latest()
 	}
+
+	// One-shot large-rig notice, ahead of the migration loop below. Treats a
+	// missing issues table as "fresh install" and emits nothing — on a
+	// first-ever run there is no rig to warn about, and the COUNT(*) query
+	// would error on the missing table. issueRowCounter/emitLargeRigNotice
+	// predate this call site (be-8ja); this just threads them onto main's
+	// existing TTY-gated `stderr` writer instead of a second progressOut.
+	rowCount, rowCountErr := issueRowCounter(ctx, db)
+	emitLargeRigNotice(stderr, rowCount, rowCountErr)
+
 	count := 0
 	for _, mf := range src.list() {
 		if mf.version <= minVersion || mf.version > upTo {
@@ -1212,7 +1217,8 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 			return count, fmt.Errorf("pre-repair for migration %s: %w", mf.name, err)
 		}
 
-		fmt.Fprintf(stderr, "migrating schema: %s\n", mf.name)
+		fmt.Fprintf(stderr, "Applying migration %04d: %s…\n", mf.version, humanMigrationName(mf.name))
+		start := time.Now()
 		if _, err := db.ExecContext(ctx, string(data)); err != nil {
 			return count, fmt.Errorf("migration %s: %w", mf.name, err)
 		}
@@ -1221,6 +1227,7 @@ func runMigrations(ctx context.Context, db DBConn, src migrationSource, minVersi
 		if _, err := db.ExecContext(ctx, "INSERT IGNORE INTO "+src.cursorTable+" (version, content_hash) VALUES (?, ?)", mf.version, contentHash); err != nil {
 			return count, fmt.Errorf("recording %s in %s: %w", mf.name, src.cursorTable, err)
 		}
+		fmt.Fprintf(stderr, "  done (%.1fs)\n", time.Since(start).Seconds())
 		count++
 
 		if commitEachStep {

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1984,3 +1984,39 @@ func TestRunMigrationsUsesProvidedSource(t *testing.T) {
 		t.Errorf("runMigrations ignored its source argument: main and ignored both returned %d", main)
 	}
 }
+
+// TestRunMigrationsLargeRigNoticeOnlyOnMainSource pins the round-2 review
+// fix: MigrateUp calls runMigrations once for mainSource and once for
+// ignoredSource in the same pass (schema.go's MigrateUp). Without gating the
+// large-rig notice to the main-source pass, a large rig with pending
+// migrations in both sources would print the "one-shot" warning twice (and
+// issue the COUNT(*) query twice). The notice must fire on the mainSource
+// call and stay silent on the ignoredSource call.
+func TestRunMigrationsLargeRigNoticeOnlyOnMainSource(t *testing.T) {
+	origCounter := issueRowCounter
+	issueRowCounter = func(context.Context, DBConn) (int64, error) { return 49_187, nil }
+	defer func() { issueRowCounter = origCounter }()
+
+	var mainBuf bytes.Buffer
+	orig := stderr
+	stderr = &mainBuf
+	if _, err := runMigrations(context.Background(), &mockDB{}, mainSource, 0, 46, false); err != nil {
+		stderr = orig
+		t.Fatalf("runMigrations(mainSource): %v", err)
+	}
+	if !strings.Contains(mainBuf.String(), "Large rig detected") {
+		stderr = orig
+		t.Errorf("expected mainSource pass to emit the large-rig notice; got: %q", mainBuf.String())
+	}
+
+	var ignoredBuf bytes.Buffer
+	stderr = &ignoredBuf
+	_, err := runMigrations(context.Background(), &mockDB{}, ignoredSource, 0, 46, false)
+	stderr = orig
+	if err != nil {
+		t.Fatalf("runMigrations(ignoredSource): %v", err)
+	}
+	if strings.Contains(ignoredBuf.String(), "Large rig detected") {
+		t.Errorf("expected ignoredSource pass to stay silent on the large-rig notice (main-source pass already warned); got: %q", ignoredBuf.String())
+	}
+}

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1910,11 +1910,19 @@ func TestRunMigrationsStderrOutput(t *testing.T) {
 	stderr = &buf
 	defer func() { stderr = orig }()
 
+	// mockDB.QueryRowContext panics, so stub issueRowCounter (be-8ja's
+	// large-rig check, which now runs unconditionally at the top of
+	// runMigrations) to report a small rig — no warning line, so this test's
+	// line-count assertion stays scoped to the per-migration progress lines.
+	origCounter := issueRowCounter
+	issueRowCounter = func(context.Context, DBConn) (int64, error) { return 0, nil }
+	defer func() { issueRowCounter = origCounter }()
+
 	// Bounded below migration 47: that version's preMigrationRepair (and 53's)
 	// issues real INFORMATION_SCHEMA probes (see
 	// TestPreMigrationRepairScopedToMain0047 /
 	// TestPreMigrationRepairScopedToMain0053), which mockDB.QueryRowContext
-	// doesn't support. This test only exercises the stderr line, not the
+	// doesn't support. This test only exercises the stderr lines, not the
 	// repair path.
 	n, err := runMigrations(context.Background(), &mockDB{}, mainSource, 0, 46, false)
 	if err != nil {
@@ -1925,12 +1933,16 @@ func TestRunMigrationsStderrOutput(t *testing.T) {
 	}
 
 	got := buf.String()
-	if !strings.Contains(got, "migrating schema: ") {
-		t.Errorf("expected stderr to contain 'migrating schema: ', got: %q", got)
+	if !strings.Contains(got, "Applying migration ") {
+		t.Errorf("expected stderr to contain 'Applying migration ', got: %q", got)
 	}
+	if !strings.Contains(got, "  done (") {
+		t.Errorf("expected stderr to contain a '  done (Ns)' timing line, got: %q", got)
+	}
+	// One "Applying" line + one "done" line per migration.
 	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
-	if len(lines) != n {
-		t.Errorf("expected %d stderr lines, got %d", n, len(lines))
+	if len(lines) != 2*n {
+		t.Errorf("expected %d stderr lines (2 per migration), got %d", 2*n, len(lines))
 	}
 }
 
@@ -1942,6 +1954,12 @@ func TestRunMigrationsUsesProvidedSource(t *testing.T) {
 	orig := stderr
 	stderr = &bytes.Buffer{}
 	defer func() { stderr = orig }()
+
+	// Stub the large-rig row counter for the same reason as
+	// TestRunMigrationsStderrOutput: mockDB.QueryRowContext panics.
+	origCounter := issueRowCounter
+	issueRowCounter = func(context.Context, DBConn) (int64, error) { return 0, nil }
+	defer func() { issueRowCounter = origCounter }()
 
 	// Bounded below migration 47 for the same reason as
 	// TestRunMigrationsStderrOutput: mockDB can't answer the real


### PR DESCRIPTION
## Maintainer edit (2026-07-23): slimmed to the pieces #3914 doesn't cover

`bd` now writes per-migration progress lines to stderr as it runs `MigrateUp`. Each line names the migration and reports how long it took:

```
Applying migration 0033: add_date_indexes…
  done (0.1s)
```

On databases with more than 10 000 issues, a one-shot warning fires before the first migration: "Large rig detected (N issues). This migration may take up to 90 seconds; do not interrupt."

Output goes to the same stderr writer #3914 already uses (TTY-gated — piped/non-terminal stderr stays silent, so `bd list --json | jq` etc. are unaffected). Fresh installs where the issues table does not yet exist suppress the warning — `COUNT(*)` errors are treated as "no issues, no warning needed."

**Why this PR was rebased and slimmed rather than merged as-is:** this PR's core progress-visibility feature (a package-level `progressOut` writer, printing a migration name to stderr) was superseded on `main` by #3914 — same author, same intent, landed independently with a different, TTY-gated mechanism (`stderr` var + `defaultStderr()`), plus a `preMigrationRepair`/`commitEachStep` evolution of `runMigrations` this branch predates. Rebasing this PR as-is would have reintroduced a second, parallel progress writer and reverted #3914's TTY gating and the newer `runMigrations` machinery.

What survives here is only what #3914 does **not** cover, verified absent from current `main` before doing this work:

- (a) the large-rig warning before slow migrations (`emitLargeRigNotice` / `issueRowCounter` / `largeRigThreshold`)
- (b) per-migration timing output (`done (N.Ns)`)
- (c) human-readable migration names (`humanMigrationName`, e.g. `add_date_indexes` instead of the raw filename)

These are layered onto #3914's existing `stderr` writer — no second writer, no change to `preMigrationRepair` threading or `commitEachStep`. Net diff: ~171 lines, mostly a new test file (`progress_test.go`), touching only `internal/storage/schema/schema.go` and its tests.

Quad341's original acceptance-criteria commits (`ce9d6e04`, `602ea7c4`) are preserved verbatim as the first commit; a second, separately-authored commit does the #3914-compatible wiring and updates the two existing `runMigrations` mock-DB tests that would otherwise panic on the new `issueRowCounter` call.

---

## Original PR description (quad341)

`bd` now writes per-migration progress lines to stderr as it runs `MigrateUp`. Each line names the migration and reports how long it took:

```
Applying migration 0033: add_date_indexes…
  done (0.1s)
```

On databases with more than 10 000 issues, a one-shot warning fires before the first migration: "Large rig detected (N issues). This migration may take up to 90 seconds; do not interrupt."

Output goes to stderr so it does not pollute stdout pipelines (`bd list --json | jq` etc.). Fresh installs where the issues table does not yet exist suppress the warning — `COUNT(*)` errors are treated as "no issues, no warning needed."

### Review notes

- `largeRigThreshold = 10000` — triggers at **strictly greater than** 10 000 (not at 10 000 exactly; test `at_threshold_no_warning` covers this)
- `issueRowCounter` var — stubbed in tests so schema tests don't need a live DB
- The 90-second estimate in the warning text is a conservative ceiling for typical large-rig schema runs; not enforced by code

### Test plan

- [x] `go build -tags gms_pure_go ./...` — clean
- [x] `go vet -tags gms_pure_go ./...` — clean
- [x] `go test -tags gms_pure_go -count=1 -run 'Migrat' ./internal/storage/schema/...` — PASS (7.0s)
- [x] `gofmt -l internal/storage/schema/` — clean

This is a rebase of PR #3780 (closed) onto current main after PR #3871 removed the `tolerateExisting` bool from `runMigrations`, then slimmed on 2026-07-23 after #3914 landed the progress-line subset independently.
