### PR TITLE
fix(setup): harden symlink follow-up handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Symlinked `CLAUDE.md` repair guidance** - troubleshooting docs now include
+  a tested `git update-index --cacheinfo` recipe for repositories that already
+  contain a corrupted `mode 120000` `CLAUDE.md` entry with Markdown content.
+  The setup bug was fixed in [#4192](https://github.com/gastownhall/beads/pull/4192);
+  this note is for repairing affected clones.
 - **Codex hook metadata isolation** - Codex hook metadata now lives under
   `.codex-plugin/hooks/`, preventing Claude from loading Codex-only hooks from
   the shared plugin root while keeping Codex setup pointed at `bd codex-hook`.

--- a/cmd/bd/setup/agents.go
+++ b/cmd/bd/setup/agents.go
@@ -33,6 +33,7 @@ type agentsEnv struct {
 	agentsPath string
 	stdout     io.Writer
 	stderr     io.Writer
+	skipped    *bool
 }
 
 type agentsIntegration struct {
@@ -87,6 +88,12 @@ func agentsFileName(path string) string {
 	return base
 }
 
+func (env agentsEnv) markSkipped() {
+	if env.skipped != nil {
+		*env.skipped = true
+	}
+}
+
 func installAgents(env agentsEnv, integration agentsIntegration) error {
 	_, _ = fmt.Fprintf(env.stdout, "Installing %s integration...\n", integration.name)
 	agentsFile := agentsFileName(env.agentsPath)
@@ -101,6 +108,7 @@ func installAgents(env agentsEnv, integration agentsIntegration) error {
 			targetHint = fmt.Sprintf(" to %s", target)
 		}
 		_, _ = fmt.Fprintf(env.stderr, "Warning: %s is a symlink%s; skipping managed section injection to preserve link mode/content. Update the target file directly, or replace the symlink with a regular file and re-run '%s'.\n", agentsFile, targetHint, integration.setupCommand)
+		env.markSkipped()
 		return nil
 	} else if err != nil && !os.IsNotExist(err) {
 		_, _ = fmt.Fprintf(env.stderr, "Error: failed to inspect %s: %v\n", env.agentsPath, err)

--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -204,12 +204,20 @@ func installClaude(env claudeEnv, global bool, stealth bool) error {
 
 	// Install minimal beads section in CLAUDE.md.
 	// Hooks handle the heavy lifting via bd prime; CLAUDE.md just needs a pointer.
-	if err := installAgents(claudeAgentsEnv(env), claudeAgentsIntegration); err != nil {
+	agentsEnv := claudeAgentsEnv(env)
+	agentsSkipped := false
+	agentsEnv.skipped = &agentsSkipped
+	if err := installAgents(agentsEnv, claudeAgentsIntegration); err != nil {
 		// Non-fatal: hooks are already installed
 		_, _ = fmt.Fprintf(env.stderr, "Warning: failed to update %s: %v\n", claudeInstructionsFile, err)
 	}
 
-	_, _ = fmt.Fprintln(env.stdout, "\n✓ Claude Code integration installed")
+	if agentsSkipped {
+		_, _ = fmt.Fprintln(env.stdout, "\n✓ Claude Code hooks installed")
+		_, _ = fmt.Fprintf(env.stdout, "  Agent instructions skipped: %s is a symlink\n", claudeInstructionsFile)
+	} else {
+		_, _ = fmt.Fprintln(env.stdout, "\n✓ Claude Code integration installed")
+	}
 	_, _ = fmt.Fprintf(env.stdout, "  Settings: %s\n", settingsPath)
 	_, _ = fmt.Fprintln(env.stdout, "\nRestart Claude Code for changes to take effect.")
 	return nil

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -1075,6 +1075,46 @@ func TestInstallClaudeWritesHooksWithoutPlugin(t *testing.T) {
 	}
 }
 
+func TestInstallClaudeReportsSkippedSymlinkInstructions(t *testing.T) {
+	env, stdout, stderr := newClaudeTestEnv(t)
+	target := filepath.Join(env.projectDir, "AGENTS.md")
+	if err := os.WriteFile(target, []byte("# Shared instructions\n"), 0644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(env.projectDir, claudeInstructionsFile)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := installClaude(env, false, false); err != nil {
+		t.Fatalf("installClaude: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Claude Code hooks installed") {
+		t.Fatalf("expected partial hook success message, got:\n%s", out)
+	}
+	if strings.Contains(out, "Claude Code integration installed") {
+		t.Fatalf("should not report full integration success when instructions are skipped:\n%s", out)
+	}
+	if !strings.Contains(out, "Agent instructions skipped: CLAUDE.md is a symlink") {
+		t.Fatalf("expected skipped instructions summary, got:\n%s", out)
+	}
+	if !strings.Contains(stderr.String(), "CLAUDE.md is a symlink") {
+		t.Fatalf("expected symlink warning on stderr, got:\n%s", stderr.String())
+	}
+	if _, err := os.Stat(projectSettingsPath(env.projectDir)); err != nil {
+		t.Fatalf("settings should still be installed: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if strings.Contains(string(data), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("symlink target should remain untouched:\n%s", data)
+	}
+}
+
 func TestCheckClaudePluginManaged(t *testing.T) {
 	stubDetectRenderOpts(t)
 	env, stdout, _ := newClaudeTestEnv(t)

--- a/cmd/bd/setup/mux.go
+++ b/cmd/bd/setup/mux.go
@@ -212,11 +212,16 @@ func InstallMux(project bool, global bool) {
 }
 
 func installMux(env agentsEnv, project bool, global bool) error {
+	rootSkipped := false
+	env.skipped = &rootSkipped
 	if err := installAgents(env, muxIntegration); err != nil {
 		return err
 	}
 	if err := installMuxProjectHooks(env); err != nil {
 		return err
+	}
+	if rootSkipped {
+		_, _ = fmt.Fprintf(env.stdout, "✓ Mux hooks installed; managed section skipped for symlinked %s\n", env.agentsPath)
 	}
 
 	if project {
@@ -227,8 +232,13 @@ func installMux(env agentsEnv, project bool, global bool) error {
 
 		projectEnv := env
 		projectEnv.agentsPath = projectPath
+		projectSkipped := false
+		projectEnv.skipped = &projectSkipped
 		if err := installAgents(projectEnv, muxProjectIntegration); err != nil {
 			return err
+		}
+		if projectSkipped {
+			_, _ = fmt.Fprintf(env.stdout, "✓ Mux project hooks installed; managed section skipped for symlinked %s\n", projectPath)
 		}
 	}
 
@@ -246,7 +256,15 @@ func installMux(env agentsEnv, project bool, global bool) error {
 
 	globalEnv := env
 	globalEnv.agentsPath = globalPath
-	return installAgents(globalEnv, muxGlobalIntegration)
+	globalSkipped := false
+	globalEnv.skipped = &globalSkipped
+	if err := installAgents(globalEnv, muxGlobalIntegration); err != nil {
+		return err
+	}
+	if globalSkipped {
+		_, _ = fmt.Fprintf(env.stdout, "✓ Mux global setup completed; managed section skipped for symlinked %s\n", globalPath)
+	}
+	return nil
 }
 
 // CheckMux checks if Mux integration is installed.

--- a/cmd/bd/setup/mux_test.go
+++ b/cmd/bd/setup/mux_test.go
@@ -29,6 +29,47 @@ func TestInstallMuxCreatesNewFile(t *testing.T) {
 	}
 }
 
+func TestInstallMuxReportsSkippedSymlinkRootInstructions(t *testing.T) {
+	env, stdout, stderr := newFactoryTestEnv(t)
+	target := filepath.Join(filepath.Dir(env.agentsPath), "SHARED_AGENTS.md")
+	if err := os.WriteFile(target, []byte("# Shared instructions\n"), 0644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, env.agentsPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := installMux(env, false, false); err != nil {
+		t.Fatalf("installMux returned error: %v", err)
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "Mux hooks installed; managed section skipped") {
+		t.Fatalf("expected partial Mux success message, got:\n%s", out)
+	}
+	if strings.Contains(out, "Mux integration installed") {
+		t.Fatalf("should not report full Mux integration success when root instructions are skipped:\n%s", out)
+	}
+	if !strings.Contains(stderr.String(), "AGENTS.md is a symlink") {
+		t.Fatalf("expected symlink warning on stderr, got:\n%s", stderr.String())
+	}
+	if !FileExists(muxProjectHookPathsFirst(env.agentsPath)) {
+		t.Fatalf("expected Mux init hook to be installed")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if strings.Contains(string(data), "BEGIN BEADS INTEGRATION") {
+		t.Fatalf("symlink target should remain untouched:\n%s", data)
+	}
+}
+
+func muxProjectHookPathsFirst(baseAgentsPath string) string {
+	initPath, _, _ := muxProjectHookPaths(baseAgentsPath)
+	return initPath
+}
+
 func TestCheckMuxMissingFile(t *testing.T) {
 	env, stdout, _ := newFactoryTestEnv(t)
 	err := checkMux(env, false, false)

--- a/cmd/bd/setup/utils.go
+++ b/cmd/bd/setup/utils.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,13 +9,28 @@ import (
 	"github.com/steveyegge/beads/internal/utils"
 )
 
+var errRefuseSymlinkWrite = errors.New("refusing to write through symlink")
+
 // atomicWriteFile writes data to a file atomically using a unique temporary file.
 // This prevents race conditions when multiple processes write to the same file.
-// If path is a symlink, writes to the resolved target (preserving the symlink).
+// If path is a symlink, the write is refused; callers that deliberately want
+// write-through behavior should use atomicWriteFileFollowingSymlink.
 // An optional permissions argument sets the file mode (default 0644).
 //
 //nolint:unparam // perm is intentionally variadic for callers that need non-default permissions
 func atomicWriteFile(path string, data []byte, perm ...os.FileMode) error {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: %s", errRefuseSymlinkWrite, path)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("inspect path: %w", err)
+	}
+
+	return atomicWriteFileFollowingSymlink(path, data, perm...)
+}
+
+// atomicWriteFileFollowingSymlink writes atomically to the resolved target.
+// Keep this helper named at call sites so symlink write-through is explicit.
+func atomicWriteFileFollowingSymlink(path string, data []byte, perm ...os.FileMode) error {
 	mode := os.FileMode(0644)
 	if len(perm) > 0 {
 		mode = perm[0]

--- a/cmd/bd/setup/utils_test.go
+++ b/cmd/bd/setup/utils_test.go
@@ -88,7 +88,7 @@ func TestAtomicWriteFile_ExplicitPermissions(t *testing.T) {
 	}
 }
 
-func TestAtomicWriteFile_PreservesSymlink(t *testing.T) {
+func TestAtomicWriteFile_RefusesSymlink(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create target file
@@ -103,9 +103,8 @@ func TestAtomicWriteFile_PreservesSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write via symlink
-	if err := atomicWriteFile(link, []byte("updated")); err != nil {
-		t.Fatalf("atomicWriteFile failed: %v", err)
+	if err := atomicWriteFile(link, []byte("updated")); err == nil {
+		t.Fatal("expected atomicWriteFile to refuse symlink")
 	}
 
 	// Verify symlink still exists
@@ -117,7 +116,40 @@ func TestAtomicWriteFile_PreservesSymlink(t *testing.T) {
 		t.Error("symlink was replaced with regular file")
 	}
 
-	// Verify target was updated
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("failed to read target: %v", err)
+	}
+	if string(data) != "original" {
+		t.Errorf("target content = %q, want %q", string(data), "original")
+	}
+}
+
+func TestAtomicWriteFileFollowingSymlink_PreservesSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	target := filepath.Join(tmpDir, "target.txt")
+	if err := os.WriteFile(target, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(tmpDir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicWriteFileFollowingSymlink(link, []byte("updated")); err != nil {
+		t.Fatalf("atomicWriteFileFollowingSymlink failed: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("failed to lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("symlink was replaced with regular file")
+	}
+
 	data, err := os.ReadFile(target)
 	if err != nil {
 		t.Fatalf("failed to read target: %v", err)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -639,6 +639,41 @@ chmod +x .git/hooks/post-merge
 chmod +x .git/hooks/post-checkout
 ```
 
+### Corrupted symlinked `CLAUDE.md`
+
+**Symptom:** Git reports `CLAUDE.md` as a symlink entry (`mode 120000`), but
+the indexed blob contains multi-line Markdown instead of a one-line symlink
+target. On macOS this can make clones or checkouts fail because symlink targets
+cannot contain newline-separated Markdown content.
+
+This affects repositories that were already corrupted by older setup behavior.
+The setup bug has been fixed ([#4192](https://github.com/gastownhall/beads/pull/4192));
+the recipe below repairs an existing bad Git index entry.
+
+**Confirm the bad entry:**
+
+```bash
+git ls-files -s CLAUDE.md
+git cat-file -p :CLAUDE.md | sed -n '1,5p'
+```
+
+If `git ls-files -s` starts with `120000` and `git cat-file` prints Markdown,
+convert the existing blob to a regular tracked file without changing its
+content:
+
+```bash
+sha=$(git rev-parse :CLAUDE.md)
+git update-index --cacheinfo 100644,$sha,CLAUDE.md
+git checkout-index -f -- CLAUDE.md
+
+# Verify that the index now records a normal file.
+git ls-files -s CLAUDE.md
+git diff -- CLAUDE.md
+```
+
+Commit the mode repair after review. The first column from `git ls-files -s`
+should now be `100644`.
+
 ### "Branch already checked out" when switching branches
 
 **Symptom:**


### PR DESCRIPTION
Why:

PR #4192 closed the immediate `CLAUDE.md` symlink corruption bug, but its review left three follow-ups:

- sibling setup `atomicWriteFile` callers still followed symlinks by default
- Claude/Mux could still report full setup success when managed agent instructions were skipped
- users with already-corrupted `mode 120000` `CLAUDE.md` entries needed repair guidance

What changed:

- Make setup `atomicWriteFile` refuse symlink targets by default.
- Keep symlink write-through available only through the explicitly named `atomicWriteFileFollowingSymlink` helper.
- Thread a skip flag out of managed agent-section installation so Claude and Mux report partial setup accurately when instructions are skipped.
- Add regression tests for the default symlink refusal, explicit follow-through helper, Claude partial success, and Mux partial success.
- Document a tested `git update-index --cacheinfo 100644,$sha,CLAUDE.md` repair recipe for repositories already affected by #3722.

Drift check:

- #4192 is merged as of 2026-05-27.
- #3722 is closed as fixed by #4192.

Validation:

- `go test ./cmd/bd/setup`
- `make check-docs`
- `git diff --check`

Refs #3722

_codex-gpt-5.5-medium on behalf of matt wilkie_
