### PR TITLE
gc: recheck closed deletion candidates

### DIFF
--- a/cmd/bd/closed_delete_candidates.go
+++ b/cmd/bd/closed_delete_candidates.go
@@ -8,13 +8,14 @@ import (
 
 type closedDeletionCandidateStats struct {
 	PinnedSkipped          int
+	NilSkipped             int
 	NonClosedSkipped       int
 	MissingClosedAtSkipped int
 	RecentClosedAtSkipped  int
 }
 
 func (s closedDeletionCandidateStats) SafetySkipped() int {
-	return s.NonClosedSkipped + s.MissingClosedAtSkipped + s.RecentClosedAtSkipped
+	return s.NilSkipped + s.NonClosedSkipped + s.MissingClosedAtSkipped + s.RecentClosedAtSkipped
 }
 
 func filterClosedDeletionCandidates(issues []*types.Issue, cutoff *time.Time) ([]*types.Issue, closedDeletionCandidateStats) {
@@ -23,7 +24,7 @@ func filterClosedDeletionCandidates(issues []*types.Issue, cutoff *time.Time) ([
 
 	for _, issue := range issues {
 		if issue == nil {
-			stats.MissingClosedAtSkipped++
+			stats.NilSkipped++
 			continue
 		}
 		if issue.Pinned {
@@ -52,8 +53,9 @@ func warnClosedDeletionSafetySkips(stats closedDeletionCandidateStats) {
 	if stats.SafetySkipped() == 0 {
 		return
 	}
-	WarnError("skipped %d deletion candidate(s) after closed_at safety recheck (non_closed=%d, missing_closed_at=%d, too_recent=%d)",
+	WarnError("skipped %d deletion candidate(s) after closed_at safety recheck (nil=%d, non_closed=%d, missing_closed_at=%d, too_recent=%d)",
 		stats.SafetySkipped(),
+		stats.NilSkipped,
 		stats.NonClosedSkipped,
 		stats.MissingClosedAtSkipped,
 		stats.RecentClosedAtSkipped,

--- a/cmd/bd/closed_delete_candidates.go
+++ b/cmd/bd/closed_delete_candidates.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type closedDeletionCandidateStats struct {
+	PinnedSkipped          int
+	NonClosedSkipped       int
+	MissingClosedAtSkipped int
+	RecentClosedAtSkipped  int
+}
+
+func (s closedDeletionCandidateStats) SafetySkipped() int {
+	return s.NonClosedSkipped + s.MissingClosedAtSkipped + s.RecentClosedAtSkipped
+}
+
+func filterClosedDeletionCandidates(issues []*types.Issue, cutoff *time.Time) ([]*types.Issue, closedDeletionCandidateStats) {
+	filtered := make([]*types.Issue, 0, len(issues))
+	var stats closedDeletionCandidateStats
+
+	for _, issue := range issues {
+		if issue == nil {
+			stats.MissingClosedAtSkipped++
+			continue
+		}
+		if issue.Pinned {
+			stats.PinnedSkipped++
+			continue
+		}
+		if issue.Status != types.StatusClosed {
+			stats.NonClosedSkipped++
+			continue
+		}
+		if issue.ClosedAt == nil {
+			stats.MissingClosedAtSkipped++
+			continue
+		}
+		if cutoff != nil && !issue.ClosedAt.Before(*cutoff) {
+			stats.RecentClosedAtSkipped++
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+
+	return filtered, stats
+}
+
+func warnClosedDeletionSafetySkips(stats closedDeletionCandidateStats) {
+	if stats.SafetySkipped() == 0 {
+		return
+	}
+	WarnError("skipped %d deletion candidate(s) after closed_at safety recheck (non_closed=%d, missing_closed_at=%d, too_recent=%d)",
+		stats.SafetySkipped(),
+		stats.NonClosedSkipped,
+		stats.MissingClosedAtSkipped,
+		stats.RecentClosedAtSkipped,
+	)
+}

--- a/cmd/bd/closed_delete_candidates_test.go
+++ b/cmd/bd/closed_delete_candidates_test.go
@@ -18,6 +18,7 @@ func TestFilterClosedDeletionCandidatesRechecksClosedAtCutoff(t *testing.T) {
 		{ID: "missing-closed-at", Status: types.StatusClosed},
 		{ID: "open-with-old-closed-at", Status: types.StatusOpen, ClosedAt: &oldClosedAt},
 		{ID: "pinned-old", Status: types.StatusClosed, ClosedAt: &oldClosedAt, Pinned: true},
+		nil,
 	}
 
 	filtered, stats := filterClosedDeletionCandidates(candidates, &cutoff)
@@ -36,6 +37,9 @@ func TestFilterClosedDeletionCandidatesRechecksClosedAtCutoff(t *testing.T) {
 	}
 	if stats.NonClosedSkipped != 1 {
 		t.Fatalf("NonClosedSkipped = %d, want 1", stats.NonClosedSkipped)
+	}
+	if stats.NilSkipped != 1 {
+		t.Fatalf("NilSkipped = %d, want 1", stats.NilSkipped)
 	}
 }
 

--- a/cmd/bd/closed_delete_candidates_test.go
+++ b/cmd/bd/closed_delete_candidates_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestFilterClosedDeletionCandidatesRechecksClosedAtCutoff(t *testing.T) {
+	cutoff := time.Date(2026, 3, 27, 20, 1, 44, 0, time.UTC)
+	oldClosedAt := cutoff.Add(-time.Second)
+	recentClosedAt := cutoff.Add(time.Second)
+
+	candidates := []*types.Issue{
+		{ID: "old-closed", Status: types.StatusClosed, ClosedAt: &oldClosedAt},
+		{ID: "recent-closed", Status: types.StatusClosed, ClosedAt: &recentClosedAt},
+		{ID: "missing-closed-at", Status: types.StatusClosed},
+		{ID: "open-with-old-closed-at", Status: types.StatusOpen, ClosedAt: &oldClosedAt},
+		{ID: "pinned-old", Status: types.StatusClosed, ClosedAt: &oldClosedAt, Pinned: true},
+	}
+
+	filtered, stats := filterClosedDeletionCandidates(candidates, &cutoff)
+
+	if len(filtered) != 1 || filtered[0].ID != "old-closed" {
+		t.Fatalf("filtered IDs = %v, want only old-closed", closedDeletionCandidateIDs(filtered))
+	}
+	if stats.PinnedSkipped != 1 {
+		t.Fatalf("PinnedSkipped = %d, want 1", stats.PinnedSkipped)
+	}
+	if stats.RecentClosedAtSkipped != 1 {
+		t.Fatalf("RecentClosedAtSkipped = %d, want 1", stats.RecentClosedAtSkipped)
+	}
+	if stats.MissingClosedAtSkipped != 1 {
+		t.Fatalf("MissingClosedAtSkipped = %d, want 1", stats.MissingClosedAtSkipped)
+	}
+	if stats.NonClosedSkipped != 1 {
+		t.Fatalf("NonClosedSkipped = %d, want 1", stats.NonClosedSkipped)
+	}
+}
+
+func TestFilterClosedDeletionCandidatesWithoutCutoffStillRequiresClosedAt(t *testing.T) {
+	closedAt := time.Date(2026, 4, 26, 18, 30, 18, 0, time.UTC)
+	candidates := []*types.Issue{
+		{ID: "closed", Status: types.StatusClosed, ClosedAt: &closedAt},
+		{ID: "closed-missing-time", Status: types.StatusClosed},
+	}
+
+	filtered, stats := filterClosedDeletionCandidates(candidates, nil)
+
+	if len(filtered) != 1 || filtered[0].ID != "closed" {
+		t.Fatalf("filtered IDs = %v, want only closed", closedDeletionCandidateIDs(filtered))
+	}
+	if stats.MissingClosedAtSkipped != 1 {
+		t.Fatalf("MissingClosedAtSkipped = %d, want 1", stats.MissingClosedAtSkipped)
+	}
+	if stats.RecentClosedAtSkipped != 0 {
+		t.Fatalf("RecentClosedAtSkipped = %d, want 0 without cutoff", stats.RecentClosedAtSkipped)
+	}
+}
+
+func closedDeletionCandidateIDs(issues []*types.Issue) []string {
+	ids := make([]string, len(issues))
+	for i, issue := range issues {
+		ids[i] = issue.ID
+	}
+	return ids
+}

--- a/cmd/bd/gc.go
+++ b/cmd/bd/gc.go
@@ -66,7 +66,7 @@ Examples:
 			}
 
 			cutoffDays := gcOlderThan
-			cutoffTime := time.Now().AddDate(0, 0, -cutoffDays)
+			cutoffTime := time.Now().UTC().AddDate(0, 0, -cutoffDays)
 			statusClosed := types.StatusClosed
 			filter := types.IssueFilter{
 				Status:       &statusClosed,
@@ -78,14 +78,9 @@ Examples:
 				FatalError("searching closed issues: %v", err)
 			}
 
-			// Filter out pinned issues
-			filtered := make([]*types.Issue, 0, len(closedIssues))
-			for _, issue := range closedIssues {
-				if !issue.Pinned {
-					filtered = append(filtered, issue)
-				}
-			}
-			closedIssues = filtered
+			var stats closedDeletionCandidateStats
+			closedIssues, stats = filterClosedDeletionCandidates(closedIssues, &cutoffTime)
+			warnClosedDeletionSafetySkips(stats)
 
 			if len(closedIssues) == 0 {
 				detail := fmt.Sprintf("  No closed issues older than %d days", cutoffDays)

--- a/cmd/bd/purge.go
+++ b/cmd/bd/purge.go
@@ -115,13 +115,15 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 	}
 
 	// Parse --older-than duration (e.g., "7d", "30d", "24h", or just "30" for days)
+	var cutoff *time.Time
 	if olderThan != "" {
 		days, err := parseHumanDuration(olderThan)
 		if err != nil {
 			FatalError("invalid --older-than value %q: %v", olderThan, err)
 		}
-		cutoff := time.Now().AddDate(0, 0, -days)
-		filter.ClosedBefore = &cutoff
+		cutoffTime := time.Now().UTC().AddDate(0, 0, -days)
+		cutoff = &cutoffTime
+		filter.ClosedBefore = cutoff
 	}
 
 	// Get matching issues
@@ -141,17 +143,10 @@ func runPurgeOrPrune(cmd *cobra.Command, scope purgeScope) {
 		closedIssues = matched
 	}
 
-	// Filter out pinned beads
-	pinnedCount := 0
-	filtered := make([]*types.Issue, 0, len(closedIssues))
-	for _, issue := range closedIssues {
-		if issue.Pinned {
-			pinnedCount++
-			continue
-		}
-		filtered = append(filtered, issue)
-	}
-	closedIssues = filtered
+	var safetyStats closedDeletionCandidateStats
+	closedIssues, safetyStats = filterClosedDeletionCandidates(closedIssues, cutoff)
+	pinnedCount := safetyStats.PinnedSkipped
+	warnClosedDeletionSafetySkips(safetyStats)
 
 	// Report nothing-to-do
 	if len(closedIssues) == 0 {


### PR DESCRIPTION
## Why This Exists

`bd gc --older-than` is destructive. After it deletes issues, a later compact or garbage-collection step can make recovery partial or impossible.

#3543 reports that failure class in production: `bd gc --older-than 30 --force` deleted recently closed beads that should not have matched the age cutoff. The storage query already asks for `status = closed` and `closed_at < cutoff`, and a small sandbox case does not reproduce the incident. That makes this a defensive safety patch, not a narrow repro fix.

For destructive lifecycle commands, the command layer should independently verify the deletion contract immediately before `DeleteIssue`. If a backend, query path, timezone conversion, row-shape bug, or future refactor ever returns an unsafe candidate, `bd gc`, `bd prune`, and `bd purge` should skip it instead of deleting it.

## What Changed

- Add a shared closed-delete candidate safety filter.
- Require each candidate to still be closed, have `closed_at`, pass the cutoff in Go, and not be pinned.
- Use UTC cutoffs for age-based deletion commands.
- Apply the same pre-delete recheck to `bd gc`, `bd prune`, and `bd purge`.
- Warn when a storage result is skipped by the application-level safety recheck.

Fixes #3543.

## Validation

- `CGO_ENABLED=0 go test ./cmd/bd -run 'TestFilterClosedDeletionCandidates'`
- `CGO_ENABLED=0 go test -tags gms_pure_go -c -o /tmp/bd-cmd-test ./cmd/bd`
- `git diff --check`

Default cgo `cmd/bd` test compilation is blocked in this local environment by missing ICU header `unicode/uregex.h`.

_codex-gpt-5.5-medium on behalf of CI Bot_
