### PR TITLE
docs: check reference doc freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,9 @@ jobs:
         run: CGO_ENABLED=0 go build -tags gms_pure_go -o bd ./cmd/bd/
 
       - name: Validate docs against CLI
-        run: ./scripts/check-doc-flags.sh ./bd
+        run: |
+          ./scripts/check-doc-flags.sh ./bd
+          ./scripts/check-doc-freshness.sh
 
   # Fast check to catch accidental .beads/issues.jsonl changes from contributors
   check-no-beads-changes:

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ check-docs:
 	@echo "Building bd for docs checks..."
 	@CGO_ENABLED=0 go build -tags "$(BUILD_TAGS)" -ldflags="-X main.Build=$(GIT_BUILD)" -o $(BUILD_DIR)/bd ./cmd/bd
 	@./scripts/check-doc-flags.sh ./bd
+	@./scripts/check-doc-freshness.sh
 
 # Clean build artifacts and benchmark profiles
 clean:

--- a/scripts/check-doc-freshness.sh
+++ b/scripts/check-doc-freshness.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# check-doc-freshness.sh - Validate marker-based freshness for reference docs.
+#
+# Usage: ./scripts/check-doc-freshness.sh
+#
+# Environment:
+#   DOC_FRESHNESS_MAX_AGE_DAYS  Maximum accepted age for Last reviewed markers.
+#                               Defaults to 90 days.
+#   DOC_FRESHNESS_TODAY         Override today's date for deterministic tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+MAX_AGE_DAYS="${DOC_FRESHNESS_MAX_AGE_DAYS:-90}"
+TODAY="${DOC_FRESHNESS_TODAY:-$(date +%F)}"
+ERRORS=0
+
+DOCS=(
+    "docs/CONFIG.md|cmd/bd/main.go;cmd/bd/config.go;internal/configfile/"
+    "docs/SETUP.md|cmd/bd/setup*.go;internal/recipes/"
+    "docs/ADO_CONFIG.md|cmd/bd/ado*.go;internal/ado/"
+    "docs/JSON_SCHEMA.md|cmd/bd/output.go;cmd/bd/errors.go;cmd/bd/protocol/json_contract_test.go"
+    "docs/RECOVERY.md|cmd/bd/init.go;cmd/bd/init_safety.go;cmd/bd/init_safety_test.go"
+    "docs/ERROR_HANDLING.md|cmd/bd/*.go;cmd/bd/errors.go"
+    "docs/LINTING.md|.golangci.yml"
+    "docs/design/otel/otel-data-model.md|internal/telemetry/;internal/storage/dolt/store.go;internal/compact/haiku.go;cmd/bd/find_duplicates.go;internal/hooks/"
+)
+
+echo "Checking reference doc freshness markers..."
+echo "Max age: ${MAX_AGE_DAYS} days"
+echo "Today: ${TODAY}"
+echo ""
+
+date_age_days() {
+    local reviewed="$1"
+    python3 - "$reviewed" "$TODAY" <<'PY'
+import datetime
+import sys
+
+reviewed = datetime.date.fromisoformat(sys.argv[1])
+today = datetime.date.fromisoformat(sys.argv[2])
+print((today - reviewed).days)
+PY
+}
+
+inventory_ref_for_doc() {
+    local doc="$1"
+    doc="${doc#docs/}"
+    printf '%s\n' "$doc"
+}
+
+path_exists_or_glob_matches() {
+    local pattern="$1"
+
+    if [[ "$pattern" == *"*"* || "$pattern" == *"?"* || "$pattern" == *"["* ]]; then
+        compgen -G "$PROJECT_ROOT/$pattern" >/dev/null
+    else
+        [[ -e "$PROJECT_ROOT/$pattern" ]]
+    fi
+}
+
+for entry in "${DOCS[@]}"; do
+    IFS='|' read -r doc sources <<<"$entry"
+    doc_path="$PROJECT_ROOT/$doc"
+    inventory_ref="$(inventory_ref_for_doc "$doc")"
+
+    echo "=== $doc ==="
+
+    if [[ ! -f "$doc_path" ]]; then
+        echo "FAIL: missing document"
+        ERRORS=$((ERRORS + 1))
+        echo ""
+        continue
+    fi
+
+    if ! grep -Fq "\`$inventory_ref\`" "$PROJECT_ROOT/docs/DOC_INVENTORY.md"; then
+        echo "FAIL: docs/DOC_INVENTORY.md does not list \`$inventory_ref\`"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "PASS: listed in docs/DOC_INVENTORY.md"
+    fi
+
+    reviewed_line="$(grep -E -m1 '^Last reviewed: [0-9]{4}-[0-9]{2}-[0-9]{2}$' "$doc_path" || true)"
+    if [[ -z "$reviewed_line" ]]; then
+        echo "FAIL: missing Last reviewed marker in YYYY-MM-DD format"
+        ERRORS=$((ERRORS + 1))
+    else
+        reviewed="${reviewed_line#Last reviewed: }"
+        if ! age_days="$(date_age_days "$reviewed" 2>/dev/null)"; then
+            echo "FAIL: invalid Last reviewed date: $reviewed"
+            ERRORS=$((ERRORS + 1))
+        elif (( age_days < 0 )); then
+            echo "FAIL: Last reviewed date is in the future: $reviewed"
+            ERRORS=$((ERRORS + 1))
+        elif (( age_days > MAX_AGE_DAYS )); then
+            echo "FAIL: Last reviewed date is stale: $reviewed (${age_days} days old)"
+            ERRORS=$((ERRORS + 1))
+        else
+            echo "PASS: Last reviewed marker is current: $reviewed (${age_days} days old)"
+        fi
+    fi
+
+    if ! grep -Eq '^Freshness source:' "$doc_path"; then
+        echo "FAIL: missing Freshness source marker"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "PASS: Freshness source marker present"
+    fi
+
+    IFS=';' read -ra source_list <<<"$sources"
+    for source in "${source_list[@]}"; do
+        if ! grep -Fq "$source" "$doc_path"; then
+            echo "FAIL: Freshness source does not name $source"
+            ERRORS=$((ERRORS + 1))
+        elif ! path_exists_or_glob_matches "$source"; then
+            echo "FAIL: Freshness source path does not exist: $source"
+            ERRORS=$((ERRORS + 1))
+        else
+            echo "PASS: Freshness source path exists: $source"
+        fi
+    done
+
+    echo ""
+done
+
+echo "=== Summary ==="
+if (( ERRORS > 0 )); then
+    echo "FAILED: $ERRORS reference doc freshness issue(s) found"
+    echo ""
+    echo "To fix:"
+    echo "  1. Re-review the failing doc against its Freshness source paths."
+    echo "  2. Update the doc's Last reviewed marker and Freshness source list."
+    echo "  3. Re-run: ./scripts/check-doc-freshness.sh"
+    exit 1
+fi
+
+echo "PASSED: Reference doc freshness markers are current and checkable"

--- a/scripts/docs.md
+++ b/scripts/docs.md
@@ -31,6 +31,21 @@ Generates maintained CLI reference docs from the live Cobra command tree exposed
 
 `scripts/check-doc-flags.sh` runs the `--check` mode in CI and fails when live top-level commands are missing from generated docs.
 
+## check-doc-freshness.sh
+
+Validates marker-based freshness for reference-shaped docs that are not generated from a single clean source.
+
+### Usage
+
+```bash
+./scripts/check-doc-freshness.sh
+make check-docs
+```
+
+The script currently checks the reference docs named in `docs/DOC_INVENTORY.md`: `CONFIG.md`, `SETUP.md`, `ADO_CONFIG.md`, `JSON_SCHEMA.md`, `RECOVERY.md`, `ERROR_HANDLING.md`, `LINTING.md`, and `design/otel/otel-data-model.md`. Each doc must be listed in the inventory, include a recent `Last reviewed:` marker, include a `Freshness source:` marker, and name source paths or globs that exist in the repository.
+
+Set `DOC_FRESHNESS_MAX_AGE_DAYS` to override the default 90-day review window. Set `DOC_FRESHNESS_TODAY=YYYY-MM-DD` when testing date behaviour.
+
 ### How it fits into the larger codebase
 
 - **Build Integration**: The `install.sh` script is referenced in documentation and release processes as the primary user-facing installation mechanism. It integrates directly with the Go build system to ensure full version information is embedded.


### PR DESCRIPTION
## Why

Reference-shaped docs already carry review markers and source pointers, but CI did not verify them. This adds a lightweight freshness gate so those docs cannot silently drift like generated CLI docs did before their check was added.

## What

- Add `scripts/check-doc-freshness.sh` for the reference docs listed in `docs/DOC_INVENTORY.md`.
- Require current `Last reviewed:` markers, `Freshness source:` markers, inventory entries, and existing source paths/globs.
- Wire the checker into `make check-docs` and docs CI.
- Document usage and override environment variables.

## Validation

- `bash -n scripts/check-doc-freshness.sh`
- `./scripts/check-doc-freshness.sh`
- `make check-docs`
- `git diff --check`

Tracks mybd-xfr.

_codex-gpt-5.5-medium on behalf of matt wilkie_