### PR TITLE
fix: cache CLI remote listing

### DIFF
--- a/internal/storage/doltutil/remotes.go
+++ b/internal/storage/doltutil/remotes.go
@@ -1,9 +1,16 @@
 package doltutil
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/beads/internal/remotecache"
 	"github.com/steveyegge/beads/internal/storage"
@@ -35,12 +42,107 @@ func IsGitProtocolURL(url string) bool {
 		strings.HasPrefix(url, "git://")
 }
 
-// ListCLIRemotes parses `dolt remote -v` output from the given database directory.
+// --- per-write `dolt remote -v` fork mitigation (gastown#4070 / beads#3948) ---
+// `dolt remote -v` shells out to the dolt CLI, which loads the whole DB into
+// memory (~2GB on large stores) even just to print the remote list. In a
+// multi-store federation, the write path resolves peers via ListCLIRemotes /
+// FindCLIRemote on every write, forking one ~2GB process per peer-check and
+// OOM-storming the box. Remotes change rarely (manual `bd dolt remote
+// add/remove`), so we cache the parsed list per dbPath with a short TTL and
+// invalidate on mutation. Set BEADS_NO_REMOTE_CACHE=1 to disable (fall back to
+// the original uncached behavior).
+
+// remoteListTTL bounds how long a parsed remote list is cached per dbPath.
+// Remotes are stable infrastructure (set at rig creation) and bd-driven
+// mutations invalidate the cache, so a long default is safe and minimizes the
+// 2GB `dolt remote -v` forks. Override with BEADS_REMOTE_CACHE_TTL_SEC.
+var remoteListTTL = func() time.Duration {
+	if s := strings.TrimSpace(os.Getenv("BEADS_REMOTE_CACHE_TTL_SEC")); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return 30 * time.Minute
+}()
+
+func remoteCacheDisabled() bool {
+	v := os.Getenv("BEADS_NO_REMOTE_CACHE")
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+func remoteCacheFile(dbPath string) string {
+	h := sha256.Sum256([]byte(dbPath))
+	return filepath.Join(os.TempDir(), "bd-remotes-"+hex.EncodeToString(h[:8])+".json")
+}
+
+type remoteCacheEntry struct {
+	Stamp   time.Time            `json:"stamp"`
+	Remotes []storage.RemoteInfo `json:"remotes"`
+}
+
+func readRemoteCache(dbPath string) ([]storage.RemoteInfo, bool) {
+	if remoteCacheDisabled() {
+		return nil, false
+	}
+	b, err := os.ReadFile(remoteCacheFile(dbPath))
+	if err != nil {
+		return nil, false
+	}
+	var e remoteCacheEntry
+	if err := json.Unmarshal(b, &e); err != nil {
+		return nil, false
+	}
+	// Reject expired or clock-skewed (future-stamped) entries.
+	if time.Since(e.Stamp) > remoteListTTL || e.Stamp.After(time.Now()) {
+		return nil, false
+	}
+	return e.Remotes, true
+}
+
+func writeRemoteCache(dbPath string, remotes []storage.RemoteInfo) {
+	if remoteCacheDisabled() {
+		return
+	}
+	b, err := json.Marshal(remoteCacheEntry{Stamp: time.Now(), Remotes: remotes})
+	if err != nil {
+		return
+	}
+	f := remoteCacheFile(dbPath)
+	tmp := fmt.Sprintf("%s.%d.tmp", f, os.Getpid())
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return
+	}
+	if err := os.Rename(tmp, f); err != nil {
+		_ = os.Remove(tmp)
+	}
+}
+
+// InvalidateCLIRemotes drops the cached remote list for dbPath. Called after
+// any CLI-level remote mutation so the next read re-forks dolt exactly once.
+func InvalidateCLIRemotes(dbPath string) {
+	_ = os.Remove(remoteCacheFile(dbPath))
+}
+
+// ListCLIRemotes parses `dolt remote -v` output from the given database
+// directory. The result is cached per dbPath (see the mitigation note above);
+// AddCLIRemote/RemoveCLIRemote invalidate it.
 func ListCLIRemotes(dbPath string) ([]storage.RemoteInfo, error) {
+	if cached, ok := readRemoteCache(dbPath); ok {
+		return cached, nil
+	}
+	// Skip the fork entirely when dbPath isn't a dolt repository: `dolt remote -v`
+	// loads the whole DB (~2GB) only to error "not a valid dolt repository". The
+	// multi-store write path calls this with non-dolt dirs (e.g. the agent CWD),
+	// which is the per-write fork storm (gastown#4070 / beads#3948).
+	if fi, statErr := os.Stat(filepath.Join(dbPath, ".dolt")); statErr != nil || !fi.IsDir() {
+		writeRemoteCache(dbPath, nil)
+		return nil, nil
+	}
 	cmd := exec.Command("dolt", "remote", "-v") // #nosec G204 -- fixed command
 	cmd.Dir = dbPath
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		writeRemoteCache(dbPath, nil) // negative-cache transient errors to avoid re-forking
 		return nil, fmt.Errorf("dolt remote -v failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	seen := map[string]bool{}
@@ -57,6 +159,7 @@ func ListCLIRemotes(dbPath string) ([]storage.RemoteInfo, error) {
 			remotes = append(remotes, storage.RemoteInfo{Name: parts[0], URL: parts[1]})
 		}
 	}
+	writeRemoteCache(dbPath, remotes)
 	return remotes, nil
 }
 
@@ -76,6 +179,7 @@ func AddCLIRemote(dbPath, name, url string) error {
 	if err != nil {
 		return fmt.Errorf("dolt remote add failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
+	InvalidateCLIRemotes(dbPath)
 	return nil
 }
 
@@ -91,6 +195,7 @@ func RemoveCLIRemote(dbPath, name string) error {
 	if err != nil {
 		return fmt.Errorf("dolt remote remove failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
+	InvalidateCLIRemotes(dbPath)
 	return nil
 }
 

--- a/internal/storage/doltutil/remotes_cache_test.go
+++ b/internal/storage/doltutil/remotes_cache_test.go
@@ -1,0 +1,77 @@
+package doltutil
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+)
+
+func TestRemoteCacheRoundTrip(t *testing.T) {
+	t.Setenv("BEADS_NO_REMOTE_CACHE", "")
+
+	dbPath := filepath.Join(t.TempDir(), "db")
+	InvalidateCLIRemotes(dbPath)
+	t.Cleanup(func() { InvalidateCLIRemotes(dbPath) })
+
+	if _, ok := readRemoteCache(dbPath); ok {
+		t.Fatal("cache unexpectedly existed before write")
+	}
+
+	want := []storage.RemoteInfo{{Name: "origin", URL: "git+ssh://git@example.com/org/repo.git"}}
+	writeRemoteCache(dbPath, want)
+
+	got, ok := readRemoteCache(dbPath)
+	if !ok {
+		t.Fatal("cache miss after write")
+	}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("cache = %#v, want %#v", got, want)
+	}
+}
+
+func TestRemoteCacheRejectsExpiredEntries(t *testing.T) {
+	t.Setenv("BEADS_NO_REMOTE_CACHE", "")
+
+	dbPath := filepath.Join(t.TempDir(), "db")
+	InvalidateCLIRemotes(dbPath)
+	t.Cleanup(func() { InvalidateCLIRemotes(dbPath) })
+
+	entry := remoteCacheEntry{
+		Stamp:   time.Now().Add(-remoteListTTL - time.Second),
+		Remotes: []storage.RemoteInfo{{Name: "origin", URL: "git+ssh://git@example.com/org/repo.git"}},
+	}
+	b, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(remoteCacheFile(dbPath), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := readRemoteCache(dbPath); ok {
+		t.Fatal("expired cache entry was accepted")
+	}
+}
+
+func TestListCLIRemotesSkipsNonDoltDirectory(t *testing.T) {
+	t.Setenv("BEADS_NO_REMOTE_CACHE", "")
+
+	dbPath := t.TempDir()
+	InvalidateCLIRemotes(dbPath)
+	t.Cleanup(func() { InvalidateCLIRemotes(dbPath) })
+
+	got, err := ListCLIRemotes(dbPath)
+	if err != nil {
+		t.Fatalf("ListCLIRemotes(non-dolt dir) error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ListCLIRemotes(non-dolt dir) = %#v, want empty", got)
+	}
+	if cached, ok := readRemoteCache(dbPath); !ok || len(cached) != 0 {
+		t.Fatalf("negative cache = %#v, ok=%v; want empty cached result", cached, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- cache parsed `dolt remote -v` results per Dolt db path with a 30 minute TTL
- negative-cache non-Dolt directories and transient CLI remote-list failures to avoid repeat fork storms
- invalidate the cache after CLI remote add/remove

## Why
`dolt remote -v` loads large Dolt stores into memory even when it only prints remotes. In Gas City, ordinary write/list paths can call this repeatedly, which turns a busy hq store into a multi-GB fork storm and contributes to SQL stalls/OOM pressure.

## Tests
- `/home/charlie/.local/go/bin/go test ./internal/storage/doltutil`