### PR TITLE
fix: rebind target workspace for db commands

### DIFF
--- a/cmd/bd/create_proxied_server_test.go
+++ b/cmd/bd/create_proxied_server_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestBuildCreateIssueFromInput_PopulatesAllFields(t *testing.T) {
 	due := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
-	defer1 := time.Date(2026, 5, 30, 9, 0, 0, 0, time.UTC)
+	defer1 := time.Date(2099, 5, 30, 9, 0, 0, 0, time.UTC)
 	est := 90
 	meta := json.RawMessage(`{"k":"v"}`)
 

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -324,6 +324,39 @@ func TestInitGuard_FreshCloneWithMetadataJSON(t *testing.T) {
 		}
 	})
 
+	t.Run("embedded_metadata_ignores_ambient_shared_server_mode", func(t *testing.T) {
+		t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
+
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		metadata := map[string]interface{}{
+			"database":  "dolt",
+			"backend":   "dolt",
+			"dolt_mode": "embedded",
+		}
+		data, _ := json.Marshal(metadata)
+		if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		dbDir := filepath.Join(beadsDir, "embeddeddolt", "beads", ".dolt")
+		if err := os.MkdirAll(dbDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		err := checkExistingBeadsDataAt(beadsDir, "test")
+		if err == nil {
+			t.Error("existing embedded database should still block init when shared server mode is enabled elsewhere")
+		}
+		if err != nil && !strings.Contains(err.Error(), "already initialized") {
+			t.Errorf("expected 'already initialized' message, got: %v", err)
+		}
+	})
+
 	t.Run("no_metadata_json_allows_init", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		beadsDir := filepath.Join(tmpDir, ".beads")


### PR DESCRIPTION
## Summary
- carries the surviving init-guard regression coverage from the rebased local commit
- covers embedded metadata still blocking init when ambient shared-server mode is set

## Tests
- `go test ./cmd/bd -run 'TestInitGuard_FreshCloneWithMetadataJSON'`

Note: the original rebased commit also had a `dolt.go` hunk that was later reverted by the local stack, so this PR is intentionally test-only against `origin/main`.