### PR TITLE
feat(doctor): detect orphaned child issues in deep validation (bd-3852)

### DIFF
--- a/cmd/bd/doctor/deep.go
+++ b/cmd/bd/doctor/deep.go
@@ -18,6 +18,7 @@ type DeepValidationResult struct {
 	EpicCompleteness    DoctorCheck   `json:"epic_completeness"`
 	MailThreadIntegrity DoctorCheck   `json:"mail_thread_integrity"`
 	MoleculeIntegrity   DoctorCheck   `json:"molecule_integrity"`
+	OrphanedChildren    DoctorCheck   `json:"orphaned_children"`
 	AllChecks           []DoctorCheck `json:"all_checks"`
 	TotalIssues         int           `json:"total_issues"`
 	TotalDependencies   int           `json:"total_dependencies"`
@@ -115,6 +116,9 @@ func RunDeepValidation(path string) DeepValidationResult {
 	if result.MoleculeIntegrity.Status == StatusError {
 		result.OverallOK = false
 	}
+
+	result.OrphanedChildren = checkOrphanedChildren(db)
+	result.AllChecks = append(result.AllChecks, result.OrphanedChildren)
 
 	return result
 }
@@ -455,6 +459,57 @@ func checkMoleculeIntegrity(db *sql.DB) DoctorCheck {
 
 	check.Status = StatusOK
 	check.Message = fmt.Sprintf("%d molecules validated", len(molecules))
+	return check
+}
+
+// checkOrphanedChildren finds issues whose ID contains a '.' but whose parent
+// prefix does not exist in the issues table (e.g. "parent.1" where "parent" is gone).
+func checkOrphanedChildren(db *sql.DB) DoctorCheck {
+	check := DoctorCheck{
+		Name:     "Orphaned Children",
+		Category: CategoryMetadata,
+	}
+
+	query := `
+		SELECT id
+		FROM issues
+		WHERE id LIKE '%.%'
+		  AND SUBSTRING_INDEX(id, '.', 1) NOT IN (SELECT id FROM issues)
+		LIMIT 10`
+
+	rows, err := db.Query(query)
+	if err != nil {
+		check.Status = StatusWarning
+		check.Message = "Unable to check for orphaned children"
+		check.Detail = err.Error()
+		return check
+	}
+	defer rows.Close()
+
+	var orphans []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err == nil {
+			orphans = append(orphans, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		check.Status = StatusWarning
+		check.Message = "Row iteration error checking orphaned children"
+		check.Detail = err.Error()
+		return check
+	}
+
+	if len(orphans) == 0 {
+		check.Status = StatusOK
+		check.Message = "No orphaned child issues found"
+		return check
+	}
+
+	check.Status = StatusWarning
+	check.Message = fmt.Sprintf("Found %d+ child issues whose parent no longer exists", len(orphans))
+	check.Detail = fmt.Sprintf("Examples: %s", strings.Join(orphans[:min(3, len(orphans))], ", "))
+	check.Fix = "Delete orphaned issues with 'bd admin delete <id>' or re-create the parent"
 	return check
 }
 

--- a/cmd/bd/doctor/deep.go
+++ b/cmd/bd/doctor/deep.go
@@ -470,6 +470,7 @@ func checkOrphanedChildren(db *sql.DB) DoctorCheck {
 		Category: CategoryMetadata,
 	}
 
+	const orphanLimit = 10
 	query := `
 		SELECT id
 		FROM issues
@@ -507,7 +508,11 @@ func checkOrphanedChildren(db *sql.DB) DoctorCheck {
 	}
 
 	check.Status = StatusWarning
-	check.Message = fmt.Sprintf("Found %d+ child issues whose parent no longer exists", len(orphans))
+	if len(orphans) >= orphanLimit {
+		check.Message = fmt.Sprintf("Found %d+ child issues whose parent no longer exists", len(orphans))
+	} else {
+		check.Message = fmt.Sprintf("Found %d orphaned child issues whose parent no longer exists", len(orphans))
+	}
 	check.Detail = fmt.Sprintf("Examples: %s", strings.Join(orphans[:min(3, len(orphans))], ", "))
 	check.Fix = "Delete orphaned issues with 'bd admin delete <id>' or re-create the parent"
 	return check

--- a/cmd/bd/doctor/deep_test.go
+++ b/cmd/bd/doctor/deep_test.go
@@ -177,6 +177,49 @@ func TestCheckMailThreadIntegrity_ValidThreads(t *testing.T) {
 	}
 }
 
+// TestCheckOrphanedChildren verifies detection of child issues with missing parents.
+func TestCheckOrphanedChildren(t *testing.T) {
+	t.Run("no_orphans", func(t *testing.T) {
+		store := newTestDoltStore(t, "oc")
+		ctx := context.Background()
+		issue := &types.Issue{
+			ID:        "oc-1",
+			Title:     "Parent",
+			Status:    types.StatusOpen,
+			IssueType: types.TypeTask,
+			CreatedAt: time.Now(),
+		}
+		if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+			t.Fatal(err)
+		}
+		db := store.UnderlyingDB()
+		check := checkOrphanedChildren(db)
+		if check.Status != StatusOK {
+			t.Errorf("Status = %q, want %q: %s", check.Status, StatusOK, check.Message)
+		}
+	})
+
+	t.Run("one_orphan", func(t *testing.T) {
+		store := newTestDoltStore(t, "oc2")
+		db := store.UnderlyingDB()
+		// Insert a child with dotted ID whose parent does not exist via raw SQL.
+		_, err := db.Exec(
+			"INSERT INTO issues (id, title, status, issue_type, created_at) VALUES (?, ?, ?, ?, NOW())",
+			"oc2.1", "Orphan Child", "open", "task",
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		check := checkOrphanedChildren(db)
+		if check.Status != StatusWarning {
+			t.Errorf("Status = %q, want %q: %s", check.Status, StatusWarning, check.Message)
+		}
+		if strings.Contains(check.Message, "+") {
+			t.Errorf("Message should NOT contain '+' for a single orphan: %s", check.Message)
+		}
+	})
+}
+
 // TestDeepValidationResultJSON verifies JSON serialization
 func TestDeepValidationResultJSON(t *testing.T) {
 	result := DeepValidationResult{


### PR DESCRIPTION
## Summary

- Adds `checkOrphanedChildren` to `RunDeepValidation` in `cmd/bd/doctor/deep.go`
- Detects issues whose ID contains a `.` (e.g. `parent.1`) but whose parent prefix is absent from the `issues` table
- Complements the existing `checkParentConsistency` (which only scans the `dependencies` table)
- Reports as `StatusWarning` with up to 3 examples; suggests `bd admin delete <id>` or re-creating the parent
- Adds `OrphanedChildren DoctorCheck` field to `DeepValidationResult` (JSON: `orphaned_children`)

## Bead

bd-3852: Add orphan detection migration

## Test plan

- [x] Build clean: `go build ./cmd/bd/...`
- [x] `go vet ./cmd/bd/doctor/...` — 0 issues
- [x] `golangci-lint run ./cmd/bd/doctor/...` — 0 issues
- [x] Existing doctor tests pass (pre-existing failures in role/integrity tests are unrelated to this change, confirmed on main)
- [ ] Validator: add embedded test calling `RunDeepValidation` with a seeded DB that has an orphaned child, assert `OrphanedChildren.Status == StatusWarning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)