### PR TITLE
fix(export): guard empty auto-export over populated JSONL

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -91,6 +92,14 @@ func maybeAutoExport(ctx context.Context) {
 		return
 	}
 
+	if skip, existingCount, err := shouldSkipEmptyAutoExport(ctx, fullPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to check existing JSONL: %v\n", err)
+		return
+	} else if skip {
+		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: current database would export 0 issues, but %s already contains %d issue(s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, existingCount)
+		return
+	}
+
 	// Run the export — memories are excluded from auto-export because they
 	// contain private agent context that must not reach git history (GH#3650).
 	issueCount, memoryCount, err := exportToFile(ctx, fullPath, false)
@@ -143,21 +152,81 @@ func shouldExport(state *exportAutoState, interval time.Duration) bool {
 	return time.Since(state.Timestamp) >= interval
 }
 
-// exportToFile atomically exports issues + memories to the given file path.
-// Writes to a temp file first, then renames into place so readers never see
-// a partial or truncated export. Used by both `bd export -o` and auto-export.
-func exportToFile(ctx context.Context, path string, includeMemories bool) (issueCount, memoryCount int, err error) {
-	w, err := atomicfile.Create(path, 0o644)
+func shouldSkipEmptyAutoExport(ctx context.Context, path string) (bool, int, error) {
+	existingCount, err := countIssueRecordsInJSONL(path)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to create export file: %w", err)
+		return false, 0, err
 	}
-	defer func() {
-		if err != nil {
-			_ = w.Abort()
-		}
-	}()
+	if existingCount == 0 {
+		return false, 0, nil
+	}
 
-	// Build filter: exclude infra types and templates
+	issues, err := store.SearchIssues(ctx, "", autoExportFilter(ctx))
+	if err != nil {
+		return false, 0, fmt.Errorf("failed to search issues: %w", err)
+	}
+
+	return len(issues) == 0, existingCount, nil
+}
+
+func countIssueRecordsInJSONL(path string) (int, error) {
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+
+	count := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			return 0, err
+		}
+
+		if rawType, ok := raw["_type"]; ok {
+			var recordType string
+			if err := json.Unmarshal(rawType, &recordType); err == nil && recordType != "" && recordType != "issue" {
+				continue
+			}
+		}
+
+		var id string
+		if rawID, ok := raw["id"]; ok {
+			_ = json.Unmarshal(rawID, &id)
+		}
+		if id == "" {
+			continue
+		}
+
+		var status string
+		if rawStatus, ok := raw["status"]; ok {
+			_ = json.Unmarshal(rawStatus, &status)
+		}
+		if status == "tombstone" {
+			continue
+		}
+
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func autoExportFilter(ctx context.Context) types.IssueFilter {
 	filter := types.IssueFilter{Limit: 0}
 	var infraTypes []string
 	if store != nil {
@@ -182,7 +251,24 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 	persistentOnly := false
 	filter.Ephemeral = &persistentOnly
 
-	issues, err := store.SearchIssues(ctx, "", filter)
+	return filter
+}
+
+// exportToFile atomically exports issues + memories to the given file path.
+// Writes to a temp file first, then renames into place so readers never see
+// a partial or truncated export. Used by both `bd export -o` and auto-export.
+func exportToFile(ctx context.Context, path string, includeMemories bool) (issueCount, memoryCount int, err error) {
+	w, err := atomicfile.Create(path, 0o644)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to create export file: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = w.Abort()
+		}
+	}()
+
+	issues, err := store.SearchIssues(ctx, "", autoExportFilter(ctx))
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to search issues: %w", err)
 	}

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -599,3 +599,82 @@ func TestShouldExport(t *testing.T) {
 		})
 	}
 }
+
+func TestCountIssueRecordsInJSONL(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "issues.jsonl")
+	data := strings.Join([]string{
+		`{"_type":"issue","id":"bd-1","status":"open"}`,
+		`{"id":"bd-2","status":"closed"}`,
+		`{"_type":"memory","key":"note","value":"private"}`,
+		`{"_type":"issue","id":"bd-3","status":"tombstone"}`,
+		`{"_type":"issue","title":"missing id"}`,
+		``,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := countIssueRecordsInJSONL(path)
+	if err != nil {
+		t.Fatalf("countIssueRecordsInJSONL: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("countIssueRecordsInJSONL = %d, want 2", got)
+	}
+}
+
+func TestAutoExportSkipsEmptyExportOverPopulatedJSONL(t *testing.T) {
+	bd := buildBDForInitTests(t)
+	dir := t.TempDir()
+	env := autoExportDataLossTestEnv(dir)
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(bd, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd %v failed: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+
+	run("init", "--prefix", "dl", "--non-interactive")
+	run("config", "set", "export.path", "custom.jsonl")
+
+	jsonlPath := filepath.Join(dir, ".beads", "custom.jsonl")
+	original := []byte(`{"_type":"issue","id":"dl-1","title":"Recovered issue","priority":1,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}` + "\n")
+	if err := os.WriteFile(jsonlPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	run("config", "set", "export.auto", "true")
+	out := run("remember", "private context that should not be auto-exported")
+	if !strings.Contains(out, "refusing to overwrite") {
+		t.Fatalf("expected auto-export refusal warning, got:\n%s", out)
+	}
+
+	got, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatalf("expected populated JSONL to remain: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("populated JSONL was modified:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
+		t.Fatalf("empty skipped auto-export should not save export state, stat err=%v", err)
+	}
+}
+
+func autoExportDataLossTestEnv(home string) []string {
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "BEADS_") {
+			continue
+		}
+		env = append(env, e)
+	}
+	return append(env, "HOME="+home, "BEADS_DOLT_AUTO_START=0", "BEADS_NO_DAEMON=1")
+}


### PR DESCRIPTION
## Summary

- skip auto-export before writing when the current export would contain 0 issue records but the target JSONL already contains issues
- count existing JSONL issue records while ignoring memory, tombstone, and malformed issue-less records
- reuse the auto-export issue filter for both the preflight and the actual export

Fixes #4033.

## Tests

- `go test -tags gms_pure_go ./cmd/bd -run 'Test(ShouldExport|CountIssueRecordsInJSONL|AutoExportSkipsEmptyExportOverPopulatedJSONL)$'`\n\nNote: default `go test ./cmd/bd ...` cannot compile in this environment because ICU headers are unavailable (`unicode/uregex.h`).\n\n_codex-gpt-5.5-medium on behalf of matt wilkie_