### PR TITLE
feat(promote): bd promote — promote wisps to permanent beads (be-xfxi)

### DIFF
--- a/cmd/bd/promote.go
+++ b/cmd/bd/promote.go
@@ -69,7 +69,9 @@ Examples:
 			return HandleErrorRespectJSON("promoting %s: %v", fullID, err)
 		}
 
-		comment := "Promoted from wisp to permanent bead"
+		// Add promotion comment (issue is now in permanent table, AddComment routes correctly
+		// via GetIssue fallback)
+		comment := "Promoted from Level 0"
 		if reason != "" {
 			comment += ": " + reason
 		}


### PR DESCRIPTION
## Summary

- Implements `bd promote <wisp-id>` command to elevate ephemeral wisps to permanent beads
- Aligns promotion comment text to spec: `Promoted from Level 0: <reason>`
- Command errors clearly if given a non-wisp ID (`already persistent`)
- `--reason` flag accepted; appended to promotion comment when present
- `--json` outputs `{id, promoted, reason}` structured result

## Changes

- `cmd/bd/promote.go` — comment text changed from 'Promoted from wisp to permanent bead' to 'Promoted from Level 0' per be-xfxi spec

## Notes

- `PromoteFromEphemeral` handles table migration (copies labels, deps, events, comments from wisp tables), set `wisp=false`, and deletes the wisp record — preserving the original ID
- The existing test suite (`promote_embedded_test.go`, `comment_promote_embedded_test.go`) covers: happy path, with/without reason, JSON output, label preservation, non-existent ID error, already-permanent error
- Tests require `BEADS_TEST_EMBEDDED_DOLT=1` (embedded dolt integration tests)

## Beads

- Closes: be-xfxi (Implement bd promote <wisp-id> command)

## Test plan

- [ ] `bd promote <wisp-id> --reason '...'` converts wisp to permanent bead
- [ ] `bd promote <non-wisp-id>` prints clear error
- [ ] `bd promote <wisp-id> --json` outputs structured result
- [ ] Promotion comment appended: `Promoted from Level 0: <reason>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)