### PR TITLE
Make auto-export git add lock-aware

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -30,6 +30,7 @@ type exportAutoState struct {
 }
 
 const exportAutoStateFile = "export-state.json"
+const gitAddTimeout = 5 * time.Second
 
 // maybeAutoExport writes a git-tracked JSONL file if enabled and due.
 // Called from PersistentPostRun after auto-backup.
@@ -395,13 +396,30 @@ func gitAddFile(path string) error {
 		// Staging here would pollute a different repo's index; skip.
 		return nil
 	}
-	cmd := exec.Command("git", "add", path)
+
+	env := scrubGitHookEnv(os.Environ())
+	if lockPath, err := gitIndexLockPath(path, env); err == nil && lockPath != "" {
+		if _, statErr := os.Stat(lockPath); statErr == nil {
+			return fmt.Errorf("git index is locked at %s; skipping auto-stage", lockPath)
+		} else if !os.IsNotExist(statErr) {
+			return fmt.Errorf("failed to check git index lock %s: %w", lockPath, statErr)
+		}
+	} else if err != nil {
+		debug.Logf("auto-export: git add lock preflight skipped: %v\n", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), gitAddTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "add", path)
 	cmd.Dir = filepath.Dir(path)
-	cmd.Env = scrubGitHookEnv(os.Environ())
+	cmd.Env = env
 	// Capture combined output so the caller's warning surfaces git's stderr
 	// (e.g. "paths are ignored", "Unable to create index.lock") instead of
 	// just the exit-status text.
 	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("git add timed out after %s", gitAddTimeout)
+	}
 	if err != nil {
 		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
 			return fmt.Errorf("%w: %s", err, trimmed)
@@ -409,6 +427,32 @@ func gitAddFile(path string) error {
 		return err
 	}
 	return nil
+}
+
+func gitIndexLockPath(path string, env []string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitAddTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
+	cmd.Dir = filepath.Dir(path)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("git rev-parse timed out after %s", gitAddTimeout)
+	}
+	if err != nil {
+		if trimmed := strings.TrimSpace(string(out)); trimmed != "" {
+			return "", fmt.Errorf("%w: %s", err, trimmed)
+		}
+		return "", err
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if gitDir == "" {
+		return "", nil
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(filepath.Dir(path), gitDir)
+	}
+	return filepath.Join(gitDir, "index.lock"), nil
 }
 
 // scrubGitHookEnv returns env with the GIT_* variables that can poison

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -435,6 +435,74 @@ func TestGitAddFile_CapturesStderrOnFailure(t *testing.T) {
 	}
 }
 
+func TestGitAddFile_SkipsWhenIndexLocked(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "bd-index-lock-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = repo
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+
+	target := filepath.Join(repo, ".beads", "issues.jsonl")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte(`{"id":"x"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := filepath.Join(repo, ".git", "index.lock")
+	if err := os.WriteFile(lockPath, []byte("held by another git process"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Unsetenv("GIT_DIR"); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repo)
+
+	err = gitAddFile(target)
+	if err == nil {
+		t.Fatal("expected gitAddFile to fail while index.lock exists, got nil")
+	}
+	if msg := err.Error(); !strings.Contains(msg, "index is locked") || !strings.Contains(msg, "index.lock") {
+		t.Fatalf("expected index.lock error, got: %q", msg)
+	}
+
+	c := exec.Command("git", "ls-files", "--stage")
+	c.Dir = repo
+	data, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ls-files: %v\n%s", err, data)
+	}
+	if strings.Contains(string(data), ".beads/issues.jsonl") {
+		t.Fatalf("gitAddFile staged target despite index.lock:\n%s", data)
+	}
+}
+
 // TestGitAddFile_RedirectCase_DoesNotStageInMainRepo regresses the
 // silent-stage-in-main follow-up from the GH#3311 review: when a worktree
 // has .beads/redirect -> main/.beads, the worktree's pre-commit hook must


### PR DESCRIPTION
## Summary
- preflight auto-export git add for an existing Git index lock
- bound git rev-parse/git add with a timeout so opted-in auto-stage does not hang indefinitely
- add regression coverage for index.lock contention

## Validation
- `go test -tags gms_pure_go ./cmd/bd -run 'TestGitAddFile|TestScrubGitHookEnv|TestPathInsideDir|TestHookWorkTreeRoot|TestShouldExport'`\n\nRefs gastownhall/beads#3606.\n\n_codex-gpt-5.5-medium on behalf of maphew_