### PR TITLE
docs: guard plugin CLI reference pointer

### DIFF
--- a/docs/DOC_INVENTORY.md
+++ b/docs/DOC_INVENTORY.md
@@ -25,6 +25,7 @@ freshness source.
 | Doc | Freshness path |
 |---|---|
 | `CLI_REFERENCE.md` | Generated from `bd help --all`. |
+| `plugins/beads/skills/beads/resources/CLI_REFERENCE.md` | Pointer-only doc: must link to live CLI help and canonical generated `docs/CLI_REFERENCE.md`; do not duplicate generated command tables. |
 | `CONFIG.md` | `Last reviewed:` marker tied to `cmd/bd/main.go`, `cmd/bd/config.go`, and `internal/configfile/`. |
 | `SETUP.md` | `Last reviewed:` marker tied to `cmd/bd/setup*.go` and `internal/recipes/`. |
 | `ADO_CONFIG.md` | `Last reviewed:` marker tied to `cmd/bd/ado*.go` and `internal/ado/`. |
@@ -54,6 +55,7 @@ Follow-up automation should replace marker-only checks with generated or
 | `CLAUDE.md` | Revise | Kept as architecture orientation only; command/workflow duplication was reduced in favour of root `AGENTS.md` and `AGENT_INSTRUCTIONS.md`. |
 | `CLI_REFERENCE.md` | Keep/generated | Generated command reference from live help output. |
 | `CI_TEST_SURFACE_AUDIT.md` | Keep with freshness | Snapshot of local validation commands, GitHub Actions coverage, gaps, and CI cleanup roadmap. |
+| `plugins/beads/skills/beads/resources/CLI_REFERENCE.md` | Keep pointer | Plugin skill resource intentionally points at live CLI sources to avoid duplicate generated command snapshots. |
 | `CODEX_INTEGRATION.md` | Keep | User-facing Codex integration guide. |
 | `COLLISION_MATH.md` | Keep | Mathematical background; low product drift. |
 | `COMMUNITY_TOOLS.md` | Keep | Curated external tools list; external links need periodic review. |

--- a/scripts/check-doc-flags.sh
+++ b/scripts/check-doc-flags.sh
@@ -157,7 +157,14 @@ if [ -f "$CLI_REF" ]; then
         done
 
         if [ -x "$PROJECT_ROOT/scripts/generate-cli-docs.sh" ]; then
-            if "$PROJECT_ROOT/scripts/generate-cli-docs.sh" --check "$BD"; then
+            BD_FOR_GEN="$BD"
+            if ! [ -x "$BD_FOR_GEN" ]; then
+                BD_FOR_GEN="$(command -v "$BD" 2>/dev/null || true)"
+            fi
+            if [ -z "$BD_FOR_GEN" ]; then
+                echo "FAIL: Could not resolve bd binary path for CLI docs freshness check"
+                ERRORS=$((ERRORS + 1))
+            elif "$PROJECT_ROOT/scripts/generate-cli-docs.sh" --check "$BD_FOR_GEN"; then
                 echo "PASS: Generated CLI docs are fresh"
             else
                 ERRORS=$((ERRORS + 1))
@@ -172,6 +179,27 @@ if [ -f "$CLI_REF" ]; then
     fi
 else
     echo "FAIL: docs/CLI_REFERENCE.md not found"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+
+# --- Check 5: Plugin CLI reference must stay a pointer ---
+echo "=== Check 5: Plugin CLI reference pointer policy ==="
+
+PLUGIN_CLI_REF="$PROJECT_ROOT/plugins/beads/skills/beads/resources/CLI_REFERENCE.md"
+if [ -f "$PLUGIN_CLI_REF" ]; then
+    if grep -q 'This skill does not bundle a copied CLI command reference' "$PLUGIN_CLI_REF" \
+        && grep -q 'docs/CLI_REFERENCE.md' "$PLUGIN_CLI_REF"; then
+        echo "PASS: plugin CLI resource is a pointer to live/canonical references"
+    else
+        echo "FAIL: plugin CLI resource drifted from pointer policy"
+        echo "  Expected pointer language and canonical docs/CLI_REFERENCE.md reference in:"
+        echo "  plugins/beads/skills/beads/resources/CLI_REFERENCE.md"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    echo "FAIL: plugin CLI resource missing: plugins/beads/skills/beads/resources/CLI_REFERENCE.md"
     ERRORS=$((ERRORS + 1))
 fi
 


### PR DESCRIPTION
## Why

The plugin skill has its own resources/CLI_REFERENCE.md file, which made it look like a second hand-maintained CLI reference that could drift away from the generated docs/CLI_REFERENCE.md. The intended policy is better as a pointer: plugin users should rely on live bd help output and the canonical generated reference instead of a copied command table.

## What changed

- Records the plugin CLI resource as pointer-only in docs/DOC_INVENTORY.md.
- Adds a doc freshness guard so scripts/check-doc-flags.sh fails if the plugin resource stops linking to the canonical CLI reference.
- Resolves the bd executable path before handing it to generate-cli-docs.sh --check.

## Validation

- ./scripts/generate-cli-docs.sh --check <built-bd> passed.
- ./scripts/check-doc-flags.sh <built-bd> passed.

_codex-gpt-5.5-medium on behalf of CI Bot_