### PR TITLE
docs: schema-version guard in README and CHANGELOG (be-x0rl6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Schema-version guard**: `bd` now hard-fails at database-open time when the
+  database schema is ahead of the binary's embedded migrations. This protects
+  against cryptic SQL errors (e.g., `column X could not be found in any table
+  in scope`) that occur when an older binary opens a database migrated by a
+  newer one. The error message names the exact version mismatch and provides a
+  copy-paste rebuild command. Use `--ignore-schema-skew` (or env var
+  `BD_IGNORE_SCHEMA_SKEW=1`) to bypass the guard when you know the forward
+  migrations are safe for your workload. Fresh databases and normal
+  forward-migration paths are unaffected.
+
 - **Foreign keys across issue and wisp tables.** Migrations `0040`–`0042` and the new `ignored/0001`–`ignored/0004` add explicit FKs with `ON DELETE CASCADE ON UPDATE CASCADE` on `dependencies`, `labels`, `comments`, `events`, `issue_snapshots`, `compaction_snapshots`, `child_counters`, and the matching `wisp_*` tables. Deleting or renaming a parent row now cascades automatically — the manual cleanup loops in `issueops/delete.go`, `dolt/wisps.go`, `dolt/ephemeral_routing.go`, and `cmd/bd/rename_prefix.go` have been removed (net ~300 lines down). ([#3952](https://github.com/gastownhall/beads/pull/3952))
 - **`issueops.DeleteWispFromDependenciesInTx` / `UpdateWispIDInDependenciesInTx`.** Because Dolt forbids foreign keys from tracked tables (`dependencies`) to `dolt_ignore`'d tables (`wisps`), wisp deletion and rename now invoke these helpers explicitly to keep `dependencies.depends_on_wisp_id` consistent. The standard store APIs (`DeleteIssue`, `UpdateIssueID`, `deleteWispBatch`, etc.) wire them up automatically; only call them directly if you bypass those entry points. ([#3952](https://github.com/gastownhall/beads/pull/3952))
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ schema version mismatch: database is at v45, binary knows up to v42 (3 migration
     CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd
 
   Or install the latest release:
-    go install github.com/steveyegge/beads/cmd/bd@latest
+    CGO_ENABLED=0 go install -tags gms_pure_go github.com/steveyegge/beads/cmd/bd@latest
 
   To proceed despite the risk (some read commands may still work):
     BD_IGNORE_SCHEMA_SKEW=1 bd <command>

--- a/README.md
+++ b/README.md
@@ -172,6 +172,39 @@ for review, migration, and interoperability, but they do not capture Dolt
 branches, commit history, working-set state, or non-issue tables. Use
 `bd backup` or a manual Dolt backup when you need a restorable database backup.
 
+### Schema Version Guard
+
+`bd` checks the database schema version at open time. If the database has been
+migrated by a newer binary and an older binary tries to open it, `bd` exits
+with an actionable error rather than issuing queries that fail with cryptic SQL
+errors:
+
+````
+schema version mismatch: database is at v45, binary knows up to v42 (3 migrations ahead)
+
+  Your bd binary is stale. Queries for dropped or renamed columns will fail
+  with cryptic SQL errors (e.g. "column X could not be found in any table in scope").
+
+  Rebuild from main:
+    CGO_ENABLED=0 go build -tags gms_pure_go ./cmd/bd
+
+  Or install the latest release:
+    go install github.com/steveyegge/beads/cmd/bd@latest
+
+  To proceed despite the risk (some read commands may still work):
+    BD_IGNORE_SCHEMA_SKEW=1 bd <command>
+    bd --ignore-schema-skew <command>
+````
+
+**When this fires:** only when the database schema is *ahead* of the binary
+(a newer binary migrated the database; this binary doesn't know those
+migrations). Normal upgrades, where the binary migrates the database forward,
+are unaffected.
+
+**Escape hatch:** `BD_IGNORE_SCHEMA_SKEW=1` (or `--ignore-schema-skew`) bypasses
+the guard with a warning on stderr. Use this only if you know the forward
+migrations are additive and safe for your specific workload.
+
 ## 🌐 Community Tools
 
 See [docs/COMMUNITY_TOOLS.md](docs/COMMUNITY_TOOLS.md) for a curated list of community-built UIs, extensions, and integrations—including terminal interfaces, web UIs, editor extensions, and native apps.


### PR DESCRIPTION
## Summary

- Adds **Schema Version Guard** subsection to README.md under `## 💾 Storage Modes` (after `### Backup & Migration`)
- Adds CHANGELOG entry under `[Unreleased] > Added` describing the guard, the protected scenario, and the bypass mechanism

## Related

- PR #4152 — schema-skew guard implementation (`feat/be-wwbsv-schema-skew-guard`); this docs PR should be merged after or with that PR.

## Flag description note

PR #4152 currently registers `--ignore-schema-skew` with description:
> "Proceed despite forward schema drift (some queries may fail)"

The designer spec (be-x0rl6) recommends expanding it to:
> "Bypass the schema-version guard when the database is ahead of the binary. Sets BD_IGNORE_SCHEMA_SKEW=1. Use only when forward migrations are safe for your workload."

That change belongs in PR #4152 alongside the flag registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)