### PR TITLE
fix: skip JSONL auto-import and auto-export when serverMode=true

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -68,6 +68,11 @@ func writeAutoImportStamp(beadsDir string, info os.FileInfo) {
 // .beads/dolt/) to 1.0+ (which uses .beads/embeddeddolt/) don't appear to
 // lose their issues.  See GH#2994.
 //
+// serverMode must be true when the store is connected to an external
+// dolt sql-server. In server mode the database is persistent and shared;
+// the JSONL recovery path is irrelevant and attempting it causes a
+// serialization conflict with initSchema's open transaction (Error 1213).
+//
 // The top-level emptiness guard (GetStatistics) is the primary
 // protection for BOTH the embedded fast-path and the server-mode
 // fallback. Defense in depth backs each path up: the embedded
@@ -81,7 +86,10 @@ func writeAutoImportStamp(beadsDir string, info os.FileInfo) {
 //
 // The function is best-effort: failures are logged as warnings but do not
 // prevent the store from being used.
-func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir string) {
+func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir string, serverMode bool) {
+	if serverMode {
+		return
+	}
 	// Quick check: does the JSONL file exist and have content?
 	jsonlPath := configuredImportJSONLPath(beadsDir)
 	info, err := os.Stat(jsonlPath)

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -90,7 +90,7 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenNonEmpty(t *testing.T) {
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
 
 	store := &fakeFallbackStore{statsTotalIssues: 5}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("regression: fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
@@ -138,7 +138,7 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsReportNonEmpty
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		maybeAutoImportJSONL(ctx, store, dir)
+		maybeAutoImportJSONL(ctx, store, dir, false)
 	}()
 
 	select {
@@ -202,7 +202,7 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsNil(t *testing
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
 
 	store := &fakeFallbackStore{statsNil: true}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("fallback importer was invoked %d time(s) when statistics were nil; expected 0", got)
@@ -222,7 +222,7 @@ func TestMaybeAutoImportJSONL_FallbackImporter_RunsWhenEmpty(t *testing.T) {
 	count := swapFallbackImporter(t, errors.New("test importer: short-circuit before s.Commit"))
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 1 {
 		t.Fatalf("fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
@@ -245,7 +245,7 @@ func TestMaybeAutoImportJSONL_UsesConfiguredImportPath(t *testing.T) {
 	t.Cleanup(func() { fallbackImporter = orig })
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	wantPath := filepath.Join(dir, "beads.jsonl")
 	if gotPath != wantPath {
@@ -259,8 +259,8 @@ func TestMaybeAutoImportJSONL_FailedImportStampPreventsRepeatedImport(t *testing
 	count := swapFallbackImporter(t, errors.New("test importer failed"))
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir)
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 1 {
 		t.Fatalf("fallback importer invoked %d time(s), want 1 for unchanged JSONL after failed attempt stamp", got)
@@ -279,8 +279,8 @@ func TestMaybeAutoImportJSONL_SuccessStampPreventsRepeatedImport(t *testing.T) {
 	t.Cleanup(func() { fallbackImporter = orig })
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir)
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 1 {
 		t.Fatalf("fallback importer invoked %d time(s), want 1 for unchanged JSONL after success stamp", got)
@@ -299,11 +299,11 @@ func TestMaybeAutoImportJSONL_ChangedJSONLBypassesSuccessStamp(t *testing.T) {
 	t.Cleanup(func() { fallbackImporter = orig })
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 	if err := os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte(`{"_type":"issue","id":"unit-2","title":"changed","status":"open","priority":2,"issue_type":"task"}`+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 2 {
 		t.Fatalf("fallback importer invoked %d time(s), want 2 after JSONL changed", got)
@@ -400,4 +400,22 @@ func TestAutoImportFallbackSeamUsesConflictSkip(t *testing.T) {
 			t.Fatalf("bd bootstrap / init --from-jsonl must keep UPSERT (ConflictSkip=false); got true")
 		}
 	})
+}
+
+// TestMaybeAutoImportJSONL_SkipsEntirelyInServerMode verifies the early return
+// added in the serverMode guard. In server mode the database is persistent and
+// shared; the JSONL recovery path is irrelevant and would trigger a
+// serialization conflict (Error 1213) with initSchema's open transaction.
+// Passing nil as the store is safe because the early return fires before any
+// store method is called.
+func TestMaybeAutoImportJSONL_SkipsEntirelyInServerMode(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	count := swapFallbackImporter(t, nil)
+
+	maybeAutoImportJSONL(context.Background(), nil, dir, true)
+
+	if got := count.Load(); got != 0 {
+		t.Fatalf("fallbackImporter invoked %d time(s) with serverMode=true; expected 0", got)
+	}
 }

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -1032,3 +1032,20 @@ func autoExportDataLossTestEnv(home string) []string {
 	}
 	return append(env, "HOME="+home, "BEADS_DOLT_AUTO_START=0", "BEADS_NO_DAEMON=1")
 }
+
+// TestMaybeAutoExportJSONL_SkipsEntirelyInServerMode verifies that
+// maybeAutoExport returns immediately when serverMode is true, making
+// no store access and causing no side effects. Mirrors the guard in
+// maybeAutoImportJSONL (GH#3944).
+func TestMaybeAutoExportJSONL_SkipsEntirelyInServerMode(t *testing.T) {
+	// Leave the global store nil — any access would panic, so a clean return
+	// without panic is proof the serverMode guard fires before any store call.
+	orig := store
+	store = nil
+	t.Cleanup(func() { store = orig })
+
+	// Must not panic.
+	if err := maybeAutoExport(context.Background(), true, false); err != nil {
+		t.Fatalf("maybeAutoExport(serverMode=true): %v", err)
+	}
+}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1099,7 +1099,7 @@ var rootCmd = &cobra.Command{
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
 		if shouldRunAutoImportJSONL(cmd, store, useReadOnly, globalFlag, doltCfg.ServerMode) {
-			maybeAutoImportJSONL(rootCtx, store, beadsDir)
+			maybeAutoImportJSONL(rootCtx, store, beadsDir, doltCfg.ServerMode)
 		}
 
 		// Validate workspace identity for write commands (GH#2438, GH#2372)


### PR DESCRIPTION
fix: skip JSONL auto-import and auto-export when serverMode=true

## What

Two related guards added to prevent unnecessary store access in server mode:

1. `maybeAutoImportJSONL` now accepts a `serverMode bool` parameter and returns immediately when true.
2. `maybeAutoExport` now accepts a `serverMode bool` parameter and returns immediately when true.

## Why

**Auto-import (#2994):** The auto-import introduced in #2994 (upgrade recovery for users migrating from pre-0.56 `.beads/dolt/` to 1.0+ `.beads/embeddeddolt/`) fires on every write command in server mode (`dolt_mode=server` in `metadata.json`), where it is never relevant. In server mode the database lives on a persistent external `dolt sql-server`; the "empty database" condition that triggers the recovery never applies. The fallback import path conflicts with `initSchema`'s open transaction, producing a spurious Error 1213 serialization failure warning on every write.

**Auto-export (this PR):** The auto-export path performs git operations and store reads after every write command. In server mode these are also irrelevant and add unnecessary overhead. Mirroring the same guard keeps the two paths consistent.

## How

**Commit 1 — auto-import:**
- Added `serverMode bool` to `maybeAutoImportJSONL` (early return when true)
- Updated the sole call site in `main.go` to pass `doltCfg.ServerMode`
- Added `TestMaybeAutoImportJSONL_SkipsEntirelyInServerMode` (no CGO required, passes nil store safely) to `auto_import_upgrade_unit_test.go`
- Updated the three existing unit tests to pass `serverMode=false`

**Commit 2 — auto-export:**
- Added `serverMode bool` to `maybeAutoExport` (early return when true)
- Updated the call site in `PersistentPostRun` to pass the global `serverMode` variable
- Added `TestMaybeAutoExportJSONL_SkipsEntirelyInServerMode` to `export_auto_test.go`: leaves `store=nil` and verifies no panic (store access would panic, so clean return proves the guard fires first)

## Verification

```bash
# Unit tests (no CGO, no running server required)
go test -tags gms_pure_go -run 'TestMaybeAutoImportJSONL|TestMaybeAutoExportJSONL|TestShouldRunPostCommand' ./cmd/bd/

# Full test suite
make test

# Manual: run any write command against a server-mode store and confirm
# neither "auto-importing N bytes from ..." nor auto-export output appears
bd update <any-id> --status open
```
