### PR TITLE
test(dolt): fix t.Setenv-before-t.Parallel panic in TestCheckForwardDrift_EscapeHatch

### DIFF
--- a/internal/storage/dolt/schema_skew_test.go
+++ b/internal/storage/dolt/schema_skew_test.go
@@ -64,10 +64,10 @@ func TestCheckForwardDrift_CurrentVersion_NoError(t *testing.T) {
 // TestCheckForwardDrift_EscapeHatch_ReturnsNil verifies that
 // BD_IGNORE_SCHEMA_SKEW=1 suppresses the forward-drift error.
 //
-// Uses a dedicated CREATE/DROP database rather than setupTestStore: this test
-// calls t.Setenv, which Go forbids in a parallel test, and setupTestStore marks
-// the test parallel. (setupTestStore + t.Setenv panics the dolt test binary
-// whenever the test Dolt server is running.)
+// Uses a dedicated database rather than setupTestStore: this test calls
+// t.Setenv, which Go forbids in a parallel test, and setupTestStore marks the
+// test parallel. (setupTestStore + t.Setenv panics the dolt test binary whenever
+// the test Dolt server is running.)
 func TestCheckForwardDrift_EscapeHatch_ReturnsNil(t *testing.T) {
 	skipIfNoDolt(t)
 	t.Setenv("BD_IGNORE_SCHEMA_SKEW", "1")
@@ -88,12 +88,9 @@ func TestCheckForwardDrift_EscapeHatch_ReturnsNil(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New (create): %v", err)
 	}
-	defer func() {
-		dropCtx, dropCancel := context.WithTimeout(context.Background(), 5*testTimeout)
-		defer dropCancel()
-		_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
-		store.Close()
-	}()
+	// Do not DROP DATABASE here: rapid CREATE/DROP cycles can crash the Dolt
+	// testcontainer. The random test database is discarded with the container.
+	defer store.Close()
 
 	if _, err := store.db.ExecContext(ctx,
 		"INSERT INTO schema_migrations (version) VALUES (?)",

--- a/internal/storage/dolt/schema_skew_test.go
+++ b/internal/storage/dolt/schema_skew_test.go
@@ -63,14 +63,37 @@ func TestCheckForwardDrift_CurrentVersion_NoError(t *testing.T) {
 
 // TestCheckForwardDrift_EscapeHatch_ReturnsNil verifies that
 // BD_IGNORE_SCHEMA_SKEW=1 suppresses the forward-drift error.
+//
+// Uses a dedicated CREATE/DROP database rather than setupTestStore: this test
+// calls t.Setenv, which Go forbids in a parallel test, and setupTestStore marks
+// the test parallel. (setupTestStore + t.Setenv panics the dolt test binary
+// whenever the test Dolt server is running.)
 func TestCheckForwardDrift_EscapeHatch_ReturnsNil(t *testing.T) {
+	skipIfNoDolt(t)
 	t.Setenv("BD_IGNORE_SCHEMA_SKEW", "1")
-
-	store, cleanup := setupTestStore(t)
-	defer cleanup()
 
 	ctx, cancel := testContext(t)
 	defer cancel()
+
+	tmpDir := t.TempDir()
+	dbName := uniqueTestDBName(t)
+
+	store, err := New(ctx, &Config{
+		Path:            tmpDir,
+		CommitterName:   "test",
+		CommitterEmail:  "test@example.com",
+		Database:        dbName,
+		CreateIfMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("New (create): %v", err)
+	}
+	defer func() {
+		dropCtx, dropCancel := context.WithTimeout(context.Background(), 5*testTimeout)
+		defer dropCancel()
+		_, _ = store.db.ExecContext(dropCtx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		store.Close()
+	}()
 
 	if _, err := store.db.ExecContext(ctx,
 		"INSERT INTO schema_migrations (version) VALUES (?)",


### PR DESCRIPTION
## Why

`TestCheckForwardDrift_EscapeHatch_ReturnsNil` (added in 7da4f7817) calls `t.Setenv("BD_IGNORE_SCHEMA_SKEW", "1")` and then `setupTestStore`, which marks the test parallel via `t.Parallel()`. Go forbids `t.Setenv` in a parallel test (or one with parallel ancestors), so the test panics the entire `dolt` test binary whenever the isolated test Dolt server is running. `skipIfNoDolt` only skips when the server is absent, so `go test ./internal/storage/dolt/` (or `make test`) on a Dolt-equipped machine reliably hits the panic:

```text
panic: testing: test using t.Setenv, t.Chdir, or cryptotest.SetGlobalRandom can not use t.Parallel
--- FAIL: TestCheckForwardDrift_EscapeHatch_ReturnsNil
```

## Fix

Give the test its own dedicated database so it is non-parallel and may call `t.Setenv`. The test closes the store without `DROP DATABASE`: rapid CREATE/DROP cycles can crash the Dolt testcontainer, and the random test database is discarded when the container terminates.

_claude-opus-4-8-xhigh on behalf of matt wilkie_

Reviewed follow-up: feba2481 avoids the mid-package `DROP DATABASE` cleanup that could make the next schema-skew test lose the Dolt server connection.

_codex-gpt-5.5-xhigh on behalf of maphew_
