### PR TITLE
debug missing dolt database metadata

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -163,6 +163,10 @@ func logConfigDiscovery(beadsDir, reason string) {
 		reason, beadsDir, metadataErr == nil, metadataErr, yamlErr == nil, yamlErr)
 }
 
+func shouldLogDefaultDoltDatabase(cfg *configfile.Config) bool {
+	return cfg != nil && cfg.DoltDatabase == "" && os.Getenv("BEADS_DOLT_SERVER_DATABASE") == ""
+}
+
 // loadBeadsSelectionEnvFile loads only the selector keys needed for early
 // workspace/database discovery. Unlike loadBeadsEnvFile, this intentionally
 // limits itself to BEADS_DIR / BEADS_DB / BD_DB so caller credentials and
@@ -970,7 +974,7 @@ var rootCmd = &cobra.Command{
 			// Always set database name (needed for bootstrap to find
 			// prefix-based databases like "beads_hq"; see #1669)
 			doltCfg.Database = cfg.GetDoltDatabase()
-			if cfg.DoltDatabase == "" && os.Getenv("BEADS_DOLT_SERVER_DATABASE") == "" {
+			if shouldLogDefaultDoltDatabase(cfg) {
 				logConfigDiscovery(beadsDir, fmt.Sprintf("metadata loaded without dolt_database; using default database name %q", configfile.DefaultDoltDatabase))
 			}
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -154,6 +154,15 @@ func loadBeadsEnvFile(beadsDir string) {
 	_ = gotenv.Load(envFile)
 }
 
+func logConfigDiscovery(beadsDir, reason string) {
+	metadataPath := filepath.Join(beadsDir, configfile.ConfigFileName)
+	configYAMLPath := filepath.Join(beadsDir, "config.yaml")
+	_, metadataErr := os.Stat(metadataPath)
+	_, yamlErr := os.Stat(configYAMLPath)
+	debug.Logf("Debug: %s at %s -> metadata=%v (%v), config.yaml=%v (%v)\n",
+		reason, beadsDir, metadataErr == nil, metadataErr, yamlErr == nil, yamlErr)
+}
+
 // loadBeadsSelectionEnvFile loads only the selector keys needed for early
 // workspace/database discovery. Unlike loadBeadsEnvFile, this intentionally
 // limits itself to BEADS_DIR / BEADS_DB / BD_DB so caller credentials and
@@ -961,6 +970,9 @@ var rootCmd = &cobra.Command{
 			// Always set database name (needed for bootstrap to find
 			// prefix-based databases like "beads_hq"; see #1669)
 			doltCfg.Database = cfg.GetDoltDatabase()
+			if cfg.DoltDatabase == "" && os.Getenv("BEADS_DOLT_SERVER_DATABASE") == "" {
+				logConfigDiscovery(beadsDir, fmt.Sprintf("metadata loaded without dolt_database; using default database name %q", configfile.DefaultDoltDatabase))
+			}
 
 			doltCfg.ServerHost = cfg.GetDoltServerHost()
 			// Use doltserver.DefaultConfig for port resolution (env > port file >
@@ -973,12 +985,7 @@ var rootCmd = &cobra.Command{
 			doltCfg.ServerPassword = cfg.GetDoltServerPasswordForPort(doltCfg.ServerPort)
 			doltCfg.ServerTLS = cfg.GetDoltServerTLS()
 		} else if cfgErr == nil {
-			metadataPath := filepath.Join(beadsDir, configfile.ConfigFileName)
-			configYAMLPath := filepath.Join(beadsDir, "config.yaml")
-			_, metadataErr := os.Stat(metadataPath)
-			_, yamlErr := os.Stat(configYAMLPath)
-			debug.Logf("Debug: config discovery at %s -> metadata=%v (%v), config.yaml=%v (%v)\n",
-				beadsDir, metadataErr == nil, metadataErr, yamlErr == nil, yamlErr)
+			logConfigDiscovery(beadsDir, "config discovery")
 			// Load returned (nil, nil) — no config file found.
 			// Fall back to the canonical default database name; matches the
 			// behavior of newDoltStoreFromConfig / newReadOnlyStoreFromConfig

--- a/cmd/bd/main_config_debug_test.go
+++ b/cmd/bd/main_config_debug_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/debug"
+)
+
+func TestLogConfigDiscoveryIncludesMetadataAndYAMLState(t *testing.T) {
+	beadsDir := t.TempDir()
+	metadataPath := filepath.Join(beadsDir, configfile.ConfigFileName)
+	if err := os.WriteFile(metadataPath, []byte(`{"database":"dolt"}`), 0o600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	debug.SetVerbose(true)
+	defer debug.SetVerbose(false)
+
+	stderr := captureStderr(t, func() {
+		logConfigDiscovery(beadsDir, "metadata loaded without dolt_database; using default database name \"beads\"")
+	})
+
+	for _, want := range []string{
+		`metadata loaded without dolt_database; using default database name "beads"`,
+		"metadata=true",
+		"config.yaml=false",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("debug output missing %q:\n%s", want, stderr)
+		}
+	}
+}

--- a/cmd/bd/main_config_debug_test.go
+++ b/cmd/bd/main_config_debug_test.go
@@ -34,3 +34,45 @@ func TestLogConfigDiscoveryIncludesMetadataAndYAMLState(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldLogDefaultDoltDatabase(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *configfile.Config
+		envDatabase string
+		want        bool
+	}{
+		{
+			name: "missing metadata database and env",
+			cfg:  &configfile.Config{},
+			want: true,
+		},
+		{
+			name:        "env database suppresses diagnostic",
+			cfg:         &configfile.Config{},
+			envDatabase: "envdb",
+			want:        false,
+		},
+		{
+			name: "metadata database suppresses diagnostic",
+			cfg: &configfile.Config{
+				DoltDatabase: "metadb",
+			},
+			want: false,
+		},
+		{
+			name: "nil config suppresses diagnostic",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BEADS_DOLT_SERVER_DATABASE", tt.envDatabase)
+
+			if got := shouldLogDefaultDoltDatabase(tt.cfg); got != tt.want {
+				t.Fatalf("shouldLogDefaultDoltDatabase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

PR #4191 added useful debug output when config discovery returns no config file, but the adjacent loaded-config case was still opaque: `metadata.json` can exist while `dolt_database` is missing or blank, causing bd to fall back to the default `beads` database name without any debug trail.

That makes non-default database drift difficult to diagnose. This keeps normal behavior unchanged and adds only debug/verbose diagnostics.

## What

- Factor config discovery stat logging into a helper.
- Log when loaded metadata lacks `dolt_database` and no `BEADS_DOLT_SERVER_DATABASE` override is set.
- Add a focused test for the debug helper output.

## Tests

- `go test -tags gms_pure_go ./cmd/bd -run TestLogConfigDiscoveryIncludesMetadataAndYAMLState`
- `go test -tags gms_pure_go ./cmd/bd`

_codex-gpt-5.5-medium on behalf of matt wilkie_
