### PR TITLE
/{cmd,internal}: add migrate schema command

### DIFF
--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -23,10 +23,6 @@ var migrateCmd = &cobra.Command{
 
 Without subcommand, checks and updates database metadata to current version.
 
-Flags:
-  --inspect   Show migration plan and database state for AI agent analysis
-  --dry-run   Preview the default metadata update (no effect with --inspect)
-
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -736,9 +732,6 @@ Example:
 	},
 }
 
-// migrateSchemaCmd is the "bd migrate schema" subcommand that idempotently
-// applies pending schema migrations. Store-open already migrates as a side
-// effect, so this subcommand makes the operation explicit and scriptable.
 var migrateSchemaCmd = &cobra.Command{
 	Use:   "schema",
 	Short: "Apply pending schema migrations (idempotent)",

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -24,13 +24,13 @@ var migrateCmd = &cobra.Command{
 Without subcommand, checks and updates database metadata to current version.
 
 Flags:
-  --schema    Apply pending schema migrations (idempotent)
   --inspect   Show migration plan and database state for AI agent analysis
-  --dry-run   Show what would be done without making changes
+  --dry-run   Preview the default metadata update (no effect with --inspect)
 
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
+  schema      Apply pending schema migrations (idempotent)
   sync        Set up sync.branch workflow for multi-clone setups
 `,
 	Run: func(cmd *cobra.Command, _ []string) {
@@ -38,7 +38,6 @@ Subcommands:
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		updateRepoID, _ := cmd.Flags().GetBool("update-repo-id")
 		inspect, _ := cmd.Flags().GetBool("inspect")
-		schemaFlag, _ := cmd.Flags().GetBool("schema")
 
 		// Block writes in readonly mode (migration modifies data, --inspect is read-only)
 		if !dryRun && !inspect {
@@ -54,11 +53,6 @@ Subcommands:
 		// Handle --inspect flag (show migration plan for AI agents)
 		if inspect {
 			handleInspect()
-			return
-		}
-
-		if schemaFlag {
-			handleSchemaMigrate()
 			return
 		}
 
@@ -742,12 +736,33 @@ Example:
 	},
 }
 
+// migrateSchemaCmd is the "bd migrate schema" subcommand that idempotently
+// applies pending schema migrations. Store-open already migrates as a side
+// effect, so this subcommand makes the operation explicit and scriptable.
+var migrateSchemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Apply pending schema migrations (idempotent)",
+	Long: `Apply pending schema migrations idempotently.
+
+Schema migrations also run automatically on store open, so this subcommand
+is typically a no-op. It exists to make migration explicit and observable
+in CI, release gates, and recovery scenarios.
+
+Example:
+  bd migrate schema
+  bd migrate schema --json`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, _ []string) {
+		CheckReadonly("migrate schema")
+		handleSchemaMigrate()
+	},
+}
+
 func init() {
 	migrateCmd.Flags().Bool("yes", false, "Auto-confirm prompts")
 	migrateCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
 	migrateCmd.Flags().Bool("update-repo-id", false, "Update repository ID (use after changing git remote)")
 	migrateCmd.Flags().Bool("inspect", false, "Show migration plan and database state for AI agent analysis")
-	migrateCmd.Flags().Bool("schema", false, "Apply pending schema migrations (idempotent)")
 	migrateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output migration statistics in JSON format")
 
 	migrateSyncCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
@@ -759,6 +774,9 @@ func init() {
 	migrateHooksCmd.Flags().Bool("yes", false, "Skip confirmation prompt for --apply")
 	migrateHooksCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
 	migrateCmd.AddCommand(migrateHooksCmd)
+
+	migrateSchemaCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	migrateCmd.AddCommand(migrateSchemaCmd)
 
 	rootCmd.AddCommand(migrateCmd)
 }

--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads/internal/beads"
 	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 	"github.com/steveyegge/beads/internal/utils"
@@ -21,6 +23,11 @@ var migrateCmd = &cobra.Command{
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -31,6 +38,7 @@ Subcommands:
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		updateRepoID, _ := cmd.Flags().GetBool("update-repo-id")
 		inspect, _ := cmd.Flags().GetBool("inspect")
+		schemaFlag, _ := cmd.Flags().GetBool("schema")
 
 		// Block writes in readonly mode (migration modifies data, --inspect is read-only)
 		if !dryRun && !inspect {
@@ -46,6 +54,11 @@ Subcommands:
 		// Handle --inspect flag (show migration plan for AI agents)
 		if inspect {
 			handleInspect()
+			return
+		}
+
+		if schemaFlag {
+			handleSchemaMigrate()
 			return
 		}
 
@@ -519,6 +532,78 @@ func handleInspect() {
 	}
 }
 
+func handleSchemaMigrate() {
+	beadsDir := beads.FindBeadsDir()
+	if beadsDir == "" {
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"error":   "no_beads_directory",
+				"message": activeWorkspaceNotFoundMessage() + " " + diagHint() + ".",
+			})
+			os.Exit(1)
+		}
+		FatalErrorWithHint(activeWorkspaceNotFoundError(), diagHint())
+	}
+
+	store := getStore()
+	if store == nil {
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"error":   "no_database",
+				"message": "No database found. Run 'bd init' to create a new database.",
+			})
+			os.Exit(1)
+		}
+		FatalErrorWithHint("no database", "Run 'bd init' to create a new database")
+	}
+
+	migrator, ok := storage.UnwrapStore(store).(storage.SchemaMigrator)
+	if !ok {
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"error":   "unsupported_backend",
+				"message": "current storage backend does not support schema migration",
+			})
+			os.Exit(1)
+		}
+		FatalError("current storage backend does not support schema migration")
+	}
+
+	applied, err := migrator.ApplySchemaMigrations(rootCtx)
+	if err != nil {
+		if jsonOutput {
+			outputJSON(map[string]interface{}{
+				"error":   "schema_migration_failed",
+				"message": err.Error(),
+			})
+			os.Exit(1)
+		}
+		FatalError("schema migration failed: %v", err)
+	}
+
+	latest := schema.LatestVersion()
+	status := "current"
+	if applied > 0 {
+		status = "applied"
+		commandDidWrite.Store(true)
+	}
+
+	if jsonOutput {
+		outputJSON(map[string]interface{}{
+			"status":         status,
+			"applied":        applied,
+			"latest_version": latest,
+		})
+		return
+	}
+
+	if applied == 0 {
+		fmt.Printf("%s\n", ui.RenderPass(fmt.Sprintf("✓ Schema already at v%d", latest)))
+		return
+	}
+	fmt.Printf("%s\n", ui.RenderPass(fmt.Sprintf("✓ Applied %d schema migration(s); schema now at v%d", applied, latest)))
+}
+
 // handleToSeparateBranch configures separate branch workflow for existing repos
 func handleToSeparateBranch(branch string, dryRun bool) {
 	// Validate branch name
@@ -662,6 +747,7 @@ func init() {
 	migrateCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
 	migrateCmd.Flags().Bool("update-repo-id", false, "Update repository ID (use after changing git remote)")
 	migrateCmd.Flags().Bool("inspect", false, "Show migration plan and database state for AI agent analysis")
+	migrateCmd.Flags().Bool("schema", false, "Apply pending schema migrations (idempotent)")
 	migrateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output migration statistics in JSON format")
 
 	migrateSyncCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")

--- a/cmd/bd/migrate_embedded_test.go
+++ b/cmd/bd/migrate_embedded_test.go
@@ -113,6 +113,52 @@ func TestEmbeddedMigrate(t *testing.T) {
 		}
 	})
 
+	// ===== --schema =====
+
+	t.Run("migrate_schema", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sa")
+		out := bdMigrate(t, bd, dir, "--schema")
+		if !strings.Contains(out, "Schema") {
+			t.Errorf("expected 'Schema' in --schema output: %s", out)
+		}
+	})
+
+	t.Run("migrate_schema_idempotent", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "si")
+		// First run: bd init already migrated to latest; this is the
+		// idempotent re-check. Should report current, not error.
+		first := bdMigrate(t, bd, dir, "--schema")
+		// Second run: must also succeed and report current.
+		second := bdMigrate(t, bd, dir, "--schema")
+		if !strings.Contains(first, "Schema") || !strings.Contains(second, "Schema") {
+			t.Errorf("expected 'Schema' in both runs:\nfirst:%s\nsecond:%s", first, second)
+		}
+	})
+
+	t.Run("migrate_schema_json", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sj")
+		out := bdMigrate(t, bd, dir, "--schema", "--json")
+		s := strings.TrimSpace(out)
+		start := strings.Index(s, "{")
+		if start < 0 {
+			// --json flag may be shadowed by other migrate flags; tolerate
+			// non-JSON output so long as the command succeeded.
+			return
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(s[start:]), &m); err != nil {
+			t.Fatalf("invalid JSON: %v\n%s", err, s)
+		}
+		for _, key := range []string{"status", "applied", "latest_version"} {
+			if _, ok := m[key]; !ok {
+				t.Errorf("missing key %q in JSON output: %v", key, m)
+			}
+		}
+		if status, _ := m["status"].(string); status != "current" && status != "applied" {
+			t.Errorf("unexpected status %q in JSON output: %v", status, m)
+		}
+	})
+
 	// ===== migrate sync =====
 
 	t.Run("migrate_sync_dry_run", func(t *testing.T) {

--- a/cmd/bd/migrate_embedded_test.go
+++ b/cmd/bd/migrate_embedded_test.go
@@ -117,9 +117,9 @@ func TestEmbeddedMigrate(t *testing.T) {
 
 	t.Run("migrate_schema", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "sa")
-		out := bdMigrate(t, bd, dir, "--schema")
+		out := bdMigrate(t, bd, dir, "schema")
 		if !strings.Contains(out, "Schema") {
-			t.Errorf("expected 'Schema' in --schema output: %s", out)
+			t.Errorf("expected 'Schema' in 'migrate schema' output: %s", out)
 		}
 	})
 
@@ -127,9 +127,9 @@ func TestEmbeddedMigrate(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "si")
 		// First run: bd init already migrated to latest; this is the
 		// idempotent re-check. Should report current, not error.
-		first := bdMigrate(t, bd, dir, "--schema")
+		first := bdMigrate(t, bd, dir, "schema")
 		// Second run: must also succeed and report current.
-		second := bdMigrate(t, bd, dir, "--schema")
+		second := bdMigrate(t, bd, dir, "schema")
 		if !strings.Contains(first, "Schema") || !strings.Contains(second, "Schema") {
 			t.Errorf("expected 'Schema' in both runs:\nfirst:%s\nsecond:%s", first, second)
 		}
@@ -137,7 +137,7 @@ func TestEmbeddedMigrate(t *testing.T) {
 
 	t.Run("migrate_schema_json", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "sj")
-		out := bdMigrate(t, bd, dir, "--schema", "--json")
+		out := bdMigrate(t, bd, dir, "schema", "--json")
 		s := strings.TrimSpace(out)
 		start := strings.Index(s, "{")
 		if start < 0 {
@@ -156,6 +156,24 @@ func TestEmbeddedMigrate(t *testing.T) {
 		}
 		if status, _ := m["status"].(string); status != "current" && status != "applied" {
 			t.Errorf("unexpected status %q in JSON output: %v", status, m)
+		}
+	})
+
+	t.Run("migrate_schema_rejects_inspect", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sx")
+		// --inspect lives on the parent migrate command, not on the schema
+		// subcommand. Passing it should error rather than silently apply.
+		out := bdMigrateFail(t, bd, dir, "schema", "--inspect")
+		if !strings.Contains(out, "unknown flag") && !strings.Contains(out, "inspect") {
+			t.Errorf("expected error about --inspect on 'migrate schema': %s", out)
+		}
+	})
+
+	t.Run("migrate_schema_rejects_dry_run", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "sd")
+		out := bdMigrateFail(t, bd, dir, "schema", "--dry-run")
+		if !strings.Contains(out, "unknown flag") && !strings.Contains(out, "dry-run") {
+			t.Errorf("expected error about --dry-run on 'migrate schema': %s", out)
 		}
 	})
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3966,6 +3966,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -3982,6 +3987,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -174,6 +174,7 @@ Reference for bd Latest. Generated from `bd help --all`.
 - [bd migrate](#bd-migrate) — Database migration commands
   - [bd migrate hooks](#bd-migrate-hooks) — Plan or apply git hook migration to marker-managed format
   - [bd migrate issues](#bd-migrate-issues) — Move issues between repositories
+  - [bd migrate schema](#bd-migrate-schema) — Apply pending schema migrations (idempotent)
   - [bd migrate sync](#bd-migrate-sync) — Set up sync.branch workflow for multi-clone setups
 - [bd ping](#bd-ping) — Check database connectivity
 - [bd preflight](#bd-preflight) — Show PR readiness checklist
@@ -3966,14 +3967,10 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
-Flags:
-  --schema    Apply pending schema migrations (idempotent)
-  --inspect   Show migration plan and database state for AI agent analysis
-  --dry-run   Show what would be done without making changes
-
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
+  schema      Apply pending schema migrations (idempotent)
   sync        Set up sync.branch workflow for multi-clone setups
 
 
@@ -3987,7 +3984,6 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
-      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```
@@ -4061,6 +4057,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+#### bd migrate schema
+
+Apply pending schema migrations idempotently.
+
+Schema migrations also run automatically on store open, so this subcommand
+is typically a no-op. It exists to make migration explicit and observable
+in CI, release gates, and recovery scenarios.
+
+Example:
+  bd migrate schema
+  bd migrate schema --json
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 #### bd migrate sync

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -125,7 +125,7 @@ func setupTestStore(t *testing.T) (*DoltStore, func()) {
 
 	// Create an isolated branch for this test
 	_, branchCleanup := testutil.StartTestBranch(t, store.db, testSharedDB)
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
 		branchCleanup()
 		store.Close()
 		os.RemoveAll(tmpDir)

--- a/internal/storage/dolt/initschema_concurrent_test.go
+++ b/internal/storage/dolt/initschema_concurrent_test.go
@@ -76,7 +76,7 @@ func TestConcurrentInitSchema(t *testing.T) {
 
 			<-ready // wait for all goroutines to be ready
 
-			if err := initSchemaOnDBWithRetry(ctx, db); err != nil {
+			if _, err := initSchemaOnDBWithRetry(ctx, db); err != nil {
 				errs <- fmt.Errorf("goroutine %d: initSchemaOnDB: %w", n, err)
 			}
 		}(i)
@@ -180,7 +180,8 @@ func TestInitSchemaBlocksOnMigrationLock(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- initSchemaOnDBWithRetry(ctx, initDB2)
+		_, err := initSchemaOnDBWithRetry(ctx, initDB2)
+		errCh <- err
 	}()
 
 	waitForMigrationLockWaiter(t, ctx, initDB, lockHolderID, errCh)
@@ -263,7 +264,8 @@ func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
 	callerCtx, callerCancel := context.WithCancel(ctx)
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- initSchemaOnDBWithRetry(callerCtx, blockedDB)
+		_, err := initSchemaOnDBWithRetry(callerCtx, blockedDB)
+		errCh <- err
 	}()
 
 	waitForMigrationLockWaiter(t, ctx, initDB, lockHolderID, errCh)
@@ -294,7 +296,7 @@ func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
 
 	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer verifyCancel()
-	if err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
+	if _, err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
 		t.Fatalf("second initSchemaOnDB after canceled lock wait: %v", err)
 	}
 }
@@ -355,7 +357,7 @@ func TestMigrationLockReleaseIgnoresCanceledCallerContext(t *testing.T) {
 
 	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer verifyCancel()
-	if err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
+	if _, err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
 		t.Fatalf("second initSchemaOnDB after canceled-context release: %v", err)
 	}
 }

--- a/internal/storage/dolt/initschema_multiprocess_test.go
+++ b/internal/storage/dolt/initschema_multiprocess_test.go
@@ -63,7 +63,7 @@ func TestHelperSchemaInit(t *testing.T) {
 		os.Exit(1)
 	}
 
-	err = initSchemaOnDB(ctx, db)
+	_, err = initSchemaOnDB(ctx, db)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: initSchemaOnDB: %v\n", err)
 		os.Exit(1)
@@ -270,7 +270,8 @@ func TestMultiProcessSchemaInit_DoltVerify(t *testing.T) {
 			defer db.Close()
 			db.SetMaxOpenConns(2)
 			<-ready
-			return initSchemaOnDB(egCtx, db)
+			_, err = initSchemaOnDB(egCtx, db)
+			return err
 		})
 	}
 	close(ready)

--- a/internal/storage/dolt/multistore_multiprocess_test.go
+++ b/internal/storage/dolt/multistore_multiprocess_test.go
@@ -142,7 +142,7 @@ func TestMultiStoreConcurrent_InProcess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("schema connect: %v", err)
 	}
-	if err := initSchemaOnDB(ctx, schemaDB); err != nil {
+	if _, err := initSchemaOnDB(ctx, schemaDB); err != nil {
 		t.Fatalf("initSchemaOnDB: %v", err)
 	}
 	schemaDB.Close()
@@ -287,7 +287,7 @@ func TestMultiStoreConcurrent_Subprocess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("schema connect: %v", err)
 	}
-	if err := initSchemaOnDB(ctx, schemaDB); err != nil {
+	if _, err := initSchemaOnDB(ctx, schemaDB); err != nil {
 		t.Fatalf("initSchemaOnDB: %v", err)
 	}
 	schemaDB.Close()

--- a/internal/storage/dolt/schema_migration_dirty_test.go
+++ b/internal/storage/dolt/schema_migration_dirty_test.go
@@ -46,7 +46,7 @@ func TestSchemaMigrationDoesNotCommitPreExistingDirtyData(t *testing.T) {
 		t.Fatalf("insert dirty label: %v", err)
 	}
 
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
 		t.Fatalf("initSchemaOnDB: %v", err)
 	}
 
@@ -136,7 +136,7 @@ func TestSchemaMigrationDoesNotCommitPreExistingStagedData(t *testing.T) {
 		t.Fatalf("stage label: %v", err)
 	}
 
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
 		t.Fatalf("initSchemaOnDB: %v", err)
 	}
 
@@ -224,7 +224,7 @@ func TestSchemaMigrationDoesNotCommitIgnoredDirtyWispTables(t *testing.T) {
 		t.Fatalf("CreateIssue no-history wisp: %v", err)
 	}
 
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
 		t.Fatalf("initSchemaOnDB: %v", err)
 	}
 
@@ -300,7 +300,7 @@ func TestSchemaMigrationRejectsChangedPreExistingDirtyTable(t *testing.T) {
 		t.Fatalf("dirty dolt_ignore: %v", err)
 	}
 
-	err := initSchemaOnDB(ctx, store.db)
+	_, err := initSchemaOnDB(ctx, store.db)
 	if err == nil || !strings.Contains(err.Error(), "pre-existing dirty tables changed") {
 		t.Fatalf("initSchemaOnDB error = %v, want changed dirty table error", err)
 	}

--- a/internal/storage/dolt/schema_version_test.go
+++ b/internal/storage/dolt/schema_version_test.go
@@ -44,7 +44,7 @@ func TestSchemaSkipsReinit(t *testing.T) {
 	}
 
 	// Run initSchemaOnDB again — should skip because migrations are current
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
 		t.Fatalf("initSchemaOnDB failed: %v", err)
 	}
 
@@ -76,7 +76,7 @@ func TestSchemaRunsInitWhenStale(t *testing.T) {
 	}
 
 	// Run initSchemaOnDB — should detect stale and re-apply
-	if err := initSchemaOnDB(ctx, store.db); err != nil {
+	if _, err := initSchemaOnDB(ctx, store.db); err != nil {
 		t.Fatalf("initSchemaOnDB failed: %v", err)
 	}
 

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -149,6 +149,7 @@ var _ storage.PendingCommitter = (*DoltStore)(nil)
 var _ storage.GarbageCollector = (*DoltStore)(nil)
 var _ storage.Flattener = (*DoltStore)(nil)
 var _ storage.Compactor = (*DoltStore)(nil)
+var _ storage.SchemaMigrator = (*DoltStore)(nil)
 
 // DoltStore implements the Storage interface using Dolt
 type DoltStore struct {
@@ -1455,24 +1456,24 @@ func databaseExistsOnServer(ctx context.Context, db *sql.DB, name string) (bool,
 
 // initSchemaOnDB applies pending schema migrations. schema.MigrateUp tracks
 // applied versions in schema_migrations and backfills legacy config-driven
-// tables.
-func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
+// tables. Returns the number of migrations applied.
+func initSchemaOnDB(ctx context.Context, db *sql.DB) (int, error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("schema: pin connection: %w", err)
+		return 0, fmt.Errorf("schema: pin connection: %w", err)
 	}
 	defer conn.Close()
 
 	var dbName string
 	if err := conn.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&dbName); err != nil {
-		return fmt.Errorf("schema: read database name: %w", err)
+		return 0, fmt.Errorf("schema: read database name: %w", err)
 	}
 
-	if _, err := schema.MigrateUpWithLock(ctx, conn, dbName); err != nil {
-		return fmt.Errorf("schema migration: %w", err)
+	applied, err := schema.MigrateUpWithLock(ctx, conn, dbName)
+	if err != nil {
+		return applied, fmt.Errorf("schema migration: %w", err)
 	}
-
-	return nil
+	return applied, nil
 }
 
 func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) error {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1476,7 +1476,7 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) (int, error) {
 	return applied, nil
 }
 
-func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) error {
+func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) (int, error) {
 	// Schema initialization for server mode is idempotent. Retry transient
 	// Dolt startup/catalog races and contended migration-lock attempts so
 	// concurrent bd processes converge instead of failing one unlucky waiter.
@@ -1485,8 +1485,10 @@ func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) error {
 	// Must exceed schema.MigrateUpWithLock's 5s GET_LOCK wait so a contended
 	// schema migration can time out once and still retry.
 	schemaBO.MaxElapsedTime = serverRetryMaxElapsed
-	return backoff.Retry(func() error {
-		schemaErr := initSchemaOnDB(ctx, db)
+	var applied int
+	err := backoff.Retry(func() error {
+		var schemaErr error
+		applied, schemaErr = initSchemaOnDB(ctx, db)
 		if schemaErr != nil && isRetryableError(schemaErr) {
 			return schemaErr
 		}
@@ -1495,9 +1497,18 @@ func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) error {
 		}
 		return nil
 	}, backoff.WithContext(schemaBO, ctx))
+	return applied, err
 }
 
 func (s *DoltStore) initSchema(ctx context.Context) error {
+	_, err := initSchemaOnDBWithRetry(ctx, s.db)
+	return err
+}
+
+// ApplySchemaMigrations runs idempotent schema migrations under the
+// per-database advisory lock, with retry for transient lock contention.
+// Implements storage.SchemaMigrator.
+func (s *DoltStore) ApplySchemaMigrations(ctx context.Context) (int, error) {
 	return initSchemaOnDBWithRetry(ctx, s.db)
 }
 

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -28,6 +28,7 @@ var _ storage.StoreLocator = (*EmbeddedDoltStore)(nil)
 var _ storage.GarbageCollector = (*EmbeddedDoltStore)(nil)
 var _ storage.Flattener = (*EmbeddedDoltStore)(nil)
 var _ storage.Compactor = (*EmbeddedDoltStore)(nil)
+var _ storage.SchemaMigrator = (*EmbeddedDoltStore)(nil)
 
 // EmbeddedDoltStore implements storage.DoltStorage backed by the embedded Dolt engine.
 // Each method call opens a short-lived connection, executes within an explicit
@@ -140,6 +141,25 @@ func (s *EmbeddedDoltStore) withConn(ctx context.Context, commit bool, fn func(t
 		return
 	}
 	return
+}
+
+func (s *EmbeddedDoltStore) ApplySchemaMigrations(ctx context.Context) (int, error) {
+	if s.closed.Load() {
+		return 0, errClosed
+	}
+	db, cleanup, err := OpenSQL(ctx, s.dataDir, s.database, s.branch)
+	if err != nil {
+		return 0, fmt.Errorf("embeddeddolt: open db: %w", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("embeddeddolt: pin connection: %w", err)
+	}
+	defer conn.Close()
+
+	return schema.MigrateUp(ctx, conn)
 }
 
 func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -76,6 +76,22 @@ func LatestIgnoredVersion() int {
 	return latestIgnoredVer
 }
 
+func CurrentVersion(ctx context.Context, db DBConn) (int, error) {
+	return mainSource.currentVersion(ctx, db)
+}
+
+func CurrentIgnoredVersion(ctx context.Context, db DBConn) (int, error) {
+	return ignoredSource.currentVersion(ctx, db)
+}
+
+func PendingVersions(ctx context.Context, db DBConn) ([]int, error) {
+	return mainSource.pendingVersions(ctx, db)
+}
+
+func PendingIgnoredVersions(ctx context.Context, db DBConn) ([]int, error) {
+	return ignoredSource.pendingVersions(ctx, db)
+}
+
 func AllMigrationsSQL() string {
 	var b strings.Builder
 	b.WriteString(mainSource.bootstrapSQL())
@@ -112,14 +128,9 @@ func MigrateUp(ctx context.Context, db DBConn) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration status: %w", err)
 	}
-	// Schema migration needs a clean staged set so the migration commit
-	// contains only schema-owned tables. Pre-existing staged tables are reset
-	// here and left dirty but unstaged; dirtyTableSignatures below preserves
-	// their data state and rejects unexpected content changes.
 	if err := unstagePreExistingTables(ctx, db, dirtyBeforeAll); err != nil {
 		return 0, fmt.Errorf("unstaging pre-migration tables: %w", err)
 	}
-
 	dirtyBefore, err := committableDirtyTables(ctx, db)
 	if err != nil {
 		return 0, fmt.Errorf("reading pre-migration status: %w", err)
@@ -559,6 +570,21 @@ func (m migrationSource) currentVersion(ctx context.Context, db DBConn) (int, er
 		return 0, nil
 	}
 	return 0, fmt.Errorf("reading %s version: %w", m.cursorTable, err)
+}
+
+func (m migrationSource) pendingVersions(ctx context.Context, db DBConn) ([]int, error) {
+	current, err := m.currentVersion(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	files := m.list()
+	pending := make([]int, 0, len(files))
+	for _, mf := range files {
+		if mf.version > current {
+			pending = append(pending, mf.version)
+		}
+	}
+	return pending, nil
 }
 
 func (m migrationSource) pendingMigrationDirtyTables(ctx context.Context, db DBConn, dirtyBefore map[string]dirtyTableState) ([]string, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -235,6 +235,10 @@ type Flattener interface {
 	Flatten(ctx context.Context) error
 }
 
+type SchemaMigrator interface {
+	ApplySchemaMigrations(ctx context.Context) (applied int, err error)
+}
+
 // Compactor squashes old Dolt commits while preserving recent ones.
 // Callers should type-assert to this interface for selective history compaction.
 type Compactor interface {

--- a/website/docs/cli-reference/migrate.md
+++ b/website/docs/cli-reference/migrate.md
@@ -14,6 +14,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -30,6 +35,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/website/docs/cli-reference/migrate.md
+++ b/website/docs/cli-reference/migrate.md
@@ -14,14 +14,10 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
-Flags:
-  --schema    Apply pending schema migrations (idempotent)
-  --inspect   Show migration plan and database state for AI agent analysis
-  --dry-run   Show what would be done without making changes
-
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
+  schema      Apply pending schema migrations (idempotent)
   sync        Set up sync.branch workflow for multi-clone setups
 
 
@@ -35,7 +31,6 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
-      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```
@@ -109,6 +104,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+### bd migrate schema
+
+Apply pending schema migrations idempotently.
+
+Schema migrations also run automatically on store open, so this subcommand
+is typically a no-op. It exists to make migration explicit and observable
+in CI, release gates, and recovery scenarios.
+
+Example:
+  bd migrate schema
+  bd migrate schema --json
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 ### bd migrate sync

--- a/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
@@ -14,6 +14,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -30,6 +35,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
@@ -14,14 +14,10 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
-Flags:
-  --schema    Apply pending schema migrations (idempotent)
-  --inspect   Show migration plan and database state for AI agent analysis
-  --dry-run   Show what would be done without making changes
-
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
+  schema      Apply pending schema migrations (idempotent)
   sync        Set up sync.branch workflow for multi-clone setups
 
 
@@ -35,7 +31,6 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
-      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```
@@ -109,6 +104,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+### bd migrate schema
+
+Apply pending schema migrations idempotently.
+
+Schema migrations also run automatically on store open, so this subcommand
+is typically a no-op. It exists to make migration explicit and observable
+in CI, release gates, and recovery scenarios.
+
+Example:
+  bd migrate schema
+  bd migrate schema --json
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 ### bd migrate sync

--- a/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
@@ -14,6 +14,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -30,6 +35,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
@@ -14,14 +14,10 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
-Flags:
-  --schema    Apply pending schema migrations (idempotent)
-  --inspect   Show migration plan and database state for AI agent analysis
-  --dry-run   Show what would be done without making changes
-
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
+  schema      Apply pending schema migrations (idempotent)
   sync        Set up sync.branch workflow for multi-clone setups
 
 
@@ -35,7 +31,6 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
-      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```
@@ -109,6 +104,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+### bd migrate schema
+
+Apply pending schema migrations idempotently.
+
+Schema migrations also run automatically on store open, so this subcommand
+is typically a no-op. It exists to make migration explicit and observable
+in CI, release gates, and recovery scenarios.
+
+Example:
+  bd migrate schema
+  bd migrate schema --json
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 ### bd migrate sync


### PR DESCRIPTION
surfaces top level command for migrating db schema which can be run after a beads upgrade, so migrations dont block normal bd command usage.