### PR TITLE
fix(create): normalize trailing hyphen in dbPrefix before prefix validation

### DIFF
--- a/internal/validation/bead.go
+++ b/internal/validation/bead.go
@@ -137,6 +137,7 @@ func validatePrefixWithAllowed(requestedPrefix, dbPrefix, allowedPrefixes string
 // - id starts with any prefix in allowedPrefixes + "-"
 // Returns an error if none of these conditions are met.
 func ValidateIDPrefixAllowed(id, dbPrefix, allowedPrefixes string, force bool) error {
+	dbPrefix = strings.TrimSuffix(dbPrefix, "-")
 	if force || dbPrefix == "" {
 		return nil
 	}

--- a/internal/validation/bead_test.go
+++ b/internal/validation/bead_test.go
@@ -370,6 +370,11 @@ func TestValidateIDPrefixAllowed(t *testing.T) {
 		{"empty allowed list", "gt-abc123", "hq", "", false, true},
 		{"single allowed prefix", "gt-abc123", "hq", "gt", false, false},
 
+		// DB prefix with trailing hyphen (GH#4208)
+		{"db prefix trailing hyphen", "v2-abc123", "v2-", "", false, false},
+		{"db prefix trailing hyphen with allowed", "v2-abc123", "v2-", "v2-", false, false},
+		{"db prefix only hyphen", "abc123", "-", "", false, false},
+
 		// Multi-hyphen allowed prefixes
 		{"multi-hyphen in allowed list", "my-cool-prefix-abc123", "hq", "my-cool-prefix,other", false, false},
 		{"partial match should fail", "hq-cv-extra-test", "hq", "hq-cv-extra", false, false},


### PR DESCRIPTION
## Summary

- `bd create` threw a false "prefix mismatch" error when the database stored `config.issue_prefix` with a trailing hyphen (e.g. `"bd-"` vs `"bd"`)
- Root cause: `ValidateIDPrefixAllowed` compared the raw `dbPrefix` against the generated ID prefix without normalizing
- Fix: `strings.TrimSuffix(dbPrefix, "-")` before the comparison
- Added test cases covering the trailing-hyphen scenario

## Test plan

- [x] `go build -tags gms_pure_go ./cmd/bd/` passes
- [x] `go test -tags gms_pure_go -run TestValidateIDPrefixAllowed ./internal/validation/` passes
- [ ] `bd create "test" -p 2` works when config has `issue_prefix: "bd-"`

Fixes #4208