### PR TITLE
fix(schema): use dynamic column intersection in migration 0035

### DIFF
--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
@@ -1,5 +1,26 @@
-INSERT IGNORE INTO issues SELECT * FROM wisps
-WHERE issue_type IN ('agent', 'rig', 'role', 'message');
+-- Move infra-type rows from wisps back into issues using the intersection
+-- of columns common to both tables. See up migration for rationale.
+SET SESSION group_concat_max_len = 32768;
+SET @cols = (
+    SELECT GROUP_CONCAT(COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ',')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'issues'
+      AND COLUMN_NAME IN (
+          SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps'
+      )
+);
+SET @sql = IF(
+    @cols IS NOT NULL AND @cols <> '',
+    CONCAT(
+        'INSERT IGNORE INTO issues (', @cols, ') ',
+        'SELECT ', @cols, ' FROM wisps ',
+        'WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')'
+    ),
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 UPDATE issues SET ephemeral = 0
 WHERE issue_type IN ('agent', 'rig', 'role', 'message');

--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
@@ -1,7 +1,26 @@
+-- Move infra-type rows from issues into wisps using the intersection of
+-- columns common to both tables. Using SELECT * crashes on upgraded DBs
+-- where the two tables have drifted (e.g. 0033 added wisp_type and 0034
+-- added spec_id to issues only). Mirrors the fix in #2168 / commit
+-- 4891d870f for the Go predecessor migration 007.
+SET SESSION group_concat_max_len = 32768;
+SET @cols = (
+    SELECT GROUP_CONCAT(COLUMN_NAME ORDER BY ORDINAL_POSITION SEPARATOR ',')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisps'
+      AND COLUMN_NAME IN (
+          SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'issues'
+      )
+);
 SET @sql = IF(
-    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
-        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisps') > 0,
-    'INSERT IGNORE INTO wisps SELECT * FROM issues WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    @cols IS NOT NULL AND @cols <> '',
+    CONCAT(
+        'INSERT IGNORE INTO wisps (', @cols, ') ',
+        'SELECT ', @cols, ' FROM issues ',
+        'WHERE issue_type IN (''agent'', ''rig'', ''role'', ''message'')'
+    ),
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## What

rewrites the two SELECT * lines in migration 0035 (up and down) to use INFORMATION_SCHEMA-driven dynamic column intersection via GROUP_CONCAT + PREPARE/EXECUTE.

## Why

Fixes #3938.

migration 0035 (move infra-type rows from issues to wisps) fails with Error 1105 on databases upgraded across the asymmetric column additions in 0033 (wisp_type) and 0034 (spec_id) - SELECT * pulls a different column count than the target accepts. Dolt v2's stricter MySQL semantics reject the mismatch.

same bug class was fixed for the Go predecessor migration 007 in commit 4891d870f (PR #2168) and returned when 007 was rewritten as SQL. down has the symmetric pattern, fixed the same way.

approach mirrors the existing INFORMATION_SCHEMA + PREPARE pattern already used in migrations 0023, 0027, 0033, 0034, 0037, 0038 - so this isn't introducing a new shape, just applying the existing convention where it was missing.

## Verification

reproduced and fixed against an upgraded DB locally:

- before: migration cursor stuck at 34, every `bd` write fails with `failed to initialize schema: ... Error 1105 (HY000): number of values does not match number of columns provided`
- after: chain advances cleanly through 0040, `bd create` succeeds, `bd list` continues to work

column counts on my DB confirmed asymmetric (issues=49, wisps=55). fix moves rows via the intersection of common columns; doesn't touch the table schemas themselves.

scope is intentionally narrow - just the two broken statements. flagged in #3938 that a chain-replay regression test would catch the next instance of this class (third occurrence after #758, #2168), but that's separate work with its own design decisions about test infra. happy to take that on as a follow-up if it'd be useful.
