### PR TITLE
fix(doctor): skip CLI remote comparison in server mode

### DIFF
--- a/cmd/bd/doctor/remotes.go
+++ b/cmd/bd/doctor/remotes.go
@@ -47,6 +47,15 @@ func CheckRemoteConsistency(repoPath string) DoctorCheck {
 		}
 	}
 
+	// In server mode the per-repo CLI dolt dir doesn't exist by design — Dolt
+	// manages data via the server, not under .beads/dolt/<db>/. Skip the CLI
+	// comparison and report SQL-only. This covers all server flavors: in-process
+	// server start, beads-managed shared server, and externally-managed servers
+	// (BEADS_DOLT_SERVER_MODE / BEADS_DOLT_SHARED_SERVER / dolt_mode=server).
+	if cfg.IsDoltServerMode() {
+		return serverModeRemoteConsistencyCheck(sqlRemotes, repoPath)
+	}
+
 	// Get CLI remotes
 	doltDir := doltserver.ResolveDoltDir(beadsDir)
 	dbName := cfg.GetDoltDatabase()
@@ -125,6 +134,34 @@ func CheckRemoteConsistency(repoPath string) DoctorCheck {
 		Message:  fmt.Sprintf("%d discrepancies found", len(issues)),
 		Detail:   strings.Join(issues, "\n"),
 		Fix:      fix,
+		Category: CategoryData,
+	}
+}
+
+// serverModeRemoteConsistencyCheck reports SQL remotes only, since CLI remotes
+// are an embedded-mode concept (per-repo .beads/dolt/<db>/ on disk).
+func serverModeRemoteConsistencyCheck(sqlRemotes []storage.RemoteInfo, repoPath string) DoctorCheck {
+	if len(sqlRemotes) == 0 {
+		return DoctorCheck{
+			Name:     "Remote Consistency",
+			Status:   StatusWarning,
+			Message:  "No remotes configured",
+			Detail:   remoteAdoptionDetail(repoPath),
+			Category: CategoryData,
+		}
+	}
+
+	msg := fmt.Sprintf("%d remote(s) configured (server mode — CLI N/A)", len(sqlRemotes))
+	for _, r := range sqlRemotes {
+		if doltutil.IsSSHURL(r.URL) {
+			msg += " — git+ssh remotes also support refs/dolt/data (see https://docs.dolthub.com/concepts/dolt/git/remotes)"
+			break
+		}
+	}
+	return DoctorCheck{
+		Name:     "Remote Consistency",
+		Status:   StatusOK,
+		Message:  msg,
 		Category: CategoryData,
 	}
 }

--- a/cmd/bd/doctor/remotes_test.go
+++ b/cmd/bd/doctor/remotes_test.go
@@ -105,6 +105,84 @@ func TestCheckRemoteConsistencyNoRemotesIncludesGitOriginAdoptionDetail(t *testi
 	}
 }
 
+func TestCheckRemoteConsistency_ServerModeSkipsCLIComparison(t *testing.T) {
+	clearResolveBeadsDirCache()
+	t.Cleanup(clearResolveBeadsDirCache)
+
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads: %v", err)
+	}
+	cfg := &configfile.Config{DoltMode: configfile.DoltModeServer}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	oldQuerySQLRemotes := querySQLRemotesForDoctor
+	oldListCLIRemotes := listCLIRemotesForDoctor
+	t.Cleanup(func() {
+		querySQLRemotesForDoctor = oldQuerySQLRemotes
+		listCLIRemotesForDoctor = oldListCLIRemotes
+	})
+	querySQLRemotesForDoctor = func(string) ([]storage.RemoteInfo, error) {
+		return []storage.RemoteInfo{{Name: "origin", URL: "git+ssh://git@github.com/org/repo.git"}}, nil
+	}
+	// CLI listing should NOT be called in server mode; fail loudly if it is.
+	listCLIRemotesForDoctor = func(string) ([]storage.RemoteInfo, error) {
+		t.Fatalf("listCLIRemotes should not be called in server mode")
+		return nil, nil
+	}
+
+	check := CheckRemoteConsistency(repoDir)
+	if check.Status != StatusOK {
+		t.Fatalf("expected OK in server mode with one SQL remote, got %q: %s", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Message, "server mode") {
+		t.Fatalf("expected server-mode note in message, got: %s", check.Message)
+	}
+	if !strings.Contains(check.Message, "1 remote") {
+		t.Fatalf("expected remote count in message, got: %s", check.Message)
+	}
+}
+
+func TestCheckRemoteConsistency_ServerModeNoRemotesStillWarns(t *testing.T) {
+	clearResolveBeadsDirCache()
+	t.Cleanup(clearResolveBeadsDirCache)
+
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("failed to create .beads: %v", err)
+	}
+	cfg := &configfile.Config{DoltMode: configfile.DoltModeServer}
+	if err := cfg.Save(beadsDir); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	oldQuerySQLRemotes := querySQLRemotesForDoctor
+	oldListCLIRemotes := listCLIRemotesForDoctor
+	t.Cleanup(func() {
+		querySQLRemotesForDoctor = oldQuerySQLRemotes
+		listCLIRemotesForDoctor = oldListCLIRemotes
+	})
+	querySQLRemotesForDoctor = func(string) ([]storage.RemoteInfo, error) {
+		return nil, nil
+	}
+	listCLIRemotesForDoctor = func(string) ([]storage.RemoteInfo, error) {
+		t.Fatalf("listCLIRemotes should not be called in server mode")
+		return nil, nil
+	}
+
+	check := CheckRemoteConsistency(repoDir)
+	if check.Status != StatusWarning {
+		t.Fatalf("expected warning when no remotes in server mode, got %q: %s", check.Status, check.Message)
+	}
+	if !strings.Contains(check.Message, "No remotes configured") {
+		t.Fatalf("expected 'No remotes configured' message, got: %s", check.Message)
+	}
+}
+
 func TestRemoteAdoptionDetailWithoutGitOrigin(t *testing.T) {
 	detail := remoteAdoptionDetail(t.TempDir())
 	if !strings.Contains(detail, "bd dolt remote add origin <url>") {


### PR DESCRIPTION
## Summary

`bd doctor`'s **Remote Consistency** check tries to `chdir` into `.beads/dolt/<dbName>/` and run `dolt remote -v`. That per-repo CLI dir only exists in **embedded** mode — in any server flavor (in-process server, beads-managed shared server, or externally-managed shared server) Dolt manages data centrally and the dir is absent by design.

Result is a misleading warning on every doctor run for server-mode users:

```
⚠  Remote Consistency: Could not query CLI remotes:
    dolt remote -v failed: : chdir /path/to/.beads/dolt/<dbName>:
    no such file or directory
```

This affects users running a single Dolt `sql-server` hosting multiple `beads_*` databases — a setup the rest of beads already supports via `BEADS_DOLT_SERVER_MODE` / `BEADS_DOLT_SHARED_SERVER` / `dolt_mode=server` in `metadata.json`.

## Fix

In `CheckRemoteConsistency`, if `cfg.IsDoltServerMode()` is true, skip the CLI listing and report SQL remotes only via a new `serverModeRemoteConsistencyCheck` helper. The "no remotes configured" warning + git-origin adoption hint path is preserved. Embedded-mode behavior is unchanged.

Output in server mode becomes:

```
✓  Remote Consistency: 2 remote(s) configured (server mode — CLI N/A) — git+ssh remotes also support refs/dolt/data ...
```

## Test plan

- [x] `go test ./cmd/bd/doctor/ -count=1` — full doctor package passes
- [x] New: `TestCheckRemoteConsistency_ServerModeSkipsCLIComparison` — verifies CLI listing is not called and message reflects server mode
- [x] New: `TestCheckRemoteConsistency_ServerModeNoRemotesStillWarns` — verifies no-remotes warning still fires in server mode
- [x] `go vet ./cmd/bd/doctor/` clean

## Notes

Filed as a draft for your review of the approach. Scope is intentionally narrow: only the Remote Consistency check. A separate question exists for the **Phantom Databases** check (which flags sibling `beads_*` databases on a shared server as "phantom"), but the right fix there depends on whether `dolt.shared-server` should be decoupled from the server-lifecycle behavior it currently controls — happy to follow up in a separate PR if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)