### PR TITLE
auto-import: gate server mode at call site

### DIFF
--- a/cmd/bd/auto_import_upgrade.go
+++ b/cmd/bd/auto_import_upgrade.go
@@ -18,10 +18,10 @@ type jsonlImporter interface {
 }
 
 // fallbackImporter is the function maybeAutoImportJSONL invokes for stores
-// that do not implement jsonlImporter (server-mode dolt). It exists as a
-// package-level variable so tests can substitute a counter and verify the
-// top-level emptiness guard prevents the fallback path from running on a
-// non-empty database. Production builds always use importFromLocalJSONLFull.
+// that do not implement jsonlImporter. It exists as a package-level variable
+// so tests can substitute a counter and verify the top-level emptiness guard
+// prevents the fallback path from running on a non-empty database. Production
+// builds always use importFromLocalJSONLFull.
 var fallbackImporter = importFromLocalJSONLFull
 
 // maybeAutoImportJSONL checks whether the database is empty and the configured
@@ -30,22 +30,17 @@ var fallbackImporter = importFromLocalJSONLFull
 // .beads/dolt/) to 1.0+ (which uses .beads/embeddeddolt/) don't appear to
 // lose their issues.  See GH#2994.
 //
-// The top-level emptiness guard (GetStatistics) protects BOTH the
-// embedded fast-path and the server-mode fallback. The embedded
-// jsonlImporter has its own in-transaction emptiness check as a
-// concurrency-safe second line of defense; the fallback path's
-// importFromLocalJSONLFull uses INSERT … ON DUPLICATE KEY UPDATE
-// semantics under the hood, so without this guard a stale
-// issues.jsonl would be re-imposed on top of live Dolt rows on
-// every command, clobbering recent partial-update writes.
+// The top-level emptiness guard (GetStatistics) protects both the embedded
+// fast-path and the fallback path. The embedded jsonlImporter has its own
+// in-transaction emptiness check as a concurrency-safe second line of defense;
+// the fallback path's importFromLocalJSONLFull uses INSERT … ON DUPLICATE KEY
+// UPDATE semantics under the hood, so without this guard a stale issues.jsonl
+// would be re-imposed on top of live Dolt rows on every command, clobbering
+// recent partial-update writes.
 //
 // The function is best-effort: failures are logged as warnings but do not
 // prevent the store from being used.
-func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir string, serverMode bool) {
-	if serverMode {
-		return
-	}
-
+func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir string) {
 	// Quick check: does the JSONL file exist and have content?
 	jsonlPath := configuredImportJSONLPath(beadsDir)
 	info, err := os.Stat(jsonlPath)
@@ -102,7 +97,7 @@ func maybeAutoImportJSONL(ctx context.Context, s storage.DoltStorage, beadsDir s
 		return
 	}
 
-	// Fallback for non-embedded stores: multi-call path (original behavior).
+	// Fallback for stores without a single-transaction importer.
 	fmt.Fprintf(os.Stderr, "auto-importing %d bytes from %s into empty database...\n", info.Size(), jsonlPath)
 
 	result, err := fallbackImporter(ctx, s, jsonlPath)

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
@@ -81,22 +83,42 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty(t *testing.T)
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
 
 	store := &fakeFallbackStore{statsTotalIssues: 5}
-	maybeAutoImportJSONL(context.Background(), store, dir, false)
+	maybeAutoImportJSONL(context.Background(), store, dir)
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("regression: server-mode fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
 	}
 }
 
-func TestMaybeAutoImportJSONL_SkipsEntirelyInServerMode(t *testing.T) {
-	dir := t.TempDir()
-	writeAutoImportFixtureJSONL(t, dir)
-	count := swapFallbackImporter(t, errors.New("test importer should not run"))
+func TestShouldRunAutoImportJSONL(t *testing.T) {
+	store := &fakeFallbackStore{}
+	writeCmd := &cobra.Command{Use: "update"}
 
-	maybeAutoImportJSONL(context.Background(), nil, dir, true)
+	tests := []struct {
+		name        string
+		cmd         *cobra.Command
+		store       storage.DoltStorage
+		useReadOnly bool
+		globalFlag  bool
+		serverMode  bool
+		want        bool
+	}{
+		{name: "write command embedded", cmd: writeCmd, store: store, want: true},
+		{name: "server mode", cmd: writeCmd, store: store, serverMode: true, want: false},
+		{name: "read only", cmd: writeCmd, store: store, useReadOnly: true, want: false},
+		{name: "global", cmd: writeCmd, store: store, globalFlag: true, want: false},
+		{name: "import command", cmd: &cobra.Command{Use: "import"}, store: store, want: false},
+		{name: "nil store", cmd: writeCmd, want: false},
+		{name: "nil command", store: store, want: false},
+	}
 
-	if got := count.Load(); got != 0 {
-		t.Fatalf("server-mode auto-import invoked fallback importer %d time(s); expected 0", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRunAutoImportJSONL(tt.cmd, tt.store, tt.useReadOnly, tt.globalFlag, tt.serverMode)
+			if got != tt.want {
+				t.Fatalf("shouldRunAutoImportJSONL() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -109,7 +131,7 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenStatisticsNil(t *testi
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
 
 	store := &fakeFallbackStore{statsNil: true}
-	maybeAutoImportJSONL(context.Background(), store, dir, false)
+	maybeAutoImportJSONL(context.Background(), store, dir)
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("server-mode fallback importer was invoked %d time(s) when statistics were nil; expected 0", got)
@@ -129,7 +151,7 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty(t *testing.T) {
 	count := swapFallbackImporter(t, errors.New("test importer: short-circuit before s.Commit"))
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir, false)
+	maybeAutoImportJSONL(context.Background(), store, dir)
 
 	if got := count.Load(); got != 1 {
 		t.Fatalf("server-mode fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
@@ -152,7 +174,7 @@ func TestMaybeAutoImportJSONL_UsesConfiguredImportPath(t *testing.T) {
 	t.Cleanup(func() { fallbackImporter = orig })
 
 	store := &fakeFallbackStore{statsTotalIssues: 0}
-	maybeAutoImportJSONL(context.Background(), store, dir, false)
+	maybeAutoImportJSONL(context.Background(), store, dir)
 
 	wantPath := filepath.Join(dir, "beads.jsonl")
 	if gotPath != wantPath {

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -18,7 +18,7 @@ import (
 // fakeFallbackStore satisfies storage.DoltStorage via an embedded nil
 // interface (any unimplemented method panics) and returns a configurable
 // Statistics. It does NOT implement jsonlImporter, so the type assertion
-// in maybeAutoImportJSONL fails and the server-mode fallback path is taken
+// in maybeAutoImportJSONL fails and the fallback importer path is taken
 // — exactly the path that lacked an emptiness guard prior to the fix.
 type fakeFallbackStore struct {
 	storage.DoltStorage // nil — panics on any non-overridden method
@@ -64,20 +64,20 @@ func swapFallbackImporter(t *testing.T, returnErr error) *atomic.Int32 {
 	return &count
 }
 
-// TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty is the
+// TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenNonEmpty is the
 // regression test for the auto-import-on-non-empty data-clobber bug
 // introduced upstream by PR #3630.
 //
 // Pre-fix, maybeAutoImportJSONL had no top-level emptiness guard for
-// stores that did not implement jsonlImporter (i.e. server-mode dolt).
-// Every command unconditionally invoked importFromLocalJSONLFull, which
-// UPSERTs JSONL contents on top of live Dolt rows — silently clobbering
-// recent partial-update writes whose values had not yet been re-exported
-// to JSONL.
+// stores that did not implement jsonlImporter. Every command
+// unconditionally invoked importFromLocalJSONLFull, which UPSERTs JSONL
+// contents on top of live Dolt rows — silently clobbering recent
+// partial-update writes whose values had not yet been re-exported to
+// JSONL.
 //
 // This test fails on the buggy code (counter == 1) and passes after the
 // guard is restored (counter == 0).
-func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty(t *testing.T) {
+func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenNonEmpty(t *testing.T) {
 	dir := t.TempDir()
 	writeAutoImportFixtureJSONL(t, dir)
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
@@ -86,7 +86,7 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenNonEmpty(t *testing.T)
 	maybeAutoImportJSONL(context.Background(), store, dir)
 
 	if got := count.Load(); got != 0 {
-		t.Fatalf("regression: server-mode fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
+		t.Fatalf("regression: fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
 	}
 }
 
@@ -122,10 +122,10 @@ func TestShouldRunAutoImportJSONL(t *testing.T) {
 	}
 }
 
-// TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenStatisticsNil covers
+// TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsNil covers
 // the defensive nil-statistics guard: if the store reports no error but also
 // no counts, auto-import should skip rather than panic or assume emptiness.
-func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenStatisticsNil(t *testing.T) {
+func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsNil(t *testing.T) {
 	dir := t.TempDir()
 	writeAutoImportFixtureJSONL(t, dir)
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
@@ -134,18 +134,18 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_SkipsWhenStatisticsNil(t *testi
 	maybeAutoImportJSONL(context.Background(), store, dir)
 
 	if got := count.Load(); got != 0 {
-		t.Fatalf("server-mode fallback importer was invoked %d time(s) when statistics were nil; expected 0", got)
+		t.Fatalf("fallback importer was invoked %d time(s) when statistics were nil; expected 0", got)
 	}
 }
 
-// TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty is the negative
+// TestMaybeAutoImportJSONL_FallbackImporter_RunsWhenEmpty is the negative
 // control. Without it, a future change that always short-circuits would
 // leave the regression test above passing vacuously.
 //
 // The substituted importer returns an error to short-circuit before
 // s.Commit is called, so the bare fakeFallbackStore (which panics on
 // every other method) does not need the full DoltStorage surface.
-func TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty(t *testing.T) {
+func TestMaybeAutoImportJSONL_FallbackImporter_RunsWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	writeAutoImportFixtureJSONL(t, dir)
 	count := swapFallbackImporter(t, errors.New("test importer: short-circuit before s.Commit"))
@@ -154,7 +154,7 @@ func TestMaybeAutoImportJSONL_ServerModeFallback_RunsWhenEmpty(t *testing.T) {
 	maybeAutoImportJSONL(context.Background(), store, dir)
 
 	if got := count.Load(); got != 1 {
-		t.Fatalf("server-mode fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
+		t.Fatalf("fallback importer invoked %d time(s) on empty store; expected exactly 1", got)
 	}
 }
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1053,8 +1053,8 @@ var rootCmd = &cobra.Command{
 		// Skip auto-import when the user is explicitly running "bd import" —
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
-		if store != nil && !useReadOnly && !globalFlag && cmd.Name() != "import" {
-			maybeAutoImportJSONL(rootCtx, store, beadsDir, doltCfg.ServerMode)
+		if shouldRunAutoImportJSONL(cmd, store, useReadOnly, globalFlag, doltCfg.ServerMode) {
+			maybeAutoImportJSONL(rootCtx, store, beadsDir)
 		}
 
 		// Validate workspace identity for write commands (GH#2438, GH#2372)
@@ -1206,6 +1206,13 @@ func shouldRunPostCommandAutoExport(cmd *cobra.Command) bool {
 		return true
 	}
 	return !isReadOnlyCommand(cmd.Name())
+}
+
+func shouldRunAutoImportJSONL(cmd *cobra.Command, s storage.DoltStorage, useReadOnly, globalFlag, serverMode bool) bool {
+	if cmd == nil || s == nil || useReadOnly || globalFlag || serverMode {
+		return false
+	}
+	return cmd.Name() != "import"
 }
 
 func commandAllowsEmptyAutoExport(cmd *cobra.Command) bool {


### PR DESCRIPTION
## Summary

- move the JSONL auto-import server-mode guard from `maybeAutoImportJSONL` into the `main.go` call-site predicate
- keep server/shared-server mode from invoking auto-import recovery behavior
- update the auto-import unit coverage so the server-mode skip is tested at the caller predicate instead of inside the importer

## Why

`maybeAutoImportJSONL` is an embedded-database upgrade recovery path: it exists for users moving from the old pre-0.56 `.beads/dolt/` layout to the newer `.beads/embeddeddolt/` layout, where the embedded DB can appear empty while the git-tracked JSONL still has the user's data.

Server-backed modes do not have that recovery scenario. #4091 already fixed the functional bug by passing `serverMode` into `maybeAutoImportJSONL` and returning before any store probing/import work. That made behavior safe, but it left the call shape misleading: the main command path still "called auto-import" in server mode and relied on the importer to reject a mode it should never be responsible for handling.

This PR makes the ownership boundary explicit. `main.go` decides whether JSONL upgrade recovery is eligible for this command and storage mode; `maybeAutoImportJSONL` only performs the recovery behavior once called. That keeps the embedded-only policy visible at the boundary, avoids future readers reintroducing server-mode assumptions inside the importer, and preserves the server/shared-server skip behavior already landed in #4091.

## Context

This is a maintainer follow-up to #3995. Credit to @shaunc for identifying and documenting the poor calling shape there; this PR keeps the merged #4091 behavior while adopting the cleaner boundary raised by #3995.

## Validation

- `go test -tags gms_pure_go -run 'TestMaybeAutoImportJSONL|TestShouldRunAutoImportJSONL' ./cmd/bd`
- `go test -tags gms_pure_go -run '^$' ./cmd/bd`
- `git diff --check`

_codex-gpt-5.5-medium on behalf of CI Bot_
