### PR TITLE
fix(create): set status=deferred on future --defer (rebased #4112, GH#4071)

### DIFF
--- a/cmd/bd/create.go
+++ b/cmd/bd/create.go
@@ -773,6 +773,11 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		externalRefPtr = &params.ExternalRef
 	}
 
+	status := types.StatusOpen
+	if params.DeferUntil != nil && params.DeferUntil.After(time.Now()) {
+		status = types.StatusDeferred
+	}
+
 	return &types.Issue{
 		ID:                 params.ID,
 		Title:              params.Title,
@@ -781,7 +786,7 @@ func buildCreateIssue(params createIssueParams) *types.Issue {
 		AcceptanceCriteria: params.AcceptanceCriteria,
 		Notes:              params.Notes,
 		SpecID:             params.SpecID,
-		Status:             types.StatusOpen,
+		Status:             status,
 		Priority:           params.Priority,
 		IssueType:          params.IssueType,
 		Assignee:           params.Assignee,

--- a/cmd/bd/create_defer_test.go
+++ b/cmd/bd/create_defer_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestBuildCreateIssueDeferStatus(t *testing.T) {
+	future := time.Now().Add(24 * time.Hour)
+	past := time.Now().Add(-24 * time.Hour)
+
+	tests := []struct {
+		name       string
+		deferUntil *time.Time
+		want       types.Status
+	}{
+		{"future defer is deferred", &future, types.StatusDeferred},
+		{"past defer stays open", &past, types.StatusOpen},
+		{"no defer stays open", nil, types.StatusOpen},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issue := buildCreateIssue(createIssueParams{
+				Title:      "defer create",
+				Priority:   2,
+				IssueType:  types.TypeTask,
+				DeferUntil: tt.deferUntil,
+			})
+			if issue.Status != tt.want {
+				t.Fatalf("status = %q, want %q", issue.Status, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/bd/create_proxied_server_test.go
+++ b/cmd/bd/create_proxied_server_test.go
@@ -15,7 +15,9 @@ import (
 
 func TestBuildCreateIssueFromInput_PopulatesAllFields(t *testing.T) {
 	due := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
-	defer1 := time.Date(2026, 5, 30, 9, 0, 0, 0, time.UTC)
+	// Future defer time so the status assertion below is deterministic
+	// regardless of wall-clock date (a future --defer yields StatusDeferred).
+	defer1 := time.Now().Add(48 * time.Hour).UTC()
 	est := 90
 	meta := json.RawMessage(`{"k":"v"}`)
 
@@ -61,8 +63,8 @@ func TestBuildCreateIssueFromInput_PopulatesAllFields(t *testing.T) {
 	if got.Priority != 1 {
 		t.Errorf("Priority = %d", got.Priority)
 	}
-	if got.Status != types.StatusOpen {
-		t.Errorf("Status = %q, want %q", got.Status, types.StatusOpen)
+	if got.Status != types.StatusDeferred {
+		t.Errorf("Status = %q, want %q (future --defer)", got.Status, types.StatusDeferred)
 	}
 	if got.ExternalRef == nil || *got.ExternalRef != "gh-9" {
 		t.Errorf("ExternalRef = %v, want pointer to gh-9", got.ExternalRef)


### PR DESCRIPTION
Rebased, tested version of #4112 by @kevglynn, landed on top of current `main`.

### What this does
`bd create --defer <future-date>` now sets `status=deferred` instead of `open` (GH#4071). Original commit by @kevglynn is preserved; a second commit adds test coverage.

### Why a new PR
#4112's branch is ~50 commits behind `main`. Merging it as-is would also **break an existing test**: `TestBuildCreateIssueFromInput_PopulatesAllFields` hard-codes a future defer date and asserts `StatusOpen` — correct today only by accident, and broken the moment this behavior lands. That test file doesn't even exist on the stale branch, so the fix has to be applied on the `main` side.

### Changes on top of @kevglynn's commit
- `cmd/bd/create_defer_test.go` — unit test: future defer → deferred; past/nil → open.
- `cmd/bd/create_proxied_server_test.go` — switched the hard-coded defer date to a relative future time and updated the assertion to the now-correct `StatusDeferred` (de-flakes a latent date dependency).

Supersedes #4112.
