### PR TITLE
test(cmd/bd): flag-to-env-var propagation gate for --ignore-schema-skew (be-0x25q)

### DIFF
--- a/cmd/bd/schema_skew_test.go
+++ b/cmd/bd/schema_skew_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/storage/schema"
 )
 
@@ -81,5 +82,31 @@ func TestIgnoreSchemaSkewFlagRegistered(t *testing.T) {
 	}
 	if f.Value.Type() != "bool" {
 		t.Errorf("--ignore-schema-skew flag type = %q, want bool", f.Value.Type())
+	}
+}
+
+// TestIgnoreSchemaSkewFlagPropagatesEnvVar verifies that PersistentPreRun
+// sets BD_IGNORE_SCHEMA_SKEW=1 when --ignore-schema-skew is true, so all
+// store-open paths see the escape hatch uniformly (not just checkSchemaSkew).
+func TestIgnoreSchemaSkewFlagPropagatesEnvVar(t *testing.T) {
+	t.Setenv("BD_IGNORE_SCHEMA_SKEW", "")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "")
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+
+	savePersistentPreRunState(t)
+	old := ignoreSchemaSkew
+	ignoreSchemaSkew = true
+	t.Cleanup(func() { ignoreSchemaSkew = old })
+
+	if rootCmd.PersistentPreRun == nil {
+		t.Fatal("rootCmd.PersistentPreRun must be set")
+	}
+	rootCmd.PersistentPreRun(versionCmd, nil)
+
+	if got := os.Getenv("BD_IGNORE_SCHEMA_SKEW"); got != "1" {
+		t.Errorf("BD_IGNORE_SCHEMA_SKEW = %q after PersistentPreRun with --ignore-schema-skew; want 1", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `TestIgnoreSchemaSkewFlagPropagatesEnvVar` to `cmd/bd/schema_skew_test.go`
- Verifies that `PersistentPreRun` sets `BD_IGNORE_SCHEMA_SKEW=1` when `--ignore-schema-skew` is true
- Closes a coverage gap identified during post-implementation verification of be-wwbsv (PR #4152)
- The existing tests in be-cdhvj cover `checkSchemaSkew()` itself; this test covers the flag→env-var propagation path that all store-open paths use

## Context

PR #4152 (feat: schema-skew guard, be-wwbsv) landed the implementation. During verification, the validator identified that the flag→env-var propagation in `PersistentPreRun` had no direct test — only the downstream `checkSchemaSkew()` behavior was covered. This commit fills that gap.

## Test plan

- [x] `go test ./cmd/bd/ -run TestIgnoreSchemaSkew -v -count=1` — both tests PASS
- [x] No live Dolt required for these unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)