### PR TITLE
fix(setup): match beads plugin name exactly, not by substring

### DIFF
--- a/cmd/bd/setup/claude.go
+++ b/cmd/bd/setup/claude.go
@@ -545,7 +545,12 @@ func checkBeadsPluginInFile(readFile func(string) ([]byte, error), path string) 
 		return false
 	}
 	for key, value := range enabledPlugins {
-		if strings.Contains(strings.ToLower(key), "beads") {
+		// enabledPlugins keys are "<pluginName>@<marketplace>". Match the
+		// plugin-name segment exactly: a substring test (GH#4244) mistakes any
+		// "*beads*" plugin (e.g. design-to-beads) for the beads hook plugin and
+		// wrongly skips the SessionStart hook write.
+		name, _, _ := strings.Cut(strings.ToLower(key), "@")
+		if name == "beads" {
 			if enabled, ok := value.(bool); ok && enabled {
 				return true
 			}

--- a/cmd/bd/setup/claude_test.go
+++ b/cmd/bd/setup/claude_test.go
@@ -1013,6 +1013,36 @@ func TestHasBeadsPlugin(t *testing.T) {
 			t.Error("expected no plugin detected")
 		}
 	})
+
+	t.Run("design-to-beads not mistaken for beads plugin", func(t *testing.T) {
+		// GH#4244: a plugin whose name merely contains "beads" (here
+		// design-to-beads) must NOT be taken for the beads hook plugin, or the
+		// SessionStart hook write is wrongly skipped.
+		env, _, _ := newClaudeTestEnv(t)
+		writeSettings(t, projectSettingsPath(env.projectDir), map[string]interface{}{
+			"enabledPlugins": map[string]interface{}{
+				"design-to-beads@xexr-marketplace": true,
+			},
+		})
+		if hasBeadsPlugin(env) {
+			t.Error("design-to-beads should not be detected as the beads plugin")
+		}
+	})
+
+	t.Run("real beads plugin detected past a decoy", func(t *testing.T) {
+		// The exact-name match must still find a real beads@<marketplace> even
+		// when a *beads*-named decoy is enabled too (GH#3192 preserved).
+		env, _, _ := newClaudeTestEnv(t)
+		writeSettings(t, projectSettingsPath(env.projectDir), map[string]interface{}{
+			"enabledPlugins": map[string]interface{}{
+				"design-to-beads@xexr-marketplace": true,
+				"beads@beads-marketplace":          true,
+			},
+		})
+		if !hasBeadsPlugin(env) {
+			t.Error("real beads@beads-marketplace should be detected even alongside a decoy")
+		}
+	})
 }
 
 func TestInstallClaudeSkipsHooksWhenPluginPresent(t *testing.T) {

--- a/cmd/bd/setup/codex.go
+++ b/cmd/bd/setup/codex.go
@@ -458,7 +458,16 @@ func codexConfigEnablesBeadsPlugin(content string) bool {
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
 			table := strings.Trim(trimmed, "[]")
-			inBeadsPlugin = strings.HasPrefix(table, "plugins.") && strings.Contains(strings.ToLower(table), "beads")
+			// Plugin tables are [plugins.<name>] or [plugins."<name>@<marketplace>"]
+			// (TOML quotes a key containing "@"). Match the <name> segment
+			// exactly: a substring test (GH#4244) mistakes any "*beads*" plugin
+			// (e.g. design-to-beads) for the beads hook plugin and wrongly skips
+			// the hooks write.
+			inBeadsPlugin = false
+			if rest, ok := strings.CutPrefix(table, "plugins."); ok {
+				name, _, _ := strings.Cut(strings.ToLower(strings.Trim(rest, "\"'")), "@")
+				inBeadsPlugin = name == "beads"
+			}
 			continue
 		}
 		if inBeadsPlugin && codexConfigLineKey(trimmed) == "enabled" {

--- a/cmd/bd/setup/codex_test.go
+++ b/cmd/bd/setup/codex_test.go
@@ -348,3 +348,56 @@ func TestInstallCodexNativeHooksSkipsFallbackWhenPluginEnabled(t *testing.T) {
 		t.Fatalf("plugin-managed check should pass: %v", err)
 	}
 }
+
+func TestCodexConfigEnablesBeadsPlugin(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			// GH#4244: a plugin whose name merely contains "beads" (here
+			// design-to-beads) must NOT be taken for the beads hook plugin, or
+			// the hooks fallback write is wrongly skipped.
+			name:    "design-to-beads not mistaken for beads plugin",
+			content: "[plugins.\"design-to-beads@xexr-marketplace\"]\nenabled = true\n",
+			want:    false,
+		},
+		{
+			name:    "bare design-to-beads not mistaken for beads plugin",
+			content: "[plugins.design-to-beads]\nenabled = true\n",
+			want:    false,
+		},
+		{
+			// The exact-name match must still find a real beads@<marketplace>;
+			// this is the quoted form bd setup codex actually writes.
+			name:    "real quoted beads plugin detected",
+			content: "[plugins.\"beads@local\"]\nenabled = true\n",
+			want:    true,
+		},
+		{
+			name:    "bare beads plugin detected",
+			content: "[plugins.beads]\nenabled = true\n",
+			want:    true,
+		},
+		{
+			// GH#3192 preserved: a real beads plugin is still found alongside a
+			// *beads*-named decoy.
+			name:    "real beads plugin detected past a decoy",
+			content: "[plugins.\"design-to-beads@xexr-marketplace\"]\nenabled = true\n[plugins.\"beads@local\"]\nenabled = true\n",
+			want:    true,
+		},
+		{
+			name:    "beads plugin present but disabled",
+			content: "[plugins.\"beads@local\"]\nenabled = false\n",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexConfigEnablesBeadsPlugin(tc.content); got != tc.want {
+				t.Errorf("codexConfigEnablesBeadsPlugin() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`bd setup` decides whether the beads hook plugin is already enabled by
checking plugin membership with a **substring** match — in both the Claude
and Codex setup paths. A derived plugin name like
`design-to-beads@<marketplace>` contains the substring `beads`, so it is
mistaken for "beads hook plugin enabled". `bd setup` then prints
`✓ Beads plugin detected — hooks are plugin-managed, skipping` and **skips
writing the SessionStart hook** — but the beads hook plugin is not actually
installed, so the hook lands nowhere.

## Why it happens

Plugin identifiers are `<pluginName>@<marketplace>`. The detection matched the
substring `beads` anywhere in the key/table instead of the plugin-name segment:

- `cmd/bd/setup/claude.go` (`checkBeadsPluginInFile`) — `enabledPlugins` JSON keys.
- `cmd/bd/setup/codex.go` (`codexConfigEnablesBeadsPlugin`) — TOML
  `[plugins.<name>]` / `[plugins."<name>@<marketplace>"]` table headers.

## Fix

Match the plugin-name segment (the part before `@`, surrounding TOML quotes
stripped for the Codex case) **exactly**, not by substring, in both setup
paths. A real `beads@<marketplace>` still matches, so the GH#3192 double-fire
prevention is preserved.

## Testing

- `cmd/bd/setup` package green on a fresh checkout, with Claude and Codex
  regression subtests added (`design-to-beads` not detected; a real beads
  plugin still detected, including past a `*beads*` decoy).
- `golangci-lint run ./cmd/bd/setup/...` reports 0 issues.
- Remaining `make test` failures are pre-existing/environmental (server-mode
  tests needing an ambient Dolt server) and reproduce identically on the
  unmodified base — no new regressions introduced by this change.

Fixes #4244
