### PR TITLE
fix(init): honor dolt local-only remote wiring

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -85,7 +85,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
-  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
+  bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
   bd config get export.auto
   bd config list
   bd config unset jira.url`,

--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -85,6 +85,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
+  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
   bd config get export.auto
   bd config list
   bd config unset jira.url`,

--- a/cmd/bd/config_validate_key_test.go
+++ b/cmd/bd/config_validate_key_test.go
@@ -10,6 +10,7 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		"export.auto", "dolt.auto-push", "jira.url", "custom.anything",
 		"doctor.suppress.git-hooks", "no-git-ops", "beads.role",
 		"status.custom", "ai.model", "backup.enabled", "import.path",
+		"dolt.local-only",
 	}
 	for _, key := range recognized {
 		if !isRecognizedConfigKey(key) {
@@ -24,6 +25,12 @@ func TestIsRecognizedConfigKey(t *testing.T) {
 		if isRecognizedConfigKey(key) {
 			t.Errorf("isRecognizedConfigKey(%q) = true, want false", key)
 		}
+	}
+}
+
+func TestConfigHelpMentionsDoltLocalOnly(t *testing.T) {
+	if !strings.Contains(configCmd.Long, "bd config set dolt.local-only true") {
+		t.Fatalf("config help missing dolt.local-only example:\n%s", configCmd.Long)
 	}
 }
 

--- a/cmd/bd/init.go
+++ b/cmd/bd/init.go
@@ -960,7 +960,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 		// remote even before refs/dolt/data exists; the first bd dolt push
 		// creates that ref. This keeps the default path durable without
 		// falling back to JSONL-as-sync.
-		if shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin) {
+		if shouldConfigureInitDoltRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin, isDoltLocalOnly()) {
 			configureInitDoltRemote(ctx, store, syncURL, quiet)
 		}
 
@@ -1463,7 +1463,7 @@ Non-interactive mode (--non-interactive or BD_NON_INTERACTIVE=1):
 					fmt.Printf("  Skipping %s generation in bare repository\n", resolvedAgentsFile)
 				}
 			} else {
-				renderOpts := agents.RenderOpts{HasRemote: shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin)}
+				renderOpts := agents.RenderOpts{HasRemote: shouldConfigureInitDoltRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin, isDoltLocalOnly())}
 				addAgentsInstructions(resolvedAgentsFile, !quiet, agentsTemplate, agentsProfile, renderOpts)
 			}
 		}
@@ -2122,6 +2122,14 @@ func shouldWireInitRemote(syncURL string, syncFromRemote, syncURLFromConfig, syn
 	// still keep explicit empty --remote as an opt-out because that leaves
 	// syncURL empty and syncURLFromGitOrigin false.
 	return syncURL != "" && (syncFromRemote || syncURLFromConfig || syncURLFromGitOrigin)
+}
+
+func shouldConfigureInitDoltRemote(syncURL string, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin, localOnly bool) bool {
+	return !localOnly && shouldWireInitRemote(syncURL, syncFromRemote, syncURLFromConfig, syncURLFromGitOrigin)
+}
+
+func isDoltLocalOnly() bool {
+	return config.GetBool("dolt.local-only")
 }
 
 func configureInitDoltRemote(ctx context.Context, store storage.DoltStorage, syncURL string, quiet bool) {

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/config"
 )
 
 func TestCheckRemoteSafety_GuardMatrix(t *testing.T) {
@@ -293,6 +295,44 @@ func TestLocalOnlyInitSkipsConfigureButPersistsExplicitRemote(t *testing.T) {
 	if !strings.Contains(string(data), `sync.remote: "git+ssh://git@example.com/org/project.git"`) &&
 		!strings.Contains(string(data), "sync.remote: git+ssh://git@example.com/org/project.git") {
 		t.Fatalf("sync.remote was not persisted under local-only config:\n%s", data)
+	}
+}
+
+// TestIsDoltLocalOnly covers the config-reading helper that
+// TestLocalOnlyInitSkipsConfigureButPersistsExplicitRemote bypasses by
+// passing localOnly directly. dolt.local-only maps to BD_DOLT_LOCAL_ONLY
+// through the config env-key replacer (".","-" → "_").
+func TestIsDoltLocalOnly(t *testing.T) {
+	// Cannot be parallel: mutates the global env + config singleton.
+	tests := []struct {
+		name   string
+		envVal string
+		setEnv bool
+		want   bool
+	}{
+		{name: "default off when unset", setEnv: false, want: false},
+		{name: "explicit true", envVal: "true", setEnv: true, want: true},
+		{name: "explicit false", envVal: "false", setEnv: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv("BD_DOLT_LOCAL_ONLY", tt.envVal)
+			} else {
+				os.Unsetenv("BD_DOLT_LOCAL_ONLY")
+				t.Cleanup(func() { os.Unsetenv("BD_DOLT_LOCAL_ONLY") })
+			}
+
+			config.ResetForTesting()
+			t.Cleanup(func() { config.ResetForTesting() })
+			if err := config.Initialize(); err != nil {
+				t.Fatalf("config.Initialize: %v", err)
+			}
+
+			if got := isDoltLocalOnly(); got != tt.want {
+				t.Errorf("isDoltLocalOnly() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/bd/init_safety_test.go
+++ b/cmd/bd/init_safety_test.go
@@ -213,6 +213,89 @@ func TestShouldWireInitRemote(t *testing.T) {
 	}
 }
 
+func TestShouldConfigureInitDoltRemoteHonorsLocalOnly(t *testing.T) {
+	tests := []struct {
+		name              string
+		syncURL           string
+		syncFromRemote    bool
+		syncURLFromConfig bool
+		syncURLFromGit    bool
+		localOnly         bool
+		wantConfigure     bool
+		wantWire          bool
+	}{
+		{
+			name:           "git origin configures by default",
+			syncURL:        "git+https://github.com/org/project.git",
+			syncURLFromGit: true,
+			wantConfigure:  true,
+			wantWire:       true,
+		},
+		{
+			name:           "local only suppresses init remote wiring without changing predicate",
+			syncURL:        "git+https://github.com/org/project.git",
+			syncURLFromGit: true,
+			localOnly:      true,
+			wantConfigure:  false,
+			wantWire:       true,
+		},
+		{
+			name:          "no url remains false",
+			localOnly:     true,
+			wantConfigure: false,
+			wantWire:      false,
+		},
+		{
+			name:              "explicit sync remote configures when local only is false",
+			syncURL:           "https://dolt.example.invalid/repo",
+			syncURLFromConfig: true,
+			wantConfigure:     true,
+			wantWire:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotConfigure := shouldConfigureInitDoltRemote(tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig, tt.syncURLFromGit, tt.localOnly)
+			if gotConfigure != tt.wantConfigure {
+				t.Errorf("shouldConfigureInitDoltRemote(..., localOnly=%v) = %v, want %v", tt.localOnly, gotConfigure, tt.wantConfigure)
+			}
+			gotWire := shouldWireInitRemote(tt.syncURL, tt.syncFromRemote, tt.syncURLFromConfig, tt.syncURLFromGit)
+			if gotWire != tt.wantWire {
+				t.Errorf("shouldWireInitRemote(...) = %v, want %v", gotWire, tt.wantWire)
+			}
+		})
+	}
+}
+
+func TestLocalOnlyInitSkipsConfigureButPersistsExplicitRemote(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0o700); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("dolt.local-only: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	remote := "git+ssh://git@example.com/org/project.git"
+	if shouldConfigureInitDoltRemote(remote, false, true, false, true) {
+		t.Fatal("local-only init should not configure a Dolt remote")
+	}
+
+	if err := persistInitSyncRemote(beadsDir, remote, remote, false, true, false); err != nil {
+		t.Fatalf("persistInitSyncRemote failed: %v", err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(data), `sync.remote: "git+ssh://git@example.com/org/project.git"`) &&
+		!strings.Contains(string(data), "sync.remote: git+ssh://git@example.com/org/project.git") {
+		t.Fatalf("sync.remote was not persisted under local-only config:\n%s", data)
+	}
+}
+
 // TestFormatDestroyToken asserts the token format contract that
 // bd help init-safety documents. If this format changes, help text
 // and the ADR must update together.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2643,6 +2643,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
+  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2643,7 +2643,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
-  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
+  bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -73,7 +73,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
-  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
+  bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/docs/cli-reference/config.md
+++ b/website/docs/cli-reference/config.md
@@ -73,6 +73,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
+  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2941,7 +2941,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
-  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
+  bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2941,6 +2941,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
+  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/versioned_docs/version-1.0.0/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/config.md
@@ -73,7 +73,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
-  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
+  bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/versioned_docs/version-1.0.0/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.0/cli-reference/config.md
@@ -73,6 +73,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
+  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/versioned_docs/version-1.0.4/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/config.md
@@ -73,7 +73,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
-  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
+  bd config set dolt.local-only true                   # Skip wiring a Dolt sync remote during bd init
   bd config get export.auto
   bd config list
   bd config unset jira.url

--- a/website/versioned_docs/version-1.0.4/cli-reference/config.md
+++ b/website/versioned_docs/version-1.0.4/cli-reference/config.md
@@ -73,6 +73,7 @@ Examples:
   bd config set status.custom "awaiting_review,awaiting_testing"
   bd config set doctor.suppress.pending-migrations true
   bd config set dolt.debug true                        # Enable Dolt sql-server debug mode (loglevel=debug, --prof cpu)
+  bd config set dolt.local-only true                   # Suppress Dolt remote wiring and sync
   bd config get export.auto
   bd config list
   bd config unset jira.url


### PR DESCRIPTION
## Summary
- Guard bd init Dolt remote configuration at the call site when `dolt.local-only:true`.
- Render agent instructions as no-remote under local-only while preserving `sync.remote` persistence for explicit `--remote`.
- Add config help coverage for `dolt.local-only`.

## Tests
- `go test ./cmd/bd -run Test(ShouldConfigureInitDoltRemoteHonorsLocalOnly|LocalOnlyInitSkipsConfigureButPersistsExplicitRemote|ConfigHelpMentionsDoltLocalOnly) -count=1`
- CI-style short `go test -tags gms_pure_go ... ./cmd/bd` focused set
- `go vet ./...` with clean env
- `make test` in an independent temp clone with clean HOME and Dolt identity

Related Gas City bead: `ga-vjefud.1`. Inspected overlapping PR #4212; this patch is scoped to `dolt.local-only` and does not change no-push behavior.