### PR TITLE
fix: allow local-only config validation

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -498,7 +498,7 @@ var configValidateCmd = &cobra.Command{
 
 Checks:
   - federation.sovereignty is valid (T1, T2, T3, T4, or empty)
-  - federation.remote is set for Dolt sync
+  - sync.remote or federation.remote is set for Dolt sync, unless dolt.local-only is true
   - Remote URL format is valid (dolthub://, gs://, s3://, az://, file://)
   - routing.mode is valid (auto, maintainer, contributor, explicit)
 
@@ -570,36 +570,54 @@ func validateSyncConfig(repoPath string) []string {
 
 	// Get config from yaml
 	federationSov := v.GetString("federation.sovereignty")
-	federationRemote := v.GetString("federation.remote")
+	localOnly := v.GetBool("dolt.local-only")
+	remoteEntries := declaredRemoteEntriesFromViper(v)
 
 	// Validate federation.sovereignty
 	if federationSov != "" && !config.IsValidSovereignty(federationSov) {
 		issues = append(issues, fmt.Sprintf("federation.sovereignty: %q is invalid (valid values: %s, or empty for no restriction)", federationSov, strings.Join(config.ValidSovereigntyTiers(), ", ")))
 	}
 
-	// Validate federation.remote is set (required for Dolt sync)
-	if federationRemote == "" {
-		issues = append(issues, "federation.remote: required for Dolt sync")
+	// Validate a remote is set when this project expects Dolt sync. Local-only
+	// repos intentionally have no remote; they still use embedded Dolt locally.
+	if len(remoteEntries) == 0 && !localOnly {
+		issues = append(issues, "sync.remote: required for Dolt sync (or set dolt.local-only: true)")
 	}
 
 	// Strict security validation of remote URL
-	if federationRemote != "" {
-		if err := remotecache.ValidateRemoteURL(federationRemote); err != nil {
-			issues = append(issues, fmt.Sprintf("federation.remote: %s", err))
+	for _, entry := range remoteEntries {
+		if err := remotecache.ValidateRemoteURL(entry.value); err != nil {
+			issues = append(issues, fmt.Sprintf("%s: %s", entry.key, err))
 		}
 	}
 
 	// Validate against allowed-remote-patterns if configured
-	if federationRemote != "" {
+	for _, entry := range remoteEntries {
 		patterns := v.GetStringSlice("federation.allowed-remote-patterns")
 		if len(patterns) > 0 {
-			if err := remotecache.ValidateRemoteURLWithPatterns(federationRemote, patterns); err != nil {
-				issues = append(issues, fmt.Sprintf("federation.remote: %s", err))
+			if err := remotecache.ValidateRemoteURLWithPatterns(entry.value, patterns); err != nil {
+				issues = append(issues, fmt.Sprintf("%s: %s", entry.key, err))
 			}
 		}
 	}
 
 	return issues
+}
+
+type configRemoteEntry struct {
+	key   string
+	value string
+}
+
+func declaredRemoteEntriesFromViper(v *viper.Viper) []configRemoteEntry {
+	keys := []string{"sync.remote", "sync.git-remote", "federation.remote"}
+	entries := make([]configRemoteEntry, 0, len(keys))
+	for _, key := range keys {
+		if value := strings.TrimSpace(v.GetString(key)); value != "" {
+			entries = append(entries, configRemoteEntry{key: key, value: value})
+		}
+	}
+	return entries
 }
 
 // isValidRemoteURL validates remote URL formats for sync configuration.

--- a/cmd/bd/config_apply.go
+++ b/cmd/bd/config_apply.go
@@ -37,7 +37,7 @@ var configApplyCmd = &cobra.Command{
 Runs drift detection and then fixes any mismatches it finds:
 
   - hooks     Reinstall git hooks if missing or outdated
-  - remote    Add/update Dolt origin remote to match federation.remote
+  - remote    Add/update Dolt origin remote to match sync.remote/federation.remote
   - server    Start Dolt server if dolt.shared-server is enabled
 
 This command is idempotent — safe to run multiple times. Use --dry-run
@@ -138,7 +138,7 @@ func applyHooks(drifted bool, dryRun bool) ApplyResult {
 	}
 }
 
-// applyRemote ensures the Dolt origin remote matches federation.remote config.
+// applyRemote ensures the Dolt origin remote matches declared sync remote config.
 func applyRemote(drifted bool, dryRun bool) ApplyResult {
 	if !drifted {
 		return ApplyResult{
@@ -159,13 +159,13 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 		}
 	}
 
-	federationRemote := config.GetString("federation.remote")
-	if federationRemote == "" {
+	remoteKey, declaredRemote := resolveDeclaredDoltRemote()
+	if declaredRemote == "" {
 		return ApplyResult{
 			Check:   "remote",
 			Action:  "configure",
 			Status:  applyStatusSkipped,
-			Message: "federation.remote is not set in config",
+			Message: "sync.remote is not set in config",
 		}
 	}
 
@@ -178,20 +178,20 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 				Check:   "remote",
 				Action:  "add_remote",
 				Status:  applyStatusDryRun,
-				Message: fmt.Sprintf("Would add Dolt origin remote: %s", federationRemote),
+				Message: fmt.Sprintf("Would add Dolt origin remote from %s: %s", remoteKey, declaredRemote),
 			}
 		}
 		return ApplyResult{
 			Check:   "remote",
 			Action:  "update_remote",
 			Status:  applyStatusDryRun,
-			Message: fmt.Sprintf("Would update Dolt origin remote from %s to %s", currentURL, federationRemote),
+			Message: fmt.Sprintf("Would update Dolt origin remote from %s to %s", currentURL, declaredRemote),
 		}
 	}
 
 	if currentURL == "" {
 		// No origin exists — add it
-		if err := doltutil.AddCLIRemote(doltDir, "origin", federationRemote); err != nil {
+		if err := doltutil.AddCLIRemote(doltDir, "origin", declaredRemote); err != nil {
 			return ApplyResult{
 				Check:   "remote",
 				Action:  "add_remote",
@@ -204,7 +204,7 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 			Check:   "remote",
 			Action:  "add_remote",
 			Status:  applyStatusApplied,
-			Message: fmt.Sprintf("Added Dolt origin remote: %s", federationRemote),
+			Message: fmt.Sprintf("Added Dolt origin remote from %s: %s", remoteKey, declaredRemote),
 		}
 	}
 
@@ -221,7 +221,7 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 		}
 	}
 
-	if err := doltutil.AddCLIRemote(doltDir, "origin", federationRemote); err != nil {
+	if err := doltutil.AddCLIRemote(doltDir, "origin", declaredRemote); err != nil {
 		// Try to restore the old remote on failure
 		_ = doltutil.AddCLIRemote(doltDir, "origin", oldURL)
 		return ApplyResult{
@@ -237,7 +237,7 @@ func applyRemote(drifted bool, dryRun bool) ApplyResult {
 		Check:   "remote",
 		Action:  "update_remote",
 		Status:  applyStatusApplied,
-		Message: fmt.Sprintf("Updated Dolt origin remote from %s to %s", oldURL, federationRemote),
+		Message: fmt.Sprintf("Updated Dolt origin remote from %s to %s", oldURL, declaredRemote),
 	}
 }
 

--- a/cmd/bd/config_drift.go
+++ b/cmd/bd/config_drift.go
@@ -42,7 +42,7 @@ with my config?" — no mutations are performed.
 
 Checks:
   - hooks     Git hooks installed and up-to-date
-  - remote    Dolt remote matches federation.remote config
+  - remote    Dolt remote matches sync.remote/federation.remote config
   - server    Server state matches dolt.shared-server config
 
 Exit codes:
@@ -139,9 +139,9 @@ func checkHooksDrift() []DriftItem {
 	return items
 }
 
-// checkRemoteDrift compares federation.remote config against actual Dolt remotes.
+// checkRemoteDrift compares declared sync remote config against actual Dolt remotes.
 func checkRemoteDrift() []DriftItem {
-	federationRemote := config.GetString("federation.remote")
+	remoteKey, declaredRemote := resolveDeclaredDoltRemote()
 
 	// Find the dolt data directory for CLI remote listing
 	beadsDir := beads.FindBeadsDir()
@@ -150,6 +150,14 @@ func checkRemoteDrift() []DriftItem {
 			Check:   "remote",
 			Status:  driftStatusSkipped,
 			Message: "No active beads workspace found",
+		}}
+	}
+
+	if config.GetBool("dolt.local-only") {
+		return []DriftItem{{
+			Check:   "remote",
+			Status:  driftStatusInfo,
+			Message: "Dolt remote check skipped because dolt.local-only is true",
 		}}
 	}
 
@@ -173,39 +181,39 @@ func checkRemoteDrift() []DriftItem {
 		}
 	}
 
-	// Case 1: federation.remote set, no origin remote
-	if federationRemote != "" && originURL == "" {
+	// Case 1: sync remote set, no origin remote
+	if declaredRemote != "" && originURL == "" {
 		return []DriftItem{{
 			Check:    "remote",
 			Status:   driftStatusDrift,
-			Message:  "federation.remote is configured but no Dolt 'origin' remote exists",
-			Expected: federationRemote,
+			Message:  fmt.Sprintf("%s is configured but no Dolt 'origin' remote exists", remoteKey),
+			Expected: declaredRemote,
 			Actual:   "(no origin remote)",
 		}}
 	}
 
-	// Case 2: federation.remote set, origin exists but doesn't match
-	if federationRemote != "" && originURL != "" && originURL != federationRemote {
+	// Case 2: sync remote set, origin exists but doesn't match
+	if declaredRemote != "" && originURL != "" && originURL != declaredRemote {
 		return []DriftItem{{
 			Check:    "remote",
 			Status:   driftStatusDrift,
-			Message:  "Dolt origin remote URL does not match federation.remote",
-			Expected: federationRemote,
+			Message:  fmt.Sprintf("Dolt origin remote URL does not match %s", remoteKey),
+			Expected: declaredRemote,
 			Actual:   originURL,
 		}}
 	}
 
-	// Case 3: federation.remote set and matches origin
-	if federationRemote != "" && originURL == federationRemote {
+	// Case 3: sync remote set and matches origin
+	if declaredRemote != "" && originURL == declaredRemote {
 		return []DriftItem{{
 			Check:   "remote",
 			Status:  driftStatusOK,
-			Message: "Dolt origin remote matches federation.remote",
+			Message: fmt.Sprintf("Dolt origin remote matches %s", remoteKey),
 		}}
 	}
 
-	// Case 4: federation.remote not set but remotes exist
-	if federationRemote == "" && len(cliRemotes) > 0 {
+	// Case 4: sync remote not set but remotes exist
+	if declaredRemote == "" && len(cliRemotes) > 0 {
 		names := make([]string, len(cliRemotes))
 		for i, r := range cliRemotes {
 			names[i] = r.Name
@@ -213,7 +221,7 @@ func checkRemoteDrift() []DriftItem {
 		return []DriftItem{{
 			Check:   "remote",
 			Status:  driftStatusInfo,
-			Message: fmt.Sprintf("Dolt remotes configured (%s) but federation.remote is not set", strings.Join(names, ", ")),
+			Message: fmt.Sprintf("Dolt remotes configured (%s) but sync.remote is not set", strings.Join(names, ", ")),
 		}}
 	}
 
@@ -221,7 +229,7 @@ func checkRemoteDrift() []DriftItem {
 	return []DriftItem{{
 		Check:   "remote",
 		Status:  driftStatusInfo,
-		Message: "No federation.remote configured and no Dolt remotes found",
+		Message: "No sync.remote configured and no Dolt remotes found",
 	}}
 }
 

--- a/cmd/bd/config_drift_test.go
+++ b/cmd/bd/config_drift_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/steveyegge/beads/internal/config"
 	"github.com/steveyegge/beads/internal/git"
 )
 
@@ -55,6 +56,36 @@ func TestCheckRemoteDriftNoBeadsDir(t *testing.T) {
 	}
 	if items[0].Status != driftStatusSkipped {
 		t.Errorf("expected status %q, got %q", driftStatusSkipped, items[0].Status)
+	}
+}
+
+// TestCheckRemoteDriftLocalOnlySkipsDoltCLI verifies local-only repos do not
+// require the external dolt binary just to report drift state.
+func TestCheckRemoteDriftLocalOnlySkipsDoltCLI(t *testing.T) {
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("dolt:\n  local-only: true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	chdirForDriftTest(t, dir)
+	t.Setenv("BEADS_DIR", beadsDir)
+	if err := config.Initialize(); err != nil {
+		t.Fatalf("config.Initialize: %v", err)
+	}
+	t.Cleanup(func() { _ = config.Initialize() })
+
+	items := checkRemoteDrift()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Status != driftStatusInfo {
+		t.Errorf("expected status %q, got %q (%s)", driftStatusInfo, items[0].Status, items[0].Message)
+	}
+	if items[0].Check != "remote" {
+		t.Errorf("expected check %q, got %q", "remote", items[0].Check)
 	}
 }
 

--- a/cmd/bd/config_test.go
+++ b/cmd/bd/config_test.go
@@ -329,9 +329,24 @@ func TestValidateSyncConfig(t *testing.T) {
 		}
 
 		issues := validateSyncConfig(tmpDir)
-		// After JSONL removal, Dolt sync requires federation.remote
+		// By default, Dolt sync requires sync.remote unless local-only is explicit.
 		if len(issues) != 1 {
-			t.Errorf("Expected 1 issue (missing federation.remote) for empty config, got: %v", issues)
+			t.Errorf("Expected 1 issue (missing sync.remote) for empty config, got: %v", issues)
+		}
+	})
+
+	t.Run("local-only config without remote", func(t *testing.T) {
+		configContent := `prefix: test
+dolt:
+  local-only: true
+`
+		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		issues := validateSyncConfig(tmpDir)
+		if len(issues) != 0 {
+			t.Errorf("Expected no issues for local-only config without remote, got: %v", issues)
 		}
 	})
 
@@ -369,13 +384,13 @@ sync:
 		issues := validateSyncConfig(tmpDir)
 		found := false
 		for _, issue := range issues {
-			if strings.Contains(issue, "federation.remote") && strings.Contains(issue, "required") {
+			if strings.Contains(issue, "sync.remote") && strings.Contains(issue, "required") {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Errorf("Expected issue about federation.remote being required, got: %v", issues)
+			t.Errorf("Expected issue about sync.remote being required, got: %v", issues)
 		}
 	})
 
@@ -418,6 +433,21 @@ federation:
 		issues := validateSyncConfig(tmpDir)
 		if len(issues) != 0 {
 			t.Errorf("Expected no issues for valid config, got: %v", issues)
+		}
+	})
+
+	t.Run("valid sync.remote config", func(t *testing.T) {
+		configContent := `prefix: test
+sync:
+  remote: "https://github.com/user/beads-data.git"
+`
+		if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write config.yaml: %v", err)
+		}
+
+		issues := validateSyncConfig(tmpDir)
+		if len(issues) != 0 {
+			t.Errorf("Expected no issues for valid sync.remote config, got: %v", issues)
 		}
 	})
 

--- a/cmd/bd/sync_remote.go
+++ b/cmd/bd/sync_remote.go
@@ -33,6 +33,22 @@ func resolveSyncRemoteFromDir(beadsDir string) string {
 	return config.GetStringFromDir(beadsDir, "sync.git-remote")
 }
 
+// resolveDeclaredDoltRemote returns the project-declared remote URL used by
+// config reconciliation commands. sync.remote is the current key; federation.remote
+// is retained here because config drift/apply historically used it.
+func resolveDeclaredDoltRemote() (key, url string) {
+	if v := config.GetString("sync.remote"); v != "" {
+		return "sync.remote", v
+	}
+	if v := config.GetString("sync.git-remote"); v != "" {
+		return "sync.git-remote", v
+	}
+	if v := config.GetString("federation.remote"); v != "" {
+		return "federation.remote", v
+	}
+	return "", ""
+}
+
 // commitBeadsConfig stages .beads/config.yaml and commits it.
 // Silently no-ops if the file is clean or the commit fails (e.g. hooks,
 // nothing to commit). Used by bd dolt remote add/remove to keep the


### PR DESCRIPTION
## Summary
- Treat `dolt.local-only: true` as an intentional no-remote configuration in `bd config validate` and `bd config drift`.
- Recognize `sync.remote` / `sync.git-remote` in config validation and remote drift/apply paths, while retaining `federation.remote` compatibility.
- Add focused tests for local-only validation and drift behavior.

## Testing
- `scripts/pr-preflight.sh --search "dolt local-only config validate sync.remote federation.remote" --repo gastownhall/beads`
- `go test -tags gms_pure_go ./cmd/bd -run 'TestValidateSyncConfig|TestCheckRemoteDrift|TestConfigHelpMentionsDoltLocalOnly|TestIsRecognizedConfigKey|TestRunApply|TestApplyRemote'`