### PR TITLE
fix(compact): complete MiniMax provider integration

### DIFF
--- a/cmd/bd/compact.go
+++ b/cmd/bd/compact.go
@@ -46,7 +46,7 @@ actively referenced. This is permanent graceful decay - original content is disc
 Modes:
   - Analyze: Export candidates for agent review (no API key needed)
   - Apply: Accept agent-provided summary (no API key needed)
-  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY or ai.api_key, legacy)
+  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
   - Dolt: Run Dolt garbage collection (for Dolt-backend repositories)
 
 Tiers:
@@ -70,10 +70,11 @@ Examples:
   bd compact --apply --id bd-42 --summary summary.txt
   bd compact --apply --id bd-42 --summary - < summary.txt
 
-  # Legacy AI-powered workflow
+  # AI-powered workflow
   bd compact --auto --dry-run              # Preview candidates
   bd compact --auto --all                  # Compact all eligible issues
   bd compact --auto --id bd-42             # Compact specific issue
+  MINIMAX_API_KEY=... bd compact --auto --all
 
   # Statistics
   bd compact --stats                       # Show statistics
@@ -172,12 +173,9 @@ Examples:
 			}
 
 			// Direct mode
-			apiKey := os.Getenv("ANTHROPIC_API_KEY")
-			if apiKey == "" {
-				apiKey = config.GetString("ai.api_key")
-			}
+			apiKey, _ := config.ResolveAIAPIKey("")
 			if apiKey == "" && !compactDryRun {
-				fmt.Fprintf(os.Stderr, "Error: --auto mode requires ANTHROPIC_API_KEY environment variable or ai.api_key in config\n")
+				fmt.Fprintf(os.Stderr, "Error: --auto mode requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key in config\n")
 				os.Exit(1)
 			}
 
@@ -923,7 +921,7 @@ func init() {
 	// New mode flags
 	compactCmd.Flags().BoolVar(&compactAnalyze, "analyze", false, "Analyze mode: export candidates for agent review")
 	compactCmd.Flags().BoolVar(&compactApply, "apply", false, "Apply mode: accept agent-provided summary")
-	compactCmd.Flags().BoolVar(&compactAuto, "auto", false, "Auto mode: AI-powered compaction (legacy)")
+	compactCmd.Flags().BoolVar(&compactAuto, "auto", false, "Auto mode: AI-powered compaction")
 	compactCmd.Flags().StringVar(&compactSummary, "summary", "", "Path to summary file (use '-' for stdin)")
 	compactCmd.Flags().StringVar(&compactActor, "actor", "agent", "Actor name for audit trail")
 	compactCmd.Flags().IntVar(&compactLimit, "limit", 0, "Limit number of candidates (0 = no limit)")

--- a/cmd/bd/find_duplicates.go
+++ b/cmd/bd/find_duplicates.go
@@ -36,13 +36,13 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY or ai.api_key)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may
 miss semantically similar issues with very different wording.
 
-The AI approach sends candidate pairs to Claude for semantic comparison.
+The AI approach sends candidate pairs to an Anthropic-compatible model for semantic comparison.
 It first uses mechanical pre-filtering to reduce the number of API calls,
 then asks the LLM to judge whether the remaining pairs are true duplicates.
 
@@ -93,8 +93,8 @@ func runFindDuplicates(cmd *cobra.Command, _ []string) {
 
 	// AI method requires API key
 	if method == "ai" {
-		if os.Getenv("ANTHROPIC_API_KEY") == "" && config.GetString("ai.api_key") == "" {
-			FatalError("--method ai requires ANTHROPIC_API_KEY environment variable or ai.api_key in config")
+		if apiKey, _ := config.ResolveAIAPIKey(""); apiKey == "" {
+			FatalError("--method ai requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key in config")
 		}
 	}
 
@@ -362,11 +362,12 @@ func findAIDuplicates(ctx context.Context, issues []*types.Issue, threshold floa
 
 	fmt.Fprintf(os.Stderr, "Analyzing %d candidate pairs with AI...\n", len(candidates))
 
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		apiKey = config.GetString("ai.api_key")
+	apiKey, keySource := config.ResolveAIAPIKey("")
+	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if baseURL := config.DefaultAIBaseURL(keySource); baseURL != "" {
+		clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
 	}
-	client := anthropic.NewClient(option.WithAPIKey(apiKey))
+	client := anthropic.NewClient(clientOptions...)
 
 	var pairs []duplicatePair
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1564,13 +1564,13 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY or ai.api_key)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may
 miss semantically similar issues with very different wording.
 
-The AI approach sends candidate pairs to Claude for semantic comparison.
+The AI approach sends candidate pairs to an Anthropic-compatible model for semantic comparison.
 It first uses mechanical pre-filtering to reduce the number of API calls,
 then asks the LLM to judge whether the remaining pairs are true duplicates.
 
@@ -4586,7 +4586,7 @@ actively referenced. This is permanent graceful decay - original content is disc
 Modes:
   - Analyze: Export candidates for agent review (no API key needed)
   - Apply: Accept agent-provided summary (no API key needed)
-  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY or ai.api_key, legacy)
+  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
   - Dolt: Run Dolt garbage collection (for Dolt-backend repositories)
 
 Tiers:
@@ -4610,10 +4610,11 @@ Examples:
   bd compact --apply --id bd-42 --summary summary.txt
   bd compact --apply --id bd-42 --summary - &lt; summary.txt
 
-  # Legacy AI-powered workflow
+  # AI-powered workflow
   bd compact --auto --dry-run              # Preview candidates
   bd compact --auto --all                  # Compact all eligible issues
   bd compact --auto --id bd-42             # Compact specific issue
+  MINIMAX_API_KEY=... bd compact --auto --all
 
   # Statistics
   bd compact --stats                       # Show statistics
@@ -4630,7 +4631,7 @@ bd admin compact [flags]
       --all              Process all candidates
       --analyze          Analyze mode: export candidates for agent review
       --apply            Apply mode: accept agent-provided summary
-      --auto             Auto mode: AI-powered compaction (legacy)
+      --auto             Auto mode: AI-powered compaction
       --batch-size int   Issues per batch (default 10)
       --dolt             Dolt mode: run Dolt garbage collection on .beads/dolt
       --dry-run          Preview without compacting

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -358,6 +358,9 @@ Configuration keys use dot-notation namespaces to organize settings:
 - `export.write_manifest` - Write .manifest.json with export metadata (default: false)
 - `auto_export.error_policy` - Override error policy for auto-exports (default: `best-effort`)
 - `import.auto` - Legacy hook fallback that imports JSONL after git merge/checkout only when no Dolt remote is configured (default: `true`)
+- `ai.model` - Anthropic-compatible model for AI compaction and duplicate detection (default: `claude-haiku-4-5-20251001`; MiniMax examples: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`)
+- `ai.api_key` - Local config fallback for AI calls. Prefer `ANTHROPIC_API_KEY` or `MINIMAX_API_KEY` environment variables for secrets.
+- `ai.base_url` - Optional Anthropic-compatible API base URL. Can also be set with `BD_AI_BASE_URL`; `MINIMAX_API_KEY` defaults to `https://api.minimax.io/anthropic` unless `MINIMAX_BASE_URL` is set.
 - `sync.branch` - Name of the dedicated sync branch for beads data (see docs/PROTECTED_BRANCHES.md)
 - `sync.require_confirmation_on_mass_delete` - Require interactive confirmation before pushing when >50% of issues vanish during a merge AND more than 5 issues existed before (default: `false`)
 
@@ -1008,6 +1011,7 @@ jira_project = get_config("jira.project")
 Some bd commands automatically use configuration:
 
 - `bd admin compact` uses `compact_tier1_days`, `compact_tier1_dep_levels`, etc.
+- `bd compact --auto` and `bd find-duplicates --method ai` use `ANTHROPIC_API_KEY`, `MINIMAX_API_KEY`, or `ai.api_key`; set `ai.base_url` or `BD_AI_BASE_URL` for other Anthropic-compatible endpoints.
 - `bd init` sets `issue_prefix`
 
 External integration scripts can read configuration to sync with Jira, Linear, GitHub, etc.

--- a/docs/design/otel/otel-data-model.md
+++ b/docs/design/otel/otel-data-model.md
@@ -282,7 +282,7 @@ Stdout/stderr are added as span **events** (not attributes):
 
 ## 7. AI Events
 
-Emitted by the compaction engine (`bd compact`) via `internal/compact/haiku.go`, and by duplicate detection (`bd find-duplicates --method ai`) via `cmd/bd/find_duplicates.go`. Both use the Anthropic SDK directly via `ANTHROPIC_API_KEY`.
+Emitted by the compaction engine (`bd compact`) via `internal/compact/haiku.go`, and by duplicate detection (`bd find-duplicates --method ai`) via `cmd/bd/find_duplicates.go`. Both use the Anthropic SDK with Anthropic-compatible credentials from `ANTHROPIC_API_KEY`, `MINIMAX_API_KEY`, or `ai.api_key`.
 
 > **Note**: Only `compact/haiku.go` records to the `bd.ai.*` OTel metric instruments. `find_duplicates.go` records token counts as span attributes only.
 

--- a/internal/compact/compactor_unit_test.go
+++ b/internal/compact/compactor_unit_test.go
@@ -197,6 +197,7 @@ func TestCompactTier1_UpdateError(t *testing.T) {
 
 func TestNew_NilConfig(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
 	store := &stubStore{}
 	c, err := New(store, "", nil)
 	if err != nil {
@@ -226,6 +227,7 @@ func TestNew_DryRunExplicit(t *testing.T) {
 
 func TestNew_NoAPIKeyFallsToDryRun(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
 	store := &stubStore{}
 	c, err := New(store, "", &Config{})
 	if err != nil {
@@ -238,6 +240,7 @@ func TestNew_NoAPIKeyFallsToDryRun(t *testing.T) {
 
 func TestNew_WithAPIKey(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
 	store := &stubStore{}
 	c, err := New(store, "test-key-123", &Config{Concurrency: 2, AuditEnabled: true, Actor: "testbot"})
 	if err != nil {

--- a/internal/compact/haiku.go
+++ b/internal/compact/haiku.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"os"
 	"sync"
 	"text/template"
 	"time"
@@ -35,6 +34,8 @@ var errAPIKeyRequired = errors.New("API key required")
 type haikuClient struct {
 	client         anthropic.Client
 	model          anthropic.Model
+	apiKeySource   config.AIAPIKeySource
+	baseURL        string
 	tier1Template  *template.Template
 	maxRetries     int
 	initialBackoff time.Duration
@@ -43,19 +44,20 @@ type haikuClient struct {
 }
 
 // newHaikuClient creates a new Haiku API client.
-// API key resolution order: ANTHROPIC_API_KEY env var > ai.api_key config > explicit apiKey parameter.
+// API key resolution order: ANTHROPIC_API_KEY env var > MINIMAX_API_KEY env var > ai.api_key config > explicit apiKey parameter.
 func newHaikuClient(apiKey string) (*haikuClient, error) {
-	envKey := os.Getenv("ANTHROPIC_API_KEY")
-	if envKey != "" {
-		apiKey = envKey
-	} else if configKey := config.GetString("ai.api_key"); configKey != "" {
-		apiKey = configKey
-	}
+	apiKey, keySource := config.ResolveAIAPIKey(apiKey)
 	if apiKey == "" {
-		return nil, fmt.Errorf("%w: set ANTHROPIC_API_KEY environment variable or ai.api_key in config", errAPIKeyRequired)
+		return nil, fmt.Errorf("%w: set ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key in config", errAPIKeyRequired)
 	}
 
-	client := anthropic.NewClient(option.WithAPIKey(apiKey))
+	clientOptions := []option.RequestOption{option.WithAPIKey(apiKey)}
+	baseURL := config.DefaultAIBaseURL(keySource)
+	if baseURL != "" {
+		clientOptions = append(clientOptions, option.WithBaseURL(baseURL))
+	}
+
+	client := anthropic.NewClient(clientOptions...)
 
 	tier1Tmpl, err := template.New("tier1").Parse(tier1PromptTemplate)
 	if err != nil {
@@ -67,6 +69,8 @@ func newHaikuClient(apiKey string) (*haikuClient, error) {
 	return &haikuClient{
 		client:         client,
 		model:          config.DefaultAIModel(),
+		apiKeySource:   keySource,
+		baseURL:        baseURL,
 		tier1Template:  tier1Tmpl,
 		maxRetries:     maxRetries,
 		initialBackoff: initialBackoff,

--- a/internal/compact/haiku_test.go
+++ b/internal/compact/haiku_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -20,6 +21,7 @@ func (timeoutErr) Temporary() bool { return true }
 
 func TestNewHaikuClient_RequiresAPIKey(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
 
 	_, err := newHaikuClient("")
 	if err == nil {
@@ -54,6 +56,67 @@ func TestNewHaikuClient_EnvVarOverridesExplicitKey(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestNewHaikuClient_MiniMaxKeyUsesMiniMaxBaseURL(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "test-minimax-key")
+	t.Setenv("MINIMAX_BASE_URL", "")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config initialize: %v", err)
+	}
+	config.Set("ai.api_key", "")
+	config.Set("ai.base_url", "")
+
+	client, err := newHaikuClient("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.apiKeySource != config.AIAPIKeySourceMiniMaxEnv {
+		t.Fatalf("apiKeySource = %q, want %q", client.apiKeySource, config.AIAPIKeySourceMiniMaxEnv)
+	}
+	if client.baseURL != config.MiniMaxDefaultBaseURL {
+		t.Fatalf("baseURL = %q, want %q", client.baseURL, config.MiniMaxDefaultBaseURL)
+	}
+}
+
+func TestNewHaikuClient_AnthropicKeyOverridesMiniMaxKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+	t.Setenv("MINIMAX_API_KEY", "test-minimax-key")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config initialize: %v", err)
+	}
+	config.Set("ai.base_url", "")
+
+	client, err := newHaikuClient("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.apiKeySource != config.AIAPIKeySourceAnthropicEnv {
+		t.Fatalf("apiKeySource = %q, want %q", client.apiKeySource, config.AIAPIKeySourceAnthropicEnv)
+	}
+	if client.baseURL != "" {
+		t.Fatalf("baseURL = %q, want SDK default", client.baseURL)
+	}
+}
+
+func TestNewHaikuClient_ConfigBaseURLOverridesMiniMaxDefault(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "test-minimax-key")
+	t.Setenv("MINIMAX_BASE_URL", "https://minimax.example/anthropic")
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config initialize: %v", err)
+	}
+	config.Set("ai.api_key", "")
+	config.Set("ai.base_url", "https://proxy.example/anthropic")
+
+	client, err := newHaikuClient("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.baseURL != "https://proxy.example/anthropic" {
+		t.Fatalf("baseURL = %q, want config proxy URL", client.baseURL)
 	}
 }
 
@@ -205,6 +268,7 @@ func TestIsRetryable(t *testing.T) {
 
 func TestSummarizeTier1_CancelledContext(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
 	client, err := newHaikuClient("test-key-fake")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -227,6 +291,7 @@ func TestSummarizeTier1_CancelledContext(t *testing.T) {
 
 func TestSummarizeTier1_WithAuditEnabled(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
 	client, err := newHaikuClient("test-key-fake")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -251,6 +316,7 @@ func TestSummarizeTier1_WithAuditEnabled(t *testing.T) {
 
 func TestCallWithRetry_ImmediateContextCancel(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
 	client, err := newHaikuClient("test-key-fake")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,6 +253,7 @@ func Initialize() error {
 
 	// AI configuration defaults
 	v.SetDefault("ai.model", "claude-haiku-4-5-20251001")
+	v.SetDefault("ai.base_url", "")
 
 	// Output configuration (GH#1384)
 	// Controls title display in command feedback messages.
@@ -682,6 +683,55 @@ func Set(key string, value interface{}) {
 // Override via: bd config set ai.model "model-name" or BD_AI_MODEL=model-name
 func DefaultAIModel() string {
 	return GetString("ai.model")
+}
+
+// AIAPIKeySource identifies where the active Anthropic-compatible API key came from.
+type AIAPIKeySource string
+
+const (
+	AIAPIKeySourceNone         AIAPIKeySource = ""
+	AIAPIKeySourceAnthropicEnv AIAPIKeySource = "ANTHROPIC_API_KEY" //nolint:gosec // Environment variable name, not a credential.
+	AIAPIKeySourceMiniMaxEnv   AIAPIKeySource = "MINIMAX_API_KEY"   //nolint:gosec // Environment variable name, not a credential.
+	AIAPIKeySourceConfig       AIAPIKeySource = "ai.api_key"
+	AIAPIKeySourceExplicit     AIAPIKeySource = "explicit"
+
+	MiniMaxDefaultBaseURL = "https://api.minimax.io/anthropic"
+)
+
+// ResolveAIAPIKey returns the API key for Anthropic-compatible AI calls.
+//
+// Precedence: ANTHROPIC_API_KEY > MINIMAX_API_KEY > ai.api_key > explicit.
+func ResolveAIAPIKey(explicit string) (string, AIAPIKeySource) {
+	if envKey := os.Getenv("ANTHROPIC_API_KEY"); envKey != "" {
+		return envKey, AIAPIKeySourceAnthropicEnv
+	}
+	if envKey := os.Getenv("MINIMAX_API_KEY"); envKey != "" {
+		return envKey, AIAPIKeySourceMiniMaxEnv
+	}
+	if configKey := GetString("ai.api_key"); configKey != "" {
+		return configKey, AIAPIKeySourceConfig
+	}
+	if explicit != "" {
+		return explicit, AIAPIKeySourceExplicit
+	}
+	return "", AIAPIKeySourceNone
+}
+
+// DefaultAIBaseURL returns the configured base URL for Anthropic-compatible AI calls.
+//
+// Precedence: ai.base_url (or BD_AI_BASE_URL) > MINIMAX_BASE_URL > MiniMax default
+// when MINIMAX_API_KEY selected the key. Empty means use the SDK's Anthropic default.
+func DefaultAIBaseURL(keySource AIAPIKeySource) string {
+	if baseURL := GetString("ai.base_url"); baseURL != "" {
+		return baseURL
+	}
+	if keySource == AIAPIKeySourceMiniMaxEnv {
+		if baseURL := os.Getenv("MINIMAX_BASE_URL"); baseURL != "" {
+			return baseURL
+		}
+		return MiniMaxDefaultBaseURL
+	}
+	return ""
 }
 
 // AllSettings returns all configuration settings as a map

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -80,6 +80,75 @@ func TestDefaults(t *testing.T) {
 	}
 }
 
+func TestResolveAIAPIKeyPrecedence(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("MINIMAX_API_KEY", "")
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+	Set("ai.api_key", "")
+
+	key, source := ResolveAIAPIKey("explicit-key")
+	if key != "explicit-key" || source != AIAPIKeySourceExplicit {
+		t.Fatalf("explicit fallback = (%q, %q), want explicit-key/%s", key, source, AIAPIKeySourceExplicit)
+	}
+
+	Set("ai.api_key", "config-key")
+	key, source = ResolveAIAPIKey("explicit-key")
+	if key != "config-key" || source != AIAPIKeySourceConfig {
+		t.Fatalf("config fallback = (%q, %q), want config-key/%s", key, source, AIAPIKeySourceConfig)
+	}
+
+	t.Setenv("MINIMAX_API_KEY", "minimax-key")
+	key, source = ResolveAIAPIKey("explicit-key")
+	if key != "minimax-key" || source != AIAPIKeySourceMiniMaxEnv {
+		t.Fatalf("MiniMax env = (%q, %q), want minimax-key/%s", key, source, AIAPIKeySourceMiniMaxEnv)
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-key")
+	key, source = ResolveAIAPIKey("explicit-key")
+	if key != "anthropic-key" || source != AIAPIKeySourceAnthropicEnv {
+		t.Fatalf("Anthropic env = (%q, %q), want anthropic-key/%s", key, source, AIAPIKeySourceAnthropicEnv)
+	}
+}
+
+func TestDefaultAIBaseURLPrecedence(t *testing.T) {
+	restore := envSnapshot(t)
+	defer restore()
+
+	t.Setenv("MINIMAX_BASE_URL", "")
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+	Set("ai.base_url", "")
+
+	if got := DefaultAIBaseURL(AIAPIKeySourceAnthropicEnv); got != "" {
+		t.Fatalf("Anthropic base URL = %q, want SDK default", got)
+	}
+	if got := DefaultAIBaseURL(AIAPIKeySourceMiniMaxEnv); got != MiniMaxDefaultBaseURL {
+		t.Fatalf("MiniMax default base URL = %q, want %q", got, MiniMaxDefaultBaseURL)
+	}
+
+	t.Setenv("MINIMAX_BASE_URL", "https://minimax.example/anthropic")
+	if got := DefaultAIBaseURL(AIAPIKeySourceMiniMaxEnv); got != "https://minimax.example/anthropic" {
+		t.Fatalf("MINIMAX_BASE_URL = %q, want custom MiniMax URL", got)
+	}
+
+	t.Setenv("BD_AI_BASE_URL", "https://proxy.example/anthropic")
+	if err := Initialize(); err != nil {
+		t.Fatalf("Initialize() returned error after BD_AI_BASE_URL: %v", err)
+	}
+	if got := DefaultAIBaseURL(AIAPIKeySourceMiniMaxEnv); got != "https://proxy.example/anthropic" {
+		t.Fatalf("BD_AI_BASE_URL MiniMax override = %q, want proxy URL", got)
+	}
+	if got := DefaultAIBaseURL(AIAPIKeySourceAnthropicEnv); got != "https://proxy.example/anthropic" {
+		t.Fatalf("BD_AI_BASE_URL Anthropic override = %q, want proxy URL", got)
+	}
+}
+
 func TestEnvironmentBinding(t *testing.T) {
 	// Test environment variable binding
 	tests := []struct {

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -126,7 +126,7 @@ func isGitTracked(path string) bool {
 }
 
 var secretKeyEnvVarHints = map[string]string{ //nolint:gosec // Values are environment variable names, not credentials.
-	"ai.api_key":     "ANTHROPIC_API_KEY",
+	"ai.api_key":     "ANTHROPIC_API_KEY or MINIMAX_API_KEY",
 	"github.token":   "GITHUB_TOKEN",
 	"linear.api_key": "LINEAR_API_KEY",
 }

--- a/internal/config/yaml_config_test.go
+++ b/internal/config/yaml_config_test.go
@@ -601,7 +601,7 @@ func TestSecretKeyEnvVarHint(t *testing.T) {
 	}{
 		{"linear.api_key", "LINEAR_API_KEY"},
 		{"github.token", "GITHUB_TOKEN"},
-		{"ai.api_key", "ANTHROPIC_API_KEY"},
+		{"ai.api_key", "ANTHROPIC_API_KEY or MINIMAX_API_KEY"},
 		{"custom.secret-token", "BD_CUSTOM_SECRET_TOKEN"},
 	}
 

--- a/website/docs/cli-reference/admin.md
+++ b/website/docs/cli-reference/admin.md
@@ -76,7 +76,7 @@ actively referenced. This is permanent graceful decay - original content is disc
 Modes:
   - Analyze: Export candidates for agent review (no API key needed)
   - Apply: Accept agent-provided summary (no API key needed)
-  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY or ai.api_key, legacy)
+  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
   - Dolt: Run Dolt garbage collection (for Dolt-backend repositories)
 
 Tiers:
@@ -100,10 +100,11 @@ Examples:
   bd compact --apply --id bd-42 --summary summary.txt
   bd compact --apply --id bd-42 --summary - &lt; summary.txt
 
-  # Legacy AI-powered workflow
+  # AI-powered workflow
   bd compact --auto --dry-run              # Preview candidates
   bd compact --auto --all                  # Compact all eligible issues
   bd compact --auto --id bd-42             # Compact specific issue
+  MINIMAX_API_KEY=... bd compact --auto --all
 
   # Statistics
   bd compact --stats                       # Show statistics
@@ -120,7 +121,7 @@ bd admin compact [flags]
       --all              Process all candidates
       --analyze          Analyze mode: export candidates for agent review
       --apply            Apply mode: accept agent-provided summary
-      --auto             Auto mode: AI-powered compaction (legacy)
+      --auto             Auto mode: AI-powered compaction
       --batch-size int   Issues per batch (default 10)
       --dolt             Dolt mode: run Dolt garbage collection on .beads/dolt
       --dry-run          Preview without compacting

--- a/website/docs/cli-reference/find-duplicates.md
+++ b/website/docs/cli-reference/find-duplicates.md
@@ -18,13 +18,13 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY or ai.api_key)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may
 miss semantically similar issues with very different wording.
 
-The AI approach sends candidate pairs to Claude for semantic comparison.
+The AI approach sends candidate pairs to an Anthropic-compatible model for semantic comparison.
 It first uses mechanical pre-filtering to reduce the number of API calls,
 then asks the LLM to judge whether the remaining pairs are true duplicates.
 

--- a/website/versioned_docs/version-1.0.0/cli-reference/admin.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/admin.md
@@ -76,7 +76,7 @@ actively referenced. This is permanent graceful decay - original content is disc
 Modes:
   - Analyze: Export candidates for agent review (no API key needed)
   - Apply: Accept agent-provided summary (no API key needed)
-  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY or ai.api_key, legacy)
+  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
   - Dolt: Run Dolt garbage collection (for Dolt-backend repositories)
 
 Tiers:
@@ -100,10 +100,11 @@ Examples:
   bd compact --apply --id bd-42 --summary summary.txt
   bd compact --apply --id bd-42 --summary - &lt; summary.txt
 
-  # Legacy AI-powered workflow
+  # AI-powered workflow
   bd compact --auto --dry-run              # Preview candidates
   bd compact --auto --all                  # Compact all eligible issues
   bd compact --auto --id bd-42             # Compact specific issue
+  MINIMAX_API_KEY=... bd compact --auto --all
 
   # Statistics
   bd compact --stats                       # Show statistics
@@ -120,7 +121,7 @@ bd admin compact [flags]
       --all              Process all candidates
       --analyze          Analyze mode: export candidates for agent review
       --apply            Apply mode: accept agent-provided summary
-      --auto             Auto mode: AI-powered compaction (legacy)
+      --auto             Auto mode: AI-powered compaction
       --batch-size int   Issues per batch (default 10)
       --dolt             Dolt mode: run Dolt garbage collection on .beads/dolt
       --dry-run          Preview without compacting

--- a/website/versioned_docs/version-1.0.0/cli-reference/find-duplicates.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/find-duplicates.md
@@ -18,13 +18,13 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY or ai.api_key)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may
 miss semantically similar issues with very different wording.
 
-The AI approach sends candidate pairs to Claude for semantic comparison.
+The AI approach sends candidate pairs to an Anthropic-compatible model for semantic comparison.
 It first uses mechanical pre-filtering to reduce the number of API calls,
 then asks the LLM to judge whether the remaining pairs are true duplicates.
 

--- a/website/versioned_docs/version-1.0.4/cli-reference/admin.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/admin.md
@@ -76,7 +76,7 @@ actively referenced. This is permanent graceful decay - original content is disc
 Modes:
   - Analyze: Export candidates for agent review (no API key needed)
   - Apply: Accept agent-provided summary (no API key needed)
-  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY or ai.api_key, legacy)
+  - Auto: AI-powered compaction (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
   - Dolt: Run Dolt garbage collection (for Dolt-backend repositories)
 
 Tiers:
@@ -100,10 +100,11 @@ Examples:
   bd compact --apply --id bd-42 --summary summary.txt
   bd compact --apply --id bd-42 --summary - &lt; summary.txt
 
-  # Legacy AI-powered workflow
+  # AI-powered workflow
   bd compact --auto --dry-run              # Preview candidates
   bd compact --auto --all                  # Compact all eligible issues
   bd compact --auto --id bd-42             # Compact specific issue
+  MINIMAX_API_KEY=... bd compact --auto --all
 
   # Statistics
   bd compact --stats                       # Show statistics
@@ -120,7 +121,7 @@ bd admin compact [flags]
       --all              Process all candidates
       --analyze          Analyze mode: export candidates for agent review
       --apply            Apply mode: accept agent-provided summary
-      --auto             Auto mode: AI-powered compaction (legacy)
+      --auto             Auto mode: AI-powered compaction
       --batch-size int   Issues per batch (default 10)
       --dolt             Dolt mode: run Dolt garbage collection on .beads/dolt
       --dry-run          Preview without compacting

--- a/website/versioned_docs/version-1.0.4/cli-reference/find-duplicates.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/find-duplicates.md
@@ -18,13 +18,13 @@ with different wording.
 
 Approaches:
   mechanical  Token-based text similarity (default, no API key needed)
-  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY or ai.api_key)
+  ai          LLM-based semantic comparison (requires ANTHROPIC_API_KEY, MINIMAX_API_KEY, or ai.api_key)
 
 The mechanical approach tokenizes titles and descriptions, then computes
 Jaccard similarity between all issue pairs. It's fast and free but may
 miss semantically similar issues with very different wording.
 
-The AI approach sends candidate pairs to Claude for semantic comparison.
+The AI approach sends candidate pairs to an Anthropic-compatible model for semantic comparison.
 It first uses mechanical pre-filtering to reduce the number of API calls,
 then asks the LLM to judge whether the remaining pairs are true duplicates.
 


### PR DESCRIPTION
## Why

PR #3610 adds useful MiniMax support, but the original patch leaves the integration only partially usable: `bd compact --auto` still rejects a setup that only has `MINIMAX_API_KEY`, provider base URL handling is duplicated across call sites, and the generated help/config docs do not describe the new knobs. That means a user can follow the MiniMax instructions and still hit the Anthropic preflight path instead of the Anthropic-compatible MiniMax endpoint.

This fix-merge branch keeps the contributor's provider idea and API shape, then centralizes key/base URL resolution so compact and AI duplicate detection behave consistently.

## What Changed

- Added shared AI key resolution with precedence: `ANTHROPIC_API_KEY`, then `MINIMAX_API_KEY`, then config/explicit key.
- Added shared base URL resolution for `ai.base_url`, `BD_AI_BASE_URL`, `MINIMAX_BASE_URL`, and the MiniMax Anthropic-compatible default.
- Wired the shared resolution into compact auto mode and `find-duplicates --method ai`.
- Updated generated help/config docs.
- Added tests for key precedence, MiniMax default base URL, and override behavior.

## Attribution

Preserves and fixes the useful work from #3610 by @octo-patch. The implementation commit includes:

`Co-authored-by: octo-patch <octo-patch@github.com>`

## Validation

- `go test ./internal/config ./internal/compact`
- `CGO_ENABLED=0 go test -tags gms_pure_go ./cmd/bd -run 'TestHelpAll|TestHelpCommandsHaveRequiredSections|TestConfigValidateKeys'`
- `git diff --check`

Broader `cmd/bd` package runs are blocked in this local environment by missing ICU headers for the CGO path and existing embedded-Dolt pure-Go test constraints.

_codex-gpt-5.5-medium on behalf of CI Bot_
