### PR TITLE
docs: link canonical SYNC_CONCEPTS.md from deeper docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -358,6 +358,7 @@ The `bd mol squash` command uses hard delete intentionally - tombstones would be
 
 ## Related Documentation
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) - How cross-machine sync works (Dolt source of truth, wire format, anti-patterns)
 - [PROJECT_CHARTER.md](PROJECT_CHARTER.md) - Product scope and boundaries
 - [MOLECULES.md](MOLECULES.md) - Molecular chemistry metaphor (protos, pour, bond, squash, burn)
 - [INTERNALS.md](INTERNALS.md) - FlushManager, Blocked Cache implementation details

--- a/docs/DOLT.md
+++ b/docs/DOLT.md
@@ -782,6 +782,7 @@ rm .beads/*.backup-*.db
 
 ## See Also
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) - The conceptual model behind cross-machine sync (Dolt source of truth, wire format, anti-patterns)
 - [SYNC_SETUP.md](SYNC_SETUP.md) - Setting up sync across multiple computers
 - [CONFIG.md](CONFIG.md) - Full configuration reference
 - [DEPENDENCIES.md](DEPENDENCIES.md) - Dependencies and gates

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -201,6 +201,8 @@ bd dolt pull    # Pull changes from Dolt remote
 
 The `bd export` command exists for issue portability and interchange. For backup and restore, use `bd backup init <path>` / `bd backup sync` to push Dolt-native backups, and `bd backup restore <path>` to restore from them. None of these are needed for day-to-day Dolt sync.
 
+For the full conceptual model — why the local Dolt database is the source of truth, what `issues.jsonl` is and is not for, and which sync patterns to avoid — see [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md).
+
 ### What if my database feels stale after a colleague pushes changes?
 
 Pull from the Dolt remote:

--- a/docs/GIT_INTEGRATION.md
+++ b/docs/GIT_INTEGRATION.md
@@ -348,6 +348,7 @@ This configures Jujutsu to invoke `bd merge` as its merge tool, restricted to `.
 
 ## See Also
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) - How beads data syncs across machines (Dolt remotes vs. git; what JSONL-via-git is and is not for)
 - [AGENTS.md](../AGENTS.md) - Main agent workflow guide
 - [PROTECTED_BRANCHES.md](PROTECTED_BRANCHES.md) - Protected branch workflows
 - [MULTI_REPO_MIGRATION.md](MULTI_REPO_MIGRATION.md) - Multi-repo patterns

--- a/docs/SYNC_SETUP.md
+++ b/docs/SYNC_SETUP.md
@@ -278,8 +278,7 @@ bd dolt start
 
 - [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) — The conceptual model behind this setup (why Dolt is the source of truth, what JSONL is for)
 - [QUICKSTART.md](QUICKSTART.md) — Getting started with beads
-- [DOLT.md](DOLT.md) — Dolt backend details, server modes, federation
-- [DOLT.md](DOLT.md) — Remote types, sync modes, advanced usage
+- [DOLT.md](DOLT.md) — Dolt backend details, server modes, federation, remote types, and sync modes
 - [INSTALLING.md](INSTALLING.md) — Installation for all platforms
 
 ## Attribution

--- a/docs/SYNC_SETUP.md
+++ b/docs/SYNC_SETUP.md
@@ -276,6 +276,7 @@ bd dolt start
 
 ## See Also
 
+- [SYNC_CONCEPTS.md](SYNC_CONCEPTS.md) — The conceptual model behind this setup (why Dolt is the source of truth, what JSONL is for)
 - [QUICKSTART.md](QUICKSTART.md) — Getting started with beads
 - [DOLT.md](DOLT.md) — Dolt backend details, server modes, federation
 - [DOLT.md](DOLT.md) — Remote types, sync modes, advanced usage


### PR DESCRIPTION
## What

Adds a one-line pointer to the canonical `docs/SYNC_CONCEPTS.md` from the five deeper docs that currently never reference it:

- `docs/ARCHITECTURE.md` — Related Documentation
- `docs/DOLT.md` — See Also
- `docs/FAQ.md` — under "Do I need to run export/import manually?"
- `docs/GIT_INTEGRATION.md` — See Also
- `docs/SYNC_SETUP.md` — See Also

## Why

`docs/SYNC_CONCEPTS.md` is the canonical explanation of how cross-machine sync works (local Dolt database is the source of truth; Dolt remotes are the wire format; what `issues.jsonl` is and is not for). Today it is only linked from `README.md`, so a reader deep in the architecture, Dolt, git-integration, FAQ, or sync-setup docs has no path to it — exactly the readers most likely to hit the "is JSONL-via-git my sync channel?" confusion the concepts doc resolves.

This is docs-only and policy-aligned: every pointer steers readers toward `bd dolt push` / `bd dolt pull` as canonical sync and toward the anti-patterns section, rather than legitimizing JSONL-through-git or routine `bd import`.

## Context

This salvages the only still-relevant piece of #3726. That PR predates the independent creation of `SYNC_CONCEPTS.md` on main (#3909) and is being closed as superseded; its proposed new doc is now a worse duplicate and its cross-link table referenced a since-stubbed `DOLT-BACKEND.md`. Here the links point only at files that exist on current `main`, and `README.md` is left untouched (already linked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
