### PR TITLE
feat(dolt): dolt.local-only enforcement — push/pull/remote-add/status guards (be-3v2ou)

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -254,6 +254,16 @@ uncommitted changes in its working set).
 Use --remote to push to a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if isDoltLocalOnly() {
+			if jsonOutput {
+				outputJSONRaw(map[string]string{"status": "disabled", "reason": "dolt.local-only=true"})
+				return
+			}
+			fmt.Println("Remote sync is disabled for this project (dolt.local-only=true).")
+			fmt.Println("Your issues are stored locally in .beads/.")
+			fmt.Println("To re-enable remote sync: bd config unset dolt.local-only")
+			return
+		}
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {
@@ -323,6 +333,16 @@ variables for authentication.
 Use --remote to pull from a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if isDoltLocalOnly() {
+			if jsonOutput {
+				outputJSONRaw(map[string]string{"status": "disabled", "reason": "dolt.local-only=true"})
+				return
+			}
+			fmt.Println("Remote sync is disabled for this project (dolt.local-only=true).")
+			fmt.Println("Nothing to pull.")
+			fmt.Println("To re-enable remote sync: bd config unset dolt.local-only")
+			return
+		}
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {
@@ -558,6 +578,9 @@ func renderLocalDoltStatus(state *doltserver.State, serverDir string) {
 		fmt.Println("  Debug: on (loglevel=debug, --prof cpu)")
 		fmt.Printf("  Profile dir: %s\n", doltserver.DebugProfileDir(serverDir))
 	}
+	if isDoltLocalOnly() {
+		fmt.Println("  Remote sync: disabled (dolt.local-only=true)")
+	}
 }
 
 // shouldUseExternalDoltStatus reports whether bd dolt status should treat
@@ -708,6 +731,9 @@ func showEmbeddedDoltStatus(beadsDir string) {
 	fmt.Printf("  Data: %s\n", dataDir)
 	if !dataDirExists {
 		fmt.Printf("  %s\n", ui.RenderWarn("Data directory does not exist — run 'bd init' to create it"))
+	}
+	if isDoltLocalOnly() {
+		fmt.Println("  Remote sync: disabled (dolt.local-only=true)")
 	}
 }
 
@@ -943,6 +969,11 @@ var doltRemoteAddCmd = &cobra.Command{
 	Short: "Add a Dolt remote (both SQL server and CLI)",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
+		if isDoltLocalOnly() {
+			fmt.Fprintln(os.Stderr, "Error: cannot add Dolt remote: remote sync is disabled (dolt.local-only=true).")
+			fmt.Fprintln(os.Stderr, "To re-enable remote sync: bd config unset dolt.local-only")
+			os.Exit(1)
+		}
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {

--- a/cmd/bd/dolt_autopush.go
+++ b/cmd/bd/dolt_autopush.go
@@ -107,6 +107,10 @@ func maybeAutoPush(ctx context.Context) {
 		debug.Logf("dolt auto-push: skipped (sandbox mode)\n")
 		return
 	}
+	if isDoltLocalOnly() {
+		debug.Logf("dolt auto-push: skipped (dolt.local-only=true)\n")
+		return
+	}
 	if !isDoltAutoPushEnabled(ctx) {
 		return
 	}

--- a/cmd/bd/dolt_local_only.go
+++ b/cmd/bd/dolt_local_only.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/steveyegge/beads/internal/config"
+
+// isDoltLocalOnly reports whether this project has remote sync disabled via
+// the dolt.local-only config key. When true, bd dolt push, pull, and
+// remote add are no-ops or errors (be-3v2ou).
+func isDoltLocalOnly() bool {
+	return config.GetBool("dolt.local-only")
+}

--- a/cmd/bd/dolt_local_only_embedded_test.go
+++ b/cmd/bd/dolt_local_only_embedded_test.go
@@ -1,0 +1,232 @@
+//go:build embeddeddolt
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Integration tests for be-3v2ou: dolt.local-only enforcement (FR-01 to FR-05).
+//
+// TDD gate tests: these fail before the implementation because the guards
+// don't exist yet.  Run with BEADS_TEST_EMBEDDED_DOLT=1.
+
+// bdLocalOnlySetup inits a project and enables dolt.local-only=true.
+func bdLocalOnlySetup(t *testing.T, bd string) (dir string) {
+	t.Helper()
+	dir, _, _ = bdInit(t, bd, "--prefix", "lo")
+	bdConfig(t, bd, dir, "set", "dolt.local-only", "true")
+	return dir
+}
+
+// bdDoltSeparate runs "bd dolt <args>" and returns (stdout, stderr, err)
+// with separate buffers.  Used when tests must distinguish stdout from stderr.
+func bdDoltSeparate(t *testing.T, bd, dir string, args ...string) (string, string, error) {
+	t.Helper()
+	fullArgs := append([]string{"dolt"}, args...)
+	cmd := exec.Command(bd, fullArgs...)
+	cmd.Dir = dir
+	cmd.Env = bdEnv(dir)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+// -- push --
+
+func TestDoltLocalOnly_Push_ExitsZeroWithMessage(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	// bdDolt fatals on non-zero exit — this asserts exit 0.
+	out := bdDolt(t, bd, dir, "push")
+
+	for _, want := range []string{
+		"Remote sync is disabled for this project (dolt.local-only=true).",
+		"bd config unset dolt.local-only",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("push stdout missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoltLocalOnly_Push_LocalStoreCopy(t *testing.T) {
+	// The push no-op message must include the "Your issues are stored locally" line.
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	out := bdDolt(t, bd, dir, "push")
+	if !strings.Contains(out, "stored locally") {
+		t.Errorf("push no-op missing 'stored locally'\ngot:\n%s", out)
+	}
+}
+
+func TestDoltLocalOnly_Push_JSON_DisabledStatus(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	out := bdDolt(t, bd, dir, "--json", "push")
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &got); err != nil {
+		t.Fatalf("bd dolt --json push: stdout not valid JSON: %v\nout: %s", err, out)
+	}
+	if got["status"] != "disabled" {
+		t.Errorf("JSON[status] = %q, want \"disabled\"", got["status"])
+	}
+	if got["reason"] != "dolt.local-only=true" {
+		t.Errorf("JSON[reason] = %q, want \"dolt.local-only=true\"", got["reason"])
+	}
+}
+
+// -- pull --
+
+func TestDoltLocalOnly_Pull_ExitsZeroWithMessage(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	out := bdDolt(t, bd, dir, "pull")
+
+	for _, want := range []string{
+		"Remote sync is disabled for this project (dolt.local-only=true).",
+		"Nothing to pull",
+		"bd config unset dolt.local-only",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("pull stdout missing %q\ngot:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoltLocalOnly_Pull_JSON_DisabledStatus(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	out := bdDolt(t, bd, dir, "--json", "pull")
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &got); err != nil {
+		t.Fatalf("bd dolt --json pull: stdout not valid JSON: %v\nout: %s", err, out)
+	}
+	if got["status"] != "disabled" {
+		t.Errorf("JSON[status] = %q, want \"disabled\"", got["status"])
+	}
+	if got["reason"] != "dolt.local-only=true" {
+		t.Errorf("JSON[reason] = %q, want \"dolt.local-only=true\"", got["reason"])
+	}
+}
+
+// -- remote add --
+
+func TestDoltLocalOnly_RemoteAdd_RefusesExitOne(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	stdout, stderr, err := bdDoltSeparate(t, bd, dir, "remote", "add", "origin", "https://doltremoteapi.dolthub.com/test/repo")
+	if err == nil {
+		t.Fatalf("bd dolt remote add: expected exit non-zero, but succeeded\nstdout:\n%s", stdout)
+	}
+	for _, want := range []string{
+		"cannot add Dolt remote",
+		"dolt.local-only",
+		"bd config unset dolt.local-only",
+	} {
+		if !strings.Contains(strings.ToLower(stderr+stdout), strings.ToLower(want)) {
+			t.Errorf("remote-add output missing %q\nstdout: %s\nstderr: %s", want, stdout, stderr)
+		}
+	}
+}
+
+func TestDoltLocalOnly_RemoteAdd_ErrorOnStderr(t *testing.T) {
+	// The refusal must go to stderr (not stdout) so agents can distinguish errors.
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	stdout, stderr, _ := bdDoltSeparate(t, bd, dir, "remote", "add", "origin", "https://doltremoteapi.dolthub.com/test/repo")
+	if !strings.Contains(strings.ToLower(stderr), "disabled") {
+		t.Errorf("remote-add refusal not on stderr\nstderr: %s", stderr)
+	}
+	if strings.Contains(strings.ToLower(stdout), "disabled") {
+		t.Errorf("remote-add refusal leaked onto stdout\nstdout: %s", stdout)
+	}
+}
+
+// -- config round-trip --
+
+func TestDoltLocalOnly_ConfigRoundTrip(t *testing.T) {
+	// bd config set dolt.local-only true / unset must persist via config.yaml.
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir, _, _ := bdInit(t, bd, "--prefix", "cr")
+
+	// Set: push becomes a no-op.
+	bdConfig(t, bd, dir, "set", "dolt.local-only", "true")
+	out := bdDolt(t, bd, dir, "push")
+	if !strings.Contains(out, "dolt.local-only=true") {
+		t.Errorf("after set: push output = %q, want to mention dolt.local-only=true", out)
+	}
+
+	// Unset: key must be absent from config.
+	bdConfig(t, bd, dir, "unset", "dolt.local-only")
+	val := bdConfig(t, bd, dir, "get", "dolt.local-only")
+	if strings.TrimSpace(val) != "" {
+		t.Errorf("after unset: bd config get dolt.local-only = %q, want empty", val)
+	}
+}
+
+// -- bd dolt status --
+
+func TestDoltLocalOnly_DoltStatus_ShowsDisabled(t *testing.T) {
+	// When dolt.local-only=true, bd dolt status must include the indicator line.
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run dolt.local-only embedded tests")
+	}
+	t.Parallel()
+	bd := buildEmbeddedBD(t)
+	dir := bdLocalOnlySetup(t, bd)
+
+	out := bdDolt(t, bd, dir, "status")
+	want := "Remote sync: disabled (dolt.local-only=true)"
+	if !strings.Contains(out, want) {
+		t.Errorf("dolt status missing %q\ngot:\n%s", want, out)
+	}
+}

--- a/cmd/bd/dolt_local_only_embedded_test.go
+++ b/cmd/bd/dolt_local_only_embedded_test.go
@@ -1,4 +1,4 @@
-//go:build embeddeddolt
+//go:build cgo
 
 package main
 
@@ -205,11 +205,11 @@ func TestDoltLocalOnly_ConfigRoundTrip(t *testing.T) {
 		t.Errorf("after set: push output = %q, want to mention dolt.local-only=true", out)
 	}
 
-	// Unset: key must be absent from config.
+	// Unset: key must be absent from config. bd config get returns "(not set ...)" for missing keys.
 	bdConfig(t, bd, dir, "unset", "dolt.local-only")
 	val := bdConfig(t, bd, dir, "get", "dolt.local-only")
-	if strings.TrimSpace(val) != "" {
-		t.Errorf("after unset: bd config get dolt.local-only = %q, want empty", val)
+	if !strings.Contains(val, "not set") {
+		t.Errorf("after unset: bd config get dolt.local-only = %q, want 'not set'", val)
 	}
 }
 

--- a/cmd/bd/dolt_local_only_test.go
+++ b/cmd/bd/dolt_local_only_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
+)
+
+// Unit tests for isDoltLocalOnly() and related guards.
+// These fail to compile until the builder adds isDoltLocalOnly() in dolt.go.
+// Cannot be parallel: tests modify global config state.
+
+func TestIsDoltLocalOnly_FalseByDefault(t *testing.T) {
+	config.ResetForTesting()
+	t.Cleanup(func() { config.ResetForTesting() })
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+
+	if isDoltLocalOnly() {
+		t.Error("isDoltLocalOnly() = true, want false when dolt.local-only not set")
+	}
+}
+
+func TestIsDoltLocalOnly_TrueWhenConfigSet(t *testing.T) {
+	config.ResetForTesting()
+	t.Cleanup(func() { config.ResetForTesting() })
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	config.Set("dolt.local-only", true)
+
+	if !isDoltLocalOnly() {
+		t.Error("isDoltLocalOnly() = false, want true when dolt.local-only=true")
+	}
+}
+
+func TestIsDoltLocalOnly_FalseAfterUnset(t *testing.T) {
+	config.ResetForTesting()
+	t.Cleanup(func() { config.ResetForTesting() })
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	config.Set("dolt.local-only", true)
+	if !isDoltLocalOnly() {
+		t.Fatal("precondition: isDoltLocalOnly() should be true after set")
+	}
+	config.Set("dolt.local-only", false)
+	if isDoltLocalOnly() {
+		t.Error("isDoltLocalOnly() = true after unsetting, want false")
+	}
+}
+
+func TestMaybeAutoPush_SkipsWhenLocalOnly(t *testing.T) {
+	// When dolt.local-only=true, maybeAutoPush must return early (no push attempt).
+	// Local-only guard must fire BEFORE getStore(); store is nil here.
+	config.ResetForTesting()
+	t.Cleanup(func() { config.ResetForTesting() })
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	config.Set("dolt.local-only", true)
+	// Enable auto-push so the local-only guard, not the disabled-check, short-circuits.
+	t.Setenv("BD_DOLT_AUTO_PUSH", "true")
+
+	// Must not panic. The local-only guard fires before any store interaction.
+	maybeAutoPush(context.Background())
+}


### PR DESCRIPTION
## Summary

Implements the `dolt.local-only` config key (be-3v2ou, FR-01 to FR-05) that disables all remote Dolt sync when set to `true`.

- **`bd dolt push`**: exits 0 with `Remote sync is disabled for this project (dolt.local-only=true).` + hint to unset; `--json` emits `{\"status\":\"disabled\",\"reason\":\"dolt.local-only=true\"}`
- **`bd dolt pull`**: same exit-0 no-op, additionally prints `Nothing to pull.`
- **`bd dolt remote add`**: exits 1, writes error to stderr (`cannot add Dolt remote: remote sync is disabled`)
- **`bd dolt status`**: appends `Remote sync: disabled (dolt.local-only=true)` to both embedded and server-mode output
- **`maybeAutoPush`**: guard fires before `getStore()` — no store interaction when local-only
- New `isDoltLocalOnly()` helper in `cmd/bd/dolt_local_only.go` reads `config.GetBool(\"dolt.local-only\")`

## Key name constraint
Config key is `dolt.local-only` (hyphen) to match `gascity`'s `ga-d457b` which sets exactly that key.

## Test plan

- [x] Unit tests: `TestIsDoltLocalOnly_*`, `TestMaybeAutoPush_SkipsWhenLocalOnly` — all pass (pure-Go)
- [x] Integration tests: `TestDoltLocalOnly_Push_*`, `TestDoltLocalOnly_Pull_*`, `TestDoltLocalOnly_RemoteAdd_*`, `TestDoltLocalOnly_ConfigRoundTrip`, `TestDoltLocalOnly_DoltStatus_ShowsDisabled` — all 9 pass (CGO embedded dolt)
- [x] Build clean: `CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)