### PR TITLE
cleanup: remove unused private helpers

### DIFF
--- a/cmd/bd/setup/agent_skill.go
+++ b/cmd/bd/setup/agent_skill.go
@@ -25,24 +25,6 @@ type agentSkillEnv struct {
 	removeFile func(string) error
 }
 
-func defaultAgentSkillEnv() (agentSkillEnv, error) {
-	workDir, err := os.Getwd()
-	if err != nil {
-		return agentSkillEnv{}, fmt.Errorf("working directory: %w", err)
-	}
-	return agentSkillEnv{
-		stdout:     os.Stdout,
-		stderr:     os.Stderr,
-		projectDir: workDir,
-		ensureDir:  EnsureDir,
-		readFile:   os.ReadFile,
-		writeFile: func(path string, data []byte) error {
-			return atomicWriteFile(path, data)
-		},
-		removeFile: os.Remove,
-	}, nil
-}
-
 func agentSkillRootPath(base string) string {
 	return filepath.Join(base, ".agents", "skills", "beads")
 }

--- a/internal/config/yaml_config.go
+++ b/internal/config/yaml_config.go
@@ -518,21 +518,6 @@ func isDuration(s string) bool {
 	return isNumeric(s[:len(s)-1])
 }
 
-func needsQuoting(s string) bool {
-	// Quote if contains special YAML characters
-	special := []string{":", "#", "[", "]", "{", "}", ",", "&", "*", "!", "|", ">", "'", "\"", "%", "@", "`"}
-	for _, c := range special {
-		if strings.Contains(s, c) {
-			return true
-		}
-	}
-	// Quote if starts/ends with whitespace
-	if strings.TrimSpace(s) != s {
-		return true
-	}
-	return false
-}
-
 // validateYamlConfigValue validates a configuration value before setting.
 // Returns an error if the value is invalid for the given key.
 func validateYamlConfigValue(key, value string) error {


### PR DESCRIPTION
## Summary

- remove unused `defaultAgentSkillEnv`
- remove unused YAML helper `needsQuoting`

## Why

This is the lowest-risk slice from a pattern-collapse inventory pass: both helpers have zero call sites, so removing them reduces maintenance surface without changing behavior. Larger duplicate-helper candidates remain for separate, more targeted cleanup.

## Validation

- `go test ./internal/config ./cmd/bd/setup`
- `git diff --check`

Broader `cmd/bd` test runs were not useful in this local environment because they hit unrelated ICU/CGO and integration-test prerequisites.

_codex-gpt-5.5-medium on behalf of matt wilkie_
