### PR TITLE
test: separate stdout/stderr in count and swarm embedded helpers

### DIFF
--- a/cmd/bd/count_embedded_test.go
+++ b/cmd/bd/count_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,17 +14,21 @@ import (
 )
 
 // bdCount runs "bd count" with the given args and returns raw stdout.
+// Stderr (warnings, tips) is captured separately so it does not pollute
+// callers that parse stdout.
 func bdCount(t *testing.T, bd, dir string, args ...string) string {
 	t.Helper()
 	fullArgs := append([]string{"count"}, args...)
 	cmd := exec.Command(bd, fullArgs...)
 	cmd.Dir = dir
 	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("bd count %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd count %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
-	return string(out)
+	return stdout.String()
 }
 
 // bdCountFail runs "bd count" expecting failure.
@@ -41,24 +46,27 @@ func bdCountFail(t *testing.T, bd, dir string, args ...string) string {
 }
 
 // bdCountJSON runs "bd count --json" and parses the result.
+// Stderr is captured separately so warnings do not corrupt JSON parsing.
 func bdCountJSON(t *testing.T, bd, dir string, args ...string) map[string]interface{} {
 	t.Helper()
 	fullArgs := append([]string{"count", "--json"}, args...)
 	cmd := exec.Command(bd, fullArgs...)
 	cmd.Dir = dir
 	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("bd count --json %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd count --json %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
-	s := strings.TrimSpace(string(out))
+	s := strings.TrimSpace(stdout.String())
 	start := strings.IndexAny(s, "{")
 	if start < 0 {
-		t.Fatalf("no JSON object in count output: %s", s)
+		t.Fatalf("no JSON object in count output: %s\nstderr:\n%s", s, stderr.String())
 	}
 	var m map[string]interface{}
 	if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
-		t.Fatalf("parse count JSON: %v\n%s", err, s)
+		t.Fatalf("parse count JSON: %v\n%s\nstderr:\n%s", err, s, stderr.String())
 	}
 	return m
 }
@@ -519,24 +527,26 @@ func TestEmbeddedCountConcurrent(t *testing.T) {
 			cmd := exec.Command(bd, args...)
 			cmd.Dir = dir
 			cmd.Env = bdEnv(dir)
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				r.err = fmt.Errorf("worker %d count %v: %v\n%s", worker, q, err, out)
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				r.err = fmt.Errorf("worker %d count %v: %v\nstdout:\n%s\nstderr:\n%s", worker, q, err, stdout.String(), stderr.String())
 				results[worker] = r
 				return
 			}
 
-			// Verify JSON is parseable
-			s := strings.TrimSpace(string(out))
+			// Verify JSON is parseable (parse stdout only; stderr may carry warnings).
+			s := strings.TrimSpace(stdout.String())
 			start := strings.IndexAny(s, "{")
 			if start < 0 {
-				r.err = fmt.Errorf("worker %d: no JSON in output: %s", worker, s)
+				r.err = fmt.Errorf("worker %d: no JSON in stdout: %s\nstderr: %s", worker, s, stderr.String())
 				results[worker] = r
 				return
 			}
 			var m map[string]interface{}
 			if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
-				r.err = fmt.Errorf("worker %d: JSON parse: %v\n%s", worker, err, s)
+				r.err = fmt.Errorf("worker %d: JSON parse: %v\nstdout: %s\nstderr: %s", worker, err, s, stderr.String())
 				results[worker] = r
 				return
 			}

--- a/cmd/bd/swarm_embedded_test.go
+++ b/cmd/bd/swarm_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,17 +14,21 @@ import (
 )
 
 // bdSwarm runs "bd swarm" with the given args and returns raw stdout.
+// Stderr (warnings, tips) is captured separately so it does not pollute
+// callers that parse stdout.
 func bdSwarm(t *testing.T, bd, dir string, args ...string) string {
 	t.Helper()
 	fullArgs := append([]string{"swarm"}, args...)
 	cmd := exec.Command(bd, fullArgs...)
 	cmd.Dir = dir
 	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("bd swarm %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd swarm %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
-	return string(out)
+	return stdout.String()
 }
 
 // bdSwarmFail runs "bd swarm" expecting failure.
@@ -41,6 +46,7 @@ func bdSwarmFail(t *testing.T, bd, dir string, args ...string) string {
 }
 
 // bdSwarmJSON runs "bd swarm" with --json and parses the result as a map.
+// Stderr is captured separately so warnings do not corrupt JSON parsing.
 func bdSwarmJSON(t *testing.T, bd, dir string, args ...string) map[string]interface{} {
 	t.Helper()
 	fullArgs := append([]string{"swarm"}, args...)
@@ -48,18 +54,20 @@ func bdSwarmJSON(t *testing.T, bd, dir string, args ...string) map[string]interf
 	cmd := exec.Command(bd, fullArgs...)
 	cmd.Dir = dir
 	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("bd swarm --json %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd swarm --json %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
-	s := strings.TrimSpace(string(out))
+	s := strings.TrimSpace(stdout.String())
 	start := strings.IndexAny(s, "{[")
 	if start < 0 {
-		t.Fatalf("no JSON in swarm output: %s", s)
+		t.Fatalf("no JSON in swarm stdout: %s\nstderr:\n%s", s, stderr.String())
 	}
 	var m map[string]interface{}
 	if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
-		t.Fatalf("parse swarm JSON: %v\n%s", err, s)
+		t.Fatalf("parse swarm JSON: %v\n%s\nstderr:\n%s", err, s, stderr.String())
 	}
 	return m
 }
@@ -213,14 +221,16 @@ func TestEmbeddedSwarm(t *testing.T) {
 		cmd := exec.Command(bd, fullArgs...)
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("swarm list --json failed: %v\n%s", err, out)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("swarm list --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 		}
-		// Should be valid JSON
-		s := strings.TrimSpace(string(out))
+		// Should be valid JSON on stdout (warnings, if any, are on stderr).
+		s := strings.TrimSpace(stdout.String())
 		if !strings.HasPrefix(s, "{") && !strings.HasPrefix(s, "[") {
-			t.Errorf("expected JSON output: %s", s)
+			t.Errorf("expected JSON output on stdout: %s\nstderr: %s", s, stderr.String())
 		}
 	})
 


### PR DESCRIPTION
## Problem

Upstream main CI is failing on two embedded-Dolt shards:

- `Test (Embedded Dolt Cmd 5/20)` — `TestEmbeddedCount/filter_by_id`
- `Test (Embedded Dolt Cmd 11/20)` — `TestEmbeddedSwarm/create_coordinator`

Both fail because the helpers use `exec.CombinedOutput()` to read command output and then parse it as JSON / issue ID. The new auto-export warnings introduced in #3909 correctly emit on stderr (e.g. `beads: .beads/issues.jsonl is an export, not cross-machine sync...`) but get merged into the same buffer the test parses.

## Fix

Apply the same stdout/stderr separation pattern that #3909 already applied to the `close`, `create`, `gate`, `init`, `list`, `quick`, and `update` embedded test helpers, but now to:

- `bdCount`, `bdCountJSON`
- `TestEmbeddedCountConcurrent` worker
- `bdSwarm`, `bdSwarmJSON`
- `TestEmbeddedSwarm/list_json` subtest

`bdCountFail` and `bdSwarmFail` keep `CombinedOutput` (they only assert non-zero exit and surface diagnostics, no parsing). `TestEmbeddedSwarmConcurrent` worker keeps `CombinedOutput` (only matches expected error strings).

## Verification

```
BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 \
  go test -tags gms_pure_go \
  -run '^TestEmbeddedCount$|^TestEmbeddedCountConcurrent$|^TestEmbeddedSwarm$|^TestEmbeddedSwarmConcurrent$' \
  -timeout 600s ./cmd/bd/
ok  github.com/steveyegge/beads/cmd/bd  98.722s
```

The originally-failing subtests now pass:

- `TestEmbeddedCount/filter_by_id` ✓ (0.54s)
- `TestEmbeddedSwarm/create_coordinator` ✓ (6.33s)

_amp-claude-sonnet-4.5 on behalf of CI Bot_