### PR TITLE
fix(where): read prefix from active beads dir

### DIFF
--- a/cmd/bd/config_drift_test.go
+++ b/cmd/bd/config_drift_test.go
@@ -5,11 +5,20 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/beads/internal/git"
 )
+
+func chdirForDriftTest(t *testing.T, dir string) {
+	t.Helper()
+	t.Chdir(dir)
+	git.ResetCaches()
+	t.Cleanup(git.ResetCaches)
+}
 
 // TestCheckHooksDriftNotGitRepo verifies hooks check skips when not in a git repo.
 func TestCheckHooksDriftNotGitRepo(t *testing.T) {
-	t.Chdir(t.TempDir())
+	chdirForDriftTest(t, t.TempDir())
 
 	items := checkHooksDrift()
 	if len(items) != 1 {
@@ -25,7 +34,7 @@ func TestCheckHooksDriftNotGitRepo(t *testing.T) {
 
 // TestCheckServerDriftNoBeadsDir verifies server check skips when no .beads exists.
 func TestCheckServerDriftNoBeadsDir(t *testing.T) {
-	t.Chdir(t.TempDir())
+	chdirForDriftTest(t, t.TempDir())
 
 	items := checkServerDrift()
 	if len(items) != 1 {
@@ -38,7 +47,7 @@ func TestCheckServerDriftNoBeadsDir(t *testing.T) {
 
 // TestCheckRemoteDriftNoBeadsDir verifies remote check skips when no .beads exists.
 func TestCheckRemoteDriftNoBeadsDir(t *testing.T) {
-	t.Chdir(t.TempDir())
+	chdirForDriftTest(t, t.TempDir())
 
 	items := checkRemoteDrift()
 	if len(items) != 1 {
@@ -117,7 +126,7 @@ func TestDriftItemStatuses(t *testing.T) {
 // TestRunDriftChecksReturnsResults verifies the aggregator returns results from all checks.
 func TestRunDriftChecksReturnsResults(t *testing.T) {
 	// When run from a non-beads directory, we should still get results (skipped checks)
-	t.Chdir(t.TempDir())
+	chdirForDriftTest(t, t.TempDir())
 
 	items := runDriftChecks()
 	if len(items) == 0 {

--- a/cmd/bd/where.go
+++ b/cmd/bd/where.go
@@ -71,10 +71,12 @@ Examples:
 			result.DatabasePath = dbPath
 		}
 
-		// Prefer YAML when available, otherwise do a scoped read-only reopen
-		// using the already-resolved dbPath so we can preserve prefix output
-		// without paying the old worktree-discovery cost.
-		if prefix := config.GetString("issue-prefix"); prefix != "" {
+		// Prefer the active workspace YAML when available. Avoid process-global
+		// config here because `bd where` may be reporting a workspace selected
+		// by BEADS_DB/BEADS_DIR rather than the caller's current repository.
+		if prefix := config.GetStringFromDir(beadsDir, "issue-prefix"); prefix != "" {
+			result.Prefix = prefix
+		} else if prefix := config.GetStringFromDir(beadsDir, "issue_prefix"); prefix != "" {
 			result.Prefix = prefix
 		} else if dbPath != "" && shouldReadWherePrefixFromStore(beadsDir) {
 			_ = withStorage(getRootContext(), nil, dbPath, func(currentStore storage.DoltStorage) error {


### PR DESCRIPTION
Splits the bd where prefix leak fix out of the CI refactor branch. bd where now reads prefix config from the resolved active .beads directory instead of process-global config, with drift tests resetting git caches after chdir.\n\nValidation:\n- go test ./cmd/bd -run 'TestCheckHooksDriftNotGitRepo|TestCheckServerDriftNoBeadsDir|TestCheckRemoteDriftNoBeadsDir|TestRunDriftChecksReturnsResults'