### PR TITLE
fix(schema): generate CLI-compatible migration SQL

### DIFF
--- a/internal/storage/dolt/schema_cli_parity_integration_test.go
+++ b/internal/storage/dolt/schema_cli_parity_integration_test.go
@@ -1,0 +1,164 @@
+//go:build integration
+
+package dolt
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+func TestCLIBundleMatchesRuntimeCommittedSchema(t *testing.T) {
+	skipIfNoDolt(t)
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	baseDir := t.TempDir()
+	cliDir := filepath.Join(baseDir, "cli")
+	if err := os.MkdirAll(cliDir, 0o755); err != nil {
+		t.Fatalf("create CLI schema dir: %v", err)
+	}
+	runCmd(t, cliDir, "dolt", "init")
+	runDoltSQL(t, cliDir, schema.AllMigrationsSQL())
+
+	dbName := uniqueTestDBName(t)
+	runtimeDir := filepath.Join(baseDir, "runtime")
+	if err := os.MkdirAll(runtimeDir, 0o755); err != nil {
+		t.Fatalf("create runtime schema dir: %v", err)
+	}
+	store, err := New(ctx, &Config{
+		Path:            runtimeDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		ServerHost:      "127.0.0.1",
+		ServerPort:      testServerPort,
+		Database:        dbName,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("create runtime store: %v", err)
+	}
+	defer store.Close()
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer dropCancel()
+		_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+	}()
+
+	cliSnapshot := cliCommittedSchemaSnapshot(t, cliDir)
+	runtimeSnapshot := runtimeCommittedSchemaSnapshot(t, store.db)
+	if diff := firstSchemaSnapshotDiff(cliSnapshot, runtimeSnapshot); diff != "" {
+		t.Fatalf("CLI bundle schema does not match runtime committed schema:\n%s", diff)
+	}
+}
+
+func cliCommittedSchemaSnapshot(t *testing.T, dir string) []string {
+	t.Helper()
+
+	var snapshot []string
+	for name, query := range committedSchemaSnapshotQueries() {
+		for _, row := range queryCSV(t, dir, query) {
+			snapshot = append(snapshot, name+"|"+row["line"])
+		}
+	}
+	sort.Strings(snapshot)
+	return snapshot
+}
+
+func runtimeCommittedSchemaSnapshot(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	var snapshot []string
+	for name, query := range committedSchemaSnapshotQueries() {
+		rows, err := db.QueryContext(ctx, query)
+		if err != nil {
+			t.Fatalf("query runtime %s snapshot: %v", name, err)
+		}
+		for rows.Next() {
+			var line string
+			if err := rows.Scan(&line); err != nil {
+				rows.Close()
+				t.Fatalf("scan runtime %s snapshot: %v", name, err)
+			}
+			snapshot = append(snapshot, name+"|"+line)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			t.Fatalf("iterate runtime %s snapshot: %v", name, err)
+		}
+		rows.Close()
+	}
+	sort.Strings(snapshot)
+	return snapshot
+}
+
+func committedSchemaSnapshotQueries() map[string]string {
+	// Wisp tables are owned by the ignored-migration stream and are intentionally
+	// excluded from the committed-schema parity oracle. CLI substitutions that
+	// touch wisps still have focused coverage in internal/storage/schema tests.
+	return map[string]string{
+		"tables": `
+SELECT CONCAT('table|', t.table_name, '|', t.table_type) AS line
+FROM information_schema.tables t
+WHERE t.table_schema = DATABASE()
+  AND t.table_name NOT IN ('ignored_schema_migrations', 'local_metadata', 'repo_mtimes', 'wisps')
+  AND LEFT(t.table_name, 5) <> 'wisp_'
+  AND LEFT(t.table_name, 5) <> 'dolt_'`,
+		"columns": `
+SELECT CONCAT('column|', c.table_name, '|', LPAD(c.ordinal_position, 3, '0'), '|',
+  c.column_name, '|', c.column_type, '|', c.is_nullable, '|',
+  COALESCE(c.column_default, '<NULL>'), '|', c.extra, '|',
+  COALESCE(c.generation_expression, '')) AS line
+FROM information_schema.columns c
+JOIN information_schema.tables t
+  ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+WHERE c.table_schema = DATABASE()
+  AND t.table_name NOT IN ('ignored_schema_migrations', 'local_metadata', 'repo_mtimes', 'wisps')
+  AND LEFT(t.table_name, 5) <> 'wisp_'
+  AND LEFT(t.table_name, 5) <> 'dolt_'`,
+		"indexes": `
+SELECT CONCAT('index|', s.table_name, '|', s.index_name, '|', LPAD(s.seq_in_index, 3, '0'), '|',
+  s.column_name, '|', s.non_unique, '|', COALESCE(s.sub_part, ''), '|',
+  COALESCE(s.nullable, ''), '|', s.index_type) AS line
+FROM information_schema.statistics s
+JOIN information_schema.tables t
+  ON t.table_schema = s.table_schema AND t.table_name = s.table_name
+WHERE s.table_schema = DATABASE()
+  AND t.table_name NOT IN ('ignored_schema_migrations', 'local_metadata', 'repo_mtimes', 'wisps')
+  AND LEFT(t.table_name, 5) <> 'wisp_'
+  AND LEFT(t.table_name, 5) <> 'dolt_'`,
+		"constraints": `
+SELECT CONCAT('constraint|', tc.table_name, '|', tc.constraint_name, '|', tc.constraint_type, '|',
+  LPAD(COALESCE(kcu.ordinal_position, 0), 3, '0'), '|',
+  COALESCE(kcu.column_name, ''), '|', COALESCE(kcu.referenced_table_name, ''), '|',
+  COALESCE(kcu.referenced_column_name, ''), '|', COALESCE(rc.update_rule, ''), '|',
+  COALESCE(rc.delete_rule, '')) AS line
+FROM information_schema.table_constraints tc
+JOIN information_schema.tables t
+  ON t.table_schema = tc.table_schema AND t.table_name = tc.table_name
+LEFT JOIN information_schema.key_column_usage kcu
+  ON kcu.constraint_schema = tc.constraint_schema
+ AND kcu.table_name = tc.table_name
+ AND kcu.constraint_name = tc.constraint_name
+LEFT JOIN information_schema.referential_constraints rc
+  ON rc.constraint_schema = tc.constraint_schema
+ AND rc.constraint_name = tc.constraint_name
+WHERE tc.constraint_schema = DATABASE()
+  AND t.table_name NOT IN ('ignored_schema_migrations', 'local_metadata', 'repo_mtimes', 'wisps')
+  AND LEFT(t.table_name, 5) <> 'wisp_'
+  AND LEFT(t.table_name, 5) <> 'dolt_'`,
+		"version": `
+SELECT CONCAT('version|', COALESCE(MAX(version), 0)) AS line
+FROM schema_migrations`,
+	}
+}

--- a/internal/storage/dolt/schema_cli_parity_test.go
+++ b/internal/storage/dolt/schema_cli_parity_test.go
@@ -1,0 +1,72 @@
+package dolt
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func firstSchemaSnapshotDiff(cliSnapshot, runtimeSnapshot []string) string {
+	i, j := 0, 0
+	var diffs []string
+	omitted := 0
+	addDiff := func(diff string) {
+		if len(diffs) < 10 {
+			diffs = append(diffs, diff)
+			return
+		}
+		omitted++
+	}
+
+	for i < len(cliSnapshot) && j < len(runtimeSnapshot) {
+		switch {
+		case cliSnapshot[i] == runtimeSnapshot[j]:
+			i++
+			j++
+		case cliSnapshot[i] < runtimeSnapshot[j]:
+			addDiff(fmt.Sprintf("only in CLI: %s", cliSnapshot[i]))
+			i++
+		default:
+			addDiff(fmt.Sprintf("only in runtime: %s", runtimeSnapshot[j]))
+			j++
+		}
+	}
+	for ; i < len(cliSnapshot); i++ {
+		addDiff(fmt.Sprintf("only in CLI: %s", cliSnapshot[i]))
+	}
+	for ; j < len(runtimeSnapshot); j++ {
+		addDiff(fmt.Sprintf("only in runtime: %s", runtimeSnapshot[j]))
+	}
+	if len(diffs) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, diff := range diffs {
+		b.WriteString(diff)
+		b.WriteByte('\n')
+	}
+	if omitted > 0 {
+		fmt.Fprintf(&b, "... %d more differences omitted\n", omitted)
+	}
+	fmt.Fprintf(&b, "CLI entries: %d\nruntime entries: %d", len(cliSnapshot), len(runtimeSnapshot))
+	return b.String()
+}
+
+func TestFirstSchemaSnapshotDiff(t *testing.T) {
+	cliSnapshot := []string{"a", "c", "e"}
+	runtimeSnapshot := []string{"a", "b", "d"}
+	diff := firstSchemaSnapshotDiff(cliSnapshot, runtimeSnapshot)
+	for _, want := range []string{
+		"only in runtime: b",
+		"only in CLI: c",
+		"only in runtime: d",
+		"only in CLI: e",
+		"CLI entries: 3",
+		"runtime entries: 3",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("diff = %q, want %q", diff, want)
+		}
+	}
+}

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -3,34 +3,59 @@ package schema
 // cliCompatibleMigrationSQL returns migration SQL suitable for `dolt sql -q`
 // against a fresh test database. The Dolt CLI accepts PREPARE/EXECUTE DDL but
 // does not apply some prepared ALTER TABLE statements in this path, so the
-// fresh-schema bundle uses direct DDL for migrations that create columns later
-// statements depend on. Runtime migrations still use the source files.
+// fresh-schema bundle uses direct DDL for prepared DDL that can change the
+// committed schema shape. The bundle's contract is to reproduce the runtime
+// committed schema for a fresh database; runtime migrations still use the source
+// files and remain the source of truth for upgrades of existing databases.
 func cliCompatibleMigrationSQL(name, sqlText string) string {
 	switch name {
+	case "0008_create_child_counters.up.sql":
+		// Fresh bundle bakes the final FK shape that runtime reaches after
+		// 0039 drops the original FK and ignored migration 0002 re-adds it.
+		return cliMigration0008CreateChildCounters
 	case "0023_add_no_history_column.up.sql":
 		return cliMigration0023AddNoHistoryColumn
 	case "0027_add_started_at.up.sql":
 		return cliMigration0027AddStartedAt
+	case "0032_drop_schema_migrations_applied_at.up.sql":
+		return cliMigration0032DropSchemaMigrationsAppliedAt
 	case "0033_add_wisp_type_column.up.sql":
+		// No-op on fresh schema: wisp_type is already in squashed base 0001.
 		return "SELECT 1;"
 	case "0034_add_spec_id_column.up.sql":
+		// No-op on fresh schema: spec_id and idx_issues_spec_id are in 0001.
+		return "SELECT 1;"
+	case "0039_drop_child_counters_fk.up.sql":
+		// No-op here because 0008 already emits the final ignored-0002 FK.
 		return "SELECT 1;"
 	case "0041_split_dependencies_target.up.sql":
 		return cliMigration0041SplitDependenciesTarget
 	case "0043_drop_dependencies_generated_column.up.sql":
 		return cliMigration0043DropDependenciesGeneratedColumn
 	case "0046_add_is_blocked.up.sql":
+		// Fresh databases contain no issue graph, so only the schema delta is
+		// needed; the source migration's recursive backfill is dead work here.
 		return cliMigration0046AddIsBlocked
+	case "0049_longtext_large_content_columns.up.sql":
+		return cliMigration0049LongtextLargeContentColumns
 	default:
 		return sqlText
 	}
 }
+
+const cliMigration0008CreateChildCounters = `CREATE TABLE IF NOT EXISTS child_counters (
+    parent_id VARCHAR(255) PRIMARY KEY,
+    last_child INT NOT NULL DEFAULT 0,
+    CONSTRAINT fk_counter_parent FOREIGN KEY (parent_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE
+);`
 
 const cliMigration0023AddNoHistoryColumn = `ALTER TABLE issues ADD COLUMN no_history TINYINT(1) DEFAULT 0;
 ALTER TABLE wisps ADD COLUMN no_history TINYINT(1) DEFAULT 0;`
 
 const cliMigration0027AddStartedAt = `ALTER TABLE issues ADD COLUMN started_at DATETIME;
 ALTER TABLE wisps ADD COLUMN started_at DATETIME;`
+
+const cliMigration0032DropSchemaMigrationsAppliedAt = `ALTER TABLE schema_migrations DROP COLUMN applied_at;`
 
 const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
 CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');
@@ -82,31 +107,10 @@ ALTER TABLE dependencies ADD CONSTRAINT fk_dep_issue_target FOREIGN KEY (depends
 SET FOREIGN_KEY_CHECKS = 1;`
 
 const cliMigration0046AddIsBlocked = `ALTER TABLE issues ADD COLUMN is_blocked TINYINT(1) NOT NULL DEFAULT 0;
-CREATE INDEX idx_issues_is_blocked ON issues(is_blocked, status);
+CREATE INDEX idx_issues_is_blocked ON issues(is_blocked, status);`
 
-UPDATE issues SET is_blocked = 0;
-
-WITH RECURSIVE
-  directly_blocked(id) AS (
-    SELECT DISTINCT i.id
-    FROM issues i
-    JOIN dependencies d ON d.issue_id = i.id
-    JOIN issues t ON t.id = d.depends_on_issue_id
-    WHERE i.status NOT IN ('closed', 'pinned')
-      AND d.type IN ('blocks', 'conditional-blocks', 'waits-for')
-      AND t.status NOT IN ('closed', 'pinned')
-  ),
-  recursively_blocked(id) AS (
-    SELECT id FROM directly_blocked
-    UNION
-    SELECT d.issue_id
-    FROM dependencies d
-    JOIN recursively_blocked rb ON rb.id = d.depends_on_issue_id
-    JOIN issues i ON i.id = d.issue_id
-    WHERE i.status NOT IN ('closed', 'pinned')
-      AND d.type IN ('blocks', 'conditional-blocks', 'waits-for')
-  )
-UPDATE issues
-JOIN recursively_blocked rb ON rb.id = issues.id
-SET is_blocked = 1
-WHERE issues.status NOT IN ('closed', 'pinned');`
+const cliMigration0049LongtextLargeContentColumns = `ALTER TABLE issues MODIFY COLUMN description LONGTEXT NOT NULL, MODIFY COLUMN design LONGTEXT NOT NULL, MODIFY COLUMN acceptance_criteria LONGTEXT NOT NULL, MODIFY COLUMN notes LONGTEXT NOT NULL;
+ALTER TABLE issues MODIFY COLUMN close_reason LONGTEXT DEFAULT '';
+ALTER TABLE wisps MODIFY COLUMN description LONGTEXT NOT NULL DEFAULT '', MODIFY COLUMN design LONGTEXT NOT NULL DEFAULT '', MODIFY COLUMN acceptance_criteria LONGTEXT NOT NULL DEFAULT '', MODIFY COLUMN notes LONGTEXT NOT NULL DEFAULT '';
+ALTER TABLE wisps MODIFY COLUMN close_reason LONGTEXT DEFAULT '';
+ALTER TABLE comments MODIFY COLUMN text LONGTEXT NOT NULL;`

--- a/internal/storage/schema/cli_migrations.go
+++ b/internal/storage/schema/cli_migrations.go
@@ -1,0 +1,112 @@
+package schema
+
+// cliCompatibleMigrationSQL returns migration SQL suitable for `dolt sql -q`
+// against a fresh test database. The Dolt CLI accepts PREPARE/EXECUTE DDL but
+// does not apply some prepared ALTER TABLE statements in this path, so the
+// fresh-schema bundle uses direct DDL for migrations that create columns later
+// statements depend on. Runtime migrations still use the source files.
+func cliCompatibleMigrationSQL(name, sqlText string) string {
+	switch name {
+	case "0023_add_no_history_column.up.sql":
+		return cliMigration0023AddNoHistoryColumn
+	case "0027_add_started_at.up.sql":
+		return cliMigration0027AddStartedAt
+	case "0033_add_wisp_type_column.up.sql":
+		return "SELECT 1;"
+	case "0034_add_spec_id_column.up.sql":
+		return "SELECT 1;"
+	case "0041_split_dependencies_target.up.sql":
+		return cliMigration0041SplitDependenciesTarget
+	case "0043_drop_dependencies_generated_column.up.sql":
+		return cliMigration0043DropDependenciesGeneratedColumn
+	case "0046_add_is_blocked.up.sql":
+		return cliMigration0046AddIsBlocked
+	default:
+		return sqlText
+	}
+}
+
+const cliMigration0023AddNoHistoryColumn = `ALTER TABLE issues ADD COLUMN no_history TINYINT(1) DEFAULT 0;
+ALTER TABLE wisps ADD COLUMN no_history TINYINT(1) DEFAULT 0;`
+
+const cliMigration0027AddStartedAt = `ALTER TABLE issues ADD COLUMN started_at DATETIME;
+ALTER TABLE wisps ADD COLUMN started_at DATETIME;`
+
+const cliMigration0041SplitDependenciesTarget = `DELETE FROM dolt_nonlocal_tables;
+CALL DOLT_COMMIT('-Am', 'disable nonlocal tables for fk migrations');
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE dependencies ADD COLUMN depends_on_issue_id VARCHAR(255) NULL;
+ALTER TABLE dependencies ADD COLUMN depends_on_wisp_id VARCHAR(255) NULL;
+ALTER TABLE dependencies ADD COLUMN depends_on_external VARCHAR(255) NULL;
+
+UPDATE dependencies SET depends_on_external = depends_on_id WHERE depends_on_id LIKE 'external:%';
+UPDATE dependencies d JOIN wisps w ON w.id = d.depends_on_id SET d.depends_on_wisp_id = d.depends_on_id WHERE d.depends_on_external IS NULL;
+UPDATE dependencies d JOIN issues i ON i.id = d.depends_on_id SET d.depends_on_issue_id = d.depends_on_id WHERE d.depends_on_external IS NULL AND d.depends_on_wisp_id IS NULL;
+UPDATE dependencies SET depends_on_external = depends_on_id WHERE depends_on_external IS NULL AND depends_on_wisp_id IS NULL AND depends_on_issue_id IS NULL;
+
+ALTER TABLE dependencies DROP INDEX idx_dependencies_depends_on;
+ALTER TABLE dependencies DROP INDEX idx_dependencies_depends_on_type;
+ALTER TABLE dependencies DROP PRIMARY KEY;
+ALTER TABLE dependencies DROP COLUMN depends_on_id;
+
+ALTER TABLE dependencies ADD CONSTRAINT fk_dep_issue_target FOREIGN KEY (depends_on_issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE dependencies ADD COLUMN depends_on_id VARCHAR(255) AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED;
+ALTER TABLE dependencies ADD PRIMARY KEY (issue_id, depends_on_id);
+ALTER TABLE dependencies ADD INDEX idx_dep_wisp_target (depends_on_wisp_id);
+ALTER TABLE dependencies ADD INDEX idx_dep_issue_target (depends_on_issue_id);
+ALTER TABLE dependencies ADD INDEX idx_dep_external_target (depends_on_external);
+ALTER TABLE dependencies ADD INDEX idx_dep_type_target (type, depends_on_id);
+ALTER TABLE dependencies ADD CONSTRAINT ck_dep_one_target CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1);
+
+SET FOREIGN_KEY_CHECKS = 1;`
+
+const cliMigration0043DropDependenciesGeneratedColumn = `SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE dependencies DROP INDEX idx_dep_type_target;
+ALTER TABLE dependencies DROP FOREIGN KEY fk_dep_issue_target;
+ALTER TABLE dependencies DROP FOREIGN KEY fk_dep_issue;
+ALTER TABLE dependencies DROP PRIMARY KEY;
+ALTER TABLE dependencies DROP COLUMN depends_on_id;
+
+ALTER TABLE dependencies ADD COLUMN id CHAR(36) NOT NULL DEFAULT (UUID()) PRIMARY KEY FIRST;
+ALTER TABLE dependencies ADD UNIQUE KEY uk_dep_issue_target (issue_id, depends_on_issue_id);
+ALTER TABLE dependencies ADD UNIQUE KEY uk_dep_wisp_target (issue_id, depends_on_wisp_id);
+ALTER TABLE dependencies ADD UNIQUE KEY uk_dep_external_target (issue_id, depends_on_external);
+ALTER TABLE dependencies ADD INDEX idx_dep_type_issue (type, depends_on_issue_id);
+ALTER TABLE dependencies ADD INDEX idx_dep_type_wisp (type, depends_on_wisp_id);
+ALTER TABLE dependencies ADD INDEX idx_dep_type_external (type, depends_on_external);
+ALTER TABLE dependencies ADD CONSTRAINT fk_dep_issue FOREIGN KEY (issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE dependencies ADD CONSTRAINT fk_dep_issue_target FOREIGN KEY (depends_on_issue_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE;
+
+SET FOREIGN_KEY_CHECKS = 1;`
+
+const cliMigration0046AddIsBlocked = `ALTER TABLE issues ADD COLUMN is_blocked TINYINT(1) NOT NULL DEFAULT 0;
+CREATE INDEX idx_issues_is_blocked ON issues(is_blocked, status);
+
+UPDATE issues SET is_blocked = 0;
+
+WITH RECURSIVE
+  directly_blocked(id) AS (
+    SELECT DISTINCT i.id
+    FROM issues i
+    JOIN dependencies d ON d.issue_id = i.id
+    JOIN issues t ON t.id = d.depends_on_issue_id
+    WHERE i.status NOT IN ('closed', 'pinned')
+      AND d.type IN ('blocks', 'conditional-blocks', 'waits-for')
+      AND t.status NOT IN ('closed', 'pinned')
+  ),
+  recursively_blocked(id) AS (
+    SELECT id FROM directly_blocked
+    UNION
+    SELECT d.issue_id
+    FROM dependencies d
+    JOIN recursively_blocked rb ON rb.id = d.depends_on_issue_id
+    JOIN issues i ON i.id = d.issue_id
+    WHERE i.status NOT IN ('closed', 'pinned')
+      AND d.type IN ('blocks', 'conditional-blocks', 'waits-for')
+  )
+UPDATE issues
+JOIN recursively_blocked rb ON rb.id = issues.id
+SET is_blocked = 1
+WHERE issues.status NOT IN ('closed', 'pinned');`

--- a/internal/storage/schema/schema.go
+++ b/internal/storage/schema/schema.go
@@ -179,8 +179,8 @@ func AllMigrationsSQL() string {
 		if err != nil {
 			continue
 		}
-		b.Write(data)
-		b.WriteByte('\n')
+		b.WriteString(cliCompatibleMigrationSQL(f.name, string(data)))
+		fmt.Fprintf(&b, "\nINSERT IGNORE INTO %s (version) VALUES (%d);\n", mainSource.cursorTable, f.version)
 	}
 	return b.String()
 }

--- a/internal/storage/schema/schema_test.go
+++ b/internal/storage/schema/schema_test.go
@@ -2,11 +2,17 @@ package schema
 
 import (
 	"context"
+	"encoding/csv"
+	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 func TestPendingMigrationDirtyTablesDetectsMigration0043Dependencies(t *testing.T) {
@@ -200,6 +206,248 @@ func TestMigration0047HandlesLegacyWispDependenciesShape(t *testing.T) {
 			t.Fatalf("0047 migration missing legacy wisp_dependencies compatibility marker %q", want)
 		}
 	}
+}
+
+func TestCLICompatibleMigration0046UsesFreshSchemaDDLOnly(t *testing.T) {
+	got := cliCompatibleMigrationSQL("0046_add_is_blocked.up.sql", "source migration")
+	for _, want := range []string{
+		"ALTER TABLE issues ADD COLUMN is_blocked TINYINT(1) NOT NULL DEFAULT 0",
+		"CREATE INDEX idx_issues_is_blocked ON issues(is_blocked, status)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("0046 CLI migration missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"UPDATE issues",
+		"WITH RECURSIVE",
+		"directly_blocked",
+		"recursively_blocked",
+		"parent-child",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("0046 CLI migration contains dead backfill marker %q", forbidden)
+		}
+	}
+}
+
+func TestCLICompatibleMigration0008MatchesRuntimeChildCountersFK(t *testing.T) {
+	got := cliCompatibleMigrationSQL("0008_create_child_counters.up.sql", "source migration")
+	if want := "CONSTRAINT fk_counter_parent FOREIGN KEY (parent_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE"; !strings.Contains(got, want) {
+		t.Fatalf("0008 CLI migration missing %q", want)
+	}
+}
+
+func TestCLICompatibleMigration0032UsesDirectDropColumn(t *testing.T) {
+	got := cliCompatibleMigrationSQL("0032_drop_schema_migrations_applied_at.up.sql", "source migration")
+	if want := "ALTER TABLE schema_migrations DROP COLUMN applied_at"; !strings.Contains(got, want) {
+		t.Fatalf("0032 CLI migration missing %q", want)
+	}
+	for _, forbidden := range []string{
+		"PREPARE",
+		"EXECUTE",
+		"DEALLOCATE",
+		"@needs_drop",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("0032 CLI migration contains prepared-DDL marker %q", forbidden)
+		}
+	}
+}
+
+func TestCLICompatibleMigration0049UsesDirectLongtextDDL(t *testing.T) {
+	got := cliCompatibleMigrationSQL("0049_longtext_large_content_columns.up.sql", "source migration")
+	for _, want := range []string{
+		"ALTER TABLE issues MODIFY COLUMN description LONGTEXT NOT NULL",
+		"MODIFY COLUMN design LONGTEXT NOT NULL",
+		"MODIFY COLUMN acceptance_criteria LONGTEXT NOT NULL",
+		"MODIFY COLUMN notes LONGTEXT NOT NULL",
+		"ALTER TABLE issues MODIFY COLUMN close_reason LONGTEXT DEFAULT ''",
+		"ALTER TABLE wisps MODIFY COLUMN description LONGTEXT NOT NULL DEFAULT ''",
+		"ALTER TABLE wisps MODIFY COLUMN close_reason LONGTEXT DEFAULT ''",
+		"ALTER TABLE comments MODIFY COLUMN text LONGTEXT NOT NULL",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("0049 CLI migration missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"PREPARE",
+		"EXECUTE",
+		"DEALLOCATE",
+		"@issues_needs_fix",
+		"@comments_needs_fix",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("0049 CLI migration contains prepared-DDL marker %q", forbidden)
+		}
+	}
+}
+
+func TestCLICompatibleMigration0039PreservesRuntimeChildCountersFK(t *testing.T) {
+	got := cliCompatibleMigrationSQL("0039_drop_child_counters_fk.up.sql", "source migration")
+	if strings.TrimSpace(got) != "SELECT 1;" {
+		t.Fatalf("0039 CLI migration = %q, want SELECT 1", got)
+	}
+}
+
+func TestAllMigrationsSQLUsesDirectDDLForKnownCLIIncompatibilities(t *testing.T) {
+	got := AllMigrationsSQL()
+	for _, want := range []string{
+		"CONSTRAINT fk_counter_parent FOREIGN KEY (parent_id) REFERENCES issues(id) ON DELETE CASCADE ON UPDATE CASCADE",
+		"ALTER TABLE schema_migrations DROP COLUMN applied_at",
+		"ALTER TABLE issues MODIFY COLUMN close_reason LONGTEXT DEFAULT ''",
+		"ALTER TABLE comments MODIFY COLUMN text LONGTEXT NOT NULL",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("AllMigrationsSQL missing direct CLI DDL %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"COLUMN_NAME = 'applied_at'",
+		"ALTER TABLE child_counters DROP FOREIGN KEY fk_counter_parent",
+		"@issues_cr_needs_fix",
+		"@comments_needs_fix",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("AllMigrationsSQL contains source prepared-DDL guard %q", forbidden)
+		}
+	}
+}
+
+func TestAllMigrationsSQLAppliesThroughDoltCLIAndRecordsLatestVersion(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	dir := filepath.Join(t.TempDir(), "cli-bundle")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create CLI bundle dir: %v", err)
+	}
+	runDoltCommand(t, dir, "init", "--name", "test", "--email", "test@example.com")
+	runDoltSQL(t, dir, AllMigrationsSQL())
+
+	rows := queryDoltCSV(t, dir, `
+SELECT COALESCE(MAX(version), 0) AS max_version, COUNT(*) AS version_count
+FROM schema_migrations`)
+	if len(rows) != 1 {
+		t.Fatalf("schema_migrations query returned %d rows, want 1", len(rows))
+	}
+	want := strconv.Itoa(LatestVersion())
+	if got := rows[0]["max_version"]; got != want {
+		t.Fatalf("MAX(version) = %s, want %s", got, want)
+	}
+	if got := rows[0]["version_count"]; got != want {
+		t.Fatalf("COUNT(*) = %s, want %s", got, want)
+	}
+
+	requireDoltNoRows(t, dir, `
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'schema_migrations'
+  AND column_name = 'applied_at'`, "schema_migrations.applied_at")
+	requireDoltFKRules(t, dir, "fk_comments_issue", "CASCADE", "CASCADE")
+	requireDoltColumnShape(t, dir, "comments", "text", "longtext", "NO")
+	requireDoltColumnShape(t, dir, "issues", "description", "longtext", "NO")
+	requireDoltColumnShape(t, dir, "wisps", "description", "longtext", "NO")
+	requireDoltColumnShape(t, dir, "wisps", "no_history", "tinyint(1)", "YES")
+	requireDoltColumnShape(t, dir, "wisps", "started_at", "datetime", "YES")
+	requireDoltColumnShape(t, dir, "wisps", "wisp_type", "varchar(32)", "YES")
+}
+
+func runDoltCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("dolt", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("dolt %v failed in %s: %v\nOutput: %s", args, dir, err, output)
+	}
+}
+
+func runDoltSQL(t *testing.T, dir, query string) {
+	t.Helper()
+	args := []string{"sql", "-q", query}
+	runDoltCommand(t, dir, args...)
+}
+
+func queryDoltCSV(t *testing.T, dir, query string) []map[string]string {
+	t.Helper()
+	cmd := exec.Command("dolt", "sql", "-q", query, "-r", "csv")
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("dolt sql query failed in %s: %v\nQuery: %s\nOutput: %s", dir, err, query, output)
+	}
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil
+	}
+	records, err := csv.NewReader(strings.NewReader(trimmed)).ReadAll()
+	if err != nil {
+		t.Fatalf("parse dolt CSV output: %v\nRaw: %s", err, output)
+	}
+	if len(records) < 2 {
+		return nil
+	}
+	headers := records[0]
+	rows := make([]map[string]string, 0, len(records)-1)
+	for _, record := range records[1:] {
+		row := make(map[string]string, len(headers))
+		for i, header := range headers {
+			if i < len(record) {
+				row[header] = record[i]
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func requireDoltNoRows(t *testing.T, dir, query, subject string) {
+	t.Helper()
+	if rows := queryDoltCSV(t, dir, query); len(rows) != 0 {
+		t.Fatalf("%s query returned %d rows, want none: %v", subject, len(rows), rows)
+	}
+}
+
+func requireDoltFKRules(t *testing.T, dir, constraintName, wantUpdate, wantDelete string) {
+	t.Helper()
+	rows := queryDoltCSV(t, dir, fmt.Sprintf(`
+SELECT update_rule AS update_rule, delete_rule AS delete_rule
+FROM information_schema.referential_constraints
+WHERE constraint_schema = DATABASE()
+  AND constraint_name = %s`, doltSQLString(constraintName)))
+	if len(rows) != 1 {
+		t.Fatalf("%s FK query returned %d rows, want 1: %v", constraintName, len(rows), rows)
+	}
+	if got := rows[0]["update_rule"]; got != wantUpdate {
+		t.Fatalf("%s UPDATE_RULE = %s, want %s", constraintName, got, wantUpdate)
+	}
+	if got := rows[0]["delete_rule"]; got != wantDelete {
+		t.Fatalf("%s DELETE_RULE = %s, want %s", constraintName, got, wantDelete)
+	}
+}
+
+func requireDoltColumnShape(t *testing.T, dir, tableName, columnName, wantType, wantNullable string) {
+	t.Helper()
+	rows := queryDoltCSV(t, dir, fmt.Sprintf(`
+SELECT column_type AS column_type, is_nullable AS is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = %s
+  AND column_name = %s`, doltSQLString(tableName), doltSQLString(columnName)))
+	if len(rows) != 1 {
+		t.Fatalf("%s.%s column query returned %d rows, want 1: %v", tableName, columnName, len(rows), rows)
+	}
+	if got := rows[0]["column_type"]; got != wantType {
+		t.Fatalf("%s.%s COLUMN_TYPE = %s, want %s", tableName, columnName, got, wantType)
+	}
+	if got := rows[0]["is_nullable"]; got != wantNullable {
+		t.Fatalf("%s.%s IS_NULLABLE = %s, want %s", tableName, columnName, got, wantNullable)
+	}
+}
+
+func doltSQLString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
 }
 
 func TestStageSchemaTablesSkipsIgnoredTables(t *testing.T) {


### PR DESCRIPTION
Splits the fresh-schema migration SQL repair out of the CI refactor branch. AllMigrationsSQL now emits Dolt CLI-compatible DDL for migrations that prepared ALTER statements do not apply correctly in dolt sql -q fresh database setup; runtime migrations still use the source migration files.\n\nValidation:\n- go test ./internal/storage/schema\n- go test -tags integration ./internal/storage/dolt -run TestGitRemotePushEmptyDB -count=1