### PR TITLE
fix(doctor): use repoPath for archive size stat (be-qqggak)

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -143,8 +143,26 @@ var configSetCmd = &cobra.Command{
 		// These must be written to config.yaml, not SQLite, because they're read
 		// before the database is opened. (GH#536)
 		if config.IsYamlOnlyKey(key) {
-			if err := config.SetYamlConfig(key, value); err != nil {
-				fmt.Fprintf(os.Stderr, "Error setting config: %v\n", err)
+			// export.auto and archive.format go through the alias layer so
+			// they stay in sync and the deprecation warning is surfaced.
+			var setErr error
+			if key == "export.auto" || key == "archive.format" {
+				setErr = config.SetArchiveFormat(key, value)
+				// Normalise reported key/value to the canonical form.
+				if key == "export.auto" {
+					key = "archive.format"
+					switch value {
+					case "true", "1", "yes":
+						value = config.ArchiveFormatJSONL
+					default:
+						value = config.ArchiveFormatNone
+					}
+				}
+			} else {
+				setErr = config.SetYamlConfig(key, value)
+			}
+			if setErr != nil {
+				fmt.Fprintf(os.Stderr, "Error setting config: %v\n", setErr)
 				os.Exit(1)
 			}
 
@@ -230,7 +248,20 @@ var configGetCmd = &cobra.Command{
 		// Check if this is a yaml-only key (startup settings)
 		// These are read from config.yaml via viper, not SQLite. (GH#536)
 		if config.IsYamlOnlyKey(key) {
-			value := config.GetYamlConfig(key)
+			var value string
+			if key == "export.auto" {
+				// Resolve via the archive alias layer so callers see the
+				// canonical value and receive the deprecation notice on stderr.
+				resolved := config.ResolveArchiveFormat()
+				switch resolved {
+				case config.ArchiveFormatJSONL:
+					value = "true"
+				default:
+					value = "false"
+				}
+			} else {
+				value = config.GetYamlConfig(key)
+			}
 
 			if jsonOutput {
 				outputJSON(map[string]interface{}{

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -251,8 +251,12 @@ var configGetCmd = &cobra.Command{
 			var value string
 			if key == "export.auto" {
 				// Resolve via the archive alias layer so callers see the
-				// canonical value and receive the deprecation notice on stderr.
-				resolved := config.ResolveArchiveFormat()
+				// canonical value; print the deprecation notice here at the
+				// call site where user-visible output is expected.
+				resolved, warn := config.ResolveArchiveFormat()
+				if warn != "" {
+					fmt.Fprint(os.Stderr, warn)
+				}
 				switch resolved {
 				case config.ArchiveFormatJSONL:
 					value = "true"

--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -519,6 +519,14 @@ func runDiagnostics(path string) doctorResult {
 	result.Checks = append(result.Checks, configValuesCheck)
 	// Don't fail overall check for config value warnings, just warn
 
+	// Check 7a2: Archive configuration status (be-tsjke3)
+	archiveCheck := convertWithCategory(doctor.CheckArchiveConfig(path), doctor.CategoryData)
+	result.Checks = append(result.Checks, archiveCheck)
+	if archiveCheck.Status == statusWarning {
+		result.OverallOK = false
+	}
+	// StatusOK and disabled archive are informational — no overall failure
+
 	// Check 7a1: Project identity (GH#2372 backfill)
 	projectIDCheck := convertWithCategory(doctor.CheckProjectIdentityWithStore(sharedStore, path), doctor.CategoryData)
 	result.Checks = append(result.Checks, projectIDCheck)

--- a/cmd/bd/doctor/archive.go
+++ b/cmd/bd/doctor/archive.go
@@ -75,7 +75,7 @@ func CheckArchiveConfig(repoPath string) DoctorCheck {
 	}
 
 	// Probe the archive file for its size.
-	fullPath := filepath.Join(beadsDir, archivePath)
+	fullPath := filepath.Join(repoPath, archivePath)
 	var sizeStr string
 	if fi, err := os.Stat(fullPath); err == nil {
 		sizeStr = humanBytes(fi.Size())

--- a/cmd/bd/doctor/archive.go
+++ b/cmd/bd/doctor/archive.go
@@ -1,0 +1,127 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// exportAutoStateSnapshot is a minimal view of export-state.json used to show
+// the archive last-run timestamp and issue count in bd doctor output.
+type exportAutoStateSnapshot struct {
+	Timestamp time.Time `json:"timestamp"`
+	Issues    int       `json:"issues"`
+}
+
+// CheckArchiveConfig reports the current archive configuration as a doctor
+// check. A disabled archive (format=none) is shown as OK — disabled is a
+// deliberate choice, not an error. StatusWarning is returned only when the
+// deprecated export.auto key is present without archive.* migration.
+func CheckArchiveConfig(repoPath string) DoctorCheck {
+	beadsDir := ResolveBeadsDirForRepo(repoPath)
+	configPath := filepath.Join(beadsDir, "config.yaml")
+
+	v := viper.New()
+	v.SetConfigFile(configPath)
+	_ = v.ReadInConfig()
+
+	hasArchiveFormat := v.IsSet("archive.format")
+	hasExportAuto := v.IsSet("export.auto")
+
+	// Deprecation warning: export.auto present without archive.* migration.
+	if hasExportAuto && !hasArchiveFormat {
+		return DoctorCheck{
+			Name:    "Archive",
+			Status:  StatusWarning,
+			Message: "deprecated key 'export.auto' found without archive.* — migrate with:",
+			Fix:     "bd config set archive.format jsonl",
+		}
+	}
+
+	format := v.GetString("archive.format")
+	if format == "" {
+		// Unset — derive from export.auto for display when present, else none.
+		if hasExportAuto {
+			if v.GetBool("export.auto") {
+				format = "jsonl"
+			} else {
+				format = "none"
+			}
+		} else {
+			format = "none"
+		}
+	}
+
+	if format == "none" {
+		return DoctorCheck{
+			Name:    "Archive",
+			Status:  StatusOK,
+			Message: "none (disabled)",
+		}
+	}
+
+	// Enabled: show path, throttle, and last-run stats.
+	archivePath := v.GetString("archive.path")
+	if archivePath == "" {
+		archivePath = ".beads/issues.jsonl"
+	}
+	throttle := v.GetInt("archive.throttle_seconds")
+	if throttle == 0 {
+		throttle = 60
+	}
+
+	// Probe the archive file for its size.
+	fullPath := filepath.Join(beadsDir, archivePath)
+	var sizeStr string
+	if fi, err := os.Stat(fullPath); err == nil {
+		sizeStr = humanBytes(fi.Size())
+	}
+
+	// Read the last-run state file.
+	var lastRunStr string
+	stateData, err := os.ReadFile(filepath.Join(beadsDir, "export-state.json")) //nolint:gosec
+	if err == nil {
+		var snap exportAutoStateSnapshot
+		if json.Unmarshal(stateData, &snap) == nil && !snap.Timestamp.IsZero() {
+			ago := time.Since(snap.Timestamp).Round(time.Second)
+			lastRunStr = fmt.Sprintf("%s (%s ago)", snap.Timestamp.Format(time.RFC3339), ago)
+		}
+	}
+
+	message := fmt.Sprintf("%s — %s, %ds throttle", format, archivePath, throttle)
+	detail := ""
+	if lastRunStr != "" || sizeStr != "" {
+		if lastRunStr != "" && sizeStr != "" {
+			detail = fmt.Sprintf("last run: %s · size: %s", lastRunStr, sizeStr)
+		} else if lastRunStr != "" {
+			detail = "last run: " + lastRunStr
+		} else {
+			detail = "size: " + sizeStr
+		}
+	}
+
+	return DoctorCheck{
+		Name:    "Archive",
+		Status:  StatusOK,
+		Message: message,
+		Detail:  detail,
+	}
+}
+
+// humanBytes formats a byte count as a human-readable string (KB, MB, GB).
+func humanBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1307,6 +1307,34 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
+		// Write archive.* config keys for the active backend so the archive
+		// subsystem knows its format, path, and throttle from the very first run.
+		// Dolt: jsonl at .beads/issues.jsonl, 60s throttle.
+		// Other backends: disabled (format=none).
+		archiveFmt := config.ArchiveDefaultForBackend(backend)
+		archiveWriteErrs := false
+		if err := config.SetYamlConfig("archive.format", archiveFmt); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write archive.format: %v\n", err)
+			archiveWriteErrs = true
+		}
+		if archiveFmt == config.ArchiveFormatJSONL {
+			if err := config.SetYamlConfig("archive.path", ".beads/issues.jsonl"); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to write archive.path: %v\n", err)
+				archiveWriteErrs = true
+			}
+		}
+		if err := config.SetYamlConfig("archive.throttle_seconds", "60"); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to write archive.throttle_seconds: %v\n", err)
+			archiveWriteErrs = true
+		}
+		if !quiet && !archiveWriteErrs {
+			if archiveFmt == config.ArchiveFormatJSONL {
+				fmt.Printf("  %s Archive enabled (.beads/issues.jsonl — git-tracked, 60s throttle)\n", ui.RenderPass("✓"))
+			} else {
+				fmt.Printf("  %s Archive disabled — enable: bd config set archive.format jsonl\n", ui.RenderPass("✓"))
+			}
+		}
+
 		// Check if we're in a git repo and hooks aren't installed
 		// Install by default unless --skip-hooks is passed
 		// Hooks are installed to .beads/hooks/ (uses git config core.hooksPath)

--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -6,31 +6,31 @@ import (
 	"strings"
 )
 
-// ResolveArchiveFormat returns the effective archive format for the current workspace.
+// ResolveArchiveFormat returns the effective archive format for the current
+// workspace, and a non-empty warningMsg when the value was resolved via the
+// deprecated export.auto alias.
 //
 // Resolution order:
 //  1. archive.format in config.yaml — the canonical key.
-//  2. export.auto in config.yaml — the deprecated alias. When found, a
-//     deprecation notice is printed to stderr and the translated value is
-//     returned without mutating config on disk (read-only resolution).
+//  2. export.auto in config.yaml — the deprecated alias. When found,
+//     warningMsg is set; the caller decides whether and where to print it.
 //
 // Returns ArchiveFormatNone when neither key is set.
-func ResolveArchiveFormat() string {
-	if format, err := GetArchiveFormat(); err == nil && format != "" {
-		return format
+func ResolveArchiveFormat() (format string, warningMsg string) {
+	if f, err := GetArchiveFormat(); err == nil && f != "" {
+		return f, ""
 	}
 	// Fall back to export.auto alias.
 	raw := GetYamlConfig("export.auto")
 	if raw == "" {
-		return ArchiveFormatNone
+		return ArchiveFormatNone, ""
 	}
-	fmt.Fprintf(os.Stderr,
-		"⚠ Deprecated config key 'export.auto' — migrate: bd config set archive.format jsonl\n")
+	msg := "⚠ Deprecated config key 'export.auto' — migrate: bd config set archive.format jsonl\n"
 	switch strings.ToLower(raw) {
 	case "true", "1", "yes":
-		return ArchiveFormatJSONL
+		return ArchiveFormatJSONL, msg
 	default:
-		return ArchiveFormatNone
+		return ArchiveFormatNone, msg
 	}
 }
 

--- a/internal/config/alias.go
+++ b/internal/config/alias.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ResolveArchiveFormat returns the effective archive format for the current workspace.
+//
+// Resolution order:
+//  1. archive.format in config.yaml — the canonical key.
+//  2. export.auto in config.yaml — the deprecated alias. When found, a
+//     deprecation notice is printed to stderr and the translated value is
+//     returned without mutating config on disk (read-only resolution).
+//
+// Returns ArchiveFormatNone when neither key is set.
+func ResolveArchiveFormat() string {
+	if format, err := GetArchiveFormat(); err == nil && format != "" {
+		return format
+	}
+	// Fall back to export.auto alias.
+	raw := GetYamlConfig("export.auto")
+	if raw == "" {
+		return ArchiveFormatNone
+	}
+	fmt.Fprintf(os.Stderr,
+		"⚠ Deprecated config key 'export.auto' — migrate: bd config set archive.format jsonl\n")
+	switch strings.ToLower(raw) {
+	case "true", "1", "yes":
+		return ArchiveFormatJSONL
+	default:
+		return ArchiveFormatNone
+	}
+}
+
+// SetArchiveFormat writes the archive format config key, handling the
+// export.auto → archive.format backwards-compat alias.
+//
+//   - key == "export.auto": translates "true"/"false" to "jsonl"/"none",
+//     writes archive.format, and prints a deprecation notice to stderr.
+//   - key == "archive.format": validates and writes directly.
+//
+// Any other key is rejected.
+func SetArchiveFormat(key, value string) error {
+	switch key {
+	case "export.auto":
+		fmt.Fprintf(os.Stderr,
+			"⚠ 'export.auto' is deprecated — writing 'archive.format' instead.\n"+
+				"  Migrate with: bd config set archive.format jsonl\n")
+		switch strings.ToLower(value) {
+		case "true", "1", "yes":
+			value = ArchiveFormatJSONL
+		default:
+			value = ArchiveFormatNone
+		}
+		return SetYamlConfig("archive.format", value)
+	case "archive.format":
+		return SetYamlConfig("archive.format", value)
+	default:
+		return fmt.Errorf("SetArchiveFormat: unexpected key %q", key)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -983,6 +983,46 @@ func ValidateAgentsFile(filename string) error {
 	return nil
 }
 
+// Archive format constants for the archive.format config key.
+const (
+	ArchiveFormatJSONL = "jsonl"
+	ArchiveFormatNone  = "none"
+)
+
+// ArchiveDefaultForBackend returns the appropriate archive.format default for the
+// named storage backend: "jsonl" for "dolt" (archive is git-tracked alongside the
+// repo), "none" for all other backends.
+func ArchiveDefaultForBackend(driverName string) string {
+	if driverName == "dolt" {
+		return ArchiveFormatJSONL
+	}
+	return ArchiveFormatNone
+}
+
+// ValidateArchiveFormat returns an error when format is not "jsonl" or "none".
+func ValidateArchiveFormat(format string) error {
+	switch format {
+	case ArchiveFormatJSONL, ArchiveFormatNone:
+		return nil
+	default:
+		return fmt.Errorf("archive.format must be %q or %q, got %q", ArchiveFormatJSONL, ArchiveFormatNone, format)
+	}
+}
+
+// GetArchiveFormat reads archive.format from config and validates it.
+// Returns ("", nil) when the key is unset; the caller should call
+// ArchiveDefaultForBackend to determine the effective value.
+func GetArchiveFormat() (string, error) {
+	format := GetString("archive.format")
+	if format == "" {
+		return "", nil
+	}
+	if err := ValidateArchiveFormat(format); err != nil {
+		return "", err
+	}
+	return format, nil
+}
+
 // getConfigList retrieves a list-typed configuration value from config.yaml,
 // accepting either the YAML list form (e.g. `types: { custom: [step, wisp] }`)
 // or the legacy comma-separated string form (e.g.

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -89,7 +89,7 @@ func IsYamlOnlyKey(key string) bool {
 	}
 
 	// Check prefix matches for nested keys
-	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "backup.", "export.", "dolt.", "federation."}
+	prefixes := []string{"routing.", "sync.", "git.", "directory.", "repos.", "external_projects.", "validation.", "hierarchy.", "ai.", "backup.", "export.", "archive.", "dolt.", "federation."}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(key, prefix) {
 			return true
@@ -529,6 +529,10 @@ func validateYamlConfigValue(key, value string) error {
 		lower := strings.ToLower(value)
 		if lower != "true" && lower != "false" {
 			return fmt.Errorf("dolt.debug must be \"true\" or \"false\", got %q", value)
+		}
+	case "archive.format":
+		if err := ValidateArchiveFormat(value); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- `CheckArchiveConfig` in `cmd/bd/doctor/archive.go` computed `fullPath` as `filepath.Join(beadsDir, archivePath)`, but `archivePath` defaults to `.beads/issues.jsonl` (relative to repo root)
- Since `beadsDir` IS `.beads/`, this double-nests to `/repo/.beads/.beads/issues.jsonl`, which never exists
- `os.Stat` always failed silently, so the `size:` line never appeared in `bd doctor` output
- Fix: use `filepath.Join(repoPath, archivePath)` — `repoPath` is the parameter already passed into `CheckArchiveConfig`

Closes be-qqggak. Found during review of be-i6lh5q (be-6lydih, be-tsjke3).

## Test plan

- [ ] Build passes: `CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd/doctor/...`
- [ ] `bd doctor` output now shows `size:` line for repos with archive enabled
- [ ] `TestCheckBeadsRole_*` failures are pre-existing (unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)