### PR TITLE
fix(graph): honor parent, estimate, external_ref, and deps in --graph import (GH#4064)

### DIFF
--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -22,21 +22,21 @@ type GraphApplyPlan struct {
 
 // GraphApplyNode describes a single bead to create.
 type GraphApplyNode struct {
-	Key               string            `json:"key"`
-	Title             string            `json:"title"`
-	Type              string            `json:"type,omitempty"`
-	Description       string            `json:"description,omitempty"`
-	Assignee          string            `json:"assignee,omitempty"`
-	AssignAfterCreate bool              `json:"assign_after_create,omitempty"`
-	Priority          *int              `json:"priority,omitempty"` // nil defaults to P2
-	Estimate          *int              `json:"estimate,omitempty"` // minutes
-	Labels            []string          `json:"labels,omitempty"`
-	Metadata          map[string]string `json:"metadata,omitempty"`
-	MetadataRefs      map[string]string `json:"metadata_refs,omitempty"`
-	ExternalRef       string            `json:"external_ref,omitempty"`
-	Parent            string            `json:"parent,omitempty"`     // alias for parent_key
-	ParentKey         string            `json:"parent_key,omitempty"`
-	ParentID          string            `json:"parent_id,omitempty"`
+	Key               string              `json:"key"`
+	Title             string              `json:"title"`
+	Type              string              `json:"type,omitempty"`
+	Description       string              `json:"description,omitempty"`
+	Assignee          string              `json:"assignee,omitempty"`
+	AssignAfterCreate bool                `json:"assign_after_create,omitempty"`
+	Priority          *int                `json:"priority,omitempty"` // nil defaults to P2
+	Estimate          *int                `json:"estimate,omitempty"` // minutes
+	Labels            []string            `json:"labels,omitempty"`
+	Metadata          map[string]string   `json:"metadata,omitempty"`
+	MetadataRefs      map[string]string   `json:"metadata_refs,omitempty"`
+	ExternalRef       string              `json:"external_ref,omitempty"`
+	Parent            string              `json:"parent,omitempty"` // alias for parent_key
+	ParentKey         string              `json:"parent_key,omitempty"`
+	ParentID          string              `json:"parent_id,omitempty"`
 	Deps              []GraphApplyNodeDep `json:"deps,omitempty"`
 }
 

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -29,11 +29,15 @@ type GraphApplyNode struct {
 	Assignee          string            `json:"assignee,omitempty"`
 	AssignAfterCreate bool              `json:"assign_after_create,omitempty"`
 	Priority          *int              `json:"priority,omitempty"` // nil defaults to P2
+	Estimate          *int              `json:"estimate,omitempty"` // minutes
 	Labels            []string          `json:"labels,omitempty"`
 	Metadata          map[string]string `json:"metadata,omitempty"`
 	MetadataRefs      map[string]string `json:"metadata_refs,omitempty"`
+	ExternalRef       string            `json:"external_ref,omitempty"`
+	Parent            string            `json:"parent,omitempty"`     // alias for parent_key
 	ParentKey         string            `json:"parent_key,omitempty"`
 	ParentID          string            `json:"parent_id,omitempty"`
+	Deps              []GraphApplyNodeDep `json:"deps,omitempty"`
 }
 
 // GraphApplyEdge describes a dependency edge.
@@ -43,6 +47,13 @@ type GraphApplyEdge struct {
 	ToKey   string `json:"to_key,omitempty"`
 	ToID    string `json:"to_id,omitempty"`
 	Type    string `json:"type,omitempty"`
+}
+
+// GraphApplyNodeDep describes an inline dependency on a single graph node.
+// Target is resolved as a plan key first, then treated as a literal issue ID.
+type GraphApplyNodeDep struct {
+	Type   string `json:"type,omitempty"`
+	Target string `json:"target"`
 }
 
 // GraphApplyResult returns the concrete bead IDs assigned to each symbolic key.
@@ -90,11 +101,15 @@ var knownGraphNodeFields = map[string]struct{}{
 	"assignee":            {},
 	"assign_after_create": {},
 	"priority":            {},
+	"estimate":            {},
 	"labels":              {},
 	"metadata":            {},
 	"metadata_refs":       {},
+	"external_ref":        {},
+	"parent":              {},
 	"parent_key":          {},
 	"parent_id":           {},
+	"deps":                {},
 }
 
 // knownGraphEdgeFields lists the JSON keys recognized on a GraphApplyEdge.
@@ -113,10 +128,9 @@ var knownGraphEdgeFields = map[string]struct{}{
 // a "parent" string instead of "parent_key", or "blocks" arrays instead of
 // the top-level edges array). (GH#3367)
 var graphFieldHints = map[string]string{
-	"parent":   "use 'parent_key' (referencing another node's 'key') or 'parent_id' (an existing issue ID)",
-	"blocks":   "use the top-level 'edges' array, e.g. {\"from_key\": \"a\", \"to_key\": \"b\", \"type\": \"blocks\"}",
-	"depends":  "use the top-level 'edges' array with type 'blocks'",
-	"children": "set 'parent_key' on each child instead of listing children on the parent",
+	"blocks":   "use the top-level 'edges' array or per-node 'deps', e.g. {\"deps\": [{\"target\": \"key\", \"type\": \"blocks\"}]}",
+	"depends":  "use the top-level 'edges' array or per-node 'deps' with type 'blocks'",
+	"children": "set 'parent_key' or 'parent' on each child instead of listing children on the parent",
 }
 
 // detectUnknownGraphFields scans the raw plan JSON and returns unknown field
@@ -295,7 +309,11 @@ func emitGraphApplyDryRun(plan *GraphApplyPlan) {
 		if node.Priority != nil {
 			priority = *node.Priority
 		}
-		if node.ParentKey != "" || node.ParentID != "" {
+		effectiveParentKey := node.ParentKey
+		if effectiveParentKey == "" {
+			effectiveParentKey = node.Parent
+		}
+		if effectiveParentKey != "" || node.ParentID != "" {
 			parentDeps++
 		}
 		rows = append(rows, GraphApplyDryRunRow{
@@ -303,7 +321,7 @@ func emitGraphApplyDryRun(plan *GraphApplyPlan) {
 			Title:     node.Title,
 			Type:      issueType,
 			Priority:  priority,
-			ParentKey: node.ParentKey,
+			ParentKey: effectiveParentKey,
 			ParentID:  node.ParentID,
 		})
 	}
@@ -384,16 +402,34 @@ func validateGraphApplyPlan(plan *GraphApplyPlan) error {
 				}
 			}
 		}
-		if node.ParentKey != "" && !seenKeys[node.ParentKey] {
+		parentKey := node.ParentKey
+		if parentKey == "" {
+			parentKey = node.Parent
+		}
+		if parentKey != "" && !seenKeys[parentKey] {
 			found := false
 			for _, other := range plan.Nodes {
-				if other.Key == node.ParentKey {
+				if other.Key == parentKey {
 					found = true
 					break
 				}
 			}
 			if !found {
-				return fmt.Errorf("node %q: parent key %q not found in plan", node.Key, node.ParentKey)
+				return fmt.Errorf("node %q: parent key %q not found in plan", node.Key, parentKey)
+			}
+		}
+		if node.Estimate != nil && *node.Estimate < 0 {
+			return fmt.Errorf("node %q: estimate cannot be negative", node.Key)
+		}
+		for j, dep := range node.Deps {
+			if dep.Target == "" {
+				return fmt.Errorf("node %q: dep %d has empty target", node.Key, j)
+			}
+			if dep.Type != "" {
+				dt := types.DependencyType(dep.Type)
+				if !dt.IsValid() {
+					return fmt.Errorf("node %q: dep %d: invalid dependency type %q", node.Key, j, dep.Type)
+				}
 			}
 		}
 	}
@@ -464,6 +500,12 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyRe
 			}
 			if node.Description != "" {
 				issue.Description = node.Description
+			}
+			if node.Estimate != nil {
+				issue.EstimatedMinutes = node.Estimate
+			}
+			if node.ExternalRef != "" {
+				issue.ExternalRef = &node.ExternalRef
 			}
 			if node.Assignee != "" {
 				if node.AssignAfterCreate {
@@ -539,9 +581,13 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyRe
 
 		// Add parent-child dependencies.
 		for i, node := range plan.Nodes {
+			parentKey := node.ParentKey
+			if parentKey == "" {
+				parentKey = node.Parent
+			}
 			parentID := node.ParentID
-			if node.ParentKey != "" {
-				parentID = keyToID[node.ParentKey]
+			if parentKey != "" {
+				parentID = keyToID[parentKey]
 			}
 			if parentID != "" {
 				dep := &types.Dependency{
@@ -551,6 +597,31 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan) (*GraphApplyRe
 				}
 				if err := tx.AddDependency(ctx, dep, actor); err != nil {
 					return fmt.Errorf("node %q: adding parent-child dep: %w", node.Key, err)
+				}
+			}
+		}
+
+		// Add per-node inline dependencies.
+		for i, node := range plan.Nodes {
+			for _, dep := range node.Deps {
+				depType := types.DependencyType(dep.Type)
+				if depType == "" {
+					depType = types.DepBlocks
+				}
+				targetID := keyToID[dep.Target]
+				if targetID == "" {
+					targetID = dep.Target
+				}
+				if targetID == "" {
+					return fmt.Errorf("node %q: dep target %q not found", node.Key, dep.Target)
+				}
+				d := &types.Dependency{
+					IssueID:     issues[i].ID,
+					DependsOnID: targetID,
+					Type:        depType,
+				}
+				if err := tx.AddDependency(ctx, d, actor); err != nil {
+					return fmt.Errorf("node %q: adding dep to %q: %w", node.Key, dep.Target, err)
 				}
 			}
 		}

--- a/cmd/bd/graph_apply_test.go
+++ b/cmd/bd/graph_apply_test.go
@@ -73,12 +73,129 @@ func TestValidateGraphApplyPlanAcceptsEmptyType(t *testing.T) {
 	}
 }
 
+// TestValidateGraphApplyPlanAcceptsNewFields verifies that estimate,
+// external_ref, parent (alias), and deps are accepted without error. (GH#4064)
+func TestValidateGraphApplyPlanAcceptsNewFields(t *testing.T) {
+	est := 120
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{
+				Key:         "epic",
+				Title:       "Epic node",
+				Type:        "epic",
+				Estimate:    &est,
+				ExternalRef: "gh-42",
+			},
+			{
+				Key:    "child",
+				Title:  "Child node",
+				Parent: "epic",
+				Deps: []GraphApplyNodeDep{
+					{Target: "epic", Type: "blocks"},
+				},
+			},
+		},
+	}
+	if err := validateGraphApplyPlan(plan); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
+// TestValidateGraphApplyPlanRejectsNegativeEstimate verifies that a negative
+// estimate is caught at validation time. (GH#4064)
+func TestValidateGraphApplyPlanRejectsNegativeEstimate(t *testing.T) {
+	neg := -5
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "n", Title: "Node", Estimate: &neg},
+		},
+	}
+	err := validateGraphApplyPlan(plan)
+	if err == nil {
+		t.Fatal("expected error for negative estimate")
+	}
+	if !strings.Contains(err.Error(), "estimate cannot be negative") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateGraphApplyPlanRejectsEmptyDepTarget verifies that a dep with an
+// empty target is caught at validation time. (GH#4064)
+func TestValidateGraphApplyPlanRejectsEmptyDepTarget(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "n", Title: "Node", Deps: []GraphApplyNodeDep{{Target: ""}}},
+		},
+	}
+	err := validateGraphApplyPlan(plan)
+	if err == nil {
+		t.Fatal("expected error for empty dep target")
+	}
+	if !strings.Contains(err.Error(), "empty target") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateGraphApplyPlanParentAliasResolvesCorrectly verifies that the
+// "parent" field works as an alias for "parent_key" in validation. (GH#4064)
+func TestValidateGraphApplyPlanParentAliasResolvesCorrectly(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root"},
+			{Key: "child", Title: "Child", Parent: "root"},
+		},
+	}
+	if err := validateGraphApplyPlan(plan); err != nil {
+		t.Fatalf("parent alias should resolve: %v", err)
+	}
+}
+
+// TestValidateGraphApplyPlanParentAliasRejectsUnknownKey verifies that the
+// "parent" field rejects unknown keys just like "parent_key". (GH#4064)
+func TestValidateGraphApplyPlanParentAliasRejectsUnknownKey(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "child", Title: "Child", Parent: "nonexistent"},
+		},
+	}
+	err := validateGraphApplyPlan(plan)
+	if err == nil {
+		t.Fatal("expected error for unknown parent key via alias")
+	}
+	if !strings.Contains(err.Error(), "parent key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestEmitGraphApplyDryRun_ParentAlias verifies that the "parent" alias
+// is counted and displayed in dry-run output. (GH#4064)
+func TestEmitGraphApplyDryRun_ParentAlias(t *testing.T) {
+	plan := &GraphApplyPlan{
+		Nodes: []GraphApplyNode{
+			{Key: "root", Title: "Root", Type: "epic"},
+			{Key: "c1", Title: "Child 1", Parent: "root"},
+		},
+	}
+	out := captureStdout(t, func() error {
+		emitGraphApplyDryRun(plan)
+		return nil
+	})
+	if !strings.Contains(out, "1 parent-child link(s)") {
+		t.Errorf("dry-run should count parent alias as parent-child link:\n%s", out)
+	}
+	if !strings.Contains(out, "parent_key=root") {
+		t.Errorf("dry-run should display resolved parent_key from alias:\n%s", out)
+	}
+}
+
 // TestDetectUnknownGraphFields_ReporterRepro reproduces the schema-mismatch
 // pattern from GH#3367: the user passes 'parent' (a string) and 'blocks' (an
 // array) directly on nodes, expecting them to wire hierarchy/dependencies.
 // json.Unmarshal silently drops them. detectUnknownGraphFields must surface
 // both fields, scoped to the offending nodes.
 func TestDetectUnknownGraphFields_ReporterRepro(t *testing.T) {
+	// After GH#4064, "parent" is a recognized alias for "parent_key".
+	// Only "blocks" (an array, not an edge or dep) remains unknown.
 	planJSON := []byte(`{
         "nodes": [
             {"key": "root",   "type": "epic", "title": "Root epic",    "priority": 2},
@@ -89,8 +206,7 @@ func TestDetectUnknownGraphFields_ReporterRepro(t *testing.T) {
 
 	got := detectUnknownGraphFields(planJSON)
 	want := map[string][]string{
-		`node["child1"]`: {"blocks", "parent"},
-		`node["child2"]`: {"parent"},
+		`node["child1"]`: {"blocks"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("detectUnknownGraphFields:\n got=%#v\nwant=%#v", got, want)
@@ -107,9 +223,11 @@ func TestDetectUnknownGraphFields_KnownSchemaIsClean(t *testing.T) {
         "nodes": [
             {"key": "root", "title": "Root", "type": "epic", "priority": 2,
              "description": "d", "assignee": "alice", "assign_after_create": false,
-             "labels": ["a"], "metadata": {"k": "v"}, "metadata_refs": {"r": "root"}},
+             "estimate": 60, "labels": ["a"], "metadata": {"k": "v"},
+             "metadata_refs": {"r": "root"}, "external_ref": "gh-1",
+             "deps": [{"target": "child", "type": "blocks"}]},
             {"key": "child", "title": "Child", "parent_key": "root",
-             "parent_id": "ext-1"}
+             "parent_id": "ext-1", "parent": "root"}
         ],
         "edges": [
             {"from_key": "child", "to_key": "root", "type": "blocks"},
@@ -153,25 +271,23 @@ func TestDetectUnknownGraphFields_BadJSON(t *testing.T) {
 // text for the two highest-friction fields ('parent', 'blocks' from GH#3367)
 // is emitted and points the user at the canonical schema field.
 func TestWarnUnknownGraphFields_HintsForReporterFields(t *testing.T) {
+	// After GH#4064, "parent" is a recognized field. Only "blocks" triggers a hint.
 	var buf bytes.Buffer
 	hinted := warnUnknownGraphFields(&buf, map[string][]string{
-		`node["c1"]`: {"parent", "blocks"},
+		`node["c1"]`: {"blocks"},
 	})
 
 	out := buf.String()
-	if !strings.Contains(out, `unknown field(s): [blocks parent]`) {
+	if !strings.Contains(out, `unknown field(s): [blocks]`) {
 		t.Errorf("warning missing field list: %q", out)
 	}
-	if !strings.Contains(out, "parent_key") {
-		t.Errorf("expected 'parent' hint to mention parent_key: %q", out)
-	}
-	if !strings.Contains(out, "edges") {
-		t.Errorf("expected 'blocks' hint to mention edges array: %q", out)
+	if !strings.Contains(out, "deps") {
+		t.Errorf("expected 'blocks' hint to mention deps: %q", out)
 	}
 
 	got := append([]string(nil), hinted...)
 	sort.Strings(got)
-	want := []string{"blocks", "parent"}
+	want := []string{"blocks"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("hinted fields: got=%v want=%v", got, want)
 	}


### PR DESCRIPTION
## Summary
- Adds `estimate`, `external_ref`, `parent` (alias for `parent_key`), and per-node `deps:[{type,target}]` support to `bd create --graph` JSON plan nodes
- Previously these fields were silently dropped by `encoding/json` because the struct lacked corresponding tags
- `labels` was fixed in a prior commit; this extends the same pattern to the remaining documented fields
- Per-node `deps` complement the existing top-level `edges` array for simpler plans where edges are co-located with their source node

Closes #4064

## Test plan
- [x] `make build` succeeds
- [x] `go vet` passes
- [x] Existing graph_apply tests pass
- [x] New fields are accepted in plan JSON without error
- [x] `estimate` maps to `EstimatedMinutes` on created issues
- [x] `external_ref` maps to `ExternalRef` on created issues
- [x] `parent` resolves to parent-child dependency (same as `parent_key`)
- [x] `deps:[{type:"blocks",target:"key"}]` creates blocking dependencies
- [x] Negative estimate rejected at validation
- [x] Empty dep target rejected at validation
- [x] Parent alias resolves and rejects unknown keys
- [x] Dry-run counts parent alias as parent-child link
- [x] Reflection guardrail test confirms struct tags match known-fields sets