### PR TITLE
fix(test): bump listenWait 2s→10s to fix flaky TestProxy_IdleTimeout_Fires

### DIFF
--- a/internal/storage/dbproxy/proxy/server_test.go
+++ b/internal/storage/dbproxy/proxy/server_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	listenWait   = 2 * time.Second
+	listenWait   = 10 * time.Second
 	shutdownWait = 5 * time.Second
 	ioTimeout    = 2 * time.Second
 )

--- a/release-gates/be-0x7ztf-gate.md
+++ b/release-gates/be-0x7ztf-gate.md
@@ -1,0 +1,27 @@
+# Release Gate: be-0x7ztf — fix flaky TestProxy_IdleTimeout_Fires
+
+**Branch:** `deploy/be-0x7ztf-proxy-listen-wait` (cherry-pick of d647f8837 onto origin/main)  
+**Date:** 2026-05-16  
+**Deployer:** beads/deployer
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | **PASS** | be-lw9lkj: "Review verdict: PASS" — no findings, gofmt clean, all acceptance criteria met |
+| 2 | Acceptance criteria met | **PASS** | server_test.go:26 reads `listenWait = 10 * time.Second`; `go test ./internal/storage/dbproxy/proxy/...` exits 0; `gofmt -l` clean; no other lines changed |
+| 3 | Tests pass | **PASS** | `go test ./internal/storage/dbproxy/proxy/... -count=1`: `ok` 6.012s |
+| 4 | No high-severity findings open | **PASS** | Review table: 0 findings (— / — / — / —) |
+| 5 | Final branch is clean | **PASS** | One cherry-pick commit; `git status` clean |
+| 6 | Branch diverges cleanly from main | **PASS** | Clean cherry-pick of d647f8837 onto origin/main — zero conflicts |
+
+**Overall: PASS**
+
+## Branch Note
+
+The builder's feature branch (`fix/be-0x7ztf-proxy-listen-wait`) was based on
+`feat/be-fqjs3v-bdd-daemon-foundation` and carried 5 unrelated upstream commits.
+The deploy branch is a clean cherry-pick of just the fix commit (d647f8837) onto
+`origin/main`, since `internal/storage/dbproxy/proxy/server_test.go` already
+exists on main and the patch applies without conflict. The reviewer reviewed the
+one-line change; the deploy branch carries exactly that change.


### PR DESCRIPTION
## What this changes

`TestProxy_IdleTimeout_Fires` in `internal/storage/dbproxy/proxy/server_test.go` was using a 2-second deadline for the proxy to write its pidfile. The proxy only writes the pidfile after completing `net.Listen`, `server.Start`, and `waitForServerReady` — under heavy CI load with parallel tests, this multi-step startup can exceed 2s, producing a spurious failure unrelated to the PR under test.

The fix raises the deadline to 10s, which comfortably covers worst-case CI scheduling while remaining well under `go test`'s default 10-minute per-package timeout. The passing path is unchanged: the pidfile typically appears in under 50ms.

## Review notes

- Only `server_test.go` line 26 changes (`listenWait = 2 * time.Second` → `10 * time.Second`)
- `shutdownWait`, `ioTimeout`, and `serverReadyTimeout` are not touched
- No production code changes

## Test plan

- [x] `go test ./internal/storage/dbproxy/proxy/... -count=1` exits 0 (6.0s)
- [x] `gofmt -l internal/storage/dbproxy/proxy/server_test.go` — no output (clean)
- [x] Release gate: [`release-gates/be-0x7ztf-gate.md`](release-gates/be-0x7ztf-gate.md)

🤖 Deployed by actual-factory