### PR TITLE
docs: gate llms-full freshness with CLI reference

### DIFF
--- a/scripts/check-docs-version.sh
+++ b/scripts/check-docs-version.sh
@@ -50,12 +50,12 @@ echo ""
 
 LATEST_DOCS_VERSION=$(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' website/versions.json | head -1 | tr -d '"' || true)
 LAST_VERSION=$(grep -oE "lastVersion: '[0-9]+\.[0-9]+\.[0-9]+'" website/docusaurus.config.ts | head -1 | sed "s/.*'\([^']*\)'.*/\1/" || true)
-LLMS_VERSION=$(grep -oE 'version: [0-9]+\.[0-9]+\.[0-9]+' website/static/llms-full.txt | head -1 | sed 's/version: //' || true)
+LLMS_VERSION_LABEL=$(grep -oE 'version: [^)]+' website/static/llms-full.txt | head -1 | sed 's/version: //' || true)
 CLI_REF_LABEL=$(grep -oE 'Reference for bd v[0-9]+\.[0-9]+\.[0-9]+' "website/versioned_docs/version-$CANONICAL/cli-reference/index.md" 2>/dev/null | head -1 | sed 's/Reference for bd v//' || true)
 
 check_equal "website/versions.json latest docs version" "$LATEST_DOCS_VERSION" "$CANONICAL"
 check_equal "website/docusaurus.config.ts lastVersion" "$LAST_VERSION" "$CANONICAL"
-check_equal "website/static/llms-full.txt source version" "$LLMS_VERSION" "$CANONICAL"
+check_equal "website/static/llms-full.txt source version label" "$LLMS_VERSION_LABEL" "latest released"
 check_equal "versioned CLI reference label" "$CLI_REF_LABEL" "$CANONICAL"
 
 check_exists "versioned docs snapshot" "website/versioned_docs/version-$CANONICAL"

--- a/scripts/docs.md
+++ b/scripts/docs.md
@@ -28,8 +28,9 @@ Generates maintained CLI reference docs from the live Cobra command tree exposed
 - `docs/CLI_REFERENCE.md` from `bd help --all`
 - `website/docs/cli-reference/*.md` from `bd help --list` and `bd help --doc <command>`
 - `website/versioned_docs/version-1.0.0/cli-reference/*.md` so the published default docs and llms artifact source stay in sync
+- `website/static/llms-full.txt` freshness is checked from the same generated website docs tree
 
-`scripts/check-doc-flags.sh` runs the `--check` mode in CI and fails when live top-level commands are missing from generated docs.
+`scripts/check-doc-flags.sh` runs the `--check` mode in CI and fails when live top-level commands are missing from generated docs or `llms-full.txt` is stale.
 
 ### How it fits into the larger codebase
 

--- a/scripts/generate-cli-docs.sh
+++ b/scripts/generate-cli-docs.sh
@@ -142,6 +142,15 @@ generate_all() {
 
 if [ "$CHECK_MODE" -eq 1 ]; then
     TMP_OUTPUT_DIR="$(mktemp -d)"
+    mkdir -p "$TMP_OUTPUT_DIR/website"
+    cp -Rf "$PROJECT_ROOT/website/docs" "$TMP_OUTPUT_DIR/website/docs"
+    if [ -d "$PROJECT_ROOT/website/versioned_docs" ]; then
+        cp -Rf "$PROJECT_ROOT/website/versioned_docs" "$TMP_OUTPUT_DIR/website/versioned_docs"
+    fi
+    if [ -f "$PROJECT_ROOT/website/versions.json" ]; then
+        cp -f "$PROJECT_ROOT/website/versions.json" "$TMP_OUTPUT_DIR/website/versions.json"
+    fi
+
     generate_all "$TMP_OUTPUT_DIR"
 
     if ! diff -qr \
@@ -171,6 +180,8 @@ if [ "$CHECK_MODE" -eq 1 ]; then
             fi
         fi
     done
+
+    "$PROJECT_ROOT/scripts/generate-llms-full.sh" --check --source-root "$TMP_OUTPUT_DIR"
 
     echo "PASS: generated CLI docs are fresh"
 else

--- a/scripts/generate-llms-full.sh
+++ b/scripts/generate-llms-full.sh
@@ -4,36 +4,91 @@
 # Uses the latest *released* docs snapshot (versioned_docs) when present so
 # llms-full matches the default site version, not unreleased "Next".
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SOURCE_ROOT="$PROJECT_ROOT"
 OUTPUT_FILE="$PROJECT_ROOT/website/static/llms-full.txt"
+CHECK_MODE=0
+TMP_OUTPUT_FILE=""
+
+usage() {
+  echo "Usage: $0 [--check] [--source-root DIR] [--output FILE]" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check)
+      CHECK_MODE=1
+      shift
+      ;;
+    --source-root)
+      if [ "$#" -lt 2 ]; then
+        usage
+        exit 1
+      fi
+      SOURCE_ROOT="$2"
+      shift 2
+      ;;
+    --output)
+      if [ "$#" -lt 2 ]; then
+        usage
+        exit 1
+      fi
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+cleanup() {
+  if [ -n "$TMP_OUTPUT_FILE" ]; then
+    rm -f "$TMP_OUTPUT_FILE"
+  fi
+}
+trap cleanup EXIT
 
 resolve_docs_dir() {
-  local vfile="$PROJECT_ROOT/website/versions.json"
+  local vfile="$SOURCE_ROOT/website/versions.json"
   if [ ! -f "$vfile" ]; then
-    echo "$PROJECT_ROOT/website/docs"
+    echo "$SOURCE_ROOT/website/docs"
     return
   fi
   # versions.json lists newest first; first semver-like string wins
   local ver
   ver=$(grep -oE '"[0-9][^"]*"' "$vfile" | head -1 | tr -d '"')
-  if [ -n "$ver" ] && [ -d "$PROJECT_ROOT/website/versioned_docs/version-$ver" ]; then
-    echo "$PROJECT_ROOT/website/versioned_docs/version-$ver"
+  if [ -n "$ver" ] && [ -d "$SOURCE_ROOT/website/versioned_docs/version-$ver" ]; then
+    echo "$SOURCE_ROOT/website/versioned_docs/version-$ver"
   else
-    echo "$PROJECT_ROOT/website/docs"
+    echo "$SOURCE_ROOT/website/docs"
   fi
 }
 
 DOCS_DIR="$(resolve_docs_dir)"
-DOC_VERSION_LABEL="development"
+DOC_VERSION_LABEL="Latest"
 if [[ "$DOCS_DIR" == *"/versioned_docs/version-"* ]]; then
-  DOC_VERSION_LABEL="${DOCS_DIR##*version-}"
+  DOC_VERSION_LABEL="latest released"
+fi
+
+if [ "$CHECK_MODE" -eq 1 ]; then
+  TMP_OUTPUT_FILE="$(mktemp)"
+  GENERATED_FILE="$TMP_OUTPUT_FILE"
+else
+  mkdir -p "$(dirname "$OUTPUT_FILE")"
+  GENERATED_FILE="$OUTPUT_FILE"
 fi
 
 # Header
-cat > "$OUTPUT_FILE" << EOF
+cat > "$GENERATED_FILE" << EOF
 # Beads Documentation (Complete)
 
 > This file contains the complete beads documentation for LLM consumption.
@@ -44,20 +99,30 @@ cat > "$OUTPUT_FILE" << EOF
 
 EOF
 
+normalize_content() {
+    local relative_path="$1"
+
+    if [ "$relative_path" = "cli-reference/index.md" ]; then
+        sed -E 's/^Reference for bd v[0-9][A-Za-z0-9._-]*\. Generated/Reference for bd Latest. Generated/'
+    else
+        cat
+    fi
+}
+
 # Function to process a markdown file
 process_file() {
     local file="$1"
     local relative_path="${file#$DOCS_DIR/}"
 
-    echo "<document path=\"docs/$relative_path\">" >> "$OUTPUT_FILE"
-    echo "" >> "$OUTPUT_FILE"
+    echo "<document path=\"docs/$relative_path\">" >> "$GENERATED_FILE"
+    echo "" >> "$GENERATED_FILE"
 
     # Remove frontmatter and add content
-    sed '/^---$/,/^---$/d' "$file" >> "$OUTPUT_FILE"
+    sed '/^---$/,/^---$/d' "$file" | normalize_content "$relative_path" >> "$GENERATED_FILE"
 
-    echo "" >> "$OUTPUT_FILE"
-    echo "</document>" >> "$OUTPUT_FILE"
-    echo "" >> "$OUTPUT_FILE"
+    echo "" >> "$GENERATED_FILE"
+    echo "</document>" >> "$GENERATED_FILE"
+    echo "" >> "$GENERATED_FILE"
 }
 
 # Process files in order (intro first, then by category)
@@ -83,7 +148,7 @@ for dir in getting-started core-concepts architecture cli-reference workflows mu
 done
 
 # Add footer
-cat >> "$OUTPUT_FILE" << 'EOF'
+cat >> "$GENERATED_FILE" << 'EOF'
 ---
 
 # End of Documentation
@@ -91,7 +156,17 @@ cat >> "$OUTPUT_FILE" << 'EOF'
 For updates and contributions, visit: https://github.com/gastownhall/beads
 EOF
 
-echo "Generated: $OUTPUT_FILE"
-echo "Source docs: $DOCS_DIR"
-echo "Size: $(wc -c < "$OUTPUT_FILE" | tr -d ' ') bytes"
-echo "Lines: $(wc -l < "$OUTPUT_FILE" | tr -d ' ')"
+if [ "$CHECK_MODE" -eq 1 ]; then
+  if ! diff -q "$OUTPUT_FILE" "$GENERATED_FILE" >/dev/null; then
+    echo "FAIL: website/static/llms-full.txt is out of sync with generated website docs."
+    echo "Run: ./scripts/generate-llms-full.sh"
+    diff -u "$OUTPUT_FILE" "$GENERATED_FILE" | sed -n '1,160p' || true
+    exit 1
+  fi
+  echo "PASS: website/static/llms-full.txt is fresh"
+else
+  echo "Generated: $OUTPUT_FILE"
+  echo "Source docs: $DOCS_DIR"
+  echo "Size: $(wc -c < "$OUTPUT_FILE" | tr -d ' ') bytes"
+  echo "Lines: $(wc -l < "$OUTPUT_FILE" | tr -d ' ')"
+fi

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1,7 +1,7 @@
 # Beads Documentation (Complete)
 
 > This file contains the complete beads documentation for LLM consumption.
-> Generated automatically from the documentation source files (version: 1.0.4).
+> Generated automatically from the documentation source files (version: latest released).
 > For the web version, visit: https://gastownhall.github.io/beads/
 
 ---
@@ -1779,7 +1779,7 @@ For these use cases, consider GitHub Issues, Linear, or Jira.
 # CLI Reference
 
 <!-- AUTO-GENERATED: do not edit manually -->
-Reference for bd v1.0.4. Generated from `bd help --list` and `bd help --doc <command>`.
+Reference for bd Latest. Generated from `bd help --list` and `bd help --doc <command>`.
 
 This reference covers all 106 live top-level `bd` commands. Regenerate it with:
 
@@ -2879,6 +2879,7 @@ Configuration is stored per-project in the beads database and is version-control
 
 Common namespaces:
   - export.*          Auto-export settings (stored in config.yaml)
+  - import.*          JSONL import settings (stored in config.yaml)
   - jira.*            Jira integration settings
   - linear.*          Linear integration settings
   - github.*          GitHub integration settings
@@ -2887,15 +2888,25 @@ Common namespaces:
   - doctor.suppress.* Suppress specific bd doctor warnings (GH#1095)
 
 Auto-Export (config.yaml):
-  Writes .beads/issues.jsonl after every write command (throttled).
-  Enabled by default. Useful for viewers (bv) and interchange; not a backup.
+  Optional JSONL export to .beads/issues.jsonl after write commands (throttled).
+  Useful for viewers (bv), interchange, and issue-level migration; not a backup.
   It is not cross-machine sync; use bd dolt push/pull with a Dolt remote.
+  Disabled by default. Enable only for integrations that need fresh JSONL.
+  Auto-staging is separate and disabled by default.
 
   Keys:
-    export.auto       Enable/disable auto-export (default: true)
+    export.auto       Enable/disable auto-export (default: false)
     export.path       Output filename relative to .beads/ (default: issues.jsonl)
     export.interval   Minimum time between exports (default: 60s)
-    export.git-add    Auto-stage the export file (default: true)
+    export.git-add    Auto-stage the export file (default: false)
+
+Auto-Import (config.yaml):
+  Reads .beads/issues.jsonl by default when a JSONL import path is implied.
+  Use a relative filename/path so the import stays within the project .beads/
+  directory and remains portable across machines.
+
+  Keys:
+    import.path       Input filename relative to .beads/ (default: issues.jsonl)
 
 Custom Status States:
   You can define custom status states for multi-step pipelines using the
@@ -2916,8 +2927,10 @@ Suppressing Doctor Warnings:
   To unsuppress: bd config unset doctor.suppress.&lt;slug&gt;
 
 Examples:
-  bd config set export.auto false                      # Disable auto-export
+  bd config set export.auto true                       # Enable auto-export for viewer integrations
   bd config set export.path "beads.jsonl"              # Custom export filename
+  bd config set import.path "beads.jsonl"              # Custom import filename
+  bd config set export.git-add true                    # Also stage the export file
   bd config set jira.url "https://company.atlassian.net"
   bd config set jira.project "PROJ"
   bd config set status.custom "awaiting_review,awaiting_testing"
@@ -5287,8 +5300,8 @@ Generated from `bd help --doc import`
 
 Import issues from a JSONL file (newline-delimited JSON) into the database.
 
-If no file is specified, imports from .beads/issues.jsonl (the git-tracked
-export). Use "-" to read from stdin. This is the incremental counterpart to
+If no file is specified, imports from the configured import.path under .beads/
+(default: issues.jsonl). Use "-" to read from stdin. This is the incremental counterpart to
 'bd export': new issues are created and existing issues are updated (upsert
 semantics).
 
@@ -5324,7 +5337,7 @@ when present in the JSONL and otherwise filled in by the importer. The
 legacy "wisp" boolean is accepted as an alias for "ephemeral".
 
 EXAMPLES:
-  bd import                        # Import from .beads/issues.jsonl
+  bd import                        # Import from configured import.path
   bd import backup.jsonl           # Import from a specific file
   bd import -i backup.jsonl        # Legacy alias for a specific file
   bd import -                      # Read JSONL from stdin
@@ -5491,17 +5504,17 @@ Pass --server to use an external dolt sql-server instead. In server mode,
 set connection details with --server-host, --server-port, and --server-user.
 Password should be set via BEADS_DOLT_PASSWORD environment variable.
 
-Auto-export is enabled by default. After every write command, bd exports
-issues to .beads/issues.jsonl (throttled to once per 60s). This keeps
-viewers (bv) and interchange up to date without extra steps.
+Auto-export is optional. When enabled, bd exports issues to
+.beads/issues.jsonl after write commands (throttled to once per 60s). This is
+for viewers (bv), interchange, and issue-level migration; not backup.
 Cross-machine sync and backups use Dolt remotes/backups, not JSONL import/export.
-To disable: bd config set export.auto false
+To enable: bd config set export.auto true
 
 Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
   Skips all interactive prompts, using sensible defaults:
   • Role defaults to "maintainer" (override with --role)
   • Fork exclude auto-configured when fork detected
-  • Auto-export left at default (enabled)
+  • Auto-export left at default (disabled)
   • --contributor and --team flags are rejected (wizards require interaction)
   Also auto-detected when stdin is not a terminal or CI=true is set.
 
@@ -5523,7 +5536,7 @@ bd init [flags]
       --discard-remote                    Authorize discarding the configured remote's Dolt history when re-initializing. Requires --destroy-token in non-interactive mode; see 'bd help init-safety'.
       --external                          Server is externally managed (skip server startup); use with --shared-server or --server
       --force                             Deprecated alias for --reinit-local. Bypasses only the LOCAL data-safety guard; does NOT authorize remote divergence (see 'bd help init-safety').
-      --from-jsonl                        Import issues from .beads/issues.jsonl instead of git history
+      --from-jsonl                        Import issues from configured import.path instead of git history
       --non-interactive                   Skip all interactive prompts (auto-detected in CI or non-TTY environments)
   -p, --prefix string                     Issue prefix (default: current directory name)
       --proxied-server                    [EXPERIMENTAL] Use a per-workspace proxied dolt sql-server (proxy + child dolt) rooted at .beads/proxieddb
@@ -5541,7 +5554,7 @@ bd init [flags]
       --server-user string                Dolt server MySQL user (default: root)
       --setup-exclude                     Configure .git/info/exclude to keep beads files local (for forks)
       --shared-server                     Enable shared Dolt server mode (all projects share one server at ~/.beads/shared-server/)
-      --skip-agents                       Skip AGENTS.md and Claude settings generation
+      --skip-agents                       Skip AGENTS.md and Claude/Codex setup generation
       --skip-hooks                        Skip git hooks installation
       --stealth                           Enable stealth mode: global gitattributes and gitignore, no local repo tracking
       --team                              Run team workflow setup wizard
@@ -6149,6 +6162,7 @@ bd list [flags]
       --priority-min string          Filter by minimum priority (inclusive, 0-4 or P0-P4)
       --ready                        Show only ready issues (no active blockers, same semantics as bd ready)
   -r, --reverse                      Reverse sort order
+      --skip-labels                  Skip label hydration. The labels field in output will be empty regardless of actual labels. Use only when the caller does not depend on label data. Cannot combine with --label, --label-any, --label-pattern, --label-regex, --exclude-label, or --no-labels.
       --sort string                  Sort by field: priority, created, updated, closed, status, id, title, type, assignee
       --spec string                  Filter by spec_id prefix
   -s, --status string                Filter by stored status (open, in_progress, blocked, deferred, closed). Comma-separated for multiple: --status open,in_progress
@@ -6333,6 +6347,7 @@ Without subcommand, checks and updates database metadata to current version.
 Subcommands:
   hooks       Plan git hook migration to marker-managed format
   issues      Move issues between repositories
+  schema      Apply pending schema migrations (idempotent)
   sync        Set up sync.branch workflow for multi-clone setups
 
 
@@ -6419,6 +6434,28 @@ bd migrate issues [flags]
       --type string        Filter by issue type (bug/feature/task/epic/chore/decision)
       --within-from-only   Only include dependencies from source repo (default true)
       --yes                Skip confirmation prompt
+```
+
+### bd migrate schema
+
+Apply pending schema migrations idempotently.
+
+Schema migrations also run automatically on store open, so this subcommand
+is typically a no-op. It exists to make migration explicit and observable
+in CI, release gates, and recovery scenarios.
+
+Example:
+  bd migrate schema
+  bd migrate schema --json
+
+```
+bd migrate schema [flags]
+```
+
+**Flags:**
+
+```
+      --json   Output in JSON format
 ```
 
 ### bd migrate sync
@@ -7219,7 +7256,7 @@ by default. This approach:
   • bd prime provides dynamic, always-current workflow details
   • Hooks auto-inject bd prime at session start
 
-For agents that don't support hooks (Codex, Factory, etc.), use
+For agents or environments that do not auto-inject hook output, use
 'bd init --agents-profile=full' to embed the complete command reference.
 
 ```
@@ -8174,8 +8211,8 @@ include cursor, claude, copilot, gemini, aider, factory, codex, mux, opencode, j
 
 Examples:
   bd setup cursor          # Install Cursor IDE integration
-  bd setup codex           # Install Codex skill + AGENTS.md guidance
-  bd setup codex --global  # Install global Codex skill + global AGENTS.md guidance
+  bd setup codex           # Install Codex skill + AGENTS.md guidance + native hooks
+  bd setup codex --global  # Install global Codex skill + guidance + native hooks
   bd setup copilot         # Install Copilot CLI plugin + repository instructions
   bd setup mux --project   # Install Mux workspace layer (.mux/AGENTS.md)
   bd setup mux --global    # Install Mux global layer (~/.mux/AGENTS.md)
@@ -8266,16 +8303,18 @@ bd show [id...] [--id=<id>...] [--current] [flags]
 **Flags:**
 
 ```
-      --as-of string     Show issue as it existed at a specific commit hash or branch (requires Dolt)
-      --children         Show only the children of this issue
-      --current          Show the currently active issue (in-progress, hooked, or last touched)
-      --id stringArray   Issue ID (use for IDs that look like flags, e.g., --id=gt--xyz)
-      --local-time       Show timestamps in local time instead of UTC
-      --long             Show all available fields (extended metadata, agent identity, gate fields, etc.)
-      --refs             Show issues that reference this issue (reverse lookup)
-      --short            Show compact one-line output per issue
-      --thread           Show full conversation thread (for messages)
-  -w, --watch            Watch for changes and auto-refresh display
+      --as-of string         Show issue as it existed at a specific commit hash or branch (requires Dolt)
+      --children             Show only the children of this issue
+      --current              Show the currently active issue (in-progress, hooked, or last touched)
+      --id stringArray       Issue ID (use for IDs that look like flags, e.g., --id=gt--xyz)
+      --include-comments     Stream full comment bodies in JSON output (--json only; may be slow on issues with many comments)
+      --include-dependents   Stream full dependent issues in JSON output (--json only; may be slow on hub beads)
+      --local-time           Show timestamps in local time instead of UTC
+      --long                 Show all available fields (extended metadata, agent identity, gate fields, etc.)
+      --refs                 Show issues that reference this issue (reverse lookup)
+      --short                Show compact one-line output per issue
+      --thread               Show full conversation thread (for messages)
+  -w, --watch                Watch for changes and auto-refresh display
 ```
 
 </document>
@@ -12051,6 +12090,7 @@ Secrets in this list are refused on git-tracked `config.yaml` files unless you p
 | `backup.git-repo` | — | `BD_BACKUP_GIT_REPO` | (none) | Backup git repo URL |
 | `export.auto` | — | — | `true` | Refresh `.beads/issues.jsonl` after every write |
 | `export.path` | — | — | `issues.jsonl` | Output filename relative to `.beads/` |
+| `import.path` | — | — | `issues.jsonl` | Input filename relative to `.beads/` for implied JSONL imports; use relative paths for portability |
 | `export.interval` | — | — | `60s` | Minimum time between auto-exports |
 | `export.git-add` | — | — | `true` | Run `git add` on the export file |
 | `routing.mode` | — | — | (none) | Multi-repo routing: `auto`, `maintainer`, `contributor`, `explicit` |


### PR DESCRIPTION
## Why

`website/static/llms-full.txt` is generated separately from the live-help CLI reference, so it can drift silently even when `scripts/generate-cli-docs.sh --check` is green. That already left stale versioned CLI text in the llms export, which weakens the docs freshness guarantee added for the generated CLI reference.

This PR puts the llms export under the same freshness path so future command/help changes and release version changes do not create inconsistent generated docs.

## What Changed

- Added `generate-llms-full.sh --check`.
- Wired `generate-cli-docs.sh --check` to validate `website/static/llms-full.txt` from the freshly generated CLI docs tree.
- Normalized llms-only version labels so release-version-only changes do not churn the export.
- Regenerated `website/static/llms-full.txt`.
- Updated script docs/version checks for the new gate.

## Validation

- `CGO_ENABLED=0 go build -tags gms_pure_go -o /tmp/mybd-ssn-bd ./cmd/bd/`
- `./scripts/generate-llms-full.sh --check`
- `./scripts/generate-cli-docs.sh --check /tmp/mybd-ssn-bd`
- `./scripts/check-doc-flags.sh /tmp/mybd-ssn-bd` with existing non-fatal legacy SQLite warnings
- `./scripts/check-docs-version.sh`
- `bash -n ...`
- `git diff --check`

A simulated release-version-only docs bump produced no `llms-full.txt` diff.

_codex-gpt-5.5-medium on behalf of CI Bot_
