### PR TITLE
fix(dolt): adopt git origin on first push

### DIFF
--- a/cmd/bd/doctor/remotes.go
+++ b/cmd/bd/doctor/remotes.go
@@ -1,15 +1,23 @@
 package doctor
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltremote"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+)
+
+var (
+	querySQLRemotesForDoctor = querySQLRemotes
+	listCLIRemotesForDoctor  = doltutil.ListCLIRemotes
 )
 
 // CheckRemoteConsistency compares remotes registered in the SQL server
@@ -29,7 +37,7 @@ func CheckRemoteConsistency(repoPath string) DoctorCheck {
 	}
 
 	// Get SQL remotes via direct connection
-	sqlRemotes, sqlErr := querySQLRemotes(beadsDir)
+	sqlRemotes, sqlErr := querySQLRemotesForDoctor(beadsDir)
 	if sqlErr != nil {
 		return DoctorCheck{
 			Name:     "Remote Consistency",
@@ -43,7 +51,7 @@ func CheckRemoteConsistency(repoPath string) DoctorCheck {
 	doltDir := doltserver.ResolveDoltDir(beadsDir)
 	dbName := cfg.GetDoltDatabase()
 	dbDir := filepath.Join(doltDir, dbName)
-	cliRemotes, cliErr := doltutil.ListCLIRemotes(dbDir)
+	cliRemotes, cliErr := listCLIRemotesForDoctor(dbDir)
 	if cliErr != nil {
 		return DoctorCheck{
 			Name:     "Remote Consistency",
@@ -123,32 +131,21 @@ func CheckRemoteConsistency(repoPath string) DoctorCheck {
 
 func remoteAdoptionDetail(repoPath string) string {
 	if originURL := gitOriginRemoteURL(repoPath); originURL != "" {
-		remoteURL := normalizeGitOriginForDolt(originURL)
+		remoteURL := doltremote.Normalize(originURL)
 		return fmt.Sprintf("git origin is configured. Adopt it with: bd dolt remote add origin %s", remoteURL)
 	}
 	return "Add a remote with: bd dolt remote add origin <url>"
 }
 
 func gitOriginRemoteURL(repoPath string) string {
-	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "remote", "get-url", "origin")
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
-}
-
-func normalizeGitOriginForDolt(url string) string {
-	if strings.HasPrefix(url, "git+") || strings.HasPrefix(url, "file://") || strings.HasPrefix(url, "aws://") || strings.HasPrefix(url, "gs://") || strings.HasPrefix(url, "dolthub://") {
-		return url
-	}
-	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "ssh://") {
-		return "git+" + url
-	}
-	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") && strings.Contains(url, "@") {
-		return "git+ssh://" + url[:idx] + "/" + url[idx+1:]
-	}
-	return url
 }
 
 // querySQLRemotes gets remotes from the SQL server.

--- a/cmd/bd/doctor/remotes.go
+++ b/cmd/bd/doctor/remotes.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -58,7 +59,7 @@ func CheckRemoteConsistency(repoPath string) DoctorCheck {
 			Name:     "Remote Consistency",
 			Status:   StatusWarning,
 			Message:  "No remotes configured",
-			Detail:   "Add a remote with: bd dolt remote add origin <url>",
+			Detail:   remoteAdoptionDetail(repoPath),
 			Category: CategoryData,
 		}
 	}
@@ -118,6 +119,36 @@ func CheckRemoteConsistency(repoPath string) DoctorCheck {
 		Fix:      fix,
 		Category: CategoryData,
 	}
+}
+
+func remoteAdoptionDetail(repoPath string) string {
+	if originURL := gitOriginRemoteURL(repoPath); originURL != "" {
+		remoteURL := normalizeGitOriginForDolt(originURL)
+		return fmt.Sprintf("git origin is configured. Adopt it with: bd dolt remote add origin %s", remoteURL)
+	}
+	return "Add a remote with: bd dolt remote add origin <url>"
+}
+
+func gitOriginRemoteURL(repoPath string) string {
+	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func normalizeGitOriginForDolt(url string) string {
+	if strings.HasPrefix(url, "git+") || strings.HasPrefix(url, "file://") || strings.HasPrefix(url, "aws://") || strings.HasPrefix(url, "gs://") || strings.HasPrefix(url, "dolthub://") {
+		return url
+	}
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "ssh://") {
+		return "git+" + url
+	}
+	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") && strings.Contains(url, "@") {
+		return "git+ssh://" + url[:idx] + "/" + url[idx+1:]
+	}
+	return url
 }
 
 // querySQLRemotes gets remotes from the SQL server.

--- a/cmd/bd/doctor/remotes_test.go
+++ b/cmd/bd/doctor/remotes_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
 )
 
 func TestCheckRemoteConsistency_WorktreeFallbackUsesSharedConfig(t *testing.T) {
@@ -55,6 +56,52 @@ func TestRemoteAdoptionDetailUsesGitOrigin(t *testing.T) {
 		if !strings.Contains(detail, want) {
 			t.Fatalf("remote adoption detail missing %q:\n%s", want, detail)
 		}
+	}
+}
+
+func TestCheckRemoteConsistencyNoRemotesIncludesGitOriginAdoptionDetail(t *testing.T) {
+	clearResolveBeadsDirCache()
+	t.Cleanup(clearResolveBeadsDirCache)
+
+	repoDir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"remote", "add", "origin", "git@github.com:org/repo.git"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %v\n%s", args[0], err, out)
+		}
+	}
+
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads: %v", err)
+	}
+	if err := (&configfile.Config{}).Save(beadsDir); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	oldQuerySQLRemotes := querySQLRemotesForDoctor
+	oldListCLIRemotes := listCLIRemotesForDoctor
+	t.Cleanup(func() {
+		querySQLRemotesForDoctor = oldQuerySQLRemotes
+		listCLIRemotesForDoctor = oldListCLIRemotes
+	})
+	querySQLRemotesForDoctor = func(string) ([]storage.RemoteInfo, error) {
+		return nil, nil
+	}
+	listCLIRemotesForDoctor = func(string) ([]storage.RemoteInfo, error) {
+		return nil, nil
+	}
+
+	check := CheckRemoteConsistency(repoDir)
+	if check.Status != StatusWarning {
+		t.Fatalf("expected warning when no remotes are configured, got %q: %s", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Detail, "bd dolt remote add origin git+ssh://git@github.com/org/repo.git") {
+		t.Fatalf("remote consistency detail missing git origin adoption command:\n%s", check.Detail)
 	}
 }
 

--- a/cmd/bd/doctor/remotes_test.go
+++ b/cmd/bd/doctor/remotes_test.go
@@ -2,7 +2,9 @@ package doctor
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/configfile"
@@ -29,5 +31,36 @@ func TestCheckRemoteConsistency_WorktreeFallbackUsesSharedConfig(t *testing.T) {
 	}
 	if check.Message == "N/A (not using Dolt backend)" {
 		t.Fatalf("expected shared worktree config to be used, got %q", check.Message)
+	}
+}
+
+func TestRemoteAdoptionDetailUsesGitOrigin(t *testing.T) {
+	repoDir := t.TempDir()
+	for _, args := range [][]string{
+		{"init"},
+		{"remote", "add", "origin", "git@github.com:org/repo.git"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s failed: %v\n%s", args[0], err, out)
+		}
+	}
+
+	detail := remoteAdoptionDetail(repoDir)
+	for _, want := range []string{
+		"git origin is configured",
+		"bd dolt remote add origin git+ssh://git@github.com/org/repo.git",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("remote adoption detail missing %q:\n%s", want, detail)
+		}
+	}
+}
+
+func TestRemoteAdoptionDetailWithoutGitOrigin(t *testing.T) {
+	detail := remoteAdoptionDetail(t.TempDir())
+	if !strings.Contains(detail, "bd dolt remote add origin <url>") {
+		t.Fatalf("remote adoption detail without git origin should keep generic command, got:\n%s", detail)
 	}
 }

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -176,6 +176,44 @@ func printNoRemoteGuidance() {
 	fmt.Println("  • Azure Blob Storage: az://account.blob.core.windows.net/container/path")
 }
 
+func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage) (bool, error) {
+	remotes, err := st.ListRemotes(ctx)
+	if err != nil {
+		return false, err
+	}
+	if len(remotes) > 0 {
+		return false, nil
+	}
+	originURL, err := gitOriginGetURLForActiveRepo(ctx)
+	if err != nil || originURL == "" {
+		return false, nil
+	}
+	remoteURL := normalizeRemoteURL(originURL)
+	if err := st.AddRemote(ctx, "origin", remoteURL); err != nil {
+		return false, err
+	}
+
+	if usesSQLServer() {
+		if locator, ok := storage.UnwrapStore(st).(storage.StoreLocator); ok {
+			if dbPath := locator.CLIDir(); dbPath != "" && doltutil.FindCLIRemote(dbPath, "origin") == "" {
+				if err := doltutil.AddCLIRemote(dbPath, "origin", remoteURL); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: SQL remote added but CLI remote failed: %v\n", err)
+				}
+			}
+		}
+	}
+
+	beadsDir := selectedDoltBeadsDir()
+	if beadsDir == "" {
+		return false, fmt.Errorf("no active beads workspace")
+	}
+	if err := config.SetYamlConfigInDir(beadsDir, "sync.remote", remoteURL); err != nil {
+		return false, fmt.Errorf("failed to persist sync.remote to config.yaml: %w", err)
+	}
+	commitBeadsConfigForActiveRepo(ctx, "bd: update sync.remote")
+	return true, nil
+}
+
 // printDivergedHistoryGuidance prints recovery guidance when push/pull fails
 // due to diverged local and remote histories.
 func printDivergedHistoryGuidance(operation string) {
@@ -239,6 +277,12 @@ The remote must already exist (see 'bd dolt remote add').`,
 			}
 			fmt.Println("Push complete.")
 			return
+		}
+		if adopted, err := adoptGitOriginRemoteForPush(ctx, st); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to adopt git origin as Dolt remote: %v\n", err)
+			os.Exit(1)
+		} else if adopted {
+			fmt.Println("Configured Dolt remote origin from git origin.")
 		}
 		fmt.Println("Pushing to Dolt remote...")
 

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -184,6 +184,10 @@ func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage) (b
 	if len(remotes) > 0 {
 		return false, nil
 	}
+	beadsDir := selectedDoltBeadsDir()
+	if beadsDir == "" {
+		return false, fmt.Errorf("no active beads workspace")
+	}
 	originURL, err := gitOriginGetURLForActiveRepo(ctx)
 	if err != nil || originURL == "" {
 		return false, nil
@@ -203,10 +207,6 @@ func adoptGitOriginRemoteForPush(ctx context.Context, st storage.DoltStorage) (b
 		}
 	}
 
-	beadsDir := selectedDoltBeadsDir()
-	if beadsDir == "" {
-		return false, fmt.Errorf("no active beads workspace")
-	}
 	if err := config.SetYamlConfigInDir(beadsDir, "sync.remote", remoteURL); err != nil {
 		return false, fmt.Errorf("failed to persist sync.remote to config.yaml: %w", err)
 	}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1995,8 +1995,7 @@ func printInitNoDoltRemoteWarning() {
 		return
 	}
 	fmt.Fprintln(os.Stderr, "  To enable durable sync, add a git origin and then run:")
-	fmt.Fprintf(os.Stderr, "    %s\n", ui.RenderAccent("bd dolt remote add origin <git-remote-url>"))
-	fmt.Fprintf(os.Stderr, "    %s\n\n", ui.RenderAccent("bd dolt push"))
+	fmt.Fprintf(os.Stderr, "    %s\n", ui.RenderAccent("bd dolt push"))
 }
 
 type initSyncRemoteSource int

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -376,6 +376,103 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("no_git_origin_stays_local", func(t *testing.T) {
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+
+		runBDInit(t, bd, dir, "--prefix", "local", "--skip-hooks", "--skip-agents")
+
+		out := bdDolt(t, bd, dir, "remote", "list")
+		if strings.Contains(out, "origin") {
+			t.Fatalf("init without git origin should not configure a Dolt remote; remote list:\n%s", out)
+		}
+
+		configYAML, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if strings.Contains(string(configYAML), "sync.remote:") || strings.Contains(string(configYAML), "sync-remote:") {
+			t.Fatalf("init without git origin should not persist sync.remote; config.yaml:\n%s", configYAML)
+		}
+	})
+
+	t.Run("dolt_push_lazily_adopts_later_git_origin", func(t *testing.T) {
+		bareDir := filepath.Join(t.TempDir(), "later-origin.git")
+		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", bareDir)
+		remoteURL := "file://" + bareDir
+
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+		runGitForBootstrapTest(t, dir, "branch", "-M", "main")
+		runGitForBootstrapTest(t, dir, "commit", "--allow-empty", "-m", "init")
+		runBDInit(t, bd, dir, "--prefix", "late", "--skip-hooks", "--skip-agents")
+		bdCreate(t, bd, dir, "Lazy remote adoption", "--type", "task")
+
+		runGitForBootstrapTest(t, dir, "remote", "add", "origin", remoteURL)
+		runGitForBootstrapTest(t, dir, "push", "-u", "origin", "main")
+
+		bdDolt(t, bd, dir, "push")
+
+		out := bdDolt(t, bd, dir, "remote", "list")
+		if !strings.Contains(out, "origin") || !strings.Contains(out, remoteURL) {
+			t.Fatalf("bd dolt push should adopt later git origin %q; remote list:\n%s", remoteURL, out)
+		}
+
+		configYAML, err := os.ReadFile(filepath.Join(dir, ".beads", "config.yaml"))
+		if err != nil {
+			t.Fatalf("read config.yaml: %v", err)
+		}
+		if !strings.Contains(string(configYAML), remoteURL) {
+			t.Fatalf("bd dolt push should persist sync.remote; config.yaml:\n%s", configYAML)
+		}
+
+		ls := exec.Command("git", "ls-remote", remoteURL, "refs/dolt/data")
+		lsOut, err := ls.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git ls-remote refs/dolt/data failed: %v\n%s", err, lsOut)
+		}
+		if !strings.Contains(string(lsOut), "refs/dolt/data") {
+			t.Fatalf("bd dolt push did not publish refs/dolt/data:\n%s", lsOut)
+		}
+	})
+
+	t.Run("dolt_push_adopts_target_origin_with_dash_c", func(t *testing.T) {
+		targetBare := filepath.Join(t.TempDir(), "target-origin.git")
+		ambientBare := filepath.Join(t.TempDir(), "ambient-origin.git")
+		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", targetBare)
+		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", ambientBare)
+		targetURL := "file://" + targetBare
+		ambientURL := "file://" + ambientBare
+
+		targetDir := t.TempDir()
+		initGitRepoAt(t, targetDir)
+		runGitForBootstrapTest(t, targetDir, "branch", "-M", "main")
+		runGitForBootstrapTest(t, targetDir, "commit", "--allow-empty", "-m", "init")
+		runBDInit(t, bd, targetDir, "--prefix", "dc", "--skip-hooks", "--skip-agents")
+		bdCreate(t, bd, targetDir, "Dash C remote adoption", "--type", "task")
+		runGitForBootstrapTest(t, targetDir, "remote", "add", "origin", targetURL)
+		runGitForBootstrapTest(t, targetDir, "push", "-u", "origin", "main")
+
+		ambientDir := t.TempDir()
+		initGitRepoAt(t, ambientDir)
+		runGitForBootstrapTest(t, ambientDir, "remote", "add", "origin", ambientURL)
+
+		cmd := exec.Command(bd, "-C", targetDir, "dolt", "push")
+		cmd.Dir = ambientDir
+		cmd.Env = bdEnv(ambientDir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd -C target dolt push failed: %v\n%s", err, out)
+		}
+
+		out := bdDolt(t, bd, targetDir, "remote", "list")
+		if !strings.Contains(out, "origin") || !strings.Contains(out, targetURL) {
+			t.Fatalf("bd -C target dolt push should adopt target origin %q; remote list:\n%s", targetURL, out)
+		}
+		if strings.Contains(out, ambientURL) {
+			t.Fatalf("bd -C target dolt push adopted ambient origin %q; remote list:\n%s", ambientURL, out)
+		}
+	})
+
 	t.Run("stealth_skips_git_origin_remote_synthesis", func(t *testing.T) {
 		bareDir := filepath.Join(t.TempDir(), "stealth.git")
 		runGitForBootstrapTest(t, "", "init", "--bare", "-b", "main", bareDir)

--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -79,6 +79,19 @@ func gitOriginGetURL() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+func gitOriginGetURLForActiveRepo(ctx context.Context) (string, error) {
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		return "", err
+	}
+	cmd := rc.GitCmd(ctx, "remote", "get-url", "origin")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
 // gitOriginHasDoltDataRef checks if origin has refs/dolt/data.
 // Returns false on any error (network, no remote, timeout, etc).
 // Uses a 10s timeout since this is a network call used for auto-detection,

--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/beads/internal/beads"
+	"github.com/steveyegge/beads/internal/doltremote"
 )
 
 // isGitRepo checks if the current working directory is in a git repository.
@@ -114,33 +115,7 @@ func gitOriginHasDoltDataRef() bool {
 // SSH URLs get "git+" prefix: ssh://... → git+ssh://...
 // URLs that already have "git+" prefix are returned as-is.
 func gitURLToDoltRemote(url string) string {
-	if strings.HasPrefix(url, "git+") {
-		return url
-	}
-	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
-		return "git+" + url
-	}
-	if strings.HasPrefix(url, "ssh://") {
-		return "git+" + url
-	}
-	if isWindowsDrivePath(url) {
-		return "git+" + url
-	}
-	// SCP-style: git@github.com:org/repo.git → git+ssh://git@github.com/org/repo.git
-	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") {
-		return "git+ssh://" + url[:idx] + "/" + url[idx+1:]
-	}
-	// Fallback: just prepend git+
-	return "git+" + url
-}
-
-func isWindowsDrivePath(path string) bool {
-	if len(path) < 3 || path[1] != ':' {
-		return false
-	}
-	drive := path[0]
-	return ((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) &&
-		(path[2] == '/' || path[2] == '\\')
+	return doltremote.FromGitURL(url)
 }
 
 // gitBranchHasUpstream checks if a specific branch has an upstream configured.

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/doltremote"
 )
 
 // resolveSyncRemote returns the effective sync remote URL.
@@ -68,38 +69,11 @@ func commitBeadsConfigForActiveRepo(ctx context.Context, msg string) {
 	}
 }
 
-// doltNativeSchemes are URL schemes that Dolt understands natively
-// and should not be converted through gitURLToDoltRemote.
-var doltNativeSchemes = []string{
-	"dolthub://",
-	"file://",
-	"aws://",
-	"gs://",
-	"git+https://",
-	"git+ssh://",
-	"git+http://",
-}
-
 // normalizeRemoteURL converts a remote URL to a Dolt-compatible format.
 // Dolt-native URLs (dolthub://, file://, aws://, gs://, git+...) are
 // returned as-is. Git URLs (https://, ssh://, git@...) are converted
 // via gitURLToDoltRemote. Unknown schemes are returned as-is and let
 // dolt clone decide.
 func normalizeRemoteURL(url string) string {
-	for _, scheme := range doltNativeSchemes {
-		if strings.HasPrefix(url, scheme) {
-			return url
-		}
-	}
-	// Git-style URLs need conversion to dolt remote format
-	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") ||
-		strings.HasPrefix(url, "ssh://") {
-		return gitURLToDoltRemote(url)
-	}
-	// SCP-style git@host:path
-	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") && strings.Contains(url, "@") {
-		return gitURLToDoltRemote(url)
-	}
-	// Unknown scheme — return as-is, let dolt handle it
-	return url
+	return doltremote.Normalize(url)
 }

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/config"
 )
 
@@ -43,6 +45,23 @@ func commitBeadsConfig(msg string) {
 	commitCmd := exec.Command("git", "commit", "-m", msg) //nolint:gosec // G702: msg is from internal callers only, not user input
 	if out, err := commitCmd.CombinedOutput(); err != nil {
 		// "nothing to commit" is normal if the file was already staged
+		if !strings.Contains(string(out), "nothing to commit") {
+			fmt.Fprintf(os.Stderr, "Warning: failed to commit config change: %v\n", err)
+		}
+	}
+}
+
+func commitBeadsConfigForActiveRepo(ctx context.Context, msg string) {
+	rc, err := beads.GetRepoContext()
+	if err != nil {
+		return
+	}
+	addCmd := rc.GitCmd(ctx, "add", ".beads/config.yaml")
+	if err := addCmd.Run(); err != nil {
+		return
+	}
+	commitCmd := rc.GitCmd(ctx, "commit", "-m", msg)
+	if out, err := commitCmd.CombinedOutput(); err != nil {
 		if !strings.Contains(string(out), "nothing to commit") {
 			fmt.Fprintf(os.Stderr, "Warning: failed to commit config change: %v\n", err)
 		}

--- a/cmd/bd/sync_remote_test.go
+++ b/cmd/bd/sync_remote_test.go
@@ -21,6 +21,8 @@ func TestNormalizeRemoteURL(t *testing.T) {
 		{"http://github.com/org/repo.git", "git+http://github.com/org/repo.git"},
 		{"ssh://git@github.com/org/repo.git", "git+ssh://git@github.com/org/repo.git"},
 		{"git@github.com:org/repo.git", "git+ssh://git@github.com/org/repo.git"},
+		{"C:/Users/alice/repos/beads.git", "git+C:/Users/alice/repos/beads.git"},
+		{`D:\repos\beads.git`, `git+D:\repos\beads.git`},
 
 		// Dolt remotesapi URLs — also converted (callers that need
 		// pass-through for user-provided URLs should skip normalization)

--- a/internal/doltremote/remote.go
+++ b/internal/doltremote/remote.go
@@ -1,0 +1,78 @@
+package doltremote
+
+import "strings"
+
+// NativeSchemes are URL schemes that Dolt understands natively and should not
+// be converted through FromGitURL.
+var NativeSchemes = []string{
+	"dolthub://",
+	"file://",
+	"aws://",
+	"gs://",
+	"git+https://",
+	"git+ssh://",
+	"git+http://",
+}
+
+// Normalize converts a remote URL to a Dolt-compatible format.
+// Dolt-native URLs (dolthub://, file://, aws://, gs://, git+...) are returned
+// as-is. Git URLs (https://, ssh://, git@...) are converted via FromGitURL.
+// Unknown schemes are returned as-is and let dolt clone decide.
+func Normalize(url string) string {
+	for _, scheme := range NativeSchemes {
+		if strings.HasPrefix(url, scheme) {
+			return url
+		}
+	}
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") ||
+		strings.HasPrefix(url, "ssh://") {
+		return FromGitURL(url)
+	}
+	if isWindowsDrivePath(url) {
+		return FromGitURL(url)
+	}
+	if isSCPStyleGitURL(url) {
+		return FromGitURL(url)
+	}
+	return url
+}
+
+// FromGitURL converts a git remote URL to Dolt's remote format.
+// HTTPS URLs get "git+" prefix: https://... -> git+https://...
+// SCP-style SSH URLs are converted: git@host:path -> git+ssh://git@host/path
+// SSH URLs get "git+" prefix: ssh://... -> git+ssh://...
+// URLs that already have "git+" prefix are returned as-is.
+func FromGitURL(url string) string {
+	if strings.HasPrefix(url, "git+") {
+		return url
+	}
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://") {
+		return "git+" + url
+	}
+	if strings.HasPrefix(url, "ssh://") {
+		return "git+" + url
+	}
+	if isWindowsDrivePath(url) {
+		return "git+" + url
+	}
+	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") {
+		return "git+ssh://" + url[:idx] + "/" + url[idx+1:]
+	}
+	return "git+" + url
+}
+
+func isSCPStyleGitURL(url string) bool {
+	if idx := strings.Index(url, ":"); idx > 0 && !strings.Contains(url[:idx], "/") && strings.Contains(url, "@") {
+		return true
+	}
+	return false
+}
+
+func isWindowsDrivePath(path string) bool {
+	if len(path) < 3 || path[1] != ':' {
+		return false
+	}
+	drive := path[0]
+	return ((drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')) &&
+		(path[2] == '/' || path[2] == '\\')
+}


### PR DESCRIPTION
## Summary

- Auto-adopt the active repo's git `origin` as a Dolt remote when `bd dolt push` is run with no Dolt remote configured.
- Keep `bd init` without git origin local-first, with simpler guidance to add origin and run `bd dolt push` later.
- Improve `bd doctor` no-remote diagnostics to show the exact `bd dolt remote add origin <converted-origin-url>` command when git origin exists.

## Test Plan

- `go test -tags gms_pure_go ./cmd/bd/doctor -run 'TestRemoteAdoptionDetail|TestCheckRemoteConsistency_WorktreeFallbackUsesSharedConfig'`
- `go test -tags gms_pure_go ./cmd/bd -run 'TestShouldWireInitRemote|TestIsRemoteNotFoundErr|TestPrintNoRemoteGuidance'`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -v -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedInit/(git_origin_registered_as_dolt_remote|no_git_origin_stays_local|dolt_push_lazily_adopts_later_git_origin|dolt_push_adopts_target_origin_with_dash_c|stealth_skips_git_origin_remote_synthesis)|TestEmbeddedBootstrap/bootstrap_from_git_origin_wires_remote'`
- `go test -tags gms_pure_go ./cmd/bd ./cmd/bd/doctor`
- `make fmt-check`
- `make check-docs`
- `make test`

Fixes #3937.

_kilocode-openai/gpt-5.5- on behalf of maphew_