### PR TITLE
ci(release): guard against version/docs drift on release

### DIFF
--- a/.beads/formulas/beads-release.formula.toml
+++ b/.beads/formulas/beads-release.formula.toml
@@ -536,40 +536,18 @@ description = """
 Create or verify the Docusaurus snapshot for {{version}} so the published docs
 version dropdown, default docs route, and llms-full artifact match the release.
 
-Install website dependencies if needed:
+This is a single, idempotent script so version.go and the docs snapshot cannot
+drift apart. It installs website deps if needed, creates the versioned snapshot
+(if missing), points `docusaurus.config.ts` lastVersion at it, regenerates the
+CLI reference and llms-full.txt, and verifies consistency.
+
 ```bash
-cd website
-npm ci
+./scripts/snapshot-release-docs.sh {{version}}
 ```
 
-Create the release snapshot if it does not exist yet:
-```bash
-test -d versioned_docs/version-{{version}} || npx docusaurus docs:version {{version}}
-cd ..
-```
-
-Ensure `website/docusaurus.config.ts` selects the new release snapshot:
-```bash
-# macOS
-sed -i '' "s/lastVersion: '[^']*'/lastVersion: '{{version}}'/" website/docusaurus.config.ts
-
-# Linux
-sed -i "s/lastVersion: '[^']*'/lastVersion: '{{version}}'/" website/docusaurus.config.ts
-```
-
-Regenerate docs artifacts from the release snapshot:
-```bash
-CGO_ENABLED=0 go build -tags gms_pure_go -o ./bd-docs ./cmd/bd/
-./scripts/generate-cli-docs.sh ./bd-docs
-./scripts/generate-llms-full.sh
-```
-
-Verify:
-```bash
-./scripts/check-docs-version.sh
-./scripts/check-doc-flags.sh ./bd-docs
-rm -f ./bd-docs
-```
+If `scripts/update-versions.sh {{version}}` was used for the version bump, the
+docs snapshot has already run as part of that step (unless --skip-docs was
+passed) and this step just re-verifies.
 """
 
 [[steps]]

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Pre-push hook: when pushing a release tag (refs/tags/v*), refuse the push if
+# version constants and the Docusaurus docs snapshot disagree. This stops a
+# release from being tagged/published with drifted docs (the failure mode that
+# left main red after the 1.0.5 release) before it ever reaches CI.
+#
+# Installed via: git config core.hooksPath .githooks
+# See also: make install (sets hooksPath automatically)
+#
+# Bypass (not recommended for release tags): git push --no-verify
+
+set -euo pipefail
+
+# git feeds "<local ref> <local sha> <remote ref> <remote sha>" lines on stdin.
+pushing_version_tag=0
+while read -r local_ref _local_sha _remote_ref _remote_sha; do
+    case "$local_ref" in
+        refs/tags/v[0-9]*) pushing_version_tag=1 ;;
+    esac
+done
+
+[ "$pushing_version_tag" -eq 0 ] && exit 0
+
+repo_root="$(git rev-parse --show-toplevel)"
+if [ ! -x "$repo_root/scripts/check-versions.sh" ]; then
+    # Older checkout without the consistency check; do not block.
+    exit 0
+fi
+
+echo "Release tag push detected — verifying version + docs consistency..."
+if ! (cd "$repo_root" && ./scripts/check-versions.sh); then
+    echo ""
+    echo "❌ Refusing to push release tag: version/docs are inconsistent." >&2
+    echo "   Fix with: scripts/update-versions.sh <version>" >&2
+    echo "   (or scripts/snapshot-release-docs.sh <version> for the docs side)." >&2
+    echo "   Override with --no-verify only if you know what you are doing." >&2
+    exit 1
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,34 @@ permissions:
   attestations: write
 
 jobs:
+  # Pre-publish gate: refuse to publish a release whose version constants and
+  # Docusaurus docs snapshot disagree. This blocks the failure mode where a tag
+  # ships with version.go bumped but the docs snapshot missing (which otherwise
+  # only surfaces as a red main after the artifacts are already published).
+  verify-version-consistency:
+    if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Verify tag matches version.go
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          code_version="$(grep 'Version = ' cmd/bd/version.go | sed 's/.*"\(.*\)".*/\1/')"
+          if [ "$tag_version" != "$code_version" ]; then
+            echo "ERROR: tag v$tag_version does not match cmd/bd/version.go ($code_version)" >&2
+            exit 1
+          fi
+          echo "OK: tag and version.go agree on $code_version"
+
+      - name: Check version + docs consistency
+        run: ./scripts/check-versions.sh
+
   goreleaser:
     # Guard: only run goreleaser in the canonical repository (not in forks)
     if: ${{ github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
+    needs: verify-version-consistency
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -329,8 +354,10 @@ jobs:
 
   publish-pypi:
     runs-on: ubuntu-latest
-    needs: goreleaser
-    if: ${{ always() && github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
+    # always() decouples PyPI from goreleaser success, but the version gate must
+    # still pass — otherwise a tag with drifted docs/versions could publish.
+    needs: [verify-version-consistency, goreleaser]
+    if: ${{ always() && needs.verify-version-consistency.result == 'success' && github.repository == 'gastownhall/beads' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/scripts/snapshot-release-docs.sh
+++ b/scripts/snapshot-release-docs.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# snapshot-release-docs.sh — Create/refresh the Docusaurus release snapshot for a
+# given version so the published docs (version dropdown, default docs route, and
+# the llms-full artifact) match the released bd version.
+#
+# This is the single source of truth for the docs side of a version bump. It is
+# called by scripts/update-versions.sh and referenced by the beads-release
+# formula, so version.go and the docs snapshot cannot drift apart (the failure
+# mode that left main red after the 1.0.5 release).
+#
+# Usage: scripts/snapshot-release-docs.sh <version>
+#   e.g. scripts/snapshot-release-docs.sh 1.0.5
+#
+# Idempotent: re-running for an existing snapshot only regenerates artifacts and
+# re-verifies; it does not duplicate the versioned_docs directory.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version>" >&2
+    echo "Example: $0 1.0.5" >&2
+    exit 1
+fi
+
+VERSION="$1"
+
+if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Error: Invalid version format '$VERSION'${NC}" >&2
+    echo "Expected: MAJOR.MINOR.PATCH (e.g., 1.0.5)" >&2
+    exit 1
+fi
+
+if [ ! -f "cmd/bd/version.go" ] || [ ! -f "website/docusaurus.config.ts" ]; then
+    echo -e "${RED}Error: must run from repository root${NC}" >&2
+    exit 1
+fi
+
+if ! command -v npx >/dev/null 2>&1; then
+    echo -e "${RED}Error: npx (Node.js) is required to snapshot Docusaurus docs.${NC}" >&2
+    echo "Install Node.js, or re-run the version bump with --skip-docs and snapshot separately." >&2
+    exit 1
+fi
+
+echo -e "${YELLOW}Snapshotting release docs for $VERSION${NC}"
+
+# 1. Install website dependencies if needed.
+if [ ! -d "website/node_modules" ]; then
+    echo "  • website: npm ci"
+    (cd website && npm ci)
+fi
+
+# 2. Create the versioned snapshot if it does not already exist.
+if [ -d "website/versioned_docs/version-$VERSION" ]; then
+    echo "  • snapshot website/versioned_docs/version-$VERSION already exists (skipping docs:version)"
+else
+    echo "  • docusaurus docs:version $VERSION"
+    (cd website && npx docusaurus docs:version "$VERSION")
+fi
+
+# 3. Point the site default at the new release snapshot.
+echo "  • docusaurus.config.ts lastVersion -> $VERSION"
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "s/lastVersion: '[^']*'/lastVersion: '$VERSION'/" website/docusaurus.config.ts
+else
+    sed -i "s/lastVersion: '[^']*'/lastVersion: '$VERSION'/" website/docusaurus.config.ts
+fi
+
+# 4. Regenerate docs artifacts from a freshly built bd so the versioned CLI
+#    reference carries the "Reference for bd v$VERSION" label and llms-full.txt
+#    reflects the release snapshot.
+echo "  • building bd for docs generation"
+BD_DOCS="$(pwd)/bd-docs-snapshot"
+trap 'rm -f "$BD_DOCS"' EXIT
+CGO_ENABLED=0 go build -tags gms_pure_go -o "$BD_DOCS" ./cmd/bd/
+
+echo "  • generate-cli-docs.sh"
+./scripts/generate-cli-docs.sh "$BD_DOCS"
+
+echo "  • generate-llms-full.sh"
+./scripts/generate-llms-full.sh
+
+# 5. Verify consistency (fails non-zero if anything still drifts).
+echo ""
+./scripts/check-docs-version.sh
+./scripts/check-doc-flags.sh "$BD_DOCS"
+
+echo ""
+echo -e "${GREEN}✓ Release docs snapshot ready for $VERSION${NC}"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -19,18 +19,42 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 <version>"
+usage() {
+    echo "Usage: $0 <version> [--skip-docs]"
     echo ""
-    echo "Updates version numbers across all components (no git operations)."
+    echo "Updates version numbers across all components (no git operations),"
+    echo "and snapshots the Docusaurus release docs so version.go and the docs"
+    echo "snapshot cannot drift apart."
+    echo ""
+    echo "  --skip-docs   Skip the Docusaurus snapshot (e.g. on a host without"
+    echo "                Node.js). You must then run scripts/snapshot-release-docs.sh"
+    echo "                <version> elsewhere before tagging, or CI will fail."
     echo ""
     echo "Example: $0 0.47.1"
     echo ""
     echo "For full releases, use: bd mol wisp beads-release --var version=X.Y.Z"
+}
+
+NEW_VERSION=""
+SKIP_DOCS=0
+for arg in "$@"; do
+    case "$arg" in
+        --skip-docs) SKIP_DOCS=1 ;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo "Unknown option: $arg" >&2; usage; exit 1 ;;
+        *)
+            if [ -n "$NEW_VERSION" ]; then
+                echo "Error: multiple versions given" >&2; usage; exit 1
+            fi
+            NEW_VERSION="$arg"
+            ;;
+    esac
+done
+
+if [ -z "$NEW_VERSION" ]; then
+    usage
     exit 1
 fi
-
-NEW_VERSION=$1
 
 # Validate semantic versioning
 if ! [[ $NEW_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -106,7 +130,21 @@ echo "  • cmd/bd/winres/manifest.xml"
 update_file "cmd/bd/winres/manifest.xml" "version=\"$CURRENT_VERSION.0\"" "version=\"$NEW_VERSION.0\""
 
 echo ""
-echo -e "${GREEN}✓ Versions updated to $NEW_VERSION${NC}"
+echo -e "${GREEN}✓ Version constants updated to $NEW_VERSION${NC}"
+echo ""
+
+# Snapshot the Docusaurus release docs as part of the same bump so version.go
+# and the published docs cannot diverge. This is the failure mode that left
+# main red after the 1.0.5 release (version bumped, docs snapshot missing).
+if [ "$SKIP_DOCS" -eq 1 ]; then
+    echo -e "${YELLOW}Skipping docs snapshot (--skip-docs).${NC}"
+    echo "  Run scripts/snapshot-release-docs.sh $NEW_VERSION before tagging,"
+    echo "  or CI (check-version-consistency) will fail."
+else
+    echo "Snapshotting release docs..."
+    ./scripts/snapshot-release-docs.sh "$NEW_VERSION"
+fi
+
 echo ""
 echo "Changed files:"
 git diff --stat 2>/dev/null || true
@@ -114,7 +152,4 @@ echo ""
 echo "Next steps:"
 echo "  • Update CHANGELOG.md with release notes"
 echo "  • Update cmd/bd/info.go versionChanges"
-echo "  • Snapshot release docs: cd website && npm ci && npx docusaurus docs:version $NEW_VERSION"
-echo "  • Set website/docusaurus.config.ts lastVersion to $NEW_VERSION"
-echo "  • Regenerate docs artifacts: ./scripts/generate-cli-docs.sh ./bd && ./scripts/generate-llms-full.sh"
 echo "  • Or use: bd mol wisp beads-release --var version=$NEW_VERSION"


### PR DESCRIPTION
## Why

`v1.0.5` shipped with `cmd/bd/version.go` bumped but the Docusaurus docs snapshot missing, which turned `check-version-consistency` red on `main` *after* the artifacts were already published (fix: gastownhall/beads#4246).

Root cause: the `beads-release` formula's `snapshot-docs` step is **advisory prose**, not enforced. A release can bump the version and tag/push while skipping the snapshot, and nothing gates publish — so the drift only surfaces post-release.

This PR adds three layered guards so it can't happen silently again.

## What

**A — Atomic bump (can't diverge).** New `scripts/snapshot-release-docs.sh <version>` encapsulates the whole docs side (`docusaurus docs:version` → `lastVersion` → regenerate CLI/llms → `check-docs-version.sh` + `check-doc-flags.sh`) as one idempotent script. `scripts/update-versions.sh` now calls it as part of the bump, so `version.go` and the docs snapshot move together. Escape hatch `--skip-docs` for hosts without Node.js (with a warning that CI will fail until snapshotted). The formula's `snapshot-docs` step now invokes the same script instead of duplicating the sequence.

**B — Pre-publish gate (drift blocks publish, not main).** `release.yml` gains a `verify-version-consistency` job that (1) asserts the tag matches `version.go` and (2) runs `scripts/check-versions.sh`. `goreleaser` `needs:` it, so every downstream publish job is transitively gated. `publish-pypi` keeps its `always()` decoupling from goreleaser but is hard-gated on `needs.verify-version-consistency.result == 'success'`. A drifted tag now fails *before* publishing artifacts.

**C — Pre-push refusal (catches it locally).** `.githooks/pre-push` runs `check-versions.sh` when a `refs/tags/v*` ref is pushed and refuses on drift — caught on the developer's machine before CI. Picked up automatically by the existing `core.hooksPath` (`make install`). Bypassable with `--no-verify`.

## Verification

- `shellcheck -S warning` clean on all three shell files
- `release.yml` validated as parseable YAML
- script guard paths exercised: bad/missing version, wrong dir, `--help`, unknown flag, `--skip-docs` without version
- hook dispatch tested: branch push passes through; a `v1.0.5` tag push on a drifted tree correctly refuses

This is the follow-up to gastownhall/beads#4246 (which restores 1.0.5 consistency now); this PR prevents the recurrence.

_claude-opus-4-8-medium on behalf of matt wilkie_
