### PR TITLE
fix(deps): replace undirected sibling check with directed ancestor query

### DIFF
--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -1643,4 +1643,80 @@ func TestGetBlockedIssues_WithBlockerDetails(t *testing.T) {
 	}
 }
 
+// TestAddDependency_Blocks_SiblingsAllowed is a regression test for the
+// parentChildLinkedQuery bug: the old undirected connected-component walk
+// treated siblings (two children of the same parent) as "connected", so a
+// blocks edge between them was rejected. The new directed ancestor query
+// (parentChildAncestorQuery) allows it.
+func TestAddDependency_Blocks_SiblingsAllowed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic := &types.Issue{ID: "sb-epic", Title: "Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	t1 := &types.Issue{ID: "sb-task1", Title: "Task 1", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	t2 := &types.Issue{ID: "sb-task2", Title: "Task 2", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	for _, issue := range []*types.Issue{epic, t1, t2} {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+
+	pc1 := &types.Dependency{IssueID: "sb-task1", DependsOnID: "sb-epic", Type: types.DepParentChild}
+	pc2 := &types.Dependency{IssueID: "sb-task2", DependsOnID: "sb-epic", Type: types.DepParentChild}
+	if err := store.AddDependency(ctx, pc1, "tester"); err != nil {
+		t.Fatalf("AddDependency pc1: %v", err)
+	}
+	if err := store.AddDependency(ctx, pc2, "tester"); err != nil {
+		t.Fatalf("AddDependency pc2: %v", err)
+	}
+
+	dep := &types.Dependency{IssueID: "sb-task1", DependsOnID: "sb-task2", Type: types.DepBlocks}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("sibling blocks edge should be allowed: %v", err)
+	}
+}
+
+// TestAddDependency_Blocks_CousinsAllowed is a regression test for the same
+// parentChildLinkedQuery bug: tasks under different child epics of the same
+// grandparent (cousins) are not ancestors of each other and must be allowed
+// to form blocks edges.
+func TestAddDependency_Blocks_CousinsAllowed(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	gp := &types.Issue{ID: "co-gp", Title: "Grandparent", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	ce1 := &types.Issue{ID: "co-ce1", Title: "Child Epic 1", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	ce2 := &types.Issue{ID: "co-ce2", Title: "Child Epic 2", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	ct1 := &types.Issue{ID: "co-ct1", Title: "Cousin Task 1", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	ct2 := &types.Issue{ID: "co-ct2", Title: "Cousin Task 2", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+	for _, issue := range []*types.Issue{gp, ce1, ce2, ct1, ct2} {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+
+	for _, pc := range []struct{ child, parent string }{
+		{"co-ce1", "co-gp"},
+		{"co-ce2", "co-gp"},
+		{"co-ct1", "co-ce1"},
+		{"co-ct2", "co-ce2"},
+	} {
+		d := &types.Dependency{IssueID: pc.child, DependsOnID: pc.parent, Type: types.DepParentChild}
+		if err := store.AddDependency(ctx, d, "tester"); err != nil {
+			t.Fatalf("AddDependency parent-child %s->%s: %v", pc.child, pc.parent, err)
+		}
+	}
+
+	dep := &types.Dependency{IssueID: "co-ct1", DependsOnID: "co-ct2", Type: types.DepBlocks}
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("cousin blocks edge should be allowed: %v", err)
+	}
+}
+
 // Note: testContext is already defined in dolt_test.go for this package

--- a/internal/storage/dolt/dependencies_extended_test.go
+++ b/internal/storage/dolt/dependencies_extended_test.go
@@ -1,6 +1,7 @@
 package dolt
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -902,10 +903,15 @@ func TestAddDependency_SamePrefix_RequiresTargetExistence(t *testing.T) {
 }
 
 // =============================================================================
-// Cross-Type Blocking Validation Tests (GH#1495)
+// Parent-Child Shadow Blocking Validation Tests (GH#1495)
 // =============================================================================
+//
+// Cross-type blocks edges between unrelated issues are allowed. Only blocks
+// edges that would shadow an existing parent-child relationship are rejected,
+// because they livelock the ready-work computation (the blocked parent
+// propagates its blocked state to all children, including the blocking child).
 
-func TestAddDependency_BlocksCrossType_TaskBlocksEpic(t *testing.T) {
+func TestAddDependency_BlocksCrossType_TaskBlocksEpic_Unrelated(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -933,22 +939,18 @@ func TestAddDependency_BlocksCrossType_TaskBlocksEpic(t *testing.T) {
 		t.Fatalf("failed to create epic: %v", err)
 	}
 
-	// Task blocks epic -> should fail
+	// Task blocks unrelated epic -> should succeed.
 	dep := &types.Dependency{
 		IssueID:     "ct-epic-1",
 		DependsOnID: "ct-task-1",
 		Type:        types.DepBlocks,
 	}
-	err := store.AddDependency(ctx, dep, "tester")
-	if err == nil {
-		t.Fatal("expected error when task blocks epic, got nil")
-	}
-	if !strings.Contains(err.Error(), "can only block") {
-		t.Errorf("unexpected error message: %v", err)
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("task blocking unrelated epic should succeed: %v", err)
 	}
 }
 
-func TestAddDependency_BlocksCrossType_EpicBlocksTask(t *testing.T) {
+func TestAddDependency_BlocksCrossType_EpicBlocksTask_Unrelated(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
@@ -976,18 +978,219 @@ func TestAddDependency_BlocksCrossType_EpicBlocksTask(t *testing.T) {
 		t.Fatalf("failed to create epic: %v", err)
 	}
 
-	// Epic blocks task -> should fail
+	// Epic blocks unrelated task -> should succeed.
 	dep := &types.Dependency{
 		IssueID:     "ct-task-2",
 		DependsOnID: "ct-epic-2",
 		Type:        types.DepBlocks,
 	}
-	err := store.AddDependency(ctx, dep, "tester")
-	if err == nil {
-		t.Fatal("expected error when epic blocks task, got nil")
+	if err := store.AddDependency(ctx, dep, "tester"); err != nil {
+		t.Fatalf("epic blocking unrelated task should succeed: %v", err)
 	}
-	if !strings.Contains(err.Error(), "can only block") {
+}
+
+func TestAddDependency_Blocks_ChildBlocksParent_Rejected(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic := &types.Issue{
+		ID:        "sh-epic-1",
+		Title:     "Parent epic",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	task := &types.Issue{
+		ID:        "sh-task-1",
+		Title:     "Child task",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, epic, "tester"); err != nil {
+		t.Fatalf("failed to create epic: %v", err)
+	}
+	if err := store.CreateIssue(ctx, task, "tester"); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	// Establish parent-child: task is a child of epic.
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "sh-task-1",
+		DependsOnID: "sh-epic-1",
+		Type:        types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("parent-child setup failed: %v", err)
+	}
+
+	// Child task tries to block parent epic -> rejected (shadow edge).
+	err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "sh-epic-1",
+		DependsOnID: "sh-task-1",
+		Type:        types.DepBlocks,
+	}, "tester")
+	if err == nil {
+		t.Fatal("expected rejection of child-blocks-parent shadow edge")
+	}
+	if !strings.Contains(err.Error(), "parent-child relationship") {
 		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestAddDependency_Blocks_ParentBlocksChild_Rejected(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	epic := &types.Issue{
+		ID:        "sh-epic-2",
+		Title:     "Parent epic",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeEpic,
+	}
+	task := &types.Issue{
+		ID:        "sh-task-2",
+		Title:     "Child task",
+		Status:    types.StatusOpen,
+		Priority:  1,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, epic, "tester"); err != nil {
+		t.Fatalf("failed to create epic: %v", err)
+	}
+	if err := store.CreateIssue(ctx, task, "tester"); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	// Parent-child: task is a child of epic.
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "sh-task-2",
+		DependsOnID: "sh-epic-2",
+		Type:        types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("parent-child setup failed: %v", err)
+	}
+
+	// Parent epic tries to block its own child task -> rejected.
+	err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "sh-task-2",
+		DependsOnID: "sh-epic-2",
+		Type:        types.DepBlocks,
+	}, "tester")
+	if err == nil {
+		t.Fatal("expected rejection of parent-blocks-child shadow edge")
+	}
+	if !strings.Contains(err.Error(), "parent-child relationship") &&
+		!strings.Contains(err.Error(), "already exists") {
+		// The shadow check fires first, but the existing-pair check might
+		// fire instead since the same pair already has a parent-child row.
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestAddDependency_Blocks_AncestorBlocksDescendant_Rejected(t *testing.T) {
+	// Grandparent epic should not be able to block a grandchild task via a
+	// transitive parent-child path.
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	grandparent := &types.Issue{ID: "sh-gp-1", Title: "Grandparent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	parent := &types.Issue{ID: "sh-p-1", Title: "Parent", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeEpic}
+	child := &types.Issue{ID: "sh-c-1", Title: "Child", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask}
+	for _, iss := range []*types.Issue{grandparent, parent, child} {
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create %s: %v", iss.ID, err)
+		}
+	}
+
+	// parent is child of grandparent; child is child of parent.
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: "sh-p-1", DependsOnID: "sh-gp-1", Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("parent-child p->gp: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{IssueID: "sh-c-1", DependsOnID: "sh-p-1", Type: types.DepParentChild}, "tester"); err != nil {
+		t.Fatalf("parent-child c->p: %v", err)
+	}
+
+	// Grandparent blocks grandchild -> rejected (transitive shadow).
+	err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     "sh-c-1",
+		DependsOnID: "sh-gp-1",
+		Type:        types.DepBlocks,
+	}, "tester")
+	if err == nil {
+		t.Fatal("expected rejection of grandparent-blocks-grandchild")
+	}
+	if !strings.Contains(err.Error(), "parent-child relationship") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestAddDependency_Blocks_DeepCrossTypeChain(t *testing.T) {
+	// Build a multi-level chain: each task blocks one epic and is the child
+	// of a different epic. None of the blocks edges shadow a parent-child
+	// relationship, so all should be allowed. Documents the scenario from
+	// the user request: "an epic which depends on a task, which could be
+	// part of another epic, which depends on a different task, and so on."
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	const levels = 4
+	for i := 1; i <= levels; i++ {
+		epic := &types.Issue{
+			ID:        fmt.Sprintf("dc-e%d", i),
+			Title:     fmt.Sprintf("Epic %d", i),
+			Status:    types.StatusOpen,
+			Priority:  1,
+			IssueType: types.TypeEpic,
+		}
+		task := &types.Issue{
+			ID:        fmt.Sprintf("dc-t%d", i),
+			Title:     fmt.Sprintf("Task %d", i),
+			Status:    types.StatusOpen,
+			Priority:  1,
+			IssueType: types.TypeTask,
+		}
+		if err := store.CreateIssue(ctx, epic, "tester"); err != nil {
+			t.Fatalf("create epic %d: %v", i, err)
+		}
+		if err := store.CreateIssue(ctx, task, "tester"); err != nil {
+			t.Fatalf("create task %d: %v", i, err)
+		}
+	}
+
+	for i := 1; i <= levels; i++ {
+		// Task i blocks Epic i.
+		if err := store.AddDependency(ctx, &types.Dependency{
+			IssueID:     fmt.Sprintf("dc-e%d", i),
+			DependsOnID: fmt.Sprintf("dc-t%d", i),
+			Type:        types.DepBlocks,
+		}, "tester"); err != nil {
+			t.Fatalf("blocks t%d->e%d: %v", i, i, err)
+		}
+		// Task i is a child of Epic i+1 (if it exists). This is what makes
+		// the chain: e_i is blocked by t_i, and t_i belongs to e_{i+1},
+		// which is blocked by t_{i+1}, ...
+		if i+1 <= levels {
+			if err := store.AddDependency(ctx, &types.Dependency{
+				IssueID:     fmt.Sprintf("dc-t%d", i),
+				DependsOnID: fmt.Sprintf("dc-e%d", i+1),
+				Type:        types.DepParentChild,
+			}, "tester"); err != nil {
+				t.Fatalf("parent-child t%d->e%d: %v", i, i+1, err)
+			}
+		}
 	}
 }
 

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -766,8 +766,8 @@ func TestDoltStoreDependencies(t *testing.T) {
 	ctx, cancel := testContext(t)
 	defer cancel()
 
-	// Create parent and child issues (both tasks — cross-type blocking
-	// is disallowed per GH#1495)
+	// Create parent and child issues (both tasks for a same-type blocks
+	// pair; cross-type blocks edges are now allowed for unrelated issues).
 	parent := &types.Issue{
 		ID:          "test-parent",
 		Title:       "Parent Issue",

--- a/internal/storage/embeddeddolt/dependencies_test.go
+++ b/internal/storage/embeddeddolt/dependencies_test.go
@@ -368,4 +368,35 @@ func TestAddDependency(t *testing.T) {
 			t.Fatalf("epic blocking unrelated task should succeed: %v", err)
 		}
 	})
+
+	// Regression for parentChildLinkedQuery: siblings (two tasks under the same
+	// epic) were incorrectly rejected because the undirected walk saw them as
+	// "connected". The new directed ancestor query allows sibling blocks edges.
+	t.Run("siblings_allowed", func(t *testing.T) {
+		te := newTestEnv(t, "si")
+		ctx := t.Context()
+
+		epic := &types.Issue{ID: "si-epic", Title: "Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+		t1 := &types.Issue{ID: "si-t1", Title: "Task 1", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		t2 := &types.Issue{ID: "si-t2", Title: "Task 2", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		for _, issue := range []*types.Issue{epic, t1, t2} {
+			if err := te.store.CreateIssue(ctx, issue, "tester"); err != nil {
+				t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+			}
+		}
+
+		pc1 := &types.Dependency{IssueID: "si-t1", DependsOnID: "si-epic", Type: types.DepParentChild}
+		pc2 := &types.Dependency{IssueID: "si-t2", DependsOnID: "si-epic", Type: types.DepParentChild}
+		if err := te.store.AddDependency(ctx, pc1, "tester"); err != nil {
+			t.Fatalf("AddDependency pc1: %v", err)
+		}
+		if err := te.store.AddDependency(ctx, pc2, "tester"); err != nil {
+			t.Fatalf("AddDependency pc2: %v", err)
+		}
+
+		dep := &types.Dependency{IssueID: "si-t1", DependsOnID: "si-t2", Type: types.DepBlocks}
+		if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("sibling blocks edge should be allowed: %v", err)
+		}
+	})
 }

--- a/internal/storage/embeddeddolt/dependencies_test.go
+++ b/internal/storage/embeddeddolt/dependencies_test.go
@@ -128,7 +128,7 @@ func TestAddDependency(t *testing.T) {
 		}
 	})
 
-	t.Run("cross_type_validation", func(t *testing.T) {
+	t.Run("cross_type_unrelated_allowed", func(t *testing.T) {
 		te := newTestEnv(t, "ct")
 		ctx := t.Context()
 
@@ -141,14 +141,40 @@ func TestAddDependency(t *testing.T) {
 			t.Fatalf("CreateIssue task: %v", err)
 		}
 
-		// Task blocking epic should fail.
-		dep := &types.Dependency{IssueID: "ct-task", DependsOnID: "ct-epic", Type: types.DepBlocks}
+		// Task blocking an unrelated epic should succeed; only parent-child
+		// shadow edges are rejected.
+		dep := &types.Dependency{IssueID: "ct-epic", DependsOnID: "ct-task", Type: types.DepBlocks}
+		if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("task blocking unrelated epic should succeed: %v", err)
+		}
+	})
+
+	t.Run("parent_child_shadow_rejected", func(t *testing.T) {
+		te := newTestEnv(t, "sh")
+		ctx := t.Context()
+
+		epic := &types.Issue{ID: "sh-epic", Title: "Epic", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+		task := &types.Issue{ID: "sh-task", Title: "Task", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		if err := te.store.CreateIssue(ctx, epic, "tester"); err != nil {
+			t.Fatalf("CreateIssue epic: %v", err)
+		}
+		if err := te.store.CreateIssue(ctx, task, "tester"); err != nil {
+			t.Fatalf("CreateIssue task: %v", err)
+		}
+
+		// Establish parent-child: task is a child of epic.
+		if err := te.store.AddDependency(ctx, &types.Dependency{IssueID: "sh-task", DependsOnID: "sh-epic", Type: types.DepParentChild}, "tester"); err != nil {
+			t.Fatalf("parent-child setup: %v", err)
+		}
+
+		// Child task blocking its parent epic creates a shadow edge -> reject.
+		dep := &types.Dependency{IssueID: "sh-epic", DependsOnID: "sh-task", Type: types.DepBlocks}
 		err := te.store.AddDependency(ctx, dep, "tester")
 		if err == nil {
-			t.Fatal("expected cross-type error")
+			t.Fatal("expected rejection of parent-child shadow blocks edge")
 		}
-		if !strings.Contains(err.Error(), "epics") {
-			t.Errorf("expected cross-type error message, got: %v", err)
+		if !strings.Contains(err.Error(), "parent-child relationship") {
+			t.Errorf("expected shadow rejection message, got: %v", err)
 		}
 	})
 
@@ -322,7 +348,7 @@ func TestAddDependency(t *testing.T) {
 		}
 	})
 
-	t.Run("epic_blocks_task_fails", func(t *testing.T) {
+	t.Run("epic_blocks_unrelated_task_succeeds", func(t *testing.T) {
 		te := newTestEnv(t, "et")
 		ctx := t.Context()
 
@@ -335,14 +361,11 @@ func TestAddDependency(t *testing.T) {
 			t.Fatalf("CreateIssue task: %v", err)
 		}
 
-		// Epic blocking task should fail (reverse direction of existing cross_type_validation test).
-		dep := &types.Dependency{IssueID: "et-epic", DependsOnID: "et-task", Type: types.DepBlocks}
-		err := te.store.AddDependency(ctx, dep, "tester")
-		if err == nil {
-			t.Fatal("expected cross-type error")
-		}
-		if !strings.Contains(err.Error(), "epics") {
-			t.Errorf("expected cross-type error message, got: %v", err)
+		// Epic blocking an unrelated task is allowed; only parent-child shadow
+		// blocks edges are rejected.
+		dep := &types.Dependency{IssueID: "et-task", DependsOnID: "et-epic", Type: types.DepBlocks}
+		if err := te.store.AddDependency(ctx, dep, "tester"); err != nil {
+			t.Fatalf("epic blocking unrelated task should succeed: %v", err)
 		}
 	})
 }

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -171,8 +171,9 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	// redundant. Cross-type blocks edges between unrelated issues are fine.
 	if dep.Type == types.DepBlocks && targetType != "" {
 		var linked int
-		query := parentChildLinkedQuery(depTables)
-		if err := tx.QueryRowContext(ctx, query, dep.IssueID, dep.DependsOnID).Scan(&linked); err != nil {
+		// Four params: seed-src, seed-tgt, target-in-src-tree, source-in-tgt-tree.
+		query := parentChildAncestorQuery(depTables)
+		if err := tx.QueryRowContext(ctx, query, dep.IssueID, dep.DependsOnID, dep.DependsOnID, dep.IssueID).Scan(&linked); err != nil {
 			return fmt.Errorf("failed to check parent-child relationship: %w", err)
 		}
 		if linked > 0 {
@@ -373,30 +374,37 @@ func cycleDetectionTables() []string {
 	return []string{"dependencies", "wisp_dependencies"}
 }
 
-// parentChildLinkedQuery returns >0 if the two endpoints share a parent-child
-// connected component (i.e., one is an ancestor of the other via parent-child
-// edges). Parent-child rows are directed (issue_id = child, depends_on_id =
-// parent); we emit both directions into a derived edge relation so the
-// recursive CTE has a single recursive term, which MySQL/Dolt require.
-// Parameters: seed ID, target ID.
-func parentChildLinkedQuery(depTables []string) string {
+// parentChildAncestorQuery returns >0 if one endpoint is a directed
+// parent-child ancestor of the other. Parent-child rows are directed
+// (issue_id = child, parent via DepTargetExpr); we walk edges only in the
+// child→parent direction from each seed. Siblings/cousins that share a
+// common parent but are not ancestors of each other return 0 and are allowed
+// to form blocks edges. Two CTEs (one seeded from source, one from target)
+// share the same edge relation via %[1]s.
+// Parameters: source, target, target, source.
+func parentChildAncestorQuery(depTables []string) string {
 	var unions []string
 	for _, t := range depTables {
 		unions = append(unions,
-			fmt.Sprintf("SELECT issue_id AS src, depends_on_id AS dst FROM %s WHERE type = 'parent-child'", t),
-			fmt.Sprintf("SELECT depends_on_id AS src, issue_id AS dst FROM %s WHERE type = 'parent-child'", t),
+			fmt.Sprintf("SELECT issue_id AS child, %s AS parent FROM %s WHERE type = 'parent-child'", DepTargetExpr, t),
 		)
 	}
 	edges := strings.Join(unions, " UNION ")
 	return fmt.Sprintf(`
-		WITH RECURSIVE related(node) AS (
+		WITH RECURSIVE
+		anc_src(node) AS (
 			SELECT ?
 			UNION
-			SELECT e.dst
-			FROM related r
-			JOIN (%s) e ON e.src = r.node
+			SELECT e.parent FROM anc_src r JOIN (%[1]s) e ON e.child = r.node
+		),
+		anc_tgt(node) AS (
+			SELECT ?
+			UNION
+			SELECT e.parent FROM anc_tgt r JOIN (%[1]s) e ON e.child = r.node
 		)
-		SELECT COUNT(*) FROM related WHERE node = ?
+		SELECT
+			(SELECT COUNT(*) FROM anc_src WHERE node = ?)
+			+ (SELECT COUNT(*) FROM anc_tgt WHERE node = ?)
 	`, edges)
 }
 

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -92,7 +92,7 @@ type AddDependencyOpts struct {
 // transaction. It handles:
 //   - Wisp routing (auto-detected or caller-provided)
 //   - Source/target existence validation
-//   - Cross-type blocking validation (GH#1495)
+//   - Parent-child shadow rejection for blocks edges (GH#1495)
 //   - Cycle detection via recursive CTE across both dependency tables
 //   - Idempotent same-type updates (metadata only)
 //   - Type conflict detection
@@ -156,22 +156,39 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 		}
 	}
 
-	// Cross-type blocking validation (GH#1495): tasks can only block tasks,
-	// epics can only block epics.
+	// Self-dependency check (must run before graph queries that would
+	// otherwise treat source == target as a trivial match).
+	if dep.IssueID == dep.DependsOnID {
+		return fmt.Errorf("cannot add self-dependency: %s cannot depend on itself", dep.IssueID)
+	}
+
+	// Parent-child shadow rejection (GH#1495): a blocks edge between an
+	// issue and one of its parent-child ancestors or descendants creates a
+	// livelock in ready-work computation, because the blocked parent
+	// propagates its blocked state back down to the blocking child, which
+	// the child can never escape. The parent-child hierarchy already
+	// encodes scheduling for these pairs, so the blocks edge is also
+	// redundant. Cross-type blocks edges between unrelated issues are fine.
 	if dep.Type == types.DepBlocks && targetType != "" {
-		sourceIsEpic := sourceType == string(types.TypeEpic)
-		targetIsEpic := targetType == string(types.TypeEpic)
-		if sourceIsEpic != targetIsEpic {
-			if sourceIsEpic {
-				return fmt.Errorf("epics can only block other epics, not tasks")
-			}
-			return fmt.Errorf("tasks can only block other tasks, not epics")
+		var linked int
+		query := parentChildLinkedQuery(depTables)
+		if err := tx.QueryRowContext(ctx, query, dep.IssueID, dep.DependsOnID).Scan(&linked); err != nil {
+			return fmt.Errorf("failed to check parent-child relationship: %w", err)
+		}
+		if linked > 0 {
+			return fmt.Errorf("cannot add blocks dependency: %s and %s already share a parent-child relationship; the existing hierarchy encodes their scheduling", dep.IssueID, dep.DependsOnID)
 		}
 	}
 
-	if !opts.SkipCycleCheck {
-		if err := CheckDependencyCycleInTx(ctx, tx, dep, depTables); err != nil {
-			return err
+	// Cycle detection for blocking deps via recursive CTE.
+	if !opts.SkipCycleCheck && (dep.Type == types.DepBlocks || dep.Type == types.DepConditionalBlocks) {
+		var reachable int
+		query := cycleReachabilityQuery(depTables)
+		if err := tx.QueryRowContext(ctx, query, dep.DependsOnID, dep.IssueID).Scan(&reachable); err != nil {
+			return fmt.Errorf("failed to check for dependency cycle: %w", err)
+		}
+		if reachable > 0 {
+			return fmt.Errorf("adding dependency would create a cycle")
 		}
 	}
 
@@ -354,6 +371,33 @@ func cycleReachabilityQuery(depTables []string) string {
 
 func cycleDetectionTables() []string {
 	return []string{"dependencies", "wisp_dependencies"}
+}
+
+// parentChildLinkedQuery returns >0 if the two endpoints share a parent-child
+// connected component (i.e., one is an ancestor of the other via parent-child
+// edges). Parent-child rows are directed (issue_id = child, depends_on_id =
+// parent); we emit both directions into a derived edge relation so the
+// recursive CTE has a single recursive term, which MySQL/Dolt require.
+// Parameters: seed ID, target ID.
+func parentChildLinkedQuery(depTables []string) string {
+	var unions []string
+	for _, t := range depTables {
+		unions = append(unions,
+			fmt.Sprintf("SELECT issue_id AS src, depends_on_id AS dst FROM %s WHERE type = 'parent-child'", t),
+			fmt.Sprintf("SELECT depends_on_id AS src, issue_id AS dst FROM %s WHERE type = 'parent-child'", t),
+		)
+	}
+	edges := strings.Join(unions, " UNION ")
+	return fmt.Sprintf(`
+		WITH RECURSIVE related(node) AS (
+			SELECT ?
+			UNION
+			SELECT e.dst
+			FROM related r
+			JOIN (%s) e ON e.src = r.node
+		)
+		SELECT COUNT(*) FROM related WHERE node = ?
+	`, edges)
 }
 
 func DeleteWispFromDependenciesInTx(ctx context.Context, tx *sql.Tx, wispID string) error {


### PR DESCRIPTION
## Summary

Closes #4034 via maintainer cherry-pick (contributor fork write-access not available).

- **Bug**: `parentChildLinkedQuery` walked the parent-child graph as an **undirected** connected component, so siblings (two tasks under the same epic) were seen as "connected" and their `blocks` edge was incorrectly rejected with "would create parent-child relationship shadow".
- **Fix**: Replace with `parentChildAncestorQuery` — two directed recursive CTEs walk `child→parent` from each endpoint. A `blocks` edge is rejected only when one endpoint is a true ancestor of the other. Siblings and cousins share no ancestor relation and are correctly allowed.
- **Schema fix**: Uses `DepTargetExpr` (`COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)`) instead of the dropped `depends_on_id` generated column (removed in migration 0043 / PR #4027).

## Changes

- `internal/storage/issueops/dependencies.go`: new `parentChildAncestorQuery`, updated call site (4 params)
- `internal/storage/dolt/dependencies_extended_test.go`: `TestAddDependency_Blocks_SiblingsAllowed`, `TestAddDependency_Blocks_CousinsAllowed`
- `internal/storage/embeddeddolt/dependencies_test.go`: `siblings_allowed` subtest in `TestAddDependency`

## Test plan

- [ ] `go test ./internal/storage/issueops/...` passes
- [ ] `go test ./internal/storage/dolt/...` — new sibling/cousin tests pass with live Dolt server
- [ ] `go test ./internal/storage/embeddeddolt/...` (CGO) — `siblings_allowed` subtest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)