### PR TITLE
fix(ready): apply filters to wisp ready work

### DIFF
--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -380,8 +380,8 @@ func TestEmbeddedDep(t *testing.T) {
 		b := bdCreate(t, bd, dir2, "No cycle B", "--type", "task")
 		bdDep(t, bd, dir2, "add", a.ID, b.ID)
 		out := bdDep(t, bd, dir2, "cycles")
-		if !strings.Contains(out, "No cycles") && !strings.Contains(out, "no cycles") {
-			t.Logf("expected 'No cycles' message: %s", out)
+		if !strings.Contains(out, "No dependency cycles detected") {
+			t.Logf("expected no-cycle message: %s", out)
 		}
 	})
 }

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // TestGitAddFile_InWorktreeHook_StagesCorrectPath is a regression test for
@@ -173,6 +175,15 @@ func TestScrubGitHookEnv(t *testing.T) {
 		if !strings.Contains(joined, k) {
 			t.Errorf("scrubGitHookEnv dropped %s\nresult:\n%s", k, joined)
 		}
+	}
+}
+
+func TestShouldRunPostCommandAutoExportSkipsReadOnlyCommands(t *testing.T) {
+	if shouldRunPostCommandAutoExport(&cobra.Command{Use: "search"}) {
+		t.Fatal("search is read-only and must not trigger post-command auto-export")
+	}
+	if !shouldRunPostCommandAutoExport(&cobra.Command{Use: "create"}) {
+		t.Fatal("write commands should still trigger post-command auto-export")
 	}
 }
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1125,8 +1125,12 @@ var rootCmd = &cobra.Command{
 		// Auto-backup: export JSONL to .beads/backup/ if enabled and due
 		maybeAutoBackup(rootCtx)
 
-		// Auto-export: write git-tracked JSONL for portability if enabled and due
-		maybeAutoExport(rootCtx)
+		// Auto-export: write git-tracked JSONL for portability if enabled and due.
+		// Read-only commands must not perform post-run maintenance writes or emit
+		// sync guidance after machine-readable output.
+		if shouldRunPostCommandAutoExport(cmd) {
+			maybeAutoExport(rootCtx)
+		}
 
 		// Auto-push: push to Dolt remote if enabled and due.
 		// Skip for read-only commands to avoid unnecessary network operations
@@ -1167,6 +1171,13 @@ var rootCmd = &cobra.Command{
 			rootCancel()
 		}
 	},
+}
+
+func shouldRunPostCommandAutoExport(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return true
+	}
+	return !isReadOnlyCommand(cmd.Name())
 }
 
 // blockedEnvVars lists environment variables that must not be set because they

--- a/internal/storage/embeddeddolt/new_methods_test.go
+++ b/internal/storage/embeddeddolt/new_methods_test.go
@@ -4,6 +4,7 @@ package embeddeddolt_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -278,6 +279,47 @@ func TestGetReadyWorkIncludeEphemeralAppliesWispFilters(t *testing.T) {
 	te := newTestEnv(t, "rwf")
 	ctx := t.Context()
 
+	createIssue := func(issue *types.Issue) {
+		t.Helper()
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
+		}
+	}
+	addDep := func(issueID, dependsOnID string, depType types.DependencyType) {
+		t.Helper()
+		if err := te.store.AddDependency(ctx, &types.Dependency{
+			IssueID:     issueID,
+			DependsOnID: dependsOnID,
+			Type:        depType,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency(%s -> %s): %v", issueID, dependsOnID, err)
+		}
+	}
+	readyIDs := func(filter types.WorkFilter) map[string]bool {
+		t.Helper()
+		filter.IncludeEphemeral = true
+		ready, err := te.store.GetReadyWork(ctx, filter)
+		if err != nil {
+			t.Fatalf("GetReadyWork: %v", err)
+		}
+		ids := make(map[string]bool, len(ready))
+		for _, issue := range ready {
+			ids[issue.ID] = true
+		}
+		return ids
+	}
+	assertReady := func(ids map[string]bool, want string, rejects ...string) {
+		t.Helper()
+		if !ids[want] {
+			t.Fatalf("matching wisp %s missing from ready work: %v", want, ids)
+		}
+		for _, reject := range rejects {
+			if ids[reject] {
+				t.Fatalf("non-matching wisp %s leaked into ready work: %v", reject, ids)
+			}
+		}
+	}
+
 	matching := &types.Issue{
 		ID:        "rwf-wisp-filter-match",
 		Title:     "Matching routed wisp",
@@ -307,34 +349,165 @@ func TestGetReadyWorkIncludeEphemeralAppliesWispFilters(t *testing.T) {
 		Metadata:  []byte(`{"gc.routed_to":"beads/workflows.codex-max"}`),
 	}
 	for _, issue := range []*types.Issue{matching, assigned, wrongRoute} {
-		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
-			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
-		}
+		createIssue(issue)
 	}
 
-	ready, err := te.store.GetReadyWork(ctx, types.WorkFilter{
-		Status:           types.StatusOpen,
-		Unassigned:       true,
-		IncludeEphemeral: true,
+	ids := readyIDs(types.WorkFilter{
+		Status:     types.StatusOpen,
+		Unassigned: true,
 		MetadataFields: map[string]string{
 			"gc.routed_to": "beads/workflows.kimi",
 		},
 	})
-	if err != nil {
-		t.Fatalf("GetReadyWork: %v", err)
+	assertReady(ids, matching.ID, assigned.ID, wrongRoute.ID)
+
+	labelsMatch := &types.Issue{ID: "rwf-labels-match", Title: "Labels match", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true, Labels: []string{"route", "keep"}}
+	labelsWrong := &types.Issue{ID: "rwf-labels-wrong", Title: "Labels wrong", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true, Labels: []string{"other", "keep"}}
+	labelsExcluded := &types.Issue{ID: "rwf-labels-excluded", Title: "Labels excluded", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true, Labels: []string{"route", "skip"}}
+	for _, issue := range []*types.Issue{labelsMatch, labelsWrong, labelsExcluded} {
+		createIssue(issue)
+	}
+	ids = readyIDs(types.WorkFilter{
+		Status:        types.StatusOpen,
+		LabelsAny:     []string{"route"},
+		ExcludeLabels: []string{"skip"},
+	})
+	assertReady(ids, labelsMatch.ID, labelsWrong.ID, labelsExcluded.ID)
+
+	alice := "alice"
+	metaAssigneeMatch := &types.Issue{ID: "rwf-meta-assignee-match", Title: "Metadata assignee match", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Assignee: alice, Ephemeral: true, Metadata: []byte(`{"flag":"yes"}`)}
+	metaAssigneeMissing := &types.Issue{ID: "rwf-meta-assignee-missing", Title: "Metadata missing", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Assignee: alice, Ephemeral: true}
+	metaAssigneeWrong := &types.Issue{ID: "rwf-meta-assignee-wrong", Title: "Assignee wrong", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Assignee: "bob", Ephemeral: true, Metadata: []byte(`{"flag":"yes"}`)}
+	for _, issue := range []*types.Issue{metaAssigneeMatch, metaAssigneeMissing, metaAssigneeWrong} {
+		createIssue(issue)
+	}
+	ids = readyIDs(types.WorkFilter{
+		Status:         types.StatusOpen,
+		Assignee:       &alice,
+		HasMetadataKey: "flag",
+	})
+	assertReady(ids, metaAssigneeMatch.ID, metaAssigneeMissing.ID, metaAssigneeWrong.ID)
+
+	typeMatch := &types.Issue{ID: "rwf-type-match", Title: "Type match", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeBug, Ephemeral: true}
+	typeWrong := &types.Issue{ID: "rwf-type-wrong", Title: "Type wrong", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	excludeTypeMatch := &types.Issue{ID: "rwf-exclude-type-match", Title: "Exclude type match", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	excludeTypeWrong := &types.Issue{ID: "rwf-exclude-type-wrong", Title: "Exclude type wrong", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeBug, Ephemeral: true}
+	for _, issue := range []*types.Issue{typeMatch, typeWrong, excludeTypeMatch, excludeTypeWrong} {
+		createIssue(issue)
+	}
+	ids = readyIDs(types.WorkFilter{Status: types.StatusOpen, Type: string(types.TypeBug)})
+	assertReady(ids, typeMatch.ID, typeWrong.ID)
+	ids = readyIDs(types.WorkFilter{Status: types.StatusOpen, ExcludeTypes: []types.IssueType{types.TypeBug}})
+	assertReady(ids, excludeTypeMatch.ID, excludeTypeWrong.ID)
+
+	swarm := types.MolTypeSwarm
+	errorWisp := types.WispTypeError
+	typeClassMatch := &types.Issue{ID: "rwf-class-match", Title: "Class match", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true, MolType: swarm, WispType: errorWisp}
+	typeClassWrong := &types.Issue{ID: "rwf-class-wrong", Title: "Class wrong", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true, MolType: swarm, WispType: types.WispTypePing}
+	for _, issue := range []*types.Issue{typeClassMatch, typeClassWrong} {
+		createIssue(issue)
+	}
+	ids = readyIDs(types.WorkFilter{Status: types.StatusOpen, MolType: &swarm, WispType: &errorWisp})
+	assertReady(ids, typeClassMatch.ID, typeClassWrong.ID)
+
+	molecule := &types.Issue{ID: "rwf-molecule", Title: "Molecule", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	moleculeMatch := &types.Issue{ID: "rwf-molecule-match", Title: "Molecule child", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	moleculeWrong := &types.Issue{ID: "rwf-molecule-wrong", Title: "Molecule non-child", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	for _, issue := range []*types.Issue{molecule, moleculeMatch, moleculeWrong} {
+		createIssue(issue)
+	}
+	addDep(moleculeMatch.ID, molecule.ID, types.DepParentChild)
+	ids = readyIDs(types.WorkFilter{Status: types.StatusOpen, MoleculeID: molecule.ID})
+	assertReady(ids, moleculeMatch.ID, moleculeWrong.ID)
+
+	root := &types.Issue{ID: "rwf-root", Title: "Root", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "rwf-child", Title: "Child", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask}
+	recursiveMatch := &types.Issue{ID: "rwf-recursive-match", Title: "Recursive wisp child", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	recursiveWrong := &types.Issue{ID: "rwf-recursive-wrong", Title: "Recursive wisp wrong", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	for _, issue := range []*types.Issue{root, child, recursiveMatch, recursiveWrong} {
+		createIssue(issue)
+	}
+	addDep(child.ID, root.ID, types.DepParentChild)
+	addDep(recursiveMatch.ID, child.ID, types.DepParentChild)
+	parentID := root.ID
+	ids = readyIDs(types.WorkFilter{Status: types.StatusOpen, ParentID: &parentID})
+	assertReady(ids, recursiveMatch.ID, recursiveWrong.ID)
+}
+
+func TestGetReadyWorkIncludeEphemeralExcludesNonReadyWisps(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "rwn")
+	ctx := t.Context()
+	future := time.Now().UTC().Add(24 * time.Hour)
+
+	createIssue := func(issue *types.Issue) {
+		t.Helper()
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
+		}
+	}
+	addDep := func(issueID, dependsOnID string, depType types.DependencyType) {
+		t.Helper()
+		if err := te.store.AddDependency(ctx, &types.Dependency{
+			IssueID:     issueID,
+			DependsOnID: dependsOnID,
+			Type:        depType,
+		}, "tester"); err != nil {
+			t.Fatalf("AddDependency(%s -> %s): %v", issueID, dependsOnID, err)
+		}
+	}
+	readyIDs := func(includeDeferred bool) map[string]bool {
+		t.Helper()
+		ready, err := te.store.GetReadyWork(ctx, types.WorkFilter{
+			Status:           types.StatusOpen,
+			IncludeEphemeral: true,
+			IncludeDeferred:  includeDeferred,
+		})
+		if err != nil {
+			t.Fatalf("GetReadyWork: %v", err)
+		}
+		ids := make(map[string]bool, len(ready))
+		for _, issue := range ready {
+			ids[issue.ID] = true
+		}
+		return ids
 	}
 
-	ids := make(map[string]bool, len(ready))
-	for _, issue := range ready {
-		ids[issue.ID] = true
+	ready := &types.Issue{ID: "rwn-ready", Title: "Ready wisp", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	pinned := &types.Issue{ID: "rwn-pinned", Title: "Pinned wisp", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true, Pinned: true}
+	deferred := &types.Issue{ID: "rwn-deferred", Title: "Deferred wisp", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true, DeferUntil: &future}
+	deferredParent := &types.Issue{ID: "rwn-deferred-parent", Title: "Deferred parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, DeferUntil: &future}
+	childOfDeferred := &types.Issue{ID: "rwn-child-of-deferred", Title: "Child of deferred", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	blocked := &types.Issue{ID: "rwn-blocked", Title: "Blocked wisp", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask, Ephemeral: true}
+	blocker := &types.Issue{ID: "rwn-blocker", Title: "Blocker", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask}
+	for _, issue := range []*types.Issue{ready, pinned, deferred, deferredParent, childOfDeferred, blocked, blocker} {
+		createIssue(issue)
 	}
-	if !ids[matching.ID] {
-		t.Fatalf("matching wisp missing from ready work: %v", ids)
+	addDep(childOfDeferred.ID, deferredParent.ID, types.DepParentChild)
+	addDep(blocked.ID, blocker.ID, types.DepBlocks)
+
+	ids := readyIDs(false)
+	if !ids[ready.ID] {
+		t.Fatalf("ready wisp missing from ready work: %v", ids)
 	}
-	if ids[assigned.ID] {
-		t.Fatalf("assigned wisp leaked through unassigned ready filter: %v", ids)
+	for _, reject := range []string{pinned.ID, deferred.ID, childOfDeferred.ID, blocked.ID} {
+		if ids[reject] {
+			t.Fatalf("non-ready wisp %s leaked into ready work: %v", reject, ids)
+		}
 	}
-	if ids[wrongRoute.ID] {
-		t.Fatalf("wrong-route wisp leaked through metadata ready filter: %v", ids)
+
+	ids = readyIDs(true)
+	if !ids[deferred.ID] {
+		t.Fatalf("deferred wisp should be included when IncludeDeferred=true: %v", ids)
+	}
+	if !ids[childOfDeferred.ID] {
+		t.Fatalf("child of deferred parent should be included when IncludeDeferred=true: %v", ids)
+	}
+	if ids[pinned.ID] {
+		t.Fatalf("pinned wisp leaked with IncludeDeferred=true: %v", ids)
+	}
+	if ids[blocked.ID] {
+		t.Fatalf("blocked wisp leaked with IncludeDeferred=true: %v", ids)
 	}
 }

--- a/internal/storage/embeddeddolt/new_methods_test.go
+++ b/internal/storage/embeddeddolt/new_methods_test.go
@@ -271,3 +271,70 @@ func TestGetReadyWorkMoleculeFilter(t *testing.T) {
 		}
 	})
 }
+
+func TestGetReadyWorkIncludeEphemeralAppliesWispFilters(t *testing.T) {
+	skipUnlessEmbeddedDolt(t)
+
+	te := newTestEnv(t, "rwf")
+	ctx := t.Context()
+
+	matching := &types.Issue{
+		ID:        "rwf-wisp-filter-match",
+		Title:     "Matching routed wisp",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+		Metadata:  []byte(`{"gc.routed_to":"beads/workflows.kimi"}`),
+	}
+	assigned := &types.Issue{
+		ID:        "rwf-wisp-filter-assigned",
+		Title:     "Assigned routed wisp",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+		Assignee:  "beads--control-dispatcher",
+		Ephemeral: true,
+		Metadata:  []byte(`{"gc.routed_to":"beads/workflows.kimi"}`),
+	}
+	wrongRoute := &types.Issue{
+		ID:        "rwf-wisp-filter-wrong-route",
+		Title:     "Wrong routed wisp",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+		Metadata:  []byte(`{"gc.routed_to":"beads/workflows.codex-max"}`),
+	}
+	for _, issue := range []*types.Issue{matching, assigned, wrongRoute} {
+		if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue(%s): %v", issue.ID, err)
+		}
+	}
+
+	ready, err := te.store.GetReadyWork(ctx, types.WorkFilter{
+		Status:           types.StatusOpen,
+		Unassigned:       true,
+		IncludeEphemeral: true,
+		MetadataFields: map[string]string{
+			"gc.routed_to": "beads/workflows.kimi",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetReadyWork: %v", err)
+	}
+
+	ids := make(map[string]bool, len(ready))
+	for _, issue := range ready {
+		ids[issue.ID] = true
+	}
+	if !ids[matching.ID] {
+		t.Fatalf("matching wisp missing from ready work: %v", ids)
+	}
+	if ids[assigned.ID] {
+		t.Fatalf("assigned wisp leaked through unassigned ready filter: %v", ids)
+	}
+	if ids[wrongRoute.ID] {
+		t.Fatalf("wrong-route wisp leaked through metadata ready filter: %v", ids)
+	}
+}

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -52,23 +52,11 @@ func GetReadyWorkInTx(
 		whereClauses = append(whereClauses, "id IN (SELECT id FROM issues WHERE issue_type = ?)")
 		args = append(args, filter.Type)
 	} else {
-		excludeTypes := []string{"merge-request", "gate", "molecule", "message", "agent", "role", "rig"}
-		seen := make(map[string]bool, len(excludeTypes)+len(filter.ExcludeTypes))
-		for _, t := range excludeTypes {
-			seen[t] = true
-		}
-		for _, t := range filter.ExcludeTypes {
-			s := string(t)
-			if s == "" || seen[s] {
-				continue
-			}
-			seen[s] = true
-			excludeTypes = append(excludeTypes, s)
-		}
+		excludeTypes := readyWorkExcludeTypes(filter.ExcludeTypes)
 		placeholders := make([]string, len(excludeTypes))
 		for i, t := range excludeTypes {
 			placeholders[i] = "?"
-			args = append(args, t)
+			args = append(args, string(t))
 		}
 		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT id FROM issues WHERE issue_type NOT IN (%s))", strings.Join(placeholders, ",")))
 	}
@@ -290,12 +278,7 @@ func GetReadyWorkInTx(
 
 	// When IncludeEphemeral is set, also query the wisps table.
 	if filter.IncludeEphemeral {
-		ephTrue := true
-		wispFilter := types.IssueFilter{Limit: filter.Limit, Ephemeral: &ephTrue}
-		if filter.Status != "" {
-			s := filter.Status
-			wispFilter.Status = &s
-		}
+		wispFilter := readyWorkWispIssueFilter(filter)
 		wisps, wErr := SearchIssuesInTx(ctx, tx, "", wispFilter)
 		if wErr != nil {
 			return nil, fmt.Errorf("search wisps (ready work): %w", wErr)
@@ -304,6 +287,70 @@ func GetReadyWorkInTx(
 	}
 
 	return ordered, nil
+}
+
+func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
+	excludeTypes := []types.IssueType{
+		types.IssueType("merge-request"),
+		types.TypeGate,
+		types.TypeMolecule,
+		types.TypeMessage,
+		types.IssueType("agent"),
+		types.IssueType("role"),
+		types.IssueType("rig"),
+	}
+	seen := make(map[types.IssueType]bool, len(excludeTypes)+len(extra))
+	for _, t := range excludeTypes {
+		seen[t] = true
+	}
+	for _, t := range extra {
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		excludeTypes = append(excludeTypes, t)
+	}
+	return excludeTypes
+}
+
+func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
+	ephTrue := true
+	wispFilter := types.IssueFilter{
+		Priority:       filter.Priority,
+		Labels:         filter.Labels,
+		LabelsAny:      filter.LabelsAny,
+		ExcludeLabels:  filter.ExcludeLabels,
+		Limit:          filter.Limit,
+		MolType:        filter.MolType,
+		WispType:       filter.WispType,
+		Ephemeral:      &ephTrue,
+		MetadataFields: filter.MetadataFields,
+		HasMetadataKey: filter.HasMetadataKey,
+	}
+	if filter.Status != "" {
+		s := filter.Status
+		wispFilter.Status = &s
+	} else {
+		wispFilter.Statuses = []types.Status{types.StatusOpen, types.StatusInProgress}
+	}
+	if filter.Type != "" {
+		t := types.IssueType(filter.Type)
+		wispFilter.IssueType = &t
+	} else {
+		wispFilter.ExcludeTypes = readyWorkExcludeTypes(filter.ExcludeTypes)
+	}
+	if filter.Unassigned {
+		wispFilter.NoAssignee = true
+	} else if filter.Assignee != nil {
+		wispFilter.Assignee = filter.Assignee
+	}
+	if filter.MoleculeID != "" {
+		moleculeID := filter.MoleculeID
+		wispFilter.ParentID = &moleculeID
+	} else if filter.ParentID != nil {
+		wispFilter.ParentID = filter.ParentID
+	}
+	return wispFilter
 }
 
 func readyWorkPageSize(limit int) int {

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -279,11 +279,21 @@ func GetReadyWorkInTx(
 	// When IncludeEphemeral is set, also query the wisps table.
 	if filter.IncludeEphemeral {
 		wispFilter := readyWorkWispIssueFilter(filter)
+		// Ready-only wisp predicates are applied after search, so avoid limiting
+		// before that filtering can drop non-ready candidates.
+		wispFilter.Limit = 0
 		wisps, wErr := SearchIssuesInTx(ctx, tx, "", wispFilter)
 		if wErr != nil {
 			return nil, fmt.Errorf("search wisps (ready work): %w", wErr)
 		}
+		wisps, wErr = filterReadyWispsInTx(ctx, tx, filter, wisps)
+		if wErr != nil {
+			return nil, wErr
+		}
 		ordered = append(ordered, wisps...)
+		if filter.Limit > 0 && len(ordered) > filter.Limit {
+			ordered = ordered[:filter.Limit]
+		}
 	}
 
 	return ordered, nil
@@ -315,6 +325,7 @@ func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
 
 func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
 	ephTrue := true
+	pinnedFalse := false
 	wispFilter := types.IssueFilter{
 		Priority:       filter.Priority,
 		Labels:         filter.Labels,
@@ -324,6 +335,7 @@ func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
 		MolType:        filter.MolType,
 		WispType:       filter.WispType,
 		Ephemeral:      &ephTrue,
+		Pinned:         &pinnedFalse,
 		MetadataFields: filter.MetadataFields,
 		HasMetadataKey: filter.HasMetadataKey,
 	}
@@ -347,10 +359,83 @@ func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
 	if filter.MoleculeID != "" {
 		moleculeID := filter.MoleculeID
 		wispFilter.ParentID = &moleculeID
-	} else if filter.ParentID != nil {
-		wispFilter.ParentID = filter.ParentID
 	}
 	return wispFilter
+}
+
+func filterReadyWispsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter, wisps []*types.Issue) ([]*types.Issue, error) {
+	if len(wisps) == 0 {
+		return wisps, nil
+	}
+
+	wispIDs := make([]string, 0, len(wisps))
+	for _, wisp := range wisps {
+		wispIDs = append(wispIDs, wisp.ID)
+	}
+
+	excluded := make(map[string]struct{})
+	if filter.ParentID != nil {
+		parentID := *filter.ParentID
+		descendantIDs, err := GetDescendantIDsInTx(ctx, tx, parentID, 0)
+		if err != nil {
+			return nil, fmt.Errorf("get wisp parent descendants: %w", err)
+		}
+		descendantSet := make(map[string]struct{}, len(descendantIDs))
+		for _, id := range descendantIDs {
+			descendantSet[id] = struct{}{}
+		}
+		parentedSet, err := getParentedIDSetInTx(ctx, tx, wispIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, wisp := range wisps {
+			if _, ok := descendantSet[wisp.ID]; ok {
+				continue
+			}
+			if strings.HasPrefix(wisp.ID, parentID+".") {
+				if _, hasParent := parentedSet[wisp.ID]; !hasParent {
+					continue
+				}
+			}
+			excluded[wisp.ID] = struct{}{}
+		}
+	}
+
+	if !filter.IncludeDeferred {
+		now := time.Now().UTC()
+		for _, wisp := range wisps {
+			if wisp.DeferUntil != nil && wisp.DeferUntil.After(now) {
+				excluded[wisp.ID] = struct{}{}
+			}
+		}
+		deferredChildIDs, err := getChildrenOfDeferredParentsInTx(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range deferredChildIDs {
+			excluded[id] = struct{}{}
+		}
+	}
+
+	blockedIDs, err := ComputeBlockedCandidateIDsInTx(ctx, tx, wispIDs, true)
+	if err != nil {
+		return nil, fmt.Errorf("get ready work: filter blocked wisps: %w", err)
+	}
+	for _, id := range blockedIDs {
+		excluded[id] = struct{}{}
+	}
+
+	ready := wisps[:0]
+	for _, wisp := range wisps {
+		if wisp.Pinned {
+			continue
+		}
+		if _, skip := excluded[wisp.ID]; skip {
+			continue
+		}
+		ready = append(ready, wisp)
+	}
+	return ready, nil
 }
 
 func readyWorkPageSize(limit int) int {
@@ -390,25 +475,31 @@ func queryReadyIssueIDPage(ctx context.Context, tx *sql.Tx, query string, args [
 // future defer_until. Works within an existing transaction.
 func getChildrenOfDeferredParentsInTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
 	// Step 1: Get IDs of issues with future defer_until.
-	deferredRows, err := tx.QueryContext(ctx, `
-		SELECT id FROM issues
-		WHERE defer_until IS NOT NULL AND defer_until > UTC_TIMESTAMP()
-	`)
-	if err != nil {
-		return nil, fmt.Errorf("deferred parents: get deferred issues: %w", err)
-	}
 	var deferredIDs []string
-	for deferredRows.Next() {
-		var id string
-		if err := deferredRows.Scan(&id); err != nil {
-			_ = deferredRows.Close()
-			return nil, fmt.Errorf("deferred parents: scan deferred issue: %w", err)
+	for _, issueTable := range []string{"issues", "wisps"} {
+		//nolint:gosec // G201: issueTable is hardcoded to "issues" or "wisps"
+		deferredRows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+			SELECT id FROM %s
+			WHERE defer_until IS NOT NULL AND defer_until > UTC_TIMESTAMP()
+		`, issueTable))
+		if err != nil {
+			if issueTable == "wisps" && isTableNotExistError(err) {
+				break
+			}
+			return nil, fmt.Errorf("deferred parents: get deferred issues from %s: %w", issueTable, err)
 		}
-		deferredIDs = append(deferredIDs, id)
-	}
-	_ = deferredRows.Close()
-	if err := deferredRows.Err(); err != nil {
-		return nil, fmt.Errorf("deferred parents: deferred rows: %w", err)
+		for deferredRows.Next() {
+			var id string
+			if err := deferredRows.Scan(&id); err != nil {
+				_ = deferredRows.Close()
+				return nil, fmt.Errorf("deferred parents: scan deferred issue from %s: %w", issueTable, err)
+			}
+			deferredIDs = append(deferredIDs, id)
+		}
+		_ = deferredRows.Close()
+		if err := deferredRows.Err(); err != nil {
+			return nil, fmt.Errorf("deferred parents: deferred rows from %s: %w", issueTable, err)
+		}
 	}
 	if len(deferredIDs) == 0 {
 		return nil, nil
@@ -416,6 +507,47 @@ func getChildrenOfDeferredParentsInTx(ctx context.Context, tx *sql.Tx) ([]string
 
 	// Step 2: Get children of those deferred parents.
 	return getChildrenOfIssuesInTx(ctx, tx, deferredIDs)
+}
+
+//nolint:gosec // G201: depTable is hardcoded to "dependencies" or "wisp_dependencies"
+func getParentedIDSetInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (map[string]struct{}, error) {
+	parented := make(map[string]struct{})
+	if len(issueIDs) == 0 {
+		return parented, nil
+	}
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		for start := 0; start < len(issueIDs); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(issueIDs) {
+				end = len(issueIDs)
+			}
+			placeholders, args := buildSQLInClause(issueIDs[start:end])
+			query := fmt.Sprintf(`
+				SELECT issue_id FROM %s
+				WHERE type = 'parent-child' AND issue_id IN (%s)
+			`, depTable, placeholders)
+			rows, err := tx.QueryContext(ctx, query, args...)
+			if err != nil {
+				if depTable == "wisp_dependencies" && isTableNotExistError(err) {
+					break
+				}
+				return nil, fmt.Errorf("get parented IDs from %s: %w", depTable, err)
+			}
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("get parented IDs: scan: %w", err)
+				}
+				parented[id] = struct{}{}
+			}
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("get parented IDs: rows from %s: %w", depTable, err)
+			}
+		}
+	}
+	return parented, nil
 }
 
 // getChildrenOfIssuesInTx returns IDs of direct children (parent-child deps)


### PR DESCRIPTION
## Summary

Fixes a ready-work filter parity bug in `GetReadyWorkInTx` when callers use `IncludeEphemeral`.

The permanent `issues` query already applied the full `WorkFilter` surface, including:

- `Unassigned` / `Assignee`
- `MetadataFields` / `HasMetadataKey`
- label and exclude-label filters
- type and exclude-type filters
- priority, molecule, parent, mol type, and wisp type filters

But the `IncludeEphemeral` append path built a fresh wisp-side `IssueFilter` with only `Limit`, `Ephemeral=true`, and `Status`. As a result, commands like:

```bash
bd ready --include-ephemeral \
  --metadata-field gc.routed_to=beads/workflows.kimi \
  --unassigned --json --limit=10
```

could return assigned wisps or wisps routed to other workflow lanes.

## Root Cause

This is not a new regression from the latest ready perf work. `git blame` shows the lossy wisp filter path dates back to the March 19 shared `issueops.GetReadyWorkInTx` extraction:

- `2119ce928` introduced the `IncludeEphemeral` wisp append path.
- `ceae18d96` added `Ephemeral=true`, but still only carried `Limit` and `Status`.
- Later ready/list correctness fixes covered the permanent `issues` query path, not wisp filter parity.
- The May 16 ready paging perf change touched nearby code but did not introduce this filter loss.

We noticed it now because Gas City workflow routing relies on routed ephemeral wisps and calls `bd ready --include-ephemeral --metadata-field gc.routed_to=... --unassigned` as a hot path. The missing filters caused workers to see already-assigned control-dispatcher wisps and wrong-route wisps.

## Fix

- Extracted `readyWorkExcludeTypes` so both permanent and wisp ready paths share the same default plus user-provided exclude-type semantics.
- Added `readyWorkWispIssueFilter` to translate `WorkFilter` into an `IssueFilter` without dropping route, assignment, label, metadata, type, priority, molecule, or parent constraints.
- Added an embedded-Dolt regression test that creates three ephemeral wisps:
  - matching route and unassigned
  - matching route but assigned
  - unassigned but wrong route

The test proves only the matching unassigned/routed wisp is returned.

## Validation

```bash
go test ./internal/storage/issueops -count=1
BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh ./internal/storage/embeddeddolt -run '^TestGetReadyWorkIncludeEphemeralAppliesWispFilters$' -count=1
BEADS_TEST_EMBEDDED_DOLT=1 ./scripts/test.sh ./internal/storage/embeddeddolt -run 'TestGetReadyWork|TestListWisps' -count=1
go build -tags gms_pure_go -ldflags="-X main.Build=$(git rev-parse --short HEAD)" -o /tmp/bd-ready-wisp-filter-main ./cmd/bd
```

Also validated against the live Beads/Gas City repos with a local build before install: routed `bd ready --include-ephemeral --metadata-field ... --unassigned` no longer returned assigned or wrong-route wisps.

## Known Existing Test Noise

A broad `go test ./cmd/bd -run '^Test.*Ready|Test.*Metadata' -count=1` still hits pre-existing Dolt-server harness failures where the test database lacks the `wisps` table. That predates this change and is unrelated to the ready wisp filter translation fixed here.
