### PR TITLE
Guard auto-export against JSONL-only records

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -99,6 +99,13 @@ func maybeAutoExport(ctx context.Context) {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: current database would export 0 issues, but %s already contains %d issue(s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, existingCount)
 		return
 	}
+	if missingIDs, err := missingJSONLIssueIDsInStore(ctx, fullPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to compare existing JSONL against local store: %v\n", err)
+		return
+	} else if len(missingIDs) > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: %s contains %d JSONL-only issue record(s) absent from the local Dolt store (%s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, len(missingIDs), strings.Join(sampleStrings(missingIDs, 5), ", "))
+		return
+	}
 
 	// Run the export — memories are excluded from auto-export because they
 	// contain private agent context that must not reach git history (GH#3650).
@@ -170,19 +177,55 @@ func shouldSkipEmptyAutoExport(ctx context.Context, path string) (bool, int, err
 }
 
 func countIssueRecordsInJSONL(path string) (int, error) {
+	ids, err := issueIDsInJSONL(path)
+	if err != nil {
+		return 0, err
+	}
+	return len(ids), nil
+}
+
+func missingJSONLIssueIDsInStore(ctx context.Context, path string) ([]string, error) {
+	existingIDs, err := issueIDsInJSONL(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(existingIDs) == 0 {
+		return nil, nil
+	}
+
+	issues, err := store.SearchIssues(ctx, "", types.IssueFilter{Limit: 0})
+	if err != nil {
+		return nil, fmt.Errorf("failed to search issues: %w", err)
+	}
+	localIDs := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		localIDs[issue.ID] = struct{}{}
+	}
+
+	missing := make([]string, 0)
+	for _, id := range existingIDs {
+		if _, ok := localIDs[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing, nil
+}
+
+func issueIDsInJSONL(path string) ([]string, error) {
 	f, err := os.Open(path) //nolint:gosec
 	if err != nil {
 		if os.IsNotExist(err) {
-			return 0, nil
+			return nil, nil
 		}
-		return 0, err
+		return nil, err
 	}
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
 
-	count := 0
+	seen := make(map[string]struct{})
+	var ids []string
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -191,7 +234,7 @@ func countIssueRecordsInJSONL(path string) (int, error) {
 
 		var raw map[string]json.RawMessage
 		if err := json.Unmarshal([]byte(line), &raw); err != nil {
-			return 0, err
+			return nil, err
 		}
 
 		if rawType, ok := raw["_type"]; ok {
@@ -217,13 +260,27 @@ func countIssueRecordsInJSONL(path string) (int, error) {
 			continue
 		}
 
-		count++
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
 	}
 	if err := scanner.Err(); err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return count, nil
+	sort.Strings(ids)
+	return ids, nil
+}
+
+func sampleStrings(values []string, limit int) []string {
+	if len(values) <= limit {
+		return values
+	}
+	out := append([]string{}, values[:limit]...)
+	out = append(out, "...")
+	return out
 }
 
 func autoExportFilter(ctx context.Context) types.IssueFilter {

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -606,6 +606,7 @@ func TestCountIssueRecordsInJSONL(t *testing.T) {
 	data := strings.Join([]string{
 		`{"_type":"issue","id":"bd-1","status":"open"}`,
 		`{"id":"bd-2","status":"closed"}`,
+		`{"_type":"issue","id":"bd-2","status":"closed"}`,
 		`{"_type":"memory","key":"note","value":"private"}`,
 		`{"_type":"issue","id":"bd-3","status":"tombstone"}`,
 		`{"_type":"issue","title":"missing id"}`,
@@ -621,6 +622,14 @@ func TestCountIssueRecordsInJSONL(t *testing.T) {
 	}
 	if got != 2 {
 		t.Fatalf("countIssueRecordsInJSONL = %d, want 2", got)
+	}
+
+	ids, err := issueIDsInJSONL(path)
+	if err != nil {
+		t.Fatalf("issueIDsInJSONL: %v", err)
+	}
+	if got := strings.Join(ids, ","); got != "bd-1,bd-2" {
+		t.Fatalf("issueIDsInJSONL = %q, want bd-1,bd-2", got)
 	}
 }
 
@@ -665,6 +674,56 @@ func TestAutoExportSkipsEmptyExportOverPopulatedJSONL(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
 		t.Fatalf("empty skipped auto-export should not save export state, stat err=%v", err)
+	}
+}
+
+func TestAutoExportSkipsWhenExistingJSONLHasIDsMissingFromStore(t *testing.T) {
+	bd := buildBDForInitTests(t)
+	dir := t.TempDir()
+	env := autoExportDataLossTestEnv(dir)
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(bd, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd %v failed: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+
+	run("init", "--prefix", "dl", "--non-interactive")
+	run("config", "set", "export.path", "custom.jsonl")
+	run("create", "local issue", "-p", "2")
+
+	jsonlPath := filepath.Join(dir, ".beads", "custom.jsonl")
+	original := []byte(strings.Join([]string{
+		`{"_type":"issue","id":"dl-1","title":"Local issue","priority":2,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`,
+		`{"_type":"issue","id":"dl-jsonl-only","title":"Only in JSONL","priority":1,"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}`,
+		``,
+	}, "\n"))
+	if err := os.WriteFile(jsonlPath, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	run("config", "set", "export.interval", "1ms")
+	run("config", "set", "export.auto", "true")
+	out := run("create", "another local issue", "-p", "2")
+	if !strings.Contains(out, "JSONL-only issue record") || !strings.Contains(out, "dl-jsonl-only") {
+		t.Fatalf("expected JSONL-only refusal warning, got:\n%s", out)
+	}
+
+	got, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatalf("expected JSONL to remain: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("JSONL-only records were overwritten:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
+		t.Fatalf("skipped auto-export should not save export state, stat err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- compare existing JSONL issue IDs against the local Dolt store before auto-export
- refuse auto-export with a machine-detectable warning when JSONL-only issue records would be dropped
- add regression coverage preserving the existing JSONL file

## Validation
- `go test -tags gms_pure_go ./cmd/bd -run 'TestCountIssueRecordsInJSONL|TestAutoExportSkips'`\n\nRefs gastownhall/beads#3931.\n\n_codex-gpt-5.5-medium on behalf of maphew_