### PR TITLE
fix: honor no-db target precedence consistently

### DIFF
--- a/cmd/bd/main.go
+++ b/cmd/bd/main.go
@@ -313,13 +313,13 @@ func selectedNoDBBeadsDir(cmd *cobra.Command) string {
 			return selectedBeadsDir
 		}
 	}
-	if dbPath != "" {
-		if selectedBeadsDir := resolveCommandBeadsDir(dbPath); selectedBeadsDir != "" {
+	if os.Getenv("BEADS_DIR") != "" {
+		if selectedBeadsDir := beads.FindBeadsDir(); selectedBeadsDir != "" {
 			return selectedBeadsDir
 		}
 	}
-	if os.Getenv("BEADS_DIR") != "" {
-		if selectedBeadsDir := beads.FindBeadsDir(); selectedBeadsDir != "" {
+	if dbPath != "" {
+		if selectedBeadsDir := resolveCommandBeadsDir(dbPath); selectedBeadsDir != "" {
 			return selectedBeadsDir
 		}
 	}


### PR DESCRIPTION
## Summary
- makes `BEADS_DIR` selection win before fallback `dbPath` for no-db commands
- keeps explicit `--db`, `BEADS_DB`, and `BD_DB` precedence ahead of `BEADS_DIR`

## Tests
- `go test ./cmd/bd -run 'TestContextPreservesShellEnvPrecedenceForNoDBCommand|TestDoctorPersistentPreRunUsesExplicitDBTarget|TestBootstrapPersistentPreRunUsesExplicitDBTarget'`