### PR TITLE
fix(ready): use FIFO ordering within same priority tier (GH#4043)

### DIFF
--- a/internal/storage/dolt/wisps.go
+++ b/internal/storage/dolt/wisps.go
@@ -358,7 +358,7 @@ func (s *DoltStore) searchWisps(ctx context.Context, query string, filter types.
 	querySQL := fmt.Sprintf(`
 		SELECT id FROM wisps
 		%s
-		ORDER BY priority ASC, created_at DESC
+		ORDER BY priority ASC, created_at ASC
 		%s
 	`, whereSQL, limitSQL)
 

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -195,7 +195,7 @@ func GetReadyWorkInTx(
 	case types.SortPolicyOldest:
 		orderBySQL = "ORDER BY created_at ASC, id ASC"
 	case types.SortPolicyPriority:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
+		orderBySQL = "ORDER BY priority ASC, created_at ASC, id ASC"
 	case types.SortPolicyHybrid, "":
 		recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
 		orderBySQL = `ORDER BY
@@ -204,7 +204,7 @@ func GetReadyWorkInTx(
 			created_at ASC, id ASC`
 		args = append(args, recentCutoff, recentCutoff)
 	default:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
+		orderBySQL = "ORDER BY priority ASC, created_at ASC, id ASC"
 	}
 
 	var issueIDs []string


### PR DESCRIPTION
## Summary
- Changes `bd ready` default sort from `created_at DESC` (newest-first) to `created_at ASC` (FIFO) within the same priority tier
- Under concurrent `bd ready --claim --limit=1`, the previous DESC ordering caused the oldest item to be consistently skipped when pool sizing contracted between successive claims
- Only affects `SortPolicyPriority` (the default); `--sort=oldest` and `--sort=hybrid` already use ASC
- Three sites updated: `GetReadyWorkInTx` (priority + default cases), and `searchWisps`

Closes #4043

## Test plan
- [x] `make build` succeeds
- [x] Existing ready work tests pass (no test asserts DESC within same priority)
- [x] `TestProtocol_ReadyOrderingIsPriorityAsc` still passes (only tests cross-priority)
- [x] `TestGetReadyWorkSortPolicy` still passes (tests P1 → P2 → P3, not intra-priority)