### PR TITLE
/{cmd,internal}: add migrate schema command (docs fix from PR #4116)

### DIFF
--- a/cmd/bd/migrate.go
+++ b/cmd/bd/migrate.go
@@ -23,6 +23,11 @@ var migrateCmd = &cobra.Command{
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -34,6 +39,7 @@ Subcommands:
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		updateRepoID, _ := cmd.Flags().GetBool("update-repo-id")
 		inspect, _ := cmd.Flags().GetBool("inspect")
+		schemaFlag, _ := cmd.Flags().GetBool("schema")
 
 		// Block writes in readonly mode (migration modifies data, --inspect is read-only)
 		if !dryRun && !inspect {
@@ -49,6 +55,11 @@ Subcommands:
 		// Handle --inspect flag (show migration plan for AI agents)
 		if inspect {
 			handleInspect()
+			return
+		}
+
+		if schemaFlag {
+			handleSchemaMigrate()
 			return
 		}
 
@@ -756,6 +767,7 @@ func init() {
 	migrateCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")
 	migrateCmd.Flags().Bool("update-repo-id", false, "Update repository ID (use after changing git remote)")
 	migrateCmd.Flags().Bool("inspect", false, "Show migration plan and database state for AI agent analysis")
+	migrateCmd.Flags().Bool("schema", false, "Apply pending schema migrations (idempotent)")
 	migrateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output migration statistics in JSON format")
 
 	migrateSyncCmd.Flags().Bool("dry-run", false, "Show what would be done without making changes")

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3968,6 +3968,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -3985,6 +3990,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/website/docs/cli-reference/migrate.md
+++ b/website/docs/cli-reference/migrate.md
@@ -14,6 +14,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -31,6 +36,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6344,6 +6344,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -6361,6 +6366,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/migrate.md
@@ -14,6 +14,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -31,6 +36,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```

--- a/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/migrate.md
@@ -14,6 +14,11 @@ Database migration and data transformation commands.
 
 Without subcommand, checks and updates database metadata to current version.
 
+Flags:
+  --schema    Apply pending schema migrations (idempotent)
+  --inspect   Show migration plan and database state for AI agent analysis
+  --dry-run   Show what would be done without making changes
+
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
@@ -31,6 +36,7 @@ bd migrate [flags]
       --dry-run          Show what would be done without making changes
       --inspect          Show migration plan and database state for AI agent analysis
       --json             Output migration statistics in JSON format
+      --schema           Apply pending schema migrations (idempotent)
       --update-repo-id   Update repository ID (use after changing git remote)
       --yes              Auto-confirm prompts
 ```


### PR DESCRIPTION
## Summary

Maintainer cherry-pick of #4116 with CI blocker fixed.

- Includes all commits from #4116 (add `bd migrate schema` command by @coffeegoddd)
- Adds: `chore(docs): regenerate CLI reference for migrate schema command` — fixes the `Check doc flags freshness` CI failure (#4116 added the new command without regenerating docs)

Closes #4116

## Test plan

- [ ] `Check doc flags freshness` CI check passes
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)