### PR TITLE
fix-merge: PR 4028 fork contributor routing

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1226,7 +1226,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// Non-interactive, idempotent; only fires when upstream remote detected
 		// and routing.contributor is not already set.
 		if !contributor && isGitRepo() {
-			if err := autoConfigureForkContributor(ctx, store, quiet, roleFlag); err != nil && !quiet {
+			if err := autoConfigureForkContributor(ctx, store, quiet || nonInteractive, roleFlag); err != nil && !quiet {
 				fmt.Fprintf(os.Stderr, "Warning: failed to auto-configure fork contributor routing: %v\n", err)
 			}
 		}

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1222,6 +1222,15 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			}
 		}
 
+		// Auto-configure contributor routing for fork repos (bd-umbf Child 1).
+		// Non-interactive, idempotent; only fires when upstream remote detected
+		// and routing.contributor is not already set.
+		if !contributor && isGitRepo() {
+			if err := autoConfigureForkContributor(ctx, store, quiet, roleFlag); err != nil && !quiet {
+				fmt.Fprintf(os.Stderr, "Warning: failed to auto-configure fork contributor routing: %v\n", err)
+			}
+		}
+
 		// Auto-commit Dolt state so bd doctor doesn't warn about uncommitted
 		// changes and users don't need a separate "bd vc commit" step.
 		if err := store.Commit(ctx, "bd init"); err != nil {

--- a/cmd/bd/init_contributor.go
+++ b/cmd/bd/init_contributor.go
@@ -263,6 +263,89 @@ Created by: bd init --contributor
 	return nil
 }
 
+// autoConfigureForkContributor configures contributor routing when bd init
+// detects a fork (upstream remote present) and routing is not yet set.
+// Non-interactive and idempotent. roleFlag is the --role flag value (if any).
+func autoConfigureForkContributor(ctx context.Context, store storage.DoltStorage, quiet bool, roleFlag string) error {
+	isFork, upstreamURL := detectForkSetup()
+	if !isFork {
+		return nil
+	}
+
+	// Explicit --role=maintainer on a fork: acknowledge fork, skip routing.
+	if roleFlag == "maintainer" {
+		if !quiet {
+			fmt.Printf("\n  %s Fork detected (upstream: %s)\n", ui.RenderWarn("⚠"), upstreamURL)
+			fmt.Printf("    Contributor routing skipped (--role=maintainer).\n")
+			fmt.Printf("    To set up contributor routing later: bd init --contributor\n")
+		}
+		return nil
+	}
+
+	// Already configured: idempotent re-init.
+	if existing, err := store.GetConfig(ctx, "routing.contributor"); err == nil && existing != "" {
+		if !quiet {
+			fmt.Printf("\n  %s Fork detected (upstream: %s)\n", ui.RenderWarn("⚠"), upstreamURL)
+			fmt.Printf("    Contributor routing already configured → %s\n", existing)
+			fmt.Printf("    Skipping auto-setup. To reconfigure: bd init --contributor\n")
+		}
+		return nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+	planningPath := filepath.Join(homeDir, ".beads-planning")
+
+	createdPlanning := false
+	if _, err := os.Stat(planningPath); os.IsNotExist(err) {
+		createdPlanning = true
+		if err := os.MkdirAll(planningPath, 0750); err != nil {
+			return fmt.Errorf("failed to create planning repo: %w", err)
+		}
+		gitInit := exec.Command("git", "init")
+		gitInit.Dir = planningPath
+		if err := gitInit.Run(); err != nil {
+			return fmt.Errorf("failed to init git in planning repo: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Join(planningPath, ".beads"), 0750); err != nil {
+			return fmt.Errorf("failed to create .beads in planning repo: %w", err)
+		}
+	}
+
+	if err := store.SetConfig(ctx, "routing.mode", "auto"); err != nil {
+		return fmt.Errorf("failed to set routing.mode: %w", err)
+	}
+	if err := store.SetConfig(ctx, "routing.contributor", planningPath); err != nil {
+		return fmt.Errorf("failed to set routing.contributor: %w", err)
+	}
+	if err := store.SetConfig(ctx, "sync.remote", "upstream"); err != nil {
+		return fmt.Errorf("failed to set sync.remote: %w", err)
+	}
+
+	_ = exec.Command("git", "config", "beads.role", "contributor").Run()
+
+	if configPath, err := config.FindConfigYAMLPath(); err == nil {
+		if addErr := config.AddRepo(configPath, planningPath); addErr != nil && !strings.Contains(addErr.Error(), "already exists") {
+			// Non-fatal: hydration config failure doesn't block routing setup
+		}
+	}
+
+	if !quiet {
+		fmt.Printf("\n%s Fork detected — configuring contributor routing\n", ui.RenderAccent("▶"))
+		fmt.Printf("  upstream: %s\n\n", upstreamURL)
+		fmt.Printf("  %s Planning repo: %s\n", ui.RenderPass("✓"), planningPath)
+		fmt.Printf("  %s Issues will route to planning repo (routing.mode=auto)\n", ui.RenderPass("✓"))
+		fmt.Printf("  %s Sync remote set to upstream\n", ui.RenderPass("✓"))
+		if createdPlanning {
+			fmt.Printf("  %s Added .beads/ to planning repo\n", ui.RenderPass("✓"))
+		}
+		fmt.Printf("\n  To use maintainer mode instead: bd init --role=maintainer\n")
+	}
+	return nil
+}
+
 // detectForkSetup checks if we're in a fork by looking for upstream remote
 func detectForkSetup() (isFork bool, upstreamURL string) {
 	cmd := exec.Command("git", "remote", "get-url", "upstream")

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -314,6 +314,61 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("fork_auto_contributor", func(t *testing.T) {
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+
+		origin := filepath.Join(dir, "origin.git")
+		upstream := filepath.Join(dir, "upstream.git")
+		for _, bareRepo := range []string{origin, upstream} {
+			if err := os.MkdirAll(bareRepo, 0755); err != nil {
+				t.Fatalf("mkdir %s: %v", bareRepo, err)
+			}
+			cmd := exec.Command("git", "init", "--bare")
+			cmd.Dir = bareRepo
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git init --bare %s failed: %v\n%s", bareRepo, err, out)
+			}
+		}
+		for name, url := range map[string]string{"origin": origin, "upstream": upstream} {
+			cmd := exec.Command("git", "remote", "add", name, url)
+			cmd.Dir = dir
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git remote add %s failed: %v\n%s", name, err, out)
+			}
+		}
+
+		out := runBDInit(t, bd, dir, "--prefix", "forkauto")
+		if strings.Contains(out, "Fork detected") {
+			t.Errorf("--quiet should suppress fork auto-routing output, got:\n%s", out)
+		}
+
+		beadsDir := filepath.Join(dir, ".beads")
+		planningDir := filepath.Join(dir, ".beads-planning")
+		if val := readBack(t, beadsDir, "forkauto", "routing.mode", false); val != "auto" {
+			t.Errorf("routing.mode: got %q, want %q", val, "auto")
+		}
+		if val := readBack(t, beadsDir, "forkauto", "routing.contributor", false); val != planningDir {
+			t.Errorf("routing.contributor: got %q, want %q", val, planningDir)
+		}
+		if val := readBack(t, beadsDir, "forkauto", "sync.remote", false); val != "upstream" {
+			t.Errorf("sync.remote: got %q, want %q", val, "upstream")
+		}
+		if _, err := os.Stat(filepath.Join(planningDir, ".beads")); err != nil {
+			t.Errorf("planning .beads missing: %v", err)
+		}
+
+		roleCmd := exec.Command("git", "config", "--get", "beads.role")
+		roleCmd.Dir = dir
+		roleOut, err := roleCmd.Output()
+		if err != nil {
+			t.Fatalf("git config --get beads.role failed: %v", err)
+		}
+		if role := strings.TrimSpace(string(roleOut)); role != "contributor" {
+			t.Errorf("beads.role: got %q, want %q", role, "contributor")
+		}
+	})
+
 	t.Run("prefix_trailing_hyphen", func(t *testing.T) {
 		_, beadsDir, _ := bdInit(t, bd, "--prefix", "test-")
 		if val := readBack(t, beadsDir, "test", "issue_prefix", false); val != "test" {

--- a/release-gates/be-7daa14-gate.md
+++ b/release-gates/be-7daa14-gate.md
@@ -5,16 +5,22 @@
 **Date**: 2026-05-19
 **Deployer**: beads/deployer
 
+**Maintainer update**: 2026-05-23, rebased onto current `upstream/main` as
+`codex/fix-pr-4028`. The rebase keeps the current disabled-by-default
+auto-export behavior from `main` and places `autoConfigureForkContributor`
+before the initial `store.Commit` / `store.Close` so routing config is written
+to an open store and included in the initial Dolt commit.
+
 ## Gate Result: PASS
 
 | # | Criterion | Evidence | Result |
 |---|-----------|----------|--------|
 | 1 | Review PASS present | be-rev-169eb4 PASS (2026-05-18) | ✅ PASS |
 | 2 | Acceptance criteria met | See below | ✅ PASS |
-| 3 | Tests pass | CI run 26009117468 — all checks PASS (ubuntu, macOS, Windows smoke, Embedded Dolt cmd 1–20, Storage, lint, fmt, doc freshness, upgrade smokes) | ✅ PASS |
+| 3 | Tests pass | CI run 26009117468 all checks PASS; maintainer rebase adds `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedInit/fork_auto_contributor' -count=1` PASS | ✅ PASS |
 | 4 | No high-severity findings | be-rev-169eb4: "None blocking" — N1/N2/N3 are non-blocking observations about output text deviations from the design mockup; design accepted them as semantically correct | ✅ PASS |
 | 5 | Final branch is clean | `git status` — clean; only `.gc/` and `.gitkeep` untracked (rig artifacts) | ✅ PASS |
-| 6 | Branch diverges cleanly from main | 2 commits ahead of `origin/main`; `git merge-tree` shows 0 conflicts | ✅ PASS |
+| 6 | Branch diverges cleanly from main | Original PR conflicted with current `main` around the auto-export block; maintainer rebase resolved the conflict and preserved current `main` semantics | ✅ PASS |
 
 ## Acceptance Criteria Verification (be-7daa14 + be-0ccf34 design spec)
 
@@ -26,12 +32,13 @@
 | CI / `--quiet` | Silent (no fork block) | All output guarded by `!quiet` | ✅ |
 | No new lipgloss styles | Only `ui.RenderAccent`, `ui.RenderPass`, `ui.RenderWarn` used | Code review confirmed | ✅ |
 | All existing init tests pass | CI run 26009117468 all PASS | CI evidence | ✅ |
-| `bd init` wires `autoConfigureForkContributor` | Called in `init.go` after fork-exclude block | `init.go` wiring (commit `0a5a16eaa`) | ✅ |
+| `bd init` wires `autoConfigureForkContributor` | Called in `init.go` before initial `store.Commit` / `store.Close` so store-backed config writes succeed | Maintainer rebase verified | ✅ |
 | Suppress output in non-interactive mode | Second commit `32d3eb41e` adds `nonInteractive` guard | Code review confirmed | ✅ |
+| Fork auto-routing regression coverage | Temp git fork with `upstream`, non-interactive quiet init, read back `routing.mode`, `routing.contributor`, `sync.remote`, and `beads.role` | `TestEmbeddedInit/fork_auto_contributor` | ✅ |
 
 ## Commits
 
 | SHA | Description |
 |-----|-------------|
-| `0a5a16eaa` | feat(init): auto-configure contributor routing on fork detect (be-7daa14) |
-| `32d3eb41e` | fix(init): suppress autoConfigureForkContributor output in non-interactive mode |
+| `f884d63cd` | feat(init): auto-configure contributor routing on fork detect (be-7daa14), rebased onto current `main` |
+| `8827af348` | fix(init): suppress autoConfigureForkContributor output in non-interactive mode, rebased onto current `main` |

--- a/release-gates/be-7daa14-gate.md
+++ b/release-gates/be-7daa14-gate.md
@@ -1,0 +1,37 @@
+# Release Gate: be-7daa14 — feat(init): auto-configure contributor routing on fork detect
+
+**PR**: https://github.com/gastownhall/beads/pull/4028
+**Branch**: `fix/be-7daa14-fork-detection-output` (quad341/beads)
+**Date**: 2026-05-19
+**Deployer**: beads/deployer
+
+## Gate Result: PASS
+
+| # | Criterion | Evidence | Result |
+|---|-----------|----------|--------|
+| 1 | Review PASS present | be-rev-169eb4 PASS (2026-05-18) | ✅ PASS |
+| 2 | Acceptance criteria met | See below | ✅ PASS |
+| 3 | Tests pass | CI run 26009117468 — all checks PASS (ubuntu, macOS, Windows smoke, Embedded Dolt cmd 1–20, Storage, lint, fmt, doc freshness, upgrade smokes) | ✅ PASS |
+| 4 | No high-severity findings | be-rev-169eb4: "None blocking" — N1/N2/N3 are non-blocking observations about output text deviations from the design mockup; design accepted them as semantically correct | ✅ PASS |
+| 5 | Final branch is clean | `git status` — clean; only `.gc/` and `.gitkeep` untracked (rig artifacts) | ✅ PASS |
+| 6 | Branch diverges cleanly from main | 2 commits ahead of `origin/main`; `git merge-tree` shows 0 conflicts | ✅ PASS |
+
+## Acceptance Criteria Verification (be-7daa14 + be-0ccf34 design spec)
+
+| Scenario | Expected output | Code path | Result |
+|----------|-----------------|-----------|--------|
+| Happy path (fork, first run) | `▶ Fork detected — configuring contributor routing` + `upstream: <url>` + 3–4 `✓` lines + opt-out hint | `autoConfigureForkContributor`: `isFork=true`, `existing=""`, `!quiet` block at function end | ✅ |
+| Opt-out (`--role=maintainer` on fork) | `⚠ Fork detected (upstream: <url>) / Contributor routing skipped / To set up later: bd init --contributor` | `roleFlag == "maintainer"` branch | ✅ |
+| Re-init (already configured) | `⚠ Fork detected (upstream: <url>) / already configured → <path> / Skipping auto-setup` | `existing != ""` branch | ✅ |
+| CI / `--quiet` | Silent (no fork block) | All output guarded by `!quiet` | ✅ |
+| No new lipgloss styles | Only `ui.RenderAccent`, `ui.RenderPass`, `ui.RenderWarn` used | Code review confirmed | ✅ |
+| All existing init tests pass | CI run 26009117468 all PASS | CI evidence | ✅ |
+| `bd init` wires `autoConfigureForkContributor` | Called in `init.go` after fork-exclude block | `init.go` wiring (commit `0a5a16eaa`) | ✅ |
+| Suppress output in non-interactive mode | Second commit `32d3eb41e` adds `nonInteractive` guard | Code review confirmed | ✅ |
+
+## Commits
+
+| SHA | Description |
+|-----|-------------|
+| `0a5a16eaa` | feat(init): auto-configure contributor routing on fork detect (be-7daa14) |
+| `32d3eb41e` | fix(init): suppress autoConfigureForkContributor output in non-interactive mode |


### PR DESCRIPTION
## Fix-merge for #4028

This branch preserves Jim Wordelman's PR #4028 commits, rebases them onto current `upstream/main`, and applies the maintainer conflict fix needed before landing.

Changes beyond the contributor branch:

- Resolves the current `main` conflict around the auto-export prompt while preserving `main`'s disabled-by-default auto-export behavior.
- Places `autoConfigureForkContributor` before the initial `store.Commit` / `store.Close`, so `routing.mode`, `routing.contributor`, and `sync.remote` are written while the store is still open and included in the initial Dolt commit.
- Adds `TestEmbeddedInit/fork_auto_contributor`, covering a temp git fork with `upstream`, quiet non-interactive init, stored routing config, `sync.remote=upstream`, planning repo creation, and `beads.role=contributor`.
- Updates the release-gate evidence for the rebase and added regression coverage.

Tested:

```bash
BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedInit/fork_auto_contributor' -count=1
```

Attribution: preserves the original contributor commits from #4028 and adds one maintainer test/gate update commit.

_codex-gpt-5.5-high on behalf of matt wilkie_
