### PR TITLE
fix(cli): skip redundant server-mode write auto-commits

### DIFF
--- a/cmd/bd/assign.go
+++ b/cmd/bd/assign.go
@@ -55,7 +55,10 @@ Examples:
 			FatalErrorRespectJSON("updating %s: %v", id, err)
 		}
 
-		if err := commitPendingIfEmbedded(ctx, issueStore, actor); err != nil {
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor, doltAutoCommitParams{
+			Command:  "assign",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
 			FatalErrorRespectJSON("failed to commit: %v", err)
 		}
 

--- a/cmd/bd/assign.go
+++ b/cmd/bd/assign.go
@@ -55,7 +55,9 @@ Examples:
 			FatalErrorRespectJSON("updating %s: %v", id, err)
 		}
 
-		commandDidWrite.Store(true)
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
 
 		SetLastTouchedID(result.ResolvedID)
 

--- a/cmd/bd/autocommit_embedded_test.go
+++ b/cmd/bd/autocommit_embedded_test.go
@@ -1,0 +1,247 @@
+//go:build cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func bdCommand(t *testing.T, bd, dir string, args ...string) string {
+	t.Helper()
+	out, err := bdRunWithFlockRetry(t, bd, dir, args...)
+	if err != nil {
+		t.Fatalf("bd %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func assertEmbeddedHeadUnchanged(t *testing.T, beadsDir, database, before, command string) {
+	t.Helper()
+	after := embeddedCurrentCommit(t, beadsDir, database)
+	if after != before {
+		t.Fatalf("%s advanced HEAD in batch mode; before=%s after=%s", command, before, after)
+	}
+}
+
+func assertEmbeddedHeadAdvanced(t *testing.T, beadsDir, database, before, command string) {
+	t.Helper()
+	after := embeddedCurrentCommit(t, beadsDir, database)
+	if after == before {
+		t.Fatalf("%s did not advance target HEAD; before=%s after=%s", command, before, after)
+	}
+}
+
+func setupRoutedEmbeddedRepo(t *testing.T, bd string, sourcePrefix, targetPrefix string) (sourceDir, targetDir, targetBeadsDir string) {
+	t.Helper()
+
+	sourceDir, _, _ = bdInit(t, bd, "--prefix", sourcePrefix)
+	targetDir = filepath.Join(sourceDir, "target-repo")
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, targetDir)
+	runBDInit(t, bd, targetDir, "--prefix", targetPrefix)
+
+	route := `{"prefix":"` + targetPrefix + `-","path":"target-repo"}` + "\n"
+	if err := os.WriteFile(filepath.Join(sourceDir, ".beads", "routes.jsonl"), []byte(route), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	return sourceDir, targetDir, filepath.Join(targetDir, ".beads")
+}
+
+func TestEmbeddedDepAndLinkBatchAutoCommitDoesNotAdvanceHead(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt auto-commit tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("dep_add", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "da")
+		from := bdCreate(t, bd, dir, "Dependent issue")
+		to := bdCreate(t, bd, dir, "Blocking issue")
+		before := embeddedCurrentCommit(t, beadsDir, "da")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "dep", "add", from.ID, to.ID)
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "da", before, "dep add")
+	})
+
+	t.Run("dep_blocks", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "db")
+		blocker := bdCreate(t, bd, dir, "Blocking issue")
+		blocked := bdCreate(t, bd, dir, "Blocked issue")
+		before := embeddedCurrentCommit(t, beadsDir, "db")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "dep", blocker.ID, "--blocks", blocked.ID)
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "db", before, "dep --blocks")
+	})
+
+	t.Run("dep_remove", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dr")
+		from := bdCreate(t, bd, dir, "Dependent issue")
+		to := bdCreate(t, bd, dir, "Blocking issue")
+		bdDep(t, bd, dir, "add", from.ID, to.ID)
+		before := embeddedCurrentCommit(t, beadsDir, "dr")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "dep", "remove", from.ID, to.ID)
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "dr", before, "dep remove")
+	})
+
+	t.Run("link", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dl")
+		from := bdCreate(t, bd, dir, "Dependent issue")
+		to := bdCreate(t, bd, dir, "Blocking issue")
+		before := embeddedCurrentCommit(t, beadsDir, "dl")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "link", from.ID, to.ID)
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "dl", before, "link")
+	})
+}
+
+func TestEmbeddedDirectCommitPathsBatchAutoCommitDoesNotAdvanceHead(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt auto-commit tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("create", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dc")
+		before := embeddedCurrentCommit(t, beadsDir, "dc")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "create", "Deferred create")
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "dc", before, "create")
+	})
+
+	t.Run("markdown_create", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dm")
+		mdFile := filepath.Join(dir, "issues.md")
+		mdContent := `## Markdown batch issue
+
+### Priority
+2
+
+### Type
+task
+
+### Description
+Created while Dolt auto-commit is in batch mode.
+`
+		if err := os.WriteFile(mdFile, []byte(mdContent), 0644); err != nil {
+			t.Fatalf("write markdown fixture: %v", err)
+		}
+		before := embeddedCurrentCommit(t, beadsDir, "dm")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "create", "-f", mdFile)
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "dm", before, "markdown create")
+	})
+
+	t.Run("label_add", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dlb")
+		issue := bdCreate(t, bd, dir, "Batch label target")
+		before := embeddedCurrentCommit(t, beadsDir, "dlb")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "label", "add", issue.ID, "batched")
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "dlb", before, "label add")
+		labels := showLabels(t, bd, dir, issue.ID)
+		if !slices.Contains(labels, "batched") {
+			t.Fatalf("labels = %v, want batched", labels)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "dd")
+		issue := bdCreate(t, bd, dir, "Batch delete target")
+		before := embeddedCurrentCommit(t, beadsDir, "dd")
+
+		bdCommand(t, bd, dir, "--dolt-auto-commit", "batch", "delete", issue.ID, "--force")
+
+		assertEmbeddedHeadUnchanged(t, beadsDir, "dd", before, "delete")
+	})
+}
+
+func TestEmbeddedRoutedSiblingWritesCommitTargetHead(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt auto-commit tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	t.Run("comment", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "sc", "tc")
+		issue := bdCreate(t, bd, targetDir, "Routed comment target")
+		before := embeddedCurrentCommit(t, targetBeadsDir, "tc")
+
+		bdCommand(t, bd, sourceDir, "comment", issue.ID, "routed comment")
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tc", before, "routed comment")
+		targetStore := openStore(t, targetBeadsDir, "tc")
+		comments, err := targetStore.GetIssueComments(t.Context(), issue.ID)
+		if err != nil {
+			t.Fatalf("GetIssueComments: %v", err)
+		}
+		found := false
+		for _, c := range comments {
+			if c.Text == "routed comment" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("routed comment was not persisted in target store")
+		}
+	})
+
+	t.Run("note", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "sn", "tn")
+		issue := bdCreate(t, bd, targetDir, "Routed note target")
+		before := embeddedCurrentCommit(t, targetBeadsDir, "tn")
+
+		bdCommand(t, bd, sourceDir, "note", issue.ID, "routed note")
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tn", before, "routed note")
+		targetStore := openStore(t, targetBeadsDir, "tn")
+		got, err := targetStore.GetIssue(t.Context(), issue.ID)
+		if err != nil {
+			t.Fatalf("GetIssue: %v", err)
+		}
+		if !strings.Contains(got.Notes, "routed note") {
+			t.Fatalf("target notes = %q, want routed note", got.Notes)
+		}
+	})
+
+	t.Run("reopen", func(t *testing.T) {
+		sourceDir, targetDir, targetBeadsDir := setupRoutedEmbeddedRepo(t, bd, "sr", "tr")
+		issue := bdCreate(t, bd, targetDir, "Routed reopen target")
+		bdClose(t, bd, targetDir, issue.ID)
+		before := embeddedCurrentCommit(t, targetBeadsDir, "tr")
+
+		bdCommand(t, bd, sourceDir, "reopen", issue.ID, "--reason", "routed reopen")
+
+		assertEmbeddedHeadAdvanced(t, targetBeadsDir, "tr", before, "routed reopen")
+		targetStore := openStore(t, targetBeadsDir, "tr")
+		got, err := targetStore.GetIssue(t.Context(), issue.ID)
+		if err != nil {
+			t.Fatalf("GetIssue: %v", err)
+		}
+		if got.Status != types.StatusOpen {
+			t.Fatalf("target status = %s, want %s", got.Status, types.StatusOpen)
+		}
+	})
+}

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -90,7 +90,7 @@ the flags appear in the command line.`,
 
 		// Track which stores were mutated so routed closes can commit before
 		// cleanup closes the routed handle. Deduped by pointer.
-		mutatedStores := map[storage.DoltStorage]struct{}{}
+		mutatedStores := map[storage.DoltStorage][]string{}
 
 		// Direct mode
 		closedIssues := []*types.Issue{}
@@ -142,7 +142,7 @@ the flags appear in the command line.`,
 				fmt.Fprintf(os.Stderr, "Error closing %s: %v\n", id, err)
 				continue
 			}
-			mutatedStores[activeStore] = struct{}{}
+			mutatedStores[activeStore] = append(mutatedStores[activeStore], id)
 
 			// Audit log the close (survives Dolt GC flatten)
 			oldStatus := "open"
@@ -230,7 +230,7 @@ the flags appear in the command line.`,
 				err := postCloseStore.ClaimIssue(ctx, nextIssue.ID, actor)
 				if err == nil {
 					claimedNextIssue = nextIssue
-					mutatedStores[postCloseStore] = struct{}{}
+					mutatedStores[postCloseStore] = append(mutatedStores[postCloseStore], nextIssue.ID)
 					if jsonOutput {
 						// JSON handled below
 					} else {
@@ -257,11 +257,14 @@ the flags appear in the command line.`,
 		}
 
 		if closedCount > 0 {
-			for s := range mutatedStores {
+			for s, ids := range mutatedStores {
 				if s == nil {
 					continue
 				}
-				if err := commitPendingIfEmbedded(ctx, s, actor); err != nil {
+				if err := commitPendingIfEmbedded(ctx, s, actor, doltAutoCommitParams{
+					Command:  "close",
+					IssueIDs: ids,
+				}); err != nil {
 					FatalErrorRespectJSON("failed to commit: %v", err)
 				}
 			}

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -257,28 +257,13 @@ the flags appear in the command line.`,
 		}
 
 		if closedCount > 0 {
-			hasRoutedMutation := false
 			for s := range mutatedStores {
-				if s != nil && s != store {
-					hasRoutedMutation = true
-					break
+				if s == nil {
+					continue
 				}
-			}
-			if hasRoutedMutation {
-				for s := range mutatedStores {
-					if s == nil {
-						continue
-					}
-					if err := maybeAutoCommitStore(ctx, s, doltAutoCommitParams{
-						Command:  cmd.Name(),
-						IssueIDs: resolvedIDs,
-					}); err != nil {
-						FatalErrorRespectJSON("dolt auto-commit failed: %v", err)
-					}
+				if err := commitPendingIfEmbedded(ctx, s, actor); err != nil {
+					FatalErrorRespectJSON("failed to commit: %v", err)
 				}
-				commandDidExplicitDoltCommit = true
-			} else {
-				commandDidWrite.Store(true)
 			}
 		}
 

--- a/cmd/bd/comment.go
+++ b/cmd/bd/comment.go
@@ -87,8 +87,12 @@ Examples:
 		if err != nil {
 			FatalErrorRespectJSON("adding comment: %v", err)
 		}
-
-		commandDidWrite.Store(true)
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor, doltAutoCommitParams{
+			Command:  "comment",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
 
 		SetLastTouchedID(result.ResolvedID)
 

--- a/cmd/bd/comments.go
+++ b/cmd/bd/comments.go
@@ -176,8 +176,12 @@ Examples:
 		if err != nil {
 			FatalErrorRespectJSON("adding comment: %v", err)
 		}
-
-		commandDidWrite.Store(true)
+		if err := commitPendingIfEmbedded(ctx, result.Store, actor, doltAutoCommitParams{
+			Command:  "comments add",
+			IssueIDs: []string{issueID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
 
 		if jsonOutput {
 			outputJSON(comment)

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -689,12 +689,14 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		// Commit to Dolt. In DoltStore mode, CreateIssue commits the issue
-		// row internally, so only post-create metadata (deps) needs a separate
-		// commit. In EmbeddedDoltStore mode, CreateIssue writes
-		// to the working set without a Dolt commit, so we always commit
-		// everything together at the end.
-		if shouldCommitCreatePostWrites(issue, postCreateWrites) {
+		// Commit to Dolt. Server-mode DoltStore writes version themselves.
+		// EmbeddedDoltStore writes to the working set and commits here only
+		// when --dolt-auto-commit=on.
+		shouldCommit, err := shouldCommitCreatePostWrites(issue, postCreateWrites)
+		if err != nil {
+			FatalError("dolt auto-commit failed: %v", err)
+		}
+		if shouldCommit {
 			commitMsg := fmt.Sprintf("bd: create %s", issue.ID)
 			if err := store.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
 				WarnError("failed to commit: %v", err)
@@ -706,7 +708,10 @@ var createCmd = &cobra.Command{
 		// DoltHub remotes. Per-create pushes caused 22GB of git-remote-cache
 		// bloat with dozens of agents creating wisps constantly (hq-glw).
 		if repoPath != "." && targetStore != nil {
-			if err := targetStore.Commit(ctx, fmt.Sprintf("bd: create (auto-commit) by %s", actor)); err != nil && !isDoltNothingToCommit(err) {
+			if err := commitPendingIfEmbedded(ctx, targetStore, actor, doltAutoCommitParams{
+				Command:  "create",
+				IssueIDs: []string{issue.ID},
+			}); err != nil {
 				debug.Logf("warning: failed to commit routed repo: %v", err)
 			}
 		}
@@ -860,17 +865,18 @@ func renderCreateDryRunPreview(issue *types.Issue, labels, deps []string) {
 	}
 }
 
-func shouldCommitCreatePostWrites(issue *types.Issue, postCreateWrites bool) bool {
+func shouldCommitCreatePostWrites(_ *types.Issue, _ bool) (bool, error) {
 	if isEmbeddedMode() {
-		return true
+		if strings.TrimSpace(doltAutoCommit) == "" {
+			return true, nil
+		}
+		mode, err := getDoltAutoCommitMode()
+		if err != nil {
+			return false, err
+		}
+		return mode == doltAutoCommitOn, nil
 	}
-	if !postCreateWrites {
-		return false
-	}
-	if issue != nil && (issue.Ephemeral || issue.NoHistory) {
-		return false
-	}
-	return true
+	return false, nil
 }
 
 func createDepsAcceptedTypeList() string {

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -694,7 +694,7 @@ var createCmd = &cobra.Command{
 		// commit. In EmbeddedDoltStore mode, CreateIssue writes
 		// to the working set without a Dolt commit, so we always commit
 		// everything together at the end.
-		if !usesSQLServer() || postCreateWrites {
+		if shouldCommitCreatePostWrites(issue, postCreateWrites) {
 			commitMsg := fmt.Sprintf("bd: create %s", issue.ID)
 			if err := store.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
 				WarnError("failed to commit: %v", err)
@@ -858,6 +858,19 @@ func renderCreateDryRunPreview(issue *types.Issue, labels, deps []string) {
 	if issue.EventKind != "" {
 		fmt.Printf("  Event category: %s\n", issue.EventKind)
 	}
+}
+
+func shouldCommitCreatePostWrites(issue *types.Issue, postCreateWrites bool) bool {
+	if isEmbeddedMode() {
+		return true
+	}
+	if !postCreateWrites {
+		return false
+	}
+	if issue != nil && (issue.Ephemeral || issue.NoHistory) {
+		return false
+	}
+	return true
 }
 
 func createDepsAcceptedTypeList() string {

--- a/cmd/bd/create_form.go
+++ b/cmd/bd/create_form.go
@@ -238,9 +238,13 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 		}
 	}
 
-	// Commit embedded creates and post-create metadata to Dolt. Without this,
-	// working-set rows are visible locally but absent from HEAD and sync.
-	if !usesSQLServer() || postCreateWrites {
+	// Match bd create: server-mode writes version themselves, while embedded
+	// create commits pending writes only when auto-commit is on.
+	shouldCommit, err := shouldCommitCreatePostWrites(issue, postCreateWrites)
+	if err != nil {
+		return nil, fmt.Errorf("dolt auto-commit: %w", err)
+	}
+	if shouldCommit {
 		commitMsg := fmt.Sprintf("bd: create %s", issue.ID)
 		if postCreateWrites {
 			commitMsg = fmt.Sprintf("bd: create %s (metadata)", issue.ID)

--- a/cmd/bd/delete.go
+++ b/cmd/bd/delete.go
@@ -168,7 +168,7 @@ Force: Delete and orphan dependents
 		// Actually delete — all writes in a single transaction
 		updatedIssueCount := 0
 		totalDepsRemoved := 0
-		deleteErr := transact(ctx, activeStore, fmt.Sprintf("bd: delete %s", issueID), func(tx storage.Transaction) error {
+		deleteErr := transactHonoringAutoCommit(ctx, activeStore, fmt.Sprintf("bd: delete %s", issueID), func(tx storage.Transaction) error {
 			// 1. Update text references in connected issues
 			for id, connIssue := range connectedIssues {
 				updates := make(map[string]interface{})

--- a/cmd/bd/dep.go
+++ b/cmd/bd/dep.go
@@ -158,10 +158,11 @@ Examples:
 				warnIfCyclesExist(fromStore)
 			}
 
-			if !usesSQLServer() && fromStore != nil {
-				if err := fromStore.Commit(ctx, fmt.Sprintf("bd: dep add (auto-commit) by %s", actor)); err != nil && !isDoltNothingToCommit(err) {
-					FatalErrorRespectJSON("failed to commit: %v", err)
-				}
+			if err := commitPendingIfEmbedded(ctx, fromStore, actor, doltAutoCommitParams{
+				Command:  "dep add",
+				IssueIDs: []string{fromID, toID},
+			}); err != nil {
+				FatalErrorRespectJSON("failed to commit: %v", err)
 			}
 
 			if jsonOutput {
@@ -340,10 +341,11 @@ Examples:
 			warnIfCyclesExist(fromStore)
 		}
 
-		if !usesSQLServer() && fromStore != nil {
-			if err := fromStore.Commit(ctx, fmt.Sprintf("bd: dep add (auto-commit) by %s", actor)); err != nil && !isDoltNothingToCommit(err) {
-				FatalErrorRespectJSON("failed to commit: %v", err)
-			}
+		if err := commitPendingIfEmbedded(ctx, fromStore, actor, doltAutoCommitParams{
+			Command:  "dep add",
+			IssueIDs: []string{fromID, toID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
 		}
 
 		if jsonOutput {
@@ -862,10 +864,11 @@ var depRemoveCmd = &cobra.Command{
 			FatalErrorRespectJSON("%v", err)
 		}
 
-		if !usesSQLServer() && fromStore != nil {
-			if err := fromStore.Commit(ctx, fmt.Sprintf("bd: dep remove (auto-commit) by %s", actor)); err != nil && !isDoltNothingToCommit(err) {
-				FatalErrorRespectJSON("failed to commit: %v", err)
-			}
+		if err := commitPendingIfEmbedded(ctx, fromStore, actor, doltAutoCommitParams{
+			Command:  "dep remove",
+			IssueIDs: []string{fullFromID, fullToID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
 		}
 
 		if jsonOutput {

--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -22,6 +22,30 @@ func transact(ctx context.Context, s storage.DoltStorage, commitMsg string, fn f
 	return err
 }
 
+// transactHonoringAutoCommit wraps transactional CLI writes whose Dolt commit is
+// part of command auto-commit policy. In embedded batch/off modes the SQL
+// transaction still commits, but no Dolt version commit is created.
+func transactHonoringAutoCommit(ctx context.Context, s storage.DoltStorage, commitMsg string, fn func(tx storage.Transaction) error) error {
+	msg := commitMsg
+	committedExplicitly := strings.TrimSpace(msg) != ""
+	if isEmbeddedMode() {
+		mode, err := getDoltAutoCommitMode()
+		if err != nil {
+			return err
+		}
+		if mode != doltAutoCommitOn {
+			msg = ""
+			committedExplicitly = false
+		}
+	}
+
+	err := s.RunInTransaction(ctx, msg, fn)
+	if err == nil && committedExplicitly {
+		commandDidExplicitDoltCommit = true
+	}
+	return err
+}
+
 type doltAutoCommitParams struct {
 	// Command is the top-level bd command name (e.g., "create", "update").
 	Command string
@@ -35,20 +59,26 @@ type doltAutoCommitParams struct {
 //
 // Semantics:
 //   - Only applies when dolt auto-commit is "on" AND the active store is versioned (Dolt).
+//   - Skips SQL server modes; the server owns transaction commit lifecycle there.
 //   - In "batch" mode, commits are deferred — changes accumulate in the working set
 //     until an explicit commit point (bd dolt commit).
 //   - Uses Dolt's "commit all" behavior under the hood (DOLT_COMMIT -Am).
 //   - Treats "nothing to commit" as a no-op.
 func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
+	if !isEmbeddedMode() {
+		return nil
+	}
 	return maybeAutoCommitStore(ctx, getStore(), p)
 }
 
-func commitPendingIfEmbedded(ctx context.Context, st storage.DoltStorage, actor string) error {
+func commitPendingIfEmbedded(ctx context.Context, st storage.DoltStorage, actor string, p doltAutoCommitParams) error {
 	if !isEmbeddedMode() || st == nil {
 		return nil
 	}
-	_, err := st.CommitPending(ctx, actor)
-	return err
+	if strings.TrimSpace(p.MessageOverride) == "" {
+		p.MessageOverride = formatDoltAutoCommitMessage(p.Command, actor, p.IssueIDs)
+	}
+	return maybeAutoCommitStore(ctx, st, p)
 }
 
 func maybeAutoCommitStore(ctx context.Context, st storage.DoltStorage, p doltAutoCommitParams) error {

--- a/cmd/bd/dolt_autocommit.go
+++ b/cmd/bd/dolt_autocommit.go
@@ -43,6 +43,14 @@ func maybeAutoCommit(ctx context.Context, p doltAutoCommitParams) error {
 	return maybeAutoCommitStore(ctx, getStore(), p)
 }
 
+func commitPendingIfEmbedded(ctx context.Context, st storage.DoltStorage, actor string) error {
+	if !isEmbeddedMode() || st == nil {
+		return nil
+	}
+	_, err := st.CommitPending(ctx, actor)
+	return err
+}
+
 func maybeAutoCommitStore(ctx context.Context, st storage.DoltStorage, p doltAutoCommitParams) error {
 	mode, err := getDoltAutoCommitMode()
 	if err != nil {

--- a/cmd/bd/dolt_autocommit_server_test.go
+++ b/cmd/bd/dolt_autocommit_server_test.go
@@ -1,0 +1,113 @@
+//go:build cgo
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type fakeCommitPendingStore struct {
+	storage.DoltStorage
+	calls int
+	actor string
+	err   error
+}
+
+func (f *fakeCommitPendingStore) CommitPending(_ context.Context, actor string) (bool, error) {
+	f.calls++
+	f.actor = actor
+	return true, f.err
+}
+
+func saveStorageMode(t *testing.T) {
+	t.Helper()
+	oldServerMode := serverMode
+	oldProxiedServerMode := proxiedServerMode
+	oldCmdCtx := cmdCtx
+	oldUseGlobals := testModeUseGlobals
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
+	testModeUseGlobals = true
+	cmdCtx = nil
+	t.Cleanup(func() {
+		serverMode = oldServerMode
+		proxiedServerMode = oldProxiedServerMode
+		cmdCtx = oldCmdCtx
+		testModeUseGlobals = oldUseGlobals
+	})
+}
+
+func TestCommitPendingIfEmbeddedSkipsServerMode(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = true
+
+	fake := &fakeCommitPendingStore{}
+	if err := commitPendingIfEmbedded(context.Background(), fake, "tester"); err != nil {
+		t.Fatalf("commitPendingIfEmbedded: %v", err)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("CommitPending calls = %d, want 0 in server mode", fake.calls)
+	}
+}
+
+func TestCommitPendingIfEmbeddedFlushesEmbeddedMode(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = false
+	proxiedServerMode = false
+
+	fake := &fakeCommitPendingStore{}
+	if err := commitPendingIfEmbedded(context.Background(), fake, "tester"); err != nil {
+		t.Fatalf("commitPendingIfEmbedded: %v", err)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("CommitPending calls = %d, want 1 in embedded mode", fake.calls)
+	}
+	if fake.actor != "tester" {
+		t.Fatalf("actor = %q, want tester", fake.actor)
+	}
+}
+
+func TestCommitPendingIfEmbeddedPropagatesEmbeddedError(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = false
+
+	want := errors.New("commit failed")
+	fake := &fakeCommitPendingStore{err: want}
+	if err := commitPendingIfEmbedded(context.Background(), fake, "tester"); !errors.Is(err, want) {
+		t.Fatalf("commitPendingIfEmbedded error = %v, want %v", err, want)
+	}
+}
+
+func TestShouldCommitCreatePostWritesSkipsNoHistoryWispsInServerMode(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = true
+
+	if shouldCommitCreatePostWrites(&types.Issue{NoHistory: true}, true) {
+		t.Fatal("no-history create post-writes should not issue a Dolt commit in server mode")
+	}
+	if shouldCommitCreatePostWrites(&types.Issue{Ephemeral: true}, true) {
+		t.Fatal("ephemeral create post-writes should not issue a Dolt commit in server mode")
+	}
+	if !shouldCommitCreatePostWrites(&types.Issue{}, true) {
+		t.Fatal("persistent create post-writes should issue a Dolt commit in server mode")
+	}
+	if shouldCommitCreatePostWrites(&types.Issue{}, false) {
+		t.Fatal("create without post-writes should not issue an extra Dolt commit in server mode")
+	}
+}
+
+func TestShouldCommitCreatePostWritesPreservesEmbeddedFlush(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = false
+
+	if !shouldCommitCreatePostWrites(&types.Issue{NoHistory: true}, true) {
+		t.Fatal("embedded create should still flush pending writes")
+	}
+	if !shouldCommitCreatePostWrites(&types.Issue{}, false) {
+		t.Fatal("embedded create should keep the existing commit behavior")
+	}
+}

--- a/cmd/bd/dolt_autocommit_server_test.go
+++ b/cmd/bd/dolt_autocommit_server_test.go
@@ -13,14 +13,20 @@ import (
 
 type fakeCommitPendingStore struct {
 	storage.DoltStorage
-	calls int
-	actor string
-	err   error
+	commitCalls  int
+	pendingCalls int
+	message      string
+	err          error
+}
+
+func (f *fakeCommitPendingStore) Commit(_ context.Context, message string) error {
+	f.commitCalls++
+	f.message = message
+	return f.err
 }
 
 func (f *fakeCommitPendingStore) CommitPending(_ context.Context, actor string) (bool, error) {
-	f.calls++
-	f.actor = actor
+	f.pendingCalls++
 	return true, f.err
 }
 
@@ -29,15 +35,20 @@ func saveStorageMode(t *testing.T) {
 	oldServerMode := serverMode
 	oldProxiedServerMode := proxiedServerMode
 	oldCmdCtx := cmdCtx
+	oldStore := store
 	oldUseGlobals := testModeUseGlobals
+	oldDoltAutoCommit := doltAutoCommit
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "0")
 	testModeUseGlobals = true
 	cmdCtx = nil
+	doltAutoCommit = string(doltAutoCommitOn)
 	t.Cleanup(func() {
 		serverMode = oldServerMode
 		proxiedServerMode = oldProxiedServerMode
 		cmdCtx = oldCmdCtx
+		store = oldStore
 		testModeUseGlobals = oldUseGlobals
+		doltAutoCommit = oldDoltAutoCommit
 	})
 }
 
@@ -46,28 +57,83 @@ func TestCommitPendingIfEmbeddedSkipsServerMode(t *testing.T) {
 	serverMode = true
 
 	fake := &fakeCommitPendingStore{}
-	if err := commitPendingIfEmbedded(context.Background(), fake, "tester"); err != nil {
+	if err := commitPendingIfEmbedded(context.Background(), fake, "tester", doltAutoCommitParams{Command: "update"}); err != nil {
 		t.Fatalf("commitPendingIfEmbedded: %v", err)
 	}
-	if fake.calls != 0 {
-		t.Fatalf("CommitPending calls = %d, want 0 in server mode", fake.calls)
+	if fake.commitCalls != 0 {
+		t.Fatalf("Commit calls = %d, want 0 in server mode", fake.commitCalls)
 	}
 }
 
-func TestCommitPendingIfEmbeddedFlushesEmbeddedMode(t *testing.T) {
+func TestMaybeAutoCommitSkipsSQLServerMode(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		server      bool
+		proxied     bool
+		description string
+	}{
+		{name: "server", server: true, description: "server mode"},
+		{name: "proxied", proxied: true, description: "proxied server mode"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			saveStorageMode(t)
+			serverMode = tc.server
+			proxiedServerMode = tc.proxied
+
+			fake := &fakeCommitPendingStore{}
+			setStore(fake)
+			if err := maybeAutoCommit(context.Background(), doltAutoCommitParams{Command: "note"}); err != nil {
+				t.Fatalf("maybeAutoCommit: %v", err)
+			}
+			if fake.commitCalls != 0 {
+				t.Fatalf("Commit calls = %d, want 0 in %s", fake.commitCalls, tc.description)
+			}
+		})
+	}
+}
+
+func TestCommitPendingIfEmbeddedCommitsWhenEnabled(t *testing.T) {
 	saveStorageMode(t)
 	serverMode = false
 	proxiedServerMode = false
 
 	fake := &fakeCommitPendingStore{}
-	if err := commitPendingIfEmbedded(context.Background(), fake, "tester"); err != nil {
+	if err := commitPendingIfEmbedded(context.Background(), fake, "tester", doltAutoCommitParams{
+		Command:  "update",
+		IssueIDs: []string{"bd-1"},
+	}); err != nil {
 		t.Fatalf("commitPendingIfEmbedded: %v", err)
 	}
-	if fake.calls != 1 {
-		t.Fatalf("CommitPending calls = %d, want 1 in embedded mode", fake.calls)
+	if fake.commitCalls != 1 {
+		t.Fatalf("Commit calls = %d, want 1 in embedded mode", fake.commitCalls)
 	}
-	if fake.actor != "tester" {
-		t.Fatalf("actor = %q, want tester", fake.actor)
+	if fake.pendingCalls != 0 {
+		t.Fatalf("CommitPending calls = %d, want 0", fake.pendingCalls)
+	}
+	if fake.message != "bd: update (auto-commit) by tester [bd-1]" {
+		t.Fatalf("message = %q, want command-aware auto-commit message", fake.message)
+	}
+}
+
+func TestCommitPendingIfEmbeddedHonorsBatchAndOffModes(t *testing.T) {
+	for _, mode := range []doltAutoCommitMode{doltAutoCommitBatch, doltAutoCommitOff} {
+		t.Run(string(mode), func(t *testing.T) {
+			saveStorageMode(t)
+			serverMode = false
+			proxiedServerMode = false
+			doltAutoCommit = string(mode)
+
+			fake := &fakeCommitPendingStore{}
+			if err := commitPendingIfEmbedded(context.Background(), fake, "tester", doltAutoCommitParams{Command: "update"}); err != nil {
+				t.Fatalf("commitPendingIfEmbedded: %v", err)
+			}
+			if fake.commitCalls != 0 {
+				t.Fatalf("Commit calls = %d, want 0 in %s mode", fake.commitCalls, mode)
+			}
+			if fake.pendingCalls != 0 {
+				t.Fatalf("CommitPending calls = %d, want 0 in %s mode", fake.pendingCalls, mode)
+			}
+		})
 	}
 }
 
@@ -77,37 +143,65 @@ func TestCommitPendingIfEmbeddedPropagatesEmbeddedError(t *testing.T) {
 
 	want := errors.New("commit failed")
 	fake := &fakeCommitPendingStore{err: want}
-	if err := commitPendingIfEmbedded(context.Background(), fake, "tester"); !errors.Is(err, want) {
+	if err := commitPendingIfEmbedded(context.Background(), fake, "tester", doltAutoCommitParams{Command: "update"}); !errors.Is(err, want) {
 		t.Fatalf("commitPendingIfEmbedded error = %v, want %v", err, want)
 	}
 }
 
-func TestShouldCommitCreatePostWritesSkipsNoHistoryWispsInServerMode(t *testing.T) {
+func TestShouldCommitCreatePostWritesSkipsServerMode(t *testing.T) {
 	saveStorageMode(t)
 	serverMode = true
 
-	if shouldCommitCreatePostWrites(&types.Issue{NoHistory: true}, true) {
+	if got, err := shouldCommitCreatePostWrites(&types.Issue{NoHistory: true}, true); err != nil || got {
 		t.Fatal("no-history create post-writes should not issue a Dolt commit in server mode")
 	}
-	if shouldCommitCreatePostWrites(&types.Issue{Ephemeral: true}, true) {
+	if got, err := shouldCommitCreatePostWrites(&types.Issue{Ephemeral: true}, true); err != nil || got {
 		t.Fatal("ephemeral create post-writes should not issue a Dolt commit in server mode")
 	}
-	if !shouldCommitCreatePostWrites(&types.Issue{}, true) {
-		t.Fatal("persistent create post-writes should issue a Dolt commit in server mode")
+	if got, err := shouldCommitCreatePostWrites(&types.Issue{}, true); err != nil || got {
+		t.Fatal("server-mode create post-writes are versioned by storage and should not issue a command-level commit")
 	}
-	if shouldCommitCreatePostWrites(&types.Issue{}, false) {
+	if got, err := shouldCommitCreatePostWrites(&types.Issue{}, false); err != nil || got {
 		t.Fatal("create without post-writes should not issue an extra Dolt commit in server mode")
 	}
 }
 
-func TestShouldCommitCreatePostWritesPreservesEmbeddedFlush(t *testing.T) {
+func TestShouldCommitCreatePostWritesPreservesEmbeddedFlushWhenEnabled(t *testing.T) {
 	saveStorageMode(t)
 	serverMode = false
 
-	if !shouldCommitCreatePostWrites(&types.Issue{NoHistory: true}, true) {
+	if got, err := shouldCommitCreatePostWrites(&types.Issue{NoHistory: true}, true); err != nil || !got {
 		t.Fatal("embedded create should still flush pending writes")
 	}
-	if !shouldCommitCreatePostWrites(&types.Issue{}, false) {
+	if got, err := shouldCommitCreatePostWrites(&types.Issue{}, false); err != nil || !got {
 		t.Fatal("embedded create should keep the existing commit behavior")
+	}
+}
+
+func TestShouldCommitCreatePostWritesDefaultsEmbeddedToOn(t *testing.T) {
+	saveStorageMode(t)
+	serverMode = false
+	proxiedServerMode = false
+	doltAutoCommit = ""
+
+	if got, err := shouldCommitCreatePostWrites(&types.Issue{}, false); err != nil || !got {
+		t.Fatal("unset embedded create mode should match CLI default and commit")
+	}
+}
+
+func TestShouldCommitCreatePostWritesHonorsEmbeddedBatchAndOffModes(t *testing.T) {
+	for _, mode := range []doltAutoCommitMode{doltAutoCommitBatch, doltAutoCommitOff} {
+		t.Run(string(mode), func(t *testing.T) {
+			saveStorageMode(t)
+			serverMode = false
+			doltAutoCommit = string(mode)
+
+			if got, err := shouldCommitCreatePostWrites(&types.Issue{}, true); err != nil || got {
+				t.Fatalf("embedded create post-writes should not commit in %s mode", mode)
+			}
+			if got, err := shouldCommitCreatePostWrites(&types.Issue{}, false); err != nil || got {
+				t.Fatalf("embedded create without post-writes should not commit in %s mode", mode)
+			}
+		})
 	}
 }

--- a/cmd/bd/edit.go
+++ b/cmd/bd/edit.go
@@ -165,8 +165,13 @@ Examples:
 			FatalErrorRespectJSON("updating issue: %v", err)
 		}
 		editSaved = true
-
-		commandDidWrite.Store(true)
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor, doltAutoCommitParams{
+			Command:  "edit",
+			IssueIDs: []string{id},
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Your edits are preserved in: %s\n", tmpPath)
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
 
 		displayTitle := issue.Title
 		if fieldToEdit == "title" {

--- a/cmd/bd/label.go
+++ b/cmd/bd/label.go
@@ -27,7 +27,7 @@ func processBatchLabelOperation(issueIDs []string, label string, operation strin
 	txFunc func(context.Context, storage.Transaction, string, string, string) error) {
 	ctx := rootCtx
 	commitMsg := fmt.Sprintf("bd: label %s '%s' on %d issue(s)", operation, label, len(issueIDs))
-	err := transact(ctx, store, commitMsg, func(tx storage.Transaction) error {
+	err := transactHonoringAutoCommit(ctx, store, commitMsg, func(tx storage.Transaction) error {
 		for _, issueID := range issueIDs {
 			if err := txFunc(ctx, tx, issueID, label, actor); err != nil {
 				return fmt.Errorf("%s label '%s' on %s: %w", operation, label, issueID, err)
@@ -287,7 +287,7 @@ var labelPropagateCmd = &cobra.Command{
 
 		// Add label to each child in a single transaction (AddLabel is idempotent)
 		commitMsg := fmt.Sprintf("bd: propagate label '%s' from %s to %d children", label, parentID, len(children))
-		err = transact(ctx, store, commitMsg, func(tx storage.Transaction) error {
+		err = transactHonoringAutoCommit(ctx, store, commitMsg, func(tx storage.Transaction) error {
 			for _, child := range children {
 				if err := tx.AddLabel(ctx, child.ID, label, actor); err != nil {
 					return fmt.Errorf("add label '%s' on %s: %w", label, child.ID, err)

--- a/cmd/bd/link.go
+++ b/cmd/bd/link.go
@@ -68,10 +68,11 @@ Examples:
 		// Check for cycles after adding dependency
 		warnIfCyclesExist(fromStore)
 
-		if !usesSQLServer() && fromStore != nil {
-			if err := fromStore.Commit(ctx, fmt.Sprintf("bd: link (auto-commit) by %s", actor)); err != nil && !isDoltNothingToCommit(err) {
-				FatalErrorRespectJSON("failed to commit: %v", err)
-			}
+		if err := commitPendingIfEmbedded(ctx, fromStore, actor, doltAutoCommitParams{
+			Command:  "link",
+			IssueIDs: []string{fromID, toID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
 		}
 
 		SetLastTouchedID(fromID)

--- a/cmd/bd/markdown.go
+++ b/cmd/bd/markdown.go
@@ -382,7 +382,15 @@ func createIssuesFromMarkdown(_ *cobra.Command, filepath string) {
 		FatalError("creating issues from markdown: %v", err)
 	}
 	commitMsg := fmt.Sprintf("bd: create %d issue(s) from %s", len(templates), filepath)
-	if err := store.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
+	issueIDs := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		issueIDs = append(issueIDs, issue.ID)
+	}
+	if err := commitPendingIfEmbedded(ctx, store, actor, doltAutoCommitParams{
+		Command:         "create",
+		IssueIDs:        issueIDs,
+		MessageOverride: commitMsg,
+	}); err != nil {
 		WarnError("failed to commit: %v", err)
 	}
 	createdIssues = append(createdIssues, issues...)

--- a/cmd/bd/note.go
+++ b/cmd/bd/note.go
@@ -95,8 +95,12 @@ Examples:
 		if err := issueStore.UpdateIssue(ctx, result.ResolvedID, updates, actor); err != nil {
 			FatalErrorRespectJSON("updating %s: %v", id, err)
 		}
-
-		commandDidWrite.Store(true)
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor, doltAutoCommitParams{
+			Command:  "note",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
 
 		SetLastTouchedID(result.ResolvedID)
 

--- a/cmd/bd/priority.go
+++ b/cmd/bd/priority.go
@@ -67,8 +67,12 @@ Examples:
 		if err := issueStore.UpdateIssue(ctx, result.ResolvedID, updates, actor); err != nil {
 			FatalErrorRespectJSON("updating %s: %v", id, err)
 		}
-
-		commandDidWrite.Store(true)
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor, doltAutoCommitParams{
+			Command:  "priority",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
 
 		SetLastTouchedID(result.ResolvedID)
 

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -208,7 +208,9 @@ This is useful for agents executing molecules to see which steps can run next.`,
 				}
 				return
 			}
-			commandDidWrite.Store(true)
+			if err := commitPendingIfEmbedded(ctx, activeStore, actor); err != nil {
+				FatalErrorRespectJSON("failed to commit: %v", err)
+			}
 			SetLastTouchedID(claimed.ID)
 			if jsonOutput {
 				outputJSON(buildReadyIssueOutput(ctx, activeStore, []*types.Issue{claimed}))

--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -208,7 +208,10 @@ This is useful for agents executing molecules to see which steps can run next.`,
 				}
 				return
 			}
-			if err := commitPendingIfEmbedded(ctx, activeStore, actor); err != nil {
+			if err := commitPendingIfEmbedded(ctx, activeStore, actor, doltAutoCommitParams{
+				Command:  "ready",
+				IssueIDs: []string{claimed.ID},
+			}); err != nil {
 				FatalErrorRespectJSON("failed to commit: %v", err)
 			}
 			SetLastTouchedID(claimed.ID)

--- a/cmd/bd/reopen.go
+++ b/cmd/bd/reopen.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 	"github.com/steveyegge/beads/internal/ui"
 )
@@ -23,6 +24,8 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 
 		reopenedIssues := []*types.Issue{}
 		hasError := false
+		mutatedStores := map[storage.DoltStorage][]string{}
+		pendingCloseResults := []*RoutedResult{}
 		if store == nil {
 			FatalErrorWithHint("database not initialized",
 				diagHint())
@@ -51,6 +54,8 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 				result.Close()
 				continue
 			}
+			mutatedStores[issueStore] = append(mutatedStores[issueStore], fullID)
+			pendingCloseResults = append(pendingCloseResults, result)
 			if jsonOutput {
 				updated, _ := issueStore.GetIssue(ctx, fullID)
 				if updated != nil {
@@ -63,10 +68,22 @@ This is more explicit than 'bd update --status open' and emits a Reopened event.
 				}
 				fmt.Printf("%s Reopened %s%s\n", ui.RenderAccent("↻"), fullID, reasonMsg)
 			}
-			result.Close()
 		}
 
-		commandDidWrite.Store(true)
+		for s, ids := range mutatedStores {
+			if err := commitPendingIfEmbedded(ctx, s, actor, doltAutoCommitParams{
+				Command:  "reopen",
+				IssueIDs: ids,
+			}); err != nil {
+				for _, result := range pendingCloseResults {
+					result.Close()
+				}
+				FatalErrorRespectJSON("failed to commit: %v", err)
+			}
+		}
+		for _, result := range pendingCloseResults {
+			result.Close()
+		}
 
 		if jsonOutput && len(reopenedIssues) > 0 {
 			outputJSON(reopenedIssues)

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -31,6 +31,11 @@ func usesSQLServer() bool {
 	return false // default: embedded
 }
 
+// isEmbeddedMode reports whether the command is using embedded Dolt storage.
+func isEmbeddedMode() bool {
+	return !usesSQLServer()
+}
+
 func usesProxiedServer() bool {
 	if shouldUseGlobals() {
 		return proxiedServerMode

--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -16,6 +16,11 @@ func usesSQLServer() bool {
 	return true
 }
 
+// isEmbeddedMode reports whether the command is using embedded Dolt storage.
+func isEmbeddedMode() bool {
+	return false
+}
+
 func usesProxiedServer() bool {
 	if shouldUseGlobals() {
 		return proxiedServerMode

--- a/cmd/bd/tag.go
+++ b/cmd/bd/tag.go
@@ -51,8 +51,12 @@ Examples:
 		if err := issueStore.AddLabel(ctx, result.ResolvedID, label, actor); err != nil {
 			FatalErrorRespectJSON("adding label to %s: %v", id, err)
 		}
-
-		commandDidWrite.Store(true)
+		if err := commitPendingIfEmbedded(ctx, issueStore, actor, doltAutoCommitParams{
+			Command:  "tag",
+			IssueIDs: []string{result.ResolvedID},
+		}); err != nil {
+			FatalErrorRespectJSON("failed to commit: %v", err)
+		}
 
 		SetLastTouchedID(result.ResolvedID)
 

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -293,6 +293,34 @@ create, update, show, or close operation).`,
 
 		updatedIssues := []*types.Issue{}
 		var firstUpdatedID string // Track first successful update for last-touched
+		mutatedStores := map[storage.DoltStorage][]string{}
+		mutatedResults := map[*RoutedResult]bool{}
+		pendingCloseResults := []*RoutedResult{}
+		trackMutation := func(result *RoutedResult) {
+			if result == nil || result.Store == nil {
+				return
+			}
+			if !mutatedResults[result] {
+				pendingCloseResults = append(pendingCloseResults, result)
+				mutatedResults[result] = true
+			}
+			mutatedStores[result.Store] = append(mutatedStores[result.Store], result.ResolvedID)
+		}
+		closeIfUnmutated := func(result *RoutedResult) {
+			if result == nil {
+				return
+			}
+			if mutatedResults[result] {
+				return
+			}
+			result.Close()
+		}
+		closePendingResults := func() {
+			for _, result := range pendingCloseResults {
+				result.Close()
+			}
+			pendingCloseResults = nil
+		}
 		for _, id := range args {
 			// Resolve and get issue with routing (e.g., gt-xyz routes to another rig)
 			result, err := resolveAndGetIssueWithRouting(ctx, store, id)
@@ -315,7 +343,7 @@ create, update, show, or close operation).`,
 
 			if err := validateIssueUpdatable(id, issue); err != nil {
 				fmt.Fprintf(os.Stderr, "%s\n", err)
-				result.Close()
+				closeIfUnmutated(result)
 				continue
 			}
 
@@ -323,9 +351,10 @@ create, update, show, or close operation).`,
 			if claimFlag {
 				if err := issueStore.ClaimIssue(ctx, result.ResolvedID, actor); err != nil {
 					fmt.Fprintf(os.Stderr, "Error claiming %s: %v\n", id, err)
-					result.Close()
+					closeIfUnmutated(result)
 					continue
 				}
+				trackMutation(result)
 			}
 
 			// Apply regular field updates if any
@@ -372,9 +401,10 @@ create, update, show, or close operation).`,
 			if len(regularUpdates) > 0 {
 				if err := issueStore.UpdateIssue(ctx, result.ResolvedID, regularUpdates, actor); err != nil {
 					fmt.Fprintf(os.Stderr, "Error updating %s: %v\n", id, err)
-					result.Close()
+					closeIfUnmutated(result)
 					continue
 				}
+				trackMutation(result)
 				// Audit log key field changes (survives Dolt GC flatten)
 				if s, ok := regularUpdates["status"].(string); ok {
 					audit.LogFieldChange(result.ResolvedID, "status", string(issue.Status), s, actor, "")
@@ -401,9 +431,10 @@ create, update, show, or close operation).`,
 			if len(setLabels) > 0 || len(addLabels) > 0 || len(removeLabels) > 0 {
 				if err := applyLabelUpdates(ctx, issueStore, result.ResolvedID, actor, setLabels, addLabels, removeLabels); err != nil {
 					fmt.Fprintf(os.Stderr, "Error updating labels for %s: %v\n", id, err)
-					result.Close()
+					closeIfUnmutated(result)
 					continue
 				}
+				trackMutation(result)
 			}
 
 			// Handle parent reparenting
@@ -413,12 +444,12 @@ create, update, show, or close operation).`,
 					parentIssue, err := issueStore.GetIssue(ctx, newParent)
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "Error getting parent %s: %v\n", newParent, err)
-						result.Close()
+						closeIfUnmutated(result)
 						continue
 					}
 					if parentIssue == nil {
 						fmt.Fprintf(os.Stderr, "Error: parent issue %s not found\n", newParent)
-						result.Close()
+						closeIfUnmutated(result)
 						continue
 					}
 				}
@@ -427,13 +458,15 @@ create, update, show, or close operation).`,
 				deps, err := issueStore.GetDependencyRecords(ctx, result.ResolvedID)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error getting dependencies for %s: %v\n", id, err)
-					result.Close()
+					closeIfUnmutated(result)
 					continue
 				}
 				for _, dep := range deps {
 					if dep.Type == types.DepParentChild {
 						if err := issueStore.RemoveDependency(ctx, result.ResolvedID, dep.DependsOnID, actor); err != nil {
 							fmt.Fprintf(os.Stderr, "Error removing old parent dependency: %v\n", err)
+						} else {
+							trackMutation(result)
 						}
 						break
 					}
@@ -448,9 +481,10 @@ create, update, show, or close operation).`,
 					}
 					if err := issueStore.AddDependency(ctx, newDep, actor); err != nil {
 						fmt.Fprintf(os.Stderr, "Error adding parent dependency: %v\n", err)
-						result.Close()
+						closeIfUnmutated(result)
 						continue
 					}
+					trackMutation(result)
 				}
 			}
 
@@ -473,14 +507,24 @@ create, update, show, or close operation).`,
 			if firstUpdatedID == "" {
 				firstUpdatedID = result.ResolvedID
 			}
-			result.Close()
+			closeIfUnmutated(result)
 		}
 
-		if firstUpdatedID != "" {
-			if err := commitPendingIfEmbedded(ctx, store, actor); err != nil {
-				FatalErrorRespectJSON("failed to commit: %v", err)
+		if len(mutatedStores) > 0 {
+			for s, ids := range mutatedStores {
+				if s == nil {
+					continue
+				}
+				if err := commitPendingIfEmbedded(ctx, s, actor, doltAutoCommitParams{
+					Command:  "update",
+					IssueIDs: ids,
+				}); err != nil {
+					closePendingResults()
+					FatalErrorRespectJSON("failed to commit: %v", err)
+				}
 			}
 		}
+		closePendingResults()
 
 		// Set last touched after all updates complete
 		if firstUpdatedID != "" {

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -477,7 +477,9 @@ create, update, show, or close operation).`,
 		}
 
 		if firstUpdatedID != "" {
-			commandDidWrite.Store(true)
+			if err := commitPendingIfEmbedded(ctx, store, actor); err != nil {
+				FatalErrorRespectJSON("failed to commit: %v", err)
+			}
 		}
 
 		// Set last touched after all updates complete

--- a/cmd/bd/update_embedded_test.go
+++ b/cmd/bd/update_embedded_test.go
@@ -45,6 +45,24 @@ func bdUpdateFail(t *testing.T, bd, dir string, args ...string) string {
 	return string(out)
 }
 
+func embeddedCurrentCommit(t *testing.T, beadsDir, database string) string {
+	t.Helper()
+	store, err := embeddeddolt.Open(t.Context(), beadsDir, database, "main")
+	if err != nil {
+		t.Fatalf("open embedded store: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	head, err := store.GetCurrentCommit(t.Context())
+	if err != nil {
+		t.Fatalf("GetCurrentCommit: %v", err)
+	}
+	if head == "" {
+		t.Fatal("GetCurrentCommit returned empty hash")
+	}
+	return head
+}
+
 // bdShowJSON runs "bd show <id> --json" and returns the raw JSON output.
 func bdShowJSON(t *testing.T, bd, dir, id string) string {
 	t.Helper()
@@ -119,6 +137,71 @@ func showDeps(t *testing.T, bd, dir, id string) []struct {
 }
 
 // ===== Update tests =====
+
+func TestEmbeddedUpdateBatchAutoCommitDoesNotAdvanceHead(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt update tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ub")
+	issue := bdCreate(t, bd, dir, "Batch update")
+	before := embeddedCurrentCommit(t, beadsDir, "ub")
+
+	cmd := exec.Command(bd, "--dolt-auto-commit", "batch", "update", issue.ID, "--title", "Deferred batch update")
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd --dolt-auto-commit batch update failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	after := embeddedCurrentCommit(t, beadsDir, "ub")
+	if after != before {
+		t.Fatalf("batch-mode update advanced HEAD; before=%s after=%s", before, after)
+	}
+}
+
+func TestEmbeddedUpdateRoutedStoreCommitsTargetHead(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt update tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "src")
+
+	targetDir := filepath.Join(dir, "target-repo")
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, targetDir)
+	runBDInit(t, bd, targetDir, "--prefix", "tgt")
+
+	issue := bdCreate(t, bd, targetDir, "Routed target issue")
+	route := `{"prefix":"tgt-","path":"target-repo"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".beads", "routes.jsonl"), []byte(route), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	targetBeadsDir := filepath.Join(targetDir, ".beads")
+	before := embeddedCurrentCommit(t, targetBeadsDir, "tgt")
+	bdUpdate(t, bd, dir, issue.ID, "--title", "Updated through route")
+	after := embeddedCurrentCommit(t, targetBeadsDir, "tgt")
+	if after == before {
+		t.Fatalf("routed update did not advance target HEAD; before=%s after=%s", before, after)
+	}
+
+	targetStore := openStore(t, targetBeadsDir, "tgt")
+	got, err := targetStore.GetIssue(t.Context(), issue.ID)
+	if err != nil {
+		t.Fatalf("GetIssue in target: %v", err)
+	}
+	if got.Title != "Updated through route" {
+		t.Fatalf("target title = %q, want routed update title", got.Title)
+	}
+}
 
 func TestEmbeddedUpdate(t *testing.T) {
 	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {

--- a/internal/storage/dolt/events.go
+++ b/internal/storage/dolt/events.go
@@ -12,6 +12,7 @@ import (
 
 // AddComment adds a comment event to an issue
 func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment string) error {
+	isWisp := s.isActiveWisp(ctx, issueID)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -21,7 +22,13 @@ func (s *DoltStore) AddComment(ctx context.Context, issueID, actor, comment stri
 	if err := issueops.AddCommentEventInTx(ctx, tx, issueID, actor, comment); err != nil {
 		return err
 	}
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return wrapTransactionError("commit add comment event", err)
+	}
+	if isWisp {
+		return nil
+	}
+	return s.doltAddAndCommit(ctx, []string{"events"}, fmt.Sprintf("bd: comment %s", issueID))
 }
 
 // GetEvents retrieves events for an issue
@@ -55,13 +62,23 @@ func (s *DoltStore) AddIssueComment(ctx context.Context, issueID, author, text s
 // ImportIssueComment adds a comment during import, preserving the original timestamp.
 // This prevents comment timestamp drift across import/export cycles.
 func (s *DoltStore) ImportIssueComment(ctx context.Context, issueID, author, text string, createdAt time.Time) (*types.Comment, error) {
+	isWisp := s.isActiveWisp(ctx, issueID)
 	var result *types.Comment
 	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		var err error
 		result, err = issueops.ImportIssueCommentInTx(ctx, tx, issueID, author, text, createdAt)
 		return err
 	})
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+	if isWisp {
+		return result, nil
+	}
+	if err := s.doltAddAndCommit(ctx, []string{"comments"}, fmt.Sprintf("bd: comment %s", issueID)); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // GetIssueComments retrieves all comments for an issue

--- a/internal/storage/dolt/labels.go
+++ b/internal/storage/dolt/labels.go
@@ -3,6 +3,7 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
@@ -10,17 +11,31 @@ import (
 
 // AddLabel adds a label to an issue
 func (s *DoltStore) AddLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+	isWisp := s.isActiveWisp(ctx, issueID)
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		return issueops.AddLabelInTx(ctx, tx, "", "", issueID, label, actor)
-	})
+	}); err != nil {
+		return err
+	}
+	if isWisp {
+		return nil
+	}
+	return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label add %s", issueID))
 }
 
 // RemoveLabel removes a label from an issue.
 // Delegates SQL work to issueops.RemoveLabelInTx which handles wisp routing.
 func (s *DoltStore) RemoveLabel(ctx context.Context, issueID, label, actor string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+	isWisp := s.isActiveWisp(ctx, issueID)
+	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		return issueops.RemoveLabelInTx(ctx, tx, "", "", issueID, label, actor)
-	})
+	}); err != nil {
+		return err
+	}
+	if isWisp {
+		return nil
+	}
+	return s.doltAddAndCommit(ctx, []string{"events", "labels"}, fmt.Sprintf("bd: label remove %s", issueID))
 }
 
 // GetLabels retrieves all labels for an issue


### PR DESCRIPTION
## What

This updates CLI write paths to flush pending Dolt commits only when `bd` is running embedded storage. In server/proxied-server mode, claim, assign, update, and close no longer schedule redundant command-level auto-commits; no-history and ephemeral create post-writes also avoid extra server-mode Dolt commits.

## Why

Server-mode writes are already handled through the server storage path, so the old command-level write marker could trigger unnecessary follow-up commits after mutations. Embedded mode still needs explicit pending-write flushing, so this keeps that behavior through a focused helper while avoiding redundant work in server mode.

## Verification

- `./scripts/test.sh -run '^Test(CommitPendingIfEmbedded|ShouldCommitCreatePostWrites)' ./cmd/bd`

## PR Hygiene

- Focused on one behavior fix: redundant server-mode write auto-commits.
- No `.beads/` data or generated artifacts included.
- No documentation update needed; this does not change user-facing CLI flags or output.