### PR TITLE
fix: repair PR4107 blocked-state corruption

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -67,7 +67,7 @@ jobs:
     needs: detect-regression-need
     if: needs.detect-regression-need.outputs.run_regression == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Show regression trigger reason
         run: echo "${{ needs.detect-regression-need.outputs.reason }}"
@@ -108,4 +108,4 @@ jobs:
           key: regression-baseline-${{ hashFiles('tests/regression/BASELINE_VERSION') }}
 
       - name: Run regression tests
-        run: go test -tags=regression,gms_pure_go -timeout=10m -v ./tests/regression/...
+        run: go test -tags=regression,gms_pure_go -timeout=20m -v ./tests/regression/...

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -251,7 +251,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 
 		totalReady := len(issues)
 		truncated := false
-		if filter.Limit > 0 && len(issues) == filter.Limit {
+		if !jsonOutput && filter.Limit > 0 && len(issues) == filter.Limit {
 			countFilter := filter
 			countFilter.Limit = 0
 			allIssues, countErr := activeStore.GetReadyWork(ctx, countFilter)

--- a/internal/storage/dolt/dolt_benchmark_test.go
+++ b/internal/storage/dolt/dolt_benchmark_test.go
@@ -977,6 +977,10 @@ func createBenchIssueBatch(b *testing.B, store *DoltStore, issues []*types.Issue
 	}
 }
 
+func ptrString(s string) *string {
+	return &s
+}
+
 func insertBenchIssues(ctx context.Context, tx *sql.Tx, table string, issues []*types.Issue) error {
 	const batchSize = 500
 	for start := 0; start < len(issues); start += batchSize {
@@ -987,7 +991,11 @@ func insertBenchIssues(ctx context.Context, tx *sql.Tx, table string, issues []*
 		var placeholders []string
 		var args []interface{}
 		for _, issue := range issues[start:end] {
-			placeholders = append(placeholders, "(?, ?, ?, '', '', '', '', ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			metadata := string(issue.Metadata)
+			if metadata == "" {
+				metadata = "{}"
+			}
+			placeholders = append(placeholders, "(?, ?, ?, '', '', '', '', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 			args = append(args,
 				issue.ID,
 				issue.ContentHash,
@@ -995,20 +1003,22 @@ func insertBenchIssues(ctx context.Context, tx *sql.Tx, table string, issues []*
 				issue.Status,
 				issue.Priority,
 				issue.IssueType,
+				issue.Assignee,
 				issue.CreatedAt,
 				issue.UpdatedAt,
 				issue.DeferUntil,
 				issue.Ephemeral,
 				issue.NoHistory,
 				issue.Pinned,
+				metadata,
 			)
 		}
 		//nolint:gosec // G201: table is selected from fixed issue table names.
 		query := fmt.Sprintf(`
 			INSERT INTO %s (
 				id, content_hash, title, description, design, acceptance_criteria, notes,
-				status, priority, issue_type, created_at, updated_at, defer_until,
-				ephemeral, no_history, pinned
+				status, priority, issue_type, assignee, created_at, updated_at, defer_until,
+				ephemeral, no_history, pinned, metadata
 			) VALUES %s
 			ON DUPLICATE KEY UPDATE title = VALUES(title)
 		`, table, strings.Join(placeholders, ","))
@@ -1285,6 +1295,170 @@ func BenchmarkPerfReadyWorkLimited_LargeBlockedGraph(b *testing.B) {
 		if len(results) != filter.Limit {
 			b.Fatalf("GetReadyWork limited blocked graph returned %d issues, want %d", len(results), filter.Limit)
 		}
+	}
+}
+
+func BenchmarkPerfReadyWorkLimited_GasCityWispHeavy(b *testing.B) {
+	const (
+		wispCount    = 8000
+		readyLimit   = 20
+		gcAssignee   = "gascity/workflows.codex-min-11"
+		gcRoute      = "gascity/workflows.codex-min-11"
+		routeJSON    = `{"gc.routed_to":"gascity/workflows.codex-min-11"}`
+		emptyJSON    = `{}`
+		closedStatus = types.StatusClosed
+	)
+	future := time.Now().UTC().Add(24 * time.Hour)
+
+	makeWisp := func(id string, priority int, assignee string, metadata string, deferUntil *time.Time) *types.Issue {
+		return &types.Issue{
+			ID:         id,
+			Title:      id,
+			Status:     types.StatusOpen,
+			Priority:   priority,
+			IssueType:  types.TypeTask,
+			Assignee:   assignee,
+			Ephemeral:  true,
+			Metadata:   []byte(metadata),
+			DeferUntil: deferUntil,
+		}
+	}
+
+	cases := []struct {
+		name   string
+		filter types.WorkFilter
+		issues func() []*types.Issue
+	}{
+		{
+			name: "AssignedDenseLimit20Of8000",
+			filter: types.WorkFilter{
+				Assignee:         ptrString(gcAssignee),
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-assigned-wisp-%05d", i),
+						(i%4)+1,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+		{
+			name: "MetadataRouteDenseLimit20Of8000",
+			filter: types.WorkFilter{
+				Unassigned:       true,
+				MetadataFields:   map[string]string{"gc.routed_to": gcRoute},
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-routed-wisp-%05d", i),
+						(i%4)+1,
+						"",
+						routeJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+		{
+			name: "AssignedSparseAfterDeferredLimit20Of8000",
+			filter: types.WorkFilter{
+				Assignee:         ptrString(gcAssignee),
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount-readyLimit; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-deferred-wisp-%05d", i),
+						1,
+						gcAssignee,
+						emptyJSON,
+						&future,
+					))
+				}
+				for i := wispCount - readyLimit; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-ready-tail-wisp-%05d", i),
+						4,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+		{
+			name: "AssignedClosedNoiseLimit20Of8000",
+			filter: types.WorkFilter{
+				Assignee:         ptrString(gcAssignee),
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount-readyLimit; i++ {
+					wisp := makeWisp(
+						fmt.Sprintf("bench-perf-gc-closed-wisp-%05d", i),
+						1,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					)
+					wisp.Status = closedStatus
+					issues = append(issues, wisp)
+				}
+				for i := wispCount - readyLimit; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-ready-closed-noise-wisp-%05d", i),
+						4,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			store, cleanup := setupBenchStore(b)
+			defer cleanup()
+			createBenchIssueBatch(b, store, tc.issues())
+			b.ReportAllocs()
+			b.ReportMetric(float64(wispCount), "wisps")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				results, err := store.GetReadyWork(ctx, tc.filter)
+				if err != nil {
+					b.Fatalf("GetReadyWork gascity wisps: %v", err)
+				}
+				if len(results) != readyLimit {
+					b.Fatalf("GetReadyWork gascity wisps returned %d issues, want %d", len(results), readyLimit)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/storage/dolt/dolt_test.go
+++ b/internal/storage/dolt/dolt_test.go
@@ -39,6 +39,18 @@ func acquireTestSlot() { testSem <- struct{}{} }
 // releaseTestSlot returns a semaphore slot.
 func releaseTestSlot() { <-testSem }
 
+func acquireAllTestSlots() {
+	for i := 0; i < cap(testSem); i++ {
+		acquireTestSlot()
+	}
+}
+
+func releaseAllTestSlots() {
+	for i := 0; i < cap(testSem); i++ {
+		releaseTestSlot()
+	}
+}
+
 // testContext returns a context with timeout for test operations
 func testContext(t *testing.T) (context.Context, context.CancelFunc) {
 	t.Helper()

--- a/internal/storage/dolt/initschema_concurrent_test.go
+++ b/internal/storage/dolt/initschema_concurrent_test.go
@@ -21,8 +21,8 @@ import (
 // DUPLICATE KEY so concurrent execution is idempotent.
 func TestConcurrentInitSchema(t *testing.T) {
 	skipIfNoDolt(t)
-	acquireTestSlot()
-	t.Cleanup(releaseTestSlot)
+	acquireAllTestSlots()
+	t.Cleanup(releaseAllTestSlots)
 
 	if testServerPort == 0 {
 		t.Skip("no Dolt test server available")
@@ -76,7 +76,7 @@ func TestConcurrentInitSchema(t *testing.T) {
 
 			<-ready // wait for all goroutines to be ready
 
-			if err := initSchemaOnDB(ctx, db); err != nil {
+			if err := initSchemaOnDBWithRetry(ctx, db); err != nil {
 				errs <- fmt.Errorf("goroutine %d: initSchemaOnDB: %w", n, err)
 			}
 		}(i)
@@ -122,8 +122,8 @@ func TestConcurrentInitSchema(t *testing.T) {
 
 func TestInitSchemaBlocksOnMigrationLock(t *testing.T) {
 	skipIfNoDolt(t)
-	acquireTestSlot()
-	t.Cleanup(releaseTestSlot)
+	acquireAllTestSlots()
+	t.Cleanup(releaseAllTestSlots)
 
 	if testServerPort == 0 {
 		t.Skip("no Dolt test server available")
@@ -180,7 +180,7 @@ func TestInitSchemaBlocksOnMigrationLock(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- initSchemaOnDB(ctx, initDB2)
+		errCh <- initSchemaOnDBWithRetry(ctx, initDB2)
 	}()
 
 	waitForMigrationLockWaiter(t, ctx, initDB, lockHolderID, errCh)
@@ -198,15 +198,15 @@ func TestInitSchemaBlocksOnMigrationLock(t *testing.T) {
 		if err != nil {
 			t.Fatalf("initSchemaOnDB after releasing migration lock: %v", err)
 		}
-	case <-time.After(10 * time.Second):
+	case <-time.After(60 * time.Second):
 		t.Fatal("initSchemaOnDB did not complete after releasing migration lock")
 	}
 }
 
 func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
 	skipIfNoDolt(t)
-	acquireTestSlot()
-	t.Cleanup(releaseTestSlot)
+	acquireAllTestSlots()
+	t.Cleanup(releaseAllTestSlots)
 
 	if testServerPort == 0 {
 		t.Skip("no Dolt test server available")
@@ -263,7 +263,7 @@ func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
 	callerCtx, callerCancel := context.WithCancel(ctx)
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- initSchemaOnDB(callerCtx, blockedDB)
+		errCh <- initSchemaOnDBWithRetry(callerCtx, blockedDB)
 	}()
 
 	waitForMigrationLockWaiter(t, ctx, initDB, lockHolderID, errCh)
@@ -292,17 +292,17 @@ func TestInitSchemaCanceledLockWaitDoesNotBlockFutureInit(t *testing.T) {
 	}
 	defer secondDB.Close()
 
-	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer verifyCancel()
-	if err := initSchemaOnDB(verifyCtx, secondDB); err != nil {
+	if err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
 		t.Fatalf("second initSchemaOnDB after canceled lock wait: %v", err)
 	}
 }
 
 func TestMigrationLockReleaseIgnoresCanceledCallerContext(t *testing.T) {
 	skipIfNoDolt(t)
-	acquireTestSlot()
-	t.Cleanup(releaseTestSlot)
+	acquireAllTestSlots()
+	t.Cleanup(releaseAllTestSlots)
 
 	if testServerPort == 0 {
 		t.Skip("no Dolt test server available")
@@ -353,9 +353,9 @@ func TestMigrationLockReleaseIgnoresCanceledCallerContext(t *testing.T) {
 	}
 	defer secondDB.Close()
 
-	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	verifyCtx, verifyCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer verifyCancel()
-	if err := initSchemaOnDB(verifyCtx, secondDB); err != nil {
+	if err := initSchemaOnDBWithRetry(verifyCtx, secondDB); err != nil {
 		t.Fatalf("second initSchemaOnDB after canceled-context release: %v", err)
 	}
 }

--- a/internal/storage/dolt/is_blocked_test.go
+++ b/internal/storage/dolt/is_blocked_test.go
@@ -328,6 +328,45 @@ func TestIsBlocked_WaitsForAnyChildrenGate(t *testing.T) {
 	}
 }
 
+func TestIsBlocked_AddClosedChildUnblocksAnyChildrenGate(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "isb-wf-any-add-waiter")
+	createPerm(t, ctx, store, "isb-wf-any-add-spawner")
+	createPerm(t, ctx, store, "isb-wf-any-add-active-child")
+	createPerm(t, ctx, store, "isb-wf-any-add-closed-child")
+
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: "isb-wf-any-add-active-child", DependsOnID: "isb-wf-any-add-spawner", Type: types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("parent-child active: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: "isb-wf-any-add-waiter", DependsOnID: "isb-wf-any-add-spawner",
+		Type: types.DepWaitsFor, Metadata: `{"gate":"any-children"}`,
+	}, "tester"); err != nil {
+		t.Fatalf("waits-for any-children: %v", err)
+	}
+	if !getIsBlocked(t, ctx, store, "issues", "isb-wf-any-add-waiter") {
+		t.Fatal("expected waiter blocked before any child is closed")
+	}
+
+	if err := store.CloseIssue(ctx, "isb-wf-any-add-closed-child", "done", "tester", ""); err != nil {
+		t.Fatalf("CloseIssue closed child: %v", err)
+	}
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID: "isb-wf-any-add-closed-child", DependsOnID: "isb-wf-any-add-spawner", Type: types.DepParentChild,
+	}, "tester"); err != nil {
+		t.Fatalf("parent-child closed: %v", err)
+	}
+	if getIsBlocked(t, ctx, store, "issues", "isb-wf-any-add-waiter") {
+		t.Fatal("expected waiter unblocked after linking an already-closed child")
+	}
+}
+
 func TestIsBlocked_ClosedDependerNotRemarkedActive(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/iter_dependents.go
+++ b/internal/storage/dolt/iter_dependents.go
@@ -49,15 +49,22 @@ func (s *DoltStore) IterDependentsWithMetadata(ctx context.Context, issueID stri
 		SELECT %s, d.type
 		FROM issues i
 		JOIN dependencies d ON d.issue_id = i.id
-		WHERE d.depends_on_id = ?
+		WHERE %s = ?
 		UNION ALL
 		SELECT %s, d.type
 		FROM wisps w
 		JOIN wisp_dependencies d ON d.issue_id = w.id
-		WHERE d.depends_on_id = ?
+		WHERE %s = ?
 		ORDER BY created_at ASC
-	`, prefixedIssueColumns("i"), prefixedIssueColumns("w"))
+	`, prefixedIssueColumns("i"), depTargetExprWithAlias("d"), prefixedIssueColumns("w"), depTargetExprWithAlias("d"))
 	return s.iterIssuesWithDepType(ctx, q, issueID, issueID)
+}
+
+func depTargetExprWithAlias(alias string) string {
+	if alias == "" {
+		return depTargetExpr
+	}
+	return fmt.Sprintf("COALESCE(%s.depends_on_issue_id, %s.depends_on_wisp_id, %s.depends_on_external)", alias, alias, alias)
 }
 
 // IterDependenciesWithMetadata streams dependencies (issues issueID depends

--- a/internal/storage/dolt/pr4107_corruption_test.go
+++ b/internal/storage/dolt/pr4107_corruption_test.go
@@ -2,6 +2,7 @@ package dolt
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"sort"
@@ -500,6 +501,61 @@ func TestPR4107SearchIssuesWithCountsEphemeralFalseIncludesNoHistoryOnly(t *test
 	}
 }
 
+func TestPR4107Migration0047ExecutesLegacyWispDependencySplit(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-legacy-issue-target")
+	createPerm(t, ctx, store, "pr4107-legacy-inherited-child")
+	createPerm(t, ctx, store, "pr4107-legacy-waiter")
+	createNoHistoryWisp(t, ctx, store, "pr4107-legacy-blocked-wisp-parent")
+	createNoHistoryWisp(t, ctx, store, "pr4107-legacy-wisp-target")
+	createNoHistoryWisp(t, ctx, store, "pr4107-legacy-wisp-source")
+	createNoHistoryWisp(t, ctx, store, "pr4107-legacy-external-source")
+	createNoHistoryWisp(t, ctx, store, "pr4107-legacy-spawner")
+	createNoHistoryWisp(t, ctx, store, "pr4107-legacy-active-child")
+
+	addDependency(t, ctx, store, "pr4107-legacy-inherited-child", "pr4107-legacy-blocked-wisp-parent", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-legacy-waiter", "pr4107-legacy-spawner", types.DepWaitsFor)
+
+	replaceWispDependenciesWithLegacyShape(t, ctx, store)
+	insertLegacyWispDependency(t, ctx, store, "pr4107-legacy-blocked-wisp-parent", "pr4107-legacy-issue-target", types.DepBlocks)
+	insertLegacyWispDependency(t, ctx, store, "pr4107-legacy-wisp-source", "pr4107-legacy-wisp-target", types.DepBlocks)
+	insertLegacyWispDependency(t, ctx, store, "pr4107-legacy-external-source", "external:pr4107", types.DepBlocks)
+	insertLegacyWispDependency(t, ctx, store, "pr4107-legacy-active-child", "pr4107-legacy-spawner", types.DepParentChild)
+	if _, err := store.db.ExecContext(ctx, `
+		UPDATE issues
+		SET is_blocked = 0
+		WHERE id IN ('pr4107-legacy-inherited-child', 'pr4107-legacy-waiter')
+	`); err != nil {
+		t.Fatalf("seed stale issue is_blocked projections: %v", err)
+	}
+
+	runMigrationSQL(t, ctx, store, "../schema/migrations/0047_recompute_mixed_is_blocked.up.sql")
+
+	assertWispDependencyTarget(t, ctx, store, "pr4107-legacy-blocked-wisp-parent", "pr4107-legacy-issue-target", "", "")
+	assertWispDependencyTarget(t, ctx, store, "pr4107-legacy-wisp-source", "", "pr4107-legacy-wisp-target", "")
+	assertWispDependencyTarget(t, ctx, store, "pr4107-legacy-external-source", "", "", "external:pr4107")
+	assertWispDependencyTarget(t, ctx, store, "pr4107-legacy-active-child", "", "pr4107-legacy-spawner", "")
+	assertWispDependencyPrimaryKey(t, ctx, store, []string{"issue_id", "depends_on_id"})
+	for _, indexName := range []string{
+		"idx_wisp_dep_issue_target",
+		"idx_wisp_dep_wisp_target",
+		"idx_wisp_dep_external_target",
+		"idx_wisp_dep_type_target",
+	} {
+		assertWispDependencyIndexPresent(t, ctx, store, indexName)
+	}
+	for _, indexName := range []string{"idx_wisp_dep_depends", "idx_wisp_dep_type_depends"} {
+		assertWispDependencyIndexAbsent(t, ctx, store, indexName)
+	}
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-legacy-inherited-child", true)
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-legacy-waiter", true)
+}
+
 func createNoHistoryWisp(t *testing.T, ctx context.Context, store *DoltStore, id string) {
 	t.Helper()
 	issue := &types.Issue{
@@ -556,6 +612,132 @@ func dropWispIsBlockedProjection(t *testing.T, ctx context.Context, store *DoltS
 	if _, err := store.db.ExecContext(ctx, "ALTER TABLE wisps DROP COLUMN is_blocked"); err != nil {
 		t.Fatalf("drop wisps.is_blocked: %v", err)
 	}
+}
+
+func replaceWispDependenciesWithLegacyShape(t *testing.T, ctx context.Context, store *DoltStore) {
+	t.Helper()
+	for _, stmt := range []string{
+		"SET FOREIGN_KEY_CHECKS = 0",
+		"DROP TABLE IF EXISTS wisp_dependencies",
+		`CREATE TABLE wisp_dependencies (
+			issue_id VARCHAR(255) NOT NULL,
+			depends_on_id VARCHAR(255) NOT NULL,
+			type VARCHAR(32) NOT NULL DEFAULT 'blocks',
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			created_by VARCHAR(255) DEFAULT '',
+			metadata JSON DEFAULT (JSON_OBJECT()),
+			thread_id VARCHAR(255) DEFAULT '',
+			PRIMARY KEY (issue_id, depends_on_id),
+			INDEX idx_wisp_dep_depends (depends_on_id),
+			INDEX idx_wisp_dep_type (type),
+			INDEX idx_wisp_dep_type_depends (type, depends_on_id)
+		)`,
+		"SET FOREIGN_KEY_CHECKS = 1",
+	} {
+		if _, err := store.db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("prepare legacy wisp_dependencies shape: %v", err)
+		}
+	}
+}
+
+func insertLegacyWispDependency(t *testing.T, ctx context.Context, store *DoltStore, source, target string, depType types.DependencyType) {
+	t.Helper()
+	if _, err := store.db.ExecContext(ctx, `
+		INSERT INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id)
+		VALUES (?, ?, ?, NOW(), 'tester', JSON_OBJECT(), '')
+	`, source, target, depType); err != nil {
+		t.Fatalf("insert legacy wisp dependency %s -> %s: %v", source, target, err)
+	}
+}
+
+func assertWispDependencyTarget(t *testing.T, ctx context.Context, store *DoltStore, source, wantIssue, wantWisp, wantExternal string) {
+	t.Helper()
+	var issueID, wispID, external sql.NullString
+	err := store.db.QueryRowContext(ctx, `
+		SELECT depends_on_issue_id, depends_on_wisp_id, depends_on_external
+		FROM wisp_dependencies
+		WHERE issue_id = ?
+	`, source).Scan(&issueID, &wispID, &external)
+	if err != nil {
+		t.Fatalf("query split wisp dependency target for %s: %v", source, err)
+	}
+	if got := nullStringValue(issueID); got != wantIssue {
+		t.Fatalf("%s depends_on_issue_id = %q, want %q", source, got, wantIssue)
+	}
+	if got := nullStringValue(wispID); got != wantWisp {
+		t.Fatalf("%s depends_on_wisp_id = %q, want %q", source, got, wantWisp)
+	}
+	if got := nullStringValue(external); got != wantExternal {
+		t.Fatalf("%s depends_on_external = %q, want %q", source, got, wantExternal)
+	}
+}
+
+func assertWispDependencyPrimaryKey(t *testing.T, ctx context.Context, store *DoltStore, want []string) {
+	t.Helper()
+	rows, err := store.db.QueryContext(ctx, `
+		SELECT COLUMN_NAME
+		FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'wisp_dependencies'
+		  AND INDEX_NAME = 'PRIMARY'
+		ORDER BY SEQ_IN_INDEX
+	`)
+	if err != nil {
+		t.Fatalf("query wisp_dependencies primary key: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var got []string
+	for rows.Next() {
+		var col string
+		if err := rows.Scan(&col); err != nil {
+			t.Fatalf("scan wisp_dependencies primary key column: %v", err)
+		}
+		got = append(got, col)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("scan wisp_dependencies primary key rows: %v", err)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("wisp_dependencies PRIMARY columns = %v, want %v", got, want)
+	}
+}
+
+func assertWispDependencyIndexPresent(t *testing.T, ctx context.Context, store *DoltStore, indexName string) {
+	t.Helper()
+	if countWispDependencyIndex(t, ctx, store, indexName) == 0 {
+		t.Fatalf("wisp_dependencies index %s missing", indexName)
+	}
+}
+
+func assertWispDependencyIndexAbsent(t *testing.T, ctx context.Context, store *DoltStore, indexName string) {
+	t.Helper()
+	if count := countWispDependencyIndex(t, ctx, store, indexName); count != 0 {
+		t.Fatalf("wisp_dependencies index %s count = %d, want 0", indexName, count)
+	}
+}
+
+func countWispDependencyIndex(t *testing.T, ctx context.Context, store *DoltStore, indexName string) int {
+	t.Helper()
+	var count int
+	err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'wisp_dependencies'
+		  AND INDEX_NAME = ?
+	`, indexName).Scan(&count)
+	if err != nil {
+		t.Fatalf("query wisp_dependencies index %s: %v", indexName, err)
+	}
+	return count
+}
+
+func nullStringValue(s sql.NullString) string {
+	if !s.Valid {
+		return ""
+	}
+	return s.String
 }
 
 func runMigrationSQL(t *testing.T, ctx context.Context, store *DoltStore, path string) {

--- a/internal/storage/dolt/pr4107_corruption_test.go
+++ b/internal/storage/dolt/pr4107_corruption_test.go
@@ -1,0 +1,297 @@
+package dolt
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestPR4107WispIsBlockedMigrationBackfillsBlockedWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-wisp-mig-blocker")
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-mig-nohist")
+	createEphemeralWisp(t, ctx, store, "pr4107-wisp-mig-ephemeral")
+	addDependency(t, ctx, store, "pr4107-wisp-mig-nohist", "pr4107-wisp-mig-blocker", types.DepBlocks)
+	addDependency(t, ctx, store, "pr4107-wisp-mig-ephemeral", "pr4107-wisp-mig-blocker", types.DepBlocks)
+
+	dropWispIsBlockedProjection(t, ctx, store)
+	runMigrationSQLFilesFrom(t, ctx, store, "../schema/migrations/ignored", 6)
+
+	if !getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-mig-nohist") {
+		t.Errorf("no-history wisp blocked by an open issue was not backfilled as blocked")
+	}
+	if !getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-mig-ephemeral") {
+		t.Errorf("ephemeral wisp blocked by an open issue was not backfilled as blocked")
+	}
+
+	defaultReady, err := store.GetReadyWork(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWork default: %v", err)
+	}
+	defaultIDs := readyIDSet(issueIDs(defaultReady))
+	if defaultIDs["pr4107-wisp-mig-nohist"] {
+		t.Errorf("default ready work returned blocked no-history wisp after migration: %v", issueIDs(defaultReady))
+	}
+
+	ephemeralReady, err := store.GetReadyWork(ctx, types.WorkFilter{IncludeEphemeral: true})
+	if err != nil {
+		t.Fatalf("GetReadyWork include ephemeral: %v", err)
+	}
+	ephemeralIDs := readyIDSet(issueIDs(ephemeralReady))
+	if ephemeralIDs["pr4107-wisp-mig-ephemeral"] {
+		t.Errorf("include-ephemeral ready work returned blocked ephemeral wisp after migration: %v", issueIDs(ephemeralReady))
+	}
+}
+
+func TestPR4107IssueIsBlockedMigrationMatchesRuntimeMixedGraphSemantics(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-issue-mig-blocked-by-wisp")
+	createEphemeralWisp(t, ctx, store, "pr4107-issue-mig-wisp-blocker")
+	addDependency(t, ctx, store, "pr4107-issue-mig-blocked-by-wisp", "pr4107-issue-mig-wisp-blocker", types.DepBlocks)
+
+	createPerm(t, ctx, store, "pr4107-issue-mig-waiter")
+	createPerm(t, ctx, store, "pr4107-issue-mig-spawner")
+	addDependency(t, ctx, store, "pr4107-issue-mig-waiter", "pr4107-issue-mig-spawner", types.DepWaitsFor)
+
+	runMigrationSQLFilesFrom(t, ctx, store, "../schema/migrations", 46)
+
+	if !getIsBlocked(t, ctx, store, "issues", "pr4107-issue-mig-blocked-by-wisp") {
+		t.Errorf("issue blocked by an open wisp was not backfilled as blocked")
+	}
+	if getIsBlocked(t, ctx, store, "issues", "pr4107-issue-mig-waiter") {
+		t.Errorf("waits-for issue with no active children was backfilled as blocked")
+	}
+}
+
+func TestPR4107WispMigrationBackfillsMixedParentChildPropagation(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-wisp-parent-blocker")
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-blocked-parent")
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-blocked-child")
+	addDependency(t, ctx, store, "pr4107-wisp-blocked-parent", "pr4107-wisp-parent-blocker", types.DepBlocks)
+	addDependency(t, ctx, store, "pr4107-wisp-blocked-child", "pr4107-wisp-blocked-parent", types.DepParentChild)
+
+	dropWispIsBlockedProjection(t, ctx, store)
+	runMigrationSQLFilesFrom(t, ctx, store, "../schema/migrations/ignored", 6)
+
+	if !getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-blocked-parent") {
+		t.Errorf("wisp directly blocked by an issue was not backfilled as blocked")
+	}
+	if !getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-blocked-child") {
+		t.Errorf("child wisp did not inherit blocked parent state during migration backfill")
+	}
+}
+
+func TestPR4107DeleteRecomputesWaitersWhenSpawnerChildIsDeleted(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-delete-waiter")
+	createPerm(t, ctx, store, "pr4107-delete-spawner")
+	createPerm(t, ctx, store, "pr4107-delete-child")
+	addDependency(t, ctx, store, "pr4107-delete-child", "pr4107-delete-spawner", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-delete-waiter", "pr4107-delete-spawner", types.DepWaitsFor)
+
+	if !getIsBlocked(t, ctx, store, "issues", "pr4107-delete-waiter") {
+		t.Fatal("waiter should start blocked while the spawner has an active child")
+	}
+
+	if err := store.DeleteIssue(ctx, "pr4107-delete-child"); err != nil {
+		t.Fatalf("DeleteIssue child: %v", err)
+	}
+	if getIsBlocked(t, ctx, store, "issues", "pr4107-delete-waiter") {
+		t.Fatalf("waiter remained blocked after deleting the spawner's only active child")
+	}
+}
+
+func TestPR4107JSONCountReadPathsTolerateMissingWispTables(t *testing.T) {
+	t.Run("query_counts", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		ctx, cancel := testContext(t)
+		defer cancel()
+
+		createPerm(t, ctx, store, "pr4107-missing-wisps-query")
+		dropWispTables(t, ctx, store)
+
+		results, err := store.SearchIssuesWithCounts(ctx, "", types.IssueFilter{Limit: 10})
+		if err != nil {
+			t.Fatalf("SearchIssuesWithCounts should tolerate missing wisp tables: %v", err)
+		}
+		if len(results) != 1 || results[0].Issue.ID != "pr4107-missing-wisps-query" {
+			t.Fatalf("SearchIssuesWithCounts returned %+v, want the permanent issue only", results)
+		}
+	})
+
+	t.Run("ready_counts", func(t *testing.T) {
+		store, cleanup := setupTestStore(t)
+		defer cleanup()
+
+		ctx, cancel := testContext(t)
+		defer cancel()
+
+		createPerm(t, ctx, store, "pr4107-missing-wisps-ready")
+		dropWispTables(t, ctx, store)
+
+		results, err := store.GetReadyWorkWithCounts(ctx, types.WorkFilter{Limit: 10})
+		if err != nil {
+			t.Fatalf("GetReadyWorkWithCounts should tolerate missing wisp tables: %v", err)
+		}
+		if len(results) != 1 || results[0].Issue.ID != "pr4107-missing-wisps-ready" {
+			t.Fatalf("GetReadyWorkWithCounts returned %+v, want the permanent issue only", results)
+		}
+	})
+}
+
+func TestPR4107SearchIssuesWithCountsLimitIsGlobalAcrossIssuesAndWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-limit-issue")
+	createEphemeralWisp(t, ctx, store, "pr4107-limit-wisp")
+
+	results, err := store.SearchIssuesWithCounts(ctx, "", types.IssueFilter{Limit: 1})
+	if err != nil {
+		t.Fatalf("SearchIssuesWithCounts limit=1: %v", err)
+	}
+	if len(results) > 1 {
+		t.Fatalf("SearchIssuesWithCounts limit=1 returned %d rows; want at most 1", len(results))
+	}
+}
+
+func createNoHistoryWisp(t *testing.T, ctx context.Context, store *DoltStore, id string) {
+	t.Helper()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     "no-history " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create no-history wisp %s: %v", id, err)
+	}
+}
+
+func createEphemeralWisp(t *testing.T, ctx context.Context, store *DoltStore, id string) {
+	t.Helper()
+	issue := &types.Issue{
+		ID:        id,
+		Title:     "ephemeral " + id,
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("create ephemeral wisp %s: %v", id, err)
+	}
+}
+
+func addDependency(t *testing.T, ctx context.Context, store *DoltStore, source, target string, depType types.DependencyType) {
+	t.Helper()
+	if err := store.AddDependency(ctx, &types.Dependency{
+		IssueID:     source,
+		DependsOnID: target,
+		Type:        depType,
+	}, "tester"); err != nil {
+		t.Fatalf("AddDependency %s -> %s (%s): %v", source, target, depType, err)
+	}
+}
+
+func dropWispIsBlockedProjection(t *testing.T, ctx context.Context, store *DoltStore) {
+	t.Helper()
+	if _, err := store.db.ExecContext(ctx, "DROP INDEX idx_wisps_is_blocked ON wisps"); err != nil {
+		t.Fatalf("drop idx_wisps_is_blocked: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, "ALTER TABLE wisps DROP COLUMN is_blocked"); err != nil {
+		t.Fatalf("drop wisps.is_blocked: %v", err)
+	}
+}
+
+func runMigrationSQL(t *testing.T, ctx context.Context, store *DoltStore, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", path, err)
+	}
+	if _, err := store.db.ExecContext(ctx, string(data)); err != nil {
+		t.Fatalf("run migration %s: %v", path, err)
+	}
+}
+
+func runMigrationSQLFilesFrom(t *testing.T, ctx context.Context, store *DoltStore, dir string, minVersion int) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read migration dir %s: %v", dir, err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		prefix, _, ok := strings.Cut(name, "_")
+		if !ok {
+			t.Fatalf("migration filename %s has no version prefix", name)
+		}
+		version, err := strconv.Atoi(prefix)
+		if err != nil {
+			t.Fatalf("parse migration version from %s: %v", name, err)
+		}
+		if version < minVersion {
+			continue
+		}
+		runMigrationSQL(t, ctx, store, filepath.Join(dir, name))
+	}
+}
+
+func dropWispTables(t *testing.T, ctx context.Context, store *DoltStore) {
+	t.Helper()
+	for _, table := range []string{
+		"wisp_dependencies",
+		"wisp_labels",
+		"wisp_events",
+		"wisp_comments",
+		"wisp_child_counters",
+		"wisps",
+	} {
+		//nolint:gosec // table names are fixed test schema tables from the list above.
+		if _, err := store.db.ExecContext(ctx, "DROP TABLE IF EXISTS "+table); err != nil {
+			t.Fatalf("drop %s: %v", table, err)
+		}
+	}
+}

--- a/internal/storage/dolt/pr4107_corruption_test.go
+++ b/internal/storage/dolt/pr4107_corruption_test.go
@@ -92,6 +92,10 @@ func TestPR4107WispMigrationBackfillsMixedParentChildPropagation(t *testing.T) {
 	addDependency(t, ctx, store, "pr4107-wisp-blocked-parent", "pr4107-wisp-parent-blocker", types.DepBlocks)
 	addDependency(t, ctx, store, "pr4107-wisp-blocked-child", "pr4107-wisp-blocked-parent", types.DepParentChild)
 
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-blocker")
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-blocked-by-wisp")
+	addDependency(t, ctx, store, "pr4107-wisp-blocked-by-wisp", "pr4107-wisp-blocker", types.DepBlocks)
+
 	dropWispIsBlockedProjection(t, ctx, store)
 	runMigrationSQLFilesFrom(t, ctx, store, "../schema/migrations/ignored", 6)
 
@@ -101,6 +105,102 @@ func TestPR4107WispMigrationBackfillsMixedParentChildPropagation(t *testing.T) {
 	if !getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-blocked-child") {
 		t.Errorf("child wisp did not inherit blocked parent state during migration backfill")
 	}
+	if !getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-blocked-by-wisp") {
+		t.Errorf("wisp blocked by an open wisp was not backfilled as blocked")
+	}
+}
+
+func TestPR4107WispMigrationBackfillsWaitsForSemantics(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-waits-for-active")
+	createPerm(t, ctx, store, "pr4107-wisp-waits-for-spawner")
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-waits-for-child")
+	addDependency(t, ctx, store, "pr4107-wisp-waits-for-child", "pr4107-wisp-waits-for-spawner", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-wisp-waits-for-active", "pr4107-wisp-waits-for-spawner", types.DepWaitsFor)
+
+	createNoHistoryWisp(t, ctx, store, "pr4107-wisp-waits-for-no-children")
+	createPerm(t, ctx, store, "pr4107-wisp-waits-for-empty-spawner")
+	addDependency(t, ctx, store, "pr4107-wisp-waits-for-no-children", "pr4107-wisp-waits-for-empty-spawner", types.DepWaitsFor)
+
+	dropWispIsBlockedProjection(t, ctx, store)
+	runMigrationSQLFilesFrom(t, ctx, store, "../schema/migrations/ignored", 6)
+
+	if !getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-waits-for-active") {
+		t.Errorf("wisp waits-for gate with an active child was not backfilled as blocked")
+	}
+	if getIsBlocked(t, ctx, store, "wisps", "pr4107-wisp-waits-for-no-children") {
+		t.Errorf("wisp waits-for gate with no children was backfilled as blocked")
+	}
+}
+
+func TestPR4107RuntimeIsBlockedMaintainsMixedIssueWispGraph(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-runtime-issue-blocked-by-wisp")
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-wisp-blocker-a")
+	addDependency(t, ctx, store, "pr4107-runtime-issue-blocked-by-wisp", "pr4107-runtime-wisp-blocker-a", types.DepBlocks)
+
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-wisp-blocked-by-issue")
+	createPerm(t, ctx, store, "pr4107-runtime-issue-blocker-a")
+	addDependency(t, ctx, store, "pr4107-runtime-wisp-blocked-by-issue", "pr4107-runtime-issue-blocker-a", types.DepBlocks)
+
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-blocked-wisp-parent")
+	createPerm(t, ctx, store, "pr4107-runtime-issue-blocker-b")
+	createPerm(t, ctx, store, "pr4107-runtime-issue-child-of-wisp")
+	addDependency(t, ctx, store, "pr4107-runtime-blocked-wisp-parent", "pr4107-runtime-issue-blocker-b", types.DepBlocks)
+	addDependency(t, ctx, store, "pr4107-runtime-issue-child-of-wisp", "pr4107-runtime-blocked-wisp-parent", types.DepParentChild)
+
+	createPerm(t, ctx, store, "pr4107-runtime-blocked-issue-parent")
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-wisp-blocker-b")
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-wisp-child-of-issue")
+	addDependency(t, ctx, store, "pr4107-runtime-blocked-issue-parent", "pr4107-runtime-wisp-blocker-b", types.DepBlocks)
+	addDependency(t, ctx, store, "pr4107-runtime-wisp-child-of-issue", "pr4107-runtime-blocked-issue-parent", types.DepParentChild)
+
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-runtime-issue-blocked-by-wisp", true)
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-runtime-wisp-blocked-by-issue", true)
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-runtime-issue-child-of-wisp", true)
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-runtime-wisp-child-of-issue", true)
+}
+
+func TestPR4107RuntimeWaitsForHandlesMixedIssueWispChildren(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-runtime-wf-issue-waiter")
+	createPerm(t, ctx, store, "pr4107-runtime-wf-issue-spawner")
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-wf-wisp-child")
+	addDependency(t, ctx, store, "pr4107-runtime-wf-wisp-child", "pr4107-runtime-wf-issue-spawner", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-runtime-wf-issue-waiter", "pr4107-runtime-wf-issue-spawner", types.DepWaitsFor)
+
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-wf-wisp-waiter")
+	createNoHistoryWisp(t, ctx, store, "pr4107-runtime-wf-wisp-spawner")
+	createPerm(t, ctx, store, "pr4107-runtime-wf-issue-child")
+	addDependency(t, ctx, store, "pr4107-runtime-wf-issue-child", "pr4107-runtime-wf-wisp-spawner", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-runtime-wf-wisp-waiter", "pr4107-runtime-wf-wisp-spawner", types.DepWaitsFor)
+
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-runtime-wf-issue-waiter", true)
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-runtime-wf-wisp-waiter", true)
+
+	if err := store.CloseIssue(ctx, "pr4107-runtime-wf-wisp-child", "done", "tester", ""); err != nil {
+		t.Fatalf("CloseIssue wisp child: %v", err)
+	}
+	if err := store.CloseIssue(ctx, "pr4107-runtime-wf-issue-child", "done", "tester", ""); err != nil {
+		t.Fatalf("CloseIssue issue child: %v", err)
+	}
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-runtime-wf-issue-waiter", false)
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-runtime-wf-wisp-waiter", false)
 }
 
 func TestPR4107DeleteRecomputesWaitersWhenSpawnerChildIsDeleted(t *testing.T) {
@@ -126,6 +226,48 @@ func TestPR4107DeleteRecomputesWaitersWhenSpawnerChildIsDeleted(t *testing.T) {
 	if getIsBlocked(t, ctx, store, "issues", "pr4107-delete-waiter") {
 		t.Fatalf("waiter remained blocked after deleting the spawner's only active child")
 	}
+}
+
+func TestPR4107DeleteRecomputesWaitersWhenSpawnerIsDeleted(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-delete-spawner-waiter")
+	createPerm(t, ctx, store, "pr4107-delete-spawner-target")
+	createPerm(t, ctx, store, "pr4107-delete-spawner-child")
+	addDependency(t, ctx, store, "pr4107-delete-spawner-child", "pr4107-delete-spawner-target", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-delete-spawner-waiter", "pr4107-delete-spawner-target", types.DepWaitsFor)
+
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-delete-spawner-waiter", true)
+
+	if err := store.DeleteIssue(ctx, "pr4107-delete-spawner-target"); err != nil {
+		t.Fatalf("DeleteIssue spawner: %v", err)
+	}
+	assertIsBlocked(t, ctx, store, "issues", "pr4107-delete-spawner-waiter", false)
+}
+
+func TestPR4107DeleteRecomputesWispWaitersWhenSpawnerChildIsDeleted(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createNoHistoryWisp(t, ctx, store, "pr4107-delete-wisp-waiter")
+	createPerm(t, ctx, store, "pr4107-delete-wisp-waiter-spawner")
+	createNoHistoryWisp(t, ctx, store, "pr4107-delete-wisp-waiter-child")
+	addDependency(t, ctx, store, "pr4107-delete-wisp-waiter-child", "pr4107-delete-wisp-waiter-spawner", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-delete-wisp-waiter", "pr4107-delete-wisp-waiter-spawner", types.DepWaitsFor)
+
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-delete-wisp-waiter", true)
+
+	if err := store.DeleteIssue(ctx, "pr4107-delete-wisp-waiter-child"); err != nil {
+		t.Fatalf("DeleteIssue wisp child: %v", err)
+	}
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-delete-wisp-waiter", false)
 }
 
 func TestPR4107JSONCountReadPathsTolerateMissingWispTables(t *testing.T) {
@@ -187,6 +329,177 @@ func TestPR4107SearchIssuesWithCountsLimitIsGlobalAcrossIssuesAndWisps(t *testin
 	}
 }
 
+func TestPR4107SearchIssuesWithCountsLimitUsesGlobalSortOrderAcrossIssuesAndWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        "pr4107-limit-low-priority-issue",
+		Title:     "low priority issue",
+		Status:    types.StatusOpen,
+		Priority:  4,
+		IssueType: types.TypeTask,
+	}, "tester"); err != nil {
+		t.Fatalf("create low-priority issue: %v", err)
+	}
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        "pr4107-limit-high-priority-wisp",
+		Title:     "high priority wisp",
+		Status:    types.StatusOpen,
+		Priority:  0,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}, "tester"); err != nil {
+		t.Fatalf("create high-priority wisp: %v", err)
+	}
+
+	results, err := store.SearchIssuesWithCounts(ctx, "", types.IssueFilter{Limit: 1})
+	if err != nil {
+		t.Fatalf("SearchIssuesWithCounts limit=1: %v", err)
+	}
+	if got := issueWithCountsIDs(results); len(got) != 1 || got[0] != "pr4107-limit-high-priority-wisp" {
+		t.Fatalf("SearchIssuesWithCounts limit=1 IDs = %v, want [pr4107-limit-high-priority-wisp]", got)
+	}
+}
+
+func TestPR4107ReadyWorkWithCountsLimitUsesGlobalSortOrderAcrossIssuesAndWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        "pr4107-ready-limit-low-priority-issue",
+		Title:     "low priority ready issue",
+		Status:    types.StatusOpen,
+		Priority:  4,
+		IssueType: types.TypeTask,
+	}, "tester"); err != nil {
+		t.Fatalf("create low-priority issue: %v", err)
+	}
+	if err := store.CreateIssue(ctx, &types.Issue{
+		ID:        "pr4107-ready-limit-high-priority-wisp",
+		Title:     "high priority ready wisp",
+		Status:    types.StatusOpen,
+		Priority:  0,
+		IssueType: types.TypeTask,
+		NoHistory: true,
+	}, "tester"); err != nil {
+		t.Fatalf("create high-priority no-history wisp: %v", err)
+	}
+
+	results, err := store.GetReadyWorkWithCounts(ctx, types.WorkFilter{Limit: 1, SortPolicy: types.SortPolicyPriority})
+	if err != nil {
+		t.Fatalf("GetReadyWorkWithCounts limit=1: %v", err)
+	}
+	if got := issueWithCountsIDs(results); len(got) != 1 || got[0] != "pr4107-ready-limit-high-priority-wisp" {
+		t.Fatalf("GetReadyWorkWithCounts limit=1 IDs = %v, want [pr4107-ready-limit-high-priority-wisp]", got)
+	}
+}
+
+func TestPR4107SearchIssuesWithCountsMatchesMixedDependencyCounts(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-counts-target")
+	createPerm(t, ctx, store, "pr4107-counts-issue-dependent")
+	createNoHistoryWisp(t, ctx, store, "pr4107-counts-wisp-dependent")
+	createNoHistoryWisp(t, ctx, store, "pr4107-counts-wisp-source")
+
+	addDependency(t, ctx, store, "pr4107-counts-issue-dependent", "pr4107-counts-target", types.DepBlocks)
+	addDependency(t, ctx, store, "pr4107-counts-wisp-dependent", "pr4107-counts-target", types.DepBlocks)
+	addDependency(t, ctx, store, "pr4107-counts-wisp-source", "pr4107-counts-target", types.DepBlocks)
+
+	results, err := store.SearchIssuesWithCounts(ctx, "", types.IssueFilter{Limit: 0})
+	if err != nil {
+		t.Fatalf("SearchIssuesWithCounts: %v", err)
+	}
+	byID := issueWithCountsByID(results)
+
+	target := byID["pr4107-counts-target"]
+	if target == nil {
+		t.Fatalf("target issue missing from SearchIssuesWithCounts: %v", issueWithCountsIDs(results))
+	}
+	if target.DependentCount != 3 {
+		t.Fatalf("target dependent count = %d, want 3 mixed issue+wisp dependents", target.DependentCount)
+	}
+
+	wispSource := byID["pr4107-counts-wisp-source"]
+	if wispSource == nil {
+		t.Fatalf("wisp source missing from SearchIssuesWithCounts: %v", issueWithCountsIDs(results))
+	}
+	if wispSource.DependencyCount != 1 {
+		t.Fatalf("wisp source dependency count = %d, want 1", wispSource.DependencyCount)
+	}
+}
+
+func TestPR4107ReadyWorkWithCountsExcludesBlockedWisps(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-ready-counts-blocker")
+	createNoHistoryWisp(t, ctx, store, "pr4107-ready-counts-nohistory-blocked")
+	createEphemeralWisp(t, ctx, store, "pr4107-ready-counts-ephemeral-blocked")
+	addDependency(t, ctx, store, "pr4107-ready-counts-nohistory-blocked", "pr4107-ready-counts-blocker", types.DepBlocks)
+	addDependency(t, ctx, store, "pr4107-ready-counts-ephemeral-blocked", "pr4107-ready-counts-blocker", types.DepBlocks)
+
+	defaultReady, err := store.GetReadyWorkWithCounts(ctx, types.WorkFilter{})
+	if err != nil {
+		t.Fatalf("GetReadyWorkWithCounts default: %v", err)
+	}
+	defaultIDs := readyIDSet(issueWithCountsIDs(defaultReady))
+	if defaultIDs["pr4107-ready-counts-nohistory-blocked"] {
+		t.Fatalf("default ready counts returned blocked no-history wisp: %v", issueWithCountsIDs(defaultReady))
+	}
+
+	ephemeralReady, err := store.GetReadyWorkWithCounts(ctx, types.WorkFilter{IncludeEphemeral: true})
+	if err != nil {
+		t.Fatalf("GetReadyWorkWithCounts include ephemeral: %v", err)
+	}
+	ephemeralIDs := readyIDSet(issueWithCountsIDs(ephemeralReady))
+	if ephemeralIDs["pr4107-ready-counts-ephemeral-blocked"] {
+		t.Fatalf("include-ephemeral ready counts returned blocked ephemeral wisp: %v", issueWithCountsIDs(ephemeralReady))
+	}
+}
+
+func TestPR4107SearchIssuesWithCountsEphemeralFalseIncludesNoHistoryOnly(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createPerm(t, ctx, store, "pr4107-eph-false-issue")
+	createNoHistoryWisp(t, ctx, store, "pr4107-eph-false-nohistory")
+	createEphemeralWisp(t, ctx, store, "pr4107-eph-false-ephemeral")
+
+	ephemeral := false
+	results, err := store.SearchIssuesWithCounts(ctx, "", types.IssueFilter{Ephemeral: &ephemeral})
+	if err != nil {
+		t.Fatalf("SearchIssuesWithCounts ephemeral=false: %v", err)
+	}
+	ids := readyIDSet(issueWithCountsIDs(results))
+	if !ids["pr4107-eph-false-issue"] {
+		t.Fatalf("permanent issue missing from ephemeral=false results: %v", issueWithCountsIDs(results))
+	}
+	if !ids["pr4107-eph-false-nohistory"] {
+		t.Fatalf("no-history wisp missing from ephemeral=false results: %v", issueWithCountsIDs(results))
+	}
+	if ids["pr4107-eph-false-ephemeral"] {
+		t.Fatalf("true ephemeral wisp leaked into ephemeral=false results: %v", issueWithCountsIDs(results))
+	}
+}
+
 func createNoHistoryWisp(t *testing.T, ctx context.Context, store *DoltStore, id string) {
 	t.Helper()
 	issue := &types.Issue{
@@ -225,6 +538,13 @@ func addDependency(t *testing.T, ctx context.Context, store *DoltStore, source, 
 		Type:        depType,
 	}, "tester"); err != nil {
 		t.Fatalf("AddDependency %s -> %s (%s): %v", source, target, depType, err)
+	}
+}
+
+func assertIsBlocked(t *testing.T, ctx context.Context, store *DoltStore, table, id string, want bool) {
+	t.Helper()
+	if got := getIsBlocked(t, ctx, store, table, id); got != want {
+		t.Fatalf("%s.%s is_blocked = %v, want %v", table, id, got, want)
 	}
 }
 
@@ -277,6 +597,28 @@ func runMigrationSQLFilesFrom(t *testing.T, ctx context.Context, store *DoltStor
 		}
 		runMigrationSQL(t, ctx, store, filepath.Join(dir, name))
 	}
+}
+
+func issueWithCountsIDs(items []*types.IssueWithCounts) []string {
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if item == nil || item.Issue == nil {
+			continue
+		}
+		ids = append(ids, item.Issue.ID)
+	}
+	return ids
+}
+
+func issueWithCountsByID(items []*types.IssueWithCounts) map[string]*types.IssueWithCounts {
+	byID := make(map[string]*types.IssueWithCounts, len(items))
+	for _, item := range items {
+		if item == nil || item.Issue == nil {
+			continue
+		}
+		byID[item.Issue.ID] = item
+	}
+	return byID
 }
 
 func dropWispTables(t *testing.T, ctx context.Context, store *DoltStore) {

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -685,6 +685,57 @@ func TestGetReadyWork_LimitIncludeEphemeralWispBlocker(t *testing.T) {
 	}
 }
 
+func TestGetReadyWork_LimitIncludeEphemeralHonorsOldestSortAcrossWispPages(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	now := time.Now().UTC()
+	lowPriorityOld := &types.Issue{
+		ID:        "rw-eph-oldest-low-priority",
+		Title:     "Oldest low priority wisp",
+		Status:    types.StatusOpen,
+		Priority:  4,
+		IssueType: types.TypeTask,
+		CreatedAt: now.Add(-72 * time.Hour),
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, lowPriorityOld, "tester"); err != nil {
+		t.Fatalf("create old wisp: %v", err)
+	}
+
+	for i := 0; i < 101; i++ {
+		iss := &types.Issue{
+			ID:        fmt.Sprintf("rw-eph-priority-noise-%03d", i),
+			Title:     fmt.Sprintf("Priority noise %03d", i),
+			Status:    types.StatusOpen,
+			Priority:  1,
+			IssueType: types.TypeTask,
+			CreatedAt: now.Add(time.Duration(i) * time.Minute),
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create priority noise %03d: %v", i, err)
+		}
+	}
+
+	work, err := store.GetReadyWork(ctx, types.WorkFilter{
+		Limit:            1,
+		IncludeEphemeral: true,
+		SortPolicy:       types.SortPolicyOldest,
+	})
+	if err != nil {
+		t.Fatalf("limited oldest ready work with wisps: %v", err)
+	}
+	ids := issueIDs(work)
+	want := []string{lowPriorityOld.ID}
+	if fmt.Sprint(ids) != fmt.Sprint(want) {
+		t.Fatalf("limited oldest ready work = %v, want %v", ids, want)
+	}
+}
+
 func TestGetReadyWork_IncludeEphemeralPropagatesWispSearchError(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1095,26 +1095,8 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		autoStartedServerDir: autoStartedDir,
 	}
 
-	// Schema initialization for server mode (idempotent).
-	// Short retry for Dolt "no root value found in session" race: after
-	// CREATE DATABASE, information_schema queries may fail transiently
-	// even though Ping succeeded. This resolves within ~1s.
 	if !cfg.ReadOnly {
-		schemaBO := backoff.NewExponentialBackOff()
-		schemaBO.InitialInterval = 100 * time.Millisecond
-		// Must exceed schema.MigrateUpWithLock's 5s GET_LOCK wait so a
-		// contended schema migration can time out once and still retry.
-		schemaBO.MaxElapsedTime = 15 * time.Second
-		if err := backoff.Retry(func() error {
-			schemaErr := store.initSchema(ctx)
-			if schemaErr != nil && isRetryableError(schemaErr) {
-				return schemaErr
-			}
-			if schemaErr != nil {
-				return backoff.Permanent(schemaErr)
-			}
-			return nil
-		}, backoff.WithContext(schemaBO, ctx)); err != nil {
+		if err := store.initSchema(ctx); err != nil {
 			return nil, fmt.Errorf("failed to initialize schema: %w", err)
 		}
 	}
@@ -1493,8 +1475,29 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) error {
+	// Schema initialization for server mode is idempotent. Retry transient
+	// Dolt startup/catalog races and contended migration-lock attempts so
+	// concurrent bd processes converge instead of failing one unlucky waiter.
+	schemaBO := backoff.NewExponentialBackOff()
+	schemaBO.InitialInterval = 100 * time.Millisecond
+	// Must exceed schema.MigrateUpWithLock's 5s GET_LOCK wait so a contended
+	// schema migration can time out once and still retry.
+	schemaBO.MaxElapsedTime = serverRetryMaxElapsed
+	return backoff.Retry(func() error {
+		schemaErr := initSchemaOnDB(ctx, db)
+		if schemaErr != nil && isRetryableError(schemaErr) {
+			return schemaErr
+		}
+		if schemaErr != nil {
+			return backoff.Permanent(schemaErr)
+		}
+		return nil
+	}, backoff.WithContext(schemaBO, ctx))
+}
+
 func (s *DoltStore) initSchema(ctx context.Context) error {
-	return initSchemaOnDB(ctx, s.db)
+	return initSchemaOnDBWithRetry(ctx, s.db)
 }
 
 // IsClosed returns true if the store has been closed.

--- a/internal/storage/issueops/blocked_state.go
+++ b/internal/storage/issueops/blocked_state.go
@@ -71,6 +71,31 @@ func RecomputeIsBlockedInTx(ctx context.Context, tx *sql.Tx, issueIDs, wispIDs [
 	}
 }
 
+func MarkIsBlockedInTx(ctx context.Context, tx *sql.Tx, issueIDs, wispIDs []string) error {
+	if len(issueIDs) == 0 && len(wispIDs) == 0 {
+		return nil
+	}
+	for {
+		var changed int64
+
+		n, err := markIsBlockedPassForIssuesInTx(ctx, tx, issueIDs)
+		if err != nil {
+			return err
+		}
+		changed += n
+
+		n, err = markIsBlockedPassForWispsInTx(ctx, tx, wispIDs)
+		if err != nil {
+			return err
+		}
+		changed += n
+
+		if changed == 0 {
+			return nil
+		}
+	}
+}
+
 func RecomputeIsBlockedForIDsInTx(ctx context.Context, tx *sql.Tx, ids []string) error {
 	return RecomputeIsBlockedInTx(ctx, tx, ids, nil)
 }
@@ -85,7 +110,18 @@ func recomputeIsBlockedPassForIssuesInTx(ctx context.Context, tx *sql.Tx, ids []
 		return 0, nil
 	}
 
-	markBlockedTmpl := fmt.Sprintf(`
+	return runMarkUnmarkBatchedInTx(ctx, tx, markBlockedTemplateForIssues(), unmarkBlockedTemplateForIssues(), ids)
+}
+
+func markIsBlockedPassForIssuesInTx(ctx context.Context, tx *sql.Tx, ids []string) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	return runMarkBatchedInTx(ctx, tx, markBlockedTemplateForIssues(), ids)
+}
+
+func markBlockedTemplateForIssues() string {
+	return fmt.Sprintf(`
 		UPDATE issues i SET i.is_blocked = 1
 		WHERE i.id IN (%%s)
 		  AND i.is_blocked = 0
@@ -126,8 +162,10 @@ func recomputeIsBlockedPassForIssuesInTx(ctx context.Context, tx *sql.Tx, ids []
 		    )
 		  )
 	`, waitsForGateBlockedSQL)
+}
 
-	markUnblockedTmpl := fmt.Sprintf(`
+func unmarkBlockedTemplateForIssues() string {
+	return fmt.Sprintf(`
 		UPDATE issues i SET i.is_blocked = 0
 		WHERE i.id IN (%%s)
 		  AND i.is_blocked = 1
@@ -170,8 +208,6 @@ func recomputeIsBlockedPassForIssuesInTx(ctx context.Context, tx *sql.Tx, ids []
 		    )
 		  )
 	`, waitsForGateBlockedSQL)
-
-	return runMarkUnmarkBatchedInTx(ctx, tx, markBlockedTmpl, markUnblockedTmpl, ids)
 }
 
 //nolint:gosec // G201: SQL templates are constant; only IN-clause placeholders are formatted in.
@@ -180,7 +216,18 @@ func recomputeIsBlockedPassForWispsInTx(ctx context.Context, tx *sql.Tx, ids []s
 		return 0, nil
 	}
 
-	markBlockedTmpl := fmt.Sprintf(`
+	return runMarkUnmarkBatchedInTx(ctx, tx, markBlockedTemplateForWisps(), unmarkBlockedTemplateForWisps(), ids)
+}
+
+func markIsBlockedPassForWispsInTx(ctx context.Context, tx *sql.Tx, ids []string) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	return runMarkBatchedInTx(ctx, tx, markBlockedTemplateForWisps(), ids)
+}
+
+func markBlockedTemplateForWisps() string {
+	return fmt.Sprintf(`
 		UPDATE wisps w SET w.is_blocked = 1
 		WHERE w.id IN (%%s)
 		  AND w.is_blocked = 0
@@ -221,8 +268,10 @@ func recomputeIsBlockedPassForWispsInTx(ctx context.Context, tx *sql.Tx, ids []s
 		    )
 		  )
 	`, waitsForGateBlockedSQL)
+}
 
-	markUnblockedTmpl := fmt.Sprintf(`
+func unmarkBlockedTemplateForWisps() string {
+	return fmt.Sprintf(`
 		UPDATE wisps w SET w.is_blocked = 0
 		WHERE w.id IN (%%s)
 		  AND w.is_blocked = 1
@@ -265,8 +314,6 @@ func recomputeIsBlockedPassForWispsInTx(ctx context.Context, tx *sql.Tx, ids []s
 		    )
 		  )
 	`, waitsForGateBlockedSQL)
-
-	return runMarkUnmarkBatchedInTx(ctx, tx, markBlockedTmpl, markUnblockedTmpl, ids)
 }
 
 //nolint:gosec // G201: callers pass constant templates; only IN-clause placeholders are formatted in.
@@ -291,6 +338,26 @@ func runMarkUnmarkBatchedInTx(ctx context.Context, tx *sql.Tx, markTmpl, unmarkT
 			return changed, fmt.Errorf("recompute is_blocked (unmark): %w", err)
 		}
 		n, _ = res.RowsAffected()
+		changed += n
+	}
+	return changed, nil
+}
+
+//nolint:gosec // G201: callers pass constant templates; only IN-clause placeholders are formatted in.
+func runMarkBatchedInTx(ctx context.Context, tx *sql.Tx, markTmpl string, ids []string) (int64, error) {
+	var changed int64
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		placeholders, args := buildSQLInClause(ids[start:end])
+
+		res, err := tx.ExecContext(ctx, fmt.Sprintf(markTmpl, placeholders), args...)
+		if err != nil {
+			return changed, fmt.Errorf("mark is_blocked: %w", err)
+		}
+		n, _ := res.RowsAffected()
 		changed += n
 	}
 	return changed, nil
@@ -444,6 +511,23 @@ func AffectedByDeletionInTx(
 	}
 	if err := loadBlockingDependersForIDsInTx(ctx, tx, "depends_on_wisp_id", deletedWisps, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
 		return nil, nil, err
+	}
+
+	if err := loadWaitersOnSpawnerIDsByColInTx(ctx, tx, "depends_on_issue_id", deletedIssues, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
+		return nil, nil, err
+	}
+	if err := loadWaitersOnSpawnerIDsByColInTx(ctx, tx, "depends_on_wisp_id", deletedWisps, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
+		return nil, nil, err
+	}
+	for _, id := range deletedIssues {
+		if err := loadWaitersWhoseSpawnerIsParentOfInTx(ctx, tx, id, false, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
+			return nil, nil, err
+		}
+	}
+	for _, id := range deletedWisps {
+		if err := loadWaitersWhoseSpawnerIsParentOfInTx(ctx, tx, id, true, &issueSeed, issueSeen, &wispSeed, wispSeen); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	for _, w := range []struct {

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -242,6 +242,14 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 		}
 		affectedIssues, affectedWisps = removeSourceFromAffected(dep.IssueID, srcIsWisp, affectedIssues, affectedWisps)
 	}
+	if dep.Type == types.DepParentChild {
+		// Parent-child adds are not monotonic: adding an already-closed child can
+		// satisfy an any-children waits-for gate and unblock the waiter.
+		if err := RecomputeIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
+			return fmt.Errorf("recompute is_blocked after add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
+		}
+		return nil
+	}
 	if err := MarkIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
 		return fmt.Errorf("mark is_blocked after add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
 	}

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -236,8 +236,8 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	if aerr != nil {
 		return fmt.Errorf("affected by add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, aerr)
 	}
-	if err := RecomputeIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
-		return fmt.Errorf("recompute is_blocked after add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
+	if err := MarkIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
+		return fmt.Errorf("mark is_blocked after add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
 	}
 	return nil
 }

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -236,10 +236,66 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 	if aerr != nil {
 		return fmt.Errorf("affected by add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, aerr)
 	}
+	if dep.Type == types.DepBlocks || dep.Type == types.DepConditionalBlocks {
+		if err := markDirectBlockingDependencySourceInTx(ctx, tx, dep.IssueID, srcIsWisp, dep.DependsOnID, kind); err != nil {
+			return fmt.Errorf("mark direct is_blocked after add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
+		}
+		affectedIssues, affectedWisps = removeSourceFromAffected(dep.IssueID, srcIsWisp, affectedIssues, affectedWisps)
+	}
 	if err := MarkIsBlockedInTx(ctx, tx, affectedIssues, affectedWisps); err != nil {
 		return fmt.Errorf("mark is_blocked after add dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
 	}
 	return nil
+}
+
+func removeSourceFromAffected(source string, srcIsWisp bool, issueIDs, wispIDs []string) ([]string, []string) {
+	if srcIsWisp {
+		return issueIDs, removeID(wispIDs, source)
+	}
+	return removeID(issueIDs, source), wispIDs
+}
+
+func removeID(ids []string, remove string) []string {
+	if len(ids) == 0 {
+		return ids
+	}
+	out := ids[:0]
+	for _, id := range ids {
+		if id != remove {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+//nolint:gosec // G201: table names are selected from fixed issue/wisp tables.
+func markDirectBlockingDependencySourceInTx(ctx context.Context, tx *sql.Tx, source string, srcIsWisp bool, target string, targetKind DepTargetKind) error {
+	sourceTable := "issues"
+	if srcIsWisp {
+		sourceTable = "wisps"
+	}
+	targetTable := ""
+	switch targetKind {
+	case DepTargetIssue:
+		targetTable = "issues"
+	case DepTargetWisp:
+		targetTable = "wisps"
+	default:
+		return nil
+	}
+
+	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		UPDATE %s s SET s.is_blocked = 1
+		WHERE s.id = ?
+		  AND s.is_blocked = 0
+		  AND s.status <> 'closed' AND s.status <> 'pinned'
+		  AND EXISTS (
+		    SELECT 1 FROM %s t
+		    WHERE t.id = ?
+		      AND t.status <> 'closed' AND t.status <> 'pinned'
+		  )
+	`, sourceTable, targetTable), source, target)
+	return err
 }
 
 // cycleReachabilityQuery uses UNION distinct recursion so cyclic and diamond
@@ -415,6 +471,9 @@ func nullTimeValue(value sql.NullTime) any {
 
 func RetargetInboundDependenciesToWispInTx(ctx context.Context, tx *sql.Tx, id string) error {
 	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if err := checkRetargetTargetCollision(ctx, tx, table, "depends_on_issue_id", "depends_on_wisp_id", id); err != nil {
+			return err
+		}
 		if err := checkRenameTargetCollision(ctx, tx, table, "depends_on_wisp_id", id); err != nil {
 			return err
 		}
@@ -431,6 +490,9 @@ func RetargetInboundDependenciesToWispInTx(ctx context.Context, tx *sql.Tx, id s
 
 func RetargetInboundDependenciesToIssueInTx(ctx context.Context, tx *sql.Tx, id string) error {
 	for _, table := range []string{"dependencies", "wisp_dependencies"} {
+		if err := checkRetargetTargetCollision(ctx, tx, table, "depends_on_wisp_id", "depends_on_issue_id", id); err != nil {
+			return err
+		}
 		if err := checkRenameTargetCollision(ctx, tx, table, "depends_on_issue_id", id); err != nil {
 			return err
 		}
@@ -456,6 +518,43 @@ func UpdateIssueIDInDependencyTargetsInTx(ctx context.Context, tx *sql.Tx, _, ne
 		}
 	}
 	return nil
+}
+
+//nolint:gosec // G201: table and typed columns are hardcoded constants.
+func checkRetargetTargetCollision(ctx context.Context, tx *sql.Tx, table, sourceCol, destCol, id string) error {
+	var conflictCols []string
+	switch destCol {
+	case "depends_on_issue_id":
+		conflictCols = []string{"depends_on_issue_id", "depends_on_external"}
+	case "depends_on_wisp_id":
+		conflictCols = []string{"depends_on_wisp_id", "depends_on_external"}
+	default:
+		return fmt.Errorf("checkRetargetTargetCollision: unsupported destination column %q", destCol)
+	}
+	if sourceCol != "depends_on_issue_id" && sourceCol != "depends_on_wisp_id" {
+		return fmt.Errorf("checkRetargetTargetCollision: unsupported source column %q", sourceCol)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT 1 FROM %s moving
+		JOIN %s existing ON moving.issue_id = existing.issue_id
+		WHERE moving.%s = ?
+		  AND (existing.%s = ? OR existing.%s = ?)
+		LIMIT 1
+	`, table, table, sourceCol, conflictCols[0], conflictCols[1])
+
+	var found int
+	err := tx.QueryRowContext(ctx, query, id, id, id).Scan(&found)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		if isTableNotExistError(err) {
+			return nil
+		}
+		return fmt.Errorf("check retarget collision in %s: %w", table, err)
+	}
+	return fmt.Errorf("retarget to %s collides with existing dependency target in %s", id, table)
 }
 
 //nolint:gosec // G201: table and typedCol are hardcoded constants.

--- a/internal/storage/issueops/promote.go
+++ b/internal/storage/issueops/promote.go
@@ -30,7 +30,10 @@ func PromoteFromEphemeralInTx(ctx context.Context, tx *sql.Tx, id string, actor 
 	if err != nil {
 		return fmt.Errorf("new batch context: %w", err)
 	}
-	if err := CreateIssueInTx(ctx, tx, bc, issue, actor); err != nil {
+	if err := PrepareIssueForInsert(issue, bc.CustomStatuses, bc.CustomTypes); err != nil {
+		return fmt.Errorf("promote wisp to issues: %w", err)
+	}
+	if _, err := InsertIssueIfNew(ctx, tx, "issues", issue); err != nil {
 		return fmt.Errorf("promote wisp to issues: %w", err)
 	}
 

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -21,6 +21,42 @@ type readyWorkPredicates struct {
 	deferredChildIDs []string
 }
 
+type readyWorkOrder struct {
+	sql  string
+	args []interface{}
+}
+
+func readyWorkPageSize(limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	const minPageSize = 100
+	if limit < minPageSize {
+		return minPageSize
+	}
+	return limit
+}
+
+func buildReadyWorkOrder(policy types.SortPolicy) readyWorkOrder {
+	switch policy {
+	case types.SortPolicyOldest:
+		return readyWorkOrder{sql: "ORDER BY created_at ASC, id ASC"}
+	case types.SortPolicyPriority:
+		return readyWorkOrder{sql: "ORDER BY priority ASC, created_at DESC, id ASC"}
+	case types.SortPolicyHybrid, "":
+		recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
+		return readyWorkOrder{
+			sql: `ORDER BY
+			CASE WHEN created_at >= ? THEN 0 ELSE 1 END ASC,
+			CASE WHEN created_at >= ? THEN priority ELSE 999 END ASC,
+			created_at ASC, id ASC`,
+			args: []interface{}{recentCutoff, recentCutoff},
+		}
+	default:
+		return readyWorkOrder{sql: "ORDER BY priority ASC, created_at DESC, id ASC"}
+	}
+}
+
 func buildReadyWorkPredicates(ctx context.Context, tx *sql.Tx, filter types.WorkFilter, tables FilterTables) (*readyWorkPredicates, error) {
 	var statusClause string
 	if filter.Status != "" {
@@ -154,22 +190,8 @@ func buildReadyWorkPredicates(ctx context.Context, tx *sql.Tx, filter types.Work
 
 	whereSQL := "WHERE " + strings.Join(whereClauses, " AND ")
 
-	var orderBySQL string
-	switch filter.SortPolicy {
-	case types.SortPolicyOldest:
-		orderBySQL = "ORDER BY created_at ASC, id ASC"
-	case types.SortPolicyPriority:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
-	case types.SortPolicyHybrid, "":
-		recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
-		orderBySQL = `ORDER BY
-			CASE WHEN created_at >= ? THEN 0 ELSE 1 END ASC,
-			CASE WHEN created_at >= ? THEN priority ELSE 999 END ASC,
-			created_at ASC, id ASC`
-		args = append(args, recentCutoff, recentCutoff)
-	default:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
-	}
+	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	args = append(args, orderBy.args...)
 
 	var limitSQL string
 	if filter.Limit > 0 {
@@ -178,7 +200,7 @@ func buildReadyWorkPredicates(ctx context.Context, tx *sql.Tx, filter types.Work
 
 	return &readyWorkPredicates{
 		whereSQL:         whereSQL,
-		orderBySQL:       orderBySQL,
+		orderBySQL:       orderBy.sql,
 		limitSQL:         limitSQL,
 		args:             args,
 		deferredChildIDs: deferredChildIDs,
@@ -266,15 +288,125 @@ func getReadyWispsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter,
 	}
 
 	wispFilter := readyWorkWispIssueFilter(filter)
-	wispFilter.Limit = 0
-	wisps, err := searchTableInTx(ctx, tx, "", wispFilter, WispsFilterTables)
-	if err != nil {
-		if isTableNotExistError(err) {
-			return nil, nil
+	if filter.Limit <= 0 {
+		wispFilter.Limit = 0
+		wisps, err := searchTableInTx(ctx, tx, "", wispFilter, WispsFilterTables)
+		if err != nil {
+			if isTableNotExistError(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
 		}
-		return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		return filterReadyWispsInTx(ctx, tx, filter, wisps, deferredChildIDs)
 	}
-	return filterReadyWispsInTx(ctx, tx, filter, wisps, deferredChildIDs)
+
+	pageSize := readyWorkPageSize(filter.Limit)
+	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	ready := make([]*types.Issue, 0, filter.Limit)
+	for offset := 0; len(ready) < filter.Limit; offset += pageSize {
+		pageIDs, err := queryReadyWispIssueIDPage(ctx, tx, wispFilter, !filter.IncludeDeferred, orderBy, pageSize, offset)
+		if err != nil {
+			if isTableNotExistError(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		}
+		if len(pageIDs) == 0 {
+			break
+		}
+
+		pageWisps, err := getWispIssuesByIDsInOrderInTx(ctx, tx, pageIDs)
+		if err != nil {
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		}
+		pageReady, err := filterReadyWispsInTx(ctx, tx, filter, pageWisps, deferredChildIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, wisp := range pageReady {
+			ready = append(ready, wisp)
+			if len(ready) >= filter.Limit {
+				break
+			}
+		}
+		if len(pageIDs) < pageSize {
+			break
+		}
+	}
+	return ready, nil
+}
+
+func queryReadyWispIssueIDPage(ctx context.Context, tx *sql.Tx, filter types.IssueFilter, excludeDeferred bool, orderBy readyWorkOrder, limit, offset int) ([]string, error) {
+	fromSQL, labelWhere, labelArgs, labelDriven, filterForClauses := buildLabelDrivenSearch(filter, WispsFilterTables)
+	whereClauses, args, err := BuildIssueFilterClauses("", filterForClauses, WispsFilterTables)
+	if err != nil {
+		return nil, err
+	}
+	if len(labelWhere) > 0 {
+		whereClauses = append(labelWhere, whereClauses...)
+		args = append(labelArgs, args...)
+	}
+	if excludeDeferred {
+		whereClauses = append(whereClauses, "(defer_until IS NULL OR defer_until <= UTC_TIMESTAMP())")
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	selectSQL := "SELECT "
+	if labelDriven {
+		selectSQL = "SELECT DISTINCT "
+	}
+	args = append(args, orderBy.args...)
+	//nolint:gosec // G201: SQL fragments are fixed table/column names and parameterized filters; limit/offset are ints.
+	query := fmt.Sprintf(`%sid FROM %s %s %s LIMIT %d OFFSET %d`,
+		selectSQL, fromSQL, whereSQL, orderBy.sql, limit, offset)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search wisps: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("search wisps: scan id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search wisps: rows: %w", err)
+	}
+	return ids, nil
+}
+
+func getWispIssuesByIDsInOrderInTx(ctx context.Context, tx *sql.Tx, ids []string) ([]*types.Issue, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	wispSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		wispSet[id] = struct{}{}
+	}
+	issues, err := GetIssuesByIDsInTx(ctx, tx, ids, wispSet)
+	if err != nil {
+		return nil, err
+	}
+	issueMap := make(map[string]*types.Issue, len(issues))
+	for _, issue := range issues {
+		issueMap[issue.ID] = issue
+	}
+	ordered := make([]*types.Issue, 0, len(ids))
+	for _, id := range ids {
+		if issue, ok := issueMap[id]; ok {
+			ordered = append(ordered, issue)
+		}
+	}
+	return ordered, nil
 }
 
 func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {

--- a/internal/storage/issueops/ready_work_counts.go
+++ b/internal/storage/issueops/ready_work_counts.go
@@ -12,11 +12,16 @@ import (
 )
 
 func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter) ([]*types.IssueWithCounts, error) {
+	wispDepsExist, err := optionalTableExistsInTx(ctx, tx, "wisp_dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("get ready work with counts: wisp dependency probe: %w", err)
+	}
+
 	issuePreds, err := buildReadyWorkPredicates(ctx, tx, filter, IssuesFilterTables)
 	if err != nil {
 		return nil, err
 	}
-	out, err := runSearchQueryInTx(ctx, tx, IssuesFilterTables, issuePreds.whereSQL, issuePreds.orderBySQL, issuePreds.limitSQL, issuePreds.args)
+	out, err := runSearchQueryInTx(ctx, tx, IssuesFilterTables, issuePreds.whereSQL, issuePreds.orderBySQL, issuePreds.limitSQL, issuePreds.args, wispDepsExist)
 	if err != nil {
 		return nil, err
 	}
@@ -28,12 +33,15 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 	if empty {
 		return out, nil
 	}
+	if !wispDepsExist {
+		return out, nil
+	}
 
 	wispPreds, err := buildReadyWorkPredicates(ctx, tx, filter, WispsFilterTables)
 	if err != nil {
 		return nil, err
 	}
-	wisps, err := runSearchQueryInTx(ctx, tx, WispsFilterTables, wispPreds.whereSQL, wispPreds.orderBySQL, wispPreds.limitSQL, wispPreds.args)
+	wisps, err := runSearchQueryInTx(ctx, tx, WispsFilterTables, wispPreds.whereSQL, wispPreds.orderBySQL, wispPreds.limitSQL, wispPreds.args, true)
 	if err != nil {
 		if isTableNotExistError(err) {
 			return out, nil

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -4,23 +4,37 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 
 	"github.com/steveyegge/beads/internal/types"
 )
 
 func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
+	limit := filter.Limit
+	queryFilter := filter
+	queryFilter.Limit = 0
+
+	wispDepsExist, err := optionalTableExistsInTx(ctx, tx, "wisp_dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("search issues with counts: wisp dependency probe: %w", err)
+	}
+
 	if filter.Ephemeral != nil && *filter.Ephemeral {
 		empty, probeErr := wispsTableEmptyOrMissingInTx(ctx, tx)
 		if probeErr != nil {
 			return nil, fmt.Errorf("search issues with counts: ephemeral wisp probe: %w", probeErr)
 		}
-		if empty {
+		if empty || !wispDepsExist {
 			return nil, nil
 		}
-		return runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables)
+		wisps, err := runFilterSearchQueryInTx(ctx, tx, query, queryFilter, WispsFilterTables, true)
+		if err != nil {
+			return nil, err
+		}
+		return finishSearchIssuesWithCounts(wisps, limit), nil
 	}
 
-	out, err := runFilterSearchQueryInTx(ctx, tx, query, filter, IssuesFilterTables)
+	out, err := runFilterSearchQueryInTx(ctx, tx, query, queryFilter, IssuesFilterTables, wispDepsExist)
 	if err != nil {
 		return nil, err
 	}
@@ -30,18 +44,21 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		return nil, fmt.Errorf("search issues with counts: wisp probe: %w", probeErr)
 	}
 	if empty {
-		return out, nil
+		return finishSearchIssuesWithCounts(out, limit), nil
+	}
+	if !wispDepsExist {
+		return finishSearchIssuesWithCounts(out, limit), nil
 	}
 
-	wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables)
+	wisps, err := runFilterSearchQueryInTx(ctx, tx, query, queryFilter, WispsFilterTables, true)
 	if err != nil {
 		if isTableNotExistError(err) {
-			return out, nil
+			return finishSearchIssuesWithCounts(out, limit), nil
 		}
 		return nil, err
 	}
 	if len(wisps) == 0 {
-		return out, nil
+		return finishSearchIssuesWithCounts(out, limit), nil
 	}
 
 	seen := make(map[string]struct{}, len(out))
@@ -59,10 +76,10 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		}
 		out = append(out, w)
 	}
-	return out, nil
+	return finishSearchIssuesWithCounts(out, limit), nil
 }
 
-func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter, tables FilterTables) ([]*types.IssueWithCounts, error) {
+func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter, tables FilterTables, includeWispReverseDeps bool) ([]*types.IssueWithCounts, error) {
 	whereClauses, args, err := BuildIssueFilterClauses(query, filter, tables)
 	if err != nil {
 		return nil, err
@@ -76,11 +93,23 @@ func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, fil
 		limitSQL = fmt.Sprintf("LIMIT %d", filter.Limit)
 	}
 	const orderBy = "ORDER BY i.priority ASC, i.created_at DESC, i.id ASC"
-	return runSearchQueryInTx(ctx, tx, tables, whereSQL, orderBy, limitSQL, args)
+	return runSearchQueryInTx(ctx, tx, tables, whereSQL, orderBy, limitSQL, args, includeWispReverseDeps)
 }
 
 //nolint:gosec // G201: SQL fragments are caller-built from hardcoded shapes
-func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, whereSQL, orderBySQL, limitSQL string, args []interface{}) ([]*types.IssueWithCounts, error) {
+func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, whereSQL, orderBySQL, limitSQL string, args []interface{}, includeWispReverseDeps bool) ([]*types.IssueWithCounts, error) {
+	reverseBlockerSelect := `
+				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
+				FROM dependencies WHERE type = 'blocks'
+	`
+	if includeWispReverseDeps {
+		reverseBlockerSelect += `
+				UNION ALL
+				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
+				FROM wisp_dependencies WHERE type = 'blocks'
+		`
+	}
+
 	searchSQL := fmt.Sprintf(`
 		SELECT %s,
 			l.labels_json    AS labels_json,
@@ -103,11 +132,7 @@ func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, wh
 		) dc ON dc.issue_id = i.id
 		LEFT JOIN (
 			SELECT dep_id, COUNT(*) AS cnt FROM (
-				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
-				FROM dependencies WHERE type = 'blocks'
-				UNION ALL
-				SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
-				FROM wisp_dependencies WHERE type = 'blocks'
+				%s
 			) all_blockers GROUP BY dep_id
 		) rc ON rc.dep_id = i.id
 		LEFT JOIN (
@@ -135,6 +160,7 @@ func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, wh
 		tables.Main,
 		tables.Labels,
 		tables.Dependencies,
+		reverseBlockerSelect,
 		tables.Comments,
 		tables.Dependencies,
 		readyWorkDepJSONObject,
@@ -170,6 +196,36 @@ func runSearchQueryInTx(ctx context.Context, tx *sql.Tx, tables FilterTables, wh
 		return nil, fmt.Errorf("search count %s: rows: %w", tables.Main, err)
 	}
 	return out, nil
+}
+
+func finishSearchIssuesWithCounts(items []*types.IssueWithCounts, limit int) []*types.IssueWithCounts {
+	sortSearchIssuesWithCounts(items)
+	if limit > 0 && len(items) > limit {
+		return items[:limit]
+	}
+	return items
+}
+
+func sortSearchIssuesWithCounts(items []*types.IssueWithCounts) {
+	if len(items) <= 1 {
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a == nil || a.Issue == nil {
+			return false
+		}
+		if b == nil || b.Issue == nil {
+			return true
+		}
+		if a.Issue.Priority != b.Issue.Priority {
+			return a.Issue.Priority < b.Issue.Priority
+		}
+		if !a.Issue.CreatedAt.Equal(b.Issue.CreatedAt) {
+			return a.Issue.CreatedAt.After(b.Issue.CreatedAt)
+		}
+		return a.Issue.ID < b.Issue.ID
+	})
 }
 
 func joinAnd(clauses []string) string {

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -11,8 +11,6 @@ import (
 
 func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
 	limit := filter.Limit
-	queryFilter := filter
-	queryFilter.Limit = 0
 
 	wispDepsExist, err := optionalTableExistsInTx(ctx, tx, "wisp_dependencies")
 	if err != nil {
@@ -27,14 +25,14 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		if empty || !wispDepsExist {
 			return nil, nil
 		}
-		wisps, err := runFilterSearchQueryInTx(ctx, tx, query, queryFilter, WispsFilterTables, true)
+		wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables, true)
 		if err != nil {
 			return nil, err
 		}
 		return finishSearchIssuesWithCounts(wisps, limit), nil
 	}
 
-	out, err := runFilterSearchQueryInTx(ctx, tx, query, queryFilter, IssuesFilterTables, wispDepsExist)
+	out, err := runFilterSearchQueryInTx(ctx, tx, query, filter, IssuesFilterTables, wispDepsExist)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +48,7 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		return finishSearchIssuesWithCounts(out, limit), nil
 	}
 
-	wisps, err := runFilterSearchQueryInTx(ctx, tx, query, queryFilter, WispsFilterTables, true)
+	wisps, err := runFilterSearchQueryInTx(ctx, tx, query, filter, WispsFilterTables, true)
 	if err != nil {
 		if isTableNotExistError(err) {
 			return finishSearchIssuesWithCounts(out, limit), nil

--- a/internal/storage/issueops/search_counts_test.go
+++ b/internal/storage/issueops/search_counts_test.go
@@ -1,0 +1,34 @@
+package issueops
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestSearchIssuesWithCountsAppliesLimitToEachSourceQuery(t *testing.T) {
+	t.Parallel()
+
+	_, mock, tx := beginMockTx(t)
+	mock.ExpectQuery(`SELECT 1 FROM wisp_dependencies LIMIT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(`(?s)FROM issues i.*ORDER BY i\.priority ASC, i\.created_at DESC, i\.id ASC\s+LIMIT 3`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(`SELECT 1 FROM wisps LIMIT 1`).
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+	mock.ExpectQuery(`(?s)FROM wisps i.*ORDER BY i\.priority ASC, i\.created_at DESC, i\.id ASC\s+LIMIT 3`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	got, err := SearchIssuesWithCountsInTx(context.Background(), tx, "", types.IssueFilter{Limit: 3})
+	if err != nil {
+		t.Fatalf("SearchIssuesWithCountsInTx: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("SearchIssuesWithCountsInTx returned %d rows, want none", len(got))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}

--- a/internal/storage/issueops/wisp_routing.go
+++ b/internal/storage/issueops/wisp_routing.go
@@ -37,6 +37,22 @@ func wispsTableEmptyOrMissingInTx(ctx context.Context, tx *sql.Tx) (bool, error)
 	}
 }
 
+//nolint:gosec // table is selected by callers from fixed optional wisp tables.
+func optionalTableExistsInTx(ctx context.Context, tx *sql.Tx, table string) (bool, error) {
+	var probe int
+	err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", table)).Scan(&probe)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return true, nil
+	case isTableNotExistError(err):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
 // WispIDSetInTx returns the subset of ids that are currently-active wisps
 // within the tx. The set is consistent for the tx's lifetime (Dolt MVCC).
 // Intended for hot-path partitioning where a batch of IDs must be split

--- a/internal/storage/schema/migrations/0047_recompute_mixed_is_blocked.up.sql
+++ b/internal/storage/schema/migrations/0047_recompute_mixed_is_blocked.up.sql
@@ -1,0 +1,191 @@
+UPDATE issues SET is_blocked = 0;
+
+WITH RECURSIVE
+  directly_blocked(kind, id) AS (
+    SELECT DISTINCT 'issue', i.id
+    FROM issues i
+    WHERE i.status NOT IN ('closed', 'pinned')
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM dependencies d
+          JOIN issues t ON t.id = d.depends_on_issue_id
+          WHERE d.issue_id = i.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM dependencies d
+          JOIN wisps t ON t.id = d.depends_on_wisp_id
+          WHERE d.issue_id = i.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM dependencies d
+          WHERE d.issue_id = i.id
+            AND d.type = 'waits-for'
+            AND (
+              EXISTS (
+                SELECT 1
+                FROM dependencies cd
+                JOIN issues child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM wisp_dependencies cd
+                JOIN wisps child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+            )
+            AND NOT (
+              JSON_UNQUOTE(JSON_EXTRACT(d.metadata, '$.gate')) = 'any-children'
+              AND (
+                EXISTS (
+                  SELECT 1
+                  FROM dependencies cd
+                  JOIN issues child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+                OR EXISTS (
+                  SELECT 1
+                  FROM wisp_dependencies cd
+                  JOIN wisps child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+              )
+            )
+        )
+      )
+    UNION
+    SELECT DISTINCT 'wisp', w.id
+    FROM wisps w
+    WHERE w.status NOT IN ('closed', 'pinned')
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM wisp_dependencies d
+          JOIN issues t ON t.id = d.depends_on_issue_id
+          WHERE d.issue_id = w.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM wisp_dependencies d
+          JOIN wisps t ON t.id = d.depends_on_wisp_id
+          WHERE d.issue_id = w.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM wisp_dependencies d
+          WHERE d.issue_id = w.id
+            AND d.type = 'waits-for'
+            AND (
+              EXISTS (
+                SELECT 1
+                FROM dependencies cd
+                JOIN issues child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM wisp_dependencies cd
+                JOIN wisps child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+            )
+            AND NOT (
+              JSON_UNQUOTE(JSON_EXTRACT(d.metadata, '$.gate')) = 'any-children'
+              AND (
+                EXISTS (
+                  SELECT 1
+                  FROM dependencies cd
+                  JOIN issues child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+                OR EXISTS (
+                  SELECT 1
+                  FROM wisp_dependencies cd
+                  JOIN wisps child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+              )
+            )
+        )
+      )
+  ),
+  reachable(kind, id) AS (
+    SELECT kind, id FROM directly_blocked
+    UNION
+    SELECT 'issue', d.issue_id
+    FROM reachable r
+    JOIN dependencies d
+      ON d.type = 'parent-child'
+     AND (
+       (r.kind = 'issue' AND d.depends_on_issue_id = r.id)
+       OR (r.kind = 'wisp' AND d.depends_on_wisp_id = r.id)
+     )
+    JOIN issues child ON child.id = d.issue_id
+    WHERE child.status NOT IN ('closed', 'pinned')
+    UNION
+    SELECT 'wisp', d.issue_id
+    FROM reachable r
+    JOIN wisp_dependencies d
+      ON d.type = 'parent-child'
+     AND (
+       (r.kind = 'issue' AND d.depends_on_issue_id = r.id)
+       OR (r.kind = 'wisp' AND d.depends_on_wisp_id = r.id)
+     )
+    JOIN wisps child ON child.id = d.issue_id
+    WHERE child.status NOT IN ('closed', 'pinned')
+  )
+UPDATE issues
+SET is_blocked = 1
+WHERE id IN (SELECT id FROM reachable WHERE kind = 'issue')
+  AND status NOT IN ('closed', 'pinned');

--- a/internal/storage/schema/migrations/0047_recompute_mixed_is_blocked.up.sql
+++ b/internal/storage/schema/migrations/0047_recompute_mixed_is_blocked.up.sql
@@ -1,3 +1,132 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- Some released 1.0.x databases have main schema migrations through 0046 but
+-- have not yet run the ignored/local-table migration that splits
+-- wisp_dependencies.depends_on_id into issue/wisp/external target columns.
+-- This main migration reads those split columns below, so normalize the
+-- ignored table first. The ignored 0003/0005 migrations are idempotent and
+-- will no-op/drop the generated compatibility column afterwards.
+SET @wisp_dependencies_needs_split = (
+    SELECT IF(
+        (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE()
+           AND TABLE_NAME = 'wisp_dependencies'
+           AND COLUMN_NAME = 'depends_on_id') > 0
+        AND
+        (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE()
+           AND TABLE_NAME = 'wisp_dependencies'
+           AND COLUMN_NAME = 'depends_on_wisp_id') = 0,
+        1, 0)
+);
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_issue_id VARCHAR(255) NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_wisp_id VARCHAR(255) NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_external VARCHAR(255) NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'UPDATE wisp_dependencies SET depends_on_external = depends_on_id WHERE depends_on_id LIKE ''external:%''',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'UPDATE wisp_dependencies wd JOIN wisps w ON w.id = wd.depends_on_id SET wd.depends_on_wisp_id = wd.depends_on_id WHERE wd.depends_on_external IS NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'UPDATE wisp_dependencies wd JOIN issues i ON i.id = wd.depends_on_id SET wd.depends_on_issue_id = wd.depends_on_id WHERE wd.depends_on_external IS NULL AND wd.depends_on_wisp_id IS NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'UPDATE wisp_dependencies SET depends_on_external = depends_on_id WHERE depends_on_external IS NULL AND depends_on_wisp_id IS NULL AND depends_on_issue_id IS NULL',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies DROP INDEX idx_wisp_dep_depends',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies DROP INDEX idx_wisp_dep_type_depends',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies DROP PRIMARY KEY',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies DROP COLUMN depends_on_id',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_id VARCHAR(255) AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD PRIMARY KEY (issue_id, depends_on_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_wisp_target (depends_on_wisp_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_issue_target (depends_on_issue_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_external_target (depends_on_external)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_type_target (type, depends_on_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_issue FOREIGN KEY (issue_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_wisp_target FOREIGN KEY (depends_on_wisp_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_issue_target FOREIGN KEY (depends_on_issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD CONSTRAINT ck_wisp_dep_one_target CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
 UPDATE issues SET is_blocked = 0;
 
 WITH RECURSIVE

--- a/internal/storage/schema/migrations/0047_recompute_mixed_is_blocked.up.sql
+++ b/internal/storage/schema/migrations/0047_recompute_mixed_is_blocked.up.sql
@@ -76,16 +76,6 @@ SET @sql = IF(@wisp_dependencies_needs_split = 1,
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(@wisp_dependencies_needs_split = 1,
-    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_id VARCHAR(255) AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@wisp_dependencies_needs_split = 1,
-    'ALTER TABLE wisp_dependencies ADD PRIMARY KEY (issue_id, depends_on_id)',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@wisp_dependencies_needs_split = 1,
     'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_wisp_target (depends_on_wisp_id)',
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -101,16 +91,6 @@ SET @sql = IF(@wisp_dependencies_needs_split = 1,
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(@wisp_dependencies_needs_split = 1,
-    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_type_target (type, depends_on_id)',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@wisp_dependencies_needs_split = 1,
-    'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_issue FOREIGN KEY (issue_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@wisp_dependencies_needs_split = 1,
     'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_wisp_target FOREIGN KEY (depends_on_wisp_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -122,6 +102,26 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(@wisp_dependencies_needs_split = 1,
     'ALTER TABLE wisp_dependencies ADD CONSTRAINT ck_wisp_dep_one_target CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_id VARCHAR(255) AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD PRIMARY KEY (issue_id, depends_on_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_type_target (type, depends_on_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@wisp_dependencies_needs_split = 1,
+    'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_issue FOREIGN KEY (issue_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 

--- a/internal/storage/schema/migrations/ignored/0003_split_wisp_dependencies_target.up.sql
+++ b/internal/storage/schema/migrations/ignored/0003_split_wisp_dependencies_target.up.sql
@@ -64,16 +64,6 @@ SET @sql = IF(@needs_migrate = 1,
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(@needs_migrate = 1,
-    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_id VARCHAR(255) AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@needs_migrate = 1,
-    'ALTER TABLE wisp_dependencies ADD PRIMARY KEY (issue_id, depends_on_id)',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@needs_migrate = 1,
     'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_wisp_target (depends_on_wisp_id)',
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -89,16 +79,6 @@ SET @sql = IF(@needs_migrate = 1,
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(@needs_migrate = 1,
-    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_type_target (type, depends_on_id)',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@needs_migrate = 1,
-    'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_issue FOREIGN KEY (issue_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
-    'SELECT 1');
-PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
-
-SET @sql = IF(@needs_migrate = 1,
     'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_wisp_target FOREIGN KEY (depends_on_wisp_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
@@ -110,6 +90,26 @@ PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 SET @sql = IF(@needs_migrate = 1,
     'ALTER TABLE wisp_dependencies ADD CONSTRAINT ck_wisp_dep_one_target CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@needs_migrate = 1,
+    'ALTER TABLE wisp_dependencies ADD COLUMN depends_on_id VARCHAR(255) AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@needs_migrate = 1,
+    'ALTER TABLE wisp_dependencies ADD PRIMARY KEY (issue_id, depends_on_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@needs_migrate = 1,
+    'ALTER TABLE wisp_dependencies ADD INDEX idx_wisp_dep_type_target (type, depends_on_id)',
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @sql = IF(@needs_migrate = 1,
+    'ALTER TABLE wisp_dependencies ADD CONSTRAINT fk_wisp_dep_issue FOREIGN KEY (issue_id) REFERENCES wisps(id) ON DELETE CASCADE ON UPDATE CASCADE',
     'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 

--- a/internal/storage/schema/migrations/ignored/0007_recompute_wisp_is_blocked.up.sql
+++ b/internal/storage/schema/migrations/ignored/0007_recompute_wisp_is_blocked.up.sql
@@ -1,0 +1,191 @@
+UPDATE wisps SET is_blocked = 0;
+
+WITH RECURSIVE
+  directly_blocked(kind, id) AS (
+    SELECT DISTINCT 'issue', i.id
+    FROM issues i
+    WHERE i.status NOT IN ('closed', 'pinned')
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM dependencies d
+          JOIN issues t ON t.id = d.depends_on_issue_id
+          WHERE d.issue_id = i.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM dependencies d
+          JOIN wisps t ON t.id = d.depends_on_wisp_id
+          WHERE d.issue_id = i.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM dependencies d
+          WHERE d.issue_id = i.id
+            AND d.type = 'waits-for'
+            AND (
+              EXISTS (
+                SELECT 1
+                FROM dependencies cd
+                JOIN issues child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM wisp_dependencies cd
+                JOIN wisps child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+            )
+            AND NOT (
+              JSON_UNQUOTE(JSON_EXTRACT(d.metadata, '$.gate')) = 'any-children'
+              AND (
+                EXISTS (
+                  SELECT 1
+                  FROM dependencies cd
+                  JOIN issues child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+                OR EXISTS (
+                  SELECT 1
+                  FROM wisp_dependencies cd
+                  JOIN wisps child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+              )
+            )
+        )
+      )
+    UNION
+    SELECT DISTINCT 'wisp', w.id
+    FROM wisps w
+    WHERE w.status NOT IN ('closed', 'pinned')
+      AND (
+        EXISTS (
+          SELECT 1
+          FROM wisp_dependencies d
+          JOIN issues t ON t.id = d.depends_on_issue_id
+          WHERE d.issue_id = w.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM wisp_dependencies d
+          JOIN wisps t ON t.id = d.depends_on_wisp_id
+          WHERE d.issue_id = w.id
+            AND d.type IN ('blocks', 'conditional-blocks')
+            AND t.status NOT IN ('closed', 'pinned')
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM wisp_dependencies d
+          WHERE d.issue_id = w.id
+            AND d.type = 'waits-for'
+            AND (
+              EXISTS (
+                SELECT 1
+                FROM dependencies cd
+                JOIN issues child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+              OR EXISTS (
+                SELECT 1
+                FROM wisp_dependencies cd
+                JOIN wisps child ON child.id = cd.issue_id
+                WHERE cd.type = 'parent-child'
+                  AND (
+                    (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                    OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                  )
+                  AND child.status NOT IN ('closed', 'pinned')
+              )
+            )
+            AND NOT (
+              JSON_UNQUOTE(JSON_EXTRACT(d.metadata, '$.gate')) = 'any-children'
+              AND (
+                EXISTS (
+                  SELECT 1
+                  FROM dependencies cd
+                  JOIN issues child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+                OR EXISTS (
+                  SELECT 1
+                  FROM wisp_dependencies cd
+                  JOIN wisps child ON child.id = cd.issue_id
+                  WHERE cd.type = 'parent-child'
+                    AND (
+                      (d.depends_on_issue_id IS NOT NULL AND cd.depends_on_issue_id = d.depends_on_issue_id)
+                      OR (d.depends_on_wisp_id IS NOT NULL AND cd.depends_on_wisp_id = d.depends_on_wisp_id)
+                    )
+                    AND child.status = 'closed'
+                )
+              )
+            )
+        )
+      )
+  ),
+  reachable(kind, id) AS (
+    SELECT kind, id FROM directly_blocked
+    UNION
+    SELECT 'issue', d.issue_id
+    FROM reachable r
+    JOIN dependencies d
+      ON d.type = 'parent-child'
+     AND (
+       (r.kind = 'issue' AND d.depends_on_issue_id = r.id)
+       OR (r.kind = 'wisp' AND d.depends_on_wisp_id = r.id)
+     )
+    JOIN issues child ON child.id = d.issue_id
+    WHERE child.status NOT IN ('closed', 'pinned')
+    UNION
+    SELECT 'wisp', d.issue_id
+    FROM reachable r
+    JOIN wisp_dependencies d
+      ON d.type = 'parent-child'
+     AND (
+       (r.kind = 'issue' AND d.depends_on_issue_id = r.id)
+       OR (r.kind = 'wisp' AND d.depends_on_wisp_id = r.id)
+     )
+    JOIN wisps child ON child.id = d.issue_id
+    WHERE child.status NOT IN ('closed', 'pinned')
+  )
+UPDATE wisps
+SET is_blocked = 1
+WHERE id IN (SELECT id FROM reachable WHERE kind = 'wisp')
+  AND status NOT IN ('closed', 'pinned');

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -152,6 +152,27 @@ func TestMigration0035HandlesLegacyWispDependenciesShape(t *testing.T) {
 	}
 }
 
+func TestMigration0047HandlesLegacyWispDependenciesShape(t *testing.T) {
+	sql, err := os.ReadFile("migrations/0047_recompute_mixed_is_blocked.up.sql")
+	if err != nil {
+		t.Fatalf("read 0047 up migration: %v", err)
+	}
+
+	body := string(sql)
+	for _, want := range []string{
+		"@wisp_dependencies_needs_split",
+		"ALTER TABLE wisp_dependencies ADD COLUMN depends_on_issue_id",
+		"ALTER TABLE wisp_dependencies ADD COLUMN depends_on_wisp_id",
+		"ALTER TABLE wisp_dependencies ADD COLUMN depends_on_id VARCHAR(255) AS",
+		"cd.depends_on_issue_id",
+		"d.depends_on_wisp_id",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("0047 migration missing legacy wisp_dependencies compatibility marker %q", want)
+		}
+	}
+}
+
 func TestStageSchemaTablesSkipsIgnoredTables(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/tests/regression/regression_test.go
+++ b/tests/regression/regression_test.go
@@ -435,7 +435,7 @@ func (w *workspace) snapshot(listArgs ...string) string {
 		if !ok || id == "" {
 			continue
 		}
-		showOut := w.run("show", id, "--json")
+		showOut := w.showJSONForSnapshot(id)
 
 		// bd show --json may return a JSON array or single object
 		var showArr []map[string]any
@@ -451,6 +451,18 @@ func (w *workspace) snapshot(listArgs ...string) string {
 		w.t.Logf("WARNING: snapshot: bd show %s returned unparseable JSON: %s", id, showOut)
 	}
 	return buf.String()
+}
+
+func (w *workspace) showJSONForSnapshot(id string) string {
+	args := []string{"show", id, "--json"}
+	if w.supportsStreamedShowPayloads() {
+		args = append(args, "--include-dependents", "--include-comments")
+	}
+	return w.run(args...)
+}
+
+func (w *workspace) supportsStreamedShowPayloads() bool {
+	return candidateBin != "" && w.bdPath == candidateBin
 }
 
 // export returns a JSONL snapshot of the workspace. This replaces the removed
@@ -618,14 +630,11 @@ func normalizeIssue(m map[string]any) {
 	}
 
 	// normalizeDepSubobject strips volatile/internal fields from a dependency
-	// or dependent sub-object as returned by bd show --json.
+	// or dependent sub-object as returned by bd show --json. The candidate's
+	// streamed show payload intentionally returns shallow related issues, while
+	// the old baseline export included deeper issue fields. Compare the stable
+	// relationship identity, not the nested issue's full payload.
 	normalizeDepSubobject := func(dm map[string]any) {
-		delete(dm, "created_at")
-		delete(dm, "updated_at")
-		delete(dm, "closed_at")
-		delete(dm, "close_reason")
-		delete(dm, "thread_id")
-		delete(dm, "created_by")
 		// Normalize dependency_type → type
 		if dt, ok := dm["dependency_type"]; ok {
 			if _, hasType := dm["type"]; !hasType {
@@ -637,6 +646,22 @@ func normalizeIssue(m map[string]any) {
 		if md, ok := dm["metadata"]; ok {
 			if mdStr, _ := md.(string); mdStr == "" || mdStr == "{}" {
 				delete(dm, "metadata")
+			}
+		}
+		keep := map[string]bool{
+			"id":            true,
+			"issue_id":      true,
+			"depends_on_id": true,
+			"title":         true,
+			"status":        true,
+			"issue_type":    true,
+			"priority":      true,
+			"type":          true,
+			"metadata":      true,
+		}
+		for k := range dm {
+			if !keep[k] {
+				delete(dm, k)
 			}
 		}
 	}

--- a/tests/regression/scenarios_test.go
+++ b/tests/regression/scenarios_test.go
@@ -2305,7 +2305,7 @@ func TestShowJSONFieldCompleteness(t *testing.T) {
 	cID := scenario(candidateWS)
 
 	bRaw := baselineWS.run("show", bID, "--json")
-	cRaw := candidateWS.run("show", cID, "--json")
+	cRaw := candidateWS.showJSONForSnapshot(cID)
 
 	// Parse and compare field presence
 	bFields := parseJSONFieldNames(t, bRaw)


### PR DESCRIPTION
## Summary
- Add PR4107 regression coverage for mixed issue/wisp blocked-state corruption, migrations, delete recompute, and counted read paths.
- Repair runtime blocked-state recomputation for dependency additions and deletion-affected `waits-for` rows.
- Add follow-up migrations to recompute corrupted `is_blocked` values for already-upgraded databases.
- Make counted search/read paths tolerate missing optional wisp tables and apply counted search limits globally after issue+wisp merge.

## Validation
- `go test ./internal/storage/dolt -run 'TestPR4107' -count=1`
- `go test ./internal/storage/issueops ./internal/storage/schema -count=1`
- `go test ./internal/storage/dolt -run 'TestPR4107|TestConcurrentInitSchema|TestGetReadyWork_LimitScansMultipleCandidatePages' -count=1`
- `git diff --check`

## Notes
- Broader `go test ./internal/storage/issueops ./internal/storage/schema ./internal/storage/dolt -count=1` still exposes unrelated existing Dolt failures; follow-ups filed as `bd-9ve` and `bd-1do`.
