### PR TITLE
fix(docs): pin LC_ALL=C in generate-llms-full.sh to stop locale-order drift

### DIFF
--- a/release-gates/be-d1c-lc-all-c-gate.md
+++ b/release-gates/be-d1c-lc-all-c-gate.md
@@ -1,0 +1,42 @@
+# Release Gate: be-d1c — fix LC_ALL=C in generate-llms-full.sh
+
+**Bead:** be-dsj (deploy) → be-d1c (task) → be-dsp (review)
+**Branch:** fix/be-d1c-lc-all-c
+**Commit:** 5ef705287 (cherry-picked from 8e07ad962 on feat/be-3w6-be-0c8-nopush-dolt)
+**Date:** 2026-05-29
+
+## Gate Checklist
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | **PASS** | be-dsp: `REVIEW VERDICT: PASS` — style clean, security clean, spec fully met, both --check modes verified by builder |
+| 2 | Acceptance criteria met | **PASS** | See AC verification below |
+| 3 | Tests pass | **PASS** | `go test ./scripts/...` — all pass. `internal/tracker` fails with Dolt server infrastructure error pre-existing on main (database "tracker_pkg_shared" not found at 127.0.0.1:28231; unrelated to this script change) |
+| 4 | No high-severity review findings open | **PASS** | Review found no HIGH findings; style/security/spec all clean |
+| 5 | Final branch is clean | **PASS** | `git status` shows branch ahead of main by 1 commit; no uncommitted changes to tracked files |
+| 6 | Branch diverges cleanly from main | **PASS** | Cherry-pick of 8e07ad962 onto origin/main applied with no conflicts; single file changed: `scripts/generate-llms-full.sh` |
+| 7 | Single feature theme | **PASS** | One commit, one file (`scripts/generate-llms-full.sh`), one-line locale pin. Source branch (`feat/be-3w6-be-0c8-nopush-dolt`) also carries no-push commits, but those are being tracked separately under PR #4212. This PR is cherry-picked clean. |
+
+**Overall: PASS**
+
+## Acceptance Criteria Verification
+
+From be-d1c done-when:
+
+1. **`./scripts/generate-llms-full.sh` produces byte-identical output to `LC_ALL=C ./scripts/generate-llms-full.sh` regardless of caller locale** — PASS: both run passes `--check` (exit 0). `export LC_ALL=C` inside the script makes every invocation locale-proof.
+
+2. **`./scripts/generate-llms-full.sh --check` passes under both default locale and `LC_ALL=C`** — PASS:
+   - `./scripts/generate-llms-full.sh --check` → `PASS: website/static/llms-full.txt is fresh` (exit 0)
+   - `LC_ALL=C ./scripts/generate-llms-full.sh --check` → `PASS: website/static/llms-full.txt is fresh` (exit 0)
+
+3. **CI "Check doc flags freshness" passes on a PR that merges current main** — to be verified by CI on the opened PR.
+
+## Change Scope
+
+Single-line addition to `scripts/generate-llms-full.sh`:
+```diff
+ set -euo pipefail
++export LC_ALL=C
+```
+
+Placed immediately after `set -euo pipefail` (line 8). Ensures glob collation in `for file in $DOCS_DIR/$dir/*.md` (line 143) uses byte order (matching CI) regardless of caller locale. Addresses recurring CI failure on PRs #3908/#3985/#4157/#4160/#4212.

--- a/scripts/generate-llms-full.sh
+++ b/scripts/generate-llms-full.sh
@@ -5,6 +5,7 @@
 # llms-full matches the default site version, not unreleased "Next".
 
 set -euo pipefail
+export LC_ALL=C
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"


### PR DESCRIPTION
## What this changes

`scripts/generate-llms-full.sh` now pins `LC_ALL=C` at the top of the script, immediately after `set -euo pipefail`. This makes every invocation locale-proof: the glob expansion that concatenates `cli-reference/*.md` files previously produced different orderings under C/byte-collation (CI) vs UTF-8 (most developer/agent environments), causing `init-safety.md` to sort before or after `init.md` depending on who regenerated the file. The committed `website/static/llms-full.txt` would drift from what CI regenerates, and "Check doc flags freshness" would fail on any PR that merges a main with a drifted file.

This has recurred on PRs #3908, #3985, #4157, #4160, and #4212. The fix is one line inside the script so it's locale-proof for all callers — humans, agents, and CI alike — without requiring call-site changes.

## Review notes

- **Sole change:** `scripts/generate-llms-full.sh` line 8 — `export LC_ALL=C` after `set -euo pipefail`. No Go code touched.
- **Acceptance:** Both `./scripts/generate-llms-full.sh --check` and `LC_ALL=C ./scripts/generate-llms-full.sh --check` return exit 0 and print PASS.
- **Out of scope:** Making doc-flags run on push-to-main; touching `check-doc-freshness.sh` or `generate-cli-docs.sh`; regenerating versioned_docs snapshots.

## Test plan

- [x] `./scripts/generate-llms-full.sh --check` — PASS (exit 0)
- [x] `LC_ALL=C ./scripts/generate-llms-full.sh --check` — PASS (exit 0)
- [x] `go test ./scripts/...` — all pass
- [x] Release gate: [`release-gates/be-d1c-lc-all-c-gate.md`](release-gates/be-d1c-lc-all-c-gate.md)

🤖 Deployed by actual-factory