### PR TITLE
perf(ready): restrict blocked dependency scans to active IDs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,7 @@ buildGoModule {
   # proxyVendor avoids vendor/modules.txt consistency checks when the vendored
   # tree lags go.mod/go.sum.
   proxyVendor = true;
-  vendorHash = "sha256-go7jXdZoyHR6UjofEvLZAPu9dUn+N+Yi6ieQlT9rNCI=";
+  vendorHash = "sha256-e1eLkC2+PRn4PUn0orLvhcO9mzDlMOyxAAfVuZhL3Lg=";
 
   # Match go.mod to the selected Nix Go toolchain. buildGoModule also builds
   # vendored dependencies in the Nix sandbox, where toolchain downloads are not

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/BurntSushi/toml v1.6.0
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.0
 	github.com/anthropics/anthropic-sdk-go v1.37.0
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -58,190 +58,48 @@ func ComputeBlockedIDsInTx(ctx context.Context, tx *sql.Tx, includeWisps bool) (
 		}
 	}
 
-	// Step 2: Get blocking deps, waits-for gates, and conditional-blocks
-	type depRecord struct {
-		issueID, dependsOnID, depType string
-		metadata                      sql.NullString
-	}
-	var allDeps []depRecord
-	for _, depTable := range depTables {
-		depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-			SELECT issue_id, depends_on_id, type, metadata FROM %s
-			WHERE type IN ('blocks', 'waits-for', 'conditional-blocks')
-		`, depTable))
-		if err != nil {
-			if optionalBlockedTable(depTable) && isTableNotExistError(err) {
-				continue
-			}
-			return nil, nil, fmt.Errorf("compute blocked IDs: deps from %s: %w", depTable, err)
-		}
-		for depRows.Next() {
-			var rec depRecord
-			if err := depRows.Scan(&rec.issueID, &rec.dependsOnID, &rec.depType, &rec.metadata); err != nil {
-				_ = depRows.Close()
-				return nil, nil, fmt.Errorf("compute blocked IDs: scan dep: %w", err)
-			}
-			allDeps = append(allDeps, rec)
-		}
-		_ = depRows.Close()
-		if err := depRows.Err(); err != nil {
-			return nil, nil, fmt.Errorf("compute blocked IDs: dep rows from %s: %w", depTable, err)
-		}
+	activeIDList := make([]string, 0, len(activeIDs))
+	for id := range activeIDs {
+		activeIDList = append(activeIDList, id)
 	}
 
-	// Step 3: Filter direct blockers; collect waits-for edges
-	type waitsForDep struct {
-		issueID   string
-		spawnerID string
-		gate      string
+	var allDeps []blockingDepRecord
+	for _, depTable := range depTables {
+		for start := 0; start < len(activeIDList); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(activeIDList) {
+				end = len(activeIDList)
+			}
+			placeholders, args := buildSQLInClause(activeIDList[start:end])
+			depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+				SELECT issue_id, depends_on_id, type, metadata FROM %s
+				WHERE issue_id IN (%s)
+				  AND type IN ('blocks', 'waits-for', 'conditional-blocks')
+			`, depTable, placeholders), args...)
+			if err != nil {
+				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
+					break
+				}
+				return nil, nil, fmt.Errorf("compute blocked IDs: deps from %s: %w", depTable, err)
+			}
+			for depRows.Next() {
+				var rec blockingDepRecord
+				if err := depRows.Scan(&rec.issueID, &rec.dependsOnID, &rec.depType, &rec.metadata); err != nil {
+					_ = depRows.Close()
+					return nil, nil, fmt.Errorf("compute blocked IDs: scan dep: %w", err)
+				}
+				allDeps = append(allDeps, rec)
+			}
+			_ = depRows.Close()
+			if err := depRows.Err(); err != nil {
+				return nil, nil, fmt.Errorf("compute blocked IDs: dep rows from %s: %w", depTable, err)
+			}
+		}
 	}
-	var waitsForDeps []waitsForDep
-	needsClosedChildren := false
 
 	blockedSet := make(map[string]bool)
-	for _, rec := range allDeps {
-		switch rec.depType {
-		case string(types.DepBlocks), string(types.DepConditionalBlocks):
-			if activeIDs[rec.issueID] && activeIDs[rec.dependsOnID] {
-				blockedSet[rec.issueID] = true
-			}
-		case string(types.DepWaitsFor):
-			if !activeIDs[rec.issueID] {
-				continue
-			}
-			gate := types.ParseWaitsForGateMetadata(rec.metadata.String)
-			if gate == types.WaitsForAnyChildren {
-				needsClosedChildren = true
-			}
-			waitsForDeps = append(waitsForDeps, waitsForDep{
-				issueID:   rec.issueID,
-				spawnerID: rec.dependsOnID,
-				gate:      gate,
-			})
-		}
-	}
-
-	if len(waitsForDeps) > 0 {
-		// Step 4: Load direct children for each waits-for spawner.
-		spawnerIDs := make(map[string]struct{})
-		for _, dep := range waitsForDeps {
-			spawnerIDs[dep.spawnerID] = struct{}{}
-		}
-
-		allSpawnerIDs := make([]string, 0, len(spawnerIDs))
-		for spawnerID := range spawnerIDs {
-			allSpawnerIDs = append(allSpawnerIDs, spawnerID)
-		}
-
-		spawnerChildren := make(map[string][]string)
-		childIDs := make(map[string]struct{})
-		for _, depTbl := range depTables {
-			for start := 0; start < len(allSpawnerIDs); start += queryBatchSize {
-				end := start + queryBatchSize
-				if end > len(allSpawnerIDs) {
-					end = len(allSpawnerIDs)
-				}
-				placeholders, args := buildSQLInClause(allSpawnerIDs[start:end])
-
-				childRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-					SELECT issue_id, depends_on_id FROM %s
-					WHERE type = 'parent-child' AND depends_on_id IN (%s)
-				`, depTbl, placeholders), args...)
-				if err != nil {
-					if optionalBlockedTable(depTbl) && isTableNotExistError(err) {
-						continue
-					}
-					return nil, nil, fmt.Errorf("compute blocked IDs: children from %s: %w", depTbl, err)
-				}
-
-				for childRows.Next() {
-					var childID, parentID string
-					if err := childRows.Scan(&childID, &parentID); err != nil {
-						_ = childRows.Close()
-						return nil, nil, fmt.Errorf("compute blocked IDs: scan child: %w", err)
-					}
-					spawnerChildren[parentID] = append(spawnerChildren[parentID], childID)
-					childIDs[childID] = struct{}{}
-				}
-				_ = childRows.Close()
-				if err := childRows.Err(); err != nil {
-					return nil, nil, fmt.Errorf("compute blocked IDs: child rows from %s: %w", depTbl, err)
-				}
-			}
-		}
-
-		closedChildren := make(map[string]bool)
-		if needsClosedChildren && len(childIDs) > 0 {
-			allChildIDs := make([]string, 0, len(childIDs))
-			for childID := range childIDs {
-				allChildIDs = append(allChildIDs, childID)
-			}
-
-			for _, issueTbl := range issueTables {
-				for start := 0; start < len(allChildIDs); start += queryBatchSize {
-					end := start + queryBatchSize
-					if end > len(allChildIDs) {
-						end = len(allChildIDs)
-					}
-					placeholders, args := buildSQLInClause(allChildIDs[start:end])
-
-					closedRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-						SELECT id FROM %s
-						WHERE status = 'closed' AND id IN (%s)
-					`, issueTbl, placeholders), args...)
-					if err != nil {
-						if optionalBlockedTable(issueTbl) && isTableNotExistError(err) {
-							continue
-						}
-						return nil, nil, fmt.Errorf("compute blocked IDs: closed children from %s: %w", issueTbl, err)
-					}
-					for closedRows.Next() {
-						var childID string
-						if err := closedRows.Scan(&childID); err != nil {
-							_ = closedRows.Close()
-							return nil, nil, fmt.Errorf("compute blocked IDs: scan closed child: %w", err)
-						}
-						closedChildren[childID] = true
-					}
-					_ = closedRows.Close()
-					if err := closedRows.Err(); err != nil {
-						return nil, nil, fmt.Errorf("compute blocked IDs: closed child rows from %s: %w", issueTbl, err)
-					}
-				}
-			}
-		}
-
-		// Step 5: Evaluate waits-for gates against current child states.
-		for _, dep := range waitsForDeps {
-			children := spawnerChildren[dep.spawnerID]
-			switch dep.gate {
-			case types.WaitsForAnyChildren:
-				if len(children) == 0 {
-					continue
-				}
-				hasClosedChild := false
-				hasActiveChild := false
-				for _, childID := range children {
-					if closedChildren[childID] {
-						hasClosedChild = true
-						break
-					}
-					if activeIDs[childID] {
-						hasActiveChild = true
-					}
-				}
-				if !hasClosedChild && hasActiveChild {
-					blockedSet[dep.issueID] = true
-				}
-			default:
-				for _, childID := range children {
-					if activeIDs[childID] {
-						blockedSet[dep.issueID] = true
-						break
-					}
-				}
-			}
-		}
+	if err := markBlockedFromDepsInTx(ctx, tx, issueTables, depTables, allDeps, activeIDs, blockedSet); err != nil {
+		return nil, nil, err
 	}
 
 	result := make([]string, 0, len(blockedSet))

--- a/internal/storage/issueops/blocked.go
+++ b/internal/storage/issueops/blocked.go
@@ -21,6 +21,8 @@ func optionalBlockedTable(table string) bool {
 
 // ComputeBlockedIDsInTx returns the set of issue IDs that are blocked by active issues.
 // This is the core computation without caching — callers manage their own cache.
+// The returned active ID set is owned by the caller, but waits-for evaluation
+// may expand it with active children discovered while resolving spawner deps.
 //
 //nolint:gosec // G201: tables are hardcoded
 func ComputeBlockedIDsInTx(ctx context.Context, tx *sql.Tx, includeWisps bool) ([]string, map[string]bool, error) {
@@ -63,38 +65,12 @@ func ComputeBlockedIDsInTx(ctx context.Context, tx *sql.Tx, includeWisps bool) (
 		activeIDList = append(activeIDList, id)
 	}
 
-	var allDeps []blockingDepRecord
-	for _, depTable := range depTables {
-		for start := 0; start < len(activeIDList); start += queryBatchSize {
-			end := start + queryBatchSize
-			if end > len(activeIDList) {
-				end = len(activeIDList)
-			}
-			placeholders, args := buildSQLInClause(activeIDList[start:end])
-			depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-				SELECT issue_id, depends_on_id, type, metadata FROM %s
-				WHERE issue_id IN (%s)
-				  AND type IN ('blocks', 'waits-for', 'conditional-blocks')
-			`, depTable, placeholders), args...)
-			if err != nil {
-				if optionalBlockedTable(depTable) && isTableNotExistError(err) {
-					break
-				}
-				return nil, nil, fmt.Errorf("compute blocked IDs: deps from %s: %w", depTable, err)
-			}
-			for depRows.Next() {
-				var rec blockingDepRecord
-				if err := depRows.Scan(&rec.issueID, &rec.dependsOnID, &rec.depType, &rec.metadata); err != nil {
-					_ = depRows.Close()
-					return nil, nil, fmt.Errorf("compute blocked IDs: scan dep: %w", err)
-				}
-				allDeps = append(allDeps, rec)
-			}
-			_ = depRows.Close()
-			if err := depRows.Err(); err != nil {
-				return nil, nil, fmt.Errorf("compute blocked IDs: dep rows from %s: %w", depTable, err)
-			}
-		}
+	// This only narrows the expensive scan when inactive or closed rows dominate.
+	// Active-heavy repositories still pay one indexed lookup per queryBatchSize
+	// active IDs, so callers should not treat this as a universal speedup.
+	allDeps, err := loadBlockingDepsForIssueIDsInTx(ctx, tx, depTables, activeIDList)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	blockedSet := make(map[string]bool)
@@ -222,6 +198,10 @@ type candidateWaitsForDep struct {
 	gate      string
 }
 
+// markBlockedFromDepsInTx evaluates preloaded blocking dependency rows.
+// activeIDs must be caller-owned: waits-for handling expands it with active
+// children discovered from spawner dependencies so downstream callers can reuse
+// the same active lookup for transitively blocked children.
 func markBlockedFromDepsInTx(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -705,28 +685,13 @@ func GetBlockedIssuesInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilt
 
 	// Step 3: Get blocking deps to build BlockedBy lists
 	blockerMap := make(map[string][]string)
-	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
-		depRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-			SELECT issue_id, depends_on_id FROM %s
-			WHERE type IN ('blocks', 'waits-for', 'conditional-blocks')
-		`, depTable))
-		if err != nil {
-			return nil, fmt.Errorf("get blocking deps from %s: %w", depTable, err)
-		}
-
-		for depRows.Next() {
-			var issueID, blockerID string
-			if err := depRows.Scan(&issueID, &blockerID); err != nil {
-				_ = depRows.Close()
-				return nil, fmt.Errorf("scan dependency: %w", err)
-			}
-			if blockedSet[issueID] && activeIDs[blockerID] {
-				blockerMap[issueID] = append(blockerMap[issueID], blockerID)
-			}
-		}
-		_ = depRows.Close()
-		if err := depRows.Err(); err != nil {
-			return nil, fmt.Errorf("dependency rows from %s: %w", depTable, err)
+	blockingDeps, err := loadBlockingDepsForIssueIDsInTx(ctx, tx, []string{"dependencies", "wisp_dependencies"}, blockedIDList)
+	if err != nil {
+		return nil, fmt.Errorf("get blocking deps: %w", err)
+	}
+	for _, rec := range blockingDeps {
+		if blockedSet[rec.issueID] && activeIDs[rec.dependsOnID] {
+			blockerMap[rec.issueID] = append(blockerMap[rec.issueID], rec.dependsOnID)
 		}
 	}
 

--- a/internal/storage/issueops/blocked_test.go
+++ b/internal/storage/issueops/blocked_test.go
@@ -1,0 +1,187 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"testing"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+const (
+	activeIssuesQuery = `(?s)SELECT id FROM issues\s+WHERE status NOT IN \('closed', 'pinned'\)`
+	blockingDepsQuery = `(?s)SELECT issue_id, depends_on_id, type, metadata FROM dependencies\s+WHERE issue_id IN \(.+\)\s+AND type IN \('blocks', 'waits-for', 'conditional-blocks'\)`
+	childrenQuery     = `(?s)SELECT issue_id, depends_on_id FROM dependencies\s+WHERE type = 'parent-child' AND depends_on_id IN \(.+\)`
+	activeChildQuery  = `(?s)SELECT id FROM issues\s+WHERE id IN \(.+\)\s+AND status NOT IN \('closed', 'pinned'\)`
+	closedChildQuery  = `(?s)SELECT id FROM issues\s+WHERE status = 'closed' AND id IN \(.+\)`
+)
+
+func TestComputeBlockedIDsInTxDependencySemantics(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := newBlockedMockTx(t, ctx)
+	defer closeBlockedMockTx(t, db, mock, tx)
+
+	mock.ExpectQuery(activeIssuesQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).
+		AddRow("issue-blocked").
+		AddRow("blocker-active").
+		AddRow("issue-closed-blocker").
+		AddRow("issue-conditional").
+		AddRow("conditional-blocker").
+		AddRow("wait-default-active-child").
+		AddRow("spawner-default").
+		AddRow("child-default-active").
+		AddRow("wait-default-closed-child").
+		AddRow("spawner-default-closed").
+		AddRow("wait-any-active-only").
+		AddRow("spawner-any-active").
+		AddRow("child-any-active").
+		AddRow("wait-any-with-closed").
+		AddRow("spawner-any-closed").
+		AddRow("child-any-active2"))
+
+	mock.ExpectQuery(blockingDepsQuery).WillReturnRows(sqlmock.NewRows([]string{"issue_id", "depends_on_id", "type", "metadata"}).
+		AddRow("issue-blocked", "blocker-active", "blocks", nil).
+		AddRow("issue-closed-blocker", "blocker-closed", "blocks", nil).
+		AddRow("issue-conditional", "conditional-blocker", "conditional-blocks", nil).
+		AddRow("wait-default-active-child", "spawner-default", "waits-for", nil).
+		AddRow("wait-default-closed-child", "spawner-default-closed", "waits-for", nil).
+		AddRow("wait-any-active-only", "spawner-any-active", "waits-for", `{"gate":"any-children"}`).
+		AddRow("wait-any-with-closed", "spawner-any-closed", "waits-for", `{"gate":"any-children"}`))
+
+	mock.ExpectQuery(childrenQuery).WillReturnRows(sqlmock.NewRows([]string{"issue_id", "depends_on_id"}).
+		AddRow("child-default-active", "spawner-default").
+		AddRow("child-default-closed", "spawner-default-closed").
+		AddRow("child-any-active", "spawner-any-active").
+		AddRow("child-any-active2", "spawner-any-closed").
+		AddRow("child-any-closed", "spawner-any-closed"))
+
+	mock.ExpectQuery(activeChildQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).
+		AddRow("child-default-active").
+		AddRow("child-any-active").
+		AddRow("child-any-active2"))
+
+	mock.ExpectQuery(closedChildQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).
+		AddRow("child-default-closed").
+		AddRow("child-any-closed"))
+
+	got, activeIDs, err := ComputeBlockedIDsInTx(ctx, tx, false)
+	if err != nil {
+		t.Fatalf("ComputeBlockedIDsInTx: %v", err)
+	}
+	assertStringSet(t, got, []string{
+		"issue-blocked",
+		"issue-conditional",
+		"wait-default-active-child",
+		"wait-any-active-only",
+	})
+
+	for _, id := range []string{
+		"issue-closed-blocker",
+		"wait-default-closed-child",
+		"wait-any-with-closed",
+	} {
+		if containsString(got, id) {
+			t.Fatalf("expected %s not to be blocked; got %v", id, got)
+		}
+	}
+
+	if !activeIDs["child-default-active"] || activeIDs["child-default-closed"] {
+		t.Fatalf("active child lookup = %v, want active child only", activeIDs)
+	}
+}
+
+func TestComputeBlockedIDsInTxEmptyActiveSetSkipsDependencyLoad(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := newBlockedMockTx(t, ctx)
+	defer closeBlockedMockTx(t, db, mock, tx)
+
+	mock.ExpectQuery(activeIssuesQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	got, activeIDs, err := ComputeBlockedIDsInTx(ctx, tx, false)
+	if err != nil {
+		t.Fatalf("ComputeBlockedIDsInTx: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("blocked IDs = %v, want empty", got)
+	}
+	if len(activeIDs) != 0 {
+		t.Fatalf("active IDs = %v, want empty", activeIDs)
+	}
+}
+
+func TestComputeBlockedIDsInTxBatchesActiveDependencyScan(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := newBlockedMockTx(t, ctx)
+	defer closeBlockedMockTx(t, db, mock, tx)
+
+	activeRows := sqlmock.NewRows([]string{"id"}).
+		AddRow("issue-batch").
+		AddRow("blocker-batch")
+	for i := 0; i < queryBatchSize-1; i++ {
+		activeRows.AddRow(fmt.Sprintf("filler-%03d", i))
+	}
+	mock.ExpectQuery(activeIssuesQuery).WillReturnRows(activeRows)
+
+	mock.ExpectQuery(blockingDepsQuery).WillReturnRows(sqlmock.NewRows([]string{"issue_id", "depends_on_id", "type", "metadata"}))
+	mock.ExpectQuery(blockingDepsQuery).WillReturnRows(sqlmock.NewRows([]string{"issue_id", "depends_on_id", "type", "metadata"}).
+		AddRow("issue-batch", "blocker-batch", "blocks", nil))
+
+	got, _, err := ComputeBlockedIDsInTx(ctx, tx, false)
+	if err != nil {
+		t.Fatalf("ComputeBlockedIDsInTx: %v", err)
+	}
+	assertStringSet(t, got, []string{"issue-batch"})
+}
+
+func newBlockedMockTx(t *testing.T, ctx context.Context) (*sql.DB, sqlmock.Sqlmock, *sql.Tx) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	mock.ExpectBegin()
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	return db, mock, tx
+}
+
+func closeBlockedMockTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock, tx *sql.Tx) {
+	t.Helper()
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+	mock.ExpectClose()
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func assertStringSet(t *testing.T, got []string, want []string) {
+	t.Helper()
+
+	sort.Strings(got)
+	sort.Strings(want)
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("IDs = %v, want %v", got, want)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Limit full blocked-set dependency scans to currently active issue/wisp IDs.
- Preserve limited ready-work candidate paging behavior.
- Reduce unnecessary graph work for large rigs where closed/inactive rows dominate dependency tables.

## Validation
- go test ./internal/storage/issueops

## Notes
- Broader Dolt ready/blocked subset is currently noisy on origin/main with missing wisps/wisp_dependencies table setup and prefix-validation failures, so I did not use it as the gate for this isolated issueops change.