### PR TITLE
fix: skip setup injection for symlinked agent files

### DIFF
--- a/cmd/bd/setup/agents.go
+++ b/cmd/bd/setup/agents.go
@@ -95,7 +95,12 @@ func installAgents(env agentsEnv, integration agentsIntegration) error {
 	// can unexpectedly mutate other instruction files and, in some workflows,
 	// corrupt tracked symlink entries.
 	if info, err := os.Lstat(env.agentsPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		_, _ = fmt.Fprintf(env.stdout, "Warning: %s is a symlink; skipping managed section injection to preserve link mode/content\n", agentsFile)
+		target, readErr := os.Readlink(env.agentsPath)
+		targetHint := ""
+		if readErr == nil && target != "" {
+			targetHint = fmt.Sprintf(" to %s", target)
+		}
+		_, _ = fmt.Fprintf(env.stderr, "Warning: %s is a symlink%s; skipping managed section injection to preserve link mode/content. Update the target file directly, or replace the symlink with a regular file and re-run '%s'.\n", agentsFile, targetHint, integration.setupCommand)
 		return nil
 	} else if err != nil && !os.IsNotExist(err) {
 		_, _ = fmt.Fprintf(env.stderr, "Error: failed to inspect %s: %v\n", env.agentsPath, err)

--- a/cmd/bd/setup/agents.go
+++ b/cmd/bd/setup/agents.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/templates/agents"
-	"github.com/steveyegge/beads/internal/utils"
 )
 
 // readFileBytesImpl is used in tests; avoids import cycle.
@@ -92,20 +91,22 @@ func installAgents(env agentsEnv, integration agentsIntegration) error {
 	_, _ = fmt.Fprintf(env.stdout, "Installing %s integration...\n", integration.name)
 	agentsFile := agentsFileName(env.agentsPath)
 
-	profile := resolveProfile(integration)
-	opts := detectRenderOpts()
-
-	// Resolve symlinks so that e.g. CLAUDE.md -> AGENTS.md writes to the real target.
-	// This uses the existing atomicWriteFile path which also calls ResolveForWrite,
-	// but we need the resolved path here to read the current content from the right place.
-	resolvedPath, err := utils.ResolveForWrite(env.agentsPath)
-	if err != nil {
-		_, _ = fmt.Fprintf(env.stderr, "Error: resolve path %s: %v\n", env.agentsPath, err)
+	// Never inject managed sections through symlinks. Following symlink targets
+	// can unexpectedly mutate other instruction files and, in some workflows,
+	// corrupt tracked symlink entries.
+	if info, err := os.Lstat(env.agentsPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		_, _ = fmt.Fprintf(env.stdout, "Warning: %s is a symlink; skipping managed section injection to preserve link mode/content\n", agentsFile)
+		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		_, _ = fmt.Fprintf(env.stderr, "Error: failed to inspect %s: %v\n", env.agentsPath, err)
 		return err
 	}
 
+	profile := resolveProfile(integration)
+	opts := detectRenderOpts()
+
 	var currentContent string
-	data, err := os.ReadFile(resolvedPath) // #nosec G304 -- resolvedPath is derived from env.agentsPath via ResolveForWrite
+	data, err := os.ReadFile(env.agentsPath) // #nosec G304 -- env.agentsPath is trusted setup destination
 	if err == nil {
 		currentContent = string(data)
 	} else if !os.IsNotExist(err) {

--- a/cmd/bd/setup/agents_marker_test.go
+++ b/cmd/bd/setup/agents_marker_test.go
@@ -318,9 +318,9 @@ func TestInstallAgentsSymlinkSafety(t *testing.T) {
 	realFile := filepath.Join(dir, "AGENTS.md")
 	linkPath := filepath.Join(dir, "CLAUDE.md")
 
-	// Write full profile content to the real file
-	fullSection := agents.RenderSection(agents.ProfileFull)
-	if err := os.WriteFile(realFile, []byte(fullSection), 0644); err != nil {
+	// Seed the target with content that should remain unchanged.
+	original := "# Existing target content\n"
+	if err := os.WriteFile(realFile, []byte(original), 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -345,13 +345,26 @@ func TestInstallAgentsSymlinkSafety(t *testing.T) {
 		t.Fatalf("installAgents via symlink: %v", err)
 	}
 
-	// Read the real file — should still have full profile
+	// Symlink should still be a symlink.
+	if info, err := os.Lstat(linkPath); err != nil {
+		t.Fatalf("lstat symlink: %v", err)
+	} else if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("expected CLAUDE.md to remain a symlink")
+	}
+
+	// Read the real file — should be untouched (no managed section injection).
 	data, err := os.ReadFile(realFile)
 	if err != nil {
 		t.Fatalf("read real file: %v", err)
 	}
-	if !strings.Contains(string(data), "profile:full") {
-		t.Error("symlink target should preserve full profile")
+	if string(data) != original {
+		t.Errorf("symlink target changed:\n got: %q\nwant: %q", string(data), original)
+	}
+	if strings.Contains(string(data), "BEGIN BEADS INTEGRATION") {
+		t.Error("symlink target should not receive managed section")
+	}
+	if !strings.Contains(stdout.String(), "is a symlink; skipping managed section injection") {
+		t.Error("expected skip warning in output")
 	}
 }
 

--- a/cmd/bd/setup/agents_marker_test.go
+++ b/cmd/bd/setup/agents_marker_test.go
@@ -363,8 +363,47 @@ func TestInstallAgentsSymlinkSafety(t *testing.T) {
 	if strings.Contains(string(data), "BEGIN BEADS INTEGRATION") {
 		t.Error("symlink target should not receive managed section")
 	}
-	if !strings.Contains(stdout.String(), "is a symlink; skipping managed section injection") {
-		t.Error("expected skip warning in output")
+	if stdout.String() != "Installing ClaudeCode integration...\n" {
+		t.Errorf("expected stdout to contain only install start, got: %q", stdout.String())
+	}
+	stderrText := stderr.String()
+	if !strings.Contains(stderrText, "CLAUDE.md is a symlink to "+realFile) {
+		t.Errorf("expected warning to include symlink target, got: %s", stderrText)
+	}
+	if !strings.Contains(stderrText, "re-run 'bd setup claude'") {
+		t.Errorf("expected warning to include corrective command, got: %s", stderrText)
+	}
+}
+
+func TestInstallAgentsInspectError(t *testing.T) {
+	dir := t.TempDir()
+	notDir := filepath.Join(dir, "not-dir")
+	if err := os.WriteFile(notDir, []byte("not a directory"), 0644); err != nil {
+		t.Fatalf("write sentinel file: %v", err)
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	env := agentsEnv{
+		agentsPath: filepath.Join(notDir, "AGENTS.md"),
+		stdout:     stdout,
+		stderr:     stderr,
+	}
+	integration := agentsIntegration{
+		name:         "TestAgent",
+		setupCommand: "bd setup testagent",
+		profile:      agents.ProfileMinimal,
+	}
+
+	err := installAgents(env, integration)
+	if err == nil {
+		t.Fatal("expected inspect error")
+	}
+	if os.IsNotExist(err) {
+		t.Fatalf("expected non-not-exist error, got: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Error: failed to inspect") {
+		t.Errorf("expected inspect error on stderr, got: %s", stderr.String())
 	}
 }
 


### PR DESCRIPTION
Why:
`bd setup claude` currently follows symlinked instruction files such as `CLAUDE.md -> AGENTS.md` and injects Beads managed text into the target file. That preserves the symlink path but mutates the linked target unexpectedly, which is the corruption mode reported in #3722.

What changed:
- Detect symlinked agent instruction paths with `Lstat` before managed-section injection.
- Skip injection for symlink paths and emit a warning instead of following the target.
- Tighten symlink safety coverage so the target content and symlink mode remain unchanged.

Drift check:
- #3722 is still open on GitHub as of 2026-05-27.

Validation:
- `go test ./cmd/bd/setup`
- `git diff --check`

Refs #3722

_codex-gpt-5.5-medium on behalf of matt wilkie_