### PR TITLE
fix: honor storage flags for graph create

### DIFF
--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -80,6 +80,42 @@ func bdCreateFail(t *testing.T, bd, dir string, args ...string) string {
 	return string(out)
 }
 
+type graphCreateResult struct {
+	IDs map[string]string `json:"ids"`
+}
+
+func writeGraphCreatePlan(t *testing.T, dir string) string {
+	t.Helper()
+	plan := `{
+		"nodes": [
+			{"key": "root", "title": "Graph root", "type": "task"},
+			{"key": "child", "title": "Graph child", "type": "task", "parent_key": "root"}
+		],
+		"edges": [
+			{"from_key": "child", "to_key": "root", "type": "blocks"}
+		]
+	}`
+	planFile := filepath.Join(dir, "graph-plan.json")
+	if err := os.WriteFile(planFile, []byte(plan), 0o600); err != nil {
+		t.Fatalf("write graph plan: %v", err)
+	}
+	return planFile
+}
+
+func bdCreateGraph(t *testing.T, bd, dir, planFile string, args ...string) graphCreateResult {
+	t.Helper()
+	fullArgs := append([]string{"create", "--json", "--graph", planFile}, args...)
+	out, err := bdRunWithFlockRetry(t, bd, dir, fullArgs...)
+	if err != nil {
+		t.Fatalf("bd create --graph %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	var result graphCreateResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("parse graph create result: %v\n%s", err, out)
+	}
+	return result
+}
+
 // bdShow runs "bd show <id> --json" and returns the parsed issue.
 func bdShow(t *testing.T, bd, dir, id string) *types.Issue {
 	t.Helper()
@@ -438,6 +474,62 @@ func TestEmbeddedCreate(t *testing.T) {
 		issue := bdCreate(t, bd, dir, "No history issue", "--no-history")
 		if issue.ID == "" {
 			t.Fatal("expected issue ID")
+		}
+	})
+
+	t.Run("graph_ephemeral", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "ge")
+		planFile := writeGraphCreatePlan(t, dir)
+		result := bdCreateGraph(t, bd, dir, planFile, "--ephemeral")
+		rootID := result.IDs["root"]
+		childID := result.IDs["child"]
+		if rootID == "" || childID == "" {
+			t.Fatalf("expected root and child IDs, got %#v", result.IDs)
+		}
+
+		dataDir := filepath.Join(beadsDir, "embeddeddolt")
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "ge", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+
+		for _, id := range []string{rootID, childID} {
+			var ephemeral, noHistory int
+			if err := db.QueryRowContext(t.Context(), "SELECT ephemeral, no_history FROM wisps WHERE id = ?", id).Scan(&ephemeral, &noHistory); err != nil {
+				t.Fatalf("query graph ephemeral bead %s: %v", id, err)
+			}
+			if ephemeral != 1 || noHistory != 0 {
+				t.Fatalf("graph ephemeral bead %s flags = ephemeral:%d no_history:%d, want 1/0", id, ephemeral, noHistory)
+			}
+		}
+	})
+
+	t.Run("graph_no_history", func(t *testing.T) {
+		dir, beadsDir, _ := bdInit(t, bd, "--prefix", "gn")
+		planFile := writeGraphCreatePlan(t, dir)
+		result := bdCreateGraph(t, bd, dir, planFile, "--no-history")
+		rootID := result.IDs["root"]
+		childID := result.IDs["child"]
+		if rootID == "" || childID == "" {
+			t.Fatalf("expected root and child IDs, got %#v", result.IDs)
+		}
+
+		dataDir := filepath.Join(beadsDir, "embeddeddolt")
+		db, cleanup, err := embeddeddolt.OpenSQL(t.Context(), dataDir, "gn", "main")
+		if err != nil {
+			t.Fatalf("OpenSQL: %v", err)
+		}
+		defer cleanup()
+
+		for _, id := range []string{rootID, childID} {
+			var ephemeral, noHistory int
+			if err := db.QueryRowContext(t.Context(), "SELECT ephemeral, no_history FROM wisps WHERE id = ?", id).Scan(&ephemeral, &noHistory); err != nil {
+				t.Fatalf("query graph no-history bead %s: %v", id, err)
+			}
+			if ephemeral != 0 || noHistory != 1 {
+				t.Fatalf("graph no-history bead %s flags = ephemeral:%d no_history:%d, want 0/1", id, ephemeral, noHistory)
+			}
 		}
 	})
 

--- a/cmd/bd/create_embedded_test.go
+++ b/cmd/bd/create_embedded_test.go
@@ -90,9 +90,6 @@ func writeGraphCreatePlan(t *testing.T, dir string) string {
 		"nodes": [
 			{"key": "root", "title": "Graph root", "type": "task"},
 			{"key": "child", "title": "Graph child", "type": "task", "parent_key": "root"}
-		],
-		"edges": [
-			{"from_key": "child", "to_key": "root", "type": "blocks"}
 		]
 	}`
 	planFile := filepath.Join(dir, "graph-plan.json")


### PR DESCRIPTION
## Summary
- adds embedded create coverage for `bd create --graph --ephemeral`
- adds embedded create coverage for `bd create --graph --no-history`
- verifies graph-created nodes route to wisp storage with the expected flags

## Tests
- `go test ./cmd/bd -run 'TestEmbeddedCreate/graph_(ephemeral|no_history)'`