### PR TITLE
test: keep update JSON stderr separate

### DIFF
--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -743,11 +743,14 @@ func TestEmbeddedUpdate(t *testing.T) {
 		cmd := exec.Command(bd, "update", issue.ID, "--status", "in_progress", "--json")
 		cmd.Dir = dir
 		cmd.Env = bdEnv(dir)
-		out, err := cmd.CombinedOutput()
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err := cmd.Run()
 		if err != nil {
-			t.Fatalf("bd update --json failed: %v\n%s", err, out)
+			t.Fatalf("bd update --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 		}
-		s := string(out)
+		s := stdout.String()
 		start := strings.Index(s, "[")
 		if start < 0 {
 			start = strings.Index(s, "{")


### PR DESCRIPTION
## Summary

- Capture stdout and stderr separately in the embedded update JSON-output test.
- Validate only stdout as JSON so post-run stderr advisories do not contaminate the parsed output.

## Test Plan

- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags=gms_pure_go ./cmd/bd -run '^TestEmbeddedUpdate$/^update_json_output$' -count=1 -timeout=10m -v`
- `git diff --check`

_codex-gpt-5- on behalf of maphew_