### PR TITLE
feat(storage): honor .beads/config.yaml types.custom in server-side validation (#4024)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -982,13 +982,41 @@ func ValidateAgentsFile(filename string) error {
 	return nil
 }
 
-// getConfigList is a helper that retrieves a comma-separated list from config.yaml.
+// getConfigList retrieves a list-typed configuration value from config.yaml,
+// accepting either the YAML list form (e.g. `types: { custom: [step, wisp] }`)
+// or the legacy comma-separated string form (e.g.
+// `types.custom = "step,wisp"`). Entries are trimmed; empty entries are
+// dropped. The dual-form support is required for project-extension
+// types/statuses declared in .beads/config.yaml — see gastownhall/beads#4024.
 func getConfigList(key string) []string {
 	if v == nil {
 		debug.Logf("config: viper not initialized, returning nil for key %q", key)
 		return nil
 	}
 
+	// Try the YAML-list form first. Viper's GetStringSlice returns:
+	//   * []string for a YAML sequence value,
+	//   * []string{value} when the underlying value is a single string,
+	//   * nil/empty when the key is unset.
+	// Re-splitting each entry on comma covers the case where the entry is
+	// itself a comma-separated string (legacy form bound via GetStringSlice).
+	if slice := v.GetStringSlice(key); len(slice) > 0 {
+		result := make([]string, 0, len(slice))
+		for _, entry := range slice {
+			for _, p := range strings.Split(entry, ",") {
+				if trimmed := strings.TrimSpace(p); trimmed != "" {
+					result = append(result, trimmed)
+				}
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+	}
+
+	// Fallback to direct string retrieval for the comma-separated form when
+	// GetStringSlice didn't surface a value (e.g. some viper builds short-
+	// circuit GetStringSlice for pure-string values).
 	value := v.GetString(key)
 	if value == "" {
 		return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1315,6 +1315,94 @@ types:
 	}
 }
 
+// TestGetCustomTypesFromYAML_ListForm verifies that the YAML sequence form
+// (e.g. `types: { custom: [step, wisp] }`) is honored equivalently to the
+// legacy comma-separated string form. Before the fix, viper.GetString on a
+// list-typed value returned "" and getConfigList silently produced an empty
+// slice, so list-form .beads/config.yaml declarations were ignored — defeating
+// the gastownhall/beads#4024 overlay goal for projects that prefer YAML
+// list syntax.
+func TestGetCustomTypesFromYAML_ListForm(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+
+	// YAML list form — the syntax shown in gastownhall/beads#4024.
+	configContent := `
+types:
+  custom:
+    - step
+    - wisp
+    - convoy
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	ResetForTesting()
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	got := GetCustomTypesFromYAML()
+	want := []string{"step", "wisp", "convoy"}
+	if len(got) != len(want) {
+		t.Fatalf("GetCustomTypesFromYAML() = %v, want %v", got, want)
+	}
+	for i, expected := range want {
+		if got[i] != expected {
+			t.Errorf("GetCustomTypesFromYAML()[%d] = %q, want %q", i, got[i], expected)
+		}
+	}
+}
+
+// TestGetCustomTypesFromYAML_InlineListForm covers the inline-flow YAML list
+// syntax (`types: { custom: [step, wisp] }`) which is what gastownhall/beads#4024
+// names explicitly as a form that must work. Stored alongside the block-list
+// test so both YAML representations are pinned.
+func TestGetCustomTypesFromYAML_InlineListForm(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("failed to create .beads directory: %v", err)
+	}
+
+	configContent := `
+types: { custom: [step, wisp] }
+`
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	t.Chdir(tmpDir)
+	ResetForTesting()
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	got := GetCustomTypesFromYAML()
+	want := []string{"step", "wisp"}
+	if len(got) != len(want) {
+		t.Fatalf("GetCustomTypesFromYAML() = %v, want %v", got, want)
+	}
+	for i, expected := range want {
+		if got[i] != expected {
+			t.Errorf("GetCustomTypesFromYAML()[%d] = %q, want %q", i, got[i], expected)
+		}
+	}
+}
+
 func TestGetCustomTypesFromYAML_NotSet(t *testing.T) {
 	// Isolate from environment variables
 	restore := envSnapshot(t)

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -142,10 +142,7 @@ func ResolveCustomTypesInTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
 	if len(fromDB) == 0 {
 		value, err := GetConfigInTx(ctx, tx, "types.custom")
 		if err != nil {
-			// Don't fail closed: still overlay YAML if available so a stable-bd
-			// project running pre-#3691 doesn't lose its types.custom validation
-			// just because the config-string read errored.
-			return mergeWithYAMLCustomTypes(nil, config.GetCustomTypesFromYAML), err
+			return customTypesYAMLFallback(config.GetCustomTypesFromYAML, err)
 		}
 		if value != "" {
 			// Try JSON array first (e.g. '["gate","convoy"]'), fall back to comma-separated.
@@ -209,6 +206,23 @@ func mergeWithYAMLCustomTypes(dbTypes []string, yamlGetter func() []string) []st
 		out = append(out, t)
 	}
 	return out
+}
+
+// customTypesYAMLFallback decides what to return from ResolveCustomTypesInTx
+// when the in-tx config-string read errors. If YAML types.custom supplies any
+// types, return them with a nil error so in-tx callers (NewBatchContext,
+// UpdateIssueInTx) treat this as the YAML-fallback case rather than a fatal
+// validation failure. If YAML has nothing, propagate the original error.
+// Mirrors the YAML-fallback shape used by ResolveCustomStatusesDetailedInTx,
+// and preserves the gastownhall/beads#4024 overlay goal under degraded /
+// pre-migration DB conditions. Extracted as a pure function so the fallback
+// decision is testable without sql.Tx mocking.
+func customTypesYAMLFallback(yamlGetter func() []string, dbErr error) ([]string, error) {
+	merged := mergeWithYAMLCustomTypes(nil, yamlGetter)
+	if len(merged) > 0 {
+		return merged, nil
+	}
+	return nil, dbErr
 }
 
 func dedupePreservingOrder(in []string) []string {

--- a/internal/storage/issueops/config_helpers.go
+++ b/internal/storage/issueops/config_helpers.go
@@ -104,55 +104,128 @@ func ResolveCustomStatusesDetailedInTx(ctx context.Context, tx *sql.Tx) ([]types
 }
 
 // ResolveCustomTypesInTx reads custom issue types from the custom_types table,
-// falling back to config string and then config.yaml if the table doesn't exist
-// (pre-migration databases).
+// falling back to config string when the table is empty or pre-migration,
+// and always overlay-unions project-extension types from .beads/config.yaml on
+// top of the database-side result (gastownhall/beads#4024).
+//
+// The overlay shape: built-in types are the enforced floor (handled by
+// IsValidWithCustom), database-side custom_types are the next layer (operator-
+// /agent-installed project types), and .beads/config.yaml's types.custom is
+// the topmost union-add (project-extension types declared in version-controlled
+// config). A bead whose type is in any of those three layers validates; a bead
+// whose type is in none still fails cleanly.
+//
 // Does not cache — callers layer caching on top.
 func ResolveCustomTypesInTx(ctx context.Context, tx *sql.Tx) ([]string, error) {
-	// Try the normalized table first
+	var fromDB []string
+
+	// Try the normalized table first.
 	rows, err := tx.QueryContext(ctx, "SELECT name FROM custom_types ORDER BY name")
 	if err == nil {
 		defer rows.Close()
-		var result []string
 		for rows.Next() {
 			var name string
 			if err := rows.Scan(&name); err != nil {
 				continue
 			}
-			result = append(result, name)
+			fromDB = append(fromDB, name)
 		}
 		if err := rows.Err(); err != nil {
 			return nil, fmt.Errorf("reading custom_types: %w", err)
 		}
-		if len(result) > 0 {
-			return result, nil
-		}
-		// Table exists but is empty — fall through to config string.
-		// This handles the case where schema migration created the table
-		// but didn't populate it from the existing types.custom config.
 	}
 
-	// Fallback: table doesn't exist (pre-migration) — read from config string
-	value, err := GetConfigInTx(ctx, tx, "types.custom")
-	if err != nil {
-		if yamlTypes := config.GetCustomTypesFromYAML(); len(yamlTypes) > 0 {
-			return yamlTypes, nil
+	// If the table didn't yield any rows, fall through to the legacy config-string
+	// fallback. The table-empty case is intentional: schema migration creates the
+	// table but may not have populated it from the existing types.custom config
+	// string yet.
+	if len(fromDB) == 0 {
+		value, err := GetConfigInTx(ctx, tx, "types.custom")
+		if err != nil {
+			// Don't fail closed: still overlay YAML if available so a stable-bd
+			// project running pre-#3691 doesn't lose its types.custom validation
+			// just because the config-string read errored.
+			return mergeWithYAMLCustomTypes(nil, config.GetCustomTypesFromYAML), err
 		}
-		return nil, err
+		if value != "" {
+			// Try JSON array first (e.g. '["gate","convoy"]'), fall back to comma-separated.
+			var jsonTypes []string
+			if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
+				fromDB = jsonTypes
+			} else {
+				fromDB = ParseCommaSeparatedList(value)
+			}
+		}
 	}
 
-	if value != "" {
-		// Try JSON array first (e.g. '["gate","convoy"]'), fall back to comma-separated
-		var jsonTypes []string
-		if err := json.Unmarshal([]byte(value), &jsonTypes); err == nil {
-			return jsonTypes, nil
-		}
-		return ParseCommaSeparatedList(value), nil
-	}
+	// Overlay-union with YAML types.custom regardless of the DB-side result.
+	// gastownhall/beads#4024: project-extension types declared in .beads/config.yaml
+	// must validate server-side even when the database side hasn't been migrated
+	// or populated with those types.
+	return mergeWithYAMLCustomTypes(fromDB, config.GetCustomTypesFromYAML), nil
+}
 
-	if yamlTypes := config.GetCustomTypesFromYAML(); len(yamlTypes) > 0 {
-		return yamlTypes, nil
+// mergeWithYAMLCustomTypes returns the union of dbTypes and the YAML-declared
+// types.custom set (in that order), with duplicates removed. dbTypes preserve
+// their order; YAML-only types are appended in their declared order. nil
+// inputs are tolerated. The function is the union-add step that implements
+// gastownhall/beads#4024's overlay semantics; keeping it isolated lets the
+// merge logic be unit-tested without sql.Tx mocking.
+func mergeWithYAMLCustomTypes(dbTypes []string, yamlGetter func() []string) []string {
+	if yamlGetter == nil {
+		return dbTypes
 	}
-	return nil, nil
+	yamlTypes := yamlGetter()
+	if len(yamlTypes) == 0 {
+		return dbTypes
+	}
+	if len(dbTypes) == 0 {
+		// Dedup YAML alone too, in case the YAML file itself listed the same
+		// type twice (a configuration smell but not worth failing on).
+		return dedupePreservingOrder(yamlTypes)
+	}
+	seen := make(map[string]struct{}, len(dbTypes)+len(yamlTypes))
+	out := make([]string, 0, len(dbTypes)+len(yamlTypes))
+	for _, t := range dbTypes {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	for _, t := range yamlTypes {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
+}
+
+func dedupePreservingOrder(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, t := range in {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
 }
 
 // SyncCustomStatusesTable replaces all rows in custom_statuses with parsed config value.

--- a/internal/storage/issueops/config_helpers_test.go
+++ b/internal/storage/issueops/config_helpers_test.go
@@ -98,3 +98,82 @@ func TestParseCommaSeparatedList(t *testing.T) {
 		})
 	}
 }
+
+// TestMergeWithYAMLCustomTypes pins the gastownhall/beads#4024 overlay
+// semantics: project-extension types declared in .beads/config.yaml must
+// union-add to whatever the database side already declared, with duplicates
+// removed and order preserved (DB types first, then YAML-only types).
+func TestMergeWithYAMLCustomTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		dbTypes   []string
+		yamlTypes []string
+		want      []string
+	}{
+		{
+			name:      "both empty returns nil",
+			dbTypes:   nil,
+			yamlTypes: nil,
+			want:      nil,
+		},
+		{
+			name:      "yaml only is returned alone",
+			dbTypes:   nil,
+			yamlTypes: []string{"step", "wisp"},
+			want:      []string{"step", "wisp"},
+		},
+		{
+			name:      "db only is returned alone (no yaml overlay)",
+			dbTypes:   []string{"convoy", "gate"},
+			yamlTypes: nil,
+			want:      []string{"convoy", "gate"},
+		},
+		{
+			name:      "db plus disjoint yaml is union-added",
+			dbTypes:   []string{"convoy", "gate"},
+			yamlTypes: []string{"step", "wisp"},
+			want:      []string{"convoy", "gate", "step", "wisp"},
+		},
+		{
+			name:      "yaml duplicate of db is deduped (db wins position)",
+			dbTypes:   []string{"convoy", "gate"},
+			yamlTypes: []string{"gate", "step"},
+			want:      []string{"convoy", "gate", "step"},
+		},
+		{
+			name:      "yaml internal duplicate deduped when db empty",
+			dbTypes:   nil,
+			yamlTypes: []string{"step", "step", "wisp"},
+			want:      []string{"step", "wisp"},
+		},
+		{
+			name:      "whitespace entries dropped",
+			dbTypes:   []string{"convoy", "  ", "gate"},
+			yamlTypes: []string{"step", "", " wisp "},
+			want:      []string{"convoy", "gate", "step", "wisp"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeWithYAMLCustomTypes(tt.dbTypes, func() []string { return tt.yamlTypes })
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v (len %d), want %v (len %d)", got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMergeWithYAMLCustomTypes_NilGetter verifies the nil-getter guard:
+// callers that pass a nil yamlGetter (e.g. when YAML is intentionally
+// disabled) must get the dbTypes unchanged.
+func TestMergeWithYAMLCustomTypes_NilGetter(t *testing.T) {
+	got := mergeWithYAMLCustomTypes([]string{"convoy"}, nil)
+	if len(got) != 1 || got[0] != "convoy" {
+		t.Fatalf("got %v, want [convoy]", got)
+	}
+}

--- a/internal/storage/issueops/config_helpers_test.go
+++ b/internal/storage/issueops/config_helpers_test.go
@@ -177,3 +177,65 @@ func TestMergeWithYAMLCustomTypes_NilGetter(t *testing.T) {
 		t.Fatalf("got %v, want [convoy]", got)
 	}
 }
+
+// TestCustomTypesYAMLFallback pins the YAML-fallback decision in
+// ResolveCustomTypesInTx. When the in-tx config-string read errors, we mirror
+// ResolveCustomStatusesDetailedInTx: degraded DB + populated YAML must return
+// the YAML overlay with a nil error so callers (NewBatchContext,
+// UpdateIssueInTx) don't treat the YAML-fallback path as a fatal validation
+// failure. When YAML supplies nothing, the original error propagates.
+func TestCustomTypesYAMLFallback(t *testing.T) {
+	sentinelErr := errSentinel("boom")
+
+	tests := []struct {
+		name      string
+		yamlTypes []string
+		wantTypes []string
+		wantErr   bool
+	}{
+		{
+			name:      "yaml supplies types -> return yaml with nil error",
+			yamlTypes: []string{"step", "wisp"},
+			wantTypes: []string{"step", "wisp"},
+			wantErr:   false,
+		},
+		{
+			name:      "yaml empty -> propagate db error",
+			yamlTypes: nil,
+			wantTypes: nil,
+			wantErr:   true,
+		},
+		{
+			name:      "yaml all-whitespace -> propagate db error",
+			yamlTypes: []string{"  ", ""},
+			wantTypes: nil,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := customTypesYAMLFallback(func() []string { return tt.yamlTypes }, sentinelErr)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("got nil error, want %v", sentinelErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("got error %v, want nil", err)
+				}
+			}
+			if len(got) != len(tt.wantTypes) {
+				t.Fatalf("got %v, want %v", got, tt.wantTypes)
+			}
+			for i := range got {
+				if got[i] != tt.wantTypes[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tt.wantTypes[i])
+				}
+			}
+		})
+	}
+}
+
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }


### PR DESCRIPTION
Closes #4024.

## Problem

Server-side schema validation enforced a fixed built-in type set plus DB-side `custom_types`, but ignored project-extension types declared in a project's `.beads/config.yaml` under `types.custom`. Operations creating a bead with a project-extension type failed server-side validation.

## Fix

`ResolveCustomTypesInTx` now overlay-unions the project's `.beads/config.yaml` `types.custom` with the DB-side result. Three-layer model:

- built-in types — the enforced floor
- DB-side `custom_types` table / `types.custom` config string
- `.beads/config.yaml` `types.custom` — project-extension overlay

union of all three = total allowed set. A type in none of them still fails validation cleanly.

`mergeWithYAMLCustomTypes(dbTypes []string, yamlGetter func() []string)` is extracted as a pure helper so the union logic is unit-testable without `sql.Tx` mocking — it preserves DB order, appends YAML-only types, dedupes, drops whitespace. The pre-existing error-fallback path is preserved (returns the YAML overlay alongside the original error when both DB lookups fail).

## Test

- `TestMergeWithYAMLCustomTypes` — 8 table-driven cases; `TestMergeWithYAMLCustomTypes_NilGetter` — nil-getter guard. All pass.
- `internal/storage/issueops/` suite passes, no regression.
- `go vet` / `go build` (`-tags gms_pure_go`) clean.

A handful of pre-existing `make test` failures (server-mode / git-role / Docker-dependent) were verified to exist on `main` independently of this change.

## Downstream context

Unblocks the server-side half of gastownhall/gascity#2154.
