### PR TITLE
fix(export): fail on auto-export git add errors

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -34,31 +34,31 @@ const gitAddTimeout = 5 * time.Second
 
 // maybeAutoExport writes a git-tracked JSONL file if enabled and due.
 // Called from PersistentPostRun after auto-backup.
-func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) {
+func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) error {
 	if serverMode {
 		debug.Logf("auto-export: skipping — server mode\n")
-		return
+		return nil
 	}
 
 	// Skip when running as a git hook to avoid re-export during pre-commit.
 	if os.Getenv("BD_GIT_HOOK") == "1" {
 		debug.Logf("auto-export: skipping — running as git hook\n")
-		return
+		return nil
 	}
 
 	if !config.GetBool("export.auto") {
-		return
+		return nil
 	}
 	if store == nil {
-		return
+		return nil
 	}
 	if lm, ok := storage.UnwrapStore(store).(storage.LifecycleManager); ok && lm.IsClosed() {
-		return
+		return nil
 	}
 
 	beadsDir := beads.FindBeadsDir()
 	if beadsDir == "" {
-		return
+		return nil
 	}
 
 	// Resolve the export path before throttle/check detection so all decisions
@@ -85,35 +85,35 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	currentCommit, err := store.GetCurrentCommit(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to get current commit: %v\n", err)
-		return
+		return nil
 	}
 	if currentCommit == state.LastDoltCommit && state.LastDoltCommit != "" {
 		debug.Logf("auto-export: no changes since last export\n")
-		return
+		return nil
 	}
 
 	if !shouldExport(state, interval) {
 		debug.Logf("auto-export: throttled (last export %s ago, interval %s)\n",
 			time.Since(state.Timestamp).Round(time.Second), interval)
-		return
+		return nil
 	}
 
 	if !allowEmptyOverwrite {
 		if skip, existingCount, err := shouldSkipEmptyAutoExport(ctx, fullPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to check existing JSONL: %v\n", err)
-			return
+			return nil
 		} else if skip {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: current database would export 0 issues, but %s already contains %d issue(s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, existingCount)
-			return
+			return nil
 		}
 	}
 	if !allowEmptyOverwrite {
 		if missingIDs, err := missingJSONLIssueIDsInStore(ctx, fullPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to compare existing JSONL against local store: %v\n", err)
-			return
+			return nil
 		} else if len(missingIDs) > 0 {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: %s contains %d JSONL-only issue record(s) absent from the local Dolt store (%s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, len(missingIDs), strings.Join(sampleStrings(missingIDs, 5), ", "))
-			return
+			return nil
 		}
 	}
 
@@ -122,7 +122,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	issueCount, memoryCount, err := exportToFile(ctx, fullPath, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export failed: %v\n", err)
-		return
+		return nil
 	}
 
 	debug.Logf("auto-export: wrote %d issues and %d memories to %s\n",
@@ -141,7 +141,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 			Issues:         0,
 			Memories:       0,
 		})
-		return
+		return nil
 	}
 	warnJSONLWithoutDoltRemote("auto-export")
 
@@ -149,7 +149,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	// git repo (standalone BEADS_DIR flow), or when export.git-add is false.
 	if config.GetBool("export.git-add") && !config.GetBool("no-git-ops") && isGitRepo() {
 		if err := gitAddFile(fullPath); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: auto-export: git add failed: %v\n", err)
+			return fmt.Errorf("auto-export: git add failed: %w", err)
 		}
 	}
 
@@ -161,6 +161,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 		Memories:       memoryCount,
 	}
 	saveExportAutoState(beadsDir, &newState)
+	return nil
 }
 
 // shouldExport reports whether the throttle window has elapsed, or whether

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -504,7 +504,9 @@ func TestGitAddFile_CapturesStderrOnFailure(t *testing.T) {
 	}
 }
 
-func TestGitAddFile_SkipsWhenIndexLocked(t *testing.T) {
+// TestGitAddFile_CapturesLockedIndexFailure verifies that a locked git index
+// is surfaced as a rich, caller-visible error rather than a bare exit status.
+func TestGitAddFile_CapturesLockedIndexFailure(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -569,6 +571,68 @@ func TestGitAddFile_SkipsWhenIndexLocked(t *testing.T) {
 	}
 	if strings.Contains(string(data), ".beads/issues.jsonl") {
 		t.Fatalf("gitAddFile staged target despite index.lock:\n%s", data)
+	}
+}
+
+func TestAutoExportGitAddFailureExitsNonZero(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	bd := buildBDForInitTests(t)
+	dir := t.TempDir()
+	env := append(autoExportDataLossTestEnv(dir), "BD_NON_INTERACTIVE=1")
+
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(bd, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd %v failed: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+
+	run("init", "--prefix", "agf", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".beads/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("config", "set", "export.interval", "1ms")
+	run("config", "set", "export.auto", "true")
+	run("config", "set", "export.git-add", "true")
+	if err := os.Remove(filepath.Join(dir, ".beads", exportAutoStateFile)); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	cmd := exec.Command(bd, "create", "caller visible git add failure", "-p", "2")
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("bd create succeeded despite auto-export git add failure:\n%s", out)
+	}
+	output := string(out)
+	if !strings.Contains(output, "Error: auto-export: git add failed") {
+		t.Fatalf("expected caller-visible auto-export git add error, got:\n%s", output)
+	}
+	if !strings.Contains(strings.ToLower(output), "ignored") {
+		t.Fatalf("expected git add stderr to explain ignored path, got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
+		t.Fatalf("git-add failure should not save export state, stat err=%v", err)
 	}
 }
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1154,7 +1154,9 @@ var rootCmd = &cobra.Command{
 			// Read-only commands must not perform post-run maintenance writes or emit
 			// sync guidance after machine-readable output.
 			if shouldRunPostCommandAutoExport(cmd) {
-				maybeAutoExport(rootCtx, serverMode, commandAllowsEmptyAutoExport(cmd))
+				if err := maybeAutoExport(rootCtx, serverMode, commandAllowsEmptyAutoExport(cmd)); err != nil {
+					FatalError("%v", err)
+				}
 			}
 
 			// Auto-push: push to Dolt remote if enabled and due.


### PR DESCRIPTION
## Summary
- surface opted-in auto-export git-add failures through the CLI error path
- leave auto-export state unsaved after staging failure so the next run can retry
- add regressions for ignored paths and locked git indexes

Fixes #3970.

## Validation
- `go test -tags gms_pure_go ./cmd/bd -run 'Test(GitAddFile_CapturesLockedIndexFailure|AutoExportGitAddFailureExitsNonZero|GitAddFile_CapturesStderrOnFailure)' -count=1` -> `ok github.com/steveyegge/beads/cmd/bd 89.991s`
- `git diff --check HEAD~1..HEAD` -> passed

_codex-gpt-5.5-medium on behalf of matt wilkie_