### PR TITLE
fix(list): disable default truncation when stdout is piped (test fix from PR #4114)

### DIFF
--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -228,12 +228,13 @@ func TestEmbeddedList(t *testing.T) {
 	})
 
 	t.Run("limit_truncation_hint", func(t *testing.T) {
-		// Truncated: --limit < seeded count should emit stderr hint (GH#3212).
+		// GH#4094: hint is suppressed when stderr is not a terminal (piped).
+		// bdListCapture always runs in piped mode, so no hint expected even when truncated.
 		stdout, stderr := bdListCapture(t, bd, dir, "--limit", "2")
-		if !strings.Contains(stderr, "more results matched") {
-			t.Errorf("expected truncation hint on stderr, got:\nstderr: %q\nstdout: %q", stderr, stdout)
+		if strings.Contains(stderr, "more results matched") {
+			t.Errorf("truncation hint must not appear on piped stderr (GH#4094):\nstderr: %q\nstdout: %q", stderr, stdout)
 		}
-		// The hint must go to stderr only, not stdout, so JSON consumers can parse stdout cleanly.
+		// Hint must never appear in stdout.
 		if strings.Contains(stdout, "more results matched") {
 			t.Errorf("truncation hint leaked into stdout:\n%s", stdout)
 		}

--- a/cmd/bd/list_input.go
+++ b/cmd/bd/list_input.go
@@ -286,6 +286,8 @@ func gatherListInput(cmd *cobra.Command) listInput {
 		in.effectiveLimit = limit
 	case in.allFlag:
 		in.effectiveLimit = 0
+	case !ui.IsTerminal():
+		in.effectiveLimit = 0 // Piped stdout should not truncate (GH#4094)
 	case ui.IsAgentMode():
 		in.effectiveLimit = 20
 	}

--- a/cmd/bd/list_output.go
+++ b/cmd/bd/list_output.go
@@ -14,7 +14,7 @@ import (
 // was truncated by --limit, so users and agents can't mistake a partial view
 // for a complete one (GH#3212, GH#788).
 func printTruncationHint(truncated bool, effectiveLimit int) {
-	if !truncated || effectiveLimit <= 0 {
+	if !truncated || effectiveLimit <= 0 || !ui.IsStderrTerminal() {
 		return
 	}
 	msg := fmt.Sprintf("\nShowing %d issues; more results matched but were hidden by --limit. Use --limit 0 for all, or --limit N to raise the cap.\n", effectiveLimit)


### PR DESCRIPTION
## Summary

Maintainer cherry-pick of #4114 with CI test fix applied.

- Includes all commits from #4114 (disable truncation when stdout is piped by @kevglynn, GH#4094)
- Adds: `test(list): update limit_truncation_hint for piped stderr contract` — updates `TestEmbeddedList/limit_truncation_hint` to reflect the new behavior (no hint on piped stderr) rather than the old expectation that the hint always appears

**Root cause of CI failure:** `list_embedded_test.go:205` asserted that the truncation hint appears on stderr when `--limit 2` is set. With GH#4094, `printTruncationHint` now early-returns when `!ui.IsStderrTerminal()`. Since `bdListCapture` always pipes stderr via `exec.Command`, the hint is now correctly suppressed — the test was asserting the old (pre-#4094) behavior.

Closes #4114

## Test plan

- [ ] `Test (Embedded Dolt Cmd 3/20)` CI check passes
- [ ] All other CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)