### PR TITLE
fix(init): initialize planning Dolt schema in fork auto-config (be-wqt8)

### DIFF
--- a/cmd/bd/init_contributor.go
+++ b/cmd/bd/init_contributor.go
@@ -282,7 +282,8 @@ func autoConfigureForkContributor(ctx context.Context, store storage.DoltStorage
 		return nil
 	}
 
-	// Already configured: idempotent re-init.
+	// Already configured: idempotent re-init. Check both DB config and YAML
+	// config — a YAML-configured contributor setup would be missed by DB-only check.
 	if existing, err := store.GetConfig(ctx, "routing.contributor"); err == nil && existing != "" {
 		if !quiet {
 			fmt.Printf("\n  %s Fork detected (upstream: %s)\n", ui.RenderWarn("⚠"), upstreamURL)
@@ -290,6 +291,16 @@ func autoConfigureForkContributor(ctx context.Context, store storage.DoltStorage
 			fmt.Printf("    Skipping auto-setup. To reconfigure: bd init --contributor\n")
 		}
 		return nil
+	}
+	if src := config.GetValueSource("routing.contributor"); src != config.SourceDefault {
+		if yamlVal := strings.TrimSpace(config.GetString("routing.contributor")); yamlVal != "" {
+			if !quiet {
+				fmt.Printf("\n  %s Fork detected (upstream: %s)\n", ui.RenderWarn("⚠"), upstreamURL)
+				fmt.Printf("    Contributor routing configured via config.yaml → %s\n", yamlVal)
+				fmt.Printf("    Skipping auto-setup. To reconfigure: bd init --contributor\n")
+			}
+			return nil
+		}
 	}
 
 	homeDir, err := os.UserHomeDir()
@@ -309,8 +320,16 @@ func autoConfigureForkContributor(ctx context.Context, store storage.DoltStorage
 		if err := gitInit.Run(); err != nil {
 			return fmt.Errorf("failed to init git in planning repo: %w", err)
 		}
-		if err := os.MkdirAll(filepath.Join(planningPath, ".beads"), 0750); err != nil {
+		planningBeadsDir := filepath.Join(planningPath, ".beads")
+		if err := os.MkdirAll(planningBeadsDir, 0750); err != nil {
 			return fmt.Errorf("failed to create .beads in planning repo: %w", err)
+		}
+		// Initialize the planning Dolt schema so commands like bd migrate-personal
+		// can open the store immediately without hitting an uninitialized DB.
+		// Non-fatal: no-CGO and server-mode builds skip this silently; the schema
+		// initializes on first use once a Dolt server is running for that path.
+		if planningStore, storeErr := newDoltStoreFromConfig(ctx, planningBeadsDir); storeErr == nil {
+			_ = planningStore.Close()
 		}
 	}
 

--- a/cmd/bd/init_embedded_test.go
+++ b/cmd/bd/init_embedded_test.go
@@ -358,6 +358,14 @@ func TestEmbeddedInit(t *testing.T) {
 			t.Errorf("planning .beads missing: %v", err)
 		}
 
+		// Regression: autoConfigureForkContributor must initialize the planning
+		// Dolt schema, not just create the .beads directory. An uninitialized
+		// store causes "Dolt server unreachable" on first use (e.g. bd migrate-personal).
+		planningEmbeddedDir := filepath.Join(planningDir, ".beads", "embeddeddolt")
+		if _, err := os.Stat(planningEmbeddedDir); err != nil {
+			t.Errorf("planning embeddeddolt dir missing (planning store not pre-initialized): %v", err)
+		}
+
 		roleCmd := exec.Command("git", "config", "--get", "beads.role")
 		roleCmd.Dir = dir
 		roleOut, err := roleCmd.Output()

--- a/release-gates/be-wqt8-planning-init-gate.md
+++ b/release-gates/be-wqt8-planning-init-gate.md
@@ -1,0 +1,39 @@
+# Release Gate: be-wqt8 — fork auto-config planning store init fix
+
+**Bead:** be-chhm (deploy bead for be-mx1y / be-wqt8)  
+**Branch:** fix/be-wqt8-planning-init  
+**Cherry-picked from:** feat/be-3w6-be-0c8-nopush-dolt  
+**Commit:** 3cb77b014 (cherry-pick of 1d9c835a2)  
+**Date:** 2026-06-02  
+
+## Gate Result: PASS
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Review PASS present | PASS | be-mx1y: reviewer PASS verdict in bead notes. All 3 acceptance criteria verified by reviewer. |
+| 2 | Acceptance criteria met | PASS | See below |
+| 3 | Tests pass | PASS | `make test` exit 0 on fresh branch off origin/main. Coverage 37.3%. |
+| 4 | No high-severity review findings open | PASS | Reviewer posted 5 findings, all PASS. Zero HIGH or MEDIUM severity findings. |
+| 5 | Final branch is clean | PASS | `git status` clean, working tree clean, nothing to commit. |
+| 6 | Branch diverges cleanly from main | PASS | Cherry-picked cleanly onto origin/main (fbcee6c62). No conflicts. |
+| 7 | Single feature theme | PASS | Single commit touching `cmd/bd/init_contributor.go` and `cmd/bd/init_embedded_test.go`. One subsystem (fork auto-config init path). |
+
+## Acceptance Criteria
+
+1. **Planning Dolt schema initialized during fork auto-config** → SATISFIED  
+   `init_contributor.go:331-337`: `newDoltStoreFromConfig` called on `planningBeadsDir` immediately after creation. CGO builds initialize schema; no-CGO builds skip silently (non-fatal).
+
+2. **YAML-configured contributor setup covered by idempotency guard** → SATISFIED  
+   `init_contributor.go:295-303`: new check on `config.GetValueSource("routing.contributor")` catches `SourceConfigFile` and `SourceEnvVar` — correctly broader than DB-only check.
+
+3. **Regression test exercises the fix** → SATISFIED  
+   `init_embedded_test.go:369-373`: asserts `embeddeddolt` dir exists after `bd init` on fork, proving `initSchema` ran. Gated `//go:build cgo`. No-CGO builds compile clean.
+
+## Test Notes
+
+- `make test` passes clean on a fresh worktree off `origin/main` with this commit cherry-picked.  
+- The builder worktree's `../../bd` binary (v1.0.4, no-CGO, built May 20) caused unrelated test failures when tests ran there — these are NOT regressions from this commit. Verified by running the same tests in a temp worktree at both `31e416872` (parent) and `1d9c835a2` (this commit) without the stale binary, both pass.
+
+## Deploy Notes
+
+The source branch `feat/be-3w6-be-0c8-nopush-dolt` fork remote has diverged from the local branch (non-fast-forward; builder rebase not pushed to fork). The commit deploys cleanly as a standalone cherry-pick because it is independent of the no-push feature in that branch. PR #4212 continues to track the no-push feature separately.


### PR DESCRIPTION
## What this changes

`bd init` on a fork now correctly initializes the planning Dolt schema before returning. Previously, `autoConfigureForkContributor` created `~/.beads-planning/.beads` but never ran schema initialization. Any command that opened the planning store immediately after `bd init` (e.g., `bd migrate-personal`) would hit "Dolt server unreachable" because the schema tables didn't exist yet.

The fix calls `newDoltStoreFromConfig` on the fresh planning directory right after it is created. In CGO/embedded builds this runs `initSchema` so the store is ready for first use. In no-CGO and server-mode builds the call is a no-op (schema initializes on first use once a server is running) — this path is explicitly non-fatal.

A second, independent fix extends the idempotency guard for `autoConfigureForkContributor` to cover YAML-configured contributor setups. Previously, only the DB config key was checked; contributors configured via `config.yaml` or `BD_ROUTING_CONTRIBUTOR` would trigger a spurious re-setup. The new check on `config.GetValueSource` covers both cases.

## Review notes

- Path for no-CGO/server builds: `newDoltStoreFromConfig` returns `nocgoEmbeddedErrMsg`; the error is intentionally discarded with `_ = planningStore.Close()` (non-fatal by design).
- The idempotency guard is intentionally broader than the description says: catches both `SourceConfigFile` and `SourceEnvVar`, which is correct.
- New test `fork_auto_contributor` is gated `//go:build cgo`; no-CGO builds compile clean.

## Test plan

- [x] `make test` — zero regressions vs main (exit 0, 37.3% total coverage)
- [x] Fork auto-config regression test (`fork_auto_contributor`) asserts `embeddeddolt` dir exists after `bd init`, proving `initSchema` ran
- [x] Release gate: [`release-gates/be-wqt8-planning-init-gate.md`](release-gates/be-wqt8-planning-init-gate.md)

🤖 Deployed by actual-factory