### PR TITLE
fix: guard JSONL auto import/export edge cases

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -41,7 +41,11 @@ var fallbackImporter = importFromLocalJSONLFull
 //
 // The function is best-effort: failures are logged as warnings but do not
 // prevent the store from being used.
-func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir string) {
+func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir string, serverMode bool) {
+	if serverMode {
+		return
+	}
+
 	// Quick check: does the JSONL file exist and have content?
 	jsonlPath := configuredImportJSONLPath(beadsDir)
 	info, err := os.Stat(jsonlPath)

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -81,10 +81,22 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty(t *testing.T)
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
 
 	store := &fakeFallbackStore{statsTotalIssues: 5}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("regression: server-mode fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
+	}
+}
+
+func TestMaybeAutoImportJSONL_SkipsEntirelyInServerMode(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	count := swapFallbackImporter(t, errors.New("test importer should not run"))
+
+	maybeAutoImportJSONL(context.Background(), nil, dir, true)
+
+	if got := count.Load(); got != 0 {
+		t.Fatalf("server-mode auto-import invoked fallback importer %d time(s); expected 0", got)
 	}
 }
 
@@ -97,7 +109,7 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenStatisticsNil(t *testi
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
 
 	store := &fakeFallbackStore{statsNil: true}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("server-mode fallback importer was invoked %d time(s) when statistics were nil; expected 0", got)
@@ -117,7 +129,7 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty(t *testing.T) {
 	count := swapFallbackImporter(t, errors.New("test importer: short-circuit before s.Commit"))
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	if got := count.Load(); got != 1 {
 		t.Fatalf("server-mode fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
@@ -140,7 +152,7 @@ func TestMaybeAutoImportJSONL_UsesConfiguredImportPath(t *testing.T) {
 	t.Cleanup(func() { fallbackImporter = orig })
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir)
+	maybeAutoImportJSONL(context.Background(), store, dir, false)
 
 	wantPath := filepath.Join(dir, "beads.jsonl")
 	if gotPath != wantPath {

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -34,7 +34,12 @@ const gitAddTimeout = 5 * time.Second
 
 // maybeAutoExport writes a git-tracked JSONL file if enabled and due.
 // Called from PersistentPostRun after auto-backup.
-func maybeAutoExport(ctx context.Context) {
+func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) {
+	if serverMode {
+		debug.Logf("auto-export: skipping — server mode\n")
+		return
+	}
+
 	// Skip when running as a git hook to avoid re-export during pre-commit.
 	if os.Getenv("BD_GIT_HOOK") == "1" {
 		debug.Logf("auto-export: skipping — running as git hook\n")
@@ -93,19 +98,23 @@ func maybeAutoExport(ctx context.Context) {
 		return
 	}
 
-	if skip, existingCount, err := shouldSkipEmptyAutoExport(ctx, fullPath); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to check existing JSONL: %v\n", err)
-		return
-	} else if skip {
-		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: current database would export 0 issues, but %s already contains %d issue(s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, existingCount)
-		return
+	if !allowEmptyOverwrite {
+		if skip, existingCount, err := shouldSkipEmptyAutoExport(ctx, fullPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to check existing JSONL: %v\n", err)
+			return
+		} else if skip {
+			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: current database would export 0 issues, but %s already contains %d issue(s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, existingCount)
+			return
+		}
 	}
-	if missingIDs, err := missingJSONLIssueIDsInStore(ctx, fullPath); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to compare existing JSONL against local store: %v\n", err)
-		return
-	} else if len(missingIDs) > 0 {
-		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: %s contains %d JSONL-only issue record(s) absent from the local Dolt store (%s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, len(missingIDs), strings.Join(sampleStrings(missingIDs, 5), ", "))
-		return
+	if !allowEmptyOverwrite {
+		if missingIDs, err := missingJSONLIssueIDsInStore(ctx, fullPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to compare existing JSONL against local store: %v\n", err)
+			return
+		} else if len(missingIDs) > 0 {
+			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: %s contains %d JSONL-only issue record(s) absent from the local Dolt store (%s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, len(missingIDs), strings.Join(sampleStrings(missingIDs, 5), ", "))
+			return
+		}
 	}
 
 	// Run the export — memories are excluded from auto-export because they
@@ -126,6 +135,12 @@ func maybeAutoExport(ctx context.Context) {
 	// issues.jsonl before any issues exist.
 	if issueCount == 0 && memoryCount == 0 {
 		_ = os.Remove(fullPath)
+		saveExportAutoState(beadsDir, &exportAutoState{
+			LastDoltCommit: currentCommit,
+			Timestamp:      time.Now(),
+			Issues:         0,
+			Memories:       0,
+		})
 		return
 	}
 	warnJSONLWithoutDoltRemote("auto-export")

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -617,6 +617,76 @@ func TestGitAddFile_RedirectCase_DoesNotStageInMainRepo(t *testing.T) {
 	checkNoStage("main", mainRepo)
 }
 
+func TestPreCommitHasStagedBeadsFiles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "bd-staged-beads-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	tmpDir, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = repo
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+	runGit("config", "user.email", "t@t")
+	runGit("config", "user.name", "t")
+
+	readme := filepath.Join(repo, "README.md")
+	if err := os.WriteFile(readme, []byte("code\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "README.md")
+	if preCommitHasStagedBeadsFiles(filepath.Join(repo, ".beads")) {
+		t.Fatal("staged non-.beads file should not trigger pre-commit JSONL export")
+	}
+
+	configPath := filepath.Join(repo, ".beads", "config.yaml")
+	if err := os.WriteFile(configPath, []byte("export:\n  auto: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", ".beads/config.yaml")
+	if !preCommitHasStagedBeadsFiles(filepath.Join(repo, ".beads")) {
+		t.Fatal("staged .beads file should trigger pre-commit JSONL export")
+	}
+}
+
+func TestCommandAllowsEmptyAutoExport(t *testing.T) {
+	commandMayEmptyJSONLExport.Store(false)
+	t.Cleanup(func() { commandMayEmptyJSONLExport.Store(false) })
+
+	if commandAllowsEmptyAutoExport(&cobra.Command{Use: "prune"}) {
+		t.Fatal("prune should not allow an empty auto-export before deleting rows")
+	}
+
+	commandMayEmptyJSONLExport.Store(true)
+	if !commandAllowsEmptyAutoExport(&cobra.Command{Use: "prune"}) {
+		t.Fatal("prune should allow an intentional empty auto-export")
+	}
+	if !commandAllowsEmptyAutoExport(&cobra.Command{Use: "purge"}) {
+		t.Fatal("purge should allow an intentional empty auto-export")
+	}
+	if commandAllowsEmptyAutoExport(&cobra.Command{Use: "create"}) {
+		t.Fatal("create should not bypass empty auto-export protection")
+	}
+}
+
 // TestShouldExport covers the pure throttle-window decision used by
 // maybeAutoExport. Adapted from Jeremy Longshore's GH#4061 refactor.
 func TestShouldExport(t *testing.T) {

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -1347,6 +1347,10 @@ func exportJSONLForCommit() {
 		exportPath = "issues.jsonl"
 	}
 	fullPath := filepath.Join(beadsDir, exportPath)
+	if !preCommitHasStagedBeadsFiles(beadsDir) {
+		debug.Logf("pre-commit: skipping JSONL export — no staged .beads paths\n")
+		return
+	}
 
 	debug.Logf("pre-commit: exporting JSONL to %s\n", fullPath)
 	warnJSONLWithoutDoltRemote("pre-commit auto-export")
@@ -1382,6 +1386,22 @@ func exportJSONLForCommit() {
 			debug.Logf("pre-commit: git add failed: %v\n", err)
 		}
 	}
+}
+
+func preCommitHasStagedBeadsFiles(beadsDir string) bool {
+	cmdDir := exportSubprocessDir(beadsDir)
+	if hookRoot := hookWorkTreeRoot(); hookRoot != "" {
+		cmdDir = hookRoot
+	}
+	cmd := exec.Command("git", "diff", "--cached", "--name-only", "--", ".beads")
+	cmd.Dir = cmdDir
+	cmd.Env = scrubGitHookEnv(os.Environ())
+	out, err := cmd.Output()
+	if err != nil {
+		debug.Logf("pre-commit: failed to inspect staged .beads paths: %v\n", err)
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
 }
 
 func exportSubprocessDir(beadsDir string) string {

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -89,6 +89,11 @@ var (
 	// Thread-safe via atomic.Bool to avoid data races in concurrent flush operations.
 	commandDidWrite atomic.Bool
 
+	// commandMayEmptyJSONLExport is set by destructive maintenance commands
+	// after they actually delete rows, allowing post-run auto-export to record
+	// an intentional empty JSONL artifact instead of treating it as ambiguous.
+	commandMayEmptyJSONLExport atomic.Bool
+
 	// commandDidExplicitDoltCommit is set when a command already created a Dolt commit
 	// explicitly (e.g., bd sync in dolt-native mode, hook flows, bd vc commit).
 	// This prevents a redundant auto-commit attempt in PersistentPostRun.
@@ -602,6 +607,7 @@ var rootCmd = &cobra.Command{
 
 		// Reset per-command write tracking (used by Dolt auto-commit).
 		commandDidWrite.Store(false)
+		commandMayEmptyJSONLExport.Store(false)
 		commandDidExplicitDoltCommit = false
 		commandDidWriteTipMetadata = false
 		commandTipIDsShown = make(map[string]struct{})
@@ -1048,7 +1054,7 @@ var rootCmd = &cobra.Command{
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
 		if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" {
-			maybeAutoImportJSONL(rootCtx, store, beadsDir)
+			maybeAutoImportJSONL(rootCtx, store, beadsDir, doltCfg.ServerMode)
 		}
 
 		// Validate workspace identity for write commands (GH#2438, GH#2372)
@@ -1148,7 +1154,7 @@ var rootCmd = &cobra.Command{
 			// Read-only commands must not perform post-run maintenance writes or emit
 			// sync guidance after machine-readable output.
 			if shouldRunPostCommandAutoExport(cmd) {
-				maybeAutoExport(rootCtx)
+				maybeAutoExport(rootCtx, serverMode, commandAllowsEmptyAutoExport(cmd))
 			}
 
 			// Auto-push: push to Dolt remote if enabled and due.
@@ -1198,6 +1204,18 @@ func shouldRunPostCommandAutoExport(cmd *cobra.Command) bool {
 		return true
 	}
 	return !isReadOnlyCommand(cmd.Name())
+}
+
+func commandAllowsEmptyAutoExport(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	switch cmd.Name() {
+	case "prune", "purge":
+		return commandMayEmptyJSONLExport.Load()
+	default:
+		return false
+	}
 }
 
 // blockedEnvVars lists environment variables that must not be set because they

--- a/cmd/bd/prune_embedded_test.go
+++ b/cmd/bd/prune_embedded_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -88,6 +89,44 @@ func TestEmbeddedPrune(t *testing.T) {
 		listing := bdList(t, bd, dir, "--status=closed", "--json")
 		if strings.Contains(listing, target) {
 			t.Errorf("expected %s to be deleted, still present in: %s", target, listing)
+		}
+	})
+
+	t.Run("prune_last_issue_removes_gitignored_auto_export", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "pjx")
+		if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".beads/\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"config", "set", "export.auto", "true"},
+			{"config", "set", "export.git-add", "true"},
+		} {
+			cmd := exec.Command(bd, args...)
+			cmd.Dir = dir
+			cmd.Env = bdEnv(dir)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("bd %s failed: %v\n%s", strings.Join(args, " "), err, out)
+			}
+		}
+
+		target := createAndClose(t, bd, dir, "Closed exported task")
+		jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+		cmd := exec.Command(bd, "export", "-o", jsonlPath)
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("bd export failed: %v\n%s", err, out)
+		}
+		if _, err := os.Stat(jsonlPath); err != nil {
+			t.Fatalf("expected stale JSONL before prune: %v", err)
+		}
+		if err := os.Remove(filepath.Join(beadsDir, exportAutoStateFile)); err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+
+		bdPrune(t, bd, dir, "--pattern", target, "--force")
+		if _, err := os.Stat(jsonlPath); !os.IsNotExist(err) {
+			t.Fatalf("expected prune of last issue to remove stale JSONL, stat err=%v", err)
 		}
 	})
 

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -263,6 +263,7 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 
 	if result.DeletedCount > 0 {
 		commandDidWrite.Store(true)
+		commandMayEmptyJSONLExport.Store(true)
 	}
 }
 


### PR DESCRIPTION
## Summary
- skip JSONL auto-import and auto-export entirely in server mode
- skip pre-commit JSONL auto-export unless the pending commit already stages .beads paths
- let prune/purge that actually delete rows record intentional empty JSONL removal, including gitignored opt-in JSONL workflows

## Validation
- go test -tags gms_pure_go -run 'TestMaybeAutoImportJSONL|TestPreCommitHasStagedBeadsFiles|TestCommandAllowsEmptyAutoExport|TestShouldRunPostCommandAutoExport|TestShouldExport|TestGitAddFile' ./cmd/bd
- go test -tags gms_pure_go -run '^$' ./cmd/bd
- git diff --check

Full package note: go test -tags gms_pure_go ./cmd/bd was attempted, but this local environment hit unrelated integration prerequisites: missing ICU headers for an inner CGO build, a shared Dolt server port conflict, and existing integration test failures outside this change.

Fixes follow-up scope for #4038, #3962, and #3944.

_codex-gpt-5.5-medium on behalf of matt wilkie_