### PR TITLE
fix(init): mark server-mode Dolt dirs compatible

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1232,6 +1232,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			fmt.Fprintf(os.Stderr, "Warning: failed to close database: %v\n", err)
 		}
 
+		if initServerMode {
+			if err := doltserver.MarkDoltDirCompatible(storagePath); err != nil && !quiet {
+				fmt.Fprintf(os.Stderr, "Warning: failed to write Dolt compatibility marker: %v\n", err)
+			}
+		}
+
 		// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
 		// directory — including noms/LOCK files. These are Dolt-internal files.
 		// Removing them WILL cause unrecoverable data corruption and data loss.

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1233,7 +1233,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		}
 
 		if initServerMode {
-			if err := doltserver.MarkDoltDirCompatible(storagePath); err != nil && !quiet {
+			if err := doltserver.MarkDoltDirCompatible(storagePath); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to write Dolt compatibility marker: %v\n", err)
 			}
 		}

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1643,6 +1643,53 @@ func TestInitDoltMetadataNoGit(t *testing.T) {
 	}
 }
 
+func TestInitServerModeWritesDoltCompatibilityMarker(t *testing.T) {
+	skipIfNoDolt(t)
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+	dbPath = ""
+	store = nil
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("creating beads dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0o750); err != nil {
+		t.Fatalf("creating simulated server data dir: %v", err)
+	}
+
+	database := uniqueTestDBName(t)
+	t.Cleanup(func() {
+		dropTestDatabase(database, testDoltServerPort)
+	})
+
+	rootCmd.SetArgs([]string{
+		"init",
+		"--server",
+		"--external",
+		"--server-host", "127.0.0.1",
+		"--server-port", fmt.Sprintf("%d", testDoltServerPort),
+		"--database", database,
+		"--prefix", "marker",
+		"--quiet",
+		"--skip-hooks",
+		"--skip-agents",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("server init failed: %v", err)
+	}
+
+	markerPath := filepath.Join(doltDir, ".bd-dolt-ok")
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected server init to write %s: %v", markerPath, err)
+	}
+}
+
 func setupBareParentInitWorktree(t *testing.T) (string, string) {
 	t.Helper()
 

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1690,6 +1690,71 @@ func TestInitServerModeWritesDoltCompatibilityMarker(t *testing.T) {
 	}
 }
 
+func TestInitServerModeWarnsOnMarkerFailureInQuietMode(t *testing.T) {
+	skipIfNoDolt(t)
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+	dbPath = ""
+	store = nil
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	doltDir := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0o700); err != nil {
+		t.Fatalf("creating dolt dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDir, ".dolt"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("creating invalid dot-dolt marker: %v", err)
+	}
+
+	database := uniqueTestDBName(t)
+	t.Cleanup(func() {
+		dropTestDatabase(database, testDoltServerPort)
+	})
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = w
+	defer func() {
+		os.Stderr = oldStderr
+	}()
+
+	rootCmd.SetArgs([]string{
+		"init",
+		"--server",
+		"--external",
+		"--server-host", "127.0.0.1",
+		"--server-port", fmt.Sprintf("%d", testDoltServerPort),
+		"--database", database,
+		"--prefix", "marker",
+		"--quiet",
+		"--skip-hooks",
+		"--skip-agents",
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		w.Close()
+		t.Fatalf("server init failed: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	var stderr bytes.Buffer
+	if _, err := stderr.ReadFrom(r); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+
+	if !strings.Contains(stderr.String(), "Warning: failed to write Dolt compatibility marker") {
+		t.Fatalf("expected marker warning in stderr, got:\n%s", stderr.String())
+	}
+}
+
 func setupBareParentInitWorktree(t *testing.T) (string, string) {
 	t.Helper()
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1274,6 +1274,36 @@ func ensureDoltIdentity() error {
 // Those databases are incompatible with the current server-only architecture.
 const bdDoltMarker = ".bd-dolt-ok"
 
+// MarkDoltDirCompatible writes the bd compatibility marker when doltDir contains
+// a local Dolt repository.
+func MarkDoltDirCompatible(doltDir string) error {
+	if doltDir == "" {
+		return errors.New("dolt directory is required")
+	}
+	dotDolt := filepath.Join(doltDir, ".dolt")
+	if info, err := os.Stat(dotDolt); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("checking dolt metadata directory %s: %w", dotDolt, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("dolt metadata path %s is not a directory", dotDolt)
+	}
+	markerPath := filepath.Join(doltDir, bdDoltMarker)
+	if info, err := os.Stat(markerPath); err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("dolt compatibility marker %s is a directory", markerPath)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking dolt compatibility marker %s: %w", markerPath, err)
+	}
+	if err := os.WriteFile(markerPath, []byte("ok\n"), 0600); err != nil {
+		return fmt.Errorf("writing dolt compatibility marker %s: %w", markerPath, err)
+	}
+	return nil
+}
+
 // ensureDoltInit initializes a dolt database directory if .dolt/ doesn't exist.
 // If .dolt/ exists, seeds the .bd-dolt-ok marker for existing working databases.
 // See GH#2137 for background on pre-0.56 database compatibility.

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1291,9 +1291,7 @@ func MarkDoltDirCompatible(doltDir string) error {
 	}
 	markerPath := filepath.Join(doltDir, bdDoltMarker)
 	if info, err := os.Stat(markerPath); err == nil {
-		if info.IsDir() {
-			return fmt.Errorf("dolt compatibility marker %s is a directory", markerPath)
-		}
+		_ = info
 		return nil
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("checking dolt compatibility marker %s: %w", markerPath, err)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1113,6 +1113,88 @@ func TestEnsureDoltInit_SeedsMarker(t *testing.T) {
 	}
 }
 
+func TestMarkDoltDirCompatible(t *testing.T) {
+	t.Run("empty path errors", func(t *testing.T) {
+		if err := MarkDoltDirCompatible(""); err == nil {
+			t.Fatal("expected empty path to error")
+		}
+	})
+
+	t.Run("missing dot-dolt is noop", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := MarkDoltDirCompatible(doltDir); err != nil {
+			t.Fatalf("MarkDoltDirCompatible: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(doltDir, bdDoltMarker)); !os.IsNotExist(err) {
+			t.Fatalf("marker should not be created without .dolt/, stat err=%v", err)
+		}
+	})
+
+	t.Run("dot-dolt file errors", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(doltDir, ".dolt"), []byte("not a dir"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err == nil {
+			t.Fatal("expected .dolt file to error")
+		}
+	})
+
+	t.Run("writes missing marker", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err != nil {
+			t.Fatalf("MarkDoltDirCompatible: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(doltDir, bdDoltMarker))
+		if err != nil {
+			t.Fatalf("reading marker: %v", err)
+		}
+		if string(got) != "ok\n" {
+			t.Fatalf("marker content = %q, want %q", string(got), "ok\n")
+		}
+		if IsPreV56DoltDir(doltDir) {
+			t.Fatal("marked dolt dir should not report as pre-v56")
+		}
+	})
+
+	t.Run("existing marker is preserved", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0750); err != nil {
+			t.Fatal(err)
+		}
+		markerPath := filepath.Join(doltDir, bdDoltMarker)
+		if err := os.WriteFile(markerPath, []byte("custom\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err != nil {
+			t.Fatalf("MarkDoltDirCompatible: %v", err)
+		}
+		got, err := os.ReadFile(markerPath)
+		if err != nil {
+			t.Fatalf("reading marker: %v", err)
+		}
+		if string(got) != "custom\n" {
+			t.Fatalf("existing marker content = %q, want %q", string(got), "custom\n")
+		}
+	})
+
+	t.Run("marker directory errors", func(t *testing.T) {
+		doltDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(doltDir, bdDoltMarker), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := MarkDoltDirCompatible(doltDir); err == nil {
+			t.Fatal("expected marker directory to error")
+		}
+	})
+}
+
 func TestRecoverPreV56DoltDir(t *testing.T) {
 	doltDir := t.TempDir()
 	dotDolt := filepath.Join(doltDir, ".dolt", "noms")

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1181,16 +1181,22 @@ func TestMarkDoltDirCompatible(t *testing.T) {
 		}
 	})
 
-	t.Run("marker directory errors", func(t *testing.T) {
+	t.Run("marker directory is preserved", func(t *testing.T) {
 		doltDir := t.TempDir()
 		if err := os.MkdirAll(filepath.Join(doltDir, ".dolt"), 0750); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.MkdirAll(filepath.Join(doltDir, bdDoltMarker), 0750); err != nil {
+		markerPath := filepath.Join(doltDir, bdDoltMarker)
+		if err := os.MkdirAll(markerPath, 0750); err != nil {
 			t.Fatal(err)
 		}
-		if err := MarkDoltDirCompatible(doltDir); err == nil {
-			t.Fatal("expected marker directory to error")
+		if err := MarkDoltDirCompatible(doltDir); err != nil {
+			t.Fatalf("MarkDoltDirCompatible: %v", err)
+		}
+		if info, err := os.Stat(markerPath); err != nil {
+			t.Fatalf("stat marker path: %v", err)
+		} else if !info.IsDir() {
+			t.Fatal("existing marker path should be preserved as-is")
 		}
 	})
 }


### PR DESCRIPTION
## What

Supersedes #4072 by preserving the original server-mode Dolt compatibility-marker fix and adding the maintainer review follow-ups that keep marker-write failures visible in quiet automation flows.

## Why

#4072 correctly fixed the false pre-v0.56 detection path after `bd init --server --external`, but review found two follow-ups that needed to land with it:
- marker-write failures were suppressed under `--quiet`, which is the mode most automation uses
- the new helper treated a pre-existing marker directory as an error even though the rest of the compatibility checks already treat marker existence as sufficient

Supersedes #4072.
Credit: Original fix by @julianknutsen.
Context: this replaces the Gas City-side workaround discussed in gastownhall/gascity#2108 with the fix in Beads itself.

## Verification

- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/doltserver -run 'TestMarkDoltDirCompatible|TestIsPreV56DoltDir|TestEnsureDoltInit|TestRecoverPreV56DoltDir'`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestInitServerModeWritesDoltCompatibilityMarker|TestInitServerModeWarnsOnMarkerFailureInQuietMode'`
- `git diff --check refs/adopt-pr/upstream-base...HEAD`
