### PR TITLE
perf(ready): page limited ephemeral scans

### DIFF
--- a/cmd/bd/ready.go
+++ b/cmd/bd/ready.go
@@ -251,7 +251,7 @@ This is useful for agents executing molecules to see which steps can run next.`,
 
 		totalReady := len(issues)
 		truncated := false
-		if filter.Limit > 0 && len(issues) == filter.Limit {
+		if !jsonOutput && filter.Limit > 0 && len(issues) == filter.Limit {
 			countFilter := filter
 			countFilter.Limit = 0
 			allIssues, countErr := activeStore.GetReadyWork(ctx, countFilter)

--- a/internal/storage/dolt/dolt_benchmark_test.go
+++ b/internal/storage/dolt/dolt_benchmark_test.go
@@ -977,6 +977,10 @@ func createBenchIssueBatch(b *testing.B, store *DoltStore, issues []*types.Issue
 	}
 }
 
+func ptrString(s string) *string {
+	return &s
+}
+
 func insertBenchIssues(ctx context.Context, tx *sql.Tx, table string, issues []*types.Issue) error {
 	const batchSize = 500
 	for start := 0; start < len(issues); start += batchSize {
@@ -987,7 +991,11 @@ func insertBenchIssues(ctx context.Context, tx *sql.Tx, table string, issues []*
 		var placeholders []string
 		var args []interface{}
 		for _, issue := range issues[start:end] {
-			placeholders = append(placeholders, "(?, ?, ?, '', '', '', '', ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			metadata := string(issue.Metadata)
+			if metadata == "" {
+				metadata = "{}"
+			}
+			placeholders = append(placeholders, "(?, ?, ?, '', '', '', '', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 			args = append(args,
 				issue.ID,
 				issue.ContentHash,
@@ -995,20 +1003,22 @@ func insertBenchIssues(ctx context.Context, tx *sql.Tx, table string, issues []*
 				issue.Status,
 				issue.Priority,
 				issue.IssueType,
+				issue.Assignee,
 				issue.CreatedAt,
 				issue.UpdatedAt,
 				issue.DeferUntil,
 				issue.Ephemeral,
 				issue.NoHistory,
 				issue.Pinned,
+				metadata,
 			)
 		}
 		//nolint:gosec // G201: table is selected from fixed issue table names.
 		query := fmt.Sprintf(`
 			INSERT INTO %s (
 				id, content_hash, title, description, design, acceptance_criteria, notes,
-				status, priority, issue_type, created_at, updated_at, defer_until,
-				ephemeral, no_history, pinned
+				status, priority, issue_type, assignee, created_at, updated_at, defer_until,
+				ephemeral, no_history, pinned, metadata
 			) VALUES %s
 			ON DUPLICATE KEY UPDATE title = VALUES(title)
 		`, table, strings.Join(placeholders, ","))
@@ -1285,6 +1295,170 @@ func BenchmarkPerfReadyWorkLimited_LargeBlockedGraph(b *testing.B) {
 		if len(results) != filter.Limit {
 			b.Fatalf("GetReadyWork limited blocked graph returned %d issues, want %d", len(results), filter.Limit)
 		}
+	}
+}
+
+func BenchmarkPerfReadyWorkLimited_GasCityWispHeavy(b *testing.B) {
+	const (
+		wispCount    = 8000
+		readyLimit   = 20
+		gcAssignee   = "gascity/workflows.codex-min-11"
+		gcRoute      = "gascity/workflows.codex-min-11"
+		routeJSON    = `{"gc.routed_to":"gascity/workflows.codex-min-11"}`
+		emptyJSON    = `{}`
+		closedStatus = types.StatusClosed
+	)
+	future := time.Now().UTC().Add(24 * time.Hour)
+
+	makeWisp := func(id string, priority int, assignee string, metadata string, deferUntil *time.Time) *types.Issue {
+		return &types.Issue{
+			ID:         id,
+			Title:      id,
+			Status:     types.StatusOpen,
+			Priority:   priority,
+			IssueType:  types.TypeTask,
+			Assignee:   assignee,
+			Ephemeral:  true,
+			Metadata:   []byte(metadata),
+			DeferUntil: deferUntil,
+		}
+	}
+
+	cases := []struct {
+		name   string
+		filter types.WorkFilter
+		issues func() []*types.Issue
+	}{
+		{
+			name: "AssignedDenseLimit20Of8000",
+			filter: types.WorkFilter{
+				Assignee:         ptrString(gcAssignee),
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-assigned-wisp-%05d", i),
+						(i%4)+1,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+		{
+			name: "MetadataRouteDenseLimit20Of8000",
+			filter: types.WorkFilter{
+				Unassigned:       true,
+				MetadataFields:   map[string]string{"gc.routed_to": gcRoute},
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-routed-wisp-%05d", i),
+						(i%4)+1,
+						"",
+						routeJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+		{
+			name: "AssignedSparseAfterDeferredLimit20Of8000",
+			filter: types.WorkFilter{
+				Assignee:         ptrString(gcAssignee),
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount-readyLimit; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-deferred-wisp-%05d", i),
+						1,
+						gcAssignee,
+						emptyJSON,
+						&future,
+					))
+				}
+				for i := wispCount - readyLimit; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-ready-tail-wisp-%05d", i),
+						4,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+		{
+			name: "AssignedClosedNoiseLimit20Of8000",
+			filter: types.WorkFilter{
+				Assignee:         ptrString(gcAssignee),
+				IncludeEphemeral: true,
+				Limit:            readyLimit,
+				SortPolicy:       types.SortPolicyPriority,
+			},
+			issues: func() []*types.Issue {
+				issues := make([]*types.Issue, 0, wispCount)
+				for i := 0; i < wispCount-readyLimit; i++ {
+					wisp := makeWisp(
+						fmt.Sprintf("bench-perf-gc-closed-wisp-%05d", i),
+						1,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					)
+					wisp.Status = closedStatus
+					issues = append(issues, wisp)
+				}
+				for i := wispCount - readyLimit; i < wispCount; i++ {
+					issues = append(issues, makeWisp(
+						fmt.Sprintf("bench-perf-gc-ready-closed-noise-wisp-%05d", i),
+						4,
+						gcAssignee,
+						emptyJSON,
+						nil,
+					))
+				}
+				return issues
+			},
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			store, cleanup := setupBenchStore(b)
+			defer cleanup()
+			createBenchIssueBatch(b, store, tc.issues())
+			b.ReportAllocs()
+			b.ReportMetric(float64(wispCount), "wisps")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				results, err := store.GetReadyWork(ctx, tc.filter)
+				if err != nil {
+					b.Fatalf("GetReadyWork gascity wisps: %v", err)
+				}
+				if len(results) != readyLimit {
+					b.Fatalf("GetReadyWork gascity wisps returned %d issues, want %d", len(results), readyLimit)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/storage/dolt/queries_test.go
+++ b/internal/storage/dolt/queries_test.go
@@ -685,6 +685,57 @@ func TestGetReadyWork_LimitIncludeEphemeralWispBlocker(t *testing.T) {
 	}
 }
 
+func TestGetReadyWork_LimitIncludeEphemeralHonorsOldestSortAcrossWispPages(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	now := time.Now().UTC()
+	lowPriorityOld := &types.Issue{
+		ID:        "rw-eph-oldest-low-priority",
+		Title:     "Oldest low priority wisp",
+		Status:    types.StatusOpen,
+		Priority:  4,
+		IssueType: types.TypeTask,
+		CreatedAt: now.Add(-72 * time.Hour),
+		Ephemeral: true,
+	}
+	if err := store.CreateIssue(ctx, lowPriorityOld, "tester"); err != nil {
+		t.Fatalf("create old wisp: %v", err)
+	}
+
+	for i := 0; i < 101; i++ {
+		iss := &types.Issue{
+			ID:        fmt.Sprintf("rw-eph-priority-noise-%03d", i),
+			Title:     fmt.Sprintf("Priority noise %03d", i),
+			Status:    types.StatusOpen,
+			Priority:  1,
+			IssueType: types.TypeTask,
+			CreatedAt: now.Add(time.Duration(i) * time.Minute),
+			Ephemeral: true,
+		}
+		if err := store.CreateIssue(ctx, iss, "tester"); err != nil {
+			t.Fatalf("create priority noise %03d: %v", i, err)
+		}
+	}
+
+	work, err := store.GetReadyWork(ctx, types.WorkFilter{
+		Limit:            1,
+		IncludeEphemeral: true,
+		SortPolicy:       types.SortPolicyOldest,
+	})
+	if err != nil {
+		t.Fatalf("limited oldest ready work with wisps: %v", err)
+	}
+	ids := issueIDs(work)
+	want := []string{lowPriorityOld.ID}
+	if fmt.Sprint(ids) != fmt.Sprint(want) {
+		t.Fatalf("limited oldest ready work = %v, want %v", ids, want)
+	}
+}
+
 func TestGetReadyWork_IncludeEphemeralPropagatesWispSearchError(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -21,6 +21,42 @@ type readyWorkPredicates struct {
 	deferredChildIDs []string
 }
 
+type readyWorkOrder struct {
+	sql  string
+	args []interface{}
+}
+
+func readyWorkPageSize(limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	const minPageSize = 100
+	if limit < minPageSize {
+		return minPageSize
+	}
+	return limit
+}
+
+func buildReadyWorkOrder(policy types.SortPolicy) readyWorkOrder {
+	switch policy {
+	case types.SortPolicyOldest:
+		return readyWorkOrder{sql: "ORDER BY created_at ASC, id ASC"}
+	case types.SortPolicyPriority:
+		return readyWorkOrder{sql: "ORDER BY priority ASC, created_at DESC, id ASC"}
+	case types.SortPolicyHybrid, "":
+		recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
+		return readyWorkOrder{
+			sql: `ORDER BY
+			CASE WHEN created_at >= ? THEN 0 ELSE 1 END ASC,
+			CASE WHEN created_at >= ? THEN priority ELSE 999 END ASC,
+			created_at ASC, id ASC`,
+			args: []interface{}{recentCutoff, recentCutoff},
+		}
+	default:
+		return readyWorkOrder{sql: "ORDER BY priority ASC, created_at DESC, id ASC"}
+	}
+}
+
 func buildReadyWorkPredicates(ctx context.Context, tx *sql.Tx, filter types.WorkFilter, tables FilterTables) (*readyWorkPredicates, error) {
 	var statusClause string
 	if filter.Status != "" {
@@ -154,22 +190,8 @@ func buildReadyWorkPredicates(ctx context.Context, tx *sql.Tx, filter types.Work
 
 	whereSQL := "WHERE " + strings.Join(whereClauses, " AND ")
 
-	var orderBySQL string
-	switch filter.SortPolicy {
-	case types.SortPolicyOldest:
-		orderBySQL = "ORDER BY created_at ASC, id ASC"
-	case types.SortPolicyPriority:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
-	case types.SortPolicyHybrid, "":
-		recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
-		orderBySQL = `ORDER BY
-			CASE WHEN created_at >= ? THEN 0 ELSE 1 END ASC,
-			CASE WHEN created_at >= ? THEN priority ELSE 999 END ASC,
-			created_at ASC, id ASC`
-		args = append(args, recentCutoff, recentCutoff)
-	default:
-		orderBySQL = "ORDER BY priority ASC, created_at DESC, id ASC"
-	}
+	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	args = append(args, orderBy.args...)
 
 	var limitSQL string
 	if filter.Limit > 0 {
@@ -178,7 +200,7 @@ func buildReadyWorkPredicates(ctx context.Context, tx *sql.Tx, filter types.Work
 
 	return &readyWorkPredicates{
 		whereSQL:         whereSQL,
-		orderBySQL:       orderBySQL,
+		orderBySQL:       orderBy.sql,
 		limitSQL:         limitSQL,
 		args:             args,
 		deferredChildIDs: deferredChildIDs,
@@ -266,15 +288,125 @@ func getReadyWispsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter,
 	}
 
 	wispFilter := readyWorkWispIssueFilter(filter)
-	wispFilter.Limit = 0
-	wisps, err := searchTableInTx(ctx, tx, "", wispFilter, WispsFilterTables)
-	if err != nil {
-		if isTableNotExistError(err) {
-			return nil, nil
+	if filter.Limit <= 0 {
+		wispFilter.Limit = 0
+		wisps, err := searchTableInTx(ctx, tx, "", wispFilter, WispsFilterTables)
+		if err != nil {
+			if isTableNotExistError(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
 		}
-		return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		return filterReadyWispsInTx(ctx, tx, filter, wisps, deferredChildIDs)
 	}
-	return filterReadyWispsInTx(ctx, tx, filter, wisps, deferredChildIDs)
+
+	pageSize := readyWorkPageSize(filter.Limit)
+	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	ready := make([]*types.Issue, 0, filter.Limit)
+	for offset := 0; len(ready) < filter.Limit; offset += pageSize {
+		pageIDs, err := queryReadyWispIssueIDPage(ctx, tx, wispFilter, !filter.IncludeDeferred, orderBy, pageSize, offset)
+		if err != nil {
+			if isTableNotExistError(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		}
+		if len(pageIDs) == 0 {
+			break
+		}
+
+		pageWisps, err := getWispIssuesByIDsInOrderInTx(ctx, tx, pageIDs)
+		if err != nil {
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		}
+		pageReady, err := filterReadyWispsInTx(ctx, tx, filter, pageWisps, deferredChildIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, wisp := range pageReady {
+			ready = append(ready, wisp)
+			if len(ready) >= filter.Limit {
+				break
+			}
+		}
+		if len(pageIDs) < pageSize {
+			break
+		}
+	}
+	return ready, nil
+}
+
+func queryReadyWispIssueIDPage(ctx context.Context, tx *sql.Tx, filter types.IssueFilter, excludeDeferred bool, orderBy readyWorkOrder, limit, offset int) ([]string, error) {
+	fromSQL, labelWhere, labelArgs, labelDriven, filterForClauses := buildLabelDrivenSearch(filter, WispsFilterTables)
+	whereClauses, args, err := BuildIssueFilterClauses("", filterForClauses, WispsFilterTables)
+	if err != nil {
+		return nil, err
+	}
+	if len(labelWhere) > 0 {
+		whereClauses = append(labelWhere, whereClauses...)
+		args = append(labelArgs, args...)
+	}
+	if excludeDeferred {
+		whereClauses = append(whereClauses, "(defer_until IS NULL OR defer_until <= UTC_TIMESTAMP())")
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	selectSQL := "SELECT "
+	if labelDriven {
+		selectSQL = "SELECT DISTINCT "
+	}
+	args = append(args, orderBy.args...)
+	//nolint:gosec // G201: SQL fragments are fixed table/column names and parameterized filters; limit/offset are ints.
+	query := fmt.Sprintf(`%sid FROM %s %s %s LIMIT %d OFFSET %d`,
+		selectSQL, fromSQL, whereSQL, orderBy.sql, limit, offset)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search wisps: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("search wisps: scan id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search wisps: rows: %w", err)
+	}
+	return ids, nil
+}
+
+func getWispIssuesByIDsInOrderInTx(ctx context.Context, tx *sql.Tx, ids []string) ([]*types.Issue, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	wispSet := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		wispSet[id] = struct{}{}
+	}
+	issues, err := GetIssuesByIDsInTx(ctx, tx, ids, wispSet)
+	if err != nil {
+		return nil, err
+	}
+	issueMap := make(map[string]*types.Issue, len(issues))
+	for _, issue := range issues {
+		issueMap[issue.ID] = issue
+	}
+	ordered := make([]*types.Issue, 0, len(ids))
+	for _, id := range ids {
+		if issue, ok := issueMap[id]; ok {
+			ordered = append(ordered, issue)
+		}
+	}
+	return ordered, nil
 }
 
 func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {


### PR DESCRIPTION
## What

- Adds a Gas City-shaped benchmark for limited ready-work queries over large ephemeral wisp sets.
- Pages limited ephemeral ready-work scans instead of hydrating every matching wisp before applying the limit.
- Preserves ready-work ordering semantics for priority, oldest, and hybrid sort policies while paging wisp candidates.

## Why

Gas City worker routing calls `bd ready`/ready-work paths with small limits against cities that can accumulate thousands of ephemeral wisps. Before this change, limited ready-work queries could still hydrate the full matching wisp set, making common `Limit: 20` calls take multiple seconds and allocate tens of MB.

The benchmark covers the degenerate cases we are likely to see from Gas City usage: dense assigned worker wisps, dense metadata-routed wisps, high-priority deferred wisp noise before a small ready tail, and mostly closed assigned wisp noise.

## Benchmark

Command:

```bash
source .buildflags
go test -run '^$' -bench '^BenchmarkPerfReadyWorkLimited_GasCityWispHeavy$' -benchmem -benchtime=3x -count=3 ./internal/storage/dolt
```

Mean of three runs on this host:

| Case | Before | After | Impact |
| --- | ---: | ---: | --- |
| Assigned dense, limit 20 of 8000 | 4.687s/op, 32.2 MB, 634,616 allocs | 186.9ms/op, 449 KB, 8,550 allocs | 25.1x faster, 71.6x less memory |
| Metadata route dense, limit 20 of 8000 | 4.565s/op, 32.7 MB, 634,624 allocs | 227.2ms/op, 464 KB, 8,557 allocs | 20.1x faster, 70.4x less memory |
| Deferred noise before ready tail, limit 20 of 8000 | 4.600s/op, 33.0 MB, 642,748 allocs | 72.4ms/op, 109 KB, 2,058 allocs | 63.6x faster, 302x less memory |
| Closed noise before ready tail, limit 20 of 8000 | 82.2ms/op, 106 KB, 1,879 allocs | 68.5ms/op, 106 KB, 1,978 allocs | 1.2x faster, memory effectively flat |

The deferred-noise case initially exposed a paging regression, so this PR filters future-deferred wisps in SQL before paginating and adds coverage for limited ephemeral scans preserving non-priority sort order.

## Verification

- `./scripts/test.sh -run '^TestGetReadyWork_LimitIncludeEphemeralHonorsOldestSortAcrossWispPages$' ./internal/storage/dolt`
- `./scripts/test.sh -run '^TestGetReadyWork_LimitIncludeEphemeralWispBlocker$' ./internal/storage/dolt`
- `./scripts/test.sh -run '^TestGetReadyWorkIncludeEphemeral(ExcludesNonReadyWisps|AppliesWispFilters)$' ./internal/storage/embeddeddolt`
- `./scripts/test.sh ./internal/storage/issueops`
- `./scripts/test.sh -run '^$' ./internal/storage/dolt`
- Benchmark command above, before and after this implementation commit.
- `./scripts/test.sh -run '^TestNewDoltStore$' ./internal/storage/dolt`

I also attempted `./scripts/test.sh ./internal/storage/dolt`; it timed out after 3m while running existing `TestNewDoltStore` with many unrelated package tests blocked in `t.Parallel`. `TestNewDoltStore` passes when run by itself, and the touched ready-work tests above passed.
