### PR TITLE
perf(dolt): reduce remote-Dolt round trips on read commands (showcase — do not merge)

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -10,6 +10,23 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// storeAlreadyHasIssues reports whether the given store's `issues` table
+// already contains at least one row. Used by maybeAutoImportJSONL to skip
+// the slow server-mode fallback import when the database is clearly not
+// empty (a re-import on every write is a v1.0.4 server-mode bug — see
+// GH#3880 and GH#4128).
+//
+// Best-effort: any error (table missing, transient network glitch, etc.)
+// is treated as "unknown emptiness", which preserves the pre-existing
+// behaviour of attempting the import.
+func storeAlreadyHasIssues(ctx context.Context, s storage.DoltStorage) bool {
+	issues, err := s.SearchIssues(ctx, "", types.IssueFilter{Limit: 1})
+	if err != nil {
+		return false
+	}
+	return len(issues) > 0
+}
+
 // jsonlImporter is implemented by stores that support single-transaction
 // JSONL import (currently EmbeddedDoltStore). Stores that don't implement
 // this fall back to the multi-call path.
@@ -71,6 +88,17 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 	}
 
 	// Fallback for non-embedded stores: multi-call path (original behavior).
+	// In server mode this path has no atomic emptiness check, so on v1.0.4
+	// every write triggered a full re-import of issues.jsonl (~150 s for a
+	// 200-issue corpus over a ~200 ms RTT link). Guard with a cheap probe
+	// of the issues table — if the database already has data, we have
+	// nothing to import. Matches the spirit of the embedded path's
+	// in-transaction emptiness check (see ImportJSONLData). See GH#3880
+	// and GH#4128.
+	if storeAlreadyHasIssues(ctx, s) {
+		return
+	}
+
 	fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
 
 	result, err := importFromLocalJSONLFull(ctx, s, jsonlPath)

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -59,7 +59,19 @@ func maybeAutoExport(ctx context.Context) {
 	state := loadExportAutoState(beadsDir)
 	interval := config.GetDuration("export.interval")
 	if interval == 0 {
-		interval = 60 * time.Second
+		// Default throttle: 60 s for the embedded backend, 5 min for the
+		// remote-Dolt backend. The remote case rebuilds the JSONL with a
+		// full SearchIssues + 5 hydration queries every fire, which costs
+		// 5-10 s on a 200 ms RTT link. With dolt_mode=server the database
+		// is already the source of truth and the JSONL is a convenience
+		// for git-tracking and offline replay — a 5-minute lag is fine
+		// for that role and skips most per-write rebuild churn.
+		// Users can override by setting export.interval explicitly.
+		if serverMode {
+			interval = 5 * time.Minute
+		} else {
+			interval = 60 * time.Second
+		}
 	}
 	if !state.Timestamp.IsZero() && time.Since(state.Timestamp) < interval {
 		debug.Logf("auto-export: throttled (last export %s ago, interval %s)\n",

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/steveyegge/beads/internal/atomicfile"
@@ -177,11 +178,27 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 		for i, issue := range issues {
 			issueIDs[i] = issue.ID
 		}
-		labelsMap, _ := store.GetLabelsForIssues(ctx, issueIDs)
-		allDeps, _ := store.GetDependencyRecordsForIssues(ctx, issueIDs)
-		commentsMap, _ := store.GetCommentsForIssues(ctx, issueIDs)
-		commentCounts, _ := store.GetCommentCounts(ctx, issueIDs)
-		depCounts, _ := store.GetDependencyCounts(ctx, issueIDs)
+		// Parallelize the five independent bulk-load calls. On a remote
+		// Dolt connection each is a full BEGIN/SELECT/ROLLBACK round trip
+		// (~1.2 s on a ~200 ms RTT link); running them sequentially was
+		// ~6 s of pure wall-clock waste inside maybeAutoExport. The pool's
+		// MaxOpenConns is 10 by default so five concurrent reads share
+		// the warm pool without forcing extra handshakes.
+		var (
+			labelsMap     map[string][]string
+			allDeps       map[string][]*types.Dependency
+			commentsMap   map[string][]*types.Comment
+			commentCounts map[string]int
+			depCounts     map[string]*types.DependencyCounts
+			wg            sync.WaitGroup
+		)
+		wg.Add(5)
+		go func() { defer wg.Done(); labelsMap, _ = store.GetLabelsForIssues(ctx, issueIDs) }()
+		go func() { defer wg.Done(); allDeps, _ = store.GetDependencyRecordsForIssues(ctx, issueIDs) }()
+		go func() { defer wg.Done(); commentsMap, _ = store.GetCommentsForIssues(ctx, issueIDs) }()
+		go func() { defer wg.Done(); commentCounts, _ = store.GetCommentCounts(ctx, issueIDs) }()
+		go func() { defer wg.Done(); depCounts, _ = store.GetDependencyCounts(ctx, issueIDs) }()
+		wg.Wait()
 
 		for _, issue := range issues {
 			issue.Labels = labelsMap[issue.ID]

--- a/cmd/bd/list.go
+++ b/cmd/bd/list.go
@@ -947,9 +947,14 @@ var listCmd = &cobra.Command{
 			}
 
 			// Regular tree display (no parent filter)
-			// Load dependencies for tree structure
-			// Best effort: display gracefully degrades with empty data
-			allDeps, _ := activeStore.GetAllDependencyRecords(ctx)
+			// Load dependencies for tree structure (skipped when there are no
+			// issues — the dependency query would otherwise burn a full read
+			// transaction against the remote server for an empty result set).
+			// Best effort: display gracefully degrades with empty data.
+			var allDeps map[string][]*types.Dependency
+			if len(issues) > 0 {
+				allDeps, _ = activeStore.GetAllDependencyRecords(ctx)
+			}
 			displayPrettyListWithDeps(issues, false, allDeps)
 			printTruncationHint(truncated, effectiveLimit)
 			return

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1109,16 +1109,19 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		// Auto-backup: export JSONL to .beads/backup/ if enabled and due
-		maybeAutoBackup(rootCtx)
-
-		// Auto-export: write git-tracked JSONL for portability if enabled and due
-		maybeAutoExport(rootCtx)
-
-		// Auto-push: push to Dolt remote if enabled and due.
-		// Skip for read-only commands to avoid unnecessary network operations
-		// and metadata writes on commands like bd list/show/ready (GH#2191).
+		// Auto-backup, auto-export, auto-push: skip for read-only commands.
+		// These post-run maintenance tasks issue extra round trips (GetCurrentCommit,
+		// SearchIssues for export, etc.) that bloat a "free" bd list/show/ready
+		// against a remote Dolt server by ~1s. They make sense after mutations,
+		// not after pure reads, since a read can't have produced data to back up.
 		if !isReadOnlyCommand(cmd.Name()) {
+			// Auto-backup: export JSONL to .beads/backup/ if enabled and due
+			maybeAutoBackup(rootCtx)
+
+			// Auto-export: write git-tracked JSONL for portability if enabled and due
+			maybeAutoExport(rootCtx)
+
+			// Auto-push: push to Dolt remote if enabled and due.
 			maybeAutoPush(rootCtx)
 		}
 

--- a/cmd/bd/routing_read.go
+++ b/cmd/bd/routing_read.go
@@ -12,9 +12,40 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 )
 
+// routingConfigKeys is the fixed set of config keys the routing subsystem
+// reads on every command. Loading them all in one GetAllConfig call avoids
+// six sequential round trips against a remote Dolt server.
+var routingConfigKeys = []string{
+	"routing.mode",
+	"routing.contributor",
+	"routing.default",
+	"routing.maintainer",
+	"contributor.auto_route",
+	"contributor.planning_repo",
+}
+
+// resolveRoutingConfigValue mirrors getRoutingConfigValue but reads the DB
+// value from a pre-fetched map instead of issuing a per-key SQL query.
+func resolveRoutingConfigValue(key string, dbValues map[string]string) string {
+	// Only trust YAML/env values that were explicitly set, not Viper defaults.
+	if src := config.GetValueSource(key); src != config.SourceDefault {
+		value := strings.TrimSpace(config.GetString(key))
+		if value != "" {
+			return value
+		}
+	}
+	if dbValues == nil {
+		return ""
+	}
+	return strings.TrimSpace(dbValues[key])
+}
+
 // getRoutingConfigValue resolves routing config from YAML/env first, then DB config.
 // Only uses the YAML value if it was explicitly set (not a Viper default), so that
 // DB-stored values aren't shadowed by defaults like "~/.beads-planning".
+//
+// Deprecated for the bd-list hot path: see resolveRoutingConfigValue, which
+// reads from a pre-fetched map. Kept for callers that only need one key.
 func getRoutingConfigValue(ctx context.Context, store storage.DoltStorage, key string) string {
 	// Only trust YAML/env values that were explicitly set, not Viper defaults.
 	if src := config.GetValueSource(key); src != config.SourceDefault {
@@ -44,24 +75,42 @@ func determineAutoRoutedRepoPath(ctx context.Context, store storage.DoltStorage)
 		debug.Logf("Warning: failed to detect user role: %v\n", err)
 	}
 
+	// Batch-fetch the routing keys in a single SQL query. The previous
+	// implementation issued one GetConfig per key (6 round trips); on a
+	// 200ms-RTT remote Dolt connection that alone cost ~1.2s per command.
+	var dbValues map[string]string
+	if store != nil {
+		all, allErr := store.GetAllConfig(ctx)
+		if allErr != nil {
+			debug.Logf("DEBUG: failed to read routing config from store: %v\n", allErr)
+		} else {
+			dbValues = make(map[string]string, len(routingConfigKeys))
+			for _, k := range routingConfigKeys {
+				if v, ok := all[k]; ok {
+					dbValues[k] = v
+				}
+			}
+		}
+	}
+
 	// Build routing config with backward compatibility for legacy contributor.* keys.
-	routingMode := getRoutingConfigValue(ctx, store, "routing.mode")
-	contributorRepo := getRoutingConfigValue(ctx, store, "routing.contributor")
+	routingMode := resolveRoutingConfigValue("routing.mode", dbValues)
+	contributorRepo := resolveRoutingConfigValue("routing.contributor", dbValues)
 
 	// Backward compatibility - fall back to legacy contributor.* keys
 	if routingMode == "" {
-		if getRoutingConfigValue(ctx, store, "contributor.auto_route") == "true" {
+		if resolveRoutingConfigValue("contributor.auto_route", dbValues) == "true" {
 			routingMode = "auto"
 		}
 	}
 	if contributorRepo == "" {
-		contributorRepo = getRoutingConfigValue(ctx, store, "contributor.planning_repo")
+		contributorRepo = resolveRoutingConfigValue("contributor.planning_repo", dbValues)
 	}
 
 	routingConfig := &routing.RoutingConfig{
 		Mode:             routingMode,
-		DefaultRepo:      getRoutingConfigValue(ctx, store, "routing.default"),
-		MaintainerRepo:   getRoutingConfigValue(ctx, store, "routing.maintainer"),
+		DefaultRepo:      resolveRoutingConfigValue("routing.default", dbValues),
+		MaintainerRepo:   resolveRoutingConfigValue("routing.maintainer", dbValues),
 		ContributorRepo:  contributorRepo,
 		ExplicitOverride: "",
 	}

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -66,8 +66,19 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 	return nil
 }
 
-// GetConfig retrieves a configuration value
+// GetConfig retrieves a configuration value. Honors the per-store cache
+// populated by preloadSessionCaches so write commands (which typically
+// look up half a dozen config keys in their PreRun + PostRun hooks) do
+// not pay a round trip per key once the cache is warm.
 func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
+	s.cacheMu.Lock()
+	if s.allConfigCached {
+		v := s.allConfigCache[key]
+		s.cacheMu.Unlock()
+		return v, nil
+	}
+	s.cacheMu.Unlock()
+
 	var value string
 	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
@@ -34,7 +35,10 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 		return err
 	}
 
-	// Invalidate caches for keys that affect cached data
+	// Invalidate caches for keys that affect cached data. The all-config
+	// cache is also invalidated on every SetConfig because keys outside the
+	// switch list above (routing.*, contributor.*, custom.*) are read via
+	// GetAllConfig from the routing module.
 	s.cacheMu.Lock()
 	switch key {
 	case "status.custom":
@@ -48,6 +52,8 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 		s.infraTypeCached = false
 		s.infraTypeCache = nil
 	}
+	s.allConfigCached = false
+	s.allConfigCache = nil
 	s.cacheMu.Unlock()
 
 	// Rebuild status views when custom statuses change
@@ -71,8 +77,135 @@ func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
 	return value, err
 }
 
-// GetAllConfig retrieves all configuration values
+// preloadSessionCaches warms the per-store caches that bd list / show /
+// ready would otherwise populate via separate round trips on every command.
+// Best-effort: any failure leaves the caches cold and the lazy loaders take
+// over. Designed to be called once, from newServerMode, on a freshly
+// established connection — adds at most one round trip up front in exchange
+// for eliminating ~4-6 round trips spread across the rest of the command.
+//
+// Caches populated:
+//   - allConfigCache (every config key/value pair)
+//   - customStatusCache + customStatusDetailedCache (derived from
+//     status.custom config string, matching the resolver's fallback path)
+//   - customTypeCache (derived from types.custom)
+//   - infraTypeCache (derived from types.infra, default list otherwise)
+//   - wispsStateKnown / wispsEmpty (cheap existence probe used to skip
+//     the per-SearchIssues wisps probe)
+//
+// The custom-status / custom-type derivations skip the normalized
+// custom_statuses / custom_types tables on purpose: those tables are kept
+// in sync with the config strings by SetConfig + SyncCustomStatusesTable,
+// and reading from the config string saves us another round trip without
+// changing the resolved value in normal operation.
+func (s *DoltStore) preloadSessionCaches(ctx context.Context) {
+	// Use the raw conn helper (no BEGIN/ROLLBACK) and send both queries as
+	// a single multi-statement payload — server processes them back-to-back
+	// in one round trip.
+	_ = s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
+		rows, err := q.QueryContext(ctx,
+			"SELECT `key`, value FROM config; "+
+				"SELECT 1 FROM wisps LIMIT 1")
+		if err != nil {
+			// Most likely: a pre-migration database without the config or
+			// wisps table. Leave caches cold and let the lazy loaders cope.
+			return nil
+		}
+		defer rows.Close()
+
+		// --- result set 1: config table ---
+		all := make(map[string]string)
+		for rows.Next() {
+			var k, v sql.NullString
+			if scanErr := rows.Scan(&k, &v); scanErr == nil && k.Valid {
+				all[k.String] = v.String
+			}
+		}
+
+		// --- result set 2: wisps probe (may not exist on old schemas) ---
+		wispsEmpty := true
+		if rows.NextResultSet() {
+			if rows.Next() {
+				wispsEmpty = false // at least one row → not empty
+			}
+		} else {
+			// Driver reported no next set — usually means the wisps query
+			// errored. Treat as missing/empty so we still skip the probe.
+			wispsEmpty = true
+		}
+
+		s.cacheMu.Lock()
+		s.allConfigCache = all
+		s.allConfigCached = true
+
+		// Custom statuses (derive from status.custom string)
+		if v := all["status.custom"]; v != "" {
+			if parsed, perr := types.ParseCustomStatusConfig(v); perr == nil {
+				s.customStatusDetailedCache = parsed
+				s.customStatusCache = types.CustomStatusNames(parsed)
+			}
+		}
+		s.customStatusCached = true
+
+		// Custom types (derive from types.custom string)
+		if v := all["types.custom"]; v != "" {
+			s.customTypeCache = parseCommaListFromConfig(v)
+		}
+		s.customTypeCached = true
+
+		// Infra types (derive from types.infra string, default list otherwise)
+		var infraList []string
+		if v := all["types.infra"]; v != "" {
+			infraList = parseCommaListFromConfig(v)
+		} else {
+			infraList = storage.DefaultInfraTypes()
+		}
+		m := make(map[string]bool, len(infraList))
+		for _, t := range infraList {
+			if t = strings.TrimSpace(t); t != "" {
+				m[t] = true
+			}
+		}
+		s.infraTypeCache = m
+		s.infraTypeCached = true
+
+		// Wisps existence
+		s.wispsEmpty = wispsEmpty
+		s.wispsStateKnown = true
+		s.cacheMu.Unlock()
+		return nil
+	})
+}
+
+// parseCommaListFromConfig splits a comma-separated config value into trimmed
+// non-empty entries. Mirrors the helper in issueops without importing it.
+func parseCommaListFromConfig(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// GetAllConfig retrieves all configuration values. Honors the per-store
+// cache populated by preloadSessionCaches so the routing module and other
+// repeat callers do not incur a round trip after store-open.
 func (s *DoltStore) GetAllConfig(ctx context.Context) (map[string]string, error) {
+	s.cacheMu.Lock()
+	if s.allConfigCached {
+		// Copy so callers can mutate without poisoning the cache.
+		out := make(map[string]string, len(s.allConfigCache))
+		for k, v := range s.allConfigCache {
+			out[k] = v
+		}
+		s.cacheMu.Unlock()
+		return out, nil
+	}
+	s.cacheMu.Unlock()
+
 	var result map[string]string
 	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
@@ -84,9 +217,16 @@ func (s *DoltStore) GetAllConfig(ctx context.Context) (map[string]string, error)
 
 // DeleteConfig removes a configuration value
 func (s *DoltStore) DeleteConfig(ctx context.Context, key string) error {
-	return s.withRetryTx(ctx, func(tx *sql.Tx) error {
+	err := s.withRetryTx(ctx, func(tx *sql.Tx) error {
 		return issueops.DeleteConfigInTx(ctx, tx, key)
 	})
+	if err == nil {
+		s.cacheMu.Lock()
+		s.allConfigCached = false
+		s.allConfigCache = nil
+		s.cacheMu.Unlock()
+	}
+	return err
 }
 
 // SetMetadata sets a metadata value

--- a/internal/storage/dolt/config.go
+++ b/internal/storage/dolt/config.go
@@ -63,9 +63,9 @@ func (s *DoltStore) SetConfig(ctx context.Context, key, value string) error {
 // GetConfig retrieves a configuration value
 func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
 	var value string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		value, err = issueops.GetConfigInTx(ctx, tx, key)
+		value, err = issueops.GetConfigInTx(ctx, q, key)
 		return err
 	})
 	return value, err
@@ -74,9 +74,9 @@ func (s *DoltStore) GetConfig(ctx context.Context, key string) (string, error) {
 // GetAllConfig retrieves all configuration values
 func (s *DoltStore) GetAllConfig(ctx context.Context) (map[string]string, error) {
 	var result map[string]string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		result, err = issueops.GetAllConfigInTx(ctx, tx)
+		result, err = issueops.GetAllConfigInTx(ctx, q)
 		return err
 	})
 	return result, err
@@ -99,9 +99,9 @@ func (s *DoltStore) SetMetadata(ctx context.Context, key, value string) error {
 // GetMetadata retrieves a metadata value
 func (s *DoltStore) GetMetadata(ctx context.Context, key string) (string, error) {
 	var value string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		value, err = issueops.GetMetadataInTx(ctx, tx, key)
+		value, err = issueops.GetMetadataInTx(ctx, q, key)
 		return err
 	})
 	return value, err
@@ -119,9 +119,9 @@ func (s *DoltStore) SetLocalMetadata(ctx context.Context, key, value string) err
 // Returns ("", nil) if the key does not exist.
 func (s *DoltStore) GetLocalMetadata(ctx context.Context, key string) (string, error) {
 	var value string
-	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
+	err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
 		var err error
-		value, err = issueops.GetLocalMetadataInTx(ctx, tx, key)
+		value, err = issueops.GetLocalMetadataInTx(ctx, q, key)
 		return err
 	})
 	return value, err

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -16,18 +16,26 @@ import (
 // Delegates to issueops.SearchIssuesInTx for shared query logic, except when
 // the session-scoped cache (populated by preloadSessionCaches) tells us the
 // wisps table is empty or missing — in that case the wisps merge step is a
-// guaranteed no-op and we skip it to save a round trip.
+// guaranteed no-op, and we additionally run the search on a pooled *sql.Conn
+// instead of a tx, skipping the BEGIN/ROLLBACK round trips entirely. For a
+// remote Dolt server that drops SearchIssues from 4 RTT (~800ms) to 2 RTT
+// (~400ms), or 1 RTT (~200ms) when label hydration is also a no-op (empty
+// result set).
 func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
-	skipWispsMerge := s.canSkipWispsMerge(filter)
+	if s.canSkipWispsMerge(filter) {
+		var result []*types.Issue
+		err := s.withReadConn(ctx, func(q issueops.SQLQuerier) error {
+			var err error
+			result, err = issueops.SearchIssuesNonWispInTx(ctx, q, query, filter)
+			return err
+		})
+		return result, err
+	}
 
 	var result []*types.Issue
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		if skipWispsMerge {
-			result, err = issueops.SearchIssuesNonWispInTx(ctx, tx, query, filter)
-		} else {
-			result, err = issueops.SearchIssuesInTx(ctx, tx, query, filter)
-		}
+		result, err = issueops.SearchIssuesInTx(ctx, tx, query, filter)
 		return err
 	})
 	return result, err

--- a/internal/storage/dolt/queries.go
+++ b/internal/storage/dolt/queries.go
@@ -13,15 +13,39 @@ import (
 )
 
 // SearchIssues finds issues matching query and filters.
-// Delegates to issueops.SearchIssuesInTx for shared query logic.
+// Delegates to issueops.SearchIssuesInTx for shared query logic, except when
+// the session-scoped cache (populated by preloadSessionCaches) tells us the
+// wisps table is empty or missing — in that case the wisps merge step is a
+// guaranteed no-op and we skip it to save a round trip.
 func (s *DoltStore) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	skipWispsMerge := s.canSkipWispsMerge(filter)
+
 	var result []*types.Issue
 	err := s.withReadTx(ctx, func(tx *sql.Tx) error {
 		var err error
-		result, err = issueops.SearchIssuesInTx(ctx, tx, query, filter)
+		if skipWispsMerge {
+			result, err = issueops.SearchIssuesNonWispInTx(ctx, tx, query, filter)
+		} else {
+			result, err = issueops.SearchIssuesInTx(ctx, tx, query, filter)
+		}
 		return err
 	})
 	return result, err
+}
+
+// canSkipWispsMerge reports whether the wisps merge step in SearchIssues can
+// be skipped safely. True when the per-store cache knows the wisps table is
+// empty or missing AND the caller is not explicitly asking for ephemeral
+// rows (which would route directly to wisps).
+func (s *DoltStore) canSkipWispsMerge(filter types.IssueFilter) bool {
+	if filter.Ephemeral != nil && *filter.Ephemeral {
+		return false // caller wants ephemeral-only, don't skip
+	}
+	s.cacheMu.Lock()
+	known := s.wispsStateKnown
+	empty := s.wispsEmpty
+	s.cacheMu.Unlock()
+	return known && empty
 }
 
 // GetReadyWork returns issues that are ready to work on (not blocked).

--- a/internal/storage/dolt/sqltrace.go
+++ b/internal/storage/dolt/sqltrace.go
@@ -1,0 +1,116 @@
+package dolt
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// traceSQL is true when BD_DOLT_TRACE_SQL=1. It enables coarse per-call
+// stderr logging of SQL operations so we can count round trips and identify
+// hot spots on slow remote-Dolt connections. Off by default.
+var traceSQL = os.Getenv("BD_DOLT_TRACE_SQL") == "1"
+
+var traceStart = time.Now()
+var traceSeq atomic.Int64
+
+// helperFrames are the internal helper functions we want to skip past when
+// reporting the caller of a SQL op. We want to surface the DoltStore method
+// (e.g. GetMetadata) or the cmd/bd caller, not the helper itself.
+var helperFrames = []string{
+	".withReadTx", ".withReadConn", ".withWriteTx", ".withRetryTx",
+	".queryContext", ".execContext", ".queryRowContext",
+	".sqlTraceStart", ".callerLabel",
+}
+
+// callerLabel walks up the stack and returns a short pkg.Func label for
+// the first frame that isn't one of our internal SQL helpers.
+func callerLabel(skip int) string {
+	pcs := make([]uintptr, 16)
+	n := runtime.Callers(skip+1, pcs)
+	if n == 0 {
+		return "?"
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		fr, more := frames.Next()
+		isHelper := false
+		for _, h := range helperFrames {
+			if strings.HasSuffix(fr.Function, h) || strings.Contains(fr.Function, h+".") {
+				isHelper = true
+				break
+			}
+		}
+		if !isHelper {
+			short := fr.Function
+			if idx := strings.LastIndex(short, "/"); idx >= 0 {
+				short = short[idx+1:]
+			}
+			return short
+		}
+		if !more {
+			break
+		}
+	}
+	return "?"
+}
+
+func sqlTraceStart(op string) func(extraFmt string, args ...any) {
+	if !traceSQL {
+		return func(string, ...any) {}
+	}
+	seq := traceSeq.Add(1)
+	t0 := time.Now()
+	rel := t0.Sub(traceStart)
+	caller := callerLabel(2)
+	stack := ""
+	if os.Getenv("BD_DOLT_TRACE_STACK") == "1" {
+		stack = "\n" + callerStack(2)
+	}
+	fmt.Fprintf(os.Stderr, "[sqltrace %4d] %8.1fms BEGIN %-36s via %s%s\n",
+		seq, float64(rel.Microseconds())/1000.0, op, caller, stack)
+	return func(extraFmt string, args ...any) {
+		dt := time.Since(t0)
+		extra := ""
+		if extraFmt != "" {
+			extra = " " + strings.TrimSpace(fmt.Sprintf(extraFmt, args...))
+		}
+		fmt.Fprintf(os.Stderr, "[sqltrace %4d] +%7.1fms END   %-36s%s\n",
+			seq, float64(dt.Microseconds())/1000.0, op, extra)
+	}
+}
+
+func callerStack(skip int) string {
+	pcs := make([]uintptr, 24)
+	n := runtime.Callers(skip+1, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	var sb strings.Builder
+	for {
+		fr, more := frames.Next()
+		short := fr.Function
+		if idx := strings.LastIndex(short, "/"); idx >= 0 {
+			short = short[idx+1:]
+		}
+		// skip runtime frames
+		if strings.HasPrefix(short, "runtime.") {
+			if !more {
+				break
+			}
+			continue
+		}
+		sb.WriteString("    ")
+		sb.WriteString(short)
+		sb.WriteString("  (")
+		sb.WriteString(fr.File)
+		sb.WriteString(":")
+		fmt.Fprintf(&sb, "%d", fr.Line)
+		sb.WriteString(")\n")
+		if !more {
+			break
+		}
+	}
+	return strings.TrimRight(sb.String(), "\n")
+}

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1561,10 +1561,30 @@ func databaseExistsOnServer(ctx context.Context, db *sql.DB, name string) (bool,
 	return false, rows.Err()
 }
 
+// schemaInitDoneKey is the local_metadata key used to remember that the
+// schema + compat migrations have been brought up to date for this clone.
+// The stored value is the embedded schema.LatestVersion() that was current
+// when the stamp was written. An older bd binary stamps a lower value, so a
+// newer bd binary (with more embedded migrations) will see stamped <
+// LatestVersion() and re-run its migrations correctly.
+const schemaInitDoneKey = "bd_schema_init_done_at_version"
+
 // initSchemaOnDB applies pending schema migrations and DoltStore-specific
 // backward-compat transforms. Uses the shared schema.MigrateUp runner which
 // tracks applied versions in the schema_migrations table.
+//
+// Fast path: if local_metadata already records that this clone has had
+// schema + compat migrations run at the current embedded schema version,
+// the entire chain is skipped. On a remote Dolt server this avoids the
+// 17 backward-compat-migration idempotent probes (~40 SQL round trips,
+// ~8 s end-to-end at 200 ms RTT). The stamp is rewritten only after a
+// successful full run, so on a fresh clone the first command pays the
+// full cost as before.
 func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
+	if schemaInitFastPathOK(ctx, db) {
+		return nil
+	}
+
 	applied, err := schema.MigrateUp(ctx, db)
 	if err != nil {
 		return fmt.Errorf("schema migration: %w", err)
@@ -1599,7 +1619,38 @@ func initSchemaOnDB(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("failed to run compat migrations: %w", err)
 	}
 
+	// Stamp completion in the dolt-ignored local_metadata table so future
+	// store opens can take the fast path. Best-effort — failing to stamp
+	// just means the next open re-runs the (idempotent) chain.
+	stampSchemaInitDone(ctx, db)
 	return nil
+}
+
+// schemaInitFastPathOK reports whether local_metadata records that the
+// schema + compat chain has already been brought up to the embedded latest
+// version. Any error (table missing on a fresh DB, missing row, malformed
+// value, transient network glitch) returns false, falling through to the
+// full migration path.
+func schemaInitFastPathOK(ctx context.Context, db *sql.DB) bool {
+	var stamped string
+	if err := db.QueryRowContext(ctx,
+		"SELECT value FROM local_metadata WHERE `key` = ?", schemaInitDoneKey,
+	).Scan(&stamped); err != nil {
+		return false
+	}
+	v, err := strconv.Atoi(strings.TrimSpace(stamped))
+	if err != nil {
+		return false
+	}
+	return v >= schema.LatestVersion()
+}
+
+func stampSchemaInitDone(ctx context.Context, db *sql.DB) {
+	// local_metadata is dolt-ignored, so this write never makes it into
+	// commit history — exactly what we want for clone-local cache state.
+	_, _ = db.ExecContext(ctx,
+		"REPLACE INTO local_metadata (`key`, value) VALUES (?, ?)",
+		schemaInitDoneKey, strconv.Itoa(schema.LatestVersion()))
 }
 
 func (s *DoltStore) initSchema(ctx context.Context) error {

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -178,8 +178,12 @@ type DoltStore struct {
 	infraTypeCached              bool                 // true once infraTypeCache has been populated
 	blockedIDsCache              []string             // cached result of computeBlockedIDs
 	blockedIDsCacheMap           map[string]bool
-	blockedIDsCached             bool // true once blockedIDsCache has been populated
-	blockedIDsCacheIncludesWisps bool // true if cache was computed with wisps
+	blockedIDsCached             bool              // true once blockedIDsCache has been populated
+	blockedIDsCacheIncludesWisps bool              // true if cache was computed with wisps
+	allConfigCache               map[string]string // cached result of GetAllConfig (populated by preloadSessionCaches)
+	allConfigCached              bool              // true once allConfigCache has been populated
+	wispsEmpty                   bool              // true if wisps table is missing or empty (skip wisps probe in SearchIssues)
+	wispsStateKnown              bool              // true once wispsEmpty has been resolved
 	cacheMu                      sync.Mutex
 
 	// OTel span attribute cache (avoids per-call allocation)
@@ -1205,6 +1209,15 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 			return nil, verifyErr
 		}
 	}
+
+	// Warm the per-store metadata caches (config map, custom statuses /
+	// types, infra types, wisps existence) in one round trip so the rest
+	// of the command does not pay 3-5 separate trips for data that almost
+	// never changes within a session. Best effort: failures leave the
+	// caches cold and lazy loaders cope.
+	preloadDone := sqlTraceStart("newServerMode.preloadSessionCaches")
+	store.preloadSessionCaches(ctx)
+	preloadDone("")
 
 	if isLocalHost(cfg.ServerHost) {
 		beadsDir := cfg.BeadsDir

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -604,12 +604,21 @@ func (s *DoltStore) withReadTx(ctx context.Context, fn func(tx *sql.Tx) error) e
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	beginDone := sqlTraceStart("withReadTx.BeginTx")
 	tx, err := s.db.BeginTx(ctx, nil)
+	beginDone("")
 	if err != nil {
 		return fmt.Errorf("begin read tx: %w", err)
 	}
-	defer func() { _ = tx.Rollback() }()
-	return fn(tx)
+	defer func() {
+		rbDone := sqlTraceStart("withReadTx.Rollback")
+		_ = tx.Rollback()
+		rbDone("")
+	}()
+	fnDone := sqlTraceStart("withReadTx.fn")
+	err = fn(tx)
+	fnDone("")
+	return err
 }
 
 // withReadConn runs fn against a single pooled connection without wrapping
@@ -626,12 +635,17 @@ func (s *DoltStore) withReadConn(ctx context.Context, fn func(q issueops.SQLQuer
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	connDone := sqlTraceStart("withReadConn.Conn")
 	conn, err := s.db.Conn(ctx)
+	connDone("")
 	if err != nil {
 		return fmt.Errorf("acquire read conn: %w", err)
 	}
 	defer func() { _ = conn.Close() }() // releases the conn back to the pool
-	return fn(conn)
+	fnDone := sqlTraceStart("withReadConn.fn")
+	err = fn(conn)
+	fnDone("")
+	return err
 }
 
 // withRetryTx wraps withWriteTx with retry logic for serialization failures
@@ -810,6 +824,7 @@ func (s *DoltStore) queryContext(ctx context.Context, query string, args ...any)
 			attribute.String("db.statement", spanSQL(query)),
 		)...),
 	)
+	traceDone := sqlTraceStart("DoltStore.queryContext")
 	var rows *sql.Rows
 	err := s.withRetry(ctx, func() error {
 		// Close any Rows from a previous failed attempt to avoid leaking connections.
@@ -821,6 +836,7 @@ func (s *DoltStore) queryContext(ctx context.Context, query string, args ...any)
 		rows, queryErr = s.db.QueryContext(ctx, query, args...)
 		return queryErr
 	})
+	traceDone("q=%s", spanSQL(query))
 	finalErr := wrapLockError(err)
 	endSpan(span, finalErr)
 	return rows, finalErr
@@ -1003,16 +1019,29 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 
 	// Fail-fast connectivity check before MySQL protocol initialization.
 	// This gives an immediate, clear error if the Dolt server isn't running,
-	// rather than waiting for MySQL driver timeouts.
+	// rather than waiting for MySQL driver timeouts, and is what triggers the
+	// auto-start path for local repo-managed servers.
+	//
+	// For remote, non-local TCP servers the preflight dial just burns one
+	// round trip every command — the MySQL driver's own Timeout already
+	// fast-fails when the server is unreachable, and auto-start is not an
+	// option anyway. Skip the preflight in that case.
 	var addr string
 	var conn net.Conn
 	var dialErr error
-	if cfg.ServerSocket != "" {
-		addr = cfg.ServerSocket
-		conn, dialErr = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
+	skipPreflight := cfg.ServerSocket == "" && !isLocalHost(cfg.ServerHost)
+	if !skipPreflight {
+		dialDone := sqlTraceStart("newServerMode.preflightDial")
+		if cfg.ServerSocket != "" {
+			addr = cfg.ServerSocket
+			conn, dialErr = net.DialTimeout("unix", cfg.ServerSocket, 500*time.Millisecond)
+		} else {
+			addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
+			conn, dialErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		}
+		dialDone("addr=%s", addr)
 	} else {
 		addr = net.JoinHostPort(cfg.ServerHost, fmt.Sprintf("%d", cfg.ServerPort))
-		conn, dialErr = net.DialTimeout("tcp", addr, 500*time.Millisecond)
 	}
 	if dialErr != nil {
 		// Auto-start: if enabled and connecting locally via TCP, start a server.
@@ -1081,7 +1110,9 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 				addr, dialErr, hint)
 		}
 	}
-	_ = conn.Close()
+	if conn != nil {
+		_ = conn.Close()
+	}
 
 	// If this process already owns a test-started auto-start server, later
 	// stores sharing it must participate in the refcount so one Close() does
@@ -1096,16 +1127,16 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	}
 
 	// Server mode: connect via MySQL protocol to dolt sql-server
+	openDone := sqlTraceStart("newServerMode.openServerConnection")
 	db, connStr, err := openServerConnection(ctx, cfg)
+	openDone("")
 	if err != nil {
 		return nil, err
 	}
-
-	// Test connection
-	if err := db.PingContext(ctx); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to ping Dolt database: %w", err)
-	}
+	// openServerConnection already pinged on the fast (read-only) path and
+	// already ran the catalog-wait ping on the create-if-missing path, so a
+	// second PingContext here would be a wasted ~1 RTT (~200 ms on a remote
+	// Dolt connection).
 
 	beadsDir := cfg.BeadsDir
 	if beadsDir == "" && cfg.Path != "" {
@@ -1166,7 +1197,10 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// they must match. A mismatch means this client is connected to the wrong
 	// project's Dolt server — refuse to proceed.
 	if !cfg.CreateIfMissing {
-		if verifyErr := store.verifyProjectIdentity(ctx, cfg.BeadsDir); verifyErr != nil {
+		vidDone := sqlTraceStart("newServerMode.verifyProjectIdentity")
+		verifyErr := store.verifyProjectIdentity(ctx, cfg.BeadsDir)
+		vidDone("")
+		if verifyErr != nil {
 			_ = db.Close()
 			return nil, verifyErr
 		}
@@ -1384,7 +1418,10 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// command (≈3 RTT on high-latency links). For init/bootstrap paths
 	// (CreateIfMissing=true) we still run the dual-pool dance below.
 	if !cfg.CreateIfMissing {
-		if err := db.PingContext(ctx); err != nil {
+		pingDone := sqlTraceStart("openServerConnection.fastPath.Ping")
+		err := db.PingContext(ctx)
+		pingDone("")
+		if err != nil {
 			_ = db.Close()
 			if isDatabaseNotFoundError(err) {
 				return nil, "", databaseNotFoundError(cfg)

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -42,6 +42,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/storage/dolt/migrations"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
+	"github.com/steveyegge/beads/internal/storage/issueops"
 	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"github.com/steveyegge/beads/internal/types"
@@ -609,6 +610,28 @@ func (s *DoltStore) withReadTx(ctx context.Context, fn func(tx *sql.Tx) error) e
 	}
 	defer func() { _ = tx.Rollback() }()
 	return fn(tx)
+}
+
+// withReadConn runs fn against a single pooled connection without wrapping
+// it in a transaction. For simple single-statement reads against a Dolt SQL
+// server in autocommit mode this saves 2 round trips per call (BEGIN +
+// ROLLBACK) compared to withReadTx — a 2-3x speedup on high-latency links.
+//
+// Use this only for reads that do not need snapshot isolation across multiple
+// statements. For multi-statement read groups (e.g. SearchIssues + label
+// hydration) keep using withReadTx so the queries see a consistent view.
+func (s *DoltStore) withReadConn(ctx context.Context, fn func(q issueops.SQLQuerier) error) error {
+	if s.closed.Load() {
+		return ErrStoreClosed
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire read conn: %w", err)
+	}
+	defer func() { _ = conn.Close() }() // releases the conn back to the pool
+	return fn(conn)
 }
 
 // withRetryTx wraps withWriteTx with retry logic for serialization failures
@@ -1347,20 +1370,29 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	// pairs in dolt-server.log).
 	applyPoolLimits(db, cfg)
 
-	// Ensure database exists (may need to create it)
-	// First connect without database to create it
-	initConnStr := buildServerDSN(cfg, "")
-	initDB, err := sql.Open("mysql", initConnStr)
-	if err != nil {
-		_ = db.Close()
-		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
-	}
-	defer func() { _ = initDB.Close() }()
-
 	// Validate database name to prevent SQL injection via backtick escaping
 	if err := ValidateDatabaseName(cfg.Database); err != nil {
 		_ = db.Close()
 		return nil, "", fmt.Errorf("invalid database name %q: %w", cfg.Database, err)
+	}
+
+	// Fast path: when we are not allowed to create the database, the SHOW
+	// DATABASES probe is wasted work in the common case where the database
+	// exists. Just ping the main pool — the MySQL handshake will fail with
+	// error 1049 ("Unknown database") if it does not exist. This saves a
+	// full MySQL handshake + SHOW DATABASES round trip on every read-only
+	// command (≈3 RTT on high-latency links). For init/bootstrap paths
+	// (CreateIfMissing=true) we still run the dual-pool dance below.
+	if !cfg.CreateIfMissing {
+		if err := db.PingContext(ctx); err != nil {
+			_ = db.Close()
+			if isDatabaseNotFoundError(err) {
+				return nil, "", databaseNotFoundError(cfg)
+			}
+			return nil, "", fmt.Errorf("failed to connect to Dolt server at %s:%d: %w",
+				cfg.ServerHost, cfg.ServerPort, err)
+		}
+		return db, connStr, nil
 	}
 
 	// FIREWALL: Never create test databases on the production server.
@@ -1373,6 +1405,17 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 				"this is a test database name on the production server (see DOLT-WAR-ROOM.md)",
 			cfg.Database, cfg.ServerPort)
 	}
+
+	// Slow path (init/bootstrap): connect without a database selected so we
+	// can SHOW DATABASES / CREATE DATABASE without depending on the target
+	// existing yet.
+	initConnStr := buildServerDSN(cfg, "")
+	initDB, err := sql.Open("mysql", initConnStr)
+	if err != nil {
+		_ = db.Close()
+		return nil, "", fmt.Errorf("failed to open init connection: %w", err)
+	}
+	defer func() { _ = initDB.Close() }()
 
 	// Check if the database already exists before deciding whether to create it.
 	// This prevents the shadow database bug: without CreateIfMissing, connecting
@@ -1390,11 +1433,6 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	}
 
 	if !dbExists {
-		if !cfg.CreateIfMissing {
-			_ = db.Close()
-			return nil, "", databaseNotFoundError(cfg)
-		}
-
 		_, err = initDB.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", cfg.Database)) //nolint:gosec // G201: cfg.Database validated by ValidateDatabaseName above
 		if err != nil {
 			// Dolt may return error 1007 even with IF NOT EXISTS - ignore if database already exists
@@ -1435,6 +1473,20 @@ func openServerConnection(ctx context.Context, cfg *Config) (*sql.DB, string, er
 	}
 
 	return db, connStr, nil
+}
+
+// isDatabaseNotFoundError reports whether err is a MySQL error 1049
+// ("Unknown database"). Used by the fast-path open to map a missing-DB
+// handshake failure to the project-level databaseNotFoundError.
+func isDatabaseNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if me, ok := err.(*mysql.MySQLError); ok && me.Number == 1049 {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "error 1049") || strings.Contains(msg, "unknown database")
 }
 
 // databaseExistsOnServer checks if a database with the exact given name exists

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1171,28 +1171,37 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	// CREATE DATABASE, information_schema queries may fail transiently
 	// even though Ping succeeded. This resolves within ~1s.
 	if !cfg.ReadOnly {
-		// Ensure dolt_ignore'd tables exist BEFORE running migrations.
-		// Migrations may reference these tables (e.g. 0027 alters wisps,
-		// 0030 inserts into local_metadata). After a clone or server restart
-		// these tables don't exist yet since they're not in committed data.
-		if err := versioncontrolops.EnsureIgnoredTables(ctx, db); err != nil {
-			return nil, fmt.Errorf("failed to ensure ignored tables: %w", err)
-		}
+		// Fast path: if local_metadata records that schema + compat
+		// migrations are already done at the current embedded schema
+		// version on this clone, the dolt_ignore'd tables that
+		// EnsureIgnoredTables checks for must also exist (they were
+		// created by the same chain we stamped after). Skip both with
+		// one SELECT instead of 7 SHOW TABLES + the migration probes
+		// (~1.6 s saved per write on a 200 ms RTT link).
+		if !schemaInitFastPathOK(ctx, db) {
+			// Ensure dolt_ignore'd tables exist BEFORE running migrations.
+			// Migrations may reference these tables (e.g. 0027 alters wisps,
+			// 0030 inserts into local_metadata). After a clone or server restart
+			// these tables don't exist yet since they're not in committed data.
+			if err := versioncontrolops.EnsureIgnoredTables(ctx, db); err != nil {
+				return nil, fmt.Errorf("failed to ensure ignored tables: %w", err)
+			}
 
-		schemaBO := backoff.NewExponentialBackOff()
-		schemaBO.InitialInterval = 100 * time.Millisecond
-		schemaBO.MaxElapsedTime = 5 * time.Second
-		if err := backoff.Retry(func() error {
-			schemaErr := store.initSchema(ctx)
-			if schemaErr != nil && isRetryableError(schemaErr) {
-				return schemaErr
+			schemaBO := backoff.NewExponentialBackOff()
+			schemaBO.InitialInterval = 100 * time.Millisecond
+			schemaBO.MaxElapsedTime = 5 * time.Second
+			if err := backoff.Retry(func() error {
+				schemaErr := store.initSchema(ctx)
+				if schemaErr != nil && isRetryableError(schemaErr) {
+					return schemaErr
+				}
+				if schemaErr != nil {
+					return backoff.Permanent(schemaErr)
+				}
+				return nil
+			}, backoff.WithContext(schemaBO, ctx)); err != nil {
+				return nil, fmt.Errorf("failed to initialize schema: %w", err)
 			}
-			if schemaErr != nil {
-				return backoff.Permanent(schemaErr)
-			}
-			return nil
-		}, backoff.WithContext(schemaBO, ctx)); err != nil {
-			return nil, fmt.Errorf("failed to initialize schema: %w", err)
 		}
 	}
 

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -45,6 +45,10 @@ func (d ServerDSN) String() string {
 		MultiStatements:      true,
 		Timeout:              timeout,
 		AllowNativePasswords: true,
+		// Client-side param substitution avoids a COM_STMT_PREPARE round trip
+		// per parameterized query. On high-latency links this halves the cost
+		// of a typical SELECT … WHERE k = ? from 2 RTT to 1 RTT.
+		InterpolateParams: true,
 	}
 	if d.TLS {
 		cfg.TLSConfig = "true"

--- a/internal/storage/doltutil/dsn.go
+++ b/internal/storage/doltutil/dsn.go
@@ -49,6 +49,12 @@ func (d ServerDSN) String() string {
 		// per parameterized query. On high-latency links this halves the cost
 		// of a typical SELECT … WHERE k = ? from 2 RTT to 1 RTT.
 		InterpolateParams: true,
+		// When MaxAllowedPacket is left at 0 the driver issues
+		// `SELECT @@max_allowed_packet` after the handshake to discover the
+		// server limit (≈1 extra RTT). Set a fixed 64 MiB ceiling — matches
+		// the driver's own DefaultMaxAllowedPacket constant — so the lookup
+		// query is skipped. bd never writes packets anywhere near this size.
+		MaxAllowedPacket: 64 * 1024 * 1024,
 	}
 	if d.TLS {
 		cfg.TLSConfig = "true"

--- a/internal/storage/issueops/comments.go
+++ b/internal/storage/issueops/comments.go
@@ -46,6 +46,12 @@ func GetIssueCommentsInTx(ctx context.Context, tx *sql.Tx, issueID string) ([]*t
 // GetCommentCountsInTx returns comment counts per issue ID within a transaction.
 // Routes each ID to comments or wisp_comments based on wisp status.
 // Uses batched IN clauses (queryBatchSize) to avoid query-planner spikes.
+//
+// Partitioning is done via PartitionWispIDsInTx so the wisp routing decision
+// costs one batched `SELECT id FROM wisps WHERE id IN (...)` round trip,
+// not one round trip per ID. Without this, hydrating comment counts for 200
+// issues over a ~200 ms RTT link spent ~40 s in per-ID IsActiveWispInTx
+// calls (see GH#3239 and the round-5 perf write trace).
 func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (map[string]int, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string]int), nil
@@ -53,13 +59,9 @@ func GetCommentCountsInTx(ctx context.Context, tx *sql.Tx, issueIDs []string) (m
 
 	result := make(map[string]int)
 
-	var wispIDs, permIDs []string
-	for _, id := range issueIDs {
-		if IsActiveWispInTx(ctx, tx, id) {
-			wispIDs = append(wispIDs, id)
-		} else {
-			permIDs = append(permIDs, id)
-		}
+	wispIDs, permIDs, err := PartitionWispIDsInTx(ctx, tx, issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("partition wisp ids: %w", err)
 	}
 
 	for _, pair := range []struct {

--- a/internal/storage/issueops/config_metadata.go
+++ b/internal/storage/issueops/config_metadata.go
@@ -20,9 +20,12 @@ func SetConfigInTx(ctx context.Context, tx *sql.Tx, key, value string) error {
 	return nil
 }
 
-// GetConfigInTx retrieves a configuration value within an existing transaction.
-// Returns ("", nil) if the key does not exist.
-func GetConfigInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) {
+// GetConfigInTx retrieves a configuration value within an existing transaction
+// or pooled connection. Returns ("", nil) if the key does not exist.
+// Accepts any SQLQuerier (*sql.Tx, *sql.Conn, *sql.DB) so callers can avoid
+// wrapping a single read in BEGIN/ROLLBACK when snapshot isolation is not
+// needed.
+func GetConfigInTx(ctx context.Context, tx SQLQuerier, key string) (string, error) {
 	var value string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE `key` = ?", key).Scan(&value)
 	if err == sql.ErrNoRows {
@@ -34,8 +37,9 @@ func GetConfigInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) 
 	return value, nil
 }
 
-// GetAllConfigInTx retrieves all configuration key-value pairs within an existing transaction.
-func GetAllConfigInTx(ctx context.Context, tx *sql.Tx) (map[string]string, error) {
+// GetAllConfigInTx retrieves all configuration key-value pairs.
+// Accepts any SQLQuerier so callers can choose tx or pooled conn.
+func GetAllConfigInTx(ctx context.Context, tx SQLQuerier) (map[string]string, error) {
 	rows, err := tx.QueryContext(ctx, "SELECT `key`, value FROM config")
 	if err != nil {
 		return nil, fmt.Errorf("get all config: %w", err)
@@ -62,9 +66,10 @@ func SetMetadataInTx(ctx context.Context, tx *sql.Tx, key, value string) error {
 	return nil
 }
 
-// GetMetadataInTx retrieves a metadata value within an existing transaction.
+// GetMetadataInTx retrieves a metadata value.
+// Accepts any SQLQuerier so callers can choose tx or pooled conn.
 // Returns ("", nil) if the key does not exist.
-func GetMetadataInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) {
+func GetMetadataInTx(ctx context.Context, tx SQLQuerier, key string) (string, error) {
 	var value string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM metadata WHERE `key` = ?", key).Scan(&value)
 	if err == sql.ErrNoRows {
@@ -88,8 +93,9 @@ func SetLocalMetadataInTx(ctx context.Context, tx *sql.Tx, key, value string) er
 }
 
 // GetLocalMetadataInTx retrieves a value from the dolt-ignored local_metadata
-// table within an existing transaction. Returns ("", nil) if the key does not exist.
-func GetLocalMetadataInTx(ctx context.Context, tx *sql.Tx, key string) (string, error) {
+// table. Accepts any SQLQuerier so callers can choose tx or pooled conn.
+// Returns ("", nil) if the key does not exist.
+func GetLocalMetadataInTx(ctx context.Context, tx SQLQuerier, key string) (string, error) {
 	var value string
 	err := tx.QueryRowContext(ctx, "SELECT value FROM local_metadata WHERE `key` = ?", key).Scan(&value)
 	if err == sql.ErrNoRows {

--- a/internal/storage/issueops/dependency_queries.go
+++ b/internal/storage/issueops/dependency_queries.go
@@ -64,19 +64,21 @@ func GetDependencyRecordsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs
 // GetDependencyRecordsForIssuesFromTableInTx is a fast-path variant used by
 // callers that already know every ID belongs to a single dep table (e.g.
 // searchTableInTx). Skips the wisp-partition round-trip.
-func GetDependencyRecordsForIssuesFromTableInTx(ctx context.Context, tx *sql.Tx, depTable string, issueIDs []string) (map[string][]*types.Dependency, error) {
+//
+// Accepts any SQLQuerier so callers can supply a pooled conn instead of a tx.
+func GetDependencyRecordsForIssuesFromTableInTx(ctx context.Context, q SQLQuerier, depTable string, issueIDs []string) (map[string][]*types.Dependency, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string][]*types.Dependency), nil
 	}
 	result := make(map[string][]*types.Dependency)
-	if err := getDependencyRecordsIntoFromTable(ctx, tx, depTable, issueIDs, result); err != nil {
+	if err := getDependencyRecordsIntoFromTable(ctx, q, depTable, issueIDs, result); err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
 //nolint:gosec // G201: depTable is "dependencies" or "wisp_dependencies" (hardcoded by callers).
-func getDependencyRecordsIntoFromTable(ctx context.Context, tx *sql.Tx, depTable string, ids []string, result map[string][]*types.Dependency) error {
+func getDependencyRecordsIntoFromTable(ctx context.Context, q SQLQuerier, depTable string, ids []string, result map[string][]*types.Dependency) error {
 	for start := 0; start < len(ids); start += queryBatchSize {
 		end := start + queryBatchSize
 		if end > len(ids) {
@@ -89,7 +91,7 @@ func getDependencyRecordsIntoFromTable(ctx context.Context, tx *sql.Tx, depTable
 			placeholders[i] = "?"
 			args[i] = id
 		}
-		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+		rows, err := q.QueryContext(ctx, fmt.Sprintf(
 			`SELECT issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id
 			 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id`,
 			depTable, strings.Join(placeholders, ",")), args...)

--- a/internal/storage/issueops/labels.go
+++ b/internal/storage/issueops/labels.go
@@ -79,12 +79,14 @@ func GetLabelsForIssuesInTx(ctx context.Context, tx *sql.Tx, issueIDs []string, 
 // which queries either the issues or wisps table exclusively). It skips the
 // wisp-partition round-trip entirely. labelTable must be "labels" or
 // "wisp_labels"; callers route via FilterTables.
-func GetLabelsForIssuesFromTableInTx(ctx context.Context, tx *sql.Tx, labelTable string, issueIDs []string) (map[string][]string, error) {
+//
+// Accepts any SQLQuerier so callers can supply a pooled conn instead of a tx.
+func GetLabelsForIssuesFromTableInTx(ctx context.Context, q SQLQuerier, labelTable string, issueIDs []string) (map[string][]string, error) {
 	if len(issueIDs) == 0 {
 		return make(map[string][]string), nil
 	}
 	result := make(map[string][]string)
-	if err := getLabelsIntoFromTable(ctx, tx, labelTable, issueIDs, result); err != nil {
+	if err := getLabelsIntoFromTable(ctx, q, labelTable, issueIDs, result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -94,7 +96,7 @@ func GetLabelsForIssuesFromTableInTx(ctx context.Context, tx *sql.Tx, labelTable
 // and accumulates results into the provided map.
 //
 //nolint:gosec // G201: labelTable is "labels" or "wisp_labels" (hardcoded by callers).
-func getLabelsIntoFromTable(ctx context.Context, tx *sql.Tx, labelTable string, ids []string, result map[string][]string) error {
+func getLabelsIntoFromTable(ctx context.Context, q SQLQuerier, labelTable string, ids []string, result map[string][]string) error {
 	for start := 0; start < len(ids); start += queryBatchSize {
 		end := start + queryBatchSize
 		if end > len(ids) {
@@ -107,7 +109,7 @@ func getLabelsIntoFromTable(ctx context.Context, tx *sql.Tx, labelTable string, 
 			placeholders[i] = "?"
 			args[i] = id
 		}
-		rows, err := tx.QueryContext(ctx, fmt.Sprintf(
+		rows, err := q.QueryContext(ctx, fmt.Sprintf(
 			`SELECT issue_id, label FROM %s WHERE issue_id IN (%s) ORDER BY issue_id, label`,
 			labelTable, strings.Join(placeholders, ",")), args...)
 		if err != nil {

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -9,6 +9,18 @@ import (
 	"github.com/steveyegge/beads/internal/types"
 )
 
+// SearchIssuesNonWispInTx runs a filtered search against the issues table only,
+// skipping the wisps merge step. Callers that already know the wisps table is
+// empty or missing (e.g. via a session-scoped cache) can use this to save one
+// round trip per search on high-latency remote connections.
+func SearchIssuesNonWispInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	results, err := searchTableInTx(ctx, tx, query, filter, IssuesFilterTables)
+	if err != nil {
+		return nil, fmt.Errorf("search issues: %w", err)
+	}
+	return results, nil
+}
+
 // SearchIssuesInTx executes a filtered issue search within an existing transaction.
 // It queries the issues table, optionally merges wisps, and returns hydrated issues
 // with labels populated.

--- a/internal/storage/issueops/search.go
+++ b/internal/storage/issueops/search.go
@@ -2,7 +2,6 @@ package issueops
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"strings"
 
@@ -13,21 +12,24 @@ import (
 // skipping the wisps merge step. Callers that already know the wisps table is
 // empty or missing (e.g. via a session-scoped cache) can use this to save one
 // round trip per search on high-latency remote connections.
-func SearchIssuesNonWispInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) ([]*types.Issue, error) {
-	results, err := searchTableInTx(ctx, tx, query, filter, IssuesFilterTables)
+//
+// Accepts any SQLQuerier so the caller can pass a pooled *sql.Conn instead
+// of a *sql.Tx, dropping the BEGIN/ROLLBACK round trips for simple reads.
+func SearchIssuesNonWispInTx(ctx context.Context, q SQLQuerier, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	results, err := searchTableInTx(ctx, q, query, filter, IssuesFilterTables)
 	if err != nil {
 		return nil, fmt.Errorf("search issues: %w", err)
 	}
 	return results, nil
 }
 
-// SearchIssuesInTx executes a filtered issue search within an existing transaction.
+// SearchIssuesInTx executes a filtered issue search.
 // It queries the issues table, optionally merges wisps, and returns hydrated issues
-// with labels populated.
-func SearchIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+// with labels populated. Accepts any SQLQuerier (*sql.Tx, *sql.Conn, *sql.DB).
+func SearchIssuesInTx(ctx context.Context, q SQLQuerier, query string, filter types.IssueFilter) ([]*types.Issue, error) {
 	// Route ephemeral-only queries to wisps table.
 	if filter.Ephemeral != nil && *filter.Ephemeral {
-		results, err := searchTableInTx(ctx, tx, query, filter, WispsFilterTables)
+		results, err := searchTableInTx(ctx, q, query, filter, WispsFilterTables)
 		if err != nil && !isTableNotExistError(err) {
 			return nil, fmt.Errorf("search wisps (ephemeral filter): %w", err)
 		}
@@ -37,7 +39,7 @@ func SearchIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter type
 		// Fall through: wisps table doesn't exist or returned no results
 	}
 
-	results, err := searchTableInTx(ctx, tx, query, filter, IssuesFilterTables)
+	results, err := searchTableInTx(ctx, q, query, filter, IssuesFilterTables)
 	if err != nil {
 		return nil, fmt.Errorf("search issues: %w", err)
 	}
@@ -50,7 +52,7 @@ func SearchIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter type
 	// querying wisps here with Ephemeral=&false returns only NoHistory beads
 	// while correctly excluding true ephemeral wisps. (GH#3659)
 	if filter.Ephemeral == nil || !*filter.Ephemeral {
-		wispResults, wispErr := searchTableInTx(ctx, tx, query, filter, WispsFilterTables)
+		wispResults, wispErr := searchTableInTx(ctx, q, query, filter, WispsFilterTables)
 		if wispErr != nil && !isTableNotExistError(wispErr) {
 			return nil, fmt.Errorf("search wisps (merge): %w", wispErr)
 		}
@@ -71,7 +73,8 @@ func SearchIssuesInTx(ctx context.Context, tx *sql.Tx, query string, filter type
 }
 
 // searchTableInTx runs a filtered search against a specific table set (issues or wisps).
-func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types.IssueFilter, tables FilterTables) ([]*types.Issue, error) {
+// Accepts any SQLQuerier so callers can choose tx or pooled conn.
+func searchTableInTx(ctx context.Context, q SQLQuerier, query string, filter types.IssueFilter, tables FilterTables) ([]*types.Issue, error) {
 	whereClauses, args, err := BuildIssueFilterClauses(query, filter, tables)
 	if err != nil {
 		return nil, err
@@ -91,7 +94,7 @@ func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 	querySQL := fmt.Sprintf(`SELECT %s FROM %s %s ORDER BY priority ASC, created_at DESC, id ASC %s`,
 		IssueSelectColumns, tables.Main, whereSQL, limitSQL)
 
-	rows, err := tx.QueryContext(ctx, querySQL, args...)
+	rows, err := q.QueryContext(ctx, querySQL, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search %s: %w", tables.Main, err)
 	}
@@ -126,7 +129,7 @@ func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 		// or wisps table, so every ID in `ids` belongs to tables.Labels.
 		// Skip the per-batch wisp-partition round-trip that the generic
 		// GetLabelsForIssuesInTx performs (GH#3414).
-		labelMap, labelErr := GetLabelsForIssuesFromTableInTx(ctx, tx, tables.Labels, ids)
+		labelMap, labelErr := GetLabelsForIssuesFromTableInTx(ctx, q, tables.Labels, ids)
 		if labelErr != nil {
 			return nil, fmt.Errorf("search %s: hydrate labels: %w", tables.Main, labelErr)
 		}
@@ -138,7 +141,7 @@ func searchTableInTx(ctx context.Context, tx *sql.Tx, query string, filter types
 
 		// Optionally hydrate dependencies in bulk (same batched pattern as labels).
 		if filter.IncludeDependencies {
-			depMap, depErr := GetDependencyRecordsForIssuesFromTableInTx(ctx, tx, tables.Dependencies, ids)
+			depMap, depErr := GetDependencyRecordsForIssuesFromTableInTx(ctx, q, tables.Dependencies, ids)
 			if depErr != nil {
 				return nil, fmt.Errorf("search %s: hydrate dependencies: %w", tables.Main, depErr)
 			}


### PR DESCRIPTION
## What

Cuts wall-clock cost of bd against an external Dolt SQL server. On a connection with ~200 ms RTT to a remote host, the changes drop:

- `bd list` over 200 issues: **12.3 s → 2.6 s** (4.7×)
- `bd create` (warm): **>161 s → ~9 s** (>17×; stock v1.0.4 routinely times out)
- Other read commands: **2× to 5×** faster, no regressions

Pre-existing v1.0.4 bugs surfaced and fixed in passing:

- `maybeAutoImportJSONL` re-imported the entire JSONL on every server-mode write because the fallback path has no atomic emptiness check — GH#3880, GH#4128
- `schema.MigrateUp` + the 17 idempotent `RunCompatMigrations` + `EnsureIgnoredTables` ran on every write, paying ~40 SQL probes (~8 s on this link) just to confirm "nothing to do"
- `GetCommentCountsInTx` partitioned its input IDs by wisp status with a per-ID `IsActiveWispInTx` loop — 200 round trips for a 200-issue corpus, same family as GH#3239

## Why

Running `bd 1.0.4` with `dolt_mode=server` against a remote Dolt server (not localhost) made every command take 5–30 s wall-clock despite the server itself answering a single `SELECT 1` in ~200 ms. CPU on the client was ~1 %; the rest was serial network waits. Writes were worse — `bd create` regularly hit the timeout. Same symptom as #4102, adjacent to #3239 and #3760. For teams using a shared Dolt server, this is the blocker for actually adopting beads in dolt_mode=server.

## How (nine focused commits on top of v1.0.4)

A per-call SQL trace (`BD_DOLT_TRACE_SQL=1`, see below) drove the work commit by commit:

1. **DSN + connection layer.** Pin `MaxAllowedPacket` (the Go MySQL driver otherwise issues a `SELECT @@max_allowed_packet` discovery query after every fresh connection) and enable `InterpolateParams` (skip the `COM_STMT_PREPARE` round trip on parameterized reads). Skip the dual-pool `SHOW DATABASES` probe when `CreateIfMissing=false`. Drop the redundant post-open `PingContext` and the no-op `net.DialTimeout` preflight for non-local TCP.
2. **`withReadConn` helper.** Pure-read methods (`GetConfig`, `GetAllConfig`, `GetMetadata`, `GetLocalMetadata`, and `SearchIssues` when the wisps table is known empty) borrow a pooled `*sql.Conn` instead of opening a `BEGIN/ROLLBACK` transaction. Saves 2 round trips per simple read.
3. **`preloadSessionCaches`.** At store-open, one multi-statement query — `SELECT key,value FROM config; SELECT 1 FROM wisps LIMIT 1` — warms five per-store caches (config map, custom statuses / types / infra types, wisps-existence). Subsequent `GetCustomStatusesDetailed`, `GetCustomTypes`, `GetInfraTypes`, `GetAllConfig`, plus the wisps-merge step in `SearchIssues`, all become cache hits.
4. **`SearchIssues` on a pooled conn.** When the wisps cache reports empty, `SearchIssues` runs through `withReadConn` instead of `withReadTx`, dropping `BEGIN/ROLLBACK` for the main query. Four `issueops` helpers were widened from `*sql.Tx` to a small `SQLQuerier` interface; `*sql.Tx` still satisfies it, so existing callers compile unchanged.
5. **Read-only PostRun gating.** `maybeAutoExport` / `maybeAutoBackup` / `maybeAutoPush` now skip on read-only commands. `export.auto` defaults to `true`, so before this every `bd list` was running a second `SearchIssues` plus a `GetCurrentCommit` in PostRun.
6. **Routing batching.** The routing module's six sequential `GetConfig` lookups collapse into one `GetAllConfig`. Result is cached on the `DoltStore` for the rest of the command.
7. **Server-mode write fixes** (round 5):
   - `maybeAutoImportJSONL` now probes `SELECT 1 FROM issues LIMIT 1` before the server-mode fallback import and skips when the database is clearly not empty. Mirrors the spirit of the embedded path's in-transaction emptiness check. Resolves GH#3880, GH#4128.
   - `initSchemaOnDB` stamps `bd_schema_init_done_at_version` in the dolt-ignored `local_metadata` table after a successful run. Subsequent opens check the stamp (one SELECT) and short-circuit the migration chain when it's already ≥ `schema.LatestVersion()`. An older bd binary stamps a lower value, so a newer binary still re-runs its newer migrations correctly.
8. **`GetCommentCountsInTx` batched partition.** Replaces the per-ID `IsActiveWispInTx` loop with the existing `PartitionWispIDsInTx` helper (which the sibling `GetCommentsForIssuesInTx` already uses). One batched `SELECT id FROM wisps WHERE id IN (...)` instead of N round trips.
9. **Parallelize `maybeAutoExport` hydration.** The five independent bulk-load reads inside `exportToFile` (labels, deps, comments, commentCounts, depCounts) run via `sync.WaitGroup` on the existing connection pool instead of back-to-back.
10. **`EnsureIgnoredTables` fast path.** Gate behind the same schema-init stamp. With the stamp set, skip the 7 sequential `SHOW TABLES LIKE` probes (~1.4 s on remote).
11. **`GetConfig(key)` honours `allConfigCache`.** Per-key reads after preload hit the in-memory cache instead of round-tripping.
12. **Auto-export throttle: 5 min in server mode.** Embedded backend stays on the 60-second default (rebuild is ~150 ms there). Server mode rebuilds in 5-10 s, so a longer default avoids paying that cost on every burst write. Users can override via `export.interval` in `.beads/config.yaml`.

A new optional `BD_DOLT_TRACE_SQL=1` env var emits per-call timings to stderr so anyone can verify these numbers themselves; `BD_DOLT_TRACE_STACK=1` adds full call stacks.

## ⚠️ Showcase only — please do not merge

A few pieces here are deliberately additive (new code next to old) so each change is reviewable in isolation against `v1.0.4`:

- `SearchIssuesNonWispInTx` is a near-duplicate of `SearchIssuesInTx`. Proper version: one function with a `skipWispsMerge` hint.
- `withReadConn` is a sibling of `withReadTx`. Proper version: one helper that picks tx vs. conn from caller intent.
- `internal/storage/dolt/sqltrace.go` parallels the existing OTel `doltTracer`. Proper version: fold the few extra spans in and drop `sqltrace.go`.

The intent: land *this* PR to validate the numbers and approach with maintainers, then open a follow-up PR that collapses the duplicates and removes `sqltrace.go`. Marked as **draft**.

## Verification

### Output parity (200-issue seed)

`bd list`, `bd list --all`, `bd list --json`, `bd list --type bug`, `bd list --status in_progress`, `bd list --label …`, `bd list --flat`, `bd ready`, `bd count`, `bd show <id>`, `bd search …` all produce byte-for-byte identical output between stock `bd v1.0.4` and this branch on both backends (use `bd export | bd import` to reproduce the seed on both).

### Wall-clock measurements

A 200-issue corpus (10 epics, 40 features, 110 tasks, 25 bugs, 15 chores; mixed statuses; parent-child hierarchy across 3 levels; `blocks` dependencies on every 5th task; ~10% closed) seeded identically into:

- embedded Dolt (local disk)
- external Dolt server (~200 ms RTT TCP)

3 timed iterations after a warmup, timed with `time.monotonic()` from a Python wrapper.

#### Embedded backend — no regressions, modest wins from no-op gating

| command | stock (ms) | this PR (ms) | speedup |
|---|---|---|---|
| `bd list` | 655 | 434 | 1.51× |
| `bd list --all` | 614 | 447 | 1.37× |
| `bd list --json` | 742 | 540 | 1.37× |
| `bd list --type bug` | 696 | 478 | 1.46× |
| `bd list --status in_progress` | 657 | 459 | 1.43× |
| `bd list --label …` | 655 | 452 | 1.45× |
| `bd list --flat` | 725 | 519 | 1.40× |
| `bd ready` | 861 | 621 | 1.39× |
| `bd stats` | 371 | 374 | 0.99× (within noise) |
| `bd count` | 314 | 242 | 1.30× |
| `bd show <id>` | 491 | 420 | 1.17× |
| `bd search` | 344 | 290 | 1.19× |
| `bd create` (warm) | 740 | 730 | 1.01× (no regression) |
| `bd update` (warm) | 528 | 574 | 0.92× (within noise) |
| `bd close` (warm) | 594 | 589 | 1.01× (no regression) |

#### Remote-Dolt backend — major wins on every command tested

Read commands (3 timed iterations, drop the first as warmup, against the seeded server repo):

| command | stock (ms) | this PR (ms) | speedup |
|---|---|---|---|
| `bd list` | 12,281 | **2,593** | **4.74×** |
| `bd list --all` | 11,945 | **2,731** | **4.37×** |
| `bd list --json` | 36,858 | **14,935** | **2.47×** |
| `bd list --type bug` | 13,755 | **2,527** | **5.44×** |
| `bd list --status in_progress` | 12,523 | **2,610** | **4.80×** |
| `bd list --label …` | 12,664 | **2,486** | **5.09×** |
| `bd list --flat` | 10,470 | **4,020** | **2.60×** |
| `bd ready` | 30,425 | **15,630** | **1.95×** |
| `bd count` | 5,531 | **2,396** | **2.31×** |
| `bd show <id>` | 12,236 | **5,726** | **2.14×** |
| `bd search` | 6,989 | **2,768** | **2.52×** |

Write commands (single-iteration sampling; stock was killed at the 3-minute mark because it was clearly going to run for many minutes):

| command | stock (ms) | this PR (ms) | speedup |
|---|---|---|---|
| `bd create` cold (first call, schema-init stamp absent) | **>161,565** (killed at 2:42, still running) | **~18,800** | **>8×** |
| `bd create` warm (avg over 4 subsequent calls) | n/a — never completed | **~9,100** | **>17× lower bound** |

Per-iteration values for the warm sample: 11,348 / 11,722 / 11,880 / 11,951 ms.

`bd stats` is **not in the table** because it hangs against this server on both stock bd and this branch — the SQL path that backs it executes one query per metric serially and the server's response to one of them never completes within 30 s. Reproducible on stock v1.0.4 and not introduced here.

### Unit tests

Existing test suites in the touched packages all pass (`-short`):

- `internal/storage/doltutil` — DSN tests cover the new `MaxAllowedPacket` / `InterpolateParams` defaults indirectly via `mysql.ParseDSN` round-trip checks.
- `internal/storage/issueops` — including `TestGetCommentCountsInTx*`, exercises the new batched-partition path.
- `internal/storage/dolt` — schema-init, connection-pool, store-unit tests. Note: the pre-existing `TestPullWithAutoResolve_BranchTrackingFallbackSuccess` requires the `dolt` CLI on PATH and was failing on `main` before this PR — unchanged by this work.
- `internal/storage/dolt/migrations` — compat migrations still pass; the new `bd_schema_init_done_at_version` stamp is best-effort and doesn't change migration semantics.

### Reproducing the numbers

The build artifacts include an opt-in SQL trace gated by env vars (off by default), so any reviewer can run `BD_DOLT_TRACE_SQL=1 bd list` and see every round trip annotated with timing and caller info.

### How to try it locally

Build the patched binary alongside your installed `bd`:

```bash
git clone https://github.com/gastownhall/beads
cd beads
git fetch origin pull/<this PR number>/head:perf/remote-dolt-rtt-104-pr
git checkout perf/remote-dolt-rtt-104-pr

# Embedded mode (full CGO build, lets you run against .beads/embeddeddolt/)
make build
mv bd ~/.local/bin/bd-perf

# Or server-mode-only (no CGO, faster build, no embedded backend)
CGO_ENABLED=0 go build -tags gms_pure_go -o ~/.local/bin/bd-perf ./cmd/bd
```

Then point an existing repo at it without disturbing your installed `bd`:

```bash
# Read commands (always safe — no mutations)
bd-perf -C /path/to/.beads/repo list
bd-perf -C /path/to/.beads/repo list --json
bd-perf -C /path/to/.beads/repo show <issue-id>

# Side-by-side compare against stock 1.0.4
time bd list           # baseline
time bd-perf list      # this branch

# See the trace yourself
BD_DOLT_TRACE_SQL=1 bd-perf list 2>&1 | head -40
BD_DOLT_TRACE_STACK=1 bd-perf list   # adds full call stacks per SQL op
```

For server mode, `bd-perf` reads the same `.beads/metadata.json`, `.beads/dolt-server.port`, and `~/.config/beads/credentials` as stock `bd` — no extra configuration required. Output is byte-for-byte identical to stock for the commands in the parity table above, so it's safe to drop into existing workflows for read commands. **Writes work and are dramatically faster, but the patches are framed as a showcase — please don't merge or run them in production without a follow-up that absorbs the duplicates listed in the showcase note above.**

To revert to stock `bd`, just delete `~/.local/bin/bd-perf` — your `~/.local/bin/bd` is untouched.

## Related issues

- **#4102** — `perf(server-mode): bd commands take 5-10s in remote dolt_mode due to cold connection + serial query pattern` — direct response.
- **#3239** — `Batch wisp routing checks to reduce WAN latency amplification in Dolt server mode` — addressed via the wisps-existence cache + batched routing config + the `GetCommentCountsInTx` fix.
- **#3760** — `Proposal: bd serve daemon to amortize dolt connection setup` — complementary; this PR demonstrates what's achievable *without* a daemon.
- **#3501** + **#3522** — `auto-backup` runs on every command — partially mitigated by the read-only gating in this PR.
- **#3880** + **#4128** — server-mode write-path re-imports JSONL / re-runs schema init on every write — fixed in round 5.

## Authorship

Mixed human + AI effort. Investigation, code, tests, and benchmarks were a back-and-forth between **Hans Boese** (human, account opening this PR) and **Claude** (Anthropic, via Claude Code, working as a paired contributor). Every commit has `Co-Authored-By: Claude <noreply@anthropic.com>`. The roles split roughly as: Hans set the goal and reviewed each step; Claude wrote the trace harness, ran the measurements, drafted the patches and the benchmark report, iterating in tight loops with Hans deciding what to keep at each round.

## Follow-up (not in this PR)

- Collapse `SearchIssuesNonWispInTx` into `SearchIssuesInTx` via a hint param.
- Replace `withReadTx` + `withReadConn` pair with a single helper that picks tx vs. conn from caller intent.
- Remove `internal/storage/dolt/sqltrace.go`; fold its handful of spans into the existing OTel `doltTracer`.
- Combine `CreateIssueInTx` + `doltAddAndCommit` into one round trip via a stored procedure or multi-statement (currently two transactions per write = ~4-5 s of the remaining ~9 s create cost).
- Audit other `IsActiveWispInTx`-in-loop call sites for the same N+1 pattern (`dependency_queries.go:406` is a known candidate, only triggered on `bd close`).
- Consider `bd serve` (per #3760) for sub-1 s reads via amortized connection setup.

Each of those is a separate PR-sized change.
