### PR TITLE
fix: commit federation metadata before sync

### DIFF
--- a/internal/storage/dolt/credentials.go
+++ b/internal/storage/dolt/credentials.go
@@ -297,12 +297,16 @@ func (s *DoltStore) AddFederationPeer(ctx context.Context, peer *storage.Federat
 		return fmt.Errorf("failed to add federation peer: %w", err)
 	}
 
-	// Also add the Dolt remote
+	// Also add the Dolt remote.
 	if err := s.AddRemote(ctx, peer.Name, peer.RemoteURL); err != nil {
 		// Ignore "remote already exists" errors
 		if !strings.Contains(err.Error(), "already exists") {
 			return fmt.Errorf("failed to add dolt remote: %w", err)
 		}
+	}
+
+	if err := s.doltAddAndCommit(ctx, []string{"federation_peers"}, "federation: add peer "+peer.Name); err != nil {
+		return fmt.Errorf("failed to commit federation peer: %w", err)
 	}
 
 	return nil

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -311,6 +311,17 @@ func (s *DoltStore) Sync(ctx context.Context, peer string, strategy string) (*Sy
 		StartTime: time.Now(),
 	}
 
+	// Match PullFrom: federation metadata writes such as add-peer must not
+	// leave the working set dirty before fetch/merge.
+	if !s.readOnly {
+		if err := s.Commit(ctx, "auto-commit before sync"); err != nil {
+			if !isDoltNothingToCommit(err) {
+				result.Error = fmt.Errorf("failed to commit pending changes before sync: %w", err)
+				return result, result.Error
+			}
+		}
+	}
+
 	// Step 1: Fetch from peer
 	if err := s.Fetch(ctx, peer); err != nil {
 		result.Error = fmt.Errorf("fetch failed: %w", err)

--- a/internal/storage/dolt/federation_test.go
+++ b/internal/storage/dolt/federation_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
 
@@ -383,6 +384,58 @@ func TestFederationSyncStatus(t *testing.T) {
 	if status.LocalAhead != -1 || status.LocalBehind != -1 {
 		t.Logf("Note: Status returned values for nonexistent peer (may be expected behavior)")
 	}
+}
+
+func TestFederationSyncCommitsPendingPeerMetadataBeforeFetch(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	peer := &storage.FederationPeer{
+		Name:        "peer-metadata-sync",
+		RemoteURL:   "file:///tmp/beads-no-such-federation-peer",
+		Sovereignty: "T2",
+	}
+	if err := store.AddFederationPeer(ctx, peer); err != nil {
+		t.Fatalf("add federation peer: %v", err)
+	}
+
+	if federationStatusHasTable(t, ctx, store, "federation_peers") {
+		t.Fatal("add-peer should commit federation_peers metadata")
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		"UPDATE federation_peers SET sovereignty = ? WHERE name = ?", "T3", peer.Name,
+	); err != nil {
+		t.Fatalf("dirty federation peer metadata: %v", err)
+	}
+	if !federationStatusHasTable(t, ctx, store, "federation_peers") {
+		t.Fatal("expected direct federation_peers update to dirty the working set")
+	}
+
+	_, err := store.Sync(ctx, peer.Name, "")
+	if err == nil {
+		t.Fatal("expected sync to fail for nonexistent file remote")
+	}
+	if federationStatusHasTable(t, ctx, store, "federation_peers") {
+		t.Fatal("sync should commit pending federation_peers metadata before fetch/merge")
+	}
+}
+
+func federationStatusHasTable(t *testing.T, ctx context.Context, store *DoltStore, table string) bool {
+	t.Helper()
+
+	var count int
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM dolt_status WHERE table_name = ?", table,
+	).Scan(&count); err != nil {
+		t.Fatalf("query dolt_status for %s: %v", table, err)
+	}
+	return count > 0
 }
 
 // TestFederationPushPullMethods tests PushTo and PullFrom


### PR DESCRIPTION
Why:
#3852 reports that `bd federation add-peer` leaves `federation_peers` dirty, so a later sync can be blocked before it reaches fetch/merge. Current `Sync` also did not perform the pre-sync cleanup that `PullFrom` already does.

What changed:
- Commit `federation_peers` after add-peer writes peer metadata and remote setup.
- Auto-commit pending non-config changes before `Sync` fetch/merge, matching `PullFrom` behavior.
- Add regression coverage for committed add-peer metadata and pre-sync cleanup.

Drift check:
- #3852 is still open on GitHub as of 2026-05-27.

Validation:
- `go test ./internal/storage/dolt -run '^$' -count=1`\n- `go test -tags=integration ./internal/storage/dolt -run TestFederationSyncCommitsPendingPeerMetadataBeforeFetch -count=1 -v` skipped here because Docker/Dolt test server is unavailable\n- `git diff --check`\n\nRefs #3852\n\n_codex-gpt-5.5-medium on behalf of matt wilkie_