### PR TITLE
fix(issueops/dependencies): wrap EXISTS subquery in derived table for MySQL 8+ compat

### DIFF
--- a/internal/storage/issueops/dependencies.go
+++ b/internal/storage/issueops/dependencies.go
@@ -290,15 +290,22 @@ func markDirectBlockingDependencySourceInTx(ctx context.Context, tx *sql.Tx, sou
 		return nil
 	}
 
+	// MySQL 8.0+ rejects UPDATE <T> ... WHERE EXISTS (SELECT FROM <T> ...)
+	// even with distinct aliases (Error 1093: can't specify target table
+	// for update in FROM clause), which fires here whenever sourceTable ==
+	// targetTable. Wrapping the inner SELECT in a derived table makes MySQL
+	// treat it as an independent rowset, satisfying the restriction. Dolt
+	// accepts both forms, so this is a no-op there.
 	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
 		UPDATE %s s SET s.is_blocked = 1, s.updated_at = s.updated_at
 		WHERE s.id = ?
 		  AND s.is_blocked = 0
 		  AND s.status <> 'closed' AND s.status <> 'pinned'
 		  AND EXISTS (
-		    SELECT 1 FROM %s t
-		    WHERE t.id = ?
-		      AND t.status <> 'closed' AND t.status <> 'pinned'
+		    SELECT 1 FROM (
+		      SELECT id, status FROM %s WHERE id = ?
+		    ) AS t
+		    WHERE t.status <> 'closed' AND t.status <> 'pinned'
 		  )
 	`, sourceTable, targetTable), source, target)
 	return err


### PR DESCRIPTION
## Summary

`markDirectIsBlockedAfterAddDependencyInTx` in `internal/storage/issueops/dependencies.go` issues an `UPDATE issues s ... WHERE EXISTS (SELECT FROM issues t ...)` after every dependency insert. MySQL 8.0+ rejects this pattern with **Error 1093** ("You can't specify target table 's' for update in FROM clause") even with distinct table aliases.

Dolt's GMS-based SQL parser is more permissive on this rule, which is why the bug never surfaces against the default backend. Anyone running `bd` against real MySQL hits it on the first `bd dep add` between two issues — `bd` rolls back the transaction and reports the 1093 error, blocking every multi-step workflow that creates dependent issues.

This PR wraps the inner SELECT in a derived table — the canonical MySQL workaround — so the statement runs cleanly on real MySQL while remaining a no-op semantic change for Dolt.

### Why we surfaced this

We're bringing up a MySQL backend in a fork by @zpriddy (https://github.com/zpriddy/beads) to give our workspace a stable storage tier while the Dolt-side performance + compaction story settles. The MySQL backend path itself lives in that fork, but the bug is in **shared** `internal/storage/issueops/` code on `main` — both backends route through the same `AddDependencyInTx` and hit the same post-insert UPDATE. The fix is correspondingly shared and benefits both engines.

## Change

- `internal/storage/issueops/dependencies.go`: wrap the EXISTS subquery's inner SELECT in `(SELECT id, status FROM <target_table> WHERE id = ?) AS t`. The derived-table form satisfies MySQL's restriction because MySQL treats it as an independent rowset. Semantics are preserved — EXISTS still returns true iff there's a row in target with `id = target` and `status NOT IN ('closed', 'pinned')`.
- Inline comment naming the MySQL restriction and the workaround so future readers don't accidentally "simplify" it back.

## What this doesn't solve

- Doesn't add CI integration tests against a real MySQL server. The existing unit tests under `internal/storage/issueops/` pass with the new SQL (sqlmock doesn't enforce engine-specific parser rules), but a real MySQL would catch this kind of regression on first run. Adding MySQL-backed integration coverage is a larger, separate change.
- Doesn't audit the rest of the codebase for similar `UPDATE <T> ... EXISTS (SELECT FROM <T>)` shapes. A targeted grep would be quick if MySQL backend support is moving toward first-class.

## Test plan

- [x] `go test -tags gms_pure_go ./internal/storage/issueops/...` — PASS.
- [x] Raw SQL against MySQL 9.6.0 (Homebrew): old form returns `ERROR 1093 (HY000)`; new form runs cleanly with no error. Issued via `mysql -uroot <db> -e "..."`.
- [x] Raw SQL against Dolt (current release via `dolt sql -q`): both old and new forms accepted; no behavior difference.
- [x] End-to-end on Dolt: `bd init --prefix test`, two `bd create`, `bd dep add A B` — succeeds, DEPENDS-ON link lands as expected.
- [x] End-to-end on a ~8000-row MySQL-backed issues table: two `bd create`, `bd dep add A B` — was Error 1093 before this change, succeeds and link lands after.
- [ ] Repo CI run on this PR.

## Credit

@zpriddy for the MySQL backend work in his fork that exposed this; the bug is independent of that fork (the buggy SQL is in `main`) but his work is what put real MySQL exercise on it.