### PR TITLE
ci: gate regression tests on risky PR paths

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -4,15 +4,74 @@ on:
   # Run on merges to main
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   # Allow manual trigger
   workflow_dispatch:
 
 jobs:
+  detect-regression-need:
+    name: Detect regression need
+    runs-on: ubuntu-latest
+    outputs:
+      run_regression: ${{ steps.detect.outputs.run_regression }}
+      reason: ${{ steps.detect.outputs.reason }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to run differential regression tests
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "run_regression=true" >> "$GITHUB_OUTPUT"
+            echo "reason=$EVENT_NAME event always runs regression tests" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          labels="$(jq -r '.pull_request.labels[].name // empty' "$GITHUB_EVENT_PATH")"
+          if grep -Fxq "run-regression" <<<"$labels"; then
+            echo "run_regression=true" >> "$GITHUB_OUTPUT"
+            echo "reason=run-regression label present" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -Fxq "skip-regression" <<<"$labels"; then
+            echo "run_regression=false" >> "$GITHUB_OUTPUT"
+            echo "reason=skip-regression label present" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA")"
+          echo "Changed files:"
+          printf '%s\n' "$changed"
+
+          risky_pattern='^(\.github/workflows/regression\.yml|Makefile|go\.(mod|sum)|cmd/bd/|internal/storage/|internal/types/|tests/regression/)'
+          if grep -Eq "$risky_pattern" <<<"$changed"; then
+            echo "run_regression=true" >> "$GITHUB_OUTPUT"
+            echo "reason=PR changes CLI, storage, types, regression, or build inputs" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "run_regression=false" >> "$GITHUB_OUTPUT"
+          echo "reason=PR does not touch regression-sensitive paths" >> "$GITHUB_OUTPUT"
+
   regression:
     name: Differential Regression (v0.49.6 baseline)
+    needs: detect-regression-need
+    if: needs.detect-regression-need.outputs.run_regression == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Show regression trigger reason
+        run: echo "${{ needs.detect-regression-need.outputs.reason }}"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go


### PR DESCRIPTION
## Summary

- Add `pull_request` coverage to the `Regression Tests` workflow.
- Keep the expensive differential regression job behind a lightweight detector.
- Run regression tests for PRs that touch CLI, storage, type, regression, or build-input paths.
- Allow maintainers to force with `run-regression` or suppress with `skip-regression` labels.
- Keep `push` to `main` and manual dispatch running regression tests unconditionally.

## Why

PR #4010 had green PR CI but broke the post-merge differential regression workflow because `Regression Tests` only ran on `push` to `main` or manual dispatch. This keeps the compatibility suite available before merge without adding the ~8-10 minute cost to unrelated PRs.

## Validation

- `git diff --check`
- detector shell simulation: `cmd/bd/show.go` => run
- detector shell simulation: docs-only changes => skip
- detector shell simulation: `run-regression` label => run

Local workflow lint was limited by missing local tooling (`ruby`, PyYAML, and `actionlint` are not installed in this environment).

Refs bd-yd7.

_codex-gpt-5.5-medium on behalf of matt wilkie_