### PR TITLE
fix(dolt): honor local-only when syncing CLI remotes

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1017,6 +1017,7 @@ var rootCmd = &cobra.Command{
 			doltCfg.Database = configfile.DefaultDoltDatabase
 		}
 		doltCfg.SyncRemote = resolveSyncRemote()
+		doltCfg.LocalOnly = config.GetBool("dolt.local-only")
 
 		// --global flag: switch to the global shared-server database.
 		// Must be in shared-server mode; errors otherwise.

--- a/cmd/bd/store_factory.go
+++ b/cmd/bd/store_factory.go
@@ -46,6 +46,9 @@ func usesProxiedServer() bool {
 // newDoltStore creates a storage backend from an explicit config.
 // Used by bd init and PersistentPreRun.
 func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, error) {
+	if cfg != nil {
+		dolt.ApplyLocalOnlyConfig(cfg.BeadsDir, cfg)
+	}
 	if cfg.ProxiedServer {
 		// TODO: this should not be a store
 		// it should be a uow provider

--- a/cmd/bd/store_factory_nocgo.go
+++ b/cmd/bd/store_factory_nocgo.go
@@ -29,6 +29,9 @@ func usesProxiedServer() bool {
 }
 
 func newDoltStore(ctx context.Context, cfg *dolt.Config) (storage.DoltStorage, error) {
+	if cfg != nil {
+		dolt.ApplyLocalOnlyConfig(cfg.BeadsDir, cfg)
+	}
 	if cfg.ProxiedServer {
 		// TODO: this should not be a store
 		// it should be a uow provider

--- a/internal/storage/dolt/open.go
+++ b/internal/storage/dolt/open.go
@@ -199,6 +199,7 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 	if cfg.BeadsDir == "" {
 		cfg.BeadsDir = beadsDir
 	}
+	ApplyLocalOnlyConfig(beadsDir, cfg)
 
 	// GH#2438: Warn if data-dir is set in server mode — it has no effect on
 	// which database the server uses and can cause silent DB context switches.
@@ -254,6 +255,26 @@ func applyResolvedConfig(beadsDir string, fileCfg *configfile.Config, cfg *Confi
 				cfg.MaxOpenConns = n
 			}
 		}
+	}
+}
+
+// ApplyLocalOnlyConfig applies dolt.local-only from beads config to cfg.
+func ApplyLocalOnlyConfig(beadsDir string, cfg *Config) {
+	if cfg == nil || cfg.LocalOnly {
+		return
+	}
+	cfg.LocalOnly = resolveLocalOnly(beadsDir)
+}
+
+func resolveLocalOnly(beadsDir string) bool {
+	if config.GetBool("dolt.local-only") {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(config.GetStringFromDir(beadsDir, "dolt.local-only"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -106,6 +106,29 @@ func TestResolveAutoStart(t *testing.T) {
 	}
 }
 
+func TestShouldSyncCLIRemotesToSQL(t *testing.T) {
+	tests := []struct {
+		name      string
+		readOnly  bool
+		localOnly bool
+		want      bool
+	}{
+		{name: "default writer syncs", want: true},
+		{name: "read only skips", readOnly: true, want: false},
+		{name: "local only skips", localOnly: true, want: false},
+		{name: "read only and local only skips", readOnly: true, localOnly: true, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldSyncCLIRemotesToSQL(tc.readOnly, tc.localOnly); got != tc.want {
+				t.Fatalf("shouldSyncCLIRemotesToSQL(readOnly=%v, localOnly=%v) = %v, want %v",
+					tc.readOnly, tc.localOnly, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestApplyCLIAutoStart_RespectsExternalMode verifies that an external-mode
 // repo (metadata.json with explicit dolt_server_port) suppresses the CLI
 // auto-start path, preventing the shadow-database fallback when the
@@ -315,6 +338,39 @@ func TestApplyResolvedConfig(t *testing.T) {
 		}
 		if cfg.ServerUser != "custom" {
 			t.Fatalf("ServerUser override lost: %q", cfg.ServerUser)
+		}
+	})
+
+	t.Run("sets local only from config yaml", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("dolt:\n  local-only: true\n"), 0o644); err != nil {
+			t.Fatalf("write config.yaml: %v", err)
+		}
+		fileCfg := &configfile.Config{
+			Backend:      configfile.BackendDolt,
+			DoltDatabase: "beads_codex",
+		}
+		cfg := &Config{}
+
+		applyResolvedConfig(beadsDir, fileCfg, cfg)
+
+		if !cfg.LocalOnly {
+			t.Fatal("LocalOnly = false, want true from dolt.local-only config")
+		}
+	})
+
+	t.Run("preserves caller local only", func(t *testing.T) {
+		beadsDir := t.TempDir()
+		fileCfg := &configfile.Config{
+			Backend:      configfile.BackendDolt,
+			DoltDatabase: "beads_codex",
+		}
+		cfg := &Config{LocalOnly: true}
+
+		applyResolvedConfig(beadsDir, fileCfg, cfg)
+
+		if !cfg.LocalOnly {
+			t.Fatal("LocalOnly override lost")
 		}
 	})
 }

--- a/internal/storage/dolt/open_test.go
+++ b/internal/storage/dolt/open_test.go
@@ -106,29 +106,6 @@ func TestResolveAutoStart(t *testing.T) {
 	}
 }
 
-func TestShouldSyncCLIRemotesToSQL(t *testing.T) {
-	tests := []struct {
-		name      string
-		readOnly  bool
-		localOnly bool
-		want      bool
-	}{
-		{name: "default writer syncs", want: true},
-		{name: "read only skips", readOnly: true, want: false},
-		{name: "local only skips", localOnly: true, want: false},
-		{name: "read only and local only skips", readOnly: true, localOnly: true, want: false},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := shouldSyncCLIRemotesToSQL(tc.readOnly, tc.localOnly); got != tc.want {
-				t.Fatalf("shouldSyncCLIRemotesToSQL(readOnly=%v, localOnly=%v) = %v, want %v",
-					tc.readOnly, tc.localOnly, got, tc.want)
-			}
-		})
-	}
-}
-
 // TestApplyCLIAutoStart_RespectsExternalMode verifies that an external-mode
 // repo (metadata.json with explicit dolt_server_port) suppresses the CLI
 // auto-start path, preventing the shadow-database fallback when the

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1148,10 +1148,6 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	return store, nil
 }
 
-func shouldSyncCLIRemotesToSQL(readOnly, localOnly bool) bool {
-	return !readOnly && !localOnly
-}
-
 func shouldPersistResolvedPortFile() bool {
 	return os.Getenv("BEADS_DOLT_SERVER_PORT") == "" && os.Getenv("BEADS_DOLT_PORT") == ""
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -203,6 +203,7 @@ type Config struct {
 	Remote         string // Default remote name (e.g., "origin")
 	Database       string // Database name within Dolt (default: "beads")
 	ReadOnly       bool   // Open in read-only mode (skip schema init)
+	LocalOnly      bool   // Suppress runtime remote re-registration from CLI config
 
 	// Server connection options
 	ServerSocket   string // Unix domain socket path (overrides Host/Port when set)
@@ -1145,6 +1146,10 @@ func newServerMode(ctx context.Context, cfg *Config) (*DoltStore, error) {
 	store.registerPoolGauges()
 
 	return store, nil
+}
+
+func shouldSyncCLIRemotesToSQL(readOnly, localOnly bool) bool {
+	return !readOnly && !localOnly
 }
 
 func shouldPersistResolvedPortFile() bool {


### PR DESCRIPTION
## Summary
- Add `dolt.Config.LocalOnly` and resolve it from `dolt.local-only` for config-backed store construction.
- Pass local-only through direct CLI store construction paths and skip only `syncCLIRemotesToSQL` when local-only is true.
- Preserve default writer sync and existing read-only skip behavior.

## Tests
- RED: focused storage tests failed before implementation with missing `Config.LocalOnly` / `shouldSyncCLIRemotesToSQL`.
- `go test ./internal/storage/dolt -run Test(ShouldSyncCLIRemotesToSQL|ApplyResolvedConfig) -count=1`
- `go test -tags integration ./internal/storage/dolt -run Test(NewLocalOnlySkipsCLIRemoteSync|SyncCLIRemotesToSQL) -count=1`
- `go test ./cmd/bd -run ^TestHelp$ -count=1`
- `go vet ./...` with clean env
- `make test` in an independent temp clone with clean HOME and Dolt identity

Related Gas City bead: `ga-acrtc9.1`. Preflight reviewed overlapping PRs #4151, #4153, #4212, and #4227. `backup_export` code was audited and not touched.