### PR TITLE
docs(advanced): document test pollution detection — bd doctor --check=pollution (bd-au0.9)

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -5,6 +5,7 @@ This guide covers advanced features for power users and specific use cases.
 ## Table of Contents
 
 - [Renaming Prefix](#renaming-prefix)
+- [Detecting Test Pollution](#detecting-test-pollution)
 - [Merging Duplicate Issues](#merging-duplicate-issues)
 - [Git Worktrees](#git-worktrees)
 - [Database Redirects](#database-redirects)
@@ -55,6 +56,31 @@ bd rename-prefix kw-
 # Now you have kw-1, kw-2, etc.
 bd list  # Shows kw-* issues
 ```
+
+## Detecting Test Pollution
+
+Test pollution occurs when test or scratch issues accumulate in a production database. Use `bd doctor --check=pollution` to detect and optionally remove them:
+
+```bash
+# Scan for test issues (dry-run)
+bd doctor --check=pollution
+
+# Remove detected test issues
+bd doctor --check=pollution --fix
+
+# JSON output for scripting
+bd doctor --check=pollution --json
+```
+
+Test issues are identified by title patterns (`test-`, `benchmark-`, `tmp-`, `debug-`, etc.) and signals like rapid creation bursts or sequential IDs in a non-sequential database.
+
+**Repair with `--fix`:**
+- Closes detected test issues with reason `Removed: test pollution`
+- Preserves open non-test issues and all closed issues
+- Prints a summary of what was removed
+
+> **Legacy note:** An older `bd detect-pollution` command existed in early versions.
+> It was removed and its functionality merged into `bd doctor --check=pollution`.
 
 ## Duplicate Detection
 


### PR DESCRIPTION
## Summary

- Adds **Detecting Test Pollution** section to `docs/ADVANCED.md`
- Documents `bd doctor --check=pollution` as the current interface (replacing removed `bd detect-pollution`)
- Adds legacy note for users migrating from the old `bd detect-pollution` command
- Adds Table of Contents entry for the new section

## Background (bd-au0.9)

This bead asked to review and document rarely-used commands: `rename-prefix`,
`detect-pollution`, and `migrate-hash-ids`. Investigation found:

- `rename-prefix` — already well-documented in help text and ADVANCED.md ✓
- `detect-pollution` — **removed** in a prior refactor; functionality lives in `bd doctor --check=pollution`
- `migrate-hash-ids` — does not exist in the current codebase (was a one-time migration)

The only documentation gap was that `bd doctor --check=pollution` wasn't surfaced
in ADVANCED.md as the replacement for the removed command.

## Test plan

- [x] Section renders correctly in Markdown
- [x] `bd doctor --check=pollution --help` output matches the documented behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)