### PR TITLE
test(fs): make domain/fs suite hermetic when run from a linked worktree

### DIFF
--- a/internal/storage/domain/fs/suite_test.go
+++ b/internal/storage/domain/fs/suite_test.go
@@ -2,16 +2,43 @@ package fs
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/steveyegge/beads/internal/git"
 	"github.com/steveyegge/beads/internal/storage/domain"
 )
 
 type testSuite struct {
 	suite.Suite
+	origDir  string
+	suiteDir string
+}
+
+func (s *testSuite) SetupSuite() {
+	origDir, err := os.Getwd()
+	s.Require().NoError(err, "SetupSuite: get working directory")
+	s.origDir = origDir
+
+	suiteDir, err := os.MkdirTemp("", "beads-fs-suite-*")
+	s.Require().NoError(err, "SetupSuite: create temp dir")
+	s.suiteDir = suiteDir
+
+	s.Require().NoError(os.Chdir(suiteDir), "SetupSuite: chdir to non-git dir")
+	git.ResetCaches()
+}
+
+func (s *testSuite) TearDownSuite() {
+	if s.origDir != "" {
+		_ = os.Chdir(s.origDir)
+		git.ResetCaches()
+	}
+	if s.suiteDir != "" {
+		_ = os.RemoveAll(s.suiteDir)
+	}
 }
 
 func (s *testSuite) Ctx() context.Context {


### PR DESCRIPTION
## Summary

- `go test ./internal/storage/domain/fs/` run from any linked git worktree was silently clobbering the primary checkout's `.beads/metadata.json` with `{"dolt_database":"my_db","project_id":"pid-123"}` from the `readBeadsConfigParses` fixture (real incident: gm-q6biba).
- Root cause: `resolveBeadsDir` checks `GetWorktreeFallbackBeadsDir()` which calls `git.IsWorktree()` — a process-global `sync.Once` that caches `isWorktree=true` when the test binary runs from a linked worktree, so the intended `workDir/.beads` branch is never reached.
- Fix is test-only (no runtime behaviour changed): `SetupSuite` chdirs to a fresh `os.MkdirTemp` (not a git repo) and calls `git.ResetCaches()` before any test runs, seeding the cache with `isWorktree=false`. `TearDownSuite` restores the original dir and resets again.

## Test plan

- [x] `go test ./internal/storage/domain/fs/ -count=1` green from primary checkout
- [x] `go test ./internal/storage/domain/fs/ -count=1` green from linked worktree
- [x] Primary `.beads/metadata.json` sentinel unchanged after suite run from linked worktree (clobber eliminated)
- [x] Existing tests: no regressions (27 subtests all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)