### PR TITLE
Fix ephemeral graph apply readiness and dependency cost

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -59,7 +59,15 @@ var createCmd = &cobra.Command{
 				FatalError("cannot specify both title and --graph flag")
 			}
 			graphDryRun, _ := cmd.Flags().GetBool("dry-run")
-			createIssuesFromGraph(graphFile, graphDryRun)
+			wisp, _ := cmd.Flags().GetBool("ephemeral")
+			noHistory, _ := cmd.Flags().GetBool("no-history")
+			if wisp && noHistory {
+				FatalError("--ephemeral and --no-history are mutually exclusive")
+			}
+			createIssuesFromGraph(graphFile, graphDryRun, GraphApplyOptions{
+				Ephemeral: wisp,
+				NoHistory: noHistory,
+			})
 			return
 		}
 

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -61,13 +61,14 @@ var createCmd = &cobra.Command{
 			graphDryRun, _ := cmd.Flags().GetBool("dry-run")
 			wisp, _ := cmd.Flags().GetBool("ephemeral")
 			noHistory, _ := cmd.Flags().GetBool("no-history")
-			if wisp && noHistory {
-				FatalError("--ephemeral and --no-history are mutually exclusive")
-			}
-			createIssuesFromGraph(graphFile, graphDryRun, GraphApplyOptions{
+			graphOpts := GraphApplyOptions{
 				Ephemeral: wisp,
 				NoHistory: noHistory,
-			})
+			}
+			if err := graphOpts.Validate(); err != nil {
+				FatalError("invalid graph options: %v", err)
+			}
+			createIssuesFromGraph(graphFile, graphDryRun, graphOpts)
 			return
 		}
 

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -585,17 +585,21 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 		}
 
 		parentDepPairs := graphApplyParentDepPairs(plan.Nodes, keyToID)
+		canSkipLocalCycleChecks := graphApplyPlanCanSkipSQLCycleChecks(plan)
 
 		// Add dependencies from edges.
-		for _, edge := range plan.Edges {
+		for i, edge := range plan.Edges {
 			fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
 			toID := resolveEdgeRef(edge.ToKey, edge.ToID, keyToID)
-			if parentDepPairs[graphApplyDepPairKey(fromID, toID)] {
-				continue
-			}
 			depType := types.DependencyType(edge.Type)
 			if depType == "" {
 				depType = types.DepBlocks
+			}
+			if parentDepPairs[graphApplyDepPairKey(fromID, toID)] {
+				if depType == types.DepParentChild {
+					continue
+				}
+				return fmt.Errorf("edge %d %s->%s duplicates a parent-child relationship with dependency type %q", i, fromID, toID, depType)
 			}
 			dep := &types.Dependency{
 				IssueID:     fromID,
@@ -603,7 +607,7 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 				Type:        depType,
 			}
 			addOpts := storage.DependencyAddOptions{}
-			if graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
+			if canSkipLocalCycleChecks && graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
 				addOpts.SkipCycleCheck = true
 			}
 			if err := tx.AddDependencyWithOptions(ctx, dep, actor, addOpts); err != nil {
@@ -645,6 +649,22 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 	}
 
 	return &GraphApplyResult{IDs: keyToID}, nil
+}
+
+func graphApplyPlanCanSkipSQLCycleChecks(plan *GraphApplyPlan) bool {
+	for _, edge := range plan.Edges {
+		depType := types.DependencyType(edge.Type)
+		if depType == "" {
+			depType = types.DepBlocks
+		}
+		if depType != types.DepBlocks && depType != types.DepConditionalBlocks {
+			continue
+		}
+		if !graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
+			return false
+		}
+	}
+	return true
 }
 
 func graphApplyEdgeCanSkipSQLCycleCheck(edge GraphApplyEdge, depType types.DependencyType) bool {

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -57,14 +57,22 @@ type GraphApplyOptions struct {
 	NoHistory bool
 }
 
+func (opts GraphApplyOptions) Validate() error {
+	if opts.Ephemeral && opts.NoHistory {
+		return fmt.Errorf("ephemeral and no_history are mutually exclusive")
+	}
+	return nil
+}
+
 // GraphApplyDryRun describes the actions that would be taken by a graph plan,
 // without performing any writes. Emitted by `bd create --graph --dry-run`.
 type GraphApplyDryRun struct {
-	DryRun     bool                  `json:"dry_run"`
-	NodeCount  int                   `json:"node_count"`
-	EdgeCount  int                   `json:"edge_count"`
-	ParentDeps int                   `json:"parent_deps"`
-	Nodes      []GraphApplyDryRunRow `json:"nodes"`
+	DryRun          bool                  `json:"dry_run"`
+	NodeCount       int                   `json:"node_count"`
+	EdgeCount       int                   `json:"edge_count"`
+	ParentDeps      int                   `json:"parent_deps"`
+	ValidationNotes []string              `json:"validation_notes,omitempty"`
+	Nodes           []GraphApplyDryRunRow `json:"nodes"`
 }
 
 // GraphApplyDryRunRow describes a single planned node in the dry-run preview.
@@ -76,6 +84,8 @@ type GraphApplyDryRunRow struct {
 	ParentKey string `json:"parent_key,omitempty"`
 	ParentID  string `json:"parent_id,omitempty"`
 }
+
+const graphApplyDryRunTransactionValidationNote = "dry-run validates the graph structure only; live create may still reject parent-child blocking paths after resolving stored dependencies"
 
 // knownGraphPlanFields lists the JSON keys recognized at the top level of a
 // GraphApplyPlan. Any other top-level keys produce a warning so users can spot
@@ -316,11 +326,12 @@ func emitGraphApplyDryRun(plan *GraphApplyPlan) {
 	}
 
 	preview := GraphApplyDryRun{
-		DryRun:     true,
-		NodeCount:  len(plan.Nodes),
-		EdgeCount:  len(plan.Edges),
-		ParentDeps: parentDeps,
-		Nodes:      rows,
+		DryRun:          true,
+		NodeCount:       len(plan.Nodes),
+		EdgeCount:       len(plan.Edges),
+		ParentDeps:      parentDeps,
+		ValidationNotes: []string{graphApplyDryRunTransactionValidationNote},
+		Nodes:           rows,
 	}
 
 	if jsonOutput {
@@ -330,6 +341,7 @@ func emitGraphApplyDryRun(plan *GraphApplyPlan) {
 
 	fmt.Printf("Dry run: would create %d issue(s) and %d edge(s) (%d parent-child link(s))\n",
 		preview.NodeCount, preview.EdgeCount, preview.ParentDeps)
+	fmt.Printf("Note: %s.\n", graphApplyDryRunTransactionValidationNote)
 	for _, row := range rows {
 		parent := ""
 		switch {
@@ -435,18 +447,19 @@ func validateGraphApplyPlan(plan *GraphApplyPlan) error {
 
 func validateGraphApplyLocalCycles(plan *GraphApplyPlan, knownKeys map[string]bool) error {
 	adj := make(map[string][]string)
+	for _, node := range plan.Nodes {
+		if node.ParentKey != "" && knownKeys[node.Key] && knownKeys[node.ParentKey] {
+			// ParentKey is guaranteed local by validateGraphApplyPlan, so it is
+			// safe to model the implicit parent-child dependency by key here.
+			adj[node.Key] = append(adj[node.Key], node.ParentKey)
+		}
+	}
 	for _, edge := range plan.Edges {
-		if edge.FromKey == "" || edge.ToKey == "" {
+		depType := graphApplyDependencyType(edge.Type)
+		if !graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
 			continue
 		}
 		if !knownKeys[edge.FromKey] || !knownKeys[edge.ToKey] {
-			continue
-		}
-		depType := types.DependencyType(edge.Type)
-		if depType == "" {
-			depType = types.DepBlocks
-		}
-		if depType != types.DepBlocks && depType != types.DepConditionalBlocks {
 			continue
 		}
 		adj[edge.FromKey] = append(adj[edge.FromKey], edge.ToKey)
@@ -454,36 +467,36 @@ func validateGraphApplyLocalCycles(plan *GraphApplyPlan, knownKeys map[string]bo
 
 	visiting := make(map[string]bool, len(knownKeys))
 	visited := make(map[string]bool, len(knownKeys))
-	var visit func(string) bool
-	visit = func(key string) bool {
+	var visit func(string) (string, bool)
+	visit = func(key string) (string, bool) {
 		if visiting[key] {
-			return true
+			return key, true
 		}
 		if visited[key] {
-			return false
+			return "", false
 		}
 		visiting[key] = true
 		for _, next := range adj[key] {
-			if visit(next) {
-				return true
+			if cycleKey, ok := visit(next); ok {
+				return cycleKey, true
 			}
 		}
 		visiting[key] = false
 		visited[key] = true
-		return false
+		return "", false
 	}
 
-	for key := range knownKeys {
-		if visit(key) {
-			return fmt.Errorf("graph contains a blocking dependency cycle involving node %q", key)
+	for _, key := range graphApplySortedKeys(knownKeys) {
+		if cycleKey, ok := visit(key); ok {
+			return fmt.Errorf("graph contains a blocking dependency cycle involving node %q", cycleKey)
 		}
 	}
 	return nil
 }
 
 func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphApplyOptions) (*GraphApplyResult, error) {
-	if opts.Ephemeral && opts.NoHistory {
-		return nil, fmt.Errorf("ephemeral and no_history are mutually exclusive")
+	if err := opts.Validate(); err != nil {
+		return nil, err
 	}
 
 	keyToID := make(map[string]string, len(plan.Nodes))
@@ -585,21 +598,24 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 		}
 
 		parentDepPairs := graphApplyParentDepPairs(plan.Nodes, keyToID)
+		if err := validateGraphApplyPlannedParentBlockingPaths(ctx, tx, plan, keyToID, parentDepPairs); err != nil {
+			return err
+		}
 		canSkipLocalCycleChecks := graphApplyPlanCanSkipSQLCycleChecks(plan)
 
 		// Add dependencies from edges.
 		for i, edge := range plan.Edges {
 			fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
 			toID := resolveEdgeRef(edge.ToKey, edge.ToID, keyToID)
-			depType := types.DependencyType(edge.Type)
-			if depType == "" {
-				depType = types.DepBlocks
-			}
+			depType := graphApplyDependencyType(edge.Type)
 			if parentDepPairs[graphApplyDepPairKey(fromID, toID)] {
 				if depType == types.DepParentChild {
 					continue
 				}
 				return fmt.Errorf("edge %d %s->%s duplicates a parent-child relationship with dependency type %q", i, fromID, toID, depType)
+			}
+			if parentDepPairs[graphApplyDepPairKey(toID, fromID)] && graphApplyCycleRelevantDependencyType(depType) {
+				return fmt.Errorf("edge %d %s->%s creates a blocking reverse of a parent-child relationship", i, fromID, toID)
 			}
 			dep := &types.Dependency{
 				IssueID:     fromID,
@@ -651,13 +667,97 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 	return &GraphApplyResult{IDs: keyToID}, nil
 }
 
+func validateGraphApplyPlannedParentBlockingPaths(ctx context.Context, tx storage.Transaction, plan *GraphApplyPlan, keyToID map[string]string, parentDepPairs map[string]bool) error {
+	adj := make(map[string][]string)
+	for pair := range parentDepPairs {
+		fromID, toID, ok := graphApplyDepPairIDs(pair)
+		if ok {
+			adj[fromID] = append(adj[fromID], toID)
+		}
+	}
+	for _, edge := range plan.Edges {
+		depType := graphApplyDependencyType(edge.Type)
+		if !graphApplyReadyPathDependencyType(depType) {
+			continue
+		}
+		fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
+		toID := resolveEdgeRef(edge.ToKey, edge.ToID, keyToID)
+		if fromID == "" || toID == "" {
+			continue
+		}
+		// Direct parent -> child blocking edges have a dedicated error below.
+		// This prewrite pass covers transitive parent -> ... -> child paths.
+		if graphApplyCycleRelevantDependencyType(depType) && parentDepPairs[graphApplyDepPairKey(toID, fromID)] {
+			continue
+		}
+		adj[fromID] = append(adj[fromID], toID)
+	}
+
+	depCache := make(map[string][]*types.Dependency)
+	for _, node := range plan.Nodes {
+		childID := keyToID[node.Key]
+		parentID := node.ParentID
+		if node.ParentKey != "" {
+			parentID = keyToID[node.ParentKey]
+		}
+		if childID == "" || parentID == "" {
+			continue
+		}
+		hasPath, err := graphApplyHasPath(ctx, tx, adj, depCache, parentID, childID)
+		if err != nil {
+			return err
+		}
+		if hasPath {
+			return fmt.Errorf("node %q: planned blocking dependencies create a path from parent %q to child %q", node.Key, parentID, childID)
+		}
+	}
+	return nil
+}
+
+func graphApplyHasPath(ctx context.Context, tx storage.Transaction, adj map[string][]string, depCache map[string][]*types.Dependency, fromID, toID string) (bool, error) {
+	seen := make(map[string]bool)
+	var visit func(string) (bool, error)
+	visit = func(id string) (bool, error) {
+		if id == toID {
+			return true, nil
+		}
+		if seen[id] {
+			return false, nil
+		}
+		seen[id] = true
+		for _, next := range adj[id] {
+			found, err := visit(next)
+			if err != nil || found {
+				return found, err
+			}
+		}
+		deps, ok := depCache[id]
+		if !ok {
+			var err error
+			deps, err = tx.GetDependencyRecords(ctx, id)
+			if err != nil {
+				return false, fmt.Errorf("reading existing dependencies for %s: %w", id, err)
+			}
+			depCache[id] = deps
+		}
+		for _, dep := range deps {
+			if !graphApplyReadyPathDependencyType(dep.Type) {
+				continue
+			}
+			found, err := visit(dep.DependsOnID)
+			if err != nil || found {
+				return found, err
+			}
+		}
+		return false, nil
+	}
+	return visit(fromID)
+}
+
 func graphApplyPlanCanSkipSQLCycleChecks(plan *GraphApplyPlan) bool {
 	for _, edge := range plan.Edges {
-		depType := types.DependencyType(edge.Type)
-		if depType == "" {
-			depType = types.DepBlocks
-		}
-		if depType != types.DepBlocks && depType != types.DepConditionalBlocks {
+		depType := graphApplyDependencyType(edge.Type)
+		if !graphApplyCycleRelevantDependencyType(depType) {
 			continue
 		}
 		if !graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
@@ -671,10 +771,31 @@ func graphApplyEdgeCanSkipSQLCycleCheck(edge GraphApplyEdge, depType types.Depen
 	if edge.FromKey == "" || edge.ToKey == "" || edge.FromID != "" || edge.ToID != "" {
 		return false
 	}
+	return graphApplyCycleRelevantDependencyType(depType)
+}
+
+func graphApplyDependencyType(depType string) types.DependencyType {
 	if depType == "" {
-		depType = types.DepBlocks
+		return types.DepBlocks
 	}
+	return types.DependencyType(depType)
+}
+
+func graphApplyCycleRelevantDependencyType(depType types.DependencyType) bool {
 	return depType == types.DepBlocks || depType == types.DepConditionalBlocks
+}
+
+func graphApplyReadyPathDependencyType(depType types.DependencyType) bool {
+	return depType.AffectsReadyWork()
+}
+
+func graphApplySortedKeys(keys map[string]bool) []string {
+	out := make([]string, 0, len(keys))
+	for key := range keys {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func graphApplyParentDepPairs(nodes []GraphApplyNode, keyToID map[string]string) map[string]bool {
@@ -694,6 +815,15 @@ func graphApplyParentDepPairs(nodes []GraphApplyNode, keyToID map[string]string)
 
 func graphApplyDepPairKey(issueID, dependsOnID string) string {
 	return issueID + "\x00" + dependsOnID
+}
+
+func graphApplyDepPairIDs(pair string) (string, string, bool) {
+	for i := 0; i < len(pair); i++ {
+		if pair[i] == 0 {
+			return pair[:i], pair[i+1:], true
+		}
+	}
+	return "", "", false
 }
 
 func resolveEdgeRef(key, id string, keyToID map[string]string) string {

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -50,6 +50,13 @@ type GraphApplyResult struct {
 	IDs map[string]string `json:"ids"`
 }
 
+// GraphApplyOptions carries CLI-level storage options that apply to every node
+// in the graph.
+type GraphApplyOptions struct {
+	Ephemeral bool
+	NoHistory bool
+}
+
 // GraphApplyDryRun describes the actions that would be taken by a graph plan,
 // without performing any writes. Emitted by `bd create --graph --dry-run`.
 type GraphApplyDryRun struct {
@@ -236,7 +243,7 @@ func warnUnknownGraphFields(w io.Writer, unknown map[string][]string) []string {
 // a preview is emitted to stdout (JSON when jsonOutput is set, otherwise
 // human-readable). Unknown plan/node/edge fields are reported to stderr in
 // both modes so schema gaps are visible before any writes happen. (GH#3367)
-func createIssuesFromGraph(planFile string, dryRun bool) {
+func createIssuesFromGraph(planFile string, dryRun bool, opts GraphApplyOptions) {
 	data, err := os.ReadFile(planFile) // #nosec G304 -- user-provided path is intentional
 	if err != nil {
 		FatalError("reading graph plan: %v", err)
@@ -260,7 +267,7 @@ func createIssuesFromGraph(planFile string, dryRun bool) {
 		return
 	}
 
-	result, err := executeGraphApply(rootCtx, &plan)
+	result, err := executeGraphApply(rootCtx, &plan, opts)
 	if err != nil {
 		FatalError("graph create: %v", err)
 	}
@@ -419,10 +426,66 @@ func validateGraphApplyPlan(plan *GraphApplyPlan) error {
 		}
 	}
 
+	if err := validateGraphApplyLocalCycles(plan, seenKeys); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyResult, error) {
+func validateGraphApplyLocalCycles(plan *GraphApplyPlan, knownKeys map[string]bool) error {
+	adj := make(map[string][]string)
+	for _, edge := range plan.Edges {
+		if edge.FromKey == "" || edge.ToKey == "" {
+			continue
+		}
+		if !knownKeys[edge.FromKey] || !knownKeys[edge.ToKey] {
+			continue
+		}
+		depType := types.DependencyType(edge.Type)
+		if depType == "" {
+			depType = types.DepBlocks
+		}
+		if depType != types.DepBlocks && depType != types.DepConditionalBlocks {
+			continue
+		}
+		adj[edge.FromKey] = append(adj[edge.FromKey], edge.ToKey)
+	}
+
+	visiting := make(map[string]bool, len(knownKeys))
+	visited := make(map[string]bool, len(knownKeys))
+	var visit func(string) bool
+	visit = func(key string) bool {
+		if visiting[key] {
+			return true
+		}
+		if visited[key] {
+			return false
+		}
+		visiting[key] = true
+		for _, next := range adj[key] {
+			if visit(next) {
+				return true
+			}
+		}
+		visiting[key] = false
+		visited[key] = true
+		return false
+	}
+
+	for key := range knownKeys {
+		if visit(key) {
+			return fmt.Errorf("graph contains a blocking dependency cycle involving node %q", key)
+		}
+	}
+	return nil
+}
+
+func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphApplyOptions) (*GraphApplyResult, error) {
+	if opts.Ephemeral && opts.NoHistory {
+		return nil, fmt.Errorf("ephemeral and no_history are mutually exclusive")
+	}
+
 	keyToID := make(map[string]string, len(plan.Nodes))
 
 	commitMsg := plan.CommitMessage
@@ -461,6 +524,8 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyRe
 				Priority:  priority,
 				Labels:    node.Labels,
 				Metadata:  metadataJSON,
+				Ephemeral: opts.Ephemeral,
+				NoHistory: opts.NoHistory,
 			}
 			if node.Description != "" {
 				issue.Description = node.Description
@@ -519,10 +584,15 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyRe
 			}
 		}
 
+		parentDepPairs := graphApplyParentDepPairs(plan.Nodes, keyToID)
+
 		// Add dependencies from edges.
 		for _, edge := range plan.Edges {
 			fromID := resolveEdgeRef(edge.FromKey, edge.FromID, keyToID)
 			toID := resolveEdgeRef(edge.ToKey, edge.ToID, keyToID)
+			if parentDepPairs[graphApplyDepPairKey(fromID, toID)] {
+				continue
+			}
 			depType := types.DependencyType(edge.Type)
 			if depType == "" {
 				depType = types.DepBlocks
@@ -532,7 +602,11 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyRe
 				DependsOnID: toID,
 				Type:        depType,
 			}
-			if err := tx.AddDependency(ctx, dep, actor); err != nil {
+			addOpts := storage.DependencyAddOptions{}
+			if graphApplyEdgeCanSkipSQLCycleCheck(edge, depType) {
+				addOpts.SkipCycleCheck = true
+			}
+			if err := tx.AddDependencyWithOptions(ctx, dep, actor, addOpts); err != nil {
 				return fmt.Errorf("adding edge %s->%s: %w", fromID, toID, err)
 			}
 		}
@@ -571,6 +645,35 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyRe
 	}
 
 	return &GraphApplyResult{IDs: keyToID}, nil
+}
+
+func graphApplyEdgeCanSkipSQLCycleCheck(edge GraphApplyEdge, depType types.DependencyType) bool {
+	if edge.FromKey == "" || edge.ToKey == "" || edge.FromID != "" || edge.ToID != "" {
+		return false
+	}
+	if depType == "" {
+		depType = types.DepBlocks
+	}
+	return depType == types.DepBlocks || depType == types.DepConditionalBlocks
+}
+
+func graphApplyParentDepPairs(nodes []GraphApplyNode, keyToID map[string]string) map[string]bool {
+	pairs := make(map[string]bool)
+	for _, node := range nodes {
+		parentID := node.ParentID
+		if node.ParentKey != "" {
+			parentID = keyToID[node.ParentKey]
+		}
+		childID := keyToID[node.Key]
+		if childID != "" && parentID != "" {
+			pairs[graphApplyDepPairKey(childID, parentID)] = true
+		}
+	}
+	return pairs
+}
+
+func graphApplyDepPairKey(issueID, dependsOnID string) string {
+	return issueID + "\x00" + dependsOnID
 }
 
 func resolveEdgeRef(key, id string, keyToID map[string]string) string {

--- a/cmd/bd/graph_apply_execution_test.go
+++ b/cmd/bd/graph_apply_execution_test.go
@@ -1,0 +1,171 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func withGraphApplyTestStore(t *testing.T) (context.Context, *sql.DB) {
+	t.Helper()
+
+	ctx := context.Background()
+	testStore := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), ".beads", "beads.db"), "ga")
+
+	oldStore, oldCtx, oldActor := store, rootCtx, actor
+	store, rootCtx, actor = testStore, ctx, "graph-apply-test"
+	t.Cleanup(func() {
+		store, rootCtx, actor = oldStore, oldCtx, oldActor
+	})
+
+	return ctx, testStore.DB()
+}
+
+func TestExecuteGraphApplyEphemeralAndNoHistoryRouteToWisps(t *testing.T) {
+	ctx, db := withGraphApplyTestStore(t)
+
+	tests := []struct {
+		name string
+		opts GraphApplyOptions
+	}{
+		{name: "ephemeral", opts: GraphApplyOptions{Ephemeral: true}},
+		{name: "no history", opts: GraphApplyOptions{NoHistory: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := &GraphApplyPlan{
+				Nodes: []GraphApplyNode{{Key: "a", Title: "A", Type: "task"}},
+			}
+
+			result, err := executeGraphApply(ctx, plan, tt.opts)
+			if err != nil {
+				t.Fatalf("executeGraphApply: %v", err)
+			}
+			id := result.IDs["a"]
+			got, err := store.GetIssue(ctx, id)
+			if err != nil {
+				t.Fatalf("GetIssue(%s): %v", id, err)
+			}
+			if got.Ephemeral != tt.opts.Ephemeral {
+				t.Fatalf("Ephemeral = %v, want %v", got.Ephemeral, tt.opts.Ephemeral)
+			}
+			if got.NoHistory != tt.opts.NoHistory {
+				t.Fatalf("NoHistory = %v, want %v", got.NoHistory, tt.opts.NoHistory)
+			}
+
+			var count int
+			if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM wisps WHERE id = ?", id).Scan(&count); err != nil {
+				t.Fatalf("query wisps for %s: %v", id, err)
+			}
+			if count != 1 {
+				t.Fatalf("wisps row count for %s = %d, want 1", id, count)
+			}
+			if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", id).Scan(&count); err != nil {
+				t.Fatalf("query issues for %s: %v", id, err)
+			}
+			if count != 0 {
+				t.Fatalf("issues row count for %s = %d, want 0", id, count)
+			}
+		})
+	}
+}
+
+func TestExecuteGraphApplyRejectsMixedLocalExternalBlockingCycle(t *testing.T) {
+	ctx, _ := withGraphApplyTestStore(t)
+
+	existing := &types.Issue{
+		ID:        "ga-existing",
+		Title:     "Existing",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, existing, actor); err != nil {
+		t.Fatalf("CreateIssue(existing): %v", err)
+	}
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task"},
+			{Key: "b", Title: "B", Type: "task"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromID: existing.ID, ToKey: "a", Type: "blocks"},
+			{FromKey: "b", ToID: existing.ID, Type: "blocks"},
+			{FromKey: "a", ToKey: "b", Type: "blocks"},
+		},
+	}
+
+	if err := validateGraphApplyPlan(plan); err != nil {
+		t.Fatalf("validateGraphApplyPlan: %v", err)
+	}
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected mixed local/external blocking cycle to be rejected")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("error = %q, want cycle rejection", err.Error())
+	}
+}
+
+func TestExecuteGraphApplyAllowsExplicitParentChildDuplicate(t *testing.T) {
+	ctx, _ := withGraphApplyTestStore(t)
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "child", Title: "Child", Type: "task", ParentKey: "root"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "child", ToKey: "root", Type: string(types.DepParentChild)},
+		},
+	}
+
+	result, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err != nil {
+		t.Fatalf("executeGraphApply: %v", err)
+	}
+
+	deps, err := store.GetDependenciesWithMetadata(ctx, result.IDs["child"])
+	if err != nil {
+		t.Fatalf("GetDependenciesWithMetadata(child): %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("dependency count = %d, want 1", len(deps))
+	}
+	if deps[0].ID != result.IDs["root"] {
+		t.Fatalf("dependency target = %s, want %s", deps[0].ID, result.IDs["root"])
+	}
+	if deps[0].DependencyType != types.DepParentChild {
+		t.Fatalf("dependency type = %s, want %s", deps[0].DependencyType, types.DepParentChild)
+	}
+}
+
+func TestExecuteGraphApplyRejectsBlockingChildToParentDuplicate(t *testing.T) {
+	ctx, _ := withGraphApplyTestStore(t)
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "child", Title: "Child", Type: "task", ParentKey: "root"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "child", ToKey: "root"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected default blocking child-to-parent duplicate to be rejected")
+	}
+	if !strings.Contains(err.Error(), "parent-child") {
+		t.Fatalf("error = %q, want parent-child duplicate rejection", err.Error())
+	}
+}

--- a/cmd/bd/graph_apply_execution_test.go
+++ b/cmd/bd/graph_apply_execution_test.go
@@ -115,6 +115,62 @@ func TestExecuteGraphApplyRejectsMixedLocalExternalBlockingCycle(t *testing.T) {
 	}
 }
 
+func TestExecuteGraphApplyRejectsStoredPrefixParentBlockingPath(t *testing.T) {
+	ctx, db := withGraphApplyTestStore(t)
+
+	parent := &types.Issue{
+		ID:        "ga-parent",
+		Title:     "Existing Parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	mid := &types.Issue{
+		ID:        "ga-existing-mid",
+		Title:     "Existing Middle",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	for _, issue := range []*types.Issue{parent, mid} {
+		if err := store.CreateIssue(ctx, issue, actor); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
+		}
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     parent.ID,
+		DependsOnID: mid.ID,
+		Type:        types.DepBlocks,
+	}, actor); err != nil {
+		t.Fatalf("AddDependency(parent -> mid): %v", err)
+	}
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "child", Title: "Child", Type: "task", ParentID: parent.ID},
+		},
+		Edges: []GraphApplyEdge{
+			{FromID: mid.ID, ToKey: "child", Type: "blocks"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected stored-prefix parent blocking path to be rejected")
+	}
+	if got, want := err.Error(), "planned blocking dependencies create a path from parent"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want to contain %q", got, want)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE title = 'Child'").Scan(&count); err != nil {
+		t.Fatalf("query child rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("child issue rows after failed transaction = %d, want 0", count)
+	}
+}
+
 func TestExecuteGraphApplyAllowsExplicitParentChildDuplicate(t *testing.T) {
 	ctx, _ := withGraphApplyTestStore(t)
 

--- a/cmd/bd/graph_apply_execution_unit_test.go
+++ b/cmd/bd/graph_apply_execution_unit_test.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type graphApplyFakeStore struct {
+	storage.DoltStorage
+	issues map[string]*types.Issue
+	deps   []*types.Dependency
+	nextID int
+}
+
+func newGraphApplyFakeStore() *graphApplyFakeStore {
+	return &graphApplyFakeStore{
+		issues: make(map[string]*types.Issue),
+	}
+}
+
+func (s *graphApplyFakeStore) CreateIssue(_ context.Context, issue *types.Issue, _ string) error {
+	cp := *issue
+	if cp.ID == "" {
+		cp.ID = s.nextIssueID(&cp)
+	}
+	issue.ID = cp.ID
+	s.issues[cp.ID] = &cp
+	return nil
+}
+
+func (s *graphApplyFakeStore) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	cp := *issue
+	return &cp, nil
+}
+
+func (s *graphApplyFakeStore) GetDependenciesWithMetadata(_ context.Context, issueID string) ([]*types.IssueWithDependencyMetadata, error) {
+	var out []*types.IssueWithDependencyMetadata
+	for _, dep := range s.deps {
+		if dep.IssueID != issueID {
+			continue
+		}
+		issue, ok := s.issues[dep.DependsOnID]
+		if !ok {
+			continue
+		}
+		cp := *issue
+		out = append(out, &types.IssueWithDependencyMetadata{
+			Issue:          cp,
+			DependencyType: dep.Type,
+		})
+	}
+	return out, nil
+}
+
+func (s *graphApplyFakeStore) RunInTransaction(ctx context.Context, _ string, fn func(storage.Transaction) error) error {
+	txStore := s.clone()
+	tx := &graphApplyFakeTx{store: txStore}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	s.issues = txStore.issues
+	s.deps = txStore.deps
+	s.nextID = txStore.nextID
+	return nil
+}
+
+func (s *graphApplyFakeStore) clone() *graphApplyFakeStore {
+	cp := &graphApplyFakeStore{
+		issues: make(map[string]*types.Issue, len(s.issues)),
+		deps:   make([]*types.Dependency, 0, len(s.deps)),
+		nextID: s.nextID,
+	}
+	for id, issue := range s.issues {
+		issueCopy := *issue
+		cp.issues[id] = &issueCopy
+	}
+	for _, dep := range s.deps {
+		depCopy := *dep
+		cp.deps = append(cp.deps, &depCopy)
+	}
+	return cp
+}
+
+func (s *graphApplyFakeStore) nextIssueID(issue *types.Issue) string {
+	s.nextID++
+	if issue.Ephemeral {
+		return fmt.Sprintf("ga-wisp-%d", s.nextID)
+	}
+	return fmt.Sprintf("ga-%d", s.nextID)
+}
+
+type graphApplyFakeTx struct {
+	storage.Transaction
+	store *graphApplyFakeStore
+}
+
+func (tx *graphApplyFakeTx) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
+	for _, issue := range issues {
+		if err := tx.store.CreateIssue(ctx, issue, actor); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tx *graphApplyFakeTx) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
+	return tx.AddDependencyWithOptions(ctx, dep, actor, storage.DependencyAddOptions{})
+}
+
+func (tx *graphApplyFakeTx) AddDependencyWithOptions(_ context.Context, dep *types.Dependency, _ string, opts storage.DependencyAddOptions) error {
+	for _, existing := range tx.store.deps {
+		if existing.IssueID == dep.IssueID && existing.DependsOnID == dep.DependsOnID {
+			if existing.Type == dep.Type {
+				return nil
+			}
+			return fmt.Errorf("dependency already exists with type %s", existing.Type)
+		}
+	}
+	if isGraphApplyFakeBlocking(dep.Type) && !opts.SkipCycleCheck && tx.hasBlockingPath(dep.DependsOnID, dep.IssueID) {
+		return fmt.Errorf("adding dependency would create a cycle")
+	}
+	depCopy := *dep
+	tx.store.deps = append(tx.store.deps, &depCopy)
+	return nil
+}
+
+func (tx *graphApplyFakeTx) AddLabel(context.Context, string, string, string) error {
+	return nil
+}
+
+func (tx *graphApplyFakeTx) UpdateIssue(_ context.Context, id string, updates map[string]interface{}, _ string) error {
+	issue, ok := tx.store.issues[id]
+	if !ok {
+		return storage.ErrNotFound
+	}
+	if assignee, ok := updates["assignee"].(string); ok {
+		issue.Assignee = assignee
+	}
+	return nil
+}
+
+func (tx *graphApplyFakeTx) hasBlockingPath(fromID, toID string) bool {
+	seen := make(map[string]bool)
+	var visit func(string) bool
+	visit = func(id string) bool {
+		if id == toID {
+			return true
+		}
+		if seen[id] {
+			return false
+		}
+		seen[id] = true
+		for _, dep := range tx.store.deps {
+			if dep.IssueID != id || !isGraphApplyFakeBlocking(dep.Type) {
+				continue
+			}
+			if visit(dep.DependsOnID) {
+				return true
+			}
+		}
+		return false
+	}
+	return visit(fromID)
+}
+
+func isGraphApplyFakeBlocking(depType types.DependencyType) bool {
+	return depType == types.DepBlocks || depType == types.DepConditionalBlocks
+}
+
+func withGraphApplyFakeStore(t *testing.T) (context.Context, *graphApplyFakeStore) {
+	t.Helper()
+	ctx := context.Background()
+	fakeStore := newGraphApplyFakeStore()
+	oldStore, oldCtx, oldActor := store, rootCtx, actor
+	store, rootCtx, actor = fakeStore, ctx, "graph-apply-test"
+	t.Cleanup(func() {
+		store, rootCtx, actor = oldStore, oldCtx, oldActor
+	})
+	return ctx, fakeStore
+}
+
+func TestExecuteGraphApplyUnitRejectsMixedLocalExternalBlockingCycle(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+	if err := fakeStore.CreateIssue(ctx, &types.Issue{
+		ID:        "ga-existing",
+		Title:     "Existing",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}, actor); err != nil {
+		t.Fatalf("CreateIssue(existing): %v", err)
+	}
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task"},
+			{Key: "b", Title: "B", Type: "task"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromID: "ga-existing", ToKey: "a", Type: "blocks"},
+			{FromKey: "b", ToID: "ga-existing", Type: "blocks"},
+			{FromKey: "a", ToKey: "b", Type: "blocks"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected mixed local/external blocking cycle to be rejected")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("error = %q, want cycle rejection", err.Error())
+	}
+}
+
+func TestExecuteGraphApplyUnitRejectsBlockingChildToParentDuplicate(t *testing.T) {
+	ctx, _ := withGraphApplyFakeStore(t)
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "child", Title: "Child", Type: "task", ParentKey: "root"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "child", ToKey: "root"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected default blocking child-to-parent duplicate to be rejected")
+	}
+	if !strings.Contains(err.Error(), "parent-child") {
+		t.Fatalf("error = %q, want parent-child duplicate rejection", err.Error())
+	}
+}
+
+func TestExecuteGraphApplyUnitAllowsExplicitParentChildDuplicate(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "child", Title: "Child", Type: "task", ParentKey: "root"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "child", ToKey: "root", Type: string(types.DepParentChild)},
+		},
+	}
+
+	result, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err != nil {
+		t.Fatalf("executeGraphApply: %v", err)
+	}
+	deps, err := fakeStore.GetDependenciesWithMetadata(ctx, result.IDs["child"])
+	if err != nil {
+		t.Fatalf("GetDependenciesWithMetadata(child): %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("dependency count = %d, want 1", len(deps))
+	}
+	if deps[0].ID != result.IDs["root"] {
+		t.Fatalf("dependency target = %s, want %s", deps[0].ID, result.IDs["root"])
+	}
+	if deps[0].DependencyType != types.DepParentChild {
+		t.Fatalf("dependency type = %s, want %s", deps[0].DependencyType, types.DepParentChild)
+	}
+}

--- a/cmd/bd/graph_apply_execution_unit_test.go
+++ b/cmd/bd/graph_apply_execution_unit_test.go
@@ -61,6 +61,18 @@ func (s *graphApplyFakeStore) GetDependenciesWithMetadata(_ context.Context, iss
 	return out, nil
 }
 
+func (s *graphApplyFakeStore) GetDependencyRecords(_ context.Context, issueID string) ([]*types.Dependency, error) {
+	var out []*types.Dependency
+	for _, dep := range s.deps {
+		if dep.IssueID != issueID {
+			continue
+		}
+		cp := *dep
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
 func (s *graphApplyFakeStore) RunInTransaction(ctx context.Context, _ string, fn func(storage.Transaction) error) error {
 	txStore := s.clone()
 	tx := &graphApplyFakeTx{store: txStore}
@@ -120,6 +132,9 @@ func (tx *graphApplyFakeTx) AddDependencyWithOptions(_ context.Context, dep *typ
 	for _, existing := range tx.store.deps {
 		if existing.IssueID == dep.IssueID && existing.DependsOnID == dep.DependsOnID {
 			if existing.Type == dep.Type {
+				// Real storage accepts this duplicate and updates metadata; graph
+				// apply never sets dependency metadata, so the fake treats it as
+				// idempotent for duplicate-suppression tests.
 				return nil
 			}
 			return fmt.Errorf("dependency already exists with type %s", existing.Type)
@@ -131,6 +146,10 @@ func (tx *graphApplyFakeTx) AddDependencyWithOptions(_ context.Context, dep *typ
 	depCopy := *dep
 	tx.store.deps = append(tx.store.deps, &depCopy)
 	return nil
+}
+
+func (tx *graphApplyFakeTx) GetDependencyRecords(ctx context.Context, issueID string) ([]*types.Dependency, error) {
+	return tx.store.GetDependencyRecords(ctx, issueID)
 }
 
 func (tx *graphApplyFakeTx) AddLabel(context.Context, string, string, string) error {
@@ -173,7 +192,7 @@ func (tx *graphApplyFakeTx) hasBlockingPath(fromID, toID string) bool {
 }
 
 func isGraphApplyFakeBlocking(depType types.DependencyType) bool {
-	return depType == types.DepBlocks || depType == types.DepConditionalBlocks
+	return graphApplyCycleRelevantDependencyType(depType)
 }
 
 func withGraphApplyFakeStore(t *testing.T) (context.Context, *graphApplyFakeStore) {
@@ -240,6 +259,201 @@ func TestExecuteGraphApplyUnitRejectsBlockingChildToParentDuplicate(t *testing.T
 	}
 	if !strings.Contains(err.Error(), "parent-child") {
 		t.Fatalf("error = %q, want parent-child duplicate rejection", err.Error())
+	}
+}
+
+func TestExecuteGraphApplyUnitRejectsReverseParentToChildBlockingEdge(t *testing.T) {
+	tests := []struct {
+		name       string
+		depType    string
+		externalID bool
+	}{
+		{name: "local blocks", depType: "blocks"},
+		{name: "local conditional blocks", depType: "conditional-blocks"},
+		{name: "external blocks", depType: "blocks", externalID: true},
+		{name: "external conditional blocks", depType: "conditional-blocks", externalID: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, fakeStore := withGraphApplyFakeStore(t)
+			nodes := []GraphApplyNode{
+				{Key: "root", Title: "Root", Type: "epic"},
+				{Key: "child", Title: "Child", Type: "task", ParentKey: "root"},
+			}
+			edge := GraphApplyEdge{FromKey: "root", ToKey: "child", Type: tt.depType}
+			if tt.externalID {
+				if err := fakeStore.CreateIssue(ctx, &types.Issue{
+					ID:        "ga-parent",
+					Title:     "Existing Parent",
+					Status:    types.StatusOpen,
+					Priority:  2,
+					IssueType: types.TypeEpic,
+				}, actor); err != nil {
+					t.Fatalf("CreateIssue(existing parent): %v", err)
+				}
+				nodes = []GraphApplyNode{
+					{Key: "child", Title: "Child", Type: "task", ParentID: "ga-parent"},
+				}
+				edge = GraphApplyEdge{FromID: "ga-parent", ToKey: "child", Type: tt.depType}
+			}
+
+			plan := &GraphApplyPlan{
+				Nodes: nodes,
+				Edges: []GraphApplyEdge{edge},
+			}
+
+			_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+			if err == nil {
+				t.Fatal("expected reverse parent-to-child blocking edge to be rejected")
+			}
+			if !strings.Contains(err.Error(), "parent-child") {
+				t.Fatalf("error = %q, want parent-child reverse rejection", err.Error())
+			}
+		})
+	}
+}
+
+func TestExecuteGraphApplyUnitRejectsExternalParentTransitiveBlockingPath(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+	if err := fakeStore.CreateIssue(ctx, &types.Issue{
+		ID:        "ga-parent",
+		Title:     "Existing Parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}, actor); err != nil {
+		t.Fatalf("CreateIssue(existing parent): %v", err)
+	}
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "mid", Title: "Middle", Type: "task"},
+			{Key: "child", Title: "Child", Type: "task", ParentID: "ga-parent"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromID: "ga-parent", ToKey: "mid", Type: "blocks"},
+			{FromKey: "mid", ToKey: "child", Type: "blocks"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected external parent transitive blocking path to be rejected")
+	}
+	if got, want := err.Error(), "planned blocking dependencies create a path from parent"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want to contain %q", got, want)
+	}
+	if _, ok := fakeStore.issues["ga-1"]; ok {
+		t.Fatal("transaction committed graph issues after validation failure")
+	}
+}
+
+func TestExecuteGraphApplyUnitRejectsStoredPrefixParentBlockingPath(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+	for _, issue := range []*types.Issue{
+		{
+			ID:        "ga-parent",
+			Title:     "Existing Parent",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		},
+		{
+			ID:        "ga-existing-mid",
+			Title:     "Existing Middle",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		},
+	} {
+		if err := fakeStore.CreateIssue(ctx, issue, actor); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
+		}
+	}
+	fakeStore.deps = append(fakeStore.deps, &types.Dependency{
+		IssueID:     "ga-parent",
+		DependsOnID: "ga-existing-mid",
+		Type:        types.DepBlocks,
+	})
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "child", Title: "Child", Type: "task", ParentID: "ga-parent"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromID: "ga-existing-mid", ToKey: "child", Type: "blocks"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected stored-prefix parent blocking path to be rejected")
+	}
+	if got, want := err.Error(), "planned blocking dependencies create a path from parent"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want to contain %q", got, want)
+	}
+	if _, ok := fakeStore.issues["ga-1"]; ok {
+		t.Fatal("transaction committed graph issues after validation failure")
+	}
+}
+
+func TestExecuteGraphApplyUnitRejectsTransitiveParentChainBlockingCycle(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+	if err := fakeStore.CreateIssue(ctx, &types.Issue{
+		ID:        "ga-existing-parent",
+		Title:     "Existing Parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}, actor); err != nil {
+		t.Fatalf("CreateIssue(existing parent): %v", err)
+	}
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task", ParentKey: "b"},
+			{Key: "b", Title: "B", Type: "task", ParentID: "ga-existing-parent"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromID: "ga-existing-parent", ToKey: "a", Type: "blocks"},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected transitive parent-chain blocking cycle to be rejected")
+	}
+	if got, want := err.Error(), "planned blocking dependencies create a path from parent"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want to contain %q", got, want)
+	}
+	if _, ok := fakeStore.issues["ga-1"]; ok {
+		t.Fatal("transaction committed graph issues after validation failure")
+	}
+}
+
+func TestExecuteGraphApplyUnitRejectsReverseParentChildEdgeCycle(t *testing.T) {
+	ctx, fakeStore := withGraphApplyFakeStore(t)
+
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "child", Title: "Child", Type: "task", ParentKey: "root"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "root", ToKey: "child", Type: string(types.DepParentChild)},
+		},
+	}
+
+	_, err := executeGraphApply(ctx, plan, GraphApplyOptions{})
+	if err == nil {
+		t.Fatal("expected reverse parent-child edge to be rejected")
+	}
+	if got, want := err.Error(), "planned blocking dependencies create a path from parent"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want to contain %q", got, want)
+	}
+	if _, ok := fakeStore.issues["ga-1"]; ok {
+		t.Fatal("transaction committed graph issues after validation failure")
 	}
 }
 

--- a/cmd/bd/graph_apply_test.go
+++ b/cmd/bd/graph_apply_test.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func TestValidateGraphApplyPlanAcceptsCustomTypes(t *testing.T) {
@@ -253,5 +255,98 @@ func TestEmitGraphApplyDryRun_Counts(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("dry-run missing %q in output:\n%s", want, out)
 		}
+	}
+}
+
+func TestValidateGraphApplyPlanRejectsLocalBlockingCycle(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task"},
+			{Key: "b", Title: "B", Type: "task"},
+			{Key: "c", Title: "C", Type: "task"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "a", ToKey: "b", Type: "blocks"},
+			{FromKey: "b", ToKey: "c", Type: "conditional-blocks"},
+			{FromKey: "c", ToKey: "a", Type: "blocks"},
+		},
+	}
+
+	err := validateGraphApplyPlan(plan)
+	if err == nil {
+		t.Fatal("expected local graph cycle to be rejected")
+	}
+	if got, want := err.Error(), "graph contains a blocking dependency cycle"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want to contain %q", got, want)
+	}
+}
+
+func TestValidateGraphApplyPlanAllowsNonBlockingLocalCycle(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task"},
+			{Key: "b", Title: "B", Type: "task"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "a", ToKey: "b", Type: "related"},
+			{FromKey: "b", ToKey: "a", Type: "related"},
+		},
+	}
+
+	if err := validateGraphApplyPlan(plan); err != nil {
+		t.Fatalf("non-blocking cycle rejected: %v", err)
+	}
+}
+
+func TestGraphApplyEdgeCanSkipSQLCycleCheckOnlyForLocalBlockingEdges(t *testing.T) {
+	tests := []struct {
+		name string
+		edge GraphApplyEdge
+		typ  string
+		want bool
+	}{
+		{name: "local default blocks", edge: GraphApplyEdge{FromKey: "a", ToKey: "b"}, want: true},
+		{name: "local conditional blocks", edge: GraphApplyEdge{FromKey: "a", ToKey: "b"}, typ: "conditional-blocks", want: true},
+		{name: "local nonblocking", edge: GraphApplyEdge{FromKey: "a", ToKey: "b"}, typ: "related"},
+		{name: "existing id target", edge: GraphApplyEdge{FromKey: "a", ToID: "bd-123"}, want: false},
+		{name: "explicit id overrides key", edge: GraphApplyEdge{FromKey: "a", FromID: "bd-1", ToKey: "b"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := graphApplyEdgeCanSkipSQLCycleCheck(tt.edge, types.DependencyType(tt.typ))
+			if got != tt.want {
+				t.Fatalf("skip = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGraphApplyParentDepPairs(t *testing.T) {
+	nodes := []GraphApplyNode{
+		{Key: "root", Title: "Root"},
+		{Key: "child", Title: "Child", ParentKey: "root"},
+		{Key: "external-child", Title: "External child", ParentID: "bd-parent"},
+	}
+	keyToID := map[string]string{
+		"root":           "bd-root",
+		"child":          "bd-child",
+		"external-child": "bd-external-child",
+	}
+
+	pairs := graphApplyParentDepPairs(nodes, keyToID)
+	for _, pair := range []struct {
+		child  string
+		parent string
+	}{
+		{"bd-child", "bd-root"},
+		{"bd-external-child", "bd-parent"},
+	} {
+		if !pairs[graphApplyDepPairKey(pair.child, pair.parent)] {
+			t.Fatalf("missing parent dep pair %s -> %s", pair.child, pair.parent)
+		}
+	}
+	if pairs[graphApplyDepPairKey("bd-root", "bd-child")] {
+		t.Fatal("unexpected reverse parent dep pair")
 	}
 }

--- a/cmd/bd/graph_apply_test.go
+++ b/cmd/bd/graph_apply_test.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/steveyegge/beads/internal/types"
 )
 
 func TestValidateGraphApplyPlanAcceptsCustomTypes(t *testing.T) {
@@ -251,10 +249,20 @@ func TestEmitGraphApplyDryRun_Counts(t *testing.T) {
 	if !strings.Contains(out, "would create 3 issue(s) and 1 edge(s) (2 parent-child link(s))") {
 		t.Errorf("dry-run summary missing or wrong:\n%s", out)
 	}
-	for _, want := range []string{"root", "c1", "c2", "parent_key=root"} {
+	for _, want := range []string{"root", "c1", "c2", "parent_key=root", "live create may still reject parent-child blocking paths"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("dry-run missing %q in output:\n%s", want, out)
 		}
+	}
+}
+
+func TestGraphApplyOptionsValidateRejectsEphemeralNoHistory(t *testing.T) {
+	err := (GraphApplyOptions{Ephemeral: true, NoHistory: true}).Validate()
+	if err == nil {
+		t.Fatal("expected mutually exclusive graph options to be rejected")
+	}
+	if got, want := err.Error(), "ephemeral and no_history are mutually exclusive"; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
 	}
 }
 
@@ -281,6 +289,29 @@ func TestValidateGraphApplyPlanRejectsLocalBlockingCycle(t *testing.T) {
 	}
 }
 
+func TestValidateGraphApplyPlanReportsDeterministicCycleNode(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task"},
+			{Key: "b", Title: "B", Type: "task"},
+			{Key: "c", Title: "C", Type: "task"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "b", ToKey: "c", Type: "blocks"},
+			{FromKey: "c", ToKey: "a", Type: "blocks"},
+			{FromKey: "a", ToKey: "b", Type: "blocks"},
+		},
+	}
+
+	err := validateGraphApplyPlan(plan)
+	if err == nil {
+		t.Fatal("expected local graph cycle to be rejected")
+	}
+	if got, want := err.Error(), `graph contains a blocking dependency cycle involving node "a"`; got != want {
+		t.Fatalf("error = %q, want %q", got, want)
+	}
+}
+
 func TestValidateGraphApplyPlanAllowsNonBlockingLocalCycle(t *testing.T) {
 	plan := &GraphApplyPlan{
 		Nodes: []GraphApplyNode{
@@ -295,6 +326,43 @@ func TestValidateGraphApplyPlanAllowsNonBlockingLocalCycle(t *testing.T) {
 
 	if err := validateGraphApplyPlan(plan); err != nil {
 		t.Fatalf("non-blocking cycle rejected: %v", err)
+	}
+}
+
+func TestValidateGraphApplyPlanRejectsImplicitParentChildReverseBlockingCycle(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "child", Title: "Child", Type: "task", ParentKey: "root"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "root", ToKey: "child", Type: "blocks"},
+		},
+	}
+
+	err := validateGraphApplyPlan(plan)
+	if err == nil {
+		t.Fatal("expected implicit parent-child plus reverse blocking edge to be rejected")
+	}
+	if got, want := err.Error(), "blocking dependency cycle"; !strings.Contains(got, want) {
+		t.Fatalf("error = %q, want to contain %q", got, want)
+	}
+}
+
+func TestValidateGraphApplyPlanIgnoresIDOverridesForLocalCycleValidation(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "a", Title: "A", Type: "task"},
+			{Key: "b", Title: "B", Type: "task"},
+		},
+		Edges: []GraphApplyEdge{
+			{FromKey: "a", FromID: "bd-existing", ToKey: "b", Type: "blocks"},
+			{FromKey: "b", ToKey: "a", Type: "blocks"},
+		},
+	}
+
+	if err := validateGraphApplyPlan(plan); err != nil {
+		t.Fatalf("ID override edge should not be treated as a local key cycle: %v", err)
 	}
 }
 
@@ -314,7 +382,7 @@ func TestGraphApplyEdgeCanSkipSQLCycleCheckOnlyForLocalBlockingEdges(t *testing.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := graphApplyEdgeCanSkipSQLCycleCheck(tt.edge, types.DependencyType(tt.typ))
+			got := graphApplyEdgeCanSkipSQLCycleCheck(tt.edge, graphApplyDependencyType(tt.typ))
 			if got != tt.want {
 				t.Fatalf("skip = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
## Summary
- pass --ephemeral/--no-history through `bd create --graph`
- validate graph-local blocking cycles in memory
- skip per-edge SQL cycle checks for graph-local blocking edges after validation
- avoid duplicate parent dependency edges when `parent_key` already creates the same dependency

## Validation
- `go test ./cmd/bd -run 'TestValidateGraphApplyPlan|TestGraphApplyEdgeCanSkipSQLCycleCheck|TestGraphApplyParentDepPairs' -count=1`\n- `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -run 'TestEmbeddedCreate/(graph_ephemeral|graph_no_history)$' -count=1`\n- live maintainer-city post-merge graph launches now complete in ~25-26s instead of timing out around 90s\n