### PR TITLE
fix(schema): unify migration advisory lock path

### DIFF
--- a/internal/storage/schema/lock_test.go
+++ b/internal/storage/schema/lock_test.go
@@ -1,9 +1,13 @@
 package schema
 
 import (
+	"context"
 	"errors"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestMigrationLockNameUsesRawNameWhenBounded(t *testing.T) {
@@ -33,4 +37,93 @@ func TestIsMigrationLockError(t *testing.T) {
 	if !IsMigrationLockError(err) {
 		t.Fatal("IsMigrationLockError() = false, want true")
 	}
+}
+
+func TestMigrateUpRunsWithoutAdvisoryLock(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	expectOnePendingMigration(t, mock)
+
+	applied, err := MigrateUp(context.Background(), db)
+	if err != nil {
+		t.Fatalf("MigrateUp() error = %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("MigrateUp() applied = %d, want 1", applied)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestMigrateUpWithLockUsesDatabaseScopedLockOnly(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin mock connection: %v", err)
+	}
+	defer conn.Close()
+
+	lockName := MigrationLockName("testdb")
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT GET_LOCK(?, ?)")).
+		WithArgs(lockName, migrationLockAcquireTimeoutSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"locked"}).AddRow(1))
+	expectOnePendingMigration(t, mock)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT RELEASE_LOCK(?)")).
+		WithArgs(lockName).
+		WillReturnRows(sqlmock.NewRows([]string{"released"}).AddRow(1))
+
+	applied, err := MigrateUpWithLock(ctx, conn, "testdb")
+	if err != nil {
+		t.Fatalf("MigrateUpWithLock() error = %v", err)
+	}
+	if applied != 1 {
+		t.Fatalf("MigrateUpWithLock() applied = %d, want 1", applied)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func expectOnePendingMigration(t *testing.T, mock sqlmock.Sqlmock) {
+	t.Helper()
+
+	latest := LatestVersion()
+	latestIgnored := LatestIgnoredVersion()
+
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
+	mock.ExpectExec("(?s)^CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM schema_migrations", "version", latest-1)
+	mock.ExpectExec("(?s).*").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT IGNORE INTO schema_migrations (version) VALUES (?)")).
+		WithArgs(latest).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_types", "count", 1)
+	expectScalar(mock, "SELECT COUNT(*) FROM custom_statuses", "count", 1)
+	mock.ExpectExec(regexp.QuoteMeta("REPLACE INTO dolt_ignore VALUES ('ignored_schema_migrations', true)")).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("(?s)^CREATE TABLE IF NOT EXISTS ignored_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	expectScalar(mock, "SELECT COALESCE(MAX(version), 0) FROM ignored_schema_migrations", "version", latestIgnored)
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_ADD('-A')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("CALL DOLT_COMMIT('-m', 'schema: apply migrations')")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func expectScalar(mock sqlmock.Sqlmock, query, column string, value any) {
+	mock.ExpectQuery(regexp.QuoteMeta(query)).
+		WillReturnRows(sqlmock.NewRows([]string{column}).AddRow(value))
 }

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 type DBConn interface {
@@ -80,36 +79,6 @@ func AllMigrationsSQL() string {
 	return b.String()
 }
 
-func acquireMigrateLock(ctx context.Context, db DBConn) error {
-	var locked sql.NullInt64
-	if err := db.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", migrateLockName, migrateLockTimeoutSec).Scan(&locked); err != nil {
-		return fmt.Errorf("failed to acquire schema advisory lock: %w", err)
-	}
-	if !locked.Valid {
-		return fmt.Errorf("failed to acquire schema advisory lock")
-	}
-	if locked.Int64 != 1 {
-		return fmt.Errorf("schema advisory lock timeout")
-	}
-	return nil
-}
-
-func releaseMigrateLock(ctx context.Context, db DBConn) {
-	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-	defer cancel()
-
-	var released sql.NullInt64
-	if err := db.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", migrateLockName).Scan(&released); err != nil {
-		return
-	}
-	if !released.Valid {
-		return
-	}
-	if released.Int64 != 1 {
-		panic("failed to release schema advisory lock: lock not held")
-	}
-}
-
 func parseVersion(name string) (int, error) {
 	parts := strings.SplitN(name, "_", 2)
 	if len(parts) == 0 {
@@ -118,20 +87,10 @@ func parseVersion(name string) (int, error) {
 	return strconv.Atoi(parts[0])
 }
 
-const (
-	migrateLockName       = "bd_schema_migrate"
-	migrateLockTimeoutSec = 30
-)
-
 func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if mainSource.atLatest(ctx, db) && ignoredSource.atLatest(ctx, db) {
 		return 0, nil
 	}
-
-	if err := acquireMigrateLock(ctx, db); err != nil {
-		return 0, err
-	}
-	defer releaseMigrateLock(ctx, db)
 
 	applied, err := mainSource.migrate(ctx, db)
 	if err != nil {


### PR DESCRIPTION
## What

Remove the older generic `MigrateUp` advisory lock from PR #4017 so schema migration locking has one explicit path: `MigrateUpWithLock(ctx, *sql.Conn, databaseName)`.

This keeps the shared schema-package locking API, but makes the lock contract pinned-connection based, database-scoped, and typed for retry behavior. Bare `MigrateUp` remains the unlocked migration runner for embedded Dolt and tests.

## Why

After #4005 and #4017 both landed, server-mode Dolt initialization acquired two advisory locks: the hardened per-database `bd_schema_init:<database>` lock and the older global `bd_schema_migrate` lock inside `MigrateUp`. That over-serializes unrelated database migrations and leaves a generic `DBConn` API holding a session-scoped lock without expressing the pinned-connection requirement.

## Verification

Passed:

- `./scripts/test.sh ./internal/storage/schema`
- `./scripts/test.sh -run 'TestConcurrentInitSchema|TestInitSchemaBlocksOnMigrationLock|TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit|TestMigrationLockReleaseIgnoresCanceledCallerContext|TestMultiProcessSchemaInit|TestIsRetryableErrorSchemaMigrationLock' ./internal/storage/dolt`
- `go vet ./...`
- `git diff --check`

Also ran `make test`; it did not complete cleanly in this worktree. Failures were broad-suite/environmental and unrelated to the schema package change, including timeouts in `cmd/bd`, `internal/storage/dolt`, and `internal/tracker`, plus existing-looking failures in `cmd/bd/doctor` and `cmd/bd/protocol`. The touched schema package and targeted Dolt init-lock regression set passed when run in isolation.
