### PR TITLE
fix(init): tighten Dolt marker handling

### DIFF
--- a/cmd/bd/doctor/fix/dolt_format.go
+++ b/cmd/bd/doctor/fix/dolt_format.go
@@ -2,7 +2,6 @@ package fix
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/steveyegge/beads/internal/doltserver"
@@ -23,8 +22,7 @@ func DoltFormat(path string) error {
 		return nil // Already OK or no .dolt/ directory
 	}
 
-	markerPath := filepath.Join(doltDir, ".bd-dolt-ok")
-	if err := os.WriteFile(markerPath, []byte("ok\n"), 0600); err != nil {
+	if err := doltserver.MarkDoltDirCompatible(doltDir); err != nil {
 		return fmt.Errorf("creating .bd-dolt-ok marker: %w", err)
 	}
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -112,6 +112,9 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			initProxiedServer = true
 		}
 		if initProxiedServer {
+			// Proxied-server mode has no local Dolt init lifecycle yet. When it
+			// is implemented, that path must mark any local .dolt/ it creates or
+			// acknowledges with doltserver.MarkDoltDirCompatible.
 			FatalError("--proxied-server is not yet implemented")
 		}
 		if initProxiedServer && initServerMode {
@@ -1234,7 +1237,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 
 		if initServerMode {
 			if err := doltserver.MarkDoltDirCompatible(storagePath); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to write Dolt compatibility marker: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: failed to write Dolt compatibility marker at %s: %v\n", storagePath, err)
 			}
 		}
 

--- a/cmd/bd/init_test.go
+++ b/cmd/bd/init_test.go
@@ -1753,6 +1753,9 @@ func TestInitServerModeWarnsOnMarkerFailureInQuietMode(t *testing.T) {
 	if !strings.Contains(stderr.String(), "Warning: failed to write Dolt compatibility marker") {
 		t.Fatalf("expected marker warning in stderr, got:\n%s", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), doltDir) {
+		t.Fatalf("expected marker warning to include dolt dir %s, got:\n%s", doltDir, stderr.String())
+	}
 }
 
 func setupBareParentInitWorktree(t *testing.T) (string, string) {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1268,14 +1268,15 @@ func ensureDoltIdentity() error {
 	return nil
 }
 
-// bdDoltMarker is a file written after ensureDoltInit successfully creates a
-// dolt database. Its absence in an existing .dolt/ directory indicates the
-// database was created by a pre-0.56 bd version (which used embedded mode).
+// bdDoltMarker is written after a current bd process creates or acknowledges a
+// local Dolt repository. Its absence in an existing .dolt/ directory indicates
+// the database was created by a pre-0.56 bd version (which used embedded mode).
 // Those databases are incompatible with the current server-only architecture.
 const bdDoltMarker = ".bd-dolt-ok"
 
-// MarkDoltDirCompatible writes the bd compatibility marker when doltDir contains
-// a local Dolt repository.
+// MarkDoltDirCompatible writes the canonical bd compatibility marker when
+// doltDir contains a local Dolt repository. It no-ops when there is no .dolt/
+// directory, which lets server and repair paths call it defensively.
 func MarkDoltDirCompatible(doltDir string) error {
 	if doltDir == "" {
 		return errors.New("dolt directory is required")
@@ -1290,8 +1291,7 @@ func MarkDoltDirCompatible(doltDir string) error {
 		return fmt.Errorf("dolt metadata path %s is not a directory", dotDolt)
 	}
 	markerPath := filepath.Join(doltDir, bdDoltMarker)
-	if info, err := os.Stat(markerPath); err == nil {
-		_ = info
+	if _, err := os.Stat(markerPath); err == nil {
 		return nil
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("checking dolt compatibility marker %s: %w", markerPath, err)
@@ -1311,16 +1311,13 @@ func ensureDoltInit(doltDir string) error {
 	}
 
 	dotDolt := filepath.Join(doltDir, ".dolt")
-	markerPath := filepath.Join(doltDir, bdDoltMarker)
 
 	if _, err := os.Stat(dotDolt); err == nil {
 		// .dolt/ exists — seed the marker if missing.
 		// This is the non-destructive path: we just mark existing databases
 		// as known. The destructive recovery path (RecoverPreV56DoltDir) is
 		// triggered separately during version upgrades.
-		if _, markerErr := os.Stat(markerPath); os.IsNotExist(markerErr) {
-			_ = os.WriteFile(markerPath, []byte("ok\n"), 0600) // Seed marker
-		}
+		_ = MarkDoltDirCompatible(doltDir)
 		return nil // Already initialized
 	}
 
@@ -1330,8 +1327,8 @@ func ensureDoltInit(doltDir string) error {
 		return fmt.Errorf("dolt init: %w\n%s", err, out)
 	}
 
-	// Write version marker so future runs know this database is compatible
-	_ = os.WriteFile(markerPath, []byte("ok\n"), 0600)
+	// Write version marker so future runs know this database is compatible.
+	_ = MarkDoltDirCompatible(doltDir)
 
 	return nil
 }


### PR DESCRIPTION
Maintainer follow-up for https://github.com/gastownhall/beads/pull/4072.

Original PR title: fix(init): mark server-mode Dolt dirs compatible
Original PR state: CLOSED
Configured base: main
Original GitHub base: main
Base mismatch: none

This follow-up carries the approved final patch from the adopt-pr review after the original PR was already closed. It preserves @julianknutsen's contributor authorship while applying the maintainer-review tightening needed before merge.

Review outcome:
- The original contribution fixed the server-mode Dolt compatibility-marker gap for `bd init --server --external`.
- Adoption review found quiet-mode marker failures could be hidden, marker-writing responsibilities were split, the warning lacked the affected storage path, and proxied-server marker scope needed an explicit note.
- The final patch keeps marker failure warnings visible in quiet mode, includes the storage path, reuses `MarkDoltDirCompatible` from doctor/init paths, records the proxied-server future contract, and keeps broader fresh-init coverage as non-gating follow-up scope.

Validation recorded by the workflow:
- Approval helper: passed for reviewed head `c6691a6bb38609b3cb34d9f239397d20b2560926`.
- Base refresh: already current against configured `main` (`3988db7e0da1d5488e5ff972349f736466bec1c8`).
- Review decision: approve on attempt 2.

After GitHub CI passes on this follow-up head, the workflow will post the public review-results comment and mark this PR `status/merge-ready` for the merge queue.
