### PR TITLE
fix(schema): update renumbered migration comment

### DIFF
--- a/internal/storage/schema/migrations/0049_longtext_large_content_columns.up.sql
+++ b/internal/storage/schema/migrations/0049_longtext_large_content_columns.up.sql
@@ -1,4 +1,4 @@
--- Migration 0046: Use LONGTEXT for large-content columns.
+-- Migration 0049: Use LONGTEXT for large-content columns.
 --
 -- issues/wisps: description, design, acceptance_criteria, notes, close_reason
 -- comments: text


### PR DESCRIPTION
## Summary

- update the longtext migration header comment to match its renumbered `0049` filename

## Why

gastownhall/beads#4224 renumbered the duplicate release migrations so upstream test startup no longer panics on duplicate versions. One embedded comment still referred to the longtext migration as `0046`, which could mislead future migration archaeology.

## Verification

- `go test ./internal/storage/schema`
- checked main schema migration `.up.sql` prefixes for duplicate numbers, excluding `migrations/ignored`
- attempted `go test ./internal/storage/schema ./internal/storage/dolt ./cmd/bd`; stopped after Dolt-dependent packages reported missing host ICU header `unicode/uregex.h`

_codex-gpt-5.5-medium on behalf of matt wilkie_
