### PR TITLE
fix: prefer wisp on cross-table dup; add CGO-free duplicate check (be-iabdi)

### DIFF
--- a/cmd/bd/doctor/cross_table.go
+++ b/cmd/bd/doctor/cross_table.go
@@ -1,0 +1,38 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/beads/cmd/bd/doctor/fix"
+)
+
+// CheckCrossTableDuplicates detects IDs that exist in both the issues and
+// wisps tables. Such dups arise from the message→wisp dual-write window
+// (be-iabdi) and block every id-resolver lookup until removed.
+//
+// This check does not require CGO: it queries via MySQL wire protocol using
+// the same dolt-server connection as the fix package.
+func CheckCrossTableDuplicates(path string) DoctorCheck {
+	count, err := fix.CountCrossTableDuplicates(path)
+	if err != nil {
+		return DoctorCheck{
+			Name:    "Cross-Table Duplicates",
+			Status:  StatusOK,
+			Message: "N/A (no database or wisps table absent)",
+		}
+	}
+	if count == 0 {
+		return DoctorCheck{
+			Name:    "Cross-Table Duplicates",
+			Status:  StatusOK,
+			Message: "No cross-table duplicates",
+		}
+	}
+	return DoctorCheck{
+		Name:    "Cross-Table Duplicates",
+		Status:  StatusError,
+		Message: fmt.Sprintf("%d id(s) exist in both issues and wisps", count),
+		Detail:  "Stale issues-table copies break every lookup for the affected IDs",
+		Fix:     "Run 'bd doctor --check=validate --fix' to remove stale issues copies (wisps are canonical)",
+	}
+}

--- a/cmd/bd/doctor/fix/validation.go
+++ b/cmd/bd/doctor/fix/validation.go
@@ -208,6 +208,102 @@ func ChildParentDependencies(path string, verbose bool) error {
 	return nil
 }
 
+// CrossTableDuplicates removes issues-table rows whose IDs also exist in the
+// wisps table. The wisps copy is canonical (be-iabdi); stale issues rows are
+// deleted along with their child rows (labels, events, dependencies, comments).
+func CrossTableDuplicates(path string, verbose bool) error {
+	beadsDir, err := resolvedWorkspaceBeadsDir(path)
+	if err != nil {
+		return err
+	}
+
+	db, err := openDoltDB(beadsDir)
+	if err != nil {
+		fmt.Printf("  Cross-table duplicates fix skipped (%v)\n", err)
+		return nil
+	}
+	defer db.Close()
+
+	// Find IDs present in both tables — the wisp copy is canonical.
+	rows, err := db.Query(`SELECT id FROM issues WHERE id IN (SELECT id FROM wisps)`)
+	if err != nil {
+		return fmt.Errorf("failed to query cross-table duplicates: %w", err)
+	}
+	var dupIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err == nil {
+			dupIDs = append(dupIDs, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("row iteration error: %w", err)
+	}
+	_ = rows.Close()
+
+	if len(dupIDs) == 0 {
+		fmt.Println("  No cross-table duplicates to fix")
+		return nil
+	}
+
+	showIndividual := verbose || len(dupIDs) < 20
+	tx, txErr := db.Begin()
+	if txErr != nil {
+		return fmt.Errorf("failed to begin transaction: %w", txErr)
+	}
+
+	var removed int
+	for _, id := range dupIDs {
+		// Delete child rows first (FK-safe order), then the issues row.
+		for _, childTable := range []string{"labels", "events", "dependencies", "comments"} {
+			//nolint:gosec // G202: childTable is from a hardcoded list above.
+			if _, err := tx.Exec(fmt.Sprintf("DELETE FROM %s WHERE issue_id = ?", childTable), id); err != nil {
+				fmt.Printf("  Warning: failed to delete %s rows for %s: %v\n", childTable, id, err)
+			}
+		}
+		if _, err := tx.Exec("DELETE FROM issues WHERE id = ?", id); err != nil {
+			fmt.Printf("  Warning: failed to delete issues row for %s: %v\n", id, err)
+		} else {
+			removed++
+			if showIndividual {
+				fmt.Printf("  Removed stale issues-table copy of %s (canonical in wisps)\n", id)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit cross-table duplicate removals: %w", err)
+	}
+
+	_, _ = db.Exec("CALL DOLT_COMMIT('-Am', 'doctor: remove stale issues copies of wisps (be-iabdi)')") // Best effort
+
+	fmt.Printf("  Fixed %d cross-table duplicate(s)\n", removed)
+	return nil
+}
+
+// CountCrossTableDuplicates returns the number of IDs present in both the
+// issues and wisps tables. Returns 0 and an error if the database is
+// unreachable. Used by CheckCrossTableDuplicates in the doctor package.
+func CountCrossTableDuplicates(path string) (int, error) {
+	beadsDir, err := resolvedWorkspaceBeadsDir(path)
+	if err != nil {
+		return 0, err
+	}
+
+	db, err := openDoltDB(beadsDir)
+	if err != nil {
+		return 0, err
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM issues WHERE id IN (SELECT id FROM wisps)`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("query cross-table duplicates: %w", err)
+	}
+	return count, nil
+}
+
 // openDoltDB opens a Dolt database connection via MySQL protocol.
 // Delegates to openFixDB for DSN construction (timeout + password support).
 func openDoltDB(beadsDir string) (*sql.DB, error) {

--- a/cmd/bd/doctor_fix.go
+++ b/cmd/bd/doctor_fix.go
@@ -294,6 +294,8 @@ func applyFixList(path string, fixes []doctorCheck) {
 		case "Untracked Files":
 			fmt.Printf("  ⚠ Untracked JSONL fix removed (Dolt-native storage)\n")
 			continue
+		case "Cross-Table Duplicates":
+			err = fix.CrossTableDuplicates(path, doctorVerbose)
 		case "Orphaned Dependencies":
 			err = fix.OrphanedDependencies(path, doctorVerbose)
 		case "Dependency Keys":

--- a/cmd/bd/doctor_validate.go
+++ b/cmd/bd/doctor_validate.go
@@ -75,9 +75,10 @@ func runValidateCheckInner(path string) bool {
 	return overallOK
 }
 
-// collectValidateChecks runs the four data-integrity checks.
+// collectValidateChecks runs the data-integrity checks.
 func collectValidateChecks(path string) []validateCheckResult {
 	return []validateCheckResult{
+		{check: convertDoctorCheck(doctor.CheckCrossTableDuplicates(path)), fixable: true},
 		{check: convertDoctorCheck(doctor.CheckDuplicateIssues(path, doctorOrchestrator, orchestratorDuplicatesThreshold))},
 		{check: convertDoctorCheck(doctor.CheckOrphanedDependencies(path)), fixable: true},
 		{check: convertDoctorCheck(doctor.CheckTestPollution(path))},

--- a/internal/storage/dolt/mixed_table_lifecycle_test.go
+++ b/internal/storage/dolt/mixed_table_lifecycle_test.go
@@ -650,24 +650,40 @@ func TestGetNewlyUnblockedByCloseKeepsCandidateBlockedByNoHistoryWisp(t *testing
 	}
 }
 
-func TestSearchIssuesRejectsDuplicateIssueWispID(t *testing.T) {
+func TestSearchIssuesPreferWispOnDuplicateID(t *testing.T) {
 	store, cleanup := setupTestStore(t)
 	defer cleanup()
 
 	ctx, cancel := testContext(t)
 	defer cancel()
 
+	// Create an issue in the issues table (title: "perm mixed-search-duplicate")
 	createPerm(t, ctx, store, "mixed-search-duplicate")
+	// Insert a row with the same ID into wisps with a distinct title
 	if _, err := store.execContext(ctx, `
 		INSERT INTO wisps (id, title, description, design, acceptance_criteria, notes, status, priority, issue_type, ephemeral, no_history)
 		VALUES (?, ?, '', '', '', '', ?, ?, ?, ?, ?)
-	`, "mixed-search-duplicate", "duplicate wisp", types.StatusOpen, 2, types.TypeTask, false, true); err != nil {
+	`, "mixed-search-duplicate", "wisp canonical", types.StatusOpen, 2, types.TypeTask, false, true); err != nil {
 		t.Fatalf("insert duplicate wisp row: %v", err)
 	}
 
-	_, err := store.SearchIssues(ctx, "", types.IssueFilter{})
-	if err == nil || !strings.Contains(err.Error(), `id "mixed-search-duplicate" exists in both issues and wisps`) {
-		t.Fatalf("SearchIssues error = %v, want duplicate issue/wisp ID error", err)
+	// SearchIssues must succeed and return the wisp (canonical) copy, not error.
+	results, err := store.SearchIssues(ctx, "", types.IssueFilter{})
+	if err != nil {
+		t.Fatalf("SearchIssues error = %v, want no error on cross-table dup", err)
+	}
+	var found *types.Issue
+	for _, r := range results {
+		if r.ID == "mixed-search-duplicate" {
+			found = r
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("SearchIssues: mixed-search-duplicate not found in results")
+	}
+	if found.Title != "wisp canonical" {
+		t.Errorf("SearchIssues: got title %q, want %q (wisp preferred over issues copy)", found.Title, "wisp canonical")
 	}
 }
 

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -453,9 +453,12 @@ func loadStatusByIDInTx(ctx context.Context, tx *sql.Tx, ids []string) (map[stri
 					_ = rows.Close()
 					return nil, fmt.Errorf("scan status: %w", err)
 				}
-				if existingTable, exists := sourceByID[id]; exists {
-					_ = rows.Close()
-					return nil, fmt.Errorf("status id %q exists in both %s and %s", id, existingTable, issueTable)
+				if _, exists := sourceByID[id]; exists {
+					// Prefer wisps-table status on cross-table dup (be-iabdi).
+					// Tables iterate issues→wisps so the second encounter is always wisps.
+					sourceByID[id] = issueTable
+					statusByID[id] = status
+					continue
 				}
 				sourceByID[id] = issueTable
 				statusByID[id] = status

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -126,16 +126,13 @@ func GetReadyWorkInTx(
 		return nil, wErr
 	}
 	if len(wisps) > 0 {
-		ordered, err = mergeReadyWisps(ordered, wisps, filter)
-		if err != nil {
-			return nil, err
-		}
+		ordered = mergeReadyWisps(ordered, wisps, filter)
 	}
 
 	return ordered, nil
 }
 
-func mergeReadyWisps(ordered []*types.Issue, wisps []*types.Issue, filter types.WorkFilter) ([]*types.Issue, error) {
+func mergeReadyWisps(ordered []*types.Issue, wisps []*types.Issue, filter types.WorkFilter) []*types.Issue {
 	// Prefer the canonical wisp record when an ID exists in both tables (be-iabdi).
 	wispByID := make(map[string]*types.Issue, len(wisps))
 	for _, w := range wisps {
@@ -152,7 +149,7 @@ func mergeReadyWisps(ordered []*types.Issue, wisps []*types.Issue, filter types.
 	if filter.Limit > 0 && len(kept) > filter.Limit {
 		kept = kept[:filter.Limit]
 	}
-	return kept, nil
+	return kept
 }
 
 func getReadyWispsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter, deferredChildIDs []string) ([]*types.Issue, error) {

--- a/internal/storage/issueops/ready_work.go
+++ b/internal/storage/issueops/ready_work.go
@@ -136,21 +136,23 @@ func GetReadyWorkInTx(
 }
 
 func mergeReadyWisps(ordered []*types.Issue, wisps []*types.Issue, filter types.WorkFilter) ([]*types.Issue, error) {
-	seen := make(map[string]struct{}, len(ordered))
+	// Prefer the canonical wisp record when an ID exists in both tables (be-iabdi).
+	wispByID := make(map[string]*types.Issue, len(wisps))
+	for _, w := range wisps {
+		wispByID[w.ID] = w
+	}
+	var kept []*types.Issue
 	for _, issue := range ordered {
-		seen[issue.ID] = struct{}{}
-	}
-	for _, wisp := range wisps {
-		if _, exists := seen[wisp.ID]; exists {
-			return nil, fmt.Errorf("ready work id %q exists in both issues and wisps", wisp.ID)
+		if wispByID[issue.ID] == nil {
+			kept = append(kept, issue)
 		}
-		ordered = append(ordered, wisp)
 	}
-	sortReadyIssues(ordered, filter.SortPolicy)
-	if filter.Limit > 0 && len(ordered) > filter.Limit {
-		ordered = ordered[:filter.Limit]
+	kept = append(kept, wisps...)
+	sortReadyIssues(kept, filter.SortPolicy)
+	if filter.Limit > 0 && len(kept) > filter.Limit {
+		kept = kept[:filter.Limit]
 	}
-	return ordered, nil
+	return kept, nil
 }
 
 func getReadyWispsInTx(ctx context.Context, tx *sql.Tx, filter types.WorkFilter, deferredChildIDs []string) ([]*types.Issue, error) {

--- a/internal/storage/issueops/ready_work_counts.go
+++ b/internal/storage/issueops/ready_work_counts.go
@@ -51,26 +51,29 @@ func GetReadyWorkWithCountsInTx(ctx context.Context, tx *sql.Tx, filter types.Wo
 		return out, nil
 	}
 
-	seen := make(map[string]struct{}, len(out))
-	for _, iwc := range out {
-		if iwc != nil && iwc.Issue != nil {
-			seen[iwc.Issue.ID] = struct{}{}
+	// Prefer the canonical wisp record when an ID exists in both tables (be-iabdi).
+	wispByID := make(map[string]struct{}, len(wisps))
+	for _, w := range wisps {
+		if w != nil && w.Issue != nil {
+			wispByID[w.Issue.ID] = struct{}{}
 		}
 	}
-	for _, w := range wisps {
-		if w == nil || w.Issue == nil {
+	var kept []*types.IssueWithCounts
+	for _, iwc := range out {
+		if iwc == nil || iwc.Issue == nil {
+			kept = append(kept, iwc)
 			continue
 		}
-		if _, dup := seen[w.Issue.ID]; dup {
-			return nil, fmt.Errorf("get ready work with counts: id %q exists in both issues and wisps", w.Issue.ID)
+		if _, dup := wispByID[iwc.Issue.ID]; !dup {
+			kept = append(kept, iwc)
 		}
-		out = append(out, w)
 	}
-	sortIssuesWithCountsByPolicy(out, filter.SortPolicy)
-	if filter.Limit > 0 && len(out) > filter.Limit {
-		out = out[:filter.Limit]
+	kept = append(kept, wisps...)
+	sortIssuesWithCountsByPolicy(kept, filter.SortPolicy)
+	if filter.Limit > 0 && len(kept) > filter.Limit {
+		kept = kept[:filter.Limit]
 	}
-	return out, nil
+	return kept, nil
 }
 
 func sortIssuesWithCountsByPolicy(items []*types.IssueWithCounts, policy types.SortPolicy) {

--- a/internal/storage/issueops/ready_work_test.go
+++ b/internal/storage/issueops/ready_work_test.go
@@ -122,7 +122,7 @@ func TestGetReadyWorkInTx_PropagatesDeferredParentChildError(t *testing.T) {
 	}
 }
 
-func TestLoadStatusByIDInTxErrorsOnIssueWispCollision(t *testing.T) {
+func TestLoadStatusByIDInTxPrefersWispOnCollision(t *testing.T) {
 	t.Parallel()
 
 	_, mock, tx := beginMockTx(t)
@@ -133,31 +133,37 @@ func TestLoadStatusByIDInTxErrorsOnIssueWispCollision(t *testing.T) {
 		WithArgs("dup-id").
 		WillReturnRows(sqlmock.NewRows([]string{"id", "status"}).AddRow("dup-id", types.StatusClosed))
 
-	_, err := loadStatusByIDInTx(context.Background(), tx, []string{"dup-id"})
-	if err == nil {
-		t.Fatal("expected duplicate issue/wisp status error")
+	got, err := loadStatusByIDInTx(context.Background(), tx, []string{"dup-id"})
+	if err != nil {
+		t.Fatalf("loadStatusByIDInTx error = %v, want no error on cross-table dup", err)
 	}
-	if !strings.Contains(err.Error(), `id "dup-id" exists in both issues and wisps`) {
-		t.Fatalf("error = %v, want duplicate issue/wisp context", err)
+	if got["dup-id"] != types.StatusClosed {
+		t.Errorf("status = %v, want %v (wisp canonical preferred over issues)", got["dup-id"], types.StatusClosed)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)
 	}
 }
 
-func TestMergeReadyWispsErrorsOnIssueWispCollision(t *testing.T) {
+func TestMergeReadyWispsPrefersWispOnCollision(t *testing.T) {
 	t.Parallel()
 
-	_, err := mergeReadyWisps(
-		[]*types.Issue{{ID: "dup-id", Status: types.StatusOpen}},
-		[]*types.Issue{{ID: "dup-id", Status: types.StatusClosed}},
+	issuesCopy := &types.Issue{ID: "dup-id", Status: types.StatusOpen, Title: "issues copy"}
+	wispCopy := &types.Issue{ID: "dup-id", Status: types.StatusClosed, Title: "wisp canonical"}
+
+	got, err := mergeReadyWisps(
+		[]*types.Issue{issuesCopy},
+		[]*types.Issue{wispCopy},
 		types.WorkFilter{},
 	)
-	if err == nil {
-		t.Fatal("expected duplicate issue/wisp ready-work error")
+	if err != nil {
+		t.Fatalf("mergeReadyWisps error = %v, want no error on cross-table dup", err)
 	}
-	if !strings.Contains(err.Error(), `id "dup-id" exists in both issues and wisps`) {
-		t.Fatalf("error = %v, want duplicate issue/wisp context", err)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1 (deduped)", len(got))
+	}
+	if got[0].Title != "wisp canonical" {
+		t.Errorf("title = %q, want %q (wisp preferred over issues copy)", got[0].Title, "wisp canonical")
 	}
 }
 

--- a/internal/storage/issueops/ready_work_test.go
+++ b/internal/storage/issueops/ready_work_test.go
@@ -151,14 +151,11 @@ func TestMergeReadyWispsPrefersWispOnCollision(t *testing.T) {
 	issuesCopy := &types.Issue{ID: "dup-id", Status: types.StatusOpen, Title: "issues copy"}
 	wispCopy := &types.Issue{ID: "dup-id", Status: types.StatusClosed, Title: "wisp canonical"}
 
-	got, err := mergeReadyWisps(
+	got := mergeReadyWisps(
 		[]*types.Issue{issuesCopy},
 		[]*types.Issue{wispCopy},
 		types.WorkFilter{},
 	)
-	if err != nil {
-		t.Fatalf("mergeReadyWisps error = %v, want no error on cross-table dup", err)
-	}
 	if len(got) != 1 {
 		t.Fatalf("len(got) = %d, want 1 (deduped)", len(got))
 	}

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -59,16 +59,20 @@ func SearchIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter type
 			return nil, fmt.Errorf("search wisps (merge): %w", wispErr)
 		}
 		if len(wispResults) > 0 {
-			seen := make(map[string]bool, len(results))
-			for _, issue := range results {
-				seen[issue.ID] = true
+			// Prefer the canonical wisp record when an ID exists in both tables.
+			// Cross-table dups are a transient data-integrity issue (be-iabdi);
+			// hard-erroring breaks every lookup city-wide.
+			wispByID := make(map[string]*types.Issue, len(wispResults))
+			for _, w := range wispResults {
+				wispByID[w.ID] = w
 			}
-			for _, issue := range wispResults {
-				if seen[issue.ID] {
-					return nil, fmt.Errorf("id %q exists in both issues and wisps", issue.ID)
+			var filtered []*types.Issue
+			for _, r := range results {
+				if wispByID[r.ID] == nil {
+					filtered = append(filtered, r)
 				}
-				results = append(results, issue)
 			}
+			results = append(filtered, wispResults...)
 		}
 	}
 

--- a/internal/storage/issueops/search_counts.go
+++ b/internal/storage/issueops/search_counts.go
@@ -75,22 +75,25 @@ func SearchIssuesWithCountsInTx(ctx context.Context, tx *sql.Tx, query string, f
 		return finishSearchIssuesWithCounts(out, filter), nil
 	}
 
-	seen := make(map[string]struct{}, len(out))
-	for _, iwc := range out {
-		if iwc != nil && iwc.Issue != nil {
-			seen[iwc.Issue.ID] = struct{}{}
+	// Prefer the canonical wisp record when an ID exists in both tables (be-iabdi).
+	wispByID := make(map[string]struct{}, len(wisps))
+	for _, w := range wisps {
+		if w != nil && w.Issue != nil {
+			wispByID[w.Issue.ID] = struct{}{}
 		}
 	}
-	for _, w := range wisps {
-		if w == nil || w.Issue == nil {
+	var kept []*types.IssueWithCounts
+	for _, iwc := range out {
+		if iwc == nil || iwc.Issue == nil {
+			kept = append(kept, iwc)
 			continue
 		}
-		if _, dup := seen[w.Issue.ID]; dup {
-			return nil, fmt.Errorf("search issues with counts: id %q exists in both issues and wisps", w.Issue.ID)
+		if _, dup := wispByID[iwc.Issue.ID]; !dup {
+			kept = append(kept, iwc)
 		}
-		out = append(out, w)
 	}
-	return finishSearchIssuesWithCounts(out, filter), nil
+	kept = append(kept, wisps...)
+	return finishSearchIssuesWithCounts(kept, filter), nil
 }
 
 func runFilterSearchQueryInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter, tables FilterTables, includeWispReverseDeps bool) ([]*types.IssueWithCounts, error) {


### PR DESCRIPTION
## Summary

- **Lookup robustness** — five merge sites in `issueops` (search.go, ready_work.go, ready_work_counts.go, search_counts.go, dependency_queries.go) replaced the hard-error on cross-table ID collision with graceful dedup: the wisp record is preferred (canonical) and the issues-table copy is silently dropped. This fixes the city-wide lookup breakage that occurred when any single ID existed in both tables.

- **CGO-free duplicate detection** — new `CheckCrossTableDuplicates` in the doctor package (no CGO build tag) uses MySQL wire protocol via the existing `fix.openDoltDB` path to count IDs present in both tables. Wired into `bd doctor --check=validate` (reports `StatusError`) and `bd doctor --check=validate --fix` (calls new `fix.CrossTableDuplicates` which deletes stale issues rows and their children, keeping the wisp canonical). Works on any dolt-server backend without requiring an embedded Dolt build.

- **Test updates** — three tests that previously asserted the old hard-error behaviour (`TestSearchIssuesRejectsDuplicateIssueWispID`, `TestLoadStatusByIDInTxErrorsOnIssueWispCollision`, `TestMergeReadyWispsErrorsOnIssueWispCollision`) updated to assert the new graceful wisp-preferring dedup.

Fixes: be-iabdi (issues/wisps id collision: message→wisp migration leaves dup rows; lookup hard-errors on dual-presence)

## Test plan

- [ ] `CGO_ENABLED=0 go build -tags gms_pure_go ./...` builds cleanly
- [ ] `CGO_ENABLED=0 go test -tags gms_pure_go ./internal/storage/issueops/...` passes
- [ ] `CGO_ENABLED=0 go test -tags gms_pure_go -run TestSearchIssuesPreferWispOnDuplicateID ./internal/storage/dolt/...` passes
- [ ] `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd/doctor/fix/...` passes
- [ ] `CGO_ENABLED=0 go vet -tags gms_pure_go ./cmd/bd/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)