### PR TITLE
feat(schema): schema-stale guard + bd migrate schema subcommand (be-o7fh35, be-gudo26, be-l4z4xw)

### DIFF
--- a/beads_cgo.go
+++ b/beads_cgo.go
@@ -34,7 +34,7 @@ func OpenBestAvailable(ctx context.Context, beadsDir string) (Storage, error) {
 	if cfg != nil {
 		database = cfg.GetDoltDatabase()
 	}
-	store, err := embeddeddolt.Open(ctx, beadsDir, database, "main")
+	store, err := embeddeddolt.Open(ctx, beadsDir, database, "main", false)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -527,7 +527,7 @@ func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		CreateIfMissing: true,
 		AutoStart:       true,
 		BeadsDir:        plan.BeadsDir,
-	}, true)
+	}, true, false)
 	if err != nil {
 		return fmt.Errorf("create database: %w", err)
 	}
@@ -554,7 +554,7 @@ func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfi
 		CreateIfMissing: true,
 		AutoStart:       true,
 		BeadsDir:        plan.BeadsDir,
-	}, true)
+	}, true, false)
 	if err != nil {
 		return fmt.Errorf("create database: %w", err)
 	}
@@ -585,7 +585,7 @@ func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *conf
 		CreateIfMissing: true,
 		AutoStart:       true,
 		BeadsDir:        plan.BeadsDir,
-	}, true)
+	}, true, false)
 	if err != nil {
 		return fmt.Errorf("create database: %w", err)
 	}

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -527,7 +527,7 @@ func executeInitAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 		CreateIfMissing: true,
 		AutoStart:       true,
 		BeadsDir:        plan.BeadsDir,
-	})
+	}, true)
 	if err != nil {
 		return fmt.Errorf("create database: %w", err)
 	}
@@ -554,7 +554,7 @@ func executeRestoreAction(ctx context.Context, plan BootstrapPlan, cfg *configfi
 		CreateIfMissing: true,
 		AutoStart:       true,
 		BeadsDir:        plan.BeadsDir,
-	})
+	}, true)
 	if err != nil {
 		return fmt.Errorf("create database: %w", err)
 	}
@@ -585,7 +585,7 @@ func executeJSONLImportAction(ctx context.Context, plan BootstrapPlan, cfg *conf
 		CreateIfMissing: true,
 		AutoStart:       true,
 		BeadsDir:        plan.BeadsDir,
-	})
+	}, true)
 	if err != nil {
 		return fmt.Errorf("create database: %w", err)
 	}

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -908,7 +908,7 @@ func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore s
 				BeadsDir:        beadsDir,
 				Database:        dbName,
 				CreateIfMissing: true,
-			})
+			}, true)
 			if err != nil {
 				return fmt.Errorf("failed to initialize target database: %w", err)
 			}

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -908,7 +908,7 @@ func ensureBeadsDirForPath(ctx context.Context, targetPath string, sourceStore s
 				BeadsDir:        beadsDir,
 				Database:        dbName,
 				CreateIfMissing: true,
-			}, true)
+			}, true, false)
 			if err != nil {
 				return fmt.Errorf("failed to initialize target database: %w", err)
 			}

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -96,7 +96,7 @@ func bdShow(t *testing.T, bd, dir, id string) *types.Issue {
 // openStore opens an EmbeddedDoltStore for direct verification queries.
 func openStore(t *testing.T, beadsDir, database string) *embeddeddolt.EmbeddedDoltStore {
 	t.Helper()
-	store, err := embeddeddolt.Open(t.Context(), beadsDir, database, "main")
+	store, err := embeddeddolt.Open(t.Context(), beadsDir, database, "main", true)
 	if err != nil {
 		t.Fatalf("openStore: %v", err)
 	}

--- a/cmd/bd/diff_embedded_test.go
+++ b/cmd/bd/diff_embedded_test.go
@@ -67,7 +67,7 @@ func bdDiffJSON(t *testing.T, bd, dir string, args ...string) []map[string]inter
 // bd subprocess commands to acquire it.
 func getCommitHash(t *testing.T, beadsDir, database string) string {
 	t.Helper()
-	s, err := embeddeddolt.Open(t.Context(), beadsDir, database, "main")
+	s, err := embeddeddolt.Open(t.Context(), beadsDir, database, "main", true)
 	if err != nil {
 		t.Fatalf("openStore for getCommitHash: %v", err)
 	}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -815,7 +815,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
-		store, err := newDoltStore(ctx, doltCfg)
+		store, err := newDoltStore(ctx, doltCfg, true)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to open Dolt store: %v\n", err)
 			os.Exit(1)
@@ -2114,7 +2114,7 @@ func initGlobalDatabaseConfig(ctx context.Context, projectCfg *dolt.Config, quie
 		AutoStart:       false, // server is already running
 	}
 
-	globalStore, err := newDoltStore(ctx, globalCfg)
+	globalStore, err := newDoltStore(ctx, globalCfg, true)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to open global database: %v\n", err)
 		return

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -815,7 +815,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
-		store, err := newDoltStore(ctx, doltCfg, true)
+		store, err := newDoltStore(ctx, doltCfg, true, false)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to open Dolt store: %v\n", err)
 			os.Exit(1)
@@ -2114,7 +2114,7 @@ func initGlobalDatabaseConfig(ctx context.Context, projectCfg *dolt.Config, quie
 		AutoStart:       false, // server is already running
 	}
 
-	globalStore, err := newDoltStore(ctx, globalCfg, true)
+	globalStore, err := newDoltStore(ctx, globalCfg, true, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to open global database: %v\n", err)
 		return

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -205,7 +205,7 @@ func readBackOnce(t *testing.T, beadsDir, database, key string, metadata bool) (
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	store, err := embeddeddolt.Open(ctx, beadsDir, database, "main")
+	store, err := embeddeddolt.Open(ctx, beadsDir, database, "main", true)
 	if err != nil {
 		return "", fmt.Errorf("New failed: %w", err)
 	}
@@ -824,7 +824,7 @@ func TestEmbeddedInit(t *testing.T) {
 		func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
-			store, err := embeddeddolt.Open(ctx, beadsDir, "meta", "main")
+			store, err := embeddeddolt.Open(ctx, beadsDir, "meta", "main", true)
 			if err != nil {
 				t.Fatalf("failed to open store for bd_version check: %v", err)
 			}

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1009,7 +1009,10 @@ var rootCmd = &cobra.Command{
 		// Removing them WILL cause unrecoverable data corruption and data loss.
 		// Dolt manages these files itself; external interference is never safe.
 
-		store, err = newDoltStore(rootCtx, doltCfg, false)
+		// bd migrate schema must open with autoMigrate=true — the schema guard
+		// would otherwise block it before it can run, creating a circular failure.
+		autoMigrateForCmd := cmd.Name() == "schema" && cmd.Parent() != nil && cmd.Parent().Name() == "migrate"
+		store, err = newDoltStore(rootCtx, doltCfg, autoMigrateForCmd)
 
 		// Track final read-only state for staleness checks (GH#1089)
 		storeIsReadOnly = doltCfg.ReadOnly

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1009,7 +1009,7 @@ var rootCmd = &cobra.Command{
 		// Removing them WILL cause unrecoverable data corruption and data loss.
 		// Dolt manages these files itself; external interference is never safe.
 
-		store, err = newDoltStore(rootCtx, doltCfg)
+		store, err = newDoltStore(rootCtx, doltCfg, false)
 
 		// Track final read-only state for staleness checks (GH#1089)
 		storeIsReadOnly = doltCfg.ReadOnly

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1009,10 +1009,10 @@ var rootCmd = &cobra.Command{
 		// Removing them WILL cause unrecoverable data corruption and data loss.
 		// Dolt manages these files itself; external interference is never safe.
 
-		// bd migrate schema must open with autoMigrate=true — the schema guard
-		// would otherwise block it before it can run, creating a circular failure.
-		autoMigrateForCmd := cmd.Name() == "schema" && cmd.Parent() != nil && cmd.Parent().Name() == "migrate"
-		store, err = newDoltStore(rootCtx, doltCfg, autoMigrateForCmd)
+		// 'bd migrate schema' skips schema init entirely so MigrateSchemaUp can
+		// apply pending migrations and report the correct count. Pointer comparison
+		// (cmd == migrateSchemaCmd) is immune to renames unlike string comparison.
+		store, err = newDoltStore(rootCtx, doltCfg, false, cmd == migrateSchemaCmd)
 
 		// Track final read-only state for staleness checks (GH#1089)
 		storeIsReadOnly = doltCfg.ReadOnly

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -657,7 +657,7 @@ Examples:
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		ctx := rootCtx
 
-		s := getStore()
+		s := storage.UnwrapStore(getStore())
 		if s == nil {
 			if jsonOutput {
 				outputJSON(map[string]interface{}{

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
@@ -22,6 +23,7 @@ var migrateCmd = &cobra.Command{
 Without subcommand, checks and updates database metadata to current version.
 
 Subcommands:
+  schema      Apply pending SQL schema migrations explicitly
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
   sync        Set up sync.branch workflow for multi-clone setups
@@ -637,6 +639,72 @@ func listMigrations() []string {
 // configures the separate-branch workflow for multi-clone setups.
 // Previously this was documented but never wired as an actual subcommand,
 // so bd doctor's recommendation to run "bd migrate sync beads-sync" would fail.
+// migrateSchemaCmd is the "bd migrate schema" subcommand. It applies any
+// pending SQL schema migrations explicitly, replacing the previous behavior of
+// silently migrating on every Store Open (be-3z3fmi).
+var migrateSchemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Apply pending schema migrations explicitly",
+	Long: `Apply any pending SQL schema migrations to the beads database.
+
+After upgrading bd, run this once to bring the database schema up to date.
+Store Open commands will refuse to operate on a stale schema once the guard
+is active (see be-o7fh35); this command is the explicit migration path.
+
+Examples:
+  bd migrate schema           # apply pending migrations, show count
+  bd migrate schema --json    # machine-readable output`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ctx := rootCtx
+
+		s := getStore()
+		if s == nil {
+			if jsonOutput {
+				outputJSON(map[string]interface{}{
+					"error":   "no_store",
+					"message": activeWorkspaceNotFoundMessage() + " " + diagHint() + ".",
+				})
+				os.Exit(1)
+			}
+			return fmt.Errorf("no beads database found: %s", diagHint())
+		}
+
+		sm, ok := s.(storage.SchemaMigrator)
+		if !ok {
+			// Postgres and other non-Dolt backends handle schema differently.
+			fmt.Fprintln(os.Stderr, "bd migrate schema: current backend does not support explicit schema migration")
+			os.Exit(1)
+		}
+
+		applied, currentVersion, err := sm.MigrateSchemaUp(ctx)
+		if err != nil {
+			return fmt.Errorf("applying schema migrations: %w", err)
+		}
+
+		if applied == 0 {
+			if jsonOutput {
+				outputJSON(map[string]interface{}{
+					"applied":         0,
+					"current_version": currentVersion,
+				})
+			} else {
+				fmt.Println("already up to date")
+			}
+			return nil
+		}
+
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"applied":         applied,
+				"current_version": currentVersion,
+			})
+		} else {
+			fmt.Printf("%d migration(s) applied, schema now at version %d\n", applied, currentVersion)
+		}
+		return nil
+	},
+}
+
 var migrateSyncCmd = &cobra.Command{
 	Use:   "sync <branch>",
 	Short: "Set up sync.branch workflow for multi-clone setups",
@@ -663,6 +731,9 @@ func init() {
 	migrateCmd.Flags().Bool("update-repo-id", false, "Update repository ID (use after changing git remote)")
 	migrateCmd.Flags().Bool("inspect", false, "Show migration plan and database state for AI agent analysis")
 	migrateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output migration statistics in JSON format")
+
+	migrateSchemaCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	migrateCmd.AddCommand(migrateSchemaCmd)
 
 	migrateSyncCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
 	migrateSyncCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")

--- a/cmd/bd/mol_embedded_test.go
+++ b/cmd/bd/mol_embedded_test.go
@@ -21,7 +21,7 @@ func TestSpawnMolecule_PreservesStepLabels(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	s, err := embeddeddolt.Open(ctx, t.TempDir(), "beads", "main")
+	s, err := embeddeddolt.Open(ctx, t.TempDir(), "beads", "main", true)
 	if err != nil {
 		t.Fatalf("embeddeddolt.Open failed: %v", err)
 	}

--- a/cmd/bd/mol_squash_embedded_test.go
+++ b/cmd/bd/mol_squash_embedded_test.go
@@ -23,7 +23,7 @@ func TestEmbeddedSquashWispMoleculeClearsRootEphemeral(t *testing.T) {
 	ctx := context.Background()
 	beadsDir := t.TempDir()
 
-	s, err := embeddeddolt.Open(ctx, beadsDir, "moltest", "main")
+	s, err := embeddeddolt.Open(ctx, beadsDir, "moltest", "main", true)
 	if err != nil {
 		t.Fatalf("embeddeddolt.Open: %v", err)
 	}

--- a/cmd/bd/restore_embedded_test.go
+++ b/cmd/bd/restore_embedded_test.go
@@ -62,7 +62,7 @@ func simulateCompaction(t *testing.T, bd, dir, beadsDir, database string) string
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	for i := 0; i < 5; i++ {
-		store, err = embeddeddolt.Open(ctx, beadsDir, database, "main")
+		store, err = embeddeddolt.Open(ctx, beadsDir, database, "main", true)
 		if err == nil {
 			break
 		}
@@ -181,7 +181,7 @@ func TestEmbeddedRestoreConcurrent(t *testing.T) {
 	var store *embeddeddolt.EmbeddedDoltStore
 	var err error
 	for i := 0; i < 5; i++ {
-		store, err = embeddeddolt.Open(ctx, beadsDir, "rstcon", "main")
+		store, err = embeddeddolt.Open(ctx, beadsDir, "rstcon", "main", true)
 		if err == nil {
 			break
 		}

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -40,7 +40,10 @@ func usesProxiedServer() bool {
 
 // newDoltStore creates a storage backend from an explicit config.
 // Used by bd init and PersistentPreRun.
-func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool) (storage.DoltStorage, error) {
+// When skipSchemaInit is true (used by 'bd migrate schema'), schema
+// initialization is bypassed entirely — no auto-migration and no staleness
+// check — so MigrateSchemaUp can apply and count pending migrations.
+func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool, skipSchemaInit bool) (storage.DoltStorage, error) {
 	if cfg.ProxiedServer {
 		// TODO: this should not be a store
 		// it should be a uow provider
@@ -48,7 +51,11 @@ func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool) (stor
 	}
 	if cfg.ServerMode {
 		cfg.AutoMigrate = autoMigrate
+		cfg.SkipSchemaInit = skipSchemaInit
 		return dolt.New(ctx, cfg)
+	}
+	if skipSchemaInit {
+		return embeddeddolt.OpenForMigration(ctx, cfg.BeadsDir, cfg.Database, "main")
 	}
 	return embeddeddolt.Open(ctx, cfg.BeadsDir, cfg.Database, "main", autoMigrate)
 }

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -40,16 +40,17 @@ func usesProxiedServer() bool {
 
 // newDoltStore creates a storage backend from an explicit config.
 // Used by bd init and PersistentPreRun.
-func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, error) {
+func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool) (storage.DoltStorage, error) {
 	if cfg.ProxiedServer {
 		// TODO: this should not be a store
 		// it should be a uow provider
 		return nil, fmt.Errorf("proxy server store should be uow provider")
 	}
 	if cfg.ServerMode {
+		cfg.AutoMigrate = autoMigrate
 		return dolt.New(ctx, cfg)
 	}
-	return embeddeddolt.Open(ctx, cfg.BeadsDir, cfg.Database, "main")
+	return embeddeddolt.Open(ctx, cfg.BeadsDir, cfg.Database, "main", autoMigrate)
 }
 
 // acquireEmbeddedLock acquires an exclusive flock on the embeddeddolt data
@@ -103,7 +104,7 @@ func newDoltStoreFromConfig(ctx context.Context, beadsDir string) (storage.DoltS
 		}
 		database = sanitized
 	}
-	return embeddeddolt.Open(ctx, beadsDir, database, "main")
+	return embeddeddolt.Open(ctx, beadsDir, database, "main", false)
 }
 
 // migrateHyphenatedDB renames a legacy hyphenated database directory and
@@ -174,5 +175,5 @@ func newReadOnlyStoreFromConfig(ctx context.Context, beadsDir string) (storage.D
 	if sanitized := sanitizeDBName(database); sanitized != database {
 		database = sanitized
 	}
-	return embeddeddolt.Open(ctx, beadsDir, database, "main")
+	return embeddeddolt.Open(ctx, beadsDir, database, "main", false)
 }

--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -23,7 +23,7 @@ func usesProxiedServer() bool {
 	return cmdCtx != nil && cmdCtx.ProxiedServerMode
 }
 
-func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, error) {
+func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool) (storage.DoltStorage, error) {
 	if cfg.ProxiedServer {
 		// TODO: this should not be a store
 		// it should be a uow provider
@@ -32,6 +32,7 @@ func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, e
 	if !cfg.ServerMode {
 		return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 	}
+	cfg.AutoMigrate = autoMigrate
 	return dolt.New(ctx, cfg)
 }
 

--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -23,7 +23,7 @@ func usesProxiedServer() bool {
 	return cmdCtx != nil && cmdCtx.ProxiedServerMode
 }
 
-func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool) (storage.DoltStorage, error) {
+func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool, skipSchemaInit bool) (storage.DoltStorage, error) {
 	if cfg.ProxiedServer {
 		// TODO: this should not be a store
 		// it should be a uow provider
@@ -33,6 +33,7 @@ func newDoltStore(ctx context.Context, cfg *dolt.Config, autoMigrate bool) (stor
 		return nil, fmt.Errorf("%s", nocgoEmbeddedErrMsg)
 	}
 	cfg.AutoMigrate = autoMigrate
+	cfg.SkipSchemaInit = skipSchemaInit
 	return dolt.New(ctx, cfg)
 }
 

--- a/cmd/bd/store_factory_nocgo_test.go
+++ b/cmd/bd/store_factory_nocgo_test.go
@@ -14,7 +14,7 @@ import (
 // is false.
 func TestNocgoNewDoltStore_ErrorSuggestsCorrectFlag(t *testing.T) {
 	cfg := &dolt.Config{ServerMode: false}
-	_, err := newDoltStore(t.Context(), cfg)
+	_, err := newDoltStore(t.Context(), cfg, false, false)
 	if err == nil {
 		t.Fatal("expected error when ServerMode is false")
 	}

--- a/cmd/bd/store_factory_test.go
+++ b/cmd/bd/store_factory_test.go
@@ -46,7 +46,7 @@ func TestNewDoltStoreFromConfig_NoMetadata(t *testing.T) {
 // deferring to a confusing "no database selected" SQL error.
 // Belt-and-suspenders defense for be-sy8 / GH#2988.
 func TestEmbeddedOpen_EmptyDatabaseRejected(t *testing.T) {
-	_, err := embeddeddolt.Open(t.Context(), t.TempDir(), "", "main")
+	_, err := embeddeddolt.Open(t.Context(), t.TempDir(), "", "main", true)
 	if err == nil {
 		t.Fatal("expected error for empty database name")
 	}

--- a/cmd/bd/where_cgo_test.go
+++ b/cmd/bd/where_cgo_test.go
@@ -47,7 +47,7 @@ func TestWhereCommand_ReadsPrefixFromEmbeddedStore(t *testing.T) {
 		t.Fatalf("save metadata: %v", err)
 	}
 
-	store, err := embeddeddolt.Open(context.Background(), beadsDir, "embedcfg", "main")
+	store, err := embeddeddolt.Open(context.Background(), beadsDir, "embedcfg", "main", true)
 	if err != nil {
 		t.Fatalf("embeddeddolt.Open: %v", err)
 	}

--- a/cmd/bd/where_cgo_test.go
+++ b/cmd/bd/where_cgo_test.go
@@ -16,6 +16,15 @@ import (
 )
 
 func TestWhereCommand_ReadsPrefixFromEmbeddedStore(t *testing.T) {
+	// Repo dogfoods bd; opt out of its .beads/config.yaml so issue-prefix isn't masked here.
+	t.Setenv("BEADS_TEST_IGNORE_REPO_CONFIG", "1")
+	// BEADS_TEST_IGNORE_REPO_CONFIG only suppresses the cwd-walk's hit on the
+	// module-root .beads/config.yaml. In git-worktree checkouts, the
+	// worktreeFallbackConfigPath probe in config.Initialize still loads the
+	// upstream repo's .beads/config.yaml via the git common-dir, which
+	// reintroduces issue-prefix. Chdir to a non-git tempdir so neither probe
+	// finds anything and the store-fallback in where.go can be exercised.
+	t.Chdir(t.TempDir())
 	saveAndRestoreGlobals(t)
 	ensureCleanGlobalState(t)
 	initConfigForTest(t)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -174,6 +174,7 @@ Reference for bd Latest. Generated from `bd help --all`.
 - [bd migrate](#bd-migrate) — Database migration commands
   - [bd migrate hooks](#bd-migrate-hooks) — Plan or apply git hook migration to marker-managed format
   - [bd migrate issues](#bd-migrate-issues) — Move issues between repositories
+  - [bd migrate schema](#bd-migrate-schema) — Apply pending schema migrations explicitly
   - [bd migrate sync](#bd-migrate-sync) — Set up sync.branch workflow for multi-clone setups
 - [bd ping](#bd-ping) — Check database connectivity
 - [bd preflight](#bd-preflight) — Show PR readiness checklist
@@ -3940,6 +3941,7 @@ Database migration and data transformation commands.
 Without subcommand, checks and updates database metadata to current version.
 
 Subcommands:
+  schema      Apply pending SQL schema migrations explicitly
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
   sync        Set up sync.branch workflow for multi-clone setups
@@ -4028,6 +4030,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+#### bd migrate schema
+
+Apply any pending SQL schema migrations to the beads database.
+
+After upgrading bd, run this once to bring the database schema up to date.
+Store Open commands will refuse to operate on a stale schema once the guard
+is active (see be-o7fh35); this command is the explicit migration path.
+
+Examples:
+  bd migrate schema           # apply pending migrations, show count
+  bd migrate schema --json    # machine-readable output
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 #### bd migrate sync

--- a/internal/storage/dolt/initschema_concurrent_test.go
+++ b/internal/storage/dolt/initschema_concurrent_test.go
@@ -74,7 +74,7 @@ func TestConcurrentInitSchema(t *testing.T) {
 
 			<-ready // wait for all goroutines to be ready
 
-			if err := initSchemaOnDB(ctx, db); err != nil {
+			if err := initSchemaOnDB(ctx, db, true); err != nil {
 				errs <- fmt.Errorf("goroutine %d: initSchemaOnDB: %w", n, err)
 			}
 		}(i)

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -44,7 +44,7 @@ func TestSchemaSkipsReinit(t *testing.T) {
 	}
 
 	// Run initSchemaOnDB again — should skip because migrations are current
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if err := initSchemaOnDB(ctx, store.db, true); err != nil {
 		t.Fatalf("initSchemaOnDB failed: %v", err)
 	}
 
@@ -76,7 +76,7 @@ func TestSchemaRunsInitWhenStale(t *testing.T) {
 	}
 
 	// Run initSchemaOnDB — should detect stale and re-apply
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if err := initSchemaOnDB(ctx, store.db, true); err != nil {
 		t.Fatalf("initSchemaOnDB failed: %v", err)
 	}
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1505,7 +1505,10 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB, autoMigrate bool) error {
 		}
 		if pending > 0 {
 			latestVersion := schema.LatestVersion()
-			currentVersion := latestVersion - pending
+			currentVersion, err := schema.CurrentVersion(ctx, conn)
+			if err != nil {
+				return fmt.Errorf("schema: reading current version: %w", err)
+			}
 			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion)
 		}
 	}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -183,6 +183,10 @@ type DoltStore struct {
 	// Circuit breaker for Dolt server connections
 	breaker *circuitBreaker
 
+	// autoMigrate controls schema migration behavior: when true, apply
+	// pending migrations automatically; when false, error if schema is stale.
+	autoMigrate bool
+
 	// Version control config
 	committerName  string
 	committerEmail string
@@ -249,6 +253,12 @@ type Config struct {
 	// When true and the host is localhost, bd will start a dolt sql-server
 	// automatically if one isn't running. Disabled under orchestrator (GT_ROOT set).
 	AutoStart bool
+
+	// AutoMigrate controls schema migration behavior on Open. When true,
+	// pending migrations are applied automatically (init and bootstrap paths).
+	// When false, Open returns an error if the schema is behind the binary's
+	// expected version, directing the user to run "bd migrate schema".
+	AutoMigrate bool
 
 	// MaxOpenConns overrides the connection pool size (0 = default 10).
 	// Set to 1 for branch isolation in tests (DOLT_CHECKOUT is session-level).
@@ -1094,6 +1104,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		remotePassword:       cfg.RemotePassword,
 		serverMode:           true,
 		readOnly:             cfg.ReadOnly,
+		autoMigrate:          cfg.AutoMigrate,
 		autoStartedServerDir: autoStartedDir,
 	}
 
@@ -1471,25 +1482,39 @@ func databaseExistsOnServer(ctx context.Context, db *sql.DB, name string) (bool,
 	return false, rows.Err()
 }
 
-// initSchemaOnDB applies pending schema migrations. schema.MigrateUp tracks
-// applied versions in schema_migrations and backfills legacy config-driven
-// tables.
-func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
+// initSchemaOnDB applies pending schema migrations or checks for staleness.
+// When autoMigrate is true, schema.MigrateUp is called to apply any pending
+// migrations. When autoMigrate is false, the function checks for pending
+// migrations and returns an error if any are found, directing the user to run
+// "bd migrate schema".
+func initSchemaOnDB(ctx context.Context, db *sql.DB, autoMigrate bool) error {
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return fmt.Errorf("schema: pin connection: %w", err)
 	}
 	defer conn.Close()
 
-	if _, err := schema.MigrateUp(ctx, conn); err != nil {
-		return fmt.Errorf("schema migration: %w", err)
+	if autoMigrate {
+		if _, err := schema.MigrateUp(ctx, conn); err != nil {
+			return fmt.Errorf("schema migration: %w", err)
+		}
+	} else {
+		pending, err := schema.PendingMigrationCount(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("schema: checking version: %w", err)
+		}
+		if pending > 0 {
+			latestVersion := schema.LatestVersion()
+			currentVersion := latestVersion - pending
+			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion)
+		}
 	}
 
 	return nil
 }
 
 func (s *DoltStore) initSchema(ctx context.Context) error {
-	return initSchemaOnDB(ctx, s.db)
+	return initSchemaOnDB(ctx, s.db, s.autoMigrate)
 }
 
 // MigrateSchemaUp applies any pending schema migrations and returns the count

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -187,6 +187,11 @@ type DoltStore struct {
 	// pending migrations automatically; when false, error if schema is stale.
 	autoMigrate bool
 
+	// skipSchemaInit bypasses both auto-migration and the staleness check on
+	// Open. Used by 'bd migrate schema' so MigrateSchemaUp reports the correct
+	// applied count rather than 0 (pre-migrated during open).
+	skipSchemaInit bool
+
 	// Version control config
 	committerName  string
 	committerEmail string
@@ -259,6 +264,11 @@ type Config struct {
 	// When false, Open returns an error if the schema is behind the binary's
 	// expected version, directing the user to run "bd migrate schema".
 	AutoMigrate bool
+
+	// SkipSchemaInit bypasses both auto-migration and the staleness check.
+	// Set by 'bd migrate schema' so MigrateSchemaUp handles the migration and
+	// reports the correct applied count instead of always seeing 0.
+	SkipSchemaInit bool
 
 	// MaxOpenConns overrides the connection pool size (0 = default 10).
 	// Set to 1 for branch isolation in tests (DOLT_CHECKOUT is session-level).
@@ -1105,6 +1115,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		serverMode:           true,
 		readOnly:             cfg.ReadOnly,
 		autoMigrate:          cfg.AutoMigrate,
+		skipSchemaInit:       cfg.SkipSchemaInit,
 		autoStartedServerDir: autoStartedDir,
 	}
 
@@ -1499,17 +1510,12 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB, autoMigrate bool) error {
 			return fmt.Errorf("schema migration: %w", err)
 		}
 	} else {
-		pending, err := schema.PendingMigrationCount(ctx, conn)
+		pending, current, err := schema.PendingCountAndCurrentVersion(ctx, conn)
 		if err != nil {
 			return fmt.Errorf("schema: checking version: %w", err)
 		}
 		if pending > 0 {
-			latestVersion := schema.LatestVersion()
-			currentVersion, err := schema.CurrentVersion(ctx, conn)
-			if err != nil {
-				return fmt.Errorf("schema: reading current version: %w", err)
-			}
-			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion)
+			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", current, schema.LatestVersion())
 		}
 	}
 
@@ -1517,6 +1523,9 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB, autoMigrate bool) error {
 }
 
 func (s *DoltStore) initSchema(ctx context.Context) error {
+	if s.skipSchemaInit {
+		return nil
+	}
 	return initSchemaOnDB(ctx, s.db, s.autoMigrate)
 }
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1492,6 +1492,22 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 	return initSchemaOnDB(ctx, s.db)
 }
 
+// MigrateSchemaUp applies any pending schema migrations and returns the count
+// applied and the resulting current schema version.
+func (s *DoltStore) MigrateSchemaUp(ctx context.Context) (applied int, currentVersion int, err error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("schema: pin connection: %w", err)
+	}
+	defer conn.Close()
+
+	applied, err = schema.MigrateUp(ctx, conn)
+	if err != nil {
+		return 0, 0, err
+	}
+	return applied, schema.LatestVersion(), nil
+}
+
 // IsClosed returns true if the store has been closed.
 func (s *DoltStore) IsClosed() bool {
 	return s.closed.Load()

--- a/internal/storage/embeddeddolt/cache.go
+++ b/internal/storage/embeddeddolt/cache.go
@@ -28,7 +28,12 @@ type cacheEntry struct {
 //
 // This prevents redundant engine initializations when multiple code paths open
 // connectors against the same data directory in the same process.
-func Open(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
+//
+// When autoMigrate is true, any pending schema migrations are applied
+// automatically (used by init and bootstrap paths). When autoMigrate is false,
+// Open returns an error if the schema is behind the binary's expected version,
+// directing the user to run "bd migrate schema".
+func Open(ctx context.Context, beadsDir, database, branch string, autoMigrate bool) (*EmbeddedDoltStore, error) {
 	key, err := cacheKey(beadsDir)
 	if err != nil {
 		return nil, err
@@ -43,7 +48,7 @@ func Open(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDolt
 	cacheMu.Unlock()
 
 	// Slow path: create a new store outside the lock.
-	s, err := newStore(ctx, beadsDir, database, branch)
+	s, err := newStore(ctx, beadsDir, database, branch, autoMigrate)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/embeddeddolt/cache.go
+++ b/internal/storage/embeddeddolt/cache.go
@@ -34,6 +34,17 @@ type cacheEntry struct {
 // Open returns an error if the schema is behind the binary's expected version,
 // directing the user to run "bd migrate schema".
 func Open(ctx context.Context, beadsDir, database, branch string, autoMigrate bool) (*EmbeddedDoltStore, error) {
+	return openCached(ctx, beadsDir, database, branch, autoMigrate, false)
+}
+
+// OpenForMigration opens the store without running schema initialization —
+// neither auto-migration nor the staleness check. Used by 'bd migrate schema'
+// so MigrateSchemaUp applies pending migrations and returns the correct count.
+func OpenForMigration(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
+	return openCached(ctx, beadsDir, database, branch, false, true)
+}
+
+func openCached(ctx context.Context, beadsDir, database, branch string, autoMigrate bool, skipSchemaInit bool) (*EmbeddedDoltStore, error) {
 	key, err := cacheKey(beadsDir)
 	if err != nil {
 		return nil, err
@@ -48,7 +59,7 @@ func Open(ctx context.Context, beadsDir, database, branch string, autoMigrate bo
 	cacheMu.Unlock()
 
 	// Slow path: create a new store outside the lock.
-	s, err := newStore(ctx, beadsDir, database, branch, autoMigrate)
+	s, err := newStore(ctx, beadsDir, database, branch, autoMigrate, skipSchemaInit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/embeddeddolt/cache_test.go
+++ b/internal/storage/embeddeddolt/cache_test.go
@@ -18,13 +18,13 @@ func TestOpenReturnsCachedStore(t *testing.T) {
 	beadsDir := filepath.Join(t.TempDir(), ".beads")
 
 	// First Open creates a new store.
-	store1, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	store1, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
 
 	// Second Open with same beadsDir returns the same pointer.
-	store2, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	store2, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("second Open: %v", err)
 	}
@@ -58,13 +58,13 @@ func TestOpenDifferentDirsReturnsDifferentStores(t *testing.T) {
 	beadsDir1 := filepath.Join(t.TempDir(), ".beads")
 	beadsDir2 := filepath.Join(t.TempDir(), ".beads")
 
-	store1, err := embeddeddolt.Open(ctx, beadsDir1, "testdb", "main")
+	store1, err := embeddeddolt.Open(ctx, beadsDir1, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("Open dir1: %v", err)
 	}
 	defer store1.Close()
 
-	store2, err := embeddeddolt.Open(ctx, beadsDir2, "testdb", "main")
+	store2, err := embeddeddolt.Open(ctx, beadsDir2, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("Open dir2: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestOpenAfterCloseCreatesNewStore(t *testing.T) {
 	ctx := t.Context()
 	beadsDir := filepath.Join(t.TempDir(), ".beads")
 
-	store1, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	store1, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestOpenAfterCloseCreatesNewStore(t *testing.T) {
 	store1.Close()
 
 	// Re-opening should create a fresh store, not return the closed one.
-	store2, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	store2, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("Open after Close: %v", err)
 	}

--- a/internal/storage/embeddeddolt/cmd/main.go
+++ b/internal/storage/embeddeddolt/cmd/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	store, err := embeddeddolt.Open(ctx, absDir, *database, *branch)
+	store, err := embeddeddolt.Open(ctx, absDir, *database, *branch, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/internal/storage/embeddeddolt/concurrency_test.go
+++ b/internal/storage/embeddeddolt/concurrency_test.go
@@ -226,13 +226,13 @@ func TestConcurrentOpenReturnsCached(t *testing.T) {
 	ctx := t.Context()
 	beadsDir := t.TempDir()
 
-	store1, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	store1, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("first Open: %v", err)
 	}
 
 	// Second Open should return immediately with the same cached store.
-	store2, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	store2, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("second Open: %v", err)
 	}

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -28,7 +28,7 @@ func newTestEnv(t *testing.T, prefix string) *testEnv {
 	t.Helper()
 	ctx := t.Context()
 	beadsDir := filepath.Join(t.TempDir(), ".beads")
-	store, err := embeddeddolt.Open(ctx, beadsDir, prefix, "main")
+	store, err := embeddeddolt.Open(ctx, beadsDir, prefix, "main", true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestCreateIssue(t *testing.T) {
 	t.Run("missing_prefix_errors", func(t *testing.T) {
 		ctx := t.Context()
 		beadsDir := filepath.Join(t.TempDir(), ".beads")
-		store, err := embeddeddolt.Open(ctx, beadsDir, "noprefix", "main")
+		store, err := embeddeddolt.Open(ctx, beadsDir, "noprefix", "main", true)
 		if err != nil {
 			t.Fatalf("Open: %v", err)
 		}

--- a/internal/storage/embeddeddolt/schema_test.go
+++ b/internal/storage/embeddeddolt/schema_test.go
@@ -19,7 +19,7 @@ func TestSchemaAfterInit(t *testing.T) {
 	beadsDir := filepath.Join(t.TempDir(), ".beads")
 	dataDir := filepath.Join(beadsDir, "embeddeddolt")
 
-	store, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	store, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main", true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -63,7 +63,7 @@ func (s *EmbeddedDoltStore) IsClosed() bool {
 // The dolthub/driver handles its own concurrency internally. File-level locking
 // is only used during bd init (via util.TryLock in the init command) to protect
 // one-time initialization steps — the store itself does not hold any lock.
-func newStore(ctx context.Context, beadsDir, database, branch string) (*EmbeddedDoltStore, error) {
+func newStore(ctx context.Context, beadsDir, database, branch string, autoMigrate bool) (*EmbeddedDoltStore, error) {
 	if database == "" {
 		return nil, fmt.Errorf("embeddeddolt: database name must not be empty (caller should default to %q)", "beads")
 	}
@@ -87,7 +87,7 @@ func newStore(ctx context.Context, beadsDir, database, branch string) (*Embedded
 		branch:   branch,
 	}
 
-	if err := s.initSchema(ctx); err != nil {
+	if err := s.initSchema(ctx, autoMigrate); err != nil {
 		return nil, fmt.Errorf("embeddeddolt: init schema: %w", err)
 	}
 
@@ -142,7 +142,7 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 	return
 }
 
-func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
+func (s *EmbeddedDoltStore) initSchema(ctx context.Context, autoMigrate bool) error {
 	db, cleanup, err := OpenSQL(ctx, s.dataDir, "", "")
 	if err != nil {
 		return fmt.Errorf("embeddeddolt: open db: %w", err)
@@ -176,8 +176,20 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 		}
 	}
 
-	if _, err := schema.MigrateUp(ctx, conn); err != nil {
-		return fmt.Errorf("embeddeddolt: migrate: %w", err)
+	if autoMigrate {
+		if _, err := schema.MigrateUp(ctx, conn); err != nil {
+			return fmt.Errorf("embeddeddolt: migrate: %w", err)
+		}
+	} else {
+		pending, err := schema.PendingMigrationCount(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("embeddeddolt: checking schema version: %w", err)
+		}
+		if pending > 0 {
+			latestVersion := schema.LatestVersion()
+			currentVersion := latestVersion - pending
+			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion)
+		}
 	}
 
 	return nil

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -63,7 +63,7 @@ func (s *EmbeddedDoltStore) IsClosed() bool {
 // The dolthub/driver handles its own concurrency internally. File-level locking
 // is only used during bd init (via util.TryLock in the init command) to protect
 // one-time initialization steps — the store itself does not hold any lock.
-func newStore(ctx context.Context, beadsDir, database, branch string, autoMigrate bool) (*EmbeddedDoltStore, error) {
+func newStore(ctx context.Context, beadsDir, database, branch string, autoMigrate bool, skipSchemaInit bool) (*EmbeddedDoltStore, error) {
 	if database == "" {
 		return nil, fmt.Errorf("embeddeddolt: database name must not be empty (caller should default to %q)", "beads")
 	}
@@ -87,8 +87,10 @@ func newStore(ctx context.Context, beadsDir, database, branch string, autoMigrat
 		branch:   branch,
 	}
 
-	if err := s.initSchema(ctx, autoMigrate); err != nil {
-		return nil, fmt.Errorf("embeddeddolt: init schema: %w", err)
+	if !skipSchemaInit {
+		if err := s.initSchema(ctx, autoMigrate); err != nil {
+			return nil, fmt.Errorf("embeddeddolt: init schema: %w", err)
+		}
 	}
 
 	return s, nil
@@ -181,17 +183,12 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context, autoMigrate bool) er
 			return fmt.Errorf("embeddeddolt: migrate: %w", err)
 		}
 	} else {
-		pending, err := schema.PendingMigrationCount(ctx, conn)
+		pending, current, err := schema.PendingCountAndCurrentVersion(ctx, conn)
 		if err != nil {
 			return fmt.Errorf("embeddeddolt: checking schema version: %w", err)
 		}
 		if pending > 0 {
-			latestVersion := schema.LatestVersion()
-			currentVersion, err := schema.CurrentVersion(ctx, conn)
-			if err != nil {
-				return fmt.Errorf("embeddeddolt: reading current version: %w", err)
-			}
-			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion)
+			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", current, schema.LatestVersion())
 		}
 	}
 

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -461,6 +461,39 @@ func (s *EmbeddedDoltStore) CLIDir() string {
 }
 
 // ---------------------------------------------------------------------------
+// storage.SchemaMigrator
+// ---------------------------------------------------------------------------
+
+// MigrateSchemaUp applies any pending schema migrations. It opens a fresh
+// SQL connection (bypassing the auto-migration guard added in be-o7fh35) so
+// that "bd migrate schema" works even when the schema is stale.
+func (s *EmbeddedDoltStore) MigrateSchemaUp(ctx context.Context) (applied int, currentVersion int, err error) {
+	db, cleanup, err := OpenSQL(ctx, s.dataDir, "", "")
+	if err != nil {
+		return 0, 0, fmt.Errorf("embeddeddolt: open db for schema migration: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("embeddeddolt: pin connection for schema migration: %w", err)
+	}
+	defer conn.Close()
+
+	if s.database != "" {
+		if _, err := conn.ExecContext(ctx, "USE `"+s.database+"`"); err != nil {
+			return 0, 0, fmt.Errorf("embeddeddolt: switch to database: %w", err)
+		}
+	}
+
+	applied, err = schema.MigrateUp(ctx, conn)
+	if err != nil {
+		return 0, 0, fmt.Errorf("embeddeddolt: schema migration: %w", err)
+	}
+	return applied, schema.LatestVersion(), nil
+}
+
+// ---------------------------------------------------------------------------
 // storage.VersionControl
 // ---------------------------------------------------------------------------
 

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -187,7 +187,10 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context, autoMigrate bool) er
 		}
 		if pending > 0 {
 			latestVersion := schema.LatestVersion()
-			currentVersion := latestVersion - pending
+			currentVersion, err := schema.CurrentVersion(ctx, conn)
+			if err != nil {
+				return fmt.Errorf("embeddeddolt: reading current version: %w", err)
+			}
 			return fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion)
 		}
 	}

--- a/internal/storage/embeddeddolt/store_stub.go
+++ b/internal/storage/embeddeddolt/store_stub.go
@@ -17,6 +17,6 @@ type EmbeddedDoltStore struct {
 var errNoCGO = errors.New("embeddeddolt: requires CGO (build with CGO_ENABLED=1)")
 
 // Open returns an error when CGO is not enabled.
-func Open(_ context.Context, _, _, _ string) (*EmbeddedDoltStore, error) {
+func Open(_ context.Context, _, _, _ string, _ bool) (*EmbeddedDoltStore, error) {
 	return nil, errNoCGO
 }

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -93,6 +93,21 @@ func PendingMigrationCount(ctx context.Context, db DBConn) (int, error) {
 	return mainSource.pendingCount(ctx, db)
 }
 
+// CurrentVersion returns the highest schema migration version that has been
+// applied to db, or 0 if no migrations have been applied. Prefer this over
+// computing latestVersion - pending, which breaks when migration numbers have gaps.
+func CurrentVersion(ctx context.Context, db DBConn) (int, error) {
+	if _, err := db.ExecContext(ctx, mainSource.bootstrapSQL()); err != nil {
+		return 0, fmt.Errorf("creating %s: %w", mainSource.cursorTable, err)
+	}
+	var current int
+	err := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+mainSource.cursorTable).Scan(&current)
+	if err != nil && err != sql.ErrNoRows {
+		return 0, fmt.Errorf("reading %s version: %w", mainSource.cursorTable, err)
+	}
+	return current, nil
+}
+
 func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -93,6 +93,24 @@ func PendingMigrationCount(ctx context.Context, db DBConn) (int, error) {
 	return mainSource.pendingCount(ctx, db)
 }
 
+// PendingCountAndCurrentVersion returns both the pending migration count and
+// the current applied version in a single DB roundtrip. Use this instead of
+// calling PendingMigrationCount + CurrentVersion in sequence.
+func PendingCountAndCurrentVersion(ctx context.Context, db DBConn) (pending int, current int, err error) {
+	if _, err = db.ExecContext(ctx, mainSource.bootstrapSQL()); err != nil {
+		return 0, 0, fmt.Errorf("creating %s: %w", mainSource.cursorTable, err)
+	}
+	if scanErr := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+mainSource.cursorTable).Scan(&current); scanErr != nil && scanErr != sql.ErrNoRows {
+		return 0, 0, fmt.Errorf("reading %s version: %w", mainSource.cursorTable, scanErr)
+	}
+	for _, mf := range mainSource.list() {
+		if mf.version > current {
+			pending++
+		}
+	}
+	return pending, current, nil
+}
+
 // CurrentVersion returns the highest schema migration version that has been
 // applied to db, or 0 if no migrations have been applied. Prefer this over
 // computing latestVersion - pending, which breaks when migration numbers have gaps.

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -87,6 +87,12 @@ func parseVersion(name string) (int, error) {
 	return strconv.Atoi(parts[0])
 }
 
+// PendingMigrationCount returns the number of main-track migrations that have
+// not yet been applied to db. Returns 0 if the schema is current.
+func PendingMigrationCount(ctx context.Context, db DBConn) (int, error) {
+	return mainSource.pendingCount(ctx, db)
+}
+
 func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {
@@ -161,6 +167,26 @@ func (m migrationSource) latest() int {
 		return 0
 	}
 	return files[len(files)-1].version
+}
+
+func (m migrationSource) pendingCount(ctx context.Context, db DBConn) (int, error) {
+	if _, err := db.ExecContext(ctx, m.bootstrapSQL()); err != nil {
+		return 0, fmt.Errorf("creating %s: %w", m.cursorTable, err)
+	}
+
+	var current int
+	err := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+m.cursorTable).Scan(&current)
+	if err != nil && err != sql.ErrNoRows {
+		return 0, fmt.Errorf("reading %s version: %w", m.cursorTable, err)
+	}
+
+	count := 0
+	for _, mf := range m.list() {
+		if mf.version > current {
+			count++
+		}
+	}
+	return count, nil
 }
 
 func (m migrationSource) migrate(ctx context.Context, db DBConn) (int, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -166,6 +166,16 @@ type RawDBAccessor interface {
 	UnderlyingDB() *sql.DB
 }
 
+// SchemaMigrator provides explicit schema migration control.
+// Commands that must apply pending migrations (e.g. "bd migrate schema") type-assert
+// to this interface instead of relying on auto-migration during Store Open.
+type SchemaMigrator interface {
+	// MigrateSchemaUp applies any pending schema migrations. Returns the count applied
+	// and the resulting current version. Returns (0, currentVersion, nil) if already
+	// up to date.
+	MigrateSchemaUp(ctx context.Context) (applied int, currentVersion int, err error)
+}
+
 // StoreLocator provides filesystem path information for the store.
 // Callers that need the store's on-disk location should type-assert to this interface.
 type StoreLocator interface {

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -192,7 +192,10 @@ func (p *doltServerProvider) initSchema(ctx context.Context, database string) er
 			}
 			if pending > 0 {
 				latestVersion := schema.LatestVersion()
-				currentVersion := latestVersion - pending
+				currentVersion, err := schema.CurrentVersion(ctx, conn)
+				if err != nil {
+					return backoff.Permanent(fmt.Errorf("uow: reading current version: %w", err))
+				}
 				return backoff.Permanent(fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion))
 			}
 		}

--- a/internal/storage/uow/doltserver_provider.go
+++ b/internal/storage/uow/doltserver_provider.go
@@ -24,6 +24,7 @@ const defaultBranch = "main"
 type doltServerProvider struct {
 	defaultBranch string
 	db            *sql.DB
+	autoMigrate   bool
 }
 
 var (
@@ -41,6 +42,7 @@ func NewDoltServerUOWProvider(
 	rootUser string,
 	rootPassword string,
 	doltBinExec string,
+	autoMigrate bool,
 ) (UnitOfWorkProvider, error) {
 	if database == "" {
 		return nil, fmt.Errorf("uow: database name must not be empty (caller should default to %q)", "beads")
@@ -81,6 +83,7 @@ func NewDoltServerUOWProvider(
 	initProvider := &doltServerProvider{
 		defaultBranch: defaultBranch,
 		db:            initDB,
+		autoMigrate:   autoMigrate,
 	}
 
 	if err := initProvider.initSchema(ctx, database); err != nil {
@@ -172,11 +175,26 @@ func (p *doltServerProvider) initSchema(ctx context.Context, database string) er
 			return backoff.Permanent(fmt.Errorf("uow: switching to database: %w", err))
 		}
 
-		if _, err := schema.MigrateUp(ctx, conn); err != nil {
-			if isSerializationError(err) {
-				return fmt.Errorf("uow: migrate: %w", err)
+		if p.autoMigrate {
+			if _, err := schema.MigrateUp(ctx, conn); err != nil {
+				if isSerializationError(err) {
+					return fmt.Errorf("uow: migrate: %w", err)
+				}
+				return backoff.Permanent(fmt.Errorf("uow: migrate: %w", err))
 			}
-			return backoff.Permanent(fmt.Errorf("uow: migrate: %w", err))
+		} else {
+			pending, err := schema.PendingMigrationCount(ctx, conn)
+			if err != nil {
+				if isSerializationError(err) {
+					return fmt.Errorf("uow: schema version check: %w", err)
+				}
+				return backoff.Permanent(fmt.Errorf("uow: schema version check: %w", err))
+			}
+			if pending > 0 {
+				latestVersion := schema.LatestVersion()
+				currentVersion := latestVersion - pending
+				return backoff.Permanent(fmt.Errorf("beads schema is at version %d, binary requires %d — run: bd migrate schema", currentVersion, latestVersion))
+			}
 		}
 		return nil
 	}, backoff.WithContext(bo, ctx))

--- a/internal/storage/uow/doltserver_provider_test.go
+++ b/internal/storage/uow/doltserver_provider_test.go
@@ -65,6 +65,7 @@ func TestNewDoltServerUOWProvider_ValidationErrors(t *testing.T) {
 				tc.database,
 				"", "", tc.backend,
 				tc.rootUser, "", tc.doltBin,
+				true,
 			)
 			assert.Nil(t, p)
 			require.Error(t, err)
@@ -107,6 +108,7 @@ func TestNewDoltServerUOWProvider_HappyPath(t *testing.T) {
 		"root",
 		"",
 		bin,
+		true,
 	)
 
 	require.NoError(t, err)

--- a/release-gates/be-o7fh35-be-gudo26-gate.md
+++ b/release-gates/be-o7fh35-be-gudo26-gate.md
@@ -1,0 +1,160 @@
+# Release Gate: be-o7fh35 + be-gudo26 (schema-stale guard + bd migrate schema)
+
+**Branch:** `feat/be-o7fh35-be-gudo26-schema-guards`
+**PR:** https://github.com/gastownhall/beads/pull/4015
+**Deploy bead:** be-b7ixnu
+**Gate date:** 2026-05-17
+
+## Beads in this PR
+
+| Bead | Title | Status |
+|------|-------|--------|
+| be-lw5fak | Build: schema.PendingMigrationCount() | ✓ CLOSED |
+| be-l4z4xw | Build: add 'bd migrate schema' subcommand | ✓ CLOSED |
+| be-o7fh35 | Build: embedded Dolt Store Open refuses stale schema | ✓ CLOSED |
+| be-gudo26 | Build: Dolt server Store Open refuses stale schema | ✓ CLOSED |
+| be-ipgt8m | Build: regenerate CLI reference docs | ✓ CLOSED |
+
+## Criterion 1: Review PASS present
+
+**PASS**
+
+- Reviewer: beads/reviewer (maintainer-pr-review ensemble: Qwen + Claude/Opus 4.7 + Codex)
+- Verdict: PASS (auto-merge), published 2026-05-17T10:39:41Z
+- Evidence: bead be-b7ixnu notes: `Reviewer verdict: PASS (auto-merge)`
+- CI: All 41 checks green, upgrade-smoke v1.0.0–v1.0.4 all pass
+
+## Criterion 2: Acceptance criteria met
+
+**PASS**
+
+### be-lw5fak: PendingMigrationCount
+- `internal/storage/schema/schema.go` — `PendingMigrationCount()` returns count of pending migrations without applying them ✓
+
+### be-l4z4xw: bd migrate schema subcommand
+- `cmd/bd/migrate.go:645` — `migrateSchemaCmd` implemented with `--json` flag ✓
+- `cmd/bd/migrate.go:679` — calls `sm.MigrateSchemaUp(ctx)` on `storage.SchemaMigrator` ✓
+- `cmd/bd/migrate.go:691` — prints "already up to date" for idempotent case ✓
+- `internal/storage/embeddeddolt/store.go:482` — `EmbeddedDoltStore.MigrateSchemaUp` ✓
+- `internal/storage/dolt/store.go:1532` — `DoltStore.MigrateSchemaUp` ✓
+
+### be-o7fh35: embedded Dolt schema guard
+- `internal/storage/embeddeddolt/store.go:66` — `autoMigrate bool` flag on `newStore` ✓
+- `internal/storage/embeddeddolt/store.go:191` — returns `"beads schema is at version %d, binary requires %d — run: bd migrate schema"` when stale ✓
+- `internal/storage/embeddeddolt/store.go:181` — `autoMigrate=true` bypasses guard for `bd init` / bootstrap ✓
+
+### be-gudo26: Dolt server schema guard
+- `internal/storage/dolt/store.go:262` — `AutoMigrate bool` in `dolt.Config` ✓
+- `internal/storage/dolt/store.go:1518` — same error message on stale schema ✓
+- `internal/storage/uow/doltserver_provider.go` — guard applied consistently ✓
+
+### Fix: HookFiringStore unwrap
+- `cmd/bd/migrate.go:660` — `storage.UnwrapStore(getStore())` before `SchemaMigrator` type assertion ✓
+- Prevents `bd migrate schema` from failing when `HookFiringStore` wraps the underlying store ✓
+
+### be-ipgt8m: CLI docs
+- `docs/CLI_REFERENCE.md` — `bd migrate schema` subcommand documented ✓
+- Website docs updated (version-1.0.0, version-1.0.4 canonical paths) ✓
+
+## Criterion 3: Tests pass
+
+**PASS** (with gc-rig environment caveat)
+
+Tests run on `deployer/schema-guards` (same HEAD as `fork/feat/be-o7fh35-be-gudo26-schema-guards`):
+
+**Passing packages (no regression):**
+```
+ok  github.com/steveyegge/beads
+ok  github.com/steveyegge/beads/cmd/bd/doctor/fix
+ok  github.com/steveyegge/beads/cmd/bd/protocol
+ok  github.com/steveyegge/beads/cmd/bd/setup
+ok  github.com/steveyegge/beads/format
+ok  github.com/steveyegge/beads/internal/ado
+ok  github.com/steveyegge/beads/internal/atomicfile
+ok  github.com/steveyegge/beads/internal/audit
+ok  github.com/steveyegge/beads/internal/compact
+ok  github.com/steveyegge/beads/internal/configfile
+ok  github.com/steveyegge/beads/internal/debug
+ok  github.com/steveyegge/beads/internal/doltserver
+ok  github.com/steveyegge/beads/internal/git
+ok  github.com/steveyegge/beads/internal/github
+ok  github.com/steveyegge/beads/internal/gitlab
+ok  github.com/steveyegge/beads/internal/hooks
+ok  github.com/steveyegge/beads/internal/idgen
+ok  github.com/steveyegge/beads/internal/jira
+ok  github.com/steveyegge/beads/internal/linear
+ok  github.com/steveyegge/beads/internal/lockfile
+ok  github.com/steveyegge/beads/internal/molecules
+ok  github.com/steveyegge/beads/internal/notion
+ok  github.com/steveyegge/beads/internal/query
+ok  github.com/steveyegge/beads/internal/recipes
+ok  github.com/steveyegge/beads/internal/remotecache
+ok  github.com/steveyegge/beads/internal/routing
+ok  github.com/steveyegge/beads/internal/storage
+ok  github.com/steveyegge/beads/internal/storage/dbproxy/proxy
+ok  github.com/steveyegge/beads/internal/storage/dbproxy/server
+ok  github.com/steveyegge/beads/internal/storage/dolt
+ok  github.com/steveyegge/beads/internal/storage/doltutil
+ok  github.com/steveyegge/beads/internal/storage/embeddeddolt
+ok  github.com/steveyegge/beads/internal/storage/issueops
+ok  github.com/steveyegge/beads/internal/storage/uow
+ok  github.com/steveyegge/beads/internal/storage/versioncontrolops
+ok  github.com/steveyegge/beads/internal/templates/agents
+ok  github.com/steveyegge/beads/internal/testutil
+ok  github.com/steveyegge/beads/internal/timeparsing
+ok  github.com/steveyegge/beads/internal/tracker
+ok  github.com/steveyegge/beads/internal/types
+ok  github.com/steveyegge/beads/internal/ui
+ok  github.com/steveyegge/beads/internal/utils
+ok  github.com/steveyegge/beads/internal/validation
+ok  github.com/steveyegge/beads/scripts
+```
+
+**Failing packages (pre-existing, identical to origin/main baseline):**
+```
+FAIL github.com/steveyegge/beads/cmd/bd
+FAIL github.com/steveyegge/beads/cmd/bd/doctor
+FAIL github.com/steveyegge/beads/internal/beads
+FAIL github.com/steveyegge/beads/internal/config
+FAIL github.com/steveyegge/beads/internal/formula
+```
+
+These failures are present in `origin/main` with the exact same test names — caused by the gc-rig worktree environment (live `.beads/` database present, repo detection tests assume a clean environment). Verified by running `make test` on `origin/main` and comparing output.
+
+Coverage changes (minor, expected): dolt 17.0%→16.9%, embeddeddolt 3.0%→2.9%, uow 28.9%→27.3%. New guard paths not yet directly tested — tracked in be-3zy32x and be-vuf19k.
+
+CI on PR #4015: All 41 checks green (clean environment).
+
+## Criterion 4: No high-severity review findings open
+
+**PASS**
+
+Review findings from maintainer-pr-review:
+- info: `SchemaMigrator` interface + `UnwrapStore(getStore())` — clean abstraction, right defensive call
+- info: `embeddeddolt.OpenForMigration` split from `Open` bypasses schema-init correctly
+- low: Codecov patch coverage ~4.9%; stale-refusal paths not directly tested — tracked in be-3zy32x and be-vuf19k (acceptable to ship)
+- info: Upgrade-smoke `|| true` bidirectional shim for pre-`migrate schema` versions is correct
+
+No HIGH or CRITICAL findings.
+
+## Criterion 5: Final branch is clean
+
+**PASS**
+
+```
+On branch deployer/schema-guards
+Untracked files: .gc/, .gitkeep  (gc-rig management files, not part of beads)
+nothing added to commit but untracked files present
+```
+
+## Criterion 6: Branch diverges cleanly from main
+
+**PASS**
+
+- `git merge-base --is-ancestor origin/main HEAD` → true (HEAD descends from main)
+- PR #4015 shows `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`
+- 10 commits ahead of origin/main, no conflicts
+
+## Verdict: PASS
+
+All 6 criteria pass. PR #4015 is ready to merge.

--- a/scripts/upgrade-smoke-test.sh
+++ b/scripts/upgrade-smoke-test.sh
@@ -252,6 +252,12 @@ prev_create --title "Another issue" --type bug || true
 # Upgrade: run candidate init (simulates upgrade)
 cand_init 2>/dev/null || true
 
+# PR #4015 (be-o7fh35): schema-stale guard refuses to open stale schemas;
+# explicit migration is now required after a binary upgrade. Tolerate
+# failure on candidates that don't yet have "bd migrate schema" — this
+# script is bidirectional across versions.
+cand migrate schema >/dev/null 2>&1 || true
+
 # Verify
 ROLE=$(git -C "$WS" config --get beads.role 2>/dev/null || echo "MISSING")
 if [ "$ROLE" = "maintainer" ]; then
@@ -402,6 +408,9 @@ else
 
     # Upgrade: run candidate init
     cand_init 2>/dev/null || true
+
+    # PR #4015 (be-o7fh35): schema-stale guard requires explicit migration.
+    cand migrate schema >/dev/null 2>&1 || true
 
     # Mutate using the candidate binary
     cand update "$MUT_ID" --notes "smoke test mutation" 2>/dev/null || true

--- a/website/docs/cli-reference/migrate.md
+++ b/website/docs/cli-reference/migrate.md
@@ -15,6 +15,7 @@ Database migration and data transformation commands.
 Without subcommand, checks and updates database metadata to current version.
 
 Subcommands:
+  schema      Apply pending SQL schema migrations explicitly
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
   sync        Set up sync.branch workflow for multi-clone setups
@@ -103,6 +104,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+### bd migrate schema
+
+Apply any pending SQL schema migrations to the beads database.
+
+After upgrading bd, run this once to bring the database schema up to date.
+Store Open commands will refuse to operate on a stale schema once the guard
+is active (see be-o7fh35); this command is the explicit migration path.
+
+Examples:
+  bd migrate schema           # apply pending migrations, show count
+  bd migrate schema --json    # machine-readable output
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 ### bd migrate sync

--- a/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
@@ -15,6 +15,7 @@ Database migration and data transformation commands.
 Without subcommand, checks and updates database metadata to current version.
 
 Subcommands:
+  schema      Apply pending SQL schema migrations explicitly
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
   sync        Set up sync.branch workflow for multi-clone setups
@@ -103,6 +104,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+### bd migrate schema
+
+Apply any pending SQL schema migrations to the beads database.
+
+After upgrading bd, run this once to bring the database schema up to date.
+Store Open commands will refuse to operate on a stale schema once the guard
+is active (see be-o7fh35); this command is the explicit migration path.
+
+Examples:
+  bd migrate schema           # apply pending migrations, show count
+  bd migrate schema --json    # machine-readable output
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 ### bd migrate sync

--- a/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
@@ -15,6 +15,7 @@ Database migration and data transformation commands.
 Without subcommand, checks and updates database metadata to current version.
 
 Subcommands:
+  schema      Apply pending SQL schema migrations explicitly
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
   sync        Set up sync.branch workflow for multi-clone setups
@@ -103,6 +104,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+### bd migrate schema
+
+Apply any pending SQL schema migrations to the beads database.
+
+After upgrading bd, run this once to bring the database schema up to date.
+Store Open commands will refuse to operate on a stale schema once the guard
+is active (see be-o7fh35); this command is the explicit migration path.
+
+Examples:
+  bd migrate schema           # apply pending migrations, show count
+  bd migrate schema --json    # machine-readable output
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 ### bd migrate sync


### PR DESCRIPTION
## Summary

- **`schema.PendingMigrationCount()`** — new helper that counts unapplied migrations without running them (be-lw5fak)
- **`bd migrate schema`** — new subcommand for explicit, operator-visible schema migration with progress output and `--json` flag (be-l4z4xw)
- **Schema-stale guard** — `EmbeddedDoltStore.initSchema`, `DoltStore.initSchemaOnDB`, and `DoltServerProvider` now call `PendingMigrationCount` on Open and return an error if schema is behind: `beads schema is at version N, binary requires M — run: bd migrate schema`. `autoMigrate=true` bypasses guard for `bd init`/bootstrap paths (be-o7fh35, be-gudo26)
- **Fix: circular failure** — `migrate schema` was blocked by its own guard because `PersistentPreRun` opened the store for all commands. Added `migrate` to `noDbCommands`; `migrateSchemaCmd.RunE` opens the store itself with `autoMigrate=true` (be-p6wzsr)
- **Fix: `CurrentVersion` at uow callsite** — reviewer follow-up on uow provider (be-lh1e58)
- **Docs** — CLI reference regenerated for `bd migrate schema` (be-ipgt8m)

## Test plan

- [ ] `make test` passes (gc-rig isolation failures in `TestBackupDir_NoWorkspaceReturnsActiveWorkspaceError`, `TestDetectBootstrapAction_WorktreeSynthesizedDirPrefersSyncOverDefaultSharedDB`, and `TestCheckServerDriftNoBeadsDir` are pre-existing environment failures, not caused by this PR)
- [ ] `go build ./...` clean with and without CGO
- [ ] Manual: `bd migrate schema` on a stale embedded store exits 0 and reports applied count
- [ ] Manual: `bd migrate schema` on a current store exits 0 with "already up to date"
- [ ] Manual: any other `bd` command against a stale store exits non-zero with the redirect message
- [ ] Tests for stale-refusal scenarios tracked in be-3zy32x and be-vuf19k (validator follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)