### PR TITLE
fix(storage): preserve mixed issue and wisp reads

### DIFF
--- a/cmd/bd/doctor/deep.go
+++ b/cmd/bd/doctor/deep.go
@@ -84,6 +84,10 @@ func RunDeepValidation(path string) DeepValidationResult {
 	// Get counts for progress reporting
 	_ = db.QueryRow("SELECT COUNT(*) FROM issues").Scan(&result.TotalIssues)             // Best effort: zero counts are safe defaults for diagnostic display
 	_ = db.QueryRow("SELECT COUNT(*) FROM dependencies").Scan(&result.TotalDependencies) // Best effort: zero counts are safe defaults for diagnostic display
+	var wispDependencyCount int
+	if err := db.QueryRow("SELECT COUNT(*) FROM wisp_dependencies").Scan(&wispDependencyCount); err == nil {
+		result.TotalDependencies += wispDependencyCount
+	}
 
 	// Run all deep checks
 	result.ParentConsistency = checkParentConsistency(db)
@@ -127,13 +131,18 @@ func checkParentConsistency(db *sql.DB) DoctorCheck {
 	}
 
 	// Find parent-child deps where either side doesn't exist
+	//nolint:gosec // G202: doctorDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
-		SELECT d.issue_id, COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id
-		FROM dependencies d
+		SELECT d.issue_id, d.depends_on_id
+		FROM (` + doctorDependencyUnionSQL() + `) d
 		WHERE d.type = 'parent-child'
 		  AND (
-		    NOT EXISTS (SELECT 1 FROM issues WHERE id = d.issue_id)
-		    OR NOT EXISTS (SELECT 1 FROM issues WHERE id = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external))
+		    (d.dep_table = 'dependencies' AND NOT EXISTS (SELECT 1 FROM issues WHERE id = d.issue_id))
+		    OR (d.dep_table = 'wisp_dependencies' AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = d.issue_id))
+		    OR (
+		      NOT EXISTS (SELECT 1 FROM issues WHERE id = d.depends_on_id)
+		      AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = d.depends_on_id)
+		    )
 		  )
 		LIMIT 10`
 
@@ -181,12 +190,18 @@ func checkDependencyIntegrity(db *sql.DB) DoctorCheck {
 	}
 
 	// Find any deps where either side is missing
+	//nolint:gosec // G202: doctorDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
-		SELECT d.issue_id, COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id, d.type
-		FROM dependencies d
+		SELECT d.issue_id, d.depends_on_id, d.type
+		FROM (` + doctorDependencyUnionSQL() + `) d
 		WHERE (
-		    NOT EXISTS (SELECT 1 FROM issues WHERE id = d.issue_id)
-		    OR NOT EXISTS (SELECT 1 FROM issues WHERE id = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external))
+		    (d.dep_table = 'dependencies' AND NOT EXISTS (SELECT 1 FROM issues WHERE id = d.issue_id))
+		    OR (d.dep_table = 'wisp_dependencies' AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = d.issue_id))
+		    OR (
+		      d.depends_on_id NOT LIKE 'external:%'
+		      AND NOT EXISTS (SELECT 1 FROM issues WHERE id = d.depends_on_id)
+		      AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = d.depends_on_id)
+		    )
 		  )
 		LIMIT 10`
 
@@ -234,15 +249,18 @@ func checkEpicCompleteness(db *sql.DB) DoctorCheck {
 	}
 
 	// Find epics where all children are closed but epic is still open
+	//nolint:gosec // G202: doctorDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
 		SELECT e.id, e.title,
-		       COUNT(c.id) as total_children,
-		       SUM(CASE WHEN c.status = 'closed' THEN 1 ELSE 0 END) as closed_children
+		       COUNT(COALESCE(c.id, cw.id)) as total_children,
+		       SUM(CASE WHEN COALESCE(c.status, cw.status) = 'closed' THEN 1 ELSE 0 END) as closed_children
 		FROM issues e
-		JOIN dependencies d ON d.depends_on_issue_id = e.id AND d.type = 'parent-child'
-		JOIN issues c ON c.id = d.issue_id
+		JOIN (` + doctorDependencyUnionSQL() + `) d ON d.depends_on_id = e.id AND d.type = 'parent-child'
+		LEFT JOIN issues c ON c.id = d.issue_id
+		LEFT JOIN wisps cw ON cw.id = d.issue_id
 		WHERE e.issue_type = 'epic'
 		  AND e.status != 'closed'
+		  AND COALESCE(c.id, cw.id) IS NOT NULL
 		GROUP BY e.id
 		HAVING total_children > 0 AND total_children = closed_children
 		LIMIT 20`
@@ -291,25 +309,36 @@ func checkMailThreadIntegrity(db *sql.DB) DoctorCheck {
 		Category: CategoryMetadata,
 	}
 
-	// Check if thread_id column exists
+	// Check if both dependency tables can supply thread_id before using the
+	// union query below.
 	var hasThreadID bool
 	err := db.QueryRow(`
-		SELECT COUNT(*) > 0 FROM INFORMATION_SCHEMA.COLUMNS
-		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'dependencies' AND COLUMN_NAME = 'thread_id'
+		SELECT COUNT(DISTINCT TABLE_NAME) = 2 FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME IN ('dependencies', 'wisp_dependencies')
+		  AND COLUMN_NAME = 'thread_id'
 	`).Scan(&hasThreadID)
-	if err != nil || !hasThreadID {
+	if err != nil {
+		check.Status = StatusWarning
+		check.Message = "Unable to check thread integrity schema"
+		check.Detail = err.Error()
+		return check
+	}
+	if !hasThreadID {
 		check.Status = StatusOK
 		check.Message = "N/A (schema doesn't support thread_id)"
 		return check
 	}
 
 	// Find thread_ids that don't point to existing issues
+	//nolint:gosec // G202: doctorDependencyUnionWithThreadSQL returns a fixed internal SELECT fragment.
 	query := `
 		SELECT d.thread_id, COUNT(*) as refs
-		FROM dependencies d
+		FROM (` + doctorDependencyUnionWithThreadSQL() + `) d
 		WHERE d.thread_id != ''
 		  AND d.thread_id IS NOT NULL
 		  AND NOT EXISTS (SELECT 1 FROM issues WHERE id = d.thread_id)
+		  AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = d.thread_id)
 		GROUP BY d.thread_id
 		LIMIT 10`
 
@@ -425,12 +454,13 @@ func checkMoleculeIntegrity(db *sql.DB) DoctorCheck {
 
 		// nolint:gosec // G201: placeholders contains only ? markers, actual values passed via args
 		brokenQuery := fmt.Sprintf(`
-			SELECT d.depends_on_issue_id, COUNT(*) AS orphan_count
-			FROM dependencies d
-			WHERE d.depends_on_issue_id IN (%s)
+			SELECT d.depends_on_id, COUNT(*) AS orphan_count
+			FROM (`+doctorDependencyUnionSQL()+`) d
+			WHERE d.depends_on_id IN (%s)
 			  AND d.type = 'parent-child'
 			  AND NOT EXISTS (SELECT 1 FROM issues WHERE id = d.issue_id)
-			GROUP BY d.depends_on_issue_id`, strings.Join(placeholders, ","))
+			  AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = d.issue_id)
+			GROUP BY d.depends_on_id`, strings.Join(placeholders, ","))
 
 		brokenRows, err := db.Query(brokenQuery, molIDs...)
 		if err == nil {

--- a/cmd/bd/doctor/deep_test.go
+++ b/cmd/bd/doctor/deep_test.go
@@ -137,6 +137,95 @@ func TestCheckEpicCompleteness_CompletedEpic(t *testing.T) {
 	}
 }
 
+func TestCheckEpicCompleteness_CountsWispChildren(t *testing.T) {
+	store := newTestDoltStore(t, "epic")
+	ctx := context.Background()
+
+	epic := &types.Issue{
+		ID:        "epic-wisp",
+		Title:     "Epic",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeEpic,
+		CreatedAt: time.Now(),
+	}
+	if err := store.CreateIssue(ctx, epic, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	child := &types.Issue{
+		ID:        "epic-wisp.1",
+		Title:     "Wisp child",
+		Status:    types.StatusClosed,
+		IssueType: types.TypeTask,
+		ClosedAt:  ptrTime(time.Now()),
+		NoHistory: true,
+		CreatedAt: time.Now(),
+	}
+	if err := store.CreateIssue(ctx, child, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	dep := &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: epic.ID,
+		Type:        types.DepParentChild,
+		CreatedAt:   time.Now(),
+		CreatedBy:   "test",
+	}
+	if err := store.AddDependency(ctx, dep, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := checkEpicCompleteness(store.UnderlyingDB())
+	if check.Status != StatusWarning {
+		t.Errorf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+}
+
+func TestCheckEpicCompleteness_OpenWispChildPreventsCompletedEpic(t *testing.T) {
+	store := newTestDoltStore(t, "epic")
+	ctx := context.Background()
+
+	epic := &types.Issue{
+		ID:        "epic-open-wisp",
+		Title:     "Epic",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeEpic,
+		CreatedAt: time.Now(),
+	}
+	if err := store.CreateIssue(ctx, epic, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	child := &types.Issue{
+		ID:        "epic-open-wisp.1",
+		Title:     "Open wisp child",
+		Status:    types.StatusOpen,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+		CreatedAt: time.Now(),
+	}
+	if err := store.CreateIssue(ctx, child, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	dep := &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: epic.ID,
+		Type:        types.DepParentChild,
+		CreatedAt:   time.Now(),
+		CreatedBy:   "test",
+	}
+	if err := store.AddDependency(ctx, dep, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := checkEpicCompleteness(store.UnderlyingDB())
+	if check.Status != StatusOK {
+		t.Errorf("Status = %q, want %q; detail=%s", check.Status, StatusOK, check.Detail)
+	}
+}
+
 // TestCheckMailThreadIntegrity_ValidThreads verifies valid thread references pass
 func TestCheckMailThreadIntegrity_ValidThreads(t *testing.T) {
 	store := newTestDoltStore(t, "thread")

--- a/cmd/bd/doctor/dependency_sql.go
+++ b/cmd/bd/doctor/dependency_sql.go
@@ -1,0 +1,22 @@
+package doctor
+
+// Keep in sync with issueops.DepTargetExpr.
+const doctorDependencyTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"
+
+func doctorDependencyUnionSQL() string {
+	return `
+		SELECT 'dependencies' AS dep_table, issue_id, ` + doctorDependencyTargetExpr + ` AS depends_on_id, type
+		FROM dependencies
+		UNION ALL
+		SELECT 'wisp_dependencies' AS dep_table, issue_id, ` + doctorDependencyTargetExpr + ` AS depends_on_id, type
+		FROM wisp_dependencies`
+}
+
+func doctorDependencyUnionWithThreadSQL() string {
+	return `
+		SELECT 'dependencies' AS dep_table, issue_id, ` + doctorDependencyTargetExpr + ` AS depends_on_id, type, thread_id
+		FROM dependencies
+		UNION ALL
+		SELECT 'wisp_dependencies' AS dep_table, issue_id, ` + doctorDependencyTargetExpr + ` AS depends_on_id, type, thread_id
+		FROM wisp_dependencies`
+}

--- a/cmd/bd/doctor/dependency_sql_test.go
+++ b/cmd/bd/doctor/dependency_sql_test.go
@@ -1,0 +1,115 @@
+package doctor
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+func TestDoctorDependencyTargetExprMatchesCanonical(t *testing.T) {
+	if doctorDependencyTargetExpr != issueops.DepTargetExpr {
+		t.Fatalf("doctorDependencyTargetExpr = %q, want %q", doctorDependencyTargetExpr, issueops.DepTargetExpr)
+	}
+}
+
+func TestCheckMailThreadIntegrityRequiresBothDependencyThreadColumns(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("TABLE_NAME IN ('dependencies', 'wisp_dependencies')")).
+		WillReturnRows(sqlmock.NewRows([]string{"has_thread_id"}).AddRow(false))
+
+	check := checkMailThreadIntegrity(db)
+	if check.Status != StatusOK {
+		t.Fatalf("Status = %q, want %q: %s", check.Status, StatusOK, check.Message)
+	}
+	if !strings.Contains(check.Message, "N/A") {
+		t.Fatalf("Message = %q, want N/A schema message", check.Message)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCheckMailThreadIntegrityWarnsWhenSchemaGateFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("TABLE_NAME IN ('dependencies', 'wisp_dependencies')")).
+		WillReturnError(errors.New("information schema unavailable"))
+
+	check := checkMailThreadIntegrity(db)
+	if check.Status != StatusWarning {
+		t.Fatalf("Status = %q, want %q: %s", check.Status, StatusWarning, check.Message)
+	}
+	if !strings.Contains(check.Message, "Unable to check thread integrity schema") {
+		t.Fatalf("Message = %q, want schema warning", check.Message)
+	}
+	if !strings.Contains(check.Detail, "information schema unavailable") {
+		t.Fatalf("Detail = %q, want query error", check.Detail)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCheckMailThreadIntegrityRunsUnionWhenBothTablesHaveThreadID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("TABLE_NAME IN ('dependencies', 'wisp_dependencies')")).
+		WillReturnRows(sqlmock.NewRows([]string{"has_thread_id"}).AddRow(true))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT d.thread_id, COUNT(*) as refs")).
+		WillReturnRows(sqlmock.NewRows([]string{"thread_id", "refs"}))
+
+	check := checkMailThreadIntegrity(db)
+	if check.Status != StatusOK {
+		t.Fatalf("Status = %q, want %q: %s", check.Status, StatusOK, check.Message)
+	}
+	if !strings.Contains(check.Message, "All thread references valid") {
+		t.Fatalf("Message = %q, want valid thread message", check.Message)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCheckMailThreadIntegrityWarnsForOrphanedUnionRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("TABLE_NAME IN ('dependencies', 'wisp_dependencies')")).
+		WillReturnRows(sqlmock.NewRows([]string{"has_thread_id"}).AddRow(true))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT d.thread_id, COUNT(*) as refs")).
+		WillReturnRows(sqlmock.NewRows([]string{"thread_id", "refs"}).AddRow("missing-thread", 2))
+
+	check := checkMailThreadIntegrity(db)
+	if check.Status != StatusWarning {
+		t.Fatalf("Status = %q, want %q: %s", check.Status, StatusWarning, check.Message)
+	}
+	if !strings.Contains(check.Message, "Found 2 orphaned thread references") {
+		t.Fatalf("Message = %q, want orphan warning", check.Message)
+	}
+	if !strings.Contains(check.Detail, "missing-thread (2 refs)") {
+		t.Fatalf("Detail = %q, want missing thread detail", check.Detail)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/cmd/bd/doctor/fix/dependency_sql.go
+++ b/cmd/bd/doctor/fix/dependency_sql.go
@@ -1,0 +1,13 @@
+package fix
+
+// Keep in sync with issueops.DepTargetExpr.
+const fixDependencyTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"
+
+func fixDependencyUnionSQL() string {
+	return `
+		SELECT 'dependencies' AS dep_table, issue_id, ` + fixDependencyTargetExpr + ` AS depends_on_id, type
+		FROM dependencies
+		UNION ALL
+		SELECT 'wisp_dependencies' AS dep_table, issue_id, ` + fixDependencyTargetExpr + ` AS depends_on_id, type
+		FROM wisp_dependencies`
+}

--- a/cmd/bd/doctor/fix/dependency_sql_test.go
+++ b/cmd/bd/doctor/fix/dependency_sql_test.go
@@ -1,0 +1,13 @@
+package fix
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/issueops"
+)
+
+func TestFixDependencyTargetExprMatchesCanonical(t *testing.T) {
+	if fixDependencyTargetExpr != issueops.DepTargetExpr {
+		t.Fatalf("fixDependencyTargetExpr = %q, want %q", fixDependencyTargetExpr, issueops.DepTargetExpr)
+	}
+}

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -36,12 +36,13 @@ func OrphanedDependencies(path string, verbose bool) error {
 	defer db.Close()
 
 	// Find orphaned dependencies (exclude external: cross-rig tracking refs, #1593)
+	//nolint:gosec // G202: fixDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
-		SELECT d.issue_id, COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id
-		FROM dependencies d
-		LEFT JOIN issues i ON i.id = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)
-		WHERE i.id IS NULL
-		  AND d.depends_on_external IS NULL
+		SELECT d.dep_table, d.issue_id, d.depends_on_id
+		FROM (` + fixDependencyUnionSQL() + `) d
+		WHERE NOT EXISTS (SELECT 1 FROM issues i WHERE i.id = d.depends_on_id)
+		  AND NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id)
+		  AND d.depends_on_id NOT LIKE 'external:%'
 	`
 	rows, err := db.Query(query)
 	if err != nil {
@@ -50,6 +51,7 @@ func OrphanedDependencies(path string, verbose bool) error {
 	defer rows.Close()
 
 	type orphan struct {
+		depTable    string
 		issueID     string
 		dependsOnID string
 	}
@@ -57,7 +59,7 @@ func OrphanedDependencies(path string, verbose bool) error {
 
 	for rows.Next() {
 		var o orphan
-		if err := rows.Scan(&o.issueID, &o.dependsOnID); err == nil {
+		if err := rows.Scan(&o.depTable, &o.issueID, &o.dependsOnID); err == nil {
 			orphans = append(orphans, o)
 		}
 	}
@@ -80,8 +82,16 @@ func OrphanedDependencies(path string, verbose bool) error {
 	}
 	var removed int
 	for _, o := range orphans {
-		_, err := tx.Exec("DELETE FROM dependencies WHERE issue_id = ? AND COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) = ?",
-			o.issueID, o.dependsOnID)
+		var err error
+		switch o.depTable {
+		case "dependencies":
+			_, err = tx.Exec("DELETE FROM dependencies WHERE issue_id = ? AND "+fixDependencyTargetExpr+" = ?", o.issueID, o.dependsOnID)
+		case "wisp_dependencies":
+			_, err = tx.Exec("DELETE FROM wisp_dependencies WHERE issue_id = ? AND "+fixDependencyTargetExpr+" = ?", o.issueID, o.dependsOnID)
+		default:
+			fmt.Printf("  Warning: skipped orphaned dependency from unexpected table %s\n", o.depTable)
+			continue
+		}
 		if err != nil {
 			fmt.Printf("  Warning: failed to remove %s→%s: %v\n", o.issueID, o.dependsOnID, err)
 		} else {
@@ -119,13 +129,14 @@ func ChildParentDependencies(path string, verbose bool) error {
 	}
 	defer db.Close()
 
-	// Find child→parent BLOCKING dependencies where issue_id starts with target id + "."
+	// Find child→parent BLOCKING dependencies where issue_id starts with depends_on_id + "."
 	// Only matches blocking types (blocks, conditional-blocks, waits-for) that cause deadlock.
 	// Excludes 'parent-child' type which is a legitimate structural hierarchy relationship.
+	//nolint:gosec // G202: fixDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
-		SELECT d.issue_id, COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id, d.type
-		FROM dependencies d
-		WHERE d.issue_id LIKE CONCAT(COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external), '.%')
+		SELECT d.dep_table, d.issue_id, d.depends_on_id, d.type
+		FROM (` + fixDependencyUnionSQL() + `) d
+		WHERE d.issue_id LIKE CONCAT(d.depends_on_id, '.%')
 		  AND d.type IN ('blocks', 'conditional-blocks', 'waits-for')
 	`
 	rows, err := db.Query(query)
@@ -135,6 +146,7 @@ func ChildParentDependencies(path string, verbose bool) error {
 	defer rows.Close()
 
 	type badDep struct {
+		depTable    string
 		issueID     string
 		dependsOnID string
 		depType     string
@@ -143,7 +155,7 @@ func ChildParentDependencies(path string, verbose bool) error {
 
 	for rows.Next() {
 		var d badDep
-		if err := rows.Scan(&d.issueID, &d.dependsOnID, &d.depType); err == nil {
+		if err := rows.Scan(&d.depTable, &d.issueID, &d.dependsOnID, &d.depType); err == nil {
 			badDeps = append(badDeps, d)
 		}
 	}
@@ -166,8 +178,16 @@ func ChildParentDependencies(path string, verbose bool) error {
 	}
 	var removed int
 	for _, d := range badDeps {
-		_, err := tx.Exec("DELETE FROM dependencies WHERE issue_id = ? AND COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) = ? AND type = ?",
-			d.issueID, d.dependsOnID, d.depType)
+		var err error
+		switch d.depTable {
+		case "dependencies":
+			_, err = tx.Exec("DELETE FROM dependencies WHERE issue_id = ? AND "+fixDependencyTargetExpr+" = ? AND type = ?", d.issueID, d.dependsOnID, d.depType)
+		case "wisp_dependencies":
+			_, err = tx.Exec("DELETE FROM wisp_dependencies WHERE issue_id = ? AND "+fixDependencyTargetExpr+" = ? AND type = ?", d.issueID, d.dependsOnID, d.depType)
+		default:
+			fmt.Printf("  Warning: skipped child→parent dependency from unexpected table %s\n", d.depTable)
+			continue
+		}
 		if err != nil {
 			fmt.Printf("  Warning: failed to remove %s→%s: %v\n", d.issueID, d.dependsOnID, err)
 		} else {

--- a/cmd/bd/doctor/validation.go
+++ b/cmd/bd/doctor/validation.go
@@ -57,12 +57,13 @@ func checkOrphanedDependenciesDB(db *sql.DB) DoctorCheck {
 	// Exclude external: refs — these are synthetic cross-rig tracking deps
 	// injected by the JSONL exporter and intentionally reference issues not
 	// present in the local database (#1593).
+	//nolint:gosec // G202: doctorDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
-		SELECT d.issue_id, COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id, d.type
-		FROM dependencies d
-		LEFT JOIN issues i ON i.id = COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)
-		WHERE i.id IS NULL
-		  AND d.depends_on_external IS NULL
+		SELECT d.issue_id, d.depends_on_id, d.type
+		FROM (` + doctorDependencyUnionSQL() + `) d
+		WHERE d.depends_on_id NOT LIKE 'external:%'
+		  AND NOT EXISTS (SELECT 1 FROM issues i WHERE i.id = d.depends_on_id)
+		  AND NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id)
 	`
 	rows, err := db.Query(query)
 	if err != nil {
@@ -419,10 +420,11 @@ func checkChildParentDependenciesDB(db *sql.DB) DoctorCheck {
 	// Query for child→parent BLOCKING dependencies where issue_id starts with target id + "."
 	// Only matches blocking types (blocks, conditional-blocks, waits-for) that cause deadlock.
 	// Excludes 'parent-child' type which is a legitimate structural hierarchy relationship.
+	//nolint:gosec // G202: doctorDependencyUnionSQL returns a fixed internal SELECT fragment.
 	query := `
-		SELECT d.issue_id, COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id
-		FROM dependencies d
-		WHERE d.issue_id LIKE CONCAT(COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external), '.%')
+		SELECT d.issue_id, d.depends_on_id
+		FROM (` + doctorDependencyUnionSQL() + `) d
+		WHERE d.issue_id LIKE CONCAT(d.depends_on_id, '.%')
 		  AND d.type IN ('blocks', 'conditional-blocks', 'waits-for')
 	`
 	rows, err := db.Query(query)

--- a/cmd/bd/doctor/validation_test.go
+++ b/cmd/bd/doctor/validation_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -504,6 +505,104 @@ func TestCheckChildParentDependenciesDB_NonBlockingIgnored(t *testing.T) {
 
 	if check.Status != StatusOK {
 		t.Errorf("Status = %q, want %q (parent-child type should be ignored)", check.Status, StatusOK)
+	}
+}
+
+func TestCheckOrphanedDependenciesDB_IssueToWispTargetIsNotOrphan(t *testing.T) {
+	store := newTestDoltStore(t, "test")
+	ctx := context.Background()
+
+	issue := &types.Issue{ID: "test-mixed-source", Title: "Source", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue source: %v", err)
+	}
+
+	wisp := &types.Issue{ID: "test-wisp-target", Title: "Target wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, NoHistory: true}
+	if err := store.CreateIssue(ctx, wisp, "test"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+
+	dep := &types.Dependency{
+		IssueID:     issue.ID,
+		DependsOnID: wisp.ID,
+		Type:        types.DepBlocks,
+		CreatedAt:   time.Now(),
+		CreatedBy:   "test",
+	}
+	if err := store.AddDependency(ctx, dep, "test"); err != nil {
+		t.Fatalf("AddDependency issue->wisp: %v", err)
+	}
+
+	check := checkOrphanedDependenciesDB(store.DB())
+	if check.Status != StatusOK {
+		t.Fatalf("Status = %q, want %q; detail=%s", check.Status, StatusOK, check.Detail)
+	}
+}
+
+func TestCheckOrphanedDependenciesDB_WispDependencyMissingTargetDetected(t *testing.T) {
+	store := newTestDoltStore(t, "test")
+	ctx := context.Background()
+
+	wisp := &types.Issue{ID: "test-wisp-source", Title: "Source wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, NoHistory: true}
+	if err := store.CreateIssue(ctx, wisp, "test"); err != nil {
+		t.Fatalf("CreateIssue wisp: %v", err)
+	}
+
+	db := store.DB()
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 0"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO wisp_dependencies (issue_id, depends_on_issue_id, type, created_at, created_by)
+		 VALUES (?, ?, 'blocks', NOW(), 'test')`,
+		wisp.ID, "test-missing-target")
+	if err != nil {
+		t.Fatalf("insert wisp orphan dependency: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "SET FOREIGN_KEY_CHECKS = 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := checkOrphanedDependenciesDB(db)
+	if check.Status != StatusWarning {
+		t.Fatalf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if !strings.Contains(check.Detail, wisp.ID+"→test-missing-target") {
+		t.Fatalf("Detail = %q, want missing wisp dependency", check.Detail)
+	}
+}
+
+func TestCheckChildParentDependenciesDB_WispChildBlockingParentDetected(t *testing.T) {
+	store := newTestDoltStore(t, "test")
+	ctx := context.Background()
+
+	parent := &types.Issue{ID: "test-parent", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	if err := store.CreateIssue(ctx, parent, "test"); err != nil {
+		t.Fatalf("CreateIssue parent: %v", err)
+	}
+
+	child := &types.Issue{ID: "test-parent.1", Title: "Child wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, NoHistory: true}
+	if err := store.CreateIssue(ctx, child, "test"); err != nil {
+		t.Fatalf("CreateIssue child wisp: %v", err)
+	}
+
+	dep := &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: parent.ID,
+		Type:        types.DepBlocks,
+		CreatedAt:   time.Now(),
+		CreatedBy:   "test",
+	}
+	if err := store.AddDependency(ctx, dep, "test"); err != nil {
+		t.Fatalf("AddDependency wisp child->parent: %v", err)
+	}
+
+	check := checkChildParentDependenciesDB(store.DB())
+	if check.Status != StatusWarning {
+		t.Fatalf("Status = %q, want %q", check.Status, StatusWarning)
+	}
+	if !strings.Contains(check.Detail, child.ID+"→"+parent.ID) {
+		t.Fatalf("Detail = %q, want child-parent dependency", check.Detail)
 	}
 }
 

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -379,7 +379,8 @@ func hookWorkTreeRoot() string {
 		return ""
 	}
 	var root string
-	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil { // #nosec G304 -- path is GIT_DIR/gitdir, a well-known git internal file
+	//nolint:gosec // G304: path is GIT_DIR/gitdir, a well-known git internal file.
+	if data, err := os.ReadFile(filepath.Join(gitDir, "gitdir")); err == nil {
 		if dotGit := strings.TrimSpace(string(data)); dotGit != "" {
 			root = filepath.Dir(dotGit)
 		}

--- a/cmd/bd/list_test.go
+++ b/cmd/bd/list_test.go
@@ -680,6 +680,56 @@ func TestStableTreeOrdering(t *testing.T) {
 	})
 }
 
+func TestTreeViewUsesWispDependencyRecords(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStoreWithPrefix(t, filepath.Join(t.TempDir(), "test.db"), "test")
+
+	parent := &types.Issue{
+		ID:        "tree-wisp-parent",
+		Title:     "Parent epic",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	child := &types.Issue{
+		ID:        "tree-wisp-child",
+		Title:     "Wisp child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	for _, issue := range []*types.Issue{parent, child} {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
+		}
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     child.ID,
+		DependsOnID: parent.ID,
+		Type:        types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency: %v", err)
+	}
+
+	allDeps, err := store.GetAllDependencyRecords(ctx)
+	if err != nil {
+		t.Fatalf("GetAllDependencyRecords: %v", err)
+	}
+	if ds := allDeps[child.ID]; len(ds) != 1 || ds[0].DependsOnID != parent.ID {
+		t.Fatalf("wisp dependency records = %+v, want child -> parent", ds)
+	}
+
+	roots, childrenMap := buildIssueTreeWithDeps([]*types.Issue{parent, child}, allDeps)
+	if len(roots) != 1 || roots[0].ID != parent.ID {
+		t.Fatalf("roots = %+v, want only parent root", roots)
+	}
+	children := childrenMap[parent.ID]
+	if len(children) != 1 || children[0].ID != child.ID {
+		t.Fatalf("children[%s] = %+v, want wisp child", parent.ID, children)
+	}
+}
+
 // Helper function to compare string slices for equality
 func slicesEqual(a, b []string) bool {
 	if len(a) != len(b) {

--- a/internal/storage/dberrors/errors.go
+++ b/internal/storage/dberrors/errors.go
@@ -1,0 +1,33 @@
+package dberrors
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+var (
+	quotedTableMissingPattern   = regexp.MustCompile(`(?i)\btable\s+'[^']+'\s+(doesn't exist|does not exist)\b`)
+	unquotedTableMissingPattern = regexp.MustCompile("(?i)^table\\s+`?[^\\s'`]+`?\\s+(doesn't exist|does not exist)\\b")
+)
+
+// IsTableNotExist reports whether err is specifically a MySQL/Dolt
+// table-not-found error. It intentionally does not classify missing columns,
+// schemas, or other objects as optional-table absence.
+func IsTableNotExist(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return mysqlErr.Number == 1146
+	}
+
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "error 1146") ||
+		quotedTableMissingPattern.MatchString(s) ||
+		unquotedTableMissingPattern.MatchString(s)
+}

--- a/internal/storage/dolt/demote_to_wisp_test.go
+++ b/internal/storage/dolt/demote_to_wisp_test.go
@@ -155,6 +155,49 @@ func TestDemoteToWisp_FieldUpdatesApplied(t *testing.T) {
 	}
 }
 
+func TestDemoteToWisp_MetadataAndClosedAtUpdatesApplied(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		Title:     "will close as wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	if err := store.UpdateIssue(ctx, issue.ID, map[string]interface{}{
+		"no_history": true,
+		"status":     string(types.StatusClosed),
+		"metadata":   `{"review":"kept"}`,
+	}, "tester"); err != nil {
+		t.Fatalf("UpdateIssue: %v", err)
+	}
+
+	wisp, err := store.GetIssue(ctx, issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if !wisp.NoHistory {
+		t.Error("NoHistory should be true")
+	}
+	if wisp.Status != types.StatusClosed {
+		t.Errorf("status: got %q, want %q", wisp.Status, types.StatusClosed)
+	}
+	if wisp.ClosedAt == nil {
+		t.Fatal("ClosedAt should be set when demotion closes the issue")
+	}
+	if string(wisp.Metadata) != `{"review":"kept"}` {
+		t.Errorf("metadata: got %s, want %s", string(wisp.Metadata), `{"review":"kept"}`)
+	}
+}
+
 // TestDemoteToWisp_LabelsPreserved verifies that labels are migrated
 // from the permanent labels table to wisp_labels during demotion. (be-x4l)
 func TestDemoteToWisp_LabelsPreserved(t *testing.T) {

--- a/internal/storage/dolt/dependencies.go
+++ b/internal/storage/dolt/dependencies.go
@@ -316,38 +316,18 @@ func (s *DoltStore) IsBlocked(ctx context.Context, issueID string) (bool, []stri
 		return false, nil, nil
 	}
 
-	// Issue is blocked — gather blocker IDs for display.
-	// Query all blocking dependency types to stay consistent with
-	// computeBlockedIDs which considers blocks, waits-for, and
-	// conditional-blocks (GH-1524).
-	rows, err := s.queryContext(ctx, `
-		SELECT d.depends_on_issue_id, d.type
-		FROM dependencies d
-		JOIN issues i ON d.depends_on_issue_id = i.id
-		WHERE d.issue_id = ?
-		  AND d.type IN ('blocks', 'waits-for', 'conditional-blocks')
-		  AND i.status NOT IN ('closed', 'pinned')
-	`, issueID)
-	if err != nil {
-		return false, nil, fmt.Errorf("failed to check blockers: %w", err)
-	}
-
 	var blockers []string
-	for rows.Next() {
-		var id, depType string
-		if err := rows.Scan(&id, &depType); err != nil {
-			_ = rows.Close()
-			return false, nil, wrapScanError("is blocked: scan blocker", err)
+	if err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		blocked, got, err := issueops.IsBlockedInTx(ctx, tx, issueID)
+		if err != nil {
+			return err
 		}
-		if depType != "blocks" {
-			blockers = append(blockers, id+" ("+depType+")")
-		} else {
-			blockers = append(blockers, id)
+		if blocked {
+			blockers = got
 		}
-	}
-	_ = rows.Close()
-	if err := rows.Err(); err != nil {
-		return false, nil, wrapQueryError("is blocked: blocker rows", err)
+		return nil
+	}); err != nil {
+		return false, nil, fmt.Errorf("failed to check blockers: %w", err)
 	}
 
 	return true, blockers, nil
@@ -359,90 +339,13 @@ func (s *DoltStore) IsBlocked(ctx context.Context, issueID string) (bool, []stri
 // sequential queries to avoid Dolt query-planner issues with nested JOIN subqueries.
 // See bd-o23 / hq-g4nxe for the SQL audit that identified this pattern.
 func (s *DoltStore) GetNewlyUnblockedByClose(ctx context.Context, closedIssueID string) ([]*types.Issue, error) {
-	// Step 1: Find open/blocked issues that depend on the closed issue.
-	candidateRows, err := s.queryContext(ctx, `
-		SELECT d.issue_id
-		FROM dependencies d
-		JOIN issues i ON d.issue_id = i.id
-		WHERE d.depends_on_issue_id = ?
-		  AND d.type = 'blocks'
-		  AND i.status NOT IN ('closed', 'pinned')
-	`, closedIssueID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find blocked candidates: %w", err)
-	}
-
-	var candidateIDs []string
-	for candidateRows.Next() {
-		var id string
-		if err := candidateRows.Scan(&id); err != nil {
-			_ = candidateRows.Close()
-			return nil, fmt.Errorf("failed to scan candidate: %w", err)
-		}
-		candidateIDs = append(candidateIDs, id)
-	}
-	_ = candidateRows.Close()
-	if err := candidateRows.Err(); err != nil {
-		return nil, wrapQueryError("get newly unblocked: candidate rows", err)
-	}
-
-	if len(candidateIDs) == 0 {
-		return nil, nil
-	}
-
-	// Step 2: Among candidates, find those that still have OTHER open blockers.
-	// Uses batched IN clauses (queryBatchSize) to avoid full table scans on Dolt.
-	stillBlocked := make(map[string]bool)
-	for start := 0; start < len(candidateIDs); start += queryBatchSize {
-		end := start + queryBatchSize
-		if end > len(candidateIDs) {
-			end = len(candidateIDs)
-		}
-		batch := candidateIDs[start:end]
-		placeholders, args := doltBuildSQLInClause(batch)
-		// Append the closedIssueID to exclude it from "other blockers"
-		args = append(args, closedIssueID)
-
-		// nolint:gosec // G201: placeholders contains only ? markers, actual values passed via args
-		stillBlockedQuery := fmt.Sprintf(`
-			SELECT DISTINCT d2.issue_id
-			FROM dependencies d2
-			JOIN issues blocker ON d2.depends_on_issue_id = blocker.id
-			WHERE d2.issue_id IN (%s)
-			  AND d2.type = 'blocks'
-			  AND d2.depends_on_issue_id != ?
-			  AND blocker.status NOT IN ('closed', 'pinned')
-		`, placeholders)
-
-		blockedRows, err := s.queryContext(ctx, stillBlockedQuery, args...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check remaining blockers: %w", err)
-		}
-
-		for blockedRows.Next() {
-			var id string
-			if err := blockedRows.Scan(&id); err != nil {
-				_ = blockedRows.Close()
-				return nil, fmt.Errorf("failed to scan still-blocked: %w", err)
-			}
-			stillBlocked[id] = true
-		}
-		_ = blockedRows.Close()
-	}
-
-	// Filter to only candidates with no remaining open blockers
-	var unblockedIDs []string
-	for _, id := range candidateIDs {
-		if !stillBlocked[id] {
-			unblockedIDs = append(unblockedIDs, id)
-		}
-	}
-
-	if len(unblockedIDs) == 0 {
-		return nil, nil
-	}
-
-	return s.GetIssuesByIDs(ctx, unblockedIDs)
+	var result []*types.Issue
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.GetNewlyUnblockedByCloseInTx(ctx, tx, closedIssueID)
+		return err
+	})
+	return result, err
 }
 
 // Helper functions

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -3,7 +3,6 @@ package dolt
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -184,66 +183,15 @@ func (s *DoltStore) batchWispExists(ctx context.Context, ids []string) map[strin
 // Uses direct SQL inserts to bypass IsEphemeralID routing, which would otherwise
 // redirect label/dependency/event writes back to wisp tables.
 func (s *DoltStore) PromoteFromEphemeral(ctx context.Context, id string, actor string) error {
-	issue, err := s.getWisp(ctx, id)
-	if errors.Is(err, storage.ErrNotFound) {
-		return fmt.Errorf("wisp %s not found", id)
-	}
-	if err != nil {
-		return wrapDBError("get wisp for promote", err)
-	}
-	if issue == nil {
-		return fmt.Errorf("wisp %s not found", id)
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		return issueops.PromoteFromEphemeralInTx(ctx, tx, id, actor)
+	}); err != nil {
+		return err
 	}
 
-	// Clear ephemeral flag for persistent storage
-	issue.Ephemeral = false
-
-	// Create in issues table (bypasses ephemeral routing since Ephemeral=false)
-	if err := s.CreateIssue(ctx, issue, actor); err != nil {
-		return fmt.Errorf("failed to promote wisp to issues: %w", err)
-	}
-
-	// Copy labels directly to permanent labels table (bypass IsEphemeralID routing)
-	labels, err := s.getWispLabels(ctx, id)
-	if err != nil {
-		return wrapQueryError("get wisp labels for promote", err)
-	}
-	for _, label := range labels {
-		if _, err := s.execContext(ctx,
-			`INSERT IGNORE INTO labels (issue_id, label) VALUES (?, ?)`,
-			id, label); err != nil {
-			return fmt.Errorf("failed to copy label %q: %w", label, err)
-		}
-	}
-
-	if _, err := s.execContext(ctx, `
-		INSERT IGNORE INTO dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)
-		SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id
-		FROM wisp_dependencies WHERE issue_id = ?
-	`, id); err != nil {
-		log.Printf("promote %s: failed to copy dependencies: %v", id, err)
-	}
-
-	// Copy events via INSERT...SELECT (best-effort: log but don't fail promotion)
-	if _, err := s.execContext(ctx, `
-		INSERT IGNORE INTO events (issue_id, event_type, actor, old_value, new_value, comment, created_at)
-		SELECT issue_id, event_type, actor, old_value, new_value, comment, created_at
-		FROM wisp_events WHERE issue_id = ?
-	`, id); err != nil {
-		log.Printf("promote %s: failed to copy events (data may be lost): %v", id, err)
-	}
-
-	// Copy comments via INSERT...SELECT (best-effort: log but don't fail promotion)
-	if _, err := s.execContext(ctx, `
-		INSERT IGNORE INTO comments (issue_id, author, text, created_at)
-		SELECT issue_id, author, text, created_at
-		FROM wisp_comments WHERE issue_id = ?
-	`, id); err != nil {
-		log.Printf("promote %s: failed to copy comments (data may be lost): %v", id, err)
-	}
-
-	// Delete from wisps table (and all wisp_* auxiliary tables)
-	return s.deleteWisp(ctx, id)
+	return s.doltAddAndCommit(ctx,
+		[]string{"issues", "labels", "dependencies", "events", "comments"},
+		fmt.Sprintf("bd: promote %s", id))
 }
 
 // DemoteToWisp moves an issue from the issues table to the wisps table.
@@ -303,6 +251,10 @@ func (s *DoltStore) DemoteToWisp(ctx context.Context, id string, updates map[str
 			VALUES (?, ?, ?, ?, ?)
 		`, id, types.EventUpdated, actor, "", "demoted to wisp"); err != nil {
 			log.Printf("demote %s: failed to record demotion event: %v", id, err)
+		}
+
+		if err := issueops.RetargetInboundDependenciesToWispInTx(ctx, tx, id); err != nil {
+			return err
 		}
 
 		if _, err := tx.ExecContext(ctx, "DELETE FROM issues WHERE id = ?", id); err != nil {

--- a/internal/storage/dolt/ephemeral_routing.go
+++ b/internal/storage/dolt/ephemeral_routing.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"strings"
-	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
+
+var permanentIssueAuxTables = []string{"issues", "labels", "dependencies", "events", "comments"}
 
 // IsEphemeralID returns true if the ID belongs to an ephemeral issue.
 func IsEphemeralID(id string) bool {
@@ -184,73 +184,87 @@ func (s *DoltStore) batchWispExists(ctx context.Context, ids []string) map[strin
 // redirect label/dependency/event writes back to wisp tables.
 func (s *DoltStore) PromoteFromEphemeral(ctx context.Context, id string, actor string) error {
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		return issueops.PromoteFromEphemeralInTx(ctx, tx, id, actor)
+		if err := issueops.PromoteFromEphemeralInTx(ctx, tx, id, actor); err != nil {
+			return err
+		}
+		return s.doltAddAndCommitInTx(ctx, tx, permanentIssueAuxTables, fmt.Sprintf("bd: promote %s", id))
 	}); err != nil {
 		return err
 	}
-
-	return s.doltAddAndCommit(ctx,
-		[]string{"issues", "labels", "dependencies", "events", "comments"},
-		fmt.Sprintf("bd: promote %s", id))
+	s.invalidateBlockedIDsCache()
+	return nil
 }
 
 // DemoteToWisp moves an issue from the issues table to the wisps table.
 // This is the inverse of PromoteFromEphemeral. It applies any provided updates
-// (e.g., setting no_history or ephemeral) to the issue in-memory, then migrates
-// it atomically: insert into wisps, copy auxiliary data, delete from issues.
+// (e.g., setting no_history or ephemeral) without recording an intermediate
+// update event, then migrates it atomically: insert into wisps, copy auxiliary
+// data, delete from issues.
 //
 // Called by UpdateIssue when no_history=true or wisp=true is set on a regular issue.
 func (s *DoltStore) DemoteToWisp(ctx context.Context, id string, updates map[string]interface{}, actor string) error {
-	// Read the current issue from the issues table.
-	issue, err := scanIssueFromTable(ctx, s.db, "issues", id)
-	if err != nil {
-		return fmt.Errorf("failed to get issue for demotion: %w", err)
-	}
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
+		if _, err := issueops.UpdateIssueWithoutEventInTx(ctx, tx, id, updates, actor); err != nil {
+			return fmt.Errorf("update issue before demotion: %w", err)
+		}
 
-	// Apply in-memory updates so the wisps row reflects all requested changes.
-	applyUpdatesToIssueStruct(issue, updates)
+		issue, err := scanIssueTxFromTable(ctx, tx, "issues", id)
+		if err != nil {
+			return fmt.Errorf("failed to get updated issue for demotion: %w", err)
+		}
 
-	return s.withWriteTx(ctx, func(tx *sql.Tx) error {
 		if err := insertIssueTxIntoTable(ctx, tx, "wisps", issue); err != nil {
 			return fmt.Errorf("failed to insert issue into wisps: %w", err)
 		}
 
 		if _, err := tx.ExecContext(ctx, `
-			INSERT IGNORE INTO wisp_labels (issue_id, label)
-			SELECT issue_id, label FROM labels WHERE issue_id = ?
-		`, id); err != nil {
-			log.Printf("demote %s: failed to copy labels (data may be lost): %v", id, err)
+		INSERT IGNORE INTO wisp_labels (issue_id, label)
+		SELECT issue_id, label FROM labels WHERE issue_id = ?
+	`, id); err != nil {
+			return fmt.Errorf("copy labels for demoted issue %s: %w", id, err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM labels WHERE issue_id = ?`, id); err != nil {
+			return fmt.Errorf("delete copied labels for demoted issue %s: %w", id, err)
 		}
 
 		if _, err := tx.ExecContext(ctx, `
-			INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)
-			SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id
-			FROM dependencies WHERE issue_id = ?
-		`, id); err != nil {
-			log.Printf("demote %s: failed to copy dependencies (data may be lost): %v", id, err)
+		INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)
+		SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id
+		FROM dependencies WHERE issue_id = ?
+	`, id); err != nil {
+			return fmt.Errorf("copy dependencies for demoted issue %s: %w", id, err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM dependencies WHERE issue_id = ?`, id); err != nil {
+			return fmt.Errorf("delete copied dependencies for demoted issue %s: %w", id, err)
 		}
 
 		if _, err := tx.ExecContext(ctx, `
-			INSERT IGNORE INTO wisp_events (issue_id, event_type, actor, old_value, new_value, comment, created_at)
-			SELECT issue_id, event_type, actor, old_value, new_value, comment, created_at
-			FROM events WHERE issue_id = ?
-		`, id); err != nil {
-			log.Printf("demote %s: failed to copy events (data may be lost): %v", id, err)
+		INSERT IGNORE INTO wisp_events (issue_id, event_type, actor, old_value, new_value, comment, created_at)
+		SELECT issue_id, event_type, actor, old_value, new_value, comment, created_at
+		FROM events WHERE issue_id = ?
+	`, id); err != nil {
+			return fmt.Errorf("copy events for demoted issue %s: %w", id, err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE issue_id = ?`, id); err != nil {
+			return fmt.Errorf("delete copied events for demoted issue %s: %w", id, err)
 		}
 
 		if _, err := tx.ExecContext(ctx, `
-			INSERT IGNORE INTO wisp_comments (issue_id, author, text, created_at)
-			SELECT issue_id, author, text, created_at
-			FROM comments WHERE issue_id = ?
-		`, id); err != nil {
-			log.Printf("demote %s: failed to copy comments (data may be lost): %v", id, err)
+		INSERT IGNORE INTO wisp_comments (issue_id, author, text, created_at)
+		SELECT issue_id, author, text, created_at
+		FROM comments WHERE issue_id = ?
+	`, id); err != nil {
+			return fmt.Errorf("copy comments for demoted issue %s: %w", id, err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM comments WHERE issue_id = ?`, id); err != nil {
+			return fmt.Errorf("delete copied comments for demoted issue %s: %w", id, err)
 		}
 
 		if _, err := tx.ExecContext(ctx, `
-			INSERT INTO wisp_events (issue_id, event_type, actor, old_value, new_value)
-			VALUES (?, ?, ?, ?, ?)
-		`, id, types.EventUpdated, actor, "", "demoted to wisp"); err != nil {
-			log.Printf("demote %s: failed to record demotion event: %v", id, err)
+		INSERT INTO wisp_events (issue_id, event_type, actor, old_value, new_value)
+		VALUES (?, ?, ?, ?, ?)
+	`, id, types.EventUpdated, actor, "", "demoted to wisp"); err != nil {
+			return fmt.Errorf("record demotion event for demoted issue %s: %w", id, err)
 		}
 
 		if err := issueops.RetargetInboundDependenciesToWispInTx(ctx, tx, id); err != nil {
@@ -261,92 +275,25 @@ func (s *DoltStore) DemoteToWisp(ctx context.Context, id string, updates map[str
 			return fmt.Errorf("failed to delete issue from issues: %w", err)
 		}
 
-		for _, table := range []string{"issues", "labels", "dependencies", "events", "comments"} {
-			_, _ = tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table)
-		}
-		commitMsg := fmt.Sprintf("bd: demote %s to wisp", id)
-		if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
-			commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
-			return fmt.Errorf("dolt commit after demotion: %w", err)
-		}
-
-		return nil
-	})
+		return s.doltAddAndCommitInTx(ctx, tx, permanentIssueAuxTables, fmt.Sprintf("bd: demote %s to wisp", id))
+	}); err != nil {
+		return err
+	}
+	s.invalidateBlockedIDsCache()
+	return nil
 }
 
-// applyUpdatesToIssueStruct applies an updates map (as used by UpdateIssue) to
-// an Issue struct in memory. Used by DemoteToWisp so the wisps row reflects all
-// requested field changes alongside the routing-flag change.
-func applyUpdatesToIssueStruct(issue *types.Issue, updates map[string]interface{}) {
-	now := time.Now().UTC()
-	issue.UpdatedAt = now
-
-	for key, value := range updates {
-		switch key {
-		case "status":
-			if v, ok := value.(string); ok {
-				issue.Status = types.Status(v)
-			}
-		case "title":
-			if v, ok := value.(string); ok {
-				issue.Title = v
-			}
-		case "description":
-			if v, ok := value.(string); ok {
-				issue.Description = v
-			}
-		case "design":
-			if v, ok := value.(string); ok {
-				issue.Design = v
-			}
-		case "notes":
-			if v, ok := value.(string); ok {
-				issue.Notes = v
-			}
-		case "assignee":
-			if v, ok := value.(string); ok {
-				issue.Assignee = v
-			}
-		case "priority":
-			if v, ok := value.(int); ok {
-				issue.Priority = v
-			}
-		case "issue_type":
-			if v, ok := value.(string); ok {
-				issue.IssueType = types.IssueType(v)
-			}
-		case "wisp":
-			if v, ok := value.(bool); ok {
-				issue.Ephemeral = v
-			}
-		case "no_history":
-			if v, ok := value.(bool); ok {
-				issue.NoHistory = v
-			}
-		case "acceptance_criteria":
-			if v, ok := value.(string); ok {
-				issue.AcceptanceCriteria = v
-			}
-		case "external_ref":
-			// nil clears the ref (CLI passes nil for --external-ref ""); non-nil
-			// string sets it. GH#3902.
-			if value == nil {
-				issue.ExternalRef = nil
-			} else if v, ok := value.(string); ok {
-				issue.ExternalRef = &v
-			}
-		case "spec_id":
-			if v, ok := value.(string); ok {
-				issue.SpecID = v
-			}
-		case "estimated_minutes":
-			if v, ok := value.(int); ok {
-				issue.EstimatedMinutes = &v
-			}
+func (s *DoltStore) doltAddAndCommitInTx(ctx context.Context, tx *sql.Tx, tables []string, commitMsg string) error {
+	for _, table := range tables {
+		if _, err := tx.ExecContext(ctx, "CALL DOLT_ADD(?)", table); err != nil {
+			return fmt.Errorf("dolt add %s: %w", table, err)
 		}
-		// closed_at is managed by manageClosedAt; skip here.
-		// Labels, metadata, and other complex fields are handled outside this path.
 	}
+	if _, err := tx.ExecContext(ctx, "CALL DOLT_COMMIT('-m', ?, '--author', ?)",
+		commitMsg, s.commitAuthorString()); err != nil && !isDoltNothingToCommit(err) {
+		return fmt.Errorf("dolt commit: %w", err)
+	}
+	return nil
 }
 
 // getAllWispDependencyRecords returns all wisp dependency records, keyed by issue_id.

--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -11,6 +11,7 @@ import (
 	mysql "github.com/go-sql-driver/mysql"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 )
 
 // Sentinel errors for the dolt storage layer.
@@ -41,8 +42,7 @@ var (
 // fallthrough (pre-migration databases without wisps table) from real errors
 // (timeouts, connection failures, corrupt data).
 func isTableNotExistError(err error) bool {
-	var mysqlErr *mysql.MySQLError
-	return errors.As(err, &mysqlErr) && mysqlErr.Number == 1146
+	return dberrors.IsTableNotExist(err)
 }
 
 // isBranchTrackingError returns true if the error indicates that DOLT_PULL

--- a/internal/storage/dolt/generated_dependency_target_repro_test.go
+++ b/internal/storage/dolt/generated_dependency_target_repro_test.go
@@ -1,0 +1,78 @@
+package dolt
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+)
+
+func TestDoltStoredGeneratedColumnStaleAfterFKCascade(t *testing.T) {
+	if os.Getenv("BEADS_RUN_DOLT_UPSTREAM_REPRO") == "" {
+		t.Skip("set BEADS_RUN_DOLT_UPSTREAM_REPRO=1 to reproduce the Dolt stored generated-column FK cascade bug")
+	}
+
+	// MySQL rejects ON UPDATE CASCADE on a base column referenced by a stored
+	// generated column. Dolt currently accepts the schema and executes the FK
+	// cascade, so this test documents the resulting consistency bug: the base
+	// column updates to the new value, but the stored generated column remains
+	// at the old value.
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if _, err := store.db.ExecContext(ctx, `
+		CREATE TABLE repro_generated_parent (
+			id VARCHAR(255) PRIMARY KEY
+		)
+	`); err != nil {
+		t.Fatalf("create parent table: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		CREATE TABLE repro_generated_child (
+			source_id VARCHAR(255) NOT NULL,
+			target_issue_id VARCHAR(255) NULL,
+			target_wisp_id VARCHAR(255) NULL,
+			target_id VARCHAR(255) AS (COALESCE(target_issue_id, target_wisp_id)) STORED,
+			PRIMARY KEY (source_id, target_id),
+			CONSTRAINT fk_repro_generated_target FOREIGN KEY (target_issue_id)
+				REFERENCES repro_generated_parent(id) ON UPDATE CASCADE
+		)
+	`); err != nil {
+		t.Fatalf("create child table: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO repro_generated_parent (id) VALUES ('old-target')
+	`); err != nil {
+		t.Fatalf("insert parent: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO repro_generated_child (source_id, target_issue_id)
+		VALUES ('source', 'old-target')
+	`); err != nil {
+		t.Fatalf("insert child: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx, `
+		UPDATE repro_generated_parent SET id = 'new-target' WHERE id = 'old-target'
+	`); err != nil {
+		t.Fatalf("rename parent via FK cascade: %v", err)
+	}
+
+	var splitTarget, generatedTarget sql.NullString
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT target_issue_id, target_id
+		FROM repro_generated_child
+		WHERE source_id = 'source'
+	`).Scan(&splitTarget, &generatedTarget); err != nil {
+		t.Fatalf("query child: %v", err)
+	}
+
+	if !splitTarget.Valid || splitTarget.String != "new-target" {
+		t.Fatalf("target_issue_id = %v after FK cascade, want new-target", splitTarget)
+	}
+	if !generatedTarget.Valid || generatedTarget.String != "new-target" {
+		t.Fatalf("target_id = %v after FK cascade, want new-target", generatedTarget)
+	}
+}

--- a/internal/storage/dolt/mixed_table_lifecycle_test.go
+++ b/internal/storage/dolt/mixed_table_lifecycle_test.go
@@ -1,8 +1,12 @@
 package dolt
 
 import (
+	"database/sql"
+	"errors"
+	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -44,6 +48,163 @@ func TestDemoteToWispPreservesInboundDependencies(t *testing.T) {
 	if len(dependents) != 1 || dependents[0].ID != "mixed-demote-src" {
 		t.Fatalf("dependents after demote = %+v, want source", dependents)
 	}
+
+	assertDependencyTargetColumns(t, store, "dependencies", "mixed-demote-src", "mixed-demote-target", false)
+}
+
+func TestDemoteToWispRemovesCopiedOutboundDependencies(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-demote-outbound")
+	createPerm(t, ctx, store, "mixed-demote-outbound-blocker")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-demote-outbound",
+		DependsOnID: "mixed-demote-outbound-blocker",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency before demote: %v", err)
+	}
+
+	if err := store.UpdateIssue(ctx, "mixed-demote-outbound", map[string]interface{}{
+		"no_history": true,
+	}, "tester"); err != nil {
+		t.Fatalf("demote source to no-history wisp: %v", err)
+	}
+
+	assertNoRowsForIssue(t, store, "dependencies", "mixed-demote-outbound")
+
+	deps, err := store.GetDependencies(ctx, "mixed-demote-outbound")
+	if err != nil {
+		t.Fatalf("GetDependencies after demote: %v", err)
+	}
+	if len(deps) != 1 || deps[0].ID != "mixed-demote-outbound-blocker" {
+		t.Fatalf("dependencies after demote = %+v, want demoted wisp to keep outbound dependency", deps)
+	}
+}
+
+func TestDemoteToWispRollsBackWhenAuxiliaryCopyFails(t *testing.T) {
+	cases := []struct {
+		name      string
+		dropTable string
+		wantErr   string
+		issueID   string
+	}{
+		{"labels", "wisp_labels", "copy labels for demoted issue", "mixed-demote-labels-fail"},
+		{"dependencies", "wisp_dependencies", "copy dependencies for demoted issue", "mixed-demote-dependencies-fail"},
+		{"events", "wisp_events", "copy events for demoted issue", "mixed-demote-events-fail"},
+		{"comments", "wisp_comments", "copy comments for demoted issue", "mixed-demote-comments-fail"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			ctx, cancel := testContext(t)
+			defer cancel()
+
+			createPerm(t, ctx, store, tc.issueID)
+
+			if _, err := store.db.ExecContext(ctx, "DROP TABLE "+tc.dropTable); err != nil {
+				t.Fatalf("drop %s: %v", tc.dropTable, err)
+			}
+
+			err := store.UpdateIssue(ctx, tc.issueID, map[string]interface{}{
+				"no_history": true,
+			}, "tester")
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("UpdateIssue error = %v, want %q", err, tc.wantErr)
+			}
+
+			assertRowCountForIssue(t, store, "issues", tc.issueID, 1)
+			assertRowCountForIssue(t, store, "wisps", tc.issueID, 0)
+		})
+	}
+}
+
+func TestDemoteToWispInvalidatesBlockedCache(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-demote-cache-blocker")
+	createPerm(t, ctx, store, "mixed-demote-cache-blocked")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-demote-cache-blocked",
+		DependsOnID: "mixed-demote-cache-blocker",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency before demote: %v", err)
+	}
+
+	if _, err := store.computeBlockedIDs(ctx, true); err != nil {
+		t.Fatalf("computeBlockedIDs: %v", err)
+	}
+	if !store.blockedIDsCached {
+		t.Fatal("expected blocked-ID cache to be populated before demotion")
+	}
+
+	if err := store.UpdateIssue(ctx, "mixed-demote-cache-blocker", map[string]interface{}{
+		"no_history": true,
+		"status":     string(types.StatusClosed),
+	}, "tester"); err != nil {
+		t.Fatalf("demote closed blocker: %v", err)
+	}
+	if store.blockedIDsCached {
+		t.Fatal("expected demotion to invalidate blocked-ID cache")
+	}
+
+	blocked, _, err := store.IsBlocked(ctx, "mixed-demote-cache-blocked")
+	if err != nil {
+		t.Fatalf("IsBlocked after demotion: %v", err)
+	}
+	if blocked {
+		t.Fatal("issue remained blocked after its demoted blocker was closed")
+	}
+}
+
+func TestDemoteToWispLeavesIgnoredWispTablesUnstaged(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-demote-ignored-stage")
+	if err := store.UpdateIssue(ctx, "mixed-demote-ignored-stage", map[string]interface{}{
+		"no_history": true,
+	}, "tester"); err != nil {
+		t.Fatalf("demote to no-history wisp: %v", err)
+	}
+
+	var stagedIgnored int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name IN ('wisps', 'wisp_labels', 'wisp_dependencies', 'wisp_events', 'wisp_comments')
+		  AND staged = TRUE
+	`).Scan(&stagedIgnored); err != nil {
+		t.Fatalf("query ignored staged status: %v", err)
+	}
+	if stagedIgnored != 0 {
+		t.Fatalf("demotion staged %d ignored wisp table(s)", stagedIgnored)
+	}
+
+	var committedWisp int
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM wisps AS OF 'HEAD' WHERE id = ?`,
+		"mixed-demote-ignored-stage",
+	).Scan(&committedWisp); err != nil {
+		t.Fatalf("count committed wisp: %v", err)
+	}
+	if committedWisp != 0 {
+		t.Fatalf("demotion committed ignored wisp row, count = %d", committedWisp)
+	}
 }
 
 func TestPromoteFromEphemeralPreservesInboundDependencies(t *testing.T) {
@@ -81,6 +242,88 @@ func TestPromoteFromEphemeralPreservesInboundDependencies(t *testing.T) {
 	}
 	if len(dependents) != 1 || dependents[0].ID != "mixed-promote-src" {
 		t.Fatalf("dependents after promote = %+v, want source", dependents)
+	}
+
+	assertDependencyTargetColumns(t, store, "dependencies", "mixed-promote-src", "mixed-promote-target", true)
+}
+
+func TestPromoteFromEphemeralRejectsCrossTypedTargetCollision(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-promote-collision-source")
+	createWisp(t, ctx, store, "mixed-promote-collision-target")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-promote-collision-source",
+		DependsOnID: "mixed-promote-collision-target",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency before promote: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO dependencies (issue_id, depends_on_external, type, created_at, created_by, metadata)
+		VALUES (?, ?, ?, NOW(), ?, ?)
+	`, "mixed-promote-collision-source", "mixed-promote-collision-target", types.DepRelated, "tester", "{}"); err != nil {
+		t.Fatalf("seed external collision: %v", err)
+	}
+
+	err := store.PromoteFromEphemeral(ctx, "mixed-promote-collision-target", "tester")
+	if err == nil || !strings.Contains(err.Error(), "collides with existing dependency target") {
+		t.Fatalf("PromoteFromEphemeral error = %v, want collision", err)
+	}
+
+	assertRowCountForIssue(t, store, "wisps", "mixed-promote-collision-target", 1)
+	assertRowCountForIssue(t, store, "issues", "mixed-promote-collision-target", 0)
+	var wispTargetRows, externalTargetRows int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dependencies
+		WHERE issue_id = ? AND depends_on_wisp_id = ?
+	`, "mixed-promote-collision-source", "mixed-promote-collision-target").Scan(&wispTargetRows); err != nil {
+		t.Fatalf("count wisp target rows after failed promote: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dependencies
+		WHERE issue_id = ? AND depends_on_external = ?
+	`, "mixed-promote-collision-source", "mixed-promote-collision-target").Scan(&externalTargetRows); err != nil {
+		t.Fatalf("count external target rows after failed promote: %v", err)
+	}
+	if wispTargetRows != 1 || externalTargetRows != 1 {
+		t.Fatalf("dependency rows after failed promote: wisp=%d external=%d, want 1 each", wispTargetRows, externalTargetRows)
+	}
+}
+
+func TestPromoteFromEphemeralRemovesCopiedOutboundWispDependencies(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createWisp(t, ctx, store, "mixed-promote-outbound")
+	createPerm(t, ctx, store, "mixed-promote-outbound-blocker")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-promote-outbound",
+		DependsOnID: "mixed-promote-outbound-blocker",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency before promote: %v", err)
+	}
+
+	if err := store.PromoteFromEphemeral(ctx, "mixed-promote-outbound", "tester"); err != nil {
+		t.Fatalf("PromoteFromEphemeral: %v", err)
+	}
+
+	assertNoRowsForIssue(t, store, "wisp_dependencies", "mixed-promote-outbound")
+
+	deps, err := store.GetDependencies(ctx, "mixed-promote-outbound")
+	if err != nil {
+		t.Fatalf("GetDependencies after promote: %v", err)
+	}
+	if len(deps) != 1 || deps[0].ID != "mixed-promote-outbound-blocker" {
+		t.Fatalf("dependencies after promote = %+v, want promoted issue to keep outbound dependency", deps)
 	}
 }
 
@@ -126,6 +369,48 @@ func TestPromoteFromEphemeralCommitsAuxiliaryTables(t *testing.T) {
 	}
 	if dirty != 0 {
 		t.Fatalf("promotion left %d committable table(s) dirty", dirty)
+	}
+
+	assertNoRowsForIssue(t, store, "wisp_labels", "mixed-promote-aux")
+	assertNoRowsForIssue(t, store, "wisp_dependencies", "mixed-promote-aux")
+	assertNoRowsForIssue(t, store, "wisp_comments", "mixed-promote-aux")
+}
+
+func TestPromoteFromEphemeralRollsBackWhenAuxiliaryCopyFails(t *testing.T) {
+	cases := []struct {
+		name      string
+		dropTable string
+		wantErr   string
+		wispID    string
+	}{
+		{"labels", "labels", "copy labels for promoted wisp", "mixed-promote-labels-fail"},
+		{"dependencies", "dependencies", "copy dependencies for promoted wisp", "mixed-promote-dependencies-fail"},
+		{"events", "events", "copy events for promoted wisp", "mixed-promote-events-fail"},
+		{"comments", "comments", "copy comments for promoted wisp", "mixed-promote-comments-fail"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, cleanup := setupTestStore(t)
+			defer cleanup()
+
+			ctx, cancel := testContext(t)
+			defer cancel()
+
+			createWisp(t, ctx, store, tc.wispID)
+
+			if _, err := store.db.ExecContext(ctx, "DROP TABLE "+tc.dropTable); err != nil {
+				t.Fatalf("drop %s: %v", tc.dropTable, err)
+			}
+
+			err := store.PromoteFromEphemeral(ctx, tc.wispID, "tester")
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("PromoteFromEphemeral error = %v, want %q", err, tc.wantErr)
+			}
+
+			assertRowCountForIssue(t, store, "wisps", tc.wispID, 1)
+			assertRowCountForIssue(t, store, "issues", tc.wispID, 0)
+		})
 	}
 }
 
@@ -199,6 +484,357 @@ func TestGetReadyWorkExcludesBlockedNoHistoryWisp(t *testing.T) {
 	}
 }
 
+func TestGetReadyWorkExcludesPermBlockedByNoHistoryWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-ready-blocked-perm")
+	noHistory := &types.Issue{
+		ID:        "mixed-ready-blocking-no-history",
+		Title:     "no-history blocker",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history blocker: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-ready-blocked-perm",
+		DependsOnID: "mixed-ready-blocking-no-history",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency blocker: %v", err)
+	}
+
+	ready, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	ids := issueIDs(ready)
+	if containsID(ids, "mixed-ready-blocked-perm") {
+		t.Fatalf("GetReadyWork returned perm issue blocked by no-history wisp; got %v", ids)
+	}
+}
+
+func TestGetBlockingInfoForIssuesHandlesCrossClassDeps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-blocking-info-perm")
+	createWisp(t, ctx, store, "mixed-blocking-info-wisp")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-blocking-info-wisp",
+		DependsOnID: "mixed-blocking-info-perm",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency wisp blocked by perm: %v", err)
+	}
+
+	blockedBy, blocks, _, err := store.GetBlockingInfoForIssues(ctx, []string{"mixed-blocking-info-perm", "mixed-blocking-info-wisp"})
+	if err != nil {
+		t.Fatalf("GetBlockingInfoForIssues: %v", err)
+	}
+	if got := blockedBy["mixed-blocking-info-wisp"]; len(got) != 1 || got[0] != "mixed-blocking-info-perm" {
+		t.Fatalf("blockedBy[wisp] = %v, want perm blocker", got)
+	}
+	if got := blocks["mixed-blocking-info-perm"]; len(got) != 1 || got[0] != "mixed-blocking-info-wisp" {
+		t.Fatalf("blocks[perm] = %v, want wisp dependent", got)
+	}
+}
+
+func TestGetBlockingInfoForIssuesSkipsClosedCrossClassBlockers(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-blocking-info-blocked")
+	createWisp(t, ctx, store, "mixed-blocking-info-closed-wisp")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-blocking-info-blocked",
+		DependsOnID: "mixed-blocking-info-closed-wisp",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency perm blocked by wisp: %v", err)
+	}
+	if err := store.CloseIssue(ctx, "mixed-blocking-info-closed-wisp", "done", "tester", "s1"); err != nil {
+		t.Fatalf("CloseIssue wisp blocker: %v", err)
+	}
+
+	blockedBy, _, _, err := store.GetBlockingInfoForIssues(ctx, []string{"mixed-blocking-info-blocked"})
+	if err != nil {
+		t.Fatalf("GetBlockingInfoForIssues: %v", err)
+	}
+	if got := blockedBy["mixed-blocking-info-blocked"]; len(got) != 0 {
+		t.Fatalf("blockedBy[perm] = %v, want no active blockers", got)
+	}
+}
+
+func TestIsBlockedReportsNoHistoryWispBlocker(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-is-blocked-perm")
+	noHistory := &types.Issue{
+		ID:        "mixed-is-blocked-no-history",
+		Title:     "no-history blocker",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history blocker: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-is-blocked-perm",
+		DependsOnID: "mixed-is-blocked-no-history",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency perm blocked by wisp: %v", err)
+	}
+
+	blocked, blockers, err := store.IsBlocked(ctx, "mixed-is-blocked-perm")
+	if err != nil {
+		t.Fatalf("IsBlocked: %v", err)
+	}
+	if !blocked {
+		t.Fatalf("IsBlocked = false, want true")
+	}
+	if len(blockers) != 1 || blockers[0] != "mixed-is-blocked-no-history" {
+		t.Fatalf("blockers = %v, want [mixed-is-blocked-no-history]", blockers)
+	}
+}
+
+func TestGetNewlyUnblockedByCloseIncludesNoHistoryWispCandidate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-close-blocker")
+	noHistory := &types.Issue{
+		ID:        "mixed-close-unblocked-no-history",
+		Title:     "no-history candidate",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history candidate: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-close-unblocked-no-history",
+		DependsOnID: "mixed-close-blocker",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency wisp blocked by perm: %v", err)
+	}
+
+	unblocked, err := store.GetNewlyUnblockedByClose(ctx, "mixed-close-blocker")
+	if err != nil {
+		t.Fatalf("GetNewlyUnblockedByClose: %v", err)
+	}
+	if len(unblocked) != 1 || unblocked[0].ID != "mixed-close-unblocked-no-history" {
+		t.Fatalf("unblocked = %+v, want no-history candidate", unblocked)
+	}
+}
+
+func TestGetNewlyUnblockedByCloseKeepsCandidateBlockedByNoHistoryWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-close-primary-blocker")
+	createPerm(t, ctx, store, "mixed-close-still-blocked")
+	noHistory := &types.Issue{
+		ID:        "mixed-close-remaining-no-history",
+		Title:     "remaining no-history blocker",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue remaining no-history blocker: %v", err)
+	}
+	for _, blockerID := range []string{"mixed-close-primary-blocker", "mixed-close-remaining-no-history"} {
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID:     "mixed-close-still-blocked",
+			DependsOnID: blockerID,
+			Type:        types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency blocked by %s: %v", blockerID, err)
+		}
+	}
+
+	unblocked, err := store.GetNewlyUnblockedByClose(ctx, "mixed-close-primary-blocker")
+	if err != nil {
+		t.Fatalf("GetNewlyUnblockedByClose: %v", err)
+	}
+	if len(unblocked) != 0 {
+		t.Fatalf("unblocked = %+v, want none because no-history blocker is still open", unblocked)
+	}
+}
+
+func TestSearchIssuesRejectsDuplicateIssueWispID(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-search-duplicate")
+	if _, err := store.execContext(ctx, `
+		INSERT INTO wisps (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral, no_history)
+		VALUES (?, ?, '', '', '', '', ?, ?, ?, ?, ?)
+	`, "mixed-search-duplicate", "duplicate wisp", types.StatusOpen, 2, types.TypeTask, false, true); err != nil {
+		t.Fatalf("insert duplicate wisp row: %v", err)
+	}
+
+	_, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+	if err == nil || !strings.Contains(err.Error(), `id "mixed-search-duplicate" exists in both issues and wisps`) {
+		t.Fatalf("SearchIssues error = %v, want duplicate issue/wisp ID error", err)
+	}
+}
+
+func TestDeleteIssuesNonCascadeDetectsNoHistoryWispDependent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-delete-parent")
+	noHistory := &types.Issue{
+		ID:        "mixed-delete-wisp-child",
+		Title:     "wisp child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history child: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-delete-wisp-child",
+		DependsOnID: "mixed-delete-parent",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency wisp child: %v", err)
+	}
+
+	result, err := store.DeleteIssues(ctx, []string{"mixed-delete-parent"}, false, false, false)
+	if err == nil {
+		t.Fatal("DeleteIssues succeeded, want dependent safety error")
+	}
+	if result == nil || !containsID(result.OrphanedIssues, "mixed-delete-wisp-child") {
+		t.Fatalf("OrphanedIssues = %+v, want no-history wisp child", result)
+	}
+}
+
+func TestDeleteIssuesCascadeDeletesNoHistoryWispDependent(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-delete-cascade-parent")
+	noHistory := &types.Issue{
+		ID:        "mixed-delete-cascade-wisp-child",
+		Title:     "wisp child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history child: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-delete-cascade-wisp-child",
+		DependsOnID: "mixed-delete-cascade-parent",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency wisp child: %v", err)
+	}
+
+	dryRun, err := store.DeleteIssues(ctx, []string{"mixed-delete-cascade-parent"}, true, false, true)
+	if err != nil {
+		t.Fatalf("DeleteIssues dry-run cascade: %v", err)
+	}
+	if dryRun.DeletedCount != 2 {
+		t.Fatalf("dry-run DeletedCount = %d, want parent plus wisp child", dryRun.DeletedCount)
+	}
+
+	result, err := store.DeleteIssues(ctx, []string{"mixed-delete-cascade-parent"}, true, false, false)
+	if err != nil {
+		t.Fatalf("DeleteIssues cascade: %v", err)
+	}
+	if result.DeletedCount != 2 {
+		t.Fatalf("DeletedCount = %d, want parent plus wisp child", result.DeletedCount)
+	}
+	for _, id := range []string{"mixed-delete-cascade-parent", "mixed-delete-cascade-wisp-child"} {
+		if _, err := store.GetIssue(ctx, id); !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("GetIssue(%s) after cascade err = %v, want ErrNotFound", id, err)
+		}
+	}
+}
+
+func TestDemoteToWispRecordsOnlyCreateAndDemotionEvents(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-demote-event-contract")
+	if err := store.UpdateIssue(ctx, "mixed-demote-event-contract", map[string]interface{}{
+		"no_history": true,
+		"title":      "demoted without update event",
+	}, "tester"); err != nil {
+		t.Fatalf("demote issue: %v", err)
+	}
+
+	events, err := store.GetEvents(ctx, "mixed-demote-event-contract", 0)
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("event count = %d, want create plus demotion only: %+v", len(events), events)
+	}
+	foundDemotion := false
+	for _, event := range events {
+		if event.NewValue != nil && *event.NewValue == "demoted to wisp" {
+			foundDemotion = true
+		}
+		if event.NewValue != nil && strings.Contains(*event.NewValue, "no_history") {
+			t.Fatalf("found intermediate update event in demotion stream: %+v", event)
+		}
+	}
+	if !foundDemotion {
+		t.Fatalf("events = %+v, want demotion marker", events)
+	}
+}
+
 func containsID(ids []string, want string) bool {
 	for _, id := range ids {
 		if id == want {
@@ -206,4 +842,65 @@ func containsID(ids []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func assertDependencyTargetColumns(t *testing.T, store *DoltStore, table, sourceID, targetID string, wantIssueTarget bool) {
+	t.Helper()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	var computedTarget, issueTarget, wispTarget sql.NullString
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), depends_on_issue_id, depends_on_wisp_id
+		FROM `+table+`
+		WHERE issue_id = ?
+	`, sourceID).Scan(&computedTarget, &issueTarget, &wispTarget); err != nil {
+		t.Fatalf("query dependency target columns: %v", err)
+	}
+
+	if !computedTarget.Valid || computedTarget.String != targetID {
+		t.Fatalf("computed dependency target = %+v, want %q", computedTarget, targetID)
+	}
+	if wantIssueTarget {
+		if !issueTarget.Valid || issueTarget.String != targetID {
+			t.Fatalf("depends_on_issue_id = %+v, want %q", issueTarget, targetID)
+		}
+		if wispTarget.Valid {
+			t.Fatalf("depends_on_wisp_id = %+v, want NULL", wispTarget)
+		}
+		return
+	}
+	if issueTarget.Valid {
+		t.Fatalf("depends_on_issue_id = %+v, want NULL", issueTarget)
+	}
+	if !wispTarget.Valid || wispTarget.String != targetID {
+		t.Fatalf("depends_on_wisp_id = %+v, want %q", wispTarget, targetID)
+	}
+}
+
+func assertNoRowsForIssue(t *testing.T, store *DoltStore, table, issueID string) {
+	t.Helper()
+	assertRowCountForIssue(t, store, table, issueID, 0)
+}
+
+func assertRowCountForIssue(t *testing.T, store *DoltStore, table, issueID string, want int) {
+	t.Helper()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	var count int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table+` WHERE issue_id = ?`, issueID).Scan(&count); err != nil {
+		if table == "issues" || table == "wisps" {
+			if rowErr := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table+` WHERE id = ?`, issueID).Scan(&count); rowErr != nil {
+				t.Fatalf("count %s rows: %v", table, rowErr)
+			}
+		} else {
+			t.Fatalf("count %s rows: %v", table, err)
+		}
+	}
+	if count != want {
+		t.Fatalf("%s row count for %s = %d, want %d", table, issueID, count, want)
+	}
 }

--- a/internal/storage/dolt/mixed_table_lifecycle_test.go
+++ b/internal/storage/dolt/mixed_table_lifecycle_test.go
@@ -1,0 +1,209 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestDemoteToWispPreservesInboundDependencies(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-demote-src")
+	createPerm(t, ctx, store, "mixed-demote-target")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-demote-src",
+		DependsOnID: "mixed-demote-target",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency before demote: %v", err)
+	}
+
+	if err := store.UpdateIssue(ctx, "mixed-demote-target", map[string]interface{}{
+		"no_history": true,
+	}, "tester"); err != nil {
+		t.Fatalf("demote target to no-history wisp: %v", err)
+	}
+
+	deps, err := store.GetDependencies(ctx, "mixed-demote-src")
+	if err != nil {
+		t.Fatalf("GetDependencies after demote: %v", err)
+	}
+	if len(deps) != 1 || deps[0].ID != "mixed-demote-target" || !deps[0].NoHistory {
+		t.Fatalf("dependencies after demote = %+v, want no-history target", deps)
+	}
+
+	dependents, err := store.GetDependents(ctx, "mixed-demote-target")
+	if err != nil {
+		t.Fatalf("GetDependents after demote: %v", err)
+	}
+	if len(dependents) != 1 || dependents[0].ID != "mixed-demote-src" {
+		t.Fatalf("dependents after demote = %+v, want source", dependents)
+	}
+}
+
+func TestPromoteFromEphemeralPreservesInboundDependencies(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mixed-promote-src")
+	createWisp(t, ctx, store, "mixed-promote-target")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-promote-src",
+		DependsOnID: "mixed-promote-target",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency before promote: %v", err)
+	}
+
+	if err := store.PromoteFromEphemeral(ctx, "mixed-promote-target", "tester"); err != nil {
+		t.Fatalf("PromoteFromEphemeral: %v", err)
+	}
+
+	deps, err := store.GetDependencies(ctx, "mixed-promote-src")
+	if err != nil {
+		t.Fatalf("GetDependencies after promote: %v", err)
+	}
+	if len(deps) != 1 || deps[0].ID != "mixed-promote-target" || deps[0].Ephemeral {
+		t.Fatalf("dependencies after promote = %+v, want permanent target", deps)
+	}
+
+	dependents, err := store.GetDependents(ctx, "mixed-promote-target")
+	if err != nil {
+		t.Fatalf("GetDependents after promote: %v", err)
+	}
+	if len(dependents) != 1 || dependents[0].ID != "mixed-promote-src" {
+		t.Fatalf("dependents after promote = %+v, want source", dependents)
+	}
+}
+
+func TestPromoteFromEphemeralCommitsAuxiliaryTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createWisp(t, ctx, store, "mixed-promote-aux")
+	createPerm(t, ctx, store, "mixed-promote-blocker")
+
+	if err := store.AddLabel(ctx, "mixed-promote-aux", "keep", "tester"); err != nil {
+		t.Fatalf("AddLabel before promote: %v", err)
+	}
+	if _, err := store.AddIssueComment(ctx, "mixed-promote-aux", "tester", "retain this context"); err != nil {
+		t.Fatalf("AddIssueComment before promote: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-promote-aux",
+		DependsOnID: "mixed-promote-blocker",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency before promote: %v", err)
+	}
+
+	if err := store.PromoteFromEphemeral(ctx, "mixed-promote-aux", "tester"); err != nil {
+		t.Fatalf("PromoteFromEphemeral: %v", err)
+	}
+
+	var dirty int
+	err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status s
+		WHERE NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			  AND s.table_name LIKE di.pattern
+		)
+	`).Scan(&dirty)
+	if err != nil {
+		t.Fatalf("query dolt_status after promote: %v", err)
+	}
+	if dirty != 0 {
+		t.Fatalf("promotion left %d committable table(s) dirty", dirty)
+	}
+}
+
+func TestGetReadyWorkIncludesNoHistoryWispsByDefault(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	noHistory := &types.Issue{
+		ID:        "mixed-ready-no-history",
+		Title:     "no-history ready work",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history: %v", err)
+	}
+	createWisp(t, ctx, store, "mixed-ready-ephemeral")
+
+	ready, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	ids := issueIDs(ready)
+	if !containsID(ids, "mixed-ready-no-history") {
+		t.Fatalf("GetReadyWork default omitted no-history wisp; got %v", ids)
+	}
+	if containsID(ids, "mixed-ready-ephemeral") {
+		t.Fatalf("GetReadyWork default included ephemeral wisp; got %v", ids)
+	}
+}
+
+func TestGetReadyWorkExcludesBlockedNoHistoryWisp(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	noHistory := &types.Issue{
+		ID:        "mixed-ready-blocked-no-history",
+		Title:     "blocked no-history ready work",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, noHistory, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history: %v", err)
+	}
+	createPerm(t, ctx, store, "mixed-ready-blocker")
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mixed-ready-blocked-no-history",
+		DependsOnID: "mixed-ready-blocker",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency blocker: %v", err)
+	}
+
+	ready, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+	ids := issueIDs(ready)
+	if containsID(ids, "mixed-ready-blocked-no-history") {
+		t.Fatalf("GetReadyWork returned blocked no-history wisp; got %v", ids)
+	}
+}
+
+func containsID(ids []string, want string) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/storage/dolt/schema_migration_dirty_test.go
+++ b/internal/storage/dolt/schema_migration_dirty_test.go
@@ -1,6 +1,7 @@
 package dolt
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/types"
@@ -90,5 +91,108 @@ func TestSchemaMigrationDoesNotCommitPreExistingDirtyData(t *testing.T) {
 	}
 	if committedCustomStatuses != 1 {
 		t.Fatalf("committed custom status count = %d, want 1", committedCustomStatuses)
+	}
+}
+
+func TestSchemaMigrationRejectsPreExistingStagedData(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "schema-staged-label",
+		Title:     "schema migration staged label",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "status.custom", "review:wip"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if err := store.CommitWithConfig(ctx, "test: configure custom status"); err != nil {
+		t.Fatalf("CommitWithConfig: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM custom_statuses"); err != nil {
+		t.Fatalf("clear custom_statuses: %v", err)
+	}
+	if err := store.doltAddAndCommit(ctx, []string{"custom_statuses"}, "test: simulate missing custom status backfill"); err != nil {
+		t.Fatalf("commit cleared custom_statuses: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO labels (issue_id, label) VALUES (?, ?)",
+		issue.ID, "staged-before-schema",
+	); err != nil {
+		t.Fatalf("insert staged label: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "CALL DOLT_ADD(?)", "labels"); err != nil {
+		t.Fatalf("stage label: %v", err)
+	}
+
+	err := initSchemaOnDB(ctx, store.db)
+	if err == nil || !strings.Contains(err.Error(), "pre-existing staged tables") {
+		t.Fatalf("initSchemaOnDB error = %v, want pre-existing staged tables error", err)
+	}
+
+	var committedLabelCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ? AND label = ?",
+		issue.ID, "staged-before-schema",
+	).Scan(&committedLabelCount); err != nil {
+		t.Fatalf("count committed staged label: %v", err)
+	}
+	if committedLabelCount != 0 {
+		t.Fatalf("staged label was committed by schema migration, count = %d", committedLabelCount)
+	}
+}
+
+func TestSchemaMigrationRejectsChangedPreExistingDirtyTable(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.SetConfig(ctx, "status.custom", "review:wip"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if err := store.CommitWithConfig(ctx, "test: configure custom status"); err != nil {
+		t.Fatalf("CommitWithConfig: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM custom_statuses"); err != nil {
+		t.Fatalf("clear custom_statuses: %v", err)
+	}
+	if err := store.doltAddAndCommit(ctx, []string{"custom_statuses"}, "test: simulate missing custom status backfill"); err != nil {
+		t.Fatalf("commit cleared custom_statuses: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"REPLACE INTO dolt_ignore VALUES ('ignored_schema_migrations', false)",
+	); err != nil {
+		t.Fatalf("dirty dolt_ignore: %v", err)
+	}
+
+	err := initSchemaOnDB(ctx, store.db)
+	if err == nil || !strings.Contains(err.Error(), "pre-existing dirty tables changed") {
+		t.Fatalf("initSchemaOnDB error = %v, want changed dirty table error", err)
+	}
+
+	var committedCustomStatuses int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM custom_statuses AS OF 'HEAD' WHERE name = ?",
+		"review",
+	).Scan(&committedCustomStatuses); err != nil {
+		t.Fatalf("count committed custom statuses: %v", err)
+	}
+	if committedCustomStatuses != 0 {
+		t.Fatalf("custom status was committed after dirty-table drift, count = %d", committedCustomStatuses)
 	}
 }

--- a/internal/storage/dolt/schema_migration_dirty_test.go
+++ b/internal/storage/dolt/schema_migration_dirty_test.go
@@ -94,7 +94,7 @@ func TestSchemaMigrationDoesNotCommitPreExistingDirtyData(t *testing.T) {
 	}
 }
 
-func TestSchemaMigrationRejectsPreExistingStagedData(t *testing.T) {
+func TestSchemaMigrationDoesNotCommitPreExistingStagedData(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -136,9 +136,8 @@ func TestSchemaMigrationRejectsPreExistingStagedData(t *testing.T) {
 		t.Fatalf("stage label: %v", err)
 	}
 
-	err := initSchemaOnDB(ctx, store.db)
-	if err == nil || !strings.Contains(err.Error(), "pre-existing staged tables") {
-		t.Fatalf("initSchemaOnDB error = %v, want pre-existing staged tables error", err)
+	if err := initSchemaOnDB(ctx, store.db); err != nil {
+		t.Fatalf("initSchemaOnDB: %v", err)
 	}
 
 	var committedLabelCount int
@@ -150,6 +149,27 @@ func TestSchemaMigrationRejectsPreExistingStagedData(t *testing.T) {
 	}
 	if committedLabelCount != 0 {
 		t.Fatalf("staged label was committed by schema migration, count = %d", committedLabelCount)
+	}
+
+	var workingLabelCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels WHERE issue_id = ? AND label = ?",
+		issue.ID, "staged-before-schema",
+	).Scan(&workingLabelCount); err != nil {
+		t.Fatalf("count working staged label: %v", err)
+	}
+	if workingLabelCount != 1 {
+		t.Fatalf("working staged label count = %d, want 1", workingLabelCount)
+	}
+
+	var stagedLabelTables int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_status WHERE table_name = 'labels' AND staged = true",
+	).Scan(&stagedLabelTables); err != nil {
+		t.Fatalf("count staged label tables: %v", err)
+	}
+	if stagedLabelTables != 0 {
+		t.Fatalf("labels remained staged after schema migration, count = %d", stagedLabelTables)
 	}
 }
 

--- a/internal/storage/dolt/schema_migration_dirty_test.go
+++ b/internal/storage/dolt/schema_migration_dirty_test.go
@@ -173,6 +173,106 @@ func TestSchemaMigrationDoesNotCommitPreExistingStagedData(t *testing.T) {
 	}
 }
 
+func TestSchemaMigrationDoesNotCommitIgnoredDirtyWispTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "schema-dirty-with-wisp-label",
+		Title:     "schema migration dirty label with ignored wisp",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "status.custom", "review:wip"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if err := store.CommitWithConfig(ctx, "test: configure custom status"); err != nil {
+		t.Fatalf("CommitWithConfig: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM custom_statuses"); err != nil {
+		t.Fatalf("clear custom_statuses: %v", err)
+	}
+	if err := store.doltAddAndCommit(ctx, []string{"custom_statuses"}, "test: simulate missing custom status backfill"); err != nil {
+		t.Fatalf("commit cleared custom_statuses: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO labels (issue_id, label) VALUES (?, ?)",
+		issue.ID, "dirty-before-schema-with-wisp",
+	); err != nil {
+		t.Fatalf("insert dirty label: %v", err)
+	}
+
+	wisp := &types.Issue{
+		ID:        "schema-dirty-ignored-wisp",
+		Title:     "ignored wisp must stay local",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue no-history wisp: %v", err)
+	}
+
+	if err := initSchemaOnDB(ctx, store.db); err != nil {
+		t.Fatalf("initSchemaOnDB: %v", err)
+	}
+
+	var committedLabelCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ? AND label = ?",
+		issue.ID, "dirty-before-schema-with-wisp",
+	).Scan(&committedLabelCount); err != nil {
+		t.Fatalf("count committed dirty label: %v", err)
+	}
+	if committedLabelCount != 0 {
+		t.Fatalf("dirty label was committed by schema migration, count = %d", committedLabelCount)
+	}
+
+	var committedWispCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM wisps AS OF 'HEAD' WHERE id = ?",
+		wisp.ID,
+	).Scan(&committedWispCount); err != nil {
+		t.Fatalf("count committed ignored wisp: %v", err)
+	}
+	if committedWispCount != 0 {
+		t.Fatalf("ignored wisp was committed by schema migration, count = %d", committedWispCount)
+	}
+
+	var workingWispCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM wisps WHERE id = ?",
+		wisp.ID,
+	).Scan(&workingWispCount); err != nil {
+		t.Fatalf("count working ignored wisp: %v", err)
+	}
+	if workingWispCount != 1 {
+		t.Fatalf("working wisp count = %d, want 1", workingWispCount)
+	}
+
+	var committedCustomStatuses int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM custom_statuses AS OF 'HEAD' WHERE name = ?",
+		"review",
+	).Scan(&committedCustomStatuses); err != nil {
+		t.Fatalf("count committed custom statuses: %v", err)
+	}
+	if committedCustomStatuses != 1 {
+		t.Fatalf("committed custom status count = %d, want 1", committedCustomStatuses)
+	}
+}
+
 func TestSchemaMigrationRejectsChangedPreExistingDirtyTable(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/schema_migration_dirty_test.go
+++ b/internal/storage/dolt/schema_migration_dirty_test.go
@@ -1,0 +1,94 @@
+package dolt
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestSchemaMigrationDoesNotCommitPreExistingDirtyData(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "schema-dirty-label",
+		Title:     "schema migration dirty label",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "status.custom", "review:wip"); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if err := store.CommitWithConfig(ctx, "test: configure custom status"); err != nil {
+		t.Fatalf("CommitWithConfig: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx, "DELETE FROM custom_statuses"); err != nil {
+		t.Fatalf("clear custom_statuses: %v", err)
+	}
+	if err := store.doltAddAndCommit(ctx, []string{"custom_statuses"}, "test: simulate missing custom status backfill"); err != nil {
+		t.Fatalf("commit cleared custom_statuses: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO labels (issue_id, label) VALUES (?, ?)",
+		issue.ID, "dirty-before-schema",
+	); err != nil {
+		t.Fatalf("insert dirty label: %v", err)
+	}
+
+	if err := initSchemaOnDB(ctx, store.db); err != nil {
+		t.Fatalf("initSchemaOnDB: %v", err)
+	}
+
+	var committedLabelCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ? AND label = ?",
+		issue.ID, "dirty-before-schema",
+	).Scan(&committedLabelCount); err != nil {
+		t.Fatalf("count committed dirty label: %v", err)
+	}
+	if committedLabelCount != 0 {
+		t.Fatalf("dirty label was committed by schema migration, count = %d", committedLabelCount)
+	}
+
+	var workingLabelCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels WHERE issue_id = ? AND label = ?",
+		issue.ID, "dirty-before-schema",
+	).Scan(&workingLabelCount); err != nil {
+		t.Fatalf("count working dirty label: %v", err)
+	}
+	if workingLabelCount != 1 {
+		t.Fatalf("working label count = %d, want 1", workingLabelCount)
+	}
+
+	var dirtyLabelTables int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_status WHERE table_name = 'labels'",
+	).Scan(&dirtyLabelTables); err != nil {
+		t.Fatalf("count dirty label tables: %v", err)
+	}
+	if dirtyLabelTables != 1 {
+		t.Fatalf("dirty labels table count = %d, want 1", dirtyLabelTables)
+	}
+
+	var committedCustomStatuses int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM custom_statuses AS OF 'HEAD' WHERE name = ?",
+		"review",
+	).Scan(&committedCustomStatuses); err != nil {
+		t.Fatalf("count committed custom statuses: %v", err)
+	}
+	if committedCustomStatuses != 1 {
+		t.Fatalf("committed custom status count = %d, want 1", committedCustomStatuses)
+	}
+}

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -128,6 +128,32 @@ func TestSchemaRunsInitWhenMissing(t *testing.T) {
 		t.Errorf("max migration version = %d, want %d", maxVersion, schema.LatestVersion())
 	}
 
+	var legacyTargetColumns int
+	err = store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = DATABASE()
+		  AND table_name = 'wisp_dependencies'
+		  AND column_name = 'depends_on_id'`).Scan(&legacyTargetColumns)
+	if err != nil {
+		t.Fatalf("query wisp_dependencies legacy target column: %v", err)
+	}
+	if legacyTargetColumns != 0 {
+		t.Fatalf("wisp_dependencies.depends_on_id exists after fresh migration")
+	}
+
+	var splitTargetColumns int
+	err = store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = DATABASE()
+		  AND table_name = 'wisp_dependencies'
+		  AND column_name IN ('depends_on_issue_id', 'depends_on_wisp_id', 'depends_on_external')`).Scan(&splitTargetColumns)
+	if err != nil {
+		t.Fatalf("query wisp_dependencies split target columns: %v", err)
+	}
+	if splitTargetColumns != 3 {
+		t.Fatalf("wisp_dependencies split target column count = %d, want 3", splitTargetColumns)
+	}
+
 	dropCtx, dropCancel := context.WithTimeout(context.Background(), 5*testTimeout)
 	defer dropCancel()
 	_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))

--- a/internal/storage/dolt/wisp_partition_test.go
+++ b/internal/storage/dolt/wisp_partition_test.go
@@ -347,6 +347,45 @@ func TestGetDependencyRecordsForIssues_MixedWispAndPermanent(t *testing.T) {
 	}
 }
 
+func TestGetAllDependencyRecordsIncludesWispDependencies(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	createPerm(t, ctx, store, "mix-all-dep-perm-src")
+	createPerm(t, ctx, store, "mix-all-dep-perm-tgt")
+	createWisp(t, ctx, store, "mix-all-dep-wisp-src")
+	createWisp(t, ctx, store, "mix-all-dep-wisp-tgt")
+
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mix-all-dep-perm-src",
+		DependsOnID: "mix-all-dep-perm-tgt",
+		Type:        types.DepBlocks,
+	}, "tester"); err != nil {
+		t.Fatalf("add perm dep: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "mix-all-dep-wisp-src",
+		DependsOnID: "mix-all-dep-wisp-tgt",
+		Type:        types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("add wisp dep: %v", err)
+	}
+
+	got, err := store.GetAllDependencyRecords(ctx)
+	if err != nil {
+		t.Fatalf("GetAllDependencyRecords: %v", err)
+	}
+	if ds := got["mix-all-dep-perm-src"]; len(ds) != 1 || ds[0].DependsOnID != "mix-all-dep-perm-tgt" {
+		t.Fatalf("perm deps: want 1 record targeting mix-all-dep-perm-tgt, got %+v", ds)
+	}
+	if ds := got["mix-all-dep-wisp-src"]; len(ds) != 1 || ds[0].DependsOnID != "mix-all-dep-wisp-tgt" {
+		t.Fatalf("wisp deps: want 1 record targeting mix-all-dep-wisp-tgt, got %+v", ds)
+	}
+}
+
 // TestGetLabelsForIssues_ManyIDs exercises the queryBatchSize chunking path
 // inside GetLabelsForIssuesInTx — regression guard for partition + label
 // fetch crossing the 200-ID boundary.

--- a/internal/storage/issueops/batching.go
+++ b/internal/storage/issueops/batching.go
@@ -1,6 +1,6 @@
 package issueops
 
-import "strings"
+import "github.com/steveyegge/beads/internal/storage/dberrors"
 
 // queryBatchSize limits the number of IDs in a single IN (...) clause.
 // Large IN clauses cause Dolt query-planner spikes and MySQL packet-size
@@ -8,13 +8,7 @@ import "strings"
 const queryBatchSize = 200
 
 // isTableNotExistError returns true if the error indicates a missing table
-// (MySQL/Dolt error 1146). Uses string matching to avoid importing a
-// driver-specific package.
+// (MySQL/Dolt error 1146).
 func isTableNotExistError(err error) bool {
-	if err == nil {
-		return false
-	}
-	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "doesn't exist") || strings.Contains(s, "does not exist") ||
-		strings.Contains(s, "error 1146")
+	return dberrors.IsTableNotExist(err)
 }

--- a/internal/storage/issueops/batching_test.go
+++ b/internal/storage/issueops/batching_test.go
@@ -54,6 +54,16 @@ func TestIsTableNotExistError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "column does not exist",
+			err:  errors.New("column 'depends_on_id' doesn't exist"),
+			want: false,
+		},
+		{
+			name: "schema does not exist",
+			err:  errors.New("schema 'archive' does not exist"),
+			want: false,
+		},
+		{
 			name: "different mysql error code",
 			err:  errors.New("Error 1045: Access denied"),
 			want: false,

--- a/internal/storage/issueops/bulk_ops.go
+++ b/internal/storage/issueops/bulk_ops.go
@@ -226,7 +226,7 @@ func updateIssueIDInTx(ctx context.Context, tx *sql.Tx, oldID, newID string, iss
 		return fmt.Errorf("issue not found: %s", oldID)
 	}
 
-	if err := UpdateIssueIDInDependencyTargetsInTx(ctx, tx, oldID, newID); err != nil {
+	if err := UpdateIssueIDInDependenciesInTx(ctx, tx, oldID, newID); err != nil {
 		return err
 	}
 

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -53,13 +53,9 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 
 	result := make(map[string]int)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionWispIDsInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("partition comment issue IDs: %w", err)
 	}
 
 	for _, pair := range []struct {

--- a/internal/storage/issueops/delete.go
+++ b/internal/storage/issueops/delete.go
@@ -71,8 +71,11 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 		return &types.DeleteIssuesResult{DeletedCount: wispDeleteCount}, nil
 	}
 
-	idSet := make(map[string]bool, len(ids))
+	idSet := make(map[string]bool, len(ids)+len(wispIDs))
 	for _, id := range ids {
+		idSet[id] = true
+	}
+	for _, id := range wispIDs {
 		idSet[id] = true
 	}
 
@@ -97,27 +100,32 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 			batch := ids[i:end]
 			inClause, args := buildSQLInClause(batch)
 
-			rows, err := tx.QueryContext(ctx,
-				fmt.Sprintf(`SELECT depends_on_issue_id, issue_id FROM dependencies WHERE depends_on_issue_id IN (%s)`, inClause),
-				args...)
-			if err != nil {
-				return nil, fmt.Errorf("check dependents: %w", err)
-			}
-
 			externalBySource := make(map[string][]string)
-			for rows.Next() {
-				var depOnID, issueID string
-				if err := rows.Scan(&depOnID, &issueID); err != nil {
-					_ = rows.Close()
-					return nil, fmt.Errorf("scan dependent: %w", err)
+			for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+				rows, err := tx.QueryContext(ctx,
+					fmt.Sprintf(`SELECT %s AS depends_on_id, issue_id FROM %s WHERE %s`, DepTargetExpr, depTable, depTargetIn("", inClause)),
+					args...)
+				if err != nil {
+					if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+						continue
+					}
+					return nil, fmt.Errorf("check dependents from %s: %w", depTable, err)
 				}
-				if !idSet[issueID] {
-					externalBySource[depOnID] = append(externalBySource[depOnID], issueID)
+
+				for rows.Next() {
+					var depOnID, issueID string
+					if err := rows.Scan(&depOnID, &issueID); err != nil {
+						_ = rows.Close()
+						return nil, fmt.Errorf("scan dependent: %w", err)
+					}
+					if !idSet[issueID] {
+						externalBySource[depOnID] = append(externalBySource[depOnID], issueID)
+					}
 				}
-			}
-			_ = rows.Close()
-			if err := rows.Err(); err != nil {
-				return nil, fmt.Errorf("iterate dependents: %w", err)
+				_ = rows.Close()
+				if err := rows.Err(); err != nil {
+					return nil, fmt.Errorf("iterate dependents from %s: %w", depTable, err)
+				}
 			}
 
 			for _, id := range batch {
@@ -135,83 +143,94 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 		result.OrphanedIssues = orphans
 	}
 
-	expandedIDSet := make(map[string]bool, len(expandedIDs))
-	for _, id := range expandedIDs {
+	allExpandedIDs := expandedIDs
+	expandedWispIDs, expandedRegularIDs, err := PartitionWispIDsInTx(ctx, tx, allExpandedIDs)
+	if err != nil {
+		return nil, fmt.Errorf("partition expanded delete IDs: %w", err)
+	}
+	expandedIDSet := make(map[string]bool, len(allExpandedIDs))
+	for _, id := range allExpandedIDs {
 		expandedIDSet[id] = true
 	}
+	expandedIDs = expandedRegularIDs
 
 	var depsCount, labelsCount, eventsCount int
-	for i := 0; i < len(expandedIDs); i += deleteBatchSize {
-		end := i + deleteBatchSize
-		if end > len(expandedIDs) {
-			end = len(expandedIDs)
-		}
-		batch := expandedIDs[i:end]
-		batchInClause, batchArgs := buildSQLInClause(batch)
-
-		var batchDeps int
-		if err := tx.QueryRowContext(ctx,
-			fmt.Sprintf(`SELECT COUNT(*) FROM dependencies WHERE issue_id IN (%s)`, batchInClause),
-			batchArgs...).Scan(&batchDeps); err != nil {
-			return nil, fmt.Errorf("count dependencies: %w", err)
-		}
-		depsCount += batchDeps
-
-		var batchLabels int
-		if err := tx.QueryRowContext(ctx,
-			fmt.Sprintf(`SELECT COUNT(*) FROM labels WHERE issue_id IN (%s)`, batchInClause),
-			batchArgs...).Scan(&batchLabels); err != nil {
-			return nil, fmt.Errorf("count labels: %w", err)
-		}
-		labelsCount += batchLabels
-
-		var batchEvents int
-		if err := tx.QueryRowContext(ctx,
-			fmt.Sprintf(`SELECT COUNT(*) FROM events WHERE issue_id IN (%s)`, batchInClause),
-			batchArgs...).Scan(&batchEvents); err != nil {
-			return nil, fmt.Errorf("count events: %w", err)
-		}
-		eventsCount += batchEvents
+	if depsCount, err = countRowsForIssueIDsInTx(ctx, tx, "dependencies", expandedIDs); err != nil {
+		return nil, fmt.Errorf("count dependencies: %w", err)
 	}
+	wispDepsCount, err := countRowsForIssueIDsInTx(ctx, tx, "wisp_dependencies", expandedWispIDs)
+	if err != nil {
+		return nil, fmt.Errorf("count wisp dependencies: %w", err)
+	}
+	depsCount += wispDepsCount
+
+	if labelsCount, err = countRowsForIssueIDsInTx(ctx, tx, "labels", expandedIDs); err != nil {
+		return nil, fmt.Errorf("count labels: %w", err)
+	}
+	wispLabelsCount, err := countRowsForIssueIDsInTx(ctx, tx, "wisp_labels", expandedWispIDs)
+	if err != nil {
+		return nil, fmt.Errorf("count wisp labels: %w", err)
+	}
+	labelsCount += wispLabelsCount
+
+	if eventsCount, err = countRowsForIssueIDsInTx(ctx, tx, "events", expandedIDs); err != nil {
+		return nil, fmt.Errorf("count events: %w", err)
+	}
+	wispEventsCount, err := countRowsForIssueIDsInTx(ctx, tx, "wisp_events", expandedWispIDs)
+	if err != nil {
+		return nil, fmt.Errorf("count wisp events: %w", err)
+	}
+	eventsCount += wispEventsCount
 
 	// Pass 2: inbound deps from outside the deletion set.
-	for i := 0; i < len(expandedIDs); i += deleteBatchSize {
+	for i := 0; i < len(allExpandedIDs); i += deleteBatchSize {
 		end := i + deleteBatchSize
-		if end > len(expandedIDs) {
-			end = len(expandedIDs)
+		if end > len(allExpandedIDs) {
+			end = len(allExpandedIDs)
 		}
-		batch := expandedIDs[i:end]
+		batch := allExpandedIDs[i:end]
 		batchInClause, batchArgs := buildSQLInClause(batch)
 
-		rows, err := tx.QueryContext(ctx,
-			fmt.Sprintf(`SELECT issue_id FROM dependencies WHERE depends_on_issue_id IN (%s)`, batchInClause),
-			batchArgs...)
-		if err != nil {
-			return nil, fmt.Errorf("count inbound dependencies: %w", err)
-		}
-		for rows.Next() {
-			var issID string
-			if err := rows.Scan(&issID); err != nil {
-				_ = rows.Close()
-				return nil, fmt.Errorf("scan inbound dependency: %w", err)
+		for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+			rows, err := tx.QueryContext(ctx,
+				fmt.Sprintf(`SELECT issue_id FROM %s WHERE %s`, depTable, depTargetIn("", batchInClause)),
+				batchArgs...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					continue
+				}
+				return nil, fmt.Errorf("count inbound dependencies from %s: %w", depTable, err)
 			}
-			if !expandedIDSet[issID] {
-				depsCount++
+			for rows.Next() {
+				var issID string
+				if err := rows.Scan(&issID); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("scan inbound dependency: %w", err)
+				}
+				if !expandedIDSet[issID] {
+					depsCount++
+				}
 			}
-		}
-		_ = rows.Close()
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("iterate inbound dependencies: %w", err)
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("iterate inbound dependencies from %s: %w", depTable, err)
+			}
 		}
 	}
 
 	result.DependenciesCount = depsCount
 	result.LabelsCount = labelsCount
 	result.EventsCount = eventsCount
-	result.DeletedCount = len(expandedIDs) + wispDeleteCount
+	result.DeletedCount = len(expandedIDs) + len(expandedWispIDs) + wispDeleteCount
 
 	if dryRun {
 		return result, nil
+	}
+
+	for _, id := range expandedWispIDs {
+		if err := DeleteIssueInTx(ctx, tx, id); err != nil {
+			return nil, fmt.Errorf("delete cascaded wisp %s: %w", id, err)
+		}
 	}
 
 	totalDeleted := 0
@@ -232,7 +251,7 @@ func DeleteIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string, cascade boo
 		rowsAffected, _ := deleteResult.RowsAffected()
 		totalDeleted += int(rowsAffected)
 	}
-	result.DeletedCount = totalDeleted + wispDeleteCount
+	result.DeletedCount = totalDeleted + len(expandedWispIDs) + wispDeleteCount
 
 	return result, nil
 }
@@ -263,27 +282,32 @@ func findAllDependentsRecursiveInTx(ctx context.Context, tx *sql.Tx, ids []strin
 		toProcess = toProcess[batchEnd:]
 
 		inClause, args := buildSQLInClause(batch)
-		rows, err := tx.QueryContext(ctx,
-			fmt.Sprintf(`SELECT issue_id FROM dependencies WHERE depends_on_issue_id IN (%s)`, inClause),
-			args...)
-		if err != nil {
-			return nil, fmt.Errorf("query dependents for batch: %w", err)
-		}
+		for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+			rows, err := tx.QueryContext(ctx,
+				fmt.Sprintf(`SELECT issue_id FROM %s WHERE %s`, depTable, depTargetIn("", inClause)),
+				args...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					continue
+				}
+				return nil, fmt.Errorf("query dependents for batch from %s: %w", depTable, err)
+			}
 
-		for rows.Next() {
-			var depID string
-			if err := rows.Scan(&depID); err != nil {
-				_ = rows.Close()
-				return nil, fmt.Errorf("scan dependent: %w", err)
+			for rows.Next() {
+				var depID string
+				if err := rows.Scan(&depID); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("scan dependent: %w", err)
+				}
+				if !result[depID] {
+					result[depID] = true
+					toProcess = append(toProcess, depID)
+				}
 			}
-			if !result[depID] {
-				result[depID] = true
-				toProcess = append(toProcess, depID)
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("iterate dependents for batch from %s: %w", depTable, err)
 			}
-		}
-		_ = rows.Close()
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("iterate dependents for batch: %w", err)
 		}
 	}
 
@@ -304,25 +328,30 @@ func findExternalDependentsBatchedInTx(ctx context.Context, tx *sql.Tx, ids []st
 		batch := ids[i:end]
 		inClause, args := buildSQLInClause(batch)
 
-		rows, err := tx.QueryContext(ctx,
-			fmt.Sprintf(`SELECT issue_id FROM dependencies WHERE depends_on_issue_id IN (%s)`, inClause),
-			args...)
-		if err != nil {
-			return nil, fmt.Errorf("query dependents: %w", err)
-		}
-		for rows.Next() {
-			var depID string
-			if err := rows.Scan(&depID); err != nil {
-				_ = rows.Close()
-				return nil, fmt.Errorf("scan dependent: %w", err)
+		for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+			rows, err := tx.QueryContext(ctx,
+				fmt.Sprintf(`SELECT issue_id FROM %s WHERE %s`, depTable, depTargetIn("", inClause)),
+				args...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					continue
+				}
+				return nil, fmt.Errorf("query dependents from %s: %w", depTable, err)
 			}
-			if !idSet[depID] {
-				orphanSet[depID] = true
+			for rows.Next() {
+				var depID string
+				if err := rows.Scan(&depID); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("scan dependent: %w", err)
+				}
+				if !idSet[depID] {
+					orphanSet[depID] = true
+				}
 			}
-		}
-		_ = rows.Close()
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("iterate dependents: %w", err)
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("iterate dependents from %s: %w", depTable, err)
+			}
 		}
 	}
 
@@ -331,4 +360,27 @@ func findExternalDependentsBatchedInTx(ctx context.Context, tx *sql.Tx, ids []st
 		result = append(result, id)
 	}
 	return result, nil
+}
+
+//nolint:gosec // G201: table is selected by callers from fixed issue/wisp auxiliary tables.
+func countRowsForIssueIDsInTx(ctx context.Context, tx *sql.Tx, table string, ids []string) (int, error) {
+	total := 0
+	for i := 0; i < len(ids); i += deleteBatchSize {
+		end := i + deleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		inClause, args := buildSQLInClause(ids[i:end])
+		var count int
+		if err := tx.QueryRowContext(ctx,
+			fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE issue_id IN (%s)`, table, inClause),
+			args...).Scan(&count); err != nil {
+			if optionalBlockedTable(table) && isTableNotExistError(err) {
+				continue
+			}
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
 }

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -269,28 +269,139 @@ func DeleteWispsFromDependenciesInTx(ctx context.Context, tx *sql.Tx, wispIDs []
 	return nil
 }
 
-// Dependency target rewrite contract:
-//   - Persistent issue renames are covered by FK ON UPDATE CASCADE
-//     (fk_dep_issue / fk_dep_issue_target / fk_wisp_dep_issue_target). The
-//     surrogate `id` PK on dependencies/wisp_dependencies is independent of any
-//     target column, so cascade is sufficient and UK collisions (uk_dep_*_target)
-//     naturally fail the caller's transaction.
-//   - Wisp renames cascade automatically on wisp_dependencies (fk_wisp_dep_issue
-//     / fk_wisp_dep_wisp_target). The `dependencies` table has no FK to wisps
-//     (wisps are dolt_ignored), so depends_on_wisp_id there needs an explicit
-//     UPDATE.
+// Dependency target rewrites reinsert matching rows because Dolt can leave the
+// stored generated depends_on_id column stale after a split target column is
+// updated by FK cascade.
 func UpdateWispIDInDependenciesInTx(ctx context.Context, tx *sql.Tx, oldID, newID string) error {
+	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if err := replaceDependencyTargetInTx(ctx, tx, table, "depends_on_wisp_id", oldID, newID); err != nil {
+			return fmt.Errorf("update wisp %s -> %s in %s: %w", oldID, newID, table, err)
+		}
+	}
+	return nil
+}
+
+func UpdateIssueIDInDependenciesInTx(ctx context.Context, tx *sql.Tx, oldID, newID string) error {
+	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if err := replaceDependencyTargetInTx(ctx, tx, table, "depends_on_issue_id", oldID, newID); err != nil {
+			return fmt.Errorf("update issue target %s -> %s in %s: %w", oldID, newID, table, err)
+		}
+	}
 	if _, err := tx.ExecContext(ctx,
-		"UPDATE dependencies SET depends_on_wisp_id = ? WHERE depends_on_wisp_id = ?",
+		"UPDATE dependencies SET issue_id = ? WHERE issue_id = ?",
 		newID, oldID); err != nil {
-		return fmt.Errorf("update wisp %s -> %s in dependencies: %w", oldID, newID, err)
+		return fmt.Errorf("update issue source %s -> %s in dependencies: %w", oldID, newID, err)
+	}
+	return nil
+}
+
+func replaceDependencyTargetInTx(ctx context.Context, tx *sql.Tx, table, column, oldID, newID string) error {
+	// Dolt does not reliably recompute the stored generated depends_on_id when
+	// only the split target column changes. Reinsert rows so the generated key
+	// is calculated from the new target value.
+	if err := checkRenameTargetCollision(ctx, tx, table, column, newID); err != nil {
+		return err
+	}
+
+	type depRow struct {
+		issueID     string
+		issueTarget sql.NullString
+		wispTarget  sql.NullString
+		external    sql.NullString
+		depType     string
+		createdAt   sql.NullTime
+		createdBy   sql.NullString
+		metadata    sql.NullString
+		threadID    sql.NullString
+	}
+
+	rows := make([]depRow, 0)
+	//nolint:gosec // table and column are hardcoded by callers.
+	queryRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id
+		FROM %s
+		WHERE %s = ? OR (depends_on_id = ? AND depends_on_external IS NULL)
+	`, table, column), oldID, oldID)
+	if err != nil {
+		return fmt.Errorf("query dependency targets: %w", err)
+	}
+	for queryRows.Next() {
+		var row depRow
+		if err := queryRows.Scan(&row.issueID, &row.issueTarget, &row.wispTarget, &row.external, &row.depType, &row.createdAt, &row.createdBy, &row.metadata, &row.threadID); err != nil {
+			_ = queryRows.Close()
+			return fmt.Errorf("scan dependency target: %w", err)
+		}
+		if column == "depends_on_issue_id" {
+			row.issueTarget = sql.NullString{String: newID, Valid: true}
+		} else {
+			row.wispTarget = sql.NullString{String: newID, Valid: true}
+		}
+		rows = append(rows, row)
+	}
+	_ = queryRows.Close()
+	if err := queryRows.Err(); err != nil {
+		return fmt.Errorf("iterate dependency targets: %w", err)
+	}
+
+	//nolint:gosec // table and column are hardcoded by callers.
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE %s = ? OR (depends_on_id = ? AND depends_on_external IS NULL)`, table, column), oldID, oldID); err != nil {
+		return fmt.Errorf("delete old dependency target: %w", err)
+	}
+	for _, row := range rows {
+		//nolint:gosec // table is hardcoded by callers.
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO %s (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, table), row.issueID, nullStringValue(row.issueTarget), nullStringValue(row.wispTarget), nullStringValue(row.external), row.depType, nullTimeValue(row.createdAt), nullStringValue(row.createdBy), nullStringValue(row.metadata), nullStringValue(row.threadID)); err != nil {
+			return fmt.Errorf("insert replacement dependency target: %w", err)
+		}
+	}
+	return nil
+}
+
+func nullStringValue(value sql.NullString) any {
+	if !value.Valid {
+		return nil
+	}
+	return value.String
+}
+
+func nullTimeValue(value sql.NullTime) any {
+	if !value.Valid {
+		return nil
+	}
+	return value.Time
+}
+
+func RetargetInboundDependenciesToWispInTx(ctx context.Context, tx *sql.Tx, id string) error {
+	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE %s
+			SET depends_on_wisp_id = ?, depends_on_issue_id = NULL
+			WHERE depends_on_issue_id = ?
+		`, table), id, id); err != nil {
+			return fmt.Errorf("retarget inbound dependencies to wisp in %s for %s: %w", table, id, err)
+		}
+	}
+	return nil
+}
+
+func RetargetInboundDependenciesToIssueInTx(ctx context.Context, tx *sql.Tx, id string) error {
+	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			UPDATE %s
+			SET depends_on_issue_id = ?, depends_on_wisp_id = NULL
+			WHERE depends_on_wisp_id = ?
+		`, table), id, id); err != nil {
+			return fmt.Errorf("retarget inbound dependencies to issue in %s for %s: %w", table, id, err)
+		}
 	}
 	// wisp_dependencies.depends_on_wisp_id cascades via fk_wisp_dep_wisp_target.
 	// Reject cross-typed-column target collisions (same source already has the
 	// new ID in depends_on_issue_id / depends_on_external) that the per-column
 	// UK constraints don't catch.
 	for _, table := range []string{"dependencies", "wisp_dependencies"} {
-		if err := checkRenameTargetCollision(ctx, tx, table, "depends_on_wisp_id", newID); err != nil {
+		if err := checkRenameTargetCollision(ctx, tx, table, "depends_on_wisp_id", id); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -35,6 +35,21 @@ func (k DepTargetKind) Column() string {
 // kind ahead of time.
 const DepTargetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"
 
+func depTargetExpr(alias string) string {
+	if alias == "" {
+		return DepTargetExpr
+	}
+	return fmt.Sprintf("COALESCE(%s.depends_on_issue_id, %s.depends_on_wisp_id, %s.depends_on_external)", alias, alias, alias)
+}
+
+func depTargetEquals(alias string) string {
+	return depTargetExpr(alias) + " = ?"
+}
+
+func depTargetIn(alias, placeholders string) string {
+	return depTargetExpr(alias) + " IN (" + placeholders + ")"
+}
+
 func ClassifyDepTarget(ctx context.Context, tx *sql.Tx, dep *types.Dependency, isCrossPrefix bool) DepTargetKind {
 	if isCrossPrefix || strings.HasPrefix(dep.DependsOnID, "external:") {
 		return DepTargetExternal
@@ -179,16 +194,18 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	}
 	targetCol := kind.Column()
 
-	// Check for existing dependency between the same pair.
+	// Check for existing dependency between the same pair. Use the resolved
+	// target expression defensively so stale/reclassified rows in another typed
+	// target column cannot bypass the idempotency/conflict check.
 	var existingType string
-	//nolint:gosec // G201: writeTable from WispTableRouting; targetCol from DepTargetKind.Column()
-	err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT type FROM %s WHERE issue_id = ? AND %s = ?`, writeTable, targetCol),
+	//nolint:gosec // G201: writeTable from WispTableRouting; depTargetEquals has no user input.
+	err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT type FROM %s WHERE issue_id = ? AND %s`, writeTable, depTargetEquals("")),
 		dep.IssueID, dep.DependsOnID).Scan(&existingType)
 	if err == nil {
 		if existingType == string(dep.Type) {
 			// Same type — idempotent; update metadata.
-			//nolint:gosec // G201: writeTable from WispTableRouting; targetCol from DepTargetKind.Column()
-			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET metadata = ? WHERE issue_id = ? AND %s = ?`, writeTable, targetCol),
+			//nolint:gosec // G201: writeTable from WispTableRouting; depTargetEquals has no user input.
+			if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE %s SET metadata = ? WHERE issue_id = ? AND %s`, writeTable, depTargetEquals("")),
 				metadata, dep.IssueID, dep.DependsOnID); err != nil {
 				return fmt.Errorf("failed to update dependency metadata: %w", err)
 			}
@@ -320,8 +337,8 @@ func replaceDependencyTargetInTx(ctx context.Context, tx *sql.Tx, table, column,
 	queryRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
 		SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id
 		FROM %s
-		WHERE %s = ? OR (depends_on_id = ? AND depends_on_external IS NULL)
-	`, table, column), oldID, oldID)
+		WHERE %s = ? OR (%s = ? AND depends_on_external IS NULL)
+	`, table, column, DepTargetExpr), oldID, oldID)
 	if err != nil {
 		return fmt.Errorf("query dependency targets: %w", err)
 	}
@@ -331,10 +348,18 @@ func replaceDependencyTargetInTx(ctx context.Context, tx *sql.Tx, table, column,
 			_ = queryRows.Close()
 			return fmt.Errorf("scan dependency target: %w", err)
 		}
-		if column == "depends_on_issue_id" {
+		switch column {
+		case "depends_on_issue_id":
 			row.issueTarget = sql.NullString{String: newID, Valid: true}
-		} else {
+			row.wispTarget = sql.NullString{}
+			row.external = sql.NullString{}
+		case "depends_on_wisp_id":
+			row.issueTarget = sql.NullString{}
 			row.wispTarget = sql.NullString{String: newID, Valid: true}
+			row.external = sql.NullString{}
+		default:
+			_ = queryRows.Close()
+			return fmt.Errorf("replace dependency target: unsupported typed column %q", column)
 		}
 		rows = append(rows, row)
 	}
@@ -344,7 +369,7 @@ func replaceDependencyTargetInTx(ctx context.Context, tx *sql.Tx, table, column,
 	}
 
 	//nolint:gosec // table and column are hardcoded by callers.
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE %s = ? OR (depends_on_id = ? AND depends_on_external IS NULL)`, table, column), oldID, oldID); err != nil {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE %s = ? OR (%s = ? AND depends_on_external IS NULL)`, table, column, DepTargetExpr), oldID, oldID); err != nil {
 		return fmt.Errorf("delete old dependency target: %w", err)
 	}
 	for _, row := range rows {
@@ -375,6 +400,9 @@ func nullTimeValue(value sql.NullTime) any {
 
 func RetargetInboundDependenciesToWispInTx(ctx context.Context, tx *sql.Tx, id string) error {
 	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if err := checkRenameTargetCollision(ctx, tx, table, "depends_on_wisp_id", id); err != nil {
+			return err
+		}
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET depends_on_wisp_id = ?, depends_on_issue_id = NULL
@@ -388,21 +416,15 @@ func RetargetInboundDependenciesToWispInTx(ctx context.Context, tx *sql.Tx, id s
 
 func RetargetInboundDependenciesToIssueInTx(ctx context.Context, tx *sql.Tx, id string) error {
 	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if err := checkRenameTargetCollision(ctx, tx, table, "depends_on_issue_id", id); err != nil {
+			return err
+		}
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 			UPDATE %s
 			SET depends_on_issue_id = ?, depends_on_wisp_id = NULL
 			WHERE depends_on_wisp_id = ?
 		`, table), id, id); err != nil {
 			return fmt.Errorf("retarget inbound dependencies to issue in %s for %s: %w", table, id, err)
-		}
-	}
-	// wisp_dependencies.depends_on_wisp_id cascades via fk_wisp_dep_wisp_target.
-	// Reject cross-typed-column target collisions (same source already has the
-	// new ID in depends_on_issue_id / depends_on_external) that the per-column
-	// UK constraints don't catch.
-	for _, table := range []string{"dependencies", "wisp_dependencies"} {
-		if err := checkRenameTargetCollision(ctx, tx, table, "depends_on_wisp_id", id); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/internal/storage/issueops/dependencies_test.go
+++ b/internal/storage/issueops/dependencies_test.go
@@ -1,10 +1,99 @@
 package issueops
 
 import (
+	"context"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
+
+func TestReplaceDependencyTargetNormalizesTargetColumns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		targetCol    string
+		rowIssue     any
+		rowWisp      any
+		wantIssue    any
+		wantWisp     any
+		wantExternal any
+	}{
+		{
+			name:         "issue target clears stale wisp target",
+			targetCol:    "depends_on_issue_id",
+			rowIssue:     nil,
+			rowWisp:      "old-target",
+			wantIssue:    "new-target",
+			wantWisp:     nil,
+			wantExternal: nil,
+		},
+		{
+			name:         "wisp target clears stale issue target",
+			targetCol:    "depends_on_wisp_id",
+			rowIssue:     "old-target",
+			rowWisp:      nil,
+			wantIssue:    nil,
+			wantWisp:     "new-target",
+			wantExternal: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectBegin()
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM dependencies a")).
+				WithArgs("new-target", "new-target", "new-target").
+				WillReturnRows(sqlmock.NewRows([]string{"found"}))
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id")).
+				WithArgs("old-target", "old-target").
+				WillReturnRows(sqlmock.NewRows([]string{
+					"issue_id",
+					"depends_on_issue_id",
+					"depends_on_wisp_id",
+					"depends_on_external",
+					"type",
+					"created_at",
+					"created_by",
+					"metadata",
+					"thread_id",
+				}).AddRow("source", tt.rowIssue, tt.rowWisp, nil, "blocks", nil, "tester", "{}", "thread-1"))
+			mock.ExpectExec(regexp.QuoteMeta("DELETE FROM dependencies")).
+				WithArgs("old-target", "old-target").
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec(regexp.QuoteMeta("INSERT INTO dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)")).
+				WithArgs("source", tt.wantIssue, tt.wantWisp, tt.wantExternal, "blocks", nil, "tester", "{}", "thread-1").
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+
+			tx, err := db.BeginTx(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("BeginTx: %v", err)
+			}
+			if err := replaceDependencyTargetInTx(context.Background(), tx, "dependencies", tt.targetCol, "old-target", "new-target"); err != nil {
+				_ = tx.Rollback()
+				t.Fatalf("replaceDependencyTargetInTx: %v", err)
+			}
+			if err := tx.Commit(); err != nil {
+				t.Fatalf("Commit: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet sql expectations: %v", err)
+			}
+		})
+	}
+}
 
 func TestCycleDetectionTablesUseBothTablesByDefault(t *testing.T) {
 	got := cycleDetectionTables()

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -4,32 +4,50 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// GetAllDependencyRecordsInTx returns all dependency records from the dependencies table.
+// GetAllDependencyRecordsInTx returns all dependency records from permanent and
+// wisp dependency tables.
 func GetAllDependencyRecordsInTx(ctx context.Context, tx *sql.Tx) (map[string][]*types.Dependency, error) {
+	result := make(map[string][]*types.Dependency)
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		if err := getAllDependencyRecordsIntoFromTable(ctx, tx, depTable, result); err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+//nolint:gosec // G201: depTable is "dependencies" or "wisp_dependencies" (hardcoded by caller).
+func getAllDependencyRecordsIntoFromTable(ctx context.Context, tx *sql.Tx, depTable string, result map[string][]*types.Dependency) error {
 	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-		SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
-		FROM dependencies
-		ORDER BY issue_id
-	`, DepTargetExpr))
+			SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+			FROM %s
+			ORDER BY issue_id
+		`, DepTargetExpr, depTable))
 	if err != nil {
-		return nil, fmt.Errorf("get all dependency records: %w", err)
+		return fmt.Errorf("get all dependency records from %s: %w", depTable, err)
 	}
 	defer rows.Close()
 
-	result := make(map[string][]*types.Dependency)
 	for rows.Next() {
 		dep, scanErr := scanDependencyRow(rows)
 		if scanErr != nil {
-			return nil, fmt.Errorf("get all dependency records: %w", scanErr)
+			return fmt.Errorf("get all dependency records from %s: %w", depTable, scanErr)
 		}
 		result[dep.IssueID] = append(result[dep.IssueID], dep)
 	}
-	return result, rows.Err()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("get all dependency records from %s: %w", depTable, err)
+	}
+	return nil
 }
 
 // GetDependencyRecordsForIssuesInTx returns dependency records for specific issues,
@@ -139,57 +157,65 @@ func GetDependencyCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string)
 		}
 		inClause := strings.Join(placeholders, ",")
 
-		// Blockers: issues that block the given IDs
-		//nolint:gosec // G201: inClause contains only ? placeholders
-		depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-			SELECT issue_id, COUNT(*) as cnt
-			FROM dependencies
-			WHERE issue_id IN (%s) AND type = 'blocks'
-			GROUP BY issue_id
-		`, inClause), args...)
-		if err != nil {
-			return nil, fmt.Errorf("get dependency counts (blockers): %w", err)
-		}
-		for depRows.Next() {
-			var id string
-			var cnt int
-			if err := depRows.Scan(&id, &cnt); err != nil {
-				_ = depRows.Close()
-				return nil, fmt.Errorf("get dependency counts: scan blocker: %w", err)
+		for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+			// Blockers: issues that block the given IDs.
+			//nolint:gosec // G201: depTable is hardcoded and inClause contains only ? placeholders.
+			depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+				SELECT issue_id, COUNT(*) as cnt
+				FROM %s
+				WHERE issue_id IN (%s) AND type = 'blocks'
+				GROUP BY issue_id
+			`, depTable, inClause), args...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					continue
+				}
+				return nil, fmt.Errorf("get dependency counts (blockers from %s): %w", depTable, err)
 			}
-			if c, ok := result[id]; ok {
-				c.DependencyCount = cnt
+			for depRows.Next() {
+				var id string
+				var cnt int
+				if err := depRows.Scan(&id, &cnt); err != nil {
+					_ = depRows.Close()
+					return nil, fmt.Errorf("get dependency counts: scan blocker: %w", err)
+				}
+				if c, ok := result[id]; ok {
+					c.DependencyCount += cnt
+				}
 			}
-		}
-		_ = depRows.Close()
-		if err := depRows.Err(); err != nil {
-			return nil, fmt.Errorf("get dependency counts: blocker rows: %w", err)
-		}
+			_ = depRows.Close()
+			if err := depRows.Err(); err != nil {
+				return nil, fmt.Errorf("get dependency counts: blocker rows: %w", err)
+			}
 
-		//nolint:gosec // G201: inClause contains only ? placeholders
-		blockingRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-			SELECT %s AS depends_on_id, COUNT(*) as cnt
-			FROM dependencies
-			WHERE %s IN (%s) AND type = 'blocks'
-			GROUP BY %s
-		`, DepTargetExpr, DepTargetExpr, inClause, DepTargetExpr), args...)
-		if err != nil {
-			return nil, fmt.Errorf("get dependency counts (dependents): %w", err)
-		}
-		for blockingRows.Next() {
-			var id string
-			var cnt int
-			if err := blockingRows.Scan(&id, &cnt); err != nil {
-				_ = blockingRows.Close()
-				return nil, fmt.Errorf("get dependency counts: scan dependent: %w", err)
+			//nolint:gosec // G201: depTable is hardcoded and inClause contains only ? placeholders.
+			blockingRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+				SELECT %s AS depends_on_id, COUNT(*) as cnt
+				FROM %s
+				WHERE %s AND type = 'blocks'
+				GROUP BY %s
+			`, DepTargetExpr, depTable, depTargetIn("", inClause), DepTargetExpr), args...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					continue
+				}
+				return nil, fmt.Errorf("get dependency counts (dependents from %s): %w", depTable, err)
 			}
-			if c, ok := result[id]; ok {
-				c.DependentCount = cnt
+			for blockingRows.Next() {
+				var id string
+				var cnt int
+				if err := blockingRows.Scan(&id, &cnt); err != nil {
+					_ = blockingRows.Close()
+					return nil, fmt.Errorf("get dependency counts: scan dependent: %w", err)
+				}
+				if c, ok := result[id]; ok {
+					c.DependentCount += cnt
+				}
 			}
-		}
-		_ = blockingRows.Close()
-		if err := blockingRows.Err(); err != nil {
-			return nil, fmt.Errorf("get dependency counts: dependent rows: %w", err)
+			_ = blockingRows.Close()
+			if err := blockingRows.Err(); err != nil {
+				return nil, fmt.Errorf("get dependency counts: dependent rows: %w", err)
+			}
 		}
 	}
 
@@ -225,29 +251,40 @@ func GetBlockingInfoForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []st
 
 	// Process wisp IDs against wisp_dependencies.
 	if len(wispIDs) > 0 {
-		if err := queryBlockingInfo(ctx, tx, wispIDs, "wisp_dependencies", "wisps", "depends_on_wisp_id", blockedByMap, blocksMap, parentMap); err != nil {
+		if err := queryBlockedByInfo(ctx, tx, wispIDs, "wisp_dependencies", blockedByMap, parentMap); err != nil {
 			return nil, nil, nil, err
 		}
 	}
 
 	// Process perm IDs against dependencies.
 	if len(permIDs) > 0 {
-		if err := queryBlockingInfo(ctx, tx, permIDs, "dependencies", "issues", "depends_on_issue_id", blockedByMap, blocksMap, parentMap); err != nil {
+		if err := queryBlockedByInfo(ctx, tx, permIDs, "dependencies", blockedByMap, parentMap); err != nil {
 			return nil, nil, nil, err
 		}
+	}
+
+	// "Blocks" is target-oriented, so scan both dependency tables regardless of
+	// the target issue's storage class.
+	if err := queryBlocksInfo(ctx, tx, issueIDs, []string{"dependencies", "wisp_dependencies"}, blocksMap); err != nil {
+		return nil, nil, nil, err
 	}
 
 	return blockedByMap, blocksMap, parentMap, nil
 }
 
-// queryBlockingInfo queries blocking info from a specific dep table + issue table pair.
+type blockingInfoRow struct {
+	issueID, blockerID, depType string
+}
+
+// queryBlockedByInfo queries outbound blocking info from a specific dependency
+// table. Blocker status is resolved against both issue storage classes so
+// cross-class closed blockers do not appear active.
 // Uses batched IN clauses (queryBatchSize) to avoid query-planner spikes.
-func queryBlockingInfo(
+func queryBlockedByInfo(
 	ctx context.Context, tx *sql.Tx,
 	issueIDs []string,
-	depTable, issueTable, targetCol string,
+	depTable string,
 	blockedByMap map[string][]string,
-	blocksMap map[string][]string,
 	parentMap map[string]string,
 ) error {
 	for start := 0; start < len(issueIDs); start += queryBatchSize {
@@ -265,73 +302,166 @@ func queryBlockingInfo(
 		}
 		inClause := strings.Join(placeholders, ",")
 
-		// Query 1: "blocked by" — deps where issue_id is in our set.
-		//nolint:gosec // G201: depTable, issueTable, targetCol are caller-controlled constants
+		// Query: "blocked by" — deps where issue_id is in our set.
+		//nolint:gosec // G201: depTable is a caller-controlled constant.
 		blockedByQuery := fmt.Sprintf(`
-			SELECT d.issue_id, %s AS depends_on_id, d.type, COALESCE(i.status, '') AS blocker_status
+			SELECT d.issue_id, %s AS depends_on_id, d.type
 			FROM %s d
-			LEFT JOIN %s i ON i.id = d.%s
 			WHERE d.issue_id IN (%s) AND d.type IN ('blocks', 'parent-child')
-		`, DepTargetExpr, depTable, issueTable, targetCol, inClause)
+		`, depTargetExpr("d"), depTable, inClause)
 
 		rows, err := tx.QueryContext(ctx, blockedByQuery, args...)
 		if err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
 			return fmt.Errorf("get blocked-by info from %s: %w", depTable, err)
 		}
+		var depRows []blockingInfoRow
+		var blockerIDs []string
 		for rows.Next() {
-			var issueID, blockerID, depType, blockerStatus string
-			if scanErr := rows.Scan(&issueID, &blockerID, &depType, &blockerStatus); scanErr != nil {
+			var row blockingInfoRow
+			if scanErr := rows.Scan(&row.issueID, &row.blockerID, &row.depType); scanErr != nil {
 				_ = rows.Close()
 				return fmt.Errorf("get blocking info: scan blocked-by: %w", scanErr)
 			}
-			if types.Status(blockerStatus) == types.StatusClosed {
-				continue
-			}
-			if depType == "parent-child" {
-				parentMap[issueID] = blockerID
-			} else {
-				blockedByMap[issueID] = append(blockedByMap[issueID], blockerID)
-			}
+			depRows = append(depRows, row)
+			blockerIDs = append(blockerIDs, row.blockerID)
 		}
 		_ = rows.Close()
 		if err := rows.Err(); err != nil {
 			return fmt.Errorf("get blocking info: blocked-by rows: %w", err)
 		}
 
-		// Query 2: "blocks" — deps where the typed target is in our set
-		//nolint:gosec // G201: depTable, issueTable, targetCol are caller-controlled constants
-		blocksQuery := fmt.Sprintf(`
-			SELECT d.%s, d.issue_id, d.type, COALESCE(i.status, '') AS blocker_status
-			FROM %s d
-			LEFT JOIN %s i ON i.id = d.%s
-			WHERE d.%s IN (%s) AND d.type IN ('blocks', 'parent-child')
-		`, targetCol, depTable, issueTable, targetCol, targetCol, inClause)
-
-		rows2, err := tx.QueryContext(ctx, blocksQuery, args...)
+		statusByID, err := loadStatusByIDInTx(ctx, tx, blockerIDs)
 		if err != nil {
-			return fmt.Errorf("get blocks info from %s: %w", depTable, err)
+			return fmt.Errorf("get blocking info: blocker status: %w", err)
 		}
-		for rows2.Next() {
-			var blockerID, blockedID, depType, blockerStatus string
-			if scanErr := rows2.Scan(&blockerID, &blockedID, &depType, &blockerStatus); scanErr != nil {
-				_ = rows2.Close()
-				return fmt.Errorf("get blocking info: scan blocks: %w", scanErr)
-			}
-			if types.Status(blockerStatus) == types.StatusClosed {
+		for _, row := range depRows {
+			if statusByID[row.blockerID] == types.StatusClosed {
 				continue
 			}
-			if depType == "parent-child" {
-				continue
+			if row.depType == "parent-child" {
+				parentMap[row.issueID] = row.blockerID
+			} else {
+				blockedByMap[row.issueID] = append(blockedByMap[row.issueID], row.blockerID)
 			}
-			blocksMap[blockerID] = append(blocksMap[blockerID], blockedID)
-		}
-		_ = rows2.Close()
-		if err := rows2.Err(); err != nil {
-			return fmt.Errorf("get blocking info: blocks rows: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// queryBlocksInfo queries inbound blocking info across dependency tables.
+func queryBlocksInfo(
+	ctx context.Context, tx *sql.Tx,
+	issueIDs []string,
+	depTables []string,
+	blocksMap map[string][]string,
+) error {
+	for start := 0; start < len(issueIDs); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(issueIDs) {
+			end = len(issueIDs)
+		}
+		batch := issueIDs[start:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		inClause := strings.Join(placeholders, ",")
+		statusByID, err := loadStatusByIDInTx(ctx, tx, batch)
+		if err != nil {
+			return fmt.Errorf("get blocking info: blocker status: %w", err)
+		}
+
+		for _, depTable := range depTables {
+			// Query: "blocks" — deps where depends_on_id is in our set.
+			//nolint:gosec // G201: depTable is a caller-controlled constant.
+			blocksQuery := fmt.Sprintf(`
+				SELECT %s AS depends_on_id, d.issue_id, d.type
+				FROM %s d
+				WHERE %s AND d.type IN ('blocks', 'parent-child')
+			`, depTargetExpr("d"), depTable, depTargetIn("d", inClause))
+
+			rows, err := tx.QueryContext(ctx, blocksQuery, args...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					continue
+				}
+				return fmt.Errorf("get blocks info from %s: %w", depTable, err)
+			}
+			for rows.Next() {
+				var blockerID, blockedID, depType string
+				if scanErr := rows.Scan(&blockerID, &blockedID, &depType); scanErr != nil {
+					_ = rows.Close()
+					return fmt.Errorf("get blocking info: scan blocks: %w", scanErr)
+				}
+				if statusByID[blockerID] == types.StatusClosed {
+					continue
+				}
+				if depType == "parent-child" {
+					continue
+				}
+				blocksMap[blockerID] = append(blocksMap[blockerID], blockedID)
+			}
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("get blocking info: blocks rows: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func loadStatusByIDInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[string]types.Status, error) {
+	statusByID := make(map[string]types.Status)
+	if len(ids) == 0 {
+		return statusByID, nil
+	}
+
+	sourceByID := make(map[string]string)
+	for _, issueTable := range []string{"issues", "wisps"} {
+		for start := 0; start < len(ids); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			placeholders, args := buildSQLInClause(ids[start:end])
+			rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+				SELECT id, status FROM %s WHERE id IN (%s)
+			`, issueTable, placeholders), args...)
+			if err != nil {
+				if optionalBlockedTable(issueTable) && isTableNotExistError(err) {
+					break
+				}
+				return nil, fmt.Errorf("status from %s: %w", issueTable, err)
+			}
+			for rows.Next() {
+				var id string
+				var status types.Status
+				if err := rows.Scan(&id, &status); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("scan status: %w", err)
+				}
+				if existingTable, exists := sourceByID[id]; exists {
+					_ = rows.Close()
+					return nil, fmt.Errorf("status id %q exists in both %s and %s", id, existingTable, issueTable)
+				}
+				sourceByID[id] = issueTable
+				statusByID[id] = status
+			}
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("status rows from %s: %w", issueTable, err)
+			}
+		}
+	}
+	return statusByID, nil
 }
 
 // GetNewlyUnblockedByCloseInTx finds issues that become unblocked when the
@@ -348,9 +478,12 @@ func GetNewlyUnblockedByCloseInTx(ctx context.Context, tx *sql.Tx, closedIssueID
 	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
 		rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
 			SELECT issue_id FROM %s
-			WHERE %s = ? AND type = 'blocks'
-		`, depTable, DepTargetExpr), closedIssueID)
+			WHERE %s AND type = 'blocks'
+		`, depTable, depTargetEquals("")), closedIssueID)
 		if err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
 			return nil, fmt.Errorf("find blocked candidates from %s: %w", depTable, err)
 		}
 		for rows.Next() {
@@ -372,66 +505,89 @@ func GetNewlyUnblockedByCloseInTx(ctx context.Context, tx *sql.Tx, closedIssueID
 	}
 
 	// Filter to only open/active candidates (check both tables, no JOINs).
-	var candidateIDs []string
+	candidateIDs := make([]string, 0, len(candidateSet))
 	for id := range candidateSet {
-		var status string
-		found := false
-		for _, table := range []string{"issues", "wisps"} {
-			err := tx.QueryRowContext(ctx, fmt.Sprintf(
-				`SELECT status FROM %s WHERE id = ?`, table), id).Scan(&status)
-			if err == nil {
-				found = true
-				break
-			}
-		}
-		if !found || status == "closed" || status == "pinned" {
-			continue
-		}
 		candidateIDs = append(candidateIDs, id)
 	}
+	sort.Strings(candidateIDs)
+
+	candidateStatusByID, err := loadStatusByIDInTx(ctx, tx, candidateIDs)
+	if err != nil {
+		return nil, fmt.Errorf("check candidate status: %w", err)
+	}
+	activeCandidateIDs := candidateIDs[:0]
+	for _, id := range candidateIDs {
+		status, ok := candidateStatusByID[id]
+		if !ok || status == types.StatusClosed || status == types.StatusPinned {
+			continue
+		}
+		activeCandidateIDs = append(activeCandidateIDs, id)
+	}
+	candidateIDs = activeCandidateIDs
 
 	if len(candidateIDs) == 0 {
 		return nil, nil
 	}
 
 	// Step 2: Filter out candidates that still have other open blockers.
-	// For each candidate, get all its blocking deps (excluding the closed issue),
-	// then check if any of those blockers are still active.
+	// Batch by candidate to avoid one dependency/status round-trip per
+	// candidate on remote Dolt backends.
 	stillBlocked := make(map[string]bool)
-	for _, candidateID := range candidateIDs {
-		// Determine which dep table this candidate uses.
-		isWisp := IsActiveWispInTx(ctx, tx, candidateID)
-		_, _, _, depTable := WispTableRouting(isWisp)
-
-		//nolint:gosec // G201: depTable from WispTableRouting (hardcoded)
-		depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-			SELECT %s AS depends_on_id FROM %s
-			WHERE issue_id = ? AND type = 'blocks' AND %s != ?
-		`, DepTargetExpr, depTable, DepTargetExpr), candidateID, closedIssueID)
-		if err != nil {
-			return nil, fmt.Errorf("check remaining blockers for %s: %w", candidateID, err)
+	for start := 0; start < len(candidateIDs); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(candidateIDs) {
+			end = len(candidateIDs)
 		}
-		for depRows.Next() {
-			var blockerID string
-			if err := depRows.Scan(&blockerID); err != nil {
-				_ = depRows.Close()
-				return nil, fmt.Errorf("scan remaining blocker: %w", err)
+		batch := candidateIDs[start:end]
+		placeholders, batchArgs := buildSQLInClause(batch)
+
+		remainingByCandidate := make(map[string][]string, len(batch))
+		remainingBlockerSet := make(map[string]struct{})
+		for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+			//nolint:gosec // G201: depTable is hardcoded.
+			depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+				SELECT issue_id, %s AS depends_on_id FROM %s
+				WHERE issue_id IN (%s) AND type = 'blocks' AND %s != ?
+			`, DepTargetExpr, depTable, placeholders, DepTargetExpr), append(batchArgs, closedIssueID)...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					continue
+				}
+				return nil, fmt.Errorf("check remaining blockers from %s: %w", depTable, err)
 			}
-			// Check if this blocker is still active (in either table).
-			var blockerStatus string
-			for _, table := range []string{"issues", "wisps"} {
-				err := tx.QueryRowContext(ctx, fmt.Sprintf(
-					`SELECT status FROM %s WHERE id = ?`, table), blockerID).Scan(&blockerStatus)
-				if err == nil {
+			for depRows.Next() {
+				var candidateID, blockerID string
+				if err := depRows.Scan(&candidateID, &blockerID); err != nil {
+					_ = depRows.Close()
+					return nil, fmt.Errorf("scan remaining blocker: %w", err)
+				}
+				remainingByCandidate[candidateID] = append(remainingByCandidate[candidateID], blockerID)
+				remainingBlockerSet[blockerID] = struct{}{}
+			}
+			_ = depRows.Close()
+			if err := depRows.Err(); err != nil {
+				return nil, fmt.Errorf("remaining blocker rows from %s: %w", depTable, err)
+			}
+		}
+
+		remainingBlockerIDs := make([]string, 0, len(remainingBlockerSet))
+		for blockerID := range remainingBlockerSet {
+			remainingBlockerIDs = append(remainingBlockerIDs, blockerID)
+		}
+		sort.Strings(remainingBlockerIDs)
+		statusByID, err := loadStatusByIDInTx(ctx, tx, remainingBlockerIDs)
+		if err != nil {
+			return nil, fmt.Errorf("check remaining blocker status: %w", err)
+		}
+		for candidateID, blockerIDs := range remainingByCandidate {
+			for _, blockerID := range blockerIDs {
+				status, ok := statusByID[blockerID]
+				if ok && status != types.StatusClosed && status != types.StatusPinned {
+					stillBlocked[candidateID] = true
 					break
 				}
 			}
-			if blockerStatus != "" && blockerStatus != "closed" && blockerStatus != "pinned" {
-				stillBlocked[candidateID] = true
-				break
-			}
 		}
-		_ = depRows.Close()
 	}
 
 	// Step 3: Collect unblocked issues.
@@ -456,34 +612,36 @@ func GetNewlyUnblockedByCloseInTx(ctx context.Context, tx *sql.Tx, closedIssueID
 // Uses separate single-table queries (no JOINs) to avoid Dolt's mergeJoinKvIter
 // panic when joining across tables with different tuple formats.
 //
-//nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
+//nolint:gosec // G201: table names are hardcoded constants.
 func IsBlockedInTx(ctx context.Context, tx *sql.Tx, issueID string) (bool, []string, error) {
-	isWisp := IsActiveWispInTx(ctx, tx, issueID)
-	_, _, _, depTable := WispTableRouting(isWisp)
-
-	// Step 1: Get all blocking dependency targets from the dep table.
+	// Step 1: Get all blocking dependency targets from both dep tables.
 	type depEdge struct {
 		dependsOnID, depType string
 	}
-	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-		SELECT %s AS depends_on_id, type FROM %s
-		WHERE issue_id = ? AND type IN ('blocks', 'waits-for', 'conditional-blocks')
-	`, DepTargetExpr, depTable), issueID)
-	if err != nil {
-		return false, nil, fmt.Errorf("check blockers: %w", err)
-	}
 	var edges []depEdge
-	for rows.Next() {
-		var e depEdge
-		if err := rows.Scan(&e.dependsOnID, &e.depType); err != nil {
-			_ = rows.Close()
-			return false, nil, fmt.Errorf("scan blocker edge: %w", err)
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+			SELECT %s AS depends_on_id, type FROM %s
+			WHERE issue_id = ? AND type IN ('blocks', 'waits-for', 'conditional-blocks')
+		`, DepTargetExpr, depTable), issueID)
+		if err != nil {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+				continue
+			}
+			return false, nil, fmt.Errorf("check blockers from %s: %w", depTable, err)
 		}
-		edges = append(edges, e)
-	}
-	_ = rows.Close()
-	if err := rows.Err(); err != nil {
-		return false, nil, fmt.Errorf("blocker edge rows: %w", err)
+		for rows.Next() {
+			var e depEdge
+			if err := rows.Scan(&e.dependsOnID, &e.depType); err != nil {
+				_ = rows.Close()
+				return false, nil, fmt.Errorf("scan blocker edge: %w", err)
+			}
+			edges = append(edges, e)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return false, nil, fmt.Errorf("blocker edge rows from %s: %w", depTable, err)
+		}
 	}
 
 	if len(edges) == 0 {
@@ -491,23 +649,21 @@ func IsBlockedInTx(ctx context.Context, tx *sql.Tx, issueID string) (bool, []str
 	}
 
 	// Step 2: Check each blocker's status in both issues and wisps tables.
-	// Uses single-row queries to avoid cross-table JOINs.
+	blockerIDs := make([]string, 0, len(edges))
+	for _, e := range edges {
+		blockerIDs = append(blockerIDs, e.dependsOnID)
+	}
+	statusByID, err := loadStatusByIDInTx(ctx, tx, blockerIDs)
+	if err != nil {
+		return false, nil, fmt.Errorf("check blocker status: %w", err)
+	}
 	var blockers []string
 	for _, e := range edges {
-		var status string
-		found := false
-		for _, table := range []string{"issues", "wisps"} {
-			err := tx.QueryRowContext(ctx, fmt.Sprintf(
-				`SELECT status FROM %s WHERE id = ?`, table), e.dependsOnID).Scan(&status)
-			if err == nil {
-				found = true
-				break
-			}
-		}
+		status, found := statusByID[e.dependsOnID]
 		if !found {
 			continue // Blocker not found in either table
 		}
-		if status == "closed" || status == "pinned" {
+		if status == types.StatusClosed || status == types.StatusPinned {
 			continue // Not an active blocker
 		}
 		if e.depType != "blocks" {

--- a/internal/storage/issueops/dependency_queries_test.go
+++ b/internal/storage/issueops/dependency_queries_test.go
@@ -1,0 +1,94 @@
+package issueops
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func allDependencyRecordsQueryRegex(table string) string {
+	return `(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type, created_at, created_by, metadata, thread_id\s+FROM ` +
+		regexp.QuoteMeta(table) + `\s+ORDER BY issue_id`
+}
+
+func dependencyRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"issue_id",
+		"depends_on_id",
+		"type",
+		"created_at",
+		"created_by",
+		"metadata",
+		"thread_id",
+	})
+}
+
+func TestGetAllDependencyRecordsInTxReadsPermanentAndWispDependencies(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	now := time.Now()
+	mock.ExpectQuery(allDependencyRecordsQueryRegex("dependencies")).
+		WillReturnRows(dependencyRows().AddRow(
+			"perm-source", "perm-target", types.DepBlocks, now, "tester", "{}", "thread-perm",
+		))
+	mock.ExpectQuery(allDependencyRecordsQueryRegex("wisp_dependencies")).
+		WillReturnRows(dependencyRows().AddRow(
+			"wisp-source", "wisp-target", types.DepParentChild, now, "tester", "{}", "thread-wisp",
+		))
+
+	got, err := GetAllDependencyRecordsInTx(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("GetAllDependencyRecordsInTx: %v", err)
+	}
+	if dep := onlyDependency(t, got, "perm-source"); dep.DependsOnID != "perm-target" {
+		t.Fatalf("perm dependency target = %q, want perm-target", dep.DependsOnID)
+	}
+	if dep := onlyDependency(t, got, "wisp-source"); dep.DependsOnID != "wisp-target" {
+		t.Fatalf("wisp dependency target = %q, want wisp-target", dep.DependsOnID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestGetAllDependencyRecordsInTxToleratesMissingWispDependencyTable(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(allDependencyRecordsQueryRegex("dependencies")).
+		WillReturnRows(dependencyRows().AddRow(
+			"perm-source", "perm-target", types.DepBlocks, time.Now(), "tester", "{}", "",
+		))
+	mock.ExpectQuery(allDependencyRecordsQueryRegex("wisp_dependencies")).
+		WillReturnError(errors.New("Error 1146: Table 'db.wisp_dependencies' doesn't exist"))
+
+	got, err := GetAllDependencyRecordsInTx(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("GetAllDependencyRecordsInTx: %v", err)
+	}
+	if dep := onlyDependency(t, got, "perm-source"); dep.DependsOnID != "perm-target" {
+		t.Fatalf("perm dependency target = %q, want perm-target", dep.DependsOnID)
+	}
+	if _, ok := got["wisp-source"]; ok {
+		t.Fatal("unexpected wisp dependency records from missing table")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func onlyDependency(t *testing.T, deps map[string][]*types.Dependency, issueID string) *types.Dependency {
+	t.Helper()
+
+	got := deps[issueID]
+	if len(got) != 1 {
+		t.Fatalf("deps[%q] length = %d, want 1: %+v", issueID, len(got), got)
+	}
+	return got[0]
+}

--- a/internal/storage/issueops/epic_closure.go
+++ b/internal/storage/issueops/epic_closure.go
@@ -48,11 +48,11 @@ func GetEpicsEligibleForClosureInTx(ctx context.Context, tx *sql.Tx) ([]*types.E
 	}
 	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
 		depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-			SELECT depends_on_issue_id, issue_id FROM %s
-			WHERE type = 'parent-child' AND depends_on_issue_id IS NOT NULL
-		`, depTable))
+			SELECT %s AS parent_id, issue_id FROM %s
+			WHERE type = 'parent-child' AND %s IS NOT NULL
+		`, DepTargetExpr, depTable, DepTargetExpr))
 		if err != nil {
-			if isTableNotExistError(err) {
+			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
 				continue // wisp_dependencies may not exist on pre-migration databases
 			}
 			return nil, fmt.Errorf("failed to get parent-child deps from %s: %w", depTable, err)

--- a/internal/storage/issueops/promote.go
+++ b/internal/storage/issueops/promote.go
@@ -66,5 +66,9 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx *sql.Tx, id string, actor 
 		log.Printf("promote %s: failed to copy comments: %v", id, err)
 	}
 
+	if err := RetargetInboundDependenciesToIssueInTx(ctx, tx, id); err != nil {
+		return err
+	}
+
 	return DeleteIssueInTx(ctx, tx, id)
 }

--- a/internal/storage/issueops/promote.go
+++ b/internal/storage/issueops/promote.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 
 	"github.com/steveyegge/beads/internal/storage"
 )
@@ -39,7 +38,10 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx *sql.Tx, id string, actor 
 		INSERT IGNORE INTO labels (issue_id, label)
 		SELECT issue_id, label FROM wisp_labels WHERE issue_id = ?
 	`, id); err != nil {
-		log.Printf("promote %s: failed to copy labels: %v", id, err)
+		return fmt.Errorf("copy labels for promoted wisp %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM wisp_labels WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied wisp labels for promoted wisp %s: %w", id, err)
 	}
 
 	if _, err := tx.ExecContext(ctx, `
@@ -47,7 +49,10 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx *sql.Tx, id string, actor 
 		SELECT issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id
 		FROM wisp_dependencies WHERE issue_id = ?
 	`, id); err != nil {
-		log.Printf("promote %s: failed to copy dependencies: %v", id, err)
+		return fmt.Errorf("copy dependencies for promoted wisp %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM wisp_dependencies WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied wisp dependencies for promoted wisp %s: %w", id, err)
 	}
 
 	if _, err := tx.ExecContext(ctx, `
@@ -55,7 +60,10 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx *sql.Tx, id string, actor 
 		SELECT issue_id, event_type, actor, old_value, new_value, comment, created_at
 		FROM wisp_events WHERE issue_id = ?
 	`, id); err != nil {
-		log.Printf("promote %s: failed to copy events: %v", id, err)
+		return fmt.Errorf("copy events for promoted wisp %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM wisp_events WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied wisp events for promoted wisp %s: %w", id, err)
 	}
 
 	if _, err := tx.ExecContext(ctx, `
@@ -63,12 +71,26 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx *sql.Tx, id string, actor 
 		SELECT issue_id, author, text, created_at
 		FROM wisp_comments WHERE issue_id = ?
 	`, id); err != nil {
-		log.Printf("promote %s: failed to copy comments: %v", id, err)
+		return fmt.Errorf("copy comments for promoted wisp %s: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM wisp_comments WHERE issue_id = ?`, id); err != nil {
+		return fmt.Errorf("delete copied wisp comments for promoted wisp %s: %w", id, err)
 	}
 
 	if err := RetargetInboundDependenciesToIssueInTx(ctx, tx, id); err != nil {
 		return err
 	}
 
-	return DeleteIssueInTx(ctx, tx, id)
+	result, err := tx.ExecContext(ctx, `DELETE FROM wisps WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete promoted wisp row %s: %w", id, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("get promoted wisp rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("wisp %s not found", id)
+	}
+	return nil
 }

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -280,27 +280,43 @@ func GetReadyWorkInTx(
 		}
 	}
 
-	// When IncludeEphemeral is set, also query the wisps table.
-	if filter.IncludeEphemeral {
-		wispFilter := readyWorkWispIssueFilter(filter)
-		// Ready-only wisp predicates are applied after search, so avoid limiting
-		// before that filtering can drop non-ready candidates.
-		wispFilter.Limit = 0
-		wisps, wErr := SearchIssuesInTx(ctx, tx, "", wispFilter)
-		if wErr != nil {
-			return nil, fmt.Errorf("search wisps (ready work): %w", wErr)
+	wisps, wErr := getReadyWispsInTx(ctx, tx, filter)
+	if wErr != nil {
+		return nil, wErr
+	}
+	if len(wisps) > 0 {
+		seen := make(map[string]struct{}, len(ordered))
+		for _, issue := range ordered {
+			seen[issue.ID] = struct{}{}
 		}
-		wisps, wErr = filterReadyWispsInTx(ctx, tx, filter, wisps)
-		if wErr != nil {
-			return nil, wErr
+		for _, wisp := range wisps {
+			if _, exists := seen[wisp.ID]; exists {
+				continue
+			}
+			ordered = append(ordered, wisp)
 		}
-		ordered = append(ordered, wisps...)
+		sortReadyIssues(ordered, filter.SortPolicy)
 		if filter.Limit > 0 && len(ordered) > filter.Limit {
 			ordered = ordered[:filter.Limit]
 		}
 	}
 
 	return ordered, nil
+}
+
+func getReadyWispsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter) ([]*types.Issue, error) {
+	wispFilter := readyWorkWispIssueFilter(filter)
+	// Ready-only wisp predicates are applied after search, so avoid limiting
+	// before that filtering can drop non-ready candidates.
+	wispFilter.Limit = 0
+	wisps, err := searchTableInTx(ctx, tx, "", wispFilter, WispsFilterTables)
+	if err != nil {
+		if isTableNotExistError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("search wisps (ready work): %w", err)
+	}
+	return filterReadyWispsInTx(ctx, tx, filter, wisps)
 }
 
 func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
@@ -328,7 +344,6 @@ func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
 }
 
 func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
-	ephTrue := true
 	pinnedFalse := false
 	wispFilter := types.IssueFilter{
 		Priority:       filter.Priority,
@@ -338,7 +353,6 @@ func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
 		Limit:          filter.Limit,
 		MolType:        filter.MolType,
 		WispType:       filter.WispType,
-		Ephemeral:      &ephTrue,
 		Pinned:         &pinnedFalse,
 		MetadataFields: filter.MetadataFields,
 		HasMetadataKey: filter.HasMetadataKey,
@@ -363,6 +377,10 @@ func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
 	if filter.MoleculeID != "" {
 		moleculeID := filter.MoleculeID
 		wispFilter.ParentID = &moleculeID
+	}
+	if !filter.IncludeEphemeral {
+		ephFalse := false
+		wispFilter.Ephemeral = &ephFalse
 	}
 	return wispFilter
 }
@@ -440,6 +458,48 @@ func filterReadyWispsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilt
 		ready = append(ready, wisp)
 	}
 	return ready, nil
+}
+
+func sortReadyIssues(issues []*types.Issue, policy types.SortPolicy) {
+	recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
+	sort.SliceStable(issues, func(i, j int) bool {
+		a, b := issues[i], issues[j]
+		switch policy {
+		case types.SortPolicyOldest:
+			return issueCreatedBefore(a, b)
+		case types.SortPolicyPriority:
+			return issuePriorityBefore(a, b)
+		case types.SortPolicyHybrid, "":
+			aRecent := !a.CreatedAt.Before(recentCutoff)
+			bRecent := !b.CreatedAt.Before(recentCutoff)
+			if aRecent != bRecent {
+				return aRecent
+			}
+			if aRecent && a.Priority != b.Priority {
+				return a.Priority < b.Priority
+			}
+			return issueCreatedBefore(a, b)
+		default:
+			return issuePriorityBefore(a, b)
+		}
+	})
+}
+
+func issuePriorityBefore(a, b *types.Issue) bool {
+	if a.Priority != b.Priority {
+		return a.Priority < b.Priority
+	}
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.After(b.CreatedAt)
+	}
+	return a.ID < b.ID
+}
+
+func issueCreatedBefore(a, b *types.Issue) bool {
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.Before(b.CreatedAt)
+	}
+	return a.ID < b.ID
 }
 
 func readyWorkPageSize(limit int) int {

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -163,7 +163,7 @@ func GetReadyWorkInTx(
 	// candidate IDs first and filter blockers per page below, avoiding a full
 	// dependency graph scan when the caller only needs a small ready set.
 	if filter.Limit == 0 {
-		blockedIDs, err := computeBlockedFn(ctx, tx, filter.IncludeEphemeral)
+		blockedIDs, err := computeBlockedFn(ctx, tx, true)
 		if err != nil {
 			return nil, fmt.Errorf("compute blocked IDs: %w", err)
 		}
@@ -227,7 +227,7 @@ func GetReadyWorkInTx(
 				break
 			}
 
-			blockedPageIDs, err := ComputeBlockedCandidateIDsInTx(ctx, tx, pageIDs, filter.IncludeEphemeral)
+			blockedPageIDs, err := ComputeBlockedCandidateIDsInTx(ctx, tx, pageIDs, true)
 			if err != nil {
 				return nil, fmt.Errorf("get ready work: filter blocked candidates: %w", err)
 			}
@@ -285,22 +285,30 @@ func GetReadyWorkInTx(
 		return nil, wErr
 	}
 	if len(wisps) > 0 {
-		seen := make(map[string]struct{}, len(ordered))
-		for _, issue := range ordered {
-			seen[issue.ID] = struct{}{}
-		}
-		for _, wisp := range wisps {
-			if _, exists := seen[wisp.ID]; exists {
-				continue
-			}
-			ordered = append(ordered, wisp)
-		}
-		sortReadyIssues(ordered, filter.SortPolicy)
-		if filter.Limit > 0 && len(ordered) > filter.Limit {
-			ordered = ordered[:filter.Limit]
+		ordered, err = mergeReadyWisps(ordered, wisps, filter)
+		if err != nil {
+			return nil, err
 		}
 	}
 
+	return ordered, nil
+}
+
+func mergeReadyWisps(ordered []*types.Issue, wisps []*types.Issue, filter types.WorkFilter) ([]*types.Issue, error) {
+	seen := make(map[string]struct{}, len(ordered))
+	for _, issue := range ordered {
+		seen[issue.ID] = struct{}{}
+	}
+	for _, wisp := range wisps {
+		if _, exists := seen[wisp.ID]; exists {
+			return nil, fmt.Errorf("ready work id %q exists in both issues and wisps", wisp.ID)
+		}
+		ordered = append(ordered, wisp)
+	}
+	sortReadyIssues(ordered, filter.SortPolicy)
+	if filter.Limit > 0 && len(ordered) > filter.Limit {
+		ordered = ordered[:filter.Limit]
+	}
 	return ordered, nil
 }
 
@@ -672,7 +680,7 @@ func getChildrenOfIssuesInTx(ctx context.Context, tx *sql.Tx, parentIDs []string
 			rows, err := tx.QueryContext(ctx, query, args...)
 			if err != nil {
 				// wisp_dependencies table may not exist on pre-migration databases.
-				if depTable == "wisp_dependencies" {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
 					break
 				}
 				return nil, fmt.Errorf("get children of issues from %s: %w", depTable, err)

--- a/internal/storage/issueops/ready_work_test.go
+++ b/internal/storage/issueops/ready_work_test.go
@@ -24,6 +24,10 @@ func deferredChildrenQueryRegex(depTable, issueTable string) string {
 	return `SELECT dep\.issue_id\s+FROM ` + depTable + ` dep\s+JOIN ` + issueTable + ` parent ON parent\.id = dep\.` + targetCol + `\s+WHERE dep\.type = 'parent-child'\s+AND parent\.defer_until IS NOT NULL\s+AND parent\.defer_until > UTC_TIMESTAMP\(\)`
 }
 
+func childrenOfIssuesQueryRegex(depTable string) string {
+	return `SELECT issue_id FROM ` + depTable + `\s+WHERE type = 'parent-child' AND COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) IN \(\?\)`
+}
+
 func beginMockTx(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *sql.Tx) {
 	t.Helper()
 
@@ -119,6 +123,28 @@ func TestGetReadyWorkInTx_UnboundedPropagatesBlockedComputationError(t *testing.
 	}
 }
 
+func TestGetReadyWorkInTx_UnboundedComputesBlockersAcrossWispsByDefault(t *testing.T) {
+	t.Parallel()
+
+	stopErr := errors.New("stop after blocker computation")
+	var gotIncludeWisps bool
+	_, err := GetReadyWorkInTx(
+		context.Background(),
+		nil,
+		types.WorkFilter{IncludeDeferred: true},
+		func(_ context.Context, _ *sql.Tx, includeWisps bool) ([]string, error) {
+			gotIncludeWisps = includeWisps
+			return nil, stopErr
+		},
+	)
+	if !errors.Is(err, stopErr) {
+		t.Fatalf("error = %v, want stop error", err)
+	}
+	if !gotIncludeWisps {
+		t.Fatal("computeBlockedFn includeWisps = false, want true")
+	}
+}
+
 func TestGetReadyWorkInTx_PropagatesDeferredParentChildError(t *testing.T) {
 	t.Parallel()
 
@@ -146,6 +172,121 @@ func TestGetReadyWorkInTx_PropagatesDeferredParentChildError(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestIsBlockedInTxErrorsOnIssueWispCollision(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type FROM dependencies\s+WHERE issue_id = \? AND type IN`).
+		WithArgs("blocked-id").
+		WillReturnRows(sqlmock.NewRows([]string{"depends_on_id", "type"}).AddRow("dup-id", "blocks"))
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id, type FROM wisp_dependencies\s+WHERE issue_id = \? AND type IN`).
+		WithArgs("blocked-id").
+		WillReturnRows(sqlmock.NewRows([]string{"depends_on_id", "type"}))
+	mock.ExpectQuery("SELECT id, status FROM issues").
+		WithArgs("dup-id").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow("dup-id", types.StatusOpen))
+	mock.ExpectQuery("SELECT id, status FROM wisps").
+		WithArgs("dup-id").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow("dup-id", types.StatusOpen))
+
+	_, _, err := IsBlockedInTx(context.Background(), tx, "blocked-id")
+	if err == nil {
+		t.Fatal("expected duplicate issue/wisp status error")
+	}
+	if !strings.Contains(err.Error(), `id "dup-id" exists in both issues and wisps`) {
+		t.Fatalf("error = %v, want duplicate issue/wisp context", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestGetNewlyUnblockedByCloseInTxChecksRemainingBlockersInBatches(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(`(?s)SELECT issue_id FROM dependencies\s+WHERE COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) = \? AND type = 'blocks'`).
+		WithArgs("closed-blocker").
+		WillReturnRows(sqlmock.NewRows([]string{"issue_id"}).
+			AddRow("candidate-a").
+			AddRow("candidate-b"))
+	mock.ExpectQuery(`(?s)SELECT issue_id FROM wisp_dependencies\s+WHERE COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) = \? AND type = 'blocks'`).
+		WithArgs("closed-blocker").
+		WillReturnRows(sqlmock.NewRows([]string{"issue_id"}))
+	mock.ExpectQuery(`SELECT id, status FROM issues WHERE id IN \(\?,\?\)`).
+		WithArgs("candidate-a", "candidate-b").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).
+			AddRow("candidate-a", types.StatusOpen).
+			AddRow("candidate-b", types.StatusOpen))
+	mock.ExpectQuery(`SELECT id, status FROM wisps WHERE id IN \(\?,\?\)`).
+		WithArgs("candidate-a", "candidate-b").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
+	mock.ExpectQuery(`(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id FROM dependencies\s+WHERE issue_id IN \(\?,\?\) AND type = 'blocks' AND COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) != \?`).
+		WithArgs("candidate-a", "candidate-b", "closed-blocker").
+		WillReturnRows(sqlmock.NewRows([]string{"issue_id", "depends_on_id"}).
+			AddRow("candidate-a", "other-blocker").
+			AddRow("candidate-b", "other-blocker"))
+	mock.ExpectQuery(`(?s)SELECT issue_id, COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) AS depends_on_id FROM wisp_dependencies\s+WHERE issue_id IN \(\?,\?\) AND type = 'blocks' AND COALESCE\(depends_on_issue_id, depends_on_wisp_id, depends_on_external\) != \?`).
+		WithArgs("candidate-a", "candidate-b", "closed-blocker").
+		WillReturnRows(sqlmock.NewRows([]string{"issue_id", "depends_on_id"}))
+	mock.ExpectQuery(`SELECT id, status FROM issues WHERE id IN \(\?\)`).
+		WithArgs("other-blocker").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow("other-blocker", types.StatusOpen))
+	mock.ExpectQuery(`SELECT id, status FROM wisps WHERE id IN \(\?\)`).
+		WithArgs("other-blocker").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}))
+
+	got, err := GetNewlyUnblockedByCloseInTx(context.Background(), tx, "closed-blocker")
+	if err != nil {
+		t.Fatalf("GetNewlyUnblockedByCloseInTx: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("unblocked = %v, want none because both candidates still have an open blocker", got)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestLoadStatusByIDInTxErrorsOnIssueWispCollision(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery("SELECT id, status FROM issues").
+		WithArgs("dup-id").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow("dup-id", types.StatusOpen))
+	mock.ExpectQuery("SELECT id, status FROM wisps").
+		WithArgs("dup-id").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow("dup-id", types.StatusClosed))
+
+	_, err := loadStatusByIDInTx(context.Background(), tx, []string{"dup-id"})
+	if err == nil {
+		t.Fatal("expected duplicate issue/wisp status error")
+	}
+	if !strings.Contains(err.Error(), `id "dup-id" exists in both issues and wisps`) {
+		t.Fatalf("error = %v, want duplicate issue/wisp context", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestMergeReadyWispsErrorsOnIssueWispCollision(t *testing.T) {
+	t.Parallel()
+
+	_, err := mergeReadyWisps(
+		[]*types.Issue{{ID: "dup-id", Status: types.StatusOpen}},
+		[]*types.Issue{{ID: "dup-id", Status: types.StatusClosed}},
+		types.WorkFilter{},
+	)
+	if err == nil {
+		t.Fatal("expected duplicate issue/wisp ready-work error")
+	}
+	if !strings.Contains(err.Error(), `id "dup-id" exists in both issues and wisps`) {
+		t.Fatalf("error = %v, want duplicate issue/wisp context", err)
 	}
 }
 
@@ -223,6 +364,30 @@ func TestGetChildrenOfDeferredParentsInTx_IgnoresMissingWispDependenciesTable(t 
 	want := []string{"child-from-dependencies-issues", "child-from-dependencies-wisps"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("children = %v, want %v", got, want)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestGetChildrenOfIssuesInTxPropagatesWispDependencyReadError(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	readErr := errors.New("permission denied reading wisp_dependencies")
+	mock.ExpectQuery(childrenOfIssuesQueryRegex("dependencies")).
+		WithArgs("parent-id").
+		WillReturnRows(sqlmock.NewRows([]string{"issue_id"}))
+	mock.ExpectQuery(childrenOfIssuesQueryRegex("wisp_dependencies")).
+		WithArgs("parent-id").
+		WillReturnError(readErr)
+
+	_, err := getChildrenOfIssuesInTx(context.Background(), tx, []string{"parent-id"})
+	if err == nil {
+		t.Fatal("expected wisp_dependencies read error")
+	}
+	if !errors.Is(err, readErr) {
+		t.Fatalf("error = %v, want wrapped read error", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -48,9 +48,10 @@ func SearchIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter type
 				seen[issue.ID] = true
 			}
 			for _, issue := range wispResults {
-				if !seen[issue.ID] {
-					results = append(results, issue)
+				if seen[issue.ID] {
+					return nil, fmt.Errorf("id %q exists in both issues and wisps", issue.ID)
 				}
+				results = append(results, issue)
 			}
 		}
 	}

--- a/internal/storage/issueops/update.go
+++ b/internal/storage/issueops/update.go
@@ -126,6 +126,17 @@ type UpdateResult struct {
 //
 //nolint:gosec // G201: table names come from WispTableRouting (hardcoded constants)
 func UpdateIssueInTx(ctx context.Context, tx *sql.Tx, id string, updates map[string]interface{}, actor string) (*UpdateResult, error) {
+	return updateIssueInTx(ctx, tx, id, updates, actor, true)
+}
+
+// UpdateIssueWithoutEventInTx applies normal update semantics without recording
+// an intermediate event. Demotion uses this to preserve the historical event
+// stream: create/update history is copied, then a single demotion event is added.
+func UpdateIssueWithoutEventInTx(ctx context.Context, tx *sql.Tx, id string, updates map[string]interface{}, actor string) (*UpdateResult, error) {
+	return updateIssueInTx(ctx, tx, id, updates, actor, false)
+}
+
+func updateIssueInTx(ctx context.Context, tx *sql.Tx, id string, updates map[string]interface{}, actor string, recordEvent bool) (*UpdateResult, error) {
 	// Route to correct table.
 	isWisp := IsActiveWispInTx(ctx, tx, id)
 	issueTable, _, eventTable, _ := WispTableRouting(isWisp)
@@ -213,13 +224,14 @@ func UpdateIssueInTx(ctx context.Context, tx *sql.Tx, id string, updates map[str
 		return nil, fmt.Errorf("failed to update issue: %w", err)
 	}
 
-	// Record event.
-	oldData, _ := json.Marshal(oldIssue)
-	newData, _ := json.Marshal(updates)
-	eventType := DetermineEventType(oldIssue, updates)
+	if recordEvent {
+		oldData, _ := json.Marshal(oldIssue)
+		newData, _ := json.Marshal(updates)
+		eventType := DetermineEventType(oldIssue, updates)
 
-	if err := RecordFullEventInTable(ctx, tx, eventTable, id, eventType, actor, string(oldData), string(newData)); err != nil {
-		return nil, fmt.Errorf("failed to record event: %w", err)
+		if err := RecordFullEventInTable(ctx, tx, eventTable, id, eventType, actor, string(oldData), string(newData)); err != nil {
+			return nil, fmt.Errorf("failed to record event: %w", err)
+		}
 	}
 
 	return &UpdateResult{OldIssue: oldIssue, IsWisp: isWisp}, nil

--- a/internal/storage/schema/backfill.go
+++ b/internal/storage/schema/backfill.go
@@ -23,6 +23,66 @@ func ensureBackfilledCustomStatusesCustomTypes(ctx context.Context, db DBConn) (
 	return typesWrote || statusesWrote, nil
 }
 
+func needsBackfilledCustomStatusesCustomTypes(ctx context.Context, db DBConn) (bool, error) {
+	typesNeed, err := needsCustomTypesBackfill(ctx, db)
+	if err != nil {
+		return false, fmt.Errorf("custom_types: %w", err)
+	}
+	statusesNeed, err := needsCustomStatusesBackfill(ctx, db)
+	if err != nil {
+		return false, fmt.Errorf("custom_statuses: %w", err)
+	}
+	return typesNeed || statusesNeed, nil
+}
+
+func needsCustomTypesBackfill(ctx context.Context, db DBConn) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM custom_types").Scan(&count); err != nil {
+		return false, err
+	}
+	if count > 0 {
+		return false, nil
+	}
+
+	var value string
+	err := db.QueryRowContext(ctx, "SELECT `value` FROM config WHERE `key` = 'types.custom'").Scan(&value)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(parseTypesValue(value)) > 0, nil
+}
+
+func needsCustomStatusesBackfill(ctx context.Context, db DBConn) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM custom_statuses").Scan(&count); err != nil {
+		return false, err
+	}
+	if count > 0 {
+		return false, nil
+	}
+
+	var value string
+	err := db.QueryRowContext(ctx, "SELECT `value` FROM config WHERE `key` = 'status.custom'").Scan(&value)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(value) == "" {
+		return false, nil
+	}
+
+	parsed, parseErr := types.ParseCustomStatusConfig(value)
+	if parseErr != nil {
+		return false, nil
+	}
+	return len(parsed) > 0, nil
+}
+
 func backfillCustomTypes(ctx context.Context, db DBConn) (bool, error) {
 	var count int
 	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM custom_types").Scan(&count); err != nil {

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -102,6 +102,8 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	latestIgnored := LatestIgnoredVersion()
 
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
+	expectDoltStatusRows(mock)
+	expectDoltStatusRows(mock)
 	mock.ExpectExec("(?s)^CREATE TABLE IF NOT EXISTS schema_migrations").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
@@ -117,7 +119,12 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 	mock.ExpectExec("(?s)^CREATE TABLE IF NOT EXISTS ignored_schema_migrations").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", latestIgnored)
-	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_ADD('-A')")).
+	expectDoltStatusRows(mock)
+	expectDoltStatusRows(mock)
+	mock.ExpectQuery("(?s)SELECT t\\.TABLE_NAME\\s+FROM INFORMATION_SCHEMA\\.TABLES t").
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).AddRow("schema_migrations"))
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_ADD('-f', ?)")).
+		WithArgs("schema_migrations").
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: apply migrations')")).
 		WillReturnResult(sqlmock.NewResult(0, 0))
@@ -126,4 +133,9 @@ func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
 func expectScalar(mock sqlmock.Sqlmock, query, column string, value any) {
 	mock.ExpectQuery(regexp.QuoteMeta(query)).
 		WillReturnRows(sqlmock.NewRows([]string{column}).AddRow(value))
+}
+
+func expectDoltStatusRows(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("(?s)SELECT s\\.table_name, s\\.staged\\s+FROM dolt_status s").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}))
 }

--- a/internal/storage/schema/migrations/0021_create_wisp_auxiliary.up.sql
+++ b/internal/storage/schema/migrations/0021_create_wisp_auxiliary.up.sql
@@ -6,15 +6,26 @@ CREATE TABLE IF NOT EXISTS wisp_labels (
 );
 
 CREATE TABLE IF NOT EXISTS wisp_dependencies (
+    id CHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY,
     issue_id VARCHAR(255) NOT NULL,
-    depends_on_id VARCHAR(255) NOT NULL,
+    depends_on_issue_id VARCHAR(255) NULL,
+    depends_on_wisp_id VARCHAR(255) NULL,
+    depends_on_external VARCHAR(255) NULL,
     type VARCHAR(32) NOT NULL DEFAULT 'blocks',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(255) DEFAULT '',
     metadata JSON DEFAULT (JSON_OBJECT()),
     thread_id VARCHAR(255) DEFAULT '',
-    PRIMARY KEY (issue_id, depends_on_id),
-    INDEX idx_wisp_dep_depends (depends_on_id)
+    UNIQUE KEY uk_wisp_dep_issue_target (issue_id, depends_on_issue_id),
+    UNIQUE KEY uk_wisp_dep_wisp_target (issue_id, depends_on_wisp_id),
+    UNIQUE KEY uk_wisp_dep_external_target (issue_id, depends_on_external),
+    INDEX idx_wisp_dep_type_issue (type, depends_on_issue_id),
+    INDEX idx_wisp_dep_type_wisp (type, depends_on_wisp_id),
+    INDEX idx_wisp_dep_type_external (type, depends_on_external),
+    CONSTRAINT fk_wisp_dep_issue FOREIGN KEY (issue_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_wisp_dep_wisp_target FOREIGN KEY (depends_on_wisp_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT fk_wisp_dep_issue_target FOREIGN KEY (depends_on_issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT ck_wisp_dep_one_target CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)
 );
 
 CREATE TABLE IF NOT EXISTS wisp_events (

--- a/internal/storage/schema/migrations/0022_wisp_dep_type_index.down.sql
+++ b/internal/storage/schema/migrations/0022_wisp_dep_type_index.down.sql
@@ -1,2 +1,9 @@
-DROP INDEX idx_wisp_dep_type_depends ON wisp_dependencies;
-DROP INDEX idx_wisp_dep_type ON wisp_dependencies;
+SET @sql = IF(
+    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'wisp_dependencies'
+          AND INDEX_NAME = 'idx_wisp_dep_type') > 0,
+    'DROP INDEX idx_wisp_dep_type ON wisp_dependencies',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0022_wisp_dep_type_index.up.sql
+++ b/internal/storage/schema/migrations/0022_wisp_dep_type_index.up.sql
@@ -6,10 +6,24 @@ SET @sql = IF(
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
-SET @sql = IF(
-    (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
-        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies') > 0,
-    'CREATE INDEX IF NOT EXISTS idx_wisp_dep_type_depends ON wisp_dependencies (type, depends_on_id)',
-    'SELECT 1'
+SET @has_split_targets = (
+    SELECT COUNT(*) = 3
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_dependencies'
+      AND COLUMN_NAME IN ('depends_on_issue_id', 'depends_on_wisp_id', 'depends_on_external')
 );
+SET @sql = IF(@has_split_targets,
+    'CREATE INDEX IF NOT EXISTS idx_wisp_dep_type_issue ON wisp_dependencies (type, depends_on_issue_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_split_targets,
+    'CREATE INDEX IF NOT EXISTS idx_wisp_dep_type_wisp ON wisp_dependencies (type, depends_on_wisp_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@has_split_targets,
+    'CREATE INDEX IF NOT EXISTS idx_wisp_dep_type_external ON wisp_dependencies (type, depends_on_external)',
+    'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.down.sql
@@ -23,10 +23,18 @@ SELECT issue_id, label FROM wisp_labels wl
 WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wl.issue_id
               AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
 
-INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id)
-SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd
-WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id
-              AND i.issue_type IN ('agent', 'rig', 'role', 'message'));
+SET @has_split_wisp_dependencies = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_dependencies'
+      AND COLUMN_NAME IN ('depends_on_issue_id', 'depends_on_wisp_id', 'depends_on_external')
+);
+SET @sql = IF(
+    @has_split_wisp_dependencies = 3,
+    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''rig'', ''role'', ''message''))',
+    'INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies wd WHERE EXISTS (SELECT 1 FROM issues i WHERE i.id = wd.issue_id AND i.issue_type IN (''agent'', ''rig'', ''role'', ''message''))'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 INSERT IGNORE INTO events (id, issue_id, event_type, actor, old_value, new_value, comment, created_at)
 SELECT id, issue_id, event_type, actor, old_value, new_value, comment, created_at FROM wisp_events we

--- a/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
+++ b/internal/storage/schema/migrations/0035_migrate_infra_to_wisps.up.sql
@@ -31,10 +31,20 @@ SET @sql = IF(
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
+SET @has_split_wisp_dependencies = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'wisp_dependencies'
+      AND COLUMN_NAME IN ('depends_on_issue_id', 'depends_on_wisp_id', 'depends_on_external')
+);
 SET @sql = IF(
     (SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'wisp_dependencies') > 0,
-    'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+    IF(
+        @has_split_wisp_dependencies = 3,
+        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN NULL WHEN EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN NULL WHEN EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, CASE WHEN d.depends_on_id LIKE ''external:%'' THEN d.depends_on_id WHEN NOT EXISTS (SELECT 1 FROM wisps w WHERE w.id = d.depends_on_id) AND NOT EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id) THEN d.depends_on_id ELSE NULL END, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')',
+        'INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d JOIN issues i ON i.id = d.issue_id WHERE i.issue_type IN (''agent'', ''rig'', ''role'', ''message'')'
+    ),
     'SELECT 1'
 );
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -2,8 +2,10 @@ package schema
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"embed"
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"sort"
@@ -16,6 +18,10 @@ type DBConn interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+type dirtyTableState struct {
+	staged bool
 }
 
 //go:embed migrations/*.up.sql
@@ -96,6 +102,13 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration status: %w", err)
 	}
+	if staged := stagedDirtyTables(dirtyBefore); len(staged) > 0 {
+		return 0, fmt.Errorf("refusing to apply migrations with pre-existing staged tables: %s", strings.Join(staged, ", "))
+	}
+	dirtyBeforeSignatures, err := dirtyTableSignatures(ctx, db, dirtyBefore)
+	if err != nil {
+		return 0, fmt.Errorf("reading pre-migration dirty table diffs: %w", err)
+	}
 
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {
@@ -119,6 +132,13 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if applied == 0 && !backfilled && appliedIgnored == 0 {
 		return applied, nil
 	}
+	changedDirtyTables, err := changedDirtyTableSignatures(ctx, db, dirtyBeforeSignatures)
+	if err != nil {
+		return applied, fmt.Errorf("checking pre-existing dirty table diffs: %w", err)
+	}
+	if len(changedDirtyTables) > 0 {
+		return applied, fmt.Errorf("pre-existing dirty tables changed during schema migration: %s", strings.Join(changedDirtyTables, ", "))
+	}
 
 	staged, err := stageNewDirtyTables(ctx, db, dirtyBefore)
 	if err != nil {
@@ -136,9 +156,9 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	return applied, nil
 }
 
-func committableDirtyTables(ctx context.Context, db DBConn) (map[string]struct{}, error) {
+func committableDirtyTables(ctx context.Context, db DBConn) (map[string]dirtyTableState, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT s.table_name
+		SELECT s.table_name, s.staged
 		FROM dolt_status s
 		WHERE NOT EXISTS (
 			SELECT 1 FROM dolt_ignore di
@@ -151,13 +171,16 @@ func committableDirtyTables(ctx context.Context, db DBConn) (map[string]struct{}
 	}
 	defer rows.Close()
 
-	tables := make(map[string]struct{})
+	tables := make(map[string]dirtyTableState)
 	for rows.Next() {
 		var table string
-		if err := rows.Scan(&table); err != nil {
+		var staged bool
+		if err := rows.Scan(&table, &staged); err != nil {
 			return nil, err
 		}
-		tables[table] = struct{}{}
+		state := tables[table]
+		state.staged = state.staged || staged
+		tables[table] = state
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -165,7 +188,139 @@ func committableDirtyTables(ctx context.Context, db DBConn) (map[string]struct{}
 	return tables, nil
 }
 
-func stageNewDirtyTables(ctx context.Context, db DBConn, dirtyBefore map[string]struct{}) (bool, error) {
+func stagedDirtyTables(tables map[string]dirtyTableState) []string {
+	var staged []string
+	for table, state := range tables {
+		if state.staged {
+			staged = append(staged, table)
+		}
+	}
+	sort.Strings(staged)
+	return staged
+}
+
+func dirtyTableSignatures(ctx context.Context, db DBConn, tables map[string]dirtyTableState) (map[string]string, error) {
+	signatures := make(map[string]string, len(tables))
+	names := sortedDirtyTableNames(tables)
+	for _, table := range names {
+		signature, err := dirtyTableSignature(ctx, db, table)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", table, err)
+		}
+		signatures[table] = signature
+	}
+	return signatures, nil
+}
+
+func changedDirtyTableSignatures(ctx context.Context, db DBConn, before map[string]string) ([]string, error) {
+	var changed []string
+	names := sortedSignatureTableNames(before)
+	for _, table := range names {
+		signature, err := dirtyTableSignature(ctx, db, table)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", table, err)
+		}
+		if signature != before[table] {
+			changed = append(changed, table)
+		}
+	}
+	return changed, nil
+}
+
+func sortedDirtyTableNames(tables map[string]dirtyTableState) []string {
+	names := make([]string, 0, len(tables))
+	for table := range tables {
+		names = append(names, table)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedSignatureTableNames(signatures map[string]string) []string {
+	names := make([]string, 0, len(signatures))
+	for table := range signatures {
+		names = append(names, table)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func dirtyTableSignature(ctx context.Context, db DBConn, table string) (string, error) {
+	//nolint:gosec // table comes from dolt_status; dolt_diff requires a literal table argument.
+	rows, err := db.QueryContext(ctx, "SELECT * FROM dolt_diff('HEAD', 'WORKING', "+sqlStringLiteral(table)+")")
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return "", err
+	}
+
+	var rowSignatures []string
+	for rows.Next() {
+		values := make([]any, len(columns))
+		dest := make([]any, len(columns))
+		for i := range values {
+			dest[i] = &values[i]
+		}
+		if err := rows.Scan(dest...); err != nil {
+			return "", err
+		}
+
+		var b strings.Builder
+		for i, column := range columns {
+			if isDiffMetadataColumn(column) {
+				continue
+			}
+			b.WriteString(column)
+			b.WriteByte('=')
+			writeSignatureValue(&b, values[i])
+			b.WriteByte(0)
+		}
+		rowSignatures = append(rowSignatures, b.String())
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	sort.Strings(rowSignatures)
+
+	h := sha256.New()
+	for _, row := range rowSignatures {
+		_, _ = h.Write([]byte(row))
+		_, _ = h.Write([]byte{0xff})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func isDiffMetadataColumn(column string) bool {
+	switch strings.ToLower(column) {
+	case "from_commit", "to_commit", "from_commit_date", "to_commit_date":
+		return true
+	default:
+		return false
+	}
+}
+
+func sqlStringLiteral(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `''`)
+	return "'" + s + "'"
+}
+
+func writeSignatureValue(b *strings.Builder, v any) {
+	switch typed := v.(type) {
+	case nil:
+		b.WriteString("<nil>")
+	case []byte:
+		b.Write(typed)
+	default:
+		b.WriteString(fmt.Sprintf("%v", typed))
+	}
+}
+
+func stageNewDirtyTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState) (bool, error) {
 	dirtyAfter, err := committableDirtyTables(ctx, db)
 	if err != nil {
 		return false, err

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -98,22 +98,22 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return 0, nil
 	}
 
-	dirtyBefore, err := committableDirtyTables(ctx, db)
+	dirtyBeforeAll, err := dirtyTables(ctx, db, false)
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration status: %w", err)
 	}
-	if staged := stagedDirtyTables(dirtyBefore); len(staged) > 0 {
-		return 0, fmt.Errorf("refusing to apply migrations with pre-existing staged tables: %s", strings.Join(staged, ", "))
+	if err := unstagePreExistingTables(ctx, db, dirtyBeforeAll); err != nil {
+		return 0, fmt.Errorf("unstaging pre-migration tables: %w", err)
+	}
+
+	dirtyBefore, err := committableDirtyTables(ctx, db)
+	if err != nil {
+		return 0, fmt.Errorf("reading pre-migration status: %w", err)
 	}
 	dirtyBeforeSignatures, err := dirtyTableSignatures(ctx, db, dirtyBefore)
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration dirty table diffs: %w", err)
 	}
-	tablesBefore, err := existingTables(ctx, db)
-	if err != nil {
-		return 0, fmt.Errorf("reading pre-migration tables: %w", err)
-	}
-
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {
 		return applied, err
@@ -144,7 +144,7 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return applied, fmt.Errorf("pre-existing dirty tables changed during schema migration: %s", strings.Join(changedDirtyTables, ", "))
 	}
 
-	staged, err := stageNewSchemaTables(ctx, db, dirtyBefore, tablesBefore)
+	staged, err := stageSchemaTables(ctx, db, dirtyBefore)
 	if err != nil {
 		return applied, fmt.Errorf("staging migrations: %w", err)
 	}
@@ -179,6 +179,15 @@ func stagedDirtyTables(tables map[string]dirtyTableState) []string {
 	}
 	sort.Strings(staged)
 	return staged
+}
+
+func unstagePreExistingTables(ctx context.Context, db DBConn, tables map[string]dirtyTableState) error {
+	for _, table := range stagedDirtyTables(tables) {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_RESET(?)", table); err != nil {
+			return fmt.Errorf("dolt reset %s: %w", table, err)
+		}
+	}
+	return nil
 }
 
 func dirtyTableSignatures(ctx context.Context, db DBConn, tables map[string]dirtyTableState) (map[string]string, error) {
@@ -302,7 +311,7 @@ func writeSignatureValue(b *strings.Builder, v any) {
 	}
 }
 
-func stageNewSchemaTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState, tablesBefore map[string]struct{}) (bool, error) {
+func stageSchemaTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState) (bool, error) {
 	dirtyAfter, err := dirtyTables(ctx, db, false)
 	if err != nil {
 		return false, err
@@ -320,9 +329,10 @@ func stageNewSchemaTables(ctx context.Context, db DBConn, dirtyBefore map[string
 		return false, err
 	}
 	for table := range tablesAfter {
-		if _, existed := tablesBefore[table]; !existed {
-			tableSet[table] = struct{}{}
+		if _, wasDirty := dirtyBefore[table]; wasDirty {
+			continue
 		}
+		tableSet[table] = struct{}{}
 	}
 
 	tables := make([]string, 0, len(tableSet))

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -8,10 +8,14 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/fs"
+	"log"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/steveyegge/beads/internal/storage/dberrors"
 )
 
 type DBConn interface {
@@ -23,6 +27,8 @@ type DBConn interface {
 type dirtyTableState struct {
 	staged bool
 }
+
+var doltStatusTableNameRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 //go:embed migrations/*.up.sql
 var upMigrations embed.FS
@@ -94,7 +100,11 @@ func parseVersion(name string) (int, error) {
 }
 
 func MigrateUp(ctx context.Context, db DBConn) (int, error) {
-	if mainSource.atLatest(ctx, db) && ignoredSource.atLatest(ctx, db) {
+	needed, err := migrationWorkNeeded(ctx, db)
+	if err != nil {
+		return 0, fmt.Errorf("checking schema migration work: %w", err)
+	}
+	if !needed {
 		return 0, nil
 	}
 
@@ -102,6 +112,10 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration status: %w", err)
 	}
+	// Schema migration needs a clean staged set so the migration commit
+	// contains only schema-owned tables. Pre-existing staged tables are reset
+	// here and left dirty but unstaged; dirtyTableSignatures below preserves
+	// their data state and rejects unexpected content changes.
 	if err := unstagePreExistingTables(ctx, db, dirtyBeforeAll); err != nil {
 		return 0, fmt.Errorf("unstaging pre-migration tables: %w", err)
 	}
@@ -109,6 +123,13 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	dirtyBefore, err := committableDirtyTables(ctx, db)
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration status: %w", err)
+	}
+	touchedDirtyTables, err := mainSource.pendingMigrationDirtyTables(ctx, db, dirtyBefore)
+	if err != nil {
+		return 0, fmt.Errorf("checking dirty tables against pending migrations: %w", err)
+	}
+	if len(touchedDirtyTables) > 0 {
+		return 0, fmt.Errorf("pending schema migrations alter pre-existing dirty tables: %s", strings.Join(touchedDirtyTables, ", "))
 	}
 	dirtyBeforeSignatures, err := dirtyTableSignatures(ctx, db, dirtyBefore)
 	if err != nil {
@@ -128,9 +149,20 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return applied, fmt.Errorf("registering ignored_schema_migrations in dolt_ignore: %w", err)
 	}
 
+	touchedIgnoredDirtyTables, err := ignoredSource.pendingMigrationDirtyTables(ctx, db, dirtyBeforeAll)
+	if err != nil {
+		return applied, fmt.Errorf("checking dirty tables against pending ignored migrations: %w", err)
+	}
+	if len(touchedIgnoredDirtyTables) > 0 {
+		return applied, fmt.Errorf("pending ignored schema migrations alter pre-existing dirty tables: %s", strings.Join(touchedIgnoredDirtyTables, ", "))
+	}
+
 	appliedIgnored, err := ignoredSource.migrate(ctx, db)
 	if err != nil {
 		return applied, fmt.Errorf("ignored migrations: %w", err)
+	}
+	if err := unstageIgnoredTables(ctx, db); err != nil {
+		return applied, fmt.Errorf("unstaging ignored migration tables: %w", err)
 	}
 
 	if applied == 0 && !backfilled && appliedIgnored == 0 {
@@ -160,6 +192,13 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	return applied, nil
 }
 
+func migrationWorkNeeded(ctx context.Context, db DBConn) (bool, error) {
+	if !mainSource.atLatest(ctx, db) || !ignoredSource.atLatest(ctx, db) {
+		return true, nil
+	}
+	return needsBackfilledCustomStatusesCustomTypes(ctx, db)
+}
+
 func committableDirtyTables(ctx context.Context, db DBConn) (map[string]dirtyTableState, error) {
 	tables, err := dirtyTables(ctx, db, true)
 	if err != nil {
@@ -182,12 +221,24 @@ func stagedDirtyTables(tables map[string]dirtyTableState) []string {
 }
 
 func unstagePreExistingTables(ctx context.Context, db DBConn, tables map[string]dirtyTableState) error {
-	for _, table := range stagedDirtyTables(tables) {
+	staged := stagedDirtyTables(tables)
+	if len(staged) > 0 {
+		log.Printf("schema migration unstaging pre-existing staged tables: %s", strings.Join(staged, ", "))
+	}
+	for _, table := range staged {
 		if _, err := db.ExecContext(ctx, "CALL DOLT_RESET(?)", table); err != nil {
 			return fmt.Errorf("dolt reset %s: %w", table, err)
 		}
 	}
 	return nil
+}
+
+func unstageIgnoredTables(ctx context.Context, db DBConn) error {
+	tables, err := existingIgnoredTables(ctx, db)
+	if err != nil {
+		return err
+	}
+	return unstagePreExistingTables(ctx, db, tables)
 }
 
 func dirtyTableSignatures(ctx context.Context, db DBConn, tables map[string]dirtyTableState) (map[string]string, error) {
@@ -237,6 +288,9 @@ func sortedSignatureTableNames(signatures map[string]string) []string {
 }
 
 func dirtyTableSignature(ctx context.Context, db DBConn, table string) (string, error) {
+	if !doltStatusTableNameRE.MatchString(table) {
+		return "", fmt.Errorf("unsafe dolt status table name %q", table)
+	}
 	//nolint:gosec // table comes from dolt_status; dolt_diff requires a literal table argument.
 	rows, err := db.QueryContext(ctx, "SELECT * FROM dolt_diff('HEAD', 'WORKING', "+sqlStringLiteral(table)+")")
 	if err != nil {
@@ -312,7 +366,7 @@ func writeSignatureValue(b *strings.Builder, v any) {
 }
 
 func stageSchemaTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState) (bool, error) {
-	dirtyAfter, err := dirtyTables(ctx, db, false)
+	dirtyAfter, err := dirtyTables(ctx, db, true)
 	if err != nil {
 		return false, err
 	}
@@ -324,7 +378,7 @@ func stageSchemaTables(ctx context.Context, db DBConn, dirtyBefore map[string]di
 		}
 		tableSet[table] = struct{}{}
 	}
-	tablesAfter, err := existingTables(ctx, db)
+	tablesAfter, err := existingCommittableTables(ctx, db)
 	if err != nil {
 		return false, err
 	}
@@ -349,12 +403,17 @@ func stageSchemaTables(ctx context.Context, db DBConn, dirtyBefore map[string]di
 	return len(tables) > 0, nil
 }
 
-func existingTables(ctx context.Context, db DBConn) (map[string]struct{}, error) {
+func existingCommittableTables(ctx context.Context, db DBConn) (map[string]struct{}, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT TABLE_NAME
-		FROM INFORMATION_SCHEMA.TABLES
-		WHERE TABLE_SCHEMA = DATABASE()
-		  AND TABLE_TYPE = 'BASE TABLE'
+		SELECT t.TABLE_NAME
+		FROM INFORMATION_SCHEMA.TABLES t
+		WHERE t.TABLE_SCHEMA = DATABASE()
+		  AND t.TABLE_TYPE = 'BASE TABLE'
+		  AND NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			  AND t.TABLE_NAME LIKE di.pattern
+		  )
 	`)
 	if err != nil {
 		return nil, err
@@ -368,6 +427,36 @@ func existingTables(ctx context.Context, db DBConn) (map[string]struct{}, error)
 			return nil, err
 		}
 		tables[table] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return tables, nil
+}
+
+func existingIgnoredTables(ctx context.Context, db DBConn) (map[string]dirtyTableState, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT s.table_name, s.staged
+		FROM dolt_status s
+		WHERE EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			  AND s.table_name LIKE di.pattern
+		)
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tables := make(map[string]dirtyTableState)
+	for rows.Next() {
+		var table string
+		var staged bool
+		if err := rows.Scan(&table, &staged); err != nil {
+			return nil, err
+		}
+		tables[table] = dirtyTableState{staged: staged}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -453,11 +542,76 @@ func (m migrationSource) latest() int {
 }
 
 func (m migrationSource) atLatest(ctx context.Context, db DBConn) bool {
-	var current int
-	if err := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+m.cursorTable).Scan(&current); err != nil {
+	current, err := m.currentVersion(ctx, db)
+	if err != nil {
 		return false
 	}
 	return current >= m.latest()
+}
+
+func (m migrationSource) currentVersion(ctx context.Context, db DBConn) (int, error) {
+	var current int
+	err := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+m.cursorTable).Scan(&current)
+	if err == nil || err == sql.ErrNoRows {
+		return current, nil
+	}
+	if dberrors.IsTableNotExist(err) {
+		return 0, nil
+	}
+	return 0, fmt.Errorf("reading %s version: %w", m.cursorTable, err)
+}
+
+func (m migrationSource) pendingMigrationDirtyTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState) ([]string, error) {
+	if len(dirtyBefore) == 0 {
+		return nil, nil
+	}
+	current, err := m.currentVersion(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	dirtyNames := sortedDirtyTableNames(dirtyBefore)
+	touched := make(map[string]struct{})
+	for _, mf := range m.list() {
+		if mf.version <= current {
+			continue
+		}
+		data, err := m.files.ReadFile(m.dir + "/" + mf.name)
+		if err != nil {
+			return nil, fmt.Errorf("reading migration %s: %w", mf.name, err)
+		}
+		sqlText := string(data)
+		for _, table := range dirtyNames {
+			if migrationSQLTouchesTable(sqlText, table) {
+				touched[table] = struct{}{}
+			}
+		}
+	}
+
+	names := make([]string, 0, len(touched))
+	for table := range touched {
+		names = append(names, table)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func migrationSQLTouchesTable(sqlText, table string) bool {
+	tableRef := "`?" + regexp.QuoteMeta(table) + "`?"
+	// This intentionally scans raw migration text so PREPARE strings that run
+	// DDL/DML are treated as real table touches.
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\b(?:alter\s+table|update|delete\s+from|insert(?:\s+ignore)?\s+into|replace\s+into|truncate\s+table|drop\s+table|create\s+table(?:\s+if\s+not\s+exists)?|rename\s+table)\s+` + tableRef + `\b`),
+		regexp.MustCompile(`(?i)\brename\s+table\b[^;]*\bto\s+` + tableRef + `\b`),
+		regexp.MustCompile(`(?i)\bcreate\s+(?:unique\s+)?index\b[^;]*\bon\s+` + tableRef + `\b`),
+		regexp.MustCompile(`(?i)\b(?:create\s+(?:or\s+replace\s+)?view|alter\s+view)\s+` + tableRef + `\b`),
+	}
+	for _, pattern := range patterns {
+		if pattern.MatchString(sqlText) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m migrationSource) migrate(ctx context.Context, db DBConn) (int, error) {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -109,6 +109,10 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration dirty table diffs: %w", err)
 	}
+	tablesBefore, err := existingTables(ctx, db)
+	if err != nil {
+		return 0, fmt.Errorf("reading pre-migration tables: %w", err)
+	}
 
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {
@@ -140,7 +144,7 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return applied, fmt.Errorf("pre-existing dirty tables changed during schema migration: %s", strings.Join(changedDirtyTables, ", "))
 	}
 
-	staged, err := stageNewDirtyTables(ctx, db, dirtyBefore)
+	staged, err := stageNewSchemaTables(ctx, db, dirtyBefore, tablesBefore)
 	if err != nil {
 		return applied, fmt.Errorf("staging migrations: %w", err)
 	}
@@ -157,34 +161,12 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 }
 
 func committableDirtyTables(ctx context.Context, db DBConn) (map[string]dirtyTableState, error) {
-	rows, err := db.QueryContext(ctx, `
-		SELECT s.table_name, s.staged
-		FROM dolt_status s
-		WHERE NOT EXISTS (
-			SELECT 1 FROM dolt_ignore di
-			WHERE di.ignored = 1
-			AND s.table_name LIKE di.pattern
-		)
-	`)
+	tables, err := dirtyTables(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	tables := make(map[string]dirtyTableState)
-	for rows.Next() {
-		var table string
-		var staged bool
-		if err := rows.Scan(&table, &staged); err != nil {
-			return nil, err
-		}
-		state := tables[table]
-		state.staged = state.staged || staged
-		tables[table] = state
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
+	delete(tables, mainSource.cursorTable)
+	delete(tables, ignoredSource.cursorTable)
 	return tables, nil
 }
 
@@ -320,27 +302,104 @@ func writeSignatureValue(b *strings.Builder, v any) {
 	}
 }
 
-func stageNewDirtyTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState) (bool, error) {
-	dirtyAfter, err := committableDirtyTables(ctx, db)
+func stageNewSchemaTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState, tablesBefore map[string]struct{}) (bool, error) {
+	dirtyAfter, err := dirtyTables(ctx, db, false)
 	if err != nil {
 		return false, err
 	}
 
-	var tables []string
+	tableSet := make(map[string]struct{})
 	for table := range dirtyAfter {
 		if _, wasDirty := dirtyBefore[table]; wasDirty {
 			continue
 		}
+		tableSet[table] = struct{}{}
+	}
+	tablesAfter, err := existingTables(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	for table := range tablesAfter {
+		if _, existed := tablesBefore[table]; !existed {
+			tableSet[table] = struct{}{}
+		}
+	}
+
+	tables := make([]string, 0, len(tableSet))
+	for table := range tableSet {
 		tables = append(tables, table)
 	}
 	sort.Strings(tables)
 
 	for _, table := range tables {
-		if _, err := db.ExecContext(ctx, "CALL DOLT_ADD(?)", table); err != nil {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_ADD('-f', ?)", table); err != nil {
 			return false, fmt.Errorf("dolt add %s: %w", table, err)
 		}
 	}
 	return len(tables) > 0, nil
+}
+
+func existingTables(ctx context.Context, db DBConn) (map[string]struct{}, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT TABLE_NAME
+		FROM INFORMATION_SCHEMA.TABLES
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_TYPE = 'BASE TABLE'
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tables := make(map[string]struct{})
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			return nil, err
+		}
+		tables[table] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return tables, nil
+}
+
+func dirtyTables(ctx context.Context, db DBConn, excludeIgnored bool) (map[string]dirtyTableState, error) {
+	query := `
+		SELECT s.table_name, s.staged
+		FROM dolt_status s
+	`
+	if excludeIgnored {
+		query += `
+		WHERE NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			AND s.table_name LIKE di.pattern
+		)
+		`
+	}
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tables := make(map[string]dirtyTableState)
+	for rows.Next() {
+		var table string
+		var staged bool
+		if err := rows.Scan(&table, &staged); err != nil {
+			return nil, err
+		}
+		state := tables[table]
+		state.staged = state.staged || staged
+		tables[table] = state
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return tables, nil
 }
 
 type migrationFile struct {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -92,6 +92,11 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return 0, nil
 	}
 
+	dirtyBefore, err := committableDirtyTables(ctx, db)
+	if err != nil {
+		return 0, fmt.Errorf("reading pre-migration status: %w", err)
+	}
+
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {
 		return applied, err
@@ -115,8 +120,12 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 		return applied, nil
 	}
 
-	if _, err := db.ExecContext(ctx, "CALL DOLT_ADD('-A')"); err != nil {
+	staged, err := stageNewDirtyTables(ctx, db, dirtyBefore)
+	if err != nil {
 		return applied, fmt.Errorf("staging migrations: %w", err)
+	}
+	if !staged {
+		return applied, nil
 	}
 	if _, err := db.ExecContext(ctx, "CALL DOLT_COMMIT('-m', 'schema: apply migrations')"); err != nil {
 		if !strings.Contains(strings.ToLower(err.Error()), "nothing to commit") {
@@ -125,6 +134,58 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	}
 
 	return applied, nil
+}
+
+func committableDirtyTables(ctx context.Context, db DBConn) (map[string]struct{}, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT s.table_name
+		FROM dolt_status s
+		WHERE NOT EXISTS (
+			SELECT 1 FROM dolt_ignore di
+			WHERE di.ignored = 1
+			AND s.table_name LIKE di.pattern
+		)
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tables := make(map[string]struct{})
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			return nil, err
+		}
+		tables[table] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return tables, nil
+}
+
+func stageNewDirtyTables(ctx context.Context, db DBConn, dirtyBefore map[string]struct{}) (bool, error) {
+	dirtyAfter, err := committableDirtyTables(ctx, db)
+	if err != nil {
+		return false, err
+	}
+
+	var tables []string
+	for table := range dirtyAfter {
+		if _, wasDirty := dirtyBefore[table]; wasDirty {
+			continue
+		}
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+
+	for _, table := range tables {
+		if _, err := db.ExecContext(ctx, "CALL DOLT_ADD(?)", table); err != nil {
+			return false, fmt.Errorf("dolt add %s: %w", table, err)
+		}
+	}
+	return len(tables) > 0, nil
 }
 
 type migrationFile struct {

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -1,0 +1,209 @@
+package schema
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestPendingMigrationDirtyTablesDetectsMigration0043Dependencies(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT COALESCE\(MAX\(version\), 0\) FROM schema_migrations`).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(42))
+
+	touched, err := mainSource.pendingMigrationDirtyTables(context.Background(), db, map[string]dirtyTableState{
+		"dependencies": {},
+	})
+	if err != nil {
+		t.Fatalf("pendingMigrationDirtyTables: %v", err)
+	}
+	if len(touched) != 1 || touched[0] != "dependencies" {
+		t.Fatalf("touched = %v, want [dependencies]", touched)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestIgnoredPendingMigrationDirtyTablesDetectsWispDependencies(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT COALESCE\(MAX\(version\), 0\) FROM ignored_schema_migrations`).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(2))
+
+	touched, err := ignoredSource.pendingMigrationDirtyTables(context.Background(), db, map[string]dirtyTableState{
+		"wisp_dependencies": {},
+	})
+	if err != nil {
+		t.Fatalf("pendingMigrationDirtyTables: %v", err)
+	}
+	if len(touched) != 1 || touched[0] != "wisp_dependencies" {
+		t.Fatalf("touched = %v, want [wisp_dependencies]", touched)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestMigrationSQLTouchesTableStatementForms(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{
+			name: "rename table source",
+			sql:  "RENAME TABLE dependencies TO old_dependencies",
+			want: true,
+		},
+		{
+			name: "rename table target",
+			sql:  "RENAME TABLE old_dependencies TO dependencies",
+			want: true,
+		},
+		{
+			name: "create index on table",
+			sql:  "CREATE INDEX idx_dep_type ON dependencies (type)",
+			want: true,
+		},
+		{
+			name: "create unique index on quoted table",
+			sql:  "CREATE UNIQUE INDEX idx_dep_type ON `dependencies` (type)",
+			want: true,
+		},
+		{
+			name: "create view named table",
+			sql:  "CREATE OR REPLACE VIEW dependencies AS SELECT 1",
+			want: true,
+		},
+		{
+			name: "select only",
+			sql:  "SELECT * FROM dependencies",
+			want: false,
+		},
+		{
+			name: "unrelated ddl",
+			sql:  "ALTER TABLE comments ADD COLUMN reviewed_at DATETIME",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := migrationSQLTouchesTable(tt.sql, "dependencies"); got != tt.want {
+				t.Fatalf("migrationSQLTouchesTable(%q) = %v, want %v", tt.sql, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDirtyTableSignatureRejectsUnsafeTableName(t *testing.T) {
+	_, err := dirtyTableSignature(context.Background(), nil, "issues'); SELECT 1; --")
+	if err == nil {
+		t.Fatal("expected unsafe table name error")
+	}
+	if !strings.Contains(err.Error(), "unsafe dolt status table name") {
+		t.Fatalf("error = %v, want unsafe table name context", err)
+	}
+}
+
+func TestMigration0035HandlesLegacyWispDependenciesShape(t *testing.T) {
+	upSQL, err := os.ReadFile("migrations/0035_migrate_infra_to_wisps.up.sql")
+	if err != nil {
+		t.Fatalf("read 0035 up migration: %v", err)
+	}
+	downSQL, err := os.ReadFile("migrations/0035_migrate_infra_to_wisps.down.sql")
+	if err != nil {
+		t.Fatalf("read 0035 down migration: %v", err)
+	}
+
+	up := string(upSQL)
+	for _, want := range []string{
+		"@has_split_wisp_dependencies",
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id)",
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)",
+	} {
+		if !strings.Contains(up, want) {
+			t.Fatalf("0035 up migration missing legacy/split branch marker %q", want)
+		}
+	}
+
+	down := string(downSQL)
+	for _, want := range []string{
+		"@has_split_wisp_dependencies",
+		"SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id FROM wisp_dependencies",
+		"SELECT issue_id, COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external), type, created_at, created_by, metadata, thread_id FROM wisp_dependencies",
+	} {
+		if !strings.Contains(down, want) {
+			t.Fatalf("0035 down migration missing legacy/split branch marker %q", want)
+		}
+	}
+}
+
+func TestStageSchemaTablesSkipsIgnoredTables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`(?s)SELECT s\.table_name, s\.staged\s+FROM dolt_status s\s+WHERE NOT EXISTS`).
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}).
+			AddRow("schema_migrations", false))
+	mock.ExpectQuery(`(?s)SELECT t\.TABLE_NAME\s+FROM INFORMATION_SCHEMA\.TABLES t\s+WHERE .*NOT EXISTS`).
+		WillReturnRows(sqlmock.NewRows([]string{"TABLE_NAME"}).
+			AddRow("schema_migrations"))
+	mock.ExpectExec(`CALL DOLT_ADD\('-f', \?\)`).
+		WithArgs("schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	staged, err := stageSchemaTables(context.Background(), db, map[string]dirtyTableState{})
+	if err != nil {
+		t.Fatalf("stageSchemaTables: %v", err)
+	}
+	if !staged {
+		t.Fatal("stageSchemaTables staged = false, want true")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUnstageIgnoredTablesResetsExistingIgnoredTables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`(?s)SELECT s\.table_name, s\.staged\s+FROM dolt_status s\s+WHERE EXISTS`).
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "staged"}).
+			AddRow("ignored_schema_migrations", true).
+			AddRow("wisp_dependencies", true).
+			AddRow("wisps", false))
+	mock.ExpectExec(`CALL DOLT_RESET\(\?\)`).
+		WithArgs("ignored_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`CALL DOLT_RESET\(\?\)`).
+		WithArgs("wisp_dependencies").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := unstageIgnoredTables(context.Background(), db); err != nil {
+		t.Fatalf("unstageIgnoredTables: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1331,8 +1331,9 @@ type WorkFilter struct {
 	IncludeDeferred bool // If true, include issues with future defer_until timestamps
 
 	// Ephemeral issue filtering
-	// By default, GetReadyWork excludes ephemeral issues (wisps).
-	// Set to true to include them (e.g., for merge-request processing).
+	// By default, GetReadyWork excludes ephemeral wisps but includes
+	// no-history wisps because they are durable work items without Dolt history.
+	// Set to true to include ephemeral wisps too (e.g., for merge-request processing).
 	IncludeEphemeral bool
 
 	// Type exclusion: exclude issues with these types from results.


### PR DESCRIPTION
## Summary
- preserve dependency reads and dependents across promotion/demotion between `issues` and `wisps`
- make `GetReadyWork` include no-history beads stored in `wisps` by default while still excluding true ephemeral wisps
- commit promoted auxiliary rows (`labels`, `dependencies`, `events`, `comments`) with the promoted issue
- stage newly-created ignored schema tables during migrations without sweeping pre-existing dirty user data

## Tests
- `go test ./internal/storage/issueops ./internal/storage/dolt -run 'Wisp|Demote|Promote|Dependency|Delete|GetIssue|Mixed|SchemaParityIssuesVsWisps|UpdateIssueIDUpdatesWispTables|GetCommentsForIssues_MixedWispAndPermanent|SchemaRunsInitWhenStale|GetReadyWorkIncludesNoHistoryWispsByDefault|GetReadyWorkExcludesBlockedNoHistoryWisp' -count=1`
- `go test ./cmd/bd -run 'Ready|NoHistory|Promote|Delete' -count=1`
- `go test ./internal/storage/issueops -count=1`
- `git diff --check`
