### PR TITLE
fix(show): bd show --include-dependents silently returns no dependents on Dolt server (regression from #4010)

### DIFF
--- a/internal/storage/dolt/iter_dependents.go
+++ b/internal/storage/dolt/iter_dependents.go
@@ -45,16 +45,21 @@ type doltDependentsIter struct {
 // matches GetDependentsWithMetadata. See the package doc for why the join
 // target per edge table is unambiguous.
 func (s *DoltStore) IterDependentsWithMetadata(ctx context.Context, issueID string) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	// Resolve each edge's target from the split columns, NOT a physical
+	// depends_on_id: that generated column was dropped from both edge tables
+	// by migration 0043, so `d.depends_on_id` errors with 1105 on a post-split
+	// DB. Mirrors the count path (counts.go depTargetExpr) and the slice path
+	// (GetDependenciesWithMetadata, issueops.DepTargetExpr).
 	q := fmt.Sprintf(`
 		SELECT %s, d.type
 		FROM issues i
 		JOIN dependencies d ON d.issue_id = i.id
-		WHERE d.depends_on_id = ?
+		WHERE COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) = ?
 		UNION ALL
 		SELECT %s, d.type
 		FROM wisps w
 		JOIN wisp_dependencies d ON d.issue_id = w.id
-		WHERE d.depends_on_id = ?
+		WHERE COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) = ?
 		ORDER BY created_at ASC
 	`, prefixedIssueColumns("i"), prefixedIssueColumns("w"))
 	return s.iterIssuesWithDepType(ctx, q, issueID, issueID)


### PR DESCRIPTION
## Summary

`bd show <id> --json --include-dependents` **silently returns no dependents** on the Dolt sql-server backend, even when the issue has dependents. The default count-only output reports a correct nonzero `dependent_count`, so the JSON is self-contradictory (claims N dependents, lists none) — with **no error** surfaced to the user.

This is a regression introduced in #4010 (commit `9e35080be`).

## Root cause

`DoltStore.IterDependentsWithMetadata` (`internal/storage/dolt/iter_dependents.go`) filtered both UNION branches with `WHERE d.depends_on_id = ?`. The generated `depends_on_id` column was dropped from both `dependencies` and `wisp_dependencies` by migration `0043_drop_dependencies_generated_column`. On a post-split Dolt server the query fails with:

```
ERROR 1105 (HY000): table "d" does not have column "depends_on_id"
```

The error is returned up to `cmd/bd/show.go:163`, where the `if err == nil { … }` guard has **no else branch**, so the 1105 is silently dropped and `details.Dependents` stays nil.

`9e35080be` rewrote this query to UNION the wisp table and fixed the **count** path (`counts.go` `depTargetExpr`), but left the **iter** path's WHERE clauses on the dropped physical column.

## Why CI didn't catch it

- The dolt-backend guard `TestCountAndIterIncludeWispDependencies` *does* assert this path — but it is **skipped without a running test Dolt server** (`"Test Dolt server not running, skipping test"`), which is the CI tier that ran for #4010.
- The embedded backend's `IterDependentsWithMetadata` is a slice-delegating stub (`embeddeddolt/iter_stubs.go`) that reuses the correct `GetDependentsWithMetadata` path, so the embedded test was green.

## Fix

Filter on the split-column target expression, matching the slice path (`issueops.DepTargetExpr`) and the count path (`counts.go` `depTargetExpr`):

```sql
WHERE COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) = ?
```

One file, both UNION branches. No API or behavior change beyond fixing the query.

## Verification (end-to-end, live post-split Dolt server)

`bd show bd-rbxi --json --include-dependents` (bd-rbxi has 12 dependents):

| binary | `dependent_count` | `dependents[]` |
|---|---|---|
| before (origin/main) | 12 | **absent** |
| after (this PR) | 12 | **12** |

The existing `TestCountAndIterIncludeWispDependencies` covers this once a test Dolt server is available; no new test is added because the guard already exists (the gap is CI not running it, tracked separately).

## Follow-up (not in this PR)

`cmd/bd/show.go:163-164` silently swallows the iter error — that is *why* this break was silent rather than loud. Surfacing it would turn a future query break into an immediate failure. Left out here to keep the fix surgical; recommend a small hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)