### PR TITLE
fix(dolt): detect managed handoff port conflicts

### DIFF
--- a/cmd/bd/doctor.go
+++ b/cmd/bd/doctor.go
@@ -421,6 +421,13 @@ func runDiagnostics(path string) doctorResult {
 		})
 	}
 
+	// Check 1c: Managed-city handoff port conflict (GH#3926)
+	managedHandoffCheck := convertDoctorCheck(doctor.CheckManagedHandoffPort(path))
+	result.Checks = append(result.Checks, managedHandoffCheck)
+	if managedHandoffCheck.Status == statusWarning || managedHandoffCheck.Status == statusError {
+		result.OverallOK = false
+	}
+
 	// bd-jgxi: Auto-migrate database version before checking it.
 	// Since doctor skips PersistentPreRun DB init (it's in noDbCommands),
 	// trackBdVersion() and autoMigrateOnVersionBump() haven't run yet.

--- a/cmd/bd/doctor/managed_handoff.go
+++ b/cmd/bd/doctor/managed_handoff.go
@@ -1,0 +1,90 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltserver"
+)
+
+// CheckManagedHandoffPort detects the #3926 split-brain risk where a managed
+// city/orchestrator port override differs from an existing standalone port file.
+func CheckManagedHandoffPort(repoPath string) DoctorCheck {
+	beadsDir := ResolveBeadsDirForRepo(repoPath)
+
+	cfg, err := configfile.Load(beadsDir)
+	if err != nil || cfg == nil || cfg.GetBackend() != configfile.BackendDolt {
+		return DoctorCheck{
+			Name:     "Managed Handoff Port",
+			Status:   StatusOK,
+			Message:  "N/A (not using Dolt backend)",
+			Category: CategoryRuntime,
+		}
+	}
+
+	localPort := doltserver.ReadPortFile(beadsDir)
+	if localPort == 0 {
+		return DoctorCheck{
+			Name:     "Managed Handoff Port",
+			Status:   StatusOK,
+			Message:  "No local standalone port file",
+			Category: CategoryRuntime,
+		}
+	}
+
+	envName, envPort := runtimePortOverride()
+	if envPort == 0 {
+		return DoctorCheck{
+			Name:     "Managed Handoff Port",
+			Status:   StatusOK,
+			Message:  fmt.Sprintf("local port file points at %d", localPort),
+			Category: CategoryRuntime,
+		}
+	}
+	if envPort == localPort {
+		return DoctorCheck{
+			Name:     "Managed Handoff Port",
+			Status:   StatusOK,
+			Message:  fmt.Sprintf("%s matches local port file (%d)", envName, localPort),
+			Category: CategoryRuntime,
+		}
+	}
+
+	detail := fmt.Sprintf(
+		"%s=%d but %s contains %d. This can mean commands are reading a managed-city database while the standalone store still exists locally.",
+		envName,
+		envPort,
+		filepath.Join(beadsDir, doltserver.PortFileName),
+		localPort,
+	)
+	if gtRoot := strings.TrimSpace(os.Getenv("GT_ROOT")); gtRoot != "" {
+		detail += fmt.Sprintf("\nGT_ROOT=%s", gtRoot)
+	}
+
+	return DoctorCheck{
+		Name:     "Managed Handoff Port",
+		Status:   StatusWarning,
+		Message:  "managed Dolt port override differs from local standalone port file",
+		Detail:   detail,
+		Fix:      "Before removing the local port file, export from the standalone store, stop its server, then import into the managed server. See docs/DOLT.md#standalone-to-managed-city-handoff",
+		Category: CategoryRuntime,
+	}
+}
+
+func runtimePortOverride() (string, int) {
+	for _, name := range []string{"BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+		raw := strings.TrimSpace(os.Getenv(name))
+		if raw == "" {
+			continue
+		}
+		port, err := strconv.Atoi(raw)
+		if err == nil && port > 0 {
+			return name, port
+		}
+	}
+	return "", 0
+}

--- a/cmd/bd/doctor/managed_handoff_test.go
+++ b/cmd/bd/doctor/managed_handoff_test.go
@@ -1,0 +1,73 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/configfile"
+	"github.com/steveyegge/beads/internal/doltserver"
+)
+
+func TestCheckManagedHandoffPortWarnsOnManagedPortConflict(t *testing.T) {
+	clearResolveBeadsDirCache()
+	t.Cleanup(clearResolveBeadsDirCache)
+
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := (&configfile.Config{}).Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, doltserver.PortFileName), []byte("37953"), 0o600); err != nil {
+		t.Fatalf("write port file: %v", err)
+	}
+
+	t.Setenv("BEADS_DOLT_PORT", "54418")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+	t.Setenv("GT_ROOT", filepath.Join(repoDir, "city"))
+
+	check := CheckManagedHandoffPort(repoDir)
+	if check.Status != StatusWarning {
+		t.Fatalf("expected warning, got %s: %s", check.Status, check.Message)
+	}
+	for _, want := range []string{
+		"managed Dolt port override differs",
+		"BEADS_DOLT_PORT=54418",
+		"contains 37953",
+		"GT_ROOT=",
+		"standalone store",
+	} {
+		if !strings.Contains(check.Message+check.Detail+check.Fix, want) {
+			t.Fatalf("check missing %q:\n%+v", want, check)
+		}
+	}
+}
+
+func TestCheckManagedHandoffPortOKWithoutConflict(t *testing.T) {
+	clearResolveBeadsDirCache()
+	t.Cleanup(clearResolveBeadsDirCache)
+
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := (&configfile.Config{}).Save(beadsDir); err != nil {
+		t.Fatalf("save metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, doltserver.PortFileName), []byte("37953"), 0o600); err != nil {
+		t.Fatalf("write port file: %v", err)
+	}
+
+	t.Setenv("BEADS_DOLT_PORT", "37953")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	check := CheckManagedHandoffPort(repoDir)
+	if check.Status != StatusOK {
+		t.Fatalf("expected ok, got %s: %s", check.Status, check.Message)
+	}
+}

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -540,6 +540,45 @@ gt dolt sql              # Open SQL shell
 
 Server runs on port 3307 (avoids MySQL conflict on 3306).
 
+### Standalone-to-managed-city handoff
+
+When an existing standalone project is later added to a managed city or
+orchestrator, avoid letting two Dolt servers become sources of truth for the
+same beads database name. A common split-brain symptom is that `.beads/dolt-server.port`
+points at the old standalone server while the shell environment points `bd` at
+the managed server with `BEADS_DOLT_PORT` or `BEADS_DOLT_SERVER_PORT`.
+
+Check before migrating:
+
+```bash
+bd doctor
+bd dolt status
+```
+
+`bd doctor` warns when the runtime managed port differs from the local port
+file. The warning is intentionally diagnostic only; do not delete the local port
+file until the standalone store has been exported and imported into the managed
+server.
+
+Safe manual handoff:
+
+```bash
+# From the standalone project, without managed-city port overrides:
+unset BEADS_DOLT_PORT BEADS_DOLT_SERVER_PORT
+bd backup
+bd export > /tmp/beads-standalone.jsonl
+bd dolt stop
+
+# Then enter the managed-city environment and import into its Dolt server:
+bd import /tmp/beads-standalone.jsonl
+bd doctor
+```
+
+After `bd doctor` shows one healthy store and the imported issue count is
+correct, archive the old local Dolt data directory instead of deleting it
+immediately. Keep the backup until the managed city has been pushed or otherwise
+snapshotted.
+
 ### Shared Server Mode
 
 On machines with multiple beads projects, each project normally starts its own Dolt server.

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1115,7 +1115,7 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 		}
 	}
 
-	if isLocalHost(cfg.ServerHost) {
+	if isLocalHost(cfg.ServerHost) && shouldPersistResolvedPortFile() {
 		beadsDir := cfg.BeadsDir
 		if beadsDir == "" && cfg.Path != "" {
 			beadsDir = filepath.Dir(cfg.Path)
@@ -1139,6 +1139,10 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	store.registerPoolGauges()
 
 	return store, nil
+}
+
+func shouldPersistResolvedPortFile() bool {
+	return os.Getenv("BEADS_DOLT_SERVER_PORT") == "" && os.Getenv("BEADS_DOLT_PORT") == ""
 }
 
 // verifyProjectIdentity checks that the database belongs to the expected project.

--- a/internal/storage/dolt/store_unit_test.go
+++ b/internal/storage/dolt/store_unit_test.go
@@ -357,6 +357,35 @@ func TestApplyConfigDefaults_ProductionFallback(t *testing.T) {
 	}
 }
 
+func TestShouldPersistResolvedPortFile(t *testing.T) {
+	t.Run("default runtime port may be persisted", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+		t.Setenv("BEADS_DOLT_PORT", "")
+
+		if !shouldPersistResolvedPortFile() {
+			t.Fatal("expected local resolved port to be persisted")
+		}
+	})
+
+	t.Run("explicit server port is runtime override only", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "15432")
+		t.Setenv("BEADS_DOLT_PORT", "")
+
+		if shouldPersistResolvedPortFile() {
+			t.Fatal("expected BEADS_DOLT_SERVER_PORT to suppress port file persistence")
+		}
+	})
+
+	t.Run("legacy orchestrator port is runtime override only", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+		t.Setenv("BEADS_DOLT_PORT", "15433")
+
+		if shouldPersistResolvedPortFile() {
+			t.Fatal("expected BEADS_DOLT_PORT to suppress port file persistence")
+		}
+	})
+}
+
 // TestApplyConfigDefaults_SocketFromEnv verifies that BEADS_DOLT_SERVER_SOCKET
 // populates ServerSocket when not already set.
 func TestApplyConfigDefaults_SocketFromEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

- avoid persisting environment-supplied managed Dolt ports into the repo-local port file
- add `bd doctor` detection for standalone-to-managed-city handoff port conflicts
- document the recovery path in `docs/DOLT.md`

## Why

When an existing standalone `.beads/dolt-server.port` meets a managed-city `DOLT_SERVER_PORT`, silently rewriting or trusting the wrong port can strand users between two Dolt servers. The conservative behavior is to avoid persisting the managed environment port into repo-local state and have doctor surface the handoff conflict with a clear recovery path.

Refs #3926.

## Validation

- `go test -tags gms_pure_go ./internal/storage/dolt -run 'TestShouldPersistResolvedPortFile|TestApplyConfigDefaults' -count=1`
- `go test -tags gms_pure_go ./cmd/bd/doctor -run 'TestCheckManagedHandoffPort' -count=1`
- `go test -tags gms_pure_go ./cmd/bd -run '^$' -count=1`

_codex-gpt-5.5-medium on behalf of matt wilkie_
