### PR TITLE
fix(hooks): skip bash injection on non-shell hook scripts (GH#4000)

### DIFF
--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1600,8 +1600,20 @@ func isShellShebang(content string) bool {
 	if len(parts) == 0 {
 		return true // bare #! with no interpreter = assume shell
 	}
-	// Handle "env" wrapper: #!/usr/bin/env bash → last token is interpreter
-	interpreter := filepath.Base(parts[len(parts)-1])
+	interpreter := filepath.Base(parts[0])
+	if interpreter == "env" {
+		interpreter = ""
+		for _, tok := range parts[1:] {
+			if strings.HasPrefix(tok, "-") {
+				continue // skip env options like -S, -i
+			}
+			interpreter = filepath.Base(tok)
+			break
+		}
+		if interpreter == "" {
+			return true // bare "#!/usr/bin/env" = assume shell
+		}
+	}
 	switch interpreter {
 	case "sh", "bash", "zsh", "dash", "ksh", "ash":
 		return true

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -805,6 +805,10 @@ func installHooksWithOptions(hookNames []string, force bool, shared bool, chain 
 					newContent = "#!/usr/bin/env sh\n" + section
 				} else {
 					// Non-bd hook — inject section (preserving existing content)
+					if !isShellShebang(existingStr) {
+						fmt.Fprintf(os.Stderr, "warning: skipping hook injection for %q: non-shell interpreter detected; run 'bd hooks run %s' from a wrapper\n", hookName, hookName)
+						continue
+					}
 					newContent = injectHookSection(existingStr, section)
 				}
 			}
@@ -1579,6 +1583,31 @@ func runPrepareCommitMsgHook(args []string) int {
 // =============================================================================
 // Hook Helper Functions
 // =============================================================================
+
+// isShellShebang returns true if the content has no shebang (assumed shell)
+// or has a shebang pointing to a shell interpreter (sh, bash, zsh, dash, ksh, ash).
+// Used to guard against injecting bash syntax into non-shell hook scripts
+// (Python, Ruby, Node, Perl, etc.) which would cause SyntaxError. (GH#4000)
+func isShellShebang(content string) bool {
+	firstLine, _, _ := strings.Cut(content, "\n")
+	firstLine = strings.TrimSpace(firstLine)
+	if !strings.HasPrefix(firstLine, "#!") {
+		return true // no shebang = assume shell
+	}
+	shebang := strings.TrimPrefix(firstLine, "#!")
+	shebang = strings.TrimSpace(shebang)
+	parts := strings.Fields(shebang)
+	if len(parts) == 0 {
+		return true // bare #! with no interpreter = assume shell
+	}
+	// Handle "env" wrapper: #!/usr/bin/env bash → last token is interpreter
+	interpreter := filepath.Base(parts[len(parts)-1])
+	switch interpreter {
+	case "sh", "bash", "zsh", "dash", "ksh", "ash":
+		return true
+	}
+	return false
+}
 
 // isRebaseInProgress checks if a rebase is in progress.
 func isRebaseInProgress() bool {

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -1085,6 +1085,120 @@ func TestHooksNeedUpdate(t *testing.T) {
 	}
 }
 
+// TestIsShellShebang verifies the shebang detection used to guard against
+// injecting bash syntax into non-shell hook scripts (GH#4000).
+func TestIsShellShebang(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"no shebang", "echo hello", true},
+		{"bash", "#!/bin/bash\necho hi", true},
+		{"env bash", "#!/usr/bin/env bash\necho hi", true},
+		{"sh", "#!/bin/sh\necho hi", true},
+		{"env sh", "#!/usr/bin/env sh\necho hi", true},
+		{"zsh", "#!/usr/bin/env zsh\necho hi", true},
+		{"dash", "#!/usr/bin/dash\necho hi", true},
+		{"ksh", "#!/usr/bin/env ksh\necho hi", true},
+		{"ash", "#!/bin/ash\necho hi", true},
+		{"python", "#!/usr/bin/env python3\nimport sys", false},
+		{"ruby", "#!/usr/bin/ruby\nputs 'hi'", false},
+		{"node", "#!/usr/bin/env node\nconsole.log('hi')", false},
+		{"perl", "#!/usr/bin/perl\nprint 'hi'", false},
+		{"empty content", "", true},
+		{"bare shebang", "#!\n", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isShellShebang(tt.content); got != tt.want {
+				t.Errorf("isShellShebang() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInstallHooksWithOptions_SkipsNonShellHook verifies that installHooksWithOptions
+// does NOT inject bash into a hook with a non-shell shebang (GH#4000).
+func TestInstallHooksWithOptions_SkipsNonShellHook(t *testing.T) {
+	tmpDir := newGitRepo(t)
+	runInDir(t, tmpDir, func() {
+		gitDirPath, err := git.GetGitDir()
+		if err != nil {
+			t.Fatalf("git.GetGitDir() failed: %v", err)
+		}
+		hooksDir := filepath.Join(gitDirPath, "hooks")
+		if err := os.MkdirAll(hooksDir, 0750); err != nil {
+			t.Fatalf("Failed to create hooks directory: %v", err)
+		}
+
+		pythonHook := "#!/usr/bin/env python3\nimport sys\nprint('lint passed')\n"
+		preCommitPath := filepath.Join(hooksDir, "pre-commit")
+		if err := os.WriteFile(preCommitPath, []byte(pythonHook), 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := installHooksWithOptions([]string{"pre-commit"}, false, false, false, false); err != nil {
+			t.Fatalf("installHooksWithOptions() failed: %v", err)
+		}
+
+		content, err := os.ReadFile(preCommitPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		contentStr := string(content)
+
+		if contentStr != pythonHook {
+			t.Errorf("Python hook should not be modified.\nExpected:\n%s\nGot:\n%s", pythonHook, contentStr)
+		}
+		if strings.Contains(contentStr, hookSectionBeginPrefix) {
+			t.Error("bash section markers should not be injected into a Python hook")
+		}
+	})
+}
+
+// TestInstallHooksWithOptions_InjectsShellHook verifies that shell hooks
+// still get the section injected after the shebang guard (GH#4000).
+func TestInstallHooksWithOptions_InjectsShellHook(t *testing.T) {
+	tmpDir := newGitRepo(t)
+	runInDir(t, tmpDir, func() {
+		gitDirPath, err := git.GetGitDir()
+		if err != nil {
+			t.Fatalf("git.GetGitDir() failed: %v", err)
+		}
+		hooksDir := filepath.Join(gitDirPath, "hooks")
+		if err := os.MkdirAll(hooksDir, 0750); err != nil {
+			t.Fatalf("Failed to create hooks directory: %v", err)
+		}
+
+		bashHook := "#!/usr/bin/env bash\necho 'lint passed'\n"
+		preCommitPath := filepath.Join(hooksDir, "pre-commit")
+		if err := os.WriteFile(preCommitPath, []byte(bashHook), 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := installHooksWithOptions([]string{"pre-commit"}, false, false, false, false); err != nil {
+			t.Fatalf("installHooksWithOptions() failed: %v", err)
+		}
+
+		content, err := os.ReadFile(preCommitPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		contentStr := string(content)
+
+		if !strings.Contains(contentStr, "echo 'lint passed'") {
+			t.Error("existing bash hook content should be preserved")
+		}
+		if !strings.Contains(contentStr, hookSectionBeginPrefix) {
+			t.Error("section markers should be injected into a bash hook")
+		}
+		if !strings.Contains(contentStr, "bd hooks run pre-commit") {
+			t.Error("hook invocation should be present in bash hook")
+		}
+	})
+}
+
 // TestInstallHooksBeads_HuskyV8Helper verifies that the husky v8 _/ helper
 // directory is symlinked when hooks are preserved from a husky-managed directory.
 // GH#3132 Bug 1: without this, hooks that source $(dirname "$0")/_/husky.sh fail.

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -1108,6 +1108,11 @@ func TestIsShellShebang(t *testing.T) {
 		{"perl", "#!/usr/bin/perl\nprint 'hi'", false},
 		{"empty content", "", true},
 		{"bare shebang", "#!\n", true},
+		{"bash with flag", "#!/bin/bash -e\nset -x", true},
+		{"env -S bash", "#!/usr/bin/env -S bash\necho hi", true},
+		{"env python with flag", "#!/usr/bin/env -S python3 -u\nimport sys", false},
+		{"bare env", "#!/usr/bin/env\n", true},
+		{"env with only flags", "#!/usr/bin/env -i -S\n", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/bd/migrate_hooks_apply.go
+++ b/cmd/bd/migrate_hooks_apply.go
@@ -320,6 +320,10 @@ func renderMigratedHookContent(op hookMigrationWriteOp) ([]byte, error) {
 	baseContent = strings.ReplaceAll(baseContent, "\r\n", "\n")
 	baseContent = ensureHookShebang(baseContent)
 
+	if !isShellShebang(baseContent) {
+		return nil, fmt.Errorf("skipping hook migration for %s: non-shell interpreter detected (GH#4000)", op.HookName)
+	}
+
 	content := injectHookSection(baseContent, generateHookSection(op.HookName))
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	if !strings.HasSuffix(content, "\n") {


### PR DESCRIPTION
## Summary
- Adds `isShellShebang()` helper to detect the hook file's interpreter from its shebang line before injecting bash syntax
- Non-shell hooks (Python, Ruby, Node, Perl) are skipped with a stderr warning instead of being corrupted with bash syntax
- Files without a shebang are still treated as shell (preserves existing behavior)
- Same guard applied to the hook migration path (`renderMigratedHookContent`)

Closes #4000

## Test plan
- [x] `make build` succeeds
- [x] `isShellShebang` unit tests cover all interpreter types (sh, bash, zsh, dash, ksh, ash, python, ruby, node, perl, empty, bare shebang)
- [x] Python hook is NOT modified by `installHooksWithOptions`
- [x] Bash/sh hooks still get section injected correctly
- [x] All existing hook tests pass (no regressions)