### PR TITLE
fix(test): split stdout/stderr in bdDepJSON and update_json_output (be-h2rukt)

### DIFF
--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -49,11 +50,13 @@ func bdDepJSON(t *testing.T, bd, dir string, args ...string) map[string]interfac
 	cmd := exec.Command(bd, fullArgs...)
 	cmd.Dir = dir
 	cmd.Env = bdEnv(dir)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("bd dep --json %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bd dep --json %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
 	}
-	s := strings.TrimSpace(string(out))
+	s := strings.TrimSpace(stdout.String())
 	start := strings.IndexAny(s, "{[")
 	if start < 0 {
 		t.Fatalf("no JSON in dep output: %s", s)

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -743,11 +743,13 @@ func TestEmbeddedUpdate(t *testing.T) {
 		cmd := exec.Command(bd, "update", issue.ID, "--status", "in_progress", "--json")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("bd update --json failed: %v\n%s", err, out)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("bd update --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 		}
-		s := string(out)
+		s := stdout.String()
 		start := strings.Index(s, "[")
 		if start < 0 {
 			start = strings.Index(s, "{")


### PR DESCRIPTION
## Summary

- `bdDepJSON` in `cmd/bd/dep_embedded_test.go`: replace `CombinedOutput()` with split `bytes.Buffer` for stdout/stderr; parse only stdout
- `update_json_output` sub-test in `cmd/bd/update_embedded_test.go`: same fix inline
- Both mirror the pattern from PR #3967 (`cmd/bd/label_embedded_test.go`)

## Root cause

`warnJSONLWithoutDoltRemote` (cmd/bd/hooks.go) emits a `beads: ...` warning to stderr when a test repo has no Dolt remote. `CombinedOutput()` merges stdout+stderr, so `json.Unmarshal` sees the warning prefix and fails with `invalid character 'b' after top-level value`.

## Fixes

- `TestEmbeddedDep/add_json_output`
- `TestEmbeddedUpdate/update_json_output`

Closes be-h2rukt. Unblocks CI on PRs #3971 and #3973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)