### PR TITLE
feat(bd): honor MIGRATION-FREEZE sentinel in write commands (gt-xcecn)

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -28,6 +28,7 @@ create, update, show, or close operation).`,
 	Args: cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("close")
+		CheckMigrationFreeze("close")
 
 		// If no IDs provided, use last touched issue
 		if len(args) == 0 {

--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -33,6 +33,7 @@ var createCmd = &cobra.Command{
 	Args:    cobra.MinimumNArgs(0), // Changed to allow no args when using -f
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("create")
+		CheckMigrationFreeze("create")
 		file, _ := cmd.Flags().GetString("file")
 		graphFile, _ := cmd.Flags().GetString("graph")
 

--- a/cmd/bd/errors.go
+++ b/cmd/bd/errors.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 func activeWorkspaceNotFoundError() string {
@@ -177,4 +179,76 @@ func CheckReadonly(operation string) {
 	if readonlyMode {
 		FatalError("operation '%s' is not allowed in read-only mode", operation)
 	}
+}
+
+// CheckMigrationFreeze exits with an error if a Gas Town migration freeze is active.
+// Call this at the start of write commands alongside CheckReadonly.
+// Safe to call from any directory: returns silently if not in a Gas Town workspace
+// or no freeze is active.
+//
+// Example:
+//
+//	var createCmd = &cobra.Command{
+//	    Run: func(cmd *cobra.Command, args []string) {
+//	        CheckReadonly("create")
+//	        CheckMigrationFreeze("create")
+//	        // ... rest of command
+//	    },
+//	}
+func CheckMigrationFreeze(operation string) {
+	townRoot := findTownRootForFreeze()
+	if townRoot == "" {
+		return
+	}
+	freezeFile := filepath.Join(townRoot, "MIGRATION-FREEZE")
+	if _, err := os.Stat(freezeFile); os.IsNotExist(err) {
+		return
+	}
+	operator := "unknown"
+	reason := ""
+	if data, err := os.ReadFile(freezeFile); err == nil {
+		parts := strings.SplitN(strings.TrimSpace(string(data)), "\t", 3)
+		if len(parts) >= 1 && parts[0] != "" {
+			operator = parts[0]
+		}
+		if len(parts) >= 3 {
+			reason = parts[2]
+		}
+	}
+	fmt.Fprintf(os.Stderr, "⛔ ERROR: town is frozen for migration (by %s).\n", operator)
+	if reason != "" {
+		fmt.Fprintf(os.Stderr, "   Reason: %s\n", reason)
+	}
+	fmt.Fprintf(os.Stderr, "   Clear the freeze: gt migrate thaw\n")
+	os.Exit(1)
+}
+
+// findTownRootForFreeze locates the Gas Town workspace root.
+// Checks GT_TOWN_ROOT/GT_ROOT env vars first (fast path for Gas Town sessions),
+// then walks up the directory tree looking for the outermost mayor/town.json.
+// Returns empty string if not in a Gas Town workspace.
+func findTownRootForFreeze() string {
+	for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
+		if root := os.Getenv(envName); root != "" {
+			if _, err := os.Stat(filepath.Join(root, "mayor")); err == nil {
+				return root
+			}
+		}
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	var outermost string
+	for dir := cwd; ; {
+		if _, err := os.Stat(filepath.Join(dir, "mayor", "town.json")); err == nil {
+			outermost = dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return outermost
 }

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -84,6 +84,7 @@ func init() {
 }
 
 func runImport(cmd *cobra.Command, args []string) error {
+	CheckMigrationFreeze("import")
 	ctx := rootCtx
 	if importInput != "" && len(args) > 0 {
 		return fmt.Errorf("use either --input or a positional file, not both")

--- a/cmd/bd/memory.go
+++ b/cmd/bd/memory.go
@@ -58,6 +58,7 @@ Examples:
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("remember")
+		CheckMigrationFreeze("remember")
 
 		if err := ensureDirectMode("remember requires direct database access"); err != nil {
 			FatalError("%v", err)

--- a/cmd/bd/migration_freeze_test.go
+++ b/cmd/bd/migration_freeze_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFindTownRootForFreezeEnvVar verifies that findTownRootForFreeze
+// returns the root from GT_ROOT/GT_TOWN_ROOT when set and valid.
+func TestFindTownRootForFreezeEnvVar(t *testing.T) {
+	// Create a temp directory that looks like a town root (has mayor/ dir)
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GT_TOWN_ROOT", tmpDir)
+	t.Setenv("GT_ROOT", "")
+
+	got := findTownRootForFreeze()
+	if got != tmpDir {
+		t.Errorf("findTownRootForFreeze() = %q, want %q", got, tmpDir)
+	}
+}
+
+// TestFindTownRootForFreezeGTROOT verifies GT_ROOT is used as fallback.
+func TestFindTownRootForFreezeGTROOT(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", tmpDir)
+
+	got := findTownRootForFreeze()
+	if got != tmpDir {
+		t.Errorf("findTownRootForFreeze() = %q, want %q", got, tmpDir)
+	}
+}
+
+// TestFindTownRootForFreezeEnvInvalid verifies that an env var pointing to a
+// non-town directory is ignored and the CWD walk is used instead.
+func TestFindTownRootForFreezeEnvInvalid(t *testing.T) {
+	t.Setenv("GT_TOWN_ROOT", "/nonexistent/path")
+	t.Setenv("GT_ROOT", "/also/nonexistent")
+
+	// With no valid env var and CWD not in a town, should return ""
+	// (We can't easily control CWD in tests, but we can verify the env
+	// var path doesn't cause a panic or crash.)
+	_ = findTownRootForFreeze()
+}
+
+// TestCheckMigrationFreezeNoFreeze verifies CheckMigrationFreeze is a no-op
+// when no freeze is active.
+func TestCheckMigrationFreezeNoFreeze(t *testing.T) {
+	// Point GT_ROOT to a temp dir with no MIGRATION-FREEZE file
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GT_ROOT", tmpDir)
+	t.Setenv("GT_TOWN_ROOT", "")
+
+	// Should return without calling os.Exit. If it exits, the test process dies.
+	CheckMigrationFreeze("create")
+}
+
+// TestCheckMigrationFreezeNoTownRoot verifies CheckMigrationFreeze is a no-op
+// when no town root is found.
+func TestCheckMigrationFreezeNoTownRoot(t *testing.T) {
+	t.Setenv("GT_ROOT", "")
+	t.Setenv("GT_TOWN_ROOT", "")
+
+	// With no env vars and CWD not in a Gas Town workspace (in temp dir),
+	// CheckMigrationFreeze should be a no-op.
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Skip("cannot change directory:", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Should return without calling os.Exit.
+	CheckMigrationFreeze("create")
+}
+
+// TestMigrationFreezeFileFormat verifies the sentinel file is parsed correctly.
+// The format is: operator\ttimestamp\treason\n
+func TestMigrationFreezeFileFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	freezeFile := filepath.Join(tmpDir, "MIGRATION-FREEZE")
+	content := "mayor\t2026-05-25T10:00:00Z\thq migration\n"
+	if err := os.WriteFile(freezeFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the file exists and can be stat'd
+	if _, err := os.Stat(freezeFile); err != nil {
+		t.Fatalf("freeze file should exist: %v", err)
+	}
+
+	// Verify the parse logic (test the parsing inline since CheckMigrationFreeze
+	// calls os.Exit and can't be tested directly when a freeze is active)
+	data, err := os.ReadFile(freezeFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := splitFreezeContent(string(data))
+	if len(parts) < 1 || parts[0] != "mayor" {
+		t.Errorf("expected operator 'mayor', got %v", parts)
+	}
+	if len(parts) < 3 || parts[2] != "hq migration" {
+		t.Errorf("expected reason 'hq migration', got %v", parts)
+	}
+}
+
+// splitFreezeContent is a test helper that mirrors the parsing logic in
+// CheckMigrationFreeze to allow testing without triggering os.Exit.
+func splitFreezeContent(content string) []string {
+	trimmed := content
+	for len(trimmed) > 0 && (trimmed[len(trimmed)-1] == '\n' || trimmed[len(trimmed)-1] == '\r') {
+		trimmed = trimmed[:len(trimmed)-1]
+	}
+	if trimmed == "" {
+		return nil
+	}
+	result := []string{}
+	start := 0
+	count := 0
+	for i, ch := range trimmed {
+		if ch == '\t' && count < 2 {
+			result = append(result, trimmed[start:i])
+			start = i + 1
+			count++
+		}
+	}
+	result = append(result, trimmed[start:])
+	return result
+}

--- a/cmd/bd/update.go
+++ b/cmd/bd/update.go
@@ -28,6 +28,7 @@ create, update, show, or close operation).`,
 	Args: cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("update")
+		CheckMigrationFreeze("update")
 
 		// If no IDs provided, use last touched issue
 		if len(args) == 0 {


### PR DESCRIPTION
## Summary

- Add `CheckMigrationFreeze(operation)` in `errors.go` next to `CheckReadonly`, mirroring the gt-side gate from dc-qcd2
- Gate `bd create`, `bd update`, `bd close`, `bd remember`, and `bd import` with the new check
- Town-root discovery checks `GT_TOWN_ROOT`/`GT_ROOT` env vars first, then walks the directory tree for `mayor/town.json`

## Context

Follow-up to dc-qcd2 / B2 (`feat/migrate-freeze-thaw` branch in gastown). The gt CLI
already refuses write commands when a `MIGRATION-FREEZE` sentinel sits at the town root.
This PR closes the gap on the bd side so human-typed `bd create` / `bd update` / etc.
are also blocked during a migration window.

Residual risk addressed: continuous bd writers (mail-poller, daemon patrols) are already
stopped via the playbook's plist-unload step; this gates the remaining human-typed writes.

## Test plan

- [ ] `TestFindTownRootForFreezeEnvVar` — env var fast path
- [ ] `TestFindTownRootForFreezeGTROOT` — GT_ROOT fallback
- [ ] `TestFindTownRootForFreezeEnvInvalid` — invalid env var falls through gracefully
- [ ] `TestCheckMigrationFreezeNoFreeze` — no-op when no sentinel present
- [ ] `TestCheckMigrationFreezeNoTownRoot` — no-op outside Gas Town workspace
- [ ] `TestMigrationFreezeFileFormat` — sentinel parsing is correct
- [ ] Manual: `GT_ROOT=<tmpdir> bd create` during freeze prints `⛔ ERROR:` and exits 1

Closes gt-xcecn

🤖 Generated with [Claude Code](https://claude.com/claude-code)