### PR TITLE
fix(create): set status=deferred when --defer date is in the future (GH#4071)

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -759,6 +759,11 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		externalRefPtr = &params.ExternalRef
 	}
 
+	status := types.StatusOpen
+	if params.DeferUntil != nil && params.DeferUntil.After(time.Now()) {
+		status = types.StatusDeferred
+	}
+
 	return &types.Issue{
 		ID:                 params.ID,
 		Title:              params.Title,
@@ -767,7 +772,7 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		AcceptanceCriteria: params.AcceptanceCriteria,
 		Notes:              params.Notes,
 		SpecID:             params.SpecID,
-		Status:             types.StatusOpen,
+		Status:             status,
 		Priority:           params.Priority,
 		IssueType:          params.IssueType,
 		Assignee:           params.Assignee,


### PR DESCRIPTION
## Summary

Fixes #4071.

`bd create --defer=+2h` correctly sets `defer_until` but leaves `status` as `open`. This was fixed for `bd update --defer` in GH#3233 but the create path was missed.

**Impact:**
- `bd list --status deferred` misses these issues
- `bd undefer` rejects them (requires status=deferred)
- UI shows open icon instead of deferred icon

## Fix

In `buildCreateIssue`, set `status=deferred` when `DeferUntil` is in the future. Past defer dates keep `open` (matching existing warning behavior and `update.go` logic).

## Test plan

- [ ] `bd create "test" --defer=+1h --json` shows `status: "deferred"`
- [ ] `bd create "test" --defer=-1h --json` shows `status: "open"` (past date)
- [ ] `bd list --status deferred` includes the deferred issue
- [ ] `bd undefer <id>` works on the created issue