### PR TITLE
fix(schema): reorder 0041 FK before generated column (Dolt 2.0.6 compat) — unblocks all CI

### DIFF
--- a/internal/storage/schema/migrations/0041_split_dependencies_target.up.sql
+++ b/internal/storage/schema/migrations/0041_split_dependencies_target.up.sql
@@ -83,6 +83,15 @@ SET @sql = IF(@needs_migrate = 1,
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
+-- NOTE: the FK on depends_on_issue_id must be added BEFORE the generated
+-- depends_on_id column exists. Dolt 2.0.6 rejects adding a foreign key on the
+-- base column of a stored generated column (errno 1105). The final schema is
+-- identical to adding it last.
+SET @sql = IF(@needs_migrate = 1,
+    'ALTER TABLE dependencies ADD CONSTRAINT fk_dep_issue_target FOREIGN KEY (depends_on_issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
 SET @sql = IF(@needs_migrate = 1,
     'ALTER TABLE dependencies ADD COLUMN depends_on_id VARCHAR(255) AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED',
     'SELECT 1');
@@ -110,11 +119,6 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(@needs_migrate = 1,
     'ALTER TABLE dependencies ADD INDEX idx_dep_type_target (type, depends_on_id)',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@needs_migrate = 1,
-    'ALTER TABLE dependencies ADD CONSTRAINT fk_dep_issue_target FOREIGN KEY (depends_on_issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE',
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 


### PR DESCRIPTION
## TL;DR
Dolt **2.0.6** (shipped 2026-05-22) broke migration `0041_split_dependencies_target.up.sql` on fresh databases, turning **every PR's CI red**. This is a one-statement reorder that produces an **identical final schema** and is verified to fix all affected tests on 2.0.6 with no regression on 2.0.5. Not caused by any application change.

## Root cause
Dolt 2.0.6 added a check that rejects `ADD FOREIGN KEY` on the **base column of a stored generated column** (errno 1105: *"Cannot add foreign key on the base column of a stored generated column"*).

Migration 0041:
1. re-adds `depends_on_id` as a **STORED generated column** = `COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)`, then
2. adds `fk_dep_issue_target FOREIGN KEY (depends_on_issue_id)` — and `depends_on_issue_id` is a **base column** of that generated column.

On Dolt 2.0.5 this was allowed; on 2.0.6 step 2 fails, aborting the migration mid-chain. (The generated `depends_on_id` is itself dropped later in migration 0043, so the FK/generated-column overlap exists only inside 0041's intermediate state.)

## Why every PR went red
CI installs dolt via `install.sh latest` (`.github/workflows/ci.yml`). The last green main run (`cfcc95799`) ran on **dolt 2.0.5**; all runs after 2.0.6 shipped fail. Confirmed across unrelated branches (e.g. `feat/linear-epic-parent-child` fails identically).

Minimal repro (same DDL, both dolt versions):
```
2.0.5: ALTER TABLE ... ADD CONSTRAINT fk_dep_issue_target ...  -> OK
2.0.6: ALTER TABLE ... ADD CONSTRAINT fk_dep_issue_target ...  -> ERROR 1105: Cannot add foreign key on the base column of a stored generated column
```

## The fix
Move the `fk_dep_issue_target` add to **before** the generated `depends_on_id` column is created. At that point `depends_on_issue_id` exists and no generated column references it, so 2.0.6 accepts it. `SHOW CREATE TABLE dependencies` after the reordered sequence is byte-identical to before.

## Verification (local, dolt 2.0.6 downloaded in isolation)
Failed before the fix, **pass after** under dolt 2.0.6:
- `internal/storage/uow` — `TestNewDoltServerUOWProvider_HappyPath`
- `internal/storage/uow` — `TestNewDoltServerUOWProvider_ConcurrentInstantiation`
- `scripts/repro-dolt-prod-timeouts` — `TestSeedProductionShapeFullSmallIssueCountRealSchema`

No regression on dolt 2.0.5 (UOW suite still green).

> The two `TestNewDoltServerUOWProvider_*` failures surfaced as `pending schema migrations alter pre-existing dirty tables: dependencies` — that is the **secondary** effect of 0041 aborting mid-migration and leaving `dependencies` dirty; the dirty-tables guard error is then non-retryable in `initSchema`. Both are resolved by this fix.

## Note for reviewers
This edits a shipped migration. That is the correct (and only) fix here: a migration that aborts mid-chain cannot be repaired by a later forward migration, no DB has successfully applied 0041 on 2.0.6, DBs created on 2.0.5 are already past it, and the resulting schema is identical. Migrations are tracked by version cursor (no content checksum), so editing 0041 does not invalidate existing databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)