### PR TITLE
fix(human): remove non-existent bd sync from help text

### DIFF
--- a/cmd/bd/human.go
+++ b/cmd/bd/human.go
@@ -68,9 +68,8 @@ SUBCOMMANDS:
 		fmt.Println()
 
 		// Setup & Maintenance
-		fmt.Printf("%s\n", ui.RenderAccent("Setup & Sync:"))
+		fmt.Printf("%s\n", ui.RenderAccent("Setup & Maintenance:"))
 		printCmd("init", "Initialize bd in current directory")
-		printCmd("sync", "Sync issues with git remote")
 		printCmd("doctor", "Check installation health")
 		fmt.Println()
 


### PR DESCRIPTION
## What
Remove the `sync` entry from `bd human`'s help output, and rename the
section heading from "Setup & Sync:" to "Setup & Maintenance:" — which
matches the existing source comment on the same block.

## Why
`bd sync` isn't a registered top-level command. Running it errors with
`unknown command "sync" for "bd"`, so the help line was actively
misleading users. `sync` only exists as a sub-subcommand of integrations
(`bd github sync`, `bd jira sync`, ...).

The section comment in `cmd/bd/human.go:62` already said
`// Setup & Maintenance`, so the rendered heading and the code intent
had drifted apart.

Closes GH#3851

## Verification
- `go test -tags gms_pure_go -run TestHuman ./cmd/bd/...` passes
- `go vet -tags gms_pure_go ./cmd/bd/...` clean
- Grepped `cmd/` for `Use: "sync"` — only sub-subcommand registrations
  found (integrations), confirming no top-level `sync` exists.