### PR TITLE
fix(mcp): route validate and detect-pollution to bd doctor (GH#4037)

### DIFF
--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -786,17 +786,17 @@ class BdCliClient(BdClientBase):
         Returns:
             Dict with detected test issues and deleted count if clean=True
         """
-        args = ["detect-pollution"]
+        args = ["doctor", "--check=pollution"]
         if clean:
             args.extend(["--clean", "--yes"])
 
         data = await self._run_command(*args)
         if not isinstance(data, dict):
-            raise BdCommandError("Invalid response for detect-pollution")
+            raise BdCommandError("Invalid response for doctor --check=pollution")
         return data
 
     async def validate(self, checks: str | None = None, fix_all: bool = False) -> dict[str, Any]:
-        """Run database validation checks.
+        """Run database validation checks via bd doctor --check=validate.
 
         Args:
             checks: Comma-separated list of checks (orphans,duplicates,pollution,conflicts)
@@ -805,15 +805,14 @@ class BdCliClient(BdClientBase):
         Returns:
             Dict with validation results for each check
         """
-        args = ["validate"]
-        if checks:
-            args.extend(["--checks", checks])
+        args = ["doctor", "--check=validate"]
         if fix_all:
-            args.append("--fix-all")
+            args.append("--fix")
+            args.append("--yes")
 
         data = await self._run_command(*args)
         if not isinstance(data, dict):
-            raise BdCommandError("Invalid response for validate")
+            raise BdCommandError("Invalid response for doctor --check=validate")
         return data
 
     async def init(self, params: InitParams | None = None) -> str:


### PR DESCRIPTION
## Summary

Fixes #4037.

The `beads-mcp` admin tool's `validate` action calls `bd validate` and `detect-pollution` calls `bd detect-pollution` — neither exists as a standalone command. Both are subcommands of `bd doctor`:

- `validate` → `bd doctor --check=validate [--fix --yes]`
- `detect-pollution` → `bd doctor --check=pollution [--clean --yes]`

## Fix

Update `BdCliClient.validate()` and `BdCliClient.detect_pollution()` in `bd_client.py` to invoke the correct `bd doctor` subcommands with appropriate flags.

## Test plan

- [ ] MCP `admin(action="validate")` succeeds (no "unknown command" error)
- [ ] MCP `admin(action="validate", fix_all=True)` passes `--fix --yes`
- [ ] MCP `admin(action="pollution")` succeeds
- [ ] MCP `admin(action="pollution", clean=True)` passes `--clean --yes`
- [ ] Other admin actions (repair, schema, debug, migration) unaffected