### PR TITLE
import: skip beads-jsonl metadata/header line on JSONL import

### DIFF
--- a/cmd/bd/import_from_jsonl_test.go
+++ b/cmd/bd/import_from_jsonl_test.go
@@ -87,6 +87,38 @@ func TestImportFromLocalJSONL(t *testing.T) {
 		}
 	})
 
+	t.Run("skips beads-jsonl metadata header line", func(t *testing.T) {
+		// Canonical beads-jsonl exports prepend a schema/provenance
+		// header record (no _type, no issue fields). Without the
+		// header-skip guard it falls through to the issue path and
+		// aborts the whole import with
+		// "validation failed for issue : title is required",
+		// stranding every command on an empty auto-imported DB.
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "dolt")
+		store := newTestStore(t, dbPath)
+
+		jsonlContent := `{"_dolt_branch":"main","_dolt_commit":"abc123","_project_id":"p1","_schema":"beads-jsonl/1","_sort":"stable-v1"}
+{"id":"test-hdr1","title":"After header","type":"bug","status":"open","priority":2,"created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T00:00:00Z"}
+`
+		jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(jsonlContent), 0644); err != nil {
+			t.Fatalf("Failed to write JSONL file: %v", err)
+		}
+
+		ctx := context.Background()
+		count, err := importFromLocalJSONL(ctx, store, jsonlPath)
+		if err != nil {
+			t.Fatalf("importFromLocalJSONL failed on header line: %v", err)
+		}
+		if count != 1 {
+			t.Errorf("Expected 1 issue imported (header skipped), got %d", count)
+		}
+		if _, err := store.GetIssue(ctx, "test-hdr1"); err != nil {
+			t.Fatalf("issue after header was not imported: %v", err)
+		}
+	})
+
 	t.Run("invalid JSON returns error", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		dbPath := filepath.Join(tmpDir, "dolt")

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -113,6 +113,20 @@ func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, lo
 			return nil, fmt.Errorf("failed to parse JSONL line: %w", err)
 		}
 
+		// Skip the optional beads-jsonl metadata/header record.
+		// Canonical exports produced by the stable-ordering /
+		// git-merge convention prepend a schema+provenance line, e.g.
+		// {"_schema":"beads-jsonl/1","_dolt_branch":"main",
+		// "_dolt_commit":"...","_sort":"stable-v1"}. It carries no
+		// _type and no issue fields; without this guard it falls
+		// through to the issue path, unmarshals into an empty Issue,
+		// and aborts the whole import with "validation failed for
+		// issue : title is required". Identified by the _schema
+		// sentinel, which real issue/memory records never carry.
+		if _, isHeader := peek["_schema"]; isHeader {
+			continue
+		}
+
 		// Check if this is a memory record
 		if rawType, ok := peek["_type"]; ok {
 			var typeStr string


### PR DESCRIPTION
## Problem

`importFromLocalJSONLFull` (`cmd/bd/import_shared.go`) special-cases
only `_type=="memory"`; every other line is force-parsed as an issue.

If a `.beads/issues.jsonl` carries a leading **metadata/header
record** — e.g. a schema/provenance line some export & git-merge
conventions prepend:

```
{"_schema":"beads-jsonl/1","_dolt_branch":"main","_dolt_commit":"<hash>","_sort":"stable-v1"}
```

…it has no `_type` and no issue fields, so it falls through to the
issue path, `json.Unmarshal`s into an empty `types.Issue`, and the
whole import aborts at validation:

```
validation failed for issue : title is required
```

This is especially severe because `maybeAutoImportJSONL`
(`cmd/bd/auto_import_upgrade.go`, GH#2994 upgrade-recovery) runs the
importer on **every command** when the embedded DB is empty — a single
header line then strands *every* `bd` invocation on an empty
auto-imported database, with only the warning:

```
auto-importing N bytes from .beads/issues.jsonl into empty database...
warning: auto-import from .beads/issues.jsonl failed: validation failed for issue : title is required
```

## Fix

Skip records carrying the `_schema` sentinel before the memory/issue
branch. Real issue and memory records never carry `_schema`, so the
guard is precise and side-effect-free; it simply makes the importer
tolerant of an optional leading metadata/header record instead of
hard-aborting the entire import on it.

```go
if _, isHeader := peek["_schema"]; isHeader {
    continue
}
```

## Test

Adds a regression subtest to `TestImportFromLocalJSONL`
(`cmd/bd/import_from_jsonl_test.go`): a JSONL whose first line is the
metadata/header record followed by a normal issue — asserts the header
is skipped and the issue imports (count == 1, issue retrievable).

`go build ./cmd/bd/` clean; full `TestImportFromLocalJSONL` green.

## Notes

- Behavior-preserving for files with no header line (no `_schema` →
  guard never fires).
- Tombstone / `wisp`→`ephemeral` / memory handling unchanged.
- Rationale for skipping rather than erroring: an unknown leading
  metadata record is a forward-compatible export convention, not
  corrupt data; aborting the whole import (and, via auto-import,
  every command) is a disproportionate failure mode.
