### PR TITLE
fix(compact): pass --allow-empty to DOLT_CHERRY_PICK (#3815)

### DIFF
--- a/internal/storage/versioncontrolops/compact.go
+++ b/internal/storage/versioncontrolops/compact.go
@@ -55,8 +55,14 @@ func Compact(ctx context.Context, conn DBConn, initialHash, boundaryHash string,
 		return err
 	}
 
+	// --allow-empty: the preserved window can contain empty commits (a Dolt
+	// auto-commit with no table change, or a bd create double-commit whose
+	// leading member has 0 changed tables). Without this flag DOLT_CHERRY_PICK
+	// aborts the entire replay at the first empty commit with Error 1105
+	// ("The previous cherry-pick commit is empty. Use --allow-empty ..."),
+	// leaving compaction permanently blocked on active databases. See #3815.
 	for _, hash := range recentHashes {
-		if err := execSQL(fmt.Sprintf("cherry-pick %s", hash[:min(8, len(hash))]), "CALL DOLT_CHERRY_PICK(?)", hash); err != nil {
+		if err := execSQL(fmt.Sprintf("cherry-pick %s", hash[:min(8, len(hash))]), "CALL DOLT_CHERRY_PICK('--allow-empty', ?)", hash); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## What

`bd compact` replays the recent-window commits onto the squashed base via `DOLT_CHERRY_PICK`. This change passes `--allow-empty` to that call so the replay no longer aborts on empty commits.

`internal/storage/versioncontrolops/compact.go`:
```go
CALL DOLT_CHERRY_PICK('--allow-empty', ?)   // was: CALL DOLT_CHERRY_PICK(?)
```

## Why

Fixes #3815.

Without `--allow-empty`, the first empty commit in the preserved window aborts the entire cherry-pick replay:

```
Error 1105 (HY000): The previous cherry-pick commit is empty.
                    Use --allow-empty to cherry-pick empty commits.
```

Empty commits occur in two ways on active databases:
- a Dolt auto-commit with no table change, and
- a `bd create` double-commit whose **leading** member carries 0 changed tables (the data lands in the identically-messaged commit that immediately follows).

Even a single empty commit anywhere in the window blocks compaction permanently, so the Dolt store never shrinks. We hit this independently on a shared server-mode store (~6.8k-commit recent window, 1.2 GB and growing): the replay aborted at ~commit 152/6677. #3815 reports the same on a ~75k-commit `hq` store, and recommends exactly this fix (its "option 1").

`--allow-empty` is the flag Dolt's own error message instructs using. Empty vs. non-empty is a Dolt implementation detail with no bd-level UI distinction, so preserving empties on replay is the correct, least-surprising behavior.

## Verification

- The flag follows the variadic-flag convention already used throughout this package — e.g. `CALL DOLT_RESET('--soft', ?)` and `CALL DOLT_COMMIT('-Am', ?, '--author', ?)` — so it is syntactically consistent with existing `DOLT_*` calls.
- The change is a single SQL-string literal; it does not alter the function signature, control flow, or any existing test. `Compact` has no unit-test harness in this package (it requires a live `DBConn` running Dolt stored procedures; `backup_test.go` only covers a pure string helper), so this is validated as an integration behavior rather than a new unit test. Reproduction and confirmation are in #3815 and corroborated above.

One issue per PR — this is the only change.