### PR TITLE
fix(export): sort issues and sub-objects for deterministic JSONL output

### DIFF
--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -161,27 +161,8 @@ func runExport(cmd *cobra.Command, args []string) error {
 		issue.Comments = commentsMap[issue.ID]
 	}
 
-	// Sort issues for deterministic JSONL output (GH#4127).
-	// SearchIssues has ORDER BY but wisp-merge can break that ordering.
-	sort.SliceStable(issues, func(i, j int) bool {
-		if issues[i].Priority != issues[j].Priority {
-			return issues[i].Priority < issues[j].Priority
-		}
-		if !issues[i].CreatedAt.Equal(issues[j].CreatedAt) {
-			return issues[i].CreatedAt.After(issues[j].CreatedAt)
-		}
-		return issues[i].ID < issues[j].ID
-	})
-
-	// Sort sub-objects within each issue for stable nested ordering.
-	for _, issue := range issues {
-		sort.Slice(issue.Dependencies, func(a, b int) bool {
-			if issue.Dependencies[a].DependsOnID != issue.Dependencies[b].DependsOnID {
-				return issue.Dependencies[a].DependsOnID < issue.Dependencies[b].DependsOnID
-			}
-			return issue.Dependencies[a].Type < issue.Dependencies[b].Type
-		})
-	}
+	// Sort for deterministic JSONL output (GH#4127).
+	sortIssuesForExport(issues)
 
 	// Write JSONL: one JSON object per line
 	count := 0
@@ -295,6 +276,30 @@ func sanitizeZeroTime(issue *types.Issue) {
 	}
 	if issue.UpdatedAt.IsZero() {
 		issue.UpdatedAt = epoch
+	}
+}
+
+// sortIssuesForExport orders issues and their dependencies deterministically
+// so JSONL export output is byte-stable across runs (GH#4127). SearchIssues
+// applies SQL ORDER BY, but wisp-merge can append rows without re-sorting, and
+// the dependency query lacks a within-issue tiebreaker.
+func sortIssuesForExport(issues []*types.Issue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].Priority != issues[j].Priority {
+			return issues[i].Priority < issues[j].Priority
+		}
+		if !issues[i].CreatedAt.Equal(issues[j].CreatedAt) {
+			return issues[i].CreatedAt.After(issues[j].CreatedAt)
+		}
+		return issues[i].ID < issues[j].ID
+	})
+	for _, issue := range issues {
+		sort.Slice(issue.Dependencies, func(a, b int) bool {
+			if issue.Dependencies[a].DependsOnID != issue.Dependencies[b].DependsOnID {
+				return issue.Dependencies[a].DependsOnID < issue.Dependencies[b].DependsOnID
+			}
+			return issue.Dependencies[a].Type < issue.Dependencies[b].Type
+		})
 	}
 }
 

--- a/cmd/bd/export.go
+++ b/cmd/bd/export.go
@@ -161,6 +161,28 @@ func runExport(cmd *cobra.Command, args []string) error {
 		issue.Comments = commentsMap[issue.ID]
 	}
 
+	// Sort issues for deterministic JSONL output (GH#4127).
+	// SearchIssues has ORDER BY but wisp-merge can break that ordering.
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].Priority != issues[j].Priority {
+			return issues[i].Priority < issues[j].Priority
+		}
+		if !issues[i].CreatedAt.Equal(issues[j].CreatedAt) {
+			return issues[i].CreatedAt.After(issues[j].CreatedAt)
+		}
+		return issues[i].ID < issues[j].ID
+	})
+
+	// Sort sub-objects within each issue for stable nested ordering.
+	for _, issue := range issues {
+		sort.Slice(issue.Dependencies, func(a, b int) bool {
+			if issue.Dependencies[a].DependsOnID != issue.Dependencies[b].DependsOnID {
+				return issue.Dependencies[a].DependsOnID < issue.Dependencies[b].DependsOnID
+			}
+			return issue.Dependencies[a].Type < issue.Dependencies[b].Type
+		})
+	}
+
 	// Write JSONL: one JSON object per line
 	count := 0
 	for _, issue := range issues {

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -381,23 +381,7 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 		}
 
 		// Sort for deterministic output (GH#4127)
-		sort.SliceStable(issues, func(i, j int) bool {
-			if issues[i].Priority != issues[j].Priority {
-				return issues[i].Priority < issues[j].Priority
-			}
-			if !issues[i].CreatedAt.Equal(issues[j].CreatedAt) {
-				return issues[i].CreatedAt.After(issues[j].CreatedAt)
-			}
-			return issues[i].ID < issues[j].ID
-		})
-		for _, issue := range issues {
-			sort.Slice(issue.Dependencies, func(a, b int) bool {
-				if issue.Dependencies[a].DependsOnID != issue.Dependencies[b].DependsOnID {
-					return issue.Dependencies[a].DependsOnID < issue.Dependencies[b].DependsOnID
-				}
-				return issue.Dependencies[a].Type < issue.Dependencies[b].Type
-			})
-		}
+		sortIssuesForExport(issues)
 
 		// Write issues
 		enc := json.NewEncoder(w)

--- a/cmd/bd/export_auto.go
+++ b/cmd/bd/export_auto.go
@@ -380,6 +380,25 @@ func exportToFile(ctx context.Context, path string, includeMemories bool) (issue
 			issue.Comments = commentsMap[issue.ID]
 		}
 
+		// Sort for deterministic output (GH#4127)
+		sort.SliceStable(issues, func(i, j int) bool {
+			if issues[i].Priority != issues[j].Priority {
+				return issues[i].Priority < issues[j].Priority
+			}
+			if !issues[i].CreatedAt.Equal(issues[j].CreatedAt) {
+				return issues[i].CreatedAt.After(issues[j].CreatedAt)
+			}
+			return issues[i].ID < issues[j].ID
+		})
+		for _, issue := range issues {
+			sort.Slice(issue.Dependencies, func(a, b int) bool {
+				if issue.Dependencies[a].DependsOnID != issue.Dependencies[b].DependsOnID {
+					return issue.Dependencies[a].DependsOnID < issue.Dependencies[b].DependsOnID
+				}
+				return issue.Dependencies[a].Type < issue.Dependencies[b].Type
+			})
+		}
+
 		// Write issues
 		enc := json.NewEncoder(w)
 		for _, issue := range issues {

--- a/cmd/bd/export_sort_test.go
+++ b/cmd/bd/export_sort_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func TestSortIssuesForExport_OrdersByPriorityThenCreatedThenID(t *testing.T) {
+	t.Parallel()
+
+	early := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	late := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	issues := []*types.Issue{
+		{ID: "bd-3", Priority: 2, CreatedAt: early},
+		{ID: "bd-1", Priority: 0, CreatedAt: early},
+		{ID: "bd-2", Priority: 0, CreatedAt: late},
+		{ID: "bd-4", Priority: 0, CreatedAt: early},
+	}
+
+	sortIssuesForExport(issues)
+
+	// Expected order:
+	//  P0 + late created (bd-2)  — newer created_at sorts first (DESC)
+	//  P0 + early created, id bd-1
+	//  P0 + early created, id bd-4
+	//  P2 (bd-3)
+	want := []string{"bd-2", "bd-1", "bd-4", "bd-3"}
+	for i, id := range want {
+		if issues[i].ID != id {
+			t.Errorf("position %d: got %s, want %s (full order: %v)", i, issues[i].ID, id, ids(issues))
+		}
+	}
+}
+
+func TestSortIssuesForExport_SortsDependenciesWithinIssue(t *testing.T) {
+	t.Parallel()
+
+	issues := []*types.Issue{
+		{
+			ID:       "bd-1",
+			Priority: 1,
+			Dependencies: []*types.Dependency{
+				{IssueID: "bd-1", DependsOnID: "bd-9", Type: types.DepBlocks},
+				{IssueID: "bd-1", DependsOnID: "bd-2", Type: types.DepRelated},
+				{IssueID: "bd-1", DependsOnID: "bd-2", Type: types.DepBlocks},
+			},
+		},
+	}
+
+	sortIssuesForExport(issues)
+
+	deps := issues[0].Dependencies
+	// Sorted by DependsOnID, then Type.
+	if deps[0].DependsOnID != "bd-2" || deps[1].DependsOnID != "bd-2" || deps[2].DependsOnID != "bd-9" {
+		t.Fatalf("dependencies not ordered by DependsOnID: %+v", deps)
+	}
+	if deps[0].Type != types.DepBlocks || deps[1].Type != types.DepRelated {
+		t.Errorf("ties not broken by Type: %+v", deps)
+	}
+}
+
+func TestSortIssuesForExport_StableAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 3, 3, 0, 0, 0, 0, time.UTC)
+	build := func() []*types.Issue {
+		return []*types.Issue{
+			{ID: "bd-5", Priority: 1, CreatedAt: created},
+			{ID: "bd-2", Priority: 1, CreatedAt: created},
+			{ID: "bd-8", Priority: 1, CreatedAt: created},
+			{ID: "bd-1", Priority: 1, CreatedAt: created},
+		}
+	}
+
+	a := build()
+	b := build()
+	sortIssuesForExport(a)
+	sortIssuesForExport(b)
+
+	for i := range a {
+		if a[i].ID != b[i].ID {
+			t.Fatalf("non-deterministic order at %d: %v vs %v", i, ids(a), ids(b))
+		}
+	}
+	// With equal priority and created_at, order falls back to ID ascending.
+	want := []string{"bd-1", "bd-2", "bd-5", "bd-8"}
+	for i, id := range want {
+		if a[i].ID != id {
+			t.Errorf("position %d: got %s, want %s", i, a[i].ID, id)
+		}
+	}
+}
+
+func ids(issues []*types.Issue) []string {
+	out := make([]string, len(issues))
+	for i, is := range issues {
+		out[i] = is.ID
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- `bd export` relied on `SearchIssues` SQL ordering, but wisp-merge appends without re-sorting
- This caused non-deterministic export output and phantom git diffs in auto-exported `.beads/` files
- Adds explicit `sort.SliceStable` before writing JSONL (matching SQL order: priority ASC, created_at DESC, id ASC)
- Also sorts dependencies within each issue by `depends_on_id` + `type` for nested stability
- Applied to both `bd export` and the auto-export path in `export_auto.go`

Mirrors the approach used for memories (GH#3474) where `sort.Strings(memKeys)` was added for deterministic output.

## Test plan

- [x] `go build -tags gms_pure_go ./cmd/bd/` passes
- [ ] `bd export > a.jsonl && bd export > b.jsonl && diff a.jsonl b.jsonl` shows no diff
- [ ] Export with wisps present maintains stable ordering across runs

Fixes #4127