### PR TITLE
feat(verbosity): wire --quiet into create/close/update (bd-au0.10)

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/audit"
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -182,7 +183,7 @@ the flags appear in the command line.`,
 					closedIssues = append(closedIssues, closedIssue)
 				}
 			} else {
-				fmt.Printf("%s Closed %s: %s\n", ui.RenderPass("✓"), formatFeedbackID(id, issueTitleOrEmpty(issue)), reason)
+				debug.PrintNormal("%s Closed %s: %s\n", ui.RenderPass("✓"), formatFeedbackID(id, issueTitleOrEmpty(issue)), reason)
 			}
 		}
 
@@ -254,14 +255,14 @@ the flags appear in the command line.`,
 					if jsonOutput {
 						// JSON handled below
 					} else {
-						fmt.Printf("%s Auto-claimed next ready issue: %s (P%d)\n", ui.RenderPass("✓"), formatFeedbackID(nextIssue.ID, nextIssue.Title), nextIssue.Priority)
+						debug.PrintNormal("%s Auto-claimed next ready issue: %s (P%d)\n", ui.RenderPass("✓"), formatFeedbackID(nextIssue.ID, nextIssue.Title), nextIssue.Priority)
 					}
 					SetLastTouchedID(nextIssue.ID)
 				} else {
 					fmt.Fprintf(os.Stderr, "Warning: could not claim next issue %s: %v\n", nextIssue.ID, err)
 				}
 			} else if !jsonOutput {
-				fmt.Printf("\n%s No ready issues available to claim.\n", ui.RenderWarn("✨"))
+				debug.PrintNormal("\n%s No ready issues available to claim.\n", ui.RenderWarn("✨"))
 			}
 		}
 
@@ -531,7 +532,7 @@ func autoCloseCompletedMolecule(ctx context.Context, s storage.DoltStorage, clos
 	}
 
 	if !jsonOutput {
-		fmt.Printf("%s Auto-closed completed molecule %s\n", ui.RenderPass("✓"), formatFeedbackID(moleculeID, root.Title))
+		debug.PrintNormal("%s Auto-closed completed molecule %s\n", ui.RenderPass("✓"), formatFeedbackID(moleculeID, root.Title))
 	}
 }
 

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -703,9 +703,9 @@ var createCmd = &cobra.Command{
 		} else if silent {
 			fmt.Println(issue.ID)
 		} else {
-			fmt.Printf("%s Created issue: %s\n", ui.RenderPass("✓"), formatFeedbackID(issue.ID, issue.Title))
-			fmt.Printf("  Priority: P%d\n", issue.Priority)
-			fmt.Printf("  Status: %s\n", issue.Status)
+			debug.PrintNormal("%s Created issue: %s\n", ui.RenderPass("✓"), formatFeedbackID(issue.ID, issue.Title))
+			debug.PrintNormal("  Priority: P%d\n", issue.Priority)
+			debug.PrintNormal("  Status: %s\n", issue.Status)
 
 			maybeShowTip(store)
 		}

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/audit"
+	"github.com/steveyegge/beads/internal/debug"
 	"github.com/steveyegge/beads/internal/metrics"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/timeparsing"
@@ -521,7 +522,7 @@ create, update, show, or close operation).`,
 					updatedIssues = append(updatedIssues, updatedIssue)
 				}
 			} else {
-				fmt.Printf("%s Updated issue: %s\n", ui.RenderPass("✓"), formatFeedbackID(result.ResolvedID, updateTitle))
+				debug.PrintNormal("%s Updated issue: %s\n", ui.RenderPass("✓"), formatFeedbackID(result.ResolvedID, updateTitle))
 			}
 
 			// Track first successful update for last-touched

--- a/cmd/bd/verbosity_quiet_embedded_test.go
+++ b/cmd/bd/verbosity_quiet_embedded_test.go
@@ -1,0 +1,106 @@
+//go:build cgo
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestQuietFlagSuppressesSuccessOutput verifies that --quiet suppresses success
+// output on create, close, and update while still exiting 0.
+//
+// Each sub-test: run the command with --quiet, capture stdout+stderr separately,
+// assert stdout is empty and exit code is 0. Errors still flow to stderr (not
+// tested here — the contract is "success output suppressed", not "all output").
+func TestQuietFlagSuppressesSuccessOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow embedded-bd quiet-mode tests in short mode")
+	}
+
+	bd := buildEmbeddedBD(t)
+	dir := t.TempDir()
+	initGitRepoAt(t, dir)
+	env := bdEnv(dir)
+
+	// Initialize a beads store in the temp dir.
+	initCmd := exec.Command(bd, "init", "--prefix", "q", "--quiet")
+	initCmd.Dir = dir
+	initCmd.Env = env
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd init failed: %v\n%s", err, out)
+	}
+
+	t.Run("create", func(t *testing.T) {
+		cmd := exec.Command(bd, "--quiet", "create", "quiet-create-test-title", "-p", "2")
+		cmd.Dir = dir
+		cmd.Env = env
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd --quiet create failed: %v\nstdout:%s\nstderr:%s", err, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "" {
+			t.Errorf("--quiet create: expected empty stdout, got:\n%s", got)
+		}
+	})
+
+	// Retrieve the issue ID created above for close/update tests.
+	listCmd := exec.Command(bd, "list", "--json", "--limit", "1")
+	listCmd.Dir = dir
+	listCmd.Env = env
+	listStdout, _, err := runCommandBuffers(t, listCmd)
+	if err != nil {
+		t.Fatalf("bd list --json failed: %v", err)
+	}
+	issueID := ""
+	for _, line := range strings.Split(listStdout.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, `"id"`) {
+			parts := strings.SplitN(line, `"`, 4)
+			if len(parts) >= 4 {
+				issueID = parts[3]
+			}
+			break
+		}
+	}
+	if issueID == "" {
+		// Fallback: scan for first `"id": "..."` pattern
+		s := listStdout.String()
+		if idx := strings.Index(s, `"id": "`); idx >= 0 {
+			rest := s[idx+7:]
+			if end := strings.Index(rest, `"`); end >= 0 {
+				issueID = rest[:end]
+			}
+		}
+	}
+	if issueID == "" {
+		t.Skip("could not determine created issue ID; skipping close/update quiet tests")
+	}
+
+	t.Run("update", func(t *testing.T) {
+		cmd := exec.Command(bd, "--quiet", "update", issueID, "--priority", "1")
+		cmd.Dir = dir
+		cmd.Env = env
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd --quiet update failed: %v\nstdout:%s\nstderr:%s", err, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "" {
+			t.Errorf("--quiet update: expected empty stdout, got:\n%s", got)
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		cmd := exec.Command(bd, "--quiet", "close", issueID, "--reason", "quiet-test-done")
+		cmd.Dir = dir
+		cmd.Env = env
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd --quiet close failed: %v\nstdout:%s\nstderr:%s", err, stdout.String(), stderr.String())
+		}
+		if got := strings.TrimSpace(stdout.String()); got != "" {
+			t.Errorf("--quiet close: expected empty stdout, got:\n%s", got)
+		}
+	})
+}

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -42,16 +42,16 @@ func Printf(format string, args ...interface{}) {
 	}
 }
 
-// printNormal prints output unless quiet mode is enabled
-// Use this for normal informational output that should be suppressed in quiet mode
-func printNormal(format string, args ...interface{}) {
+// PrintNormal prints output unless quiet mode is enabled.
+// Use this for normal informational output that should be suppressed in quiet mode.
+func PrintNormal(format string, args ...interface{}) {
 	if !quietMode {
 		fmt.Printf(format, args...)
 	}
 }
 
-// printlnNormal prints a line unless quiet mode is enabled
-func printlnNormal(args ...interface{}) {
+// PrintlnNormal prints a line unless quiet mode is enabled.
+func PrintlnNormal(args ...interface{}) {
 	if !quietMode {
 		fmt.Println(args...)
 	}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -223,14 +223,14 @@ func TestPrintNormal(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 
-			printNormal(tt.format, tt.args...)
+			PrintNormal(tt.format, tt.args...)
 
 			w.Close()
 			var buf bytes.Buffer
 			io.Copy(&buf, r)
 
 			if got := buf.String(); got != tt.wantOutput {
-				t.Errorf("printNormal() output = %q, want %q", got, tt.wantOutput)
+				t.Errorf("PrintNormal() output = %q, want %q", got, tt.wantOutput)
 			}
 		})
 	}
@@ -271,7 +271,7 @@ func TestPrintlnNormal(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 
-			printlnNormal(tt.args...)
+			PrintlnNormal(tt.args...)
 
 			w.Close()
 			var buf bytes.Buffer


### PR DESCRIPTION
## Summary

- Exports `debug.PrintNormal` / `debug.PrintlnNormal` (previously unexported helpers)
- Wires `--quiet` flag into `bd create`, `bd close`, and `bd update` success output
- `--verbose` and error output are unchanged and always show

## Behavior

```
bd --quiet create --title="my issue" ...   # no output (returns 0)
bd --quiet close my-id                     # no output (returns 0)  
bd --quiet update my-id --status=open      # no output (returns 0)
bd --quiet show nonexistent                # still prints error (stderr)
```

## Background

Global `--verbose/-v` and `--quiet/-q` flags were already wired into
`debug.SetVerbose`/`debug.SetQuiet`. The `--verbose` path worked end-to-end;
`--quiet` had no effect on success output because the main output paths
used raw `fmt.Printf`. This commit applies `debug.PrintNormal` to the three
most-used write commands.

## Test plan

- [x] `go build ./cmd/bd/` — passes
- [x] `go test ./internal/debug/` — all 7 tests pass
- [x] Manual: `bd --quiet create` produces no output
- [x] Manual: `bd --quiet close` produces no output
- [x] Manual: `bd --verbose list` shows debug lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)