### PR TITLE
fix(storage/dolt): IterDependentsWithMetadata uses 3-way split deps (post-0043)

### DIFF
--- a/internal/storage/dolt/iter_dependents.go
+++ b/internal/storage/dolt/iter_dependents.go
@@ -45,16 +45,20 @@ type doltDependentsIter struct {
 // matches GetDependentsWithMetadata. See the package doc for why the join
 // target per edge table is unambiguous.
 func (s *DoltStore) IterDependentsWithMetadata(ctx context.Context, issueID string) (storage.Iter[types.IssueWithDependencyMetadata], error) {
+	// Migration 0043 dropped the generated `depends_on_id` column on both
+	// `dependencies` and `wisp_dependencies`. Resolve the target via the
+	// split physical columns, matching the qualified form used by sibling
+	// JOIN sites (e.g. CountDependentsByStatus in counts.go).
 	q := fmt.Sprintf(`
 		SELECT %s, d.type
 		FROM issues i
 		JOIN dependencies d ON d.issue_id = i.id
-		WHERE d.depends_on_id = ?
+		WHERE COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) = ?
 		UNION ALL
 		SELECT %s, d.type
 		FROM wisps w
 		JOIN wisp_dependencies d ON d.issue_id = w.id
-		WHERE d.depends_on_id = ?
+		WHERE COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) = ?
 		ORDER BY created_at ASC
 	`, prefixedIssueColumns("i"), prefixedIssueColumns("w"))
 	return s.iterIssuesWithDepType(ctx, q, issueID, issueID)


### PR DESCRIPTION
## Summary

Migration `0043_drop_dependencies_generated_column` removed the generated `depends_on_id` column from both `dependencies` and `wisp_dependencies`. `IterDependentsWithMetadata` still referenced it in both UNION arms.

Every `bd show <id>` dependents lookup and the deps walk inside `gc doctor` were hitting a prepare-time error:

```
unable to prepare query: table "d" does not have column "depends_on_id"
query="JOIN dependencies d ON d.issue_id = i.id WHERE d.depends_on_id = ? ..."
```

## Fix

Resolve the target via the split physical columns using the same qualified `COALESCE` form already used by sibling JOIN sites — e.g. `CountDependentsByStatus` in `counts.go:127-149`:

```sql
WHERE COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) = ?
```

Applied to both UNION arms (permanent and wisp dependents).

## Regression coverage

Already in place. `TestCountAndIterIncludeWispDependencies` in `internal/storage/dolt/counts_wisp_test.go:82-95` exercises `IterDependentsWithMetadata` against both edge tables — it will fail without this fix once executed against post-0043 schema.

## Test plan

- [ ] `go test -run TestCountAndIterIncludeWispDependencies ./internal/storage/dolt/...` (requires Docker / Dolt test container — skipped locally; CI exercises it)
- [ ] After merge: dolt server log no longer emits the `table "d" does not have column "depends_on_id"` prepare error
- [ ] After merge: `bd show <id>` returns dependents in JSON

Refs: downstream bead bds-md5 (beads-contrib rig)