### PR TITLE
fix(export): guard auto-export against richer JSONL overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **JSONL auto-export shrink guard** - when opt-in `export.auto` is enabled,
+  auto-export now refuses to overwrite an existing `.beads/issues.jsonl` that
+  contains records outside the auto-export scope (memories, infrastructure
+  beads, templates, ephemeral wisps, or unknown record types). This prevents
+  a viewer/interchange refresh from silently replacing a richer JSONL file
+  with the filtered auto-export subset. ([#4069](https://github.com/gastownhall/beads/issues/4069))
 - **`bd dolt status` reports externally-managed local servers truthfully** - when a rig is configured as `dolt_mode: server` pointing at a local host but `dolt.auto-start: false` (so an orchestrator or systemd owns the sql-server lifecycle), `bd dolt status` previously said `not running` because no PID file existed. It now SQL-probes the configured endpoint, matching the path already used for non-local hosts, and reports `running (external)` with host/port/database/version when the server answers. **JSON output shape change**: on affected rigs, `bd dolt status --json` now emits `{"running": true, "mode": "external", ...}` instead of `{"running": false, "pid": 0, ...}`. Automation that parsed the old `running:false` as a "needs restart" sentinel should switch to checking `running` directly. (be-0eyj, [#3550](https://github.com/gastownhall/beads/pull/3550))
 
 ## [1.0.4] - 2026-05-07

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -145,7 +146,7 @@ func shouldExport(state *exportAutoState, interval time.Duration) bool {
 
 // exportToFile atomically exports issues + memories to the given file path.
 // Writes to a temp file first, then renames into place so readers never see
-// a partial or truncated export. Used by both `bd export -o` and auto-export.
+// a partial or truncated export. Used by auto-export.
 func exportToFile(ctx context.Context, path string, includeMemories bool) (issueCount, memoryCount int, err error) {
 	w, err := atomicfile.Create(path, 0o644)
 	if err != nil {
@@ -171,7 +172,9 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 	if len(infraTypes) == 0 {
 		infraTypes = dolt.DefaultInfraTypes()
 	}
+	infraTypeSet := make(map[string]bool, len(infraTypes))
 	for _, t := range infraTypes {
+		infraTypeSet[t] = true
 		filter.ExcludeTypes = append(filter.ExcludeTypes, types.IssueType(t))
 	}
 	isTemplate := false
@@ -185,6 +188,10 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 	issues, err := store.SearchIssues(ctx, "", filter)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to search issues: %w", err)
+	}
+
+	if err := guardAutoExportOverwrite(path, infraTypeSet, includeMemories); err != nil {
+		return 0, 0, err
 	}
 
 	// Bulk-load relational data
@@ -270,6 +277,84 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 	}
 
 	return issueCount, memoryCount, nil
+}
+
+func guardAutoExportOverwrite(path string, infraTypes map[string]bool, includeMemories bool) error {
+	f, err := os.Open(path) //nolint:gosec
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("auto-export shrink guard: inspect existing JSONL: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var stats autoExportOverwriteStats
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if err := classifyExistingAutoExportRecord([]byte(line), infraTypes, includeMemories, &stats); err != nil {
+			return fmt.Errorf("auto-export shrink guard: inspect existing JSONL line %d: %w", lineNo, err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("auto-export shrink guard: inspect existing JSONL: %w", err)
+	}
+
+	if stats.FilteredRecords == 0 {
+		return nil
+	}
+	return fmt.Errorf("auto-export shrink guard: refusing to overwrite %s because it contains %d record(s) outside auto-export scope (%d memories, %d infra/template/ephemeral issues, %d unknown); run an explicit export if you want to replace it", path, stats.FilteredRecords, stats.Memories, stats.FilteredIssues, stats.UnknownRecords)
+}
+
+type autoExportOverwriteStats struct {
+	FilteredRecords int
+	Memories        int
+	FilteredIssues  int
+	UnknownRecords  int
+}
+
+func classifyExistingAutoExportRecord(line []byte, infraTypes map[string]bool, includeMemories bool, stats *autoExportOverwriteStats) error {
+	var record struct {
+		Type       string          `json:"_type"`
+		IssueType  types.IssueType `json:"issue_type"`
+		IsTemplate bool            `json:"is_template"`
+		Ephemeral  bool            `json:"ephemeral"`
+		ID         string          `json:"id"`
+	}
+	if err := json.Unmarshal(line, &record); err != nil {
+		return err
+	}
+
+	switch record.Type {
+	case "memory":
+		if !includeMemories {
+			stats.FilteredRecords++
+			stats.Memories++
+		}
+		return nil
+	case "", "issue":
+		if record.ID == "" {
+			stats.FilteredRecords++
+			stats.UnknownRecords++
+			return nil
+		}
+		if infraTypes[string(record.IssueType)] || record.IsTemplate || record.Ephemeral {
+			stats.FilteredRecords++
+			stats.FilteredIssues++
+		}
+		return nil
+	default:
+		stats.FilteredRecords++
+		stats.UnknownRecords++
+		return nil
+	}
 }
 
 func loadExportAutoState(beadsDir string) *exportAutoState {

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -185,6 +186,74 @@ func TestShouldRunPostCommandAutoExportSkipsReadOnlyCommands(t *testing.T) {
 	}
 	if !shouldRunPostCommandAutoExport(&cobra.Command{Use: "create"}) {
 		t.Fatal("write commands should still trigger post-command auto-export")
+	}
+}
+
+func TestGuardAutoExportOverwriteAllowsViewerScopedJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "issues.jsonl")
+	writeJSONLLines(t, path,
+		map[string]any{"_type": "issue", "id": "bd-1", "issue_type": "task", "title": "kept"},
+		map[string]any{"id": "bd-legacy", "issue_type": "bug", "title": "legacy issue record"},
+	)
+
+	if err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false); err != nil {
+		t.Fatalf("guardAutoExportOverwrite: %v", err)
+	}
+}
+
+func TestGuardAutoExportOverwriteBlocksRicherJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "issues.jsonl")
+	writeJSONLLines(t, path,
+		map[string]any{"_type": "issue", "id": "bd-1", "issue_type": "task", "title": "kept"},
+		map[string]any{"_type": "memory", "key": "keep-me", "value": "private context"},
+		map[string]any{"_type": "issue", "id": "bd-agent", "issue_type": "agent", "title": "infra"},
+		map[string]any{"_type": "issue", "id": "bd-template", "issue_type": "task", "is_template": true},
+		map[string]any{"_type": "issue", "id": "bd-wisp", "issue_type": "task", "ephemeral": true},
+		map[string]any{"_type": "event", "id": "bd-event"},
+	)
+
+	err := guardAutoExportOverwrite(path, map[string]bool{"agent": true}, false)
+	if err == nil {
+		t.Fatal("expected guardAutoExportOverwrite to reject richer JSONL, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"refusing to overwrite",
+		"5 record(s) outside auto-export scope",
+		"1 memories",
+		"3 infra/template/ephemeral issues",
+		"1 unknown",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("guard error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestGuardAutoExportOverwriteAllowsMemoriesWhenIncluded(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "issues.jsonl")
+	writeJSONLLines(t, path,
+		map[string]any{"_type": "memory", "key": "keep-me", "value": "private context"},
+	)
+
+	if err := guardAutoExportOverwrite(path, nil, true); err != nil {
+		t.Fatalf("guardAutoExportOverwrite with memories included: %v", err)
+	}
+}
+
+func writeJSONLLines(t *testing.T, path string, records ...map[string]any) {
+	t.Helper()
+	var b strings.Builder
+	for _, rec := range records {
+		data, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(data)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an auto-export shrink guard that refuses to overwrite existing JSONL containing records outside auto-export scope
- classify memories, infra/template/ephemeral issues, and unknown record types as richer than viewer-scoped auto-export
- document the user-visible guard in the changelog

Fixes #4069

## Test plan
- `go test -tags gms_pure_go ./cmd/bd -run 'TestGuardAutoExportOverwrite|TestShouldExport|TestShouldRunPostCommandAutoExport' -count=1`\n- `go test -tags gms_pure_go ./cmd/bd` (fails in existing/environment-sensitive tests: missing ICU headers for nested build, Dolt test DB setup failures, import/comment regressions)\n\n_codex-gpt-5.5-medium on behalf of matt wilkie_