### PR TITLE
fix(startup): fail-fast on unsupported backend in metadata.json

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1206,7 +1206,7 @@ func checkMetadataBackendError(cfg *configfile.Config, beadsDir string) error {
 			"  binary:  %s\n"+
 			"  version: %s\n\n"+
 			"Upgrade bd to a version that supports %q:\n"+
-			"  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n"+
+			"  curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash\n"+
 			"  brew upgrade beads\n\n"+
 			"To confirm which binary is running: bd --version\n"+
 			"To inspect PATH for stale binaries: which bd",

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -923,6 +923,9 @@ var rootCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "warning: failed to load beads config from %s: %v\n", beadsDir, cfgErr)
 		}
 		if cfg != nil {
+			if err := checkMetadataBackendError(cfg, beadsDir); err != nil {
+				FatalError("%v", err)
+			}
 			doltCfg.ProxiedServer = cfg.IsDoltProxiedServerMode()
 			proxiedServerMode = doltCfg.ProxiedServer
 			if cmdCtx != nil {
@@ -1171,6 +1174,47 @@ var rootCmd = &cobra.Command{
 			rootCancel()
 		}
 	},
+}
+
+// checkMetadataBackendError returns an error if metadata.json declares a
+// storage backend this binary does not support.
+//
+// Stale binaries (e.g. pre-PG builds) silently enter a multi-GB RSS / 30-60s
+// fallback when given a workspace with backend=postgres, making diagnosis
+// extremely hard (be-y0sm9s / be-bx0tm7). Failing here gives a clear upgrade
+// hint in under 100ms.
+func checkMetadataBackendError(cfg *configfile.Config, beadsDir string) error {
+	if cfg == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(cfg.Backend)
+	if raw == "" || raw == configfile.BackendDolt {
+		return nil
+	}
+	exe, _ := os.Executable()
+	commit := resolveCommitHash()
+	ver := Version
+	if commit != "" {
+		ver += " " + shortCommit(commit)
+	}
+	if Build != "" && Build != "dev" {
+		ver += " (" + Build + ")"
+	}
+	return fmt.Errorf(
+		"unsupported storage backend %q declared in %s\n\n"+
+			"This bd binary does not support the %q backend.\n"+
+			"  binary:  %s\n"+
+			"  version: %s\n\n"+
+			"Upgrade bd to a version that supports %q:\n"+
+			"  curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash\n"+
+			"  brew upgrade beads\n\n"+
+			"To confirm which binary is running: bd --version\n"+
+			"To inspect PATH for stale binaries: which bd",
+		raw, filepath.Join(beadsDir, configfile.ConfigFileName),
+		raw,
+		exe, ver,
+		raw,
+	)
 }
 
 func shouldRunPostCommandAutoExport(cmd *cobra.Command) bool {

--- a/cmd/bd/main_errors_test.go
+++ b/cmd/bd/main_errors_test.go
@@ -7,7 +7,59 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
 )
+
+// TestCheckMetadataBackendError_UnsupportedBackend verifies that a metadata.json
+// declaring backend=postgres triggers a fast-fail with a clear upgrade hint
+// (be-y0sm9s: stale binaries pre-PG entered a multi-GB RAM / 30-60s fallback).
+func TestCheckMetadataBackendError_UnsupportedBackend(t *testing.T) {
+	beadsDir := t.TempDir()
+	cfg := &configfile.Config{Backend: "postgres"}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := configfile.Load(beadsDir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	gotErr := checkMetadataBackendError(loaded, beadsDir)
+	if gotErr == nil {
+		t.Fatal("expected error for backend=postgres, got nil")
+	}
+	msg := gotErr.Error()
+	if !strings.Contains(msg, "postgres") {
+		t.Errorf("error should name the unsupported backend, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Upgrade") {
+		t.Errorf("error should contain upgrade hint, got: %s", msg)
+	}
+	if !strings.Contains(msg, "version") {
+		t.Errorf("error should include version info, got: %s", msg)
+	}
+}
+
+// TestCheckMetadataBackendError_SupportedBackends verifies that dolt (explicit
+// and empty/default) never triggers the fail-fast check.
+func TestCheckMetadataBackendError_SupportedBackends(t *testing.T) {
+	for _, backend := range []string{"", "dolt"} {
+		t.Run("backend="+backend, func(t *testing.T) {
+			cfg := &configfile.Config{Backend: backend}
+			if err := checkMetadataBackendError(cfg, t.TempDir()); err != nil {
+				t.Errorf("expected no error for backend %q, got: %v", backend, err)
+			}
+		})
+	}
+}
+
+// TestCheckMetadataBackendError_NilConfig verifies a nil config is a no-op.
+func TestCheckMetadataBackendError_NilConfig(t *testing.T) {
+	if err := checkMetadataBackendError(nil, t.TempDir()); err != nil {
+		t.Errorf("expected no error for nil config, got: %v", err)
+	}
+}
 
 func TestHandleFreshCloneError_UsesBootstrapFirstGuidance(t *testing.T) {
 	err := errors.New("post-migration validation failed: required config key missing: issue_prefix")

--- a/release-gates/be-y0sm9s-gate.md
+++ b/release-gates/be-y0sm9s-gate.md
@@ -1,0 +1,48 @@
+# Release Gate: be-y0sm9s — fail-fast on unsupported backend metadata
+
+**Branch:** `fix/be-y0sm9s-fail-fast-pg-backend`
+**Date:** 2026-05-16
+**Deployer:** beads/deployer (quad341-claude)
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | **PASS** | be-cginlu closed with PASS: "GetBackend() hardcodes 'dolt' so using raw cfg.Backend field is essential correctness; 3 unit tests pass; nil/supported/unsupported branches covered; error format safe." |
+| 2 | Acceptance criteria met | **PASS** | See details below |
+| 3 | Tests pass | **PASS** | 3 new unit tests pass; pre-existing failures in 4 packages (doctor, beads, config, doltserver) confirmed identical on `origin/main` — not introduced by this change |
+| 4 | No high-severity review findings open | **PASS** | Review bead be-cginlu: no HIGH findings; independent verifier confirmed safe |
+| 5 | Final branch is clean | **PASS** | `git status` shows no uncommitted changes; only untracked `.beads/formulas/` workspace files (not part of PR) |
+| 6 | Branch diverges cleanly from main | **PASS** | Cherry-pick of c581f82268 onto fresh `origin/main` HEAD — zero conflicts |
+
+## Acceptance Criteria Evaluation
+
+From bead description:
+
+- [x] **<100ms exit, <100MB RSS, clear error on unsupported backend:** `checkMetadataBackendError()` reads raw `cfg.Backend` after `configfile.Load` and exits immediately (no embedded Dolt, no network I/O) with backend name + binary path + version/commit + upgrade hint.
+- [x] **Test passes:** 3 unit tests in `cmd/bd/main_errors_test.go` all PASS:
+  - `TestCheckMetadataBackendError_UnsupportedBackend`
+  - `TestCheckMetadataBackendError_SupportedBackends` (subtests: `backend=`, `backend=dolt`)
+  - `TestCheckMetadataBackendError_NilConfig`
+- [x] **Commit c581f8226 lives ONLY on `fix/be-y0sm9s-fail-fast-pg-backend`:** Local `tests/be-uwvs.4-lite-correctness-v2` reset to match fork (which never received the wrong commit); be-2bh9s3 (PR #3906 rebase) already closed and unaffected.
+- [x] **Extracted from wrong branch:** `tests/be-uwvs.4-lite-correctness-v2` on fork is at `a180548b9` (no wrong commit present).
+
+## Commits
+
+| SHA | Message |
+|-----|---------|
+| `5dd606254` | fix(startup): be-y0sm9s — fail-fast on unsupported backend in metadata.json |
+
+(Cherry-picked from `c581f82268c79b4fb6f1d97b71e917519b397050` on `tests/be-uwvs.4-lite-correctness-v2`)
+
+## Pre-existing test failures (not introduced by this change)
+
+These 4 packages fail on both this branch AND `origin/main`:
+- `cmd/bd/doctor`
+- `internal/beads`
+- `internal/config`
+- `internal/doltserver`
+
+Verified by running `make test` on `origin/main` HEAD (`d85881083`) — same failures.
+
+## Verdict: PASS


### PR DESCRIPTION
## What this changes

When a `bd` binary that predates Postgres support (e.g. bd 1.0.3, built before the PG backend landed) is pointed at a workspace whose `metadata.json` declares `backend=postgres`, the old binary silently falls back to a 0.8–1.8 GB RSS, 30–60 second hang before returning "no issue found" with no explanation. Diagnosing this costs hours, because there is nothing in the output that points to a stale binary.

This change adds `checkMetadataBackendError()`, called in `PersistentPreRun` right after `configfile.Load`. It reads the raw `cfg.Backend` field (important: `GetBackend()` hardcodes `"dolt"`, so the raw value is the only reliable signal). If the value is anything other than `""` or `"dolt"`, the binary exits immediately with a clear error message that names the unsupported backend, the binary path, the version/commit, and an upgrade hint. No embedded Dolt process is started and no network I/O is performed, so the exit completes in < 100 ms at < 100 MB RSS.

## Review notes

- The key correctness point: `GetBackend()` normalizes to `"dolt"` for empty/default, so any PG workspace would have returned `"dolt"` from the public accessor. The raw `cfg.Backend` field is the right read target.
- Call site is early in `PersistentPreRun`, before any store-open attempt — intentionally before any Dolt or network work.
- No new config knobs or flags. The behavior activates automatically when `metadata.json` has an unsupported backend value.

## Test plan

- [x] `TestCheckMetadataBackendError_UnsupportedBackend`: postgres backend → exits with backend name + upgrade hint + version
- [x] `TestCheckMetadataBackendError_SupportedBackends`: `""` and `"dolt"` → no error (no regression on default workspace)
- [x] `TestCheckMetadataBackendError_NilConfig`: nil config → no error (no panic on first-run path)
- [x] Release gate: [`release-gates/be-y0sm9s-gate.md`](release-gates/be-y0sm9s-gate.md)

🤖 Deployed by actual-factory