### PR TITLE
internal/storage/domain/db: bd list method implementations for proxied-server mode

### DIFF
--- a/internal/storage/domain/config.go
+++ b/internal/storage/domain/config.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"context"
 	"fmt"
+
+	"github.com/steveyegge/beads/internal/types"
 )
 
 type ConfigSQLRepository interface {
@@ -15,12 +17,19 @@ type ConfigSQLRepository interface {
 	GetCustomTypes(ctx context.Context) ([]string, error)
 	GetAllowedPrefixes(ctx context.Context) (string, error)
 	GetAdaptiveIDConfig(ctx context.Context) (AdaptiveIDConfig, error)
+
+	GetCustomStatuses(ctx context.Context) ([]types.CustomStatus, error)
+	GetInfraTypes(ctx context.Context) (map[string]bool, error)
 }
 
 type ConfigUseCase interface {
 	VerifyInit(ctx context.Context) (VerifyResult, error)
 	GetCustomTypes(ctx context.Context) ([]string, error)
 	LoadCreateContext(ctx context.Context) (CreateContext, error)
+
+	GetCustomStatuses(ctx context.Context) ([]types.CustomStatus, error)
+	GetInfraTypes(ctx context.Context) (map[string]bool, error)
+	IsInfraTypeCtx(ctx context.Context, t types.IssueType) (bool, error)
 }
 
 // CreateContext bundles the read-only config inputs that bd create needs
@@ -87,6 +96,30 @@ func (u *configUseCaseImpl) GetCustomTypes(ctx context.Context) ([]string, error
 		return nil, fmt.Errorf("GetCustomTypes: %w", err)
 	}
 	return out, nil
+}
+
+func (u *configUseCaseImpl) GetCustomStatuses(ctx context.Context) ([]types.CustomStatus, error) {
+	out, err := u.cfgRepo.GetCustomStatuses(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetCustomStatuses: %w", err)
+	}
+	return out, nil
+}
+
+func (u *configUseCaseImpl) GetInfraTypes(ctx context.Context) (map[string]bool, error) {
+	out, err := u.cfgRepo.GetInfraTypes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetInfraTypes: %w", err)
+	}
+	return out, nil
+}
+
+func (u *configUseCaseImpl) IsInfraTypeCtx(ctx context.Context, t types.IssueType) (bool, error) {
+	infra, err := u.GetInfraTypes(ctx)
+	if err != nil {
+		return false, err
+	}
+	return infra[string(t)], nil
 }
 
 func (u *configUseCaseImpl) LoadCreateContext(ctx context.Context) (CreateContext, error) {

--- a/internal/storage/domain/db/config.go
+++ b/internal/storage/domain/db/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func NewConfigSQLRepository(runner Runner) domain.ConfigSQLRepository {
@@ -136,4 +137,47 @@ func (r *configSQLRepositoryImpl) GetAdaptiveIDConfig(ctx context.Context) (doma
 	}
 
 	return cfg, nil
+}
+
+func (r *configSQLRepositoryImpl) GetCustomStatuses(ctx context.Context) ([]types.CustomStatus, error) {
+	rows, err := r.runner.QueryContext(ctx, "SELECT name, category FROM custom_statuses ORDER BY name")
+	if err != nil {
+		return nil, fmt.Errorf("db: GetCustomStatuses: query custom_statuses: %w", err)
+	}
+	defer rows.Close()
+	var result []types.CustomStatus
+	for rows.Next() {
+		var name, category string
+		if err := rows.Scan(&name, &category); err != nil {
+			return nil, fmt.Errorf("db: GetCustomStatuses: scan: %w", err)
+		}
+		result = append(result, types.CustomStatus{
+			Name:     name,
+			Category: types.StatusCategory(category),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: GetCustomStatuses: read custom_statuses: %w", err)
+	}
+	return result, nil
+}
+
+func (r *configSQLRepositoryImpl) GetInfraTypes(ctx context.Context) (map[string]bool, error) {
+	value, err := r.GetConfig(ctx, "types.infra")
+	if err != nil {
+		return nil, fmt.Errorf("db: GetInfraTypes: %w", err)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return map[string]bool{}, nil
+	}
+	parts := strings.Split(value, ",")
+	result := make(map[string]bool, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result[p] = true
+		}
+	}
+	return result, nil
 }

--- a/internal/storage/domain/db/config_test.go
+++ b/internal/storage/domain/db/config_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
 )
 
 func (s *testSuite) TestConfigSQLRepository() {
@@ -39,6 +40,16 @@ func (s *testSuite) TestConfigSQLRepository() {
 		s.Run("MissingKeysReturnsDefaults", s.configGetAdaptiveIDConfigDefaults)
 		s.Run("OverridesApplied", s.configGetAdaptiveIDConfigOverrides)
 		s.Run("MalformedValuesFallBackToDefaults", s.configGetAdaptiveIDConfigMalformed)
+	})
+	s.Run("GetCustomStatuses", func() {
+		s.Run("EmptyTableReturnsNil", s.configGetCustomStatusesEmpty)
+		s.Run("ReturnsRowsOrderedByName", s.configGetCustomStatusesRows)
+	})
+	s.Run("GetInfraTypes", func() {
+		s.Run("MissingKeyReturnsEmpty", s.configGetInfraTypesMissing)
+		s.Run("EmptyValueReturnsEmpty", s.configGetInfraTypesEmpty)
+		s.Run("CommaSeparated", s.configGetInfraTypesCommaSeparated)
+		s.Run("TrimsWhitespaceAndSkipsEmpty", s.configGetInfraTypesTrimsAndSkipsEmpty)
 	})
 }
 
@@ -189,6 +200,60 @@ func (s *testSuite) configGetAdaptiveIDConfigOverrides() {
 	s.InDelta(0.05, got.MaxCollisionProbability, 0.0001)
 	s.Equal(4, got.MinLength)
 	s.Equal(7, got.MaxLength)
+}
+
+func (s *testSuite) configGetCustomStatusesEmpty() {
+	got, err := s.configRepo().GetCustomStatuses(s.Ctx())
+	s.Require().NoError(err)
+	s.Nil(got)
+}
+
+func (s *testSuite) configGetCustomStatusesRows() {
+	_, err := s.Runner().ExecContext(s.Ctx(),
+		"INSERT INTO custom_statuses (name, category) VALUES (?, ?), (?, ?), (?, ?)",
+		"review", string(types.CategoryWIP),
+		"archived", string(types.CategoryDone),
+		"blocked", string(types.CategoryFrozen),
+	)
+	s.Require().NoError(err)
+
+	got, err := s.configRepo().GetCustomStatuses(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal([]types.CustomStatus{
+		{Name: "archived", Category: types.CategoryDone},
+		{Name: "blocked", Category: types.CategoryFrozen},
+		{Name: "review", Category: types.CategoryWIP},
+	}, got)
+}
+
+func (s *testSuite) configGetInfraTypesMissing() {
+	got, err := s.configRepo().GetInfraTypes(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]bool{}, got)
+}
+
+func (s *testSuite) configGetInfraTypesEmpty() {
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "types.infra", ""))
+	got, err := r.GetInfraTypes(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]bool{}, got)
+}
+
+func (s *testSuite) configGetInfraTypesCommaSeparated() {
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "types.infra", "agent,rig,role"))
+	got, err := r.GetInfraTypes(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]bool{"agent": true, "rig": true, "role": true}, got)
+}
+
+func (s *testSuite) configGetInfraTypesTrimsAndSkipsEmpty() {
+	r := s.configRepo()
+	s.Require().NoError(r.SetConfig(s.Ctx(), "types.infra", "  agent , , rig  ,"))
+	got, err := r.GetInfraTypes(s.Ctx())
+	s.Require().NoError(err)
+	s.Equal(map[string]bool{"agent": true, "rig": true}, got)
 }
 
 func (s *testSuite) configGetAdaptiveIDConfigMalformed() {

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -404,32 +404,42 @@ func (r *dependencySQLRepositoryImpl) loadStatusByID(ctx context.Context, idSet 
 		ids = append(ids, id)
 	}
 	placeholders, args := buildInPlaceholders(ids)
+	sourceByID := make(map[string]string, len(idSet))
 	for _, table := range []string{"issues", "wisps"} {
 		//nolint:gosec // G201: table is a hardcoded constant
 		q := fmt.Sprintf("SELECT id, status FROM %s WHERE id IN (%s)", table, placeholders)
-		rows, err := r.runner.QueryContext(ctx, q, args...)
-		if err != nil {
-			if dberrors.IsTableNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("status from %s: %w", table, err)
-		}
-		func() {
-			defer rows.Close()
-			for rows.Next() {
-				var id string
-				var status types.Status
-				if err := rows.Scan(&id, &status); err != nil {
-					return
-				}
-				statusByID[id] = status
-			}
-		}()
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("status rows from %s: %w", table, err)
+		if err := r.scanStatusRows(ctx, q, args, table, statusByID, sourceByID); err != nil {
+			return nil, err
 		}
 	}
 	return statusByID, nil
+}
+
+func (r *dependencySQLRepositoryImpl) scanStatusRows(ctx context.Context, q string, args []any, table string, statusByID map[string]types.Status, sourceByID map[string]string) error {
+	rows, err := r.runner.QueryContext(ctx, q, args...)
+	if err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("status from %s: %w", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var status types.Status
+		if err := rows.Scan(&id, &status); err != nil {
+			return fmt.Errorf("status from %s: scan: %w", table, err)
+		}
+		if existing, dup := sourceByID[id]; dup {
+			return fmt.Errorf("status id %q exists in both %s and %s", id, existing, table)
+		}
+		sourceByID[id] = table
+		statusByID[id] = status
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("status rows from %s: %w", table, err)
+	}
+	return nil
 }
 
 func (r *dependencySQLRepositoryImpl) queryDeps(ctx context.Context, q string, args []any, into map[string][]*types.Dependency, keyByIssueID bool) error {

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -293,10 +293,6 @@ func (r *dependencySQLRepositoryImpl) GetBlockingInfo(ctx context.Context, issue
 		return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: inbound: %w", err)
 	}
 
-	// Status check targets:
-	//   - outbound: the blocker is the depends-on (the thing we depend on).
-	//   - inbound: the issue in our query set is the blocker; row.dependsOnID
-	//     equals one of our queried IDs, row.issueID is whoever depends on us.
 	statusIDs := make(map[string]struct{})
 	for _, row := range outRows {
 		statusIDs[row.dependsOnID] = struct{}{}
@@ -320,10 +316,6 @@ func (r *dependencySQLRepositoryImpl) GetBlockingInfo(ctx context.Context, issue
 		}
 	}
 	for _, row := range inRows {
-		// Blocks is keyed by the blocker (which is in our query set =
-		// row.dependsOnID), values are the issues that depend on us
-		// (row.issueID). Skip when the blocker itself is closed — a closed
-		// issue does not actively block anything.
 		if statusByID[row.dependsOnID] == types.StatusClosed {
 			continue
 		}

--- a/internal/storage/domain/db/dependency.go
+++ b/internal/storage/domain/db/dependency.go
@@ -242,6 +242,204 @@ func (r *dependencySQLRepositoryImpl) CountsByIssueIDs(ctx context.Context, issu
 	return result, nil
 }
 
+func (r *dependencySQLRepositoryImpl) GetAll(ctx context.Context, opts domain.DepListOpts) (map[string][]*types.Dependency, error) {
+	table := pickDepTable(opts.UseWispsTable)
+	typeWhere, typeArgs := buildTypeFilter(opts.Types)
+	whereClause := ""
+	if typeWhere != "" {
+		whereClause = " WHERE" + strings.TrimPrefix(typeWhere, " AND")
+	}
+
+	//nolint:gosec // G201: table and depSelectColumns are hardcoded constants
+	q := fmt.Sprintf("SELECT %s FROM %s%s ORDER BY issue_id", depSelectColumns, table, whereClause)
+
+	result := make(map[string][]*types.Dependency)
+	if err := r.queryDeps(ctx, q, typeArgs, result, true); err != nil {
+		return nil, fmt.Errorf("db: DependencySQLRepository.GetAll: %w", err)
+	}
+	return result, nil
+}
+
+func (r *dependencySQLRepositoryImpl) GetBlockingInfo(ctx context.Context, issueIDs []string, opts domain.DepListOpts) (domain.BlockingInfo, error) {
+	info := domain.BlockingInfo{
+		BlockedBy: make(map[string][]string),
+		Blocks:    make(map[string][]string),
+		Parent:    make(map[string]string),
+	}
+	if len(issueIDs) == 0 {
+		return info, nil
+	}
+
+	table := pickDepTable(opts.UseWispsTable)
+	idPlaceholders, idArgs := buildInPlaceholders(issueIDs)
+
+	//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
+	outQ := fmt.Sprintf(
+		"SELECT issue_id, %s AS depends_on_id, type FROM %s WHERE issue_id IN (%s) AND type IN ('blocks', 'parent-child')",
+		depTargetExpr, table, idPlaceholders,
+	)
+	outRows, err := r.scanBlockingRows(ctx, outQ, idArgs)
+	if err != nil {
+		return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: outbound: %w", err)
+	}
+
+	//nolint:gosec // G201: table and depTargetExpr are hardcoded constants
+	inQ := fmt.Sprintf(
+		"SELECT issue_id, %s AS depends_on_id, type FROM %s WHERE %s IN (%s) AND type = 'blocks'",
+		depTargetExpr, table, depTargetExpr, idPlaceholders,
+	)
+	inRows, err := r.scanBlockingRows(ctx, inQ, idArgs)
+	if err != nil {
+		return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: inbound: %w", err)
+	}
+
+	// Status check targets:
+	//   - outbound: the blocker is the depends-on (the thing we depend on).
+	//   - inbound: the issue in our query set is the blocker; row.dependsOnID
+	//     equals one of our queried IDs, row.issueID is whoever depends on us.
+	statusIDs := make(map[string]struct{})
+	for _, row := range outRows {
+		statusIDs[row.dependsOnID] = struct{}{}
+	}
+	for _, row := range inRows {
+		statusIDs[row.dependsOnID] = struct{}{}
+	}
+	statusByID, err := r.loadStatusByID(ctx, statusIDs)
+	if err != nil {
+		return domain.BlockingInfo{}, fmt.Errorf("db: DependencySQLRepository.GetBlockingInfo: status lookup: %w", err)
+	}
+
+	for _, row := range outRows {
+		if statusByID[row.dependsOnID] == types.StatusClosed {
+			continue
+		}
+		if row.depType == "parent-child" {
+			info.Parent[row.issueID] = row.dependsOnID
+		} else {
+			info.BlockedBy[row.issueID] = append(info.BlockedBy[row.issueID], row.dependsOnID)
+		}
+	}
+	for _, row := range inRows {
+		// Blocks is keyed by the blocker (which is in our query set =
+		// row.dependsOnID), values are the issues that depend on us
+		// (row.issueID). Skip when the blocker itself is closed — a closed
+		// issue does not actively block anything.
+		if statusByID[row.dependsOnID] == types.StatusClosed {
+			continue
+		}
+		info.Blocks[row.dependsOnID] = append(info.Blocks[row.dependsOnID], row.issueID)
+	}
+
+	return info, nil
+}
+
+func (r *dependencySQLRepositoryImpl) GetAllAcrossIssuesAndWisps(ctx context.Context, opts domain.DepListOpts) (map[string][]*types.Dependency, error) {
+	perm, err := r.GetAll(ctx, domain.DepListOpts{Types: opts.Types, UseWispsTable: false})
+	if err != nil {
+		return nil, err
+	}
+	wisp, err := r.GetAll(ctx, domain.DepListOpts{Types: opts.Types, UseWispsTable: true})
+	if err != nil {
+		if !dberrors.IsTableNotExist(err) {
+			return nil, err
+		}
+		wisp = nil
+	}
+	for k, v := range wisp {
+		perm[k] = append(perm[k], v...)
+	}
+	return perm, nil
+}
+
+func (r *dependencySQLRepositoryImpl) GetBlockingInfoAcrossIssuesAndWisps(ctx context.Context, issueIDs []string) (domain.BlockingInfo, error) {
+	perm, err := r.GetBlockingInfo(ctx, issueIDs, domain.DepListOpts{UseWispsTable: false})
+	if err != nil {
+		return domain.BlockingInfo{}, err
+	}
+	wisp, err := r.GetBlockingInfo(ctx, issueIDs, domain.DepListOpts{UseWispsTable: true})
+	if err != nil {
+		if !dberrors.IsTableNotExist(err) {
+			return domain.BlockingInfo{}, err
+		}
+		wisp = domain.BlockingInfo{
+			BlockedBy: map[string][]string{},
+			Blocks:    map[string][]string{},
+			Parent:    map[string]string{},
+		}
+	}
+	for k, v := range wisp.BlockedBy {
+		perm.BlockedBy[k] = append(perm.BlockedBy[k], v...)
+	}
+	for k, v := range wisp.Blocks {
+		perm.Blocks[k] = append(perm.Blocks[k], v...)
+	}
+	for k, v := range wisp.Parent {
+		if _, ok := perm.Parent[k]; !ok {
+			perm.Parent[k] = v
+		}
+	}
+	return perm, nil
+}
+
+type blockingRow struct {
+	issueID, dependsOnID, depType string
+}
+
+func (r *dependencySQLRepositoryImpl) scanBlockingRows(ctx context.Context, q string, args []any) ([]blockingRow, error) {
+	rows, err := r.runner.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []blockingRow
+	for rows.Next() {
+		var row blockingRow
+		if err := rows.Scan(&row.issueID, &row.dependsOnID, &row.depType); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (r *dependencySQLRepositoryImpl) loadStatusByID(ctx context.Context, idSet map[string]struct{}) (map[string]types.Status, error) {
+	statusByID := make(map[string]types.Status, len(idSet))
+	if len(idSet) == 0 {
+		return statusByID, nil
+	}
+	ids := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	placeholders, args := buildInPlaceholders(ids)
+	for _, table := range []string{"issues", "wisps"} {
+		//nolint:gosec // G201: table is a hardcoded constant
+		q := fmt.Sprintf("SELECT id, status FROM %s WHERE id IN (%s)", table, placeholders)
+		rows, err := r.runner.QueryContext(ctx, q, args...)
+		if err != nil {
+			if dberrors.IsTableNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("status from %s: %w", table, err)
+		}
+		func() {
+			defer rows.Close()
+			for rows.Next() {
+				var id string
+				var status types.Status
+				if err := rows.Scan(&id, &status); err != nil {
+					return
+				}
+				statusByID[id] = status
+			}
+		}()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("status rows from %s: %w", table, err)
+		}
+	}
+	return statusByID, nil
+}
+
 func (r *dependencySQLRepositoryImpl) queryDeps(ctx context.Context, q string, args []any, into map[string][]*types.Dependency, keyByIssueID bool) error {
 	rows, err := r.runner.QueryContext(ctx, q, args...)
 	if err != nil {

--- a/internal/storage/domain/db/dependency_test.go
+++ b/internal/storage/domain/db/dependency_test.go
@@ -33,6 +33,24 @@ func (s *testSuite) TestDependencySQLRepository() {
 		s.Run("CountsBlockingEdgesOnly", s.depCountsBlocksOnly)
 		s.Run("ZeroCountsPresentInMap", s.depCountsZeroPresent)
 	})
+	s.Run("GetAll", func() {
+		s.Run("KeyedByIssueID", s.depGetAllKeyedByIssueID)
+		s.Run("TypeFilterApplied", s.depGetAllTypeFilter)
+		s.Run("WispTableRouting", s.depGetAllWispRouting)
+	})
+	s.Run("GetAllAcrossIssuesAndWisps", func() {
+		s.Run("UnionsBothTables", s.depGetAllAcrossUnions)
+		s.Run("IgnoresUseWispsTableOpt", s.depGetAllAcrossIgnoresUseWispsOpt)
+	})
+	s.Run("GetBlockingInfo", func() {
+		s.Run("EmptyInputReturnsEmptyMaps", s.depBlockingInfoEmpty)
+		s.Run("PopulatesBlockedByAndBlocks", s.depBlockingInfoBlockedByAndBlocks)
+		s.Run("ParentChildPopulatesParent", s.depBlockingInfoParent)
+		s.Run("ClosedBlockerFiltered", s.depBlockingInfoSkipsClosed)
+	})
+	s.Run("GetBlockingInfoAcrossIssuesAndWisps", func() {
+		s.Run("UnionsBothTables", s.depBlockingInfoAcrossUnions)
+	})
 	s.Run("Wisp", func() {
 		s.Run("InsertRoutesToWispDependencies", s.depWispInsertRouting)
 		s.Run("ListReadsFromWispDependencies", s.depWispListRouting)
@@ -389,6 +407,169 @@ func (s *testSuite) depWispHasCycleCrossTable() {
 	cycle, err := r.HasCycle(s.Ctx(), "bd-dep-cx-b", "bd-dep-cx-a")
 	s.Require().NoError(err)
 	s.False(cycle, "wisp-target edges are intentionally not followed in cycle detection")
+}
+
+func (s *testSuite) depGetAllKeyedByIssueID() {
+	s.seedIssueRow("bd-getall-a")
+	s.seedIssueRow("bd-getall-b")
+	s.seedIssueRow("bd-getall-c")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-getall-a", "bd-getall-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-getall-a", "bd-getall-c", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetAll(s.Ctx(), domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-getall-a"], 2)
+}
+
+func (s *testSuite) depGetAllTypeFilter() {
+	s.seedIssueRow("bd-getall-tf-a")
+	s.seedIssueRow("bd-getall-tf-b")
+	s.seedIssueRow("bd-getall-tf-c")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-getall-tf-a", "bd-getall-tf-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-getall-tf-a", "bd-getall-tf-c", types.DepRelated), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetAll(s.Ctx(), domain.DepListOpts{Types: []types.DependencyType{types.DepBlocks}})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-getall-tf-a"], 1)
+	s.Equal(types.DepBlocks, out["bd-getall-tf-a"][0].Type)
+}
+
+func (s *testSuite) depGetAllWispRouting() {
+	s.seedWispRow("bd-getall-w-src")
+	s.seedIssueRow("bd-getall-w-tgt")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-getall-w-src", "bd-getall-w-tgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	wispOut, err := r.GetAll(s.Ctx(), domain.DepListOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Require().Len(wispOut["bd-getall-w-src"], 1)
+
+	permOut, err := r.GetAll(s.Ctx(), domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.Empty(permOut["bd-getall-w-src"], "perm-table GetAll must not see wisp_dependencies rows")
+}
+
+func (s *testSuite) depGetAllAcrossUnions() {
+	s.seedIssueRow("bd-getall-x-a")
+	s.seedIssueRow("bd-getall-x-b")
+	s.seedWispRow("bd-getall-x-w")
+	s.seedIssueRow("bd-getall-x-wtgt")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-getall-x-a", "bd-getall-x-b", types.DepBlocks), "tester",
+		domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-getall-x-w", "bd-getall-x-wtgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	out, err := r.GetAllAcrossIssuesAndWisps(s.Ctx(), domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-getall-x-a"], 1, "perm-table row present")
+	s.Require().Len(out["bd-getall-x-w"], 1, "wisp-table row present")
+}
+
+func (s *testSuite) depGetAllAcrossIgnoresUseWispsOpt() {
+	s.seedIssueRow("bd-getall-ig-a")
+	s.seedIssueRow("bd-getall-ig-b")
+	s.seedWispRow("bd-getall-ig-w")
+	s.seedIssueRow("bd-getall-ig-wtgt")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-getall-ig-a", "bd-getall-ig-b", types.DepBlocks), "tester",
+		domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-getall-ig-w", "bd-getall-ig-wtgt", types.DepBlocks), "tester",
+		domain.DepInsertOpts{UseWispsTable: true}))
+
+	// UseWispsTable=true should still return rows from BOTH tables.
+	out, err := r.GetAllAcrossIssuesAndWisps(s.Ctx(), domain.DepListOpts{UseWispsTable: true})
+	s.Require().NoError(err)
+	s.Require().Len(out["bd-getall-ig-a"], 1)
+	s.Require().Len(out["bd-getall-ig-w"], 1)
+}
+
+func (s *testSuite) depBlockingInfoEmpty() {
+	info, err := s.depRepo().GetBlockingInfo(s.Ctx(), nil, domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.NotNil(info.BlockedBy)
+	s.NotNil(info.Blocks)
+	s.NotNil(info.Parent)
+	s.Empty(info.BlockedBy)
+	s.Empty(info.Blocks)
+	s.Empty(info.Parent)
+}
+
+func (s *testSuite) depBlockingInfoBlockedByAndBlocks() {
+	s.seedIssueRow("bd-bi-mid")
+	s.seedIssueRow("bd-bi-up")
+	s.seedIssueRow("bd-bi-down")
+	r := s.depRepo()
+	// up blocks mid; mid blocks down.
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-bi-mid", "bd-bi-up", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-bi-down", "bd-bi-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	info, err := r.GetBlockingInfo(s.Ctx(), []string{"bd-bi-mid"}, domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.Equal([]string{"bd-bi-up"}, info.BlockedBy["bd-bi-mid"])
+	s.Equal([]string{"bd-bi-down"}, info.Blocks["bd-bi-mid"])
+	s.Empty(info.Parent)
+}
+
+func (s *testSuite) depBlockingInfoParent() {
+	s.seedIssueRow("bd-bi-child")
+	s.seedIssueRow("bd-bi-parent")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-bi-child", "bd-bi-parent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	info, err := r.GetBlockingInfo(s.Ctx(), []string{"bd-bi-child"}, domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.Equal("bd-bi-parent", info.Parent["bd-bi-child"])
+	s.Empty(info.BlockedBy, "parent-child must not appear in BlockedBy")
+}
+
+func (s *testSuite) depBlockingInfoSkipsClosed() {
+	s.seedIssueRow("bd-bi-cls-mid")
+	s.seedIssueRow("bd-bi-cls-blocker")
+	r := s.depRepo()
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-bi-cls-mid", "bd-bi-cls-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	// Close the blocker.
+	_, err := s.Runner().ExecContext(s.Ctx(),
+		"UPDATE issues SET status = ? WHERE id = ?", string(types.StatusClosed), "bd-bi-cls-blocker")
+	s.Require().NoError(err)
+
+	info, err := r.GetBlockingInfo(s.Ctx(), []string{"bd-bi-cls-mid"}, domain.DepListOpts{})
+	s.Require().NoError(err)
+	s.Empty(info.BlockedBy["bd-bi-cls-mid"], "closed blockers should be filtered out")
+}
+
+func (s *testSuite) depBlockingInfoAcrossUnions() {
+	// Two blockers for one target: one in dependencies, one in wisp_dependencies.
+	s.seedIssueRow("bd-bi-x-target")
+	s.seedIssueRow("bd-bi-x-permblocker")
+	s.seedWispRow("bd-bi-x-wispblocker")
+	r := s.depRepo()
+	// Perm blocker: target blocks-on permblocker, recorded in dependencies.
+	s.Require().NoError(r.Insert(s.Ctx(),
+		newDep("bd-bi-x-target", "bd-bi-x-permblocker", types.DepBlocks), "tester",
+		domain.DepInsertOpts{}))
+	// Wisp blocker: write directly to wisp_dependencies with issue_id=target,
+	// depends_on_wisp_id=wispblocker. (Our Insert routing always uses issue
+	// targets, so go around it.)
+	_, err := s.Runner().ExecContext(s.Ctx(), `
+		INSERT INTO wisp_dependencies (issue_id, depends_on_wisp_id, type, created_at, created_by, metadata)
+		VALUES (?, ?, 'blocks', NOW(), 'tester', '{}')
+	`, "bd-bi-x-target", "bd-bi-x-wispblocker")
+	s.Require().NoError(err)
+
+	info, err := r.GetBlockingInfoAcrossIssuesAndWisps(s.Ctx(), []string{"bd-bi-x-target"})
+	s.Require().NoError(err)
+	s.ElementsMatch([]string{"bd-bi-x-permblocker", "bd-bi-x-wispblocker"}, info.BlockedBy["bd-bi-x-target"])
 }
 
 func (s *testSuite) depWispDirectBackEdge() {

--- a/internal/storage/domain/db/dependency_test.go
+++ b/internal/storage/domain/db/dependency_test.go
@@ -484,8 +484,6 @@ func (s *testSuite) depGetAllAcrossIgnoresUseWispsOpt() {
 	s.Require().NoError(r.Insert(s.Ctx(),
 		newDep("bd-getall-ig-w", "bd-getall-ig-wtgt", types.DepBlocks), "tester",
 		domain.DepInsertOpts{UseWispsTable: true}))
-
-	// UseWispsTable=true should still return rows from BOTH tables.
 	out, err := r.GetAllAcrossIssuesAndWisps(s.Ctx(), domain.DepListOpts{UseWispsTable: true})
 	s.Require().NoError(err)
 	s.Require().Len(out["bd-getall-ig-a"], 1)
@@ -508,7 +506,6 @@ func (s *testSuite) depBlockingInfoBlockedByAndBlocks() {
 	s.seedIssueRow("bd-bi-up")
 	s.seedIssueRow("bd-bi-down")
 	r := s.depRepo()
-	// up blocks mid; mid blocks down.
 	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-bi-mid", "bd-bi-up", types.DepBlocks), "tester", domain.DepInsertOpts{}))
 	s.Require().NoError(r.Insert(s.Ctx(), newDep("bd-bi-down", "bd-bi-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
 
@@ -537,8 +534,6 @@ func (s *testSuite) depBlockingInfoSkipsClosed() {
 	r := s.depRepo()
 	s.Require().NoError(r.Insert(s.Ctx(),
 		newDep("bd-bi-cls-mid", "bd-bi-cls-blocker", types.DepBlocks), "tester", domain.DepInsertOpts{}))
-
-	// Close the blocker.
 	_, err := s.Runner().ExecContext(s.Ctx(),
 		"UPDATE issues SET status = ? WHERE id = ?", string(types.StatusClosed), "bd-bi-cls-blocker")
 	s.Require().NoError(err)
@@ -549,18 +544,13 @@ func (s *testSuite) depBlockingInfoSkipsClosed() {
 }
 
 func (s *testSuite) depBlockingInfoAcrossUnions() {
-	// Two blockers for one target: one in dependencies, one in wisp_dependencies.
 	s.seedIssueRow("bd-bi-x-target")
 	s.seedIssueRow("bd-bi-x-permblocker")
 	s.seedWispRow("bd-bi-x-wispblocker")
 	r := s.depRepo()
-	// Perm blocker: target blocks-on permblocker, recorded in dependencies.
 	s.Require().NoError(r.Insert(s.Ctx(),
 		newDep("bd-bi-x-target", "bd-bi-x-permblocker", types.DepBlocks), "tester",
 		domain.DepInsertOpts{}))
-	// Wisp blocker: write directly to wisp_dependencies with issue_id=target,
-	// depends_on_wisp_id=wispblocker. (Our Insert routing always uses issue
-	// targets, so go around it.)
 	_, err := s.Runner().ExecContext(s.Ctx(), `
 		INSERT INTO wisp_dependencies (issue_id, depends_on_wisp_id, type, created_at, created_by, metadata)
 		VALUES (?, ?, 'blocks', NOW(), 'tester', '{}')
@@ -573,9 +563,6 @@ func (s *testSuite) depBlockingInfoAcrossUnions() {
 }
 
 func (s *testSuite) depWispDirectBackEdge() {
-	// Direct back-edge in wisp_dependencies: source wisp s already blocks
-	// issue t; adding t -> s closes a 2-cycle. The fast path probes both
-	// tables, so this should be caught.
 	s.seedWispRow("bd-dep-wd-s")
 	s.seedIssueRow("bd-dep-wd-t")
 	r := s.depRepo()

--- a/internal/storage/domain/db/issue.go
+++ b/internal/storage/domain/db/issue.go
@@ -694,3 +694,19 @@ func normalizeUpdateValue(key string, value any) any {
 	}
 	return value
 }
+
+func (r *issueSQLRepositoryImpl) SearchAcrossIssuesAndWisps(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	return r.searchAcrossIssuesAndWisps(ctx, query, filter)
+}
+
+func (r *issueSQLRepositoryImpl) SearchAcrossIssuesAndWispsWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
+	return r.searchAcrossIssuesAndWispsWithCounts(ctx, query, filter)
+}
+
+func (r *issueSQLRepositoryImpl) GetReadyWork(ctx context.Context, filter types.WorkFilter) ([]*types.Issue, error) {
+	return r.getReadyWork(ctx, filter)
+}
+
+func (r *issueSQLRepositoryImpl) GetReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) ([]*types.IssueWithCounts, error) {
+	return r.getReadyWorkWithCounts(ctx, filter)
+}

--- a/internal/storage/domain/db/issue_search.go
+++ b/internal/storage/domain/db/issue_search.go
@@ -1,0 +1,697 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dberrors"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+const queryBatchSize = 200
+
+type filterTables struct {
+	Main         string
+	Labels       string
+	Dependencies string
+	Comments     string
+}
+
+var (
+	issuesFilterTables = filterTables{Main: "issues", Labels: "labels", Dependencies: "dependencies", Comments: "comments"}
+	wispsFilterTables  = filterTables{Main: "wisps", Labels: "wisp_labels", Dependencies: "wisp_dependencies", Comments: "wisp_comments"}
+)
+
+func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWisps(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	if filter.Ephemeral != nil && *filter.Ephemeral {
+		results, err := r.searchTable(ctx, query, filter, wispsFilterTables)
+		if err != nil && !dberrors.IsTableNotExist(err) {
+			return nil, fmt.Errorf("search wisps (ephemeral filter): %w", err)
+		}
+		if len(results) > 0 {
+			return results, nil
+		}
+	}
+
+	results, err := r.searchTable(ctx, query, filter, issuesFilterTables)
+	if err != nil {
+		return nil, fmt.Errorf("search issues: %w", err)
+	}
+
+	if filter.SkipWisps {
+		return results, nil
+	}
+
+	if filter.Ephemeral == nil || !*filter.Ephemeral {
+		empty, probeErr := r.wispsTableEmptyOrMissing(ctx)
+		if probeErr != nil {
+			return nil, fmt.Errorf("search wisps (merge): probe: %w", probeErr)
+		}
+		if empty {
+			return results, nil
+		}
+		wispResults, wispErr := r.searchTable(ctx, query, filter, wispsFilterTables)
+		if wispErr != nil && !dberrors.IsTableNotExist(wispErr) {
+			return nil, fmt.Errorf("search wisps (merge): %w", wispErr)
+		}
+		if len(wispResults) > 0 {
+			seen := make(map[string]bool, len(results))
+			for _, issue := range results {
+				seen[issue.ID] = true
+			}
+			for _, issue := range wispResults {
+				if seen[issue.ID] {
+					return nil, fmt.Errorf("id %q exists in both issues and wisps", issue.ID)
+				}
+				results = append(results, issue)
+			}
+		}
+	}
+
+	return results, nil
+}
+
+func (r *issueSQLRepositoryImpl) searchTable(ctx context.Context, query string, filter types.IssueFilter, tables filterTables) ([]*types.Issue, error) {
+	fromSQL, labelWhere, labelArgs, labelDriven, filterForClauses := buildLabelDrivenSearch(filter, tables)
+	whereClauses, args, err := buildIssueFilterClauses(query, filterForClauses, tables)
+	if err != nil {
+		return nil, err
+	}
+	if len(labelWhere) > 0 {
+		whereClauses = append(labelWhere, whereClauses...)
+		args = append(labelArgs, args...)
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	if filter.Limit > 0 && !filter.NoIDShrink {
+		return r.searchTablePatternB(ctx, fromSQL, whereSQL, args, filter, tables, labelDriven)
+	}
+
+	limitSQL := ""
+	if filter.Limit > 0 {
+		limitSQL = fmt.Sprintf(" LIMIT %d", filter.Limit)
+	}
+
+	selectSQL := "SELECT "
+	if labelDriven {
+		selectSQL = "SELECT DISTINCT "
+	}
+	//nolint:gosec // G201: SQL fragments from fixed table names and parameterized filters.
+	querySQL := fmt.Sprintf(`%s%s FROM %s %s ORDER BY priority ASC, created_at DESC, id ASC %s`,
+		selectSQL, issueSelectColumns, fromSQL, whereSQL, limitSQL)
+
+	rows, err := r.runner.QueryContext(ctx, querySQL, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search %s: %w", tables.Main, err)
+	}
+
+	var issues []*types.Issue
+	seen := make(map[string]bool)
+	for rows.Next() {
+		issue, scanErr := scanIssue(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("search %s: scan: %w", tables.Main, scanErr)
+		}
+		if seen[issue.ID] {
+			continue
+		}
+		seen[issue.ID] = true
+		issues = append(issues, issue)
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search %s: rows: %w", tables.Main, err)
+	}
+
+	if err := r.hydrateIssues(ctx, issues, tables, filter.IncludeDependencies, filter.SkipLabels); err != nil {
+		return nil, fmt.Errorf("search %s: hydrate: %w", tables.Main, err)
+	}
+
+	return issues, nil
+}
+
+func (r *issueSQLRepositoryImpl) searchTablePatternB(ctx context.Context, fromSQL, whereSQL string, args []any, filter types.IssueFilter, tables filterTables, labelDriven bool) ([]*types.Issue, error) {
+	idSelect := "SELECT "
+	if labelDriven {
+		idSelect = "SELECT DISTINCT "
+	}
+	//nolint:gosec // G201: SQL fragments from fixed table names and parameterized filters.
+	idQuery := fmt.Sprintf(`%s%s.id FROM %s %s ORDER BY %s.priority ASC, %s.created_at DESC, %s.id ASC LIMIT %d`,
+		idSelect, tables.Main, fromSQL, whereSQL, tables.Main, tables.Main, tables.Main, filter.Limit)
+
+	rows, err := r.runner.QueryContext(ctx, idQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search %s (id scan): %w", tables.Main, err)
+	}
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("search %s (id scan): scan: %w", tables.Main, err)
+		}
+		ids = append(ids, id)
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search %s (id scan): rows: %w", tables.Main, err)
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(ids))
+	fetchArgs := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		fetchArgs[i] = id
+	}
+	//nolint:gosec // G201: tables.Main is "issues" or "wisps"; placeholders are ?.
+	fetchSQL := fmt.Sprintf(`SELECT %s FROM %s WHERE id IN (%s)`,
+		issueSelectColumns, tables.Main, strings.Join(placeholders, ","))
+
+	fetchRows, err := r.runner.QueryContext(ctx, fetchSQL, fetchArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("search %s (hydrate): %w", tables.Main, err)
+	}
+
+	issueMap := make(map[string]*types.Issue, len(ids))
+	for fetchRows.Next() {
+		issue, scanErr := scanIssue(fetchRows)
+		if scanErr != nil {
+			_ = fetchRows.Close()
+			return nil, fmt.Errorf("search %s (hydrate): scan: %w", tables.Main, scanErr)
+		}
+		issueMap[issue.ID] = issue
+	}
+	_ = fetchRows.Close()
+	if err := fetchRows.Err(); err != nil {
+		return nil, fmt.Errorf("search %s (hydrate): rows: %w", tables.Main, err)
+	}
+
+	issues := make([]*types.Issue, 0, len(ids))
+	for _, id := range ids {
+		if issue, ok := issueMap[id]; ok {
+			issues = append(issues, issue)
+		}
+	}
+
+	if err := r.hydrateIssues(ctx, issues, tables, filter.IncludeDependencies, filter.SkipLabels); err != nil {
+		return nil, fmt.Errorf("search %s (pattern B): hydrate: %w", tables.Main, err)
+	}
+
+	return issues, nil
+}
+
+func (r *issueSQLRepositoryImpl) hydrateIssues(ctx context.Context, issues []*types.Issue, tables filterTables, includeDeps bool, skipLabels bool) error {
+	if len(issues) == 0 {
+		return nil
+	}
+
+	ids := make([]string, len(issues))
+	for i, issue := range issues {
+		ids[i] = issue.ID
+	}
+
+	if !skipLabels {
+		labelMap, err := r.getLabelsFromTable(ctx, tables.Labels, ids)
+		if err != nil {
+			return fmt.Errorf("hydrate labels: %w", err)
+		}
+		for _, issue := range issues {
+			if labels, ok := labelMap[issue.ID]; ok {
+				issue.Labels = labels
+			}
+		}
+	}
+
+	if includeDeps {
+		depMap, err := r.getDependencyRecordsFromTable(ctx, tables.Dependencies, ids)
+		if err != nil {
+			return fmt.Errorf("hydrate dependencies: %w", err)
+		}
+		for _, issue := range issues {
+			if deps, ok := depMap[issue.ID]; ok {
+				issue.Dependencies = deps
+			}
+		}
+	}
+
+	return nil
+}
+
+//nolint:gosec // G201: labelTable is "labels" or "wisp_labels" (hardcoded by callers).
+func (r *issueSQLRepositoryImpl) getLabelsFromTable(ctx context.Context, labelTable string, ids []string) (map[string][]string, error) {
+	result := make(map[string][]string)
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := r.runner.QueryContext(ctx, fmt.Sprintf(
+			`SELECT issue_id, label FROM %s WHERE issue_id IN (%s) ORDER BY issue_id, label`,
+			labelTable, strings.Join(placeholders, ",")), args...)
+		if err != nil {
+			return nil, fmt.Errorf("get labels from %s: %w", labelTable, err)
+		}
+		for rows.Next() {
+			var issueID, label string
+			if err := rows.Scan(&issueID, &label); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("get labels: scan: %w", err)
+			}
+			result[issueID] = append(result[issueID], label)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("get labels: rows: %w", err)
+		}
+	}
+	return result, nil
+}
+
+//nolint:gosec // G201: depTable is "dependencies" or "wisp_dependencies" (hardcoded by callers).
+func (r *issueSQLRepositoryImpl) getDependencyRecordsFromTable(ctx context.Context, depTable string, ids []string) (map[string][]*types.Dependency, error) {
+	result := make(map[string][]*types.Dependency)
+	for start := 0; start < len(ids); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		rows, err := r.runner.QueryContext(ctx, fmt.Sprintf(
+			`SELECT issue_id, %s AS depends_on_id, type, created_at, created_by, metadata, thread_id
+			 FROM %s WHERE issue_id IN (%s) ORDER BY issue_id`,
+			depTargetExpr, depTable, strings.Join(placeholders, ",")), args...)
+		if err != nil {
+			return nil, fmt.Errorf("get dep records from %s: %w", depTable, err)
+		}
+		for rows.Next() {
+			dep, scanErr := scanDepRow(rows)
+			if scanErr != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("get dep records: scan: %w", scanErr)
+			}
+			result[dep.IssueID] = append(result[dep.IssueID], dep)
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("get dep records: rows: %w", err)
+		}
+	}
+	return result, nil
+}
+
+func scanDepRow(rows *sql.Rows) (*types.Dependency, error) {
+	var dep types.Dependency
+	var createdAt sql.NullTime
+	var createdBy, metadata, threadID sql.NullString
+	if err := rows.Scan(&dep.IssueID, &dep.DependsOnID, &dep.Type, &createdAt, &createdBy, &metadata, &threadID); err != nil {
+		return nil, err
+	}
+	if createdAt.Valid {
+		dep.CreatedAt = createdAt.Time
+	}
+	if createdBy.Valid {
+		dep.CreatedBy = createdBy.String
+	}
+	if metadata.Valid {
+		dep.Metadata = metadata.String
+	}
+	if threadID.Valid {
+		dep.ThreadID = threadID.String
+	}
+	return &dep, nil
+}
+
+func (r *issueSQLRepositoryImpl) wispsTableEmptyOrMissing(ctx context.Context) (bool, error) {
+	var probe int
+	err := r.runner.QueryRowContext(ctx, "SELECT 1 FROM wisps LIMIT 1").Scan(&probe)
+	switch {
+	case err == nil:
+		return false, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return true, nil
+	case dberrors.IsTableNotExist(err):
+		return true, nil
+	default:
+		return false, err
+	}
+}
+
+func buildLabelDrivenSearch(filter types.IssueFilter, tables filterTables) (string, []string, []any, bool, types.IssueFilter) {
+	labels := compactNonEmptyStrings(filter.Labels)
+	labelsAny := compactNonEmptyStrings(filter.LabelsAny)
+	if len(labels) == 0 && len(labelsAny) == 0 {
+		return tables.Main, nil, nil, false, filter
+	}
+
+	filterForClauses := filter
+	filterForClauses.Labels = nil
+	filterForClauses.LabelsAny = nil
+
+	var joins []string
+	var where []string
+	var args []any
+
+	for i, label := range labels {
+		alias := fmt.Sprintf("label_filter_%d", i)
+		joins = append(joins, fmt.Sprintf("JOIN %s %s ON %s.issue_id = %s.id", tables.Labels, alias, alias, tables.Main))
+		where = append(where, fmt.Sprintf("%s.label = ?", alias))
+		args = append(args, label)
+	}
+
+	if len(labelsAny) > 0 {
+		alias := "label_filter_any"
+		joins = append(joins, fmt.Sprintf("JOIN %s %s ON %s.issue_id = %s.id", tables.Labels, alias, alias, tables.Main))
+		placeholders := make([]string, len(labelsAny))
+		for i, label := range labelsAny {
+			placeholders[i] = "?"
+			args = append(args, label)
+		}
+		where = append(where, fmt.Sprintf("%s.label IN (%s)", alias, strings.Join(placeholders, ", ")))
+	}
+
+	return tables.Main + " " + strings.Join(joins, " "), where, args, true, filterForClauses
+}
+
+func compactNonEmptyStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func buildIssueFilterClauses(query string, filter types.IssueFilter, tables filterTables) ([]string, []any, error) {
+	var whereClauses []string
+	var args []any
+
+	if query != "" {
+		lowerQuery := strings.ToLower(query)
+		if looksLikeIssueID(query) {
+			whereClauses = append(whereClauses, "(id = ? OR id LIKE ? OR LOWER(title) LIKE ? OR LOWER(external_ref) LIKE ?)")
+			args = append(args, lowerQuery, lowerQuery+"%", "%"+lowerQuery+"%", "%"+lowerQuery+"%")
+		} else {
+			whereClauses = append(whereClauses, "(LOWER(title) LIKE ? OR id LIKE ?)")
+			pattern := "%" + lowerQuery + "%"
+			args = append(args, pattern, pattern)
+		}
+	}
+
+	if filter.TitleSearch != "" {
+		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.TitleSearch)+"%")
+	}
+	if filter.TitleContains != "" {
+		whereClauses = append(whereClauses, "LOWER(title) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.TitleContains)+"%")
+	}
+	if filter.DescriptionContains != "" {
+		whereClauses = append(whereClauses, "LOWER(description) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.DescriptionContains)+"%")
+	}
+	if filter.NotesContains != "" {
+		whereClauses = append(whereClauses, "LOWER(notes) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.NotesContains)+"%")
+	}
+	if filter.ExternalRefContains != "" {
+		whereClauses = append(whereClauses, "LOWER(external_ref) LIKE ?")
+		args = append(args, "%"+strings.ToLower(filter.ExternalRefContains)+"%")
+	}
+
+	if filter.Status != nil {
+		whereClauses = append(whereClauses, "status = ?")
+		args = append(args, *filter.Status)
+	}
+	if len(filter.Statuses) > 0 {
+		placeholders := make([]string, len(filter.Statuses))
+		for i, s := range filter.Statuses {
+			placeholders[i] = "?"
+			args = append(args, string(s))
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("status IN (%s)", strings.Join(placeholders, ",")))
+	}
+	if len(filter.ExcludeStatus) > 0 {
+		placeholders := make([]string, len(filter.ExcludeStatus))
+		for i, s := range filter.ExcludeStatus {
+			placeholders[i] = "?"
+			args = append(args, string(s))
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("status NOT IN (%s)", strings.Join(placeholders, ",")))
+	}
+
+	if filter.IssueType != nil {
+		whereClauses = append(whereClauses, "issue_type = ?")
+		args = append(args, *filter.IssueType)
+	}
+	if len(filter.ExcludeTypes) > 0 {
+		placeholders := make([]string, len(filter.ExcludeTypes))
+		for i, t := range filter.ExcludeTypes {
+			placeholders[i] = "?"
+			args = append(args, string(t))
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("issue_type NOT IN (%s)", strings.Join(placeholders, ",")))
+	}
+
+	if filter.Assignee != nil {
+		whereClauses = append(whereClauses, "assignee = ?")
+		args = append(args, *filter.Assignee)
+	}
+
+	if filter.Priority != nil {
+		whereClauses = append(whereClauses, "priority = ?")
+		args = append(args, *filter.Priority)
+	}
+	if filter.PriorityMin != nil {
+		whereClauses = append(whereClauses, "priority >= ?")
+		args = append(args, *filter.PriorityMin)
+	}
+	if filter.PriorityMax != nil {
+		whereClauses = append(whereClauses, "priority <= ?")
+		args = append(args, *filter.PriorityMax)
+	}
+
+	if len(filter.IDs) > 0 {
+		placeholders := make([]string, len(filter.IDs))
+		for i, id := range filter.IDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("id IN (%s)", strings.Join(placeholders, ", ")))
+	}
+	if filter.IDPrefix != "" {
+		whereClauses = append(whereClauses, "id LIKE ?")
+		args = append(args, filter.IDPrefix+"%")
+	}
+	if filter.SpecIDPrefix != "" {
+		whereClauses = append(whereClauses, "spec_id LIKE ?")
+		args = append(args, filter.SpecIDPrefix+"%")
+	}
+
+	if filter.ParentID != nil {
+		parentID := *filter.ParentID
+		whereClauses = append(whereClauses, fmt.Sprintf("(id IN (SELECT issue_id FROM %s WHERE type = 'parent-child' AND %s = ?) OR (id LIKE CONCAT(?, '.%%') AND id NOT IN (SELECT issue_id FROM %s WHERE type = 'parent-child')))", tables.Dependencies, depTargetExpr, tables.Dependencies))
+		args = append(args, parentID, parentID)
+	}
+	if filter.NoParent {
+		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT issue_id FROM %s WHERE type = 'parent-child')", tables.Dependencies))
+	}
+
+	if filter.MolType != nil {
+		whereClauses = append(whereClauses, "mol_type = ?")
+		args = append(args, string(*filter.MolType))
+	}
+	if filter.WispType != nil {
+		whereClauses = append(whereClauses, "wisp_type = ?")
+		args = append(args, string(*filter.WispType))
+	}
+
+	if len(filter.Labels) > 0 {
+		for _, label := range filter.Labels {
+			whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label = ?)", tables.Labels))
+			args = append(args, label)
+		}
+	}
+	if len(filter.LabelsAny) > 0 {
+		placeholders := make([]string, len(filter.LabelsAny))
+		for i, label := range filter.LabelsAny {
+			placeholders[i] = "?"
+			args = append(args, label)
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label IN (%s))", tables.Labels, strings.Join(placeholders, ", ")))
+	}
+	if len(filter.ExcludeLabels) > 0 {
+		placeholders := make([]string, len(filter.ExcludeLabels))
+		for i, label := range filter.ExcludeLabels {
+			placeholders[i] = "?"
+			args = append(args, label)
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT issue_id FROM %s WHERE label IN (%s))", tables.Labels, strings.Join(placeholders, ", ")))
+	}
+	if filter.NoLabels {
+		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT DISTINCT issue_id FROM %s)", tables.Labels))
+	}
+
+	if filter.Pinned != nil {
+		if *filter.Pinned {
+			whereClauses = append(whereClauses, "pinned = 1")
+		} else {
+			whereClauses = append(whereClauses, "(pinned = 0 OR pinned IS NULL)")
+		}
+	}
+	if filter.SourceRepo != nil {
+		whereClauses = append(whereClauses, "source_repo = ?")
+		args = append(args, *filter.SourceRepo)
+	}
+	if filter.Ephemeral != nil {
+		if *filter.Ephemeral {
+			whereClauses = append(whereClauses, "ephemeral = 1")
+		} else {
+			whereClauses = append(whereClauses, "(ephemeral = 0 OR ephemeral IS NULL)")
+		}
+	}
+	if filter.IsTemplate != nil {
+		if *filter.IsTemplate {
+			whereClauses = append(whereClauses, "is_template = 1")
+		} else {
+			whereClauses = append(whereClauses, "(is_template = 0 OR is_template IS NULL)")
+		}
+	}
+
+	if filter.EmptyDescription {
+		whereClauses = append(whereClauses, "(description IS NULL OR description = '')")
+	}
+	if filter.NoAssignee {
+		whereClauses = append(whereClauses, "(assignee IS NULL OR assignee = '')")
+	}
+
+	if filter.CreatedAfter != nil {
+		whereClauses = append(whereClauses, "created_at > ?")
+		args = append(args, filter.CreatedAfter.Format(time.RFC3339))
+	}
+	if filter.CreatedBefore != nil {
+		whereClauses = append(whereClauses, "created_at < ?")
+		args = append(args, filter.CreatedBefore.Format(time.RFC3339))
+	}
+	if filter.UpdatedAfter != nil {
+		whereClauses = append(whereClauses, "updated_at > ?")
+		args = append(args, filter.UpdatedAfter.Format(time.RFC3339))
+	}
+	if filter.UpdatedBefore != nil {
+		whereClauses = append(whereClauses, "updated_at < ?")
+		args = append(args, filter.UpdatedBefore.Format(time.RFC3339))
+	}
+	if filter.ClosedAfter != nil {
+		whereClauses = append(whereClauses, "closed_at > ?")
+		args = append(args, filter.ClosedAfter.Format(time.RFC3339))
+	}
+	if filter.ClosedBefore != nil {
+		whereClauses = append(whereClauses, "closed_at < ?")
+		args = append(args, filter.ClosedBefore.Format(time.RFC3339))
+	}
+	if filter.StartedAfter != nil {
+		whereClauses = append(whereClauses, "started_at > ?")
+		args = append(args, filter.StartedAfter.Format(time.RFC3339))
+	}
+	if filter.StartedBefore != nil {
+		whereClauses = append(whereClauses, "started_at < ?")
+		args = append(args, filter.StartedBefore.Format(time.RFC3339))
+	}
+	if filter.DeferAfter != nil {
+		whereClauses = append(whereClauses, "defer_until > ?")
+		args = append(args, filter.DeferAfter.Format(time.RFC3339))
+	}
+	if filter.DeferBefore != nil {
+		whereClauses = append(whereClauses, "defer_until < ?")
+		args = append(args, filter.DeferBefore.Format(time.RFC3339))
+	}
+	if filter.DueAfter != nil {
+		whereClauses = append(whereClauses, "due_at > ?")
+		args = append(args, filter.DueAfter.Format(time.RFC3339))
+	}
+	if filter.DueBefore != nil {
+		whereClauses = append(whereClauses, "due_at < ?")
+		args = append(args, filter.DueBefore.Format(time.RFC3339))
+	}
+
+	if filter.Deferred {
+		whereClauses = append(whereClauses, "(defer_until IS NOT NULL OR status = ?)")
+		args = append(args, types.StatusDeferred)
+	}
+	if filter.Overdue {
+		whereClauses = append(whereClauses, "due_at IS NOT NULL AND due_at < ? AND status != ?")
+		args = append(args, time.Now().UTC().Format(time.RFC3339), types.StatusClosed)
+	}
+
+	if filter.HasMetadataKey != "" {
+		if err := storage.ValidateMetadataKey(filter.HasMetadataKey); err != nil {
+			return nil, nil, err
+		}
+		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
+		args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
+	}
+	if len(filter.MetadataFields) > 0 {
+		metaKeys := make([]string, 0, len(filter.MetadataFields))
+		for k := range filter.MetadataFields {
+			metaKeys = append(metaKeys, k)
+		}
+		sort.Strings(metaKeys)
+		for _, k := range metaKeys {
+			if err := storage.ValidateMetadataKey(k); err != nil {
+				return nil, nil, err
+			}
+			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
+			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
+		}
+	}
+
+	return whereClauses, args, nil
+}
+
+func looksLikeIssueID(query string) bool {
+	idx := strings.Index(query, "-")
+	if idx <= 0 || idx >= len(query)-1 {
+		return false
+	}
+	if strings.Contains(query, " ") {
+		return false
+	}
+	for _, c := range query {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-' || c == '.') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/storage/domain/db/issue_search_counts.go
+++ b/internal/storage/domain/db/issue_search_counts.go
@@ -1,0 +1,340 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/steveyegge/beads/internal/storage/dberrors"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (r *issueSQLRepositoryImpl) searchAcrossIssuesAndWispsWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
+	limit := filter.Limit
+
+	wispDepsExist, err := r.optionalTableExists(ctx, "wisp_dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("search issues with counts: wisp dependency probe: %w", err)
+	}
+
+	if filter.Ephemeral != nil && *filter.Ephemeral {
+		empty, probeErr := r.wispsTableEmptyOrMissing(ctx)
+		if probeErr != nil {
+			return nil, fmt.Errorf("search issues with counts: ephemeral wisp probe: %w", probeErr)
+		}
+		if empty || !wispDepsExist {
+			return nil, nil
+		}
+		wisps, err := r.runFilterSearchQuery(ctx, query, filter, wispsFilterTables, true)
+		if err != nil {
+			return nil, err
+		}
+		return finishSearchIssuesWithCounts(wisps, limit), nil
+	}
+
+	out, err := r.runFilterSearchQuery(ctx, query, filter, issuesFilterTables, wispDepsExist)
+	if err != nil {
+		return nil, err
+	}
+
+	if filter.SkipWisps {
+		return finishSearchIssuesWithCounts(out, limit), nil
+	}
+
+	empty, probeErr := r.wispsTableEmptyOrMissing(ctx)
+	if probeErr != nil {
+		return nil, fmt.Errorf("search issues with counts: wisp probe: %w", probeErr)
+	}
+	if empty || !wispDepsExist {
+		return finishSearchIssuesWithCounts(out, limit), nil
+	}
+
+	wisps, err := r.runFilterSearchQuery(ctx, query, filter, wispsFilterTables, true)
+	if err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return finishSearchIssuesWithCounts(out, limit), nil
+		}
+		return nil, err
+	}
+	if len(wisps) == 0 {
+		return finishSearchIssuesWithCounts(out, limit), nil
+	}
+
+	seen := make(map[string]struct{}, len(out))
+	for _, iwc := range out {
+		if iwc != nil && iwc.Issue != nil {
+			seen[iwc.Issue.ID] = struct{}{}
+		}
+	}
+	for _, w := range wisps {
+		if w == nil || w.Issue == nil {
+			continue
+		}
+		if _, dup := seen[w.Issue.ID]; dup {
+			return nil, fmt.Errorf("search issues with counts: id %q exists in both issues and wisps", w.Issue.ID)
+		}
+		out = append(out, w)
+	}
+	return finishSearchIssuesWithCounts(out, limit), nil
+}
+
+func (r *issueSQLRepositoryImpl) runFilterSearchQuery(ctx context.Context, query string, filter types.IssueFilter, tables filterTables, includeWispReverseDeps bool) ([]*types.IssueWithCounts, error) {
+	whereClauses, args, err := buildIssueFilterClauses(query, filter, tables)
+	if err != nil {
+		return nil, err
+	}
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+	limitSQL := ""
+	if filter.Limit > 0 {
+		limitSQL = fmt.Sprintf("LIMIT %d", filter.Limit)
+	}
+	const orderBy = "ORDER BY i.priority ASC, i.created_at DESC, i.id ASC"
+	return r.runSearchQuery(ctx, tables, whereSQL, orderBy, limitSQL, args, includeWispReverseDeps, filter.SkipLabels)
+}
+
+//nolint:gosec // G201: SQL fragments are built from hardcoded table names and parameterized filters.
+func (r *issueSQLRepositoryImpl) runSearchQuery(ctx context.Context, tables filterTables, whereSQL, orderBySQL, limitSQL string, args []any, includeWispReverseDeps bool, skipLabels bool) ([]*types.IssueWithCounts, error) {
+	reverseBlockerSelect := `
+			SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
+			FROM dependencies WHERE type = 'blocks'
+	`
+	if includeWispReverseDeps {
+		reverseBlockerSelect += `
+			UNION ALL
+			SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS dep_id
+			FROM wisp_dependencies WHERE type = 'blocks'
+		`
+	}
+
+	labelsSelect := "l.labels_json AS labels_json"
+	labelsJoin := fmt.Sprintf(`
+		LEFT JOIN (
+			SELECT issue_id, JSON_ARRAYAGG(label) AS labels_json
+			FROM %s
+			GROUP BY issue_id
+		) l ON l.issue_id = i.id`, tables.Labels)
+	if skipLabels {
+		labelsSelect = "NULL AS labels_json"
+		labelsJoin = ""
+	}
+
+	searchSQL := fmt.Sprintf(`
+		SELECT %s,
+			%s,
+			COALESCE(dc.cnt, 0) AS dep_count,
+			COALESCE(rc.cnt, 0) AS rdep_count,
+			COALESCE(cc.cnt, 0) AS comment_count,
+			pc.parent_id     AS parent_id,
+			d.deps_json      AS deps_json
+		FROM %s i
+		%s
+		LEFT JOIN (
+			SELECT issue_id, COUNT(*) AS cnt
+			FROM %s
+			WHERE type = 'blocks'
+			GROUP BY issue_id
+		) dc ON dc.issue_id = i.id
+		LEFT JOIN (
+			SELECT dep_id, COUNT(*) AS cnt FROM (
+				%s
+			) all_blockers GROUP BY dep_id
+		) rc ON rc.dep_id = i.id
+		LEFT JOIN (
+			SELECT issue_id, COUNT(*) AS cnt
+			FROM %s
+			GROUP BY issue_id
+		) cc ON cc.issue_id = i.id
+		LEFT JOIN (
+			SELECT issue_id,
+			       MIN(COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) AS parent_id
+			FROM %s
+			WHERE type = 'parent-child'
+			GROUP BY issue_id
+		) pc ON pc.issue_id = i.id
+		LEFT JOIN (
+			SELECT issue_id, JSON_ARRAYAGG(%s) AS deps_json
+			FROM %s
+			GROUP BY issue_id
+		) d ON d.issue_id = i.id
+		%s
+		%s
+		%s
+	`,
+		readyWorkIssueColumns,
+		labelsSelect,
+		tables.Main,
+		labelsJoin,
+		tables.Dependencies,
+		reverseBlockerSelect,
+		tables.Comments,
+		tables.Dependencies,
+		readyWorkDepJSONObject,
+		tables.Dependencies,
+		whereSQL,
+		orderBySQL,
+		limitSQL,
+	)
+
+	rows, err := r.runner.QueryContext(ctx, searchSQL, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search count %s: %w", tables.Main, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []*types.IssueWithCounts
+	seen := make(map[string]bool)
+	for rows.Next() {
+		iwc, scanErr := scanReadyWorkRowWithCounts(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		if iwc == nil || iwc.Issue == nil {
+			continue
+		}
+		if seen[iwc.Issue.ID] {
+			continue
+		}
+		seen[iwc.Issue.ID] = true
+		out = append(out, iwc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search count %s: rows: %w", tables.Main, err)
+	}
+	return out, nil
+}
+
+func (r *issueSQLRepositoryImpl) optionalTableExists(ctx context.Context, table string) (bool, error) {
+	var probe int
+	//nolint:gosec // G201: table is a hardcoded constant from caller (issues, wisps, dependencies, wisp_dependencies, ...).
+	err := r.runner.QueryRowContext(ctx, fmt.Sprintf("SELECT 1 FROM %s LIMIT 1", table)).Scan(&probe)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return true, nil
+	case dberrors.IsTableNotExist(err):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+var readyWorkIssueColumns = func() string {
+	raw := strings.ReplaceAll(issueSelectColumns, "\n", " ")
+	raw = strings.ReplaceAll(raw, "\t", " ")
+	parts := strings.Split(raw, ",")
+	for i, p := range parts {
+		parts[i] = "i." + strings.TrimSpace(p)
+	}
+	return strings.Join(parts, ", ")
+}()
+
+const readyWorkDepJSONObject = `JSON_OBJECT(
+	'issue_id', issue_id,
+	'depends_on_id', COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external),
+	'type', type,
+	'created_at', DATE_FORMAT(created_at, '%Y-%m-%dT%H:%i:%sZ'),
+	'created_by', created_by,
+	'metadata', CAST(metadata AS CHAR),
+	'thread_id', thread_id
+)`
+
+func scanReadyWorkRowWithCounts(rows *sql.Rows) (*types.IssueWithCounts, error) {
+	var labelsJSON, depsJSON sql.NullString
+	var parentID sql.NullString
+	var depCount, rdepCount, commentCount sql.NullInt64
+
+	composite := &compositeReadyRow{
+		row: rows,
+		extra: []any{
+			&labelsJSON,
+			&depCount,
+			&rdepCount,
+			&commentCount,
+			&parentID,
+			&depsJSON,
+		},
+	}
+	issue, err := scanIssue(composite)
+	if err != nil {
+		return nil, fmt.Errorf("scan issue with counts: %w", err)
+	}
+
+	if labelsJSON.Valid && labelsJSON.String != "" {
+		var labels []string
+		if err := json.Unmarshal([]byte(labelsJSON.String), &labels); err != nil {
+			return nil, fmt.Errorf("scan issue with counts: parse labels_json: %w", err)
+		}
+		sort.Strings(labels)
+		issue.Labels = labels
+	}
+
+	if depsJSON.Valid && depsJSON.String != "" {
+		var deps []*types.Dependency
+		if err := json.Unmarshal([]byte(depsJSON.String), &deps); err != nil {
+			return nil, fmt.Errorf("scan issue with counts: parse deps_json: %w", err)
+		}
+		issue.Dependencies = deps
+	}
+
+	iwc := &types.IssueWithCounts{
+		Issue:           issue,
+		DependencyCount: int(depCount.Int64),
+		DependentCount:  int(rdepCount.Int64),
+		CommentCount:    int(commentCount.Int64),
+	}
+	if parentID.Valid {
+		s := parentID.String
+		iwc.Parent = &s
+	}
+	return iwc, nil
+}
+
+type compositeReadyRow struct {
+	row   *sql.Rows
+	extra []any
+}
+
+func (c *compositeReadyRow) Scan(dest ...any) error {
+	combined := make([]any, 0, len(dest)+len(c.extra))
+	combined = append(combined, dest...)
+	combined = append(combined, c.extra...)
+	return c.row.Scan(combined...)
+}
+
+func finishSearchIssuesWithCounts(items []*types.IssueWithCounts, limit int) []*types.IssueWithCounts {
+	sortSearchIssuesWithCounts(items)
+	if limit > 0 && len(items) > limit {
+		return items[:limit]
+	}
+	return items
+}
+
+func sortSearchIssuesWithCounts(items []*types.IssueWithCounts) {
+	if len(items) <= 1 {
+		return
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a == nil || a.Issue == nil {
+			return false
+		}
+		if b == nil || b.Issue == nil {
+			return true
+		}
+		if a.Issue.Priority != b.Issue.Priority {
+			return a.Issue.Priority < b.Issue.Priority
+		}
+		if !a.Issue.CreatedAt.Equal(b.Issue.CreatedAt) {
+			return a.Issue.CreatedAt.After(b.Issue.CreatedAt)
+		}
+		return a.Issue.ID < b.Issue.ID
+	})
+}

--- a/internal/storage/domain/db/issue_search_counts_test.go
+++ b/internal/storage/domain/db/issue_search_counts_test.go
@@ -1,0 +1,222 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueSearchAcrossIssuesAndWispsWithCounts() {
+	s.Run("DependencyAndDependentCounts", s.searchCountsDepAndRDep)
+	s.Run("CommentCount", s.searchCountsComment)
+	s.Run("ParentPopulated", s.searchCountsParent)
+	s.Run("MergesIssuesAndWisps", s.searchCountsMergesTables)
+	s.Run("SkipWispsExcludesWisps", s.searchCountsSkipWisps)
+	s.Run("EphemeralTrueOnlyWisps", s.searchCountsEphemeralOnly)
+	s.Run("LabelHydration", s.searchCountsLabelHydration)
+	s.Run("SkipLabelsLeavesEmpty", s.searchCountsSkipLabels)
+	s.Run("SortByPriorityThenCreatedAt", s.searchCountsSortOrder)
+	s.Run("LimitRespected", s.searchCountsLimit)
+	s.Run("CollisionAcrossTablesIsError", s.searchCountsCollision)
+}
+
+func (s *testSuite) searchCountsDepAndRDep() {
+	r := s.issueRepo()
+	dep := s.depRepo()
+
+	mid := newTestIssue("bd-srxc-dr-mid", "mid")
+	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
+	a := newTestIssue("bd-srxc-dr-a", "a")
+	s.Require().NoError(r.Insert(s.Ctx(), a, "tester", domain.InsertIssueOpts{}))
+	b := newTestIssue("bd-srxc-dr-b", "b")
+	s.Require().NoError(r.Insert(s.Ctx(), b, "tester", domain.InsertIssueOpts{}))
+	c := newTestIssue("bd-srxc-dr-c", "c")
+	s.Require().NoError(r.Insert(s.Ctx(), c, "tester", domain.InsertIssueOpts{}))
+
+	// mid blocks-on a, b → DependencyCount=2
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-dr-mid", "bd-srxc-dr-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-dr-mid", "bd-srxc-dr-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	// c blocks-on mid → DependentCount=1 for mid
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-dr-c", "bd-srxc-dr-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDs: []string{"bd-srxc-dr-mid"}, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal(2, out[0].DependencyCount, "outgoing blocks count")
+	s.Equal(1, out[0].DependentCount, "incoming blocks count")
+}
+
+func (s *testSuite) searchCountsComment() {
+	r := s.issueRepo()
+	issue := newTestIssue("bd-srxc-cmt-1", "with comments")
+	s.Require().NoError(r.Insert(s.Ctx(), issue, "tester", domain.InsertIssueOpts{}))
+
+	for i := 0; i < 3; i++ {
+		_, err := s.Runner().ExecContext(s.Ctx(),
+			"INSERT INTO comments (issue_id, author, text) VALUES (?, ?, ?)",
+			"bd-srxc-cmt-1", "tester", "comment")
+		s.Require().NoError(err)
+	}
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDs: []string{"bd-srxc-cmt-1"}, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Equal(3, out[0].CommentCount)
+}
+
+func (s *testSuite) searchCountsParent() {
+	r := s.issueRepo()
+	dep := s.depRepo()
+	parent := newTestIssue("bd-srxc-par-parent", "parent")
+	s.Require().NoError(r.Insert(s.Ctx(), parent, "tester", domain.InsertIssueOpts{}))
+	child := newTestIssue("bd-srxc-par-child", "child")
+	s.Require().NoError(r.Insert(s.Ctx(), child, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-srxc-par-child", "bd-srxc-par-parent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDs: []string{"bd-srxc-par-child"}, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Require().NotNil(out[0].Parent)
+	s.Equal("bd-srxc-par-parent", *out[0].Parent)
+}
+
+func (s *testSuite) searchCountsMergesTables() {
+	r := s.issueRepo()
+	perm := newTestIssue("bd-srxc-mrg-perm", "perm")
+	s.Require().NoError(r.Insert(s.Ctx(), perm, "tester", domain.InsertIssueOpts{}))
+
+	w := newTestIssue("bd-srxc-mrg-wisp", "wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-mrg-"})
+	s.Require().NoError(err)
+	got := iwcIDs(out)
+	s.Contains(got, "bd-srxc-mrg-perm")
+	s.Contains(got, "bd-srxc-mrg-wisp")
+}
+
+func (s *testSuite) searchCountsSkipWisps() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-srxc-sk-perm", "perm"), "tester", domain.InsertIssueOpts{}))
+	w := newTestIssue("bd-srxc-sk-wisp", "wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-sk-", SkipWisps: true})
+	s.Require().NoError(err)
+	got := iwcIDs(out)
+	s.Contains(got, "bd-srxc-sk-perm")
+	s.NotContains(got, "bd-srxc-sk-wisp")
+}
+
+func (s *testSuite) searchCountsEphemeralOnly() {
+	r := s.issueRepo()
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue("bd-srxc-eo-perm", "perm"), "tester", domain.InsertIssueOpts{}))
+	w := newTestIssue("bd-srxc-eo-wisp", "wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	yes := true
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-eo-", Ephemeral: &yes})
+	s.Require().NoError(err)
+	got := iwcIDs(out)
+	s.Contains(got, "bd-srxc-eo-wisp")
+	s.NotContains(got, "bd-srxc-eo-perm")
+}
+
+func (s *testSuite) searchCountsLabelHydration() {
+	r := s.issueRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+	issue := newTestIssue("bd-srxc-lbl-1", "labeled")
+	s.Require().NoError(r.Insert(s.Ctx(), issue, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srxc-lbl-1", "alpha", "tester", domain.LabelOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srxc-lbl-1", "beta", "tester", domain.LabelOpts{}))
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDs: []string{"bd-srxc-lbl-1"}, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.ElementsMatch([]string{"alpha", "beta"}, out[0].Issue.Labels)
+}
+
+func (s *testSuite) searchCountsSkipLabels() {
+	r := s.issueRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+	issue := newTestIssue("bd-srxc-nolbl-1", "labeled")
+	s.Require().NoError(r.Insert(s.Ctx(), issue, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srxc-nolbl-1", "gamma", "tester", domain.LabelOpts{}))
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDs: []string{"bd-srxc-nolbl-1"}, SkipWisps: true, SkipLabels: true})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Empty(out[0].Issue.Labels)
+}
+
+func (s *testSuite) searchCountsSortOrder() {
+	r := s.issueRepo()
+	// Insert with explicit priorities; default-priority issues from newTestIssue
+	// would tie on priority and require created_at-ordering to be deterministic.
+	hi := newTestIssue("bd-srxc-srt-hi", "hi")
+	hi.Priority = 1
+	s.Require().NoError(r.Insert(s.Ctx(), hi, "tester", domain.InsertIssueOpts{}))
+	mid := newTestIssue("bd-srxc-srt-mid", "mid")
+	mid.Priority = 2
+	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
+	lo := newTestIssue("bd-srxc-srt-lo", "lo")
+	lo.Priority = 3
+	s.Require().NoError(r.Insert(s.Ctx(), lo, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-srt-", SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(out, 3)
+	s.Equal("bd-srxc-srt-hi", out[0].Issue.ID)
+	s.Equal("bd-srxc-srt-mid", out[1].Issue.ID)
+	s.Equal("bd-srxc-srt-lo", out[2].Issue.ID)
+}
+
+func (s *testSuite) searchCountsLimit() {
+	r := s.issueRepo()
+	for i := 0; i < 5; i++ {
+		s.Require().NoError(r.Insert(s.Ctx(),
+			newTestIssue("bd-srxc-lim-"+string(rune('a'+i)), "x"),
+			"tester", domain.InsertIssueOpts{}))
+	}
+	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-lim-", Limit: 3, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Len(out, 3)
+}
+
+func (s *testSuite) searchCountsCollision() {
+	r := s.issueRepo()
+	const id = "bd-srxc-coll-1"
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, "perm"), "tester", domain.InsertIssueOpts{}))
+	w := newTestIssue(id, "wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	_, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srxc-coll-"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "exists in both issues and wisps")
+}
+
+func iwcIDs(items []*types.IssueWithCounts) []string {
+	out := make([]string, 0, len(items))
+	for _, iwc := range items {
+		if iwc == nil || iwc.Issue == nil {
+			continue
+		}
+		out = append(out, iwc.Issue.ID)
+	}
+	return out
+}

--- a/internal/storage/domain/db/issue_search_counts_test.go
+++ b/internal/storage/domain/db/issue_search_counts_test.go
@@ -31,11 +31,8 @@ func (s *testSuite) searchCountsDepAndRDep() {
 	s.Require().NoError(r.Insert(s.Ctx(), b, "tester", domain.InsertIssueOpts{}))
 	c := newTestIssue("bd-srxc-dr-c", "c")
 	s.Require().NoError(r.Insert(s.Ctx(), c, "tester", domain.InsertIssueOpts{}))
-
-	// mid blocks-on a, b → DependencyCount=2
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-dr-mid", "bd-srxc-dr-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-dr-mid", "bd-srxc-dr-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
-	// c blocks-on mid → DependentCount=1 for mid
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-srxc-dr-c", "bd-srxc-dr-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
 
 	out, err := r.SearchAcrossIssuesAndWispsWithCounts(s.Ctx(), "",
@@ -162,8 +159,6 @@ func (s *testSuite) searchCountsSkipLabels() {
 
 func (s *testSuite) searchCountsSortOrder() {
 	r := s.issueRepo()
-	// Insert with explicit priorities; default-priority issues from newTestIssue
-	// would tie on priority and require created_at-ordering to be deterministic.
 	hi := newTestIssue("bd-srxc-srt-hi", "hi")
 	hi.Priority = 1
 	s.Require().NoError(r.Insert(s.Ctx(), hi, "tester", domain.InsertIssueOpts{}))

--- a/internal/storage/domain/db/issue_search_test.go
+++ b/internal/storage/domain/db/issue_search_test.go
@@ -1,0 +1,182 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueSearchAcrossIssuesAndWisps() {
+	s.Run("MergesIssuesAndWisps", s.searchAcrossMergesTables)
+	s.Run("SkipWispsReturnsOnlyIssues", s.searchAcrossSkipWisps)
+	s.Run("EphemeralTrueReturnsOnlyWisps", s.searchAcrossEphemeralTrueOnlyWisps)
+	s.Run("FilterByStatusAppliesAcrossTables", s.searchAcrossStatusFilter)
+	s.Run("FilterByLabelAppliesAcrossTables", s.searchAcrossLabelFilter)
+	s.Run("LabelHydrationOnResults", s.searchAcrossLabelHydration)
+	s.Run("LimitRespectedPerTable", s.searchAcrossLimitRespected)
+	s.Run("CollisionAcrossTablesIsError", s.searchAcrossCollisionError)
+	s.Run("SkipLabelsLeavesLabelsNil", s.searchAcrossSkipLabels)
+}
+
+func (s *testSuite) searchAcrossMergesTables() {
+	r := s.issueRepo()
+	perm := newTestIssue("bd-srx-merge-perm", "perm one")
+	s.Require().NoError(r.Insert(s.Ctx(), perm, "tester", domain.InsertIssueOpts{}))
+
+	w := newTestIssue("bd-srx-merge-wisp", "wisp one")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "", types.IssueFilter{IDPrefix: "bd-srx-merge-"})
+	s.Require().NoError(err)
+	gotIDs := idsFrom(out)
+	s.Contains(gotIDs, "bd-srx-merge-perm")
+	s.Contains(gotIDs, "bd-srx-merge-wisp")
+}
+
+func (s *testSuite) searchAcrossSkipWisps() {
+	r := s.issueRepo()
+	perm := newTestIssue("bd-srx-skip-perm", "perm")
+	s.Require().NoError(r.Insert(s.Ctx(), perm, "tester", domain.InsertIssueOpts{}))
+
+	w := newTestIssue("bd-srx-skip-wisp", "wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-skip-", SkipWisps: true})
+	s.Require().NoError(err)
+	gotIDs := idsFrom(out)
+	s.Contains(gotIDs, "bd-srx-skip-perm")
+	s.NotContains(gotIDs, "bd-srx-skip-wisp", "SkipWisps must exclude wisps from results")
+}
+
+func (s *testSuite) searchAcrossEphemeralTrueOnlyWisps() {
+	r := s.issueRepo()
+	perm := newTestIssue("bd-srx-eph-perm", "perm")
+	s.Require().NoError(r.Insert(s.Ctx(), perm, "tester", domain.InsertIssueOpts{}))
+
+	w := newTestIssue("bd-srx-eph-wisp", "wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	ephTrue := true
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-eph-", Ephemeral: &ephTrue})
+	s.Require().NoError(err)
+	gotIDs := idsFrom(out)
+	s.Contains(gotIDs, "bd-srx-eph-wisp")
+	s.NotContains(gotIDs, "bd-srx-eph-perm", "Ephemeral=true must route to wisps table only")
+}
+
+func (s *testSuite) searchAcrossStatusFilter() {
+	r := s.issueRepo()
+	openIssue := newTestIssue("bd-srx-st-open", "open")
+	s.Require().NoError(r.Insert(s.Ctx(), openIssue, "tester", domain.InsertIssueOpts{}))
+
+	closedIssue := newTestIssue("bd-srx-st-closed", "closed")
+	closedIssue.Status = types.StatusClosed
+	s.Require().NoError(r.Insert(s.Ctx(), closedIssue, "tester", domain.InsertIssueOpts{}))
+
+	closedWisp := newTestIssue("bd-srx-st-wclosed", "wisp closed")
+	closedWisp.Ephemeral = true
+	closedWisp.Status = types.StatusClosed
+	s.Require().NoError(r.Insert(s.Ctx(), closedWisp, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	closed := types.StatusClosed
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-st-", Status: &closed})
+	s.Require().NoError(err)
+	gotIDs := idsFrom(out)
+	s.ElementsMatch([]string{"bd-srx-st-closed", "bd-srx-st-wclosed"}, gotIDs)
+}
+
+func (s *testSuite) searchAcrossLabelFilter() {
+	r := s.issueRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+
+	hot := newTestIssue("bd-srx-lbl-hot", "tagged hot")
+	s.Require().NoError(r.Insert(s.Ctx(), hot, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srx-lbl-hot", "hot", "tester", domain.LabelOpts{}))
+
+	cold := newTestIssue("bd-srx-lbl-cold", "tagged cold")
+	s.Require().NoError(r.Insert(s.Ctx(), cold, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srx-lbl-cold", "cold", "tester", domain.LabelOpts{}))
+
+	wispHot := newTestIssue("bd-srx-lbl-whot", "wisp hot")
+	wispHot.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), wispHot, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srx-lbl-whot", "hot", "tester", domain.LabelOpts{UseWispsTable: true}))
+
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-lbl-", Labels: []string{"hot"}})
+	s.Require().NoError(err)
+	gotIDs := idsFrom(out)
+	s.ElementsMatch([]string{"bd-srx-lbl-hot", "bd-srx-lbl-whot"}, gotIDs)
+}
+
+func (s *testSuite) searchAcrossLabelHydration() {
+	r := s.issueRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+
+	issue := newTestIssue("bd-srx-hyd-1", "labeled")
+	s.Require().NoError(r.Insert(s.Ctx(), issue, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srx-hyd-1", "alpha", "tester", domain.LabelOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srx-hyd-1", "beta", "tester", domain.LabelOpts{}))
+
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-hyd-"})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.ElementsMatch([]string{"alpha", "beta"}, out[0].Labels)
+}
+
+func (s *testSuite) searchAcrossLimitRespected() {
+	r := s.issueRepo()
+	for i := 0; i < 5; i++ {
+		s.Require().NoError(r.Insert(s.Ctx(),
+			newTestIssue("bd-srx-lim-"+string(rune('a'+i)), "x"),
+			"tester", domain.InsertIssueOpts{}))
+	}
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-lim-", Limit: 3, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Len(out, 3)
+}
+
+func (s *testSuite) searchAcrossCollisionError() {
+	r := s.issueRepo()
+	const id = "bd-srx-collision-1"
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, "perm"), "tester", domain.InsertIssueOpts{}))
+
+	w := newTestIssue(id, "wisp")
+	w.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	_, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-collision-"})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "exists in both issues and wisps")
+}
+
+func (s *testSuite) searchAcrossSkipLabels() {
+	r := s.issueRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+
+	issue := newTestIssue("bd-srx-nolbl-1", "labeled")
+	s.Require().NoError(r.Insert(s.Ctx(), issue, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-srx-nolbl-1", "gamma", "tester", domain.LabelOpts{}))
+
+	out, err := r.SearchAcrossIssuesAndWisps(s.Ctx(), "",
+		types.IssueFilter{IDPrefix: "bd-srx-nolbl-", SkipLabels: true, SkipWisps: true})
+	s.Require().NoError(err)
+	s.Require().Len(out, 1)
+	s.Empty(out[0].Labels, "SkipLabels must leave Labels nil/empty")
+}
+
+func idsFrom(issues []*types.Issue) []string {
+	out := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, issue.ID)
+	}
+	return out
+}

--- a/internal/storage/domain/db/ready_work.go
+++ b/internal/storage/domain/db/ready_work.go
@@ -1,0 +1,891 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage"
+	"github.com/steveyegge/beads/internal/storage/dberrors"
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+type readyWorkPredicates struct {
+	whereSQL         string
+	orderBySQL       string
+	limitSQL         string
+	args             []any
+	deferredChildIDs []string
+}
+
+type readyWorkOrder struct {
+	sql  string
+	args []any
+}
+
+func readyWorkPageSize(limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	const minPageSize = 100
+	if limit < minPageSize {
+		return minPageSize
+	}
+	return limit
+}
+
+func buildReadyWorkOrder(policy types.SortPolicy) readyWorkOrder {
+	switch policy {
+	case types.SortPolicyOldest:
+		return readyWorkOrder{sql: "ORDER BY created_at ASC, id ASC"}
+	case types.SortPolicyPriority:
+		return readyWorkOrder{sql: "ORDER BY priority ASC, created_at DESC, id ASC"}
+	case types.SortPolicyHybrid, "":
+		recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
+		return readyWorkOrder{
+			sql: `ORDER BY
+			CASE WHEN created_at >= ? THEN 0 ELSE 1 END ASC,
+			CASE WHEN created_at >= ? THEN priority ELSE 999 END ASC,
+			created_at ASC, id ASC`,
+			args: []any{recentCutoff, recentCutoff},
+		}
+	default:
+		return readyWorkOrder{sql: "ORDER BY priority ASC, created_at DESC, id ASC"}
+	}
+}
+
+func readyWorkExcludeTypes(extra []types.IssueType) []types.IssueType {
+	excludeTypes := []types.IssueType{
+		types.IssueType("merge-request"),
+		types.TypeGate,
+		types.TypeMolecule,
+		types.TypeMessage,
+		types.IssueType("agent"),
+		types.IssueType("role"),
+		types.IssueType("rig"),
+	}
+	seen := make(map[types.IssueType]bool, len(excludeTypes)+len(extra))
+	for _, t := range excludeTypes {
+		seen[t] = true
+	}
+	for _, t := range extra {
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		excludeTypes = append(excludeTypes, t)
+	}
+	return excludeTypes
+}
+
+func (r *issueSQLRepositoryImpl) buildReadyWorkPredicates(ctx context.Context, filter types.WorkFilter, tables filterTables) (*readyWorkPredicates, error) {
+	var statusClause string
+	if filter.Status != "" {
+		statusClause = "status = ?"
+	} else {
+		statusClause = "status IN ('open', 'in_progress')"
+	}
+	whereClauses := []string{
+		statusClause,
+		"(pinned = 0 OR pinned IS NULL)",
+		"is_blocked = 0",
+	}
+	if !filter.IncludeEphemeral {
+		whereClauses = append(whereClauses, "(ephemeral = 0 OR ephemeral IS NULL)")
+	}
+	var args []any
+	if filter.Status != "" {
+		args = append(args, string(filter.Status))
+	}
+
+	if filter.Priority != nil {
+		whereClauses = append(whereClauses, "priority = ?")
+		args = append(args, *filter.Priority)
+	}
+	if filter.Type != "" {
+		whereClauses = append(whereClauses, "issue_type = ?")
+		args = append(args, filter.Type)
+	} else {
+		excludeTypes := readyWorkExcludeTypes(filter.ExcludeTypes)
+		placeholders := make([]string, len(excludeTypes))
+		for i, t := range excludeTypes {
+			placeholders[i] = "?"
+			args = append(args, string(t))
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("issue_type NOT IN (%s)", strings.Join(placeholders, ",")))
+	}
+	if filter.Unassigned {
+		whereClauses = append(whereClauses, "(assignee IS NULL OR assignee = '')")
+	} else if filter.Assignee != nil {
+		whereClauses = append(whereClauses, "assignee = ?")
+		args = append(args, *filter.Assignee)
+	}
+
+	var deferredChildIDs []string
+	if !filter.IncludeDeferred {
+		whereClauses = append(whereClauses, "(defer_until IS NULL OR defer_until <= UTC_TIMESTAMP())")
+		var dcErr error
+		deferredChildIDs, dcErr = r.getChildrenOfDeferredParents(ctx)
+		if dcErr != nil {
+			return nil, fmt.Errorf("get ready work: compute deferred parent children: %w", dcErr)
+		}
+		if len(deferredChildIDs) > 0 {
+			for start := 0; start < len(deferredChildIDs); start += queryBatchSize {
+				end := start + queryBatchSize
+				if end > len(deferredChildIDs) {
+					end = len(deferredChildIDs)
+				}
+				placeholders, batchArgs := buildInPlaceholders(deferredChildIDs[start:end])
+				args = append(args, batchArgs...)
+				whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (%s)", placeholders))
+			}
+		}
+	}
+
+	if len(filter.Labels) > 0 {
+		for _, label := range filter.Labels {
+			whereClauses = append(whereClauses, fmt.Sprintf("id IN (SELECT issue_id FROM %s WHERE label = ?)", tables.Labels))
+			args = append(args, label)
+		}
+	}
+	if len(filter.ExcludeLabels) > 0 {
+		placeholders := make([]string, len(filter.ExcludeLabels))
+		for i, label := range filter.ExcludeLabels {
+			placeholders[i] = "?"
+			args = append(args, label)
+		}
+		whereClauses = append(whereClauses, fmt.Sprintf("id NOT IN (SELECT issue_id FROM %s WHERE label IN (%s))", tables.Labels, strings.Join(placeholders, ", ")))
+	}
+
+	if filter.ParentID != nil {
+		parentID := *filter.ParentID
+		descendantIDs, descErr := r.getDescendantIDs(ctx, parentID, 0)
+		if descErr != nil {
+			return nil, fmt.Errorf("get parent descendants: %w", descErr)
+		}
+		parentClauses := []string{fmt.Sprintf("(id LIKE CONCAT(?, '.%%') AND id NOT IN (SELECT issue_id FROM %s WHERE type = 'parent-child'))", tables.Dependencies)}
+		args = append(args, parentID)
+		for start := 0; start < len(descendantIDs); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(descendantIDs) {
+				end = len(descendantIDs)
+			}
+			placeholders, batchArgs := buildInPlaceholders(descendantIDs[start:end])
+			parentClauses = append(parentClauses, fmt.Sprintf("id IN (%s)", placeholders))
+			args = append(args, batchArgs...)
+		}
+		whereClauses = append(whereClauses, "("+strings.Join(parentClauses, " OR ")+")")
+	}
+
+	if filter.MoleculeID != "" {
+		whereClauses = append(whereClauses, fmt.Sprintf("(id IN (SELECT issue_id FROM %s WHERE type = 'parent-child' AND %s = ?) OR (id LIKE CONCAT(?, '.%%') AND id NOT IN (SELECT issue_id FROM %s WHERE type = 'parent-child')))", tables.Dependencies, depTargetExpr, tables.Dependencies))
+		args = append(args, filter.MoleculeID, filter.MoleculeID)
+	}
+
+	if filter.HasMetadataKey != "" {
+		if err := storage.ValidateMetadataKey(filter.HasMetadataKey); err != nil {
+			return nil, err
+		}
+		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
+		args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
+	}
+
+	if len(filter.MetadataFields) > 0 {
+		metaKeys := make([]string, 0, len(filter.MetadataFields))
+		for k := range filter.MetadataFields {
+			metaKeys = append(metaKeys, k)
+		}
+		sort.Strings(metaKeys)
+		for _, k := range metaKeys {
+			if err := storage.ValidateMetadataKey(k); err != nil {
+				return nil, err
+			}
+			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
+			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
+		}
+	}
+
+	whereSQL := "WHERE " + strings.Join(whereClauses, " AND ")
+
+	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	args = append(args, orderBy.args...)
+
+	var limitSQL string
+	if filter.Limit > 0 {
+		limitSQL = fmt.Sprintf("LIMIT %d", filter.Limit)
+	}
+
+	return &readyWorkPredicates{
+		whereSQL:         whereSQL,
+		orderBySQL:       orderBy.sql,
+		limitSQL:         limitSQL,
+		args:             args,
+		deferredChildIDs: deferredChildIDs,
+	}, nil
+}
+
+//nolint:gosec // G201: whereSQL/orderBySQL built from hardcoded strings and ? placeholders
+func (r *issueSQLRepositoryImpl) getReadyWork(ctx context.Context, filter types.WorkFilter) ([]*types.Issue, error) {
+	preds, err := r.buildReadyWorkPredicates(ctx, filter, issuesFilterTables)
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf(`
+		SELECT id FROM issues
+		%s
+		%s
+		%s
+	`, preds.whereSQL, preds.orderBySQL, preds.limitSQL)
+
+	issueIDs, err := r.queryReadyIDPage(ctx, query, preds.args)
+	if err != nil {
+		return nil, err
+	}
+
+	issues, err := r.GetByIDs(ctx, issueIDs, domain.IssueTableOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("get ready work: fetch issues: %w", err)
+	}
+	issueMap := make(map[string]*types.Issue, len(issues))
+	for _, iss := range issues {
+		issueMap[iss.ID] = iss
+	}
+	ordered := make([]*types.Issue, 0, len(issueIDs))
+	for _, id := range issueIDs {
+		if iss, ok := issueMap[id]; ok {
+			ordered = append(ordered, iss)
+		}
+	}
+
+	wisps, wErr := r.getReadyWisps(ctx, filter, preds.deferredChildIDs)
+	if wErr != nil {
+		return nil, wErr
+	}
+	if len(wisps) > 0 {
+		ordered, err = mergeReadyWisps(ordered, wisps, filter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ordered, nil
+}
+
+func (r *issueSQLRepositoryImpl) getReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) ([]*types.IssueWithCounts, error) {
+	wispDepsExist, err := r.optionalTableExists(ctx, "wisp_dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("get ready work with counts: wisp dependency probe: %w", err)
+	}
+
+	issuePreds, err := r.buildReadyWorkPredicates(ctx, filter, issuesFilterTables)
+	if err != nil {
+		return nil, err
+	}
+	out, err := r.runSearchQuery(ctx, issuesFilterTables, issuePreds.whereSQL, issuePreds.orderBySQL, issuePreds.limitSQL, issuePreds.args, wispDepsExist, false)
+	if err != nil {
+		return nil, err
+	}
+
+	empty, probeErr := r.wispsTableEmptyOrMissing(ctx)
+	if probeErr != nil {
+		return nil, fmt.Errorf("get ready work with counts: wisp probe: %w", probeErr)
+	}
+	if empty || !wispDepsExist {
+		return out, nil
+	}
+
+	wispPreds, err := r.buildReadyWorkPredicates(ctx, filter, wispsFilterTables)
+	if err != nil {
+		return nil, err
+	}
+	wisps, err := r.runSearchQuery(ctx, wispsFilterTables, wispPreds.whereSQL, wispPreds.orderBySQL, wispPreds.limitSQL, wispPreds.args, true, false)
+	if err != nil {
+		if dberrors.IsTableNotExist(err) {
+			return out, nil
+		}
+		return nil, err
+	}
+	if len(wisps) == 0 {
+		return out, nil
+	}
+
+	seen := make(map[string]struct{}, len(out))
+	for _, iwc := range out {
+		if iwc != nil && iwc.Issue != nil {
+			seen[iwc.Issue.ID] = struct{}{}
+		}
+	}
+	for _, w := range wisps {
+		if w == nil || w.Issue == nil {
+			continue
+		}
+		if _, dup := seen[w.Issue.ID]; dup {
+			return nil, fmt.Errorf("get ready work with counts: id %q exists in both issues and wisps", w.Issue.ID)
+		}
+		out = append(out, w)
+	}
+	sortIssuesWithCountsByPolicy(out, filter.SortPolicy)
+	if filter.Limit > 0 && len(out) > filter.Limit {
+		out = out[:filter.Limit]
+	}
+	return out, nil
+}
+
+func sortIssuesWithCountsByPolicy(items []*types.IssueWithCounts, policy types.SortPolicy) {
+	if len(items) <= 1 {
+		return
+	}
+	issues := make([]*types.Issue, 0, len(items))
+	for _, item := range items {
+		if item == nil || item.Issue == nil {
+			continue
+		}
+		issues = append(issues, item.Issue)
+	}
+	if len(issues) != len(items) {
+		return
+	}
+	sortReadyIssues(issues, policy)
+	byID := make(map[string]int, len(issues))
+	for i, iss := range issues {
+		byID[iss.ID] = i
+	}
+	sorted := make([]*types.IssueWithCounts, len(items))
+	for _, item := range items {
+		sorted[byID[item.Issue.ID]] = item
+	}
+	copy(items, sorted)
+}
+
+func mergeReadyWisps(ordered []*types.Issue, wisps []*types.Issue, filter types.WorkFilter) ([]*types.Issue, error) {
+	seen := make(map[string]struct{}, len(ordered))
+	for _, issue := range ordered {
+		seen[issue.ID] = struct{}{}
+	}
+	for _, wisp := range wisps {
+		if _, exists := seen[wisp.ID]; exists {
+			return nil, fmt.Errorf("ready work id %q exists in both issues and wisps", wisp.ID)
+		}
+		ordered = append(ordered, wisp)
+	}
+	sortReadyIssues(ordered, filter.SortPolicy)
+	if filter.Limit > 0 && len(ordered) > filter.Limit {
+		ordered = ordered[:filter.Limit]
+	}
+	return ordered, nil
+}
+
+func (r *issueSQLRepositoryImpl) getReadyWisps(ctx context.Context, filter types.WorkFilter, deferredChildIDs []string) ([]*types.Issue, error) {
+	empty, err := r.wispsTableEmptyOrMissing(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("search wisps (ready work): probe: %w", err)
+	}
+	if empty {
+		return nil, nil
+	}
+
+	wispFilter := readyWorkWispIssueFilter(filter)
+	if filter.Limit <= 0 {
+		wispFilter.Limit = 0
+		wisps, err := r.searchTable(ctx, "", wispFilter, wispsFilterTables)
+		if err != nil {
+			if dberrors.IsTableNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		}
+		return r.filterReadyWisps(ctx, filter, wisps, deferredChildIDs)
+	}
+
+	pageSize := readyWorkPageSize(filter.Limit)
+	orderBy := buildReadyWorkOrder(filter.SortPolicy)
+	ready := make([]*types.Issue, 0, filter.Limit)
+	for offset := 0; len(ready) < filter.Limit; offset += pageSize {
+		pageIDs, err := r.queryReadyWispIssueIDPage(ctx, wispFilter, !filter.IncludeDeferred, orderBy, pageSize, offset)
+		if err != nil {
+			if dberrors.IsTableNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		}
+		if len(pageIDs) == 0 {
+			break
+		}
+
+		pageWisps, err := r.getWispIssuesByIDsInOrder(ctx, pageIDs)
+		if err != nil {
+			return nil, fmt.Errorf("search wisps (ready work): %w", err)
+		}
+		pageReady, err := r.filterReadyWisps(ctx, filter, pageWisps, deferredChildIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, wisp := range pageReady {
+			ready = append(ready, wisp)
+			if len(ready) >= filter.Limit {
+				break
+			}
+		}
+		if len(pageIDs) < pageSize {
+			break
+		}
+	}
+	return ready, nil
+}
+
+func (r *issueSQLRepositoryImpl) queryReadyWispIssueIDPage(ctx context.Context, filter types.IssueFilter, excludeDeferred bool, orderBy readyWorkOrder, limit, offset int) ([]string, error) {
+	fromSQL, labelWhere, labelArgs, labelDriven, filterForClauses := buildLabelDrivenSearch(filter, wispsFilterTables)
+	whereClauses, args, err := buildIssueFilterClauses("", filterForClauses, wispsFilterTables)
+	if err != nil {
+		return nil, err
+	}
+	if len(labelWhere) > 0 {
+		whereClauses = append(labelWhere, whereClauses...)
+		args = append(labelArgs, args...)
+	}
+	if excludeDeferred {
+		whereClauses = append(whereClauses, "(defer_until IS NULL OR defer_until <= UTC_TIMESTAMP())")
+	}
+
+	whereSQL := ""
+	if len(whereClauses) > 0 {
+		whereSQL = "WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	selectSQL := "SELECT "
+	if labelDriven {
+		selectSQL = "SELECT DISTINCT "
+	}
+	args = append(args, orderBy.args...)
+	//nolint:gosec // G201: SQL fragments are fixed table/column names and parameterized filters; limit/offset are ints.
+	query := fmt.Sprintf(`%sid FROM %s %s %s LIMIT %d OFFSET %d`,
+		selectSQL, fromSQL, whereSQL, orderBy.sql, limit, offset)
+
+	rows, err := r.runner.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("search wisps: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("search wisps: scan id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("search wisps: rows: %w", err)
+	}
+	return ids, nil
+}
+
+func (r *issueSQLRepositoryImpl) getWispIssuesByIDsInOrder(ctx context.Context, ids []string) ([]*types.Issue, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	issues, err := r.GetByIDs(ctx, ids, domain.IssueTableOpts{UseWispsTable: true})
+	if err != nil {
+		return nil, err
+	}
+	issueMap := make(map[string]*types.Issue, len(issues))
+	for _, issue := range issues {
+		issueMap[issue.ID] = issue
+	}
+	ordered := make([]*types.Issue, 0, len(ids))
+	for _, id := range ids {
+		if issue, ok := issueMap[id]; ok {
+			ordered = append(ordered, issue)
+		}
+	}
+	return ordered, nil
+}
+
+func readyWorkWispIssueFilter(filter types.WorkFilter) types.IssueFilter {
+	pinnedFalse := false
+	wispFilter := types.IssueFilter{
+		Priority:       filter.Priority,
+		Labels:         filter.Labels,
+		LabelsAny:      filter.LabelsAny,
+		ExcludeLabels:  filter.ExcludeLabels,
+		Limit:          filter.Limit,
+		MolType:        filter.MolType,
+		WispType:       filter.WispType,
+		Pinned:         &pinnedFalse,
+		MetadataFields: filter.MetadataFields,
+		HasMetadataKey: filter.HasMetadataKey,
+	}
+	if filter.Status != "" {
+		s := filter.Status
+		wispFilter.Status = &s
+	} else {
+		wispFilter.Statuses = []types.Status{types.StatusOpen, types.StatusInProgress}
+	}
+	if filter.Type != "" {
+		t := types.IssueType(filter.Type)
+		wispFilter.IssueType = &t
+	} else {
+		wispFilter.ExcludeTypes = readyWorkExcludeTypes(filter.ExcludeTypes)
+	}
+	if filter.Unassigned {
+		wispFilter.NoAssignee = true
+	} else if filter.Assignee != nil {
+		wispFilter.Assignee = filter.Assignee
+	}
+	if filter.MoleculeID != "" {
+		moleculeID := filter.MoleculeID
+		wispFilter.ParentID = &moleculeID
+	}
+	if !filter.IncludeEphemeral {
+		ephFalse := false
+		wispFilter.Ephemeral = &ephFalse
+	}
+	return wispFilter
+}
+
+func (r *issueSQLRepositoryImpl) filterReadyWisps(ctx context.Context, filter types.WorkFilter, wisps []*types.Issue, deferredChildIDs []string) ([]*types.Issue, error) {
+	if len(wisps) == 0 {
+		return wisps, nil
+	}
+
+	wispIDs := make([]string, 0, len(wisps))
+	for _, wisp := range wisps {
+		wispIDs = append(wispIDs, wisp.ID)
+	}
+
+	excluded := make(map[string]struct{})
+	if filter.ParentID != nil {
+		parentID := *filter.ParentID
+		descendantIDs, err := r.getDescendantIDs(ctx, parentID, 0)
+		if err != nil {
+			return nil, fmt.Errorf("get wisp parent descendants: %w", err)
+		}
+		descendantSet := make(map[string]struct{}, len(descendantIDs))
+		for _, id := range descendantIDs {
+			descendantSet[id] = struct{}{}
+		}
+		parentedSet, err := r.getParentedIDSet(ctx, wispIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, wisp := range wisps {
+			if _, ok := descendantSet[wisp.ID]; ok {
+				continue
+			}
+			if strings.HasPrefix(wisp.ID, parentID+".") {
+				if _, hasParent := parentedSet[wisp.ID]; !hasParent {
+					continue
+				}
+			}
+			excluded[wisp.ID] = struct{}{}
+		}
+	}
+
+	if !filter.IncludeDeferred {
+		now := time.Now().UTC()
+		for _, wisp := range wisps {
+			if wisp.DeferUntil != nil && wisp.DeferUntil.After(now) {
+				excluded[wisp.ID] = struct{}{}
+			}
+		}
+		for _, id := range deferredChildIDs {
+			excluded[id] = struct{}{}
+		}
+	}
+
+	for start := 0; start < len(wispIDs); start += queryBatchSize {
+		end := start + queryBatchSize
+		if end > len(wispIDs) {
+			end = len(wispIDs)
+		}
+		placeholders, args := buildInPlaceholders(wispIDs[start:end])
+		//nolint:gosec // G201: only IN-clause placeholders are formatted in.
+		rows, err := r.runner.QueryContext(ctx, fmt.Sprintf(`
+			SELECT id FROM wisps WHERE id IN (%s) AND is_blocked = 1
+		`, placeholders), args...)
+		if err != nil {
+			return nil, fmt.Errorf("get ready work: filter blocked wisps: %w", err)
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan blocked wisp: %w", err)
+			}
+			excluded[id] = struct{}{}
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("blocked wisp rows: %w", err)
+		}
+	}
+
+	ready := wisps[:0]
+	for _, wisp := range wisps {
+		if wisp.Pinned {
+			continue
+		}
+		if _, skip := excluded[wisp.ID]; skip {
+			continue
+		}
+		ready = append(ready, wisp)
+	}
+	return ready, nil
+}
+
+func sortReadyIssues(issues []*types.Issue, policy types.SortPolicy) {
+	recentCutoff := time.Now().UTC().Add(-48 * time.Hour)
+	sort.SliceStable(issues, func(i, j int) bool {
+		a, b := issues[i], issues[j]
+		switch policy {
+		case types.SortPolicyOldest:
+			return issueCreatedBefore(a, b)
+		case types.SortPolicyPriority:
+			return issuePriorityBefore(a, b)
+		case types.SortPolicyHybrid, "":
+			aRecent := !a.CreatedAt.Before(recentCutoff)
+			bRecent := !b.CreatedAt.Before(recentCutoff)
+			if aRecent != bRecent {
+				return aRecent
+			}
+			if aRecent && a.Priority != b.Priority {
+				return a.Priority < b.Priority
+			}
+			return issueCreatedBefore(a, b)
+		default:
+			return issuePriorityBefore(a, b)
+		}
+	})
+}
+
+func issuePriorityBefore(a, b *types.Issue) bool {
+	if a.Priority != b.Priority {
+		return a.Priority < b.Priority
+	}
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.After(b.CreatedAt)
+	}
+	return a.ID < b.ID
+}
+
+func issueCreatedBefore(a, b *types.Issue) bool {
+	if !a.CreatedAt.Equal(b.CreatedAt) {
+		return a.CreatedAt.Before(b.CreatedAt)
+	}
+	return a.ID < b.ID
+}
+
+func (r *issueSQLRepositoryImpl) queryReadyIDPage(ctx context.Context, query string, args []any) ([]string, error) {
+	rows, err := r.runner.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ready work: %w", err)
+	}
+
+	var issueIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("get ready work: scan id: %w", err)
+		}
+		issueIDs = append(issueIDs, id)
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get ready work: rows: %w", err)
+	}
+	return issueIDs, nil
+}
+
+//nolint:gosec // G201: depTable/issueTable are hardcoded values.
+func (r *issueSQLRepositoryImpl) getChildrenOfDeferredParents(ctx context.Context) ([]string, error) {
+	hasDeferredParent := false
+	for _, issueTable := range []string{"issues", "wisps"} {
+		var exists int
+		err := r.runner.QueryRowContext(ctx, fmt.Sprintf(`
+			SELECT 1 FROM %s
+			WHERE defer_until IS NOT NULL
+			  AND defer_until > UTC_TIMESTAMP()
+			LIMIT 1
+		`, issueTable)).Scan(&exists)
+		if err == nil {
+			hasDeferredParent = true
+			break
+		}
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if issueTable == "wisps" && dberrors.IsTableNotExist(err) {
+			continue
+		}
+		return nil, fmt.Errorf("deferred parents: check future-deferred parents from %s: %w", issueTable, err)
+	}
+	if !hasDeferredParent {
+		return nil, nil
+	}
+
+	var childIDs []string
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		for _, issueTable := range []string{"issues", "wisps"} {
+			targetCol := "depends_on_issue_id"
+			if issueTable == "wisps" {
+				targetCol = "depends_on_wisp_id"
+			}
+			rows, err := r.runner.QueryContext(ctx, fmt.Sprintf(`
+				SELECT dep.issue_id
+				FROM %s dep
+				JOIN %s parent ON parent.id = dep.%s
+				WHERE dep.type = 'parent-child'
+				  AND parent.defer_until IS NOT NULL
+				  AND parent.defer_until > UTC_TIMESTAMP()
+			`, depTable, issueTable, targetCol))
+			if err != nil {
+				if depTable == "wisp_dependencies" && dberrors.IsTableNotExist(err) {
+					break
+				}
+				if issueTable == "wisps" && dberrors.IsTableNotExist(err) {
+					continue
+				}
+				return nil, fmt.Errorf("deferred parents: get deferred children from %s/%s: %w", depTable, issueTable, err)
+			}
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("deferred parents: scan deferred child from %s/%s: %w", depTable, issueTable, err)
+				}
+				childIDs = append(childIDs, id)
+			}
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("deferred parents: child rows from %s/%s: %w", depTable, issueTable, err)
+			}
+		}
+	}
+	return childIDs, nil
+}
+
+//nolint:gosec // G201: depTable is hardcoded.
+func (r *issueSQLRepositoryImpl) getParentedIDSet(ctx context.Context, issueIDs []string) (map[string]struct{}, error) {
+	parented := make(map[string]struct{})
+	if len(issueIDs) == 0 {
+		return parented, nil
+	}
+	for _, depTable := range []string{"dependencies", "wisp_dependencies"} {
+		for start := 0; start < len(issueIDs); start += queryBatchSize {
+			end := start + queryBatchSize
+			if end > len(issueIDs) {
+				end = len(issueIDs)
+			}
+			placeholders, args := buildInPlaceholders(issueIDs[start:end])
+			query := fmt.Sprintf(`
+				SELECT issue_id FROM %s
+				WHERE type = 'parent-child' AND issue_id IN (%s)
+			`, depTable, placeholders)
+			rows, err := r.runner.QueryContext(ctx, query, args...)
+			if err != nil {
+				if depTable == "wisp_dependencies" && dberrors.IsTableNotExist(err) {
+					break
+				}
+				return nil, fmt.Errorf("get parented IDs from %s: %w", depTable, err)
+			}
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					_ = rows.Close()
+					return nil, fmt.Errorf("get parented IDs: scan: %w", err)
+				}
+				parented[id] = struct{}{}
+			}
+			_ = rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, fmt.Errorf("get parented IDs: rows from %s: %w", depTable, err)
+			}
+		}
+	}
+	return parented, nil
+}
+
+func (r *issueSQLRepositoryImpl) getDescendantIDs(ctx context.Context, rootID string, maxDepth int) ([]string, error) {
+	if rootID == "" {
+		return nil, nil
+	}
+
+	queryDescendants := func(includeWisps bool) ([]string, bool, error) {
+		edgeQuery := fmt.Sprintf(`
+			SELECT issue_id, %s FROM dependencies WHERE type = 'parent-child'
+		`, depTargetExpr)
+		if includeWisps {
+			edgeQuery += fmt.Sprintf(`
+			UNION ALL
+			SELECT issue_id, %s FROM wisp_dependencies WHERE type = 'parent-child'
+		`, depTargetExpr)
+		}
+
+		//nolint:gosec // G201: edgeQuery is built from hardcoded SQL plus depTargetExpr (no user input)
+		query := fmt.Sprintf(`
+			WITH RECURSIVE
+			parent_edges(issue_id, depends_on_id) AS (
+				%s
+			),
+			descendants(id, depth, path) AS (
+				SELECT issue_id, 1, CONCAT(',', ?, ',', issue_id, ',')
+				FROM parent_edges
+				WHERE depends_on_id = ?
+				UNION ALL
+				SELECT e.issue_id, d.depth + 1, CONCAT(d.path, e.issue_id, ',')
+				FROM parent_edges e
+				JOIN descendants d ON e.depends_on_id = d.id
+				WHERE (? <= 0 OR d.depth < ?)
+				  AND LOCATE(CONCAT(',', e.issue_id, ','), d.path) = 0
+			)
+			SELECT id, depth FROM descendants WHERE id <> ?
+		`, edgeQuery)
+
+		rows, err := r.runner.QueryContext(ctx, query, rootID, rootID, maxDepth, maxDepth, rootID)
+		if err != nil {
+			return nil, false, err
+		}
+		defer func() { _ = rows.Close() }()
+
+		var result []string
+		reachedMaxDepth := false
+		for rows.Next() {
+			var id string
+			var depth int
+			if err := rows.Scan(&id, &depth); err != nil {
+				return nil, false, fmt.Errorf("scan descendant: %w", err)
+			}
+			result = append(result, id)
+			if maxDepth > 0 && depth >= maxDepth {
+				reachedMaxDepth = true
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, false, fmt.Errorf("descendant rows: %w", err)
+		}
+		return result, reachedMaxDepth, nil
+	}
+
+	result, reachedMaxDepth, err := queryDescendants(true)
+	if err != nil {
+		if !dberrors.IsTableNotExist(err) {
+			return nil, err
+		}
+		result, reachedMaxDepth, err = queryDescendants(false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if reachedMaxDepth {
+		return nil, fmt.Errorf("parent descendant traversal for %s reached max depth %d", rootID, maxDepth)
+	}
+	return result, nil
+}

--- a/internal/storage/domain/db/ready_work_counts_test.go
+++ b/internal/storage/domain/db/ready_work_counts_test.go
@@ -1,0 +1,241 @@
+package db
+
+import (
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueGetReadyWorkWithCounts() {
+	s.Run("ReturnsReadyIssues", s.readyCountsReturnsReady)
+	s.Run("DependencyAndDependentCounts", s.readyCountsDepAndRDep)
+	s.Run("CommentCount", s.readyCountsComment)
+	s.Run("ParentPopulated", s.readyCountsParent)
+	s.Run("ExcludesClosed", s.readyCountsExcludesClosed)
+	s.Run("ExcludesPinned", s.readyCountsExcludesPinned)
+	s.Run("ExcludesBlocked", s.readyCountsExcludesBlocked)
+	s.Run("PriorityFilter", s.readyCountsPriorityFilter)
+	s.Run("LabelHydration", s.readyCountsLabelHydration)
+	s.Run("SortByPriority", s.readyCountsSortByPriority)
+	s.Run("LimitRespected", s.readyCountsLimit)
+	s.Run("CollisionAcrossTablesIsError", s.readyCountsCollision)
+}
+
+func (s *testSuite) readyCountsReturnsReady() {
+	r := s.issueRepo()
+	open := newTestIssue("bd-rdyc-r-open", "open")
+	s.Require().NoError(r.Insert(s.Ctx(), open, "tester", domain.InsertIssueOpts{}))
+	ip := newTestIssue("bd-rdyc-r-ip", "in progress")
+	ip.Status = types.StatusInProgress
+	s.Require().NoError(r.Insert(s.Ctx(), ip, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	got := iwcIDs(out)
+	s.Contains(got, "bd-rdyc-r-open")
+	s.Contains(got, "bd-rdyc-r-ip")
+}
+
+func (s *testSuite) readyCountsDepAndRDep() {
+	r := s.issueRepo()
+	dep := s.depRepo()
+
+	mid := newTestIssue("bd-rdyc-dr-mid", "mid")
+	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
+	a := newTestIssue("bd-rdyc-dr-a", "a")
+	a.Status = types.StatusClosed // closed blockers so mid is not is_blocked
+	s.Require().NoError(r.Insert(s.Ctx(), a, "tester", domain.InsertIssueOpts{}))
+	b := newTestIssue("bd-rdyc-dr-b", "b")
+	b.Status = types.StatusClosed
+	s.Require().NoError(r.Insert(s.Ctx(), b, "tester", domain.InsertIssueOpts{}))
+	c := newTestIssue("bd-rdyc-dr-c", "c")
+	s.Require().NoError(r.Insert(s.Ctx(), c, "tester", domain.InsertIssueOpts{}))
+
+	// mid blocks-on a, b (both closed) → DependencyCount=2 but mid still ready
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-rdyc-dr-mid", "bd-rdyc-dr-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-rdyc-dr-mid", "bd-rdyc-dr-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+	// c blocks-on mid → DependentCount=1 for mid
+	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-rdyc-dr-c", "bd-rdyc-dr-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	var midIWC *types.IssueWithCounts
+	for _, iwc := range out {
+		if iwc.Issue.ID == "bd-rdyc-dr-mid" {
+			midIWC = iwc
+			break
+		}
+	}
+	s.Require().NotNil(midIWC, "mid should be in ready work output")
+	s.Equal(2, midIWC.DependencyCount)
+	s.Equal(1, midIWC.DependentCount)
+}
+
+func (s *testSuite) readyCountsComment() {
+	r := s.issueRepo()
+	issue := newTestIssue("bd-rdyc-cmt-1", "commented")
+	s.Require().NoError(r.Insert(s.Ctx(), issue, "tester", domain.InsertIssueOpts{}))
+	for i := 0; i < 3; i++ {
+		_, err := s.Runner().ExecContext(s.Ctx(),
+			"INSERT INTO comments (issue_id, author, text) VALUES (?, ?, ?)",
+			"bd-rdyc-cmt-1", "tester", "comment")
+		s.Require().NoError(err)
+	}
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	var got *types.IssueWithCounts
+	for _, iwc := range out {
+		if iwc.Issue.ID == "bd-rdyc-cmt-1" {
+			got = iwc
+			break
+		}
+	}
+	s.Require().NotNil(got)
+	s.Equal(3, got.CommentCount)
+}
+
+func (s *testSuite) readyCountsParent() {
+	r := s.issueRepo()
+	dep := s.depRepo()
+	parent := newTestIssue("bd-rdyc-par-parent", "parent")
+	s.Require().NoError(r.Insert(s.Ctx(), parent, "tester", domain.InsertIssueOpts{}))
+	child := newTestIssue("bd-rdyc-par-child", "child")
+	s.Require().NoError(r.Insert(s.Ctx(), child, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(dep.Insert(s.Ctx(),
+		newDep("bd-rdyc-par-child", "bd-rdyc-par-parent", types.DepParentChild), "tester", domain.DepInsertOpts{}))
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	var got *types.IssueWithCounts
+	for _, iwc := range out {
+		if iwc.Issue.ID == "bd-rdyc-par-child" {
+			got = iwc
+			break
+		}
+	}
+	s.Require().NotNil(got)
+	s.Require().NotNil(got.Parent)
+	s.Equal("bd-rdyc-par-parent", *got.Parent)
+}
+
+func (s *testSuite) readyCountsExcludesClosed() {
+	r := s.issueRepo()
+	closed := newTestIssue("bd-rdyc-cls-1", "closed")
+	closed.Status = types.StatusClosed
+	s.Require().NoError(r.Insert(s.Ctx(), closed, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(iwcIDs(out), "bd-rdyc-cls-1")
+}
+
+func (s *testSuite) readyCountsExcludesPinned() {
+	r := s.issueRepo()
+	pinned := newTestIssue("bd-rdyc-pin-1", "pinned")
+	s.Require().NoError(r.Insert(s.Ctx(), pinned, "tester", domain.InsertIssueOpts{}))
+	_, err := s.Runner().ExecContext(s.Ctx(), "UPDATE issues SET pinned = 1 WHERE id = ?", "bd-rdyc-pin-1")
+	s.Require().NoError(err)
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(iwcIDs(out), "bd-rdyc-pin-1")
+}
+
+func (s *testSuite) readyCountsExcludesBlocked() {
+	r := s.issueRepo()
+	blocked := newTestIssue("bd-rdyc-blk-1", "blocked")
+	s.Require().NoError(r.Insert(s.Ctx(), blocked, "tester", domain.InsertIssueOpts{}))
+	_, err := s.Runner().ExecContext(s.Ctx(), "UPDATE issues SET is_blocked = 1 WHERE id = ?", "bd-rdyc-blk-1")
+	s.Require().NoError(err)
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(iwcIDs(out), "bd-rdyc-blk-1")
+}
+
+func (s *testSuite) readyCountsPriorityFilter() {
+	r := s.issueRepo()
+	hi := newTestIssue("bd-rdyc-pr-hi", "hi")
+	hi.Priority = 1
+	s.Require().NoError(r.Insert(s.Ctx(), hi, "tester", domain.InsertIssueOpts{}))
+	lo := newTestIssue("bd-rdyc-pr-lo", "lo")
+	lo.Priority = 3
+	s.Require().NoError(r.Insert(s.Ctx(), lo, "tester", domain.InsertIssueOpts{}))
+
+	pri := 1
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{Priority: &pri})
+	s.Require().NoError(err)
+	got := iwcIDs(out)
+	s.Contains(got, "bd-rdyc-pr-hi")
+	s.NotContains(got, "bd-rdyc-pr-lo")
+}
+
+func (s *testSuite) readyCountsLabelHydration() {
+	r := s.issueRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+	issue := newTestIssue("bd-rdyc-lbl-1", "labeled")
+	s.Require().NoError(r.Insert(s.Ctx(), issue, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-rdyc-lbl-1", "alpha", "tester", domain.LabelOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-rdyc-lbl-1", "beta", "tester", domain.LabelOpts{}))
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	var got *types.IssueWithCounts
+	for _, iwc := range out {
+		if iwc.Issue.ID == "bd-rdyc-lbl-1" {
+			got = iwc
+			break
+		}
+	}
+	s.Require().NotNil(got)
+	s.ElementsMatch([]string{"alpha", "beta"}, got.Issue.Labels)
+}
+
+func (s *testSuite) readyCountsSortByPriority() {
+	r := s.issueRepo()
+	lo := newTestIssue("bd-rdyc-srt-lo", "lo")
+	lo.Priority = 3
+	s.Require().NoError(r.Insert(s.Ctx(), lo, "tester", domain.InsertIssueOpts{}))
+	hi := newTestIssue("bd-rdyc-srt-hi", "hi")
+	hi.Priority = 1
+	s.Require().NoError(r.Insert(s.Ctx(), hi, "tester", domain.InsertIssueOpts{}))
+	mid := newTestIssue("bd-rdyc-srt-mid", "mid")
+	mid.Priority = 2
+	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{SortPolicy: types.SortPolicyPriority})
+	s.Require().NoError(err)
+	got := iwcIDs(out)
+	hiIdx, midIdx, loIdx := indexOf(got, "bd-rdyc-srt-hi"), indexOf(got, "bd-rdyc-srt-mid"), indexOf(got, "bd-rdyc-srt-lo")
+	s.Require().GreaterOrEqual(hiIdx, 0)
+	s.Require().GreaterOrEqual(midIdx, 0)
+	s.Require().GreaterOrEqual(loIdx, 0)
+	s.Less(hiIdx, midIdx)
+	s.Less(midIdx, loIdx)
+}
+
+func (s *testSuite) readyCountsLimit() {
+	r := s.issueRepo()
+	for i := 0; i < 5; i++ {
+		iss := newTestIssue("bd-rdyc-lim-"+string(rune('a'+i)), "x")
+		iss.Priority = 1
+		s.Require().NoError(r.Insert(s.Ctx(), iss, "tester", domain.InsertIssueOpts{}))
+	}
+	pri := 1
+	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{Priority: &pri, Limit: 3, SortPolicy: types.SortPolicyPriority})
+	s.Require().NoError(err)
+	s.Len(out, 3)
+}
+
+func (s *testSuite) readyCountsCollision() {
+	r := s.issueRepo()
+	const id = "bd-rdyc-coll-1"
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, "perm"), "tester", domain.InsertIssueOpts{}))
+	w := newTestIssue(id, "wisp")
+	w.Ephemeral = false // NoHistory wisp — survives default ephemeral filter
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	_, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "exists in both issues and wisps")
+}

--- a/internal/storage/domain/db/ready_work_counts_test.go
+++ b/internal/storage/domain/db/ready_work_counts_test.go
@@ -42,18 +42,15 @@ func (s *testSuite) readyCountsDepAndRDep() {
 	mid := newTestIssue("bd-rdyc-dr-mid", "mid")
 	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
 	a := newTestIssue("bd-rdyc-dr-a", "a")
-	a.Status = types.StatusClosed // closed blockers so mid is not is_blocked
+	a.Status = types.StatusClosed
 	s.Require().NoError(r.Insert(s.Ctx(), a, "tester", domain.InsertIssueOpts{}))
 	b := newTestIssue("bd-rdyc-dr-b", "b")
 	b.Status = types.StatusClosed
 	s.Require().NoError(r.Insert(s.Ctx(), b, "tester", domain.InsertIssueOpts{}))
 	c := newTestIssue("bd-rdyc-dr-c", "c")
 	s.Require().NoError(r.Insert(s.Ctx(), c, "tester", domain.InsertIssueOpts{}))
-
-	// mid blocks-on a, b (both closed) → DependencyCount=2 but mid still ready
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-rdyc-dr-mid", "bd-rdyc-dr-a", types.DepBlocks), "tester", domain.DepInsertOpts{}))
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-rdyc-dr-mid", "bd-rdyc-dr-b", types.DepBlocks), "tester", domain.DepInsertOpts{}))
-	// c blocks-on mid → DependentCount=1 for mid
 	s.Require().NoError(dep.Insert(s.Ctx(), newDep("bd-rdyc-dr-c", "bd-rdyc-dr-mid", types.DepBlocks), "tester", domain.DepInsertOpts{}))
 
 	out, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})
@@ -232,7 +229,7 @@ func (s *testSuite) readyCountsCollision() {
 	const id = "bd-rdyc-coll-1"
 	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, "perm"), "tester", domain.InsertIssueOpts{}))
 	w := newTestIssue(id, "wisp")
-	w.Ephemeral = false // NoHistory wisp — survives default ephemeral filter
+	w.Ephemeral = false
 	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
 
 	_, err := r.GetReadyWorkWithCounts(s.Ctx(), types.WorkFilter{})

--- a/internal/storage/domain/db/ready_work_test.go
+++ b/internal/storage/domain/db/ready_work_test.go
@@ -1,0 +1,271 @@
+package db
+
+import (
+	"time"
+
+	"github.com/steveyegge/beads/internal/storage/domain"
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func (s *testSuite) TestIssueGetReadyWork() {
+	s.Run("ReturnsOpenAndInProgress", s.readyOpenAndInProgress)
+	s.Run("ExcludesClosed", s.readyExcludesClosed)
+	s.Run("ExcludesPinned", s.readyExcludesPinned)
+	s.Run("ExcludesBlocked", s.readyExcludesBlocked)
+	s.Run("ExcludesEphemeralByDefault", s.readyExcludesEphemeral)
+	s.Run("ExcludesDefaultTypes", s.readyExcludesDefaultTypes)
+	s.Run("FilterByPriority", s.readyFilterByPriority)
+	s.Run("FilterByAssignee", s.readyFilterByAssignee)
+	s.Run("Unassigned", s.readyUnassigned)
+	s.Run("ExcludesDeferred", s.readyExcludesDeferred)
+	s.Run("IncludeDeferred", s.readyIncludeDeferred)
+	s.Run("LabelFilter", s.readyLabelFilter)
+	s.Run("LimitRespected", s.readyLimitRespected)
+	s.Run("SortByPriority", s.readySortByPriority)
+	s.Run("CrossTableCollisionError", s.readyCollisionError)
+}
+
+func (s *testSuite) readyOpenAndInProgress() {
+	r := s.issueRepo()
+
+	openIss := newTestIssue("bd-rdy-oa-open", "open")
+	s.Require().NoError(r.Insert(s.Ctx(), openIss, "tester", domain.InsertIssueOpts{}))
+
+	ip := newTestIssue("bd-rdy-oa-ip", "in progress")
+	ip.Status = types.StatusInProgress
+	s.Require().NoError(r.Insert(s.Ctx(), ip, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, "bd-rdy-oa-open")
+	s.Contains(got, "bd-rdy-oa-ip")
+}
+
+func (s *testSuite) readyExcludesClosed() {
+	r := s.issueRepo()
+
+	closed := newTestIssue("bd-rdy-cls-1", "closed")
+	closed.Status = types.StatusClosed
+	s.Require().NoError(r.Insert(s.Ctx(), closed, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(issueIDsFrom(out), "bd-rdy-cls-1")
+}
+
+func (s *testSuite) readyExcludesPinned() {
+	r := s.issueRepo()
+	pinned := newTestIssue("bd-rdy-pin-1", "pinned")
+	s.Require().NoError(r.Insert(s.Ctx(), pinned, "tester", domain.InsertIssueOpts{}))
+	_, err := s.Runner().ExecContext(s.Ctx(), "UPDATE issues SET pinned = 1 WHERE id = ?", "bd-rdy-pin-1")
+	s.Require().NoError(err)
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(issueIDsFrom(out), "bd-rdy-pin-1")
+}
+
+func (s *testSuite) readyExcludesBlocked() {
+	r := s.issueRepo()
+	blocked := newTestIssue("bd-rdy-blk-1", "blocked")
+	s.Require().NoError(r.Insert(s.Ctx(), blocked, "tester", domain.InsertIssueOpts{}))
+	_, err := s.Runner().ExecContext(s.Ctx(), "UPDATE issues SET is_blocked = 1 WHERE id = ?", "bd-rdy-blk-1")
+	s.Require().NoError(err)
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(issueIDsFrom(out), "bd-rdy-blk-1")
+}
+
+func (s *testSuite) readyExcludesEphemeral() {
+	r := s.issueRepo()
+	ephemeral := newTestIssue("bd-rdy-eph-1", "ephemeral")
+	ephemeral.Ephemeral = true
+	s.Require().NoError(r.Insert(s.Ctx(), ephemeral, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(issueIDsFrom(out), "bd-rdy-eph-1", "ephemeral=1 must be excluded by default")
+}
+
+func (s *testSuite) readyExcludesDefaultTypes() {
+	r := s.issueRepo()
+	mol := newTestIssue("bd-rdy-dt-mol", "molecule")
+	mol.IssueType = types.TypeMolecule
+	s.Require().NoError(r.Insert(s.Ctx(), mol, "tester", domain.InsertIssueOpts{}))
+
+	gate := newTestIssue("bd-rdy-dt-gate", "gate")
+	gate.IssueType = types.TypeGate
+	s.Require().NoError(r.Insert(s.Ctx(), gate, "tester", domain.InsertIssueOpts{}))
+
+	task := newTestIssue("bd-rdy-dt-task", "task")
+	s.Require().NoError(r.Insert(s.Ctx(), task, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, "bd-rdy-dt-task")
+	s.NotContains(got, "bd-rdy-dt-mol")
+	s.NotContains(got, "bd-rdy-dt-gate")
+}
+
+func (s *testSuite) readyFilterByPriority() {
+	r := s.issueRepo()
+	hi := newTestIssue("bd-rdy-pr-hi", "hi")
+	hi.Priority = 1
+	s.Require().NoError(r.Insert(s.Ctx(), hi, "tester", domain.InsertIssueOpts{}))
+	lo := newTestIssue("bd-rdy-pr-lo", "lo")
+	lo.Priority = 3
+	s.Require().NoError(r.Insert(s.Ctx(), lo, "tester", domain.InsertIssueOpts{}))
+
+	pri := 1
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{Priority: &pri})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, "bd-rdy-pr-hi")
+	s.NotContains(got, "bd-rdy-pr-lo")
+}
+
+func (s *testSuite) readyFilterByAssignee() {
+	r := s.issueRepo()
+	mine := newTestIssue("bd-rdy-as-mine", "mine")
+	mine.Assignee = "alice"
+	s.Require().NoError(r.Insert(s.Ctx(), mine, "tester", domain.InsertIssueOpts{}))
+	theirs := newTestIssue("bd-rdy-as-theirs", "theirs")
+	theirs.Assignee = "bob"
+	s.Require().NoError(r.Insert(s.Ctx(), theirs, "tester", domain.InsertIssueOpts{}))
+
+	alice := "alice"
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{Assignee: &alice})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, "bd-rdy-as-mine")
+	s.NotContains(got, "bd-rdy-as-theirs")
+}
+
+func (s *testSuite) readyUnassigned() {
+	r := s.issueRepo()
+	unassigned := newTestIssue("bd-rdy-un-yes", "unassigned")
+	s.Require().NoError(r.Insert(s.Ctx(), unassigned, "tester", domain.InsertIssueOpts{}))
+	assigned := newTestIssue("bd-rdy-un-no", "assigned")
+	assigned.Assignee = "alice"
+	s.Require().NoError(r.Insert(s.Ctx(), assigned, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{Unassigned: true})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, "bd-rdy-un-yes")
+	s.NotContains(got, "bd-rdy-un-no")
+}
+
+func (s *testSuite) readyExcludesDeferred() {
+	r := s.issueRepo()
+	deferred := newTestIssue("bd-rdy-df-1", "deferred")
+	s.Require().NoError(r.Insert(s.Ctx(), deferred, "tester", domain.InsertIssueOpts{}))
+	future := time.Now().UTC().Add(24 * time.Hour)
+	_, err := s.Runner().ExecContext(s.Ctx(), "UPDATE issues SET defer_until = ? WHERE id = ?", future, "bd-rdy-df-1")
+	s.Require().NoError(err)
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().NoError(err)
+	s.NotContains(issueIDsFrom(out), "bd-rdy-df-1")
+}
+
+func (s *testSuite) readyIncludeDeferred() {
+	r := s.issueRepo()
+	deferred := newTestIssue("bd-rdy-idf-1", "deferred")
+	s.Require().NoError(r.Insert(s.Ctx(), deferred, "tester", domain.InsertIssueOpts{}))
+	future := time.Now().UTC().Add(24 * time.Hour)
+	_, err := s.Runner().ExecContext(s.Ctx(), "UPDATE issues SET defer_until = ? WHERE id = ?", future, "bd-rdy-idf-1")
+	s.Require().NoError(err)
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{IncludeDeferred: true})
+	s.Require().NoError(err)
+	s.Contains(issueIDsFrom(out), "bd-rdy-idf-1")
+}
+
+func (s *testSuite) readyLabelFilter() {
+	r := s.issueRepo()
+	labelRepo := NewLabelSQLRepository(s.Runner())
+
+	hot := newTestIssue("bd-rdy-lbl-hot", "hot")
+	s.Require().NoError(r.Insert(s.Ctx(), hot, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-rdy-lbl-hot", "hot", "tester", domain.LabelOpts{}))
+
+	cold := newTestIssue("bd-rdy-lbl-cold", "cold")
+	s.Require().NoError(r.Insert(s.Ctx(), cold, "tester", domain.InsertIssueOpts{}))
+	s.Require().NoError(labelRepo.Insert(s.Ctx(), "bd-rdy-lbl-cold", "cold", "tester", domain.LabelOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{Labels: []string{"hot"}})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	s.Contains(got, "bd-rdy-lbl-hot")
+	s.NotContains(got, "bd-rdy-lbl-cold")
+}
+
+func (s *testSuite) readyLimitRespected() {
+	r := s.issueRepo()
+	for i := 0; i < 5; i++ {
+		iss := newTestIssue("bd-rdy-lim-"+string(rune('a'+i)), "x")
+		iss.Priority = 1
+		s.Require().NoError(r.Insert(s.Ctx(), iss, "tester", domain.InsertIssueOpts{}))
+	}
+	pri := 1
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{Priority: &pri, Limit: 3, SortPolicy: types.SortPolicyPriority})
+	s.Require().NoError(err)
+	s.Len(out, 3)
+}
+
+func (s *testSuite) readySortByPriority() {
+	r := s.issueRepo()
+	lo := newTestIssue("bd-rdy-srt-lo", "lo")
+	lo.Priority = 3
+	s.Require().NoError(r.Insert(s.Ctx(), lo, "tester", domain.InsertIssueOpts{}))
+	hi := newTestIssue("bd-rdy-srt-hi", "hi")
+	hi.Priority = 1
+	s.Require().NoError(r.Insert(s.Ctx(), hi, "tester", domain.InsertIssueOpts{}))
+	mid := newTestIssue("bd-rdy-srt-mid", "mid")
+	mid.Priority = 2
+	s.Require().NoError(r.Insert(s.Ctx(), mid, "tester", domain.InsertIssueOpts{}))
+
+	out, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{SortPolicy: types.SortPolicyPriority})
+	s.Require().NoError(err)
+	got := issueIDsFrom(out)
+	hiIdx, midIdx, loIdx := indexOf(got, "bd-rdy-srt-hi"), indexOf(got, "bd-rdy-srt-mid"), indexOf(got, "bd-rdy-srt-lo")
+	s.Require().GreaterOrEqual(hiIdx, 0)
+	s.Require().GreaterOrEqual(midIdx, 0)
+	s.Require().GreaterOrEqual(loIdx, 0)
+	s.Less(hiIdx, midIdx, "priority=1 should sort before priority=2")
+	s.Less(midIdx, loIdx, "priority=2 should sort before priority=3")
+}
+
+func (s *testSuite) readyCollisionError() {
+	r := s.issueRepo()
+	const id = "bd-rdy-coll-1"
+	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, "perm"), "tester", domain.InsertIssueOpts{}))
+	w := newTestIssue(id, "wisp")
+	w.Ephemeral = false // NoHistory wisp — survives default filter
+	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
+
+	_, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "exists in both issues and wisps")
+}
+
+func issueIDsFrom(issues []*types.Issue) []string {
+	out := make([]string, 0, len(issues))
+	for _, iss := range issues {
+		out = append(out, iss.ID)
+	}
+	return out
+}
+
+func indexOf(haystack []string, needle string) int {
+	for i, v := range haystack {
+		if v == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/storage/domain/db/ready_work_test.go
+++ b/internal/storage/domain/db/ready_work_test.go
@@ -245,7 +245,7 @@ func (s *testSuite) readyCollisionError() {
 	const id = "bd-rdy-coll-1"
 	s.Require().NoError(r.Insert(s.Ctx(), newTestIssue(id, "perm"), "tester", domain.InsertIssueOpts{}))
 	w := newTestIssue(id, "wisp")
-	w.Ephemeral = false // NoHistory wisp — survives default filter
+	w.Ephemeral = false
 	s.Require().NoError(r.Insert(s.Ctx(), w, "tester", domain.InsertIssueOpts{UseWispsTable: true}))
 
 	_, err := r.GetReadyWork(s.Ctx(), types.WorkFilter{})

--- a/internal/storage/domain/dependency.go
+++ b/internal/storage/domain/dependency.go
@@ -39,17 +39,30 @@ type DepListFilter struct {
 	Direction DepDirection
 }
 
+type BlockingInfo struct {
+	BlockedBy map[string][]string
+	Blocks    map[string][]string
+	Parent    map[string]string
+}
+
 type DependencySQLRepository interface {
 	Insert(ctx context.Context, dep *types.Dependency, actor string, opts DepInsertOpts) error
 	HasCycle(ctx context.Context, issueID, dependsOnID string) (bool, error)
 	ListByIssueIDs(ctx context.Context, issueIDs []string, opts DepListOpts) (DepBulkResult, error)
 	CountsByIssueIDs(ctx context.Context, issueIDs []string, opts DepCountsOpts) (map[string]*types.DependencyCounts, error)
+
+	GetAll(ctx context.Context, opts DepListOpts) (map[string][]*types.Dependency, error)
+	GetAllAcrossIssuesAndWisps(ctx context.Context, opts DepListOpts) (map[string][]*types.Dependency, error)
+	GetBlockingInfo(ctx context.Context, issueIDs []string, opts DepListOpts) (BlockingInfo, error)
+	GetBlockingInfoAcrossIssuesAndWisps(ctx context.Context, issueIDs []string) (BlockingInfo, error)
 }
 
 type DependencyUseCase interface {
 	AddDependency(ctx context.Context, dep *types.Dependency, actor string) error
 	ListByIssueIDs(ctx context.Context, issueIDs []string, filter DepListFilter) (DepBulkResult, error)
 	CountsByIssueIDs(ctx context.Context, issueIDs []string) (map[string]*types.DependencyCounts, error)
+	GetAll(ctx context.Context) (map[string][]*types.Dependency, error)
+	GetBlockingInfo(ctx context.Context, issueIDs []string) (BlockingInfo, error)
 
 	AddWispDependency(ctx context.Context, dep *types.Dependency, actor string) error
 	ListByWispIDs(ctx context.Context, wispIDs []string, filter DepListFilter) (DepBulkResult, error)
@@ -139,6 +152,29 @@ func (u *dependencyUseCaseImpl) counts(ctx context.Context, ids []string, useWis
 	out, err := u.depRepo.CountsByIssueIDs(ctx, ids, DepCountsOpts{UseWispsTable: useWisp})
 	if err != nil {
 		return nil, fmt.Errorf("dep counts: %w", err)
+	}
+	return out, nil
+}
+
+func (u *dependencyUseCaseImpl) GetAll(ctx context.Context) (map[string][]*types.Dependency, error) {
+	out, err := u.depRepo.GetAllAcrossIssuesAndWisps(ctx, DepListOpts{})
+	if err != nil {
+		return nil, fmt.Errorf("GetAll: %w", err)
+	}
+	return out, nil
+}
+
+func (u *dependencyUseCaseImpl) GetBlockingInfo(ctx context.Context, issueIDs []string) (BlockingInfo, error) {
+	if len(issueIDs) == 0 {
+		return BlockingInfo{
+			BlockedBy: map[string][]string{},
+			Blocks:    map[string][]string{},
+			Parent:    map[string]string{},
+		}, nil
+	}
+	out, err := u.depRepo.GetBlockingInfoAcrossIssuesAndWisps(ctx, issueIDs)
+	if err != nil {
+		return BlockingInfo{}, fmt.Errorf("GetBlockingInfo: %w", err)
 	}
 	return out, nil
 }

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -23,24 +23,16 @@ type IssueSQLRepository interface {
 	Insert(ctx context.Context, issue *types.Issue, actor string, opts InsertIssueOpts) error
 	InsertBatch(ctx context.Context, issues []*types.Issue, actor string, opts InsertIssueOpts) error
 	Update(ctx context.Context, id string, updates map[string]any, actor string, opts IssueTableOpts) error
-
 	Get(ctx context.Context, id string, opts IssueTableOpts) (*types.Issue, error)
 	GetByIDs(ctx context.Context, ids []string, opts IssueTableOpts) ([]*types.Issue, error)
-
 	Search(ctx context.Context, filter types.IssueFilter, opts IssueTableOpts) ([]*types.Issue, error)
-
-	// Exists returns true if an issue with id exists in the routed table.
 	Exists(ctx context.Context, id string, opts IssueTableOpts) (bool, error)
-
-	// CountForPrefix returns the number of top-level issues sharing the prefix
-	// in the routed table. Child IDs (containing '.' in the suffix) are
-	// excluded so adaptive sizing reflects only top-level density.
 	CountForPrefix(ctx context.Context, prefix string, opts IssueTableOpts) (int, error)
-
-	// NextCounterID atomically increments and returns the next counter value
-	// for the prefix in counter mode. Seeds from the max existing numeric
-	// suffix when the counter row is missing. Counter mode is `issues`-only.
 	NextCounterID(ctx context.Context, prefix string) (int, error)
+	SearchAcrossIssuesAndWisps(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
+	SearchAcrossIssuesAndWispsWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error)
+	GetReadyWork(ctx context.Context, filter types.WorkFilter) ([]*types.Issue, error)
+	GetReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) ([]*types.IssueWithCounts, error)
 }
 
 type CreateIssueParams struct {
@@ -126,6 +118,16 @@ type IssueUseCase interface {
 	GetIssue(ctx context.Context, id string) (*types.Issue, error)
 	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
 	ListIssues(ctx context.Context, filter types.IssueFilter, proj ListProjection) (ListResult, error)
+
+	// SearchIssues mirrors storage.DoltStorage.SearchIssues: returns fully
+	// hydrated issues (with labels) matching filter, merging the issues and
+	// wisps tables unless filter.SkipWisps is set. Used by `bd list` in
+	// proxied-server mode.
+	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
+	SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error)
+	GetReadyWork(ctx context.Context, filter types.WorkFilter) ([]*types.Issue, error)
+	GetReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) ([]*types.IssueWithCounts, error)
+
 	CreateIssue(ctx context.Context, params CreateIssueParams, actor string) (CreateIssueResult, error)
 	CreateIssues(ctx context.Context, params []CreateIssueParams, actor string) (CreateIssuesResult, error)
 	UpdateIssue(ctx context.Context, id string, updates map[string]any, actor string) error
@@ -353,6 +355,38 @@ func (u *issueUseCaseImpl) list(ctx context.Context, filter types.IssueFilter, p
 		})
 	}
 
+	return out, nil
+}
+
+func (u *issueUseCaseImpl) SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error) {
+	out, err := u.issueRepo.SearchAcrossIssuesAndWisps(ctx, query, filter)
+	if err != nil {
+		return nil, fmt.Errorf("SearchIssues: %w", err)
+	}
+	return out, nil
+}
+
+func (u *issueUseCaseImpl) SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error) {
+	out, err := u.issueRepo.SearchAcrossIssuesAndWispsWithCounts(ctx, query, filter)
+	if err != nil {
+		return nil, fmt.Errorf("SearchIssuesWithCounts: %w", err)
+	}
+	return out, nil
+}
+
+func (u *issueUseCaseImpl) GetReadyWork(ctx context.Context, filter types.WorkFilter) ([]*types.Issue, error) {
+	out, err := u.issueRepo.GetReadyWork(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("GetReadyWork: %w", err)
+	}
+	return out, nil
+}
+
+func (u *issueUseCaseImpl) GetReadyWorkWithCounts(ctx context.Context, filter types.WorkFilter) ([]*types.IssueWithCounts, error) {
+	out, err := u.issueRepo.GetReadyWorkWithCounts(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("GetReadyWorkWithCounts: %w", err)
+	}
 	return out, nil
 }
 

--- a/internal/storage/domain/issue.go
+++ b/internal/storage/domain/issue.go
@@ -118,11 +118,6 @@ type IssueUseCase interface {
 	GetIssue(ctx context.Context, id string) (*types.Issue, error)
 	GetIssuesByIDs(ctx context.Context, ids []string) ([]*types.Issue, error)
 	ListIssues(ctx context.Context, filter types.IssueFilter, proj ListProjection) (ListResult, error)
-
-	// SearchIssues mirrors storage.DoltStorage.SearchIssues: returns fully
-	// hydrated issues (with labels) matching filter, merging the issues and
-	// wisps tables unless filter.SkipWisps is set. Used by `bd list` in
-	// proxied-server mode.
 	SearchIssues(ctx context.Context, query string, filter types.IssueFilter) ([]*types.Issue, error)
 	SearchIssuesWithCounts(ctx context.Context, query string, filter types.IssueFilter) ([]*types.IssueWithCounts, error)
 	GetReadyWork(ctx context.Context, filter types.WorkFilter) ([]*types.Issue, error)


### PR DESCRIPTION
## Summary

Adds the SQL-repository and use-case methods needed for `bd list` to work in proxied-server mode. All four `IssueSQLRepository` search/ready-work entry points are now implemented in the `db/` layer, ported from the existing `issueops` SQL with the same semantics.

### Domain interface additions

- `IssueSQLRepository`: `SearchAcrossIssuesAndWisps`, `SearchAcrossIssuesAndWispsWithCounts`, `GetReadyWork`, `GetReadyWorkWithCounts`
- `DependencySQLRepository`: `GetAll`, `GetAllAcrossIssuesAndWisps`, `GetBlockingInfo`, `GetBlockingInfoAcrossIssuesAndWisps`; new `BlockingInfo` value type
- `ConfigSQLRepository`: `GetCustomStatuses`, `GetInfraTypes`
- `IssueUseCase`: search/ready-work pass-throughs
- `DependencyUseCase`: `GetAll`, `GetBlockingInfo` (delegate to `*AcrossIssuesAndWisps` variants)
- `ConfigUseCase`: `GetCustomStatuses`, `GetInfraTypes`, `IsInfraTypeCtx`

### Implementation files (new)

- `db/issue_search.go` — `SearchAcrossIssuesAndWisps` with full `IssueFilter` coverage (filters, label-driven join, Pattern A/B with id-shrink limit, wisp union, label/dep hydration)
- `db/issue_search_counts.go` — counts variant with the big LEFT-JOIN producing dep/dependent/comment counts, parent, hydrated labels (JSON_ARRAYAGG) and deps
- `db/ready_work.go` — ready-work predicates (open + not pinned + not blocked + ephemeral/deferred/parent/molecule/label/metadata filters), wisp paging and cross-table merge, three sort policies, deferred-children CTE, recursive descendant CTE
- Counts variant of ready-work reuses `runSearchQuery` from `issue_search_counts.go`

### Behavioral note

`SearchAcrossIssuesAndWispsWithCounts` now honors `filter.SkipWisps` for consistency with `SearchAcrossIssuesAndWisps`. Upstream `issueops.SearchIssuesWithCountsInTx` does not — looks like an oversight, fixed in this port.

## Test plan

- [ ] All new `db/` tests pass against a Dolt SQL server container
- [ ] `go test ./...` is green
- [ ] No `not implemented` stubs remain in `internal/storage/domain/`
- [ ] Existing storage path (dolt-direct) unaffected — no changes to `storage/dolt/` or `storage/issueops/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)