### PR TITLE
fix: make dolt push fsck timeout non-fatal

### DIFF
--- a/internal/storage/dolt/errors.go
+++ b/internal/storage/dolt/errors.go
@@ -35,6 +35,10 @@ var (
 	// prevent propagating the corruption to the remote. Run bd dolt verify
 	// to diagnose and recover.
 	ErrDanglingReference = errors.New("dangling chunk reference")
+
+	// ErrDoltPushInProgress indicates another local process is already running
+	// a Dolt CLI push for the same database directory.
+	ErrDoltPushInProgress = errors.New("dolt push already in progress")
 )
 
 // isTableNotExistError returns true if the error indicates a MySQL/Dolt

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -468,18 +468,20 @@ func (s *DoltStore) doltCLIPushToPeer(ctx context.Context, peer string, creds *r
 // doltCLIPushRefToPeer shells out to `dolt push` with a specific refspec.
 // The refspec can be a branch name or a "local:remote" mapping.
 func (s *DoltStore) doltCLIPushRefToPeer(ctx context.Context, peer string, refspec string, creds *remoteCredentials) error {
-	if err := s.prePushFSCK(ctx); err != nil {
-		return err
-	}
-	cmd := exec.CommandContext(ctx, "dolt", "push", peer, refspec) // #nosec G204 -- fixed command with validated peer/refspec
-	cmd.Dir = s.CLIDir()
-	creds.applyToCmd(cmd)
-	applyNoGitHooksToCmd(cmd) // GH#3724
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to push to peer %s: %s: %w", peer, strings.TrimSpace(string(out)), err)
-	}
-	return nil
+	return s.withDoltPushLock(ctx, func(ctx context.Context) error {
+		if err := s.prePushFSCK(ctx); err != nil {
+			return err
+		}
+		cmd := exec.CommandContext(ctx, "dolt", "push", peer, refspec) // #nosec G204 -- fixed command with validated peer/refspec
+		cmd.Dir = s.CLIDir()
+		creds.applyToCmd(cmd)
+		applyNoGitHooksToCmd(cmd) // GH#3724
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to push to peer %s: %s: %w", peer, strings.TrimSpace(string(out)), err)
+		}
+		return nil
+	})
 }
 
 // doltCLIPullFromPeer shells out to `dolt pull` for a specific peer remote.

--- a/internal/storage/dolt/fsck_test.go
+++ b/internal/storage/dolt/fsck_test.go
@@ -2,10 +2,12 @@ package dolt
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // TestPrePushFSCK_EmptyCLIDir verifies that prePushFSCK is a no-op when
@@ -83,6 +85,67 @@ func TestPrePushFSCK_UnopenableDB(t *testing.T) {
 	s := &DoltStore{dbPath: tmp, database: "mydb"}
 	if err := s.prePushFSCK(context.Background()); err != nil {
 		t.Fatalf("expected nil when fsck cannot open db (should warn and proceed), got %v", err)
+	}
+}
+
+func TestPrePushFSCK_TimeoutSkipsIntegrityCheck(t *testing.T) {
+	t.Setenv("BEADS_DOLT_FSCK_TIMEOUT", "1ms")
+	old := prePushFSCKCommandContext
+	prePushFSCKCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestPrePushFSCKHelperProcess", "--")
+		cmd.Env = append(os.Environ(), "BEADS_TEST_FSCK_HELPER=sleep")
+		return cmd
+	}
+	t.Cleanup(func() { prePushFSCKCommandContext = old })
+
+	tmp := t.TempDir()
+	dbDir := filepath.Join(tmp, "mydb")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt", "noms"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	s := &DoltStore{dbPath: tmp, database: "mydb"}
+	if err := s.prePushFSCK(context.Background()); err != nil {
+		t.Fatalf("timeout should skip the integrity check with a warning, got %v", err)
+	}
+}
+
+func TestPrePushFSCK_TimeoutWithCorruptionOutputAborts(t *testing.T) {
+	t.Setenv("BEADS_DOLT_FSCK_TIMEOUT", "250ms")
+	old := prePushFSCKCommandContext
+	prePushFSCKCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestPrePushFSCKHelperProcess", "--")
+		cmd.Env = append(os.Environ(), "BEADS_TEST_FSCK_HELPER=dangling-sleep")
+		return cmd
+	}
+	t.Cleanup(func() { prePushFSCKCommandContext = old })
+
+	tmp := t.TempDir()
+	dbDir := filepath.Join(tmp, "mydb")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt", "noms"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	s := &DoltStore{dbPath: tmp, database: "mydb"}
+	err := s.prePushFSCK(context.Background())
+	if !errors.Is(err, ErrDanglingReference) {
+		t.Fatalf("expected ErrDanglingReference when timeout captured corruption output, got %v", err)
+	}
+}
+
+func TestPrePushFSCKHelperProcess(t *testing.T) {
+	switch os.Getenv("BEADS_TEST_FSCK_HELPER") {
+	case "":
+		return
+	case "sleep":
+		time.Sleep(time.Hour)
+		os.Exit(0)
+	case "dangling-sleep":
+		_, _ = os.Stdout.WriteString("dangling chunk reference: hash abc123 referenced but not present\n")
+		time.Sleep(time.Hour)
+		os.Exit(1)
+	default:
+		os.Exit(2)
 	}
 }
 

--- a/internal/storage/dolt/push_lock_test.go
+++ b/internal/storage/dolt/push_lock_test.go
@@ -1,0 +1,52 @@
+package dolt
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/lockfile"
+)
+
+func TestDoltPushLockSerializesSameCLIDir(t *testing.T) {
+	tmp := t.TempDir()
+	dbDir := filepath.Join(tmp, "mydb")
+	if err := os.MkdirAll(filepath.Join(dbDir, ".dolt"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	s := &DoltStore{dbPath: tmp, database: "mydb"}
+	first, err := s.acquireDoltPushLock(context.Background())
+	if err != nil {
+		t.Fatalf("first lock acquisition failed: %v", err)
+	}
+	defer func() {
+		if first != nil {
+			_ = lockfile.FlockUnlock(first)
+			_ = first.Close()
+		}
+	}()
+
+	t.Setenv("BEADS_DOLT_PUSH_LOCK_TIMEOUT", "10ms")
+	second, err := s.acquireDoltPushLock(context.Background())
+	if second != nil {
+		_ = lockfile.FlockUnlock(second)
+		_ = second.Close()
+	}
+	if !errors.Is(err, ErrDoltPushInProgress) {
+		t.Fatalf("expected ErrDoltPushInProgress under contention, got %v", err)
+	}
+
+	_ = lockfile.FlockUnlock(first)
+	_ = first.Close()
+	first = nil
+
+	third, err := s.acquireDoltPushLock(context.Background())
+	if err != nil {
+		t.Fatalf("lock should be acquirable after release: %v", err)
+	}
+	_ = lockfile.FlockUnlock(third)
+	_ = third.Close()
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
+	"github.com/steveyegge/beads/internal/lockfile"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
@@ -276,10 +277,14 @@ const (
 // this prevents the process from blocking forever.
 const cliExecTimeout = 5 * time.Minute
 
-// fsckTimeout is the maximum time to wait for dolt fsck to verify the local
-// chunk store before a push. fsck reads local files only; 30 seconds is ample
-// for any DB size we currently operate.
-const fsckTimeout = 30 * time.Second
+// defaultFSCKTimeout is the maximum time to wait for dolt fsck to verify the
+// local chunk store before a push. Large NBS stores can legitimately take
+// longer than the old 30s budget, so this is configurable through
+// BEADS_DOLT_FSCK_TIMEOUT. Set BEADS_DOLT_PRE_PUSH_FSCK=0 to skip the preflight.
+const defaultFSCKTimeout = 30 * time.Second
+
+// prePushFSCKCommandContext is injectable for tests.
+var prePushFSCKCommandContext = exec.CommandContext
 
 // Retry configuration for transient connection errors (stale pool connections,
 // brief network issues, server restarts).
@@ -1896,18 +1901,42 @@ func (s *DoltStore) credentialsForRemote(remote string) *remoteCredentials {
 	return nil
 }
 
+func prePushFSCKDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEADS_DOLT_PRE_PUSH_FSCK"))) {
+	case "0", "false", "no", "off", "skip", "disabled":
+		return true
+	default:
+		return false
+	}
+}
+
+func prePushFSCKTimeout() time.Duration {
+	s := strings.TrimSpace(os.Getenv("BEADS_DOLT_FSCK_TIMEOUT"))
+	if s == "" {
+		return defaultFSCKTimeout
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return d
+	}
+	if n, err := strconv.Atoi(s); err == nil {
+		return time.Duration(n) * time.Second
+	}
+	log.Printf("invalid BEADS_DOLT_FSCK_TIMEOUT=%q, using %s", s, defaultFSCKTimeout)
+	return defaultFSCKTimeout
+}
+
 // prePushFSCK runs dolt fsck --quiet to verify local chunk integrity before
-// pushing. This prevents propagating Dolt remote corruption (dangling blob
-// references) that arise when concurrent pushes race on the remote manifest.
+// pushing. This prevents propagating Dolt corruption when local or remote state
+// already has dangling blob references.
 //
-// When multiple agents push simultaneously, one push's manifest update can
-// land before another's chunks finish uploading, leaving a manifest that
-// references chunks that were never stored. Any agent that then fetches and
-// re-pushes that remote faithfully propagates the dangling reference.
-//
-// If CLIDir is empty or .dolt/noms does not exist, the check is skipped.
-// Any fsck failure returns ErrDanglingReference — the push is NOT attempted.
+// If CLIDir is empty, .dolt/noms does not exist, the check is disabled, or fsck
+// cannot complete before the configured timeout, the check is skipped with a
+// warning. A completed fsck that reports integrity failures still aborts the
+// push with ErrDanglingReference.
 func (s *DoltStore) prePushFSCK(ctx context.Context) error {
+	if prePushFSCKDisabled() {
+		return nil
+	}
 	dir := s.CLIDir()
 	if dir == "" {
 		return nil
@@ -1915,13 +1944,28 @@ func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 	if _, err := os.Stat(filepath.Join(dir, ".dolt", "noms")); os.IsNotExist(err) {
 		return nil
 	}
-	fsckCtx, cancel := context.WithTimeout(ctx, fsckTimeout)
+	timeout := prePushFSCKTimeout()
+	if timeout <= 0 {
+		return nil
+	}
+	fsckCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	cmd := exec.CommandContext(fsckCtx, "dolt", "fsck", "--quiet") // #nosec G204 -- fixed command
+	cmd := prePushFSCKCommandContext(fsckCtx, "dolt", "fsck", "--quiet") // #nosec G204 -- fixed command
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		output := strings.TrimSpace(string(out))
+		if errors.Is(fsckCtx.Err(), context.DeadlineExceeded) {
+			if fsckOutputIndicatesIntegrityFailure(output) {
+				return fmt.Errorf("%w: aborting push to prevent propagating corrupt chunks: %s",
+					ErrDanglingReference, output)
+			}
+			log.Printf("pre-push fsck timed out after %s, skipping integrity check; set BEADS_DOLT_FSCK_TIMEOUT to a larger duration to require a full check", timeout)
+			return nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		// Distinguish "fsck couldn't run the integrity check" (environmental /
 		// tooling issue) from "fsck ran and found integrity problems" (the actual
 		// concern of PR #3447). Wrapping an open-failure as ErrDanglingReference
@@ -1945,6 +1989,10 @@ func (s *DoltStore) prePushFSCK(ctx context.Context) error {
 	return nil
 }
 
+func fsckOutputIndicatesIntegrityFailure(output string) bool {
+	return strings.TrimSpace(output) != "" && !fsckCouldNotOpen(output)
+}
+
 // fsckCouldNotOpen reports whether dolt fsck output indicates the check
 // could not run at all (as opposed to finding integrity problems). Matches
 // the known error phrasings dolt emits before any integrity work begins.
@@ -1959,33 +2007,124 @@ func fsckCouldNotOpen(output string) bool {
 	}
 }
 
+func doltPushLockDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BEADS_DOLT_PUSH_LOCK"))) {
+	case "0", "false", "no", "off", "skip", "disabled":
+		return true
+	default:
+		return false
+	}
+}
+
+func doltPushLockTimeout() time.Duration {
+	s := strings.TrimSpace(os.Getenv("BEADS_DOLT_PUSH_LOCK_TIMEOUT"))
+	if s != "" {
+		if d, err := time.ParseDuration(s); err == nil {
+			return d
+		}
+		if n, err := strconv.Atoi(s); err == nil {
+			return time.Duration(n) * time.Second
+		}
+		log.Printf("invalid BEADS_DOLT_PUSH_LOCK_TIMEOUT=%q, using default", s)
+	}
+	timeout := prePushFSCKTimeout() + cliExecTimeout + 30*time.Second
+	if timeout < cliExecTimeout {
+		return cliExecTimeout
+	}
+	return timeout
+}
+
+func (s *DoltStore) withDoltPushLock(ctx context.Context, fn func(context.Context) error) error {
+	f, err := s.acquireDoltPushLock(ctx)
+	if err != nil {
+		return err
+	}
+	if f != nil {
+		defer func() {
+			_ = lockfile.FlockUnlock(f)
+			_ = f.Close()
+		}()
+	}
+	return fn(ctx)
+}
+
+func (s *DoltStore) acquireDoltPushLock(ctx context.Context) (*os.File, error) {
+	if doltPushLockDisabled() {
+		return nil, nil
+	}
+	dir := s.CLIDir()
+	if dir == "" {
+		return nil, nil
+	}
+	lockDir := filepath.Join(dir, ".dolt")
+	if _, err := os.Stat(lockDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("check dolt push lock dir: %w", err)
+	}
+	lockPath := filepath.Join(lockDir, "beads-push.lock")
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600) // #nosec G304 -- lockPath is constrained to the Dolt repo dir.
+	if err != nil {
+		return nil, fmt.Errorf("open dolt push lock: %w", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, doltPushLockTimeout())
+	defer cancel()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if err := lockfile.FlockExclusiveNonBlocking(f); err == nil {
+			_ = f.Truncate(0)
+			_, _ = f.Seek(0, 0)
+			_, _ = fmt.Fprintf(f, "pid=%d\nstarted=%s\n", os.Getpid(), time.Now().UTC().Format(time.RFC3339))
+			return f, nil
+		} else if !lockfile.IsLocked(err) {
+			_ = f.Close()
+			return nil, fmt.Errorf("acquire dolt push lock: %w", err)
+		}
+
+		select {
+		case <-waitCtx.Done():
+			_ = f.Close()
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return nil, fmt.Errorf("%w: timed out after %s waiting for %s", ErrDoltPushInProgress, doltPushLockTimeout(), lockPath)
+			}
+			return nil, waitCtx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 // doltCLIPush shells out to `dolt push` from the database directory.
 // Used for git-protocol remotes where CALL DOLT_PUSH times out through the SQL connection.
 // If creds is non-nil, credentials are set on the subprocess environment only,
 // avoiding process-wide env var races with concurrent goroutines.
 func (s *DoltStore) doltCLIPush(ctx context.Context, remote string, force bool, creds *remoteCredentials) error {
-	if err := s.prePushFSCK(ctx); err != nil {
-		return err
-	}
-	ctx, cancel := context.WithTimeout(ctx, cliExecTimeout)
-	defer cancel()
-	args := []string{"push"}
-	if force {
-		args = append(args, "--force")
-	}
-	args = append(args, remote, s.branch)
-	cmd := exec.CommandContext(ctx, "dolt", args...) // #nosec G204 -- fixed command with validated remote/branch
-	cmd.Dir = s.CLIDir()
-	creds.applyToCmd(cmd)
-	if s.isS3Remote(ctx, remote) {
-		applyS3ChecksumEnvToCmd(cmd)
-	}
-	applyNoGitHooksToCmd(cmd) // GH#3724
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("dolt push failed: %s: %w", strings.TrimSpace(string(out)), err)
-	}
-	return nil
+	return s.withDoltPushLock(ctx, func(ctx context.Context) error {
+		if err := s.prePushFSCK(ctx); err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(ctx, cliExecTimeout)
+		defer cancel()
+		args := []string{"push"}
+		if force {
+			args = append(args, "--force")
+		}
+		args = append(args, remote, s.branch)
+		cmd := exec.CommandContext(ctx, "dolt", args...) // #nosec G204 -- fixed command with validated remote/branch
+		cmd.Dir = s.CLIDir()
+		creds.applyToCmd(cmd)
+		if s.isS3Remote(ctx, remote) {
+			applyS3ChecksumEnvToCmd(cmd)
+		}
+		applyNoGitHooksToCmd(cmd) // GH#3724
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("dolt push failed: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+		return nil
+	})
 }
 
 // doltCLIPull shells out to `dolt pull` from the database directory.


### PR DESCRIPTION
## Summary

- Treat a pre-push `dolt fsck --quiet` timeout as an incomplete check instead of a dangling-reference corruption finding when no integrity-failure output was captured.
- Add `BEADS_DOLT_FSCK_TIMEOUT` and `BEADS_DOLT_PRE_PUSH_FSCK` controls for operators with large Dolt stores.
- Serialize Beads-managed CLI pushes per local Dolt repo with `.dolt/beads-push.lock` to avoid multiple local agents running `fsck`/`push` against the same store at once.

## Problem

Large Dolt stores can legitimately fail to complete `dolt fsck --quiet` inside the existing fixed timeout. Before this change, any fsck process failure except a narrow "could not open" case was wrapped as `ErrDanglingReference`, so a timeout or cancellation with empty output could surface to users as:

```text
dangling chunk reference: aborting push to prevent propagating corrupt chunks
```

That message implies confirmed local corruption even when fsck did not finish and did not report corrupt chunks.

## Changes

- Keeps completed fsck integrity failures fatal.
- Skips timed-out fsck checks when output does not indicate an integrity failure, with an operator warning.
- Allows disabling the pre-push fsck with `BEADS_DOLT_PRE_PUSH_FSCK=0`.
- Allows tuning the timeout with `BEADS_DOLT_FSCK_TIMEOUT`.
- Adds a per-repo push lock, configurable with `BEADS_DOLT_PUSH_LOCK` and `BEADS_DOLT_PUSH_LOCK_TIMEOUT`.
- Applies the lock to normal CLI pushes and federation peer CLI pushes.

## Testing

```text
go test -tags gms_pure_go ./internal/storage/dolt -count=1
ok github.com/steveyegge/beads/internal/storage/dolt 22.996s

go test -tags gms_pure_go ./cmd/bd -run '^TestDoltPushPullCommitNeedStore$|^TestDoltRemoteSubcommandsNeedStore$' -count=1
ok github.com/steveyegge/beads/cmd/bd 0.185s

git diff --check
```

## Notes

This is intentionally a narrow fix. It prevents Beads from reporting an incomplete fsck as confirmed dangling-reference corruption and reduces local push concurrency. It does not claim to fix every Dolt push failure mode; real `dolt push` failures still return as push errors after the fsck phase.