### PR TITLE
fix(install): use declared module path for Go fallback

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -105,6 +105,8 @@ BEADS_INSTALL_RESIGN_MACOS=1 curl -fsSL https://raw.githubusercontent.com/gastow
 - **Nocgo (simplest, default in this doc):** `CGO_ENABLED=0 go install ...`. Works on any machine with a Go toolchain, no C compiler needed. Produces a **server-mode-only** binary — you must run an external `dolt sql-server` and use `bd init --server`. See [DOLT.md](DOLT.md) for server-mode setup.
 - **Cgo (embedded-capable):** `CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install ...`. Requires a C compiler (gcc/clang on Unix, MinGW on Windows). Produces a binary with the default embedded-Dolt backend — `bd init` Just Works.
 
+Use the `github.com/steveyegge/beads` path for `go install`. The repository now lives under `gastownhall/beads`, but released Go modules still declare `github.com/steveyegge/beads` for compatibility.
+
 If you don't have a preference, `brew install beads` / `install.sh` give you the embedded-capable build with no fuss.
 
 ## Platform-Specific Installation

--- a/scripts/check-go-install-guidance.sh
+++ b/scripts/check-go-install-guidance.sh
@@ -15,6 +15,18 @@ while IFS= read -r hit; do
     file="${hit%%:*}"
     rest="${hit#*:}"
     line_no="${rest%%:*}"
+
+    printf 'error: %s:%s: unsupported go install module path\n' "$file" "$line_no" >&2
+    printf '       use github.com/steveyegge/beads/cmd/bd because go.mod still declares that module path\n' >&2
+    fail=1
+done < <(
+    git grep -n -E 'go install github\.com/gastownhall/beads/cmd/bd@latest' -- . || true
+)
+
+while IFS= read -r hit; do
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    line_no="${rest%%:*}"
     line="${rest#*:}"
 
     case "$file" in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -482,7 +482,9 @@ install_with_go() {
         bin_dir="$(go env GOPATH)/bin"
     fi
 
-    if CGO_ENABLED=1 GOFLAGS="${GOFLAGS:+$GOFLAGS }-tags=gms_pure_go" go install github.com/gastownhall/beads/cmd/bd@latest; then
+    # The repository lives under gastownhall, but the Go module path remains
+    # github.com/steveyegge/beads for compatibility with released tags.
+    if CGO_ENABLED=1 GOFLAGS="${GOFLAGS:+$GOFLAGS }-tags=gms_pure_go" go install github.com/steveyegge/beads/cmd/bd@latest; then
         log_success "bd installed via go install (embedded-capable)"
         LAST_INSTALL_PATH="$bin_dir/bd"
 
@@ -491,7 +493,7 @@ install_with_go() {
         fi
     else
         log_warning "go install with CGO failed; retrying without CGO (server-mode-only binary)"
-        if CGO_ENABLED=0 go install github.com/gastownhall/beads/cmd/bd@latest; then
+        if CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest; then
             log_success "bd installed via go install (CGO_ENABLED=0, server mode only)"
             log_warning "This bd cannot use embedded Dolt. Run 'bd init --server' to use an external dolt sql-server, or reinstall with a C toolchain for embedded mode."
             LAST_INSTALL_PATH="$bin_dir/bd"
@@ -751,7 +753,7 @@ main() {
     echo ""
     echo "Or install from source:"
     echo "  1. Install Go from https://go.dev/dl/"
-    echo "  2. Run: CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/gastownhall/beads/cmd/bd@latest"
+    echo "  2. Run: CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/cmd/bd@latest"
     echo ""
     exit 1
 }

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -45,6 +45,8 @@ Use Homebrew, npm, or the install script if you do not specifically need `go ins
 
 ICU headers are not required. The embedded-capable command uses `gms_pure_go` so go-mysql-server uses Go's stdlib regexp instead of ICU.
 
+Use the `github.com/steveyegge/beads` path for `go install`. The repository now lives under `gastownhall/beads`, but released Go modules still declare `github.com/steveyegge/beads` for compatibility.
+
 ## Platform-Specific Installation
 
 ### macOS


### PR DESCRIPTION
## Summary

- use the declared Go module path, `github.com/steveyegge/beads`, for `install.sh` Go fallback installs
- add a guidance check that rejects `go install github.com/gastownhall/beads/cmd/bd@latest`
- clarify the repository-transfer/module-path split in install docs

## Why

The repository now lives at `gastownhall/beads`, but released Go modules still declare `github.com/steveyegge/beads`. `go install github.com/gastownhall/beads/cmd/bd@latest` fails with a module path mismatch, so the installer fallback should use the declared module path while docs explain why.

Refs #3312, #3338, #3281.

## Validation

- `bash -n scripts/install.sh scripts/check-go-install-guidance.sh`
- `./scripts/check-go-install-guidance.sh`
- `./scripts/check-build-tags.sh`
- `git diff --check`
- `CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest`
- `CGO_ENABLED=1 GOFLAGS=-tags=gms_pure_go go install github.com/steveyegge/beads/cmd/bd@latest`
- `CGO_ENABLED=0 go install github.com/gastownhall/beads/cmd/bd@latest` failed as expected with module path mismatch

_codex-gpt-5.5-medium on behalf of matt wilkie_
