### PR TITLE
fix: restore dolt target workspace rebind

### DIFF
--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -1299,7 +1299,13 @@ func init() {
 }
 
 func selectedDoltBeadsDir() string {
-	beadsDir := beads.FindBeadsDir()
+	beadsDir := ""
+	if os.Getenv("BEADS_DIR") != "" {
+		beadsDir = beads.FindBeadsDir()
+	}
+	if beadsDir == "" {
+		beadsDir = selectedNoDBBeadsDir(nil)
+	}
 	if beadsDir == "" {
 		return ""
 	}

--- a/cmd/bd/init_guard_test.go
+++ b/cmd/bd/init_guard_test.go
@@ -324,39 +324,6 @@ func TestInitGuard_FreshCloneWithMetadataJSON(t *testing.T) {
 		}
 	})
 
-	t.Run("embedded_metadata_ignores_ambient_shared_server_mode", func(t *testing.T) {
-		t.Setenv("BEADS_DOLT_SHARED_SERVER", "1")
-
-		tmpDir := t.TempDir()
-		beadsDir := filepath.Join(tmpDir, ".beads")
-		if err := os.MkdirAll(beadsDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-
-		metadata := map[string]interface{}{
-			"database":  "dolt",
-			"backend":   "dolt",
-			"dolt_mode": "embedded",
-		}
-		data, _ := json.Marshal(metadata)
-		if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), data, 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		dbDir := filepath.Join(beadsDir, "embeddeddolt", "beads", ".dolt")
-		if err := os.MkdirAll(dbDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-
-		err := checkExistingBeadsDataAt(beadsDir, "test")
-		if err == nil {
-			t.Error("existing embedded database should still block init when shared server mode is enabled elsewhere")
-		}
-		if err != nil && !strings.Contains(err.Error(), "already initialized") {
-			t.Errorf("expected 'already initialized' message, got: %v", err)
-		}
-	})
-
 	t.Run("no_metadata_json_allows_init", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		beadsDir := filepath.Join(tmpDir, ".beads")


### PR DESCRIPTION
Maintainer follow-up for the adopted PR review of #4275.

Original PR: https://github.com/gastownhall/beads/pull/4275
Original title: fix: rebind target workspace for db commands
Original state: MERGED
Configured workflow base: main
Original GitHub base: main
Base mismatch: none
Latest base used for this follow-up: b0a01c0c899fb255a3472ab6c333a285fff801fd

Why this follow-up exists:
- The original contributor PR merged before the adoption workflow could push the maintainer fixup.
- The workflow therefore carried only the maintainer-side fixup onto current `main`, preserving the original merged contribution instead of rewriting or mutating it.

Changes in this follow-up:
- Restores `selectedDoltBeadsDir` so Dolt/db commands preserve a rebound `BEADS_DIR` and fall back through the no-DB workspace selector.
- Removes duplicate init-guard subtest coverage while retaining the embedded metadata behavior coverage already present in the surrounding test.

Validation:
- `go test ./cmd/bd -run 'TestSelectedDoltBeadsDirUsesReboundBEADSDir|TestInitGuard_FreshCloneWithMetadataJSON'`
- `adopt_pr_base_refresh.py` completed with `status=already_current` for the repaired head.
- `adopt_pr_approval_summary.py` passed against the repaired final head.

Authorship:
- The original contributor commits remain preserved in the already-merged PR #4275.
- This follow-up contains only the maintainer fixup commit required by the adoption review.
