### PR TITLE
fix(github) bd github sync (GitHub issues integration)

### DIFF
--- a/internal/github/tracker.go
+++ b/internal/github/tracker.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
@@ -194,7 +195,23 @@ func (t *Tracker) BuildExternalRef(issue *tracker.TrackerIssue) string {
 }
 
 // getConfig reads a config value from storage, falling back to env var.
+// For yaml-only keys (e.g. github.token), reads from config.yaml first
+// to match the behavior of cmd/bd/github.go:getGitHubConfigValue().
 func (t *Tracker) getConfig(ctx context.Context, key, envVar string) string {
+	// Secret keys are stored in config.yaml, not the Dolt database,
+	// to avoid leaking secrets when pushing to remotes.
+	if config.IsYamlOnlyKey(key) {
+		if val := config.GetString(key); val != "" {
+			return val
+		}
+		if envVar != "" {
+			if envVal := os.Getenv(envVar); envVal != "" {
+				return envVal
+			}
+		}
+		return ""
+	}
+
 	val, err := t.store.GetConfig(ctx, key)
 	if err == nil && val != "" {
 		return val

--- a/internal/github/tracker_test.go
+++ b/internal/github/tracker_test.go
@@ -2,10 +2,13 @@ package github
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/tracker"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -283,6 +286,51 @@ func TestGetConfig_YamlOnlyKeyBypassesStore(t *testing.T) {
 			t.Errorf("getConfig(github.token) = %q, want empty", got)
 		}
 	})
+}
+
+// TestGetConfig_YamlOnlyKeyReadsFromYaml is the positive case for the fix:
+// when github.token is present in .beads/config.yaml, getConfig must return
+// that value (and not depend on GITHUB_TOKEN being set). This is the primary
+// behavior the PR restores; the BypassesStore test only proves the env-var
+// fallback path. Together they cover both branches of the yaml-only handler.
+func TestGetConfig_YamlOnlyKeyReadsFromYaml(t *testing.T) {
+	const wantToken = "yaml-config-token-value"
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	yamlBody := "github.token: \"" + wantToken + "\"\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(yamlBody), 0o600); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+
+	// Isolate from the developer's environment so we read only the temp yaml.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	t.Setenv("HOME", filepath.Join(tmpDir, "home"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
+	t.Chdir(tmpDir)
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+
+	// Sanity-check that the yaml actually loaded — otherwise a getConfig
+	// failure could be mistaken for a tracker bug.
+	if got := config.GetString("github.token"); got != wantToken {
+		t.Fatalf("config.GetString(github.token) = %q, want %q (yaml not loaded?)", got, wantToken)
+	}
+
+	tr := &Tracker{store: nil}
+	got := tr.getConfig(context.Background(), "github.token", "GITHUB_TOKEN")
+	if got != wantToken {
+		t.Errorf("getConfig(github.token) = %q, want %q (yaml value)", got, wantToken)
+	}
 }
 
 func TestValidate(t *testing.T) {

--- a/internal/github/tracker_test.go
+++ b/internal/github/tracker_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -252,6 +253,36 @@ func TestFieldMapperIssueToBeads_NilRaw(t *testing.T) {
 	if conv != nil {
 		t.Error("IssueToBeads with nil Raw should return nil")
 	}
+}
+
+// TestGetConfig_YamlOnlyKeyBypassesStore is a regression test for the bug where
+// `bd github sync` errored "GitHub token not configured" even though the token
+// was set in .beads/config.yaml. The github tracker's getConfig used to read
+// every key from the Dolt store, but github.token is a yaml-only secret key
+// (never written to the DB). The fix routes yaml-only keys through config.yaml
+// and env var, skipping the store entirely.
+//
+// We verify the store-bypass by passing a nil store: before the fix this would
+// panic on the store deref; after the fix it falls through to GITHUB_TOKEN.
+func TestGetConfig_YamlOnlyKeyBypassesStore(t *testing.T) {
+	ctx := context.Background()
+	tr := &Tracker{store: nil}
+
+	t.Run("falls back to env var", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "env-token-value")
+		got := tr.getConfig(ctx, "github.token", "GITHUB_TOKEN")
+		if got != "env-token-value" {
+			t.Errorf("getConfig(github.token) = %q, want %q", got, "env-token-value")
+		}
+	})
+
+	t.Run("returns empty when no value is set", func(t *testing.T) {
+		t.Setenv("GITHUB_TOKEN", "")
+		got := tr.getConfig(ctx, "github.token", "GITHUB_TOKEN")
+		if got != "" {
+			t.Errorf("getConfig(github.token) = %q, want empty", got)
+		}
+	})
 }
 
 func TestValidate(t *testing.T) {


### PR DESCRIPTION

Fixed: `bd github sync now` reads `github.token` from `.bead/config.yaml` correctly, by borrowing the pattern already set in the Linear integration.

## What

internal/github/tracker.go:Init called t.getConfig(...), which only checked t.store.GetConfig (Dolt DB) and the env var

github.token is a yaml-only secret key (per internal/config/yaml_config.go:73), so it's never in the DB. The yaml lookup was missing.


## How

Mirror the pattern already used by internal/linear/tracker.go and cmd/bd/github.go:getGitHubConfigValue(): check config.IsYamlOnlyKey first and read from config.yaml for those keys.

Also adds TestGetConfig_YamlOnlyKeyBypassesStore: constructs a Tracker with a nil store and verifies getConfig still resolves github.token via env-var fallback — proof that yaml-only keys no longer deref the store. Without the fix this test would panic on the nil store.

## Why

```sh
bd github sync
Error: initializing GitHub tracker: GitHub token not configured (set github.token or GITHUB_TOKEN)
```

The github tracker's getConfig() only checked store.GetConfig (Dolt DB) and the env var, but github.token is a yaml-only secret key and is never stored in the DB. As a result, `bd github sync` errored with "GitHub token not configured" even when the token was correctly set in .beads/config.yaml via `bd config set github.token <token>`.

## Verification

```
bd config set github.user your-username
bd config set github.repo your-repo
bd config set github.token "github_pat_1234" # your GH PAT
```

## TODO

* check if the same bug exists in the jira, gitlab, ado, and notion integration/trackers
