### PR TITLE
fix(hooks): bound prime and hook waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.codex-plugin/hooks/`, preventing Claude from loading Codex-only hooks from
   the shared plugin root while keeping Codex setup pointed at `bd codex-hook`.
   ([#3924](https://github.com/gastownhall/beads/issues/3924))
+- **Hook and prime wait bounds** - generated git hooks now fall back from
+  `timeout` to `gtimeout` to Perl `alarm`, and `bd prime` memory loading is
+  bounded by `BEADS_PRIME_TIMEOUT` (default 10s). Non-positive
+  `BEADS_PRIME_TIMEOUT` values fall back to the default instead of silently
+  disabling the safety bound. Internal beads-repo git operations also run with
+  hooks suppressed via `core.hooksPath=` so automated `.beads/` commits and
+  pushes cannot recurse through user hook managers. `GitCmdCWD()` remains for
+  user-working-repo status/ref operations and does not perform beads commits.
+  ([#4172](https://github.com/gastownhall/beads/pull/4172))
 - **JSONL auto-export shrink guard** - when opt-in `export.auto` is enabled,
   auto-export now refuses to overwrite an existing `.beads/issues.jsonl` that
   contains records outside the auto-export scope (memories, infrastructure

--- a/cmd/bd/direct_mode.go
+++ b/cmd/bd/direct_mode.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/steveyegge/beads/internal/beads"
@@ -14,6 +15,14 @@ func ensureDirectMode(_ string) error {
 // ensureStoreActive guarantees that a storage backend is initialized and tracked.
 // Uses the factory to respect metadata.json backend configuration.
 func ensureStoreActive() error {
+	return ensureStoreActiveWithContext(getRootContext())
+}
+
+func ensureStoreActiveWithContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	lockStore()
 	active := isStoreActive() && getStore() != nil
 	unlockStore()
@@ -30,7 +39,7 @@ func ensureStoreActive() error {
 
 	// Use the factory to create the appropriate backend
 	// based on metadata.json configuration and build tags
-	store, err := newDoltStoreFromConfig(getRootContext(), beadsDir)
+	store, err := newDoltStoreFromConfig(ctx, beadsDir)
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w\nHint: %s", err, diagHint())
 	}

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -67,6 +67,7 @@ func generateHookSection(hookName string) string {
 		"if command -v bd >/dev/null 2>&1; then\n" +
 		"  export BD_GIT_HOOK=1\n" +
 		"  _bd_timeout=${BEADS_HOOK_TIMEOUT:-" + fmt.Sprintf("%d", hookTimeoutSeconds) + "}\n" +
+		"  _bd_used_perl=0\n" +
 		"  if command -v timeout >/dev/null 2>&1; then\n" +
 		"    timeout \"$_bd_timeout\" bd hooks run " + hookName + " \"$@\"\n" +
 		"    _bd_exit=$?\n" +
@@ -74,6 +75,7 @@ func generateHookSection(hookName string) string {
 		"    gtimeout \"$_bd_timeout\" bd hooks run " + hookName + " \"$@\"\n" +
 		"    _bd_exit=$?\n" +
 		"  elif command -v perl >/dev/null 2>&1; then\n" +
+		"    _bd_used_perl=1\n" +
 		"    perl -e 'alarm shift; exec @ARGV' \"$_bd_timeout\" bd hooks run " + hookName + " \"$@\"\n" +
 		"    _bd_exit=$?\n" +
 		"  else\n" +
@@ -81,7 +83,7 @@ func generateHookSection(hookName string) string {
 		"    bd hooks run " + hookName + " \"$@\"\n" +
 		"    _bd_exit=$?\n" +
 		"  fi\n" +
-		"  if [ $_bd_exit -eq 124 ] || [ $_bd_exit -eq 142 ]; then\n" +
+		"  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then\n" +
 		"    echo >&2 \"beads: hook '" + hookName + "' timed out after ${_bd_timeout}s — continuing without beads\"\n" +
 		"    _bd_exit=0\n" +
 		"  fi\n" +

--- a/cmd/bd/hooks.go
+++ b/cmd/bd/hooks.go
@@ -70,13 +70,20 @@ func generateHookSection(hookName string) string {
 		"  if command -v timeout >/dev/null 2>&1; then\n" +
 		"    timeout \"$_bd_timeout\" bd hooks run " + hookName + " \"$@\"\n" +
 		"    _bd_exit=$?\n" +
-		"    if [ $_bd_exit -eq 124 ]; then\n" +
-		"      echo >&2 \"beads: hook '" + hookName + "' timed out after ${_bd_timeout}s — continuing without beads\"\n" +
-		"      _bd_exit=0\n" +
-		"    fi\n" +
+		"  elif command -v gtimeout >/dev/null 2>&1; then\n" +
+		"    gtimeout \"$_bd_timeout\" bd hooks run " + hookName + " \"$@\"\n" +
+		"    _bd_exit=$?\n" +
+		"  elif command -v perl >/dev/null 2>&1; then\n" +
+		"    perl -e 'alarm shift; exec @ARGV' \"$_bd_timeout\" bd hooks run " + hookName + " \"$@\"\n" +
+		"    _bd_exit=$?\n" +
 		"  else\n" +
+		"    echo >&2 \"beads: hook '" + hookName + "' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT\"\n" +
 		"    bd hooks run " + hookName + " \"$@\"\n" +
 		"    _bd_exit=$?\n" +
+		"  fi\n" +
+		"  if [ $_bd_exit -eq 124 ] || [ $_bd_exit -eq 142 ]; then\n" +
+		"    echo >&2 \"beads: hook '" + hookName + "' timed out after ${_bd_timeout}s — continuing without beads\"\n" +
+		"    _bd_exit=0\n" +
 		"  fi\n" +
 		"  if [ $_bd_exit -eq 3 ]; then\n" +
 		"    echo >&2 \"beads: database not initialized — skipping hook '" + hookName + "'\"\n" +

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -215,13 +215,16 @@ func TestGenerateHookSection_Timeout(t *testing.T) {
 	if !strings.Contains(section, "perl -e 'alarm shift; exec @ARGV'") {
 		t.Error("section missing perl alarm fallback for stock macOS")
 	}
+	if !strings.Contains(section, "_bd_used_perl=1") {
+		t.Error("section missing perl branch marker")
+	}
 
 	// Timeout exit code (124) must be handled gracefully — continue, don't block git
 	if !strings.Contains(section, "_bd_exit -eq 124") {
 		t.Error("section missing timeout exit code handling")
 	}
-	if !strings.Contains(section, "_bd_exit -eq 142") {
-		t.Error("section missing SIGALRM timeout exit code handling")
+	if !strings.Contains(section, "[ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]") {
+		t.Error("section missing perl-scoped SIGALRM timeout exit code handling")
 	}
 	if !strings.Contains(section, "timed out") {
 		t.Error("section missing timeout warning message")

--- a/cmd/bd/init_hooks_test.go
+++ b/cmd/bd/init_hooks_test.go
@@ -209,18 +209,27 @@ func TestGenerateHookSection_Timeout(t *testing.T) {
 	if !strings.Contains(section, "command -v timeout") {
 		t.Error("section missing timeout availability check")
 	}
+	if !strings.Contains(section, "command -v gtimeout") {
+		t.Error("section missing gtimeout fallback for macOS coreutils")
+	}
+	if !strings.Contains(section, "perl -e 'alarm shift; exec @ARGV'") {
+		t.Error("section missing perl alarm fallback for stock macOS")
+	}
 
 	// Timeout exit code (124) must be handled gracefully — continue, don't block git
 	if !strings.Contains(section, "_bd_exit -eq 124") {
 		t.Error("section missing timeout exit code handling")
 	}
+	if !strings.Contains(section, "_bd_exit -eq 142") {
+		t.Error("section missing SIGALRM timeout exit code handling")
+	}
 	if !strings.Contains(section, "timed out") {
 		t.Error("section missing timeout warning message")
 	}
 
-	// Fallback path when timeout command is not available (e.g. macOS without coreutils)
-	if !strings.Contains(section, "else") {
-		t.Error("section missing fallback for systems without timeout command")
+	// Last-resort path is explicit when no timeout implementation is available.
+	if !strings.Contains(section, "running without timeout") {
+		t.Error("section missing clear fallback warning for systems without timeout support")
 	}
 }
 

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -43,10 +43,16 @@ func primeStoreTimeout() time.Duration {
 		return primeStoreTimeoutDefault
 	}
 	if d, err := time.ParseDuration(raw); err == nil {
-		return d
+		if d > 0 {
+			return d
+		}
+		return primeStoreTimeoutDefault
 	}
 	if d, err := time.ParseDuration(raw + "s"); err == nil {
-		return d
+		if d > 0 {
+			return d
+		}
+		return primeStoreTimeoutDefault
 	}
 	return primeStoreTimeoutDefault
 }

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/beads"
@@ -27,6 +29,27 @@ var (
 	primeMemoriesOnly bool
 	primeHookJSONMode bool
 )
+
+const (
+	primeStoreTimeoutEnv     = "BEADS_PRIME_TIMEOUT"
+	primeStoreTimeoutDefault = 10 * time.Second
+)
+
+var ensureStoreActiveForPrime = ensureStoreActiveWithContext
+
+func primeStoreTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(primeStoreTimeoutEnv))
+	if raw == "" {
+		return primeStoreTimeoutDefault
+	}
+	if d, err := time.ParseDuration(raw); err == nil {
+		return d
+	}
+	if d, err := time.ParseDuration(raw + "s"); err == nil {
+		return d
+	}
+	return primeStoreTimeoutDefault
+}
 
 // resolveGlobalPrimePath returns the path to ~/.config/beads/PRIME.md if it
 // exists. configDirOverride is used for testing; pass "" for production.
@@ -305,7 +328,17 @@ func outputMemoriesOnlyContext(w io.Writer) error {
 func formatMemoriesForPrime(compact bool) string {
 	// Try to initialize store if not already active (prime may run before other commands)
 	if store == nil {
-		if err := ensureDirectMode("memory injection"); err != nil {
+		timeout := primeStoreTimeout()
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if timeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		if err := ensureStoreActiveForPrime(ctx); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return formatPrimeMemoryTimeout(compact, timeout)
+			}
 			return "" // Silently skip — store unavailable
 		}
 	}
@@ -352,6 +385,17 @@ func formatMemoriesForPrime(compact bool) string {
 		}
 	}
 	return sb.String()
+}
+
+func formatPrimeMemoryTimeout(compact bool, timeout time.Duration) string {
+	if timeout <= 0 {
+		timeout = primeStoreTimeoutDefault
+	}
+	msg := fmt.Sprintf("Skipped: timed out after %s opening beads storage. Another bd process or stale storage lock may be blocking memory injection; run `bd doctor` and stop stuck bd processes before retrying.", timeout.Round(time.Millisecond))
+	if compact {
+		return "\n## Memories\n- " + msg + "\n"
+	}
+	return "\n## Persistent Memories\n\n" + msg + "\n"
 }
 
 // maybePullStaleLinearData checks if Linear data is stale and auto-pulls

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -202,6 +203,32 @@ func TestPrimeMemoriesOnlyNoMemories(t *testing.T) {
 	}
 	if strings.Contains(output, "Essential Commands") {
 		t.Fatalf("memories-only output should not include the full workflow guide: %s", output)
+	}
+}
+
+func TestFormatMemoriesForPrimeTimesOutOpeningStore(t *testing.T) {
+	oldStore := store
+	oldStoreActive := storeActive
+	oldEnsure := ensureStoreActiveForPrime
+	store = nil
+	storeActive = false
+	ensureStoreActiveForPrime = func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	t.Cleanup(func() {
+		store = oldStore
+		storeActive = oldStoreActive
+		ensureStoreActiveForPrime = oldEnsure
+	})
+	t.Setenv(primeStoreTimeoutEnv, "1ms")
+
+	out := formatMemoriesForPrime(false)
+	if !strings.Contains(out, "timed out") {
+		t.Fatalf("expected timeout warning in prime memory output, got %q", out)
+	}
+	if !strings.Contains(out, "stale storage lock") {
+		t.Fatalf("expected stale-lock guidance in prime memory output, got %q", out)
 	}
 }
 

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -232,6 +232,17 @@ func TestFormatMemoriesForPrimeTimesOutOpeningStore(t *testing.T) {
 	}
 }
 
+func TestPrimeStoreTimeoutNonPositiveUsesDefault(t *testing.T) {
+	for _, value := range []string{"0", "0s", "-5s"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(primeStoreTimeoutEnv, value)
+			if got := primeStoreTimeout(); got != primeStoreTimeoutDefault {
+				t.Fatalf("primeStoreTimeout() = %s, want default %s", got, primeStoreTimeoutDefault)
+			}
+		})
+	}
+}
+
 func TestPrimeContextUsesWorkspaceLanguage(t *testing.T) {
 	defer stubIsEphemeralBranch(false)()
 	defer stubPrimeHasGitRemote(true)()

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/steveyegge/beads/internal/beads"
@@ -39,17 +38,7 @@ func resolveSyncRemoteFromDir(beadsDir string) string {
 // nothing to commit). Used by bd dolt remote add/remove to keep the
 // working tree clean after persisting sync.remote.
 func commitBeadsConfig(msg string) {
-	addCmd := exec.Command("git", "add", ".beads/config.yaml")
-	if err := addCmd.Run(); err != nil {
-		return
-	}
-	commitCmd := exec.Command("git", "commit", "-m", msg) //nolint:gosec // G702: msg is from internal callers only, not user input
-	if out, err := commitCmd.CombinedOutput(); err != nil {
-		// "nothing to commit" is normal if the file was already staged
-		if !strings.Contains(string(out), "nothing to commit") {
-			fmt.Fprintf(os.Stderr, "Warning: failed to commit config change: %v\n", err)
-		}
-	}
+	commitBeadsConfigForActiveRepo(context.Background(), msg)
 }
 
 func commitBeadsConfigForActiveRepo(ctx context.Context, msg string) {

--- a/cmd/bd/sync_remote_test.go
+++ b/cmd/bd/sync_remote_test.go
@@ -1,6 +1,15 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	internalbeads "github.com/steveyegge/beads/internal/beads"
+	internalgit "github.com/steveyegge/beads/internal/git"
+)
 
 func TestNormalizeRemoteURL(t *testing.T) {
 	tests := []struct {
@@ -37,4 +46,69 @@ func TestNormalizeRemoteURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommitBeadsConfigSkipsGitHooks(t *testing.T) {
+	repo := t.TempDir()
+	runGitForCommitConfigTest(t, repo, "init")
+	runGitForCommitConfigTest(t, repo, "config", "user.email", "test@example.com")
+	runGitForCommitConfigTest(t, repo, "config", "user.name", "Test User")
+
+	beadsDir := filepath.Join(repo, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("sync:\n  remote: git+https://example.com/repo.git\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	hooksDir := filepath.Join(repo, ".git", "hooks")
+	hookMarker := filepath.Join(repo, "hook-ran")
+	hook := "#!/bin/sh\n" +
+		"echo hook-ran > " + shellQuoteForTest(hookMarker) + "\n" +
+		"exit 42\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "pre-commit"), []byte(hook), 0o755); err != nil {
+		t.Fatalf("write pre-commit hook: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	internalbeads.ResetCaches()
+	internalgit.ResetCaches()
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+		internalbeads.ResetCaches()
+		internalgit.ResetCaches()
+	})
+
+	commitBeadsConfig("bd: update sync.remote")
+
+	if _, err := os.Stat(hookMarker); !os.IsNotExist(err) {
+		t.Fatalf("pre-commit hook ran during internal config commit")
+	}
+	out := runGitForCommitConfigTest(t, repo, "log", "-1", "--format=%s")
+	if got := strings.TrimSpace(out); got != "bd: update sync.remote" {
+		t.Fatalf("commit subject = %q, want %q", got, "bd: update sync.remote")
+	}
+}
+
+func runGitForCommitConfigTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
+}
+
+func shellQuoteForTest(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/cmd/bd/worktree_cmd.go
+++ b/cmd/bd/worktree_cmd.go
@@ -434,14 +434,14 @@ func runWorktreeInfo(cmd *cobra.Command, args []string) error {
 // This is used for worktree operations that need to run in a specific location
 // (either the CWD repo root or a specific worktree path).
 //
-// Security: Sets GIT_HOOKS_PATH and GIT_TEMPLATE_DIR to disable hooks/templates
+// Security: Sets core.hooksPath and GIT_TEMPLATE_DIR to disable hooks/templates
 // for defense-in-depth, matching the pattern in RepoContext.GitCmd().
 func gitCmdInDir(ctx context.Context, dir string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	gitArgs := append([]string{"-c", "core.hooksPath="}, args...)
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Dir = dir
 	// Security: Disable git hooks and templates (SEC-001, SEC-002)
 	cmd.Env = append(os.Environ(),
-		"GIT_HOOKS_PATH=",
 		"GIT_TEMPLATE_DIR=",
 	)
 	return cmd

--- a/cmd/bd/worktree_test.go
+++ b/cmd/bd/worktree_test.go
@@ -68,6 +68,31 @@ func TestGitRevParse(t *testing.T) {
 	}
 }
 
+func TestGitCmdInDirSuppressesHooksViaGitConfig(t *testing.T) {
+	cmd := gitCmdInDir(t.Context(), "/tmp/example", "status", "--porcelain")
+	if cmd.Dir != "/tmp/example" {
+		t.Fatalf("cmd.Dir = %q, want /tmp/example", cmd.Dir)
+	}
+	wantArgs := []string{"-c", "core.hooksPath=", "status", "--porcelain"}
+	if len(cmd.Args) != len(wantArgs)+1 {
+		t.Fatalf("cmd.Args = %#v, want git plus %#v", cmd.Args, wantArgs)
+	}
+	for i, want := range wantArgs {
+		if got := cmd.Args[i+1]; got != want {
+			t.Fatalf("cmd.Args[%d] = %q, want %q; full args: %#v", i+1, got, want, cmd.Args)
+		}
+	}
+	for _, env := range cmd.Env {
+		if env == "GIT_HOOKS_PATH=" {
+			t.Fatal("cmd.Env contains dead GIT_HOOKS_PATH hook suppression")
+		}
+		if env == "GIT_TEMPLATE_DIR=" {
+			return
+		}
+	}
+	t.Fatal("cmd.Env missing GIT_TEMPLATE_DIR suppression")
+}
+
 // TestResolveWorktreePathByName verifies that resolveWorktreePath can find
 // worktrees by name (basename) when they're in subdirectories like .worktrees/
 func TestResolveWorktreePathByName(t *testing.T) {

--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -233,7 +233,8 @@ func getRepoRootFromPath(path string) (string, error) {
 // We explicitly set GIT_DIR and GIT_WORK_TREE to ensure git operates on
 // the correct repository (the one containing .beads/).
 func (rc *RepoContext) GitCmd(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "git", args...)
+	gitArgs := append([]string{"-c", "core.hooksPath="}, args...)
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 	cmd.Dir = rc.RepoRoot
 
 	// GH#2538: Ensure git uses the target repository, not the worktree we may be running from.
@@ -243,7 +244,7 @@ func (rc *RepoContext) GitCmd(ctx context.Context, args ...string) *exec.Cmd {
 	// Security: Disable git hooks and templates to prevent code execution
 	// in potentially malicious repositories (SEC-001, SEC-002)
 	cmd.Env = append(os.Environ(),
-		"GIT_HOOKS_PATH=",            // Disable hooks
+		"GIT_HOOKS_PATH=",            // Defense in depth; core.hooksPath is disabled via git -c above.
 		"GIT_TEMPLATE_DIR=",          // Disable templates
 		"GIT_DIR="+gitDir,            // Ensure git uses the correct .git directory
 		"GIT_WORK_TREE="+rc.RepoRoot, // Ensure git uses the correct work tree

--- a/internal/beads/context.go
+++ b/internal/beads/context.go
@@ -244,7 +244,6 @@ func (rc *RepoContext) GitCmd(ctx context.Context, args ...string) *exec.Cmd {
 	// Security: Disable git hooks and templates to prevent code execution
 	// in potentially malicious repositories (SEC-001, SEC-002)
 	cmd.Env = append(os.Environ(),
-		"GIT_HOOKS_PATH=",            // Defense in depth; core.hooksPath is disabled via git -c above.
 		"GIT_TEMPLATE_DIR=",          // Disable templates
 		"GIT_DIR="+gitDir,            // Ensure git uses the correct .git directory
 		"GIT_WORK_TREE="+rc.RepoRoot, // Ensure git uses the correct work tree


### PR DESCRIPTION
## Summary
- Bound `bd prime` memory-store opening with `BEADS_PRIME_TIMEOUT` (default 10s) so SessionStart hooks do not hang indefinitely when storage acquisition stalls.
- Treat non-positive `BEADS_PRIME_TIMEOUT` values as the default bound instead of silently disabling the timeout.
- Added macOS-capable hook timeout fallback: `timeout`, then `gtimeout`, then Perl `alarm`; SIGALRM exit handling is scoped to the Perl fallback.
- Routed internal beads-repo git commands through `git -c core.hooksPath=` and disabled templates so automated `.beads/` commits and pushes do not recurse through user hook managers. `GitCmdCWD()` remains for user-working-repo status/ref operations and does not perform beads commits.

## Why
Agent and hook workflows call `bd prime` and beads-managed git operations from automation paths where an unbounded storage open or recursive hook can strand the whole session. This keeps those automation paths bounded and non-reentrant.

## Tests
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestGenerateHookSection_Timeout|TestPrimeStoreTimeoutNonPositiveUsesDefault|TestFormatMemoriesForPrimeTimesOutOpeningStore|TestGitCmdInDirSuppressesHooksViaGitConfig' -count=1`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./internal/beads -run 'TestRepoContext_GitCmdCWD|TestGitCmd|TestRepoContext' -count=1`
- `git diff --check`

Fixes #3701
Fixes #3707

_codex-gpt-5.5-medium on behalf of matt wilkie_
