### PR TITLE
fix(mcp): route validate/detect-pollution to bd doctor (rebased #4115, GH#4037)

### DIFF
--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -786,17 +786,17 @@ class BdCliClient(BdClientBase):
         Returns:
             Dict with detected test issues and deleted count if clean=True
         """
-        args = ["detect-pollution"]
+        args = ["doctor", "--check=pollution"]
         if clean:
             args.extend(["--clean", "--yes"])
 
         data = await self._run_command(*args)
         if not isinstance(data, dict):
-            raise BdCommandError("Invalid response for detect-pollution")
+            raise BdCommandError("Invalid response for doctor --check=pollution")
         return data
 
     async def validate(self, checks: str | None = None, fix_all: bool = False) -> dict[str, Any]:
-        """Run database validation checks.
+        """Run database validation checks via bd doctor --check=validate.
 
         Args:
             checks: Comma-separated list of checks (orphans,duplicates,pollution,conflicts)
@@ -805,15 +805,14 @@ class BdCliClient(BdClientBase):
         Returns:
             Dict with validation results for each check
         """
-        args = ["validate"]
-        if checks:
-            args.extend(["--checks", checks])
+        args = ["doctor", "--check=validate"]
         if fix_all:
-            args.append("--fix-all")
+            args.append("--fix")
+            args.append("--yes")
 
         data = await self._run_command(*args)
         if not isinstance(data, dict):
-            raise BdCommandError("Invalid response for validate")
+            raise BdCommandError("Invalid response for doctor --check=validate")
         return data
 
     async def init(self, params: InitParams | None = None) -> str:

--- a/integrations/beads-mcp/src/beads_mcp/bd_client.py
+++ b/integrations/beads-mcp/src/beads_mcp/bd_client.py
@@ -799,12 +799,16 @@ class BdCliClient(BdClientBase):
         """Run database validation checks via bd doctor --check=validate.
 
         Args:
-            checks: Comma-separated list of checks (orphans,duplicates,pollution,conflicts)
+            checks: Accepted for backward compatibility but no longer applied.
+                bd doctor --check=validate runs the full data-integrity suite
+                (duplicates, orphaned issues, conflicts) and has no flag for
+                selecting a subset. Use detect_pollution() for the pollution check.
             fix_all: If True, auto-fix all fixable issues
 
         Returns:
             Dict with validation results for each check
         """
+        del checks  # subset selection is unsupported by bd doctor (see docstring)
         args = ["doctor", "--check=validate"]
         if fix_all:
             args.append("--fix")

--- a/integrations/beads-mcp/tests/test_bd_client.py
+++ b/integrations/beads-mcp/tests/test_bd_client.py
@@ -780,3 +780,43 @@ async def test_init_failure(bd_client, mock_process):
         pytest.raises(BdCommandError, match="bd init failed"),
     ):
         await bd_client.init()
+
+
+@pytest.mark.asyncio
+async def test_validate_routes_to_doctor(bd_client):
+    """validate() routes to `bd doctor --check=validate` (GH#4037)."""
+    with patch.object(bd_client, "_run_command", new=AsyncMock(return_value={})) as run:
+        await bd_client.validate()
+    run.assert_awaited_once_with("doctor", "--check=validate")
+
+
+@pytest.mark.asyncio
+async def test_validate_fix_all_adds_fix_yes(bd_client):
+    """validate(fix_all=True) appends --fix --yes for non-interactive fixing."""
+    with patch.object(bd_client, "_run_command", new=AsyncMock(return_value={})) as run:
+        await bd_client.validate(fix_all=True)
+    run.assert_awaited_once_with("doctor", "--check=validate", "--fix", "--yes")
+
+
+@pytest.mark.asyncio
+async def test_validate_ignores_checks_arg(bd_client):
+    """The legacy `checks` arg is accepted but no longer forwarded to bd."""
+    with patch.object(bd_client, "_run_command", new=AsyncMock(return_value={})) as run:
+        await bd_client.validate(checks="orphans,duplicates")
+    run.assert_awaited_once_with("doctor", "--check=validate")
+
+
+@pytest.mark.asyncio
+async def test_detect_pollution_routes_to_doctor(bd_client):
+    """detect_pollution() routes to `bd doctor --check=pollution` (GH#4037)."""
+    with patch.object(bd_client, "_run_command", new=AsyncMock(return_value={})) as run:
+        await bd_client.detect_pollution()
+    run.assert_awaited_once_with("doctor", "--check=pollution")
+
+
+@pytest.mark.asyncio
+async def test_detect_pollution_clean_adds_flags(bd_client):
+    """detect_pollution(clean=True) appends --clean --yes."""
+    with patch.object(bd_client, "_run_command", new=AsyncMock(return_value={})) as run:
+        await bd_client.detect_pollution(clean=True)
+    run.assert_awaited_once_with("doctor", "--check=pollution", "--clean", "--yes")


### PR DESCRIPTION
Rebased, tested version of #4115 by @kevglynn, landed on top of current `main`.

### What this does
Routes the MCP client's `validate` and `detect_pollution` to `bd doctor --check=validate` / `--check=pollution` (GH#4037), matching the current CLI. Original commit by @kevglynn is preserved; a second commit adds tests and a doc fix.

### Why a new PR
#4115's branch is ~50 commits behind `main`. Also, `validate(checks=...)` was left accepting a `checks` argument that is now silently ignored — `bd doctor` has no flag to select a subset of validate checks.

### Changes on top of @kevglynn's commit
- `bd_client.py` — docstring no longer advertises the unsupported `checks` selection; `del checks` makes the no-op explicit.
- `tests/test_bd_client.py` — asserts the exact `bd doctor --check=...` argv for both methods, including `--fix/--yes` and `--clean/--yes` forwarding, and that the legacy `checks` arg is not forwarded.

Supersedes #4115.
