### PR TITLE
fix(close): treat re-close of already-closed issue as idempotent success (GH#4025)

### DIFF
--- a/internal/storage/issueops/close.go
+++ b/internal/storage/issueops/close.go
@@ -56,7 +56,20 @@ func closeIssueInTx(ctx context.Context, tx *sql.Tx, id string, reason, actor, s
 		return nil, fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rows == 0 {
-		return nil, fmt.Errorf("issue not found: %s", id)
+		var status string
+		qerr := tx.QueryRowContext(ctx,
+			fmt.Sprintf(`SELECT status FROM %s WHERE id = ?`, issueTable), id,
+		).Scan(&status)
+		if qerr == sql.ErrNoRows {
+			return nil, fmt.Errorf("issue not found: %s", id)
+		}
+		if qerr != nil {
+			return nil, fmt.Errorf("failed to check issue existence: %w", qerr)
+		}
+		if types.Status(status) == types.StatusClosed {
+			return &CloseResult{IsWisp: isWisp}, nil
+		}
+		return nil, fmt.Errorf("failed to close issue: %s", id)
 	}
 
 	if recordEvent {


### PR DESCRIPTION
## Summary

Fixes #4025.

`bd close <id>` returns "issue not found" when re-closing an already-closed issue within the same wall-clock second. The root cause: the UPDATE touches no columns (status already closed, timestamps identical within the same second), so `RowsAffected()` returns 0 — previously misinterpreted as "row doesn't exist."

## Fix

When `RowsAffected == 0`, query the row's current status in the same transaction:
- If already closed → return success silently (idempotent, no duplicate event)
- If row truly missing → preserve "issue not found" error
- If row exists but in unexpected state → return generic failure

Follows the same idempotent pattern already used in `claim.go`.

## Test plan

- [ ] Close an issue, immediately close again → success (no error)
- [ ] Close a nonexistent ID → still returns "issue not found"
- [ ] No duplicate `closed` event recorded on re-close
- [ ] Scripts doing `bd close $id && bd close $id` no longer fail