### PR TITLE
test(embedded): split stdout/stderr in getIssueStatus (be-yemge6)

### DIFF
--- a/release-gates/be-yemge6-gate.md
+++ b/release-gates/be-yemge6-gate.md
@@ -1,0 +1,37 @@
+# Release gate: be-yemge6 — split stdout/stderr in getIssueStatus
+
+**Verdict: PASS.**
+
+Branch: `fix/be-yemge6-defer-status-stdout-split`
+Base on origin: `origin/main` @ `d85881083` (commit before the fix)
+HEAD: `afaf390dd`
+Source bead: `be-yemge6`; review bead: `be-8fypm3` (PASS).
+
+## Commit
+
+| # | SHA | Subject |
+|---|-----|---------|
+| 1 | `afaf390dd` | test(embedded): split stdout/stderr in getIssueStatus to fix TestEmbeddedUndeferConcurrent flake (be-yemge6) |
+
+1 file changed: `cmd/bd/defer_embedded_test.go` (+7 / -4 lines). No production code changes.
+
+## Criteria
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | Review PASS present | **PASS** | be-8fypm3 notes: "VERDICT: PASS. No findings. Clean test fix." Gemini second-pass disabled per current policy. |
+| 2 | Acceptance criteria met | **PASS** | `getIssueStatus` now uses separate `bytes.Buffer` for stdout/stderr via `cmd.Stdout` / `cmd.Stderr` instead of `cmd.CombinedOutput()`. JSON parsed from `stdout.String()` only. Error messages improved to show both streams. Matches fix spec exactly. |
+| 3 | Tests pass | **PASS** | `go build -tags gms_pure_go ./...` clean. `go vet -tags gms_pure_go ./cmd/bd/...` clean. `go test -tags gms_pure_go -count=1 -short ./cmd/bd/...`: `cmd/bd` PASS (0.269s). `cmd/bd/doctor` 2 pre-existing failures (`TestCheckBeadsRole_NotConfigured`, `TestCheckBeadsRole_NotGitRepo`) byte-equal with `origin/main` — rig worktree has `beads.role=maintainer` configured globally. No new regressions. |
+| 4 | No high-severity review findings open | **PASS** | 0 findings of any severity in be-8fypm3. |
+| 5 | Final branch is clean | **PASS** | `git status` clean (untracked `.gc/`, `.gitkeep` are rig scaffolding). |
+| 6 | Branch diverges cleanly from main | **PASS** | 1 commit ahead of `origin/main`. `git merge-tree` shows zero conflicts. |
+
+## Test environment
+
+- Host: Linux 6.19.14-300.fc44.x86_64
+- `TMPDIR`/`GOTMPDIR` pinned to `~/.gotmp` (per /tmp per-user quota constraint).
+- `go test -tags gms_pure_go -count=1 -short ./cmd/bd/...` on this branch and `origin/main` produce byte-equal failure sets.
+
+## Push target
+
+`PUSH_REMOTE=fork` (origin returns 403 for quad341). Cross-repo PR head: `quad341:fix/be-yemge6-defer-status-stdout-split`.


### PR DESCRIPTION
## What this changes

`getIssueStatus` in `cmd/bd/defer_embedded_test.go` was using `CombinedOutput()` to run `bd show <id> --json`, then searching the combined output for the first `[` or `{` and parsing everything from there to end-of-string as JSON. When `bd` emits a diagnostic to stderr (e.g. the auto-export warning), the combined buffer becomes `[{...}]\nbeads: .beads/issues.jsonl is an export...`, causing `json.Unmarshal` to fail with "invalid character 'b' after top-level value".

The fix separates stdout and stderr using explicit `bytes.Buffer` captures. JSON is parsed from stdout only. The error message on failure now shows both streams independently for easier debugging.

Observed in CI run 25966653249, `TestEmbeddedUndeferConcurrent`, for PR #3988.

## Review notes

- Only `defer_embedded_test.go:getIssueStatus` changes — no production code touched
- 7 lines added, 4 removed; the logic is a straight substitution of `CombinedOutput()` for separate `Stdout`/`Stderr` buffers

## Test plan

- [x] `go build -tags gms_pure_go ./...` — clean
- [x] `go vet -tags gms_pure_go ./cmd/bd/...` — clean
- [x] `go test -tags gms_pure_go -count=1 -short ./cmd/bd/...` — `cmd/bd` PASS; pre-existing `cmd/bd/doctor` failures byte-equal with main
- [x] Release gate: [`release-gates/be-yemge6-gate.md`](release-gates/be-yemge6-gate.md)

🤖 Deployed by actual-factory