### PR TITLE
formula: surface intent field in JSON output

### DIFF
--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -117,6 +117,10 @@ type Formula struct {
 
 	// Source tracks where this formula was loaded from (set by parser).
 	Source string `json:"source,omitempty"`
+
+	// Intent is an optional caller-defined hint about the formula's runtime
+	// intent (e.g. "mail_only"). Opaque to bd; consumed by downstream tools.
+	Intent string `json:"intent,omitempty" toml:"intent,omitempty"`
 }
 
 // VarDef defines a template variable with optional validation.


### PR DESCRIPTION
## Problem

Formula TOML may declare `intent = "mail_only"` at the top level. The TOML parser reads it (no errors), but the `Formula` struct in `internal/formula/types.go` has no corresponding field, so `bd formula show --json` silently drops the value:

```
$ bd formula show mol-formula-dryrun --json | jq '.intent'
null
```

Downstream tooling that introspects intent (doctor checks, dispatch gates that route mail-only formulas to a dedicated burn path) sees `null` regardless of the TOML, which breaks the contract.

## Fix

Add `Intent string` with `json:"intent,omitempty" toml:"intent,omitempty"` tags to the `Formula` struct. Field is empty/absent for formulas that don't declare it (omitempty preserves prior output for those).

## Verification

Built `bd` at commit `ce242a879` (matches release 1.0.4) with build flags identical to a production stripped binary on the host (`CGO_ENABLED=1 -tags=gms_pure_go -ldflags="-s -w -X main.Version=1.0.4 ..."`), then tested against three mail-only formulas:

| Formula | Before | After |
|---|---|---|
| `mol-formula-dryrun` | `null` | `"mail_only"` |
| `mol-proposal-followup` | `null` | `"mail_only"` |
| `mol-refinery-circuit-breaker` | `null` | `"mail_only"` |
| `mol-do-work` (no intent in TOML) | absent | absent (omitempty) |

Diff vs prod for `mol-formula-dryrun --json | jq -S .`:

```diff
+   "intent": "mail_only",
```

Exactly one line added. No other fields gained or lost.

`ldd` of the rebuilt binary matches prod (libc-only) — the build env was matched intentionally so this PR's output can be a drop-in for installed instances.

Tests pass: `go test -tags=gms_pure_go ./internal/formula/... -count=1` → ok.

## Context

This surfaced from a downstream Gas City instance where three mail-only formulas (`intent="mail_only"` declared in TOML) couldn't be distinguished from regular formulas via the JSON API, breaking a "skip refinery handoff for mail-only" gate.