### PR TITLE
fix(create): commit labels during initial issue creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   beads, templates, ephemeral wisps, or unknown record types). This prevents
   a viewer/interchange refresh from silently replacing a richer JSONL file
   with the filtered auto-export subset. ([#4069](https://github.com/gastownhall/beads/issues/4069))
+- `bd quick` now treats label insertion as part of issue creation: label
+  failures abort the create instead of being silently dropped.
 - **`bd dolt status` reports externally-managed local servers truthfully** - when a rig is configured as `dolt_mode: server` pointing at a local host but `dolt.auto-start: false` (so an orchestrator or systemd owns the sql-server lifecycle), `bd dolt status` previously said `not running` because no PID file existed. It now SQL-probes the configured endpoint, matching the path already used for non-local hosts, and reports `running (external)` with host/port/database/version when the server answers. **JSON output shape change**: on affected rigs, `bd dolt status --json` now emits `{"running": true, "mode": "external", ...}` instead of `{"running": false, "pid": 0, ...}`. Automation that parsed the old `running:false` as a "needs restart" sentinel should switch to checking `running` directly. (be-0eyj, [#3550](https://github.com/gastownhall/beads/pull/3550))
 
 ## [1.0.4] - 2026-05-07

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -290,6 +290,7 @@ var createCmd = &cobra.Command{
 				NoHistory:          noHistory,
 				CreatedBy:          getActorWithGit(),
 				Owner:              getOwner(),
+				Labels:             labels,
 				MolType:            molType,
 				WispType:           wispType,
 				DueAt:              dueAt,
@@ -473,6 +474,8 @@ var createCmd = &cobra.Command{
 			}
 		}
 
+		labels = mergeCreateLabels(labels, inheritedLabels)
+
 		issue := buildCreateIssue(createIssueParams{
 			ID:                 explicitID,
 			Title:              title,
@@ -490,6 +493,7 @@ var createCmd = &cobra.Command{
 			NoHistory:          noHistory,
 			CreatedBy:          getActorWithGit(),
 			Owner:              getOwner(),
+			Labels:             labels,
 			MolType:            molType,
 			WispType:           wispType,
 			EventKind:          eventCategory,
@@ -543,9 +547,9 @@ var createCmd = &cobra.Command{
 		}
 
 		// Track whether any post-create writes occurred. CreateIssue commits
-		// the issue to Dolt internally, but subsequent AddDependency/AddLabel
-		// calls only write to the working set. A follow-up Dolt commit is
-		// needed to persist them (GH#2009).
+		// the issue and its initial labels to Dolt internally, but subsequent
+		// AddDependency calls only write to the working set. A follow-up Dolt
+		// commit is needed to persist them (GH#2009).
 		postCreateWrites := false
 
 		// If parent was specified, add parent-child dependency
@@ -557,28 +561,6 @@ var createCmd = &cobra.Command{
 			}
 			if err := store.AddDependency(ctx, dep, actor); err != nil {
 				WarnError("failed to add parent-child dependency %s -> %s: %v", issue.ID, parentID, err)
-			} else {
-				postCreateWrites = true
-			}
-		}
-
-		// Merge inherited parent labels with user-specified labels (GH#2100)
-		if len(inheritedLabels) > 0 {
-			seen := make(map[string]bool)
-			for _, l := range labels {
-				seen[l] = true
-			}
-			for _, l := range inheritedLabels {
-				if !seen[l] {
-					labels = append(labels, l)
-				}
-			}
-		}
-
-		// Add labels if specified
-		for _, label := range labels {
-			if err := store.AddLabel(ctx, issue.ID, label, actor); err != nil {
-				WarnError("failed to add label %s: %v", label, err)
 			} else {
 				postCreateWrites = true
 			}
@@ -677,8 +659,8 @@ var createCmd = &cobra.Command{
 		}
 
 		// Commit to Dolt. In DoltStore mode, CreateIssue commits the issue
-		// row internally, so only post-create metadata (deps, labels) needs
-		// a separate commit. In EmbeddedDoltStore mode, CreateIssue writes
+		// row internally, so only post-create metadata (deps) needs a separate
+		// commit. In EmbeddedDoltStore mode, CreateIssue writes
 		// to the working set without a Dolt commit, so we always commit
 		// everything together at the end.
 		if !usesSQLServer() || postCreateWrites {
@@ -742,6 +724,7 @@ type createIssueParams struct {
 	NoHistory          bool
 	CreatedBy          string
 	Owner              string
+	Labels             []string
 	MolType            types.MolType
 	WispType           types.WispType
 	EventKind          string
@@ -777,6 +760,7 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		NoHistory:          params.NoHistory,
 		CreatedBy:          params.CreatedBy,
 		Owner:              params.Owner,
+		Labels:             append([]string(nil), params.Labels...),
 		MolType:            params.MolType,
 		WispType:           params.WispType,
 		EventKind:          params.EventKind,
@@ -787,6 +771,25 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		DeferUntil:         params.DeferUntil,
 		Metadata:           params.Metadata,
 	}
+}
+
+func mergeCreateLabels(labels, inheritedLabels []string) []string {
+	merged := append([]string(nil), labels...)
+	if len(inheritedLabels) == 0 {
+		return merged
+	}
+	seen := make(map[string]struct{}, len(merged)+len(inheritedLabels))
+	for _, label := range merged {
+		seen[label] = struct{}{}
+	}
+	for _, label := range inheritedLabels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		merged = append(merged, label)
+	}
+	return merged
 }
 
 func renderCreateDryRunPreview(issue *types.Issue, labels, deps []string) {

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -271,44 +271,7 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		// Handle --dry-run flag (before --rig to ensure it works with cross-rig creation)
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		if dryRun {
-			previewIssue := buildCreateIssue(createIssueParams{
-				ID:                 explicitID,
-				Title:              title,
-				Description:        description,
-				Design:             design,
-				AcceptanceCriteria: acceptance,
-				Notes:              notes,
-				SpecID:             specID,
-				Priority:           priority,
-				IssueType:          types.IssueType(issueType).Normalize(),
-				Assignee:           assignee,
-				ExternalRef:        externalRef,
-				Ephemeral:          wisp,
-				NoHistory:          noHistory,
-				CreatedBy:          getActorWithGit(),
-				Owner:              getOwner(),
-				Labels:             labels,
-				MolType:            molType,
-				WispType:           wispType,
-				DueAt:              dueAt,
-				DeferUntil:         deferUntil,
-				Metadata:           metadata,
-				EventKind:          eventCategory,
-				Actor:              eventActor,
-				Target:             eventTarget,
-				Payload:            eventPayload,
-			})
-
-			if jsonOutput {
-				outputJSON(previewIssue)
-			} else {
-				renderCreateDryRunPreview(previewIssue, labels, deps)
-			}
-			return
-		}
 
 		// Get estimate if provided
 		var estimatedMinutes *int
@@ -360,11 +323,53 @@ var createCmd = &cobra.Command{
 			repoPath = routing.DetermineTargetRepo(routingConfig, userRole, ".")
 		}
 
+		renderDryRun := func() {
+			previewIssue := buildCreateIssue(createIssueParams{
+				ID:                 explicitID,
+				Title:              title,
+				Description:        description,
+				Design:             design,
+				AcceptanceCriteria: acceptance,
+				Notes:              notes,
+				SpecID:             specID,
+				Priority:           priority,
+				IssueType:          types.IssueType(issueType).Normalize(),
+				Assignee:           assignee,
+				ExternalRef:        externalRef,
+				EstimatedMinutes:   estimatedMinutes,
+				Ephemeral:          wisp,
+				NoHistory:          noHistory,
+				CreatedBy:          getActorWithGit(),
+				Owner:              getOwner(),
+				Labels:             labels,
+				MolType:            molType,
+				WispType:           wispType,
+				DueAt:              dueAt,
+				DeferUntil:         deferUntil,
+				Metadata:           metadata,
+				EventKind:          eventCategory,
+				Actor:              eventActor,
+				Target:             eventTarget,
+				Payload:            eventPayload,
+			})
+
+			if jsonOutput {
+				outputJSON(previewIssue)
+			} else {
+				renderCreateDryRunPreview(previewIssue, labels, deps)
+			}
+		}
+
+		if dryRun && parentID == "" {
+			renderDryRun()
+			return
+		}
+
 		// Switch to target repo for multi-repo support (bd-6x6g)
 		// When routing to a different repo, we use direct storage access
 		var targetStore storage.DoltStorage
 		var remoteCache *remotecache.Cache // non-nil when routing to a remote URL
-		if repoPath != "." {
+		if !dryRun && repoPath != "." {
 			if remotecache.IsRemoteURL(repoPath) {
 				// Remote URL: pull into cache, open store, push explicitly after create
 				var err error
@@ -417,29 +422,52 @@ var createCmd = &cobra.Command{
 			FatalError("cannot specify both --id and --parent flags")
 		}
 
-		// If parent is specified, generate child ID and optionally inherit labels
+		parentLookupStore := store
+		if dryRun && repoPath != "." {
+			var err error
+			parentLookupStore, err = openDryRunTargetStore(rootCtx, repoPath)
+			if err != nil {
+				FatalError("%v", err)
+			}
+			defer func() { _ = parentLookupStore.Close() }()
+		}
+
+		// If parent is specified, validate it and optionally inherit labels.
+		// Child ID allocation is delayed until after the dry-run gate so
+		// previews do not consume the next child counter.
 		var inheritedLabels []string
 		if parentID != "" {
 			ctx := rootCtx
-			// Validate parent exists before generating child ID
-			_, err := store.GetIssue(ctx, parentID)
+			_, err := parentLookupStore.GetIssue(ctx, parentID)
 			if err != nil {
 				if errors.Is(err, storage.ErrNotFound) {
 					FatalError("parent issue %s not found", parentID)
 				}
 				FatalError("failed to check parent issue: %v", err)
 			}
-			childID, err := store.GetNextChildID(ctx, parentID)
-			if err != nil {
-				FatalError("%v", err)
-			}
-			explicitID = childID // Set as explicit ID for the rest of the flow
 
 			// Inherit parent labels unless --no-inherit-labels is set (GH#2100)
 			noInheritLabels, _ := cmd.Flags().GetBool("no-inherit-labels")
 			if !noInheritLabels {
-				inheritedLabels, _ = store.GetLabels(ctx, parentID)
+				inheritedLabels, _ = parentLookupStore.GetLabels(ctx, parentID)
 			}
+		}
+
+		labels = mergeCreateLabels(labels, inheritedLabels)
+
+		if dryRun {
+			renderDryRun()
+			return
+		}
+
+		createCtx := rootCtx
+		if parentID != "" {
+			childID, err := store.GetNextChildID(rootCtx, parentID)
+			if err != nil {
+				FatalError("%v", err)
+			}
+			explicitID = childID // Set as explicit ID for the rest of the flow.
+			createCtx = storage.WithReservedChildCounter(createCtx, parentID, childID)
 		}
 
 		// Validate explicit ID format if provided
@@ -453,7 +481,7 @@ var createCmd = &cobra.Command{
 			}
 
 			// Validate prefix matches database prefix
-			ctx := rootCtx
+			ctx := createCtx
 
 			// Get database prefix and allowed prefixes from config.
 			// YAML config takes precedence over DB — in shared-server mode the DB
@@ -473,8 +501,6 @@ var createCmd = &cobra.Command{
 				FatalError("%v", err)
 			}
 		}
-
-		labels = mergeCreateLabels(labels, inheritedLabels)
 
 		issue := buildCreateIssue(createIssueParams{
 			ID:                 explicitID,
@@ -505,7 +531,7 @@ var createCmd = &cobra.Command{
 			Metadata:           metadata,
 		})
 
-		ctx := rootCtx
+		ctx := createCtx
 
 		// Check if any dependencies are discovered-from type
 		// If so, inherit source_repo from the parent issue
@@ -774,13 +800,14 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 }
 
 func mergeCreateLabels(labels, inheritedLabels []string) []string {
-	merged := append([]string(nil), labels...)
-	if len(inheritedLabels) == 0 {
-		return merged
-	}
-	seen := make(map[string]struct{}, len(merged)+len(inheritedLabels))
-	for _, label := range merged {
+	merged := make([]string, 0, len(labels)+len(inheritedLabels))
+	seen := make(map[string]struct{}, len(labels)+len(inheritedLabels))
+	for _, label := range labels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
 		seen[label] = struct{}{}
+		merged = append(merged, label)
 	}
 	for _, label := range inheritedLabels {
 		if _, ok := seen[label]; ok {
@@ -788,6 +815,9 @@ func mergeCreateLabels(labels, inheritedLabels []string) []string {
 		}
 		seen[label] = struct{}{}
 		merged = append(merged, label)
+	}
+	if len(merged) == 0 {
+		return nil
 	}
 	return merged
 }
@@ -885,6 +915,38 @@ func formatTimeForRPC(t *time.Time) string {
 		return ""
 	}
 	return t.Format(time.RFC3339)
+}
+
+func openDryRunTargetStore(ctx context.Context, repoPath string) (storage.DoltStorage, error) {
+	if remotecache.IsRemoteURL(repoPath) {
+		cache, err := remotecache.DefaultCache()
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize remote cache: %w", err)
+		}
+		// The dry-run parent lookup only reads from this cached remote store.
+		// Do not add writes here; dry-runs must not mutate cached remotes.
+		store, err := cache.OpenStore(ctx, repoPath, newDoltStoreFromConfig)
+		if err != nil {
+			return nil, fmt.Errorf("dry-run parent lookup requires an existing cached remote store for %s: %w", repoPath, err)
+		}
+		return store, nil
+	}
+
+	targetPath := routing.ExpandPath(repoPath)
+	beadsDir := filepath.Join(targetPath, ".beads")
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if _, err := os.Stat(metadataPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("target repo %s is not initialized; refusing to initialize it during dry-run", targetPath)
+		}
+		return nil, fmt.Errorf("failed to inspect target repo %s: %w", targetPath, err)
+	}
+
+	store, err := newDoltStoreFromConfig(ctx, beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open target store for dry-run: %w", err)
+	}
+	return store, nil
 }
 
 // ensureBeadsDirForPath ensures a beads directory exists at the target path.

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -515,6 +515,39 @@ func TestEmbeddedCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("dry_run_parent_label_inheritance", func(t *testing.T) {
+		dir, _, _ := bdInit(t, bd, "--prefix", "dp")
+		parent := bdCreate(t, bd, dir, "Parent with labels", "-t", "epic", "-l", "team-a,shared")
+
+		cmd := exec.Command(bd, "create", "--dry-run", "Preview child", "--json",
+			"--parent", parent.ID, "-l", "child,shared")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd create --dry-run --parent failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+
+		preview := parseIssueJSON(t, stdout.Bytes())
+		labelMap := make(map[string]bool)
+		for _, label := range preview.Labels {
+			labelMap[label] = true
+		}
+		for _, want := range []string{"team-a", "shared", "child"} {
+			if !labelMap[want] {
+				t.Fatalf("dry-run labels = %v, want %q", preview.Labels, want)
+			}
+		}
+		if len(preview.Labels) != 3 {
+			t.Fatalf("dry-run labels = %v, want 3 deduped labels", preview.Labels)
+		}
+
+		child := bdCreate(t, bd, dir, "Real child after dry-run", "--parent", parent.ID)
+		if child.ID != parent.ID+".1" {
+			t.Fatalf("child ID after dry-run = %q, want %q", child.ID, parent.ID+".1")
+		}
+	})
+
 	t.Run("skills_and_context", func(t *testing.T) {
 		dir, _, _ := bdInit(t, bd, "--prefix", "sc")
 		issue := bdCreate(t, bd, dir, "Skills issue",
@@ -591,6 +624,62 @@ A new feature
 		}
 		if stats.TotalIssues < 2 {
 			t.Errorf("expected at least 2 issues from markdown, got %d", stats.TotalIssues)
+		}
+	})
+
+	t.Run("graph_initial_labels_not_duplicated", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gl")
+		plan := `{
+  "nodes": [
+    {"key": "root", "title": "Graph root", "type": "task", "labels": ["team-a", "shared"]}
+  ]
+}`
+		planFile := filepath.Join(dir, "graph-labels.json")
+		if err := os.WriteFile(planFile, []byte(plan), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := exec.Command(bd, "create", "--graph", planFile, "--json")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd create --graph failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+
+		var result GraphApplyResult
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("parse graph result: %v\nstdout:\n%s", err, stdout.String())
+		}
+		id := result.IDs["root"]
+		if id == "" {
+			t.Fatalf("graph result missing root ID: %#v", result.IDs)
+		}
+
+		dataDir := filepath.Join(beadsDir, "embeddeddolt")
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "gl", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+
+		var labelCount int
+		if err := db.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?", id).Scan(&labelCount); err != nil {
+			t.Fatalf("count labels: %v", err)
+		}
+		if labelCount != 2 {
+			t.Fatalf("label count = %d, want 2", labelCount)
+		}
+
+		var labelEventCount int
+		if err := db.QueryRowContext(t.Context(),
+			"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+			id, types.EventLabelAdded).Scan(&labelEventCount); err != nil {
+			t.Fatalf("count label events: %v", err)
+		}
+		if labelEventCount != 2 {
+			t.Fatalf("label_added event count = %d, want 2", labelEventCount)
 		}
 	})
 
@@ -752,6 +841,47 @@ func TestEmbeddedCreateCommitPending(t *testing.T) {
 	})
 }
 
+func TestEmbeddedCreateFormCommitsLabelOnlyCreate(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+
+	bd := buildEmbeddedBD(t)
+	_, beadsDir, _ := bdInit(t, bd, "--prefix", "cfl")
+	store := openStore(t, beadsDir, "cfl")
+
+	issue, err := CreateIssueFromFormValues(t.Context(), store, &createFormValues{
+		Title:     "Form labels commit",
+		Priority:  2,
+		IssueType: "task",
+		Labels:    []string{"form", "initial"},
+	}, "tester")
+	if err != nil {
+		t.Fatalf("CreateIssueFromFormValues: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+	db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "cfl", "main")
+	if err != nil {
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	defer cleanup()
+
+	var labelCount int
+	if err := db.QueryRowContext(t.Context(),
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?",
+		issue.ID,
+	).Scan(&labelCount); err != nil {
+		t.Fatalf("count committed labels: %v", err)
+	}
+	if labelCount != 2 {
+		t.Fatalf("committed label count = %d, want 2", labelCount)
+	}
+}
+
 // TestEmbeddedCreateCrossRepo verifies that bd create --repo routes to a different
 // repo's embedded dolt store, creates the issue there, and commits it.
 func TestEmbeddedCreateCrossRepo(t *testing.T) {
@@ -835,6 +965,77 @@ func TestEmbeddedCreateCrossRepoWithParent(t *testing.T) {
 	// Verify parent-child dependency exists in the target store
 	targetBeadsDir := filepath.Join(targetDir, ".beads")
 	assertDepExists(t, targetBeadsDir, "tgt", child.ID, parent.ID)
+}
+
+func TestEmbeddedCreateDryRunRepoDoesNotInitializeTarget(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	dir, _, _ := bdInit(t, bd, "--prefix", "dr")
+	targetDir := filepath.Join(dir, "uninit-dry-run-target")
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, targetDir)
+
+	cmd := exec.Command(bd, "create", "--dry-run", "Preview only", "--json", "--repo", targetDir)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd create --dry-run --repo failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	if _, err := os.Stat(filepath.Join(targetDir, ".beads")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run target .beads stat err = %v, want not exist", err)
+	}
+}
+
+func TestEmbeddedCreateCrossRepoDryRunWithParent(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt create tests")
+	}
+	t.Parallel()
+
+	bd := buildEmbeddedBD(t)
+
+	dir, _, _ := bdInit(t, bd, "--prefix", "drp")
+	targetDir := filepath.Join(dir, "target-repo")
+	if err := os.MkdirAll(targetDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoAt(t, targetDir)
+	runBDInit(t, bd, targetDir, "--prefix", "tgt")
+
+	parent := bdCreate(t, bd, dir, "Parent epic", "-t", "epic", "-l", "team-a,shared", "--repo", targetDir)
+	cmd := exec.Command(bd, "create", "--dry-run", "Preview child", "--json",
+		"--parent", parent.ID, "-l", "child,shared", "--repo", targetDir)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	stdout, stderr, err := runCommandBuffers(t, cmd)
+	if err != nil {
+		t.Fatalf("bd create --dry-run --repo --parent failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	preview := parseIssueJSON(t, stdout.Bytes())
+	labelMap := make(map[string]bool)
+	for _, label := range preview.Labels {
+		labelMap[label] = true
+	}
+	for _, want := range []string{"team-a", "shared", "child"} {
+		if !labelMap[want] {
+			t.Fatalf("dry-run labels = %v, want %q", preview.Labels, want)
+		}
+	}
+
+	child := bdCreate(t, bd, dir, "Real child after dry-run", "--parent", parent.ID, "--repo", targetDir)
+	if child.ID != parent.ID+".1" {
+		t.Fatalf("child ID after dry-run = %q, want %q", child.ID, parent.ID+".1")
+	}
 }
 
 // TestEmbeddedCreateCrossRepoUninit verifies that bd create --repo works when

--- a/cmd/bd/create_form.go
+++ b/cmd/bd/create_form.go
@@ -113,6 +113,7 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 			return nil, fmt.Errorf("failed to generate child ID: %w", err)
 		}
 		explicitID = childID
+		ctx = storage.WithReservedChildCounter(ctx, fv.ParentID, childID)
 
 		// Inherit parent labels (GH#2100), matching bd create --parent behavior
 		inheritedLabels, _ = s.GetLabels(ctx, fv.ParentID)
@@ -122,6 +123,8 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 	if fv.ExternalRef != "" {
 		externalRefPtr = &fv.ExternalRef
 	}
+
+	labels := mergeCreateLabels(fv.Labels, inheritedLabels)
 
 	issue := &types.Issue{
 		Title:              fv.Title,
@@ -134,6 +137,7 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 		Assignee:           fv.Assignee,
 		ExternalRef:        externalRefPtr,
 		CreatedBy:          getActorWithGit(), // GH#748: track who created the issue
+		Labels:             labels,
 	}
 
 	if explicitID != "" {
@@ -175,10 +179,9 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 		return nil, fmt.Errorf("failed to create issue: %w", err)
 	}
 
-	// Track whether any post-create writes occurred. CreateIssue commits
-	// the issue to Dolt internally, but subsequent AddDependency/AddLabel
-	// calls only write to the working set. A follow-up Dolt commit is
-	// needed to persist them (GH#2009).
+	// Track whether any post-create writes occurred. In embedded mode,
+	// CreateIssue writes the SQL working set and the caller must commit it.
+	// Subsequent AddDependency calls also need a follow-up Dolt commit.
 	postCreateWrites := false
 
 	// If parent was specified, add parent-child dependency (GH#1983)
@@ -190,29 +193,6 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 		}
 		if err := s.AddDependency(ctx, dep, actor); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to add parent-child dependency %s -> %s: %v\n", issue.ID, fv.ParentID, err)
-		} else {
-			postCreateWrites = true
-		}
-	}
-
-	// Merge inherited parent labels with user-specified labels (GH#2100)
-	if len(inheritedLabels) > 0 {
-		seen := make(map[string]bool)
-		for _, l := range fv.Labels {
-			seen[l] = true
-		}
-		for _, l := range inheritedLabels {
-			if !seen[l] {
-				fv.Labels = append(fv.Labels, l)
-			}
-		}
-	}
-
-	// Add labels if specified
-	for _, label := range fv.Labels {
-		if err := s.AddLabel(ctx, issue.ID, label, actor); err != nil {
-			// Log warning but don't fail the entire operation
-			fmt.Fprintf(os.Stderr, "Warning: failed to add label %s: %v\n", label, err)
 		} else {
 			postCreateWrites = true
 		}
@@ -258,13 +238,13 @@ func CreateIssueFromFormValues(ctx context.Context, s storage.DoltStorage, fv *c
 		}
 	}
 
-	// Commit post-create metadata (deps, labels) to Dolt. CreateIssue's
-	// internal DOLT_COMMIT only covers the issue row; AddDependency and
-	// AddLabel write to the SQL working set without a Dolt commit. Without
-	// this, the metadata is visible but not durable — it can be lost on
-	// push, sync, or server restart (GH#2009).
-	if postCreateWrites {
-		commitMsg := fmt.Sprintf("bd: create %s (metadata)", issue.ID)
+	// Commit embedded creates and post-create metadata to Dolt. Without this,
+	// working-set rows are visible locally but absent from HEAD and sync.
+	if !usesSQLServer() || postCreateWrites {
+		commitMsg := fmt.Sprintf("bd: create %s", issue.ID)
+		if postCreateWrites {
+			commitMsg = fmt.Sprintf("bd: create %s (metadata)", issue.ID)
+		}
 		if err := s.Commit(ctx, commitMsg); err != nil && !isDoltNothingToCommit(err) {
 			WarnError("failed to commit post-create metadata: %v", err)
 		}

--- a/cmd/bd/create_labels_test.go
+++ b/cmd/bd/create_labels_test.go
@@ -28,7 +28,7 @@ func TestBuildCreateIssuePreservesLabels(t *testing.T) {
 
 func TestMergeCreateLabelsKeepsUserOrderAndDedupesInherited(t *testing.T) {
 	got := mergeCreateLabels(
-		[]string{"gc:wisp", "status:pending"},
+		[]string{"gc:wisp", "status:pending", "gc:wisp"},
 		[]string{"status:pending", "owner:agent"},
 	)
 	want := []string{"gc:wisp", "status:pending", "owner:agent"}

--- a/cmd/bd/create_labels_test.go
+++ b/cmd/bd/create_labels_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestBuildCreateIssuePreservesLabels(t *testing.T) {
+	labels := []string{"gc:wisp", "status:pending"}
+	issue := buildCreateIssue(createIssueParams{
+		Title:     "labelled create",
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Labels:    labels,
+	})
+
+	if !reflect.DeepEqual(issue.Labels, labels) {
+		t.Fatalf("labels = %v, want %v", issue.Labels, labels)
+	}
+
+	labels[0] = "mutated"
+	if issue.Labels[0] != "gc:wisp" {
+		t.Fatalf("issue labels alias input slice: got %v", issue.Labels)
+	}
+}
+
+func TestMergeCreateLabelsKeepsUserOrderAndDedupesInherited(t *testing.T) {
+	got := mergeCreateLabels(
+		[]string{"gc:wisp", "status:pending"},
+		[]string{"status:pending", "owner:agent"},
+	)
+	want := []string{"gc:wisp", "status:pending", "owner:agent"}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("merged labels = %v, want %v", got, want)
+	}
+}

--- a/cmd/bd/graph_apply.go
+++ b/cmd/bd/graph_apply.go
@@ -562,15 +562,6 @@ func executeGraphApply(ctx context.Context, plan *GraphApplyPlan, opts GraphAppl
 			keyToID[node.Key] = issues[i].ID
 		}
 
-		// Persist labels.
-		for i, node := range plan.Nodes {
-			for _, label := range node.Labels {
-				if err := tx.AddLabel(ctx, issues[i].ID, label, actor); err != nil {
-					return fmt.Errorf("node %q: adding label %q: %w", node.Key, label, err)
-				}
-			}
-		}
-
 		// Resolve MetadataRefs now that all IDs are known.
 		for i, node := range plan.Nodes {
 			if len(node.MetadataRefs) == 0 {

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -136,13 +136,14 @@ func runImport(cmd *cobra.Command, args []string) error {
 }
 
 type importResultJSON struct {
-	Source    string   `json:"source"`
-	Created   int      `json:"created"`
-	Skipped   int      `json:"skipped"`
-	DedupHits int      `json:"dedup_skipped,omitempty"`
-	Memories  int      `json:"memories,omitempty"`
-	IDs       []string `json:"ids,omitempty"`
-	DryRun    bool     `json:"dry_run,omitempty"`
+	Source              string   `json:"source"`
+	Created             int      `json:"created"`
+	Skipped             int      `json:"skipped"`
+	DedupHits           int      `json:"dedup_skipped,omitempty"`
+	Memories            int      `json:"memories,omitempty"`
+	IDs                 []string `json:"ids,omitempty"`
+	SkippedDependencies []string `json:"skipped_dependencies,omitempty"`
+	DryRun              bool     `json:"dry_run,omitempty"`
 }
 
 func runImportFromReader(ctx context.Context, r io.Reader, source string) error {
@@ -247,6 +248,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		}
 		result.Created = importResult.Created
 		result.Skipped += importResult.Skipped
+		result.SkippedDependencies = append(result.SkippedDependencies, importResult.SkippedDependencies...)
 		for _, issue := range issues {
 			result.IDs = append(result.IDs, issue.ID)
 		}
@@ -276,6 +278,9 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		fmt.Fprintf(os.Stderr, " (%d duplicates skipped)", dedupHits)
 	}
 	fmt.Fprintln(os.Stderr)
+	for _, skipped := range result.SkippedDependencies {
+		fmt.Fprintf(os.Stderr, "Skipped dependency: %s\n", skipped)
+	}
 	return nil
 }
 

--- a/cmd/bd/import_from_jsonl_test.go
+++ b/cmd/bd/import_from_jsonl_test.go
@@ -6,7 +6,11 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func TestImportFromLocalJSONL(t *testing.T) {
@@ -209,6 +213,90 @@ func TestImportFromLocalJSONL(t *testing.T) {
 		}
 		if child2.Title != "Child 2" {
 			t.Errorf("Child 2 title changed unexpectedly: got %q", child2.Title)
+		}
+	})
+
+	t.Run("skips cyclic and self dependencies instead of aborting import", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "dolt")
+		store := newTestStore(t, dbPath)
+
+		ctx := context.Background()
+		now := time.Now().UTC()
+		issues := []*types.Issue{
+			{
+				ID:        "test-cycle-a",
+				Title:     "Cycle A",
+				Status:    types.StatusOpen,
+				IssueType: types.TypeTask,
+				Priority:  2,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Dependencies: []*types.Dependency{{
+					DependsOnID: "test-cycle-b",
+					Type:        types.DepBlocks,
+				}},
+			},
+			{
+				ID:        "test-cycle-b",
+				Title:     "Cycle B",
+				Status:    types.StatusOpen,
+				IssueType: types.TypeTask,
+				Priority:  2,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Dependencies: []*types.Dependency{{
+					DependsOnID: "test-cycle-a",
+					Type:        types.DepBlocks,
+				}},
+			},
+			{
+				ID:        "test-self",
+				Title:     "Self dependency",
+				Status:    types.StatusOpen,
+				IssueType: types.TypeTask,
+				Priority:  2,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Dependencies: []*types.Dependency{{
+					DependsOnID: "test-self",
+					Type:        types.DepBlocks,
+				}},
+			},
+		}
+
+		result, err := importIssuesCore(ctx, "", store, issues, ImportOptions{SkipPrefixValidation: true})
+		if err != nil {
+			t.Fatalf("importIssuesCore failed: %v", err)
+		}
+		if result.Created != 3 {
+			t.Fatalf("Created = %d, want 3", result.Created)
+		}
+		if got := strings.Join(result.SkippedDependencies, "\n"); !strings.Contains(got, "test-cycle-b -> test-cycle-a") ||
+			!strings.Contains(got, "test-self -> test-self") {
+			t.Fatalf("SkippedDependencies = %#v, want cycle and self-dependency details", result.SkippedDependencies)
+		}
+
+		for _, id := range []string{"test-cycle-a", "test-cycle-b", "test-self"} {
+			if _, err := store.GetIssue(ctx, id); err != nil {
+				t.Fatalf("imported issue %s missing: %v", id, err)
+			}
+		}
+		deps, err := store.GetDependencyRecords(ctx, "test-cycle-a")
+		if err != nil {
+			t.Fatalf("GetDependencyRecords(test-cycle-a): %v", err)
+		}
+		if len(deps) != 1 || deps[0].DependsOnID != "test-cycle-b" {
+			t.Fatalf("test-cycle-a deps = %#v, want only test-cycle-a -> test-cycle-b", deps)
+		}
+		for _, id := range []string{"test-cycle-b", "test-self"} {
+			deps, err := store.GetDependencyRecords(ctx, id)
+			if err != nil {
+				t.Fatalf("GetDependencyRecords(%s): %v", id, err)
+			}
+			if len(deps) != 0 {
+				t.Fatalf("%s deps = %#v, want none", id, deps)
+			}
 		}
 	})
 

--- a/cmd/bd/import_from_jsonl_test.go
+++ b/cmd/bd/import_from_jsonl_test.go
@@ -300,6 +300,65 @@ func TestImportFromLocalJSONL(t *testing.T) {
 		}
 	})
 
+	t.Run("skips mixed regular and wisp in-batch dependencies instead of aborting import", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "dolt")
+		store := newTestStore(t, dbPath)
+
+		ctx := context.Background()
+		now := time.Now().UTC()
+		issues := []*types.Issue{
+			{
+				ID:        "test-mixed-regular",
+				Title:     "Regular source",
+				Status:    types.StatusOpen,
+				IssueType: types.TypeTask,
+				Priority:  2,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Dependencies: []*types.Dependency{{
+					DependsOnID: "test-mixed-wisp",
+					Type:        types.DepBlocks,
+				}},
+			},
+			{
+				ID:        "test-mixed-wisp",
+				Title:     "Wisp target",
+				Status:    types.StatusOpen,
+				IssueType: types.TypeTask,
+				Priority:  2,
+				CreatedAt: now,
+				UpdatedAt: now,
+				Ephemeral: true,
+			},
+		}
+
+		result, err := importIssuesCore(ctx, "", store, issues, ImportOptions{SkipPrefixValidation: true})
+		if err != nil {
+			t.Fatalf("importIssuesCore failed: %v", err)
+		}
+		if result.Created != 2 {
+			t.Fatalf("Created = %d, want 2", result.Created)
+		}
+		if got := strings.Join(result.SkippedDependencies, "\n"); !strings.Contains(got, "test-mixed-regular -> test-mixed-wisp") ||
+			!strings.Contains(got, "cross-bucket dependency") {
+			t.Fatalf("SkippedDependencies = %#v, want mixed regular/wisp dependency detail", result.SkippedDependencies)
+		}
+
+		for _, id := range []string{"test-mixed-regular", "test-mixed-wisp"} {
+			if _, err := store.GetIssue(ctx, id); err != nil {
+				t.Fatalf("imported issue %s missing: %v", id, err)
+			}
+		}
+		deps, err := store.GetDependencyRecords(ctx, "test-mixed-regular")
+		if err != nil {
+			t.Fatalf("GetDependencyRecords(test-mixed-regular): %v", err)
+		}
+		if len(deps) != 0 {
+			t.Fatalf("test-mixed-regular deps = %#v, want none", deps)
+		}
+	})
+
 	t.Run("skips tombstone entries during import", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		dbPath := filepath.Join(tmpDir, "dolt")

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -50,15 +50,26 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		return &ImportResult{Skipped: len(issues)}, nil
 	}
 
+	var skippedDependencies []string
+	skippedDependencySet := make(map[string]struct{})
 	err := store.CreateIssuesWithFullOptions(ctx, issues, getActorWithGit(), storage.BatchCreateOptions{
-		OrphanHandling:       storage.OrphanAllow,
-		SkipPrefixValidation: opts.SkipPrefixValidation,
+		OrphanHandling:                 storage.OrphanAllow,
+		SkipPrefixValidation:           opts.SkipPrefixValidation,
+		SkipDependencyValidationErrors: true,
+		OnSkippedDependency: func(issueID, dependsOnID, reason string) {
+			skipped := fmt.Sprintf("%s -> %s: %s", issueID, dependsOnID, reason)
+			if _, ok := skippedDependencySet[skipped]; ok {
+				return
+			}
+			skippedDependencySet[skipped] = struct{}{}
+			skippedDependencies = append(skippedDependencies, skipped)
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	return &ImportResult{Created: len(issues)}, nil
+	return &ImportResult{Created: len(issues), SkippedDependencies: skippedDependencies}, nil
 }
 
 // importLocalResult holds counts from a local JSONL import.

--- a/cmd/bd/quick.go
+++ b/cmd/bd/quick.go
@@ -43,16 +43,12 @@ Example:
 			Status:    types.StatusOpen,
 			Priority:  priority,
 			IssueType: types.IssueType(issueType).Normalize(),
+			Labels:    mergeCreateLabels(labels, nil),
 		}
 
 		ctx := rootCtx
 		if err := store.CreateIssue(ctx, issue, actor); err != nil {
 			FatalError("%v", err)
-		}
-
-		// Add labels if specified (silently ignore failures)
-		for _, label := range labels {
-			_ = store.AddLabel(ctx, issue.ID, label, actor)
 		}
 
 		commandDidWrite.Store(true)

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -111,6 +111,14 @@ Scripts in `.beads/hooks/` run after certain events:
 
 Hooks receive event data as JSON on stdin. This enables orchestrator integration (e.g., notifying services of new messages) without beads knowing about the orchestrator.
 
+Creates with initial labels preserve the legacy hook sequence: `on_create` receives the issue snapshot before labels, followed by one or more `on_update` events with cumulative label snapshots. The labels are already persisted before those hooks run, so hook scripts that need the create-time sequence should rely on the JSON payload instead of re-reading the issue from the store during the hook.
+
+Batch creates with initial dependencies emit `on_update` for each persisted
+dependency after the create-time hooks. Each payload carries a cumulative
+dependency snapshot in request order, matching the event shape produced by
+explicit post-create dependency additions; dependencies skipped because their
+target was not persisted do not produce hooks.
+
 ## See Also
 
 - [Graph Links](graph-links.md) - relates_to, duplicates, supersedes, replies_to

--- a/internal/storage/batch.go
+++ b/internal/storage/batch.go
@@ -22,4 +22,9 @@ type BatchCreateOptions struct {
 	OrphanHandling OrphanHandling
 	// SkipPrefixValidation skips prefix validation for existing IDs (used during import)
 	SkipPrefixValidation bool
+	// SkipDependencyValidationErrors skips dependency validation failures that
+	// legacy imports tolerated, such as cycles or self-dependencies.
+	SkipDependencyValidationErrors bool
+	// OnSkippedDependency records dependency edges skipped during batch create.
+	OnSkippedDependency func(issueID, dependsOnID, reason string)
 }

--- a/internal/storage/child_counter_reservation.go
+++ b/internal/storage/child_counter_reservation.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"context"
+	"strconv"
+	"strings"
+)
+
+type childCounterReservationKey struct{}
+
+type childCounterReservation struct {
+	parentID string
+	childNum int
+}
+
+// WithReservedChildCounter marks ctx as carrying a child-counter reservation
+// from a prior GetNextChildID call for the given child ID.
+func WithReservedChildCounter(ctx context.Context, parentID, childID string) context.Context {
+	childText, ok := strings.CutPrefix(childID, parentID+".")
+	if !ok {
+		return ctx
+	}
+	childNum, err := strconv.Atoi(childText)
+	if err != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, childCounterReservationKey{}, childCounterReservation{
+		parentID: parentID,
+		childNum: childNum,
+	})
+}
+
+// HasReservedChildCounter reports whether ctx carries a reservation matching
+// the parent and child number about to be committed.
+func HasReservedChildCounter(ctx context.Context, parentID string, childNum int) bool {
+	reservation, ok := ctx.Value(childCounterReservationKey{}).(childCounterReservation)
+	if !ok {
+		return false
+	}
+	return reservation.parentID == parentID && reservation.childNum == childNum
+}

--- a/internal/storage/dolt/create_issue_commit_test.go
+++ b/internal/storage/dolt/create_issue_commit_test.go
@@ -1,0 +1,82 @@
+package dolt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestCreateIssueCommitsInitialRelationalData(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createdAt := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	issue := &types.Issue{
+		ID:          "create-relational-data",
+		Title:       "Create with relational data",
+		Description: "labels and comments should live in the create commit",
+		Status:      types.StatusOpen,
+		Priority:    1,
+		IssueType:   types.TypeTask,
+		Labels:      []string{"gc:wisp", "status:pending"},
+		Comments: []*types.Comment{
+			{
+				Author:    "tester",
+				Text:      "seed comment",
+				CreatedAt: createdAt,
+			},
+		},
+	}
+
+	if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	var labelCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?",
+		issue.ID,
+	).Scan(&labelCount); err != nil {
+		t.Fatalf("count committed labels: %v", err)
+	}
+	if labelCount != 2 {
+		t.Fatalf("committed label count = %d, want 2", labelCount)
+	}
+
+	var commentCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM comments AS OF 'HEAD' WHERE issue_id = ?",
+		issue.ID,
+	).Scan(&commentCount); err != nil {
+		t.Fatalf("count committed comments: %v", err)
+	}
+	if commentCount != 1 {
+		t.Fatalf("committed comment count = %d, want 1", commentCount)
+	}
+
+	var labelEventCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM events AS OF 'HEAD' WHERE issue_id = ? AND event_type = ?",
+		issue.ID, types.EventLabelAdded,
+	).Scan(&labelEventCount); err != nil {
+		t.Fatalf("count committed label events: %v", err)
+	}
+	if labelEventCount != 2 {
+		t.Fatalf("committed label_added event count = %d, want 2", labelEventCount)
+	}
+
+	var dirtyRelationalTables int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name IN ('labels', 'comments', 'events')
+	`).Scan(&dirtyRelationalTables); err != nil {
+		t.Fatalf("count dirty relational tables: %v", err)
+	}
+	if dirtyRelationalTables != 0 {
+		t.Fatalf("dirty relational table count = %d, want 0", dirtyRelationalTables)
+	}
+}

--- a/internal/storage/dolt/create_issue_commit_test.go
+++ b/internal/storage/dolt/create_issue_commit_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -78,5 +79,594 @@ func TestCreateIssueCommitsInitialRelationalData(t *testing.T) {
 	}
 	if dirtyRelationalTables != 0 {
 		t.Fatalf("dirty relational table count = %d, want 0", dirtyRelationalTables)
+	}
+}
+
+func TestCreateIssueWithoutInitialRelationalDataDoesNotCommitDirtySideTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	dirtyOwner := &types.Issue{
+		ID:        "dirty-owner",
+		Title:     "Dirty side table owner",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, dirtyOwner, "tester"); err != nil {
+		t.Fatalf("CreateIssue dirty owner: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO labels (issue_id, label) VALUES (?, ?)",
+		dirtyOwner.ID, "uncommitted-label",
+	); err != nil {
+		t.Fatalf("dirty label insert: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO comments (issue_id, author, text, created_at) VALUES (?, ?, ?, ?)",
+		dirtyOwner.ID, "tester", "uncommitted comment", time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("dirty comment insert: %v", err)
+	}
+
+	plain := &types.Issue{
+		ID:        "plain-create",
+		Title:     "Plain create",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, plain, "tester"); err != nil {
+		t.Fatalf("CreateIssue plain: %v", err)
+	}
+
+	var committedLabels int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?",
+		dirtyOwner.ID,
+	).Scan(&committedLabels); err != nil {
+		t.Fatalf("count committed dirty labels: %v", err)
+	}
+	if committedLabels != 0 {
+		t.Fatalf("committed dirty labels = %d, want 0", committedLabels)
+	}
+
+	var committedComments int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM comments AS OF 'HEAD' WHERE issue_id = ?",
+		dirtyOwner.ID,
+	).Scan(&committedComments); err != nil {
+		t.Fatalf("count committed dirty comments: %v", err)
+	}
+	if committedComments != 0 {
+		t.Fatalf("committed dirty comments = %d, want 0", committedComments)
+	}
+
+	var dirtySideTables int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name IN ('labels', 'comments')
+	`).Scan(&dirtySideTables); err != nil {
+		t.Fatalf("count dirty side tables: %v", err)
+	}
+	if dirtySideTables != 2 {
+		t.Fatalf("dirty side table count = %d, want 2", dirtySideTables)
+	}
+}
+
+func TestCreateIssueCommitsChildCounterForHierarchicalID(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{
+		ID:        "parent-child-counter",
+		Title:     "Parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, parent, "tester"); err != nil {
+		t.Fatalf("CreateIssue parent: %v", err)
+	}
+
+	childID, err := store.GetNextChildID(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("GetNextChildID: %v", err)
+	}
+	child := &types.Issue{
+		ID:        childID,
+		Title:     "Child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	createCtx := storage.WithReservedChildCounter(ctx, parent.ID, childID)
+	if err := store.CreateIssue(createCtx, child, "tester"); err != nil {
+		t.Fatalf("CreateIssue child: %v", err)
+	}
+
+	var dirtyChildCounters int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name = 'child_counters'
+	`).Scan(&dirtyChildCounters); err != nil {
+		t.Fatalf("count dirty child counters: %v", err)
+	}
+	if dirtyChildCounters != 0 {
+		t.Fatalf("dirty child_counters count = %d, want 0", dirtyChildCounters)
+	}
+}
+
+func TestCreateIssueWithExplicitHierarchicalIDDoesNotCommitDirtyChildCounters(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{
+		ID:        "explicit-child-parent",
+		Title:     "Explicit child parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, parent, "tester"); err != nil {
+		t.Fatalf("CreateIssue parent: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?)",
+		parent.ID, 7,
+	); err != nil {
+		t.Fatalf("dirty child counter insert: %v", err)
+	}
+
+	explicitChild := &types.Issue{
+		ID:        parent.ID + ".7",
+		Title:     "Explicit child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssue(ctx, explicitChild, "tester"); err != nil {
+		t.Fatalf("CreateIssue explicit child: %v", err)
+	}
+
+	var committedDirtyCounters int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM child_counters AS OF 'HEAD' WHERE parent_id = ?",
+		parent.ID,
+	).Scan(&committedDirtyCounters); err != nil {
+		t.Fatalf("count committed dirty child counters: %v", err)
+	}
+	if committedDirtyCounters != 0 {
+		t.Fatalf("committed dirty child counters = %d, want 0", committedDirtyCounters)
+	}
+
+	var dirtyChildCounters int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name = 'child_counters'
+	`).Scan(&dirtyChildCounters); err != nil {
+		t.Fatalf("count dirty child counters: %v", err)
+	}
+	if dirtyChildCounters != 1 {
+		t.Fatalf("dirty child_counters count = %d, want 1", dirtyChildCounters)
+	}
+}
+
+func TestCreateIssuesWithoutInitialRelationalDataDoesNotCommitDirtySideTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	dirtyOwner := &types.Issue{
+		ID:        "batch-dirty-owner",
+		Title:     "Batch dirty side table owner",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, dirtyOwner, "tester"); err != nil {
+		t.Fatalf("CreateIssue dirty owner: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO labels (issue_id, label) VALUES (?, ?)",
+		dirtyOwner.ID, "batch-uncommitted-label",
+	); err != nil {
+		t.Fatalf("dirty label insert: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO comments (issue_id, author, text, created_at) VALUES (?, ?, ?, ?)",
+		dirtyOwner.ID, "tester", "batch uncommitted comment", time.Now().UTC(),
+	); err != nil {
+		t.Fatalf("dirty comment insert: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?)",
+		dirtyOwner.ID, 42,
+	); err != nil {
+		t.Fatalf("dirty child counter insert: %v", err)
+	}
+
+	plain := []*types.Issue{{
+		ID:        "test-batch-plain-create",
+		Title:     "Batch plain create",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}}
+	if err := store.CreateIssues(ctx, plain, "tester"); err != nil {
+		t.Fatalf("CreateIssues plain: %v", err)
+	}
+
+	var committedLabels int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ?",
+		dirtyOwner.ID,
+	).Scan(&committedLabels); err != nil {
+		t.Fatalf("count committed dirty labels: %v", err)
+	}
+	if committedLabels != 0 {
+		t.Fatalf("committed dirty labels = %d, want 0", committedLabels)
+	}
+
+	var committedComments int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM comments AS OF 'HEAD' WHERE issue_id = ?",
+		dirtyOwner.ID,
+	).Scan(&committedComments); err != nil {
+		t.Fatalf("count committed dirty comments: %v", err)
+	}
+	if committedComments != 0 {
+		t.Fatalf("committed dirty comments = %d, want 0", committedComments)
+	}
+
+	var committedChildCounters int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM child_counters AS OF 'HEAD' WHERE parent_id = ?",
+		dirtyOwner.ID,
+	).Scan(&committedChildCounters); err != nil {
+		t.Fatalf("count committed dirty child counters: %v", err)
+	}
+	if committedChildCounters != 0 {
+		t.Fatalf("committed dirty child counters = %d, want 0", committedChildCounters)
+	}
+
+	var dirtySideTables int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name IN ('labels', 'comments', 'child_counters')
+	`).Scan(&dirtySideTables); err != nil {
+		t.Fatalf("count dirty side tables: %v", err)
+	}
+	if dirtySideTables != 3 {
+		t.Fatalf("dirty side table count = %d, want 3", dirtySideTables)
+	}
+}
+
+func TestCreateIssuesWithExplicitHierarchicalIDDoesNotCommitDirtyChildCounters(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{
+		ID:        "test-batch-explicit-child-parent",
+		Title:     "Batch explicit child parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	if err := store.CreateIssue(ctx, parent, "tester"); err != nil {
+		t.Fatalf("CreateIssue parent: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO child_counters (parent_id, last_child) VALUES (?, ?)",
+		parent.ID, 7,
+	); err != nil {
+		t.Fatalf("dirty child counter insert: %v", err)
+	}
+
+	explicitChildren := []*types.Issue{{
+		ID:        parent.ID + ".7",
+		Title:     "Batch explicit child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}}
+	if err := store.CreateIssues(ctx, explicitChildren, "tester"); err != nil {
+		t.Fatalf("CreateIssues explicit child: %v", err)
+	}
+
+	var committedDirtyCounters int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM child_counters AS OF 'HEAD' WHERE parent_id = ?",
+		parent.ID,
+	).Scan(&committedDirtyCounters); err != nil {
+		t.Fatalf("count committed dirty child counters: %v", err)
+	}
+	if committedDirtyCounters != 0 {
+		t.Fatalf("committed dirty child counters = %d, want 0", committedDirtyCounters)
+	}
+
+	var dirtyChildCounters int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name = 'child_counters'
+	`).Scan(&dirtyChildCounters); err != nil {
+		t.Fatalf("count dirty child counters: %v", err)
+	}
+	if dirtyChildCounters != 1 {
+		t.Fatalf("dirty child_counters count = %d, want 1", dirtyChildCounters)
+	}
+}
+
+func TestCreateIssuesHierarchicalIDsCommitChildCounters(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{
+		ID:        "test-batch-child-counter-parent",
+		Title:     "Batch child counter parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeEpic,
+	}
+	children := []*types.Issue{
+		parent,
+		{
+			ID:        parent.ID + ".1",
+			Title:     "Batch child one",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		},
+		{
+			ID:        parent.ID + ".2",
+			Title:     "Batch child two",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		},
+	}
+	if err := store.CreateIssues(ctx, children, "tester"); err != nil {
+		t.Fatalf("CreateIssues hierarchical children: %v", err)
+	}
+
+	var lastChild int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT last_child FROM child_counters AS OF 'HEAD' WHERE parent_id = ?",
+		parent.ID,
+	).Scan(&lastChild); err != nil {
+		t.Fatalf("read committed child counter: %v", err)
+	}
+	if lastChild != 2 {
+		t.Fatalf("committed last_child = %d, want 2", lastChild)
+	}
+
+	var dirtyChildCounters int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name = 'child_counters'
+	`).Scan(&dirtyChildCounters); err != nil {
+		t.Fatalf("count dirty child counters: %v", err)
+	}
+	if dirtyChildCounters != 0 {
+		t.Fatalf("dirty child_counters count = %d, want 0", dirtyChildCounters)
+	}
+}
+
+func TestCreateIssuesAllWispBatchPersistsDependenciesAndCounters(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	source := &types.Issue{
+		ID:        "test-wisp-batch-source",
+		Title:     "Wisp source",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "test-wisp-batch-target",
+			Type:        types.DepBlocks,
+		}},
+	}
+	target := &types.Issue{
+		ID:        "test-wisp-batch-target",
+		Title:     "Wisp target",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	child := &types.Issue{
+		ID:        source.ID + ".3",
+		Title:     "Wisp child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+
+	if err := store.CreateIssues(ctx, []*types.Issue{source, target, child}, "tester"); err != nil {
+		t.Fatalf("CreateIssues all-wisp batch: %v", err)
+	}
+
+	records, err := store.GetDependencyRecords(ctx, source.ID)
+	if err != nil {
+		t.Fatalf("GetDependencyRecords: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("wisp dependency count = %d, want 1", len(records))
+	}
+	if records[0].DependsOnID != target.ID {
+		t.Fatalf("wisp dependency target = %q, want %q", records[0].DependsOnID, target.ID)
+	}
+
+	var lastChild int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT last_child FROM wisp_child_counters WHERE parent_id = ?",
+		source.ID,
+	).Scan(&lastChild); err != nil {
+		t.Fatalf("read wisp child counter: %v", err)
+	}
+	if lastChild != 3 {
+		t.Fatalf("wisp last_child = %d, want 3", lastChild)
+	}
+}
+
+func TestCreateIssuesDuplicateSideTableInputsDoNotCommitDirtySideTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createdAt := time.Date(2026, 5, 22, 11, 0, 0, 0, time.UTC)
+	source := &types.Issue{
+		ID:        "test-dedupe-source",
+		Title:     "Dedupe source",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Labels:    []string{"existing-label"},
+		Comments: []*types.Comment{{
+			Author:    "tester",
+			Text:      "existing comment",
+			CreatedAt: createdAt,
+		}},
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "test-dedupe-target",
+			Type:        types.DepBlocks,
+		}},
+	}
+	target := &types.Issue{
+		ID:        "test-dedupe-target",
+		Title:     "Dedupe target",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	dirtyOwner := &types.Issue{
+		ID:        "test-dedupe-dirty-owner",
+		Title:     "Dirty owner",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	dirtyTarget := &types.Issue{
+		ID:        "test-dedupe-dirty-target",
+		Title:     "Dirty target",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.CreateIssues(ctx, []*types.Issue{source, target, dirtyOwner, dirtyTarget}, "tester"); err != nil {
+		t.Fatalf("CreateIssues seed: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO labels (issue_id, label) VALUES (?, ?)",
+		dirtyOwner.ID, "uncommitted-label",
+	); err != nil {
+		t.Fatalf("dirty label insert: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO comments (issue_id, author, text, created_at) VALUES (?, ?, ?, ?)",
+		dirtyOwner.ID, "tester", "uncommitted comment", createdAt.Add(time.Minute),
+	); err != nil {
+		t.Fatalf("dirty comment insert: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx,
+		"INSERT INTO dependencies (issue_id, depends_on_issue_id, type, created_at, created_by) VALUES (?, ?, ?, ?, ?)",
+		dirtyOwner.ID, dirtyTarget.ID, types.DepBlocks, createdAt.Add(2*time.Minute), "tester",
+	); err != nil {
+		t.Fatalf("dirty dependency insert: %v", err)
+	}
+
+	duplicateSource := &types.Issue{
+		ID:        source.ID,
+		Title:     source.Title,
+		Status:    source.Status,
+		Priority:  source.Priority,
+		IssueType: source.IssueType,
+		Labels:    []string{"existing-label"},
+		Comments: []*types.Comment{{
+			Author:    "tester",
+			Text:      "existing comment",
+			CreatedAt: createdAt,
+		}},
+		Dependencies: []*types.Dependency{{
+			DependsOnID: target.ID,
+			Type:        types.DepBlocks,
+		}},
+	}
+	if err := store.CreateIssues(ctx, []*types.Issue{duplicateSource}, "tester"); err != nil {
+		t.Fatalf("CreateIssues duplicate side tables: %v", err)
+	}
+
+	var committedDirtyLabels int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM labels AS OF 'HEAD' WHERE issue_id = ? AND label = ?",
+		dirtyOwner.ID, "uncommitted-label",
+	).Scan(&committedDirtyLabels); err != nil {
+		t.Fatalf("count committed dirty labels: %v", err)
+	}
+	if committedDirtyLabels != 0 {
+		t.Fatalf("committed dirty labels = %d, want 0", committedDirtyLabels)
+	}
+
+	var committedDirtyComments int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM comments AS OF 'HEAD' WHERE issue_id = ? AND text = ?",
+		dirtyOwner.ID, "uncommitted comment",
+	).Scan(&committedDirtyComments); err != nil {
+		t.Fatalf("count committed dirty comments: %v", err)
+	}
+	if committedDirtyComments != 0 {
+		t.Fatalf("committed dirty comments = %d, want 0", committedDirtyComments)
+	}
+
+	var committedDirtyDependencies int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dependencies AS OF 'HEAD' WHERE issue_id = ? AND depends_on_issue_id = ?",
+		dirtyOwner.ID, dirtyTarget.ID,
+	).Scan(&committedDirtyDependencies); err != nil {
+		t.Fatalf("count committed dirty dependencies: %v", err)
+	}
+	if committedDirtyDependencies != 0 {
+		t.Fatalf("committed dirty dependencies = %d, want 0", committedDirtyDependencies)
+	}
+
+	var dirtySideTables int
+	if err := store.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM dolt_status
+		WHERE table_name IN ('labels', 'comments', 'dependencies')
+	`).Scan(&dirtySideTables); err != nil {
+		t.Fatalf("count dirty side tables: %v", err)
+	}
+	if dirtySideTables != 3 {
+		t.Fatalf("dirty side table count = %d, want 3", dirtySideTables)
 	}
 }

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -43,7 +43,7 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 
 	// Dolt versioning — wisps and no-history issues skip DOLT_COMMIT.
 	if !issue.Ephemeral && !issue.NoHistory {
-		if err := s.doltAddAndCommit(ctx, []string{"issues", "events"},
+		if err := s.doltAddAndCommit(ctx, []string{"issues", "events", "labels", "comments"},
 			fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
 			return err
 		}

--- a/internal/storage/dolt/issues.go
+++ b/internal/storage/dolt/issues.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 		issue.Ephemeral = true // infra types get marked ephemeral (legacy behavior)
 	}
 
+	var result issueops.CreateIssueResult
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		// SkipPrefixValidation matches legacy behavior: single-issue path does
 		// not validate prefixes for explicit IDs.
@@ -36,19 +38,40 @@ func (s *DoltStore) CreateIssue(ctx context.Context, issue *types.Issue, actor s
 		if err != nil {
 			return err
 		}
-		return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
+		result, err = issueops.CreateIssueInTxWithResult(ctx, tx, bc, issue, actor)
+		return err
 	}); err != nil {
 		return err
 	}
 
 	// Dolt versioning — wisps and no-history issues skip DOLT_COMMIT.
 	if !issue.Ephemeral && !issue.NoHistory {
-		if err := s.doltAddAndCommit(ctx, []string{"issues", "events", "labels", "comments"},
+		if err := s.doltAddAndCommit(ctx, createIssueCommitTables(ctx, issue, result),
 			fmt.Sprintf("bd: create %s", issue.ID)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func createIssueCommitTables(ctx context.Context, issue *types.Issue, result issueops.CreateIssueResult) []string {
+	return sortedDirtyTables(issueops.CreateIssueDirtyTables(ctx, issue, result))
+}
+
+func createIssuesCommitTables(ctx context.Context, issues []*types.Issue, result issueops.CreateIssuesResult) []string {
+	return sortedDirtyTables(issueops.CreateIssuesDirtyTables(ctx, issues, result))
+}
+
+func sortedDirtyTables(dirty map[string]bool) []string {
+	if len(dirty) == 0 {
+		return nil
+	}
+	tables := make([]string, 0, len(dirty))
+	for table := range dirty {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	return tables
 }
 
 // CreateIssues creates multiple issues in a single transaction
@@ -66,35 +89,32 @@ func (s *DoltStore) CreateIssuesWithFullOptions(ctx context.Context, issues []*t
 		return nil
 	}
 
-	// All-wisps fast path: individual transactions, no Dolt versioning.
+	// All-wisps fast path: one SQL transaction, no Dolt versioning.
 	// Covers both ephemeral issues and no-history issues (both skip DOLT_COMMIT).
 	if issueops.AllWisps(issues) {
 		for _, issue := range issues {
 			if !issue.NoHistory {
 				issue.Ephemeral = true
 			}
-			if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-				bc, err := issueops.NewBatchContext(ctx, tx, opts)
-				if err != nil {
-					return err
-				}
-				return issueops.CreateIssueInTx(ctx, tx, bc, issue, actor)
-			}); err != nil {
-				return err
-			}
 		}
-		return nil
+		return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+			_, err := issueops.CreateIssuesInTxWithResult(ctx, tx, issues, actor, opts)
+			return err
+		})
 	}
 
+	var result issueops.CreateIssuesResult
 	if err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
-		return issueops.CreateIssuesInTx(ctx, tx, issues, actor, opts)
+		var err error
+		result, err = issueops.CreateIssuesInTxWithResult(ctx, tx, issues, actor, opts)
+		return err
 	}); err != nil {
 		return err
 	}
 
 	// GH#2455: Stage only the tables we modified, then commit without -A.
 	return s.doltAddAndCommit(ctx,
-		[]string{"issues", "events", "labels", "comments", "dependencies", "child_counters"},
+		createIssuesCommitTables(ctx, issues, result),
 		fmt.Sprintf("bd: create %d issue(s)", len(issues)))
 }
 

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -181,67 +181,73 @@ func isDoltNothingToCommit(err error) bool {
 // CreateIssue creates an issue within the transaction.
 // Routes ephemeral issues to the wisps table.
 func (t *doltTransaction) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
-	now := time.Now().UTC()
-	if issue.CreatedAt.IsZero() {
-		issue.CreatedAt = now
-	}
-	if issue.UpdatedAt.IsZero() {
-		issue.UpdatedAt = now
-	}
-	if issue.ContentHash == "" {
-		issue.ContentHash = issue.ComputeContentHash()
+	if issue == nil {
+		return fmt.Errorf("issue must not be nil")
 	}
 
-	table := "issues"
-	if issue.Ephemeral || issue.NoHistory {
-		table = "wisps"
-	}
-
-	// Generate ID if not provided
-	if issue.ID == "" {
-		var configPrefix string
-		err := t.regularTx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", "issue_prefix").Scan(&configPrefix)
-		if err == sql.ErrNoRows || configPrefix == "" {
-			return fmt.Errorf("%w: issue_prefix config is missing", storage.ErrNotInitialized)
-		} else if err != nil {
-			return fmt.Errorf("failed to get config: %w", err)
-		}
-
-		// Normalize prefix: strip trailing hyphen to prevent double-hyphen IDs (bd-6uly)
-		configPrefix = strings.TrimSuffix(configPrefix, "-")
-
-		var prefix string
-		if issue.Ephemeral {
-			prefix = wispPrefix(configPrefix, issue)
-		} else {
-			prefix = configPrefix
-			if issue.PrefixOverride != "" {
-				prefix = issue.PrefixOverride
-			} else if issue.IDPrefix != "" {
-				prefix = configPrefix + "-" + issue.IDPrefix
-			}
-		}
-
-		generatedID, err := generateIssueIDInTable(ctx, t.txFor(table), table, prefix, issue, actor)
+	if issueops.IsWisp(issue) {
+		bc, err := issueops.NewBatchContext(ctx, t.ignoredTx, storage.BatchCreateOptions{SkipPrefixValidation: true})
 		if err != nil {
-			return fmt.Errorf("failed to generate issue ID: %w", err)
+			return err
 		}
-		issue.ID = generatedID
-	}
-
-	// Validate metadata against schema if configured (GH#1416 Phase 2)
-	if err := validateMetadataIfConfigured(issue.Metadata); err != nil {
+		_, err = issueops.CreateIssueInTxWithResult(ctx, t.ignoredTx, bc, issue, actor)
 		return err
 	}
 
-	t.dirty.MarkDirty(table)
-	return insertIssueTxIntoTable(ctx, t.txFor(table), table, issue)
+	bc, err := issueops.NewBatchContext(ctx, t.regularTx, storage.BatchCreateOptions{SkipPrefixValidation: true})
+	if err != nil {
+		return err
+	}
+	result, err := issueops.CreateIssueInTxWithResult(ctx, t.regularTx, bc, issue, actor)
+	if err != nil {
+		return err
+	}
+	for table := range issueops.CreateIssueDirtyTables(ctx, issue, result) {
+		t.dirty.MarkDirty(table)
+	}
+	return nil
 }
 
 // CreateIssues creates multiple issues within the transaction
 func (t *doltTransaction) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
+	if len(issues) == 0 {
+		return nil
+	}
+
+	// This must run before splitting regular issues from wisps: the shared
+	// create helper below only sees the regular subset.
+	if err := issueops.ValidateCreateIssuesMixedBucketDependencies(issues); err != nil {
+		return err
+	}
+
+	var regularIssues []*types.Issue
+	var wispIssues []*types.Issue
 	for _, issue := range issues {
-		if err := t.CreateIssue(ctx, issue, actor); err != nil {
+		if issueops.IsWisp(issue) {
+			wispIssues = append(wispIssues, issue)
+		} else {
+			regularIssues = append(regularIssues, issue)
+		}
+	}
+
+	if len(regularIssues) > 0 {
+		result, err := issueops.CreateIssuesInTxWithResult(ctx, t.regularTx, regularIssues, actor, storage.BatchCreateOptions{
+			OrphanHandling:       storage.OrphanAllow,
+			SkipPrefixValidation: true,
+		})
+		if err != nil {
+			return err
+		}
+		for table := range issueops.CreateIssuesDirtyTables(ctx, regularIssues, result) {
+			t.dirty.MarkDirty(table)
+		}
+	}
+
+	if len(wispIssues) > 0 {
+		if _, err := issueops.CreateIssuesInTxWithResult(ctx, t.ignoredTx, wispIssues, actor, storage.BatchCreateOptions{
+			OrphanHandling:       storage.OrphanAllow,
+			SkipPrefixValidation: true,
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/storage/dolt/transaction_test.go
+++ b/internal/storage/dolt/transaction_test.go
@@ -3,9 +3,13 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -49,6 +53,337 @@ func TestRunInTransactionIgnoredWritesStayOnActiveBranch(t *testing.T) {
 	assertWispCount(ctx, t, store.db, wispID, 1)
 }
 
+func TestRunInTransactionWispCreatePersistsInitialSideTables(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createdAt := time.Date(2026, 5, 22, 6, 0, 0, 0, time.UTC)
+	wisp := &types.Issue{
+		ID:        "test-wisp-tx-side-tables",
+		Title:     "transactional wisp with initial side tables",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+		Labels:    []string{"alpha", "beta"},
+		Comments: []*types.Comment{{
+			Author:    "tester",
+			Text:      "seed comment",
+			CreatedAt: createdAt,
+		}},
+	}
+	if err := store.RunInTransaction(ctx, "test: create wisp side tables", func(tx storage.Transaction) error {
+		return tx.CreateIssue(ctx, wisp, "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction create wisp: %v", err)
+	}
+
+	assertWispCount(ctx, t, store.db, wisp.ID, 1)
+	assertTableCount(ctx, t, store.db, "wisp_labels", wisp.ID, 2)
+	assertTableCount(ctx, t, store.db, "wisp_comments", wisp.ID, 1)
+
+	var labelEventCount int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM wisp_events WHERE issue_id = ? AND event_type = ?",
+		wisp.ID, types.EventLabelAdded,
+	).Scan(&labelEventCount); err != nil {
+		t.Fatalf("query wisp label events for %s: %v", wisp.ID, err)
+	}
+	if labelEventCount != 2 {
+		t.Fatalf("wisp label event count for %s = %d, want 2", wisp.ID, labelEventCount)
+	}
+}
+
+func TestRunInTransactionCreateIssuesMixedWispReadYourWrites(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	regular := &types.Issue{
+		ID:        "test-mixed-batch-regular",
+		Title:     "regular issue in mixed transaction batch",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	wisp := &types.Issue{
+		ID:        "test-mixed-batch-wisp",
+		Title:     "wisp issue in mixed transaction batch",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+		Labels:    []string{"seed"},
+	}
+	if err := store.RunInTransaction(ctx, "test: create mixed transaction batch", func(tx storage.Transaction) error {
+		if err := tx.CreateIssues(ctx, []*types.Issue{regular, wisp}, "tester"); err != nil {
+			return err
+		}
+		got, err := tx.GetIssue(ctx, wisp.ID)
+		if err != nil {
+			return err
+		}
+		if got.ID != wisp.ID || !got.Ephemeral {
+			return fmt.Errorf("GetIssue(%s) = %+v, want active wisp", wisp.ID, got)
+		}
+		if err := tx.AddLabel(ctx, wisp.ID, "txn", "tester"); err != nil {
+			return err
+		}
+		labels, err := tx.GetLabels(ctx, wisp.ID)
+		if err != nil {
+			return err
+		}
+		if len(labels) != 2 || labels[0] != "seed" || labels[1] != "txn" {
+			return fmt.Errorf("wisp labels in tx = %v, want [seed txn]", labels)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("RunInTransaction mixed CreateIssues: %v", err)
+	}
+
+	assertIssueCount(ctx, t, store.db, regular.ID, 1)
+	assertWispCount(ctx, t, store.db, wisp.ID, 1)
+	assertTableCount(ctx, t, store.db, "wisp_labels", wisp.ID, 2)
+}
+
+func TestRunInTransactionCreateIssuesAllWispBatchReconcilesChildCounters(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	parent := &types.Issue{
+		ID:        "test-tx-wisp-parent",
+		Title:     "transactional wisp parent",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	child := &types.Issue{
+		ID:        parent.ID + ".3",
+		Title:     "transactional wisp child",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	if err := store.RunInTransaction(ctx, "test: create wisp transaction batch", func(tx storage.Transaction) error {
+		return tx.CreateIssues(ctx, []*types.Issue{parent, child}, "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction all-wisp CreateIssues: %v", err)
+	}
+
+	var lastChild int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT last_child FROM wisp_child_counters WHERE parent_id = ?",
+		parent.ID,
+	).Scan(&lastChild); err != nil {
+		t.Fatalf("read wisp child counter: %v", err)
+	}
+	if lastChild != 3 {
+		t.Fatalf("wisp last_child = %d, want 3", lastChild)
+	}
+}
+
+func TestValidateCreateIssuesMixedBucketDependenciesRejectsCrossBucketEdges(t *testing.T) {
+	regularA := &types.Issue{ID: "test-regular-a", IssueType: types.TypeTask}
+	regularB := &types.Issue{ID: "test-regular-b", IssueType: types.TypeTask}
+	wispA := &types.Issue{ID: "test-wisp-a", IssueType: types.TypeTask, Ephemeral: true}
+	wispB := &types.Issue{ID: "test-wisp-b", IssueType: types.TypeTask, Ephemeral: true}
+
+	tests := []struct {
+		name      string
+		regulars  []*types.Issue
+		wisps     []*types.Issue
+		wantError bool
+	}{
+		{
+			name: "regular to wisp",
+			regulars: []*types.Issue{{
+				ID:        regularA.ID,
+				IssueType: types.TypeTask,
+				Dependencies: []*types.Dependency{{
+					DependsOnID: wispA.ID,
+					Type:        types.DepBlocks,
+				}},
+			}},
+			wisps:     []*types.Issue{wispA},
+			wantError: true,
+		},
+		{
+			name:     "wisp to regular",
+			regulars: []*types.Issue{regularA},
+			wisps: []*types.Issue{{
+				ID:        wispA.ID,
+				IssueType: types.TypeTask,
+				Ephemeral: true,
+				Dependencies: []*types.Dependency{{
+					DependsOnID: regularA.ID,
+					Type:        types.DepBlocks,
+				}},
+			}},
+			wantError: true,
+		},
+		{
+			name: "same bucket dependencies",
+			regulars: []*types.Issue{
+				regularB,
+				{
+					ID:        regularA.ID,
+					IssueType: types.TypeTask,
+					Dependencies: []*types.Dependency{{
+						DependsOnID: regularB.ID,
+						Type:        types.DepBlocks,
+					}},
+				},
+			},
+			wisps: []*types.Issue{
+				wispB,
+				{
+					ID:        wispA.ID,
+					IssueType: types.TypeTask,
+					Ephemeral: true,
+					Dependencies: []*types.Dependency{{
+						DependsOnID: wispB.ID,
+						Type:        types.DepBlocks,
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := append(append([]*types.Issue{}, tt.regulars...), tt.wisps...)
+			err := issueops.ValidateCreateIssuesMixedBucketDependencies(issues)
+			if tt.wantError {
+				if err == nil || !strings.Contains(err.Error(), "cross-bucket dependency") {
+					t.Fatalf("error = %v, want cross-bucket dependency", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestRunInTransactionCreateIssuesRejectsRegularToWispBatchDependency(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	regular := &types.Issue{
+		ID:        "test-mixed-batch-regular-dep-source",
+		Title:     "regular issue with wisp dependency",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "test-mixed-batch-wisp-dep-target",
+			Type:        types.DepBlocks,
+		}},
+	}
+	wisp := &types.Issue{
+		ID:        "test-mixed-batch-wisp-dep-target",
+		Title:     "wisp dependency target",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	err := store.RunInTransaction(ctx, "test: reject regular-to-wisp batch dependency", func(tx storage.Transaction) error {
+		return tx.CreateIssues(ctx, []*types.Issue{regular, wisp}, "tester")
+	})
+	if err == nil || !strings.Contains(err.Error(), "cross-bucket dependency") {
+		t.Fatalf("RunInTransaction mixed CreateIssues error = %v, want cross-bucket dependency", err)
+	}
+
+	assertIssueCount(ctx, t, store.db, regular.ID, 0)
+	assertWispCount(ctx, t, store.db, wisp.ID, 0)
+}
+
+func TestRunInTransactionCreateIssuesRejectsWispToRegularBatchDependency(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	regular := &types.Issue{
+		ID:        "test-mixed-batch-regular-dep-target",
+		Title:     "regular dependency target",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	wisp := &types.Issue{
+		ID:        "test-mixed-batch-wisp-dep-source",
+		Title:     "wisp issue with regular dependency",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: regular.ID,
+			Type:        types.DepBlocks,
+		}},
+	}
+	err := store.RunInTransaction(ctx, "test: reject wisp-to-regular batch dependency", func(tx storage.Transaction) error {
+		return tx.CreateIssues(ctx, []*types.Issue{regular, wisp}, "tester")
+	})
+	if err == nil || !strings.Contains(err.Error(), "cross-bucket dependency") {
+		t.Fatalf("RunInTransaction mixed CreateIssues error = %v, want cross-bucket dependency", err)
+	}
+
+	assertIssueCount(ctx, t, store.db, regular.ID, 0)
+	assertWispCount(ctx, t, store.db, wisp.ID, 0)
+}
+
+func TestRunInTransactionCreateIssuesSkipsExplicitIDPrefixValidation(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	issue := &types.Issue{
+		ID:        "foreign-explicit-batch-id",
+		Title:     "explicit ID outside configured prefix",
+		Status:    types.StatusOpen,
+		Priority:  2,
+		IssueType: types.TypeTask,
+	}
+	if err := store.RunInTransaction(ctx, "test: create explicit id batch", func(tx storage.Transaction) error {
+		return tx.CreateIssues(ctx, []*types.Issue{issue}, "tester")
+	}); err != nil {
+		t.Fatalf("RunInTransaction explicit-ID CreateIssues: %v", err)
+	}
+
+	assertIssueCount(ctx, t, store.db, issue.ID, 1)
+}
+
+func assertIssueCount(ctx context.Context, t *testing.T, db *sql.DB, id string, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM issues WHERE id = ?", id).Scan(&got); err != nil {
+		t.Fatalf("query issue count for %s: %v", id, err)
+	}
+	if got != want {
+		t.Fatalf("issue count for %s = %d, want %d", id, got, want)
+	}
+}
+
 func assertWispCount(ctx context.Context, t *testing.T, db *sql.DB, id string, want int) {
 	t.Helper()
 	var got int
@@ -57,5 +392,17 @@ func assertWispCount(ctx context.Context, t *testing.T, db *sql.DB, id string, w
 	}
 	if got != want {
 		t.Fatalf("wisp count for %s = %d, want %d", id, got, want)
+	}
+}
+
+func assertTableCount(ctx context.Context, t *testing.T, db *sql.DB, table, id string, want int) {
+	t.Helper()
+	var got int
+	query := "SELECT COUNT(*) FROM " + table + " WHERE issue_id = ?"
+	if err := db.QueryRowContext(ctx, query, id).Scan(&got); err != nil {
+		t.Fatalf("query %s count for %s: %v", table, id, err)
+	}
+	if got != want {
+		t.Fatalf("%s count for %s = %d, want %d", table, id, got, want)
 	}
 }

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -993,6 +993,58 @@ func TestCreateIssues(t *testing.T) {
 		te.assertRowNotExists(t, ctx, "wisps", wisp.ID)
 	})
 
+	t.Run("skips_mixed_batch_dependency_when_validation_errors_are_tolerated", func(t *testing.T) {
+		te := newTestEnv(t, "sk")
+		ctx := t.Context()
+
+		regular := &types.Issue{
+			ID:        "sk-regular-source",
+			Title:     "Regular source",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Dependencies: []*types.Dependency{{
+				DependsOnID: "sk-wisp-target",
+				Type:        types.DepBlocks,
+			}},
+		}
+		wisp := &types.Issue{
+			ID:        "sk-wisp-target",
+			Title:     "Wisp target",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		var skipped []string
+
+		err := te.store.CreateIssuesWithFullOptions(ctx, []*types.Issue{regular, wisp}, "tester", storage.BatchCreateOptions{
+			OrphanHandling:                 storage.OrphanAllow,
+			SkipPrefixValidation:           true,
+			SkipDependencyValidationErrors: true,
+			OnSkippedDependency: func(issueID, dependsOnID, reason string) {
+				skipped = append(skipped, fmt.Sprintf("%s -> %s: %s", issueID, dependsOnID, reason))
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateIssuesWithFullOptions: %v", err)
+		}
+		te.assertRowExists(t, ctx, "issues", regular.ID)
+		te.assertRowExists(t, ctx, "wisps", wisp.ID)
+		if len(skipped) != 1 ||
+			!strings.Contains(skipped[0], "sk-regular-source -> sk-wisp-target") ||
+			!strings.Contains(skipped[0], "cross-bucket dependency") {
+			t.Fatalf("skipped = %#v, want cross-bucket dependency detail", skipped)
+		}
+
+		var regularDeps, wispDeps int
+		te.queryScalar(t, ctx, "SELECT COUNT(*) FROM dependencies WHERE issue_id = ?", []any{regular.ID}, &regularDeps)
+		te.queryScalar(t, ctx, "SELECT COUNT(*) FROM wisp_dependencies WHERE issue_id = ?", []any{regular.ID}, &wispDeps)
+		if regularDeps != 0 || wispDeps != 0 {
+			t.Fatalf("persisted dependency counts = regular:%d wisp:%d, want none", regularDeps, wispDeps)
+		}
+	})
+
 	t.Run("rejects_wisp_dependency_cycle", func(t *testing.T) {
 		te := newTestEnv(t, "wc")
 		ctx := t.Context()

--- a/internal/storage/embeddeddolt/create_issue_test.go
+++ b/internal/storage/embeddeddolt/create_issue_test.go
@@ -4,13 +4,17 @@ package embeddeddolt_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/hooks"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -851,6 +855,43 @@ func TestCreateIssues(t *testing.T) {
 		te.assertEventCount(t, ctx, "events", "ud-dup", "created", 1) // still just 1
 	})
 
+	t.Run("upsert_records_events_for_new_labels", func(t *testing.T) {
+		te := newTestEnv(t, "ul")
+		ctx := t.Context()
+
+		issues := []*types.Issue{
+			{
+				ID:        "ul-dup",
+				Title:     "Original",
+				Status:    types.StatusOpen,
+				Priority:  2,
+				IssueType: types.TypeTask,
+				Labels:    []string{"existing"},
+			},
+		}
+		if err := te.store.CreateIssues(ctx, issues, "tester"); err != nil {
+			t.Fatalf("first CreateIssues: %v", err)
+		}
+		te.assertEventCount(t, ctx, "events", "ul-dup", string(types.EventLabelAdded), 1)
+
+		issues2 := []*types.Issue{
+			{
+				ID:        "ul-dup",
+				Title:     "Updated",
+				Status:    types.StatusOpen,
+				Priority:  2,
+				IssueType: types.TypeTask,
+				Labels:    []string{"existing", "new"},
+			},
+		}
+		if err := te.store.CreateIssues(ctx, issues2, "tester"); err != nil {
+			t.Fatalf("second CreateIssues: %v", err)
+		}
+
+		te.assertLabelCount(t, ctx, "labels", "ul-dup", 2)
+		te.assertEventCount(t, ctx, "events", "ul-dup", string(types.EventLabelAdded), 2)
+	})
+
 	t.Run("all_ephemeral", func(t *testing.T) {
 		te := newTestEnv(t, "ae")
 		ctx := t.Context()
@@ -886,6 +927,185 @@ func TestCreateIssues(t *testing.T) {
 		te.assertRowExists(t, ctx, "issues", "mx-reg1")
 		te.assertRowExists(t, ctx, "wisps", "mx-wisp-1")
 		te.assertRowNotExists(t, ctx, "issues", "mx-wisp-1")
+	})
+
+	t.Run("rejects_regular_to_wisp_batch_dependency", func(t *testing.T) {
+		te := newTestEnv(t, "rw")
+		ctx := t.Context()
+
+		regular := &types.Issue{
+			ID:        "rw-regular-source",
+			Title:     "Regular source",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Dependencies: []*types.Dependency{{
+				DependsOnID: "rw-wisp-target",
+				Type:        types.DepBlocks,
+			}},
+		}
+		wisp := &types.Issue{
+			ID:        "rw-wisp-target",
+			Title:     "Wisp target",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+
+		err := te.store.CreateIssues(ctx, []*types.Issue{regular, wisp}, "tester")
+		if err == nil || !strings.Contains(err.Error(), "cross-bucket dependency") {
+			t.Fatalf("CreateIssues error = %v, want cross-bucket dependency", err)
+		}
+		te.assertRowNotExists(t, ctx, "issues", regular.ID)
+		te.assertRowNotExists(t, ctx, "wisps", wisp.ID)
+	})
+
+	t.Run("rejects_wisp_to_regular_batch_dependency", func(t *testing.T) {
+		te := newTestEnv(t, "wr")
+		ctx := t.Context()
+
+		regular := &types.Issue{
+			ID:        "wr-regular-target",
+			Title:     "Regular target",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		wisp := &types.Issue{
+			ID:        "wr-wisp-source",
+			Title:     "Wisp source",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+			Dependencies: []*types.Dependency{{
+				DependsOnID: regular.ID,
+				Type:        types.DepBlocks,
+			}},
+		}
+
+		err := te.store.CreateIssues(ctx, []*types.Issue{regular, wisp}, "tester")
+		if err == nil || !strings.Contains(err.Error(), "cross-bucket dependency") {
+			t.Fatalf("CreateIssues error = %v, want cross-bucket dependency", err)
+		}
+		te.assertRowNotExists(t, ctx, "issues", regular.ID)
+		te.assertRowNotExists(t, ctx, "wisps", wisp.ID)
+	})
+
+	t.Run("rejects_wisp_dependency_cycle", func(t *testing.T) {
+		te := newTestEnv(t, "wc")
+		ctx := t.Context()
+
+		wispA := &types.Issue{
+			ID:        "wc-wisp-a",
+			Title:     "Wisp A",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+			Dependencies: []*types.Dependency{{
+				DependsOnID: "wc-wisp-b",
+				Type:        types.DepBlocks,
+			}},
+		}
+		wispB := &types.Issue{
+			ID:        "wc-wisp-b",
+			Title:     "Wisp B",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+			Dependencies: []*types.Dependency{{
+				DependsOnID: "wc-wisp-a",
+				Type:        types.DepBlocks,
+			}},
+		}
+
+		err := te.store.RunInTransaction(ctx, "test: reject wisp dependency cycle", func(tx storage.Transaction) error {
+			return tx.CreateIssues(ctx, []*types.Issue{wispA, wispB}, "tester")
+		})
+		if err == nil || !strings.Contains(err.Error(), "cycle") {
+			t.Fatalf("CreateIssues error = %v, want cycle rejection", err)
+		}
+		te.assertRowNotExists(t, ctx, "wisps", wispA.ID)
+		te.assertRowNotExists(t, ctx, "wisps", wispB.ID)
+	})
+
+	t.Run("transaction_wisp_dependency_does_not_stage_regular_dependency_rows", func(t *testing.T) {
+		te := newTestEnv(t, "ws")
+		ctx := t.Context()
+
+		dirtyOwner := &types.Issue{
+			ID:        "ws-dirty-owner",
+			Title:     "Dirty dependency owner",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		dirtyTarget := &types.Issue{
+			ID:        "ws-dirty-target",
+			Title:     "Dirty dependency target",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+		}
+		if err := te.store.CreateIssues(ctx, []*types.Issue{dirtyOwner, dirtyTarget}, "tester"); err != nil {
+			t.Fatalf("CreateIssues seed regular issues: %v", err)
+		}
+		if err := te.store.Commit(ctx, "test: seed regular issues"); err != nil {
+			t.Fatalf("Commit seed regular issues: %v", err)
+		}
+
+		te.exec(t, ctx,
+			"INSERT INTO dependencies (issue_id, depends_on_issue_id, type, created_at, created_by) VALUES (?, ?, ?, ?, ?)",
+			dirtyOwner.ID, dirtyTarget.ID, types.DepBlocks, time.Now().UTC(), "tester")
+
+		wispSource := &types.Issue{
+			ID:        "ws-wisp-source",
+			Title:     "Wisp dependency source",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		wispTarget := &types.Issue{
+			ID:        "ws-wisp-target",
+			Title:     "Wisp dependency target",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Ephemeral: true,
+		}
+		err := te.store.RunInTransaction(ctx, "test: add wisp dependency", func(tx storage.Transaction) error {
+			if err := tx.CreateIssues(ctx, []*types.Issue{wispSource, wispTarget}, "tester"); err != nil {
+				return err
+			}
+			return tx.AddDependency(ctx, &types.Dependency{
+				IssueID:     wispSource.ID,
+				DependsOnID: wispTarget.ID,
+				Type:        types.DepBlocks,
+			}, "tester")
+		})
+		if err != nil {
+			t.Fatalf("RunInTransaction add wisp dependency: %v", err)
+		}
+
+		var committedDirtyDependencies int
+		te.queryScalar(t, ctx,
+			"SELECT COUNT(*) FROM dependencies AS OF 'HEAD' WHERE issue_id = ? AND depends_on_issue_id = ?",
+			[]any{dirtyOwner.ID, dirtyTarget.ID}, &committedDirtyDependencies)
+		if committedDirtyDependencies != 0 {
+			t.Fatalf("committed dirty dependencies = %d, want 0", committedDirtyDependencies)
+		}
+
+		var workingDirtyDependencies int
+		te.queryScalar(t, ctx,
+			"SELECT COUNT(*) FROM dependencies WHERE issue_id = ? AND depends_on_issue_id = ?",
+			[]any{dirtyOwner.ID, dirtyTarget.ID}, &workingDirtyDependencies)
+		if workingDirtyDependencies != 1 {
+			t.Fatalf("working dirty dependencies = %d, want 1", workingDirtyDependencies)
+		}
 	})
 
 	t.Run("with_labels", func(t *testing.T) {
@@ -990,4 +1210,133 @@ func TestCreateIssues(t *testing.T) {
 			t.Errorf("expected prefix error, got: %v", err)
 		}
 	})
+}
+
+func TestHookFiringStoreCreateIssuesFiresDependencyUpdatesFromEmbeddedStore(t *testing.T) {
+	t.Run("non_transactional", func(t *testing.T) {
+		te := newTestEnv(t, "hk")
+		ctx := t.Context()
+		store, logPath := newEmbeddedHookStore(t, te)
+
+		source := &types.Issue{
+			ID:        "hk-source",
+			Title:     "Source",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Dependencies: []*types.Dependency{
+				{DependsOnID: "hk-target-a", Type: types.DepBlocks},
+				{DependsOnID: "hk-target-b", Type: types.DepBlocks},
+			},
+		}
+		targetA := &types.Issue{ID: "hk-target-a", Title: "Target A", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		targetB := &types.Issue{ID: "hk-target-b", Title: "Target B", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+		if err := store.CreateIssues(ctx, []*types.Issue{source, targetA, targetB}, "tester"); err != nil {
+			t.Fatalf("CreateIssues: %v", err)
+		}
+
+		assertDependencyHookPayloads(t, logPath, []string{"hk-target-a", "hk-target-b"})
+	})
+
+	t.Run("transactional", func(t *testing.T) {
+		te := newTestEnv(t, "txh")
+		ctx := t.Context()
+		store, logPath := newEmbeddedHookStore(t, te)
+
+		source := &types.Issue{
+			ID:        "txh-source",
+			Title:     "Source",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			Dependencies: []*types.Dependency{
+				{DependsOnID: "txh-target-a", Type: types.DepBlocks},
+				{DependsOnID: "txh-target-b", Type: types.DepBlocks},
+			},
+		}
+		targetA := &types.Issue{ID: "txh-target-a", Title: "Target A", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+		targetB := &types.Issue{ID: "txh-target-b", Title: "Target B", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask}
+
+		err := store.RunInTransaction(ctx, "test: hook batch deps", func(tx storage.Transaction) error {
+			return tx.CreateIssues(ctx, []*types.Issue{source, targetA, targetB}, "tester")
+		})
+		if err != nil {
+			t.Fatalf("RunInTransaction: %v", err)
+		}
+
+		assertDependencyHookPayloads(t, logPath, []string{"txh-target-a", "txh-target-b"})
+	})
+}
+
+func newEmbeddedHookStore(t *testing.T, te *testEnv) (storage.DoltStorage, string) {
+	t.Helper()
+	hooksDir := filepath.Join(t.TempDir(), "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll hooks: %v", err)
+	}
+	logPath := filepath.Join(t.TempDir(), "updates.jsonl")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$2" = "update" ]; then
+  payload="$(cat)"
+  printf '%%s\n' "$payload" >> %q
+else
+  cat >/dev/null
+fi
+`, logPath)
+	if err := os.WriteFile(filepath.Join(hooksDir, hooks.HookOnUpdate), []byte(script), 0o755); err != nil {
+		t.Fatalf("write update hook: %v", err)
+	}
+	return storage.NewHookFiringStore(te.store, hooks.NewRunner(hooksDir)), logPath
+}
+
+func assertDependencyHookPayloads(t *testing.T, logPath string, targets []string) {
+	t.Helper()
+	var payloads []types.Issue
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		payloads = readHookPayloads(t, logPath)
+		if len(payloads) >= len(targets) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(payloads) != len(targets) {
+		t.Fatalf("dependency update hook count = %d, want %d", len(payloads), len(targets))
+	}
+	sort.Slice(payloads, func(i, j int) bool {
+		return len(payloads[i].Dependencies) < len(payloads[j].Dependencies)
+	})
+	for i, target := range targets {
+		if got := len(payloads[i].Dependencies); got != i+1 {
+			t.Fatalf("payload %d dependency count = %d, want %d", i, got, i+1)
+		}
+		if got := payloads[i].Dependencies[i].DependsOnID; got != target {
+			t.Fatalf("payload %d dependency target = %q, want %q", i, got, target)
+		}
+	}
+}
+
+func readHookPayloads(t *testing.T, logPath string) []types.Issue {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read hook log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	var payloads []types.Issue
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var issue types.Issue
+		if err := json.Unmarshal([]byte(line), &issue); err != nil {
+			t.Fatalf("decode hook payload %q: %v", line, err)
+		}
+		payloads = append(payloads, issue)
+	}
+	return payloads
 }

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -45,16 +45,26 @@ func (t *embeddedTransaction) CreateIssue(ctx context.Context, issue *types.Issu
 	if err != nil {
 		return err
 	}
-	t.dirty.MarkDirty("issues")
-	t.dirty.MarkDirty("events")
-	return issueops.CreateIssueInTx(ctx, t.tx, bc, issue, actor)
+	result, err := issueops.CreateIssueInTxWithResult(ctx, t.tx, bc, issue, actor)
+	if err != nil {
+		return err
+	}
+	for table := range issueops.CreateIssueDirtyTables(ctx, issue, result) {
+		t.dirty.MarkDirty(table)
+	}
+	return nil
 }
 
 func (t *embeddedTransaction) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
-	for _, issue := range issues {
-		if err := t.CreateIssue(ctx, issue, actor); err != nil {
-			return err
-		}
+	result, err := issueops.CreateIssuesInTxWithResult(ctx, t.tx, issues, actor, storage.BatchCreateOptions{
+		OrphanHandling:       storage.OrphanAllow,
+		SkipPrefixValidation: true,
+	})
+	if err != nil {
+		return err
+	}
+	for table := range issueops.CreateIssuesDirtyTables(ctx, issues, result) {
+		t.dirty.MarkDirty(table)
 	}
 	return nil
 }
@@ -95,11 +105,15 @@ func (t *embeddedTransaction) AddDependency(ctx context.Context, dep *types.Depe
 }
 
 func (t *embeddedTransaction) AddDependencyWithOptions(ctx context.Context, dep *types.Dependency, actor string, addOpts storage.DependencyAddOptions) error {
-	t.dirty.MarkDirty("dependencies")
-	return issueops.AddDependencyInTx(ctx, t.tx, dep, actor, issueops.AddDependencyOpts{
+	_, _, _, depTable := issueops.WispTableRouting(issueops.IsActiveWispInTx(ctx, t.tx, dep.IssueID))
+	if err := issueops.AddDependencyInTx(ctx, t.tx, dep, actor, issueops.AddDependencyOpts{
 		IsCrossPrefix:  types.ExtractPrefix(dep.IssueID) != types.ExtractPrefix(dep.DependsOnID),
 		SkipCycleCheck: addOpts.SkipCycleCheck,
-	})
+	}); err != nil {
+		return err
+	}
+	t.dirty.MarkDirty(depTable)
+	return nil
 }
 
 func (t *embeddedTransaction) RemoveDependency(ctx context.Context, issueID, dependsOnID string, actor string) error {
@@ -188,7 +202,12 @@ func (t *embeddedTransaction) CreateIssueImport(ctx context.Context, issue *type
 	if err != nil {
 		return err
 	}
-	t.dirty.MarkDirty("issues")
-	t.dirty.MarkDirty("events")
-	return issueops.CreateIssueInTx(ctx, t.tx, bc, issue, actor)
+	result, err := issueops.CreateIssueInTxWithResult(ctx, t.tx, bc, issue, actor)
+	if err != nil {
+		return err
+	}
+	for table := range issueops.CreateIssueDirtyTables(ctx, issue, result) {
+		t.dirty.MarkDirty(table)
+	}
+	return nil
 }

--- a/internal/storage/hook_decorator.go
+++ b/internal/storage/hook_decorator.go
@@ -27,16 +27,24 @@ import (
 type HookFiringStore struct {
 	DoltStorage             // embed for passthrough of non-overridden methods
 	inner       DoltStorage // the real store
-	runner      *hooks.Runner
+	runner      hookRunner
+}
+
+type hookRunner interface {
+	Run(event string, issue *types.Issue)
 }
 
 // NewHookFiringStore wraps store with automatic hook firing.
 // If runner is nil, hooks are silently skipped (passthrough only).
 func NewHookFiringStore(store DoltStorage, runner *hooks.Runner) *HookFiringStore {
+	var r hookRunner
+	if runner != nil {
+		r = runner
+	}
 	return &HookFiringStore{
 		DoltStorage: store,
 		inner:       store,
-		runner:      runner,
+		runner:      r,
 	}
 }
 
@@ -58,22 +66,33 @@ func UnwrapStore(s DoltStorage) DoltStorage {
 
 // ── Issue mutations ─────────────────────────────────────────────────
 
-// CreateIssue creates an issue and fires on_create.
+// CreateIssue creates an issue and fires on_create plus synthetic on_update
+// hooks for initial labels, matching the old post-create AddLabel behavior.
 func (h *HookFiringStore) CreateIssue(ctx context.Context, issue *types.Issue, actor string) error {
 	if err := h.inner.CreateIssue(ctx, issue, actor); err != nil {
 		return err
 	}
-	h.fireHook(hooks.EventCreate, issue)
+	for _, p := range createHookEvents(issue) {
+		h.fireHook(p.event, p.issue)
+	}
 	return nil
 }
 
-// CreateIssues creates multiple issues and fires on_create for each.
+// CreateIssues creates multiple issues and fires create-time hooks for each,
+// followed by dependency update hooks for batch-persisted dependencies.
 func (h *HookFiringStore) CreateIssues(ctx context.Context, issues []*types.Issue, actor string) error {
 	if err := h.inner.CreateIssues(ctx, issues, actor); err != nil {
 		return err
 	}
 	for _, issue := range issues {
-		h.fireHook(hooks.EventCreate, issue)
+		for _, p := range createHookEvents(issue) {
+			h.fireHook(p.event, p.issue)
+		}
+	}
+	if h.runner != nil {
+		for _, p := range dependencyHookEvents(ctx, issues, h.inner.GetIssue, h.inner.GetDependencyRecords) {
+			h.fireHook(p.event, p.issue)
+		}
 	}
 	return nil
 }
@@ -121,7 +140,7 @@ func (h *HookFiringStore) AddDependency(ctx context.Context, dep *types.Dependen
 	if err := h.inner.AddDependency(ctx, dep, actor); err != nil {
 		return err
 	}
-	h.fireHookByID(ctx, hooks.EventUpdate, dep.IssueID)
+	h.fireDependencyHookByID(ctx, hooks.EventUpdate, dep.IssueID)
 	return nil
 }
 
@@ -130,7 +149,7 @@ func (h *HookFiringStore) RemoveDependency(ctx context.Context, issueID, depends
 	if err := h.inner.RemoveDependency(ctx, issueID, dependsOnID, actor); err != nil {
 		return err
 	}
-	h.fireHookByID(ctx, hooks.EventUpdate, issueID)
+	h.fireDependencyHookByID(ctx, hooks.EventUpdate, issueID)
 	return nil
 }
 
@@ -208,12 +227,199 @@ func (h *HookFiringStore) fireHookByID(ctx context.Context, event, id string) {
 	h.runner.Run(event, issue)
 }
 
+func (h *HookFiringStore) fireDependencyHookByID(ctx context.Context, event, id string) {
+	if h.runner == nil {
+		return
+	}
+	issue, err := dependencySnapshot(ctx, id, h.inner.GetIssue, h.inner.GetDependencyRecords)
+	if err != nil {
+		return
+	}
+	h.runner.Run(event, issue)
+}
+
 // ── Hook tracking transaction ───────────────────────────────────────
 
 // pendingHook records a hook to fire after transaction commit.
 type pendingHook struct {
 	event string
 	issue *types.Issue
+}
+
+func createHookEvents(issue *types.Issue) []pendingHook {
+	if issue == nil {
+		return nil
+	}
+	if len(issue.Labels) == 0 {
+		return []pendingHook{{event: hooks.EventCreate, issue: cloneIssueForHook(issue)}}
+	}
+
+	// Initial labels are persisted before hooks fire, but the hook stream keeps
+	// the legacy post-create AddLabel shape: on_create receives a label-free
+	// snapshot, then on_update receives cumulative synthetic label snapshots.
+	// Hook implementations should use the issue payload for that sequence; live
+	// store reads during these synthetic events observe the fully persisted issue.
+	labels := make([]string, 0, len(issue.Labels))
+	seen := make(map[string]struct{}, len(issue.Labels))
+	for _, label := range issue.Labels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		labels = append(labels, label)
+	}
+	createSnapshot := cloneIssueForHook(issue)
+	createSnapshot.Labels = nil
+	events := []pendingHook{{event: hooks.EventCreate, issue: createSnapshot}}
+	for i := range labels {
+		updateSnapshot := cloneIssueForHook(issue)
+		updateSnapshot.Labels = append([]string(nil), labels[:i+1]...)
+		events = append(events, pendingHook{event: hooks.EventUpdate, issue: updateSnapshot})
+	}
+	return events
+}
+
+type issueGetter func(context.Context, string) (*types.Issue, error)
+type dependencyRecordsGetter func(context.Context, string) ([]*types.Dependency, error)
+
+func dependencyHookEvents(ctx context.Context, issues []*types.Issue, get issueGetter, getDeps dependencyRecordsGetter) []pendingHook {
+	var events []pendingHook
+	states := make(map[string]*dependencyHookState)
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		for _, dep := range issue.Dependencies {
+			if dep == nil {
+				continue
+			}
+			issueID := dep.IssueID
+			if issueID == "" {
+				issueID = issue.ID
+			}
+			if issueID == "" {
+				continue
+			}
+			state, ok := states[issueID]
+			if !ok {
+				snapshot, err := dependencySnapshot(ctx, issueID, get, getDeps)
+				if err != nil {
+					continue
+				}
+				state = &dependencyHookState{
+					snapshot: snapshot,
+					used:     make([]bool, len(snapshot.Dependencies)),
+				}
+				states[issueID] = state
+			}
+			persisted := state.take(dep, issueID)
+			if persisted == nil {
+				continue
+			}
+			state.emitted = append(state.emitted, persisted)
+			updateSnapshot := cloneIssueForHook(state.snapshot)
+			updateSnapshot.Dependencies = cloneDependenciesForHook(state.emitted)
+			events = append(events, pendingHook{event: hooks.EventUpdate, issue: updateSnapshot})
+		}
+	}
+	return events
+}
+
+func dependencySnapshot(ctx context.Context, issueID string, get issueGetter, getDeps dependencyRecordsGetter) (*types.Issue, error) {
+	snapshot, err := get(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	deps, err := getDeps(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	snapshot.Dependencies = cloneDependenciesForHook(deps)
+	return snapshot, nil
+}
+
+type dependencyHookState struct {
+	snapshot *types.Issue
+	used     []bool
+	emitted  []*types.Dependency
+}
+
+func (s *dependencyHookState) take(requested *types.Dependency, issueID string) *types.Dependency {
+	for i, dep := range s.snapshot.Dependencies {
+		if s.used[i] || !sameDependency(dep, requested, issueID) {
+			continue
+		}
+		s.used[i] = true
+		return dep
+	}
+	return nil
+}
+
+func sameDependency(persisted, requested *types.Dependency, issueID string) bool {
+	if persisted == nil || requested == nil {
+		return false
+	}
+	requestedIssueID := requested.IssueID
+	if requestedIssueID == "" {
+		requestedIssueID = issueID
+	}
+	return persisted.IssueID == requestedIssueID &&
+		persisted.DependsOnID == requested.DependsOnID &&
+		persisted.Type == requested.Type
+}
+
+func cloneIssueForHook(issue *types.Issue) *types.Issue {
+	if issue == nil {
+		return nil
+	}
+	clone := *issue
+	clone.EstimatedMinutes = clonePtr(issue.EstimatedMinutes)
+	clone.StartedAt = clonePtr(issue.StartedAt)
+	clone.ClosedAt = clonePtr(issue.ClosedAt)
+	clone.DueAt = clonePtr(issue.DueAt)
+	clone.DeferUntil = clonePtr(issue.DeferUntil)
+	clone.ExternalRef = clonePtr(issue.ExternalRef)
+	clone.Labels = append([]string(nil), issue.Labels...)
+	clone.Metadata = append([]byte(nil), issue.Metadata...)
+	clone.CompactedAt = clonePtr(issue.CompactedAt)
+	clone.CompactedAtCommit = clonePtr(issue.CompactedAtCommit)
+	clone.Dependencies = cloneDependenciesForHook(issue.Dependencies)
+	if issue.Comments != nil {
+		clone.Comments = make([]*types.Comment, len(issue.Comments))
+		for i, comment := range issue.Comments {
+			if comment == nil {
+				continue
+			}
+			commentCopy := *comment
+			clone.Comments[i] = &commentCopy
+		}
+	}
+	clone.BondedFrom = append([]types.BondRef(nil), issue.BondedFrom...)
+	clone.Waiters = append([]string(nil), issue.Waiters...)
+	return &clone
+}
+
+func clonePtr[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func cloneDependenciesForHook(deps []*types.Dependency) []*types.Dependency {
+	if deps == nil {
+		return nil
+	}
+	cloned := make([]*types.Dependency, len(deps))
+	for i, dep := range deps {
+		if dep == nil {
+			continue
+		}
+		depCopy := *dep
+		cloned[i] = &depCopy
+	}
+	return cloned
 }
 
 // hookTrackingTransaction wraps a Transaction, recording mutations
@@ -227,7 +433,7 @@ func (t *hookTrackingTransaction) CreateIssue(ctx context.Context, issue *types.
 	if err := t.Transaction.CreateIssue(ctx, issue, actor); err != nil {
 		return err
 	}
-	t.pending = append(t.pending, pendingHook{hooks.EventCreate, issue})
+	t.pending = append(t.pending, createHookEvents(issue)...)
 	return nil
 }
 
@@ -236,8 +442,9 @@ func (t *hookTrackingTransaction) CreateIssues(ctx context.Context, issues []*ty
 		return err
 	}
 	for _, issue := range issues {
-		t.pending = append(t.pending, pendingHook{hooks.EventCreate, issue})
+		t.pending = append(t.pending, createHookEvents(issue)...)
 	}
+	t.pending = append(t.pending, dependencyHookEvents(ctx, issues, t.Transaction.GetIssue, t.Transaction.GetDependencyRecords)...)
 	return nil
 }
 
@@ -270,7 +477,7 @@ func (t *hookTrackingTransaction) AddDependencyWithOptions(ctx context.Context, 
 	if err := t.Transaction.AddDependencyWithOptions(ctx, dep, actor, opts); err != nil {
 		return err
 	}
-	if issue, err := t.Transaction.GetIssue(ctx, dep.IssueID); err == nil {
+	if issue, err := dependencySnapshot(ctx, dep.IssueID, t.Transaction.GetIssue, t.Transaction.GetDependencyRecords); err == nil {
 		t.pending = append(t.pending, pendingHook{hooks.EventUpdate, issue})
 	}
 	return nil
@@ -280,7 +487,7 @@ func (t *hookTrackingTransaction) RemoveDependency(ctx context.Context, issueID,
 	if err := t.Transaction.RemoveDependency(ctx, issueID, dependsOnID, actor); err != nil {
 		return err
 	}
-	if issue, err := t.Transaction.GetIssue(ctx, issueID); err == nil {
+	if issue, err := dependencySnapshot(ctx, issueID, t.Transaction.GetIssue, t.Transaction.GetDependencyRecords); err == nil {
 		t.pending = append(t.pending, pendingHook{hooks.EventUpdate, issue})
 	}
 	return nil

--- a/internal/storage/hook_decorator_internal_test.go
+++ b/internal/storage/hook_decorator_internal_test.go
@@ -1,0 +1,452 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/hooks"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type recordingHookRunner struct {
+	events []string
+	issues []*types.Issue
+}
+
+func (r *recordingHookRunner) Run(event string, issue *types.Issue) {
+	r.events = append(r.events, event)
+	r.issues = append(r.issues, issue)
+}
+
+type fakeHookStore struct {
+	DoltStorage
+	issues           map[string]*types.Issue
+	dropDependencies bool
+}
+
+func (s fakeHookStore) CreateIssue(_ context.Context, issue *types.Issue, _ string) error {
+	if s.issues != nil {
+		s.issues[issue.ID] = cloneForFakeHookStore(issue, s.dropDependencies)
+	}
+	return nil
+}
+
+func (s fakeHookStore) CreateIssues(_ context.Context, issues []*types.Issue, _ string) error {
+	for _, issue := range issues {
+		if s.issues != nil {
+			s.issues[issue.ID] = cloneForFakeHookStore(issue, s.dropDependencies)
+		}
+	}
+	return nil
+}
+
+func (s fakeHookStore) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return cloneIssueForHook(issue), nil
+}
+
+func (s fakeHookStore) GetDependencyRecords(_ context.Context, id string) ([]*types.Dependency, error) {
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	if s.dropDependencies {
+		return nil, nil
+	}
+	return cloneDependenciesForHook(issue.Dependencies), nil
+}
+
+func (s fakeHookStore) RunInTransaction(ctx context.Context, _ string, fn func(tx Transaction) error) error {
+	return fn(fakeHookTransaction{issues: s.issues, dropDependencies: s.dropDependencies})
+}
+
+type fakeHookTransaction struct {
+	Transaction
+	issues           map[string]*types.Issue
+	dropDependencies bool
+}
+
+func (tx fakeHookTransaction) CreateIssue(_ context.Context, issue *types.Issue, _ string) error {
+	if tx.issues != nil {
+		tx.issues[issue.ID] = cloneForFakeHookStore(issue, tx.dropDependencies)
+	}
+	return nil
+}
+
+func (tx fakeHookTransaction) CreateIssues(_ context.Context, issues []*types.Issue, _ string) error {
+	for _, issue := range issues {
+		if tx.issues != nil {
+			tx.issues[issue.ID] = cloneForFakeHookStore(issue, tx.dropDependencies)
+		}
+	}
+	return nil
+}
+
+func (tx fakeHookTransaction) GetIssue(_ context.Context, id string) (*types.Issue, error) {
+	issue, ok := tx.issues[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return cloneIssueForHook(issue), nil
+}
+
+func (tx fakeHookTransaction) GetDependencyRecords(_ context.Context, id string) ([]*types.Dependency, error) {
+	issue, ok := tx.issues[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	if tx.dropDependencies {
+		return nil, nil
+	}
+	return cloneDependenciesForHook(issue.Dependencies), nil
+}
+
+func cloneForFakeHookStore(issue *types.Issue, dropDependencies bool) *types.Issue {
+	clone := cloneIssueForHook(issue)
+	if dropDependencies {
+		clone.Dependencies = nil
+		return clone
+	}
+	for _, dep := range clone.Dependencies {
+		if dep != nil && dep.IssueID == "" {
+			dep.IssueID = clone.ID
+		}
+	}
+	return clone
+}
+
+func TestCreateHookEventsIncludeSyntheticLabelUpdates(t *testing.T) {
+	issue := &types.Issue{ID: "hooked-issue", Labels: []string{"a", "b"}}
+
+	got := createHookEvents(issue)
+	gotEvents := make([]string, len(got))
+	for i, event := range got {
+		gotEvents[i] = event.event
+	}
+
+	wantEvents := []string{hooks.EventCreate, hooks.EventUpdate, hooks.EventUpdate}
+	if !reflect.DeepEqual(gotEvents, wantEvents) {
+		t.Fatalf("events = %v, want %v", gotEvents, wantEvents)
+	}
+	wantLabels := [][]string{nil, []string{"a"}, []string{"a", "b"}}
+	for i, want := range wantLabels {
+		if !reflect.DeepEqual(got[i].issue.Labels, want) {
+			t.Fatalf("event %d labels = %v, want %v", i, got[i].issue.Labels, want)
+		}
+	}
+	if !reflect.DeepEqual(issue.Labels, []string{"a", "b"}) {
+		t.Fatalf("source issue labels mutated to %v", issue.Labels)
+	}
+}
+
+func TestCreateHookEventsDedupesLabels(t *testing.T) {
+	issue := &types.Issue{ID: "hooked-issue", Labels: []string{"a", "a", "b"}}
+
+	got := createHookEvents(issue)
+	gotEvents := make([]string, len(got))
+	for i, event := range got {
+		gotEvents[i] = event.event
+	}
+
+	wantEvents := []string{hooks.EventCreate, hooks.EventUpdate, hooks.EventUpdate}
+	if !reflect.DeepEqual(gotEvents, wantEvents) {
+		t.Fatalf("events = %v, want %v", gotEvents, wantEvents)
+	}
+	wantLabels := [][]string{nil, []string{"a"}, []string{"a", "b"}}
+	for i, want := range wantLabels {
+		if !reflect.DeepEqual(got[i].issue.Labels, want) {
+			t.Fatalf("event %d labels = %v, want %v", i, got[i].issue.Labels, want)
+		}
+	}
+	if !reflect.DeepEqual(issue.Labels, []string{"a", "a", "b"}) {
+		t.Fatalf("source issue labels mutated to %v", issue.Labels)
+	}
+}
+
+func TestCreateHookEventsCloneNoLabelIssue(t *testing.T) {
+	closedAt := time.Date(2026, 5, 22, 10, 0, 0, 0, time.UTC)
+	issue := &types.Issue{
+		ID:       "hooked-issue",
+		Metadata: []byte(`{"key":"value"}`),
+		ClosedAt: &closedAt,
+	}
+
+	got := createHookEvents(issue)
+	if len(got) != 1 {
+		t.Fatalf("event count = %d, want 1", len(got))
+	}
+	snapshot := got[0].issue
+	if snapshot == issue {
+		t.Fatalf("create hook reused source issue pointer")
+	}
+	if len(snapshot.Metadata) == 0 {
+		t.Fatalf("snapshot metadata is empty")
+	}
+	snapshot.Metadata[0] = '['
+	if string(issue.Metadata) != `{"key":"value"}` {
+		t.Fatalf("source metadata mutated to %s", issue.Metadata)
+	}
+	if snapshot.ClosedAt == issue.ClosedAt {
+		t.Fatalf("snapshot ClosedAt shares source pointer")
+	}
+	snapshot.ClosedAt = nil
+	if issue.ClosedAt == nil {
+		t.Fatalf("source ClosedAt mutated to nil")
+	}
+}
+
+func TestCloneIssueForHookCopiesReferenceFields(t *testing.T) {
+	estimatedMinutes := 15
+	startedAt := time.Date(2026, 5, 22, 10, 1, 0, 0, time.UTC)
+	closedAt := time.Date(2026, 5, 22, 10, 2, 0, 0, time.UTC)
+	dueAt := time.Date(2026, 5, 22, 10, 3, 0, 0, time.UTC)
+	deferUntil := time.Date(2026, 5, 22, 10, 4, 0, 0, time.UTC)
+	externalRef := "gh:owner/repo#1"
+	compactedAt := time.Date(2026, 5, 22, 10, 5, 0, 0, time.UTC)
+	compactedAtCommit := "abc123"
+	issue := &types.Issue{
+		ID:                "hooked-issue",
+		EstimatedMinutes:  &estimatedMinutes,
+		StartedAt:         &startedAt,
+		ClosedAt:          &closedAt,
+		DueAt:             &dueAt,
+		DeferUntil:        &deferUntil,
+		ExternalRef:       &externalRef,
+		Metadata:          []byte(`{"key":"value"}`),
+		CompactedAt:       &compactedAt,
+		CompactedAtCommit: &compactedAtCommit,
+		Labels:            []string{"alpha"},
+		Dependencies: []*types.Dependency{{
+			IssueID:     "hooked-issue",
+			DependsOnID: "target",
+			Type:        types.DepBlocks,
+		}},
+		Comments: []*types.Comment{{
+			ID:     "1",
+			Author: "tester",
+			Text:   "note",
+		}},
+		BondedFrom: []types.BondRef{{SourceID: "proto-1", BondType: "sequential"}},
+		Waiters:    []string{"agent@example.com"},
+	}
+
+	snapshot := cloneIssueForHook(issue)
+	if snapshot.EstimatedMinutes == issue.EstimatedMinutes ||
+		snapshot.StartedAt == issue.StartedAt ||
+		snapshot.ClosedAt == issue.ClosedAt ||
+		snapshot.DueAt == issue.DueAt ||
+		snapshot.DeferUntil == issue.DeferUntil ||
+		snapshot.ExternalRef == issue.ExternalRef ||
+		snapshot.CompactedAt == issue.CompactedAt ||
+		snapshot.CompactedAtCommit == issue.CompactedAtCommit {
+		t.Fatalf("clone shares pointer fields with source issue")
+	}
+	snapshot.Metadata[0] = '['
+	snapshot.Labels[0] = "beta"
+	snapshot.Dependencies[0].DependsOnID = "other-target"
+	snapshot.Comments[0].Text = "changed"
+	snapshot.BondedFrom[0].SourceID = "proto-2"
+	snapshot.Waiters[0] = "other@example.com"
+
+	if string(issue.Metadata) != `{"key":"value"}` ||
+		issue.Labels[0] != "alpha" ||
+		issue.Dependencies[0].DependsOnID != "target" ||
+		issue.Comments[0].Text != "note" ||
+		issue.BondedFrom[0].SourceID != "proto-1" ||
+		issue.Waiters[0] != "agent@example.com" {
+		t.Fatalf("mutating clone changed source issue")
+	}
+}
+
+func TestCloneIssueForHookCoversReferenceFields(t *testing.T) {
+	copiedFields := map[string]struct{}{
+		"EstimatedMinutes":  {},
+		"StartedAt":         {},
+		"ClosedAt":          {},
+		"DueAt":             {},
+		"DeferUntil":        {},
+		"ExternalRef":       {},
+		"Metadata":          {},
+		"CompactedAt":       {},
+		"CompactedAtCommit": {},
+		"Labels":            {},
+		"Dependencies":      {},
+		"Comments":          {},
+		"BondedFrom":        {},
+		"Waiters":           {},
+	}
+	issueType := reflect.TypeOf(types.Issue{})
+	for i := 0; i < issueType.NumField(); i++ {
+		field := issueType.Field(i)
+		switch field.Type.Kind() {
+		case reflect.Ptr, reflect.Slice, reflect.Map:
+			if _, ok := copiedFields[field.Name]; !ok {
+				t.Fatalf("reference field %s must be cloned by cloneIssueForHook", field.Name)
+			}
+		}
+	}
+}
+
+func TestHookFiringStoreCreateIssueFiresInitialLabelUpdates(t *testing.T) {
+	runner := &recordingHookRunner{}
+	inner := fakeHookStore{}
+	store := &HookFiringStore{DoltStorage: inner, inner: inner, runner: runner}
+	issue := &types.Issue{ID: "hooked-issue", Labels: []string{"a", "b"}}
+
+	if err := store.CreateIssue(context.Background(), issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	wantEvents := []string{hooks.EventCreate, hooks.EventUpdate, hooks.EventUpdate}
+	if !reflect.DeepEqual(runner.events, wantEvents) {
+		t.Fatalf("events = %v, want %v", runner.events, wantEvents)
+	}
+	wantLabels := [][]string{nil, []string{"a"}, []string{"a", "b"}}
+	for i, want := range wantLabels {
+		if !reflect.DeepEqual(runner.issues[i].Labels, want) {
+			t.Fatalf("event %d labels = %v, want %v", i, runner.issues[i].Labels, want)
+		}
+	}
+}
+
+func TestHookFiringStoreTransactionCreateIssueFiresInitialLabelUpdates(t *testing.T) {
+	runner := &recordingHookRunner{}
+	inner := fakeHookStore{}
+	store := &HookFiringStore{DoltStorage: inner, inner: inner, runner: runner}
+	issue := &types.Issue{ID: "tx-hooked-issue", Labels: []string{"a", "b"}}
+
+	err := store.RunInTransaction(context.Background(), "test", func(tx Transaction) error {
+		return tx.CreateIssue(context.Background(), issue, "tester")
+	})
+	if err != nil {
+		t.Fatalf("RunInTransaction: %v", err)
+	}
+
+	wantEvents := []string{hooks.EventCreate, hooks.EventUpdate, hooks.EventUpdate}
+	if !reflect.DeepEqual(runner.events, wantEvents) {
+		t.Fatalf("events = %v, want %v", runner.events, wantEvents)
+	}
+	wantLabels := [][]string{nil, []string{"a"}, []string{"a", "b"}}
+	for i, want := range wantLabels {
+		if !reflect.DeepEqual(runner.issues[i].Labels, want) {
+			t.Fatalf("event %d labels = %v, want %v", i, runner.issues[i].Labels, want)
+		}
+	}
+}
+
+func TestHookFiringStoreCreateIssuesFiresDependencyUpdates(t *testing.T) {
+	runner := &recordingHookRunner{}
+	inner := fakeHookStore{issues: map[string]*types.Issue{}}
+	store := &HookFiringStore{DoltStorage: inner, inner: inner, runner: runner}
+	source := &types.Issue{
+		ID:        "source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{
+			{
+				DependsOnID: "target-a",
+				Type:        types.DepBlocks,
+			},
+			{
+				DependsOnID: "target-b",
+				Type:        types.DepBlocks,
+			},
+		},
+	}
+	targetA := &types.Issue{ID: "target-a", IssueType: types.TypeTask}
+	targetB := &types.Issue{ID: "target-b", IssueType: types.TypeTask}
+
+	if err := store.CreateIssues(context.Background(), []*types.Issue{source, targetA, targetB}, "tester"); err != nil {
+		t.Fatalf("CreateIssues: %v", err)
+	}
+
+	wantEvents := []string{hooks.EventCreate, hooks.EventCreate, hooks.EventCreate, hooks.EventUpdate, hooks.EventUpdate}
+	if !reflect.DeepEqual(runner.events, wantEvents) {
+		t.Fatalf("events = %v, want %v", runner.events, wantEvents)
+	}
+	if got := len(runner.issues[3].Dependencies); got != 1 {
+		t.Fatalf("first dependency update dependency count = %d, want 1", got)
+	}
+	if got := len(runner.issues[4].Dependencies); got != 2 {
+		t.Fatalf("second dependency update dependency count = %d, want 2", got)
+	}
+	if runner.issues[3].Dependencies[0].DependsOnID != "target-a" {
+		t.Fatalf("first dependency update target = %q, want target-a", runner.issues[3].Dependencies[0].DependsOnID)
+	}
+	if runner.issues[4].Dependencies[1].DependsOnID != "target-b" {
+		t.Fatalf("second dependency update target = %q, want target-b", runner.issues[4].Dependencies[1].DependsOnID)
+	}
+}
+
+func TestHookFiringStoreTransactionCreateIssuesFiresDependencyUpdates(t *testing.T) {
+	runner := &recordingHookRunner{}
+	inner := fakeHookStore{issues: map[string]*types.Issue{}}
+	store := &HookFiringStore{DoltStorage: inner, inner: inner, runner: runner}
+	source := &types.Issue{
+		ID:        "source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "target",
+			Type:        types.DepBlocks,
+		}},
+	}
+	target := &types.Issue{ID: "target", IssueType: types.TypeTask}
+
+	err := store.RunInTransaction(context.Background(), "test", func(tx Transaction) error {
+		return tx.CreateIssues(context.Background(), []*types.Issue{source, target}, "tester")
+	})
+	if err != nil {
+		t.Fatalf("RunInTransaction: %v", err)
+	}
+
+	wantEvents := []string{hooks.EventCreate, hooks.EventCreate, hooks.EventUpdate}
+	if !reflect.DeepEqual(runner.events, wantEvents) {
+		t.Fatalf("events = %v, want %v", runner.events, wantEvents)
+	}
+	if runner.issues[2].ID != source.ID {
+		t.Fatalf("dependency update issue ID = %q, want %q", runner.issues[2].ID, source.ID)
+	}
+}
+
+func TestHookFiringStoreCreateIssuesSkipsUnpersistedDependencies(t *testing.T) {
+	runner := &recordingHookRunner{}
+	inner := fakeHookStore{
+		issues:           map[string]*types.Issue{},
+		dropDependencies: true,
+	}
+	store := &HookFiringStore{DoltStorage: inner, inner: inner, runner: runner}
+	source := &types.Issue{
+		ID:        "source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "missing-target",
+			Type:        types.DepBlocks,
+		}},
+	}
+	target := &types.Issue{ID: "target", IssueType: types.TypeTask}
+
+	if err := store.CreateIssues(context.Background(), []*types.Issue{source, target}, "tester"); err != nil {
+		t.Fatalf("CreateIssues: %v", err)
+	}
+
+	wantEvents := []string{hooks.EventCreate, hooks.EventCreate}
+	if !reflect.DeepEqual(runner.events, wantEvents) {
+		t.Fatalf("events = %v, want %v", runner.events, wantEvents)
+	}
+}
+
+func TestNewHookFiringStoreNilRunnerSkipsCreateHooks(t *testing.T) {
+	var runner *hooks.Runner
+	inner := fakeHookStore{}
+	store := NewHookFiringStore(inner, runner)
+	issue := &types.Issue{ID: "nil-runner-issue", Labels: []string{"a"}}
+
+	if err := store.CreateIssue(context.Background(), issue, "tester"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+}

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -48,8 +48,39 @@ func NewBatchContext(ctx context.Context, tx *sql.Tx, opts storage.BatchCreateOp
 }
 
 func CreateIssueInTx(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *types.Issue, actor string) error {
+	_, err := CreateIssueInTxWithResult(ctx, tx, bc, issue, actor)
+	return err
+}
+
+// CreateIssueResult reports the tables actually written by CreateIssueInTx.
+type CreateIssueResult struct {
+	ChangedTables map[string]bool
+}
+
+func (r *CreateIssueResult) markChanged(table string) {
+	if table == "" {
+		return
+	}
+	if r.ChangedTables == nil {
+		r.ChangedTables = map[string]bool{}
+	}
+	r.ChangedTables[table] = true
+}
+
+func mergeChangedTables(dst map[string]bool, src map[string]bool) map[string]bool {
+	for table := range src {
+		if dst == nil {
+			dst = map[string]bool{}
+		}
+		dst[table] = true
+	}
+	return dst
+}
+
+func CreateIssueInTxWithResult(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *types.Issue, actor string) (CreateIssueResult, error) {
+	var result CreateIssueResult
 	if err := PrepareIssueForInsert(issue, bc.CustomStatuses, bc.CustomTypes); err != nil {
-		return err
+		return result, err
 	}
 
 	issueTable, eventTable := TableRouting(issue)
@@ -66,57 +97,214 @@ func CreateIssueInTx(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *t
 		var err error
 		issue.ID, err = GenerateIssueIDInTable(ctx, tx, issueTable, prefix, issue, actor)
 		if err != nil {
-			return fmt.Errorf("failed to generate issue ID: %w", err)
+			return result, fmt.Errorf("failed to generate issue ID: %w", err)
 		}
 	} else if !bc.Opts.SkipPrefixValidation {
 		if err := ValidateIssueIDPrefix(issue.ID, bc.ConfigPrefix, bc.AllowedPrefixes); err != nil {
-			return fmt.Errorf("prefix validation failed for %s: %w", issue.ID, err)
+			return result, fmt.Errorf("prefix validation failed for %s: %w", issue.ID, err)
 		}
 	}
 
 	if skip, err := CheckOrphan(ctx, tx, issue, issueTable, bc.Opts.OrphanHandling); err != nil {
-		return err
+		return result, err
 	} else if skip {
-		return nil
+		return result, nil
 	}
 
 	isNew, err := InsertIssueIfNew(ctx, tx, issueTable, issue)
 	if err != nil {
-		return err
+		return result, err
 	}
+	result.markChanged(issueTable)
 
 	if isNew {
 		if err := RecordEventInTable(ctx, tx, eventTable, issue.ID, types.EventCreated, actor, ""); err != nil {
-			return fmt.Errorf("failed to record event for %s: %w", issue.ID, err)
+			return result, fmt.Errorf("failed to record event for %s: %w", issue.ID, err)
 		}
+		result.markChanged(eventTable)
 	}
 
-	if err := PersistLabels(ctx, tx, issue, actor, eventTable, isNew); err != nil {
-		return err
+	labelResult, err := PersistLabels(ctx, tx, issue, actor, eventTable)
+	if err != nil {
+		return result, err
 	}
-	return PersistComments(ctx, tx, issue)
+	result.ChangedTables = mergeChangedTables(result.ChangedTables, labelResult.ChangedTables)
+	commentResult, err := PersistComments(ctx, tx, issue)
+	if err != nil {
+		return result, err
+	}
+	result.ChangedTables = mergeChangedTables(result.ChangedTables, commentResult.ChangedTables)
+	return result, nil
+}
+
+// CreateIssuesResult reports side effects that callers need for selective
+// Dolt staging after CreateIssuesInTxWithResult returns.
+type CreateIssuesResult struct {
+	ChangedTables             map[string]bool
+	ChangedChildCounterTables map[string]bool
+}
+
+func (r *CreateIssuesResult) markChanged(table string) {
+	if table == "" {
+		return
+	}
+	if r.ChangedTables == nil {
+		r.ChangedTables = map[string]bool{}
+	}
+	r.ChangedTables[table] = true
+}
+
+func (r *CreateIssuesResult) merge(changed map[string]bool) {
+	r.ChangedTables = mergeChangedTables(r.ChangedTables, changed)
 }
 
 func CreateIssuesInTx(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) error {
+	_, err := CreateIssuesInTxWithResult(ctx, tx, issues, actor, opts)
+	return err
+}
+
+// CreateIssuesInTxWithResult creates issues and reports tables whose writes are
+// only knowable after SQL reconciliation, such as child counter advances.
+func CreateIssuesInTxWithResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssuesResult, error) {
+	if err := ValidateCreateIssuesMixedBucketDependencies(issues); err != nil {
+		return CreateIssuesResult{}, err
+	}
+
 	bc, err := NewBatchContext(ctx, tx, opts)
 	if err != nil {
-		return err
+		return CreateIssuesResult{}, err
+	}
+
+	result := CreateIssuesResult{}
+	for _, issue := range issues {
+		issueResult, err := CreateIssueInTxWithResult(ctx, tx, bc, issue, actor)
+		if err != nil {
+			return CreateIssuesResult{}, err
+		}
+		result.merge(issueResult.ChangedTables)
+	}
+
+	depResult, err := PersistDependenciesWithResult(ctx, tx, issues, actor)
+	if err != nil {
+		return CreateIssuesResult{}, err
+	}
+	result.merge(depResult.ChangedTables)
+
+	changedCounters, err := ReconcileChildCounters(ctx, tx, issues)
+	if err != nil {
+		return CreateIssuesResult{}, err
+	}
+	result.ChangedChildCounterTables = changedCounters
+	for table := range changedCounters {
+		result.markChanged(table)
+	}
+	issueIDs, wispIDs := createBlockedRecomputeIDs(issues)
+	if err := RecomputeIsBlockedInTx(ctx, tx, issueIDs, wispIDs); err != nil {
+		return CreateIssuesResult{}, err
+	}
+	if len(issueIDs) > 0 {
+		result.markChanged("issues")
+	}
+	if len(wispIDs) > 0 {
+		result.markChanged("wisps")
+	}
+	return result, nil
+}
+
+// CreateIssueDirtyTables returns the regular Dolt tables CreateIssueInTx may
+// dirty for the given issue. Wisp tables are intentionally omitted because they
+// are Dolt-ignored and cannot be staged.
+func CreateIssueDirtyTables(ctx context.Context, issue *types.Issue, result CreateIssueResult) map[string]bool {
+	dirty := stageableChangedTables(result.ChangedTables)
+	if issue == nil {
+		return dirty
+	}
+	if parentID, childNum, ok := ParseHierarchicalID(issue.ID); ok &&
+		storage.HasReservedChildCounter(ctx, parentID, childNum) {
+		dirty["child_counters"] = true
+	}
+	return dirty
+}
+
+// CreateIssuesDirtyTables returns the regular Dolt tables CreateIssuesInTx may
+// dirty, including child counters that reconciliation actually advanced.
+func CreateIssuesDirtyTables(ctx context.Context, issues []*types.Issue, result CreateIssuesResult) map[string]bool {
+	dirty := stageableChangedTables(result.ChangedTables)
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		if parentID, childNum, ok := ParseHierarchicalID(issue.ID); ok &&
+			storage.HasReservedChildCounter(ctx, parentID, childNum) {
+			dirty["child_counters"] = true
+		}
+	}
+	return dirty
+}
+
+func stageableChangedTables(changed map[string]bool) map[string]bool {
+	dirty := map[string]bool{}
+	for table := range changed {
+		if table == "wisps" || strings.HasPrefix(table, "wisp_") {
+			continue
+		}
+		dirty[table] = true
+	}
+	return dirty
+}
+
+// ValidateCreateIssuesMixedBucketDependencies rejects same-batch dependency
+// edges between regular issues and wisps. Dependencies are stored in separate
+// backing tables per bucket, so a batch cannot create both ends atomically when
+// the edge crosses buckets.
+func ValidateCreateIssuesMixedBucketDependencies(issues []*types.Issue) error {
+	batchWispByID := make(map[string]bool, len(issues))
+	hasRegular := false
+	hasWisp := false
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		isWisp := IsWisp(issue)
+		if isWisp {
+			hasWisp = true
+		} else {
+			hasRegular = true
+		}
+		if issue.ID != "" {
+			batchWispByID[issue.ID] = isWisp
+		}
+	}
+	if !hasRegular || !hasWisp {
+		return nil
 	}
 
 	for _, issue := range issues {
-		if err := CreateIssueInTx(ctx, tx, bc, issue, actor); err != nil {
-			return err
+		if issue == nil {
+			continue
+		}
+		for _, dep := range issue.Dependencies {
+			if dep == nil {
+				continue
+			}
+			sourceID := issue.ID
+			sourceIsWisp := IsWisp(issue)
+			if dep.IssueID != "" {
+				sourceID = dep.IssueID
+				if isWisp, ok := batchWispByID[sourceID]; ok {
+					sourceIsWisp = isWisp
+				}
+			}
+			targetIsWisp, targetInBatch := batchWispByID[dep.DependsOnID]
+			if targetInBatch && sourceIsWisp != targetIsWisp {
+				return fmt.Errorf("mixed regular/wisp CreateIssues batch cannot include cross-bucket dependency %s -> %s; create the issues first, then add the in-batch dependency after both issues exist", sourceID, dep.DependsOnID)
+			}
 		}
 	}
+	return nil
+}
 
-	if err := PersistDependencies(ctx, tx, issues, actor); err != nil {
-		return err
-	}
-
-	if err := ReconcileChildCounters(ctx, tx, issues); err != nil {
-		return err
-	}
-
+func createBlockedRecomputeIDs(issues []*types.Issue) ([]string, []string) {
 	issueSeen := make(map[string]bool, len(issues))
 	wispSeen := make(map[string]bool, len(issues))
 	issueIDs := make([]string, 0, len(issues))
@@ -144,6 +332,9 @@ func CreateIssuesInTx(ctx context.Context, tx *sql.Tx, issues []*types.Issue, ac
 		isWisp := IsWisp(issue)
 		add(issue.ID, isWisp)
 		for _, dep := range issue.Dependencies {
+			if dep == nil {
+				continue
+			}
 			src := dep.IssueID
 			if src == "" {
 				src = issue.ID
@@ -151,7 +342,7 @@ func CreateIssuesInTx(ctx context.Context, tx *sql.Tx, issues []*types.Issue, ac
 			add(src, isWisp)
 		}
 	}
-	return RecomputeIsBlockedInTx(ctx, tx, issueIDs, wispIDs)
+	return issueIDs, wispIDs
 }
 
 // PrepareIssueForInsert normalizes timestamps, validates, and computes the content hash.
@@ -283,9 +474,10 @@ func InsertIssueIfNew(ctx context.Context, tx *sql.Tx, issueTable string, issue 
 	return existingCount == 0, nil
 }
 
-func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, eventTable string, recordEvents bool) error {
+func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, eventTable string) (CreateIssueResult, error) {
+	var result CreateIssueResult
 	if len(issue.Labels) == 0 {
-		return nil
+		return result, nil
 	}
 	labelTable := "labels"
 	if IsWisp(issue) {
@@ -297,28 +489,39 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, e
 			continue
 		}
 		seen[label] = struct{}{}
-		if recordEvents {
-			if err := AddLabelInTx(ctx, tx, labelTable, eventTable, issue.ID, label, actor); err != nil {
-				return fmt.Errorf("failed to insert label %q for %s: %w", label, issue.ID, err)
-			}
-			continue
-		}
 		//nolint:gosec // G201: table is determined by ephemeral flag
-		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-			INSERT INTO %s (issue_id, label)
+		sqlResult, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT IGNORE INTO %s (issue_id, label)
 			VALUES (?, ?)
-			ON DUPLICATE KEY UPDATE label = label
 		`, labelTable), issue.ID, label)
 		if err != nil {
-			return fmt.Errorf("failed to insert label %q for %s: %w", label, issue.ID, err)
+			return result, fmt.Errorf("failed to insert label %q for %s: %w", label, issue.ID, err)
 		}
+		rowsAffected, err := sqlResult.RowsAffected()
+		if err != nil {
+			return result, fmt.Errorf("failed to check label insert result for %q on %s: %w", label, issue.ID, err)
+		}
+		if rowsAffected == 0 {
+			continue
+		}
+		result.markChanged(labelTable)
+		comment := "Added label: " + label
+		//nolint:gosec // G201: eventTable is determined by ephemeral flag
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO %s (issue_id, event_type, actor, comment)
+			VALUES (?, ?, ?, ?)
+		`, eventTable), issue.ID, types.EventLabelAdded, actor, comment); err != nil {
+			return result, fmt.Errorf("failed to record label event %q for %s: %w", label, issue.ID, err)
+		}
+		result.markChanged(eventTable)
 	}
-	return nil
+	return result, nil
 }
 
-func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) error {
+func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) (CreateIssueResult, error) {
+	var result CreateIssueResult
 	if len(issue.Comments) == 0 {
-		return nil
+		return result, nil
 	}
 	commentTable := "comments"
 	if IsWisp(issue) {
@@ -335,10 +538,10 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) error 
 		var exists int
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		if err := tx.QueryRowContext(ctx, fmt.Sprintf(`
-			SELECT COUNT(*) FROM %s
-			WHERE issue_id = ? AND author = ? AND created_at = ? AND text = ?
-		`, commentTable), issue.ID, comment.Author, createdAt, comment.Text).Scan(&exists); err != nil {
-			return fmt.Errorf("failed to check comment existence for %s: %w", issue.ID, err)
+				SELECT COUNT(*) FROM %s
+				WHERE issue_id = ? AND author = ? AND created_at = ? AND text = ?
+			`, commentTable), issue.ID, comment.Author, createdAt, comment.Text).Scan(&exists); err != nil {
+			return result, fmt.Errorf("failed to check comment existence for %s: %w", issue.ID, err)
 		}
 		if exists > 0 {
 			continue
@@ -354,13 +557,20 @@ func PersistComments(ctx context.Context, tx *sql.Tx, issue *types.Issue) error 
 			VALUES (?, ?, ?, ?, ?)
 		`, commentTable), commentID, issue.ID, comment.Author, comment.Text, createdAt)
 		if err != nil {
-			return fmt.Errorf("failed to insert comment for %s: %w", issue.ID, err)
+			return result, fmt.Errorf("failed to insert comment for %s: %w", issue.ID, err)
 		}
+		result.markChanged(commentTable)
 	}
-	return nil
+	return result, nil
 }
 
 func PersistDependencies(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string) error {
+	_, err := PersistDependenciesWithResult(ctx, tx, issues, actor)
+	return err
+}
+
+func PersistDependenciesWithResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string) (CreateIssueResult, error) {
+	var result CreateIssueResult
 	for _, issue := range issues {
 		if len(issue.Dependencies) == 0 {
 			continue
@@ -388,8 +598,15 @@ func PersistDependencies(ctx context.Context, tx *sql.Tx, issues []*types.Issue,
 				if err := tx.QueryRowContext(ctx,
 					fmt.Sprintf("SELECT 1 FROM %s WHERE id = ?", lookupTable),
 					dep.DependsOnID).Scan(&exists); err != nil {
-					continue
+					if err == sql.ErrNoRows {
+						continue
+					}
+					return result, fmt.Errorf("failed to check dependency target %s for %s: %w", dep.DependsOnID, dep.IssueID, err)
 				}
+			}
+
+			if err := CheckDependencyCycleInTx(ctx, tx, dep, nil); err != nil {
+				return result, err
 			}
 
 			createdAt := dep.CreatedAt
@@ -397,28 +614,39 @@ func PersistDependencies(ctx context.Context, tx *sql.Tx, issues []*types.Issue,
 				createdAt = time.Now().UTC()
 			}
 			//nolint:gosec // G201: depTable is one of two hardcoded constants; target column from DepTargetKind.Column()
-			_, err := tx.ExecContext(ctx, fmt.Sprintf(`
-				INSERT INTO %s (issue_id, %s, type, created_by, created_at)
-				VALUES (?, ?, ?, ?, ?)
-				ON DUPLICATE KEY UPDATE type = type
-			`, depTable, kind.Column()), dep.IssueID, dep.DependsOnID, dep.Type, actor, createdAt)
+			sqlResult, err := tx.ExecContext(ctx, fmt.Sprintf(`
+					INSERT INTO %s (issue_id, %s, type, created_by, created_at)
+					VALUES (?, ?, ?, ?, ?)
+					ON DUPLICATE KEY UPDATE type = type
+				`, depTable, kind.Column()), dep.IssueID, dep.DependsOnID, dep.Type, actor, createdAt)
 			if err != nil {
-				return fmt.Errorf("failed to insert dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
+				return result, fmt.Errorf("failed to insert dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
+			}
+			rowsAffected, err := sqlResult.RowsAffected()
+			if err != nil {
+				return result, fmt.Errorf("failed to check dependency insert result for %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
+			}
+			if rowsAffected > 0 {
+				result.markChanged(depTable)
 			}
 		}
 	}
-	return nil
+	return result, nil
 }
 
-func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Issue) error {
+func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Issue) (map[string]bool, error) {
 	type bucket struct {
 		maxChild int
 		isWisp   bool
 		known    bool
 	}
 	parents := make(map[string]*bucket)
+	var changed map[string]bool
 
 	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
 		if IsWisp(issue) {
 			if b, ok := parents[issue.ID]; ok {
 				b.isWisp, b.known = true, true
@@ -429,6 +657,9 @@ func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Iss
 	}
 
 	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
 		parentID, childNum, ok := ParseHierarchicalID(issue.ID)
 		if !ok {
 			continue
@@ -454,13 +685,28 @@ func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Iss
 		if b.isWisp {
 			table = "wisp_child_counters"
 		}
+		var current int
+		//nolint:gosec // G201: table is one of two hardcoded constants.
+		err := tx.QueryRowContext(ctx, fmt.Sprintf(`
+			SELECT last_child FROM %s WHERE parent_id = ?
+		`, table), parentID).Scan(&current)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, fmt.Errorf("failed to read child counter for %s: %w", parentID, err)
+		}
+		if err == nil && current >= b.maxChild {
+			continue
+		}
 		//nolint:gosec // G201: table is one of two hardcoded constants.
 		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
 			INSERT INTO %s (parent_id, last_child) VALUES (?, ?)
 			ON DUPLICATE KEY UPDATE last_child = GREATEST(last_child, ?)
 		`, table), parentID, b.maxChild, b.maxChild); err != nil {
-			return fmt.Errorf("failed to reconcile child counter for %s: %w", parentID, err)
+			return nil, fmt.Errorf("failed to reconcile child counter for %s: %w", parentID, err)
 		}
+		if changed == nil {
+			changed = map[string]bool{}
+		}
+		changed[table] = true
 	}
-	return nil
+	return changed, nil
 }

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -91,7 +91,7 @@ func CreateIssueInTx(ctx context.Context, tx *sql.Tx, bc *BatchContext, issue *t
 		}
 	}
 
-	if err := PersistLabels(ctx, tx, issue); err != nil {
+	if err := PersistLabels(ctx, tx, issue, actor, eventTable, isNew); err != nil {
 		return err
 	}
 	return PersistComments(ctx, tx, issue)
@@ -283,7 +283,7 @@ func InsertIssueIfNew(ctx context.Context, tx *sql.Tx, issueTable string, issue 
 	return existingCount == 0, nil
 }
 
-func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue) error {
+func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue, actor, eventTable string, recordEvents bool) error {
 	if len(issue.Labels) == 0 {
 		return nil
 	}
@@ -291,7 +291,18 @@ func PersistLabels(ctx context.Context, tx *sql.Tx, issue *types.Issue) error {
 	if IsWisp(issue) {
 		labelTable = "wisp_labels"
 	}
+	seen := make(map[string]struct{}, len(issue.Labels))
 	for _, label := range issue.Labels {
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		if recordEvents {
+			if err := AddLabelInTx(ctx, tx, labelTable, eventTable, issue.ID, label, actor); err != nil {
+				return fmt.Errorf("failed to insert label %q for %s: %w", label, issue.ID, err)
+			}
+			continue
+		}
 		//nolint:gosec // G201: table is determined by ephemeral flag
 		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 			INSERT INTO %s (issue_id, label)

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -166,9 +166,11 @@ func CreateIssuesInTx(ctx context.Context, tx *sql.Tx, issues []*types.Issue, ac
 // CreateIssuesInTxWithResult creates issues and reports tables whose writes are
 // only knowable after SQL reconciliation, such as child counter advances.
 func CreateIssuesInTxWithResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssuesResult, error) {
-	if err := ValidateCreateIssuesMixedBucketDependencies(issues); err != nil {
+	filteredIssues, err := filterCreateIssuesMixedBucketDependencies(issues, opts)
+	if err != nil {
 		return CreateIssuesResult{}, err
 	}
+	issues = filteredIssues
 
 	bc, err := NewBatchContext(ctx, tx, opts)
 	if err != nil {
@@ -258,6 +260,11 @@ func stageableChangedTables(changed map[string]bool) map[string]bool {
 // backing tables per bucket, so a batch cannot create both ends atomically when
 // the edge crosses buckets.
 func ValidateCreateIssuesMixedBucketDependencies(issues []*types.Issue) error {
+	_, err := filterCreateIssuesMixedBucketDependencies(issues, storage.BatchCreateOptions{})
+	return err
+}
+
+func filterCreateIssuesMixedBucketDependencies(issues []*types.Issue, opts storage.BatchCreateOptions) ([]*types.Issue, error) {
 	batchWispByID := make(map[string]bool, len(issues))
 	hasRegular := false
 	hasWisp := false
@@ -276,15 +283,21 @@ func ValidateCreateIssuesMixedBucketDependencies(issues []*types.Issue) error {
 		}
 	}
 	if !hasRegular || !hasWisp {
-		return nil
+		return issues, nil
 	}
 
-	for _, issue := range issues {
+	var filteredIssues []*types.Issue
+	for issueIndex, issue := range issues {
 		if issue == nil {
 			continue
 		}
-		for _, dep := range issue.Dependencies {
+		var keptDeps []*types.Dependency
+		filteredDeps := false
+		for depIndex, dep := range issue.Dependencies {
 			if dep == nil {
+				if filteredDeps {
+					keptDeps = append(keptDeps, dep)
+				}
 				continue
 			}
 			sourceID := issue.ID
@@ -297,11 +310,33 @@ func ValidateCreateIssuesMixedBucketDependencies(issues []*types.Issue) error {
 			}
 			targetIsWisp, targetInBatch := batchWispByID[dep.DependsOnID]
 			if targetInBatch && sourceIsWisp != targetIsWisp {
-				return fmt.Errorf("mixed regular/wisp CreateIssues batch cannot include cross-bucket dependency %s -> %s; create the issues first, then add the in-batch dependency after both issues exist", sourceID, dep.DependsOnID)
+				if !opts.SkipDependencyValidationErrors {
+					return nil, fmt.Errorf("mixed regular/wisp CreateIssues batch cannot include cross-bucket dependency %s -> %s; create the issues first, then add the in-batch dependency after both issues exist", sourceID, dep.DependsOnID)
+				}
+				if !filteredDeps {
+					keptDeps = append([]*types.Dependency(nil), issue.Dependencies[:depIndex]...)
+					filteredDeps = true
+				}
+				recordSkippedDependencyEdge(opts, sourceID, dep.DependsOnID, "cross-bucket dependency between regular issue and wisp in the same batch")
+				continue
+			}
+			if filteredDeps {
+				keptDeps = append(keptDeps, dep)
 			}
 		}
+		if filteredDeps {
+			if filteredIssues == nil {
+				filteredIssues = append([]*types.Issue(nil), issues...)
+			}
+			issueCopy := *issue
+			issueCopy.Dependencies = keptDeps
+			filteredIssues[issueIndex] = &issueCopy
+		}
 	}
-	return nil
+	if filteredIssues != nil {
+		return filteredIssues, nil
+	}
+	return issues, nil
 }
 
 func createBlockedRecomputeIDs(issues []*types.Issue) ([]string, []string) {
@@ -644,10 +679,17 @@ func PersistDependenciesWithOptionsResult(ctx context.Context, tx *sql.Tx, issue
 }
 
 func recordSkippedDependency(opts storage.BatchCreateOptions, dep *types.Dependency, reason string) {
-	if opts.OnSkippedDependency == nil || dep == nil {
+	if dep == nil {
 		return
 	}
-	opts.OnSkippedDependency(dep.IssueID, dep.DependsOnID, reason)
+	recordSkippedDependencyEdge(opts, dep.IssueID, dep.DependsOnID, reason)
+}
+
+func recordSkippedDependencyEdge(opts storage.BatchCreateOptions, issueID, dependsOnID, reason string) {
+	if opts.OnSkippedDependency == nil {
+		return
+	}
+	opts.OnSkippedDependency(issueID, dependsOnID, reason)
 }
 
 func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Issue) (map[string]bool, error) {

--- a/internal/storage/issueops/create.go
+++ b/internal/storage/issueops/create.go
@@ -184,7 +184,7 @@ func CreateIssuesInTxWithResult(ctx context.Context, tx *sql.Tx, issues []*types
 		result.merge(issueResult.ChangedTables)
 	}
 
-	depResult, err := PersistDependenciesWithResult(ctx, tx, issues, actor)
+	depResult, err := PersistDependenciesWithOptionsResult(ctx, tx, issues, actor, opts)
 	if err != nil {
 		return CreateIssuesResult{}, err
 	}
@@ -570,6 +570,10 @@ func PersistDependencies(ctx context.Context, tx *sql.Tx, issues []*types.Issue,
 }
 
 func PersistDependenciesWithResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string) (CreateIssueResult, error) {
+	return PersistDependenciesWithOptionsResult(ctx, tx, issues, actor, storage.BatchCreateOptions{})
+}
+
+func PersistDependenciesWithOptionsResult(ctx context.Context, tx *sql.Tx, issues []*types.Issue, actor string, opts storage.BatchCreateOptions) (CreateIssueResult, error) {
 	var result CreateIssueResult
 	for _, issue := range issues {
 		if len(issue.Dependencies) == 0 {
@@ -599,6 +603,7 @@ func PersistDependenciesWithResult(ctx context.Context, tx *sql.Tx, issues []*ty
 					fmt.Sprintf("SELECT 1 FROM %s WHERE id = ?", lookupTable),
 					dep.DependsOnID).Scan(&exists); err != nil {
 					if err == sql.ErrNoRows {
+						recordSkippedDependency(opts, dep, "target not found")
 						continue
 					}
 					return result, fmt.Errorf("failed to check dependency target %s for %s: %w", dep.DependsOnID, dep.IssueID, err)
@@ -606,7 +611,11 @@ func PersistDependenciesWithResult(ctx context.Context, tx *sql.Tx, issues []*ty
 			}
 
 			if err := CheckDependencyCycleInTx(ctx, tx, dep, nil); err != nil {
-				return result, err
+				if opts.SkipDependencyValidationErrors {
+					recordSkippedDependency(opts, dep, err.Error())
+					continue
+				}
+				return result, fmt.Errorf("invalid dependency %s -> %s: %w", dep.IssueID, dep.DependsOnID, err)
 			}
 
 			createdAt := dep.CreatedAt
@@ -632,6 +641,13 @@ func PersistDependenciesWithResult(ctx context.Context, tx *sql.Tx, issues []*ty
 		}
 	}
 	return result, nil
+}
+
+func recordSkippedDependency(opts storage.BatchCreateOptions, dep *types.Dependency, reason string) {
+	if opts.OnSkippedDependency == nil || dep == nil {
+		return
+	}
+	opts.OnSkippedDependency(dep.IssueID, dep.DependsOnID, reason)
 }
 
 func ReconcileChildCounters(ctx context.Context, tx *sql.Tx, issues []*types.Issue) (map[string]bool, error) {

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -1,0 +1,144 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestValidateCreateIssuesMixedBucketDependenciesRejectsCrossBucketEdges(t *testing.T) {
+	regularA := &types.Issue{ID: "test-regular-a", IssueType: types.TypeTask}
+	regularB := &types.Issue{ID: "test-regular-b", IssueType: types.TypeTask}
+	wispA := &types.Issue{ID: "test-wisp-a", IssueType: types.TypeTask, Ephemeral: true}
+	wispB := &types.Issue{ID: "test-wisp-b", IssueType: types.TypeTask, Ephemeral: true}
+
+	tests := []struct {
+		name      string
+		issues    []*types.Issue
+		wantError bool
+	}{
+		{
+			name: "regular to wisp",
+			issues: []*types.Issue{
+				{
+					ID:        regularA.ID,
+					IssueType: types.TypeTask,
+					Dependencies: []*types.Dependency{{
+						DependsOnID: wispA.ID,
+						Type:        types.DepBlocks,
+					}},
+				},
+				wispA,
+			},
+			wantError: true,
+		},
+		{
+			name: "wisp to regular",
+			issues: []*types.Issue{
+				regularA,
+				{
+					ID:        wispA.ID,
+					IssueType: types.TypeTask,
+					Ephemeral: true,
+					Dependencies: []*types.Dependency{{
+						DependsOnID: regularA.ID,
+						Type:        types.DepBlocks,
+					}},
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "same bucket dependencies",
+			issues: []*types.Issue{
+				regularB,
+				{
+					ID:        regularA.ID,
+					IssueType: types.TypeTask,
+					Dependencies: []*types.Dependency{{
+						DependsOnID: regularB.ID,
+						Type:        types.DepBlocks,
+					}},
+				},
+				wispB,
+				{
+					ID:        wispA.ID,
+					IssueType: types.TypeTask,
+					Ephemeral: true,
+					Dependencies: []*types.Dependency{{
+						DependsOnID: wispB.ID,
+						Type:        types.DepBlocks,
+					}},
+				},
+			},
+		},
+		{
+			name: "out of batch target",
+			issues: []*types.Issue{
+				{
+					ID:        regularA.ID,
+					IssueType: types.TypeTask,
+					Dependencies: []*types.Dependency{{
+						DependsOnID: "test-external-wisp",
+						Type:        types.DepBlocks,
+					}},
+				},
+				wispA,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCreateIssuesMixedBucketDependencies(tt.issues)
+			if tt.wantError {
+				if err == nil || !strings.Contains(err.Error(), "cross-bucket dependency") {
+					t.Fatalf("error = %v, want cross-bucket dependency", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestPersistDependenciesReturnsTargetLookupErrors(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+	targetErr := errors.New("target lookup failed")
+	issue := &types.Issue{
+		ID:        "source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "target",
+			Type:        types.DepBlocks,
+		}},
+	}
+
+	mock.ExpectQuery("SELECT 1 FROM wisps WHERE id = \\? LIMIT 1").
+		WithArgs("target").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM issues WHERE id = \\?").
+		WithArgs("target").
+		WillReturnError(targetErr)
+
+	err := PersistDependencies(ctx, tx, []*types.Issue{issue}, "tester")
+	if err == nil || !strings.Contains(err.Error(), "failed to check dependency target target for source") {
+		t.Fatalf("error = %v, want dependency target lookup error", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -132,6 +134,53 @@ func TestPersistDependenciesReturnsTargetLookupErrors(t *testing.T) {
 	err := PersistDependencies(ctx, tx, []*types.Issue{issue}, "tester")
 	if err == nil || !strings.Contains(err.Error(), "failed to check dependency target target for source") {
 		t.Fatalf("error = %v, want dependency target lookup error", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestPersistDependenciesSkipsValidationErrorsWhenConfigured(t *testing.T) {
+	ctx := context.Background()
+	db, mock, tx := beginMockTx(t)
+	defer db.Close()
+	issue := &types.Issue{
+		ID:        "source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "source",
+			Type:        types.DepBlocks,
+		}},
+	}
+	var skipped []string
+
+	mock.ExpectQuery("SELECT 1 FROM wisps WHERE id = \\? LIMIT 1").
+		WithArgs("source").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT 1 FROM issues WHERE id = \\?").
+		WithArgs("source").
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+
+	result, err := PersistDependenciesWithOptionsResult(ctx, tx, []*types.Issue{issue}, "tester", storage.BatchCreateOptions{
+		SkipDependencyValidationErrors: true,
+		OnSkippedDependency: func(issueID, dependsOnID, reason string) {
+			skipped = append(skipped, issueID+" -> "+dependsOnID+": "+reason)
+		},
+	})
+	if err != nil {
+		t.Fatalf("PersistDependenciesWithOptionsResult error = %v, want nil", err)
+	}
+	if len(result.ChangedTables) != 0 {
+		t.Fatalf("ChangedTables = %#v, want none", result.ChangedTables)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0], "source -> source") ||
+		!strings.Contains(skipped[0], "cannot depend on itself") {
+		t.Fatalf("skipped = %#v, want self-dependency detail", skipped)
 	}
 
 	mock.ExpectRollback()

--- a/internal/storage/issueops/create_test.go
+++ b/internal/storage/issueops/create_test.go
@@ -110,6 +110,46 @@ func TestValidateCreateIssuesMixedBucketDependenciesRejectsCrossBucketEdges(t *t
 	}
 }
 
+func TestFilterCreateIssuesMixedBucketDependenciesSkipsWhenConfigured(t *testing.T) {
+	regular := &types.Issue{
+		ID:        "test-regular-source",
+		IssueType: types.TypeTask,
+		Dependencies: []*types.Dependency{{
+			DependsOnID: "test-wisp-target",
+			Type:        types.DepBlocks,
+		}},
+	}
+	wisp := &types.Issue{
+		ID:        "test-wisp-target",
+		IssueType: types.TypeTask,
+		Ephemeral: true,
+	}
+	var skipped []string
+
+	filtered, err := filterCreateIssuesMixedBucketDependencies([]*types.Issue{regular, wisp}, storage.BatchCreateOptions{
+		SkipDependencyValidationErrors: true,
+		OnSkippedDependency: func(issueID, dependsOnID, reason string) {
+			skipped = append(skipped, issueID+" -> "+dependsOnID+": "+reason)
+		},
+	})
+	if err != nil {
+		t.Fatalf("filterCreateIssuesMixedBucketDependencies error = %v, want nil", err)
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("len(filtered) = %d, want 2", len(filtered))
+	}
+	if len(filtered[0].Dependencies) != 0 {
+		t.Fatalf("filtered[0].Dependencies = %#v, want none", filtered[0].Dependencies)
+	}
+	if len(regular.Dependencies) != 1 {
+		t.Fatalf("regular.Dependencies was mutated to %#v, want original dependency preserved", regular.Dependencies)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0], "test-regular-source -> test-wisp-target") ||
+		!strings.Contains(skipped[0], "cross-bucket dependency") {
+		t.Fatalf("skipped = %#v, want cross-bucket dependency detail", skipped)
+	}
+}
+
 func TestPersistDependenciesReturnsTargetLookupErrors(t *testing.T) {
 	ctx := context.Background()
 	db, mock, tx := beginMockTx(t)

--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -169,20 +169,9 @@ func AddDependencyInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, a
 		}
 	}
 
-	// Self-dependency check
-	if dep.IssueID == dep.DependsOnID {
-		return fmt.Errorf("cannot add self-dependency: %s cannot depend on itself", dep.IssueID)
-	}
-
-	// Cycle detection for blocking deps via recursive CTE.
-	if !opts.SkipCycleCheck && (dep.Type == types.DepBlocks || dep.Type == types.DepConditionalBlocks) {
-		var reachable int
-		query := cycleReachabilityQuery(depTables)
-		if err := tx.QueryRowContext(ctx, query, dep.DependsOnID, dep.IssueID).Scan(&reachable); err != nil {
-			return fmt.Errorf("failed to check for dependency cycle: %w", err)
-		}
-		if reachable > 0 {
-			return fmt.Errorf("adding dependency would create a cycle")
+	if !opts.SkipCycleCheck {
+		if err := CheckDependencyCycleInTx(ctx, tx, dep, depTables); err != nil {
+			return err
 		}
 	}
 
@@ -304,6 +293,30 @@ func markDirectBlockingDependencySourceInTx(ctx context.Context, tx *sql.Tx, sou
 		  )
 	`, sourceTable, targetTable), source, target)
 	return err
+}
+
+// CheckDependencyCycleInTx rejects self-dependencies and blocking dependency
+// cycles before a dependency insert. The caller may pass a restricted depTables
+// list for a known storage bucket; nil uses all dependency tables.
+func CheckDependencyCycleInTx(ctx context.Context, tx *sql.Tx, dep *types.Dependency, depTables []string) error {
+	if dep.IssueID == dep.DependsOnID {
+		return fmt.Errorf("cannot add self-dependency: %s cannot depend on itself", dep.IssueID)
+	}
+	if dep.Type != types.DepBlocks && dep.Type != types.DepConditionalBlocks {
+		return nil
+	}
+	if len(depTables) == 0 {
+		depTables = cycleDetectionTables()
+	}
+	var reachable int
+	query := cycleReachabilityQuery(depTables)
+	if err := tx.QueryRowContext(ctx, query, dep.DependsOnID, dep.IssueID).Scan(&reachable); err != nil {
+		return fmt.Errorf("failed to check for dependency cycle: %w", err)
+	}
+	if reachable > 0 {
+		return fmt.Errorf("adding dependency would create a cycle")
+	}
+	return nil
 }
 
 // cycleReachabilityQuery uses UNION distinct recursion so cyclic and diamond


### PR DESCRIPTION
## Summary
- reconcile and rebase #3989 and #3990 onto current origin/main
- commit initial labels/comments/events in the Dolt create transaction
- pass CLI-created labels into CreateIssue so label writes do not need a second create commit
- keep the review-fix changes for dry-run child IDs, selective Dolt staging, quick label failure handling, and hook compatibility tests

Supersedes #3989 and #3990.

## Tests
- go test ./internal/storage/issueops -run 'TestCreate|TestPersist|TestReconcile|TestValidateCreateIssuesMixedBucketDependencies' -count=1
- go test ./internal/storage -run 'TestCreateHookEvents|TestCloneIssueForHook|TestHookFiringStore' -count=1
- go test ./cmd/bd -run 'TestBuildCreateIssuePreservesLabels|TestMergeCreateLabelsKeepsUserOrderAndDedupesInherited' -count=1
- go test ./internal/storage/dolt -run 'TestCreateIssue|TestCreateIssues|TestDoltStoreCreateIssues|TestTransaction' -count=1
- go test ./internal/storage/embeddeddolt -run 'Test.*CreateIssue|Test.*CreateIssues' -count=1
- CGO_ENABLED=0 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --new-from-rev=origin/main

Note: I also started a broader package sweep across cmd/storage packages, but stopped it after the targeted suites were green because it was still in long-running create/init tests with no output.