### PR TITLE
fix(auto-import): gate JSONL upgrade-recovery to embedded server mode

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1034,7 +1034,17 @@ var rootCmd = &cobra.Command{
 		// Skip auto-import when the user is explicitly running "bd import" —
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
-		if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" {
+		//
+		// Gate to ServerModeEmbedded only. In Owned/External (shared)
+		// server mode there is no per-clone embedded DB to recover into:
+		// the empty-DB probe runs before the session selects the
+		// configured database, always reports "empty", and fires a
+		// spurious auto-import against the wrong/empty view on every
+		// command. The data is safe on the shared server; the import
+		// just fails noisily. Auto-import is only meaningful for the
+		// legacy in-process embedded path it was written for.
+		if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" &&
+			doltserver.ResolveServerMode(beadsDir) == doltserver.ServerModeEmbedded {
 			maybeAutoImportJSONL(rootCtx, store, beadsDir)
 		}
 

--- a/release-gates/be-5hl6-gate.md
+++ b/release-gates/be-5hl6-gate.md
@@ -1,0 +1,28 @@
+# Release gate: be-5hl6 — gate JSONL auto-import to embedded server mode
+
+- **Bead:** be-5hl6 (Review: gate JSONL upgrade-recovery to embedded server mode, PR #3995)
+- **Source PR:** https://github.com/gastownhall/beads/pull/3995 (shaunc:fix/auto-import-gate-embedded-mode)
+- **Deploy branch:** `release/be-5hl6-auto-import-embedded` off `origin/main` (e569c7488)
+- **Cherry-picked commit:** `b1609dff` (auto-import: gate JSONL upgrade-recovery to embedded server mode)
+- **Evaluated:** 2026-05-19 by beads/deployer
+
+## Commit
+
+| SHA | Subject |
+|-----|---------|
+| `32b8b32be` | auto-import: gate JSONL upgrade-recovery to embedded server mode (cherry-pick of b1609dff) |
+
+1 file changed: `cmd/bd/main.go` — gates `maybeAutoImportJSONL` call with `doltserver.ResolveServerMode(beadsDir) == doltserver.ServerModeEmbedded`.
+
+## Gate criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | **PASS** | be-5hl6 notes: "Review verdict: PASS. Gate correct: maybeAutoImportJSONL gated to ServerModeEmbedded using existing tested ResolveServerMode. CI all green. No findings." (2026-05-19) |
+| 2 | Acceptance criteria met | **PASS** | cmd/bd/main.go:1018 — condition now includes `&& doltserver.ResolveServerMode(beadsDir) == doltserver.ServerModeEmbedded`; compiles clean with `-tags gms_pure_go` |
+| 3 | Tests pass | **PASS** | CI 40/40 SUCCESS on source PR #3995; local TestWhereCommand_ReadsPrefixFromEmbeddedStore fails identically on origin/main (pre-existing, Docker not available in this environment — covered by cross-version smokes in CI) |
+| 4 | No high-severity review findings open | **PASS** | 0 findings in be-5hl6 (reviewer noted only a coverage gap on PersistentPreRun as legitimately hard to test) |
+| 5 | Final branch is clean | **PASS** | `git status` clean after cherry-pick commit |
+| 6 | Branch diverges cleanly from main | **PASS** | Cherry-pick applied with no conflicts onto origin/main; 1 commit ahead |
+
+## Verdict: PASS


### PR DESCRIPTION
## What this changes

`bd` calls `maybeAutoImportJSONL` in its `PersistentPreRun` hook to recover
issues from a git-tracked `issues.jsonl` on first startup after upgrading from
an older embedded-DB layout. This call was unconditional: it fired in every
server mode, including `Owned` and `External` (shared-server modes).

In shared-server modes the call misfires: the empty-DB probe runs before the
session connects to the configured database, always sees an empty view, and
triggers a spurious JSONL import against the wrong (empty) database. The data
on the shared server is safe, but the import exits noisily on every command.

The fix adds a mode guard using the existing `doltserver.ResolveServerMode`
function (already unit-tested). `maybeAutoImportJSONL` now runs only when
`ResolveServerMode` returns `ServerModeEmbedded`.

## Review notes

- The only changed line is the condition in `cmd/bd/main.go` around the
  `maybeAutoImportJSONL` call. No other logic changes.
- `doltserver.ResolveServerMode` reads `config.yaml`; the same function drives
  server-mode branching elsewhere in the codebase.
- Source PR: #3995 (shaunc). This deploy branch is a clean cherry-pick onto
  current `main` (no conflicts).

## Test plan

- [x] `go test ./...` — all shards PASS (CI 40/40 on source PR #3995)
- [x] Cherry-pick applied without conflicts onto current `main`
- [x] Release gate: `release-gates/be-5hl6-gate.md`

🤖 Deployed by actual-factory