### PR TITLE
feat(linear): add linear.outbound_state_map for push disambiguation

### DIFF
--- a/internal/linear/mapping.go
+++ b/internal/linear/mapping.go
@@ -137,6 +137,15 @@ type MappingConfig struct {
 	// mappings from type-based fallbacks.
 	ExplicitStateMap map[string]string
 
+	// OutboundStateMap maps a Beads status to the Linear workflow state NAME to
+	// use when pushing. Populated from linear.outbound_state_map.<beads_status>
+	// config keys. Used to disambiguate cases where multiple Linear states share
+	// the same state type (e.g. "In Progress" and "In Review" are both
+	// "started"), which would otherwise fail the push with an ambiguity error.
+	// Keys are lowercase beads status strings; values are Linear state names
+	// matched case-insensitively against the workflow state cache.
+	OutboundStateMap map[string]string
+
 	// LabelTypeMap maps Linear label names to Beads issue types.
 	// Key is lowercase label name, value is Beads issue type.
 	LabelTypeMap map[string]string
@@ -167,6 +176,7 @@ func DefaultMappingConfig() *MappingConfig {
 			"canceled":  "closed",
 		},
 		ExplicitStateMap: make(map[string]string),
+		OutboundStateMap: make(map[string]string),
 		// Label patterns for issue type inference
 		LabelTypeMap: map[string]string{
 			"bug":         "bug",
@@ -204,6 +214,7 @@ type ConfigLoader interface {
 //
 //	linear.priority_map.0 = 4       (Linear "no priority" -> Beads backlog)
 //	linear.state_map.started = in_progress
+//	linear.outbound_state_map.in_progress = "In Progress"
 //	linear.label_type_map.bug = bug
 //	linear.relation_map.blocks = blocks
 func LoadMappingConfig(loader ConfigLoader) *MappingConfig {
@@ -233,6 +244,13 @@ func LoadMappingConfig(loader ConfigLoader) *MappingConfig {
 			stateKey := strings.ToLower(strings.TrimPrefix(key, "linear.state_map."))
 			config.StateMap[stateKey] = value
 			config.ExplicitStateMap[stateKey] = value
+		}
+
+		// Parse outbound state mappings: linear.outbound_state_map.<beads_status>
+		// Value is the Linear workflow state name to use for that status on push.
+		if strings.HasPrefix(key, "linear.outbound_state_map.") {
+			statusKey := strings.ToLower(strings.TrimPrefix(key, "linear.outbound_state_map."))
+			config.OutboundStateMap[statusKey] = value
 		}
 
 		// Parse label-to-type mappings: linear.label_type_map.<label_name>
@@ -338,6 +356,21 @@ func ResolveStateIDForBeadsStatus(cache *StateCache, status types.Status, config
 		return "", fmt.Errorf("%s", missingExplicitStateMapMessage)
 	}
 
+	// Outbound override: an explicit linear.outbound_state_map.<status> entry
+	// names the exact Linear workflow state to push to and short-circuits the
+	// name/type matching below. This is the escape hatch when multiple Linear
+	// states share a type (e.g. "In Progress" and "In Review" are both
+	// "started") and the type-based fallback would otherwise be ambiguous.
+	if outboundName, ok := config.OutboundStateMap[strings.ToLower(strings.TrimSpace(string(status)))]; ok {
+		want := strings.ToLower(strings.TrimSpace(outboundName))
+		for _, state := range cache.States {
+			if strings.ToLower(strings.TrimSpace(state.Name)) == want {
+				return state.ID, nil
+			}
+		}
+		return "", fmt.Errorf("linear.outbound_state_map.%s = %q does not match any Linear workflow state", status, outboundName)
+	}
+
 	var nameMatches []State
 	for _, state := range cache.States {
 		mapped, ok := config.ExplicitStateMap[strings.ToLower(strings.TrimSpace(state.Name))]
@@ -371,7 +404,7 @@ func ResolveStateIDForBeadsStatus(cache *StateCache, status types.Status, config
 		for _, state := range typeMatches {
 			names = append(names, state.Name)
 		}
-		return "", fmt.Errorf("linear.state_map type fallback is ambiguous for beads status %q across Linear states: %s", status, strings.Join(names, ", "))
+		return "", fmt.Errorf("linear.state_map type fallback is ambiguous for beads status %q across Linear states: %s. Set linear.outbound_state_map.%s = \"<state name>\" to disambiguate", status, strings.Join(names, ", "), status)
 	}
 
 	return "", fmt.Errorf("linear.state_map has no configured Linear state for beads status %q", status)

--- a/internal/linear/mapping_test.go
+++ b/internal/linear/mapping_test.go
@@ -774,6 +774,132 @@ func TestResolveStateIDForBeadsStatusPrefersExplicitStateName(t *testing.T) {
 	}
 }
 
+func TestResolveStateIDForBeadsStatusOutboundOverrideResolvesAmbiguousType(t *testing.T) {
+	// Reproduces the be-9gt scenario: Linear's default workspace has two
+	// "started"-type states. Without an outbound override the push would error
+	// with the ambiguity message; with one it resolves cleanly.
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-progress", Name: "In Progress", Type: "started"},
+			{ID: "state-review", Name: "In Review", Type: "started"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["started"] = "in_progress"
+	config.OutboundStateMap["in_progress"] = "In Progress"
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusInProgress, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus() error = %v", err)
+	}
+	if got != "state-progress" {
+		t.Fatalf("ResolveStateIDForBeadsStatus() = %q, want state-progress", got)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusOutboundOverrideIsCaseInsensitive(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-progress", Name: "In Progress", Type: "started"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["started"] = "in_progress"
+	config.OutboundStateMap["in_progress"] = "  in progress  " // mixed case, padding
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusInProgress, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus() error = %v", err)
+	}
+	if got != "state-progress" {
+		t.Fatalf("ResolveStateIDForBeadsStatus() = %q, want state-progress", got)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusOutboundOverrideUnknownStateNameErrors(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-progress", Name: "In Progress", Type: "started"},
+			{ID: "state-review", Name: "In Review", Type: "started"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["started"] = "in_progress"
+	config.OutboundStateMap["in_progress"] = "Doing"
+
+	_, err := ResolveStateIDForBeadsStatus(cache, types.StatusInProgress, config)
+	if err == nil {
+		t.Fatal("expected error for unknown outbound state name")
+	}
+	if got := err.Error(); !strings.Contains(got, "linear.outbound_state_map.in_progress") || !strings.Contains(got, `"Doing"`) {
+		t.Fatalf("error message should name the bad config key and value, got: %v", err)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusOutboundOverrideWinsOverExplicitStateName(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-progress", Name: "In Progress", Type: "started"},
+			{ID: "state-review", Name: "In Review", Type: "started"},
+		},
+	}
+	config := DefaultMappingConfig()
+	// ExplicitStateMap would route in_progress to "In Review" by name match,
+	// but OutboundStateMap takes precedence and picks "In Progress".
+	config.ExplicitStateMap["in review"] = "in_progress"
+	config.OutboundStateMap["in_progress"] = "In Progress"
+
+	got, err := ResolveStateIDForBeadsStatus(cache, types.StatusInProgress, config)
+	if err != nil {
+		t.Fatalf("ResolveStateIDForBeadsStatus() error = %v", err)
+	}
+	if got != "state-progress" {
+		t.Fatalf("ResolveStateIDForBeadsStatus() = %q, want state-progress (outbound override should win over explicit name match)", got)
+	}
+}
+
+func TestResolveStateIDForBeadsStatusAmbiguousErrorPointsAtOutboundOverride(t *testing.T) {
+	cache := &StateCache{
+		States: []State{
+			{ID: "state-progress", Name: "In Progress", Type: "started"},
+			{ID: "state-review", Name: "In Review", Type: "started"},
+		},
+	}
+	config := DefaultMappingConfig()
+	config.ExplicitStateMap["started"] = "in_progress"
+
+	_, err := ResolveStateIDForBeadsStatus(cache, types.StatusInProgress, config)
+	if err == nil {
+		t.Fatal("expected ambiguous mapping to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "linear.outbound_state_map.in_progress") {
+		t.Fatalf("ambiguity error should mention the outbound_state_map escape hatch, got: %v", err)
+	}
+}
+
+func TestLoadMappingConfigParsesOutboundStateMap(t *testing.T) {
+	loader := &mockConfigLoader{
+		config: map[string]string{
+			"linear.state_map.started":              "in_progress",
+			"linear.outbound_state_map.in_progress": "In Progress",
+			"linear.outbound_state_map.blocked":     "Blocked",
+		},
+	}
+
+	config := LoadMappingConfig(loader)
+
+	if got := config.OutboundStateMap["in_progress"]; got != "In Progress" {
+		t.Errorf("OutboundStateMap[in_progress] = %q, want %q", got, "In Progress")
+	}
+	if got := config.OutboundStateMap["blocked"]; got != "Blocked" {
+		t.Errorf("OutboundStateMap[blocked] = %q, want %q", got, "Blocked")
+	}
+	// Defaults still empty for unset keys.
+	if got, ok := config.OutboundStateMap["closed"]; ok {
+		t.Errorf("OutboundStateMap[closed] = %q, want unset", got)
+	}
+}
+
 func TestPushFieldsEqualIgnoresLocalOnlyDifferences(t *testing.T) {
 	config := DefaultMappingConfig()
 	local := &types.Issue{


### PR DESCRIPTION
## Summary

`bd linear sync --push` errors with `linear.state_map type fallback is ambiguous for beads status "in_progress" across Linear states: In Review, In Progress` when a beads status maps to a Linear state type that has multiple workflow states. Linear's default workspace ships with both "In Progress" and "In Review" as `started`-type states, so any push that needs to set a beads `in_progress` issue fails with no escape hatch.

This change adds an opt-in config key that names the exact Linear state for outbound pushes:

```
linear.outbound_state_map.<beads_status> = "<Linear state name>"
```

When set, `ResolveStateIDForBeadsStatus` resolves by case-insensitive name match against the workflow state cache and short-circuits the existing name-then-type logic. Falls back to today's behavior when unset.

## Why

The existing `linear.state_map` is symmetric — used for both inbound (Linear → Beads) and outbound (Beads → Linear) resolution. The type-based fallback is essential for pull (a brand-new "Discovery" `started` state should still pull as `in_progress`) but fatal for push (it can't pick *which* `started` state to send writes to).

A separate outbound map is the smallest user-visible knob that fixes push without weakening pull or asking users to reorder their existing config:

- **Backwards-compatible**: empty map ⇒ no behavior change. All existing tests continue to pass without modification.
- **Push-only**: the field is consulted exclusively from `ResolveStateIDForBeadsStatus`, which is only called from the push path in `internal/linear/tracker.go`.
- **Discoverable**: the existing ambiguity error now points users at the new key by name.

Considered alternatives:
- *First-wins by declaration order in `linear.state_map`*: implicit, depends on map iteration order, surprising. Rejected.
- *Add a `--skip-state-update` push flag*: useful but orthogonal; doesn't let users push the *correct* state.

## Verification

- Targeted tests (new + existing):
  ```
  $ go test -tags gms_pure_go -run '^TestResolveStateIDForBeadsStatus|^TestLoadMappingConfig|^TestDefaultMappingConfig' -v ./internal/linear/...
  ok  	github.com/steveyegge/beads/internal/linear	0.364s   (13 PASS, 0 FAIL)
  ```
  The new tests directly reproduce the bug (two `started`-type states ⇒ ambiguity error without override, resolves to the named one with override) and cover the precedence, case-insensitive name matching, unknown-state-name error path, and the augmented ambiguity error.
- `make build` — clean.
- `golangci-lint run --build-tags gms_pure_go ./internal/linear/...` — `0 issues.`.

## Notes for reviewers

- Naming: I considered `linear.push_state_map` and `linear.write_state_map` but went with `outbound_` to mirror the project's inbound/outbound vocabulary in the linear package (and to leave room for a possible `linear.outbound_priority_map` etc. later without re-naming).
- The new field is `OutboundStateMap` on `MappingConfig`, initialized to an empty map in `DefaultMappingConfig` — same pattern as `ExplicitStateMap`.
- The error path when an outbound state name doesn't match any cached Linear state names the offending config key and value explicitly so the user can fix their `bd config set` line without guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)