### PR TITLE
feat(config): configurable JSONL import path + hooks fallback (maintainer cherry-pick from PR #4041)

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -24,8 +24,8 @@ type jsonlImporter interface {
 // non-empty database. Production builds always use importFromLocalJSONLFull.
 var fallbackImporter = importFromLocalJSONLFull
 
-// maybeAutoImportJSONL checks whether the database is empty and a
-// issues.jsonl file exists in beadsDir. When both conditions are true it
+// maybeAutoImportJSONL checks whether the database is empty and the configured
+// import.path JSONL file exists in beadsDir. When both conditions are true it
 // auto-imports the JSONL data so users upgrading from pre-0.56 (which used
 // .beads/dolt/) to 1.0+ (which uses .beads/embeddeddolt/) don't appear to
 // lose their issues.  See GH#2994.
@@ -43,7 +43,7 @@ var fallbackImporter = importFromLocalJSONLFull
 // prevent the store from being used.
 func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir string) {
 	// Quick check: does the JSONL file exist and have content?
-	jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+	jsonlPath := configuredImportJSONLPath(beadsDir)
 	info, err := os.Stat(jsonlPath)
 	if err != nil || info.Size() == 0 {
 		return // no JSONL file or empty — nothing to import

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -32,11 +33,16 @@ func (f *fakeFallbackStore) GetStatistics(_ context.Context) (*types.Statistics,
 
 func writeAutoImportFixtureJSONL(t *testing.T, dir string) {
 	t.Helper()
+	writeAutoImportFixtureJSONLNamed(t, dir, "issues.jsonl")
+}
+
+func writeAutoImportFixtureJSONLNamed(t *testing.T, dir, name string) {
+	t.Helper()
 	// Minimal valid issue line. Contents are irrelevant for the
 	// skip-when-non-empty test (returns before parseJSONLFile) and are
 	// only required to be parseable for the negative-control test.
 	line := `{"_type":"issue","id":"unit-1","title":"unit-test-fixture","status":"open","priority":2,"issue_type":"task"}`
-	if err := os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte(line+"\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(line+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -115,5 +121,29 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty(t *testing.T) {
 
 	if got := count.Load(); got != 1 {
 		t.Fatalf("server-mode fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
+	}
+}
+
+func TestMaybeAutoImportJSONL_UsesConfiguredImportPath(t *testing.T) {
+	initConfigForTest(t)
+	config.Set("import.path", "beads.jsonl")
+
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONLNamed(t, dir, "beads.jsonl")
+
+	orig := fallbackImporter
+	var gotPath string
+	fallbackImporter = func(_ context.Context, _ storage.DoltStorage, path string) (*importLocalResult, error) {
+		gotPath = path
+		return nil, errors.New("test importer: short-circuit before s.Commit")
+	}
+	t.Cleanup(func() { fallbackImporter = orig })
+
+	store := &fakeFallbackStore{statsTotalIssues: 0}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+
+	wantPath := filepath.Join(dir, "beads.jsonl")
+	if gotPath != wantPath {
+		t.Fatalf("auto-import path = %q, want %q", gotPath, wantPath)
 	}
 }

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -28,6 +28,7 @@ Configuration is stored per-project in the beads database and is version-control
 
 Common namespaces:
   - export.*          Auto-export settings (stored in config.yaml)
+  - import.*          JSONL import settings (stored in config.yaml)
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
@@ -47,6 +48,12 @@ Auto-Export (config.yaml):
     export.path       Output filename relative to .beads/ (default: issues.jsonl)
     export.interval   Minimum time between exports (default: 60s)
     export.git-add    Auto-stage the export file (default: false)
+
+Auto-Import (config.yaml):
+  Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+
+  Keys:
+    import.path       Input filename relative to .beads/ (default: issues.jsonl)
 
 Custom Status States:
   You can define custom status states for multi-step pipelines using the
@@ -70,6 +77,7 @@ Examples:
   bd config set export.auto true                       # Enable auto-export for viewer integrations
   bd config set export.path "beads.jsonl"              # Custom export filename
   bd config set export.git-add true                    # Also stage the export file
+  bd config set import.path "beads.jsonl"              # Custom import filename
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
@@ -768,7 +776,7 @@ Examples:
 // recognizedConfigPrefixes lists valid top-level config namespaces.
 // Keys under custom.* are always accepted (user-extensible).
 var recognizedConfigPrefixes = []string{
-	"export.", "dolt.", "jira.", "linear.", "github.", "custom.",
+	"export.", "import.", "dolt.", "jira.", "linear.", "github.", "custom.",
 	"status.", "doctor.suppress.", "routing.", "sync.", "git.",
 	"directory.", "repos.", "external_projects.", "validation.",
 	"hierarchy.", "ai.", "backup.", "federation.",

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -51,6 +51,8 @@ Auto-Export (config.yaml):
 
 Auto-Import (config.yaml):
   Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+  Use a relative filename/path so the import stays within the project .beads/
+  directory and remains portable across machines.
 
   Keys:
     import.path       Input filename relative to .beads/ (default: issues.jsonl)

--- a/cmd/bd/config_setmany_test.go
+++ b/cmd/bd/config_setmany_test.go
@@ -53,7 +53,7 @@ func TestConfigSetManyArgParsing(t *testing.T) {
 // TestConfigSetManyYamlKeyDetection tests that yaml-only keys are correctly identified
 // for routing in the set-many command.
 func TestConfigSetManyYamlKeyDetection(t *testing.T) {
-	yamlKeys := []string{"no-db", "json", "routing.mode", "routing.default", "no-push"}
+	yamlKeys := []string{"no-db", "json", "routing.mode", "routing.default", "no-push", "import.path"}
 	for _, key := range yamlKeys {
 		if !config.IsYamlOnlyKey(key) {
 			t.Errorf("expected %q to be yaml-only", key)

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -9,7 +9,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 	recognized := []string{
 		"export.auto", "dolt.auto-push", "jira.url", "custom.anything",
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
-		"status.custom", "ai.model", "backup.enabled",
+		"status.custom", "ai.model", "backup.enabled", "import.path",
 	}
 	for _, key := range recognized {
 		if !isRecognizedConfigKey(key) {

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1388,7 +1388,7 @@ func exportSubprocessDir(beadsDir string) string {
 	return filepath.Dir(beadsDir)
 }
 
-// importJSONLForSync imports .beads/issues.jsonl into Dolt after a git
+// importJSONLForSync imports the configured import.path JSONL into Dolt after a git
 // pull/merge/branch-checkout only for legacy projects with no Dolt remote.
 // When sync.remote is configured, Dolt remains the source of truth and JSONL
 // import is skipped because upsert-only import cannot reconcile stale exports.
@@ -1412,11 +1412,7 @@ func importJSONLForSync(reason string) {
 		return
 	}
 
-	exportPath := config.GetString("export.path")
-	if exportPath == "" {
-		exportPath = "issues.jsonl"
-	}
-	fullPath := filepath.Join(beadsDir, exportPath)
+	fullPath := configuredImportJSONLPath(beadsDir)
 
 	if info, err := os.Stat(fullPath); err != nil || info.Size() == 0 {
 		return

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1393,6 +1393,10 @@ func exportSubprocessDir(beadsDir string) string {
 // When sync.remote is configured, Dolt remains the source of truth and JSONL
 // import is skipped because upsert-only import cannot reconcile stale exports.
 //
+// Unlike the other implied-import callsites, this hook falls back to export.path
+// when import.path is unset/default so legacy projects that customized only
+// export.path continue to sync the file git just updated.
+//
 // Errors are logged as warnings but never block the merge/checkout. The
 // import is upsert; running it on an unchanged JSONL is a no-op (bd
 // import returns "Error 1105: nothing to commit", which we tolerate).
@@ -1412,7 +1416,21 @@ func importJSONLForSync(reason string) {
 		return
 	}
 
-	fullPath := configuredImportJSONLPath(beadsDir)
+	// Prefer import.path; fall back to export.path for legacy projects that
+	// customized only export.path and haven't set import.path yet.
+	// Only fall back if export.path differs from the shared default ("issues.jsonl")
+	// so that uncustomised setups still read "issues.jsonl" as before.
+	const defaultJSONLName = "issues.jsonl"
+	importPath := config.GetString("import.path")
+	if importPath == "" || importPath == defaultJSONLName {
+		if exportPath := config.GetString("export.path"); exportPath != "" && exportPath != defaultJSONLName {
+			importPath = exportPath
+		}
+	}
+	if importPath == "" {
+		importPath = defaultJSONLName
+	}
+	fullPath := filepath.Join(beadsDir, importPath)
 
 	if info, err := os.Stat(fullPath); err != nil || info.Size() == 0 {
 		return

--- a/cmd/bd/hooks_post_merge_import_test.go
+++ b/cmd/bd/hooks_post_merge_import_test.go
@@ -105,6 +105,52 @@ func captureHookStderr(t *testing.T, fn func()) string {
 	return string(out)
 }
 
+// TestImportJSONLForSync_FallsBackToExportPath verifies that when a project has
+// customised export.path but not import.path, the git-hook sync still finds the
+// right file. Without the fallback, importJSONLForSync would stat the default
+// "issues.jsonl" (which does not exist here), get ENOENT, and return silently.
+func TestImportJSONLForSync_FallsBackToExportPath(t *testing.T) {
+	tmp := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	initConfigForTest(t) // initialise viper from tmp (no real config files here)
+
+	beadsDir := filepath.Join(tmp, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// metadata.json makes FindBeadsDir() recognise this as a beads project dir.
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Write only the export-path file, not the default "issues.jsonl".
+	if err := os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	config.Set("import.auto", true)
+	config.Set("export.path", "beads.jsonl")
+	config.Set("no-git-ops", true) // suppress warnJSONLWithoutDoltRemote chatter
+
+	stderr := captureHookStderr(t, func() {
+		importJSONLForSync("test")
+	})
+	// The subprocess ("bd import ...") will fail since there is no working
+	// beads store here. The failure is surfaced as "import warning" on stderr —
+	// that line is only reached after os.Stat succeeds, so seeing it proves
+	// the fallback resolved to "beads.jsonl" instead of the missing "issues.jsonl".
+	if !strings.Contains(stderr, "import warning") {
+		t.Fatalf("expected 'import warning' on stderr (proving fallback to export.path worked), got:\n%s", stderr)
+	}
+}
+
 // TestRunPostCheckoutHook_FileModeSkipsImport asserts that file-mode
 // checkouts (flag=0, e.g. `git checkout -- <file>`) do NOT trigger the
 // import path — only branch-mode checkouts (flag=1) do. Without this

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -21,8 +21,8 @@ var importCmd = &cobra.Command{
 	Short: "Import issues from a JSONL file or stdin into the database",
 	Long: `Import issues from a JSONL file (newline-delimited JSON) into the database.
 
-If no file is specified, imports from .beads/issues.jsonl (the git-tracked
-export). Use "-" to read from stdin. This is the incremental counterpart to
+If no file is specified, imports from the configured import.path under .beads/
+(default: issues.jsonl). Use "-" to read from stdin. This is the incremental counterpart to
 'bd export': new issues are created and existing issues are updated (upsert
 semantics).
 
@@ -58,7 +58,7 @@ when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
-  bd import                        # Import from .beads/issues.jsonl
+  bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
   bd import -i backup.jsonl        # Legacy alias for a specific file
   bd import -                      # Read JSONL from stdin
@@ -109,7 +109,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 		if globalFlag {
 			jsonlPath = filepath.Join(beadsDir, "global-issues.jsonl")
 		} else {
-			jsonlPath = filepath.Join(beadsDir, "issues.jsonl")
+			jsonlPath = configuredImportJSONLPath(beadsDir)
 		}
 	}
 

--- a/cmd/bd/import_embedded_test.go
+++ b/cmd/bd/import_embedded_test.go
@@ -89,6 +89,28 @@ func TestEmbeddedImport(t *testing.T) {
 		}
 	})
 
+	t.Run("from_configured_import_path", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "imcfg")
+
+		cmd := exec.Command(bd, "config", "set", "import.path", "beads.jsonl")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd config set import.path failed: %v\n%s", err, out)
+		}
+
+		jsonlPath := filepath.Join(dir, ".beads", "beads.jsonl")
+		now := time.Now().UTC()
+		writeJSONLFile(t, jsonlPath, []types.Issue{
+			{ID: "imcfg-xxx", Title: "Configured Import Path Issue", Status: types.StatusOpen, IssueType: types.TypeTask, CreatedAt: now, UpdatedAt: now},
+		})
+
+		out := bdImport(t, bd, dir)
+		if !strings.Contains(out, "Imported 1 issue") {
+			t.Errorf("expected 'Imported 1 issue', got: %s", out)
+		}
+	})
+
 	t.Run("dry_run", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "imdry")
 

--- a/cmd/bd/import_path.go
+++ b/cmd/bd/import_path.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+const defaultImportJSONLPath = "issues.jsonl"
+
+func configuredImportJSONLPath(beadsDir string) string {
+	importPath := config.GetString("import.path")
+	if importPath == "" {
+		importPath = defaultImportJSONLPath
+	}
+	return filepath.Join(beadsDir, importPath)
+}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1113,7 +1113,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// Import from local JSONL if requested (GH#2023).
 		// This must run after the store is created and prefix is set.
 		if fromJSONL {
-			localJSONLPath := filepath.Join(beadsDir, "issues.jsonl")
+			localJSONLPath := configuredImportJSONLPath(beadsDir)
 			if _, statErr := os.Stat(localJSONLPath); os.IsNotExist(statErr) {
 				_ = store.Close()
 				FatalError("--from-jsonl specified but %s does not exist", localJSONLPath)
@@ -1540,7 +1540,7 @@ func init() {
 	initCmd.Flags().Bool("force", false, "Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').")
 	initCmd.Flags().Bool("reinit-local", false, "Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.")
 	initCmd.Flags().Bool("discard-remote", false, "Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.")
-	initCmd.Flags().Bool("from-jsonl", false, "Import issues from .beads/issues.jsonl instead of git history")
+	initCmd.Flags().Bool("from-jsonl", false, "Import issues from configured import.path instead of git history")
 	initCmd.Flags().String("destroy-token", "", "Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')")
 	initCmd.Flags().String("agents-template", "", "Path to custom AGENTS.md template (overrides embedded default)")
 	initCmd.Flags().String("agents-profile", "", "AGENTS.md profile: 'minimal' (default, pointer to bd prime) or 'full' (complete command reference)")

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -876,6 +876,46 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("from_jsonl_uses_import_path", func(t *testing.T) {
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+		beadsDir := filepath.Join(dir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("import:\n  path: beads.jsonl\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		issue := types.Issue{
+			ID:        "jlcfg-abc123",
+			Title:     "Configured JSONL",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		line, _ := json.Marshal(issue)
+		if err := os.WriteFile(filepath.Join(beadsDir, "beads.jsonl"), append(line, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := exec.Command(bd, "init", "--prefix", "jlcfg", "--from-jsonl", "--quiet")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("--from-jsonl with import.path failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+
+		showCmd := exec.Command(bd, "show", "jlcfg-abc123", "--json")
+		showCmd.Dir = dir
+		showCmd.Env = bdEnv(dir)
+		if out, err := showCmd.CombinedOutput(); err != nil {
+			t.Fatalf("imported issue not found: %v\n%s", err, out)
+		}
+	})
+
 	t.Run("backend_dolt", func(t *testing.T) {
 		_, beadsDir, _ := bdInit(t, bd, "--prefix", "bdolt", "--backend", "dolt")
 		embeddedDir := filepath.Join(beadsDir, "embeddeddolt")

--- a/cmd/bd/init_templates.go
+++ b/cmd/bd/init_templates.go
@@ -88,6 +88,8 @@ func renderInitConfigYAML(prefix string, noDbMode bool) []byte {
 #   path: issues.jsonl
 #   interval: 60s
 #   git-add: false
+# import:
+#   path: issues.jsonl
 
 # Integration settings (access with 'bd config get/set')
 # Non-secret keys (stored in the database):

--- a/cmd/bd/init_templates.go
+++ b/cmd/bd/init_templates.go
@@ -83,6 +83,7 @@ func renderInitConfigYAML(prefix string, noDbMode bool) []byte {
 
 # Optional JSONL auto-export for viewers, interchange, and issue-level migration.
 # Disabled by default; enable only when an integration needs fresh .beads/issues.jsonl.
+# Use relative paths under .beads/ so configs remain portable across machines.
 # export:
 #   auto: false
 #   path: issues.jsonl

--- a/cmd/bd/kv.go
+++ b/cmd/bd/kv.go
@@ -28,7 +28,8 @@ func validateKVKey(key string) error {
 	// Prevent keys that look like internal config
 	if strings.HasPrefix(key, "sync.") || strings.HasPrefix(key, "conflict.") ||
 		strings.HasPrefix(key, "federation.") || strings.HasPrefix(key, "jira.") ||
-		strings.HasPrefix(key, "linear.") || strings.HasPrefix(key, "export.") {
+		strings.HasPrefix(key, "linear.") || strings.HasPrefix(key, "export.") ||
+		strings.HasPrefix(key, "import.") {
 		return fmt.Errorf("key cannot start with reserved prefix %q", strings.Split(key, ".")[0]+".")
 	}
 	return nil

--- a/cmd/bd/kv_test.go
+++ b/cmd/bd/kv_test.go
@@ -202,6 +202,7 @@ func TestValidateKVKey(t *testing.T) {
 		{"jira prefix", "jira.url", true, "reserved prefix"},
 		{"linear prefix", "linear.key", true, "reserved prefix"},
 		{"export prefix", "export.path", true, "reserved prefix"},
+		{"import prefix", "import.path", true, "reserved prefix"},
 	}
 
 	for _, tc := range testCases {

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2599,6 +2599,8 @@ Auto-Export (config.yaml):
 
 Auto-Import (config.yaml):
   Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+  Use a relative filename/path so the import stays within the project .beads/
+  directory and remains portable across machines.
 
   Keys:
     import.path       Input filename relative to .beads/ (default: issues.jsonl)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2380,8 +2380,8 @@ bd federation
 
 Import issues from a JSONL file (newline-delimited JSON) into the database.
 
-If no file is specified, imports from .beads/issues.jsonl (the git-tracked
-export). Use "-" to read from stdin. This is the incremental counterpart to
+If no file is specified, imports from the configured import.path under .beads/
+(default: issues.jsonl). Use "-" to read from stdin. This is the incremental counterpart to
 'bd export': new issues are created and existing issues are updated (upsert
 semantics).
 
@@ -2417,7 +2417,7 @@ when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
-  bd import                        # Import from .beads/issues.jsonl
+  bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
   bd import -i backup.jsonl        # Legacy alias for a specific file
   bd import -                      # Read JSONL from stdin
@@ -2576,6 +2576,7 @@ Configuration is stored per-project in the beads database and is version-control
 
 Common namespaces:
   - export.*          Auto-export settings (stored in config.yaml)
+  - import.*          JSONL import settings (stored in config.yaml)
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
@@ -2595,6 +2596,12 @@ Auto-Export (config.yaml):
     export.path       Output filename relative to .beads/ (default: issues.jsonl)
     export.interval   Minimum time between exports (default: 60s)
     export.git-add    Auto-stage the export file (default: false)
+
+Auto-Import (config.yaml):
+  Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+
+  Keys:
+    import.path       Input filename relative to .beads/ (default: issues.jsonl)
 
 Custom Status States:
   You can define custom status states for multi-step pipelines using the
@@ -2618,6 +2625,7 @@ Examples:
   bd config set export.auto true                       # Enable auto-export for viewer integrations
   bd config set export.path "beads.jsonl"              # Custom export filename
   bd config set export.git-add true                    # Also stage the export file
+  bd config set import.path "beads.jsonl"              # Custom import filename
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
@@ -3378,7 +3386,7 @@ bd init [flags]
       --discard-remote                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                          Server is externally managed (skip server startup); use with --shared-server or --server
       --force                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                        Import issues from .beads/issues.jsonl instead of git history
+      --from-jsonl                        Import issues from configured import.path instead of git history
       --non-interactive                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                     Issue prefix (default: current directory name)
       --proxied-server                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -346,6 +346,7 @@ Configuration keys use dot-notation namespaces to organize settings:
 - `min_hash_length` - Minimum hash ID length (default: 4)
 - `max_hash_length` - Maximum hash ID length (default: 8)
 - `import.orphan_handling` - How to handle hierarchical issues with missing parents during import (default: `allow`)
+- `import.path` - Input filename relative to `.beads/` for implied JSONL imports, including `bd init --from-jsonl` and empty-DB auto-import (default: `issues.jsonl`)
 - `export.auto` - Refresh the JSONL export after every write command (default: `false`). This is for viewers, interchange, and issue-level migration; it is not cross-machine sync and not a full database backup.
 - `export.path` - Output filename relative to `.beads/` (default: `issues.jsonl`)
 - `export.interval` - Minimum time between auto-exports (default: `60s`)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -346,7 +346,7 @@ Configuration keys use dot-notation namespaces to organize settings:
 - `min_hash_length` - Minimum hash ID length (default: 4)
 - `max_hash_length` - Maximum hash ID length (default: 8)
 - `import.orphan_handling` - How to handle hierarchical issues with missing parents during import (default: `allow`)
-- `import.path` - Input filename relative to `.beads/` for implied JSONL imports, including `bd init --from-jsonl` and empty-DB auto-import (default: `issues.jsonl`)
+- `import.path` - Input filename relative to `.beads/` for implied JSONL imports, including `bd init --from-jsonl` and empty-DB auto-import (default: `issues.jsonl`). Use a relative filename/path such as `beads.jsonl` so the import remains project-local and portable across machines.
 - `export.auto` - Refresh the JSONL export after every write command (default: `false`). This is for viewers, interchange, and issue-level migration; it is not cross-machine sync and not a full database backup.
 - `export.path` - Output filename relative to `.beads/` (default: `issues.jsonl`)
 - `export.interval` - Minimum time between auto-exports (default: `60s`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,6 +249,7 @@ func Initialize() error {
 	// configured a Dolt remote yet. Hook code skips this path when sync.remote
 	// is configured because JSONL import is upsert-only, not reconciliation.
 	v.SetDefault("import.auto", true)
+	v.SetDefault("import.path", "issues.jsonl") // relative to .beads/; canonical import name
 
 	// AI configuration defaults
 	v.SetDefault("ai.model", "claude-haiku-4-5-20251001")

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -63,6 +63,9 @@ var YamlOnlyKeys = map[string]bool{
 	"backup.git-push": true,
 	"backup.git-repo": true,
 
+	// Import settings
+	"import.path": true,
+
 	// Dolt server settings
 	"dolt.shared-server": true, // Shared Dolt server at ~/.beads/shared-server/ (GH#2377)
 	"dolt.max-conns":     true, // Connection pool size override (default 10, GH#3140)

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -40,6 +40,10 @@ func TestIsYamlOnlyKey(t *testing.T) {
 		{"backup.git-repo", true},
 		{"backup.future-key", true}, // prefix match
 
+		// Import settings
+		{"import.path", true},
+		{"import.orphan_handling", false},
+
 		// Secret keys (stored in yaml to avoid leaking via Dolt push)
 		{"github.token", true},
 		{"linear.api_key", true},

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -39,6 +39,8 @@ Auto-Export (config.yaml):
 
 Auto-Import (config.yaml):
   Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+  Use a relative filename/path so the import stays within the project .beads/
+  directory and remains portable across machines.
 
   Keys:
     import.path       Input filename relative to .beads/ (default: issues.jsonl)

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -16,6 +16,7 @@ Configuration is stored per-project in the beads database and is version-control
 
 Common namespaces:
   - export.*          Auto-export settings (stored in config.yaml)
+  - import.*          JSONL import settings (stored in config.yaml)
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
@@ -35,6 +36,12 @@ Auto-Export (config.yaml):
     export.path       Output filename relative to .beads/ (default: issues.jsonl)
     export.interval   Minimum time between exports (default: 60s)
     export.git-add    Auto-stage the export file (default: false)
+
+Auto-Import (config.yaml):
+  Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+
+  Keys:
+    import.path       Input filename relative to .beads/ (default: issues.jsonl)
 
 Custom Status States:
   You can define custom status states for multi-step pipelines using the
@@ -58,6 +65,7 @@ Examples:
   bd config set export.auto true                       # Enable auto-export for viewer integrations
   bd config set export.path "beads.jsonl"              # Custom export filename
   bd config set export.git-add true                    # Also stage the export file
+  bd config set import.path "beads.jsonl"              # Custom import filename
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"

--- a/website/docs/cli-reference/import.md
+++ b/website/docs/cli-reference/import.md
@@ -12,8 +12,8 @@ Generated from `bd help --doc import`
 
 Import issues from a JSONL file (newline-delimited JSON) into the database.
 
-If no file is specified, imports from .beads/issues.jsonl (the git-tracked
-export). Use "-" to read from stdin. This is the incremental counterpart to
+If no file is specified, imports from the configured import.path under .beads/
+(default: issues.jsonl). Use "-" to read from stdin. This is the incremental counterpart to
 'bd export': new issues are created and existing issues are updated (upsert
 semantics).
 
@@ -49,7 +49,7 @@ when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
-  bd import                        # Import from .beads/issues.jsonl
+  bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
   bd import -i backup.jsonl        # Legacy alias for a specific file
   bd import -                      # Read JSONL from stdin

--- a/website/docs/cli-reference/init.md
+++ b/website/docs/cli-reference/init.md
@@ -62,7 +62,7 @@ bd init [flags]
       --discard-remote                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                          Server is externally managed (skip server startup); use with --shared-server or --server
       --force                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                        Import issues from .beads/issues.jsonl instead of git history
+      --from-jsonl                        Import issues from configured import.path instead of git history
       --non-interactive                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                     Issue prefix (default: current directory name)
       --proxied-server                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -110,6 +110,7 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `backup.git-repo` | — | `BD_BACKUP_GIT_REPO` | (none) | Backup git repo URL |
 | `export.auto` | — | — | `false` | Refresh `.beads/issues.jsonl` export after every write; not cross-machine sync |
 | `export.path` | — | — | `issues.jsonl` | Output filename relative to `.beads/` |
+| `import.path` | — | — | `issues.jsonl` | Input filename relative to `.beads/` for implied JSONL imports; use relative paths for portability |
 | `export.interval` | — | — | `60s` | Minimum time between auto-exports |
 | `export.git-add` | — | — | `false` | Run `git add` on the export file |
 | `routing.mode` | — | — | (none) | Multi-repo routing: `auto`, `maintainer`, `contributor`, `explicit` |

--- a/website/versioned_docs/version-1.0.0/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/config.md
@@ -39,6 +39,8 @@ Auto-Export (config.yaml):
 
 Auto-Import (config.yaml):
   Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+  Use a relative filename/path so the import stays within the project .beads/
+  directory and remains portable across machines.
 
   Keys:
     import.path       Input filename relative to .beads/ (default: issues.jsonl)

--- a/website/versioned_docs/version-1.0.0/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/config.md
@@ -16,6 +16,7 @@ Configuration is stored per-project in the beads database and is version-control
 
 Common namespaces:
   - export.*          Auto-export settings (stored in config.yaml)
+  - import.*          JSONL import settings (stored in config.yaml)
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
@@ -35,6 +36,12 @@ Auto-Export (config.yaml):
     export.path       Output filename relative to .beads/ (default: issues.jsonl)
     export.interval   Minimum time between exports (default: 60s)
     export.git-add    Auto-stage the export file (default: false)
+
+Auto-Import (config.yaml):
+  Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+
+  Keys:
+    import.path       Input filename relative to .beads/ (default: issues.jsonl)
 
 Custom Status States:
   You can define custom status states for multi-step pipelines using the
@@ -58,6 +65,7 @@ Examples:
   bd config set export.auto true                       # Enable auto-export for viewer integrations
   bd config set export.path "beads.jsonl"              # Custom export filename
   bd config set export.git-add true                    # Also stage the export file
+  bd config set import.path "beads.jsonl"              # Custom import filename
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"

--- a/website/versioned_docs/version-1.0.0/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/import.md
@@ -12,8 +12,8 @@ Generated from `bd help --doc import`
 
 Import issues from a JSONL file (newline-delimited JSON) into the database.
 
-If no file is specified, imports from .beads/issues.jsonl (the git-tracked
-export). Use "-" to read from stdin. This is the incremental counterpart to
+If no file is specified, imports from the configured import.path under .beads/
+(default: issues.jsonl). Use "-" to read from stdin. This is the incremental counterpart to
 'bd export': new issues are created and existing issues are updated (upsert
 semantics).
 
@@ -49,7 +49,7 @@ when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
-  bd import                        # Import from .beads/issues.jsonl
+  bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
   bd import -i backup.jsonl        # Legacy alias for a specific file
   bd import -                      # Read JSONL from stdin

--- a/website/versioned_docs/version-1.0.0/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/init.md
@@ -62,7 +62,7 @@ bd init [flags]
       --discard-remote                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                          Server is externally managed (skip server startup); use with --shared-server or --server
       --force                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                        Import issues from .beads/issues.jsonl instead of git history
+      --from-jsonl                        Import issues from configured import.path instead of git history
       --non-interactive                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                     Issue prefix (default: current directory name)
       --proxied-server                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/versioned_docs/version-1.0.0/reference/configuration.md
+++ b/website/versioned_docs/version-1.0.0/reference/configuration.md
@@ -110,6 +110,7 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `backup.git-repo` | — | `BD_BACKUP_GIT_REPO` | (none) | Backup git repo URL |
 | `export.auto` | — | — | `true` | Refresh `.beads/issues.jsonl` after every write |
 | `export.path` | — | — | `issues.jsonl` | Output filename relative to `.beads/` |
+| `import.path` | — | — | `issues.jsonl` | Input filename relative to `.beads/` for implied JSONL imports; use relative paths for portability |
 | `export.interval` | — | — | `60s` | Minimum time between auto-exports |
 | `export.git-add` | — | — | `true` | Run `git add` on the export file |
 | `routing.mode` | — | — | (none) | Multi-repo routing: `auto`, `maintainer`, `contributor`, `explicit` |

--- a/website/versioned_docs/version-1.0.4/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/config.md
@@ -39,6 +39,8 @@ Auto-Export (config.yaml):
 
 Auto-Import (config.yaml):
   Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+  Use a relative filename/path so the import stays within the project .beads/
+  directory and remains portable across machines.
 
   Keys:
     import.path       Input filename relative to .beads/ (default: issues.jsonl)

--- a/website/versioned_docs/version-1.0.4/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/config.md
@@ -16,6 +16,7 @@ Configuration is stored per-project in the beads database and is version-control
 
 Common namespaces:
   - export.*          Auto-export settings (stored in config.yaml)
+  - import.*          JSONL import settings (stored in config.yaml)
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
@@ -35,6 +36,12 @@ Auto-Export (config.yaml):
     export.path       Output filename relative to .beads/ (default: issues.jsonl)
     export.interval   Minimum time between exports (default: 60s)
     export.git-add    Auto-stage the export file (default: false)
+
+Auto-Import (config.yaml):
+  Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+
+  Keys:
+    import.path       Input filename relative to .beads/ (default: issues.jsonl)
 
 Custom Status States:
   You can define custom status states for multi-step pipelines using the
@@ -58,6 +65,7 @@ Examples:
   bd config set export.auto true                       # Enable auto-export for viewer integrations
   bd config set export.path "beads.jsonl"              # Custom export filename
   bd config set export.git-add true                    # Also stage the export file
+  bd config set import.path "beads.jsonl"              # Custom import filename
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"

--- a/website/versioned_docs/version-1.0.4/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/import.md
@@ -12,8 +12,8 @@ Generated from `bd help --doc import`
 
 Import issues from a JSONL file (newline-delimited JSON) into the database.
 
-If no file is specified, imports from .beads/issues.jsonl (the git-tracked
-export). Use "-" to read from stdin. This is the incremental counterpart to
+If no file is specified, imports from the configured import.path under .beads/
+(default: issues.jsonl). Use "-" to read from stdin. This is the incremental counterpart to
 'bd export': new issues are created and existing issues are updated (upsert
 semantics).
 
@@ -49,7 +49,7 @@ when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
-  bd import                        # Import from .beads/issues.jsonl
+  bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
   bd import -i backup.jsonl        # Legacy alias for a specific file
   bd import -                      # Read JSONL from stdin

--- a/website/versioned_docs/version-1.0.4/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/init.md
@@ -62,7 +62,7 @@ bd init [flags]
       --discard-remote                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                          Server is externally managed (skip server startup); use with --shared-server or --server
       --force                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                        Import issues from .beads/issues.jsonl instead of git history
+      --from-jsonl                        Import issues from configured import.path instead of git history
       --non-interactive                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                     Issue prefix (default: current directory name)
       --proxied-server                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb

--- a/website/versioned_docs/version-1.0.4/reference/configuration.md
+++ b/website/versioned_docs/version-1.0.4/reference/configuration.md
@@ -110,6 +110,7 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `backup.git-repo` | — | `BD_BACKUP_GIT_REPO` | (none) | Backup git repo URL |
 | `export.auto` | — | — | `true` | Refresh `.beads/issues.jsonl` after every write |
 | `export.path` | — | — | `issues.jsonl` | Output filename relative to `.beads/` |
+| `import.path` | — | — | `issues.jsonl` | Input filename relative to `.beads/` for implied JSONL imports; use relative paths for portability |
 | `export.interval` | — | — | `60s` | Minimum time between auto-exports |
 | `export.git-add` | — | — | `true` | Run `git add` on the export file |
 | `routing.mode` | — | — | (none) | Multi-repo routing: `auto`, `maintainer`, `contributor`, `explicit` |


### PR DESCRIPTION
## Summary

Cherry-pick of medhatgalal's PR #4041 with maintainer-side backward-compatibility fix applied.

**Changes from #4041:**
- Add `import.path` config key (YAML-only, default `"issues.jsonl"`) that routes all implied JSONL imports through one helper (`configuredImportJSONLPath`)
- Unified import path used for `bd init --from-jsonl`, empty-DB auto-import, and `bd import`
- Registered as YAML-only key (startup-sensitive: needed before storage opens)
- `import.` added to reserved KV prefix list

**Maintainer addition:**
- `importJSONLForSync` (git-hook sync path) now falls back to `export.path` when `import.path` is at its default. Legacy projects that customized only `export.path="beads.jsonl"` and hadn't set `import.path` would otherwise silently lose post-pull JSONL sync after this PR. Fix scoped to this hook only; other callsites use `configuredImportJSONLPath` directly (they don't have the git-sync invariant).
- Added `TestImportJSONLForSync_FallsBackToExportPath` to lock the behavior.

## Attribution
- Original feature: medhatgalal (PR #4041, `medhat.galal@appian.com`)
- Hooks fallback: maintainer (beads reviewer)

Closes #4041

🤖 Generated with [Claude Code](https://claude.com/claude-code)