### PR TITLE
feat(metadata): index metadata fields for fast equality filtering

### DIFF
--- a/internal/storage/dolt/metadata_schema.go
+++ b/internal/storage/dolt/metadata_schema.go
@@ -84,6 +84,10 @@ func parseFieldSchema(m map[string]interface{}) storage.MetadataFieldSchema {
 		schema.Max = &max
 	}
 
+	if indexed, ok := m["indexed"].(bool); ok {
+		schema.Indexed = indexed
+	}
+
 	return schema
 }
 

--- a/internal/storage/issueops/filters.go
+++ b/internal/storage/issueops/filters.go
@@ -272,8 +272,13 @@ func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables Filt
 		if err := storage.ValidateMetadataKey(filter.HasMetadataKey); err != nil {
 			return nil, nil, err
 		}
-		whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
-		args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
+		if filter.IndexedMetadataKeys[filter.HasMetadataKey] {
+			// Indexed generated column: index lookup instead of a JSON scan.
+			whereClauses = append(whereClauses, storage.MetadataColumnName(filter.HasMetadataKey)+" IS NOT NULL")
+		} else {
+			whereClauses = append(whereClauses, "JSON_EXTRACT(metadata, ?) IS NOT NULL")
+			args = append(args, storage.JSONMetadataPath(filter.HasMetadataKey))
+		}
 	}
 	if len(filter.MetadataFields) > 0 {
 		metaKeys := make([]string, 0, len(filter.MetadataFields))
@@ -285,8 +290,16 @@ func BuildIssueFilterClauses(query string, filter types.IssueFilter, tables Filt
 			if err := storage.ValidateMetadataKey(k); err != nil {
 				return nil, nil, err
 			}
-			whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
-			args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
+			if filter.IndexedMetadataKeys[k] {
+				// Equality against the indexed generated column avoids a
+				// JSON_EXTRACT full scan. Dolt's optimizer does not rewrite the
+				// JSON form to use the index, so the column is targeted directly.
+				whereClauses = append(whereClauses, storage.MetadataColumnName(k)+" = ?")
+				args = append(args, filter.MetadataFields[k])
+			} else {
+				whereClauses = append(whereClauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?")
+				args = append(args, storage.JSONMetadataPath(k), filter.MetadataFields[k])
+			}
 		}
 	}
 

--- a/internal/storage/issueops/filters_metadata_index_test.go
+++ b/internal/storage/issueops/filters_metadata_index_test.go
@@ -1,0 +1,99 @@
+package issueops
+
+import (
+	"testing"
+
+	"github.com/steveyegge/beads/internal/types"
+)
+
+func clausesContain(clauses []string, want string) bool {
+	for _, c := range clauses {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func argsContain(args []interface{}, want interface{}) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Without IndexedMetadataKeys, a metadata-field equality filter falls back to a
+// JSON_EXTRACT scan (preserving legacy behavior).
+func TestBuildIssueFilterClauses_MetadataField_JSONFallback(t *testing.T) {
+	filter := types.IssueFilter{
+		MetadataFields: map[string]string{"alias": "gastown.boot"},
+	}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses: %v", err)
+	}
+	if !clausesContain(clauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?") {
+		t.Fatalf("expected JSON fallback clause, got: %v", clauses)
+	}
+	if !argsContain(args, "$.alias") || !argsContain(args, "gastown.boot") {
+		t.Fatalf("expected JSON path + value in args, got: %v", args)
+	}
+}
+
+// With the key marked indexed, the filter targets the generated column so Dolt
+// uses the index instead of scanning every row's JSON (Dolt does not rewrite
+// the JSON_EXTRACT form to the index — verified empirically).
+func TestBuildIssueFilterClauses_MetadataField_IndexedColumn(t *testing.T) {
+	filter := types.IssueFilter{
+		MetadataFields:      map[string]string{"alias": "gastown.boot"},
+		IndexedMetadataKeys: map[string]bool{"alias": true},
+	}
+	clauses, args, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses: %v", err)
+	}
+	if !clausesContain(clauses, "bd_md_alias = ?") {
+		t.Fatalf("expected indexed-column clause, got: %v", clauses)
+	}
+	if !argsContain(args, "gastown.boot") {
+		t.Fatalf("expected value in args, got: %v", args)
+	}
+	if argsContain(args, "$.alias") {
+		t.Fatalf("indexed path must not bind a JSON path arg, got: %v", args)
+	}
+}
+
+// HasMetadataKey uses the indexed column for an IS NOT NULL existence check.
+func TestBuildIssueFilterClauses_HasMetadataKey_IndexedColumn(t *testing.T) {
+	filter := types.IssueFilter{
+		HasMetadataKey:      "alias",
+		IndexedMetadataKeys: map[string]bool{"alias": true},
+	}
+	clauses, _, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses: %v", err)
+	}
+	if !clausesContain(clauses, "bd_md_alias IS NOT NULL") {
+		t.Fatalf("expected indexed existence clause, got: %v", clauses)
+	}
+}
+
+// A non-indexed key still uses JSON even when other keys are indexed.
+func TestBuildIssueFilterClauses_MixedIndexedAndFallback(t *testing.T) {
+	filter := types.IssueFilter{
+		MetadataFields:      map[string]string{"alias": "x", "note": "y"},
+		IndexedMetadataKeys: map[string]bool{"alias": true},
+	}
+	clauses, _, err := BuildIssueFilterClauses("", filter, IssuesFilterTables)
+	if err != nil {
+		t.Fatalf("BuildIssueFilterClauses: %v", err)
+	}
+	if !clausesContain(clauses, "bd_md_alias = ?") {
+		t.Fatalf("expected indexed clause for alias, got: %v", clauses)
+	}
+	if !clausesContain(clauses, "JSON_UNQUOTE(JSON_EXTRACT(metadata, ?)) = ?") {
+		t.Fatalf("expected JSON fallback clause for note, got: %v", clauses)
+	}
+}

--- a/internal/storage/metadata.go
+++ b/internal/storage/metadata.go
@@ -53,6 +53,7 @@ type MetadataFieldSchema struct {
 	Required bool
 	Min      *float64 // min value for int/float
 	Max      *float64 // max value for int/float
+	Indexed  bool     // maintain an indexed generated column for fast equality filtering
 }
 
 // MetadataSchemaConfig holds the parsed metadata validation configuration.
@@ -228,4 +229,28 @@ func JSONMetadataPath(key string) string {
 		return `$."` + key + `"`
 	}
 	return "$." + key
+}
+
+// MetadataColumnName returns the deterministic name of the generated column
+// that mirrors a metadata key for indexed equality filtering. The key is
+// sanitized to a safe SQL identifier, e.g. "session_name" -> "bd_md_session_name"
+// and "gc.routed_to" -> "bd_md_gc_routed_to".
+func MetadataColumnName(key string) string {
+	var b strings.Builder
+	b.Grow(len("bd_md_") + len(key))
+	b.WriteString("bd_md_")
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// MetadataIndexName returns the index name for a metadata generated column.
+func MetadataIndexName(key string) string {
+	return "idx_" + MetadataColumnName(key)
 }

--- a/internal/storage/schema/metadata_index.go
+++ b/internal/storage/schema/metadata_index.go
@@ -1,0 +1,81 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+)
+
+// MetadataIndexSpec describes a STORED generated column plus secondary index
+// that mirrors a JSON metadata key, enabling indexed equality filtering.
+//
+// Column and Index must be safe SQL identifiers (the caller builds them via
+// storage.MetadataColumnName / storage.MetadataIndexName, which sanitize the
+// key). JSONPath is a validated JSON path expression (storage.JSONMetadataPath).
+type MetadataIndexSpec struct {
+	Column   string // e.g. "bd_md_alias"
+	Index    string // e.g. "idx_bd_md_alias"
+	JSONPath string // e.g. `$.alias`
+}
+
+// EnsureMetadataIndexes idempotently creates, for each spec, a STORED generated
+// column mirroring issues.metadata at JSONPath plus a secondary index, so that
+// equality filters on that metadata key use an index instead of a full
+// JSON_EXTRACT scan. Columns/indexes that already exist are left untouched.
+//
+// Background: Dolt (like MySQL) cannot index a JSON column directly, and its
+// optimizer does NOT rewrite a JSON_EXTRACT predicate onto a generated-column
+// index — verified empirically — so the query layer must target the generated
+// column (see issueops.BuildIssueFilterClauses and
+// types.IssueFilter.IndexedMetadataKeys). On a 31k-row store this is ~24x
+// faster for the per-key equality lookups used by session/mail routing.
+func EnsureMetadataIndexes(ctx context.Context, db DBConn, specs []MetadataIndexSpec) error {
+	for _, s := range specs {
+		hasCol, err := metadataColumnExists(ctx, db, "issues", s.Column)
+		if err != nil {
+			return err
+		}
+		if !hasCol {
+			// Generated-column expression cannot be a bound parameter; Column and
+			// JSONPath are sanitized/validated by the caller.
+			ddl := fmt.Sprintf(
+				"ALTER TABLE issues ADD COLUMN %s VARCHAR(255) AS (JSON_UNQUOTE(JSON_EXTRACT(metadata, '%s'))) STORED",
+				s.Column, s.JSONPath)
+			if _, err := db.ExecContext(ctx, ddl); err != nil {
+				return fmt.Errorf("add metadata column %s: %w", s.Column, err)
+			}
+		}
+
+		hasIdx, err := metadataIndexExists(ctx, db, "issues", s.Index)
+		if err != nil {
+			return err
+		}
+		if !hasIdx {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE INDEX %s ON issues (%s)", s.Index, s.Column)); err != nil {
+				return fmt.Errorf("create metadata index %s: %w", s.Index, err)
+			}
+		}
+	}
+	return nil
+}
+
+func metadataColumnExists(ctx context.Context, db DBConn, table, column string) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.columns WHERE table_name = ? AND column_name = ?",
+		table, column).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("checking column %s.%s: %w", table, column, err)
+	}
+	return n > 0, nil
+}
+
+func metadataIndexExists(ctx context.Context, db DBConn, table, index string) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = ? AND index_name = ?",
+		table, index).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("checking index %s on %s: %w", index, table, err)
+	}
+	return n > 0, nil
+}

--- a/internal/storage/schema/metadata_index_test.go
+++ b/internal/storage/schema/metadata_index_test.go
@@ -1,0 +1,59 @@
+package schema
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestEnsureMetadataIndexes_CreatesWhenMissing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("information_schema.columns").
+		WithArgs("issues", "bd_md_alias").
+		WillReturnRows(sqlmock.NewRows([]string{"n"}).AddRow(0))
+	mock.ExpectExec("ALTER TABLE issues ADD COLUMN bd_md_alias").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("information_schema.statistics").
+		WithArgs("issues", "idx_bd_md_alias").
+		WillReturnRows(sqlmock.NewRows([]string{"n"}).AddRow(0))
+	mock.ExpectExec("CREATE INDEX idx_bd_md_alias ON issues").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	specs := []MetadataIndexSpec{{Column: "bd_md_alias", Index: "idx_bd_md_alias", JSONPath: "$.alias"}}
+	if err := EnsureMetadataIndexes(context.Background(), db, specs); err != nil {
+		t.Fatalf("EnsureMetadataIndexes: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestEnsureMetadataIndexes_SkipsWhenPresent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("information_schema.columns").
+		WithArgs("issues", "bd_md_alias").
+		WillReturnRows(sqlmock.NewRows([]string{"n"}).AddRow(1))
+	mock.ExpectQuery("information_schema.statistics").
+		WithArgs("issues", "idx_bd_md_alias").
+		WillReturnRows(sqlmock.NewRows([]string{"n"}).AddRow(1))
+	// No ALTER/CREATE expected — column and index already exist.
+
+	specs := []MetadataIndexSpec{{Column: "bd_md_alias", Index: "idx_bd_md_alias", JSONPath: "$.alias"}}
+	if err := EnsureMetadataIndexes(context.Background(), db, specs); err != nil {
+		t.Fatalf("EnsureMetadataIndexes: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1273,6 +1273,10 @@ type IssueFilter struct {
 	// Metadata field filtering (GH#1406)
 	MetadataFields map[string]string // Top-level key=value equality; AND semantics (all must match)
 	HasMetadataKey string            // Existence check: issue has this top-level key set (non-null)
+	// IndexedMetadataKeys names metadata keys backed by an indexed generated
+	// column (see storage.MetadataColumnName); listed keys use that column
+	// instead of a JSON_EXTRACT scan. Populated from the metadata schema config.
+	IndexedMetadataKeys map[string]bool
 
 	// Hydration options — control which relational data is populated on returned issues.
 	// Labels are always hydrated. Dependencies are not by default (for performance).


### PR DESCRIPTION
## Problem

`bd` stores per-issue metadata as one JSON column (`issues.metadata`), so `bd list --metadata-field key=value` runs `WHERE JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.key')) = ?` — a **full table scan** with per-row JSON extraction. On large stores this dominates latency: in a real 31,243-issue store the session/mail-routing lookups (`alias`, `session_name`) take **~28–54s**, cascading into downstream start-deadline timeouts.

## Why an index alone isn't enough (prototyped)

On a throwaway copy of a 31k-issue Dolt DB, a STORED generated column + index is dramatically faster — **but Dolt's optimizer does not rewrite the `JSON_EXTRACT` predicate onto the index:**

| query form | plan | 15-query time |
|---|---|---|
| `metadata->>'$.alias' = X` | `Filter → Table(issues)` (full scan) | **5.28s** |
| `bd_md_alias = X` (generated col) | `IndexedTableAccess [bd_md_alias]` | **0.22s** |

~24× faster, identical results (390 = 390). So the **query layer must target the generated column** — adding the index without changing the query buys nothing.

## What this PR does (opt-in — keeps `bd` general, no hardcoded keys)

A field opts in via the existing metadata schema config:
```yaml
metadata:
  fields:
    alias: { type: string, indexed: true }   # <-- new flag
```

- **storage**: `Indexed` flag on `MetadataFieldSchema`; `MetadataColumnName`/`MetadataIndexName` helpers (sanitized identifiers).
- **dolt**: parse `indexed: true`.
- **schema**: `EnsureMetadataIndexes(db, specs)` idempotently creates a STORED generated column `bd_md_<key> AS (JSON_UNQUOTE(JSON_EXTRACT(metadata,'$.<key>'))) STORED` + index per field. **sqlmock-tested**.
- **query**: `IssueFilter.IndexedMetadataKeys` + `BuildIssueFilterClauses` target the generated column for indexed keys, falling back to `JSON_EXTRACT` otherwise. **Unit-tested** (indexed / fallback / mixed / existence).

## Proposed Dolt wiring (the two glue points — paste-and-build)

These touch CGO/Dolt-linked code I couldn't compile in my environment, so they're proposed diffs against current `main` (line numbers approximate; build in CI). Both reuse the existing `loadMetadataSchema()` parser, so there is no duplicated config logic.

**1. Create the columns/indexes on schema init** — `internal/storage/dolt/store.go` (already imports `schema` + `storage`; `loadMetadataSchema` is same-package; `migDB` is a `*sql.DB`, which satisfies `schema.DBConn`):

```diff
 func (s *DoltStore) initSchema(ctx context.Context) error {
 	migDB, err := s.openMigrationDB()
 	if err != nil {
 		return err
 	}
 	defer migDB.Close()
-	_, err = initSchemaOnDBWithRetry(ctx, migDB)
-	return err
+	if _, err = initSchemaOnDBWithRetry(ctx, migDB); err != nil {
+		return err
+	}
+	// Maintain indexed generated columns for metadata fields declared
+	// `indexed: true` in the schema config. Idempotent; safe on every open.
+	return schema.EnsureMetadataIndexes(ctx, migDB, indexedMetadataSpecs())
 }
+
+// indexedMetadataSpecs builds generated-column/index specs for each metadata
+// field declared `indexed: true` in the schema config.
+func indexedMetadataSpecs() []schema.MetadataIndexSpec {
+	cfg := loadMetadataSchema()
+	specs := make([]schema.MetadataIndexSpec, 0, len(cfg.Fields))
+	for name, f := range cfg.Fields {
+		if !f.Indexed {
+			continue
+		}
+		specs = append(specs, schema.MetadataIndexSpec{
+			Column:   storage.MetadataColumnName(name),
+			Index:    storage.MetadataIndexName(name),
+			JSONPath: storage.JSONMetadataPath(name),
+		})
+	}
+	return specs
+}
```

**2. Tell the query layer which keys are indexed.** Add an exported helper next to the parser — `internal/storage/dolt/metadata_schema.go`:

```diff
+// IndexedMetadataKeys returns the set of metadata field names declared
+// `indexed: true` in the schema config, for IssueFilter.IndexedMetadataKeys.
+func IndexedMetadataKeys() map[string]bool {
+	cfg := loadMetadataSchema()
+	keys := make(map[string]bool, len(cfg.Fields))
+	for name, f := range cfg.Fields {
+		if f.Indexed {
+			keys[name] = true
+		}
+	}
+	return keys
+}
```

…and populate the filter where it's built — `cmd/bd/list.go` (add import `github.com/steveyegge/beads/internal/storage/dolt`):

```diff
 				filter.MetadataFields[k] = v
 			}
 		}
+		// Route equality filters on indexed metadata keys to their generated
+		// columns (avoids a JSON_EXTRACT full scan).
+		filter.IndexedMetadataKeys = dolt.IndexedMetadataKeys()
 		hasMetadataKey, _ := cmd.Flags().GetString("has-metadata-key")
```

The same one-liner applies to the other filter-construction sites (`search.go`, `ready.go`) as follow-ups.

## Testing
`go test ./internal/storage/issueops/ ./internal/storage/schema/` pass; `gofmt`/`go vet` clean. CGO/Dolt-linked packages build in CI.

**Draft** pending the two wiring diffs above + maintainer input on the approach (generated columns vs. a normalized metadata KV table for fully-arbitrary keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)