### PR TITLE
docs: add conservative Beads agent profile

### DIFF
--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -243,6 +243,12 @@ var isEphemeralBranch = func() bool {
 	return cmd.Run() != nil
 }
 
+// primeNoPushConfigured reports whether the "no-push" config flag is set
+// (stubbable for tests).
+var primeNoPushConfigured = func() bool {
+	return config.GetBool("no-push")
+}
+
 // primeHasGitRemote detects if any git remote is configured (stubbable for tests)
 var primeHasGitRemote = func() bool {
 	rc, err := internalbeads.GetRepoContext()
@@ -404,7 +410,7 @@ func maybePullStaleLinearData(beadsDir string) {
 // outputMCPContext outputs minimal context for MCP users
 func outputMCPContext(w io.Writer, stealthMode bool) error {
 	ephemeral := isEphemeralBranch()
-	noPush := config.GetBool("no-push")
+	noPush := primeNoPushConfigured()
 	localOnly := !primeHasGitRemote()
 
 	var closeProtocol string
@@ -420,8 +426,8 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks; report git status and proposed handoff (push disabled)"
 		profileRule = "Profile model: conservative by default; push only with explicit user/orchestrator authority"
 	} else {
-		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks; follow active profile: conservative reports handoff, team-maintainer may commit/sync/push when explicitly enabled"
-		profileRule = "Profile model: conservative/minimal do not commit or push without approval; team-maintainer is opt-in and still subordinate to user/orchestrator instructions"
+		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks. Then follow the active profile — conservative reports handoff; team-maintainer may commit/sync/push when explicitly enabled."
+		profileRule = "Default: do not commit, push, or run dolt remote sync without explicit authority. Team-maintainer behavior is opt-in and still subordinate to user/orchestrator instructions."
 	}
 
 	redirectNotice := getRedirectNotice(false)
@@ -456,7 +462,7 @@ Start: Check ` + "`ready`" + ` tool for available work.
 // outputCLIContext outputs full CLI reference for non-MCP users
 func outputCLIContext(w io.Writer, stealthMode bool) error {
 	ephemeral := isEphemeralBranch()
-	noPush := config.GetBool("no-push")
+	noPush := primeNoPushConfigured()
 	localOnly := !primeHasGitRemote()
 
 	var closeProtocol string
@@ -541,7 +547,7 @@ git status                  # Check changed files
 # git push
 ` + "```"
 		gitWorkflowRule = "Git workflow: conservative by default; commit/push only with explicit user/orchestrator or team-maintainer authority"
-		profileRule = "Profile model: conservative/minimal do not commit or push without approval; team-maintainer is opt-in and still subordinate to user/orchestrator instructions"
+		profileRule = "Default: do not commit, push, or run dolt remote sync without explicit authority. Team-maintainer behavior is opt-in and still subordinate to user/orchestrator instructions."
 	}
 
 	redirectNotice := getRedirectNotice(true)

--- a/cmd/bd/prime.go
+++ b/cmd/bd/prime.go
@@ -408,15 +408,20 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 	localOnly := !primeHasGitRemote()
 
 	var closeProtocol string
+	var profileRule string
 	if stealthMode || localOnly {
 		// Stealth mode or local-only: close issues, no git operations
 		closeProtocol = "Before saying \"done\": bd close <completed-ids>"
+		profileRule = "Git authority: no git operations in this context"
 	} else if ephemeral {
-		closeProtocol = "Before saying \"done\": git status → git add → git commit (no push - ephemeral branch)"
+		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks; report git status and proposed handoff (no push - ephemeral branch)"
+		profileRule = "Profile model: conservative by default; commit only with explicit user/orchestrator authority"
 	} else if noPush {
-		closeProtocol = "Before saying \"done\": git status → git add → git commit (push disabled - run git push manually)"
+		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks; report git status and proposed handoff (push disabled)"
+		profileRule = "Profile model: conservative by default; push only with explicit user/orchestrator authority"
 	} else {
-		closeProtocol = "Before saying \"done\": git status → git add → git commit → git push"
+		closeProtocol = "Before saying \"done\": bd close <completed-ids>; run checks; follow active profile: conservative reports handoff, team-maintainer may commit/sync/push when explicitly enabled"
+		profileRule = "Profile model: conservative/minimal do not commit or push without approval; team-maintainer is opt-in and still subordinate to user/orchestrator instructions"
 	}
 
 	redirectNotice := getRedirectNotice(false)
@@ -439,6 +444,7 @@ func outputMCPContext(w io.Writer, stealthMode bool) error {
 - **Workflow**: Create beads issue BEFORE writing code, mark in_progress when starting
 - **Memory**: Use ` + "`bd remember`" + ` for persistent knowledge. Do NOT use MEMORY.md files.
 - Persistence you don't need beats lost context
+- ` + profileRule + `
 
 Start: Check ` + "`ready`" + ` tool for available work.
 `
@@ -458,6 +464,7 @@ func outputCLIContext(w io.Writer, stealthMode bool) error {
 	var syncSection string
 	var completingWorkflow string
 	var gitWorkflowRule string
+	var profileRule string
 
 	if stealthMode || localOnly {
 		// Stealth mode or local-only: close issues, no git operations
@@ -475,12 +482,13 @@ bd close <id1> <id2> ...    # Close all completed issues at once
 		} else {
 			gitWorkflowRule = "Git workflow: stealth mode (no git ops)"
 		}
+		profileRule = "Git authority: no git operations in this context"
 	} else if ephemeral {
-		closeProtocol = `[ ] 1. git status              (check what changed)
-[ ] 2. git add <files>         (stage code changes)
-[ ] 3. bd dolt pull            (pull beads updates from main)
-[ ] 4. git commit -m "..."     (commit code changes)`
-		closeNote = "**Note:** This is an ephemeral branch (no upstream). Code is merged to main locally, not pushed."
+		closeProtocol = `[ ] 1. bd close <id1> <id2> ...   (close completed issues)
+[ ] 2. run quality gates        (tests, linters, builds when relevant)
+[ ] 3. git status               (check what changed)
+[ ] 4. report handoff           (changed files, validation, proposed commit if authorized)`
+		closeNote = "**Note:** This is an ephemeral branch (no upstream). Do not push it unless the user or orchestrator explicitly says to."
 		syncSection = `### Sync & Collaboration
 - ` + "`bd dolt pull`" + ` - Pull beads updates from Dolt remote
 - ` + "`bd dolt push`" + ` - Push beads to Dolt remote
@@ -489,16 +497,17 @@ bd close <id1> <id2> ...    # Close all completed issues at once
 ` + "```bash" + `
 bd close <id1> <id2> ...    # Close all completed issues at once
 bd dolt pull                # Pull latest beads from main
-git add . && git commit -m "..."  # Commit your changes
-# Merge to main when ready (local merge, not push)
+git status                  # Report changed files and proposed commit; wait for authority
+# Merge to main locally only when the active instructions grant that authority
 ` + "```"
-		gitWorkflowRule = "Git workflow: run `bd dolt pull` at session start"
+		gitWorkflowRule = "Git workflow: conservative by default on ephemeral branches"
+		profileRule = "Profile model: conservative/minimal report handoff; team-maintainer may commit only when explicitly enabled"
 	} else if noPush {
-		closeProtocol = `[ ] 1. git status              (check what changed)
-[ ] 2. git add <files>         (stage code changes)
-[ ] 3. git commit -m "..."     (commit code)
-[ ] 4. git push                (push when ready)`
-		closeNote = "**Note:** Push disabled via config. Run `git push` manually when ready."
+		closeProtocol = `[ ] 1. bd close <id1> <id2> ...   (close completed issues)
+[ ] 2. run quality gates        (tests, linters, builds when relevant)
+[ ] 3. git status               (check what changed)
+[ ] 4. report handoff           (push disabled; wait for explicit authority)`
+		closeNote = "**Note:** Push disabled via config. Do not push unless the user or orchestrator explicitly says to."
 		syncSection = `### Sync & Collaboration
 - ` + "`bd dolt push`" + ` - Push beads to Dolt remote
 - ` + "`bd dolt pull`" + ` - Pull beads from Dolt remote
@@ -506,16 +515,17 @@ git add . && git commit -m "..."  # Commit your changes
 		completingWorkflow = `**Completing work:**
 ` + "```bash" + `
 bd close <id1> <id2> ...    # Close all completed issues at once
-git add . && git commit -m "..."  # Commit code changes
-# git push                  # Run manually when ready
+git status                  # Report changed files and proposed commands
+# Do not push unless current instructions explicitly allow it
 ` + "```"
-		gitWorkflowRule = "Git workflow: beads auto-commit to Dolt (push disabled)"
+		gitWorkflowRule = "Git workflow: push disabled; report handoff unless explicitly authorized"
+		profileRule = "Profile model: conservative/minimal report handoff; team-maintainer still respects no-push/user instructions"
 	} else {
-		closeProtocol = `[ ] 1. git status              (check what changed)
-[ ] 2. git add <files>         (stage code changes)
-[ ] 3. git commit -m "..."     (commit code)
-[ ] 4. git push                (push to remote)`
-		closeNote = "**NEVER skip this.** Work is not done until pushed."
+		closeProtocol = `[ ] 1. bd close <id1> <id2> ...   (close completed issues)
+[ ] 2. run quality gates        (tests, linters, builds when relevant)
+[ ] 3. git status               (check what changed)
+[ ] 4. follow active profile    (conservative: report handoff; team-maintainer: commit/sync/push if enabled)`
+		closeNote = "**Policy:** Conservative is the default. Commit, sync, or push only when the active user, orchestrator, or repository profile grants that authority."
 		syncSection = `### Sync & Collaboration
 - ` + "`bd dolt push`" + ` - Push beads to Dolt remote
 - ` + "`bd dolt pull`" + ` - Pull beads from Dolt remote
@@ -523,10 +533,15 @@ git add . && git commit -m "..."  # Commit code changes
 		completingWorkflow = `**Completing work:**
 ` + "```bash" + `
 bd close <id1> <id2> ...    # Close all completed issues at once
-git add . && git commit -m "..."  # Commit code changes
-git push                    # Push to remote
+git status                  # Check changed files
+# Conservative/minimal/default: report status and proposed commands; wait for approval
+# Team-maintainer opt-in only, unless current instructions forbid it:
+# git add . && git commit -m "..."
+# bd dolt push
+# git push
 ` + "```"
-		gitWorkflowRule = "Git workflow: beads auto-commit to Dolt, run `git push` at session end"
+		gitWorkflowRule = "Git workflow: conservative by default; commit/push only with explicit user/orchestrator or team-maintainer authority"
+		profileRule = "Profile model: conservative/minimal do not commit or push without approval; team-maintainer is opt-in and still subordinate to user/orchestrator instructions"
 	}
 
 	redirectNotice := getRedirectNotice(true)
@@ -558,6 +573,7 @@ git push                    # Push to remote
 - **Workflow**: Create beads issue BEFORE writing code, mark in_progress when starting
 - **Memory**: Use ` + "`bd remember \"insight\"`" + ` for persistent knowledge across sessions. Do NOT use MEMORY.md files — they fragment across accounts. Search with ` + "`bd memories <keyword>`" + `.
 - Persistence you don't need beats lost context
+- ` + profileRule + `
 - ` + gitWorkflowRule + `
 - Session management: check ` + "`bd ready`" + ` for available work
 

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -16,6 +16,7 @@ func TestOutputContextFunction(t *testing.T) {
 		stealthMode   bool
 		ephemeralMode bool
 		localOnlyMode bool
+		noPushMode    bool
 		expectText    []string
 		rejectText    []string
 	}{
@@ -25,7 +26,7 @@ func TestOutputContextFunction(t *testing.T) {
 			stealthMode:   false,
 			ephemeralMode: false,
 			localOnlyMode: false,
-			expectText:    []string{"Beads Workflow Context", "bd dolt push", "team-maintainer", "conservative by default"},
+			expectText:    []string{"Beads Workflow Context", "bd dolt push", "Team-maintainer behavior is opt-in", "conservative by default"},
 			rejectText:    []string{"bd export", "--from-main"},
 		},
 		{
@@ -36,6 +37,16 @@ func TestOutputContextFunction(t *testing.T) {
 			localOnlyMode: false,
 			expectText:    []string{"Beads Workflow Context", "bd dolt pull", "ephemeral branch"},
 			rejectText:    []string{"bd export", "git push", "--from-main"},
+		},
+		{
+			name:          "CLI no-push",
+			mcpMode:       false,
+			stealthMode:   false,
+			ephemeralMode: false,
+			localOnlyMode: false,
+			noPushMode:    true,
+			expectText:    []string{"Beads Workflow Context", "push disabled", "report handoff"},
+			rejectText:    []string{"bd export", "--from-main"},
 		},
 		{
 			name:          "CLI Stealth",
@@ -79,7 +90,7 @@ func TestOutputContextFunction(t *testing.T) {
 			stealthMode:   false,
 			ephemeralMode: false,
 			localOnlyMode: false,
-			expectText:    []string{"Beads Issue Tracker Active", "team-maintainer", "conservative/minimal"},
+			expectText:    []string{"Beads Issue Tracker Active", "Team-maintainer behavior is opt-in"},
 			rejectText:    []string{"bd export", "--from-main"},
 		},
 		{
@@ -90,6 +101,16 @@ func TestOutputContextFunction(t *testing.T) {
 			localOnlyMode: false,
 			expectText:    []string{"Beads Issue Tracker Active", "ephemeral branch"},
 			rejectText:    []string{"bd export", "git push", "--from-main"},
+		},
+		{
+			name:          "MCP no-push",
+			mcpMode:       true,
+			stealthMode:   false,
+			ephemeralMode: false,
+			localOnlyMode: false,
+			noPushMode:    true,
+			expectText:    []string{"Beads Issue Tracker Active", "push disabled"},
+			rejectText:    []string{"bd export", "--from-main"},
 		},
 		{
 			name:          "MCP Stealth",
@@ -133,6 +154,7 @@ func TestOutputContextFunction(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			defer stubIsEphemeralBranch(tt.ephemeralMode)()
 			defer stubPrimeHasGitRemote(!tt.localOnlyMode)() // localOnly = !primeHasGitRemote
+			defer stubPrimeNoPushConfigured(tt.noPushMode)()
 
 			var buf bytes.Buffer
 			err := outputPrimeContext(&buf, tt.mcpMode, tt.stealthMode)
@@ -254,6 +276,18 @@ func stubPrimeHasGitRemote(hasRemote bool) func() {
 	}
 	return func() {
 		primeHasGitRemote = original
+	}
+}
+
+// stubPrimeNoPushConfigured temporarily replaces primeNoPushConfigured
+// with a stub returning noPush.
+func stubPrimeNoPushConfigured(noPush bool) func() {
+	original := primeNoPushConfigured
+	primeNoPushConfigured = func() bool {
+		return noPush
+	}
+	return func() {
+		primeNoPushConfigured = original
 	}
 }
 

--- a/cmd/bd/prime_test.go
+++ b/cmd/bd/prime_test.go
@@ -25,7 +25,7 @@ func TestOutputContextFunction(t *testing.T) {
 			stealthMode:   false,
 			ephemeralMode: false,
 			localOnlyMode: false,
-			expectText:    []string{"Beads Workflow Context", "bd dolt push", "git push"},
+			expectText:    []string{"Beads Workflow Context", "bd dolt push", "team-maintainer", "conservative by default"},
 			rejectText:    []string{"bd export", "--from-main"},
 		},
 		{
@@ -79,7 +79,7 @@ func TestOutputContextFunction(t *testing.T) {
 			stealthMode:   false,
 			ephemeralMode: false,
 			localOnlyMode: false,
-			expectText:    []string{"Beads Issue Tracker Active", "git push"},
+			expectText:    []string{"Beads Issue Tracker Active", "team-maintainer", "conservative/minimal"},
 			rejectText:    []string{"bd export", "--from-main"},
 		},
 		{

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -16,7 +16,7 @@ The `bd setup` command uses a **recipe-based architecture** to configure beads i
 
 `bd prime` is the **single source of truth** for operational workflow commands. The beads section in each tool's instruction file provides a pointer to `bd prime` for hook-enabled agents (Claude, Gemini) or the full command reference for AGENTS-first agents (Factory, Mux). Codex uses a Beads skill, generated `AGENTS.md` guidance, and native Codex hooks.
 
-### Profiles
+### Template Profiles
 
 Each integration uses one of two **profiles** that control how much content is written to tool instruction files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or `.github/copilot-instructions.md`):
 
@@ -28,6 +28,18 @@ Each integration uses one of two **profiles** that control how much content is w
 Hook-enabled agents (Claude, Copilot CLI, Gemini) use the `minimal` profile because `bd prime` injects full context at session start. AGENTS-first agents use the `full` profile because their instruction file remains the primary integration surface. Skill-aware agents use `.agents/skills/beads/SKILL.md`, with project `AGENTS.md` or global `$CODEX_HOME/AGENTS.md`/`~/.codex/AGENTS.md` telling Codex when to use the skill.
 
 **Profile precedence:** If a file already has a `full` profile section and a `minimal` profile tool installs to the same file (e.g., via symlinks), the `full` profile is preserved to avoid information loss.
+
+### Policy Profiles
+
+Template profiles control how much text gets installed. Policy profiles control what an agent is authorized to do at handoff:
+
+| Policy | Default Scope | Commit/Push Guidance |
+|--------|---------------|----------------------|
+| `conservative` | Standalone projects, unknown projects, and one-off assistance | Use `bd` for task tracking, then report changed files, validation, and proposed commands. Do not commit, push, or run Dolt remote sync without explicit user or orchestrator approval. |
+| `minimal` | Hook-first integrations where `bd prime` carries the detailed workflow | Same git authority as conservative; the installed file stays short and points to `bd prime`. |
+| `team-maintainer` | Repositories that explicitly delegate session close to agents | Agents may close beads, run quality gates, commit, run `bd dolt push`, and `git push` only when repository/user/orchestrator instructions grant that authority. Current "do not commit" or "do not push" instructions override the profile. |
+
+The generated Beads block and `bd prime` default to conservative git authority. Projects that want team-maintainer behavior should say so in their own top-level instructions; Beads does not infer that authority merely because a remote exists.
 
 ### Built-in Recipes
 
@@ -143,7 +155,7 @@ Factory Droid and other AGENTS.md-compatible tools automatically read `AGENTS.md
 The beads section teaches AI agents:
 - To use `bd ready` for finding work
 - To use `bd create` for tracking new issues
-- To use `bd dolt push` at session end
+- To treat commit, push, and Dolt remote sync as policy-controlled handoff actions
 - The complete workflow pattern and best practices
 
 ### Updating Existing AGENTS.md
@@ -411,7 +423,7 @@ bd setup cursor --remove
 Cursor reads `.cursor/rules/*.mdc` files and includes them in the AI's context. The beads rules file teaches the AI:
 - To use `bd ready` for finding work
 - To use `bd create` for tracking new issues
-- To use `bd dolt push` at session end
+- To treat commit, push, and Dolt remote sync as policy-controlled handoff actions
 - The basic workflow pattern
 
 ## Aider

--- a/internal/recipes/template.go
+++ b/internal/recipes/template.go
@@ -6,7 +6,7 @@ import "fmt"
 // This content is written to all file-based recipes.
 const Template = `# Beads Issue Tracking
 
-This project uses [Beads (bd)](https://github.com/steveyegge/beads) for issue tracking.
+This project uses [Beads (bd)](https://github.com/gastownhall/beads) for issue tracking.
 
 ## Core Rules
 

--- a/internal/recipes/template.go
+++ b/internal/recipes/template.go
@@ -13,8 +13,9 @@ This project uses [Beads (bd)](https://github.com/steveyegge/beads) for issue tr
 - Track ALL work in bd (never use markdown TODOs or comment-based task lists)
 - Use ` + "`bd ready`" + ` to find available work
 - Use ` + "`bd create`" + ` to track new issues/tasks/bugs
-- Use ` + "`bd dolt push`" + ` at end of session to sync with remote
+- Treat commit, push, and Dolt remote sync as policy-controlled handoff actions
 - Run ` + "`bd prime`" + ` for complete workflow context (SSOT for operational commands)
+- Default to conservative git authority: report status and proposed commands unless the user, orchestrator, or repository profile explicitly authorizes commit/sync/push
 
 ## Quick Reference
 
@@ -26,7 +27,7 @@ bd create "title" -t task -p 2        # Create new issue
 bd update <id> --claim                # Claim work atomically
 bd close <id>                         # Mark complete
 bd dep add <issue> <depends-on>       # Add dependency
-bd dolt push                          # Sync with remote
+bd dolt push                          # Sync with remote when authorized
 ` + "```" + `
 
 ## Workflow
@@ -35,7 +36,7 @@ bd dolt push                          # Sync with remote
 2. Claim an issue atomically: ` + "`bd update <id> --claim`" + `
 3. Do the work
 4. Mark complete: ` + "`bd close <id>`" + `
-5. Push changes: ` + "`bd dolt push`" + `
+5. Handoff: report changed files, validation, issue status, and any proposed commit/sync/push commands
 
 ## Issue Types
 
@@ -73,7 +74,8 @@ This repository uses **Beads (bd)** for issue tracking.
 - Use ` + "`bd create`" + ` to track new work
 - Use ` + "`bd update <id> --claim`" + ` before starting
 - Use ` + "`bd close <id>`" + ` when work is complete
-- Use ` + "`bd dolt push`" + ` at the end of the session
+- Treat commit, push, and Dolt remote sync as policy-controlled handoff actions
+- Do not commit, push, or run Dolt remote sync unless explicitly authorized
 
 ## Context Loading
 

--- a/internal/templates/agents/defaults/agents.md.tmpl
+++ b/internal/templates/agents/defaults/agents.md.tmpl
@@ -47,7 +47,7 @@ cp -rf source dest          # NOT: cp -r source dest
 - `apt-get` - use `-y` flag
 - `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
 
-<!-- BEGIN BEADS INTEGRATION profile:full hash:d4f96305 -->
+<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:b3c584c2 -->
 ## Issue Tracking with bd (beads)
 
 **IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
@@ -112,13 +112,13 @@ bd close bd-42 --reason "Completed" --json
    - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
 5. **Complete**: `bd close <id> --reason "Done"`
 
-### Auto-Sync
+### Sync
 
-bd automatically syncs via Dolt:
+bd stores issue history in Dolt:
 
 - Each write auto-commits to Dolt history
 - Use `bd dolt push`/`bd dolt pull` for remote sync
-- No manual export/import needed!
+- Do not treat `.beads/issues.jsonl` as the sync protocol
 
 ### Important Rules
 
@@ -132,30 +132,37 @@ bd automatically syncs via Dolt:
 
 For more details, see README.md and docs/QUICKSTART.md.
 
+## Agent Context Profiles
+
+The managed Beads block is task-tracking guidance, not permission to override repository, user, or orchestrator instructions.
+
+- **Conservative (default)**: Use `bd` for task tracking. Do not run git commits, git pushes, or Dolt remote sync unless explicitly asked. At handoff, report changed files, validation, and suggested next commands.
+- **Minimal**: Keep tool instruction files as pointers to `bd prime`; use the same conservative git policy unless active instructions say otherwise.
+- **Team-maintainer**: Only when the repository explicitly opts in, agents may close beads, run quality gates, commit, and push as part of session close. A current "do not commit" or "do not push" instruction still wins.
+
 ## Session Completion
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+This protocol applies when ending a Beads implementation workflow. It is subordinate to explicit user, repository, and orchestrator instructions.
 
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Create beads for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
 3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+4. **Handle git/sync by active profile**:
    ```bash
+   # Conservative/minimal/default: report status and proposed commands; wait for approval.
+   git status
+
+   # Team-maintainer opt-in only, unless current instructions forbid it:
    git pull --rebase
    bd dolt push
    git push
-   git status  # MUST show "up to date with origin"
+   git status
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+5. **Hand off** - Summarize changes, validation, issue status, and any blocked sync/commit/push step
 
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
+**Critical rules:**
+- Explicit user or orchestrator instructions override this Beads block.
+- Do not commit or push without clear authority from the active profile or the current user request.
+- If a required sync or push is blocked, stop and report the exact command and error.
 
 <!-- END BEADS INTEGRATION -->

--- a/internal/templates/agents/defaults/beads-section-minimal.md
+++ b/internal/templates/agents/defaults/beads-section-minimal.md
@@ -19,28 +19,35 @@ bd close <id>         # Complete work
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
+## Agent Context Profiles
+
+The managed Beads block is task-tracking guidance, not permission to override repository, user, or orchestrator instructions.
+
+- **Conservative (default)**: Use `bd` for task tracking. Do not run git commits, git pushes, or Dolt remote sync unless explicitly asked. At handoff, report changed files, validation, and suggested next commands.
+- **Minimal**: Keep tool instruction files as pointers to `bd prime`; use the same conservative git policy unless active instructions say otherwise.
+- **Team-maintainer**: Only when the repository explicitly opts in, agents may close beads, run quality gates, commit, and push as part of session close. A current "do not commit" or "do not push" instruction still wins.
+
 ## Session Completion
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+This protocol applies when ending a Beads implementation workflow. It is subordinate to explicit user, repository, and orchestrator instructions.
 
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Create beads for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
 3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+4. **Handle git/sync by active profile**:
    ```bash
+   # Conservative/minimal/default: report status and proposed commands; wait for approval.
+   git status
+
+   # Team-maintainer opt-in only, unless current instructions forbid it:
    git pull --rebase
    bd dolt push
    git push
-   git status  # MUST show "up to date with origin"
+   git status
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+5. **Hand off** - Summarize changes, validation, issue status, and any blocked sync/commit/push step
 
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
+**Critical rules:**
+- Explicit user or orchestrator instructions override this Beads block.
+- Do not commit or push without clear authority from the active profile or the current user request.
+- If a required sync or push is blocked, stop and report the exact command and error.

--- a/internal/templates/agents/defaults/beads-section.md
+++ b/internal/templates/agents/defaults/beads-section.md
@@ -73,13 +73,13 @@ bd close bd-42 --reason "Completed" --json
 - `bd human <id>` to flag for human decisions
 - `bd formula list` / `bd mol pour <name>` for structured workflows
 
-### Auto-Sync
+### Sync
 
-bd automatically syncs via Dolt:
+bd stores issue history in Dolt:
 
 - Each write auto-commits to Dolt history
 - Use `bd dolt push`/`bd dolt pull` for remote sync
-- No manual export/import needed!
+- Do not treat `.beads/issues.jsonl` as the sync protocol
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
@@ -95,30 +95,37 @@ bd automatically syncs via Dolt:
 
 For more details, see README.md and docs/QUICKSTART.md.
 
+## Agent Context Profiles
+
+The managed Beads block is task-tracking guidance, not permission to override repository, user, or orchestrator instructions.
+
+- **Conservative (default)**: Use `bd` for task tracking. Do not run git commits, git pushes, or Dolt remote sync unless explicitly asked. At handoff, report changed files, validation, and suggested next commands.
+- **Minimal**: Keep tool instruction files as pointers to `bd prime`; use the same conservative git policy unless active instructions say otherwise.
+- **Team-maintainer**: Only when the repository explicitly opts in, agents may close beads, run quality gates, commit, and push as part of session close. A current "do not commit" or "do not push" instruction still wins.
+
 ## Session Completion
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+This protocol applies when ending a Beads implementation workflow. It is subordinate to explicit user, repository, and orchestrator instructions.
 
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Create beads for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
 3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+4. **Handle git/sync by active profile**:
    ```bash
+   # Conservative/minimal/default: report status and proposed commands; wait for approval.
+   git status
+
+   # Team-maintainer opt-in only, unless current instructions forbid it:
    git pull --rebase
    bd dolt push
    git push
-   git status  # MUST show "up to date with origin"
+   git status
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+5. **Hand off** - Summarize changes, validation, issue status, and any blocked sync/commit/push step
 
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
+**Critical rules:**
+- Explicit user or orchestrator instructions override this Beads block.
+- Do not commit or push without clear authority from the active profile or the current user request.
+- If a required sync or push is blocked, stop and report the exact command and error.
 
 <!-- END BEADS INTEGRATION -->


### PR DESCRIPTION
## What

- Defines Beads agent policy profiles: `conservative`, `minimal`, and `team-maintainer`.
- Makes conservative git authority the default in generated Beads instructions and `bd prime`.
- Updates setup docs and recipe output so commit, push, and Dolt remote sync are explicit handoff authority decisions.

## Why

#3423 asks for a standard Beads context profile, while #3451 shows the current injected guidance is too aggressive for standalone projects. This keeps team-maintainer automation available only when a repository, user, or orchestrator explicitly opts in, and makes generated instructions subordinate to active user guidance.

PR #3395 was checked for drift; it remains governance-value work but is still open, behind `main`, and not the implementation target for this profile-policy change.

## Scope note

This PR introduces the *vocabulary* of profiles and switches the default wording to conservative; it does **not** add a runtime knob (config key / env var / detection). "Team-maintainer is opt-in" currently means "edit your own AGENTS.md." The next-step runtime plumbing — so `bd prime` branches off an `agent.profile` config rather than hard-coded conservative wording — is tracked locally as a personal follow-up rather than expanded into this PR. Happy to file a public issue if that would help reviewers.

## Verification

- `go test ./internal/templates/agents`
- `go test -tags gms_pure_go ./internal/recipes ./cmd/bd/setup`
- `go test -tags gms_pure_go ./cmd/bd -run 'TestOutputContextFunction|TestPrimeClaimGuidanceUsesAtomicClaim|TestPrimeStartsWithTruncationDirective|TestPrimeContextUsesWorkspaceLanguage|TestPrime_RawMarkdown_NotJSON_WithoutFlag'`
- `git diff --check`

Plain `go test ./cmd/bd ...` was not usable on this host because local ICU headers are missing (`unicode/uregex.h`), so the project `gms_pure_go` tag was used for focused CLI tests.

## Changes in latest push

- Drop "Profile model:" prefix from the default-branch profile rule; lead with the actual instruction.
- Split the long single-sentence MCP `closeProtocol` into two sentences for readability.
- Fix the user-facing repo URL in `internal/recipes/template.go` (steveyegge/beads → gastownhall/beads). Go module imports are unchanged.
- Add `prime_test` cases that exercise the no-push branch for both CLI and MCP outputs, via a new `primeNoPushConfigured` stub seam.

_codex-gpt-5.5-medium on behalf of maphew_
_claude-opus-4-7-medium on behalf of maphew_
