### PR TITLE
docs: clarify export versus database backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ This is the recommended mode for most users.
 When the git repo has an `origin` remote, `bd init` configures a Dolt remote
 named `origin` automatically. Cross-machine sync uses `bd dolt push` and
 `bd dolt pull` against `refs/dolt/data`; `.beads/issues.jsonl` is an export
-for viewers, interchange, and backup, not the source of truth.
+for viewers and interchange, not the source of truth or a full database
+backup.
 
 ### Server Mode
 
@@ -165,6 +166,11 @@ bd backup restore --force /path/to/backup
 
 See [docs/DOLT.md](docs/DOLT.md#migrating-between-backends) for full
 migration instructions.
+
+`bd export` and `.beads/issues.jsonl` are issue-table exports. They are useful
+for review, migration, and interoperability, but they do not capture Dolt
+branches, commit history, working-set state, or non-issue tables. Use
+`bd backup` or a manual Dolt backup when you need a restorable database backup.
 
 ## 🌐 Community Tools
 

--- a/cmd/bd/backup.go
+++ b/cmd/bd/backup.go
@@ -14,6 +14,11 @@ var backupCmd = &cobra.Command{
 	Short: "Back up your beads database",
 	Long: `Back up your beads database for off-machine recovery.
 
+This is a Dolt-native database backup. It preserves the database state,
+including tables, branches, commit history, and working-set data. This is
+different from 'bd export', which writes issue records to JSONL for migration
+and interoperability.
+
 Commands:
   bd backup init <path>    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination

--- a/cmd/bd/backup_dolt.go
+++ b/cmd/bd/backup_dolt.go
@@ -20,7 +20,7 @@ import (
 // These wrap Dolt's built-in backup feature (CALL DOLT_BACKUP(...)) for standalone
 // users who want their beads database backed up to a filesystem path, NAS, or DoltHub.
 //
-// Unlike the JSONL backup (bd backup), Dolt backups preserve full commit history
+// Unlike issue JSONL exports, Dolt-native backups preserve full commit history
 // and are faster for large databases.
 
 const defaultDoltBackupName = "default"

--- a/cmd/bd/backup_restore.go
+++ b/cmd/bd/backup_restore.go
@@ -21,6 +21,10 @@ var backupRestoreCmd = &cobra.Command{
 By default, reads from .beads/backup/ (or the configured backup directory).
 Optionally specify a path to a directory containing a Dolt backup.
 
+This restores a full database backup created by 'bd backup sync' or an
+equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
+not restore targets for this command.
+
 Use --force to overwrite an existing database with the backup contents.
 
 The database must already be initialized (run 'bd init' first if needed).

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -37,7 +37,7 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  Enabled by default. Useful for viewers (bv) and interchange; not a backup.
   It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -23,9 +23,10 @@ var exportCmd = &cobra.Command{
 Each line is a complete JSON object representing one issue, including its
 labels, dependencies, and comments.
 
-This command is for issue export, migration, and interoperability. It does
-not produce the JSONL backup snapshot used by 'bd backup restore'. For
-supported backup/restore flows, use 'bd backup', 'bd backup export-git',
+This command is for issue export, migration, and interoperability. It exports
+records from the issues table; it is not a full database backup and does not
+capture Dolt branches, commit history, working-set state, or non-issue tables.
+For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
@@ -37,7 +38,7 @@ include them.
 
 EXAMPLES:
   bd export                              # Export issues to stdout
-  bd export -o backup.jsonl              # Export to file
+  bd export -o issues.jsonl              # Export issues to file
   bd export --include-memories           # Export issues + memories
   bd export --all -o full.jsonl          # Include infra + templates + gates + memories
   bd export --scrub -o clean.jsonl       # Exclude test/pollution records`,
@@ -88,7 +89,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 		w = os.Stdout
 	}
 
-	// Build filter for issues table. Export all statuses (this is a backup tool).
+	// Build filter for issues table. Export all statuses by default.
 	filter := types.IssueFilter{Limit: 0}
 
 	// Exclude infra types by default (agents, rigs, roles, messages)

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -55,8 +55,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv), interchange, and backups up to date without extra steps.
-Cross-machine sync uses Dolt remotes, not JSONL import/export.
+viewers (bv) and interchange up to date without extra steps.
+Cross-machine sync and backups use Dolt remotes/backups, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
@@ -1976,7 +1976,7 @@ func promptContributorMode() (isContributor bool, err error) {
 // Returns true to keep it enabled, false to disable.
 func promptAutoExport() (bool, error) {
 	fmt.Printf("\n%s Auto-export keeps .beads/issues.jsonl up to date after every write command.\n", ui.RenderAccent("▶"))
-	fmt.Println("  This is useful for viewers (bv), interchange, and backups. Dolt remotes handle sync.")
+	fmt.Println("  This is useful for viewers (bv) and interchange. Dolt remotes/backups handle sync and backup.")
 	fmt.Print("\nEnable auto-export? [Y/n]: ")
 
 	reader := bufio.NewReader(os.Stdin)

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -290,7 +290,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				fmt.Fprintf(os.Stderr, "  This action CANNOT be undone. All issues, dependencies, and\n")
 				fmt.Fprintf(os.Stderr, "  Dolt commit history will be permanently lost.\n\n")
 				fmt.Fprintf(os.Stderr, "  Before proceeding, consider:\n")
-				fmt.Fprintf(os.Stderr, "    bd export > backup.jsonl    # Export issues to JSONL\n")
+				fmt.Fprintf(os.Stderr, "    bd export > issue-export.jsonl    # Export issue records, not full DB state\n")
 				fmt.Fprintf(os.Stderr, "    bd dolt status              # Check if this is a server config issue\n\n")
 				if term.IsTerminal(int(os.Stdin.Fd())) {
 					fmt.Fprintf(os.Stderr, "Type 'destroy %d issues' to confirm: ", count)
@@ -315,7 +315,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					} else {
 						fmt.Fprintf(os.Stderr, "Refusing to destroy %d issues in non-interactive mode.\n", count)
 						fmt.Fprintf(os.Stderr, "  See 'bd help init-safety' for the required --destroy-token format.\n")
-						fmt.Fprintf(os.Stderr, "  Or export first: bd export > backup.jsonl\n")
+						fmt.Fprintf(os.Stderr, "  Or export issue records first: bd export > issue-export.jsonl\n")
 						os.Exit(ExitDestroyTokenMissing)
 					}
 				}
@@ -1675,7 +1675,7 @@ To use the existing database:
   Just run bd commands normally (e.g., %s)
 
 If the database is genuinely corrupt and unrecoverable:
-  bd export > backup.jsonl              # Back up first!
+  bd export > issue-export.jsonl        # Export issue records first
   bd init --reinit-local --prefix %s    # Then reinitialize
 
 Aborting.`, ui.RenderWarn("⚠"), location, ui.RenderAccent("bd list"), prefix)
@@ -1736,7 +1736,7 @@ To use the existing database:
   Just run bd commands normally (e.g., %s)
 
 If the database is genuinely corrupt and unrecoverable:
-  bd export > backup.jsonl              # Back up first!
+  bd export > issue-export.jsonl        # Export issue records first
   bd init --reinit-local --prefix %s    # Then reinitialize
 
 Aborting.`, ui.RenderWarn("⚠"), location, ui.RenderAccent("bd list"), prefix)
@@ -1765,7 +1765,7 @@ To use the existing database:
   The redirect will route to the canonical database.
 
 If the database is genuinely corrupt and unrecoverable:
-  bd export > backup.jsonl              # Back up first!
+  bd export > issue-export.jsonl        # Export issue records first
   bd init --reinit-local --prefix %s    # Then reinitialize
 
 Aborting.`, ui.RenderWarn("⚠"), redirectTarget, targetDBPath, ui.RenderAccent("bd list"), prefix)
@@ -1785,7 +1785,7 @@ To use the existing database:
   Just run bd commands normally (e.g., %s)
 
 If the database is genuinely corrupt and unrecoverable:
-  bd export > backup.jsonl              # Back up first!
+  bd export > issue-export.jsonl        # Export issue records first
   bd init --reinit-local --prefix %s    # Then reinitialize
 
 Aborting.`, ui.RenderWarn("⚠"), dbPath, ui.RenderAccent("bd list"), prefix)

--- a/cmd/bd/init_templates.go
+++ b/cmd/bd/init_templates.go
@@ -73,12 +73,12 @@ func renderInitConfigYAML(prefix string, noDbMode bool) []byte {
 #     - ~/beads-planning  # Personal planning repo
 #     - ~/work-planning   # Work planning repo
 
-# JSONL backup (periodic export for off-machine recovery)
-# This is backup/export only. Cross-machine sync uses Dolt remotes.
+# Dolt-native backup (periodic backup for off-machine recovery)
+# This is full database backup only. Cross-machine sync uses Dolt remotes.
 # backup:
 #   enabled: false     # Disable auto-backup entirely
-#   interval: 15m      # Minimum time between auto-exports
-#   git-push: false    # Disable git push (export locally only)
+#   interval: 15m      # Minimum time between auto-backups
+#   git-push: false    # Disable git push (backup locally only)
 #   git-repo: ""       # Separate git repo for backups (default: project repo)
 
 # Integration settings (access with 'bd config get/set')

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1141,7 +1141,7 @@ var rootCmd = &cobra.Command{
 				}
 			}
 
-			// Auto-backup: export JSONL to .beads/backup/ if enabled and due
+			// Auto-backup: sync a Dolt-native backup if enabled and due
 			maybeAutoBackup(rootCtx)
 
 			// Auto-export: write git-tracked JSONL for portability if enabled and due.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2585,7 +2585,7 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  Enabled by default. Useful for viewers (bv) and interchange; not a backup.
   It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
@@ -3345,8 +3345,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv), interchange, and backups up to date without extra steps.
-Cross-machine sync uses Dolt remotes, not JSONL import/export.
+viewers (bv) and interchange up to date without extra steps.
+Cross-machine sync and backups use Dolt remotes/backups, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2200,6 +2200,11 @@ bd swarm validate [epic-id] [flags]
 
 Back up your beads database for off-machine recovery.
 
+This is a Dolt-native database backup. It preserves the database state,
+including tables, branches, commit history, and working-set data. This is
+different from 'bd export', which writes issue records to JSONL for migration
+and interoperability.
+
 Commands:
   bd backup init &lt;path&gt;    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination
@@ -2257,6 +2262,10 @@ Restore the beads database from a Dolt-native backup.
 
 By default, reads from .beads/backup/ (or the configured backup directory).
 Optionally specify a path to a directory containing a Dolt backup.
+
+This restores a full database backup created by 'bd backup sync' or an
+equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
+not restore targets for this command.
 
 Use --force to overwrite an existing database with the backup contents.
 
@@ -2318,9 +2327,10 @@ Export all issues to JSONL (newline-delimited JSON) format.
 Each line is a complete JSON object representing one issue, including its
 labels, dependencies, and comments.
 
-This command is for issue export, migration, and interoperability. It does
-not produce the JSONL backup snapshot used by 'bd backup restore'. For
-supported backup/restore flows, use 'bd backup', 'bd backup export-git',
+This command is for issue export, migration, and interoperability. It exports
+records from the issues table; it is not a full database backup and does not
+capture Dolt branches, commit history, working-set state, or non-issue tables.
+For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
@@ -2332,7 +2342,7 @@ include them.
 
 EXAMPLES:
   bd export                              # Export issues to stdout
-  bd export -o backup.jsonl              # Export to file
+  bd export -o issues.jsonl              # Export issues to file
   bd export --include-memories           # Export issues + memories
   bd export --all -o full.jsonl          # Include infra + templates + gates + memories
   bd export --scrub -o clean.jsonl       # Exclude test/pollution records

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -92,6 +92,10 @@ dolt:
 
 Periodic Dolt-native backup to `.beads/backup/` provides an off-machine recovery path. Local Dolt snapshots (via `dolt.auto-commit`) remain the primary safety net; backup is a secondary layer.
 
+This is a full database backup, unlike `bd export` or `.beads/issues.jsonl`.
+It preserves Dolt state such as tables, branches, commit history, and
+working-set data.
+
 ```yaml
 backup:
   enabled: true    # Enable auto-backup after write commands
@@ -101,7 +105,7 @@ backup:
 **How it works:**
 - After each write command (in PersistentPostRun), `bd` checks the Dolt HEAD commit hash against the last backup state
 - If data changed and the throttle interval has passed, a Dolt-native backup is synced to `.beads/backup/`
-- Full commit history is preserved in the backup
+- Full database state and commit history are preserved in the backup
 - State is tracked in `.beads/backup/backup_state.json`
 
 **Manual commands:**
@@ -342,7 +346,7 @@ Configuration keys use dot-notation namespaces to organize settings:
 - `min_hash_length` - Minimum hash ID length (default: 4)
 - `max_hash_length` - Maximum hash ID length (default: 8)
 - `import.orphan_handling` - How to handle hierarchical issues with missing parents during import (default: `allow`)
-- `export.auto` - Refresh the JSONL export after every write command (default: `true`). This is for viewers, interchange, and backup, not cross-machine sync.
+- `export.auto` - Refresh the JSONL export after every write command (default: `true`). This is for viewers, interchange, and issue-level migration; it is not cross-machine sync and not a full database backup.
 - `export.path` - Output filename relative to `.beads/` (default: `issues.jsonl`)
 - `export.interval` - Minimum time between auto-exports (default: `60s`)
 - `export.git-add` - Run `git add` on the export file after writing (default: `true`)

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -89,6 +89,12 @@ Switch to server mode when you need:
 You can migrate data between embedded mode and server mode using `bd backup`.
 Both directions preserve full Dolt commit history.
 
+`bd export` is not a substitute for this flow. JSONL exports contain issue
+records from the issues table for migration and interoperability; they do not
+capture Dolt branches, full commit history, working-set state, or non-issue
+tables. Use `bd backup` or a manual Dolt backup when you need a restorable
+database backup.
+
 ### Server → Embedded
 
 1. **Create a backup from the server-mode project:**
@@ -158,7 +164,7 @@ Both directions preserve full Dolt commit history.
 ### Notes
 
 - Data locations differ between modes: `.beads/embeddeddolt/` (embedded) vs `.beads/dolt/` (server)
-- The backup directory is a full Dolt backup — it can be on a local drive, NAS, or DoltHub
+- The backup directory is a full Dolt backup, not an `issues.jsonl` export — it can be on a local drive, NAS, or DoltHub
 - You can also migrate via Dolt remotes (`bd dolt push` / `bd dolt pull`) if both projects share a remote
 
 The sections below are the canonical backend migration reference.

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -139,11 +139,13 @@ permanently destroy them.
 ### 1. Export first, then proceed
 
 ```
-bd export > backup.jsonl
+bd export > issue-export.jsonl
 bd init --reinit-local
 ```
 
-`backup.jsonl` lets you re-import individual issues if needed.
+`issue-export.jsonl` lets you re-import individual issues if needed. It is not
+a full database backup; use `bd backup` when the Dolt database is healthy
+enough to create a restorable backup before reinitializing.
 
 ### 2. Investigate why you hit this
 

--- a/docs/SYNC_CONCEPTS.md
+++ b/docs/SYNC_CONCEPTS.md
@@ -47,7 +47,7 @@ machine with the authoritative local Dolt database first. Then run:
 
 ```bash
 bd dolt remote list
-bd export -o .beads/issues.pre-remote.jsonl   # optional audit backup
+bd export -o .beads/issues.pre-remote.jsonl   # optional issue audit export
 bd dolt remote add origin <git-origin-url>
 bd dolt push
 ```

--- a/docs/SYNC_SETUP.md
+++ b/docs/SYNC_SETUP.md
@@ -84,7 +84,7 @@ that from the machine whose local database is authoritative:
 
 ```bash
 bd dolt remote list
-bd export -o .beads/issues.pre-remote.jsonl   # optional audit backup
+bd export -o .beads/issues.pre-remote.jsonl   # optional issue audit export
 bd dolt remote add origin git+ssh://git@github.com/org/repo.git
 bd dolt push
 ```
@@ -220,7 +220,7 @@ bd list                            # sees the closed task
 - **Always use `bd dolt ...` commands** — never run raw `dolt` CLI commands while the Dolt server is running. It causes journal corruption.
 - **Commit before pulling** — if you have uncommitted working set changes, `bd dolt pull` will fail with "cannot merge with uncommitted changes". Run `bd dolt commit` first.
 - **Push before switching machines** — unpushed changes only exist locally.
-- **Do not use JSONL as sync** — `.beads/issues.jsonl` is an export for viewers, interchange, and backup. It is not the source of truth and cannot safely reconcile deletes or pruning.
+- **Do not use JSONL as sync** — `.beads/issues.jsonl` is an export for viewers and interchange. It is not the source of truth, not a full database backup, and cannot safely reconcile deletes or pruning.
 
 ## Troubleshooting
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -523,7 +523,7 @@ This means bd found multiple `.beads` directories in your directory hierarchy. T
 
 2. **If you have accidental duplicates** (unintentional):
    - Decide which database to keep
-   - Export issues from the unwanted database: `cd <unwanted-dir> && bd export -o backup.jsonl`
+   - Export issues from the unwanted database: `cd <unwanted-dir> && bd export -o issue-export.jsonl`
    - Remove the unwanted `.beads` directory: `rm -rf <unwanted-dir>/.beads`
    - Optionally import issues into the main database if needed
 

--- a/plugins/beads/skills/beads/commands/export.md
+++ b/plugins/beads/skills/beads/commands/export.md
@@ -16,6 +16,10 @@ Issues are sorted by ID for consistent diffs, making git diffs readable.
 ## When to Use
 
 Dolt is the primary storage backend, so manual export is rarely needed. Use `bd export` when you need:
-- A JSONL snapshot for backup
+- A JSONL snapshot of issue records
 - Data migration to another system
 - Sharing issues outside the Dolt workflow
+
+`bd export` is not a full database backup. It does not capture Dolt branches,
+commit history, working-set state, or non-issue tables. Use `bd backup` for a
+restorable Dolt-native database backup.

--- a/website/docs/cli-reference/backup.md
+++ b/website/docs/cli-reference/backup.md
@@ -12,6 +12,11 @@ Generated from `bd help --doc backup`
 
 Back up your beads database for off-machine recovery.
 
+This is a Dolt-native database backup. It preserves the database state,
+including tables, branches, commit history, and working-set data. This is
+different from 'bd export', which writes issue records to JSONL for migration
+and interoperability.
+
 Commands:
   bd backup init &lt;path&gt;    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination
@@ -69,6 +74,10 @@ Restore the beads database from a Dolt-native backup.
 
 By default, reads from .beads/backup/ (or the configured backup directory).
 Optionally specify a path to a directory containing a Dolt backup.
+
+This restores a full database backup created by 'bd backup sync' or an
+equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
+not restore targets for this command.
 
 Use --force to overwrite an existing database with the backup contents.
 

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -25,7 +25,7 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  Enabled by default. Useful for viewers (bv) and interchange; not a backup.
   It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:

--- a/website/docs/cli-reference/export.md
+++ b/website/docs/cli-reference/export.md
@@ -15,9 +15,10 @@ Export all issues to JSONL (newline-delimited JSON) format.
 Each line is a complete JSON object representing one issue, including its
 labels, dependencies, and comments.
 
-This command is for issue export, migration, and interoperability. It does
-not produce the JSONL backup snapshot used by 'bd backup restore'. For
-supported backup/restore flows, use 'bd backup', 'bd backup export-git',
+This command is for issue export, migration, and interoperability. It exports
+records from the issues table; it is not a full database backup and does not
+capture Dolt branches, commit history, working-set state, or non-issue tables.
+For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
@@ -29,7 +30,7 @@ include them.
 
 EXAMPLES:
   bd export                              # Export issues to stdout
-  bd export -o backup.jsonl              # Export to file
+  bd export -o issues.jsonl              # Export issues to file
   bd export --include-memories           # Export issues + memories
   bd export --all -o full.jsonl          # Include infra + templates + gates + memories
   bd export --scrub -o clean.jsonl       # Exclude test/pollution records

--- a/website/docs/cli-reference/init.md
+++ b/website/docs/cli-reference/init.md
@@ -32,8 +32,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv), interchange, and backups up to date without extra steps.
-Cross-machine sync uses Dolt remotes, not JSONL import/export.
+viewers (bv) and interchange up to date without extra steps.
+Cross-machine sync and backups use Dolt remotes/backups, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):

--- a/website/docs/getting-started/upgrading.md
+++ b/website/docs/getting-started/upgrading.md
@@ -139,7 +139,7 @@ When the list is empty, fix it on the machine whose local database is
 authoritative:
 
 ```bash
-bd export -o .beads/issues.pre-remote.jsonl   # optional audit backup
+bd export -o .beads/issues.pre-remote.jsonl   # optional issue audit export
 bd dolt remote add origin git+ssh://git@github.com/org/repo.git
 bd dolt push
 ```

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -212,7 +212,7 @@ backup:
   enabled: true
   interval: 15m
 
-# Auto-export issues.jsonl after writes for viewers/interchange/backup
+# Auto-export issues.jsonl after writes for viewers/interchange
 export:
   auto: true
   path: issues.jsonl

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2888,7 +2888,7 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  Enabled by default. Useful for viewers (bv) and interchange; not a backup.
   It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
@@ -2922,6 +2922,7 @@ Examples:
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
+  bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
   bd config get export.auto
   bd config list
   bd config unset jira.url
@@ -5492,8 +5493,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv), interchange, and backups up to date without extra steps.
-Cross-machine sync uses Dolt remotes, not JSONL import/export.
+viewers (bv) and interchange up to date without extra steps.
+Cross-machine sync and backups use Dolt remotes/backups, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
@@ -5517,6 +5518,7 @@ bd init [flags]
       --backend string                    Storage backend (default: dolt). --backend=sqlite prints deprecation notice.
       --contributor                       Run OSS contributor setup wizard
       --database string                   Use existing server database name (overrides prefix-based naming)
+      --debug                             Run the managed Dolt sql-server with --loglevel=debug and CPU profiling (--prof cpu). Persisted to config.yaml as dolt.debug. No effect on externally-managed servers.
       --destroy-token string              Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')
       --discard-remote                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                          Server is externally managed (skip server startup); use with --shared-server or --server

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2266,6 +2266,11 @@ Generated from `bd help --doc backup`
 
 Back up your beads database for off-machine recovery.
 
+This is a Dolt-native database backup. It preserves the database state,
+including tables, branches, commit history, and working-set data. This is
+different from 'bd export', which writes issue records to JSONL for migration
+and interoperability.
+
 Commands:
   bd backup init &lt;path&gt;    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination
@@ -2323,6 +2328,10 @@ Restore the beads database from a Dolt-native backup.
 
 By default, reads from .beads/backup/ (or the configured backup directory).
 Optionally specify a path to a directory containing a Dolt backup.
+
+This restores a full database backup created by 'bd backup sync' or an
+equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
+not restore targets for this command.
 
 Use --force to overwrite an existing database with the backup contents.
 
@@ -2463,7 +2472,7 @@ Unlike 'bd init --force', bootstrap will never delete existing issues.
 
 Bootstrap auto-detects the right action:
   • If sync.remote is configured: clones from the remote
-  • If git origin has Dolt data (refs/dolt/data): clones from git
+  • If git origin has Dolt data (refs/dolt/data): clones from git and wires origin for future push/pull
   • If .beads/backup/*.jsonl exists: restores from backup
   • If .beads/issues.jsonl exists: imports from git-tracked JSONL
   • If no database exists: creates a fresh one
@@ -2879,7 +2888,8 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv) and git-based sync.
+  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:
     export.auto       Enable/disable auto-export (default: true)
@@ -3745,7 +3755,7 @@ Examples:
   bd doctor --fix -i     # Confirm each fix individually
   bd doctor --fix --fix-child-parent  # Also fix child→parent deps (opt-in)
   bd doctor --fix --force # Force repair even when database can't be opened
-  bd doctor --fix --source=jsonl # Rebuild database from JSONL (source of truth)
+  bd doctor --fix --source=jsonl # Rebuild database from a JSONL export
   bd doctor --dry-run    # Preview what --fix would do without making changes
   bd doctor --perf       # Performance diagnostics
   bd doctor --output diagnostics.json  # Export diagnostics to file
@@ -4245,9 +4255,10 @@ Export all issues to JSONL (newline-delimited JSON) format.
 Each line is a complete JSON object representing one issue, including its
 labels, dependencies, and comments.
 
-This command is for issue export, migration, and interoperability. It does
-not produce the JSONL backup snapshot used by 'bd backup restore'. For
-supported backup/restore flows, use 'bd backup', 'bd backup export-git',
+This command is for issue export, migration, and interoperability. It exports
+records from the issues table; it is not a full database backup and does not
+capture Dolt branches, commit history, working-set state, or non-issue tables.
+For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
@@ -4259,7 +4270,7 @@ include them.
 
 EXAMPLES:
   bd export                              # Export issues to stdout
-  bd export -o backup.jsonl              # Export to file
+  bd export -o issues.jsonl              # Export issues to file
   bd export --include-memories           # Export issues + memories
   bd export --all -o full.jsonl          # Include infra + templates + gates + memories
   bd export --scrub -o clean.jsonl       # Exclude test/pollution records
@@ -4430,19 +4441,14 @@ Generated from `bd help --doc formula`
 
 Manage workflow formulas - the source layer for molecule templates.
 
-Formulas are YAML/JSON files that define workflows with composition rules.
-They are "cooked" into proto beads which can then be poured or wisped.
-
-The Rig → Cook → Run lifecycle:
-  - Rig: Compose formulas (extends, compose)
-  - Cook: Transform to proto (bd cook expands macros, applies aspects)
-  - Run: Agents execute poured mols or wisps
+Formulas are TOML/JSON files that define workflows with composition rules.
+Define formulas, cook them into protos, then pour or wisp them into work.
 
 Search paths (in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Commands:
   list   List available formulas from all search paths
@@ -4491,7 +4497,7 @@ Search paths (in order of priority):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project - highest priority)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Formulas in earlier paths shadow those with the same name in later paths.
 
@@ -5486,7 +5492,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv) and git-based workflows up to date without extra steps.
+viewers (bv), interchange, and backups up to date without extra steps.
+Cross-machine sync uses Dolt remotes, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
@@ -5504,34 +5511,38 @@ bd init [flags]
 **Flags:**
 
 ```
-      --agents-file string       Custom filename for agent instructions (default: AGENTS.md)
-      --agents-profile string    AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
-      --agents-template string   Path to custom AGENTS.md template (overrides embedded default)
-      --backend string           Storage backend (default: dolt). --backend=sqlite prints deprecation notice.
-      --contributor              Run OSS contributor setup wizard
-      --database string          Use existing server database name (overrides prefix-based naming)
-      --destroy-token string     Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')
-      --discard-remote           Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
-      --external                 Server is externally managed (skip server startup); use with --shared-server or --server
-      --force                    Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl               Import issues from .beads/issues.jsonl instead of git history
-      --non-interactive          Skip all interactive prompts (auto-detected in CI or non-TTY environments)
-  -p, --prefix string            Issue prefix (default: current directory name)
-  -q, --quiet                    Suppress output (quiet mode)
-      --reinit-local             Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.
-      --remote string            Dolt remote URL to clone from and persist as sync.remote
-      --role string              Set beads role without prompting: "maintainer" or "contributor"
-      --server                   Use external dolt sql-server instead of embedded engine
-      --server-host string       Dolt server host (default: 127.0.0.1)
-      --server-port int          Dolt server port (default: 3307)
-      --server-socket string     Unix domain socket path (overrides host/port)
-      --server-user string       Dolt server MySQL user (default: root)
-      --setup-exclude            Configure .git/info/exclude to keep beads files local (for forks)
-      --shared-server            Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)
-      --skip-agents              Skip AGENTS.md and Claude settings generation
-      --skip-hooks               Skip git hooks installation
-      --stealth                  Enable stealth mode: global gitattributes and gitignore, no local repo tracking
-      --team                     Run team workflow setup wizard
+      --agents-file string                Custom filename for agent instructions (default: AGENTS.md)
+      --agents-profile string             AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)
+      --agents-template string            Path to custom AGENTS.md template (overrides embedded default)
+      --backend string                    Storage backend (default: dolt). --backend=sqlite prints deprecation notice.
+      --contributor                       Run OSS contributor setup wizard
+      --database string                   Use existing server database name (overrides prefix-based naming)
+      --destroy-token string              Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')
+      --discard-remote                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
+      --external                          Server is externally managed (skip server startup); use with --shared-server or --server
+      --force                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
+      --from-jsonl                        Import issues from .beads/issues.jsonl instead of git history
+      --non-interactive                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
+  -p, --prefix string                     Issue prefix (default: current directory name)
+      --proxied-server                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb
+      --proxied-server-config string      [EXPERIMENTAL] Path to an existing dolt sql-server YAML config (proxied-server mode only). When set, bd uses this file instead of auto-generating one.
+      --proxied-server-log-path string    [EXPERIMENTAL] Path to the proxied dolt sql-server log file (proxied-server mode only). Default: <beadsDir>/proxieddb/server.log.
+      --proxied-server-root-path string   [EXPERIMENTAL] Directory holding the proxied dolt sql-server's lockfiles, pidfiles, and child .dolt repository (proxied-server mode only). Default: <beadsDir>/proxieddb. May not exist yet — bd will create it.
+  -q, --quiet                             Suppress output (quiet mode)
+      --reinit-local                      Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.
+      --remote string                     Dolt remote URL to clone from and persist as sync.remote
+      --role string                       Set beads role without prompting: "maintainer" or "contributor"
+      --server                            Use external dolt sql-server instead of embedded engine
+      --server-host string                Dolt server host (default: 127.0.0.1)
+      --server-port int                   Dolt server port (default: 3307)
+      --server-socket string              Unix domain socket path (overrides host/port)
+      --server-user string                Dolt server MySQL user (default: root)
+      --setup-exclude                     Configure .git/info/exclude to keep beads files local (for forks)
+      --shared-server                     Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)
+      --skip-agents                       Skip AGENTS.md and Claude settings generation
+      --skip-hooks                        Skip git hooks installation
+      --stealth                           Enable stealth mode: global gitattributes and gitignore, no local repo tracking
+      --team                              Run team workflow setup wizard
 ```
 
 </document>
@@ -6762,7 +6773,7 @@ Formula search paths (checked in order):
   1. &lt;resolved-beads-dir&gt;/formulas/ (active project)
   2. &lt;checkout-root&gt;/.beads/formulas/ (repo-local formulas)
   3. ~/.beads/formulas/ (user level)
-  4. $GT_ROOT/.beads/formulas/ (orchestrator level, if GT_ROOT set)
+  4. $GT_ROOT/.beads/formulas/ (shared workspace root, if GT_ROOT set)
 
 Examples:
   bd mol seed mol-feature                 # Verify specific formula
@@ -8157,12 +8168,13 @@ Generated from `bd help --doc setup`
 Setup integration files for AI editors and coding assistants.
 
 Recipes define where beads workflow instructions are written. Built-in recipes
-include cursor, claude, gemini, aider, factory, codex, mux, opencode, junie, windsurf, cody, and kilocode.
+include cursor, claude, copilot, gemini, aider, factory, codex, mux, opencode, junie, windsurf, cody, and kilocode.
 
 Examples:
   bd setup cursor          # Install Cursor IDE integration
   bd setup codex           # Install Codex skill + AGENTS.md guidance
   bd setup codex --global  # Install global Codex skill + global AGENTS.md guidance
+  bd setup copilot         # Install Copilot CLI plugin + repository instructions
   bd setup mux --project   # Install Mux workspace layer (.mux/AGENTS.md)
   bd setup mux --global    # Install Mux global layer (~/.mux/AGENTS.md)
   bd setup mux --project --global  # Install both Mux layers
@@ -10307,6 +10319,48 @@ bd hydrate --from backend-repo
 
 </document>
 
+<document path="docs/integrations/index.md">
+
+
+# Integrations
+
+Beads integration pages are based on two sources of support in the repository:
+
+- Built-in `bd setup` recipes from `internal/recipes/recipes.go`
+- First-party MCP integrations and editor guides already shipped in the repo
+
+Run this command to see the built-in setup recipes supported by your installed `bd` binary:
+
+```bash
+bd setup --list
+```
+
+## Built-in Setup Recipes
+
+| Recipe | Integration | Primary setup surface |
+|--------|-------------|-----------------------|
+| `aider` | [Aider](/integrations/aider) | `.aider.conf.yml` and `.aider/` instructions |
+| `claude` | [Claude Code](/integrations/claude-code) | Claude hooks and `CLAUDE.md` |
+| `codex` | [Codex](/integrations/codex) | Beads skill, `AGENTS.md`, and Codex hooks |
+| `cody` | [Sourcegraph Cody](/integrations/cody) | `.cody/rules/beads.md` |
+| `cursor` | [Cursor](/integrations/cursor) | `.cursor/rules/beads.mdc` |
+| `factory` | [Factory.ai Droid](/integrations/factory) | `AGENTS.md` |
+| `gemini` | [Gemini CLI](/integrations/gemini) | Gemini hooks and `GEMINI.md` |
+| `junie` | [Junie](/integrations/junie) | `.junie/guidelines.md` and MCP config |
+| `kilocode` | [Kilo Code](/integrations/kilocode) | `.kilocode/rules/beads.md` |
+| `mux` | [Mux](/integrations/mux) | `AGENTS.md`, optional `.mux/AGENTS.md`, and Mux hooks |
+| `opencode` | [OpenCode](/integrations/opencode) | `AGENTS.md` |
+| `windsurf` | [Windsurf](/integrations/windsurf) | `.windsurf/rules/beads.md` |
+
+## MCP-Based Integrations
+
+These integrations use the Beads MCP server rather than a dedicated `bd setup` recipe:
+
+- [MCP Server](/integrations/mcp-server)
+- [GitHub Copilot](/integrations/github-copilot)
+
+</document>
+
 <document path="docs/integrations/aider.md">
 
 
@@ -10632,6 +10686,110 @@ Codex 0.129.0+ supports `/hooks`, compact lifecycle hooks, and hook-provided dev
 `PreCompact` alone does not inject context because Codex ignores plain stdout from compact hooks. The post-compact marker plus first-prompt refresh is the reliable recovery path.
 
 The Beads Codex plugin declares `"hooks": "./hooks/hooks.json"`. Without the plugin, `bd setup codex` installs the same hook config in `.codex/hooks.json` and enables `[features].hooks = true`.
+
+</document>
+
+<document path="docs/integrations/cody.md">
+
+
+# Sourcegraph Cody Integration
+
+Use Beads with Sourcegraph Cody through a project rules file.
+
+```bash
+bd setup cody
+bd setup cody --check
+```
+
+The setup command creates `.cody/rules/beads.md` with Beads workflow guidance.
+
+## Remove
+
+```bash
+bd setup cody --remove
+```
+
+</document>
+
+<document path="docs/integrations/cursor.md">
+
+
+# Cursor Integration
+
+Use Beads with Cursor through a project rules file.
+
+```bash
+bd setup cursor
+bd setup cursor --check
+```
+
+The setup command creates `.cursor/rules/beads.mdc` with Beads workflow guidance and quick `bd` command references. Restart Cursor after setup so the rules file is loaded into new agent sessions.
+
+## Remove
+
+```bash
+bd setup cursor --remove
+```
+
+</document>
+
+<document path="docs/integrations/factory.md">
+
+
+# Factory.ai Droid Integration
+
+Use Beads with Factory.ai Droid through managed `AGENTS.md` guidance.
+
+```bash
+bd setup factory
+bd setup factory --check
+```
+
+The setup command creates or updates `AGENTS.md` with a managed Beads section. Factory Droid reads `AGENTS.md` automatically when it starts a session.
+
+## Remove
+
+```bash
+bd setup factory --remove
+```
+
+</document>
+
+<document path="docs/integrations/gemini.md">
+
+
+# Gemini CLI Integration
+
+Use Beads with Gemini CLI through SessionStart hooks and `GEMINI.md` guidance.
+
+```bash
+bd setup gemini
+bd setup gemini --check
+```
+
+By default, setup installs global hooks in `~/.gemini/settings.json`. For project-local hooks, use:
+
+```bash
+bd setup gemini --project
+```
+
+The hook runs `bd prime --hook-json` so Gemini receives compact Beads workflow context at session start. The setup also writes Beads guidance to `GEMINI.md`.
+
+## Stealth Mode
+
+For CI or other environments where setup should avoid git operations:
+
+```bash
+bd setup gemini --stealth
+bd setup gemini --project --stealth
+```
+
+## Remove
+
+```bash
+bd setup gemini --remove
+bd setup gemini --project --remove
+```
 
 </document>
 
@@ -10999,6 +11157,28 @@ This removes:
 
 </document>
 
+<document path="docs/integrations/kilocode.md">
+
+
+# Kilo Code Integration
+
+Use Beads with Kilo Code through a project rules file.
+
+```bash
+bd setup kilocode
+bd setup kilocode --check
+```
+
+The setup command creates `.kilocode/rules/beads.md` with Beads workflow guidance.
+
+## Remove
+
+```bash
+bd setup kilocode --remove
+```
+
+</document>
+
 <document path="docs/integrations/mcp-server.md">
 
 
@@ -11182,6 +11362,92 @@ bd init --quiet
 
 - [Claude Code](/integrations/claude-code) - CLI integration
 - [Installation](/getting-started/installation) - Full install guide
+
+</document>
+
+<document path="docs/integrations/mux.md">
+
+
+# Mux Integration
+
+Use Beads with Mux through `AGENTS.md`, optional layered Mux instruction files, and Mux hooks.
+
+```bash
+bd setup mux
+bd setup mux --check
+```
+
+The default setup writes a managed Beads section to root `AGENTS.md`.
+
+## Workspace and Global Layers
+
+Mux also supports workspace and global instruction layers:
+
+```bash
+bd setup mux --project
+bd setup mux --global
+bd setup mux --project --global
+```
+
+Project setup writes `.mux/AGENTS.md` and installs Mux hook files under `.mux/`:
+
+- `.mux/init`
+- `.mux/tool_post`
+- `.mux/tool_env`
+
+Global setup writes `~/.mux/AGENTS.md`.
+
+## Remove
+
+```bash
+bd setup mux --remove
+bd setup mux --project --remove
+bd setup mux --global --remove
+```
+
+</document>
+
+<document path="docs/integrations/opencode.md">
+
+
+# OpenCode Integration
+
+Use Beads with OpenCode through managed `AGENTS.md` guidance.
+
+```bash
+bd setup opencode
+bd setup opencode --check
+```
+
+The setup command creates or updates `AGENTS.md` with a managed Beads section. Restart OpenCode after setup if it is already running.
+
+## Remove
+
+```bash
+bd setup opencode --remove
+```
+
+</document>
+
+<document path="docs/integrations/windsurf.md">
+
+
+# Windsurf Integration
+
+Use Beads with Windsurf through a project rules file.
+
+```bash
+bd setup windsurf
+bd setup windsurf --check
+```
+
+The setup command creates `.windsurf/rules/beads.md` with Beads workflow guidance.
+
+## Remove
+
+```bash
+bd setup windsurf --remove
+```
 
 </document>
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -25,7 +25,7 @@ bd update bd-42 --claim                   # Start work
 bd close bd-42 --reason "Done"            # Close issue
 bd ready --json                           # Show unblocked work
 bd dolt push                              # Push to Dolt remote
-bd backup export-git                      # Publish backup snapshot to a git branch
+bd backup sync                            # Push a Dolt-native backup
 ```
 
 ## For AI Agents
@@ -34,7 +34,7 @@ bd backup export-git                      # Publish backup snapshot to a git bra
 - Always include `--description` when creating issues
 - Use `--deps discovered-from:<id>` to link found issues
 - Use `bd dolt push` / `bd dolt pull` for Dolt remotes
-- Use `bd backup` / `bd backup export-git` for portable backups
+- Use `bd backup init` / `bd backup sync` / `bd backup restore` for portable backups
 
 ## Key Concepts
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -43,7 +43,7 @@ bd backup sync                            # Push a Dolt-native backup
 - **Formulas**: Declarative workflow templates (TOML/JSON)
 - **Molecules**: Work graphs from formulas
 - **Gates**: Async coordination (human/timer/github)
-- **Wisps**: Ephemeral workflows (excluded from JSONL backups)
+- **Wisps**: Ephemeral workflows (excluded from issue JSONL exports)
 
 ## Recovery
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/backup.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/backup.md
@@ -12,6 +12,11 @@ Generated from `bd help --doc backup`
 
 Back up your beads database for off-machine recovery.
 
+This is a Dolt-native database backup. It preserves the database state,
+including tables, branches, commit history, and working-set data. This is
+different from 'bd export', which writes issue records to JSONL for migration
+and interoperability.
+
 Commands:
   bd backup init &lt;path&gt;    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination
@@ -69,6 +74,10 @@ Restore the beads database from a Dolt-native backup.
 
 By default, reads from .beads/backup/ (or the configured backup directory).
 Optionally specify a path to a directory containing a Dolt backup.
+
+This restores a full database backup created by 'bd backup sync' or an
+equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
+not restore targets for this command.
 
 Use --force to overwrite an existing database with the backup contents.
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/config.md
@@ -25,7 +25,7 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  Enabled by default. Useful for viewers (bv) and interchange; not a backup.
   It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:

--- a/website/versioned_docs/version-1.0.0/cli-reference/export.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/export.md
@@ -15,9 +15,10 @@ Export all issues to JSONL (newline-delimited JSON) format.
 Each line is a complete JSON object representing one issue, including its
 labels, dependencies, and comments.
 
-This command is for issue export, migration, and interoperability. It does
-not produce the JSONL backup snapshot used by 'bd backup restore'. For
-supported backup/restore flows, use 'bd backup', 'bd backup export-git',
+This command is for issue export, migration, and interoperability. It exports
+records from the issues table; it is not a full database backup and does not
+capture Dolt branches, commit history, working-set state, or non-issue tables.
+For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
@@ -29,7 +30,7 @@ include them.
 
 EXAMPLES:
   bd export                              # Export issues to stdout
-  bd export -o backup.jsonl              # Export to file
+  bd export -o issues.jsonl              # Export issues to file
   bd export --include-memories           # Export issues + memories
   bd export --all -o full.jsonl          # Include infra + templates + gates + memories
   bd export --scrub -o clean.jsonl       # Exclude test/pollution records

--- a/website/versioned_docs/version-1.0.0/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/init.md
@@ -32,8 +32,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv), interchange, and backups up to date without extra steps.
-Cross-machine sync uses Dolt remotes, not JSONL import/export.
+viewers (bv) and interchange up to date without extra steps.
+Cross-machine sync and backups use Dolt remotes/backups, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):

--- a/website/versioned_docs/version-1.0.4/cli-reference/backup.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/backup.md
@@ -12,6 +12,11 @@ Generated from `bd help --doc backup`
 
 Back up your beads database for off-machine recovery.
 
+This is a Dolt-native database backup. It preserves the database state,
+including tables, branches, commit history, and working-set data. This is
+different from 'bd export', which writes issue records to JSONL for migration
+and interoperability.
+
 Commands:
   bd backup init &lt;path&gt;    Set up a backup destination (filesystem or DoltHub)
   bd backup sync           Push to configured backup destination
@@ -69,6 +74,10 @@ Restore the beads database from a Dolt-native backup.
 
 By default, reads from .beads/backup/ (or the configured backup directory).
 Optionally specify a path to a directory containing a Dolt backup.
+
+This restores a full database backup created by 'bd backup sync' or an
+equivalent Dolt backup. JSONL files produced by 'bd export' are issue exports,
+not restore targets for this command.
 
 Use --force to overwrite an existing database with the backup contents.
 

--- a/website/versioned_docs/version-1.0.4/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/config.md
@@ -25,7 +25,7 @@ Common namespaces:
 
 Auto-Export (config.yaml):
   Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv), interchange, and backup.
+  Enabled by default. Useful for viewers (bv) and interchange; not a backup.
   It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
 
   Keys:

--- a/website/versioned_docs/version-1.0.4/cli-reference/export.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/export.md
@@ -15,9 +15,10 @@ Export all issues to JSONL (newline-delimited JSON) format.
 Each line is a complete JSON object representing one issue, including its
 labels, dependencies, and comments.
 
-This command is for issue export, migration, and interoperability. It does
-not produce the JSONL backup snapshot used by 'bd backup restore'. For
-supported backup/restore flows, use 'bd backup', 'bd backup export-git',
+This command is for issue export, migration, and interoperability. It exports
+records from the issues table; it is not a full database backup and does not
+capture Dolt branches, commit history, working-set state, or non-issue tables.
+For supported full backup/restore flows, use 'bd backup init', 'bd backup sync',
 and 'bd backup restore'.
 
 By default, exports only regular issues (excluding infrastructure beads
@@ -29,7 +30,7 @@ include them.
 
 EXAMPLES:
   bd export                              # Export issues to stdout
-  bd export -o backup.jsonl              # Export to file
+  bd export -o issues.jsonl              # Export issues to file
   bd export --include-memories           # Export issues + memories
   bd export --all -o full.jsonl          # Include infra + templates + gates + memories
   bd export --scrub -o clean.jsonl       # Exclude test/pollution records

--- a/website/versioned_docs/version-1.0.4/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/init.md
@@ -32,8 +32,8 @@ Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
 Auto-export is enabled by default. After every write command, bd exports
 issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv), interchange, and backups up to date without extra steps.
-Cross-machine sync uses Dolt remotes, not JSONL import/export.
+viewers (bv) and interchange up to date without extra steps.
+Cross-machine sync and backups use Dolt remotes/backups, not JSONL import/export.
 To disable: bd config set export.auto false
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):


### PR DESCRIPTION
## Summary
- Clarify that `bd export` / `.beads/issues.jsonl` are issue-table JSONL exports, not full database backups
- Document `bd backup` as the Dolt-native restorable backup path that preserves database state, branches, history, and working-set data
- Regenerate CLI reference docs and LLM docs artifacts

## Verification
- `make check-docs`
- `GOFLAGS=-tags=gms_pure_go go test ./cmd/bd -run 'TestHelp|Test.*Doc'`

_codex-gpt-5-medium on behalf of CI Bot_