### PR TITLE
test: improve coverage signal policy

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,12 +18,14 @@ coverage:
       default:
         target: auto
         threshold: 5%
+        informational: true
 
     # Patch coverage (for new code in PRs)
     patch:
       default:
         target: 60%
         threshold: 10%
+        informational: true
 
 # Component management for domain-based coverage views
 # Components are purely configuration-driven — no upload-time setup needed

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -194,6 +194,18 @@ the command documented in the failing workflow or in the CI cleanup plan.
 Use `scripts/test.sh` for local default validation and targeted development
 runs.
 
+### Coverage Signal Policy
+
+PR confidence is based on behavior checks, not raw coverage percentage.
+
+- Treat Codecov percentages as informational trend data.
+- Prefer focused tests for risky paths (storage, sync/git, migrations, state
+  transitions, and corruption/integrity handling) over broad line-coverage
+  churn.
+- Add or extend at least one targeted regression test when fixing risky logic.
+- Do not block a change solely on overall coverage movement when behavioral
+  checks are strong.
+
 For the current CI/test-surface inventory and cleanup roadmap, see
 [CI_TEST_SURFACE_AUDIT.md](CI_TEST_SURFACE_AUDIT.md). That audit documents
 where local commands and GitHub Actions currently diverge before the CI cleanup

--- a/internal/storage/dolt/pr4107_corruption_test.go
+++ b/internal/storage/dolt/pr4107_corruption_test.go
@@ -271,6 +271,27 @@ func TestPR4107DeleteRecomputesWispWaitersWhenSpawnerChildIsDeleted(t *testing.T
 	assertIsBlocked(t, ctx, store, "wisps", "pr4107-delete-wisp-waiter", false)
 }
 
+func TestPR4107DeleteRecomputesWispWaitersWhenSpawnerIsDeleted(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	createNoHistoryWisp(t, ctx, store, "pr4107-delete-wisp-spawner-waiter")
+	createPerm(t, ctx, store, "pr4107-delete-wisp-spawner-target")
+	createNoHistoryWisp(t, ctx, store, "pr4107-delete-wisp-spawner-child")
+	addDependency(t, ctx, store, "pr4107-delete-wisp-spawner-child", "pr4107-delete-wisp-spawner-target", types.DepParentChild)
+	addDependency(t, ctx, store, "pr4107-delete-wisp-spawner-waiter", "pr4107-delete-wisp-spawner-target", types.DepWaitsFor)
+
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-delete-wisp-spawner-waiter", true)
+
+	if err := store.DeleteIssue(ctx, "pr4107-delete-wisp-spawner-target"); err != nil {
+		t.Fatalf("DeleteIssue wisp spawner target: %v", err)
+	}
+	assertIsBlocked(t, ctx, store, "wisps", "pr4107-delete-wisp-spawner-waiter", false)
+}
+
 func TestPR4107JSONCountReadPathsTolerateMissingWispTables(t *testing.T) {
 	t.Run("query_counts", func(t *testing.T) {
 		store, cleanup := setupTestStore(t)


### PR DESCRIPTION
## What

- Makes Codecov project and patch statuses informational.
- Documents a coverage signal policy that prioritizes behavior confidence over raw percentage.
- Adds a focused high-risk regression test for blocked-state recomputation when a mixed issue/wisp spawner is deleted.

## Why

The current coverage signal can over-emphasize raw percentage even though Beads confidence depends more on risky-path behavior tests. This keeps Codecov useful for trend visibility while making storage, sync, migration, and state-integrity regressions the expected testing focus.

## Verification

- `go test ./internal/storage/dolt -run TestPR4107DeleteRecomputesWispWaitersWhenSpawnerIsDeleted -count=1`
- `git diff --check`

_codex-gpt-5.5-medium on behalf of maphew_
