### PR TITLE
fix(export): fail on auto-export git add errors (maintainer cherry-pick from PR #4092)

### DIFF
--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -142,7 +142,18 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	// git repo (standalone BEADS_DIR flow), or when export.git-add is false.
 	if config.GetBool("export.git-add") && !config.GetBool("no-git-ops") && isGitRepo() {
 		if err := gitAddFile(fullPath); err != nil {
-			return fmt.Errorf("auto-export: git add failed: %w", err)
+			// A gitignored .beads/ is a supported workflow: the JSONL export is
+			// written for local use / Dolt sync but intentionally left untracked,
+			// so `git add` can never stage it. That is not a failure and must not
+			// abort the command. Only genuine staging failures — e.g. a locked
+			// index, the real GH#3970 repro — are fatal. See be-1wzr / PR #4098
+			// for the contract decision; the gitignored-success path is regressed
+			// by TestEmbeddedPrune/prune_last_issue_removes_gitignored_auto_export.
+			if pathIsGitIgnored(fullPath) {
+				debug.Logf("auto-export: %s is gitignored; skipping git add\n", fullPath)
+			} else {
+				return fmt.Errorf("auto-export: git add failed: %w", err)
+			}
 		}
 	}
 
@@ -493,6 +504,26 @@ func gitAddFile(path string) error {
 		return err
 	}
 	return nil
+}
+
+// pathIsGitIgnored reports whether path is excluded by a .gitignore rule in
+// the enclosing repo. It is used by auto-export to classify a gitAddFile
+// failure: a gitignored .beads/ is a supported workflow (the JSONL export is
+// intentionally untracked), so failing to stage it must be benign, whereas a
+// real staging failure such as a locked index stays fatal (be-1wzr / PR #4098).
+//
+// `git check-ignore -q` exits 0 when the path is ignored, 1 when it is not,
+// and 128 on error. Anything other than a clean exit 0 is treated as "not
+// ignored" so genuine failures are never masked. The git-hook env is scrubbed
+// and the command runs from the file's directory, mirroring gitAddFile so the
+// ignore decision matches the repo `git add` actually consulted.
+func pathIsGitIgnored(path string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), gitAddTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "check-ignore", "-q", "--", path)
+	cmd.Dir = filepath.Dir(path)
+	cmd.Env = scrubGitHookEnv(os.Environ())
+	return cmd.Run() == nil
 }
 
 func gitIndexLockPath(path string, env []string) (string, error) {

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -34,31 +34,30 @@ const gitAddTimeout = 5 * time.Second
 
 // maybeAutoExport writes a git-tracked JSONL file if enabled and due.
 // Called from PersistentPostRun after auto-backup.
-func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) {
+func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) error {
 	if serverMode {
 		debug.Logf("auto-export: skipping — server mode\n")
-		return
+		return nil
 	}
-
 	// Skip when running as a git hook to avoid re-export during pre-commit.
 	if os.Getenv("BD_GIT_HOOK") == "1" {
 		debug.Logf("auto-export: skipping — running as git hook\n")
-		return
+		return nil
 	}
 
 	if !config.GetBool("export.auto") {
-		return
+		return nil
 	}
 	if store == nil {
-		return
+		return nil
 	}
 	if lm, ok := storage.UnwrapStore(store).(storage.LifecycleManager); ok && lm.IsClosed() {
-		return
+		return nil
 	}
 
 	beadsDir := beads.FindBeadsDir()
 	if beadsDir == "" {
-		return
+		return nil
 	}
 
 	// Resolve the export path before throttle/check detection so all decisions
@@ -85,35 +84,35 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	currentCommit, err := store.GetCurrentCommit(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to get current commit: %v\n", err)
-		return
+		return nil
 	}
 	if currentCommit == state.LastDoltCommit && state.LastDoltCommit != "" {
 		debug.Logf("auto-export: no changes since last export\n")
-		return
+		return nil
 	}
 
 	if !shouldExport(state, interval) {
 		debug.Logf("auto-export: throttled (last export %s ago, interval %s)\n",
 			time.Since(state.Timestamp).Round(time.Second), interval)
-		return
+		return nil
 	}
 
 	if !allowEmptyOverwrite {
 		if skip, existingCount, err := shouldSkipEmptyAutoExport(ctx, fullPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to check existing JSONL: %v\n", err)
-			return
+			return nil
 		} else if skip {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: current database would export 0 issues, but %s already contains %d issue(s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, existingCount)
-			return
+			return nil
 		}
 	}
 	if !allowEmptyOverwrite {
 		if missingIDs, err := missingJSONLIssueIDsInStore(ctx, fullPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: failed to compare existing JSONL against local store: %v\n", err)
-			return
+			return nil
 		} else if len(missingIDs) > 0 {
 			fmt.Fprintf(os.Stderr, "Warning: auto-export skipped: %s contains %d JSONL-only issue record(s) absent from the local Dolt store (%s); refusing to overwrite. Run `bd init --from-jsonl` to import the JSONL file, or move it aside and retry.\n", fullPath, len(missingIDs), strings.Join(sampleStrings(missingIDs, 5), ", "))
-			return
+			return nil
 		}
 	}
 
@@ -122,7 +121,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	issueCount, memoryCount, err := exportToFile(ctx, fullPath, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: auto-export failed: %v\n", err)
-		return
+		return nil
 	}
 
 	debug.Logf("auto-export: wrote %d issues and %d memories to %s\n",
@@ -135,13 +134,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	// issues.jsonl before any issues exist.
 	if issueCount == 0 && memoryCount == 0 {
 		_ = os.Remove(fullPath)
-		saveExportAutoState(beadsDir, &exportAutoState{
-			LastDoltCommit: currentCommit,
-			Timestamp:      time.Now(),
-			Issues:         0,
-			Memories:       0,
-		})
-		return
+		return nil
 	}
 	warnJSONLWithoutDoltRemote("auto-export")
 
@@ -149,7 +142,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 	// git repo (standalone BEADS_DIR flow), or when export.git-add is false.
 	if config.GetBool("export.git-add") && !config.GetBool("no-git-ops") && isGitRepo() {
 		if err := gitAddFile(fullPath); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: auto-export: git add failed: %v\n", err)
+			return fmt.Errorf("auto-export: git add failed: %w", err)
 		}
 	}
 
@@ -161,6 +154,7 @@ func maybeAutoExport(ctx context.Context, serverMode, allowEmptyOverwrite bool) 
 		Memories:       memoryCount,
 	}
 	saveExportAutoState(beadsDir, &newState)
+	return nil
 }
 
 // shouldExport reports whether the throttle window has elapsed, or whether

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -503,6 +503,65 @@ func TestGitAddFile_SkipsWhenIndexLocked(t *testing.T) {
 	}
 }
 
+func TestAutoExportGitAddFailureExitsNonZero(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	bd := buildBDForInitTests(t)
+	dir := t.TempDir()
+	env := append(autoExportDataLossTestEnv(dir), "BD_NON_INTERACTIVE=1")
+
+	runGit := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q")
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(bd, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("bd %v failed: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+
+	run("init", "--prefix", "agf", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".beads/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("config", "set", "export.interval", "1ms")
+	run("config", "set", "export.auto", "true")
+	run("config", "set", "export.git-add", "true")
+	time.Sleep(10 * time.Millisecond)
+
+	cmd := exec.Command(bd, "create", "caller visible git add failure", "-p", "2")
+	cmd.Dir = dir
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("bd create succeeded despite auto-export git add failure:\n%s", out)
+	}
+	output := string(out)
+	if !strings.Contains(output, "Error: auto-export: git add failed") {
+		t.Fatalf("expected caller-visible auto-export git add error, got:\n%s", output)
+	}
+	if !strings.Contains(strings.ToLower(output), "ignored") {
+		t.Fatalf("expected git add stderr to explain ignored path, got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
+		t.Fatalf("git-add failure should not save export state, stat err=%v", err)
+	}
+}
+
 // TestGitAddFile_RedirectCase_DoesNotStageInMainRepo regresses the
 // silent-stage-in-main follow-up from the GH#3311 review: when a worktree
 // has .beads/redirect -> main/.beads, the worktree's pre-commit hook must

--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -503,6 +503,14 @@ func TestGitAddFile_SkipsWhenIndexLocked(t *testing.T) {
 	}
 }
 
+// TestAutoExportGitAddFailureExitsNonZero verifies that a *genuine* auto-export
+// staging failure is fatal and surfaces to the caller as a non-zero exit. The
+// trigger is a held git index lock — the real GH#3970 repro of a tracked .beads
+// whose index is contended — NOT a gitignored .beads. A gitignored .beads/ is a
+// supported workflow (the JSONL is intentionally untracked) and must remain
+// non-fatal; that contract is regressed separately by
+// TestEmbeddedPrune/prune_last_issue_removes_gitignored_auto_export. See be-1wzr
+// / PR #4098 for the contract decision.
 func TestAutoExportGitAddFailureExitsNonZero(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
@@ -535,13 +543,19 @@ func TestAutoExportGitAddFailureExitsNonZero(t *testing.T) {
 	}
 
 	run("init", "--prefix", "agf", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
-	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".beads/\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
 	run("config", "set", "export.interval", "1ms")
 	run("config", "set", "export.auto", "true")
 	run("config", "set", "export.git-add", "true")
 	time.Sleep(10 * time.Millisecond)
+
+	// Hold the git index lock so the auto-export `git add` cannot proceed. The
+	// preflight in gitAddFile detects this and returns a non-nil error, which
+	// maybeAutoExport must escalate to a fatal, caller-visible error. .beads is
+	// NOT gitignored here, so the only reason staging fails is the lock.
+	lockPath := filepath.Join(dir, ".git", "index.lock")
+	if err := os.WriteFile(lockPath, []byte("held by another git process"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	cmd := exec.Command(bd, "create", "caller visible git add failure", "-p", "2")
 	cmd.Dir = dir
@@ -554,8 +568,8 @@ func TestAutoExportGitAddFailureExitsNonZero(t *testing.T) {
 	if !strings.Contains(output, "Error: auto-export: git add failed") {
 		t.Fatalf("expected caller-visible auto-export git add error, got:\n%s", output)
 	}
-	if !strings.Contains(strings.ToLower(output), "ignored") {
-		t.Fatalf("expected git add stderr to explain ignored path, got:\n%s", output)
+	if !strings.Contains(strings.ToLower(output), "index is locked") {
+		t.Fatalf("expected git add stderr to explain locked index, got:\n%s", output)
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
 		t.Fatalf("git-add failure should not save export state, stat err=%v", err)

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1154,7 +1154,9 @@ var rootCmd = &cobra.Command{
 			// Read-only commands must not perform post-run maintenance writes or emit
 			// sync guidance after machine-readable output.
 			if shouldRunPostCommandAutoExport(cmd) {
-				maybeAutoExport(rootCtx, serverMode, commandAllowsEmptyAutoExport(cmd))
+				if err := maybeAutoExport(rootCtx, serverMode, commandAllowsEmptyAutoExport(cmd)); err != nil {
+					FatalError("%v", err)
+				}
 			}
 
 			// Auto-push: push to Dolt remote if enabled and due.


### PR DESCRIPTION
## Summary

Closes #4092 via maintainer cherry-pick (contributor fork write-access not available).

- **Bug**: `maybeAutoExport` swallowed git-add errors and still wrote the `LastDoltCommit` state, causing the next run to skip retrying a failed stage.
- **Fix**: Change `maybeAutoExport` signature to return `error`. Propagate git-add failures through the cobra `PostRun` hook via `FatalError`. Do not write state on failure, so the next run sees a dirty state and retries.
- **Tests**: `TestGitAddFile_CapturesLockedIndexFailure` (low-level error wrapping), `TestAutoExportGitAddFailureExitsNonZero` (end-to-end: non-zero exit + user-visible error string + no state file written on failure).

Conflict with PR #4091 (serverMode/allowEmptyOverwrite params) and PR #4090 (bare returns) resolved during cherry-pick.

---
Original contributor: @maphew — exactly the right fix for #3970. Converting `maybeAutoExport` to return `error` and holding off on `saveExportAutoState` until after a successful git-add are the right calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)