### PR TITLE
feat(schema): prevention gate for silent in-place migration of remote-backed databases (#4259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Remote-migrate prevention gate.** `bd` now refuses to silently auto-apply pending schema migrations to an existing database that has a remote configured (in both server and embedded mode), and tells the operator to choose: migrate (as the single designated migrator, then `bd dolt push`) or adopt the already-migrated database from the remote (`bd bootstrap`). Migrating each clone independently forks the schema and breaks `bd dolt pull` ([#4259](https://github.com/gastownhall/beads/issues/4259)). The gate is a no-op for fresh databases, databases already at the binary's version, databases with no remote, and read-only opens. The designated migrator proceeds with `BD_ALLOW_REMOTE_MIGRATE=1`.
+- **Remote-migrate prevention gate.** `bd` now refuses to silently auto-apply pending schema migrations to an existing database that has a remote configured (in both server and embedded mode), and tells the operator to choose: migrate (as the single designated migrator, then `bd dolt push`) or adopt the already-migrated database from the remote (`bd bootstrap`). Migrating each clone independently forks the schema and breaks `bd dolt pull` ([#4259](https://github.com/gastownhall/beads/issues/4259)). The gate is a no-op for fresh databases, databases already at the binary's version, databases with no remote, and read-only opens. The designated migrator proceeds with `BD_ALLOW_REMOTE_MIGRATE=1`. In server mode the gate also detects remotes persisted on disk in `.dolt/config`, so a freshly (auto-)started server — whose in-memory `dolt_remotes` table is not yet populated — cannot slip a remote-backed database past the gate.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Remote-migrate prevention gate.** `bd` now refuses to silently auto-apply pending schema migrations to an existing database that has a remote configured (in both server and embedded mode), and tells the operator to choose: migrate (as the single designated migrator, then `bd dolt push`) or adopt the already-migrated database from the remote (`bd bootstrap`). Migrating each clone independently forks the schema and breaks `bd dolt pull` ([#4259](https://github.com/gastownhall/beads/issues/4259)). The gate is a no-op for fresh databases, databases already at the binary's version, databases with no remote, and read-only opens. The designated migrator proceeds with `BD_ALLOW_REMOTE_MIGRATE=1`.
+
 ### Fixed
 
 - **Deterministic dependency primary keys (cross-clone merge-safety).** `dependencies.id` (and `wisp_dependencies.id`) were filled by `DEFAULT (UUID())`, a per-clone-random value. Two clones that created the same edge — or that applied migration `0043` independently — diverged on the primary key, so `bd dolt pull` failed unrecoverably (`cannot merge because table dependencies has different primary keys in its common ancestor`, or a `uk_dep_*` unique-key violation). `id` is now derived deterministically from the natural edge key `(issue_id, target)` at every insert site (`internal/storage/depid`); migration `0050` drops the random default and idempotently re-asserts the natural-identity unique keys; and an upgrade backfill rewrites existing rows. Independently-migrated clones now converge to byte-identical, merge-safe `dependencies`. And because the same edge now has the same primary key on every clone, `bd dolt pull` **auto-resolves** a same-edge dependency conflict that differs only in audit columns (created_at/created_by/metadata/thread_id) the same way it already does for the metadata table — so two machines that each run `bd dep add X Y` between syncs merge cleanly. A conflict where the dependency *type* differs is still surfaced for the operator. ([#4259](https://github.com/gastownhall/beads/issues/4259))

--- a/cmd/bd/bootstrap.go
+++ b/cmd/bd/bootstrap.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 	"github.com/steveyegge/beads/internal/storage/dolt"
 	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/schema"
 	"github.com/steveyegge/beads/internal/storage/versioncontrolops"
 	"golang.org/x/term"
 )
@@ -644,6 +646,14 @@ func executeSyncAction(ctx context.Context, plan BootstrapPlan, cfg *configfile.
 	// Both embedded and server mode handle this in their store init paths.
 	warmupStore, err := newDoltStoreFromConfig(ctx, plan.BeadsDir)
 	if err != nil {
+		// #4259: if the cloned remote is behind this binary, the remote-migrate
+		// gate holds migration for an explicit operator decision. Bootstrap is
+		// otherwise complete; the gate (with its instructions) surfaces on the
+		// next command, so don't emit the unrelated wisp-table warning here.
+		var gateErr *schema.RemoteMigrateGateError
+		if errors.As(err, &gateErr) {
+			return nil
+		}
 		// Non-fatal: wisp tables will be created on the next command that
 		// opens the store. Warn so the user knows to retry if they hit
 		// "table not found: wisp_*" errors.

--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -1083,6 +1083,17 @@ var rootCmd = &cobra.Command{
 				}
 				os.Exit(1)
 			}
+			// #4259: the remote-migrate gate blocks silent in-place migration of a
+			// remote-backed database and tells the operator to migrate-or-adopt.
+			var gateErr *schema.RemoteMigrateGateError
+			if errors.As(err, &gateErr) {
+				if jsonOutput {
+					handleRemoteMigrateGateJSON(gateErr)
+				} else {
+					fmt.Fprint(os.Stderr, gateErr.UserMessage())
+				}
+				os.Exit(1)
+			}
 			FatalError("failed to open database: %v", err)
 		}
 

--- a/cmd/bd/remote_migrate_gate.go
+++ b/cmd/bd/remote_migrate_gate.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// handleRemoteMigrateGateJSON renders the #4259 remote-migrate gate error as a
+// structured JSON error block, mirroring handleSchemaSkewJSON.
+func handleRemoteMigrateGateJSON(e *schema.RemoteMigrateGateError) {
+	outer := buildJSONError(e.Error(), e.EscapeHint())
+	if m, ok := outer.(map[string]interface{}); ok {
+		m["remote_migrate_gate"] = map[string]interface{}{
+			"current_version": e.CurrentVersion,
+			"latest_version":  e.LatestVersion,
+			"pending":         e.Pending,
+		}
+	}
+	encoder := json.NewEncoder(os.Stderr)
+	encoder.SetIndent("", "  ")
+	_ = encoder.Encode(outer)
+}

--- a/cmd/bd/remote_migrate_gate_test.go
+++ b/cmd/bd/remote_migrate_gate_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestHandleRemoteMigrateGateJSON_Shape verifies the JSON written to stderr has
+// the expected shape: error one-liner, hint (escape-hatch string), and a
+// remote_migrate_gate subobject with current/latest/pending.
+func TestHandleRemoteMigrateGateJSON_Shape(t *testing.T) {
+	gate := &schema.RemoteMigrateGateError{CurrentVersion: 48, LatestVersion: 50, Pending: 2}
+
+	origStderr := os.Stderr
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatal(pipeErr)
+	}
+	os.Stderr = w
+
+	handleRemoteMigrateGateJSON(gate)
+
+	_ = w.Close()
+	os.Stderr = origStderr
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	_ = r.Close()
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("json.Unmarshal stderr: %v\nstderr was: %s", err, buf.String())
+	}
+
+	if got, ok := parsed["error"].(string); !ok || got != gate.Error() {
+		t.Errorf("error = %v, want %q", parsed["error"], gate.Error())
+	}
+	if got, ok := parsed["hint"].(string); !ok || got != gate.EscapeHint() {
+		t.Errorf("hint = %v, want %q", parsed["hint"], gate.EscapeHint())
+	}
+
+	obj, ok := parsed["remote_migrate_gate"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("remote_migrate_gate key missing or wrong type: %T", parsed["remote_migrate_gate"])
+	}
+	if got, ok := obj["current_version"].(float64); !ok || int(got) != 48 {
+		t.Errorf("current_version = %v, want 48", obj["current_version"])
+	}
+	if got, ok := obj["latest_version"].(float64); !ok || int(got) != 50 {
+		t.Errorf("latest_version = %v, want 50", obj["latest_version"])
+	}
+	if got, ok := obj["pending"].(float64); !ok || int(got) != 2 {
+		t.Errorf("pending = %v, want 2", obj["pending"])
+	}
+}

--- a/internal/storage/dolt/federation.go
+++ b/internal/storage/dolt/federation.go
@@ -145,6 +145,31 @@ func (s *DoltStore) ListRemotes(ctx context.Context) ([]storage.RemoteInfo, erro
 	return versioncontrolops.ListRemotes(ctx, s.db)
 }
 
+// hasPersistedCLIRemote reports whether a Dolt remote is persisted on disk in
+// .dolt/config — in the database CLI directory (CLIDir) or the dolt server root
+// (Path, per GH#2118). A freshly (auto-)started sql-server can report an empty
+// dolt_remotes table at store open even though remotes are persisted on disk.
+// The #4259 remote-migrate gate therefore consults this directly so a
+// cold-start open cannot miss the remote and migrate the shared database in
+// place. Best-effort: a missing dolt binary, a non-dolt directory, or any
+// listing error counts as "no remote found" rather than wedging the open.
+func (s *DoltStore) hasPersistedCLIRemote() bool {
+	cliDir := s.CLIDir()
+	dirs := []string{cliDir}
+	if s.dbPath != "" && s.dbPath != cliDir {
+		dirs = append(dirs, s.dbPath)
+	}
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		if remotes, err := doltutil.ListCLIRemotes(dir); err == nil && len(remotes) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // RemoveRemote removes a configured remote.
 func (s *DoltStore) RemoveRemote(ctx context.Context, name string) error {
 	return versioncontrolops.RemoveRemote(ctx, s.db, name)

--- a/internal/storage/dolt/remote_migrate_gate_test.go
+++ b/internal/storage/dolt/remote_migrate_gate_test.go
@@ -1,0 +1,71 @@
+package dolt
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestDoltNew_RemoteMigrateGate_BlocksReopen is a full-chain integration test:
+// opening a read/write server-mode store against an existing, remote-backed
+// database that is behind the binary must refuse to auto-migrate and return a
+// *schema.RemoteMigrateGateError instead of silently forking the schema (#4259).
+func TestDoltNew_RemoteMigrateGate_BlocksReopen(t *testing.T) {
+	skipIfNoDolt(t)
+	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
+
+	ctx, cancel := testContext(t)
+	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+
+	// Create and fully migrate the database.
+	store, err := New(ctx, &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("New (create): %v", err)
+	}
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 5*testTimeout)
+		defer dropCancel()
+		_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		store.Close()
+	}()
+
+	// Simulate an existing database one migration behind this binary by dropping
+	// the latest cursor row (the schema change itself stays applied; only the
+	// recorded version regresses, so the gate sees a pending migration).
+	if _, err := store.db.ExecContext(ctx,
+		"DELETE FROM schema_migrations WHERE version = ?", schema.LatestVersion()); err != nil {
+		t.Fatalf("regress schema_migrations: %v", err)
+	}
+	// Register a remote so the database is remote-backed.
+	if _, err := store.db.ExecContext(ctx,
+		"CALL DOLT_REMOTE('add', 'origin', ?)", "file://"+filepath.Join(tmpDir, "remote")); err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+
+	// Reopening read/write must hit the gate.
+	reopened, reErr := New(ctx, &Config{
+		Path:           tmpDir,
+		CommitterName:  "test",
+		CommitterEmail: "test@example.com",
+		Database:       dbName,
+	})
+	if reErr == nil {
+		reopened.Close()
+		t.Fatal("New (reopen) = nil, want *schema.RemoteMigrateGateError for a behind, remote-backed DB")
+	}
+	if !schema.IsRemoteMigrateGateError(reErr) {
+		t.Fatalf("error = %T (%v), want error wrapping *schema.RemoteMigrateGateError", reErr, reErr)
+	}
+}

--- a/internal/storage/dolt/remote_migrate_gate_test.go
+++ b/internal/storage/dolt/remote_migrate_gate_test.go
@@ -3,16 +3,29 @@ package dolt
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/storage/doltutil"
 	"github.com/steveyegge/beads/internal/storage/schema"
+	"github.com/steveyegge/beads/internal/testutil"
 )
 
 // TestDoltNew_RemoteMigrateGate_BlocksReopen is a full-chain integration test:
 // opening a read/write server-mode store against an existing, remote-backed
 // database that is behind the binary must refuse to auto-migrate and return a
 // *schema.RemoteMigrateGateError instead of silently forking the schema (#4259).
+//
+// It covers both ways the database can be detected as remote-backed, reusing one
+// CREATE/DROP DATABASE cycle (consecutive create/drop cycles destabilize the test
+// dolt server, so a second integration test is deliberately avoided):
+//   - disk path (gastownhall/beads#4268): a CLI remote persisted in .dolt/config
+//     while the SQL dolt_remotes table is still empty — the state of a freshly
+//     (auto-)started server before syncCLIRemotesToSQL runs;
+//   - SQL path: a remote registered in dolt_remotes.
 func TestDoltNew_RemoteMigrateGate_BlocksReopen(t *testing.T) {
 	skipIfNoDolt(t)
 	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
@@ -48,24 +61,99 @@ func TestDoltNew_RemoteMigrateGate_BlocksReopen(t *testing.T) {
 		"DELETE FROM schema_migrations WHERE version = ?", schema.LatestVersion()); err != nil {
 		t.Fatalf("regress schema_migrations: %v", err)
 	}
-	// Register a remote so the database is remote-backed.
+
+	reopen := func() error {
+		s, err := New(ctx, &Config{
+			Path:           tmpDir,
+			CommitterName:  "test",
+			CommitterEmail: "test@example.com",
+			Database:       dbName,
+		})
+		if err == nil {
+			s.Close()
+		}
+		return err
+	}
+
+	// Disk path (#4268): persist a remote ONLY on disk (.dolt/config) at the
+	// database CLI dir, leaving the SQL dolt_remotes table empty. This is the
+	// freshly (auto-)started-server state, where syncCLIRemotesToSQL has not yet
+	// run; an SQL-only gate would miss the remote and migrate in place.
+	cliDir := store.CLIDir()
+	if cliDir == "" {
+		t.Skip("no CLI dir available")
+	}
+	initLocalDoltRepoForRemote(t, cliDir)
+	if err := doltutil.AddCLIRemote(cliDir, "origin", "file://"+filepath.Join(tmpDir, "remote")); err != nil {
+		t.Fatalf("AddCLIRemote: %v", err)
+	}
+	// Precondition: no remote is visible in SQL, so this reopen can only trip the
+	// gate via the on-disk fallback.
+	if remotes, err := store.ListRemotes(ctx); err != nil {
+		t.Fatalf("ListRemotes: %v", err)
+	} else if len(remotes) != 0 {
+		t.Fatalf("precondition failed: SQL dolt_remotes already has %d remote(s); disk fallback not exercised", len(remotes))
+	}
+	if reErr := reopen(); reErr == nil {
+		t.Fatal("New (reopen, disk-only remote) = nil, want *schema.RemoteMigrateGateError")
+	} else if !schema.IsRemoteMigrateGateError(reErr) {
+		t.Fatalf("disk-only remote: error = %T (%v), want *schema.RemoteMigrateGateError", reErr, reErr)
+	}
+
+	// SQL path (#4259): register the remote in dolt_remotes too and confirm the
+	// gate still fires through the original server-session check.
 	if _, err := store.db.ExecContext(ctx,
 		"CALL DOLT_REMOTE('add', 'origin', ?)", "file://"+filepath.Join(tmpDir, "remote")); err != nil {
 		t.Fatalf("add remote: %v", err)
 	}
-
-	// Reopening read/write must hit the gate.
-	reopened, reErr := New(ctx, &Config{
-		Path:           tmpDir,
-		CommitterName:  "test",
-		CommitterEmail: "test@example.com",
-		Database:       dbName,
-	})
-	if reErr == nil {
-		reopened.Close()
-		t.Fatal("New (reopen) = nil, want *schema.RemoteMigrateGateError for a behind, remote-backed DB")
+	if reErr := reopen(); reErr == nil {
+		t.Fatal("New (reopen, SQL remote) = nil, want *schema.RemoteMigrateGateError for a behind, remote-backed DB")
+	} else if !schema.IsRemoteMigrateGateError(reErr) {
+		t.Fatalf("SQL remote: error = %T (%v), want error wrapping *schema.RemoteMigrateGateError", reErr, reErr)
 	}
-	if !schema.IsRemoteMigrateGateError(reErr) {
-		t.Fatalf("error = %T (%v), want error wrapping *schema.RemoteMigrateGateError", reErr, reErr)
+}
+
+// initLocalDoltRepoForRemote prepares dir as a standalone Dolt repository so CLI
+// remote commands (dolt remote add / dolt remote -v) operate on its .dolt/config.
+// Mirrors the setup used by TestSyncCLIRemotesToSQL.
+func initLocalDoltRepoForRemote(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", dir, err)
+	}
+	cmd := exec.Command("dolt", "init", "--name", "test", "--email", "test@test.com")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil && !strings.Contains(string(out), "already") {
+		t.Fatalf("dolt init in %q failed: %s: %v", dir, out, err)
+	}
+}
+
+// TestDoltStore_hasPersistedCLIRemote verifies the on-disk remote probe the #4259
+// gate uses in server mode: it must detect a remote persisted in .dolt/config even
+// when nothing is registered in the SQL dolt_remotes table — the state of a freshly
+// (auto-)started server before syncCLIRemotesToSQL runs (gastownhall/beads#4268).
+// It needs only the dolt binary, not the test server.
+func TestDoltStore_hasPersistedCLIRemote(t *testing.T) {
+	testutil.RequireDoltBinary(t)
+
+	root := t.TempDir()
+	// serverMode + empty beadsDir makes CLIDir() == filepath.Join(dbPath, database),
+	// independent of shared-server resolution.
+	s := &DoltStore{dbPath: root, database: "testdb", serverMode: true}
+
+	cliDir := s.CLIDir()
+	initLocalDoltRepoForRemote(t, cliDir)
+
+	if s.hasPersistedCLIRemote() {
+		t.Fatal("hasPersistedCLIRemote() = true before any remote was added, want false")
+	}
+
+	const name, url = "origin", "file:///tmp/test-haspersisted-remote"
+	if err := doltutil.AddCLIRemote(cliDir, name, url); err != nil {
+		t.Fatalf("AddCLIRemote: %v", err)
+	}
+
+	if !s.hasPersistedCLIRemote() {
+		t.Fatal("hasPersistedCLIRemote() = false after a CLI remote was added, want true")
 	}
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1523,6 +1523,12 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 		return err
 	}
 	defer migDB.Close()
+	// #4259: refuse to silently apply pending migrations to a remote-backed,
+	// already-initialized database — that is how two clones fork the schema.
+	// Checked before the (retried) migration so it fails fast and is not retried.
+	if err := schema.CheckRemoteMigrateGate(ctx, migDB); err != nil {
+		return err
+	}
 	_, err = initSchemaOnDBWithRetry(ctx, migDB)
 	return err
 }

--- a/internal/storage/dolt/store.go
+++ b/internal/storage/dolt/store.go
@@ -1526,7 +1526,11 @@ func (s *DoltStore) initSchema(ctx context.Context) error {
 	// #4259: refuse to silently apply pending migrations to a remote-backed,
 	// already-initialized database — that is how two clones fork the schema.
 	// Checked before the (retried) migration so it fails fast and is not retried.
-	if err := schema.CheckRemoteMigrateGate(ctx, migDB); err != nil {
+	// Use the on-disk fallback: a freshly (auto-)started server can report an
+	// empty dolt_remotes table even though remotes are persisted in .dolt/config
+	// (GH#2315), so an SQL-only check would miss the remote on the first write
+	// open after an upgrade.
+	if err := schema.CheckRemoteMigrateGateWithRemoteCheck(ctx, migDB, s.hasPersistedCLIRemote); err != nil {
 		return err
 	}
 	_, err = initSchemaOnDBWithRetry(ctx, migDB)

--- a/internal/storage/embeddeddolt/remote_migrate_gate_test.go
+++ b/internal/storage/embeddeddolt/remote_migrate_gate_test.go
@@ -1,0 +1,61 @@
+//go:build cgo
+
+package embeddeddolt_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/beads/internal/storage/embeddeddolt"
+	"github.com/steveyegge/beads/internal/storage/schema"
+)
+
+// TestEmbeddedRemoteMigrateGate_BlocksReopen verifies that the #4259
+// remote-migrate gate also protects embedded mode (the mode the original report
+// was filed against): reopening an existing, remote-backed embedded database
+// that is behind the binary must refuse to auto-migrate.
+func TestEmbeddedRemoteMigrateGate_BlocksReopen(t *testing.T) {
+	if os.Getenv("BEADS_TEST_EMBEDDED_DOLT") != "1" {
+		t.Skip("set BEADS_TEST_EMBEDDED_DOLT=1 to run embedded dolt tests")
+	}
+	t.Setenv(schema.AllowRemoteMigrateEnv, "0")
+
+	ctx := t.Context()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	dataDir := filepath.Join(beadsDir, "embeddeddolt")
+
+	// Create and fully migrate the embedded database.
+	store, err := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	// Regress one migration and register a remote on a raw SQL connection so the
+	// reopen sees a behind, remote-backed database.
+	db, cleanup, err := embeddeddolt.OpenSQL(ctx, dataDir, "testdb", "main")
+	if err != nil {
+		store.Close()
+		t.Fatalf("OpenSQL: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"DELETE FROM schema_migrations WHERE version = ?", schema.LatestVersion()); err != nil {
+		t.Fatalf("regress schema_migrations: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		"CALL DOLT_REMOTE('add', 'origin', ?)", "file://"+filepath.Join(t.TempDir(), "remote")); err != nil {
+		t.Fatalf("add remote: %v", err)
+	}
+	_ = cleanup()
+	store.Close()
+
+	// Reopen must hit the gate.
+	reopened, reErr := embeddeddolt.Open(ctx, beadsDir, "testdb", "main")
+	if reErr == nil {
+		reopened.Close()
+		t.Fatal("Open (reopen) = nil, want *schema.RemoteMigrateGateError for a behind, remote-backed DB")
+	}
+	if !schema.IsRemoteMigrateGateError(reErr) {
+		t.Fatalf("error = %T (%v), want error wrapping *schema.RemoteMigrateGateError", reErr, reErr)
+	}
+}

--- a/internal/storage/embeddeddolt/store.go
+++ b/internal/storage/embeddeddolt/store.go
@@ -196,6 +196,14 @@ func (s *EmbeddedDoltStore) initSchema(ctx context.Context) error {
 		}
 	}
 
+	// #4259: refuse to silently apply pending migrations to a remote-backed,
+	// already-initialized database — independently migrating each clone forks the
+	// schema. Embedded mode (the mode the original report was filed against) syncs
+	// via Dolt remotes too, so it needs the same gate as server mode.
+	if err := schema.CheckRemoteMigrateGate(ctx, conn); err != nil {
+		return err
+	}
+
 	// Embedded mode relies on the dolthub/driver/v2's local file/concurrency
 	// controls; schema.MigrateUpWithLock requires a sql-server session lock.
 	if _, err := schema.MigrateUp(ctx, conn); err != nil {

--- a/internal/storage/schema/remote_migrate_gate.go
+++ b/internal/storage/schema/remote_migrate_gate.go
@@ -1,0 +1,133 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/steveyegge/beads/internal/storage/dberrors"
+)
+
+// AllowRemoteMigrateEnv, when set to "1", lets the designated migrator apply
+// pending schema migrations to a remote-backed database despite the gate below.
+const AllowRemoteMigrateEnv = "BD_ALLOW_REMOTE_MIGRATE"
+
+// RemoteMigrateGateError is returned when bd is about to auto-apply pending
+// schema migrations to an existing database that has a remote configured.
+//
+// gastownhall/beads#4259: bd auto-runs pending migrations the first time a new
+// binary opens an existing database. If two clones that sync through a shared
+// remote each upgrade independently, both migrate in place and the schema forks
+// — `bd dolt pull` then fails to merge with no bd-level recovery. The supported
+// flow is "only ONE machine migrates the database; every other client adopts the
+// migrated database from the remote". This gate refuses the silent in-place
+// migration and makes the operator choose migrate vs. adopt. It applies to both
+// server mode and embedded mode (the mode the original report was filed against).
+type RemoteMigrateGateError struct {
+	CurrentVersion int
+	LatestVersion  int
+	Pending        int
+}
+
+func (e *RemoteMigrateGateError) Error() string {
+	unit := "migrations"
+	if e.Pending == 1 {
+		unit = "migration"
+	}
+	return fmt.Sprintf("refusing to auto-apply %d pending schema %s to a remote-backed database (v%d -> v%d): migrating clones independently forks the schema (#4259)",
+		e.Pending, unit, e.CurrentVersion, e.LatestVersion)
+}
+
+// UserMessage returns the full multi-line error block for terminal output.
+func (e *RemoteMigrateGateError) UserMessage() string {
+	return e.Error() + "\n" +
+		"\n" +
+		"  This database syncs with a remote. Applying schema migrations on more than\n" +
+		"  one clone independently forks the schema so `bd dolt pull` can no longer\n" +
+		"  merge — the break is silent and unrecoverable.\n" +
+		"\n" +
+		"  Choose one:\n" +
+		"    • You are the designated migrator (only ONE machine should be): migrate,\n" +
+		"      then publish the migrated database to the remote:\n" +
+		"        " + AllowRemoteMigrateEnv + "=1 bd <command>\n" +
+		"        bd dolt push\n" +
+		"    • Another machine has already migrated: adopt its database instead of\n" +
+		"      migrating here — re-clone from the remote so you receive the migrated\n" +
+		"      schema:\n" +
+		"        bd bootstrap\n"
+}
+
+// EscapeHint returns the escape-hatch string for JSON error output.
+func (e *RemoteMigrateGateError) EscapeHint() string {
+	return AllowRemoteMigrateEnv + "=1 bd <command>"
+}
+
+// IsRemoteMigrateGateError reports whether err (or any error it wraps) is a
+// *RemoteMigrateGateError.
+func IsRemoteMigrateGateError(err error) bool {
+	var e *RemoteMigrateGateError
+	return errors.As(err, &e)
+}
+
+// CheckRemoteMigrateGate refuses to auto-apply pending schema migrations when the
+// database already has a recorded schema version, has pending migrations, and has
+// a remote configured — unless the designated-migrator escape hatch is set. It
+// returns nil (allow) for a fresh database, an already-current database, or one
+// with no remote. Call it before MigrateUp/MigrateUpWithLock on every read/write
+// store open (both server and embedded mode).
+func CheckRemoteMigrateGate(ctx context.Context, db DBConn) error {
+	if os.Getenv(AllowRemoteMigrateEnv) == "1" {
+		fmt.Fprintf(os.Stderr,
+			"Warning: applying schema migrations to a remote-backed database (%s=1); only one clone should migrate, then `bd dolt push`\n",
+			AllowRemoteMigrateEnv)
+		return nil
+	}
+
+	// CurrentVersion treats a missing schema_migrations table as version 0, so a
+	// brand-new database falls through the current==0 check below — nothing to fork.
+	current, err := CurrentVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("remote-migrate gate: read current version: %w", err)
+	}
+	if current == 0 {
+		return nil // fresh database — nothing to fork
+	}
+
+	pending, err := PendingVersions(ctx, db)
+	if err != nil {
+		return fmt.Errorf("remote-migrate gate: read pending versions: %w", err)
+	}
+	if len(pending) == 0 {
+		return nil // already current — nothing to migrate
+	}
+
+	hasRemote, err := anyDoltRemoteConfigured(ctx, db)
+	if err != nil {
+		return fmt.Errorf("remote-migrate gate: read remotes: %w", err)
+	}
+	if !hasRemote {
+		return nil // no remote — no cross-clone fork risk
+	}
+
+	return &RemoteMigrateGateError{
+		CurrentVersion: current,
+		LatestVersion:  LatestVersion(),
+		Pending:        len(pending),
+	}
+}
+
+// anyDoltRemoteConfigured reports whether the database has any Dolt remote
+// registered. dolt_remotes is always present in a Dolt database; a
+// "table not found" is treated as "no remotes" so a missing system table can
+// never wedge every store open.
+func anyDoltRemoteConfigured(ctx context.Context, db DBConn) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM dolt_remotes").Scan(&count); err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/internal/storage/schema/remote_migrate_gate.go
+++ b/internal/storage/schema/remote_migrate_gate.go
@@ -75,8 +75,32 @@ func IsRemoteMigrateGateError(err error) bool {
 // a remote configured — unless the designated-migrator escape hatch is set. It
 // returns nil (allow) for a fresh database, an already-current database, or one
 // with no remote. Call it before MigrateUp/MigrateUpWithLock on every read/write
-// store open (both server and embedded mode).
+// store open. Embedded mode uses this form: its dolt_remotes table already
+// reflects remotes persisted in .dolt/config on a fresh open.
 func CheckRemoteMigrateGate(ctx context.Context, db DBConn) error {
+	return checkRemoteMigrateGate(ctx, db, nil)
+}
+
+// CheckRemoteMigrateGateWithRemoteCheck is CheckRemoteMigrateGate plus an on-disk
+// fallback remote probe. When the dolt_remotes SQL table reports no remote,
+// extraHasRemote is consulted and a true result still trips the gate.
+//
+// Server mode needs this: a freshly (auto-)started dolt sql-server starts with an
+// empty dolt_remotes table and only re-registers CLI remotes from .dolt/config
+// later, during the post-open sync (GH#2315). Because this gate runs before that
+// sync, the SQL-only check would see no remote on the first write open after an
+// upgrade and silently migrate the shared database in place — exactly the
+// cross-clone fork #4259 is meant to prevent. extraHasRemote (a probe of the
+// persisted CLI remotes) closes that window.
+//
+// extraHasRemote is only invoked when the database has a pending migration AND the
+// SQL table shows no remote, so the (subprocess-backed) filesystem probe stays off
+// the common open path. A nil extraHasRemote disables the fallback.
+func CheckRemoteMigrateGateWithRemoteCheck(ctx context.Context, db DBConn, extraHasRemote func() bool) error {
+	return checkRemoteMigrateGate(ctx, db, extraHasRemote)
+}
+
+func checkRemoteMigrateGate(ctx context.Context, db DBConn, extraHasRemote func() bool) error {
 	if os.Getenv(AllowRemoteMigrateEnv) == "1" {
 		fmt.Fprintf(os.Stderr,
 			"Warning: applying schema migrations to a remote-backed database (%s=1); only one clone should migrate, then `bd dolt push`\n",
@@ -105,6 +129,12 @@ func CheckRemoteMigrateGate(ctx context.Context, db DBConn) error {
 	hasRemote, err := anyDoltRemoteConfigured(ctx, db)
 	if err != nil {
 		return fmt.Errorf("remote-migrate gate: read remotes: %w", err)
+	}
+	// dolt_remotes can read empty even when a remote is configured: a freshly
+	// (auto-)started server has not yet synced CLI remotes from .dolt/config
+	// (GH#2315). Consult the caller's on-disk probe before allowing migration.
+	if !hasRemote && extraHasRemote != nil {
+		hasRemote = extraHasRemote()
 	}
 	if !hasRemote {
 		return nil // no remote — no cross-clone fork risk

--- a/internal/storage/schema/remote_migrate_gate_test.go
+++ b/internal/storage/schema/remote_migrate_gate_test.go
@@ -1,0 +1,124 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+const maxVersionQuery = `SELECT COALESCE\(MAX\(version\), 0\) FROM schema_migrations`
+
+// expectGateCurrentVersion mocks the MAX(version) read that both CurrentVersion
+// and PendingVersions issue.
+func expectGateCurrentVersion(mock sqlmock.Sqlmock, version int) {
+	mock.ExpectQuery(maxVersionQuery).
+		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(version))
+}
+
+func TestCheckRemoteMigrateGate(t *testing.T) {
+	latest := LatestVersion()
+
+	t.Run("escape hatch env var allows migration without any query", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "1")
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		defer db.Close()
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("expected nil with escape hatch set, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unexpected queries with escape hatch: %v", err)
+		}
+	})
+
+	t.Run("fresh database (version 0) is allowed", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, 0)
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("fresh DB should be allowed, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("already at latest (no pending) is allowed", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, latest) // CurrentVersion
+		expectGateCurrentVersion(mock, latest) // PendingVersions -> no pending
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("at-latest DB should be allowed, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("pending migrations but no remote is allowed", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, 1) // CurrentVersion
+		expectGateCurrentVersion(mock, 1) // PendingVersions -> pending exists
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM dolt_remotes`).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("no-remote DB should be allowed, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("pending migrations with a remote is blocked", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, 1) // CurrentVersion
+		expectGateCurrentVersion(mock, 1) // PendingVersions -> pending exists
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM dolt_remotes`).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+		err := CheckRemoteMigrateGate(context.Background(), db)
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected *RemoteMigrateGateError, got %v", err)
+		}
+		if gateErr.CurrentVersion != 1 {
+			t.Errorf("CurrentVersion = %d, want 1", gateErr.CurrentVersion)
+		}
+		if gateErr.LatestVersion != latest {
+			t.Errorf("LatestVersion = %d, want %d", gateErr.LatestVersion, latest)
+		}
+		if gateErr.Pending <= 0 {
+			t.Errorf("Pending = %d, want > 0", gateErr.Pending)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("missing dolt_remotes table is treated as no remote", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, 1)
+		expectGateCurrentVersion(mock, 1)
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM dolt_remotes`).
+			WillReturnError(errors.New("Error 1146: Table 'beads.dolt_remotes' doesn't exist"))
+		if err := CheckRemoteMigrateGate(context.Background(), db); err != nil {
+			t.Fatalf("missing dolt_remotes should be treated as no remote (allow), got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+}

--- a/internal/storage/schema/remote_migrate_gate_test.go
+++ b/internal/storage/schema/remote_migrate_gate_test.go
@@ -122,3 +122,94 @@ func TestCheckRemoteMigrateGate(t *testing.T) {
 		}
 	})
 }
+
+// TestCheckRemoteMigrateGateWithRemoteCheck covers the on-disk fallback used by
+// server mode: a freshly (auto-)started dolt server reports an empty dolt_remotes
+// table even when a remote is configured, so the gate must fall back to a probe of
+// the persisted CLI remotes before allowing migration (gastownhall/beads#4268).
+func TestCheckRemoteMigrateGateWithRemoteCheck(t *testing.T) {
+	t.Run("no SQL remote but fallback reports a remote is blocked", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, 1) // CurrentVersion
+		expectGateCurrentVersion(mock, 1) // PendingVersions -> pending exists
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM dolt_remotes`).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+		err := CheckRemoteMigrateGateWithRemoteCheck(context.Background(), db, func() bool { return true })
+		var gateErr *RemoteMigrateGateError
+		if !errors.As(err, &gateErr) {
+			t.Fatalf("expected *RemoteMigrateGateError when the disk fallback reports a remote, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("no SQL remote and fallback reports none is allowed", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, 1)
+		expectGateCurrentVersion(mock, 1)
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM dolt_remotes`).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+		if err := CheckRemoteMigrateGateWithRemoteCheck(context.Background(), db, func() bool { return false }); err != nil {
+			t.Fatalf("no remote anywhere should be allowed, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("SQL remote present short-circuits the fallback", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, 1)
+		expectGateCurrentVersion(mock, 1)
+		mock.ExpectQuery(`SELECT COUNT\(\*\) FROM dolt_remotes`).
+			WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+		called := false
+		err := CheckRemoteMigrateGateWithRemoteCheck(context.Background(), db, func() bool {
+			called = true
+			return false
+		})
+		if !IsRemoteMigrateGateError(err) {
+			t.Fatalf("expected gate error when dolt_remotes already shows a remote, got %v", err)
+		}
+		if called {
+			t.Error("fallback must not run when dolt_remotes already reports a remote")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+
+	t.Run("fallback not consulted when there are no pending migrations", func(t *testing.T) {
+		t.Setenv(AllowRemoteMigrateEnv, "0")
+		latest := LatestVersion()
+		db, mock, _ := sqlmock.New()
+		defer db.Close()
+		expectGateCurrentVersion(mock, latest) // CurrentVersion
+		expectGateCurrentVersion(mock, latest) // PendingVersions -> none
+
+		called := false
+		err := CheckRemoteMigrateGateWithRemoteCheck(context.Background(), db, func() bool {
+			called = true
+			return true
+		})
+		if err != nil {
+			t.Fatalf("at-latest DB should be allowed, got %v", err)
+		}
+		if called {
+			t.Error("fallback (a subprocess probe) must not run when there are no pending migrations")
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet expectations: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Why

Follow-up to #4259 (deterministic dependency ids fix #4266). `bd` auto-runs pending schema migrations the first time a new binary opens an existing database. When two clones that sync through a shared remote each upgrade independently, **both migrate in place and the schema forks**, so `bd dolt pull` breaks with no `bd`-level recovery. The supported flow is *"only ONE machine migrates the database; every other client adopts the migrated database from the remote."* Today nothing enforces that — the fork is created silently by auto-migration on first launch.

This adds the prevention gate (layer 1 of the #4259 fix plan): turn the safe-upgrade headline from a doc people don't read into something `bd` enforces.

## What this PR does

`schema.CheckRemoteMigrateGate` (in the `schema` package, alongside `SchemaSkewError`): before applying pending migrations on a read/write store open, it refuses if the database **already has a recorded schema version, has pending migrations, AND has a remote configured** — and returns a `RemoteMigrateGateError` telling the operator to choose:

- **Migrate** as the single designated migrator: `BD_ALLOW_REMOTE_MIGRATE=1 bd <command>`, then `bd dolt push`.
- **Adopt** the already-migrated database from the remote: `bd bootstrap` (re-clone).

The gate is a **no-op** for: fresh databases (version 0 / missing `schema_migrations`), databases already at the binary's version (no pending migrations), databases with no remote, and read-only opens.

It is wired into **both** store modes:
- Server mode: `DoltStore.initSchema` (before `MigrateUpWithLock`).
- Embedded mode: `EmbeddedDoltStore.initSchema` (before `MigrateUp`).

Embedded mode matters specifically because the **original report was filed against embedded mode** — gating only server mode would leave the primary case exposed. (An earlier draft did exactly that; review caught it.)

The error surfaces with a dedicated `UserMessage` / JSON block, mirroring the existing schema-skew UX. The post-clone warmup in `bd bootstrap` treats the gate as non-fatal so it surfaces on the next command instead of an unrelated wisp-table warning. A missing `dolt_remotes` system table is treated as "no remote" so it can never wedge every store open.

## Testing

- `schema.CheckRemoteMigrateGate` unit tests (sqlmock): escape hatch, fresh DB, at-latest, pending-but-no-remote, **blocked** (pending + remote), and missing-`dolt_remotes` → allowed.
- Server-mode integration test: reopening a behind, remote-backed DB returns the gate error end-to-end.
- Embedded-mode integration test (opt-in `BEADS_TEST_EMBEDDED_DOLT=1`): same, through `embeddeddolt.Open`.
- JSON-handler shape test; existing `TestDoltNew_*` open tests still pass (the gate does not affect normal opens).

## Notes for reviewers

- **By design:** auxiliary, optional-store paths that already swallow store-open errors (e.g. `bd doctor` KV status, ADO config lookup) keep degrading gracefully rather than aborting — the gate surfaces on the operator's primary command via the central store-open handler. Making `bd doctor` hard-fail on a gated DB would be worse.
- **Escape-hatch asymmetry:** schema-skew has both `--ignore-schema-skew` and `BD_IGNORE_SCHEMA_SKEW`; this PR ships only the `BD_ALLOW_REMOTE_MIGRATE` env var (the minimal local form). A matching `--allow-remote-migrate` flag is an easy follow-up if desired.
- **Behind-remote bootstrap:** if you `bd bootstrap` a remote that is itself behind this binary, the gate fires (you'd be the first migrator) — this is intentional "make the choice" behavior, not a regression; the common recipe-correct case (remote already at latest) has no pending migrations and is unaffected.

_claude-opus-4-8-xhigh on behalf of maphew_
