### PR TITLE
fix(migration): run schema migrations on a connection with no read timeout

### DIFF
--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1501,7 +1501,19 @@ func initSchemaOnDBWithRetry(ctx context.Context, db *sql.DB) (int, error) {
 }
 
 func (s *DoltStore) initSchema(ctx context.Context) error {
-	_, err := initSchemaOnDBWithRetry(ctx, s.db)
+	// Schema migrations can run arbitrarily long (e.g. full-table recomputes
+	// such as the is_blocked backfill in migration 0047). The main connection
+	// pool sets a 10s ReadTimeout (see buildServerDSN); a slow migration over
+	// that pool aborts mid-flight with "i/o timeout" and leaves tables dirty,
+	// which then blocks every subsequent migration attempt. Run the migration
+	// pass over a dedicated connection with no read/write timeout. Cancellation
+	// is governed by the caller's context, not a fixed deadline.
+	migDB, err := s.openMigrationDB()
+	if err != nil {
+		return err
+	}
+	defer migDB.Close()
+	_, err = initSchemaOnDBWithRetry(ctx, migDB)
 	return err
 }
 
@@ -1509,7 +1521,31 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 // per-database advisory lock, with retry for transient lock contention.
 // Implements storage.SchemaMigrator.
 func (s *DoltStore) ApplySchemaMigrations(ctx context.Context) (int, error) {
-	return initSchemaOnDBWithRetry(ctx, s.db)
+	migDB, err := s.openMigrationDB()
+	if err != nil {
+		return 0, err
+	}
+	defer migDB.Close()
+	return initSchemaOnDBWithRetry(ctx, migDB)
+}
+
+// openMigrationDB opens a one-off connection pool for schema migrations with no
+// read/write timeout. Migrations may run far longer than the default 10s pool
+// timeout, and timing out part-way leaves the database in a dirty, half-migrated
+// state. The single connection is closed by the caller once migration completes.
+func (s *DoltStore) openMigrationDB() (*sql.DB, error) {
+	cfg, err := mysql.ParseDSN(s.connStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DSN for migration connection: %w", err)
+	}
+	cfg.ReadTimeout = 0
+	cfg.WriteTimeout = 0
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open migration connection: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	return db, nil
 }
 
 // IsClosed returns true if the store has been closed.


### PR DESCRIPTION
## Problem

Schema migrations run over the main connection pool, which sets a **10s `ReadTimeout`** in `buildServerDSN` (`internal/storage/dolt/store.go`). Migrations that touch large tables can far exceed this — e.g. `0047_recompute_mixed_is_blocked` does a full-table recursive-CTE `is_blocked` recompute that takes ~60s on a few-thousand-row database.

When the read deadline fires mid-migration:
- the migration aborts with `read tcp ...: i/o timeout`;
- `schema.MigrateUp`'s `unstagePreExistingTables` has already dirtied the working set, so the table is left **dirty / half-migrated**;
- every subsequent attempt then trips the `pending schema migrations alter pre-existing dirty tables` guard.

Net effect: a database that needs a slow migration becomes **permanently un-upgradeable** — `bd migrate` and store-open both fail in a loop. This bit us recovering a real city whose `hq`/rig stores were a few migrations behind; the only workaround was running migrations out-of-band.

## Fix

`initSchema` now runs the migration pass over a **dedicated single connection with no read/write timeout** (`openMigrationDB`), mirroring the existing `execWithLongTimeout` pattern but unbounded, since a migration has no sensible fixed deadline. Cancellation is governed by the caller's `context`, not a fixed socket deadline. The normal pool keeps its 10s timeout for regular queries.

## Testing

Built with `make install` (CGO=1) and migrated 3 real databases that were stuck at cursor 45/46 → 47:
- gascity (`0047`): completed in **~57s** (previously failed at 10s every time).
- mcdclient, pwu (`0046`+`0047`): completed cleanly.
- All ended at cursor 47 with clean working sets; the city then started normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)