### PR TITLE
Skip JSONL auto-import for external Dolt servers

### DIFF
--- a/cmd/bd/auto_import_upgrade_unit_test.go
+++ b/cmd/bd/auto_import_upgrade_unit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/steveyegge/beads/internal/config"
+	"github.com/steveyegge/beads/internal/configfile"
 	"github.com/steveyegge/beads/internal/storage"
 	"github.com/steveyegge/beads/internal/types"
 )
@@ -114,11 +115,31 @@ func TestShouldRunAutoImportJSONL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldRunAutoImportJSONL(tt.cmd, tt.store, tt.useReadOnly, tt.globalFlag, tt.serverMode)
+			got := shouldRunAutoImportJSONL(tt.cmd, tt.store, tt.useReadOnly, tt.globalFlag, tt.serverMode, "")
 			if got != tt.want {
 				t.Fatalf("shouldRunAutoImportJSONL() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestShouldRunAutoImportJSONL_SkipsResolvedExternalServer(t *testing.T) {
+	store := &fakeFallbackStore{}
+	writeCmd := &cobra.Command{Use: "update"}
+	beadsDir := t.TempDir()
+
+	metaCfg := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "10.10.10.27",
+		DoltServerUser: "beads",
+		DoltDatabase:   "HomeLab",
+	}
+	if err := metaCfg.Save(beadsDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := shouldRunAutoImportJSONL(writeCmd, store, false, false, false, beadsDir); got {
+		t.Fatal("shouldRunAutoImportJSONL() = true for resolved external server mode, want false")
 	}
 }
 

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1078,7 +1078,7 @@ var rootCmd = &cobra.Command{
 		// Skip auto-import when the user is explicitly running "bd import" —
 		// the import command handles JSONL files itself and auto-importing
 		// first would interfere (double-import / upsert confusion).
-		if shouldRunAutoImportJSONL(cmd, store, useReadOnly, globalFlag, doltCfg.ServerMode) {
+		if shouldRunAutoImportJSONL(cmd, store, useReadOnly, globalFlag, doltCfg.ServerMode, beadsDir) {
 			maybeAutoImportJSONL(rootCtx, store, beadsDir)
 		}
 
@@ -1233,8 +1233,11 @@ func shouldRunPostCommandAutoExport(cmd *cobra.Command) bool {
 	return !isReadOnlyCommand(cmd.Name())
 }
 
-func shouldRunAutoImportJSONL(cmd *cobra.Command, s storage.DoltStorage, useReadOnly, globalFlag, serverMode bool) bool {
+func shouldRunAutoImportJSONL(cmd *cobra.Command, s storage.DoltStorage, useReadOnly, globalFlag, serverMode bool, beadsDir string) bool {
 	if cmd == nil || s == nil || useReadOnly || globalFlag || serverMode {
+		return false
+	}
+	if beadsDir != "" && doltserver.ResolveServerMode(beadsDir) == doltserver.ServerModeExternal {
 		return false
 	}
 	return cmd.Name() != "import"

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1480,6 +1480,72 @@ func TestResolveServerMode_ExplicitPort(t *testing.T) {
 	}
 }
 
+func TestResolveServerMode_ServerConnectionMetadata(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	config.ResetForTesting()
+
+	dir := t.TempDir()
+	metaCfg := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "10.10.10.27",
+		DoltServerUser: "beads",
+		DoltDatabase:   "HomeLab",
+	}
+	if err := metaCfg.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	mode := ResolveServerMode(dir)
+	if mode != ServerModeExternal {
+		t.Errorf("expected ServerModeExternal with explicit server connection metadata, got %v", mode)
+	}
+}
+
+func TestResolveServerMode_PortFile(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	config.ResetForTesting()
+
+	dir := t.TempDir()
+	metaCfg := &configfile.Config{
+		DoltMode:     configfile.DoltModeServer,
+		DoltDatabase: "HomeLab",
+	}
+	if err := metaCfg.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writePortFile(dir, 3306); err != nil {
+		t.Fatal(err)
+	}
+
+	mode := ResolveServerMode(dir)
+	if mode != ServerModeExternal {
+		t.Errorf("expected ServerModeExternal with runtime port file, got %v", mode)
+	}
+}
+
+func TestResolveServerMode_LocalhostServerModeRemainsOwned(t *testing.T) {
+	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
+	t.Setenv("BEADS_DOLT_SERVER_MODE", "")
+	config.ResetForTesting()
+
+	dir := t.TempDir()
+	metaCfg := &configfile.Config{
+		DoltMode:       configfile.DoltModeServer,
+		DoltServerHost: "127.0.0.1",
+		DoltServerUser: "root",
+		DoltDatabase:   "beads",
+	}
+	if err := metaCfg.Save(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	mode := ResolveServerMode(dir)
+	if mode != ServerModeOwned {
+		t.Errorf("expected ServerModeOwned for localhost server mode without port file, got %v", mode)
+	}
+}
 func TestResolveServerMode_ServerModeEnv(t *testing.T) {
 	t.Setenv("BEADS_DOLT_SHARED_SERVER", "")
 	t.Setenv("BEADS_DOLT_SERVER_MODE", "1")

--- a/internal/doltserver/servermode.go
+++ b/internal/doltserver/servermode.go
@@ -18,8 +18,8 @@ const (
 
 	// ServerModeExternal means the user manages the server lifecycle
 	// (e.g., systemd, Docker, Hosted Dolt, VPS). Beads never starts or
-	// stops the server. Determined when metadata.json has an explicit
-	// dolt_server_port or BEADS_DOLT_SHARED_SERVER is set.
+	// stops the server. Determined when metadata.json points at an external
+	// SQL server, a runtime port file exists, or shared-server mode is set.
 	ServerModeExternal
 
 	// ServerModeEmbedded is the legacy in-process embedded dolt path.
@@ -43,13 +43,14 @@ func (m ServerMode) String() string {
 
 // ResolveServerMode determines the server mode from the given beadsDir.
 // This is the single source of truth for how the server lifecycle is managed.
-//
 // Decision logic (checked in order):
 //  1. BEADS_DOLT_SERVER_MODE=1 env var             -> ServerModeExternal
 //  2. BEADS_DOLT_SHARED_SERVER env var is set       -> ServerModeExternal
 //  3. metadata.json dolt_mode == "embedded"         -> ServerModeEmbedded
-//  4. metadata.json has explicit dolt_server_port   -> ServerModeExternal
-//  5. default                                       -> ServerModeOwned
+//  4. metadata.json dolt_mode == "server" with explicit server connection
+//  5. .beads/dolt-server.port exists                -> ServerModeExternal
+//  6. metadata.json has explicit dolt_server_port   -> ServerModeExternal
+//  7. default                                       -> ServerModeOwned
 //
 // Runtime env vars (1, 2) take precedence over persisted metadata.json
 // to prevent stale dolt_mode=embedded from silently overriding an active
@@ -86,11 +87,44 @@ func ResolveServerMode(beadsDir string) ServerMode {
 		return ServerModeEmbedded
 	}
 
-	// 4. Explicit server port in metadata.json -> external
+	// 4. Explicit external server connection in metadata.json -> external.
+	// A non-local host, socket, or deprecated metadata port means the server
+	// lifecycle is owned outside this project. Without this guard, bd may
+	// auto-start a shadow local server and run JSONL recovery against
+	// .beads/dolt instead of the configured SQL server.
+	if fileCfg != nil && strings.ToLower(fileCfg.DoltMode) == configfile.DoltModeServer {
+		if isExplicitExternalHost(fileCfg.DoltServerHost) ||
+			fileCfg.DoltServerSocket != "" || fileCfg.DoltServerPort > 0 {
+			return ServerModeExternal
+		}
+	}
+
+	// 5. Runtime port file -> external.
+	// The port file is gitignored local state written/maintained by the
+	// connection setup path. Treat it as a lifecycle boundary so CLI helpers
+	// do not spawn a different server when metadata omits the deprecated
+	// dolt_server_port field.
+	if readPortFile(beadsDir) > 0 {
+		return ServerModeExternal
+	}
+
+	// 6. Explicit server port in metadata.json -> external.
+	// Kept as a standalone fallback for older metadata that may not set
+	// dolt_mode even though it has server connection fields.
 	if fileCfg != nil && fileCfg.DoltServerPort > 0 {
 		return ServerModeExternal
 	}
 
-	// 5. Default: beads owns the server
+	// 7. Default: beads owns the server
 	return ServerModeOwned
+}
+
+func isExplicitExternalHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	switch host {
+	case "", "localhost", "127.0.0.1", "::1", "[::1]":
+		return false
+	default:
+		return true
+	}
 }


### PR DESCRIPTION
## Summary

- classify server-mode configs with an explicit external SQL host, socket, metadata port, or runtime port file as externally managed
- use the resolved server lifecycle mode as a second guard before running `issues.jsonl` auto-import
- add regression coverage for external server metadata, port-file-only server configs, and the auto-import guard

## Why

`issues.jsonl` is an export/interchange surface, not canonical storage. For direct SQL server mode, the configured Dolt SQL database is canonical. If lifecycle detection falls back to owned/local mode, CLI helpers can auto-start or inspect `.beads/dolt` and run the empty-database JSONL recovery path against a shadow local database instead of the configured server.

This showed up with a HomeLab setup using:

```json
{
  "backend": "dolt",
  "dolt_mode": "server",
  "dolt_server_host": "10.10.10.27",
  "dolt_server_user": "beads",
  "dolt_database": "HomeLab"
}
```

plus a local `.beads/dolt-server.port` of `3306`. Normal context reported server mode correctly, but commands could still emit `auto-importing ... issues.jsonl into empty database...` from the local fallback path.

## Tests

- `go test -tags gms_pure_go ./internal/doltserver ./cmd/bd`
- `env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" GOCACHE="$HOME/Library/Caches/go-build" GOPATH="$HOME/go" go test -tags gms_pure_go ./...`
- manual verification with a patched `bd` against an external server-mode HomeLab repo: `bd create --dry-run ...` no longer emits auto-import and `bd dolt status` reports `running (external)`
