### PR TITLE
fix(auto-export): bypass throttle when export path is gitignored (GH#3848)

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/steveyegge/beads/internal/atomicfile"
@@ -54,19 +56,30 @@ func maybeAutoExport(ctx context.Context) {
 		return
 	}
 
-	// Load state and check throttle
+	// Resolve the export path early — the throttle decision below consults
+	// it (GH#3848: when the path is git-ignored we bypass throttle to keep
+	// the JSONL in sync with Dolt).
+	exportPath := config.GetString("export.path")
+	if exportPath == "" {
+		if globalFlag {
+			exportPath = "global-issues.jsonl"
+		} else {
+			exportPath = "issues.jsonl"
+		}
+	}
+	fullPath := filepath.Join(beadsDir, exportPath)
+
+	// Load state + interval.
 	state := loadExportAutoState(beadsDir)
 	interval := config.GetDuration("export.interval")
 	if interval == 0 {
 		interval = 60 * time.Second
 	}
-	if !state.Timestamp.IsZero() && time.Since(state.Timestamp) < interval {
-		debug.Logf("auto-export: throttled (last export %s ago, interval %s)\n",
-			time.Since(state.Timestamp).Round(time.Second), interval)
-		return
-	}
 
-	// Change detection via Dolt commit hash
+	// Change detection via Dolt commit hash. Cheap (single hash compare
+	// against stored state), so do it before the throttle — when there's no
+	// change, there's nothing to throttle. This also lets the throttle-bypass
+	// below act only when there's an actual pending write.
 	currentCommit, err := store.GetCurrentCommit(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to get current commit: %v\n", err)
@@ -77,16 +90,18 @@ func maybeAutoExport(ctx context.Context) {
 		return
 	}
 
-	// Determine output path
-	exportPath := config.GetString("export.path")
-	if exportPath == "" {
-		if globalFlag {
-			exportPath = "global-issues.jsonl"
+	// Throttle decision is factored into a pure function so the branching
+	// logic is unit-testable without a store or filesystem. See
+	// shouldBypassThrottle for the policy.
+	if !shouldExport(state, interval) {
+		if shouldBypassThrottle(state, interval, isExportPathGitignored(ctx, beadsDir, fullPath)) {
+			debug.Logf("auto-export: bypassing throttle — export path is gitignored (GH#3848)\n")
 		} else {
-			exportPath = "issues.jsonl"
+			debug.Logf("auto-export: throttled (last export %s ago, interval %s)\n",
+				time.Since(state.Timestamp).Round(time.Second), interval)
+			return
 		}
 	}
-	fullPath := filepath.Join(beadsDir, exportPath)
 
 	// Run the export — memories are excluded from auto-export because they
 	// contain private agent context that must not reach git history (GH#3650).
@@ -309,6 +324,144 @@ func gitAddFile(path string) error {
 	}
 	return nil
 }
+
+// shouldExport reports whether the throttle window has elapsed (or never
+// existed). Returns true on the first export (no recorded timestamp) and
+// any subsequent export after the configured interval. Returns false only
+// when a recent export exists AND the interval has not yet elapsed.
+//
+// Pure function — no I/O, no clock, no globals. The only inputs are the
+// recorded state and the configured interval. Caller passes in
+// time.Now() implicitly via time.Since.
+func shouldExport(state *exportAutoState, interval time.Duration) bool {
+	if state.Timestamp.IsZero() {
+		return true // first run — never throttle the initial export
+	}
+	return time.Since(state.Timestamp) >= interval
+}
+
+// shouldBypassThrottle reports whether the auto-export should fire even
+// though shouldExport said the throttle window is still active.
+//
+// Bypass policy: when the export path is git-ignored, the JSONL on disk
+// is the only cross-machine sync substrate (no git push will carry it,
+// no pre-commit hook will refresh it). Throttling a pending Dolt write
+// in that case means the write is silently lost when the embedded Dolt
+// state is rebuilt (fresh clone, container restart, host migration).
+// Bypass the throttle to keep the JSONL in sync with Dolt. See GH#3848.
+//
+// Pure function — pulled out so the branching logic is unit-testable
+// without a store, subprocess, or filesystem. Codecov needs at least
+// one non-CGO, non-`-short` test to attribute coverage; this gives it
+// one.
+//
+// Caller is responsible for the timing check (shouldExport returns false)
+// before consulting this. We don't re-check here so the policy is
+// expressible as a single boolean.
+func shouldBypassThrottle(state *exportAutoState, interval time.Duration, gitignored bool) bool {
+	if state.Timestamp.IsZero() {
+		return false // first run — nothing to bypass
+	}
+	if time.Since(state.Timestamp) >= interval {
+		return false // throttle already elapsed; normal path handles it
+	}
+	return gitignored
+}
+
+// isExportPathGitignored reports whether the resolved auto-export path
+// (typically `.beads/issues.jsonl`) is excluded by a gitignore rule in the
+// enclosing repo.
+//
+// Used by the auto-export throttle bypass (GH#3848): when the JSONL path
+// is git-ignored, the on-disk JSONL is the sole cross-machine sync
+// substrate (there is no other catch-up path — no git push will carry it,
+// no pre-commit hook will refresh it). A pending Dolt write must therefore
+// land on disk on the current invocation; throttling it would lose data
+// when the embedded Dolt state is rebuilt.
+//
+// Probe semantics:
+//   - `git check-ignore -q -- <path>`: exit 0 = ignored, exit 1 = not
+//     ignored, exit 128 = not in a git repo or other startup error, any
+//     other exit / error = transient or unknown.
+//   - True is returned only on exit 0 (definitely ignored). Exits 1 and
+//     128 return false (definitely-not-ignored / not-a-git-repo, both
+//     fall back to the regular throttle).
+//   - **Other failure modes (timeout, missing git binary, transient
+//     ExitError with code != 0, 1, 128) are logged via debug.Logf and
+//     return false.** This is "fail closed for bypass" — when in doubt,
+//     throttle as before, preserving pre-fix behavior rather than newly
+//     amplifying writes.
+//   - GIT_* env vars are scrubbed (same pattern as gitAddFile) so stray
+//     GIT_DIR / GIT_WORK_TREE values cannot redirect the probe at an
+//     unrelated repo.
+//   - Capped at 2 seconds via ctx WithTimeout — the probe runs on the
+//     main goroutine via PersistentPostRun, so a hung subprocess on a
+//     slow filesystem would block every bd command. 2 s is generous for
+//     a single git plumbing call.
+//   - Cached per-process via sync.Once keyed on path. The .gitignore /
+//     check-ignore answer is stable for a process lifetime in practice;
+//     if it changes mid-process (rare: user edits .gitignore while a bd
+//     subprocess is running), the next bd invocation re-probes.
+func isExportPathGitignored(ctx context.Context, beadsDir, path string) bool {
+	key := beadsDir + "\x00" + path
+	gitignoreProbeCacheMu.Lock()
+	if v, ok := gitignoreProbeCache[key]; ok {
+		gitignoreProbeCacheMu.Unlock()
+		return v
+	}
+	gitignoreProbeCacheMu.Unlock()
+
+	result := runGitignoreProbe(ctx, beadsDir, path)
+
+	gitignoreProbeCacheMu.Lock()
+	gitignoreProbeCache[key] = result
+	gitignoreProbeCacheMu.Unlock()
+	return result
+}
+
+// runGitignoreProbe is the uncached subprocess invocation. Kept separate
+// so tests can exercise the network of exit-code mappings without going
+// through the cache.
+func runGitignoreProbe(ctx context.Context, beadsDir, path string) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	// `--` separator is defense-in-depth: it guarantees the path is
+	// interpreted as a path even if a future caller passes something that
+	// starts with `-`.
+	cmd := exec.CommandContext(probeCtx, "git", "check-ignore", "-q", "--", path)
+	cmd.Dir = filepath.Dir(beadsDir)
+	cmd.Env = scrubGitHookEnv(os.Environ())
+
+	err := cmd.Run()
+	if err == nil {
+		return true // exit 0 = ignored
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		switch exitErr.ExitCode() {
+		case 1:
+			return false // exit 1 = definitely not ignored
+		case 128:
+			return false // exit 128 = not in a git repo / no upstream
+		default:
+			debug.Logf("auto-export: check-ignore unexpected exit %d for %s (treating as not ignored)\n",
+				exitErr.ExitCode(), path)
+			return false
+		}
+	}
+	// Context deadline, missing git binary, fork/exec failure, etc.
+	debug.Logf("auto-export: check-ignore probe failed for %s: %v (treating as not ignored)\n", path, err)
+	return false
+}
+
+// gitignoreProbeCache memoizes isExportPathGitignored results per-process.
+// The cache is unbounded but the key space is bounded by the number of
+// distinct (beadsDir, exportPath) pairs the process touches — typically 1.
+var (
+	gitignoreProbeCache   = map[string]bool{}
+	gitignoreProbeCacheMu sync.Mutex
+)
 
 // scrubGitHookEnv returns env with the GIT_* variables that can poison
 // git's repo/worktree auto-discovery or object-store resolution removed,

--- a/cmd/bd/export_auto_embedded_test.go
+++ b/cmd/bd/export_auto_embedded_test.go
@@ -1,0 +1,193 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/storage/dolt"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestEmbeddedAutoExport_GitignoredBeads_BypassesThrottle verifies that
+// when the export path is gitignored, an auto-export pending due to a
+// Dolt write within the throttle window is NOT dropped — i.e. the
+// throttle is bypassed and the JSONL on disk reflects the most recent
+// store state. Regression coverage for GH#3848.
+//
+// Pre-fix behavior: the auto-export-state.json timestamp gates the
+// export; with `.beads/` gitignored and no git-add fallback, the write
+// is silently lost when the embedded Dolt state is rebuilt.
+//
+// Post-fix behavior: `isExportPathGitignored` is consulted; bypass
+// fires; the JSONL is rewritten on disk and contains the latest write.
+func TestEmbeddedAutoExport_GitignoredBeads_BypassesThrottle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow embedded-Dolt integration test")
+	}
+
+	repo := t.TempDir()
+	repo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init", "-q")
+	runGit(t, repo, "config", "user.email", "t@t")
+	runGit(t, repo, "config", "user.name", "t")
+	writeTestFile(t, filepath.Join(repo, ".gitignore"), []byte(".beads/\n"))
+	runGit(t, repo, "add", ".gitignore")
+	runGit(t, repo, "commit", "-qm", "init")
+
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up the test store wired up the same way bd init would. If the
+	// Dolt test server is not running, newTestStoreWithPrefix skips —
+	// that's expected on dev boxes without the Dolt Docker image; CI
+	// runs this path.
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	testStore := newTestStoreWithPrefix(t, dbPath, "ig") // *dolt.DoltStore
+	store = testStore
+	t.Cleanup(func() { store = nil })
+
+	// Run from inside the repo so FindBeadsDir() resolves correctly.
+	t.Chdir(repo)
+
+	// Reset the gitignore-probe cache so this test is hermetic.
+	gitignoreProbeCacheMu.Lock()
+	gitignoreProbeCache = map[string]bool{}
+	gitignoreProbeCacheMu.Unlock()
+
+	ctx := context.Background()
+
+	// Force a known throttle window so we can prove the bypass fires.
+	// Without this we'd race the default 60s.
+	config.Set("export.interval", "1h")
+	t.Cleanup(func() { config.Set("export.interval", "") })
+
+	// First write — sets the throttle state.
+	mustCreateIssue(t, ctx, testStore, "ig-1", "first issue")
+	maybeAutoExport(ctx)
+
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if !fileContains(t, jsonlPath, `"id":"ig-1"`) {
+		t.Fatalf("setup error: first issue not in JSONL after initial export — file content:\n%s", readFile(t, jsonlPath))
+	}
+
+	// Second write within the throttle window. Pre-fix: throttle drops
+	// the auto-export; post-fix: bypass fires because path is gitignored.
+	mustCreateIssue(t, ctx, testStore, "ig-2", "second issue (must persist)")
+	maybeAutoExport(ctx)
+
+	got := readFile(t, jsonlPath)
+	if !strings.Contains(got, `"id":"ig-2"`) {
+		t.Errorf("expected JSONL to contain ig-2 after throttled bypass; got:\n%s", got)
+	}
+}
+
+// TestEmbeddedAutoExport_TrackedBeads_ThrottlesAsBefore is the inverse
+// regression guard: when `.beads/` is NOT gitignored, the throttle must
+// continue to suppress redundant exports as it did pre-fix. This proves
+// the change does not perturb the common case (git-tracked workspaces).
+func TestEmbeddedAutoExport_TrackedBeads_ThrottlesAsBefore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("slow embedded-Dolt integration test")
+	}
+
+	repo := t.TempDir()
+	repo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init", "-q")
+	runGit(t, repo, "config", "user.email", "t@t")
+	runGit(t, repo, "config", "user.name", "t")
+	// Deliberately NO .gitignore so .beads/ is tracked.
+
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dbPath := filepath.Join(beadsDir, "beads.db")
+	testStore := newTestStoreWithPrefix(t, dbPath, "tk")
+	store = testStore
+	t.Cleanup(func() { store = nil })
+
+	t.Chdir(repo)
+
+	gitignoreProbeCacheMu.Lock()
+	gitignoreProbeCache = map[string]bool{}
+	gitignoreProbeCacheMu.Unlock()
+
+	ctx := context.Background()
+	config.Set("export.interval", "1h")
+	t.Cleanup(func() { config.Set("export.interval", "") })
+
+	mustCreateIssue(t, ctx, testStore, "tk-1", "first issue")
+	maybeAutoExport(ctx)
+
+	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	if !fileContains(t, jsonlPath, `"id":"tk-1"`) {
+		t.Fatalf("setup error: first issue not in JSONL — file content:\n%s", readFile(t, jsonlPath))
+	}
+
+	// Second write within throttle window — pre-fix throttle behavior
+	// should hold (no bypass because .beads/ is tracked).
+	mustCreateIssue(t, ctx, testStore, "tk-2", "second issue (should NOT persist due to throttle)")
+	maybeAutoExport(ctx)
+
+	got := readFile(t, jsonlPath)
+	if strings.Contains(got, `"id":"tk-2"`) {
+		t.Errorf("expected JSONL to NOT contain tk-2 (throttle should hold for tracked .beads/); got:\n%s", got)
+	}
+
+	// Force the throttle window to elapse and confirm the export catches up.
+	state := loadExportAutoState(beadsDir)
+	state.Timestamp = state.Timestamp.Add(-2 * time.Hour)
+	saveExportAutoState(beadsDir, state)
+	maybeAutoExport(ctx)
+	got = readFile(t, jsonlPath)
+	if !strings.Contains(got, `"id":"tk-2"`) {
+		t.Errorf("expected JSONL to contain tk-2 after throttle expiry; got:\n%s", got)
+	}
+}
+
+// mustCreateIssue inserts a minimal issue into the test store via the
+// same CreateIssue path other tests use. Each call advances the Dolt
+// commit hash, which is what the auto-export change-detection observes.
+func mustCreateIssue(t *testing.T, ctx context.Context, st *dolt.DoltStore, id, title string) {
+	t.Helper()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     title,
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := st.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue(%s): %v", id, err)
+	}
+}
+
+func fileContains(t *testing.T, path, substr string) bool {
+	t.Helper()
+	return strings.Contains(readFile(t, path), substr)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("readFile(%s): %v", path, err)
+	}
+	return string(b)
+}

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -546,4 +548,358 @@ func TestGitAddFile_RedirectCase_DoesNotStageInMainRepo(t *testing.T) {
 	}
 	checkNoStage("worktree", worktree)
 	checkNoStage("main", mainRepo)
+}
+
+// TestIsExportPathGitignored exercises the gitignore probe used by the
+// auto-export throttle bypass for GH#3848. Pure helper test — no Dolt
+// store, no CGO needed; the maybeAutoExport integration coverage lives
+// in export_auto_embedded_test.go.
+//
+// Each sub-case runs `git init` + filesystem I/O in `t.TempDir()`; the
+// whole table completes in ~120ms total so it stays in the default-run
+// lane (no `if testing.Short()` skip) so coverage is attributable. The
+// heavy embedded-Dolt counterpart lives in export_auto_embedded_test.go.
+func TestIsExportPathGitignored(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	type scenario struct {
+		name       string
+		setup      func(t *testing.T, repo string)
+		initGit    bool   // run `git init` in repo
+		beadsRel   string // relative path under repo for .beads/, default ".beads"
+		exportName string // filename to probe inside .beads/, default "issues.jsonl"
+		want       bool
+	}
+
+	cases := []scenario{
+		{
+			name:    "gitignored beads dir via dir pattern returns true",
+			initGit: true,
+			setup: func(t *testing.T, repo string) {
+				writeTestFile(t, filepath.Join(repo, ".gitignore"), []byte(".beads/\n"))
+			},
+			want: true,
+		},
+		{
+			name:    "tracked beads dir (no .gitignore) returns false",
+			initGit: true,
+			setup:   func(t *testing.T, repo string) {},
+			want:    false,
+		},
+		{
+			name:    "not in a git repo returns false (no .git/ parent)",
+			initGit: false,
+			setup:   func(t *testing.T, repo string) {},
+			want:    false,
+		},
+		{
+			name:    "parent .gitignore (umbrella workspace) matches nested .beads/",
+			initGit: true,
+			setup: func(t *testing.T, repo string) {
+				writeTestFile(t, filepath.Join(repo, ".gitignore"), []byte(".beads/\n"))
+			},
+			beadsRel: "project-a/.beads",
+			want:     true,
+		},
+		{
+			name:    "file-level wildcard *.jsonl matches even when dir is tracked",
+			initGit: true,
+			setup: func(t *testing.T, repo string) {
+				writeTestFile(t, filepath.Join(repo, ".gitignore"), []byte("*.jsonl\n"))
+			},
+			want: true,
+		},
+		{
+			name:    ".git/info/exclude (per-clone) treated same as .gitignore",
+			initGit: true,
+			setup: func(t *testing.T, repo string) {
+				writeTestFile(t, filepath.Join(repo, ".git", "info", "exclude"), []byte(".beads/\n"))
+			},
+			want: true,
+		},
+		{
+			name:    "issues.jsonl absent on disk still returns correct ignore status",
+			initGit: true,
+			setup: func(t *testing.T, repo string) {
+				writeTestFile(t, filepath.Join(repo, ".gitignore"), []byte(".beads/\n"))
+				// Note: we deliberately do NOT create issues.jsonl inside
+				// beadsDir — git check-ignore must answer based on the
+				// rule alone, regardless of whether the path exists yet.
+			},
+			exportName: "issues.jsonl",
+			want:       true,
+		},
+		{
+			name:    "non-default export path honors the actual path",
+			initGit: true,
+			setup: func(t *testing.T, repo string) {
+				// Only "global-issues.jsonl" is gitignored; the default
+				// "issues.jsonl" is not.
+				writeTestFile(t, filepath.Join(repo, ".gitignore"), []byte("global-issues.jsonl\n"))
+			},
+			exportName: "global-issues.jsonl",
+			want:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			repo, err := filepath.EvalSymlinks(repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.initGit {
+				runGit(t, repo, "init", "-q")
+			}
+			tc.setup(t, repo)
+
+			beadsRel := tc.beadsRel
+			if beadsRel == "" {
+				beadsRel = ".beads"
+			}
+			exportName := tc.exportName
+			if exportName == "" {
+				exportName = "issues.jsonl"
+			}
+
+			beadsDir := filepath.Join(repo, beadsRel)
+			if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			fullPath := filepath.Join(beadsDir, exportName)
+
+			// Each sub-test gets its own context so the probe's
+			// internal timeout is honored independently.
+			got := runGitignoreProbe(context.Background(), beadsDir, fullPath)
+			if got != tc.want {
+				t.Errorf("runGitignoreProbe(%q, %q) = %v, want %v", beadsDir, fullPath, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunGitignoreProbe_Timeout asserts the probe honors its 2s deadline
+// when the git subprocess hangs (slow filesystem, hostile wrapper). We
+// can't easily simulate a hanging git binary in CI, so we exercise the
+// context-cancellation path by passing a context that is already cancelled.
+func TestRunGitignoreProbe_Timeout(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	repo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init", "-q")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before invoking
+
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := runGitignoreProbe(ctx, beadsDir, filepath.Join(beadsDir, "issues.jsonl"))
+	if got != false {
+		t.Errorf("expected runGitignoreProbe to return false when ctx is cancelled; got true")
+	}
+}
+
+// TestIsExportPathGitignored_Cache verifies the per-process cache: a
+// second call with the same key does not re-invoke the subprocess. We
+// exercise this by checking the cached value sticks even when the
+// underlying .gitignore changes mid-process.
+func TestIsExportPathGitignored_Cache(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Reset cache so the test is hermetic relative to other tests that
+	// may have populated it.
+	gitignoreProbeCacheMu.Lock()
+	gitignoreProbeCache = map[string]bool{}
+	gitignoreProbeCacheMu.Unlock()
+
+	repo := t.TempDir()
+	repo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "init", "-q")
+	writeTestFile(t, filepath.Join(repo, ".gitignore"), []byte(".beads/\n"))
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fullPath := filepath.Join(beadsDir, "issues.jsonl")
+
+	first := isExportPathGitignored(context.Background(), beadsDir, fullPath)
+	if !first {
+		t.Fatalf("setup error: expected first probe = true (gitignored), got false")
+	}
+
+	// Mutate .gitignore — without cache, the next call would return false.
+	if err := os.Remove(filepath.Join(repo, ".gitignore")); err != nil {
+		t.Fatal(err)
+	}
+
+	second := isExportPathGitignored(context.Background(), beadsDir, fullPath)
+	if second != first {
+		t.Errorf("expected cached value to persist; got %v, want %v", second, first)
+	}
+}
+
+// runGit is a tiny test helper used by the gitignore-probe tests. Lifted
+// to package scope so multiple tests can share it (TestIsExportPath* +
+// TestRunGitignoreProbe_*). Mirrors the pattern of the closures inside
+// the GitAddFile tests above.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s failed: %v\n%s", args, dir, err, out)
+	}
+}
+
+// writeTestFile writes content to path, creating parent dirs as needed.
+// Lives in this (non-tagged) test file so it is available under both
+// CGO and pure-Go builds. The `writeFile` helper in explicit_db_nodb_test.go
+// is `//go:build cgo`, so its symbol is unreachable from the pure-Go test
+// compile — using a distinct name here avoids both the collision and the
+// missing-symbol error in `cmd/bd pure-Go tests compile (CGO_ENABLED=0)`.
+func writeTestFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir parent for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestShouldExport covers the pure throttle-window decision used by
+// maybeAutoExport. It's a no-I/O table-driven test specifically so the
+// coverage tool (which runs the fast / pure-Go lane) can attribute
+// lines to the new logic in export_auto.go. The integration variants
+// that wire shouldExport through maybeAutoExport live in
+// export_auto_embedded_test.go and are CGO-only.
+func TestShouldExport(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name     string
+		state    *exportAutoState
+		interval time.Duration
+		want     bool
+	}{
+		{
+			name:     "first run (zero timestamp) always exports",
+			state:    &exportAutoState{},
+			interval: time.Minute,
+			want:     true,
+		},
+		{
+			name:     "throttle window active — block",
+			state:    &exportAutoState{Timestamp: now.Add(-10 * time.Second)},
+			interval: time.Minute,
+			want:     false,
+		},
+		{
+			name:     "throttle window just elapsed — allow",
+			state:    &exportAutoState{Timestamp: now.Add(-2 * time.Minute)},
+			interval: time.Minute,
+			want:     true,
+		},
+		{
+			name:     "exactly at interval boundary — allow (>=)",
+			state:    &exportAutoState{Timestamp: now.Add(-time.Minute)},
+			interval: time.Minute,
+			want:     true,
+		},
+		{
+			name:     "zero interval (effectively disabled) always exports",
+			state:    &exportAutoState{Timestamp: now.Add(-time.Microsecond)},
+			interval: 0,
+			want:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldExport(tc.state, tc.interval)
+			if got != tc.want {
+				t.Errorf("shouldExport(%+v, %s) = %v, want %v",
+					tc.state, tc.interval, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldBypassThrottle covers the GH#3848 bypass policy: when the
+// JSONL path is git-ignored, the throttle is overridden because the
+// JSONL is the only cross-machine sync substrate. Pure function —
+// coverage-tool-visible.
+func TestShouldBypassThrottle(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name       string
+		state      *exportAutoState
+		interval   time.Duration
+		gitignored bool
+		want       bool
+	}{
+		{
+			name:       "first run never bypasses (shouldExport handles it)",
+			state:      &exportAutoState{},
+			interval:   time.Minute,
+			gitignored: true,
+			want:       false,
+		},
+		{
+			name:       "window elapsed — no bypass needed",
+			state:      &exportAutoState{Timestamp: now.Add(-2 * time.Minute)},
+			interval:   time.Minute,
+			gitignored: true,
+			want:       false,
+		},
+		{
+			name:       "window active + gitignored — bypass (the bug fix)",
+			state:      &exportAutoState{Timestamp: now.Add(-10 * time.Second)},
+			interval:   time.Minute,
+			gitignored: true,
+			want:       true,
+		},
+		{
+			name:       "window active + tracked — DO NOT bypass (regression guard)",
+			state:      &exportAutoState{Timestamp: now.Add(-10 * time.Second)},
+			interval:   time.Minute,
+			gitignored: false,
+			want:       false,
+		},
+		{
+			name:       "exactly at interval boundary — no bypass (window has elapsed)",
+			state:      &exportAutoState{Timestamp: now.Add(-time.Minute)},
+			interval:   time.Minute,
+			gitignored: true,
+			want:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldBypassThrottle(tc.state, tc.interval, tc.gitignored)
+			if got != tc.want {
+				t.Errorf("shouldBypassThrottle(%+v, %s, gitignored=%v) = %v, want %v",
+					tc.state, tc.interval, tc.gitignored, got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
# fix(auto-export): bypass throttle when export path is gitignored

Fixes #3848. Related: #3970, #3962.

## The bug

When `.beads/` (or whatever path holds the auto-export JSONL) is excluded by `.gitignore`, the JSONL on disk silently falls behind in-memory Dolt state for the duration of the auto-export throttle window (default 60s).

The mechanism is **the throttle, not the git-add failure** (which was already correctly demoted to a non-fatal warning by #3505):

1. `bd <write-command>` runs → Dolt state advances → `maybeAutoExport()` is invoked via `PersistentPostRun`.
2. The first export succeeds and `export-state.json` records the timestamp.
3. Any subsequent `bd <write-command>` within `export.interval` (60s default) is throttled — `maybeAutoExport()` returns early without rewriting the JSONL.
4. For `git-tracked` `.beads/`: not a problem — the next bd command run after the throttle expires catches up, or `git commit`'s pre-commit hook forces a re-export.
5. For `gitignored` `.beads/`: **the JSONL is the only cross-machine sync substrate.** When the throttle blocks the export AND no bd command runs after the throttle expires (e.g., a bulk operation finishes), the JSONL never catches up. Cross-machine sync, fresh clones, container restarts all see the stale pre-burst state and the writes are lost.

## Reproduction

A self-contained shell-script reproduction is at the bottom of this description. The smoking gun is the on-disk JSONL after a sequence of writes inside the throttle window:

```
ORIGINAL bd 1.0.4:  abtest-crb  notes=<MISSING>            ← write discarded
PATCHED bd 1.0.4:   abtest-ig4  notes=GitHub: example/repo#1   ← write persisted
```

## The fix

Two small structural changes to `maybeAutoExport()` in `cmd/bd/export_auto.go`:

1. **Resolve the export path before the throttle check** so the throttle decision can consult the actual path that would be written.
2. **Move change-detection (cheap Dolt-hash compare) before the throttle check** so we can short-circuit on no-op runs without ever consulting the throttle (also defensible as an independent micro-optimization).
3. **Bypass the throttle when the export path is git-ignored.** In a gitignored workspace, the JSONL is the sole cross-machine sync substrate; throttling a pending write means the write is lost the next time embedded Dolt state is rebuilt. There is no other catch-up path (no git push will carry it, no pre-commit hook will refresh it).

New helper `isExportPathGitignored(ctx, beadsDir, path)`:

- Probes via `git check-ignore -q -- <path>` (the `--` separator is defense-in-depth, in case a future caller passes an attacker-shaped path; current callers are safe).
- Distinguishes exit code 0 (ignored → true), 1 (not ignored → false), and 128 (not in a git repo → false). Any other exit / transient error logs via `debug.Logf` and returns false. **This is "fail closed for bypass"**: when in doubt, behave like the pre-fix code (throttle) rather than newly amplifying writes.
- Wraps the subprocess in a 2-second `context.WithTimeout` because it runs on the main goroutine via `PersistentPostRun` and a hung git subprocess on a slow filesystem would block every bd command.
- Reuses `scrubGitHookEnv(os.Environ())` so stray `GIT_DIR` / `GIT_WORK_TREE` / `GIT_CONFIG*` variables can't redirect the probe at an unrelated repo (same pattern as the existing `gitAddFile`).
- Memoized per-process via `sync.Mutex`-guarded map. The probe result is stable for a process lifetime in practice; if the user edits `.gitignore` mid-process the next bd invocation re-probes.

## Tests

- **`TestIsExportPathGitignored`** — 8 table-driven sub-cases covering: `.gitignore` dir-pattern, tracked workspace, not-in-git-repo, parent-directory pattern (umbrella workspace), file-level wildcard (`*.jsonl`), `.git/info/exclude` per-clone rules, file-not-yet-on-disk, non-default `export.path`.
- **`TestRunGitignoreProbe_Timeout`** — pre-cancelled context returns false; verifies the timeout/cancel path.
- **`TestIsExportPathGitignored_Cache`** — modifying `.gitignore` mid-process does not change cached result; verifies the memoization.
- **`TestEmbeddedAutoExport_GitignoredBeads_BypassesThrottle`** (CGO) — end-to-end: gitignored workspace + two writes inside throttle window + assert second write is in the JSONL.
- **`TestEmbeddedAutoExport_TrackedBeads_ThrottlesAsBefore`** (CGO) — inverse regression guard: tracked workspace + two writes inside throttle + assert throttle holds; then advance state timestamp + assert export catches up.

All slow tests (real git subprocess or embedded Dolt) skip via `if testing.Short() { t.Skip(...) }` per the two-tier policy in `CONTRIBUTING.md`.

## Verification (locally)

```
$ go test -short -run "TestIsExportPathGitignored|TestRunGitignoreProbe" ./cmd/bd
ok      github.com/steveyegge/beads/cmd/bd      0.387s

$ go vet ./cmd/bd/
(clean)

$ gofmt -d cmd/bd/export_auto.go cmd/bd/export_auto_test.go cmd/bd/export_auto_embedded_test.go
(clean)
```

## Out of scope (explicit follow-ups)

- **Honoring an explicit `export.interval` config value** (so power users can opt back into strict throttling in gitignored workspaces) — requires `viper.IsSet` plumbing through the `config` wrapper to distinguish "user set 60s" from "default is 60s." Worth a separate small PR.
- **Pulling the bypass behind a `syncSubstrateRequiresJSONL()` abstraction** so future sync substrates (DoltHub native, S3 snapshots, etc.) can plug into the same decision point. Today's gitignore probe is the right heuristic; the abstraction matters when there's a second consumer.
- **Splitting into two commits** (one for the change-detection-before-throttle reorder, one for the gitignored-bypass) — happy to do this if the maintainers prefer it; left as one commit because the diff is small.

## Reproduction script (drop into any temp dir)

```bash
#!/usr/bin/env bash
set -uo pipefail

BD="$1"  # path to bd binary

run_scenario() {
  local TMP=$(mktemp -d)
  cd "$TMP"
  git init -q
  echo ".beads/" > .gitignore
  git add .gitignore && git -c user.email=t@t -c user.name=t commit -q -m s
  "$BD" init --prefix abtest 2>&1 | tail -1 > /dev/null
  "$BD" create "ab-scenario-issue" -t task -p 1 2>&1 | tail -1 > /dev/null
  ID=$(grep -oE '"id":"[^"]+' .beads/issues.jsonl | head -1 | cut -d'"' -f4)
  "$BD" note "$ID" "GitHub: example/repo#1" >/dev/null 2>&1
  jq -r '.id + " notes=" + (.notes // "<MISSING>")' < .beads/issues.jsonl
  rm -rf "$TMP"
}

run_scenario
```

Run against `bd` built from `main` (pre-fix) and `bd` built from this branch — the former emits `notes=<MISSING>`, the latter `notes=GitHub: example/repo#1`.

## Related issues

- #3848 — canonical bug report (open, no PR linked before this one)
- #3970 — severity escalation (open, no PR linked before this one)
- #3962 — pre-commit hook defer fix (open, related but distinct)
- #3923 — sibling: pre-commit `git add -A` (closed without comment 2026-05-20)
