### PR TITLE
/internal/storage/schema/schema.go: advisory lock for concurrent inits

### DIFF
--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -91,7 +91,10 @@ func acquireMigrateLock(ctx context.Context, db DBConn) error {
 }
 
 func releaseMigrateLock(ctx context.Context, db DBConn) {
-	_, _ = db.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", migrateLockName)
+	_, err := db.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", migrateLockName)
+	if err != nil {
+		panic(fmt.Errorf("failed to release sql advisory lock: %w", err))
+	}
 }
 
 func parseVersion(name string) (int, error) {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -82,18 +82,27 @@ func AllMigrationsSQL() string {
 func acquireMigrateLock(ctx context.Context, db DBConn) error {
 	var locked sql.NullInt64
 	if err := db.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", migrateLockName, migrateLockTimeoutSec).Scan(&locked); err != nil {
-		return fmt.Errorf("acquiring schema migration lock %q: %w", migrateLockName, err)
+		return fmt.Errorf("failed to acquire schema advisory lock: %w", err)
 	}
-	if !locked.Valid || locked.Int64 != 1 {
-		return fmt.Errorf("acquiring schema migration lock %q: timed out after %ds (another connection holds it)", migrateLockName, migrateLockTimeoutSec)
+	if !locked.Valid {
+		return fmt.Errorf("failed to acquire schema advisory lock")
+	}
+	if locked.Int64 != 1 {
+		return fmt.Errorf("schema advisory lock timeout")
 	}
 	return nil
 }
 
 func releaseMigrateLock(ctx context.Context, db DBConn) {
-	_, err := db.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", migrateLockName)
-	if err != nil {
-		panic(fmt.Errorf("failed to release sql advisory lock: %w", err))
+	var released sql.NullInt64
+	if err := db.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", migrateLockName).Scan(&released); err != nil {
+		panic(fmt.Sprintf("failed to release schema advisory lock: %v", err))
+	}
+	if !released.Valid {
+		panic("failed to release schema advisory lock")
+	}
+	if released.Int64 != 1 {
+		panic("failed to release schema advisory lock: lock not held")
 	}
 }
 

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 type DBConn interface {
@@ -94,12 +95,15 @@ func acquireMigrateLock(ctx context.Context, db DBConn) error {
 }
 
 func releaseMigrateLock(ctx context.Context, db DBConn) {
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
 	var released sql.NullInt64
-	if err := db.QueryRowContext(ctx, "SELECT RELEASE_LOCK(?)", migrateLockName).Scan(&released); err != nil {
-		panic(fmt.Sprintf("failed to release schema advisory lock: %v", err))
+	if err := db.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", migrateLockName).Scan(&released); err != nil {
+		return
 	}
 	if !released.Valid {
-		panic("failed to release schema advisory lock")
+		return
 	}
 	if released.Int64 != 1 {
 		panic("failed to release schema advisory lock: lock not held")

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -79,6 +79,21 @@ func AllMigrationsSQL() string {
 	return b.String()
 }
 
+func acquireMigrateLock(ctx context.Context, db DBConn) error {
+	var locked sql.NullInt64
+	if err := db.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", migrateLockName, migrateLockTimeoutSec).Scan(&locked); err != nil {
+		return fmt.Errorf("acquiring schema migration lock %q: %w", migrateLockName, err)
+	}
+	if !locked.Valid || locked.Int64 != 1 {
+		return fmt.Errorf("acquiring schema migration lock %q: timed out after %ds (another connection holds it)", migrateLockName, migrateLockTimeoutSec)
+	}
+	return nil
+}
+
+func releaseMigrateLock(ctx context.Context, db DBConn) {
+	_, _ = db.ExecContext(ctx, "SELECT RELEASE_LOCK(?)", migrateLockName)
+}
+
 func parseVersion(name string) (int, error) {
 	parts := strings.SplitN(name, "_", 2)
 	if len(parts) == 0 {
@@ -87,7 +102,21 @@ func parseVersion(name string) (int, error) {
 	return strconv.Atoi(parts[0])
 }
 
+const (
+	migrateLockName       = "bd_schema_migrate"
+	migrateLockTimeoutSec = 30
+)
+
 func MigrateUp(ctx context.Context, db DBConn) (int, error) {
+	if mainSource.atLatest(ctx, db) && ignoredSource.atLatest(ctx, db) {
+		return 0, nil
+	}
+
+	if err := acquireMigrateLock(ctx, db); err != nil {
+		return 0, err
+	}
+	defer releaseMigrateLock(ctx, db)
+
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {
 		return applied, err
@@ -161,6 +190,14 @@ func (m migrationSource) latest() int {
 		return 0
 	}
 	return files[len(files)-1].version
+}
+
+func (m migrationSource) atLatest(ctx context.Context, db DBConn) bool {
+	var current int
+	if err := db.QueryRowContext(ctx, "SELECT COALESCE(MAX(version), 0) FROM "+m.cursorTable).Scan(&current); err != nil {
+		return false
+	}
+	return current >= m.latest()
 }
 
 func (m migrationSource) migrate(ctx context.Context, db DBConn) (int, error) {


### PR DESCRIPTION
<!--
This is a starting scaffold to help reviewers (human and agent) parse intent before diff.
Replace, expand, or delete sections freely. CONTRIBUTING.md has the full hygiene rules.
-->

## What

<!-- One or two plain-language sentences: what does this change do? -->

## Why

<!-- The problem this solves, the motivation, or a link to the issue: e.g. "Fixes #123" -->

## Verification

<!-- How you tested. Commands a reviewer can run to confirm. -->
