### PR TITLE
fix(init): mark server-mode Dolt dirs compatible

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1232,6 +1232,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			fmt.Fprintf(os.Stderr, "Warning: failed to close database: %v\n", err)
 		}
 
+		if initServerMode {
+			if err := doltserver.MarkDoltDirCompatible(storagePath); err != nil && !quiet {
+				fmt.Fprintf(os.Stderr, "Warning: failed to write Dolt compatibility marker: %v\n", err)
+			}
+		}
+
 		// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
 		// directory — including noms/LOCK files. These are Dolt-internal files.
 		// Removing them WILL cause unrecoverable data corruption and data loss.

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1643,6 +1643,53 @@ func TestInitDoltMetadataNoGit(t *testing.T) {
 	}
 }
 
+func TestInitServerModeWritesDoltCompatibilityMarker(t *testing.T) {
+	skipIfNoDolt(t)
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+	dbPath = ""
+	store = nil
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("creating beads dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0o750); err != nil {
+		t.Fatalf("creating simulated server data dir: %v", err)
+	}
+
+	database := uniqueTestDBName(t)
+	t.Cleanup(func() {
+		dropTestDatabase(database, testDoltServerPort)
+	})
+
+	rootCmd.SetArgs([]string{
+		"init",
+		"--server",
+		"--external",
+		"--server-host", "127.0.0.1",
+		"--server-port", fmt.Sprintf("%d", testDoltServerPort),
+		"--database", database,
+		"--prefix", "marker",
+		"--quiet",
+		"--skip-hooks",
+		"--skip-agents",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("server init failed: %v", err)
+	}
+
+	markerPath := filepath.Join(doltDir, ".bd-dolt-ok")
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected server init to write %s: %v", markerPath, err)
+	}
+}
+
 func setupBareParentInitWorktree(t *testing.T) (string, string) {
 	t.Helper()
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1274,6 +1274,36 @@ func ensureDoltIdentity() error {
 // Those databases are incompatible with the current server-only architecture.
 const bdDoltMarker = ".bd-dolt-ok"
 
+// MarkDoltDirCompatible writes the bd compatibility marker when doltDir contains
+// a local Dolt repository.
+func MarkDoltDirCompatible(doltDir string) error {
+	if doltDir == "" {
+		return errors.New("dolt directory is required")
+	}
+	dotDolt := filepath.Join(doltDir, ".dolt")
+	if info, err := os.Stat(dotDolt); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("checking dolt metadata directory %s: %w", dotDolt, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("dolt metadata path %s is not a directory", dotDolt)
+	}
+	markerPath := filepath.Join(doltDir, bdDoltMarker)
+	if info, err := os.Stat(markerPath); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("dolt compatibility marker %s is a directory", markerPath)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking dolt compatibility marker %s: %w", markerPath, err)
+	}
+	if err := os.WriteFile(markerPath, []byte("ok\n"), 0600); err != nil {
+		return fmt.Errorf("writing dolt compatibility marker %s: %w", markerPath, err)
+	}
+	return nil
+}
+
 // ensureDoltInit initializes a dolt database directory if .dolt/ doesn't exist.
 // If .dolt/ exists, seeds the .bd-dolt-ok marker for existing working databases.
 // See GH#2137 for background on pre-0.56 database compatibility.

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1113,6 +1113,88 @@ func TestEnsureDoltInit_SeedsMarker(t *testing.T) {
 	}
 }
 
+func TestMarkDoltDirCompatible(t *testing.T) {
+	t.Run("empty path errors", func(t *testing.T) {
+		if err := MarkDoltDirCompatible(""); err == nil {
+			t.Fatal("expected empty path to error")
+		}
+	})
+
+	t.Run("missing dot-dolt is noop", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := MarkDoltDirCompatible(doltDir); err != nil {
+			t.Fatalf("MarkDoltDirCompatible: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(doltDir, bdDoltMarker)); !os.IsNotExist(err) {
+			t.Fatalf("marker should not be created without .dolt/, stat err=%v", err)
+		}
+	})
+
+	t.Run("dot-dolt file errors", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(doltDir, ".dolt"), []byte("not a dir"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err == nil {
+			t.Fatal("expected .dolt file to error")
+		}
+	})
+
+	t.Run("writes missing marker", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err != nil {
+			t.Fatalf("MarkDoltDirCompatible: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(doltDir, bdDoltMarker))
+		if err != nil {
+			t.Fatalf("reading marker: %v", err)
+		}
+		if string(got) != "ok\n" {
+			t.Fatalf("marker content = %q, want %q", string(got), "ok\n")
+		}
+		if IsPreV56DoltDir(doltDir) {
+			t.Fatal("marked dolt dir should not report as pre-v56")
+		}
+	})
+
+	t.Run("existing marker is preserved", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0750); err != nil {
+			t.Fatal(err)
+		}
+		markerPath := filepath.Join(doltDir, bdDoltMarker)
+		if err := os.WriteFile(markerPath, []byte("custom\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err != nil {
+			t.Fatalf("MarkDoltDirCompatible: %v", err)
+		}
+		got, err := os.ReadFile(markerPath)
+		if err != nil {
+			t.Fatalf("reading marker: %v", err)
+		}
+		if string(got) != "custom\n" {
+			t.Fatalf("existing marker content = %q, want %q", string(got), "custom\n")
+		}
+	})
+
+	t.Run("marker directory errors", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(doltDir, bdDoltMarker), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err == nil {
+			t.Fatal("expected marker directory to error")
+		}
+	})
+}
+
 func TestRecoverPreV56DoltDir(t *testing.T) {
 	doltDir := t.TempDir()
 	dotDolt := filepath.Join(doltDir, ".dolt", "noms")


### PR DESCRIPTION
## Summary

- write the existing `.bd-dolt-ok` compatibility marker after successful `bd init --server` when the configured Dolt data dir contains a local `.dolt/` repository
- keep marker ownership in `internal/doltserver`, next to the existing pre-0.56 detection and recovery logic
- add helper-level edge case coverage plus an init regression test for externally managed server mode

This supersedes the Gas City wrapper workaround in gastownhall/gascity#2108; the marker should be emitted by Beads itself.

## Tests

- `./scripts/test.sh -run 'TestMarkDoltDirCompatible|Test(IsPreV56DoltDir|EnsureDoltInit|RecoverPreV56DoltDir)' ./internal/doltserver`\n- `./scripts/test.sh -run '^TestInitServerModeWritesDoltCompatibilityMarker$' ./cmd/bd`\n- `go vet ./...`\n- `git diff --check`\n\nI also attempted `make test`; local full-suite baseline still fails outside this patch with broad existing/environmental failures, including shared server port 3308 already in use and several unrelated cmd/domain/tracker expectations.