### PR TITLE
fix(dolt): commit initial create relations

### DIFF
--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -743,9 +743,11 @@ func TestEmbeddedUpdate(t *testing.T) {
 		cmd := exec.Command(bd, "update", issue.ID, "--status", "in_progress", "--json")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		out, err := cmd.CombinedOutput()
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
 		if err != nil {
-			t.Fatalf("bd update --json failed: %v\n%s", err, out)
+			t.Fatalf("bd update --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, out, stderr.String())
 		}
 		s := string(out)
 		start := strings.Index(s, "[")

--- a/internal/storage/dolt/create_issue_commit_test.go
+++ b/internal/storage/dolt/create_issue_commit_test.go
@@ -1,0 +1,82 @@
+package dolt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestCreateIssueCommitsInitialRelationalData(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createdAt := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	issue := &types.Issue{
+		ID:          "create-relational-data",
+		Title:       "Create with relational data",
+		Description: "labels and comments should live in the create commit",
+		Status:      types.StatusOpen,
+		Priority:    1,
+		IssueType:   types.TypeTask,
+		Labels:      []string{"gc:wisp", "status:pending"},
+		Comments: []*types.Comment{
+			{
+				Author:    "tester",
+				Text:      "seed comment",
+				CreatedAt: createdAt,
+			},
+		},
+	}
+
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	var labelCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?",
+		issue.ID,
+	).Scan(&labelCount); err != nil {
+		t.Fatalf("count committed labels: %v", err)
+	}
+	if labelCount != 2 {
+		t.Fatalf("committed label count = %d, want 2", labelCount)
+	}
+
+	var commentCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM comments AS OF 'HEAD' WHERE issue_id = ?",
+		issue.ID,
+	).Scan(&commentCount); err != nil {
+		t.Fatalf("count committed comments: %v", err)
+	}
+	if commentCount != 1 {
+		t.Fatalf("committed comment count = %d, want 1", commentCount)
+	}
+
+	var labelEventCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+		issue.ID, types.EventLabelAdded,
+	).Scan(&labelEventCount); err != nil {
+		t.Fatalf("count committed label events: %v", err)
+	}
+	if labelEventCount != 2 {
+		t.Fatalf("committed label_added event count = %d, want 2", labelEventCount)
+	}
+
+	var dirtyRelationalTables int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name IN ('labels', 'comments', 'events')
+	`).Scan(&dirtyRelationalTables); err != nil {
+		t.Fatalf("count dirty relational tables: %v", err)
+	}
+	if dirtyRelationalTables != 0 {
+		t.Fatalf("dirty relational table count = %d, want 0", dirtyRelationalTables)
+	}
+}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -43,7 +43,7 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 
 	// Dolt versioning — wisps and no-history issues skip DOLT_COMMIT.
 	if !issue.Ephemeral && !issue.NoHistory {
-		if err := s.doltAddAndCommit(ctx, []string{"issues", "events"},
+		if err := s.doltAddAndCommit(ctx, []string{"issues", "events", "labels", "comments"},
 			fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
 			return err
 		}

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -90,7 +90,7 @@ func CreateIssueInTx(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *t
 		}
 	}
 
-	if err := PersistLabels(ctx, tx, issue); err != nil {
+	if err := PersistLabels(ctx, tx, issue, actor, eventTable, isNew); err != nil {
 		return err
 	}
 	return PersistComments(ctx, tx, issue)
@@ -244,7 +244,7 @@ func InsertIssueIfNew(ctx context.Context, tx *sql.Tx, issueTable string, issue 
 	return existingCount == 0, nil
 }
 
-func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue) error {
+func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, eventTable string, recordEvents bool) error {
 	if len(issue.Labels) == 0 {
 		return nil
 	}
@@ -252,7 +252,18 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue) error {
 	if IsWisp(issue) {
 		labelTable = "wisp_labels"
 	}
+	seen := make(map[string]struct{}, len(issue.Labels))
 	for _, label := range issue.Labels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		if recordEvents {
+			if err := AddLabelInTx(ctx, tx, labelTable, eventTable, issue.ID, label, actor); err != nil {
+				return fmt.Errorf("failed to insert label %q for %s: %w", label, issue.ID, err)
+			}
+			continue
+		}
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 			INSERT INTO %s (issue_id, label)


### PR DESCRIPTION
## Summary
- commit initial labels and comments in the single Dolt create commit
- record initial label_added events from lower-level CreateIssue handling
- add a Dolt regression test that checks committed HEAD state and clean relational tables

## Tests
- go test ./internal/storage/dolt -run TestCreateIssueCommitsInitialRelationalData -count=1 -v
- go test ./internal/storage/issueops
- go test ./internal/storage/dolt -run 'TestCreateIssueCommitsInitialRelationalData|TestGetLabelsForIssues$' -count=1\n- GOTOOLCHAIN=go1.26.2 .githooks/pre-commit