### PR TITLE
test(create): guard external-ref prelinking

### DIFF
--- a/cmd/bd/create_external_ref_test.go
+++ b/cmd/bd/create_external_ref_test.go
@@ -32,6 +32,6 @@ func TestBuildCreateIssueEmptyExternalRefIsNil(t *testing.T) {
 	})
 
 	if issue.ExternalRef != nil {
-		t.Fatalf("ExternalRef = %q, want nil", *issue.ExternalRef)
+		t.Fatalf("ExternalRef = %v, want nil", issue.ExternalRef)
 	}
 }

--- a/cmd/bd/create_external_ref_test.go
+++ b/cmd/bd/create_external_ref_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestBuildCreateIssueExternalRefPrelink(t *testing.T) {
+	ref := "https://linear.app/team/issue/TEAM-123/fix-login"
+
+	issue := buildCreateIssue(createIssueParams{
+		Title:       "Pre-linked Linear issue",
+		Priority:    2,
+		IssueType:   types.TypeTask,
+		ExternalRef: ref,
+	})
+
+	if issue.ExternalRef == nil {
+		t.Fatal("ExternalRef is nil, want pre-linked Linear URL")
+	}
+	if *issue.ExternalRef != ref {
+		t.Fatalf("ExternalRef = %q, want %q", *issue.ExternalRef, ref)
+	}
+}
+
+func TestBuildCreateIssueEmptyExternalRefIsNil(t *testing.T) {
+	issue := buildCreateIssue(createIssueParams{
+		Title:     "Local-only issue",
+		Priority:  2,
+		IssueType: types.TypeTask,
+	})
+
+	if issue.ExternalRef != nil {
+		t.Fatalf("ExternalRef = %q, want nil", *issue.ExternalRef)
+	}
+}


### PR DESCRIPTION
## Summary

- add a fast create-builder regression test for explicit `--external-ref` pre-linking
- cover the nil behavior when no external ref is supplied

## Why

Current `main` already implements the #3254 `bd create --external-ref` path and merged #3517 documents it, but the direct builder behavior did not have a small unit guard. This keeps the implemented pre-linking behavior from regressing while the larger Linear roadmap still has open work, especially #3186.

Refs #3254, #3186, #3184.

## Validation

- `CGO_ENABLED=0 go test ./cmd/bd -run 'TestBuildCreateIssue(ExternalRefPrelink|EmptyExternalRefIsNil)$' -count=1`
- `CGO_ENABLED=1 go test -tags gms_pure_go ./cmd/bd -run 'TestBuildCreateIssue(ExternalRefPrelink|EmptyExternalRefIsNil)$' -count=1`
- `git diff --check`

_codex-gpt-5.5-medium on behalf of matt wilkie_
