### PR TITLE
perf(get): query primary issues before wisp fallback

### DIFF
--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -2136,6 +2136,40 @@ func TestEphemeralExplicitID_GetIssue(t *testing.T) {
 	}
 }
 
+func TestGetIssue_WispLabelTableErrorPropagates(t *testing.T) {
+	store, cleanup := setupConcurrentTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	wisp := &types.Issue{
+		ID:        "test-wisp-label-error",
+		Title:     "Wisp with missing labels table",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "DROP TABLE wisp_labels"); err != nil {
+		t.Fatalf("drop wisp_labels: %v", err)
+	}
+
+	_, err := store.GetIssue(ctx, wisp.ID)
+	if err == nil {
+		t.Fatal("expected error for missing wisp_labels table")
+	}
+	if errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("expected table error, got ErrNotFound: %v", err)
+	}
+	if !strings.Contains(err.Error(), "wisp_labels") {
+		t.Fatalf("expected error to mention wisp_labels, got: %v", err)
+	}
+}
+
 // TestEphemeralExplicitID_UpdateIssue verifies that UpdateIssue works on
 // ephemeral beads created with explicit IDs. Regression test for GH#2053.
 func TestEphemeralExplicitID_UpdateIssue(t *testing.T) {

--- a/internal/storage/embeddeddolt/get_issue_test.go
+++ b/internal/storage/embeddeddolt/get_issue_test.go
@@ -4,6 +4,7 @@ package embeddeddolt_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -101,6 +102,35 @@ func TestGetIssue(t *testing.T) {
 		// Labels should be sorted
 		if got.Labels[0] != "bug" || got.Labels[1] != "urgent" {
 			t.Errorf("Labels: got %v, want [bug urgent]", got.Labels)
+		}
+	})
+
+	t.Run("wisp_label_table_error_propagates", func(t *testing.T) {
+		te := newTestEnv(t, "wl")
+		ctx := t.Context()
+
+		wisp := &types.Issue{
+			ID:        "wl-wisp",
+			Title:     "Wisp with missing labels table",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		if err := te.store.CreateIssue(ctx, wisp, "tester"); err != nil {
+			t.Fatalf("CreateIssue: %v", err)
+		}
+		te.exec(t, ctx, "DROP TABLE wisp_labels")
+
+		_, err := te.store.GetIssue(ctx, "wl-wisp")
+		if err == nil {
+			t.Fatal("expected error for missing wisp_labels table")
+		}
+		if errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("expected table error, got ErrNotFound: %v", err)
+		}
+		if !strings.Contains(err.Error(), "wisp_labels") {
+			t.Fatalf("expected error to mention wisp_labels, got: %v", err)
 		}
 	})
 }

--- a/internal/storage/issueops/get_issue.go
+++ b/internal/storage/issueops/get_issue.go
@@ -3,6 +3,7 @@ package issueops
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage"
@@ -14,14 +15,30 @@ import (
 // if the ID is an active wisp. Returns storage.ErrNotFound (wrapped) if the
 // issue does not exist in either table.
 func GetIssueInTx(ctx context.Context, tx *sql.Tx, id string) (*types.Issue, error) {
-	isWisp := IsActiveWispInTx(ctx, tx, id)
-	issueTable, labelTable, _, _ := WispTableRouting(isWisp)
+	issue, err := getIssueFromTableInTx(ctx, tx, "issues", "labels", id)
+	if err == nil {
+		return issue, nil
+	}
+	if !errors.Is(err, storage.ErrNotFound) {
+		return nil, err
+	}
 
+	issue, err = getIssueFromTableInTx(ctx, tx, "wisps", "wisp_labels", id)
+	if err == nil {
+		return issue, nil
+	}
+	if errors.Is(err, storage.ErrNotFound) || isTableNotExistError(err) {
+		return nil, fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
+	}
+	return nil, err
+}
+
+func getIssueFromTableInTx(ctx context.Context, tx *sql.Tx, issueTable, labelTable, id string) (*types.Issue, error) {
 	//nolint:gosec // G201: issueTable is from WispTableRouting ("issues" or "wisps")
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT %s FROM %s WHERE id = ?`, IssueSelectColumns, issueTable), id)
 	issue, err := ScanIssueFrom(row)
 	if err == sql.ErrNoRows {
-		return nil, fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
+		return nil, storage.ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get issue: %w", err)

--- a/internal/storage/issueops/get_issue.go
+++ b/internal/storage/issueops/get_issue.go
@@ -27,17 +27,17 @@ func GetIssueInTx(ctx context.Context, tx *sql.Tx, id string) (*types.Issue, err
 	if err == nil {
 		return issue, nil
 	}
-	if errors.Is(err, storage.ErrNotFound) || isTableNotExistError(err) {
+	if errors.Is(err, storage.ErrNotFound) {
 		return nil, fmt.Errorf("%w: issue %s", storage.ErrNotFound, id)
 	}
 	return nil, err
 }
 
 func getIssueFromTableInTx(ctx context.Context, tx *sql.Tx, issueTable, labelTable, id string) (*types.Issue, error) {
-	//nolint:gosec // G201: issueTable is from WispTableRouting ("issues" or "wisps")
+	//nolint:gosec // G201: issueTable is a hardcoded literal supplied by GetIssueInTx ("issues" or "wisps")
 	row := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT %s FROM %s WHERE id = ?`, IssueSelectColumns, issueTable), id)
 	issue, err := ScanIssueFrom(row)
-	if err == sql.ErrNoRows {
+	if err == sql.ErrNoRows || isTableNotExistError(err) {
 		return nil, storage.ErrNotFound
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary
- Try the primary issues table first in GetIssueInTx.
- Fall back to wisps only after the primary row is not found.
- Preserve promoted-wisp behavior and tolerate pre-migration stores without a wisps table.

## Validation
- go test ./internal/storage/issueops

## Notes
- Dolt-backed GetIssue tests that create wisps currently fail on origin/main before reaching this change because the test database is missing the wisps table: Error 1146 table not found: wisps.