### PR TITLE
auto-import: gate JSONL upgrade-recovery to embedded server mode

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1009,7 +1009,17 @@ var rootCmd = &cobra.Command{
 		// Skip auto-import when the user is explicitly running "bd import" —
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
-		if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" {
+		//
+		// Gate to ServerModeEmbedded only. In Owned/External (shared)
+		// server mode there is no per-clone embedded DB to recover into:
+		// the empty-DB probe runs before the session selects the
+		// configured database, always reports "empty", and fires a
+		// spurious auto-import against the wrong/empty view on every
+		// command. The data is safe on the shared server; the import
+		// just fails noisily. Auto-import is only meaningful for the
+		// legacy in-process embedded path it was written for.
+		if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" &&
+			doltserver.ResolveServerMode(beadsDir) == doltserver.ServerModeEmbedded {
 			maybeAutoImportJSONL(rootCtx, store, beadsDir)
 		}
 


### PR DESCRIPTION
## Problem

`maybeAutoImportJSONL` (`cmd/bd/auto_import_upgrade.go`, GH#2994) is
the **embedded-DB upgrade-recovery** path: it exists so users
upgrading from pre-0.56 (`.beads/dolt/`) to 1.0+
(`.beads/embeddeddolt/`) don't appear to lose data when the new
embedded DB starts empty but the git-tracked `issues.jsonl` still has
everything.

But `cmd/bd/main.go` calls it in **every** server mode:

```go
if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" {
    maybeAutoImportJSONL(rootCtx, store, beadsDir)
}
```

In `ServerModeOwned` / `ServerModeExternal` (shared-server) there is
no per-clone embedded DB to recover into. The function's
`GetStatistics` "is the DB empty?" probe runs before the session has
selected the configured database and races shared-server
reachability, so it **intermittently reports empty** even though the
shared server is fully populated. It then fires a spurious
auto-import against the wrong/empty view — on **every command**
whenever the server is transiently slow/unreachable. Observed
fleet-wide as a recurring:

```
auto-importing N bytes from .beads/issues.jsonl into empty database...
warning: auto-import from .beads/issues.jsonl failed: ...
```

The real data is safe on the shared server; normal command execution
(which does select the configured DB) works correctly. The
auto-import is pure noise + wasted work in server mode, and turns any
non-issue JSONL record into a scary hard failure.

## Fix

Gate the call to `ServerModeEmbedded` only:

```go
if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" &&
    doltserver.ResolveServerMode(beadsDir) == doltserver.ServerModeEmbedded {
    maybeAutoImportJSONL(rootCtx, store, beadsDir)
}
```

`ResolveServerMode` is already the single source of truth (env /
`metadata.json`) and is test-covered
(`TestResolveServerMode_*`). The auto-import only runs in the legacy
in-process embedded path it was written for; Owned/External never
trigger it.

## Why this is correct

- `ServerModeEmbedded` is *defined* as "the legacy in-process
  embedded dolt path" (`internal/doltserver/servermode.go`) — exactly
  the upgrade scenario `maybeAutoImportJSONL` targets.
- Owned/External manage a real server; an empty-DB probe there is a
  connection/selection-timing artifact, not a genuine "needs
  recovery from JSONL" signal. Auto-importing on that false signal is
  never desired.
- Behavior-preserving for genuine embedded users (mode == Embedded →
  unchanged).

## Verification

- `go build ./cmd/bd/` clean; `go vet ./cmd/bd/` clean.
- `go test ./internal/doltserver/ -run 'TestResolveServerMode|TestIsSharedServerMode'` green (resolver behavior the gate relies on).
- `go test ./cmd/bd/ -run TestImportFromLocalJSONL` green (no import regression).
