### PR TITLE
feat(formula): surface intent field in JSON output (maintainer cherry-pick from PR #4056)

### DIFF
--- a/internal/formula/intent_test.go
+++ b/internal/formula/intent_test.go
@@ -1,0 +1,71 @@
+package formula
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestFormulaIntentRoundTrip verifies that the intent field survives a
+// TOML→Formula→JSON round-trip (presence case) and is correctly absent
+// when not declared (omitempty case).
+func TestFormulaIntentRoundTrip(t *testing.T) {
+	t.Run("intent_present", func(t *testing.T) {
+		tomlData := []byte(`
+formula     = "mol-intent-test"
+description = "round-trip test"
+intent      = "mail_only"
+
+[[steps]]
+id    = "s1"
+title = "Step one"
+type  = "task"
+`)
+		p := NewParser()
+		f, err := p.ParseTOML(tomlData)
+		if err != nil {
+			t.Fatalf("ParseTOML failed: %v", err)
+		}
+		if f.Intent != "mail_only" {
+			t.Errorf("Intent after ParseTOML = %q, want %q", f.Intent, "mail_only")
+		}
+
+		jsonBytes, err := json.Marshal(f)
+		if err != nil {
+			t.Fatalf("json.Marshal failed: %v", err)
+		}
+		jsonStr := string(jsonBytes)
+		if !strings.Contains(jsonStr, `"intent":"mail_only"`) {
+			t.Errorf("JSON does not contain intent field; got:\n%s", jsonStr)
+		}
+	})
+
+	t.Run("intent_absent", func(t *testing.T) {
+		tomlData := []byte(`
+formula     = "mol-no-intent"
+description = "no intent declared"
+
+[[steps]]
+id    = "s1"
+title = "Step one"
+type  = "task"
+`)
+		p := NewParser()
+		f, err := p.ParseTOML(tomlData)
+		if err != nil {
+			t.Fatalf("ParseTOML failed: %v", err)
+		}
+		if f.Intent != "" {
+			t.Errorf("Intent = %q, want empty string when not declared", f.Intent)
+		}
+
+		jsonBytes, err := json.Marshal(f)
+		if err != nil {
+			t.Fatalf("json.Marshal failed: %v", err)
+		}
+		jsonStr := string(jsonBytes)
+		if strings.Contains(jsonStr, `"intent"`) {
+			t.Errorf("JSON should NOT contain intent field when absent; got:\n%s", jsonStr)
+		}
+	})
+}

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -117,6 +117,10 @@ type Formula struct {
 
 	// Source tracks where this formula was loaded from (set by parser).
 	Source string `json:"source,omitempty"`
+
+	// Intent is an optional caller-defined hint about the formula's runtime
+	// intent (e.g. "mail_only"). Opaque to bd; consumed by downstream tools.
+	Intent string `json:"intent,omitempty" toml:"intent,omitempty"`
 }
 
 // VarDef defines a template variable with optional validation.


### PR DESCRIPTION
## Summary

Maintainer cherry-pick from @Dev-KVN's PR #4056, with one maintainer-side addition:

- **@Dev-KVN's change** (`internal/formula/types.go`): adds `Intent string` field with `json:"intent,omitempty" toml:"intent,omitempty"` tags. Opaque to bd; consumed downstream.
- **Maintainer addition** (`internal/formula/intent_test.go`): `TestFormulaIntentRoundTrip` — TOML→`Formula`→JSON round-trip test (presence + omission cases), covering the silent-regression failure mode for `omitempty` fields.

The contributor's diff is untouched and fully credited. All CI green on the original PR.

Closes #4056 — thank you @Dev-KVN for the clean, focused addition!

## Test plan
- [ ] All existing formula tests pass
- [ ] `TestFormulaIntentRoundTrip/intent_present` and `/intent_absent` pass
- [ ] `go test ./internal/formula/... -run TestFormulaIntentRoundTrip` green