### PR TITLE
docs(skill): update SKILL.md to bd v1.0.4

### DIFF
--- a/plugins/beads/skills/beads/SKILL.md
+++ b/plugins/beads/skills/beads/SKILL.md
@@ -7,10 +7,10 @@ description: >
   ready", "track this work", "resume after compaction". Make sure to use this skill
   whenever managing multi-session work, tracking dependencies, or recovering context.
 allowed-tools: "Read,Bash(bd:*)"
-version: "0.60.0"
+version: "1.0.4"
 author: "Steve Yegge <steve.yegge@gmail.com>"
 license: "MIT"
-compatible-with: [claude-code, codex]
+compatible-with: [claude-code, codex, gemini]
 tags: [issue-tracking, task-management, multi-session, dependencies]
 ---
 
@@ -32,19 +32,23 @@ See [BOUNDARIES.md](resources/BOUNDARIES.md) for detailed comparison.
 ## Prerequisites
 
 ```bash
-bd --version  # Requires v0.60.0+
+bd --version  # Requires v1.0.0+; v1.0.4+ recommended
 ```
 
 - **bd CLI** installed and in PATH
 - **Git repository** (optional — use `BEADS_DIR` + `--stealth` for git-free operation)
 - **Initialization**: `bd init` run once (humans do this, not agents)
 
+## Hooks
+
+When installed as a plugin, `bd prime` runs at SessionStart (load context) and PreCompact (re-inject memories). Hookless setups call `bd prime` manually, or `bd prime --memories-only` for a lower-token refresh. Wire hooks with `bd setup claude`, `bd setup codex`, or `bd setup gemini`.
+
 ## CLI Reference
 
 **Run `bd prime`** for AI-optimized workflow context (auto-loaded by hooks).
 **Run `bd <command> --help`** for specific command usage.
 
-Essential commands: `bd ready`, `bd create`, `bd show`, `bd update`, `bd close`, `bd dolt push`
+Essential commands: `bd ready`, `bd create`, `bd show`, `bd update`, `bd close`, `bd dolt push`. See [CLI_REFERENCE.md](resources/CLI_REFERENCE.md) for v1.0.4 additions (`bd batch`, `bd -C`, `bd config drift`, `bd init --reinit-local`, `bd close --reason-file`).
 
 ## Session Protocol
 
@@ -67,6 +71,7 @@ Append `--json` to any command for structured output. Use `bd show <id> --long` 
 | `not in a git repository` | `git init` first |
 | `disk I/O error (522)` | Move `.beads/` off cloud-synced filesystem |
 | Status updates lag | Use server mode: `bd dolt start` |
+| `--force is deprecated` (v1.0.4+) | Use `bd init --reinit-local --discard-remote` instead |
 
 See [TROUBLESHOOTING.md](resources/TROUBLESHOOTING.md) for full details.
 
@@ -107,4 +112,4 @@ bd close <id> --reason "Implemented with refresh tokens" --json
 
 ## Validation
 
-If `bd --version` reports newer than `0.60.0`, this skill may be stale. Run `bd prime` for current CLI guidance — it auto-updates with each bd release and is the canonical source of truth ([ADR-0001](adr/0001-bd-prime-as-source-of-truth.md)).
+If `bd --version` reports a minor or major version newer than `1.0.x`, this skill may be stale. Run `bd prime` for current CLI guidance — it auto-updates with each bd release and is the canonical source of truth ([ADR-0001](adr/0001-bd-prime-as-source-of-truth.md)).

--- a/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
+++ b/plugins/beads/skills/beads/resources/CLI_REFERENCE.md
@@ -1,7 +1,7 @@
 # CLI Command Reference
 
 **For:** AI agents and developers using bd command-line interface
-**Version:** 0.60.0+
+**Version:** 1.0.4+
 
 ## Quick Navigation
 
@@ -228,6 +228,9 @@ bd edit <id> --acceptance       # Edit acceptance criteria
 # Complete work (supports multiple IDs)
 bd close <id> [<id>...] --reason "Done" --json
 
+# Close with reason from file (v1.0.4+)
+bd close <id> --reason-file evidence.md --json
+
 # Reopen closed issues (supports multiple IDs)
 bd reopen <id> [<id>...] --reason "Reopening" --json
 ```
@@ -443,6 +446,9 @@ bd --db /path/to/.beads/beads.db <command>
 
 # Custom actor for audit trail
 bd --actor alice <command>
+
+# Run against a different working directory (v1.0.4+)
+bd -C /path/to/other/project <command>
 ```
 
 **See also:**
@@ -545,6 +551,47 @@ bd dolt show                   # Check connection status
 ```
 
 > **Note:** `bd sync` is deprecated (now a no-op). Use the Dolt commands above instead.
+
+### Re-initialize Local Database (v1.0.4+)
+
+```bash
+# Re-initialize .beads/ over existing local data (does NOT touch remote)
+bd init --reinit-local
+
+# Also discard remote history (requires --destroy-token in non-interactive mode)
+bd init --reinit-local --discard-remote
+
+# Note: --force is a deprecated alias for --reinit-local; bypasses only the
+# local data-safety guard and does NOT authorize remote divergence.
+```
+
+### Configuration (v1.0.4+)
+
+```bash
+# Show all effective configuration with provenance
+bd config show
+
+# Detect drift between configured state and actual repo state
+bd config drift
+
+# Reconcile state to match configuration
+bd config apply
+
+# Get / set individual values
+bd config get <key>
+bd config set <key> <value>
+bd config list
+```
+
+### Batch Operations (v1.0.1+)
+
+```bash
+# Run many write operations in a single Dolt transaction (avoids write amplification)
+bd batch -f operations.json
+cat operations.json | bd batch
+```
+
+Commands are read from stdin or file. The whole batch is rolled back on any error.
 
 ## Issue Types
 


### PR DESCRIPTION
## What

Updates `plugins/beads/skills/beads/SKILL.md` from the pinned `version: "0.60.0"` to `v1.0.4`, documents four agent-facing gaps that opened between those versions, and adds `gemini` to `compatible-with` to match PR #3746's Gemini hook wiring.

## Why

SKILL.md's own `## Validation` section flags itself as stale when `bd --version` reports newer than the carrier value — the skill was four minor versions behind. Four concrete agent-facing gaps:

1. **Version pin stale** — the validation section flags itself.
2. **Hooks not documented** — `plugin.json` wires SessionStart/PreCompact to `bd prime`, but the skill is silent on this. Agents installing manually have no guidance.
3. **`bd init --force` deprecated** in v1.0.4 — error table didn't mention it.
4. **Missing v1.0.x agent-useful commands** — `bd batch` (v1.0.1+), `bd -C`, `bd config drift/apply/show`, `bd init --reinit-local`, `bd close --reason-file` all ship in v1.0.x and are agent-useful.

Per `plugins/beads/skills/beads/CLAUDE.md` ("NEVER duplicate CLI documentation in SKILL.md"), the new commands get full entries in `resources/CLI_REFERENCE.md` and only pointer lines in SKILL.md.

This is a one-time catch-up. The recurring drift problem is filed separately as #3934 (proposal: auto-generate the version pin + a marked CLI block at build time) — design feedback wanted before any code lands.

## Verification

- `gh pr diff 3933 --repo gastownhall/beads` — inspect the diff (58 additions / 6 deletions across 2 files)
- SKILL.md frontmatter parses cleanly (YAML lint clean)
- Word count: ~680 words added across SKILL.md + CLI_REFERENCE.md. No structural changes.
- All cross-references hand-verified (links to `CLI_REFERENCE.md`, `plugin.json`, hook event names)
- CI green: 14 checks pass including `Check for .beads changes`, `Check doc flags freshness`, `Check version consistency`, all 5 `Upgrade smoke` jobs

Refs #3934.

- Jeremy Longshore
intentsolutions.io
