### PR TITLE
Stamp auto-import attempts for unchanged JSONL

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,6 +24,36 @@ type jsonlImporter interface {
 // top-level emptiness guard prevents the fallback path from running on a
 // non-empty database. Production builds always use importFromLocalJSONLFull.
 var fallbackImporter = importFromLocalJSONLFull
+
+type autoImportStamp struct {
+	Size        int64 `json:"size"`
+	ModTimeNano int64 `json:"mtime_ns"`
+}
+
+func autoImportStampPath(beadsDir string) string {
+	return filepath.Join(beadsDir, ".auto-import-issues.jsonl")
+}
+
+func autoImportStampMatches(beadsDir string, info os.FileInfo) bool {
+	data, err := os.ReadFile(autoImportStampPath(beadsDir))
+	if err != nil {
+		return false
+	}
+	var stamp autoImportStamp
+	if err := json.Unmarshal(data, &stamp); err != nil {
+		return false
+	}
+	return stamp.Size == info.Size() && stamp.ModTimeNano == info.ModTime().UnixNano()
+}
+
+func writeAutoImportStamp(beadsDir string, info os.FileInfo) {
+	stamp := autoImportStamp{Size: info.Size(), ModTimeNano: info.ModTime().UnixNano()}
+	data, err := json.Marshal(stamp)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(autoImportStampPath(beadsDir), data, 0o600)
+}
 
 // maybeAutoImportJSONL checks whether the database is empty and a
 // issues.jsonl file exists in beadsDir. When both conditions are true it
@@ -48,6 +79,9 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	if err != nil || info.Size() == 0 {
 		return // no JSONL file or empty — nothing to import
 	}
+	if autoImportStampMatches(beadsDir, info) {
+		return // this exact JSONL export was already auto-imported successfully
+	}
 
 	// Top-level emptiness guard (covers both embedded and fallback paths).
 	// Without this, the fallback path silently re-imposes stale JSONL on
@@ -68,6 +102,7 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	// Parse the JSONL file without touching the store.
 	issues, configEntries, err := parseJSONLFile(jsonlPath)
 	if err != nil {
+		writeAutoImportStamp(beadsDir, info)
 		fmt.Fprintf(os.Stderr, "warning: auto-import: failed to parse %s: %v\n", jsonlPath, err)
 		return
 	}
@@ -80,6 +115,7 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	if importer, ok := s.(jsonlImporter); ok {
 		imported, err := importer.ImportJSONLData(ctx, issues, configEntries, "auto-import")
 		if err != nil {
+			writeAutoImportStamp(beadsDir, info)
 			fmt.Fprintf(os.Stderr, "warning: auto-import from %s failed: %v\n", jsonlPath, err)
 			fmt.Fprintf(os.Stderr, "\nYour issues are still safe in %s.\n", jsonlPath)
 			fmt.Fprintf(os.Stderr, "Try: bd init --from-jsonl   (re-initialize and import from the JSONL file)\n")
@@ -87,6 +123,7 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 			return
 		}
 		if imported > 0 {
+			writeAutoImportStamp(beadsDir, info)
 			// Signal PersistentPostRun to auto-commit (no explicit DOLT_COMMIT here).
 			commandDidWrite.Store(true)
 			fmt.Fprintf(os.Stderr, "auto-imported %d issues", imported)
@@ -103,6 +140,7 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 
 	result, err := fallbackImporter(ctx, s, jsonlPath)
 	if err != nil {
+		writeAutoImportStamp(beadsDir, info)
 		fmt.Fprintf(os.Stderr, "warning: auto-import from %s failed: %v\n", jsonlPath, err)
 		fmt.Fprintf(os.Stderr, "\nYour issues are still safe in %s.\n", jsonlPath)
 		fmt.Fprintf(os.Stderr, "Try: bd init --from-jsonl   (re-initialize and import from the JSONL file)\n")
@@ -116,8 +154,12 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 		commitMsg = fmt.Sprintf("auto-import: %d issues, %d memories from %s (upgrade recovery, GH#2994)", result.Issues, result.Memories, filepath.Base(jsonlPath))
 	}
 	if err := s.Commit(ctx, commitMsg); err != nil {
+		writeAutoImportStamp(beadsDir, info)
 		fmt.Fprintf(os.Stderr, "warning: auto-import: dolt commit failed: %v\n", err)
 		return
+	}
+	if result.Issues > 0 || result.Memories > 0 {
+		writeAutoImportStamp(beadsDir, info)
 	}
 
 	if result.Memories > 0 {

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -30,6 +30,8 @@ func (f *fakeFallbackStore) GetStatistics(_ context.Context) (*types.Statistics,
 	return &types.Statistics{TotalIssues: f.statsTotalIssues}, nil
 }
 
+func (f *fakeFallbackStore) Commit(_ context.Context, _ string) error { return nil }
+
 func writeAutoImportFixtureJSONL(t *testing.T, dir string) {
 	t.Helper()
 	// Minimal valid issue line. Contents are irrelevant for the
@@ -115,5 +117,62 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty(t *testing.T) {
 
 	if got := count.Load(); got != 1 {
 		t.Fatalf("server-mode fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
+	}
+}
+
+func TestMaybeAutoImportJSONL_FailedImportStampPreventsRepeatedImport(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	count := swapFallbackImporter(t, errors.New("test importer failed"))
+
+	store := &fakeFallbackStore{statsTotalIssues: 0}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir)
+
+	if got := count.Load(); got != 1 {
+		t.Fatalf("fallback importer invoked %d time(s), want 1 for unchanged JSONL after failed attempt stamp", got)
+	}
+}
+
+func TestMaybeAutoImportJSONL_SuccessStampPreventsRepeatedImport(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	orig := fallbackImporter
+	var count atomic.Int32
+	fallbackImporter = func(_ context.Context, _ storage.DoltStorage, _ string) (*importLocalResult, error) {
+		count.Add(1)
+		return &importLocalResult{Issues: 1}, nil
+	}
+	t.Cleanup(func() { fallbackImporter = orig })
+
+	store := &fakeFallbackStore{statsTotalIssues: 0}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir)
+
+	if got := count.Load(); got != 1 {
+		t.Fatalf("fallback importer invoked %d time(s), want 1 for unchanged JSONL after success stamp", got)
+	}
+}
+
+func TestMaybeAutoImportJSONL_ChangedJSONLBypassesSuccessStamp(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	orig := fallbackImporter
+	var count atomic.Int32
+	fallbackImporter = func(_ context.Context, _ storage.DoltStorage, _ string) (*importLocalResult, error) {
+		count.Add(1)
+		return &importLocalResult{Issues: 1}, nil
+	}
+	t.Cleanup(func() { fallbackImporter = orig })
+
+	store := &fakeFallbackStore{statsTotalIssues: 0}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+	if err := os.WriteFile(filepath.Join(dir, "issues.jsonl"), []byte(`{"_type":"issue","id":"unit-2","title":"changed","status":"open","priority":2,"issue_type":"task"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	maybeAutoImportJSONL(context.Background(), store, dir)
+
+	if got := count.Load(); got != 2 {
+		t.Fatalf("fallback importer invoked %d time(s), want 2 after JSONL changed", got)
 	}
 }


### PR DESCRIPTION
## Summary\n- Add a local issues.jsonl auto-import attempt stamp keyed by size and mtime\n- Skip repeated auto-import attempts for the same unchanged JSONL after success or failure\n- Allow retry when issues.jsonl changes\n\n## Verification\n- go test -tags gms_pure_go ./cmd/bd -run 'TestMaybeAutoImportJSONL'\n- make build\n- Manual production check after installing candidate bd locally: repeated 'bd status' in /Users/admin/gt no longer prints auto-importing ... into empty database; both runs report 517 issues directly\n\nContext: Homebrew bd 1.0.4 repeatedly attempted auto-import on every command in Gas Town, causing bd/mail/convoy slowness and stale JSONL risk.