### PR TITLE
fix(close): support per-id reasons

### DIFF
--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -27,7 +27,9 @@ If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
 When closing multiple issues, provide one --reason for all IDs or repeat
---reason once per ID in the same order.`,
+--reason once per ID. Reasons map positionally: the first --reason applies
+to the first ID, the second --reason to the second ID, regardless of where
+the flags appear in the command line.`,
 	Args: cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("close")
@@ -369,7 +371,7 @@ func resolveCloseReasons(cmd *cobra.Command, args []string) ([]string, []string,
 func collectCloseReasonFlags(cmd *cobra.Command) ([]string, error) {
 	if flag := cmd.Flags().Lookup("reason"); flag != nil {
 		if v, ok := flag.Value.(interface{ Values() []string }); ok {
-			if reasons := v.Values(); len(reasons) > 0 {
+			if reasons := nonEmptyCloseReasons(v.Values()); len(reasons) > 0 {
 				return reasons, nil
 			}
 		}
@@ -385,6 +387,16 @@ func collectCloseReasonFlags(cmd *cobra.Command) ([]string, error) {
 		}
 	}
 	return nil, nil
+}
+
+func nonEmptyCloseReasons(reasons []string) []string {
+	out := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		if reason != "" {
+			out = append(out, reason)
+		}
+	}
+	return out
 }
 
 func reasonForCloseIndex(reasons []string, i int) string {

--- a/cmd/bd/close.go
+++ b/cmd/bd/close.go
@@ -24,7 +24,10 @@ var closeCmd = &cobra.Command{
 	Long: `Close one or more issues.
 
 If no issue ID is provided, closes the last touched issue (from most recent
-create, update, show, or close operation).`,
+create, update, show, or close operation).
+
+When closing multiple issues, provide one --reason for all IDs or repeat
+--reason once per ID in the same order.`,
 	Args: cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		CheckReadonly("close")
@@ -37,49 +40,14 @@ create, update, show, or close operation).`,
 			}
 			args = []string{lastTouched}
 		}
-		reason, _ := cmd.Flags().GetString("reason")
-		if reason == "" {
-			// Check --resolution alias (Jira CLI convention)
-			reason, _ = cmd.Flags().GetString("resolution")
-		}
-		if reason == "" {
-			// Check -m alias (git commit convention)
-			reason, _ = cmd.Flags().GetString("message")
-		}
-		if reason == "" {
-			// Check --comment alias (desire-path from hq-ftpg)
-			reason, _ = cmd.Flags().GetString("comment")
-		}
-
-		// --reason-file <path> (with - for stdin) mirrors `bd create --body-file`,
-		// so agents can pass structured close templates without shell-escaping hell (#3512).
-		if fileReason, ok, err := resolveReasonFile(cmd, reason); err != nil {
+		reasons, updatedArgs, err := resolveCloseReasons(cmd, args)
+		if err != nil {
 			FatalErrorRespectJSON("%v", err)
-		} else if ok {
-			reason = fileReason
 		}
+		args = updatedArgs
 
-		// Desire-path: "bd done <id> <message>" treats last positional arg as reason
-		// when no reason flag was explicitly provided (hq-pe8ce)
-		if reason == "" && cmd.CalledAs() == "done" && len(args) >= 2 {
-			reason = args[len(args)-1]
-			args = args[:len(args)-1]
-		}
-
-		if reason == "" {
-			reason = "Closed"
-		}
-
-		// Validate close reason if configured
-		closeValidation := config.GetString("validation.on-close")
-		if closeValidation == "error" || closeValidation == "warn" {
-			if err := validation.ValidateCloseReason(reason); err != nil {
-				if closeValidation == "error" {
-					FatalErrorRespectJSON("%v", err)
-				}
-				// warn mode: print warning but proceed
-				fmt.Fprintf(os.Stderr, "%s %v\n", ui.RenderWarn("⚠"), err)
-			}
+		if err := validateCloseReasons(reasons); err != nil {
+			FatalErrorRespectJSON("%v", err)
 		}
 
 		force, _ := cmd.Flags().GetBool("force")
@@ -129,6 +97,7 @@ create, update, show, or close operation).`,
 		for i, id := range resolvedIDs {
 			result := results[i]
 			activeStore := result.Store
+			reason := reasonForCloseIndex(reasons, i)
 			// Get issue for checks (nil issue is handled by validateIssueClosable)
 			issue := result.Issue
 
@@ -321,7 +290,7 @@ create, update, show, or close operation).`,
 }
 
 func init() {
-	closeCmd.Flags().StringP("reason", "r", "", "Reason for closing")
+	registerCloseReasonFlag(closeCmd)
 	closeCmd.Flags().String("resolution", "", "Alias for --reason (Jira CLI convention)")
 	_ = closeCmd.Flags().MarkHidden("resolution") // Hidden alias for agent/CLI ergonomics
 	closeCmd.Flags().StringP("message", "m", "", "Alias for --reason (git commit convention)")
@@ -337,6 +306,110 @@ func init() {
 	closeCmd.Flags().String("session", "", "Claude Code session ID (or set CLAUDE_SESSION_ID env var)")
 	closeCmd.ValidArgsFunction = issueIDCompletion
 	rootCmd.AddCommand(closeCmd)
+}
+
+type closeReasonFlagValue struct {
+	values []string
+}
+
+func registerCloseReasonFlag(cmd *cobra.Command) {
+	cmd.Flags().VarP(&closeReasonFlagValue{}, "reason", "r", "Reason for closing")
+}
+
+func (v *closeReasonFlagValue) Set(s string) error {
+	v.values = append(v.values, s)
+	return nil
+}
+
+func (v *closeReasonFlagValue) String() string {
+	if len(v.values) == 0 {
+		return ""
+	}
+	return v.values[len(v.values)-1]
+}
+
+func (v *closeReasonFlagValue) Type() string {
+	return "string"
+}
+
+func (v *closeReasonFlagValue) Values() []string {
+	out := make([]string, len(v.values))
+	copy(out, v.values)
+	return out
+}
+
+func resolveCloseReasons(cmd *cobra.Command, args []string) ([]string, []string, error) {
+	reasons, err := collectCloseReasonFlags(cmd)
+	if err != nil {
+		return nil, args, err
+	}
+
+	if fileReason, ok, err := resolveReasonFile(cmd, len(reasons) > 0); err != nil {
+		return nil, args, err
+	} else if ok {
+		reasons = []string{fileReason}
+	}
+
+	// Desire-path: "bd done <id> <message>" treats last positional arg as reason
+	// when no reason flag was explicitly provided (hq-pe8ce)
+	if len(reasons) == 0 && cmd.CalledAs() == "done" && len(args) >= 2 {
+		reasons = []string{args[len(args)-1]}
+		args = args[:len(args)-1]
+	}
+
+	if len(reasons) == 0 {
+		reasons = []string{"Closed"}
+	}
+	if len(reasons) > 1 && len(reasons) != len(args) {
+		return nil, args, fmt.Errorf("got %d close reasons for %d issue IDs; provide exactly one shared reason or one reason per issue", len(reasons), len(args))
+	}
+	return reasons, args, nil
+}
+
+func collectCloseReasonFlags(cmd *cobra.Command) ([]string, error) {
+	if flag := cmd.Flags().Lookup("reason"); flag != nil {
+		if v, ok := flag.Value.(interface{ Values() []string }); ok {
+			if reasons := v.Values(); len(reasons) > 0 {
+				return reasons, nil
+			}
+		}
+	}
+
+	for _, name := range []string{"resolution", "message", "comment"} {
+		reason, err := cmd.Flags().GetString(name)
+		if err != nil {
+			return nil, err
+		}
+		if reason != "" {
+			return []string{reason}, nil
+		}
+	}
+	return nil, nil
+}
+
+func reasonForCloseIndex(reasons []string, i int) string {
+	if len(reasons) == 1 {
+		return reasons[0]
+	}
+	return reasons[i]
+}
+
+func validateCloseReasons(reasons []string) error {
+	closeValidation := config.GetString("validation.on-close")
+	if closeValidation != "error" && closeValidation != "warn" {
+		return nil
+	}
+
+	for _, reason := range reasons {
+		if err := validation.ValidateCloseReason(reason); err != nil {
+			if closeValidation == "error" {
+				return err
+			}
+			// warn mode: print warning but proceed
+			fmt.Fprintf(os.Stderr, "%s %v\n", ui.RenderWarn("⚠"), err)
+		}
+	}
+	return nil
 }
 
 // isMachineCheckableGate returns true if the issue is a gate with a machine-checkable await type.
@@ -471,11 +544,11 @@ func shouldAutoCloseCompletedRoot(root *types.Issue) bool {
 // Returns an error on conflict with an existing reason, file read failure, or empty content.
 // Mirrors the --body-file pattern from `bd create` so agents can pass structured close
 // templates without shell-escaping hell.
-func resolveReasonFile(cmd *cobra.Command, existingReason string) (string, bool, error) {
+func resolveReasonFile(cmd *cobra.Command, hasExistingReason bool) (string, bool, error) {
 	if !cmd.Flags().Changed("reason-file") {
 		return "", false, nil
 	}
-	if existingReason != "" {
+	if hasExistingReason {
 		return "", false, fmt.Errorf("cannot specify both --reason-file and --reason/--resolution/--message/--comment")
 	}
 	path, _ := cmd.Flags().GetString("reason-file")

--- a/cmd/bd/close_embedded_test.go
+++ b/cmd/bd/close_embedded_test.go
@@ -178,6 +178,22 @@ func TestEmbeddedClose(t *testing.T) {
 		}
 	})
 
+	t.Run("close_multiple_ids_with_per_id_reasons", func(t *testing.T) {
+		issue1 := bdCreate(t, bd, dir, "Multi close reason 1", "--type", "task")
+		issue2 := bdCreate(t, bd, dir, "Multi close reason 2", "--type", "task")
+
+		bdClose(t, bd, dir, issue1.ID, "--reason", "fixed A", issue2.ID, "--reason", "fixed B")
+
+		got1 := bdShow(t, bd, dir, issue1.ID)
+		got2 := bdShow(t, bd, dir, issue2.ID)
+		if got1.CloseReason != "fixed A" {
+			t.Errorf("issue1 close_reason = %q, want %q", got1.CloseReason, "fixed A")
+		}
+		if got2.CloseReason != "fixed B" {
+			t.Errorf("issue2 close_reason = %q, want %q", got2.CloseReason, "fixed B")
+		}
+	})
+
 	t.Run("close_already_closed", func(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "Double close", "--type", "task")
 		bdClose(t, bd, dir, issue.ID)

--- a/cmd/bd/close_reason_file_test.go
+++ b/cmd/bd/close_reason_file_test.go
@@ -219,6 +219,60 @@ func TestCloseResolveReasons_SharedReasonForMultipleIDs(t *testing.T) {
 	}
 }
 
+func TestCloseResolveReasons_EmptyReasonFallsBackToDefault(t *testing.T) {
+	cmd := newCloseLikeCmd()
+	cmd.SetArgs([]string{"issue-a", "--reason", ""})
+
+	var gotReasons, gotArgs []string
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		var err error
+		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		if err != nil {
+			t.Fatalf("resolveCloseReasons: %v", err)
+		}
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !slices.Equal(gotArgs, []string{"issue-a"}) {
+		t.Fatalf("args = %v, want [issue-a]", gotArgs)
+	}
+	if !slices.Equal(gotReasons, []string{"Closed"}) {
+		t.Fatalf("reasons = %v, want default reason", gotReasons)
+	}
+}
+
+func TestCloseResolveReasons_EmptyReasonDoesNotConflictWithReasonFile(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "reason.md")
+	if err := os.WriteFile(path, []byte("from file"), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cmd := newCloseLikeCmd()
+	cmd.SetArgs([]string{"issue-a", "--reason", "", "--reason-file", path})
+
+	var gotReasons, gotArgs []string
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		var err error
+		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		if err != nil {
+			t.Fatalf("resolveCloseReasons: %v", err)
+		}
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !slices.Equal(gotArgs, []string{"issue-a"}) {
+		t.Fatalf("args = %v, want [issue-a]", gotArgs)
+	}
+	if !slices.Equal(gotReasons, []string{"from file"}) {
+		t.Fatalf("reasons = %v, want file reason", gotReasons)
+	}
+}
+
 func TestCloseResolveReasons_RejectsMismatchedPerIDReasons(t *testing.T) {
 	cmd := newCloseLikeCmd()
 	cmd.SetArgs([]string{"issue-a", "--reason", "reason A", "issue-b", "--reason", "reason B", "issue-c"})

--- a/cmd/bd/close_reason_file_test.go
+++ b/cmd/bd/close_reason_file_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -17,7 +18,7 @@ func newCloseLikeCmd() *cobra.Command {
 		Use: "close",
 		Run: func(cmd *cobra.Command, args []string) {},
 	}
-	cmd.Flags().StringP("reason", "r", "", "Reason for closing")
+	registerCloseReasonFlag(cmd)
 	cmd.Flags().String("resolution", "", "")
 	cmd.Flags().StringP("message", "m", "", "")
 	cmd.Flags().String("comment", "", "")
@@ -38,7 +39,7 @@ func TestCloseResolveReasonFile_FileWithContent(t *testing.T) {
 		t.Fatalf("parse flags: %v", err)
 	}
 
-	got, ok, err := resolveReasonFile(cmd, "")
+	got, ok, err := resolveReasonFile(cmd, false)
 	if err != nil {
 		t.Fatalf("resolveReasonFile: %v", err)
 	}
@@ -70,7 +71,7 @@ func TestCloseResolveReasonFile_StdinDash(t *testing.T) {
 		t.Fatalf("parse flags: %v", err)
 	}
 
-	got, ok, err := resolveReasonFile(cmd, "")
+	got, ok, err := resolveReasonFile(cmd, false)
 	if err != nil {
 		t.Fatalf("resolveReasonFile: %v", err)
 	}
@@ -89,7 +90,7 @@ func TestCloseResolveReasonFile_FileNotFound(t *testing.T) {
 		t.Fatalf("parse flags: %v", err)
 	}
 
-	_, ok, err := resolveReasonFile(cmd, "")
+	_, ok, err := resolveReasonFile(cmd, false)
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
 	}
@@ -116,7 +117,7 @@ func TestCloseResolveReasonFile_ConflictWithReason(t *testing.T) {
 
 	// Caller has already collected the inline reason from the various aliases,
 	// so we pass it in directly to mirror how close.go invokes the helper.
-	_, ok, err := resolveReasonFile(cmd, "from flag")
+	_, ok, err := resolveReasonFile(cmd, true)
 	if err == nil {
 		t.Fatal("expected conflict error, got nil")
 	}
@@ -140,7 +141,7 @@ func TestCloseResolveReasonFile_EmptyFile(t *testing.T) {
 		t.Fatalf("parse flags: %v", err)
 	}
 
-	_, ok, err := resolveReasonFile(cmd, "")
+	_, ok, err := resolveReasonFile(cmd, false)
 	if err == nil {
 		t.Fatal("expected error for whitespace-only file, got nil")
 	}
@@ -158,7 +159,7 @@ func TestCloseResolveReasonFile_FlagNotSet(t *testing.T) {
 		t.Fatalf("parse flags: %v", err)
 	}
 
-	got, ok, err := resolveReasonFile(cmd, "inline")
+	got, ok, err := resolveReasonFile(cmd, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -167,5 +168,71 @@ func TestCloseResolveReasonFile_FlagNotSet(t *testing.T) {
 	}
 	if got != "" {
 		t.Errorf("expected empty content, got %q", got)
+	}
+}
+
+func TestCloseResolveReasons_PerIDReasons(t *testing.T) {
+	cmd := newCloseLikeCmd()
+	cmd.SetArgs([]string{"issue-a", "--reason", "reason A", "issue-b", "--reason", "reason B"})
+
+	var gotReasons, gotArgs []string
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		var err error
+		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		if err != nil {
+			t.Fatalf("resolveCloseReasons: %v", err)
+		}
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !slices.Equal(gotArgs, []string{"issue-a", "issue-b"}) {
+		t.Fatalf("args = %v, want [issue-a issue-b]", gotArgs)
+	}
+	if !slices.Equal(gotReasons, []string{"reason A", "reason B"}) {
+		t.Fatalf("reasons = %v, want per-ID reasons", gotReasons)
+	}
+}
+
+func TestCloseResolveReasons_SharedReasonForMultipleIDs(t *testing.T) {
+	cmd := newCloseLikeCmd()
+	cmd.SetArgs([]string{"issue-a", "issue-b", "--reason", "same reason"})
+
+	var gotReasons, gotArgs []string
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		var err error
+		gotReasons, gotArgs, err = resolveCloseReasons(cmd, args)
+		if err != nil {
+			t.Fatalf("resolveCloseReasons: %v", err)
+		}
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if !slices.Equal(gotArgs, []string{"issue-a", "issue-b"}) {
+		t.Fatalf("args = %v, want [issue-a issue-b]", gotArgs)
+	}
+	if !slices.Equal(gotReasons, []string{"same reason"}) {
+		t.Fatalf("reasons = %v, want one shared reason", gotReasons)
+	}
+}
+
+func TestCloseResolveReasons_RejectsMismatchedPerIDReasons(t *testing.T) {
+	cmd := newCloseLikeCmd()
+	cmd.SetArgs([]string{"issue-a", "--reason", "reason A", "issue-b", "--reason", "reason B", "issue-c"})
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		_, _, err := resolveCloseReasons(cmd, args)
+		if err == nil {
+			t.Fatal("expected mismatch error, got nil")
+		}
+		if !strings.Contains(err.Error(), "2 close reasons for 3 issue IDs") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
 	}
 }

--- a/cmd/bd/ready_embedded_test.go
+++ b/cmd/bd/ready_embedded_test.go
@@ -28,6 +28,32 @@ func TestEmbeddedReady(t *testing.T) {
 
 	// ===== Default =====
 
+	t.Run("ready_includes_open_issue_with_zero_dependencies", func(t *testing.T) {
+		issue := bdCreate(t, bd, dir, "GH3268 zero dependency ready issue", "--type", "task", "--label", "gh3268-zero-deps")
+
+		cmd := exec.Command(bd, "ready", "--json", "--label", "gh3268-zero-deps")
+		cmd.Dir = dir
+		cmd.Env = bdEnv(dir)
+		stdout, stderr, err := runCommandBuffers(t, cmd)
+		if err != nil {
+			t.Fatalf("bd ready --json failed: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+		}
+
+		var ready []types.IssueWithCounts
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &ready); err != nil {
+			t.Fatalf("parse ready JSON: %v\n%s", err, stdout.String())
+		}
+		if len(ready) != 1 {
+			t.Fatalf("ready count = %d, want 1: %s", len(ready), stdout.String())
+		}
+		if ready[0].ID != issue.ID {
+			t.Fatalf("ready ID = %s, want %s", ready[0].ID, issue.ID)
+		}
+		if ready[0].DependencyCount != 0 {
+			t.Fatalf("dependency_count = %d, want 0", ready[0].DependencyCount)
+		}
+	})
+
 	t.Run("ready_default", func(t *testing.T) {
 		cmd := exec.Command(bd, "ready")
 		cmd.Dir = dir

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -346,6 +346,9 @@ Close one or more issues.
 If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
+When closing multiple issues, provide one --reason for all IDs or repeat
+--reason once per ID in the same order.
+
 ```
 bd close [id...] [flags]
 ```

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -347,7 +347,9 @@ If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
 When closing multiple issues, provide one --reason for all IDs or repeat
---reason once per ID in the same order.
+--reason once per ID. Reasons map positionally: the first --reason applies
+to the first ID, the second --reason to the second ID, regardless of where
+the flags appear in the command line.
 
 ```
 bd close [id...] [flags]

--- a/website/docs/cli-reference/close.md
+++ b/website/docs/cli-reference/close.md
@@ -16,7 +16,9 @@ If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
 When closing multiple issues, provide one --reason for all IDs or repeat
---reason once per ID in the same order.
+--reason once per ID. Reasons map positionally: the first --reason applies
+to the first ID, the second --reason to the second ID, regardless of where
+the flags appear in the command line.
 
 ```
 bd close [id...] [flags]

--- a/website/docs/cli-reference/close.md
+++ b/website/docs/cli-reference/close.md
@@ -15,6 +15,9 @@ Close one or more issues.
 If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
+When closing multiple issues, provide one --reason for all IDs or repeat
+--reason once per ID in the same order.
+
 ```
 bd close [id...] [flags]
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2569,6 +2569,9 @@ Close one or more issues.
 If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
+When closing multiple issues, provide one --reason for all IDs or repeat
+--reason once per ID in the same order.
+
 ```
 bd close [id...] [flags]
 ```

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2570,7 +2570,9 @@ If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
 When closing multiple issues, provide one --reason for all IDs or repeat
---reason once per ID in the same order.
+--reason once per ID. Reasons map positionally: the first --reason applies
+to the first ID, the second --reason to the second ID, regardless of where
+the flags appear in the command line.
 
 ```
 bd close [id...] [flags]

--- a/website/versioned_docs/version-1.0.0/cli-reference/close.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/close.md
@@ -16,7 +16,9 @@ If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
 When closing multiple issues, provide one --reason for all IDs or repeat
---reason once per ID in the same order.
+--reason once per ID. Reasons map positionally: the first --reason applies
+to the first ID, the second --reason to the second ID, regardless of where
+the flags appear in the command line.
 
 ```
 bd close [id...] [flags]

--- a/website/versioned_docs/version-1.0.0/cli-reference/close.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/close.md
@@ -15,6 +15,9 @@ Close one or more issues.
 If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
+When closing multiple issues, provide one --reason for all IDs or repeat
+--reason once per ID in the same order.
+
 ```
 bd close [id...] [flags]
 ```

--- a/website/versioned_docs/version-1.0.4/cli-reference/close.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/close.md
@@ -16,7 +16,9 @@ If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
 When closing multiple issues, provide one --reason for all IDs or repeat
---reason once per ID in the same order.
+--reason once per ID. Reasons map positionally: the first --reason applies
+to the first ID, the second --reason to the second ID, regardless of where
+the flags appear in the command line.
 
 ```
 bd close [id...] [flags]

--- a/website/versioned_docs/version-1.0.4/cli-reference/close.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/close.md
@@ -15,6 +15,9 @@ Close one or more issues.
 If no issue ID is provided, closes the last touched issue (from most recent
 create, update, show, or close operation).
 
+When closing multiple issues, provide one --reason for all IDs or repeat
+--reason once per ID in the same order.
+
 ```
 bd close [id...] [flags]
 ```


### PR DESCRIPTION
Why:
- #3279 reports that repeated `bd close --reason` values do not map cleanly to multi-ID closes.
- #3268 is still open upstream, but current main did not reproduce the zero-dependency ready bug; this adds a regression guard for that ready path.

What:
- Allow one shared close reason or one repeated `--reason` per issue ID.
- Reject mismatched reason/ID counts.
- Add embedded CLI regressions for per-ID close reasons and ready zero-dependency output.

Validation:
- `CGO_ENABLED=0 go test ./cmd/bd -tags gms_pure_go -run 'TestCloseResolveReasonFile|TestCloseResolveReasons' -count=1`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test ./cmd/bd -tags gms_pure_go -run '^(TestEmbeddedClose|TestEmbeddedReady)$/^(close_multiple_ids|close_multiple_ids_with_per_id_reasons|ready_includes_open_issue_with_zero_dependencies)$' -count=1`
- `go test ./internal/storage/dolt -run 'Test.*Ready|Test.*Blocked|TestIsBlocked' -count=1`
- `go test ./internal/storage/issueops -run 'Test.*Ready|Test.*Blocked|Test.*Close' -count=1`
- `git diff --check`

Refs #3268
Fixes #3279
Bead: mybd-r1cb

_codex-gpt-5.5-medium on behalf of matt wilkie_
