### PR TITLE
fix(init): guard JSONL init against remote history

### DIFF
--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -487,6 +487,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// non-letter is prefixed with "bd_" so the derived MySQL identifier is
 		// valid (directory names like "001" are common in temp dirs).
 		prefix = normalizeIssuePrefix(prefix)
+		remoteDivergenceConfirmed := false
 
 		// Cross-boundary safety (bd-q83 / ADR 0002): check remote state
 		// BEFORE any filesystem side-effects so a refusal exits cleanly.
@@ -500,9 +501,12 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 			if earlyRemoteSource == initSyncRemoteExplicit {
 				// An explicit --remote is intent to bootstrap or wire that URL,
 				// but it is not proof that the remote already contains Dolt
-				// history. Let the clone attempt below distinguish populated
-				// remotes from empty remotes so --reinit-local can still fall
-				// back to a fresh local init against a new remote.
+				// history. --from-jsonl is the exception: it selects a local
+				// source and skips cloning, so we must probe now rather than
+				// silently wiring a populated remote to orphan local history.
+				if fromJSONL {
+					earlyRemoteHasDoltData = gitRemoteHasDoltDataRef(earlySyncURL)
+				}
 			} else if earlyRemoteSource == initSyncRemoteConfigured {
 				earlyRemoteHasDoltData = true // sync.remote configured = user intends bootstrap
 			} else if earlyRemoteSource == initSyncRemoteNone && !stealth && isGitRepo() && !isBareGitRepo() {
@@ -515,15 +519,25 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				earlyDecision := CheckRemoteSafety(RemoteSafetyInput{
 					Force:             force,
 					ReinitLocal:       reinitLocal,
+					FromJSONL:         fromJSONL,
 					DiscardRemote:     discardRemote,
 					DestroyToken:      destroyToken,
 					ExpectedToken:     FormatDestroyToken(prefix),
 					RemoteHasDoltData: earlyRemoteHasDoltData,
 					IsInteractive:     term.IsTerminal(int(os.Stdin.Fd())),
 				})
-				if earlyDecision.Action == ActionRefuseDivergence || earlyDecision.Action == ActionRequireDestroyToken {
-					fmt.Fprintf(os.Stderr, "\n%s\n\n", earlyDecision.UserMessage)
-					os.Exit(earlyDecision.ExitCode)
+				if handleRemoteSafetyDecision(earlyDecision, prefix, earlySyncURL, destroyToken, func() bool {
+					switch earlyRemoteSource {
+					case initSyncRemoteExplicit:
+						return gitRemoteHasDoltDataRef(earlySyncURL)
+					case initSyncRemoteConfigured:
+						return earlyRemoteHasDoltData
+					default:
+						return gitOriginHasDoltDataRef()
+					}
+				}, earlyRemoteHasDoltData, &remoteDivergenceConfirmed) {
+					// The early guard refuses and confirms only; bootstrap
+					// selection happens later after beadsDir/dbName are known.
 				}
 			}
 		}
@@ -792,13 +806,42 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		remoteHasDoltData := false
 
 		if syncURL != "" {
-			// sync.remote was explicitly configured. Treat as bootstrap-
-			// from-remote intent; CheckRemoteSafety still enforces that
-			// --force/--reinit-local can't silently fight that intent.
+			// sync.remote was explicitly configured. Treat it as bootstrap-
+			// from-remote intent unless --from-jsonl selected a local JSONL
+			// source. CheckRemoteSafety still enforces that local-source
+			// flags can't silently fight a configured remote.
 			// Trust the URL format as-is: normalizeRemoteURL would convert
 			// http:// to git+http:// and break Dolt remotesapi endpoints
 			// configured explicitly by the user (GH#3339).
-			syncFromRemote = true
+			if syncRemoteSource == initSyncRemoteExplicit && !fromJSONL {
+				syncFromRemote = true
+			} else if syncRemoteSource == initSyncRemoteConfigured {
+				remoteHasDoltData = true
+			} else if syncRemoteSource == initSyncRemoteExplicit {
+				remoteHasDoltData = gitRemoteHasDoltDataRef(syncURL)
+			}
+			if !syncFromRemote {
+				decision := CheckRemoteSafety(RemoteSafetyInput{
+					Force:             force,
+					ReinitLocal:       reinitLocal,
+					FromJSONL:         fromJSONL,
+					DiscardRemote:     discardRemote,
+					DestroyToken:      destroyToken,
+					ExpectedToken:     FormatDestroyToken(prefix),
+					RemoteHasDoltData: remoteHasDoltData,
+					IsInteractive:     term.IsTerminal(int(os.Stdin.Fd())),
+				})
+				if handleRemoteSafetyDecision(decision, prefix, syncURL, destroyToken, func() bool {
+					if syncRemoteSource == initSyncRemoteExplicit {
+						return gitRemoteHasDoltDataRef(syncURL)
+					}
+					return remoteHasDoltData
+				}, remoteHasDoltData, &remoteDivergenceConfirmed) {
+					syncFromRemote = true
+				} else {
+					syncFromRemote = false
+				}
+			}
 		} else if syncRemoteSource == initSyncRemoteNone && !stealth && isGitRepo() && !isBareGitRepo() {
 			if originURL, err := gitOriginGetURL(); err == nil && originURL != "" {
 				syncURL = normalizeRemoteURL(originURL)
@@ -808,6 +851,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 				decision := CheckRemoteSafety(RemoteSafetyInput{
 					Force:             force,
 					ReinitLocal:       reinitLocal,
+					FromJSONL:         fromJSONL,
 					DiscardRemote:     discardRemote,
 					DestroyToken:      destroyToken,
 					ExpectedToken:     FormatDestroyToken(prefix),
@@ -815,40 +859,8 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					IsInteractive:     term.IsTerminal(int(os.Stdin.Fd())),
 				})
 
-				switch decision.Action {
-				case ActionRefuseDivergence, ActionRequireDestroyToken:
-					fmt.Fprintf(os.Stderr, "\n%s\n\n", decision.UserMessage)
-					os.Exit(decision.ExitCode)
-				case ActionBootstrap:
+				if handleRemoteSafetyDecision(decision, prefix, syncURL, destroyToken, gitOriginHasDoltDataRef, remoteHasDoltData, &remoteDivergenceConfirmed) {
 					syncFromRemote = true
-				case ActionProceedWithDivergence:
-					// Interactive destroy-token prompt (non-interactive
-					// path already validated by CheckRemoteSafety).
-					if decision.Reason == "authorized-divergence" && term.IsTerminal(int(os.Stdin.Fd())) && destroyToken == "" {
-						expected := FormatDestroyToken(prefix)
-						fmt.Fprintf(os.Stderr, "\n%s You are about to discard the remote's Dolt history.\n\n", ui.RenderWarn("WARNING:"))
-						fmt.Fprintf(os.Stderr, "  Remote: %s\n", syncURL)
-						fmt.Fprintf(os.Stderr, "  Type %q to confirm: ", expected)
-						scanner := bufio.NewScanner(os.Stdin)
-						scanner.Scan()
-						if strings.TrimSpace(scanner.Text()) != expected {
-							fmt.Fprintf(os.Stderr, "\nAborted. See 'bd help init-safety' for details.\n")
-							os.Exit(ExitDestroyTokenMissing)
-						}
-					}
-					// Race-safety: re-verify the remote state hasn't
-					// changed between our earlier gitOriginHasDoltDataRef and
-					// the user's confirmation. If another agent pushed
-					// during the prompt window, fail rather than silently
-					// overwriting their fresh work.
-					if gitOriginHasDoltDataRef() != remoteHasDoltData {
-						fmt.Fprintf(os.Stderr, "\nAborted: remote state changed during confirmation. Re-run to re-verify intent.\n")
-						os.Exit(ExitRemoteDivergenceRefused)
-					}
-					// Proceed without bootstrap; remote will be overwritten on next push.
-					// syncFromRemote stays false.
-				case ActionNoRemoteData:
-					// Fresh remote, no-op for bootstrap decision.
 				}
 			}
 		}
@@ -1706,7 +1718,7 @@ func init() {
 	initCmd.Flags().Bool("force", false, "Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').")
 	initCmd.Flags().Bool("reinit-local", false, "Re-initialize local .beads/ over existing local data. Does NOT authorize remote divergence; see --discard-remote.")
 	initCmd.Flags().Bool("discard-remote", false, "Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.")
-	initCmd.Flags().Bool("from-jsonl", false, "Import issues from configured import.path instead of git history")
+	initCmd.Flags().Bool("from-jsonl", false, "Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement")
 	initCmd.Flags().Bool("init-if-missing", false, "If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)")
 	initCmd.Flags().String("destroy-token", "", "Explicit confirmation token for destructive re-init in non-interactive mode (format: 'DESTROY-<prefix>')")
 	initCmd.Flags().String("agents-template", "", "Path to custom AGENTS.md template (overrides embedded default)")
@@ -2285,6 +2297,35 @@ func shouldConfigureInitDoltRemote(syncURL string, syncFromRemote, syncURLFromCo
 
 func isDoltLocalOnly() bool {
 	return config.GetBool("dolt.local-only")
+}
+
+func handleRemoteSafetyDecision(decision RemoteSafetyDecision, prefix, syncURL, destroyToken string, remoteHasDoltData func() bool, observedRemoteHasDoltData bool, confirmed *bool) bool {
+	switch decision.Action {
+	case ActionRefuseDivergence, ActionRequireDestroyToken:
+		fmt.Fprintf(os.Stderr, "\n%s\n\n", decision.UserMessage)
+		os.Exit(decision.ExitCode)
+	case ActionBootstrap:
+		return true
+	case ActionProceedWithDivergence:
+		if decision.Reason == "authorized-divergence" && term.IsTerminal(int(os.Stdin.Fd())) && destroyToken == "" && !*confirmed {
+			expected := FormatDestroyToken(prefix)
+			fmt.Fprintf(os.Stderr, "\n%s You are about to discard the remote's Dolt history.\n\n", ui.RenderWarn("WARNING:"))
+			fmt.Fprintf(os.Stderr, "  Remote: %s\n", syncURL)
+			fmt.Fprintf(os.Stderr, "  Type %q to confirm: ", expected)
+			scanner := bufio.NewScanner(os.Stdin)
+			scanner.Scan()
+			if strings.TrimSpace(scanner.Text()) != expected {
+				fmt.Fprintf(os.Stderr, "\nAborted. See 'bd help init-safety' for details.\n")
+				os.Exit(ExitDestroyTokenMissing)
+			}
+			*confirmed = true
+		}
+		if remoteHasDoltData != nil && remoteHasDoltData() != observedRemoteHasDoltData {
+			fmt.Fprintf(os.Stderr, "\nAborted: remote state changed during confirmation. Re-run to re-verify intent.\n")
+			os.Exit(ExitRemoteDivergenceRefused)
+		}
+	}
+	return false
 }
 
 func configureInitDoltRemote(ctx context.Context, store storage.DoltStorage, syncURL string, quiet bool) {

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -1220,6 +1220,61 @@ func TestEmbeddedInit(t *testing.T) {
 		}
 	})
 
+	t.Run("from_jsonl_with_remote_data_requires_discard_and_skips_clone", func(t *testing.T) {
+		bareDir := filepath.Join(t.TempDir(), "remote.git")
+		runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+
+		sourceDir := t.TempDir()
+		runGitForBootstrapTest(t, sourceDir, "init", "-b", "main")
+		runGitForBootstrapTest(t, sourceDir, "config", "user.email", "test@test.com")
+		runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
+		runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
+		runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
+		runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+		runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
+
+		dir := t.TempDir()
+		initGitRepoAt(t, dir)
+		runGitForBootstrapTest(t, dir, "remote", "add", "origin", bareDir)
+
+		beadsDir := filepath.Join(dir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		issue := types.Issue{
+			ID:        "jlremote-abc123",
+			Title:     "JSONL authoritative",
+			Status:    types.StatusOpen,
+			Priority:  2,
+			IssueType: types.TypeTask,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		line, _ := json.Marshal(issue)
+		if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), append(line, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := exec.Command(bd, "init", "--prefix", "jlremote", "--from-jsonl", "--discard-remote", "--destroy-token=DESTROY-jlremote", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("--from-jsonl with authorized remote discard should import without cloning: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+
+		showCmd := exec.Command(bd, "show", "jlremote-abc123", "--json")
+		showCmd.Dir = dir
+		showCmd.Env = bdEnv(dir)
+		out, err := showCmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("imported issue not found: %v\n%s", err, out)
+		}
+		if !strings.Contains(string(out), "JSONL authoritative") {
+			t.Fatalf("imported issue title missing from show output:\n%s", out)
+		}
+	})
+
 	t.Run("from_jsonl_uses_import_path", func(t *testing.T) {
 		dir := t.TempDir()
 		initGitRepoAt(t, dir)

--- a/cmd/bd/init_safety.go
+++ b/cmd/bd/init_safety.go
@@ -21,7 +21,7 @@ import "fmt"
 // Exit codes for init-safety refusals. Stable values so CI scripts can
 // branch on them without grep'ing stderr.
 const (
-	// ExitRemoteDivergenceRefused signals `bd init --force` was called
+	// ExitRemoteDivergenceRefused signals a local-source init was called
 	// against a remote that already has `refs/dolt/data`, without
 	// `--discard-remote`. Ambiguous identity source.
 	ExitRemoteDivergenceRefused = 10
@@ -76,8 +76,12 @@ type RemoteSafetyInput struct {
 	// Flag state. Force is kept as a separate field so callers can route
 	// deprecation warnings at the call site; CheckRemoteSafety treats it
 	// as equivalent to ReinitLocal.
-	Force         bool
-	ReinitLocal   bool
+	Force       bool
+	ReinitLocal bool
+	// FromJSONL selects local JSONL as the init source instead of remote
+	// Dolt history. When remote history exists, this is a local-source
+	// override and must not silently diverge without DiscardRemote.
+	FromJSONL     bool
 	DiscardRemote bool
 
 	// Destroy-token supplied on the command line, plus the token the
@@ -118,11 +122,12 @@ func CheckRemoteSafety(in RemoteSafetyInput) RemoteSafetyDecision {
 		return RemoteSafetyDecision{Action: ActionNoRemoteData, Reason: "no-remote-data"}
 	}
 
-	// Any explicit override intent (force / reinit-local / discard-remote)
+	// Any explicit override intent (force / reinit-local / from-jsonl /
+	// discard-remote)
 	// means the user is not accepting the default bootstrap. DiscardRemote
 	// is treated as override-intent too — naming discard explicitly
 	// implies the user knows the remote has data and wants to replace it.
-	userOverride := in.Force || in.ReinitLocal || in.DiscardRemote
+	userOverride := in.Force || in.ReinitLocal || in.FromJSONL || in.DiscardRemote
 
 	// Remote has data, user did not override anything. Bootstrap is the
 	// safe adoption path — this is the existing correct behavior.
@@ -131,7 +136,8 @@ func CheckRemoteSafety(in RemoteSafetyInput) RemoteSafetyDecision {
 	}
 
 	// User wanted to override but did NOT authorize the cross-boundary
-	// operation. This is the bd-q83 bug in pre-fix code: `--force` without
+	// operation. This is the bd-q83 bug class: a local-source init flag
+	// (`--force`, `--reinit-local`, or `--from-jsonl`) without
 	// `--discard-remote`. Refuse with structured message.
 	if !in.DiscardRemote {
 		return RemoteSafetyDecision{
@@ -158,16 +164,17 @@ func CheckRemoteSafety(in RemoteSafetyInput) RemoteSafetyDecision {
 	return RemoteSafetyDecision{Action: ActionProceedWithDivergence, Reason: "authorized-divergence"}
 }
 
-// refusalMessageDivergence returns the What/Why/Next refusal text for the
-// `--force` / `--reinit-local` without `--discard-remote` case. Deliberately
-// does not echo a complete destructive invocation — the ADR invariant bars
-// runtime error output from constructing a copy-pasteable override.
+// refusalMessageDivergence returns the What/Why/Next refusal text for local
+// source selection without `--discard-remote`. Deliberately does not echo a
+// complete destructive invocation — the ADR invariant bars runtime error
+// output from constructing a copy-pasteable override.
 func refusalMessageDivergence() string {
 	return `bd init refuses: remote 'origin' already has Dolt history (refs/dolt/data).
 
-  Why: --force / --reinit-local bypasses only the LOCAL data-safety
-       guard. It does not authorize silent divergence of remote history.
-       Proceeding would orphan-push over the team's data on first write.
+  Why: this init mode would create or reuse local history instead of
+       adopting the remote. --force / --reinit-local bypasses only the
+       LOCAL data-safety guard; --from-jsonl selects JSONL as the local
+       source. Neither authorizes silent divergence of remote history.
 
   Next:
     Adopt the remote (recommended):

--- a/cmd/bd/init_safety_help.go
+++ b/cmd/bd/init_safety_help.go
@@ -39,6 +39,11 @@ FLAG SURFACE
   bd init --force               Deprecated alias for --reinit-local.
                                 Kept working for ≥2 releases.
 
+  bd init --from-jsonl          Import from configured import.path. If
+                                origin has Dolt data, this refuses unless
+                                --discard-remote authorizes replacing that
+                                remote history.
+
 ADOPTING A REMOTE
 
   If you want to use the remote's existing history, use:
@@ -65,7 +70,7 @@ DESTROY-TOKEN (non-interactive only)
 
 EXIT CODES
 
-  10    refused: remote has Dolt history and you passed --force/--reinit-local
+  10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
   12    refused: --discard-remote passed without a valid --destroy-token

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -30,6 +30,7 @@ func TestCheckRemoteSafety_GuardMatrix(t *testing.T) {
 		{"fresh/no-flags", RemoteSafetyInput{}, ActionNoRemoteData, 0},
 		{"fresh/force", RemoteSafetyInput{Force: true}, ActionNoRemoteData, 0},
 		{"fresh/reinit-local", RemoteSafetyInput{ReinitLocal: true}, ActionNoRemoteData, 0},
+		{"fresh/from-jsonl", RemoteSafetyInput{FromJSONL: true}, ActionNoRemoteData, 0},
 		{"fresh/discard-remote", RemoteSafetyInput{DiscardRemote: true}, ActionNoRemoteData, 0},
 		{"fresh/force+discard", RemoteSafetyInput{Force: true, DiscardRemote: true}, ActionNoRemoteData, 0},
 
@@ -54,12 +55,22 @@ func TestCheckRemoteSafety_GuardMatrix(t *testing.T) {
 			RemoteSafetyInput{RemoteHasDoltData: true, Force: true, ReinitLocal: true},
 			ActionRefuseDivergence, ExitRemoteDivergenceRefused,
 		},
+		{
+			"remote/from-jsonl",
+			RemoteSafetyInput{RemoteHasDoltData: true, FromJSONL: true},
+			ActionRefuseDivergence, ExitRemoteDivergenceRefused,
+		},
 
 		// Remote-has-data, user forced WITH discard-remote, non-interactive,
 		// no token: requires destroy-token.
 		{
 			"remote/force+discard/non-interactive/no-token",
 			RemoteSafetyInput{RemoteHasDoltData: true, Force: true, DiscardRemote: true, ExpectedToken: "DESTROY-bd"},
+			ActionRequireDestroyToken, ExitDestroyTokenMissing,
+		},
+		{
+			"remote/from-jsonl+discard/non-interactive/no-token",
+			RemoteSafetyInput{RemoteHasDoltData: true, FromJSONL: true, DiscardRemote: true, ExpectedToken: "DESTROY-bd"},
 			ActionRequireDestroyToken, ExitDestroyTokenMissing,
 		},
 
@@ -80,6 +91,14 @@ func TestCheckRemoteSafety_GuardMatrix(t *testing.T) {
 			"remote/force+discard/non-interactive/matching-token",
 			RemoteSafetyInput{
 				RemoteHasDoltData: true, Force: true, DiscardRemote: true,
+				DestroyToken: "DESTROY-bd", ExpectedToken: "DESTROY-bd",
+			},
+			ActionProceedWithDivergence, 0,
+		},
+		{
+			"remote/from-jsonl+discard/non-interactive/matching-token",
+			RemoteSafetyInput{
+				RemoteHasDoltData: true, FromJSONL: true, DiscardRemote: true,
 				DestroyToken: "DESTROY-bd", ExpectedToken: "DESTROY-bd",
 			},
 			ActionProceedWithDivergence, 0,
@@ -158,6 +177,9 @@ func TestCheckRemoteSafety_RefusalTextNoEcho(t *testing.T) {
 	// And it must point to the help topic for the destructive path.
 	if !strings.Contains(msg, "bd help init-safety") {
 		t.Errorf("refusal text does not point to 'bd help init-safety':\n%s", msg)
+	}
+	if !strings.Contains(msg, "--from-jsonl") {
+		t.Errorf("refusal text does not name the JSONL local-source flag:\n%s", msg)
 	}
 }
 
@@ -412,6 +434,126 @@ func TestInitForceRefusesWhenRemoteHasDoltData(t *testing.T) {
 	beadsDir := filepath.Join(cloneDir, ".beads")
 	if _, err := os.Stat(beadsDir); err == nil {
 		t.Errorf("refusal should not have created %s", beadsDir)
+	}
+}
+
+// TestInitFromJSONLRefusesWhenRemoteHasDoltData is the GH#3427 regression
+// guard for the safe default: --from-jsonl must not be silently ignored and
+// must not start a remote clone when origin advertises refs/dolt/data.
+func TestInitFromJSONLRefusesWhenRemoteHasDoltData(t *testing.T) {
+	bdBin := buildBDForInitTests(t)
+
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+
+	sourceDir := t.TempDir()
+	runGitForBootstrapTest(t, sourceDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.email", "test@test.com")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
+	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
+	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
+
+	cloneDir := t.TempDir()
+	runGitForBootstrapTest(t, cloneDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, cloneDir, "remote", "add", "origin", bareDir)
+	runGitForBootstrapTest(t, cloneDir, "config", "core.hooksPath", ".git/hooks")
+
+	beadsDir := filepath.Join(cloneDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte(`{"id":"jl-abc123","title":"Local JSONL wins","type":"task","status":"open","priority":2}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bdBin, "init", "--from-jsonl", "--prefix", "jl", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	cmd.Dir = cloneDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if err == nil {
+		t.Fatalf("bd init --from-jsonl succeeded; expected remote-divergence refusal. stderr:\n%s", stderr.String())
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("non-exec-exit error: %v\nstderr:\n%s", err, stderr.String())
+	}
+	if code := exitErr.ExitCode(); code != ExitRemoteDivergenceRefused {
+		t.Errorf("exit code = %d, want %d (ExitRemoteDivergenceRefused)", code, ExitRemoteDivergenceRefused)
+	}
+
+	stderrStr := stderr.String()
+	for _, must := range []string{"bd bootstrap", "bd help init-safety", "--from-jsonl", "remote 'origin'"} {
+		if !strings.Contains(stderrStr, must) {
+			t.Errorf("refusal missing %q:\n%s", must, stderrStr)
+		}
+	}
+	if strings.Contains(stderrStr, "failed to clone remote") {
+		t.Errorf("--from-jsonl should refuse before attempting remote clone:\n%s", stderrStr)
+	}
+	if _, err := os.Stat(filepath.Join(beadsDir, "embeddeddolt")); err == nil {
+		t.Errorf("refusal should not have created an embedded Dolt database")
+	}
+}
+
+func TestInitFromJSONLExplicitRemoteRefusesWhenRemoteHasDoltData(t *testing.T) {
+	bdBin := buildBDForInitTests(t)
+
+	bareDir := filepath.Join(t.TempDir(), "bare.git")
+	runGitForBootstrapTest(t, "", "init", "--bare", bareDir)
+
+	sourceDir := t.TempDir()
+	runGitForBootstrapTest(t, sourceDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.email", "test@test.com")
+	runGitForBootstrapTest(t, sourceDir, "config", "user.name", "Test User")
+	runGitForBootstrapTest(t, sourceDir, "commit", "--allow-empty", "-m", "init")
+	runGitForBootstrapTest(t, sourceDir, "remote", "add", "origin", bareDir)
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "main")
+	runGitForBootstrapTest(t, sourceDir, "push", "origin", "HEAD:refs/dolt/data")
+
+	cloneDir := t.TempDir()
+	runGitForBootstrapTest(t, cloneDir, "init", "-b", "main")
+	runGitForBootstrapTest(t, cloneDir, "config", "core.hooksPath", ".git/hooks")
+
+	beadsDir := filepath.Join(cloneDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte(`{"id":"jl-abc123","title":"Local JSONL wins","type":"task","status":"open","priority":2}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bdBin, "init", "--from-jsonl", "--remote", bareDir, "--prefix", "jl", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents")
+	cmd.Dir = cloneDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if err == nil {
+		t.Fatalf("bd init --from-jsonl --remote succeeded; expected remote-divergence refusal. stderr:\n%s", stderr.String())
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("non-exec-exit error: %v\nstderr:\n%s", err, stderr.String())
+	}
+	if code := exitErr.ExitCode(); code != ExitRemoteDivergenceRefused {
+		t.Errorf("exit code = %d, want %d (ExitRemoteDivergenceRefused)", code, ExitRemoteDivergenceRefused)
+	}
+
+	stderrStr := stderr.String()
+	for _, must := range []string{"bd bootstrap", "bd help init-safety", "--from-jsonl", "remote 'origin'"} {
+		if !strings.Contains(stderrStr, must) {
+			t.Errorf("refusal missing %q:\n%s", must, stderrStr)
+		}
+	}
+	if strings.Contains(stderrStr, "failed to clone remote") {
+		t.Errorf("--from-jsonl should refuse before attempting remote clone:\n%s", stderrStr)
+	}
+	if _, err := os.Stat(filepath.Join(beadsDir, "embeddeddolt")); err == nil {
+		t.Errorf("refusal should not have created an embedded Dolt database")
 	}
 }
 

--- a/cmd/bd/sync_git.go
+++ b/cmd/bd/sync_git.go
@@ -98,15 +98,23 @@ func gitOriginGetURLForActiveRepo(ctx context.Context) (string, error) {
 // Uses a 10s timeout since this is a network call used for auto-detection,
 // and suppresses credential prompts to avoid blocking on SSH remotes.
 func gitOriginHasDoltDataRef() bool {
+	return gitRemoteHasDoltDataRef("origin")
+}
+
+func gitRemoteHasDoltDataRef(remote string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "git", "ls-remote", "origin", "refs/dolt/data")
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", gitRemoteURLForLsRemote(remote), "refs/dolt/data")
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.Output()
 	if err != nil {
 		return false
 	}
 	return strings.TrimSpace(string(output)) != ""
+}
+
+func gitRemoteURLForLsRemote(remote string) string {
+	return strings.TrimPrefix(remote, "git+")
 }
 
 // gitURLToDoltRemote converts a git remote URL to dolt's remote format.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -3426,7 +3426,7 @@ bd init [flags]
       --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path instead of git history
+      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
       --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
@@ -5893,6 +5893,11 @@ FLAG SURFACE
   bd init --force               Deprecated alias for --reinit-local.
                                 Kept working for ≥2 releases.
 
+  bd init --from-jsonl          Import from configured import.path. If
+                                origin has Dolt data, this refuses unless
+                                --discard-remote authorizes replacing that
+                                remote history.
+
 ADOPTING A REMOTE
 
   If you want to use the remote's existing history, use:
@@ -5919,7 +5924,7 @@ DESTROY-TOKEN (non-interactive only)
 
 EXIT CODES
 
-  10    refused: remote has Dolt history and you passed --force/--reinit-local
+  10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
   12    refused: --discard-remote passed without a valid --destroy-token

--- a/docs/RECOVERY.md
+++ b/docs/RECOVERY.md
@@ -29,17 +29,18 @@ See also: `bd help init-safety`, and
 
 ```
 bd init refuses: remote 'origin' already has Dolt history (refs/dolt/data).
-  Why: --force / --reinit-local bypasses only the LOCAL data-safety
-       guard. ...
+  Why: this init mode would create or reuse local history instead of
+       adopting the remote. ...
 ```
 
 **Why this happens**
 
 `bd init --force` (or `--reinit-local`) tells `bd` to bypass the local
-data-safety guard. But the remote already has project history. Proceeding
-would create an orphan local Dolt branch with no common ancestor on
-origin. The next `bd dolt push` would either fail (no common ancestor)
-or — worse, if force-pushed — destroy the team's data.
+data-safety guard. `bd init --from-jsonl` selects a local JSONL export as
+the source. But the remote already has project history. Proceeding would
+create an orphan local Dolt branch with no common ancestor on origin. The
+next `bd dolt push` would either fail (no common ancestor) or — worse, if
+force-pushed — destroy the team's data.
 
 **Recovery paths**
 
@@ -67,10 +68,10 @@ bd dolt status
 ### 3. You intentionally want to overwrite the remote's history (destructive)
 
 This is a cross-boundary operation that affects every collaborator. You
-need to pair `--reinit-local` with `--discard-remote`. In interactive
-mode `bd` will prompt for confirmation; in non-interactive mode you must
-supply a `--destroy-token`. See `bd help init-safety` for the token
-format.
+need to pair the local-source init (`--reinit-local` or `--from-jsonl`)
+with `--discard-remote`. In interactive mode `bd` will prompt for
+confirmation; in non-interactive mode you must supply a `--destroy-token`.
+See `bd help init-safety` for the token format.
 
 After `bd init --reinit-local --discard-remote`, your next
 `bd dolt push` must be a history-replacing push. Coordinate with your

--- a/docs/adr/0002-init-safety-invariants.md
+++ b/docs/adr/0002-init-safety-invariants.md
@@ -94,6 +94,7 @@ bd init                         mint, or auto-bootstrap if origin has refs/dolt/
 bd init --reinit-local          local reinit; refuses remote divergence
 bd init --reinit-local \        local reinit, overwrite remote on next push
     --discard-remote            (interactive confirm or --destroy-token required)
+bd init --from-jsonl            local JSONL import; refuses remote divergence
 bd init --force                 deprecated alias for --reinit-local (≥2 releases)
 bd bootstrap                    adopt remote — signposted by init refusal
 ```
@@ -101,7 +102,7 @@ bd bootstrap                    adopt remote — signposted by init refusal
 ### Exit codes (stable, grep-safe)
 
 ```
-10   ExitRemoteDivergenceRefused   --force/--reinit-local without --discard-remote
+10   ExitRemoteDivergenceRefused   local-source init without --discard-remote
 11   ExitLocalExistsRefused        existing local data, declined destroy confirm
 12   ExitDestroyTokenMissing       --discard-remote without valid --destroy-token
 ```

--- a/website/docs/cli-reference/init-safety.md
+++ b/website/docs/cli-reference/init-safety.md
@@ -35,6 +35,11 @@ FLAG SURFACE
   bd init --force               Deprecated alias for --reinit-local.
                                 Kept working for ≥2 releases.
 
+  bd init --from-jsonl          Import from configured import.path. If
+                                origin has Dolt data, this refuses unless
+                                --discard-remote authorizes replacing that
+                                remote history.
+
 ADOPTING A REMOTE
 
   If you want to use the remote's existing history, use:
@@ -61,7 +66,7 @@ DESTROY-TOKEN (non-interactive only)
 
 EXIT CODES
 
-  10    refused: remote has Dolt history and you passed --force/--reinit-local
+  10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
   12    refused: --discard-remote passed without a valid --destroy-token

--- a/website/docs/cli-reference/init.md
+++ b/website/docs/cli-reference/init.md
@@ -62,7 +62,7 @@ bd init [flags]
       --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path instead of git history
+      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
       --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6428,6 +6428,11 @@ FLAG SURFACE
   bd init --force               Deprecated alias for --reinit-local.
                                 Kept working for ≥2 releases.
 
+  bd init --from-jsonl          Import from configured import.path. If
+                                origin has Dolt data, this refuses unless
+                                --discard-remote authorizes replacing that
+                                remote history.
+
 ADOPTING A REMOTE
 
   If you want to use the remote's existing history, use:
@@ -6454,7 +6459,7 @@ DESTROY-TOKEN (non-interactive only)
 
 EXIT CODES
 
-  10    refused: remote has Dolt history and you passed --force/--reinit-local
+  10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
   12    refused: --discard-remote passed without a valid --destroy-token
@@ -6532,7 +6537,7 @@ bd init [flags]
       --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path instead of git history
+      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
       --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)
@@ -7171,7 +7176,7 @@ bd list [flags]
       --skip-labels                  Skip label hydration. The labels field in output will be empty regardless of actual labels. Use only when the caller does not depend on label data. Cannot combine with --label, --label-any, --label-pattern, --label-regex, --exclude-label, or --no-labels.
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)

--- a/website/versioned_docs/version-1.0.0/cli-reference/init-safety.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/init-safety.md
@@ -35,6 +35,11 @@ FLAG SURFACE
   bd init --force               Deprecated alias for --reinit-local.
                                 Kept working for ≥2 releases.
 
+  bd init --from-jsonl          Import from configured import.path. If
+                                origin has Dolt data, this refuses unless
+                                --discard-remote authorizes replacing that
+                                remote history.
+
 ADOPTING A REMOTE
 
   If you want to use the remote's existing history, use:
@@ -61,7 +66,7 @@ DESTROY-TOKEN (non-interactive only)
 
 EXIT CODES
 
-  10    refused: remote has Dolt history and you passed --force/--reinit-local
+  10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
   12    refused: --discard-remote passed without a valid --destroy-token

--- a/website/versioned_docs/version-1.0.0/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/init.md
@@ -62,7 +62,7 @@ bd init [flags]
       --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path instead of git history
+      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
       --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)

--- a/website/versioned_docs/version-1.0.4/cli-reference/init-safety.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/init-safety.md
@@ -35,6 +35,11 @@ FLAG SURFACE
   bd init --force               Deprecated alias for --reinit-local.
                                 Kept working for ≥2 releases.
 
+  bd init --from-jsonl          Import from configured import.path. If
+                                origin has Dolt data, this refuses unless
+                                --discard-remote authorizes replacing that
+                                remote history.
+
 ADOPTING A REMOTE
 
   If you want to use the remote's existing history, use:
@@ -61,7 +66,7 @@ DESTROY-TOKEN (non-interactive only)
 
 EXIT CODES
 
-  10    refused: remote has Dolt history and you passed --force/--reinit-local
+  10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
   12    refused: --discard-remote passed without a valid --destroy-token

--- a/website/versioned_docs/version-1.0.4/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/init.md
@@ -62,7 +62,7 @@ bd init [flags]
       --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path instead of git history
+      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
       --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)

--- a/website/versioned_docs/version-1.0.5/cli-reference/init-safety.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/init-safety.md
@@ -35,6 +35,11 @@ FLAG SURFACE
   bd init --force               Deprecated alias for --reinit-local.
                                 Kept working for ≥2 releases.
 
+  bd init --from-jsonl          Import from configured import.path. If
+                                origin has Dolt data, this refuses unless
+                                --discard-remote authorizes replacing that
+                                remote history.
+
 ADOPTING A REMOTE
 
   If you want to use the remote's existing history, use:
@@ -61,7 +66,7 @@ DESTROY-TOKEN (non-interactive only)
 
 EXIT CODES
 
-  10    refused: remote has Dolt history and you passed --force/--reinit-local
+  10    refused: remote has Dolt history and you selected local history
         without --discard-remote
   11    refused: existing local data and you declined the destroy confirm
   12    refused: --discard-remote passed without a valid --destroy-token

--- a/website/versioned_docs/version-1.0.5/cli-reference/init.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/init.md
@@ -62,7 +62,7 @@ bd init [flags]
       --discard-remote                                 Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                                       Server is externally managed (skip server startup); use with --shared-server or --server
       --force                                          Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                                     Import issues from configured import.path instead of git history
+      --from-jsonl                                     Import issues from configured import.path; refuses remote history unless --discard-remote authorizes replacement
       --init-if-missing                                If the workspace is already initialized, skip init and exit 0 instead of failing (idempotent init for scaffolds)
       --non-interactive                                Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                                  Issue prefix (default: current directory name)

--- a/website/versioned_docs/version-1.0.5/cli-reference/list.md
+++ b/website/versioned_docs/version-1.0.5/cli-reference/list.md
@@ -68,7 +68,7 @@ bd list [flags]
       --skip-labels                  Skip label hydration. The labels field in output will be empty regardless of actual labels. Use only when the caller does not depend on label data. Cannot combine with --label, --label-any, --label-pattern, --label-regex, --exclude-label, or --no-labels.
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
-  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
+  -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress. Note: repeating -s/--status silently overwrites the previous value — always use the comma-separated form for multi-status filters.
       --title string                 Filter by title text (case-insensitive substring match)
       --title-contains string        Filter by title substring (case-insensitive)
       --tree                         Hierarchical tree format (default: true; use --flat to disable) (default true)


### PR DESCRIPTION
## Summary
- route `bd init --from-jsonl` through the init remote-safety chokepoint when `refs/dolt/data` exists
- refuse ambiguous JSONL-vs-remote source selection unless `--discard-remote` explicitly authorizes replacing remote history
- skip remote clone on the authorized JSONL path and add focused regression coverage
- refresh generated CLI docs and recovery/init-safety docs

Fixes #3427.

## Validation
- `go test -tags gms_pure_go ./cmd/bd -run 'TestCheckRemoteSafety_GuardMatrix|TestCheckRemoteSafety_RefusalTextNoEcho|TestInitFromJSONLRefusesWhenRemoteHasDoltData|TestInitForceRefusesWhenRemoteHasDoltData' -count=1`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedInit/from_jsonl_with_remote_data_requires_discard_and_skips_clone|TestEmbeddedInit/from_jsonl$|TestEmbeddedInit/from_jsonl_uses_import_path' -count=1`
- `./scripts/generate-cli-docs.sh --check`
- `git diff --check upstream/main..HEAD`

_codex-gpt-5.5-xhigh on behalf of CI Bot_