### PR TITLE
test: clear BEADS_DOLT_SERVER_PORT in server-mode isolation tests

### DIFF
--- a/beads_test.go
+++ b/beads_test.go
@@ -143,16 +143,13 @@ func TestOpenFromConfig_DefaultsToEmbedded(t *testing.T) {
 
 func TestOpenFromConfig_ServerModeFailsWithoutServer(t *testing.T) {
 	// Server mode should fail-fast when no server is listening.
-	// Temporarily unset BEADS_DOLT_PORT/BEADS_TEST_MODE so the config port
-	// isn't overridden by applyConfigDefaults to the test server.
-	if prev := os.Getenv("BEADS_DOLT_PORT"); prev != "" {
-		os.Unsetenv("BEADS_DOLT_PORT")
-		t.Cleanup(func() { os.Setenv("BEADS_DOLT_PORT", prev) })
-	}
-	if prev := os.Getenv("BEADS_TEST_MODE"); prev != "" {
-		os.Unsetenv("BEADS_TEST_MODE")
-		t.Cleanup(func() { os.Setenv("BEADS_TEST_MODE", prev) })
-	}
+	// Clear port env vars so the config port from metadata.json is used —
+	// BEADS_DOLT_SERVER_PORT takes priority over BEADS_DOLT_PORT in
+	// GetDoltServerPort, so both must be cleared. Keep BEADS_TEST_MODE=1
+	// so auto-start is suppressed and the connection uses the free port
+	// from metadata.json (which has nothing listening).
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
 
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
@@ -233,14 +230,11 @@ func TestOpenBestAvailable_ServerMode(t *testing.T) {
 
 func TestOpenBestAvailable_ServerMode_FailsWithoutServer(t *testing.T) {
 	// OpenBestAvailable in server mode should propagate the fail-fast error.
-	if prev := os.Getenv("BEADS_DOLT_PORT"); prev != "" {
-		os.Unsetenv("BEADS_DOLT_PORT")
-		t.Cleanup(func() { os.Setenv("BEADS_DOLT_PORT", prev) })
-	}
-	if prev := os.Getenv("BEADS_TEST_MODE"); prev != "" {
-		os.Unsetenv("BEADS_TEST_MODE")
-		t.Cleanup(func() { os.Setenv("BEADS_TEST_MODE", prev) })
-	}
+	// Clear port env vars (both BEADS_DOLT_SERVER_PORT and BEADS_DOLT_PORT)
+	// so the config port from metadata.json is used. Keep BEADS_TEST_MODE=1
+	// so auto-start is suppressed.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
 
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")

--- a/docs/plans/schema-skew-guard.md
+++ b/docs/plans/schema-skew-guard.md
@@ -1,0 +1,99 @@
+# Plan: Schema-Skew Guard Implementation
+
+**Filed:** 2026-05-22  
+**PM:** beads/pm  
+**Root cause:** be-85qfg — stale bd binary accumulated ~25,000 errno-1105 errors over 16h  
+**Architecture:** be-blpg3  
+**Status:** In-flight
+
+---
+
+## Goal
+
+Hard-fail at db-open time when the database schema is ahead of the binary's
+embedded migrations, preventing cryptic SQL errors caused by stale binaries.
+
+## Work Breakdown
+
+### be-wwbsv — Implement schema-skew guard (P1, builder)
+
+**What:** Core implementation of the schema-skew guard.
+
+**Files:**
+- `internal/storage/schema/schema.go` — SchemaSkewError type, IsSchemaSkewError helper, checkSchemaSkew (unexported), CheckForwardDrift (exported), call in MigrateUp
+- `internal/storage/dolt/store.go` — CheckForwardDrift in ReadOnly branch of newServerMode
+- `cmd/bd/main.go` — --ignore-schema-skew PersistentFlag, env-var set in PersistentPreRun, dedicated SchemaSkewError handler before FatalError
+
+**Key UX decisions (from designer, be-wwbsv):**
+- Dedicated `errors.As(err, &skewErr)` check before FatalError (avoids triple-prefix)
+- SchemaSkewError.UserMessage() for human output, Error() for terse one-liner
+- Singular/plural: "1 migration ahead" / "N migrations ahead"
+- Warning line: `Warning: schema skew ignored — database (v{DBVersion}) is ahead of binary (v{BinaryVersion}); some queries may fail`
+- JSON: extend buildJSONError with "schema_skew" subobject (current_version, required_version, delta)
+
+**Acceptance criteria:**
+- `bd list` / `bd ready` exits 1 with actionable SchemaSkewError when DB > binary
+- BD_IGNORE_SCHEMA_SKEW=1 bypasses guard, prints Warning line to stderr
+- --ignore-schema-skew flag sets env var in PersistentPreRun
+- --json flag produces schema_skew subobject on stderr
+- Fresh DB (currentVersion=0) and normal upgrade path unaffected
+- bd migrate and bd init excluded from guard
+
+### be-x0rl6 — Document schema-skew guard (P2, builder)
+
+**What:** Documentation additions (no new files).
+
+**Files:**
+- `cmd/bd/main.go` — flag description for --ignore-schema-skew (exact copy in be-x0rl6 §2a)
+- `README.md` — ### Schema Version Guard section after ### Backup & Migration (exact copy in be-x0rl6 §3b)
+- `CHANGELOG.md` — entry under [Unreleased] → Added (exact copy in be-x0rl6 §4b)
+
+**Acceptance criteria:**
+- `bd --help` shows --ignore-schema-skew with exact description text
+- README renders ### Schema Version Guard section with correct code block (using 4-backtick or ~~~ fence)
+- CHANGELOG entry present under [Unreleased] → Added
+
+### be-cdhvj — Tests: schema-skew guard (P1, validator)
+
+**Blocked on:** be-wwbsv  
+**What:** Unit, integration, and escape-hatch test coverage.
+
+**Acceptance criteria:**
+- Unit: checkSchemaSkew mock for version=0/equal/+1/+3, BD_IGNORE_SCHEMA_SKEW path
+- Error copy exact-match assertions: Error(), UserMessage(), warning line, EscapeHint()
+- JSON --json flag: schema_skew subobject present with correct field types
+- Integration: dolt.New at N+1 returns *SchemaSkewError; + BD_IGNORE_SCHEMA_SKEW succeeds
+- ReadOnly CheckForwardDrift: same integration scenarios
+- bd init guard no-op (fresh DB)
+- IsSchemaSkewError distinguishes skew from other errors
+
+---
+
+## Dependency Graph
+
+```
+be-wwbsv (impl) ──blocks──> be-cdhvj (tests)
+be-x0rl6 (docs)  ── independent
+```
+
+Builder ships be-wwbsv and be-x0rl6 in one PR. Validator writes be-cdhvj after.
+
+---
+
+## Routing
+
+| Bead | Agent | Label |
+|------|-------|-------|
+| be-wwbsv | beads/builder | ready-to-build |
+| be-x0rl6 | beads/builder | ready-to-build |
+| be-cdhvj | beads/validator | needs-tests |
+
+---
+
+## Guardrails (carry forward from be-blpg3)
+
+- BD_IGNORE_SCHEMA_SKEW is the ONLY bypass — no ReadOnly=true bypass
+- checkSchemaSkew returns nil on currentVersion=0 — do not break bd init
+- CheckForwardDrift called only in ReadOnly branch (write path gets it via MigrateUp)
+- Do NOT add guard to bd migrate command
+- Error message in README must match SchemaSkewError.UserMessage() exactly — update both in same PR

--- a/internal/configfile/configfile_test.go
+++ b/internal/configfile/configfile_test.go
@@ -311,6 +311,9 @@ func TestDoltServerMode(t *testing.T) {
 	})
 
 	t.Run("GetDoltServerPort", func(t *testing.T) {
+		// Clear port env vars so the table-driven configs are the source of truth.
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+		t.Setenv("BEADS_DOLT_PORT", "")
 		tests := []struct {
 			name string
 			cfg  *Config
@@ -705,6 +708,9 @@ func TestGetCapabilities(t *testing.T) {
 
 // TestDoltServerModeRoundtrip tests that server mode config survives save/load
 func TestDoltServerModeRoundtrip(t *testing.T) {
+	// Clear port env vars so saved/loaded port comes from config, not ambient env.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0750); err != nil {

--- a/internal/configfile/credentials_test.go
+++ b/internal/configfile/credentials_test.go
@@ -114,7 +114,9 @@ func TestLookupCredentialsPassword_FallsBackToFile(t *testing.T) {
 	}
 	t.Setenv("BEADS_CREDENTIALS_FILE", credFile)
 
-	// Clear BEADS_DOLT_PASSWORD so file lookup kicks in
+	// Clear port and password env vars so defaults + file lookup kick in.
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PASSWORD", "")
 
 	cfg := DefaultConfig()
@@ -138,6 +140,8 @@ password=workServerPass
 		t.Fatalf("failed to write credentials file: %v", err)
 	}
 	t.Setenv("BEADS_CREDENTIALS_FILE", credFile)
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PASSWORD", "")
 
 	// Personal project uses localhost
@@ -177,6 +181,8 @@ password=tunnelPass
 		t.Fatalf("failed to write credentials file: %v", err)
 	}
 	t.Setenv("BEADS_CREDENTIALS_FILE", credFile)
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("BEADS_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PASSWORD", "")
 
 	cfg := DefaultConfig()


### PR DESCRIPTION
## Summary

- Tests that simulate "no Dolt server running" cleared `BEADS_DOLT_PORT` but not `BEADS_DOLT_SERVER_PORT`. Since `GetDoltServerPort()` checks `BEADS_DOLT_SERVER_PORT` first, these tests connect to the ambient test-server port when CI has that env var set, falsely succeeding.
- Also fixes the test logic in `beads_test.go`: the old code cleared `BEADS_TEST_MODE`, which re-enabled auto-start and allowed the server to auto-start when the configured free port was unreachable. Keeping `BEADS_TEST_MODE=1` (set by `TestMain`) ensures auto-start is suppressed.

## Affected tests

- `TestOpenFromConfig_ServerModeFailsWithoutServer`
- `TestOpenBestAvailable_ServerMode_FailsWithoutServer`
- `TestDoltServerMode/GetDoltServerPort`
- `TestDoltServerModeRoundtrip`
- `TestLookupCredentialsPassword_FallsBackToFile` + 2 related sites in credentials_test.go

## Test plan

- [ ] `CGO_ENABLED=0 go test -tags gms_pure_go -count=1 -run 'TestOpenFromConfig_ServerModeFailsWithoutServer|TestOpenBestAvailable_ServerMode_FailsWithoutServer' .` passes
- [ ] `CGO_ENABLED=0 go test -tags gms_pure_go -count=1 ./internal/configfile/...` passes
- [ ] CI green

Bead: be-ko6jm

🤖 Generated with [Claude Code](https://claude.ai/claude-code)