### PR TITLE
test(auto-import): model concurrent writer guard

### DIFF
--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -95,26 +95,34 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenNonEmpty(t *testing.T) {
 	}
 }
 
-// TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenConcurrentWriterWinsRace
-// models the #3948 hazard where a separate Dolt writer commits data while a bd
-// process with stale issues.jsonl is deciding whether auto-import should run.
+// TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsReportNonEmptyLate
+// asserts the top-level emptiness guard still fires when GetStatistics returns
+// late (e.g. blocked on a busy store) rather than instantly. It is a timing
+// variant of SkipsWhenNonEmpty: GetStatistics ultimately reports a populated
+// store, so the fallback UPSERT path must not run.
 //
-// The fallback path is the important branch here: embedded stores have an
-// additional in-transaction guard, but fallbackImporter is an UPSERT path that
-// can re-impose stale JSONL over live rows if the top-level guard is removed.
-func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenConcurrentWriterWinsRace(t *testing.T) {
+// Scope note — this does NOT cover the gastownhall/beads#3948 root cause. #3948
+// is the case where GetStatistics wrongly returns TotalIssues=0 on a populated
+// DB (a count/transaction-isolation defect), which defeats the guard entirely;
+// the dangerous fallback TOCTOU is empty-at-check -> concurrent writer commits
+// -> UPSERT clobbers the new rows. This test feeds a *correct* non-empty count,
+// so it exercises the happy path of the guard, not that hazard. The #3948 root
+// cause is tracked separately (mybd-w02o); maybeAutoImportJSONL makes a single
+// synchronous GetStatistics call, so there is no second observation point a
+// writer could race against at this layer.
+func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenStatisticsReportNonEmptyLate(t *testing.T) {
 	dir := t.TempDir()
 	writeAutoImportFixtureJSONL(t, dir)
 	count := swapFallbackImporter(t, errors.New("test importer should not run"))
 
 	statsCalled := make(chan struct{})
-	writerCommitted := make(chan struct{})
+	statsUnblocked := make(chan struct{})
 
 	store := &fakeFallbackStore{
 		getStatistics: func(ctx context.Context) (*types.Statistics, error) {
 			close(statsCalled)
 			select {
-			case <-writerCommitted:
+			case <-statsUnblocked:
 				return &types.Statistics{TotalIssues: 1}, nil
 			case <-ctx.Done():
 				return nil, ctx.Err()
@@ -137,9 +145,8 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenConcurrentWriterWinsRace
 		t.Fatal("auto-import did not check store statistics before considering fallback import")
 	}
 
-	// Simulate a concurrent Dolt write becoming visible before auto-import's
-	// emptiness decision returns.
-	close(writerCommitted)
+	// Release the delayed GetStatistics so it reports a populated store.
+	close(statsUnblocked)
 
 	select {
 	case <-done:
@@ -148,7 +155,7 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenConcurrentWriterWinsRace
 	}
 
 	if got := count.Load(); got != 0 {
-		t.Fatalf("regression: fallback importer was invoked %d time(s) after a concurrent writer populated the store; expected 0", got)
+		t.Fatalf("regression: fallback importer was invoked %d time(s) after statistics reported a non-empty store; expected 0", got)
 	}
 }
 

--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -24,9 +25,13 @@ type fakeFallbackStore struct {
 	storage.DoltStorage // nil — panics on any non-overridden method
 	statsTotalIssues    int
 	statsNil            bool
+	getStatistics       func(context.Context) (*types.Statistics, error)
 }
 
-func (f *fakeFallbackStore) GetStatistics(_ context.Context) (*types.Statistics, error) {
+func (f *fakeFallbackStore) GetStatistics(ctx context.Context) (*types.Statistics, error) {
+	if f.getStatistics != nil {
+		return f.getStatistics(ctx)
+	}
 	if f.statsNil {
 		return nil, nil
 	}
@@ -87,6 +92,63 @@ func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenNonEmpty(t *testing.T) {
 
 	if got := count.Load(); got != 0 {
 		t.Fatalf("regression: fallback importer was invoked %d time(s) on a non-empty store; expected 0 (top-level emptiness guard missing or broken)", got)
+	}
+}
+
+// TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenConcurrentWriterWinsRace
+// models the #3948 hazard where a separate Dolt writer commits data while a bd
+// process with stale issues.jsonl is deciding whether auto-import should run.
+//
+// The fallback path is the important branch here: embedded stores have an
+// additional in-transaction guard, but fallbackImporter is an UPSERT path that
+// can re-impose stale JSONL over live rows if the top-level guard is removed.
+func TestMaybeAutoImportJSONL_FallbackImporter_SkipsWhenConcurrentWriterWinsRace(t *testing.T) {
+	dir := t.TempDir()
+	writeAutoImportFixtureJSONL(t, dir)
+	count := swapFallbackImporter(t, errors.New("test importer should not run"))
+
+	statsCalled := make(chan struct{})
+	writerCommitted := make(chan struct{})
+
+	store := &fakeFallbackStore{
+		getStatistics: func(ctx context.Context) (*types.Statistics, error) {
+			close(statsCalled)
+			select {
+			case <-writerCommitted:
+				return &types.Statistics{TotalIssues: 1}, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		maybeAutoImportJSONL(ctx, store, dir)
+	}()
+
+	select {
+	case <-statsCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("auto-import did not check store statistics before considering fallback import")
+	}
+
+	// Simulate a concurrent Dolt write becoming visible before auto-import's
+	// emptiness decision returns.
+	close(writerCommitted)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("auto-import did not return after statistics reported a non-empty store")
+	}
+
+	if got := count.Load(); got != 0 {
+		t.Fatalf("regression: fallback importer was invoked %d time(s) after a concurrent writer populated the store; expected 0", got)
 	}
 }
 


### PR DESCRIPTION
## What

- Adds a focused fallback auto-import test exercising the top-level emptiness guard.
- `SkipsWhenStatisticsReportNonEmptyLate`: asserts the guard still fires when `GetStatistics` returns late (blocked on a busy store) rather than instantly — a timing variant of the existing `SkipsWhenNonEmpty`.
- Asserts the destructive fallback importer is not invoked once statistics report a populated store.

## Why

This hardens the guardrail restored in #3691 against a future refactor that might make the guard's correctness timing-dependent. Current `main` already contains #3691, but the release drift around v1.0.4 and #3870 motivated extra coverage on this path.

## Scope / correction

An earlier revision of this PR named the test `...SkipsWhenConcurrentWriterWinsRace` and described it as covering the #3948 hazard. That was an overclaim and has been corrected:

- `maybeAutoImportJSONL` makes a **single synchronous `GetStatistics` call**, so there is no second observation point a concurrent writer could race against at this layer. The goroutine/channel choreography only delays that one call's return; with a correct non-empty count it is behaviorally a timing variant of `SkipsWhenNonEmpty`, not a race model.
- #3948's actual root cause is the opposite interleaving: `GetStatistics` wrongly returning `TotalIssues=0` on a populated DB (a count / transaction-isolation defect), which defeats the guard entirely; the dangerous fallback TOCTOU is empty-at-check → concurrent writer commits → UPSERT clobbers the new rows. **This PR does not cover that** — it feeds a correct non-empty count and exercises the happy path of the guard.

The #3948 root cause is tracked separately and remains open; #3870 (cut v1.0.5 with #3691) is the higher-leverage release item for anyone currently on v1.0.4.

## Verification

- `go test -tags gms_pure_go ./cmd/bd -run 'TestMaybeAutoImportJSONL|TestShouldRunAutoImportJSONL' -count=1`
- `BEADS_TEST_EMBEDDED_DOLT=1 go test -tags gms_pure_go ./cmd/bd -run 'TestEmbeddedAutoImportJSONL|TestMaybeAutoImportJSONL|TestShouldRunAutoImportJSONL' -count=1`
- `git diff --check`

_codex-gpt-5.5-medium on behalf of maphew_ (original)
_claude-opus-4-8-high on behalf of maphew_ (scope correction)
