### PR TITLE
feat(no-push): guard dolt push/pull and strip push from rendered templates

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -413,10 +413,6 @@ variables for authentication.
 Use --remote to pull from a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if config.GetBool("no-push") {
-			fmt.Println("skipping pull: rig is local-only (no-push: true)")
-			return
-		}
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -336,6 +336,10 @@ uncommitted changes in its working set).
 Use --remote to push to a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if config.GetBool("no-push") {
+			fmt.Println("skipping push: rig is local-only (no-push: true)")
+			return
+		}
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {
@@ -409,6 +413,10 @@ variables for authentication.
 Use --remote to pull from a specific named remote instead of the default.
 The remote must already exist (see 'bd dolt remote add').`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if config.GetBool("no-push") {
+			fmt.Println("skipping pull: rig is local-only (no-push: true)")
+			return
+		}
 		ctx := context.Background()
 		st := getStore()
 		if st == nil {

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/doltserver"
 	"github.com/steveyegge/beads/internal/storage"
@@ -1609,4 +1611,58 @@ func TestRenderLocalDoltStatus(t *testing.T) {
 			t.Errorf("did not expect mode=external on bd-managed path, got:\n%s", out)
 		}
 	})
+}
+
+// minimalPullStore implements storage.DoltStorage by embedding the interface
+// (all methods panic on nil) with Pull overridden for controlled testing.
+type minimalPullStore struct {
+	storage.DoltStorage
+	pullCalled bool
+	pullErr    error
+}
+
+func (m *minimalPullStore) Pull(ctx context.Context) error {
+	m.pullCalled = true
+	return m.pullErr
+}
+
+func TestNoPushDoesNotSkipDoltPull(t *testing.T) {
+	// no-push is a push-only guard. bd dolt pull must contact the remote even when
+	// no-push: true — contributor clones need to receive upstream updates.
+	// Regression guard for be-ve2x6 (PR #4212, maphew review-4382359270).
+
+	// Cannot be parallel: modifies process-global store and config.
+	saveAndRestoreGlobals(t)
+	resetCommandContext()
+
+	fake := &minimalPullStore{
+		// Return "remote not found" so the command exits cleanly without os.Exit.
+		pullErr: errors.New("remote not found"),
+	}
+	store = fake
+
+	t.Setenv("BD_NO_PUSH", "true")
+	config.ResetForTesting()
+	t.Cleanup(func() { config.ResetForTesting() })
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	if !config.GetBool("no-push") {
+		t.Fatal("test setup: BD_NO_PUSH=true must make no-push=true")
+	}
+
+	out := captureStdout(t, func() error {
+		doltPullCmd.Run(doltPullCmd, nil)
+		return nil
+	})
+
+	if !fake.pullCalled {
+		t.Error("bd dolt pull must attempt the pull even when no-push: true; Pull() was not called")
+	}
+	if strings.Contains(out, "skipping pull") {
+		t.Errorf("bd dolt pull must not skip under no-push: true; got output: %q", out)
+	}
+	if !strings.Contains(out, "Pulling from Dolt remote") {
+		t.Errorf("expected pull attempt output, got: %q", out)
+	}
 }

--- a/cmd/bd/dolt_test.go
+++ b/cmd/bd/dolt_test.go
@@ -1626,6 +1626,17 @@ func (m *minimalPullStore) Pull(ctx context.Context) error {
 	return m.pullErr
 }
 
+// ListRemotes keeps the post-pull error classifier alive. After this PR was
+// cut, main routed bd dolt pull's failure handling through isConfirmedNoRemote
+// (cmd/bd/dolt.go), which calls store.ListRemotes; without this method the call
+// would dereference the nil embedded DoltStorage and panic. Reporting no
+// remotes keeps the simulated "remote not found" failure on the benign
+// no-remote path (clean exit, no os.Exit), which is what this test needs to
+// observe that the pull was attempted rather than skipped.
+func (m *minimalPullStore) ListRemotes(context.Context) ([]storage.RemoteInfo, error) {
+	return nil, nil
+}
+
 func TestNoPushDoesNotSkipDoltPull(t *testing.T) {
 	// no-push is a push-only guard. bd dolt pull must contact the remote even when
 	// no-push: true — contributor clones need to receive upstream updates.

--- a/cmd/bd/fs_adapters.go
+++ b/cmd/bd/fs_adapters.go
@@ -28,7 +28,7 @@ func newFileSystemAdapters() domain.BeadsDirFSAdapters {
 		},
 		InstallJJHooks: installJJHooks,
 		AddAgentsInstructions: func(p domain.AgentsFileParams) {
-			addAgentsInstructions(p.File, p.Verbose, p.TemplatePath, agents.Profile(p.Profile), agents.RenderOpts{HasRemote: p.HasRemote})
+			addAgentsInstructions(p.File, p.Verbose, p.TemplatePath, agents.Profile(p.Profile), agents.RenderOpts{HasRemote: p.HasRemote, NoPush: p.NoPush})
 		},
 		InstallClaudeProject: setup.InstallClaudeProject,
 		SetYAMLConfig:        config.SetYamlConfig,

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -1493,7 +1493,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
 				}
 			} else {
-				renderOpts := agents.RenderOpts{HasRemote: shouldConfigureInitDoltRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin, isDoltLocalOnly())}
+				renderOpts := agents.RenderOpts{HasRemote: shouldConfigureInitDoltRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin, isDoltLocalOnly()), NoPush: config.GetBool("no-push")}
 				addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile, renderOpts)
 			}
 		}

--- a/cmd/bd/init_proxied_server.go
+++ b/cmd/bd/init_proxied_server.go
@@ -407,6 +407,7 @@ func runInitProxiedServerTail(cmd *cobra.Command, ctx context.Context, in initPr
 				TemplatePath: agentsTemplate,
 				Profile:      agentsProfileStr,
 				HasRemote:    t.remoteURL != "",
+				NoPush:       config.GetBool("no-push"),
 			})
 			if err := t.fsUseCase.InstallClaudeProject(ctx, in.stealth); err != nil && !in.quiet {
 				fmt.Fprintf(os.Stderr, "Warning: failed to setup Claude hooks: %v\n", err)

--- a/cmd/bd/setup/agents.go
+++ b/cmd/bd/setup/agents.go
@@ -59,6 +59,7 @@ func defaultAgentsEnv() agentsEnv {
 var detectRenderOptsImpl = func() agents.RenderOpts {
 	return agents.RenderOpts{
 		HasRemote: config.GetString("sync.remote") != "" || config.GetString("sync.git-remote") != "",
+		NoPush:    config.GetBool("no-push"),
 	}
 }
 

--- a/internal/storage/domain/beads.go
+++ b/internal/storage/domain/beads.go
@@ -96,6 +96,7 @@ type AgentsFileParams struct {
 	TemplatePath string
 	Profile      string
 	HasRemote    bool
+	NoPush       bool
 }
 
 type BeadsDirFSAdapters struct {

--- a/internal/templates/agents/render.go
+++ b/internal/templates/agents/render.go
@@ -49,6 +49,9 @@ type RenderOpts struct {
 	// HasRemote indicates whether a Dolt remote is configured.
 	// When false, "bd dolt push" is omitted from session-completion instructions.
 	HasRemote bool
+	// NoPush indicates the rig is declared local-only (no-push: true in config).
+	// When true, "bd dolt push" is omitted regardless of HasRemote.
+	NoPush bool
 }
 
 // DefaultRenderOpts returns opts that assume a remote is configured,
@@ -211,7 +214,7 @@ func templateBodyWithOpts(profile Profile, opts RenderOpts) string {
 		body = strings.TrimSuffix(body, "\n<!-- END BEADS INTEGRATION -->")
 	}
 
-	if !opts.HasRemote {
+	if !opts.HasRemote || opts.NoPush {
 		body = stripDoltPushReferences(body)
 	}
 

--- a/internal/templates/agents/render.go
+++ b/internal/templates/agents/render.go
@@ -229,8 +229,14 @@ func normalizeEmbeddedMarkdown(content string) string {
 // Strips the indented code-block line from session completion, and the
 // informational Auto-Sync bullet that references dolt push/pull.
 func stripDoltPushReferences(body string) string {
-	// Session completion code block: "   bd dolt push\n"
-	body = strings.ReplaceAll(body, "   bd dolt push\n", "")
+	// Session completion code block: exactly "   bd dolt push\n" (3-space indent).
+	// Pad both ends with "\n" so a single anchored ReplaceAll handles the line
+	// whether it appears at the start, middle, or end of the body, without
+	// accidentally matching a 4-space indented variant via substring.
+	const pushLine = "   bd dolt push\n"
+	padded := "\n" + body + "\n"
+	padded = strings.ReplaceAll(padded, "\n"+pushLine, "\n")
+	body = padded[1 : len(padded)-1]
 	// Auto-Sync informational bullet (full profile only)
 	body = strings.ReplaceAll(body, "- Use `bd dolt push`/`bd dolt pull` for remote sync\n", "")
 	return body

--- a/release-gates/be-4i9a-no-push-dolt-gate.md
+++ b/release-gates/be-4i9a-no-push-dolt-gate.md
@@ -1,0 +1,52 @@
+# Release Gate: be-4i9a — feat(no-push): guard dolt push/pull + strip templates
+
+**Date:** 2026-06-07
+**Bead:** be-4i9a
+**Commit:** 07ae3e57f308c8d016af5dcda6308eaf957fdc18
+**Branch:** quad341:feat/be-3w6-be-0c8-nopush-dolt
+**PR:** https://github.com/gastownhall/beads/pull/4212
+**Deployer:** beads/deployer
+
+---
+
+## Gate Verdict: PASS
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | **PASS** | be-iici (review bead) closed with reason "pass". Verdict: PASS (2026-06-07T22:38:27Z) by beads/reviewer (engineering-manager + principal-engineer + security-engineer) |
+| 2 | Acceptance criteria met | **PASS** | Reviewer confirmed: push guard (cmd/bd/dolt.go:254-257), NoPush propagation x7 files (fs_adapters, init, init_proxied_server, setup/agents, domain/beads, internal/templates), pull guard removed (be-ve2x6 fix), TestNoPushDoesNotSkipDoltPull regression test added |
+| 3 | Tests pass | **PASS** | `go build ./...` clean. `go test ./cmd/bd/setup/... ./internal/templates/agents/...` PASS. `TestNoPushDoesNotSkipDoltPull` PASS. Pre-existing cmd/bd failures (TestBackupDir_NoWorkspaceReturnsActiveWorkspaceError, etc.) reproduce identically on origin/main — local ~/.beads env noise, not regressions. CI 44/44 SUCCESS (2026-05-29 run). |
+| 4 | No high-severity findings open | **PASS** | Reviewer findings: [INFO] push guard has 0% direct unit test coverage (follow-up filed as be-i9e2); [PASS] security, spec, style, docs. Zero HIGH findings. |
+| 5 | Final branch is clean | **PASS** | Working tree clean at 07ae3e57f (detached HEAD). No uncommitted changes. |
+| 6 | Branch diverges cleanly from main | **PASS** | `git merge-tree origin/main FETCH_HEAD` exits 0, no conflicts. GitHub mergeStateStatus=CLEAN. |
+| 7 | Single feature theme | **PASS** | All changes are cohesive no-push feature: dolt push guard, NoPush propagation through rendering pipeline, pull guard removal, regression test. One logical extension of the existing no-push config option. |
+
+---
+
+## Review Summary
+
+- **First-pass reviewer:** beads/reviewer — PASS
+- **Second-pass (gemini):** not required (single-pass policy)
+- **Reviewer findings:** INFO-only (coverage gap filed as be-i9e2); all spec/security/style/docs checks PASS
+
+## Commit Set
+
+| Commit | Message |
+|--------|---------|
+| 82595d2dc | feat(no-push): guard dolt push/pull and strip push from rendered templates |
+| 34a7741fb | fix(no-push): anchor stripDoltPushReferences to prevent 4-space indent false match |
+| f05d07cd1 | fix(no-push): remove pull guard from bd dolt pull (be-ve2x6) |
+| bc8ddba59 | Merge remote-tracking branch 'origin/main' into pr-4212-work |
+| 07ae3e57f | docs: regenerate llms-full.txt under C locale after merging main |
+
+## Files Changed
+
+- `cmd/bd/dolt.go` — push guard added (exit 0 with skip message when no-push: true)
+- `cmd/bd/dolt_test.go` — TestNoPushDoesNotSkipDoltPull regression test
+- `cmd/bd/fs_adapters.go` — NoPush propagated to RenderOpts
+- `cmd/bd/init.go` — NoPush propagated to renderOpts
+- `cmd/bd/init_proxied_server.go` — NoPush propagated to AgentsFileParams
+- `cmd/bd/setup/agents.go` — NoPush in detectRenderOptsImpl
+- `internal/storage/domain/beads.go` — AgentsFileParams.NoPush field added
+- `internal/templates/agents/` — stripDoltPushReferences used in rendering
+- `website/static/llms-full.txt` — C-locale sort reorder (no content changes)


### PR DESCRIPTION
## Summary

Extends the existing `no-push` config option (added in eff58e494) to cover Dolt operations and agent template rendering:

- `bd dolt push` / `bd dolt pull` skip silently (exit 0) when `no-push: true` in config
- `RenderOpts` gains a `NoPush bool`; when `!HasRemote || NoPush`, the `bd dolt push` line is stripped from rendered AGENTS.md templates
- `NoPush` propagated through `AgentsFileParams`, `fs_adapters`, `init`, `setup/agents`, `init_proxied_server`

This is the natural completion of the no-push feature: the existing flag suppressed `git push`, but `bd dolt push` and the template-generated push step were still active in no-push environments.

## Test plan

- [ ] `go test ./cmd/bd/setup/... ./internal/templates/agents/...` — passes
- [ ] `go build ./...` — clean
- [ ] `bd dolt push` on a no-push config returns exit 0 with skip message
- [ ] Generated AGENTS.md omits `bd dolt push` when `NoPush=true`
- [ ] Generated AGENTS.md retains `bd dolt push` when `NoPush=false` (backward compat)
- [ ] Test PR with full unit coverage to follow after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)