### PR TITLE
Fix Dolt endpoint resolution and port handoff safety

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -411,6 +411,16 @@ on the next bd command unless auto-start is disabled.`,
 		if beadsDir == "" {
 			FatalErrorWithHint(activeWorkspaceNotFoundError(), diagHint())
 		}
+		endpoint, _, err := doltserver.ResolveEndpoint(beadsDir, doltserver.ResolveOptions{Purpose: doltserver.EndpointPurposeLifecycle})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if endpoint.Owner == doltserver.EndpointOwnerExternal || endpoint.Owner == doltserver.EndpointOwnerGC {
+			fmt.Fprintf(os.Stderr, "Dolt server is %s-managed; bd will not stop it from this workspace.\n", endpoint.Owner)
+			fmt.Fprintf(os.Stderr, "Endpoint: %s:%d database %s\n", endpoint.Host, endpoint.Port, endpoint.Database)
+			os.Exit(1)
+		}
 		serverDir := doltserver.ResolveServerDir(beadsDir)
 		force, _ := cmd.Flags().GetBool("force")
 
@@ -444,29 +454,16 @@ reachability, server version, and database.`,
 			return
 		}
 
-		// For externally-managed Dolt servers, the local PID file is
-		// meaningless or absent — ping the configured endpoint via SQL
-		// instead. Two flavors qualify:
-		//   - non-local host (Hosted Dolt, remote shared sql-server, bd-q35w)
-		//   - local host with auto-start disabled (an orchestrator or
-		//     systemd manages the server lifecycle, be-0eyj)
-		//
-		// IsAutoStartDisabled reads the active (globally-bound) config and
-		// BEADS_DOLT_AUTO_START env, not the per-beadsDir cfg loaded just
-		// below. That coupling is intentional and consistent with every
-		// other call site of IsAutoStartDisabled in this package — both
-		// resolve against the same active workspace at command time.
-		cfg, cfgErr := configfile.Load(beadsDir)
-		if cfgErr != nil {
-			// Don't silently swallow. A corrupted or missing metadata.json
-			// would otherwise mask the externally-managed routing for both
-			// the remote-host and auto-start-disabled-local cases, falling
-			// through to the PID-file path with a misleading "not running"
-			// — which is the exact failure mode this PR addresses.
-			fmt.Fprintf(os.Stderr, "Warning: cannot load .beads config (%v); falling back to PID-file status path\n", cfgErr)
+		endpoint, _, err := doltserver.ResolveEndpoint(beadsDir, doltserver.ResolveOptions{Purpose: doltserver.EndpointPurposeRead})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
 		}
-		if cfg != nil && shouldUseExternalDoltStatus(cfg, doltserver.IsAutoStartDisabled()) {
-			runExternalDoltStatus(beadsDir, cfg)
+		if endpoint.Owner == doltserver.EndpointOwnerExternal ||
+			endpoint.Owner == doltserver.EndpointOwnerGC ||
+			endpoint.Owner == doltserver.EndpointOwnerShared ||
+			!isLocalHost(endpoint.Host) {
+			runEndpointDoltStatus(beadsDir, endpoint)
 			return
 		}
 
@@ -494,7 +491,11 @@ func renderLocalDoltStatus(state *doltserver.State, serverDir string) {
 	if state == nil || !state.Running {
 		cfg := doltserver.DefaultConfig(serverDir)
 		fmt.Println("Dolt server: not running")
-		fmt.Printf("  Expected port: %d\n", cfg.Port)
+		if cfg.Port > 0 {
+			fmt.Printf("  Expected port: %d\n", cfg.Port)
+		} else {
+			fmt.Println("  Expected port: unresolved")
+		}
 		return
 	}
 	fmt.Println("Dolt server: running")
@@ -552,11 +553,33 @@ func isLocalHost(host string) bool {
 // log file — reachability, version, host/port/database, and TLS mode are the
 // user-relevant signals.
 func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
-	host := cfg.GetDoltServerHost()
-	port := doltserver.DefaultConfig(beadsDir).Port
-	user := cfg.GetDoltServerUser()
-	database := cfg.GetDoltDatabase()
-	tls := cfg.GetDoltServerTLS()
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+	endpoint := doltserver.Endpoint{
+		Host:     cfg.GetDoltServerHost(),
+		Port:     doltserver.DefaultConfig(beadsDir).Port,
+		User:     cfg.GetDoltServerUser(),
+		Database: cfg.GetDoltDatabase(),
+		TLS:      cfg.GetDoltServerTLS(),
+		Owner:    doltserver.EndpointOwnerExternal,
+		Source:   doltserver.EndpointSourceMetadata,
+		Resolved: doltserver.DefaultConfig(beadsDir).Port > 0,
+		Dialable: doltserver.DefaultConfig(beadsDir).Port > 0,
+	}
+	runEndpointDoltStatus(beadsDir, endpoint)
+}
+
+func runEndpointDoltStatus(beadsDir string, endpoint doltserver.Endpoint) {
+	host := endpoint.Host
+	port := endpoint.Port
+	user := endpoint.User
+	database := endpoint.Database
+	tls := endpoint.TLS
+	cfg, _ := configfile.Load(beadsDir)
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
 	password := cfg.GetDoltServerPasswordForPort(port)
 
 	dsn := doltutil.ServerDSN{
@@ -569,12 +592,23 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 	}.String()
 
 	result := map[string]interface{}{
-		"mode":     "external",
+		"mode":     string(endpoint.Owner),
 		"host":     host,
 		"port":     port,
 		"user":     user,
 		"database": database,
 		"tls":      tls,
+	}
+	if !endpoint.Resolved || !endpoint.Dialable {
+		result["running"] = false
+		result["error"] = "Dolt server endpoint is unresolved"
+		if jsonOutput {
+			outputJSON(result)
+			return
+		}
+		fmt.Printf("Dolt server: unresolved (%s)\n", endpoint.Owner)
+		fmt.Println("  Error:    no resolved Dolt server port")
+		return
 	}
 
 	db, openErr := sql.Open("mysql", dsn)
@@ -611,9 +645,9 @@ func runExternalDoltStatus(beadsDir string, cfg *configfile.Config) {
 	}
 
 	if running {
-		fmt.Println("Dolt server: running (external)")
+		fmt.Printf("Dolt server: running (%s)\n", endpoint.Owner)
 	} else {
-		fmt.Println("Dolt server: not reachable (external)")
+		fmt.Printf("Dolt server: not reachable (%s)\n", endpoint.Owner)
 	}
 	fmt.Printf("  Host:     %s\n", host)
 	fmt.Printf("  Port:     %d\n", port)
@@ -1272,10 +1306,13 @@ func showDoltConfig(testConnection bool) {
 	backend := cfg.GetBackend()
 	embedded := !usesSQLServer()
 
-	// Resolve actual server port for connection testing
-	showHost := cfg.GetDoltServerHost()
-	dsCfg := doltserver.DefaultConfig(beadsDir)
-	showPort := dsCfg.Port
+	endpoint, diagnostics, err := doltserver.ResolveEndpoint(beadsDir, doltserver.ResolveOptions{Purpose: doltserver.EndpointPurposeRead})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving Dolt endpoint: %v\n", err)
+		os.Exit(1)
+	}
+	showHost := endpoint.Host
+	showPort := endpoint.Port
 	embeddedDataDir := filepath.Join(beadsDir, "embeddeddolt")
 
 	if jsonOutput {
@@ -1291,9 +1328,12 @@ func showDoltConfig(testConnection bool) {
 				result["host"] = showHost
 				result["port"] = showPort
 				result["user"] = cfg.GetDoltServerUser()
+				result["endpoint_owner"] = string(endpoint.Owner)
+				result["endpoint_source"] = string(endpoint.Source)
+				result["endpoint_resolved"] = endpoint.Resolved
 				result["shared_server"] = doltserver.IsSharedServerMode()
 				if testConnection {
-					result["connection_ok"] = testServerConnection(showHost, showPort)
+					result["connection_ok"] = endpoint.Dialable && testServerConnection(showHost, showPort)
 				}
 			}
 		}
@@ -1314,7 +1354,11 @@ func showDoltConfig(testConnection bool) {
 		fmt.Printf("  Data:     %s\n", embeddedDataDir)
 	} else {
 		fmt.Printf("  Host:     %s\n", showHost)
-		fmt.Printf("  Port:     %d\n", showPort)
+		if endpoint.Resolved {
+			fmt.Printf("  Port:     %d\n", showPort)
+		} else {
+			fmt.Println("  Port:     unresolved")
+		}
 		fmt.Printf("  User:     %s\n", cfg.GetDoltServerUser())
 		if doltserver.IsSharedServerMode() {
 			fmt.Println("  Mode:     shared server")
@@ -1327,11 +1371,14 @@ func showDoltConfig(testConnection bool) {
 
 		if testConnection {
 			fmt.Println()
-			if testServerConnection(showHost, showPort) {
+			if endpoint.Dialable && testServerConnection(showHost, showPort) {
 				fmt.Printf("  %s\n", ui.RenderPass("✓ Server connection OK"))
 			} else {
 				fmt.Printf("  %s\n", ui.RenderWarn("✗ Server not reachable"))
 			}
+		}
+		for _, diagnostic := range diagnostics {
+			fmt.Printf("  %s\n", ui.RenderWarn(diagnostic.Message))
 		}
 	}
 
@@ -1530,6 +1577,13 @@ func setDoltConfig(key, value string, updateConfig bool) {
 		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
 		os.Exit(1)
 	}
+	if key == "port" {
+		port, _ := strconv.Atoi(value)
+		if err := doltserver.WriteResolvedPort(beadsDir, port, doltserver.PortWriteReasonSetPort); err != nil {
+			fmt.Fprintf(os.Stderr, "Error saving port file: %v\n", err)
+			os.Exit(1)
+		}
+	}
 
 	if jsonOutput {
 		result := map[string]interface{}{
@@ -1576,16 +1630,27 @@ func testDoltConnection() {
 		os.Exit(1)
 	}
 
-	host := cfg.GetDoltServerHost()
-	port := doltserver.DefaultConfig(beadsDir).Port
-	addr := fmt.Sprintf("%s:%d", host, port)
+	endpoint, _, err := doltserver.ResolveEndpoint(beadsDir, doltserver.ResolveOptions{Purpose: doltserver.EndpointPurposeRead})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving Dolt endpoint: %v\n", err)
+		os.Exit(1)
+	}
+	host := endpoint.Host
+	port := endpoint.Port
+	addr := "unresolved Dolt endpoint"
+	if endpoint.Resolved {
+		addr = fmt.Sprintf("%s:%d", host, port)
+	}
 
 	if jsonOutput {
-		ok := testServerConnection(host, port)
+		ok := endpoint.Dialable && testServerConnection(host, port)
 		outputJSON(map[string]interface{}{
-			"host":          host,
-			"port":          port,
-			"connection_ok": ok,
+			"host":              host,
+			"port":              port,
+			"endpoint_owner":    string(endpoint.Owner),
+			"endpoint_source":   string(endpoint.Source),
+			"endpoint_resolved": endpoint.Resolved,
+			"connection_ok":     ok,
 		})
 		if !ok {
 			os.Exit(1)
@@ -1595,11 +1660,15 @@ func testDoltConnection() {
 
 	fmt.Printf("Testing connection to %s...\n", addr)
 
-	if testServerConnection(host, port) {
+	if endpoint.Dialable && testServerConnection(host, port) {
 		fmt.Printf("%s\n", ui.RenderPass("✓ Connection successful"))
 	} else {
 		fmt.Printf("%s\n", ui.RenderWarn("✗ Connection failed"))
-		fmt.Println("\nStart the server with: bd dolt start")
+		if endpoint.Owner == doltserver.EndpointOwnerBeads {
+			fmt.Println("\nStart the server with: bd dolt start")
+		} else {
+			fmt.Printf("\nEndpoint is %s-managed; start or repair that owner instead of starting a competing per-project server.\n", endpoint.Owner)
+		}
 		os.Exit(1)
 	}
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -391,8 +391,8 @@ func writePortFile(beadsDir string, port int) error {
 }
 
 // EnsurePortFile makes the repo-local port file match the connected server port.
-// This is a best-effort repair path for upgraded repos that are missing
-// .beads/dolt-server.port even though commands can still connect.
+// Deprecated: read paths must not call this. Use WriteResolvedPort with an
+// explicit lifecycle/config/doctor reason at the actual mutation site.
 func EnsurePortFile(beadsDir string, port int) error {
 	if beadsDir == "" || port <= 0 {
 		return nil
@@ -404,7 +404,7 @@ func EnsurePortFile(beadsDir string, port int) error {
 	if existing > 0 {
 		fmt.Fprintf(os.Stderr, "Info: updating port file %d → %d in %s\n", existing, port, beadsDir)
 	}
-	return writePortFile(beadsDir, port)
+	return WriteResolvedPort(beadsDir, port, PortWriteReasonDoctorHandoff)
 }
 
 // ReadPortFile returns the port from the project's dolt-server.port file,
@@ -423,69 +423,19 @@ func ReadPortFile(beadsDir string) int {
 // the server is listening on. Consulting it here ensures that commands
 // connecting to an already-running server use the correct port.
 func DefaultConfig(beadsDir string) *Config {
-	// In shared mode, use the shared server directory for port resolution
+	endpoint, _, _ := ResolveEndpoint(beadsDir, ResolveOptions{Purpose: EndpointPurposeRead})
+	cfgBeadsDir := beadsDir
 	if IsSharedServerMode() {
 		if sharedDir, err := SharedServerDir(); err == nil {
-			beadsDir = sharedDir
+			cfgBeadsDir = sharedDir
 		}
 	}
-
 	cfg := &Config{
-		BeadsDir: beadsDir,
-		Host:     "127.0.0.1",
+		BeadsDir: cfgBeadsDir,
+		Host:     endpoint.Host,
+		Port:     endpoint.Port,
 		Mode:     ResolveServerMode(beadsDir),
 	}
-
-	// Check env var override first (used by tests and manual overrides)
-	if p := os.Getenv("BEADS_DOLT_SERVER_PORT"); p != "" {
-		if port, err := strconv.Atoi(p); err == nil {
-			cfg.Port = port
-			return cfg
-		}
-	}
-
-	// Check the port file (gitignored, local-only) — this is the primary
-	// persistent source. Start() writes the actual listening port here.
-	// Elevated to top priority (after env var) to prevent git-tracked values
-	// from causing cross-project data leakage (GH#2372).
-	if p := readPortFile(beadsDir); 0 < p {
-		cfg.Port = p
-		return cfg
-	}
-
-	// Check config.yaml / global config (~/.config/bd/config.yaml) (GH#2073)
-	// Note: project-level config.yaml dolt.port is git-tracked and could
-	// propagate to collaborators. Prefer the gitignored port file above.
-	if cfg.Port == 0 {
-		if p := config.GetYamlConfig("dolt.port"); p != "" {
-			if port, err := strconv.Atoi(p); err == nil && port > 0 {
-				cfg.Port = port
-			}
-		}
-	}
-
-	// Deprecated: metadata.json DoltServerPort is git-tracked and propagates
-	// to all contributors, causing cross-project data leakage (GH#2372).
-	// Emit a one-time warning but still use the value as a fallback so
-	// existing setups don't break silently.
-	if cfg.Port == 0 {
-		if metaCfg, err := configfile.Load(beadsDir); err == nil && metaCfg != nil {
-			if metaCfg.DoltServerPort > 0 {
-				fmt.Fprintf(os.Stderr, "Warning: dolt_server_port in metadata.json is deprecated (can cause cross-project data leakage).\n")
-				fmt.Fprintf(os.Stderr, "  The port file (.beads/dolt-server.port) is now the primary source.\n")
-				fmt.Fprintf(os.Stderr, "  Remove dolt_server_port from .beads/metadata.json to silence this warning.\n")
-				cfg.Port = metaCfg.DoltServerPort
-			}
-		}
-	}
-
-	// Port 0 means "no configured port". In shared mode, use the fixed
-	// shared server port. In per-project mode, Start() will allocate an
-	// ephemeral port from the OS (GH#2098, GH#2372).
-	if cfg.Port == 0 && IsSharedServerMode() {
-		cfg.Port = DefaultSharedServerPort // 3308 - avoids orchestrator conflict on 3307
-	}
-
 	return cfg
 }
 
@@ -583,7 +533,6 @@ func EnsureRunningDetailed(beadsDir string) (port int, startedByUs bool, err err
 		return 0, false, err
 	}
 	if state.Running {
-		_ = EnsurePortFile(serverDir, state.Port)
 		return state.Port, false, nil
 	}
 
@@ -754,7 +703,7 @@ startupLoop:
 			if adoptPID > 0 {
 				_ = logFile.Close()
 				_ = os.WriteFile(pidPath(beadsDir), []byte(strconv.Itoa(adoptPID)), 0600)
-				_ = writePortFile(beadsDir, actualPort)
+				_ = WriteResolvedPort(beadsDir, actualPort, PortWriteReasonStartedServer)
 				return &State{Running: true, PID: adoptPID, Port: actualPort, DataDir: doltDir}, nil
 			}
 		}
@@ -842,7 +791,7 @@ startupLoop:
 		}
 		return nil, fmt.Errorf("writing PID file: %w", err)
 	}
-	if err := writePortFile(beadsDir, actualPort); err != nil {
+	if err := WriteResolvedPort(beadsDir, actualPort, PortWriteReasonStartedServer); err != nil {
 		if proc, findErr := os.FindProcess(pid); findErr == nil {
 			_ = proc.Kill()
 		}

--- a/internal/doltserver/endpoint.go
+++ b/internal/doltserver/endpoint.go
@@ -1,0 +1,215 @@
+package doltserver
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+type EndpointPurpose string
+
+const (
+	EndpointPurposeRead      EndpointPurpose = "read"
+	EndpointPurposeLifecycle EndpointPurpose = "lifecycle"
+	EndpointPurposeConfig    EndpointPurpose = "config"
+	EndpointPurposeDoctorFix EndpointPurpose = "doctor-fix"
+)
+
+type EndpointOwner string
+
+const (
+	EndpointOwnerBeads    EndpointOwner = "beads"
+	EndpointOwnerShared   EndpointOwner = "shared"
+	EndpointOwnerExternal EndpointOwner = "external"
+	EndpointOwnerGC       EndpointOwner = "gc"
+	EndpointOwnerEmbedded EndpointOwner = "embedded"
+	EndpointOwnerUnknown  EndpointOwner = "unknown"
+)
+
+type EndpointSource string
+
+const (
+	EndpointSourceEnv           EndpointSource = "env"
+	EndpointSourcePortFile      EndpointSource = "port-file"
+	EndpointSourceConfigYAML    EndpointSource = "config-yaml"
+	EndpointSourceMetadata      EndpointSource = "metadata"
+	EndpointSourceSharedDefault EndpointSource = "shared-default"
+	EndpointSourceUnresolved    EndpointSource = "unresolved"
+)
+
+type Diagnostic struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+}
+
+type Endpoint struct {
+	Host     string
+	Port     int
+	Database string
+	User     string
+	TLS      bool
+
+	Owner  EndpointOwner
+	Source EndpointSource
+
+	Resolved bool
+	Dialable bool
+}
+
+type ResolveOptions struct {
+	Purpose EndpointPurpose
+}
+
+type PortWriteReason string
+
+const (
+	PortWriteReasonStartedServer PortWriteReason = "started-server"
+	PortWriteReasonSetPort       PortWriteReason = "set-port"
+	PortWriteReasonDoctorHandoff PortWriteReason = "doctor-handoff"
+)
+
+func ResolveEndpoint(beadsDir string, opts ResolveOptions) (Endpoint, []Diagnostic, error) {
+	if opts.Purpose == "" {
+		opts.Purpose = EndpointPurposeRead
+	}
+
+	var diagnostics []Diagnostic
+	cfg := loadEndpointConfig(beadsDir, &diagnostics)
+	if cfg == nil {
+		cfg = configfile.DefaultConfig()
+	}
+
+	host := cfg.GetDoltServerHost()
+	owner := resolveEndpointOwner(cfg)
+	if owner == EndpointOwnerEmbedded {
+		return Endpoint{
+			Host:     host,
+			Database: cfg.GetDoltDatabase(),
+			User:     cfg.GetDoltServerUser(),
+			TLS:      cfg.GetDoltServerTLS(),
+			Owner:    EndpointOwnerEmbedded,
+			Source:   EndpointSourceUnresolved,
+		}, diagnostics, nil
+	}
+
+	port, source := resolveEndpointPort(beadsDir, owner, cfg)
+	if port <= 0 {
+		diagnostics = append(diagnostics, Diagnostic{
+			Level:   "error",
+			Message: "Dolt server endpoint is unresolved; port 0 is not dialable",
+		})
+		return Endpoint{
+			Host:     host,
+			Port:     0,
+			Database: cfg.GetDoltDatabase(),
+			User:     cfg.GetDoltServerUser(),
+			TLS:      cfg.GetDoltServerTLS(),
+			Owner:    owner,
+			Source:   EndpointSourceUnresolved,
+		}, diagnostics, nil
+	}
+
+	return Endpoint{
+		Host:     host,
+		Port:     port,
+		Database: cfg.GetDoltDatabase(),
+		User:     cfg.GetDoltServerUser(),
+		TLS:      cfg.GetDoltServerTLS(),
+		Owner:    owner,
+		Source:   source,
+		Resolved: true,
+		Dialable: true,
+	}, diagnostics, nil
+}
+
+func WriteResolvedPort(beadsDir string, port int, reason PortWriteReason) error {
+	if port <= 0 {
+		return fmt.Errorf("refusing to write unresolved Dolt port %d", port)
+	}
+	switch reason {
+	case PortWriteReasonStartedServer, PortWriteReasonSetPort, PortWriteReasonDoctorHandoff:
+	default:
+		return fmt.Errorf("refusing to write Dolt port without explicit reason: %q", reason)
+	}
+	if existing := readPortFile(beadsDir); existing > 0 && existing != port && reason == PortWriteReasonStartedServer {
+		return fmt.Errorf("refusing to overwrite existing Dolt port file %d with started server port %d; use an explicit handoff or bd dolt set port", existing, port)
+	}
+	return writePortFile(beadsDir, port)
+}
+
+func loadEndpointConfig(beadsDir string, diagnostics *[]Diagnostic) *configfile.Config {
+	if beadsDir == "" {
+		return nil
+	}
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil {
+		*diagnostics = append(*diagnostics, Diagnostic{
+			Level:   "warning",
+			Message: fmt.Sprintf("failed to load metadata.json: %v", err),
+		})
+		return nil
+	}
+	return cfg
+}
+
+func resolveEndpointOwner(cfg *configfile.Config) EndpointOwner {
+	if cfg != nil && strings.ToLower(cfg.DoltMode) == configfile.DoltModeEmbedded && cfg.DoltMode != "" &&
+		os.Getenv("BEADS_DOLT_SERVER_MODE") != "1" && !IsSharedServerMode() {
+		return EndpointOwnerEmbedded
+	}
+	if os.Getenv("GT_ROOT") != "" && os.Getenv("BEADS_DOLT_PORT") != "" {
+		return EndpointOwnerGC
+	}
+	if IsSharedServerMode() {
+		return EndpointOwnerShared
+	}
+	if IsAutoStartDisabled() || os.Getenv("BEADS_DOLT_SERVER_MODE") == "1" || (cfg != nil && cfg.DoltServerPort > 0) {
+		return EndpointOwnerExternal
+	}
+	return EndpointOwnerBeads
+}
+
+func resolveEndpointPort(beadsDir string, owner EndpointOwner, cfg *configfile.Config) (int, EndpointSource) {
+	if p := os.Getenv("BEADS_DOLT_SERVER_PORT"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port, EndpointSourceEnv
+		}
+	}
+	if p := os.Getenv("BEADS_DOLT_PORT"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port, EndpointSourceEnv
+		}
+	}
+
+	portDir := beadsDir
+	if owner == EndpointOwnerShared {
+		if sharedDir, err := SharedServerDir(); err == nil {
+			portDir = sharedDir
+		}
+	}
+	if p := readPortFile(portDir); p > 0 {
+		return p, EndpointSourcePortFile
+	}
+
+	if p := config.GetYamlConfig("dolt.port"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port, EndpointSourceConfigYAML
+		}
+	}
+	if p := config.GetStringFromDir(beadsDir, "dolt.port"); p != "" {
+		if port, err := strconv.Atoi(p); err == nil && port > 0 {
+			return port, EndpointSourceConfigYAML
+		}
+	}
+	if cfg != nil && cfg.DoltServerPort > 0 {
+		return cfg.DoltServerPort, EndpointSourceMetadata
+	}
+	if owner == EndpointOwnerShared {
+		return DefaultSharedServerPort, EndpointSourceSharedDefault
+	}
+	return 0, EndpointSourceUnresolved
+}

--- a/internal/doltserver/endpoint_test.go
+++ b/internal/doltserver/endpoint_test.go
@@ -1,0 +1,122 @@
+package doltserver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+)
+
+func writeEndpointMetadata(t *testing.T, beadsDir string) {
+	t.Helper()
+	cfg := configfile.DefaultConfig()
+	cfg.DoltMode = configfile.DoltModeServer
+	cfg.DoltDatabase = "beads_test"
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+}
+
+func isolateEndpointEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_PORT",
+		"BEADS_DOLT_SHARED_SERVER",
+		"BEADS_DOLT_SERVER_MODE",
+		"BEADS_DOLT_AUTO_START",
+		"GT_ROOT",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestResolveEndpointReadUsesPortFileWithoutMutating(t *testing.T) {
+	isolateEndpointEnv(t)
+	beadsDir := t.TempDir()
+	writeEndpointMetadata(t, beadsDir)
+	portPath := filepath.Join(beadsDir, PortFileName)
+	if err := os.WriteFile(portPath, []byte("14567"), 0o600); err != nil {
+		t.Fatalf("write port file: %v", err)
+	}
+
+	endpoint, diagnostics, err := ResolveEndpoint(beadsDir, ResolveOptions{Purpose: EndpointPurposeRead})
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
+	}
+	if len(diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want none", diagnostics)
+	}
+	if !endpoint.Resolved || !endpoint.Dialable {
+		t.Fatalf("endpoint should be resolved and dialable: %#v", endpoint)
+	}
+	if endpoint.Port != 14567 || endpoint.Source != EndpointSourcePortFile {
+		t.Fatalf("endpoint = %#v, want port-file port 14567", endpoint)
+	}
+	data, err := os.ReadFile(portPath)
+	if err != nil {
+		t.Fatalf("read port file: %v", err)
+	}
+	if string(data) != "14567" {
+		t.Fatalf("port file mutated to %q", string(data))
+	}
+}
+
+func TestResolveEndpointUnresolvedPortIsNotDialable(t *testing.T) {
+	isolateEndpointEnv(t)
+	beadsDir := t.TempDir()
+	writeEndpointMetadata(t, beadsDir)
+
+	endpoint, diagnostics, err := ResolveEndpoint(beadsDir, ResolveOptions{Purpose: EndpointPurposeRead})
+	if err != nil {
+		t.Fatalf("ResolveEndpoint: %v", err)
+	}
+	if endpoint.Resolved || endpoint.Dialable || endpoint.Port != 0 {
+		t.Fatalf("endpoint = %#v, want unresolved port 0", endpoint)
+	}
+	if endpoint.Source != EndpointSourceUnresolved {
+		t.Fatalf("source = %q, want unresolved", endpoint.Source)
+	}
+	if len(diagnostics) == 0 {
+		t.Fatal("expected unresolved diagnostic")
+	}
+}
+
+func TestWriteResolvedPortRequiresExplicitReasonAndPositivePort(t *testing.T) {
+	isolateEndpointEnv(t)
+	beadsDir := t.TempDir()
+
+	if err := WriteResolvedPort(beadsDir, 0, PortWriteReasonStartedServer); err == nil {
+		t.Fatal("WriteResolvedPort accepted port 0")
+	}
+	if err := WriteResolvedPort(beadsDir, 12345, ""); err == nil {
+		t.Fatal("WriteResolvedPort accepted empty reason")
+	}
+	if err := WriteResolvedPort(beadsDir, 12345, PortWriteReasonStartedServer); err != nil {
+		t.Fatalf("WriteResolvedPort: %v", err)
+	}
+	if got := readPortFile(beadsDir); got != 12345 {
+		t.Fatalf("readPortFile = %d, want 12345", got)
+	}
+}
+
+func TestWriteResolvedPortRefusesImplicitStartedServerSwitch(t *testing.T) {
+	isolateEndpointEnv(t)
+	beadsDir := t.TempDir()
+	if err := WriteResolvedPort(beadsDir, 12345, PortWriteReasonSetPort); err != nil {
+		t.Fatalf("initial WriteResolvedPort: %v", err)
+	}
+	if err := WriteResolvedPort(beadsDir, 12346, PortWriteReasonStartedServer); err == nil {
+		t.Fatal("WriteResolvedPort allowed started-server overwrite of existing port")
+	}
+	if got := readPortFile(beadsDir); got != 12345 {
+		t.Fatalf("readPortFile = %d, want original 12345", got)
+	}
+	if err := WriteResolvedPort(beadsDir, 12346, PortWriteReasonDoctorHandoff); err != nil {
+		t.Fatalf("doctor handoff WriteResolvedPort: %v", err)
+	}
+	if got := readPortFile(beadsDir); got != 12346 {
+		t.Fatalf("readPortFile = %d, want handoff port 12346", got)
+	}
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -990,6 +990,9 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	if cfg.ServerSocket != "" {
 		addr = cfg.ServerSocket
 		conn, dialErr = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
+	} else if cfg.ServerPort <= 0 {
+		addr = "unresolved Dolt endpoint"
+		dialErr = fmt.Errorf("no Dolt server port resolved")
 	} else {
 		addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
 		conn, dialErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
@@ -1143,14 +1146,6 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			_ = db.Close()
 			return nil, verifyErr
 		}
-	}
-
-	if isLocalHost(cfg.ServerHost) {
-		beadsDir := cfg.BeadsDir
-		if beadsDir == "" && cfg.Path != "" {
-			beadsDir = filepath.Dir(cfg.Path)
-		}
-		_ = doltserver.EnsurePortFile(beadsDir, cfg.ServerPort)
 	}
 
 	// All writers operate on main — transaction isolation via RunInTransaction


### PR DESCRIPTION
## Summary

- Add an explicit Dolt endpoint resolver that reports host, port, database, owner, source, and dialability.
- Add `WriteResolvedPort` so `.beads/dolt-server.port` writes require an explicit lifecycle/config/doctor reason.
- Stop storage open and read-oriented Dolt CLI paths from silently repairing or rewriting the port file.
- Make `bd dolt show/status/test/stop` reason about unresolved, external, shared, and gc-managed endpoints instead of treating port `0` as dialable or relying only on Beads-owned PID state.

## Validation

- `scripts/pr-preflight.sh --search "Dolt server port resolution gc-managed handoff split-brain" --repo gastownhall/beads`
- `go test ./internal/doltserver`
- `go test ./internal/storage/dolt`
- `go test -tags gms_pure_go ./cmd/bd -run 'TestRenderLocalDoltStatus|TestRunExternalDoltStatus'`

`make test` was also run, but it failed on local/environmental issues outside this patch: `cmd/bd` timed out in `TestContextUsesExplicitDBFlagForNoDBCommand`, and role tests observed local `beads.role=maintainer` from git config.
