### PR TITLE
import: skip stale JSONL issue snapshots

### DIFF
--- a/cmd/bd/export_auto_test.go
+++ b/cmd/bd/export_auto_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/beads/internal/config"
 )
 
 // TestGitAddFile_InWorktreeHook_StagesCorrectPath is a regression test for
@@ -186,6 +188,28 @@ func TestShouldRunPostCommandAutoExportSkipsReadOnlyCommands(t *testing.T) {
 	}
 	if !shouldRunPostCommandAutoExport(&cobra.Command{Use: "create"}) {
 		t.Fatal("write commands should still trigger post-command auto-export")
+	}
+}
+
+func TestMaybeAutoExportSkipsServerModeBeforeStoreAccess(t *testing.T) {
+	initConfigForTest(t)
+	config.Set("export.auto", true)
+
+	saveAndRestoreGlobals(t)
+	store = &fakeFallbackStore{}
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	if err := maybeAutoExport(context.Background(), true, false); err != nil {
+		t.Fatalf("maybeAutoExport(serverMode=true): %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".beads", exportAutoStateFile)); !os.IsNotExist(err) {
+		t.Fatalf("server-mode auto-export wrote state file, stat err=%v", err)
 	}
 }
 

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -65,7 +65,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
-  bd import --json                 # Structured output with created IDs`,
+  bd import --json                 # Structured output with created and skipped IDs`,
 	GroupID: "sync",
 	RunE:    runImport,
 }
@@ -142,6 +142,7 @@ type importResultJSON struct {
 	DedupHits           int      `json:"dedup_skipped,omitempty"`
 	Memories            int      `json:"memories,omitempty"`
 	IDs                 []string `json:"ids,omitempty"`
+	StaleSkippedIDs     []string `json:"stale_skipped_ids,omitempty"`
 	SkippedDependencies []string `json:"skipped_dependencies,omitempty"`
 	DryRun              bool     `json:"dry_run,omitempty"`
 }
@@ -250,6 +251,7 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		result.Skipped += importResult.Skipped
 		result.SkippedDependencies = append(result.SkippedDependencies, importResult.SkippedDependencies...)
 		result.IDs = append(result.IDs, importResult.ImportedIDs...)
+		result.StaleSkippedIDs = append(result.StaleSkippedIDs, importResult.StaleSkippedIDs...)
 	}
 
 	if result.Created > 0 || result.Memories > 0 {

--- a/cmd/bd/import.go
+++ b/cmd/bd/import.go
@@ -249,19 +249,18 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 		result.Created = importResult.Created
 		result.Skipped += importResult.Skipped
 		result.SkippedDependencies = append(result.SkippedDependencies, importResult.SkippedDependencies...)
-		for _, issue := range issues {
-			result.IDs = append(result.IDs, issue.ID)
-		}
+		result.IDs = append(result.IDs, importResult.ImportedIDs...)
 	}
 
-	// Commit
-	commitMsg := fmt.Sprintf("bd import: %d issues", result.Created)
-	if result.Memories > 0 {
-		commitMsg += fmt.Sprintf(", %d memories", result.Memories)
-	}
-	commitMsg += fmt.Sprintf(" from %s", filepath.Base(source))
-	if err := store.Commit(ctx, commitMsg); err != nil {
-		return fmt.Errorf("commit: %w", err)
+	if result.Created > 0 || result.Memories > 0 {
+		commitMsg := fmt.Sprintf("bd import: %d issues", result.Created)
+		if result.Memories > 0 {
+			commitMsg += fmt.Sprintf(", %d memories", result.Memories)
+		}
+		commitMsg += fmt.Sprintf(" from %s", filepath.Base(source))
+		if err := store.Commit(ctx, commitMsg); err != nil {
+			return fmt.Errorf("commit: %w", err)
+		}
 	}
 
 	if jsonOutput {
@@ -276,6 +275,9 @@ func runImportFromReader(ctx context.Context, r io.Reader, source string) error 
 	fmt.Fprintf(os.Stderr, " from %s", source)
 	if dedupHits > 0 {
 		fmt.Fprintf(os.Stderr, " (%d duplicates skipped)", dedupHits)
+	}
+	if staleSkipped := result.Skipped - dedupHits; staleSkipped > 0 {
+		fmt.Fprintf(os.Stderr, " (%d stale skipped)", staleSkipped)
 	}
 	fmt.Fprintln(os.Stderr)
 	for _, skipped := range result.SkippedDependencies {

--- a/cmd/bd/import_from_jsonl_test.go
+++ b/cmd/bd/import_from_jsonl_test.go
@@ -163,6 +163,57 @@ func TestImportFromLocalJSONL(t *testing.T) {
 		}
 	})
 
+	t.Run("stale JSONL does not clobber newer local issue", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbPath := filepath.Join(tmpDir, "dolt")
+		store := newTestStore(t, dbPath)
+
+		ctx := context.Background()
+		createdAt := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		localUpdatedAt := createdAt.Add(2 * time.Hour)
+		local := &types.Issue{
+			ID:        "test-stale-import",
+			Title:     "newer local title",
+			Status:    types.StatusInProgress,
+			IssueType: types.TypeTask,
+			Priority:  1,
+			CreatedAt: createdAt,
+			UpdatedAt: localUpdatedAt,
+		}
+		if err := store.CreateIssue(ctx, local, "test"); err != nil {
+			t.Fatalf("CreateIssue local: %v", err)
+		}
+
+		jsonlContent := `{"id":"test-stale-import","title":"stale exported title","status":"open","priority":3,"issue_type":"task","created_at":"2025-01-01T00:00:00Z","updated_at":"2025-01-01T01:00:00Z"}
+`
+		jsonlPath := filepath.Join(tmpDir, "issues.jsonl")
+		if err := os.WriteFile(jsonlPath, []byte(jsonlContent), 0644); err != nil {
+			t.Fatalf("Failed to write JSONL file: %v", err)
+		}
+
+		count, err := importFromLocalJSONL(ctx, store, jsonlPath)
+		if err != nil {
+			t.Fatalf("importFromLocalJSONL failed: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("Expected stale import to import 0 issues, got %d", count)
+		}
+
+		got, err := store.GetIssue(ctx, "test-stale-import")
+		if err != nil {
+			t.Fatalf("GetIssue: %v", err)
+		}
+		if got.Title != "newer local title" {
+			t.Fatalf("stale JSONL clobbered title: got %q", got.Title)
+		}
+		if got.Status != types.StatusInProgress {
+			t.Fatalf("stale JSONL clobbered status: got %q", got.Status)
+		}
+		if got.Priority != 1 {
+			t.Fatalf("stale JSONL clobbered priority: got %d", got.Priority)
+		}
+	})
+
 	t.Run("child counter reconciled after JSONL import prevents overwrites", func(t *testing.T) {
 		// Regression test for GH#2166: bd create --parent after bd init --from-jsonl
 		// must not overwrite existing child issues. The child_counters table

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -41,6 +41,7 @@ type ImportResult struct {
 	ExpectedPrefix      string
 	MismatchPrefixes    map[string]int
 	ImportedIDs         []string
+	StaleSkippedIDs     []string
 	SkippedDependencies []string
 }
 
@@ -51,13 +52,13 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		return &ImportResult{Skipped: len(issues)}, nil
 	}
 
-	filtered, staleSkipped, err := filterStaleImportIssues(ctx, store, issues)
+	filtered, staleSkippedIDs, err := filterStaleImportIssues(ctx, store, issues)
 	if err != nil {
 		return nil, err
 	}
 	issues = filtered
 	if len(issues) == 0 {
-		return &ImportResult{Skipped: staleSkipped}, nil
+		return &ImportResult{Skipped: len(staleSkippedIDs), StaleSkippedIDs: staleSkippedIDs}, nil
 	}
 
 	var skippedDependencies []string
@@ -83,10 +84,16 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 	for _, issue := range issues {
 		importedIDs = append(importedIDs, issue.ID)
 	}
-	return &ImportResult{Created: len(issues), Skipped: staleSkipped, ImportedIDs: importedIDs, SkippedDependencies: skippedDependencies}, nil
+	return &ImportResult{
+		Created:             len(issues),
+		Skipped:             len(staleSkippedIDs),
+		ImportedIDs:         importedIDs,
+		StaleSkippedIDs:     staleSkippedIDs,
+		SkippedDependencies: skippedDependencies,
+	}, nil
 }
 
-func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) ([]*types.Issue, int, error) {
+func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) ([]*types.Issue, []string, error) {
 	ids := make([]string, 0, len(issues))
 	seen := make(map[string]struct{}, len(issues))
 	for _, issue := range issues {
@@ -100,12 +107,12 @@ func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, iss
 		ids = append(ids, issue.ID)
 	}
 	if len(ids) == 0 {
-		return issues, 0, nil
+		return issues, nil, nil
 	}
 
 	localIssues, err := store.GetIssuesByIDs(ctx, ids)
 	if err != nil {
-		return nil, 0, fmt.Errorf("check existing issues before import: %w", err)
+		return nil, nil, fmt.Errorf("check existing issues before import: %w", err)
 	}
 	localUpdatedAt := make(map[string]time.Time, len(localIssues))
 	for _, issue := range localIssues {
@@ -114,23 +121,23 @@ func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, iss
 		}
 	}
 	if len(localUpdatedAt) == 0 {
-		return issues, 0, nil
+		return issues, nil, nil
 	}
 
 	filtered := make([]*types.Issue, 0, len(issues))
-	skipped := 0
+	skippedIDs := make([]string, 0)
 	for _, issue := range issues {
 		if issue == nil || issue.ID == "" || issue.UpdatedAt.IsZero() {
 			filtered = append(filtered, issue)
 			continue
 		}
 		if local, ok := localUpdatedAt[issue.ID]; ok && issue.UpdatedAt.UTC().Before(local.UTC()) {
-			skipped++
+			skippedIDs = append(skippedIDs, issue.ID)
 			continue
 		}
 		filtered = append(filtered, issue)
 	}
-	return filtered, skipped, nil
+	return filtered, skippedIDs, nil
 }
 
 // importLocalResult holds counts from a local JSONL import.

--- a/cmd/bd/import_shared.go
+++ b/cmd/bd/import_shared.go
@@ -40,6 +40,7 @@ type ImportResult struct {
 	PrefixMismatch      bool
 	ExpectedPrefix      string
 	MismatchPrefixes    map[string]int
+	ImportedIDs         []string
 	SkippedDependencies []string
 }
 
@@ -50,9 +51,18 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		return &ImportResult{Skipped: len(issues)}, nil
 	}
 
+	filtered, staleSkipped, err := filterStaleImportIssues(ctx, store, issues)
+	if err != nil {
+		return nil, err
+	}
+	issues = filtered
+	if len(issues) == 0 {
+		return &ImportResult{Skipped: staleSkipped}, nil
+	}
+
 	var skippedDependencies []string
 	skippedDependencySet := make(map[string]struct{})
-	err := store.CreateIssuesWithFullOptions(ctx, issues, getActorWithGit(), storage.BatchCreateOptions{
+	err = store.CreateIssuesWithFullOptions(ctx, issues, getActorWithGit(), storage.BatchCreateOptions{
 		OrphanHandling:                 storage.OrphanAllow,
 		SkipPrefixValidation:           opts.SkipPrefixValidation,
 		SkipDependencyValidationErrors: true,
@@ -69,7 +79,58 @@ func importIssuesCore(ctx context.Context, _ string, store storage.DoltStorage, 
 		return nil, err
 	}
 
-	return &ImportResult{Created: len(issues), SkippedDependencies: skippedDependencies}, nil
+	importedIDs := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		importedIDs = append(importedIDs, issue.ID)
+	}
+	return &ImportResult{Created: len(issues), Skipped: staleSkipped, ImportedIDs: importedIDs, SkippedDependencies: skippedDependencies}, nil
+}
+
+func filterStaleImportIssues(ctx context.Context, store storage.DoltStorage, issues []*types.Issue) ([]*types.Issue, int, error) {
+	ids := make([]string, 0, len(issues))
+	seen := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		if issue == nil || issue.ID == "" {
+			continue
+		}
+		if _, ok := seen[issue.ID]; ok {
+			continue
+		}
+		seen[issue.ID] = struct{}{}
+		ids = append(ids, issue.ID)
+	}
+	if len(ids) == 0 {
+		return issues, 0, nil
+	}
+
+	localIssues, err := store.GetIssuesByIDs(ctx, ids)
+	if err != nil {
+		return nil, 0, fmt.Errorf("check existing issues before import: %w", err)
+	}
+	localUpdatedAt := make(map[string]time.Time, len(localIssues))
+	for _, issue := range localIssues {
+		if issue != nil && issue.ID != "" && !issue.UpdatedAt.IsZero() {
+			localUpdatedAt[issue.ID] = issue.UpdatedAt
+		}
+	}
+	if len(localUpdatedAt) == 0 {
+		return issues, 0, nil
+	}
+
+	filtered := make([]*types.Issue, 0, len(issues))
+	skipped := 0
+	for _, issue := range issues {
+		if issue == nil || issue.ID == "" || issue.UpdatedAt.IsZero() {
+			filtered = append(filtered, issue)
+			continue
+		}
+		if local, ok := localUpdatedAt[issue.ID]; ok && issue.UpdatedAt.UTC().Before(local.UTC()) {
+			skipped++
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered, skipped, nil
 }
 
 // importLocalResult holds counts from a local JSONL import.
@@ -204,11 +265,11 @@ func importFromLocalJSONLFull(ctx context.Context, store storage.DoltStorage, lo
 		opts := ImportOptions{
 			SkipPrefixValidation: true,
 		}
-		_, err = importIssuesCore(ctx, "", store, issues, opts)
+		importResult, err := importIssuesCore(ctx, "", store, issues, opts)
 		if err != nil {
 			return nil, err
 		}
-		result.Issues = len(issues)
+		result.Issues = importResult.Created
 	}
 
 	return result, nil

--- a/cmd/bd/import_shared_unit_test.go
+++ b/cmd/bd/import_shared_unit_test.go
@@ -32,12 +32,12 @@ func TestFilterStaleImportIssuesSkipsOlderIncomingRecords(t *testing.T) {
 		{ID: "bd-newer", UpdatedAt: base.Add(time.Hour)},
 	}}
 
-	filtered, skipped, err := filterStaleImportIssues(context.Background(), store, incoming)
+	filtered, skippedIDs, err := filterStaleImportIssues(context.Background(), store, incoming)
 	if err != nil {
 		t.Fatalf("filterStaleImportIssues: %v", err)
 	}
-	if skipped != 1 {
-		t.Fatalf("skipped = %d, want 1", skipped)
+	if len(skippedIDs) != 1 || skippedIDs[0] != "bd-stale" {
+		t.Fatalf("skippedIDs = %#v, want [bd-stale]", skippedIDs)
 	}
 
 	got := make(map[string]bool, len(filtered))
@@ -51,5 +51,31 @@ func TestFilterStaleImportIssuesSkipsOlderIncomingRecords(t *testing.T) {
 	}
 	if got["bd-stale"] {
 		t.Fatalf("stale issue was not filtered: %#v", got)
+	}
+}
+
+func TestImportIssuesCoreReportsStaleSkippedIDs(t *testing.T) {
+	base := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	store := &fakeImportIssueLookupStore{issues: []*types.Issue{
+		{ID: "bd-stale", UpdatedAt: base.Add(time.Hour)},
+	}}
+
+	result, err := importIssuesCore(context.Background(), "", store, []*types.Issue{
+		{ID: "bd-stale", Title: "stale snapshot", UpdatedAt: base},
+	}, ImportOptions{})
+	if err != nil {
+		t.Fatalf("importIssuesCore: %v", err)
+	}
+	if result.Created != 0 {
+		t.Fatalf("Created = %d, want 0", result.Created)
+	}
+	if result.Skipped != 1 {
+		t.Fatalf("Skipped = %d, want 1", result.Skipped)
+	}
+	if len(result.ImportedIDs) != 0 {
+		t.Fatalf("ImportedIDs = %#v, want empty", result.ImportedIDs)
+	}
+	if len(result.StaleSkippedIDs) != 1 || result.StaleSkippedIDs[0] != "bd-stale" {
+		t.Fatalf("StaleSkippedIDs = %#v, want [bd-stale]", result.StaleSkippedIDs)
 	}
 }

--- a/cmd/bd/import_shared_unit_test.go
+++ b/cmd/bd/import_shared_unit_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type fakeImportIssueLookupStore struct {
+	storage.DoltStorage
+	issues []*types.Issue
+}
+
+func (f *fakeImportIssueLookupStore) GetIssuesByIDs(_ context.Context, _ []string) ([]*types.Issue, error) {
+	return f.issues, nil
+}
+
+func TestFilterStaleImportIssuesSkipsOlderIncomingRecords(t *testing.T) {
+	base := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	incoming := []*types.Issue{
+		{ID: "bd-stale", Title: "stale snapshot", UpdatedAt: base},
+		{ID: "bd-equal", Title: "same snapshot time", UpdatedAt: base},
+		{ID: "bd-newer", Title: "newer snapshot", UpdatedAt: base.Add(2 * time.Hour)},
+		{ID: "bd-new", Title: "new record", UpdatedAt: base},
+	}
+	store := &fakeImportIssueLookupStore{issues: []*types.Issue{
+		{ID: "bd-stale", UpdatedAt: base.Add(time.Hour)},
+		{ID: "bd-equal", UpdatedAt: base},
+		{ID: "bd-newer", UpdatedAt: base.Add(time.Hour)},
+	}}
+
+	filtered, skipped, err := filterStaleImportIssues(context.Background(), store, incoming)
+	if err != nil {
+		t.Fatalf("filterStaleImportIssues: %v", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", skipped)
+	}
+
+	got := make(map[string]bool, len(filtered))
+	for _, issue := range filtered {
+		got[issue.ID] = true
+	}
+	for _, id := range []string{"bd-equal", "bd-newer", "bd-new"} {
+		if !got[id] {
+			t.Fatalf("filtered issues missing %s: %#v", id, got)
+		}
+	}
+	if got["bd-stale"] {
+		t.Fatalf("stale issue was not filtered: %#v", got)
+	}
+}

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2428,7 +2428,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
-  bd import --json                 # Structured output with created IDs
+  bd import --json                 # Structured output with created and skipped IDs
 
 ```
 bd import [file|-] [flags]

--- a/website/docs/cli-reference/import.md
+++ b/website/docs/cli-reference/import.md
@@ -56,7 +56,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
-  bd import --json                 # Structured output with created IDs
+  bd import --json                 # Structured output with created and skipped IDs
 
 ```
 bd import [file|-] [flags]

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -5344,7 +5344,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
-  bd import --json                 # Structured output with created IDs
+  bd import --json                 # Structured output with created and skipped IDs
 
 ```
 bd import [file|-] [flags]

--- a/website/versioned_docs/version-1.0.0/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/import.md
@@ -56,7 +56,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
-  bd import --json                 # Structured output with created IDs
+  bd import --json                 # Structured output with created and skipped IDs
 
 ```
 bd import [file|-] [flags]

--- a/website/versioned_docs/version-1.0.4/cli-reference/import.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/import.md
@@ -56,7 +56,7 @@ EXAMPLES:
   cat issues.jsonl | bd import -   # Pipe JSONL from another tool
   bd import --dry-run              # Show what would be imported
   bd import --dedup                # Skip issues with duplicate titles
-  bd import --json                 # Structured output with created IDs
+  bd import --json                 # Structured output with created and skipped IDs
 
 ```
 bd import [file|-] [flags]


### PR DESCRIPTION
## Summary

- skip imported JSONL issue records when the local issue has a newer `updated_at`
- report stale JSONL skips separately from same-file duplicate skips
- include `stale_skipped_ids` in `bd import --json` so callers can distinguish imported IDs from stale records that were referenced but not applied
- avoid creating an import commit when stale filtering leaves no issue or memory changes
- add regression coverage for stale import filtering and the existing server-mode auto-export guard
- regenerate CLI reference docs and `llms-full.txt` from the pure-Go binary used by CI

## Why

#3822 reports a data-loss class around JSONL import/export in server-backed workflows. Current `main` already skips server-mode auto import/export, but manual or recovery JSONL import can still replay an older snapshot over a newer local row because import unconditionally upserts matching issue IDs.

This keeps JSONL import from moving an existing issue backward in time: if the incoming row is older than the local row, it is skipped instead of clobbering the local title, status, priority, or other fields.

One residual concurrency caveat remains: the stale check currently reads local `updated_at` before the batch upsert, so another writer could still advance the row between that read and the write. This PR narrows the unconditional clobber case but does not make the stale guard fully transactional; making it airtight should happen inside the storage upsert path or a shared transaction.

Fixes #3822.

## Validation

- `go test -tags gms_pure_go ./cmd/bd -run 'TestFilterStaleImportIssuesSkipsOlderIncomingRecords|TestImportIssuesCoreReportsStaleSkippedIDs|TestMaybeAutoExportSkipsServerModeBeforeStoreAccess|TestShouldRunAutoImportJSONL' -count=1`
- `CGO_ENABLED=0 go build -tags gms_pure_go -o bd ./cmd/bd/`
- `./scripts/generate-cli-docs.sh ./bd`
- `./scripts/generate-llms-full.sh`
- `./scripts/check-doc-flags.sh ./bd`
- `./scripts/check-doc-freshness.sh`
- `git diff --check`

The cgo end-to-end import test was added but skipped locally because the Docker/Dolt test server is unavailable in this environment.

_codex-gpt-5.5-medium on behalf of maphew_
