### PR TITLE
fix(list): disable default truncation when stdout is piped (GH#4094)

### DIFF
--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -535,8 +535,9 @@ var listCmd = &cobra.Command{
 		// Resolve effective limit. Priority order:
 		// 1. Explicit --limit always wins (user intent is clear)
 		// 2. --all implies unlimited when --limit is not set (GH#1840)
-		// 3. Agent mode uses a lower default for context efficiency
-		// 4. Default limit (50) otherwise
+		// 3. Non-interactive (piped) stdout disables truncation (GH#4094)
+		// 4. Agent mode uses a lower default for context efficiency
+		// 5. Default limit (50) otherwise
 		limitChanged := cmd.Flags().Changed("limit")
 		effectiveLimit := limit
 		switch {
@@ -544,6 +545,8 @@ var listCmd = &cobra.Command{
 			effectiveLimit = limit // Explicit value (including --limit 0 for unlimited)
 		case allFlag:
 			effectiveLimit = 0 // --all implies unlimited regardless of other flags
+		case !ui.IsTerminal():
+			effectiveLimit = 0 // Piped stdout should not truncate (GH#4094)
 		case ui.IsAgentMode():
 			effectiveLimit = 20 // Agent mode default
 		}

--- a/cmd/bd/list_output.go
+++ b/cmd/bd/list_output.go
@@ -16,7 +16,7 @@ import (
 // was truncated by --limit, so users and agents can't mistake a partial view
 // for a complete one (GH#3212, GH#788).
 func printTruncationHint(truncated bool, effectiveLimit int) {
-	if !truncated || effectiveLimit <= 0 {
+	if !truncated || effectiveLimit <= 0 || !ui.IsStderrTerminal() {
 		return
 	}
 	msg := fmt.Sprintf("\nShowing %d issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.\n", effectiveLimit)


### PR DESCRIPTION
## Summary

Fixes #4094.

When `bd list` output is piped (e.g. `bd list | grep merge`), the default `--limit 50` silently truncates results and prints a warning to stderr. Users expect piped commands to emit all matching data without truncation.

## Fix

Two changes:

1. **`cmd/bd/list.go`** — Extend the effective-limit resolution: when stdout is not a TTY and `--limit` was not explicitly set, default to unlimited (0). Priority order:
   - Explicit `--limit` wins
   - `--all` implies unlimited
   - **Non-TTY stdout → unlimited** (new)
   - Agent mode → 20
   - Default → 50

2. **`cmd/bd/list_output.go`** — Suppress the truncation hint when stderr is not a terminal (matches existing pattern in `output.go` for deprecation notices).

Uses the existing `ui.IsTerminal()` and `ui.IsStderrTerminal()` helpers from `internal/ui/terminal.go`.

## Test plan

- [ ] `bd list | cat` → outputs all issues (no truncation)
- [ ] `bd list` in terminal → still truncates at 50 with hint
- [ ] `bd list --limit 10 | cat` → respects explicit limit (10 results)
- [ ] `bd list --all` → unlimited regardless of TTY
- [ ] Truncation hint suppressed when stderr is piped