### PR TITLE
fix(schema): panic on duplicate migration version numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,32 @@ jobs:
       - name: Check all versions match
         run: ./scripts/check-versions.sh
 
+  # Catch duplicate migration version numbers before any Go build.
+  # Two long-lived branches both claiming 'the next number' produce a silent
+  # under-apply when merged; this job fails at PR time with the conflicting
+  # filenames so it is caught before any test even compiles.
+  check-no-duplicate-migrations:
+    name: Check no duplicate migration versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check for duplicate migration version numbers
+        run: |
+          dup=$(ls internal/storage/schema/migrations/*.up.sql \
+                | xargs -I{} basename {} \
+                | sed 's/^\([0-9]*\)_.*/\1/' \
+                | sort | uniq -d)
+          if [ -n "$dup" ]; then
+            echo "Duplicate migration version(s) detected: $dup"
+            echo "Conflicting files:"
+            for v in $dup; do
+              ls internal/storage/schema/migrations/${v}_*.up.sql
+            done
+            echo "Renumber one of the colliding files before merging."
+            exit 1
+          fi
+
   # Check documentation references match actual CLI flags
   check-doc-flags:
     name: Check doc flags freshness

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -524,6 +524,19 @@ func (m migrationSource) bootstrapSQL() string {
 )`, m.cursorTable)
 }
 
+func checkNoDuplicateVersions(files []migrationFile) {
+	seen := make(map[int]string, len(files))
+	for _, m := range files {
+		if prior, ok := seen[m.version]; ok {
+			panic(fmt.Sprintf(
+				"schema: duplicate migration version %d: %q and %q — renumber one before commit",
+				m.version, prior, m.name,
+			))
+		}
+		seen[m.version] = m.name
+	}
+}
+
 func (m migrationSource) list() []migrationFile {
 	entries, err := fs.ReadDir(m.files, m.dir)
 	if err != nil {
@@ -540,6 +553,7 @@ func (m migrationSource) list() []migrationFile {
 		}
 		files = append(files, migrationFile{version: v, name: e.Name()})
 	}
+	checkNoDuplicateVersions(files)
 	sort.Slice(files, func(i, j int) bool { return files[i].version < files[j].version })
 	return files
 }

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -109,6 +109,35 @@ func TestMigrationSQLTouchesTableStatementForms(t *testing.T) {
 	}
 }
 
+func TestCheckNoDuplicateVersionsPanicsWithBothFilenames(t *testing.T) {
+	files := []migrationFile{
+		{version: 7, name: "0007_create_metadata.up.sql"},
+		{version: 12, name: "0012_create_routes.up.sql"},
+		{version: 7, name: "0007_create_duplicate.up.sql"},
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic on duplicate version, got none")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", r, r)
+		}
+		for _, want := range []string{
+			"duplicate migration version 7",
+			"0007_create_metadata.up.sql",
+			"0007_create_duplicate.up.sql",
+			"renumber one before commit",
+		} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("panic message %q missing expected substring %q", msg, want)
+			}
+		}
+	}()
+	checkNoDuplicateVersions(files)
+}
+
 func TestDirtyTableSignatureRejectsUnsafeTableName(t *testing.T) {
 	_, err := dirtyTableSignature(context.Background(), nil, "issues'); SELECT 1; --")
 	if err == nil {


### PR DESCRIPTION
Adds two redundant guards against silently under-applying migrations when two branches independently pick the same "next free" version number.

## Motivation

Two empirical incidents (versions 0033 and 0043) where parallel branches each claimed the same migration version number, merged cleanly at the git level (no textual conflict), and then silently under-applied the second migration because `INSERT IGNORE` records only one row per version.

## Changes

- `internal/storage/schema/schema.go`: `list()` calls a new `checkNoDuplicateVersions(files)` helper after parsing the migrations directory. The panic names both colliding filenames and the duplicate version number so the developer knows exactly what to renumber.
- `internal/storage/schema/schema_test.go`: unit test covering the new check.
- `.github/workflows/ci.yml`: a shell-glob CI step that catches the same collision at PR time with no Go build required — earlier signal than the panic for contributors who don't run the test suite locally.

## Test plan

- [x] `go test ./internal/storage/schema/...` passes
- [ ] Maintainer verify: CI shell-glob step triggers correctly on a manually-introduced duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
