### PR TITLE
test(where): isolate initialized db path state

### DIFF
--- a/cmd/bd/where_test.go
+++ b/cmd/bd/where_test.go
@@ -113,10 +113,11 @@ func TestResolveWhereBeadsDir_ReturnsEmptyWithoutWorkspace(t *testing.T) {
 }
 
 func TestResolveWhereBeadsDir_UsesInitializedDBPath(t *testing.T) {
-	originalDBPath := dbPath
+	saveAndRestoreGlobals(t)
+	ensureCleanGlobalState(t)
+
 	originalCmdCtx := cmdCtx
 	defer func() {
-		dbPath = originalDBPath
 		cmdCtx = originalCmdCtx
 	}()
 
@@ -149,7 +150,10 @@ func TestResolveWhereBeadsDir_UsesInitializedDBPath(t *testing.T) {
 		_ = os.Chdir(originalWD)
 	})
 
-	dbPath = dbDir
+	t.Setenv("BEADS_DIR", "")
+	t.Setenv("BEADS_DB", "")
+	t.Setenv("BD_DB", "")
+	setDBPath(dbDir)
 
 	if got := resolveWhereBeadsDir(nil); !utils.PathsEqual(got, beadsDir) {
 		t.Fatalf("resolveWhereBeadsDir(nil) = %q, want %q", got, beadsDir)


### PR DESCRIPTION
Why:
- The initialized-db-path where test could inherit `BEADS_DB`, `BD_DB`, or `BEADS_DIR` from the environment and resolve the repository `.beads` path instead of its temporary initialized path.
- That made the test flaky under broader parallel `cmd/bd` runs.

What:
- Save and restore global command state.
- Clear database routing env vars with `t.Setenv`.
- Use `setDBPath` for the initialized test path.

Validation:
- `CGO_ENABLED=1 go test -tags gms_pure_go -run '^TestResolveWhereBeadsDir_UsesInitializedDBPath$' -count=10 ./cmd/bd/`\n- Worker also ran `CGO_ENABLED=1 go test -tags gms_pure_go -count=3 -p 4 ./cmd/bd/` successfully after the fix.\n- `git diff --check`\n\nBead: mybd-b8i\n\n_codex-gpt-5.5-medium on behalf of matt wilkie_