### PR TITLE
fix(dep): keep relates-to out of dependency tree

### DIFF
--- a/cmd/bd/dep_embedded_test.go
+++ b/cmd/bd/dep_embedded_test.go
@@ -362,6 +362,34 @@ func TestEmbeddedDep(t *testing.T) {
 		}
 	})
 
+	t.Run("tree_ignores_bidirectional_relates_to", func(t *testing.T) {
+		root := bdCreate(t, bd, dir, "Tree relates root", "--type", "task")
+		blocker := bdCreate(t, bd, dir, "Tree real blocker", "--type", "task")
+		related := bdCreate(t, bd, dir, "Tree loose relation", "--type", "task")
+
+		bdDep(t, bd, dir, "add", root.ID, blocker.ID, "--type", "blocks")
+		bdDep(t, bd, dir, "add", root.ID, related.ID, "--type", "relates-to")
+		bdDep(t, bd, dir, "add", related.ID, root.ID, "--type", "relates-to")
+
+		listOut := bdDep(t, bd, dir, "list", root.ID)
+		if !strings.Contains(listOut, related.ID) || !strings.Contains(listOut, "relates-to") {
+			t.Fatalf("expected relates-to edge in dep list output: %s", listOut)
+		}
+
+		treeOut := bdDep(t, bd, dir, "tree", root.ID)
+		if !strings.Contains(treeOut, root.ID) || !strings.Contains(treeOut, blocker.ID) {
+			t.Fatalf("expected root and real blocker in dep tree: %s", treeOut)
+		}
+		if strings.Contains(treeOut, related.ID) {
+			t.Fatalf("relates-to edge should not render as a dependency tree edge: %s", treeOut)
+		}
+
+		upOut := bdDep(t, bd, dir, "tree", related.ID, "--direction", "up")
+		if strings.Contains(upOut, root.ID) {
+			t.Fatalf("reverse relates-to edge should not render as a dependent tree edge: %s", upOut)
+		}
+	})
+
 	// ===== dep cycles =====
 
 	t.Run("cycles_detect", func(t *testing.T) {

--- a/cmd/bd/list_embedded_test.go
+++ b/cmd/bd/list_embedded_test.go
@@ -420,6 +420,30 @@ func TestEmbeddedList(t *testing.T) {
 		}
 	})
 
+	// Regression for gastownhall/beads#3936: relates-to between two epics
+	// must not nest them in `bd list` tree mode, and a bidirectional
+	// relates-to must not silently drop both epics from the output.
+	t.Run("tree_relates_to_does_not_nest_or_drop_epics", func(t *testing.T) {
+		epicA := bdCreate(t, bd, dir, "Relates Epic A", "--type", "epic", "--priority", "2")
+		epicB := bdCreate(t, bd, dir, "Relates Epic B", "--type", "epic", "--priority", "2")
+
+		bdDep(t, bd, dir, "add", epicA.ID, epicB.ID, "--type", "relates-to")
+		out := bdList(t, bd, dir, "--no-pager", "--type", "epic")
+		if !strings.Contains(out, epicA.ID) || !strings.Contains(out, epicB.ID) {
+			t.Fatalf("one-direction relates-to should keep both epics visible:\n%s", out)
+		}
+		if strings.Contains(out, "└── "+epicA.ID) || strings.Contains(out, "└── "+epicB.ID) ||
+			strings.Contains(out, "├── "+epicA.ID) || strings.Contains(out, "├── "+epicB.ID) {
+			t.Fatalf("relates-to must not nest epics under each other:\n%s", out)
+		}
+
+		bdDep(t, bd, dir, "add", epicB.ID, epicA.ID, "--type", "relates-to")
+		out = bdList(t, bd, dir, "--no-pager", "--type", "epic")
+		if !strings.Contains(out, epicA.ID) || !strings.Contains(out, epicB.ID) {
+			t.Fatalf("bidirectional relates-to must not drop epics from tree output:\n%s", out)
+		}
+	})
+
 	t.Run("ready_parent_filter_includes_grandchildren", func(t *testing.T) {
 		parent := bdCreate(t, bd, dir, "Ready parent recursive", "--type", "epic")
 		child := bdCreate(t, bd, dir, "Ready child recursive", "--type", "task", "--parent", parent.ID)

--- a/cmd/bd/list_helpers_test.go
+++ b/cmd/bd/list_helpers_test.go
@@ -90,6 +90,45 @@ func TestListBuildIssueTree_ParentChildByDotID(t *testing.T) {
 	}
 }
 
+// Regression test for gastownhall/beads#3936:
+// `relates-to` is a loose graph link, not a hierarchy edge. It must not nest
+// issues under each other in `bd list` — and a bidirectional relates-to between
+// two epics must not collapse both subtrees out of the root set.
+func TestListBuildIssueTree_RelatesToDoesNotNestEpics(t *testing.T) {
+	epicA := &types.Issue{ID: "bd-a", Title: "Epic A", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+	epicB := &types.Issue{ID: "bd-b", Title: "Epic B", Status: types.StatusOpen, Priority: 2, IssueType: types.TypeEpic}
+
+	t.Run("OneDirection", func(t *testing.T) {
+		allDeps := map[string][]*types.Dependency{
+			"bd-a": {
+				{IssueID: "bd-a", DependsOnID: "bd-b", Type: types.DepRelatesTo},
+			},
+		}
+		roots, children := buildIssueTreeWithDeps([]*types.Issue{epicA, epicB}, allDeps)
+		if len(roots) != 2 {
+			t.Fatalf("expected both epics as roots, got %d: %+v", len(roots), roots)
+		}
+		if len(children["bd-b"]) != 0 {
+			t.Fatalf("relates-to must not nest under target epic, got children: %+v", children["bd-b"])
+		}
+	})
+
+	t.Run("Bidirectional", func(t *testing.T) {
+		allDeps := map[string][]*types.Dependency{
+			"bd-a": {
+				{IssueID: "bd-a", DependsOnID: "bd-b", Type: types.DepRelatesTo},
+			},
+			"bd-b": {
+				{IssueID: "bd-b", DependsOnID: "bd-a", Type: types.DepRelatesTo},
+			},
+		}
+		roots, _ := buildIssueTreeWithDeps([]*types.Issue{epicA, epicB}, allDeps)
+		if len(roots) != 2 {
+			t.Fatalf("bidirectional relates-to must not drop epics from roots, got %d: %+v", len(roots), roots)
+		}
+	})
+}
+
 // Regression test for https://github.com/steveyegge/beads/issues/1446
 // A task with multiple dependencies on the same epic should only appear once.
 func TestListBuildIssueTree_NoDuplicateChildrenFromMultipleDeps(t *testing.T) {

--- a/cmd/bd/list_tree.go
+++ b/cmd/bd/list_tree.go
@@ -47,6 +47,15 @@ func buildIssueTreeWithDeps(issues []*types.Issue, allDeps map[string][]*types.D
 					continue
 				}
 
+				// relates-to is a loose graph link, not a hierarchical edge:
+				// treating it as parent-child causes incorrect nesting and, when
+				// bidirectional, marks both endpoints as children of each other
+				// — collapsing them out of the root set and silently dropping
+				// whole subtrees from `bd list`. See gastownhall/beads#3936.
+				if dep.Type == types.DepRelatesTo {
+					continue
+				}
+
 				// Treat as parent-child if:
 				// 1. Explicit parent-child dependency type, OR
 				// 2. Any dependency where the target is an epic

--- a/internal/storage/issueops/dependency_tree.go
+++ b/internal/storage/issueops/dependency_tree.go
@@ -47,6 +47,9 @@ func buildDependencyTreeInTx(ctx context.Context, tx *sql.Tx, issueID string, de
 	// TreeNode doesn't have Children field - return flat list
 	nodes := []*types.TreeNode{node}
 	for _, rel := range related {
+		if !isDependencyTreeEdge(rel.DependencyType) {
+			continue
+		}
 		children, err := buildDependencyTreeInTx(ctx, tx, rel.ID, depth+1, maxDepth, reverse, visited, issueID, rel.DependencyType)
 		if err != nil {
 			return nil, err
@@ -55,4 +58,8 @@ func buildDependencyTreeInTx(ctx context.Context, tx *sql.Tx, issueID string, de
 	}
 
 	return nodes, nil
+}
+
+func isDependencyTreeEdge(depType types.DependencyType) bool {
+	return depType != types.DepRelatesTo
 }

--- a/internal/storage/issueops/dependency_tree_test.go
+++ b/internal/storage/issueops/dependency_tree_test.go
@@ -1,0 +1,183 @@
+package issueops
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestIsDependencyTreeEdge(t *testing.T) {
+	tests := []struct {
+		name    string
+		depType types.DependencyType
+		want    bool
+	}{
+		{
+			name:    "blocks remains a tree edge",
+			depType: types.DepBlocks,
+			want:    true,
+		},
+		{
+			name:    "parent-child remains a tree edge",
+			depType: types.DepParentChild,
+			want:    true,
+		},
+		{
+			name:    "related remains a tree edge",
+			depType: types.DepRelated,
+			want:    true,
+		},
+		{
+			name:    "relates-to is a graph link, not a tree edge",
+			depType: types.DepRelatesTo,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDependencyTreeEdge(tt.depType); got != tt.want {
+				t.Fatalf("isDependencyTreeEdge(%q) = %v, want %v", tt.depType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDependencyTreeInTxSkipsRelatesToEdges(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	expectIssue(mock, "root", "Root")
+	expectDependencies(mock, "root", []dependencyRow{
+		{id: "blocker", depType: string(types.DepBlocks)},
+		{id: "related", depType: string(types.DepRelatesTo)},
+	})
+	expectIssueBatch(mock, []string{"blocker", "related"})
+	expectIssue(mock, "blocker", "Blocker")
+	expectDependencies(mock, "blocker", nil)
+	mock.ExpectRollback()
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	tree, err := GetDependencyTreeInTx(context.Background(), tx, "root", 3, false, false)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("GetDependencyTreeInTx: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+
+	if len(tree) != 2 {
+		t.Fatalf("len(tree) = %d, want 2 nodes: %+v", len(tree), tree)
+	}
+	if tree[0].ID != "root" || tree[1].ID != "blocker" {
+		t.Fatalf("tree IDs = %v, want [root blocker]", treeIDs(tree))
+	}
+	if tree[1].EdgeFromParent != types.DepBlocks {
+		t.Fatalf("blocker edge = %q, want %q", tree[1].EdgeFromParent, types.DepBlocks)
+	}
+}
+
+type dependencyRow struct {
+	id      string
+	depType string
+}
+
+func expectIssue(mock sqlmock.Sqlmock, id, title string) {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + IssueSelectColumns + " FROM issues WHERE id = ?")).
+		WithArgs(id).
+		WillReturnRows(issueRows().AddRow(issueRowValues(id, title)...))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT label FROM labels WHERE issue_id = ? ORDER BY label")).
+		WithArgs(id).
+		WillReturnRows(sqlmock.NewRows([]string{"label"}))
+}
+
+func expectDependencies(mock sqlmock.Sqlmock, issueID string, deps []dependencyRow) {
+	rows := sqlmock.NewRows([]string{"depends_on_id", "type"})
+	for _, dep := range deps {
+		rows.AddRow(dep.id, dep.depType)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + DepTargetExpr + " AS depends_on_id, type FROM dependencies WHERE issue_id = ?")).
+		WithArgs(issueID).
+		WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT " + DepTargetExpr + " AS depends_on_id, type FROM wisp_dependencies WHERE issue_id = ?")).
+		WithArgs(issueID).
+		WillReturnRows(sqlmock.NewRows([]string{"depends_on_id", "type"}))
+}
+
+func expectIssueBatch(mock sqlmock.Sqlmock, ids []string) {
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1 FROM wisps LIMIT 1")).
+		WillReturnError(sql.ErrNoRows)
+
+	rows := issueRows()
+	for _, id := range ids {
+		rows.AddRow(issueRowValues(id, id)...)
+	}
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT "+IssueSelectColumns+" FROM issues WHERE id IN (?,?)")).
+		WithArgs(ids[0], ids[1]).
+		WillReturnRows(rows)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT issue_id, label FROM labels WHERE issue_id IN (?,?) ORDER BY issue_id, label")).
+		WithArgs(ids[0], ids[1]).
+		WillReturnRows(sqlmock.NewRows([]string{"issue_id", "label"}))
+}
+
+func issueRows() *sqlmock.Rows {
+	return sqlmock.NewRows(issueColumns())
+}
+
+func issueColumns() []string {
+	parts := strings.Split(strings.ReplaceAll(IssueSelectColumns, "\n", " "), ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+func issueRowValues(id, title string) []driver.Value {
+	values := make([]driver.Value, 0, len(issueColumns()))
+	for _, col := range issueColumns() {
+		switch col {
+		case "id":
+			values = append(values, id)
+		case "title":
+			values = append(values, title)
+		case "description", "design", "acceptance_criteria", "notes":
+			values = append(values, "")
+		case "status":
+			values = append(values, string(types.StatusOpen))
+		case "priority":
+			values = append(values, 1)
+		case "issue_type":
+			values = append(values, string(types.TypeTask))
+		case "compaction_level":
+			values = append(values, 0)
+		default:
+			values = append(values, nil)
+		}
+	}
+	return values
+}
+
+func treeIDs(tree []*types.TreeNode) []string {
+	ids := make([]string, 0, len(tree))
+	for _, node := range tree {
+		ids = append(ids, node.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
## Why

`relates-to` is a loose graph link, not a hierarchy edge. Beads has two
separate tree builders that both treat it as if it were one, and the
combined effect makes `bd list` lose entire subtrees silently:

- `bd dep tree` (storage helper `GetDependencyTreeInTx`) walked
  `relates-to` edges as tree edges, so related issues showed up nested
  under their target with traversal cycle-detection further hiding
  endpoints of bidirectional relates-to.
- `bd list` (`buildIssueTreeWithDeps`) treats *any* dependency whose
  target is an epic as parent-child. A `relates-to` between two epics
  nests one under the other; a **bidirectional** relates-to marks both
  endpoints as children of each other, so neither lands in the root
  set and both subtrees silently drop from output while the footer
  count stays correct. This is the symptom #3936 reports.

This PR fixes both code paths so `relates-to` keeps showing up under
`bd dep list` (where it belongs) but never shapes tree output.

Fixes #3936.

## What changed

- `internal/storage/issueops/dependency_tree.go`: skip `relates-to`
  during dependency-tree traversal; add `isDependencyTreeEdge` for the
  predicate.
- `cmd/bd/list_tree.go`: skip `relates-to` in
  `buildIssueTreeWithDeps` so the epic-target heuristic does not turn
  it into a parent edge.
- Add issueops unit coverage for the tree-edge filter and traversal
  behavior.
- Add `cmd/bd` unit coverage for `buildIssueTreeWithDeps` (both
  one-direction and bidirectional relates-to between epics).
- Add embedded CLI regressions: bidirectional `relates-to` remains
  listed under `bd dep list` but is excluded from `bd dep tree` in
  both directions; `bd list --type=epic` keeps both epics visible and
  unnested.

## Validation

- `go test ./internal/storage/issueops -run 'Test(IsDependencyTreeEdge|GetDependencyTreeInTxSkipsRelatesToEdges)'`
- `go test ./internal/storage/issueops`
- `go test ./cmd/bd -run 'TestListBuildIssueTree'`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedDep/tree_ignores_bidirectional_relates_to'`
- `BEADS_TEST_EMBEDDED_DOLT=1 CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedList/tree_relates_to_does_not_nest_or_drop_epics'`
- End-to-end `bd list` repro from #3936 against the built binary: both
  one-direction and bidirectional relates-to between two epics now
  keep both epics rendered as roots.

_claude-opus-4-7-xhigh on behalf of matt wilkie_
