### PR TITLE
fix(schema): serialize Dolt schema migrations

### DIFF
--- a/internal/storage/dolt/initschema_concurrent_test.go
+++ b/internal/storage/dolt/initschema_concurrent_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -116,4 +118,330 @@ func TestConcurrentInitSchema(t *testing.T) {
 			t.Errorf("table %s missing after concurrent init", table)
 		}
 	}
+}
+
+func TestInitSchemaBlocksOnMigrationLock(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dbName := uniqueTestDBName(t)
+	initDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root"}.String()
+	initDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("open init connection: %v", err)
+	}
+	defer initDB.Close()
+
+	if _, err := initDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	dsn := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root", Database: dbName}.String()
+	lockHolder, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open lock holder: %v", err)
+	}
+	defer lockHolder.Close()
+
+	lockConn, err := lockHolder.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin lock holder: %v", err)
+	}
+	defer lockConn.Close()
+
+	var lockHolderID int64
+	if err := lockConn.QueryRowContext(ctx, "SELECT CONNECTION_ID()").Scan(&lockHolderID); err != nil {
+		t.Fatalf("read lock holder connection id: %v", err)
+	}
+
+	lockName := schema.MigrationLockName(dbName)
+	var locked int
+	if err := lockConn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&locked); err != nil {
+		t.Fatalf("hold migration lock: %v", err)
+	}
+	if locked != 1 {
+		t.Fatalf("GET_LOCK returned %d, want 1", locked)
+	}
+
+	initDB2, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open init db: %v", err)
+	}
+	defer initDB2.Close()
+	initDB2.SetMaxOpenConns(2)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- initSchemaOnDB(ctx, initDB2)
+	}()
+
+	waitForMigrationLockWaiter(t, ctx, initDB, lockHolderID, errCh)
+
+	var released int
+	if err := lockConn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released); err != nil {
+		t.Fatalf("release migration lock: %v", err)
+	}
+	if released != 1 {
+		t.Fatalf("RELEASE_LOCK returned %d, want 1", released)
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("initSchemaOnDB after releasing migration lock: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("initSchemaOnDB did not complete after releasing migration lock")
+	}
+}
+
+func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dbName := uniqueTestDBName(t)
+	initDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root"}.String()
+	initDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("open init connection: %v", err)
+	}
+	defer initDB.Close()
+
+	if _, err := initDB.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	dsn := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root", Database: dbName}.String()
+	lockHolder, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open lock holder: %v", err)
+	}
+	defer lockHolder.Close()
+
+	lockConn, err := lockHolder.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin lock holder: %v", err)
+	}
+	defer lockConn.Close()
+
+	var lockHolderID int64
+	if err := lockConn.QueryRowContext(ctx, "SELECT CONNECTION_ID()").Scan(&lockHolderID); err != nil {
+		t.Fatalf("read lock holder connection id: %v", err)
+	}
+
+	lockName := schema.MigrationLockName(dbName)
+	var locked int
+	if err := lockConn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&locked); err != nil {
+		t.Fatalf("hold migration lock: %v", err)
+	}
+	if locked != 1 {
+		t.Fatalf("GET_LOCK returned %d, want 1", locked)
+	}
+
+	blockedDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open blocked db: %v", err)
+	}
+	defer blockedDB.Close()
+
+	callerCtx, callerCancel := context.WithCancel(ctx)
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- initSchemaOnDB(callerCtx, blockedDB)
+	}()
+
+	waitForMigrationLockWaiter(t, ctx, initDB, lockHolderID, errCh)
+	callerCancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("initSchemaOnDB succeeded after caller context was canceled while waiting for the migration lock")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("initSchemaOnDB did not return after caller context cancellation")
+	}
+
+	var released int
+	if err := lockConn.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released); err != nil {
+		t.Fatalf("release migration lock: %v", err)
+	}
+	if released != 1 {
+		t.Fatalf("RELEASE_LOCK returned %d, want 1", released)
+	}
+
+	secondDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open second db: %v", err)
+	}
+	defer secondDB.Close()
+
+	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer verifyCancel()
+	if err := initSchemaOnDB(verifyCtx, secondDB); err != nil {
+		t.Fatalf("second initSchemaOnDB after canceled lock wait: %v", err)
+	}
+}
+
+func TestMigrationLockReleaseIgnoresCanceledCallerContext(t *testing.T) {
+	skipIfNoDolt(t)
+	acquireTestSlot()
+	t.Cleanup(releaseTestSlot)
+
+	if testServerPort == 0 {
+		t.Skip("no Dolt test server available")
+	}
+
+	setupCtx, setupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer setupCancel()
+
+	dbName := uniqueTestDBName(t)
+	initDSN := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root"}.String()
+	initDB, err := sql.Open("mysql", initDSN)
+	if err != nil {
+		t.Fatalf("open init connection: %v", err)
+	}
+	defer initDB.Close()
+
+	if _, err := initDB.ExecContext(setupCtx, "CREATE DATABASE IF NOT EXISTS `"+dbName+"`"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+
+	dsn := doltutil.ServerDSN{Host: "127.0.0.1", Port: testServerPort, User: "root", Database: dbName}.String()
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open lock db: %v", err)
+	}
+	defer db.Close()
+
+	callerCtx, callerCancel := context.WithCancel(context.Background())
+	conn, err := db.Conn(callerCtx)
+	if err != nil {
+		t.Fatalf("pin lock conn: %v", err)
+	}
+	defer conn.Close()
+
+	lockName := schema.MigrationLockName(dbName)
+	if err := schema.AcquireMigrationLock(callerCtx, conn, lockName); err != nil {
+		t.Fatalf("acquire migration lock: %v", err)
+	}
+	callerCancel()
+
+	if err := schema.ReleaseMigrationLock(conn, lockName); err != nil {
+		t.Fatalf("release migration lock with canceled caller context: %v", err)
+	}
+
+	secondDB, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open second db: %v", err)
+	}
+	defer secondDB.Close()
+
+	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer verifyCancel()
+	if err := initSchemaOnDB(verifyCtx, secondDB); err != nil {
+		t.Fatalf("second initSchemaOnDB after canceled-context release: %v", err)
+	}
+}
+
+func waitForMigrationLockWaiter(t *testing.T, ctx context.Context, observer *sql.DB, holderID int64, errCh <-chan error) {
+	t.Helper()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case err := <-errCh:
+			t.Fatalf("initSchemaOnDB completed before a GET_LOCK waiter was observed: %v", err)
+		default:
+		}
+
+		visible, err := migrationLockWaiterVisible(waitCtx, observer, holderID)
+		if err != nil {
+			t.Fatalf("observe migration lock waiter: %v", err)
+		}
+		if visible {
+			return
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatal("timed out waiting for initSchemaOnDB to appear as a GET_LOCK waiter")
+		case <-ticker.C:
+		}
+	}
+}
+
+func migrationLockWaiterVisible(ctx context.Context, observer *sql.DB, holderID int64) (bool, error) {
+	rows, err := observer.QueryContext(ctx, "SHOW PROCESSLIST")
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return false, err
+	}
+
+	idIndex := -1
+	infoIndex := -1
+	for i, column := range columns {
+		switch strings.ToLower(column) {
+		case "id":
+			idIndex = i
+		case "info":
+			infoIndex = i
+		}
+	}
+	if idIndex < 0 || infoIndex < 0 {
+		return false, fmt.Errorf("SHOW PROCESSLIST columns missing id/info: %v", columns)
+	}
+
+	values := make([]sql.NullString, len(columns))
+	scanArgs := make([]any, len(columns))
+	for i := range values {
+		scanArgs[i] = &values[i]
+	}
+
+	for rows.Next() {
+		for i := range values {
+			values[i] = sql.NullString{}
+		}
+		if err := rows.Scan(scanArgs...); err != nil {
+			return false, err
+		}
+
+		if values[idIndex].Valid {
+			id, err := strconv.ParseInt(values[idIndex].String, 10, 64)
+			if err == nil && id == holderID {
+				continue
+			}
+		}
+		if values[infoIndex].Valid && strings.Contains(strings.ToUpper(values[infoIndex].String), "GET_LOCK") {
+			return true, nil
+		}
+	}
+
+	return false, rows.Err()
 }

--- a/internal/storage/dolt/initschema_multiprocess_test.go
+++ b/internal/storage/dolt/initschema_multiprocess_test.go
@@ -69,10 +69,8 @@ func TestHelperSchemaInit(t *testing.T) {
 		os.Exit(1)
 	}
 
-	// Report which path was taken. The parent test asserts exactly 1 slow path.
-	// We detect the path by checking if schema_version existed before our init.
-	// Since initSchemaOnDB is idempotent, we can't truly distinguish from here,
-	// but the important thing is all subprocesses succeed without corruption.
+	// initSchemaOnDB is idempotent, so the parent test only needs to know that
+	// every subprocess reached a clean schema without corruption.
 	fmt.Fprintf(os.Stdout, "OK proc=%s\n", procID)
 }
 
@@ -172,19 +170,19 @@ func TestMultiProcessSchemaInit(t *testing.T) {
 	verifyCtx, verifyCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer verifyCancel()
 
-	// Check schema_version exists and is current.
+	// Check schema_migrations exists and is current.
 	var version int
-	err = verifyDB.QueryRowContext(verifyCtx, "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").Scan(&version)
+	err = verifyDB.QueryRowContext(verifyCtx, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations").Scan(&version)
 	if err != nil {
-		t.Fatalf("schema_version query failed: %v", err)
+		t.Fatalf("schema_migrations query failed: %v", err)
 	}
 	if version == 0 {
-		t.Error("schema_version is 0 after concurrent init")
+		t.Error("schema_migrations max version is 0 after concurrent init")
 	}
-	t.Logf("schema_version: %d", version)
+	t.Logf("schema_migrations max version: %d", version)
 
 	// Verify core tables exist.
-	requiredTables := []string{"issues", "dependencies", "comments", "schema_version"}
+	requiredTables := []string{"issues", "dependencies", "comments", "schema_migrations"}
 	for _, table := range requiredTables {
 		var count int
 		err := verifyDB.QueryRowContext(verifyCtx, "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?", dbName, table).Scan(&count)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -302,6 +302,9 @@ func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if schema.IsMigrationLockError(err) {
+		return true
+	}
 	errStr := strings.ToLower(err.Error())
 	// MySQL driver transient errors
 	if strings.Contains(errStr, "driver: bad connection") {
@@ -1104,7 +1107,9 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	if !cfg.ReadOnly {
 		schemaBO := backoff.NewExponentialBackOff()
 		schemaBO.InitialInterval = 100 * time.Millisecond
-		schemaBO.MaxElapsedTime = 5 * time.Second
+		// Must exceed schema.MigrateUpWithLock's 5s GET_LOCK wait so a
+		// contended schema migration can time out once and still retry.
+		schemaBO.MaxElapsedTime = 15 * time.Second
 		if err := backoff.Retry(func() error {
 			schemaErr := store.initSchema(ctx)
 			if schemaErr != nil && isRetryableError(schemaErr) {
@@ -1486,21 +1491,7 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("schema: read database name: %w", err)
 	}
 
-	// Serialize schema migrations per database; migration scripts are not safe
-	// to execute concurrently against the same fresh database.
-	lockName := "bd_schema_init:" + dbName
-	var locked int
-	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 30)", lockName).Scan(&locked); err != nil {
-		return fmt.Errorf("schema: acquire migration lock: %w", err)
-	}
-	if locked != 1 {
-		return fmt.Errorf("schema: acquire migration lock: timeout")
-	}
-	defer func() {
-		_, _ = conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", lockName)
-	}()
-
-	if _, err := schema.MigrateUp(ctx, conn); err != nil {
+	if _, err := schema.MigrateUpWithLock(ctx, conn, dbName); err != nil {
 		return fmt.Errorf("schema migration: %w", err)
 	}
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1481,6 +1481,25 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 	}
 	defer conn.Close()
 
+	var dbName string
+	if err := conn.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&dbName); err != nil {
+		return fmt.Errorf("schema: read database name: %w", err)
+	}
+
+	// Serialize schema migrations per database; migration scripts are not safe
+	// to execute concurrently against the same fresh database.
+	lockName := "bd_schema_init:" + dbName
+	var locked int
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 30)", lockName).Scan(&locked); err != nil {
+		return fmt.Errorf("schema: acquire migration lock: %w", err)
+	}
+	if locked != 1 {
+		return fmt.Errorf("schema: acquire migration lock: timeout")
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", lockName)
+	}()
+
 	if _, err := schema.MigrateUp(ctx, conn); err != nil {
 		return fmt.Errorf("schema migration: %w", err)
 	}

--- a/internal/storage/dolt/store_unit_test.go
+++ b/internal/storage/dolt/store_unit_test.go
@@ -10,6 +10,7 @@ import (
 
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/schema"
 )
 
 // newTestDoltDB creates a temporary database on the test Dolt server.
@@ -46,6 +47,13 @@ func newTestDoltDB(t *testing.T) (*sql.DB, func()) {
 		db.Close()
 		// Skip DROP DATABASE — rapid CREATE/DROP cycles crash the Dolt container.
 		// Orphan databases are cleaned up when the container terminates.
+	}
+}
+
+func TestIsRetryableErrorSchemaMigrationLock(t *testing.T) {
+	err := fmt.Errorf("schema migration: %w", schema.ErrMigrationLockUnavailable)
+	if !isRetryableError(err) {
+		t.Fatal("schema migration lock errors should be retryable")
 	}
 }
 

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -176,6 +176,8 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 		}
 	}
 
+	// Embedded mode relies on the dolthub/driver's local file/concurrency
+	// controls; schema.MigrateUpWithLock requires a sql-server session lock.
 	if _, err := schema.MigrateUp(ctx, conn); err != nil {
 		return fmt.Errorf("embeddeddolt: migrate: %w", err)
 	}

--- a/internal/storage/schema/lock.go
+++ b/internal/storage/schema/lock.go
@@ -1,0 +1,112 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"time"
+)
+
+const (
+	migrationLockPrefix        = "bd_schema_init:"
+	migrationLockNameMaxLength = 64
+	// Keep this below the server-mode callers' retry budgets so a contended
+	// lock wait can time out and still leave room for a real retry.
+	migrationLockAcquireTimeoutSeconds = 5
+	migrationLockCleanupTimeout        = 5 * time.Second
+)
+
+var (
+	// ErrMigrationLockUnavailable marks transient failures to acquire the
+	// per-database migration lock.
+	ErrMigrationLockUnavailable = errors.New("schema migration lock unavailable")
+
+	// ErrMigrationLockRelease marks uncertain lock cleanup after migrations.
+	ErrMigrationLockRelease = errors.New("schema migration lock release failed")
+)
+
+// IsMigrationLockError reports whether err came from migration lock acquisition
+// or cleanup and should be treated as retryable by callers with a retry budget.
+func IsMigrationLockError(err error) bool {
+	return errors.Is(err, ErrMigrationLockUnavailable) || errors.Is(err, ErrMigrationLockRelease)
+}
+
+// MigrationLockName returns a Dolt/MySQL named-lock key within the documented
+// 64-byte limit while preserving readable names when they already fit.
+func MigrationLockName(databaseName string) string {
+	raw := migrationLockPrefix + databaseName
+	if len(raw) <= migrationLockNameMaxLength {
+		return raw
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(databaseName))
+	return fmt.Sprintf("%s%016x", migrationLockPrefix, h.Sum64())
+}
+
+// MigrateUpWithLock serializes schema migrations for a single Dolt sql-server
+// database. conn must be a pinned *sql.Conn because MySQL/Dolt named locks are
+// session-scoped; GET_LOCK, migrations, and RELEASE_LOCK must run on the same
+// server session. Embedded Dolt intentionally uses bare MigrateUp because it
+// relies on the embedded driver's file/concurrency controls instead of
+// sql-server session locks.
+func MigrateUpWithLock(ctx context.Context, conn *sql.Conn, databaseName string) (applied int, err error) {
+	lockName := MigrationLockName(databaseName)
+	if err := AcquireMigrationLock(ctx, conn, lockName); err != nil {
+		return 0, err
+	}
+	defer func() {
+		if releaseErr := ReleaseMigrationLock(conn, lockName); releaseErr != nil {
+			err = errors.Join(err, releaseErr)
+		}
+	}()
+
+	return MigrateUp(ctx, conn)
+}
+
+// AcquireMigrationLock acquires the named schema migration lock on the pinned
+// connection's current Dolt/MySQL session.
+func AcquireMigrationLock(ctx context.Context, conn *sql.Conn, lockName string) error {
+	var locked sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, migrationLockAcquireTimeoutSeconds).Scan(&locked); err != nil {
+		return fmt.Errorf("schema: acquire migration lock: %w: %w", ErrMigrationLockUnavailable, err)
+	}
+	if !locked.Valid {
+		return fmt.Errorf("schema: acquire migration lock: %w: returned NULL", ErrMigrationLockUnavailable)
+	}
+	if locked.Int64 != 1 {
+		return fmt.Errorf("schema: acquire migration lock: %w: timeout", ErrMigrationLockUnavailable)
+	}
+	return nil
+}
+
+// ReleaseMigrationLock releases the named schema migration lock from the same
+// pinned Dolt/MySQL session used to acquire it.
+func ReleaseMigrationLock(conn *sql.Conn, lockName string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), migrationLockCleanupTimeout)
+	defer cancel()
+
+	var released sql.NullInt64
+	if err := conn.QueryRowContext(cleanupCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released); err != nil {
+		discardConn(conn)
+		return fmt.Errorf("schema: release migration lock: %w: %w", ErrMigrationLockRelease, err)
+	}
+	if !released.Valid {
+		discardConn(conn)
+		return fmt.Errorf("schema: release migration lock: %w: returned NULL", ErrMigrationLockRelease)
+	}
+	if released.Int64 != 1 {
+		discardConn(conn)
+		return fmt.Errorf("schema: release migration lock: %w: returned %d", ErrMigrationLockRelease, released.Int64)
+	}
+	return nil
+}
+
+func discardConn(conn *sql.Conn) {
+	_ = conn.Raw(func(driverConn any) error {
+		return driver.ErrBadConn
+	})
+}

--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -1,0 +1,36 @@
+package schema
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestMigrationLockNameUsesRawNameWhenBounded(t *testing.T) {
+	got := MigrationLockName("testdb_short")
+	want := migrationLockPrefix + "testdb_short"
+	if got != want {
+		t.Fatalf("MigrationLockName() = %q, want %q", got, want)
+	}
+}
+
+func TestMigrationLockNameHashesLongNames(t *testing.T) {
+	dbName := strings.Repeat("a", 64)
+	got := MigrationLockName(dbName)
+	if len(got) > migrationLockNameMaxLength {
+		t.Fatalf("MigrationLockName() length = %d, want <= %d", len(got), migrationLockNameMaxLength)
+	}
+	if got == migrationLockPrefix+dbName {
+		t.Fatalf("MigrationLockName() used over-limit raw name %q", got)
+	}
+	if got != MigrationLockName(dbName) {
+		t.Fatal("MigrationLockName() is not deterministic")
+	}
+}
+
+func TestIsMigrationLockError(t *testing.T) {
+	err := errors.Join(ErrMigrationLockUnavailable, errors.New("timeout"))
+	if !IsMigrationLockError(err) {
+		t.Fatal("IsMigrationLockError() = false, want true")
+	}
+}

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -153,7 +153,9 @@ func openDB(ctx context.Context, dsn string) (*sql.DB, error) {
 func (p *doltServerProvider) initSchema(ctx context.Context, database string) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 25 * time.Millisecond
-	bo.MaxElapsedTime = 5 * time.Second
+	// Must exceed schema.MigrateUpWithLock's 5s GET_LOCK wait so a
+	// contended schema migration can time out once and still retry.
+	bo.MaxElapsedTime = 15 * time.Second
 	return backoff.Retry(func() error {
 		conn, err := p.db.Conn(ctx)
 		if err != nil {
@@ -172,8 +174,8 @@ func (p *doltServerProvider) initSchema(ctx context.Context, database string) er
 			return backoff.Permanent(fmt.Errorf("uow: switching to database: %w", err))
 		}
 
-		if _, err := schema.MigrateUp(ctx, conn); err != nil {
-			if isSerializationError(err) {
+		if _, err := schema.MigrateUpWithLock(ctx, conn, database); err != nil {
+			if isSerializationError(err) || schema.IsMigrationLockError(err) {
 				return fmt.Errorf("uow: migrate: %w", err)
 			}
 			return backoff.Permanent(fmt.Errorf("uow: migrate: %w", err))


### PR DESCRIPTION
## Summary

This PR serializes Dolt schema migration execution per database by acquiring a database-scoped advisory lock before calling `schema.MigrateUp`.

The fix is intentionally small:

- Keep `initSchemaOnDB` pinned to one SQL connection.
- Read the active database name with `SELECT DATABASE()`.
- Acquire `GET_LOCK('bd_schema_init:<database>', 30)` on that same connection.
- Run `schema.MigrateUp` while the lock is held.
- Release the lock with `RELEASE_LOCK(...)` on function exit.

This does not serialize normal Beads reads/writes. It only serializes schema initialization/migration work for one Dolt database at a time.

## RCA

While validating the local Beads perf stack, `./scripts/test.sh ./internal/storage/dolt` failed locally even though CI was green.

The first deterministic failure was:

```text
--- FAIL: TestConcurrentInitSchema
concurrent init error: goroutine N: initSchemaOnDB: schema migration: migration 0023_add_no_history_column.up.sql: Error 1105 (HY000): Column "no_history" already exists
```

I reproduced the same failure on pristine `origin/main` with:

```bash
./scripts/test.sh -run '^TestConcurrentInitSchema$' ./internal/storage/dolt
```

So this is not introduced by the current perf/index work. It is already present on `main` when the Dolt server-mode testcontainer tests actually run locally.

## Why CI Did Not Catch This

CI is green because the normal CI test job does not run these server-mode Dolt container tests in the same way this machine does.

Local conditions:

- Docker is available.
- `dolthub/dolt-sql-server:1.88.1` is cached locally.
- `internal/storage/dolt` therefore starts the Dolt testcontainer and runs `TestConcurrentInitSchema`.

CI conditions:

- The normal test job installs the `dolt` CLI, but does not pull/cache `dolthub/dolt-sql-server:1.88.1` for this package path.
- `EnsureDoltContainerForTestMain` treats the missing image as a skip condition.
- The server-mode concurrency test does not actually exercise the failure in that CI lane.

This is a CI coverage gap, not evidence that the local failure is spurious.

## Historical Context

There was a prior advisory-lock fix in `f73a9ca34` for GH#2672. That commit described the problem as concurrent fresh schema init causing Dolt journal/CRC corruption.

That lock was removed by `910ad1310` with the subject:

```text
/internal/{storage,doltserver}: remove incorrect locking attempt for journal corruption that does not repro
```

That removal deleted both the lock and the then-current concurrency test.

However, the test was later reintroduced by `52319c1ff` (`/internal/storage/dolt: fix test and migration`) and subsequently updated by the shared schema migration work.

The current failure is different from the old journal-corruption claim. It is a plain concurrent DDL race:

1. Multiple processes/goroutines enter schema migration on the same fresh database.
2. Each evaluates migration preconditions before another connection finishes its DDL.
3. One connection adds `issues.no_history`.
4. Other connections then run their stale prepared `ALTER TABLE issues ADD COLUMN no_history ...` and fail with `Column "no_history" already exists`.

The old RCA may have been wrong, but the current migration path is still not concurrency-safe.

## Why This Fix

We could try to make every migration script perfectly idempotent under concurrent execution, but that is brittle:

- Existing migrations use check-then-DDL patterns through `INFORMATION_SCHEMA` and prepared statements.
- Check-then-DDL is not atomic across concurrent sessions.
- Future migrations can easily reintroduce the same race.
- Schema migration is naturally a singleton operation per database.

A database-scoped advisory lock makes the invariant explicit: only one session may apply schema migrations to a given database at once.

The lock name includes the database name so unrelated databases on the same Dolt server do not block each other.

## Validation

The failing reproducer now passes on this branch:

```bash
./scripts/test.sh -run '^TestConcurrentInitSchema$' ./internal/storage/dolt
```

Result:

```text
ok  github.com/steveyegge/beads/internal/storage/dolt  5.923s
```

Additional checks run:

```bash
./scripts/test.sh ./internal/storage/schema
go build -tags gms_pure_go ./cmd/bd
```

Results:

```text
?   github.com/steveyegge/beads/internal/storage/schema [no test files]
```

`go build -tags gms_pure_go ./cmd/bd` completed successfully.

## Follow-Up

The CI/local mismatch should be addressed separately. The normal CI test lane currently lets server-mode Dolt container coverage skip when the Docker image is absent. That made `main` look green while a locally cached testcontainer image exposed a real failure.
