### PR TITLE
docs(changelog): credit Kevin Glynn for JSONL cleanup origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disabled unless a viewer or JSONL integration explicitly enables them. This
   keeps `.beads/issues.jsonl` as an optional export surface, not the default
   mutation path. ([GH#4062](https://github.com/gastownhall/beads/issues/4062))
+  Thanks [Kevin Glynn](https://github.com/kevglynn) for surfacing the JSONL
+  source-of-truth mismatch through the export cleanup work that led to this
+  change.
 
 - **Release workflow uses the checked-in beads-release formula** — the old release shell path now delegates to the formula-backed release workflow with CI gates.
 


### PR DESCRIPTION
## Summary

Add the missing changelog attribution for Kevin Glynn surfacing the JSONL source-of-truth mismatch in GH #4067 that led to GH #4062 and the follow-up JSONL export/import cleanup.

The commit also carries a `Reported-by: Kevin Glynn <kglynn@pryoninc.com>` trailer so the credit is present in git history, not only in rendered release notes.

**Edit:** the issue was _surfaced_ in #4000 by @mjacobs, with @kevglynn providing the first fix.

## Validation

- `git diff --check`

_codex-gpt-5.5-high on behalf of matt wilkie_
