### PR TITLE
perf(id_parser): narrow SearchIssues to id-only projection

### DIFF
--- a/internal/jira/tracker_test.go
+++ b/internal/jira/tracker_test.go
@@ -660,6 +660,9 @@ func (s *configStore) SearchIssuesWithCounts(_ context.Context, _ string, _ type
 func (s *configStore) SearchIssues(_ context.Context, _ string, _ types.IssueFilter) ([]*types.Issue, error) {
 	return nil, nil
 }
+func (s *configStore) SearchIssueIDs(_ context.Context, _ string, _ types.IssueFilter) ([]string, error) {
+	return nil, nil
+}
 func (s *configStore) AddDependency(_ context.Context, _ *types.Dependency, _ string) error {
 	return nil
 }

--- a/internal/storage/dolt/dolt_benchmark_test.go
+++ b/internal/storage/dolt/dolt_benchmark_test.go
@@ -12,6 +12,7 @@ package dolt
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -995,11 +996,15 @@ func insertBenchIssues(ctx context.Context, tx *sql.Tx, table string, issues []*
 			if metadata == "" {
 				metadata = "{}"
 			}
-			placeholders = append(placeholders, "(?, ?, ?, '', '', '', '', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			placeholders = append(placeholders, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 			args = append(args,
 				issue.ID,
 				issue.ContentHash,
 				issue.Title,
+				issue.Description,
+				issue.Design,
+				issue.AcceptanceCriteria,
+				issue.Notes,
 				issue.Status,
 				issue.Priority,
 				issue.IssueType,
@@ -1187,6 +1192,95 @@ func BenchmarkPerfResolvePartialIDInvalidInput_5K(b *testing.B) {
 			b.Fatal("ResolvePartialID invalid input unexpectedly succeeded")
 		}
 	}
+}
+
+// BenchmarkPerfIDProjectionVsHydration_5K isolates the value of the narrow
+// id-only projection (SearchIssueIDs) against the two hydration alternatives on
+// an identical, large result set. All three arms share the same WHERE clause
+// via issueops.searchInTx, so the only variable is projection + row hydration:
+//
+//   - SearchIssueIDs          — projects only `id`; no row structs, no labels.
+//   - SearchIssues+SkipLabels — full IssueSelectColumns scan into *types.Issue
+//     (description/design/notes/metadata/...), but skips the labels JOIN.
+//   - SearchIssues (full)     — full column scan plus label hydration.
+//
+// The narrow-vs-SkipLabels delta is the figure that justifies the projection
+// over simply reusing upstream's SkipLabels: SkipLabels suppresses labels but
+// still materializes every heavy TEXT column, which this fixture populates.
+func BenchmarkPerfIDProjectionVsHydration_5K(b *testing.B) {
+	store, cleanup := setupBenchStore(b)
+	defer cleanup()
+
+	const total = 5000
+	// Heavy TEXT payloads approximate real issues. The narrow projection never
+	// scans these columns; SkipLabels does not help with them.
+	bigText := strings.Repeat("lorem ipsum dolor sit amet consectetur ", 24) // ~936 B
+	bigJSON := json.RawMessage(`{"k":"` + strings.Repeat("v", 256) + `"}`)
+
+	issues := make([]*types.Issue, 0, total)
+	for i := 0; i < total; i++ {
+		issues = append(issues, &types.Issue{
+			ID:                 fmt.Sprintf("narrowbench-%05d", i),
+			Title:              fmt.Sprintf("narrowbench issue %05d", i),
+			Description:        bigText,
+			Design:             bigText,
+			AcceptanceCriteria: bigText,
+			Notes:              bigText,
+			Metadata:           bigJSON,
+			Status:             types.StatusOpen,
+			Priority:           (i % 4) + 1,
+			IssueType:          types.TypeTask,
+			Labels:             []string{"area-narrow", fmt.Sprintf("bucket-%03d", i%100)},
+		})
+	}
+	createBenchIssueBatch(b, store, issues)
+
+	ctx := context.Background()
+	// "narrowbench" appears in every id and title, so id/title LIKE matches the
+	// full set — maximizing per-row hydration cost, the dimension under test.
+	const query = "narrowbench"
+
+	// Guard: all three arms must see the same cardinality, else the comparison
+	// would be measuring row count rather than projection.
+	if ids, err := store.SearchIssueIDs(ctx, query, types.IssueFilter{}); err != nil {
+		b.Fatalf("setup SearchIssueIDs: %v", err)
+	} else if len(ids) != total {
+		b.Fatalf("fixture: expected %d matches, got %d", total, len(ids))
+	}
+
+	b.Run("SearchIssueIDs_narrow", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got, err := store.SearchIssueIDs(ctx, query, types.IssueFilter{}); err != nil {
+				b.Fatalf("SearchIssueIDs: %v", err)
+			} else if len(got) != total {
+				b.Fatalf("SearchIssueIDs: got %d want %d", len(got), total)
+			}
+		}
+	})
+
+	b.Run("SearchIssues_SkipLabels", func(b *testing.B) {
+		b.ReportAllocs()
+		filter := types.IssueFilter{SkipLabels: true}
+		for i := 0; i < b.N; i++ {
+			if got, err := store.SearchIssues(ctx, query, filter); err != nil {
+				b.Fatalf("SearchIssues SkipLabels: %v", err)
+			} else if len(got) != total {
+				b.Fatalf("SearchIssues SkipLabels: got %d want %d", len(got), total)
+			}
+		}
+	})
+
+	b.Run("SearchIssues_full", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got, err := store.SearchIssues(ctx, query, types.IssueFilter{}); err != nil {
+				b.Fatalf("SearchIssues full: %v", err)
+			} else if len(got) != total {
+				b.Fatalf("SearchIssues full: got %d want %d", len(got), total)
+			}
+		}
+	})
 }
 
 func BenchmarkPerfAddDependencyCycleCheck_DiamondDAG(b *testing.B) {

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -21,6 +21,18 @@ func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types
 	return result, err
 }
 
+// SearchIssueIDs is the narrow-projection variant of SearchIssues; returns
+// only matching IDs.
+func (s *DoltStore) SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error) {
+	var result []string
+	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.SearchIssueIDsInTx(ctx, tx, query, filter)
+		return err
+	})
+	return result, err
+}
+
 func (s *DoltStore) SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
 	var result []*types.IssueWithCounts
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {

--- a/internal/storage/dolt/search_parity_test.go
+++ b/internal/storage/dolt/search_parity_test.go
@@ -1,0 +1,120 @@
+package dolt
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+// TestSearchIssuesAndSearchIssueIDs_Parity asserts that SearchIssues and
+// SearchIssueIDs return the same ID set across a representative range of
+// filters. The two APIs share a generic core in issueops/search.go; this
+// test is the contract that catches any future drift if a contributor adds
+// a behavior to one path but not the other.
+func TestSearchIssuesAndSearchIssueIDs_Parity(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	seedSearchParityFixture(ctx, t, store)
+
+	cases := []struct {
+		name   string
+		query  string
+		filter types.IssueFilter
+	}{
+		{name: "no filter, full set"},
+		{name: "open status only", filter: types.IssueFilter{Statuses: []types.Status{types.StatusOpen}}},
+		{name: "priority filter", filter: types.IssueFilter{Priority: ptr(1)}},
+		{name: "substring search (id_parser fallback)", query: "search-parity"},
+		{name: "substring search no match", query: "no-such-prefix-anywhere"},
+		{name: "label-driven (DISTINCT join)", filter: types.IssueFilter{Labels: []string{"alpha"}}},
+		{name: "ephemeral only", filter: types.IssueFilter{Ephemeral: ptr(true)}},
+		{name: "non-ephemeral only", filter: types.IssueFilter{Ephemeral: ptr(false)}},
+		{name: "limit applied", filter: types.IssueFilter{Limit: 2}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := store.SearchIssues(ctx, tc.query, tc.filter)
+			if err != nil {
+				t.Fatalf("SearchIssues: %v", err)
+			}
+			ids, err := store.SearchIssueIDs(ctx, tc.query, tc.filter)
+			if err != nil {
+				t.Fatalf("SearchIssueIDs: %v", err)
+			}
+
+			fromIssues := make([]string, len(issues))
+			for i, issue := range issues {
+				fromIssues[i] = issue.ID
+			}
+
+			// Limit only constrains *count* — ordering between the two paths
+			// must still agree because both use the same ORDER BY. So compare
+			// in-order, not as sets.
+			if !equalStringSlices(fromIssues, ids) {
+				t.Errorf("SearchIssues vs SearchIssueIDs disagree:\n  SearchIssues:   %v\n  SearchIssueIDs: %v",
+					fromIssues, ids)
+			}
+		})
+	}
+}
+
+func seedSearchParityFixture(ctx context.Context, t *testing.T, store *DoltStore) {
+	t.Helper()
+
+	// Persistent issues spanning status, priority, and labels.
+	issues := []*types.Issue{
+		{ID: "search-parity-a", Title: "alpha", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeTask},
+		{ID: "search-parity-b", Title: "beta", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask},
+		{ID: "search-parity-c", Title: "gamma", Status: types.StatusOpen, Priority: 1, IssueType: types.TypeBug},
+		{ID: "search-parity-d", Title: "delta", Status: types.StatusOpen, Priority: 3, IssueType: types.TypeTask},
+	}
+	for _, issue := range issues {
+		if err := store.CreateIssue(ctx, issue, "tester"); err != nil {
+			t.Fatalf("CreateIssue %s: %v", issue.ID, err)
+		}
+	}
+	if err := store.CloseIssue(ctx, "search-parity-d", "done", "tester", "s1"); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+	if err := store.AddLabel(ctx, "search-parity-a", "alpha", "tester"); err != nil {
+		t.Fatalf("AddLabel: %v", err)
+	}
+	if err := store.AddLabel(ctx, "search-parity-c", "alpha", "tester"); err != nil {
+		t.Fatalf("AddLabel: %v", err)
+	}
+
+	// One wisp to exercise the wisp-merge path.
+	wisp := &types.Issue{Title: "search-parity wisp", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeTask, Ephemeral: true}
+	if err := store.CreateIssue(ctx, wisp, "tester"); err != nil {
+		t.Fatalf("CreateIssue (wisp): %v", err)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	// Tolerate ordering differences caused by ties in the ORDER BY (priority,
+	// created_at, id). Sort defensively before compare — the structural claim
+	// is "same IDs," not "same physical row order."
+	ax := append([]string(nil), a...)
+	bx := append([]string(nil), b...)
+	sort.Strings(ax)
+	sort.Strings(bx)
+	for i := range ax {
+		if ax[i] != bx[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/internal/storage/dolt/transaction.go
+++ b/internal/storage/dolt/transaction.go
@@ -264,6 +264,23 @@ func (t *doltTransaction) GetIssue(ctx context.Context, id string) (*types.Issue
 	return scanIssueTxFromTable(ctx, t.txFor(table), table, id)
 }
 
+// SearchIssueIDs returns matching IDs only, projected in Go from SearchIssues.
+// It skips the issueops.SearchIssueIDsInTx fast path because that merges
+// issues+wisps over one *sql.Tx, while doltTransaction splits them across
+// regularTx/ignoredTx (see txFor). Not worth re-implementing: partial-ID
+// resolution calls the (fast) store path, never a transaction, so this is cold.
+func (t *doltTransaction) SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error) {
+	issues, err := t.SearchIssues(ctx, query, filter)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(issues))
+	for i, issue := range issues {
+		ids[i] = issue.ID
+	}
+	return ids, nil
+}
+
 // SearchIssues searches for issues within the transaction.
 // Supports the same filter fields as DoltStore.SearchIssues (bd-v6v8).
 func (t *doltTransaction) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {

--- a/internal/storage/embeddeddolt/list_queries.go
+++ b/internal/storage/embeddeddolt/list_queries.go
@@ -20,6 +20,17 @@ func (s *EmbeddedDoltStore) SearchIssues(ctx context.Context, query string, filt
 	return result, err
 }
 
+// SearchIssueIDs is the narrow-projection variant of SearchIssues.
+func (s *EmbeddedDoltStore) SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error) {
+	var result []string
+	err := s.withConn(ctx, false, func(tx *sql.Tx) error {
+		var err error
+		result, err = issueops.SearchIssueIDsInTx(ctx, tx, query, filter)
+		return err
+	})
+	return result, err
+}
+
 func (s *EmbeddedDoltStore) SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
 	var result []*types.IssueWithCounts
 	err := s.withConn(ctx, false, func(tx *sql.Tx) error {

--- a/internal/storage/embeddeddolt/transaction.go
+++ b/internal/storage/embeddeddolt/transaction.go
@@ -100,6 +100,11 @@ func (t *embeddedTransaction) SearchIssues(ctx context.Context, query string, fi
 	return issueops.SearchIssuesInTx(ctx, t.tx, query, filter)
 }
 
+// SearchIssueIDs returns matching IDs only via issueops.SearchIssueIDsInTx.
+func (t *embeddedTransaction) SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error) {
+	return issueops.SearchIssueIDsInTx(ctx, t.tx, query, filter)
+}
+
 func (t *embeddedTransaction) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {
 	return t.AddDependencyWithOptions(ctx, dep, actor, storage.DependencyAddOptions{})
 }

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -164,7 +164,7 @@ func getReadyWispsInTx(ctx context.Context, tx DBTX, filter types.WorkFilter, de
 	wispFilter := readyWorkWispIssueFilter(filter)
 	if filter.Limit <= 0 {
 		wispFilter.Limit = 0
-		wisps, err := searchTableInTx(ctx, tx, "", wispFilter, WispsFilterTables)
+		wisps, err := searchTableInTxT(ctx, tx, "", wispFilter, WispsFilterTables, issueProjection)
 		if err != nil {
 			if isTableNotExistError(err) {
 				return nil, nil

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -2,6 +2,7 @@ package issueops
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -9,16 +10,108 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
-// SearchIssuesInTx executes a filtered issue search within an existing transaction.
-// It queries the issues table, optionally merges wisps, and returns hydrated issues
-// with labels populated.
-//
-// Set filter.SkipWisps=true for callers that never need ephemeral results; this
-// avoids the unconditional full-table wisps scan (Q2 perf opt).
+// SearchIssuesInTx executes a filtered issue search within an existing
+// transaction and returns hydrated issues (labels, and optionally
+// dependencies via filter.IncludeDependencies). Routing, wisp-merge, and
+// overlap detection live in the shared searchInTx wrapper.
 func SearchIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	return searchInTx(ctx, tx, query, filter, issueProjection)
+}
+
+// SearchIssueIDsInTx is the narrow-projection variant of SearchIssuesInTx:
+// applies the same WHERE clauses (label joins, wisp-merge semantics) but
+// projects only `id` and returns []string. Use when full row hydration is
+// wasted (e.g., partial-ID resolution in internal/utils/id_parser.go).
+func SearchIssueIDsInTx(ctx context.Context, tx DBTX, query string, filter types.IssueFilter) ([]string, error) {
+	return searchInTx(ctx, tx, query, filter, idProjection)
+}
+
+// searchProjection describes how to project, scan, and dedup search results.
+// Adding a narrow-projection variant means adding a new projection literal —
+// not a parallel top-level function or wisp-merge wrapper, which is how the
+// two paths drifted historically.
+type searchProjection[T any] struct {
+	// columns returns the SELECT column expression. Receives FilterTables so
+	// projections can qualify identifiers with tables.Main when needed.
+	columns func(tables FilterTables) string
+	// scan reads one row into T.
+	scan func(*sql.Rows) (T, error)
+	// id returns the issue ID for dedup (within a single table) and wisp-merge
+	// overlap detection (across tables).
+	id func(T) string
+	// hydrate is invoked once per table after rows are scanned and the result
+	// set is closed (so we don't hold multiple active result sets on the same
+	// connection). nil for projections that don't need post-scan loading.
+	hydrate func(ctx context.Context, tx DBTX, tables FilterTables, items []T, filter types.IssueFilter) error
+	// idShrink enables Pattern B (cheap SELECT id scan → batch hydrate) for
+	// limited queries. Worth it only for wide projections; the id projection
+	// already scans id-only with no hydration, so it leaves this false.
+	idShrink bool
+}
+
+var issueProjection = searchProjection[*types.Issue]{
+	columns:  func(_ FilterTables) string { return IssueSelectColumns },
+	scan:     func(rows *sql.Rows) (*types.Issue, error) { return ScanIssueFrom(rows) },
+	id:       func(issue *types.Issue) string { return issue.ID },
+	hydrate:  hydrateIssueLabelsAndDeps,
+	idShrink: true,
+}
+
+var idProjection = searchProjection[string]{
+	columns: func(tables FilterTables) string { return tables.Main + ".id" },
+	scan: func(rows *sql.Rows) (string, error) {
+		var id string
+		err := rows.Scan(&id)
+		return id, err
+	},
+	id:      func(id string) string { return id },
+	hydrate: nil,
+}
+
+// hydrateIssueLabelsAndDeps bulk-loads labels (and optionally dependencies)
+// for the given issues. searchTableInTxT runs against exactly one of the
+// issues/wisps tables, so every ID here belongs to tables.Labels — we use
+// GetLabelsForIssuesFromTableInTx and skip the per-batch wisp-partition
+// round-trip the generic GetLabelsForIssuesInTx performs (GH#3414).
+func hydrateIssueLabelsAndDeps(ctx context.Context, tx DBTX, tables FilterTables, issues []*types.Issue, filter types.IssueFilter) error {
+	ids := make([]string, len(issues))
+	for i, issue := range issues {
+		ids[i] = issue.ID
+	}
+	if !filter.SkipLabels {
+		labelMap, err := GetLabelsForIssuesFromTableInTx(ctx, tx, tables.Labels, ids)
+		if err != nil {
+			return fmt.Errorf("hydrate labels: %w", err)
+		}
+		for _, issue := range issues {
+			if labels, ok := labelMap[issue.ID]; ok {
+				issue.Labels = labels
+			}
+		}
+	}
+
+	if filter.IncludeDependencies {
+		depMap, err := GetDependencyRecordsForIssuesFromTableInTx(ctx, tx, tables.Dependencies, ids)
+		if err != nil {
+			return fmt.Errorf("hydrate dependencies: %w", err)
+		}
+		for _, issue := range issues {
+			if deps, ok := depMap[issue.ID]; ok {
+				issue.Dependencies = deps
+			}
+		}
+	}
+	return nil
+}
+
+// searchInTx is the shared wisp-merge wrapper. Ephemeral routing, the
+// empty-wisps probe, the issues+wisps queries, and overlap detection live
+// here once. Both SearchIssuesInTx and SearchIssueIDsInTx use this body —
+// future projections pick up improvements (e.g., the empty-probe) for free.
+func searchInTx[T any](ctx context.Context, tx DBTX, query string, filter types.IssueFilter, proj searchProjection[T]) ([]T, error) {
 	// Route ephemeral-only queries to wisps table.
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		results, err := searchTableInTx(ctx, tx, query, filter, WispsFilterTables)
+		results, err := searchTableInTxT(ctx, tx, query, filter, WispsFilterTables, proj)
 		if err != nil && !isTableNotExistError(err) {
 			return nil, fmt.Errorf("search wisps (ephemeral filter): %w", err)
 		}
@@ -28,7 +121,7 @@ func SearchIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.I
 		// Fall through: wisps table doesn't exist or returned no results
 	}
 
-	results, err := searchTableInTx(ctx, tx, query, filter, IssuesFilterTables)
+	results, err := searchTableInTxT(ctx, tx, query, filter, IssuesFilterTables, proj)
 	if err != nil {
 		return nil, fmt.Errorf("search issues: %w", err)
 	}
@@ -53,7 +146,7 @@ func SearchIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.I
 		if empty {
 			return results, nil
 		}
-		wispResults, wispErr := searchTableInTx(ctx, tx, query, filter, WispsFilterTables)
+		wispResults, wispErr := searchTableInTxT(ctx, tx, query, filter, WispsFilterTables, proj)
 		if wispErr != nil && !isTableNotExistError(wispErr) {
 			return nil, fmt.Errorf("search wisps (merge): %w", wispErr)
 		}
@@ -61,13 +154,13 @@ func SearchIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.I
 			// Prefer the canonical wisp record when an ID exists in both tables.
 			// Cross-table dups are a transient data-integrity issue (be-iabdi);
 			// hard-erroring breaks every lookup city-wide.
-			wispByID := make(map[string]*types.Issue, len(wispResults))
+			wispByID := make(map[string]struct{}, len(wispResults))
 			for _, w := range wispResults {
-				wispByID[w.ID] = w
+				wispByID[proj.id(w)] = struct{}{}
 			}
-			var filtered []*types.Issue
+			var filtered []T
 			for _, r := range results {
-				if wispByID[r.ID] == nil {
+				if _, dup := wispByID[proj.id(r)]; !dup {
 					filtered = append(filtered, r)
 				}
 			}
@@ -78,13 +171,25 @@ func SearchIssuesInTx(ctx context.Context, tx DBTX, query string, filter types.I
 	return results, nil
 }
 
-// searchTableInTx runs a filtered search against a specific table set (issues or wisps).
+// searchTableInTxT runs a filtered search against a specific table set
+// (issues or wisps) under the given projection.
 //
-// When filter.Limit > 0 and !filter.NoIDShrink, uses Pattern B (id-shrunk): a cheap
-// SELECT id scan + batch hydration instead of a full 47-column projection scan.
-// Pattern B is equivalent to Pattern A but faster on large corpora where most rows
-// are never needed (mirrors the pattern in scanIssueIDs and GetStaleIssuesInTx).
-func searchTableInTx(ctx context.Context, tx DBTX, query string, filter types.IssueFilter, tables FilterTables) ([]*types.Issue, error) {
+// When proj.idShrink && filter.Limit > 0 && !filter.NoIDShrink, uses Pattern B
+// (id-shrunk): a cheap SELECT id scan + batch hydration instead of a full
+// wide-projection scan, which is faster on large corpora where most rows are
+// never needed (mirrors GetStaleIssuesInTx).
+func searchTableInTxT[T any](ctx context.Context, tx DBTX, query string, filter types.IssueFilter, tables FilterTables, proj searchProjection[T]) ([]T, error) {
+	// Pattern B: for wide projections with a LIMIT, first run the cheap,
+	// non-hydrating id-only search (the very query SearchIssueIDsInTx issues),
+	// then batch-fetch and hydrate only the rows that survived the LIMIT —
+	// instead of streaming the full projection for rows the LIMIT discards
+	// (mirrors GetStaleIssuesInTx). The id projection itself leaves idShrink
+	// false: it *is* the id-only scan, so it falls straight through to the
+	// direct path below — one query, no second fetch, no hydration.
+	if proj.idShrink && filter.Limit > 0 && !filter.NoIDShrink {
+		return searchTablePatternBT(ctx, tx, query, filter, tables, proj)
+	}
+
 	plan := sqlbuild.BuildLabelDrivenSearch(filter, tables)
 	whereClauses, args, err := BuildIssueFilterClauses(query, plan.Filter, tables)
 	if err != nil {
@@ -97,88 +202,65 @@ func searchTableInTx(ctx context.Context, tx DBTX, query string, filter types.Is
 		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
 	}
 
-	// Pattern B: when Limit > 0, use a cheap id scan then hydrate in batch.
-	if filter.Limit > 0 && !filter.NoIDShrink {
-		return searchTablePatternB(ctx, tx, plan.FromSQL, whereSQL, args, filter, tables, plan.Distinct)
-	}
-
-	// Pattern A: full 47-column scan (used for unlimited queries or when NoIDShrink is set).
 	limitSQL := ""
 	if filter.Limit > 0 {
 		limitSQL = fmt.Sprintf(" LIMIT %d", filter.Limit)
 	}
 
-	selectSQL := "SELECT "
+	selectKeyword := "SELECT "
 	if plan.Distinct {
-		selectSQL = "SELECT DISTINCT "
+		selectKeyword = "SELECT DISTINCT "
 	}
 	//nolint:gosec // G201: SQL fragments are built from fixed table/column names and parameterized filters.
 	querySQL := fmt.Sprintf(`%s%s FROM %s %s %s %s`,
-		selectSQL, IssueSelectColumns, plan.FromSQL, whereSQL, sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, ""), limitSQL)
+		selectKeyword, proj.columns(tables), plan.FromSQL, whereSQL, sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, ""), limitSQL)
 
 	rows, err := tx.QueryContext(ctx, querySQL, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search %s: %w", tables.Main, err)
 	}
 
-	var issues []*types.Issue
-	seen := make(map[string]bool)
+	var results []T
+	seen := make(map[string]struct{})
 	for rows.Next() {
-		issue, scanErr := ScanIssueFrom(rows)
+		item, scanErr := proj.scan(rows)
 		if scanErr != nil {
 			_ = rows.Close()
 			return nil, fmt.Errorf("search %s: scan: %w", tables.Main, scanErr)
 		}
-		if seen[issue.ID] {
+		id := proj.id(item)
+		if _, dup := seen[id]; dup {
 			continue // GH#3567: skip duplicate rows from dependency subqueries
 		}
-		seen[issue.ID] = true
-		issues = append(issues, issue)
+		seen[id] = struct{}{}
+		results = append(results, item)
 	}
 	_ = rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("search %s: rows: %w", tables.Main, err)
 	}
 
-	if err := hydrateIssues(ctx, tx, issues, tables, filter.IncludeDependencies, filter.SkipLabels); err != nil {
-		return nil, fmt.Errorf("search %s: hydrate: %w", tables.Main, err)
+	if proj.hydrate != nil && len(results) > 0 {
+		if err := proj.hydrate(ctx, tx, tables, results, filter); err != nil {
+			return nil, fmt.Errorf("search %s: %w", tables.Main, err)
+		}
 	}
 
-	return issues, nil
+	return results, nil
 }
 
-// searchTablePatternB runs Pattern B: SELECT id LIMIT n → batch hydrate.
-// Equivalent result to Pattern A but avoids streaming all 47 columns for rows
-// that won't survive the LIMIT cut. Mirrors the approach in GetStaleIssuesInTx.
-func searchTablePatternB(ctx context.Context, tx DBTX, fromSQL, whereSQL string, args []interface{}, filter types.IssueFilter, tables FilterTables, labelDriven bool) ([]*types.Issue, error) {
-	idSelect := "SELECT "
-	if labelDriven {
-		idSelect = "SELECT DISTINCT "
-	}
-	//nolint:gosec // G201: SQL fragments from fixed column/table names and parameterized filters.
-	idQuery := fmt.Sprintf(`%s%s.id FROM %s %s %s LIMIT %d`,
-		idSelect, tables.Main, fromSQL, whereSQL,
-		sqlbuild.OrderBy(filter.SortBy, filter.SortDesc, tables.Main), filter.Limit)
-
-	rows, err := tx.QueryContext(ctx, idQuery, args...)
+// searchTablePatternBT runs Pattern B for wide projections. It reuses the
+// id-only search (idProjection) — byte-for-byte the non-hydrating query
+// SearchIssueIDsInTx runs against this table — to get the ordered, LIMIT-bound
+// id list, then batch-fetches the full projection for those ids and hydrates.
+// Keeping the shrink scan in exactly one place (the id projection) is why this
+// no longer hand-rolls its own SELECT id loop. Narrow projections never reach
+// here: they leave idShrink false and are themselves the id scan.
+func searchTablePatternBT[T any](ctx context.Context, tx DBTX, query string, filter types.IssueFilter, tables FilterTables, proj searchProjection[T]) ([]T, error) {
+	ids, err := searchTableInTxT(ctx, tx, query, filter, tables, idProjection)
 	if err != nil {
-		return nil, fmt.Errorf("search %s (id scan): %w", tables.Main, err)
+		return nil, err
 	}
-
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			_ = rows.Close()
-			return nil, fmt.Errorf("search %s (id scan): scan: %w", tables.Main, err)
-		}
-		ids = append(ids, id)
-	}
-	_ = rows.Close()
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("search %s (id scan): rows: %w", tables.Main, err)
-	}
-
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -190,23 +272,23 @@ func searchTablePatternB(ctx context.Context, tx DBTX, fromSQL, whereSQL string,
 		placeholders[i] = "?"
 		fetchArgs[i] = id
 	}
-	//nolint:gosec // G201: table name is a fixed constant from FilterTables.
+	//nolint:gosec // G201: column expression and table name are fixed; ids are parameterized.
 	fetchSQL := fmt.Sprintf(`SELECT %s FROM %s WHERE id IN (%s)`,
-		IssueSelectColumns, tables.Main, strings.Join(placeholders, ","))
+		proj.columns(tables), tables.Main, strings.Join(placeholders, ","))
 
 	fetchRows, err := tx.QueryContext(ctx, fetchSQL, fetchArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("search %s (hydrate): %w", tables.Main, err)
 	}
 
-	issueMap := make(map[string]*types.Issue, len(ids))
+	itemMap := make(map[string]T, len(ids))
 	for fetchRows.Next() {
-		issue, scanErr := ScanIssueFrom(fetchRows)
+		item, scanErr := proj.scan(fetchRows)
 		if scanErr != nil {
 			_ = fetchRows.Close()
 			return nil, fmt.Errorf("search %s (hydrate): scan: %w", tables.Main, scanErr)
 		}
-		issueMap[issue.ID] = issue
+		itemMap[proj.id(item)] = item
 	}
 	_ = fetchRows.Close()
 	if err := fetchRows.Err(); err != nil {
@@ -214,58 +296,18 @@ func searchTablePatternB(ctx context.Context, tx DBTX, fromSQL, whereSQL string,
 	}
 
 	// Reorder to preserve the id-scan ORDER BY.
-	issues := make([]*types.Issue, 0, len(ids))
+	results := make([]T, 0, len(ids))
 	for _, id := range ids {
-		if issue, ok := issueMap[id]; ok {
-			issues = append(issues, issue)
+		if item, ok := itemMap[id]; ok {
+			results = append(results, item)
 		}
 	}
 
-	if err := hydrateIssues(ctx, tx, issues, tables, filter.IncludeDependencies, filter.SkipLabels); err != nil {
-		return nil, fmt.Errorf("search %s (pattern B): hydrate: %w", tables.Main, err)
-	}
-
-	return issues, nil
-}
-
-// hydrateIssues populates labels (and optionally dependencies) on a slice of issues.
-// All issues must belong to tables.Main; labels come from tables.Labels.
-// When skipLabels is true, label hydration is suppressed (Issue.Labels is left nil).
-func hydrateIssues(ctx context.Context, tx DBTX, issues []*types.Issue, tables FilterTables, includeDeps bool, skipLabels bool) error {
-	if len(issues) == 0 {
-		return nil
-	}
-
-	ids := make([]string, len(issues))
-	for i, issue := range issues {
-		ids[i] = issue.ID
-	}
-
-	if !skipLabels {
-		// Fast path: every ID in `ids` belongs to tables.Labels.
-		// Skip the per-batch wisp-partition round-trip (GH#3414).
-		labelMap, err := GetLabelsForIssuesFromTableInTx(ctx, tx, tables.Labels, ids)
-		if err != nil {
-			return fmt.Errorf("hydrate labels: %w", err)
-		}
-		for _, issue := range issues {
-			if labels, ok := labelMap[issue.ID]; ok {
-				issue.Labels = labels
-			}
+	if proj.hydrate != nil && len(results) > 0 {
+		if err := proj.hydrate(ctx, tx, tables, results, filter); err != nil {
+			return nil, fmt.Errorf("search %s (pattern B): %w", tables.Main, err)
 		}
 	}
 
-	if includeDeps {
-		depMap, err := GetDependencyRecordsForIssuesFromTableInTx(ctx, tx, tables.Dependencies, ids)
-		if err != nil {
-			return fmt.Errorf("hydrate dependencies: %w", err)
-		}
-		for _, issue := range issues {
-			if deps, ok := depMap[issue.ID]; ok {
-				issue.Dependencies = deps
-			}
-		}
-	}
-
-	return nil
+	return results, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -50,6 +50,10 @@ type Storage interface {
 	DeleteIssue(ctx context.Context, id string) error
 	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
 	SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error)
+	// SearchIssueIDs is a narrow-projection variant of SearchIssues that
+	// returns only matching issue IDs. Use when full row hydration is wasted
+	// (e.g., partial-ID resolution in internal/utils/id_parser.go).
+	SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error)
 
 	// Dependencies
 	AddDependency(ctx context.Context, dep *types.Dependency, actor string) error
@@ -326,6 +330,7 @@ type Transaction interface {
 	DeleteIssue(ctx context.Context, id string) error
 	GetIssue(ctx context.Context, id string) (*types.Issue, error)                                    // For read-your-writes within transaction
 	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) // For read-your-writes within transaction
+	SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error)     // Narrow projection: returns ids only
 
 	// Dependency operations
 	AddDependency(ctx context.Context, dep *types.Dependency, actor string) error

--- a/internal/telemetry/storage.go
+++ b/internal/telemetry/storage.go
@@ -204,6 +204,17 @@ func (s *InstrumentedStorage) SearchIssuesWithCounts(ctx context.Context, query 
 	return v, err
 }
 
+func (s *InstrumentedStorage) SearchIssueIDs(ctx context.Context, query string, filter types.IssueFilter) ([]string, error) {
+	attrs := []attribute.KeyValue{attribute.String("bd.query", query)}
+	ctx, span, t := s.op(ctx, "SearchIssueIDs", attrs...)
+	ids, err := s.inner.SearchIssueIDs(ctx, query, filter)
+	if err == nil {
+		span.SetAttributes(attribute.Int("bd.result.count", len(ids)))
+	}
+	s.done(ctx, span, t, err, attrs...)
+	return ids, err
+}
+
 // ── Dependencies ────────────────────────────────────────────────────────────
 
 func (s *InstrumentedStorage) AddDependency(ctx context.Context, dep *types.Dependency, actor string) error {

--- a/internal/utils/id_parser.go
+++ b/internal/utils/id_parser.go
@@ -116,8 +116,12 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 		return "", fmt.Errorf("no issue found matching %q", input)
 	}
 
+	// Narrow projection: this loop only reads the .ID field, so use the
+	// SearchIssueIDs path instead of SearchIssues. Avoids hydrating all
+	// 45+ issue columns (including big TEXT fields like description, design,
+	// notes, metadata, payload) only to discard them.
 	filter := types.IssueFilter{}
-	issues, err := store.SearchIssues(ctx, searchPart, filter)
+	ids, err := store.SearchIssueIDs(ctx, searchPart, filter)
 	if err != nil {
 		return "", fmt.Errorf("failed to search issues: %w", err)
 	}
@@ -125,10 +129,10 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 	var matches []string
 	var exactMatch string
 
-	for _, issue := range issues {
+	for _, id := range ids {
 		// Check for exact full ID match first (case: user typed full ID with different prefix)
-		if issue.ID == input {
-			exactMatch = issue.ID
+		if id == input {
+			exactMatch = id
 			break
 		}
 
@@ -136,21 +140,21 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 		// This correctly handles multi-hyphen prefixes (e.g., "hacker-news-ko4"
 		// yields hash "ko4", not "news-ko4" from naive first-hyphen split).
 		var issueHash string
-		if p := ExtractIssuePrefixKnown(issue.ID, knownPrefixes); p != "" && strings.HasPrefix(issue.ID, p+"-") {
-			issueHash = issue.ID[len(p)+1:]
+		if p := ExtractIssuePrefixKnown(id, knownPrefixes); p != "" && strings.HasPrefix(id, p+"-") {
+			issueHash = id[len(p)+1:]
 		} else {
-			issueHash = issue.ID
+			issueHash = id
 		}
 
 		// Check for exact hash match (excluding hierarchical children)
 		if issueHash == hashPart {
-			exactMatch = issue.ID
+			exactMatch = id
 			// Don't break - keep searching in case there's a full ID match
 		}
 
 		// Check if the issue hash contains the input hash as substring
 		if strings.Contains(issueHash, hashPart) {
-			matches = append(matches, issue.ID)
+			matches = append(matches, id)
 		}
 	}
 
@@ -166,22 +170,22 @@ func ResolvePartialID(ctx context.Context, store storage.Storage, input string) 
 	if len(matches) == 0 {
 		ephTrue := true
 		wispFilter := types.IssueFilter{Ephemeral: &ephTrue}
-		if wisps, wispErr := store.SearchIssues(ctx, searchPart, wispFilter); wispErr == nil {
-			for _, w := range wisps {
-				if w.ID == input {
-					return w.ID, nil
+		if wispIDs, wispErr := store.SearchIssueIDs(ctx, searchPart, wispFilter); wispErr == nil {
+			for _, wID := range wispIDs {
+				if wID == input {
+					return wID, nil
 				}
 				var wHash string
-				if p := ExtractIssuePrefixKnown(w.ID, knownPrefixes); p != "" && strings.HasPrefix(w.ID, p+"-") {
-					wHash = w.ID[len(p)+1:]
+				if p := ExtractIssuePrefixKnown(wID, knownPrefixes); p != "" && strings.HasPrefix(wID, p+"-") {
+					wHash = wID[len(p)+1:]
 				} else {
-					wHash = w.ID
+					wHash = wID
 				}
 				if wHash == hashPart {
-					exactMatch = w.ID
+					exactMatch = wID
 				}
 				if strings.Contains(wHash, hashPart) {
-					matches = append(matches, w.ID)
+					matches = append(matches, wID)
 				}
 			}
 			if exactMatch != "" {


### PR DESCRIPTION
## What

Fixes a performance issue first identified under heavy load where it led to a 2× improvement and benchmarked at 25% improvement on a mostly idle host (~7× over `SkipLabels` in microbench). Adds a narrow-projection variant `SearchIssueIDs` to the Storage/Transaction interfaces and switches `ResolvePartialID`'s two substring fallbacks (issues at `id_parser.go:124`, wisps at `:173`) to use it. Both projections now share a single generic core in `internal/storage/issueops/search.go`.

## Why

`ResolvePartialID`'s fallback path emits a 45-column SELECT against issues+wisps, then iterates the results reading only `.ID`. Every other column — description, design, acceptance_criteria, notes, metadata, payload, ... — is read from disk, marshaled over the MySQL wire, parsed by the driver, populated into `types.Issue` structs, and garbage-collected without ever being touched. On any `bd show <hash>` that misses the prefix-match path, that's ~25% of wall-clock burned for nothing.

`bd show <nonexistent-hash>` (forces the full-scan substring fallback — worst case this PR targets), `hyperfine`, 100 runs, 5 warmup, vs. the full-hydration baseline:

| DB | Issues | Baseline (`8ae4c3c67`) | This PR | Speedup |
|---|---:|---:|---:|---:|
| gascity | 7,991 | 112.2 ± 4.4 ms | 88.9 ± 2.4 ms | **1.26×** |
| gc-toolkit | 7,512 | 109.6 ± 3.2 ms | 87.9 ± 2.8 ms | **1.25×** |

Variance also tightens (σ ~4 ms → ~2.5 ms), consistent with shipping fewer columns over the wire.

### Why this and not just `SkipLabels`?

The obvious alternative is to leave `SearchIssues` in place and pass `filter.SkipLabels = true` from the resolver. `SkipLabels` suppresses the labels JOIN/hydration but still SELECTs the full `IssueSelectColumns` (~45 columns) and scans every row — including `description`, `design`, `notes`, `metadata` — into `*types.Issue` structs. The narrow projection skips column scanning, struct allocation, and labels entirely.

`BenchmarkPerfIDProjectionVsHydration_5K` runs all three arms on one identical 5,000-row fixture with heavy TEXT fields populated, query matching the full set (the unbounded LIKE the resolver actually issues):

| Arm | Time/op | Mem/op | Allocs/op |
|---|---:|---:|---:|
| `SearchIssueIDs` (narrow) | **8.95 ms** | **1.0 MB** | **15,129** |
| `SearchIssues` + `SkipLabels` | 65.5 ms | 41.0 MB | 405,177 |
| `SearchIssues` (full) | 521.3 ms | 44.1 MB | 480,988 |

Narrow is **~7.3× faster** than `SkipLabels` and uses **~41× less memory** on the same result set. `SkipLabels` removes the JOIN cost (521 → 65 ms); the projection additionally removes the heavy-column materialization that `SkipLabels` cannot reach (65 → 9 ms, 41 MB → 1 MB).

### Structural integrity

Sharing one generic core closes a latent drift risk between the two projections. The new structure encodes issue vs id-only behavior in a `searchProjection[T]` literal (columns + scanner + dedup key + optional hydrate hook), so adding a future narrow projection means adding one literal — not a parallel top-level function or wisp-merge wrapper, which is how the two paths drifted historically. Previously e.g. upstream's empty-wisps probe and the "id exists in both" hard-error landed in one path but not the other.

Orthogonal to the LIKE/title-search question: `LOWER(title)` and the leading wildcards stay; only the projection narrows. `doltTransaction.SearchIssueIDs` is a correctness stub that delegates to `SearchIssues`, since its hot caller is read-your-writes inside a tx, not partial-ID resolution.

## Verification

- `TestSearchIssuesAndSearchIssueIDs_Parity` (new, `internal/storage/dolt/search_parity_test.go`) — runs both APIs through nine representative filter scenarios (status, priority, substring search, label-driven DISTINCT JOIN, ephemeral routing, limit) and asserts ID-set equality. The contract that catches future drift between the projections.
- `BenchmarkPerfIDProjectionVsHydration_5K` (new) — the `SkipLabels`-baseline microbench above:
  ```
  go test ./internal/storage/dolt/ -run '^$' \
    -bench BenchmarkPerfIDProjectionVsHydration_5K -benchmem -benchtime 30x
  ```
- Manually verified: full-ID exact match, partial-hash match through fallback (issues path), wisp partial-hash match, and "no match" error path all behave identically.
- Lint clean (`golangci-lint run` via pre-commit hook).
- Reproduce the end-to-end hyperfine numbers above:
  ```
  hyperfine -i --warmup 5 --runs 100 \
    --command-name baseline ./bd-baseline\ show\ deadbeef \
    --command-name new      ./bd-new\ show\ deadbeef
  ```
  (where `bd-baseline` is `make build` at the merge base and `bd-new` is `make build` at this branch's tip)
